### PR TITLE
feat(webui-v2): render effective side-effects on the Paths detail (#4489)

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -19,30 +19,10 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { ChevronRight, ChevronDown, CircleDot } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { RepoChip } from "@/lib/repo-color";
+import { effectBadge } from "@/lib/effect-badge";
 import { useSourcePeek } from "@/components/SourcePeek";
 import { roleStyle, edgeStyle } from "./style";
 import type { FlowDagNodeData } from "./layout";
-
-/** Effect kind → short badge label + tone. Anything else falls through generic. */
-const EFFECT_BADGE: Record<string, { label: string; cls: string }> = {
-  db_read: { label: "DB read", cls: "text-info bg-info-soft" },
-  db_write: { label: "DB write", cls: "text-warning bg-warning-soft" },
-  http_out: { label: "HTTP", cls: "text-accent-strong bg-accent-soft" },
-  fs: { label: "FS", cls: "text-text-3 bg-surface-2" },
-  fs_read: { label: "FS read", cls: "text-text-3 bg-surface-2" },
-  fs_write: { label: "FS write", cls: "text-text-3 bg-surface-2" },
-  queue: { label: "Queue", cls: "text-accent-strong bg-accent-soft" },
-};
-
-function effectBadge(effect: string): { label: string; cls: string } {
-  return (
-    EFFECT_BADGE[effect] ?? {
-      // Humanize an unknown effect key (db_read → "db read") rather than drop it.
-      label: effect.replace(/_/g, " "),
-      cls: "text-text-3 bg-surface-2",
-    }
-  );
-}
 
 /**
  * FlowDagNode — one DAG node. Color + label come from the role; terminal

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -992,6 +992,18 @@ export interface PathDetail {
     grpc: PathEntity[];
   };
   side_effects: PathEntity[];
+  /**
+   * #4489 — the endpoint's EFFECTIVE side-effect kinds, aggregated by the
+   * backend (#4524) over the handler's downstream CALLS (transitively, capped).
+   * A thin controller that delegates the DB write to a downstream service has
+   * no DIRECT side-effect edge — its `side_effects` (the entity list above) is
+   * empty — but `effective_effects` still surfaces `{kind:"db_write",
+   * source:"downstream"}` so the panel shows "DB write (via downstream)" rather
+   * than "(0)". `source` distinguishes a sink on the handler itself ("direct")
+   * from one reached only via a delegated callee ("downstream"). Omitted /
+   * empty when the endpoint genuinely has no effects.
+   */
+  effective_effects?: { kind: string; source: "direct" | "downstream" }[];
   tests: PathEntity[];
 }
 

--- a/webui-v2/src/lib/effect-badge.ts
+++ b/webui-v2/src/lib/effect-badge.ts
@@ -1,0 +1,34 @@
+/**
+ * effect-badge.ts — shared effect-kind → badge label + token-tinted class.
+ *
+ * The single source of truth for how an effect primitive (db_read / db_write /
+ * http_out / fs / queue / …) is presented as a small tinted badge. Consumed by:
+ *   - the FlowDag downstream-DAG node cards (per-node effect chips), and
+ *   - the Paths-detail "Side effects" panel, which surfaces the endpoint's
+ *     EFFECTIVE effects aggregated from its downstream CALLS (#4489).
+ *
+ * Keeping it here (rather than inline in FlowDagNode) means both surfaces tint
+ * "DB write" the same warning token, so an effect reads identically wherever it
+ * appears.
+ */
+
+/** Effect kind → short badge label + tone class. Unknown keys fall through to a humanized generic. */
+const EFFECT_BADGE: Record<string, { label: string; cls: string }> = {
+  db_read: { label: "DB read", cls: "text-info bg-info-soft" },
+  db_write: { label: "DB write", cls: "text-warning bg-warning-soft" },
+  http_out: { label: "HTTP", cls: "text-accent-strong bg-accent-soft" },
+  fs: { label: "FS", cls: "text-text-3 bg-surface-2" },
+  fs_read: { label: "FS read", cls: "text-text-3 bg-surface-2" },
+  fs_write: { label: "FS write", cls: "text-text-3 bg-surface-2" },
+  queue: { label: "Queue", cls: "text-accent-strong bg-accent-soft" },
+};
+
+export function effectBadge(effect: string): { label: string; cls: string } {
+  return (
+    EFFECT_BADGE[effect] ?? {
+      // Humanize an unknown effect key (db_read → "db read") rather than drop it.
+      label: effect.replace(/_/g, " "),
+      cls: "text-text-3 bg-surface-2",
+    }
+  );
+}

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -33,6 +33,7 @@ import {
 import { FlowDag } from "@/components/flow-dag";
 import { RefLine } from "@/components/RefLine";
 import { getRepoColor } from "@/lib/repo-color";
+import { effectBadge } from "@/lib/effect-badge";
 import { SectionHeader } from "@/components/SectionHeader";
 import { ShapeTree, type ShapeTreeRow } from "@/components/ShapeTree";
 import { AuthSection } from "@/components/Paths/EndpointDetail/AuthSection";
@@ -605,6 +606,34 @@ function EntityRow({ entity }: { entity: PathEntity }) {
   );
 }
 
+/**
+ * EffectKindBadge — one EFFECTIVE side-effect kind (#4489), token-tinted to
+ * match the FlowDag downstream cards (shared `effectBadge`). Effects reached
+ * only via a delegated downstream call carry a "via downstream" hint so a thin
+ * controller reads "DB write (via downstream)" rather than implying the handler
+ * mutates the DB itself.
+ */
+function EffectKindBadge({ effect }: { effect: { kind: string; source: "direct" | "downstream" } }) {
+  const b = effectBadge(effect.kind);
+  const downstream = effect.source === "downstream";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 h-[18px] px-1.5 rounded text-[10px] font-medium leading-none",
+        b.cls,
+      )}
+      title={
+        downstream
+          ? `${b.label} — performed by a delegated downstream call, not the handler directly`
+          : `${b.label} — direct effect of the handler`
+      }
+    >
+      {b.label}
+      {downstream && <span className="opacity-60 font-normal">via downstream</span>}
+    </span>
+  );
+}
+
 /** HandlerRefLine — renders a handler detail using the canonical RefLine format.
  *  Issue #1910: Defined-in section collapses from verbose card to one-line ref.
  *  Issue #1934: framework/kind chip removed from RefLine — shown in header strip.
@@ -813,6 +842,7 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
     handlers: rawDetail.handlers ?? [],
     inbound_fetches: rawDetail.inbound_fetches ?? [],
     side_effects: rawDetail.side_effects ?? [],
+    effective_effects: rawDetail.effective_effects ?? [],
     tests: rawDetail.tests ?? [],
     path_hash: rawDetail.path_hash ?? "",
     path: rawDetail.path ?? "",
@@ -1175,22 +1205,42 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
           )}
         </div>
 
-        {/* 7. Side effects */}
+        {/* 7. Side effects — #4489: the count + badges reflect the EFFECTIVE
+            effects (aggregated by the backend over the handler's downstream
+            CALLS), so a thin controller that delegates the DB write to a
+            service shows "DB write (via downstream)" instead of "(0)". The
+            DIRECT side-effect entity rows are still listed below when present. */}
         <div>
           <SectionHeader
             icon={<Zap size={14} />}
             title="Side effects"
-            count={detail.side_effects.length}
-            infoText="DB writes, queue publishes, file writes, or other observable mutations performed by this endpoint."
+            count={
+              (detail.effective_effects?.length ?? 0) > 0
+                ? detail.effective_effects!.length
+                : detail.side_effects.length
+            }
+            infoText="DB writes, queue publishes, file writes, or other observable mutations performed by this endpoint — effective effects aggregated transitively over the handler's downstream calls, so effects performed by a delegated service still show here (tagged 'via downstream')."
             open={openSections.sideeffects}
             onToggle={() => toggleSection("sideeffects")}
           />
           {openSections.sideeffects && (
             <div className="py-1">
-              {detail.side_effects.length === 0 ? (
+              {(detail.effective_effects?.length ?? 0) === 0 &&
+              detail.side_effects.length === 0 ? (
                 <p className="px-4 py-2 text-xs text-text-4">None</p>
               ) : (
-                detail.side_effects.map((e, i) => <EntityRow key={i} entity={e} />)
+                <>
+                  {(detail.effective_effects?.length ?? 0) > 0 && (
+                    <div className="px-4 py-2 flex flex-wrap gap-1.5">
+                      {detail.effective_effects!.map((eff) => (
+                        <EffectKindBadge key={`${eff.kind}-${eff.source}`} effect={eff} />
+                      ))}
+                    </div>
+                  )}
+                  {detail.side_effects.map((e, i) => (
+                    <EntityRow key={i} entity={e} />
+                  ))}
+                </>
               )}
             </div>
           )}


### PR DESCRIPTION
Completes the UI half of #4489 (backend #4524 already merged on main and Closed the issue; the Paths-detail Side-effects panel still showed "(0)" for thin controllers that delegate to a service).

## What
The "Side effects" panel only rendered the handler's DIRECT side-effect edges, which are empty for a thin controller that delegates the DB write downstream. Backend #4524 now ships `effective_effects: [{kind, source}]` (effect kinds aggregated over the handler's downstream CALLS, each tagged `direct`|`downstream`). This surfaces it.

- `PathDetail.effective_effects?: {kind:string; source:'direct'|'downstream'}[]` added to `src/data/types.ts`.
- Side-effects section count + badges now driven off `effective_effects`: token-tinted effect-kind badges (DB read / DB write / HTTP / FS / Queue), with a "via downstream" hint on effects reached only through a delegated callee — so a delegating create endpoint reads "DB write (via downstream)" instead of "(0)". Direct side-effect entity rows still list below when present.
- Extracted the FlowDag effect-badge helper into shared `src/lib/effect-badge.ts` so the panel and the downstream-DAG cards tint effects identically.
- Honest-empty: "None" only when there are genuinely no effects.

## Gates
- `npm ci` ✓
- `npm run build` ✓
- `npm run lint` (tsc --noEmit) ✓

Refs #4489

🤖 Generated with [Claude Code](https://claude.com/claude-code)