### PR TITLE
fix(dashboard): aggregate endpoint effective side-effects from delegated downstream (#4489)

### DIFF
--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -233,7 +233,15 @@ type v2PathDetail struct {
 	InboundFetches     []v2PathEntity        `json:"inbound_fetches"`
 	Outbound           v2OutboundQueries     `json:"outbound"`
 	SideEffects        []v2PathEntity        `json:"side_effects"`
-	Tests              []v2PathEntity        `json:"tests"`
+	// EffectiveEffects is the union of effect KINDS (db_read/db_write/http_out/
+	// fs/…) the endpoint reaches DIRECTLY or transitively through its handler's
+	// downstream CALLS (#4489). Each is tagged source=direct|downstream so a thin
+	// controller that delegates the DB write to a service.create still shows
+	// db_write (source=downstream) instead of an empty "Side effects (0)".
+	// Computed query-time from the same canonical effects sidecar the `effects`
+	// MCP tool reads — no reindex required.
+	EffectiveEffects []v2EffectiveEffect `json:"effective_effects,omitempty"`
+	Tests            []v2PathEntity      `json:"tests"`
 }
 
 // v2AuthSignal is one evidence row in the resolved auth_policy source chain.
@@ -788,6 +796,9 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		// Both are used to match inbound cross-repo links (#1891).
 		HandlerEntityIDs []string
 		DefEntityID      string
+		// HandlerLocalIDs are the un-prefixed handler entity IDs in this hit's
+		// repo, used to root the transitive effective-effects CALLS walk (#4489).
+		HandlerLocalIDs []string
 		// Issue #1909 — JAX-RS / Spring request body type inferred from method
 		// parameter annotations (populated for POST/PUT/PATCH endpoints).
 		RequestBodyType      string
@@ -948,6 +959,7 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 				TestIDs:          classified.tests,
 				HandlerEntityIDs: prefixedHandlerIDs,
 				DefEntityID:      dashPrefixedID(repo.Slug, e.ID),
+				HandlerLocalIDs:  handlerIDs,
 				// Issue #1909 — request body type from entity properties.
 				RequestBodyType:      e.Properties["request_body_type"],
 				RequestBodyParamName: e.Properties["request_body_param_name"],
@@ -1228,6 +1240,24 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	sideEffectEntities := resolveEntitySlice(grp, sideEffectIDs, "SIDE_EFFECT")
 	testEntities := resolveEntitySlice(grp, testIDs, "TESTS")
 
+	// #4489 — EFFECTIVE side-effects: the union of effect kinds reachable from
+	// the handler DIRECTLY or transitively through its downstream CALLS. A thin
+	// controller that delegates the DB write to service.create has no direct
+	// side-effect edge (so SideEffects above reads (0)); aggregating the effect
+	// kinds off the canonical links-effects sidecar surfaces db_write as
+	// source=downstream. Query-time (no reindex). Per-repo (handler chain lives
+	// in the endpoint's own repo).
+	effEffects := loadDAGEffectsSidecar(grp.Name)
+	// Group handler local IDs by repo (a path can be served from several repos /
+	// verbs; each handler's downstream chain is walked in its own repo index).
+	handlersByRepo := map[string][]string{}
+	for _, h := range hits {
+		if len(h.HandlerLocalIDs) > 0 {
+			handlersByRepo[h.Repo] = mergeUniqueStrings(handlersByRepo[h.Repo], h.HandlerLocalIDs)
+		}
+	}
+	effectiveEffects := mergeEffectiveEffects(handlersByRepo, repoIdx, effEffects)
+
 	// Split downstream callees by kind for the structured Outbound section.
 	outbound := v2OutboundQueries{
 		DB:       []v2PathEntity{},
@@ -1346,6 +1376,7 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		InboundFetches:     inboundFetches,
 		Outbound:           outbound,
 		SideEffects:        sideEffectEntities,
+		EffectiveEffects:   effectiveEffects,
 		Tests:              testEntities,
 	}))
 }

--- a/internal/dashboard/v2_paths_effective_effects.go
+++ b/internal/dashboard/v2_paths_effective_effects.go
@@ -1,0 +1,203 @@
+// v2_paths_effective_effects.go — endpoint EFFECTIVE side-effect aggregation
+// (#4489).
+//
+// Problem: the Paths-detail "Side effects" panel collected effects ONLY from
+// edges whose FromID is the handler (QUERIES / ACCESSES_TABLE / EMITS / …; see
+// classifyHandlerEdges). For a thin controller that delegates the actual DB
+// write to a downstream service (POST create → service.create does the
+// db_write), the handler has NO direct side-effect edge, so the panel read
+// "(0)" even though the endpoint clearly writes.
+//
+// Fix (query-time, NO reindex): compute the endpoint's EFFECTIVE side-effects
+// by walking the handler's downstream CALLS transitively (depth + node capped,
+// cycle-guarded) and unioning the effect KINDS (db_read / db_write / http_out /
+// fs / …) found on every reachable function. The effect kinds come from the
+// SAME canonical source the `effects` MCP tool + the downstream-DAG cards use:
+// the <group>-links-effects.json sidecar (loadDAGEffectsSidecar), with a
+// fallback to the effect-propagation properties stamped on the entity.
+//
+// Each aggregated kind is tagged with where it was observed:
+//
+//   - "direct"     — a sink on the handler method itself.
+//   - "downstream" — reached only via a delegated callee (the common thin-
+//     controller case the ticket is about).
+//
+// This is framework-agnostic: it relies only on the universal CALLS edge and
+// the language-neutral effect sidecar, so every stack (DRF, Spring, NestJS, …)
+// benefits without any extractor change.
+
+package dashboard
+
+import (
+	"sort"
+	"strings"
+)
+
+// v2EffectiveEffect is one aggregated effect kind surfaced on the endpoint
+// detail. Source distinguishes a sink on the handler itself ("direct") from one
+// reached only through a delegated downstream callee ("downstream"), so the
+// frontend can hint "via downstream service" rather than implying the thin
+// controller does the write inline.
+type v2EffectiveEffect struct {
+	// Kind is the effect primitive: db_read | db_write | http_out | fs | … —
+	// the same vocabulary the `effects` MCP tool emits.
+	Kind string `json:"kind"`
+	// Source is "direct" (sink on the handler) or "downstream" (reached only via
+	// a delegated callee). When a kind is observed both ways "direct" wins.
+	Source string `json:"source"`
+}
+
+// mergeEffectiveEffects aggregates effective effects across every (repo →
+// handler-ID-set) the endpoint resolves to, merging per-repo results into one
+// union. "direct" provenance outranks "downstream" when a kind appears both
+// ways across repos. Deterministic order (kind asc). nil when nothing reachable.
+func mergeEffectiveEffects(handlersByRepo map[string][]string, repoIdx map[string]*repoEntityIndex, effects map[string][]string) []v2EffectiveEffect {
+	if len(handlersByRepo) == 0 {
+		return nil
+	}
+	merged := map[string]string{} // kind -> source (direct wins)
+	for slug, handlerIDs := range handlersByRepo {
+		idx := repoIdx[slug]
+		if idx == nil {
+			continue
+		}
+		for _, ee := range aggregateEffectiveEffects(idx, handlerIDs, effects) {
+			if merged[ee.Kind] == "direct" {
+				continue
+			}
+			if ee.Source == "direct" || merged[ee.Kind] == "" {
+				merged[ee.Kind] = ee.Source
+			}
+		}
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	res := make([]v2EffectiveEffect, 0, len(merged))
+	for kind, src := range merged {
+		res = append(res, v2EffectiveEffect{Kind: kind, Source: src})
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].Kind < res[j].Kind })
+	return res
+}
+
+// effectiveEffectsCaps bound the transitive CALLS walk so a pathological graph
+// can never blow up the request. Mirrors the downstream-DAG caps (dagMaxDepth /
+// dagMaxNodes) in spirit — depth covers handler → service → repo → orm-wrapper
+// → external comfortably, and the node cap guards fan-out.
+const (
+	effectiveEffectsMaxDepth = 12
+	effectiveEffectsMaxNodes = 1500
+)
+
+// aggregateEffectiveEffects walks the handler's downstream CALLS transitively
+// and returns the union of effect kinds reachable from the handler set, each
+// tagged direct/downstream.
+//
+// Inputs:
+//   - idx:        the per-repo entity index (byID + the repo's relationships).
+//   - handlerIDs: the LOCAL handler entity IDs to root the walk at.
+//   - effects:    the canonical effect index keyed by PREFIXED id
+//     ("<slug>::<localID>") loaded once per request from the links-effects
+//     sidecar (loadDAGEffectsSidecar). May be nil → property fallback only.
+//
+// The walk is single-repo: the handler → service → repository chain lives in the
+// endpoint's own repo (same assumption the downstream-DAG builder makes). It is
+// depth + node capped and cycle-guarded via a visited set.
+func aggregateEffectiveEffects(idx *repoEntityIndex, handlerIDs []string, effects map[string][]string) []v2EffectiveEffect {
+	if idx == nil || len(handlerIDs) == 0 {
+		return nil
+	}
+
+	// Forward CALLS adjacency over the repo, built once. Self-edges skipped.
+	out := make(map[string][]string)
+	for i := range idx.repo.Doc.Relationships {
+		r := &idx.repo.Doc.Relationships[i]
+		if r.Kind != "CALLS" || r.FromID == r.ToID {
+			continue
+		}
+		out[r.FromID] = append(out[r.FromID], r.ToID)
+	}
+
+	handlerSet := make(map[string]bool, len(handlerIDs))
+	for _, id := range handlerIDs {
+		handlerSet[id] = true
+	}
+
+	// effectSource records the strongest provenance seen per effect kind.
+	// "direct" outranks "downstream".
+	effectSource := map[string]string{}
+	record := func(local string, depth int) {
+		for _, kind := range effectsForLocal(idx, local, effects) {
+			src := "downstream"
+			if depth == 0 && handlerSet[local] {
+				src = "direct"
+			}
+			if effectSource[kind] == "direct" {
+				continue // already strongest
+			}
+			effectSource[kind] = src
+		}
+	}
+
+	// BFS from every handler, depth+node capped, cycle-guarded.
+	type item struct {
+		local string
+		depth int
+	}
+	visited := make(map[string]bool, len(handlerIDs))
+	queue := make([]item, 0, len(handlerIDs))
+	for _, id := range handlerIDs {
+		if !visited[id] {
+			visited[id] = true
+			queue = append(queue, item{local: id, depth: 0})
+		}
+	}
+
+	for len(queue) > 0 && len(visited) <= effectiveEffectsMaxNodes {
+		cur := queue[0]
+		queue = queue[1:]
+		record(cur.local, cur.depth)
+		if cur.depth >= effectiveEffectsMaxDepth {
+			continue
+		}
+		for _, to := range out[cur.local] {
+			if visited[to] {
+				continue
+			}
+			if len(visited) >= effectiveEffectsMaxNodes {
+				break
+			}
+			visited[to] = true
+			queue = append(queue, item{local: to, depth: cur.depth + 1})
+		}
+	}
+
+	if len(effectSource) == 0 {
+		return nil
+	}
+	res := make([]v2EffectiveEffect, 0, len(effectSource))
+	for kind, src := range effectSource {
+		res = append(res, v2EffectiveEffect{Kind: kind, Source: src})
+	}
+	// Deterministic order: kind asc.
+	sort.Slice(res, func(i, j int) bool { return res[i].Kind < res[j].Kind })
+	return res
+}
+
+// effectsForLocal returns the effect kinds for a local entity, mirroring the
+// source precedence of the `effects` MCP tool + the downstream-DAG cards: the
+// canonical sidecar (keyed by prefixed id) first, then the effect-propagation
+// properties stamped on the entity (the in-process run case).
+func effectsForLocal(idx *repoEntityIndex, local string, effects map[string][]string) []string {
+	pid := dashPrefixedID(idx.repo.Slug, local)
+	if effs := effects[pid]; len(effs) > 0 {
+		return effs
+	}
+	if e := idx.byID[local]; e != nil && e.Properties != nil {
+		if raw := strings.TrimSpace(e.Properties[effectPropertyKeyList]); raw != "" {
+			return splitNonEmptyComma(raw)
+		}
+	}
+	return nil
+}

--- a/internal/dashboard/v2_paths_effective_effects_test.go
+++ b/internal/dashboard/v2_paths_effective_effects_test.go
@@ -1,0 +1,219 @@
+package dashboard
+
+// v2_paths_effective_effects_test.go — #4489 live-validation for the endpoint
+// EFFECTIVE side-effect aggregation.
+//
+// The fixture mirrors the upvate thin-controller shape that triggered the bug:
+//
+//	POST /api/v1/widgets  →  WidgetController.create   (handler, NO direct sink)
+//	                              └─CALLS→ WidgetService.create  (db_write)
+//
+// The handler performs NO direct DB write, so the legacy direct-only "Side
+// effects" panel reads (0). The new effective-effects aggregation walks the
+// handler's downstream CALLS, reads db_write off the canonical links-effects
+// sidecar on WidgetService.create, and surfaces it on the endpoint tagged
+// source=downstream. This is the before/after the ticket asks for.
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// thinControllerFixture: a POST create endpoint whose handler delegates the DB
+// write to a downstream service method.
+func thinControllerFixture() ([]graph.Entity, []graph.Relationship) {
+	entities := []graph.Entity{
+		// Synthetic endpoint definition (router-expanded).
+		{
+			ID:         "ep_post_widgets",
+			Name:       "http:POST:/api/v1/widgets",
+			Kind:       "http_endpoint_definition",
+			SourceFile: "core/routers.py",
+			StartLine:  0,
+			Properties: map[string]string{"path": "/api/v1/widgets", "verb": "POST", "framework": "drf"},
+		},
+		// Thin controller handler — NO direct side-effect edge.
+		{
+			ID:         "op_ctrl_create",
+			Name:       "WidgetController.create",
+			Kind:       "SCOPE.Operation",
+			SourceFile: "core/views/widget_controller.py",
+			StartLine:  20,
+		},
+		// Downstream service method that performs the actual DB write.
+		{
+			ID:         "op_svc_create",
+			Name:       "WidgetService.create",
+			Kind:       "SCOPE.Operation",
+			SourceFile: "core/services/widget_service.py",
+			StartLine:  8,
+		},
+	}
+	rels := []graph.Relationship{
+		// Handler IMPLEMENTS the definition.
+		{FromID: "op_ctrl_create", ToID: "ep_post_widgets", Kind: "IMPLEMENTS"},
+		// Handler delegates to the service — the only outbound edge.
+		{FromID: "op_ctrl_create", ToID: "op_svc_create", Kind: "CALLS"},
+	}
+	return entities, rels
+}
+
+// writeEffectsSidecar writes a minimal <group>-links-effects.json under $HOME so
+// loadDAGEffectsSidecar resolves it. Sets HOME for the test process.
+func writeEffectsSidecar(t *testing.T, group string, entries map[string][]string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".archigraph", "groups")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sidecar dir: %v", err)
+	}
+	type entry struct {
+		EntityID string   `json:"entity_id"`
+		Effects  []string `json:"effects"`
+	}
+	doc := struct {
+		Version int     `json:"version"`
+		Method  string  `json:"method"`
+		Entries []entry `json:"entries"`
+	}{Version: 1, Method: "effect_propagation"}
+	for id, effs := range entries {
+		doc.Entries = append(doc.Entries, entry{EntityID: id, Effects: effs})
+	}
+	buf, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal sidecar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, group+"-links-effects.json"), buf, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+}
+
+// TestV2PathDetail_EffectiveEffects_AggregatesDownstreamWrite is the #4489
+// before/after: the direct Side-effects panel is empty (the bug), but the new
+// effective_effects surfaces db_write tagged source=downstream.
+func TestV2PathDetail_EffectiveEffects_AggregatesDownstreamWrite(t *testing.T) {
+	entities, rels := thinControllerFixture()
+
+	// db_write lives on the DOWNSTREAM service method, not the handler.
+	writeEffectsSidecar(t, "testgrp", map[string][]string{
+		"api-backend::op_svc_create": {"db_write"},
+	})
+
+	grp := makePathsTestGroup(entities, rels)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	hash := hashStr("/api/v1/widgets")
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths/" + hash)
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200 got %d", resp.StatusCode)
+	}
+	var body struct {
+		Data v2PathDetail `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d := body.Data
+
+	// BEFORE (the bug): the direct-only Side effects panel is empty — the handler
+	// has no direct sink edge.
+	if len(d.SideEffects) != 0 {
+		t.Errorf("direct side_effects: want empty (thin controller), got %+v", d.SideEffects)
+	}
+
+	// AFTER (the fix): effective_effects surfaces db_write from the downstream
+	// service, tagged source=downstream.
+	var gotWrite *v2EffectiveEffect
+	for i := range d.EffectiveEffects {
+		if d.EffectiveEffects[i].Kind == "db_write" {
+			gotWrite = &d.EffectiveEffects[i]
+		}
+	}
+	if gotWrite == nil {
+		t.Fatalf("effective_effects: want db_write, got %+v", d.EffectiveEffects)
+	}
+	if gotWrite.Source != "downstream" {
+		t.Errorf("effective_effects db_write source: want downstream, got %q", gotWrite.Source)
+	}
+}
+
+// TestV2PathDetail_EffectiveEffects_DirectSinkTaggedDirect verifies a sink ON the
+// handler itself is tagged source=direct (the non-thin case), so the hint is
+// honest about provenance.
+func TestV2PathDetail_EffectiveEffects_DirectSinkTaggedDirect(t *testing.T) {
+	entities, rels := thinControllerFixture()
+
+	// Put db_write directly on the HANDLER (no delegation needed for the write).
+	writeEffectsSidecar(t, "testgrp", map[string][]string{
+		"api-backend::op_ctrl_create": {"db_write"},
+	})
+
+	grp := makePathsTestGroup(entities, rels)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	hash := hashStr("/api/v1/widgets")
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths/" + hash)
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Data v2PathDetail `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var gotWrite *v2EffectiveEffect
+	for i := range body.Data.EffectiveEffects {
+		if body.Data.EffectiveEffects[i].Kind == "db_write" {
+			gotWrite = &body.Data.EffectiveEffects[i]
+		}
+	}
+	if gotWrite == nil {
+		t.Fatalf("effective_effects: want db_write, got %+v", body.Data.EffectiveEffects)
+	}
+	if gotWrite.Source != "direct" {
+		t.Errorf("effective_effects db_write source: want direct, got %q", gotWrite.Source)
+	}
+}
+
+// TestV2PathDetail_EffectiveEffects_PureEndpointEmpty verifies an endpoint whose
+// reachable functions have no sinks reports no effective_effects (omitempty), so
+// the panel is honest rather than fabricating effects.
+func TestV2PathDetail_EffectiveEffects_PureEndpointEmpty(t *testing.T) {
+	entities, rels := thinControllerFixture()
+	// No sidecar entries for either function → pure.
+	writeEffectsSidecar(t, "testgrp", map[string][]string{})
+
+	grp := makePathsTestGroup(entities, rels)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	hash := hashStr("/api/v1/widgets")
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths/" + hash)
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Data v2PathDetail `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data.EffectiveEffects) != 0 {
+		t.Errorf("effective_effects: want empty for pure endpoint, got %+v", body.Data.EffectiveEffects)
+	}
+}


### PR DESCRIPTION
## Problem (live on upvate-v3)

The Paths-detail **Side effects** panel showed **(0)** even for endpoints that clearly write. A POST create endpoint whose thin controller delegates the DB write to `service.create` has **no direct side-effect edge on the handler** — the `db_read`/`db_write` live on the downstream service. The panel only collected effects from edges whose `FromID` is the handler itself (`classifyHandlerEdges`: QUERIES/ACCESSES_TABLE/EMITS/…), so it read empty.

## Fix — query-time effective-effect aggregation (NO reindex)

New `effective_effects` field on the endpoint detail. It walks the handler's **downstream CALLS transitively** (depth-capped 12, node-capped 1500, cycle-guarded via visited set) and unions the effect **kinds** (`db_read`/`db_write`/`http_out`/`fs`/…) found on every reachable function.

Effect kinds come from the **same canonical source** the `effects` MCP tool and the downstream-DAG cards use: the `<group>-links-effects.json` sidecar (`loadDAGEffectsSidecar`), with a fallback to the effect-propagation properties stamped on the entity (in-process run). So a `create` endpoint delegating to `service.create` (db_write) now surfaces `db_write`.

Each kind is tagged with provenance so the panel can hint honestly:
- `source: "direct"`  — sink on the handler method itself.
- `source: "downstream"` — reached only via a delegated callee (the thin-controller case).

The existing direct-only `side_effects` list is left untouched; `effective_effects` is additive. Framework-agnostic — relies only on the universal CALLS edge + the language-neutral effect sidecar, so every stack (DRF/Spring/NestJS/…) benefits with no extractor change.

### Where the panel data is produced
- `internal/dashboard/v2_paths.go` — `handleV2Paths` assembles the detail; aggregation wired in next to `sideEffectEntities`.
- `internal/dashboard/v2_paths_effective_effects.go` (new) — the transitive CALLS BFS + sidecar union (`aggregateEffectiveEffects` / `mergeEffectiveEffects`).
- `internal/dashboard/v2_paths_downstream_dag.go` — reused `loadDAGEffectsSidecar` (canonical effects source).

### Query-time vs reindex
**Query-time** — reads the existing graph + the already-written effects sidecar at request time. No reindex/redeploy of the indexer needed; confirmable on the loaded graph.

## Validation (before/after)
`internal/dashboard/v2_paths_effective_effects_test.go`:
- **AggregatesDownstreamWrite** — thin controller (`Controller.create` → `Service.create` with db_write on the *service*): `side_effects` is empty (the bug), `effective_effects` surfaces `db_write` `source=downstream` (the fix).
- **DirectSinkTaggedDirect** — sink on the handler itself → `source=direct`.
- **PureEndpointEmpty** — no reachable sinks → empty (no fabricated effects).

## Gates
- `go build ./...` ✅
- `go vet ./internal/dashboard/...` ✅
- `go test ./internal/dashboard/...` ✅ (full suite, 29s)
- `gofmt -l` clean ✅

Closes #4489

🤖 Generated with [Claude Code](https://claude.com/claude-code)