### PR TITLE
feat(topology): surface IaC-declared queues/topics as messaging channels (#4496)

### DIFF
--- a/internal/dashboard/topology_iac_declared_test.go
+++ b/internal/dashboard/topology_iac_declared_test.go
@@ -1,0 +1,68 @@
+package dashboard
+
+// topology_iac_declared_test.go — #4496. Verifies that the synthetic topology
+// channel entities applyIaCTopologyChannels appends for IaC-declared messaging
+// resources (SCOPE.Queue broker=sqs for an aws_sqs_queue, SCOPE.MessageTopic
+// broker=sns for an aws_sns_topic) render in the messaging Topology surface
+// even with NO detected code publisher/subscriber — fixing the live upvate-v3
+// "No async channels indexed" gap where the only queues were Terraform-declared.
+//
+// The entity shapes here mirror exactly what internal/engine/
+// applyIaCTopologyChannels emits for the real core-backend-v3
+// infra/terraform/modules/sqs-queue/main.tf (aws_sqs_queue.main + .dlq).
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestCollectTopology_IaCDeclaredQueuesSurface(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "core-backend-v3",
+		Entities: []graph.Entity{
+			// As emitted by applyIaCTopologyChannels for aws_sqs_queue.dlq + .main.
+			{ID: "iac-dlq", Name: "sqs:dlq", Kind: "SCOPE.Queue",
+				Properties: map[string]string{"broker": "sqs", "iac_declared": "true", "pattern_type": "iac_declared", "iac_tool": "terraform"}},
+			{ID: "iac-main", Name: "sqs:main", Kind: "SCOPE.Queue",
+				Properties: map[string]string{"broker": "sqs", "iac_declared": "true", "pattern_type": "iac_declared", "iac_tool": "terraform"}},
+			// An aws_sns_topic declaration → MessageTopic.
+			{ID: "iac-topic", Name: "sns:order-events", Kind: "SCOPE.MessageTopic",
+				Properties: map[string]string{"broker": "sns", "iac_declared": "true", "pattern_type": "iac_declared"}},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"core-backend-v3": {Slug: "core-backend-v3", Doc: doc}},
+	}
+
+	topics, queues, _, _ := collectTopology(grp)
+
+	// BEFORE this change: queues + topics were both empty → "No async channels".
+	// AFTER: the two SQS queues and the SNS topic appear as declared channels.
+	gotQueues := map[string]bool{}
+	for _, q := range queues {
+		gotQueues[q["label"].(string)] = true
+		if q["broker"] != "sqs" {
+			t.Errorf("queue %v broker = %v, want sqs", q["label"], q["broker"])
+		}
+	}
+	for _, want := range []string{"sqs:dlq", "sqs:main"} {
+		if !gotQueues[want] {
+			t.Errorf("IaC-declared queue %q missing from topology queues: %+v", want, queues)
+		}
+	}
+
+	foundTopic := false
+	for _, tp := range topics {
+		if tp["label"] == "sns:order-events" {
+			foundTopic = true
+			if tp["broker"] != "sns" {
+				t.Errorf("topic broker = %v, want sns", tp["broker"])
+			}
+		}
+	}
+	if !foundTopic {
+		t.Errorf("IaC-declared SNS topic missing from topology topics: %+v", topics)
+	}
+}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -636,6 +636,22 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	// Append-only — cannot regress the surrounding pipeline's bug-rate.
 	applyPass(applyIaCSNSEdges)
 
+	// IaC-declared messaging infrastructure → Topology channels (#4496,
+	// ref epic #4493). Scans already-extracted IaC resource entities (any of
+	// Terraform/HCL, CDK, Pulumi, CloudFormation, Bicep) whose cross-tool
+	// resource_category is a messaging primitive (queue/topic/stream) and
+	// APPENDS a synthetic SCOPE.Queue / SCOPE.MessageTopic channel keyed by the
+	// canonical broker+name. Covers AWS SQS/SNS/Kinesis/MSK/EventBridge, GCP
+	// Pub/Sub, and Azure Service Bus / Event Hubs / Event Grid uniformly. The
+	// synthetic channel reuses the code-side sqs:/sns: IDs so a declared queue
+	// collapses onto any code publisher/consumer of the same name (free
+	// code-join); brokers with no code-side convention appear as a
+	// declared-but-unwired channel — surfacing IaC queues in /topology even
+	// when no SDK publisher/subscriber was detected. Runs AFTER the code-side
+	// and iac_sns passes so it dedupes against the IDs they already emit.
+	// Append-only — cannot regress the surrounding pipeline's bug-rate.
+	applyPass(applyIaCTopologyChannels)
+
 	// Kubernetes cross-resource edge synthesis (#3517 / epic #3512). The yaml
 	// extractor already extracts K8s resources + sub-resources well but emits no
 	// edges BETWEEN resources. This pass re-reads the manifest (file-scoped) and

--- a/internal/engine/iac_topology_channels.go
+++ b/internal/engine/iac_topology_channels.go
@@ -1,0 +1,340 @@
+// IaC-declared messaging infrastructure → messaging Topology channels — #4496.
+//
+// Background
+//
+// The messaging Topology view (handlers_topology.go) only renders CODE-level
+// channels — entities a publish/subscribe library produced (Kafka, RabbitMQ,
+// SQS SDK calls, …). Infrastructure-as-Code declarations of the SAME messaging
+// primitives — an `aws_sqs_queue`, an `aws_sns_topic`, a GCP `pubsub.Topic`, an
+// Azure `servicebus/queues`, an MSK/Kafka cluster — are extracted by the IaC
+// extractors (Terraform/HCL, CDK, Pulumi, CloudFormation, Bicep) as generic
+// resource entities (SCOPE.Component / SCOPE.InfraResource / SCOPE.Queue) that
+// classifyTopologyBucket does NOT surface. The result: a repo whose only queues
+// are declared in Terraform shows "No async channels indexed" in /topology even
+// though the IaC view lists the queues. (#4496, ref epic #4493.)
+//
+// What this pass does
+//
+// For every already-extracted IaC resource entity whose cross-tool
+// `resource_category` is a messaging primitive (queue / topic / stream), it
+// APPENDS a synthetic Topology channel entity:
+//
+//   - category queue  → SCOPE.Queue        (broker derived from the resource type)
+//   - category topic  → SCOPE.MessageTopic (broker derived from the resource type)
+//   - category stream → SCOPE.Queue        (broker derived; Kinesis/MSK/EventHub)
+//
+// The synthetic entity is keyed by the canonical broker + queue/topic NAME, so
+// it COLLAPSES onto any code-level channel of the same name. For SQS/SNS this
+// reuses the exact `sqs:<name>` / `sns:<name>` IDs the SDK passes mint, so a
+// queue declared in Terraform and published-to by boto3 renders as ONE node
+// with the code publisher attached (the bonus code-join, for free). For brokers
+// without a code-side ID convention the synthetic entity simply appears as a
+// declared-but-unwired channel — which is exactly the desired "show the queue
+// even with no detected producer/consumer" behaviour.
+//
+// Generality
+//
+// The pass is tool-agnostic and cloud-agnostic: it reads the ONE shared
+// `resource_category` join key (types.IaCResourceCategory) and the resource
+// TYPE string, both of which every IaC extractor stamps. It therefore covers
+// AWS (SQS/SNS/Kinesis/MSK/EventBridge), GCP (Pub/Sub), and Azure (Service Bus
+// queues+topics, Event Hubs, Event Grid) uniformly, across Terraform, CDK,
+// Pulumi, CloudFormation, and Bicep — without a per-tool branch.
+//
+// Scope guard
+//
+// Append-only — never modifies or removes existing entities/edges, and dedupes
+// against itself AND against the IDs the code-side / iac_sns passes already
+// emit, so it can neither regress the pipeline's bug-rate nor double-count a
+// queue that another pass already surfaced.
+//
+// Refs #4496.
+package engine
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// applyIaCTopologyChannels is the entry point. It runs near the end of the
+// detector pass chain (after the code-side and iac_sns passes) so it can dedupe
+// against the channel IDs those passes already produced. Append-only.
+func applyIaCTopologyChannels(args DetectorPassArgs) DetectorPassResult {
+	entities := args.Entities
+	relationships := args.Relationships
+	if len(entities) == 0 {
+		return DetectorPassResult{Entities: entities, Relationships: relationships}
+	}
+
+	// Index the IDs of channel entities that already exist (code-side passes,
+	// iac_sns, or a prior file) so we never emit a duplicate node. The topology
+	// view dedupes topics by (broker, name) but queues by entity ID, so we must
+	// not re-emit a queue another pass already minted.
+	existing := map[string]bool{}
+	for i := range entities {
+		existing[entities[i].Kind+":"+entities[i].Name] = true
+	}
+
+	for i := range entities {
+		e := &entities[i]
+		if !isIaCResourceEntity(e) {
+			continue
+		}
+		resourceType := iacResourceTypeOf(e)
+		category := iacChannelCategory(e, resourceType)
+		broker := iacBrokerForResourceType(resourceType)
+		if broker == "" {
+			// Recognised as messaging by category but the type string didn't map
+			// to a known broker — skip rather than emit an "unknown" broker node.
+			continue
+		}
+
+		name := iacChannelName(e, resourceType)
+		if name == "" {
+			continue
+		}
+
+		var kind, id string
+		switch category {
+		case types.IaCCategoryTopic:
+			kind = messageTopicKind
+			id = iacChannelTopicID(broker, name)
+		case types.IaCCategoryQueue, types.IaCCategoryStream:
+			kind = queueEntityKind
+			id = iacChannelQueueID(broker, name)
+		default:
+			continue
+		}
+
+		if existing[kind+":"+id] {
+			continue
+		}
+		existing[kind+":"+id] = true
+
+		props := map[string]string{
+			"broker":        broker,
+			"pattern_type":  "iac_declared",
+			"iac_declared":  "true",
+			"resource_type": resourceType,
+		}
+		if iacTool := iacToolOf(e); iacTool != "" {
+			props["iac_tool"] = iacTool
+		}
+		if kind == messageTopicKind {
+			props["topic_name"] = name
+		} else {
+			props["queue_name"] = name
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:             id,
+			Kind:             kind,
+			Language:         e.Language,
+			SourceFile:       e.SourceFile,
+			StartLine:        e.StartLine,
+			Properties:       props,
+			EnrichmentStatus: types.StatusPending,
+			QualityScore:     0.8,
+		})
+	}
+
+	return DetectorPassResult{Entities: entities, Relationships: relationships}
+}
+
+// isIaCResourceEntity reports whether an entity is an IaC resource declaration
+// (from any of the supported tools) rather than application code.
+func isIaCResourceEntity(e *types.EntityRecord) bool {
+	switch e.Kind {
+	// CDK / Pulumi / Bicep.
+	case "SCOPE.InfraResource":
+		return true
+	// CloudFormation semantic kinds (derived from category) + Terraform/HCL
+	// resource blocks share SCOPE.Component / SCOPE.Queue / SCOPE.Datastore /
+	// SCOPE.ServerlessFunction. We only treat them as IaC when they carry an
+	// IaC fingerprint (resource_type / construct_type / iac_tool / subtype).
+	case "SCOPE.Component", "SCOPE.Queue", "SCOPE.Datastore", "SCOPE.ServerlessFunction":
+		if e.Subtype == "resource" {
+			return true
+		}
+		if iacResourceTypeOf(e) != "" {
+			return true
+		}
+		if iacToolOf(e) != "" {
+			return true
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// iacChannelCategory returns the cross-tool resource_category for an IaC
+// resource, preferring an explicit property/metadata stamp and falling back to
+// the shared classifier on the resource type (covers Terraform, whose category
+// lives in Metadata that does not survive to the read layer but IS present at
+// engine time).
+func iacChannelCategory(e *types.EntityRecord, resourceType string) string {
+	if c := strings.TrimSpace(e.Properties["resource_category"]); c != "" {
+		return c
+	}
+	if c := strings.TrimSpace(e.Properties["resource_scope"]); c != "" {
+		return c
+	}
+	if e.Metadata != nil {
+		if v, ok := e.Metadata["resource_category"].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	if resourceType != "" {
+		return types.IaCResourceCategory(resourceType)
+	}
+	return ""
+}
+
+// iacResourceTypeOf extracts the raw IaC resource/construct TYPE string from an
+// entity, regardless of which tool produced it:
+//
+//   - Terraform/HCL: stored in Metadata["resource_type"], and recoverable from
+//     the entity Name (`aws_sqs_queue.main` → `aws_sqs_queue`).
+//   - CDK/Pulumi:    Properties["construct_type"] (e.g. `sqs.Queue`,
+//     `aws.sns.Topic`).
+//   - CloudFormation/Bicep: Properties["resource_type"] (e.g.
+//     `AWS::SQS::Queue`, `Microsoft.ServiceBus/namespaces/queues`).
+func iacResourceTypeOf(e *types.EntityRecord) string {
+	if v := strings.TrimSpace(e.Properties["resource_type"]); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(e.Properties["construct_type"]); v != "" {
+		return v
+	}
+	if e.Metadata != nil {
+		for _, k := range []string{"resource_type", "construct_type"} {
+			if v, ok := e.Metadata[k].(string); ok && strings.TrimSpace(v) != "" {
+				return strings.TrimSpace(v)
+			}
+		}
+	}
+	// Terraform entity Name is `<type>.<label>`; the first dotted segment that
+	// looks like a resource type (contains an underscore or is a known prefix)
+	// is the type.
+	if e.Subtype == "resource" && strings.Contains(e.Name, ".") {
+		head := e.Name[:strings.Index(e.Name, ".")]
+		if head != "" {
+			return head
+		}
+	}
+	return ""
+}
+
+// iacToolOf returns the IaC tool tag if the entity carries one.
+func iacToolOf(e *types.EntityRecord) string {
+	if v := strings.TrimSpace(e.Properties["iac_tool"]); v != "" {
+		return v
+	}
+	if e.Metadata != nil {
+		if v, ok := e.Metadata["iac_tool"].(string); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// iacChannelName resolves the queue/topic NAME to key the channel by. It prefers
+// an explicit name property (the `name`/`queue_name`/`topic_name` literal a user
+// set on the resource), falling back to the resource's logical label so a queue
+// with no explicit `name=` still appears (keyed by its declaration label).
+func iacChannelName(e *types.EntityRecord, resourceType string) string {
+	for _, k := range []string{"name", "queue_name", "topic_name", "fifo_name"} {
+		if v := strings.TrimSpace(e.Properties[k]); v != "" {
+			return v
+		}
+	}
+	if e.Metadata != nil {
+		for _, k := range []string{"name", "label", "logical_id"} {
+			if v, ok := e.Metadata[k].(string); ok && strings.TrimSpace(v) != "" {
+				return strings.TrimSpace(v)
+			}
+		}
+	}
+	if v := strings.TrimSpace(e.Properties["logical_id"]); v != "" {
+		return v
+	}
+	// Terraform: Name is `<type>.<label>` → use the label tail.
+	if strings.Contains(e.Name, ".") {
+		tail := e.Name[strings.LastIndex(e.Name, ".")+1:]
+		if tail != "" {
+			return tail
+		}
+	}
+	if e.Name != "" {
+		return e.Name
+	}
+	return ""
+}
+
+// iacBrokerForResourceType maps an IaC resource TYPE string (any tool dialect)
+// to the canonical broker name used by the topology view. Returns "" when the
+// type is not a recognised messaging primitive. Substring + case-insensitive so
+// it tolerates every tool's spelling of the "same" resource.
+func iacBrokerForResourceType(resourceType string) string {
+	t := strings.ToLower(resourceType)
+	switch {
+	// --- AWS SNS (topic) ---
+	case iacContainsAny(t, "aws_sns_topic", "::sns::", "sns.topic", "sns_topic", ".sns.", "snstopic"):
+		return "sns"
+	// --- AWS SQS (queue) ---
+	case iacContainsAny(t, "aws_sqs_queue", "::sqs::", "sqs.queue", "sqs_queue", ".sqs.", "sqsqueue"):
+		return "sqs"
+	// --- AWS EventBridge (event bus) ---
+	case iacContainsAny(t, "::events::eventbus", "eventbus", "aws_cloudwatch_event_bus", "cloudwatchevents", "events.eventbus", "aws_scheduler"):
+		return "eventbridge"
+	// --- AWS Kinesis / MSK + Kafka (stream) ---
+	case iacContainsAny(t, "kinesis", "::msk::", "managedstreaming", "msk", "kafka"):
+		return "kafka"
+	// --- GCP Pub/Sub (topic) ---
+	case iacContainsAny(t, "google_pubsub_topic", "pubsub.topic", "google_pubsub_subscription", "pubsub.subscription", "google_cloud_tasks", "cloudtasks"):
+		return "pubsub"
+	// --- Azure Service Bus (queue + topic) ---
+	case iacContainsAny(t, "microsoft.servicebus/", "servicebus", "azurerm_servicebus", "storagequeue", "microsoft.storage/storageaccounts/queueservices"):
+		return "servicebus"
+	// --- Azure Event Hubs / Event Grid (stream / topic) ---
+	case iacContainsAny(t, "microsoft.eventhub/", "eventhub", "azurerm_eventhub"):
+		return "eventhub"
+	case iacContainsAny(t, "microsoft.eventgrid/", "eventgrid", "azurerm_eventgrid"):
+		return "eventgrid"
+	default:
+		return ""
+	}
+}
+
+// iacContainsAny reports whether s contains any of the given substrings. Local
+// variadic helper (the package-level containsAny takes a []string slice).
+func iacContainsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// iacChannelQueueID returns the canonical queue entity ID. SQS reuses the exact
+// `sqs:<name>` ID the code-side SQS pass mints so an IaC queue collapses onto
+// its code publisher/consumer. Other brokers get a `<broker>:<name>` ID.
+func iacChannelQueueID(broker, name string) string {
+	if broker == "sqs" {
+		return sqsQueueID(name)
+	}
+	return broker + ":" + name
+}
+
+// iacChannelTopicID returns the canonical topic entity ID. SNS reuses the exact
+// `sns:<name>` ID the code-side SNS pass mints so an IaC topic collapses onto
+// its code publisher/subscriber.
+func iacChannelTopicID(broker, name string) string {
+	if broker == "sns" {
+		return snsTopicID(name)
+	}
+	return broker + ":" + name
+}

--- a/internal/engine/iac_topology_channels_test.go
+++ b/internal/engine/iac_topology_channels_test.go
@@ -1,0 +1,209 @@
+package engine
+
+// In-pipeline validation for #4496 — IaC-declared SQS/SNS queues surface as
+// messaging Topology channels.
+//
+// The TestIaCTopologyChannels_RealTerraformSQSModule case runs a BYTE-COPY of
+// the real core-backend-v3 `infra/terraform/modules/sqs-queue/main.tf`
+// (aws_sqs_queue.main + .dlq) through the actual HCL extractor and then through
+// applyIaCTopologyChannels, asserting both queues emerge as SCOPE.Queue
+// broker=sqs channels. Before this pass, /topology reported "No async channels
+// indexed" for repos whose only queues are Terraform-declared.
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tshcl "github.com/smacker/go-tree-sitter/hcl"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/hcl" // register hcl/terraform
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// realCoreBackendSQSModule is a verbatim copy of
+// core-backend-v3/infra/terraform/modules/sqs-queue/main.tf.
+const realCoreBackendSQSModule = `locals {
+  queue_name = "${var.env}-${var.name}"
+  dlq_name   = "${var.env}-${var.name}-dlq"
+
+  common_tags = merge(
+    {
+      env     = var.env
+      module  = "sqs-queue"
+      managed = "terraform"
+    },
+    var.tags,
+  )
+}
+
+# Dead-letter queue — receives messages that exceed max_receive_count
+resource "aws_sqs_queue" "dlq" {
+  name                      = local.dlq_name
+  message_retention_seconds = var.dlq_message_retention_seconds
+
+  tags = merge(local.common_tags, { role = "dlq" })
+}
+
+# Main queue with redrive policy pointing at the DLQ
+resource "aws_sqs_queue" "main" {
+  name                       = local.queue_name
+  visibility_timeout_seconds = var.visibility_timeout_seconds
+  message_retention_seconds  = var.message_retention_seconds
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dlq.arn
+    maxReceiveCount     = var.max_receive_count
+  })
+
+  tags = merge(local.common_tags, { role = "main" })
+}
+`
+
+// extractHCLEntities runs the real HCL extractor over src and returns the
+// extracted entity records (the input applyIaCTopologyChannels sees in-pipeline).
+func extractHCLEntities(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	content := []byte(src)
+	p := sitter.NewParser()
+	p.SetLanguage(tshcl.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, content)
+	if err != nil {
+		t.Fatalf("hcl parse failed: %v", err)
+	}
+	ext, ok := extractor.Get("hcl")
+	if !ok {
+		t.Fatalf("hcl extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: content, Language: "hcl", Tree: tree,
+	})
+	if err != nil {
+		t.Fatalf("hcl extract failed: %v", err)
+	}
+	return recs
+}
+
+func sqsChannel(ents []types.EntityRecord, id string) *types.EntityRecord {
+	want := queueEntityKind
+	for i := range ents {
+		if ents[i].Kind == want && ents[i].Name == id {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestIaCTopologyChannels_RealTerraformSQSModule(t *testing.T) {
+	path := "infra/terraform/modules/sqs-queue/main.tf"
+	extracted := extractHCLEntities(t, realCoreBackendSQSModule, path)
+
+	// Sanity: before the pass, NO topology channel (SCOPE.Queue) exists — the
+	// extractor only emits SCOPE.Component resources. This is the bug.
+	for i := range extracted {
+		if extracted[i].Kind == queueEntityKind || extracted[i].Kind == messageTopicKind {
+			t.Fatalf("pre-pass: unexpected topology channel %q already present", extracted[i].Name)
+		}
+	}
+
+	res := applyIaCTopologyChannels(DetectorPassArgs{
+		Lang:     "hcl",
+		Path:     path,
+		Entities: extracted,
+	})
+
+	// The two aws_sqs_queue resources (.dlq + .main) must now appear as
+	// SCOPE.Queue channels keyed by their declaration labels.
+	dlq := sqsChannel(res.Entities, sqsQueueID("dlq"))
+	main := sqsChannel(res.Entities, sqsQueueID("main"))
+	if dlq == nil {
+		t.Fatalf("aws_sqs_queue.dlq did not surface as a SCOPE.Queue channel; entities=%v", channelNames(res.Entities))
+	}
+	if main == nil {
+		t.Fatalf("aws_sqs_queue.main did not surface as a SCOPE.Queue channel; entities=%v", channelNames(res.Entities))
+	}
+	for _, q := range []*types.EntityRecord{dlq, main} {
+		if q.Properties["broker"] != "sqs" {
+			t.Errorf("%s broker = %q, want sqs", q.Name, q.Properties["broker"])
+		}
+		if q.Properties["iac_declared"] != "true" {
+			t.Errorf("%s missing iac_declared=true", q.Name)
+		}
+	}
+}
+
+func channelNames(ents []types.EntityRecord) []string {
+	var out []string
+	for i := range ents {
+		if ents[i].Kind == queueEntityKind || ents[i].Kind == messageTopicKind {
+			out = append(out, ents[i].Kind+":"+ents[i].Name)
+		}
+	}
+	return out
+}
+
+// TestIaCTopologyChannels_CrossCloud asserts the pass is cloud/tool-agnostic by
+// feeding synthetic IaC resource entities shaped like each tool's output for
+// AWS SNS, GCP Pub/Sub, and Azure Service Bus, then checking each yields a
+// channel on the right broker.
+func TestIaCTopologyChannels_CrossCloud(t *testing.T) {
+	ents := []types.EntityRecord{
+		// Terraform aws_sns_topic (category in Metadata, name from label).
+		{Name: "aws_sns_topic.events", Kind: "SCOPE.Component", Subtype: "resource", Language: "hcl",
+			Metadata: map[string]interface{}{"resource_type": "aws_sns_topic", "resource_category": types.IaCCategoryTopic}},
+		// CDK GCP not applicable; use Terraform google_pubsub_topic.
+		{Name: "google_pubsub_topic.jobs", Kind: "SCOPE.Component", Subtype: "resource", Language: "hcl",
+			Metadata: map[string]interface{}{"resource_type": "google_pubsub_topic", "resource_category": types.IaCCategoryTopic}},
+		// Pulumi-style Azure Service Bus queue (props carry construct_type + category).
+		{Name: "OrdersQueue", Kind: "SCOPE.InfraResource", Language: "typescript",
+			Properties: map[string]string{"construct_type": "azure.servicebus.Queue", "resource_category": types.IaCCategoryQueue, "iac_tool": "pulumi", "name": "orders"}},
+		// CloudFormation Kinesis stream (semantic Kind + props).
+		{Name: "EventStream", Kind: "SCOPE.Queue", Language: "yaml",
+			Properties: map[string]string{"resource_type": "AWS::Kinesis::Stream", "resource_category": types.IaCCategoryStream, "iac_tool": "cloudformation"}},
+	}
+
+	res := applyIaCTopologyChannels(DetectorPassArgs{Lang: "hcl", Entities: ents})
+
+	wantBrokers := map[string]string{
+		"sns:events":          "sns",
+		"pubsub:jobs":         "pubsub",
+		"servicebus:orders":   "servicebus",
+		"kafka:EventStream":   "kafka",
+	}
+	got := map[string]string{}
+	for i := range res.Entities {
+		e := &res.Entities[i]
+		if e.Properties["iac_declared"] == "true" {
+			got[e.Name] = e.Properties["broker"]
+		}
+	}
+	for id, broker := range wantBrokers {
+		if got[id] != broker {
+			t.Errorf("channel %q broker = %q, want %q (got map=%v)", id, got[id], broker, got)
+		}
+	}
+}
+
+// TestIaCTopologyChannels_DedupesCodeSide verifies the pass does not double-emit
+// a queue the code-side SQS pass already minted (same sqs:<name> ID).
+func TestIaCTopologyChannels_DedupesCodeSide(t *testing.T) {
+	ents := []types.EntityRecord{
+		// Pre-existing code-side queue.
+		{Name: sqsQueueID("orders"), Kind: queueEntityKind, Properties: map[string]string{"broker": "sqs"}},
+		// IaC declaration of the SAME queue.
+		{Name: "aws_sqs_queue.orders", Kind: "SCOPE.Component", Subtype: "resource",
+			Metadata: map[string]interface{}{"resource_type": "aws_sqs_queue", "resource_category": types.IaCCategoryQueue, "label": "orders"},
+			Properties: map[string]string{"name": "orders"}},
+	}
+	res := applyIaCTopologyChannels(DetectorPassArgs{Lang: "hcl", Entities: ents})
+	n := 0
+	for i := range res.Entities {
+		if res.Entities[i].Kind == queueEntityKind && res.Entities[i].Name == sqsQueueID("orders") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("queue sqs:orders emitted %d times, want 1 (dedup against code-side failed)", n)
+	}
+}


### PR DESCRIPTION
## Problem

The messaging Topology view (`/topology`) only rendered code-level channels. IaC-declared messaging primitives (`aws_sqs_queue`, `aws_sns_topic`, GCP `pubsub.Topic`, Azure Service Bus queue) were extracted as generic resource entities (`SCOPE.Component`/`SCOPE.InfraResource`) that `classifyTopologyBucket` ignored. Live on upvate-v3 the IaC view listed `aws_sqs_queue.dlq` + `.main`, but `/topology` said "No async channels indexed."

## Fix

New tool/cloud-agnostic engine pass `applyIaCTopologyChannels` (registered after `applyIaCSNSEdges`). Scans already-extracted IaC resources for the shared `resource_category` join key (queue/topic/stream) and appends a synthetic `SCOPE.Queue` / `SCOPE.MessageTopic` channel keyed by canonical broker+name. Covers AWS SQS/SNS/Kinesis/MSK/EventBridge, GCP Pub/Sub, Azure Service Bus/Event Hubs/Event Grid across Terraform, CDK, Pulumi, CloudFormation, Bicep (no per-tool branch). SQS/SNS reuse code-side `sqs:`/`sns:` IDs so declared queues collapse onto code publishers/consumers (free code-join); other brokers show as declared-but-unwired. Append-only, dedupes against code-side and iac_sns IDs.

## Validation (in-pipeline)

`TestIaCTopologyChannels_RealTerraformSQSModule` runs a byte-copy of the real core-backend-v3 `infra/terraform/modules/sqs-queue/main.tf` through the HCL extractor then the pass: before, zero channels; after, both queues surface as `SCOPE.Queue broker=sqs`. Plus cross-cloud, dedup, and dashboard `collectTopology` tests.

## Gates
build OK, vet OK, `go test ./internal/engine ./internal/dashboard ./internal/types` OK. Deploy-deferred (needs reindex).

Closes #4496

🤖 Generated with [Claude Code](https://claude.com/claude-code)
