### PR TITLE
Skip type definitions in inherited-member resolution

### DIFF
--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -127,6 +127,18 @@ func resolveMember(lr *LoadedRepo, e *graph.Entity) memberResolution {
 		return res
 	}
 
+	// #4465 — never run a TYPE DEFINITION through inherited-member resolution.
+	// A class/interface/struct/enum/type-alias entity carries a dotted qualified
+	// name (e.g. "src.modules.permits.dto.request.permit-list.query.dto.
+	// PermitListQueryDto"), which classifyMember would otherwise split into
+	// member=PermitListQueryDto / owning=<file-module>, then fail the EXTENDS
+	// walk and emit `inherited:true, resolved:false` noise on what is actually a
+	// definition, not an inherited member. A definition is explicit by
+	// construction — its body IS its source.
+	if isDefinitionEntity(e) {
+		return memberResolution{Provenance: provExplicit}
+	}
+
 	member, owningName, isBodyless := classifyMember(e)
 	if member == "" || owningName == "" {
 		// Not a recognisable inherited member — treat as explicit (caller keeps
@@ -432,6 +444,35 @@ func findClassEntity(lr *LoadedRepo, name string) *graph.Entity {
 		}
 	}
 	return fallback
+}
+
+// isDefinitionEntity reports whether e is itself a TYPE DEFINITION — a
+// class/interface/struct/enum/type-alias declaration — as opposed to a member
+// of one. Definitions must be excluded from inherited-member resolution (#4465):
+// they are explicit by construction (their own span is their body) and feeding
+// them through classifyMember mis-reads their dotted qualified name as
+// member=<TypeName> / owning=<file-module>, producing false
+// `inherited:true, resolved:false` noise.
+//
+// A definition is recognised by EITHER:
+//   - a definition subtype (class/struct/interface/enum/type/type_alias), OR
+//   - the SCOPE.Component class-kind WITHOUT a member subtype (method/function)
+//     — TS class definitions are emitted as SCOPE.Component. We intentionally do
+//     NOT treat a bare SCOPE.Schema as a definition here: a SCOPE.Schema can be
+//     either a DTO/model definition or a standalone field/member, and that
+//     ambiguity is the separate member-emission-shape issue (follow-up). Schema
+//     definitions are still protected because they carry a definition subtype.
+func isDefinitionEntity(e *graph.Entity) bool {
+	switch e.Subtype {
+	case "class", "struct", "interface", "enum", "type", "type_alias":
+		return true
+	case "method", "function", "field":
+		// An explicit member subtype is never a standalone definition.
+		return false
+	}
+	// SCOPE.Component is the class-kind for TS/JS class definitions. With no
+	// member subtype above, treat it as a definition.
+	return e.Kind == "SCOPE.Component"
 }
 
 // isClassEntity reports whether e is a class/struct/component declaration that

--- a/internal/mcp/mro_definition_skip_4465_test.go
+++ b/internal/mcp/mro_definition_skip_4465_test.go
@@ -1,0 +1,104 @@
+package mcp
+
+// mro_definition_skip_4465_test.go — #4465. The inheritance resolver must NOT
+// fire on TYPE DEFINITIONS. Live on upvate-v3, inspecting the TS class
+// `PermitListQueryDto` (SCOPE.Component, dotted qualified name matching its
+// file-module path, no EXTENDS edges) returned
+//   inheritance:{inherited:true, resolved:false, member:'PermitListQueryDto',
+//     owning_class:'src.modules.permits.dto.request.permit-list.query.dto',
+//     note:'no defining class found via EXTENDS or knowledge pack'}
+// — treating the class's own dotted qname as member=<TypeName>/owning=<module>
+// and failing the EXTENDS walk. A definition is explicit by construction and
+// must carry NO inheritance section.
+//
+// Regression guard alongside a genuinely-inherited member that MUST still
+// resolve, so the fix skips definitions without disabling real resolution.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// permitListQueryDtoDoc mirrors the real entity shape extracted for
+// src/modules/permits/dto/request/permit-list.query.dto.ts: a TS class
+// definition emitted as SCOPE.Component with a dotted qualified name equal to
+// its file-module path + class leaf, and a standalone Schema field member. No
+// EXTENDS edges (the DTO extends nothing).
+func permitListQueryDtoDoc() *graph.Document {
+	const modulePath = "src.modules.permits.dto.request.permit-list.query.dto"
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID:            "dto",
+				Name:          "PermitListQueryDto",
+				QualifiedName: modulePath + ".PermitListQueryDto",
+				Kind:          "SCOPE.Component",
+				SourceFile:    "src/modules/permits/dto/request/permit-list.query.dto.ts",
+				StartLine:     4, EndLine: 40, Language: "typescript",
+			},
+			// A standalone Schema field member (the engine currently emits DTO
+			// fields this way). It must not be mis-tagged as an inherited method.
+			{
+				ID:            "dto_field",
+				Name:          "PermitListQueryDto.generate_permit",
+				QualifiedName: modulePath + ".PermitListQueryDto.generate_permit",
+				Kind:          "SCOPE.Schema", Subtype: "field",
+				SourceFile: "src/modules/permits/dto/request/permit-list.query.dto.ts",
+				StartLine:  14, EndLine: 14, Language: "typescript",
+			},
+		},
+	}
+}
+
+// TestInspect_TSClassDefinition_NoInheritanceSection — the class definition must
+// NOT grow an inheritance section. Before #4465 this returned
+// inherited:true/resolved:false.
+func TestInspect_TSClassDefinition_NoInheritanceSection(t *testing.T) {
+	srv := newTestServer(t, permitListQueryDtoDoc())
+	out := callInspect(t, srv, "dto")
+	if inh, present := out["inheritance"]; present {
+		t.Fatalf("class DEFINITION must carry NO inheritance section, got %v", inh)
+	}
+}
+
+// TestResolveMember_TSClassDefinition_Explicit — unit-level guard on the
+// resolver: a definition resolves as provExplicit, never provUnresolved with a
+// fabricated member/owning_class.
+func TestResolveMember_TSClassDefinition_Explicit(t *testing.T) {
+	srv := newTestServer(t, permitListQueryDtoDoc())
+	lr := srv.State.groups["test"].Repos["repo1"]
+	var dto *graph.Entity
+	for i := range lr.Doc.Entities {
+		if lr.Doc.Entities[i].ID == "dto" {
+			dto = &lr.Doc.Entities[i]
+		}
+	}
+	if dto == nil {
+		t.Fatalf("dto entity not found in loaded repo")
+	}
+	res := resolveMember(lr, dto)
+	if res.Provenance != provExplicit {
+		t.Errorf("class definition must resolve as provExplicit, got %q (member=%q owning=%q note=%q)",
+			res.Provenance, res.Member, res.OwningClass, res.Note)
+	}
+}
+
+// TestInspect_GenuineInheritedMember_StillResolves — regression guard: skipping
+// definitions must NOT break real inherited-member resolution. ChildService
+// extends BaseService (both indexed), and ChildService.handle is a bodyless
+// inherited member that must still resolve to BaseService's body.
+func TestInspect_GenuineInheritedMember_StillResolves(t *testing.T) {
+	srv := newTestServer(t, inRepoBaseDoc())
+	out := callInspect(t, srv, "child_handle")
+	inh, ok := out["inheritance"].(map[string]any)
+	if !ok {
+		t.Fatalf("genuine inherited member must keep its inheritance section, got keys: %v", mapKeys(out))
+	}
+	if inh["inherited"] != true || inh["resolved"] != true {
+		t.Errorf("expected inherited=true/resolved=true, got %v", inh)
+	}
+	if dc, _ := inh["defining_class"].(string); dc != "BaseService" {
+		t.Errorf("expected defining_class BaseService, got %q", dc)
+	}
+}


### PR DESCRIPTION
## Problem

The MRO read-path resolver (`resolveMember` in `internal/mcp/mro.go`) classified **any** entity with a dotted qualified name as a class member, splitting it into `member=leaf` / `owning=prefix`. A TS class definition is emitted as `SCOPE.Component` with a dotted qualified name equal to its file-module path plus the class leaf. So inspecting the class `PermitListQueryDto` returned:

```
inheritance:{ inherited:true, resolved:false,
  member:'PermitListQueryDto',
  owning_class:'src.modules.permits.dto.request.permit-list.query.dto',
  note:'no defining class found via EXTENDS or knowledge pack' }
```

This is wrong — `PermitListQueryDto` is a **class definition**, not an inherited member. The resolver treated the file-module as the owning class, failed the EXTENDS walk, and emitted `inherited:true, resolved:false` noise on a real definition.

### Root cause

`classifyMember` recognises a member purely by `strings.Contains(name, ".")`. A definition's dotted FQN matches that test, so definitions were funnelled into inherited-member resolution and surfaced as honest-unresolved noise.

## Fix

Add `isDefinitionEntity` and short-circuit `resolveMember` to `provExplicit` for class/interface/struct/enum/type-alias declarations (and the `SCOPE.Component` class-kind) **before** member classification. A definition is explicit by construction — its own span is its body. The genuine inherited-member path (EXTENDS/IMPLEMENTS walk) is unchanged.

## Before / after (on the `PermitListQueryDto` class entity)

- Before: `inheritance:{inherited:true, resolved:false, member:'PermitListQueryDto', owning_class:'<module>', note:'no defining class found...'}`
- After: no inheritance section (explicit definition).

## Tests (RED→GREEN)

New `internal/mcp/mro_definition_skip_4465_test.go`, mirroring the real extracted entity shape of `permit-list.query.dto.ts`:
- `TestInspect_TSClassDefinition_NoInheritanceSection` — class definition carries NO inheritance section (fails before the fix).
- `TestResolveMember_TSClassDefinition_Explicit` — resolver returns `provExplicit`.
- `TestInspect_GenuineInheritedMember_StillResolves` — regression guard: a genuinely-inherited member still resolves to its defining class.

RED verified by disabling the guard (the definition test fails); GREEN with it.

## Scope / follow-up

Per the long-term-root-fix + generalize rules, this PR is the read-path resolver fix (skip definitions). The separate, larger issue of DTO fields being emitted as standalone `SCOPE.Schema` members instead of CONTAINS members of their class is an extraction-shape change, filed as **#4471**.

## Gates

- `go build ./...` clean
- `go vet ./internal/mcp/...` clean
- `go test ./internal/mcp/` passes (full package)

DEPLOY-DEFERRED (read-path; needs a daemon rebuild to serve).

Closes #4465

🤖 Generated with [Claude Code](https://claude.com/claude-code)