### PR TITLE
feat(webui): color exception/error nodes red on the flow DAG (#4556)

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDagLegend.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagLegend.tsx
@@ -8,7 +8,7 @@
 
 import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { ROLE_STYLE, EDGE_STYLE } from "./style";
+import { ROLE_STYLE, EXCEPTION_STYLE, EDGE_STYLE } from "./style";
 import type { DownstreamDAGTruncation } from "@/data/types";
 
 interface FlowDagLegendProps {
@@ -31,8 +31,8 @@ export function FlowDagLegend({ branchCount, nodeCount, truncation }: FlowDagLeg
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2 text-[10px] text-text-3 border-t border-border bg-bg-soft">
-      {/* Roles */}
-      {Object.values(ROLE_STYLE).map((rs) => (
+      {/* Roles + the exception/error node accent (#4556, red). */}
+      {[...Object.values(ROLE_STYLE), EXCEPTION_STYLE].map((rs) => (
         <span key={rs.label} className="inline-flex items-center gap-1">
           <span
             className="size-2.5 rounded-sm shrink-0"

--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -21,7 +21,7 @@ import { cn } from "@/lib/utils";
 import { RepoChip } from "@/lib/repo-color";
 import { effectBadge } from "@/lib/effect-badge";
 import { useSourcePeek } from "@/components/SourcePeek";
-import { roleStyle, edgeStyle } from "./style";
+import { nodeStyle, edgeStyle } from "./style";
 import type { FlowDagNodeData } from "./layout";
 
 /**
@@ -32,7 +32,9 @@ import type { FlowDagNodeData } from "./layout";
 function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps) {
   const { node, edgeKind, expanded, onToggleExpand, selected, onRoute } =
     data as FlowDagNodeData;
-  const rs = roleStyle(node.role);
+  // Exception/error nodes paint red (#4556); otherwise the role tint. The red
+  // hue matches the THROWS edge so a thrown error reads consistently node→edge.
+  const rs = nodeStyle(node, edgeKind);
   const { openSourcePeek } = useSourcePeek();
   const { groupId = "" } = useParams<{ groupId: string }>();
   const collapsed = node.collapsed_children ?? [];

--- a/webui-v2/src/components/flow-dag/style.ts
+++ b/webui-v2/src/components/flow-dag/style.ts
@@ -9,6 +9,7 @@
 
 import type {
   DownstreamDAGEdgeKind,
+  DownstreamDAGNode,
   DownstreamDAGRole,
 } from "@/data/types";
 
@@ -36,6 +37,52 @@ export const ROLE_STYLE: Record<DownstreamDAGRole, RoleStyle> = {
 /** Fallback for an unexpected/missing role — render as a generic node. */
 export function roleStyle(role: DownstreamDAGRole | undefined): RoleStyle {
   return (role && ROLE_STYLE[role]) || ROLE_STYLE.node;
+}
+
+/**
+ * Exception/error node styling (#4556). A red tint + red ink so a node where an
+ * error is raised stands out from the neutral spine. The hue matches the red
+ * THROWS edge (--danger) so a thrown error reads consistently node→edge; the
+ * ink is a contrast-tuned red (--exception-ink) that stays legible as the pill
+ * text + border over the @22% danger wash in BOTH light and dark themes.
+ */
+export const EXCEPTION_STYLE: RoleStyle = {
+  bg: "var(--danger)",
+  ink: "var(--exception-ink)",
+  label: "Exception",
+};
+
+/**
+ * Detect whether a node represents an exception/error site so it can be painted
+ * red. Conservative, signal-based (#4556): the node's KIND is ExceptionType, OR
+ * its name carries the canonical "exception:" prefix, OR the parent reached it
+ * via a THROWS edge (it's the target of a throw). We deliberately do NOT paint
+ * every node whose name merely contains "Error"/"Exception" — that over-paints
+ * ordinary error-handling helpers. `incomingEdgeKind` is the kind of the single
+ * in-edge feeding this rendered instance (undefined for the root).
+ */
+export function isExceptionNode(
+  node: Pick<DownstreamDAGNode, "kind" | "name">,
+  incomingEdgeKind?: DownstreamDAGEdgeKind,
+): boolean {
+  return (
+    node.kind === "ExceptionType" ||
+    node.name.startsWith("exception:") ||
+    incomingEdgeKind === "THROWS"
+  );
+}
+
+/**
+ * Resolve the node body style: an exception/error node gets the red EXCEPTION
+ * palette; otherwise it falls back to its role tint. Used by the node renderer.
+ */
+export function nodeStyle(
+  node: Pick<DownstreamDAGNode, "kind" | "name" | "role">,
+  incomingEdgeKind?: DownstreamDAGEdgeKind,
+): RoleStyle {
+  return isExceptionNode(node, incomingEdgeKind)
+    ? EXCEPTION_STYLE
+    : roleStyle(node.role);
 }
 
 /** Per-edge-kind styling: stroke color, dashed?, and a short label. */

--- a/webui-v2/src/styles/tokens.css
+++ b/webui-v2/src/styles/tokens.css
@@ -69,6 +69,12 @@
   --pastel-9-ink:  #59659e;   /* 4.76:1 */
   --pastel-10-ink: #8c632f;   /* 4.78:1 */
 
+  /* Exception/error node ink (#4556). The danger-tinted node body washes
+     --danger @22% over surface (≈ #f9d0d0 in light); this darkened red clears
+     WCAG AA as the pill text + border accent over that wash. Hue matches the
+     red THROWS edge so a thrown error reads consistently across node + edge. */
+  --exception-ink: #b91c1c;   /* 4.9:1 over the @22% light wash */
+
   /* -- Skeleton / loading placeholders -- */
   --skeleton-base:      #e2e6ed;   /* noticeably darker than surface-2 (#f3f5f8) */
   --skeleton-highlight: #edf0f5;   /* shimmer highlight — lighter band */
@@ -214,6 +220,10 @@
   --pastel-8-ink:  #e1aabb;
   --pastel-9-ink:  #b1b8d9;
   --pastel-10-ink: #e8be93;
+
+  /* Exception/error node ink (#4556) — light red, legible on the dark
+     danger-tinted node body (--danger @22% over the dark surface). */
+  --exception-ink: #f0a8a8;
 
   /* -- Skeleton / loading placeholders -- */
   --skeleton-base:      #2a3140;   /* clearly lighter than surface (#1a1f2b) */


### PR DESCRIPTION
Closes #4556

## Problem
On the dashboard flow/graph views only the `THROWS` **edge** was red. The exception/error **node** it pointed at still used the neutral role palette, so users couldn't visually spot where errors are raised.

## Change (frontend only — `webui-v2`)
- **`flow-dag/style.ts`** — new `EXCEPTION_STYLE` (red tint + `--exception-ink`) plus `isExceptionNode()` / `nodeStyle()` helpers. Detection is conservative and signal-based:
  - `kind === "ExceptionType"`, **or**
  - name prefix `exception:`, **or**
  - the node is the target of a `THROWS` edge (the rendered instance's incoming `edgeKind === "THROWS"`).

  Nodes whose names merely contain `Error`/`Exception` are deliberately **not** painted.
- **`flow-dag/FlowDagNode.tsx`** — renders via `nodeStyle(node, edgeKind)`, so an exception node gets the red body wash, border, role pill ("Exception"), and terminal ring. The red hue reuses `--danger`, matching the `THROWS` edge so a thrown error reads consistently node → edge.
- **`styles/tokens.css`** — new `--exception-ink` token (light `#b91c1c`, dark `#f0a8a8`), contrast-tuned to stay legible as pill text/border over the `--danger @22%` node-body wash in **both** light and dark themes. The node name keeps the neutral `--text` token (already AA on the light wash).
- **`flow-dag/FlowDagLegend.tsx`** — adds a red **Exception** node swatch alongside the existing Endpoint/Handler/Node/Collection swatches.

The shared `<FlowDag>` powers both the downstream-flow branching tree (Paths → endpoints tab) and the Flows DAG, so both views get the red exception nodes.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅
- `npx vite build` ✅
- flow-dag `layout.test.ts` (6 tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)