### PR TITLE
Add C# classifier for the effects branches facet

### DIFF
--- a/internal/mcp/effects_branches_4445_test.go
+++ b/internal/mcp/effects_branches_4445_test.go
@@ -1,0 +1,133 @@
+package mcp
+
+// effects_branches_4445_test.go — in-pipeline test for the #4445 `branches`
+// facet on C# (extends the #4423/#4435 Python flagship and the #4434 JS/TS,
+// Java, Go analyzers).
+//
+// Per the standing LIVE-VALIDATE rule: this exercises the REAL effects MCP
+// handler (handleEffects) end-to-end — resolver, on-disk source read, the
+// per-language (csharp) branch analyzer registered in
+// internal/substrate/branches_csharp.go — over a representative branchy C#
+// controller action copied into testdata/branches_4445/:
+//
+//   - UserController.cs — an ASP.NET Core controller action with an env-gate
+//     (Environment.GetEnvironmentVariable("SIGNUP_ENABLED") → StatusCode(503)),
+//     a 400 BadRequest() validation guard, a 409 Conflict() guard inside the
+//     try, and a try/catch returning StatusCode(500, ...).
+//
+// It asserts:
+//   - RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+//     `branches` key (default output unchanged — no regression), while
+//     include="branches" enumerates each branch with the right kind/outcome;
+//   - the env-gate's env_var is surfaced (SIGNUP_ENABLED) → 503;
+//   - the helper-result statuses (400 BadRequest / 409 Conflict) and the
+//     explicit StatusCode(500) catch are derived into returns.status;
+//   - the catch returns a value (return_value), not a re-throw.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const csEnt = "csharp-svc::op_create_user_cs"
+
+// branches4445Server builds a server whose single repo's Path points at the
+// branches_4445 testdata dir, with one Operation entity spanning the C#
+// controller action.
+func branches4445Server(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "csharp-svc",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_user_cs", Name: "UserController.CreateUser",
+				Kind: "SCOPE.Operation", QualifiedName: "Example.Api.UserController.CreateUser",
+				SourceFile: "UserController.cs", StartLine: 18, EndLine: 50,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4445"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["csharp-svc"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches4445_DefaultUnchanged is the RED-before assertion: a
+// default effects call (no include) must NOT carry a `branches` key. Guards the
+// no-regression contract.
+func TestEffectsBranches4445_DefaultUnchanged(t *testing.T) {
+	srv := branches4445Server(t)
+	out := callEffects(t, srv, csEnt, "")
+	if _, present := out["branches"]; present {
+		t.Fatalf("%s: default effects output must NOT contain `branches`", csEnt)
+	}
+	if _, present := out["branches_supported"]; present {
+		t.Fatalf("%s: default output must not advertise branches_supported", csEnt)
+	}
+	if out["entity_id"] == nil {
+		t.Fatalf("%s: default output lost entity_id", csEnt)
+	}
+}
+
+// TestEffectsBranches4445_CSharp is the GREEN-after assertion for C#.
+func TestEffectsBranches4445_CSharp(t *testing.T) {
+	srv := branches4445Server(t)
+	out := callEffects(t, srv, csEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for csharp; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: Environment.GetEnvironmentVariable("SIGNUP_ENABLED") → 503
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the Environment.GetEnvironmentVariable env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" {
+		t.Errorf("env-gate kind=%v; want env_gate", env["kind"])
+	}
+	if env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env_var=%v; want SIGNUP_ENABLED", env["env_var"])
+	}
+	if env["outcome"] != "return_value" {
+		t.Errorf("env-gate outcome=%v; want return_value", env["outcome"])
+	}
+	assertStatus(t, env, "503")
+
+	// 400 BadRequest() validation guard
+	g400 := findBranch(branches, "dto.Email == null")
+	if g400 == nil {
+		t.Fatalf("missing the email-required 400 guard: %v", branches)
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("400 guard outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// 409 Conflict() guard inside the try
+	g409 := findBranch(branches, "ExistsByEmail")
+	if g409 == nil {
+		t.Fatalf("missing the 409 existing-email guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// catch returns StatusCode(500, ...) → return_value, status 500
+	cat := findBranch(branches, "catch")
+	if cat == nil {
+		t.Fatalf("missing the catch handler: %v", branches)
+	}
+	if cat["kind"] != "except" {
+		t.Errorf("catch kind=%v; want except", cat["kind"])
+	}
+	if cat["outcome"] != "return_value" {
+		t.Errorf("catch returns StatusCode(500) → outcome should be return_value; got %v", cat["outcome"])
+	}
+	assertStatus(t, cat, "500")
+}

--- a/internal/mcp/testdata/branches_4445/UserController.cs
+++ b/internal/mcp/testdata/branches_4445/UserController.cs
@@ -1,0 +1,55 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Example.Api
+{
+    [ApiController]
+    [Route("api/users")]
+    public class UserController : ControllerBase
+    {
+        private readonly IUserRepository _repo;
+
+        public UserController(IUserRepository repo)
+        {
+            _repo = repo;
+        }
+
+        // CreateUser — env-gated, validated, try/catch controller action.
+        [HttpPost]
+        [ProducesResponseType(201)]
+        public IActionResult CreateUser([FromBody] UserDto dto)
+        {
+            // env-gate: the feature is off unless SIGNUP_ENABLED is set.
+            if (Environment.GetEnvironmentVariable("SIGNUP_ENABLED") != "true")
+            {
+                return StatusCode(503);
+            }
+
+            // 400 guard — email is required.
+            if (dto.Email == null)
+            {
+                return BadRequest(new { error = "email required" });
+            }
+
+            try
+            {
+                // 409 guard inside the try — email already taken.
+                if (_repo.ExistsByEmail(dto.Email))
+                {
+                    return Conflict(new { error = "email exists" });
+                }
+
+                var user = _repo.Save(dto);
+                return CreatedAtAction(nameof(GetUser), new { id = user.Id }, user);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "create failed");
+                return StatusCode(500, new { error = "internal" });
+            }
+        }
+
+        [HttpGet("{id}")]
+        public IActionResult GetUser(int id) => Ok();
+    }
+}

--- a/internal/substrate/branches_csharp.go
+++ b/internal/substrate/branches_csharp.go
@@ -1,0 +1,183 @@
+// Branch inventory analyzer for C# (#4445, extends #4423/#4435/#4434, epic
+// #4419 capability 4).
+//
+// branches.go defines the language-neutral BranchFacet schema, the
+// BranchAnalyzerFn registry, and the flagship Python analyzer.
+// branches_jsts_java_go.go (#4434) added the shared brace-block walker
+// (braceBlockBody) and analyzers for the three other brace-delimited languages
+// plus the shared classifiers (classifyBraceExceptOutcome /
+// classifyBraceGuardOutcome / attachBraceReturns / guardKind / matchEnvVar /
+// afterCloseParen / httpStatusNameToCode). C# is brace-scoped too, so this file
+// reuses every one of those helpers READ-ONLY and only adds the C#-specific
+// header regexes, env-var idioms, and HTTP-status extractor.
+//
+// C# idioms covered (per the ticket):
+//   - try/catch — `catch (Exception e)` / bare `catch` — classified raise (re
+//     throw) / return_value (returns an IActionResult) / swallow (log-only or
+//     empty);
+//   - if-guards — leading guard → early_return, mid-body → guard, conservative
+//     (only surfaced when the block throws / returns / redirects);
+//   - env-gates — Environment.GetEnvironmentVariable("X"),
+//     Configuration["X"] / _config["X"] (IConfiguration indexer),
+//     Configuration.GetValue<...>("X") / GetSection("X");
+//   - status — StatusCode(NNN) / Results.StatusCode(NNN) /
+//     response.StatusCode = NNN, the ControllerBase helpers
+//     (BadRequest/NotFound/Conflict/Unauthorized/...), the
+//     StatusCodes.StatusNNNName / HttpStatusCode.Name enums, and
+//     [ProducesResponseType(NNN)] return-shape hints.
+//
+// Same opt-in contract: this runs only when the effects MCP tool is called with
+// include="branches", so the default effects payload is byte-for-byte unchanged.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterBranchAnalyzer("csharp", analyzeBranchesCSharp) }
+
+var (
+	// csCatchRe — `catch (Exception e)` / `catch (FooException)` / bare `catch`,
+	// possibly preceded by the closing brace of the try (`} catch`).
+	csCatchRe = regexp.MustCompile(`^\s*}?\s*catch\s*(\(([^)]*)\))?\s*(?:when\s*\([^)]*\))?\s*\{?`)
+	// csIfRe — `if (cond) ...`, possibly preceded by `} else `.
+	csIfRe = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\((.*)\)\s*(.*)$`)
+
+	csThrowRe  = regexp.MustCompile(`(^|\b)throw\b`)
+	csReturnRe = regexp.MustCompile(`(^|\b)return\b`)
+	// csRedirectRe — Redirect(...) / RedirectToAction(...) / LocalRedirect(...) /
+	// Results.Redirect(...) / RedirectResult.
+	csRedirectRe = regexp.MustCompile(`\b(?:Local|Permanent)?Redirect(?:ToAction|ToRoute|Permanent)?\s*\(|\bRedirectResult\b`)
+	csLogCallRe  = regexp.MustCompile(`\b(?:_?[Ll]ogger|Log|Console)\s*\.\s*\w+\s*\(`)
+
+	// csEnvRefRe — the env/config idioms, in tried order:
+	//   Environment.GetEnvironmentVariable("X")
+	//   <cfg>["X"]            (IConfiguration indexer — Configuration["X"], _config["X"])
+	//   <cfg>.GetValue<T>("X")
+	//   <cfg>.GetSection("X")
+	csEnvRefRe = regexp.MustCompile(
+		`\bEnvironment\s*\.\s*GetEnvironmentVariable\s*\(\s*"([^"]+)"` +
+			`|(?:[Cc]onfig(?:uration)?|_config(?:uration)?|cfg)\s*\[\s*"([^"]+)"\s*\]` +
+			`|\bGetValue\s*<[^>]*>\s*\(\s*"([^"]+)"` +
+			`|\bGetSection\s*\(\s*"([^"]+)"`)
+
+	// csStatusCallRe — StatusCode(NNN) / Results.StatusCode(NNN) /
+	// .StatusCode = NNN / Problem(statusCode: NNN) / sendError-likes.
+	csStatusCallRe = regexp.MustCompile(`\bStatusCode\s*(?:=\s*|\(\s*(?:statusCode\s*:\s*)?)(\d{3})\b`)
+	csProblemRe    = regexp.MustCompile(`\bProblem\s*\([^)]*?\bstatusCode\s*:\s*(\d{3})\b`)
+	// csStatusEnumRe — StatusCodes.Status409Conflict / HttpStatusCode.Conflict.
+	csStatusCodesRe   = regexp.MustCompile(`\bStatusCodes\s*\.\s*Status(\d{3})[A-Za-z]*`)
+	csHttpStatusEnum  = regexp.MustCompile(`\bHttpStatusCode\s*\.\s*([A-Za-z]+)`)
+	csProducesRespRe  = regexp.MustCompile(`\[ProducesResponseType\s*\([^)]*?\b(\d{3})\b`)
+	// csHelperStatusRe — ControllerBase result helpers mapped to their status.
+	csHelperStatusRe = regexp.MustCompile(`\b(BadRequest|NotFound|Conflict|Unauthorized|Forbid|NoContent|Created|CreatedAtAction|CreatedAtRoute|Accepted|UnprocessableEntity|Ok)\s*\(`)
+)
+
+func analyzeBranchesCSharp(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		// catch handler.
+		if m := csCatchRe.FindStringSubmatch(raw); m != nil {
+			cond := "catch"
+			if strings.TrimSpace(m[2]) != "" {
+				cond = "catch (" + strings.TrimSpace(m[2]) + ")"
+			}
+			body := braceBlockBody(lines, i, afterCloseParen(raw))
+			outcome := classifyBraceExceptOutcome(body, csThrowRe, csReturnRe, csRedirectRe, csLogCallRe)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachBraceReturns(&bf, body, csStatusFromBody, csRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		// if guard.
+		if m := csIfRe.FindStringSubmatch(raw); m != nil {
+			cond := "if (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, m[2])
+			outcome, alters := classifyBraceGuardOutcome(body, csThrowRe, csReturnRe, csRedirectRe)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(csEnvRefRe, m[1])
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, csStatusFromBody, csRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+// csStatusFromBody extracts an HTTP status from a C# branch body. Tries the
+// explicit StatusCode(NNN) / Results.StatusCode(NNN) / .StatusCode = NNN forms,
+// then Problem(statusCode: NNN), then the StatusCodes.StatusNNN and
+// HttpStatusCode.Name enums, then the ControllerBase result helpers
+// (BadRequest()/NotFound()/...), and finally the [ProducesResponseType(NNN)]
+// attribute hint. Empty when none match.
+func csStatusFromBody(joined string) string {
+	if m := csStatusCallRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	if m := csProblemRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	if m := csStatusCodesRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	if m := csHttpStatusEnum.FindStringSubmatch(joined); m != nil {
+		if code := httpStatusNameToCode(strings.ToUpper(camelToSnake(m[1]))); code != "" {
+			return code
+		}
+	}
+	if m := csHelperStatusRe.FindStringSubmatch(joined); m != nil {
+		if code := csHelperToCode(m[1]); code != "" {
+			return code
+		}
+	}
+	if m := csProducesRespRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// csHelperToCode maps the common ControllerBase result-helper names to their
+// HTTP status. Conservative — only the helpers a porting agent most needs.
+func csHelperToCode(name string) string {
+	switch name {
+	case "Ok":
+		return "200"
+	case "Created", "CreatedAtAction", "CreatedAtRoute":
+		return "201"
+	case "Accepted":
+		return "202"
+	case "NoContent":
+		return "204"
+	case "BadRequest":
+		return "400"
+	case "Unauthorized":
+		return "401"
+	case "Forbid":
+		return "403"
+	case "NotFound":
+		return "404"
+	case "Conflict":
+		return "409"
+	case "UnprocessableEntity":
+		return "422"
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Adds a C# `BranchAnalyzerFn` to the opt-in `branches` facet on `archigraph_effects` (#4423/#4435/#4434, epic #4419), so C# functions are enumerated branch-by-branch instead of reporting `branches_supported:false`.

C# is brace-scoped, so the new analyzer lives in its own file (`internal/substrate/branches_csharp.go`) with its own `init()` and reuses the shared `braceBlockBody` walker and brace-language classifiers **read-only** — no shared analyzer file is touched. It adds only the C#-specific header regexes, env idioms, and HTTP-status extractor.

### Shapes covered
- **try/catch** — re-throw → `raise`, returns an `IActionResult` → `return_value`, log-only/empty → `swallow`.
- **if-guards** — leading → `early_return`, mid-body → `guard`; conservative (only surfaced when the block throws/returns/redirects).
- **env-gates** — `Environment.GetEnvironmentVariable("X")`, `IConfiguration` indexer (`Configuration["X"]` / `_config["X"]`), `GetValue<T>("X")`, `GetSection("X")`.
- **status** — `StatusCode(NNN)` / `Results.StatusCode(NNN)` / `.StatusCode = NNN`, `Problem(statusCode: NNN)`, `StatusCodes.StatusNNN`, `HttpStatusCode.Name` (enum→code), the `ControllerBase` result helpers (`BadRequest`/`NotFound`/`Conflict`/...), and `[ProducesResponseType(NNN)]`.

### Default unchanged
The facet stays opt-in: with no `include`, the effects payload carries no `branches`/`branches_supported` keys — asserted by `TestEffectsBranches4445_DefaultUnchanged`. Before this change C# returned `branches_supported:false`; after, `include="branches"` enumerates the branches.

### Live validation (in-pipeline, RED→GREEN)
`internal/mcp/effects_branches_4445_test.go` runs the REAL `handleEffects` with `include="branches"` over an on-disk ASP.NET Core controller action (`testdata/branches_4445/UserController.cs`) containing an `Environment.GetEnvironmentVariable` env-gate (503), a 400 `BadRequest` guard, a 409 `Conflict` guard inside the `try`, and a `try/catch` returning `StatusCode(500)`. Asserts each branch's kind/outcome/env_var/status. Confirmed RED (drops to `branches_supported:false`) when the registration is removed, GREEN with it.

### Gates
- `go build ./...` — OK
- `go vet ./internal/substrate/ ./internal/mcp/` — OK
- `go test ./internal/substrate/ ./internal/mcp/` — OK

Closes #4445

🤖 Generated with [Claude Code](https://claude.com/claude-code)