### PR TITLE
feat(extractor): index C# and Kotlin constant collections as queryable value-sets

### DIFF
--- a/internal/extractors/csharp/const_valueset.go
+++ b/internal/extractors/csharp/const_valueset.go
@@ -1,0 +1,318 @@
+package csharp
+
+// const_valueset.go — value-carrying SCOPE.Enum value-set nodes for C# constant
+// COLLECTIONS (#4428, extends #4429 / epic #4419). The shared cross-language
+// builder in internal/extractor (EnumEntity / EnumMember / StripLiteralQuotes)
+// already emits a structured `members_json` [{key,value,line}] property on every
+// value-set node, so a downstream cross-graph parity-audit can diff the literal
+// {key,value} set without re-parsing source. C# enums already feed EnumEntity
+// (buildEnumValueSet) and inherit members_json for free; THIS file adds the two
+// constant-collection shapes a `.cs` source-of-truth uses instead of an enum:
+//
+//   - `static readonly Dictionary<K,V> X = new() { {"k","v"}, ... }` /
+//     `new Dictionary<K,V> { ["k"] = "v", ... }` / collection-initializer const
+//     maps → kind_hint="csharp_const_map". Captured per {key,value,line}.
+//   - a class whose const / static-readonly STRING fields form a group
+//     (`public const string CoreAdmin = "core-admin"; ...`) → one value-set
+//     named after the class, kind_hint="csharp_const_group", each field a member.
+//
+// Honest-partial: only closed, all-string-literal collections emit a node. A
+// dictionary entry whose value is a call / identifier / non-literal expression
+// disqualifies the map (it is not a closed enumerated value-set). A class with
+// fewer than two string-const fields emits no group node (a single constant is
+// not a value-set).
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitConstCollectionsForClass scans the direct field_declaration children of a
+// class body and emits value-set nodes for the two C# constant-collection
+// shapes. className names the enclosing class (used as the const-group node
+// name). Appended nodes never replace the field entities the default walk emits.
+func emitConstCollectionsForClass(body *sitter.Node, file extractor.FileInput, className string, out *[]types.EntityRecord) {
+	if body == nil {
+		return
+	}
+	var groupMembers []extractor.EnumMember
+	for i := 0; i < int(body.ChildCount()); i++ {
+		fld := body.Child(i)
+		if fld == nil || fld.Type() != "field_declaration" {
+			continue
+		}
+		isConst, isStaticReadonly := fieldConstKind(fld)
+		if !isConst && !isStaticReadonly {
+			continue
+		}
+		// A Dictionary/collection-initialiser const map is its own value-set.
+		if vs, ok := buildConstMapValueSet(fld, file); ok {
+			*out = append(*out, vs)
+			continue
+		}
+		// Otherwise, a string-literal scalar const contributes to the
+		// class-level const group.
+		if name, val, line, ok := constStringField(fld, file); ok {
+			groupMembers = append(groupMembers, extractor.EnumMember{Name: name, Value: val, Line: line})
+		}
+	}
+	// A class-level const-string group is a value-set only when it has at
+	// least two members (a single constant is not an enumerated set).
+	if className != "" && len(groupMembers) >= 2 {
+		start := int(body.StartPoint().Row) + 1
+		end := int(body.EndPoint().Row) + 1
+		if ent, ok := extractor.EnumEntity(
+			className, "csharp", "csharp_const_group", file.Path, start, end, groupMembers,
+		); ok {
+			*out = append(*out, ent)
+		}
+	}
+}
+
+// fieldConstKind reports whether a field_declaration carries the `const`
+// modifier, or both `static` and `readonly` modifiers.
+func fieldConstKind(fld *sitter.Node) (isConst, isStaticReadonly bool) {
+	var static, readonly bool
+	for i := 0; i < int(fld.ChildCount()); i++ {
+		ch := fld.Child(i)
+		if ch == nil || ch.Type() != "modifier" {
+			continue
+		}
+		switch txt := ch.Child(0); {
+		case txt == nil:
+		default:
+			switch txt.Type() {
+			case "const":
+				isConst = true
+			case "static":
+				static = true
+			case "readonly":
+				readonly = true
+			}
+		}
+	}
+	return isConst, static && readonly
+}
+
+// constStringField extracts a scalar string-literal constant field's name,
+// value and 1-indexed line. ok=false when the field is not a single
+// string-literal-valued declarator (e.g. a Dictionary map, an int const, or a
+// non-literal initialiser).
+func constStringField(fld *sitter.Node, file extractor.FileInput) (name, value string, line int, ok bool) {
+	decl := findChildByType(fld, "variable_declaration")
+	if decl == nil {
+		return "", "", 0, false
+	}
+	// Only `string`-typed scalar consts join the group (`predefined_type`
+	// "string"); a Dictionary<...> generic_name is handled as a map.
+	pt := findChildByType(decl, "predefined_type")
+	if pt == nil || nodeText(pt, file.Content) != "string" {
+		return "", "", 0, false
+	}
+	vd := findChildByType(decl, "variable_declarator")
+	if vd == nil {
+		return "", "", 0, false
+	}
+	var mname, mval string
+	gotVal := false
+	for i := 0; i < int(vd.ChildCount()); i++ {
+		ch := vd.Child(i)
+		if ch == nil {
+			continue
+		}
+		if ch.Type() == "identifier" && mname == "" {
+			mname = nodeText(ch, file.Content)
+			continue
+		}
+		if mname != "" && ch.IsNamed() {
+			if ch.Type() != "string_literal" {
+				return "", "", 0, false // non-literal initialiser
+			}
+			mval = stringLiteralText(ch, file.Content)
+			gotVal = true
+		}
+	}
+	if mname == "" || !gotVal {
+		return "", "", 0, false
+	}
+	return mname, mval, int(vd.StartPoint().Row) + 1, true
+}
+
+// buildConstMapValueSet emits a value-set for a Dictionary / collection-
+// initialiser constant map field. It handles both the object-initialiser
+// `{ "k", "v" }` element form and the indexer `["k"] = "v"` form. ok=false when
+// the field is not a Dictionary-shaped map, has no initialiser entries, or any
+// entry is not a {string-literal key, string-literal value} pair (honest-partial
+// closed value-set).
+func buildConstMapValueSet(fld *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	decl := findChildByType(fld, "variable_declaration")
+	if decl == nil {
+		return types.EntityRecord{}, false
+	}
+	// The declared type must be a generic Dictionary<...> (or Immutable*) — a
+	// plain string const is not a map.
+	gn := findChildByType(decl, "generic_name")
+	if gn == nil {
+		return types.EntityRecord{}, false
+	}
+	typeName := nodeText(findChildByType(gn, "identifier"), file.Content)
+	if !isDictionaryType(typeName) {
+		return types.EntityRecord{}, false
+	}
+	vd := findChildByType(decl, "variable_declarator")
+	if vd == nil {
+		return types.EntityRecord{}, false
+	}
+	mapName := nodeText(findChildByType(vd, "identifier"), file.Content)
+	if mapName == "" {
+		return types.EntityRecord{}, false
+	}
+	// Locate the outer initializer_expression: it hangs off the
+	// implicit_object_creation_expression (`new() {...}`) or
+	// object_creation_expression (`new Dictionary<...> {...}`).
+	creation := findChildByType(vd, "implicit_object_creation_expression")
+	if creation == nil {
+		creation = findChildByType(vd, "object_creation_expression")
+	}
+	if creation == nil {
+		return types.EntityRecord{}, false
+	}
+	init := findChildByType(creation, "initializer_expression")
+	if init == nil {
+		return types.EntityRecord{}, false
+	}
+	members, ok := collectMapInitMembers(init, file)
+	if !ok || len(members) == 0 {
+		return types.EntityRecord{}, false
+	}
+	return extractor.EnumEntity(
+		mapName, "csharp", "csharp_const_map", file.Path,
+		int(fld.StartPoint().Row)+1, int(fld.EndPoint().Row)+1, members,
+	)
+}
+
+// collectMapInitMembers walks an initializer_expression's entries, accepting
+// either nested `{ "k", "v" }` element initialisers or `["k"] = "v"` indexer
+// assignments. It returns ok=false the moment any entry is not a
+// string-literal/string-literal pair so a non-closed map emits no node.
+func collectMapInitMembers(init *sitter.Node, file extractor.FileInput) ([]extractor.EnumMember, bool) {
+	var members []extractor.EnumMember
+	for i := 0; i < int(init.ChildCount()); i++ {
+		entry := init.Child(i)
+		if entry == nil || !entry.IsNamed() {
+			continue
+		}
+		switch entry.Type() {
+		case "initializer_expression":
+			// `{ "key", "value" }` — two string-literal element children.
+			key, val, ok := twoStringLiterals(entry, file)
+			if !ok {
+				return nil, false
+			}
+			members = append(members, extractor.EnumMember{Name: key, Value: val, Line: int(entry.StartPoint().Row) + 1})
+		case "assignment_expression":
+			// `["key"] = "value"` — element_binding_expression = string_literal.
+			key, val, ok := indexerAssignment(entry, file)
+			if !ok {
+				return nil, false
+			}
+			members = append(members, extractor.EnumMember{Name: key, Value: val, Line: int(entry.StartPoint().Row) + 1})
+		default:
+			return nil, false
+		}
+	}
+	return members, true
+}
+
+// twoStringLiterals reads the first two string_literal children of a nested
+// `{ "k", "v" }` element initializer. ok=false when fewer than two string
+// literals are present (a non-string key or value disqualifies the map).
+func twoStringLiterals(entry *sitter.Node, file extractor.FileInput) (key, val string, ok bool) {
+	var lits []string
+	for i := 0; i < int(entry.ChildCount()); i++ {
+		ch := entry.Child(i)
+		if ch == nil || ch.Type() != "string_literal" {
+			continue
+		}
+		lits = append(lits, stringLiteralText(ch, file.Content))
+	}
+	if len(lits) < 2 {
+		return "", "", false
+	}
+	return lits[0], lits[1], true
+}
+
+// indexerAssignment reads an `["key"] = "value"` assignment_expression: the key
+// is the string_literal inside the element_binding_expression, the value is the
+// string_literal RHS. ok=false when either side is not a string literal.
+func indexerAssignment(entry *sitter.Node, file extractor.FileInput) (key, val string, ok bool) {
+	binding := findChildByType(entry, "element_binding_expression")
+	if binding == nil {
+		return "", "", false
+	}
+	keyLit := findDeepStringLiteral(binding, file)
+	if keyLit == "" {
+		return "", "", false
+	}
+	// The RHS value is the first top-level string_literal child of the
+	// assignment (after the element_binding_expression / `=`).
+	var valLit string
+	for i := 0; i < int(entry.ChildCount()); i++ {
+		ch := entry.Child(i)
+		if ch != nil && ch.Type() == "string_literal" {
+			valLit = stringLiteralText(ch, file.Content)
+			break
+		}
+	}
+	if valLit == "" {
+		return "", "", false
+	}
+	return keyLit, valLit, true
+}
+
+// findDeepStringLiteral returns the text of the first string_literal found in a
+// shallow DFS of node, or "" when none is present. Used to pull the key out of
+// an `["key"]` element_binding_expression's `argument` wrapper.
+func findDeepStringLiteral(node *sitter.Node, file extractor.FileInput) string {
+	if node == nil {
+		return ""
+	}
+	if node.Type() == "string_literal" {
+		return stringLiteralText(node, file.Content)
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		if s := findDeepStringLiteral(node.Child(i), file); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// stringLiteralText returns the inner text of a C# string_literal node, with
+// the surrounding quotes stripped. Tree-sitter exposes the content as a
+// `string_literal_content` child; falling back to StripLiteralQuotes over the
+// raw token covers verbatim/interpolated tokens that lack that child.
+func stringLiteralText(lit *sitter.Node, src []byte) string {
+	if lit == nil {
+		return ""
+	}
+	if content := findChildByType(lit, "string_literal_content"); content != nil {
+		return nodeText(content, src)
+	}
+	return extractor.StripLiteralQuotes(nodeText(lit, src))
+}
+
+// isDictionaryType reports whether a generic type's bare name is a recognised
+// map-like collection (Dictionary / IDictionary / ImmutableDictionary /
+// SortedDictionary / ConcurrentDictionary / ReadOnlyDictionary).
+func isDictionaryType(name string) bool {
+	switch name {
+	case "Dictionary", "IDictionary", "IReadOnlyDictionary",
+		"ImmutableDictionary", "IImmutableDictionary",
+		"SortedDictionary", "ConcurrentDictionary", "ReadOnlyDictionary":
+		return true
+	}
+	return false
+}

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -154,6 +154,10 @@ func walk(
 		*out = append(*out, rec)
 		body := findTypeBody(node)
 		if body != nil {
+			// #4428: emit value-set nodes for class-level constant COLLECTIONS
+			// (static-readonly Dictionary const maps + grouped string consts).
+			// Append-only: never replaces the field entities the walk emits.
+			emitConstCollectionsForClass(body, file, rec.Name, out)
 			localCtx := &classCtx{fields: collectFieldTypes(body, file.Content)}
 			before := len(*out)
 			for i := range body.ChildCount() {

--- a/internal/extractors/csharp/issue4428_constmap_test.go
+++ b/internal/extractors/csharp/issue4428_constmap_test.go
@@ -1,0 +1,175 @@
+package csharp_test
+
+// issue4428_constmap_test.go — value-asserting, REAL-pipeline tests for the C#
+// constant-COLLECTION value-sets (#4428, extends #4429 / epic #4419). A C#
+// source-of-truth uses a `static readonly Dictionary` const map or a grouped
+// set of string consts instead of an enum; both must be emitted as
+// name-searchable SCOPE.Enum value-set nodes whose members enumerate the real
+// {key,value} pairs as STRUCTURED members_json so a downstream cross-graph
+// parity-audit reads the literal set without re-parsing source.
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+type csMember struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Line  int    `json:"line"`
+}
+
+func csFindEnum(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Enum" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func csMembers(t *testing.T, e *types.EntityRecord) []csMember {
+	t.Helper()
+	raw := e.Properties["members_json"]
+	if raw == "" {
+		t.Fatalf("entity %q has no members_json; props=%v", e.Name, e.Properties)
+	}
+	var got []csMember
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("members_json not valid JSON: %v (raw=%s)", err, raw)
+	}
+	return got
+}
+
+func csMemberValue(ms []csMember, key string) (string, bool) {
+	for _, m := range ms {
+		if m.Key == key {
+			return m.Value, true
+		}
+	}
+	return "", false
+}
+
+// TestIssue4428_RealCSharpConstCollections runs the live-shaped fixture through
+// the REAL extract pipeline and asserts BOTH the Dictionary const map and the
+// grouped string consts surface as searchable value-sets enumerating their real
+// key→value pairs.
+func TestIssue4428_RealCSharpConstCollections(t *testing.T) {
+	src, err := os.ReadFile("testdata/issue4428/PermissionPages.cs")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	ents := extractCSharpRecords(t, string(src))
+
+	// 1) The `static readonly Dictionary` const map (object-initialiser form).
+	labels := csFindEnum(ents, "PageLabels")
+	if labels == nil {
+		t.Fatal("SCOPE.Enum:PageLabels const-map value-set not found")
+	}
+	if got := labels.Properties["kind_hint"]; got != "csharp_const_map" {
+		t.Fatalf("PageLabels kind_hint = %q, want csharp_const_map", got)
+	}
+	lm := csMembers(t, labels)
+	if v, ok := csMemberValue(lm, "core-admin"); !ok || v != "Core Admin" {
+		t.Fatalf("PageLabels[core-admin] = %q (ok=%v), want Core Admin", v, ok)
+	}
+	if v, ok := csMemberValue(lm, "billing"); !ok || v != "Billing" {
+		t.Fatalf("PageLabels[billing] = %q (ok=%v), want Billing", v, ok)
+	}
+	if len(lm) != 3 {
+		t.Fatalf("PageLabels member count = %d, want 3", len(lm))
+	}
+
+	// 2) The indexer-init Dictionary const map (`["k"] = "v"` form).
+	routes := csFindEnum(ents, "PageRoutes")
+	if routes == nil {
+		t.Fatal("SCOPE.Enum:PageRoutes const-map value-set not found")
+	}
+	if got := routes.Properties["kind_hint"]; got != "csharp_const_map" {
+		t.Fatalf("PageRoutes kind_hint = %q, want csharp_const_map", got)
+	}
+	rm := csMembers(t, routes)
+	if v, ok := csMemberValue(rm, "core-admin"); !ok || v != "/admin" {
+		t.Fatalf("PageRoutes[core-admin] = %q (ok=%v), want /admin", v, ok)
+	}
+
+	// 3) The grouped string consts → one value-set named after the class.
+	group := csFindEnum(ents, "PermissionPages")
+	if group == nil {
+		t.Fatal("SCOPE.Enum:PermissionPages const-group value-set not found")
+	}
+	if got := group.Properties["kind_hint"]; got != "csharp_const_group" {
+		t.Fatalf("PermissionPages kind_hint = %q, want csharp_const_group", got)
+	}
+	gm := csMembers(t, group)
+	if v, ok := csMemberValue(gm, "CoreAdmin"); !ok || v != "core-admin" {
+		t.Fatalf("PermissionPages.CoreAdmin = %q (ok=%v), want core-admin", v, ok)
+	}
+	if v, ok := csMemberValue(gm, "Billing"); !ok || v != "billing" {
+		t.Fatalf("PermissionPages.Billing = %q (ok=%v), want billing", v, ok)
+	}
+	if len(gm) != 3 {
+		t.Fatalf("PermissionPages group member count = %d, want 3", len(gm))
+	}
+}
+
+// TestIssue4428_CSharpEnumCarriesMembersJSON guards that a backed C# enum also
+// carries the structured members_json the shared helper emits (the #4429
+// enrichment), so all three C# value-set shapes are diff-ready.
+func TestIssue4428_CSharpEnumCarriesMembersJSON(t *testing.T) {
+	src := `
+namespace App
+{
+    public enum Status { Active = 1, Inactive = 2 }
+}
+`
+	ents := extractCSharpRecords(t, src)
+	en := csFindEnum(ents, "Status")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:Status not found")
+	}
+	ms := csMembers(t, en)
+	if v, ok := csMemberValue(ms, "Active"); !ok || v != "1" {
+		t.Fatalf("Status.Active = %q (ok=%v), want 1", v, ok)
+	}
+}
+
+// TestIssue4428_CSharpNonLiteralMapSkipped asserts honest-partial: a Dictionary
+// whose values are non-literal (a call / identifier) is NOT a closed value-set
+// and emits no node.
+func TestIssue4428_CSharpNonLiteralMapSkipped(t *testing.T) {
+	src := `
+namespace App
+{
+    public static class Cfg
+    {
+        public static readonly Dictionary<string, string> M = new()
+        {
+            { "a", Compute() },
+        };
+    }
+}
+`
+	ents := extractCSharpRecords(t, src)
+	if en := csFindEnum(ents, "M"); en != nil {
+		t.Fatalf("non-literal-valued map M should emit no value-set, got %+v", en.Properties)
+	}
+}
+
+// TestIssue4428_CSharpSingleConstNoGroup asserts a class with a single string
+// const does not form a value-set group (a lone constant is not an enumeration).
+func TestIssue4428_CSharpSingleConstNoGroup(t *testing.T) {
+	src := `
+namespace App
+{
+    public static class One { public const string Only = "x"; }
+}
+`
+	ents := extractCSharpRecords(t, src)
+	if en := csFindEnum(ents, "One"); en != nil {
+		t.Fatalf("single-const class should emit no group value-set, got %+v", en.Properties)
+	}
+}

--- a/internal/extractors/csharp/testdata/issue4428/PermissionPages.cs
+++ b/internal/extractors/csharp/testdata/issue4428/PermissionPages.cs
@@ -1,0 +1,27 @@
+// Representative C# permission source-of-truth (#4428). Mirrors the Django
+// PERMISSION_PAGES dict / v3 PermissionPage map: a static-readonly Dictionary
+// const map AND a grouped set of string consts. The hyphenated literal values
+// (core-admin vs the underscore the v3 const-name uses) are the kind of drift a
+// downstream cross-graph parity-audit reads from the structured members_json.
+namespace App.Auth
+{
+    public static class PermissionPages
+    {
+        public const string CoreAdmin = "core-admin";
+        public const string Billing = "billing";
+        public const string Reports = "reports";
+
+        public static readonly Dictionary<string, string> PageLabels = new()
+        {
+            { "core-admin", "Core Admin" },
+            { "billing", "Billing" },
+            { "reports", "Reports" },
+        };
+
+        public static readonly Dictionary<string, string> PageRoutes = new Dictionary<string, string>
+        {
+            ["core-admin"] = "/admin",
+            ["billing"] = "/billing",
+        };
+    }
+}

--- a/internal/extractors/kotlin/const_valueset.go
+++ b/internal/extractors/kotlin/const_valueset.go
@@ -1,0 +1,292 @@
+package kotlin
+
+// const_valueset.go — value-carrying SCOPE.Enum value-set nodes for Kotlin
+// enums and constant COLLECTIONS (#4428, extends #4429 / epic #4419). The
+// shared cross-language builder in internal/extractor (EnumEntity / EnumMember /
+// StripLiteralQuotes) emits a structured `members_json` [{key,value,line}]
+// property on every value-set node, so a downstream cross-graph parity-audit
+// can diff the literal {key,value} set without re-parsing source.
+//
+// Kotlin had no value-set extraction before this; three shapes map to a node:
+//
+//   - `enum class E(val v: String) { A("a"), B("b") }` →
+//     kind_hint="kotlin_enum". Each enum_entry's name is the member; the first
+//     string-literal constructor argument is its value (value-less when the
+//     entry has no literal argument — no fabricated ordinal).
+//   - `object Pages { const val CORE_ADMIN = "core-admin"; ... }` /
+//     a class with grouped `const val` string properties →
+//     kind_hint="kotlin_const_group", node named after the object/class.
+//   - `val ROUTES = mapOf("a" to "x", ...)` top-level or object-level →
+//     kind_hint="kotlin_const_map", each `"k" to "v"` infix pair a member.
+//
+// Honest-partial: a const-group node needs ≥2 string-literal `const val`
+// members; a mapOf node is emitted only when every argument is a
+// `"literal" to "literal"` pair (any non-literal pair disqualifies the map).
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitEnumValueSet builds the value-carrying SCOPE.Enum node for a Kotlin
+// `enum class`, capturing each entry's first string-literal constructor
+// argument as its value. ok=false when the declaration is not an enum class or
+// has no entries.
+func emitEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	name := firstChildOfType(node, file.Content, "type_identifier")
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	body := findChildByTypeKt(node, "enum_class_body")
+	if body == nil {
+		return types.EntityRecord{}, false
+	}
+	var members []extractor.EnumMember
+	for i := 0; i < int(body.ChildCount()); i++ {
+		entry := body.Child(i)
+		if entry == nil || entry.Type() != "enum_entry" {
+			continue
+		}
+		mname := firstChildOfType(entry, file.Content, "simple_identifier")
+		if mname == "" {
+			continue
+		}
+		mval := firstStringArg(findChildByTypeKt(entry, "value_arguments"), file)
+		members = append(members, extractor.EnumMember{
+			Name:  mname,
+			Value: mval,
+			Line:  int(entry.StartPoint().Row) + 1,
+		})
+	}
+	return extractor.EnumEntity(
+		name, "kotlin", "kotlin_enum", file.Path,
+		int(node.StartPoint().Row)+1, int(node.EndPoint().Row)+1, members,
+	)
+}
+
+// emitConstGroupValueSet builds a value-set from the grouped `const val`
+// string-literal properties of an object/class body. groupName names the
+// enclosing object/class. ok=false when fewer than two such members exist (a
+// single constant is not an enumerated value-set).
+func emitConstGroupValueSet(body *sitter.Node, file extractor.FileInput, groupName string) (types.EntityRecord, bool) {
+	if body == nil || groupName == "" {
+		return types.EntityRecord{}, false
+	}
+	var members []extractor.EnumMember
+	for i := 0; i < int(body.ChildCount()); i++ {
+		prop := body.Child(i)
+		if prop == nil || prop.Type() != "property_declaration" {
+			continue
+		}
+		if !hasConstModifier(prop, file.Content) {
+			continue
+		}
+		name, val, ok := constValStringProp(prop, file)
+		if !ok {
+			continue
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  name,
+			Value: val,
+			Line:  int(prop.StartPoint().Row) + 1,
+		})
+	}
+	if len(members) < 2 {
+		return types.EntityRecord{}, false
+	}
+	return extractor.EnumEntity(
+		groupName, "kotlin", "kotlin_const_group", file.Path,
+		int(body.StartPoint().Row)+1, int(body.EndPoint().Row)+1, members,
+	)
+}
+
+// emitMapValueSet builds a value-set for a `val X = mapOf("a" to "b", ...)`
+// property_declaration (top-level or object/class-level). ok=false when the
+// initialiser is not a mapOf call, has no arguments, or any argument is not a
+// closed `"literal" to "literal"` pair (honest-partial).
+func emitMapValueSet(prop *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	varDecl := findChildByTypeKt(prop, "variable_declaration")
+	if varDecl == nil {
+		return types.EntityRecord{}, false
+	}
+	mapName := firstChildOfType(varDecl, file.Content, "simple_identifier")
+	if mapName == "" {
+		return types.EntityRecord{}, false
+	}
+	call := findChildByTypeKt(prop, "call_expression")
+	if call == nil {
+		return types.EntityRecord{}, false
+	}
+	if fn := firstChildOfType(call, file.Content, "simple_identifier"); !isMapFactory(fn) {
+		return types.EntityRecord{}, false
+	}
+	suffix := findChildByTypeKt(call, "call_suffix")
+	if suffix == nil {
+		return types.EntityRecord{}, false
+	}
+	args := findChildByTypeKt(suffix, "value_arguments")
+	if args == nil {
+		return types.EntityRecord{}, false
+	}
+	var members []extractor.EnumMember
+	for i := 0; i < int(args.ChildCount()); i++ {
+		va := args.Child(i)
+		if va == nil || va.Type() != "value_argument" {
+			continue
+		}
+		infix := findChildByTypeKt(va, "infix_expression")
+		if infix == nil {
+			return types.EntityRecord{}, false // not a `k to v` pair
+		}
+		key, val, ok := infixToPair(infix, file)
+		if !ok {
+			return types.EntityRecord{}, false
+		}
+		members = append(members, extractor.EnumMember{
+			Name:  key,
+			Value: val,
+			Line:  int(va.StartPoint().Row) + 1,
+		})
+	}
+	if len(members) == 0 {
+		return types.EntityRecord{}, false
+	}
+	return extractor.EnumEntity(
+		mapName, "kotlin", "kotlin_const_map", file.Path,
+		int(prop.StartPoint().Row)+1, int(prop.EndPoint().Row)+1, members,
+	)
+}
+
+// infixToPair reads a `"key" to "value"` infix_expression: the operator must be
+// the `to` infix function and both operands must be string literals. ok=false
+// otherwise (a non-`to` infix, or a non-literal operand).
+func infixToPair(infix *sitter.Node, file extractor.FileInput) (key, val string, ok bool) {
+	// Shape: string_literal | simple_identifier("to") | string_literal.
+	var lits []string
+	sawTo := false
+	for i := 0; i < int(infix.ChildCount()); i++ {
+		ch := infix.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "string_literal":
+			lits = append(lits, ktStringText(ch, file.Content))
+		case "simple_identifier":
+			if nodeTextKt(ch, file.Content) == "to" {
+				sawTo = true
+			} else {
+				return "", "", false // non-literal operand
+			}
+		}
+	}
+	if !sawTo || len(lits) < 2 {
+		return "", "", false
+	}
+	return lits[0], lits[1], true
+}
+
+// constValStringProp reads a `const val NAME = "literal"` property's name and
+// string value. ok=false when the initialiser is not a single string literal.
+func constValStringProp(prop *sitter.Node, file extractor.FileInput) (name, val string, ok bool) {
+	varDecl := findChildByTypeKt(prop, "variable_declaration")
+	if varDecl == nil {
+		return "", "", false
+	}
+	name = firstChildOfType(varDecl, file.Content, "simple_identifier")
+	if name == "" {
+		return "", "", false
+	}
+	lit := findChildByTypeKt(prop, "string_literal")
+	if lit == nil {
+		return "", "", false
+	}
+	return name, ktStringText(lit, file.Content), true
+}
+
+// hasConstModifier reports whether a property_declaration carries the `const`
+// property modifier (`modifiers > property_modifier`). The grammar represents
+// the `const` keyword as the property_modifier node's own text (it has no child
+// `const` token), so the modifier text is compared directly.
+func hasConstModifier(prop *sitter.Node, src []byte) bool {
+	mods := findChildByTypeKt(prop, "modifiers")
+	if mods == nil {
+		return false
+	}
+	for i := 0; i < int(mods.ChildCount()); i++ {
+		ch := mods.Child(i)
+		if ch == nil || ch.Type() != "property_modifier" {
+			continue
+		}
+		if nodeTextKt(ch, src) == "const" {
+			return true
+		}
+	}
+	return false
+}
+
+// firstStringArg returns the inner text of the first string_literal inside a
+// value_arguments node, or "" when none is present (a value-less enum entry).
+func firstStringArg(args *sitter.Node, file extractor.FileInput) string {
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		va := args.Child(i)
+		if va == nil || va.Type() != "value_argument" {
+			continue
+		}
+		if lit := findChildByTypeKt(va, "string_literal"); lit != nil {
+			return ktStringText(lit, file.Content)
+		}
+	}
+	return ""
+}
+
+// ktStringText returns the inner text of a Kotlin string_literal node. The
+// grammar exposes the body as `string_content` child(ren); falling back to
+// StripLiteralQuotes covers an empty / interpolated literal.
+func ktStringText(lit *sitter.Node, src []byte) string {
+	if lit == nil {
+		return ""
+	}
+	if content := findChildByTypeKt(lit, "string_content"); content != nil {
+		return nodeTextKt(content, src)
+	}
+	return extractor.StripLiteralQuotes(nodeTextKt(lit, src))
+}
+
+// isMapFactory reports whether fn is a Kotlin standard map factory whose
+// arguments are `key to value` pairs.
+func isMapFactory(fn string) bool {
+	switch fn {
+	case "mapOf", "mutableMapOf", "linkedMapOf", "sortedMapOf", "hashMapOf":
+		return true
+	}
+	return false
+}
+
+// findChildByTypeKt returns the first direct child of node with the given type,
+// or nil.
+func findChildByTypeKt(node *sitter.Node, t string) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch != nil && ch.Type() == t {
+			return ch
+		}
+	}
+	return nil
+}
+
+// nodeTextKt returns the source text spanned by node.
+func nodeTextKt(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	return string(src[node.StartByte():node.EndByte()])
+}

--- a/internal/extractors/kotlin/issue4428_constmap_test.go
+++ b/internal/extractors/kotlin/issue4428_constmap_test.go
@@ -1,0 +1,171 @@
+package kotlin_test
+
+// issue4428_constmap_test.go — value-asserting, REAL-pipeline tests for the
+// Kotlin enum + constant-COLLECTION value-sets (#4428, extends #4429 / epic
+// #4419). Kotlin had no value-set extraction before this; an `object` const-val
+// group, a top-level `mapOf` const map, and an `enum class` with constructor
+// values must all surface as name-searchable SCOPE.Enum nodes whose members
+// enumerate the real {key,value} pairs as STRUCTURED members_json.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+type ktMember struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+	Line  int    `json:"line"`
+}
+
+func extractKotlinRecords(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("kotlin")
+	if !ok {
+		t.Fatal("kotlin extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "kotlin",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract failed: %v", err)
+	}
+	return recs
+}
+
+func ktFindEnum(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Enum" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func ktMembers(t *testing.T, e *types.EntityRecord) []ktMember {
+	t.Helper()
+	raw := e.Properties["members_json"]
+	if raw == "" {
+		t.Fatalf("entity %q has no members_json; props=%v", e.Name, e.Properties)
+	}
+	var got []ktMember
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("members_json not valid JSON: %v (raw=%s)", err, raw)
+	}
+	return got
+}
+
+func ktMemberValue(ms []ktMember, key string) (string, bool) {
+	for _, m := range ms {
+		if m.Key == key {
+			return m.Value, true
+		}
+	}
+	return "", false
+}
+
+// TestIssue4428_RealKotlinConstCollections runs the live-shaped fixture through
+// the REAL extract pipeline and asserts the object const-val group, the
+// top-level mapOf const map, AND the enum class all surface as searchable
+// value-sets enumerating their real key→value pairs.
+func TestIssue4428_RealKotlinConstCollections(t *testing.T) {
+	src, err := os.ReadFile("testdata/issue4428/PermissionPages.kt")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	ents := extractKotlinRecords(t, string(src), "PermissionPages.kt")
+
+	// 1) `object Pages { const val ... }` → group named after the object.
+	group := ktFindEnum(ents, "PermissionPages")
+	if group == nil {
+		t.Fatal("SCOPE.Enum:PermissionPages const-group value-set not found")
+	}
+	if got := group.Properties["kind_hint"]; got != "kotlin_const_group" {
+		t.Fatalf("PermissionPages kind_hint = %q, want kotlin_const_group", got)
+	}
+	gm := ktMembers(t, group)
+	if v, ok := ktMemberValue(gm, "CORE_ADMIN"); !ok || v != "core-admin" {
+		t.Fatalf("PermissionPages.CORE_ADMIN = %q (ok=%v), want core-admin", v, ok)
+	}
+	if v, ok := ktMemberValue(gm, "BILLING"); !ok || v != "billing" {
+		t.Fatalf("PermissionPages.BILLING = %q (ok=%v), want billing", v, ok)
+	}
+	if len(gm) != 3 {
+		t.Fatalf("PermissionPages group member count = %d, want 3", len(gm))
+	}
+
+	// 2) top-level `val X = mapOf("a" to "b", ...)`.
+	labels := ktFindEnum(ents, "PAGE_LABELS")
+	if labels == nil {
+		t.Fatal("SCOPE.Enum:PAGE_LABELS const-map value-set not found")
+	}
+	if got := labels.Properties["kind_hint"]; got != "kotlin_const_map" {
+		t.Fatalf("PAGE_LABELS kind_hint = %q, want kotlin_const_map", got)
+	}
+	lm := ktMembers(t, labels)
+	if v, ok := ktMemberValue(lm, "core-admin"); !ok || v != "Core Admin" {
+		t.Fatalf("PAGE_LABELS[core-admin] = %q (ok=%v), want Core Admin", v, ok)
+	}
+	if len(lm) != 3 {
+		t.Fatalf("PAGE_LABELS member count = %d, want 3", len(lm))
+	}
+
+	// 3) `enum class PageGroup(val slug: String) { ADMIN("core-admin"), ... }`.
+	en := ktFindEnum(ents, "PageGroup")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:PageGroup enum value-set not found")
+	}
+	if got := en.Properties["kind_hint"]; got != "kotlin_enum" {
+		t.Fatalf("PageGroup kind_hint = %q, want kotlin_enum", got)
+	}
+	em := ktMembers(t, en)
+	if v, ok := ktMemberValue(em, "ADMIN"); !ok || v != "core-admin" {
+		t.Fatalf("PageGroup.ADMIN = %q (ok=%v), want core-admin", v, ok)
+	}
+	if v, ok := ktMemberValue(em, "FINANCE"); !ok || v != "billing" {
+		t.Fatalf("PageGroup.FINANCE = %q (ok=%v), want billing", v, ok)
+	}
+}
+
+// TestIssue4428_KotlinNonLiteralMapSkipped asserts honest-partial: a mapOf with
+// a non-literal value (`"a" to compute()`) is NOT a closed value-set and emits
+// no node.
+func TestIssue4428_KotlinNonLiteralMapSkipped(t *testing.T) {
+	src := `
+package com.example
+val M = mapOf("a" to compute(), "b" to "y")
+`
+	ents := extractKotlinRecords(t, src, "M.kt")
+	if en := ktFindEnum(ents, "M"); en != nil {
+		t.Fatalf("non-literal mapOf M should emit no value-set, got %+v", en.Properties)
+	}
+}
+
+// TestIssue4428_KotlinObjectMapMember asserts a `mapOf` declared inside an
+// object body (not just top-level) is also captured.
+func TestIssue4428_KotlinObjectMapMember(t *testing.T) {
+	src := `
+package com.example
+object Cfg {
+    val ROUTES = mapOf("home" to "/", "admin" to "/admin")
+}
+`
+	ents := extractKotlinRecords(t, src, "Cfg.kt")
+	en := ktFindEnum(ents, "ROUTES")
+	if en == nil {
+		t.Fatal("object-level mapOf ROUTES not captured as value-set")
+	}
+	ms := ktMembers(t, en)
+	if v, ok := ktMemberValue(ms, "admin"); !ok || v != "/admin" {
+		t.Fatalf("ROUTES[admin] = %q (ok=%v), want /admin", v, ok)
+	}
+}

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -144,8 +144,29 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		}
 		return
 
+	case "property_declaration":
+		// #4428: a TOP-LEVEL `val X = mapOf(...)` constant map. (Class/object
+		// body properties are intercepted by their declaration case below and
+		// never reach this top-level branch.) Emit a value-set when the
+		// initialiser is a closed all-literal map; otherwise fall through to
+		// the default recursion so nested constructs are still visited.
+		if vs, ok := emitMapValueSet(node, file); ok {
+			*out = append(*out, vs)
+		}
+		for i := range node.ChildCount() {
+			walk(node.Child(int(i)), file, out, ctx)
+		}
+		return
+
 	case "class_declaration":
 		subtype := classDeclarationSubtype(node, file.Content)
+		// #4428: an `enum class` carries a value-set (entries + constructor
+		// literal values). Emitted alongside the SCOPE.Component below.
+		if subtype == "enum" {
+			if vs, ok := emitEnumValueSet(node, file); ok {
+				*out = append(*out, vs)
+			}
+		}
 		rec, ok := buildComponent(node, file, subtype)
 		if !ok {
 			for i := range node.ChildCount() {
@@ -176,12 +197,21 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// so property entities would get bare names and CONTAINS
 				// stubs would not resolve. Emit them here instead.
 				if ch.Type() == "property_declaration" {
+					// #4428: a body-level `val X = mapOf(...)` constant map.
+					if vs, ok := emitMapValueSet(ch, file); ok {
+						*out = append(*out, vs)
+					}
 					if propRec, ok := buildProperty(ch, file, rec.Name); ok {
 						*out = append(*out, propRec)
 					}
 					continue
 				}
 				walk(ch, file, out, ctx)
+			}
+			// #4428: grouped `const val` string properties form a class-level
+			// value-set named after the class.
+			if vs, ok := emitConstGroupValueSet(body, file, rec.Name); ok {
+				*out = append(*out, vs)
 			}
 			after := len(*out)
 			for k := before; k < after; k++ {
@@ -234,12 +264,22 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// Issue #690 — intercept property_declaration children so
 				// we can qualify the name with the enclosing object name.
 				if ch.Type() == "property_declaration" {
+					// #4428: a body-level `val X = mapOf(...)` constant map.
+					if vs, ok := emitMapValueSet(ch, file); ok {
+						*out = append(*out, vs)
+					}
 					if propRec, ok := buildProperty(ch, file, rec.Name); ok {
 						*out = append(*out, propRec)
 					}
 					continue
 				}
 				walk(ch, file, out, ctx)
+			}
+			// #4428: grouped `const val` string properties form an
+			// object-level value-set named after the object (the common
+			// `object Pages { const val CORE_ADMIN = "core-admin" }` shape).
+			if vs, ok := emitConstGroupValueSet(body, file, rec.Name); ok {
+				*out = append(*out, vs)
 			}
 			after := len(*out)
 			for k := before; k < after; k++ {

--- a/internal/extractors/kotlin/testdata/issue4428/PermissionPages.kt
+++ b/internal/extractors/kotlin/testdata/issue4428/PermissionPages.kt
@@ -1,0 +1,23 @@
+// Representative Kotlin permission source-of-truth (#4428). Mirrors the v3
+// PermissionPage map: an `object` const-val group, a top-level `mapOf` const
+// map, and an `enum class` with constructor values. The hyphenated literal
+// values are the drift a downstream cross-graph parity-audit reads from the
+// structured members_json.
+package com.example.auth
+
+object PermissionPages {
+    const val CORE_ADMIN = "core-admin"
+    const val BILLING = "billing"
+    const val REPORTS = "reports"
+}
+
+val PAGE_LABELS = mapOf(
+    "core-admin" to "Core Admin",
+    "billing" to "Billing",
+    "reports" to "Reports",
+)
+
+enum class PageGroup(val slug: String) {
+    ADMIN("core-admin"),
+    FINANCE("billing"),
+}


### PR DESCRIPTION
## Summary

C# `static readonly Dictionary` const maps / grouped string consts, and Kotlin `object` const-val groups, top-level `mapOf` const maps, and `enum class` constructor values were not emitted as comparable entities with an enumerable member set — so a `.cs`/`.kt` source-of-truth map was invisible to `search_entities` and could not be diffed by a downstream cross-graph parity-audit.

This reuses the existing **SCOPE.Enum** value-set Kind (no new Kind). The shared `EnumEntity` helper already emits the structured `members_json` `[{key,value,line}]` property (#4429); this change adds the constant-collection detection that feeds it.

### C# (`internal/extractors/csharp/const_valueset.go`)
- `static readonly`/`const` `Dictionary<K,V>` const maps — both object-initialiser (`new() { {"k","v"} }`) and indexer (`["k"] = "v"`) forms → `kind_hint=csharp_const_map`.
- Grouped `const`/`static readonly` string consts in a class → one value-set named after the class, `kind_hint=csharp_const_group`.
- Backed enums already fed `EnumEntity` and now inherit `members_json` via the shared helper.

### Kotlin (`internal/extractors/kotlin/const_valueset.go`) — first value-set extraction for Kotlin
- `enum class E(val v: String) { A("a") }` → entries + first string-literal constructor value, `kind_hint=kotlin_enum`.
- `object Pages { const val CORE_ADMIN = "core-admin" }` const-val string groups → `kind_hint=kotlin_const_group`.
- `val X = mapOf("a" to "b", ...)` const maps at top-level and inside object/class bodies → `kind_hint=kotlin_const_map`.

### Honest-partial
Only closed, all-literal value-sets emit a node. A map with any non-literal value, or a class/object with fewer than two string consts, is skipped. Per-member source lines captured.

## Tests (live, real-pipeline)
In-pipeline tests run the REAL C# and Kotlin extract pipelines on representative permission-map fixtures, asserting each value-set is emitted, searchable by name, and enumerates the real key→value pairs (the `core-admin` hyphen captured as structured data), plus honest-partial RED cases for non-literal maps and single-const classes.

| Language | Before | After |
|---|---|---|
| C# | Dictionary const maps + class string-const groups invisible | both emitted as searchable SCOPE.Enum value-sets with structured members |
| Kotlin | no value-set extraction at all (enums classified only as components) | enum classes, object const-val groups, and mapOf maps all emitted as searchable value-sets |

## Gates
- `go build ./...` — pass
- `go vet ./internal/extractors/csharp/ ./internal/extractors/kotlin/ ./internal/extractor/ ./internal/types/` — pass
- `go test` for csharp + kotlin + `./internal/extractor/` + `./internal/types/` — pass

DEPLOY-DEFERRED.

Closes #4428

🤖 Generated with [Claude Code](https://claude.com/claude-code)