### PR TITLE
fix(exception): unify thrown exception's dangling constructor CALLS onto one node (#4555)

### DIFF
--- a/internal/external/exception_resolve.go
+++ b/internal/external/exception_resolve.go
@@ -2,6 +2,7 @@ package external
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -56,6 +57,12 @@ type ExceptionResolveStats struct {
 	// SyntheticKept is the number of synthetic SCOPE.ExceptionType nodes left
 	// in place because no unambiguous real class entity exists for them.
 	SyntheticKept int
+	// ConstructorCallsUnified is the number of constructor CALLS edges
+	// (`new <Type>()` / `raise <Type>(...)` / `throw new <Type>()`) re-pointed
+	// from a bare-name dangling target onto the surviving exception node, so a
+	// single exception node carries BOTH the `throws` and `calls` (construction)
+	// relationships (#4555).
+	ConstructorCallsUnified int
 }
 
 // candidateKind reports whether kind is a real, declaration-backed entity that
@@ -100,6 +107,17 @@ func ResolveExceptionTypes(doc *graph.Document) ExceptionResolveStats {
 	var synthetics []synthNode
 	byTypeName := map[string][]string{} // typeName -> candidate real entity ids
 
+	// allEntityIDs lets the constructor-CALLS unification (#4555) tell a real
+	// graph entity from a bare-name DANGLING CALLS target. A `new <Type>()`
+	// constructor call emits a CALLS edge whose ToID is the bare type name; when
+	// no ext:<Type> / declared-class entity was synthesised for it, that ToID
+	// resolves to NO entity and is rendered as a phantom node alongside the
+	// exception node — the second half of the duplicate this pass removes.
+	allEntityIDs := make(map[string]bool, len(doc.Entities))
+	for i := range doc.Entities {
+		allEntityIDs[doc.Entities[i].ID] = true
+	}
+
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
 		if e.Kind == string(types.EntityKindExceptionType) {
@@ -127,7 +145,14 @@ func ResolveExceptionTypes(doc *graph.Document) ExceptionResolveStats {
 	// remap from synthetic-id -> real-id and the set of synthetic ids to drop.
 	remap := map[string]string{} // synthetic id -> real entity id
 	drop := map[string]bool{}    // synthetic ids to remove
+	// survivorByExc maps every exception-node id to the id that SURVIVES this
+	// pass: the real class entity when the node is resolved+dropped, otherwise
+	// the exception node itself (kept). typeNameByExc carries the bare type name
+	// for the constructor-CALLS unification (#4555) leaf-name match.
+	survivorByExc := make(map[string]string, len(synthetics))
+	typeNameByExc := make(map[string]string, len(synthetics))
 	for _, sn := range synthetics {
+		typeNameByExc[sn.id] = sn.typeName
 		cands := byTypeName[sn.typeName]
 		// Deduplicate candidate ids (a class can appear once; guard anyway) and
 		// exclude the synthetic node itself defensively.
@@ -135,26 +160,40 @@ func ResolveExceptionTypes(doc *graph.Document) ExceptionResolveStats {
 		if len(uniq) != 1 {
 			// Zero real candidates -> genuinely external/unresolvable: keep the
 			// synthetic node. More than one -> ambiguous leaf name: keep it
-			// (precision over a possibly-wrong retarget).
+			// (precision over a possibly-wrong retarget). The kept node is the
+			// survivor that constructor CALLS edges fold onto.
+			survivorByExc[sn.id] = sn.id
 			stats.SyntheticKept++
 			continue
 		}
 		remap[sn.id] = uniq[0]
+		survivorByExc[sn.id] = uniq[0]
 		drop[sn.id] = true
 		stats.SyntheticDropped++
 	}
-	if len(remap) == 0 {
-		return stats
-	}
 
-	// Retarget THROWS / CATCHES edges. Only these two kinds point at the
-	// synthetic exception-type node, but gate on kind so an unrelated edge that
-	// happens to reference the id (none today) is never silently moved.
+	// Retarget THROWS / CATCHES edges, AND record which methods THROW each
+	// exception node. The throwing-method set is captured from the THROWS edge's
+	// ORIGINAL ToID (still the exception-node id at this point) so the
+	// constructor-CALLS unification below can require the `new <Type>()` call to
+	// originate from a method that also throws that very exception — never
+	// folding an unrelated same-named construction onto the exception node.
+	//
+	// throwsFrom: exception-node-id -> set of throwing-method FromIDs.
+	throwsFrom := map[string]map[string]bool{}
 	for k := range doc.Relationships {
 		r := &doc.Relationships[k]
 		if r.Kind != string(types.RelationshipKindThrows) &&
 			r.Kind != string(types.RelationshipKindCatches) {
 			continue
+		}
+		if r.Kind == string(types.RelationshipKindThrows) {
+			if _, isExc := survivorByExc[r.ToID]; isExc && r.FromID != "" {
+				if throwsFrom[r.ToID] == nil {
+					throwsFrom[r.ToID] = map[string]bool{}
+				}
+				throwsFrom[r.ToID][r.FromID] = true
+			}
 		}
 		if real, ok := remap[r.ToID]; ok {
 			r.ToID = real
@@ -162,6 +201,60 @@ func ResolveExceptionTypes(doc *graph.Document) ExceptionResolveStats {
 			// (FromID, ToID, Kind) — keeping incremental diffs and de-dup stable.
 			r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
 			stats.Retargeted++
+		}
+	}
+
+	// #4555 — constructor-CALLS unification. A `throw new <Type>()` (Java/C#/JS),
+	// `raise <Type>(...)` (Python), etc. emits, INDEPENDENTLY of throws-analysis,
+	// a CALLS edge to the constructor. When that target was never materialised as
+	// a real entity (no ext:<Type> placeholder, no declared class) it dangles as
+	// a bare-name ToID == <Type> and the dashboard renders it as a SECOND phantom
+	// node next to the exception node — one exception, two nodes.
+	//
+	// Fold the construction onto the surviving exception node so a SINGLE node
+	// carries both the `throws` and the `calls` (construction) relationships.
+	// Precision gates, all required: the CALLS target must (a) be a bare name
+	// resolving to NO entity (a genuinely dangling stub, not a real class call),
+	// (b) equal the simple name of an exception node, and (c) originate from a
+	// method that THROWS that same exception node. This is language-general:
+	// the bare-name dangling-constructor shape is identical across extractors.
+	if len(throwsFrom) > 0 {
+		// excByTypeName: bare type name -> set of exception-node survivor targets
+		// whose throwing-method set we can consult. Multiple distinct exception
+		// nodes can share a leaf name across files; we only fold when exactly one
+		// of them is thrown by the calling method (the (c) gate disambiguates).
+		excIDsByName := map[string][]string{}
+		for id, tn := range typeNameByExc {
+			excIDsByName[tn] = append(excIDsByName[tn], id)
+		}
+		for k := range doc.Relationships {
+			r := &doc.Relationships[k]
+			if r.Kind != string(types.RelationshipKindCalls) || r.FromID == "" {
+				continue
+			}
+			// (a) dangling bare-name target — not a graph entity, not an
+			// already-synthesised ext:* placeholder, not a hex id.
+			if r.ToID == "" || allEntityIDs[r.ToID] ||
+				isHexID(r.ToID) || strings.HasPrefix(r.ToID, ExtIDPrefix) {
+				continue
+			}
+			// (b)+(c) the bare name matches an exception node thrown by THIS method.
+			var target string
+			matches := 0
+			for _, excID := range excIDsByName[r.ToID] {
+				if throwsFrom[excID] != nil && throwsFrom[excID][r.FromID] {
+					target = survivorByExc[excID]
+					matches++
+				}
+			}
+			if matches != 1 || target == "" || target == r.ToID {
+				// No match, or ambiguous (same leaf name thrown by the method for
+				// two distinct exception nodes) — leave the edge untouched.
+				continue
+			}
+			r.ToID = target
+			r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
+			stats.ConstructorCallsUnified++
 		}
 	}
 

--- a/internal/external/exception_resolve_test.go
+++ b/internal/external/exception_resolve_test.go
@@ -156,6 +156,116 @@ func TestResolveExceptionTypes_ComponentCandidate(t *testing.T) {
 	}
 }
 
+func callsRel(from, to string) graph.Relationship {
+	return graph.Relationship{
+		ID:     graph.RelationshipID(from, to, string(types.RelationshipKindCalls)),
+		FromID: from, ToID: to, Kind: string(types.RelationshipKindCalls),
+	}
+}
+
+func callsTo(doc *graph.Document, from string) []string {
+	var out []string
+	for _, r := range doc.Relationships {
+		if r.Kind == string(types.RelationshipKindCalls) && r.FromID == from {
+			out = append(out, r.ToID)
+		}
+	}
+	return out
+}
+
+// #4555 — the live NotFoundException shape: a synthetic ExceptionType node with
+// THROWS on it, plus a DANGLING `new NotFoundException()` constructor CALLS edge
+// (bare-name target, no entity) from the SAME throwing method. No real class
+// entity exists, so the exception node is KEPT — and the constructor CALLS must
+// be folded onto it so ONE node carries both throws + calls.
+func TestResolveExceptionTypes_4555_UnifiesDanglingConstructorCall(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "method", Name: "remove", Kind: string(types.EntityKindFunction), SourceFile: "repo.ts"},
+			excType("exc", "NotFoundException"),
+		},
+		Relationships: []graph.Relationship{
+			throwsRel("method", "exc"),
+			callsRel("method", "NotFoundException"), // dangling bare-name ctor call
+		},
+	}
+	// RED before: two nodes — exception node + phantom dangling CALLS target.
+	if got := callsTo(doc, "method"); len(got) != 1 || got[0] != "NotFoundException" {
+		t.Fatalf("setup: want dangling CALLS to bare name, got %v", got)
+	}
+
+	st := ResolveExceptionTypes(doc)
+
+	if st.ConstructorCallsUnified != 1 {
+		t.Fatalf("want 1 constructor call unified, got %+v", st)
+	}
+	// Exception node KEPT (no real class to resolve to).
+	if !hasEntity(doc, "exc") {
+		t.Fatal("exception node must be kept (no real class)")
+	}
+	// GREEN: both THROWS and the construction CALLS now target the ONE node.
+	if throwsTo(doc) != "exc" {
+		t.Fatalf("THROWS must target exception node, got %s", throwsTo(doc))
+	}
+	got := callsTo(doc, "method")
+	if len(got) != 1 || got[0] != "exc" {
+		t.Fatalf("construction CALLS must be folded onto exception node, got %v", got)
+	}
+}
+
+// #4555 — when the exception DOES resolve to a real class, both the THROWS and
+// the dangling constructor CALLS fold onto that real class (single node).
+func TestResolveExceptionTypes_4555_UnifiesOntoRealClass(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "method", Name: "findById", Kind: string(types.EntityKindFunction), SourceFile: "svc.ts"},
+			realClass("cls", "AppNotFoundError"),
+			excType("exc", "AppNotFoundError"),
+		},
+		Relationships: []graph.Relationship{
+			throwsRel("method", "exc"),
+			callsRel("method", "AppNotFoundError"),
+		},
+	}
+	st := ResolveExceptionTypes(doc)
+	if st.SyntheticDropped != 1 || st.Retargeted != 1 || st.ConstructorCallsUnified != 1 {
+		t.Fatalf("stats: %+v", st)
+	}
+	if hasEntity(doc, "exc") {
+		t.Fatal("synthetic node must be dropped")
+	}
+	if throwsTo(doc) != "cls" {
+		t.Fatalf("THROWS must target real class, got %s", throwsTo(doc))
+	}
+	got := callsTo(doc, "method")
+	if len(got) != 1 || got[0] != "cls" {
+		t.Fatalf("CALLS must fold onto real class, got %v", got)
+	}
+}
+
+// #4555 precision — a same-named construction from a method that does NOT throw
+// the exception is left untouched (no spurious fold).
+func TestResolveExceptionTypes_4555_NonThrowingCallerNotFolded(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "thrower", Name: "a", Kind: string(types.EntityKindFunction), SourceFile: "a.ts"},
+			{ID: "other", Name: "b", Kind: string(types.EntityKindFunction), SourceFile: "b.ts"},
+			excType("exc", "NotFoundException"),
+		},
+		Relationships: []graph.Relationship{
+			throwsRel("thrower", "exc"),
+			callsRel("other", "NotFoundException"), // different method, not a thrower
+		},
+	}
+	st := ResolveExceptionTypes(doc)
+	if st.ConstructorCallsUnified != 0 {
+		t.Fatalf("non-throwing caller must not be folded, got %+v", st)
+	}
+	if got := callsTo(doc, "other"); len(got) != 1 || got[0] != "NotFoundException" {
+		t.Fatalf("non-thrower CALLS must be untouched, got %v", got)
+	}
+}
+
 func TestResolveExceptionTypes_NilSafe(t *testing.T) {
 	if st := ResolveExceptionTypes(nil); st.Retargeted != 0 {
 		t.Fatal("nil doc must be safe")

--- a/internal/extractors/javascript/throws_resolve_4480_test.go
+++ b/internal/extractors/javascript/throws_resolve_4480_test.go
@@ -277,6 +277,99 @@ func TestThrows4480_ImportedExternal_AfterFix_GREEN(t *testing.T) {
 	}
 }
 
+// --- Case 2b (#4555): dangling constructor CALLS unified onto the one node ---
+//
+// The TRUE live core-backend-v3 shape, reproduced with NO manual entity
+// injection. `throw new NotFoundException('Client not found')` produces, fully
+// independently, TWO graph artefacts after the real extractor + Synthesize:
+//
+//   1. the synthetic SCOPE.ExceptionType node `exception:NotFoundException`
+//      (id e7cb18d1694fc1d7) carrying the THROWS edge, and
+//   2. a DANGLING constructor CALLS edge whose ToID is the bare name
+//      `NotFoundException` — no ext:* placeholder is synthesised for it
+//      (the import folds to ext:@nestjs/common, not ext:NotFoundException),
+//      so it renders as a SECOND phantom node next to the exception node.
+//
+// One exception, two nodes. #4555 folds the construction CALLS onto the
+// surviving exception node so a SINGLE node carries BOTH relationships.
+
+func callsFrom(doc *graph.Document, toID string) []graph.Relationship {
+	var out []graph.Relationship
+	for _, r := range doc.Relationships {
+		if r.Kind == string(types.RelationshipKindCalls) && r.ToID == toID {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func TestThrows4555_DanglingConstructorCall_BeforeFix_RED(t *testing.T) {
+	doc := assembleDoc4480(extractTSFixture4480(t,
+		"client_repository_4480.ts",
+		"src/modules/clients/repositories/client.repository.ts"))
+	external.Synthesize(doc) // NO ResolveExceptionTypes — pre-fix snapshot.
+
+	// Artefact 1: the synthetic exception node carries THROWS.
+	if countExceptionTypeNodes(doc, "exception:NotFoundException") != 1 {
+		t.Fatal("pre-fix: expected the synthetic NotFoundException node")
+	}
+	// Artefact 2: a dangling bare-name `NotFoundException` constructor CALLS edge
+	// exists (the SECOND node the dashboard renders). No ext:NotFoundException
+	// entity backs it.
+	dangling := callsFrom(doc, "NotFoundException")
+	if len(dangling) == 0 {
+		t.Fatal("pre-fix: expected a dangling `new NotFoundException()` CALLS edge")
+	}
+	if entByID(doc, "NotFoundException") != nil || entByID(doc, "ext:NotFoundException") != nil {
+		t.Fatal("pre-fix: the constructor CALLS target must be a bare-name dangling stub (two nodes, one exception)")
+	}
+}
+
+func TestThrows4555_DanglingConstructorCall_AfterFix_GREEN(t *testing.T) {
+	doc := assembleDoc4480(extractTSFixture4480(t,
+		"client_repository_4480.ts",
+		"src/modules/clients/repositories/client.repository.ts"))
+	external.Synthesize(doc)
+	stats := external.ResolveExceptionTypes(doc)
+
+	if stats.ConstructorCallsUnified < 1 {
+		t.Fatalf("after-fix: want >=1 constructor call unified, got %+v", stats)
+	}
+	// The bare-name dangling CALLS target is gone — folded onto the one node.
+	if len(callsFrom(doc, "NotFoundException")) != 0 {
+		t.Fatal("after-fix: dangling `NotFoundException` CALLS must be re-pointed")
+	}
+	// Exactly ONE NotFoundException node survives (the exception node, kept since
+	// no real class entity exists), carrying BOTH throws and calls.
+	excNodes := 0
+	var excID string
+	for i := range doc.Entities {
+		if doc.Entities[i].Name == "exception:NotFoundException" {
+			excNodes++
+			excID = doc.Entities[i].ID
+		}
+	}
+	if excNodes != 1 {
+		t.Fatalf("after-fix: want exactly 1 exception node, got %d", excNodes)
+	}
+	// Both a THROWS and a CALLS edge now land on that single node.
+	throwsOnNode, callsOnNode := false, false
+	for _, r := range doc.Relationships {
+		if r.ToID != excID {
+			continue
+		}
+		switch r.Kind {
+		case string(types.RelationshipKindThrows):
+			throwsOnNode = true
+		case string(types.RelationshipKindCalls):
+			callsOnNode = true
+		}
+	}
+	if !throwsOnNode || !callsOnNode {
+		t.Fatalf("after-fix: single node must carry BOTH throws(%v) and calls(%v)", throwsOnNode, callsOnNode)
+	}
+}
+
 // --- Case 3: genuinely-external/unresolvable type keeps a single node --------
 //
 // When NO real class entity exists for the thrown type (truly 3rd-party type


### PR DESCRIPTION
## Problem

On the live `core-backend-v3` graph, `NotFoundException` appeared as **TWO nodes** for one exception:

1. the synthetic `SCOPE.ExceptionType` node `exception:NotFoundException` (id `e7cb18d1694fc1d7`, file `<exception>`) carrying the **THROWS** edge, and
2. a **dangling constructor CALLS** edge — from `throw new NotFoundException('...')` — whose `ToID` is the bare name `NotFoundException`. No `ext:NotFoundException` placeholder is synthesised for it (the import folds to `ext:@nestjs/common`, the package), so the bare-name target dangles and the dashboard renders it as a **second phantom node** beside the exception node.

One exception, two nodes. #4480/#4512 handled the throws→real-class dedup, but **not** this case: there is no real entity to match by name, so the prior pass left both nodes.

## Fix

Extends `external.ResolveExceptionTypes` (the shared, language-agnostic synthesis pass) to **fold the dangling constructor CALLS onto the surviving exception node** — the resolved real class when one exists, otherwise the kept exception node — so a **SINGLE** node carries both the `throws` and the `calls` (construction) relationships.

Keyed purely on graph shape, so it is **framework-general** (Java `throw new X()`, C# `throw new X()`, Python `raise X(...)`, JS/TS — any extractor that emits a typed THROWS + a constructor CALLS). Precision gates, all required:

- (a) the CALLS target is a **bare-name dangling stub** — not a graph entity, not an `ext:*` placeholder, not a hex id;
- (b) it equals the **simple name** of an exception node; and
- (c) it originates from a method that **THROWS that same exception node**.

Ambiguous same-leaf-name constructions thrown by the method for two distinct exception nodes are left untouched.

## Tests

- **In-pipeline live-fire** (real JS/TS extractor + resolver + synthesis, no manual entity injection) reproducing the exact live shape for `throw new NotFoundException()` — RED before / GREEN after — asserting exactly **one** node carries **both** the throws and the calls edge.
- Unit coverage: dangling-CALLS-onto-kept-node, dangling-CALLS-onto-resolved-real-class, and non-throwing-caller (precision: not folded).

## Gates

`go build ./...`, `go vet`, and `go test ./internal/external/... ./internal/extractor/... ./internal/extractors/... ./internal/custom/... ./internal/engine/... ./internal/substrate/... ./internal/types/... ./internal/dashboard/...` all green.

> Final live confirmation (one `NotFoundException` node in the core-backend-v3 flow view) needs a reindex = an authorised deploy and is **DEFERRED** to the coordinator.

Closes #4555

🤖 Generated with [Claude Code](https://claude.com/claude-code)