### PR TITLE
feat(flowdag): pure-tree unfold, click-to-highlight route, fullscreen modal

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDag.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDag.tsx
@@ -44,12 +44,15 @@ import { cn } from "@/lib/utils";
 import { useDownstreamDAG } from "@/hooks/use-paths";
 import type { DownstreamDAGNode, DownstreamDAGResponse } from "@/data/types";
 import {
-  layoutDAG,
+  unfoldTree,
+  layoutTree,
+  MAX_TREE_NODES,
   FLOW_DAG_NODE_TYPE,
   FLOW_DAG_EDGE_TYPE,
   type FlowDagDirection,
   type FlowDagNodeData,
 } from "./layout";
+import { routeInstanceIds } from "./route";
 import { FlowDagNode } from "./FlowDagNode";
 import { FlowDagEdge } from "./FlowDagEdge";
 import { FlowDagLegend } from "./FlowDagLegend";
@@ -99,6 +102,9 @@ function FlowDagInner({
   const [depth, setDepth] = useState<number>(payload?.depth ?? DEPTH_DEFAULT);
   const [direction, setDirection] = useState<FlowDagDirection>("LR");
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  // Click-to-highlight (#4479): the focused instance id whose route is lit, or
+  // null for the normal (everything-visible) view.
+  const [routeFocus, setRouteFocus] = useState<string | null>(null);
 
   // Only fetch when no payload was injected.
   const query = useDownstreamDAG(
@@ -121,24 +127,63 @@ function FlowDagInner({
     });
   }, []);
 
+  // Unfold the deduped DAG into a pure tree (#4479). Memoized off the payload +
+  // depth; instances are path-keyed so a node reached via N paths duplicates.
+  const unfold = useMemo(() => {
+    if (!data) return null;
+    return unfoldTree(data.root_id, data.nodes, data.edges, MAX_TREE_NODES);
+  }, [data]);
+
+  // The route highlight set: ancestors + the focus + its whole forward subtree.
+  const routeSet = useMemo(() => {
+    if (!unfold || routeFocus == null) return null;
+    return routeInstanceIds(unfold.instances, routeFocus);
+  }, [unfold, routeFocus]);
+
   const { nodes, edges } = useMemo(() => {
-    if (!data) return { nodes: [], edges: [] };
-    const laid = layoutDAG(data.nodes, data.edges, direction, expanded, onToggleExpand);
-    // Stamp the selected flag so the node renderer can highlight the active
-    // node when the caller drives selection (Flows step inspector, #4354).
-    if (selectedNodeId != null) {
-      for (const n of laid.nodes) n.data.selected = n.id === selectedNodeId;
+    if (!unfold) return { nodes: [], edges: [] };
+    const laid = layoutTree(unfold.instances, direction, expanded, onToggleExpand);
+    for (const n of laid.nodes) {
+      // Selection is driven by the ORIGINAL node id so the caller's contract
+      // (Flows step inspector, #4354) is unchanged across the tree unfold; all
+      // instances of a selected node light up.
+      if (selectedNodeId != null) {
+        n.data.selected = (n.data as FlowDagNodeData).node.id === selectedNodeId;
+      }
+      if (routeSet) n.data.onRoute = routeSet.has(n.id);
+    }
+    if (routeSet) {
+      for (const e of laid.edges) {
+        // An edge is on the route iff BOTH its endpoints are (the tree's single
+        // in-edge per node makes this exact).
+        e.data = { ...e.data, kind: e.data?.kind ?? "CALLS", onRoute: routeSet.has(e.source) && routeSet.has(e.target) };
+      }
     }
     return laid;
-  }, [data, direction, expanded, onToggleExpand, selectedNodeId]);
+  }, [unfold, direction, expanded, onToggleExpand, selectedNodeId, routeSet]);
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, n: RFNode) => {
-      if (!onNodeClick) return;
-      onNodeClick((n.data as FlowDagNodeData).node);
+      // Toggle the route highlight: same instance again clears it (#4479).
+      setRouteFocus((prev) => (prev === n.id ? null : n.id));
+      // Preserve the caller's detail/selection behavior — pass the original node.
+      onNodeClick?.((n.data as FlowDagNodeData).node);
     },
     [onNodeClick],
   );
+
+  // Clicking the empty canvas clears the route highlight (#4479).
+  const handlePaneClick = useCallback(() => setRouteFocus(null), []);
+
+  // Effective truncation: OR the payload's flags with our node-cap clip so the
+  // legend stays honest when the pure-tree unfold itself hits the cap.
+  const effectiveTruncation = useMemo(() => {
+    if (!data) return undefined;
+    return {
+      ...data.truncation,
+      node_truncated: data.truncation.node_truncated || (unfold?.capped ?? false),
+    };
+  }, [data, unfold]);
 
   const setDepthClamped = (n: number) =>
     setDepth(Math.max(DEPTH_MIN, Math.min(DEPTH_MAX, n)));
@@ -257,7 +302,8 @@ function FlowDagInner({
             edges={edges}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}
-            onNodeClick={onNodeClick ? handleNodeClick : undefined}
+            onNodeClick={handleNodeClick}
+            onPaneClick={handlePaneClick}
             fitView
             // The graph is a read-only visualization; disable interaction edits.
             nodesDraggable={false}
@@ -275,12 +321,13 @@ function FlowDagInner({
         )}
       </div>
 
-      {/* Legend + truncation/branch stats */}
-      {data && (
+      {/* Legend + truncation/branch stats. Node count reflects the unfolded
+          tree (instances), not the deduped payload, so it matches what's drawn. */}
+      {data && effectiveTruncation && (
         <FlowDagLegend
           branchCount={data.branch_count}
-          nodeCount={data.nodes.length}
-          truncation={data.truncation}
+          nodeCount={unfold?.instances.length ?? data.nodes.length}
+          truncation={effectiveTruncation}
         />
       )}
     </div>

--- a/webui-v2/src/components/flow-dag/FlowDagEdge.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagEdge.tsx
@@ -27,8 +27,11 @@ function FlowDagEdgeImpl({
   markerEnd,
   data,
 }: EdgeProps) {
-  const kind = (data as FlowDagEdgeData | undefined)?.kind ?? "CALLS";
+  const ed = data as FlowDagEdgeData | undefined;
+  const kind = ed?.kind ?? "CALLS";
   const es = edgeStyle(kind);
+  // Click-to-highlight (#4479): off-route edges dim; on-route edges stay full.
+  const dimmed = ed?.onRoute === false;
 
   const [path, labelX, labelY] = getBezierPath({
     sourceX,
@@ -48,6 +51,8 @@ function FlowDagEdgeImpl({
           stroke: es.stroke,
           strokeWidth: kind === "CALLS" ? 1.5 : 1.75,
           strokeDasharray: es.dash,
+          opacity: dimmed ? 0.18 : 1,
+          transition: "opacity 150ms",
         }}
       />
       {/* Only the non-spine semantic edges carry a label, to keep CALLS clean. */}
@@ -60,6 +65,7 @@ function FlowDagEdgeImpl({
               background: "var(--surface)",
               color: es.stroke,
               border: `1px solid color-mix(in srgb, ${es.stroke} 45%, transparent)`,
+              opacity: dimmed ? 0.18 : 1,
             }}
           >
             {es.label}

--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -20,28 +20,30 @@ import type { FlowDagNodeData } from "./layout";
  * nodes get a doubled ring so collection sinks read as endpoints of the walk.
  * The collapsed-children count badge expands an inline list on click.
  */
-function FlowDagNodeImpl({ data, sourcePosition, targetPosition }: NodeProps) {
-  const { node, expanded, onToggleExpand, selected } = data as FlowDagNodeData;
+function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps) {
+  const { node, expanded, onToggleExpand, selected, onRoute } = data as FlowDagNodeData;
   const rs = roleStyle(node.role);
   const collapsed = node.collapsed_children ?? [];
   const hasCollapsed = collapsed.length > 0;
+  // Click-to-highlight (#4479): when a route is active, off-route nodes dim.
+  const dimmed = onRoute === false;
 
   return (
     <div
       className={cn(
-        "rounded-lg border bg-surface shadow-[var(--shadow-2)] text-left",
-        "min-w-[220px] max-w-[220px]",
-        selected && "cursor-pointer",
+        "rounded-lg border bg-surface shadow-[var(--shadow-2)] text-left cursor-pointer",
+        "min-w-[220px] max-w-[220px] transition-opacity",
+        dimmed ? "opacity-25" : "opacity-100",
       )}
       style={{
         // Role tint as a soft background wash; the ink as the border.
         background: `color-mix(in srgb, ${rs.bg} 22%, var(--surface))`,
-        borderColor: selected
+        borderColor: selected || onRoute === true
           ? "var(--accent)"
           : `color-mix(in srgb, ${rs.ink} 55%, transparent)`,
-        // Selected node gets an accent ring; otherwise terminal sinks get a
-        // heavier outline ring.
-        boxShadow: selected
+        // Selected node, or a node lit on the highlighted route (#4479), gets an
+        // accent ring; otherwise terminal sinks get a heavier outline ring.
+        boxShadow: selected || onRoute === true
           ? "0 0 0 2px var(--accent)"
           : node.terminal
             ? `0 0 0 2px color-mix(in srgb, ${rs.ink} 45%, transparent)`
@@ -81,7 +83,8 @@ function FlowDagNodeImpl({ data, sourcePosition, targetPosition }: NodeProps) {
             type="button"
             onClick={(e) => {
               e.stopPropagation();
-              onToggleExpand(node.id);
+              // Keyed by INSTANCE id so duplicated instances expand independently.
+              onToggleExpand(id);
             }}
             className={cn(
               "mt-1.5 inline-flex items-center gap-1 h-[18px] px-1.5 rounded",

--- a/webui-v2/src/components/flow-dag/layout.test.ts
+++ b/webui-v2/src/components/flow-dag/layout.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the pure-tree unfold + route highlight (#4479).
+ *
+ * Run with: npx vitest run src/components/flow-dag/layout.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import { unfoldTree } from "./layout";
+import { routeInstanceIds } from "./route";
+import type { DownstreamDAGEdge, DownstreamDAGNode } from "@/data/types";
+
+function n(id: string): DownstreamDAGNode {
+  return { id, name: id, kind: "fn", repo: "api" };
+}
+function e(from: string, to: string): DownstreamDAGEdge {
+  return { from, to, kind: "CALLS" };
+}
+
+describe("unfoldTree", () => {
+  it("keeps a linear chain as one instance per node", () => {
+    const { instances, capped } = unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c")],
+      [e("a", "b"), e("b", "c")],
+    );
+    expect(capped).toBe(false);
+    expect(instances.map((i) => i.id)).toEqual(["a", "a/b", "a/b/c"]);
+    // Each non-root has exactly one parent (a tree).
+    expect(instances.filter((i) => i.parentId == null)).toHaveLength(1);
+  });
+
+  it("DUPLICATES a diamond convergence node (no fan-in)", () => {
+    // a → b → d ; a → c → d. d is reached via two paths → two instances.
+    const { instances } = unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c"), n("d")],
+      [e("a", "b"), e("a", "c"), e("b", "d"), e("c", "d")],
+    );
+    const dInstances = instances.filter((i) => i.node.id === "d");
+    expect(dInstances).toHaveLength(2);
+    expect(dInstances.map((i) => i.id).sort()).toEqual(["a/b/d", "a/c/d"]);
+    // Every node has at most one incoming edge → instance count == nodes,
+    // and each instance's parent is unique.
+    for (const inst of instances) {
+      if (inst.parentId == null) continue;
+      expect(instances.some((p) => p.id === inst.parentId)).toBe(true);
+    }
+  });
+
+  it("guards cycles via the per-path visited set", () => {
+    // a → b → a (stray cycle). The walk must terminate.
+    const { instances } = unfoldTree(
+      "a",
+      [n("a"), n("b")],
+      [e("a", "b"), e("b", "a")],
+    );
+    expect(instances.map((i) => i.id)).toEqual(["a", "a/b"]);
+  });
+
+  it("caps explosive unfolds and reports it", () => {
+    // A fan that would exceed the cap.
+    const nodes = [n("root")];
+    const edges: DownstreamDAGEdge[] = [];
+    for (let i = 0; i < 50; i++) {
+      nodes.push(n(`x${i}`));
+      edges.push(e("root", `x${i}`));
+    }
+    const { instances, capped } = unfoldTree("root", nodes, edges, 10);
+    expect(capped).toBe(true);
+    expect(instances.length).toBeLessThanOrEqual(10);
+  });
+});
+
+describe("routeInstanceIds", () => {
+  it("lights ancestors + focus + entire forward subtree", () => {
+    // a → b → d (focus b); b also → e → f. c is a sibling branch off a.
+    const { instances } = unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c"), n("d"), n("e"), n("f")],
+      [e("a", "b"), e("a", "c"), e("b", "d"), e("b", "e"), e("e", "f")],
+    );
+    const route = routeInstanceIds(instances, "a/b");
+    // ancestor a, focus a/b, descendants a/b/d, a/b/e, a/b/e/f
+    expect([...route].sort()).toEqual(
+      ["a", "a/b", "a/b/d", "a/b/e", "a/b/e/f"].sort(),
+    );
+    // The sibling branch c is OFF the route.
+    expect(route.has("a/c")).toBe(false);
+  });
+
+  it("returns empty for an unknown focus", () => {
+    const { instances } = unfoldTree("a", [n("a")], []);
+    expect(routeInstanceIds(instances, "nope").size).toBe(0);
+  });
+});

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -1,14 +1,22 @@
 /* ============================================================
-   components/flow-dag/layout.ts — dagre layout for <FlowDag>.
+   components/flow-dag/layout.ts — pure-tree unfold + dagre layout for <FlowDag>.
 
-   Maps the daemon's downstream-DAG payload onto React Flow node/edge
-   objects and runs dagre to assign positions. The H/V toggle maps directly
-   onto dagre's `rankdir`: "LR" (horizontal, left→right) or "TB" (vertical,
-   top→bottom).
+   The daemon ships a deduped DAG (each node id once; a convergence node carries
+   >1 in-edge). The renderer UNFOLDS that DAG into a pure TREE (#4479): starting
+   at `root_id` we walk the edges and DUPLICATE any node reached via more than
+   one path, so every rendered instance has exactly ONE incoming edge and may
+   have many outgoing. The result lays out cleanly under dagre with no fan-in /
+   crossing edges.
 
-   The payload is already a deduped DAG (each node id appears once; a
-   convergence node carries >1 in-edge), so layout simply keys on node id and
-   lets dagre route every incoming edge — no client-side dedupe needed.
+   Each instance is keyed by its path ("<parentInstanceId>/<nodeId>") and carries
+   the ORIGINAL node's data (name/kind/role/file/… ) for the detail panel and the
+   caller's selection contract. Safety: the unfold honors the depth control and a
+   hard max-node cap, and tracks the path's visited set so a diamond — or a stray
+   cycle, which shouldn't occur in a DAG — can never infinitely expand or hang the
+   browser. When a cap fires we stop expanding and surface honest truncation.
+
+   The H/V toggle maps directly onto dagre's `rankdir`: "LR" (horizontal,
+   left→right) or "TB" (vertical, top→bottom).
    ============================================================ */
 
 import dagre from "dagre";
@@ -16,6 +24,7 @@ import type { Edge, Node } from "@xyflow/react";
 import { Position } from "@xyflow/react";
 import type {
   DownstreamDAGEdge,
+  DownstreamDAGEdgeKind,
   DownstreamDAGNode,
 } from "@/data/types";
 
@@ -24,22 +33,51 @@ export type FlowDagDirection = "LR" | "TB";
 
 /** Data carried on each React Flow node, consumed by the custom node renderer. */
 export interface FlowDagNodeData extends Record<string, unknown> {
+  /** The original (deduped) payload node — what the detail panel reads. */
   node: DownstreamDAGNode;
-  /** Whether this node's collapsed_children are currently expanded inline. */
+  /** Whether this instance's collapsed_children are currently expanded inline. */
   expanded: boolean;
-  /** Toggle handler for the inline collapsed-children expander. */
-  onToggleExpand: (id: string) => void;
+  /** Toggle handler for the inline collapsed-children expander (keyed by instance id). */
+  onToggleExpand: (instanceId: string) => void;
   /** Whether this node is the caller's selected node (Flows inspector, #4354). */
   selected?: boolean;
+  /**
+   * Highlight state for the click-to-highlight route (#4479):
+   *  - undefined → no highlight active (normal view)
+   *  - true      → this instance is on the highlighted route
+   *  - false     → an active route exists but this instance is off it (dimmed)
+   */
+  onRoute?: boolean;
 }
 
 /** Data carried on each React Flow edge, consumed by the custom edge renderer. */
 export interface FlowDagEdgeData extends Record<string, unknown> {
   kind: DownstreamDAGEdge["kind"];
+  /** Highlight state, mirroring FlowDagNodeData.onRoute (#4479). */
+  onRoute?: boolean;
 }
 
 export type FlowDagNode = Node<FlowDagNodeData>;
 export type FlowDagEdge = Edge<FlowDagEdgeData>;
+
+/** One unfolded tree instance. The id is path-keyed; `node` is the original. */
+export interface TreeInstance {
+  /** Path-keyed instance id: "<parentInstanceId>/<nodeId>" (root = nodeId). */
+  id: string;
+  /** Parent instance id, or null for the root. Exactly one in a tree. */
+  parentId: string | null;
+  /** The original payload node this instance renders. */
+  node: DownstreamDAGNode;
+  /** The edge kind by which the parent reached this instance (root: undefined). */
+  edgeKind?: DownstreamDAGEdgeKind;
+}
+
+/** Result of the unfold, including whether the node cap clipped the tree. */
+export interface UnfoldResult {
+  instances: TreeInstance[];
+  /** True when expansion stopped because the max-node cap was hit. */
+  capped: boolean;
+}
 
 // Node box sizing fed to dagre. Kept generous so labels + repo chip fit; the
 // custom node renderer uses min-width/height matching these so edges dock
@@ -52,25 +90,119 @@ const NODE_TYPE = "flowDag";
 const EDGE_TYPE = "flowDag";
 
 /**
- * Build positioned React Flow nodes + edges from the DAG payload.
- *
- * @param nodes      payload nodes (already deduped by id)
- * @param edges      payload edges (a convergence node has >1 with same `to`)
- * @param direction  "LR" (horizontal) | "TB" (vertical) → dagre rankdir
- * @param expanded   set of node ids whose collapsed_children are shown inline
- * @param onToggle   inline-expand toggle handler
+ * Hard ceiling on unfolded instances. A pure-tree unfold of a diamond-heavy DAG
+ * can blow up combinatorially; this caps the rendered tree so the browser never
+ * hangs. The depth control is the primary lever; this is the safety net.
  */
-export function layoutDAG(
+export const MAX_TREE_NODES = 600;
+
+/**
+ * Unfold the deduped DAG into a pure tree rooted at `rootId`.
+ *
+ * BFS from the root following out-edges; every reached node becomes a NEW
+ * instance keyed by its path, so a node reached via N paths yields N instances
+ * (no fan-in). A per-path visited set guards against cycles (a node already on
+ * the path is not re-expanded). Expansion stops at `maxNodes`.
+ *
+ * @param rootId   payload root_id (the endpoint instance)
+ * @param nodes    payload nodes (deduped by id)
+ * @param edges    payload edges (directed; a convergence node has >1 same `to`)
+ * @param maxNodes hard cap on emitted instances
+ */
+export function unfoldTree(
+  rootId: string,
   nodes: DownstreamDAGNode[],
   edges: DownstreamDAGEdge[],
+  maxNodes = MAX_TREE_NODES,
+): UnfoldResult {
+  const nodeById = new Map<string, DownstreamDAGNode>();
+  for (const n of nodes) nodeById.set(n.id, n);
+
+  // Adjacency: from → list of (to, kind), preserving payload order.
+  const out = new Map<string, { to: string; kind: DownstreamDAGEdgeKind }[]>();
+  for (const e of edges) {
+    if (!nodeById.has(e.from) || !nodeById.has(e.to)) continue;
+    const list = out.get(e.from);
+    if (list) list.push({ to: e.to, kind: e.kind });
+    else out.set(e.from, [{ to: e.to, kind: e.kind }]);
+  }
+
+  const root = nodeById.get(rootId) ?? nodes[0];
+  if (!root) return { instances: [], capped: false };
+
+  const instances: TreeInstance[] = [];
+  let capped = false;
+
+  // BFS queue carries the instance plus the set of original node ids on its
+  // path, so a diamond duplicates but a cycle can't re-expand a node already
+  // on its own path.
+  interface Frame {
+    instance: TreeInstance;
+    visited: Set<string>;
+  }
+
+  const rootInstance: TreeInstance = {
+    id: root.id,
+    parentId: null,
+    node: root,
+  };
+  const queue: Frame[] = [
+    { instance: rootInstance, visited: new Set([root.id]) },
+  ];
+  instances.push(rootInstance);
+
+  while (queue.length > 0) {
+    const { instance, visited } = queue.shift()!;
+    const children = out.get(instance.node.id);
+    if (!children) continue;
+
+    for (const child of children) {
+      // Cycle guard: skip a node already on this path.
+      if (visited.has(child.to)) continue;
+      if (instances.length >= maxNodes) {
+        capped = true;
+        break;
+      }
+      const childNode = nodeById.get(child.to);
+      if (!childNode) continue;
+
+      const childInstance: TreeInstance = {
+        id: `${instance.id}/${child.to}`,
+        parentId: instance.id,
+        node: childNode,
+        edgeKind: child.kind,
+      };
+      instances.push(childInstance);
+      queue.push({
+        instance: childInstance,
+        // Clone the path set so siblings don't share a visited set.
+        visited: new Set(visited).add(child.to),
+      });
+    }
+    if (capped) break;
+  }
+
+  return { instances, capped };
+}
+
+/**
+ * Build positioned React Flow nodes + edges from the unfolded tree.
+ *
+ * @param instances  unfolded tree instances (from unfoldTree)
+ * @param direction  "LR" (horizontal) | "TB" (vertical) → dagre rankdir
+ * @param expanded   set of INSTANCE ids whose collapsed_children show inline
+ * @param onToggle   inline-expand toggle handler (keyed by instance id)
+ */
+export function layoutTree(
+  instances: TreeInstance[],
   direction: FlowDagDirection,
   expanded: Set<string>,
-  onToggle: (id: string) => void,
+  onToggle: (instanceId: string) => void,
 ): { nodes: FlowDagNode[]; edges: FlowDagEdge[] } {
   const g = new dagre.graphlib.Graph();
   g.setGraph({
     rankdir: direction,
-    // Roomy spacing so branchy DAGs don't overlap; tighter on the cross axis.
+    // Roomy spacing so branchy trees don't overlap; tighter on the cross axis.
     nodesep: direction === "LR" ? 28 : 48,
     ranksep: direction === "LR" ? 90 : 70,
     marginx: 16,
@@ -78,15 +210,11 @@ export function layoutDAG(
   });
   g.setDefaultEdgeLabel(() => ({}));
 
-  for (const n of nodes) {
-    g.setNode(n.id, { width: NODE_W, height: NODE_H });
+  for (const inst of instances) {
+    g.setNode(inst.id, { width: NODE_W, height: NODE_H });
   }
-  for (const e of edges) {
-    // dagre tolerates parallel edges between the same pair; convergence (>1
-    // edge into the same `to`) is preserved because we never dedupe here.
-    if (g.hasNode(e.from) && g.hasNode(e.to)) {
-      g.setEdge(e.from, e.to);
-    }
+  for (const inst of instances) {
+    if (inst.parentId != null) g.setEdge(inst.parentId, inst.id);
   }
 
   dagre.layout(g);
@@ -94,14 +222,18 @@ export function layoutDAG(
   const sourcePos = direction === "LR" ? Position.Right : Position.Bottom;
   const targetPos = direction === "LR" ? Position.Left : Position.Top;
 
-  const rfNodes: FlowDagNode[] = nodes.map((n) => {
-    const pos = g.node(n.id);
+  const rfNodes: FlowDagNode[] = instances.map((inst) => {
+    const pos = g.node(inst.id);
     return {
-      id: n.id,
+      id: inst.id,
       type: NODE_TYPE,
       // dagre centers nodes; React Flow positions by top-left corner.
       position: { x: (pos?.x ?? 0) - NODE_W / 2, y: (pos?.y ?? 0) - NODE_H / 2 },
-      data: { node: n, expanded: expanded.has(n.id), onToggleExpand: onToggle },
+      data: {
+        node: inst.node,
+        expanded: expanded.has(inst.id),
+        onToggleExpand: onToggle,
+      },
       sourcePosition: sourcePos,
       targetPosition: targetPos,
       width: NODE_W,
@@ -109,15 +241,17 @@ export function layoutDAG(
     };
   });
 
-  const rfEdges: FlowDagEdge[] = edges.map((e, i) => ({
-    // Edge id must be unique even for convergence (same to, different from) and
-    // for parallel kinds between the same pair — index-suffix guarantees it.
-    id: `${e.from}__${e.to}__${e.kind}__${i}`,
-    source: e.from,
-    target: e.to,
-    type: EDGE_TYPE,
-    data: { kind: e.kind },
-  }));
+  const rfEdges: FlowDagEdge[] = instances
+    .filter((inst) => inst.parentId != null)
+    .map((inst) => ({
+      // One edge per non-root instance (the tree's single in-edge). The
+      // instance id is unique, so the edge id is too.
+      id: `e__${inst.id}`,
+      source: inst.parentId!,
+      target: inst.id,
+      type: EDGE_TYPE,
+      data: { kind: inst.edgeKind ?? "CALLS" },
+    }));
 
   return { nodes: rfNodes, edges: rfEdges };
 }

--- a/webui-v2/src/components/flow-dag/route.ts
+++ b/webui-v2/src/components/flow-dag/route.ts
@@ -1,0 +1,56 @@
+/* ============================================================
+   components/flow-dag/route.ts — click-to-highlight route (#4479).
+
+   Given a clicked tree instance, compute the set of instance ids that form its
+   full route through the endpoint: its single ancestor chain back to the root
+   (trivial in a tree — one parent each) PLUS its entire forward subtree (all
+   branches). The renderer dims everything off this set.
+   ============================================================ */
+
+import type { TreeInstance } from "./layout";
+
+/**
+ * Instance ids on the full route of `focusId`: ancestors (root-ward chain) +
+ * the focus itself + descendants (its whole forward subtree). Returns an empty
+ * set if `focusId` is not found.
+ */
+export function routeInstanceIds(
+  instances: TreeInstance[],
+  focusId: string,
+): Set<string> {
+  const byId = new Map<string, TreeInstance>();
+  const childrenOf = new Map<string, string[]>();
+  for (const inst of instances) {
+    byId.set(inst.id, inst);
+    if (inst.parentId != null) {
+      const list = childrenOf.get(inst.parentId);
+      if (list) list.push(inst.id);
+      else childrenOf.set(inst.parentId, [inst.id]);
+    }
+  }
+
+  if (!byId.has(focusId)) return new Set();
+
+  const route = new Set<string>();
+
+  // Ancestor chain: walk parentId up to the root (one parent per node).
+  let cur: string | null = focusId;
+  while (cur != null) {
+    if (route.has(cur)) break; // defensive — a tree can't loop
+    route.add(cur);
+    cur = byId.get(cur)?.parentId ?? null;
+  }
+
+  // Forward subtree: BFS down the children adjacency from the focus.
+  const queue = [focusId];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    for (const childId of childrenOf.get(id) ?? []) {
+      if (route.has(childId)) continue;
+      route.add(childId);
+      queue.push(childId);
+    }
+  }
+
+  return route;
+}

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -22,7 +22,7 @@ import { useParams, useSearchParams } from "react-router-dom";
 import {
   Search, X, ChevronRight, ChevronLeft, Lock, ExternalLink, Copy,
   Database, Zap, Globe, TestTube, Server,
-  Layers, Box, List, Maximize2, FolderTree, Boxes, AlertTriangle,
+  Layers, Box, List, Maximize2, Minimize2, FolderTree, Boxes, AlertTriangle,
   Workflow,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -744,6 +744,9 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
   // endpoint. The verb passed disambiguates a multi-verb path hash (falls back
   // to the first verb when the list filter is "all").
   const [dagOpen, setDagOpen] = useState(false);
+  // Fullscreen / maximize toggle for the downstream-flow modal (#4479). Persists
+  // within the session so re-opening the modal keeps the user's last choice.
+  const [dagMaximized, setDagMaximized] = useState(false);
   const dagVerb = verbFilter !== "all" ? verbFilter : detail.verbs[0];
 
   // Filter verb-scoped data
@@ -1117,7 +1120,14 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
           open so the DAG fetch is lazy; reuses the house Dialog primitive. */}
       <Dialog open={dagOpen} onOpenChange={setDagOpen}>
         <DialogContent
-          className="max-w-[min(1100px,94vw)] w-full h-[82vh] p-0 flex flex-col overflow-hidden"
+          className={cn(
+            "p-0 flex flex-col overflow-hidden",
+            // Maximize (#4479): fill the viewport so the diagram has max room;
+            // otherwise the windowed size.
+            dagMaximized
+              ? "max-w-none w-screen h-screen rounded-none border-0"
+              : "max-w-[min(1100px,94vw)] w-full h-[82vh]",
+          )}
         >
           <div className="px-5 pt-4 pb-3 border-b border-border shrink-0">
             <DialogTitle className="flex items-center gap-2">
@@ -1125,8 +1135,19 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
               Downstream flow
             </DialogTitle>
             <DialogDescription>
-              {detail.path} — the endpoint's downstream as a branching DAG.
+              {detail.path} — the endpoint's downstream as a branching tree.
             </DialogDescription>
+            {/* Maximize / restore toggle (#4479). Sits left of the Dialog's own
+                close button (which is absolute-positioned top-right). */}
+            <button
+              type="button"
+              onClick={() => setDagMaximized((m) => !m)}
+              className="absolute right-12 top-4 text-text-3 hover:text-text rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+              title={dagMaximized ? "Restore" : "Maximize"}
+            >
+              {dagMaximized ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+              <span className="sr-only">{dagMaximized ? "Restore" : "Maximize"}</span>
+            </button>
           </div>
           <div className="flex-1 min-h-0">
             {dagOpen && (


### PR DESCRIPTION
Closes #4479. Part of the flow-rendering epic #4348 / #4350.

Three user-requested enhancements to the shared `<FlowDag>` downstream-flow renderer (`webui-v2/src/components/flow-dag/`). All client-side, driven from the existing `downstream-dag` payload (#4355) — **no backend change needed**. Pure dashboard change; ships at the next dashboard rebuild.

## What FlowDag did before
Rendered an endpoint's downstream as a **deduped DAG**: each payload node appears once, so a node reached by multiple parents showed fan-in with crossing edges. Read-only canvas with H/V toggle, Spine/Full mode, depth stepper, inline collapsed-children expansion, semantic edge styling, and a truncation/branch legend.

## 1. Pure-tree unfold (replaces the converged DAG)
`layout.ts`: `layoutDAG` → `unfoldTree` + `layoutTree`. `unfoldTree()` BFS-walks `edges` from `root_id` and **duplicates** any node reached via multiple paths into a path-keyed instance (`"<parentInstanceId>/<nodeId>"`), so every node has exactly one incoming edge and many outgoing — a pure tree with no fan-in. Each instance carries the original node data for the detail panel. dagre lays the tree out cleanly (LR=H / TB=V).
- **Safety:** honors the depth control + a hard `MAX_TREE_NODES = 600` cap so a diamond-heavy DAG can't blow up the browser; a per-path visited `Set` guards cycles (a node already on its path isn't re-expanded). When the cap fires, the legend's `node_truncated` flag is OR'd on for honest truncation. Node count in the legend reflects unfolded instances.
- H/V, Spine/Full, and depth controls all preserved.

## 2. Click-to-highlight route
`route.ts` `routeInstanceIds()`: clicking a node instance dims all other nodes+edges (low opacity) and highlights the node's full route — its single ancestor chain back to the endpoint root **and** its entire forward subtree (all branches). Clicking the pane, or the same node again, resets. On-route nodes get an accent ring. Coexists with the existing selection/detail behavior — `onNodeClick` still receives the original `DownstreamDAGNode`, and `selectedNodeId` still matches the original node id (so the Flows step inspector, #4354, is unaffected).

## 3. Fullscreen / maximize
`paths.tsx`: a Maximize/Restore button in the modal header toggles the house `Dialog` between its windowed size and full-viewport (`w-screen h-screen`), giving the diagram maximum room. The choice persists within the session.

## Notes
- Selection + inline-expand are now keyed by **instance id** so duplicated instances behave independently.
- Unit tests (`layout.test.ts`) cover diamond duplication, the cycle guard, the node cap, and ancestor+subtree route computation.

## Gates
- `npm ci` ✓ · `npm run build` ✓ (TypeScript clean) · `npm run lint` (`tsc --noEmit`) ✓
- `vitest`: new 6 tests pass; existing `flow-to-dag` 9 tests still pass.

Deploy-deferred. Visual confirmation comes at the next dashboard deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)