### PR TITLE
fix(flow-dag): same-hue intense card borders + contain repo badge

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDagLegend.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagLegend.tsx
@@ -57,8 +57,10 @@ export function FlowDagLegend({ branchCount, nodeCount, truncation }: FlowDagLeg
           <span
             className="size-2.5 rounded-sm shrink-0"
             style={{
+              // Match the card (#4617): swatch border is an intense shade of
+              // the bucket's OWN hue, not a neutral/brown frame.
               background: `color-mix(in srgb, ${rs.bg} 35%, var(--surface))`,
-              border: `1px solid color-mix(in srgb, ${rs.ink} 55%, transparent)`,
+              border: `1px solid color-mix(in srgb, ${rs.border} 72%, var(--text))`,
             }}
           />
           {rs.label}

--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -102,14 +102,17 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
         dimmed ? "opacity-25" : "opacity-100",
       )}
       style={{
-        // Role/taxonomy tint as a soft background wash; the ink as the border.
-        // External nodes read fainter so they recede from the resolved spine.
+        // Role/taxonomy tint as a soft background wash (#4566). The border is a
+        // more INTENSE shade of the card's OWN bucket hue (#4617): the bucket's
+        // solid pastel token (rs.border) deepened toward its dark anchor so the
+        // outline reads as a saturated version of the background, never a
+        // generic neutral/brown frame. External nodes stay muted.
         background: `color-mix(in srgb, ${rs.bg} ${external ? 12 : 22}%, var(--surface))`,
         borderColor: selected || onRoute === true
           ? "var(--accent)"
           : external
             ? "color-mix(in srgb, var(--text-4) 45%, transparent)"
-            : `color-mix(in srgb, ${rs.ink} 55%, transparent)`,
+            : `color-mix(in srgb, ${rs.border} 72%, var(--text))`,
         // #4557: a left module color-band groups same-module nodes visually.
         borderLeft: band ? `3px solid ${band.color}` : undefined,
         // Selected / route-lit (#4479) → accent ring; a genuine terminal
@@ -117,7 +120,7 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
         boxShadow: selected || onRoute === true
           ? "0 0 0 2px var(--accent)"
           : terminalCap || node.terminal
-            ? `0 0 0 2px color-mix(in srgb, ${rs.ink} 45%, transparent)`
+            ? `0 0 0 2px color-mix(in srgb, ${rs.border} 60%, var(--text))`
             : undefined,
       }}
     >
@@ -126,10 +129,14 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
       <Handle type="source" position={sourcePosition ?? Position.Right} className="!bg-text-4" />
 
       <div className="px-2.5 py-2">
-        {/* Header row: role pill · incoming-edge pill · terminal marker · repo */}
-        <div className="flex items-center gap-1.5">
+        {/* Header row: role pill · incoming-edge pill · terminal marker · repo.
+            #4619: the row clips to the card width (overflow-hidden + min-w-0)
+            and the role pill is allowed to truncate, so the right-aligned repo
+            chip is always pulled INSIDE the card instead of bleeding past its
+            right edge. */}
+        <div className="flex items-center gap-1.5 min-w-0 overflow-hidden">
           <span
-            className="inline-flex items-center h-[15px] px-1 rounded text-[9px] font-semibold uppercase tracking-wide leading-none shrink-0"
+            className="inline-flex items-center h-[15px] px-1 rounded text-[9px] font-semibold uppercase tracking-wide leading-none min-w-0 truncate"
             style={{
               background: `color-mix(in srgb, ${rs.bg} 38%, transparent)`,
               color: rs.ink,
@@ -139,7 +146,7 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
           </span>
           {edgeLabel && (
             <span
-              className="inline-flex items-center h-[15px] px-1 rounded text-[9px] font-medium lowercase leading-none shrink-0 text-text-3 bg-surface-2"
+              className="inline-flex items-center h-[15px] px-1 rounded text-[9px] font-medium lowercase leading-none min-w-0 truncate text-text-3 bg-surface-2"
               title={`incoming relationship: ${edgeLabel}`}
             >
               {edgeLabel}

--- a/webui-v2/src/components/flow-dag/style.ts
+++ b/webui-v2/src/components/flow-dag/style.ts
@@ -47,8 +47,15 @@ export type NodeBucket =
 export interface RoleStyle {
   /** CSS background for the node body. */
   bg: string;
-  /** CSS foreground (border + accent) for the node. */
+  /** CSS foreground (text/accent) for the node. */
   ink: string;
+  /**
+   * CSS border color for the node card — derived from the SAME bucket color
+   * family as `bg`, but more intense/saturated (the solid pastel token rather
+   * than the washed @22% bg) so the outline reads as a darker shade of the
+   * card's own hue instead of a generic neutral/brown frame (#4617).
+   */
+  border: string;
   label: string;
 }
 
@@ -61,17 +68,17 @@ export interface RoleStyle {
  * fallback.
  */
 export const NODE_BUCKET_STYLE: Record<NodeBucket, RoleStyle> = {
-  endpoint: { bg: "var(--pastel-2)", ink: "var(--pastel-2-ink)", label: "Endpoint" },
-  handler: { bg: "var(--pastel-1)", ink: "var(--pastel-1-ink)", label: "Handler" },
-  service: { bg: "var(--pastel-5)", ink: "var(--pastel-5-ink)", label: "Service / logic" },
-  repository: { bg: "var(--pastel-4)", ink: "var(--pastel-4-ink)", label: "Repository / data" },
-  schema: { bg: "var(--pastel-6)", ink: "var(--pastel-6-ink)", label: "DTO / schema" },
-  function: { bg: "var(--pastel-7)", ink: "var(--pastel-7-ink)", label: "Function" },
-  exception: { bg: "var(--danger)", ink: "var(--exception-ink)", label: "Exception" },
-  external: { bg: "var(--text-4)", ink: "var(--text-3)", label: "External / library" },
-  terminal: { bg: "var(--pastel-8)", ink: "var(--pastel-8-ink)", label: "Return / finish" },
-  collection: { bg: "var(--pastel-3)", ink: "var(--pastel-3-ink)", label: "Collection" },
-  node: { bg: "var(--pastel-5)", ink: "var(--pastel-5-ink)", label: "Node" },
+  endpoint: { bg: "var(--pastel-2)", ink: "var(--pastel-2-ink)", border: "var(--pastel-2)", label: "Endpoint" },
+  handler: { bg: "var(--pastel-1)", ink: "var(--pastel-1-ink)", border: "var(--pastel-1)", label: "Handler" },
+  service: { bg: "var(--pastel-5)", ink: "var(--pastel-5-ink)", border: "var(--pastel-5)", label: "Service / logic" },
+  repository: { bg: "var(--pastel-4)", ink: "var(--pastel-4-ink)", border: "var(--pastel-4)", label: "Repository / data" },
+  schema: { bg: "var(--pastel-6)", ink: "var(--pastel-6-ink)", border: "var(--pastel-6)", label: "DTO / schema" },
+  function: { bg: "var(--pastel-7)", ink: "var(--pastel-7-ink)", border: "var(--pastel-7)", label: "Function" },
+  exception: { bg: "var(--danger)", ink: "var(--exception-ink)", border: "var(--danger)", label: "Exception" },
+  external: { bg: "var(--text-4)", ink: "var(--text-3)", border: "var(--text-4)", label: "External / library" },
+  terminal: { bg: "var(--pastel-8)", ink: "var(--pastel-8-ink)", border: "var(--pastel-8)", label: "Return / finish" },
+  collection: { bg: "var(--pastel-3)", ink: "var(--pastel-3-ink)", border: "var(--pastel-3)", label: "Collection" },
+  node: { bg: "var(--pastel-5)", ink: "var(--pastel-5-ink)", border: "var(--pastel-5)", label: "Node" },
 };
 
 /**


### PR DESCRIPTION
## #4617 — border is an intense shade of the card's own bucket bg
After #4597/#4566 added taxonomy colors, node cards rendered with a generic neutral/brown border that clashed with their pastel bucket backgrounds (several `-ink` text tokens read brown/olive: pastel-3 `#965d2c`, pastel-6 `#816928`, pastel-10 `#8c632f`).

- Added a per-bucket `border` field to `RoleStyle` in `style.ts`, derived from the **same** bucket color family as `bg` — the bucket's solid pastel token (the saturated version of the `@22%` background wash), not the muted text ink. Exception → `--danger` (red, #4556), external → `--text-4` (muted).
- The renderer (`FlowDagNode.tsx`) now sets `borderColor: color-mix(in srgb, rs.border 72%, var(--text))`, deepening the bucket hue toward its dark anchor so the outline reads as an intense/saturated shade of the card's own color. Because `--text` is dark in light themes and light in dark themes, the border darkens in light mode and lightens in dark mode — AA contrast holds against the wash in both.
- The terminal/collection outline ring and the `FlowDagLegend.tsx` swatch borders use the identical derivation, so node, edge, and legend stay in lockstep.

All ~10 buckets (endpoint/handler/service/repository/schema/function/collection/terminal/exception/external/node) get bg + a matching intense border from one color per bucket.

## #4619 — repo badge pushed outside the card
The right-aligned repo chip (green `core-backend-v…` pill) overflowed past the card's right edge.

- The header row in `FlowDagNode.tsx` now clips to the card width (`min-w-0 overflow-hidden`), and the role / incoming-edge pills are allowed to truncate (`min-w-0 truncate`). The `shrink-0` `RepoChip` is therefore always pulled INSIDE the card — nothing bleeds past the border. The card already truncates the repo name to `core-backend-v…`; this keeps it contained.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅ (exit 0, no errors)
- `npx vite build` ✅ (built in 13.84s)
- flow-dag layout tests: `vitest run src/components/flow-dag` ✅ 22/22 passed

Closes #4617
Closes #4619

🤖 Generated with [Claude Code](https://claude.com/claude-code)