### PR TITLE
fix(di): drop redundant row tags, add search, label token groups (#4504)

### DIFF
--- a/webui-v2/src/routes/di.tsx
+++ b/webui-v2/src/routes/di.tsx
@@ -31,7 +31,7 @@
    invented name. A repo with no DI shows a clean empty state.
    ============================================================ */
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
   Syringe,
@@ -41,12 +41,22 @@ import {
   ListFilter,
   AlertTriangle,
   Package,
+  Search,
+  KeySquare,
 } from "lucide-react";
 
-import { Badge, Card, CardBody, Pill } from "@/components/ui";
+import {
+  Badge,
+  Card,
+  CardBody,
+  Pill,
+  Tooltip,
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
-import { RepoChip } from "@/lib/repo-color";
 import { cn } from "@/lib/utils";
 import { useDI } from "@/hooks/use-di";
 import type { DIConsumer, DIProvider, DIReport } from "@/data/types";
@@ -99,6 +109,39 @@ function frameworkTone(fw: string): Tone {
     default:
       return "neutral";
   }
+}
+
+// ---------------------------------------------------------------------------
+// § Token-group detection (#4504)
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic: is this "provider" actually a DI injection-TOKEN category rather
+ * than a single concrete provider? TypeORM `@InjectRepository(Foo)` and
+ * Mongoose `@InjectModel(Bar)` collapse every concrete repository/model under a
+ * shared token name ("Repository" / "Model"), so the row aggregates dozens of
+ * heterogeneous consumers via per-injection qualifiers.
+ *
+ * We surface it when the provider name is a known token keyword, OR the group
+ * fans out widely (many consumers) with distinct per-consumer qualifiers — the
+ * signature of a token category rather than one injected class.
+ */
+const TOKEN_KEYWORDS = new Set(["repository", "model", "datasource", "connection", "entitymanager"]);
+
+function tokenInfo(provider: DIProvider): { isToken: boolean; concreteCount: number } {
+  const name = (provider.name || "").toLowerCase();
+  const qualifiers = new Set(
+    provider.consumers.map((c) => (c.qualifier || "").trim()).filter(Boolean),
+  );
+  const byKeyword = TOKEN_KEYWORDS.has(name);
+  // A token category shows many consumers disambiguated by distinct qualifiers
+  // (the concrete entity each injection targets).
+  const byFanOut = provider.consumers.length >= 8 && qualifiers.size >= 4;
+  const isToken = byKeyword || byFanOut;
+  // Concrete providers behind the token = distinct qualifiers (each names the
+  // concrete repository/model); fall back to consumer count when unqualified.
+  const concreteCount = qualifiers.size > 0 ? qualifiers.size : provider.consumers.length;
+  return { isToken, concreteCount };
 }
 
 // ---------------------------------------------------------------------------
@@ -164,17 +207,21 @@ function EntityName({
   name,
   kind,
   entityId,
+  showKind = true,
 }: {
   name: string;
   kind?: string;
   entityId: string;
+  /** Render the Kind badge. Disabled on provider headers (#4504) — the kind
+      there is always the framework's Component/Injectable and adds no signal. */
+  showKind?: boolean;
 }) {
   return (
     <span className="inline-flex items-center gap-1.5 min-w-0">
       <span className="font-mono text-sm text-text truncate" title={entityId}>
         {name}
       </span>
-      {kind && (
+      {showKind && kind && (
         <Badge tone={kindTone(kind)} className="shrink-0">
           {kindLabel(kind)}
         </Badge>
@@ -188,11 +235,15 @@ function EntityRefLine({
   sourceFile,
   startLine,
   name,
+  showRepoChip = true,
 }: {
   repo?: string;
   sourceFile?: string;
   startLine?: number;
   name: string;
+  /** Drop the right-anchored repo chip for single-repo groups (#4504),
+      matching other views' single-repo convention. */
+  showRepoChip?: boolean;
 }) {
   if (!repo || !sourceFile) return null;
   return (
@@ -202,6 +253,7 @@ function EntityRefLine({
       line={startLine ?? 0}
       name={name}
       className="text-[11px]"
+      showRepoChip={showRepoChip}
     />
   );
 }
@@ -210,7 +262,13 @@ function EntityRefLine({
 // § One consumer row (provider INJECTED_INTO consumer)
 // ---------------------------------------------------------------------------
 
-function ConsumerRow({ consumer, groupId }: { consumer: DIConsumer; groupId: string }) {
+function ConsumerRow({
+  consumer,
+  multiRepo,
+}: {
+  consumer: DIConsumer;
+  multiRepo: boolean;
+}) {
   return (
     <div className="flex flex-col gap-0.5 pl-6 py-1">
       <div className="flex items-center gap-2 min-w-0 flex-wrap">
@@ -232,15 +290,13 @@ function ConsumerRow({ consumer, groupId }: { consumer: DIConsumer; groupId: str
             @{consumer.qualifier}
           </span>
         )}
-        {consumer.repo && (
-          <RepoChip slug={consumer.repo} groupId={groupId} maxLength={14} />
-        )}
       </div>
       <EntityRefLine
         repo={consumer.repo}
         sourceFile={consumer.source_file}
         startLine={consumer.start_line}
         name={consumer.name}
+        showRepoChip={multiRepo}
       />
     </div>
   );
@@ -252,20 +308,49 @@ function ConsumerRow({ consumer, groupId }: { consumer: DIConsumer; groupId: str
 
 const COLLAPSE_AT = 5; // collapse consumer lists longer than this
 
-function ProviderCard({ provider, groupId }: { provider: DIProvider; groupId: string }) {
+function ProviderCard({
+  provider,
+  multiRepo,
+}: {
+  provider: DIProvider;
+  multiRepo: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const many = provider.consumers.length > COLLAPSE_AT;
   const shown = many && !open ? provider.consumers.slice(0, COLLAPSE_AT) : provider.consumers;
+  const { isToken, concreteCount } = tokenInfo(provider);
 
   return (
     <Card>
       <CardBody className="py-2.5 space-y-1">
         {/* Provider header */}
         <div className="flex items-center gap-2 min-w-0 flex-wrap">
-          <Syringe size={13} className="text-accent shrink-0" />
-          <EntityName name={provider.name} kind={provider.kind} entityId={provider.entity_id} />
-          {provider.repo && (
-            <RepoChip slug={provider.repo} groupId={groupId} maxLength={14} />
+          {isToken ? (
+            <KeySquare size={13} className="text-success shrink-0" />
+          ) : (
+            <Syringe size={13} className="text-accent shrink-0" />
+          )}
+          <EntityName
+            name={provider.name}
+            kind={provider.kind}
+            entityId={provider.entity_id}
+            showKind={false}
+          />
+          {isToken && (
+            <TooltipProvider delayDuration={150}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex shrink-0 cursor-help">
+                    <Badge tone="success">
+                      injection token · {concreteCount} concrete
+                    </Badge>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  {`"${provider.name}" is a DI injection-token category (e.g. TypeORM @InjectRepository / Mongoose @InjectModel), not a single provider. Its ${provider.consumers.length} consumers each inject one of ${concreteCount} concrete ${provider.name.toLowerCase()}${concreteCount === 1 ? "" : "s"} via a per-injection qualifier — that is why the fan-out is so wide.`}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
           <span
             className="ml-auto text-[11px] text-text-4 tabular-nums shrink-0"
@@ -279,12 +364,13 @@ function ProviderCard({ provider, groupId }: { provider: DIProvider; groupId: st
           sourceFile={provider.source_file}
           startLine={provider.start_line}
           name={provider.name}
+          showRepoChip={multiRepo}
         />
 
         {/* Consumers */}
         <div className="border-l border-border/60 ml-1">
           {shown.map((c) => (
-            <ConsumerRow key={c.entity_id} consumer={c} groupId={groupId} />
+            <ConsumerRow key={c.entity_id} consumer={c} multiRepo={multiRepo} />
           ))}
         </div>
         {many && (
@@ -310,15 +396,52 @@ function ProviderCard({ provider, groupId }: { provider: DIProvider; groupId: st
 // § Screen
 // ---------------------------------------------------------------------------
 
-function DIBody({ data, groupId }: { data: DIReport; groupId: string }) {
-  const [framework, setFramework] = useState<string>("all");
+/** True when a provider OR any of its consumers matches the search query. */
+function providerMatches(provider: DIProvider, q: string): boolean {
+  if (!q) return true;
+  const hay = (s?: string) => (s || "").toLowerCase().includes(q);
+  if (hay(provider.name) || hay(provider.source_file)) return true;
+  return provider.consumers.some(
+    (c) => hay(c.name) || hay(c.source_file) || hay(c.qualifier),
+  );
+}
 
-  const filteredGroups = useMemo(
-    () =>
+function DIBody({ data }: { data: DIReport }) {
+  const [framework, setFramework] = useState<string>("all");
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Single-repo groups drop the repo chip entirely (#4504), matching other
+  // views' convention; multi-repo keeps a single right-anchored chip.
+  const multiRepo = useMemo(() => {
+    const repos = new Set<string>();
+    for (const g of data.groups)
+      for (const p of g.providers) {
+        if (p.repo) repos.add(p.repo);
+        for (const c of p.consumers) if (c.repo) repos.add(c.repo);
+      }
+    return repos.size > 1;
+  }, [data.groups]);
+
+  const q = query.trim().toLowerCase();
+
+  const filteredGroups = useMemo(() => {
+    const byFw =
       framework === "all"
         ? data.groups
-        : data.groups.filter((g) => g.framework === framework),
-    [data.groups, framework],
+        : data.groups.filter((g) => g.framework === framework);
+    if (!q) return byFw;
+    return byFw
+      .map((g) => {
+        const providers = g.providers.filter((p) => providerMatches(p, q));
+        return { ...g, providers, count: providers.length };
+      })
+      .filter((g) => g.providers.length > 0);
+  }, [data.groups, framework, q]);
+
+  const shownProviderCount = useMemo(
+    () => filteredGroups.reduce((n, g) => n + g.providers.length, 0),
+    [filteredGroups],
   );
 
   return (
@@ -329,6 +452,23 @@ function DIBody({ data, groupId }: { data: DIReport; groupId: string }) {
         <SummaryStat label="Consumers" value={data.total_consumers} />
         <SummaryStat label="Injections" value={data.total_injections} />
         <SummaryStat label="Frameworks" value={data.frameworks.length} />
+      </div>
+
+      {/* Search */}
+      <div className="flex items-center gap-2 h-8 px-2.5 rounded-md border border-border bg-surface text-text-3 focus-within:ring-2 focus-within:ring-[var(--accent-ring)] focus-within:border-accent">
+        <Search size={13} className="flex-none" />
+        <input
+          ref={searchRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search providers & consumers by name or file…"
+          className="flex-1 min-w-0 border-0 outline-none bg-transparent text-text text-sm placeholder:text-text-4"
+        />
+        {q && (
+          <span className="font-mono text-[10px] text-text-4 whitespace-nowrap tabular-nums">
+            {shownProviderCount} / {data.total_providers}
+          </span>
+        )}
       </div>
 
       {/* Framework filter */}
@@ -351,26 +491,37 @@ function DIBody({ data, groupId }: { data: DIReport; groupId: string }) {
       )}
 
       {/* Provider → consumers, grouped by framework */}
-      <div className="space-y-5">
-        {filteredGroups.map((g) => (
-          <section key={g.framework || "—"} className="space-y-2">
-            <div className="flex items-center gap-2">
-              <Package size={14} className="text-text-4" />
-              <Badge tone={frameworkTone(g.framework)} className="uppercase">
-                {g.framework || "unknown"}
-              </Badge>
-              <span className="text-[11px] text-text-4 tabular-nums">
-                {g.count} provider{g.count === 1 ? "" : "s"}
-              </span>
-            </div>
-            <div className="space-y-2">
-              {g.providers.map((p) => (
-                <ProviderCard key={`${g.framework}:${p.entity_id}`} provider={p} groupId={groupId} />
-              ))}
-            </div>
-          </section>
-        ))}
-      </div>
+      {filteredGroups.length === 0 ? (
+        <EmptyState
+          title="No matching providers"
+          hint={`No DI providers or consumers match "${query.trim()}". Clear the search or pick a different framework filter.`}
+        />
+      ) : (
+        <div className="space-y-5">
+          {filteredGroups.map((g) => (
+            <section key={g.framework || "—"} className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Package size={14} className="text-text-4" />
+                <Badge tone={frameworkTone(g.framework)} className="uppercase">
+                  {g.framework || "unknown"}
+                </Badge>
+                <span className="text-[11px] text-text-4 tabular-nums">
+                  {g.count} provider{g.count === 1 ? "" : "s"}
+                </span>
+              </div>
+              <div className="space-y-2">
+                {g.providers.map((p) => (
+                  <ProviderCard
+                    key={`${g.framework}:${p.entity_id}`}
+                    provider={p}
+                    multiRepo={multiRepo}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
 
       <p className="text-[10px] text-text-4">
         Each row is a genuine INJECTED_INTO edge: the provider (service / token)
@@ -414,7 +565,7 @@ export default function DIScreen() {
               providers → the consumers they inject into
             </span>
           </div>
-          <DIBody data={data!} groupId={groupId} />
+          <DIBody data={data!} />
         </>
       )}
     </div>


### PR DESCRIPTION
Polishes the Dependency-Injection view (`webui-v2/src/routes/di.tsx`).

## Changes
1. **Redundant tags removed** — provider rows previously showed an always-identical `Component` kind badge, a blue inline repo chip next to the name, *and* a green repo chip on the right. The kind badge and the inline blue chip are dropped; a single right-anchored repo chip (from `RefLine`) remains, and is suppressed entirely for single-repo groups via a computed `multiRepo` flag — matching the convention in other views (e.g. Security #4500). Consumer rows get the same single-chip treatment.
2. **Search bar** — a search input filters providers and their consumers by name and source-file path, working alongside the existing All/framework filter chips. Shows a live `shown / total` count and a clean empty state when nothing matches.
3. **Token-group clarification** — TypeORM `@InjectRepository` / Mongoose `@InjectModel` collapse many concrete entities under shared token names (`Repository` 67, `Model` 29). Such rows are detected (token keyword, or wide fan-out with many distinct qualifiers) and get a green `injection token · N concrete` badge with a key icon and an explanatory tooltip, so the large consumer count reads as expected rather than confusing.

## Gates
- `npm ci` ✓
- `npm run build` ✓
- `npm run lint` (tsc --noEmit) ✓

Pure dashboard change. Deploy-deferred.

Closes #4504

🤖 Generated with [Claude Code](https://claude.com/claude-code)