### PR TITLE
Resolve THROWS/CATCHES to the real exception class and drop the duplicate synthetic node

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1387,6 +1387,20 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	}
 	i.stats.extSynth = extStats
 
+	// #4480 — retarget THROWS / CATCHES edges from the synthetic
+	// SCOPE.ExceptionType convergence node to the REAL exception class entity
+	// (declared in-repo class, or the imported `ext:<Type>` placeholder just
+	// synthesised above), and drop the now-redundant synthetic node. Runs
+	// AFTER external.Synthesize so imported exception classes are present.
+	// Keeps exactly one node per exception with the throws/catches edge on it;
+	// the synthetic node survives only for genuinely unresolvable types.
+	excStats := external.ResolveExceptionTypes(doc)
+	if verbose() {
+		fmt.Fprintf(os.Stderr,
+			"exception-resolve: retargeted=%d synthetic_dropped=%d synthetic_kept=%d\n",
+			excStats.Retargeted, excStats.SyntheticDropped, excStats.SyntheticKept)
+	}
+
 	// Issue #1381 — stamp module="_external" on synthesised placeholder
 	// entities that have no source_file (ext:* nodes from external.Synthesize,
 	// and any other synthetic entities that buildDocument could not tag because

--- a/internal/external/exception_resolve.go
+++ b/internal/external/exception_resolve.go
@@ -1,0 +1,214 @@
+package external
+
+import (
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// exception_resolve.go — synthesis-time retarget of THROWS / CATCHES edges
+// from the synthetic SCOPE.ExceptionType convergence node to the REAL
+// exception class entity when one exists in the graph (#4480).
+//
+// PROBLEM. Every language extractor that detects a typed throw/catch emits a
+// file-agnostic SCOPE.ExceptionType node (Name "exception:<Type>", SourceFile
+// "<exception>") so the same type raised in one file and caught in another
+// converges on a single node (see internal/extractor/exception_flow.go). But
+// the SAME exception is ALSO a real entity: a `throw new NotFoundException()`
+// emits a constructor CALLS edge whose target the external-synthesis pass
+// materialises as `ext:NotFoundException` (imported 3rd-party class), and a
+// locally-declared `class NotFound(Exception)` is an in-repo class entity.
+// The graph therefore holds TWO nodes for one exception, and the THROWS edge
+// lands on the synthetic one — never on the real class.
+//
+// FIX (long-term, language-agnostic, merge-stable). After the real class
+// entities exist in the document (declared classes are present from extraction;
+// imported externals are present after external.Synthesize), walk every
+// SCOPE.ExceptionType node. If exactly one NON-synthetic entity shares its
+// type name (a declared class/interface, or an `ext:` external class), retarget
+// every THROWS / CATCHES edge from the synthetic node to that real entity and
+// DROP the synthetic node. When no real entity exists (a genuinely external
+// 3rd-party type that was never constructed in-repo, so no `ext:` node was
+// synthesised) the synthetic node is kept — exactly one node per exception,
+// never both.
+//
+// Merge-stable: resolution is by NAME through the fully-assembled symbol table
+// at synthesis time (mirrors the endpoint→handler #4319 synthesis-time-by-id
+// approach), not by any per-batch/per-file ID that could shift across
+// incremental re-indexes. The synthetic node's identity (SourceFile+Kind+Name)
+// and the real entity's identity are both deterministic, so the retarget is
+// idempotent and stable across runs.
+//
+// Precision-first: if a type name is ambiguous (two distinct real classes with
+// the same leaf name) the synthetic node is kept — a wrong retarget would
+// mislead error-contract analysis worse than the duplicate node does.
+
+// ExceptionResolveStats reports how the exception-resolve pass touched the doc.
+type ExceptionResolveStats struct {
+	// Retargeted is the number of THROWS / CATCHES edges repointed from a
+	// synthetic SCOPE.ExceptionType node to the real exception class.
+	Retargeted int
+	// SyntheticDropped is the number of synthetic SCOPE.ExceptionType nodes
+	// removed because every inbound edge was retargeted to a real class.
+	SyntheticDropped int
+	// SyntheticKept is the number of synthetic SCOPE.ExceptionType nodes left
+	// in place because no unambiguous real class entity exists for them.
+	SyntheticKept int
+}
+
+// candidateKind reports whether kind is a real, declaration-backed entity that
+// can legitimately stand in for a thrown exception type — a declared class /
+// interface / struct (in-repo exception class) or a synthesised external
+// placeholder (imported 3rd-party exception class). Synthetic convergence nodes
+// (the SCOPE.ExceptionType node itself) and edge-only scopes are excluded.
+func candidateKind(kind string) bool {
+	switch kind {
+	case KindExternal,
+		string(types.EntityKindClass),
+		string(types.EntityKindComponent):
+		// SCOPE.Class covers declared classes/interfaces/structs across
+		// languages; SCOPE.Component is the file/module-level fallback some
+		// extractors use for a declared type; SCOPE.External is the
+		// synthesised placeholder for an imported 3rd-party exception class.
+		return true
+	}
+	return false
+}
+
+// ResolveExceptionTypes retargets THROWS / CATCHES edges to the real exception
+// class and drops the now-redundant synthetic SCOPE.ExceptionType node, for
+// every exception type that resolves to exactly one real entity. It is
+// idempotent and safe on a nil/empty document. MUST run AFTER external.Synthesize
+// so imported (`ext:`) exception classes are present.
+func ResolveExceptionTypes(doc *graph.Document) ExceptionResolveStats {
+	var stats ExceptionResolveStats
+	if doc == nil || len(doc.Entities) == 0 {
+		return stats
+	}
+
+	// Index every synthetic exception-type node by its type name, and collect
+	// real-class candidates by bare leaf name. The type name lives in
+	// Properties["exception_type"] (set by ExceptionTypeEntity); fall back to
+	// stripping the "exception:" Name prefix for robustness against older
+	// graphs carried forward by incremental merge.
+	type synthNode struct {
+		id       string // synthetic node's graph id
+		typeName string
+	}
+	var synthetics []synthNode
+	byTypeName := map[string][]string{} // typeName -> candidate real entity ids
+
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == string(types.EntityKindExceptionType) {
+			tn := ""
+			if e.Properties != nil {
+				tn = e.Properties["exception_type"]
+			}
+			if tn == "" {
+				tn = stripExceptionPrefix(e.Name)
+			}
+			if tn != "" {
+				synthetics = append(synthetics, synthNode{id: e.ID, typeName: tn})
+			}
+			continue
+		}
+		if candidateKind(e.Kind) && e.Name != "" {
+			byTypeName[e.Name] = append(byTypeName[e.Name], e.ID)
+		}
+	}
+	if len(synthetics) == 0 {
+		return stats
+	}
+
+	// For each synthetic node decide its real target (if unambiguous). Build a
+	// remap from synthetic-id -> real-id and the set of synthetic ids to drop.
+	remap := map[string]string{} // synthetic id -> real entity id
+	drop := map[string]bool{}    // synthetic ids to remove
+	for _, sn := range synthetics {
+		cands := byTypeName[sn.typeName]
+		// Deduplicate candidate ids (a class can appear once; guard anyway) and
+		// exclude the synthetic node itself defensively.
+		uniq := uniqueExcept(cands, sn.id)
+		if len(uniq) != 1 {
+			// Zero real candidates -> genuinely external/unresolvable: keep the
+			// synthetic node. More than one -> ambiguous leaf name: keep it
+			// (precision over a possibly-wrong retarget).
+			stats.SyntheticKept++
+			continue
+		}
+		remap[sn.id] = uniq[0]
+		drop[sn.id] = true
+		stats.SyntheticDropped++
+	}
+	if len(remap) == 0 {
+		return stats
+	}
+
+	// Retarget THROWS / CATCHES edges. Only these two kinds point at the
+	// synthetic exception-type node, but gate on kind so an unrelated edge that
+	// happens to reference the id (none today) is never silently moved.
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		if r.Kind != string(types.RelationshipKindThrows) &&
+			r.Kind != string(types.RelationshipKindCatches) {
+			continue
+		}
+		if real, ok := remap[r.ToID]; ok {
+			r.ToID = real
+			// Recompute the edge id so it stays the deterministic hash of its
+			// (FromID, ToID, Kind) — keeping incremental diffs and de-dup stable.
+			r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
+			stats.Retargeted++
+		}
+	}
+
+	// Drop the now-redundant synthetic nodes, preserving order.
+	if len(drop) > 0 {
+		kept := doc.Entities[:0]
+		for i := range doc.Entities {
+			if drop[doc.Entities[i].ID] {
+				continue
+			}
+			kept = append(kept, doc.Entities[i])
+		}
+		doc.Entities = kept
+	}
+
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+	return stats
+}
+
+// stripExceptionPrefix returns the bare type name from an "exception:<Type>"
+// node Name, or the input unchanged when the prefix is absent.
+func stripExceptionPrefix(name string) string {
+	const p = "exception:"
+	if len(name) > len(p) && name[:len(p)] == p {
+		return name[len(p):]
+	}
+	return name
+}
+
+// uniqueExcept returns the de-duplicated ids in s, excluding except, in stable
+// sorted order so the chosen target is deterministic across runs.
+func uniqueExcept(s []string, except string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if v == "" || v == except || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// compile-time reference so the extractor package's exception constants remain
+// the single source of truth for the node Name / target-id shapes this pass
+// reverses. (No runtime cost.)
+var _ = extractor.ExceptionTypeName

--- a/internal/external/exception_resolve_test.go
+++ b/internal/external/exception_resolve_test.go
@@ -1,0 +1,166 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func excType(id, typeName string) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Name:       "exception:" + typeName,
+		Kind:       string(types.EntityKindExceptionType),
+		SourceFile: "<exception>",
+		Properties: map[string]string{"exception_type": typeName},
+	}
+}
+
+func realClass(id, name string) graph.Entity {
+	return graph.Entity{ID: id, Name: name, Kind: string(types.EntityKindClass), SourceFile: "x.ts"}
+}
+
+func throwsRel(from, to string) graph.Relationship {
+	return graph.Relationship{
+		ID:     graph.RelationshipID(from, to, string(types.RelationshipKindThrows)),
+		FromID: from, ToID: to, Kind: string(types.RelationshipKindThrows),
+	}
+}
+
+func hasEntity(doc *graph.Document, id string) bool {
+	for i := range doc.Entities {
+		if doc.Entities[i].ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func throwsTo(doc *graph.Document) string {
+	for _, r := range doc.Relationships {
+		if r.Kind == string(types.RelationshipKindThrows) {
+			return r.ToID
+		}
+	}
+	return ""
+}
+
+// Retargets to the unique real class and drops the synthetic node.
+func TestResolveExceptionTypes_RetargetAndDrop(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn", Name: "f", Kind: string(types.EntityKindFunction)},
+			realClass("cls", "MyError"),
+			excType("exc", "MyError"),
+		},
+		Relationships: []graph.Relationship{throwsRel("fn", "exc")},
+	}
+	st := ResolveExceptionTypes(doc)
+	if st.Retargeted != 1 || st.SyntheticDropped != 1 || st.SyntheticKept != 0 {
+		t.Fatalf("stats: %+v", st)
+	}
+	if hasEntity(doc, "exc") {
+		t.Fatal("synthetic node should be dropped")
+	}
+	if throwsTo(doc) != "cls" {
+		t.Fatalf("THROWS should target real class, got %s", throwsTo(doc))
+	}
+}
+
+// No real entity → keep the single synthetic node.
+func TestResolveExceptionTypes_KeepWhenUnresolvable(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn", Name: "f", Kind: string(types.EntityKindFunction)},
+			excType("exc", "ThirdPartyError"),
+		},
+		Relationships: []graph.Relationship{throwsRel("fn", "exc")},
+	}
+	st := ResolveExceptionTypes(doc)
+	if st.Retargeted != 0 || st.SyntheticDropped != 0 || st.SyntheticKept != 1 {
+		t.Fatalf("stats: %+v", st)
+	}
+	if !hasEntity(doc, "exc") {
+		t.Fatal("synthetic node should be kept")
+	}
+	if throwsTo(doc) != "exc" {
+		t.Fatalf("THROWS should stay on synthetic, got %s", throwsTo(doc))
+	}
+}
+
+// Ambiguous leaf name (two real classes) → keep synthetic (precision).
+func TestResolveExceptionTypes_AmbiguousKept(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn", Name: "f", Kind: string(types.EntityKindFunction)},
+			realClass("cls1", "Dup"),
+			realClass("cls2", "Dup"),
+			excType("exc", "Dup"),
+		},
+		Relationships: []graph.Relationship{throwsRel("fn", "exc")},
+	}
+	st := ResolveExceptionTypes(doc)
+	if st.SyntheticKept != 1 || st.SyntheticDropped != 0 {
+		t.Fatalf("ambiguous should keep synthetic: %+v", st)
+	}
+	if throwsTo(doc) != "exc" {
+		t.Fatalf("THROWS should stay on synthetic, got %s", throwsTo(doc))
+	}
+}
+
+// CATCHES edges are retargeted too, and the pass is idempotent.
+func TestResolveExceptionTypes_CatchesAndIdempotent(t *testing.T) {
+	catch := graph.Relationship{
+		ID:     graph.RelationshipID("h", "exc", string(types.RelationshipKindCatches)),
+		FromID: "h", ToID: "exc", Kind: string(types.RelationshipKindCatches),
+	}
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			realClass("cls", "E"),
+			excType("exc", "E"),
+		},
+		Relationships: []graph.Relationship{throwsRel("t", "exc"), catch},
+	}
+	st := ResolveExceptionTypes(doc)
+	if st.Retargeted != 2 || st.SyntheticDropped != 1 {
+		t.Fatalf("want 2 retargeted (throws+catches): %+v", st)
+	}
+	for _, r := range doc.Relationships {
+		if r.ToID != "cls" {
+			t.Fatalf("edge %s not retargeted: to=%s", r.Kind, r.ToID)
+		}
+	}
+	// Second run is a no-op (synthetic already gone).
+	st2 := ResolveExceptionTypes(doc)
+	if st2.Retargeted != 0 || st2.SyntheticDropped != 0 {
+		t.Fatalf("idempotency: second run mutated: %+v", st2)
+	}
+}
+
+// SCOPE.Component (declared-type fallback some extractors use) is a candidate.
+func TestResolveExceptionTypes_ComponentCandidate(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "comp", Name: "CompError", Kind: string(types.EntityKindComponent), SourceFile: "a.ts"},
+			excType("exc", "CompError"),
+		},
+		Relationships: []graph.Relationship{throwsRel("t", "exc")},
+	}
+	st := ResolveExceptionTypes(doc)
+	if st.Retargeted != 1 || st.SyntheticDropped != 1 {
+		t.Fatalf("component candidate: %+v", st)
+	}
+	if throwsTo(doc) != "comp" {
+		t.Fatalf("THROWS should target component, got %s", throwsTo(doc))
+	}
+}
+
+func TestResolveExceptionTypes_NilSafe(t *testing.T) {
+	if st := ResolveExceptionTypes(nil); st.Retargeted != 0 {
+		t.Fatal("nil doc must be safe")
+	}
+	if st := ResolveExceptionTypes(&graph.Document{}); st.Retargeted != 0 {
+		t.Fatal("empty doc must be safe")
+	}
+}

--- a/internal/external/testdata/client_repository_4480.ts
+++ b/internal/external/testdata/client_repository_4480.ts
@@ -1,0 +1,110 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Client } from '../models/client.entity';
+import { Proposal } from '../../proposals/models/proposal.entity';
+import { ClientUpdateDto } from '../dto/request/client-update.dto';
+
+export interface ClientListFilters {
+  groupId?: number;
+  filterBySearch?: string;
+  excludeAddressFromSearch?: boolean;
+  activeOnly?: boolean;
+  recentOnly?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedClients {
+  count: number;
+  items: Client[];
+}
+
+export interface PaginatedClientContracts {
+  count: number;
+  items: Proposal[];
+}
+
+@Injectable()
+export class ClientRepository {
+  constructor(
+    @InjectRepository(Client)
+    private readonly repository: Repository<Client>,
+    @InjectRepository(Proposal)
+    private readonly proposalRepository: Repository<Proposal>,
+  ) {}
+
+  async findPaginated(filters: ClientListFilters): Promise<PaginatedClients> {
+    const qb: SelectQueryBuilder<Client> = this.repository.createQueryBuilder('client').distinct(true);
+
+    if (filters.groupId !== undefined) {
+      qb.andWhere('client.group_id = :groupId', { groupId: filters.groupId });
+    }
+
+    if (filters.filterBySearch) {
+      const search = `%${filters.filterBySearch}%`;
+      if (filters.excludeAddressFromSearch) {
+        qb.leftJoin('client.proposals', 'contract').andWhere('(client.name ILIKE :search OR contract.contract_number ILIKE :search)', { search });
+      } else {
+        qb.leftJoin('client.proposals', 'contract').andWhere(
+          '(client.name ILIKE :search OR client.street_line_1 ILIKE :search OR client.street_line_2 ILIKE :search OR contract.contract_number ILIKE :search)',
+          { search },
+        );
+      }
+    }
+
+    if (filters.activeOnly) {
+      qb.andWhere('client.status = :status', { status: 'active' });
+    }
+
+    if (filters.recentOnly) {
+      const count = await qb.getCount();
+      const items = await qb.orderBy('client.modified', 'DESC').limit(10).getMany();
+      return { count, items };
+    }
+
+    const limit = filters.limit ?? 100;
+    const offset = filters.offset ?? 0;
+
+    const count = await qb.getCount();
+    const items = await qb.orderBy('client.id', 'ASC').limit(limit).offset(offset).getMany();
+
+    return { count, items };
+  }
+
+  async findById(clientId: number): Promise<Client> {
+    const client = await this.repository.findOne({ where: { id: clientId } });
+    if (!client) {
+      throw new NotFoundException('Client not found');
+    }
+    return client;
+  }
+
+  async findAvailableContracts(clientId: number): Promise<Proposal[]> {
+    return this.proposalRepository.find({ where: { clientId }, relations: ['building'], order: { id: 'ASC' } });
+  }
+
+  async findContractsByClientId(clientId: number, limit: number, offset: number): Promise<PaginatedClientContracts> {
+    const [items, count] = await this.proposalRepository.findAndCount({ where: { clientId }, order: { created: 'DESC' }, take: limit, skip: offset });
+    return { count, items };
+  }
+
+  async updateClient(client: Client, dto: ClientUpdateDto): Promise<Client> {
+    if (dto.name !== undefined) client.name = dto.name;
+    if (dto.attention_of !== undefined) client.attentionOf = dto.attention_of ?? null;
+    if (dto.street_line_1 !== undefined) client.streetLine1 = dto.street_line_1;
+    if (dto.street_line_2 !== undefined) client.streetLine2 = dto.street_line_2 ?? null;
+    if (dto.city !== undefined) client.city = dto.city;
+    if (dto.state !== undefined) client.state = dto.state;
+    if (dto.zip !== undefined) client.zip = dto.zip;
+    if (dto.dob_registered_email !== undefined) client.dobRegisteredEmail = dto.dob_registered_email ?? null;
+    if (dto.dob_notification_email !== undefined) client.dobNotificationEmail = dto.dob_notification_email ?? null;
+    if (dto.dob_owner_type !== undefined) client.dobOwnerType = dto.dob_owner_type ?? null;
+    if (dto.status !== undefined) client.status = dto.status;
+    return this.repository.save(client);
+  }
+
+  async deleteClient(client: Client): Promise<void> {
+    await this.repository.remove(client);
+  }
+}

--- a/internal/external/testdata/local_exception_4480.ts
+++ b/internal/external/testdata/local_exception_4480.ts
@@ -1,0 +1,20 @@
+// Faithful shape of a service that declares its own exception class and throws
+// it — the locally-declared-exception case for #4480. The declared class is a
+// real graph entity (SCOPE.Class); the synthetic SCOPE.ExceptionType must be
+// resolved to it.
+
+export class AppNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AppNotFoundError';
+  }
+}
+
+export class WidgetService {
+  findById(id: number): string {
+    if (id <= 0) {
+      throw new AppNotFoundError('widget not found');
+    }
+    return 'widget-' + id;
+  }
+}

--- a/internal/extractors/javascript/throws_resolve_4480_test.go
+++ b/internal/extractors/javascript/throws_resolve_4480_test.go
@@ -1,0 +1,315 @@
+package javascript_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/external"
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// throws_resolve_4480_test.go — in-pipeline live-fire for #4480.
+//
+// Runs the REAL JS/TS extractor + REAL resolver + REAL external synthesis on
+// byte-copies of representative NestJS/TS services that throw an exception, and
+// asserts the duplicate-exception-node bug is fixed:
+//
+//   BEFORE (bug): two nodes for one exception — the synthetic
+//   SCOPE.ExceptionType `exception:<Type>` (the THROWS edge lands here) AND the
+//   REAL exception class entity (a declared SCOPE.Class/Component, or an
+//   imported `ext:<Type>` external class).
+//
+//   AFTER (fix): exactly ONE exception node (the real class) carrying the
+//   THROWS edge; the synthetic SCOPE.ExceptionType node is dropped.
+//
+// Final live confirmation (one node in the core-backend-v3 flow view) needs a
+// reindex = a user-authorised deploy and is DEFERRED. These tests prove the fix
+// in the extract→resolve→synthesise pipeline byte-for-byte.
+
+const repoTag4480 = "core-backend-v3"
+
+// stampGraphIDs mirrors cmd/archigraph.(*Indexer).stampEntityIDs: it assigns
+// every record the deterministic graph.EntityID the resolver and buildDocument
+// rely on, so byQualifiedName binds THROWS edges to the synthetic node's real
+// graph id (matching production).
+func stampGraphIDs(recs []types.EntityRecord) {
+	for i := range recs {
+		recs[i].ID = graph.EntityID(repoTag4480, recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+}
+
+// assembleDoc4480 mirrors the essential parts of buildDocument: resolve embedded
+// references, then flatten EntityRecords + their (now hex-resolved) embedded
+// relationships into a graph.Document.
+func assembleDoc4480(recs []types.EntityRecord) *graph.Document {
+	stampGraphIDs(recs)
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	doc := &graph.Document{Repo: repoTag4480}
+	seenE := map[string]bool{}
+	seenR := map[string]bool{}
+	for k := range recs {
+		r := &recs[k]
+		if !seenE[r.ID] {
+			seenE[r.ID] = true
+			doc.Entities = append(doc.Entities, graph.Entity{
+				ID:            r.ID,
+				Name:          r.Name,
+				QualifiedName: r.QualifiedName,
+				Kind:          r.Kind,
+				Subtype:       r.Subtype,
+				SourceFile:    r.SourceFile,
+				Language:      r.Language,
+				Properties:    r.Properties,
+			})
+		}
+		for j := range r.Relationships {
+			rel := &r.Relationships[j]
+			from := rel.FromID
+			if from == "" {
+				from = r.ID
+			}
+			id := graph.RelationshipID(from, rel.ToID, rel.Kind)
+			if seenR[id] {
+				continue
+			}
+			seenR[id] = true
+			doc.Relationships = append(doc.Relationships, graph.Relationship{
+				ID:         id,
+				FromID:     from,
+				ToID:       rel.ToID,
+				Kind:       rel.Kind,
+				Properties: rel.Properties,
+			})
+		}
+	}
+	return doc
+}
+
+func extractTSFixture4480(t *testing.T, fixture, repoPath string) []types.EntityRecord {
+	t.Helper()
+	path := filepath.Join("..", "..", "external", "testdata", fixture)
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", fixture, err)
+	}
+	tree := parseTS(t, src)
+	e := javascript.New()
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: repoPath, Language: "typescript", Content: src, Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", fixture, err)
+	}
+	return ents
+}
+
+func throwsEdges(doc *graph.Document) []graph.Relationship {
+	var out []graph.Relationship
+	for _, r := range doc.Relationships {
+		if r.Kind == string(types.RelationshipKindThrows) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func entByID(doc *graph.Document, id string) *graph.Entity {
+	for i := range doc.Entities {
+		if doc.Entities[i].ID == id {
+			return &doc.Entities[i]
+		}
+	}
+	return nil
+}
+
+func countExceptionTypeNodes(doc *graph.Document, name string) int {
+	n := 0
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == string(types.EntityKindExceptionType) &&
+			doc.Entities[i].Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// realClassID returns the id of a non-synthetic entity with the given Name, or
+// "" if none/ambiguous.
+func realClassID(doc *graph.Document, name string) string {
+	var id string
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Name != name || e.Kind == string(types.EntityKindExceptionType) {
+			continue
+		}
+		if id != "" && id != e.ID {
+			return "" // ambiguous
+		}
+		id = e.ID
+	}
+	return id
+}
+
+// --- Case 1: locally-declared exception class (real SCOPE.Class entity) ------
+//
+// `class AppNotFoundError extends Error {}` + `throw new AppNotFoundError(...)`.
+// The declared class is a real graph entity; this is the cleanest fully-real
+// reproduction of the duplicate-node bug across the extract→resolve→synth path.
+
+func TestThrows4480_LocalClass_BeforeFix_RED(t *testing.T) {
+	doc := assembleDoc4480(extractTSFixture4480(t, "local_exception_4480.ts", "src/widget.service.ts"))
+	external.Synthesize(doc) // NO ResolveExceptionTypes — pre-fix snapshot.
+
+	// Two nodes exist for one exception: the synthetic ExceptionType AND the
+	// real declared class.
+	if got := countExceptionTypeNodes(doc, "exception:AppNotFoundError"); got != 1 {
+		t.Fatalf("pre-fix: want 1 synthetic exception node, got %d", got)
+	}
+	if realClassID(doc, "AppNotFoundError") == "" {
+		t.Fatal("pre-fix: expected the real declared AppNotFoundError class entity to exist")
+	}
+	// THROWS lands on the synthetic node (the bug).
+	landsOnSynthetic := false
+	for _, e := range throwsEdges(doc) {
+		if tgt := entByID(doc, e.ToID); tgt != nil && tgt.Kind == string(types.EntityKindExceptionType) {
+			landsOnSynthetic = true
+		}
+	}
+	if !landsOnSynthetic {
+		t.Fatal("pre-fix: expected THROWS to land on the synthetic ExceptionType node")
+	}
+}
+
+func TestThrows4480_LocalClass_AfterFix_GREEN(t *testing.T) {
+	doc := assembleDoc4480(extractTSFixture4480(t, "local_exception_4480.ts", "src/widget.service.ts"))
+	external.Synthesize(doc)
+	stats := external.ResolveExceptionTypes(doc)
+
+	realID := realClassID(doc, "AppNotFoundError")
+	if realID == "" {
+		t.Fatal("after-fix: real AppNotFoundError class entity must remain")
+	}
+	// Synthetic node dropped — exactly ONE node for the exception.
+	if got := countExceptionTypeNodes(doc, "exception:AppNotFoundError"); got != 0 {
+		t.Fatalf("after-fix: synthetic node must be dropped, found %d", got)
+	}
+	// THROWS now targets the real class; no THROWS targets a synthetic node.
+	throws := throwsEdges(doc)
+	if len(throws) == 0 {
+		t.Fatal("after-fix: THROWS edge disappeared")
+	}
+	landsOnReal := false
+	for _, e := range throws {
+		if e.ToID == realID {
+			landsOnReal = true
+		}
+		if tgt := entByID(doc, e.ToID); tgt != nil && tgt.Kind == string(types.EntityKindExceptionType) {
+			t.Fatalf("after-fix: a THROWS edge still targets a synthetic node (%s)", tgt.Name)
+		}
+	}
+	if !landsOnReal {
+		t.Fatalf("after-fix: THROWS must target the real class %s", realID)
+	}
+	if stats.Retargeted < 1 || stats.SyntheticDropped < 1 {
+		t.Fatalf("after-fix: want retargeted>=1 & dropped>=1, got %+v", stats)
+	}
+}
+
+// --- Case 2: imported external exception class (live upvate-v3 shape) ---------
+//
+// On the live graph the ticket observed `NotFoundException` as TWO nodes: the
+// synthetic SCOPE.ExceptionType AND the imported class materialised as a real
+// `ext:NotFoundException` external entity. We reproduce that exact shape by
+// running the real extractor on the byte-copied core-backend-v3 service (which
+// emits the synthetic node + the `new NotFoundException()` constructor CALLS
+// edge) and adding the imported-class external entity the live indexer carried,
+// then assert the fix collapses it to one node with THROWS on the real class.
+
+func TestThrows4480_ImportedExternal_AfterFix_GREEN(t *testing.T) {
+	doc := assembleDoc4480(extractTSFixture4480(t,
+		"client_repository_4480.ts",
+		"src/modules/clients/repositories/client.repository.ts"))
+	external.Synthesize(doc)
+
+	// Reproduce the live shape: the imported NotFoundException class present as
+	// a real external entity (kind SCOPE.External), as seen on upvate-v3.
+	doc.Entities = append(doc.Entities, graph.Entity{
+		ID:            "ext:NotFoundException",
+		Name:          "NotFoundException",
+		QualifiedName: "NotFoundException",
+		Kind:          external.KindExternal,
+		Subtype:       "class",
+	})
+
+	// Sanity: pre-resolve we have BOTH the synthetic and the real node, with
+	// THROWS on the synthetic.
+	if countExceptionTypeNodes(doc, "exception:NotFoundException") != 1 {
+		t.Fatal("setup: expected the synthetic NotFoundException node")
+	}
+
+	stats := external.ResolveExceptionTypes(doc)
+
+	if got := countExceptionTypeNodes(doc, "exception:NotFoundException"); got != 0 {
+		t.Fatalf("after-fix: synthetic NotFoundException node must be dropped, found %d", got)
+	}
+	throws := throwsEdges(doc)
+	if len(throws) == 0 {
+		t.Fatal("after-fix: THROWS edge disappeared")
+	}
+	for _, e := range throws {
+		if tgt := entByID(doc, e.ToID); tgt != nil && tgt.Kind == string(types.EntityKindExceptionType) {
+			t.Fatalf("after-fix: THROWS still targets a synthetic node (%s)", tgt.Name)
+		}
+		if e.ToID != "ext:NotFoundException" {
+			t.Fatalf("after-fix: THROWS must target ext:NotFoundException, got %s", e.ToID)
+		}
+	}
+	if stats.Retargeted < 1 || stats.SyntheticDropped < 1 {
+		t.Fatalf("after-fix: want retargeted>=1 & dropped>=1, got %+v", stats)
+	}
+}
+
+// --- Case 3: genuinely-external/unresolvable type keeps a single node --------
+//
+// When NO real class entity exists for the thrown type (truly 3rd-party type
+// constructed nowhere in-repo and folded only to its package), the synthetic
+// node is KEPT — exactly one node, with the THROWS edge on it. This guards the
+// precision invariant: never drop the only node we have.
+
+func TestThrows4480_Unresolvable_KeepsSingleNode(t *testing.T) {
+	doc := assembleDoc4480(extractTSFixture4480(t,
+		"client_repository_4480.ts",
+		"src/modules/clients/repositories/client.repository.ts"))
+	external.Synthesize(doc)
+	// In this build no real NotFoundException class entity is synthesised
+	// (the import folds to ext:@nestjs/common), so the type is unresolvable.
+	if realClassID(doc, "NotFoundException") != "" {
+		t.Skip("a real NotFoundException entity exists in this build; covered by Case 2")
+	}
+	stats := external.ResolveExceptionTypes(doc)
+
+	if got := countExceptionTypeNodes(doc, "exception:NotFoundException"); got != 1 {
+		t.Fatalf("unresolvable: synthetic node must be KEPT (exactly 1), got %d", got)
+	}
+	// THROWS still lands on the (single) synthetic node — no orphan, no drop.
+	landsOnSynthetic := false
+	for _, e := range throwsEdges(doc) {
+		if tgt := entByID(doc, e.ToID); tgt != nil && tgt.Kind == string(types.EntityKindExceptionType) {
+			landsOnSynthetic = true
+		}
+	}
+	if !landsOnSynthetic {
+		t.Fatal("unresolvable: THROWS must still land on the kept synthetic node")
+	}
+	if stats.SyntheticDropped != 0 {
+		t.Fatalf("unresolvable: nothing should be dropped, got %+v", stats)
+	}
+}


### PR DESCRIPTION
## What

Exception types currently appear as **two graph nodes**: a synthetic
`SCOPE.ExceptionType` convergence node (`exception:<Type>`, source `<exception>`)
that the THROWS/CATCHES edge lands on, **and** the real exception class (a
locally-declared class, or an imported class materialised as `ext:<Type>`). The
throws edge therefore never reaches the real class — confirmed live on upvate-v3
for `NotFoundException`.

This adds a synthesis-time pass, `external.ResolveExceptionTypes`, run right
after `external.Synthesize` in the indexer: for every `SCOPE.ExceptionType` node,
if exactly one non-synthetic entity (declared `SCOPE.Class` / `SCOPE.Component`,
or an `ext:` external) shares its type name, the THROWS/CATCHES edges are
retargeted to that real entity and the synthetic node is dropped. When the type
is genuinely unresolvable (no real entity) or ambiguous (multiple same-named
classes) the single synthetic node is kept — **exactly one node per exception,
never both**.

## Why it's the right (long-term, generalized) fix

- **Language-agnostic by construction.** Every extractor (NestJS/TS `throw new X()`,
  Python `raise X`, Java `throws X` / `throw new X()`, Ruby, Rust, C#, ...) funnels
  through the shared `SCOPE.ExceptionType` node via `EmitExceptionEdges`. Operating
  on that node at the `graph.Document` layer covers **all languages at once** — no
  per-language patching. Candidate kinds (`SCOPE.Class`, `SCOPE.Component`,
  `SCOPE.External`) cover declared exception classes across every language's
  extractor as well as imported externals.
- **Merge-stable.** Resolution is by name through the fully-assembled symbol table
  at synthesis time (mirrors endpoint→handler #4319), edge ids are recomputed as the
  deterministic hash of `(FromID, ToID, Kind)`, and the pass is idempotent (a second
  run is a no-op).
- **Precision-first.** Ambiguous or unresolvable types keep their single synthetic
  node rather than risk a wrong retarget.

## Validation (in-pipeline)

`internal/extractors/javascript/throws_resolve_4480_test.go` runs the **real**
JS/TS extractor + resolver + `external.Synthesize` on byte-copies of:
- a core-backend-v3 service doing `throw new NotFoundException(...)`
- a locally-declared-and-thrown class (`class AppNotFoundError extends Error {}`)

Before/after, on the locally-declared case (the clean real reproduction):
- **BEFORE:** 2 nodes — synthetic `exception:AppNotFoundError` + real
  `AppNotFoundError` class; THROWS on the synthetic (red).
- **AFTER:** 1 node — the real class; THROWS retargeted onto it; synthetic dropped
  (`retargeted=1, synthetic_dropped=1`) (green).

The imported-external case asserts the same collapse against the live upvate-v3
shape (real `ext:NotFoundException` present). A third case asserts the
unresolvable type keeps its single node. Unit tests in
`internal/external/exception_resolve_test.go` cover retarget+drop,
keep-when-unresolvable, ambiguity, CATCHES, component-candidate, idempotency,
nil-safety.

## Covered vs deferred

- **Covered:** all languages that emit `SCOPE.ExceptionType` nodes (the shared
  path) — NestJS/TS, Python, Java, Ruby, Rust, C#, etc. — for both declared and
  imported exception classes.
- **Deferred:** final live confirmation that the flow view shows one node requires
  a **reindex of core-backend-v3 = a user-authorised deploy**. Also noted: in builds
  where an imported exception's constructor call folds only to its package
  (`ext:@nestjs/common`) rather than a per-symbol `ext:<Type>` node, no distinct
  class entity exists, so the synthetic node is (correctly) kept; pointing THROWS at
  a per-symbol external for folded imports would be a separate
  external-synthesis enhancement.

## Gates
- `go build ./...` ✅
- `go vet ./internal/external/... ./internal/extractor/... ./internal/extractors/javascript/... ./cmd/archigraph/...` ✅
- `go test ./internal/external/... ./internal/extractor/... ./internal/types/... ./internal/extractors/javascript/...` ✅
- Pre-existing unrelated failures on `cmd/archigraph` (timing benchmarks +
  Python/Ruby endpoint line-attribution) reproduce identically on `origin/main`.

Closes #4480

🤖 Generated with [Claude Code](https://claude.com/claude-code)