### PR TITLE
fix(coverage): disambiguate same-name endpoints for e2e TESTS edges (#4651)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -3870,7 +3870,7 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	// synthetics are dropped here — keeping them would leave orphan
 	// http_endpoint nodes in the graph and inflate bug-rate.
 	var httpEndpointStats engine.ResolveHTTPEndpointStats
-	merged, httpEndpointStats = engine.ResolveHTTPEndpointHandlers(merged)
+	merged, httpEndpointStats = engine.ResolveHTTPEndpointHandlersWithRepo(merged, i.repoTag)
 	if httpEndpointStats.DTOHandlerEdgesEmitted > 0 || httpEndpointStats.DTOHandlerEdgesUnresolved > 0 {
 		// #1999 — log the DTO↔Handler bidirectional edge counters
 		// independently of the main http-endpoint stats line so the

--- a/internal/engine/http_endpoint_e2e_testmap.go
+++ b/internal/engine/http_endpoint_e2e_testmap.go
@@ -55,6 +55,7 @@ package engine
 import (
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -82,6 +83,7 @@ func linkE2ERouteTestsToEndpoints(
 	merged []types.EntityRecord,
 	definitionByPath map[string][]int,
 	defIndices []int,
+	repoTag string,
 ) int {
 	emitted := 0
 	for i := range merged {
@@ -101,7 +103,7 @@ func linkE2ERouteTestsToEndpoints(
 			if !ok {
 				continue
 			}
-			defIdx, matched := resolveRouteTestToDefinition(verb, route, merged, definitionByPath, defIndices)
+			defIdx, matched := resolveRouteTestToDefinition(verb, route, s, merged, definitionByPath, defIndices)
 			if !matched || linked[defIdx] {
 				continue
 			}
@@ -109,7 +111,7 @@ func linkE2ERouteTestsToEndpoints(
 			def := &merged[defIdx]
 			s.Relationships = append(s.Relationships, types.RelationshipRecord{
 				FromID: s.Kind + ":" + s.Name,
-				ToID:   def.Kind + ":" + def.Name,
+				ToID:   e2eEndpointToID(def, repoTag),
 				Kind:   string(types.RelationshipKindTests),
 				Properties: map[string]string{
 					"framework":    propOr(s, "framework", "jest"),
@@ -123,6 +125,30 @@ func linkE2ERouteTestsToEndpoints(
 		}
 	}
 	return emitted
+}
+
+// e2eEndpointToID returns the TESTS-edge ToID for a matched endpoint definition.
+//
+// #4651 — upvate-v3 (NestJS) has many same-named handlers/routes across modules
+// (`create`, `update`, `getCounts`, `list`, …). When two
+// http_endpoint_definition entities synthesize the SAME endpoint Name (because
+// the route shape collides, or the controller-prefix segment is lost), a
+// `Kind:Name` stub ToID is AMBIGUOUS at resolve time: resolve.BuildIndex blanks
+// the colliding name in byName/byQualifiedName, so resolve.References can't bind
+// the edge → it dangles and BOTH endpoints read uncovered.
+//
+// When a repoTag is available we sidestep the name index entirely: each
+// definition's deterministic entity ID (graph.EntityID over Kind+Name+
+// SourceFile, the SAME formula cmd/archigraph stampEntityIDs uses) is unique per
+// SOURCE FILE even when the Name collides across modules. Emitting the hex ID
+// directly makes resolve.rewriteOne short-circuit on its isHexID fast path,
+// crediting the CORRECT per-file endpoint as covered. With no repoTag (engine
+// test corpus / legacy callers) we fall back to the historical `Kind:Name` stub.
+func e2eEndpointToID(def *types.EntityRecord, repoTag string) string {
+	if repoTag != "" {
+		return graph.EntityID(repoTag, def.Kind, def.Name, def.SourceFile)
+	}
+	return def.Kind + ":" + def.Name
 }
 
 // splitVerbRoute parses a "VERB route" line into its parts. Returns ok=false
@@ -152,6 +178,7 @@ func splitVerbRoute(line string) (verb, route string, ok bool) {
 // ambiguous or empty results return matched=false.
 func resolveRouteTestToDefinition(
 	verb, route string,
+	suite *types.EntityRecord,
 	merged []types.EntityRecord,
 	definitionByPath map[string][]int,
 	defIndices []int,
@@ -172,7 +199,18 @@ func resolveRouteTestToDefinition(
 		}
 	}
 	if len(tier1) > 1 {
-		// Ambiguous on the structural key — do not guess.
+		// #4651 — multiple definitions share the SAME normalized route key
+		// (upvate-v3 synthesizes colliding endpoint Names across modules, e.g.
+		// two `getCounts` handlers whose routes fold to the same shape). The
+		// bare route can't pick one, but the SPEC carries module/file affinity:
+		// `test/inspections.e2e-spec.ts` belongs with
+		// `src/inspections/inspections.controller.ts`, not the proposals one.
+		// Break the tie by source-file/module token overlap; only resolve when
+		// EXACTLY ONE candidate maximally matches (no guessing on a tie).
+		if idx, ok := disambiguateByModuleAffinity(suite, tier1, merged); ok {
+			return idx, true
+		}
+		// Still ambiguous — do not guess.
 		return 0, false
 	}
 
@@ -196,6 +234,90 @@ func resolveRouteTestToDefinition(
 		return tier2, true
 	}
 	return 0, false
+}
+
+// disambiguateByModuleAffinity picks, among same-route candidate definitions,
+// the one whose SOURCE FILE shares the most path/module tokens with the spec's
+// own source file (#4651). The NestJS convention co-locates a module's e2e spec
+// and its controller under a shared module token (`inspections`, `proposals`,
+// …), so the spec file path is a reliable discriminator when the synthesized
+// endpoint Name collides. Returns (idx, true) only when a SINGLE candidate has
+// the strictly-highest non-zero affinity score; a tie or all-zero leaves the
+// caller to skip (no guessing).
+func disambiguateByModuleAffinity(suite *types.EntityRecord, candidates map[int]bool, merged []types.EntityRecord) (int, bool) {
+	if suite == nil || suite.SourceFile == "" {
+		return 0, false
+	}
+	specToks := pathModuleTokens(suite.SourceFile)
+	if len(specToks) == 0 {
+		return 0, false
+	}
+	bestIdx := -1
+	bestScore := 0
+	tie := false
+	for idx := range candidates {
+		score := tokenOverlap(specToks, pathModuleTokens(merged[idx].SourceFile))
+		switch {
+		case score > bestScore:
+			bestScore, bestIdx, tie = score, idx, false
+		case score == bestScore && bestScore > 0:
+			tie = true
+		}
+	}
+	if bestScore == 0 || tie {
+		return 0, false
+	}
+	return bestIdx, true
+}
+
+// pathModuleTokens extracts the lowercased path/module identifier tokens from a
+// source-file path, dropping directory noise (`src`, `test`, `tests`, `e2e`,
+// `spec`, file extensions) and splitting compound segments on the conventional
+// separators so `test/inspections.e2e-spec.ts` and
+// `src/inspections/inspections.controller.ts` both yield the `inspections`
+// token. Returns a set (deduped) of meaningful tokens.
+func pathModuleTokens(p string) map[string]bool {
+	out := map[string]bool{}
+	if p == "" {
+		return out
+	}
+	// Normalize separators and strip a query/extension tail per segment.
+	for _, seg := range strings.FieldsFunc(p, func(r rune) bool {
+		return r == '/' || r == '\\' || r == '.' || r == '-' || r == '_'
+	}) {
+		seg = strings.ToLower(strings.TrimSpace(seg))
+		if seg == "" || pathModuleNoiseToken[seg] {
+			continue
+		}
+		out[seg] = true
+	}
+	return out
+}
+
+// pathModuleNoiseToken is the set of path tokens that carry no module identity
+// and must not contribute to affinity scoring (scaffolding dirs, test-suffix
+// markers, common file extensions).
+var pathModuleNoiseToken = map[string]bool{
+	"src": true, "app": true, "test": true, "tests": true, "e2e": true,
+	"spec": true, "specs": true, "controller": true, "controllers": true,
+	"module": true, "modules": true, "ts": true, "js": true, "tsx": true,
+	"jsx": true, "mjs": true, "cjs": true, "index": true,
+}
+
+// tokenOverlap counts how many tokens the two token sets share.
+func tokenOverlap(a, b map[string]bool) int {
+	// Iterate the smaller set for cheapness.
+	small, large := a, b
+	if len(b) < len(a) {
+		small, large = b, a
+	}
+	n := 0
+	for t := range small {
+		if large[t] {
+			n++
+		}
+	}
+	return n
 }
 
 // matchConcreteRouteToDefinition reports whether a CONCRETE test route (e.g.

--- a/internal/engine/http_endpoint_e2e_testmap_4651_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4651_test.go
@@ -1,0 +1,148 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4651 — upvate-v3 (NestJS) coverage lever: duplicate-name endpoint
+// disambiguation.
+//
+// upvate-v3 has the same handler name across many modules (`create`, `update`,
+// `getCounts`, `list`, …). When two http_endpoint_definition entities
+// synthesize the SAME endpoint Name (because the route shape folds to the same
+// key — here a `getCounts` handler in BOTH the inspections and proposals
+// modules whose synthesized route collides), the e2e route-test linker hit two
+// failure modes:
+//
+//  1. resolveRouteTestToDefinition saw len(tier1) > 1 and bailed (no edge), so
+//     EACH endpoint dangled and read UNCOVERED — even though each spec names
+//     exactly one module's route. (#4628 root-cause.)
+//  2. Even when the right candidate was picked, the TESTS edge carried a
+//     `Kind:Name` stub ToID, which resolve.BuildIndex blanks on the colliding
+//     Name → resolve.References can't bind it → the edge dangles anyway.
+//
+// This fix disambiguates same-route candidates by spec↔controller module/file
+// affinity AND emits the edge with the matched definition's UNIQUE entity ID
+// (graph.EntityID over Kind+Name+SourceFile — distinct per source file even when
+// the Name collides), so each endpoint is credited to ITS OWN spec.
+
+const repo4651 = "cajasmota/upvate-v3"
+
+// dupDef is def() with an explicit controller source file so the two same-route
+// definitions get DISTINCT deterministic entity IDs (graph.EntityID folds in
+// SourceFile) while sharing the colliding endpoint Name.
+func dupDef(verb, path, sourceFile string) types.EntityRecord {
+	d := def(verb, path)
+	d.SourceFile = sourceFile
+	return d
+}
+
+// TestIssue4651_DupNameEndpointsCreditedToOwnSpec is the RED→GREEN proof. Two
+// modules expose a same-named `getCounts` route that synthesizes to the SAME
+// endpoint Name; each has its own e2e spec. BEFORE: both dangle (0 edges).
+// AFTER: each endpoint gains exactly one TESTS edge from ITS OWN spec, targeting
+// that endpoint's unique entity ID.
+func TestIssue4651_DupNameEndpointsCreditedToOwnSpec(t *testing.T) {
+	// Two definitions with the SAME synthesized Name (http:GET:/api/v1/counts)
+	// but DIFFERENT controllers/modules — exactly the upvate-v3 collision.
+	inspDef := dupDef("GET", "/api/v1/counts", "src/inspections/inspections.controller.ts")
+	propDef := dupDef("GET", "/api/v1/counts", "src/proposals/proposals.controller.ts")
+	if inspDef.Name != propDef.Name {
+		t.Fatalf("precondition: expected colliding endpoint Name, got %q vs %q", inspDef.Name, propDef.Name)
+	}
+
+	// One e2e spec per module, each issuing the (now-colliding) route. The
+	// distinguishing signal is the spec's source file / module token.
+	inspSpec := e2eSuite("GET /api/v1/counts")
+	inspSpec.Name = "spec:inspections.e2e:Inspections"
+	inspSpec.SourceFile = "test/inspections.e2e-spec.ts"
+	propSpec := e2eSuite("GET /api/v1/counts")
+	propSpec.Name = "spec:proposals.e2e:Proposals"
+	propSpec.SourceFile = "test/proposals.e2e-spec.ts"
+
+	in := []types.EntityRecord{inspDef, propDef, inspSpec, propSpec}
+	out, stats := ResolveHTTPEndpointHandlersWithRepo(in, repo4651)
+
+	// Expected unique per-file endpoint IDs.
+	inspID := graph.EntityID(repo4651, inspDef.Kind, inspDef.Name, inspDef.SourceFile)
+	propID := graph.EntityID(repo4651, propDef.Kind, propDef.Name, propDef.SourceFile)
+	if inspID == propID {
+		t.Fatalf("precondition: same-Name defs must still get distinct entity IDs (source-file folds in)")
+	}
+
+	// Each spec must produce exactly one TESTS edge, to its OWN module's endpoint.
+	got := map[string]string{} // spec FromID -> endpoint ToID
+	for _, e := range out {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) && r.Properties["match_source"] == "e2e_supertest_route" {
+				got[r.FromID] = r.ToID
+			}
+		}
+	}
+	if stats.E2ERouteTestEdges != 2 {
+		t.Fatalf("expected 2 TESTS edges (one per module spec), got %d (edges=%v)", stats.E2ERouteTestEdges, got)
+	}
+
+	wantInsp := "test_suite:" + inspSpec.Name
+	wantProp := "test_suite:" + propSpec.Name
+	if got[wantInsp] != inspID {
+		t.Errorf("inspections spec must cover the inspections endpoint: from %q -> %q, want %q", wantInsp, got[wantInsp], inspID)
+	}
+	if got[wantProp] != propID {
+		t.Errorf("proposals spec must cover the proposals endpoint: from %q -> %q, want %q", wantProp, got[wantProp], propID)
+	}
+}
+
+// TestIssue4651_LegacyStubPathStillPicksRightDef proves the affinity tie-break
+// alone (no repoTag → legacy Kind:Name stub) still selects the CORRECT
+// definition index among same-route collisions, so the existing engine-test
+// contract (stub ToID) is preserved while the ambiguity is resolved.
+func TestIssue4651_LegacyStubPathStillPicksRightDef(t *testing.T) {
+	inspDef := dupDef("GET", "/api/v1/counts", "src/inspections/inspections.controller.ts")
+	propDef := dupDef("GET", "/api/v1/counts", "src/proposals/proposals.controller.ts")
+
+	spec := e2eSuite("GET /api/v1/counts")
+	spec.Name = "spec:proposals.e2e:Proposals"
+	spec.SourceFile = "test/proposals.e2e-spec.ts"
+
+	in := []types.EntityRecord{inspDef, propDef, spec}
+	out, stats := ResolveHTTPEndpointHandlers(in) // empty repoTag → legacy stub
+	if stats.E2ERouteTestEdges != 1 {
+		t.Fatalf("expected 1 TESTS edge from the proposals spec, got %d", stats.E2ERouteTestEdges)
+	}
+	// Legacy ToID is the Kind:Name stub; the value is shared by both defs, but
+	// the disambiguation must have selected the proposals candidate. We assert
+	// the edge exists and carries the proposals spec as origin.
+	var fromID string
+	for _, e := range out {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) && r.Properties["match_source"] == "e2e_supertest_route" {
+				fromID = r.FromID
+			}
+		}
+	}
+	if fromID != "test_suite:"+spec.Name {
+		t.Fatalf("TESTS edge origin = %q, want %q", fromID, "test_suite:"+spec.Name)
+	}
+}
+
+// TestIssue4651_AmbiguousNoModuleSignalSkips guards the no-guessing posture:
+// when same-route candidates collide AND the spec carries no module token that
+// favors one, the linker must emit NO edge rather than picking arbitrarily.
+func TestIssue4651_AmbiguousNoModuleSignalSkips(t *testing.T) {
+	d1 := dupDef("GET", "/api/v1/counts", "src/inspections/inspections.controller.ts")
+	d2 := dupDef("GET", "/api/v1/counts", "src/proposals/proposals.controller.ts")
+
+	// Spec file shares NO module token with either controller.
+	spec := e2eSuite("GET /api/v1/counts")
+	spec.Name = "spec:smoke.e2e:Smoke"
+	spec.SourceFile = "test/smoke.e2e-spec.ts"
+
+	_, stats := ResolveHTTPEndpointHandlersWithRepo([]types.EntityRecord{d1, d2, spec}, repo4651)
+	if stats.E2ERouteTestEdges != 0 {
+		t.Fatalf("ambiguous match with no module signal must emit 0 edges, got %d", stats.E2ERouteTestEdges)
+	}
+}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -127,7 +127,26 @@ type httpResolveKey struct{ kind, name, sourceFile string }
 // helpers such as firstAppCandidate (#3426) can take it by value.
 type httpResolveNameKey struct{ kind, name string }
 
+// ResolveHTTPEndpointHandlers is the repoTag-less entry point retained for the
+// existing call sites and the engine test corpus. It delegates with an empty
+// repoTag, in which case the e2e route-test pass emits its TESTS edges as
+// `Kind:Name` stubs (resolved later by resolve.References). Prefer
+// ResolveHTTPEndpointHandlersWithRepo from the production pipeline so the e2e
+// pass can mint each endpoint's unique entity ID directly and resolve
+// same-Name endpoint collisions (#4651).
 func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
+	return ResolveHTTPEndpointHandlersWithRepo(merged, "")
+}
+
+// ResolveHTTPEndpointHandlersWithRepo is ResolveHTTPEndpointHandlers with the
+// caller's repoTag threaded through to the e2e route-test linker (#4651). When
+// repoTag is non-empty the linker emits each TESTS edge with the matched
+// http_endpoint_definition's deterministic entity ID (graph.EntityID over the
+// def's Kind/Name/SourceFile) instead of an ambiguous `Kind:Name` stub — so a
+// route whose synthesized endpoint Name collides across modules (upvate-v3 has
+// many same-named handlers/routes, e.g. `getCounts`) still credits the correct,
+// per-file endpoint as covered rather than dangling on an ambiguous name.
+func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag string) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
 	var stats ResolveHTTPEndpointStats
 
 	// (kind, name, sourceFile) → index into `merged`.
@@ -627,7 +646,7 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// TESTS edge from the suite to each uniquely-matched endpoint. Runs at
 	// resolve-time (merge-stable, cross-file index available) and is
 	// conservative — only unique verb+route matches produce an edge.
-	stats.E2ERouteTestEdges = linkE2ERouteTestsToEndpoints(merged, definitionByPath, defIndices)
+	stats.E2ERouteTestEdges = linkE2ERouteTestsToEndpoints(merged, definitionByPath, defIndices, repoTag)
 
 	// Issue #1999 — DTO ↔ Handler bidirectional REFERENCES edges.
 	//


### PR DESCRIPTION
## Problem (#4651 — upvate-v3 coverage lever)

After #4649 fixed non-JS `test_suite` classification, upvate-v3 (NestJS) coverage was still ~18% because of **duplicate-name endpoint ambiguity**. v3 reuses the same handler/route name across modules (`create`, `update`, `getCounts`, `list`, …). When two `http_endpoint_definition` entities synthesize the **same endpoint Name** (the route shape folds to the same key, or the controller-prefix segment is lost), the e2e route-test linker hit two failure modes:

1. `resolveRouteTestToDefinition` saw `len(tier1) > 1` and bailed — **no edge**, so each endpoint dangled and read uncovered, even though each spec names exactly one module's route.
2. Even when the right candidate was picked, the TESTS edge carried a `Kind:Name` stub ToID. `resolve.BuildIndex` blanks the colliding Name in `byName`/`byQualifiedName`, so `resolve.References` can't bind the edge → it dangles anyway.

## Fix (`internal/engine/http_endpoint_e2e_testmap.go`)

- **Disambiguate same-route candidates by spec↔controller module/file affinity.** When multiple definitions share the normalized route key, break the tie by path-token overlap between the spec's source file and each candidate controller's source file (the NestJS convention co-locates `test/inspections.e2e-spec.ts` with `src/inspections/inspections.controller.ts`). Resolves only on a strictly-unique best match — **no guessing** on ties or no-signal.
- **Emit the TESTS edge with the matched definition's unique entity ID.** A new `ResolveHTTPEndpointHandlersWithRepo` threads `repoTag` through so the linker mints `graph.EntityID(repoTag, Kind, Name, SourceFile)` — distinct per source file even when the Name collides. `resolve.rewriteOne` short-circuits on its `isHexID` fast path and credits the correct per-file endpoint. The repoTag-less `ResolveHTTPEndpointHandlers` keeps the legacy `Kind:Name` stub for existing callers and the engine test corpus.

## RED → GREEN fixture

`http_endpoint_e2e_testmap_4651_test.go`: two same-named `getCounts` routes in the inspections and proposals modules (colliding endpoint Name), each with its own e2e spec.
- **RED (today):** both endpoints dangle — `0` TESTS edges.
- **GREEN (after):** each endpoint gains exactly one TESTS edge from **its own** spec, targeting that endpoint's unique entity ID.

Plus a legacy-stub tie-break test (no repoTag still picks the right def) and a no-module-signal no-guess guard (ambiguous + no signal → 0 edges).

## Gates

- `go build ./...` ✅
- `go vet ./internal/engine/... ./internal/graph/...` ✅
- `go test ./internal/engine/... ./internal/graph/... ./internal/custom/... ./internal/types/...` ✅
- No regression to #4351 / #4487 / #4559 / #4649.

## Coverage impact

Live confirmation deferred to the coordinator via MCP `test_coverage` after rebuild + reindex. Expected to move v3 coverage materially above 18% by crediting the previously-dangling duplicate-name endpoints.

Closes #4651

🤖 Generated with [Claude Code](https://claude.com/claude-code)