### PR TITLE
feat(webui): breadcrumb Insights button + InsightContext (Phase A, #4655)

### DIFF
--- a/webui-v2/src/components/chrome/insight-button.tsx
+++ b/webui-v2/src/components/chrome/insight-button.tsx
@@ -1,0 +1,71 @@
+/* ============================================================
+   insight-button.tsx — breadcrumb "Insights" button + popover (#4655).
+
+   Lives in the TopBar breadcrumb bar. A compact button (lightbulb icon +
+   "Insights" label) that opens a popover rendering the active screen's
+   InsightBanner two-column content (green human / yellow agent).
+
+   The active insight is registered by the current page/tab via useSetInsight
+   (see ui/insight-context). When that insight CHANGES (navigation or tab
+   switch) the button pulses with a glowing ring for ~4s so users notice fresh
+   context is available. When no insight is registered the button is hidden.
+   ============================================================ */
+
+import { useEffect, useRef, useState } from "react";
+import { Lightbulb } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger, InsightBanner } from "@/components/ui";
+import { useInsight } from "@/components/ui/insight-context";
+import { cn } from "@/lib/utils";
+
+/** How long the glow ring stays on after the insight changes. */
+const GLOW_MS = 4000;
+
+export function InsightButton() {
+  const { insight, glowNonce } = useInsight();
+  const [glowing, setGlowing] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Pulse the ring whenever the active insight changes (nonce bump). Skip the
+  // initial render (nonce 0) so a fresh load doesn't glow with no interaction.
+  useEffect(() => {
+    if (glowNonce === 0) return;
+    setGlowing(true);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setGlowing(false), GLOW_MS);
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, [glowNonce]);
+
+  // No insight registered for this screen → nothing to show.
+  if (!insight) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Show screen insights"
+          className={cn(
+            "relative inline-flex items-center gap-1.5 h-7 pl-2 pr-2.5 rounded-md border text-xs font-medium",
+            "border-border bg-surface text-text-2 transition-colors hover:bg-surface-2 hover:text-text",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]",
+            glowing && "ag-insight-glow border-warning/60 text-text",
+          )}
+        >
+          <Lightbulb size={13} className={cn("shrink-0", glowing ? "text-warning" : "text-text-4")} />
+          <span>Insights</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[34rem] max-w-[90vw] p-0">
+        <div className="p-2">
+          <InsightBanner
+            human={insight.human}
+            agent={insight.agent}
+            storageKey={insight.storageKey}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/webui-v2/src/components/chrome/top-bar.tsx
+++ b/webui-v2/src/components/chrome/top-bar.tsx
@@ -18,6 +18,7 @@ import { healthDisplay, healthTooltip } from "@/lib/health";
 import { RefSelector } from "@/components/chrome/ref-selector";
 import { useRefState } from "@/lib/use-ref-state";
 import { ModeBadge } from "@/components/Topbar/ModeBadge";
+import { InsightButton } from "@/components/chrome/insight-button";
 
 export interface TopBarProps {
   group: string;
@@ -44,6 +45,10 @@ export function TopBar({ group, surfaceLabel }: TopBarProps) {
         <span className="font-mono text-text-2">{group}</span>
         <ChevronRight size={12} className="text-text-4" />
         <span className="font-medium text-text">{surfaceLabel}</span>
+
+        {/* #4655: glowing per-screen Insights button. Hidden until the active
+            screen/tab registers an insight via useSetInsight. */}
+        <InsightButton />
       </nav>
 
       <div className="flex items-center gap-2">

--- a/webui-v2/src/components/ui/index.ts
+++ b/webui-v2/src/components/ui/index.ts
@@ -29,3 +29,5 @@ export { DefTerm } from "./screen-description";
 export type { ScreenDescriptionTerm } from "./screen-description";
 export { InsightBanner } from "./insight-banner";
 export type { InsightBannerProps, InsightBannerAgent } from "./insight-banner";
+export { InsightProvider, useInsight, useSetInsight } from "./insight-context";
+export type { InsightValue } from "./insight-context";

--- a/webui-v2/src/components/ui/insight-context.tsx
+++ b/webui-v2/src/components/ui/insight-context.tsx
@@ -1,0 +1,128 @@
+/* ============================================================
+   insight-context.tsx — app-wide "current insight" register (#4655).
+
+   Phase A of moving the per-screen InsightBanner out of page bodies and
+   into a glowing breadcrumb "Insights" button + popover (see InsightButton).
+
+   Pages/tabs register the CURRENT screen's insight via useSetInsight(...),
+   and the breadcrumb button consumes the active value to render the banner
+   inside a popover. When the registered insight CHANGES identity (navigation
+   or tab switch) the button glows for ~4s; a `glowNonce` is bumped on every
+   change so the button can re-trigger its pulse, debounced so rapid changes
+   don't spam.
+
+   Usage (in a route or tab):
+     useSetInsight({
+       human: <>…</>,
+       agent: { tool: "archigraph_test_coverage", example: "…" },
+     });
+
+   `useSetInsight` registers on mount / when its value changes (by identity)
+   and CLEARS on unmount, so navigating away leaves no stale insight behind.
+   ============================================================ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { InsightBannerAgent } from "./insight-banner";
+
+/** The payload a page/tab registers as the current screen insight. */
+export interface InsightValue {
+  /** Plain-language, human-facing description (LEFT column). */
+  human: ReactNode;
+  /** How agents consume the same data via an MCP tool (RIGHT column). */
+  agent: InsightBannerAgent;
+  /**
+   * Optional persistence key forwarded to the InsightBanner (collapsed state).
+   * Mostly cosmetic in the popover but kept for parity with inline banners.
+   */
+  storageKey?: string;
+}
+
+interface InsightContextValue {
+  /** The active insight, or null when no screen has registered one. */
+  insight: InsightValue | null;
+  /**
+   * Monotonic counter bumped whenever the active insight changes identity.
+   * The button watches this to (re)trigger its ~4s glow.
+   */
+  glowNonce: number;
+  /** Register/replace the current insight (null clears). Used by useSetInsight. */
+  setInsight: (value: InsightValue | null) => void;
+}
+
+const InsightContext = createContext<InsightContextValue | null>(null);
+
+export function InsightProvider({ children }: { children: ReactNode }) {
+  const [insight, setInsightState] = useState<InsightValue | null>(null);
+  const [glowNonce, setGlowNonce] = useState(0);
+  // Debounce identity-change glow bumps so rapid re-registers (e.g. a tab that
+  // re-renders twice) don't fire multiple pulses in quick succession.
+  const glowTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const setInsight = useCallback((value: InsightValue | null) => {
+    setInsightState((prev) => {
+      // Only bump the glow when the value actually changes identity AND there
+      // is a new (non-null) insight to show — clearing shouldn't glow.
+      if (prev !== value && value != null) {
+        if (glowTimer.current) clearTimeout(glowTimer.current);
+        glowTimer.current = setTimeout(() => {
+          setGlowNonce((n) => n + 1);
+          glowTimer.current = null;
+        }, 120);
+      }
+      return value;
+    });
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (glowTimer.current) clearTimeout(glowTimer.current);
+    },
+    [],
+  );
+
+  const value = useMemo(
+    () => ({ insight, glowNonce, setInsight }),
+    [insight, glowNonce, setInsight],
+  );
+
+  return <InsightContext.Provider value={value}>{children}</InsightContext.Provider>;
+}
+
+/** Read the active insight + glow nonce. Used by the breadcrumb InsightButton. */
+export function useInsight(): InsightContextValue {
+  const ctx = useContext(InsightContext);
+  if (!ctx) {
+    // Safe fallback so a stray consumer never crashes the tree.
+    return { insight: null, glowNonce: 0, setInsight: () => {} };
+  }
+  return ctx;
+}
+
+/**
+ * useSetInsight — register the CURRENT screen/tab insight from a page or tab.
+ *
+ * Sets on mount and whenever `value` changes by identity (so a tab switch that
+ * passes a new object re-registers and re-glows the button), and CLEARS on
+ * unmount so navigating away never leaves a stale insight behind.
+ *
+ * Pass `null` to explicitly register "no insight" (button hides).
+ */
+export function useSetInsight(value: InsightValue | null): void {
+  const { setInsight } = useInsight();
+
+  useEffect(() => {
+    setInsight(value);
+    return () => setInsight(null);
+    // Re-run on identity change of `value` — callers should pass a stable/memoized
+    // object per logical insight (e.g. one object per active tab).
+  }, [value, setInsight]);
+}

--- a/webui-v2/src/layouts/app-shell.tsx
+++ b/webui-v2/src/layouts/app-shell.tsx
@@ -11,6 +11,7 @@ import { NavRail } from "@/components/chrome/nav-rail";
 import { TopBar } from "@/components/chrome/top-bar";
 import { CommandPalette } from "@/components/chrome/command-palette";
 import { SourcePeekProvider } from "@/components/SourcePeek";
+import { InsightProvider } from "@/components/ui";
 
 interface RouteHandle {
   surfaceLabel?: string;
@@ -24,16 +25,18 @@ export function AppShell() {
 
   return (
     <SourcePeekProvider>
-      <div className="flex h-full w-full">
-        <NavRail />
-        <div className="flex flex-col flex-1 min-w-0">
-          <TopBar group={groupId} surfaceLabel={surfaceLabel} />
-          <main className="flex-1 min-h-0 ag-scroll bg-bg">
-            <Outlet />
-          </main>
+      <InsightProvider>
+        <div className="flex h-full w-full">
+          <NavRail />
+          <div className="flex flex-col flex-1 min-w-0">
+            <TopBar group={groupId} surfaceLabel={surfaceLabel} />
+            <main className="flex-1 min-h-0 ag-scroll bg-bg">
+              <Outlet />
+            </main>
+          </div>
+          <CommandPalette />
         </div>
-        <CommandPalette />
-      </div>
+      </InsightProvider>
     </SourcePeekProvider>
   );
 }

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -62,9 +62,10 @@ import {
   TooltipTrigger,
   TooltipContent,
   TabCount,
-  InsightBanner,
   DefTerm,
+  useSetInsight,
 } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { useSourcePeek } from "@/components/SourcePeek";
@@ -748,26 +749,6 @@ function CoverageTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="quality.coverage"
-        human={
-          <>
-            Structural test coverage — which production entities (functions,
-            classes, endpoints) are reached by a test via a{" "}
-            <DefTerm
-              term="TESTS edge"
-              def="A graph edge linking a test entity to the production entity it exercises. Coverage here is reachability over these edges, not executed-line coverage."
-            />
-            . This is graph reachability, not line coverage.
-          </>
-        }
-        agent={{
-          tool: "archigraph_test_coverage",
-          example:
-            "Before writing tests for a payments module, an agent calls archigraph_test_coverage to list production endpoints with no inbound TESTS edge, then generates tests targeting exactly those gaps instead of duplicating existing ones.",
-        }}
-      />
-
       <CoverageGauge
         covered={data.covered_production}
         total={data.total_production}
@@ -935,23 +916,6 @@ function DependenciesTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="quality.deps"
-        human={
-          <>
-            Dependency hygiene — declared third-party packages cross-checked
-            against what the code actually imports. Surfaces unused (declared,
-            never imported) and phantom (imported, never declared) packages per
-            repository.
-          </>
-        }
-        agent={{
-          tool: "archigraph_import_cycles",
-          example:
-            "Before splitting a large module, an agent calls archigraph_import_cycles to confirm the move won't introduce a circular import, and cross-references phantom packages so it adds the right dependency to package.json instead of guessing.",
-        }}
-      />
-
       <div className="flex flex-wrap gap-3">
         <MetricStat
           label="Declared"
@@ -1090,22 +1054,6 @@ function AntiPatternsTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="quality.antipatterns"
-        human={
-          <>
-            Anti-patterns — code shapes the indexer flags as likely performance
-            or correctness smells. Currently surfaces N+1 query patterns: an ORM
-            query executed inside a loop, which issues one query per iteration.
-          </>
-        }
-        agent={{
-          tool: "archigraph_graph_patterns",
-          example:
-            "Reviewing a PR that adds a loop over orders, an agent calls archigraph_graph_patterns to detect a new N+1 query it introduced, then suggests a bulk prefetch or select_related fix before approving.",
-        }}
-      />
-
       <div className="flex flex-wrap gap-3">
         <MetricStat
           label="N+1 findings"
@@ -1205,23 +1153,6 @@ function GodNodesTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="quality.godnodes"
-        human={
-          <>
-            God-nodes — high-centrality hub entities that many other things
-            depend on or route through. They concentrate risk: a change here
-            ripples widely. Ranked by PageRank over the dependency graph;
-            refactor candidates.
-          </>
-        }
-        agent={{
-          tool: "archigraph_impact_radius",
-          example:
-            "Before refactoring a high-PageRank service class, an agent calls archigraph_impact_radius to enumerate every downstream caller and route, then scopes the change set and flags the blast radius for human review rather than editing blind.",
-        }}
-      />
-
       <div className="flex flex-wrap gap-3">
         <MetricStat
           label="God-nodes"
@@ -1436,22 +1367,6 @@ function TrendsTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="quality.trends"
-        human={
-          <>
-            Trends — how each quality metric moves across successive re-indexes.
-            A sparkline appears only once there's genuine multi-snapshot history;
-            freshly-indexed groups show the current value with a goal until
-            history builds up.
-          </>
-        }
-        agent={{
-          tool: "archigraph_test_coverage",
-          example:
-            "Running in CI after each index, an agent calls archigraph_test_coverage across snapshots to detect that coverage dropped 4% on the last merge, then opens a follow-up issue naming the newly-uncovered entities responsible for the regression.",
-        }}
-      />
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {data.metrics.map((m) => (
           <MetricTrendCard key={m.label} m={m} />
@@ -1467,9 +1382,105 @@ function TrendsTab({ groupId }: { groupId: string }) {
 
 type QualityTab = "coverage" | "dependencies" | "anti-patterns" | "god-nodes" | "trends";
 
+/**
+ * Per-tab insights (#4655). Registered with the breadcrumb Insights button via
+ * useSetInsight based on the ACTIVE tab — switching tabs re-registers a new
+ * object identity so the button re-glows and the popover updates. These are
+ * module-level constants so each tab's identity is stable across renders (only
+ * a real tab change swaps the registered value). Moved here out of the page
+ * body, which previously rendered an inline <InsightBanner> per tab.
+ */
+const QUALITY_INSIGHTS: Record<QualityTab, InsightValue> = {
+  coverage: {
+    storageKey: "quality.coverage",
+    human: (
+      <>
+        Structural test coverage — which production entities (functions,
+        classes, endpoints) are reached by a test via a{" "}
+        <DefTerm
+          term="TESTS edge"
+          def="A graph edge linking a test entity to the production entity it exercises. Coverage here is reachability over these edges, not executed-line coverage."
+        />
+        . This is graph reachability, not line coverage.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_test_coverage",
+      example:
+        "Before writing tests for a payments module, an agent calls archigraph_test_coverage to list production endpoints with no inbound TESTS edge, then generates tests targeting exactly those gaps instead of duplicating existing ones.",
+    },
+  },
+  dependencies: {
+    storageKey: "quality.deps",
+    human: (
+      <>
+        Dependency hygiene — declared third-party packages cross-checked against
+        what the code actually imports. Surfaces unused (declared, never
+        imported) and phantom (imported, never declared) packages per repository.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_import_cycles",
+      example:
+        "Before splitting a large module, an agent calls archigraph_import_cycles to confirm the move won't introduce a circular import, and cross-references phantom packages so it adds the right dependency to package.json instead of guessing.",
+    },
+  },
+  "anti-patterns": {
+    storageKey: "quality.antipatterns",
+    human: (
+      <>
+        Anti-patterns — code shapes the indexer flags as likely performance or
+        correctness smells. Currently surfaces N+1 query patterns: an ORM query
+        executed inside a loop, which issues one query per iteration.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_graph_patterns",
+      example:
+        "Reviewing a PR that adds a loop over orders, an agent calls archigraph_graph_patterns to detect a new N+1 query it introduced, then suggests a bulk prefetch or select_related fix before approving.",
+    },
+  },
+  "god-nodes": {
+    storageKey: "quality.godnodes",
+    human: (
+      <>
+        God-nodes — high-centrality hub entities that many other things depend on
+        or route through. They concentrate risk: a change here ripples widely.
+        Ranked by PageRank over the dependency graph; refactor candidates.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_impact_radius",
+      example:
+        "Before refactoring a high-PageRank service class, an agent calls archigraph_impact_radius to enumerate every downstream caller and route, then scopes the change set and flags the blast radius for human review rather than editing blind.",
+    },
+  },
+  trends: {
+    storageKey: "quality.trends",
+    human: (
+      <>
+        Trends — how each quality metric moves across successive re-indexes. A
+        sparkline appears only once there's genuine multi-snapshot history;
+        freshly-indexed groups show the current value with a goal until history
+        builds up.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_test_coverage",
+      example:
+        "Running in CI after each index, an agent calls archigraph_test_coverage across snapshots to detect that coverage dropped 4% on the last merge, then opens a follow-up issue naming the newly-uncovered entities responsible for the regression.",
+    },
+  },
+};
+
 export default function QualityScreen() {
   const { groupId = "" } = useParams<{ groupId: string }>();
   const [tab, setTab] = useState<QualityTab>("coverage");
+
+  // #4655: register the ACTIVE tab's insight with the breadcrumb Insights
+  // button. Switching tabs passes a new object identity → the button re-glows
+  // and the popover content updates. Clears on unmount (navigating away).
+  useSetInsight(QUALITY_INSIGHTS[tab]);
 
   // Lightweight count pills on the tab strip (re-uses the same cached queries).
   const coverage = useQualityCoverage(groupId);

--- a/webui-v2/src/styles/app.css
+++ b/webui-v2/src/styles/app.css
@@ -134,6 +134,22 @@
   }
 }
 
+/* ── Insight button glow (#4655) ─────────────────────────────────────────────
+   Pulsing warning-tinted ring on the breadcrumb "Insights" button, fired for
+   ~4s whenever the active screen insight changes (navigation / tab switch) so
+   users notice fresh context is available. JS removes the class after the glow
+   window; the animation simply repeats while present.
+   ──────────────────────────────────────────────────────────────────────── */
+@keyframes ag-insight-glow {
+  0%   { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.45); }
+  70%  { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0); }
+}
+
+.ag-insight-glow {
+  animation: ag-insight-glow 1.4s ease-out infinite;
+}
+
 /* Honor reduced-motion globally (per handoff motion rules). */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## Phase A — InsightButton foundation + Quality reference

Moves the per-screen `InsightBanner` out of page bodies into a **glowing breadcrumb "Insights" button + popover**, backed by an app-wide insight register that pages/tabs write into. This is **Phase A / foundation** — only Quality is converted as the reference; other routes keep their inline banners until Phase B.

### What's new
- **`InsightContext` + `InsightProvider`** (`components/ui/insight-context.tsx`)
  - `useSetInsight(insight | null)` — pages/tabs register the CURRENT insight; sets on mount / value-change and **clears on unmount** so navigating away leaves no stale insight.
  - `useInsight()` — the button consumes the active insight + a `glowNonce` that bumps (debounced) whenever the insight changes identity.
- **`<InsightButton>`** (`components/chrome/insight-button.tsx`)
  - Compact lightbulb + "Insights" button mounted in the **TopBar breadcrumb** (`archigraph › group › Surface › [Insights]`).
  - Click → popover rendering the EXISTING two-column `<InsightBanner>` (green human / yellow agent).
  - **Glows ~4s** (warning ring, `.ag-insight-glow` in `app.css`) when the active insight changes (navigation / tab switch); **hidden** when no insight is registered.
- **`InsightProvider`** wraps TopBar + `<Outlet/>` inside `AppShell` so both the button and routes share context.

### Quality adoption (Phase A reference)
- Removed the inline `<InsightBanner>` from all five Quality tabs.
- Per-tab insights are module-level constants (stable identity); `QualityScreen` calls `useSetInsight(QUALITY_INSIGHTS[tab])` keyed on the active tab, so **switching tabs re-glows the button and updates the popover** — proving the per-tab pattern.

### Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅ (exit 0)
- `npx vite build` ✅ (built in ~15s)

### Follow-up
**Phase B** — fan out `useSetInsight` to the remaining routes and remove their inline `<InsightBanner>` usages. They coexist fine for now (the button just has no content on those pages until then).

Closes #4655

🤖 Generated with [Claude Code](https://claude.com/claude-code)