### PR TITLE
feat(webui-v2): convert remaining screens to breadcrumb Insights button (#4655 Phase B)

### DIFF
--- a/webui-v2/src/routes/compare.tsx
+++ b/webui-v2/src/routes/compare.tsx
@@ -19,7 +19,8 @@ import { useCallback, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { GitCompare, Loader2, AlertTriangle } from "lucide-react";
 
-import { InsightBanner } from "@/components/ui";
+import { useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { useDiff } from "@/hooks/use-diff";
 import { useRefs } from "@/hooks/use-refs";
 import { DiffSummaryBanner } from "@/components/Compare/diff-summary-banner";
@@ -192,7 +193,28 @@ function ErrorBanner({ message }: { message: string }) {
 // Main compare screen
 // ---------------------------------------------------------------------------
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const COMPARE_INSIGHT: InsightValue = {
+  storageKey: "compare",
+  human: (
+    <>
+      Compare — a structural diff of the knowledge graph between two refs
+      (branches, tags or commits) of a repo. It shows which entities were
+      added, removed or modified and which relationships changed, so you
+      can review the architectural impact of a branch instead of reading a
+      raw line-by-line text diff.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_diff_refs",
+    example:
+      "Reviewing a feature branch, an agent calls archigraph_diff_refs(refA=main, refB=feature) to get the added/removed/modified entities and changed edges, then focuses its review on the modified callables and their new dependencies instead of skimming the whole patch.",
+  },
+};
+
 export default function CompareScreen() {
+  useSetInsight(COMPARE_INSIGHT);
   const { groupId = "" } = useParams();
   const { refA, refB, repo, filter, kind, setRefA, setRefB, setRepo, setFilter, setKind } =
     useCompareParams();
@@ -249,23 +271,6 @@ export default function CompareScreen() {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      <InsightBanner
-        storageKey="compare"
-        human={
-          <>
-            Compare — a structural diff of the knowledge graph between two refs
-            (branches, tags or commits) of a repo. It shows which entities were
-            added, removed or modified and which relationships changed, so you
-            can review the architectural impact of a branch instead of reading a
-            raw line-by-line text diff.
-          </>
-        }
-        agent={{
-          tool: "archigraph_diff_refs",
-          example:
-            "Reviewing a feature branch, an agent calls archigraph_diff_refs(refA=main, refB=feature) to get the added/removed/modified entities and changed edges, then focuses its review on the modified callables and their new dependencies instead of skimming the whole patch.",
-        }}
-      />
 
       {/* Selector row */}
       <SelectorRow

--- a/webui-v2/src/routes/dataflow.tsx
+++ b/webui-v2/src/routes/dataflow.tsx
@@ -60,8 +60,9 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
-  InsightBanner,
+  useSetInsight,
 } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
@@ -726,10 +727,25 @@ function FlowsTab({ data, groupId }: { data: DataflowReport; groupId: string }) 
 // § Screen
 // ---------------------------------------------------------------------------
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Findings and Flows share the same taint/data-flow framing, so
+// a single module-level constant (stable identity) covers both tabs.
+const DATAFLOW_INSIGHT: InsightValue = {
+  storageKey: "dataflow",
+  human: <TaintHuman />,
+  agent: {
+    tool: "archigraph_data_flows",
+    example:
+      "Reviewing a PR that builds a SQL string from a request param, an agent calls archigraph_data_flows to confirm the param reaches the query sink with no sanitizer in between, then blocks the merge and points at the exact source→sink hop as a SQL-injection finding.",
+  },
+};
+
 export default function DataflowScreen() {
   const { groupId = "" } = useParams<{ groupId: string }>();
   const { data, isLoading, isError } = useDataflow(groupId);
   const [tab, setTab] = useState<"findings" | "flows">("findings");
+
+  useSetInsight(DATAFLOW_INSIGHT);
 
   const hasAny =
     (data?.total_findings ?? 0) > 0 || (data?.total_flows ?? 0) > 0;
@@ -773,16 +789,6 @@ export default function DataflowScreen() {
           </div>
 
           <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
-            <InsightBanner
-              storageKey="dataflow"
-              human={<TaintHuman />}
-              agent={{
-                tool: "archigraph_data_flows",
-                example:
-                  "Reviewing a PR that builds a SQL string from a request param, an agent calls archigraph_data_flows to confirm the param reaches the query sink with no sanitizer in between, then blocks the merge and points at the exact source→sink hop as a SQL-injection finding.",
-              }}
-            />
-
             {/* Summary */}
             <div className="flex flex-wrap gap-3">
               <SummaryStat label="Findings" value={data!.total_findings} />

--- a/webui-v2/src/routes/di.tsx
+++ b/webui-v2/src/routes/di.tsx
@@ -54,8 +54,9 @@ import {
   TooltipProvider,
   TooltipTrigger,
   TooltipContent,
-  InsightBanner,
+  useSetInsight,
 } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { cn } from "@/lib/utils";
@@ -451,23 +452,6 @@ function DIBody({ data }: { data: DIReport }) {
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
-      <InsightBanner
-        storageKey="di"
-        human={
-          <>
-            Dependency injection — which providers (services, tokens) get
-            injected into which consumers (controllers, services, handlers).
-            Each row is a real INJECTED_INTO edge, so you can see what wires into
-            what across frameworks.
-          </>
-        }
-        agent={{
-          tool: "archigraph_neighbors",
-          example:
-            "About to change a method signature on PaymentService, an agent calls archigraph_neighbors to list every controller and service it's injected into, then updates all call sites in one pass instead of discovering broken consumers at runtime.",
-        }}
-      />
-
       {/* Summary */}
       <div className="flex flex-wrap gap-3">
         <SummaryStat label="Providers" value={data.total_providers} />
@@ -555,9 +539,30 @@ function DIBody({ data }: { data: DIReport }) {
   );
 }
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const DI_INSIGHT: InsightValue = {
+  storageKey: "di",
+  human: (
+    <>
+      Dependency injection — which providers (services, tokens) get
+      injected into which consumers (controllers, services, handlers).
+      Each row is a real INJECTED_INTO edge, so you can see what wires into
+      what across frameworks.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_neighbors",
+    example:
+      "About to change a method signature on PaymentService, an agent calls archigraph_neighbors to list every controller and service it's injected into, then updates all call sites in one pass instead of discovering broken consumers at runtime.",
+  },
+};
+
 export default function DIScreen() {
   const { groupId = "" } = useParams<{ groupId: string }>();
   const { data, isLoading, isError } = useDI(groupId);
+
+  useSetInsight(DI_INSIGHT);
 
   const hasAny = (data?.total_injections ?? 0) > 0;
 

--- a/webui-v2/src/routes/errorflow.tsx
+++ b/webui-v2/src/routes/errorflow.tsx
@@ -46,7 +46,8 @@ import {
   Bug,
 } from "lucide-react";
 
-import { Badge, Card, CardBody, Pill, InsightBanner } from "@/components/ui";
+import { Badge, Card, CardBody, Pill, useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
@@ -377,33 +378,45 @@ function ErrorFlowBody({
 
   const caughtCount = data.total_exceptions - data.total_uncaught;
 
+  // #4655: register this screen's insight with the breadcrumb Insights button.
+  // The human copy embeds live counts, so the value is memoized on those counts
+  // to keep a stable identity (re-glows only when the counts actually change).
+  const insight = useMemo<InsightValue>(
+    () => ({
+      storageKey: "errorflow",
+      human: (
+        <>
+          Error flow — every exception type in the codebase, inverted around
+          the type: for each one, who can <strong>throw</strong> it and who{" "}
+          <strong>catches</strong> it. A type flagged{" "}
+          <em>“no catcher in graph”</em> is thrown but has no typed catcher
+          indexed anywhere — a cautious uncaught warning, not a proven leak.
+          Counts: {data.total_exceptions} exception type
+          {data.total_exceptions === 1 ? "" : "s"}, {data.total_uncaught} with
+          no catcher, {data.total_throws} throw
+          {data.total_throws === 1 ? "" : "s"} and {data.total_catches} catch
+          {data.total_catches === 1 ? "" : "es"} across the graph. Only TYPED
+          throws/catches are recorded — bare <code>except:</code> / untyped{" "}
+          <code>catch(e)</code> emit no edge.
+        </>
+      ),
+      agent: {
+        tool: "archigraph_find",
+        example:
+          "Before adding a try/catch, an agent calls archigraph_find for SCOPE.ExceptionType nodes (the synthetic exception:<Type> entities) to see which exceptions are thrown but reach the top with no catcher in the graph, then wraps the one that actually escapes uncaught instead of guessing.",
+      },
+    }),
+    [
+      data.total_exceptions,
+      data.total_uncaught,
+      data.total_throws,
+      data.total_catches,
+    ],
+  );
+  useSetInsight(insight);
+
   return (
     <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
-      <InsightBanner
-        storageKey="errorflow"
-        human={
-          <>
-            Error flow — every exception type in the codebase, inverted around
-            the type: for each one, who can <strong>throw</strong> it and who{" "}
-            <strong>catches</strong> it. A type flagged{" "}
-            <em>“no catcher in graph”</em> is thrown but has no typed catcher
-            indexed anywhere — a cautious uncaught warning, not a proven leak.
-            Counts: {data.total_exceptions} exception type
-            {data.total_exceptions === 1 ? "" : "s"}, {data.total_uncaught} with
-            no catcher, {data.total_throws} throw
-            {data.total_throws === 1 ? "" : "s"} and {data.total_catches} catch
-            {data.total_catches === 1 ? "" : "es"} across the graph. Only TYPED
-            throws/catches are recorded — bare <code>except:</code> / untyped{" "}
-            <code>catch(e)</code> emit no edge.
-          </>
-        }
-        agent={{
-          tool: "archigraph_find",
-          example:
-            "Before adding a try/catch, an agent calls archigraph_find for SCOPE.ExceptionType nodes (the synthetic exception:<Type> entities) to see which exceptions are thrown but reach the top with no catcher in the graph, then wraps the one that actually escapes uncaught instead of guessing.",
-        }}
-      />
-
       {/* Summary */}
       <div className="flex flex-wrap gap-3">
         <SummaryStat label="Exception types" value={data.total_exceptions} />

--- a/webui-v2/src/routes/event-flows.tsx
+++ b/webui-v2/src/routes/event-flows.tsx
@@ -32,7 +32,8 @@ import { Radio, Workflow, ChevronRight, Copy } from "lucide-react";
 import { toast } from "sonner";
 
 import { api } from "@/lib/api";
-import { Badge, Skeleton, InsightBanner } from "@/components/ui";
+import { Badge, Skeleton, useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { useSourcePeek } from "@/components/SourcePeek";
 import { cn } from "@/lib/utils";
 
@@ -239,7 +240,28 @@ function prettyJSON(s: string): string {
 // Screen
 // ---------------------------------------------------------------------------
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const EVENT_FLOWS_INSIGHT: InsightValue = {
+  storageKey: "event-flows",
+  human: (
+    <>
+      Event flows — multi-hop publish/subscribe chains seeded from message
+      channels (Kafka topics, EventBridge buses and similar). Each chain
+      walks from a producer through every downstream handler that consumes
+      the event, so you can follow an event end-to-end across services
+      instead of guessing who reacts to it.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_flows",
+    example:
+      "Before changing the payload published to an `order.created` topic, an agent calls archigraph_flows to walk the pub/sub chain and list every downstream subscriber, so it updates all consumers in the same change instead of breaking a handler two hops away.",
+  },
+};
+
 export default function EventFlowsScreen() {
+  useSetInsight(EVENT_FLOWS_INSIGHT);
   const { groupId } = useParams<{ groupId: string }>();
   const [search, setSearch] = useSearchParams();
   const selectedId = search.get("flow");
@@ -265,23 +287,7 @@ export default function EventFlowsScreen() {
 
   return (
     <div className="flex h-full w-full flex-col gap-4 p-4">
-      <InsightBanner
-        storageKey="event-flows"
-        human={
-          <>
-            Event flows — multi-hop publish/subscribe chains seeded from message
-            channels (Kafka topics, EventBridge buses and similar). Each chain
-            walks from a producer through every downstream handler that consumes
-            the event, so you can follow an event end-to-end across services
-            instead of guessing who reacts to it.
-          </>
-        }
-        agent={{
-          tool: "archigraph_flows",
-          example:
-            "Before changing the payload published to an `order.created` topic, an agent calls archigraph_flows to walk the pub/sub chain and list every downstream subscriber, so it updates all consumers in the same change instead of breaking a handler two hops away.",
-        }}
-      />
+      
       <div className="flex min-h-0 w-full flex-1 gap-4">
       {/* Left rail */}
       <aside className="flex w-[380px] shrink-0 flex-col gap-3 rounded-lg border border-border bg-surface-0 p-3">

--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -36,7 +36,8 @@ import type {
 import { cn } from "@/lib/utils";
 import { RepoChip as SharedRepoChip } from "@/lib/repo-color";
 import { Skeleton } from "@/components/ui/skeleton";
-import { InsightBanner } from "@/components/ui";
+import { useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { FlowDag as SharedFlowDag } from "@/components/flow-dag";
 import { useSourcePeek } from "@/components/SourcePeek";
 import { flowToDagPayload } from "@/lib/flow-to-dag";
@@ -1609,7 +1610,28 @@ function DetailPanel({
 
 // ─── Main screen ──────────────────────────────────────────────────────────────
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const FLOWS_INSIGHT: InsightValue = {
+  storageKey: "flows",
+  human: (
+    <>
+      End-to-end process flows — each one traces a request from an entry
+      point (an HTTP route, a queue consumer, a job) through every
+      handler, service and side effect it touches, across repositories
+      when the path is cross-stack. Dead-ends and truncated flows
+      highlight where a trace stops short of completing.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_traces",
+    example:
+      "Asked 'what happens when a user submits the checkout form?', an agent calls archigraph_traces from the POST /checkout entry point to walk the whole flow — validation, the payment-service call, the order DB write, the confirmation-email publish — and explains the end-to-end path instead of reading each file blind.",
+  },
+};
+
 export default function FlowsScreen() {
+  useSetInsight(FLOWS_INSIGHT);
   const { groupId = "" } = useParams<{ groupId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -1721,23 +1743,7 @@ export default function FlowsScreen() {
 
       {/* Insight banner (#4604) */}
       <div className="flex-none px-5 pt-3">
-        <InsightBanner
-          storageKey="flows"
-          human={
-            <>
-              End-to-end process flows — each one traces a request from an entry
-              point (an HTTP route, a queue consumer, a job) through every
-              handler, service and side effect it touches, across repositories
-              when the path is cross-stack. Dead-ends and truncated flows
-              highlight where a trace stops short of completing.
-            </>
-          }
-          agent={{
-            tool: "archigraph_traces",
-            example:
-              "Asked 'what happens when a user submits the checkout form?', an agent calls archigraph_traces from the POST /checkout entry point to walk the whole flow — validation, the payment-service call, the order DB write, the confirmation-email publish — and explains the end-to-end path instead of reading each file blind.",
-          }}
-        />
+        
       </div>
 
       {/* Workspace grid */}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -15,7 +15,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { X, RotateCcw, SlidersHorizontal, Boxes } from "lucide-react";
-import { SearchInput, Pill, Kbd, InsightBanner } from "@/components/ui";
+import { SearchInput, Pill, Kbd, useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { useGraph } from "@/hooks/use-graph";
 import { useModuleAnalysis } from "@/hooks/use-module-analysis";
 import {
@@ -91,7 +92,32 @@ const COLOR_MODES: { id: ColorMode; label: string }[] = [
  */
 const HUB_DEGREE_CAP = 2000;
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const GRAPH_INSIGHT: InsightValue = {
+  storageKey: "graph",
+  human: (
+    <>
+      The dependency graph — every indexed entity (files, classes,
+      functions) and the edges between them (imports, calls,
+      references). Search to jump to a symbol, color by
+      repo/kind/community, or collapse to a module overview. Node color
+      encodes the active mode; faint peripheral nodes are low-degree
+      leaves, not orphans. Unconnected (zero-edge) nodes — typically
+      constants, types, and config with no graph edges — are hidden by
+      default so the connected structure reads clearly; bring them back
+      anytime with the &ldquo;isolated · show&rdquo; chip.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_find",
+    example:
+      "Asked to fix a bug in `placeOrder`, an agent calls archigraph_find to jump straight to its definition and one-hop neighbors — the callers, the services it invokes, the file it lives in — instead of grepping the repo for a name that appears in dozens of comments and strings.",
+  },
+};
+
 export default function GraphScreen() {
+  useSetInsight(GRAPH_INSIGHT);
   const { groupId = "demo" } = useParams();
   const theme = useAppStore((st) => st.theme);
   const isDark = theme === "dark";
@@ -596,27 +622,7 @@ export default function GraphScreen() {
       {/* Intro / legend header — the landing screen otherwise has no lead-in.
           Kept compact so the canvas stays the hero. */}
       <div className="shrink-0 border-b border-border bg-bg px-4 py-2 space-y-2">
-        <InsightBanner
-          storageKey="graph"
-          human={
-            <>
-              The dependency graph — every indexed entity (files, classes,
-              functions) and the edges between them (imports, calls,
-              references). Search to jump to a symbol, color by
-              repo/kind/community, or collapse to a module overview. Node color
-              encodes the active mode; faint peripheral nodes are low-degree
-              leaves, not orphans. Unconnected (zero-edge) nodes — typically
-              constants, types, and config with no graph edges — are hidden by
-              default so the connected structure reads clearly; bring them back
-              anytime with the &ldquo;isolated · show&rdquo; chip.
-            </>
-          }
-          agent={{
-            tool: "archigraph_find",
-            example:
-              "Asked to fix a bug in `placeOrder`, an agent calls archigraph_find to jump straight to its definition and one-hop neighbors — the callers, the services it invokes, the file it lives in — instead of grepping the repo for a name that appears in dozens of comments and strings.",
-          }}
-        />
+        
       </div>
 
       {/* Canvas + overlays */}

--- a/webui-v2/src/routes/graphql.tsx
+++ b/webui-v2/src/routes/graphql.tsx
@@ -39,7 +39,8 @@ import {
   Network,
 } from "lucide-react";
 
-import { Badge, Card, CardBody, Pill, InsightBanner } from "@/components/ui";
+import { Badge, Card, CardBody, Pill, useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
@@ -335,7 +336,28 @@ function SchemaTypesSection({ types }: { types: GraphQLSchemaType[] | null | und
 
 const OPERATIONS = ["query", "mutation", "subscription"] as const;
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const GRAPHQL_INSIGHT: InsightValue = {
+  storageKey: "graphql",
+  human: (
+    <>
+      GraphQL resolvers — every query, mutation and subscription
+      resolver in the group, grouped by the schema type they
+      resolve, with the side effects each one performs (DB reads/
+      writes, HTTP calls) and whether it is auth-guarded. Use it to
+      see which fields touch the database or run unauthenticated.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_effects",
+    example:
+      "Before changing a GraphQL mutation, an agent calls archigraph_effects on the resolver entity to enumerate its db_write / http side effects and confidence, so it knows the blast radius of the field it is about to edit rather than reading the resolver body and guessing.",
+  },
+};
+
 export default function GraphQLScreen() {
+  useSetInsight(GRAPHQL_INSIGHT);
   const { groupId = "" } = useParams<{ groupId: string }>();
   const { data, isLoading, isError } = useGraphQL(groupId);
   const [opFilter, setOpFilter] = useState<string>("all");
@@ -373,23 +395,6 @@ export default function GraphQLScreen() {
           </>
         ) : (
           <>
-            <InsightBanner
-              storageKey="graphql"
-              human={
-                <>
-                  GraphQL resolvers — every query, mutation and subscription
-                  resolver in the group, grouped by the schema type they
-                  resolve, with the side effects each one performs (DB reads/
-                  writes, HTTP calls) and whether it is auth-guarded. Use it to
-                  see which fields touch the database or run unauthenticated.
-                </>
-              }
-              agent={{
-                tool: "archigraph_effects",
-                example:
-                  "Before changing a GraphQL mutation, an agent calls archigraph_effects on the resolver entity to enumerate its db_write / http side effects and confidence, so it knows the blast radius of the field it is about to edit rather than reading the resolver body and guessing.",
-              }}
-            />
 
             {/* Summary */}
             <div className="flex flex-wrap gap-3">

--- a/webui-v2/src/routes/links.tsx
+++ b/webui-v2/src/routes/links.tsx
@@ -42,11 +42,12 @@ import {
   Card,
   CardBody,
   Pill,
-  InsightBanner,
+  useSetInsight,
   Tooltip,
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RepoChip } from "@/lib/repo-color";
 import { cn } from "@/lib/utils";
@@ -396,7 +397,31 @@ function RepoPairSection({
 // § Screen
 // ---------------------------------------------------------------------------
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const LINKS_INSIGHT: InsightValue = {
+  storageKey: "links",
+  human: (
+    <>
+      This view maps the resolved calls between entities — a frontend
+      fetch landing on a backend endpoint, a publisher reaching a topic,
+      a gRPC client reaching a service. Each row is one directed link:
+      where a request originates (source) and what it reaches (target),
+      with the link kind and how confident the resolver is in the match.
+      When the group spans more than one repository these are cross-repo
+      links; when it's a single repo they're intra-repo data flows.
+      Click a row to open the target entity in the graph.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_cross_links",
+    example:
+      "Debugging a frontend call that hits a 404, an agent calls archigraph_cross_links to confirm which backend endpoint the fetch actually resolves to across repos — and spots that the client points at /v1/users while the server only serves /v2/users.",
+  },
+};
+
 export default function LinksScreen() {
+  useSetInsight(LINKS_INSIGHT);
   const { groupId = "" } = useParams<{ groupId: string }>();
   const { data, isLoading, isError } = useGroupLinks(groupId);
   const [kindFilter, setKindFilter] = useState<string>("all");
@@ -474,26 +499,7 @@ export default function LinksScreen() {
   return (
     <div className="flex flex-col h-full bg-bg">
       <div className="flex-1 min-h-0 overflow-y-auto ag-scroll px-4 py-4 space-y-4">
-        <InsightBanner
-          storageKey="links"
-          human={
-            <>
-              This view maps the resolved calls between entities — a frontend
-              fetch landing on a backend endpoint, a publisher reaching a topic,
-              a gRPC client reaching a service. Each row is one directed link:
-              where a request originates (source) and what it reaches (target),
-              with the link kind and how confident the resolver is in the match.
-              When the group spans more than one repository these are cross-repo
-              links; when it's a single repo they're intra-repo data flows.
-              Click a row to open the target entity in the graph.
-            </>
-          }
-          agent={{
-            tool: "archigraph_cross_links",
-            example:
-              "Debugging a frontend call that hits a 404, an agent calls archigraph_cross_links to confirm which backend endpoint the fetch actually resolves to across repos — and spots that the client points at /v1/users while the server only serves /v2/users.",
-          }}
-        />
+        
         {isLoading ? (
           <SkeletonRows />
         ) : isError ? (

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -60,8 +60,9 @@ import {
   TabsTrigger,
   TooltipProvider,
   InfoLabel,
-  InsightBanner,
+  useSetInsight,
 } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import {
   useSystemStatus,
   useRestartDaemon,
@@ -1812,7 +1813,27 @@ function UpdatesTab() {
 // Screen root
 // ---------------------------------------------------------------------------
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const OPERATIONS_INSIGHT: InsightValue = {
+  storageKey: "operations",
+  human: (
+    <>
+      Operations — run and inspect the daemon behind this group:
+      system health and indexing, the learned-pattern store,
+      graph-quality measurement (unresolved references, orphan audit,
+      recall), and version updates.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_repairs",
+    example:
+      "Before trusting the graph to answer 'who calls this?', an agent calls archigraph_repairs to review unresolved references and pending fixes — if a key dynamic-dispatch edge is still unresolved it pauses and asks for a re-index rather than reporting an incomplete caller list as complete.",
+  },
+};
+
 export default function OperationsScreen() {
+  useSetInsight(OPERATIONS_INSIGHT);
   const { groupId = "" } = useParams<{ groupId: string }>();
 
   return (
@@ -1829,22 +1850,7 @@ export default function OperationsScreen() {
         </header>
 
         <div className="mb-6 space-y-3">
-          <InsightBanner
-            storageKey="operations"
-            human={
-              <>
-                Operations — run and inspect the daemon behind this group:
-                system health and indexing, the learned-pattern store,
-                graph-quality measurement (unresolved references, orphan audit,
-                recall), and version updates.
-              </>
-            }
-            agent={{
-              tool: "archigraph_repairs",
-              example:
-                "Before trusting the graph to answer 'who calls this?', an agent calls archigraph_repairs to review unresolved references and pending fixes — if a key dynamic-dispatch edge is still unresolved it pauses and asks for a re-index rather than reporting an incomplete caller list as complete.",
-            }}
-          />
+          
         </div>
 
         <Tabs defaultValue="system">

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -30,7 +30,8 @@ import { Badge, Tabs, TabsList, TabsTrigger, TabsContent, Skeleton } from "@/com
 import {
   Dialog, DialogContent, DialogTitle, DialogDescription,
 } from "@/components/ui";
-import { TabCount, InsightBanner } from "@/components/ui";
+import { TabCount, useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { FlowDag } from "@/components/flow-dag";
 import { RefLine } from "@/components/RefLine";
 import { getRepoColor } from "@/lib/repo-color";
@@ -1732,9 +1733,30 @@ function Breadcrumb({
    Main screen
    ============================================================ */
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const PATHS_INSIGHT: InsightValue = {
+  storageKey: "paths",
+  human: (
+    <>
+      Every API endpoint in this group — its HTTP verb and path, the
+      handler that serves it, how it's authenticated, the inputs it
+      accepts (path, query and request body), and the downstream
+      services, databases and side effects it triggers.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_endpoints",
+    example:
+      "Asked to add a field to the POST /orders payload, an agent calls archigraph_endpoints to find the exact handler, confirm it's auth-protected, see the current request-body shape and which database writes it triggers, then edits the right function without grepping for the route.",
+  },
+};
+
 export default function PathsScreen() {
   const { groupId = "" } = useParams<{ groupId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  useSetInsight(PATHS_INSIGHT);
 
   // URL state — backend drives the drill-down level.
   const activeTab = (searchParams.get("tab") ?? "endpoints") as "endpoints" | "orphans";
@@ -1988,26 +2010,6 @@ export default function PathsScreen() {
             )}
           </TabsTrigger>
         </TabsList>
-
-        {/* Page-level plain-language description + agent banner (#4574). */}
-        <div className="px-4 pt-3 pb-2 shrink-0 bg-surface border-b border-border space-y-2">
-          <InsightBanner
-            storageKey="paths"
-            human={
-              <>
-                Every API endpoint in this group — its HTTP verb and path, the
-                handler that serves it, how it's authenticated, the inputs it
-                accepts (path, query and request body), and the downstream
-                services, databases and side effects it triggers.
-              </>
-            }
-            agent={{
-              tool: "archigraph_endpoints",
-              example:
-                "Asked to add a field to the POST /orders payload, an agent calls archigraph_endpoints to find the exact handler, confirm it's auth-protected, see the current request-body shape and which database writes it triggers, then edits the right function without grepping for the route.",
-            }}
-          />
-        </div>
 
         {/* Endpoints tab */}
         <TabsContent value="endpoints" className="flex-1 min-h-0 flex flex-col mt-0">

--- a/webui-v2/src/routes/pending.tsx
+++ b/webui-v2/src/routes/pending.tsx
@@ -23,8 +23,9 @@ import {
   TabsList,
   TabsTrigger,
   Skeleton,
-  InsightBanner,
+  useSetInsight,
 } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 import type {
@@ -588,7 +589,27 @@ function PendingSkeleton() {
 // Main screen
 // ---------------------------------------------------------------------------
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const PENDING_INSIGHT: InsightValue = {
+  storageKey: "pending",
+  human: (
+    <>
+      Pending candidates — edits archigraph has queued but not yet
+      applied to the graph: repairs (resolving an unresolved reference)
+      and enrichments (adding inferred metadata). Review each, then
+      accept or dismiss it.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_enrichments",
+    example:
+      "After an index run, an agent calls archigraph_enrichments to see the queued metadata and repair candidates, auto-accepts the unambiguous ones (a single obvious URL→endpoint match), and leaves the ambiguous dynamic-dispatch repairs flagged for a human to confirm.",
+  },
+};
+
 export default function PendingScreen() {
+  useSetInsight(PENDING_INSIGHT);
   const { groupId = "demo" } = useParams();
   const { data, isLoading, isError } = useCandidates(groupId);
   const saveHintMutation = useSaveHint(groupId);
@@ -722,22 +743,7 @@ export default function PendingScreen() {
 
       {/* Intro */}
       <div className="shrink-0 px-4 pt-3 space-y-2 border-b border-border-soft bg-bg">
-        <InsightBanner
-          storageKey="pending"
-          human={
-            <>
-              Pending candidates — edits archigraph has queued but not yet
-              applied to the graph: repairs (resolving an unresolved reference)
-              and enrichments (adding inferred metadata). Review each, then
-              accept or dismiss it.
-            </>
-          }
-          agent={{
-            tool: "archigraph_enrichments",
-            example:
-              "After an index run, an agent calls archigraph_enrichments to see the queued metadata and repair candidates, auto-accepts the unambiguous ones (a single obvious URL→endpoint match), and leaves the ambiguous dynamic-dispatch repairs flagged for a human to confirm.",
-          }}
-        />
+        
       </div>
 
       {/* Tab bar */}

--- a/webui-v2/src/routes/security.tsx
+++ b/webui-v2/src/routes/security.tsx
@@ -43,9 +43,10 @@ import {
   TabsTrigger,
   TabsContent,
   TabCount,
-  InsightBanner,
+  useSetInsight,
   DefTerm,
 } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
@@ -441,31 +442,6 @@ function AuthCoverageTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="security.auth"
-        human={
-          <>
-            Which HTTP endpoints are protected by an{" "}
-            <DefTerm
-              term="auth guard"
-              def="A decorator, middleware, interceptor, or framework security rule that requires the caller to be authenticated before the handler runs."
-            />{" "}
-            and which are exposed without one. Routes that are{" "}
-            <DefTerm
-              term="public by design"
-              def="An endpoint with no auth guard that is intentionally open — e.g. login, register, password-reset, health checks, or an explicit @Public/AllowAny exemption."
-            />{" "}
-            are flagged as informational rather than High so genuine gaps stand
-            out.
-          </>
-        }
-        agent={{
-          tool: "archigraph_auth_coverage",
-          example:
-            "Reviewing a PR that adds GET /admin/users, an agent calls archigraph_auth_coverage to verify the new route picked up an auth guard — and blocks the merge when it finds the endpoint exposed without one and not on the public-by-design allowlist.",
-        }}
-      />
-
       <CoverageGauge
         covered={data.covered_count}
         uncovered={data.uncovered_count}
@@ -593,31 +569,6 @@ function SecretsTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="security.secrets"
-        human={
-          <>
-            Credentials found in the codebase: both{" "}
-            <DefTerm
-              term="hardcoded"
-              def="A password, API key, token, or private key written directly into source code instead of being injected from a secrets store at runtime."
-            />{" "}
-            secrets that should be removed and detected{" "}
-            <DefTerm
-              term="secrets-management"
-              def="An integration with a dedicated secrets store (Vault, AWS Secrets Manager, …) — the recommended way to supply credentials."
-            />{" "}
-            integrations that are doing the right thing. Each row links to the
-            exact source location.
-          </>
-        }
-        agent={{
-          tool: "archigraph_secrets",
-          example:
-            "Scanning a PR diff, an agent calls archigraph_secrets and finds a newly-added AWS key string literal in a config file; it blocks the merge, points at the exact line, and suggests moving it into the existing Vault integration instead.",
-        }}
-      />
-
       <div className="flex flex-wrap gap-3">
         <CountStat label="High severity" value={data.error_count} tone="danger" />
         <CountStat label="Medium severity" value={data.warn_count} tone="warning" />
@@ -774,31 +725,6 @@ function CyclesTab({ groupId }: { groupId: string }) {
 
   return (
     <div className="space-y-4">
-      <InsightBanner
-        storageKey="security.cycles"
-        human={
-          <>
-            Circular{" "}
-            <DefTerm
-              term="import"
-              def="A group of modules that depend on each other in a loop (A imports B imports C imports A), so none can be built, tested, or reasoned about in isolation."
-            />{" "}
-            dependencies between modules. Cycles make code harder to test and
-            refactor; each finding lists the modules in the loop and a suggested{" "}
-            <DefTerm
-              term="extraction point"
-              def="The weakest edge in the cycle — the dependency most cheaply broken (e.g. by moving a shared type to its own module) to untangle the loop."
-            />{" "}
-            to break it. Severity scales with the number of modules involved.
-          </>
-        }
-        agent={{
-          tool: "archigraph_import_cycles",
-          example:
-            "After a refactor introduces a new A→B→A loop, an agent calls archigraph_import_cycles to locate the suggested extraction point and proposes moving the shared type into its own module — breaking the cycle with the smallest possible diff.",
-        }}
-      />
-
       <div className="flex flex-wrap gap-3">
         <CountStat label="High (>5)" value={data.error_count} tone="danger" />
         <CountStat label="Medium (3-5)" value={data.warn_count} tone="warning" />
@@ -834,9 +760,97 @@ function CyclesTab({ groupId }: { groupId: string }) {
 // § Screen shell
 // ---------------------------------------------------------------------------
 
+type SecurityTab = "auth" | "secrets" | "cycles";
+
+/**
+ * Per-tab insights (#4655). Registered with the breadcrumb Insights button via
+ * useSetInsight based on the ACTIVE tab — switching tabs re-registers a new
+ * object identity so the button re-glows and the popover updates. Module-level
+ * constants for stable identity; replaces the inline per-tab <InsightBanner>.
+ */
+const SECURITY_INSIGHTS: Record<SecurityTab, InsightValue> = {
+  auth: {
+    storageKey: "security.auth",
+    human: (
+      <>
+        Which HTTP endpoints are protected by an{" "}
+        <DefTerm
+          term="auth guard"
+          def="A decorator, middleware, interceptor, or framework security rule that requires the caller to be authenticated before the handler runs."
+        />{" "}
+        and which are exposed without one. Routes that are{" "}
+        <DefTerm
+          term="public by design"
+          def="An endpoint with no auth guard that is intentionally open — e.g. login, register, password-reset, health checks, or an explicit @Public/AllowAny exemption."
+        />{" "}
+        are flagged as informational rather than High so genuine gaps stand
+        out.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_auth_coverage",
+      example:
+        "Reviewing a PR that adds GET /admin/users, an agent calls archigraph_auth_coverage to verify the new route picked up an auth guard — and blocks the merge when it finds the endpoint exposed without one and not on the public-by-design allowlist.",
+    },
+  },
+  secrets: {
+    storageKey: "security.secrets",
+    human: (
+      <>
+        Credentials found in the codebase: both{" "}
+        <DefTerm
+          term="hardcoded"
+          def="A password, API key, token, or private key written directly into source code instead of being injected from a secrets store at runtime."
+        />{" "}
+        secrets that should be removed and detected{" "}
+        <DefTerm
+          term="secrets-management"
+          def="An integration with a dedicated secrets store (Vault, AWS Secrets Manager, …) — the recommended way to supply credentials."
+        />{" "}
+        integrations that are doing the right thing. Each row links to the
+        exact source location.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_secrets",
+      example:
+        "Scanning a PR diff, an agent calls archigraph_secrets and finds a newly-added AWS key string literal in a config file; it blocks the merge, points at the exact line, and suggests moving it into the existing Vault integration instead.",
+    },
+  },
+  cycles: {
+    storageKey: "security.cycles",
+    human: (
+      <>
+        Circular{" "}
+        <DefTerm
+          term="import"
+          def="A group of modules that depend on each other in a loop (A imports B imports C imports A), so none can be built, tested, or reasoned about in isolation."
+        />{" "}
+        dependencies between modules. Cycles make code harder to test and
+        refactor; each finding lists the modules in the loop and a suggested{" "}
+        <DefTerm
+          term="extraction point"
+          def="The weakest edge in the cycle — the dependency most cheaply broken (e.g. by moving a shared type to its own module) to untangle the loop."
+        />{" "}
+        to break it. Severity scales with the number of modules involved.
+      </>
+    ),
+    agent: {
+      tool: "archigraph_import_cycles",
+      example:
+        "After a refactor introduces a new A→B→A loop, an agent calls archigraph_import_cycles to locate the suggested extraction point and proposes moving the shared type into its own module — breaking the cycle with the smallest possible diff.",
+    },
+  },
+};
+
 export default function SecurityScreen() {
   const { groupId = "" } = useParams<{ groupId: string }>();
-  const [tab, setTab] = useState<"auth" | "secrets" | "cycles">("auth");
+  const [tab, setTab] = useState<SecurityTab>("auth");
+
+  // #4655: register the ACTIVE tab's insight with the breadcrumb Insights
+  // button. Switching tabs swaps the object identity → the button re-glows and
+  // the popover updates. Clears on unmount (navigating away).
+  useSetInsight(SECURITY_INSIGHTS[tab]);
 
   // Lightweight count pills on the tab strip (re-uses the same cached queries).
   const auth = useAuthCoverage(groupId);

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -27,7 +27,8 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TabCount, InsightBanner } from "@/components/ui";
+import { TabCount, useSetInsight } from "@/components/ui";
+import type { InsightValue } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
@@ -1694,7 +1695,30 @@ function ScheduledTab({
 // § TopologyScreen — main export
 // ---------------------------------------------------------------------------
 
+// Screen insight (#4655) — registered with the breadcrumb Insights button via
+// useSetInsight. Module-level constant for stable identity across renders.
+const TOPOLOGY_INSIGHT: InsightValue = {
+  storageKey: "topology",
+  human: (
+    <>
+      This is your{" "}
+      <strong className="text-text-2">messaging topology</strong> — a
+      map of who publishes and who subscribes across your message
+      queues and topics. Use it to see which services send messages to
+      a channel, which ones receive them, and where a channel has a
+      publisher but no subscriber (or vice-versa) so messages may be
+      dropped.
+    </>
+  ),
+  agent: {
+    tool: "archigraph_topology",
+    example:
+      "Before changing the schema of the `order.created` event, an agent calls archigraph_topology to enumerate every subscriber, so it updates all consumers in lockstep — and flags the orphaned topic that has a publisher but no subscriber as a likely dropped-message bug.",
+  },
+};
+
 export default function TopologyScreen() {
+  useSetInsight(TOPOLOGY_INSIGHT);
   const { groupId = "" } = useParams<{ groupId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -1932,25 +1956,7 @@ export default function TopologyScreen() {
 
         {/* Plain-language intro + agent-usage banner */}
         <div className="px-4 pt-3 pb-1 border-b border-border shrink-0 space-y-2">
-          <InsightBanner
-            storageKey="topology"
-            human={
-              <>
-                This is your{" "}
-                <strong className="text-text-2">messaging topology</strong> — a
-                map of who publishes and who subscribes across your message
-                queues and topics. Use it to see which services send messages to
-                a channel, which ones receive them, and where a channel has a
-                publisher but no subscriber (or vice-versa) so messages may be
-                dropped.
-              </>
-            }
-            agent={{
-              tool: "archigraph_topology",
-              example:
-                "Before changing the schema of the `order.created` event, an agent calls archigraph_topology to enumerate every subscriber, so it updates all consumers in lockstep — and flags the orphaned topic that has a publisher but no subscriber as a likely dropped-message bug.",
-            }}
-          />
+          
         </div>
 
         {/* All tab */}


### PR DESCRIPTION
Phase B of #4655 — convert all remaining route screens to the breadcrumb Insights button pattern established in Phase A (#4659).

## What changed
Phase A built `InsightContext` (`useSetInsight` / `InsightValue`) and a glowing breadcrumb `<InsightButton>` that renders the active screen insight in a popover, with Quality as the reference conversion. This PR removes the inline `<InsightBanner>` from every remaining page body and instead registers the **same** human/agent copy via `useSetInsight`, so the breadcrumb button shows it and re-glows on navigation / tab change.

All insight payloads are stable module-level constants (per Quality) so identity only changes on a real navigation/tab switch.

### Converted
- **Single-insight screens** (register one constant in the default export): `di`, `topology`, `dataflow`, `paths`, `graph`, `operations`, `pending`, `links`, `graphql`, `event-flows`, `flows`, `compare`.
- **Tabbed per-tab screen**: `security` — `SECURITY_INSIGHTS[tab]` (auth / secrets / cycles), registered for the active tab and re-registered on tab change, mirroring Quality exactly.
- **errorflow** — its human copy embeds live exception counts, so the insight is a `useMemo` keyed on those counts (stable identity, re-glows only when counts change).
- **dataflow** — Findings/Flows tabs share one taint/data-flow framing, so a single insight covers both tabs.

### Intentionally left untouched
- `iac.tsx` — owned by a sibling agent (inline banner kept; will convert later).
- `quality.tsx` — already converted in Phase A.

## Verification
- No page renders a stray inline `<InsightBanner>` except `iac.tsx`.
- Gates pass: `npm ci`, `npx tsc --noEmit`, `npx vite build`.

Closes #4655 (Phase B)
Refs the foundation PR #4659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)