### PR TITLE
fix(coverage): credit http_endpoint_definition via tested handler (#4553)

### DIFF
--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -391,6 +391,115 @@ func pct(covered, total int) float64 {
 const kindTests = "TESTS"
 const kindCalls = "CALLS"
 
+// handlerEndpointEdgeKinds are the producer-side edge kinds that link a backend
+// handler (controller method / view function / Operation) to its
+// http_endpoint_definition. The link is recorded in BOTH directions across
+// frameworks:
+//
+//	handler --IMPLEMENTS/SERVES--> definition   (NestJS, DRF/Django, …: FromID = handler)
+//	definition --ROUTES_TO/SERVES--> handler    (Spring, Express routers, …: ToID = handler)
+//
+// Used by creditEndpointsViaHandlers so that an endpoint is credited as covered
+// when its backing handler is reached by a test, even though the test (a
+// controller spec, MockMvc test, APITestCase, …) targets the handler method —
+// not the synthetic endpoint-definition node. See #4553.
+var handlerEndpointEdgeKinds = map[string]bool{
+	"IMPLEMENTS": true,
+	"ROUTES_TO":  true,
+	"SERVES":     true,
+}
+
+// isEndpointKind reports whether kind denotes an HTTP endpoint definition,
+// tolerant of a leading "SCOPE." prefix some extractors emit.
+func isEndpointKind(kind string) bool {
+	k := kind
+	if i := strings.LastIndex(k, "."); i >= 0 {
+		k = k[i+1:]
+	}
+	return strings.EqualFold(k, "http_endpoint_definition") ||
+		strings.EqualFold(k, "http_endpoint")
+}
+
+// creditEndpointsViaHandlers propagates test coverage from a covered handler to
+// the http_endpoint_definition it backs (#4553).
+//
+// Background: a controller spec / MockMvc test / APITestCase exercises the
+// handler METHOD (which gets credited by the TESTS/CALLS/name-affinity phases),
+// but the synthetic http_endpoint_definition node it IMPLEMENTS is a separate
+// entity that no test points at directly. Without this hop every endpoint reads
+// uncovered and dominates the denominator, suppressing the coverage %.
+//
+// The hop is one level along the handler↔definition edge (IMPLEMENTS/ROUTES_TO/
+// SERVES, either direction) and is framework-agnostic — it relies only on the
+// edge kinds the endpoint resolver already emits, never on a framework name.
+// It mutates covered in place and returns the number of endpoints newly
+// credited.
+func creditEndpointsViaHandlers(
+	entByID map[string]*Entity,
+	rels []Relationship,
+	prodIDs map[string]bool,
+	covered map[string]int,
+) int {
+	credited := 0
+	for i := range rels {
+		r := &rels[i]
+		if !handlerEndpointEdgeKinds[strings.ToUpper(r.Kind)] {
+			continue
+		}
+		from := entByID[r.FromID]
+		to := entByID[r.ToID]
+		if from == nil || to == nil {
+			continue
+		}
+		// Determine which endpoint is the endpoint-definition and which is the
+		// handler, regardless of edge direction.
+		var defID, handlerID string
+		switch {
+		case isEndpointKind(to.Kind) && !isEndpointKind(from.Kind):
+			defID, handlerID = to.ID, from.ID // handler --IMPLEMENTS--> def
+		case isEndpointKind(from.Kind) && !isEndpointKind(to.Kind):
+			defID, handlerID = from.ID, to.ID // def --ROUTES_TO--> handler
+		default:
+			continue
+		}
+		// Only credit endpoints that are in the production denominator and not
+		// already covered, and only when their handler is itself covered.
+		if !prodIDs[defID] || covered[defID] > 0 {
+			continue
+		}
+		if covered[handlerID] > 0 {
+			covered[defID]++
+			credited++
+		}
+	}
+	return credited
+}
+
+// endpointHandlerIDs returns the handler entity IDs that back the
+// http_endpoint_definition defID, resolving the handler↔definition edge in
+// both directions (IMPLEMENTS/ROUTES_TO/SERVES). Framework-agnostic; used by the
+// single-entity coverage path (#4553).
+func endpointHandlerIDs(entByID map[string]*Entity, rels []Relationship, defID string) []string {
+	var out []string
+	for i := range rels {
+		r := &rels[i]
+		if !handlerEndpointEdgeKinds[strings.ToUpper(r.Kind)] {
+			continue
+		}
+		switch {
+		case r.ToID == defID:
+			if from := entByID[r.FromID]; from != nil && !isEndpointKind(from.Kind) {
+				out = append(out, r.FromID) // handler --IMPLEMENTS--> def
+			}
+		case r.FromID == defID:
+			if to := entByID[r.ToID]; to != nil && !isEndpointKind(to.Kind) {
+				out = append(out, r.ToID) // def --ROUTES_TO--> handler
+			}
+		}
+	}
+	return out
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-entity coverage lookup (#1774)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -481,6 +590,34 @@ func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResul
 	if len(coveringSet) == 0 {
 		for testID := range testCallsToTarget {
 			coveringSet[testID] = true
+		}
+	}
+
+	// ── phase 3: endpoint crediting via handler (#4553) ───────────────────────
+	// When the target is an http_endpoint_definition that no test points at
+	// directly, credit it as covered if its backing handler (one hop along
+	// IMPLEMENTS/ROUTES_TO/SERVES) is itself reached by a test. Mirrors the
+	// graph-wide creditEndpointsViaHandlers phase so single-entity and aggregate
+	// queries agree.
+	if len(coveringSet) == 0 && isEndpointKind(target.Kind) {
+		entByID := make(map[string]*Entity, len(doc.Entities))
+		for i := range doc.Entities {
+			entByID[doc.Entities[i].ID] = &doc.Entities[i]
+		}
+		for _, hID := range endpointHandlerIDs(entByID, doc.Relationships, entityID) {
+			for i := range doc.Relationships {
+				rel := &doc.Relationships[i]
+				switch strings.ToUpper(rel.Kind) {
+				case kindTests:
+					if rel.ToID == hID && testIDs[rel.FromID] {
+						coveringSet[rel.FromID] = true
+					}
+				case kindCalls:
+					if rel.ToID == hID && testIDs[rel.FromID] {
+						coveringSet[rel.FromID] = true
+					}
+				}
+			}
 		}
 	}
 
@@ -697,6 +834,18 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 	// redo linkage extraction — so it is a cheap, conservative boost.
 	if affinity := attributeByNameAffinity(entByID, testIDs, prodIDs, covered); affinity > 0 {
 		report.TotalTestsEdges += affinity
+	}
+
+	// ── phase 4: endpoint-definition crediting via handler (#4553) ────────────
+	// An http_endpoint_definition is a synthetic node that no test points at
+	// directly; tests target the backing handler method (controller spec,
+	// MockMvc, APITestCase, …). Once handlers are credited by phases 1-3,
+	// propagate one hop along IMPLEMENTS/ROUTES_TO/SERVES so a covered handler
+	// credits the endpoint it implements. Framework-agnostic. Without this,
+	// every endpoint reads uncovered and suppresses the coverage % (the upvate-v3
+	// symptom: 100% of the uncovered list is http_endpoint_definition).
+	if ep := creditEndpointsViaHandlers(entByID, doc.Relationships, prodIDs, covered); ep > 0 {
+		report.TotalTestsEdges += ep
 	}
 
 	// ── compute totals ────────────────────────────────────────────────────────

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -583,3 +583,102 @@ func TestComputeCoverage_4510_DenominatorAndAffinity(t *testing.T) {
 		}
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #4553: endpoint crediting via handler (read-layer shape)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestComputeCoverage_EndpointCreditedViaHandler models the upvate-v3 symptom
+// (#4553): a NestJS controller spec exercises the handler method, but the
+// http_endpoint_definition the handler IMPLEMENTS is a separate synthetic node
+// that no test points at directly. Before the phase-4 hop the endpoint reads
+// uncovered (RED); after, the covered handler credits the endpoint (GREEN).
+//
+// The graph shape mirrors the live read layer:
+//
+//	getHello (SCOPE.Operation, app.controller.ts)
+//	    --IMPLEMENTS--> GET / (http_endpoint_definition, app.controller.ts)
+//	TestGetHello (app.controller.spec.ts) --TESTS--> getHello
+func TestComputeCoverage_EndpointCreditedViaHandler(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		{ID: "handler", Name: "getHello", Kind: "SCOPE.Operation",
+			SourceFile: "src/app.controller.ts", StartLine: 9},
+		{ID: "ep", Name: "GET /", Kind: "http_endpoint_definition",
+			SourceFile: "src/app.controller.ts", StartLine: 9},
+		{ID: "spec", Name: "AppController", Kind: "SCOPE.Operation",
+			SourceFile: "src/app.controller.spec.ts"},
+	}
+	rels := []Relationship{
+		// handler IMPLEMENTS endpoint-definition (#1639/#4316 shape).
+		{ID: "i1", FromID: "handler", ToID: "ep", Kind: "IMPLEMENTS"},
+		// The controller spec tests the handler method.
+		{ID: "t1", FromID: "spec", ToID: "handler", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+
+	if report.TotalProduction != 2 {
+		t.Fatalf("TotalProduction want 2 (handler+endpoint), got %d", report.TotalProduction)
+	}
+	// Both the handler (direct TESTS) and the endpoint (handler hop) covered.
+	if report.CoveredProduction != 2 {
+		t.Errorf("CoveredProduction want 2 (handler + endpoint via IMPLEMENTS hop), got %d", report.CoveredProduction)
+	}
+	for _, u := range report.UncoveredEntities {
+		if u.EntityID == "ep" {
+			t.Errorf("endpoint should be credited covered via its tested handler but is uncovered (#4553 RED)")
+		}
+	}
+
+	// Single-entity path must agree.
+	res, ok := ComputeEntityCoverage(makeDoc(entities, rels), "ep")
+	if !ok {
+		t.Fatalf("ComputeEntityCoverage(ep) not found")
+	}
+	if !res.Tested {
+		t.Errorf("ComputeEntityCoverage(ep).Tested want true (handler hop), got false")
+	}
+}
+
+// TestComputeCoverage_EndpointNotCreditedWhenHandlerUntested is the negative
+// control: an endpoint whose handler is NOT tested stays uncovered, so the hop
+// does not fabricate coverage.
+func TestComputeCoverage_EndpointNotCreditedWhenHandlerUntested(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		{ID: "handler", Name: "getHello", Kind: "SCOPE.Operation",
+			SourceFile: "src/app.controller.ts"},
+		{ID: "ep", Name: "GET /", Kind: "http_endpoint_definition",
+			SourceFile: "src/app.controller.ts"},
+	}
+	rels := []Relationship{
+		{ID: "i1", FromID: "handler", ToID: "ep", Kind: "IMPLEMENTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	if report.CoveredProduction != 0 {
+		t.Errorf("CoveredProduction want 0 (handler untested), got %d", report.CoveredProduction)
+	}
+}
+
+// TestComputeCoverage_EndpointCreditedViaRoutesTo verifies the reverse edge
+// direction (Spring/Express shape: definition --ROUTES_TO--> handler) is also
+// honoured, proving the hop is framework-agnostic.
+func TestComputeCoverage_EndpointCreditedViaRoutesTo(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		{ID: "ep", Name: "GET /users", Kind: "http_endpoint_definition",
+			SourceFile: "UserController.java"},
+		{ID: "handler", Name: "listUsers", Kind: "SCOPE.Operation",
+			SourceFile: "UserController.java"},
+		{ID: "spec", Name: "UserControllerTest", Kind: "SCOPE.Operation",
+			SourceFile: "UserControllerTest.java"},
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "ep", ToID: "handler", Kind: "ROUTES_TO"},
+		{ID: "t1", FromID: "spec", ToID: "handler", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	if report.CoveredProduction != 2 {
+		t.Errorf("CoveredProduction want 2 (handler + endpoint via ROUTES_TO), got %d", report.CoveredProduction)
+	}
+}


### PR DESCRIPTION
## Problem
On upvate-v3 test coverage read **17.9% (471/2627)** with the **entire** uncovered-entities list being `http_endpoint_definition` — every HTTP endpoint reads uncovered (e.g. `GET /` at `src/app.controller.ts:9` despite `src/app.controller.spec.ts` existing). Endpoints get no test credit, dominate the denominator, and suppress the %.

## Root cause (investigation case 2)
An `http_endpoint_definition` is a synthetic node that no test points at directly. A controller spec / MockMvc test / DRF `APITestCase` exercises the **handler method**, which IS credited by the existing TESTS / CALLS / name-affinity phases. But `ComputeCoverage` never propagated that coverage one hop along the handler↔definition edge (`handler --IMPLEMENTS--> def`), so the endpoint stayed uncovered.

\#4487 *does* emit a TESTS edge straight to the definition — but only when a spec **names** `VERB /route` in its `describe()`/`it()` label. The common controller-unit-spec that simply calls the handler (`appController.getHello()`) never names the route, so its endpoint got zero credit. That is the upvate-v3 symptom.

## Fix
Add a framework-agnostic phase-4 hop, `creditEndpointsViaHandlers`, that credits an endpoint as covered when its backing handler is covered. It traverses `IMPLEMENTS` / `ROUTES_TO` / `SERVES` in **both** directions:
- `handler --IMPLEMENTS/SERVES--> def` (NestJS, DRF/Django)
- `def --ROUTES_TO/SERVES--> handler` (Spring, Express routers)

Mirrored in the single-entity `ComputeEntityCoverage` path so per-endpoint queries agree. Relies only on edge kinds the endpoint resolver already emits — no framework name is hardcoded (mirrors the dashboard `paths_handler_resolve.go` resolution).

## Tests (RED → GREEN, read-layer shape)
- `TestComputeCoverage_EndpointCreditedViaHandler` — NestJS shape: tested handler `getHello` IMPLEMENTS `GET /`; endpoint now credited (was uncovered).
- `TestComputeCoverage_EndpointNotCreditedWhenHandlerUntested` — negative control: untested handler → endpoint stays uncovered (no fabricated coverage).
- `TestComputeCoverage_EndpointCreditedViaRoutesTo` — Spring/Express `ROUTES_TO` direction.

Verified RED on pre-fix code (`CoveredProduction = 1, want 2`), GREEN after.

## Expected impact
Every endpoint with a tested handler flips covered. On upvate-v3 the uncovered list was 100% endpoints, so the coverage % should rise materially (endpoints stop being a dead drag on the denominator). Exact live % confirmed by the coordinator via MCP `test_coverage` after a daemon rebuild + reindex.

## Gates
- `go build ./...` ✅
- `go vet ./internal/graph/... ./internal/mcp/...` ✅
- `go test ./internal/graph/... ./internal/mcp/...` ✅

DEPLOY-DEFERRED — live confirmation pending daemon rebuild.

Closes #4553

🤖 Generated with [Claude Code](https://claude.com/claude-code)