### PR TITLE
fix(dashboard): enrich cross-repo link payload with source/target names + files (#4596)

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -182,6 +182,20 @@ type CrossRepoLink struct {
 	Confidence float64 `json:"confidence,omitempty"`
 	Channel    string  `json:"channel,omitempty"`
 	Method     string  `json:"method,omitempty"`
+
+	// Enrichment fields resolved from the source/target entities at serve time
+	// (#4596). They are NOT persisted to the on-disk links file — UnmarshalJSON
+	// ignores them — and are populated by enrichLinkEndpoints just before the
+	// /links payload is written, so the frontend can render readable names and
+	// open a real source-peek instead of only a graph deep-link fallback.
+	SourceName          string `json:"source_name,omitempty"`
+	SourceQualifiedName string `json:"source_qualified_name,omitempty"`
+	SourceFile          string `json:"source_file,omitempty"`
+	SourceLine          int    `json:"source_line,omitempty"`
+	TargetName          string `json:"target_name,omitempty"`
+	TargetQualifiedName string `json:"target_qualified_name,omitempty"`
+	TargetFile          string `json:"target_file,omitempty"`
+	TargetLine          int    `json:"target_line,omitempty"`
 }
 
 // UnmarshalJSON handles the "relation" field used by the link pass as a
@@ -546,6 +560,40 @@ func normalizeLinkEndpoints(links []CrossRepoLink, repos map[string]*DashRepo) [
 	for i, l := range links {
 		l.Source = rewrite(l.Source)
 		l.Target = rewrite(l.Target)
+		out[i] = l
+	}
+	return out
+}
+
+// enrichLinkEndpoints resolves each link's source and target entity (by its
+// prefixed "<repo>::<localId>" id) via the same findEntity lookup the rest of
+// the dashboard uses, and copies the entity's name / qualified name / source
+// file / start line onto the link (#4596). This lets the /links page render a
+// readable source name and open a real source-peek rather than only a graph
+// deep-link fallback.
+//
+// It is additive and best-effort: an endpoint that does not resolve to an
+// entity (e.g. a synthetic scope.operation node #4554 or a bare-external
+// target #4558 that has no source-derived name) simply leaves its enrichment
+// fields empty, and the frontend falls back to the graph deep-link.
+func enrichLinkEndpoints(grp *DashGroup, links []CrossRepoLink) []CrossRepoLink {
+	if grp == nil || len(links) == 0 {
+		return links
+	}
+	out := make([]CrossRepoLink, len(links))
+	for i, l := range links {
+		if _, e := findEntity(grp, l.Source); e != nil {
+			l.SourceName = e.Name
+			l.SourceQualifiedName = e.QualifiedName
+			l.SourceFile = e.SourceFile
+			l.SourceLine = e.StartLine
+		}
+		if _, e := findEntity(grp, l.Target); e != nil {
+			l.TargetName = e.Name
+			l.TargetQualifiedName = e.QualifiedName
+			l.TargetFile = e.SourceFile
+			l.TargetLine = e.StartLine
+		}
 		out[i] = l
 	}
 	return out

--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -810,5 +810,9 @@ func (s *Server) handleGroupLinks(w http.ResponseWriter, r *http.Request) {
 	if links == nil {
 		links = []CrossRepoLink{}
 	}
+	// Resolve each link's source/target entity so the /links page can render
+	// readable names and open a real source-peek (#4596). Additive and
+	// best-effort: unresolved endpoints leave the enrichment fields empty.
+	links = enrichLinkEndpoints(grp, links)
 	writeJSON(w, http.StatusOK, map[string]any{"links": links})
 }

--- a/internal/dashboard/links_enrich_test.go
+++ b/internal/dashboard/links_enrich_test.go
@@ -1,0 +1,126 @@
+package dashboard
+
+// links_enrich_test.go — coverage for #4596.
+//
+// The /links payload (CrossRepoLink) historically carried only the source/
+// target ids plus kind/confidence/channel/method — no readable name or source
+// location — so the /links page could not show source names or open a real
+// source-peek. enrichLinkEndpoints resolves each endpoint to its entity (via
+// the same findEntity lookup the rest of the dashboard uses) and copies the
+// name / qualified name / file / start line onto the link.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestEnrichLinkEndpoints_PopulatesNameAndFile asserts that a link whose source
+// and target both resolve to real entities has its name/qualified-name/file/
+// line enrichment fields populated from those entities.
+func TestEnrichLinkEndpoints_PopulatesNameAndFile(t *testing.T) {
+	grp := &DashGroup{
+		Name: "g",
+		Repos: map[string]*DashRepo{
+			"frontend": {Slug: "frontend", Doc: &graph.Document{
+				Repo: "frontend",
+				Entities: []graph.Entity{{
+					ID: "aaaa000000000000", Name: "fetchThing",
+					QualifiedName: "api.fetchThing", Kind: "Operation",
+					SourceFile: "src/api/client.ts", StartLine: 42,
+				}},
+			}},
+			"backend": {Slug: "backend", Doc: &graph.Document{
+				Repo: "backend",
+				Entities: []graph.Entity{{
+					ID: "bbbb000000000000", Name: "ThingRoute",
+					QualifiedName: "routes.ThingRoute", Kind: "Operation",
+					SourceFile: "app/routes.py", StartLine: 7,
+				}},
+			}},
+		},
+		Links: []CrossRepoLink{{
+			Source: "frontend::aaaa000000000000",
+			Target: "backend::bbbb000000000000",
+			Kind:   "calls",
+			Method: "http",
+		}},
+	}
+
+	out := enrichLinkEndpoints(grp, grp.Links)
+	if len(out) != 1 {
+		t.Fatalf("links len = %d; want 1", len(out))
+	}
+	l := out[0]
+
+	if l.SourceName != "fetchThing" {
+		t.Errorf("SourceName = %q; want %q", l.SourceName, "fetchThing")
+	}
+	if l.SourceQualifiedName != "api.fetchThing" {
+		t.Errorf("SourceQualifiedName = %q; want %q", l.SourceQualifiedName, "api.fetchThing")
+	}
+	if l.SourceFile != "src/api/client.ts" {
+		t.Errorf("SourceFile = %q; want %q", l.SourceFile, "src/api/client.ts")
+	}
+	if l.SourceLine != 42 {
+		t.Errorf("SourceLine = %d; want 42", l.SourceLine)
+	}
+
+	if l.TargetName != "ThingRoute" {
+		t.Errorf("TargetName = %q; want %q", l.TargetName, "ThingRoute")
+	}
+	if l.TargetQualifiedName != "routes.ThingRoute" {
+		t.Errorf("TargetQualifiedName = %q; want %q", l.TargetQualifiedName, "routes.ThingRoute")
+	}
+	if l.TargetFile != "app/routes.py" {
+		t.Errorf("TargetFile = %q; want %q", l.TargetFile, "app/routes.py")
+	}
+	if l.TargetLine != 7 {
+		t.Errorf("TargetLine = %d; want 7", l.TargetLine)
+	}
+
+	// The original kind/method must be preserved.
+	if l.Kind != "calls" || l.Method != "http" {
+		t.Errorf("kind/method mutated: kind=%q method=%q", l.Kind, l.Method)
+	}
+}
+
+// TestEnrichLinkEndpoints_UnresolvedSourceLeftEmpty pins the #4554/#4558
+// finding: a link whose source id maps to a synthetic node with no
+// source-derived name/file (e.g. a phantom scope.operation node or a
+// bare-external residue), or to no entity at all, leaves the enrichment fields
+// empty so the frontend (#4594) falls back to the graph deep-link rather than
+// rendering a blank source-peek. The resolvable target is still enriched.
+func TestEnrichLinkEndpoints_UnresolvedSourceLeftEmpty(t *testing.T) {
+	grp := &DashGroup{
+		Name: "g",
+		Repos: map[string]*DashRepo{
+			"backend": {Slug: "backend", Doc: &graph.Document{
+				Repo: "backend",
+				Entities: []graph.Entity{
+					// Synthetic source node: present in the graph but with no
+					// source-derived name or file (the unnamed-source case).
+					{ID: "00f991b585f18f21", Name: "", Kind: "SCOPE.Operation", SourceFile: ""},
+					// A real, resolvable target.
+					{ID: "bbbb000000000000", Name: "ThingRoute", SourceFile: "app/routes.py", StartLine: 7},
+				},
+			}},
+		},
+		Links: []CrossRepoLink{{
+			Source: "backend::00f991b585f18f21",
+			Target: "backend::bbbb000000000000",
+			Kind:   "calls",
+		}},
+	}
+
+	out := enrichLinkEndpoints(grp, grp.Links)
+	l := out[0]
+
+	if l.SourceName != "" || l.SourceFile != "" || l.SourceLine != 0 {
+		t.Errorf("unnamed synthetic source should leave enrichment empty; got name=%q file=%q line=%d",
+			l.SourceName, l.SourceFile, l.SourceLine)
+	}
+	if l.TargetName != "ThingRoute" || l.TargetFile != "app/routes.py" {
+		t.Errorf("resolvable target not enriched: name=%q file=%q", l.TargetName, l.TargetFile)
+	}
+}


### PR DESCRIPTION
## Summary

The `/api/groups/{group}/links` payload (`CrossRepoLink` in `internal/dashboard/graphstate.go`) carried only the source/target ids (`<repo>::<localId>`), `kind`, `confidence`, `channel`, `method` — **no name/file/line**. The /links page therefore could not render readable source names or open a real source-peek.

This change resolves each link's source AND target entity (by id) via the same `findEntity` lookup the rest of the dashboard uses, and adds the resolved name / qualified name / file / line to the payload.

## Fields added (all `omitempty`)

- `source_name`, `source_qualified_name`, `source_file`, `source_line`
- `target_name`, `target_qualified_name`, `target_file`, `target_line`

## Resolution path

`handleGroupLinks` → new `enrichLinkEndpoints(grp, links)` → `findEntity(grp, l.Source/l.Target)` → copies `Entity.Name / QualifiedName / SourceFile / StartLine`. Link ids are already normalised to the prefixed `<repo>::<localId>` form by `normalizeLinkEndpoints`, which `findEntity` resolves directly.

Purely additive: the new fields are NOT persisted to the on-disk links file (`UnmarshalJSON` ignores them) and are populated only at serve time. The frontend (#4594) already consumes name/file when present and falls back to a graph deep-link otherwise.

## Unnamed-source finding (id `00f991b585f18f21`)

Such an id is a real 16-hex-char graph entity id, but for some links it resolves to a **synthetic node with an empty `Name`/`SourceFile`** — confirmed by the indexer's own guards (`internal/links/*.go` repeatedly skip on `e.Name == "" || e.SourceFile == ""`). These are:

- a phantom `SCOPE.Operation` handler node whose synthesis-time bare↔qualified bridge did not reconcile (relates **scope.operation #4554**), or
- a bare-external / expression-level `sink:` data-flow residue with no indexed source entity (relates **bare-external #4558**).

When the id resolves to a **real** entity, its name/file now populate. When it resolves to a synthetic node with no source-derived name, the enrichment fields are left empty (by design) so the frontend falls back to the graph deep-link. No false blank source-peek.

## Gates

- `go build ./...` ✅
- `go vet ./internal/dashboard/...` ✅
- `go test ./internal/dashboard/...` ✅ (28.5s)
- New `links_enrich_test.go`: asserts a link's source/target name+qualified-name+file+line populate from the resolved entities, and that an unnamed synthetic source leaves enrichment empty while a resolvable target is still enriched.

Live confirmation deferred to coordinator (deploy-deferred).

Closes #4596

🤖 Generated with [Claude Code](https://claude.com/claude-code)