### PR TITLE
fix(effects): scope include=branches to the method's own body

### DIFF
--- a/internal/mcp/effects_branches_4488_test.go
+++ b/internal/mcp/effects_branches_4488_test.go
@@ -1,0 +1,112 @@
+package mcp
+
+// effects_branches_4488_test.go — method-boundary scoping regression test for
+// the #4423 `branches` facet (#4488, epic #4419).
+//
+// Wave-2 downstream feedback (mcp-wave2-test-feedback §3) reported that
+// effects(create_contact, include=branches) OVER-CAPTURED: the branch list bled
+// into the adjacent `@action` methods (update_contact and beyond), because the
+// entity's EndLine was missing/zero and branchSourceSpan padded a generous tail
+// window that overshot into sibling defs — and the analyzer walked the whole
+// padded window rather than the single method's own body.
+//
+// This test pins the fix: it uses a byte-copy of the REAL ContractViewSet
+// region (create_contact immediately followed by update_contact, copied
+// verbatim into testdata/branches_4488/) and asserts that
+// effects(create_contact, include=branches) returns ONLY create_contact's own
+// branches (400/409/200/201/500) and NONE of update_contact's distinct branches
+// (the 404 `User.DoesNotExist` handler, update_contact's own 409 conflict on
+// `conflict_user is not None`). The entity is given StartLine with NO EndLine to
+// reproduce the exact degenerate-span condition that triggered the bug.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// branchScopeTestServer builds a server whose repo Path points at the
+// branches_4488 testdata dir. The create_contact entity deliberately has NO
+// EndLine (EndLine: 0) so the source window is padded — exactly the condition
+// that produced the over-capture in the field.
+func branchScopeTestServer(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_contact", Name: "ContractViewSet.create_contact",
+				Kind:          "SCOPE.Operation",
+				QualifiedName: "core.views.contract_viewset.ContractViewSet.create_contact",
+				// StartLine is the @action decorator line (fixture line 1); the
+				// `def` is the next line. EndLine omitted (0) → degenerate span →
+				// padded window → would overshoot into update_contact pre-fix.
+				SourceFile: "contract_viewset_two_methods.py", StartLine: 1, EndLine: 0,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4488"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["upvate-core"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+// TestEffectsBranches_MethodScope is the #4488 regression: create_contact's
+// branch list must contain ONLY its own branches and must NOT bleed into the
+// adjacent update_contact method.
+func TestEffectsBranches_MethodScope(t *testing.T) {
+	srv := branchScopeTestServer(t)
+	out := callEffects(t, srv, "ContractViewSet.create_contact", "branches")
+
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for python; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+
+	// --- create_contact's OWN branches are present ---
+	if b := findBranch(branches, "client is None"); b == nil {
+		t.Fatalf("missing create_contact's 400 `client is None` guard: %v", branches)
+	} else {
+		assertStatus(t, b, "400")
+	}
+	if b := findBranch(branches, "available"); b == nil {
+		t.Fatalf("missing create_contact's 409 availability guard: %v", branches)
+	} else {
+		assertStatus(t, b, "409")
+	}
+
+	// --- update_contact's DISTINCT branches must NOT appear (the over-capture) ---
+	// The 404 handler `except User.DoesNotExist` belongs solely to
+	// update_contact. Its presence is the canonical over-capture signal.
+	for _, b := range branches {
+		cond, _ := b["condition"].(string)
+		if cond == "except User.DoesNotExist" {
+			t.Errorf("over-capture: create_contact branch list bled into update_contact's 404 handler (%q)", cond)
+		}
+		if cond == "if conflict_user is not None" {
+			t.Errorf("over-capture: create_contact branch list bled into update_contact's conflict guard (%q)", cond)
+		}
+	}
+
+	// No branch may be reported below update_contact's `def` (fixture line 73).
+	// The padded window covers all 145 lines; a correct scope stops before line
+	// 72 (the @action decorator preceding update_contact).
+	for _, b := range branches {
+		if line := toInt(b["line"]); line >= 72 {
+			t.Errorf("over-capture: branch at line %d is inside/after the sibling update_contact method (cond=%v)", line, b["condition"])
+		}
+	}
+
+	// create_contact has exactly its 400, 409, 200, 500 control-altering
+	// branches (the 201 is a fall-through bare return — not a branch). All
+	// reported lines must be within the method body (< 72).
+	if len(branches) == 0 {
+		t.Fatalf("expected create_contact's own branches, got none")
+	}
+}

--- a/internal/mcp/testdata/branches_4488/contract_viewset_two_methods.py
+++ b/internal/mcp/testdata/branches_4488/contract_viewset_two_methods.py
@@ -1,0 +1,145 @@
+    @action(methods=["post"], detail=True, serializer_class=ContractContactCreateSerializer)
+    def create_contact(self, request, pk, *args, **kwargs):
+        try:
+            contract = self.get_object()
+            client = contract.client
+            if client is None:
+                return Response(
+                    {
+                        "success": False,
+                        "message": "Contract has no client to attach the contact to.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            serializer = ContractContactCreateSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            data = serializer.validated_data
+
+            upsert_flag = data.get("upsert") or str(
+                request.query_params.get("upsert", "false")
+            ).lower() == "true"
+
+            email = data["email"]
+            email_availability = check_contact_email_availability({"email": email})
+
+            if email_availability["available"] is False and not upsert_flag:
+                existing = User.objects.filter(email__iexact=email).first()
+                return Response(
+                    {
+                        "error": "User with this email/username already exists.",
+                        "existing_user": UserSerializer(existing).data if existing else None,
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            if email_availability["available"] is False:
+                user = User.objects.filter(email__iexact=email).first()
+                if user is not None:
+                    attach_client_to_contact(user, client)
+                    attach_contract_to_contact(user, contract)
+                    return Response(
+                        {
+                            "success": True,
+                            "message": "Existing contact linked to contract",
+                            "contact": user.id,
+                        },
+                        status=status.HTTP_200_OK,
+                    )
+
+            # Create new user, attach to client (M2M + legacy FK), then to contract
+            user = create_contact_for_client(data, client)
+            attach_contract_to_contact(user, contract)
+            return Response(
+                {
+                    "success": True,
+                    "message": "Contact has been created and linked to contract",
+                    "contact": user.id,
+                },
+                status=status.HTTP_201_CREATED,
+            )
+        except Exception as e:
+            return Response(
+                {
+                    "success": False,
+                    "message": "There was an error while creating the contact.",
+                    "errors": str(e),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+
+    @action(methods=["patch"], detail=True, serializer_class=ContractContactUpdateSerializer)
+    def update_contact(self, request, pk, *args, **kwargs):
+        try:
+            contract = self.get_object()
+            client = contract.client
+
+            serializer = ContractContactUpdateSerializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            data = serializer.validated_data
+
+            try:
+                original_user = User.objects.get(pk=data["id"])
+            except User.DoesNotExist:
+                return Response(
+                    {"error": "User not found"},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+            upsert_flag = data.get("upsert") or str(
+                request.query_params.get("upsert", "false")
+            ).lower() == "true"
+
+            # Detect email collisions with other users; upsert re-targets the update.
+            user, conflict_user = resolve_contact_email_conflict(
+                original_user, data.get("email"), upsert_flag
+            )
+            if conflict_user is not None:
+                return Response(
+                    {
+                        "error": "User with this email/username already exists.",
+                        "existing_user": UserSerializer(conflict_user).data,
+                    },
+                    status=status.HTTP_409_CONFLICT,
+                )
+
+            # Upsert special case: when the resolved user is a different existing
+            # contact, move them onto this contract (and its client) and unassign
+            # the original user from this contract/client since the resolved one
+            # replaces them here.
+            if user.pk != original_user.pk:
+                UserContract.objects.filter(user=original_user, contract=contract).delete()
+                if client is not None:
+                    original_user.clients.remove(client)
+                    if original_user.client_id == client.id:
+                        original_user.client_id = None
+                        original_user.save(update_fields=["client_id"])
+                    attach_client_to_contact(user, client)
+                attach_contract_to_contact(user, contract)
+
+            # Partial update: only fields present in `data` are written
+            update_base_contact(user, data)
+
+            # Keep legacy FK in sync with the contract's client and ensure group/role/M2M linkage
+            if client is not None and user.client_id != client.id:
+                user.client_id = client.id
+                user.save(update_fields=["client_id"])
+            ensure_client_contact_membership(user, client)
+
+            # Ensure the user is linked to this contract (active UserContract)
+            ensure_contract_contact_membership(user, contract)
+
+            return Response(
+                {"success": True, "message": "Contact has been updated", "contact": user.id},
+                status=status.HTTP_200_OK,
+            )
+        except Exception as e:
+            return Response(
+                {
+                    "success": False,
+                    "message": "An error occurred while updating the contact",
+                    "errors": str(e),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/internal/substrate/branches.go
+++ b/internal/substrate/branches.go
@@ -191,12 +191,23 @@ func analyzeBranchesPython(funcSource string, startLine int) []BranchFacet {
 		return nil
 	}
 	lines := strings.Split(funcSource, "\n")
+	// Scope the walk to the method's OWN body. The source window the effects
+	// tool hands us starts at the entity's StartLine (the `def` header) but its
+	// EndLine can be missing/zero — in which case branchSourceSpan pads a
+	// generous tail that overshoots into the SIBLING methods/defs that follow
+	// (the #4419/#4488 over-capture: create_contact's branch list bled into
+	// update_contact and beyond). bodyEndPython finds the method's dedent
+	// boundary — the first non-blank line indented at or below the `def`
+	// header's own indent (a sibling `def`, a decorator, or the class body) —
+	// and we walk only up to there. This is self-correcting: even a 400-line
+	// padded window is clamped to exactly this method's body.
+	bodyEnd := bodyEndPython(lines)
 	var out []BranchFacet
 	// firstGuardSeen lets us label the LEADING guard as early_return and
 	// later same-shape guards as guard (mid-body). env-gates override both.
 	firstGuardSeen := false
 
-	for i := 0; i < len(lines); i++ {
+	for i := 0; i < bodyEnd; i++ {
 		raw := lines[i]
 		if strings.TrimSpace(raw) == "" {
 			continue
@@ -249,6 +260,101 @@ func analyzeBranchesPython(funcSource string, startLine int) []BranchFacet {
 		}
 	}
 	return out
+}
+
+// bodyEndPython returns the exclusive line index at which the method/function
+// whose `def` header is the first non-blank line of `lines` ends — i.e. the
+// index of the first line AFTER the header that dedents to or below the
+// header's own indentation (a sibling `def`/`class`, a trailing decorator, or
+// the enclosing class/module body). When the window is exactly the method body
+// (no trailing siblings) this is len(lines). This is the single source of truth
+// for the method-boundary scope: it stops the branch walk from bleeding into
+// adjacent `@action` methods when the entity's EndLine is missing and the
+// source window was padded.
+//
+// It is robust to leading decorators (`@action(...)`) preceding the `def`: the
+// header is the first `def`/`async def` line, and its indent — not a
+// decorator's — is the boundary indent.
+func bodyEndPython(lines []string) int {
+	// Locate the def header and record its indent. Leading decorator lines
+	// (`@action(...)`, possibly multi-line) precede the `def` in the source
+	// window — skip them so the boundary indent is the `def`'s own, never a
+	// decorator's. We only fall back to a bare-body anchor (first non-blank,
+	// non-decorator line) when there is NO def at all in the window.
+	headerIdx := -1
+	headerIndent := 0
+	bareIdx := -1
+	bareIndent := 0
+	inDecorator := false
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		if pyFuncDefRe.MatchString(ln) {
+			headerIdx = i
+			headerIndent = leadingWS(ln)
+			break
+		}
+		// Track (possibly multi-line) decorators so their continuation lines
+		// aren't mistaken for the bare-body anchor.
+		trimmed := strings.TrimSpace(ln)
+		if inDecorator {
+			inDecorator = !decoratorComplete(trimmed)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "@") {
+			inDecorator = !decoratorComplete(trimmed)
+			continue
+		}
+		// First real (non-decorator) non-blank line and still no def → remember
+		// it as the bare-body anchor, but keep scanning in case a def follows.
+		if bareIdx < 0 {
+			bareIdx = i
+			bareIndent = leadingWS(ln)
+		}
+	}
+	if headerIdx < 0 {
+		// No def in the window — anchor on the first bare-body line so we still
+		// clamp at the first dedent below it. No anchor at all → whole window.
+		if bareIdx < 0 {
+			return len(lines)
+		}
+		headerIdx = bareIdx
+		headerIndent = bareIndent
+	}
+	for j := headerIdx + 1; j < len(lines); j++ {
+		ln := lines[j]
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		if leadingWS(ln) <= headerIndent {
+			return j
+		}
+	}
+	return len(lines)
+}
+
+// pyFuncDefRe matches a Python function/method header (`def f(` /
+// `async def f(`), ignoring leading indentation.
+var pyFuncDefRe = regexp.MustCompile(`^\s*(?:async\s+)?def\s+[A-Za-z_]\w*\s*\(`)
+
+// decoratorComplete reports whether a decorator line that has been seen so far
+// (joined trimmed text) is syntactically complete — i.e. it opened no
+// parenthesis, or every `(` it opened has been closed. A multi-line
+// `@shared_task(\n  ...\n)` decorator is incomplete until the closing `)`.
+// Cheap paren-balance, sufficient for the well-formed windows the effects
+// pipeline feeds in (decorator args rarely embed unbalanced parens in strings).
+func decoratorComplete(trimmed string) bool {
+	depth := 0
+	for _, r := range trimmed {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		}
+	}
+	return depth <= 0
 }
 
 // pyBlockBody returns the statements belonging to the block whose header is at


### PR DESCRIPTION
## Problem
`effects(entity_id=<a method>, include=branches)` over-captured past the method boundary. The Wave-2 downstream consumer (mcp-wave2-test-feedback §3) reported that for `ContractViewSet.create_contact` (body ~:350–447) the branch list bled into the adjacent `@action` methods — it included branches up to line 710 (`update_contact` :446, `get_contracts`, the `if not sort_field` :710). The facet was scanning the whole CLASS region around the entity rather than the single method's own body, which would mis-attribute sibling branches in `response_shape_diff` (#4424), built on this facet.

## Root cause
- `internal/mcp/effects_tool.go` `branchSourceSpan`: when a method entity has a missing/zero `EndLine`, it pads `StartLine + 400` — a window that overshoots into the following sibling methods.
- `internal/substrate/branches.go` `analyzeBranchesPython`: the indentation walk had no method-boundary stop — it classified every `if`/`except` in the padded window, including ones belonging to sibling `def`s.

## Fix
`analyzeBranchesPython` now derives the method's own dedent boundary via a new `bodyEndPython` helper and walks only up to it:
- The boundary is the first non-blank line after the `def` header that dedents to or below the header's own indent — a sibling `def`/decorator/class body. The walk (and every block-body scan, which already stops at `<= headerIndent`) is clamped there.
- Leading (possibly multi-line) decorators preceding the `def` are skipped so the boundary indent is the `def`'s own, never a decorator's (`decoratorComplete` paren-balance). This was load-bearing: the env-gate fixture has a 9-line `@shared_task(...)` decorator before its `def`.

This is **self-correcting**: even the 400-line padded window is clamped to exactly the method body, so no sibling `def` is ever scanned. EndLine derivation by indent therefore happens in the analyzer (the single source of truth) regardless of how wide the source window is.

## Validation
New in-pipeline test `internal/mcp/effects_branches_4488_test.go` runs the REAL `handleEffects` over a verbatim byte-copy of the actual `ContractViewSet` region (`create_contact` immediately followed by `update_contact`) in `testdata/branches_4488/`. The `create_contact` entity is given a `StartLine` with **no `EndLine`** to reproduce the exact degenerate-span condition. It asserts:
- create_contact's OWN branches are present (400 `client is None`, 409 availability);
- update_contact's DISTINCT branches are ABSENT — no `except User.DoesNotExist` (404), no `if conflict_user is not None`;
- no branch is reported at/after the sibling `def` line.

Gates (sandboxed worktree, deploy-deferred):
- `go build ./...` ✅
- `go vet ./internal/substrate/... ./internal/mcp/...` ✅
- `go test ./internal/substrate/... ./internal/mcp/...` ✅ (incl. new `TestEffectsBranches_MethodScope`; all existing branch tests, env-gate included, pass)

Ref epic #4419.

Closes #4533

🤖 Generated with [Claude Code](https://claude.com/claude-code)