### PR TITLE
feat(quality): drill coverage tree directory → file → leaf (#4552)

### DIFF
--- a/internal/dashboard/handlers_coverage.go
+++ b/internal/dashboard/handlers_coverage.go
@@ -46,7 +46,11 @@ type GroupCoverageReport struct {
 	// the ?limit query parameter (default 200).
 	UncoveredEntities []graph.UncoveredEntity `json:"uncovered_entities"`
 	ByDirectory       []graph.DirCoverage     `json:"by_directory"`
-	ByModule          []graph.ModuleCoverage  `json:"by_module"`
+	// ByFile is the per-file breakdown (deepest grouping). Directory rollups in
+	// ByDirectory are sums of their files; the frontend nests files under their
+	// directory using the shared path segments.
+	ByFile   []graph.FileCoverage   `json:"by_file"`
+	ByModule []graph.ModuleCoverage `json:"by_module"`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -90,8 +94,13 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 	// Accumulate per-directory and per-module maps for aggregation.
 	type dirAccum struct{ total, covered int }
 	type modAccum struct{ total, covered int }
+	type fileAccum struct {
+		dir            string
+		total, covered int
+	}
 	dirAcc := make(map[string]*dirAccum)
 	modAcc := make(map[string]*modAccum)
+	fileAcc := make(map[string]*fileAccum)
 
 	// S8 (#2159): use the cached group to avoid per-request LoadGraphFromDir.
 	cachedGrpCov, _ := s.graphs.GetGroupCached(groupName)
@@ -130,6 +139,15 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 			}
 			dirAcc[d.Dir].total += d.Total
 			dirAcc[d.Dir].covered += d.Covered
+		}
+
+		// Merge per-file stats.
+		for _, f := range report.ByFile {
+			if _, ok := fileAcc[f.File]; !ok {
+				fileAcc[f.File] = &fileAccum{dir: f.Dir}
+			}
+			fileAcc[f.File].total += f.Total
+			fileAcc[f.File].covered += f.Covered
 		}
 
 		// Merge per-module stats.
@@ -195,6 +213,27 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(result.ByDirectory, func(i, j int) bool {
 		return result.ByDirectory[i].Dir < result.ByDirectory[j].Dir
+	})
+
+	// ── build ByFile with the same optional dir prefix filter ─────────────────
+	for f, acc := range fileAcc {
+		if filterDir != "" && !strings.HasPrefix(acc.dir, filterDir) {
+			continue
+		}
+		covPct := 0.0
+		if acc.total > 0 {
+			covPct = 100.0 * float64(acc.covered) / float64(acc.total)
+		}
+		result.ByFile = append(result.ByFile, graph.FileCoverage{
+			File:        f,
+			Dir:         acc.dir,
+			Total:       acc.total,
+			Covered:     acc.covered,
+			CoveragePct: covPct,
+		})
+	}
+	sort.Slice(result.ByFile, func(i, j int) bool {
+		return result.ByFile[i].File < result.ByFile[j].File
 	})
 
 	// ── build ByModule with optional name filter ──────────────────────────────

--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -68,6 +68,12 @@ type CoverageReport struct {
 	// directory path. Only directories with ≥1 production entity are included.
 	ByDirectory []DirCoverage `json:"by_directory"`
 
+	// ByFile contains per-file coverage statistics, sorted by file path. Only
+	// files with ≥1 production entity are included. Directory rollups in
+	// ByDirectory are sums of the files sharing their directory, so the
+	// frontend can nest files under their directory using the path segments.
+	ByFile []FileCoverage `json:"by_file"`
+
 	// ByModule contains per-module (Properties["module"]) coverage statistics.
 	// Only populated when entities carry the "module" property.
 	ByModule []ModuleCoverage `json:"by_module"`
@@ -93,6 +99,17 @@ type UncoveredEntity struct {
 
 // DirCoverage is per-directory coverage statistics.
 type DirCoverage struct {
+	Dir         string  `json:"dir"`
+	Total       int     `json:"total"`
+	Covered     int     `json:"covered"`
+	CoveragePct float64 `json:"coverage_pct"`
+}
+
+// FileCoverage is per-file coverage statistics. File is the full source path
+// (forward-slash normalised); Dir is its parent directory (matching the keys
+// in ByDirectory) so the frontend can nest files under directories.
+type FileCoverage struct {
+	File        string  `json:"file"`
 	Dir         string  `json:"dir"`
 	Total       int     `json:"total"`
 	Covered     int     `json:"covered"`
@@ -739,9 +756,16 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 		return report.UncoveredEntities[i].Name < report.UncoveredEntities[j].Name
 	})
 
-	// ── per-directory breakdown ───────────────────────────────────────────────
-	type dirStat struct{ total, covered int }
-	dirStats := make(map[string]*dirStat)
+	// ── per-directory & per-file breakdown ────────────────────────────────────
+	// Files are the deepest grouping; directory rollups are the sums of the
+	// files that live under them.
+	type covStat struct{ total, covered int }
+	dirStats := make(map[string]*covStat)
+	type fileStat struct {
+		dir            string
+		total, covered int
+	}
+	fileStats := make(map[string]*fileStat)
 
 	for id, e := range entByID {
 		if !prodIDs[id] {
@@ -749,11 +773,19 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 		}
 		d := dirOf(e.SourceFile)
 		if _, ok := dirStats[d]; !ok {
-			dirStats[d] = &dirStat{}
+			dirStats[d] = &covStat{}
 		}
 		dirStats[d].total++
+
+		f := filepath.ToSlash(e.SourceFile)
+		if _, ok := fileStats[f]; !ok {
+			fileStats[f] = &fileStat{dir: d}
+		}
+		fileStats[f].total++
+
 		if covered[id] > 0 {
 			dirStats[d].covered++
+			fileStats[f].covered++
 		}
 	}
 
@@ -767,6 +799,19 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 	}
 	sort.Slice(report.ByDirectory, func(i, j int) bool {
 		return report.ByDirectory[i].Dir < report.ByDirectory[j].Dir
+	})
+
+	for f, s := range fileStats {
+		report.ByFile = append(report.ByFile, FileCoverage{
+			File:        f,
+			Dir:         s.dir,
+			Total:       s.total,
+			Covered:     s.covered,
+			CoveragePct: pct(s.covered, s.total),
+		})
+	}
+	sort.Slice(report.ByFile, func(i, j int) bool {
+		return report.ByFile[i].File < report.ByFile[j].File
 	})
 
 	// ── per-module breakdown ──────────────────────────────────────────────────

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -275,6 +275,66 @@ func TestComputeCoverage_ByDirectory(t *testing.T) {
 	}
 }
 
+// TestComputeCoverage_ByFile checks per-file aggregation (the deepest tier)
+// and that directory rollups equal the sum of their files (#4552).
+func TestComputeCoverage_ByFile(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		{ID: "p1", Name: "Foo", Kind: "Function", SourceFile: "pkg/foo/foo.go"},
+		{ID: "p2", Name: "Foo2", Kind: "Function", SourceFile: "pkg/foo/foo.go"},
+		{ID: "p3", Name: "Bar", Kind: "Function", SourceFile: "pkg/foo/bar.go"},
+		{ID: "p4", Name: "Baz", Kind: "Function", SourceFile: "pkg/baz/baz.go"},
+		{ID: "t1", Name: "TestFoo", Kind: "Function", SourceFile: "pkg/foo/foo_test.go"},
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "t1", ToID: "p1", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+
+	fileMap := make(map[string]FileCoverage)
+	for _, f := range report.ByFile {
+		fileMap[f.File] = f
+	}
+	fooFile := fileMap["pkg/foo/foo.go"]
+	if fooFile.Total != 2 || fooFile.Covered != 1 {
+		t.Errorf("pkg/foo/foo.go want total=2 covered=1, got total=%d covered=%d",
+			fooFile.Total, fooFile.Covered)
+	}
+	if fooFile.Dir != "pkg/foo" {
+		t.Errorf("pkg/foo/foo.go dir want pkg/foo, got %q", fooFile.Dir)
+	}
+	barFile := fileMap["pkg/foo/bar.go"]
+	if barFile.Total != 1 || barFile.Covered != 0 {
+		t.Errorf("pkg/foo/bar.go want total=1 covered=0, got total=%d covered=%d",
+			barFile.Total, barFile.Covered)
+	}
+	bazFile := fileMap["pkg/baz/baz.go"]
+	if bazFile.Total != 1 || bazFile.Covered != 0 {
+		t.Errorf("pkg/baz/baz.go want total=1 covered=0, got total=%d covered=%d",
+			bazFile.Total, bazFile.Covered)
+	}
+
+	// Directory rollups must equal the sum of their files.
+	dirMap := make(map[string]DirCoverage)
+	for _, d := range report.ByDirectory {
+		dirMap[d.Dir] = d
+	}
+	fileSum := make(map[string]struct{ total, covered int })
+	for _, f := range report.ByFile {
+		s := fileSum[f.Dir]
+		s.total += f.Total
+		s.covered += f.Covered
+		fileSum[f.Dir] = s
+	}
+	for dir, d := range dirMap {
+		s := fileSum[dir]
+		if d.Total != s.total || d.Covered != s.covered {
+			t.Errorf("dir %q rollup want total=%d covered=%d (file sum), got total=%d covered=%d",
+				dir, s.total, s.covered, d.Total, d.Covered)
+		}
+	}
+}
+
 // TestComputeCoverage_ByModule checks per-module aggregation.
 func TestComputeCoverage_ByModule(t *testing.T) {
 	t.Parallel()

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1830,6 +1830,15 @@ export interface DirCoverage {
   coverage_pct: number;
 }
 
+/** Per-file coverage statistics (deepest grouping under a directory). */
+export interface FileCoverage {
+  file: string;
+  dir: string;
+  total: number;
+  covered: number;
+  coverage_pct: number;
+}
+
 /** Per-module coverage statistics. */
 export interface ModuleCoverage {
   module: string;
@@ -1849,6 +1858,7 @@ export interface GroupCoverageReport {
   repos: number;
   uncovered_entities: UncoveredEntity[];
   by_directory: DirCoverage[];
+  by_file: FileCoverage[];
   by_module: ModuleCoverage[];
 }
 

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -39,6 +39,7 @@ import {
   ChevronRight,
   Folder,
   FolderOpen,
+  FileCode2,
 } from "lucide-react";
 
 import {
@@ -70,6 +71,7 @@ import {
 import type {
   UncoveredEntity,
   DirCoverage,
+  FileCoverage,
   PackageEntry,
   RepoDepSummary,
   NPlusOneFinding,
@@ -322,44 +324,91 @@ interface CovTreeNode {
   depth: number;
   covered: number;
   total: number;
+  /** True when this node is a source file (deepest leaf), not a directory. */
+  isFile: boolean;
   children: CovTreeNode[];
 }
 
 /**
- * Build a nested folder tree from the flat per-directory coverage list.
- * Each leaf dir's covered/total counts are added to every ancestor so parent
- * folders report rolled-up aggregates. Intermediate folders that the backend
- * never emitted directly are synthesised so the hierarchy is complete.
+ * Build a nested folder tree from the flat per-file coverage list (falling
+ * back to the per-directory list when no files are available).
+ *
+ * Files are the deepest leaves: a file like `src/modules/aoc/aoc.controller.ts`
+ * nests under each of its directory segments, with the basename as a file leaf.
+ * Each file's covered/total counts roll up into every ancestor directory so
+ * folders report aggregates that match the backend's directory rollups.
+ * Intermediate folders the backend never emitted directly are synthesised so
+ * the hierarchy is complete.
  */
-function buildCoverageTree(dirs: DirCoverage[]): CovTreeNode[] {
-  const root: CovTreeNode = { name: "", path: "", depth: -1, covered: 0, total: 0, children: [] };
+function buildCoverageTree(dirs: DirCoverage[], files: FileCoverage[]): CovTreeNode[] {
+  const root: CovTreeNode = {
+    name: "",
+    path: "",
+    depth: -1,
+    covered: 0,
+    total: 0,
+    isFile: false,
+    children: [],
+  };
 
   const childByPath = new Map<string, CovTreeNode>();
-  const ensureChild = (parent: CovTreeNode, name: string): CovTreeNode => {
+  const ensureChild = (parent: CovTreeNode, name: string, isFile: boolean): CovTreeNode => {
     const path = parent.path ? `${parent.path}/${name}` : name;
     let node = childByPath.get(path);
     if (!node) {
-      node = { name, path, depth: parent.depth + 1, covered: 0, total: 0, children: [] };
+      node = {
+        name,
+        path,
+        depth: parent.depth + 1,
+        covered: 0,
+        total: 0,
+        isFile,
+        children: [],
+      };
       childByPath.set(path, node);
       parent.children.push(node);
     }
     return node;
   };
 
-  for (const d of dirs) {
-    const segments = (d.dir || "(root)").split("/").filter(Boolean);
-    if (segments.length === 0) segments.push("(root)");
-    let cursor = root;
-    for (const seg of segments) {
-      cursor = ensureChild(cursor, seg);
-      // Roll the leaf's counts up into this ancestor (and the leaf itself).
-      cursor.covered += d.covered;
-      cursor.total += d.total;
+  if (files.length > 0) {
+    // File-level tree: walk directory segments, then add the file basename as a
+    // leaf. Roll each file's counts up into every ancestor directory.
+    for (const f of files) {
+      const fileSegs = (f.file || "").split("/").filter(Boolean);
+      if (fileSegs.length === 0) continue;
+      const base = fileSegs[fileSegs.length - 1];
+      const dirSegs = fileSegs.slice(0, -1);
+      let cursor = root;
+      for (const seg of dirSegs) {
+        cursor = ensureChild(cursor, seg, false);
+        cursor.covered += f.covered;
+        cursor.total += f.total;
+      }
+      const fileNode = ensureChild(cursor, base, true);
+      fileNode.covered += f.covered;
+      fileNode.total += f.total;
+    }
+  } else {
+    // Fallback: directory-only tree (legacy payloads without by_file).
+    for (const d of dirs) {
+      const segments = (d.dir || "(root)").split("/").filter(Boolean);
+      if (segments.length === 0) segments.push("(root)");
+      let cursor = root;
+      for (const seg of segments) {
+        cursor = ensureChild(cursor, seg, false);
+        cursor.covered += d.covered;
+        cursor.total += d.total;
+      }
     }
   }
 
   const sortRec = (nodes: CovTreeNode[]) => {
-    nodes.sort((a, b) => a.name.localeCompare(b.name));
+    // Directories before files, then alphabetical.
+    nodes.sort((a, b) => {
+      if (a.isFile !== b.isFile) return a.isFile ? 1 : -1;
+      return a.name.localeCompare(b.name);
+    });
     nodes.forEach((n) => sortRec(n.children));
   };
   sortRec(root.children);
@@ -401,7 +450,9 @@ function CovTreeRow({
           ) : null}
         </span>
         <span className="shrink-0 text-text-4">
-          {hasChildren ? (
+          {node.isFile ? (
+            <FileCode2 size={13} className="text-text-3" />
+          ) : hasChildren ? (
             isOpen ? (
               <FolderOpen size={13} className="text-accent" />
             ) : (
@@ -435,8 +486,8 @@ function CovTreeRow({
   );
 }
 
-function CoverageTree({ dirs }: { dirs: DirCoverage[] }) {
-  const tree = useMemo(() => buildCoverageTree(dirs), [dirs]);
+function CoverageTree({ dirs, files }: { dirs: DirCoverage[]; files: FileCoverage[] }) {
+  const tree = useMemo(() => buildCoverageTree(dirs, files), [dirs, files]);
   // Default: top level expanded, deeper collapsed.
   const [expanded, setExpanded] = useState<Set<string>>(
     () => new Set(tree.map((n) => n.path)),
@@ -535,9 +586,10 @@ function CoverageTab({ groupId }: { groupId: string }) {
               <MetricInfo
                 hint={
                   <>
-                    Coverage rolled up into a folder tree. Each folder aggregates the
-                    covered ÷ total entity counts of everything beneath it; expand a
-                    folder to drill into subdirectories. Bar color: red &lt;50%, amber
+                    Coverage rolled up into a folder tree, drilling directory →
+                    file. Each folder aggregates the covered ÷ total entity counts
+                    of everything beneath it; expand a folder to reach its
+                    subdirectories and source files. Bar color: red &lt;50%, amber
                     50–80%, green 80%+.
                   </>
                 }
@@ -546,7 +598,7 @@ function CoverageTab({ groupId }: { groupId: string }) {
             <span className="text-[11px] text-text-4">expand to drill in</span>
           </CardHeader>
           <CardBody className="space-y-1.5">
-            <CoverageTree dirs={data.by_directory} />
+            <CoverageTree dirs={data.by_directory} files={data.by_file ?? []} />
           </CardBody>
         </Card>
       )}


### PR DESCRIPTION
## What

Extends the Quality "By directory" coverage tree (#4518) to drill **directory → file → leaf**, with source files as the deepest grouping. Closes #4552.

## Backend

`internal/graph/coverage.go`
- New `FileCoverage` type (`file`, `dir`, `total`, `covered`, `coverage_pct`) and `ByFile []FileCoverage` field on `CoverageReport` (JSON `by_file`).
- Per-file stats are computed in the same pass as the existing per-directory rollups. Directory rollups remain the exact sum of their files; the coverage % math is unchanged — only the file tier is added.

`internal/dashboard/handlers_coverage.go`
- `GroupCoverageReport` gains `by_file`. The handler aggregates `by_file` across repos and applies the same `?dir=` prefix filter as `by_directory`.

## Frontend

`webui-v2/src/routes/quality.tsx`
- `buildCoverageTree` now nests files under their directory path segments (e.g. `src/modules/aoc/aoc.controller.ts` nests under each dir then a `aoc.controller.ts` file leaf), rolling each file's covered/total up into ancestor folders. Falls back to the directory-only tree for legacy payloads without `by_file`.
- File leaves render with a distinct file icon (`FileCode2`) vs folder icons, reusing the existing tree/row styling, coverage bar and covered/total counts. Directories sort before files within a folder.

`webui-v2/src/data/types.ts`
- `FileCoverage` interface + `by_file` on `GroupCoverageReport`.

## Payload shape change

`GET /api/quality/coverage/{group}` now additionally returns:

```json
"by_file": [
  { "file": "pkg/foo/foo.go", "dir": "pkg/foo", "total": 2, "covered": 1, "coverage_pct": 50 }
]
```

Purely additive — `by_directory` is untouched.

## Gates

- `go build ./...` ✅ · `go vet ./internal/dashboard/... ./internal/graph/...` ✅ · `go test ./internal/dashboard/... ./internal/graph/...` ✅ (added `TestComputeCoverage_ByFile` asserting per-file counts + dir-rollup = sum-of-files)
- `npm ci` ✅ · `npx tsc --noEmit` ✅ · `npx vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
