### PR TITLE
feat(iac): resolve cross-module output refs into semantic edges (#4625)

### DIFF
--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -218,9 +218,17 @@ func iacToolForEntity(kind, subtype, language string, props map[string]string) (
 	if t := strings.TrimSpace(props["iac_tool"]); t != "" {
 		return t, true
 	}
-	if kind == "SCOPE.Component" && subtype == "resource" &&
+	if kind == "SCOPE.Component" &&
 		(language == "terraform" || language == "hcl") {
-		return "terraform", true
+		// Issue #4625 — render `module` instances as diagram nodes too, not just
+		// `resource` blocks. A resource that consumes another module's output
+		// (module.<m>.<out>) draws a cross-module USES edge whose target is the
+		// module block; without rendering the module node that edge would surface
+		// only as an unresolved relation + a disconnected box. Modules are the
+		// natural cloud-architecture aggregate node for the child stack.
+		if subtype == "resource" || subtype == "module" {
+			return "terraform", true
+		}
 	}
 	return "", false
 }
@@ -234,6 +242,11 @@ func iacResourceTypeOf(name string, props map[string]string) string {
 	}
 	if t := strings.TrimSpace(props["resource_type"]); t != "" {
 		return t
+	}
+	// Issue #4625 — a module instance is named `module.<name>`; report its
+	// type as "module" so the diagram can render it as a child-stack aggregate.
+	if strings.HasPrefix(name, "module.") {
+		return "module"
 	}
 	// Terraform self-ref form: `aws_db_instance.main`.
 	if i := strings.IndexByte(name, '.'); i > 0 {
@@ -253,6 +266,11 @@ func iacCategoryOf(resourceType string, props map[string]string) string {
 	if c := strings.TrimSpace(props["resource_scope"]); c != "" {
 		return c
 	}
+	// Issue #4625 — a Terraform module instance is its own diagram category so
+	// the cloud-tier grouping can place child-stack aggregates distinctly.
+	if resourceType == "module" {
+		return "module"
+	}
 	if resourceType != "" {
 		return types.IaCResourceCategory(resourceType)
 	}
@@ -268,6 +286,17 @@ func iacRelationFacet(kind string, props map[string]string) (facet, detail strin
 		return "grant", props["grant"]
 	case reason == "event_source":
 		return "event_source", ""
+	}
+	// Issue #4625 — cross-module output reference (module.<m>.<out>) carries a
+	// derived semantic verb (consumes / redrive / logs-to / assumes / grants /
+	// reads). Surface it as the facet so the diagram renders the edge with its
+	// cloud-architecture meaning; the consumed output is the detail.
+	if props["dataflow"] == "cross_module" {
+		if sem := strings.TrimSpace(props["semantic"]); sem != "" && sem != "dependency" {
+			detail := strings.TrimSpace(props["module_output"])
+			return sem, detail
+		}
+		return "dependency", strings.TrimSpace(props["module_output"])
 	}
 	switch kind {
 	case "TRIGGERS", "SERVES", "ROUTES_TO", "SUBSCRIBES_TO":

--- a/internal/dashboard/handlers_iac_test.go
+++ b/internal/dashboard/handlers_iac_test.go
@@ -22,6 +22,10 @@ func TestIaCToolForEntity(t *testing.T) {
 			nil, "terraform", true},
 		{"hcl resource alias", "SCOPE.Component", "resource", "hcl",
 			nil, "terraform", true},
+		{"terraform module block renders (#4625)", "SCOPE.Component", "module", "terraform",
+			nil, "terraform", true},
+		{"hcl module block renders (#4625)", "SCOPE.Component", "module", "hcl",
+			nil, "terraform", true},
 		{"terraform provider block is not a resource", "SCOPE.Component", "provider", "terraform",
 			nil, "", false},
 		{"plain component (non-iac)", "SCOPE.Component", "resource", "go",
@@ -48,6 +52,7 @@ func TestIaCResourceTypeOf(t *testing.T) {
 		{"cdk construct_type", "DataBucket", map[string]string{"construct_type": "s3.Bucket"}, "s3.Bucket"},
 		{"cfn resource_type", "MyTable", map[string]string{"resource_type": "AWS::DynamoDB::Table"}, "AWS::DynamoDB::Table"},
 		{"terraform name-encoded", "aws_db_instance.main", nil, "aws_db_instance"},
+		{"terraform module (#4625)", "module.dispatch_queue", nil, "module"},
 		{"no type", "thing", nil, ""},
 	}
 	for _, c := range cases {
@@ -75,6 +80,10 @@ func TestIaCCategoryOf(t *testing.T) {
 	if got := iacCategoryOf("", nil); got != "" {
 		t.Fatalf("empty category = %q, want empty", got)
 	}
+	// #4625 — a Terraform module instance is its own diagram category.
+	if got := iacCategoryOf("module", nil); got != "module" {
+		t.Fatalf("module category = %q, want module", got)
+	}
 }
 
 func TestIaCRelationFacet(t *testing.T) {
@@ -92,6 +101,16 @@ func TestIaCRelationFacet(t *testing.T) {
 		{"contains topology", "CONTAINS", nil, "topology", ""},
 		{"sam trigger", "TRIGGERS", map[string]string{"trigger": "Api"}, "trigger", "Api"},
 		{"serves route", "SERVES", map[string]string{"http_method": "GET", "route_path": "/x"}, "trigger", "GET"},
+		// #4625 — cross-module output ref carries a derived semantic verb as the facet.
+		{"cross-module consumes", "USES",
+			map[string]string{"dataflow": "cross_module", "semantic": "consumes", "module_output": "queue_url"},
+			"consumes", "queue_url"},
+		{"cross-module redrive", "USES",
+			map[string]string{"dataflow": "cross_module", "semantic": "redrive", "module_output": "queue_arn"},
+			"redrive", "queue_arn"},
+		{"cross-module generic falls back to dependency", "USES",
+			map[string]string{"dataflow": "cross_module", "semantic": "dependency", "module_output": "id"},
+			"dependency", "id"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/extractors/hcl/cross_module.go
+++ b/internal/extractors/hcl/cross_module.go
@@ -1,0 +1,251 @@
+package hcl
+
+import (
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ----------------------------------------------------------------
+// Issue #4625 — cross-module output references → semantic edges
+// ----------------------------------------------------------------
+//
+// The headline gap: a resource inside one module consumes another module's
+// output, e.g. inside the worker stack
+//
+//	resource "aws_ecs_service" "worker" {
+//	  environment { queue_url = module.dispatch_queue.queue_url }
+//	}
+//
+// The generic CALLS miner (extractCalls / canonicalRefFromExpression) collapses
+// `module.dispatch_queue.queue_url` to the bare ref `module.dispatch_queue`,
+// dropping the `.queue_url` OUTPUT name and carrying no semantics. Worse, the
+// resulting CALLS target is the module BLOCK, which the dashboard does not
+// render as an IaC resource node — so the edge surfaces only as one of the
+// "N relation targets could not be resolved" footer entries and the consuming
+// resource + the producing module render as DISCONNECTED boxes.
+//
+// extractCrossModuleRefs fixes this for resource / data blocks: for every
+// `module.<name>.<output>` reference in the body it emits a USES edge
+//
+//	<this resource> --USES--> module.<name>
+//
+// carrying:
+//
+//	dataflow       = "cross_module"
+//	module_output  = "<output>"        (the referenced output, e.g. queue_url)
+//	input_arg      = "<attr>"          (the consuming attribute key, when known)
+//	semantic       = "<label>"         (consumes / redrive / logs-to / assumes /
+//	                                     grants / reads / dependency — derived)
+//
+// The module block IS a same-file entity (module.<name>), so the edge binds via
+// byLocation exactly like the existing CALLS/USES edges and is no longer an
+// unresolved relation. The dashboard (#4625) promotes module nodes to rendered
+// diagram resources so the edge draws between two visible boxes, labelled with
+// its semantic.
+//
+// Generalization note: AWS CDK / Pulumi / CloudFormation / Bicep express the
+// same cross-stack export→import pattern (CfnOutput/Fn::ImportValue, StackRef
+// outputs, module outputs). The semantic-label derivation here
+// (crossModuleSemantic) is intentionally framework-agnostic so those tools can
+// reuse it once their extractors emit a comparable cross-stack ref; tracked as
+// a follow-up.
+
+// extractCrossModuleRefs walks a resource/data block body and returns USES
+// edges for every `module.<name>.<output>` reference, tagged with the output
+// name, the consuming attribute, and a derived semantic label. selfRef is the
+// canonical ref of the consuming block (used as the edge FromID and to derive
+// semantics from the consuming resource type).
+func extractCrossModuleRefs(body *sitter.Node, src []byte, path, lang, selfRef string) []types.RelationshipRecord {
+	if body == nil {
+		return nil
+	}
+	consumerType := resourceTypeOfRef(selfRef)
+	var rels []types.RelationshipRecord
+	seen := map[string]struct{}{}
+
+	// walk descends an attribute value tree carrying the enclosing attribute
+	// key (argName) so the semantic derivation can use the consuming attribute.
+	var walk func(n *sitter.Node, argName string)
+	walk = func(n *sitter.Node, argName string) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "expression" {
+			if name, output := moduleOutputRef(n, src); name != "" && output != "" {
+				moduleRef := "module." + name
+				if moduleRef != selfRef {
+					dedup := argName + "|" + moduleRef + "|" + output
+					if _, ok := seen[dedup]; !ok {
+						seen[dedup] = struct{}{}
+						sem := crossModuleSemantic(consumerType, argName, output)
+						rels = append(rels, types.RelationshipRecord{
+							FromID: extractor.BuildOperationStructuralRef(lang, path, selfRef),
+							ToID:   extractor.BuildOperationStructuralRef(lang, path, moduleRef),
+							Kind:   "USES",
+							Properties: map[string]string{
+								"dataflow":      "cross_module",
+								"module_output": output,
+								"input_arg":     argName,
+								"semantic":      sem,
+								"line":          strconv.Itoa(int(n.StartPoint().Row) + 1),
+							},
+						})
+					}
+				}
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i), argName)
+		}
+	}
+
+	// Walk top-level attributes and nested blocks, tracking the attribute key
+	// that encloses each reference so semantics can use it.
+	var descend func(n *sitter.Node)
+	descend = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			child := n.Child(i)
+			if child == nil {
+				continue
+			}
+			switch child.Type() {
+			case "attribute":
+				key := ""
+				if id := firstChildByType(child, "identifier"); id != nil {
+					key = nodeText(id, src)
+				}
+				if key == "depends_on" {
+					continue
+				}
+				walk(child, key)
+			case "block":
+				// Nested config block (e.g. environment {}, redrive_policy block).
+				// Recurse so refs inside nested blocks are captured; the nested
+				// block label is not a meaningful arg, so attribute keys inside
+				// it are re-derived by the recursive descend.
+				if bb := blockBody(child); bb != nil {
+					descend(bb)
+				}
+			}
+		}
+	}
+	descend(body)
+	return rels
+}
+
+// moduleOutputRef returns (moduleName, outputName) when the expression is a
+// `module.<name>.<output>` reference (optionally with deeper attribute access,
+// in which case outputName is the first attribute after the module name). It
+// returns ("","") for non-module refs or bare `module.<name>` (no output).
+func moduleOutputRef(expr *sitter.Node, src []byte) (string, string) {
+	parts := referenceParts(expr, src)
+	if len(parts) >= 3 && parts[0] == "module" {
+		return parts[1], parts[2]
+	}
+	return "", ""
+}
+
+// resourceTypeOfRef returns the resource type segment of a canonical resource
+// ref. For "aws_ecs_service.worker" → "aws_ecs_service"; for "data.x.y" → "x".
+// Returns "" for module/var/local refs.
+func resourceTypeOfRef(ref string) string {
+	if ref == "" {
+		return ""
+	}
+	if strings.HasPrefix(ref, "data.") {
+		rest := ref[len("data."):]
+		if i := strings.IndexByte(rest, '.'); i > 0 {
+			return rest[:i]
+		}
+		return rest
+	}
+	switch {
+	case strings.HasPrefix(ref, "module."),
+		strings.HasPrefix(ref, "var."),
+		strings.HasPrefix(ref, "local."):
+		return ""
+	}
+	if i := strings.IndexByte(ref, '.'); i > 0 {
+		return ref[:i]
+	}
+	return ref
+}
+
+// crossModuleSemantic derives a human/UI-facing semantic label for a
+// cross-module (or cross-resource) data-flow edge from the consuming resource
+// type, the consuming attribute key, and the referenced output name. The labels
+// are the cloud-architecture verbs the IaC diagram renders (#4625):
+//
+//	consumes  — a compute/function resource reads a queue/stream/topic endpoint
+//	            (queue_url / queue_arn / stream / topic), i.e. it is a consumer.
+//	redrive   — a queue points at a dead-letter queue (redrive policy / DLQ).
+//	logs-to   — a resource writes to a CloudWatch log group / log destination.
+//	assumes   — a task/exec/instance assumes an IAM role (role arn).
+//	grants    — an IAM policy/attachment empowers a role/principal.
+//	reads     — a generic read of another resource's id/arn/name (default for
+//	            data refs and unclassified id/arn outputs).
+//	dependency— fallback when nothing more specific is derivable.
+//
+// Derivation is by signal priority: attribute key first (most specific to the
+// consumer's intent), then output name, then consumer resource type.
+func crossModuleSemantic(consumerType, argName, output string) string {
+	a := strings.ToLower(argName)
+	o := strings.ToLower(output)
+	ct := strings.ToLower(consumerType)
+
+	// Dead-letter / redrive wiring.
+	if strings.Contains(a, "redrive") || strings.Contains(a, "dead_letter") ||
+		strings.Contains(a, "dlq") || strings.Contains(o, "dead_letter") ||
+		strings.Contains(o, "dlq") {
+		return "redrive"
+	}
+
+	// Observability: CloudWatch log groups / log destinations.
+	if strings.Contains(a, "log_group") || strings.Contains(a, "log_destination") ||
+		strings.Contains(a, "cloudwatch") || strings.Contains(o, "log_group") ||
+		strings.Contains(o, "cloudwatch_log") {
+		return "logs-to"
+	}
+
+	// IAM: a policy/attachment empowering a role.
+	if strings.Contains(ct, "iam_role_policy") || strings.Contains(ct, "iam_policy") ||
+		strings.Contains(ct, "policy_attachment") {
+		if strings.Contains(o, "role") || strings.Contains(a, "role") {
+			return "grants"
+		}
+	}
+	// IAM: a task/exec/instance assuming a role.
+	if strings.Contains(a, "role_arn") || strings.Contains(a, "execution_role") ||
+		strings.Contains(a, "task_role") || strings.Contains(a, "instance_role") ||
+		(strings.Contains(a, "role") && strings.Contains(o, "role")) {
+		return "assumes"
+	}
+
+	// Messaging consumption: a compute/function resource reading a queue /
+	// stream / topic endpoint is a CONSUMER of that channel.
+	if strings.Contains(o, "queue_url") || strings.Contains(o, "queue_arn") ||
+		strings.Contains(o, "queue_name") || strings.Contains(o, "topic_arn") ||
+		strings.Contains(o, "stream_arn") || strings.Contains(o, "stream_name") ||
+		strings.Contains(a, "queue_url") || strings.Contains(a, "queue_arn") ||
+		strings.Contains(a, "topic_arn") {
+		return "consumes"
+	}
+
+	// Generic id/arn/name read of another resource's output.
+	if strings.HasSuffix(o, "_arn") || o == "arn" ||
+		strings.HasSuffix(o, "_id") || o == "id" ||
+		strings.HasSuffix(o, "_name") || o == "name" ||
+		strings.HasSuffix(o, "endpoint") || strings.HasSuffix(o, "_url") {
+		return "reads"
+	}
+
+	return "dependency"
+}

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -236,6 +236,11 @@ func extractResourceBlock(n *sitter.Node, src []byte, path, lang string, start, 
 		// Issue #387 — interpolation cross-references → CALLS edges.
 		calls := extractCalls(body, src, path, lang, selfRef, selfRef)
 		out[0].Relationships = append(out[0].Relationships, calls...)
+		// Issue #4625 — cross-module output references (module.<m>.<out>) →
+		// semantic USES edges (consumes / redrive / logs-to / assumes / …),
+		// so a resource consuming another module's output is no longer an
+		// unresolved relation + a disconnected diagram box.
+		out[0].Relationships = append(out[0].Relationships, extractCrossModuleRefs(body, src, path, lang, selfRef)...)
 		// Issue #3527 — iteration meta-args (for_each / count).
 		applyIterationMeta(&out[0], body, src, path, lang, selfRef)
 		// Issue #3527 — terraform_remote_state cross-stack deps.
@@ -292,6 +297,8 @@ func extractDataBlock(n *sitter.Node, src []byte, path, lang string, start, end 
 		// Issue #387 — interpolation cross-references → CALLS edges.
 		calls := extractCalls(body, src, path, lang, selfRef, selfRef)
 		out[0].Relationships = append(out[0].Relationships, calls...)
+		// Issue #4625 — cross-module output references → semantic USES edges.
+		out[0].Relationships = append(out[0].Relationships, extractCrossModuleRefs(body, src, path, lang, selfRef)...)
 		// Issue #3527 — iteration meta-args (for_each / count).
 		applyIterationMeta(&out[0], body, src, path, lang, selfRef)
 		// Issue #3527 — dynamic "x" {} nested blocks as child entities.

--- a/internal/extractors/hcl/relationships_test.go
+++ b/internal/extractors/hcl/relationships_test.go
@@ -334,3 +334,112 @@ func TestCorpus_TerraformAwsVpc_RelationshipCounts(t *testing.T) {
 		t.Errorf("expected >= 5 CALLS edges in vpc corpus, got %d", len(calls))
 	}
 }
+
+// ----------------------------------------------------------------
+// Issue #4625 — cross-module output references → semantic USES edges
+// ----------------------------------------------------------------
+
+// crossModuleUSES collects USES edges tagged dataflow=cross_module.
+func crossModuleUSES(records []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, rel := range collectRels(records, "USES") {
+		if rel.Properties["dataflow"] == "cross_module" {
+			out = append(out, rel)
+		}
+	}
+	return out
+}
+
+// TestCrossModule_ConsumesQueueURL is the headline #4625 fixture: a worker ECS
+// service consumes another module's queue_url output. Before the fix the only
+// edge was a bare CALLS to module.dispatch_queue (output name + semantics lost,
+// surfaced as an unresolved relation). After: a semantic USES edge carrying the
+// referenced output and the derived "consumes" verb, bound to the same-file
+// module block so it resolves.
+func TestCrossModule_ConsumesQueueURL(t *testing.T) {
+	src := `
+module "dispatch_queue" {
+  source = "./modules/sqs"
+  name   = "dispatch"
+}
+
+resource "aws_ecs_service" "worker" {
+  name = "worker"
+  environment {
+    queue_url = module.dispatch_queue.queue_url
+  }
+}
+`
+	records, err := extractHCL(src, "main.tf")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	uses := crossModuleUSES(records)
+	if len(uses) != 1 {
+		t.Fatalf("expected exactly 1 cross-module USES edge, got %d: %+v", len(uses), uses)
+	}
+	rel := uses[0]
+	wantTo := extractor.BuildOperationStructuralRef("hcl", "main.tf", "module.dispatch_queue")
+	if rel.ToID != wantTo {
+		t.Errorf("ToID = %q, want %q", rel.ToID, wantTo)
+	}
+	if got := rel.Properties["module_output"]; got != "queue_url" {
+		t.Errorf("module_output = %q, want queue_url", got)
+	}
+	if got := rel.Properties["semantic"]; got != "consumes" {
+		t.Errorf("semantic = %q, want consumes", got)
+	}
+}
+
+// TestCrossModule_SemanticVariants asserts the semantic-label derivation for the
+// cloud-architecture verbs #4625 renders.
+func TestCrossModule_SemanticVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "redrive",
+			src: `
+module "dlq" { source = "./dlq" }
+resource "aws_sqs_queue" "main" {
+  redrive_policy = module.dlq.queue_arn
+}`,
+			want: "redrive",
+		},
+		{
+			name: "logs-to",
+			src: `
+module "logs" { source = "./logs" }
+resource "aws_ecs_task_definition" "task" {
+  log_group = module.logs.log_group_name
+}`,
+			want: "logs-to",
+		},
+		{
+			name: "assumes",
+			src: `
+module "iam" { source = "./iam" }
+resource "aws_ecs_task_definition" "task" {
+  execution_role_arn = module.iam.role_arn
+}`,
+			want: "assumes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			records, err := extractHCL(tc.src, "main.tf")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			uses := crossModuleUSES(records)
+			if len(uses) != 1 {
+				t.Fatalf("expected 1 cross-module USES edge, got %d: %+v", len(uses), uses)
+			}
+			if got := uses[0].Properties["semantic"]; got != tc.want {
+				t.Errorf("semantic = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
@@ -29,7 +29,7 @@ import {
   type EdgeTypes,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { ArrowRight, ArrowDown, Unlink } from "lucide-react";
+import { ArrowRight, ArrowDown, Unlink, Boxes, Layers } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { IaCReport } from "@/data/types";
 import {
@@ -39,6 +39,7 @@ import {
   IAC_EDGE_TYPE,
   MAX_DIAGRAM_NODES,
   type IaCDiagramDirection,
+  type IaCGroupMode,
 } from "./layout";
 import { IaCNode } from "./IaCNode";
 import { IaCGroupNode } from "./IaCGroupNode";
@@ -69,10 +70,11 @@ interface IaCDiagramProps {
 
 function IaCDiagramInner({ report, className }: IaCDiagramProps) {
   const [direction, setDirection] = useState<IaCDiagramDirection>("LR");
+  const [groupMode, setGroupMode] = useState<IaCGroupMode>("module");
 
   const { nodes, edges, capped, unresolvedEdges } = useMemo(
-    () => layoutIaCDiagram(report, direction),
-    [report, direction],
+    () => layoutIaCDiagram(report, direction, groupMode),
+    [report, direction, groupMode],
   );
 
   const moduleCount = useMemo(
@@ -110,10 +112,36 @@ function IaCDiagramInner({ report, className }: IaCDiagramProps) {
           </button>
         </div>
 
+        {/* Grouping toggle: module containers vs cloud-tier containers (#4625). */}
+        <div className="inline-flex overflow-hidden rounded-md border border-border">
+          <button
+            type="button"
+            onClick={() => setGroupMode("module")}
+            className={cn(
+              "inline-flex h-7 items-center gap-1 px-2 text-xs transition-colors",
+              groupMode === "module" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+            )}
+            title="Group resources by module / stack"
+          >
+            <Boxes size={12} /> Module
+          </button>
+          <button
+            type="button"
+            onClick={() => setGroupMode("tier")}
+            className={cn(
+              "inline-flex h-7 items-center gap-1 border-l border-border px-2 text-xs transition-colors",
+              groupMode === "tier" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+            )}
+            title="Group resources by cloud tier (Compute / Messaging / Observability / IAM)"
+          >
+            <Layers size={12} /> Tier
+          </button>
+        </div>
+
         <span className="text-xs text-text-4 tabular-nums">
           {resourceCount} {resourceCount === 1 ? "resource" : "resources"}
           {" · "}
-          {moduleCount} {moduleCount === 1 ? "module" : "modules"}
+          {moduleCount} {groupMode === "tier" ? (moduleCount === 1 ? "tier" : "tiers") : moduleCount === 1 ? "module" : "modules"}
         </span>
 
         {capped && (

--- a/webui-v2/src/components/iac-diagram/IaCEdge.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCEdge.tsx
@@ -34,6 +34,20 @@ export function facetStyle(facet: string): FacetStyle {
       return { stroke: "var(--info)", dash: "2 3", label: "topology" };
     case "output":
       return { stroke: "var(--text-4)", dash: "2 3", label: "output" };
+    // #4625 — cross-module semantic verbs. A consuming resource → another
+    // module's output, labelled with its cloud-architecture meaning.
+    case "consumes":
+      return { stroke: "var(--accent)", label: "consumes" };
+    case "redrive":
+      return { stroke: "var(--warning)", dash: "5 3", label: "redrive" };
+    case "logs-to":
+      return { stroke: "var(--info)", dash: "1 3", label: "logs-to" };
+    case "assumes":
+      return { stroke: "var(--danger)", dash: "4 2", label: "assumes" };
+    case "grants":
+      return { stroke: "var(--danger)", dash: "5 3", label: "grants" };
+    case "reads":
+      return { stroke: "var(--text-3)", label: "reads" };
     default:
       return { stroke: "var(--text-4)", label: "depends" };
   }

--- a/webui-v2/src/components/iac-diagram/categoryStyle.ts
+++ b/webui-v2/src/components/iac-diagram/categoryStyle.ts
@@ -21,6 +21,7 @@ import {
   Zap,
   Boxes,
   KeyRound,
+  Package,
   type LucideIcon,
 } from "lucide-react";
 
@@ -50,6 +51,8 @@ const STYLES: Record<string, Omit<CategoryStyle, "key">> = {
   network: { label: "Network", Icon: Network, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
   compute: { label: "Compute", Icon: Cpu, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
   storage: { label: "Storage", Icon: HardDrive, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
+  // #4625 — a Terraform module instance rendered as a child-stack aggregate node.
+  module: { label: "Module", Icon: Package, color: "var(--accent)", tint: "var(--accent-bg, rgba(124,108,255,0.14))" },
 };
 
 const FALLBACK: Omit<CategoryStyle, "key"> = {

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -28,6 +28,43 @@ import type { IaCReport, IaCResource } from "@/data/types";
 
 export type IaCDiagramDirection = "LR" | "TB";
 
+/**
+ * Grouping mode for the diagram's container boxes (#4625):
+ *   - "module" — group by the Terraform module / construct / stack directory.
+ *   - "tier"   — group by cloud architecture tier (Compute / Messaging /
+ *                Observability / Security & IAM / Data / Network / Other),
+ *                derived from resource_category, so the diagram reads as a
+ *                layered cloud-architecture view regardless of module layout.
+ */
+export type IaCGroupMode = "module" | "tier";
+
+/**
+ * cloudTier maps a resource_category to a coarse cloud-architecture tier used by
+ * the "tier" grouping mode. Categories that don't map fall to "Other".
+ */
+export function cloudTier(category?: string): string {
+  switch ((category || "").toLowerCase()) {
+    case "compute":
+    case "function":
+    case "module":
+      return "Compute";
+    case "queue":
+    case "topic":
+    case "stream":
+      return "Messaging";
+    case "datastore":
+    case "cache":
+    case "storage":
+      return "Data";
+    case "network":
+      return "Network";
+    case "secret":
+      return "Security & IAM";
+    default:
+      return "Other";
+  }
+}
+
 export const IAC_NODE_TYPE = "iacResource";
 export const IAC_GROUP_TYPE = "iacModule";
 export const IAC_EDGE_TYPE = "iacRelation";
@@ -101,6 +138,7 @@ function shortModuleLabel(module: string): string {
 export function layoutIaCDiagram(
   report: IaCReport | undefined,
   direction: IaCDiagramDirection,
+  groupMode: IaCGroupMode = "module",
 ): IaCLayoutResult {
   const all = flattenResources(report);
   const capped = all.length > MAX_DIAGRAM_NODES;
@@ -114,9 +152,12 @@ export function layoutIaCDiagram(
   const byEntityId = new Map<string, IaCResource>();
   for (const r of resources) byEntityId.set(r.entity_id, r);
 
-  // Assign each resource a module bucket. "" module → a synthetic "(ungrouped)"
-  // bucket so every node still has a parent container (keeps layout uniform).
-  const moduleOf = (r: IaCResource) => r.module || "(ungrouped)";
+  // Assign each resource a container bucket. In "module" mode that is the
+  // module/stack directory ("" → "(ungrouped)"); in "tier" mode it is the cloud
+  // architecture tier derived from resource_category (#4625). Either way every
+  // node gets a parent container so the compound layout stays uniform.
+  const moduleOf = (r: IaCResource) =>
+    groupMode === "tier" ? cloudTier(r.category) : r.module || "(ungrouped)";
   const modules = new Map<string, IaCResource[]>();
   for (const r of resources) {
     const m = moduleOf(r);
@@ -214,7 +255,12 @@ export function layoutIaCDiagram(
     const groupId = `group:${module}`;
     const groupData: IaCGroupData = {
       module,
-      shortLabel: module === "(ungrouped)" ? "ungrouped" : shortModuleLabel(module),
+      shortLabel:
+        module === "(ungrouped)"
+          ? "ungrouped"
+          : groupMode === "tier"
+            ? module
+            : shortModuleLabel(module),
       count: members.length,
     };
     nodes.push({


### PR DESCRIPTION
## Summary

The IaC diagram rendered a worker ECS service and its SQS queue as **disconnected boxes** even though the worker consumes the queue via `queue_url = module.dispatch_queue.queue_url`. That cross-module reference was unresolved (one of the "N relation targets could not be resolved" footer entries) so the most important edge was invisible.

Root cause: the generic CALLS miner collapses `module.dispatch_queue.queue_url` to the bare ref `module.dispatch_queue` — dropping the `.queue_url` output name and all semantics — and module blocks were never rendered as diagram nodes, so the edge had no rendered target.

## Changes

**Backend — HCL/Terraform extractor (`internal/extractors/hcl/cross_module.go`)**
- `extractCrossModuleRefs`: for `resource`/`data` blocks, every `module.<name>.<output>` reference emits a `USES` edge to the same-file `module.<name>` block (binds via `byLocation` — no longer unresolved), carrying `dataflow=cross_module`, `module_output`, `input_arg`, and a derived `semantic` verb.
- `crossModuleSemantic`: derives the verb (`consumes` / `redrive` / `logs-to` / `assumes` / `grants` / `reads`) from the consumer resource type + consuming attribute + output name.

**Backend — dashboard `/api/iac` (`internal/dashboard/handlers_iac.go`)**
- Render Terraform `module` instances as diagram nodes (category `module`) so the cross-module edge has a rendered target.
- Surface the cross-module `semantic` as the relation facet (output name as detail).

**Frontend (`webui-v2/src/components/iac-diagram/`)**
- `IaCEdge`: distinct styling + labels for the new semantic facets.
- `categoryStyle`: `module` node style.
- `layout` + `IaCDiagram`: cloud-tier grouping toggle (Compute / Messaging / Data / Network / Security & IAM / Other) alongside module grouping.

## Tests / gates
- Fixture `TestCrossModule_ConsumesQueueURL` (headline, RED before the fix) + semantic-variant cases (redrive / logs-to / assumes).
- Dashboard unit cases for module rendering + the cross-module facet.
- `go build ./...`, `go vet`, `go test ./internal/extractors/hcl/... ./internal/dashboard/... ./internal/types/...` — green.
- `npm ci`, `npx tsc --noEmit`, `npx vite build` — green.

## Cross-stack generalization
AWS CDK / Pulumi / CloudFormation / Bicep express the same export→import pattern (`CfnOutput`/`Fn::ImportValue`, StackReference outputs, module outputs). `crossModuleSemantic` is framework-agnostic and reusable once those extractors emit a comparable cross-stack ref — tracked as a follow-up.

Closes #4625

🤖 Generated with [Claude Code](https://claude.com/claude-code)
