### PR TITLE
fix(graph): MCP activity panel + replay overhaul (#4643)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -61,6 +61,15 @@ import {
 // creates a new identity each render.
 const EMPTY_HIGHLIGHT: ReadonlySet<string> = new Set();
 
+// #4643 — FREEZE FIX. A replay/glow step can carry a huge result set (the
+// reported repro matched 17,939 nodes). Glowing/dimming all of them in one
+// synchronous pass on a 12.8k-node WebGL canvas blocks the main thread. We
+// CAP the glow+dim set to the nodes actually RENDERED/in-view, never more than
+// GLOW_CAP, and the recolor only ever rewrites these ≤GLOW_CAP indices per
+// frame (the base buffers are written once, off the hot path). The same bounded
+// set drives the dim-focus selection so both stay non-blocking.
+const GLOW_CAP = 200;
+
 const SPACE_SIZE = 32768;
 // Fix #1532-3 / #1548-2: a small padding makes the settled graph FILL the
 // canvas instead of floating small in the middle. A touch more than 0.04 so
@@ -234,6 +243,13 @@ export interface GraphCanvasProps {
    * queries each re-pulse even if the node set overlaps.
    */
   highlightEpoch?: number;
+  /**
+   * #4643 — reports how many nodes were actually glowed vs how many the step
+   * matched, after the in-view/GLOW_CAP cap. Lets the panel render
+   * "glowing N of M" when a large result set is sampled. `shown === matched`
+   * means nothing was capped.
+   */
+  onGlowCap?: (shown: number, matched: number) => void;
   className?: string;
 }
 
@@ -290,6 +306,7 @@ function GraphCanvasInner(
     onSettled,
     highlightedNodeIds,
     highlightEpoch = 0,
+    onGlowCap,
     className = "",
   }: GraphCanvasProps,
   ref: React.Ref<GraphCanvasHandle>,
@@ -1503,6 +1520,21 @@ function GraphCanvasInner(
       return;
     }
 
+    // #4643 — replay/glow dim-focus. When a replay step (or a per-row replay)
+    // is active and the user isn't hovering, dim everything except the step's
+    // CAPPED node set (+ neighbors) — same spotlight mechanism as hover, driven
+    // by replayFocusIdxRef. This is cleared (set emptied) when the glow ends.
+    const replayFocus = replayFocusIdxRef.current;
+    if (replayFocus.size > 0) {
+      g.selectPointsByIndices(Array.from(replayFocus));
+      g.setConfig({
+        pointGreyoutOpacity: isDark ? 0.08 : 0.1,
+        linkGreyoutOpacity: 0,
+      });
+      g.render();
+      return;
+    }
+
     // Fix #1580: not hovering → restore the default link greyout so the
     // repo/community selection (and the un-hovered full graph) shows links again.
     const restoredLinkGreyout = render.linkOpacity * 0.5;
@@ -1538,6 +1570,12 @@ function GraphCanvasInner(
     render.linkOpacity,
   ]);
 
+  // #4643 — live ref so the glow rAF effect (mount-stable, epoch-keyed deps)
+  // can re-apply the selection/dim-focus without taking applySelection as a dep
+  // (which would re-run the glow effect on every hover change).
+  const applySelectionRef = useRef(applySelection);
+  applySelectionRef.current = applySelection;
+
   useEffect(() => {
     applySelection();
   }, [applySelection]);
@@ -1564,6 +1602,15 @@ function GraphCanvasInner(
   // endpoints are in the highlighted node set (resolved against linkData.links,
   // which is index-based and parallel to the packed link color buffer).
   const glowRafRef = useRef<number | null>(null);
+  // #4643 — the CAPPED, in-view node-index set that the current glow is driving.
+  // Shared with the dim-focus selection (applySelection) so both the glow and
+  // the "dim everything else" behaviour operate on the SAME bounded set. Empty
+  // = no replay focus active.
+  const replayFocusIdxRef = useRef<Set<number>>(new Set());
+  // #4643 — live ref to the cap reporter so the epoch-keyed glow effect can
+  // report "glowing N of M" without taking onGlowCap as a dep.
+  const onGlowCapRef = useRef(onGlowCap);
+  onGlowCapRef.current = onGlowCap;
   // Stable empty fallback so an undefined prop doesn't thrash the effect deps.
   const highlightSet = highlightedNodeIds ?? EMPTY_HIGHLIGHT;
   useEffect(() => {
@@ -1577,11 +1624,53 @@ function GraphCanvasInner(
       glowRafRef.current = null;
     }
 
-    // Resolve the affected NODE indices.
-    const nodeIdxs: number[] = [];
+    // #4643 — Resolve the affected NODE indices, but CAP to the nodes actually
+    // RENDERED / in-view (≤ GLOW_CAP). Without this a step with ~18k matches
+    // would build an 18k-index list and rewrite all of them every rAF frame →
+    // synchronous main-thread hang. We project each candidate to screen space
+    // and keep only those inside the viewport, stopping once we hit the cap.
+    // `matchedTotal` is tracked so the caller can render "glowing N of M".
+    const w = containerRef.current?.clientWidth ?? 0;
+    const h = containerRef.current?.clientHeight ?? 0;
+    const positions = g.getPointPositions();
+    const haveViewport = w > 0 && h > 0 && !!positions && positions.length > 0;
+
+    let matchedTotal = 0;
+    const inView: number[] = [];
+    const overflow: number[] = []; // resolved-but-offscreen, used only if no in-view hits
     for (const id of highlightSet) {
       const i = idToIdx.get(id);
-      if (i !== undefined) nodeIdxs.push(i);
+      if (i === undefined) continue;
+      matchedTotal++;
+      // Once both buckets are full there's nothing more to collect — but keep
+      // looping (cheap map lookups only) so matchedTotal reflects the true M for
+      // the "glowing N of M" badge. The expensive projection below is skipped.
+      if (inView.length >= GLOW_CAP) continue;
+      if (!haveViewport) {
+        inView.push(i);
+        continue;
+      }
+      // Both the in-view target and the offscreen fallback are full → skip the
+      // (relatively costly) screen projection; just keep counting matchedTotal.
+      if (overflow.length >= GLOW_CAP) continue;
+      const px = positions![i * 2];
+      const py = positions![i * 2 + 1];
+      if (px === undefined || py === undefined) continue;
+      const [sx, sy] = g.spaceToScreenPosition([px, py]);
+      if (sx >= -50 && sy >= -50 && sx <= w + 50 && sy <= h + 50) {
+        inView.push(i);
+      } else if (overflow.length < GLOW_CAP) {
+        overflow.push(i);
+      }
+    }
+    // If nothing matched is currently on-screen (e.g. the result is off in a
+    // far cluster), fall back to a capped sample of the resolved matches so the
+    // glow is never silently empty — still bounded by GLOW_CAP.
+    const nodeIdxs: number[] = inView.length > 0 ? inView : overflow.slice(0, GLOW_CAP);
+    if (matchedTotal > nodeIdxs.length) {
+      onGlowCapRef.current?.(nodeIdxs.length, matchedTotal);
+    } else {
+      onGlowCapRef.current?.(nodeIdxs.length, nodeIdxs.length);
     }
 
     // Resolve the affected EDGE (link) indices: an edge glows when both its
@@ -1597,13 +1686,35 @@ function GraphCanvasInner(
     }
 
     // Nothing to glow (decay finished, or no entity in the current view) →
-    // restore the base buffers so any prior pulse is fully cleared, then stop.
+    // restore the base buffers so any prior pulse is fully cleared, then drop
+    // the dim-focus (restore full opacity via the normal selection state).
     if (nodeIdxs.length === 0) {
       g.setPointColors(packPointColors());
       g.setPointSizes(packed.sizes);
       g.setLinkColors(packLinkColors());
       g.render();
+      if (replayFocusIdxRef.current.size > 0) {
+        replayFocusIdxRef.current = new Set();
+        applySelectionRef.current?.();
+      }
       return;
+    }
+
+    // #4643 — DIM non-step nodes during the glow. Reuse the hover-spotlight
+    // mechanism (cosmos.gl selectPointsByIndices + pointGreyoutOpacity) but
+    // drive it from the CAPPED step set (+ immediate neighbors) instead of the
+    // hovered node. Everything outside this bounded set dims; the step's nodes
+    // and their neighbors stay bright so the glow stands out of the hairball.
+    // Restored to the normal selection state when the glow ends (above / below).
+    {
+      const focus = new Set<number>(nodeIdxs);
+      for (const i of nodeIdxs) {
+        const nbs = neighborIdx.get(i);
+        if (!nbs) continue;
+        for (const nb of nbs) focus.add(nb);
+      }
+      replayFocusIdxRef.current = focus;
+      applySelectionRef.current?.();
     }
 
     // Snapshot the BASE buffers once; each frame we re-derive from these so the
@@ -1670,12 +1781,17 @@ function GraphCanvasInner(
       if (t < 1) {
         glowRafRef.current = requestAnimationFrame(frame);
       } else {
-        // Pulse done → restore the exact base buffers (clean slate).
+        // Pulse done → restore the exact base buffers (clean slate) and drop
+        // the dim-focus so the full graph returns to normal opacity.
         gg.setPointColors(baseColors);
         gg.setPointSizes(baseSizes);
         gg.setLinkColors(baseLinkColors);
         gg.render();
         glowRafRef.current = null;
+        if (replayFocusIdxRef.current.size > 0) {
+          replayFocusIdxRef.current = new Set();
+          applySelectionRef.current?.();
+        }
       }
     };
     glowRafRef.current = requestAnimationFrame(frame);
@@ -1685,6 +1801,11 @@ function GraphCanvasInner(
         cancelAnimationFrame(glowRafRef.current);
         glowRafRef.current = null;
       }
+      // #4643 — a new epoch supersedes this glow; the next effect run reasserts
+      // the focus set from its own (capped) nodes, and a final empty highlight
+      // (decay → EMPTY) restores opacity. We intentionally do NOT clear the
+      // dim-focus here so consecutive replay steps stay dimmed continuously
+      // instead of flashing back to full opacity between steps.
     };
     // Re-run on each fresh highlight (epoch) — NOT on every set identity churn.
     // packPointColors/packLinkColors/packed are stable between data/theme pushes;

--- a/webui-v2/src/components/graph/mcp-activity-overlay.tsx
+++ b/webui-v2/src/components/graph/mcp-activity-overlay.tsx
@@ -126,6 +126,12 @@ export interface MCPActivityOverlayProps {
   onReplay: (event: MCPActivityEvent) => void;
   /** Empty the activity log + reset count/replay position to 0. */
   onClear: () => void;
+  /**
+   * #4643 — when the most-recent glow step was CAPPED (matched more nodes than
+   * were glowed/in-view), this carries {shown, matched} so the panel can render
+   * "glowing N of M". null when nothing was capped.
+   */
+  glowCap?: { shown: number; matched: number } | null;
 
   // ── #1932 replay-all wiring ───────────────────────────────────────────────
   /** The shared step-engine controller (null when there's < 2 steps). */
@@ -151,6 +157,7 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
   onToggle,
   onReplay,
   onClear,
+  glowCap,
   replayController,
   replaySnapshot,
   replaySteps,
@@ -259,6 +266,18 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
                   aria-live="polite"
                 >
                   replay {replaySnapshot.paused ? "paused" : "running"}
+                </span>
+              ) : null}
+              {/* #4643 — surface the in-view glow cap so a huge result set reads
+                  as a deliberate sample ("glowing 200 of 17939"), not a freeze. */}
+              {glowCap ? (
+                <span
+                  className="ml-1 rounded bg-text-4/15 px-1.5 py-px text-[10px] font-medium text-text-3"
+                  aria-live="polite"
+                  title={`Capped to the ${glowCap.shown} in-view nodes of ${glowCap.matched} matched, to keep the canvas responsive`}
+                  data-testid="mcp-glow-cap"
+                >
+                  glowing {glowCap.shown.toLocaleString()} of {glowCap.matched.toLocaleString()}
                 </span>
               ) : null}
             </span>

--- a/webui-v2/src/hooks/use-mcp-activity.ts
+++ b/webui-v2/src/hooks/use-mcp-activity.ts
@@ -8,14 +8,17 @@
    GET /api/mcp-activity/stream SSE endpoint via the Vite /api proxy.
 
    Lifecycle:
-     • On mount, fetches the last HISTORY_LIMIT events from
-       /api/mcp-activity/history and seeds the activity list (these are
-       marked `isHistory: true` so the UI can render them muted). (#1930)
+     • #4643 — the activity list NO LONGER persists across reloads and is NOT
+       seeded from /history. On mount it starts EMPTY and fills purely from the
+       LIVE SSE event stream, so the panel always reflects what is happening NOW
+       (a reload no longer resurrects the same stale ~11 events). The replay
+       controls operate on this live-captured session.
      • Opens an EventSource when `enabled` is true (default).
-     • Reconnects on errors/close with a bounded, capped backoff (1s→2s→5s),
-       re-seeding from /history (de-duped) so a daemon RESTART self-heals
-       instead of freezing the panel. (Browser-native ES auto-reconnect does
-       NOT recover once the connection lands in CLOSED.)
+     • Reconnects on errors/close with a bounded, capped backoff (1s→2s→5s) so a
+       daemon RESTART self-heals instead of freezing the panel. (Browser-native
+       ES auto-reconnect does NOT recover once the connection lands in CLOSED.)
+       Reconnect does NOT re-seed history — events that arrived while we were
+       disconnected are simply missed (the live feed is the source of truth).
      • Closes + cleans up on unmount or when toggled off (no EventSource leaks).
      • Exposes the last event, a rolling log (last MAX_LOG), and a count.
 
@@ -37,7 +40,11 @@ export interface MCPActivityEvent {
   returned_edge_ids?: string[];
   agent_id?: string;
   timestamp: number;
-  /** True for events seeded from /api/mcp-activity/history on mount (#1930). */
+  /**
+   * #4643 — RETAINED for type back-compat (the overlay still reads it) but is
+   * never set now that history-seeding is removed: every event in the log is a
+   * live, this-session capture. Always undefined/false.
+   */
   isHistory?: boolean;
 }
 
@@ -60,14 +67,11 @@ export interface UseMCPActivityReturn extends MCPActivityState {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const SSE_URL = "/api/mcp-activity/stream";
-const HISTORY_URL = "/api/mcp-activity/history";
 // #1932: bumped from 50 → 100. Replay-all walks the whole panel and the spec
 // calls for "50+ activity entries stay smooth". With the generic flow engine
 // driving the comet, 100 entries (a few hundred flattened steps) is fine on
 // a typical laptop.
 const MAX_LOG = 100;
-// #1930: how many historical events to seed on mount.
-const HISTORY_LIMIT = 20;
 
 const INITIAL_STATE: MCPActivityState = {
   connected: false,
@@ -104,22 +108,19 @@ function eventKey(e: MCPActivityEvent): string {
 export function useMCPActivity(enabled = true): UseMCPActivityReturn {
   const [state, setState] = useState<MCPActivityState>(INITIAL_STATE);
   const esRef = useRef<EventSource | null>(null);
-  // Track the timestamp of the last history event seeded so live events
-  // arriving before subscribeAt don't double-count with history.
-  const subscribeAtRef = useRef<number>(0);
 
   const clear = useCallback(() => setState(INITIAL_STATE), []);
 
   // ── Single effect owns the whole connection lifecycle ──────────────────────
-  // History seed (#1930) + SSE subscription + ROBUST RECONNECT. Previously the
-  // browser-native EventSource auto-reconnect was relied on, but when the daemon
-  // RESTARTS the connection moves to CLOSED and is never re-opened — the panel
-  // freezes (e.g. stuck at "9/9") and silently drops every new event. We now
-  // manage reconnection explicitly with a bounded, capped backoff so any
-  // transient drop (or daemon restart) self-heals. On every (re)connect we
-  // re-seed from /history and de-dupe against the existing log so no rows are
-  // missed and none are duplicated. The 100-event cap (MAX_LOG) is enforced on
-  // BOTH the seed and the live-append paths.
+  // LIVE SSE subscription + ROBUST RECONNECT. Previously the browser-native
+  // EventSource auto-reconnect was relied on, but when the daemon RESTARTS the
+  // connection moves to CLOSED and is never re-opened — the panel freezes (e.g.
+  // stuck at "9/9") and silently drops every new event. We manage reconnection
+  // explicitly with a bounded, capped backoff so any transient drop (or daemon
+  // restart) self-heals. #4643 — the log is NOT seeded from /history: it starts
+  // empty on mount and fills purely from the live feed, so a reload no longer
+  // resurrects stale events. The 100-event cap (MAX_LOG) is enforced on the
+  // live-append path.
   useEffect(() => {
     if (!enabled) {
       setState((prev) => ({ ...prev, connected: false }));
@@ -134,7 +135,7 @@ export function useMCPActivity(enabled = true): UseMCPActivityReturn {
     // #4319 — guard against a backoff-reset busy-loop. If the daemon emits the
     // `connected` event and then the stream drops again immediately (a flapping
     // server), resetting reconnectAttempt to 0 on every `connected` would pin
-    // the backoff at its 1s floor and hammer fetch(/history) + EventSource every
+    // the backoff at its 1s floor and hammer EventSource every
     // ~1s forever. We only reset the backoff once a connection has proven STABLE
     // (stayed open past STABLE_MS), so a flapping daemon decays to the 5s cap
     // instead of a tight reconnect storm.
@@ -178,41 +179,10 @@ export function useMCPActivity(enabled = true): UseMCPActivityReturn {
       }, delay);
     };
 
-    // Re-seed the log from /history, de-duping against whatever is already
-    // present (live events received before the seed resolved are preserved).
-    // History entries keep `isHistory: true` for the muted "before this session"
-    // rendering; live entries already in the log keep their identity.
-    const seedFromHistory = () => {
-      fetch(`${HISTORY_URL}?limit=${HISTORY_LIMIT}`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((body: { events?: MCPActivityEvent[] } | null) => {
-          if (cancelled || !body?.events?.length) return;
-          const historyEvents: MCPActivityEvent[] = body.events.map((e) => ({
-            ...e,
-            isHistory: true,
-          }));
-          setState((prev) => {
-            const seen = new Set(prev.eventLog.map(eventKey));
-            const fresh = historyEvents.filter((e) => !seen.has(eventKey(e)));
-            if (fresh.length === 0) return prev;
-            // History is older than anything live, so it goes BEFORE the
-            // existing log; newest kept if we exceed the cap.
-            const log = [...fresh, ...prev.eventLog].slice(-MAX_LOG);
-            return { ...prev, eventLog: log };
-          });
-        })
-        .catch(() => {
-          // History fetch failing is non-fatal — the SSE stream still works.
-        });
-    };
-
     const connect = () => {
       if (cancelled) return;
       closeES();
-      subscribeAtRef.current = Date.now();
-      // Re-seed on first connect AND on every reconnect, so a daemon restart
-      // backfills anything emitted while we were disconnected.
-      seedFromHistory();
+      // #4643 — no history seed: the log fills purely from the live SSE feed.
 
       const conn = new EventSource(SSE_URL);
       es = conn;

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -141,6 +141,25 @@ export default function GraphScreen() {
   // (not the initial null) once mount completes.
   const liveCanvasHandle = canvasReady > 0 ? canvasRef.current : null;
 
+  // #4643 — "glowing N of M": the canvas reports how many nodes it actually
+  // glowed (capped to the in-view ≤200) vs how many the step matched. When the
+  // step is capped we surface it in the activity panel so a huge result set
+  // reads as a deliberate sample, not a bug. Cleared shortly after the glow.
+  const [glowCap, setGlowCap] = useState<{ shown: number; matched: number } | null>(null);
+  const glowCapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onGlowCap = useCallback((shown: number, matched: number) => {
+    if (glowCapTimerRef.current) clearTimeout(glowCapTimerRef.current);
+    setGlowCap(matched > shown ? { shown, matched } : null);
+    // Auto-clear after the glow decays so a stale "N of M" doesn't linger.
+    glowCapTimerRef.current = setTimeout(() => setGlowCap(null), 2200);
+  }, []);
+  useEffect(
+    () => () => {
+      if (glowCapTimerRef.current) clearTimeout(glowCapTimerRef.current);
+    },
+    [],
+  );
+
   // ── ?node= deep-link: restore on mount, persist on selection change ──────────
   // On first render, if the URL carries ?node=<id>, apply it as the selected
   // node. focusEgo is called in a separate data-ready effect below.
@@ -684,6 +703,7 @@ export default function GraphScreen() {
                 onSettled={() => {}}
                 highlightedNodeIds={jarvis.enabled ? jarvis.highlightedNodeIds : undefined}
                 highlightEpoch={jarvis.epoch}
+                onGlowCap={onGlowCap}
               />
             </Suspense>
 
@@ -718,6 +738,7 @@ export default function GraphScreen() {
               onToggle={jarvis.setEnabled}
               onReplay={jarvis.replay}
               onClear={jarvis.clearActivityLog}
+              glowCap={glowCap}
               replayController={replay.controller}
               replaySnapshot={replay.snapshot}
               replaySteps={replay.steps}


### PR DESCRIPTION
Cohesive overhaul of the graph view's **MCP activity → replay** surface. Implements all four parts of #4643.

## 1. Freeze fix (highest priority)
A glow/replay step with a large result set glowed **every** matched node synchronously on the 12.8k-node WebGL canvas → main-thread hang (repro: a `find` step matched 17,939 nodes).

- The glow set is **capped to the nodes actually rendered / in-view** (`GLOW_CAP = 200`). Each candidate index is projected via `spaceToScreenPosition`; only on-screen hits are collected (with a capped offscreen fallback so the glow is never silently empty), stopping once the cap is reached. The expensive projection is skipped once both buckets are full.
- The rAF recolor only ever rewrites these ≤200 indices per frame; the base color/size/link buffers are built **once**, off the hot path. The loop already yields to the event loop each frame, so **Stop works mid-step** and advancing never blocks input.
- A **"glowing N of M"** badge appears in the panel header when a step is sampled (reported via a new `onGlowCap` callback).

## 2. Dim non-step nodes during animation
The capped step set (+ immediate neighbors) drives the **existing hover-spotlight dim** mechanism (`selectPointsByIndices` + `pointGreyoutOpacity`), so everything outside the step dims while the step glows. Shares the same bounded set as the glow cap, so it stays non-blocking. Full opacity is restored when the glow decays/clears. Applies to both replay-all and per-row replay.

## 3. Per-row replay
Each row's ⟳ now visibly **glows + dim-focuses just that call's** (capped, in-view) result set, independent of the full-sequence replay controller (it drives `highlightedNodeIds`/`epoch` directly, never the FlowAnim engine).

## 4. No-persist + live capture
The activity log no longer seeds from `/api/mcp-activity/history`, so a reload no longer resurrects the same stale ~11 events. It **starts empty** and fills **purely from the live SSE feed** (`GET /api/mcp-activity/stream`, the daemon's `mcp_activity` event) — which `useMCPActivity` already subscribes to with robust reconnect/backoff. Replay operates on the live-captured session.

### SSE subscription used
`GET /api/mcp-activity/stream` via the Vite `/api` proxy (`EventSource`, `mcp_activity` event) — already wired in `use-mcp-activity.ts`; this PR removes the `/history` seed (and its dedupe machinery) so only the live feed populates the list. The backend live feed already exists; no backend follow-up required.

## Verification
- `npm ci && npx tsc --noEmit && npx vite build` — all green.
- `vitest run src/lib` — 58 passed.
- Big-result step: capped to ≤200 in-view nodes, rAF rewrites only those, no synchronous O(N) recolor → no freeze; badge shows "glowing 200 of 17,939".
- Non-step nodes dim (hover-spotlight greyout) during animation, restored on decay.
- Per-row ⟳ glows + dim-focuses that single call, independent of replay-all.
- Reload → empty list (no `/history` seed) that fills from live `mcp_activity` events.

Closes #4643

🤖 Generated with [Claude Code](https://claude.com/claude-code)