### PR TITLE
feat(webui-v2): add InsightBanner to errorflow + audited content pages (#4633)

### DIFF
--- a/webui-v2/src/routes/compare.tsx
+++ b/webui-v2/src/routes/compare.tsx
@@ -19,6 +19,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { GitCompare, Loader2, AlertTriangle } from "lucide-react";
 
+import { InsightBanner } from "@/components/ui";
 import { useDiff } from "@/hooks/use-diff";
 import { useRefs } from "@/hooks/use-refs";
 import { DiffSummaryBanner } from "@/components/Compare/diff-summary-banner";
@@ -248,6 +249,24 @@ export default function CompareScreen() {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
+      <InsightBanner
+        storageKey="compare"
+        human={
+          <>
+            Compare — a structural diff of the knowledge graph between two refs
+            (branches, tags or commits) of a repo. It shows which entities were
+            added, removed or modified and which relationships changed, so you
+            can review the architectural impact of a branch instead of reading a
+            raw line-by-line text diff.
+          </>
+        }
+        agent={{
+          tool: "archigraph_diff_refs",
+          example:
+            "Reviewing a feature branch, an agent calls archigraph_diff_refs(refA=main, refB=feature) to get the added/removed/modified entities and changed edges, then focuses its review on the modified callables and their new dependencies instead of skimming the whole patch.",
+        }}
+      />
+
       {/* Selector row */}
       <SelectorRow
         groupId={groupId}

--- a/webui-v2/src/routes/errorflow.tsx
+++ b/webui-v2/src/routes/errorflow.tsx
@@ -46,7 +46,7 @@ import {
   Bug,
 } from "lucide-react";
 
-import { Badge, Card, CardBody, Pill } from "@/components/ui";
+import { Badge, Card, CardBody, Pill, InsightBanner } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
@@ -379,6 +379,31 @@ function ErrorFlowBody({
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
+      <InsightBanner
+        storageKey="errorflow"
+        human={
+          <>
+            Error flow — every exception type in the codebase, inverted around
+            the type: for each one, who can <strong>throw</strong> it and who{" "}
+            <strong>catches</strong> it. A type flagged{" "}
+            <em>“no catcher in graph”</em> is thrown but has no typed catcher
+            indexed anywhere — a cautious uncaught warning, not a proven leak.
+            Counts: {data.total_exceptions} exception type
+            {data.total_exceptions === 1 ? "" : "s"}, {data.total_uncaught} with
+            no catcher, {data.total_throws} throw
+            {data.total_throws === 1 ? "" : "s"} and {data.total_catches} catch
+            {data.total_catches === 1 ? "" : "es"} across the graph. Only TYPED
+            throws/catches are recorded — bare <code>except:</code> / untyped{" "}
+            <code>catch(e)</code> emit no edge.
+          </>
+        }
+        agent={{
+          tool: "archigraph_find",
+          example:
+            "Before adding a try/catch, an agent calls archigraph_find for SCOPE.ExceptionType nodes (the synthetic exception:<Type> entities) to see which exceptions are thrown but reach the top with no catcher in the graph, then wraps the one that actually escapes uncaught instead of guessing.",
+        }}
+      />
+
       {/* Summary */}
       <div className="flex flex-wrap gap-3">
         <SummaryStat label="Exception types" value={data.total_exceptions} />

--- a/webui-v2/src/routes/event-flows.tsx
+++ b/webui-v2/src/routes/event-flows.tsx
@@ -32,7 +32,7 @@ import { Radio, Workflow, ChevronRight, Copy } from "lucide-react";
 import { toast } from "sonner";
 
 import { api } from "@/lib/api";
-import { Badge, Skeleton } from "@/components/ui";
+import { Badge, Skeleton, InsightBanner } from "@/components/ui";
 import { useSourcePeek } from "@/components/SourcePeek";
 import { cn } from "@/lib/utils";
 
@@ -264,7 +264,25 @@ export default function EventFlowsScreen() {
   }
 
   return (
-    <div className="flex h-full w-full gap-4 p-4">
+    <div className="flex h-full w-full flex-col gap-4 p-4">
+      <InsightBanner
+        storageKey="event-flows"
+        human={
+          <>
+            Event flows — multi-hop publish/subscribe chains seeded from message
+            channels (Kafka topics, EventBridge buses and similar). Each chain
+            walks from a producer through every downstream handler that consumes
+            the event, so you can follow an event end-to-end across services
+            instead of guessing who reacts to it.
+          </>
+        }
+        agent={{
+          tool: "archigraph_flows",
+          example:
+            "Before changing the payload published to an `order.created` topic, an agent calls archigraph_flows to walk the pub/sub chain and list every downstream subscriber, so it updates all consumers in the same change instead of breaking a handler two hops away.",
+        }}
+      />
+      <div className="flex min-h-0 w-full flex-1 gap-4">
       {/* Left rail */}
       <aside className="flex w-[380px] shrink-0 flex-col gap-3 rounded-lg border border-border bg-surface-0 p-3">
         <header className="flex items-center justify-between">
@@ -332,6 +350,7 @@ export default function EventFlowsScreen() {
         )}
         {selectedId && detail.data && <ChainDetail detail={detail.data} />}
       </main>
+      </div>
     </div>
   );
 }

--- a/webui-v2/src/routes/graphql.tsx
+++ b/webui-v2/src/routes/graphql.tsx
@@ -39,7 +39,7 @@ import {
   Network,
 } from "lucide-react";
 
-import { Badge, Card, CardBody, Pill } from "@/components/ui";
+import { Badge, Card, CardBody, Pill, InsightBanner } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
@@ -373,6 +373,24 @@ export default function GraphQLScreen() {
           </>
         ) : (
           <>
+            <InsightBanner
+              storageKey="graphql"
+              human={
+                <>
+                  GraphQL resolvers — every query, mutation and subscription
+                  resolver in the group, grouped by the schema type they
+                  resolve, with the side effects each one performs (DB reads/
+                  writes, HTTP calls) and whether it is auth-guarded. Use it to
+                  see which fields touch the database or run unauthenticated.
+                </>
+              }
+              agent={{
+                tool: "archigraph_effects",
+                example:
+                  "Before changing a GraphQL mutation, an agent calls archigraph_effects on the resolver entity to enumerate its db_write / http side effects and confidence, so it knows the blast radius of the field it is about to edit rather than reading the resolver body and guessing.",
+              }}
+            />
+
             {/* Summary */}
             <div className="flex flex-wrap gap-3">
               <SummaryStat label="Resolvers" value={data!.total_resolvers} />


### PR DESCRIPTION
## What

The `/errorflow` page had no `InsightBanner`. Added one, and audited all route files for other content pages missing a banner.

### Banners added
- **errorflow** — exception types, who throws / who catches each, and `no catcher in graph` (thrown but never typed-caught) with live counts (exception types / no-catcher / throws / catches). Agent tool: `archigraph_find` (the synthetic `SCOPE.ExceptionType` / `exception:<Type>` nodes).
- **graphql** — resolver effects (DB/HTTP) + auth posture. Agent tool: `archigraph_effects`.
- **event-flows** — multi-hop pub/sub chains. Agent tool: `archigraph_flows`.
- **compare** — structural graph diff between two refs. Agent tool: `archigraph_diff_refs`.

All chosen tools were verified to exist in the MCP registration (`internal/mcp/`).

### Intentionally NOT given a banner
Infra / non-graph-insight pages: `landing` (group selector, no group context), `errors` (404/status screens), `settings` (config surface), `docs` (markdown reader), `router`, `not-found`, `placeholder-screen`.

### Skipped (sibling-owned)
`security`, `topology`, `operations`, `pending`, `dataflow`, `paths`, `iac` — all already have banners and are being edited by sibling agents.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅
- `npx vite build` ✅

Closes #4633

🤖 Generated with [Claude Code](https://claude.com/claude-code)