### PR TITLE
fix(authposture): decode EFFECTIVE NestJS guard, not collapse to authenticated (#4667)

### DIFF
--- a/internal/authposture/authposture_test.go
+++ b/internal/authposture/authposture_test.go
@@ -289,3 +289,98 @@ func TestE2E_OraclePageVsV3RequirePage_Equivalent(t *testing.T) {
 		t.Fatalf("verdict=%s detail=%s, want equivalent (page client_admin ~ client-admin)", d.Verdict, d.Detail)
 	}
 }
+
+// --- #4667: EFFECTIVE-guard decode from the engine-stamped auth_guard ---------
+//
+// The engine stamps the most-specific (handler ▸ class ▸ global) guard's
+// decorator text into the auth_guard property — e.g.
+// `@RequirePage(PermissionPage.Buildings)` for a per-handler @RequirePage, or
+// the inherited class guard for a handler with no override. The resolver MUST
+// decode that decorator's page/action literal, NOT collapse every guard to
+// authenticated (the bug that produced false NO-AUTH/looser verdicts).
+
+// (A) per-handler @RequirePage with NO class guard → page grant, not authenticated.
+func TestNest_EffectiveGuard_HandlerPage_NoClassGuard(t *testing.T) {
+	reg := NewRegistry()
+	p, fw := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "nestjs", "auth_required": "true", "auth_method": "guard",
+		"auth_guard": "@RequirePage(PermissionPage.Buildings)",
+	}})
+	if fw != "nestjs" {
+		t.Fatalf("framework=%s, want nestjs", fw)
+	}
+	if p.Kind != KindPage || p.Literal != "Buildings" {
+		t.Fatalf("got %s/%q, want page/Buildings (handler guard must not collapse to authenticated)", p.Kind, p.Literal)
+	}
+}
+
+// @RequireAction enum-form decode.
+func TestNest_EffectiveGuard_HandlerAction(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "nestjs", "auth_required": "true", "auth_method": "guard",
+		"auth_guard": "@RequireAction(PermissionAction.Lite)",
+	}})
+	if p.Kind != KindAction || p.Literal != "Lite" {
+		t.Fatalf("got %s/%q, want action/Lite", p.Kind, p.Literal)
+	}
+}
+
+// (B) handler @RequirePage(ContractProposals) OVERRIDES class @RequirePage(Clients):
+// the engine stamps the EFFECTIVE (handler) guard into auth_guard, so the
+// resolver decodes ContractProposals — while a sibling that inherits the class
+// guard decodes Clients.
+func TestNest_EffectiveGuard_HandlerOverridesClass(t *testing.T) {
+	reg := NewRegistry()
+	over, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "nestjs", "auth_required": "true", "auth_method": "guard",
+		"auth_guard": "@RequirePage(PermissionPage.ContractProposals)",
+	}})
+	if over.Kind != KindPage || over.Literal != "ContractProposals" {
+		t.Fatalf("override: got %s/%q, want page/ContractProposals (handler wins)", over.Kind, over.Literal)
+	}
+	sib, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "nestjs", "auth_required": "true", "auth_method": "guard",
+		"auth_guard": "@RequirePage(PermissionPage.Clients)",
+	}})
+	if sib.Kind != KindPage || sib.Literal != "Clients" {
+		t.Fatalf("sibling: got %s/%q, want page/Clients (inherited class guard)", sib.Kind, sib.Literal)
+	}
+}
+
+// A page-guarded NestJS handler vs a Django page oracle is EQUIVALENT — the
+// pre-fix collapse to authenticated made this a FALSE looser (RBAC false alarm).
+func TestNest_EffectiveGuard_PageVsOraclePage_Equivalent(t *testing.T) {
+	reg := NewRegistry()
+	oracle, _ := reg.Resolve(Signal{
+		Props: map[string]string{"has_get_permissions": "true"}, Source: clientViewSetGetPerms, Action: "approve",
+	}) // → page client_admin
+	v3, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "nestjs", "auth_required": "true", "auth_guard": "@RequirePage(PermissionPage.client_admin)",
+	}})
+	if d := Diff(v3, oracle); d.Verdict != VerdictEquivalent {
+		t.Fatalf("verdict=%s detail=%s, want equivalent (both page client_admin)", d.Verdict, d.Detail)
+	}
+}
+
+// Authenticated-only guard (@AuthenticatedOrInternalKey) decodes to authenticated.
+func TestNest_EffectiveGuard_AuthenticatedOnly(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "nestjs", "auth_required": "true", "auth_guard": "@AuthenticatedOrInternalKey()",
+	}})
+	if p.Kind != KindAuthenticated {
+		t.Fatalf("got %s, want authenticated", p.Kind)
+	}
+}
+
+// Engine explicit public verdict (@Public → auth_required=false, no guard).
+func TestNest_EffectiveGuard_ExplicitPublic(t *testing.T) {
+	reg := NewRegistry()
+	p, fw := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "nestjs", "auth_required": "false", "auth_method": "config",
+	}})
+	if fw != "nestjs" || p.Kind != KindPublic {
+		t.Fatalf("got %s/%s, want nestjs/public", fw, p.Kind)
+	}
+}

--- a/internal/authposture/nestjs.go
+++ b/internal/authposture/nestjs.go
@@ -42,7 +42,68 @@ var (
 	requireSuperuserRe  = regexp.MustCompile(`@RequireSuperuser\s*\(`)
 	publicDecoratorRe   = regexp.MustCompile(`@Public\s*\(`)
 	authenticatedDecoRe = regexp.MustCompile(`@Authenticated\s*\(|@UseGuards\s*\(`)
+
+	// guardArgRe captures the FIRST argument of an engine-stamped guard decorator
+	// such as `@RequirePage(PermissionPage.Buildings)` or
+	// `@RequireAction(PermissionAction.Lite)`. The arg is frequently a TS enum
+	// member (PermissionPage.Buildings), not a quoted literal, so this matches the
+	// identifier/enum form too — the quoted-literal regexes above only fire on the
+	// raw-source fallback path where decorators carry string literals.
+	guardPageArgRe   = regexp.MustCompile(`@Require(?:Any)?Page\s*\(\s*([^,)]+)`)
+	guardActionArgRe = regexp.MustCompile(`@RequireAction\s*\(\s*([^,)]+)`)
 )
+
+// guardLiteral normalises an engine-stamped guard argument into the shared
+// posture literal. For an enum member (`PermissionPage.Buildings`) the literal
+// is the member name (`Buildings`); for a quoted/bare slug it is the slug as
+// written. This is what the diff core compares (after NormalizeKey) against the
+// Django page/action slug, so an enum member and the Django slug it mirrors
+// align under separator/case folding.
+func guardLiteral(arg string) string {
+	arg = strings.TrimSpace(arg)
+	arg = strings.Trim(arg, `"'`+"`")
+	if i := strings.LastIndexByte(arg, '.'); i >= 0 {
+		arg = arg[i+1:]
+	}
+	return strings.TrimSpace(arg)
+}
+
+// resolveEffectiveGuard decodes the EFFECTIVE guard the ENGINE already resolved
+// for this endpoint (handler method-decorator ▸ class controller-decorator ▸
+// global APP_GUARD — the engine stamps the most-specific winner into auth_guard
+// per `Reflector.getAllAndOverride([handler, class])`). The resolver's job here
+// is ONLY to decode that already-effective decorator text into the shared
+// {Kind, Literal} vocabulary — it must NOT re-collapse a per-handler
+// @RequirePage/@RequireAction down to plain authenticated (the #4667 bug: the
+// resolver ignored auth_guard's decorator text and every page/action grant fell
+// through to KindAuthenticated, masking RBAC drift against the Django oracle).
+func resolveEffectiveGuard(sig Signal) (Posture, bool) {
+	guard := sig.prop("auth_guard")
+	if guard == "" {
+		return Posture{}, false
+	}
+	// Tightest grant first, matching the property/source priority order.
+	if requireSuperuserRe.MatchString(guard) {
+		return Posture{Kind: KindSuperuser, Detail: "auth_guard=" + guard}, true
+	}
+	if m := guardPageArgRe.FindStringSubmatch(guard); m != nil {
+		if lit := guardLiteral(m[1]); lit != "" {
+			return Posture{Kind: KindPage, Literal: lit, Detail: "auth_guard=" + guard}, true
+		}
+	}
+	if m := guardActionArgRe.FindStringSubmatch(guard); m != nil {
+		if lit := guardLiteral(m[1]); lit != "" {
+			return Posture{Kind: KindAction, Literal: lit, Detail: "auth_guard=" + guard}, true
+		}
+	}
+	if m := requireRoleRe.FindStringSubmatch(guard); m != nil {
+		return Posture{Kind: KindRole, Literal: m[1], Detail: "auth_guard=" + guard}, true
+	}
+	// A recognised guard with no decodable page/action/role literal (e.g.
+	// @Authenticated(), @AuthenticatedOrInternalKey(), @UseGuards(JwtGuard)) is an
+	// authenticated-only gate.
+	return Posture{Kind: KindAuthenticated, Detail: "auth_guard=" + guard}, true
+}
 
 // Resolve decodes a NestJS auth signal. Recognises the framework when the entity
 // carries any Nest auth property OR Nest @Require*/@Public/@UseGuards decorators
@@ -79,8 +140,22 @@ func (n nestJSResolver) Resolve(sig Signal) (Posture, bool) {
 	if sig.prop("is_public") == "true" {
 		return Posture{Kind: KindPublic, Detail: "@Public (reconciled prop)"}, true
 	}
-	if sig.prop("auth_required") == "true" || sig.prop("auth_guard") != "" {
-		return Posture{Kind: KindAuthenticated, Detail: "auth_required guard=" + sig.prop("auth_guard")}, true
+	// Explicit public verdict from the engine (@Public()/@AllowAnonymous → the
+	// metadata pass stamps auth_required=false with no guard). Must win over the
+	// authenticated fallback so a deliberately-public handler is not mislabelled.
+	if sig.prop("auth_required") == "false" && sig.prop("auth_guard") == "" {
+		return Posture{Kind: KindPublic, Detail: "auth_required=false (engine public verdict)"}, true
+	}
+	// (1b) EFFECTIVE guard decode (#4667). The engine already resolved the
+	// most-specific guard (handler ▸ class ▸ global) and stamped the winning
+	// decorator text into auth_guard. Decode its page/action/role/superuser
+	// literal here — DO NOT collapse a per-handler @RequirePage/@RequireAction to
+	// plain authenticated (that downgrade masked RBAC drift vs the Django oracle).
+	if p, ok := resolveEffectiveGuard(sig); ok {
+		return p, true
+	}
+	if sig.prop("auth_required") == "true" {
+		return Posture{Kind: KindAuthenticated, Detail: "auth_required=true (no decodable guard literal)"}, true
 	}
 
 	// (2) Source-decorator fallback — same priority order.


### PR DESCRIPTION
## Problem
The NestJS auth-posture resolver (`internal/authposture/nestjs.go`) read reconciled `@Require*` props (`require_page`/`require_action`/`is_public`) that **the engine never stamps**, then fell through to a generic `auth_required==true || auth_guard != ""` branch that returned `KindAuthenticated` for **every** guarded endpoint. The engine had already correctly resolved the EFFECTIVE guard (handler ▸ class ▸ global, via `Reflector.getAllAndOverride([handler, class])`) into the `auth_guard` decorator text — but the resolver ignored it and collapsed every per-handler `@RequirePage(X)`/`@RequireAction(Y)` down to authenticated-only.

Against the Django page/action oracle this surfaced as a **false `looser` RBAC-drift verdict** (or masked real drift) on all per-handler-guarded endpoints (buildings, DELETEs) and any handler overriding its class guard (clients/contracts). This is the single highest-leverage fix for #4422.

## Fix
`resolveEffectiveGuard` decodes the engine-stamped `auth_guard` decorator text — most-specific-wins precedence is already baked in by the engine (handler method-decorator ▸ class controller-decorator ▸ global APP_GUARD). It parses `@RequireSuperuser` / `@Require[Any]Page` / `@RequireAction` / `@Roles` out of `auth_guard`, **including the TS enum-member arg form** (`PermissionPage.Buildings` → literal `Buildings`), and only falls to authenticated when no page/action/role literal is decodable. An explicit engine public verdict (`auth_required=false`, no guard) → `KindPublic`.

Scope: the per-group resolver only. **No edit to `auth_posture_diff_tool.go`** (the cross-group JOIN owned by #4550). Engine precedence + the handler-locator regex were already correct (`http_endpoint_jsts_auth.go`); this PR fixes the resolver that was discarding the engine's result.

## Regressions covered (`authposture_test.go`)
- **(A)** per-handler `@RequirePage` with NO class guard → page grant, not authenticated/NO-AUTH.
- **(B)** handler `@RequirePage(ContractProposals)` overriding class `@RequirePage(Clients)` → `ContractProposals`; sibling inheriting the class guard → `Clients`.
- enum-form `@RequireAction`, page-vs-oracle-page **EQUIVALENT** (the false-`looser` fix), authenticated-only `@AuthenticatedOrInternalKey`, explicit `@Public`.

## Generalization (epic #4419)
method ▸ class ▸ global precedence applies to Spring (`@PreAuthorize` method vs class) and DRF (`@action(permission_classes=...)` vs class). Filed with concrete decode rules:
- #4674 — Spring resolver effective-guard precedence
- #4675 — DRF resolver method-level `permission_classes` precedence

## Gates
`go build ./...` ✅ · `go vet` ✅ · `go test ./internal/authposture/... ./internal/dashboard/... ./internal/engine/...` ✅ (all green). Live confirmation deferred to coordinator (no deploy).

Closes #4667

🤖 Generated with [Claude Code](https://claude.com/claude-code)