### PR TITLE
fix(nestjs): surface scalar handler params + link Promise<DTO> response to Schema (#4568, #4569)

### DIFF
--- a/internal/dashboard/shape_tree.go
+++ b/internal/dashboard/shape_tree.go
@@ -362,12 +362,26 @@ func splitTopLevelComma(s string) []string {
 	return out
 }
 
-// findClassEntityByName scans the group's repos for a SCOPE.Component
-// (class/interface/enum/record) whose simple name matches `name`. The
-// match is case-sensitive; the first hit (by sorted-repo iteration)
-// wins. Returns nil when no class matches — primitives, JDK types, and
-// container element types with no in-group DTO definition all fall
-// through.
+// findClassEntityByName scans the group's repos for a class-like model
+// entity whose simple name matches `name`. The match is case-sensitive;
+// the first hit (by sorted-repo iteration) wins. Returns nil when no
+// model matches — primitives, JDK types, and container element types
+// with no in-group DTO definition all fall through.
+//
+// Two entity shapes resolve:
+//
+//   - SCOPE.Component (class/interface/record/enum) — the OO class shape
+//     emitted for Java/TS/etc. classes.
+//   - SCOPE.Schema object/model nodes — the shape emitted for DTOs and
+//     ORM/GraphQL models (NestJS response DTOs under dto/response/, Mongoose
+//     @Schema classes, Prisma/Drizzle/Mongoose models, GraphQL types, …).
+//     #4569: a `@Get() …(): Promise<ProposalCountsResponse>` handler emits a
+//     RETURNS/response_type of `ProposalCountsResponse`, but that DTO is
+//     indexed as kind SCOPE.Schema (not SCOPE.Component), so the Response row
+//     resolved the NAME yet found no entity to expand and rendered "(none)".
+//     Resolving the Schema model node lets the field-set (its SCOPE.Schema/
+//     field CONTAINS children) render. Sub-field nodes (subtype
+//     field/column/property) are excluded — only the object shape itself.
 //
 // Primitive / framework names are short-circuited so we do not pay
 // the entity scan cost for unresolvable types.
@@ -381,12 +395,24 @@ func findClassEntityByName(g *DashGroup, name string) *graph.Entity {
 		}
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
-			if e.Kind != "SCOPE.Component" {
+			if e.Name != name {
 				continue
 			}
-			if e.Name == name {
+			switch e.Kind {
+			case "SCOPE.Component":
 				switch e.Subtype {
 				case "class", "interface", "record", "enum", "":
+					return e
+				}
+			case "SCOPE.Schema":
+				// A Schema object/model shape (DTO, ORM/GraphQL model) — its
+				// fields render as the response/body field-set. Exclude the
+				// per-field/column/property sub-nodes, which are children, not
+				// the shape itself.
+				switch e.Subtype {
+				case "field", "column", "property":
+					// sub-field node — not an object shape.
+				default:
 					return e
 				}
 			}

--- a/internal/dashboard/shape_tree_test.go
+++ b/internal/dashboard/shape_tree_test.go
@@ -241,6 +241,55 @@ func TestShape_UnknownType(t *testing.T) {
 	}
 }
 
+// TestFindClassEntityByName_ResolvesSchemaKindDTO covers #4569: a NestJS
+// response DTO (e.g. ProposalCountsResponse under dto/response/) is indexed as
+// kind SCOPE.Schema, NOT SCOPE.Component. The resolver must find it so the
+// endpoint's Response row can expand its field-set instead of rendering
+// "(none)". Before the fix findClassEntityByName only matched SCOPE.Component.
+func TestFindClassEntityByName_ResolvesSchemaKindDTO(t *testing.T) {
+	entities := []graph.Entity{
+		// A response DTO indexed as a Schema model (the upvate-v3 shape).
+		{
+			ID: "schema_counts", Name: "ProposalCountsResponse",
+			Kind: "SCOPE.Schema", Subtype: "model",
+			SourceFile: "src/modules/proposals/dto/response/proposal-counts.response.dto.ts",
+			Language:   "typescript",
+		},
+		{
+			ID: "fld_total", Name: "ProposalCountsResponse.total",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: "src/modules/proposals/dto/response/proposal-counts.response.dto.ts",
+			Language:   "typescript", Signature: "total: number",
+		},
+		// A Schema FIELD sub-node with a matching simple name must NOT be
+		// mistaken for the object shape.
+		{
+			ID: "fld_decoy", Name: "DecoyShape",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: "src/x.ts", Language: "typescript",
+		},
+	}
+	rels := []graph.Relationship{
+		{FromID: "schema_counts", ToID: "fld_total", Kind: "CONTAINS"},
+	}
+	grp := makePathsTestGroup(entities, rels)
+
+	got := findClassEntityByName(grp, "ProposalCountsResponse")
+	if got == nil {
+		t.Fatal("#4569: SCOPE.Schema response DTO not resolved by findClassEntityByName")
+	}
+	if got.ID != "schema_counts" {
+		t.Errorf("#4569: resolved %q, want schema_counts", got.ID)
+	}
+	if !classHasFieldChildren(grp, got) {
+		t.Error("#4569: resolved Schema DTO must report field children (CONTAINS field)")
+	}
+	// A field sub-node must not resolve as an object shape.
+	if d := findClassEntityByName(grp, "DecoyShape"); d != nil {
+		t.Errorf("#4569: Schema/field sub-node must not resolve as a shape, got %q", d.ID)
+	}
+}
+
 // TestShape_MissingTypeParam returns 400 when no type/type_entity_id
 // query parameter is supplied.
 func TestShape_MissingTypeParam(t *testing.T) {

--- a/internal/engine/http_endpoint_nestjs_signature.go
+++ b/internal/engine/http_endpoint_nestjs_signature.go
@@ -1,0 +1,341 @@
+// NestJS handler-signature extraction for the synthesized http_endpoint entity
+// (#4568 / #4569).
+//
+// synthesizeNestJS (http_endpoint_synthesis.go) re-parses NestJS controllers
+// and emits the canonical, controller-prefixed `http_endpoint` definition — the
+// entity the dashboard Paths panel actually reads. Until now that synthesizer
+// stamped only the route / verb / handler line; it captured NONE of the handler
+// SIGNATURE. The dashboard reads `parameters` / `response_type` / `request_body_*`
+// from THIS entity, so:
+//
+//   - Scalar `@Query('year') x: string` / `@Param('id') id: number` /
+//     `@Headers('x')` params never surfaced → Parameters (0)/None (#4568). The
+//     custom nestjs extractor DID capture them onto its SCOPE.Operation/endpoint,
+//     but that is a different entity than the one the panel renders.
+//   - `Promise<ProposalCountsResponse>` return types never set `response_type`,
+//     so the Response row showed (1)→(none) even though the DTO is indexed
+//     (#4569; the Schema-kind resolution gap is fixed dashboard-side too).
+//
+// This file gives the synthesizer self-contained (engine can't import a custom
+// extractor) handler-signature parsing that writes the SAME wire shape the
+// dashboard already decodes: a `parameters` JSON []JavaParam plus the
+// response_type / response_is_array / response_void / request_body_type props.
+//
+// CROSS-FRAMEWORK NOTE: scalar request params (query/path/header) are a recurring
+// gap across frameworks — Express `req.query`/`req.params`, FastAPI
+// `Query()`/`Path()`, Spring `@RequestParam`/`@PathVariable`, DRF query_params.
+// This pass implements NestJS; follow-ups are filed for the rest.
+package engine
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// nestSigParamDecoratorRe matches a single param decorator + the parameter it
+// annotates within a handler parameter list. Group 1 = decorator
+// (Param|Query|Body|Headers|Header), group 2 = the decorator's first quoted
+// binding key (when present), group 3 = the parameter identifier, group 4 = the
+// TS type annotation (when present). Mirrors the custom extractor's
+// reNestParamDecorator so both entities agree.
+var nestSigParamDecoratorRe = regexp.MustCompile(
+	`@(Param|Query|Body|Headers|Header)\s*\(\s*(?:['"]([^'"]*)['"])?[^)]*\)\s*(\w+)\??\s*(?::\s*([A-Za-z_][\w<>\[\], |.]*))?`,
+)
+
+// nestSigReturnTypeRe captures the method return-type annotation following the
+// closing paren of the handler signature: `): Promise<UserDto> {` / `): UserDto {`.
+var nestSigReturnTypeRe = regexp.MustCompile(`\)\s*:\s*([A-Za-z_][\w<>\[\], |.]*?)\s*[{;]`)
+
+// nestSigDecoratorIn maps a NestJS param decorator to its OpenAPI `in` location.
+var nestSigDecoratorIn = map[string]string{
+	"Param":   "path",
+	"Query":   "query",
+	"Body":    "body",
+	"Header":  "header",
+	"Headers": "header",
+}
+
+// nestSigSkipTypes are TS built-in / framework types that are never response
+// DTOs (so they don't set response_type) — they are honest scalars/no-content.
+var nestSigSkipTypes = map[string]bool{
+	"string": true, "number": true, "boolean": true, "any": true, "void": true,
+	"unknown": true, "object": true, "Object": true, "Date": true, "Buffer": true,
+	"Promise": true, "Observable": true, "Array": true, "Record": true,
+	"Map": true, "Set": true, "Partial": true, "Request": true, "Response": true,
+	"null": true, "undefined": true, "never": true, "this": true,
+}
+
+// nestSigEnvelopeWrappers are convention envelope generics whose single payload
+// type argument carries the actual response DTO. Mirrors the custom extractor's
+// nestEnvelopeWrappers so the unwrap is identical on both entities.
+var nestSigEnvelopeWrappers = map[string]bool{
+	"ApiResponse": true, "PagedResponse": true, "PaginatedResponse": true,
+	"Paginated": true, "Page": true, "PageResponse": true, "Pagination": true,
+	"CollectionResponse": true, "ListResponse": true, "DataResponse": true,
+	"ResponseWrapper": true, "Wrapped": true, "Envelope": true,
+	"ResponseEntity": true, "ApiResult": true, "Result": true,
+}
+
+// nestSignature is the parsed handler signature for one NestJS route.
+type nestSignature struct {
+	Params         []JavaParam
+	ResponseType   string
+	ResponseIsArr  bool
+	ResponseVoid   bool
+	RequestBody    string // DTO type of the @Body() param, when any
+	RequestBodyArg string // identifier of the @Body() param
+}
+
+// nestjsReadSignature reads the handler signature starting at the handler
+// declaration line (handlerLineIdx, 0-based into `lines`). It stitches the
+// (possibly multi-line) parameter list via balanced-paren scanning, then reads
+// the trailing return-type annotation. Returns the parsed params + response
+// shape. A handler with no decorated params and no DTO return type yields an
+// empty (but non-nil-meaningful) signature.
+func nestjsReadSignature(lines []string, handlerLineIdx int) nestSignature {
+	var sig nestSignature
+	if handlerLineIdx < 0 || handlerLineIdx >= len(lines) {
+		return sig
+	}
+	// Join from the handler line until the signature's opening `(` is balanced.
+	// Cap the look-ahead so a malformed source can't run away.
+	const maxLines = 60
+	var b strings.Builder
+	for i := handlerLineIdx; i < len(lines) && i < handlerLineIdx+maxLines; i++ {
+		b.WriteString(lines[i])
+		b.WriteByte('\n')
+	}
+	region := b.String()
+
+	openIdx := strings.IndexByte(region, '(')
+	if openIdx < 0 {
+		return sig
+	}
+	paramsBlock, closeIdx := nestSigBalancedParens(region, openIdx+1)
+
+	sig.Params = nestSigParseParams(paramsBlock)
+	for _, p := range sig.Params {
+		if p.In == "body" && sig.RequestBody == "" {
+			sig.RequestBody = p.Type
+			sig.RequestBodyArg = p.Name
+		}
+	}
+
+	// Return type: look at the text right after the matching close paren.
+	if closeIdx >= 0 && closeIdx < len(region) {
+		tail := region[closeIdx:]
+		if rm := nestSigReturnTypeRe.FindStringSubmatch(tail); rm != nil {
+			dto, isArr, isVoid := nestSigResolveResponseType(rm[1])
+			sig.ResponseType = dto
+			sig.ResponseIsArr = isArr
+			sig.ResponseVoid = isVoid
+		}
+	}
+	return sig
+}
+
+// nestSigBalancedParens scans from `start` (just past an opening `(`) and
+// returns the inner text up to the matching close paren plus the index of that
+// close paren (in `src`). Tracks <>/[]/{} so generic args and inline object
+// types don't unbalance the count.
+func nestSigBalancedParens(src string, start int) (string, int) {
+	depth := 1
+	i := start
+	for i < len(src) && depth > 0 {
+		switch src[i] {
+		case '(', '<', '[', '{':
+			depth++
+		case ')', '>', ']', '}':
+			depth--
+		}
+		i++
+	}
+	if depth != 0 {
+		return src[start:], -1
+	}
+	return src[start : i-1], i - 1
+}
+
+// nestSigParseParams parses a handler parameter block into ordered JavaParams,
+// one per request-shaping decorator (@Param/@Query/@Body/@Header(s)). Decorator-
+// less and framework-injection params are skipped.
+func nestSigParseParams(paramsBlock string) []JavaParam {
+	if strings.TrimSpace(paramsBlock) == "" {
+		return nil
+	}
+	var out []JavaParam
+	for _, m := range nestSigParamDecoratorRe.FindAllStringSubmatch(paramsBlock, -1) {
+		dec := m[1]
+		key := strings.TrimSpace(m[2])
+		ident := strings.TrimSpace(m[3])
+		rawType := nestSigCleanType(m[4])
+
+		in := nestSigDecoratorIn[dec]
+		if in == "" {
+			continue
+		}
+		name := key
+		if name == "" {
+			name = ident // @Query()/@Body() whole-object: fall back to identifier
+		}
+		if name == "" {
+			continue
+		}
+		p := JavaParam{
+			Name:        name,
+			In:          in,
+			Annotations: []string{"@" + dec},
+		}
+		if rawType != "" {
+			if dto := nestSigUnwrapType(rawType); dto != "" {
+				p.Type = dto
+			} else {
+				p.Type = strings.TrimSpace(strings.SplitN(rawType, "|", 2)[0])
+			}
+		}
+		if in == "path" {
+			p.Required = true // path params are always required
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// nestSigCleanType trims a captured TS type to the single param's type, cutting
+// at the first top-level comma (the char class permits `,` for generic args).
+func nestSigCleanType(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	depth := 0
+	for i := 0; i < len(raw); i++ {
+		switch raw[i] {
+		case '<', '[':
+			depth++
+		case '>', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				raw = raw[:i]
+				return strings.TrimRight(strings.TrimSpace(raw), ", ")
+			}
+		}
+	}
+	return strings.TrimRight(strings.TrimSpace(raw), ", ")
+}
+
+// nestSigUnwrapType strips generic/array/envelope wrappers to the innermost user
+// DTO name, returning "" for built-ins/primitives.
+func nestSigUnwrapType(raw string) string {
+	dto, _, _ := nestSigResolveResponseType(raw)
+	return dto
+}
+
+// nestSigResolveResponseType unwraps a response/return type to its innermost
+// user DTO, reporting array-payload and genuine no-content (void) results.
+// Mirrors the custom extractor's nestResolveResponseType.
+func nestSigResolveResponseType(raw string) (dto string, isArray, isVoid bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false, false
+	}
+	if strings.HasSuffix(raw, "[]") {
+		isArray = true
+		raw = strings.TrimSpace(strings.TrimSuffix(raw, "[]"))
+	}
+	for {
+		open := strings.IndexByte(raw, '<')
+		if open < 0 {
+			break
+		}
+		base := strings.TrimSpace(raw[:open])
+		isWrapper := nestSigSkipTypes[base] || nestSigEnvelopeWrappers[base]
+		if !isWrapper {
+			raw = base // a user generic like UserDto<T> — keep the base type
+			break
+		}
+		if base == "Array" || base == "Set" {
+			isArray = true
+		}
+		closeIdx := strings.LastIndexByte(raw, '>')
+		if closeIdx <= open {
+			break
+		}
+		inner := raw[open+1 : closeIdx]
+		if comma := strings.IndexByte(inner, ','); comma >= 0 {
+			inner = inner[:comma]
+		}
+		raw = strings.TrimSpace(inner)
+		if strings.HasSuffix(raw, "[]") {
+			isArray = true
+			raw = strings.TrimSpace(strings.TrimSuffix(raw, "[]"))
+		}
+	}
+	if pipe := strings.IndexByte(raw, '|'); pipe >= 0 {
+		raw = strings.TrimSpace(raw[:pipe])
+	}
+	base := strings.TrimSpace(raw)
+	switch base {
+	case "void", "undefined", "never":
+		return "", isArray, true
+	}
+	if base == "" || nestSigSkipTypes[base] {
+		return "", isArray, false
+	}
+	for _, r := range base {
+		if !(r == '_' || r == '.' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9') {
+			return "", isArray, false
+		}
+	}
+	// Strip a qualifier prefix (e.g. `dto.UserDto` → `UserDto`) for the bare
+	// type name the entity index keys on.
+	if dot := strings.LastIndexByte(base, '.'); dot >= 0 {
+		base = base[dot+1:]
+	}
+	return base, isArray, false
+}
+
+// nestSigEncodeParams marshals the param list to the canonical JSON the
+// dashboard decodes (engine.DecodeJavaParameters). Empty → "".
+func nestSigEncodeParams(ps []JavaParam) string {
+	if len(ps) == 0 {
+		return ""
+	}
+	b, err := json.Marshal(ps)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// stampNestSignature writes the parsed handler signature onto a synthesized
+// http_endpoint entity's Properties so the dashboard Paths panel renders the
+// Parameters table and the Response shape. Idempotent: only sets a property
+// when it carries information.
+func stampNestSignature(props map[string]string, sig nestSignature) {
+	if props == nil {
+		return
+	}
+	if pj := nestSigEncodeParams(sig.Params); pj != "" {
+		props["parameters"] = pj
+	}
+	if sig.RequestBody != "" {
+		props["request_body_type"] = sig.RequestBody
+		if sig.RequestBodyArg != "" {
+			props["request_body_param_name"] = sig.RequestBodyArg
+		}
+	}
+	switch {
+	case sig.ResponseType != "":
+		props["response_type"] = sig.ResponseType
+		if sig.ResponseIsArr {
+			props["response_is_array"] = "true"
+		}
+	case sig.ResponseVoid:
+		props["response_void"] = "true"
+	}
+}

--- a/internal/engine/http_endpoint_nestjs_signature_4568_4569_test.go
+++ b/internal/engine/http_endpoint_nestjs_signature_4568_4569_test.go
@@ -1,0 +1,186 @@
+package engine
+
+import (
+	"testing"
+)
+
+// #4568 / #4569 — the synthesized NestJS http_endpoint (the entity the dashboard
+// Paths panel reads) must carry the handler SIGNATURE: scalar @Query/@Param/
+// @Headers params (Parameters table) and the unwrapped return-type DTO
+// (Response shape). Before the fix synthesizeNestJS stamped only the route/verb,
+// so the live upvate-v3 dashboard showed Parameters (0)/None and Response (none).
+
+// findEndpointProps returns the Properties of the first synthesized
+// http_endpoint whose route_path/verb match, or nil.
+func findEndpointProps(res *DetectResult, verb, routeContains string) map[string]string {
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointKind && e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		p := e.Properties
+		if p == nil {
+			continue
+		}
+		if !containsFold(p["verb"]+p["http_method"], verb) {
+			continue
+		}
+		if routeContains != "" && !containsFold(p["route_path"]+p["path"], routeContains) {
+			continue
+		}
+		return p
+	}
+	return nil
+}
+
+func containsFold(hay, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	return len(hay) >= len(needle) && indexFold(hay, needle) >= 0
+}
+
+func indexFold(s, sub string) int {
+	ls, lsub := len(s), len(sub)
+	for i := 0; i+lsub <= ls; i++ {
+		match := true
+		for j := 0; j < lsub; j++ {
+			a, b := s[i+j], sub[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+// #4568 — a handler with a scalar @Query('year') param surfaces a query
+// parameter on the synthesized endpoint's `parameters` property.
+func TestNestJS_ScalarQueryParam_Surfaced_4568(t *testing.T) {
+	src := `import { Controller, Get, Query } from '@nestjs/common';
+import { ProposalCountsResponse } from '../dto/response/proposal-counts.response.dto';
+
+@Controller('proposals')
+export class ProposalController {
+  @Get('get_counts')
+  getCounts(@Query('year') yearRaw: string): Promise<ProposalCountsResponse> {
+    return this.svc.getCounts(yearRaw);
+  }
+}
+`
+	_, res := runDetect(t, "typescript", "src/modules/proposals/api/proposal.controller.ts", src)
+	props := findEndpointProps(res, "GET", "get_counts")
+	if props == nil {
+		t.Fatal("no synthesized GET /proposals/get_counts endpoint")
+	}
+	pj := props["parameters"]
+	if pj == "" {
+		t.Fatalf("#4568: parameters property empty; want the scalar @Query('year') param. props=%v", props)
+	}
+	decoded := DecodeJavaParameters(pj)
+	var found bool
+	for _, p := range decoded {
+		if p.Name == "year" && p.In == "query" {
+			found = true
+			if p.Type != "string" {
+				t.Errorf("#4568: year param type = %q, want string", p.Type)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("#4568: scalar query param 'year' not in parameters: %v", decoded)
+	}
+}
+
+// #4568 — scalar @Param('id', ParseIntPipe) path param surfaces as required path.
+func TestNestJS_ScalarPathParam_Surfaced_4568(t *testing.T) {
+	src := `import { Controller, Get, Param } from '@nestjs/common';
+
+@Controller('buildings')
+export class BuildingController {
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number): Promise<BuildingDto> {
+    return this.svc.findOne(id);
+  }
+}
+`
+	_, res := runDetect(t, "typescript", "src/modules/buildings/api/building.controller.ts", src)
+	props := findEndpointProps(res, "GET", "buildings")
+	if props == nil {
+		t.Fatal("no synthesized GET /buildings/:id endpoint")
+	}
+	decoded := DecodeJavaParameters(props["parameters"])
+	var found bool
+	for _, p := range decoded {
+		if p.Name == "id" && p.In == "path" {
+			found = true
+			if !p.Required {
+				t.Errorf("#4568: path param 'id' must be required")
+			}
+			if p.Type != "number" {
+				t.Errorf("#4568: id param type = %q, want number", p.Type)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("#4568: scalar path param 'id' not surfaced: %v", decoded)
+	}
+}
+
+// #4569 — a Promise<DTO> return type stamps response_type with the unwrapped DTO
+// name on the synthesized endpoint so the Response row can resolve+render it.
+func TestNestJS_PromiseDTOResponseType_Stamped_4569(t *testing.T) {
+	src := `import { Controller, Get, Query } from '@nestjs/common';
+import { ProposalCountsResponse } from '../dto/response/proposal-counts.response.dto';
+
+@Controller('proposals')
+export class ProposalController {
+  @Get('get_counts')
+  getCounts(@Query('year') yearRaw: string): Promise<ProposalCountsResponse> {
+    return this.svc.getCounts(yearRaw);
+  }
+}
+`
+	_, res := runDetect(t, "typescript", "src/modules/proposals/api/proposal.controller.ts", src)
+	props := findEndpointProps(res, "GET", "get_counts")
+	if props == nil {
+		t.Fatal("no synthesized GET /proposals/get_counts endpoint")
+	}
+	if got := props["response_type"]; got != "ProposalCountsResponse" {
+		t.Errorf("#4569: response_type = %q, want ProposalCountsResponse. props=%v", got, props)
+	}
+}
+
+// #4569 — Promise<DTO[]> flags the array payload while keeping the element DTO.
+func TestNestJS_PromiseArrayDTOResponseType_4569(t *testing.T) {
+	src := `import { Controller, Get } from '@nestjs/common';
+
+@Controller('inspectors')
+export class InspectorController {
+  @Get()
+  list(): Promise<InspectorDto[]> {
+    return this.svc.list();
+  }
+}
+`
+	_, res := runDetect(t, "typescript", "src/modules/inspectors/api/inspector.controller.ts", src)
+	props := findEndpointProps(res, "GET", "inspectors")
+	if props == nil {
+		t.Fatal("no synthesized GET /inspectors endpoint")
+	}
+	if got := props["response_type"]; got != "InspectorDto" {
+		t.Errorf("#4569: response_type = %q, want InspectorDto", got)
+	}
+	if props["response_is_array"] != "true" {
+		t.Errorf("#4569: response_is_array must be true for Promise<InspectorDto[]>")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -601,6 +601,29 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		}
 	}
 
+	// emitDefSig wraps emitDef and additionally stamps the NestJS handler
+	// SIGNATURE (parameters + response/request DTO) onto the just-appended
+	// http_endpoint entity (#4568/#4569). The synthesized entity — not the
+	// custom extractor's SCOPE.Operation — is the one the dashboard Paths panel
+	// reads `parameters`/`response_type` from, so without this the Parameters
+	// table is empty and the Response row is "(none)" even though the handler
+	// declares both. defLine is the 1-based handler line; sig is parsed from it.
+	emitDefSig := func(method, canonicalPath, framework, refKind, refName string, defLine int, sig nestSignature) {
+		before := len(entities)
+		emit(method, canonicalPath, framework, refKind, refName)
+		if len(entities) == before {
+			return
+		}
+		last := &entities[len(entities)-1]
+		if defLine > 0 {
+			last.StartLine = defLine
+		}
+		if last.Properties == nil {
+			last.Properties = map[string]string{}
+		}
+		stampNestSignature(last.Properties, sig)
+	}
+
 	// emitFile wraps emit and stamps `handler_file` (cross-file hint,
 	// #2691 — Rails maps "users#index" to app/controllers/users_controller.rb)
 	// plus StartLine (#2691 — Sinatra anchors the synthetic at its verb
@@ -909,7 +932,7 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// handler by file:line co-location when the name-based source_handler
 		// resolution misses (e.g. when entity-merge keeps a same-path synthetic
 		// from another pass that carries no bindable source_handler).
-		synthesizeNestJS(string(content), emit, emitDef)
+		synthesizeNestJS(string(content), emit, emitDefSig)
 		// Producer side: Fastify — `fastify.<verb>(...)` / `server.<verb>(...)`.
 		// The Express synthesizer's receiver allowlist does not include
 		// "fastify", so a dedicated pass is needed (#2678 audit).
@@ -5247,7 +5270,7 @@ type nestController struct {
 	prefix  string
 }
 
-func synthesizeNestJS(content string, emit emitFn, emitDef emitDefFn) {
+func synthesizeNestJS(content string, emit emitFn, emitDef emitDefSigFn) {
 	if !strings.Contains(content, "@Controller") {
 		return
 	}
@@ -5298,12 +5321,16 @@ func synthesizeNestJS(content string, emit emitFn, emitDef emitDefFn) {
 		if canonical == "" {
 			continue
 		}
+		// #4568/#4569 — parse the handler signature (decorated params + return
+		// type) starting at the handler method line and stamp it onto the
+		// synthesized endpoint so the Parameters table and Response shape render.
+		sig := nestjsReadSignature(lines, methodLineIdx)
 		// #4319 — anchor the synthetic at the handler method's 1-based line so
 		// the Phase-2 resolver can bridge endpoint→handler by file:line
 		// co-location when the name-based source_handler match fails. methodLineIdx
 		// is a 0-based index into `lines`; +1 makes it the 1-based StartLine the
 		// treesitter handler Operation also carries.
-		emitDef(verb, canonical, "nestjs", "Controller", methodName, methodLineIdx+1)
+		emitDef(verb, canonical, "nestjs", "Controller", methodName, methodLineIdx+1, sig)
 	}
 }
 
@@ -5411,6 +5438,12 @@ type emitFn func(method, canonicalPath, framework, handlerKind, handlerName stri
 // routing decorator and the line is recoverable from the match offset.
 // A defLine of 0 means "unknown" and leaves StartLine untouched.
 type emitDefFn func(method, canonicalPath, framework, handlerKind, handlerName string, defLine int)
+
+// emitDefSigFn extends emitDefFn with a parsed NestJS handler signature
+// (parameters + response/request DTO), stamped onto the synthesized
+// http_endpoint entity so the dashboard renders the Parameters table and
+// Response shape (#4568/#4569).
+type emitDefSigFn func(method, canonicalPath, framework, handlerKind, handlerName string, defLine int, sig nestSignature)
 
 // lineOfOffset returns the 1-based line number containing byte offset `off`
 // in `content`. Newlines are counted up to (but not including) the offset,


### PR DESCRIPTION
The synthesized NestJS `http_endpoint` (the entity the dashboard Paths panel reads) only stamped route/verb/handler line — it captured none of the handler **signature**. Two live upvate-v3 dashboard defects resulted.

## Root causes

**#4568 — scalar params not surfaced.** `@Query('year') x: string` / `@Param('id', ParseIntPipe) id: number` / `@Headers('x')` never reached the dashboard → Parameters (0)/None. The custom extractor captured them onto its `SCOPE.Operation` entity, but the dashboard renders the engine-synthesized `http_endpoint`, which had no signature.

**#4569 — Promise<DTO> response not linked to Schema.** Two-part: (a) the synthesized endpoint never set `response_type`, so the Response row showed (1)→(none); (b) `findClassEntityByName` only matched `SCOPE.Component`, but response DTOs under `dto/response/*.dto.ts` are indexed as `SCOPE.Schema` — so even a resolved name found no entity to expand.

## Fixes
- `synthesizeNestJS` now parses the handler signature (decorated params + return type) via new self-contained engine helpers (`http_endpoint_nestjs_signature.go`) and stamps `parameters` / `response_type` / `response_is_array` / `response_void` / `request_body_type` onto the synthesized endpoint, in the exact wire shape the dashboard already decodes (`engine.JavaParam` / `DecodeJavaParameters`).
- `findClassEntityByName` resolves `SCOPE.Schema` object/model nodes (excluding `field`/`column`/`property` sub-nodes), so Schema-kind response/request DTOs expand their CONTAINS field-set.

The param/response unwrap logic mirrors the custom extractor (envelope/array/void handling) so both entities agree.

## Fixtures (RED → GREEN)
- `TestNestJS_ScalarQueryParam_Surfaced_4568` — `@Query('year')` → one query param.
- `TestNestJS_ScalarPathParam_Surfaced_4568` — `@Param('id')` → required path param.
- `TestNestJS_PromiseDTOResponseType_Stamped_4569` — `Promise<ProposalCountsResponse>` → `response_type` set.
- `TestNestJS_PromiseArrayDTOResponseType_4569` — `Promise<InspectorDto[]>` → element type + array flag.
- `TestFindClassEntityByName_ResolvesSchemaKindDTO` — `SCOPE.Schema` DTO resolves with field children; field sub-node does not.

RED confirmed by no-op-stamping (engine) and disabling the Schema case (dashboard).

## Gates
`go build ./...`, `go vet`, and the full test run over `internal/custom/... internal/engine/... internal/dashboard/... internal/types/...` all pass (19 packages ok, 0 fail).

## Cross-framework follow-ups (scalar params)
Filed per the generalize-extraction-fixes rule: #4583 (Express), #4584 (FastAPI), #4585 (Spring), #4586 (DRF).

Live dashboard confirmation deferred to coordinator (requires rebuild + reindex of upvate-v3).

Closes #4568
Closes #4569

🤖 Generated with [Claude Code](https://claude.com/claude-code)