### PR TITLE
fix(jsts): type local-variable receivers → controller-unit specs credit coverage (#4671)

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -400,6 +400,21 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	// platform-variant pass so the file entity already exists.
 	x.emitMobileNavigationSignals(root)
 
+	// Issue #4671 — module-level test-scope owner. Jest/Vitest/Mocha specs
+	// place their test logic in arrow callbacks passed to module-level
+	// `describe()` / `it()` / `test()` calls; those callbacks are NOT named
+	// function/method/const entities, so walk() never ran
+	// extractCallRelationships over them and the `controller.getCounts()`
+	// calls inside had no owning entity to carry the CALLS edge. Emit ONE
+	// SCOPE.Operation test-scope entity per test file that owns every call
+	// reachable from the module body (after local-variable receiver typing),
+	// so emitTestsEdgesForTestFile (below) can promote the resolved
+	// structural-ref CALLS edges into TESTS edges and ComputeCoverage can
+	// credit the handler via the test→CALLS→handler path. No-op for
+	// non-test files (cheap filename check) and for test files whose module
+	// body holds no calls.
+	x.emitTestScopeOwner(root)
+
 	// Fourth pass (#1726): per-operation TESTS edges. For files identified
 	// as JS/TS test files (*.test.{ts,tsx,js,jsx,mjs,cjs},
 	// *.spec.{...}, __tests__/, tests/), reclassify each CALLS edge from
@@ -2349,6 +2364,21 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 		return nil
 	}
 	calls := findAllNodes(body, "call_expression", "new_expression")
+	// Issue #4671 — local-variable receiver typing. Unit/controller specs
+	// (the dominant test mechanism in NestJS-style codebases) construct the
+	// subject under test as a LOCAL variable —
+	//   const c = new ProposalController(mockSvc);
+	//   const svc = module.get(ProposalService);
+	// — then call `c.getCounts(...)`. The class-field/param frame built by
+	// the caller does NOT type these locals, so `receiverTypedTarget` misses
+	// and `c.method()` only ever emitted a bare, unresolvable leaf (no
+	// test→handler CALLS edge → ComputeCoverage undercount). Fold the
+	// discovered `localName → Class` bindings into a derived frame so
+	// member-expression calls on those locals type-resolve to the imported
+	// class's method (Format A structural ref). Append-only: the caller's
+	// frame is never mutated; same-named fields/params (a closer binding)
+	// win over locals.
+	frame = x.withLocalReceiverTypes(body, frame)
 	// Issue #2671 — JSX navigation components (<Link>, <NavLink>, <Navigate>,
 	// <Redirect>, next/link's <Link href=...>) are emitted from any body that
 	// renders them; they do not depend on a call_expression being present.

--- a/internal/extractors/javascript/issue4671_localvar_receiver_test.go
+++ b/internal/extractors/javascript/issue4671_localvar_receiver_test.go
@@ -1,0 +1,240 @@
+// Package javascript — unit tests for issue #4671 (local-variable receiver
+// typing → test→handler CALLS edge → coverage crediting).
+//
+// Live root cause (proven on upvate-v3): the TS call resolver typed
+// `this.<field>.method()` (DI fields) and bare typed params, but NOT a
+// LOCAL variable bound from `new XController()` / NestJS `module.get(X)`.
+// Controller-unit specs are dominated by that local form —
+//
+//	const controller = new ProposalController(mockSvc);
+//	describe('ProposalController', () => {
+//	  it('counts', () => { const r = controller.getCounts('2025'); });
+//	});
+//
+// — so `controller.getCounts()` never bound to the handler, no test→handler
+// CALLS edge was emitted, and ComputeCoverage undercounted ~4x (18% vs the
+// real ~80%). These fixtures mirror the live shape EXACTLY and assert the
+// structural-ref CALLS edge is now emitted (the prior four coverage fixes
+// passed their fixtures but moved the live number by zero — these assert the
+// actual missing edge).
+package javascript_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+)
+
+// hasStructuralCallTo reports whether ANY extracted entity carries a CALLS
+// (or TESTS) relationship whose ToID is a Format A structural ref ending in
+// `:<method>` and naming `<file>` in the resolved path. We match on the
+// structural-ref shape rather than an exact file hash because the relative
+// import resolver normalizes the path; the load-bearing facts are (a) the
+// edge is a resolvable structural ref (contains ':'), not a bare leaf, and
+// (b) it targets the right method on the right source file.
+func hasStructuralCallTo(ents []entityRec4671, method, fileHint string) (string, bool) {
+	want := "scope:operation:method:typescript:"
+	for _, e := range ents {
+		for _, r := range e.rels {
+			if r.kind != "CALLS" && r.kind != "TESTS" {
+				continue
+			}
+			if !strings.HasPrefix(r.toID, want) {
+				continue
+			}
+			if !strings.HasSuffix(r.toID, ":"+method) {
+				continue
+			}
+			if fileHint != "" && !strings.Contains(r.toID, fileHint) {
+				continue
+			}
+			return r.toID, true
+		}
+	}
+	return "", false
+}
+
+type relRec4671 struct {
+	kind string
+	toID string
+}
+
+type entityRec4671 struct {
+	name string
+	kind string
+	rels []relRec4671
+}
+
+func extractTS4671(t *testing.T, src []byte, path string) []entityRec4671 {
+	t.Helper()
+	tree := parseTS(t, src)
+	ext := javascript.New()
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  src,
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	out := make([]entityRec4671, 0, len(ents))
+	for i := range ents {
+		rr := make([]relRec4671, 0, len(ents[i].Relationships))
+		for _, r := range ents[i].Relationships {
+			rr = append(rr, relRec4671{kind: r.Kind, toID: r.ToID})
+		}
+		out = append(out, entityRec4671{name: ents[i].Name, kind: ents[i].Kind, rels: rr})
+	}
+
+	return out
+}
+
+// TestLocalVarReceiver_NewExpression is the exact-mirror fixture from the
+// live root cause: a controller-unit spec that constructs the controller as
+// a local `const` and calls a handler method on it. After the fix the call
+// must resolve to a structural ref on the controller's source file (and be
+// promoted into a TESTS edge by emitTestsEdgesForTestFile).
+func TestLocalVarReceiver_NewExpression(t *testing.T) {
+	src := []byte(`
+import { ProposalController } from './proposal.controller';
+import { ProposalService } from './proposal.service';
+
+describe('ProposalController', () => {
+  it('returns counts', () => {
+    const mockSvc = {} as ProposalService;
+    const controller = new ProposalController(mockSvc);
+    const r = controller.getCounts('2025');
+    expect(r).toBeDefined();
+  });
+});
+`)
+	ents := extractTS4671(t, src, "src/proposal/proposal.controller.spec.ts")
+
+	toID, ok := hasStructuralCallTo(ents, "getCounts", "proposal.controller")
+	if !ok {
+		t.Fatalf("expected a structural-ref CALLS/TESTS edge to getCounts on proposal.controller; got entities:\n%s", dump4671(ents))
+	}
+	if !strings.HasSuffix(toID, ":getCounts") {
+		t.Errorf("structural ref %q does not target getCounts", toID)
+	}
+}
+
+// TestLocalVarReceiver_NestDIGet mirrors the NestJS Test.createTestingModule
+// flow: the subject is resolved from the DI container via module.get(Class)
+// rather than constructed directly. Same outcome required.
+func TestLocalVarReceiver_NestDIGet(t *testing.T) {
+	src := []byte(`
+import { Test } from '@nestjs/testing';
+import { ProposalController } from './proposal.controller';
+import { ProposalService } from './proposal.service';
+
+describe('ProposalController', () => {
+  it('counts via DI', async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ProposalController],
+      providers: [ProposalService],
+    }).compile();
+    const controller = moduleRef.get(ProposalController);
+    const r = controller.getCounts('2025');
+    expect(r).toBeDefined();
+  });
+});
+`)
+	ents := extractTS4671(t, src, "src/proposal/proposal.controller.spec.ts")
+
+	if _, ok := hasStructuralCallTo(ents, "getCounts", "proposal.controller"); !ok {
+		t.Fatalf("expected a structural-ref CALLS/TESTS edge to getCounts via module.get(ProposalController); got entities:\n%s", dump4671(ents))
+	}
+}
+
+// TestLocalVarReceiver_DIResolve covers request-scoped DI (`.resolve`) and an
+// awaited resolution, which the binder unwraps.
+func TestLocalVarReceiver_DIResolve(t *testing.T) {
+	src := []byte(`
+import { ProposalService } from './proposal.service';
+
+describe('ProposalService', () => {
+  it('lists', async () => {
+    const svc = await moduleRef.resolve(ProposalService);
+    const out = svc.findAll();
+    expect(out).toBeDefined();
+  });
+});
+`)
+	ents := extractTS4671(t, src, "src/proposal/proposal.service.spec.ts")
+
+	if _, ok := hasStructuralCallTo(ents, "findAll", "proposal.service"); !ok {
+		t.Fatalf("expected a structural-ref CALLS/TESTS edge to findAll via moduleRef.resolve(ProposalService); got entities:\n%s", dump4671(ents))
+	}
+}
+
+// TestLocalVarReceiver_StringTokenNotTyped is a NEGATIVE control: DI by a
+// string token (`module.get('CACHE')`) names no class identifier, so the
+// receiver must NOT be typed (no structural ref). The call falls back to the
+// bare leaf, exactly as before — we must not invent a binding.
+func TestLocalVarReceiver_StringTokenNotTyped(t *testing.T) {
+	src := []byte(`
+import { ProposalController } from './proposal.controller';
+
+describe('tokens', () => {
+  it('string DI token is opaque', () => {
+    const cache = moduleRef.get('CACHE_MANAGER');
+    const v = cache.getCounts('2025');
+    expect(v).toBeDefined();
+  });
+});
+`)
+	ents := extractTS4671(t, src, "src/proposal/cache.spec.ts")
+
+	if toID, ok := hasStructuralCallTo(ents, "getCounts", "proposal.controller"); ok {
+		t.Errorf("string DI token must not type the receiver, but got structural ref %q", toID)
+	}
+}
+
+// TestLocalVarReceiver_ExternalImportNotTyped is a NEGATIVE control: when the
+// constructed class is imported from an EXTERNAL package (no relative file),
+// the receiver binder finds no resolvedFile and must fall back to the bare
+// leaf — never a structural ref to a non-existent local file.
+func TestLocalVarReceiver_ExternalImportNotTyped(t *testing.T) {
+	src := []byte(`
+import { Repository } from 'typeorm';
+
+describe('external', () => {
+  it('does not bind external constructors', () => {
+    const repo = new Repository();
+    const x = repo.findOneBy({ id: 1 });
+    expect(x).toBeDefined();
+  });
+});
+`)
+	ents := extractTS4671(t, src, "src/proposal/repo.spec.ts")
+
+	if toID, ok := hasStructuralCallTo(ents, "findOneBy", ""); ok {
+		t.Errorf("external (typeorm) constructor must not produce a local structural ref, but got %q", toID)
+	}
+}
+
+func dump4671(ents []entityRec4671) string {
+	var b strings.Builder
+	for _, e := range ents {
+		b.WriteString("- ")
+		b.WriteString(e.kind)
+		b.WriteString(" ")
+		b.WriteString(e.name)
+		b.WriteString("\n")
+		for _, r := range e.rels {
+			if r.kind == "CALLS" || r.kind == "TESTS" {
+				b.WriteString("    ")
+				b.WriteString(r.kind)
+				b.WriteString(" -> ")
+				b.WriteString(r.toID)
+				b.WriteString("\n")
+			}
+		}
+	}
+	return b.String()
+}

--- a/internal/extractors/javascript/receiver.go
+++ b/internal/extractors/javascript/receiver.go
@@ -22,6 +22,231 @@ import (
 	extreg "github.com/cajasmota/archigraph/internal/extractor"
 )
 
+// withLocalReceiverTypes returns a classBindings frame that augments the
+// supplied base frame with local-variable receiver types discovered inside
+// `body`. It scans every `variable_declarator` reachable from the body for
+// the two construction idioms that bind a local to a concrete, imported
+// class (issue #4671):
+//
+//	const c = new ProposalController(mockSvc);   // direct construction
+//	const svc = module.get(ProposalService);     // NestJS DI resolution
+//	const svc = app.get(ProposalService);        //   (Test.createTestingModule…)
+//	const svc = app.resolve(ProposalService);    //   (request-scoped DI)
+//
+// For each match it records `localName → ClassName` so that a subsequent
+// `localName.method()` call types through `receiverTypedTarget` →
+// `importByLocal[ClassName]` → a Format A structural ref keyed on the
+// class's source file. Unit/controller specs are dominated by this local
+// form, so without it their `controller.method()` calls never bind to the
+// handler and ComputeCoverage undercounts test coverage ~4x.
+//
+// Precedence: the base frame (enclosing-class fields + the caller's typed
+// parameters) is the CLOSER binding and always wins. A local only fills a
+// name the base frame does not already type. When `base` is nil and no
+// locals are found, the base frame is returned unchanged (nil) so the hot
+// path for non-test, no-local bodies allocates nothing.
+//
+// The frame is append-only: `base` is never mutated. When at least one
+// local is discovered we copy `base` into a fresh frame first.
+func (x *extractor) withLocalReceiverTypes(body *sitter.Node, base *classBindings) *classBindings {
+	if body == nil {
+		return base
+	}
+	decls := findAllNodes(body, "variable_declarator")
+	if len(decls) == 0 {
+		return base
+	}
+	var locals map[string]string
+	for _, d := range decls {
+		name, typeName := x.localReceiverBinding(d)
+		if name == "" || typeName == "" {
+			continue
+		}
+		// The base frame is the closer binding (a class field or the
+		// caller's own typed parameter) — never let a local shadow it.
+		if base != nil {
+			if _, taken := base.fields[name]; taken {
+				continue
+			}
+		}
+		if locals == nil {
+			locals = map[string]string{}
+		}
+		// First declaration wins on a re-`let` collision — a conservative
+		// bias matching the rest of the receiver binder (better to miss
+		// than to mis-bind to a later reassignment of a different type).
+		if _, seen := locals[name]; !seen {
+			locals[name] = typeName
+		}
+	}
+	if len(locals) == 0 {
+		return base
+	}
+	frame := &classBindings{fields: map[string]string{}}
+	if base != nil {
+		frame.className = base.className
+		for k, v := range base.fields {
+			frame.fields[k] = v
+		}
+	}
+	for k, v := range locals {
+		if _, taken := frame.fields[k]; !taken {
+			frame.fields[k] = v
+		}
+	}
+	return frame
+}
+
+// localReceiverBinding inspects a `variable_declarator` node and returns
+// the (localName, className) pair when the declarator binds a single
+// identifier to a recognised class-construction idiom. Returns ("", "")
+// for any other shape (destructuring LHS, non-construction RHS, dynamic
+// class expression, …) so the caller skips it.
+//
+// Recognised RHS shapes:
+//
+//   - `new ClassName(...)`            — new_expression, constructor is a
+//     bare (type_)identifier.
+//   - `module.get(ClassName)` /
+//     `app.get(ClassName)` /
+//     `<x>.resolve(ClassName)`        — NestJS DI resolution: a member call
+//     whose method is get/resolve and whose
+//     sole argument is a class identifier.
+func (x *extractor) localReceiverBinding(decl *sitter.Node) (string, string) {
+	if decl == nil {
+		return "", ""
+	}
+	nameNode := decl.ChildByFieldName("name")
+	if nameNode == nil || nameNode.Type() != "identifier" {
+		// Destructuring / array patterns don't name a single receiver.
+		return "", ""
+	}
+	value := decl.ChildByFieldName("value")
+	if value == nil {
+		return "", ""
+	}
+	name := x.nodeText(nameNode)
+	if name == "" {
+		return "", ""
+	}
+	typeName := x.constructedTypeName(value)
+	if typeName == "" {
+		return "", ""
+	}
+	return name, typeName
+}
+
+// constructedTypeName returns the class identifier produced by a
+// construction expression, or "" when `value` is not a recognised
+// construction idiom. Handles `new ClassName(...)` and the NestJS DI
+// `<container>.get(ClassName)` / `.resolve(ClassName)` shapes. Awaited DI
+// (`await module.resolve(X)`) is unwrapped first.
+func (x *extractor) constructedTypeName(value *sitter.Node) string {
+	if value == nil {
+		return ""
+	}
+	switch value.Type() {
+	case "await_expression":
+		// `const svc = await module.resolve(X)` — unwrap and recurse.
+		count := int(value.ChildCount())
+		for i := 0; i < count; i++ {
+			ch := value.Child(i)
+			if ch == nil || ch.Type() == "await" {
+				continue
+			}
+			return x.constructedTypeName(ch)
+		}
+		return ""
+	case "new_expression":
+		// constructor field holds the class being instantiated.
+		ctor := value.ChildByFieldName("constructor")
+		if ctor == nil {
+			return ""
+		}
+		switch ctor.Type() {
+		case "identifier", "type_identifier":
+			return x.nodeText(ctor)
+		case "member_expression":
+			// `new ns.ClassName()` — bind to the trailing class name. The
+			// receiver binder resolves via importByLocal on the leaf, so a
+			// namespaced constructor still types when its leaf was imported.
+			prop := ctor.ChildByFieldName("property")
+			if prop != nil {
+				return x.nodeText(prop)
+			}
+		}
+		return ""
+	case "call_expression":
+		return x.diResolvedTypeName(value)
+	}
+	return ""
+}
+
+// diResolvedTypeName recognises NestJS-style dependency resolution calls
+// and returns the resolved class identifier:
+//
+//	module.get(ProposalService)        → "ProposalService"
+//	app.get(ProposalController)        → "ProposalController"
+//	moduleRef.resolve(RequestScopedSvc)→ "RequestScopedSvc"
+//
+// The call must be a member expression whose method is `get` or `resolve`
+// and whose sole argument is a bare class identifier (the DI token form
+// `module.get('TOKEN')` / `module.get<T>(SYMBOL)` with a string/symbol
+// token is intentionally NOT typed — there is no class identifier to bind).
+// Returns "" for any other call shape so non-DI calls (e.g. array.get(0))
+// are ignored.
+func (x *extractor) diResolvedTypeName(call *sitter.Node) string {
+	if call == nil {
+		return ""
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_expression" {
+		return ""
+	}
+	prop := fn.ChildByFieldName("property")
+	if prop == nil {
+		return ""
+	}
+	switch x.nodeText(prop) {
+	case "get", "resolve":
+	default:
+		return ""
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	// Find the single positional class-identifier argument. More than one
+	// positional argument, or a non-identifier first argument (string DI
+	// token, options object), disqualifies the binding.
+	var typeArg *sitter.Node
+	posCount := 0
+	count := int(args.ChildCount())
+	for i := 0; i < count; i++ {
+		a := args.Child(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "(", ")", ",", "comment":
+			continue
+		}
+		posCount++
+		if posCount > 1 {
+			return ""
+		}
+		typeArg = a
+	}
+	if typeArg == nil {
+		return ""
+	}
+	switch typeArg.Type() {
+	case "identifier", "type_identifier":
+		return x.nodeText(typeArg)
+	}
+	return ""
+}
+
 // receiverTypedTarget resolves a member_expression call (`<recv>.<method>`)
 // to a structural-ref CALLS target when the receiver types through the
 // supplied frame and the type is imported from a relative path. Returns

--- a/internal/extractors/javascript/tests.go
+++ b/internal/extractors/javascript/tests.go
@@ -54,8 +54,172 @@ import (
 	"path/filepath"
 	"strings"
 
+	sitter "github.com/smacker/go-tree-sitter"
+
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// testBlockCallNames is the set of test-framework block functions whose
+// arrow/function callback body hosts spec logic. A module-level call to one
+// of these (describe/it/test/...) is the owner-less call site issue #4671
+// addresses: its callback is not a named entity, so walk() never ran the
+// call-relationship extractor over it.
+var testBlockCallNames = map[string]bool{
+	"describe": true, "it": true, "test": true, "suite": true, "context": true,
+	"beforeeach": true, "beforeall": true, "aftereach": true, "afterall": true,
+	"before": true, "after": true,
+}
+
+// emitTestScopeOwner emits a single SCOPE.Operation entity per JS/TS test
+// file that owns every CALLS edge reachable from the module-level
+// test-framework blocks (describe/it/test/before*/after*). Those blocks pass
+// their spec logic as arrow/function callbacks that are NOT named entities,
+// so walk() produced no owner for the `subject.method()` calls inside them —
+// the root cause that left controller-unit specs unable to credit coverage
+// (#4671). The call extractor runs with a nil base frame; withLocalReceiverTypes
+// (invoked inside extractCallRelationships) types the locally-constructed
+// subjects (`const c = new XController()`, `module.get(X)`) so their method
+// calls resolve to the imported class's source file.
+//
+// Scope discipline: only the module-level test-block callbacks are mined.
+// Calls inside named functions / class methods already have owners from
+// walk(), so re-mining them here would double-emit CALLS edges. We therefore
+// walk the program's children, pick the test-block call statements, and
+// extract from their callback bodies only — never descending into named
+// function/class declarations.
+//
+// No-op for non-test files and for test files with no module-level blocks.
+func (x *extractor) emitTestScopeOwner(root *sitter.Node) {
+	if root == nil || !isJSTestFile(x.filePath) {
+		return
+	}
+	bodies := x.collectTestBlockBodies(root)
+	if len(bodies) == 0 {
+		return
+	}
+	scopeName := testScopeName(x.filePath)
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, body := range bodies {
+		for _, rel := range x.extractCallRelationships(body, scopeName, nil) {
+			// Only CALLS edges define the test→subject reachability that
+			// ComputeCoverage credits; drop the sibling navigation / uses /
+			// validates edges this extractor also produces (they belong to
+			// real owner entities, not this synthetic test scope).
+			if rel.Kind != "CALLS" {
+				continue
+			}
+			key := rel.ToID
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			rels = append(rels, rel)
+		}
+	}
+	if len(rels) == 0 {
+		return
+	}
+	x.emitWithRels(
+		scopeName,
+		"SCOPE.Operation",
+		root,
+		"test_scope",
+		"test scope "+scopeName,
+		rels,
+	)
+}
+
+// collectTestBlockBodies returns the callback bodies of every module-level
+// test-framework block (describe/it/test/before*/after*) in the program.
+// Blocks may be nested (describe → it); we recurse into a matched block's
+// callback so inner it() bodies are mined too, but we do NOT descend into
+// named function/class declarations (their calls already have owners).
+func (x *extractor) collectTestBlockBodies(root *sitter.Node) []*sitter.Node {
+	var out []*sitter.Node
+	x.walkTestBlocks(root, &out)
+	return out
+}
+
+// walkTestBlocks recursively finds test-block call callbacks. It treats a
+// call_expression whose callee leaf is a test-block name as a block, records
+// its callback body, and recurses into that body to catch nested blocks.
+func (x *extractor) walkTestBlocks(n *sitter.Node, out *[]*sitter.Node) {
+	if n == nil {
+		return
+	}
+	switch n.Type() {
+	// Do not descend into named declarations — walk() already owns their
+	// call relationships.
+	case "function_declaration", "class_declaration", "method_definition":
+		return
+	case "call_expression":
+		if body := x.testBlockCallbackBody(n); body != nil {
+			*out = append(*out, body)
+			// Recurse into the callback body to find nested it()/test()
+			// blocks; their bodies are appended too.
+			x.walkTestBlocks(body, out)
+			return
+		}
+	}
+	count := int(n.ChildCount())
+	for i := 0; i < count; i++ {
+		x.walkTestBlocks(n.Child(i), out)
+	}
+}
+
+// testBlockCallbackBody returns the body node of a test-block call's
+// arrow/function callback, or nil when the call is not a recognised test
+// block or carries no function callback. Handles `describe('x', () => {...})`,
+// `it('y', async () => {...})`, and `it('y', function () {...})`.
+func (x *extractor) testBlockCallbackBody(call *sitter.Node) *sitter.Node {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return nil
+	}
+	var leaf string
+	switch fn.Type() {
+	case "identifier":
+		leaf = x.nodeText(fn)
+	case "member_expression":
+		// `it.only(...)`, `describe.each(...)` etc. — match on the object leaf.
+		obj := fn.ChildByFieldName("object")
+		if obj != nil && obj.Type() == "identifier" {
+			leaf = x.nodeText(obj)
+		}
+	}
+	if leaf == "" || !testBlockCallNames[strings.ToLower(leaf)] {
+		return nil
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	count := int(args.ChildCount())
+	for i := 0; i < count; i++ {
+		a := args.Child(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "arrow_function", "function_expression", "function":
+			if b := a.ChildByFieldName("body"); b != nil {
+				return b
+			}
+		}
+	}
+	return nil
+}
+
+// testScopeName derives a stable name for the per-file test-scope owner
+// entity from the file path: the base filename with its extension stripped,
+// suffixed with "::testScope" so it never collides with a production symbol.
+func testScopeName(filePath string) string {
+	base := filepath.Base(filepath.ToSlash(filePath))
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	return stem + "::testScope"
+}
 
 // jsTestFileExts is the set of file extensions that may host JS/TS test
 // code under the `.test.` / `.spec.` naming convention. Mirrors


### PR DESCRIPTION
## What & why
Closes the TS/JS slice of the coverage root cause in #4671 (epic #4672).

The TS call resolver typed `this.<field>.method()` (DI fields) and bare typed params, but **not** a local variable bound from a constructor or NestJS DI resolution — the dominant controller-unit-spec shape:

```ts
const controller = new ProposalController(mockSvc);  // or module.get(X) / app.get(X) / moduleRef.resolve(X)
controller.getCounts('2025');
```

Untyped local → `controller.getCounts()` emitted a bare unresolvable leaf → no test→handler CALLS edge → ComputeCoverage marked the handler/endpoint untested. Live-proven ~4x undercount on upvate-v3 (18% vs real ~80%); the prior four fixes moved the live number by zero because they targeted the supertest/route-string path, not the unit-spec path.

## Changes
1. **Local-variable receiver typing** (`receiver.go`) — `withLocalReceiverTypes` scans a body for `new Class(...)` and NestJS DI `module.get(Class)` / `app.get(Class)` / `moduleRef.resolve(Class)` (awaited unwrapped), folds `localName → Class` into a **derived** frame (append-only; closer field/param bindings win), so `receiverTypedTarget` resolves `local.method()` to the imported class's source file.
2. **Test-scope owner** (`tests.go`) — `describe/it/test/before*/after*` callbacks aren't named entities, so `walk()` produced no owner for the resolved call. `emitTestScopeOwner` emits one `SCOPE.Operation` (`<file>::testScope`, subtype `test_scope`) per test file owning every CALLS edge reachable from module-level test blocks (scoped to avoid double-emitting calls already owned by named decls). `emitTestsEdgesForTestFile` then promotes them to TESTS edges.

ComputeCoverage's existing test→CALLS→handler crediting + `creditEndpointsViaHandlers` (endpoint←handler hop) complete the chain — no coverage-side change needed.

## Validation (fixtures lied 4x — these assert the actual missing edge)
- `TestLocalVarReceiver_NewExpression` — exact mirror of the live `new ProposalController()` shape; asserts the structural-ref CALLS/TESTS edge to `getCounts` on `proposal.controller`.
- `TestLocalVarReceiver_NestDIGet` — `Test.createTestingModule()…get(X)`.
- `TestLocalVarReceiver_DIResolve` — awaited `moduleRef.resolve(X)`.
- Negative controls: string DI token (`module.get('CACHE')`) and external-package constructor (`typeorm` Repository) stay bare — no invented binding.

`go test ./internal/extractors/javascript/... ./internal/resolve/... ./internal/graph/... ./internal/types/` all green; `go vet` + `gofmt` clean.

**Coordinator live-validation (gated):** at the next deploy window, MCP `test_coverage group=upvate-v3` (expect 18% → ~80%) and `neighbors direction=in` on Operation `24dc94ed127c22e5` (expect the spec→handler CALLS edge). Do not close #4671 until the live number moves.

## Generalize (standing rule)
Per-language follow-ups filed as children of #4672 for every language not implemented here.

Part of #4671 / epic #4672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)