### PR TITLE
fix(iac): resolve depends-on chip names + wrap overflowing chip row (#4495)

### DIFF
--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -95,6 +95,14 @@ type IaCRelation struct {
 	Direction string `json:"direction"`
 	// Target is the human-readable name (logical id) of the other endpoint.
 	Target string `json:"target"`
+	// TargetResolved is true when Target is a graph-resolved entity name, false
+	// when it is a fallback derived from the raw entity id (the endpoint was not
+	// found among the indexed entities). The UI uses this to render a friendlier
+	// label + an id tooltip instead of a meaningless hash. (#4495)
+	TargetResolved bool `json:"target_resolved"`
+	// TargetID is the raw graph entity id of the other endpoint, always set so
+	// the UI can show it on hover regardless of resolution. (#4495)
+	TargetID string `json:"target_id"`
 	// Detail is the grant method (for grants) or other edge qualifier, when set.
 	Detail string `json:"detail,omitempty"`
 }
@@ -390,6 +398,15 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 
 		// Pass 1: collect IaC resource entities (+ count outputs).
 		iterEntities(func(id, name, kind, subtype, sourceFile, language string, startLine int, props map[string]string) {
+			// Index a readable name for EVERY entity, not just collected IaC
+			// resources, so relation targets resolve to a display name even when
+			// the target endpoint is not itself rendered as a resource row
+			// (e.g. a Terraform variable, an output, or a resource excluded by
+			// the tool/category filter). #4495: without this, such targets fall
+			// back to idTail() — which surfaces a raw entity-id hash to the user.
+			if name != "" {
+				nameByID[id] = name
+			}
 			if iacIsOutputEntity(kind, subtype, props) {
 				report.TotalOutputs++
 				// outputs are counted but not rendered as standalone rows.
@@ -457,29 +474,38 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 			}
 			facet, detail := iacRelationFacet(kind, props)
 
-			targetName := func(id string) string {
+			// targetName resolves an endpoint id to a display name. resolved is
+			// false when no indexed entity name was found and we fell back to a
+			// segment of the raw id (#4495).
+			targetName := func(id string) (name string, resolved bool) {
 				if n, ok := nameByID[id]; ok && n != "" {
-					return n
+					return n, true
 				}
-				return idTail(id)
+				return idTail(id), false
 			}
 
 			if fromRes != nil {
+				name, resolved := targetName(toID)
 				fromRes.Relations = append(fromRes.Relations, IaCRelation{
-					Facet:     facet,
-					Kind:      kind,
-					Direction: "out",
-					Target:    targetName(toID),
-					Detail:    detail,
+					Facet:          facet,
+					Kind:           kind,
+					Direction:      "out",
+					Target:         name,
+					TargetResolved: resolved,
+					TargetID:       toID,
+					Detail:         detail,
 				})
 			}
 			if toRes != nil && toRes != fromRes {
+				name, resolved := targetName(fromID)
 				toRes.Relations = append(toRes.Relations, IaCRelation{
-					Facet:     facet,
-					Kind:      kind,
-					Direction: "in",
-					Target:    targetName(fromID),
-					Detail:    detail,
+					Facet:          facet,
+					Kind:           kind,
+					Direction:      "in",
+					Target:         name,
+					TargetResolved: resolved,
+					TargetID:       fromID,
+					Detail:         detail,
 				})
 			}
 

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2083,6 +2083,14 @@ export interface IaCRelation {
   direction: string;
   /** Human-readable name (logical id) of the other endpoint. */
   target: string;
+  /**
+   * True when `target` is a graph-resolved entity name; false when it is a
+   * fallback derived from the raw entity id (endpoint not found among indexed
+   * entities). Drives a friendlier label + id tooltip in the UI (#4495).
+   */
+  target_resolved: boolean;
+  /** Raw graph entity id of the other endpoint; shown on hover (#4495). */
+  target_id: string;
   /** Grant method or other edge qualifier, when set. */
   detail?: string;
 }

--- a/webui-v2/src/routes/iac.tsx
+++ b/webui-v2/src/routes/iac.tsx
@@ -106,20 +106,46 @@ function relationMeta(facet: string): {
   }
 }
 
+/** Short hex hash like `483f81a80cea83a1` — an unresolved raw entity id. */
+function isRawId(s: string): boolean {
+  return /^[0-9a-f]{12,}$/i.test(s);
+}
+
 function RelationBadge({ relation }: { relation: IaCRelation }) {
   const { label, tone, Icon } = relationMeta(relation.facet);
   const arrow = relation.direction === "in" ? "←" : "→";
   const detail = relation.detail ? `.${relation.detail}` : "";
+
+  // #4495: when the backend could not resolve the endpoint to a display name
+  // (target_resolved === false), the target is a meaningless raw entity-id
+  // hash. Render a friendlier fallback — the relation kind as the label, with
+  // the raw id available on hover — instead of dumping the hash inline.
+  const unresolved =
+    relation.target_resolved === false || isRawId(relation.target);
+  const display = unresolved
+    ? relation.kind.toLowerCase().replace(/_/g, " ")
+    : relation.target;
+  const rawId = relation.target_id || relation.target;
+
   return (
     <Badge
       tone={tone}
-      className="inline-flex items-center gap-1"
-      title={`${label}${detail} ${arrow} ${relation.target} (${relation.kind})`}
+      className="inline-flex items-center gap-1 max-w-full min-w-0"
+      title={
+        unresolved
+          ? `${label}${detail} ${arrow} <unresolved ${relation.kind} target> (id ${rawId})`
+          : `${label}${detail} ${arrow} ${relation.target} (${relation.kind})`
+      }
     >
-      <Icon size={11} />
-      <span className="lowercase">{label}</span>
-      <span className="font-mono opacity-70">
-        {arrow} {relation.target}
+      <Icon size={11} className="shrink-0" />
+      <span className="lowercase shrink-0">{label}</span>
+      <span
+        className={cn(
+          "font-mono opacity-70 truncate",
+          unresolved && "italic",
+        )}
+      >
+        {arrow} {display}
       </span>
     </Badge>
   );
@@ -193,15 +219,22 @@ function ResourceRow({ resource }: { resource: IaCResource }) {
             {resource.resource_type}
           </span>
         )}
-
-        {resource.relations.length > 0 && (
-          <div className="ml-auto flex items-center gap-1.5 shrink-0 flex-wrap justify-end">
-            {resource.relations.map((rel, i) => (
-              <RelationBadge key={`${rel.facet}:${rel.target}:${i}`} relation={rel} />
-            ))}
-          </div>
-        )}
       </div>
+
+      {/* Relation facets (grants / event-sources / dependencies / topology).
+          #4495: own full-width wrapping row so chips never overflow the card
+          edge — they wrap to multiple lines and each chip truncates long
+          targets internally. */}
+      {resource.relations.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5 min-w-0">
+          {resource.relations.map((rel, i) => (
+            <RelationBadge
+              key={`${rel.facet}:${rel.target_id || rel.target}:${i}`}
+              relation={rel}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Typed config properties */}
       {resource.properties.length > 0 && (


### PR DESCRIPTION
Closes #4495 (ref epic #4493).

## Problem
On the IaC / Infrastructure view (`/iac`), each resource card shows `depends on → <target>` and `topology ←` chips. Two issues, both live on upvate-v3:

1. Some `depends on → <hash>` chips render **raw entity-id hashes** (e.g. `483f81a80cea83a1`) instead of a readable name like `aws_sqs_queue.dlq`.
2. The chip row **overflows** off the right edge of the card and gets clipped.

## Finding: frontend vs data
This is primarily a **data/backend** bug, not just rendering. `IaCRelation.target` is the only name the UI receives, and `handleIaC` only indexed display names (`nameByID`) for entities it collected as IaC resource rows. `DEPENDS_ON` / `USES` edges whose endpoint is **not** a rendered row — Terraform variables, outputs, or resources excluded by the active tool/category filter — fell through to `idTail(targetID)`. For hash-form entity ids that returns the bare hash. The resolvable name existed in the graph; the handler discarded it.

## Backend (`internal/dashboard/handlers_iac.go`)
- Pass 1 now indexes a readable name for **every** visited entity (not only collected IaC resources), so relation targets resolve to a display name even when the endpoint isn't itself a row.
- Added `IaCRelation.target_resolved` + `target_id`. Any target that *still* can't be resolved (genuinely cross-repo / pruned endpoints) is flagged so the UI can render a friendly fallback with the raw id on hover, rather than dumping a hash.

## Frontend (`webui-v2/src/routes/iac.tsx`)
- `RelationBadge`: when `target_resolved === false` (or the target is hash-shaped), show the relation **kind** in italics with the raw id in the tooltip instead of the hash.
- Moved the relation chips into their own full-width `flex-wrap` row and truncate long targets inside each chip (`max-w-full min-w-0 truncate`), so the row wraps to multiple lines and never clips the card edge.

## Backend follow-up
The remaining unresolved-target cases are now self-documenting via `target_resolved=false` / `target_id` in the API payload — anyone auditing `/iac` can see exactly which `depends_on` endpoints arrive without an indexed entity (cross-repo references, pruned/uncollected entities). If epic #4493 wants these eliminated at the source, the IaC extractor should emit a resolved logical name on the edge for cross-repo / external endpoints; the dashboard already surfaces every remaining case explicitly.

## Gates
- Backend: `go build ./internal/dashboard/` + `go vet` clean.
- Frontend: `npm ci` + `npm run build` + `npm run lint` (tsc) all pass.

DEPLOY-DEFERRED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)