### PR TITLE
fix(di): classify NestJS @Injectable providers as nestjs, not angular (#4503)

### DIFF
--- a/internal/extractors/javascript/angular.go
+++ b/internal/extractors/javascript/angular.go
@@ -88,11 +88,106 @@ var nestClassDecorators = map[string]bool{
 }
 
 // frameworkForDecorator returns the framework label for a recognised class
-// decorator: "nestjs" for the NestJS DI decorators, else "angular".
+// decorator from the decorator name alone: "nestjs" for the NestJS-only DI
+// decorators, else "angular". This is the name-only fallback used when no
+// import context is available; the ambiguous @Injectable decorator (shared by
+// Angular and NestJS) is disambiguated by frameworkForClass via import origin.
 func frameworkForDecorator(decorator string) string {
 	if nestClassDecorators[decorator] {
 		return "nestjs"
 	}
+	return "angular"
+}
+
+// nestDecoratorModulePrefixes are the dotted import-source prefixes that mark a
+// decorator as coming from NestJS (e.g. `@nestjs/common`, `@nestjs/core`,
+// `@nestjs/graphql`, `@nestjs/websockets`). importBinding.sourceModule is
+// dotted (slashes → dots), so `@nestjs/common` becomes `@nestjs.common`.
+var nestDecoratorModulePrefixes = []string{"@nestjs.", "@nestjs/"}
+
+// angularDecoratorModulePrefixes are the dotted import-source prefixes that mark
+// a decorator as coming from Angular (`@angular/core`, `@angular/common`, …).
+var angularDecoratorModulePrefixes = []string{"@angular.", "@angular/"}
+
+// hasModulePrefix reports whether the dotted import source begins with any of
+// the given prefixes (matching both the dotted `@nestjs.` and raw `@nestjs/`
+// shapes so it is robust to how the source was canonicalised).
+func hasModulePrefix(source string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(source, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// frameworkForClass returns the framework label for a decorated class,
+// disambiguating the @Injectable decorator (shared by Angular's @angular/core
+// and NestJS's @nestjs/common) by the import origin of the decorator and the
+// file's surrounding framework markers (#4503).
+//
+// Angular and NestJS both spell a DI provider `@Injectable()` with a
+// constructor-injected providers list, so the bare decorator name is
+// insufficient: classifying every @Injectable as Angular mis-tags an entire
+// NestJS codebase as Angular (the upvate-v3 /di "121 angular" bug). The
+// disambiguation is by import-origin/markers, not the bare decorator:
+//
+//   - The NestJS-only decorators (@Controller / @Resolver / @WebSocketGateway)
+//     and the Angular-only decorators (@Component / @Directive / @Pipe /
+//     @NgModule) are unambiguous from the name; defer to frameworkForDecorator.
+//   - For @Injectable, look at where THIS decorator was imported from: a local
+//     name imported from `@nestjs/*` → nestjs; from `@angular/*` → angular.
+//   - When the decorator import is unresolved (re-exported through a barrel,
+//     aliased, etc.), fall back to file-level markers: any `@nestjs/*` import
+//     present → nestjs; any `@angular/*` import → angular.
+//   - With no markers at all, keep the historical default (angular) so genuine
+//     Angular projects without an explicit core import are unaffected.
+func (x *extractor) frameworkForClass(decorator string) string {
+	// Unambiguous decorators: name alone decides.
+	if decorator != "Injectable" {
+		return frameworkForDecorator(decorator)
+	}
+
+	// 1) Origin of the @Injectable decorator import itself.
+	if b, ok := x.importByLocal[decorator]; ok && b != nil {
+		if hasModulePrefix(b.sourceModule, nestDecoratorModulePrefixes) ||
+			hasModulePrefix(b.importPath, nestDecoratorModulePrefixes) {
+			return "nestjs"
+		}
+		if hasModulePrefix(b.sourceModule, angularDecoratorModulePrefixes) ||
+			hasModulePrefix(b.importPath, angularDecoratorModulePrefixes) {
+			return "angular"
+		}
+	}
+
+	// 2) Fall back to file-level framework markers.
+	var sawNest, sawAngular bool
+	for i := range x.imports {
+		src := x.imports[i].sourceModule
+		path := x.imports[i].importPath
+		if hasModulePrefix(src, nestDecoratorModulePrefixes) ||
+			hasModulePrefix(path, nestDecoratorModulePrefixes) {
+			sawNest = true
+		}
+		if hasModulePrefix(src, angularDecoratorModulePrefixes) ||
+			hasModulePrefix(path, angularDecoratorModulePrefixes) {
+			sawAngular = true
+		}
+	}
+	switch {
+	case sawNest && !sawAngular:
+		return "nestjs"
+	case sawAngular && !sawNest:
+		return "angular"
+	case sawNest && sawAngular:
+		// Mixed file (rare). Prefer the decorator-origin signal already tried;
+		// with neither matching, prefer nestjs only if the file has no Angular
+		// class decorators is hard to know here — default to angular to avoid
+		// regressing genuine Angular hybrids.
+		return "angular"
+	}
+
+	// 3) No framework markers: keep the historical default.
 	return "angular"
 }
 
@@ -167,7 +262,7 @@ func (x *extractor) handleAngularClass(n *sitter.Node, decorator string, call *s
 		return false
 	}
 
-	framework := frameworkForDecorator(decorator)
+	framework := x.frameworkForClass(decorator)
 	props := map[string]string{
 		"framework":          framework,
 		"angular_decorator":  decorator,

--- a/internal/extractors/javascript/issue4503_di_nestjs_vs_angular_test.go
+++ b/internal/extractors/javascript/issue4503_di_nestjs_vs_angular_test.go
@@ -1,0 +1,181 @@
+package javascript_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4503 LIVE-REPRO — NestJS @Injectable providers mis-classified as
+// "angular" in the DI view.
+//
+// Angular (@angular/core) and NestJS (@nestjs/common) BOTH spell a DI provider
+// `@Injectable()` with a constructor-injected providers list. The JS/TS
+// extractor mapped the bare `Injectable` decorator to framework=angular
+// unconditionally, so an entire NestJS codebase (core-backend-v3, 100% NestJS,
+// zero Angular) surfaced on /di as "angular (121)". The DI view groups
+// INJECTED_INTO edges by their `framework` property, and that property was
+// stamped angular for every NestJS provider.
+//
+// ROOT FIX (import-origin disambiguation, NOT a hack): the framework label for
+// an @Injectable class is resolved from where the decorator was imported from —
+// `@nestjs/*` → nestjs, `@angular/*` → angular — falling back to the file's
+// framework-import markers, and only then to the historical angular default.
+// Genuine Angular providers (import @angular/core, providedIn:'root', NgModule)
+// must still classify as angular.
+//
+// The test runs the REAL JSExtractor.Extract pipeline over BYTE-COPIES of real
+// core-backend-v3 NestJS providers and a faithful Angular provider, then asserts
+// the framework tag on both the provider entity and its INJECTED_INTO edges.
+
+// injectedIntoFramework returns the framework property of the first
+// INJECTED_INTO edge whose consumer (ToID) is the given class, or "".
+func injectedIntoFramework(ents []types.EntityRecord, consumer string) string {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindInjectedInto) && r.ToID == consumer {
+				return r.Properties["framework"]
+			}
+		}
+	}
+	return ""
+}
+
+// entityFramework returns the `framework` property of the first entity whose
+// Name matches and that carries an angular_decorator marker (the decorated
+// provider class), or "".
+func entityFramework(ents []types.EntityRecord, name string) string {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Properties["angular_decorator"] != "" {
+			return ents[i].Properties["framework"]
+		}
+	}
+	return ""
+}
+
+// TestIssue4503_NestJSInjectableClassifiesAsNestJS feeds byte-copies of real
+// core-backend-v3 NestJS @Injectable providers through the real extractor and
+// asserts framework=nestjs (NOT angular) on the entity and INJECTED_INTO edges.
+func TestIssue4503_NestJSInjectableClassifiesAsNestJS(t *testing.T) {
+	// Byte-copy of core-backend-v3 src/common/integrations/mailgun/services/
+	// email.service.ts (trimmed body) — a NestJS @Injectable from @nestjs/common
+	// with constructor injection. This is the exact shape the /di "angular" bug
+	// mis-tagged.
+	src := []byte(`import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class EmailService {
+  private readonly logger = new Logger(EmailService.name);
+  constructor(
+    @Inject('MAILGUN_TRANSPORT') private readonly transport: MailgunTransport,
+    config: ConfigService,
+  ) {}
+  async send(): Promise<void> {}
+}`)
+
+	ents := extractAngular(t, src)
+
+	if got := entityFramework(ents, "EmailService"); got != "nestjs" {
+		t.Errorf("EmailService entity framework = %q, want nestjs (NestJS @Injectable mis-tagged as angular)", got)
+	}
+	if got := injectedIntoFramework(ents, "EmailService"); got != "nestjs" {
+		t.Errorf("EmailService INJECTED_INTO framework = %q, want nestjs", got)
+	}
+	// No edge nor entity may be tagged angular for a pure-NestJS file.
+	for i := range ents {
+		if ents[i].Properties["angular_decorator"] != "" && ents[i].Properties["framework"] == "angular" {
+			t.Errorf("entity %q tagged framework=angular in a pure-NestJS file", ents[i].Name)
+		}
+	}
+}
+
+// TestIssue4503_AppServiceNestJS — the simplest real NestJS provider
+// (src/app.service.ts, no constructor injection) still classifies as nestjs.
+func TestIssue4503_AppServiceNestJS(t *testing.T) {
+	src := []byte(`import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AppService {
+  getHello(): string {
+    return 'Hello World!';
+  }
+}`)
+	ents := extractAngular(t, src)
+	if got := entityFramework(ents, "AppService"); got != "nestjs" {
+		t.Errorf("AppService framework = %q, want nestjs", got)
+	}
+}
+
+// TestIssue4503_GenuineAngularStillAngular guards the no-regression direction:
+// a genuine Angular provider (import @angular/core, providedIn:'root', an
+// @NgModule sibling) must still classify as angular.
+func TestIssue4503_GenuineAngularStillAngular(t *testing.T) {
+	src := []byte(`import { Injectable, NgModule } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  constructor(private http: HttpClient) {}
+  load() {}
+}
+
+@NgModule({ providers: [UserService] })
+export class AppModule {}`)
+
+	ents := extractAngular(t, src)
+
+	if got := entityFramework(ents, "UserService"); got != "angular" {
+		t.Errorf("genuine Angular UserService framework = %q, want angular (regressed real Angular detection)", got)
+	}
+	if got := injectedIntoFramework(ents, "UserService"); got != "angular" {
+		t.Errorf("genuine Angular UserService INJECTED_INTO framework = %q, want angular", got)
+	}
+	for i := range ents {
+		if ents[i].Properties["angular_decorator"] != "" && ents[i].Properties["framework"] == "nestjs" {
+			t.Errorf("entity %q tagged framework=nestjs in a pure-Angular file", ents[i].Name)
+		}
+	}
+}
+
+// TestIssue4503_NestControllerUnaffected confirms the unambiguous NestJS
+// decorators keep nestjs regardless of import disambiguation.
+func TestIssue4503_NestControllerUnaffected(t *testing.T) {
+	src := []byte(`import { Controller, Get } from '@nestjs/common';
+
+@Controller('hello')
+export class HelloController {
+  constructor(private readonly svc: AppService) {}
+  @Get()
+  hello() {}
+}`)
+	ents := extractAngular(t, src)
+	if got := entityFramework(ents, "HelloController"); got != "nestjs" {
+		t.Errorf("HelloController framework = %q, want nestjs", got)
+	}
+}
+
+// TestIssue4503_BarrelReexportedInjectableFallsBackToMarkers — when @Injectable
+// is re-exported through a project barrel (so its import origin is NOT
+// @nestjs/*), the file-level @nestjs marker still classifies it as nestjs.
+func TestIssue4503_BarrelReexportedInjectableFallsBackToMarkers(t *testing.T) {
+	src := []byte(`import { Injectable } from './common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class ReportService {
+  constructor(private config: ConfigService) {}
+}`)
+	ents := extractAngular(t, src)
+	if got := entityFramework(ents, "ReportService"); got != "nestjs" {
+		t.Errorf("barrel-reexported @Injectable framework = %q, want nestjs (file imports @nestjs/config)", got)
+	}
+	if got := injectedIntoFramework(ents, "ReportService"); got != "nestjs" && got != "" {
+		// INJECTED_INTO may be absent if ConfigService isn't a resolvable
+		// provider; when present it must be nestjs.
+		if !strings.EqualFold(got, "nestjs") {
+			t.Errorf("ReportService INJECTED_INTO framework = %q, want nestjs", got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4503

## Problem
Live on upvate-v3 `/di`, a 100%-NestJS repo (core-backend-v3, zero Angular) showed `2 Frameworks: angular (121), nestjs (88)`. Angular (`@angular/core`) and NestJS (`@nestjs/common`) **both** spell a DI provider `@Injectable()` with a constructor-injected providers list. The JS/TS extractor (`handleAngularClass`) mapped the bare `Injectable` decorator to `framework=angular` unconditionally. The `/di` view groups `INJECTED_INTO` edges by their `framework` property, so every NestJS `@Injectable` provider was counted as angular.

## Root cause
`internal/extractors/javascript/angular.go` — `frameworkForDecorator` returned `angular` for any decorator not in the NestJS-only set (`@Controller/@Resolver/@WebSocketGateway`). `@Injectable` is shared by both frameworks, so the bare-name classification mis-tagged the entire NestJS corpus.

## Fix (import-origin disambiguation, long-term root fix)
New `(*extractor).frameworkForClass(decorator)`:
- Unambiguous decorators (`@Component/@Directive/@Pipe/@NgModule` -> angular; `@Controller/@Resolver/@WebSocketGateway` -> nestjs) defer to the name-only `frameworkForDecorator`.
- For `@Injectable`, classify by **where the decorator was imported from**: `@nestjs/*` -> nestjs, `@angular/*` -> angular.
- If the decorator import is unresolved (barrel re-export, alias), fall back to **file-level framework markers** (any `@nestjs/*` import -> nestjs; any `@angular/*` import -> angular).
- With no markers at all, keep the historical `angular` default so genuine Angular projects are unaffected.

Wired into `handleAngularClass`, so both the provider entity's `framework` prop and its `INJECTED_INTO` edges get the corrected label.

## Before / after (in-pipeline test on real core-backend-v3 source)
| Provider | Before | After |
|---|---|---|
| `EmailService` (`@nestjs/common` @Injectable, ctor-injected) | angular | **nestjs** |
| `AppService` (`@nestjs/common` @Injectable) | angular | **nestjs** |
| `UserService` (genuine `@angular/core` @Injectable, providedIn:'root', @NgModule) | angular | angular (unchanged) |

A pure-NestJS repo now classifies ~all providers as nestjs, 0 angular.

## Validation
`internal/extractors/javascript/issue4503_di_nestjs_vs_angular_test.go` runs the **real** `Extract` pipeline over byte-copies of real core-backend-v3 providers + a genuine Angular provider, asserting NestJS->nestjs and Angular->angular on both the entity and the `INJECTED_INTO` edges, plus a barrel-reexport marker-fallback case and the unambiguous `@Controller` case. Confirmed the test fails on the pre-fix code (`EmailService framework = "angular"`) and passes after.

## Gates
- `go build ./...` OK
- `go vet ./internal/extractors/javascript/` OK
- `go test ./internal/extractors/javascript/ ./internal/custom/javascript/ ./internal/dashboard/` all pass (no regressions)

DEPLOY-DEFERRED: needs a daemon rebuild + reindex of upvate-v3 to reflect on live `/di`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)