### PR TITLE
fix(jest): link contract/oracle specs to endpoints via describe/it route labels (#4487)

### DIFF
--- a/internal/custom/javascript/jest.go
+++ b/internal/custom/javascript/jest.go
@@ -40,6 +40,25 @@ var (
 		`jest\s*\.\s*(mock|spyOn|fn|useFakeTimers|useRealTimers|resetAllMocks|clearAllMocks)\s*\(`,
 	)
 
+	// reLabelRouteMention captures a `VERB /route` pair embedded in a free-text
+	// describe()/it() label (issue #4487). Contract / oracle specs overwhelmingly
+	// name the endpoint they cover in their label rather than driving it through
+	// supertest, e.g.
+	//
+	//	describe('contract: clients list — GET /api/v1/clients', () => { … })
+	//	it('GET /elv3 returns 401 when unauthenticated', () => { … })
+	//
+	// The verb is a standalone HTTP method token (word-bounded so "POSTING" or a
+	// "get" property accessor never matches) immediately followed by a
+	// `/`-rooted path. The path runs to the first whitespace or label-closing
+	// quote/backtick; trailing punctuation is trimmed by the caller. Only the
+	// route ARGUMENT is interpreted here — endpoint resolution stays in the
+	// resolve pass (linkE2ERouteTestsToEndpoints), so the linkage reuses the same
+	// path normalization as supertest routes and is merge-stable.
+	reLabelRouteMention = regexp.MustCompile(
+		`\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(/[^\s'` + "`" + `"]*)`,
+	)
+
 	// ── TESTS-target resolution signals (issue #4343) ───────────────────────
 	// Named imports: `import { A, B as C } from './x'`. We record the local
 	// name (A, and the alias C) so a describe('A') / new A() inside the spec
@@ -152,6 +171,12 @@ func (e *jestExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]t
 
 	// ── collect supertest e2e route calls (issue #4351) ──────────────────────
 	routeCalls := extractSupertestRouteCalls(src)
+
+	// ── collect routes named in describe()/it() labels (issue #4487) ─────────
+	// Contract/oracle specs name the endpoint in the suite/case label rather
+	// than driving it via supertest; fold those `VERB /route` mentions into the
+	// same e2e_route_calls bucket so the resolve pass links them to endpoints.
+	routeCalls = mergeRouteCalls(routeCalls, extractLabelRouteCalls(src))
 
 	// Per-spec aggregate counts folded onto the suite(s).
 	caseCount := len(tests)
@@ -394,6 +419,82 @@ func extractSupertestRouteCalls(src string) []string {
 		out = append(out, key)
 	}
 	return out
+}
+
+// extractLabelRouteCalls returns the de-duplicated set of "VERB route" pairs
+// named in describe()/it() labels, e.g. a label
+// `'contract: clients list — GET /api/v1/clients'` yields
+// `"GET /api/v1/clients"` (issue #4487).
+//
+// Many contract/oracle/spec suites assert wire-shape or mapper behaviour in
+// pure logic and never issue a real HTTP call, but they DO encode the endpoint
+// under test in their label by convention. Surfacing those routes lets the
+// shared resolve pass (linkE2ERouteTestsToEndpoints) attach a TESTS edge from
+// the suite to the http_endpoint_definition, so the endpoint no longer looks
+// untested. The route string is emitted verbatim (after trimming trailing
+// punctuation) and normalized exactly like a supertest route at resolve time,
+// so template params (`:id`, `{id}`) and the `/api/vN` mount prefix are handled
+// uniformly. No edge is emitted here.
+func extractLabelRouteCalls(src string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	collect := func(matches [][]int) {
+		for _, m := range matches {
+			// Group 1 is the quoted label (from reJestDescribe/reJestTest).
+			label := src[m[2]:m[3]]
+			for _, rm := range reLabelRouteMention.FindAllStringSubmatch(label, -1) {
+				verb := strings.ToUpper(rm[1])
+				route := trimLabelRoute(rm[2])
+				if route == "" {
+					continue
+				}
+				key := verb + " " + route
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				out = append(out, key)
+			}
+		}
+	}
+	collect(reJestDescribe.FindAllStringSubmatchIndex(src, -1))
+	collect(reJestTest.FindAllStringSubmatchIndex(src, -1))
+	return out
+}
+
+// trimLabelRoute strips trailing prose punctuation a free-text label commonly
+// appends after the route (a comma, period, paren, colon, em-dash, or a
+// trailing slash) so `/api/v1/clients,` and `/api/v1/clients` fold together.
+// The path itself never legitimately ends in these characters.
+func trimLabelRoute(route string) string {
+	route = strings.TrimRight(route, ".,;:)]}—-")
+	// Drop a trailing slash (but keep the bare root "/").
+	if len(route) > 1 {
+		route = strings.TrimRight(route, "/")
+	}
+	if route == "" || route[0] != '/' {
+		return ""
+	}
+	return route
+}
+
+// mergeRouteCalls appends every "VERB route" entry from extra that is not
+// already present in base, preserving order and de-duplicating.
+func mergeRouteCalls(base, extra []string) []string {
+	if len(extra) == 0 {
+		return base
+	}
+	seen := make(map[string]bool, len(base))
+	for _, v := range base {
+		seen[v] = true
+	}
+	for _, v := range extra {
+		if !seen[v] {
+			seen[v] = true
+			base = append(base, v)
+		}
+	}
+	return base
 }
 
 // collectRouteConsts folds `const NAME = '/literal'` declarations into a

--- a/internal/custom/javascript/jest_label_routes_4487_test.go
+++ b/internal/custom/javascript/jest_label_routes_4487_test.go
@@ -1,0 +1,142 @@
+package javascript_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4487 — contract/oracle specs name the endpoint under test in their
+// describe()/it() label (`… — GET /api/v1/inspections/:id/…`) rather than
+// driving it through supertest. The Jest extractor must surface those
+// label-named routes on the suite's `e2e_route_calls` property so the shared
+// resolve pass links the suite to the http_endpoint_definition. Without this
+// the endpoints show Tests (0) even though a covering contract spec exists.
+
+// e2eRouteCalls returns the e2e_route_calls property of the single test_suite
+// the Jest extractor emits for src, or "" if none.
+func e2eRouteCalls(t *testing.T, path, src string) string {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_jest")
+	if !ok {
+		t.Fatal("jest extractor not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: "typescript", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	for _, ent := range ents {
+		if ent.Subtype == "test_suite" || ent.Kind == "test_suite" {
+			if ent.Properties != nil {
+				return ent.Properties["e2e_route_calls"]
+			}
+		}
+	}
+	return ""
+}
+
+// realCounterPartyContractSpec is a BYTE-COPY of the head of the live
+// core-backend-v3 contract spec
+// test/contract/inspections/inspection-counter-party-results.contract.spec.ts.
+// It issues NO supertest call — the endpoint is named only in the describe
+// label — which is exactly the shape that left endpoints showing Tests (0).
+const realCounterPartyContractSpec = `import { assertSemanticPathParams } from '../request-contract';
+import {
+  mapInspectionCounterPartyResults,
+  type CounterPartyResultsRaw,
+} from '../../../src/modules/inspections/mappers/inspection-counter-party-results.mapper';
+
+const COUNTER_PARTY_RESULTS_PATH = '/api/v1/inspections/:inspectionId/counter-party-results';
+
+describe('contract: inspections counter-party-results — GET /api/v1/inspections/:id/counter-party-results', () => {
+  it('path uses semantic :inspectionId param — not :pk or bare :id', () => {
+    expect(COUNTER_PARTY_RESULTS_PATH).toMatch(/:inspectionId/);
+  });
+  it('success status is 200', () => {
+    expect(200).toBe(200);
+  });
+  it('404 when inspection not found — verified in service via NotFoundException', () => {
+    expect(true).toBe(true);
+  });
+});
+`
+
+// TestIssue4487_LabelRouteSurfacedFromRealContractSpec is the core RED→GREEN
+// proof at the extractor boundary: the byte-copied contract spec yields the
+// label-named route on e2e_route_calls even though it never calls supertest.
+func TestIssue4487_LabelRouteSurfacedFromRealContractSpec(t *testing.T) {
+	got := e2eRouteCalls(t, "test/contract/inspections/inspection-counter-party-results.contract.spec.ts", realCounterPartyContractSpec)
+	if got == "" {
+		t.Fatal("BEFORE→AFTER: e2e_route_calls is empty; contract spec route not surfaced from describe label")
+	}
+	want := "GET /api/v1/inspections/:id/counter-party-results"
+	if !strings.Contains(got, want) {
+		t.Fatalf("e2e_route_calls = %q, want it to contain %q", got, want)
+	}
+}
+
+// TestIssue4487_LabelRoutesInDescribeAndIt covers both label positions and the
+// common formats (em-dash separator in a describe, leading verb in an it) and
+// asserts de-duplication of identical routes.
+func TestIssue4487_LabelRoutesInDescribeAndIt(t *testing.T) {
+	src := `describe('contract: clients list — GET /api/v1/clients', () => {
+  it('GET /api/v1/clients returns 200 when authorized', () => { expect(1).toBe(1); });
+  it('POST /api/v1/clients/:clientId/create_contact creates a contact', () => { expect(1).toBe(1); });
+});`
+	got := e2eRouteCalls(t, "test/contract/clients/client-list.contract.spec.ts", src)
+	lines := splitNonEmpty(got)
+	wantSet := map[string]bool{
+		"GET /api/v1/clients":                              false,
+		"POST /api/v1/clients/:clientId/create_contact":    false,
+	}
+	for _, ln := range lines {
+		if _, ok := wantSet[ln]; ok {
+			wantSet[ln] = true
+		}
+	}
+	for w, seen := range wantSet {
+		if !seen {
+			t.Errorf("missing label route %q; got=%v", w, lines)
+		}
+	}
+	// "GET /api/v1/clients" appears in BOTH the describe and an it label; it must
+	// be emitted exactly once.
+	n := 0
+	for _, ln := range lines {
+		if ln == "GET /api/v1/clients" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected de-duplicated single 'GET /api/v1/clients', got %d", n)
+	}
+}
+
+// TestIssue4487_NoFalseRouteFromProse proves a label that mentions a verb word
+// without a `/`-rooted path produces no spurious route.
+func TestIssue4487_NoFalseRouteFromProse(t *testing.T) {
+	src := `describe('mapper: getInspection transforms wire fields', () => {
+  it('POST body is not relevant here', () => { expect(1).toBe(1); });
+});`
+	got := e2eRouteCalls(t, "x.spec.ts", src)
+	if strings.TrimSpace(got) != "" {
+		t.Fatalf("expected no label routes from prose, got %q", got)
+	}
+}
+
+func splitNonEmpty(s string) []string {
+	var out []string
+	for _, ln := range strings.Split(s, "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln != "" {
+			out = append(out, ln)
+		}
+	}
+	return out
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4487_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4487_test.go
@@ -1,0 +1,56 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4487 — contract specs name the endpoint in their describe/it label and
+// the Jest extractor (after this fix) folds that into `e2e_route_calls`. This
+// engine test proves the EXISTING resolve pass links such a label-derived route
+// to the synthesized NestJS endpoint, so the endpoint's Tests panel is no longer
+// (0). The controller route is the real
+// `@Get(':inspectionId/counter-party-results')` under
+// `@Controller({ path: 'inspections', version: '1' })`, synthesized with the
+// `/api/v1` mount prefix and a `{inspectionId}` template param; the spec label
+// says `:id`. The segment matcher must wildcard BOTH param notations.
+func TestIssue4487_LabelRouteLinksToEndpoint(t *testing.T) {
+	defs := []types.EntityRecord{
+		// Real inspection.controller.ts routes (verb + synthesized path).
+		def("GET", "/api/v1/inspections/{inspectionId}/counter-party-results"),
+		def("GET", "/api/v1/inspections/{inspectionGroupId}"),
+		def("POST", "/api/v1/inspections/notes"),
+		// Unrelated endpoint that must NOT be linked.
+		def("GET", "/api/v1/buildings/{id}"),
+	}
+
+	// Route as the Jest extractor now stamps it from the describe label
+	// `… — GET /api/v1/inspections/:id/counter-party-results`.
+	suite := e2eSuite("GET /api/v1/inspections/:id/counter-party-results")
+
+	out, stats := ResolveHTTPEndpointHandlers(append(append([]types.EntityRecord{}, defs...), suite))
+	edges := testsEdgesToEndpoints(out)
+	if stats.E2ERouteTestEdges != 1 {
+		t.Fatalf("expected 1 label-route TESTS edge, got %d (edges=%v)", stats.E2ERouteTestEdges, edges)
+	}
+	want := "http_endpoint_definition:http:GET:/api/v1/inspections/{inspectionId}/counter-party-results"
+	if edges[0].ToID != want {
+		t.Fatalf("TESTS edge target = %q, want %q", edges[0].ToID, want)
+	}
+}
+
+// TestIssue4487_ControlNoLabelRouteNoEdge is the BEFORE control: with no
+// e2e_route_calls (the pre-fix extractor output for a label-only contract spec)
+// the endpoint gains no TESTS edge — reproducing the reported Tests (0).
+func TestIssue4487_ControlNoLabelRouteNoEdge(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/inspections/{inspectionId}/counter-party-results"),
+	}
+	control := e2eSuite("")
+	control.Properties = map[string]string{"framework": "jest"} // no e2e_route_calls
+	_, stats := ResolveHTTPEndpointHandlers(append(defs, control))
+	if stats.E2ERouteTestEdges != 0 {
+		t.Fatalf("control must emit 0 TESTS edges, got %d", stats.E2ERouteTestEdges)
+	}
+}


### PR DESCRIPTION
## Problem
Live on upvate-v3, endpoints showed **Tests (0)** even though core-backend-v3 has many contract/e2e specs. Entity-level coverage worked (1079 tests) but the per-endpoint Tests panel reads TESTS edges to the `http_endpoint_definition` and found none.

## Root cause
The #4351 e2e linkage only mined supertest `request(...).<verb>(route)` calls. Of 282 contract specs in core-backend-v3 only 5 use supertest. The rest assert wire-shape/mapper behaviour in pure logic and name the endpoint under test **only in their `describe()`/`it()` label**, e.g. `describe('contract: ... — GET /api/v1/inspections/:id/counter-party-results', ...)`. With no supertest call the suite linked at best to its mapper subject, never to the endpoint definition the Paths Tests panel reads. 302 describe blocks across `test/contract/` carry a `VERB /route` label.

## Fix
The Jest extractor (`internal/custom/javascript/jest.go`) now also mines `VERB /route` mentions from describe()/it() labels and folds them into the same `e2e_route_calls` property the existing resolve pass (`engine.linkE2ERouteTestsToEndpoints`) consumes. Endpoint resolution, normalization (`/api/vN` prefix tolerance, `:id`/`{id}` wildcards) and conservatism (unique-match-only, no fabricated edges) are unchanged and reused, so the linkage stays merge-stable. The dashboard side already collected TESTS edges to both the definition and its handler, so no panel change was needed. Label-route mining is verb/format-agnostic and de-duplicates against supertest routes.

## In-pipeline validation (before/after)
Byte-copy of the live inspection-counter-party-results.contract.spec.ts (label-only, no supertest) + the real inspection.controller.ts route. Before: e2e_route_calls empty, 0 TESTS edges. After: label route surfaced, resolve pass emits a TESTS edge to http_endpoint_definition GET /api/v1/inspections/{inspectionId}/counter-party-results. Tests: jest_label_routes_4487_test.go, http_endpoint_e2e_testmap_4487_test.go. Surfacing live needs a reindex (DEPLOY-DEFERRED).

## Gates
go build ./..., go vet, go test ./internal/custom/javascript/ ./internal/engine/ ./internal/types/ ./internal/dashboard/ all green. #4351/#4369/#4370/#4371 regression suites still pass.

Closes #4487

🤖 Generated with [Claude Code](https://claude.com/claude-code)
