### PR TITLE
Branch inventory facet: Scala classifier

### DIFF
--- a/internal/mcp/effects_branches_4449_test.go
+++ b/internal/mcp/effects_branches_4449_test.go
@@ -1,0 +1,131 @@
+package mcp
+
+// effects_branches_4449_test.go — in-pipeline test for the #4449 `branches`
+// facet on Scala (extends the Python #4423/#4435 flagship and the #4434
+// JS/TS/Java/Go brace-language analyzers).
+//
+// Per the standing LIVE-VALIDATE rule: this exercises the REAL effects MCP
+// handler (handleEffects) end-to-end — resolver, on-disk source read, the Scala
+// branch analyzer — over a representative branchy Scala method copied into
+// testdata/branches_4449/UserService.scala:
+//
+//   - an env-gate (sys.env.get("SIGNUP_ENABLED")) returning a Left carrying a
+//     ServiceUnavailable (503) named status;
+//   - an early-return guard yielding Left(BadRequest(...)) → 400;
+//   - a 409 Conflict guard (Either Left) inside the try;
+//   - a try/catch that logs then re-throws a ServiceException → raise.
+//
+// It asserts:
+//   - RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+//     `branches` key (default output unchanged — no regression), while
+//     include="branches" enumerates each branch with the right kind/outcome;
+//   - the env-gate's env_var is surfaced (SIGNUP_ENABLED);
+//   - named Scala statuses (503/400/409) are derived into returns.status;
+//   - the re-throwing catch classifies as except/raise.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const scalaEnt = "scala-svc::op_create_user_scala"
+
+// branches4449Server builds a server whose single repo's Path points at the
+// branches_4449 testdata dir, with one Operation entity spanning the Scala
+// createUser method.
+func branches4449Server(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "scala-svc",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_user_scala", Name: "UserService.createUser",
+				Kind: "SCOPE.Operation", QualifiedName: "com.example.api.UserService.createUser",
+				SourceFile: "UserService.scala", StartLine: 14, EndLine: 36,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4449"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["scala-svc"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches4449_DefaultUnchanged is the RED-before assertion: a
+// default effects call (no include) must NOT carry a `branches` key. Guards the
+// no-regression contract for Scala.
+func TestEffectsBranches4449_DefaultUnchanged(t *testing.T) {
+	srv := branches4449Server(t)
+	out := callEffects(t, srv, scalaEnt, "")
+	if _, present := out["branches"]; present {
+		t.Fatalf("default effects output must NOT contain `branches`")
+	}
+	if _, present := out["branches_supported"]; present {
+		t.Fatalf("default output must not advertise branches_supported")
+	}
+	if out["entity_id"] == nil {
+		t.Fatalf("default output lost entity_id")
+	}
+}
+
+// TestEffectsBranches4449_Scala is the GREEN-after assertion for Scala.
+func TestEffectsBranches4449_Scala(t *testing.T) {
+	srv := branches4449Server(t)
+	out := callEffects(t, srv, scalaEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for scala; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: sys.env.get("SIGNUP_ENABLED") → Left(ServiceUnavailable) 503
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the sys.env.get env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" {
+		t.Errorf("env-gate kind=%v; want env_gate", env["kind"])
+	}
+	if env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env_var=%v; want SIGNUP_ENABLED", env["env_var"])
+	}
+	if env["outcome"] != "return_value" {
+		t.Errorf("env-gate outcome=%v; want return_value", env["outcome"])
+	}
+	assertStatus(t, env, "503")
+
+	// 400 email-required guard (Left(BadRequest(...)))
+	g400 := findBranch(branches, "req.email == null")
+	if g400 == nil {
+		t.Fatalf("missing the email-required 400 guard: %v", branches)
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("400 guard outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// 409 existing-email guard inside the try (Left(Conflict(...)))
+	g409 := findBranch(branches, "existing.isDefined")
+	if g409 == nil {
+		t.Fatalf("missing the 409 existing-email guard: %v", branches)
+	}
+	assertStatus(t, g409, "409")
+
+	// catch re-throws ServiceException → raise
+	cat := findBranch(branches, "catch")
+	if cat == nil {
+		t.Fatalf("missing the catch handler: %v", branches)
+	}
+	if cat["kind"] != "except" {
+		t.Errorf("catch kind=%v; want except", cat["kind"])
+	}
+	if cat["outcome"] != "raise" {
+		t.Errorf("catch re-throws → outcome should be raise; got %v", cat["outcome"])
+	}
+}

--- a/internal/mcp/testdata/branches_4449/UserService.scala
+++ b/internal/mcp/testdata/branches_4449/UserService.scala
@@ -1,0 +1,36 @@
+package com.example.api
+
+import scala.util.{Try, Success, Failure}
+import org.slf4j.LoggerFactory
+
+// createUser — representative Scala service action with an env-gate
+// (sys.env.get("SIGNUP_ENABLED")), two early-return guards yielding Either Left
+// error values carrying named statuses (ServiceUnavailable 503 / BadRequest 400),
+// a 409 Conflict guard inside the try, and a try/catch that logs then re-throws.
+class UserService(repo: UserRepository) {
+
+  private val logger = LoggerFactory.getLogger(classOf[UserService])
+
+  def createUser(req: CreateUserRequest): Either[ApiError, User] = {
+    if (sys.env.get("SIGNUP_ENABLED").isEmpty) {
+      return Left(ServiceUnavailable("signup disabled"))
+    }
+
+    if (req.email == null) {
+      return Left(BadRequest("email is required"))
+    }
+
+    try {
+      val existing = repo.findByEmail(req.email)
+      if (existing.isDefined) {
+        return Left(Conflict("email already in use"))
+      }
+      val user = repo.create(req)
+      Right(user)
+    } catch {
+      case e: Exception =>
+        logger.error("createUser failed", e)
+        throw new ServiceException("create failed", 500)
+    }
+  }
+}

--- a/internal/substrate/branches_scala.go
+++ b/internal/substrate/branches_scala.go
@@ -1,0 +1,289 @@
+// Branch inventory analyzer for Scala (#4449, extends #4423/#4435/#4434, epic
+// #4419 capability 4).
+//
+// branches.go added the language-neutral BranchFacet schema, the
+// BranchAnalyzerFn registry, and the flagship Python analyzer (an
+// indentation-scoped CFG walk). branches_jsts_java_go.go generalized the facet
+// to the brace-delimited JS/TS, Java, and Go languages and contributed the
+// shared braceBlockBody / stripBraceNoise / classifyBrace* helpers. This file
+// registers the Scala analyzer alongside them in the SAME
+// substrate.RegisterBranchAnalyzer registry — in its own init() so it does not
+// touch any shared file (five sibling languages land concurrently).
+//
+// Scala is brace-scoped (`try { ... } catch { case e: T => ... }`, `if (cond) {
+// ... }`), so the analyzer reuses braceBlockBody READ-ONLY exactly like the
+// JS/TS/Java/Go analyzers. The forms it classifies, mirroring the ticket:
+//
+//   - try/catch — Scala spells the handler `catch { case e: T => ... }`. The
+//     catch BLOCK is brace-scoped; its body is classified with the shared
+//     except lattice (re-throw=raise / return or a Status response=return_value
+//     / Left/Failure error value=return_value / log-only=swallow).
+//   - if-guards — `if (cond) { return ... }` / brace-less `if (cond) return ...`,
+//     including the leading-guard → early_return slot, mirroring every sibling.
+//   - Either/Try error branches — a branch yielding `Left(...)` / `Failure(...)`
+//     is a control-altering error outcome (return_value), and a `Failure(new
+//     Exception)` / explicit `throw` is a raise. Scala methods are
+//     expression-oriented, so a guard need not literally `return`.
+//   - env-gates — `sys.env.get("X")` / `sys.env("X")` / `System.getenv("X")` /
+//     `sys.props("x")` conditions surface env_var and the env_gate kind.
+//   - status — `Status(NNN)` / `.withStatus(NNN)` (http4s/akka) plus the named
+//     Play/Akka results (Ok / BadRequest / NotFound / Conflict / ...) and
+//     `HttpStatus.NAME`, mapped to a numeric returns.status.
+//   - throw → raise.
+//
+// Same opt-in contract: the analyzer runs only when the effects MCP tool is
+// called with include="branches"; the default effects payload is byte-for-byte
+// unchanged. Classification is conservative — a branch is surfaced only when it
+// provably alters control flow (returns / throws / yields an error value /
+// writes a status); plain branching `if`s are skipped.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterBranchAnalyzer("scala", analyzeBranchesScala) }
+
+var (
+	// scalaCatchRe matches the Scala `catch {` handler header. The matching
+	// `case e: T =>` clauses live INSIDE the catch block, so the surfaced
+	// condition is simply "catch" — the precise caught types are recovered
+	// from the block body if needed by downstream consumers.
+	scalaCatchRe = regexp.MustCompile(`^\s*}?\s*catch\s*\{?`)
+	// scalaIfRe matches `if (cond) <rest>` — the brace, an inline statement, or
+	// nothing may follow. A leading `} else ` closer is tolerated.
+	scalaIfRe = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\((.*)\)\s*(.*)$`)
+
+	scalaThrowRe = regexp.MustCompile(`(^|\b)throw\b`)
+	// scalaReturnRe — an explicit `return`, OR an Either/Try error value
+	// (`Left(...)` / `Failure(...)`) which is Scala's idiomatic
+	// expression-oriented early-out, OR a `Right(...)` / `Success(...)` /
+	// status response. These are all "this branch produces a value" outcomes.
+	scalaReturnRe = regexp.MustCompile(`(^|\b)return\b|\bLeft\s*\(|\bRight\s*\(|\bFailure\s*\(|\bSuccess\s*\(`)
+	// scalaFailureRe — a `Failure(new SomethingException(...))` or a
+	// `Failure(... Exception ...)` is the Try analogue of a raise.
+	scalaFailureRe  = regexp.MustCompile(`\bFailure\s*\(\s*(?:new\s+)?\w*(?:Exception|Error|Throwable)\b`)
+	scalaRedirectRe = regexp.MustCompile(`\bRedirect\s*\(|\bSeeOther\b|\bTemporaryRedirect\b|\bPermanentRedirect\b|\.\s*redirect\s*\(`)
+	scalaLogCallRe  = regexp.MustCompile(`\b(?:log|logger|Logger|LOG|LOGGER)\s*\.\s*\w+\s*\(|\bprintln\s*\(`)
+
+	// scalaEnvRefRe — sys.env.get("X") / sys.env("X") / System.getenv("X") /
+	// sys.props("x") / sys.props.get("x").
+	scalaEnvRefRe = regexp.MustCompile(
+		`\bsys\s*\.\s*env\s*(?:\.\s*get)?\s*\(\s*"([^"]+)"` +
+			`|\bSystem\s*\.\s*getenv\s*\(\s*"([^"]+)"` +
+			`|\bsys\s*\.\s*props\s*(?:\.\s*get)?\s*\(\s*"([^"]+)"`)
+
+	// scalaStatusCallRe — Status(NNN) (http4s), .withStatus(NNN) (akka-http),
+	// .status(NNN), setStatus(NNN).
+	scalaStatusCallRe = regexp.MustCompile(`\bStatus\s*\(\s*(\d{3})\b|\.\s*(?:withStatus|status|setStatus)\s*\(\s*(\d{3})\b`)
+	// scalaHTTPStatusEnum — a Spring/akka HttpStatus.NAME / StatusCodes.NAME
+	// enum reference, mapped via httpStatusNameToCode.
+	scalaHTTPStatusEnum = regexp.MustCompile(`(?:HttpStatus|StatusCodes?)\s*\.\s*([A-Za-z_][\w]*)`)
+)
+
+// scalaNamedStatus maps the bare Play/akka result objects (Ok, BadRequest, ...)
+// to their numeric code. These are the idiomatic Scala web result values a
+// porting agent most needs reproduced; unknown names yield "".
+func scalaNamedStatus(joined string) string {
+	for _, m := range scalaNamedStatusRe.FindAllStringSubmatch(joined, -1) {
+		if code := scalaResultNameToCode(m[1]); code != "" {
+			return code
+		}
+	}
+	return ""
+}
+
+// scalaNamedStatusRe captures an identifier that may be a Play/akka named
+// result (Ok, BadRequest, NotFound, ...). It is intentionally permissive; the
+// name→code lookup is what actually filters to real result names.
+var scalaNamedStatusRe = regexp.MustCompile(`\b([A-Z][A-Za-z]+)\b`)
+
+func scalaResultNameToCode(name string) string {
+	switch name {
+	case "Ok", "OK":
+		return "200"
+	case "Created":
+		return "201"
+	case "Accepted":
+		return "202"
+	case "NoContent":
+		return "204"
+	case "MovedPermanently":
+		return "301"
+	case "Found":
+		return "302"
+	case "SeeOther":
+		return "303"
+	case "NotModified":
+		return "304"
+	case "TemporaryRedirect":
+		return "307"
+	case "BadRequest":
+		return "400"
+	case "Unauthorized":
+		return "401"
+	case "Forbidden":
+		return "403"
+	case "NotFound":
+		return "404"
+	case "MethodNotAllowed":
+		return "405"
+	case "Conflict":
+		return "409"
+	case "Gone":
+		return "410"
+	case "UnprocessableEntity":
+		return "422"
+	case "TooManyRequests":
+		return "429"
+	case "InternalServerError":
+		return "500"
+	case "NotImplemented":
+		return "501"
+	case "BadGateway":
+		return "502"
+	case "ServiceUnavailable":
+		return "503"
+	case "GatewayTimeout":
+		return "504"
+	}
+	return ""
+}
+
+func analyzeBranchesScala(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		// catch handler — `} catch {` / `catch {`. Match before the if-guard
+		// (a `catch` line never matches scalaIfRe, but keep ordering explicit).
+		if scalaCatchRe.MatchString(raw) {
+			body := braceBlockBody(lines, i, afterCatchBrace(raw))
+			outcome := classifyScalaExceptOutcome(body)
+			bf := BranchFacet{Kind: BranchExcept, Condition: "catch", Outcome: outcome, Line: absLine}
+			attachBraceReturns(&bf, body, scalaStatusFromBody, scalaRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+
+		// if-guard.
+		if m := scalaIfRe.FindStringSubmatch(raw); m != nil {
+			cond := "if (" + strings.TrimSpace(m[1]) + ")"
+			body := braceBlockBody(lines, i, m[2])
+			outcome, alters := classifyScalaGuardOutcome(body)
+			if !alters {
+				continue
+			}
+			envVar := matchEnvVar(scalaEnvRefRe, m[1])
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachBraceReturns(&bf, body, scalaStatusFromBody, scalaRedirectRe)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+// afterCatchBrace returns the text after the `catch` keyword on a header line,
+// so braceBlockBody can detect the opening `{` (it may be on the same line:
+// `catch { case e => ... }`) or fall through to the next line.
+func afterCatchBrace(ln string) string {
+	idx := strings.Index(ln, "catch")
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(ln[idx+len("catch"):])
+	// A leading `{` is what braceBlockBody scans for; return the remainder
+	// verbatim so an inline `catch { case e => return x }` is still walked.
+	return rest
+}
+
+// classifyScalaExceptOutcome classifies a `catch { case ... }` block body. A
+// re-throw (throw / Failure(new XException)) → raise; a return / Status / Right
+// / Left value → return_value; a redirect → redirect; a body that only logs or
+// is empty → swallow (the audit-critical silent-failure path).
+func classifyScalaExceptOutcome(body []string) BranchOutcome {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		if scalaThrowRe.MatchString(ln) || scalaFailureRe.MatchString(ln) {
+			return OutcomeRaise
+		}
+		if scalaReturnRe.MatchString(ln) {
+			if scalaRedirectRe.MatchString(joined) {
+				return OutcomeRedirect
+			}
+			return OutcomeReturnValue
+		}
+		if scalaRedirectRe.MatchString(ln) {
+			return OutcomeRedirect
+		}
+	}
+	// A bare status response with no return/Left/Right (e.g. `BadRequest(...)`
+	// as the last expression) is still a control-altering value outcome.
+	if scalaStatusFromBody(joined) != "" {
+		return OutcomeReturnValue
+	}
+	return OutcomeSwallow
+}
+
+// classifyScalaGuardOutcome inspects an if-block body and returns its outcome +
+// whether it alters control flow. Beyond the brace-language throw/return/
+// redirect lattice it also treats an Either/Try error value (Left/Failure) or a
+// bare status response as a control-altering outcome — Scala guards are
+// expression-oriented and need not literally `return`.
+func classifyScalaGuardOutcome(body []string) (BranchOutcome, bool) {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		if scalaThrowRe.MatchString(ln) || scalaFailureRe.MatchString(ln) {
+			return OutcomeRaise, true
+		}
+		if scalaReturnRe.MatchString(ln) {
+			if scalaRedirectRe.MatchString(joined) {
+				return OutcomeRedirect, true
+			}
+			return OutcomeReturnValue, true
+		}
+		if scalaRedirectRe.MatchString(ln) {
+			return OutcomeRedirect, true
+		}
+	}
+	if scalaStatusFromBody(joined) != "" {
+		return OutcomeReturnValue, true
+	}
+	return "", false
+}
+
+// scalaStatusFromBody derives an HTTP status from a Scala branch body: a numeric
+// Status(NNN) / .withStatus(NNN), then an HttpStatus/StatusCodes enum name, then
+// a bare Play/akka named result (Ok / BadRequest / ...). Empty when none found.
+func scalaStatusFromBody(joined string) string {
+	if m := scalaStatusCallRe.FindStringSubmatch(joined); m != nil {
+		for _, g := range m[1:] {
+			if g != "" {
+				return g
+			}
+		}
+	}
+	if m := scalaHTTPStatusEnum.FindStringSubmatch(joined); m != nil {
+		name := m[1]
+		if code := httpStatusNameToCode(strings.ToUpper(camelToSnake(name))); code != "" {
+			return code
+		}
+		if code := scalaResultNameToCode(name); code != "" {
+			return code
+		}
+	}
+	return scalaNamedStatus(joined)
+}

--- a/internal/substrate/branches_scala_test.go
+++ b/internal/substrate/branches_scala_test.go
@@ -1,0 +1,119 @@
+package substrate
+
+import "testing"
+
+// TestAnalyzeBranchesScala_Outcomes exercises the Scala classifier on a service
+// method with an env-gate (sys.env.get), an early-return guard returning a
+// BadRequest status, an Either Left error branch, and a try/catch that re-throws.
+func TestAnalyzeBranchesScala_Outcomes(t *testing.T) {
+	src := `def createUser(req: Request): Either[ApiError, User] = {
+    if (sys.env.get("SIGNUP_ENABLED").isEmpty) {
+      return Left(ServiceUnavailable("signup disabled"))
+    }
+    if (req.email == null) {
+      return Left(BadRequest("email required"))
+    }
+    try {
+      val existing = repo.findByEmail(req.email)
+      if (existing.isDefined) {
+        return Left(Conflict("email in use"))
+      }
+      Right(repo.create(req))
+    } catch {
+      case e: Exception =>
+        logger.error("createUser failed", e)
+        throw new ServiceException("create failed", 500)
+    }
+}`
+	br := analyzeBranchesScala(src, 1)
+	if len(br) != 4 {
+		t.Fatalf("expected 4 branches, got %d: %+v", len(br), br)
+	}
+
+	// env-gate: sys.env.get("SIGNUP_ENABLED") → ServiceUnavailable (503)
+	if br[0].Kind != BranchEnvGate || br[0].EnvVar != "SIGNUP_ENABLED" {
+		t.Errorf("branch0 = %+v; want env_gate SIGNUP_ENABLED", br[0])
+	}
+	if br[0].Outcome != OutcomeReturnValue {
+		t.Errorf("branch0 outcome = %v; want return_value", br[0].Outcome)
+	}
+	if br[0].Returns == nil || br[0].Returns.Status != "503" {
+		t.Errorf("branch0 returns = %+v; want 503 (ServiceUnavailable)", br[0].Returns)
+	}
+
+	// 400 guard (env-gate consumed the leading slot → guard)
+	if br[1].Kind != BranchGuard || br[1].Outcome != OutcomeReturnValue {
+		t.Errorf("branch1 = %+v; want guard/return_value", br[1])
+	}
+	if br[1].Returns == nil || br[1].Returns.Status != "400" {
+		t.Errorf("branch1 returns = %+v; want 400 (BadRequest)", br[1].Returns)
+	}
+
+	// 409 Conflict guard inside the try
+	if br[2].Returns == nil || br[2].Returns.Status != "409" {
+		t.Errorf("branch2 returns = %+v; want 409 (Conflict)", br[2].Returns)
+	}
+
+	// catch that re-throws → raise
+	if br[3].Kind != BranchExcept || br[3].Outcome != OutcomeRaise {
+		t.Errorf("branch3 = %+v; want except/raise", br[3])
+	}
+}
+
+// TestAnalyzeBranchesScala_Swallow confirms a log-only catch is swallow.
+func TestAnalyzeBranchesScala_Swallow(t *testing.T) {
+	src := `def f(): Unit = {
+    try {
+      doThing()
+    } catch {
+      case err: Throwable =>
+        logger.warn("ignored", err)
+    }
+}`
+	br := analyzeBranchesScala(src, 1)
+	if len(br) != 1 || br[0].Kind != BranchExcept || br[0].Outcome != OutcomeSwallow {
+		t.Fatalf("expected one swallow except, got %+v", br)
+	}
+}
+
+// TestAnalyzeBranchesScala_TryFailure confirms a catch yielding Failure(new
+// Exception) is a raise (the Try analogue of a re-throw).
+func TestAnalyzeBranchesScala_TryFailure(t *testing.T) {
+	src := `def f(): Try[Int] = {
+    try {
+      Success(risky())
+    } catch {
+      case e: IOException =>
+        Failure(new RuntimeException(e))
+    }
+}`
+	br := analyzeBranchesScala(src, 1)
+	if len(br) != 1 || br[0].Kind != BranchExcept || br[0].Outcome != OutcomeRaise {
+		t.Fatalf("expected one raise except (Failure(new ...)), got %+v", br)
+	}
+}
+
+// TestAnalyzeBranchesScala_WithStatus confirms a guard writing .withStatus(NNN)
+// surfaces the numeric status.
+func TestAnalyzeBranchesScala_WithStatus(t *testing.T) {
+	src := `def handle(req: Request): Response = {
+    if (!authorized(req)) {
+      return Response().withStatus(403)
+    }
+    Response().withStatus(200)
+}`
+	br := analyzeBranchesScala(src, 1)
+	if len(br) != 1 {
+		t.Fatalf("expected 1 branch, got %d: %+v", len(br), br)
+	}
+	if br[0].Outcome != OutcomeReturnValue || br[0].Returns == nil || br[0].Returns.Status != "403" {
+		t.Errorf("branch0 = %+v; want return_value/403", br[0])
+	}
+}
+
+// TestBranchAnalyzerRegistry_Scala confirms scala is registered.
+func TestBranchAnalyzerRegistry_Scala(t *testing.T) {
+	if BranchAnalyzerFor("scala") == nil {
+		t.Errorf("scala branch analyzer not registered")
+	}
+}


### PR DESCRIPTION
Extends the opt-in `branches` facet on `archigraph_effects` (#4423/#4435/#4434) to **Scala** — the last brace-delimited language in the corpus the facet did not yet cover. A Scala function previously reported `branches_supported:false`; it now enumerates its CFG decision points with the same `BranchFacet` schema and outcome lattice as every sibling.

### Isolation
The Scala `BranchAnalyzerFn` registers in the shared `substrate.RegisterBranchAnalyzer` registry from its **own `init()` in a NEW file** (`internal/substrate/branches_scala.go`). **No shared file is touched**, so the five concurrent sibling-language additions do not conflict. Scala is brace-scoped, so it reuses the #4434 `braceBlockBody` / `stripBraceNoise` / `classifyBrace*` helpers **read-only**.

### Shapes covered (per ticket)
- **try/catch** — `catch { case e: T => ... }`: re-throw / `Failure(new XException)` → `raise`; return / `Status` / `Left`/`Right` value → `return_value`; log-only / empty → `swallow`.
- **if-guards** — `if (cond) { ... }` and brace-less `if (cond) ...`, with the leading-guard → `early_return` slot.
- **Either/Try error branches** — `Left(...)` / `Failure(...)` surfaced as control-altering outcomes even without a literal `return` (Scala is expression-oriented).
- **env-gates** — `sys.env.get/("X")` / `System.getenv` / `sys.props` → `env_var` + `env_gate` kind.
- **status** — `Status(NNN)` / `.withStatus(NNN)`, `HttpStatus`/`StatusCodes.NAME`, and bare Play/akka named results (`Ok`/`BadRequest`/`Conflict`/...) → numeric `returns.status`.
- **throw → raise**.

### Default unchanged
The facet stays opt-in: the default effects payload is byte-for-byte unchanged when `include` is absent (asserted).

### Validation (LIVE in-pipeline)
`internal/mcp/effects_branches_4449_test.go` runs the **REAL** effects handler with `include="branches"` over a representative Scala service method on disk (`testdata/branches_4449/UserService.scala`) — a `sys.env` env-gate returning `Left(ServiceUnavailable)` 503, two `Either`-Left guards (BadRequest 400, Conflict 409), and a re-throwing catch — asserting each branch's kind/outcome/`env_var`/status and that the default output carries **no** `branches` key (RED→GREEN). Substrate-level unit tests cover swallow, `Failure(new ...)` → raise, and `.withStatus(NNN)`.

Gates: `go build ./...`, `go vet ./internal/substrate/ ./internal/mcp/`, `go test ./internal/substrate/ ./internal/mcp/` all green.

Closes #4449

🤖 Generated with [Claude Code](https://claude.com/claude-code)