### PR TITLE
IaC architecture diagram: render the resolved IaC resource graph with module grouping

### DIFF
--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -103,6 +103,13 @@ type IaCRelation struct {
 	// TargetID is the raw graph entity id of the other endpoint, always set so
 	// the UI can show it on hover regardless of resolution. (#4495)
 	TargetID string `json:"target_id"`
+	// TargetEntityID is the slug-prefixed entity id (`<repo>/<rawId>`) of the
+	// other endpoint WHEN that endpoint is itself a rendered IaC resource node;
+	// empty otherwise. This is the graph-joinable key the architecture-diagram
+	// view (#4526) uses to draw an edge between two rendered resource nodes —
+	// IaCResource.EntityID carries the same slug prefix, whereas TargetID does
+	// not, so the raw id alone cannot be joined client-side.
+	TargetEntityID string `json:"target_entity_id,omitempty"`
 	// Detail is the grant method (for grants) or other edge qualifier, when set.
 	Detail string `json:"detail,omitempty"`
 }
@@ -124,6 +131,12 @@ type IaCResource struct {
 	LogicalID  string `json:"logical_id,omitempty"`
 	SourceFile string `json:"source_file,omitempty"`
 	StartLine  int    `json:"start_line,omitempty"`
+	// Module is the grouping key for the architecture diagram (#4526): the
+	// module / construct / stack the resource belongs to, derived from the
+	// source-file directory (e.g. `infra/terraform/modules/network`). A
+	// modularized stack flattens to many resources sharing a Module, which the
+	// diagram renders as a grouped container. Empty when no source path is known.
+	Module string `json:"module,omitempty"`
 
 	// Properties — curated typed config props (empty when none stamped).
 	Properties []IaCProperty `json:"properties"`
@@ -288,6 +301,28 @@ func iacIsOutputEntity(kind, subtype string, props map[string]string) bool {
 	return false
 }
 
+// iacModuleOf derives the architecture-diagram grouping key (#4526) for a
+// resource from its source-file path: the containing directory, which for a
+// modularized stack is the module / construct / stack root (e.g.
+// `infra/terraform/modules/network/main.tf` → `infra/terraform/modules/network`).
+// Falls back to the repo slug when there is no directory component, and to ""
+// when no source file is known.
+func iacModuleOf(slug, sourceFile string) string {
+	sf := strings.TrimSpace(sourceFile)
+	if sf == "" {
+		return ""
+	}
+	sf = strings.ReplaceAll(sf, "\\", "/")
+	if i := strings.LastIndexByte(sf, '/'); i > 0 {
+		return sf[:i]
+	}
+	// No directory component — the file sits at the repo root.
+	if slug != "" {
+		return slug
+	}
+	return "(root)"
+}
+
 // idTail returns the last path segment of a graph entity ID (Kind:Name or
 // repo/Kind:Name), used as a readable relation target when no entity name is
 // resolvable.
@@ -450,6 +485,7 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 				LogicalID:    props["logical_id"],
 				SourceFile:   sourceFile,
 				StartLine:    startLine,
+				Module:       iacModuleOf(rp.Slug, sourceFile),
 				Properties:   cfgProps,
 				Relations:    []IaCRelation{},
 			}
@@ -484,6 +520,16 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 				return idTail(id), false
 			}
 
+			// joinableID returns the slug-prefixed entity id of the other endpoint
+			// when it is itself a collected (rendered) resource, so the diagram can
+			// draw an edge between two rendered nodes (#4526); "" otherwise.
+			joinableID := func(other *IaCResource) string {
+				if other != nil {
+					return other.EntityID
+				}
+				return ""
+			}
+
 			if fromRes != nil {
 				name, resolved := targetName(toID)
 				fromRes.Relations = append(fromRes.Relations, IaCRelation{
@@ -493,6 +539,7 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 					Target:         name,
 					TargetResolved: resolved,
 					TargetID:       toID,
+					TargetEntityID: joinableID(toRes),
 					Detail:         detail,
 				})
 			}
@@ -505,6 +552,7 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 					Target:         name,
 					TargetResolved: resolved,
 					TargetID:       fromID,
+					TargetEntityID: joinableID(fromRes),
 					Detail:         detail,
 				})
 			}

--- a/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
@@ -1,0 +1,186 @@
+/* ============================================================
+   components/iac-diagram/IaCDiagram.tsx — IaC architecture diagram (#4526).
+
+   Renders the resolved IaC resource graph (IaCReport) as a cloud-architecture
+   diagram with React Flow + dagre:
+
+     - Nodes  = IaC resources, colored + iconed by resource_category.
+     - Edges  = DEPENDS_ON / USES relations (grant / event-source / dependency /
+                topology), directional, styled by facet.
+     - Groups = module containers — resources sharing a `module` cluster into a
+                labelled box, so a modularized Terraform / CDK stack reads as
+                grouped boxes. This works across modularized IaC because
+                archigraph flattens modules to the resolved resource graph.
+
+   Controls: H/V layout toggle, zoom/fit (React Flow Controls), MiniMap. Click a
+   resource node → its source peek (file:line) via the node renderer. Unresolved
+   relation targets (#4495) are not drawn as dead edges; they surface as a count
+   chip on the owning node and in the legend footer.
+   ============================================================ */
+
+import { useMemo, useState } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MiniMap,
+  type NodeTypes,
+  type EdgeTypes,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { ArrowRight, ArrowDown, Unlink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { IaCReport } from "@/data/types";
+import {
+  layoutIaCDiagram,
+  IAC_NODE_TYPE,
+  IAC_GROUP_TYPE,
+  IAC_EDGE_TYPE,
+  MAX_DIAGRAM_NODES,
+  type IaCDiagramDirection,
+} from "./layout";
+import { IaCNode } from "./IaCNode";
+import { IaCGroupNode } from "./IaCGroupNode";
+import { IaCEdge } from "./IaCEdge";
+import { categoryStyle } from "./categoryStyle";
+
+const nodeTypes: NodeTypes = {
+  [IAC_NODE_TYPE]: IaCNode,
+  [IAC_GROUP_TYPE]: IaCGroupNode,
+};
+const edgeTypes: EdgeTypes = { [IAC_EDGE_TYPE]: IaCEdge };
+
+// Legend swatches — the categories that actually carry distinct colors.
+const LEGEND_CATEGORIES = [
+  "compute",
+  "datastore",
+  "queue",
+  "function",
+  "network",
+  "secret",
+  "other",
+];
+
+interface IaCDiagramProps {
+  report: IaCReport;
+  className?: string;
+}
+
+function IaCDiagramInner({ report, className }: IaCDiagramProps) {
+  const [direction, setDirection] = useState<IaCDiagramDirection>("LR");
+
+  const { nodes, edges, capped, unresolvedEdges } = useMemo(
+    () => layoutIaCDiagram(report, direction),
+    [report, direction],
+  );
+
+  const moduleCount = useMemo(
+    () => nodes.filter((n) => n.type === IAC_GROUP_TYPE).length,
+    [nodes],
+  );
+  const resourceCount = nodes.length - moduleCount;
+
+  return (
+    <div className={cn("flex h-full min-h-0 flex-col", className)}>
+      {/* Controls bar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface px-3 py-2">
+        <div className="inline-flex overflow-hidden rounded-md border border-border">
+          <button
+            type="button"
+            onClick={() => setDirection("LR")}
+            className={cn(
+              "inline-flex h-7 items-center gap-1 px-2 text-xs transition-colors",
+              direction === "LR" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+            )}
+            title="Horizontal layout (left → right)"
+          >
+            <ArrowRight size={12} /> H
+          </button>
+          <button
+            type="button"
+            onClick={() => setDirection("TB")}
+            className={cn(
+              "inline-flex h-7 items-center gap-1 border-l border-border px-2 text-xs transition-colors",
+              direction === "TB" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+            )}
+            title="Vertical layout (top → bottom)"
+          >
+            <ArrowDown size={12} /> V
+          </button>
+        </div>
+
+        <span className="text-xs text-text-4 tabular-nums">
+          {resourceCount} {resourceCount === 1 ? "resource" : "resources"}
+          {" · "}
+          {moduleCount} {moduleCount === 1 ? "module" : "modules"}
+        </span>
+
+        {capped && (
+          <span className="text-xs text-warning" title={`Only the first ${MAX_DIAGRAM_NODES} resources are drawn.`}>
+            showing first {MAX_DIAGRAM_NODES}
+          </span>
+        )}
+
+        {/* Category legend */}
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          {LEGEND_CATEGORIES.map((cat) => {
+            const s = categoryStyle(cat);
+            const Icon = s.Icon;
+            return (
+              <span key={cat} className="inline-flex items-center gap-1 text-[10px] text-text-4" title={s.label}>
+                <span
+                  className="inline-flex size-3.5 items-center justify-center rounded"
+                  style={{ color: s.color, background: s.tint }}
+                >
+                  <Icon size={9} />
+                </span>
+                <span className="uppercase">{cat}</span>
+              </span>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div className="relative min-h-0 flex-1">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable
+          proOptions={{ hideAttribution: true }}
+          minZoom={0.1}
+          fitViewOptions={{ padding: 0.16 }}
+        >
+          <Background gap={18} size={1} color="var(--border)" />
+          <Controls showInteractive={false} />
+          <MiniMap pannable zoomable className="!border !border-border !bg-surface" />
+        </ReactFlow>
+      </div>
+
+      {/* Footer: unresolved-target honesty note (#4495). */}
+      {unresolvedEdges > 0 && (
+        <div className="flex items-center gap-1.5 border-t border-border bg-surface px-3 py-1.5 text-[11px] text-text-4">
+          <Unlink size={11} />
+          {unresolvedEdges} relation {unresolvedEdges === 1 ? "target" : "targets"} could
+          not be resolved to a rendered resource and {unresolvedEdges === 1 ? "is" : "are"} not
+          drawn as edges (shown as a chip on the owning node).
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** IaCDiagram — wraps the inner view in a ReactFlowProvider. */
+export function IaCDiagram(props: IaCDiagramProps) {
+  return (
+    <ReactFlowProvider>
+      <IaCDiagramInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/webui-v2/src/components/iac-diagram/IaCEdge.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCEdge.tsx
@@ -1,0 +1,92 @@
+/* ============================================================
+   components/iac-diagram/IaCEdge.tsx — custom relation edge (#4526).
+
+   Draws a directional resource-to-resource relation styled by its facet:
+   grant (danger, dashed) / event_source (warning, dashed) / topology (info,
+   dotted) / dependency (neutral, solid). A small mid-edge label names the
+   facet so a dense stack stays legible.
+   ============================================================ */
+
+import { memo } from "react";
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getBezierPath,
+  type EdgeProps,
+} from "@xyflow/react";
+import type { IaCEdgeData } from "./layout";
+
+interface FacetStyle {
+  stroke: string;
+  dash?: string;
+  label: string;
+}
+
+export function facetStyle(facet: string): FacetStyle {
+  switch ((facet || "").toLowerCase()) {
+    case "grant":
+      return { stroke: "var(--danger)", dash: "5 3", label: "grant" };
+    case "event_source":
+      return { stroke: "var(--warning)", dash: "5 3", label: "event" };
+    case "trigger":
+      return { stroke: "var(--accent)", dash: "5 3", label: "trigger" };
+    case "topology":
+      return { stroke: "var(--info)", dash: "2 3", label: "topology" };
+    case "output":
+      return { stroke: "var(--text-4)", dash: "2 3", label: "output" };
+    default:
+      return { stroke: "var(--text-4)", label: "depends" };
+  }
+}
+
+function IaCEdgeImpl({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  data,
+}: EdgeProps) {
+  const ed = data as IaCEdgeData | undefined;
+  const fs = facetStyle(ed?.facet ?? "dependency");
+
+  const [path, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <BaseEdge
+        path={path}
+        markerEnd={markerEnd}
+        style={{ stroke: fs.stroke, strokeWidth: 1.5, strokeDasharray: fs.dash }}
+      />
+      {/* Label only the semantic (non-plain-dependency) edges to reduce clutter. */}
+      {ed?.facet && ed.facet.toLowerCase() !== "dependency" && (
+        <EdgeLabelRenderer>
+          <div
+            className="absolute pointer-events-none rounded px-1 py-px text-[9px] font-medium leading-none"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              background: "var(--surface)",
+              color: fs.stroke,
+              border: `1px solid color-mix(in srgb, ${fs.stroke} 45%, transparent)`,
+            }}
+            title={ed.detail ? `${fs.label}: ${ed.detail}` : fs.label}
+          >
+            {fs.label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+
+export const IaCEdge = memo(IaCEdgeImpl);

--- a/webui-v2/src/components/iac-diagram/IaCGroupNode.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCGroupNode.tsx
@@ -1,0 +1,35 @@
+/* ============================================================
+   components/iac-diagram/IaCGroupNode.tsx — module container (#4526).
+
+   A non-interactive container that visually clusters the resources of one
+   module / construct / stack. This is the key affordance for modularized IaC:
+   archigraph flattens modules to the resolved resource graph, so grouping the
+   flattened resources back by `module` reconstructs the stack structure as
+   labelled boxes. Header shows the short module label + the resource count;
+   the full module path is on hover.
+   ============================================================ */
+
+import { memo } from "react";
+import { Layers } from "lucide-react";
+import type { NodeProps } from "@xyflow/react";
+import type { IaCGroupData } from "./layout";
+
+function IaCGroupNodeImpl({ data }: NodeProps) {
+  const { module, shortLabel, count } = data as IaCGroupData;
+  return (
+    <div
+      className="h-full w-full rounded-lg border border-dashed border-border bg-surface-2/40"
+      title={module}
+    >
+      <div className="flex items-center gap-1.5 px-2.5 pt-1.5 text-text-3">
+        <Layers size={11} className="shrink-0 text-text-4" />
+        <span className="truncate font-mono text-[10px] font-medium" title={module}>
+          {shortLabel}
+        </span>
+        <span className="ml-auto shrink-0 text-[10px] tabular-nums text-text-4">{count}</span>
+      </div>
+    </div>
+  );
+}
+
+export const IaCGroupNode = memo(IaCGroupNodeImpl);

--- a/webui-v2/src/components/iac-diagram/IaCNode.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCNode.tsx
@@ -1,0 +1,103 @@
+/* ============================================================
+   components/iac-diagram/IaCNode.tsx — one IaC resource node (#4526).
+
+   A resource card colored + iconed by its resource_category. Label = the
+   resource name (e.g. `aws_sqs_queue.main`), with the tool-native type as a
+   subtitle. An unresolved-target chip appears when the resource has relations
+   whose endpoint could not be joined to a rendered node (#4495). Clicking the
+   node opens the source peek (file:line) when a source ref exists.
+   ============================================================ */
+
+import { memo } from "react";
+import { useParams } from "react-router-dom";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Unlink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useSourcePeek } from "@/components/SourcePeek";
+import { categoryStyle } from "./categoryStyle";
+import type { IaCNodeData } from "./layout";
+
+function IaCNodeImpl({ data, sourcePosition, targetPosition, selected }: NodeProps) {
+  const { resource, unresolvedCount } = data as IaCNodeData;
+  const style = categoryStyle(resource.category);
+  const Icon = style.Icon;
+  const { openSourcePeek } = useSourcePeek();
+  const { groupId = "" } = useParams<{ groupId: string }>();
+
+  const hasSource = !!resource.source_file;
+  const onClick = () => {
+    if (!hasSource) return;
+    openSourcePeek({
+      groupId,
+      file: resource.source_file!,
+      line: resource.start_line ?? 0,
+      repo: resource.repo,
+    });
+  };
+
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        "group relative flex flex-col justify-center gap-0.5 rounded-md border bg-surface px-2.5 py-1.5 shadow-sm transition-shadow",
+        hasSource && "cursor-pointer hover:shadow-md",
+        selected && "ring-2 ring-offset-1 ring-offset-bg",
+      )}
+      style={{
+        width: "100%",
+        height: "100%",
+        borderColor: style.color,
+        borderLeftWidth: 3,
+        // selection ring picks up the category color
+        ...(selected ? ({ ["--tw-ring-color" as string]: style.color }) : {}),
+      }}
+      title={
+        hasSource
+          ? `${resource.name} — ${resource.source_file}:${resource.start_line ?? 0}`
+          : resource.name
+      }
+    >
+      <Handle type="target" position={targetPosition ?? Position.Left} className="!h-1.5 !w-1.5 !border-0 !bg-[var(--text-4)]" />
+
+      <div className="flex items-center gap-1.5 min-w-0">
+        <span
+          className="inline-flex size-4 shrink-0 items-center justify-center rounded"
+          style={{ color: style.color, background: style.tint }}
+        >
+          <Icon size={11} />
+        </span>
+        <span className="truncate font-mono text-[11px] font-medium text-text" title={resource.name}>
+          {resource.name}
+        </span>
+        {unresolvedCount > 0 && (
+          <span
+            className="ml-auto inline-flex shrink-0 items-center gap-0.5 rounded px-1 text-[9px] text-text-4"
+            title={`${unresolvedCount} relation target(s) not resolved to a rendered resource (#4495)`}
+          >
+            <Unlink size={9} />
+            {unresolvedCount}
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1 min-w-0 pl-[22px]">
+        <span
+          className="truncate font-mono text-[9px] uppercase tracking-wide"
+          style={{ color: style.color }}
+          title={style.label}
+        >
+          {style.key}
+        </span>
+        {resource.resource_type && (
+          <span className="truncate font-mono text-[9px] text-text-4" title={resource.resource_type}>
+            {resource.resource_type}
+          </span>
+        )}
+      </div>
+
+      <Handle type="source" position={sourcePosition ?? Position.Right} className="!h-1.5 !w-1.5 !border-0 !bg-[var(--text-4)]" />
+    </div>
+  );
+}
+
+export const IaCNode = memo(IaCNodeImpl);

--- a/webui-v2/src/components/iac-diagram/categoryStyle.ts
+++ b/webui-v2/src/components/iac-diagram/categoryStyle.ts
@@ -1,0 +1,67 @@
+/* ============================================================
+   components/iac-diagram/categoryStyle.ts — resource_category styling.
+
+   The single cross-tool join key every IaC tool emits is resource_category
+   (datastore/queue/topic/stream/function/cache/secret/network/compute/
+   storage/other — see internal/types/iac_resource_category.go). The
+   architecture diagram (#4526) colors + icons each resource node by that
+   category so a modularized stack reads at a glance. Colors reference the
+   theme CSS vars (tone palette) used elsewhere in the dashboard rather than
+   hard-coded hex, so they track light/dark.
+   ============================================================ */
+
+import {
+  Database,
+  HardDrive,
+  Network,
+  Cpu,
+  Inbox,
+  Radio,
+  Waves,
+  Zap,
+  Boxes,
+  KeyRound,
+  type LucideIcon,
+} from "lucide-react";
+
+export interface CategoryStyle {
+  /** Lower-cased canonical category key. */
+  key: string;
+  /** Display label (upper-cased at render). */
+  label: string;
+  Icon: LucideIcon;
+  /** CSS color var for the node accent (border / icon / chip). */
+  color: string;
+  /** Translucent background tint var pairing with `color`. */
+  tint: string;
+}
+
+// Each category maps to one of the dashboard tone palette vars. We reuse the
+// existing --info / --warning / --accent / --danger / --success / --text-4
+// channels so the diagram stays on-theme without introducing new tokens.
+const STYLES: Record<string, Omit<CategoryStyle, "key">> = {
+  datastore: { label: "Datastore", Icon: Database, color: "var(--info)", tint: "var(--info-bg, rgba(56,139,253,0.12))" },
+  cache: { label: "Cache", Icon: HardDrive, color: "var(--info)", tint: "var(--info-bg, rgba(56,139,253,0.12))" },
+  queue: { label: "Queue", Icon: Inbox, color: "var(--warning)", tint: "var(--warning-bg, rgba(210,153,34,0.12))" },
+  topic: { label: "Topic", Icon: Radio, color: "var(--warning)", tint: "var(--warning-bg, rgba(210,153,34,0.12))" },
+  stream: { label: "Stream", Icon: Waves, color: "var(--warning)", tint: "var(--warning-bg, rgba(210,153,34,0.12))" },
+  function: { label: "Function", Icon: Zap, color: "var(--accent)", tint: "var(--accent-bg, rgba(124,108,255,0.14))" },
+  secret: { label: "Secret", Icon: KeyRound, color: "var(--danger)", tint: "var(--danger-bg, rgba(248,81,73,0.12))" },
+  network: { label: "Network", Icon: Network, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
+  compute: { label: "Compute", Icon: Cpu, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
+  storage: { label: "Storage", Icon: HardDrive, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
+};
+
+const FALLBACK: Omit<CategoryStyle, "key"> = {
+  label: "Other",
+  Icon: Boxes,
+  color: "var(--text-4)",
+  tint: "var(--surface-2, rgba(110,118,129,0.10))",
+};
+
+/** Resolve the styling for a resource_category (case-insensitive, "" → other). */
+export function categoryStyle(category?: string): CategoryStyle {
+  const key = (category || "other").toLowerCase();
+  const base = STYLES[key] ?? FALLBACK;
+  return { key, ...base };
+}

--- a/webui-v2/src/components/iac-diagram/index.ts
+++ b/webui-v2/src/components/iac-diagram/index.ts
@@ -1,0 +1,8 @@
+/* components/iac-diagram — IaC architecture-diagram view (#4526). */
+export { IaCDiagram } from "./IaCDiagram";
+export {
+  layoutIaCDiagram,
+  flattenResources,
+  MAX_DIAGRAM_NODES,
+  type IaCDiagramDirection,
+} from "./layout";

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -1,0 +1,269 @@
+/* ============================================================
+   components/iac-diagram/layout.ts — IaC resource-graph → React Flow layout.
+
+   Turns the resolved IaC resource graph (IaCReport, handlers_iac.go) into a
+   positioned React Flow graph for the architecture-diagram view (#4526):
+
+     - nodes  = IaC resources, styled by resource_category.
+     - edges  = DEPENDS_ON / USES relations (grants / event-sources /
+                dependencies / topology), drawn between two RENDERED resource
+                nodes by joining IaCRelation.target_entity_id against
+                IaCResource.entity_id (the slug-prefixed key the backend adds).
+     - groups = module containers: resources sharing a `module` are laid out as
+                children of a React Flow parent (group) node, so a modularized
+                Terraform / CDK stack reads as grouped boxes. This is the key
+                ask — archigraph flattens modules to the resolved resource
+                graph, so grouping by module reconstructs the stack structure.
+
+   Layout uses dagre as a COMPOUND graph (setParent) so children cluster under
+   their module; we then derive each group node's bounding box from its laid-out
+   children. Unresolved edge targets (#4495 target_resolved=false, or a target
+   that is not itself a rendered node) are NOT drawn as dead edges — the caller
+   surfaces them separately as external/unresolved chips on the node.
+   ============================================================ */
+
+import dagre from "dagre";
+import { Position, type Node, type Edge } from "@xyflow/react";
+import type { IaCReport, IaCResource } from "@/data/types";
+
+export type IaCDiagramDirection = "LR" | "TB";
+
+export const IAC_NODE_TYPE = "iacResource";
+export const IAC_GROUP_TYPE = "iacModule";
+export const IAC_EDGE_TYPE = "iacRelation";
+
+/** Resource-node box fed to dagre (the renderer matches these dims). */
+const NODE_W = 220;
+const NODE_H = 64;
+
+/** Padding inside a module group container (top leaves room for the header). */
+const GROUP_PAD_X = 18;
+const GROUP_PAD_TOP = 40;
+const GROUP_PAD_BOTTOM = 18;
+
+/** Hard ceiling so a huge stack can't hang the browser. */
+export const MAX_DIAGRAM_NODES = 500;
+
+export interface IaCEdgeData {
+  facet: string;
+  kind: string;
+  detail?: string;
+  [key: string]: unknown;
+}
+
+export interface IaCNodeData {
+  resource: IaCResource;
+  /** Count of relation targets that could not be joined to a rendered node. */
+  unresolvedCount: number;
+  [key: string]: unknown;
+}
+
+export interface IaCGroupData {
+  module: string;
+  /** Short trailing segment of the module path, for the header label. */
+  shortLabel: string;
+  count: number;
+  [key: string]: unknown;
+}
+
+export interface IaCLayoutResult {
+  nodes: Node[];
+  edges: Edge[];
+  /** True when the resource set was clipped at MAX_DIAGRAM_NODES. */
+  capped: boolean;
+  /** Number of relation endpoints that resolved to no rendered node. */
+  unresolvedEdges: number;
+}
+
+/** Flatten the tool-grouped report into a single resource list. */
+export function flattenResources(report: IaCReport | undefined): IaCResource[] {
+  if (!report) return [];
+  const out: IaCResource[] = [];
+  for (const g of report.groups) {
+    for (const r of g.resources) out.push(r);
+  }
+  return out;
+}
+
+/** Trailing path segment of a module key, for a compact group header. */
+function shortModuleLabel(module: string): string {
+  const cleaned = module.replace(/\/+$/, "");
+  const i = cleaned.lastIndexOf("/");
+  return i >= 0 ? cleaned.slice(i + 1) : cleaned;
+}
+
+/**
+ * Build a positioned, module-grouped React Flow graph from the IaC report.
+ *
+ * @param report     the IaCReport (already fetched)
+ * @param direction  "LR" (horizontal) | "TB" (vertical) → dagre rankdir
+ */
+export function layoutIaCDiagram(
+  report: IaCReport | undefined,
+  direction: IaCDiagramDirection,
+): IaCLayoutResult {
+  const all = flattenResources(report);
+  const capped = all.length > MAX_DIAGRAM_NODES;
+  const resources = capped ? all.slice(0, MAX_DIAGRAM_NODES) : all;
+
+  if (resources.length === 0) {
+    return { nodes: [], edges: [], capped, unresolvedEdges: 0 };
+  }
+
+  // Index rendered resources by their slug-prefixed entity id so edges can join.
+  const byEntityId = new Map<string, IaCResource>();
+  for (const r of resources) byEntityId.set(r.entity_id, r);
+
+  // Assign each resource a module bucket. "" module → a synthetic "(ungrouped)"
+  // bucket so every node still has a parent container (keeps layout uniform).
+  const moduleOf = (r: IaCResource) => r.module || "(ungrouped)";
+  const modules = new Map<string, IaCResource[]>();
+  for (const r of resources) {
+    const m = moduleOf(r);
+    const list = modules.get(m);
+    if (list) list.push(r);
+    else modules.set(m, [r]);
+  }
+
+  // ── Edges. Draw only edges between two rendered nodes, de-duplicated by
+  // (from,to,kind). We follow the "out" direction so each edge is drawn once;
+  // unresolved targets (no target_entity_id, or not a rendered node) are
+  // counted, not drawn. ────────────────────────────────────────────────────
+  interface RawEdge { from: string; to: string; facet: string; kind: string; detail?: string }
+  const rawEdges: RawEdge[] = [];
+  const seen = new Set<string>();
+  let unresolvedEdges = 0;
+
+  for (const r of resources) {
+    for (const rel of r.relations) {
+      if (rel.direction !== "out") continue; // "in" is the mirror of some "out".
+      const targetEntity = rel.target_entity_id;
+      if (!targetEntity || !byEntityId.has(targetEntity)) {
+        unresolvedEdges++;
+        continue;
+      }
+      const key = `${r.entity_id}|${targetEntity}|${rel.kind}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rawEdges.push({
+        from: r.entity_id,
+        to: targetEntity,
+        facet: rel.facet,
+        kind: rel.kind,
+        detail: rel.detail,
+      });
+    }
+  }
+
+  // ── Compound dagre layout: children grouped under their module cluster. ───
+  const g = new dagre.graphlib.Graph({ compound: true });
+  g.setGraph({
+    rankdir: direction,
+    nodesep: direction === "LR" ? 26 : 40,
+    ranksep: direction === "LR" ? 80 : 64,
+    marginx: 20,
+    marginy: 20,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const [module, members] of modules) {
+    const groupId = `group:${module}`;
+    // Cluster node — dagre sizes it to fit children; we recompute the box below.
+    g.setNode(groupId, { label: module });
+    for (const r of members) {
+      g.setNode(r.entity_id, { width: NODE_W, height: NODE_H });
+      g.setParent(r.entity_id, groupId);
+    }
+  }
+  for (const e of rawEdges) g.setEdge(e.from, e.to);
+
+  dagre.layout(g);
+
+  const sourcePos = direction === "LR" ? Position.Right : Position.Bottom;
+  const targetPos = direction === "LR" ? Position.Left : Position.Top;
+
+  // Resource node absolute positions (dagre centers; RF uses top-left).
+  const absPos = new Map<string, { x: number; y: number }>();
+  for (const r of resources) {
+    const n = g.node(r.entity_id);
+    absPos.set(r.entity_id, {
+      x: (n?.x ?? 0) - NODE_W / 2,
+      y: (n?.y ?? 0) - NODE_H / 2,
+    });
+  }
+
+  // Group bounding boxes derived from member positions (padded). React Flow
+  // child positions are RELATIVE to the parent, so we offset each child by its
+  // group's top-left.
+  const nodes: Node[] = [];
+
+  for (const [module, members] of modules) {
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const r of members) {
+      const p = absPos.get(r.entity_id)!;
+      minX = Math.min(minX, p.x);
+      minY = Math.min(minY, p.y);
+      maxX = Math.max(maxX, p.x + NODE_W);
+      maxY = Math.max(maxY, p.y + NODE_H);
+    }
+    const gx = minX - GROUP_PAD_X;
+    const gy = minY - GROUP_PAD_TOP;
+    const gw = maxX - minX + GROUP_PAD_X * 2;
+    const gh = maxY - minY + GROUP_PAD_TOP + GROUP_PAD_BOTTOM;
+
+    const groupId = `group:${module}`;
+    const groupData: IaCGroupData = {
+      module,
+      shortLabel: module === "(ungrouped)" ? "ungrouped" : shortModuleLabel(module),
+      count: members.length,
+    };
+    nodes.push({
+      id: groupId,
+      type: IAC_GROUP_TYPE,
+      position: { x: gx, y: gy },
+      data: groupData,
+      width: gw,
+      height: gh,
+      draggable: false,
+      selectable: false,
+      // Render behind children.
+      zIndex: 0,
+    });
+
+    for (const r of members) {
+      const p = absPos.get(r.entity_id)!;
+      const unresolvedCount = r.relations.filter(
+        (rel) => !rel.target_entity_id || !byEntityId.has(rel.target_entity_id),
+      ).length;
+      const nodeData: IaCNodeData = { resource: r, unresolvedCount };
+      nodes.push({
+        id: r.entity_id,
+        type: IAC_NODE_TYPE,
+        parentId: groupId,
+        extent: "parent",
+        // Position relative to the parent group.
+        position: { x: p.x - gx, y: p.y - gy },
+        data: nodeData,
+        sourcePosition: sourcePos,
+        targetPosition: targetPos,
+        width: NODE_W,
+        height: NODE_H,
+        zIndex: 1,
+      });
+    }
+  }
+
+  const edges: Edge[] = rawEdges.map((e, i) => {
+    const data: IaCEdgeData = { facet: e.facet, kind: e.kind, detail: e.detail };
+    return {
+      id: `e:${e.from}->${e.to}:${e.kind}:${i}`,
+      source: e.from,
+      target: e.to,
+      type: IAC_EDGE_TYPE,
+      data,
+      zIndex: 2,
+    };
+  });
+
+  return { nodes, edges, capped, unresolvedEdges };
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2099,6 +2099,14 @@ export interface IaCRelation {
   target_resolved: boolean;
   /** Raw graph entity id of the other endpoint; shown on hover (#4495). */
   target_id: string;
+  /**
+   * Slug-prefixed entity id (`<repo>/<rawId>`) of the other endpoint WHEN that
+   * endpoint is itself a rendered IaC resource node; empty otherwise. The
+   * architecture-diagram view (#4526) joins this against IaCResource.entity_id
+   * to draw an edge between two rendered nodes. (target_id alone is unprefixed
+   * and not joinable against entity_id.)
+   */
+  target_entity_id?: string;
   /** Grant method or other edge qualifier, when set. */
   detail?: string;
 }
@@ -2119,6 +2127,13 @@ export interface IaCResource {
   logical_id?: string;
   source_file?: string;
   start_line?: number;
+  /**
+   * Module / construct / stack the resource belongs to (#4526), derived from
+   * the source-file directory (e.g. `infra/terraform/modules/network`). The
+   * architecture diagram clusters resources sharing a module into a container.
+   * Empty when no source path is known.
+   */
+  module?: string;
   /** Curated typed config props; [] when none stamped. */
   properties: IaCProperty[];
   /** Grants / event-sources / dependencies / topology / triggers; [] when none. */

--- a/webui-v2/src/routes/iac.tsx
+++ b/webui-v2/src/routes/iac.tsx
@@ -39,6 +39,8 @@ import {
   GitBranch,
   Layers,
   AlertTriangle,
+  List,
+  Network,
 } from "lucide-react";
 
 import { Badge, Card, CardBody, Pill } from "@/components/ui";
@@ -47,6 +49,7 @@ import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
 import { cn } from "@/lib/utils";
 import { useIaC } from "@/hooks/use-iac";
+import { IaCDiagram } from "@/components/iac-diagram";
 import type {
   IaCRelation,
   IaCResource,
@@ -354,10 +357,43 @@ function CategorySection({ counts }: { counts: Record<string, number> }) {
 // § Screen
 // ---------------------------------------------------------------------------
 
+type IaCView = "list" | "diagram";
+
+/** List | Diagram view toggle. */
+function ViewToggle({ view, onChange }: { view: IaCView; onChange: (v: IaCView) => void }) {
+  return (
+    <div className="inline-flex overflow-hidden rounded-md border border-border">
+      <button
+        type="button"
+        onClick={() => onChange("list")}
+        className={cn(
+          "inline-flex h-7 items-center gap-1 px-2.5 text-xs transition-colors",
+          view === "list" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+        )}
+        title="List view — resources grouped by tool"
+      >
+        <List size={12} /> List
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("diagram")}
+        className={cn(
+          "inline-flex h-7 items-center gap-1 border-l border-border px-2.5 text-xs transition-colors",
+          view === "diagram" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+        )}
+        title="Diagram view — the resource graph as an architecture diagram"
+      >
+        <Network size={12} /> Diagram
+      </button>
+    </div>
+  );
+}
+
 export default function IaCScreen() {
   const { groupId = "" } = useParams<{ groupId: string }>();
   const { data, isLoading, isError } = useIaC(groupId);
   const [toolFilter, setToolFilter] = useState<string>("all");
+  const [view, setView] = useState<IaCView>("list");
 
   const groups = useMemo<IaCToolGroup[]>(() => data?.groups ?? [], [data]);
 
@@ -367,6 +403,24 @@ export default function IaCScreen() {
   }, [groups, toolFilter]);
 
   const hasResources = (data?.total_resources ?? 0) > 0;
+
+  // The diagram view fills the full height itself (its own canvas + controls),
+  // so it is rendered outside the scrolling list container.
+  if (!isLoading && !isError && hasResources && view === "diagram") {
+    return (
+      <div className="flex h-full flex-col bg-bg">
+        <div className="flex items-center gap-2 border-b border-border bg-surface px-4 py-2">
+          <ViewToggle view={view} onChange={setView} />
+          <span className="text-xs text-text-4">
+            Resource graph — resources by category, relations, grouped by module.
+          </span>
+        </div>
+        <div className="min-h-0 flex-1">
+          <IaCDiagram report={data!} />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col h-full bg-bg">
@@ -382,6 +436,11 @@ export default function IaCScreen() {
           />
         ) : (
           <>
+            {/* View toggle (List | Diagram) */}
+            <div className="flex items-center gap-2">
+              <ViewToggle view={view} onChange={setView} />
+            </div>
+
             {/* Summary */}
             <div className="flex flex-wrap gap-3">
               <SummaryStat label="Resources" value={data!.total_resources} />


### PR DESCRIPTION
## Summary

Adds an **Infrastructure architecture diagram** to `/iac`. The Infrastructure surface (#4256) rendered the extracted IaC resource graph (Terraform/OpenTofu, AWS CDK, Pulumi, CloudFormation/SAM, Serverless Framework, Bicep) only as a flat, tool-grouped **list**. The underlying data is a real graph — resources with a cross-tool `resource_category`, a tool-native type, a source location, and resource-to-resource relation edges. This PR surfaces it as a cloud-architecture diagram.

A **List | Diagram** toggle sits next to the existing list (same `/iac` route). The diagram is built with **React Flow + dagre**, matching the `flow-dag` setup already in webui-v2.

### Diagram
- **Nodes** = IaC resources, colored + iconed by `resource_category` (compute / queue / datastore / network / function / secret / storage / other). Label = the resource name (e.g. `aws_sqs_queue.main`), tool-native kind as subtitle. Clicking a node opens the existing source peek at its `file:line`.
- **Edges** = `DEPENDS_ON` / `USES` relations, directional, styled by facet — grant (danger), event-source (warning), trigger (accent), topology (info, dotted), dependency (neutral, solid) — with a small mid-edge label on the semantic ones.
- **Module grouping** (the key ask): resources sharing a `module` are laid out as children of a React Flow group/parent node via a **compound dagre layout**, so a modularized stack reads as labelled boxes. **This works across modularized Terraform / CDK / etc. because archigraph flattens modules down to the resolved underlying resource graph** — grouping the flattened resources back by module reconstructs the stack structure.
- **Controls**: H/V layout toggle, zoom/fit + MiniMap (React Flow `Controls`), a category legend.
- **Unresolved targets** (#4495): a relation whose target couldn't be joined to a rendered node is **not drawn as a dead edge** — it surfaces as an "unlink" chip on the owning node plus a footer count, so the graph stays honest.
- **Empty state**: when no IaC is indexed the existing clean empty state shows; the diagram is never reachable with zero resources. Nothing is fabricated.

### Backend — was a graph endpoint needed?
No new endpoint. The existing `GET /api/iac/{group}` (`handleIaC`) already returns the full resource graph (resources + their relation edges), so the diagram is derived **client-side** from that payload. Two **minimal** additive fields were needed to make the edges graph-joinable and the nodes groupable, both reusing the existing IaC resolution:
- `IaCResource.module` — derived from the source-file directory (e.g. `infra/terraform/modules/network`); the diagram's grouping key.
- `IaCRelation.target_entity_id` — the **slug-prefixed** entity id of the other endpoint when it is itself a rendered resource. The list payload's `target_id` is unprefixed while `entity_id` is slug-prefixed, so the raw id alone could not be joined; this is the joinable key the diagram uses to draw an edge between two rendered nodes. Empty when the target isn't a rendered resource (→ counted as unresolved, not drawn).

Both fields are additive and `omitempty`, so the existing list view is unchanged.

### Gates
- Backend: `go build ./...` ✓, `go vet ./internal/dashboard/...` ✓, `go test ./internal/dashboard/` → `ok` (exit 0) ✓
- Frontend: `npm ci` ✓, `npm run build` (tsc -b + vite) ✓, `npm run lint` ✓ (clean), `tsc -b` ✓

Visual confirmation is deferred to the next dashboard deploy.

Closes #4526. Refs epic #3512 (IaC), #4493. Builds on #4256 (IaC list) and #4495 (resolved relation targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)