### PR TITLE
feat(webui): page descriptions + agent-usage banners (refs #4574 #4581)

### DIFF
--- a/webui-v2/src/components/ui/tab-count.tsx
+++ b/webui-v2/src/components/ui/tab-count.tsx
@@ -14,6 +14,12 @@ export interface TabCountProps {
   label: string;
   /** When true, render nothing if `value === 0`. Defaults to false. */
   hideOnZero?: boolean;
+  /**
+   * Optional unit glyph appended directly after the value (e.g. "%"), so a
+   * badge can render "18%" rather than a bare "18". Included in the
+   * aria-label for screen readers.
+   */
+  suffix?: string;
 }
 
 /**
@@ -31,6 +37,7 @@ export function TabCount({
   active = false,
   label,
   hideOnZero = false,
+  suffix,
 }: TabCountProps) {
   if (hideOnZero && value === 0) return null;
 
@@ -44,7 +51,7 @@ export function TabCount({
   return (
     <span
       title={label}
-      aria-label={`${value} ${label}`}
+      aria-label={`${value}${suffix ?? ""} ${label}`}
       className={cn(
         "ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1.5",
         "rounded-full text-[11px] font-medium tabular-nums leading-none transition-colors",
@@ -54,6 +61,7 @@ export function TabCount({
       )}
     >
       {value}
+      {suffix}
     </span>
   );
 }

--- a/webui-v2/src/routes/dataflow.tsx
+++ b/webui-v2/src/routes/dataflow.tsx
@@ -61,6 +61,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
+  AgentUsage,
 } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
@@ -752,6 +753,11 @@ export default function DataflowScreen() {
 
           <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
             <PurposeHeader />
+
+            <AgentUsage
+              tool="archigraph_data_flows"
+              example="An agent reviewing a PR checks if user input reaches a DB/shell sink unsanitized."
+            />
 
             {/* Summary */}
             <div className="flex flex-wrap gap-3">

--- a/webui-v2/src/routes/di.tsx
+++ b/webui-v2/src/routes/di.tsx
@@ -54,6 +54,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
   TooltipContent,
+  ScreenDescription,
+  AgentUsage,
 } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
@@ -450,6 +452,17 @@ function DIBody({ data }: { data: DIReport }) {
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
+      <ScreenDescription>
+        Dependency injection — which providers (services, tokens) get injected
+        into which consumers (controllers, services, handlers). Each row is a real
+        INJECTED_INTO edge, so you can see what wires into what across frameworks.
+      </ScreenDescription>
+
+      <AgentUsage
+        tool="archigraph_neighbors"
+        example="An agent finds every consumer of a provider before changing its interface."
+      />
+
       {/* Summary */}
       <div className="flex flex-wrap gap-3">
         <SummaryStat label="Providers" value={data.total_providers} />

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -15,7 +15,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { X, RotateCcw, SlidersHorizontal, Boxes } from "lucide-react";
-import { SearchInput, Pill, Kbd } from "@/components/ui";
+import { SearchInput, Pill, Kbd, ScreenDescription, AgentUsage } from "@/components/ui";
 import { useGraph } from "@/hooks/use-graph";
 import { useModuleAnalysis } from "@/hooks/use-module-analysis";
 import {
@@ -540,6 +540,22 @@ export default function GraphScreen() {
         </div>
       </div>
 
+      {/* Intro / legend header — the landing screen otherwise has no lead-in.
+          Kept compact so the canvas stays the hero. */}
+      <div className="shrink-0 border-b border-border bg-bg px-4 py-2 space-y-2">
+        <ScreenDescription>
+          The dependency graph — every indexed entity (files, classes, functions)
+          and the edges between them (imports, calls, references). Search to jump
+          to a symbol, color by repo/kind/community, or collapse to a module
+          overview. Node color encodes the active mode; faint peripheral nodes are
+          low-degree leaves, not orphans.
+        </ScreenDescription>
+        <AgentUsage
+          tool="archigraph_find"
+          example="An agent locates a symbol and its neighbors instead of grepping."
+        />
+      </div>
+
       {/* Canvas + overlays */}
       <div className="relative min-h-0 flex-1">
         {s.moduleOverviewMode ? (
@@ -716,7 +732,7 @@ export default function GraphScreen() {
                   <span className="text-text-4">·</span>
                   <span className="tabular-nums">{orphanCount.toLocaleString()} unconnected</span>
                   {hiddenLowDegreeCount > 0 ? (
-                    <span className="tabular-nums text-amber-500">
+                    <span className="tabular-nums text-warning">
                       · {hiddenLowDegreeCount.toLocaleString()} hidden
                     </span>
                   ) : null}

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -60,6 +60,8 @@ import {
   TabsTrigger,
   TooltipProvider,
   InfoLabel,
+  ScreenDescription,
+  AgentUsage,
 } from "@/components/ui";
 import {
   useSystemStatus,
@@ -1826,6 +1828,18 @@ export default function OperationsScreen() {
             Daemon control, pattern store, quality measurement, and version management.
           </p>
         </header>
+
+        <div className="mb-6 space-y-3">
+          <ScreenDescription>
+            Operations — run and inspect the daemon behind this group: system health
+            and indexing, the learned-pattern store, graph-quality measurement
+            (unresolved references, orphan audit, recall), and version updates.
+          </ScreenDescription>
+          <AgentUsage
+            tool="archigraph_repairs"
+            example="An agent reviews unresolved references and repairs before relying on the graph."
+          />
+        </div>
 
         <Tabs defaultValue="system">
           <TabsList className="mb-6">

--- a/webui-v2/src/routes/pending.tsx
+++ b/webui-v2/src/routes/pending.tsx
@@ -16,7 +16,16 @@ import { toast } from "sonner";
 
 import { useCandidates, useSaveHint } from "@/hooks/use-pending";
 import { usePendingStore } from "@/store/use-pending-store";
-import { Badge, Button, Tabs, TabsList, TabsTrigger, Skeleton } from "@/components/ui";
+import {
+  Badge,
+  Button,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Skeleton,
+  ScreenDescription,
+  AgentUsage,
+} from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 import type {
@@ -710,6 +719,19 @@ export default function PendingScreen() {
             {totalUnresolved} unresolved
           </Badge>
         )}
+      </div>
+
+      {/* Intro */}
+      <div className="shrink-0 px-4 pt-3 space-y-2 border-b border-border-soft bg-bg">
+        <ScreenDescription>
+          Pending candidates — edits archigraph has queued but not yet applied to
+          the graph: repairs (resolving an unresolved reference) and enrichments
+          (adding inferred metadata). Review each, then accept or dismiss it.
+        </ScreenDescription>
+        <AgentUsage
+          tool="archigraph_enrichments"
+          example="An agent checks pending enrichments/repairs queued for the graph."
+        />
       </div>
 
       {/* Tab bar */}

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -140,11 +140,6 @@ function ErrorState({ what }: { what: string }) {
 // § Explanation primitives (#4507) — per-tab headers + per-metric tooltips
 // ---------------------------------------------------------------------------
 
-/** A short header line under the tab strip explaining what the tab shows. */
-function TabHeader({ children }: { children: React.ReactNode }) {
-  return <p className="text-sm text-text-3 -mt-1 mb-1 max-w-3xl">{children}</p>;
-}
-
 /**
  * A hoverable info icon that reveals a metric definition: what it means, how
  * it's computed, and the goal. Sits next to a metric label/title.
@@ -717,11 +712,16 @@ function DependenciesTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <TabHeader>
+      <ScreenDescription>
         Dependency hygiene — declared third-party packages cross-checked against
         what the code actually imports. Surfaces unused (declared, never imported)
         and phantom (imported, never declared) packages per repository.
-      </TabHeader>
+      </ScreenDescription>
+
+      <AgentUsage
+        tool="archigraph_import_cycles"
+        example="An agent checks for circular imports before splitting or moving a module."
+      />
 
       <div className="flex flex-wrap gap-3">
         <MetricStat
@@ -861,11 +861,16 @@ function AntiPatternsTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <TabHeader>
+      <ScreenDescription>
         Anti-patterns — code shapes the indexer flags as likely performance or
         correctness smells. Currently surfaces N+1 query patterns: an ORM query
         executed inside a loop, which issues one query per iteration.
-      </TabHeader>
+      </ScreenDescription>
+
+      <AgentUsage
+        tool="archigraph_graph_patterns"
+        example="An agent scans for recurring anti-patterns before approving a change."
+      />
 
       <div className="flex flex-wrap gap-3">
         <MetricStat
@@ -966,11 +971,16 @@ function GodNodesTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <TabHeader>
+      <ScreenDescription>
         God-nodes — high-centrality hub entities that many other things depend on
         or route through. They concentrate risk: a change here ripples widely.
         Ranked by PageRank over the dependency graph; refactor candidates.
-      </TabHeader>
+      </ScreenDescription>
+
+      <AgentUsage
+        tool="archigraph_impact_radius"
+        example="An agent measures how far a change to a hub entity ripples before touching it."
+      />
 
       <div className="flex flex-wrap gap-3">
         <MetricStat
@@ -1186,12 +1196,17 @@ function TrendsTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <TabHeader>
+      <ScreenDescription>
         Trends — how each quality metric moves across successive re-indexes. A
         sparkline appears only once there's genuine multi-snapshot history;
         freshly-indexed groups show the current value with a goal until history
         builds up.
-      </TabHeader>
+      </ScreenDescription>
+
+      <AgentUsage
+        tool="archigraph_test_coverage"
+        example="An agent tracks whether test coverage is trending up or down across re-indexes."
+      />
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {data.metrics.map((m) => (
           <MetricTrendCard key={m.label} m={m} />
@@ -1237,6 +1252,7 @@ export default function QualityScreen() {
               {!coverage.isLoading && coverage.data && (
                 <TabCount
                   value={Math.round(coverage.data.coverage_pct)}
+                  suffix="%"
                   tone="neutral"
                   label="percent of production entities reached by a test"
                 />


### PR DESCRIPTION
## What

Adds a plain-language `<ScreenDescription>` and a "How agents use this data" `<AgentUsage>` banner to each dashboard page so non-experts understand what they're looking at and power users see the matching MCP tool. Part of epic #4579 (refs #4574, #4581).

### Per-file
- **di.tsx** — description (which providers inject into which consumers) + `archigraph_neighbors` banner.
- **graph.tsx** — new compact intro/legend header (the landing screen had none) + `archigraph_find` banner. Also #4581: replaced hardcoded `text-amber-500` on the low-degree badge with the theme token `text-warning`.
- **dataflow.tsx** — kept the existing PurposeHeader; added just the `archigraph_data_flows` banner.
- **operations.tsx** — screen description for its tabs (system / patterns / quality / updates) + `archigraph_repairs` banner.
- **pending.tsx** — description (queued repairs + enrichments) + `archigraph_enrichments` banner.
- **quality.tsx** — added `<ScreenDescription>` + `<AgentUsage>` to the remaining tabs (Dependencies→`archigraph_import_cycles`, Anti-patterns→`archigraph_graph_patterns`, God-nodes→`archigraph_impact_radius`, Trends→`archigraph_test_coverage`), replacing the old local `TabHeader` (now removed). Coverage tab was already done in #4589.
- **tab-count.tsx** — added optional `suffix?: string` prop (e.g. `'%'`) and updated the Quality coverage `<TabCount>` to pass `suffix="%"` so the badge renders `18%` again (the #4589 numeric primitive had dropped the glyph).

## Gates
- `npm ci` — clean
- `npx tsc --noEmit` — passes
- `npx vite build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)