### PR TITLE
feat(flow-dag): downstream-flow readability — taxonomy, terminal, grouping, external

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDag.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDag.tsx
@@ -142,7 +142,13 @@ function FlowDagInner({
 
   const { nodes, edges } = useMemo(() => {
     if (!unfold) return { nodes: [], edges: [] };
-    const laid = layoutTree(unfold.instances, direction, expanded, onToggleExpand);
+    const laid = layoutTree(
+      unfold.instances,
+      direction,
+      expanded,
+      onToggleExpand,
+      unfold.hasOutEdge,
+    );
     for (const n of laid.nodes) {
       // Selection is driven by the ORIGINAL node id so the caller's contract
       // (Flows step inspector, #4354) is unchanged across the tree unfold; all

--- a/webui-v2/src/components/flow-dag/FlowDagLegend.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagLegend.tsx
@@ -8,7 +8,7 @@
 
 import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { ROLE_STYLE, EXCEPTION_STYLE, EDGE_STYLE } from "./style";
+import { NODE_BUCKET_STYLE, EDGE_STYLE, type NodeBucket } from "./style";
 import type { DownstreamDAGTruncation } from "@/data/types";
 
 interface FlowDagLegendProps {
@@ -26,13 +26,33 @@ function truncationLabels(t: DownstreamDAGTruncation): string[] {
   return out;
 }
 
+/**
+ * Display order of the node taxonomy buckets in the legend (#4566): the spine
+ * left→right, then the special-cased states (exception/external/terminal). The
+ * neutral 'node' fallback is shown last.
+ */
+const LEGEND_BUCKETS: NodeBucket[] = [
+  "endpoint",
+  "handler",
+  "service",
+  "repository",
+  "schema",
+  "function",
+  "collection",
+  "terminal",
+  "exception",
+  "external",
+  "node",
+];
+
 export function FlowDagLegend({ branchCount, nodeCount, truncation }: FlowDagLegendProps) {
   const trunc = truncationLabels(truncation);
 
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2 text-[10px] text-text-3 border-t border-border bg-bg-soft">
-      {/* Roles + the exception/error node accent (#4556, red). */}
-      {[...Object.values(ROLE_STYLE), EXCEPTION_STYLE].map((rs) => (
+      {/* Node taxonomy buckets (#4566): endpoint→…→data, plus exception (#4556,
+          red), external (#4558/#4564, muted), terminal end-cap (#4561). */}
+      {LEGEND_BUCKETS.map((b) => NODE_BUCKET_STYLE[b]).map((rs) => (
         <span key={rs.label} className="inline-flex items-center gap-1">
           <span
             className="size-2.5 rounded-sm shrink-0"

--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -16,12 +16,19 @@
 import { memo } from "react";
 import { useParams } from "react-router-dom";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
-import { ChevronRight, ChevronDown, CircleDot } from "lucide-react";
+import {
+  ChevronRight,
+  ChevronDown,
+  CircleDot,
+  Flag,
+  MoreHorizontal,
+  PackageOpen,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { RepoChip } from "@/lib/repo-color";
 import { effectBadge } from "@/lib/effect-badge";
 import { useSourcePeek } from "@/components/SourcePeek";
-import { nodeStyle, edgeStyle } from "./style";
+import { nodeStyle, isExternalNode, moduleBand, edgeStyle } from "./style";
 import type { FlowDagNodeData } from "./layout";
 
 /**
@@ -30,11 +37,35 @@ import type { FlowDagNodeData } from "./layout";
  * The collapsed-children count badge expands an inline list on click.
  */
 function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps) {
-  const { node, edgeKind, expanded, onToggleExpand, selected, onRoute } =
-    data as FlowDagNodeData;
-  // Exception/error nodes paint red (#4556); otherwise the role tint. The red
-  // hue matches the THROWS edge so a thrown error reads consistently node→edge.
-  const rs = nodeStyle(node, edgeKind);
+  const {
+    node,
+    edgeKind,
+    expanded,
+    onToggleExpand,
+    selected,
+    onRoute,
+    isLeaf,
+    truncatedHere,
+    module: mod,
+  } = data as FlowDagNodeData;
+  // Taxonomy bucket → tint (#4566): exception=red (#4556), external=muted
+  // (#4558/#4564), genuine leaf=Return/finish end-cap (#4561), else role/kind.
+  const rs = nodeStyle(node, edgeKind, isLeaf);
+  // #4558/#4564: an external / unresolved node — render muted, label clearly,
+  // and replace the (broken) source-peek with an 'external symbol' note.
+  const external = isExternalNode(node);
+  // #4561: a genuine terminal end-cap (NOT a branch merely cut by depth).
+  const terminalCap = !!isLeaf;
+  // #4557: per-module color band so same-module nodes read as a unit.
+  const band = moduleBand(mod);
+  // #4558(a): if the callee text is unnamed, fall back to a clear label rather
+  // than an empty card. A truly nameless external reads as 'external symbol'.
+  const displayName =
+    node.name && node.name.trim() !== "" && node.name !== "<...>"
+      ? node.name
+      : external
+        ? "external symbol"
+        : "(unnamed)";
   const { openSourcePeek } = useSourcePeek();
   const { groupId = "" } = useParams<{ groupId: string }>();
   const collapsed = node.collapsed_children ?? [];
@@ -71,16 +102,21 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
         dimmed ? "opacity-25" : "opacity-100",
       )}
       style={{
-        // Role tint as a soft background wash; the ink as the border.
-        background: `color-mix(in srgb, ${rs.bg} 22%, var(--surface))`,
+        // Role/taxonomy tint as a soft background wash; the ink as the border.
+        // External nodes read fainter so they recede from the resolved spine.
+        background: `color-mix(in srgb, ${rs.bg} ${external ? 12 : 22}%, var(--surface))`,
         borderColor: selected || onRoute === true
           ? "var(--accent)"
-          : `color-mix(in srgb, ${rs.ink} 55%, transparent)`,
-        // Selected node, or a node lit on the highlighted route (#4479), gets an
-        // accent ring; otherwise terminal sinks get a heavier outline ring.
+          : external
+            ? "color-mix(in srgb, var(--text-4) 45%, transparent)"
+            : `color-mix(in srgb, ${rs.ink} 55%, transparent)`,
+        // #4557: a left module color-band groups same-module nodes visually.
+        borderLeft: band ? `3px solid ${band.color}` : undefined,
+        // Selected / route-lit (#4479) → accent ring; a genuine terminal
+        // end-cap (#4561) or a collection sink → a heavier outline ring.
         boxShadow: selected || onRoute === true
           ? "0 0 0 2px var(--accent)"
-          : node.terminal
+          : terminalCap || node.terminal
             ? `0 0 0 2px color-mix(in srgb, ${rs.ink} 45%, transparent)`
             : undefined,
       }}
@@ -109,18 +145,37 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
               {edgeLabel}
             </span>
           )}
-          {node.terminal && (
+          {/* #4561: a genuine return/finish end-cap reads distinctly from a
+              collection sink and from a depth-truncated branch. */}
+          {terminalCap && (
+            <span
+              className="inline-flex items-center gap-0.5 h-[15px] px-1 rounded text-[9px] font-semibold uppercase tracking-wide leading-none shrink-0"
+              style={{
+                background: `color-mix(in srgb, ${rs.bg} 38%, transparent)`,
+                color: rs.ink,
+              }}
+              title="Return / finish — this branch terminates here"
+            >
+              <Flag size={9} /> end
+            </span>
+          )}
+          {!terminalCap && node.terminal && (
             <CircleDot size={11} className="shrink-0" style={{ color: rs.ink }} aria-label="terminal" />
           )}
           <RepoChip slug={node.repo} className="ml-auto" maxLength={14} />
         </div>
 
-        {/* Name — responsive size, wraps to 2 lines, full name on hover. */}
+        {/* Name — responsive size, wraps to 2 lines, full name on hover. An
+            external/unnamed callee gets a clear label instead of an empty card
+            (#4558a). */}
         <div
-          className="mt-1 text-[11px] leading-tight font-medium text-text break-words line-clamp-2"
-          title={node.name}
+          className={cn(
+            "mt-1 text-[11px] leading-tight font-medium break-words line-clamp-2",
+            external ? "text-text-3 italic" : "text-text",
+          )}
+          title={displayName}
         >
-          {node.name}
+          {displayName}
         </div>
 
         {/* doc — one-line muted subtitle when present. */}
@@ -154,31 +209,59 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
           )}
         </div>
 
-        {/* file:line — click opens the shared source-peek modal (#4499). */}
-        {fileRef && (
-          <button
-            type="button"
-            onClick={(e) => {
-              // Don't let the node-select / canvas handlers swallow the click.
-              e.stopPropagation();
-              if (node.file && groupId) {
-                openSourcePeek({
-                  groupId,
-                  file: node.file,
-                  line: node.line ?? 0,
-                  repo: node.repo,
-                });
-              }
-            }}
-            className="mt-0.5 flex items-center font-mono text-[10px] text-text-4 tabular-nums min-w-0 w-full text-left cursor-pointer hover:text-accent"
-            title={`${fileRef} — open source`}
+        {/* #4558(b)/#4564: external/unresolved nodes can't be source-peeked.
+            Show an honest 'external symbol' note (with the package name when the
+            node carries one) instead of a broken peek button. */}
+        {external ? (
+          <div
+            className="mt-0.5 flex items-center gap-1 font-mono text-[10px] text-text-4 min-w-0"
+            title={`External symbol — defined outside indexed source${
+              node.package ? ` (${node.package})` : ""
+            }`}
           >
-            {/* head (dir prefix) truncates LTR; tail (filename:line) never shrinks. */}
-            <span className="overflow-hidden whitespace-nowrap text-ellipsis min-w-0 shrink">
-              {fileHead}
+            <PackageOpen size={10} className="shrink-0" />
+            <span className="truncate">
+              external symbol{node.package ? ` · ${node.package}` : ""}
             </span>
-            <span className="shrink-0 whitespace-nowrap">{fileTail}</span>
-          </button>
+          </div>
+        ) : (
+          fileRef && (
+            <button
+              type="button"
+              onClick={(e) => {
+                // Don't let the node-select / canvas handlers swallow the click.
+                e.stopPropagation();
+                if (node.file && groupId) {
+                  openSourcePeek({
+                    groupId,
+                    file: node.file,
+                    line: node.line ?? 0,
+                    repo: node.repo,
+                  });
+                }
+              }}
+              className="mt-0.5 flex items-center font-mono text-[10px] text-text-4 tabular-nums min-w-0 w-full text-left cursor-pointer hover:text-accent"
+              title={`${fileRef} — open source`}
+            >
+              {/* head (dir prefix) truncates LTR; tail (filename:line) never shrinks. */}
+              <span className="overflow-hidden whitespace-nowrap text-ellipsis min-w-0 shrink">
+                {fileHead}
+              </span>
+              <span className="shrink-0 whitespace-nowrap">{fileTail}</span>
+            </button>
+          )
+        )}
+
+        {/* #4561: a branch CUT by the depth control (not a real leaf) keeps a
+            'more downstream' affordance so it's clearly distinct from a terminal. */}
+        {truncatedHere && (
+          <div
+            className="mt-1 inline-flex items-center gap-1 text-[10px] text-text-4"
+            title="More downstream nodes exist below the depth limit — raise depth to expand."
+          >
+            <MoreHorizontal size={11} className="shrink-0" />
+            more downstream
+          </div>
         )}
 
         {/* effect badges — small, only what's present. */}

--- a/webui-v2/src/components/flow-dag/layout.test.ts
+++ b/webui-v2/src/components/flow-dag/layout.test.ts
@@ -4,8 +4,14 @@
  * Run with: npx vitest run src/components/flow-dag/layout.test.ts
  */
 import { describe, it, expect } from "vitest";
-import { unfoldTree } from "./layout";
+import { unfoldTree, layoutTree } from "./layout";
 import { routeInstanceIds } from "./route";
+import {
+  nodeBucket,
+  isExternalNode,
+  nodeModule,
+  moduleBand,
+} from "./style";
 import type { DownstreamDAGEdge, DownstreamDAGNode } from "@/data/types";
 
 function n(id: string): DownstreamDAGNode {
@@ -90,5 +96,148 @@ describe("routeInstanceIds", () => {
   it("returns empty for an unknown focus", () => {
     const { instances } = unfoldTree("a", [n("a")], []);
     expect(routeInstanceIds(instances, "nope").size).toBe(0);
+  });
+});
+
+describe("nodeBucket taxonomy (#4566)", () => {
+  const base = (over: Partial<DownstreamDAGNode>): DownstreamDAGNode => ({
+    id: "x",
+    name: "x",
+    kind: "Operation",
+    repo: "api",
+    ...over,
+  });
+
+  it("classifies the strong backend role priors", () => {
+    expect(nodeBucket(base({ role: "endpoint" }))).toBe("endpoint");
+    expect(nodeBucket(base({ role: "handler" }))).toBe("handler");
+    expect(nodeBucket(base({ role: "collection" }))).toBe("collection");
+  });
+
+  it("routes data effects to repository", () => {
+    expect(nodeBucket(base({ effects: ["db_read"] }))).toBe("repository");
+    expect(nodeBucket(base({ kind: "Repository" }))).toBe("repository");
+  });
+
+  it("routes schema/dto kinds to schema", () => {
+    expect(nodeBucket(base({ kind: "Schema" }))).toBe("schema");
+    expect(nodeBucket(base({ kind: "Operation", subtype: "dto" }))).toBe("schema");
+  });
+
+  it("splits service methods from free functions", () => {
+    expect(nodeBucket(base({ kind: "Operation", subtype: "method" }))).toBe("service");
+    expect(nodeBucket(base({ kind: "Operation", subtype: "function" }))).toBe("function");
+  });
+
+  it("paints exceptions red (precedence over everything)", () => {
+    expect(nodeBucket(base({ kind: "ExceptionType" }))).toBe("exception");
+    expect(nodeBucket(base({ name: "x" }), "THROWS")).toBe("exception");
+  });
+
+  it("folds unknown kinds into the neutral node bucket", () => {
+    expect(nodeBucket(base({ kind: "WeirdThing", role: undefined }))).toBe("node");
+  });
+
+  it("only emits the terminal end-cap for a genuine leaf", () => {
+    // isLeaf=true on a plain node → terminal end-cap (#4561).
+    expect(nodeBucket(base({ role: "node", kind: "WeirdThing" }), undefined, true)).toBe("terminal");
+    // isLeaf=false → keeps its normal bucket (a depth-cut branch).
+    expect(nodeBucket(base({ role: "node", kind: "WeirdThing" }), undefined, false)).toBe("node");
+    // A service method that is a genuine leaf still becomes the end-cap.
+    expect(nodeBucket(base({ kind: "Operation", subtype: "method" }), undefined, true)).toBe("terminal");
+    // A collection sink keeps its own bucket even as a leaf.
+    expect(nodeBucket(base({ role: "collection" }), undefined, true)).toBe("collection");
+  });
+});
+
+describe("isExternalNode (#4558/#4564)", () => {
+  const base = (over: Partial<DownstreamDAGNode>): DownstreamDAGNode => ({
+    id: "x",
+    name: "x",
+    kind: "Operation",
+    repo: "api",
+    ...over,
+  });
+
+  it("honors the explicit external flag", () => {
+    expect(isExternalNode(base({ external: true }))).toBe(true);
+  });
+
+  it("detects synthetic/unresolved nodes with no real file", () => {
+    expect(isExternalNode(base({ file: "<external>", name: "scope.foo" }))).toBe(true);
+    expect(isExternalNode(base({ file: "", kind: "Unresolved" }))).toBe(true);
+  });
+
+  it("does NOT mark a resolved internal node external", () => {
+    expect(isExternalNode(base({ file: "src/foo.ts" }))).toBe(false);
+    // An empty file alone, with no corroborating signal, is not external.
+    expect(isExternalNode(base({ file: "" }))).toBe(false);
+  });
+});
+
+describe("nodeModule + moduleBand (#4557)", () => {
+  const nf = (file?: string): DownstreamDAGNode => ({
+    id: "x",
+    name: "x",
+    kind: "Operation",
+    repo: "api",
+    file,
+  });
+
+  it("prefers a modules/<name> anchor segment", () => {
+    expect(nodeModule(nf("src/modules/billing/svc.ts")).label).toBe("modules/billing");
+  });
+
+  it("falls back to the source directory", () => {
+    expect(nodeModule(nf("src/lib/util.ts")).label).toBe("src/lib");
+  });
+
+  it("buckets file-less nodes into a shared external module with no band", () => {
+    const mod = nodeModule(nf(undefined));
+    expect(mod.key).toBe("__external__");
+    expect(moduleBand(mod)).toBeNull();
+  });
+
+  it("gives same-module nodes the same band color", () => {
+    const a = moduleBand(nodeModule(nf("src/modules/billing/a.ts")));
+    const b = moduleBand(nodeModule(nf("src/modules/billing/b.ts")));
+    expect(a?.color).toBe(b?.color);
+  });
+});
+
+describe("layoutTree leaf vs truncated (#4561)", () => {
+  it("marks a real leaf isLeaf and a depth-cut branch truncatedHere", () => {
+    // DAG: a → b → c. Unfold with maxNodes=2 cuts c, so b is childless-but-cut.
+    const nodes = [n("a"), n("b"), n("c")];
+    const edges = [e("a", "b"), e("b", "c")];
+    const { instances, hasOutEdge } = unfoldTree("a", nodes, edges, 2);
+    const { nodes: rf } = layoutTree(
+      instances,
+      "LR",
+      new Set(),
+      () => {},
+      hasOutEdge,
+    );
+    const byId = new Map(rf.map((x) => [x.id, x.data]));
+    // b emitted no child (cut at cap) but source b has an out-edge → truncated.
+    expect(byId.get("a/b")?.truncatedHere).toBe(true);
+    expect(byId.get("a/b")?.isLeaf).toBe(false);
+  });
+
+  it("marks a node with no out-edges as a genuine leaf", () => {
+    const nodes = [n("a"), n("b")];
+    const edges = [e("a", "b")];
+    const { instances, hasOutEdge } = unfoldTree("a", nodes, edges);
+    const { nodes: rf } = layoutTree(
+      instances,
+      "LR",
+      new Set(),
+      () => {},
+      hasOutEdge,
+    );
+    const byId = new Map(rf.map((x) => [x.id, x.data]));
+    // b has no out-edge in the DAG → genuine leaf, not truncated.
+    expect(byId.get("a/b")?.isLeaf).toBe(true);
+    expect(byId.get("a/b")?.truncatedHere).toBe(false);
   });
 });

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -27,6 +27,7 @@ import type {
   DownstreamDAGEdgeKind,
   DownstreamDAGNode,
 } from "@/data/types";
+import { nodeModule, type NodeModule } from "./style";
 
 /** Orientation toggle → dagre rankdir. */
 export type FlowDagDirection = "LR" | "TB";
@@ -45,6 +46,21 @@ export interface FlowDagNodeData extends Record<string, unknown> {
   expanded: boolean;
   /** Toggle handler for the inline collapsed-children expander (keyed by instance id). */
   onToggleExpand: (instanceId: string) => void;
+  /**
+   * #4561: whether this rendered instance is a GENUINE terminal — a real leaf /
+   * return (the node had no out-edges in the source DAG, or the backend marked
+   * it terminal). Such instances get the 'Return / finish' end-cap.
+   */
+  isLeaf?: boolean;
+  /**
+   * #4561: whether this instance has rendered children CUT by the depth/node
+   * cap — i.e. the source node had out-edges but none were expanded here. These
+   * keep their normal bucket + a 'more downstream' affordance, and must NOT be
+   * confused with a genuine terminal.
+   */
+  truncatedHere?: boolean;
+  /** #4557: the node's module (file-path-derived) for the grouping band. */
+  module?: NodeModule;
   /** Whether this node is the caller's selected node (Flows inspector, #4354). */
   selected?: boolean;
   /**
@@ -83,6 +99,13 @@ export interface UnfoldResult {
   instances: TreeInstance[];
   /** True when expansion stopped because the max-node cap was hit. */
   capped: boolean;
+  /**
+   * Source-node ids that have at least one out-edge in the DAG (#4561). An
+   * instance that emitted NO children but whose source id is in this set was
+   * truncated (depth/cap/cycle-guard), not a genuine leaf. Used by layoutTree
+   * to distinguish a real terminal from a cut branch.
+   */
+  hasOutEdge: Set<string>;
 }
 
 // Node box sizing fed to dagre. Kept generous so labels + repo chip fit; the
@@ -137,8 +160,12 @@ export function unfoldTree(
     else out.set(e.from, [{ to: e.to, kind: e.kind }]);
   }
 
+  // Source ids that have ≥1 out-edge in the DAG. An instance of such a node
+  // that emits no children was truncated, not a genuine leaf (#4561).
+  const hasOutEdge = new Set<string>(out.keys());
+
   const root = nodeById.get(rootId) ?? nodes[0];
-  if (!root) return { instances: [], capped: false };
+  if (!root) return { instances: [], capped: false, hasOutEdge };
 
   const instances: TreeInstance[] = [];
   let capped = false;
@@ -192,7 +219,7 @@ export function unfoldTree(
     if (capped) break;
   }
 
-  return { instances, capped };
+  return { instances, capped, hasOutEdge };
 }
 
 /**
@@ -208,7 +235,14 @@ export function layoutTree(
   direction: FlowDagDirection,
   expanded: Set<string>,
   onToggle: (instanceId: string) => void,
+  hasOutEdge?: Set<string>,
 ): { nodes: FlowDagNode[]; edges: FlowDagEdge[] } {
+  // Which instances actually emitted children in this unfold — to tell a real
+  // leaf from a depth-truncated branch (#4561).
+  const renderedParents = new Set<string>();
+  for (const inst of instances) {
+    if (inst.parentId != null) renderedParents.add(inst.parentId);
+  }
   const g = new dagre.graphlib.Graph();
   g.setGraph({
     rankdir: direction,
@@ -234,6 +268,15 @@ export function layoutTree(
 
   const rfNodes: FlowDagNode[] = instances.map((inst) => {
     const pos = g.node(inst.id);
+    // #4561: this instance emitted no children here.
+    const childlessHere = !renderedParents.has(inst.id);
+    // The source node has downstream edges in the DAG.
+    const sourceHasChildren = hasOutEdge?.has(inst.node.id) ?? false;
+    // A genuine terminal: the backend marked it terminal, OR it's childless AND
+    // the source node truly has no out-edges (a real leaf / return).
+    const isLeaf = childlessHere && (inst.node.terminal === true || !sourceHasChildren);
+    // Cut by the depth/node cap: childless HERE but the source DID have children.
+    const truncatedHere = childlessHere && sourceHasChildren && inst.node.terminal !== true;
     return {
       id: inst.id,
       type: NODE_TYPE,
@@ -244,6 +287,9 @@ export function layoutTree(
         edgeKind: inst.edgeKind,
         expanded: expanded.has(inst.id),
         onToggleExpand: onToggle,
+        isLeaf,
+        truncatedHere,
+        module: nodeModule(inst.node),
       },
       sourcePosition: sourcePos,
       targetPosition: targetPos,

--- a/webui-v2/src/components/flow-dag/style.ts
+++ b/webui-v2/src/components/flow-dag/style.ts
@@ -1,10 +1,17 @@
 /* ============================================================
-   components/flow-dag/style.ts — role + edge-kind visual vocabulary.
+   components/flow-dag/style.ts — node taxonomy + edge-kind visual vocabulary.
 
    Single source of truth for how the downstream-DAG looks, so the node
    renderer, edge renderer, and legend all agree. All colors route through the
    shared design tokens (tokens.css) — no hardcoded hex — so theme switching is
    free.
+
+   #4566: the node palette is now a data-driven TAXONOMY. Each rendered node is
+   classified into ~8-10 buckets derived from its role + kind + subtype +
+   effects (never from a framework name), and each bucket carries a pastel token
+   pair + legend label. Rare/unknown kinds fold into a neutral 'Node'. The
+   exception bucket (#4556, red) and the terminal end-cap (#4561) are part of the
+   same map so node, edge, and legend stay in lockstep.
    ============================================================ */
 
 import type {
@@ -13,7 +20,30 @@ import type {
   DownstreamDAGRole,
 } from "@/data/types";
 
-/** Per-role node styling: a pastel token pair + a short legend label. */
+/* ------------------------------------------------------------------
+   Node taxonomy (#4566)
+   ------------------------------------------------------------------ */
+
+/**
+ * The visual bucket a node falls into. Capped at ~8-10 so the legend stays
+ * scannable; everything that doesn't classify folds into `node` (the neutral
+ * spine step). Derivation is signal-based (role/kind/subtype/effects), never
+ * framework-name based, so it generalizes across every indexed stack.
+ */
+export type NodeBucket =
+  | "endpoint"
+  | "handler"
+  | "service"
+  | "repository"
+  | "schema"
+  | "function"
+  | "exception"
+  | "external"
+  | "terminal"
+  | "collection"
+  | "node";
+
+/** Per-bucket styling: a pastel token pair + a short legend label. */
 export interface RoleStyle {
   /** CSS background for the node body. */
   bg: string;
@@ -23,43 +53,44 @@ export interface RoleStyle {
 }
 
 /**
- * Role → token pair. endpoint (the root) is the most prominent; collection
- * sinks read as terminal data stores; handler is the HTTP-boundary crossing;
- * node is a generic spine step.
+ * Bucket → token pair + label. Endpoint (the root) is the most prominent;
+ * handler is the HTTP-boundary crossing; service/repository/schema/function
+ * split the body of the spine by what the node DOES; exception is red (#4556);
+ * external is muted (#4558/#4564); terminal is the return/finish end-cap
+ * (#4561); collection sinks read as terminal data stores; node is the neutral
+ * fallback.
  */
-export const ROLE_STYLE: Record<DownstreamDAGRole, RoleStyle> = {
+export const NODE_BUCKET_STYLE: Record<NodeBucket, RoleStyle> = {
   endpoint: { bg: "var(--pastel-2)", ink: "var(--pastel-2-ink)", label: "Endpoint" },
   handler: { bg: "var(--pastel-1)", ink: "var(--pastel-1-ink)", label: "Handler" },
-  node: { bg: "var(--pastel-5)", ink: "var(--pastel-5-ink)", label: "Node" },
+  service: { bg: "var(--pastel-5)", ink: "var(--pastel-5-ink)", label: "Service / logic" },
+  repository: { bg: "var(--pastel-4)", ink: "var(--pastel-4-ink)", label: "Repository / data" },
+  schema: { bg: "var(--pastel-6)", ink: "var(--pastel-6-ink)", label: "DTO / schema" },
+  function: { bg: "var(--pastel-7)", ink: "var(--pastel-7-ink)", label: "Function" },
+  exception: { bg: "var(--danger)", ink: "var(--exception-ink)", label: "Exception" },
+  external: { bg: "var(--text-4)", ink: "var(--text-3)", label: "External / library" },
+  terminal: { bg: "var(--pastel-8)", ink: "var(--pastel-8-ink)", label: "Return / finish" },
   collection: { bg: "var(--pastel-3)", ink: "var(--pastel-3-ink)", label: "Collection" },
+  node: { bg: "var(--pastel-5)", ink: "var(--pastel-5-ink)", label: "Node" },
 };
 
-/** Fallback for an unexpected/missing role — render as a generic node. */
-export function roleStyle(role: DownstreamDAGRole | undefined): RoleStyle {
-  return (role && ROLE_STYLE[role]) || ROLE_STYLE.node;
-}
-
 /**
- * Exception/error node styling (#4556). A red tint + red ink so a node where an
- * error is raised stands out from the neutral spine. The hue matches the red
- * THROWS edge (--danger) so a thrown error reads consistently node→edge; the
- * ink is a contrast-tuned red (--exception-ink) that stays legible as the pill
- * text + border over the @22% danger wash in BOTH light and dark themes.
+ * Legacy role → bucket. The backend still ships a coarse `role`; we keep it as
+ * a strong prior, then refine with kind/subtype/effects below.
  */
-export const EXCEPTION_STYLE: RoleStyle = {
-  bg: "var(--danger)",
-  ink: "var(--exception-ink)",
-  label: "Exception",
+const ROLE_TO_BUCKET: Record<DownstreamDAGRole, NodeBucket> = {
+  endpoint: "endpoint",
+  handler: "handler",
+  collection: "collection",
+  node: "node",
 };
 
 /**
- * Detect whether a node represents an exception/error site so it can be painted
- * red. Conservative, signal-based (#4556): the node's KIND is ExceptionType, OR
- * its name carries the canonical "exception:" prefix, OR the parent reached it
- * via a THROWS edge (it's the target of a throw). We deliberately do NOT paint
- * every node whose name merely contains "Error"/"Exception" — that over-paints
- * ordinary error-handling helpers. `incomingEdgeKind` is the kind of the single
- * in-edge feeding this rendered instance (undefined for the root).
+ * #4556 (kept): is this node an exception/error site? Conservative,
+ * signal-based: the node's KIND is ExceptionType, OR its name carries the
+ * canonical "exception:" prefix, OR the parent reached it via a THROWS edge.
+ * We deliberately do NOT paint every node whose name merely contains
+ * "Error"/"Exception" — that over-paints ordinary error-handling helpers.
  */
 export function isExceptionNode(
   node: Pick<DownstreamDAGNode, "kind" | "name">,
@@ -73,17 +104,225 @@ export function isExceptionNode(
 }
 
 /**
- * Resolve the node body style: an exception/error node gets the red EXCEPTION
- * palette; otherwise it falls back to its role tint. Used by the node renderer.
+ * #4558/#4564: is this node EXTERNAL / unresolved — i.e. defined outside the
+ * indexed source? Signal-based: an explicit external flag, no resolvable
+ * source file (empty / `<...>` placeholder), or a `scope.operation` /
+ * synthetic-scope name the backend uses for symbols it couldn't bind. These
+ * nodes can't be source-peeked and should read muted, not as an empty card.
+ *
+ * (We do NOT treat ExceptionType as external here — exceptions are their own
+ * red bucket and take precedence.)
+ */
+export function isExternalNode(
+  node: Pick<DownstreamDAGNode, "kind" | "name" | "file"> & {
+    external?: boolean;
+  },
+): boolean {
+  if (node.external === true) return true;
+  const file = (node.file ?? "").trim();
+  // No file, or a synthetic placeholder like "<external>" / "<builtin>".
+  if (file === "" || (file.startsWith("<") && file.endsWith(">"))) {
+    // An empty file alone isn't conclusive (some real leaves omit it), so we
+    // require a corroborating signal: a scope-style name or an explicit
+    // external/unknown kind.
+    if (
+      node.name.startsWith("scope.") ||
+      node.name.startsWith("<") ||
+      node.kind === "External" ||
+      node.kind === "ExternalSymbol" ||
+      node.kind === "Unknown" ||
+      node.kind === "Unresolved"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Lowercased haystack of the classification signals, computed once. */
+function sig(node: Pick<DownstreamDAGNode, "kind" | "subtype">): {
+  kind: string;
+  subtype: string;
+} {
+  return {
+    kind: (node.kind ?? "").toLowerCase(),
+    subtype: (node.subtype ?? "").toLowerCase(),
+  };
+}
+
+/**
+ * Classify a node into a taxonomy bucket (#4566). Precedence, highest first:
+ *   1. exception (red, #4556)
+ *   2. external / unresolved (muted, #4558/#4564)
+ *   3. terminal end-cap (#4561) — only when the caller marks it a real leaf
+ *   4. role==endpoint / handler / collection (strong backend prior)
+ *   5. repository / data — db_read|db_write|cache effects, or a Repository kind
+ *   6. schema / dto — Schema/DTO/Model kinds or subtypes
+ *   7. service / logic — an Operation·method (a method on a service)
+ *   8. function — an Operation·function (free function)
+ *   9. node — neutral fallback
+ *
+ * `isLeaf` distinguishes a genuine terminal (real leaf / return) from a node
+ * whose children were merely cut by the depth control; the latter must NOT get
+ * the end-cap (it keeps its normal bucket + the 'more/depth' affordance).
+ */
+export function nodeBucket(
+  node: Pick<DownstreamDAGNode, "kind" | "name" | "role" | "subtype" | "effects"> & {
+    external?: boolean;
+    file?: string;
+  },
+  incomingEdgeKind?: DownstreamDAGEdgeKind,
+  isLeaf = false,
+): NodeBucket {
+  if (isExceptionNode(node, incomingEdgeKind)) return "exception";
+  if (isExternalNode(node)) return "external";
+
+  // A genuine terminal (real leaf / return) that isn't a known collection sink
+  // gets the dedicated end-cap. role==collection keeps its own bucket below.
+  if (isLeaf && node.role !== "collection" && node.role !== "endpoint") {
+    return "terminal";
+  }
+
+  if (node.role && (node.role === "endpoint" || node.role === "handler" || node.role === "collection")) {
+    return ROLE_TO_BUCKET[node.role];
+  }
+
+  const { kind, subtype } = sig(node);
+  const effects = (node.effects ?? []).map((e) => e.toLowerCase());
+
+  // Repository / data: any data effect, or an explicitly data-ish kind.
+  const dataEffect = effects.some(
+    (e) =>
+      e.includes("db_read") ||
+      e.includes("db_write") ||
+      e.includes("db") ||
+      e.includes("cache") ||
+      e.includes("query"),
+  );
+  if (
+    dataEffect ||
+    kind.includes("repository") ||
+    kind.includes("repo") ||
+    subtype.includes("repository") ||
+    subtype.includes("dao")
+  ) {
+    return "repository";
+  }
+
+  // DTO / schema: declarative data shapes.
+  if (
+    kind.includes("schema") ||
+    kind.includes("dto") ||
+    kind.includes("model") ||
+    subtype.includes("schema") ||
+    subtype.includes("dto") ||
+    subtype.includes("model")
+  ) {
+    return "schema";
+  }
+
+  // Service vs free function: an Operation carries a method/function subtype.
+  if (kind.includes("operation") || kind.includes("method") || kind.includes("function")) {
+    if (subtype.includes("method") || kind.includes("method")) return "service";
+    if (subtype.includes("function") || kind.includes("function")) return "function";
+    // Bare Operation with no subtype reads as service/logic.
+    return "service";
+  }
+
+  return "node";
+}
+
+/** Fallback for an unexpected/missing role — render as a generic node. */
+export function roleStyle(role: DownstreamDAGRole | undefined): RoleStyle {
+  return (role && NODE_BUCKET_STYLE[ROLE_TO_BUCKET[role]]) || NODE_BUCKET_STYLE.node;
+}
+
+/**
+ * Exception/error node styling (#4556). Exposed for back-compat; equal to the
+ * exception taxonomy bucket.
+ */
+export const EXCEPTION_STYLE: RoleStyle = NODE_BUCKET_STYLE.exception;
+
+/**
+ * Resolve the node body style from its taxonomy bucket (#4566). `isLeaf` lets
+ * the renderer request the terminal end-cap for a genuine leaf (#4561).
  */
 export function nodeStyle(
-  node: Pick<DownstreamDAGNode, "kind" | "name" | "role">,
+  node: Pick<DownstreamDAGNode, "kind" | "name" | "role" | "subtype" | "effects"> & {
+    external?: boolean;
+    file?: string;
+  },
   incomingEdgeKind?: DownstreamDAGEdgeKind,
+  isLeaf = false,
 ): RoleStyle {
-  return isExceptionNode(node, incomingEdgeKind)
-    ? EXCEPTION_STYLE
-    : roleStyle(node.role);
+  return NODE_BUCKET_STYLE[nodeBucket(node, incomingEdgeKind, isLeaf)];
 }
+
+/* ------------------------------------------------------------------
+   Module grouping (#4557)
+   ------------------------------------------------------------------ */
+
+/** A node's module bucket: a stable key + a human label. */
+export interface NodeModule {
+  key: string;
+  label: string;
+}
+
+/**
+ * Derive a node's MODULE from its source-file path (#4557). Mirrors the
+ * paths-view group-by-module logic (#4485): prefer a
+ * `modules|apps|packages|services|domains/<name>` anchor segment, else the
+ * file's directory, else a single shared "external"/"(ungrouped)" bucket for
+ * nodes with no resolvable file (external/synthetic). Framework-agnostic.
+ */
+export function nodeModule(
+  node: Pick<DownstreamDAGNode, "file" | "repo"> & { external?: boolean },
+): NodeModule {
+  const file = (node.file ?? "").replace(/\\/g, "/").trim();
+  if (file === "" || (file.startsWith("<") && file.endsWith(">"))) {
+    return { key: "__external__", label: "external" };
+  }
+  const segs = file.split("/").filter(Boolean);
+
+  const ANCHORS = ["modules", "apps", "packages", "services", "domains"];
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (ANCHORS.includes(segs[i].toLowerCase())) {
+      const label = `${segs[i]}/${segs[i + 1]}`;
+      return { key: `${node.repo}:${label.toLowerCase()}`, label };
+    }
+  }
+
+  if (segs.length > 1) {
+    const dir = segs.slice(0, -1).join("/");
+    return { key: `${node.repo}:${dir.toLowerCase()}`, label: dir };
+  }
+
+  return { key: `${node.repo}:__root__`, label: file };
+}
+
+/** Number of categorical pastel slots in tokens.css (--pastel-1 … --pastel-10). */
+const MODULE_BAND_SLOTS = 10;
+
+/**
+ * Stable per-module accent color (#4557). Hashes the module key onto the
+ * categorical pastel scale so every node of the same module shares a left
+ * color-band, making related work read as a unit regardless of layout
+ * direction / depth / fullscreen. The synthetic "external" bucket always reads
+ * muted (no band hue).
+ */
+export function moduleBand(mod: NodeModule | undefined): { color: string } | null {
+  if (!mod || mod.key === "__external__") return null;
+  let h = 0;
+  for (let i = 0; i < mod.key.length; i++) {
+    h = (h * 31 + mod.key.charCodeAt(i)) | 0;
+  }
+  const slot = (Math.abs(h) % MODULE_BAND_SLOTS) + 1;
+  return { color: `var(--pastel-${slot}-ink)` };
+}
+
+/* ------------------------------------------------------------------
+   Edges
+   ------------------------------------------------------------------ */
 
 /** Per-edge-kind styling: stroke color, dashed?, and a short label. */
 export interface EdgeStyle {

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2445,6 +2445,19 @@ export interface DownstreamDAGNode {
   effects?: string[];
   /** Collection/table name for a collection-terminal node (role=collection). */
   collection?: string;
+  /**
+   * True when this node is defined OUTSIDE the indexed source — an external
+   * library / unresolved symbol (#4558/#4564). When set, the renderer shows a
+   * muted 'external' card and skips the (broken) source-peek. Optional: when
+   * absent the renderer falls back to file/kind/name heuristics.
+   */
+  external?: boolean;
+  /**
+   * Package / library name an external node belongs to, when the backend can
+   * recover it (e.g. "stripe", "django.db") — surfaced on the external card's
+   * peek copy (#4564). Optional.
+   */
+  package?: string;
   /** Builder/predicate noise folded into this node in spine mode (empty in full). */
   collapsed_children?: DownstreamDAGCollapsedChild[];
 }


### PR DESCRIPTION
Implements the downstream-flow / flow-dag **readability cluster** as one coordinated pass on the flow-dag component (all touch the same files). Builds on #4556 (red exception nodes).

## What changed (all in `webui-v2/src/components/flow-dag/*` + the DAG node type)

### #4566 — node taxonomy / colors
`style.ts` now exposes a data-driven `NODE_BUCKET_STYLE` (~10 buckets, capped): **Endpoint, Handler, Service/logic, Repository/data, DTO/schema, Function, Exception (red, #4556), External/library (muted), Return/finish (terminal), Collection**, plus a neutral **Node** fallback. `nodeBucket()` classifies from `role` + `kind` + `subtype` + `effects` — no framework hardcoding (db/cache effects → repository, schema/dto/model → schema, Operation·method → service vs Operation·function → function). `FlowDagLegend` renders every bucket.

### #4561 — terminal node
`layoutTree` distinguishes a **genuine terminal** (real leaf / return — source node has no out-edges, or backend `terminal`) from a branch **cut by the depth/node cap** (childless here but the source node *did* have out-edges), using a new `hasOutEdge` set from `unfoldTree`. Genuine leaves get a distinct **Return/finish** end-cap (own color + `Flag` badge + ring); truncated branches keep their bucket and get a **'more downstream'** affordance. Both in the legend.

### #4557 — grouping by module
`nodeModule()` derives a module from the node's file path (mirrors the #4485 `modules|apps|packages|services|domains/<name>` anchors, else directory). `moduleBand()` hashes the module key onto the pastel scale so same-module nodes share a **left color-band**. Works with Spine/Full + depth + fullscreen (per-node, layout-independent).

### #4558 + #4564 — external / synthetic nodes (display side)
`isExternalNode()` flags external/unresolved nodes (explicit `external` flag, empty/`<...>` source file, `scope.*` / `<...>` names, `Unresolved`/`External`/`Unknown` kinds). Such nodes render **muted**, with a name fallback (clear `external symbol` label instead of an empty card), and replace the broken source-peek with **"External symbol — defined outside indexed source"** (plus package name when carried). Added optional `external` / `package` fields to `DownstreamDAGNode`.

## Gates
- `npx tsc --noEmit` — clean
- `npx vite build` — OK
- `npx vitest run src/components/flow-dag/layout.test.ts` — **22 passed** (taxonomy, external detection, module/band, leaf-vs-truncated)

## Note on #4558
The **display** side is handled here. The **extraction** side (recovering a lost callee name + populating `external`/`package` on the payload) is a **backend follow-up** — the UI consumes those fields when present and degrades gracefully (heuristics) when absent.

Closes #4566
Refs #4557 #4558 #4561 #4564

🤖 Generated with [Claude Code](https://claude.com/claude-code)