### PR TITLE
Add Kotlin classifier for the effects branches facet

### DIFF
--- a/internal/mcp/effects_branches_4446_test.go
+++ b/internal/mcp/effects_branches_4446_test.go
@@ -1,0 +1,126 @@
+package mcp
+
+// effects_branches_4446_test.go — in-pipeline test for the #4446 `branches`
+// facet on Kotlin (extends the Python #4423/#4435 flagship and the JS/TS+Java+Go
+// #4434 brace-language analyzers, epic #4419 capability 4).
+//
+// Per the standing LIVE-VALIDATE rule: this exercises the REAL effects MCP
+// handler (handleEffects) end-to-end — resolver, on-disk source read, the
+// per-language Kotlin branch analyzer — over a representative branchy Kotlin
+// function copied into testdata/branches_4446/:
+//
+//   - UserController.kt — Spring controller (Kotlin) with an env-gate
+//     (System.getenv), an early-return guard returning
+//     ResponseEntity.status(HttpStatus.BAD_REQUEST), a 409 guard inside a try,
+//     and a try/catch that logs then returns a 500 ResponseEntity.
+//
+// It asserts:
+//   - RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+//     `branches` key (default output unchanged — no regression), while
+//     include="branches" enumerates each branch with the right kind/outcome;
+//   - the env-gate's env_var is surfaced (SIGNUP_ENABLED) with status 503;
+//   - HTTP statuses (503/400/409/500) are derived into returns.status, including
+//     HttpStatus.NAME enum → code mapping (BAD_REQUEST → 400, CONFLICT → 409);
+//   - catch returns a 500 ResponseEntity → return_value.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const kotlinEnt = "polyglot-kt::op_create_user_kt"
+
+// branches4446Server builds a server whose single repo's Path points at the
+// branches_4446 testdata dir, with one Operation entity for the Kotlin fixture
+// spanning the create() method.
+func branches4446Server(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "polyglot-kt",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_user_kt", Name: "UserController.create",
+				Kind: "SCOPE.Operation", QualifiedName: "com.example.api.UserController.create",
+				SourceFile: "UserController.kt", StartLine: 24, EndLine: 45,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4446"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["polyglot-kt"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches4446_DefaultUnchanged is the RED-before assertion: a
+// default effects call (no include) must NOT carry a `branches` key. Guards the
+// no-regression contract.
+func TestEffectsBranches4446_DefaultUnchanged(t *testing.T) {
+	srv := branches4446Server(t)
+	out := callEffects(t, srv, kotlinEnt, "")
+	if _, present := out["branches"]; present {
+		t.Fatalf("%s: default effects output must NOT contain `branches`", kotlinEnt)
+	}
+	if _, present := out["branches_supported"]; present {
+		t.Fatalf("%s: default output must not advertise branches_supported", kotlinEnt)
+	}
+	if out["entity_id"] == nil {
+		t.Fatalf("%s: default output lost entity_id", kotlinEnt)
+	}
+}
+
+// TestEffectsBranches4446_Kotlin is the GREEN-after assertion for Kotlin.
+func TestEffectsBranches4446_Kotlin(t *testing.T) {
+	srv := branches4446Server(t)
+	out := callEffects(t, srv, kotlinEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for kotlin; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: System.getenv("SIGNUP_ENABLED") → 503
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the System.getenv env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" || env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env-gate=%v; want env_gate/SIGNUP_ENABLED", env)
+	}
+	assertStatus(t, env, "503")
+
+	// BAD_REQUEST early-return guard → 400 via HttpStatus enum mapping
+	g400 := findBranch(branches, "dto.email == null")
+	if g400 == nil {
+		t.Fatalf("missing the BAD_REQUEST guard: %v", branches)
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("400 guard outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// CONFLICT guard inside try → 409
+	g409 := findBranch(branches, "existsByEmail")
+	if g409 == nil {
+		t.Fatalf("missing the CONFLICT guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// catch logs then returns a 500 ResponseEntity → return_value, status 500
+	cat := findBranch(branches, "catch")
+	if cat == nil {
+		t.Fatalf("missing the catch handler: %v", branches)
+	}
+	if cat["kind"] != "except" {
+		t.Errorf("catch kind=%v; want except", cat["kind"])
+	}
+	if cat["outcome"] != "return_value" {
+		t.Errorf("catch returns 500 ResponseEntity → outcome should be return_value; got %v", cat["outcome"])
+	}
+	assertStatus(t, cat, "500")
+}

--- a/internal/mcp/testdata/branches_4446/UserController.kt
+++ b/internal/mcp/testdata/branches_4446/UserController.kt
@@ -1,0 +1,44 @@
+package com.example.api
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import org.slf4j.LoggerFactory
+
+@RestController
+class UserController(private val repo: UserRepository) {
+
+    private val log = LoggerFactory.getLogger(UserController::class.java)
+
+    @Value("\${signup.maxName:50}")
+    private var maxName: Int = 50
+
+    // create — Spring controller method (Kotlin) with an env-gate
+    // (System.getenv), an early-return guard returning
+    // ResponseEntity.status(HttpStatus.BAD_REQUEST), a 409 guard inside a try,
+    // and a catch that logs then returns a 500 ResponseEntity.
+    @PostMapping("/users")
+    fun create(@RequestBody dto: UserDto): ResponseEntity<Any> {
+        if (System.getenv("SIGNUP_ENABLED") == null) {
+            return ResponseEntity.status(503).build()
+        }
+
+        if (dto.email == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("email required")
+        }
+
+        try {
+            if (repo.existsByEmail(dto.email)) {
+                return ResponseEntity.status(HttpStatus.CONFLICT).body("email in use")
+            }
+            val saved = repo.save(dto.toEntity())
+            return ResponseEntity.status(HttpStatus.CREATED).body(saved)
+        } catch (e: Exception) {
+            log.error("create failed", e)
+            return ResponseEntity.status(500).body("internal error")
+        }
+    }
+}

--- a/internal/substrate/branches_kotlin.go
+++ b/internal/substrate/branches_kotlin.go
@@ -1,0 +1,128 @@
+// Branch inventory analyzer for Kotlin — a brace-delimited, JVM/Spring-flavored
+// language (#4446, extends #4423/#4435/#4434, epic #4419 capability 4).
+//
+// branches.go added the language-neutral BranchFacet schema, the
+// BranchAnalyzerFn registry, and the flagship Python analyzer.
+// branches_jsts_java_go.go added the three other brace-delimited corpus
+// languages plus the shared brace-block machinery (braceBlockBody,
+// stripLeadingCloser/stripBraceNoise, classifyBraceExceptOutcome,
+// classifyBraceGuardOutcome, attachBraceReturns, guardKind, matchEnvVar,
+// afterCloseParen, httpStatusNameToCode). This file registers Kotlin alongside
+// them, in its OWN init() so concurrent sibling language additions never touch a
+// shared file.
+//
+// Kotlin shares Java's block delimiting (`{`/`}`), so it REUSES braceBlockBody
+// read-only to scope each branch to its block. The control-flow surface mirrors
+// the Java analyzer closely (Kotlin leans on the same Spring/Jakarta stack):
+//
+//   - try/catch — `try { ... } catch (e: Exception) { ... }`. Re-throw → raise,
+//     return → return_value, log-only/empty → swallow.
+//   - if-guards + early-return — `if (dto.email == null) return ...` /
+//     `if (...) { return ResponseEntity.status(...)... }`. Kotlin permits a
+//     brace-less single-statement body, handled by braceBlockBody's afterCond.
+//   - env-gates — `System.getenv("X")`, `@Value("\${x}")`, `env.getProperty("x")`,
+//     and Kotlin's own `System.getProperty(...)`; surfaced as env_gate with the
+//     env var name.
+//   - HTTP status — `ResponseEntity.status(NNN)` / `HttpStatus.NAME` (enum→code),
+//     `response.setStatus(NNN)` / `sendError(NNN)`.
+//
+// Same opt-in contract: this runs only when archigraph_effects is called with
+// include="branches", so the default effects payload is byte-for-byte unchanged.
+// Classification stays conservative — a branch is surfaced only when it provably
+// alters control flow (returns / throws / redirects / writes an HTTP error
+// status); plain branching `if`s are skipped.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() {
+	RegisterBranchAnalyzer("kotlin", analyzeBranchesKotlin)
+}
+
+var (
+	// kotlinCatchRe matches `catch (e: Exception)` (Kotlin's typed-binding form)
+	// as well as a leading `}` closer (`} catch (...) {`). The capture is the
+	// full binding text (`e: Exception`).
+	kotlinCatchRe = regexp.MustCompile(`^\s*}?\s*catch\s*\(([^)]*)\)\s*\{?`)
+	// kotlinIfRe matches `if (cond) <rest>` with an optional leading `} else `.
+	kotlinIfRe = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\((.*)\)\s*(.*)$`)
+
+	kotlinThrowRe  = regexp.MustCompile(`(^|\b)throw\b`)
+	kotlinReturnRe = regexp.MustCompile(`(^|\b)return\b`)
+	// kotlinRedirectRe — Spring MVC redirect shapes available from Kotlin, plus
+	// servlet sendRedirect.
+	kotlinRedirectRe = regexp.MustCompile(`\bsendRedirect\s*\(|\bRedirectView\b|ModelAndView\s*\(\s*["']redirect:|["']redirect:`)
+	kotlinLogCallRe  = regexp.MustCompile(`\b(?:log|logger|LOG|LOGGER)\s*\.\s*\w+\s*\(|\bprintln\s*\(|\bprintStackTrace\s*\(|\bSystem\s*\.\s*(?:out|err)\s*\.`)
+
+	// kotlinEnvRefRe — System.getenv("X"), @Value("\${x}"), env.getProperty("x"),
+	// System.getProperty("x"), bare getenv("X"). The `\$` in @Value is escaped in
+	// Kotlin string templates, so the source carries `${...}` literally here.
+	kotlinEnvRefRe = regexp.MustCompile(
+		`\bSystem\s*\.\s*getenv\s*\(\s*"([^"]+)"` +
+			`|@Value\s*\(\s*"\$\{\s*([A-Za-z_][\w.]*)` +
+			`|\bgetProperty\s*\(\s*"([^"]+)"` +
+			`|\bgetenv\s*\(\s*"([^"]+)"`)
+
+	// kotlinStatusCallRe — ResponseEntity.status(NNN), response.setStatus(NNN),
+	// response.sendError(NNN). kotlinHttpStatusEnum maps HttpStatus.NAME → code.
+	kotlinStatusCallRe   = regexp.MustCompile(`\.\s*(?:status|setStatus|sendError)\s*\(\s*(\d{3})\b`)
+	kotlinHttpStatusEnum = regexp.MustCompile(`HttpStatus\s*\.\s*([A-Z_]+)`)
+)
+
+func analyzeBranchesKotlin(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		if m := kotlinCatchRe.FindStringSubmatch(raw); m != nil {
+			cond := "catch (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, afterCloseParen(raw))
+			outcome := classifyBraceExceptOutcome(body, kotlinThrowRe, kotlinReturnRe, kotlinRedirectRe, kotlinLogCallRe)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachBraceReturns(&bf, body, kotlinStatusFromBody, kotlinRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		if m := kotlinIfRe.FindStringSubmatch(raw); m != nil {
+			cond := "if (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, m[2])
+			outcome, alters := classifyBraceGuardOutcome(body, kotlinThrowRe, kotlinReturnRe, kotlinRedirectRe)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(kotlinEnvRefRe, m[1])
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, kotlinStatusFromBody, kotlinRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+func kotlinStatusFromBody(joined string) string {
+	if m := kotlinStatusCallRe.FindStringSubmatch(joined); m != nil {
+		return m[1]
+	}
+	if m := kotlinHttpStatusEnum.FindStringSubmatch(joined); m != nil {
+		if code := httpStatusNameToCode(m[1]); code != "" {
+			return code
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Registers a Kotlin analyzer for the opt-in `branches` facet on `archigraph_effects` (extends #4423/#4435/#4434, epic #4419 capability 4). Until now Kotlin reported `branches_supported:false`.

The facet enumerates a function's CFG decision points — each except / early-return / env-gate / guard with its outcome (`raise` / `return_value` / `redirect` / `swallow`), the env var a condition reads, and a cheap `returns.status`.

## What changed

All new files — **no shared-file edits** (5 sibling language PRs are in flight concurrently). The Kotlin analyzer + `RegisterBranchAnalyzer("kotlin", ...)` live in a new `internal/substrate/branches_kotlin.go` with its own `init()`.

Kotlin shares Java's `{`/`}` block delimiting, so it **reuses the shared `braceBlockBody` walker read-only** and the shared outcome lattice / kinding helpers:

- **try/catch** — `try { ... } catch (e: Exception) { ... }`; re-throw → `raise`, return → `return_value`, log-only/empty → `swallow`.
- **if-guards + early-return** — `if (dto.email == null) return ...`, including Kotlin's brace-less single-statement body form.
- **env-gates** — `System.getenv("X")`, `@Value("${x}")`, `getProperty("x")`, bare `getenv("X")`; surfaced as `env_gate` with the env var name.
- **HTTP status** — `ResponseEntity.status(NNN)` / `HttpStatus.NAME` (enum → code), `response.setStatus(NNN)` / `sendError(NNN)`.

## Default unchanged

Opt-in via `include="branches"`: the default effects payload is byte-for-byte unchanged when `include` is absent. Asserted by `TestEffectsBranches4446_DefaultUnchanged` (no `branches` / `branches_supported` key on the default call).

## Live-validation (in-pipeline, RED→GREEN)

`internal/mcp/effects_branches_4446_test.go` runs the **real** `handleEffects` with `include="branches"` over a representative branchy Kotlin Spring controller on disk (`testdata/branches_4446/UserController.kt`):

- env-gate `System.getenv("SIGNUP_ENABLED")` → `env_gate`, env_var `SIGNUP_ENABLED`, status 503
- `if (dto.email == null)` BAD_REQUEST early-return guard → `return_value`, status 400 (HttpStatus enum → code)
- `if (repo.existsByEmail(...))` CONFLICT guard inside the try → status 409
- `catch (e: Exception)` that logs then returns a 500 ResponseEntity → `except` / `return_value`, status 500

Verified RED before registration (`branches_supported:false` → test fails), GREEN after.

## Gates

- `go build ./...` — pass
- `go vet ./internal/substrate/ ./internal/mcp/` — clean
- `go test ./internal/substrate/ ./internal/mcp/` — pass

DEPLOY-DEFERRED.

Closes #4446

🤖 Generated with [Claude Code](https://claude.com/claude-code)