### PR TITLE
fix(dashboard): resolve source-peek refs through owning repo in multi-repo groups (#4551)

### DIFF
--- a/internal/dashboard/handlers_coverage.go
+++ b/internal/dashboard/handlers_coverage.go
@@ -120,7 +120,13 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 		result.TotalTests += report.TotalTests
 		result.TotalTestsEdges += report.TotalTestsEdges
 
-		// Merge uncovered entities.
+		// Merge uncovered entities, stamping the owning repo slug so the UI can
+		// resolve each entity's source through the correct repo root in a
+		// multi-repo group (#4551). ComputeCoverage runs per-document and does
+		// not know the slug, so it is the aggregator's job to attach it here.
+		for i := range report.UncoveredEntities {
+			report.UncoveredEntities[i].Repo = rp.Slug
+		}
 		result.UncoveredEntities = append(result.UncoveredEntities, report.UncoveredEntities...)
 
 		// Merge per-directory stats.

--- a/internal/dashboard/v2_source.go
+++ b/internal/dashboard/v2_source.go
@@ -175,9 +175,11 @@ func (s *Server) handleV2Source(w http.ResponseWriter, r *http.Request) {
 // disk within a repo of grp, guarding against path traversal. It returns the
 // absolute path, the owning repo slug, the cleaned repo-relative path, and ok.
 //
-// When wantRepo is set we only consider that repo; otherwise we try each repo
-// root and accept the first where the file exists on disk and stays within the
-// root.
+// When wantRepo is set we try that repo first, but if the file is not found
+// there (a stale/wrong hint, or a group name passed in place of a slug, #4551)
+// we fall back to scanning every repo root in the group. Otherwise we try each
+// repo root and accept the first where the file exists on disk and stays within
+// the root.
 func resolveSourcePath(grp *DashGroup, rawFile, wantRepo string) (abs, slug, rel string, ok bool) {
 	if grp == nil {
 		return "", "", "", false
@@ -208,13 +210,19 @@ func resolveSourcePath(grp *DashGroup, rawFile, wantRepo string) (abs, slug, rel
 		return candidate, clean, true
 	}
 
+	// When the caller pins a repo, prefer it — but do NOT fail hard if the file
+	// is not there. The hint may be a group name, a stale slug, or simply wrong
+	// (e.g. an aggregated list that lost the per-entity repo, #4551). Fall back
+	// to scanning every repo root in the group so a file that genuinely exists
+	// in a sibling repo still resolves. This mirrors the entity-based path used
+	// by get_source, which always resolves through the owning repo root.
 	if wantRepo != "" {
 		if repo, found := grp.Repos[wantRepo]; found {
 			if a, rl, good := tryRepo(repo); good {
 				return a, wantRepo, rl, true
 			}
 		}
-		return "", "", "", false
+		// fall through to the all-repos scan below
 	}
 
 	for s, repo := range grp.Repos {

--- a/internal/dashboard/v2_source_test.go
+++ b/internal/dashboard/v2_source_test.go
@@ -68,6 +68,39 @@ func TestResolveSourcePath_PinnedRepo(t *testing.T) {
 	}
 }
 
+// TestResolveSourcePath_StaleRepoHintFallsBackToGroupScan reproduces the
+// upvate-v3 / core-backend-v3 source-peek failure (#4551). The frontend passed
+// the GROUP name ("upvate-v3") as the repo hint instead of the entity's owning
+// repo slug ("core-backend-v3"), and the file lives in a repo that is NOT the
+// first one in the group. Before the fix the pinned-but-missing hint failed
+// hard ("file not found in any repo"); now it falls back to scanning every
+// repo root and resolves the file in its real repo.
+func TestResolveSourcePath_StaleRepoHintFallsBackToGroupScan(t *testing.T) {
+	rootEmpty := t.TempDir()       // an unrelated repo, first in iteration sometimes
+	rootBackend := t.TempDir()     // the repo that actually holds the file
+	writeRepoFile(t, rootBackend, "src/app.controller.ts", "export class AppController {}\n")
+
+	grp := &DashGroup{Repos: map[string]*DashRepo{
+		"frontend":        {Slug: "frontend", Path: rootEmpty},
+		"core-backend-v3": {Slug: "core-backend-v3", Path: rootBackend},
+	}}
+
+	// Hint is the GROUP name, which is not a repo slug — must not fail hard.
+	abs, slug, rel, ok := resolveSourcePath(grp, "src/app.controller.ts", "upvate-v3")
+	if !ok {
+		t.Fatalf("expected fallback scan to resolve file despite stale repo hint")
+	}
+	if slug != "core-backend-v3" {
+		t.Errorf("slug = %q; want core-backend-v3", slug)
+	}
+	if rel != "src/app.controller.ts" {
+		t.Errorf("rel = %q; want src/app.controller.ts", rel)
+	}
+	if !strings.HasPrefix(abs, rootBackend) {
+		t.Errorf("abs %q not under rootBackend %q", abs, rootBackend)
+	}
+}
+
 func TestResolveSourcePath_RejectsTraversal(t *testing.T) {
 	root := t.TempDir()
 	// Secret lives OUTSIDE the repo root.

--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -87,6 +87,12 @@ type UncoveredEntity struct {
 	StartLine  int    `json:"start_line"`
 	Language   string `json:"language"`
 	Module     string `json:"module,omitempty"`
+	// Repo is the slug of the owning repository. ComputeCoverage runs on a
+	// single document and leaves this empty; the group-level aggregator stamps
+	// it so the UI can resolve source through the correct repo root in a
+	// multi-repo group (#4551). Without it, a source-peek ref like
+	// "src/app.controller.ts:9" cannot be mapped to the repo it lives in.
+	Repo string `json:"repo,omitempty"`
 	// Severity is "high" | "medium" | "low".
 	Severity string `json:"severity"`
 }

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1818,6 +1818,13 @@ export interface UncoveredEntity {
   start_line: number;
   language: string;
   module?: string;
+  /**
+   * Owning repository slug, stamped by the group-level coverage aggregator
+   * (#4551). Used to resolve the entity's source through the correct repo
+   * root in a multi-repo group. May be absent on older backends — callers
+   * should fall back to the group-level repo only as a last resort.
+   */
+  repo?: string;
   /** "high" | "medium" | "low". */
   severity: string;
 }

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -459,6 +459,10 @@ function CoverageTree({ dirs }: { dirs: DirCoverage[] }) {
 }
 
 function UncoveredRow({ u, repo }: { u: UncoveredEntity; repo: string }) {
+  // Prefer the entity's own repo slug (stamped by the aggregator, #4551) so
+  // source-peek resolves through the correct repo root in a multi-repo group.
+  // The `repo` prop is the group-level slug and is only a last-resort fallback.
+  const entityRepo = u.repo || repo;
   return (
     <div className="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg border border-border bg-surface hover:bg-surface-2 transition-colors">
       <div className="flex items-center gap-2 min-w-0">
@@ -473,10 +477,10 @@ function UncoveredRow({ u, repo }: { u: UncoveredEntity; repo: string }) {
         </div>
       </div>
       <div className="flex items-center gap-2 min-w-0 -mx-1">
-        <RepoChip slug={repo} className="text-[10px] shrink-0" />
+        <RepoChip slug={entityRepo} className="text-[10px] shrink-0" />
         {u.source_file ? (
           <RefLine
-            repo={repo}
+            repo={entityRepo}
             file={u.source_file}
             line={u.start_line ?? 0}
             name={u.language ?? ""}


### PR DESCRIPTION
## Problem

The dashboard source-peek modal showed **"Could not load source — file not found in any repo of this group (or outside repo root)"** for `file:line` refs like `src/app.controller.ts:9` in group `upvate-v3`, even though the file exists and MCP `get_source` resolves it fine. The group contains repo slug `core-backend-v3` rooted at a path the bare relative ref was never mapped to.

## Root cause

The entity-based path (`get_source`) resolves source via the entity's owning repo slug → repo root → relative `source_file`. The Quality coverage drill-down's source-peek did **not**:

- The group-level coverage aggregator (`handleQualityCoverage`) merged uncovered entities from every repo but never recorded **which** repo each came from.
- `UncoveredEntity` had no `repo` field, so the frontend `UncoveredRow` fell back to passing the **group name** (`upvate-v3`) as the source-peek repo hint.
- `resolveSourcePath` treated a pinned-but-missing repo hint as a hard failure instead of scanning the group's other repo roots.

## Fix (long-term, framework-general)

- **Backend:** add `Repo` to `graph.UncoveredEntity`; the aggregator stamps each entity's owning repo slug when merging per-repo coverage reports.
- **Frontend:** `UncoveredRow` uses the entity's own `u.repo` for both the source-peek hint and the repo chip, falling back to the group slug only when absent.
- **Resolution path:** `resolveSourcePath` now tries the pinned repo first, then falls back to scanning every registered repo root in the group — mirroring the authoritative entity-based `get_source` resolution — instead of failing hard on a stale/wrong hint.
- **Test:** new `TestResolveSourcePath_StaleRepoHintFallsBackToGroupScan` reproduces the `upvate-v3 / core-backend-v3` case (file in a non-first repo, hint is a group name).

## Gates

- `go build ./...` ✓
- `go vet ./internal/dashboard/...` ✓
- `go test ./internal/dashboard/...` ✓ (+ `./internal/graph/` ✓)
- `npm ci && npx tsc --noEmit && npx vite build` ✓

Closes #4551

🤖 Generated with [Claude Code](https://claude.com/claude-code)