### PR TITLE
fix(ui): render tab triggers inline (icon + label + count on one row)

### DIFF
--- a/webui-v2/src/components/ui/tabs.tsx
+++ b/webui-v2/src/components/ui/tabs.tsx
@@ -23,7 +23,7 @@ export const TabsTrigger = forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "relative h-8 px-3 text-md font-medium text-text-3 -mb-px border-b-2 border-transparent",
+      "relative inline-flex items-center h-8 px-3 text-md font-medium text-text-3 -mb-px border-b-2 border-transparent",
       "transition-colors duration-[120ms] hover:text-text-2",
       "data-[state=active]:text-text data-[state=active]:border-accent",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] rounded-sm",


### PR DESCRIPTION
## Bug #4631

On the Security page each tab rendered its **icon stacked above the label** (shield over "Auth coverage", key over "Secrets", refresh over "Import cycles"), cramping the strip and misaligning the active underline. The gold-standard Quality tabs render icon inline with the label.

## Root cause — shared primitive, not per-page

The shared `components/ui/tabs.tsx` `TabsTrigger` did **not** set `flex`/`items-center`. With multiple children (icon, label text, `TabCount` badge), they laid out as block-level and stacked vertically. The pages that looked correct (Quality, Pending, Dataflow) only did so because each one re-added its own `flex items-center` / `inline-flex items-center` className per trigger. Security and Operations did not, so they stacked.

## Fix

Add `inline-flex items-center` to the base `TabsTrigger` className — one change that fixes every page at once. Spacing continues to use the existing per-element margins (icon `mr-1.5`, `TabCount` `ml-1.5`), so there is no double-gap. The redundant per-page flex classes remain harmless (merged via `cn`).

## Pages audited

- **security.tsx** — fixed (icons were stacked).
- **operations.tsx** — fixed (System/Patterns/Quality/Updates icons were stacked).
- **topology.tsx** — text + TabCount now reliably centered inline.
- **pending.tsx** — already inline via its own `gap-1.5`; unaffected.
- **dataflow.tsx** — already inline via its own `inline-flex items-center`; unaffected.

Labels, descriptions, `TabCount` badges and InsightBanner all preserved.

## Gates

- `npm ci` ✅
- `npx tsc --noEmit` ✅ (exit 0)
- `npx vite build` ✅ (built in 20.71s)

## Follow-up

`paths.tsx` is owned by a sibling agent and out of scope here. If its tab strip uses the shared `TabsTrigger` it is automatically fixed by this primitive change; if it has a bespoke strip with multi-child triggers and no flex class, it would need the same treatment — flagged for that agent to confirm.

Closes #4631

🤖 Generated with [Claude Code](https://claude.com/claude-code)