### PR TITLE
Index Java constant collections as queryable value-sets

### DIFF
--- a/internal/extractors/java/const_collection.go
+++ b/internal/extractors/java/const_collection.go
@@ -1,0 +1,378 @@
+package java
+
+// const_collection.go — value-carrying SCOPE.Enum value-set nodes for Java
+// constant COLLECTIONS (data-model, epic #4419 / #4334, extends #4420/#4429).
+//
+// #4429 indexed Python/TS module-level const maps and TS `as const` objects as
+// queryable SCOPE.Enum value-sets so a downstream parity-audit can diff the
+// literal {key,value} set without re-parsing source. This file adds the Java
+// const-COLLECTION shapes, feeding the SAME shared builder
+// (extractor.EnumEntity / EnumMember / StripLiteralQuotes) so Java converges on
+// the identical value-set model — NO new Kind, reuse SCOPE.Enum.
+//
+// Shapes detected (all must be a `static final` field, or an interface
+// constant, whose value is a closed all-/mostly-literal collection):
+//
+//   - `static final Map<K,V> X = Map.of("a", "b", ...)`   → java_const_map
+//   - `static final Map<K,V> X = Map.ofEntries(entry("a","b"), ...)`
+//   - Guava `ImmutableMap.of("a","b", ...)`
+//   - Guava `ImmutableMap.<K,V>builder().put("a","b").put(...).build()`
+//   - `static final String[] X = {"a", "b"}`              → java_const_array
+//   - a GROUP of `String FOO = "foo";` constants in a class/interface
+//     (≥2 sibling static-final string/number constants) → java_const_group
+//
+// Honest-partial: a key or value that is not a string/number/bool literal is
+// captured by its source expression text (so the member is still enumerable),
+// mirroring the cross-language honest-partial convention. A collection with no
+// statically-resolvable key is skipped.
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// buildJavaConstCollections inspects a class/interface/enum body and emits
+// SCOPE.Enum value-set nodes for every constant collection it recognises:
+//   - each `static final` map/array field whose initializer is a closed
+//     literal collection → one value-set named "<Type>.<FIELD>";
+//   - the GROUP of scalar string/number constants declared directly in the
+//     body (≥2) → one value-set named "<Type>" with kind_hint java_const_group.
+//
+// typeName is the enclosing class/interface/enum simple name (already package-
+// unqualified, matching buildField's parentType). bodyNode is the
+// class_body / interface_body / enum_body node.
+func buildJavaConstCollections(typeName string, bodyNode *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+	if bodyNode == nil || typeName == "" {
+		return nil
+	}
+	var out []types.EntityRecord
+	var groupMembers []extractor.EnumMember
+
+	for i := 0; i < int(bodyNode.ChildCount()); i++ {
+		ch := bodyNode.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "field_declaration":
+			// Only `static final` fields are constants.
+			if !javaFieldIsStaticFinal(ch) {
+				continue
+			}
+			decl, init := javaFieldDeclaratorInit(ch)
+			if decl == nil || init == nil {
+				continue
+			}
+			fname := childFieldText(decl, "name", file.Content)
+			if fname == "" {
+				continue
+			}
+			// Collection-shaped initializers → one value-set per field.
+			if members, hint, ok := javaCollectionMembers(init, file.Content); ok {
+				if rec, rok := extractor.EnumEntity(
+					typeName+"."+fname, "java", hint, file.Path,
+					int(ch.StartPoint().Row)+1, int(ch.EndPoint().Row)+1, members,
+				); rok {
+					out = append(out, rec)
+				}
+				continue
+			}
+			// Scalar constant (String FOO = "foo"; int LIMIT = 5;) → collect
+			// into the per-type constant group.
+			if v, ok := javaScalarLiteral(init, file.Content); ok && javaConstName(fname) {
+				groupMembers = append(groupMembers, extractor.EnumMember{
+					Name: fname, Value: v, Line: int(ch.StartPoint().Row) + 1,
+				})
+			}
+
+		case "constant_declaration":
+			// Interface constants are implicitly `public static final`.
+			decl, init := javaFieldDeclaratorInit(ch)
+			if decl == nil || init == nil {
+				continue
+			}
+			fname := childFieldText(decl, "name", file.Content)
+			if fname == "" {
+				continue
+			}
+			if members, hint, ok := javaCollectionMembers(init, file.Content); ok {
+				if rec, rok := extractor.EnumEntity(
+					typeName+"."+fname, "java", hint, file.Path,
+					int(ch.StartPoint().Row)+1, int(ch.EndPoint().Row)+1, members,
+				); rok {
+					out = append(out, rec)
+				}
+				continue
+			}
+			if v, ok := javaScalarLiteral(init, file.Content); ok && javaConstName(fname) {
+				groupMembers = append(groupMembers, extractor.EnumMember{
+					Name: fname, Value: v, Line: int(ch.StartPoint().Row) + 1,
+				})
+			}
+		}
+	}
+
+	// A GROUP of ≥2 scalar constants in one type is a value-set (the classic
+	// "constants interface" / permission-name holder). A single lone constant
+	// is left as an ordinary field — it is not a comparable value-set.
+	if len(groupMembers) >= 2 {
+		if rec, ok := extractor.EnumEntity(
+			typeName, "java", "java_const_group", file.Path,
+			groupMembers[0].Line, groupMembers[len(groupMembers)-1].Line, groupMembers,
+		); ok {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+// javaFieldIsStaticFinal reports whether a field_declaration carries BOTH the
+// `static` and `final` modifiers (the Java constant idiom).
+func javaFieldIsStaticFinal(field *sitter.Node) bool {
+	mods := firstChildOfType(field, "modifiers")
+	if mods == nil {
+		return false
+	}
+	hasStatic, hasFinal := false, false
+	for i := 0; i < int(mods.ChildCount()); i++ {
+		switch mods.Child(i).Type() {
+		case "static":
+			hasStatic = true
+		case "final":
+			hasFinal = true
+		}
+	}
+	return hasStatic && hasFinal
+}
+
+// javaFieldDeclaratorInit returns the variable_declarator and its initializer
+// (the named node after `=`) for a field_declaration / constant_declaration.
+// Returns nil,nil when there is no single-variable initializer.
+func javaFieldDeclaratorInit(field *sitter.Node) (decl *sitter.Node, init *sitter.Node) {
+	decl = firstChildOfType(field, "variable_declarator")
+	if decl == nil {
+		return nil, nil
+	}
+	init = decl.ChildByFieldName("value")
+	if init == nil {
+		// Fall back: first named child after the `=` token.
+		seenEq := false
+		for i := 0; i < int(decl.ChildCount()); i++ {
+			c := decl.Child(i)
+			if c.Type() == "=" {
+				seenEq = true
+				continue
+			}
+			if seenEq && c.IsNamed() {
+				init = c
+				break
+			}
+		}
+	}
+	return decl, init
+}
+
+// javaCollectionMembers recognises a closed literal collection initializer and
+// returns its members plus the kind_hint. Recognised:
+//   - Map.of(...) / ImmutableMap.of(...)                     → java_const_map
+//   - Map.ofEntries(entry(...), ...)                         → java_const_map
+//   - ImmutableMap.builder().put(...)...build()              → java_const_map
+//   - array_initializer { lit, lit, ... }                    → java_const_array
+//
+// ok=false for any other initializer shape.
+func javaCollectionMembers(init *sitter.Node, src []byte) ([]extractor.EnumMember, string, bool) {
+	switch init.Type() {
+	case "array_initializer":
+		members := javaArrayMembers(init, src)
+		if len(members) == 0 {
+			return nil, "", false
+		}
+		return members, "java_const_array", true
+	case "method_invocation":
+		if members, ok := javaMapInvocationMembers(init, src); ok {
+			return members, "java_const_map", true
+		}
+	}
+	return nil, "", false
+}
+
+// javaArrayMembers returns each literal element of a `{ "a", "b" }`
+// array_initializer as a self-keyed member (Name==Value==literal), so a
+// constant string array is enumerable as a value-set. The 0-based element
+// index seeds nothing; the literal text is the identity.
+func javaArrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
+	var out []extractor.EnumMember
+	for i := 0; i < int(arr.NamedChildCount()); i++ {
+		el := arr.NamedChild(i)
+		if el == nil {
+			continue
+		}
+		v, ok := javaLiteralText(el, src)
+		if !ok {
+			// Non-literal element → capture its source expr text so the
+			// member stays enumerable (honest-partial).
+			v = strings.TrimSpace(nodeText(el, src))
+		}
+		if v == "" {
+			continue
+		}
+		out = append(out, extractor.EnumMember{
+			Name: v, Value: v, Line: int(el.StartPoint().Row) + 1,
+		})
+	}
+	return out
+}
+
+// javaMapInvocationMembers handles the three map-factory shapes by inspecting
+// the receiver/leaf of a method_invocation chain. Returns the {key,value}
+// members and ok=true only when at least one key was resolved.
+func javaMapInvocationMembers(call *sitter.Node, src []byte) ([]extractor.EnumMember, bool) {
+	leaf := javaInvocationLeaf(call, src)
+	switch leaf {
+	case "of":
+		// Map.of(k,v,k,v,...) / ImmutableMap.of(k,v,...): flat alternating args.
+		args := call.ChildByFieldName("arguments")
+		if args == nil {
+			return nil, false
+		}
+		members := javaFlatPairMembers(args, src)
+		return members, len(members) > 0
+	case "ofEntries":
+		// Map.ofEntries(entry(k,v), entry(k,v), ...).
+		args := call.ChildByFieldName("arguments")
+		if args == nil {
+			return nil, false
+		}
+		var out []extractor.EnumMember
+		for i := 0; i < int(args.NamedChildCount()); i++ {
+			e := args.NamedChild(i)
+			if e == nil || e.Type() != "method_invocation" {
+				continue
+			}
+			ea := e.ChildByFieldName("arguments")
+			if ea == nil {
+				continue
+			}
+			out = append(out, javaFlatPairMembers(ea, src)...)
+		}
+		return out, len(out) > 0
+	case "build":
+		// ImmutableMap.builder().put(k,v).put(k,v).build(): walk the receiver
+		// chain collecting every .put(...) call's args.
+		members := javaBuilderPutMembers(call, src)
+		return members, len(members) > 0
+	}
+	return nil, false
+}
+
+// javaFlatPairMembers reads an argument_list of alternating key,value literals
+// and returns one member per pair. A trailing odd argument is ignored.
+func javaFlatPairMembers(args *sitter.Node, src []byte) []extractor.EnumMember {
+	var lits []*sitter.Node
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		lits = append(lits, a)
+	}
+	var out []extractor.EnumMember
+	for i := 0; i+1 < len(lits); i += 2 {
+		key, kok := javaLiteralText(lits[i], src)
+		if !kok {
+			key = strings.TrimSpace(nodeText(lits[i], src))
+		}
+		if key == "" {
+			continue
+		}
+		val, vok := javaLiteralText(lits[i+1], src)
+		if !vok {
+			val = strings.TrimSpace(nodeText(lits[i+1], src))
+		}
+		out = append(out, extractor.EnumMember{
+			Name: key, Value: val, Line: int(lits[i].StartPoint().Row) + 1,
+		})
+	}
+	return out
+}
+
+// javaBuilderPutMembers walks an ImmutableMap.builder().put(...).put(...).build()
+// chain bottom-up, collecting each `.put(key, value)` pair. The chain is a
+// left-nested method_invocation; we descend the receiver (object) field until
+// we exhaust the chain.
+func javaBuilderPutMembers(buildCall *sitter.Node, src []byte) []extractor.EnumMember {
+	var members []extractor.EnumMember
+	// Start from the receiver of `.build()` and walk down `.put(...)` links.
+	cur := buildCall.ChildByFieldName("object")
+	for cur != nil && cur.Type() == "method_invocation" {
+		if javaInvocationLeaf(cur, src) == "put" {
+			if a := cur.ChildByFieldName("arguments"); a != nil {
+				members = append(members, javaFlatPairMembers(a, src)...)
+			}
+		}
+		cur = cur.ChildByFieldName("object")
+	}
+	// Chain was collected bottom-up (last .put first); reverse to source order.
+	for l, r := 0, len(members)-1; l < r; l, r = l+1, r-1 {
+		members[l], members[r] = members[r], members[l]
+	}
+	return members
+}
+
+// javaInvocationLeaf returns the method name (the `name` field) of a
+// method_invocation, e.g. "of" for `Map.of(...)`, "build" for `...build()`.
+func javaInvocationLeaf(call *sitter.Node, src []byte) string {
+	if call == nil || call.Type() != "method_invocation" {
+		return ""
+	}
+	if n := call.ChildByFieldName("name"); n != nil {
+		return nodeText(n, src)
+	}
+	return ""
+}
+
+// javaScalarLiteral returns the literal value of a scalar constant initializer
+// (string/number/bool/char), or ok=false when the initializer is not a single
+// literal. Used to collect constant-group members.
+func javaScalarLiteral(init *sitter.Node, src []byte) (string, bool) {
+	return javaLiteralText(init, src)
+}
+
+// javaLiteralText returns the normalised literal text of a literal node
+// (quotes stripped for strings), and ok=true only for recognised literal kinds.
+func javaLiteralText(node *sitter.Node, src []byte) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	switch node.Type() {
+	case "string_literal", "decimal_integer_literal", "decimal_floating_point_literal",
+		"hex_integer_literal", "octal_integer_literal", "binary_integer_literal",
+		"hex_floating_point_literal", "character_literal", "true", "false":
+		return extractor.StripLiteralQuotes(nodeText(node, src)), true
+	}
+	return "", false
+}
+
+// javaConstName reports whether a field name follows the constant convention
+// (UPPER_SNAKE, all-caps, or contains an underscore between caps). This keeps
+// ordinary mutable-looking static-final fields (e.g. a cached `LOGGER`) — which
+// are still constants — in the group; we intentionally include any
+// all-uppercase or underscore-separated name and exclude camelCase fields,
+// which are rarely value constants.
+func javaConstName(name string) bool {
+	if name == "" {
+		return false
+	}
+	hasLower := false
+	for _, r := range name {
+		if r >= 'a' && r <= 'z' {
+			hasLower = true
+			break
+		}
+	}
+	return !hasLower
+}

--- a/internal/extractors/java/issue4430_constset_test.go
+++ b/internal/extractors/java/issue4430_constset_test.go
@@ -1,0 +1,226 @@
+package java_test
+
+// issue4430_constset_test.go — in-pipeline (REAL extract pipeline) tests for
+// the Java constant-COLLECTION value-set indexing (#4430, extends #4420/#4429).
+//
+// Each test runs the registered Java extractor over a byte-copy of a
+// representative fixture and asserts the SCOPE.Enum value-set is (a) emitted,
+// (b) searchable by name, and (c) enumerates the real {key,value} pairs via the
+// shared structured members_json property — the same RED→GREEN contract the
+// Python/TS arms use.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// constMemberJSON mirrors the shared members_json shape emitted by EnumEntity.
+type constMemberJSON struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Line  int    `json:"line,omitempty"`
+}
+
+func parseMembersJSON(t *testing.T, en *types.EntityRecord) map[string]string {
+	t.Helper()
+	raw, ok := en.Properties["members_json"]
+	if !ok {
+		t.Fatalf("members_json absent on %s", en.Name)
+	}
+	var arr []constMemberJSON
+	if err := json.Unmarshal([]byte(raw), &arr); err != nil {
+		t.Fatalf("members_json not valid JSON: %v", err)
+	}
+	m := make(map[string]string, len(arr))
+	for _, e := range arr {
+		m[e.Key] = e.Value
+	}
+	return m
+}
+
+// TestJavaConstMap_StaticFinalMapOf is the primary live-validation: a
+// `static final Map<String,String> = Map.of(...)` constant map is emitted as a
+// searchable value-set whose members enumerate the real role→slug pairs (the
+// hyphen-vs-underscore parity case from the cross-language oracle).
+func TestJavaConstMap_StaticFinalMapOf(t *testing.T) {
+	src := `
+package com.upvate.auth;
+
+import java.util.Map;
+
+public final class RoleSlugs {
+    public static final Map<String, String> ROLE_SLUGS = Map.of(
+        "CoreAdmin", "core-admin",
+        "BuildingManager", "building_manager",
+        "Tenant", "tenant"
+    );
+}
+`
+	recs := extractJavaForEnum(t, "RoleSlugs.java", src)
+
+	// (a) emitted + (b) searchable by name.
+	en := findJavaEnum(recs, "RoleSlugs.ROLE_SLUGS")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:RoleSlugs.ROLE_SLUGS value-set not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "java_const_map" {
+		t.Fatalf("kind_hint = %q, want java_const_map", got)
+	}
+	if got := en.Properties["member_count"]; got != "3" {
+		t.Fatalf("member_count = %q, want 3", got)
+	}
+
+	// (c) members enumerate the real key→value pairs (the hyphen vs underscore
+	// distinction is preserved as structured data).
+	m := parseMembersJSON(t, en)
+	if m["CoreAdmin"] != "core-admin" {
+		t.Fatalf("CoreAdmin -> %q, want core-admin", m["CoreAdmin"])
+	}
+	if m["BuildingManager"] != "building_manager" {
+		t.Fatalf("BuildingManager -> %q, want building_manager", m["BuildingManager"])
+	}
+	if m["Tenant"] != "tenant" {
+		t.Fatalf("Tenant -> %q, want tenant", m["Tenant"])
+	}
+}
+
+// TestJavaConstGroup_InterfaceConstants validates the constants-interface
+// shape: a group of `String FOO = "foo";` constants in an interface is emitted
+// as one value-set named after the interface.
+func TestJavaConstGroup_InterfaceConstants(t *testing.T) {
+	src := `
+package com.upvate.auth;
+
+public interface Permissions {
+    String READ = "read";
+    String WRITE = "write";
+    String DELETE = "delete";
+    int MAX_PAGES = 50;
+}
+`
+	recs := extractJavaForEnum(t, "Permissions.java", src)
+
+	en := findJavaEnum(recs, "Permissions")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Permissions constant-group value-set not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "java_const_group" {
+		t.Fatalf("kind_hint = %q, want java_const_group", got)
+	}
+	m := parseMembersJSON(t, en)
+	if m["READ"] != "read" || m["WRITE"] != "write" || m["DELETE"] != "delete" {
+		t.Fatalf("string constants not enumerated: %#v", m)
+	}
+	if m["MAX_PAGES"] != "50" {
+		t.Fatalf("MAX_PAGES -> %q, want 50", m["MAX_PAGES"])
+	}
+}
+
+// TestJavaConstMap_MapOfEntries covers the Map.ofEntries(entry(...)) shape.
+func TestJavaConstMap_MapOfEntries(t *testing.T) {
+	src := `
+package com.upvate.auth;
+
+import java.util.Map;
+import static java.util.Map.entry;
+
+public final class Codes {
+    static final Map<String, String> CODES = Map.ofEntries(
+        entry("ok", "200"),
+        entry("notFound", "404")
+    );
+}
+`
+	recs := extractJavaForEnum(t, "Codes.java", src)
+	en := findJavaEnum(recs, "Codes.CODES")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Codes.CODES (ofEntries) value-set not found")
+	}
+	m := parseMembersJSON(t, en)
+	if m["ok"] != "200" || m["notFound"] != "404" {
+		t.Fatalf("ofEntries members not enumerated: %#v", m)
+	}
+}
+
+// TestJavaConstMap_GuavaImmutableMap covers Guava ImmutableMap.of(...) and the
+// builder().put(...).build() chain (declaration order preserved).
+func TestJavaConstMap_GuavaImmutableMap(t *testing.T) {
+	src := `
+package com.upvate.auth;
+
+import com.google.common.collect.ImmutableMap;
+
+public final class GuavaMaps {
+    static final ImmutableMap<String, String> FLAT =
+        ImmutableMap.of("a", "1", "b", "2");
+    static final ImmutableMap<String, String> BUILT =
+        ImmutableMap.<String, String>builder()
+            .put("x", "10")
+            .put("y", "20")
+            .build();
+}
+`
+	recs := extractJavaForEnum(t, "GuavaMaps.java", src)
+
+	flat := findJavaEnum(recs, "GuavaMaps.FLAT")
+	if flat == nil {
+		t.Fatal("SCOPE.Enum:GuavaMaps.FLAT (ImmutableMap.of) not found")
+	}
+	fm := parseMembersJSON(t, flat)
+	if fm["a"] != "1" || fm["b"] != "2" {
+		t.Fatalf("ImmutableMap.of members: %#v", fm)
+	}
+
+	built := findJavaEnum(recs, "GuavaMaps.BUILT")
+	if built == nil {
+		t.Fatal("SCOPE.Enum:GuavaMaps.BUILT (builder chain) not found")
+	}
+	bm := parseMembersJSON(t, built)
+	if bm["x"] != "10" || bm["y"] != "20" {
+		t.Fatalf("ImmutableMap builder members: %#v", bm)
+	}
+	// Declaration order: x before y.
+	if built.Properties["members"] != "x, y" {
+		t.Fatalf("builder order = %q, want \"x, y\"", built.Properties["members"])
+	}
+}
+
+// TestJavaConstArray covers a static-final array of constant string literals.
+func TestJavaConstArray(t *testing.T) {
+	src := `
+package com.upvate.auth;
+
+public final class Names {
+    static final String[] NAMES = {"alpha", "beta", "gamma"};
+}
+`
+	recs := extractJavaForEnum(t, "Names.java", src)
+	en := findJavaEnum(recs, "Names.NAMES")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Names.NAMES (const array) not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "java_const_array" {
+		t.Fatalf("kind_hint = %q, want java_const_array", got)
+	}
+	if got := en.Properties["members"]; got != "alpha, beta, gamma" {
+		t.Fatalf("array members = %q", got)
+	}
+}
+
+// TestJavaConstGroup_SingleConstantNotEmitted asserts honest-partial: a lone
+// constant is NOT promoted to a value-set (needs ≥2 to be a comparable set).
+func TestJavaConstGroup_SingleConstantNotEmitted(t *testing.T) {
+	src := `
+package com.upvate.auth;
+
+public final class Lonely {
+    public static final String ONLY = "one";
+}
+`
+	recs := extractJavaForEnum(t, "Lonely.java", src)
+	if en := findJavaEnum(recs, "Lonely"); en != nil {
+		t.Fatalf("single constant should not form a value-set, got %s", en.Name)
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -342,6 +342,14 @@ func walk(
 				*out = append(*out, vs)
 			}
 		}
+		// #4430 — index constant COLLECTIONS (static-final Map.of/ImmutableMap
+		// maps & arrays, interface constant groups) as queryable SCOPE.Enum
+		// value-sets, the Java arm of the #4420/#4429 cross-language model.
+		if tn := childFieldText(node, "name", file.Content); tn != "" {
+			if body := node.ChildByFieldName("body"); body != nil {
+				*out = append(*out, buildJavaConstCollections(tn, body, file)...)
+			}
+		}
 		rec, ok := buildComponent(node, file, subtype, pkgName)
 		if ok {
 			// Issue #1996 — emit EXTENDS / IMPLEMENTS edges so the docgen


### PR DESCRIPTION
## Summary

Indexes Java constant **collections** as queryable `SCOPE.Enum` value-sets — the Java arm of the cross-language model already shipped for Python and TS in #4429 (epic #4419, ref #4334). Java const maps/arrays/constant-groups were previously invisible to `search_entities` and uncomparable by a cross-graph parity-audit; now each emits a value-set node carrying a structured, enumerable `members_json` (`[{key,value,line}]`) via the **shared** `extractor.EnumEntity` builder — **no new Kind**.

## Java shapes covered

| Shape | kind_hint |
|---|---|
| `static final Map<K,V> X = Map.of("a","b", ...)` | `java_const_map` |
| `static final Map<K,V> X = Map.ofEntries(entry(...), ...)` | `java_const_map` |
| Guava `ImmutableMap.of(...)` | `java_const_map` |
| Guava `ImmutableMap.<K,V>builder().put(...).build()` (order preserved) | `java_const_map` |
| `static final String[] X = {"a","b"}` | `java_const_array` |
| GROUP (≥2) of `String FOO = "foo";` class/interface constants | `java_const_group` |

Honest-partial: a non-literal key/value is captured by its source-expression text so the member stays enumerable; a lone single constant is **not** promoted to a value-set. Java enums already inherit `members_json` via the shared helper — verified, no change needed.

## Before / after

- **Before:** a Java `static final Map<String,String> ROLE_SLUGS = Map.of("CoreAdmin","core-admin", ...)` produced only a `SCOPE.Schema` field; the role→slug pairs (incl. the hyphen-vs-underscore parity distinction) were unreadable without re-parsing source.
- **After:** a `SCOPE.Enum:RoleSlugs.ROLE_SLUGS` value-set is emitted, searchable by name, with `members_json` enumerating `{CoreAdmin: core-admin, BuildingManager: building_manager, Tenant: tenant}`.

## Validation (in-pipeline, RED→GREEN)

New `issue4430_constset_test.go` runs the **real** registered Java extract pipeline on byte-copies of representative fixtures (a `Map.of` static-final map, an interface constant group, `Map.ofEntries`, Guava `of`/`builder`, a const array, and the lone-constant negative case), asserting each value-set is emitted, searchable, and enumerates the real key→value pairs.

## Gates

- `go build ./...` — pass
- `go vet ./internal/extractors/java/ ./internal/extractor/` — pass
- `go test ./internal/extractors/java/ ./internal/custom/java/ ./internal/extractor/ ./internal/types/` — pass

DEPLOY-DEFERRED.

Closes #4430

🤖 Generated with [Claude Code](https://claude.com/claude-code)