### PR TITLE
fix(graph): guard WebGL texture creation against empty deep-link subgraphs (#4605)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -47,6 +47,7 @@ import {
   JARVIS_GLOW,
 } from "@/lib/graph-colors";
 import { saveLayout, loadLayout, isDegenerateLayout, isLayoutHealthy } from "@/lib/graph-layout-cache";
+import { isRenderableGraph } from "@/lib/graph-render-guard";
 import {
   autoBasePx,
   type ColorMode,
@@ -333,6 +334,16 @@ function GraphCanvasInner(
   }, [nodes]);
 
   const nodeIds = useMemo(() => nodes.map((n) => n.id), [nodes]);
+
+  // #4605 — can this node set be fed to the WebGL engine at all? An EMPTY graph
+  // (0 points) makes cosmos size its point/cluster textures as 0×0, and regl
+  // throws `(regl) invalid texture shape` from `clusterTexture`/`by.create`,
+  // tripping the app error boundary. This happens on a deep-link to a SYNTHETIC /
+  // unresolved `?node=<id>` whose ego filter yields no nodes. When false we skip
+  // every engine data-push / `create()` and render a graceful empty-state below.
+  const renderable = useMemo(() => isRenderableGraph(nodes.length, edges.length), [nodes.length, edges.length]);
+  const renderableRef = useRef(renderable);
+  renderableRef.current = renderable;
 
   const repoToIdx = useMemo(() => {
     const repos = Array.from(new Set(nodes.map((n) => n.repo ?? ""))).sort();
@@ -1076,6 +1087,9 @@ function GraphCanvasInner(
   const kickFreshSettle = useCallback(() => {
     const g = graphRef.current;
     if (!g) return;
+    // #4605 — don't seed/start the engine on an empty graph (0-sized texture →
+    // regl `invalid texture shape`). The empty-state overlay is shown instead.
+    if (!renderableRef.current) return;
     const p = packedRef.current;
     hasSettledRef.current = false;
     didAutoStartRef.current = true;
@@ -1241,7 +1255,15 @@ function GraphCanvasInner(
     // baked by retired force defaults is a guaranteed MISS. On any reject we run
     // the EXACT same fresh settle the Reset button runs (kickFreshSettle) so the
     // reload converges to the good spread — reload === Reset.
-    if (saved && isLayoutHealthy(saved.positions, nodeIds.length * 2)) {
+    // #4605 — if we mounted onto an EMPTY graph (deep-link to an unresolved
+    // `?node=<id>`), do NOT seed or settle the engine: a 0-point buffer sizes the
+    // textures 0×0 and regl throws `invalid texture shape`. The empty-state
+    // overlay is rendered instead; the data-push effect re-seeds + settles if/when
+    // a renderable node set arrives (e.g. on focus exit). The cleanup below still
+    // registers so the engine is destroyed on unmount.
+    if (!renderableRef.current) {
+      // fall through to register cleanup; skip only the seed/settle.
+    } else if (saved && isLayoutHealthy(saved.positions, nodeIds.length * 2)) {
       requestAnimationFrame(() => {
         const gg = graphRef.current;
         if (!gg) return;
@@ -1275,6 +1297,10 @@ function GraphCanvasInner(
   useEffect(() => {
     const g = graphRef.current;
     if (!g) return;
+    // #4605 — an EMPTY node set sizes cosmos's point/cluster textures as 0×0 and
+    // regl throws `invalid texture shape` from `create()`. Never push a zero-point
+    // buffer; the empty-state overlay (below) is shown instead.
+    if (!renderable) return;
     const prev = g.getPointPositions();
     if (hasSettledRef.current && prev.length === packed.positions.length) {
       // Fix #1562: re-pin the settled geometry, but sanitize first so a diverged
@@ -1306,12 +1332,13 @@ function GraphCanvasInner(
     }
     if (hasSettledRef.current) g.pause();
     scheduleLabels();
-  }, [packed, packPointColors, linkData, packLinkColors, packLinkWidths, group, nodeIds, scheduleLabels]);
+  }, [renderable, packed, packPointColors, linkData, packLinkColors, packLinkWidths, group, nodeIds, scheduleLabels]);
 
   // ── recolor on theme / colorMode ────────────────────────────────────────────
   useEffect(() => {
     const g = graphRef.current;
     if (!g) return;
+    if (!renderable) return; // #4605 — no engine writes on an empty graph
     g.setPointColors(packPointColors());
     g.setLinkColors(packLinkColors());
     g.setLinkWidths(packLinkWidths());
@@ -1319,12 +1346,13 @@ function GraphCanvasInner(
     g.render();
     g.create();
     if (hasSettledRef.current) g.pause();
-  }, [packPointColors, packLinkColors, packLinkWidths, isDark]);
+  }, [renderable, packPointColors, packLinkColors, packLinkWidths, isDark]);
 
   // ── live render/sim config ──────────────────────────────────────────────────
   useEffect(() => {
     const g = graphRef.current;
     if (!g) return;
+    if (!renderable) return; // #4605 — no engine writes on an empty graph
     g.setConfig({
       pointOpacity: render.pointOpacity,
       // Fix #1607: do NOT set pointSizeScale here — the zoom-driven updater owns it
@@ -1347,7 +1375,7 @@ function GraphCanvasInner(
     g.setLinkWidths(packLinkWidths());
     g.render();
     if (hasSettledRef.current) g.pause();
-  }, [render, simulation, packLinkColors, packLinkWidths]);
+  }, [renderable, render, simulation, packLinkColors, packLinkWidths]);
 
   // ── re-layout request (Reset / re-layout) ───────────────────────────────────
   // Fix #1581: this IS the canonical fresh-settle now; it (and first load) both
@@ -1369,6 +1397,7 @@ function GraphCanvasInner(
     prevGroupRef.current = group;
     const g = graphRef.current;
     if (!g) return;
+    if (!renderable) return; // #4605 — empty ego set → empty-state, no settle
     hasSettledRef.current = false;
     didAutoStartRef.current = true;
     mountTimeRef.current = Date.now();
@@ -1384,7 +1413,7 @@ function GraphCanvasInner(
       return;
     }
     kickFreshSettleRef.current();
-  }, [group, packed, nodeIds]);
+  }, [renderable, group, packed, nodeIds]);
 
   // ── re-cluster on group-by change ───────────────────────────────────────────
   const prevGroupByRef = useRef(groupBy);
@@ -1504,6 +1533,7 @@ function GraphCanvasInner(
   useEffect(() => {
     const g = graphRef.current;
     if (!g) return;
+    if (!renderableRef.current) return; // #4605 — no glow writes on an empty graph
 
     // Cancel any in-flight glow loop (a new epoch supersedes the previous pulse).
     if (glowRafRef.current !== null) {
@@ -1808,6 +1838,21 @@ function GraphCanvasInner(
   return (
     <div className={`relative h-full w-full ${className}`} role="img" aria-label="Dependency graph">
       <div ref={containerRef} className="h-full w-full" />
+      {/* #4605 — graceful empty-state when a deep-linked / focused node resolves to
+          NO renderable nodes (synthetic or unknown id). We never feed this empty
+          set to the WebGL engine (which would crash with `invalid texture shape`);
+          we show this instead. */}
+      {!renderable && (
+        <div className="pointer-events-none absolute inset-0 z-20 grid place-items-center">
+          <div className="pointer-events-auto max-w-sm rounded-lg border border-border bg-bg/80 px-6 py-5 text-center backdrop-blur">
+            <div className="text-sm font-medium text-fg">Nothing to render for this node</div>
+            <p className="mt-1 text-xs text-fg-muted">
+              This node could not be resolved in the current graph, or it has no
+              connections to display. Clear the selection or pick another node.
+            </p>
+          </div>
+        </div>
+      )}
       <div ref={labelLayerRef} aria-hidden className="pointer-events-none absolute inset-0 z-10" />
       {/* vignette for perceived depth */}
       <div

--- a/webui-v2/src/lib/graph-render-guard.test.ts
+++ b/webui-v2/src/lib/graph-render-guard.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  MIN_TEXTURE_DIM,
+  isRenderableGraph,
+  clampTextureDim,
+  textureSideFor,
+} from "./graph-render-guard";
+
+describe("isRenderableGraph (#4605)", () => {
+  it("treats an empty graph as NON-renderable (would crash regl)", () => {
+    expect(isRenderableGraph(0)).toBe(false);
+    expect(isRenderableGraph(0, 0)).toBe(false);
+  });
+
+  it("treats a single isolated node as renderable", () => {
+    expect(isRenderableGraph(1, 0)).toBe(true);
+  });
+
+  it("treats a normal graph as renderable", () => {
+    expect(isRenderableGraph(1316, 4200)).toBe(true);
+    expect(isRenderableGraph(19000, 50000)).toBe(true);
+  });
+
+  it("rejects non-finite / negative node counts", () => {
+    expect(isRenderableGraph(NaN)).toBe(false);
+    expect(isRenderableGraph(Infinity)).toBe(false);
+    expect(isRenderableGraph(-1)).toBe(false);
+  });
+});
+
+describe("clampTextureDim (#4605)", () => {
+  it("clamps 0 to the minimum side", () => {
+    expect(clampTextureDim(0)).toBe(MIN_TEXTURE_DIM);
+  });
+
+  it("clamps negative dimensions to the minimum", () => {
+    expect(clampTextureDim(-5)).toBe(MIN_TEXTURE_DIM);
+  });
+
+  it("floors fractional dimensions", () => {
+    expect(clampTextureDim(3.9)).toBe(3);
+    expect(clampTextureDim(1.2)).toBe(1);
+  });
+
+  it("clamps non-finite dimensions to the minimum", () => {
+    expect(clampTextureDim(NaN)).toBe(MIN_TEXTURE_DIM);
+    expect(clampTextureDim(Infinity)).toBe(MIN_TEXTURE_DIM);
+    expect(clampTextureDim(-Infinity)).toBe(MIN_TEXTURE_DIM);
+  });
+
+  it("passes through valid dimensions unchanged", () => {
+    expect(clampTextureDim(1)).toBe(1);
+    expect(clampTextureDim(128)).toBe(128);
+  });
+});
+
+describe("textureSideFor (#4605)", () => {
+  it("never returns a side below the minimum, even for 0/empty", () => {
+    expect(textureSideFor(0)).toBe(MIN_TEXTURE_DIM);
+    expect(textureSideFor(-3)).toBe(MIN_TEXTURE_DIM);
+    expect(textureSideFor(NaN)).toBe(MIN_TEXTURE_DIM);
+  });
+
+  it("sizes a single point to a 1x1 texture", () => {
+    expect(textureSideFor(1)).toBe(1);
+  });
+
+  it("mirrors ceil(sqrt(count)) for real counts", () => {
+    expect(textureSideFor(4)).toBe(2);
+    expect(textureSideFor(5)).toBe(3); // ceil(sqrt(5)) = 3
+    expect(textureSideFor(1316)).toBe(Math.ceil(Math.sqrt(1316)));
+  });
+});

--- a/webui-v2/src/lib/graph-render-guard.ts
+++ b/webui-v2/src/lib/graph-render-guard.ts
@@ -1,0 +1,57 @@
+/**
+ * #4605 — guards against the cosmos.gl / regl `invalid texture shape` crash.
+ *
+ * The WebGL engine (@cosmos.gl/graph, regl under the hood) sizes its point and
+ * cluster force textures from the point COUNT — typically as a square FBO of
+ * side `ceil(sqrt(count))`. When the rendered graph is EMPTY (count === 0) that
+ * side is 0, and regl's `texture2D` is handed a 0×0 shape → it throws
+ * `(regl) invalid texture shape`, which bubbles up through `clusterTexture` /
+ * `by.create` and trips the app error boundary.
+ *
+ * This happens on deep-links: `/g/<group>/graph?node=<id>` focuses the node's
+ * ego sub-graph. When `<id>` is a SYNTHETIC / unresolved id (e.g. a Links-row
+ * sink node `repo::sink:src/...::this.x.create@22`) it isn't present in the
+ * rendered node set, so the ego filter yields ZERO nodes and an empty buffer is
+ * fed to the engine.
+ *
+ * Two small, pure guards used by the canvas:
+ *  - `isRenderableGraph` — should we feed cosmos at all? A 0-node graph is never
+ *    renderable. (1 node / 0 edges is fine — a single point textures cleanly.)
+ *  - `clampTextureDim` — never let a texture side be < 1; clamp + floor any
+ *    non-finite / fractional / non-positive dimension to a safe minimum.
+ */
+
+/** Minimum side, in texels, for any GPU texture we let the engine allocate. */
+export const MIN_TEXTURE_DIM = 1;
+
+/**
+ * True when the node set can be safely handed to the WebGL engine. An empty
+ * graph (no points) yields a 0-sized texture and must NOT be pushed to cosmos —
+ * the caller should render a graceful empty-state instead.
+ *
+ * A single isolated node (1 node, 0 edges) IS renderable: the point texture is
+ * 1×1, the link buffer is empty, and the cluster path is skipped.
+ */
+export function isRenderableGraph(nodeCount: number, _edgeCount = 0): boolean {
+  return Number.isFinite(nodeCount) && nodeCount >= 1;
+}
+
+/**
+ * Clamp a texture dimension to a safe, integral minimum so regl never receives
+ * a 0, negative, fractional, NaN or Infinity shape. Mirrors the engine's own
+ * `ceil(sqrt(count))` sizing but with a hard floor of {@link MIN_TEXTURE_DIM}.
+ */
+export function clampTextureDim(dim: number): number {
+  if (!Number.isFinite(dim)) return MIN_TEXTURE_DIM;
+  const floored = Math.floor(dim);
+  return floored < MIN_TEXTURE_DIM ? MIN_TEXTURE_DIM : floored;
+}
+
+/**
+ * Square texture side for `count` points, with the safe floor applied. Useful
+ * for any local texture/atlas allocation that mirrors the engine's sizing.
+ */
+export function textureSideFor(count: number): number {
+  if (!Number.isFinite(count) || count <= 0) return MIN_TEXTURE_DIM;
+  return clampTextureDim(Math.ceil(Math.sqrt(count)));
+}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -387,9 +387,21 @@ export default function GraphScreen() {
   }, [s.expandedModule, data]);
 
   // Once data arrives, if a node was deep-linked, focus its ego-graph.
+  // #4605 — only focus when the deep-linked id actually resolves to a RENDERED
+  // node. A synthetic / unknown `?node=<id>` (e.g. a Links-row sink node like
+  // `repo::sink:src/...::this.x.create@22`) is NOT in the node set, so an ego
+  // focus would yield an EMPTY sub-graph → cosmos sizes its textures 0×0 → regl
+  // crashes with `invalid texture shape`. For an unresolved id we leave the FULL
+  // graph rendered and clear the dangling selection instead of focusing nothing.
   useEffect(() => {
-    if (data && s.selectedNodeId && !s.focusNodeIds) {
+    if (!data || !s.selectedNodeId || s.focusNodeIds) return;
+    const resolves = nodes.some((n) => n.id === s.selectedNodeId);
+    if (resolves) {
       focusEgo(s.selectedNodeId);
+    } else {
+      // Unresolved deep-link target — drop it so the full graph shows cleanly and
+      // the ?node= param doesn't keep re-triggering a degenerate focus.
+      s.setSelectedNode(null);
     }
     // Only trigger when data first becomes available.
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Bug (#4605)
Deep-linking to a node — `/g/<group>/graph?node=<id>` (e.g. from a Links row, where `<id>` is a synthetic sink node like `core-backend-v3::sink:src/...::this.service.create@22`) — crashed the app error boundary with **`(regl) invalid texture shape`**. Stack: `graph-canvas-*.js` → `texture2D` / `clusterTexture` / `by.create`.

## Root cause
The graph canvas (`@cosmos.gl/graph`, regl under the hood) sizes its point and **cluster force textures from the point COUNT** — a square FBO of side `ceil(sqrt(count))`. When `?node=<id>` focuses the node's ego sub-graph and that id is **synthetic / not in the rendered node set**, the ego filter (`egoNodes = nodes.filter(n => focusSet.has(n.id))`) yields **zero nodes**. That empty buffer was pushed straight to cosmos, making the texture `0×0`, and regl throws `invalid texture shape` from `clusterTexture`/`by.create`.

## Fix
1. **Texture guard** — new `src/lib/graph-render-guard.ts`:
   - `isRenderableGraph(nodeCount)` — a 0-node graph is never renderable (1 isolated node is fine).
   - `clampTextureDim` / `textureSideFor` — hard floor of **1 texel**; floors fractional and clamps non-finite/negative dims so regl never gets a 0/NaN/Infinity shape.
2. **Canvas** — a `renderable` flag short-circuits **every** engine data-push / `create()` / settle / glow / recolor / relayout path when the node set is empty, so a degenerate buffer is never fed to regl. The mount effect still registers its `destroy()` cleanup. It re-pushes + re-settles normally once a renderable set arrives (e.g. focus exit). An **empty-state overlay** ("Nothing to render for this node") is shown instead.
3. **Deep-link resolution** (`routes/graph.tsx`) — only enter ego focus when the deep-linked id actually resolves to a rendered node; an unresolved `?node=` drops the dangling selection and keeps the **full graph** rendered instead of focusing nothing.

Normal full-graph rendering (no `?node`) is unchanged — the guard only triggers at 0 nodes.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅
- `npx vite build` ✅ (`graph-canvas-*.js` chunk builds clean)
- `vitest run src/lib` ✅ — **58 passed**, incl. 12 new tests for the texture-dim clamp + empty-graph guard.

Closes #4605

🤖 Generated with [Claude Code](https://claude.com/claude-code)