### PR TITLE
fix(dashboard): honest quality trends — real series or empty, never single-point (#4506)

### DIFF
--- a/internal/dashboard/handlers_quality_trends.go
+++ b/internal/dashboard/handlers_quality_trends.go
@@ -52,9 +52,20 @@ type MetricTrend struct {
 
 // QualityTrendsReply is the wire shape for GET /api/quality/trends/{group}.
 type QualityTrendsReply struct {
-	Group   string        `json:"group"`
-	Days    int           `json:"days"`
+	Group string `json:"group"`
+	Days  int    `json:"days"`
+	// Metrics holds one series per trackable metric. It is only populated
+	// when a real trend exists (≥2 recorded snapshots in the window).
 	Metrics []MetricTrend `json:"metrics"`
+	// HasHistory is true only when a genuine time series exists — i.e. there
+	// are at least two recorded snapshots so a trend can be drawn. A freshly
+	// indexed group (zero or one snapshot) reports false, and the frontend
+	// shows an honest "no trend data yet" empty-state instead of a fabricated
+	// or single-point line.
+	HasHistory bool `json:"has_history"`
+	// PointCount is the number of real snapshots in the requested window.
+	// 0 = never recorded, 1 = freshly indexed (no trend yet), ≥2 = real trend.
+	PointCount int `json:"point_count"`
 }
 
 // handleQualityTrends serves GET /api/quality/trends/{group}?days=N.
@@ -104,8 +115,20 @@ func (s *Server) handleQualityTrends(w http.ResponseWriter, r *http.Request) {
 // buildTrendsReply constructs the full trends payload from a slice of
 // HealthEntry values. The caller must pass entries sorted oldest-first.
 func buildTrendsReply(group string, days int, entries []quality.HealthEntry) QualityTrendsReply {
-	if len(entries) == 0 {
-		return QualityTrendsReply{Group: group, Days: days, Metrics: []MetricTrend{}}
+	// A trend requires at least two recorded snapshots. With zero or one
+	// snapshot there is no honest time series to draw, so we return an empty
+	// payload with has_history=false rather than emitting single-point series
+	// (which the UI would render as "insufficient history" cards) or any
+	// synthetic/fabricated line. The frontend renders its honest empty-state
+	// off has_history / an empty metrics list.
+	if len(entries) < 2 {
+		return QualityTrendsReply{
+			Group:      group,
+			Days:       days,
+			Metrics:    []MetricTrend{},
+			HasHistory: false,
+			PointCount: len(entries),
+		}
 	}
 
 	// Build per-metric point lists. We always emit the core metrics
@@ -235,7 +258,13 @@ func buildTrendsReply(group string, days int, entries []quality.HealthEntry) Qua
 		metrics = []MetricTrend{}
 	}
 
-	return QualityTrendsReply{Group: group, Days: days, Metrics: metrics}
+	return QualityTrendsReply{
+		Group:      group,
+		Days:       days,
+		Metrics:    metrics,
+		HasHistory: true,
+		PointCount: len(entries),
+	}
 }
 
 // refDelta returns (latest − reference) for a metric, where reference is

--- a/internal/dashboard/handlers_quality_trends_test.go
+++ b/internal/dashboard/handlers_quality_trends_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 // TestBuildTrendsReply_empty verifies that an empty entry slice yields
-// an empty metrics slice (not nil) so the frontend can handle it uniformly.
+// an empty metrics slice (not nil) so the frontend can handle it uniformly,
+// and reports has_history=false / point_count=0 (no fabricated series).
 func TestBuildTrendsReply_empty(t *testing.T) {
 	reply := buildTrendsReply("mygroup", 30, nil)
 	if reply.Group != "mygroup" {
@@ -19,6 +20,53 @@ func TestBuildTrendsReply_empty(t *testing.T) {
 	}
 	if len(reply.Metrics) != 0 {
 		t.Errorf("expected 0 metrics for empty input, got %d", len(reply.Metrics))
+	}
+	if reply.HasHistory {
+		t.Errorf("has_history: got true, want false for 0 snapshots")
+	}
+	if reply.PointCount != 0 {
+		t.Errorf("point_count: got %d, want 0", reply.PointCount)
+	}
+}
+
+// TestBuildTrendsReply_singleSnapshot verifies the freshly-indexed case: a
+// single recorded snapshot is NOT a trend, so we emit zero metrics and report
+// has_history=false / point_count=1. This is the honest empty-state that
+// replaces the previously confusing single-point "insufficient history" cards
+// (and any fabricated sawtooth). Ticket #4506.
+func TestBuildTrendsReply_singleSnapshot(t *testing.T) {
+	now := time.Now().UTC()
+	covPct := 65.0
+	cycles := 3
+	secrets := 2
+	entries := []quality.HealthEntry{
+		{
+			Timestamp:     now,
+			Group:         "g",
+			TotalEntities: 500,
+			OrphanRate:    10.0,
+			BugRate:       2.0,
+			HealthScore:   88.0,
+			CoveragePct:   &covPct,
+			Cycles:        &cycles,
+			Secrets:       &secrets,
+		},
+	}
+
+	reply := buildTrendsReply("g", 30, entries)
+
+	if len(reply.Metrics) != 0 {
+		t.Errorf("expected 0 metrics for a single snapshot (no trend), got %d", len(reply.Metrics))
+	}
+	if reply.HasHistory {
+		t.Errorf("has_history: got true, want false for a single snapshot")
+	}
+	if reply.PointCount != 1 {
+		t.Errorf("point_count: got %d, want 1", reply.PointCount)
+	}
+	// Must never be nil so the frontend can iterate uniformly.
+	if reply.Metrics == nil {
+		t.Error("Metrics must be a non-nil empty slice")
 	}
 }
 
@@ -46,6 +94,14 @@ func TestBuildTrendsReply_coreMetrics(t *testing.T) {
 	}
 
 	reply := buildTrendsReply("g", 30, entries)
+
+	// Two real snapshots → a genuine trend.
+	if !reply.HasHistory {
+		t.Errorf("has_history: got false, want true for 2 snapshots")
+	}
+	if reply.PointCount != 2 {
+		t.Errorf("point_count: got %d, want 2", reply.PointCount)
+	}
 
 	// At minimum the three core metrics must be present.
 	if len(reply.Metrics) < 3 {
@@ -78,11 +134,26 @@ func TestBuildTrendsReply_coreMetrics(t *testing.T) {
 // (coverage, cycles, secrets) are included only when data exists.
 func TestBuildTrendsReply_extendedMetrics(t *testing.T) {
 	now := time.Now().UTC()
+	covPct0 := 60.0
+	cycles0 := 4
+	secrets0 := 3
 	covPct := 65.0
 	cycles := 3
 	secrets := 2
 
+	// Need ≥2 snapshots for a real trend to be emitted.
 	entries := []quality.HealthEntry{
+		{
+			Timestamp:     now.Add(-48 * time.Hour),
+			Group:         "g",
+			TotalEntities: 480,
+			OrphanRate:    11.0,
+			BugRate:       2.5,
+			HealthScore:   86.5,
+			CoveragePct:   &covPct0,
+			Cycles:        &cycles0,
+			Secrets:       &secrets0,
+		},
 		{
 			Timestamp:     now.Add(-24 * time.Hour),
 			Group:         "g",
@@ -126,7 +197,17 @@ func TestBuildTrendsReply_extendedMetrics(t *testing.T) {
 // included in the reply when all entries have nil for that metric.
 func TestBuildTrendsReply_sparseMetricExcluded(t *testing.T) {
 	now := time.Now().UTC()
+	// Two snapshots so a trend is emitted, but with no extended metrics.
 	entries := []quality.HealthEntry{
+		{
+			Timestamp:     now.Add(-24 * time.Hour),
+			Group:         "g",
+			TotalEntities: 480,
+			OrphanRate:    11.0,
+			BugRate:       2.5,
+			HealthScore:   86.5,
+			// CoveragePct, Cycles, Secrets all nil → should be excluded.
+		},
 		{
 			Timestamp:     now,
 			Group:         "g",


### PR DESCRIPTION
## Problem

On upvate-v3 `/quality` (Trends), every metric card rendered a sparkline + `7d 0 / 30d 0` even for a freshly-indexed group. A trend needs at least two recorded snapshots; with one snapshot there is no honest time series, so the cards looked fabricated / placeholder.

## Investigation

The Go data source was already honest — `handleQualityTrends` reads the real `health-history.jsonl` via `quality.ReadHistory`, and `ReadHistory` returns empty (not synthetic) when no file exists. **No synthetic/oscillating series is generated in the backend.** The defect was that `buildTrendsReply` emitted one `MetricTrend` per metric even for a **single** snapshot, producing non-drawable single-point series and zero deltas. The frontend's clean "No trend history yet" empty-state only fired on `metrics.length === 0`, so a single-snapshot group fell through to confusing single-point cards instead.

Snapshot **recording** is real and unchanged: `cmd/archigraph/rebuild_history.go` → `quality.AppendEntry` is wired into the daemon rebuild path (`daemon.go`), so trends accumulate genuinely over successive rebuilds.

## Fix

`buildTrendsReply` now:
- returns an **empty** metrics list with `has_history=false` when there are fewer than two recorded snapshots (0 or 1) — never single-point or synthetic cards;
- adds explicit `has_history` and `point_count` fields to the wire shape so the frontend (honest empty-state already shipped in #4518) is driven by a real signal;
- returns the **real** series unchanged for N≥2 snapshots, with `has_history=true`.

## Tests (live, in-package)

- 0 snapshots → empty metrics, `has_history=false`, `point_count=0`
- 1 snapshot → empty metrics, `has_history=false`, `point_count=1` (no synthetic points)
- N≥2 → real series, `has_history=true`, `point_count=N`, real deltas

## Gates

- `go build ./...` ✅
- `go vet ./internal/dashboard/...` ✅
- `go test ./internal/dashboard/... ./internal/quality/...` ✅

Four `cmd/archigraph` tests fail (`TestColdLoadTiming`, `TestDaemonRebuildParallel`, `TestPythonTrioEndpointAttribution_Pyramid`, `TestIssue2691_Sinatra_EndpointAttribution`) — verified pre-existing on untouched `origin/main` (timing/extractor-attribution, unrelated to this change). DEPLOY-DEFERRED.

Closes #4506

🤖 Generated with [Claude Code](https://claude.com/claude-code)