### PR TITLE
fix(paths): remove auth/NO-AUTH badge from left-nav list rows (#4490)

### DIFF
--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -320,8 +320,6 @@ function VerbRouteRow({
   onClick: () => void;
 }) {
   const { route, verb } = row;
-  const auth = useAuthFor();
-  const finding = auth.lookup(verb, route.path);
   return (
     <button
       type="button"
@@ -347,14 +345,9 @@ function VerbRouteRow({
       </span>
       {/* Path */}
       <PathString path={route.path} className="flex-1 text-xs text-text-2 leading-tight min-w-0 truncate" />
-      {/* Right meta */}
+      {/* Right meta — repo tag only (#4490: auth badge removed from list rows,
+          auth posture still shown in the detail pane). */}
       <div className="flex items-center gap-1 shrink-0">
-        <AuthSeverityBadge finding={finding} variant="row" />
-        {route.auth && (
-          <span title="Authenticated">
-            <Lock size={10} className="text-success" />
-          </span>
-        )}
         {(route.repos?.length ?? 0) > 1 ? (
           <span className="text-[10px] text-text-4 font-mono">+{route.repos?.length}</span>
         ) : route.repos?.[0] ? (


### PR DESCRIPTION
## Summary
The Paths left-nav endpoint rows showed a `NO-AUTH · sensitive` auth severity badge plus a `Lock` icon that cluttered the list. This removes both from the list-ROW (`RouteRow`), keeping the verb chip, path, and repo tag.

Auth posture is **still shown in the detail pane** (right side) — only the list-row badge is removed.

## Changes
- `webui-v2/src/routes/paths.tsx` — `RouteRow`: dropped `AuthSeverityBadge` (`variant="row"`) and the `Lock` auth icon from the right-meta cluster; removed the now-unused `useAuthFor()`/`finding` lookup in this row. Repo tag retained. `Lock`, `AuthSeverityBadge`, and `useAuthFor` are still used by the detail pane, so imports are unchanged.

## Gates
- `npm ci` ✅
- `npm run build` ✅ (TypeScript clean)
- `npm run lint` (`tsc --noEmit`) ✅

Sequenced after the group-by-module Paths PR (#4491), based on latest `origin/main`.

Closes #4490

🤖 Generated with [Claude Code](https://claude.com/claude-code)