### PR TITLE
Branch inventory analyzer for PHP

### DIFF
--- a/internal/mcp/effects_branches_4448_test.go
+++ b/internal/mcp/effects_branches_4448_test.go
@@ -1,0 +1,122 @@
+package mcp
+
+// effects_branches_4448_test.go — in-pipeline test for the #4448 `branches`
+// facet on PHP (extends the Python #4423/#4435 flagship and the JS/TS+Java+Go
+// #4434 generalization).
+//
+// Per the standing LIVE-VALIDATE rule: this exercises the REAL effects MCP
+// handler (handleEffects) end-to-end — resolver, on-disk source read,
+// per-language PHP branch analyzer — over a representative branchy PHP
+// controller action copied into testdata/branches_4448/:
+//
+//   - UserController.php — a Laravel/Symfony controller with an env-gate
+//     (env('SIGNUP_ENABLED') → 503), an early-return 400 guard, a 409 conflict
+//     guard inside the try, and a try/catch that re-throws HttpException(500).
+//
+// It asserts:
+//   - RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+//     `branches` key (default output unchanged — no regression), while
+//     include="branches" enumerates each branch with the right kind/outcome;
+//   - the env-gate's env_var (SIGNUP_ENABLED) is surfaced as kind env_gate;
+//   - HTTP statuses (503/400/409/500) are derived into returns.status;
+//   - the catch re-throw is classified except/raise.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const phpEnt = "php-svc::op_store_user_php"
+
+// branches4448Server builds a server whose single repo's Path points at the
+// branches_4448 testdata dir, with one Operation entity spanning the PHP method.
+func branches4448Server(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "php-svc",
+		Entities: []graph.Entity{
+			{
+				ID: "op_store_user_php", Name: "UserController.store",
+				Kind: "SCOPE.Operation", QualifiedName: "App.Http.Controllers.UserController.store",
+				SourceFile: "UserController.php", StartLine: 16, EndLine: 38,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4448"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["php-svc"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches4448_DefaultUnchanged is the RED-before assertion: a
+// default effects call (no include) must NOT carry a `branches` key.
+func TestEffectsBranches4448_DefaultUnchanged(t *testing.T) {
+	srv := branches4448Server(t)
+	out := callEffects(t, srv, phpEnt, "")
+	if _, present := out["branches"]; present {
+		t.Fatalf("%s: default effects output must NOT contain `branches`", phpEnt)
+	}
+	if _, present := out["branches_supported"]; present {
+		t.Fatalf("%s: default output must not advertise branches_supported", phpEnt)
+	}
+	if out["entity_id"] == nil {
+		t.Fatalf("%s: default output lost entity_id", phpEnt)
+	}
+}
+
+// TestEffectsBranches4448_PHP is the GREEN-after assertion for PHP.
+func TestEffectsBranches4448_PHP(t *testing.T) {
+	srv := branches4448Server(t)
+	out := callEffects(t, srv, phpEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for php; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: env('SIGNUP_ENABLED') → 503
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the env('SIGNUP_ENABLED') env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" || env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env-gate=%v; want env_gate/SIGNUP_ENABLED", env)
+	}
+	assertStatus(t, env, "503")
+
+	// 400 email-required guard
+	g400 := findBranch(branches, "email') === null")
+	if g400 == nil {
+		t.Fatalf("missing the email-required 400 guard: %v", branches)
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("400 guard outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// 409 conflict guard inside the try
+	g409 := findBranch(branches, "exists()")
+	if g409 == nil {
+		t.Fatalf("missing the 409 conflict guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// catch re-throws HttpException(500) → raise, status 500
+	cat := findBranch(branches, "catch")
+	if cat == nil {
+		t.Fatalf("missing the catch handler: %v", branches)
+	}
+	if cat["kind"] != "except" {
+		t.Errorf("catch kind=%v; want except", cat["kind"])
+	}
+	if cat["outcome"] != "raise" {
+		t.Errorf("catch re-throws → outcome should be raise; got %v", cat["outcome"])
+	}
+	assertStatus(t, cat, "500")
+}

--- a/internal/mcp/testdata/branches_4448/UserController.php
+++ b/internal/mcp/testdata/branches_4448/UserController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+
+// UserController::store is a representative Laravel/Symfony controller action
+// with an env-gate (env() config helper), an early-return 400 guard, a 409
+// conflict guard inside the try, and a try/catch that re-throws an
+// HttpException(500). Used by effects_branches_4448_test.go to exercise the
+// REAL effects MCP handler over a PHP function on disk.
+class UserController
+{
+    public function store(Request $request)
+    {
+        if (!env('SIGNUP_ENABLED')) {
+            return response()->json(['error' => 'signup disabled'], 503);
+        }
+
+        if ($request->input('email') === null) {
+            return response()->json(['error' => 'email required'], 400);
+        }
+
+        try {
+            if (User::where('email', $request->email)->exists()) {
+                return response()->json(['error' => 'email taken'], 409);
+            }
+
+            $user = User::create($request->all());
+
+            return response()->json($user, 201);
+        } catch (\Exception $e) {
+            Log::error($e->getMessage());
+            throw new HttpException(500, 'could not create user');
+        }
+    }
+}

--- a/internal/substrate/branches_php.go
+++ b/internal/substrate/branches_php.go
@@ -1,0 +1,212 @@
+// Branch inventory analyzer for PHP (#4448, extends #4423/#4435/#4434, epic
+// #4419 capability 4).
+//
+// branches.go added the language-neutral BranchFacet schema, the
+// BranchAnalyzerFn registry, and the flagship Python analyzer (an
+// indentation-scoped CFG walk). branches_jsts_java_go.go generalized the facet
+// to the brace-delimited languages and shipped the shared braceBlockBody helper
+// (a brace-depth walk that scopes each branch to its own block). PHP is also
+// brace-scoped, so this file registers a PHP analyzer that REUSES braceBlockBody
+// (and its companions stripLeadingCloser / afterCloseParen / the shared
+// classify* + attachBraceReturns helpers) read-only — it adds NO shared-file
+// edits, only PHP-specific regexes and a single init().
+//
+// PHP shapes covered, mirroring the Python outcome lattice exactly:
+//   - try/catch — `} catch (\Exception $e) {` → re-throw=raise / return=
+//     return_value / log-only-or-empty=swallow;
+//   - if-guards — leading early_return + mid-body guard, both braced
+//     (`if (...) { return ...; }`) and brace-less (`if (...) return ...;`);
+//   - env-gates — getenv('X') / $_ENV['X'] / $_SERVER['X'] / env('X') (the
+//     Laravel config helper) → kind env_gate with env_var surfaced;
+//   - status — response()->setStatusCode(NNN) / http_response_code(NNN) /
+//     ->setStatusCode(NNN) / abort(NNN) / response(.., NNN) / json(.., NNN) /
+//     new HttpException(NNN) / Response::HTTP_NAME (enum→code) → returns.status.
+//
+// Same opt-in contract: this runs only when the effects MCP tool is called with
+// include="branches", so the default effects payload is byte-for-byte unchanged.
+// Classification is conservative — a branch is only surfaced when it provably
+// alters control flow (returns / throws / redirects / writes an HTTP status);
+// plain branching `if`s are skipped.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterBranchAnalyzer("php", analyzeBranchesPHP) }
+
+var (
+	// phpCatchRe matches a catch clause, with or without a leading `}` closing
+	// the try block (`} catch (\Exception $e) {`). The capture is the caught
+	// type(s) + variable.
+	phpCatchRe = regexp.MustCompile(`^\s*}?\s*catch\s*\(([^)]*)\)\s*\{?`)
+	// phpIfHeadRe matches an `if`/`elseif`/`} else if` keyword up to (and
+	// including) the opening `(` of the condition. The condition itself is then
+	// extracted by paren-matching (phpSplitIfCond) so that an inline brace-less
+	// body containing its own parens — `if ($id <= 0) throw new Exc(400);` — is
+	// not swallowed by a greedy `\((.*)\)`.
+	phpIfHeadRe = regexp.MustCompile(`^\s*(?:\}\s*)?(?:else\s*)?(?:else\s*)?(?:elseif|else\s+if|if)\s*\(`)
+
+	phpThrowRe  = regexp.MustCompile(`(^|\b)throw\b`)
+	phpReturnRe = regexp.MustCompile(`(^|\b)return\b`)
+	// phpRedirectRe — redirect()/->redirect()/RedirectResponse/header('Location:').
+	phpRedirectRe = regexp.MustCompile(`\bredirect\s*\(|\.\s*redirect\s*\(|->\s*redirect\s*\(|\bRedirectResponse\b|header\s*\(\s*['"]Location:`)
+	// phpLogCallRe — a catch body that only logs.
+	phpLogCallRe = regexp.MustCompile(`\b(?:Log|logger|error_log)\s*(?:::|->)?\s*\w*\s*\(`)
+
+	// phpEnvRefRe — getenv('X'), $_ENV['X'], $_SERVER['X'], env('X') (Laravel).
+	// Group order: getenv, $_ENV, $_SERVER, env() helper.
+	phpEnvRefRe = regexp.MustCompile(
+		`\bgetenv\s*\(\s*['"]([^'"]+)['"]` +
+			`|\$_ENV\s*\[\s*['"]([^'"]+)['"]\s*\]` +
+			`|\$_SERVER\s*\[\s*['"]([^'"]+)['"]\s*\]` +
+			`|\benv\s*\(\s*['"]([^'"]+)['"]`)
+
+	// phpStatusCallRe — setStatusCode(NNN), http_response_code(NNN),
+	// abort(NNN), setStatusCode(NNN), withStatus(NNN), response(.., NNN),
+	// json(.., NNN). The numeric status is captured from whichever shape hits.
+	phpStatusCallRe = regexp.MustCompile(
+		`\bhttp_response_code\s*\(\s*(\d{3})\b` +
+			`|\b(?:setStatusCode|withStatus|setStatus|sendError)\s*\(\s*(\d{3})\b` +
+			`|\babort\s*\(\s*(\d{3})\b` +
+			`|new\s+HttpException\s*\(\s*(\d{3})\b` +
+			`|\.\s*(?:json|make|create)\s*\([^;]*?,\s*(\d{3})\b` +
+			`|->\s*(?:json|make|create)\s*\([^;]*?,\s*(\d{3})\b` +
+			`|\bresponse\s*\([^;]*?,\s*(\d{3})\b`)
+	// phpHTTPStatusEnumRe — Response::HTTP_NOT_FOUND / JsonResponse::HTTP_OK.
+	phpHTTPStatusEnumRe = regexp.MustCompile(`::\s*HTTP_([A-Z_]+)\b`)
+)
+
+func analyzeBranchesPHP(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		// catch handler.
+		if m := phpCatchRe.FindStringSubmatch(raw); m != nil {
+			cond := "catch (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, afterCloseParen(raw))
+			outcome := classifyBraceExceptOutcome(body, phpThrowRe, phpReturnRe, phpRedirectRe, phpLogCallRe)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachBraceReturns(&bf, body, phpStatusFromBody, phpRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		// if / elseif guard.
+		if loc := phpIfHeadRe.FindStringIndex(raw); loc != nil {
+			condExpr, after, ok := phpSplitIfCond(raw, loc[1]-1)
+			if !ok {
+				continue
+			}
+			cond := "if (" + strings.TrimSpace(condExpr) + ")"
+			body := braceBlockBody(lines, i, after)
+			outcome, alters := classifyPHPGuardOutcome(body)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(phpEnvRefRe, condExpr)
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, phpStatusFromBody, phpRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+// phpSplitIfCond, given a line and the index of the `(` that opens an if
+// condition, returns the condition text (between that `(` and its matching
+// `)`), the trailing text after the matching `)` (an opening `{` or an inline
+// brace-less statement), and ok=false when the parens are unbalanced on this
+// line. String/char-literal contents are skipped so a `)` inside a literal does
+// not close the condition early — reusing stripBraceNoise's literal model via a
+// parallel paren-depth walk.
+func phpSplitIfCond(ln string, openIdx int) (cond, after string, ok bool) {
+	runes := []rune(ln)
+	if openIdx < 0 || openIdx >= len(runes) || runes[openIdx] != '(' {
+		return "", "", false
+	}
+	depth := 0
+	i := openIdx
+	for i < len(runes) {
+		c := runes[i]
+		switch c {
+		case '"', '\'', '`':
+			quote := c
+			i++
+			for i < len(runes) {
+				if runes[i] == '\\' {
+					i += 2
+					continue
+				}
+				if runes[i] == quote {
+					break
+				}
+				i++
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return string(runes[openIdx+1 : i]), strings.TrimSpace(string(runes[i+1:])), true
+			}
+		}
+		i++
+	}
+	return "", "", false
+}
+
+// classifyPHPGuardOutcome inspects an if-block body and returns its outcome +
+// whether it alters control flow. Mirrors classifyBraceGuardOutcome but also
+// treats a bare HTTP status-write (abort(NNN) / http_response_code(NNN) /
+// ->setStatusCode(NNN)) as control-altering even without a following return —
+// abort() throws internally and a status-write guard is a response branch a
+// porting agent must reproduce (parallels the Go analyzer's status-write
+// fall-through handling).
+func classifyPHPGuardOutcome(body []string) (BranchOutcome, bool) {
+	if outcome, alters := classifyBraceGuardOutcome(body, phpThrowRe, phpReturnRe, phpRedirectRe); alters {
+		return outcome, true
+	}
+	joined := strings.Join(body, "\n")
+	if strings.Contains(joined, "abort(") {
+		return OutcomeRaise, true
+	}
+	if phpStatusFromBody(joined) != "" {
+		return OutcomeReturnValue, true
+	}
+	return "", false
+}
+
+// phpStatusFromBody extracts an HTTP status from a PHP branch body — a numeric
+// status-write call (setStatusCode / http_response_code / abort / response(..,
+// NNN) / json(.., NNN) / new HttpException(NNN)) or a Symfony/Laravel
+// Response::HTTP_NAME enum mapped to its code.
+func phpStatusFromBody(joined string) string {
+	if m := phpStatusCallRe.FindStringSubmatch(joined); m != nil {
+		for _, g := range m[1:] {
+			if g != "" {
+				return g
+			}
+		}
+	}
+	if m := phpHTTPStatusEnumRe.FindStringSubmatch(joined); m != nil {
+		if code := httpStatusNameToCode(m[1]); code != "" {
+			return code
+		}
+	}
+	return ""
+}

--- a/internal/substrate/branches_php_test.go
+++ b/internal/substrate/branches_php_test.go
@@ -1,0 +1,186 @@
+package substrate
+
+import "testing"
+
+// TestAnalyzeBranchesPHP_Outcomes exercises the PHP classifier on a controller
+// action with an env-gate (env() helper), an early-return guard, a status-
+// returning guard inside the try, and a try/catch that re-throws.
+func TestAnalyzeBranchesPHP_Outcomes(t *testing.T) {
+	src := `public function store(Request $request)
+{
+    if (!env('SIGNUP_ENABLED')) {
+        return response()->json(['error' => 'disabled'], 503);
+    }
+    if ($request->input('email') === null) {
+        return response()->json(['error' => 'email required'], 400);
+    }
+    try {
+        if (User::where('email', $request->email)->exists()) {
+            return response()->json(['error' => 'conflict'], 409);
+        }
+        $u = User::create($request->all());
+        return response()->json($u, 201);
+    } catch (\Exception $e) {
+        Log::error($e->getMessage());
+        throw new HttpException(500, 'create failed');
+    }
+}`
+	br := analyzeBranchesPHP(src, 1)
+	if len(br) != 4 {
+		t.Fatalf("expected 4 branches, got %d: %+v", len(br), br)
+	}
+
+	// env-gate via env() helper
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "SIGNUP_ENABLED" {
+		t.Errorf("branch0 = %+v; want env_gate SIGNUP_ENABLED", br[0])
+	}
+	if br[0].Outcome != OutcomeReturnValue {
+		t.Errorf("branch0 outcome = %v; want return_value", br[0].Outcome)
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "503" {
+		t.Errorf("branch0 returns = %+v; want 503", br[0].Returns)
+	}
+
+	// 400 guard — the env-gate above consumed the leading-guard slot (guardKind
+	// flips firstGuardSeen for env-gates too, mirroring #4434), so this later
+	// guard is mid-body `guard`.
+	if br[1].Kind != BranchGuard || br[1].Outcome != OutcomeReturnValue {
+		t.Errorf("branch1 = %+v; want guard/return_value", br[1])
+	}
+	if br[1].Returns == nil || br[1].Returns.Status != "400" {
+		t.Errorf("branch1 returns = %+v; want 400", br[1].Returns)
+	}
+
+	// 409 guard inside the try → mid-body guard
+	if br[2].Kind != BranchGuard || br[2].Outcome != OutcomeReturnValue {
+		t.Errorf("branch2 = %+v; want guard/return_value", br[2])
+	}
+	if br[2].Returns == nil || br[2].Returns.Status != "409" {
+		t.Errorf("branch2 returns = %+v; want 409", br[2].Returns)
+	}
+
+	// catch that re-throws → raise, status 500 from HttpException
+	if br[3].Kind != BranchExcept || br[3].Outcome != OutcomeRaise {
+		t.Errorf("branch3 = %+v; want except/raise", br[3])
+	}
+	if br[3].Returns == nil || br[3].Returns.Status != "500" {
+		t.Errorf("branch3 returns = %+v; want 500", br[3].Returns)
+	}
+}
+
+// TestAnalyzeBranchesPHP_Swallow confirms a log-only catch is swallow and that
+// the getenv() / $_ENV / $_SERVER env-gate shapes + http_response_code /
+// setStatusCode / abort status writes are all recognized.
+func TestAnalyzeBranchesPHP_Swallow(t *testing.T) {
+	src := `function handle($req)
+{
+    if (getenv('FEATURE_X') === false) {
+        http_response_code(403);
+        return;
+    }
+    if (empty($_SERVER['HTTP_AUTH'])) {
+        abort(401);
+    }
+    if (empty($_ENV['TENANT'])) {
+        return response('', 404)->setStatusCode(404);
+    }
+    try {
+        risky();
+    } catch (\Throwable $e) {
+        Log::warning($e);
+    }
+}`
+	br := analyzeBranchesPHP(src, 10)
+
+	// getenv env-gate → 403, return_value (bare return after the status write)
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "FEATURE_X" {
+		t.Errorf("branch0 = %+v; want env_gate FEATURE_X", br[0])
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "403" {
+		t.Errorf("branch0 returns = %+v; want 403", br[0].Returns)
+	}
+	if br[0].Line != 12 {
+		t.Errorf("branch0 line = %d; want 12 (absolute)", br[0].Line)
+	}
+
+	// $_SERVER env-gate → abort(401) raises
+	if br[1].Kind != BranchEnvGate || br[1].EnvVar != "HTTP_AUTH" {
+		t.Errorf("branch1 = %+v; want env_gate HTTP_AUTH", br[1])
+	}
+	if br[1].Returns == nil || br[1].Returns.Status != "401" {
+		t.Errorf("branch1 returns = %+v; want 401", br[1].Returns)
+	}
+
+	// $_ENV env-gate → 404
+	if br[2].Kind != BranchEnvGate || br[2].EnvVar != "TENANT" {
+		t.Errorf("branch2 = %+v; want env_gate TENANT", br[2])
+	}
+	if br[2].Returns == nil || br[2].Returns.Status != "404" {
+		t.Errorf("branch2 returns = %+v; want 404", br[2].Returns)
+	}
+
+	// log-only catch → swallow
+	last := br[len(br)-1]
+	if last.Kind != BranchExcept || last.Outcome != OutcomeSwallow {
+		t.Errorf("catch branch = %+v; want except/swallow", last)
+	}
+}
+
+// TestAnalyzeBranchesPHP_BraceLessGuard confirms the brace-less single-statement
+// `if (...) throw ...;` form is classified, and Response::HTTP_NOT_FOUND enum
+// maps to a code.
+func TestAnalyzeBranchesPHP_BraceLessGuard(t *testing.T) {
+	src := `public function show($id)
+{
+    if ($id <= 0) throw new HttpException(400, 'bad id');
+    $row = Repo::find($id);
+    if ($row === null) return new JsonResponse([], Response::HTTP_NOT_FOUND);
+    return new JsonResponse($row);
+}`
+	br := analyzeBranchesPHP(src, 1)
+	if len(br) != 2 {
+		t.Fatalf("expected 2 branches, got %d: %+v", len(br), br)
+	}
+	if br[0].Outcome != OutcomeRaise || br[0].Returns == nil || br[0].Returns.Status != "400" {
+		t.Errorf("branch0 = %+v; want raise/400", br[0])
+	}
+	if br[1].Outcome != OutcomeReturnValue || br[1].Returns == nil || br[1].Returns.Status != "404" {
+		t.Errorf("branch1 = %+v; want return_value/404 (Response::HTTP_NOT_FOUND)", br[1])
+	}
+}
+
+// TestAnalyzeBranchesPHP_PlainIfSkipped confirms a non-control-altering `if` is
+// not surfaced (conservative — no drowning the agent in every conditional).
+func TestAnalyzeBranchesPHP_PlainIfSkipped(t *testing.T) {
+	src := `function f($x)
+{
+    if ($x > 0) {
+        $y = $x + 1;
+    }
+    return $y;
+}`
+	if br := analyzeBranchesPHP(src, 1); len(br) != 0 {
+		t.Fatalf("plain branching if should not be surfaced; got %+v", br)
+	}
+}
+
+// TestAnalyzeBranchesPHP_Empty guards the trivial inputs.
+func TestAnalyzeBranchesPHP_Empty(t *testing.T) {
+	if br := analyzeBranchesPHP("", 1); br != nil {
+		t.Fatalf("empty source should yield nil; got %+v", br)
+	}
+	if br := analyzeBranchesPHP("   \n  \n", 1); br != nil {
+		t.Fatalf("blank source should yield nil; got %+v", br)
+	}
+}
+
+// TestPHPBranchAnalyzerRegistered confirms the registry wiring so the MCP
+// effects tool resolves the PHP analyzer for .php paths.
+func TestPHPBranchAnalyzerRegistered(t *testing.T) {
+	if BranchAnalyzerFor("php") == nil {
+		t.Fatal("php branch analyzer not registered")
+	}
+	if LanguageForPath("app/Http/Controllers/UserController.php") != "php" {
+		t.Fatal("LanguageForPath should map .php to php")
+	}
+}


### PR DESCRIPTION
Registers a PHP branch-inventory analyzer for the opt-in `branches` facet on `archigraph_effects` (#4423/#4435/#4434), so PHP functions stop reporting `branches_supported:false`.

## What
- New file `internal/substrate/branches_php.go` with its own `init()` calling `RegisterBranchAnalyzer("php", …)`. PHP is brace-scoped, so the analyzer **reuses the shared `braceBlockBody` / `stripLeadingCloser` / `afterCloseParen` / `classify*` / `attachBraceReturns` helpers read-only** — no edits to shared files or the registry type (5 sibling language PRs land concurrently).

## Shapes covered (mirrors the Python outcome lattice)
- **try/catch** — re-throw=`raise` / return=`return_value` / log-only-or-empty=`swallow`.
- **if-guards** — leading `early_return` + mid-body `guard`, both braced and the brace-less `if (...) throw ...;` form (condition is paren-matched so an inline body containing its own parens isn't swallowed by a greedy regex).
- **env-gates** — `getenv('X')` / `$_ENV['X']` / `$_SERVER['X']` / `env('X')` (Laravel config helper) → kind `env_gate` with `env_var` surfaced.
- **status** — `response()->setStatusCode(NNN)` / `http_response_code(NNN)` / `->setStatusCode(NNN)` / `abort(NNN)` / `response(.., NNN)` / `json(.., NNN)` / `new HttpException(NNN)` / `Response::HTTP_NAME` (enum→code) → `returns.status`. `abort()` and bare status-write guards are treated as control-altering (parallels the Go analyzer's status-write fall-through).

## Opt-in / no regression
The facet is computed only when `include="branches"`. The default effects payload is byte-for-byte unchanged when `include` is absent — asserted per the in-pipeline test below.

## Live-validation (in-pipeline)
`internal/mcp/effects_branches_4448_test.go` runs the **real** `handleEffects` end-to-end (resolver → on-disk source read → PHP analyzer) over a representative Laravel/Symfony controller on disk (`testdata/branches_4448/UserController.php`, `UserController::store`):

| branch | kind | outcome | status |
|---|---|---|---|
| `env('SIGNUP_ENABLED')` | env_gate (`SIGNUP_ENABLED`) | return_value | 503 |
| `$request->input('email') === null` | guard | return_value | 400 |
| `User::…->exists()` (in try) | guard | return_value | 409 |
| `} catch (\Exception $e)` re-throw | except | raise | 500 |

- **before** (`include` absent): no `branches` / `branches_supported` key (RED-before / default-unchanged assertion).
- **after** (`include="branches"`): `branches_supported:true` + the table above.

Plus `internal/substrate/branches_php_test.go` unit-covers the analyzer directly (env() / getenv / `$_ENV` / `$_SERVER` gates, `abort()`→raise, `Response::HTTP_NOT_FOUND` enum→404, brace-less throw, swallow catch, plain-if skipped, registry wiring).

## Gates
- `go build ./...` ✅
- `go vet ./internal/substrate/ ./internal/mcp/` ✅
- `go test ./internal/substrate/ ./internal/mcp/` ✅ (both `ok`)

Closes #4448

🤖 Generated with [Claude Code](https://claude.com/claude-code)