### PR TITLE
Enumerate Rust control-flow branches in the effects facet

### DIFF
--- a/internal/mcp/effects_branches_4447_test.go
+++ b/internal/mcp/effects_branches_4447_test.go
@@ -1,0 +1,148 @@
+package mcp
+
+// effects_branches_4447_test.go — in-pipeline test for the #4447 `branches`
+// facet on Rust (extends the Python #4423/#4435 flagship and the JS/TS+Java+Go
+// #4434 brace-language analyzers).
+//
+// Per the standing LIVE-VALIDATE rule: this exercises the REAL effects MCP
+// handler (handleEffects) end-to-end — resolver, on-disk source read, the Rust
+// branch analyzer — over a representative branchy Rust function copied into
+// testdata/branches_4447/user_handler.rs: an axum-style handler with a
+// std::env::var env-gate, early-return guards returning Err(StatusCode::...),
+// the `?` try operator, a panic! guard, and a `match` Err(e) => arm.
+//
+// It asserts:
+//   - RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+//     `branches` key (default output unchanged — no regression), while
+//     include="branches" enumerates each branch with the right kind/outcome;
+//   - the env-gate's env_var is surfaced (SIGNUP_ENABLED), kind=env_gate;
+//   - return Err(StatusCode::...) → raise with the mapped status (503/400/409);
+//   - the `?` operator → raise (error propagation);
+//   - panic! → raise;
+//   - the `match` Err arm → except/raise, status 500.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const rustEnt = "rust-svc::op_create_user_rs"
+
+// branches4447Server builds a server whose single repo's Path points at the
+// branches_4447 testdata dir, with one Operation entity spanning the Rust
+// handler.
+func branches4447Server(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "rust-svc",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_user_rs", Name: "create_user",
+				Kind: "SCOPE.Function", QualifiedName: "api::create_user",
+				SourceFile: "user_handler.rs", StartLine: 11, EndLine: 35,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4447"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["rust-svc"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches4447_DefaultUnchanged is the RED-before / no-regression
+// assertion: a default effects call (no include) must NOT carry a `branches`
+// key nor advertise branches_supported.
+func TestEffectsBranches4447_DefaultUnchanged(t *testing.T) {
+	srv := branches4447Server(t)
+	out := callEffects(t, srv, rustEnt, "")
+	if _, present := out["branches"]; present {
+		t.Fatalf("default effects output must NOT contain `branches`")
+	}
+	if _, present := out["branches_supported"]; present {
+		t.Fatalf("default output must not advertise branches_supported")
+	}
+	if out["entity_id"] == nil {
+		t.Fatalf("default output lost entity_id")
+	}
+}
+
+// TestEffectsBranches4447_Rust is the GREEN-after assertion for Rust.
+func TestEffectsBranches4447_Rust(t *testing.T) {
+	srv := branches4447Server(t)
+	out := callEffects(t, srv, rustEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for rust; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: std::env::var("SIGNUP_ENABLED") → return Err(503)
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the std::env::var SIGNUP_ENABLED env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" {
+		t.Errorf("env-gate kind=%v; want env_gate", env["kind"])
+	}
+	if env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env_var=%v; want SIGNUP_ENABLED", env["env_var"])
+	}
+	if env["outcome"] != "raise" {
+		t.Errorf("env-gate outcome=%v; want raise (return Err)", env["outcome"])
+	}
+	assertStatus(t, env, "503")
+
+	// 400 email-required guard → return Err(StatusCode::BAD_REQUEST)
+	g400 := findBranch(branches, "email.is_empty()")
+	if g400 == nil {
+		t.Fatalf("missing the email-required 400 guard: %v", branches)
+	}
+	if g400["outcome"] != "raise" {
+		t.Errorf("400 guard outcome=%v; want raise", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// `?` operator on the find_by_email lookup → raise (propagation)
+	q := findBranch(branches, "find_by_email")
+	if q == nil {
+		t.Fatalf("missing the `?` propagation branch: %v", branches)
+	}
+	if q["outcome"] != "raise" {
+		t.Errorf("`?` branch outcome=%v; want raise", q["outcome"])
+	}
+
+	// 409 existing-email guard
+	g409 := findBranch(branches, "existing.is_some()")
+	if g409 == nil {
+		t.Fatalf("missing the 409 existing-email guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// panic! guard → raise
+	pan := findBranch(branches, "is_poisoned()")
+	if pan == nil {
+		t.Fatalf("missing the panic! guard: %v", branches)
+	}
+	if pan["outcome"] != "raise" {
+		t.Errorf("panic guard outcome=%v; want raise", pan["outcome"])
+	}
+
+	// match Err(e) => arm returning Err(500) → except/raise, status 500
+	cat := findBranch(branches, "Err(e) =>")
+	if cat == nil {
+		t.Fatalf("missing the match Err arm: %v", branches)
+	}
+	if cat["kind"] != "except" {
+		t.Errorf("match Err arm kind=%v; want except", cat["kind"])
+	}
+	if cat["outcome"] != "raise" {
+		t.Errorf("match Err arm outcome=%v; want raise (return Err 500)", cat["outcome"])
+	}
+	assertStatus(t, cat, "500")
+}

--- a/internal/mcp/testdata/branches_4447/user_handler.rs
+++ b/internal/mcp/testdata/branches_4447/user_handler.rs
@@ -1,0 +1,35 @@
+// Representative branchy Rust handler for the #4447 branches-facet in-pipeline
+// test. An axum-style handler exercising the distinctive Rust failure forms:
+//   - std::env::var env-gate returning Err(StatusCode::SERVICE_UNAVAILABLE),
+//   - an early-return guard returning Err(StatusCode::BAD_REQUEST),
+//   - the `?` try operator propagating a lookup error,
+//   - a validation guard returning Err(StatusCode::CONFLICT),
+//   - a `match` Err(e) => arm returning Err(StatusCode::INTERNAL_SERVER_ERROR),
+//   - a panic! guard.
+use axum::{extract::{State, Json}, http::StatusCode};
+
+pub async fn create_user(
+    State(db): State<Db>,
+    Json(payload): Json<NewUser>,
+) -> Result<Json<User>, StatusCode> {
+    if std::env::var("SIGNUP_ENABLED").is_err() {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    if payload.email.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let existing = db.find_by_email(&payload.email).await?;
+    if existing.is_some() {
+        return Err(StatusCode::CONFLICT);
+    }
+    if db.is_poisoned() {
+        panic!("db connection poisoned");
+    }
+    match db.insert(payload).await {
+        Ok(u) => Ok(Json(u)),
+        Err(e) => {
+            tracing::error!("insert failed: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/internal/substrate/branches_rust.go
+++ b/internal/substrate/branches_rust.go
@@ -1,0 +1,251 @@
+// Branch inventory analyzer for Rust — the `?` operator, `return Err`/`Ok`,
+// `match`-arm `Err(e) =>` handlers, `if let Err`/guard clauses, std::env::var
+// gates, StatusCode statuses, and panic! (#4447, extends #4423/#4435/#4434,
+// epic #4419 capability 4).
+//
+// branches.go defined the language-neutral BranchFacet schema, the
+// BranchAnalyzerFn registry, and the flagship Python analyzer.
+// branches_jsts_java_go.go added the brace-delimited JS/TS, Java, and Go
+// analyzers plus the shared braceBlockBody / stripLeadingCloser / guardKind /
+// matchEnvVar / httpStatusNameToCode helpers. Rust is brace-scoped too, so this
+// file REUSES those helpers READ-ONLY and only contributes a Rust-shaped
+// classifier in its own init().
+//
+// Rust's control-flow surface differs from the C-family languages in ways the
+// classifier must model so a porting agent reproduces every failure path:
+//
+//   - The `?` operator (`let x = thing()?;`) is an implicit early return: on an
+//     `Err`/`None` it returns that variant out of the function. There is no
+//     brace block — it is a one-liner — so it is surfaced as an early_return
+//     whose outcome is `raise` (it propagates the error).
+//   - `return Err(...)` / `panic!(...)` / `.unwrap()`/`.expect(...)` raise;
+//     `return Ok(...)` / a bare `return <expr>` returns a value.
+//   - A `match` arm `Err(e) => { ... }` (or `Err(e) => return ...`) is the
+//     idiomatic explicit handler — the Rust analogue of an except/catch — so it
+//     is surfaced as an `except` branch and classified raise/return/swallow.
+//   - `if let Err(e) = ...` / `if let Ok(..) = ..` and ordinary `if <cond>`
+//     guards scope a brace block like the other languages.
+//   - env-gates read std::env::var("X") / env::var("X") / env::var_os("X").
+//   - statuses come from StatusCode::NNN, StatusCode::NAME (axum/actix enum),
+//     and `.status(NNN)` builder calls.
+//
+// Same opt-in contract: this runs only when the effects MCP tool is called with
+// include="branches", so the default effects payload is byte-for-byte unchanged.
+// Classification is conservative — a branch is only surfaced when it provably
+// alters control flow (returns / raises via ? / panics / writes a status).
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() {
+	RegisterBranchAnalyzer("rust", analyzeBranchesRust)
+}
+
+var (
+	// rustMatchErrArmRe — a match arm handling the error variant:
+	// `Err(e) => { ... }` or `Err(e) => return ...,`. Also matches `None =>`
+	// (the Option failure arm). Group 2 is the optional inline arm body after
+	// `=>`.
+	rustMatchErrArmRe = regexp.MustCompile(`^\s*(Err\s*(?:\([^)]*\))?|None)\s*=>\s*(.*)$`)
+
+	// rustIfLetErrRe — `if let Err(e) = expr { ... }` / `if let None = ..`.
+	// The whole condition is captured for env-var sniffing; the leading-`}`
+	// (`} else if let ..`) is tolerated.
+	rustIfLetRe = regexp.MustCompile(`^\s*}?\s*(?:else\s+)?if\s+let\s+(.*?)\s*=\s*(.*?)\s*\{\s*$`)
+
+	// rustIfRe — ordinary guard `if <cond> {`. Rust requires the brace on the
+	// header line (no parens around the condition). A leading `} else ` closer
+	// is tolerated.
+	rustIfRe = regexp.MustCompile(`^\s*}?\s*(?:else\s+)?if\s+(.*?)\s*\{\s*$`)
+
+	// rustQuestionRe — a line containing the `?` try operator on a call/expr
+	// (`let v = f()?;`, `f().await?;`, `bar()?`). Excludes `?` inside a string
+	// (handled by stripBraceNoise) and the `?` of a turbofish/closure (rare in
+	// the statement position we scan). We require a `?` immediately before `;`,
+	// `.`, ` `, or end-of-trimmed-line preceded by `)` or an identifier.
+	rustQuestionRe = regexp.MustCompile(`[\w)\]]\?(?:;|\.|\s|$)`)
+
+	rustReturnRe   = regexp.MustCompile(`(^|\b)return\b`)
+	rustReturnErr  = regexp.MustCompile(`\breturn\s+Err\b|\bErr\s*\(`)
+	rustPanicRe    = regexp.MustCompile(`\bpanic\s*!|\bunreachable\s*!|\btodo\s*!|\bunimplemented\s*!|\.\s*(?:unwrap|expect)\s*\(`)
+	rustRedirectRe = regexp.MustCompile(`\bRedirect\s*::\s*\w+\s*\(|\bredirect\s*\(|\bLocation\b`)
+
+	// rustEnvRefRe — std::env::var("X"), env::var("X"), env::var_os("X"),
+	// std::env::var_os("X"). Group 1 / 2 hold the name.
+	rustEnvRefRe = regexp.MustCompile(
+		`\b(?:std\s*::\s*)?env\s*::\s*var(?:_os)?\s*\(\s*"([^"]+)"`)
+
+	// rustStatusCallRe — `.status(NNN)`, `StatusCode::from_u16(NNN)`,
+	// numeric status literal in a builder.
+	rustStatusCallRe = regexp.MustCompile(`\.\s*status\s*\(\s*(\d{3})\b|StatusCode\s*::\s*from_u16\s*\(\s*(\d{3})\b|\bStatusCode\s*::\s*(\d{3})\b`)
+	// rustStatusEnumRe — axum/actix `StatusCode::BAD_REQUEST` etc.
+	rustStatusEnumRe = regexp.MustCompile(`StatusCode\s*::\s*([A-Z][A-Z_]+)\b`)
+)
+
+func analyzeBranchesRust(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		absLine := startLine + i
+		clean := stripBraceNoise(raw) // ignore `?`/braces inside literals/comments
+
+		// `match` arm handling the error variant — the Rust except analogue.
+		if m := rustMatchErrArmRe.FindStringSubmatch(strings.TrimSpace(clean)); m != nil {
+			cond := strings.TrimSpace(m[1]) + " =>"
+			var body []string
+			inline := strings.TrimSpace(m[2])
+			inline = strings.TrimSuffix(strings.TrimSpace(strings.TrimSuffix(inline, ",")), "{")
+			if strings.Contains(m[2], "{") {
+				body = braceBlockBody(lines, i, m[2])
+			} else if inline != "" {
+				body = []string{inline}
+			}
+			outcome := classifyRustExceptOutcome(body)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachBraceReturns(&bf, body, rustStatusFromBody, rustRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		// `if let Err(..) = ..` / `if let None = ..` guard.
+		if m := rustIfLetRe.FindStringSubmatch(raw); m != nil {
+			pattern := strings.TrimSpace(m[1])
+			scrutinee := strings.TrimSpace(m[2])
+			cond := "if let " + pattern + " = " + scrutinee
+			body := braceBlockBody(lines, i, "{")
+			outcome, alters := classifyRustGuardOutcome(body)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(rustEnvRefRe, m[2])
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, rustStatusFromBody, rustRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		// ordinary `if <cond> {` guard (must come after the if-let branch).
+		if m := rustIfRe.FindStringSubmatch(raw); m != nil {
+			condExpr := strings.TrimSpace(m[1])
+			cond := "if " + condExpr
+			body := braceBlockBody(lines, i, "{")
+			outcome, alters := classifyRustGuardOutcome(body)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(rustEnvRefRe, m[1])
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, rustStatusFromBody, rustRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		// `?` try operator — an implicit early-return that propagates Err/None.
+		// Skip lines that are themselves a branch header (handled above) or a
+		// comment; require the `?` in a statement position.
+		if rustQuestionRe.MatchString(clean) && !strings.HasPrefix(trimmed, "//") {
+			cond := strings.TrimRight(trimmed, " ;")
+			envVar := matchEnvVar(rustEnvRefRe, clean)
+			kind := guardKind(envVar, &firstGuardSeen)
+			// `?` propagates an error variant out of the function — a raise.
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: OutcomeRaise, EnvVar: envVar, Line: absLine}
+			// A `?` rarely names a status, but attach one if the line does.
+			attachBraceReturns(&bf, []string{clean}, rustStatusFromBody, rustRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+// classifyRustGuardOutcome inspects an if / if-let block body. panic!/unwrap/
+// expect or `return Err` → raise; a `?` inside the block → raise (propagates);
+// a `return Ok(..)`/bare return → return_value; a redirect → redirect. A block
+// that does none of these is not surfaced (conservative).
+func classifyRustGuardOutcome(body []string) (BranchOutcome, bool) {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		clean := stripBraceNoise(ln)
+		if rustPanicRe.MatchString(clean) {
+			return OutcomeRaise, true
+		}
+		if rustReturnRe.MatchString(clean) {
+			if rustReturnErr.MatchString(clean) {
+				return OutcomeRaise, true
+			}
+			if rustRedirectRe.MatchString(joined) {
+				return OutcomeRedirect, true
+			}
+			return OutcomeReturnValue, true
+		}
+		if rustQuestionRe.MatchString(clean) {
+			return OutcomeRaise, true
+		}
+		if rustRedirectRe.MatchString(clean) {
+			return OutcomeRedirect, true
+		}
+	}
+	return "", false
+}
+
+// classifyRustExceptOutcome classifies a `match` Err/None arm. A re-raise
+// (panic!/return Err/`?`) → raise; a `return Ok(..)`/value return → return_value;
+// a redirect → redirect; an arm that only logs / produces a fallback value with
+// no error propagation → swallow (the audit-critical recover-and-continue path).
+func classifyRustExceptOutcome(body []string) BranchOutcome {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		clean := stripBraceNoise(ln)
+		if rustPanicRe.MatchString(clean) {
+			return OutcomeRaise
+		}
+		if rustReturnRe.MatchString(clean) {
+			if rustReturnErr.MatchString(clean) {
+				return OutcomeRaise
+			}
+			if rustRedirectRe.MatchString(joined) {
+				return OutcomeRedirect
+			}
+			return OutcomeReturnValue
+		}
+		if rustQuestionRe.MatchString(clean) {
+			return OutcomeRaise
+		}
+		if rustRedirectRe.MatchString(clean) {
+			return OutcomeRedirect
+		}
+	}
+	// No re-raise / return / redirect → swallow (recover-and-continue).
+	return OutcomeSwallow
+}
+
+func rustStatusFromBody(joined string) string {
+	if m := rustStatusCallRe.FindStringSubmatch(joined); m != nil {
+		for _, g := range m[1:] {
+			if g != "" {
+				return g
+			}
+		}
+	}
+	if m := rustStatusEnumRe.FindStringSubmatch(joined); m != nil {
+		if code := httpStatusNameToCode(m[1]); code != "" {
+			return code
+		}
+	}
+	return ""
+}

--- a/internal/substrate/branches_rust_test.go
+++ b/internal/substrate/branches_rust_test.go
@@ -1,0 +1,138 @@
+package substrate
+
+import "testing"
+
+// TestAnalyzeBranchesRust_Outcomes exercises the Rust classifier on an axum-ish
+// handler with an env-gate (std::env::var), an early-return `if` guard returning
+// a StatusCode, a `?` propagation, and a `match` Err arm that returns Err.
+func TestAnalyzeBranchesRust_Outcomes(t *testing.T) {
+	src := `async fn create_user(State(db): State<Db>, Json(payload): Json<NewUser>) -> Result<Json<User>, StatusCode> {
+    if std::env::var("SIGNUP_ENABLED").is_err() {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    if payload.email.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let existing = db.find_by_email(&payload.email).await?;
+    match db.insert(payload).await {
+        Ok(u) => Ok(Json(u)),
+        Err(e) => {
+            tracing::error!("insert failed: {e}");
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+    }
+}`
+	br := analyzeBranchesRust(src, 1)
+	if len(br) != 4 {
+		t.Fatalf("expected 4 branches, got %d: %+v", len(br), br)
+	}
+
+	// env-gate: std::env::var("SIGNUP_ENABLED") → 503
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "SIGNUP_ENABLED" {
+		t.Errorf("branch0 = %+v; want env_gate SIGNUP_ENABLED", br[0])
+	}
+	if br[0].Outcome != OutcomeRaise {
+		t.Errorf("branch0 outcome = %v; want raise (return Err)", br[0].Outcome)
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "503" {
+		t.Errorf("branch0 returns = %+v; want 503 (SERVICE_UNAVAILABLE)", br[0].Returns)
+	}
+
+	// guard returning Err(BAD_REQUEST) → raise, 400 (env-gate took leading slot)
+	if br[1].Kind != BranchGuard || br[1].Outcome != OutcomeRaise {
+		t.Errorf("branch1 = %+v; want guard/raise", br[1])
+	}
+	if br[1].Returns == nil || br[1].Returns.Status != "400" {
+		t.Errorf("branch1 returns = %+v; want 400 (BAD_REQUEST)", br[1].Returns)
+	}
+
+	// `?` propagation → raise
+	q := br[2]
+	if q.Outcome != OutcomeRaise {
+		t.Errorf("branch2 (? op) outcome = %v; want raise; %+v", q.Outcome, q)
+	}
+
+	// match Err arm returning Err(500) → except/raise, 500
+	if br[3].Kind != BranchExcept || br[3].Outcome != OutcomeRaise {
+		t.Errorf("branch3 = %+v; want except/raise", br[3])
+	}
+	if br[3].Returns == nil || br[3].Returns.Status != "500" {
+		t.Errorf("branch3 returns = %+v; want 500 (INTERNAL_SERVER_ERROR)", br[3].Returns)
+	}
+}
+
+// TestAnalyzeBranchesRust_Panic confirms panic! and .unwrap() are raise.
+func TestAnalyzeBranchesRust_Panic(t *testing.T) {
+	src := `fn f(cfg: Option<Config>) -> u32 {
+    if cfg.is_none() {
+        panic!("config required");
+    }
+    42
+}`
+	br := analyzeBranchesRust(src, 1)
+	if len(br) != 1 || br[0].Outcome != OutcomeRaise {
+		t.Fatalf("expected one raise (panic) branch, got %+v", br)
+	}
+}
+
+// TestAnalyzeBranchesRust_IfLetSwallow confirms a `match` Err arm that recovers
+// with a fallback value (no return/raise/?) is a swallow.
+func TestAnalyzeBranchesRust_MatchSwallow(t *testing.T) {
+	src := `fn load(path: &str) -> Config {
+    match read(path) {
+        Ok(c) => c,
+        Err(_) => {
+            Config::default()
+        }
+    }
+}`
+	br := analyzeBranchesRust(src, 1)
+	if len(br) != 1 || br[0].Kind != BranchExcept || br[0].Outcome != OutcomeSwallow {
+		t.Fatalf("expected one swallow except (recover-and-continue), got %+v", br)
+	}
+}
+
+// TestAnalyzeBranchesRust_IfLetErr confirms an `if let Err(e) = ..` guard that
+// returns is surfaced with its condition.
+func TestAnalyzeBranchesRust_IfLetErr(t *testing.T) {
+	src := `fn run() -> Result<(), Error> {
+    if let Err(e) = do_thing() {
+        return Err(e);
+    }
+    Ok(())
+}`
+	br := analyzeBranchesRust(src, 1)
+	if len(br) != 1 {
+		t.Fatalf("expected 1 branch, got %d: %+v", len(br), br)
+	}
+	if br[0].Outcome != OutcomeRaise {
+		t.Errorf("if-let-Err outcome = %v; want raise", br[0].Outcome)
+	}
+	if br[0].Condition != "if let Err(e) = do_thing()" {
+		t.Errorf("condition = %q; want `if let Err(e) = do_thing()`", br[0].Condition)
+	}
+}
+
+// TestAnalyzeBranchesRust_StatusBuilder confirms `.status(NNN)` extraction.
+func TestAnalyzeBranchesRust_StatusBuilder(t *testing.T) {
+	src := `fn h(ok: bool) -> Response {
+    if !ok {
+        return Response::builder().status(403).body(()).unwrap();
+    }
+    Response::new(())
+}`
+	br := analyzeBranchesRust(src, 1)
+	if len(br) != 1 {
+		t.Fatalf("expected 1 branch, got %d: %+v", len(br), br)
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "403" {
+		t.Errorf("returns = %+v; want 403", br[0].Returns)
+	}
+}
+
+// TestBranchAnalyzerRegistry_Rust confirms rust is registered.
+func TestBranchAnalyzerRegistry_Rust(t *testing.T) {
+	if BranchAnalyzerFor("rust") == nil {
+		t.Fatal("rust branch analyzer not registered")
+	}
+}


### PR DESCRIPTION
## Summary

Extends the opt-in `branches` facet on `archigraph_effects` (#4423/#4435/#4434) to **Rust**, the last brace-delimited corpus language. Until now Rust reported `branches_supported:false`; this registers a Rust `BranchAnalyzerFn` alongside the Python flagship and the JS/TS+Java+Go analyzers in the same `substrate.RegisterBranchAnalyzer` registry.

## Rust shapes covered

- **`?` try operator** (`f()?`) — implicit early return propagating `Err`/`None` → `early_return`/`guard`, outcome `raise`.
- **`return Err(...)` / `panic!` / `unreachable!` / `.unwrap()` / `.expect()`** → `raise`; `return Ok(..)` / bare value return → `return_value`.
- **`match { Err(e) => ... }`** (and `None =>`) — the idiomatic explicit handler, surfaced as an `except` branch (`raise` / `return_value` / `swallow` when it recovers with a fallback).
- **`if let Err(e) = ..` / `if let None = ..`** and ordinary `if` guards.
- **env-gates**: `std::env::var` / `env::var` / `env::var_os`.
- **status extraction**: `StatusCode::NNN`, `StatusCode::NAME` (axum/actix enum, via the shared `httpStatusNameToCode` map), `.status(NNN)`.

## No shared-file edits

Rust is brace-scoped, so the analyzer **reuses** `braceBlockBody` / `stripLeadingCloser` / `stripBraceNoise` / `guardKind` / `matchEnvVar` / `httpStatusNameToCode` **read-only** and lives entirely in the new file `internal/substrate/branches_rust.go` with its own `init()`. No shared file or registry-type was modified (5 sibling language PRs land concurrently).

## Default unchanged

The facet stays opt-in — the default effects payload is byte-for-byte unchanged when `include` is absent (asserted: `TestEffectsBranches4447_DefaultUnchanged`).

## Live-validation (in-pipeline)

`internal/mcp/effects_branches_4447_test.go` runs the REAL `handleEffects` with `include="branches"` over a representative axum handler on disk (`testdata/branches_4447/user_handler.rs`): `std::env::var` env-gate (503), `Err(StatusCode::BAD_REQUEST)` guard, a `?` propagation, an `Err(CONFLICT)` guard, a `panic!`, and a `match Err(e)` arm returning `Err(500)` — asserting each branch's kind/outcome/env_var/status and that the default call carries no `branches` key. **RED** before registration (`branches_supported:false`), **GREEN** after.

## Gates

- `go build ./...` — clean
- `go vet ./internal/substrate/ ./internal/mcp/` — clean
- `go test ./internal/substrate/ ./internal/mcp/` — pass

Closes #4447

🤖 Generated with [Claude Code](https://claude.com/claude-code)