### PR TITLE
fix(graph): auto-settle on load + hide unconnected nodes by default (#4641)

### DIFF
--- a/webui-v2/src/components/graph/filters-drawer.tsx
+++ b/webui-v2/src/components/graph/filters-drawer.tsx
@@ -59,6 +59,8 @@ export function FiltersDrawer({ repos }: { repos: GraphRepo[] }) {
   const setLod = useGraphStore((s) => s.setLod);
   const minDegree = useGraphStore((s) => s.minDegree);
   const setMinDegree = useGraphStore((s) => s.setMinDegree);
+  const hideUnconnected = useGraphStore((s) => s.hideUnconnected);
+  const setHideUnconnected = useGraphStore((s) => s.setHideUnconnected);
   const clearAllFilters = useGraphStore((s) => s.clearAllFilters);
 
   return (
@@ -182,11 +184,29 @@ export function FiltersDrawer({ repos }: { repos: GraphRepo[] }) {
             </div>
             <p className="mt-1.5 text-xs text-text-3">
               {minDegree === 0
-                ? "Showing all nodes. Low-degree nodes are de-emphasized, not hidden."
+                ? "Showing connected + low-degree leaf nodes. Low-degree nodes are de-emphasized, not hidden."
                 : minDegree === 1
                   ? "Hiding unconnected (zero-edge) nodes."
                   : "Hiding unconnected + degree-1 leaf nodes."}
             </p>
+            {/* #4641 — unconnected (zero-edge) nodes are typically constants,
+                types, and config with no graph edges; hidden by default so the
+                connected component reads clearly (not a health problem). */}
+            <label className="mt-2.5 flex cursor-pointer items-start gap-2 text-xs text-text-2">
+              <input
+                type="checkbox"
+                checked={hideUnconnected}
+                onChange={(e) => setHideUnconnected(e.target.checked)}
+                className="mt-0.5 h-3.5 w-3.5 cursor-pointer accent-accent"
+              />
+              <span>
+                Hide unconnected nodes
+                <span className="mt-0.5 block text-text-3">
+                  Zero-edge constants, types, and config — hidden by default so
+                  the connected structure reads clearly.
+                </span>
+              </span>
+            </label>
           </section>
 
           <TuningPanels />

--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -1387,6 +1387,42 @@ function GraphCanvasInner(
     kickFreshSettleRef.current();
   }, [relayoutNonce, packed]);
 
+  // ── #4641: AUTO-SETTLE on first data load (the recurring "explode"/clumped
+  //    bug, #4492/#2107). On the very first render of a NON-EMPTY renderable
+  //    graph the canvas used to arrive clumped — the seed positions paused
+  //    before the force layout spread them — and the user had to click Reset.
+  //    Reset runs kickFreshSettle; so do we, exactly once, the first time a
+  //    renderable graph appears WITHOUT a healthy cached layout. With a healthy
+  //    cache we intentionally pin+fit the saved spread instead (instant reload),
+  //    which the mount/group handlers already own. This is the single guaranteed
+  //    entry point so the graph arrives already spread with no manual Reset; it
+  //    is idempotent (autoSettledRef), respects the crash-guard (renderable),
+  //    and never double-fires against the mount/group/relayout settles (which all
+  //    set didAutoStartRef / hasSettledRef that we check before kicking). ──────
+  const autoSettledRef = useRef(false);
+  useEffect(() => {
+    if (autoSettledRef.current) return;
+    if (!renderable) return; // crash-guard: never seed/start an empty graph
+    const g = graphRef.current;
+    if (!g) return;
+    // If another settle path already claimed the first layout (mount no-cache
+    // kick, group-change, relayout) or the graph is already settled (healthy
+    // cache pinned), don't fire a competing fresh settle.
+    if (didAutoStartRef.current || hasSettledRef.current) {
+      autoSettledRef.current = true;
+      return;
+    }
+    // A healthy cache is owned by the mount/group handlers (pin + fit). Only the
+    // no-valid-cache case needs an explicit kick here.
+    const saved = loadLayout(group, nodeIds);
+    if (saved && isLayoutHealthy(saved.positions, nodeIds.length * 2)) {
+      autoSettledRef.current = true;
+      return;
+    }
+    autoSettledRef.current = true;
+    kickFreshSettleRef.current();
+  }, [renderable, group, nodeIds]);
+
   // ── re-layout when the node SET changes (Fix #1548-3 ego enter/exit) ─────────
   // Entering/leaving focus swaps `group` (…::ego) and the node set. The settled
   // engine would otherwise just re-pin the new (scattered) positions and pause —

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -211,8 +211,15 @@ export default function GraphScreen() {
   // incident edges, so cosmos.gl never sees a 15k-edge star that freezes the
   // layout. Computed from the rendered edges (not the daemon `degree`) so it
   // respects the user's edge-kind toggles. No-op on normal graphs.
-  const { nodes, edges, prunedHubCount, lowDegreeCount, orphanCount, hiddenLowDegreeCount } =
-    useMemo(() => {
+  const {
+    nodes,
+    edges,
+    prunedHubCount,
+    lowDegreeCount,
+    orphanCount,
+    hiddenLowDegreeCount,
+    hiddenUnconnectedCount,
+  } = useMemo(() => {
       const incident = new Map<string, number>();
       for (const e of kindFilteredEdges) {
         incident.set(e.source, (incident.get(e.source) ?? 0) + 1);
@@ -245,10 +252,21 @@ export default function GraphScreen() {
       }
       const lowDegree = orphans + leaves;
 
-      // Apply the min-degree filter (default 0 = show everything). Hiding is always
-      // surfaced in the badge, so it stays explicit + reversible.
+      // #4641 — the EFFECTIVE minimum rendered degree a node must have to be
+      // shown, combining two independent controls:
+      //   • hideUnconnected (default ON): drop zero-edge nodes (orphans). These
+      //     are typically constants / types / config with no graph edges, so the
+      //     main graph shows the healthy connected component by default.
+      //   • minDegree (default 0): the explicit "also hide degree-1 leaves" knob.
+      // We take the max so whichever is stricter wins, then surface the hidden
+      // counts in the footer so nothing is ever silently dropped.
       const minD = s.minDegree;
-      if (minD <= 0 && prunedIds.size === 0) {
+      const effMinD = Math.max(minD, s.hideUnconnected ? 1 : 0);
+      // How many of the hidden nodes are unconnected (degree 0) — surfaced as the
+      // calm "M isolated · show" chip when hideUnconnected is on and minDegree is 0.
+      const hiddenUnconnected = s.hideUnconnected && minD <= 0 ? orphans : 0;
+
+      if (effMinD <= 0 && prunedIds.size === 0) {
         return {
           nodes: allNodes,
           edges: kindFilteredEdges,
@@ -256,15 +274,16 @@ export default function GraphScreen() {
           lowDegreeCount: lowDegree,
           orphanCount: orphans,
           hiddenLowDegreeCount: 0,
+          hiddenUnconnectedCount: 0,
         };
       }
       const keptNodes =
-        minD <= 0
+        effMinD <= 0
           ? hubKept
-          : hubKept.filter((n) => (incident.get(n.id) ?? 0) >= minD);
+          : hubKept.filter((n) => (incident.get(n.id) ?? 0) >= effMinD);
       const keptIds = new Set(keptNodes.map((n) => n.id));
       const keptEdges =
-        minD <= 0
+        effMinD <= 0
           ? hubKeptEdges
           : hubKeptEdges.filter((e) => keptIds.has(e.source) && keptIds.has(e.target));
       return {
@@ -273,9 +292,12 @@ export default function GraphScreen() {
         prunedHubCount: prunedIds.size,
         lowDegreeCount: lowDegree,
         orphanCount: orphans,
-        hiddenLowDegreeCount: hubKept.length - keptNodes.length,
+        // hiddenLowDegreeCount reports the degree-1 leaves the minDegree knob hid
+        // (the unconnected count is reported separately as the isolated chip).
+        hiddenLowDegreeCount: hubKept.length - keptNodes.length - hiddenUnconnected,
+        hiddenUnconnectedCount: hiddenUnconnected,
       };
-    }, [allNodes, kindFilteredEdges, s.minDegree]);
+    }, [allNodes, kindFilteredEdges, s.minDegree, s.hideUnconnected]);
 
   // ── monorepo-aware default coloring/grouping (Fix #1532-1) ───────────────────
   // A monorepo is a single repo split into many modules. Repo grouping there is
@@ -564,7 +586,10 @@ export default function GraphScreen() {
               references). Search to jump to a symbol, color by
               repo/kind/community, or collapse to a module overview. Node color
               encodes the active mode; faint peripheral nodes are low-degree
-              leaves, not orphans.
+              leaves, not orphans. Unconnected (zero-edge) nodes — typically
+              constants, types, and config with no graph edges — are hidden by
+              default so the connected structure reads clearly; bring them back
+              anytime with the &ldquo;isolated · show&rdquo; chip.
             </>
           }
           agent={{
@@ -738,30 +763,58 @@ export default function GraphScreen() {
               <div className="pointer-events-none rounded-md border border-border bg-surface/80 px-2 py-1 font-mono text-xs text-text-3 backdrop-blur-sm">
                 LOD: {lodLabel}
               </div>
-              {/* #4467 — honest low-degree badge. The force layout pushes degree-1
-                  nodes to the periphery, which reads as a misleading "orphan ring";
-                  in reality almost all are degree-1 leaves (a single CONTAINS edge),
-                  not true orphans. This badge names the real counts and offers an
-                  explicit, reversible show/hide so nothing is ever silently dropped. */}
-              {lowDegreeCount > 0 ? (
+              {/* #4641 — calm "isolated" chip. Unconnected (zero-edge) nodes are
+                  typically constants / types / config that simply have no graph
+                  edges; they're hidden by default so the main graph shows the
+                  healthy connected component instead of a misleading "orphan ring."
+                  When some are hidden we show a quiet "M isolated · show" chip to
+                  bring them back; when shown we offer the reverse. Low-degree (≥1
+                  edge) leaves stay visible and are reported for context. */}
+              {hiddenUnconnectedCount > 0 ? (
+                <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface/80 px-2 py-1 text-xs text-text-3 backdrop-blur-sm">
+                  <span className="tabular-nums">
+                    {hiddenUnconnectedCount.toLocaleString()} isolated
+                  </span>
+                  <span className="text-text-4" title="Nodes with no graph edges (constants, types, config) — hidden by default; they aren't a health problem.">
+                    hidden
+                  </span>
+                  <button
+                    onClick={() => s.setHideUnconnected(false)}
+                    className="ml-0.5 rounded border border-border bg-surface px-1.5 py-0.5 text-[0.7rem] font-medium text-text-2 hover:bg-surface-2"
+                    title="Show unconnected (zero-edge) nodes — typically constants, types, and config"
+                  >
+                    show
+                  </button>
+                </div>
+              ) : lowDegreeCount > 0 ? (
                 <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface/80 px-2 py-1 text-xs text-text-3 backdrop-blur-sm">
                   <span className="tabular-nums">
                     {(lowDegreeCount - orphanCount).toLocaleString()} low-degree
                   </span>
-                  <span className="text-text-4">·</span>
-                  <span className="tabular-nums">{orphanCount.toLocaleString()} unconnected</span>
+                  {orphanCount > 0 ? (
+                    <>
+                      <span className="text-text-4">·</span>
+                      <span className="tabular-nums">
+                        {orphanCount.toLocaleString()} unconnected
+                      </span>
+                    </>
+                  ) : null}
                   {hiddenLowDegreeCount > 0 ? (
                     <span className="tabular-nums text-warning">
                       · {hiddenLowDegreeCount.toLocaleString()} hidden
                     </span>
                   ) : null}
-                  <button
-                    onClick={() => s.setMinDegree(s.minDegree > 0 ? 0 : 1)}
-                    className="ml-0.5 rounded border border-border bg-surface px-1.5 py-0.5 text-[0.7rem] font-medium text-text-2 hover:bg-surface-2"
-                    title="Toggle hiding of low-degree / unconnected nodes"
-                  >
-                    {s.minDegree > 0 ? "show" : "hide"}
-                  </button>
+                  {/* When unconnected nodes are currently SHOWN, offer to hide
+                      them again (back to the calm default). */}
+                  {orphanCount > 0 && !s.hideUnconnected ? (
+                    <button
+                      onClick={() => s.setHideUnconnected(true)}
+                      className="ml-0.5 rounded border border-border bg-surface px-1.5 py-0.5 text-[0.7rem] font-medium text-text-2 hover:bg-surface-2"
+                      title="Hide unconnected (zero-edge) nodes — typically constants, types, and config"
+                    >
+                      hide isolated
+                    </button>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -273,6 +273,24 @@ function persist<T>(key: string, value: T): void {
   }
 }
 
+/**
+ * #4641 — read a persisted BOOLEAN preference, version-independent (it's a pure
+ * UX choice, not force-tuning that a DEFAULTS_VERSION bump should reset). Falls
+ * back to `fallback` when unset or unparseable.
+ */
+function persistedBool(key: string, fallback: boolean): boolean {
+  if (typeof localStorage === "undefined") return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return JSON.parse(raw) === true;
+  } catch {
+    return fallback;
+  }
+}
+
+const HIDE_UNCONNECTED_KEY = "ag.v2.graph.hideUnconnected";
+
 interface GraphState {
   // Interaction
   selectedNodeId: string | null;
@@ -303,6 +321,17 @@ interface GraphState {
    * extraction bugs are fixed separately.
    */
   minDegree: number;
+
+  /**
+   * #4641 — hide UNCONNECTED (rendered degree 0) nodes by default. These are
+   * almost always constants / types / config with no graph edges; showing them
+   * makes the graph read as an unhealthy "orphan ring" even though the
+   * connected component is fine. Default ON (true) so the main graph shows only
+   * the connected + low-degree (≥1 edge) structure; a calm footer chip lets the
+   * user toggle them back on. Independent of `minDegree` (which also hides
+   * degree-1 leaves) and persisted to localStorage so the choice sticks.
+   */
+  hideUnconnected: boolean;
 
   // View knobs
   colorMode: ColorMode;
@@ -352,6 +381,8 @@ interface GraphState {
   setLod: (lod: LodLevel) => void;
   /** #4467 — set the min-degree threshold (clamped to 0..2). */
   setMinDegree: (d: number) => void;
+  /** #4641 — toggle hiding of unconnected (zero-edge) nodes (persisted). */
+  setHideUnconnected: (hide: boolean) => void;
   setColorMode: (m: ColorMode) => void;
   setGroupBy: (m: GroupByMode) => void;
   /**
@@ -405,6 +436,10 @@ export const useGraphStore = create<GraphState>((set) => ({
   // (smaller + dimmer) rather than hidden, so the default view is honest.
   minDegree: 0,
 
+  // #4641 — hide zero-edge nodes by default (persisted, version-independent) so
+  // the main graph shows only the connected component + low-degree leaves.
+  hideUnconnected: persistedBool(HIDE_UNCONNECTED_KEY, true),
+
   colorMode: "repo",
   groupBy: "repo",
   groupingTouched: false,
@@ -446,6 +481,10 @@ export const useGraphStore = create<GraphState>((set) => ({
   clearRepos: () => set({ activeRepos: null }),
   setLod: (lod) => set({ lod }),
   setMinDegree: (d) => set({ minDegree: Math.max(0, Math.min(2, Math.round(d))) }),
+  setHideUnconnected: (hide) => {
+    persist(HIDE_UNCONNECTED_KEY, hide);
+    set({ hideUnconnected: hide });
+  },
   setColorMode: (colorMode) => set({ colorMode, groupingTouched: true }),
   setGroupBy: (groupBy) => set({ groupBy, groupingTouched: true }),
   applyMonorepoDefaults: (isMonorepo) =>


### PR DESCRIPTION
## Summary
Three readability fixes so the dependency graph view arrives healthy-looking on first load instead of clumped with a misleading "orphan ring."

### 1. Auto-settle on load (the recurring "explode" bug, #4492/#2107)
The graph used to render clumped on first load and the user had to click **Reset** to spread it. Added a dedicated, idempotent effect in `graph-canvas.tsx` that runs the **same `kickFreshSettle` routine Reset uses** the first time a non-empty *renderable* graph appears without a healthy cached layout. It:
- fires exactly once (`autoSettledRef` guard),
- respects the empty-graph crash-guard (`renderable`), so deep-link/empty subgraphs still show the graceful empty state,
- defers to the mount/group/relayout settle paths and the healthy-layout cache (instant reload) — never double-fires.

### 2. Hide UNCONNECTED (zero-edge) nodes by default
New persisted `hideUnconnected` store flag (**default ON**) drops rendered-degree-0 nodes. It composes with the existing `minDegree` knob via `max()`, so whichever is stricter wins. Low-degree (≥1 edge) leaf nodes stay **visible**.
- Footer shows a calm `M isolated · show` chip to bring them back (and a `hide isolated` affordance when they're shown).
- Filters drawer gets a matching "Hide unconnected nodes" checkbox.
- The choice persists to `localStorage` (version-independent, since it's a pure UX preference, not force-tuning).

### 3. Reframe copy
InsightBanner, footer chip, and filters drawer now clarify that unconnected nodes are typically constants / types / config with **no graph edges** and are hidden by default — not a health problem.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅
- `npx vite build` ✅
- `vitest run src/lib` (incl. graph-render-guard) — **58 passed** ✅

## Verification notes
- Normal graph auto-spreads on load (fresh kick when no healthy cache); healthy cache still pins+fits instantly.
- Unconnected hidden by default; `show`/checkbox toggles them back on and persists.
- Crash-guard intact: empty/deep-link subgraphs skip seed/settle and render the empty state.

Closes #4641

🤖 Generated with [Claude Code](https://claude.com/claude-code)