### PR TITLE
fix(dashboard): authoritative public-by-design signal for auth coverage (#4595)

### DIFF
--- a/internal/dashboard/auth_public_flag_test.go
+++ b/internal/dashboard/auth_public_flag_test.go
@@ -1,0 +1,95 @@
+// auth_public_flag_test.go — #4595 regression for the AUTHORITATIVE
+// "public by design" signal on AuthEndpointFinding.
+//
+// Before the fix the auth-coverage wire shape collapsed every guard-less route
+// into has_auth=false with no evidence, so a route that is unauthenticated BY
+// DESIGN (@Public / AllowAny / permitAll / @AllowAnonymous) was indistinguishable
+// from a forgotten guard. resolveEndpointPublic surfaces WHY: an explicit public
+// mechanism vs no guard at all. These tests feed the EXACT property shapes the
+// engine auth resolvers stamp (stampAuthPolicy / grpcJavaPolicyProps /
+// java_annotation_routes / django_drf_actions) across frameworks.
+package dashboard
+
+import "testing"
+
+func TestResolveEndpointPublic_ExplicitPublicVerdict(t *testing.T) {
+	// JS/TS @Public() / Spring permitAll / gRPC public interceptor / HotChocolate
+	// @AllowAnonymous: the reconciled posture is auth_required=false with a named
+	// mechanism. MUST resolve public, with the mechanism echoed as the reason.
+	cases := []struct {
+		name       string
+		props      map[string]string
+		wantReason string
+	}{
+		{
+			name:       "nest @Public() decorator",
+			props:      map[string]string{"auth_required": "false", "auth_method": "decorator", "auth_confidence": "high"},
+			wantReason: "auth_method=decorator",
+		},
+		{
+			name:       "spring permitAll annotation",
+			props:      map[string]string{"auth_required": "false", "auth_method": "annotation", "auth_confidence": "high"},
+			wantReason: "auth_method=annotation",
+		},
+		{
+			name:       "config-driven public route, method known",
+			props:      map[string]string{"auth_required": "false", "auth_method": "config"},
+			wantReason: "auth_method=config",
+		},
+		{
+			name:       "explicit public, method unknown -> still public via verdict",
+			props:      map[string]string{"auth_required": "false", "auth_method": "unknown"},
+			wantReason: "auth_required=false",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pub, reason := resolveEndpointPublic(tc.props)
+			if !pub {
+				t.Fatalf("%s: want public=true (props=%v)", tc.name, tc.props)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("%s: reason=%q, want %q", tc.name, reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestResolveEndpointPublic_DRFAllowAny(t *testing.T) {
+	// DRF permission_classes=[AllowAny]: by DRF semantics the resolver does NOT
+	// stamp auth_required, but records AllowAny in the middleware chain. MUST
+	// still resolve public.
+	props := map[string]string{"middleware_names": "AllowAny"}
+	pub, reason := resolveEndpointPublic(props)
+	if !pub {
+		t.Fatalf("DRF AllowAny route not recognised as public (props=%v)", props)
+	}
+	if reason != "permission_class=AllowAny" {
+		t.Errorf("reason=%q, want permission_class=AllowAny", reason)
+	}
+}
+
+func TestResolveEndpointPublic_ForgottenGuardIsNotPublic(t *testing.T) {
+	// A genuinely-unguarded endpoint: no auth_required=false, no public permission
+	// symbol — just no posture. MUST NOT be flagged public (this is the forgotten
+	// guard the dashboard should alarm on).
+	cases := []map[string]string{
+		{},                                  // bare route, no posture at all
+		{"verb": "POST", "path": "/orders"}, // route metadata but no auth signal
+		{"middleware_names": "ThrottleClass"}, // non-auth middleware only
+	}
+	for _, props := range cases {
+		if pub, reason := resolveEndpointPublic(props); pub {
+			t.Errorf("forgotten-guard route flagged public (reason=%q, props=%v)", reason, props)
+		}
+	}
+}
+
+func TestResolveEndpointPublic_AuthenticatedRouteIsNotPublic(t *testing.T) {
+	// An authenticated route (auth_required=true) is never public, even if some
+	// AllowAny symbol leaks into a chain entry.
+	props := map[string]string{"auth_required": "true", "middleware_names": "IsAuthenticated,AllowAny"}
+	if pub, reason := resolveEndpointPublic(props); pub {
+		t.Errorf("authenticated route flagged public (reason=%q)", reason)
+	}
+}

--- a/internal/dashboard/handlers_security.go
+++ b/internal/dashboard/handlers_security.go
@@ -39,6 +39,18 @@ type AuthEndpointFinding struct {
 	Path         string `json:"path,omitempty"`
 	HasAuth      bool   `json:"has_auth"`
 	AuthEvidence string `json:"auth_evidence,omitempty"`
+	// Public is the AUTHORITATIVE "unauthenticated BY DESIGN" signal (#4595).
+	// It is true ONLY when the engine auth-posture resolution produced an
+	// explicit public verdict — an @Public / publicProcedure decorator, a DRF
+	// AllowAny / permission_classes=[], a Spring permitAll / @PermitAll, a
+	// NestJS @Public(), a gRPC/tRPC public interceptor, or @AllowAnonymous.
+	// When false AND HasAuth is false, the route has NO guard signal at all
+	// (a genuinely-forgotten guard). The frontend MUST prefer this flag over
+	// any route-name heuristic to tell "public on purpose" from "missing auth".
+	Public bool `json:"public,omitempty"`
+	// PublicReason names the detected public mechanism (e.g. "auth_method=decorator",
+	// "permission_class=AllowAny") so the UI can explain WHY a route is public.
+	PublicReason string `json:"public_reason,omitempty"`
 	Severity     string `json:"severity"` // "error" | "warn" | "info"
 	SensitiveOp  bool   `json:"sensitive_op,omitempty"`
 	IDORRisk     bool   `json:"idor_risk,omitempty"`
@@ -265,6 +277,53 @@ func determineEndpointAuth(e *graph.Entity, byFile map[string][]string, taggedID
 	return false, ""
 }
 
+// resolveEndpointPublic reports whether an endpoint is unauthenticated BY DESIGN
+// (#4595) — distinct from a genuinely-forgotten guard. It reads ONLY the
+// authoritative auth-posture signals the engine resolvers already stamp; it does
+// NOT use route-name allowlists. Returns (public, reason).
+//
+// The signal is framework-general because every auth resolver writes the same
+// contract (see engine stampAuthPolicy / grpcJavaPolicyProps / java_annotation_routes
+// / django_drf_actions):
+//
+//   - Explicit-public verdict — JS/TS @Public()/publicProcedure, Spring permitAll/
+//     @PermitAll, gRPC/tRPC public interceptors, HotChocolate @AllowAnonymous:
+//     auth_required=="false" (only stamped when a resolver matched a real
+//     mechanism, i.e. auth_method != "unknown"). auth_method names the mechanism.
+//   - DRF AllowAny / permission_classes=[AllowAny]: by DRF semantics the resolver
+//     deliberately does NOT set auth_required, but records AllowAny in the
+//     middleware chain. So auth_required is unset AND a permission/middleware
+//     symbol of AllowAny (or an empty explicit permission set) is present.
+//
+// A genuinely-unguarded endpoint has NO auth_required=="false" and NO public
+// permission symbol — it simply has no posture, so this returns (false, "").
+func resolveEndpointPublic(props map[string]string) (bool, string) {
+	// 1. Decisive explicit-public verdict from the reconciled posture.
+	if props["auth_required"] == "false" {
+		if m := props["auth_method"]; m != "" && m != "unknown" {
+			return true, "auth_method=" + m
+		}
+		return true, "auth_required=false"
+	}
+	// 2. DRF AllowAny: auth_required stays unset, but AllowAny is recorded in
+	//    the middleware/permission chain. Never treat an actually-authenticated
+	//    route (auth_required=="true") as public.
+	if props["auth_required"] != "true" {
+		names := props["middleware_names"]
+		for _, sym := range strings.Split(names, ",") {
+			if strings.EqualFold(strings.TrimSpace(sym), "AllowAny") {
+				return true, "permission_class=AllowAny"
+			}
+		}
+		// Explicit empty permission set (permission_classes=[]) — DRF treats an
+		// empty list as "no permission required", an intentional public opt-out.
+		if props["auth_permission_set"] == "empty" {
+			return true, "permission_classes=[]"
+		}
+	}
+	return false, ""
+}
+
 func isSensitiveEndpoint(name, path string) bool {
 	combined := strings.ToLower(name + " " + path)
 	for _, t := range sensitiveTerms {
@@ -389,6 +448,14 @@ func (s *Server) handleSecurityAuthCoverage(w http.ResponseWriter, r *http.Reque
 			}
 
 			hasAuth, evidence := determineEndpointAuth(e, byFile, taggedIDs)
+			// #4595 — authoritative "public by design" signal so the dashboard can
+			// distinguish an intentionally-unauthenticated route (@Public / AllowAny
+			// / permitAll) from a forgotten guard. Only meaningful when !hasAuth.
+			var isPublic bool
+			var publicReason string
+			if !hasAuth {
+				isPublic, publicReason = resolveEndpointPublic(props)
+			}
 			epath := props["path"]
 			method := props["verb"]
 			sensitiveOp := isSensitiveEndpoint(name, epath)
@@ -430,6 +497,8 @@ func (s *Server) handleSecurityAuthCoverage(w http.ResponseWriter, r *http.Reque
 				Path:         epath,
 				HasAuth:      hasAuth,
 				AuthEvidence: evidence,
+				Public:       isPublic,
+				PublicReason: publicReason,
 				Severity:     severity,
 				SensitiveOp:  sensitiveOp,
 				IDORRisk:     idorRisk,


### PR DESCRIPTION
## Problem
The auth-coverage wire shape `AuthEndpointFinding` (`internal/dashboard/handlers_security.go`) had NO public flag. The backend collapsed `@Public` / `AllowAny` / `permitAll` / intentionally-public endpoints into a single verdict and emitted them as `has_auth=false` with no evidence — indistinguishable from a forgotten guard. The frontend (#4592) had to fall back to a route-name heuristic.

## Fix
Add an **authoritative** signal to `AuthEndpointFinding`:
- `public bool` (`json:"public,omitempty"`) — true ONLY when the endpoint is unauthenticated by design.
- `public_reason string` — names the detected mechanism (e.g. `auth_method=decorator`, `permission_class=AllowAny`) so the UI can explain WHY.

The signal is sourced from the engine auth-posture resolution that **already** detects these mechanisms (it's why they resolve to `has_auth=false`). New helper `resolveEndpointPublic` reads only those resolved signals — no route-name allowlists:

1. **Explicit-public verdict** — NestJS `@Public()`/`publicProcedure`, Spring `permitAll`/`@PermitAll`, gRPC/tRPC public interceptors, HotChocolate `@AllowAnonymous`: the reconciled posture is `auth_required=false` with a named `auth_method` (only stamped when a resolver actually matched, i.e. `auth_method != "unknown"`).
2. **DRF `AllowAny` / `permission_classes=[AllowAny]`** — by DRF semantics the resolver deliberately leaves `auth_required` unset but records `AllowAny` in the middleware chain (`middleware_names`).

A genuinely-unguarded route has none of these → `public=false`, so the dashboard can finally distinguish "public on purpose" from "missing auth". An authenticated route (`auth_required=true`) is never flagged public.

Generalized across frameworks via the shared engine auth contract (`stampAuthPolicy` / `grpcJavaPolicyProps` / `java_annotation_routes` / `django_drf_actions`).

## Tests
`internal/dashboard/auth_public_flag_test.go`:
- `@Public`/permitAll/config explicit-public verdicts → `public=true` with mechanism echoed.
- DRF `AllowAny` (no `auth_required`, `AllowAny` in chain) → `public=true`.
- Genuinely-unguarded routes (bare / route-meta-only / non-auth middleware) → `public=false`.
- Authenticated route → `public=false`.

## Gates
- `go build ./...` ✅
- `go vet ./internal/dashboard/...` ✅
- `go test ./internal/dashboard/... ./internal/engine/...` ✅

## Follow-up
Frontend (#4592) should prefer this authoritative `public` flag over its route-name heuristic. Live confirmation deferred to coordinator post-rebuild.

Closes #4595

🤖 Generated with [Claude Code](https://claude.com/claude-code)