### PR TITLE
feat(ui): shared dashboard primitives — TabCount, ScreenDescription, AgentUsage

### DIFF
--- a/webui-v2/src/components/ui/agent-usage.tsx
+++ b/webui-v2/src/components/ui/agent-usage.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useState } from "react";
+import { Bot, ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface AgentUsageProps {
+  /** The MCP tool name this data backs, e.g. "archigraph_test_coverage". */
+  tool: string;
+  /** A one-line use case, e.g. "An agent lists untested endpoints…". */
+  example: string;
+  /**
+   * When true (default) the strip can be collapsed/expanded and the
+   * collapsed state is persisted in localStorage.
+   */
+  collapsible?: boolean;
+}
+
+const STORAGE_PREFIX = "ag.agentUsage.collapsed.";
+
+function storageKey(tool: string) {
+  return `${STORAGE_PREFIX}${tool}`;
+}
+
+function readCollapsed(tool: string): boolean {
+  try {
+    return localStorage.getItem(storageKey(tool)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The "How agents use this data" banner (#4574 part 2). A subtle, theme-tokened
+ * callout that tells humans how the same data is consumed by AI agents via an
+ * MCP tool. Unobtrusive and (by default) collapsible, with the collapsed state
+ * persisted per-tool in localStorage so power users can hide it for good.
+ */
+export function AgentUsage({ tool, example, collapsible = true }: AgentUsageProps) {
+  const [collapsed, setCollapsed] = useState(() =>
+    collapsible ? readCollapsed(tool) : false,
+  );
+
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(storageKey(tool), next ? "1" : "0");
+      } catch {
+        /* ignore quota / privacy-mode errors */
+      }
+      return next;
+    });
+  }, [tool]);
+
+  const header = (
+    <span className="inline-flex items-center gap-1.5 text-text-3">
+      <Bot size={13} className="text-text-4 shrink-0" />
+      <span className="text-xs font-medium uppercase tracking-wide">
+        How agents use this data
+      </span>
+    </span>
+  );
+
+  return (
+    <div className="rounded-md border border-border bg-surface-2/40 px-3 py-2 max-w-3xl">
+      {collapsible ? (
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          className="flex w-full items-center justify-between gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] rounded-sm"
+        >
+          {header}
+          {collapsed ? (
+            <ChevronRight size={14} className="text-text-4 shrink-0" />
+          ) : (
+            <ChevronDown size={14} className="text-text-4 shrink-0" />
+          )}
+        </button>
+      ) : (
+        header
+      )}
+
+      {!collapsed && (
+        <p
+          className={cn(
+            "text-sm text-text-3 leading-relaxed",
+            collapsible && "mt-1.5",
+          )}
+        >
+          <code className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[12px] text-text-2">
+            {tool}
+          </code>{" "}
+          — {example}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/webui-v2/src/components/ui/index.ts
+++ b/webui-v2/src/components/ui/index.ts
@@ -23,3 +23,12 @@ export {
 } from "./dialog";
 export { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
 export { Skeleton } from "./skeleton";
+export { TabCount } from "./tab-count";
+export type { TabCountProps } from "./tab-count";
+export { ScreenDescription, DefTerm } from "./screen-description";
+export type {
+  ScreenDescriptionProps,
+  ScreenDescriptionTerm,
+} from "./screen-description";
+export { AgentUsage } from "./agent-usage";
+export type { AgentUsageProps } from "./agent-usage";

--- a/webui-v2/src/components/ui/screen-description.tsx
+++ b/webui-v2/src/components/ui/screen-description.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+import { Tooltip, TooltipTrigger, TooltipContent } from "./tooltip";
+
+export interface ScreenDescriptionTerm {
+  /** The word/phrase to render as a hover-definable term. */
+  term: string;
+  /** The definition revealed on hover. */
+  def: ReactNode;
+}
+
+export interface ScreenDescriptionProps {
+  /** The 1-2 sentence plain-language description of the screen/tab. */
+  children: ReactNode;
+  /**
+   * Optional inline glossary. Any occurrence of `term` inside the text
+   * children is *not* auto-replaced; instead these are exposed via the
+   * {@link DefTerm} helper for callers that want hover-definitions inline.
+   * Rendered as a trailing legend so the terms are discoverable.
+   */
+  terms?: ScreenDescriptionTerm[];
+}
+
+/**
+ * A compact plain-language description block for a screen or tab
+ * (#4574 part 1). Generalizes Quality's TabHeader and Taint's PurposeHeader
+ * lead-in: a short, low-chrome paragraph that tells a non-expert what the
+ * view shows, with optional inline hover-definitions for jargon.
+ */
+export function ScreenDescription({ children, terms }: ScreenDescriptionProps) {
+  return (
+    <div className="-mt-1 mb-1 max-w-3xl space-y-1">
+      <p className="text-sm text-text-3 leading-relaxed">{children}</p>
+      {terms && terms.length > 0 && (
+        <p className="text-xs text-text-4 leading-relaxed">
+          {terms.map((t, i) => (
+            <span key={t.term}>
+              {i > 0 && <span className="mx-1.5">·</span>}
+              <DefTerm term={t.term} def={t.def} />
+            </span>
+          ))}
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A hoverable, dotted-underlined term that reveals its definition on hover.
+ * Generalizes Taint's DefTerm (dataflow.tsx). Usable standalone inside a
+ * {@link ScreenDescription}'s children to define jargon inline.
+ */
+export function DefTerm({ term, def }: ScreenDescriptionTerm) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="cursor-help underline decoration-dotted decoration-text-4 underline-offset-2 text-text-2">
+          {term}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{def}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/webui-v2/src/components/ui/tab-count.tsx
+++ b/webui-v2/src/components/ui/tab-count.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/lib/utils";
+
+export interface TabCountProps {
+  /** The numeric count to display. */
+  value: number;
+  /** Visual tone of the badge. */
+  tone?: "neutral" | "warning" | "accent";
+  /** Whether the owning tab is active (brightens the badge). */
+  active?: boolean;
+  /**
+   * Required plain-language description of *what* this count measures,
+   * surfaced as the badge's hover tooltip (e.g. "uncovered endpoints").
+   */
+  label: string;
+  /** When true, render nothing if `value === 0`. Defaults to false. */
+  hideOnZero?: boolean;
+}
+
+/**
+ * A standardized count-badge primitive for tab strips and headers
+ * (#4572 / #4573). Generalizes the ad-hoc TabCount/TabBadge that each
+ * dashboard page reinvented.
+ *
+ * Renders as a plain <span> (never a nested <button>) so it never disturbs
+ * a tab trigger's baseline or active underline. The `label` doubles as the
+ * native title/tooltip so the number is always self-explanatory.
+ */
+export function TabCount({
+  value,
+  tone = "neutral",
+  active = false,
+  label,
+  hideOnZero = false,
+}: TabCountProps) {
+  if (hideOnZero && value === 0) return null;
+
+  const toneClass =
+    tone === "warning"
+      ? "bg-warning-soft text-warning"
+      : tone === "accent"
+        ? "bg-accent-soft text-accent-strong"
+        : "bg-surface-2 text-text-3";
+
+  return (
+    <span
+      title={label}
+      aria-label={`${value} ${label}`}
+      className={cn(
+        "ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5",
+        "rounded-full text-[11px] font-medium tabular-nums leading-none transition-colors",
+        active && tone === "neutral"
+          ? "bg-accent-soft text-accent-strong"
+          : toneClass,
+      )}
+    >
+      {value}
+    </span>
+  );
+}

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -56,6 +56,9 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
+  TabCount,
+  ScreenDescription,
+  AgentUsage,
 } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
@@ -136,29 +139,6 @@ function ErrorState({ what }: { what: string }) {
 // ---------------------------------------------------------------------------
 // § Explanation primitives (#4507) — per-tab headers + per-metric tooltips
 // ---------------------------------------------------------------------------
-
-/** A small, consistent count/value badge for the tab strip. */
-function TabBadge({
-  children,
-  tone = "neutral",
-}: {
-  children: React.ReactNode;
-  tone?: "neutral" | "warning";
-}) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5 rounded-full",
-        "text-[10px] font-semibold tabular-nums leading-none",
-        tone === "warning"
-          ? "bg-warning-soft text-warning"
-          : "bg-surface-2 text-text-3",
-      )}
-    >
-      {children}
-    </span>
-  );
-}
 
 /** A short header line under the tab strip explaining what the tab shows. */
 function TabHeader({ children }: { children: React.ReactNode }) {
@@ -569,11 +549,23 @@ function CoverageTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <TabHeader>
+      <ScreenDescription
+        terms={[
+          {
+            term: "TESTS edge",
+            def: "A graph edge linking a test entity to the production entity it exercises. Coverage here is reachability over these edges, not executed-line coverage.",
+          },
+        ]}
+      >
         Structural test coverage — which production entities (functions, classes,
         endpoints) are reached by a test via a TESTS edge. This is graph reachability,
         not line coverage.
-      </TabHeader>
+      </ScreenDescription>
+
+      <AgentUsage
+        tool="archigraph_test_coverage"
+        example="An agent lists untested endpoints before writing tests."
+      />
 
       <CoverageGauge
         covered={data.covered_production}
@@ -1243,30 +1235,44 @@ export default function QualityScreen() {
               <GaugeCircle size={14} />
               Test coverage
               {!coverage.isLoading && coverage.data && (
-                <TabBadge tone="neutral">
-                  {coverage.data.coverage_pct.toFixed(0)}%
-                </TabBadge>
+                <TabCount
+                  value={Math.round(coverage.data.coverage_pct)}
+                  tone="neutral"
+                  label="percent of production entities reached by a test"
+                />
               )}
             </TabsTrigger>
             <TabsTrigger value="dependencies" className="flex items-center gap-1.5">
               <Boxes size={14} />
               Dependencies
               {!deps.isLoading && deps.data && depHygiene > 0 && (
-                <TabBadge tone="warning">{depHygiene}</TabBadge>
+                <TabCount
+                  value={depHygiene}
+                  tone="warning"
+                  label="dependency-hygiene issues (cycles + orphans)"
+                />
               )}
             </TabsTrigger>
             <TabsTrigger value="anti-patterns" className="flex items-center gap-1.5">
               <Repeat size={14} />
               Anti-patterns
               {!anti.isLoading && anti.data && anti.data.total_findings > 0 && (
-                <TabBadge tone="warning">{anti.data.total_findings}</TabBadge>
+                <TabCount
+                  value={anti.data.total_findings}
+                  tone="warning"
+                  label="anti-pattern findings"
+                />
               )}
             </TabsTrigger>
             <TabsTrigger value="god-nodes" className="flex items-center gap-1.5">
               <Crown size={14} />
               God-nodes
               {!god.isLoading && god.data && god.data.god_nodes.length > 0 && (
-                <TabBadge tone="warning">{god.data.god_nodes.length}</TabBadge>
+                <TabCount
+                  value={god.data.god_nodes.length}
+                  tone="warning"
+                  label="god-nodes (overly-connected entities)"
+                />
               )}
             </TabsTrigger>
             <TabsTrigger value="trends" className="flex items-center gap-1.5">


### PR DESCRIPTION
Foundation pass for the shared dashboard primitives epic. Builds three reusable, theme-tokened components that every dashboard page will adopt, and proves them on the **Quality** page as the single reference implementation. Per-page adoption across the other ~10 routes is a deliberate follow-up wave — no other route files are touched here.

## New shared components (`webui-v2/src/components/ui/`)

### `<TabCount>` (#4573)
One count-badge primitive generalizing Taint's ad-hoc `TabCount`/Quality's `TabBadge`.
- `value: number`
- `tone?: 'neutral' | 'warning' | 'accent'`
- `active?: boolean`
- `label: string` (**required**) — drives the `title`/tooltip describing *what* is counted
- `hideOnZero?: boolean` (default `false`) — standardized zero-handling

Renders a plain `<span>` (never a nested button) so it never disturbs a trigger's active underline. Theme tokens only.

### `<ScreenDescription>` + `<DefTerm>` (#4574 pt 1)
Compact plain-language description block for a screen/tab. Generalizes Quality's `TabHeader` and Taint's `DefTerm`.
- `children` — the 1-2 sentence description
- `terms?: { term, def }[]` — optional inline hover-definitions

### `<AgentUsage>` (#4574 pt 2)
The "How agents use this data" callout.
- `tool: string` — MCP tool name (rendered as a mono chip)
- `example: string` — one-line use case
- `collapsible?: boolean` (default `true`) — collapsed state persisted in `localStorage` per tool

Subtle, theme-tokened, unobtrusive.

## Quality adoption (reference impl)
- Replaced all four `TabBadge` usages with `<TabCount>`, each given a `label`; removed the now-unused `TabBadge`.
- Added `<ScreenDescription>` + `<AgentUsage tool="archigraph_test_coverage" example="An agent lists untested endpoints before writing tests.">` to the Test-coverage tab header.
- Other Quality tabs' descriptions left as-is.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅
- `npx vite build` ✅

Closes #4572
Refs #4573 #4574 #4579

🤖 Generated with [Claude Code](https://claude.com/claude-code)