### PR TITLE
fix(mcp): align auth_posture_diff endpoint join with stub_detector (#4550)

### DIFF
--- a/internal/mcp/auth_posture_diff_tool.go
+++ b/internal/mcp/auth_posture_diff_tool.go
@@ -156,12 +156,18 @@ type authEndpoint struct {
 }
 
 // collectAuthEndpoints scans a group for HTTP endpoint-definition entities and
-// builds an authEndpoint per endpoint, keyed by normalised <verb> <path>. When
-// two endpoints fold to the same key (e.g. ViewSet per-action expansion), the
-// one carrying the richest auth signal wins so the diff sees the most specific
-// posture.
-func collectAuthEndpoints(lg *LoadedGroup) map[string]authEndpoint {
-	out := map[string]authEndpoint{}
+// builds an authEndpoint per endpoint, keyed by the SHARED cross-group join key
+// (normalised <verb> <path>, /api[/vN] prefix stripped, path-params → {*} — the
+// same key stub_detector joins on, see endpoint_join.go). When two endpoints
+// fold to the same key (e.g. ViewSet per-action expansion), the one carrying the
+// richest auth signal wins so the diff sees the most specific posture.
+//
+// The join key deliberately does NOT include the DRF #action suffix: the oracle
+// (DRF) stamps an action while the v3 (NestJS) does not, so a #action key never
+// matched a v3 endpoint and the diff joined ZERO endpoints live (#4550). Folding
+// per-action ViewSet rows by richest-signal-wins keeps the most specific posture.
+func collectAuthEndpoints(lg *LoadedGroup) map[endpointJoinKey]authEndpoint {
+	out := map[endpointJoinKey]authEndpoint{}
 	for _, r := range lg.Repos {
 		if r == nil || r.Doc == nil {
 			continue
@@ -175,7 +181,7 @@ func collectAuthEndpoints(lg *LoadedGroup) map[string]authEndpoint {
 			if path == "" {
 				continue
 			}
-			key := authEndpointKey(verb, path, e)
+			key := newEndpointJoinKey(verb, path)
 			ae := authEndpoint{
 				display: strings.TrimSpace(strings.ToUpper(verb) + " " + path),
 				signal:  buildAuthSignal(e),
@@ -208,43 +214,6 @@ func endpointVerbPath(e *graph.Entity) (verb, path string) {
 		return "", ""
 	}
 	return e.Properties["verb"], e.Properties["path"]
-}
-
-// authEndpointKey is the normalised join key: VERB + normalised path. The path
-// is lowercased and its path-parameter NAMES are erased ({id} ~ {pk} ~ :id) so
-// the oracle and v3 align even when they name the same parameter differently.
-// The DRF action, when present, is folded in so per-action ViewSet postures
-// diff against their v3 per-action counterparts rather than colliding.
-func authEndpointKey(verb, path string, e *graph.Entity) string {
-	np := normalizeEndpointPath(path)
-	key := strings.ToUpper(strings.TrimSpace(verb)) + " " + np
-	if e.Properties != nil {
-		if a := strings.TrimSpace(e.Properties["effective_action"]); a != "" {
-			key += "#" + strings.ToLower(a)
-		} else if a := strings.TrimSpace(e.Properties["action"]); a != "" {
-			key += "#" + strings.ToLower(a)
-		}
-	}
-	return key
-}
-
-// normalizeEndpointPath lowercases a path and replaces every path-parameter
-// segment ({id}, :id, <int:pk>, {pk}) with a placeholder so parameter NAMING
-// differences between the oracle and v3 do not break the join.
-func normalizeEndpointPath(path string) string {
-	path = strings.ToLower(strings.TrimSpace(path))
-	segs := strings.Split(path, "/")
-	for i, s := range segs {
-		if s == "" {
-			continue
-		}
-		if strings.HasPrefix(s, ":") ||
-			(strings.HasPrefix(s, "{") && strings.HasSuffix(s, "}")) ||
-			(strings.HasPrefix(s, "<") && strings.HasSuffix(s, ">")) {
-			segs[i] = "{param}"
-		}
-	}
-	return strings.Join(segs, "/")
 }
 
 // buildAuthSignal harvests the framework-neutral Signal from an endpoint entity:

--- a/internal/mcp/auth_posture_diff_tool_test.go
+++ b/internal/mcp/auth_posture_diff_tool_test.go
@@ -168,6 +168,79 @@ func TestAuthPostureDiff_E2E_MissingArgs(t *testing.T) {
 	}
 }
 
+// Regression for #4550: the live upvate (DRF) ↔ upvate-v3 (NestJS) endpoint key
+// sets joined ZERO under the old auth_posture_diff key, while stub_detector
+// joined 420/446 on the SAME data. Two divergences made the old key never match:
+//
+//  1. api-prefix: DRF stamps /api/v1/... while NestJS stamps /v1/... — the old
+//     normalizeEndpointPath did NOT strip the /api[/vN] prefix.
+//  2. #action fold: the old key appended "#<action>" from the oracle's
+//     effective_action, but NestJS endpoints carry no action — so even when the
+//     paths lined up the suffix split the buckets.
+//
+// This fixture reproduces both: every oracle row is /api/v1/... + an
+// effective_action; every v3 row is /v1/... with NO action and a param-name
+// drift ({id} vs :id, dup handler names across resources). The shared join key
+// (endpoint_join.go) must produce a NON-TRIVIAL join. Under the old key this
+// asserted 0 (RED).
+func TestAuthPostureDiff_Regression4550_UpvateV3Join(t *testing.T) {
+	// DRF oracle: /api/v1 prefix, brace params, an effective_action per row.
+	oracle := []graph.Entity{
+		endpointEntity("o-list", "GET", "/api/v1/clients", map[string]string{
+			"auth_required": "true", "effective_action": "list",
+		}),
+		endpointEntity("o-retrieve", "GET", "/api/v1/clients/{id}", map[string]string{
+			"auth_required": "true", "effective_action": "retrieve",
+		}),
+		endpointEntity("o-approve", "POST", "/api/v1/clients/{id}/approve", map[string]string{
+			"auth_required": "true", "effective_action": "approve",
+		}),
+		// dup handler-name shape: a second resource with the same trailing verb.
+		endpointEntity("o-dev-list", "GET", "/api/v1/devices", map[string]string{
+			"auth_required": "true", "effective_action": "list",
+		}),
+		endpointEntity("o-dev-retrieve", "GET", "/api/v1/devices/{pk}", map[string]string{
+			"auth_required": "true", "effective_action": "retrieve",
+		}),
+	}
+	// NestJS v3: /v1 prefix (no /api), colon params, NO action stamped.
+	v3 := []graph.Entity{
+		endpointEntity("v-list", "GET", "/v1/clients", map[string]string{"auth_required": "true"}),
+		endpointEntity("v-retrieve", "GET", "/v1/clients/:id", map[string]string{"auth_required": "true"}),
+		endpointEntity("v-approve", "POST", "/v1/clients/:id/approve", map[string]string{"auth_required": "true"}),
+		endpointEntity("v-dev-list", "GET", "/v1/devices", map[string]string{"auth_required": "true"}),
+		endpointEntity("v-dev-retrieve", "GET", "/v1/devices/:id", map[string]string{"auth_required": "true"}),
+	}
+	s := twoGroupEndpointServer(t, oracle, v3)
+	out := callAuthPostureDiff(t, s, map[string]any{"group_oracle": "oracle", "group_v3": "v3"})
+
+	joined, _ := out["joined"].(float64)
+	if joined < 5 {
+		t.Fatalf("joined=%v, want all 5 oracle↔v3 pairs to join "+
+			"(api-prefix strip + no #action fold); RED=0 under the old key; out=%+v", joined, out)
+	}
+}
+
+// Regression for #4550: the shared endpoint join key must fold the DRF
+// /api/v1/... ↔ NestJS /v1/... prefix divergence and param-name drift to the
+// SAME bucket, and must NOT depend on an action suffix.
+func TestEndpointJoinKey_PrefixAndParamFold(t *testing.T) {
+	cases := []struct{ verb, oracle, v3 string }{
+		{"GET", "/api/v1/clients", "/v1/clients"},
+		{"GET", "/api/v1/clients/{id}", "/v1/clients/:id"},
+		{"POST", "/api/v1/clients/{id}/approve", "/v1/clients/:pk/approve"},
+		{"GET", "/api/v2/devices/<int:pk>", "/devices/{id}"},
+		{"GET", "/api/v1/clients/", "/v1/clients"}, // trailing slash fold
+	}
+	for _, c := range cases {
+		ok := newEndpointJoinKey(c.verb, c.oracle)
+		vk := newEndpointJoinKey(c.verb, c.v3)
+		if ok != vk {
+			t.Errorf("join keys differ: oracle %q→%+v vs v3 %q→%+v", c.oracle, ok, c.v3, vk)
+		}
+	}
+}
+
 // E2E: an unlinked oracle endpoint (no v3 counterpart) is simply omitted, not an
 // error — the join is inner.
 func TestAuthPostureDiff_E2E_UnlinkedOmitted(t *testing.T) {

--- a/internal/mcp/endpoint_join.go
+++ b/internal/mcp/endpoint_join.go
@@ -1,0 +1,125 @@
+// Shared cross-group HTTP endpoint join normalizer (#4550).
+//
+// The rewrite-parity tools (stub_detector, auth_posture_diff, and any future
+// oracle↔v3 endpoint-pairing tool) must join an oracle endpoint to its v3
+// counterpart on the SAME structural identity, or the join silently returns
+// nothing. Before this file each tool carried its OWN path normalizer and they
+// diverged: stub_detector stripped the /api[/vN] prefix and canonicalised
+// path-params to {*}, but auth_posture_diff did NOT strip the api-prefix and
+// additionally folded a DRF #action suffix into the key — so on the real
+// upvate (DRF /api/v1/...) ↔ upvate-v3 (NestJS /v1/...) groups its join matched
+// ZERO endpoints while stub_detector matched 420/446 on the same data.
+//
+// This is now the ONE normalizer both tools call. It mirrors the cross-repo
+// HTTP link pass canonicalisation (internal/links/http_pass.go
+// normalizePathForIndex + stripAPIPrefix) so MCP join keys bucket identically
+// to how the link resolver buckets route shapes:
+//
+//   - path-parameter segments ({id}, :id, <int:pk>, {pk}) → {*}
+//   - lower-cased
+//   - trailing slash folded
+//   - a leading /api[/vN] or /vN prefix stripped (so /api/v1/orders/{*} buckets
+//     with /v1/orders/{*} buckets with /orders/{*})
+//
+// Crucially it does NOT fold a framework-specific action suffix into the key:
+// the oracle (DRF) stamps an `action` while the v3 (NestJS) does not, so a
+// #action key never matched and was the proximate cause of the 0-join bug.
+package mcp
+
+import (
+	"regexp"
+	"strings"
+)
+
+// endpointPathParamRe / endpointAPIPrefixRe mirror the links-pass
+// canonicalisation. Kept here (not in the links package) to avoid widening that
+// package's API; the regexes are the literal source of truth for both the path
+// normalizer below and the join keys built on top of it.
+var (
+	endpointPathParamRe = regexp.MustCompile(`\{[^}]+\}|:[a-zA-Z][a-zA-Z0-9_]*|<[^>]+>`)
+	endpointAPIPrefixRe = regexp.MustCompile(`^/(?:api(?:/v\d+)?|v\d+)(/|$)`)
+)
+
+// endpointJoinKey is the normalized (method, path) identity used to match an
+// oracle endpoint to its v3 counterpart across groups. This is the single key
+// type both stub_detector and auth_posture_diff join on.
+type endpointJoinKey struct {
+	method string
+	path   string
+}
+
+// String renders the join key as "VERB /path" for display / map-string use.
+func (k endpointJoinKey) String() string {
+	return endpointLabel(k.method, k.path)
+}
+
+// normalizeEndpointJoinPath canonicalises an endpoint path for cross-group
+// joining: path-params → {*}, lower-cased, trailing slash folded, and a leading
+// /api[/vN] or /vN prefix stripped. This is the ONE path normalizer the
+// rewrite-parity endpoint join uses.
+func normalizeEndpointJoinPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	path = endpointPathParamRe.ReplaceAllString(path, "{*}")
+	path = strings.ToLower(path)
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+		if path == "" {
+			path = "/"
+		}
+	}
+	// Strip a leading /api[/vN] or /vN prefix so /api/v1/orders/{*} buckets with
+	// /orders/{*}.
+	if m := endpointAPIPrefixRe.FindStringSubmatchIndex(path); m != nil {
+		stripped := path[m[2]:]
+		if stripped == "" {
+			stripped = "/"
+		}
+		if !strings.HasPrefix(stripped, "/") {
+			stripped = "/" + stripped
+		}
+		path = stripped
+	}
+	return path
+}
+
+// newEndpointJoinKey builds a normalized join key from a raw verb + path.
+func newEndpointJoinKey(verb, path string) endpointJoinKey {
+	return endpointJoinKey{
+		method: strings.ToUpper(strings.TrimSpace(verb)),
+		path:   normalizeEndpointJoinPath(path),
+	}
+}
+
+// parseEndpointFilter parses a "GET /api/orders/{id}" filter into a normalized
+// join key. A bare path with no leading verb leaves method empty (matches any
+// method on that path).
+func parseEndpointFilter(raw string) endpointJoinKey {
+	raw = strings.TrimSpace(raw)
+	method := ""
+	path := raw
+	if fields := strings.Fields(raw); len(fields) == 2 {
+		method = strings.ToUpper(fields[0])
+		path = fields[1]
+	}
+	return newEndpointJoinKey(method, path)
+}
+
+// endpointLabel renders a human "VERB /path" label, falling back gracefully
+// when the verb or path is missing.
+func endpointLabel(method, path string) string {
+	method = strings.TrimSpace(method)
+	path = strings.TrimSpace(path)
+	switch {
+	case method != "" && path != "":
+		return method + " " + path
+	case path != "":
+		return path
+	case method != "":
+		return method
+	default:
+		return "(unknown endpoint)"
+	}
+}

--- a/internal/mcp/stub_detector_tool.go
+++ b/internal/mcp/stub_detector_tool.go
@@ -61,7 +61,6 @@ package mcp
 
 import (
 	"context"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -91,21 +90,9 @@ const (
 	stubEffectsMaxNodes = 1500
 )
 
-// stubPathParamRe / stubAPIPrefixRe mirror the links-pass canonicalisation
-// (internal/links/http_pass.go normalizePathForIndex + stripAPIPrefix) so the
-// oracle↔v3 join keys identically to how the cross-repo HTTP link pass buckets
-// route shapes. Kept local to avoid widening the links package API.
-var (
-	stubPathParamRe = regexp.MustCompile(`\{[^}]+\}|:[a-zA-Z][a-zA-Z0-9_]*|<[^>]+>`)
-	stubAPIPrefixRe = regexp.MustCompile(`^/(?:api(?:/v\d+)?|v\d+)(/|$)`)
-)
-
-// stubJoinKey is the normalized (method, path) identity used to match a v3
-// endpoint to its oracle counterpart.
-type stubJoinKey struct {
-	method string
-	path   string
-}
+// The oracle↔v3 endpoint join (normalized method+path, /api[/vN] prefix
+// stripped, path-params → {*}) lives in endpoint_join.go and is SHARED with
+// auth_posture_diff so the two tools join identically (#4550).
 
 // handleStubDetector implements archigraph_stub_detector.
 func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
@@ -125,7 +112,7 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 	}
 
 	// Optional single-endpoint filter — matched on the normalized join key.
-	var filter *stubJoinKey
+	var filter *endpointJoinKey
 	if raw := strings.TrimSpace(argString(req, "endpoint", "")); raw != "" {
 		k := parseEndpointFilter(raw)
 		filter = &k
@@ -167,7 +154,7 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 			}
 			method := strings.ToUpper(strings.TrimSpace(e.Properties["verb"]))
 			rawPath := e.Properties["path"]
-			key := stubJoinKey{method: method, path: normalizeStubPath(rawPath)}
+			key := newEndpointJoinKey(method, rawPath)
 			if filter != nil && (filter.method != key.method || filter.path != key.path) {
 				continue
 			}
@@ -408,8 +395,8 @@ func effectsForLocalEntity(
 // effects index for every endpoint definition in a group. Used to look up the
 // oracle counterpart of a v3 endpoint. When two oracle endpoints normalise to
 // the same key their effect kinds are unioned and Resolved OR-ed.
-func buildEndpointEffectsIndex(lg *LoadedGroup, sidecar map[string]effectsSidecarEntry, groupHasEffectData bool) map[stubJoinKey]stubdetector.Effects {
-	idx := map[stubJoinKey]stubdetector.Effects{}
+func buildEndpointEffectsIndex(lg *LoadedGroup, sidecar map[string]effectsSidecarEntry, groupHasEffectData bool) map[endpointJoinKey]stubdetector.Effects {
+	idx := map[endpointJoinKey]stubdetector.Effects{}
 	for _, r := range sortedRepos(lg) {
 		if r.Doc == nil {
 			continue
@@ -425,8 +412,7 @@ func buildEndpointEffectsIndex(lg *LoadedGroup, sidecar map[string]effectsSideca
 			if e.Properties["pattern_type"] == patternTypeHTTPEndpointClientSynthesis {
 				continue
 			}
-			method := strings.ToUpper(strings.TrimSpace(e.Properties["verb"]))
-			key := stubJoinKey{method: method, path: normalizeStubPath(e.Properties["path"])}
+			key := newEndpointJoinKey(e.Properties["verb"], e.Properties["path"])
 			eff := computeEndpointEffects(r.Repo, e, hres, callsAdj, byID, sidecar, groupHasEffectData)
 			if existing, ok := idx[key]; ok {
 				idx[key] = mergeStubEffects(existing, eff)
@@ -454,70 +440,6 @@ func mergeStubEffects(a, b stubdetector.Effects) stubdetector.Effects {
 	}
 	sort.Strings(kinds)
 	return stubdetector.Effects{Kinds: kinds, Resolved: a.Resolved || b.Resolved}
-}
-
-// normalizeStubPath canonicalises an endpoint path for cross-group joining:
-// path-params → {*}, lower-cased, trailing slash stripped, and a leading
-// /api[/vN] prefix removed. Mirrors links.normalizePathForIndex + stripAPIPrefix
-// so v3 and oracle route shapes bucket identically regardless of param names,
-// case, trailing-slash, or api-prefix convention.
-func normalizeStubPath(path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return ""
-	}
-	path = stubPathParamRe.ReplaceAllString(path, "{*}")
-	path = strings.ToLower(path)
-	if len(path) > 1 {
-		path = strings.TrimRight(path, "/")
-		if path == "" {
-			path = "/"
-		}
-	}
-	// Strip a leading /api[/vN] or /vN prefix so /api/v1/orders/{*} buckets with
-	// /orders/{*}.
-	if m := stubAPIPrefixRe.FindStringSubmatchIndex(path); m != nil {
-		stripped := path[m[2]:]
-		if stripped == "" {
-			stripped = "/"
-		}
-		if !strings.HasPrefix(stripped, "/") {
-			stripped = "/" + stripped
-		}
-		path = stripped
-	}
-	return path
-}
-
-// parseEndpointFilter parses a "GET /api/orders/{id}" filter into a normalized
-// join key. A bare path with no leading verb leaves method empty (matches any
-// method on that path).
-func parseEndpointFilter(raw string) stubJoinKey {
-	raw = strings.TrimSpace(raw)
-	method := ""
-	path := raw
-	if fields := strings.Fields(raw); len(fields) == 2 {
-		method = strings.ToUpper(fields[0])
-		path = fields[1]
-	}
-	return stubJoinKey{method: method, path: normalizeStubPath(path)}
-}
-
-// endpointLabel renders a human "VERB /path" label, falling back gracefully
-// when the verb or path is missing.
-func endpointLabel(method, path string) string {
-	method = strings.TrimSpace(method)
-	path = strings.TrimSpace(path)
-	switch {
-	case method != "" && path != "":
-		return method + " " + path
-	case path != "":
-		return path
-	case method != "":
-		return method
-	default:
-		return "(unknown endpoint)"
-	}
 }
 
 // sortedRepos returns a group's repos in deterministic slug order.


### PR DESCRIPTION
## The bug (#4550)

`archigraph_auth_posture_diff` joined **ZERO** endpoints live on `upvate` (DRF oracle) ↔ `upvate-v3` (NestJS) — returning `joined: 0, records: []` — even though `stub_detector` linked **420/446** on the *same* groups. The data joins fine; `auth_posture_diff`'s join-key normalization was broken.

Its endpoint-join key diverged from `stub_detector`'s working normalizer in two ways, each of which independently kills the match on real data:

1. **No `/api[/vN]` prefix strip** — DRF stamps `/api/v1/clients`, NestJS stamps `/v1/clients`; the old `normalizeEndpointPath` left the prefix intact so the two never bucketed together.
2. **`#<action>` fold** — the old `authEndpointKey` appended `#<effective_action>` from the oracle. NestJS endpoints carry no action, so even when paths aligned the suffix split the buckets.

## The fix

Factor the cross-group endpoint join into **one shared normalizer**, `internal/mcp/endpoint_join.go`:

- normalized **method + path**
- path-params (`{id}`, `:id`, `<int:pk>`) → `{*}`
- lower-cased, trailing-slash folded
- leading `/api[/vN]` or `/vN` prefix stripped

This is the same canonicalisation the cross-repo HTTP link pass uses. Both `stub_detector` and `auth_posture_diff` now join through it, so they can never drift again. The old per-tool `normalizeStubPath` / `stubJoinKey` / `parseEndpointFilter` / `endpointLabel` (stub_detector) and `authEndpointKey` / `normalizeEndpointPath` (auth_posture_diff) are deleted in favour of the shared `newEndpointJoinKey`. `literal_parity` joins on value-set names, not endpoints, so it is unaffected.

## Regression test

`TestAuthPostureDiff_Regression4550_UpvateV3Join` reproduces the real shape: DRF `/api/v1/...` rows with `effective_action` vs NestJS `/v1/...` rows with no action, `{id}`↔`:id` param drift, and duplicate handler names across resources. It asserts a non-trivial join. Verified **RED** under the old key (`joined=0, records=[]`, confirmed by temporarily reinstating the `#action` fold) and **GREEN** after the fix. `TestEndpointJoinKey_PrefixAndParamFold` locks the prefix/param folding directly.

## Gates

`go build ./...` ✅  ·  `go vet ./internal/mcp/...` ✅  ·  `go test ./internal/mcp/...` ✅ (`ok ... 284s`)

> NOTE: Live cross-graph confirmation via the MCP `auth_posture_diff` tool needs a daemon rebuild + reindex of both groups — **DEPLOY-DEFERRED**, flagged for coordinator. No deploy in this PR.

Closes #4550

🤖 Generated with [Claude Code](https://claude.com/claude-code)