### PR TITLE
Connect NestJS request DTOs to their handlers via ACCEPTS_INPUT edges

### DIFF
--- a/internal/custom/javascript/issue4464_livedrepro_test.go
+++ b/internal/custom/javascript/issue4464_livedrepro_test.go
@@ -1,0 +1,218 @@
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+	_ "github.com/cajasmota/archigraph/internal/extractors/javascript"
+)
+
+// Issue #4464 LIVE-REPRO — handler→request-DTO ACCEPTS_INPUT edge.
+//
+// Byte-copies of REAL core-backend-v3 files are committed under
+// testdata/dto_4464:
+//
+//   - permit.controller.ts        — `@Get() list(@Query() query: PermitListQueryDto)
+//     : Promise<PermitListResponse>` plus several @Body handlers.
+//   - permit-list.query.dto.ts    — the `@Query` request DTO class + its fields.
+//
+// PRE-FIX: the NestJS extractor emitted an ACCEPTS_INPUT edge ONLY for @Body()
+// DTOs (reNestBodyParam). The whole-object @Query()/@Param()/@Headers() request
+// DTOs got a `parameters` PROPERTY but NO graph EDGE, so PermitListQueryDto (and
+// its CONTAINS field subtree, #4328) floated as orphan degree-1 nodes — the
+// upvate-v3 'orphan ring' root cause.
+//
+// POST-FIX: each whole-object non-@Body request DTO yields an ACCEPTS_INPUT edge
+// (match_source=param_decorator) to `Class:<dto>`, which the central resolver
+// (resolve.BuildIndex / resolve.References) rewrites to the real DTO class
+// entity post-merge — so the edge is merge-stable. This test runs the REAL
+// extract → merge → resolve pipeline and asserts the handler becomes an inbound
+// neighbor of the DTO (was 0 inbound, now 1).
+
+func nestExtract4464(t *testing.T, base, repoPath string) []types.EntityRecord {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "dto_4464", base))
+	if err != nil {
+		t.Fatalf("read %s: %v", base, err)
+	}
+	e, ok := extreg.Get("custom_js_nestjs")
+	if !ok {
+		t.Fatal("custom_js_nestjs not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: repoPath, Language: "typescript", Content: b})
+	if err != nil {
+		t.Fatalf("nest extract %s: %v", base, err)
+	}
+	return ents
+}
+
+func tsExtract4464(t *testing.T, base, repoPath string) []types.EntityRecord {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "dto_4464", base))
+	if err != nil {
+		t.Fatalf("read %s: %v", base, err)
+	}
+	p := sitter.NewParser()
+	p.SetLanguage(tstypescript.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, b)
+	if err != nil {
+		t.Fatalf("parse %s: %v", base, err)
+	}
+	e, ok := extreg.Get("typescript")
+	if !ok {
+		t.Fatal("typescript extractor not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: repoPath, Language: "typescript", Content: b, Tree: tree})
+	if err != nil {
+		t.Fatalf("ts extract %s: %v", base, err)
+	}
+	return ents
+}
+
+// flattenRels lifts every entity's embedded relationships into a flat slice
+// with FromID anchored to the owning entity — the shape resolve.References
+// rewrites in place.
+func flattenRels(ents []types.EntityRecord) []types.RelationshipRecord {
+	var rels []types.RelationshipRecord
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			r.FromID = e.ID
+			rels = append(rels, r)
+		}
+	}
+	return rels
+}
+
+// TestIssue4464_QueryDTO_HandlerAcceptsInputEdge is the end-to-end gate: the
+// @Query whole-object request DTO must end up with the handler as an inbound
+// ACCEPTS_INPUT neighbor after the real merge+resolve pipeline.
+func TestIssue4464_QueryDTO_HandlerAcceptsInputEdge(t *testing.T) {
+	ctrl := nestExtract4464(t, "permit.controller.ts", "src/modules/permits/api/permit.controller.ts")
+	dto := tsExtract4464(t, "permit-list.query.dto.ts", "src/modules/permits/dto/request/permit-list.query.dto.ts")
+
+	// Extractor-side: the @Query() DTO now produces an ACCEPTS_INPUT edge (it
+	// did NOT before — only @Body did).
+	if !hasDTOEdge(ctrl, "ACCEPTS_INPUT", "Class:PermitListQueryDto") {
+		t.Fatal("expected ACCEPTS_INPUT -> Class:PermitListQueryDto from @Query() param (#4464 root fix)")
+	}
+	if owner := dtoEdgeOwner(ctrl, "ACCEPTS_INPUT", "Class:PermitListQueryDto"); owner != "GET list" {
+		t.Errorf("expected edge owner 'GET list', got %q", owner)
+	}
+
+	// The edge must be tagged so it is auditable / not confused with @Body.
+	var paramEdge *types.RelationshipRecord
+	for i := range ctrl {
+		for j := range ctrl[i].Relationships {
+			r := &ctrl[i].Relationships[j]
+			if r.Kind == "ACCEPTS_INPUT" && r.ToID == "Class:PermitListQueryDto" {
+				paramEdge = r
+			}
+		}
+	}
+	if paramEdge == nil {
+		t.Fatal("param ACCEPTS_INPUT edge not found")
+	}
+	if paramEdge.Properties["match_source"] != "param_decorator" {
+		t.Errorf("expected match_source=param_decorator, got %q", paramEdge.Properties["match_source"])
+	}
+	if paramEdge.Properties["param_in"] != "query" {
+		t.Errorf("expected param_in=query, got %q", paramEdge.Properties["param_in"])
+	}
+
+	// In-pipeline merge + resolve: the Class:<dto> stub must rewrite to the real
+	// DTO class entity (merge-stable resolution by qualified name).
+	all := append(append([]types.EntityRecord{}, ctrl...), dto...)
+	idx := resolve.BuildIndex(all)
+	dtoID, ok := idx.Lookup("Class:PermitListQueryDto")
+	if !ok || dtoID == "" {
+		t.Fatal("PermitListQueryDto stub failed to resolve through resolve.BuildIndex — would stay orphan")
+	}
+
+	// BEFORE the fix this count is 0 (the orphan-ring symptom); AFTER it is >=1.
+	rels := flattenRels(all)
+	resolve.References(rels, idx)
+	inbound := 0
+	for _, r := range rels {
+		if r.ToID == dtoID {
+			inbound++
+		}
+	}
+	if inbound < 1 {
+		t.Fatalf("expected >=1 resolved inbound edge to PermitListQueryDto after fix, got %d (still orphan)", inbound)
+	}
+	t.Logf("resolved inbound edges to PermitListQueryDto = %d (was 0 pre-fix)", inbound)
+}
+
+// TestIssue4464_BodyDTOStillEdged guards the pre-existing @Body() ACCEPTS_INPUT
+// path: the consolidation must not drop @Body DTO edges nor double-emit them.
+func TestIssue4464_BodyDTOStillEdged(t *testing.T) {
+	ctrl := nestExtract4464(t, "permit.controller.ts", "src/modules/permits/api/permit.controller.ts")
+
+	// @Body() PermitCreateBodyDto must still carry exactly one ACCEPTS_INPUT edge
+	// (emitted by reNestBodyParam, NOT duplicated by the #4464 param pass which
+	// skips In=="body").
+	count := 0
+	for _, e := range ctrl {
+		for _, r := range e.Relationships {
+			if r.Kind == "ACCEPTS_INPUT" && r.ToID == "Class:PermitCreateBodyDto" {
+				count++
+				if r.Properties["match_source"] != "body_param_annotation" {
+					t.Errorf("@Body edge should keep match_source=body_param_annotation, got %q",
+						r.Properties["match_source"])
+				}
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 ACCEPTS_INPUT to Class:PermitCreateBodyDto, got %d (double-emit?)", count)
+	}
+}
+
+// TestIssue4464_KeyedQueryParamNoDTOEdge is the false-positive gate: a
+// single-field selector like `@Query('group_id') gid: number` must NOT emit a
+// handler→DTO edge (it binds a primitive field, not a DTO type).
+func TestIssue4464_KeyedQueryParamNoDTOEdge(t *testing.T) {
+	src := `@Controller('devices')
+export class DeviceController {
+  @Get('filters')
+  filters(@Query('group_id', ParseIntPipe) groupId: number, @Query('building_id') buildingId: number) {
+    return this.svc.filters(groupId, buildingId);
+  }
+}`
+	ents := extractFull(t, "custom_js_nestjs", fi("device.controller.ts", "typescript", src))
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "ACCEPTS_INPUT" {
+				t.Errorf("keyed primitive @Query param must not emit ACCEPTS_INPUT, got -> %s", r.ToID)
+			}
+		}
+	}
+}
+
+// TestIssue4464_WholeQueryDTOEdge is the minimal positive unit: `@Query() q: Dto`
+// (no quoted key, DTO type) → ACCEPTS_INPUT edge.
+func TestIssue4464_WholeQueryDTOEdge(t *testing.T) {
+	src := `@Controller('items')
+export class ItemController {
+  @Get()
+  list(@Query() filter: ItemFilterDto) {
+    return this.svc.list(filter);
+  }
+}`
+	ents := extractFull(t, "custom_js_nestjs", fi("item.controller.ts", "typescript", src))
+	if !hasDTOEdge(ents, "ACCEPTS_INPUT", "Class:ItemFilterDto") {
+		t.Fatal("expected ACCEPTS_INPUT -> Class:ItemFilterDto from @Query() whole DTO")
+	}
+}

--- a/internal/custom/javascript/nestjs.go
+++ b/internal/custom/javascript/nestjs.go
@@ -313,6 +313,38 @@ func (e *nestjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 					break
 				}
 			}
+			// #4464 — emit an ACCEPTS_INPUT graph EDGE from the handler to each
+			// whole-DTO request param so request DTOs (and, via #4328 CONTAINS,
+			// their fields) stop floating as orphan degree-1 nodes. The @Body DTO
+			// already gets its ACCEPTS_INPUT above (reNestBodyParam), so this pass
+			// covers the @Query/@Param/@Headers whole-object DTOs that previously
+			// had NO inbound edge (the upvate-v3 PermitListQueryDto orphan-ring
+			// root cause). Conservative: only whole-object DTOs (no quoted
+			// binding key — a `@Query('id')`/`@Param('id')` selects a single
+			// primitive field, not the DTO) whose unwrapped type resolves to a
+			// real user type. The `Class:<dto>` stub is bound merge-stably by the
+			// central name resolver post-merge (same mechanism as @Body / the
+			// FastAPI/Flask req-resp DTO edges), so the edge survives merge.
+			for _, p := range params {
+				if p.In == "body" {
+					continue // already emitted via reNestBodyParam above
+				}
+				if p.QuotedKey {
+					continue // single-field selector, not a whole DTO
+				}
+				dto := nestUnwrapType(p.Type)
+				if dto == "" {
+					continue // primitive / built-in — honest-partial, no edge
+				}
+				ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+					ToID: "Class:" + dto,
+					Kind: string(types.RelationshipKindAcceptsInput),
+					Properties: map[string]string{
+						"framework": "nestjs", "match_source": "param_decorator", "dto_type": dto,
+						"param_in": p.In,
+					},
+				})
+			}
 		}
 
 		if rm := reNestReturnType.FindStringSubmatch(src[closeOff+1 : min(closeOff+200, len(src))]); rm != nil {

--- a/internal/custom/javascript/nestjs_params.go
+++ b/internal/custom/javascript/nestjs_params.go
@@ -43,6 +43,12 @@ type nestParam struct {
 	Required     bool     `json:"required"`
 	DefaultValue string   `json:"default_value,omitempty"`
 	Annotations  []string `json:"annotations,omitempty"`
+	// QuotedKey is true when the decorator had a quoted binding key
+	// (e.g. `@Query('id')`), meaning the param selects a single field rather
+	// than the whole DTO object. Not serialized — used only to gate the
+	// #4464 handler→DTO ACCEPTS_INPUT edge (a keyed param is a primitive
+	// field, not a DTO type). json:"-" keeps the dashboard wire shape stable.
+	QuotedKey bool `json:"-"`
 }
 
 var (
@@ -108,6 +114,7 @@ func extractNestHandlerParams(paramsBlock string) []nestParam {
 			Name:        name,
 			In:          in,
 			Annotations: []string{"@" + dec},
+			QuotedKey:   key != "",
 		}
 		// Type: prefer the user DTO (unwrapped); fall back to the raw TS type
 		// for primitives so the row still shows `number`/`string`.

--- a/internal/custom/javascript/testdata/dto_4464/permit-list.query.dto.ts
+++ b/internal/custom/javascript/testdata/dto_4464/permit-list.query.dto.ts
@@ -1,0 +1,54 @@
+import { IsInt, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PermitListQueryDto {
+  @IsInt()
+  @Type(() => Number)
+  group_id!: number;
+
+  @IsString()
+  @IsOptional()
+  billable?: string;
+
+  @IsString()
+  @IsOptional()
+  generate_permit?: string;
+
+  @IsString()
+  @IsOptional()
+  annual_overtime?: string;
+
+  @IsString()
+  @IsOptional()
+  fire_service_overtime?: string;
+
+  @IsString()
+  @IsOptional()
+  overtime_under_contract?: string;
+
+  @IsString()
+  @IsOptional()
+  test_due_date_from?: string;
+
+  @IsString()
+  @IsOptional()
+  test_due_date_to?: string;
+
+  @IsString()
+  @IsOptional()
+  search?: string;
+
+  @IsString()
+  @IsOptional()
+  ordering?: string;
+
+  @IsInt()
+  @Type(() => Number)
+  @IsOptional()
+  page?: number;
+
+  @IsInt()
+  @Type(() => Number)
+  @IsOptional()
+  page_size?: number;
+}

--- a/internal/custom/javascript/testdata/dto_4464/permit.controller.ts
+++ b/internal/custom/javascript/testdata/dto_4464/permit.controller.ts
@@ -1,0 +1,168 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Header,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  StreamableFile,
+} from '@nestjs/common';
+import { Authenticated } from '../../../common/auth/decorators/auth.decorators';
+import { PermitService } from '../services/permit.service';
+import { PermitIpsCartService } from '../services/permit-ips-cart.service';
+import { PermitListQueryDto } from '../dto/request/permit-list.query.dto';
+import { PermitExportQueryDto } from '../dto/request/permit-export.query.dto';
+import { PermitPatchBodyDto } from '../dto/request/permit-patch.body.dto';
+import { PermitCreateBodyDto } from '../dto/request/permit-create.body.dto';
+import { PermitRecordPaymentBodyDto } from '../dto/request/permit-record-payment.body.dto';
+import { PermitAddToIpsCartBodyDto } from '../dto/request/permit-ips-cart.body.dto';
+import { PermitScanIpsCartBodyDto } from '../dto/request/permit-scan-ips-cart.body.dto';
+import { PermitSyncIpsCartBodyDto } from '../dto/request/permit-sync-ips-cart.body.dto';
+import { PermitListResponse, PermitResponse } from '../dto/response/permit.response.dto';
+import { PermitPaymentResponse } from '../dto/response/permit-payment.response.dto';
+import type { AddToIpsCartResponse } from '../dto/response/permit-ips-cart.response.dto';
+import type { ScanIpsCartResponse } from '../dto/response/permit-scan-ips-cart.response.dto';
+import type { SyncIpsCartResponse } from '../dto/response/permit-sync-ips-cart.response.dto';
+import type { AuthenticatedRequest } from '../../../common/auth/guards/auth.guard';
+
+@Controller({ path: 'permits', version: '1' })
+@Authenticated()
+export class PermitController {
+  constructor(
+    private readonly service: PermitService,
+    private readonly ipsCartService: PermitIpsCartService,
+  ) {}
+
+  @Get()
+  list(@Query() query: PermitListQueryDto): Promise<PermitListResponse> {
+    return this.service.list({
+      groupId: query.group_id,
+      billable: parseBool(query.billable),
+      generatePermit: parseBool(query.generate_permit),
+      annualOvertime: parseBool(query.annual_overtime),
+      fireServiceOvertime: parseBool(query.fire_service_overtime),
+      overtimeUnderContract: parseBool(query.overtime_under_contract),
+      testDueDateFrom: query.test_due_date_from?.trim() || undefined,
+      testDueDateTo: query.test_due_date_to?.trim() || undefined,
+      search: query.search?.trim() || undefined,
+      ordering: query.ordering,
+      page: query.page,
+      pageSize: query.page_size,
+    });
+  }
+
+  @Get('export')
+  @Header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+  @Header('Content-Disposition', 'attachment; filename="permits.xlsx"')
+  async export(@Query() query: PermitExportQueryDto): Promise<StreamableFile> {
+    const buffer = await this.service.export({
+      groupId: query.group_id,
+      billable: parseBool(query.billable),
+      generatePermit: parseBool(query.generate_permit),
+      annualOvertime: parseBool(query.annual_overtime),
+      fireServiceOvertime: parseBool(query.fire_service_overtime),
+      overtimeUnderContract: parseBool(query.overtime_under_contract),
+      testDueDateFrom: query.test_due_date_from?.trim() || undefined,
+      testDueDateTo: query.test_due_date_to?.trim() || undefined,
+      search: query.search?.trim() || undefined,
+      groupName: query.group_name?.trim() || undefined,
+    });
+    return new StreamableFile(buffer);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() body: PermitCreateBodyDto): Promise<PermitResponse> {
+    return this.service.create({
+      deviceId: body.device_id,
+      groupId: body.group_id,
+      testDueDate: body.test_due_date,
+      contractNumber: body.contract_number,
+      ecr: body.ecr,
+      billable: body.billable,
+      notes: body.notes,
+      annualOvertime: body.annual_overtime,
+      fireServiceOvertime: body.fire_service_overtime,
+      overtimeUnderContract: body.overtime_under_contract,
+      generatePermit: body.generate_permit,
+    });
+  }
+
+  @Delete(':permitId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  destroy(@Param('permitId', ParseIntPipe) permitId: number, @Req() req: AuthenticatedRequest): Promise<void> {
+    return this.service.destroy(permitId, req.principal!);
+  }
+
+  @Post('record-payment-by-ecr')
+  @HttpCode(HttpStatus.OK)
+  recordPaymentByEcr(@Body() body: PermitRecordPaymentBodyDto): Promise<PermitPaymentResponse> {
+    return this.service.recordPaymentByEcr({ ecr: body.ecr, receiptNumber: body.receipt_number, paidAmount: body.paid_amount });
+  }
+
+  @Post('add-to-ips-cart')
+  @HttpCode(HttpStatus.OK)
+  addToIpsCart(@Body() body: PermitAddToIpsCartBodyDto): Promise<AddToIpsCartResponse> {
+    return this.service.addToIpsCart({
+      deviceIds: body.device_ids,
+      groupId: body.group_id,
+      ipsUserId: body.ips_user_id,
+      ipsUsername: body.ips_username,
+      ipsPassword: body.ips_password,
+    });
+  }
+
+  @Post('scan-ips-cart')
+  @HttpCode(HttpStatus.OK)
+  scanIpsCart(@Body() body: PermitScanIpsCartBodyDto): Promise<ScanIpsCartResponse> {
+    return this.ipsCartService.scanIpsCart({
+      groupId: body.group_id,
+      ipsUserId: body.ips_user_id,
+      ipsUsername: body.ips_username,
+      ipsPassword: body.ips_password,
+    });
+  }
+
+  @Post('sync-ips-cart')
+  @HttpCode(HttpStatus.OK)
+  syncIpsCart(@Body() body: PermitSyncIpsCartBodyDto): Promise<SyncIpsCartResponse> {
+    return this.ipsCartService.syncIpsCart({
+      groupId: body.group_id,
+      ipsUserId: body.ips_user_id,
+      ipsUsername: body.ips_username,
+      ipsPassword: body.ips_password,
+      previewResults: body.preview_results?.map((item) => ({ deviceName: item.device_name, type: item.type, ecr: item.ecr, action: item.action })),
+    });
+  }
+
+  @Patch(':permitId')
+  patch(@Param('permitId', ParseIntPipe) permitId: number, @Body() body: PermitPatchBodyDto): Promise<PermitResponse> {
+    return this.service.partialUpdate(permitId, {
+      status: body.status,
+      notes: body.notes,
+      billable: body.billable,
+      generatePermit: body.generate_permit,
+      annualOvertime: body.annual_overtime,
+      fireServiceOvertime: body.fire_service_overtime,
+      overtimeUnderContract: body.overtime_under_contract,
+      paid: body.paid,
+      ipsSubmitted: body.ips_submitted,
+      ecr: body.ecr,
+      price: body.price,
+      receiptNumber: body.receipt_number,
+      items: body.items,
+    });
+  }
+}
+
+function parseBool(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  return raw.toLowerCase() === 'true' || raw === '1';
+}


### PR DESCRIPTION
## What

NestJS whole-object `@Query()`/`@Param()`/`@Headers()` request DTOs previously got a `parameters` PROPERTY but **no graph EDGE** — only `@Body()` DTOs were edged. So every non-body request DTO (and its `CONTAINS` field subtree from #4328) floated as an orphan degree-1 node. On upvate-v3 this is the root cause of the 'orphan ring': `PermitListQueryDto` (the `@Query` DTO of `GET /v1/permits`) had 0 callers despite the param-surfacing work.

## Fix

In `internal/custom/javascript/nestjs.go`, after parsing the handler param block, emit an `ACCEPTS_INPUT` edge (`match_source=param_decorator`, `param_in=query|path|header`) from the handler endpoint to `Class:<dto>` for each whole-object **non-@Body** request DTO. `@Body` keeps its existing edge (`reNestBodyParam`); the new pass skips `In=="body"` so there is no double-emit.

**Edge Kind:** reuses the existing `ACCEPTS_INPUT` (`types.RelationshipKindAcceptsInput`) — same Kind `@Body`, FastAPI and Flask already use for request DTOs. **No new Kind.**

**Merge-stable:** the `Class:<dto>` stub is rewritten to the real DTO class entity by the central name resolver (`resolve.BuildIndex`/`resolve.References`) post-merge — resolve-time, survives merge, mirroring the #4319 bridge pattern and the existing `@Body`/FastAPI/Flask DTO edges.

**Conservative:** only whole-object DTOs (no quoted binding key — a keyed `@Query('id')` selects a primitive field, not a DTO) whose unwrapped type resolves to a real user type (`nestUnwrapType` filters primitives/built-ins). Honest-partial otherwise.

A new `QuotedKey` field on `nestParam` (json:"-", not serialized — dashboard wire shape unchanged) gates field-selectors out.

## Live-validation (in-pipeline)

`internal/custom/javascript/issue4464_livedrepro_test.go` runs the **real** extract → merge → resolve pipeline on byte-copies of real core-backend-v3 files (`permit.controller.ts` + `permit-list.query.dto.ts`, committed under `testdata/dto_4464/`):

- **BEFORE** (fix stashed): `PermitListQueryDto` has **0** inbound from the handler — test is RED (verified).
- **AFTER**: the `@Query()` DTO emits `GET list -[ACCEPTS_INPUT]-> Class:PermitListQueryDto`, the stub resolves to the real DTO entity, and the DTO gains **1** inbound ACCEPTS_INPUT neighbor — GREEN. (Via #4328 CONTAINS, its 11 fields are now reachable too.)

Plus unit gates: keyed-primitive `@Query('id')` emits no edge (false-positive guard), `@Body` still emits exactly one edge (no double-emit), minimal whole-DTO `@Query()` positive.

> Final live confirmation (PermitListQueryDto showing GET /v1/permits as an inbound neighbor on the **live** graph) requires a reindex = a user-authorized deploy. **Deferred** to that deploy.

## Generalize (epic #4334)

Audited the same handler↔DTO gap across frameworks:
- **NestJS** — fixed here (now @Body + @Query/@Param/@Headers).
- **FastAPI / Flask** — already emit handler↔DTO ACCEPTS_INPUT/RETURNS (`fastapi_reqresp.go`/`flask_reqresp.go`); filed #4476 to verify Depends()/query-model Pydantic coverage.
- **Spring** — covers `@RequestBody` only; misses `@ModelAttribute`/command-object query DTOs → **#4475**.
- **Django/DRF** — no view↔serializer edges at all → **#4474**.

## Gates

`go build ./...`, `go vet ./internal/custom/javascript ./internal/resolve`, `go test ./internal/custom/javascript ./internal/resolve ./internal/types` — all green.

Closes #4464

🤖 Generated with [Claude Code](https://claude.com/claude-code)