### PR TITLE
fix(resolve): suppress phantom scope.operation handler duplicate (#4554)

### DIFF
--- a/internal/resolve/operation_bare_qualified_4554_test.go
+++ b/internal/resolve/operation_bare_qualified_4554_test.go
@@ -1,0 +1,81 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4554 — same-file bare↔qualified method reconciliation for the
+// `scope:operation:method:<lang>:<file>:<bare>` synthesis-time endpoint→handler
+// bridge. NestJS (and every other producer synthesizer) stamps the bridge with
+// the BARE method name, while the real controller method is indexed QUALIFIED
+// (`Controller.method`). Without reconciliation the bridge's structural ref is
+// left unresolved, surfacing as a phantom grey `scope.operation` handler node
+// (no source file) that duplicates the real method — the endpoint shows TWO
+// handlers. After the fix the bare structural ref binds to the qualified method
+// so there is exactly ONE handler.
+func TestReferences_OperationBareQualified_4554(t *testing.T) {
+	const file = "src/modules/buildings/api/building.controller.ts"
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Operation", "BuildingController.updateBuilding", file),
+	}
+	idx := BuildIndex(entities)
+
+	// The bare-name synthesis-time bridge structural ref.
+	rels := []types.RelationshipRecord{{
+		FromID: "scope:operation:method:typescript:" + file + ":updateBuilding",
+		ToID:   "http_endpoint_definition:http:PUT:/buildings/{id}",
+		Kind:   "IMPLEMENTS",
+	}}
+	References(rels, idx)
+
+	if rels[0].FromID != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("bare structural ref did not bind to the qualified method "+
+			"(phantom scope.operation handler duplicate): FromID=%s", rels[0].FromID)
+	}
+}
+
+// Genuinely-unresolved handlers must still NOT bind (no false positive): a bare
+// method name with no matching same-file method leaves the stub intact so the
+// fallback paths / honest unresolved disposition still apply.
+func TestReferences_OperationBareQualified_4554_Unresolved(t *testing.T) {
+	const file = "src/modules/buildings/api/building.controller.ts"
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Operation", "BuildingController.updateBuilding", file),
+	}
+	idx := BuildIndex(entities)
+
+	rels := []types.RelationshipRecord{{
+		FromID: "scope:operation:method:typescript:" + file + ":noSuchMethod",
+		ToID:   "http_endpoint_definition:http:GET:/buildings",
+		Kind:   "IMPLEMENTS",
+	}}
+	References(rels, idx)
+
+	if rels[0].FromID == "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("unrelated bare name must not bind to a same-file method")
+	}
+}
+
+// Ambiguous: two same-file methods share the bare name → no guess (stub kept).
+func TestReferences_OperationBareQualified_4554_Ambiguous(t *testing.T) {
+	const file = "src/modules/buildings/api/building.controller.ts"
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Operation", "BuildingController.handle", file),
+		entAt("bbbbbbbbbbbbbbbb", "SCOPE.Operation", "AuditController.handle", file),
+	}
+	idx := BuildIndex(entities)
+
+	from := "scope:operation:method:typescript:" + file + ":handle"
+	rels := []types.RelationshipRecord{{
+		FromID: from,
+		ToID:   "http_endpoint_definition:http:POST:/buildings/handle",
+		Kind:   "IMPLEMENTS",
+	}}
+	References(rels, idx)
+
+	if rels[0].FromID == "aaaaaaaaaaaaaaaa" || rels[0].FromID == "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("ambiguous bare name must not bind to either candidate: %s", rels[0].FromID)
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1910,6 +1910,51 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	// fires for the "operation" scope-kind so other Format A scopes
 	// (component, schema) aren't affected.
 	if strings.EqualFold(scopeKind, "operation") {
+		// #4554 — same-file bare↔qualified method reconciliation. A producer
+		// synthesizer (NestJS / Express / Fastify / FastAPI / Flask / JAX-RS /
+		// Axum / Rocket / …) emits the endpoint→handler synthesis-time bridge as
+		// `scope:operation:method:<lang>:<file>:<bareMethodName>` (see
+		// http_endpoint_synthesis.go synthesisHandlerStructuralRef). The real
+		// handler method, however, is frequently indexed QUALIFIED
+		// (`Controller.method` — the same shape Django/Spring/ASP.NET handlers
+		// carry), so the Format-A byLocation lookup above (keyed on the FULL
+		// name) misses on the bare tail. Without this fallback the IMPLEMENTS
+		// bridge's FromID is left an unresolved stub, which surfaces in the graph
+		// as a phantom grey `scope.operation` handler node (no source file) that
+		// DUPLICATES the real method the Phase-2 ResolveHTTPEndpointHandlers pass
+		// already bound — the endpoint then shows TWO handlers (#4554).
+		//
+		// When the bare tail is NOT itself dotted and EXACTLY ONE same-file
+		// `<scope>.<tail>` method exists, bind to it. Same-file + exactly-one
+		// makes this unambiguous (a multi-method controller still maps each
+		// endpoint to its own handler by the bare method name); >1 candidate
+		// leaves the stub for the existing fallbacks rather than guessing. This
+		// mirrors the #4319 bare↔qualified step in ResolveHTTPEndpointHandlers,
+		// but at the central resolver so the synthesis-time bridge resolves to
+		// the real method (no phantom node) for EVERY framework.
+		if strings.IndexByte(tail, dottedNameSep) < 0 {
+			if fileBucket, ok := idx.byMember[filePath]; ok {
+				var match string
+				ambig := false
+				for _, scopeBucket := range fileBucket {
+					id, ok := scopeBucket[tail]
+					if !ok || id == "" {
+						continue
+					}
+					if match != "" && match != id {
+						ambig = true
+						break
+					}
+					match = id
+				}
+				if ambig {
+					return "", statusAmbiguous, true
+				}
+				if match != "" {
+					return match, statusRewritten, true
+				}
+			}
+		}
 		if pkgDir := pkgDirOf(filePath); pkgDir != "" {
 			if pkgBucket, ok := idx.byPackageOperation[pkgDir]; ok {
 				if id, ok := pkgBucket[tail]; ok {


### PR DESCRIPTION
## Problem (#4554)

A NestJS endpoint (e.g. `PUT updateBuilding` at `src/modules/buildings/api/building.controller.ts:241`) emitted **TWO** handler nodes for the same handler:

- the real `Controller.method` `SCOPE.Operation` (with a source file), and
- a phantom grey `scope.operation` node with **no source file**.

The dashboard reaches handlers by walking IMPLEMENTS-class edges in reverse from the `http_endpoint_definition`, so the endpoint showed two handlers.

## Root cause

The `#4319` synthesis-time endpoint→handler bridge (`http_endpoint_synthesis.go` → `synthesisHandlerStructuralRef`) stamps its `FromID` as a structural ref:

```
scope:operation:method:<lang>:<file>:<bareMethodName>
```

i.e. the **bare** method name. The real controller method, however, is indexed **qualified** (`BuildingController.updateBuilding`) — the same shape Django/Spring/ASP.NET handlers carry. The central resolver's Format-A `byLocation` lookup is keyed on the **full** entity name, so the bare tail missed and the bridge's `FromID` was left an **unresolved stub**, which surfaces as a phantom `scope.operation` handler node duplicating the real method that the Phase-2 `ResolveHTTPEndpointHandlers` pass already bound.

## Fix (framework-general)

Add a same-file bare↔qualified reconciliation in `lookupStructural` for the `operation` scope: when the bare tail matches **exactly one** same-file `<scope>.<tail>` method (via the `byMember` index), bind to it. More than one candidate → ambiguous (stub kept); no match → unresolved (stub kept). No guessing.

This lives at the **central resolver**, so it repairs the synthesis-time bridge for **every** producer synthesizer that emits a bare-name handler ref (NestJS / Express / Fastify / FastAPI / Flask / JAX-RS / Axum / Rocket / …), mirroring the `#4319` step in `ResolveHTTPEndpointHandlers`. Both bridges (synthesis-time + Phase-2) now target the **same** real method node → exactly one handler.

## Tests

`internal/resolve/operation_bare_qualified_4554_test.go`:
- bare structural ref binds to the qualified same-file method (no phantom duplicate),
- a genuinely-unresolved bare name does **not** bind (fallback preserved),
- an ambiguous bare name (two same-file candidates) does **not** guess.

## Gates

`go build ./...`, `go vet ./internal/custom/... ./internal/engine/...`, and `go test ./internal/custom/... ./internal/engine/... ./internal/resolve/... ./internal/types/...` all pass (only the pre-existing tree-sitter lua cgo warning).

Live confirmation deferred to a coordinator daemon rebuild + reindex (dashboard downstream-flow).

Closes #4554

🤖 Generated with [Claude Code](https://claude.com/claude-code)