### PR TITLE
feat(paths): expand request/query DTO fields on path detail (#4606)

### DIFF
--- a/internal/custom/javascript/validation_schema.go
+++ b/internal/custom/javascript/validation_schema.go
@@ -59,15 +59,6 @@ var (
 	joiFieldRe = regexp.MustCompile(`(?m)([A-Za-z_]\w*)\s*:\s*(?:Joi|joi)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
 	// yup field: `name: yup.string()`.
 	yupFieldRe = regexp.MustCompile(`(?m)([A-Za-z_]\w*)\s*:\s*(?:yup|Yup)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	// class-validator field: a `@IsString()` / `@IsInt()` ... decorator followed
-	// (possibly across blank lines / more decorators) by `name: string;` or
-	// `name!: string` or just `name;`. We capture the decorator type and the
-	// property name; the TS type annotation (if present) refines the type.
-	cvFieldRe = regexp.MustCompile(
-		`(?m)@(Is[A-Za-z]\w*|Min|Max|Length|MinLength|MaxLength|ValidateNested|Type)\s*\([^)]*\)` +
-			`(?:\s*@\w+\s*\([^)]*\))*\s*` +
-			`([A-Za-z_]\w*)\s*[!?]?\s*(?::\s*([A-Za-z_][\w.<>\[\] ]*?))?\s*[;=\n]`)
-
 	// cvNestedTypeRe: a class-transformer `@Type(() => TargetClass)` thunk,
 	// optionally preceded/followed by other decorators, bound to a property name.
 	// Group 1 = target class, group 2 = field name. Issue #4328.
@@ -156,7 +147,13 @@ func (e *validationSchemaExtractor) Extract(ctx context.Context, file extreg.Fil
 			setProps(&ent, "library", sd.lib, "pattern_type", "validation_schema",
 				"provenance", "INFERRED_FROM_"+strings.ToUpper(sd.lib)+"_OBJECT")
 			applyFieldProps(&ent, fields)
+			// Field-membership sub-entities (issue #4606): emit before addSchema
+			// so the CONTAINS edges are recorded on the owner.
+			children := emitSchemaFieldMembers(&ent, fields, sd.lib, file.Path, file.Language)
 			addSchema(ent)
+			for _, c := range children {
+				addSchema(c)
+			}
 		}
 	}
 
@@ -176,6 +173,11 @@ func (e *validationSchemaExtractor) Extract(ctx context.Context, file extreg.Fil
 			setProps(&ent, "library", "class-validator", "pattern_type", "validation_schema",
 				"provenance", "INFERRED_FROM_CLASS_VALIDATOR")
 			applyFieldProps(&ent, fields)
+			// Field-membership sub-entities (issue #4606): request `@Body` DTOs and
+			// `@Query` object DTOs now expand to their fields, parity with response
+			// Schema fields. Emitted before the nested-target edges so all
+			// relationships land on the same owner.
+			cvChildren := emitSchemaFieldMembers(&ent, fields, "class-validator", file.Path, file.Language)
 			// Nested-DTO target edges (issue #4328): `@ValidateNested()
 			// @Type(() => AddressDto)` carries a class target in a class-transformer
 			// thunk. Without an outbound edge the nested DTO rings. Emit a REFERENCES
@@ -186,6 +188,9 @@ func (e *validationSchemaExtractor) Extract(ctx context.Context, file extreg.Fil
 					referencesClassEdge(ent.ID, tgt.target, "class-validator", tgt.field))
 			}
 			addSchema(ent)
+			for _, c := range cvChildren {
+				addSchema(c)
+			}
 		}
 	}
 
@@ -334,10 +339,17 @@ func detectResponseSchemas(region string, schemaNames map[string]bool) []schemaR
 	return refs
 }
 
-// schemaField is a captured field name + normalized type.
+// schemaField is a captured field name + normalized type. `validators` carries
+// the class-validator decorators (e.g. `@IsString`, `@IsOptional`) that
+// annotate the field, and `optional` records whether the field is declared
+// optional (`name?:` or `@IsOptional()`). These feed the field-membership
+// sub-entities (issue #4606) so the dashboard /shape resolver can expand a
+// request/query DTO's fields with parity to response Schema fields.
 type schemaField struct {
-	name string
-	typ  string
+	name       string
+	typ        string
+	validators []string
+	optional   bool
 }
 
 // extractSchemaFields pulls `name: lib.<kind>()` field declarations out of a
@@ -356,28 +368,81 @@ func extractSchemaFields(re *regexp.Regexp, body string) []schemaField {
 	return fields
 }
 
+// cvFieldDecoratorsRe captures the full run of decorators preceding a property
+// declaration plus the property name and (optional) TS type annotation. Group 1
+// = the raw decorator block (one or more `@X(...)`), group 2 = property name,
+// group 3 = the TS type annotation (may be empty). Issue #4606: the per-field
+// validator set is needed so request/query DTO fields expand with their
+// validators (parity with response Schema annotations).
+var cvFieldDecoratorsRe = regexp.MustCompile(
+	`(?m)((?:@[A-Za-z]\w*\s*(?:\([^)]*\))?\s*)+)` +
+		`([A-Za-z_]\w*)\s*([!?])?\s*(?::\s*([A-Za-z_][\w.<>\[\] ]*?))?\s*[;=\n]`)
+
+// cvDecoratorNameRe pulls each decorator's bare name from a decorator block.
+var cvDecoratorNameRe = regexp.MustCompile(`@([A-Za-z]\w*)`)
+
 // extractClassValidatorFields pulls `@IsX() name: type;` fields from a class
-// body. The TS annotation refines the type; otherwise the decorator does.
+// body. The TS annotation refines the type; otherwise the decorator does. The
+// full decorator run is captured as the field's validator set, and `name?:` /
+// `@IsOptional()` mark the field optional (issue #4606).
 func extractClassValidatorFields(body string) []schemaField {
 	var fields []schemaField
 	seen := make(map[string]bool)
-	for _, m := range cvFieldRe.FindAllStringSubmatch(body, -1) {
-		decorator := m[1]
+	for _, m := range cvFieldDecoratorsRe.FindAllStringSubmatch(body, -1) {
+		decoratorBlock := m[1]
 		name := m[2]
-		annot := strings.TrimSpace(m[3])
+		optMark := m[3]
+		annot := strings.TrimSpace(m[4])
 		if name == "" || seen[name] {
 			continue
 		}
+		validators := cvDecoratorNameRe.FindAllStringSubmatch(decoratorBlock, -1)
+		var validatorNames []string
+		isValidatorDTO := false
+		for _, v := range validators {
+			validatorNames = append(validatorNames, "@"+v[1])
+			if _, isCV := cvDecoratorType[v[1]]; isCV {
+				isValidatorDTO = true
+			}
+			switch v[1] {
+			case "IsString", "IsInt", "IsNumber", "IsBoolean", "IsDate", "IsEmail",
+				"IsUUID", "IsArray", "IsObject", "IsEnum", "IsPositive", "IsNegative",
+				"IsOptional", "ValidateNested", "Type", "Min", "Max", "Length",
+				"MinLength", "MaxLength", "IsNotEmpty", "IsDefined":
+				isValidatorDTO = true
+			}
+		}
+		if !isValidatorDTO {
+			// A plain property with non-validator decorators — skip so we keep
+			// parity with the original IsX-anchored detection (no false fields).
+			continue
+		}
 		seen[name] = true
+		// Determine the scalar type: TS annotation wins, else the first
+		// type-bearing class-validator decorator.
 		typ := ""
 		if annot != "" {
 			typ = normalizeScalar(annot)
-		} else if dt, ok := cvDecoratorType[decorator]; ok {
-			typ = dt
 		} else {
+			for _, v := range validators {
+				if dt, ok := cvDecoratorType[v[1]]; ok {
+					typ = dt
+					break
+				}
+			}
+		}
+		if typ == "" {
 			typ = "unknown"
 		}
-		fields = append(fields, schemaField{name: name, typ: typ})
+		optional := optMark == "?"
+		for _, vn := range validatorNames {
+			if vn == "@IsOptional" {
+				optional = true
+			}
+		}
+		fields = append(fields, schemaField{
+			name: name, typ: typ, validators: validatorNames, optional: optional,
+		})
 	}
 	return fields
 }
@@ -450,6 +515,72 @@ func applyFieldProps(ent *types.EntityRecord, fields []schemaField) {
 	}
 	sort.Strings(names)
 	setProps(ent, "fields", strings.Join(names, ","), "field_count", fmt.Sprintf("%d", len(fields)))
+}
+
+// emitSchemaFieldMembers emits one `SCOPE.Schema/field` sub-entity per captured
+// field of a schema/DTO, plus a CONTAINS edge from the owning schema entity to
+// each child — parity with the response Schema field sub-nodes the dashboard
+// /shape resolver already expands (shape_tree.go, #4587/#4569). Issue #4606:
+// request `@Body` DTOs (CreateNoteBody), `@Query` object DTOs
+// (InspectionCountsQuery), and any zod/joi/yup/class-validator schema now carry
+// expandable field members instead of being opaque scalar-prop bags.
+//
+// The child entity's Signature is `[@Validators ...] <type> <name>` so the
+// shape resolver's parseFieldSignature recovers (annotations, type, name)
+// exactly as it does for Java/response DTO fields. Optional fields prepend an
+// `@IsOptional` marker (when not already present) so the resolver infers
+// nullability consistently. Each child is returned to the caller, and the
+// CONTAINS edge is appended to the owner entity in place.
+func emitSchemaFieldMembers(owner *types.EntityRecord, fields []schemaField, library, filePath, language string) []types.EntityRecord {
+	if owner == nil || len(fields) == 0 {
+		return nil
+	}
+	var out []types.EntityRecord
+	for _, f := range fields {
+		annots := append([]string(nil), f.validators...)
+		if f.optional {
+			hasOpt := false
+			for _, a := range annots {
+				if a == "@IsOptional" {
+					hasOpt = true
+					break
+				}
+			}
+			if !hasOpt {
+				annots = append(annots, "@IsOptional")
+			}
+		}
+		// Build a Java-style field signature: `[@Ann ...] Type name`.
+		var sb strings.Builder
+		for _, a := range annots {
+			sb.WriteString(a)
+			sb.WriteByte(' ')
+		}
+		typ := f.typ
+		if typ == "" {
+			typ = "unknown"
+		}
+		sb.WriteString(typ)
+		sb.WriteByte(' ')
+		sb.WriteString(f.name)
+
+		childName := owner.Name + "." + f.name
+		child := makeEntity(childName, "SCOPE.Schema", "field", filePath, language, owner.StartLine)
+		child.Signature = sb.String()
+		setProps(&child, "library", library, "pattern_type", "field",
+			"field_name", f.name, "field_type", typ, "parent_class", owner.Name,
+			"provenance", "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP")
+		if f.optional {
+			setProps(&child, "optional", "true")
+		}
+		if len(annots) > 0 {
+			setProps(&child, "validators", strings.Join(annots, " "))
+		}
+		owner.Relationships = append(owner.Relationships,
+			containsFieldEdge(owner.Name, child.ID, f.name, library))
+		out = append(out, child)
+	}
+	return out
 }
 
 // balancedObjectBody returns the substring inside the parentheses starting at

--- a/internal/custom/javascript/validation_schema_test.go
+++ b/internal/custom/javascript/validation_schema_test.go
@@ -88,6 +88,84 @@ router.get('/ping', (req, res) => res.send('pong'));`
 }
 
 // ---------------------------------------------------------------------------
+// Field-membership sub-entities (issue #4606)
+// ---------------------------------------------------------------------------
+
+// fieldChild returns the SCOPE.Schema/field sub-entity named "<Class>.<field>".
+func fieldChild(ents []types.EntityRecord, qualified string) *types.EntityRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == qualified {
+			return e
+		}
+	}
+	return nil
+}
+
+// A class-validator request `@Body` DTO must expand to per-field member
+// sub-entities (with CONTAINS edges + a parseable Signature) so the dashboard
+// /shape resolver can render them — parity with response Schema fields.
+func TestClassValidatorDTO_FieldMembers(t *testing.T) {
+	src := `import { IsString, IsInt, IsOptional } from 'class-validator';
+export class CreateNoteBody {
+  @IsString()
+  title: string;
+
+  @IsInt()
+  @IsOptional()
+  priority?: number;
+}`
+	ents := extractFull(t, "custom_js_validation_schema", fi("note.dto.ts", "typescript", src))
+
+	se := schemaEntity(ents, "CreateNoteBody")
+	if se == nil {
+		t.Fatal("expected SCOPE.Schema CreateNoteBody")
+	}
+	// Scalar-prop bag preserved (back-compat).
+	wantField(t, se, "title", "string")
+	// TS annotation `priority?: number` is authoritative over the @IsInt decorator.
+	wantField(t, se, "priority", "number")
+
+	// Field sub-entities exist.
+	titleChild := fieldChild(ents, "CreateNoteBody.title")
+	if titleChild == nil {
+		t.Fatal("expected field sub-entity CreateNoteBody.title")
+	}
+	if titleChild.Signature == "" {
+		t.Fatal("field sub-entity must carry a Signature for the shape resolver")
+	}
+	priorityChild := fieldChild(ents, "CreateNoteBody.priority")
+	if priorityChild == nil {
+		t.Fatal("expected field sub-entity CreateNoteBody.priority")
+	}
+	if priorityChild.Properties["optional"] != "true" {
+		t.Errorf("priority should be optional, props=%v", priorityChild.Properties)
+	}
+
+	// CONTAINS membership edges bind each field to the owner.
+	if !hasContainsTo(ents, titleChild.ID, titleChild.Name) {
+		t.Error("expected CONTAINS edge to CreateNoteBody.title")
+	}
+	if !hasContainsTo(ents, priorityChild.ID, priorityChild.Name) {
+		t.Error("expected CONTAINS edge to CreateNoteBody.priority")
+	}
+}
+
+// A zod object schema also gets field sub-entities (general parity).
+func TestZodSchema_FieldMembers(t *testing.T) {
+	src := `const CreateUser = z.object({ name: z.string(), age: z.number() });
+router.post('/users', (req, res) => { CreateUser.parse(req.body); res.json({}); });`
+	ents := extractFull(t, "custom_js_validation_schema", fi("u.ts", "typescript", src))
+	nameChild := fieldChild(ents, "CreateUser.name")
+	if nameChild == nil {
+		t.Fatal("expected field sub-entity CreateUser.name")
+	}
+	if !hasContainsTo(ents, nameChild.ID, nameChild.Name) {
+		t.Error("expected CONTAINS edge to CreateUser.name")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Joi
 // ---------------------------------------------------------------------------
 

--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -1178,6 +1178,18 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 				Desc:     describeJavaParam(jp),
 				Verbs:    []string{h.Verb},
 			}
+			// Issue #4606 — resolve object-valued params (a `@Body` DTO or a
+			// `@Query` object DTO such as InspectionCountsQuery) to their in-group
+			// class entity so the ShapeTree renders an expand chevron and can
+			// request the field subtree. Scalar params (string/number/…) fall
+			// through unresolved and render as plain leaf rows.
+			resolveParamType := unwrapElementType(jp.Type)
+			if target := findClassEntityByName(grp, resolveParamType); target != nil {
+				if slug, _ := findRepoForEntity(grp, target.ID); slug != "" {
+					row.TypeEntityID = dashPrefixedID(slug, target.ID)
+					row.HasChildren = classHasFieldChildren(grp, target)
+				}
+			}
 			params = append(params, row)
 			emitted[key] = len(params) - 1
 		}

--- a/internal/dashboard/v2_paths_test.go
+++ b/internal/dashboard/v2_paths_test.go
@@ -691,3 +691,84 @@ func TestV2PathDetail_Issue1936_JavaParametersSurfaced(t *testing.T) {
 		t.Errorf("[#1936] dryRun: should not be required when default value present, got %+v", dr)
 	}
 }
+
+// TestV2PathDetail_Issue4606_QueryBodyDTOExpandable verifies that an object-
+// valued parameter (a @Body DTO or a @Query object DTO) whose type resolves to
+// an in-group Schema class carrying CONTAINS field children is stamped with
+// TypeEntityID + HasChildren so the frontend ShapeTree renders an expand
+// chevron. Scalar params stay leaf rows.
+func TestV2PathDetail_Issue4606_QueryBodyDTOExpandable(t *testing.T) {
+	path := "/inspections/counts"
+	hash := hashStr(path)
+	paramsJSON := `[` +
+		`{"name":"q","in":"query","type":"InspectionCountsQuery","required":false,"annotations":["@Query"]},` +
+		`{"name":"body","in":"body","type":"CreateNoteBody","required":true,"annotations":["@Body"]},` +
+		`{"name":"limit","in":"query","type":"number","required":false,"annotations":["@Query"]}` +
+		`]`
+	entities := []graph.Entity{
+		{
+			ID: "e-ep-1", Name: "InspectionsController.counts", Kind: "http_endpoint",
+			SourceFile: "src/inspections.controller.ts", StartLine: 10, Language: "typescript",
+			Properties: map[string]string{
+				"path": path, "verb": "POST", "framework": "nestjs", "parameters": paramsJSON,
+			},
+		},
+		// Query DTO + one field child.
+		{ID: "e-qdto", Name: "InspectionCountsQuery", Kind: "SCOPE.Schema",
+			SourceFile: "src/dto/counts.query.ts", Language: "typescript",
+			Properties: map[string]string{"library": "class-validator"}},
+		{ID: "e-qdto-f", Name: "InspectionCountsQuery.buildingId", Kind: "SCOPE.Schema",
+			Subtype: "field", SourceFile: "src/dto/counts.query.ts", Language: "typescript",
+			Signature: "@IsUUID string buildingId"},
+		// Body DTO + one field child.
+		{ID: "e-bdto", Name: "CreateNoteBody", Kind: "SCOPE.Schema",
+			SourceFile: "src/dto/note.dto.ts", Language: "typescript",
+			Properties: map[string]string{"library": "class-validator"}},
+		{ID: "e-bdto-f", Name: "CreateNoteBody.title", Kind: "SCOPE.Schema",
+			Subtype: "field", SourceFile: "src/dto/note.dto.ts", Language: "typescript",
+			Signature: "@IsString string title"},
+	}
+	rels := []graph.Relationship{
+		{FromID: "e-qdto", ToID: "e-qdto-f", Kind: "CONTAINS"},
+		{FromID: "e-bdto", ToID: "e-bdto-f", Kind: "CONTAINS"},
+	}
+	grp := makePathsTestGroup(entities, rels)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths/" + hash)
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool         `json:"ok"`
+		Data v2PathDetail `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := map[string]v2PathParameter{}
+	for _, p := range body.Data.Parameters {
+		got[p.Name] = p
+	}
+	for _, name := range []string{"q", "body"} {
+		p, ok := got[name]
+		if !ok {
+			t.Fatalf("[#4606] param %q missing", name)
+		}
+		if !p.HasChildren {
+			t.Errorf("[#4606] object param %q should be expandable (HasChildren), got %+v", name, p)
+		}
+		if p.TypeEntityID == "" {
+			t.Errorf("[#4606] object param %q should carry TypeEntityID, got %+v", name, p)
+		}
+	}
+	// Scalar query param must NOT be expandable.
+	if lp, ok := got["limit"]; ok && lp.HasChildren {
+		t.Errorf("[#4606] scalar param 'limit' must not be expandable, got %+v", lp)
+	}
+}

--- a/webui-v2/src/components/ShapeTree.tsx
+++ b/webui-v2/src/components/ShapeTree.tsx
@@ -173,11 +173,18 @@ function ShapeTreeNode({
           {row.required && <span className="text-danger ml-0.5">*</span>}
         </span>
 
-        {/* Col 4 — type chip, 200px, monospaced */}
+        {/* Col 4 — type chip, 200px, monospaced. Expandable object types are
+            rendered as an accented, underlined "link" so the field-expansion
+            affordance is discoverable even before the chevron is noticed (#4606). */}
         <span
-          className="shrink-0 font-mono text-text-3 overflow-hidden text-ellipsis whitespace-nowrap mr-2"
+          className={cn(
+            "shrink-0 font-mono overflow-hidden text-ellipsis whitespace-nowrap mr-2",
+            expandable
+              ? "text-accent underline decoration-dotted underline-offset-2"
+              : "text-text-3",
+          )}
           style={{ width: 200 }}
-          title={row.type}
+          title={expandable ? `${row.type} — click to expand fields` : row.type}
         >
           {row.type}
         </span>


### PR DESCRIPTION
## Summary
Object inputs/outputs on the Paths detail are now **expandable to their fields** — request `@Body` DTOs (e.g. `CreateNoteBody`), `@Query` object DTOs (e.g. `InspectionCountsQuery`), and response DTOs — at parity with the response Schema field expansion already shipped under #4587.

## The blocker (relates #4471)
Verified live: request/query class-validator DTO classes had **zero member sub-entities**, so the `/shape` resolver had nothing to expand. Response Schemas already had field sub-nodes.

## Backend
- `internal/custom/javascript/validation_schema.go`: the zod/joi/yup/class-validator schema extractor now emits one `SCOPE.Schema`/`subtype=field` **member sub-entity** per field, each carrying a Java-style `Signature` (`[@Validators…] Type name`) and a `CONTAINS` edge from the owning DTO — so `shape_tree.go` (which walks `CONTAINS` → field children) can expand them. Class-validator field detection now captures the full decorator run + optionality (`name?:` / `@IsOptional()`). Scalar `field_<name>` props preserved for back-compat.
- `internal/dashboard/v2_paths.go`: object-valued params decoded from the `parameters` JSON (NestJS `@Body`/`@Query` whole-object DTOs) now resolve to their in-group class entity, stamping `TypeEntityID` + `HasChildren`. Scalar params stay leaf rows.

## Frontend
- `ShapeTree` already renders a **collapsed-by-default** expand chevron for rows carrying `has_children`/`type_entity_id`, and `paramToShapeTreeRow` already projects them — so body/query DTO rows and the response row expand via the existing component (lazy `/shape` fetch, recursive for nested DTOs).
- `webui-v2/src/components/ShapeTree.tsx`: the expandable type token is now rendered as an accented, dotted-underlined "link" with a "click to expand fields" tooltip so the affordance is discoverable (previously `CreateNoteBody`/`InspectionCountsQuery` looked like plain text).

## Tests
- Backend: a class-validator request DTO yields member field sub-entities + `CONTAINS` (`TestClassValidatorDTO_FieldMembers`), zod parity (`TestZodSchema_FieldMembers`), and a path-detail test that query/body object params get `HasChildren`+`TypeEntityID` while scalars do not (`TestV2PathDetail_Issue4606_QueryBodyDTOExpandable`).
- Frontend stays type-safe (`tsc --noEmit` clean, `vite build` green).

## Cross-framework note (#4613)
Scope is NestJS/class-validator + zod/joi/yup. Pydantic and other request-DTO frameworks (FastAPI body/query models, DRF serializers, Spring `@ModelAttribute`, etc.) tracked under capability ticket #4613.

## Gates
- `go build ./...`, `go vet ./internal/custom/... ./internal/dashboard/...`, `go test ./internal/custom/... ./internal/dashboard/... ./internal/types/...` — all green.
- `npm ci && npx tsc --noEmit && npx vite build` — green.

> Live confirmation deferred to coordinator after rebuild + reindex (backend member indexing).

Closes #4606

🤖 Generated with [Claude Code](https://claude.com/claude-code)