### PR TITLE
fix(paths): group endpoints by their own module + opaque sticky header (#4608)

### DIFF
--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -49,6 +49,13 @@ type v2PathRoute struct {
 	AuthChipTone string   `json:"auth_chip_tone,omitempty"`
 	Repos        []string `json:"repos"`
 	Controller   string   `json:"controller"`
+	// SourceFile is the repo-relative path of THIS route's own defining file
+	// (the handler/controller source). The frontend module-grouping derives the
+	// `src/modules/<MODULE>/…` bucket per-route from this field rather than from
+	// the shared controller-group file, so endpoints that happen to land in the
+	// same controller group (resolved-viewset name collisions, mixed-module
+	// router files) are never mis-bucketed under a sibling's module (#4608).
+	SourceFile string `json:"source_file,omitempty"`
 	// Confidence (#1129) is the 0..1 candidate-quality score computed at
 	// list-build time. Always populated when the confidence filter ran.
 	Confidence float64 `json:"confidence,omitempty"`
@@ -529,6 +536,10 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				Frameworks: []string{},
 				Repos:      []string{},
 				Controller: cID,
+				// #4608 — stamp THIS route's own defining file so the frontend
+				// module-grouping derives its `src/modules/<MODULE>/…` bucket
+				// per-route, never inheriting a sibling route's module.
+				SourceFile: ep.SourceFile,
 			}
 			cm.order = append(cm.order, ep.Path)
 		}

--- a/internal/dashboard/v2_paths_test.go
+++ b/internal/dashboard/v2_paths_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -491,6 +492,92 @@ func TestV2PathsList_GroupsByFile(t *testing.T) {
 	if detail.Data.Parameters == nil {
 		t.Error("parameters: want [] (non-nil), got nil")
 	}
+}
+
+// TestV2PathsList_RouteSourceFilePerEndpoint is the #4608 guard: every emitted
+// route must carry its OWN defining `source_file`, and the `src/modules/<MODULE>`
+// segment parsed from that file must match the route's own module — never a
+// sibling's. The frontend module left-tree groups per-route by this field, so a
+// stale/shared file here is exactly the cross-module mis-bucketing bug (an
+// inspections endpoint showing under modules/dob-sync).
+func TestV2PathsList_RouteSourceFilePerEndpoint(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "a", Name: "getCounts", Kind: "http_endpoint",
+			SourceFile: "src/modules/inspections/api/inspection.controller.ts",
+			Properties: map[string]string{"path": "/v1/inspections/get_counts", "verb": "GET", "owning_backend": "src"}},
+		{ID: "b", Name: "sync", Kind: "http_endpoint",
+			SourceFile: "src/modules/dob-sync/api/dob-sync.controller.ts",
+			Properties: map[string]string{"path": "/v1/dob-sync/run", "verb": "POST", "owning_backend": "src"}},
+		{ID: "c", Name: "templates", Kind: "http_endpoint",
+			SourceFile: "src/modules/me-email-templates/api/me-email-templates.controller.ts",
+			Properties: map[string]string{"path": "/v1/me-email-templates", "verb": "GET", "owning_backend": "src"}},
+	}
+	grp := makePathsTestGroup(entities, nil)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths")
+	if err != nil {
+		t.Fatalf("GET paths: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Data v2PathsListResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Expected module segment per path, derived from each endpoint's OWN file.
+	wantModule := map[string]string{
+		"/v1/inspections/get_counts": "inspections",
+		"/v1/dob-sync/run":           "dob-sync",
+		"/v1/me-email-templates":     "me-email-templates",
+	}
+	seen := 0
+	for _, b := range body.Data.Backends {
+		for _, g := range b.Groups {
+			for _, r := range g.Routes {
+				if r.SourceFile == "" {
+					t.Errorf("route %q: source_file is empty — frontend cannot derive its own module", r.Path)
+					continue
+				}
+				wantMod, ok := wantModule[r.Path]
+				if !ok {
+					continue
+				}
+				seen++
+				// Guard: an endpoint's module must equal `src/modules/<label>/`
+				// of ITS OWN source file (#4608).
+				wantPrefix := "src/modules/" + wantMod + "/"
+				if !strings.HasPrefix(r.SourceFile, wantPrefix) {
+					t.Errorf("route %q: source_file %q does not live under %q (cross-module mis-bucketing)",
+						r.Path, r.SourceFile, wantPrefix)
+				}
+				if gotMod := moduleSegmentFromFile(r.SourceFile); gotMod != wantMod {
+					t.Errorf("route %q: derived module %q, want %q", r.Path, gotMod, wantMod)
+				}
+			}
+		}
+	}
+	if seen != len(wantModule) {
+		t.Fatalf("expected %d guarded routes, saw %d", len(wantModule), seen)
+	}
+}
+
+// moduleSegmentFromFile mirrors the frontend deriveModule() anchor rule: returns
+// the segment immediately after a `modules/` (or apps/packages/services/domains)
+// anchor in the path. Used by the #4608 guard to prove the backend stamps each
+// route with a file whose module matches the route.
+func moduleSegmentFromFile(file string) string {
+	segs := strings.Split(strings.ReplaceAll(file, "\\", "/"), "/")
+	anchors := map[string]bool{"modules": true, "apps": true, "packages": true, "services": true, "domains": true}
+	for i := 0; i < len(segs)-1; i++ {
+		if anchors[strings.ToLower(segs[i])] {
+			return segs[i+1]
+		}
+	}
+	return ""
 }
 
 // ---------------------------------------------------------------------------

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -788,6 +788,13 @@ export interface PathRoute {
   auth: boolean;
   repos: string[];
   controller: string;
+  /**
+   * Repo-relative path of THIS route's own defining file (#4608). The module
+   * left-tree groups each route by the `src/modules/<MODULE>/…` segment of this
+   * field, so a route is never bucketed under a sibling's module just because
+   * they share a controller group.
+   */
+  source_file?: string;
 }
 
 /** One controller group inside a backend. */

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -212,7 +212,11 @@ function groupByModule(backend: PathBackend): ControllerGroupShape[] {
   const buckets = new Map<string, ControllerGroupShape>();
   for (const g of backend.groups ?? []) {
     for (const r of g.routes ?? []) {
-      const m = deriveModule(g.file ?? r.controller, r.controller);
+      // #4608 — group each route by the module parsed from ITS OWN defining
+      // file (`r.source_file`), not the shared controller-group file. Falling
+      // back to the group file only when a route carries no source_file keeps
+      // older/partial payloads working without cross-module mis-bucketing.
+      const m = deriveModule(r.source_file ?? g.file, r.controller);
       let bucket = buckets.get(m.key);
       if (!bucket) {
         bucket = {
@@ -477,14 +481,22 @@ function BackendSection({
         ? "var(--pastel-5-ink)"
         : "var(--pastel-1-ink)";
 
+  // #4608 — the service tint base, shared by the (translucent) section body and
+  // the OPAQUE sticky header overlay. The header lays this tint over a solid
+  // `--surface` so it keeps its colour without letting rows bleed through.
+  const svcTintBase =
+    backend.service_type === "gRPC"
+      ? "var(--pastel-9)"
+      : backend.service_type === "GraphQL"
+        ? "var(--pastel-5)"
+        : "var(--pastel-1)";
+  const svcTintOverlay = `color-mix(in srgb, ${svcTintBase} 6%, transparent)`;
+
   return (
     <div
       className="border-b border-border"
       style={{
-        background: `color-mix(in srgb, ${
-          backend.service_type === "gRPC" ? "var(--pastel-9)" :
-          backend.service_type === "GraphQL" ? "var(--pastel-5)" : "var(--pastel-1)"
-        } 6%, transparent)`,
+        background: svcTintOverlay,
       }}
     >
       {/* Backend header — sticky */}
@@ -493,13 +505,20 @@ function BackendSection({
         onClick={() => toggle(key)}
         className={cn(
           "w-full text-left flex items-center gap-2 px-3 py-2",
-          "sticky top-0 z-[3]",
+          "sticky top-0 z-[5]",
           "text-sm font-semibold text-text",
           "hover:brightness-95 transition-all duration-100",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]",
         )}
         style={{
-          background: "inherit",
+          // #4608 — the sticky header must be OPAQUE so rows scrolling beneath
+          // it don't bleed through. `inherit` resolved to the container's
+          // translucent tint (color-mix(... transparent)), letting the first
+          // row show through. Layer the same service tint over a solid surface
+          // so the header keeps its colour but is fully opaque, and raise the
+          // z-index above the sticky column header (z-[2]) and rows.
+          backgroundColor: "var(--surface)",
+          backgroundImage: `linear-gradient(0deg, ${svcTintOverlay}, ${svcTintOverlay})`,
           borderLeft: `3px solid ${svcBorderColor}`,
           paddingLeft: "calc(0.75rem - 3px)",
         }}


### PR DESCRIPTION
## Problem (#4608)
The Paths left-tree bucketed endpoints under the **wrong** module:
- `GET /v1/inspections/get_counts` (defined in `src/modules/inspections/api/inspection.controller.ts`) showed under **modules/dob-sync**
- `GET /v1/me-email-templates` (defined in `src/modules/me-email-templates/...`) showed under **modules/proposals**

The module DATA in the graph was correct (the detail 'Defined in' showed the right path) — the grouping **derivation** was wrong.

## Root cause — frontend
`groupByModule()` in `paths.tsx` derived every route's module from the **shared controller-group file** (`g.file`), so all routes in a group inherited the group's module. Routes carried no per-endpoint source file to group by, so endpoints landing in the same controller group (resolved-viewset name collisions / mixed-module files) were mis-bucketed under a sibling's module.

## Fix
- **Backend** (`internal/dashboard/v2_paths.go`): each `v2PathRoute` now carries its OWN defining `source_file` (`ep.SourceFile`).
- **Frontend** (`webui-v2/src/routes/paths.tsx` + `types.ts`): `deriveModule()` keys off `r.source_file` per route, falling back to the group file only when absent.
- **Guard** (`v2_paths_test.go`): `TestV2PathsList_RouteSourceFilePerEndpoint` asserts every route carries its own `source_file` and that the parsed `src/modules/<MODULE>/` segment equals the route's own module — inspections / dob-sync / me-email-templates never cross-bucket.

## Sticky-header fix (UI)
The sticky `core-backend-v3 REST` section header used `background: inherit`, which resolved to the container's **translucent** `color-mix(... transparent)` tint, letting the first row bleed through. It now layers the service tint over a solid `--surface` (fully opaque) and raises z-index to 5 (above the sticky column header at z-2).

## Gates
- `go build ./...` ✅ · `go vet ./internal/dashboard/...` ✅ · `go test ./internal/dashboard/...` ✅ (incl. new guard)
- `npm ci && npx tsc --noEmit && npx vite build` ✅

Closes #4608

🤖 Generated with [Claude Code](https://claude.com/claude-code)