### PR TITLE
fix(security): dedupe repo badge and align findings rows into columns

### DIFF
--- a/webui-v2/src/components/RefLine.tsx
+++ b/webui-v2/src/components/RefLine.tsx
@@ -37,6 +37,12 @@ export interface RefLineProps {
   className?: string;
   /** Called when the file path link is clicked. Receives "file:line" string. */
   onFileClick?: (fileRef: string) => void;
+  /**
+   * Render the right-anchored repo chip (default true). Set false when the
+   * caller already shows the repo elsewhere in the row to avoid a duplicate
+   * badge (e.g. single-repo lists in the Security view, #4500).
+   */
+  showRepoChip?: boolean;
 }
 
 // repoColorIndex is kept for backwards compat with any callsite that still
@@ -93,6 +99,7 @@ export function RefLine({
   title,
   className,
   onFileClick,
+  showRepoChip = true,
 }: RefLineProps) {
   const repoColors = getRepoColor(repo);
   const fileLabel = file ? `${file}:${line}` : line > 0 ? `:${line}` : "";
@@ -147,8 +154,9 @@ export function RefLine({
       </span>
 
       {/* Repo chip — right-anchored via ml-auto, never squished.
-          Uses repo-color.ts resolver for theme-aware stable color (#1946). */}
-      {repo && (
+          Uses repo-color.ts resolver for theme-aware stable color (#1946).
+          Suppressible via showRepoChip when the caller renders repo elsewhere. */}
+      {repo && showRepoChip && (
         <span
           className={cn(
             "shrink-0 inline-flex items-center h-[18px] px-1.5 rounded ml-auto",

--- a/webui-v2/src/routes/security.tsx
+++ b/webui-v2/src/routes/security.tsx
@@ -252,24 +252,34 @@ function SeverityFilter({
 // § Auth-coverage tab
 // ---------------------------------------------------------------------------
 
-function AuthFindingRow({ f }: { f: AuthEndpointFinding }) {
+function AuthFindingRow({
+  f,
+  multiRepo,
+}: {
+  f: AuthEndpointFinding;
+  multiRepo: boolean;
+}) {
   return (
     <div className="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg border border-border bg-surface hover:bg-surface-2 transition-colors">
-      <div className="flex items-center gap-2 min-w-0">
+      {/* Primary line: fixed-width columns so rows align like a table.
+          [lock] [VERB] [path …] [sensitive/IDOR/severity badges] */}
+      <div className="grid grid-cols-[14px_3rem_minmax(0,1fr)_auto] items-center gap-2 min-w-0">
         {f.has_auth ? (
           <Lock size={13} className="text-success shrink-0" />
         ) : (
           <Unlock size={13} className="text-danger shrink-0" />
         )}
-        {f.method && (
-          <span className="text-[10px] font-mono uppercase px-1.5 py-0.5 rounded bg-surface-2 text-text-3 border border-border shrink-0">
+        {f.method ? (
+          <span className="text-[10px] font-mono uppercase text-center px-1.5 py-0.5 rounded bg-surface-2 text-text-3 border border-border">
             {f.method}
           </span>
+        ) : (
+          <span aria-hidden />
         )}
         <span className="font-mono text-sm text-text truncate" title={f.path || f.name}>
           {f.path || f.name}
         </span>
-        <div className="ml-auto flex items-center gap-1.5 shrink-0">
+        <div className="flex items-center gap-1.5 shrink-0 justify-end">
           {f.sensitive_op && (
             <Badge tone="danger" className="shrink-0">
               sensitive
@@ -283,14 +293,21 @@ function AuthFindingRow({ f }: { f: AuthEndpointFinding }) {
           <SeverityBadge severity={f.severity} />
         </div>
       </div>
-      <div className="flex items-center gap-2 min-w-0 -mx-1">
-        <RepoChip slug={f.repo} className="text-[10px] shrink-0" />
+      {/* Secondary line: [repo (multi-repo only)] [source-file ref] aligned
+          on a fixed leading column so the refs line up across rows (#4500). */}
+      <div className="grid grid-cols-[8rem_minmax(0,1fr)] items-center gap-2 min-w-0 -mx-1 pl-1">
+        {multiRepo ? (
+          <RepoChip slug={f.repo} className="text-[10px] shrink-0" />
+        ) : (
+          <span aria-hidden />
+        )}
         {f.source_file ? (
           <RefLine
             repo={f.repo}
             file={f.source_file}
             line={f.start_line ?? 0}
             name={f.name}
+            showRepoChip={false}
             className="text-[11px] py-0.5 px-1 min-w-0"
           />
         ) : (
@@ -331,6 +348,10 @@ function AuthCoverageTab({ groupId }: { groupId: string }) {
       ? data.findings
       : data.findings.filter((f) => f.severity === severity);
 
+  // Repo badge is redundant for a single-repo group — gate on >1 repo,
+  // matching the convention used elsewhere in the dashboard (#4500).
+  const multiRepo = new Set(data.findings.map((f) => f.repo)).size > 1;
+
   return (
     <div className="space-y-4">
       <CoverageGauge
@@ -363,7 +384,7 @@ function AuthCoverageTab({ groupId }: { groupId: string }) {
       ) : (
         <div className="space-y-2">
           {findings.map((f) => (
-            <AuthFindingRow key={f.entity_id} f={f} />
+            <AuthFindingRow key={f.entity_id} f={f} multiRepo={multiRepo} />
           ))}
         </div>
       )}
@@ -375,15 +396,22 @@ function AuthCoverageTab({ groupId }: { groupId: string }) {
 // § Secrets tab
 // ---------------------------------------------------------------------------
 
-function SecretFindingRow({ f }: { f: SecuritySecretFinding }) {
+function SecretFindingRow({
+  f,
+  multiRepo,
+}: {
+  f: SecuritySecretFinding;
+  multiRepo: boolean;
+}) {
   return (
     <div className="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg border border-border bg-surface hover:bg-surface-2 transition-colors">
-      <div className="flex items-center gap-2 min-w-0">
+      {/* Primary line: fixed-width columns to align rows like a table. */}
+      <div className="grid grid-cols-[14px_minmax(0,1fr)_auto] items-center gap-2 min-w-0">
         <KeyRound size={13} className="text-warning shrink-0" />
         <span className="font-mono text-sm text-text truncate" title={f.name}>
           {f.name}
         </span>
-        <div className="ml-auto flex items-center gap-1.5 shrink-0">
+        <div className="flex items-center gap-1.5 shrink-0 justify-end">
           <Badge tone="neutral" className="shrink-0">
             {f.category.replace(/_/g, " ")}
           </Badge>
@@ -395,14 +423,20 @@ function SecretFindingRow({ f }: { f: SecuritySecretFinding }) {
           <SeverityBadge severity={f.severity} />
         </div>
       </div>
-      <div className="flex items-center gap-2 min-w-0 -mx-1">
-        <RepoChip slug={f.repo} className="text-[10px] shrink-0" />
+      {/* Secondary line: [repo (multi-repo only)] [source-file ref] (#4500). */}
+      <div className="grid grid-cols-[8rem_minmax(0,1fr)] items-center gap-2 min-w-0 -mx-1 pl-1">
+        {multiRepo ? (
+          <RepoChip slug={f.repo} className="text-[10px] shrink-0" />
+        ) : (
+          <span aria-hidden />
+        )}
         {f.source_file ? (
           <RefLine
             repo={f.repo}
             file={f.source_file}
             line={f.start_line ?? 0}
             name={f.language ?? ""}
+            showRepoChip={false}
             className="text-[11px] py-0.5 px-1 min-w-0"
           />
         ) : (
@@ -438,6 +472,8 @@ function SecretsTab({ groupId }: { groupId: string }) {
     severity === "all"
       ? data.findings
       : data.findings.filter((f) => f.severity === severity);
+
+  const multiRepo = new Set(data.findings.map((f) => f.repo)).size > 1;
 
   return (
     <div className="space-y-4">
@@ -477,7 +513,7 @@ function SecretsTab({ groupId }: { groupId: string }) {
       ) : (
         <div className="space-y-2">
           {findings.map((f) => (
-            <SecretFindingRow key={f.entity_id} f={f} />
+            <SecretFindingRow key={f.entity_id} f={f} multiRepo={multiRepo} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
On the Security route (`webui-v2/src/routes/security.tsx`), the 'Ranked findings' (Auth coverage tab) and Secrets lists showed each finding's repo badge **twice** per row — once via an explicit left-side `RepoChip` and again inside `RefLine`, which always renders its own right-anchored repo chip. The rows were also free-flowing flex, so refs and badges didn't line up across rows.

## Changes
- **Dedupe the repo badge.** Added an optional `showRepoChip` prop to `RefLine` (default `true`, backward-compatible) so callers that already render the repo elsewhere can suppress the internal chip. The Security view now gates the repo badge on a multi-repo group (`new Set(findings.map(f => f.repo)).size > 1`, matching the dashboard's `repos.length > 1` convention) and renders it **once on the left**; `RefLine`'s right chip is suppressed. Single-repo groups show no repo badge at all.
- **Fixed-width columns.** Both finding rows now use CSS grid:
  - Primary line: `[lock] [VERB] [path …] [badges]` (auth) / `[key] [name …] [badges]` (secrets).
  - Secondary line: a fixed `8rem` leading column for the repo badge followed by the source-file ref, so refs align across rows like a table.
- Severity filter (All/High/Medium/Low), finding messages, and click behavior are unchanged.

Pure dashboard change. Epic #4493.

## Gates
- `npm ci` — clean
- `npm run build` (tsc + vite) — pass
- `npm run lint` (tsc --noEmit) — pass

Closes #4500

🤖 Generated with [Claude Code](https://claude.com/claude-code)