### PR TITLE
fix(auth): reconcile endpoint auth posture — inherited-guard routes no longer flagged NO-AUTH

### DIFF
--- a/internal/dashboard/auth_posture_conflict_test.go
+++ b/internal/dashboard/auth_posture_conflict_test.go
@@ -1,0 +1,62 @@
+// auth_posture_conflict_test.go — reconcile regression for the contradictory
+// auth-posture dual badge (#auth-posture-conflict).
+//
+// The dashboard security/auth-coverage panel computes its own has_auth verdict
+// via hasAuthProperty. Before the fix it read only the raw per-method signal
+// keys (auth_decorator/auth_middleware/auth_annotation) and so reported NO-AUTH
+// for a route gated only by an INHERITED controller/global guard — even though
+// the engine had already reconciled it to auth_required=true and the posture
+// surface showed it authenticated. These tests feed the EXACT property shape the
+// engine stamps and assert the panel agrees.
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestHasAuthProperty_InheritedGuardPosture(t *testing.T) {
+	// The shape the engine stamps for DELETE /v1/checklists/{checklistId}: gated
+	// only by the inherited controller-level @RequirePage guard — no own
+	// decorator, so none of the legacy raw signal keys are present.
+	e := &graph.Entity{Properties: map[string]string{
+		"auth_required": "true",
+		"auth_method":   "guard",
+		"auth_guard":    "@RequirePage(PermissionPage.Checklists)",
+		"auth_confidence": "medium",
+		"verb":          "DELETE",
+		"path":          "/v1/checklists/{checklistId}",
+	}}
+	has, ev := hasAuthProperty(e)
+	if !has {
+		t.Fatalf("inherited-guard route reported NO-AUTH (the dual-badge bug); evidence=%q", ev)
+	}
+}
+
+func TestHasAuthProperty_ExplicitPublicIsUncovered(t *testing.T) {
+	// @Public() route: decisive public verdict. Genuinely unauthenticated by
+	// design — must NOT be counted as covered (and must not error: it's
+	// intentional, the posture is coherent, just public).
+	e := &graph.Entity{Properties: map[string]string{
+		"auth_required":   "false",
+		"auth_method":     "config",
+		"auth_confidence": "high",
+		"verb":            "GET",
+		"path":            "/v1/checklists/{checklistId}/items",
+	}}
+	if has, ev := hasAuthProperty(e); has {
+		t.Errorf("explicit @Public() route reported covered (evidence=%q) — should be uncovered-by-design", ev)
+	}
+}
+
+func TestHasAuthProperty_RawGuardSignalStillWorks(t *testing.T) {
+	// Method-level @UseGuards with a guard stamp but no auth_required (older index
+	// shape) still resolves authed via the raw signal-key fallback.
+	e := &graph.Entity{Properties: map[string]string{
+		"auth_guard": "JwtAuthGuard",
+	}}
+	if has, _ := hasAuthProperty(e); !has {
+		t.Errorf("auth_guard raw signal no longer resolves to authed")
+	}
+}

--- a/internal/dashboard/handlers_security.go
+++ b/internal/dashboard/handlers_security.go
@@ -137,7 +137,31 @@ func isEndpointKind(kind string) bool {
 }
 
 func hasAuthProperty(e *graph.Entity) (bool, string) {
-	for _, k := range []string{"auth_decorator", "auth_middleware", "auth_annotation"} {
+	// Authoritative reconciled posture first. The engine auth resolvers
+	// (Nest @UseGuards / @RequirePage / @RequireAction / @Authenticated, Spring
+	// Security, Quarkus, gRPC/tRPC interceptors, …) collapse every method-,
+	// controller- and global-level signal — including @Public exemptions — into a
+	// single `auth_required` verdict + an `auth_method`/`auth_guard` evidence
+	// stamp. When that verdict says the route IS authenticated, it MUST win:
+	// otherwise an endpoint gated only by an INHERITED controller/global guard
+	// (no own @UseGuards/decorator, so none of the raw signal keys below are set)
+	// is mislabelled NO-AUTH while the posture surface simultaneously shows it as
+	// authenticated — the contradictory dual badge (#auth-posture-conflict).
+	//
+	// auth_required=="false" is a DECISIVE public verdict (an explicit @Public /
+	// AllowAny / permitAll) — genuinely unauthenticated, so it deliberately does
+	// NOT count as covered here and falls through to the raw-signal checks (which
+	// will also find nothing) so the route is reported uncovered-by-design.
+	if e.Properties["auth_required"] == "true" {
+		if g := e.Properties["auth_guard"]; g != "" {
+			return true, "auth_guard=" + g
+		}
+		if m := e.Properties["auth_method"]; m != "" && m != "unknown" {
+			return true, "auth_method=" + m
+		}
+		return true, "auth_required=true"
+	}
+	for _, k := range []string{"auth_decorator", "auth_middleware", "auth_guard", "auth_annotation"} {
 		if v := e.Properties[k]; v != "" && v != "false" {
 			return true, k + "=" + v
 		}

--- a/internal/engine/http_endpoint_jsts_auth_posture_conflict_test.go
+++ b/internal/engine/http_endpoint_jsts_auth_posture_conflict_test.go
@@ -1,0 +1,97 @@
+// http_endpoint_jsts_auth_posture_conflict_test.go — regression for the
+// contradictory auth-posture dual badge (#auth-posture-conflict).
+//
+// On core-backend-v3, `DELETE /v1/checklists/{checklistId}` rendered BOTH a red
+// "NO-AUTH · sensitive" badge AND a green "Auth · Bearer" badge. The method
+// carries no own auth decorator — it inherits the CONTROLLER-level
+// `@RequirePage(PermissionPage.Checklists)` guard. The engine resolver already
+// reconciles that into a single authoritative posture (auth_required=true,
+// auth_method=guard, auth_guard=@RequirePage(...)); the bug was downstream
+// coverage code reading only the raw per-method signal keys and missing it.
+//
+// This test runs the REAL detector pipeline on a byte-copy of the controller and
+// asserts the resolved posture is internally coherent: the inherited-guard route
+// is AUTHENTICATED (so no consumer can call it NO-AUTH), and the explicit
+// @Public() route is decisively public — never both.
+package engine
+
+import "testing"
+
+// checklistControllerV3 is a byte-faithful copy of the decorator structure of
+// core-backend-v3 src/modules/checklists/api/checklist.controller.ts (bodies
+// elided — only the routing/auth decorators are load-bearing for this pass).
+const checklistControllerV3 = `
+import { Public, RequirePage } from '../../../common/auth/decorators/auth.decorators';
+import { PermissionPage } from '../../../common/auth/permission-page.enum';
+
+@Controller({ path: 'checklists', version: '1' })
+@RequirePage(PermissionPage.Checklists)
+export class ChecklistController {
+  constructor(private readonly service: ChecklistService) {}
+
+  @Get()
+  list(): Promise<any> { return null; }
+
+  @Get(':checklistId')
+  retrieve(): Promise<any> { return null; }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(): Promise<any> { return null; }
+
+  @Put(':checklistId')
+  update(): Promise<any> { return null; }
+
+  @Delete(':checklistId')
+  @HttpCode(HttpStatus.OK)
+  destroy(): Promise<any> { return null; }
+
+  @Get(':checklistId/items')
+  @Public()
+  getItems(): Promise<any> { return null; }
+}
+`
+
+func TestAuthPostureConflict_ChecklistInheritedGuard(t *testing.T) {
+	eps := authProps(t, "typescript", "src/modules/checklists/api/checklist.controller.ts", checklistControllerV3)
+
+	// The reported endpoint: gated only by the inherited controller-level
+	// @RequirePage guard (no own decorator). It MUST resolve to authenticated
+	// with a guard evidence stamp — never NO-AUTH.
+	del, ok := eps["DELETE /v1/checklists/{checklistId}"]
+	if !ok {
+		t.Fatalf("DELETE endpoint not synthesised (got: %v)", keysOf(eps))
+	}
+	if del.Properties["auth_required"] != "true" {
+		t.Errorf("DELETE: auth_required=%q, want true — inherited @RequirePage guard (props: %v)",
+			del.Properties["auth_required"], del.Properties)
+	}
+	if del.Properties["auth_method"] != "guard" {
+		t.Errorf("DELETE: auth_method=%q, want guard", del.Properties["auth_method"])
+	}
+	// A guard evidence symbol must be stamped so a coverage consumer that keys on
+	// the raw signal-1 property (not just auth_required) also resolves to authed —
+	// reconciliation belt-and-braces.
+	if del.Properties["auth_guard"] == "" {
+		t.Errorf("DELETE: auth_guard not stamped — coverage would mislabel NO-AUTH (props: %v)",
+			del.Properties)
+	}
+
+	// Mutual exclusivity: an authenticated route must NOT also carry an
+	// explicit-public verdict (auth_required=false). The two are reconciled into
+	// one posture.
+	if del.Properties["auth_required"] == "false" {
+		t.Errorf("DELETE: carries BOTH authed and public verdicts — the contradiction this fixes")
+	}
+
+	// The explicit @Public() route is decisively public (genuine no-auth by
+	// design) — the opposite, equally-coherent verdict.
+	items, ok := eps["GET /v1/checklists/{checklistId}/items"]
+	if !ok {
+		t.Fatalf("GET items endpoint not synthesised (got: %v)", keysOf(eps))
+	}
+	if items.Properties["auth_required"] != "false" {
+		t.Errorf("GET items: auth_required=%q, want false — explicit @Public() overrides inherited guard (props: %v)",
+			items.Properties["auth_required"], items.Properties)
+	}
+}

--- a/internal/mcp/auth_coverage.go
+++ b/internal/mcp/auth_coverage.go
@@ -690,6 +690,30 @@ func determineAuthCoverage(
 	drfDefaultProtected bool,
 	drfDefaultEvidence string,
 ) (bool, string) {
+	// Signal 0: the authoritative reconciled posture. The engine auth resolvers
+	// (Nest @UseGuards / @RequirePage / @RequireAction / @Authenticated, Spring
+	// Security, Quarkus, gRPC/tRPC interceptors, …) collapse every method-,
+	// controller- and global-level signal — including @Public exemptions — into a
+	// single `auth_required` verdict plus an `auth_method`/`auth_guard` evidence
+	// stamp. When that verdict says the route IS authenticated it MUST win, so an
+	// endpoint gated only by an INHERITED controller/global guard (no own
+	// decorator, so none of the raw signal-1 keys below are set) is never
+	// mislabelled NO-AUTH while the endpoint_posture surface simultaneously shows
+	// it authenticated — the contradictory dual badge (#auth-posture-conflict).
+	//
+	// auth_required=="false" is a DECISIVE public verdict (explicit @Public /
+	// AllowAny / permitAll): genuinely unauthenticated by design, so it does NOT
+	// count as covered and falls through (no raw signal will rescue it).
+	if e.Properties["auth_required"] == "true" {
+		if g := e.Properties["auth_guard"]; g != "" {
+			return true, "auth_guard=" + g
+		}
+		if m := e.Properties["auth_method"]; m != "" && m != "unknown" {
+			return true, "auth_method=" + m
+		}
+		return true, "auth_required=true"
+	}
+
 	// Signal 1: entity property directly on the endpoint.
 	for _, k := range authPropertyKeys {
 		if v := e.Properties[k]; v != "" {

--- a/internal/mcp/auth_coverage_posture_conflict_test.go
+++ b/internal/mcp/auth_coverage_posture_conflict_test.go
@@ -1,0 +1,53 @@
+// auth_coverage_posture_conflict_test.go — reconcile regression for the
+// contradictory auth-posture dual badge (#auth-posture-conflict).
+//
+// archigraph_auth_coverage's determineAuthCoverage must honor the engine's
+// authoritative reconciled posture (auth_required=true): a route gated only by
+// an INHERITED controller/global guard carries no own decorator, so the raw
+// signal-1 keys are absent, yet it IS authenticated and must not be flagged
+// NO-AUTH while archigraph_endpoint_posture shows it authenticated.
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestDetermineAuthCoverage_InheritedGuardPosture(t *testing.T) {
+	e := &graph.Entity{Properties: map[string]string{
+		"auth_required": "true",
+		"auth_method":   "guard",
+		"auth_guard":    "@RequirePage(PermissionPage.Checklists)",
+		"verb":          "DELETE",
+		"path":          "/v1/checklists/{checklistId}",
+	}}
+	has, ev := determineAuthCoverage(e, nil, nil, nil, false, "")
+	if !has {
+		t.Fatalf("inherited-guard route reported NO-AUTH (dual-badge bug); evidence=%q", ev)
+	}
+}
+
+func TestDetermineAuthCoverage_ExplicitPublicUncovered(t *testing.T) {
+	e := &graph.Entity{Properties: map[string]string{
+		"auth_required": "false",
+		"auth_method":   "config",
+		"verb":          "GET",
+		"path":          "/v1/checklists/{checklistId}/items",
+	}}
+	if has, ev := determineAuthCoverage(e, nil, nil, nil, false, ""); has {
+		t.Errorf("explicit @Public() route reported covered (evidence=%q)", ev)
+	}
+}
+
+func TestDetermineAuthCoverage_AuthRequiredOnlyStamp(t *testing.T) {
+	// gRPC/tRPC interceptor case: auth_required=true with an auth_method but no
+	// guard symbol still reconciles to authed.
+	e := &graph.Entity{Properties: map[string]string{
+		"auth_required": "true",
+		"auth_method":   "grpc_interceptor",
+	}}
+	if has, _ := determineAuthCoverage(e, nil, nil, nil, false, ""); !has {
+		t.Errorf("auth_required=true (interceptor) not honored as authed")
+	}
+}


### PR DESCRIPTION
## Problem

`DELETE /v1/checklists/{checklistId}` (upvate core-backend-v3) renders BOTH a red `NO-AUTH · sensitive` badge AND a green `Auth · Bearer` badge — contradictory. The method has no own auth decorator; it inherits the controller-level `@RequirePage(PermissionPage.Checklists)` guard, so it IS authenticated.

## Where the conflicting signals come from

The engine resolver already reconciles method/controller/global guards (incl. `@Public` exemptions) into a single authoritative posture: `auth_required=true, auth_method=guard, auth_guard=@RequirePage(...)`. `archigraph_endpoint_posture` / `buildPosturePayload` surface that → the green badge.

But TWO separate coverage implementations decide NO-AUTH independently and never read the reconciled posture — they only checked the *raw per-method* signal keys:
- `internal/dashboard/handlers_security.go` → `hasAuthProperty` (only `auth_decorator`/`auth_middleware`/`auth_annotation`) — feeds the security panel's red badge.
- `internal/mcp/auth_coverage.go` → `determineAuthCoverage` signal-1 (had `auth_guard` but lacked `auth_required`/`auth_method`).

An inherited-guard route sets none of those raw keys on the method → both fall through to NO-AUTH, contradicting the posture.

## Fix (reconcile + precedence)

Both coverage paths now consult the engine's single reconciled posture FIRST:
- `auth_required=true` ⇒ AUTHENTICATED, with `auth_guard`/`auth_method` as evidence — never NO-AUTH.
- `auth_required=false` ⇒ decisive public verdict (`@Public`/AllowAny/permitAll) — uncovered-by-design, not a contradiction.
- NO-AUTH now means genuinely no auth signal anywhere in the method/controller/global guard stack.
- `sensitive` (data-sensitivity) is orthogonal and untouched.

## Generalization

The reconcile keys on the language-agnostic `auth_required` posture the engine stamps for Nest/Spring/Quarkus/gRPC/tRPC/etc., so the contradiction is fixed for **all** frameworks, not just NestJS.

## Before / after (in-pipeline test)

New `TestAuthPostureConflict_ChecklistInheritedGuard` runs the REAL detector on a byte-copy of core-backend-v3 `checklist.controller.ts`:
- DELETE inherited-guard route → `auth_required=true, auth_method=guard, auth_guard=@RequirePage(...)` (authed, single posture).
- `@Public()` items route → `auth_required=false` (decisive public).

Reconcile unit tests (`internal/dashboard/auth_posture_conflict_test.go`, `internal/mcp/auth_coverage_posture_conflict_test.go`) feed the engine-stamped property shape. **Before fix:** `hasAuthProperty` returns NO-AUTH (`evidence=""`) → test FAILs, reproducing the dual badge. **After fix:** authed → PASS.

## Gates

- `go build ./...` ✓
- `go vet ./internal/{engine,dashboard,mcp}` ✓
- `go test ./internal/{engine,dashboard,mcp}` ✓ (all pass)

Live dashboard reflection needs a reindex — **DEPLOY-DEFERRED**.

Closes #4508

🤖 Generated with [Claude Code](https://claude.com/claude-code)