### PR TITLE
fix(paths): make Effective contract framework-aware, hide on non-DRF (#4486)

### DIFF
--- a/internal/dashboard/v2_paths_posture.go
+++ b/internal/dashboard/v2_paths_posture.go
@@ -56,6 +56,44 @@ type v2PathPostureResponse struct {
 	// ViewSet, or null when no DRF/pack-known ViewSet backs this path. Note
 	// carries the honest-partial explanation when no groups resolved.
 	Contract *mcp.EffectiveContractResult `json:"contract"`
+	// ContractApplicable reports whether the effective-contract feature is
+	// meaningful for this path at all (#4486). It is a DRF/Django-only feature;
+	// for NestJS / Express / Go / GraphQL endpoints it is N/A and the UI hides
+	// the section entirely rather than rendering DRF-specific empty-state prose.
+	// True only when at least one matched endpoint is a DRF/Django framework.
+	ContractApplicable bool `json:"contract_applicable"`
+}
+
+// contractApplicableFrameworks is the set of endpoint framework keys for which
+// the effective-contract feature (DRF router-expansion + serializer/permission
+// MRO resolution) is meaningful. Everything else (nestjs/express/fastapi/flask/
+// go/graphql/…) gets a clean N/A so the dashboard never shows DRF wording on a
+// non-Django endpoint (#4486).
+var contractApplicableFrameworks = map[string]bool{
+	"drf":    true,
+	"django": true,
+}
+
+// isContractApplicableEndpoint reports whether the effective-contract feature is
+// meaningful for an endpoint entity (#4486). It is DRF/Django-only, detected by
+// EITHER the endpoint's `framework` property (drf/django) OR a DRF router-
+// expansion marker (`pattern_type=drf_router_expanded` / a `drf_view_method`
+// attribution), which router-expanded routes carry even when they leave the
+// generic `framework` prop unset.
+func isContractApplicableEndpoint(e *graph.Entity) bool {
+	if e == nil || e.Properties == nil {
+		return false
+	}
+	if contractApplicableFrameworks[strings.ToLower(e.Properties["framework"])] {
+		return true
+	}
+	if strings.Contains(strings.ToLower(e.Properties["pattern_type"]), "drf") {
+		return true
+	}
+	if e.Properties["drf_view_method"] != "" {
+		return true
+	}
+	return false
 }
 
 // handleV2PathPosture — GET /api/v2/groups/:id/paths/:hash/posture
@@ -96,6 +134,10 @@ func (s *Server) handleV2PathPosture(w http.ResponseWriter, r *http.Request) {
 	// ViewSet (deduplicated). Lower-cased leaf is the resolution key.
 	contractTargets := []string{}
 	seenTarget := map[string]bool{}
+	// contractApplicable is OR-ed across the matched endpoints: the effective
+	// contract feature is shown only when at least one endpoint is DRF/Django
+	// (#4486). Stays false for NestJS / Express / Go / GraphQL paths.
+	contractApplicable := false
 
 	for _, repo := range sortedRepos(grp) {
 		if repo.Doc == nil {
@@ -123,6 +165,11 @@ func (s *Server) handleV2PathPosture(w http.ResponseWriter, r *http.Request) {
 			}
 			if pathStr == "" {
 				pathStr = path
+			}
+
+			// Effective-contract applicability (#4486): DRF/Django-only feature.
+			if isContractApplicableEndpoint(e) {
+				contractApplicable = true
 			}
 
 			// --- Posture: assemble from the endpoint entity itself AND its
@@ -214,11 +261,19 @@ func (s *Server) handleV2PathPosture(w http.ResponseWriter, r *http.Request) {
 		contract.Groups = append(contract.Groups, res.Groups...)
 	}
 
+	// #4486: never surface the (DRF-specific) effective contract — including its
+	// "is it a DRF ViewSet…" empty-state prose — on a non-DRF/Django endpoint.
+	// Resolved groups are only kept when the path is actually DRF/Django-backed.
+	if !contractApplicable {
+		contract = nil
+	}
+
 	writeV2JSON(w, http.StatusOK, v2OK(v2PathPostureResponse{
-		PathHash:  pathHash,
-		Path:      pathStr,
-		Endpoints: postures,
-		Contract:  contract,
+		PathHash:           pathHash,
+		Path:               pathStr,
+		Endpoints:          postures,
+		Contract:           contract,
+		ContractApplicable: contractApplicable,
 	}))
 }
 

--- a/internal/dashboard/v2_paths_posture_test.go
+++ b/internal/dashboard/v2_paths_posture_test.go
@@ -148,6 +148,9 @@ func TestPathPosture_SurfacesFacets(t *testing.T) {
 	}
 
 	// --- Effective contract assertions (reused MRO/pack-aware projection) ---
+	if !resp.ContractApplicable {
+		t.Errorf("expected ContractApplicable=true for a DRF ViewSet path")
+	}
 	if resp.Contract == nil {
 		t.Fatalf("expected non-nil effective contract for a DRF ViewSet path")
 	}
@@ -209,6 +212,43 @@ func TestPathPosture_HonestEmpty(t *testing.T) {
 	}
 	if resp.Contract != nil {
 		t.Errorf("expected nil contract for non-ViewSet endpoint, got %+v", resp.Contract)
+	}
+	if resp.ContractApplicable {
+		t.Errorf("expected ContractApplicable=false for a non-DRF endpoint")
+	}
+}
+
+// TestPathPosture_NestJSNotApplicable — #4486: a NestJS controller endpoint must
+// NOT surface the DRF-only effective contract (nor any DRF empty-state prose):
+// the contract is nil and ContractApplicable is false so the UI hides the
+// section entirely.
+func TestPathPosture_NestJSNotApplicable(t *testing.T) {
+	const path = "/api/users"
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID:   "ep:users:get",
+				Name: "UsersController.findAll",
+				Kind: "http_endpoint",
+				Properties: map[string]string{
+					"path":      path,
+					"verb":      "GET",
+					"framework": "nestjs",
+				},
+				SourceFile: "src/users/users.controller.ts",
+				StartLine:  10,
+			},
+		},
+	}
+	srv := injectPostureGroup(t, "g-nest", doc)
+	resp := fetchPosture(t, srv, "g-nest", hashStr(path))
+
+	if resp.ContractApplicable {
+		t.Errorf("expected ContractApplicable=false for a NestJS endpoint")
+	}
+	if resp.Contract != nil {
+		t.Errorf("expected nil contract for a NestJS endpoint (no DRF prose leak), got %+v", resp.Contract)
 	}
 }
 

--- a/webui-v2/src/components/Paths/EndpointDetail/PostureSection.tsx
+++ b/webui-v2/src/components/Paths/EndpointDetail/PostureSection.tsx
@@ -35,7 +35,22 @@ interface PostureSectionProps {
   contractOpen: boolean;
   onTogglePosture: () => void;
   onToggleContract: () => void;
+  /**
+   * #4486 — the endpoint's framework (e.g. "drf", "django", "nestjs",
+   * "express"). Used as a fallback applicability signal when the backend
+   * `contract_applicable` flag is absent (older payloads): the effective
+   * contract is a DRF/Django-only feature, so the section is hidden for
+   * everything else rather than showing DRF-specific empty-state wording.
+   */
+  framework?: string;
 }
+
+/**
+ * #4486 — the set of endpoint frameworks for which the (DRF-only)
+ * effective-contract feature is meaningful. Mirrors the backend
+ * `contractApplicableFrameworks` set in internal/dashboard/v2_paths_posture.go.
+ */
+const CONTRACT_FRAMEWORKS = new Set(["drf", "django"]);
 
 /* ----------------------------------------------------------------
    Small presentational helpers
@@ -238,6 +253,7 @@ export function PostureSection({
   contractOpen,
   onTogglePosture,
   onToggleContract,
+  framework,
 }: PostureSectionProps) {
   // Lazy-fetch only when at least one of the two sections is open.
   const enabledHash = postureOpen || contractOpen ? pathHash : null;
@@ -247,6 +263,20 @@ export function PostureSection({
   const postureCount = endpoints.filter((e) => e.has_posture).length;
   const contract = data?.contract ?? null;
   const contractCount = (contract?.groups ?? []).reduce((n, g) => n + g.handlers.length, 0);
+
+  // #4486 — Effective contract is a DRF/Django-only feature. Hide the section
+  // entirely (rather than render DRF-specific "is it a DRF ViewSet…" wording)
+  // for NestJS / Express / Go / GraphQL endpoints. Applicability is decided by:
+  //   1. the backend `contract_applicable` flag when present (authoritative); else
+  //   2. the endpoint framework (drf/django) as a fallback for older payloads.
+  // Before the payload loads, only hide when we already know from the framework
+  // prop that this is a non-DRF endpoint, so the section never flashes DRF prose.
+  const frameworkApplicable =
+    framework === undefined ? undefined : CONTRACT_FRAMEWORKS.has(framework.toLowerCase());
+  const contractApplicable =
+    data?.contract_applicable ?? frameworkApplicable ?? true;
+  // Once we have a resolved contract it is, by definition, applicable.
+  const showContractSection = contractApplicable || contract !== null;
 
   return (
     <>
@@ -280,7 +310,10 @@ export function PostureSection({
         )}
       </div>
 
-      {/* Effective contract */}
+      {/* Effective contract — #4486: DRF/Django-only. Omitted entirely for
+          non-DRF endpoints (NestJS/Express/Go/GraphQL) so we never surface the
+          DRF-specific empty-state wording on a non-Django group. */}
+      {showContractSection && (
       <div>
         <SectionHeader
           icon={<FileSignature size={14} />}
@@ -311,6 +344,7 @@ export function PostureSection({
           </div>
         )}
       </div>
+      )}
     </>
   );
 }

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1075,6 +1075,14 @@ export interface PathPostureResponse {
   endpoints: PosturePayload[];
   /** null when no DRF/pack-known ViewSet backs this path. */
   contract: EffectiveContractResult | null;
+  /**
+   * #4486 — whether the (DRF/Django-only) effective-contract feature is
+   * meaningful for this path. False for NestJS / Express / Go / GraphQL
+   * endpoints, where the UI hides the section entirely rather than rendering
+   * DRF-specific empty-state wording. Optional for backward-compat with older
+   * payloads (treated as "unknown" → fall back to framework/contract shape).
+   */
+  contract_applicable?: boolean;
 }
 
 /** One orphan caller row. */

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -1011,6 +1011,7 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
           contractOpen={openSections.contract}
           onTogglePosture={() => toggleSection("posture")}
           onToggleContract={() => toggleSection("contract")}
+          framework={detail.handlers[0]?.framework}
         />
 
         {/* 2. Parameters — ShapeTree subtree (#1935 Phase 1).


### PR DESCRIPTION
## Problem (#4486)

The Paths detail pane's **Effective contract** section is a Django/DRF-only feature, but it was surfaced for *every* endpoint. On a NestJS (or any non-Django) group it rendered the DRF-specific empty-state note ("…no effective contract resolvable… is it a DRF ViewSet… ModelViewSet/GenericViewSet…"), which is confusing and wrong.

## Fix — framework-aware, frontend-primary

**Frontend (primary):** `PostureSection` now **hides the Effective-contract section entirely** when it is not applicable. Applicability is decided by:
1. the backend `contract_applicable` flag when present (authoritative), else
2. the endpoint framework (`drf` / `django`) as a fallback for older payloads.

The section still renders for genuine DRF/Django endpoints (including honest-empty contracts). No DRF wording is ever shown for NestJS/Express/Go/GraphQL.

**Backend (minimal):** instead of leaking DRF prose, `internal/dashboard/v2_paths_posture.go` now emits a clean `contract_applicable` boolean, OR-ed across the matched endpoints. It's true only for DRF/Django — detected via `framework=drf/django` OR a DRF router-expansion marker (`pattern_type` contains `drf`, or a `drf_view_method` attribution, which router-expanded routes carry even when `framework` is unset). The resolved contract is defensively nulled when not applicable.

## How non-applicability is detected
- Backend: `isContractApplicableEndpoint(e)` — framework in {drf, django} OR DRF router-expansion markers.
- Frontend: `data.contract_applicable ?? framework∈{drf,django} ?? true`, never flashing DRF prose before the payload loads.

## Hide logic
`showContractSection = contractApplicable || contract !== null` — the section mounts only when applicable (or when a real contract actually resolved).

## Tests
- DRF path: asserts `ContractApplicable=true` + contract present.
- Honest-empty (Go) path: `ContractApplicable=false`, nil contract.
- New NestJS regression test: nil contract, `ContractApplicable=false` — no DRF prose leak.

## Gates
- `go build ./...` ✅ · `go vet ./internal/dashboard/...` ✅ · `go test ./internal/dashboard -run TestPathPosture` ✅
- `npm ci` ✅ · `npm run build` ✅ · `npm run lint` (tsc --noEmit) ✅

Closes #4486

🤖 Generated with [Claude Code](https://claude.com/claude-code)