### PR TITLE
feat(graph): de-emphasize low-degree nodes so they don't read as an orphan ring

### DIFF
--- a/webui-v2/src/components/graph/filters-drawer.tsx
+++ b/webui-v2/src/components/graph/filters-drawer.tsx
@@ -38,6 +38,16 @@ const EDGE_KIND_GROUPS: { title: string; kinds: EdgeKind[] }[] = [
 
 const LODS: LodLevel[] = ["low", "mid", "high"];
 
+// #4467 — min-degree quick toggles. 0 = show all (default), 1 = hide true
+// zero-edge orphans, 2 = also hide degree-1 leaves (DTO members / types / config
+// that read as a misleading "orphan ring"). Always reversible; hiding is also
+// surfaced in the on-canvas low-degree badge.
+const MIN_DEGREES: { value: number; label: string; hint: string }[] = [
+  { value: 0, label: "All", hint: "Show every node (default)" },
+  { value: 1, label: "≥1", hint: "Hide unconnected (zero-edge) nodes" },
+  { value: 2, label: "≥2", hint: "Also hide degree-1 leaf nodes" },
+];
+
 export function FiltersDrawer({ repos }: { repos: GraphRepo[] }) {
   const filtersOpen = useGraphStore((s) => s.filtersOpen);
   const setFiltersOpen = useGraphStore((s) => s.setFiltersOpen);
@@ -47,6 +57,8 @@ export function FiltersDrawer({ repos }: { repos: GraphRepo[] }) {
   const toggleRepo = useGraphStore((s) => s.toggleRepo);
   const lod = useGraphStore((s) => s.lod);
   const setLod = useGraphStore((s) => s.setLod);
+  const minDegree = useGraphStore((s) => s.minDegree);
+  const setMinDegree = useGraphStore((s) => s.setMinDegree);
   const clearAllFilters = useGraphStore((s) => s.clearAllFilters);
 
   return (
@@ -145,6 +157,36 @@ export function FiltersDrawer({ repos }: { repos: GraphRepo[] }) {
                 </button>
               ))}
             </div>
+          </section>
+
+          <section>
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">
+              Min degree
+            </h4>
+            <div className="grid grid-cols-3 gap-1">
+              {MIN_DEGREES.map((m) => (
+                <button
+                  key={m.value}
+                  onClick={() => setMinDegree(m.value)}
+                  aria-pressed={minDegree === m.value}
+                  title={m.hint}
+                  className={`h-7 rounded-md border text-xs font-medium transition-colors ${
+                    minDegree === m.value
+                      ? "border-transparent bg-accent-soft text-accent-strong"
+                      : "border-border bg-surface text-text-2 hover:bg-surface-2"
+                  }`}
+                >
+                  {m.label}
+                </button>
+              ))}
+            </div>
+            <p className="mt-1.5 text-xs text-text-3">
+              {minDegree === 0
+                ? "Showing all nodes. Low-degree nodes are de-emphasized, not hidden."
+                : minDegree === 1
+                  ? "Hiding unconnected (zero-edge) nodes."
+                  : "Hiding unconnected + degree-1 leaf nodes."}
+            </p>
           </section>
 
           <TuningPanels />

--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -377,6 +377,24 @@ function GraphCanvasInner(
     [sortedDegrees],
   );
 
+  // #4467 — RENDERED degree + a single "primary neighbor" per node, derived from
+  // the CURRENT edge set (after the edge-kind filter). Rendered degree drives the
+  // low-degree de-emphasis (opacity) honestly w.r.t. the user's edge-kind toggles;
+  // primaryNeighbor lets us SEED a degree-1 node next to its one neighbor so the
+  // force layout settles it adjacent instead of flinging it to the orphan rim.
+  const renderedDegree = useMemo(() => {
+    const deg = new Map<string, number>();
+    const primary = new Map<string, string>();
+    for (const e of edges) {
+      deg.set(e.source, (deg.get(e.source) ?? 0) + 1);
+      deg.set(e.target, (deg.get(e.target) ?? 0) + 1);
+      // First-seen neighbor is the "primary" anchor for a would-be leaf.
+      if (!primary.has(e.source)) primary.set(e.source, e.target);
+      if (!primary.has(e.target)) primary.set(e.target, e.source);
+    }
+    return { deg, primary };
+  }, [edges]);
+
   // ── packed buffers ──────────────────────────────────────────────────────────
   const packed = useMemo(() => {
     const count = nodes.length;
@@ -458,6 +476,29 @@ function GraphCanvasInner(
         : (Math.random() - 0.5) * 1600;
     });
 
+    // #4467 — ANCHOR low-degree leaves next to their single neighbor. After the
+    // group-center seeding above, re-seed any node with rendered degree ≤ 1 right
+    // on top of its primary neighbor's seed (plus a tiny jitter). The strong
+    // link-spring then keeps that leaf tucked beside its parent instead of letting
+    // global repulsion fling it to the periphery — which is what made degree-1
+    // DTO/type/config nodes read as a misleading "orphan ring." A true zero-degree
+    // node (no primary neighbor) is left at its group-center seed. Runs in a second
+    // pass so every potential anchor already has a base position.
+    for (let i = 0; i < count; i++) {
+      const n = nodes[i];
+      if ((renderedDegree.deg.get(n.id) ?? 0) > 1) continue;
+      const nbId = renderedDegree.primary.get(n.id);
+      if (nbId === undefined) continue; // true orphan — keep its group-center seed
+      const j = idToIdx.get(nbId);
+      if (j === undefined) continue;
+      // Tight jitter so coincident leaves don't fully overlap, but stay glued to
+      // the neighbor (well inside the link-spring's rest distance).
+      const a = Math.random() * 2 * Math.PI;
+      const r = Math.random() * 24;
+      positions[i * 2] = positions[j * 2] + r * Math.cos(a);
+      positions[i * 2 + 1] = positions[j * 2 + 1] + r * Math.sin(a);
+    }
+
     // Fix #1607: the largest base-px size in the buffer (a hub). The zoom-driven
     // size updater uses this to set pointSizeScale so the LARGEST node is exactly
     // capped at render.maxPointSize px when zoomed in — preventing any blob.
@@ -466,9 +507,15 @@ function GraphCanvasInner(
     if (maxSizePx <= 0) maxSizePx = 1;
 
     return { positions, sizes, clusters, clusterStrength, maxSizePx };
-  }, [nodes, repoToIdx, groupCenters, groupBy, nodeSizing]);
+  }, [nodes, repoToIdx, groupCenters, groupBy, nodeSizing, renderedDegree, idToIdx]);
 
   // Node colors — re-read pastel scale from tokens.css so theme flows through.
+  // #4467 — ALSO encode rendered degree into per-node OPACITY: degree-1 leaves
+  // (DTO members, types, config) fade back so they recede instead of dominating
+  // the view as a bright "orphan ring," while well-connected structure stays at
+  // full opacity. The size buffer already boosts hubs (degBoost); opacity is the
+  // complementary lever that DIMS the low end. Uses the rendered degree (after the
+  // edge-kind filter) so it's consistent with the min-degree filter + badge.
   const packPointColors = useCallback((): Float32Array => {
     const { fill } = readPastelScale();
     const count = nodes.length;
@@ -486,10 +533,16 @@ function GraphCanvasInner(
       } else {
         rgba = pastelAt(fill, (repoToIdx.get(n.repo ?? "") ?? 0) + 1);
       }
-      writeNormalizedRGBA(out, i, rgba);
+      // #4467 — degree-based opacity, clamped to a gentle band so low-degree nodes
+      // recede but never vanish: deg 0 → 0.45×, deg 1 → ~0.6×, deg ≥ 6 → 1.0×.
+      // Multiplies the palette alpha (the global pointOpacity is applied on top by
+      // cosmos), so coloring is unchanged — only the perceived emphasis shifts.
+      const rdeg = renderedDegree.deg.get(n.id) ?? 0;
+      const degAlpha = Math.min(1, 0.45 + 0.55 * (Math.log10(rdeg + 1) / Math.log10(7)));
+      writeNormalizedRGBA(out, i, [rgba[0], rgba[1], rgba[2], rgba[3] * degAlpha]);
     }
     return out;
-  }, [nodes, colorMode, repoToIdx, moduleToIdx, degreePercentile]);
+  }, [nodes, colorMode, repoToIdx, moduleToIdx, degreePercentile, renderedDegree]);
 
   // Links — packed [src,tgt] + an edge CLASS per link (#1564-2):
   //   2 = cross-repo (bridge), 1 = cross-module (same repo, diff module),

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -210,27 +210,71 @@ export default function GraphScreen() {
   // incident edges, so cosmos.gl never sees a 15k-edge star that freezes the
   // layout. Computed from the rendered edges (not the daemon `degree`) so it
   // respects the user's edge-kind toggles. No-op on normal graphs.
-  const { nodes, edges, prunedHubCount } = useMemo(() => {
-    const incident = new Map<string, number>();
-    for (const e of kindFilteredEdges) {
-      incident.set(e.source, (incident.get(e.source) ?? 0) + 1);
-      incident.set(e.target, (incident.get(e.target) ?? 0) + 1);
-    }
-    const prunedIds = new Set<string>();
-    for (const n of allNodes) {
-      if ((incident.get(n.id) ?? 0) > HUB_DEGREE_CAP) prunedIds.add(n.id);
-    }
-    if (prunedIds.size === 0) {
-      return { nodes: allNodes, edges: kindFilteredEdges, prunedHubCount: 0 };
-    }
-    return {
-      nodes: allNodes.filter((n) => !prunedIds.has(n.id)),
-      edges: kindFilteredEdges.filter(
-        (e) => !prunedIds.has(e.source) && !prunedIds.has(e.target),
-      ),
-      prunedHubCount: prunedIds.size,
-    };
-  }, [allNodes, kindFilteredEdges]);
+  const { nodes, edges, prunedHubCount, lowDegreeCount, orphanCount, hiddenLowDegreeCount } =
+    useMemo(() => {
+      const incident = new Map<string, number>();
+      for (const e of kindFilteredEdges) {
+        incident.set(e.source, (incident.get(e.source) ?? 0) + 1);
+        incident.set(e.target, (incident.get(e.target) ?? 0) + 1);
+      }
+      const prunedIds = new Set<string>();
+      for (const n of allNodes) {
+        if ((incident.get(n.id) ?? 0) > HUB_DEGREE_CAP) prunedIds.add(n.id);
+      }
+      // Nodes surviving the super-hub prune (the candidate render set).
+      const hubKept = prunedIds.size
+        ? allNodes.filter((n) => !prunedIds.has(n.id))
+        : allNodes;
+      const hubKeptEdges = prunedIds.size
+        ? kindFilteredEdges.filter(
+            (e) => !prunedIds.has(e.source) && !prunedIds.has(e.target),
+          )
+        : kindFilteredEdges;
+
+      // #4467 — count true orphans (rendered degree 0) and degree-1 leaves so the
+      // badge can report HOW MANY low-degree nodes exist, and apply the honest
+      // min-degree filter on top. Degree is the RENDERED degree (respects the
+      // edge-kind toggles), consistent with the canvas opacity de-emphasis.
+      let orphans = 0;
+      let leaves = 0;
+      for (const n of hubKept) {
+        const d = incident.get(n.id) ?? 0;
+        if (d === 0) orphans++;
+        else if (d === 1) leaves++;
+      }
+      const lowDegree = orphans + leaves;
+
+      // Apply the min-degree filter (default 0 = show everything). Hiding is always
+      // surfaced in the badge, so it stays explicit + reversible.
+      const minD = s.minDegree;
+      if (minD <= 0 && prunedIds.size === 0) {
+        return {
+          nodes: allNodes,
+          edges: kindFilteredEdges,
+          prunedHubCount: 0,
+          lowDegreeCount: lowDegree,
+          orphanCount: orphans,
+          hiddenLowDegreeCount: 0,
+        };
+      }
+      const keptNodes =
+        minD <= 0
+          ? hubKept
+          : hubKept.filter((n) => (incident.get(n.id) ?? 0) >= minD);
+      const keptIds = new Set(keptNodes.map((n) => n.id));
+      const keptEdges =
+        minD <= 0
+          ? hubKeptEdges
+          : hubKeptEdges.filter((e) => keptIds.has(e.source) && keptIds.has(e.target));
+      return {
+        nodes: keptNodes,
+        edges: keptEdges,
+        prunedHubCount: prunedIds.size,
+        lowDegreeCount: lowDegree,
+        orphanCount: orphans,
+        hiddenLowDegreeCount: hubKept.length - keptNodes.length,
+      };
+    }, [allNodes, kindFilteredEdges, s.minDegree]);
 
   // ── monorepo-aware default coloring/grouping (Fix #1532-1) ───────────────────
   // A monorepo is a single repo split into many modules. Repo grouping there is
@@ -406,7 +450,8 @@ export default function GraphScreen() {
     const isDefaultOn = STRUCTURAL_EDGE_KINDS.includes(k);
     return acc + (s.enabledEdgeKinds.has(k) === isDefaultOn ? 0 : 1);
   }, 0);
-  const activeFilterCount = (s.activeRepos?.size ?? 0) + edgeKindDeviations;
+  const activeFilterCount =
+    (s.activeRepos?.size ?? 0) + edgeKindDeviations + (s.minDegree > 0 ? 1 : 0);
 
   return (
     <div className="relative flex h-full flex-col">
@@ -653,8 +698,36 @@ export default function GraphScreen() {
               </div>
             ) : null}
 
-            <div className="pointer-events-none absolute bottom-3 left-3 z-20 rounded-md border border-border bg-surface/80 px-2 py-1 font-mono text-xs text-text-3 backdrop-blur-sm">
-              LOD: {lodLabel}
+            <div className="absolute bottom-3 left-3 z-20 flex flex-col items-start gap-1.5">
+              <div className="pointer-events-none rounded-md border border-border bg-surface/80 px-2 py-1 font-mono text-xs text-text-3 backdrop-blur-sm">
+                LOD: {lodLabel}
+              </div>
+              {/* #4467 — honest low-degree badge. The force layout pushes degree-1
+                  nodes to the periphery, which reads as a misleading "orphan ring";
+                  in reality almost all are degree-1 leaves (a single CONTAINS edge),
+                  not true orphans. This badge names the real counts and offers an
+                  explicit, reversible show/hide so nothing is ever silently dropped. */}
+              {lowDegreeCount > 0 ? (
+                <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface/80 px-2 py-1 text-xs text-text-3 backdrop-blur-sm">
+                  <span className="tabular-nums">
+                    {(lowDegreeCount - orphanCount).toLocaleString()} low-degree
+                  </span>
+                  <span className="text-text-4">·</span>
+                  <span className="tabular-nums">{orphanCount.toLocaleString()} unconnected</span>
+                  {hiddenLowDegreeCount > 0 ? (
+                    <span className="tabular-nums text-amber-500">
+                      · {hiddenLowDegreeCount.toLocaleString()} hidden
+                    </span>
+                  ) : null}
+                  <button
+                    onClick={() => s.setMinDegree(s.minDegree > 0 ? 0 : 1)}
+                    className="ml-0.5 rounded border border-border bg-surface px-1.5 py-0.5 text-[0.7rem] font-medium text-text-2 hover:bg-surface-2"
+                    title="Toggle hiding of low-degree / unconnected nodes"
+                  >
+                    {s.minDegree > 0 ? "show" : "hide"}
+                  </button>
+                </div>
+              ) : null}
             </div>
 
             <div className="pointer-events-none absolute bottom-3 right-3 z-20 flex items-center gap-2 text-xs text-text-4">

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -284,6 +284,16 @@ interface GraphState {
   enabledEdgeKinds: Set<EdgeKind>;
   activeRepos: Set<string> | null; // null = all
   lod: LodLevel;
+  /**
+   * #4467 — minimum RENDERED degree a node must have to be shown. Computed from
+   * the currently rendered edge set (after the edge-kind filter), so it respects
+   * the user's edge-kind toggles and stays honest. 0 = show everything (default),
+   * 1 = hide true zero-edge orphans, 2 = also hide degree-1 leaf nodes. Hiding is
+   * always surfaced in the low-degree badge so it's explicit + reversible. This
+   * DE-EMPHASIS/hide is purely a readability aid; the underlying missing-edge
+   * extraction bugs are fixed separately.
+   */
+  minDegree: number;
 
   // View knobs
   colorMode: ColorMode;
@@ -331,6 +341,8 @@ interface GraphState {
   toggleRepo: (repo: string) => void;
   clearRepos: () => void;
   setLod: (lod: LodLevel) => void;
+  /** #4467 — set the min-degree threshold (clamped to 0..2). */
+  setMinDegree: (d: number) => void;
   setColorMode: (m: ColorMode) => void;
   setGroupBy: (m: GroupByMode) => void;
   /**
@@ -380,6 +392,10 @@ export const useGraphStore = create<GraphState>((set) => ({
   // tiers via the LOD control.
   lod: "high",
 
+  // #4467 — show everything by default; low-degree nodes are de-emphasized
+  // (smaller + dimmer) rather than hidden, so the default view is honest.
+  minDegree: 0,
+
   colorMode: "repo",
   groupBy: "repo",
   groupingTouched: false,
@@ -420,6 +436,7 @@ export const useGraphStore = create<GraphState>((set) => ({
     }),
   clearRepos: () => set({ activeRepos: null }),
   setLod: (lod) => set({ lod }),
+  setMinDegree: (d) => set({ minDegree: Math.max(0, Math.min(2, Math.round(d))) }),
   setColorMode: (colorMode) => set({ colorMode, groupingTouched: true }),
   setGroupBy: (groupBy) => set({ groupBy, groupingTouched: true }),
   applyMonorepoDefaults: (isMonorepo) =>
@@ -464,6 +481,8 @@ export const useGraphStore = create<GraphState>((set) => ({
       activeRepos: null,
       // Fix #1599: clearing filters returns to the full-graph default (HIGH).
       lod: "high",
+      // #4467 — clearing filters returns to "show everything".
+      minDegree: 0,
     }),
   resetView: () =>
     set({


### PR DESCRIPTION
## Problem
The force-directed GRAPH view flings DEGREE-1 nodes (DTO members, types, config — a single `CONTAINS` edge each) to the periphery, producing a large outer "ring of dots" that looks like thousands of orphans. Verified on the live upvate-v3 graph: only ~0.2% are true zero-edge orphans; the rest of the ring is degree-1 leaves. Users misread this as "the graph is full of orphans." (The underlying missing-edge extraction bugs are fixed separately — this is purely a readability/honesty fix on the viz.)

## What changed (extends existing graph features; nothing hidden silently)
1. **Anchor low-degree leaves** (`graph-canvas.tsx`) — a new `renderedDegree` map (degree + primary neighbor, from the post-edge-kind-filter edge set) re-seeds any rendered-degree-≤1 node at its single neighbor's seed position (+tiny jitter) instead of its group-center blob. The strong link-spring then keeps the leaf tucked beside its parent instead of letting global repulsion fling it to the rim. True orphans keep their group-center seed.
2. **Degree-based opacity** (`graph-canvas.tsx`, `packPointColors`) — per-node alpha ∝ `log10(renderedDegree+1)`, clamped to a gentle `0.45..1.0` band, so degree-1 singletons recede and connected structure stands out. Repo/module/community/degree coloring is unchanged (only the palette alpha is scaled; global `pointOpacity` still applies on top).
3. **Honest min-degree control + always-visible badge** (`graph.tsx`, `filters-drawer.tsx`, `use-graph-store.ts`) — a new `minDegree` store field with an `All / ≥1 / ≥2` quick toggle in the Filters panel, and a persistent on-canvas badge `"N low-degree · M unconnected — show/hide"` (with a `K hidden` note when a threshold is active). **Default shows everything** (de-emphasis only); hiding is explicit + reversible, counts toward the Filters active-count, and resets on Clear-all / Reset. Reuses the #4319 super-hub-prune + LOD-badge pattern; rendered degree (respecting edge-kind toggles) is used consistently across the prune, the opacity, the filter, and the badge.

Pure dashboard change, no backend; ships at the next dashboard rebuild.

## Gates
- `npm ci` ✓ · `npm run build` ✓ · `npm run lint` (tsc --noEmit) ✓

Refs epics #4348 (graph-viz) + #4334.

Closes #4467

🤖 Generated with [Claude Code](https://claude.com/claude-code)