### PR TITLE
effects: branch-inventory classifiers for JS/TS, Java, and Go

### DIFF
--- a/internal/mcp/effects_branches_4434_test.go
+++ b/internal/mcp/effects_branches_4434_test.go
@@ -1,0 +1,245 @@
+package mcp
+
+// effects_branches_4434_test.go — in-pipeline test for the #4434 `branches`
+// facet on JS/TS, Java, and Go (generalizes the Python #4423/#4435 flagship).
+//
+// Per the standing LIVE-VALIDATE rule: this exercises the REAL effects MCP
+// handler (handleEffects) end-to-end — resolver, on-disk source read,
+// per-language branch analyzer — over representative branchy functions in three
+// brace-delimited languages copied into testdata/branches_4434/:
+//
+//   - user_service.ts     — Express service with env-gate (process.env), early
+//     return guards (400/409), and a try/catch that re-throws HttpException(500);
+//   - UserController.java  — Spring controller with env-gate (System.getenv),
+//     a guard returning ResponseEntity.status(HttpStatus.BAD_REQUEST), and a
+//     try/catch returning a 500 ResponseEntity;
+//   - user_handler.go      — net/http handler with env-gate (os.Getenv), the
+//     dominant `if err != nil { http.Error(..); return }` guard, and a panic.
+//
+// It asserts per language:
+//   - RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+//     `branches` key (default output unchanged — no regression), while
+//     include="branches" enumerates each branch with the right kind/outcome;
+//   - the env-gate's env_var is surfaced (SIGNUP_ENABLED);
+//   - HTTP statuses (503/400/409/500/...) are derived into returns.status;
+//   - catch outcome classification (raise vs return_value), Go panic → raise.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// Prefixed entity IDs — the fixtures' labels collide case-insensitively
+// (createUser / CreateUser), so the tests resolve via the unambiguous
+// prefixed id (mirroring archigraph_inspect's how_to_choose guidance).
+const (
+	tsEnt   = "polyglot-svc::op_create_user_ts"
+	javaEnt = "polyglot-svc::op_create_user_java"
+	goEnt   = "polyglot-svc::op_create_user_go"
+)
+
+// branches4434Server builds a server whose single repo's Path points at the
+// branches_4434 testdata dir, with one Operation entity per fixture spanning
+// the whole file.
+func branches4434Server(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "polyglot-svc",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_user_ts", Name: "createUser",
+				Kind: "SCOPE.Function", QualifiedName: "users.user_service.createUser",
+				SourceFile: "user_service.ts", StartLine: 9, EndLine: 31,
+			},
+			{
+				ID: "op_create_user_java", Name: "UserController.create",
+				Kind: "SCOPE.Operation", QualifiedName: "com.example.api.UserController.create",
+				SourceFile: "UserController.java", StartLine: 25, EndLine: 47,
+			},
+			{
+				ID: "op_create_user_go", Name: "CreateUser",
+				Kind: "SCOPE.Function", QualifiedName: "api.CreateUser",
+				SourceFile: "user_handler.go", StartLine: 13, EndLine: 42,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4434"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["polyglot-svc"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches4434_DefaultUnchanged is the RED-before assertion across
+// all three languages: a default effects call (no include) must NOT carry a
+// `branches` key. Guards the no-regression contract.
+func TestEffectsBranches4434_DefaultUnchanged(t *testing.T) {
+	srv := branches4434Server(t)
+	for _, ent := range []string{tsEnt, javaEnt, goEnt} {
+		out := callEffects(t, srv, ent, "")
+		if _, present := out["branches"]; present {
+			t.Fatalf("%s: default effects output must NOT contain `branches`", ent)
+		}
+		if _, present := out["branches_supported"]; present {
+			t.Fatalf("%s: default output must not advertise branches_supported", ent)
+		}
+		if out["entity_id"] == nil {
+			t.Fatalf("%s: default output lost entity_id", ent)
+		}
+	}
+}
+
+// TestEffectsBranches4434_JSTS is the GREEN-after assertion for JS/TS.
+func TestEffectsBranches4434_JSTS(t *testing.T) {
+	srv := branches4434Server(t)
+	out := callEffects(t, srv, tsEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for jsts; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: process.env.SIGNUP_ENABLED → 503
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the process.env.SIGNUP_ENABLED env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" {
+		t.Errorf("env-gate kind=%v; want env_gate", env["kind"])
+	}
+	if env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env_var=%v; want SIGNUP_ENABLED", env["env_var"])
+	}
+	assertStatus(t, env, "503")
+
+	// 400 email-required guard
+	g400 := findBranch(branches, "email == null")
+	if g400 == nil {
+		t.Fatalf("missing the email-required 400 guard: %v", branches)
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("400 guard outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// 409 existing-email guard inside the try
+	g409 := findBranch(branches, "existing != null")
+	if g409 == nil {
+		t.Fatalf("missing the 409 existing-email guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// catch re-throws HttpException(500) → raise, status 500
+	cat := findBranch(branches, "catch")
+	if cat == nil {
+		t.Fatalf("missing the catch handler: %v", branches)
+	}
+	if cat["kind"] != "except" {
+		t.Errorf("catch kind=%v; want except", cat["kind"])
+	}
+	if cat["outcome"] != "raise" {
+		t.Errorf("catch re-throws → outcome should be raise; got %v", cat["outcome"])
+	}
+	assertStatus(t, cat, "500")
+}
+
+// TestEffectsBranches4434_Java is the GREEN-after assertion for Java.
+func TestEffectsBranches4434_Java(t *testing.T) {
+	srv := branches4434Server(t)
+	out := callEffects(t, srv, javaEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for java; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: System.getenv("SIGNUP_ENABLED") → 503
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the System.getenv env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" || env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env-gate=%v; want env_gate/SIGNUP_ENABLED", env)
+	}
+	assertStatus(t, env, "503")
+
+	// BAD_REQUEST guard → 400 via HttpStatus enum mapping
+	g400 := findBranch(branches, "getEmail() == null")
+	if g400 == nil {
+		t.Fatalf("missing the BAD_REQUEST guard: %v", branches)
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("400 guard outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// CONFLICT guard inside try → 409
+	g409 := findBranch(branches, "existsByEmail")
+	if g409 == nil {
+		t.Fatalf("missing the CONFLICT guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// catch returns a 500 ResponseEntity → return_value, status 500
+	cat := findBranch(branches, "catch")
+	if cat == nil {
+		t.Fatalf("missing the catch handler: %v", branches)
+	}
+	if cat["kind"] != "except" {
+		t.Errorf("catch kind=%v; want except", cat["kind"])
+	}
+	if cat["outcome"] != "return_value" {
+		t.Errorf("catch returns 500 ResponseEntity → outcome should be return_value; got %v", cat["outcome"])
+	}
+	assertStatus(t, cat, "500")
+}
+
+// TestEffectsBranches4434_Go is the GREEN-after assertion for Go.
+func TestEffectsBranches4434_Go(t *testing.T) {
+	srv := branches4434Server(t)
+	out := callEffects(t, srv, goEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for go; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: os.Getenv("SIGNUP_ENABLED") → 503
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the os.Getenv env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" || env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env-gate=%v; want env_gate/SIGNUP_ENABLED", env)
+	}
+	assertStatus(t, env, "503")
+
+	// the dominant `if err != nil { http.Error(.., StatusBadRequest); return }`
+	errGuard := findBranch(branches, "err != nil")
+	if errGuard == nil {
+		t.Fatalf("missing the `if err != nil` guard: %v", branches)
+	}
+	if errGuard["outcome"] != "return_value" {
+		t.Errorf("err-guard outcome=%v; want return_value", errGuard["outcome"])
+	}
+	assertStatus(t, errGuard, "400")
+
+	// validation guard → 409 (http.StatusConflict)
+	g409 := findBranch(branches, "dto.Email ==")
+	if g409 == nil {
+		t.Fatalf("missing the email-required 409 guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// panic → raise
+	panicGuard := findBranch(branches, "w == nil")
+	if panicGuard == nil {
+		t.Fatalf("missing the panic guard: %v", branches)
+	}
+	if panicGuard["outcome"] != "raise" {
+		t.Errorf("panic guard outcome=%v; want raise", panicGuard["outcome"])
+	}
+}

--- a/internal/mcp/testdata/branches_4434/UserController.java
+++ b/internal/mcp/testdata/branches_4434/UserController.java
@@ -1,0 +1,46 @@
+package com.example.api;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RestController
+public class UserController {
+
+    private static final Logger log = LoggerFactory.getLogger(UserController.class);
+
+    private final UserRepository repo;
+
+    public UserController(UserRepository repo) {
+        this.repo = repo;
+    }
+
+    // create — Spring controller method with an env-gate (System.getenv),
+    // an early-return guard returning ResponseEntity.status(HttpStatus.BAD_REQUEST),
+    // and a try/catch that logs then returns a 500 ResponseEntity.
+    @PostMapping("/users")
+    public ResponseEntity<?> create(@RequestBody UserDto dto) {
+        if (System.getenv("SIGNUP_ENABLED") == null) {
+            return ResponseEntity.status(503).build();
+        }
+
+        if (dto.getEmail() == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("email required");
+        }
+
+        try {
+            if (repo.existsByEmail(dto.getEmail())) {
+                return ResponseEntity.status(HttpStatus.CONFLICT).body("email in use");
+            }
+            User saved = repo.save(dto.toEntity());
+            return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+        } catch (Exception e) {
+            log.error("create failed", e);
+            return ResponseEntity.status(500).body("internal error");
+        }
+    }
+}

--- a/internal/mcp/testdata/branches_4434/user_handler.go
+++ b/internal/mcp/testdata/branches_4434/user_handler.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+)
+
+// CreateUser is a representative net/http handler with an env-gate
+// (os.Getenv), the dominant `if err != nil { ... return }` guard writing an
+// http.Error status, a validation guard returning a 409 via http.Error, and a
+// panic on an invariant violation.
+func CreateUser(w http.ResponseWriter, r *http.Request) {
+	if os.Getenv("SIGNUP_ENABLED") == "" {
+		http.Error(w, "signup disabled", 503)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "could not read body", http.StatusBadRequest)
+		return
+	}
+
+	var dto userDTO
+	if err := json.Unmarshal(body, &dto); err != nil {
+		http.Error(w, "invalid json", http.StatusUnprocessableEntity)
+		return
+	}
+
+	if dto.Email == "" {
+		http.Error(w, "email required", http.StatusConflict)
+		return
+	}
+
+	if w == nil {
+		panic("nil response writer")
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}

--- a/internal/mcp/testdata/branches_4434/user_service.ts
+++ b/internal/mcp/testdata/branches_4434/user_service.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from "express";
+import { db } from "../db";
+import { logger } from "../logger";
+import { HttpException } from "../errors";
+
+// createUser — representative Express/Nest-flavoured service action with an
+// env-gate (process.env.SIGNUP_ENABLED), two early-return guards returning HTTP
+// statuses, and a try/catch that logs then re-throws an HttpException(500).
+export async function createUser(req: Request, res: Response) {
+  if (!process.env.SIGNUP_ENABLED) {
+    return res.status(503).json({ error: "signup disabled" });
+  }
+
+  if (req.body.email == null) {
+    return res.status(400).json({ error: "email is required" });
+  }
+
+  try {
+    const existing = await db.users.findByEmail(req.body.email);
+    if (existing != null) {
+      return res.status(409).json({ error: "email already in use" });
+    }
+    const user = await db.users.create(req.body);
+    return res.status(201).json(user);
+  } catch (e) {
+    logger.error("createUser failed", e);
+    throw new HttpException("create failed", 500);
+  }
+}

--- a/internal/substrate/branches.go
+++ b/internal/substrate/branches.go
@@ -19,8 +19,9 @@
 // to a function body and inspects each block's immediate statements to decide
 // the outcome. Python is the flagship (the oracle stack); the BranchFacet
 // schema and the outcome lattice are language-neutral so other languages can
-// register their own classifier (see BranchAnalyzerFor; JS/TS + Java + Go
-// classifiers are tracked in follow-up #4434, ref epic #4419).
+// register their own classifier (see BranchAnalyzerFor; the JS/TS + Java + Go
+// classifiers live in branches_jsts_java_go.go, added in #4434, ref epic
+// #4419).
 package substrate
 
 import (

--- a/internal/substrate/branches_jsts_java_go.go
+++ b/internal/substrate/branches_jsts_java_go.go
@@ -1,0 +1,611 @@
+// Branch inventory analyzers for brace-delimited languages — JS/TS, Java, Go
+// (#4434, extends #4423/#4435, epic #4419 capability 4).
+//
+// branches.go added the language-neutral BranchFacet schema, the
+// BranchAnalyzerFn registry, and the flagship Python analyzer (an
+// indentation-scoped CFG walk). This file registers analyzers for the three
+// brace-delimited languages the upvate stack and the wider corpus lean on.
+//
+// Where Python keys block scope on indentation, these languages delimit blocks
+// with `{`/`}`. The shared helper braceBlockBody walks forward from a header
+// line tracking brace depth to collect exactly the statements of the block the
+// header opens — the brace-language analogue of pyBlockBody. Each analyzer then
+// classifies the FIRST control-altering statement (throw/return/redirect/
+// status-write) in that block, exactly mirroring the Python outcome lattice.
+//
+// Same opt-in contract: these run only when the effects MCP tool is called with
+// include="branches", so the default effects payload is byte-for-byte
+// unchanged. Classification is deliberately conservative — a branch is only
+// surfaced when it provably alters control flow (returns / throws / redirects /
+// writes an HTTP error status / panics); plain branching `if`s are skipped so
+// the facet does not drown a porting agent in every conditional.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() {
+	RegisterBranchAnalyzer("jsts", analyzeBranchesJSTS)
+	RegisterBranchAnalyzer("java", analyzeBranchesJava)
+	RegisterBranchAnalyzer("go", analyzeBranchesGo)
+}
+
+// --- shared brace-block helpers -----------------------------------------
+
+// braceBlockBody returns the source lines of the block opened on or after the
+// header line lines[headerIdx]. It scans forward from the header, finds the
+// first `{` that opens the block, and returns every line until the matching
+// `}` (exclusive of the closing-brace line's trailing content). The opening
+// brace may be on the header line (K&R) or the next line (Allman). When no
+// brace is found within a small lookahead (e.g. a single-statement
+// brace-less `if (x) return;`), the remainder of the header line after the
+// condition plus the next line are returned so the classifier can still see a
+// trailing `return`/`throw`.
+//
+// String/char/line-comment contents are skipped when counting braces so a `{`
+// inside a literal does not corrupt depth tracking — a cheap scanner, not a
+// full lexer, which is sufficient for the well-formed function windows the
+// effects pipeline feeds in.
+func braceBlockBody(lines []string, headerIdx int, afterCond string) []string {
+	// Brace-less single-statement form: `if (x) return y;` — afterCond holds
+	// the text after the `)`. If it already contains a statement, that IS the
+	// body.
+	if s := strings.TrimSpace(afterCond); s != "" && !strings.HasPrefix(s, "{") {
+		return []string{s}
+	}
+
+	depth := 0
+	opened := false
+	var body []string
+	// Look a few lines ahead for the opening brace (Allman style), then collect
+	// until depth returns to zero. The header line may carry a LEADING `}` that
+	// closes the PRECEDING block (`} catch (e) {`, `} else if (x) {`); skip up
+	// to the header keyword so that closer is not counted as our depth.
+	for j := headerIdx; j < len(lines); j++ {
+		ln := lines[j]
+		scan := ln
+		if j == headerIdx {
+			scan = stripLeadingCloser(ln)
+		}
+		startDepth := depth
+		for _, r := range stripBraceNoise(scan) {
+			switch r {
+			case '{':
+				depth++
+				opened = true
+			case '}':
+				depth--
+			}
+		}
+		if !opened {
+			// Haven't seen the opening brace yet. If we've scanned past a small
+			// lookahead with no brace, treat the next non-blank line as a
+			// brace-less body (defensive; afterCond already handles the common
+			// single-line case).
+			if j-headerIdx > 2 {
+				return nil
+			}
+			continue
+		}
+		// We are inside (or just opened) the block. Collect statement lines that
+		// live strictly inside the braces — exclude the header line itself
+		// (which only opens the block) and the closing-brace line.
+		if j > headerIdx && startDepth >= 1 {
+			body = append(body, ln)
+		} else if j == headerIdx {
+			// K&R: header line may carry an inline statement after `{`.
+			if idx := strings.Index(ln, "{"); idx >= 0 {
+				rest := strings.TrimSpace(ln[idx+1:])
+				rest = strings.TrimSuffix(rest, "}")
+				if rest != "" {
+					body = append(body, rest)
+				}
+			}
+		}
+		if opened && depth <= 0 {
+			break
+		}
+	}
+	return body
+}
+
+// stripLeadingCloser blanks a leading `}` (and surrounding whitespace) on a
+// header line so the closing brace of the PRECEDING block (`} catch`, `} else`)
+// is not counted toward the new block's brace depth.
+func stripLeadingCloser(ln string) string {
+	trimmed := strings.TrimLeft(ln, " \t")
+	if strings.HasPrefix(trimmed, "}") {
+		// Replace the leading `}` with a space, preserving the rest.
+		idx := strings.IndexByte(ln, '}')
+		return ln[:idx] + " " + ln[idx+1:]
+	}
+	return ln
+}
+
+// stripBraceNoise blanks out the contents of string/char literals and
+// line/block-comment text on a single line so brace counting is not corrupted
+// by braces inside literals or comments. Returns a same-length-ish rune-safe
+// string with literal/comment bodies replaced by spaces.
+func stripBraceNoise(ln string) string {
+	var b strings.Builder
+	runes := []rune(ln)
+	i := 0
+	for i < len(runes) {
+		c := runes[i]
+		switch c {
+		case '/':
+			if i+1 < len(runes) && runes[i+1] == '/' {
+				return b.String() // rest of line is a comment
+			}
+			b.WriteRune(c)
+			i++
+		case '"', '\'', '`':
+			quote := c
+			b.WriteRune(' ')
+			i++
+			for i < len(runes) {
+				if runes[i] == '\\' { // skip escaped char
+					i += 2
+					continue
+				}
+				if runes[i] == quote {
+					break
+				}
+				i++
+			}
+			b.WriteRune(' ')
+			i++
+		default:
+			b.WriteRune(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// --- JS/TS analyzer ------------------------------------------------------
+
+var (
+	jstsCatchRe = regexp.MustCompile(`^\s*}?\s*catch\s*(\(([^)]*)\))?\s*\{?`)
+	jstsIfRe    = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\((.*)\)\s*(.*)$`)
+
+	jstsThrowRe    = regexp.MustCompile(`(^|\b)throw\b`)
+	jstsReturnRe   = regexp.MustCompile(`(^|\b)return\b`)
+	jstsRedirectRe = regexp.MustCompile(`\.\s*redirect\s*\(|\bRedirect\b`)
+	// jstsLogOnlyRe — a catch body that only logs / is empty.
+	jstsLogCallRe = regexp.MustCompile(`\b(?:console\.\w+|logger?\.\w+|log\.\w+)\s*\(`)
+
+	// jstsEnvRefRe — process.env.X, process.env['X'], import.meta.env.X.
+	jstsEnvRefRe = regexp.MustCompile(
+		`\bprocess\s*\.\s*env\s*(?:\.\s*([A-Za-z_]\w*)|\[\s*['"]([^'"]+)['"]\s*\])` +
+			`|\bimport\s*\.\s*meta\s*\.\s*env\s*\.\s*([A-Za-z_]\w*)`)
+
+	// jstsStatusRe — res.status(NNN), throw new HttpException(.., NNN),
+	// reply.code(NNN), statusCode = NNN, NestJS HttpStatus.NAME mapped loosely.
+	jstsStatusCallRe = regexp.MustCompile(`\.\s*(?:status|code|sendStatus)\s*\(\s*(\d{3})\b`)
+	jstsHTTPExcRe    = regexp.MustCompile(`HttpException\s*\([^)]*?\b(\d{3})\b`)
+	jstsStatusNumRe  = regexp.MustCompile(`statusCode\s*[:=]\s*(\d{3})\b`)
+)
+
+func analyzeBranchesJSTS(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		// catch handler.
+		if m := jstsCatchRe.FindStringSubmatch(raw); m != nil {
+			cond := "catch"
+			if strings.TrimSpace(m[2]) != "" {
+				cond = "catch (" + strings.TrimSpace(m[2]) + ")"
+			}
+			body := braceBlockBody(lines, i, afterCloseParen(raw))
+			outcome := classifyBraceExceptOutcome(body, jstsThrowRe, jstsReturnRe, jstsRedirectRe, jstsLogCallRe)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachBraceReturns(&bf, body, jstsStatusFromBody, jstsRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		// if guard.
+		if m := jstsIfRe.FindStringSubmatch(raw); m != nil {
+			cond := "if (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, m[2])
+			outcome, alters := classifyBraceGuardOutcome(body, jstsThrowRe, jstsReturnRe, jstsRedirectRe)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(jstsEnvRefRe, m[1])
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, jstsStatusFromBody, jstsRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+func jstsStatusFromBody(joined string) string {
+	if m := jstsStatusCallRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	if m := jstsHTTPExcRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	if m := jstsStatusNumRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// --- Java analyzer -------------------------------------------------------
+
+var (
+	javaCatchRe = regexp.MustCompile(`^\s*}?\s*catch\s*\(([^)]*)\)\s*\{?`)
+	javaIfRe    = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\((.*)\)\s*(.*)$`)
+
+	javaThrowRe    = regexp.MustCompile(`(^|\b)throw\b`)
+	javaReturnRe   = regexp.MustCompile(`(^|\b)return\b`)
+	javaRedirectRe = regexp.MustCompile(`\bsendRedirect\s*\(|\bRedirectView\b|new\s+ModelAndView\s*\(\s*["']redirect:|["']redirect:`)
+	javaLogCallRe  = regexp.MustCompile(`\b(?:log|logger|LOG|LOGGER)\s*\.\s*\w+\s*\(|\bSystem\s*\.\s*(?:out|err)\s*\.`)
+
+	// javaEnvRefRe — System.getenv("X"), @Value("${x}"), env.getProperty("x").
+	javaEnvRefRe = regexp.MustCompile(
+		`\bSystem\s*\.\s*getenv\s*\(\s*"([^"]+)"` +
+			`|@Value\s*\(\s*"\$\{\s*([A-Za-z_][\w.]*)` +
+			`|\bgetProperty\s*\(\s*"([^"]+)"` +
+			`|\bgetenv\s*\(\s*"([^"]+)"`)
+
+	// javaStatusRe — ResponseEntity.status(NNN) / HttpStatus.NAME(code in name?)
+	// and response.setStatus(NNN), response.sendError(NNN).
+	javaStatusCallRe   = regexp.MustCompile(`\.\s*(?:status|setStatus|sendError)\s*\(\s*(\d{3})\b`)
+	javaHttpStatusEnum = regexp.MustCompile(`HttpStatus\s*\.\s*([A-Z_]+)`)
+)
+
+func analyzeBranchesJava(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		if m := javaCatchRe.FindStringSubmatch(raw); m != nil {
+			cond := "catch (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, afterCloseParen(raw))
+			outcome := classifyBraceExceptOutcome(body, javaThrowRe, javaReturnRe, javaRedirectRe, javaLogCallRe)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachBraceReturns(&bf, body, javaStatusFromBody, javaRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		if m := javaIfRe.FindStringSubmatch(raw); m != nil {
+			cond := "if (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, m[2])
+			outcome, alters := classifyBraceGuardOutcome(body, javaThrowRe, javaReturnRe, javaRedirectRe)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(javaEnvRefRe, m[1])
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, javaStatusFromBody, javaRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+func javaStatusFromBody(joined string) string {
+	if m := javaStatusCallRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	if m := javaHttpStatusEnum.FindStringSubmatch(joined); m != nil {
+		if code := httpStatusNameToCode(m[1]); code != "" {
+			return code
+		}
+	}
+	return ""
+}
+
+// --- Go analyzer ---------------------------------------------------------
+
+var (
+	// goIfRe matches `if <cond> {` (Go requires the brace on the same line as
+	// the header, optionally with a simple-statement init: `if err := f(); err
+	// != nil {`).
+	goIfRe = regexp.MustCompile(`^\s*}?\s*(?:else\s+)?if\s+(.*?)\s*\{\s*$`)
+
+	goReturnRe   = regexp.MustCompile(`(^|\b)return\b`)
+	goPanicRe    = regexp.MustCompile(`\bpanic\s*\(`)
+	goRedirectRe = regexp.MustCompile(`\bhttp\.Redirect\s*\(|\.\s*Redirect\s*\(`)
+
+	// goEnvRefRe — os.Getenv("X"), os.LookupEnv("X").
+	goEnvRefRe = regexp.MustCompile(`\bos\s*\.\s*(?:Getenv|LookupEnv)\s*\(\s*"([^"]+)"`)
+
+	// goStatusRe — http.Error(w, .., NNN), w.WriteHeader(NNN),
+	// w.WriteHeader(http.StatusXxx), c.JSON(NNN, ..) (gin), c.Status(NNN).
+	goStatusCallRe   = regexp.MustCompile(`\bhttp\.Error\s*\([^,]+,[^,]+,\s*(\d{3})\b|\bWriteHeader\s*\(\s*(\d{3})\b|\.\s*(?:JSON|Status|AbortWithStatus(?:JSON)?)\s*\(\s*(\d{3})\b`)
+	goStatusEnumRe   = regexp.MustCompile(`http\.Status([A-Za-z]+)\b`)
+	goWrappedErrorRe = regexp.MustCompile(`\b(?:fmt\.Errorf|errors\.(?:New|Wrap)|errors\.Wrapf)\s*\(`)
+)
+
+func analyzeBranchesGo(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		m := goIfRe.FindStringSubmatch(raw)
+		if m == nil {
+			continue
+		}
+		condExpr := strings.TrimSpace(m[1])
+		// Strip a leading simple-statement init (`err := f(); err != nil`) so the
+		// surfaced condition is the boolean expression.
+		if semi := strings.LastIndex(condExpr, ";"); semi >= 0 {
+			condExpr = strings.TrimSpace(condExpr[semi+1:])
+		}
+		cond := "if " + condExpr
+		body := braceBlockBody(lines, i, "{")
+		outcome, alters := classifyGoGuardOutcome(body)
+		if !alters {
+			continue
+		}
+		envVar := matchEnvVar(goEnvRefRe, m[1])
+		// The dominant Go branch — `if err != nil { return ... }`. It is a
+		// guard, not an env_gate, unless the condition reads an env var.
+		kind := guardKind(envVar, &firstGuardSeen)
+		bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+		attachBraceReturns(&bf, body, goStatusFromBody, goRedirectRe)
+		out = append(out, bf)
+	}
+	return out
+}
+
+// classifyGoGuardOutcome — Go has no `throw`; the raise-equivalent is panic().
+// `if err != nil { return ..., err }` is the canonical early-return. A bare
+// `return` with no panic is return_value; a panic is raise; a redirect call is
+// redirect.
+func classifyGoGuardOutcome(body []string) (BranchOutcome, bool) {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		if goPanicRe.MatchString(ln) {
+			return OutcomeRaise, true
+		}
+		if goReturnRe.MatchString(ln) {
+			if goRedirectRe.MatchString(joined) {
+				return OutcomeRedirect, true
+			}
+			return OutcomeReturnValue, true
+		}
+		if goRedirectRe.MatchString(ln) {
+			return OutcomeRedirect, true
+		}
+	}
+	// A block that writes an HTTP error status then falls through (common in
+	// handlers: `http.Error(w, .., 400); return`) is caught by the return
+	// above; a status write with no return is still a control-altering response
+	// branch worth surfacing.
+	if goStatusFromBody(joined) != "" {
+		return OutcomeReturnValue, true
+	}
+	return "", false
+}
+
+func goStatusFromBody(joined string) string {
+	if m := goStatusCallRe.FindStringSubmatch(joined); m != nil {
+		for _, g := range m[1:] {
+			if g != "" {
+				return g
+			}
+		}
+	}
+	if m := goStatusEnumRe.FindStringSubmatch(joined); m != nil {
+		if code := httpStatusNameToCode(strings.ToUpper(camelToSnake(m[1]))); code != "" {
+			return code
+		}
+	}
+	return ""
+}
+
+// --- shared brace-language classification --------------------------------
+
+// classifyBraceExceptOutcome classifies a catch/handler block body. Re-throw
+// or return → raise/return_value; a body that only logs / is empty → swallow.
+func classifyBraceExceptOutcome(body []string, throwRe, returnRe, redirectRe, logRe *regexp.Regexp) BranchOutcome {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		if throwRe.MatchString(ln) {
+			return OutcomeRaise
+		}
+		if returnRe.MatchString(ln) {
+			if redirectRe.MatchString(joined) {
+				return OutcomeRedirect
+			}
+			return OutcomeReturnValue
+		}
+		if redirectRe.MatchString(ln) {
+			return OutcomeRedirect
+		}
+	}
+	// No re-throw / return / redirect → swallow (catch-and-continue), whether it
+	// logs or is empty. The audit-critical silent-failure path.
+	_ = logRe
+	return OutcomeSwallow
+}
+
+// classifyBraceGuardOutcome inspects an if-block body and returns its outcome +
+// whether it alters control flow. A guard that neither throws nor returns nor
+// redirects is not surfaced (conservative).
+func classifyBraceGuardOutcome(body []string, throwRe, returnRe, redirectRe *regexp.Regexp) (BranchOutcome, bool) {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		if throwRe.MatchString(ln) {
+			return OutcomeRaise, true
+		}
+		if returnRe.MatchString(ln) {
+			if redirectRe.MatchString(joined) {
+				return OutcomeRedirect, true
+			}
+			return OutcomeReturnValue, true
+		}
+		if redirectRe.MatchString(ln) {
+			return OutcomeRedirect, true
+		}
+	}
+	return "", false
+}
+
+// attachBraceReturns derives returns.status + returns.shape for a brace-language
+// branch using a per-language status extractor. shape descriptor is left to the
+// status for these languages (cheap-and-conservative); only attaches when a
+// status is found.
+func attachBraceReturns(bf *BranchFacet, body []string, statusFn func(string) string, redirectRe *regexp.Regexp) {
+	if bf.Outcome != OutcomeReturnValue && bf.Outcome != OutcomeRaise && bf.Outcome != OutcomeRedirect {
+		return
+	}
+	joined := strings.Join(body, "\n")
+	if st := statusFn(joined); st != "" {
+		bf.Returns = &BranchReturns{Status: st}
+	}
+}
+
+// guardKind picks env_gate / early_return / guard, threading the
+// leading-guard flag exactly like the Python analyzer.
+func guardKind(envVar string, firstGuardSeen *bool) BranchKind {
+	kind := BranchGuard
+	switch {
+	case envVar != "":
+		kind = BranchEnvGate
+	case !*firstGuardSeen:
+		kind = BranchEarlyReturn
+	}
+	*firstGuardSeen = true
+	return kind
+}
+
+// matchEnvVar runs an env-ref regex over a condition and returns the first
+// non-empty capture group (the env/setting name), or "".
+func matchEnvVar(re *regexp.Regexp, cond string) string {
+	m := re.FindStringSubmatch(cond)
+	if m == nil {
+		return ""
+	}
+	for _, g := range m[1:] {
+		if g != "" {
+			return g
+		}
+	}
+	return ""
+}
+
+// afterCloseParen returns the text on a header line after the final `)`, used
+// to detect an inline single-statement body (`if (x) return;`) or an opening
+// brace. Empty when there is no `)`.
+func afterCloseParen(ln string) string {
+	idx := strings.LastIndex(ln, ")")
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(ln[idx+1:])
+}
+
+// httpStatusNameToCode maps the common Spring HttpStatus / Go http.Status enum
+// names to their numeric code. Conservative — only the codes a porting agent
+// most needs; unknown names yield "".
+func httpStatusNameToCode(name string) string {
+	switch name {
+	case "OK":
+		return "200"
+	case "CREATED":
+		return "201"
+	case "ACCEPTED":
+		return "202"
+	case "NO_CONTENT", "NOCONTENT":
+		return "204"
+	case "MOVED_PERMANENTLY", "MOVEDPERMANENTLY":
+		return "301"
+	case "FOUND":
+		return "302"
+	case "SEE_OTHER", "SEEOTHER":
+		return "303"
+	case "NOT_MODIFIED", "NOTMODIFIED":
+		return "304"
+	case "TEMPORARY_REDIRECT", "TEMPORARYREDIRECT":
+		return "307"
+	case "BAD_REQUEST", "BADREQUEST":
+		return "400"
+	case "UNAUTHORIZED":
+		return "401"
+	case "FORBIDDEN":
+		return "403"
+	case "NOT_FOUND", "NOTFOUND":
+		return "404"
+	case "METHOD_NOT_ALLOWED", "METHODNOTALLOWED":
+		return "405"
+	case "CONFLICT":
+		return "409"
+	case "GONE":
+		return "410"
+	case "UNPROCESSABLE_ENTITY", "UNPROCESSABLEENTITY":
+		return "422"
+	case "TOO_MANY_REQUESTS", "TOOMANYREQUESTS":
+		return "429"
+	case "INTERNAL_SERVER_ERROR", "INTERNALSERVERERROR":
+		return "500"
+	case "NOT_IMPLEMENTED", "NOTIMPLEMENTED":
+		return "501"
+	case "BAD_GATEWAY", "BADGATEWAY":
+		return "502"
+	case "SERVICE_UNAVAILABLE", "SERVICEUNAVAILABLE":
+		return "503"
+	case "GATEWAY_TIMEOUT", "GATEWAYTIMEOUT":
+		return "504"
+	}
+	return ""
+}
+
+// camelToSnake converts a Go http.Status enum tail (e.g. "BadRequest",
+// "InternalServerError") to SNAKE form so it can reuse httpStatusNameToCode's
+// underscore keys. Cheap; handles ASCII camelCase only.
+func camelToSnake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if i > 0 && r >= 'A' && r <= 'Z' {
+			b.WriteByte('_')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/internal/substrate/branches_jsts_java_go_test.go
+++ b/internal/substrate/branches_jsts_java_go_test.go
@@ -1,0 +1,214 @@
+package substrate
+
+import "testing"
+
+// TestAnalyzeBranchesJSTS_Outcomes exercises the JS/TS classifier on a service
+// method with an env-gate, an early-return guard, a status-returning guard, and
+// a try/catch that re-throws.
+func TestAnalyzeBranchesJSTS_Outcomes(t *testing.T) {
+	src := `async function createUser(req, res) {
+    if (!process.env.SIGNUP_ENABLED) {
+        return res.status(503).json({ error: "disabled" });
+    }
+    if (req.body.email == null) {
+        return res.status(400).json({ error: "email required" });
+    }
+    try {
+        const u = await db.users.create(req.body);
+        return res.status(201).json(u);
+    } catch (e) {
+        logger.error(e);
+        throw new HttpException("create failed", 500);
+    }
+}`
+	br := analyzeBranchesJSTS(src, 1)
+	if len(br) != 3 {
+		t.Fatalf("expected 3 branches, got %d: %+v", len(br), br)
+	}
+
+	// env-gate
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "SIGNUP_ENABLED" {
+		t.Errorf("branch0 = %+v; want env_gate SIGNUP_ENABLED", br[0])
+	}
+	if br[0].Outcome != OutcomeReturnValue {
+		t.Errorf("branch0 outcome = %v; want return_value", br[0].Outcome)
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "503" {
+		t.Errorf("branch0 returns = %+v; want 503", br[0].Returns)
+	}
+
+	// guard (the env-gate above consumed the leading-guard slot, mirroring the
+	// Python analyzer — later guards are mid-body `guard`).
+	if br[1].Kind != BranchGuard || br[1].Outcome != OutcomeReturnValue {
+		t.Errorf("branch1 = %+v; want guard/return_value", br[1])
+	}
+	if br[1].Returns == nil || br[1].Returns.Status != "400" {
+		t.Errorf("branch1 returns = %+v; want 400", br[1].Returns)
+	}
+
+	// catch that re-throws → raise, status 500 from HttpException
+	if br[2].Kind != BranchExcept || br[2].Outcome != OutcomeRaise {
+		t.Errorf("branch2 = %+v; want except/raise", br[2])
+	}
+	if br[2].Returns == nil || br[2].Returns.Status != "500" {
+		t.Errorf("branch2 returns = %+v; want 500", br[2].Returns)
+	}
+}
+
+// TestAnalyzeBranchesJSTS_Swallow confirms a log-only catch is swallow.
+func TestAnalyzeBranchesJSTS_Swallow(t *testing.T) {
+	src := `function f() {
+    try {
+        doThing();
+    } catch (err) {
+        console.warn("ignored", err);
+    }
+}`
+	br := analyzeBranchesJSTS(src, 1)
+	if len(br) != 1 || br[0].Kind != BranchExcept || br[0].Outcome != OutcomeSwallow {
+		t.Fatalf("expected one swallow except, got %+v", br)
+	}
+}
+
+// TestAnalyzeBranchesJava_Outcomes exercises the Java classifier on a Spring
+// controller method with an env-gate (@Value is not in-body so we test
+// System.getenv), an early-return guard returning ResponseEntity.status, and a
+// try/catch that returns a 500.
+func TestAnalyzeBranchesJava_Outcomes(t *testing.T) {
+	src := `public ResponseEntity<?> create(@RequestBody Dto dto) {
+    if (System.getenv("SIGNUP_ENABLED") == null) {
+        return ResponseEntity.status(503).build();
+    }
+    if (dto.getEmail() == null) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+    try {
+        repo.save(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    } catch (Exception e) {
+        log.error("failed", e);
+        return ResponseEntity.status(500).build();
+    }
+}`
+	br := analyzeBranchesJava(src, 1)
+	if len(br) != 3 {
+		t.Fatalf("expected 3 branches, got %d: %+v", len(br), br)
+	}
+
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "SIGNUP_ENABLED" {
+		t.Errorf("branch0 = %+v; want env_gate SIGNUP_ENABLED", br[0])
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "503" {
+		t.Errorf("branch0 returns = %+v; want 503", br[0].Returns)
+	}
+
+	if br[1].Kind != BranchGuard || br[1].Outcome != OutcomeReturnValue {
+		t.Errorf("branch1 = %+v; want guard/return_value", br[1])
+	}
+	if br[1].Returns == nil || br[1].Returns.Status != "400" {
+		t.Errorf("branch1 returns = %+v; want 400 (HttpStatus.BAD_REQUEST)", br[1].Returns)
+	}
+
+	if br[2].Kind != BranchExcept || br[2].Outcome != OutcomeReturnValue {
+		t.Errorf("branch2 = %+v; want except/return_value", br[2])
+	}
+	if br[2].Returns == nil || br[2].Returns.Status != "500" {
+		t.Errorf("branch2 returns = %+v; want 500", br[2].Returns)
+	}
+}
+
+// TestAnalyzeBranchesJava_Throw confirms a catch that re-throws is raise.
+func TestAnalyzeBranchesJava_Throw(t *testing.T) {
+	src := `public void f() {
+    try {
+        risky();
+    } catch (IOException e) {
+        throw new RuntimeException(e);
+    }
+}`
+	br := analyzeBranchesJava(src, 1)
+	if len(br) != 1 || br[0].Kind != BranchExcept || br[0].Outcome != OutcomeRaise {
+		t.Fatalf("expected one raise except, got %+v", br)
+	}
+}
+
+// TestAnalyzeBranchesGo_Outcomes exercises the Go classifier on a handler with
+// an env-gate, the dominant `if err != nil { return ... }` guard, an
+// http.Error status branch, and a panic.
+func TestAnalyzeBranchesGo_Outcomes(t *testing.T) {
+	src := `func handler(w http.ResponseWriter, r *http.Request) {
+	if os.Getenv("FEATURE_X") == "" {
+		http.Error(w, "disabled", 503)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "bad", http.StatusBadRequest)
+		return
+	}
+	if body == nil {
+		panic("nil body")
+	}
+}`
+	br := analyzeBranchesGo(src, 1)
+	if len(br) != 3 {
+		t.Fatalf("expected 3 branches, got %d: %+v", len(br), br)
+	}
+
+	// env-gate
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "FEATURE_X" {
+		t.Errorf("branch0 = %+v; want env_gate FEATURE_X", br[0])
+	}
+	if br[0].Outcome != OutcomeReturnValue {
+		t.Errorf("branch0 outcome = %v; want return_value", br[0].Outcome)
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "503" {
+		t.Errorf("branch0 returns = %+v; want 503", br[0].Returns)
+	}
+
+	// err != nil guard (the env-gate consumed the leading slot → guard)
+	if br[1].Kind != BranchGuard || br[1].Outcome != OutcomeReturnValue {
+		t.Errorf("branch1 = %+v; want guard/return_value", br[1])
+	}
+	if br[1].Condition != "if err != nil" {
+		t.Errorf("branch1 condition = %q; want `if err != nil`", br[1].Condition)
+	}
+	if br[1].Returns == nil || br[1].Returns.Status != "400" {
+		t.Errorf("branch1 returns = %+v; want 400 (http.StatusBadRequest)", br[1].Returns)
+	}
+
+	// panic → raise
+	if br[2].Outcome != OutcomeRaise {
+		t.Errorf("branch2 = %+v; want raise (panic)", br[2])
+	}
+}
+
+// TestAnalyzeBranchesGo_ErrInit confirms an `if err := f(); err != nil {`
+// init-statement guard surfaces the boolean condition only.
+func TestAnalyzeBranchesGo_ErrInit(t *testing.T) {
+	src := `func f() error {
+	if err := do(); err != nil {
+		return fmt.Errorf("do: %w", err)
+	}
+	return nil
+}`
+	br := analyzeBranchesGo(src, 1)
+	if len(br) != 1 {
+		t.Fatalf("expected 1 branch, got %d: %+v", len(br), br)
+	}
+	if br[0].Condition != "if err != nil" {
+		t.Errorf("condition = %q; want `if err != nil`", br[0].Condition)
+	}
+	if br[0].Outcome != OutcomeReturnValue {
+		t.Errorf("outcome = %v; want return_value", br[0].Outcome)
+	}
+}
+
+// TestBranchAnalyzerRegistry_BraceLangs confirms jsts/java/go are registered.
+func TestBranchAnalyzerRegistry_BraceLangs(t *testing.T) {
+	for _, lang := range []string{"jsts", "java", "go"} {
+		if BranchAnalyzerFor(lang) == nil {
+			t.Errorf("%s branch analyzer not registered", lang)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Generalizes the opt-in `branches` facet on `archigraph_effects` (#4423/#4435) beyond Python to the three brace-delimited languages the corpus leans on. Until now Python was the only registered `BranchAnalyzerFn`; every other language reported `branches_supported:false` (honest-partial). This registers JS/TS, Java, and Go analyzers in the same `substrate.RegisterBranchAnalyzer` registry, each emitting the identical `BranchFacet` schema (`kind` / `condition` / `outcome` / `returns.status` / `env_var` / `line`).

### Per-language classifiers (`internal/substrate/branches_jsts_java_go.go`)

- **JS/TS** — `try/catch` (re-throw → `raise`, `return` → `return_value`, log-only/empty → `swallow`), leading `if` guards, `process.env.X` / `import.meta.env.X` env-gates, and `res.status(NNN)` / `throw new HttpException(.., NNN)` / `statusCode` status extraction.
- **Java** — `try/catch`, `if` guards, `System.getenv("X")` / `@Value("${...}")` / `getProperty("X")` env-gates, and `ResponseEntity.status(NNN)` / `HttpStatus.NAME` (enum → code) status extraction.
- **Go** — the dominant `if err != nil { ... return }` guard, `if` guards, `os.Getenv` / `os.LookupEnv` env-gates, `http.Error` / `WriteHeader` / gin `c.JSON/Status` writes (numeric + `http.StatusXxx` enum), and `panic(...)` → `raise`.

### Root-fix, not regex theater

Where Python keys block scope on indentation, these languages use braces. A shared `braceBlockBody` helper walks brace depth — skipping string/char-literal and comment noise, and the leading `} catch` / `} else` closer — to scope each branch to exactly its own block, so the FIRST control-altering statement in each block drives the outcome. The outcome lattice, env_gate/early_return/guard kinding, and leading-guard-slot semantics mirror the Python analyzer.

### Default output unchanged

The facet stays opt-in: when `include` is absent the effects payload is byte-for-byte unchanged. Asserted per language in `TestEffectsBranches4434_DefaultUnchanged`.

## Validation (in-pipeline, real handler)

`internal/mcp/effects_branches_4434_test.go` runs the REAL `handleEffects` with `include="branches"` over representative branchy functions on disk per language:

- `user_service.ts` — Express service: `process.env` env-gate + 400/409 guards + a catch that re-throws `HttpException(500)`.
- `UserController.java` — Spring controller: `System.getenv` env-gate + `ResponseEntity.status(HttpStatus.BAD_REQUEST)` guard + a catch returning a 500 `ResponseEntity`.
- `user_handler.go` — net/http handler: `os.Getenv` env-gate + `if err != nil { http.Error(.., StatusBadRequest); return }` + a 409 validation guard + `panic`.

Each asserts the per-branch `kind` / `outcome` / `env_var` / `returns.status`. **RED before** registration (`branches_supported:false`), **GREEN after**. Plus direct unit tests in `internal/substrate/branches_jsts_java_go_test.go`.

## Coverage

All three target languages fully covered — no deferrals. The Java `@Value("${...}")` annotation env-gate is matched only when the annotation text appears inside the function source window; class-field-level `@Value` injection resolved through a field reference is out of scope for a single-function window (consistent with the Python `settings.*` model) and is not a regression.

## Gates

- `go build ./...` ✅
- `go vet ./internal/substrate/ ./internal/mcp/` ✅
- `go test ./internal/substrate/ ./internal/mcp/` ✅

Closes #4434

🤖 Generated with [Claude Code](https://claude.com/claude-code)