### PR TITLE
feat(iac): resolve module instantiation + environment tabs for the IaC architecture view (#4657)

### DIFF
--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -138,6 +138,24 @@ type IaCResource struct {
 	// diagram renders as a grouped container. Empty when no source path is known.
 	Module string `json:"module,omitempty"`
 
+	// Env is the environment a resource belongs to (#4657): for a module
+	// INSTANCE it is derived from the instance file's path (envs/<env>/…); for a
+	// definition resource it is propagated from the instance(s) that instantiate
+	// the definition this resource lives in. Drives the env tabs. Empty for
+	// env-less resources (shared definitions not yet linked to any env).
+	Env string `json:"env,omitempty"`
+
+	// DefinitionDir, for a module INSTANCE only (#4657): the repo-relative
+	// directory of the module DEFINITION this instance instantiates
+	// (e.g. `modules/worker-service`). The diagram joins it to the definition's
+	// resources (those whose Module == DefinitionDir) to project them into the
+	// env and draw the INSTANTIATES edge between rendered nodes.
+	DefinitionDir string `json:"definition_dir,omitempty"`
+
+	// ModuleSource, for a module INSTANCE only (#4657): the raw `source` value
+	// (e.g. `../../modules/worker-service`, or a registry/git source).
+	ModuleSource string `json:"module_source,omitempty"`
+
 	// Properties — curated typed config props (empty when none stamped).
 	Properties []IaCProperty `json:"properties"`
 	// Relations — grants / event-sources / dependencies / topology / triggers /
@@ -166,6 +184,9 @@ type IaCReport struct {
 
 	// Tools observed.
 	Tools []string `json:"tools"`
+	// Envs observed across module instances (#4657), sorted; drives the env
+	// tabs in the architecture view. Empty when no env-scoped stacks exist.
+	Envs []string `json:"envs"`
 	// CountsByCategory — resource_category → count across all tools.
 	CountsByCategory map[string]int `json:"counts_by_category"`
 
@@ -196,6 +217,11 @@ var iacStructuralPropKeys = map[string]struct{}{
 	"deployment_role":   {},
 	"reason":            {},
 	"join":              {},
+	// #4657 module-instantiation bookkeeping — surfaced as dedicated
+	// IaCResource fields (Env / DefinitionDir / ModuleSource), not config props.
+	"env":            {},
+	"definition_dir": {},
+	"module_source":  {},
 }
 
 // iacResourceKinds are the entity Kinds an IaC resource can carry. CFN derives
@@ -298,6 +324,12 @@ func iacRelationFacet(kind string, props map[string]string) (facet, detail strin
 		}
 		return "dependency", strings.TrimSpace(props["module_output"])
 	}
+	// Issue #4657 — module instantiation: an env stack's module instance
+	// instantiates a module definition. Surfaced as its own facet so the
+	// diagram draws the env→definition link distinctly from plain dependencies.
+	if kind == "INSTANTIATES" {
+		return "instantiates", strings.TrimSpace(props["definition_dir"])
+	}
 	switch kind {
 	case "TRIGGERS", "SERVES", "ROUTES_TO", "SUBSCRIBES_TO":
 		// serverless / SAM wiring. Surface the most descriptive qualifier.
@@ -350,6 +382,42 @@ func iacModuleOf(slug, sourceFile string) string {
 		return slug
 	}
 	return "(root)"
+}
+
+// splitEnv splits a (possibly comma-joined) env field into its individual env
+// names, trimming blanks. A module definition instantiated by several envs
+// carries a comma-joined Env (e.g. "dev,prod"); a plain instance carries one.
+func splitEnv(env string) []string {
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(env, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// mergeEnv adds one env to a comma-joined env list, keeping it sorted and
+// de-duplicated. Used when a shared module definition is instantiated by more
+// than one environment (#4657).
+func mergeEnv(existing, add string) string {
+	set := map[string]bool{}
+	for _, e := range splitEnv(existing) {
+		set[e] = true
+	}
+	for _, e := range splitEnv(add) {
+		set[e] = true
+	}
+	out := make([]string, 0, len(set))
+	for e := range set {
+		out = append(out, e)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
 }
 
 // idTail returns the last path segment of a graph entity ID (Kind:Name or
@@ -505,18 +573,21 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 			sort.SliceStable(cfgProps, func(i, j int) bool { return cfgProps[i].Key < cfgProps[j].Key })
 
 			res := &IaCResource{
-				EntityID:     rp.Slug + "/" + id,
-				Repo:         rp.Slug,
-				Name:         name,
-				Tool:         tool,
-				ResourceType: rtype,
-				Category:     category,
-				LogicalID:    props["logical_id"],
-				SourceFile:   sourceFile,
-				StartLine:    startLine,
-				Module:       iacModuleOf(rp.Slug, sourceFile),
-				Properties:   cfgProps,
-				Relations:    []IaCRelation{},
+				EntityID:      rp.Slug + "/" + id,
+				Repo:          rp.Slug,
+				Name:          name,
+				Tool:          tool,
+				ResourceType:  rtype,
+				Category:      category,
+				LogicalID:     props["logical_id"],
+				SourceFile:    sourceFile,
+				StartLine:     startLine,
+				Module:        iacModuleOf(rp.Slug, sourceFile),
+				Env:           strings.TrimSpace(props["env"]),
+				DefinitionDir: strings.TrimSpace(props["definition_dir"]),
+				ModuleSource:  strings.TrimSpace(props["module_source"]),
+				Properties:    cfgProps,
+				Relations:     []IaCRelation{},
 			}
 			byID[id] = res
 			nameByID[id] = name
@@ -596,7 +667,84 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 				report.TotalDependencies++
 			}
 		})
+
+		// Pass 3 (#4657) — resolve module instantiation by DIRECTORY. The
+		// INSTANTIATES edge from Pass 2 targets `tfmodule-def:<dir>`, which is
+		// not itself a rendered resource (a Terraform module definition is a
+		// directory of .tf files, not one entity). Here we join each module
+		// INSTANCE's DefinitionDir to the definition's resources — every
+		// resource whose Module (source-file directory) equals that dir — and:
+		//
+		//   1. draw an INSTANTIATES edge between the instance node and each of
+		//      the definition's resources (so dev/staging/prod connect to the
+		//      worker-service / sqs-queue definitions as rendered nodes), and
+		//   2. propagate the instance's env onto those definition resources, so
+		//      the env tabs can scope to "this env's instances + what they
+		//      instantiate" even though the shared definition files carry no env.
+		//
+		// This is the directory-join the resolver cannot do (no entity to bind
+		// a directory to) and is what clears the bulk of the unresolved relations.
+		defByDir := map[string][]*IaCResource{}
+		for _, r := range byID {
+			if r.Repo != rp.Slug || r.Module == "" {
+				continue
+			}
+			defByDir[r.Module] = append(defByDir[r.Module], r)
+		}
+		for _, inst := range byID {
+			if inst.Repo != rp.Slug || inst.DefinitionDir == "" {
+				continue
+			}
+			defs := defByDir[inst.DefinitionDir]
+			if len(defs) == 0 {
+				continue
+			}
+			for _, def := range defs {
+				if def == inst {
+					continue
+				}
+				// Propagate env onto the (env-less) shared definition resource so
+				// it surfaces under the instantiating env's tab. A definition
+				// instantiated by multiple envs accumulates a comma-joined list.
+				if inst.Env != "" {
+					def.Env = mergeEnv(def.Env, inst.Env)
+				}
+				inst.Relations = append(inst.Relations, IaCRelation{
+					Facet:          "instantiates",
+					Kind:           "INSTANTIATES",
+					Direction:      "out",
+					Target:         def.Name,
+					TargetResolved: true,
+					TargetID:       def.EntityID,
+					TargetEntityID: def.EntityID,
+					Detail:         inst.DefinitionDir,
+				})
+				def.Relations = append(def.Relations, IaCRelation{
+					Facet:          "instantiates",
+					Kind:           "INSTANTIATES",
+					Direction:      "in",
+					Target:         inst.Name,
+					TargetResolved: true,
+					TargetID:       inst.EntityID,
+					TargetEntityID: inst.EntityID,
+					Detail:         inst.DefinitionDir,
+				})
+			}
+		}
 	}
+
+	// Collect the env set across all module instances (post-projection so
+	// definition resources have inherited an env too).
+	envSet := map[string]bool{}
+	for _, r := range byID {
+		for _, e := range splitEnv(r.Env) {
+			envSet[e] = true
+		}
+	}
+	for e := range envSet {
+		report.Envs = append(report.Envs, e)
+	}
+	sort.Strings(report.Envs)
 
 	// Assemble groups by tool.
 	byTool := map[string]*IaCToolGroup{}

--- a/internal/dashboard/handlers_iac_test.go
+++ b/internal/dashboard/handlers_iac_test.go
@@ -111,6 +111,10 @@ func TestIaCRelationFacet(t *testing.T) {
 		{"cross-module generic falls back to dependency", "USES",
 			map[string]string{"dataflow": "cross_module", "semantic": "dependency", "module_output": "id"},
 			"dependency", "id"},
+		// #4657 — module instantiation edge surfaces as its own facet.
+		{"instantiates", "INSTANTIATES",
+			map[string]string{"definition_dir": "modules/worker-service"},
+			"instantiates", "modules/worker-service"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -131,6 +135,33 @@ func TestIaCIsOutputEntity(t *testing.T) {
 	}
 	if iacIsOutputEntity("SCOPE.InfraResource", "", map[string]string{"iac_tool": "aws-cdk"}) {
 		t.Fatal("a resource is not an output entity")
+	}
+}
+
+func TestMergeEnv(t *testing.T) {
+	cases := []struct {
+		existing, add, want string
+	}{
+		{"", "prod", "prod"},
+		{"prod", "prod", "prod"},
+		{"prod", "dev", "dev,prod"},
+		{"dev,prod", "staging", "dev,prod,staging"},
+		{"prod", "", "prod"},
+	}
+	for _, c := range cases {
+		if got := mergeEnv(c.existing, c.add); got != c.want {
+			t.Errorf("mergeEnv(%q,%q) = %q, want %q", c.existing, c.add, got, c.want)
+		}
+	}
+}
+
+func TestSplitEnv(t *testing.T) {
+	got := splitEnv(" dev , prod ,")
+	if len(got) != 2 || got[0] != "dev" || got[1] != "prod" {
+		t.Errorf("splitEnv = %v, want [dev prod]", got)
+	}
+	if splitEnv("") != nil {
+		t.Error("splitEnv(\"\") should be nil")
 	}
 }
 

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -338,6 +338,13 @@ func extractModuleBlock(n *sitter.Node, src []byte, path, lang string, start, en
 		if src_ := attributeStringValue(body, "source", src); src_ != "" {
 			rec.QualifiedName = src_
 			rec.Metadata["source"] = src_
+			// Issue #4657 — resolve the module instantiation: stamp the
+			// definition directory + env onto the instance and emit an
+			// INSTANTIATES edge from the instance to its definition dir, so the
+			// env stacks connect to the shared module definitions and the IaC
+			// architecture view can project the definition's resources inline.
+			rec.Relationships = append(rec.Relationships,
+				resolveModuleInstantiation(&rec, src_, path, lang, selfRef)...)
 		}
 		deps := extractDependsOn(body, src, path, lang)
 		rec.Relationships = append(rec.Relationships, deps...)

--- a/internal/extractors/hcl/module_instantiation.go
+++ b/internal/extractors/hcl/module_instantiation.go
@@ -1,0 +1,185 @@
+package hcl
+
+import (
+	"path"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ----------------------------------------------------------------
+// Issue #4657 — module instantiation → INSTANTIATES edge + env tagging
+// ----------------------------------------------------------------
+//
+// The IaC diagram showed the module DEFINITIONS (e.g. modules/worker-service,
+// modules/sqs-queue — each with its aws_* resources) ISOLATED from the
+// environment stacks (envs/{dev,staging,prod}/main.tf, each of which only
+// renders the opaque module INSTANCES `module.worker` and `module.dispatch_queue`).
+// The instance→definition link was unresolved: a relative-path module
+// `source = "../../modules/worker-service"` lands in hclDynamicPatterns and is
+// classified Dynamic, so dev/staging/prod never connect to the definitions and
+// the definitions read as disconnected boxes. This was the bulk of the
+// "N relation targets could not be resolved" footer.
+//
+// resolveModuleInstantiation fixes this for a `module "X" { source = "<rel>" }`
+// block: it path-resolves the relative source against the instance file's
+// directory to the module DEFINITION directory (repo-relative), stamps that
+// directory + the env name + the raw source onto the module-instance entity,
+// and emits an INSTANTIATES edge
+//
+//	module.X (instance) --INSTANTIATES--> <definition dir>
+//
+// The definition directory is not a single graph entity (a Terraform module is
+// a directory of .tf files), so the ToID is a path marker the resolver leaves
+// Dynamic; the dashboard (#4657 handlers_iac.go) joins it to the definition's
+// resources by DIRECTORY — every resource emitted under <definition dir> shares
+// that directory as its IaCResource.Module — and synthesises the rendered
+// instance→definition edges from the stamped definition_dir. This connects each
+// env to the worker-service / sqs-queue definitions and lets the env view
+// project the definition's resources inline.
+//
+// The stamped properties are:
+//
+//	module_source   the raw `source` value (e.g. ../../modules/worker-service)
+//	definition_dir  the repo-relative resolved definition directory
+//	                (e.g. modules/worker-service); empty for registry/remote sources
+//	env             the environment name derived from the instance file's
+//	                directory (e.g. dev / staging / prod), used by the env tabs
+//
+// Generalization note: AWS CDK (Stack/Construct instantiation), Pulumi
+// (ComponentResource), CloudFormation nested stacks (AWS::CloudFormation::Stack
+// TemplateURL), and Bicep modules express the same instance→definition pattern.
+// resolveModuleSourceDir / envFromPath are framework-agnostic; those extractors
+// can reuse the same definition_dir / env stamping + dashboard directory-join
+// once they emit a comparable source path (tracked as a follow-up).
+
+// DefinitionDirMarkerPrefix prefixes the INSTANTIATES edge ToID so the resolved
+// definition directory is an unambiguous Dynamic target (not mistaken for a
+// registry/markdown import or an extractor bug). The dashboard strips it to
+// recover the directory for the instance→definition resource join (#4657).
+const DefinitionDirMarkerPrefix = "tfmodule-def:"
+
+// resolveModuleInstantiation stamps the module-instance entity with the resolved
+// definition directory, the env name, and the raw source, and returns an
+// INSTANTIATES edge from the instance to its definition directory (when the
+// source is a local relative path). selfRef is the instance's canonical ref
+// (e.g. "module.worker"); source is the raw `source` attribute value; filePath
+// is the instance file's repo-relative path.
+func resolveModuleInstantiation(rec *types.EntityRecord, source, filePath, lang, selfRef string) []types.RelationshipRecord {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return nil
+	}
+	// Stamp into Properties (which the dashboard reader exposes) AND Metadata
+	// (kept for parity with the existing `source` key). Terraform's other
+	// resource attributes are surfaced from Properties; module_source / env /
+	// definition_dir join the same surface so the env tabs + instance→definition
+	// projection (#4657) can read them.
+	if rec.Properties == nil {
+		rec.Properties = map[string]string{}
+	}
+	rec.Properties["module_source"] = source
+	rec.Metadata["module_source"] = source
+	if env := envFromPath(filePath); env != "" {
+		rec.Properties["env"] = env
+		rec.Metadata["env"] = env
+	}
+
+	defDir := resolveModuleSourceDir(source, filePath)
+	if defDir == "" {
+		// Registry / git / remote source — no local definition directory to
+		// join against. The raw source is still recorded above.
+		return nil
+	}
+	rec.Properties["definition_dir"] = defDir
+	rec.Metadata["definition_dir"] = defDir
+
+	return []types.RelationshipRecord{{
+		FromID: extractor.BuildOperationStructuralRef(lang, filePath, selfRef),
+		// The definition is a directory, not a single entity; emit the directory
+		// as the target under an unambiguous `tfmodule-def:` marker prefix so the
+		// resolver classifies it Dynamic (DefinitionDirMarkerPrefix in
+		// internal/resolve/dynamic_patterns_hcl.go) rather than as an unresolved
+		// extractor bug, and the dashboard (#4657) strips the prefix to recover
+		// the directory and join it to the definition's resources by
+		// IaCResource.Module.
+		ToID: DefinitionDirMarkerPrefix + defDir,
+		Kind: "INSTANTIATES",
+		Properties: map[string]string{
+			"definition_dir": defDir,
+			"module_source":  source,
+			"language":       lang,
+		},
+	}}
+}
+
+// resolveModuleSourceDir resolves a Terraform module `source` value to the
+// repo-relative module DEFINITION directory. It returns "" for non-local
+// sources (Terraform registry shorthand, git::, github.com/, http(s), etc.) for
+// which there is no in-repo directory to join against.
+//
+// A local source is one starting with "./" or "../" (or "/" — an absolute
+// in-repo path, rare but valid). The path is resolved against the directory of
+// the instance file and cleaned, so
+//
+//	file=envs/dev/main.tf  source=../../modules/worker-service
+//	  → modules/worker-service
+func resolveModuleSourceDir(source, filePath string) string {
+	if !isLocalModuleSource(source) {
+		return ""
+	}
+	src := path.Clean(toSlash(source))
+	if path.IsAbs(src) {
+		// Absolute in-repo path — strip the leading slash to keep it
+		// repo-relative and comparable to entity SourceFile dirs.
+		return strings.TrimPrefix(src, "/")
+	}
+	dir := path.Dir(toSlash(filePath))
+	resolved := path.Clean(path.Join(dir, src))
+	// path.Clean can produce a leading ".." when the source escapes the repo
+	// root; such a target cannot be joined to any in-repo resource, so drop it.
+	if resolved == "." || strings.HasPrefix(resolved, "..") {
+		return ""
+	}
+	return resolved
+}
+
+// isLocalModuleSource reports whether a module source is a local filesystem
+// path (the only kind with an in-repo definition directory). Terraform registry
+// sources ("namespace/name/provider"), git/github/bitbucket/mercurial sources,
+// and http(s) archive sources are NOT local.
+func isLocalModuleSource(source string) bool {
+	s := strings.TrimSpace(source)
+	if s == "" {
+		return false
+	}
+	return strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") ||
+		s == "." || s == ".." || strings.HasPrefix(s, "/")
+}
+
+// envFromPath derives an environment name from an instance file's path. The
+// real upvate-v3 layout is envs/{dev,staging,prod}/main.tf, so the env is the
+// path segment immediately following an "envs" / "environments" / "env"
+// directory. Returns "" when the path does not encode a recognisable env
+// (e.g. the file is itself a module definition), in which case the dashboard
+// treats the stack as env-less.
+func envFromPath(filePath string) string {
+	parts := strings.Split(strings.Trim(toSlash(filePath), "/"), "/")
+	for i := 0; i+1 < len(parts); i++ {
+		switch parts[i] {
+		case "envs", "environments", "env":
+			if seg := parts[i+1]; seg != "" {
+				return seg
+			}
+		}
+	}
+	return ""
+}
+
+// toSlash normalises OS path separators to forward slashes so resolution is
+// stable across POSIX and Windows callers (entity SourceFile is already
+// slash-normalised via filepath.ToSlash at emit time).
+func toSlash(p string) string {
+	return strings.ReplaceAll(p, "\\", "/")
+}

--- a/internal/extractors/hcl/module_instantiation_internal_test.go
+++ b/internal/extractors/hcl/module_instantiation_internal_test.go
@@ -1,0 +1,40 @@
+package hcl
+
+import "testing"
+
+// TestResolveModuleSourceDir unit-tests the path resolution directly (#4657).
+func TestResolveModuleSourceDir(t *testing.T) {
+	cases := []struct {
+		name, source, file, want string
+	}{
+		{"two-up", "../../modules/worker-service", "envs/prod/main.tf", "modules/worker-service"},
+		{"one-up", "../shared", "stacks/app/main.tf", "stacks/shared"},
+		{"dot-slash", "./local-mod", "infra/main.tf", "infra/local-mod"},
+		{"registry", "terraform-aws-modules/vpc/aws", "envs/dev/main.tf", ""},
+		{"git", "git::https://example.com/mod.git", "envs/dev/main.tf", ""},
+		{"escapes-repo", "../../../outside", "main.tf", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveModuleSourceDir(tc.source, tc.file); got != tc.want {
+				t.Errorf("resolveModuleSourceDir(%q, %q) = %q, want %q", tc.source, tc.file, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnvFromPath unit-tests env derivation (#4657).
+func TestEnvFromPath(t *testing.T) {
+	cases := []struct{ path, want string }{
+		{"envs/prod/main.tf", "prod"},
+		{"infra/environments/staging/main.tf", "staging"},
+		{"env/dev/network.tf", "dev"},
+		{"modules/worker-service/main.tf", ""},
+		{"main.tf", ""},
+	}
+	for _, tc := range cases {
+		if got := envFromPath(tc.path); got != tc.want {
+			t.Errorf("envFromPath(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/extractors/hcl/module_instantiation_test.go
+++ b/internal/extractors/hcl/module_instantiation_test.go
@@ -1,0 +1,117 @@
+package hcl_test
+
+import (
+	"testing"
+
+	hcl "github.com/cajasmota/archigraph/internal/extractors/hcl"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findModuleInstance returns the module entity with the given label, or nil.
+func findModuleInstance(records []types.EntityRecord, label string) *types.EntityRecord {
+	return findBySubtypeAndName(records, "module", label)
+}
+
+// instantiatesEdge returns the first INSTANTIATES relationship on a record.
+func instantiatesEdge(rec *types.EntityRecord) *types.RelationshipRecord {
+	if rec == nil {
+		return nil
+	}
+	for i := range rec.Relationships {
+		if rec.Relationships[i].Kind == "INSTANTIATES" {
+			return &rec.Relationships[i]
+		}
+	}
+	return nil
+}
+
+// TestModuleInstantiationResolvesDefinitionDir is the headline #4657 fixture:
+// an env stack's `module "worker" { source = "../../modules/worker-service" }`
+// must resolve to the module DEFINITION directory and emit an INSTANTIATES edge
+// tagged with that directory, plus stamp the env onto the instance.
+func TestModuleInstantiationResolvesDefinitionDir(t *testing.T) {
+	src := `
+module "worker" {
+  source       = "../../modules/worker-service"
+  queue_url    = module.dispatch_queue.queue_url
+  desired_count = 3
+}
+
+module "dispatch_queue" {
+  source = "../../modules/sqs-queue"
+}
+`
+	records, err := extractTerraform(src, "envs/prod/main.tf")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	worker := findModuleInstance(records, "worker")
+	if worker == nil {
+		t.Fatal("module.worker instance not extracted")
+	}
+
+	// definition_dir / env / module_source must be stamped on Properties (the
+	// surface the dashboard reads).
+	if got := worker.Properties["definition_dir"]; got != "modules/worker-service" {
+		t.Errorf("definition_dir = %q, want modules/worker-service", got)
+	}
+	if got := worker.Properties["env"]; got != "prod" {
+		t.Errorf("env = %q, want prod", got)
+	}
+	if got := worker.Properties["module_source"]; got != "../../modules/worker-service" {
+		t.Errorf("module_source = %q, want ../../modules/worker-service", got)
+	}
+
+	edge := instantiatesEdge(worker)
+	if edge == nil {
+		t.Fatal("no INSTANTIATES edge on module.worker")
+	}
+	if want := hcl.DefinitionDirMarkerPrefix + "modules/worker-service"; edge.ToID != want {
+		t.Errorf("INSTANTIATES ToID = %q, want %q", edge.ToID, want)
+	}
+	if got := edge.Properties["definition_dir"]; got != "modules/worker-service" {
+		t.Errorf("edge definition_dir prop = %q, want modules/worker-service", got)
+	}
+
+	// The second instance resolves to the sqs-queue definition.
+	dq := findModuleInstance(records, "dispatch_queue")
+	if dq == nil {
+		t.Fatal("module.dispatch_queue instance not extracted")
+	}
+	if got := dq.Properties["definition_dir"]; got != "modules/sqs-queue" {
+		t.Errorf("dispatch_queue definition_dir = %q, want modules/sqs-queue", got)
+	}
+}
+
+// TestModuleInstantiationRemoteSourceNoEdge verifies registry/git sources do
+// NOT get a definition_dir or an INSTANTIATES edge (no in-repo directory), but
+// still record the raw source + env.
+func TestModuleInstantiationRemoteSourceNoEdge(t *testing.T) {
+	src := `
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+}
+`
+	records, err := extractTerraform(src, "envs/staging/main.tf")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	vpc := findModuleInstance(records, "vpc")
+	if vpc == nil {
+		t.Fatal("module.vpc not extracted")
+	}
+	if got := vpc.Properties["definition_dir"]; got != "" {
+		t.Errorf("definition_dir = %q, want empty for registry source", got)
+	}
+	if got := vpc.Properties["module_source"]; got != "terraform-aws-modules/vpc/aws" {
+		t.Errorf("module_source = %q", got)
+	}
+	if got := vpc.Properties["env"]; got != "staging" {
+		t.Errorf("env = %q, want staging", got)
+	}
+	if e := instantiatesEdge(vpc); e != nil {
+		t.Errorf("unexpected INSTANTIATES edge for registry source: %+v", e)
+	}
+}

--- a/internal/resolve/dynamic_patterns_hcl.go
+++ b/internal/resolve/dynamic_patterns_hcl.go
@@ -274,6 +274,14 @@ var hclDynamicPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^git::`),
 	regexp.MustCompile(`^github\.com/`),
 	regexp.MustCompile(`^bitbucket\.org/`),
+	// #4657 — module-instantiation INSTANTIATES edge target. The HCL extractor
+	// resolves a module instance's relative `source` to its repo-relative
+	// definition directory and emits it as the edge ToID under the unambiguous
+	// `tfmodule-def:` marker prefix (DefinitionDirMarkerPrefix). The definition
+	// is a directory, not a single graph entity, so there is nothing to bind to;
+	// the dashboard (#4657) joins it to the definition's resources by directory.
+	// Tagging it Dynamic keeps it out of the unresolved-extractor-bug count.
+	regexp.MustCompile(`^tfmodule-def:`),
 }
 
 func init() {

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -1251,6 +1251,12 @@ const (
 	//              The document→section hierarchy uses the existing CONTAINS
 	//              edge (RelationshipKindContains); no new hierarchy kind.
 	RelationshipKindMentions RelationshipKind = "MENTIONS"
+
+	// #4657 IaC module instantiation: an environment stack's module instance
+	// (e.g. envs/prod/main.tf `module.worker`) → the module DEFINITION
+	// directory it instantiates (e.g. modules/worker-service). Connects the
+	// env stacks to the shared module definitions in the IaC architecture view.
+	RelationshipKindInstantiates RelationshipKind = "INSTANTIATES"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1406,6 +1412,9 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindInherits,
 		// #4306 deterministic markdown doc ingestion (opt-in):
 		RelationshipKindMentions,
+		// #4657 IaC module instantiation: env stack's module instance →
+		// the module definition directory it instantiates.
+		RelationshipKindInstantiates,
 	}
 }
 

--- a/webui-v2/src/components/iac-diagram/IaCEdge.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCEdge.tsx
@@ -48,6 +48,11 @@ export function facetStyle(facet: string): FacetStyle {
       return { stroke: "var(--danger)", dash: "5 3", label: "grants" };
     case "reads":
       return { stroke: "var(--text-3)", label: "reads" };
+    // #4657 — module instantiation: an env's module instance → the resources
+    // of the module definition it instantiates. Solid accent so the env→
+    // definition projection reads as a first-class architecture link.
+    case "instantiates":
+      return { stroke: "var(--accent)", label: "instantiates" };
     default:
       return { stroke: "var(--text-4)", label: "depends" };
   }

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2189,6 +2189,23 @@ export interface IaCResource {
    * Empty when no source path is known.
    */
   module?: string;
+  /**
+   * Environment this resource belongs to (#4657). For a module INSTANCE it is
+   * derived from the instance file's path (envs/<env>/…); for a definition
+   * resource it is propagated from the instance(s) that instantiate the
+   * definition. A definition shared by several envs carries a comma-joined
+   * list. Drives the env tabs. Empty for env-less resources.
+   */
+  env?: string;
+  /**
+   * For a module INSTANCE only (#4657): the repo-relative directory of the
+   * module DEFINITION this instance instantiates (e.g. `modules/worker-service`).
+   * Equals the `module` of the definition's resources, so the diagram joins on
+   * it to project the definition's resources into the env.
+   */
+  definition_dir?: string;
+  /** For a module INSTANCE only (#4657): the raw `source` value. */
+  module_source?: string;
   /** Curated typed config props; [] when none stamped. */
   properties: IaCProperty[];
   /** Grants / event-sources / dependencies / topology / triggers; [] when none. */
@@ -2212,6 +2229,11 @@ export interface IaCReport {
   total_outputs: number;
   with_props_count: number;
   tools: string[];
+  /**
+   * Environments observed across module instances (#4657), sorted. Drives the
+   * env tabs in the architecture view; empty when no env-scoped stacks exist.
+   */
+  envs: string[];
   /** resource_category → count across all tools. */
   counts_by_category: Record<string, number>;
   groups: IaCToolGroup[];

--- a/webui-v2/src/routes/iac.tsx
+++ b/webui-v2/src/routes/iac.tsx
@@ -28,7 +28,7 @@
    empty state.
    ============================================================ */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
   Boxes,
@@ -62,9 +62,11 @@ import { useIaC } from "@/hooks/use-iac";
 import { IaCDiagram } from "@/components/iac-diagram";
 import type {
   IaCRelation,
+  IaCReport,
   IaCResource,
   IaCToolGroup,
 } from "@/data/types";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 // ---------------------------------------------------------------------------
 // § Category styling
@@ -110,6 +112,8 @@ function relationMeta(facet: string): {
       return { label: "event source", tone: "warning", Icon: Zap };
     case "topology":
       return { label: "topology", tone: "info", Icon: Layers };
+    case "instantiates":
+      return { label: "instantiates", tone: "accent", Icon: Boxes };
     case "trigger":
       return { label: "trigger", tone: "accent", Icon: Zap };
     case "output":
@@ -145,6 +149,9 @@ const INTERP_PREFIXES = [
 ];
 
 function isInterpolationRef(rel: IaCRelation): boolean {
+  // #4657: an INSTANTIATES edge is a real architecture relation even though its
+  // instance endpoint is named `module.<x>`; never bucket it as interpolation.
+  if (rel.facet === "instantiates") return false;
   const t = (rel.target || "").toLowerCase();
   if (t === "calls" || t === "local" || t === "var" || t === "data") return true;
   return INTERP_PREFIXES.some((p) => t.startsWith(p));
@@ -772,6 +779,98 @@ function IaCInsight() {
   );
 }
 
+// ---------------------------------------------------------------------------
+// § Environment scoping (#4657)
+// ---------------------------------------------------------------------------
+
+/** The sentinel env-tab value meaning "no env filter". */
+const ALL_ENVS = "__all__";
+
+/** True when a resource belongs to the given env (its comma-joined env list). */
+function resourceInEnv(r: IaCResource, env: string): boolean {
+  if (!r.env) return false;
+  return r.env
+    .split(",")
+    .map((e) => e.trim())
+    .includes(env);
+}
+
+/**
+ * Scope an IaCReport to a single environment (#4657): keep only the resources
+ * that belong to `env` — that env's module instances PLUS the definition
+ * resources those instances instantiate (the backend propagates the env onto
+ * the shared definition's resources, so they carry it too). Totals and the
+ * per-tool grouping are recomputed over the surviving resources so the diagram
+ * and stat row read as that env's wired architecture. `ALL_ENVS` returns the
+ * report unchanged.
+ */
+function scopeReportToEnv(report: IaCReport, env: string): IaCReport {
+  if (env === ALL_ENVS) return report;
+
+  const groups: IaCToolGroup[] = [];
+  const countsByCategory: Record<string, number> = {};
+  let totalResources = 0;
+  let withProps = 0;
+  let grants = 0;
+  let eventSources = 0;
+  let dependencies = 0;
+
+  for (const g of report.groups) {
+    const kept = (g.resources ?? []).filter((r) => resourceInEnv(r, env));
+    if (kept.length === 0) continue;
+    groups.push({ tool: g.tool, count: kept.length, resources: kept });
+    for (const r of kept) {
+      totalResources++;
+      if ((r.properties?.length ?? 0) > 0) withProps++;
+      if (r.category) countsByCategory[r.category] = (countsByCategory[r.category] ?? 0) + 1;
+      for (const rel of r.relations ?? []) {
+        if (rel.direction !== "out") continue;
+        if (rel.facet === "grant") grants++;
+        else if (rel.facet === "event_source") eventSources++;
+        else if (rel.facet === "dependency") dependencies++;
+      }
+    }
+  }
+
+  return {
+    ...report,
+    groups,
+    counts_by_category: countsByCategory,
+    total_resources: totalResources,
+    with_props_count: withProps,
+    total_grants: grants,
+    total_event_sources: eventSources,
+    total_dependencies: dependencies,
+  };
+}
+
+/** Env tabs (#4657): All + one tab per detected environment. */
+function EnvTabs({
+  envs,
+  value,
+  onChange,
+}: {
+  envs: string[];
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  if (envs.length === 0) return null;
+  return (
+    <Tabs value={value} onValueChange={onChange}>
+      <TabsList className="border-b-0">
+        <TabsTrigger value={ALL_ENVS} className="h-7 px-2.5 text-xs">
+          All envs
+        </TabsTrigger>
+        {envs.map((e) => (
+          <TabsTrigger key={e} value={e} className="h-7 px-2.5 text-xs">
+            {e}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}
+
 /** List | Diagram view toggle. */
 function ViewToggle({ view, onChange }: { view: IaCView; onChange: (v: IaCView) => void }) {
   return (
@@ -807,13 +906,31 @@ export default function IaCScreen() {
   const { data, isLoading, isError } = useIaC(groupId);
   const [toolFilter, setToolFilter] = useState<string>("all");
   const [view, setView] = useState<IaCView>(readStoredView);
+  const [env, setEnv] = useState<string>(ALL_ENVS);
 
   const setAndPersistView = useCallback((v: IaCView) => {
     persistView(v);
     setView(v);
   }, []);
 
-  const groups = useMemo<IaCToolGroup[]>(() => data?.groups ?? [], [data]);
+  const envs = useMemo<string[]>(() => data?.envs ?? [], [data]);
+
+  // Once envs are known, default the selection to `prod` (the conventional
+  // top-of-promotion env) when present; otherwise leave it on All. Only fires
+  // while the selection is still the initial All sentinel, so an explicit user
+  // choice is never overridden (#4657).
+  useEffect(() => {
+    if (env === ALL_ENVS && envs.includes("prod")) setEnv("prod");
+  }, [envs, env]);
+
+  // The report scoped to the selected env (All ⇒ unchanged). Drives both the
+  // diagram and the list/stat surfaces so the whole screen reads as that env.
+  const scoped = useMemo<IaCReport | undefined>(
+    () => (data ? scopeReportToEnv(data, env) : undefined),
+    [data, env],
+  );
+
+  const groups = useMemo<IaCToolGroup[]>(() => scoped?.groups ?? [], [scoped]);
 
   const filtered = useMemo<IaCToolGroup[]>(() => {
     if (toolFilter === "all") return groups;
@@ -831,14 +948,27 @@ export default function IaCScreen() {
           <div className="flex items-center gap-2">
             <ViewToggle view={view} onChange={setAndPersistView} />
             <span className="text-xs text-text-4">
-              Resource graph — resources by category, relations, grouped by
-              module.
+              {env === ALL_ENVS
+                ? "Resource graph — resources by category, relations, grouped by module."
+                : `Architecture for the ${env} environment — its module instances and the definition resources they instantiate.`}
             </span>
+            {/* Env tabs (#4657): scope the diagram to one environment's
+                instances + what they instantiate. */}
+            <div className="ml-auto">
+              <EnvTabs envs={envs} value={env} onChange={setEnv} />
+            </div>
           </div>
           <IaCInsight />
         </div>
         <div className="min-h-0 flex-1">
-          <IaCDiagram report={data!} />
+          {scoped!.total_resources === 0 ? (
+            <EmptyState
+              title={`No resources in ${env}`}
+              hint="This environment has no resolved module instances or definition resources. Pick another environment or All envs."
+            />
+          ) : (
+            <IaCDiagram report={scoped!} />
+          )}
         </div>
       </div>
     );
@@ -858,23 +988,29 @@ export default function IaCScreen() {
           />
         ) : (
           <>
-            {/* View toggle (List | Diagram) */}
-            <div className="flex items-center gap-2">
+            {/* View toggle (List | Diagram) + env tabs (#4657) */}
+            <div className="flex flex-wrap items-center gap-2">
               <ViewToggle view={view} onChange={setAndPersistView} />
+              <div className="ml-auto">
+                <EnvTabs envs={envs} value={env} onChange={setEnv} />
+              </div>
             </div>
 
             {/* #4576: List view now carries the same insight banner
                 the Diagram view does. */}
             <IaCInsight />
 
-            {/* Summary */}
+            {/* Summary — recomputed for the selected env (#4657). */}
             <div className="flex flex-wrap gap-3">
-              <SummaryStat label="Resources" value={data!.total_resources} />
-              <SummaryStat label="With config" value={data!.with_props_count} />
-              <SummaryStat label="IAM grants" value={data!.total_grants} />
-              <SummaryStat label="Event sources" value={data!.total_event_sources} />
-              <SummaryStat label="Dependencies" value={data!.total_dependencies} />
-              <SummaryStat label="Outputs" value={data!.total_outputs} />
+              <SummaryStat label="Resources" value={scoped!.total_resources} />
+              <SummaryStat label="With config" value={scoped!.with_props_count} />
+              <SummaryStat label="IAM grants" value={scoped!.total_grants} />
+              <SummaryStat label="Event sources" value={scoped!.total_event_sources} />
+              <SummaryStat label="Dependencies" value={scoped!.total_dependencies} />
+              <SummaryStat
+                label="Outputs"
+                value={env === ALL_ENVS ? data!.total_outputs : 0}
+              />
             </div>
 
             {/* Tool filter */}
@@ -896,8 +1032,16 @@ export default function IaCScreen() {
             {/* Grouped resources */}
             {filtered.length === 0 ? (
               <EmptyState
-                title="Nothing matches this filter"
-                hint="No resources match the selected tool filter."
+                title={
+                  env === ALL_ENVS
+                    ? "Nothing matches this filter"
+                    : `No resources in ${env}`
+                }
+                hint={
+                  env === ALL_ENVS
+                    ? "No resources match the selected tool filter."
+                    : "This environment has no resolved module instances or definition resources for this tool filter."
+                }
               />
             ) : (
               <div className="space-y-3">
@@ -908,7 +1052,7 @@ export default function IaCScreen() {
             )}
 
             {/* Category roll-up (context) */}
-            <CategorySection counts={data!.counts_by_category} />
+            <CategorySection counts={scoped!.counts_by_category} />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary

Turns the IaC diagram into an **architecture view**: it now connects environment stacks to the module **definitions** they instantiate, and scopes the diagram per environment.

Real upvate-v3 layout this targets: `envs/{dev,staging,prod}/main.tf` each instantiate `module "worker" { source = "../../modules/worker-service" }` and `module "dispatch_queue" { source = "../../modules/sqs-queue" }`. Previously the definitions (`worker-service`, `sqs-queue`, with their `aws_*` resources) rendered **isolated** from the env stacks; the instance→definition link was unresolved (the bulk of the "58 unresolved relations" footer).

## Backend — module-instantiation resolution (HCL extractor)
- New `internal/extractors/hcl/module_instantiation.go`: path-resolves each module instance's relative `source` to its repo-relative **definition directory**, stamps `definition_dir` / `env` / `module_source` onto the instance (Properties + Metadata), and emits an `INSTANTIATES` edge to the resolved directory under an unambiguous `tfmodule-def:` marker. Registry/git/remote sources record the raw source + env but emit no edge (no in-repo dir).
- `env` derived from `envs|environments|env/<name>/…` path segments.
- New `RelationshipKindInstantiates` ("INSTANTIATES").
- Resolver: `^tfmodule-def:` tagged Dynamic, so the directory target is **not** counted as an unresolved extractor bug.

## Backend — dashboard (`handlers_iac.go`)
- Surfaces `Env` / `DefinitionDir` / `ModuleSource` on `IaCResource`; new `report.Envs`.
- `"instantiates"` relation facet.
- **Pass 3 directory-join**: links each instance's `DefinitionDir` to the definition's resources (`Module == dir`), draws `INSTANTIATES` between **rendered** nodes, and propagates the instance's env onto the shared definition's resources (comma-joined when instantiated by several envs). This is what clears the bulk of the unresolved instance→definition relations.

## Frontend
- **Env tabs** (shared `Tabs` primitive) in List + Diagram views; default to `prod` when present, else All.
- `scopeReportToEnv` recomputes groups/totals for the selected env, so the screen reads as that env's wired architecture — the env's module instances **plus** the definition resources they instantiate (ECS/SQS/IAM/CloudWatch), with the existing #4640 cross-module edges drawn between them.
- `"instantiates"` facet styling (edge + badge); never bucketed as an interpolation ref despite the `module.<x>` endpoint name.

## What reduced the unresolved count
The instance→definition link (relative module `source`) was the dominant unresolved relation. It is now (a) Dynamic-classified at the resolver (no longer a bug-unresolved), and (b) resolved to rendered edges via the dashboard directory-join — so dev/staging/prod connect to worker-service/sqs-queue and the env reads as a real wired architecture.

## Generalization (follow-up)
The `definition_dir`/`env` resolution + directory-join model applies to CDK Stack/Construct instantiation, Pulumi ComponentResource, CloudFormation nested stacks, and Bicep modules — noted in code for a follow-up.

## Deferred
- Scope 4 (explicit tier-flow Compute→Messaging→Observability→IAM left-to-right layout) — the existing Tier toggle (#4640) already lays out by cloud tier within the env scope; a dedicated ordered tier-flow layout was not added.

## Gates
- `go build ./... && go vet ./internal/extractors/hcl/... ./internal/dashboard/...` — pass
- `go test ./internal/extractors/hcl/... ./internal/dashboard/... ./internal/types/... ./internal/resolve/...` — pass (producer-kind scanner validated the new INSTANTIATES literal)
- `npx tsc --noEmit && npx vite build` — pass

Live confirmation by coordinator after rebuild+reindex.

Closes #4657

🤖 Generated with [Claude Code](https://claude.com/claude-code)