### PR TITLE
effects branches facet: Ruby classifier

### DIFF
--- a/internal/mcp/effects_branches_4444_test.go
+++ b/internal/mcp/effects_branches_4444_test.go
@@ -1,0 +1,133 @@
+package mcp
+
+// effects_branches_4444_test.go — in-pipeline test for the #4444 `branches`
+// facet on Ruby (generalizes the Python #4423/#4435 flagship and the #4434
+// JS/TS/Java/Go brace-language analyzers to Ruby's end-keyword block scope).
+//
+// Per the standing LIVE-VALIDATE rule: this exercises the REAL effects MCP
+// handler (handleEffects) end-to-end — resolver, on-disk source read,
+// per-language branch analyzer — over a representative branchy Rails action
+// copied into testdata/branches_4444/users_controller.rb:
+//
+//   - an env-gate (`head :service_unavailable unless ENV['SIGNUP_ENABLED']`)
+//     → env_gate / return_value / 503, env_var SIGNUP_ENABLED;
+//   - a block validation guard (`if params[:email].blank? ... render
+//     status: :bad_request`) → return_value / 400;
+//   - a trailing-modifier guard (`return render(status: :conflict) if
+//     User.exists?`) → return_value / 409;
+//   - a begin/rescue that re-raises after logging → except / raise.
+//
+// It asserts RED-before / GREEN-after: the DEFAULT call (no include) carries NO
+// `branches` key (default output unchanged — no regression), while
+// include="branches" enumerates each branch with the right kind/outcome/
+// env_var/status.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const rubyEnt = "ruby-svc::op_create_user_rb"
+
+// branches4444Server builds a server whose single repo's Path points at the
+// branches_4444 testdata dir, with one Operation entity spanning the Ruby
+// `create` action (lines 6..25 of the fixture).
+func branches4444Server(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "ruby-svc",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_user_rb", Name: "UsersController#create",
+				Kind: "SCOPE.Operation", QualifiedName: "app.controllers.users_controller.UsersController.create",
+				SourceFile: "users_controller.rb", StartLine: 6, EndLine: 25,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4444"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["ruby-svc"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches4444_DefaultUnchanged is the RED-before assertion: a
+// default effects call (no include) must NOT carry a `branches` key. Guards the
+// no-regression contract for Ruby.
+func TestEffectsBranches4444_DefaultUnchanged(t *testing.T) {
+	srv := branches4444Server(t)
+	out := callEffects(t, srv, rubyEnt, "")
+	if _, present := out["branches"]; present {
+		t.Fatalf("default effects output must NOT contain `branches`; got: %v", out["branches"])
+	}
+	if _, present := out["branches_supported"]; present {
+		t.Fatalf("default output must not advertise branches_supported")
+	}
+	if out["entity_id"] == nil {
+		t.Fatalf("default output lost entity_id: %v", out)
+	}
+}
+
+// TestEffectsBranches4444_Ruby is the GREEN-after assertion for Ruby.
+func TestEffectsBranches4444_Ruby(t *testing.T) {
+	srv := branches4444Server(t)
+	out := callEffects(t, srv, rubyEnt, "branches")
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for ruby; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// env-gate: ENV['SIGNUP_ENABLED'] → head :service_unavailable (503).
+	env := findBranch(branches, "SIGNUP_ENABLED")
+	if env == nil {
+		t.Fatalf("missing the ENV['SIGNUP_ENABLED'] env-gate: %v", branches)
+	}
+	if env["kind"] != "env_gate" {
+		t.Errorf("env-gate kind=%v; want env_gate", env["kind"])
+	}
+	if env["env_var"] != "SIGNUP_ENABLED" {
+		t.Errorf("env_var=%v; want SIGNUP_ENABLED", env["env_var"])
+	}
+	if env["outcome"] != "return_value" {
+		t.Errorf("env-gate outcome=%v; want return_value (head :service_unavailable)", env["outcome"])
+	}
+	assertStatus(t, env, "503")
+
+	// block guard: `if params[:email].blank?` renders 400.
+	g400 := findBranch(branches, "params[:email].blank?")
+	if g400 == nil {
+		t.Fatalf("missing the email-required 400 guard: %v", branches)
+	}
+	if g400["outcome"] != "return_value" {
+		t.Errorf("400 guard outcome=%v; want return_value", g400["outcome"])
+	}
+	assertStatus(t, g400, "400")
+
+	// trailing-modifier guard: `return render(status: :conflict) if User.exists?`.
+	g409 := findBranch(branches, "User.exists?")
+	if g409 == nil {
+		t.Fatalf("missing the 409 existing-email guard: %v", branches)
+	}
+	if g409["outcome"] != "return_value" {
+		t.Errorf("409 guard outcome=%v; want return_value", g409["outcome"])
+	}
+	assertStatus(t, g409, "409")
+
+	// begin/rescue re-raises after logging → except / raise.
+	resc := findBranch(branches, "rescue")
+	if resc == nil {
+		t.Fatalf("missing the rescue handler: %v", branches)
+	}
+	if resc["kind"] != "except" {
+		t.Errorf("rescue kind=%v; want except", resc["kind"])
+	}
+	if resc["outcome"] != "raise" {
+		t.Errorf("rescue re-raises → outcome should be raise; got %v", resc["outcome"])
+	}
+}

--- a/internal/mcp/testdata/branches_4444/users_controller.rb
+++ b/internal/mcp/testdata/branches_4444/users_controller.rb
@@ -1,0 +1,32 @@
+class UsersController < ApplicationController
+  # create is a representative branchy Rails action: an env-gate that disables
+  # signups outside production, leading validation guards that render error
+  # statuses, and a begin/rescue that re-raises after logging. Used verbatim by
+  # the #4444 effects-branches Ruby live-validation test.
+  def create
+    head :service_unavailable unless ENV['SIGNUP_ENABLED'] == 'true'
+
+    if params[:email].blank?
+      render json: { error: 'email required' }, status: :bad_request
+      return
+    end
+
+    return render(status: :conflict) if User.exists?(email: params[:email])
+
+    begin
+      user = User.create!(create_params)
+      audit_log(user)
+    rescue ActiveRecord::RecordInvalid => e
+      logger.error("create failed: #{e.message}")
+      raise
+    end
+
+    render json: user, status: :created
+  end
+
+  private
+
+  def create_params
+    params.require(:user).permit(:email, :name)
+  end
+end

--- a/internal/substrate/branches_ruby.go
+++ b/internal/substrate/branches_ruby.go
@@ -1,0 +1,436 @@
+// Branch inventory analyzer for Ruby — begin/rescue, modifier + block guards,
+// env-gates, render-status returns (#4444, extends #4423/#4435/#4434, epic
+// #4419 capability 4).
+//
+// branches.go added the language-neutral BranchFacet schema, the
+// BranchAnalyzerFn registry, and the flagship Python analyzer; branches_jsts_
+// java_go.go generalized it to the three brace-delimited languages via the
+// shared braceBlockBody walker. Ruby is neither indentation-scoped (Python) nor
+// brace-delimited (JS/TS/Java/Go): its blocks open with a keyword (`begin`,
+// `def`, `if`, `do`, `case`, ...) and close with a matching `end`. So this file
+// adds a Ruby-local end-keyword-depth walker (endBlockBody) instead of reusing
+// braceBlockBody, while REUSING the shared outcome lattice, the guardKind /
+// matchEnvVar / httpStatusNameToCode helpers, and the same opt-in contract.
+//
+// Ruby control-flow shapes classified:
+//   - `begin ... rescue E => e ... end` — the rescue handler body. `raise`
+//     re-raise → raise; `return`/a value-yielding `render`/`head` → return_value
+//     /redirect; a log-only / bare body → swallow (the audit-critical silent
+//     failure path), mirroring the Python except classifier.
+//   - leading guards in both forms: the trailing-modifier `return/raise unless
+//     COND` & `... if COND`, and the block `if/unless COND ... return ... end`.
+//   - env-gates: a guard whose condition reads `ENV['X']` / `ENV.fetch('X')` /
+//     `Rails.env` is surfaced as env_gate with env_var set.
+//   - returns.status from `render status: :unprocessable_entity` /
+//     `render status: 409` / `head 404` / `head :not_found` / `redirect_to`.
+//
+// Opt-in contract is unchanged: this runs only when the effects MCP tool is
+// called with include="branches", so the default effects payload is
+// byte-for-byte unchanged. Classification is conservative — a branch is only
+// surfaced when it provably alters control flow (raise / return / render /
+// head / redirect); plain branching `if`s are skipped.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterBranchAnalyzer("ruby", analyzeBranchesRuby) }
+
+var (
+	// rubyRescueRe — a `rescue` clause header. Captures the exception
+	// type/binding text after the keyword (`StandardError => e`, `=> e`, ``).
+	rubyRescueRe = regexp.MustCompile(`^(\s*)rescue\b\s*(.*)$`)
+
+	// rubyBlockGuardRe — a block-form leading guard: `if COND` / `unless COND`
+	// at the start of a statement (NOT a trailing modifier, which has code
+	// before the keyword). Captures the keyword and the condition.
+	rubyBlockGuardRe = regexp.MustCompile(`^\s*(if|unless)\b\s+(.*?)\s*(?:then)?\s*$`)
+
+	// rubyModifierGuardRe — the trailing-modifier guard form Ruby idiom prefers:
+	// `return X if COND` / `raise Y unless COND` / `head 404 if COND`. Captures
+	// the statement (group 1), the keyword (group 2), and the condition (3).
+	rubyModifierGuardRe = regexp.MustCompile(`^\s*(return\b.*?|raise\b.*?|render\b.*?|head\b.*?|redirect_to\b.*?)\s+(if|unless)\s+(.*?)\s*$`)
+
+	// control-altering statement detectors inside a block/handler body.
+	rubyRaiseRe    = regexp.MustCompile(`(^|\b)raise\b|\bfail\b`)
+	rubyReturnRe   = regexp.MustCompile(`(^|\b)return\b`)
+	rubyRenderRe   = regexp.MustCompile(`\brender\b|\bhead\b`)
+	rubyRedirectRe = regexp.MustCompile(`\bredirect_to\b|\bredirect\b`)
+
+	// rubyEnvRefRe — ENV['X'] / ENV["X"] / ENV.fetch('X') / ENV.fetch("X",..) /
+	// Rails.env (surfaced as the symbolic env name "Rails.env").
+	rubyEnvRefRe = regexp.MustCompile(
+		`\bENV\s*\[\s*['"]([^'"]+)['"]\s*\]` +
+			`|\bENV\s*\.\s*fetch\s*\(\s*['"]([^'"]+)['"]` +
+			`|\b(Rails\.env)\b`)
+
+	// rubyStatusSymRe — `status: :unprocessable_entity` / `head :not_found` /
+	// `render status: :ok`. The Rails status symbol → numeric code.
+	rubyStatusSymRe = regexp.MustCompile(`(?:status\s*:\s*|head\s+):([a-z_]+)\b`)
+	// rubyStatusNumRe — `status: 409` / `head 404` / `head(500)`.
+	rubyStatusNumRe = regexp.MustCompile(`(?:status\s*:\s*|head\s*\(?\s*)(\d{3})\b`)
+)
+
+func analyzeBranchesRuby(funcSource string, startLine int) []BranchFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	lines := strings.Split(funcSource, "\n")
+	var out []BranchFacet
+	firstGuardSeen := false
+
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		absLine := startLine + i
+
+		// rescue handler — its body is the run of statements until the next
+		// rescue / else / ensure / end at the same `begin`/`def` nesting.
+		if m := rubyRescueRe.FindStringSubmatch(raw); m != nil {
+			exc := strings.TrimSpace(m[2])
+			cond := "rescue"
+			if exc != "" {
+				cond = "rescue " + exc
+			}
+			body := rubyRescueBody(lines, i)
+			outcome := classifyRubyExceptOutcome(body)
+			bf := BranchFacet{Kind: BranchExcept, Condition: cond, Outcome: outcome, Line: absLine}
+			attachRubyReturns(&bf, body)
+			out = append(out, bf)
+			continue
+		}
+
+		// trailing-modifier guard: `return X if COND` / `raise Y unless COND`.
+		if m := rubyModifierGuardRe.FindStringSubmatch(raw); m != nil {
+			stmt := strings.TrimSpace(m[1])
+			kw := m[2]
+			condExpr := strings.TrimSpace(m[3])
+			outcome, alters := classifyRubyStmtOutcome(stmt)
+			if !alters {
+				continue
+			}
+			cond := kw + " " + condExpr
+			envVar := matchEnvVar(rubyEnvRefRe, condExpr)
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachRubyReturns(&bf, []string{stmt})
+			out = append(out, bf)
+			continue
+		}
+
+		// block-form guard: `if COND` / `unless COND` ... `end`.
+		if m := rubyBlockGuardRe.FindStringSubmatch(raw); m != nil {
+			kw := m[1]
+			condExpr := strings.TrimSpace(m[2])
+			body := endBlockBody(lines, i)
+			outcome, alters := classifyRubyGuardOutcome(body)
+			if !alters {
+				continue
+			}
+			cond := kw + " " + condExpr
+			envVar := matchEnvVar(rubyEnvRefRe, condExpr)
+			kind := guardKind(envVar, &firstGuardSeen)
+			bf := BranchFacet{Kind: kind, Condition: cond, Outcome: outcome, EnvVar: envVar, Line: absLine}
+			attachRubyReturns(&bf, body)
+			out = append(out, bf)
+			continue
+		}
+	}
+	return out
+}
+
+// rubyBlockOpenerRe matches a keyword that opens a new `end`-closed block when
+// it leads a statement: begin / def / if / unless / case / while / until / for
+// / class / module / do (trailing) and `... do |x|`. Used by endBlockBody to
+// track nesting depth so a nested block's `end` does not prematurely close the
+// guard block.
+var rubyBlockOpenerRe = regexp.MustCompile(`^\s*(?:begin|def|class|module|case|while|until|for|if|unless)\b`)
+
+// rubyDoOpenerRe matches a trailing `do` / `do |args|` block opener (e.g.
+// `items.each do |i|`), which also requires a matching `end`.
+var rubyDoOpenerRe = regexp.MustCompile(`\bdo\b(\s*\|[^|]*\|)?\s*$`)
+
+// rubyModifierKwRe detects a leading-keyword line that is actually a one-line
+// trailing-modifier statement (`return x if y`) and therefore does NOT open an
+// `end`-closed block. Such a line must not increment nesting depth.
+var rubyModifierKwRe = regexp.MustCompile(`^\s*(?:if|unless|while|until)\b`)
+
+// rubyOpensBlock reports whether a line opens a new `end`-closed block. A
+// leading if/unless/while/until that carries a trailing modifier on the SAME
+// line (`x if y`) — i.e. has code before the keyword — is handled by the caller
+// (it never reaches here as an opener candidate). A bare `if COND` /
+// `case x` / `begin` / `def` / trailing-`do` opens a block.
+func rubyOpensBlock(line string) bool {
+	if rubyBlockOpenerRe.MatchString(line) {
+		return true
+	}
+	if rubyDoOpenerRe.MatchString(line) {
+		return true
+	}
+	return false
+}
+
+// rubyClosesBlock reports whether a line is a standalone `end` (optionally with
+// a trailing modifier or method chain like `end.tap { }`), i.e. it closes one
+// nesting level.
+var rubyEndRe = regexp.MustCompile(`^\s*end\b`)
+
+// endBlockBody returns the body statements of the `end`-closed block whose
+// header is at lines[headerIdx] (an `if`/`unless`/`begin`/... opener). It walks
+// forward tracking keyword/`end` nesting depth and collects every line strictly
+// inside the block — excluding the header and the closing `end`. This is the
+// Ruby analogue of pyBlockBody / braceBlockBody.
+//
+// A trailing-modifier guard (`return x if y`) is NOT an opener and is handled
+// by the modifier path before this is called, so the header here always opens a
+// real block.
+func endBlockBody(lines []string, headerIdx int) []string {
+	depth := 1 // the header opens the first level
+	var body []string
+	for j := headerIdx + 1; j < len(lines); j++ {
+		ln := lines[j]
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" {
+			continue
+		}
+		// A standalone `end` at the current outermost level closes our block.
+		if rubyEndRe.MatchString(ln) {
+			depth--
+			if depth == 0 {
+				break
+			}
+			body = append(body, ln)
+			continue
+		}
+		// `elsif` / `else` / `ensure` at our block's top level are siblings of
+		// the body, not new nesting — include them as body lines (they don't
+		// change depth) so a guard whose return lives after an `else` is still
+		// seen.
+		if depth == 1 && rubyClauseKw(trimmed) {
+			body = append(body, ln)
+			continue
+		}
+		body = append(body, ln)
+		// Count a nested block opener — but only when it is NOT a trailing
+		// modifier (`do x if cond` style) masquerading as an opener.
+		if rubyOpensBlock(ln) && !rubyIsModifierLine(ln) {
+			depth++
+		}
+	}
+	return body
+}
+
+// rubyClauseKw reports whether a trimmed line begins an in-block clause keyword
+// (elsif/else/ensure/when) that does not open a new `end`-scoped level.
+func rubyClauseKw(trimmed string) bool {
+	for _, kw := range []string{"elsif", "else", "ensure", "when", "in "} {
+		if strings.HasPrefix(trimmed, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// rubyIsModifierLine reports whether a leading-if/unless/while/until line is in
+// fact a single-line trailing-modifier statement (it has a control-altering
+// statement BEFORE the keyword), which does not open an `end`-closed block.
+func rubyIsModifierLine(line string) bool {
+	if !rubyModifierKwRe.MatchString(line) {
+		// Not a leading conditional keyword — a `do`/`begin`/`def` opener is
+		// always a real block.
+		return false
+	}
+	// A pure `if COND` (block opener) has nothing but the condition after the
+	// keyword. The modifier regex requires a statement before the keyword, so
+	// re-use it: if the WHOLE line matches the modifier shape it is a modifier.
+	return rubyModifierGuardRe.MatchString(line)
+}
+
+// rubyRescueBody returns the statements of a `rescue` clause: the run from the
+// line after the rescue header until the next rescue/else/ensure/end that
+// belongs to the SAME begin/def block (depth 0). Nested blocks inside the
+// handler are skipped over via end-keyword depth tracking.
+func rubyRescueBody(lines []string, rescueIdx int) []string {
+	depth := 0
+	var body []string
+	for j := rescueIdx + 1; j < len(lines); j++ {
+		ln := lines[j]
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" {
+			continue
+		}
+		if depth == 0 {
+			// A sibling rescue/else/ensure or the closing end terminates this
+			// handler.
+			if rubyEndRe.MatchString(ln) ||
+				strings.HasPrefix(trimmed, "rescue") ||
+				trimmed == "else" || strings.HasPrefix(trimmed, "ensure") {
+				break
+			}
+		}
+		if rubyEndRe.MatchString(ln) {
+			depth--
+			if depth < 0 {
+				break
+			}
+			body = append(body, ln)
+			continue
+		}
+		body = append(body, ln)
+		if rubyOpensBlock(ln) && !rubyIsModifierLine(ln) {
+			depth++
+		}
+	}
+	return body
+}
+
+// classifyRubyStmtOutcome classifies a single trailing-modifier statement
+// (`return ...`, `raise ...`, `render ...`, `head ...`, `redirect_to ...`).
+func classifyRubyStmtOutcome(stmt string) (BranchOutcome, bool) {
+	switch {
+	case rubyRaiseRe.MatchString(stmt):
+		return OutcomeRaise, true
+	case rubyRedirectRe.MatchString(stmt):
+		return OutcomeRedirect, true
+	case rubyReturnRe.MatchString(stmt):
+		return OutcomeReturnValue, true
+	case rubyRenderRe.MatchString(stmt):
+		return OutcomeReturnValue, true
+	}
+	return "", false
+}
+
+// classifyRubyGuardOutcome inspects an if/unless block body and returns its
+// outcome + whether it provably alters control flow (raise/return/render/head/
+// redirect). A guard that does none is not surfaced (conservative), mirroring
+// the Python/brace analyzers.
+func classifyRubyGuardOutcome(body []string) (BranchOutcome, bool) {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		if rubyRaiseRe.MatchString(ln) {
+			return OutcomeRaise, true
+		}
+		if rubyRedirectRe.MatchString(ln) {
+			return OutcomeRedirect, true
+		}
+		if rubyReturnRe.MatchString(ln) {
+			if rubyRedirectRe.MatchString(joined) {
+				return OutcomeRedirect, true
+			}
+			return OutcomeReturnValue, true
+		}
+		if rubyRenderRe.MatchString(ln) {
+			return OutcomeReturnValue, true
+		}
+	}
+	return "", false
+}
+
+// classifyRubyExceptOutcome classifies a rescue handler body. `raise`/`fail`
+// (re-raise) → raise; a `return`/`render`/`head` (value-yielding) →
+// return_value (or redirect for redirect_to); a body that only logs / is empty
+// → swallow — the catch-and-continue silent-failure path an audit must flag.
+func classifyRubyExceptOutcome(body []string) BranchOutcome {
+	joined := strings.Join(body, "\n")
+	for _, ln := range body {
+		if rubyRaiseRe.MatchString(ln) {
+			return OutcomeRaise
+		}
+		if rubyRedirectRe.MatchString(ln) {
+			return OutcomeRedirect
+		}
+		if rubyReturnRe.MatchString(ln) {
+			if rubyRedirectRe.MatchString(joined) {
+				return OutcomeRedirect
+			}
+			return OutcomeReturnValue
+		}
+		if rubyRenderRe.MatchString(ln) {
+			return OutcomeReturnValue
+		}
+	}
+	// No re-raise / return / render / redirect anywhere → swallow.
+	return OutcomeSwallow
+}
+
+// attachRubyReturns derives returns.status from a Ruby branch body for
+// return_value/raise/redirect branches: a Rails status symbol (`status: :ok`,
+// `head :not_found`) is mapped to its numeric code, or a numeric status is read
+// directly. Only attaches when a status is found.
+func attachRubyReturns(bf *BranchFacet, body []string) {
+	if bf.Outcome != OutcomeReturnValue && bf.Outcome != OutcomeRaise && bf.Outcome != OutcomeRedirect {
+		return
+	}
+	joined := strings.Join(body, "\n")
+	status := ""
+	if m := rubyStatusNumRe.FindStringSubmatch(joined); m != nil {
+		status = m[1]
+	} else if m := rubyStatusSymRe.FindStringSubmatch(joined); m != nil {
+		status = railsStatusSymToCode(m[1])
+	}
+	if status != "" {
+		bf.Returns = &BranchReturns{Status: status}
+	}
+}
+
+// railsStatusSymToCode maps the common Rails HTTP status symbols (the keys
+// Rack::Utils::SYMBOL_TO_STATUS_CODE exposes, used by `render status: :sym` and
+// `head :sym`) to their numeric code. Conservative — the codes a porting agent
+// most needs; unknown symbols yield "".
+func railsStatusSymToCode(sym string) string {
+	switch sym {
+	case "ok":
+		return "200"
+	case "created":
+		return "201"
+	case "accepted":
+		return "202"
+	case "no_content":
+		return "204"
+	case "moved_permanently":
+		return "301"
+	case "found":
+		return "302"
+	case "see_other":
+		return "303"
+	case "not_modified":
+		return "304"
+	case "temporary_redirect":
+		return "307"
+	case "bad_request":
+		return "400"
+	case "unauthorized":
+		return "401"
+	case "forbidden":
+		return "403"
+	case "not_found":
+		return "404"
+	case "method_not_allowed":
+		return "405"
+	case "not_acceptable":
+		return "406"
+	case "conflict":
+		return "409"
+	case "gone":
+		return "410"
+	case "unprocessable_entity", "unprocessable_content":
+		return "422"
+	case "too_many_requests":
+		return "429"
+	case "internal_server_error":
+		return "500"
+	case "not_implemented":
+		return "501"
+	case "bad_gateway":
+		return "502"
+	case "service_unavailable":
+		return "503"
+	case "gateway_timeout":
+		return "504"
+	}
+	return ""
+}


### PR DESCRIPTION
Extends the opt-in `branches` effects facet (#4423/#4435/#4434, epic #4419 capability 4 / #4334 all-language mandate) to Ruby.

## What
Adds a Ruby `BranchAnalyzerFn` registered via `substrate.RegisterBranchAnalyzer("ruby", ...)` in a new file `internal/substrate/branches_ruby.go` with its own `init()`. No shared-file edits — `branches.go`, `branches_python.go`, and `branches_jsts_java_go.go` are untouched, and the sibling language PRs (#4445–#4449) merged cleanly under it on rebase.

Ruby is end-keyword-scoped (not indentation- or brace-delimited), so a Ruby-local `endBlockBody` walker tracks `if`/`unless`/`begin`/`def`/`do`/`case` ... `end` nesting depth (skipping nested blocks and trailing-modifier lines that don't open a block). It reuses the shared `BranchFacet` schema + outcome lattice and the `guardKind`/`matchEnvVar` helpers read-only.

Shapes classified:
- `begin ... rescue E => e ... end` handlers — `raise`/`fail` re-raise → `raise`; value-yielding `return`/`render`/`head` → `return_value`; `redirect_to` → `redirect`; log-only/bare body → `swallow`.
- leading guards in both Ruby forms: trailing-modifier (`return X if COND`, `raise Y unless COND`, `head 404 if COND`) and block-form (`if/unless COND ... return/render ... end`).
- env-gates: conditions reading `ENV['X']` / `ENV.fetch('X')` / `Rails.env` → `env_gate` with `env_var` surfaced.
- `returns.status` from `render status: :sym` / `render status: NNN` / `head :sym` / `head NNN`, with the common Rails status symbols mapped to numeric codes.

## Default output unchanged
The facet is computed only when the effects MCP tool is called with `include="branches"`; the default effects payload is byte-for-byte unchanged (asserted by `TestEffectsBranches4444_DefaultUnchanged`).

## Live-validated in-pipeline
`internal/mcp/effects_branches_4444_test.go` runs the REAL `handleEffects` end-to-end (resolver → on-disk source read → Ruby analyzer) over a representative Rails action in `testdata/branches_4444/users_controller.rb`: an `ENV['SIGNUP_ENABLED']` env-gate (`head :service_unavailable`, 503), a block `params[:email].blank?` guard (render 400), a trailing-modifier `User.exists?` guard (render 409), and a re-raising `rescue`. Asserts each branch's kind/outcome/env_var/status.

RED-before / GREEN-after verified: with the `RegisterBranchAnalyzer("ruby", ...)` call disabled the GREEN test fails (`branches_supported should be true for ruby; got false`); with it registered all pass.

## Gates
- `go build ./...` ✅
- `go vet ./internal/substrate/ ./internal/mcp/` ✅
- `go test ./internal/substrate/ ./internal/mcp/` ✅ (both pass on latest `origin/main`)

Closes #4444

🤖 Generated with [Claude Code](https://claude.com/claude-code)