### PR TITLE
fix(literal_parity): cross-framework key alignment + unresolved wrong-set guard (#4532)

### DIFF
--- a/internal/literalparity/literalparity.go
+++ b/internal/literalparity/literalparity.go
@@ -59,13 +59,18 @@ type IntraInconsistency struct {
 
 // Result is the full diff verdict between an oracle value-set and its v3
 // mirror.
+//
+// OnlyInOracle / OnlyInV3 are reported on the VALUE multiset (the contract for a
+// parity diff is the literal value, not the key spelling): they list the value
+// literals present on only one side. ValueMismatches reports aligned keys (after
+// canonical key-folding that also splits camelCase) whose literal value differs.
 type Result struct {
 	Set                    string               `json:"set"`
 	OnlyInOracle           []string             `json:"only_in_oracle"`
 	OnlyInV3               []string             `json:"only_in_v3"`
 	ValueMismatches        []ValueMismatch      `json:"value_mismatches"`
 	IntraV3Inconsistencies []IntraInconsistency `json:"intra_v3_inconsistencies"`
-	Verdict                string               `json:"verdict"` // "equivalent" | "drift"
+	Verdict                string               `json:"verdict"` // "equivalent" | "drift" | "unresolved"
 }
 
 const (
@@ -75,6 +80,9 @@ const (
 	// VerdictDrift means at least one membership, value, or intra-v3 difference
 	// was detected.
 	VerdictDrift = "drift"
+	// VerdictUnresolved means a real counterpart set could not be located on one
+	// side, so no comparison was performed (set by the resolver, never by Diff).
+	VerdictUnresolved = "unresolved"
 )
 
 // NormalizeKey folds a key to its alignment form: lowercase, with every run of
@@ -110,6 +118,62 @@ func toLowerRune(r rune) rune {
 	return r
 }
 
+// CanonicalKey folds a key to a stronger ALIGNMENT form than NormalizeKey: in
+// addition to case-folding and collapsing separator runs, it splits camelCase /
+// PascalCase word boundaries into the canonical '_' separator. This is what
+// makes a cross-framework parity diff align the oracle's SCREAMING_SNAKE key
+// (CORE_ADMIN → core_admin) with the v3 PascalCase key (CoreAdmin → core_admin),
+// which NormalizeKey alone could not do (CoreAdmin → coreadmin). It is used for
+// VALUE-mismatch alignment in Diff; NormalizeKey is kept for the looser
+// name-substring matching in the auto-locator.
+//
+// Boundaries split: lower→Upper (coreAdmin → core_admin), an acronym run
+// followed by a Word (HTTPServer → http_server), and letter↔digit
+// (page2Slug → page_2_slug). Existing separators ('_','-','.',' ','/') also
+// split. Runs of separators collapse to one; leading/trailing separators trim.
+func CanonicalKey(k string) string {
+	k = strings.TrimSpace(k)
+	runes := []rune(k)
+	var b strings.Builder
+	prevSep := false
+	emitSep := func() {
+		if !prevSep && b.Len() > 0 {
+			b.WriteByte('_')
+		}
+		prevSep = true
+	}
+	isUpper := func(r rune) bool { return r >= 'A' && r <= 'Z' }
+	isLower := func(r rune) bool { return r >= 'a' && r <= 'z' }
+	isDigit := func(r rune) bool { return r >= '0' && r <= '9' }
+	for i, r := range runes {
+		switch r {
+		case '_', '-', '.', ' ', '/':
+			emitSep()
+			continue
+		}
+		// Insert an implicit boundary before this rune when it starts a new word.
+		if i > 0 && !prevSep {
+			prev := runes[i-1]
+			switch {
+			// lower/digit → Upper  (coreAdmin, page2A)
+			case isUpper(r) && (isLower(prev) || isDigit(prev)):
+				emitSep()
+			// Upper → Upper followed by lower: acronym/word boundary
+			// (HTTPServer → HTTP|Server): split before the trailing Upper.
+			case isUpper(r) && isUpper(prev) && i+1 < len(runes) && isLower(runes[i+1]):
+				emitSep()
+			// letter↔digit boundary in either direction.
+			case (isDigit(r) && (isLower(prev) || isUpper(prev))) ||
+				((isLower(r) || isUpper(r)) && isDigit(prev)):
+				emitSep()
+			}
+		}
+		b.WriteRune(toLowerRune(r))
+		prevSep = false
+	}
+	return strings.TrimRight(strings.TrimLeft(b.String(), "_"), "_")
+}
+
 // separatorOf classifies the separator convention of a literal value:
 // "snake" (contains '_'), "kebab" (contains '-'), or "" (neither / single
 // token / mixed-other). Used to detect the intra-v3 convention split. When a
@@ -141,37 +205,34 @@ func Diff(setName string, oracle, v3 []Member) Result {
 		IntraV3Inconsistencies: []IntraInconsistency{},
 	}
 
-	// Index each side by normalised key. On a collision (two original keys
-	// folding to the same form) the first wins for value compare, but every
-	// original key is still tracked for membership so we never silently drop.
+	// Index each side by CANONICAL key (camelCase-aware: splits coreAdmin →
+	// core_admin so SCREAMING_SNAKE oracle keys align with PascalCase v3 keys).
+	// On a collision (two original keys folding to the same form) the first wins
+	// for value compare, but every original key is still tracked for the
+	// value-multiset membership below so we never silently drop.
 	type idx struct {
 		origKey string
 		value   string
 	}
 	oracleByNorm := map[string]idx{}
 	for _, m := range oracle {
-		nk := NormalizeKey(m.Key)
+		nk := CanonicalKey(m.Key)
 		if _, ok := oracleByNorm[nk]; !ok {
 			oracleByNorm[nk] = idx{origKey: m.Key, value: m.Value}
 		}
 	}
 	v3ByNorm := map[string]idx{}
 	for _, m := range v3 {
-		nk := NormalizeKey(m.Key)
+		nk := CanonicalKey(m.Key)
 		if _, ok := v3ByNorm[nk]; !ok {
 			v3ByNorm[nk] = idx{origKey: m.Key, value: m.Value}
 		}
 	}
 
-	// Membership + value-mismatch.
+	// Value-mismatch on aligned keys: same canonical key carrying a different
+	// literal value on each side (the headline "_ vs -" cross-framework drift).
 	for nk, o := range oracleByNorm {
-		v, ok := v3ByNorm[nk]
-		if !ok {
-			res.OnlyInOracle = append(res.OnlyInOracle, o.origKey)
-			continue
-		}
-		// Compare ORIGINAL literal values (not normalised).
-		if o.value != v.value {
+		if v, ok := v3ByNorm[nk]; ok && o.value != v.value {
 			res.ValueMismatches = append(res.ValueMismatches, ValueMismatch{
 				Key:    o.origKey,
 				Oracle: o.value,
@@ -179,11 +240,13 @@ func Diff(setName string, oracle, v3 []Member) Result {
 			})
 		}
 	}
-	for nk, v := range v3ByNorm {
-		if _, ok := oracleByNorm[nk]; !ok {
-			res.OnlyInV3 = append(res.OnlyInV3, v.origKey)
-		}
-	}
+
+	// Membership is reported on the VALUE MULTISET, because for a parity diff the
+	// VALUE is the contract, not the key spelling. only_in_oracle/only_in_v3 list
+	// the literal values present on only one side — so a drift like
+	// oracle:"core-admin" vs v3:"core_admin" surfaces DIRECTLY here even when keys
+	// fail to align (and is ALSO reported in value_mismatches when keys do align).
+	res.OnlyInOracle, res.OnlyInV3 = valueSetDiff(oracle, v3)
 
 	// Intra-v3 convention split: classify each v3 value literal's separator
 	// convention; if more than one non-empty convention appears, report the
@@ -205,6 +268,49 @@ func Diff(setName string, oracle, v3 []Member) Result {
 		res.Verdict = VerdictDrift
 	}
 	return res
+}
+
+// valueSetDiff computes the value-MULTISET difference between the two sides:
+// the literal values present on only the oracle side and only the v3 side. For
+// a parity diff the value is the contract, so this surfaces a differing literal
+// directly even when the keys carrying it cannot be aligned across frameworks.
+// A member with an empty value falls back to its key (so value-less enum members
+// still participate), mirroring detectIntraInconsistency. Each list is a SET of
+// distinct values, deterministically sorted.
+func valueSetDiff(oracle, v3 []Member) (onlyOracle, onlyV3 []string) {
+	// For members WITH a literal value the value is compared RAW (core_admin vs
+	// core-admin is a real drift). For value-LESS members we fall back to the
+	// CANONICAL key, so a pure key-casing/separator difference in a valueless enum
+	// (ACTIVE vs active) does NOT read as a value drift.
+	probe := func(m Member) string {
+		if strings.TrimSpace(m.Value) == "" {
+			return CanonicalKey(m.Key)
+		}
+		return m.Value
+	}
+	oset := map[string]bool{}
+	for _, m := range oracle {
+		oset[probe(m)] = true
+	}
+	vset := map[string]bool{}
+	for _, m := range v3 {
+		vset[probe(m)] = true
+	}
+	onlyOracle = []string{}
+	onlyV3 = []string{}
+	for val := range oset {
+		if !vset[val] {
+			onlyOracle = append(onlyOracle, val)
+		}
+	}
+	for val := range vset {
+		if !oset[val] {
+			onlyV3 = append(onlyV3, val)
+		}
+	}
+	sort.Strings(onlyOracle)
+	sort.Strings(onlyV3)
+	return onlyOracle, onlyV3
 }
 
 // detectIntraInconsistency finds a mixed separator/format convention within a

--- a/internal/literalparity/literalparity_test.go
+++ b/internal/literalparity/literalparity_test.go
@@ -24,6 +24,78 @@ func TestNormalizeKey(t *testing.T) {
 	}
 }
 
+func TestCanonicalKey(t *testing.T) {
+	cases := map[string]string{
+		"CORE_ADMIN":   "core_admin",
+		"CoreAdmin":    "core_admin", // PascalCase splits to align with SCREAMING_SNAKE
+		"coreAdmin":    "core_admin",
+		"core-admin":   "core_admin",
+		"EmailTemplates": "email_templates",
+		"EMAIL_TEMPLATES": "email_templates",
+		"HTTPServer":   "http_server", // acronym/word boundary
+		"page2Slug":    "page_2_slug", // letter↔digit boundary
+		"PERMISSION_PAGES": "permission_pages",
+		"PermissionPage":   "permission_page",
+	}
+	for in, want := range cases {
+		if got := CanonicalKey(in); got != want {
+			t.Errorf("CanonicalKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// BUG A (#4532): cross-framework key alignment. Oracle SCREAMING_SNAKE keys vs
+// v3 PascalCase keys must align by canonical form so a real value drift reaches
+// value_mismatches instead of being dumped into only_in_* by key-spelling.
+func TestDiff_CrossFrameworkKeyAlignment(t *testing.T) {
+	oracle := []Member{
+		{Key: "CORE_ADMIN", Value: "core-admin"},
+		{Key: "EMAIL_TEMPLATES", Value: "email-templates"},
+		{Key: "AOC_HARVEST", Value: "aoc-harvest"},
+	}
+	v3 := []Member{
+		{Key: "CoreAdmin", Value: "core_admin"},      // _ vs - drift, same canonical key
+		{Key: "EmailTemplates", Value: "email-templates"}, // reconciled
+		{Key: "AocHarvest", Value: "aoc-harvest"},          // reconciled
+	}
+	res := Diff("page_slugs", oracle, v3)
+	if res.Verdict != VerdictDrift {
+		t.Fatalf("verdict = %q, want drift; %+v", res.Verdict, res)
+	}
+	want := []ValueMismatch{{Key: "CORE_ADMIN", Oracle: "core-admin", V3: "core_admin"}}
+	if !reflect.DeepEqual(res.ValueMismatches, want) {
+		t.Fatalf("value_mismatches = %+v, want %+v", res.ValueMismatches, want)
+	}
+	// And the differing literals surface in the value multiset too.
+	if !reflect.DeepEqual(res.OnlyInOracle, []string{"core-admin"}) {
+		t.Errorf("only_in_oracle = %v, want [core-admin]", res.OnlyInOracle)
+	}
+	if !reflect.DeepEqual(res.OnlyInV3, []string{"core_admin"}) {
+		t.Errorf("only_in_v3 = %v, want [core_admin]", res.OnlyInV3)
+	}
+}
+
+// BUG A (#4532): a fully reconciled cross-framework set (SCREAMING_SNAKE vs
+// PascalCase keys, IDENTICAL values both sides) must return equivalent.
+func TestDiff_CrossFrameworkReconciledEquivalent(t *testing.T) {
+	oracle := []Member{
+		{Key: "CORE_ADMIN", Value: "core_admin"},
+		{Key: "EMAIL_TEMPLATES", Value: "email_templates"},
+	}
+	v3 := []Member{
+		{Key: "CoreAdmin", Value: "core_admin"},
+		{Key: "EmailTemplates", Value: "email_templates"},
+	}
+	res := Diff("page_slugs", oracle, v3)
+	if res.Verdict != VerdictEquivalent {
+		t.Fatalf("verdict = %q, want equivalent; %+v", res.Verdict, res)
+	}
+	if len(res.OnlyInOracle) != 0 || len(res.OnlyInV3) != 0 ||
+		len(res.ValueMismatches) != 0 || len(res.IntraV3Inconsistencies) != 0 {
+		t.Fatalf("expected clean equivalent, got %+v", res)
+	}
+}
+
 // equivalent: identical key+value sets (modulo key separator/case) → no diff.
 func TestDiff_Equivalent(t *testing.T) {
 	oracle := []Member{
@@ -56,8 +128,13 @@ func TestDiff_ValueMismatch(t *testing.T) {
 	if !reflect.DeepEqual(res.ValueMismatches, want) {
 		t.Fatalf("value_mismatches = %+v, want %+v", res.ValueMismatches, want)
 	}
-	if len(res.OnlyInOracle) != 0 || len(res.OnlyInV3) != 0 {
-		t.Fatalf("unexpected membership diff: %+v", res)
+	// The differing literals ALSO surface in the value-multiset membership (the
+	// value is the parity contract): oracle-only "core_admin", v3-only "core-admin".
+	if !reflect.DeepEqual(res.OnlyInOracle, []string{"core_admin"}) {
+		t.Errorf("only_in_oracle = %v, want [core_admin]", res.OnlyInOracle)
+	}
+	if !reflect.DeepEqual(res.OnlyInV3, []string{"core-admin"}) {
+		t.Errorf("only_in_v3 = %v, want [core-admin]", res.OnlyInV3)
 	}
 }
 
@@ -75,11 +152,13 @@ func TestDiff_OnlyIn(t *testing.T) {
 	if res.Verdict != VerdictDrift {
 		t.Fatalf("verdict = %q, want drift", res.Verdict)
 	}
-	if !reflect.DeepEqual(res.OnlyInOracle, []string{"DROPPED"}) {
-		t.Errorf("only_in_oracle = %v, want [DROPPED]", res.OnlyInOracle)
+	// Membership is reported on the VALUE multiset: oracle-only value "dropped",
+	// v3-only value "added" (the shared "keep" value is on both sides).
+	if !reflect.DeepEqual(res.OnlyInOracle, []string{"dropped"}) {
+		t.Errorf("only_in_oracle = %v, want [dropped]", res.OnlyInOracle)
 	}
-	if !reflect.DeepEqual(res.OnlyInV3, []string{"ADDED"}) {
-		t.Errorf("only_in_v3 = %v, want [ADDED]", res.OnlyInV3)
+	if !reflect.DeepEqual(res.OnlyInV3, []string{"added"}) {
+		t.Errorf("only_in_v3 = %v, want [added]", res.OnlyInV3)
 	}
 }
 

--- a/internal/mcp/literal_parity_tool.go
+++ b/internal/mcp/literal_parity_tool.go
@@ -89,13 +89,23 @@ func (s *Server) handleLiteralParity(_ context.Context, req mcpapi.CallToolReque
 	oracleID := argString(req, "oracle_source", "")
 	v3ID := argString(req, "v3_source", "")
 
+	// If an explicit *_source is given it is a hard pin: a miss is a real error
+	// (the caller asked for a specific entity). Without it, auto-locate may fail
+	// to find a SEMANTIC counterpart on one side — e.g. DRF action codenames are
+	// implicit lowercased @action method names with no declared enum on the
+	// oracle. In that case we MUST NOT silently compare a mismatched set; we
+	// return verdict:"unresolved" with the missing side's *_source null and a
+	// note, so the consumer can supply an explicit oracle_source/v3_source.
 	oracleEnt, oErr := locateValueSet(lgOracle, set, oracleID)
-	if oErr != "" {
+	if oErr != "" && oracleID != "" {
 		return mcpapi.NewToolResultError("oracle: " + oErr), nil
 	}
 	v3Ent, vErr := locateValueSet(lgV3, set, v3ID)
-	if vErr != "" {
+	if vErr != "" && v3ID != "" {
 		return mcpapi.NewToolResultError("v3: " + vErr), nil
+	}
+	if oErr != "" || vErr != "" {
+		return unresolvedResult(set, oracleEnt, v3Ent, oErr, vErr), nil
 	}
 
 	oracleMembers, err := parseMembersJSON(oracleEnt)
@@ -121,6 +131,45 @@ func (s *Server) handleLiteralParity(_ context.Context, req mcpapi.CallToolReque
 		"intra_v3_inconsistencies": res.IntraV3Inconsistencies,
 		"verdict":                  res.Verdict,
 	}), nil
+}
+
+// unresolvedResult builds a verdict:"unresolved" payload when a real counterpart
+// value-set could not be auto-located on one (or both) sides. The located side's
+// source id is reported; the unresolved side's is null. A note explains what to
+// do (supply an explicit oracle_source/v3_source). This is deliberately a
+// NO-RESULT, not a fabricated comparison against the wrong set.
+func unresolvedResult(set string, oracleEnt, v3Ent *graph.Entity, oErr, vErr string) *mcpapi.CallToolResult {
+	out := map[string]any{
+		"set":                      set,
+		"verdict":                  literalparity.VerdictUnresolved,
+		"oracle_source":            nil,
+		"v3_source":                nil,
+		"oracle_set_name":          nil,
+		"v3_set_name":              nil,
+		"only_in_oracle":           []string{},
+		"only_in_v3":               []string{},
+		"value_mismatches":         []literalparity.ValueMismatch{},
+		"intra_v3_inconsistencies": []literalparity.IntraInconsistency{},
+	}
+	notes := []string{}
+	if oErr != "" {
+		notes = append(notes, "oracle: "+oErr)
+	} else if oracleEnt != nil {
+		out["oracle_source"] = oracleEnt.ID
+		out["oracle_set_name"] = oracleEnt.Name
+	}
+	if vErr != "" {
+		notes = append(notes, "v3: "+vErr)
+	} else if v3Ent != nil {
+		out["v3_source"] = v3Ent.ID
+		out["v3_set_name"] = v3Ent.Name
+	}
+	notes = append(notes, "no semantic counterpart auto-located on one side; "+
+		"this set may be IMPLICIT on that side (e.g. DRF action codenames = "+
+		"lowercased @action method names, no declared enum) — supply an explicit "+
+		"oracle_source/v3_source to compare. Refusing to compare a mismatched set.")
+	out["note"] = strings.Join(notes, " | ")
+	return jsonResult(out)
 }
 
 // locateValueSet resolves the SCOPE.Enum value-set entity for a `set` within a
@@ -180,21 +229,24 @@ func findEnumByID(lg *LoadedGroup, id string) *graph.Entity {
 }
 
 // matchEnumByNames scans a group's SCOPE.Enum value-sets and returns the best
-// match against the candidate names. Matching tiers (best first):
-//  1. exact normalised name match;
-//  2. one side is a normalised substring of the other.
-// Within a tier, candidate order wins; then deterministic by entity name.
+// SEMANTIC match against the candidate names. Matching requires an EXACT
+// canonical-name match (CanonicalKey folds case + separators + camelCase, and a
+// trailing plural 's', so PERMISSION_PAGES / PermissionPage / PageSlugs all
+// canonicalise comparably). Substring matching was REMOVED (#4532 Bug B): it let
+// `action_codenames` grab unrelated "Action" enums (SyncActionStatus,
+// OutboxAction) and silently compare the wrong sets. A no-result is safer than a
+// wrong-set comparison — the caller gets verdict:"unresolved" and can pin an
+// explicit source. Within the exact tier, candidate order wins; then by name.
 func matchEnumByNames(lg *LoadedGroup, candidates []string) *graph.Entity {
 	type hit struct {
 		ent  *graph.Entity
-		tier int // 0 exact, 1 substring
 		rank int // candidate preference rank
 	}
 	var hits []hit
 
 	normCands := make([]string, len(candidates))
 	for i, c := range candidates {
-		normCands[i] = literalparity.NormalizeKey(c)
+		normCands[i] = canonicalSetName(c)
 	}
 
 	for _, r := range lg.Repos {
@@ -206,13 +258,10 @@ func matchEnumByNames(lg *LoadedGroup, candidates []string) *graph.Entity {
 			if !isValueSet(e) {
 				continue
 			}
-			en := literalparity.NormalizeKey(enumDisplayName(e))
+			en := canonicalSetName(enumDisplayName(e))
 			for rank, nc := range normCands {
-				switch {
-				case en == nc:
-					hits = append(hits, hit{ent: e, tier: 0, rank: rank})
-				case strings.Contains(en, nc) || strings.Contains(nc, en):
-					hits = append(hits, hit{ent: e, tier: 1, rank: rank})
+				if en == nc {
+					hits = append(hits, hit{ent: e, rank: rank})
 				}
 			}
 		}
@@ -221,15 +270,26 @@ func matchEnumByNames(lg *LoadedGroup, candidates []string) *graph.Entity {
 		return nil
 	}
 	sort.SliceStable(hits, func(i, j int) bool {
-		if hits[i].tier != hits[j].tier {
-			return hits[i].tier < hits[j].tier
-		}
 		if hits[i].rank != hits[j].rank {
 			return hits[i].rank < hits[j].rank
 		}
 		return hits[i].ent.Name < hits[j].ent.Name
 	})
 	return hits[0].ent
+}
+
+// canonicalSetName folds a value-set name to its semantic-match form:
+// CanonicalKey (case + separator + camelCase fold) plus a trailing-plural fold
+// so the singular/plural naming the oracle and v3 tend to differ on still align
+// (PERMISSION_PAGES ↔ PermissionPage, PageSlug ↔ PageSlugs). Only the FINAL 's'
+// of the whole canonical form is dropped (status → statu would be wrong, so we
+// keep names ending in "ss" and very short stems intact).
+func canonicalSetName(s string) string {
+	c := literalparity.CanonicalKey(s)
+	if len(c) > 3 && strings.HasSuffix(c, "s") && !strings.HasSuffix(c, "ss") {
+		c = c[:len(c)-1]
+	}
+	return c
 }
 
 // enumDisplayName returns the enum's logical name: the enum_name property when

--- a/internal/mcp/literal_parity_tool_test.go
+++ b/internal/mcp/literal_parity_tool_test.go
@@ -144,23 +144,72 @@ func TestLiteralParity_E2E_MissingArgs(t *testing.T) {
 	}
 }
 
-// End-to-end: auto-locate failure (no matching value-set) is a clean error,
-// not a panic.
-func TestLiteralParity_E2E_AutoLocateMiss(t *testing.T) {
+// BUG B (#4532): auto-locate failure on BOTH sides (no semantic counterpart) is
+// NOT a fabricated comparison — it returns verdict:"unresolved" with both
+// sources null and a note, not a tool error and not a wrong-set diff.
+func TestLiteralParity_E2E_UnresolvedBothSides(t *testing.T) {
 	s := twoGroupServer(t,
 		[]graph.Entity{enumEntity("o1", "Unrelated", `[{"key":"A","value":"a"}]`)},
 		[]graph.Entity{enumEntity("v1", "Unrelated", `[{"key":"A","value":"a"}]`)},
 	)
-	req := mcpapi.CallToolRequest{}
-	req.Params.Name = "archigraph_literal_parity"
-	req.Params.Arguments = map[string]any{
+	out := callLiteralParity(t, s, map[string]any{
 		"group_oracle": "oracle", "group_v3": "v3", "set": "status_strings",
+	})
+	if out["verdict"] != "unresolved" {
+		t.Fatalf("verdict = %v, want unresolved; out=%+v", out["verdict"], out)
 	}
-	res, err := s.handleLiteralParity(context.Background(), req)
-	if err != nil {
-		t.Fatalf("handler error: %v", err)
+	if out["oracle_source"] != nil || out["v3_source"] != nil {
+		t.Errorf("expected null sources, got %v / %v", out["oracle_source"], out["v3_source"])
 	}
-	if !res.IsError {
-		t.Fatalf("expected auto-locate miss error")
+	if _, ok := out["note"].(string); !ok || out["note"] == "" {
+		t.Errorf("expected a non-empty note, got %v", out["note"])
+	}
+	vm, _ := out["value_mismatches"].([]any)
+	if len(vm) != 0 {
+		t.Errorf("expected no fabricated comparison, got value_mismatches=%v", vm)
+	}
+}
+
+// BUG B (#4532): the OLD substring auto-locate compared unrelated "Action" enums
+// (SyncActionStatus ↔ OutboxAction). Now: no exact semantic counterpart for the
+// action_codenames alias exists on the oracle side (only SyncActionStatus, which
+// is NOT the codename set), so the result is unresolved on that side — not a
+// silent wrong-set comparison. The v3 side, which DOES have a real ActionCodename
+// set, is reported.
+func TestLiteralParity_E2E_NoSubstringWrongSet(t *testing.T) {
+	s := twoGroupServer(t,
+		[]graph.Entity{enumEntity("o1", "SyncActionStatus", `[{"key":"PENDING","value":"pending"}]`)},
+		[]graph.Entity{enumEntity("v1", "ActionCodename", `[{"key":"LITE","value":"lite"}]`)},
+	)
+	out := callLiteralParity(t, s, map[string]any{
+		"group_oracle": "oracle", "group_v3": "v3", "set": "action_codenames",
+	})
+	if out["verdict"] != "unresolved" {
+		t.Fatalf("verdict = %v, want unresolved (wrong-set must NOT be compared); out=%+v", out["verdict"], out)
+	}
+	if out["oracle_source"] != nil {
+		t.Errorf("oracle should be unresolved (SyncActionStatus is the wrong set), got %v", out["oracle_source"])
+	}
+	if out["v3_source"] != "v1" {
+		t.Errorf("v3 ActionCodename should resolve, got %v", out["v3_source"])
+	}
+}
+
+// BUG B (#4532): for an implicit-on-one-side set, an explicit oracle_source
+// override pins the value-set and yields a real comparison instead of unresolved.
+func TestLiteralParity_E2E_ExplicitOverrideResolvesImplicit(t *testing.T) {
+	s := twoGroupServer(t,
+		[]graph.Entity{enumEntity("oImplicit", "SyncActionStatus", `[{"key":"LITE","value":"lite"}]`)},
+		[]graph.Entity{enumEntity("v1", "ActionCodename", `[{"key":"LITE","value":"lite"}]`)},
+	)
+	out := callLiteralParity(t, s, map[string]any{
+		"group_oracle": "oracle", "group_v3": "v3", "set": "action_codenames",
+		"oracle_source": "oImplicit",
+	})
+	if out["verdict"] != "equivalent" {
+		t.Fatalf("verdict = %v, want equivalent with explicit oracle_source; out=%+v", out["verdict"], out)
+	}
+	if out["oracle_source"] != "oImplicit" || out["v3_source"] != "v1" {
+		t.Errorf("sources = %v / %v", out["oracle_source"], out["v3_source"])
 	}
 }


### PR DESCRIPTION
Fixes two blocking bugs a downstream parity-audit consumer (upvate oracle vs upvate-v3) reported in the shipped `literal_parity` tool — both made it MISS the very drift it targets.

## BUG A — alignment-by-key missed cross-framework drift (FALSE NEGATIVE)
`literalparity.Diff` aligned the two ConstantSets by `NormalizeKey`, which folds case/separators but does **not** split camelCase. So oracle SCREAMING_SNAKE `CORE_ADMIN` → `core_admin` while v3 PascalCase `CoreAdmin` → `coreadmin`: zero keys aligned, every entry dumped into `only_in_*`, and the headline drift (`CORE_ADMIN:"core-admin"` vs `CoreAdmin:"core_admin"`) never reached `value_mismatches`.

**Fix (both recommended approaches):**
- New `CanonicalKey` splits camelCase / PascalCase word boundaries (plus acronym `HTTPServer→http_server` and letter↔digit boundaries) on top of case+separator folding, so cross-framework keys align. `Diff` now aligns value-mismatches on `CanonicalKey`.
- Membership (`only_in_oracle`/`only_in_v3`) is now reported on the **VALUE multiset** — for a parity diff the value is the contract — so differing literals surface directly even when keys can't align (and are *also* in `value_mismatches` when keys align). Value-less enum members fall back to their canonical key so pure key-casing differences don't read as value drift.

## BUG B — auto-locate grabbed the wrong set (FALSE COMPARISON)
`set=action_codenames` substring-matched unrelated "Action" enums and silently compared `SyncActionStatus` ↔ `OutboxAction` — neither is the permission-codename set.

**Fix:**
- `matchEnumByNames` now requires an **EXACT canonical (semantic) name match**; the substring tier is removed. (`canonicalSetName` adds a trailing-plural fold so `PERMISSION_PAGES`/`PermissionPage`/`PageSlugs` still align across singular/plural naming.)
- When no real counterpart is auto-located on a side, the tool returns `verdict:"unresolved"` with that side's `*_source: null` and an explanatory `note`, instead of fabricating a comparison. Explicit `oracle_source`/`v3_source` overrides still resolve sets that are *implicit* on one side (e.g. DRF action codenames = lowercased `@action` method names with no declared enum). A no-result is safer than a wrong-set comparison.

`intra_v3_inconsistencies` (already correct) is unchanged.

## Tests
- core: `CanonicalKey` unit cases; cross-framework value-mismatch (`core_admin`/`core-admin`) populating `value_mismatches`; fully-reconciled cross-framework set → `equivalent`; updated existing membership assertions to value-multiset semantics.
- mcp e2e: `unresolved` on both-sides miss (sources null, note present, no fabricated comparison); no-substring-wrong-set (oracle unresolved, v3 resolved); explicit-override resolves an implicit set → `equivalent`.

## Gates
- `go build ./...` ✅
- `go vet ./internal/literalparity/... ./internal/mcp/...` ✅
- `go test ./internal/literalparity/... ./internal/mcp/...` ✅ (all literal_parity tests pass; one unrelated pre-existing timing flake `TestGetSource_FsnotifyWatcher_CompletesQuickly` passes on rerun)

DEPLOY-DEFERRED.

Closes #4532

🤖 Generated with [Claude Code](https://claude.com/claude-code)