### PR TITLE
feat(dashboard): app-wide source peek for file:line refs (#4499)

### DIFF
--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -749,6 +749,8 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths/{hash}/downstream-dag", s.handleV2PathDownstreamDAG)
 	// #1935 Phase 1 — ShapeTree subtree resolution (lazy class-field walk).
 	mux.HandleFunc("GET /api/v2/groups/{id}/shape", s.handleV2Shape)
+	// #4499 — shared "source peek": window of source for any file:line ref.
+	mux.HandleFunc("GET /api/v2/groups/{id}/source", s.handleV2Source)
 	// Module-level GDS analysis (#1384, epic #1380) — SCC + PageRank +
 	// betweenness over the aggregated module graph.
 	mux.HandleFunc("GET /api/v2/groups/{group}/modules/analysis", s.handleV2ModulesAnalysis)

--- a/internal/dashboard/v2_source.go
+++ b/internal/dashboard/v2_source.go
@@ -1,0 +1,336 @@
+// v2_source.go — shared "source peek" endpoint for WebUI v2 (#4499).
+//
+// The dashboard renders file:line refs all over the place (Taint paths, Flow
+// cards, Paths "defined-in", Security findings, IaC). Each was a dead string.
+// This endpoint is the get_source equivalent for the UI: given a repo-relative
+// file path and a target line, it returns a window of source (or the whole file
+// when small) read from the indexed repo's working tree, plus a language hint
+// for client-side syntax highlighting.
+//
+//	GET /api/v2/groups/{id}/source?file=<rel>&line=<n>&context=<n>&repo=<slug>
+//
+// Resolution:
+//   - The repo root comes from the group config (DashRepo.Path). A file may be
+//     relative to any repo in the group; when ?repo=<slug> is given we pin to
+//     that repo, otherwise we try each repo root and use the first that holds
+//     the file on disk.
+//   - Path traversal is guarded: the resolved absolute path MUST stay within the
+//     repo root (after symlink-free Clean) or the request is rejected.
+//   - language is derived from the file extension (a hint only; the client maps
+//     it to a highlighter grammar).
+//
+// The window is [line-context, line+context] clamped to the file bounds; when
+// the file is small (<= maxWholeFileLines) the whole file is returned so the
+// reader has full context. line==0 (no recorded position) returns the file head.
+
+package dashboard
+
+import (
+	"bufio"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Wire shapes
+// ---------------------------------------------------------------------------
+
+// v2SourceLine is one returned source line with its absolute (1-based) number.
+type v2SourceLine struct {
+	Number int    `json:"number"`
+	Text   string `json:"text"`
+}
+
+// v2SourceReply is the response for GET /api/v2/groups/{id}/source.
+type v2SourceReply struct {
+	// File is the repo-relative path that was read (as resolved).
+	File string `json:"file"`
+	// Repo is the slug of the repo the file was found in.
+	Repo string `json:"repo"`
+	// Language is the highlighter hint derived from the extension (e.g. "ts").
+	Language string `json:"language"`
+	// Line is the target line the caller asked to center on (echoed back).
+	Line int `json:"line"`
+	// StartLine is the 1-based number of the first returned line.
+	StartLine int `json:"start_line"`
+	// EndLine is the 1-based number of the last returned line.
+	EndLine int `json:"end_line"`
+	// TotalLines is the file's full line count (so the UI can show "x of N").
+	TotalLines int `json:"total_lines"`
+	// Truncated is true when the returned window is a slice of a larger file.
+	Truncated bool `json:"truncated"`
+	// Lines is the returned window.
+	Lines []v2SourceLine `json:"lines"`
+}
+
+const (
+	// v2SourceDefaultContext is the default number of lines shown around the
+	// target line when the file is too large to return whole.
+	v2SourceDefaultContext = 40
+	// v2SourceMaxContext bounds the caller-supplied context to keep responses
+	// reasonable.
+	v2SourceMaxContext = 400
+	// v2SourceWholeFileLines is the threshold below which the entire file is
+	// returned (so small files render with full context, centered on the line).
+	v2SourceWholeFileLines = 600
+	// v2SourceMaxBytes caps the file size we will read to avoid serving huge
+	// generated/minified blobs.
+	v2SourceMaxBytes = 8 << 20 // 8 MiB
+)
+
+// ---------------------------------------------------------------------------
+// GET /api/v2/groups/{id}/source
+// ---------------------------------------------------------------------------
+
+// handleV2Source serves a window of source from the indexed repo working tree
+// so the WebUI can open a "source peek" modal for any file:line ref.
+func (s *Server) handleV2Source(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeV2Err(w, http.StatusBadRequest, "group_required", "group id required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(id)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "group_not_found", err.Error())
+		return
+	}
+
+	q := r.URL.Query()
+	rawFile := strings.TrimSpace(q.Get("file"))
+	if rawFile == "" {
+		writeV2Err(w, http.StatusBadRequest, "file_required", "file query param required")
+		return
+	}
+
+	line := 0
+	if v := strings.TrimSpace(q.Get("line")); v != "" {
+		if n, e := strconv.Atoi(v); e == nil && n > 0 {
+			line = n
+		}
+	}
+
+	context := v2SourceDefaultContext
+	if v := strings.TrimSpace(q.Get("context")); v != "" {
+		if n, e := strconv.Atoi(v); e == nil && n >= 0 {
+			context = n
+		}
+	}
+	if context > v2SourceMaxContext {
+		context = v2SourceMaxContext
+	}
+
+	wantRepo := strings.TrimSpace(q.Get("repo"))
+
+	abs, repoSlug, relFile, ok := resolveSourcePath(grp, rawFile, wantRepo)
+	if !ok {
+		writeV2Err(w, http.StatusNotFound, "source_not_found",
+			"file not found in any repo of this group (or outside repo root)")
+		return
+	}
+
+	info, statErr := os.Stat(abs)
+	if statErr != nil || info.IsDir() {
+		writeV2Err(w, http.StatusNotFound, "source_not_found", "file does not exist")
+		return
+	}
+	if info.Size() > v2SourceMaxBytes {
+		writeV2Err(w, http.StatusRequestEntityTooLarge, "source_too_large",
+			"file exceeds the maximum size for source peek")
+		return
+	}
+
+	all, readErr := readAllLines(abs)
+	if readErr != nil {
+		writeV2Err(w, http.StatusInternalServerError, "source_read_failed", readErr.Error())
+		return
+	}
+
+	total := len(all)
+	start, end := sourceWindow(total, line, context)
+
+	out := make([]v2SourceLine, 0, end-start+1)
+	for i := start; i <= end && i <= total; i++ {
+		out = append(out, v2SourceLine{Number: i, Text: all[i-1]})
+	}
+
+	writeV2JSON(w, http.StatusOK, v2OK(v2SourceReply{
+		File:       relFile,
+		Repo:       repoSlug,
+		Language:   languageFromExt(relFile),
+		Line:       line,
+		StartLine:  start,
+		EndLine:    end,
+		TotalLines: total,
+		Truncated:  start > 1 || end < total,
+		Lines:      out,
+	}))
+}
+
+// resolveSourcePath maps a (possibly repo-relative) file to an absolute path on
+// disk within a repo of grp, guarding against path traversal. It returns the
+// absolute path, the owning repo slug, the cleaned repo-relative path, and ok.
+//
+// When wantRepo is set we only consider that repo; otherwise we try each repo
+// root and accept the first where the file exists on disk and stays within the
+// root.
+func resolveSourcePath(grp *DashGroup, rawFile, wantRepo string) (abs, slug, rel string, ok bool) {
+	if grp == nil {
+		return "", "", "", false
+	}
+	// Normalise the requested path: strip any leading separators and clean it.
+	// An absolute incoming path is treated as repo-relative by taking its
+	// cleaned form (we never read outside a repo root).
+	clean := filepath.Clean("/" + filepath.ToSlash(rawFile))
+	clean = strings.TrimPrefix(clean, "/")
+
+	tryRepo := func(repo *DashRepo) (string, string, bool) {
+		if repo == nil || repo.Path == "" {
+			return "", "", false
+		}
+		root, err := filepath.Abs(repo.Path)
+		if err != nil {
+			return "", "", false
+		}
+		candidate := filepath.Join(root, filepath.FromSlash(clean))
+		// Traversal guard: the joined path must remain within root.
+		rootWithSep := root + string(os.PathSeparator)
+		if candidate != root && !strings.HasPrefix(candidate, rootWithSep) {
+			return "", "", false
+		}
+		if st, e := os.Stat(candidate); e != nil || st.IsDir() {
+			return "", "", false
+		}
+		return candidate, clean, true
+	}
+
+	if wantRepo != "" {
+		if repo, found := grp.Repos[wantRepo]; found {
+			if a, rl, good := tryRepo(repo); good {
+				return a, wantRepo, rl, true
+			}
+		}
+		return "", "", "", false
+	}
+
+	for s, repo := range grp.Repos {
+		if a, rl, good := tryRepo(repo); good {
+			return a, s, rl, true
+		}
+	}
+	return "", "", "", false
+}
+
+// sourceWindow computes the inclusive [start,end] 1-based line window to return.
+// Small files are returned whole; otherwise a window of ±context around line is
+// returned (clamped to file bounds). line<=0 anchors at the file head.
+func sourceWindow(total, line, context int) (start, end int) {
+	if total <= 0 {
+		return 1, 0
+	}
+	if total <= v2SourceWholeFileLines {
+		return 1, total
+	}
+	if line <= 0 {
+		end = 1 + context*2
+		if end > total {
+			end = total
+		}
+		return 1, end
+	}
+	start = line - context
+	if start < 1 {
+		start = 1
+	}
+	end = line + context
+	if end > total {
+		end = total
+	}
+	return start, end
+}
+
+// readAllLines reads a file into a slice of lines (newline-stripped). It uses a
+// large scanner buffer so long minified lines do not error.
+func readAllLines(abs string) ([]string, error) {
+	f, err := os.Open(abs)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1<<20), 64<<20)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	return lines, scanner.Err()
+}
+
+// languageFromExt maps a file extension to a highlighter language hint. The
+// client maps these onto its highlighter grammars; unknown extensions return
+// "text".
+func languageFromExt(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	if m, ok := sourceLangByExt[ext]; ok {
+		return m
+	}
+	// Fall back to extension-less basenames we recognise.
+	switch strings.ToLower(filepath.Base(path)) {
+	case "dockerfile":
+		return "docker"
+	case "makefile":
+		return "makefile"
+	}
+	return "text"
+}
+
+// sourceLangByExt maps common source extensions to highlighter language hints.
+var sourceLangByExt = map[string]string{
+	".ts":      "typescript",
+	".tsx":     "tsx",
+	".js":      "javascript",
+	".jsx":     "jsx",
+	".mjs":     "javascript",
+	".cjs":     "javascript",
+	".go":      "go",
+	".py":      "python",
+	".rb":      "ruby",
+	".java":    "java",
+	".kt":      "kotlin",
+	".kts":     "kotlin",
+	".cs":      "csharp",
+	".cpp":     "cpp",
+	".cc":      "cpp",
+	".cxx":     "cpp",
+	".hpp":     "cpp",
+	".h":       "c",
+	".c":       "c",
+	".rs":      "rust",
+	".php":     "php",
+	".swift":   "swift",
+	".scala":   "scala",
+	".sql":     "sql",
+	".sh":      "bash",
+	".bash":    "bash",
+	".zsh":     "bash",
+	".yaml":    "yaml",
+	".yml":     "yaml",
+	".json":    "json",
+	".toml":    "toml",
+	".xml":     "xml",
+	".html":    "html",
+	".css":     "css",
+	".scss":    "scss",
+	".md":      "markdown",
+	".tf":      "hcl",
+	".hcl":     "hcl",
+	".proto":   "protobuf",
+	".graphql": "graphql",
+	".gql":     "graphql",
+	".vue":     "vue",
+}

--- a/internal/dashboard/v2_source_test.go
+++ b/internal/dashboard/v2_source_test.go
@@ -1,0 +1,161 @@
+package dashboard
+
+// v2_source_test.go — unit tests for the source-peek helpers (#4499).
+//
+// Covers the path-traversal guard and multi-repo resolution in
+// resolveSourcePath, the small-file-whole / large-file-window logic in
+// sourceWindow, and the extension → language hint mapping.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeRepoFile creates rel under root (making parent dirs) with content.
+func writeRepoFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestResolveSourcePath_FindsFileAcrossRepos(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	writeRepoFile(t, rootB, "src/app.ts", "const x = 1;\n")
+
+	grp := &DashGroup{Repos: map[string]*DashRepo{
+		"a": {Slug: "a", Path: rootA},
+		"b": {Slug: "b", Path: rootB},
+	}}
+
+	abs, slug, rel, ok := resolveSourcePath(grp, "src/app.ts", "")
+	if !ok {
+		t.Fatalf("expected to resolve file in repo b")
+	}
+	if slug != "b" {
+		t.Errorf("slug = %q; want b", slug)
+	}
+	if rel != "src/app.ts" {
+		t.Errorf("rel = %q; want src/app.ts", rel)
+	}
+	if !strings.HasPrefix(abs, rootB) {
+		t.Errorf("abs %q not under rootB %q", abs, rootB)
+	}
+}
+
+func TestResolveSourcePath_PinnedRepo(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	// Same rel path exists in BOTH repos; ?repo must pin selection.
+	writeRepoFile(t, rootA, "x.go", "package a\n")
+	writeRepoFile(t, rootB, "x.go", "package b\n")
+
+	grp := &DashGroup{Repos: map[string]*DashRepo{
+		"a": {Slug: "a", Path: rootA},
+		"b": {Slug: "b", Path: rootB},
+	}}
+
+	_, slug, _, ok := resolveSourcePath(grp, "x.go", "a")
+	if !ok || slug != "a" {
+		t.Fatalf("pinned resolve = (%q,%v); want (a,true)", slug, ok)
+	}
+}
+
+func TestResolveSourcePath_RejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	// Secret lives OUTSIDE the repo root.
+	parent := filepath.Dir(root)
+	secret := filepath.Join(parent, "secret.txt")
+	if err := os.WriteFile(secret, []byte("top secret\n"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(secret) })
+
+	grp := &DashGroup{Repos: map[string]*DashRepo{
+		"a": {Slug: "a", Path: root},
+	}}
+
+	for _, attack := range []string{
+		"../secret.txt",
+		"../../etc/passwd",
+		"foo/../../secret.txt",
+		"/etc/passwd",
+	} {
+		if _, _, _, ok := resolveSourcePath(grp, attack, ""); ok {
+			t.Errorf("traversal %q resolved; want rejected", attack)
+		}
+	}
+}
+
+func TestResolveSourcePath_MissingFile(t *testing.T) {
+	root := t.TempDir()
+	grp := &DashGroup{Repos: map[string]*DashRepo{"a": {Slug: "a", Path: root}}}
+	if _, _, _, ok := resolveSourcePath(grp, "nope.ts", ""); ok {
+		t.Errorf("missing file resolved; want false")
+	}
+}
+
+func TestSourceWindow(t *testing.T) {
+	cases := []struct {
+		name                 string
+		total, line, context int
+		wantStart, wantEnd   int
+	}{
+		{"small file returned whole", 50, 25, 10, 1, 50},
+		{"large file windowed around line", 5000, 1000, 40, 960, 1040},
+		{"window clamped at top", 5000, 5, 40, 1, 45},
+		{"window clamped at bottom", 5000, 4990, 40, 4950, 5000},
+		{"large file no line anchors head", 5000, 0, 40, 1, 81},
+		{"empty file", 0, 10, 10, 1, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			start, end := sourceWindow(c.total, c.line, c.context)
+			if start != c.wantStart || end != c.wantEnd {
+				t.Errorf("sourceWindow(%d,%d,%d) = (%d,%d); want (%d,%d)",
+					c.total, c.line, c.context, start, end, c.wantStart, c.wantEnd)
+			}
+		})
+	}
+}
+
+func TestLanguageFromExt(t *testing.T) {
+	cases := map[string]string{
+		"src/app.ts":      "typescript",
+		"src/App.tsx":     "tsx",
+		"main.go":         "go",
+		"a/b/c.py":        "python",
+		"infra/main.tf":   "hcl",
+		"Dockerfile":      "docker",
+		"Makefile":        "makefile",
+		"data.unknownext": "text",
+		"noext":           "text",
+	}
+	for path, want := range cases {
+		if got := languageFromExt(path); got != want {
+			t.Errorf("languageFromExt(%q) = %q; want %q", path, got, want)
+		}
+	}
+}
+
+func TestReadAllLines(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(p, []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	lines, err := readAllLines(p)
+	if err != nil {
+		t.Fatalf("readAllLines: %v", err)
+	}
+	if len(lines) != 3 || lines[0] != "a" || lines[2] != "c" {
+		t.Errorf("lines = %v; want [a b c]", lines)
+	}
+}

--- a/webui-v2/package-lock.json
+++ b/webui-v2/package-lock.json
@@ -28,6 +28,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.2",
+        "react-syntax-highlighter": "^15.6.6",
         "sonner": "^1.7.2",
         "tailwind-merge": "^2.6.0",
         "zustand": "^5.0.3"
@@ -37,6 +38,7 @@
         "@tailwindcss/postcss": "^4.0.17",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^4.3.4",
         "postcss": "^8.4.0",
         "tailwindcss": "^4.0.17",
@@ -303,6 +305,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2854,6 +2865,15 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmmirror.com/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2882,12 +2902,28 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/@upsetjs/venn.js": {
       "version": "2.0.0",
@@ -3222,6 +3258,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmmirror.com/check-error/-/check-error-2.1.3.tgz",
@@ -3261,6 +3327,16 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -3982,6 +4058,19 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
@@ -3998,6 +4087,14 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/fsevents": {
@@ -4068,6 +4165,48 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4097,6 +4236,50 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/jiti": {
@@ -4469,6 +4652,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4580,6 +4777,24 @@
       "resolved": "https://registry.npmmirror.com/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
@@ -4714,6 +4929,28 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/random": {
@@ -4864,6 +5101,47 @@
         }
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "15.6.6",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.6.tgz",
+      "integrity": "sha512-DgXrc+AZF47+HvAPEmn7Ua/1p10jNoVZVI/LoPiYdtY+OM+/nG5yefLHKJwdKqY1adMuHFbeyBaG9j64ML7vTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+      "license": "MIT",
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/regl": {
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/regl/-/regl-2.1.1.tgz",
@@ -4995,6 +5273,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stackback": {
@@ -5449,6 +5737,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/webui-v2/package.json
+++ b/webui-v2/package.json
@@ -33,6 +33,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.2",
+    "react-syntax-highlighter": "^15.6.6",
     "sonner": "^1.7.2",
     "tailwind-merge": "^2.6.0",
     "zustand": "^5.0.3"
@@ -42,6 +43,7 @@
     "@tailwindcss/postcss": "^4.0.17",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.3.4",
     "postcss": "^8.4.0",
     "tailwindcss": "^4.0.17",

--- a/webui-v2/src/components/RefLine.tsx
+++ b/webui-v2/src/components/RefLine.tsx
@@ -24,8 +24,10 @@
      name   — entity / caller name (regular weight)
    ============================================================ */
 
+import { useParams } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { getRepoColor } from "@/lib/repo-color";
+import { useSourcePeek } from "@/components/SourcePeek";
 
 export interface RefLineProps {
   repo: string;
@@ -35,8 +37,18 @@ export interface RefLineProps {
   /** Accessibility: full title on hover (defaults to "repo · file:line  name") */
   title?: string;
   className?: string;
-  /** Called when the file path link is clicked. Receives "file:line" string. */
+  /**
+   * Called when the file path link is clicked. Receives "file:line" string.
+   * When provided it runs IN ADDITION to opening the shared source-peek modal
+   * (#4499), so existing nav side-effects are preserved.
+   */
   onFileClick?: (fileRef: string) => void;
+  /**
+   * Disable the shared source-peek modal on click (#4499). Defaults to false
+   * (clicking the file:line opens its source). Set true when the caller wants
+   * onFileClick to be the only click behavior.
+   */
+  disableSourcePeek?: boolean;
   /**
    * Render the right-anchored repo chip (default true). Set false when the
    * caller already shows the repo elsewhere in the row to avoid a duplicate
@@ -100,11 +112,21 @@ export function RefLine({
   className,
   onFileClick,
   showRepoChip = true,
+  disableSourcePeek = false,
 }: RefLineProps) {
   const repoColors = getRepoColor(repo);
   const fileLabel = file ? `${file}:${line}` : line > 0 ? `:${line}` : "";
   const derivedTitle = title ?? `${repo} · ${file}:${line}  ${name}`;
   const { head, tail } = splitPathForEllipsis(file, line);
+  const { openSourcePeek } = useSourcePeek();
+  const { groupId = "" } = useParams<{ groupId: string }>();
+
+  const handleFileClick = () => {
+    onFileClick?.(fileLabel);
+    if (!disableSourcePeek && file && groupId) {
+      openSourcePeek({ groupId, file, line, repo });
+    }
+  };
 
   return (
     <div
@@ -120,7 +142,7 @@ export function RefLine({
       {fileLabel && (
         <button
           type="button"
-          onClick={() => onFileClick?.(fileLabel)}
+          onClick={handleFileClick}
           title={fileLabel}
           className={cn(
             "flex items-center min-w-0 text-left",

--- a/webui-v2/src/components/SourcePeek/SourcePeek.tsx
+++ b/webui-v2/src/components/SourcePeek/SourcePeek.tsx
@@ -1,0 +1,242 @@
+/* ============================================================
+   SourcePeek.tsx — shared "source peek" modal (#4499).
+
+   Clicking any file:line ref in the dashboard (Taint paths, Flow cards,
+   Paths "defined-in", Security findings, IaC, DI/quality links) opens this
+   CENTERED modal showing the actual source for that line — the get_source
+   equivalent for the UI.
+
+   - Fetches GET /api/v2/groups/:id/source (a window around the line, or the
+     whole file when small) via useSource.
+   - Syntax-highlights with react-syntax-highlighter's PrismAsyncLight build:
+     grammars are lazy-loaded per language, so only the languages actually
+     viewed are pulled in (keeps the initial bundle lean).
+   - Centers/scrolls to the target line and highlights it.
+   - Shows the file path + repo, a copy-path affordance, and loading / error /
+     empty states.
+
+   Wiring is app-wide via <SourcePeekProvider> + useSourcePeek(): any ref
+   renderer calls openSourcePeek({ groupId, file, line, repo }) and the single
+   mounted modal handles the rest.
+   ============================================================ */
+
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter";
+import { Check, Copy, FileCode2, Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { getRepoColor } from "@/lib/repo-color";
+import { useSource } from "@/hooks/use-source";
+import { sourcePeekPrismTheme } from "./syntax-theme";
+
+/** The ref a caller asks to peek at. */
+export interface SourcePeekTarget {
+  groupId: string;
+  file: string;
+  line: number;
+  /** Optional repo slug to pin resolution when the same path exists twice. */
+  repo?: string;
+}
+
+interface SourcePeekProps extends SourcePeekTarget {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * basename — last path segment, for the modal title (full path shown below).
+ */
+function basename(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i < 0 ? p : p.slice(i + 1);
+}
+
+export function SourcePeek({
+  groupId,
+  file,
+  line,
+  repo,
+  open,
+  onOpenChange,
+}: SourcePeekProps) {
+  // Only fetch while the modal is open (lazy).
+  const { data, isLoading, isError, error } = useSource(
+    groupId,
+    open ? file : null,
+    line,
+    repo,
+    open,
+  );
+
+  const [copied, setCopied] = useState(false);
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Center the highlighted line once the content paints.
+  useLayoutEffect(() => {
+    if (!open || !data) return;
+    // Defer to next frame so the highlighter has rendered the rows.
+    const id = requestAnimationFrame(() => {
+      const el = targetRef.current;
+      const scroller = scrollRef.current;
+      if (el && scroller) {
+        const elTop = el.offsetTop;
+        const center = elTop - scroller.clientHeight / 2 + el.clientHeight / 2;
+        scroller.scrollTop = Math.max(0, center);
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [open, data]);
+
+  // Reset the copied affordance when the target changes.
+  useEffect(() => {
+    setCopied(false);
+  }, [file, line, open]);
+
+  const fileLabel = `${file}${line > 0 ? `:${line}` : ""}`;
+  const repoColors = repo ? getRepoColor(repo) : null;
+
+  const code = useMemo(() => {
+    if (!data) return "";
+    return data.lines.map((l) => l.text).join("\n");
+  }, [data]);
+
+  const startLine = data?.start_line ?? 1;
+
+  const copyPath = () => {
+    void navigator.clipboard
+      ?.writeText(fileLabel)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* clipboard unavailable — no-op */
+      });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="p-0 flex flex-col overflow-hidden max-w-[min(1000px,94vw)] w-full h-[80vh]"
+      >
+        {/* Header — file basename + path + repo chip + copy affordance. */}
+        <div className="px-5 pt-4 pb-3 border-b border-border shrink-0">
+          <DialogTitle className="flex items-center gap-2 min-w-0">
+            <FileCode2 size={16} className="text-text-3 shrink-0" />
+            <span className="truncate font-mono text-md">{basename(file)}</span>
+            {data?.repo && repoColors && (
+              <span
+                className="shrink-0 inline-flex items-center h-[18px] px-1.5 rounded text-[10px] font-semibold font-mono leading-none select-none"
+                style={{
+                  background: repoColors.background,
+                  color: repoColors.foreground,
+                  border: `1px solid ${repoColors.border}`,
+                }}
+                title={data.repo}
+              >
+                {data.repo}
+              </span>
+            )}
+          </DialogTitle>
+          <DialogDescription className="flex items-center gap-2 min-w-0">
+            <span className="truncate font-mono text-[11px]" title={fileLabel}>
+              {fileLabel}
+            </span>
+            <button
+              type="button"
+              onClick={copyPath}
+              title="Copy file:line"
+              className="shrink-0 inline-flex items-center gap-1 text-text-3 hover:text-text rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+            >
+              {copied ? <Check size={12} /> : <Copy size={12} />}
+              <span className="sr-only">Copy path</span>
+            </button>
+            {data?.truncated && (
+              <span className="shrink-0 text-[10px] text-text-4">
+                lines {data.start_line}–{data.end_line} of {data.total_lines}
+              </span>
+            )}
+          </DialogDescription>
+        </div>
+
+        {/* Body — loading / error / empty / code. */}
+        <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto ag-scroll bg-surface-2">
+          {isLoading && (
+            <div className="flex items-center justify-center h-full text-text-3 gap-2 text-sm">
+              <Loader2 size={16} className="animate-spin" />
+              Loading source…
+            </div>
+          )}
+
+          {isError && !isLoading && (
+            <div className="flex flex-col items-center justify-center h-full text-text-3 gap-1 text-sm px-6 text-center">
+              <span className="text-text">Could not load source</span>
+              <span className="text-[11px] text-text-4">
+                {(error as Error)?.message ??
+                  "The file may not exist in the indexed working tree."}
+              </span>
+            </div>
+          )}
+
+          {!isLoading && !isError && data && data.lines.length === 0 && (
+            <div className="flex items-center justify-center h-full text-text-4 text-sm">
+              Empty file.
+            </div>
+          )}
+
+          {!isLoading && !isError && data && data.lines.length > 0 && (
+            <SyntaxHighlighter
+              language={data.language || "text"}
+              style={sourcePeekPrismTheme}
+              showLineNumbers
+              startingLineNumber={startLine}
+              wrapLines
+              lineNumberStyle={{
+                minWidth: "3.25em",
+                paddingRight: "1em",
+                textAlign: "right",
+                color: "var(--text-4, #6c7086)",
+                userSelect: "none",
+              }}
+              customStyle={{
+                margin: 0,
+                padding: "0.75rem 0",
+                background: "transparent",
+                fontSize: "12px",
+              }}
+              lineProps={(lineNumber: number) => {
+                const isTarget = line > 0 && lineNumber === line;
+                return {
+                  ref: isTarget
+                    ? (el: HTMLDivElement | null) => {
+                        targetRef.current = el;
+                      }
+                    : undefined,
+                  className: cn(
+                    "block w-full",
+                    isTarget && "bg-[var(--accent-soft,rgba(137,180,250,0.18))]",
+                  ),
+                  style: isTarget
+                    ? {
+                        display: "block",
+                        boxShadow:
+                          "inset 2px 0 0 var(--accent, #89b4fa)",
+                      }
+                    : { display: "block" },
+                };
+              }}
+            >
+              {code}
+            </SyntaxHighlighter>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/webui-v2/src/components/SourcePeek/SourcePeekProvider.tsx
+++ b/webui-v2/src/components/SourcePeek/SourcePeekProvider.tsx
@@ -1,0 +1,69 @@
+/* ============================================================
+   SourcePeekProvider.tsx — app-wide source-peek controller (#4499).
+
+   Mounts a single <SourcePeek> modal and exposes openSourcePeek() through
+   context so ANY file:line ref renderer (RefLine, FlowDag cards, DI/quality
+   links, IaC) can open it without threading open-state through every screen.
+
+   Usage:
+     const { openSourcePeek } = useSourcePeek();
+     openSourcePeek({ groupId, file, line, repo });
+   ============================================================ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { SourcePeek, type SourcePeekTarget } from "./SourcePeek";
+
+interface SourcePeekContextValue {
+  openSourcePeek: (target: SourcePeekTarget) => void;
+}
+
+const SourcePeekContext = createContext<SourcePeekContextValue | null>(null);
+
+export function SourcePeekProvider({ children }: { children: ReactNode }) {
+  const [target, setTarget] = useState<SourcePeekTarget | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const openSourcePeek = useCallback((t: SourcePeekTarget) => {
+    if (!t.file || !t.groupId) return;
+    setTarget(t);
+    setOpen(true);
+  }, []);
+
+  const value = useMemo(() => ({ openSourcePeek }), [openSourcePeek]);
+
+  return (
+    <SourcePeekContext.Provider value={value}>
+      {children}
+      {target && (
+        <SourcePeek
+          groupId={target.groupId}
+          file={target.file}
+          line={target.line}
+          repo={target.repo}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+    </SourcePeekContext.Provider>
+  );
+}
+
+/**
+ * useSourcePeek — open the shared source-peek modal for a file:line ref.
+ * Returns a no-op opener when used outside the provider (so a stray callsite
+ * never crashes the tree), but in practice the provider wraps the whole app.
+ */
+export function useSourcePeek(): SourcePeekContextValue {
+  const ctx = useContext(SourcePeekContext);
+  if (!ctx) {
+    return { openSourcePeek: () => {} };
+  }
+  return ctx;
+}

--- a/webui-v2/src/components/SourcePeek/index.ts
+++ b/webui-v2/src/components/SourcePeek/index.ts
@@ -1,0 +1,2 @@
+export { SourcePeek, type SourcePeekTarget } from "./SourcePeek";
+export { SourcePeekProvider, useSourcePeek } from "./SourcePeekProvider";

--- a/webui-v2/src/components/SourcePeek/syntax-theme.ts
+++ b/webui-v2/src/components/SourcePeek/syntax-theme.ts
@@ -1,0 +1,77 @@
+/* ============================================================
+   SourcePeek/syntax-theme.ts — token → CSS style map for the Prism
+   highlighter used by <SourcePeek> (#4499).
+
+   We don't ship one of react-syntax-highlighter's prebuilt themes (they
+   hardcode a background + palette that clashes with the app's themeable
+   surfaces). Instead this minimal map is transparent-backed and uses the
+   app's own CSS custom properties with sane hex fallbacks, so highlighting
+   stays coherent across dark / light / warm palettes with near-zero added
+   weight.
+   ============================================================ */
+
+import type { CSSProperties } from "react";
+
+type PrismStyle = Record<string, CSSProperties>;
+
+// Color tokens fall back to readable defaults when a var is undefined.
+const c = {
+  base: "var(--text, #cdd6f4)",
+  comment: "var(--text-4, #6c7086)",
+  keyword: "var(--accent, #89b4fa)",
+  string: "var(--success, #a6e3a1)",
+  number: "var(--warning, #fab387)",
+  func: "var(--info, #89dceb)",
+  punctuation: "var(--text-3, #9399b2)",
+  tag: "var(--accent, #f38ba8)",
+};
+
+export const sourcePeekPrismTheme: PrismStyle = {
+  'code[class*="language-"]': {
+    color: c.base,
+    background: "none",
+    fontFamily: "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
+    fontSize: "12px",
+    lineHeight: "1.5",
+    whiteSpace: "pre",
+    tabSize: 2,
+  },
+  'pre[class*="language-"]': {
+    color: c.base,
+    background: "none",
+    margin: 0,
+    padding: 0,
+    overflow: "visible",
+  },
+  comment: { color: c.comment, fontStyle: "italic" },
+  prolog: { color: c.comment },
+  doctype: { color: c.comment },
+  cdata: { color: c.comment },
+  punctuation: { color: c.punctuation },
+  property: { color: c.tag },
+  tag: { color: c.tag },
+  boolean: { color: c.number },
+  number: { color: c.number },
+  constant: { color: c.number },
+  symbol: { color: c.number },
+  deleted: { color: c.tag },
+  selector: { color: c.string },
+  "attr-name": { color: c.number },
+  string: { color: c.string },
+  char: { color: c.string },
+  builtin: { color: c.func },
+  inserted: { color: c.string },
+  operator: { color: c.punctuation },
+  entity: { color: c.base },
+  url: { color: c.func },
+  variable: { color: c.base },
+  atrule: { color: c.keyword },
+  "attr-value": { color: c.string },
+  function: { color: c.func },
+  "class-name": { color: c.func },
+  keyword: { color: c.keyword },
+  regex: { color: c.number },
+  important: { color: c.tag, fontWeight: "bold" },
+  bold: { fontWeight: "bold" },
+  italic: { fontStyle: "italic" },
+};

--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -14,10 +14,12 @@
    ============================================================ */
 
 import { memo } from "react";
+import { useParams } from "react-router-dom";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { ChevronRight, ChevronDown, CircleDot } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { RepoChip } from "@/lib/repo-color";
+import { useSourcePeek } from "@/components/SourcePeek";
 import { roleStyle, edgeStyle } from "./style";
 import type { FlowDagNodeData } from "./layout";
 
@@ -51,6 +53,8 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
   const { node, edgeKind, expanded, onToggleExpand, selected, onRoute } =
     data as FlowDagNodeData;
   const rs = roleStyle(node.role);
+  const { openSourcePeek } = useSourcePeek();
+  const { groupId = "" } = useParams<{ groupId: string }>();
   const collapsed = node.collapsed_children ?? [];
   const hasCollapsed = collapsed.length > 0;
   // Click-to-highlight (#4479): when a route is active, off-route nodes dim.
@@ -168,18 +172,31 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
           )}
         </div>
 
-        {/* file:line — plain muted text (read-only canvas, no source-open). */}
+        {/* file:line — click opens the shared source-peek modal (#4499). */}
         {fileRef && (
-          <div
-            className="mt-0.5 flex items-center font-mono text-[10px] text-text-4 tabular-nums min-w-0"
-            title={fileRef}
+          <button
+            type="button"
+            onClick={(e) => {
+              // Don't let the node-select / canvas handlers swallow the click.
+              e.stopPropagation();
+              if (node.file && groupId) {
+                openSourcePeek({
+                  groupId,
+                  file: node.file,
+                  line: node.line ?? 0,
+                  repo: node.repo,
+                });
+              }
+            }}
+            className="mt-0.5 flex items-center font-mono text-[10px] text-text-4 tabular-nums min-w-0 w-full text-left cursor-pointer hover:text-accent"
+            title={`${fileRef} — open source`}
           >
             {/* head (dir prefix) truncates LTR; tail (filename:line) never shrinks. */}
             <span className="overflow-hidden whitespace-nowrap text-ellipsis min-w-0 shrink">
               {fileHead}
             </span>
             <span className="shrink-0 whitespace-nowrap">{fileTail}</span>
-          </div>
+          </button>
         )}
 
         {/* effect badges — small, only what's present. */}

--- a/webui-v2/src/components/graph/node-inspector.tsx
+++ b/webui-v2/src/components/graph/node-inspector.tsx
@@ -9,6 +9,7 @@
 import { X } from "lucide-react";
 import { Badge, Tabs, TabsList, TabsTrigger, TabsContent, Button } from "@/components/ui";
 import { useEntityDetail } from "@/hooks/use-graph";
+import { useSourcePeek } from "@/components/SourcePeek";
 import type { GraphNode } from "@/data/types";
 
 export interface NodeInspectorProps {
@@ -20,6 +21,7 @@ export interface NodeInspectorProps {
 
 export function NodeInspector({ groupId, node, onClose, onFocusNode }: NodeInspectorProps) {
   const { data, isLoading } = useEntityDetail(groupId, node.id);
+  const { openSourcePeek } = useSourcePeek();
 
   const inbound = data?.inbound_edges ?? [];
   const outbound = data?.outbound_edges ?? [];
@@ -44,10 +46,26 @@ export function NodeInspector({ groupId, node, onClose, onFocusNode }: NodeInspe
         </button>
       </header>
 
-      <div className="border-b border-border px-4 py-2 font-mono text-xs text-text-3 break-all">
-        {data?.entity.source_file
-          ? `${data.entity.source_file}:${data.entity.start_line}`
-          : "—"}
+      <div className="border-b border-border px-4 py-2 font-mono text-xs break-all">
+        {data?.entity.source_file ? (
+          <button
+            type="button"
+            onClick={() =>
+              openSourcePeek({
+                groupId,
+                file: data.entity.source_file!,
+                line: data.entity.start_line ?? 0,
+                repo: node.repo,
+              })
+            }
+            className="text-accent hover:underline cursor-pointer text-left"
+            title={`${data.entity.source_file}:${data.entity.start_line} — open source`}
+          >
+            {`${data.entity.source_file}:${data.entity.start_line}`}
+          </button>
+        ) : (
+          <span className="text-text-3">—</span>
+        )}
       </div>
 
       <div className="grid grid-cols-3 gap-2 border-b border-border px-4 py-3 text-center">

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2424,3 +2424,39 @@ export interface DownstreamDAGResponse {
   /** Count of internal fan-out points (kept nodes with out-degree > 1). */
   branch_count: number;
 }
+
+// ---------------------------------------------------------------------------
+// Source peek (#4499) — GET /api/v2/groups/:id/source
+// ---------------------------------------------------------------------------
+
+/** One source line with its absolute 1-based number. */
+export interface SourceLine {
+  number: number;
+  text: string;
+}
+
+/**
+ * GET /api/v2/groups/:id/source — a window of source for a file:line ref,
+ * read from the indexed repo working tree. Powers the shared <SourcePeek>
+ * modal (the get_source equivalent for the UI).
+ */
+export interface SourceReply {
+  /** Repo-relative path that was read. */
+  file: string;
+  /** Slug of the repo the file was found in. */
+  repo: string;
+  /** Highlighter language hint derived from the extension (e.g. "typescript"). */
+  language: string;
+  /** Target line the caller asked to center on (echoed back). */
+  line: number;
+  /** 1-based number of the first returned line. */
+  start_line: number;
+  /** 1-based number of the last returned line. */
+  end_line: number;
+  /** Full line count of the file (for "x of N" affordances). */
+  total_lines: number;
+  /** True when the returned window is a slice of a larger file. */
+  truncated: boolean;
+  /** The returned window. */
+  lines: SourceLine[];
+}

--- a/webui-v2/src/hooks/use-source.ts
+++ b/webui-v2/src/hooks/use-source.ts
@@ -1,0 +1,38 @@
+/* ============================================================
+   hooks/use-source.ts — source-peek data hook (#4499).
+
+   Fetches a window of source for a file:line ref from the indexed repo
+   working tree (GET /api/v2/groups/:id/source). Drives the shared
+   <SourcePeek> modal — the get_source equivalent for the UI.
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export const sourceQueryKey = (
+  groupId: string,
+  file: string,
+  line: number,
+  repo: string,
+) => ["source", groupId, repo, file, line] as const;
+
+/**
+ * Fetch the source window for a file:line ref. Lazy: only runs when enabled
+ * and a file is present. Results are cached per (group, repo, file, line) so
+ * reopening the same ref is instant.
+ */
+export function useSource(
+  groupId: string,
+  file: string | null,
+  line: number,
+  repo?: string,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: sourceQueryKey(groupId, file ?? "", line, repo ?? ""),
+    queryFn: () =>
+      api.getSource(groupId, { file: file!, line: line || undefined, repo }),
+    enabled: enabled && !!groupId && !!file,
+    staleTime: 60_000,
+  });
+}

--- a/webui-v2/src/layouts/app-shell.tsx
+++ b/webui-v2/src/layouts/app-shell.tsx
@@ -10,6 +10,7 @@ import { Outlet, useParams, useMatches } from "react-router-dom";
 import { NavRail } from "@/components/chrome/nav-rail";
 import { TopBar } from "@/components/chrome/top-bar";
 import { CommandPalette } from "@/components/chrome/command-palette";
+import { SourcePeekProvider } from "@/components/SourcePeek";
 
 interface RouteHandle {
   surfaceLabel?: string;
@@ -22,15 +23,17 @@ export function AppShell() {
     [...matches].reverse().map((m) => (m.handle as RouteHandle | undefined)?.surfaceLabel).find(Boolean) ?? "Graph";
 
   return (
-    <div className="flex h-full w-full">
-      <NavRail />
-      <div className="flex flex-col flex-1 min-w-0">
-        <TopBar group={groupId} surfaceLabel={surfaceLabel} />
-        <main className="flex-1 min-h-0 ag-scroll bg-bg">
-          <Outlet />
-        </main>
+    <SourcePeekProvider>
+      <div className="flex h-full w-full">
+        <NavRail />
+        <div className="flex flex-col flex-1 min-w-0">
+          <TopBar group={groupId} surfaceLabel={surfaceLabel} />
+          <main className="flex-1 min-h-0 ag-scroll bg-bg">
+            <Outlet />
+          </main>
+        </div>
+        <CommandPalette />
       </div>
-      <CommandPalette />
-    </div>
+    </SourcePeekProvider>
   );
 }

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -73,6 +73,7 @@ import type {
   DIReport,
   ErrorFlowReport,
   DownstreamDAGResponse,
+  SourceReply,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -558,6 +559,27 @@ export const api = {
     else if (opts.type) qs.set("type", opts.type);
     return requestV2<ShapeResponse>(
       `/groups/${encodeURIComponent(groupId)}/shape?${qs.toString()}`,
+    );
+  },
+
+  /**
+   * GET /api/v2/groups/:id/source — a window of source for any file:line ref
+   * (#4499), read from the indexed repo working tree. Powers the shared
+   * <SourcePeek> modal: small files come back whole, large files as a window
+   * centered on `line`. `repo` pins resolution when the same relative path
+   * exists in more than one repo of the group; omit it to search all repos.
+   */
+  getSource: (
+    groupId: string,
+    opts: { file: string; line?: number; context?: number; repo?: string },
+  ) => {
+    const qs = new URLSearchParams();
+    qs.set("file", opts.file);
+    if (opts.line != null && opts.line > 0) qs.set("line", String(opts.line));
+    if (opts.context != null) qs.set("context", String(opts.context));
+    if (opts.repo) qs.set("repo", opts.repo);
+    return requestV2<SourceReply>(
+      `/groups/${encodeURIComponent(groupId)}/source?${qs.toString()}`,
     );
   },
 

--- a/webui-v2/src/routes/event-flows.tsx
+++ b/webui-v2/src/routes/event-flows.tsx
@@ -33,6 +33,7 @@ import { toast } from "sonner";
 
 import { api } from "@/lib/api";
 import { Badge, Skeleton } from "@/components/ui";
+import { useSourcePeek } from "@/components/SourcePeek";
 import { cn } from "@/lib/utils";
 
 import type {
@@ -67,6 +68,8 @@ function useEventFlowDetail(groupId: string | undefined, eventFlowId: string | n
 
 function StepNode({ step }: { step: EventFlowStep }) {
   const isChannel = step.is_channel;
+  const { openSourcePeek } = useSourcePeek();
+  const { groupId = "" } = useParams<{ groupId: string }>();
   return (
     <div
       className={cn(
@@ -90,7 +93,28 @@ function StepNode({ step }: { step: EventFlowStep }) {
         <div className="truncate text-sm font-medium text-text-1">{step.label || step.entity_id}</div>
         <div className="truncate text-xs text-text-3">
           {isChannel ? "channel" : "operation"} · {step.repo}
-          {step.source_file ? ` · ${step.source_file}` : ""}
+          {step.source_file && (
+            <>
+              {" · "}
+              <button
+                type="button"
+                onClick={() =>
+                  groupId &&
+                  openSourcePeek({
+                    groupId,
+                    file: step.source_file!,
+                    line: step.start_line ?? 0,
+                    repo: step.repo,
+                  })
+                }
+                className="text-accent hover:underline cursor-pointer"
+                title={`${step.source_file}${step.start_line ? `:${step.start_line}` : ""} — open source`}
+              >
+                {step.source_file}
+                {step.start_line ? `:${step.start_line}` : ""}
+              </button>
+            </>
+          )}
         </div>
       </div>
       <span className="text-xs text-text-4">#{step.step_index}</span>

--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -37,6 +37,7 @@ import { cn } from "@/lib/utils";
 import { RepoChip as SharedRepoChip } from "@/lib/repo-color";
 import { Skeleton } from "@/components/ui/skeleton";
 import { FlowDag as SharedFlowDag } from "@/components/flow-dag";
+import { useSourcePeek } from "@/components/SourcePeek";
 import { flowToDagPayload } from "@/lib/flow-to-dag";
 
 // ─── Step-kind metadata ───────────────────────────────────────────────────────
@@ -847,6 +848,8 @@ function StepInspector({
 }) {
   const meta = getStepMeta(step.step_kind);
   const snippet = flow.source_snippets?.[step.entity_id];
+  const { openSourcePeek } = useSourcePeek();
+  const { groupId = "" } = useParams<{ groupId: string }>();
 
   return (
     <div
@@ -883,10 +886,27 @@ function StepInspector({
       <div className="flex flex-wrap gap-2.5 text-[11px] text-text-3">
         <span>{meta.label}</span>
         <span>·</span>
-        <span className="font-mono">
-          {step.source_file}
-          {step.start_line ? `:${step.start_line}` : ""}
-        </span>
+        {step.source_file ? (
+          <button
+            type="button"
+            onClick={() =>
+              groupId &&
+              openSourcePeek({
+                groupId,
+                file: step.source_file,
+                line: step.start_line ?? 0,
+                repo: step.repo,
+              })
+            }
+            className="font-mono text-accent hover:underline cursor-pointer"
+            title={`${step.source_file}${step.start_line ? `:${step.start_line}` : ""} — open source`}
+          >
+            {step.source_file}
+            {step.start_line ? `:${step.start_line}` : ""}
+          </button>
+        ) : (
+          <span className="font-mono">{step.source_file}</span>
+        )}
         <span>·</span>
         <span>{step.repo}</span>
         {step.edge_kind && (


### PR DESCRIPTION
Closes #4499

Clicking any **file:line** ref in the dashboard now opens a **centered modal** showing the actual source for that line — the `get_source` equivalent for the UI — syntax-highlighted and centered/scrolled to the target line (with the line highlighted).

## Backend
- New `GET /api/v2/groups/{id}/source?file=<rel>&line=<n>&context=<n>&repo=<slug>` (`internal/dashboard/v2_source.go`). Returns `{file, repo, language, line, start_line, end_line, total_lines, truncated, lines:[{number,text}]}`.
- Window is whole-file for small files (≤600 lines), else ±context around `line` clamped to bounds; `line=0` anchors at the file head.
- Repo root resolved from the group config (`DashRepo.Path`). `?repo` pins resolution when a relative path exists in more than one repo; otherwise each repo root is tried.
- **Path-traversal guarded**: the joined absolute path must stay within a repo root, else rejected. 8 MiB size cap.
- Language hint derived by extension for client-side highlighting.
- Unit tests: cross-repo resolution, `?repo` pin, traversal rejection (`../`, absolute, embedded `..`), missing file, windowing table, language map, line reader.

## Frontend
- **Highlight library:** `react-syntax-highlighter` using the **`PrismAsyncLight`** build — grammars are lazy-loaded per language (code-split into separate chunks fetched only when a language is actually rendered), so the initial bundle only carries the small Prism parser core, not ~280 grammars. A minimal transparent-backed token theme (`syntax-theme.ts`) uses the app's CSS variables so highlighting stays coherent across dark/light/warm palettes with near-zero added weight.
- Shared **`<SourcePeek>`** centered house `Dialog` + **`<SourcePeekProvider>` / `useSourcePeek()`** mounted once in `AppShell`, so any ref renderer opens the modal app-wide via `openSourcePeek({ groupId, file, line, repo })`. Loading / error / empty states, copy file:line affordance, repo chip, target-line highlight + auto-center.
- **Ref renderers wired:**
  - `RefLine` (shared) → covers Paths, Security, IaC, Taint/Dataflow, DI, Quality, Topology, GraphQL, ErrorFlow, and FlowDagNode. Existing `onFileClick` preserved (now additive); new `disableSourcePeek` opt-out.
  - `FlowDagNode` card file:line (was read-only text) → now clickable.
  - Flows step inspector and Event-Flows step file:line → now clickable.
  - Graph `node-inspector` file:line → now clickable.

## Gates
- Backend: `go build ./...` ✅, `go vet ./internal/dashboard/...` ✅, `go test ./internal/dashboard/...` ✅
- Frontend: `npm ci` ✅, `npm run build` ✅, `npm run lint` (tsc --noEmit) ✅

Pure additive feature + one backend endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)