### PR TITLE
feat(flow-dag): richer FlowDag cards + long-name handling (#4481)

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -5,6 +5,12 @@
    distinctly, and (in spine mode) renders an inline expander for the
    collapsed builder/predicate children. Expanding is purely client-side —
    the rows are already on the payload, so no refetch.
+
+   #4481: cards handle long names (responsive font + wrap to 2 lines + wider
+   card + full-name tooltip) and surface richer info — file:line, the incoming
+   edge kind, the collapsed-children count, plus the enriched backend fields
+   (signature, subtype, doc, effects, collection). Secondary info is small +
+   muted and omitted when absent so the card stays compact.
    ============================================================ */
 
 import { memo } from "react";
@@ -12,8 +18,29 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { ChevronRight, ChevronDown, CircleDot } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { RepoChip } from "@/lib/repo-color";
-import { roleStyle } from "./style";
+import { roleStyle, edgeStyle } from "./style";
 import type { FlowDagNodeData } from "./layout";
+
+/** Effect kind → short badge label + tone. Anything else falls through generic. */
+const EFFECT_BADGE: Record<string, { label: string; cls: string }> = {
+  db_read: { label: "DB read", cls: "text-info bg-info-soft" },
+  db_write: { label: "DB write", cls: "text-warning bg-warning-soft" },
+  http_out: { label: "HTTP", cls: "text-accent-strong bg-accent-soft" },
+  fs: { label: "FS", cls: "text-text-3 bg-surface-2" },
+  fs_read: { label: "FS read", cls: "text-text-3 bg-surface-2" },
+  fs_write: { label: "FS write", cls: "text-text-3 bg-surface-2" },
+  queue: { label: "Queue", cls: "text-accent-strong bg-accent-soft" },
+};
+
+function effectBadge(effect: string): { label: string; cls: string } {
+  return (
+    EFFECT_BADGE[effect] ?? {
+      // Humanize an unknown effect key (db_read → "db read") rather than drop it.
+      label: effect.replace(/_/g, " "),
+      cls: "text-text-3 bg-surface-2",
+    }
+  );
+}
 
 /**
  * FlowDagNode — one DAG node. Color + label come from the role; terminal
@@ -21,18 +48,40 @@ import type { FlowDagNodeData } from "./layout";
  * The collapsed-children count badge expands an inline list on click.
  */
 function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps) {
-  const { node, expanded, onToggleExpand, selected, onRoute } = data as FlowDagNodeData;
+  const { node, edgeKind, expanded, onToggleExpand, selected, onRoute } =
+    data as FlowDagNodeData;
   const rs = roleStyle(node.role);
   const collapsed = node.collapsed_children ?? [];
   const hasCollapsed = collapsed.length > 0;
   // Click-to-highlight (#4479): when a route is active, off-route nodes dim.
   const dimmed = onRoute === false;
 
+  // Incoming relationship label (calls/handler/joins/throws/validates) — from
+  // the single in-edge feeding this instance. Absent on the root.
+  const edgeLabel = edgeKind ? edgeStyle(edgeKind).label : null;
+  // file:line — plain muted text; this canvas is read-only (no source-open).
+  // Split into head (dir prefix, truncates) + tail (filename:line, kept whole)
+  // so the load-bearing end of the path is always visible (cf. RefLine).
+  const fileRef = node.file
+    ? node.line
+      ? `${node.file}:${node.line}`
+      : node.file
+    : null;
+  let fileHead = "";
+  let fileTail = "";
+  if (node.file) {
+    const slash = node.file.lastIndexOf("/");
+    const filename = slash < 0 ? node.file : node.file.slice(slash + 1);
+    fileHead = slash < 0 ? "" : node.file.slice(0, slash + 1);
+    fileTail = node.line ? `${filename}:${node.line}` : filename;
+  }
+  const effects = node.effects ?? [];
+
   return (
     <div
       className={cn(
         "rounded-lg border bg-surface shadow-[var(--shadow-2)] text-left cursor-pointer",
-        "min-w-[220px] max-w-[220px] transition-opacity",
+        "min-w-[268px] max-w-[268px] transition-opacity",
         dimmed ? "opacity-25" : "opacity-100",
       )}
       style={{
@@ -55,6 +104,7 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
       <Handle type="source" position={sourcePosition ?? Position.Right} className="!bg-text-4" />
 
       <div className="px-2.5 py-2">
+        {/* Header row: role pill · incoming-edge pill · terminal marker · repo */}
         <div className="flex items-center gap-1.5">
           <span
             className="inline-flex items-center h-[15px] px-1 rounded text-[9px] font-semibold uppercase tracking-wide leading-none shrink-0"
@@ -65,18 +115,93 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
           >
             {rs.label}
           </span>
+          {edgeLabel && (
+            <span
+              className="inline-flex items-center h-[15px] px-1 rounded text-[9px] font-medium lowercase leading-none shrink-0 text-text-3 bg-surface-2"
+              title={`incoming relationship: ${edgeLabel}`}
+            >
+              {edgeLabel}
+            </span>
+          )}
           {node.terminal && (
             <CircleDot size={11} className="shrink-0" style={{ color: rs.ink }} aria-label="terminal" />
           )}
           <RepoChip slug={node.repo} className="ml-auto" maxLength={14} />
         </div>
 
-        <div className="mt-1 text-xs font-medium text-text truncate" title={node.name}>
+        {/* Name — responsive size, wraps to 2 lines, full name on hover. */}
+        <div
+          className="mt-1 text-[11px] leading-tight font-medium text-text break-words line-clamp-2"
+          title={node.name}
+        >
           {node.name}
         </div>
-        <div className="text-[10px] text-text-4 font-mono truncate" title={`${node.kind}${node.file ? ` · ${node.file}` : ""}`}>
+
+        {/* doc — one-line muted subtitle when present. */}
+        {node.doc && (
+          <div className="mt-0.5 text-[10px] text-text-3 truncate" title={node.doc}>
+            {node.doc}
+          </div>
+        )}
+
+        {/* signature — monospace, truncated, full on hover. */}
+        {node.signature && (
+          <div
+            className="mt-0.5 text-[10px] text-text-4 font-mono truncate"
+            title={node.signature}
+          >
+            {node.signature}
+          </div>
+        )}
+
+        {/* kind / subtype · collection — small muted meta line. */}
+        <div
+          className="text-[10px] text-text-4 font-mono truncate"
+          title={`${node.kind}${node.subtype ? ` · ${node.subtype}` : ""}${node.collection ? ` · ${node.collection}` : ""}`}
+        >
           {node.kind}
+          {node.subtype && node.subtype !== node.kind && (
+            <span className="text-text-3"> · {node.subtype}</span>
+          )}
+          {node.collection && (
+            <span className="text-text-3"> · {node.collection}</span>
+          )}
         </div>
+
+        {/* file:line — plain muted text (read-only canvas, no source-open). */}
+        {fileRef && (
+          <div
+            className="mt-0.5 flex items-center font-mono text-[10px] text-text-4 tabular-nums min-w-0"
+            title={fileRef}
+          >
+            {/* head (dir prefix) truncates LTR; tail (filename:line) never shrinks. */}
+            <span className="overflow-hidden whitespace-nowrap text-ellipsis min-w-0 shrink">
+              {fileHead}
+            </span>
+            <span className="shrink-0 whitespace-nowrap">{fileTail}</span>
+          </div>
+        )}
+
+        {/* effect badges — small, only what's present. */}
+        {effects.length > 0 && (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {effects.map((eff) => {
+              const b = effectBadge(eff);
+              return (
+                <span
+                  key={eff}
+                  className={cn(
+                    "inline-flex items-center h-[15px] px-1 rounded text-[9px] font-medium leading-none",
+                    b.cls,
+                  )}
+                  title={eff}
+                >
+                  {b.label}
+                </span>
+              );
+            })}
+          </div>
+        )}
 
         {hasCollapsed && (
           <button
@@ -94,7 +219,7 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
             title={expanded ? "Collapse builder/predicate calls" : "Expand builder/predicate calls"}
           >
             {expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
-            {collapsed.length} collapsed
+            +{collapsed.length} collapsed
           </button>
         )}
 

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -35,6 +35,12 @@ export type FlowDagDirection = "LR" | "TB";
 export interface FlowDagNodeData extends Record<string, unknown> {
   /** The original (deduped) payload node — what the detail panel reads. */
   node: DownstreamDAGNode;
+  /**
+   * The edge kind by which the parent reached this instance (the node's single
+   * incoming relationship in the unfolded tree) — calls/handler/joins/throws/
+   * validates. Undefined for the root (no in-edge). Surfaced on the card (#4481).
+   */
+  edgeKind?: DownstreamDAGEdgeKind;
   /** Whether this instance's collapsed_children are currently expanded inline. */
   expanded: boolean;
   /** Toggle handler for the inline collapsed-children expander (keyed by instance id). */
@@ -83,8 +89,12 @@ export interface UnfoldResult {
 // custom node renderer uses min-width/height matching these so edges dock
 // cleanly. Expanded nodes grow downward in the DOM but we keep the dagre box
 // fixed — the inline rows overlay rather than reflow the graph.
-const NODE_W = 220;
-const NODE_H = 64;
+// Widened for #4481: long names now wrap to ~2 lines and the card surfaces
+// signature / file:line / effect badges, so the box is roomier. Height is the
+// dagre rank box (edges dock to it); the card itself grows downward in the DOM
+// for the inline expander/extra rows without reflowing the graph.
+const NODE_W = 268;
+const NODE_H = 76;
 
 const NODE_TYPE = "flowDag";
 const EDGE_TYPE = "flowDag";
@@ -231,6 +241,7 @@ export function layoutTree(
       position: { x: (pos?.x ?? 0) - NODE_W / 2, y: (pos?.y ?? 0) - NODE_H / 2 },
       data: {
         node: inst.node,
+        edgeKind: inst.edgeKind,
         expanded: expanded.has(inst.id),
         onToggleExpand: onToggle,
       },

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2372,6 +2372,19 @@ export interface DownstreamDAGNode {
   role?: DownstreamDAGRole;
   /** A deliberate leaf the walk stops at (e.g. a joined collection sink). */
   terminal?: boolean;
+  // --- per-node enrichment (#4482/#4484 flow cards) ----------------------
+  // Read at query-time from the resolved graph entity; each is omitted when
+  // the underlying data is absent, so a card shows what it can and nothing more.
+  /** Function/method signature for Operation/Handler nodes (monospace, truncated). */
+  signature?: string;
+  /** Finer kind/subtype when the entity carries one more specific than `kind`. */
+  subtype?: string;
+  /** SHORT one-line summary (≤140 chars) from the entity's docstring/description. */
+  doc?: string;
+  /** Effect kinds (db_read/db_write/http_out/fs/…) — rendered as small badges. */
+  effects?: string[];
+  /** Collection/table name for a collection-terminal node (role=collection). */
+  collection?: string;
   /** Builder/predicate noise folded into this node in spine mode (empty in full). */
   collapsed_children?: DownstreamDAGCollapsedChild[];
 }


### PR DESCRIPTION
Closes #4481

FRONTEND-only card content/layout pass on `webui-v2/src/components/flow-dag/FlowDagNode.tsx`. The tree/highlight/fullscreen behavior (#4479/#4483) is untouched — only the node CARD changed.

## Long names
- Name font dropped to responsive `text-[11px] leading-tight` and now WRAPS to ~2 lines (`line-clamp-2` + `break-words`) instead of a single hard-truncate.
- Card widened: `min/max-w-[268px]` (was 220), and dagre `NODE_W`/`NODE_H` bumped to `268`/`76` so edges keep docking cleanly.
- Full name on hover via `title` attr.

## Richer info (shown when present, omitted when absent — cards stay compact)
- **file:line** — muted monospace, head/tail split (dir prefix truncates, `filename:line` kept whole) like `RefLine`. Plain text — this canvas is read-only, no source-open pattern to match.
- **incoming edge kind** — a small pill (calls/handler/joins/throws/validates) using `edgeStyle().label`. Threaded from `TreeInstance.edgeKind` → new `FlowDagNodeData.edgeKind` → card.
- **role + kind/subtype** — role pill kept; meta line now shows `kind · subtype · collection`.
- **collapsed_children** — count rendered as a `+N collapsed` badge.
- **NEW backend fields (#4482/#4484)**: `signature` (monospace, truncated + tooltip), `doc` (1-line muted subtitle), `effects` as small badges (DB read / DB write / HTTP / …), `collection` on collection terminals.

Role-based styling + terminal marker preserved.

## Type update
`DownstreamDAGNode` in `src/data/types.ts` gains optional `signature`, `subtype`, `doc`, `effects: string[]`, `collection` — matching the enriched Go wire type (`v2DAGNode`).

## Gates
- `npm ci` ✓
- `npm run build` ✓ (tsc clean)
- `npm run lint` (tsc --noEmit) ✓
- flow-dag `layout.test.ts` 6/6 ✓

DEPLOY-DEFERRED — pure dashboard change; visual confirmation at next dashboard deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)