### PR TITLE
fix(graph): auto-run force layout on load — invalidate pre-#4470 layout cache (#4492)

### DIFF
--- a/webui-v2/src/lib/graph-layout-cache.ts
+++ b/webui-v2/src/lib/graph-layout-cache.ts
@@ -43,8 +43,19 @@ const PREFIX = "archigraph.v2.layout";
  * rendered collapsed on every reload. Keeping this in lock-step with DEFAULTS_VERSION
  * guarantees all v4 caches are a guaranteed miss; first load re-settles with current
  * forces (== Reset). Reload === Reset by construction.
+ *
+ * Fix #4492: bump to 6 — #4470 (low-degree leaf ANCHORING — seeding any rendered-
+ * degree-≤1 node on top of its single neighbor instead of in its group-center blob)
+ * changed the INITIAL-POSITION SEEDING and therefore the SETTLED GEOMETRY for the
+ * same node set, but neither version stamp was bumped. So a returning user's v5
+ * cached layout (baked WITHOUT the anchoring) still passed isLayoutHealthy and was
+ * PINNED STATIC on load (the doSettle cache path) — the force sim never ran, so the
+ * graph showed the old un-anchored layout and only "exploded" into the new spread
+ * after a manual Reset (which routes through kickFreshSettle). Bumping makes every
+ * v5 layout a guaranteed miss → first load runs the unified fresh settle. Reload ===
+ * Reset by construction. (Kept in lock-step with DEFAULTS_VERSION = 6.)
  */
-export const LAYOUT_VERSION = 5;
+export const LAYOUT_VERSION = 6;
 
 function fnv1a32(s: string): string {
   let h = 0x811c9dc5 >>> 0;

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -208,7 +208,16 @@ const DEFAULT_ENABLED_EDGE_KINDS: EdgeKind[] = STRUCTURAL_EDGE_KINDS;
 // retuned). A stored v4 sizing/render blob (baseSize 90, pointSizeScale 0.22,
 // scalePointsOnZoom true) would be catastrophically wrong under the new model, so
 // discard it and adopt the new code defaults on next load — no manual Reset.
-const DEFAULTS_VERSION = 5;
+// Fix #4492: bump to 6 in LOCK-STEP with graph-layout-cache.LAYOUT_VERSION. #4470
+// changed the initial-position SEEDING (low-degree leaf anchoring), altering the
+// settled geometry for the same node set; the layout cache is scoped by
+// LAYOUT_VERSION (kept equal to this constant), so a v5→v6 bump invalidates every
+// pre-anchoring cached layout. Without it, a returning user's stale v5 layout was
+// pinned static on first load (sim never ran) and only Reset re-settled — the
+// "graph needs a manual Reset to lay out" bug. No DEFAULT_SIMULATION/sizing value
+// changed here, so persisted tuning is unaffected; this bump exists purely to keep
+// the two version stamps in lock-step per the documented protocol.
+const DEFAULTS_VERSION = 6;
 const VERSION_KEY = "ag.v2.graph.defaultsVersion";
 
 function readStoredVersion(): number {


### PR DESCRIPTION
Closes #4492

## Problem
On `/graph`, the cosmos.gl force simulation didn't auto-run on initial load — the user had to click **Reset** for the graph to "explode" into its laid-out form.

## Root cause
This is a regression from **#4470** (low-degree leaf *anchoring*). #4470 changed the **initial-position seeding** — any rendered-degree-≤1 node is now seeded on top of its single primary neighbor instead of in its group-center blob — which alters the *settled geometry* for the same node set. But neither layout-version stamp was bumped.

The layout cache (`graph-layout-cache.ts`) is scoped by `LAYOUT_VERSION`. A returning user's pre-#4470 `v5` cached layout still passed `isLayoutHealthy`, so the mount effect in `graph-canvas.tsx` took the **`doSettle()` pin-static path**: it pinned the stale cached positions and **never started the sim**. Only **Reset** (`requestRelayout` → `kickFreshSettle`) re-ran the sim with the new seeding — exactly the "press Reset to lay out" symptom.

Was #4470 seeding the cause? **Yes** — #4470 changed the seeding but forgot to bump the cache version that the file's own protocol requires whenever cluster-seeding / settled geometry changes.

## Fix
Bump both version stamps in lock-step, per the documented protocol:
- `LAYOUT_VERSION` 5 → 6 (`graph-layout-cache.ts`) — the load-bearing one: every pre-anchoring `v5` layout is now a guaranteed cache **miss**, so first load runs the unified fresh settle (`kickFreshSettle`) — identical to Reset. **Reload === Reset by construction.**
- `DEFAULTS_VERSION` 5 → 6 (`use-graph-store.ts`) — kept equal to `LAYOUT_VERSION` per protocol (no `DEFAULT_SIMULATION`/sizing value changed, so persisted tuning is unaffected).

No change to the simulation-start logic itself — `kickFreshSettle` was already correct; the bug was that a stale cache diverted first load away from it.

## #4467/#4470 behavior preserved
Low-degree anchoring, degree-based opacity, and the low-degree/unconnected badge live in the packed buffers / `packPointColors` / the route — all untouched. Only the cache version constants changed.

## Reset
Reset was never affected (it already routes through `kickFreshSettle`); it continues to work, and now matches first load.

## Gates
- `npm ci` ✓
- `npm run build` ✓ (only pre-existing chunk-size warnings)
- `npm run lint` (tsc --noEmit) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)