### PR TITLE
Install/doctor UX + state robustness: skills discovery, graceful degrade, idempotent retry, SHA severity

### DIFF
--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -144,7 +144,13 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 		return nil, err
 	}
 
-	// ── guard: refuse to run over a partial/corrupt install ─────────────────
+	// ── guard: refuse to run over a corrupt install, auto-recover a partial ──
+	// A previous install may have rolled back and left PartialInstall=true.
+	// #4461: re-running `archigraph install` must just work — the transaction
+	// below is fully idempotent (skills/MCP are re-applied, daemon re-started),
+	// so a stale partial state is treated as "resume/redo" with a warning rather
+	// than a hard error that forces --force or uninstall. We still hard-fail on
+	// an UNREADABLE state file (genuine corruption), which --force can bypass.
 	if !opts.Force {
 		if err := guardPartialInstall(opts.StatePath); err != nil {
 			return nil, err
@@ -196,55 +202,84 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	// ─────────────────────────────────────────────────────────────────────────
 	// Step 2: Skills copy
 	// ─────────────────────────────────────────────────────────────────────────
-	skillsDir := skilllink.DiscoverSkillsDir(opts.BinPath, opts.SkillsSourceDir)
-	if skillsDir == "" {
-		rollback(2)
-		cwd := opts.WorkingDir
-		if cwd == "" {
-			cwd, _ = os.Getwd()
-		}
-		return nil, fmt.Errorf("no skills/ directory found at %s; pass --skills-source-dir <path-to-archigraph-repo>/skills", cwd)
-	}
+	skillsDir, attemptedSkillPaths := skilllink.DiscoverSkillsDirVerbose(opts.BinPath, opts.SkillsSourceDir)
 
+	// Claude config dirs are needed both for the skills copy destinations and
+	// for MCP registration in step 3.  Detect them up front so a missing skills
+	// source can degrade gracefully without also tripping over config detection.
 	claudeDirs := mcpreg.DetectClaudeConfigDirs(opts.ClaudeConfigDirs)
-	if len(claudeDirs) == 0 {
-		rollback(2)
-		return nil, fmt.Errorf("step 2 – no Claude Code config directories detected")
-	}
 
-	// Copy skills into EVERY detected Claude config dir's skills/ subdir so
-	// users running multiple Claude profiles (~/.claude, ~/.claude-personal,
-	// etc.) see the skills in all of them.  The SkillRecord/Files manifest
-	// is identical regardless of how many destinations receive a copy.
-	skillRecords := map[string]SkillRecord{}
-	installedSet := map[string]bool{}
-	for _, cfgPath := range claudeDirs {
-		skillsDestDir := skilllink.ClaudeSkillsDirForConfig(cfgPath)
-		if skillsDestDir == "" {
-			fmt.Fprintf(os.Stderr,
-				"archigraph install: cannot derive skills dir for %s; skipping\n",
-				cfgPath)
-			continue
+	switch {
+	case skillsDir == "":
+		// #4460: graceful-degrade. A brand-new binary-only install (no repo
+		// checkout, no --skills-source-dir) has no skills source to copy from.
+		// Rather than HARD-FAIL + rollback (which bricks the whole install and
+		// prevents the daemon from being installed), WARN + CONTINUE and record
+		// skills_skipped in state. The error message (#4459) now names EVERY
+		// path actually probed instead of the misleading cwd.
+		state.SkillsSkipped = true
+		fmt.Fprintf(os.Stderr,
+			"archigraph install: step 2 warning – no skills/ directory found; skipping skills copy (daemon + MCP will still be installed).\n")
+		if len(attemptedSkillPaths) > 0 {
+			fmt.Fprintf(os.Stderr, "  Paths checked:\n")
+			for _, p := range attemptedSkillPaths {
+				fmt.Fprintf(os.Stderr, "    %s\n", p)
+			}
 		}
-		recs, installed, err := copySkills(skillsDir, skillsDestDir, opts.DryRun)
-		if err != nil {
-			rollback(2)
-			return nil, fmt.Errorf("step 2 – copy skills into %s: %w", skillsDestDir, err)
+		fmt.Fprintf(os.Stderr,
+			"  To install skills, pass --skills-source-dir <path-to-archigraph-repo>/skills or set ARCHIGRAPH_SKILLS_DIR.\n")
+
+	case len(claudeDirs) == 0:
+		// A skills source exists but there is nowhere to copy it. This is a real
+		// problem (Claude Code not detected), so keep failing — but with the same
+		// graceful, informative phrasing rather than a rollback-and-die.
+		state.SkillsSkipped = true
+		fmt.Fprintf(os.Stderr,
+			"archigraph install: step 2 warning – no Claude Code config directories detected; skipping skills copy.\n")
+
+	default:
+		// Copy skills into EVERY detected Claude config dir's skills/ subdir so
+		// users running multiple Claude profiles (~/.claude, ~/.claude-personal,
+		// etc.) see the skills in all of them.  The SkillRecord/Files manifest
+		// is identical regardless of how many destinations receive a copy.
+		skillRecords := map[string]SkillRecord{}
+		installedSet := map[string]bool{}
+		for _, cfgPath := range claudeDirs {
+			skillsDestDir := skilllink.ClaudeSkillsDirForConfig(cfgPath)
+			if skillsDestDir == "" {
+				fmt.Fprintf(os.Stderr,
+					"archigraph install: cannot derive skills dir for %s; skipping\n",
+					cfgPath)
+				continue
+			}
+			recs, installed, err := copySkills(skillsDir, skillsDestDir, opts.DryRun)
+			if err != nil {
+				rollback(2)
+				return nil, fmt.Errorf("step 2 – copy skills into %s: %w", skillsDestDir, err)
+			}
+			for name, rec := range recs {
+				skillRecords[name] = rec
+			}
+			for _, name := range installed {
+				installedSet[name] = true
+			}
 		}
-		for name, rec := range recs {
-			skillRecords[name] = rec
-		}
-		for _, name := range installed {
-			installedSet[name] = true
-		}
-	}
-	state.Skills = skillRecords
-	for _, name := range skilllink.SkillNames {
-		if installedSet[name] {
-			result.SkillsInstalled = append(result.SkillsInstalled, name)
+		state.Skills = skillRecords
+		for _, name := range skilllink.SkillNames {
+			if installedSet[name] {
+				result.SkillsInstalled = append(result.SkillsInstalled, name)
+			}
 		}
 	}
 	completedSteps = append(completedSteps, 2)
+
+	// MCP registration (step 3) still requires at least one Claude config dir.
+	// If skills were skipped purely because none were found, surface that here
+	// as the genuine blocker.
+	if len(claudeDirs) == 0 {
+		rollback(2)
+		return nil, fmt.Errorf("step 3 – no Claude Code config directories detected")
+	}
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Step 3: MCP registration
@@ -381,9 +416,18 @@ func (o *CopyOptions) applyDefaults() error {
 	return nil
 }
 
-// guardPartialInstall returns an error if install.json exists and
-// describes a partial/corrupt install. This prevents users from running
-// `archigraph install` twice and ending up with half-applied state.
+// guardPartialInstall inspects install.json and decides whether `install` may
+// proceed without --force.
+//
+// It returns an error ONLY when the state file exists but is unreadable
+// (genuine corruption) — that case still requires --force or a clean
+// uninstall+install.
+//
+// #4461: a *readable* state that merely records a prior PARTIAL install
+// (PartialInstall=true, set on a rollback) is NOT a blocker. The install
+// transaction is idempotent, so re-running it simply resumes/redoes the work.
+// We emit a one-line advisory and let the caller continue; the fresh State
+// written at the end of a successful run clears the partial flag automatically.
 func guardPartialInstall(statePath string) error {
 	st, err := ReadState(statePath)
 	if err != nil {
@@ -397,9 +441,12 @@ func guardPartialInstall(statePath string) error {
 		return nil
 	}
 	if st.PartialInstall {
-		return fmt.Errorf(
-			"a partial install was detected (rolled back from step %d); run `archigraph install --force` to retry or `archigraph uninstall && archigraph install` to start clean",
+		// Auto-recover: warn and proceed. The idempotent transaction below will
+		// re-apply every step and persist a clean (non-partial) state on success.
+		fmt.Fprintf(os.Stderr,
+			"archigraph install: recovering from a previous partial install (rolled back from step %d); retrying automatically.\n",
 			st.RollbackFromStep)
+		return nil
 	}
 	return nil
 }

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -194,12 +193,13 @@ func TestRunCopy_RollbackOnStep4Failure(t *testing.T) {
 	}
 }
 
-// TestRunCopy_PartialInstallGuard verifies that running install when a
-// partial install is already recorded returns an error unless --force is set.
-func TestRunCopy_PartialInstallGuard(t *testing.T) {
+// TestRunCopy_PartialInstallAutoRecovers verifies that running install when a
+// partial install is already recorded auto-recovers (idempotent retry) WITHOUT
+// requiring --force, and that the resulting state is no longer partial (#4461).
+func TestRunCopy_PartialInstallAutoRecovers(t *testing.T) {
 	env := newTestEnv(t)
 
-	// Write a fake partial state.
+	// Write a fake partial state (as would be left after a rolled-back install).
 	partial := install.NewState(install.ModeCopy)
 	partial.PartialInstall = true
 	partial.RollbackFromStep = 4
@@ -214,19 +214,55 @@ func TestRunCopy_PartialInstallGuard(t *testing.T) {
 		StatePath:         env.statePath,
 		WorkingDir:        env.gitRepo,
 		SkipDaemonRestart: true,
-		Force:             false, // no --force
+		Force:             false, // explicitly NO --force
 	}
 
-	_, err := install.RunCopy(opts)
-	if err == nil {
-		t.Fatal("expected RunCopy to refuse when PartialInstall=true and Force=false")
+	// A plain second install must just work.
+	if _, err := install.RunCopy(opts); err != nil {
+		t.Fatalf("expected partial-install retry to auto-recover without --force, got: %v", err)
+	}
+
+	// The persisted state must now be clean (partial flag cleared).
+	state, err := install.ReadState(env.statePath)
+	if err != nil {
+		t.Fatalf("read state after recovery: %v", err)
+	}
+	if state.PartialInstall {
+		t.Error("expected PartialInstall=false after successful auto-recovery")
+	}
+	if state.RollbackFromStep != 0 {
+		t.Errorf("expected RollbackFromStep=0 after recovery, got %d", state.RollbackFromStep)
+	}
+}
+
+// TestRunCopy_UnreadableStateStillBlocks verifies that a genuinely corrupt
+// (unreadable) install.json still hard-fails without --force (#4461 keeps the
+// corruption guard; only the partial-install soft-block was relaxed).
+func TestRunCopy_UnreadableStateStillBlocks(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Write garbage that cannot be parsed as JSON.
+	if err := os.WriteFile(env.statePath, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write corrupt state: %v", err)
+	}
+
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+		Force:             false,
+	}
+	if _, err := install.RunCopy(opts); err == nil {
+		t.Fatal("expected RunCopy to refuse over an unreadable install.json without --force")
 	}
 
 	// With --force it should proceed.
 	opts.Force = true
-	_, err = install.RunCopy(opts)
-	if err != nil {
-		t.Fatalf("RunCopy with --force: %v", err)
+	if _, err := install.RunCopy(opts); err != nil {
+		t.Fatalf("RunCopy with --force over corrupt state: %v", err)
 	}
 }
 
@@ -382,36 +418,75 @@ func assertGitignoreEntry(t *testing.T, repoRoot string) {
 	t.Errorf(".gitignore does not contain /.archigraph/; content: %q", string(data))
 }
 
-// TestRunCopy_MissingSkillsDirectory verifies that when the skills directory
-// cannot be discovered, the error message includes the current working directory
-// and suggests using --skills-source-dir.
-func TestRunCopy_MissingSkillsDirectory(t *testing.T) {
+// TestRunCopy_MissingSkillsDirectory_GracefulDegrade verifies that when the
+// skills directory cannot be discovered, RunCopy WARNS and CONTINUES rather
+// than hard-failing (#4460): the install still succeeds, the daemon/MCP steps
+// proceed, and the persisted state records SkillsSkipped=true. The daemon must
+// be installable from a brand-new binary-only checkout with no skills source.
+func TestRunCopy_MissingSkillsDirectory_GracefulDegrade(t *testing.T) {
 	env := newTestEnv(t)
 
+	// Ensure the env-var discovery path can't accidentally satisfy discovery.
+	t.Setenv("ARCHIGRAPH_SKILLS_DIR", "")
+
+	// Place the binary in an isolated dir with NO skills/ anywhere on its
+	// sibling/one-up/ancestor path, so discovery genuinely fails (a brand-new
+	// binary-only install). env.fakeBin lives next to env.skillsSourceDir and
+	// would be found via the sibling/ancestor walk.
+	isoBinDir := filepath.Join(t.TempDir(), "iso", "bin")
+	if err := os.MkdirAll(isoBinDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	isoBin := filepath.Join(isoBinDir, "archigraph")
+	if err := os.WriteFile(isoBin, []byte("#!/bin/sh\necho iso"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Track whether the (mocked) daemon restart still runs — it must, proving
+	// the install did not abort at step 2.
+	restartCalled := false
+
 	opts := install.CopyOptions{
-		BinPath:           env.fakeBin,
-		SkillsSourceDir:   "/nonexistent/skills",
-		ClaudeConfigDirs:  []string{env.claudeJSON},
-		StatePath:         env.statePath,
-		WorkingDir:        env.gitRepo,
-		SkipDaemonRestart: true,
+		BinPath:          isoBin,
+		SkillsSourceDir:  "/nonexistent/skills",
+		ClaudeConfigDirs: []string{env.claudeJSON},
+		StatePath:        env.statePath,
+		WorkingDir:       env.gitRepo,
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			restartCalled = true
+			return "test-daemon-v0", nil
+		},
 	}
 
-	_, err := install.RunCopy(opts)
-	if err == nil {
-		t.Fatal("expected RunCopy to fail when skills directory is missing")
+	result, err := install.RunCopy(opts)
+	if err != nil {
+		t.Fatalf("expected graceful degrade (no error) when skills dir missing, got: %v", err)
+	}
+	if len(result.SkillsInstalled) != 0 {
+		t.Errorf("expected no skills installed, got %v", result.SkillsInstalled)
+	}
+	if !restartCalled {
+		t.Error("expected daemon restart (step 4) to run after skills were skipped")
+	}
+	if result.DaemonVersion != "test-daemon-v0" {
+		t.Errorf("expected daemon to be installed, got version %q", result.DaemonVersion)
 	}
 
-	errMsg := err.Error()
-	// Check that the error message includes the actionable hints.
-	if !strings.Contains(errMsg, "no skills/ directory found") {
-		t.Errorf("error should mention missing skills directory; got: %s", errMsg)
+	// MCP must still be registered.
+	if len(result.MCPPaths) == 0 {
+		t.Error("expected MCP registration to proceed even though skills were skipped")
 	}
-	if !strings.Contains(errMsg, "--skills-source-dir") {
-		t.Errorf("error should suggest --skills-source-dir flag; got: %s", errMsg)
+
+	// State must record the skip.
+	state, err := install.ReadState(env.statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
 	}
-	if !strings.Contains(errMsg, "/skills") {
-		t.Errorf("error should show path suffix /skills; got: %s", errMsg)
+	if !state.SkillsSkipped {
+		t.Error("expected state.SkillsSkipped=true after graceful skills skip")
+	}
+	if state.PartialInstall {
+		t.Error("expected a graceful skills-skip to NOT mark the install partial")
 	}
 }
 

--- a/internal/install/dev_test.go
+++ b/internal/install/dev_test.go
@@ -176,9 +176,10 @@ func TestRunDev_Idempotent(t *testing.T) {
 	}
 }
 
-// TestRunDev_PartialInstallGuard verifies that running `archigraph install --dev`
-// when a partial install is recorded returns an error unless --force is set.
-func TestRunDev_PartialInstallGuard(t *testing.T) {
+// TestRunDev_PartialInstallAutoRecovers verifies that running `archigraph install --dev`
+// when a partial install is recorded auto-recovers (idempotent retry) WITHOUT
+// requiring --force (#4461 — the partial-install guard is shared with COPY mode).
+func TestRunDev_PartialInstallAutoRecovers(t *testing.T) {
 	env := newDevTestEnv(t)
 
 	// Write a fake partial state.
@@ -190,18 +191,19 @@ func TestRunDev_PartialInstallGuard(t *testing.T) {
 	}
 
 	opts := defaultDevOpts(env)
-	opts.Force = false
+	opts.Force = false // explicitly NO --force
 
-	_, err := install.RunDev(opts)
-	if err == nil {
-		t.Fatal("expected RunDev to refuse when PartialInstall=true and Force=false")
+	if _, err := install.RunDev(opts); err != nil {
+		t.Fatalf("expected partial-install retry to auto-recover without --force, got: %v", err)
 	}
 
-	// With --force it should proceed.
-	opts.Force = true
-	_, err = install.RunDev(opts)
+	// State must be clean after a successful recovery.
+	state, err := install.ReadState(env.statePath)
 	if err != nil {
-		t.Fatalf("RunDev with --force: %v", err)
+		t.Fatalf("read state after recovery: %v", err)
+	}
+	if state.PartialInstall {
+		t.Error("expected PartialInstall=false after successful auto-recovery")
 	}
 }
 

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -258,9 +258,14 @@ func checkCLI(state *State) CheckResult {
 	}
 
 	if actual != state.CLI.SHA256 {
+		// #4463: a SHA drift alone is NOT a broken install — the daemon stays
+		// fully usable (status.go already treats this as a non-blocking note).
+		// It typically means the binary was rebuilt/upgraded in place since the
+		// last `install`. Surface it as a Warning (exit-zero advisory), reserving
+		// Critical for unreadable/missing install.json and unhashable binaries.
 		cr.OK = false
-		cr.Severity = SeverityCritical
-		cr.Drift = []string{fmt.Sprintf("sha256 mismatch: binary=%s install=%s", actual[:16], state.CLI.SHA256[:16])}
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf("sha256 mismatch: binary=%s install=%s (daemon still usable; re-run 'archigraph install' to refresh)", actual[:16], state.CLI.SHA256[:16])}
 	}
 	return cr
 }
@@ -755,7 +760,7 @@ func RunQuickDoctor(opts QuickOptions) error {
 	if state.CLI.Path != "" && state.CLI.SHA256 != "" && !isInGitWorktree() {
 		actual, shaErr := sha256File(state.CLI.Path)
 		if shaErr == nil && actual != state.CLI.SHA256 {
-			warnings = append(warnings, "binary SHA mismatch (reinstall recommended)")
+			warnings = append(warnings, "binary updated since last install (daemon still usable)")
 		}
 	}
 

--- a/internal/install/doctor_test.go
+++ b/internal/install/doctor_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -244,14 +245,41 @@ func TestDoctorCLITamper(t *testing.T) {
 	if len(cli.Drift) == 0 {
 		t.Error("cli check should report drift")
 	}
-	// Must report as Critical.
-	if cli.Severity != install.SeverityCritical {
-		t.Errorf("cli severity = %q, want critical", cli.Severity)
+	// #4463: a SHA-only drift is a Warning, not Critical — the daemon is still
+	// usable, so it must not read as a broken install. (The overall report.OK in
+	// this test env is independently false because no daemon is running on the
+	// probe port; the CLI severity is what matters here.)
+	if cli.Severity != install.SeverityWarning {
+		t.Errorf("cli severity = %q, want warning", cli.Severity)
+	}
+}
+
+// TestDoctorMissingCLIRecordCritical: an install.json with no CLI record (a
+// genuine partial/corrupt install) must still be Critical (#4463 keeps Critical
+// for the missing-record case; only SHA drift was downgraded).
+func TestDoctorMissingCLIRecordCritical(t *testing.T) {
+	env := newDoctorTestEnv(t)
+
+	// Blank out the CLI record in install.json.
+	state, err := install.ReadState(env.statePath)
+	if err != nil || state == nil {
+		t.Fatalf("read state: %v", err)
+	}
+	state.CLI = install.CLIRecord{}
+	if err := install.WriteState(env.statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
 	}
 
-	// Overall report must be not-OK.
+	report := runDoctor(t, env, 1)
+	cli := findCheck(report, "cli")
+	if cli == nil {
+		t.Fatal("cli check missing")
+	}
+	if cli.Severity != install.SeverityCritical {
+		t.Errorf("cli severity = %q, want critical for missing CLI record", cli.Severity)
+	}
 	if report.OK {
-		t.Error("report.OK should be false after CLI tamper")
+		t.Error("report.OK should be false when CLI record is missing")
 	}
 }
 
@@ -540,6 +568,14 @@ func TestDoctorQuickMode_Tampered(t *testing.T) {
 	lines := countNonEmptyLines(output)
 	if lines > 1 {
 		t.Errorf("quick-doctor printed %d lines, want 1: %q", lines, output)
+	}
+	// #4463: the wording must not read as "broken". The old "reinstall
+	// recommended" phrasing alarmed users on every status/rebuild.
+	if strings.Contains(output, "reinstall recommended") {
+		t.Errorf("quick-doctor SHA-drift wording should be non-alarming, got: %q", output)
+	}
+	if !strings.Contains(output, "still usable") {
+		t.Errorf("quick-doctor SHA-drift message should reassure the daemon is usable, got: %q", output)
 	}
 }
 

--- a/internal/install/skilllink/skilllink.go
+++ b/internal/install/skilllink/skilllink.go
@@ -133,36 +133,64 @@ func PruneOrphanSkillSymlinks(out io.Writer, skillsSubdir string) {
 //
 // Returns "" if none of the locations exist, which signals the caller to
 // error or skip the step.
+//
+// DiscoverSkillsDir is a thin wrapper over DiscoverSkillsDirVerbose that
+// discards the list of attempted paths.
 func DiscoverSkillsDir(binPath, skillsSourceDir string) string {
-	// Explicit override from flag or config.
-	if skillsSourceDir != "" {
-		if info, err := os.Stat(skillsSourceDir); err == nil && info.IsDir() {
-			return skillsSourceDir
+	dir, _ := DiscoverSkillsDirVerbose(binPath, skillsSourceDir)
+	return dir
+}
+
+// DiscoverSkillsDirVerbose behaves like DiscoverSkillsDir but also returns the
+// ordered list of every candidate path it actually checked. When discovery
+// fails (returns ""), the attempted list lets the caller build an accurate,
+// non-misleading error that names exactly the paths that were probed — rather
+// than conflating the failure with the process's current working directory.
+//
+// Unlike the previous implementation, an explicit --skills-source-dir that
+// does not resolve to a directory no longer short-circuits discovery: we record
+// the failed explicit path and fall through to the remaining heuristics, so a
+// stale/typo'd flag never masks a perfectly valid sibling/env/ancestor dir.
+func DiscoverSkillsDirVerbose(binPath, skillsSourceDir string) (string, []string) {
+	var attempted []string
+	check := func(label, path string) (string, bool) {
+		if path == "" {
+			return "", false
 		}
-		// Don't fall through if the user explicitly set it but it doesn't exist.
-		return ""
+		attempted = append(attempted, fmt.Sprintf("%s: %s", label, path))
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			return path, true
+		}
+		return "", false
+	}
+
+	// Explicit override from flag or config. We no longer early-return on a
+	// stat failure: record the attempt and continue so a bad flag can't mask a
+	// valid auto-discovered location.
+	if skillsSourceDir != "" {
+		if p, ok := check("--skills-source-dir", skillsSourceDir); ok {
+			return p, attempted
+		}
 	}
 
 	if binPath != "" {
 		binDir := filepath.Dir(binPath)
 
 		// Try sibling: $(dirname binPath)/skills — produced by `go build` in repo root.
-		sibling := filepath.Join(binDir, "skills")
-		if info, err := os.Stat(sibling); err == nil && info.IsDir() {
-			return sibling
+		if p, ok := check("sibling", filepath.Join(binDir, "skills")); ok {
+			return p, attempted
 		}
 
 		// Try one-up: $(dirname binPath)/../skills — shipped bin/ layout.
-		oneUp := filepath.Join(binDir, "..", "skills")
-		if info, err := os.Stat(oneUp); err == nil && info.IsDir() {
-			return oneUp
+		if p, ok := check("one-up", filepath.Join(binDir, "..", "skills")); ok {
+			return p, attempted
 		}
 	}
 
 	// Try env var override (useful in CI or special deployments).
 	if envPath := os.Getenv("ARCHIGRAPH_SKILLS_DIR"); envPath != "" {
-		if info, err := os.Stat(envPath); err == nil && info.IsDir() {
-			return envPath
+		if p, ok := check("ARCHIGRAPH_SKILLS_DIR", envPath); ok {
+			return p, attempted
 		}
 	}
 
@@ -178,14 +206,13 @@ func DiscoverSkillsDir(binPath, skillsSourceDir string) string {
 				break
 			}
 			dir = parent
-			candidate := filepath.Join(dir, "skills")
-			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-				return candidate
+			if p, ok := check("ancestor", filepath.Join(dir, "skills")); ok {
+				return p, attempted
 			}
 		}
 	}
 
-	return ""
+	return "", attempted
 }
 
 // InstallSkillsInClaudeConfigs symlinks the archigraph skills into every

--- a/internal/install/skilllink/skilllink_test.go
+++ b/internal/install/skilllink/skilllink_test.go
@@ -122,6 +122,55 @@ func TestDiscoverSkillsDir(t *testing.T) {
 			t.Errorf("should return empty with empty HOME + no skills layout; got %q", result)
 		}
 	})
+
+	// #4459: a bad/typo'd --skills-source-dir must NOT short-circuit discovery.
+	// A valid sibling layout should still be found via fall-through.
+	t.Run("bad explicit flag falls through to a valid sibling layout", func(t *testing.T) {
+		dir := t.TempDir()
+		skillsDir := filepath.Join(dir, "skills")
+		if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		binPath := filepath.Join(dir, "archigraph")
+		result := DiscoverSkillsDir(binPath, "/nonexistent/typo/skills")
+		if result != skillsDir {
+			t.Errorf("expected fall-through to sibling %q, got %q", skillsDir, result)
+		}
+	})
+}
+
+// TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths verifies that when
+// discovery fails, the returned attempted-paths list names EVERY candidate that
+// was probed (#4459) — including the explicit flag, sibling, one-up, env var,
+// and ancestor walk — so the caller can build a non-misleading error instead of
+// blaming the cwd.
+func TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths(t *testing.T) {
+	envSkills := "/nonexistent/env/skills"
+	t.Setenv("ARCHIGRAPH_SKILLS_DIR", envSkills)
+
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "deep", "build", "archigraph")
+	explicit := "/nonexistent/flag/skills"
+
+	result, attempted := DiscoverSkillsDirVerbose(binPath, explicit)
+	if result != "" {
+		t.Fatalf("expected discovery to fail, got %q", result)
+	}
+
+	joined := strings.Join(attempted, "\n")
+	for _, want := range []string{
+		"--skills-source-dir",
+		explicit,
+		"sibling",
+		"one-up",
+		"ARCHIGRAPH_SKILLS_DIR",
+		envSkills,
+		"ancestor",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("attempted-paths list missing %q; got:\n%s", want, joined)
+		}
+	}
 }
 
 // TestClaudeSkillsDirForConfig table-drives the path-derivation helper.

--- a/internal/install/state.go
+++ b/internal/install/state.go
@@ -83,6 +83,13 @@ type State struct {
 	// Populated after step 2 completes.
 	Skills map[string]SkillRecord `json:"skills,omitempty"`
 
+	// SkillsSkipped is true when step 2 (skills copy) was intentionally
+	// skipped because no skills source directory could be discovered (e.g. a
+	// brand-new binary-only install with no repo checkout). The install still
+	// succeeds and the daemon is installed; doctor reports this as advisory,
+	// not as a broken install.
+	SkillsSkipped bool `json:"skills_skipped,omitempty"`
+
 	// MCP holds the MCP registration state.
 	// Populated after step 3 completes.
 	MCP MCPRecord `json:"mcp,omitempty"`

--- a/internal/install/update_test.go
+++ b/internal/install/update_test.go
@@ -1,10 +1,12 @@
 package install_test
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/archigraph/internal/install"
 )
@@ -129,14 +131,20 @@ func TestRunUpdate_RollbackOnInstallFailure(t *testing.T) {
 	}
 
 	opts := install.UpdateOptions{
-		BinPath:   env.fakeBin,
-		StatePath: env.statePath,
-		// Force skills discovery to fail so RunCopy returns an error.
-		SkillsSourceDir:   "/nonexistent-skills-dir",
-		ClaudeConfigDirs:  []string{env.claudeJSON},
-		WorkingDir:        env.gitRepo,
-		SkipDaemonRestart: true,
-		Tag:               "v0.0.1-fail",
+		BinPath:          env.fakeBin,
+		StatePath:        env.statePath,
+		SkillsSourceDir:  env.skillsSourceDir,
+		ClaudeConfigDirs: []string{env.claudeJSON},
+		WorkingDir:       env.gitRepo,
+		// Force the re-install (RunCopy) to fail at the daemon-restart step so
+		// the binary rollback path is exercised. (Skills discovery now
+		// gracefully degrades — #4460 — so it can no longer be used to force a
+		// hard install failure.)
+		SkipDaemonRestart: false,
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "", fmt.Errorf("forced daemon restart failure for test")
+		},
+		Tag: "v0.0.1-fail",
 		DownloadBinary: func(_ *http.Client, _, _, _, destPath string) error {
 			// Download a different binary.
 			return os.WriteFile(destPath, []byte("#!/bin/sh\necho different"), 0o755)


### PR DESCRIPTION
Hardens the `archigraph install` / `doctor` lifecycle against a cluster of brittleness found during a live Wave-2 deploy. The daemon was never corrupted — these are false-fails / alarming messages that trap the user.

## What changed

### Skills discovery accuracy (`skilllink.go`)
- `DiscoverSkillsDir` no longer early-returns `""` when an explicit `--skills-source-dir` fails to stat — it records the failed attempt and **falls through** to sibling / one-up / `ARCHIGRAPH_SKILLS_DIR` / ancestor-walk, so a typo'd flag can't mask a valid auto-discovered dir.
- New `DiscoverSkillsDirVerbose` returns the ordered list of **every** candidate path probed, so failures can be reported accurately.
- `Closes #4459`

### Graceful-degrade when no skills source (`copy.go`, `state.go`)
- A brand-new binary-only install (no repo checkout, no flag) now **WARNs + continues** instead of hard-failing + rolling back at step 2. The error names every path actually checked (not the cwd). The daemon + MCP still install; state records `skills_skipped`.
- `Closes #4460`

### Idempotent partial-install retry (`copy.go`)
- A readable `install.json` with `partial_install=true` (left by a prior rollback) now **auto-recovers** on a plain `install` — the transaction is idempotent, so it resumes/redoes and writes clean state. No `--force` required. An **unreadable** install.json still requires `--force`.
- `Closes #4461`

### doctor SHA severity (`doctor.go`)
- Binary-SHA drift alone is downgraded `Critical` → `Warning` (the daemon is fully usable; status already treats it as a non-blocking note). Missing/unreadable CLI record stays `Critical`. Quick-doctor wording softened from "reinstall recommended" to "binary updated since last install (daemon still usable)".
- `Closes #4463`

Scope boundary respected: the service-restart invocation (step 4) and per-platform service files were left untouched (owned by the sibling #4458/#4462 work).

## Tests
- `TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths` — failure lists flag/sibling/one-up/env/ancestor paths.
- `TestDiscoverSkillsDir` "bad explicit flag falls through to a valid sibling layout".
- `TestRunCopy_MissingSkillsDirectory_GracefulDegrade` — no error, daemon restart runs, MCP registered, `SkillsSkipped=true`, not partial.
- `TestRunCopy_PartialInstallAutoRecovers` / `TestRunDev_PartialInstallAutoRecovers` — second install succeeds without `--force`, state cleaned.
- `TestRunCopy_UnreadableStateStillBlocks` — corrupt state still requires `--force`.
- `TestDoctorCLITamper` (SHA drift → Warning) + `TestDoctorMissingCLIRecordCritical` (missing record → Critical) + quick-doctor non-alarming wording assertions.

## Gates
- `go build ./...` — green
- `GOOS=darwin/linux/windows go build ./...` — all exit 0
- `go vet ./internal/install/... ./internal/cli/...` — clean (also vetted per-GOOS)
- `go test ./internal/install/... ./internal/cli/...` — all pass

Deploy-deferred: the coordinator validates the real install→update→reinstall→uninstall lifecycle live before sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)