### PR TITLE
fix(literal_parity): derivation resolver for implicit sets (#4664, #4665)

### DIFF
--- a/internal/mcp/literal_parity_derive.go
+++ b/internal/mcp/literal_parity_derive.go
@@ -1,0 +1,203 @@
+// Derivation resolvers for literal_parity (#4665 part b).
+//
+// Some value-sets the rewrite-parity audit cares about are IMPLICIT on one side
+// — they are not declared as a constant/enum the value-set extractor can pick
+// up, but are derivable from other graph structure. The canonical example is DRF
+// "action codenames": Django REST Framework exposes a ViewSet's custom actions
+// via `@action`-decorated methods, and the codename of each action is implicitly
+// the lowercased method name (or its explicit url_path). There is no declared
+// enum on the oracle side, so locateValueSet returns "unresolved" — but the set
+// is real and DERIVABLE.
+//
+// A derivation resolver synthesises a literalparity-compatible value-set
+// (a *graph.Entity carrying members_json) from such structure, so the very same
+// Diff core can compare it to the other side. The resolver is opt-in per side via
+// the `oracle_derive` / `v3_derive` params, so it never fires silently — the
+// caller explicitly asks for a derived set instead of an explicit *_source pin.
+//
+// Currently one derivation is supported:
+//
+//	drf_action_codenames — collect @action-decorated methods (Properties
+//	  ["drf_action"]=="true") across the group, codename = url_path when set,
+//	  else the lowercased bare method name. An optional `viewset` param scopes
+//	  the collection to actions CONTAINS-owned by the named ViewSet (canonical
+//	  name match), so two unrelated ViewSets don't get merged into one set.
+package mcp
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/literalparity"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// knownDerivations is the registry of supported `*_derive` values.
+var knownDerivations = map[string]struct{}{
+	"drf_action_codenames": {},
+}
+
+// deriveValueSet builds a synthetic SCOPE.Enum value-set entity for a derivation
+// kind within a group, scoped by an optional viewset name. It returns the
+// synthetic entity (with members_json populated) and an empty error string on
+// success, or a nil entity and a non-empty error string when the derivation is
+// unknown or yields nothing.
+func deriveValueSet(lg *LoadedGroup, kind, viewset string) (*graph.Entity, string) {
+	if _, ok := knownDerivations[kind]; !ok {
+		return nil, "unknown derivation " + kind + " (supported: drf_action_codenames)"
+	}
+	switch kind {
+	case "drf_action_codenames":
+		return deriveDRFActionCodenames(lg, viewset)
+	default:
+		return nil, "unknown derivation " + kind
+	}
+}
+
+// deriveDRFActionCodenames collects the implicit action-codename value-set from a
+// group's @action-decorated methods. The codename is url_path when present, else
+// the lowercased bare method name (DRF's default url_path is the method name).
+// When viewset is non-empty only actions CONTAINS-owned by a ViewSet whose name
+// canonicalises equal to it are included.
+func deriveDRFActionCodenames(lg *LoadedGroup, viewset string) (*graph.Entity, string) {
+	wantVS := canonicalSetName(viewset)
+
+	// dedup by codename (an action may be emitted once; defensive against dups).
+	seen := map[string]bool{}
+	var members []literalparity.Member
+
+	for _, r := range lg.Repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		// Owner lookup: method entity ID -> canonical ViewSet name, via CONTAINS.
+		ownerVS := map[string]string{}
+		if wantVS != "" {
+			byID := r.getByID()
+			for i := range r.Doc.Relationships {
+				rel := &r.Doc.Relationships[i]
+				if rel.Kind != "CONTAINS" {
+					continue
+				}
+				parent, ok := byID[bareID(rel.FromID)]
+				if !ok {
+					parent, ok = byID[rel.FromID]
+				}
+				if !ok || !isViewSetLike(parent) {
+					continue
+				}
+				ownerVS[bareID(rel.ToID)] = canonicalSetName(bareEntityName(parent))
+				ownerVS[rel.ToID] = canonicalSetName(bareEntityName(parent))
+			}
+		}
+
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isDRFAction(e) {
+				continue
+			}
+			if wantVS != "" {
+				vs, ok := ownerVS[e.ID]
+				if !ok {
+					vs = ownerVS[bareID(e.ID)]
+				}
+				if vs != wantVS {
+					continue
+				}
+			}
+			code := drfActionCodename(e)
+			if code == "" || seen[code] {
+				continue
+			}
+			seen[code] = true
+			members = append(members, literalparity.Member{Key: code, Value: code, Line: e.StartLine})
+		}
+	}
+
+	if len(members) == 0 {
+		detail := ""
+		if viewset != "" {
+			detail = " under viewset " + viewset
+		}
+		return nil, "no @action-decorated methods found" + detail +
+			" to derive drf_action_codenames (need Properties[\"drf_action\"]==\"true\")"
+	}
+
+	sort.Slice(members, func(i, j int) bool { return members[i].Key < members[j].Key })
+	mj, err := json.Marshal(members)
+	if err != nil {
+		return nil, "encode derived members: " + err.Error()
+	}
+
+	name := "DerivedActionCodenames"
+	if viewset != "" {
+		name = viewset + ".DerivedActionCodenames"
+	}
+	return &graph.Entity{
+		ID:   "derived::drf_action_codenames::" + name,
+		Name: name,
+		Kind: string(types.EntityKindEnum),
+		Properties: map[string]string{
+			"enum_name":    name,
+			"members_json": string(mj),
+			"derived":      "drf_action_codenames",
+		},
+	}, ""
+}
+
+// isDRFAction reports whether an entity is a DRF @action-decorated method.
+func isDRFAction(e *graph.Entity) bool {
+	if e == nil || e.Properties == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(e.Properties["drf_action"]), "true")
+}
+
+// drfActionCodename returns the implicit codename of a DRF action: the explicit
+// url_path when present, else the lowercased bare method name (the part after the
+// final '.'), which is DRF's default url_path.
+func drfActionCodename(e *graph.Entity) string {
+	if e.Properties != nil {
+		if up := strings.TrimSpace(e.Properties["url_path"]); up != "" {
+			return strings.ToLower(up)
+		}
+	}
+	name := e.Name
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// isViewSetLike reports whether an entity looks like a DRF ViewSet / controller
+// class (a class-ish component whose name ends in ViewSet/View/Controller, or any
+// class that CONTAINS @action methods — the latter is handled by the caller).
+func isViewSetLike(e *graph.Entity) bool {
+	if e == nil {
+		return false
+	}
+	n := strings.ToLower(e.Name)
+	return strings.HasSuffix(n, "viewset") ||
+		strings.HasSuffix(n, "view") ||
+		strings.HasSuffix(n, "controller") ||
+		e.Subtype == "class"
+}
+
+// bareEntityName returns the bare class name (after the final '.') for matching.
+func bareEntityName(e *graph.Entity) string {
+	n := e.Name
+	if i := strings.LastIndex(n, "."); i >= 0 {
+		n = n[i+1:]
+	}
+	return n
+}
+
+// bareID strips a "<repo>::" prefix from an entity id, if present.
+func bareID(id string) string {
+	if i := strings.Index(id, "::"); i >= 0 {
+		return id[i+2:]
+	}
+	return id
+}

--- a/internal/mcp/literal_parity_tool.go
+++ b/internal/mcp/literal_parity_tool.go
@@ -19,7 +19,19 @@
 //	                 | "enum:<Name>",     (required — alias or enum:<Name>)
 //	  oracle_source: "<entity_id>",       (optional — pin the oracle value-set)
 //	  v3_source:     "<entity_id>",       (optional — pin the v3 value-set)
+//	  oracle_derive: "drf_action_codenames", (optional — derive an IMPLICIT
+//	                 oracle set from graph structure instead of a declared enum)
+//	  v3_derive:     "drf_action_codenames", (optional — same, v3 side)
+//	  viewset:       "<ViewSet name>",     (optional — scope a derivation to one
+//	                 ViewSet's @action methods)
 //	)
+//
+// Resolution precedence per side: *_derive (derivation resolver, opt-in) >
+// *_source (hard pin) > auto-locate by alias. A side that can be auto-located to
+// no SEMANTIC counterpart returns verdict:"unresolved" rather than silently
+// comparing a wrong set; for sets that are IMPLICIT on one side (DRF action
+// codenames have no declared enum on the oracle) use *_derive or an explicit
+// *_source.
 //
 // Result:
 //
@@ -88,20 +100,27 @@ func (s *Server) handleLiteralParity(_ context.Context, req mcpapi.CallToolReque
 
 	oracleID := argString(req, "oracle_source", "")
 	v3ID := argString(req, "v3_source", "")
+	oracleDerive := strings.TrimSpace(argString(req, "oracle_derive", ""))
+	v3Derive := strings.TrimSpace(argString(req, "v3_derive", ""))
+	viewset := strings.TrimSpace(argString(req, "viewset", ""))
 
-	// If an explicit *_source is given it is a hard pin: a miss is a real error
-	// (the caller asked for a specific entity). Without it, auto-locate may fail
-	// to find a SEMANTIC counterpart on one side — e.g. DRF action codenames are
-	// implicit lowercased @action method names with no declared enum on the
-	// oracle. In that case we MUST NOT silently compare a mismatched set; we
-	// return verdict:"unresolved" with the missing side's *_source null and a
-	// note, so the consumer can supply an explicit oracle_source/v3_source.
-	oracleEnt, oErr := locateValueSet(lgOracle, set, oracleID)
-	if oErr != "" && oracleID != "" {
+	// Resolution precedence per side:
+	//  1. *_derive — a derivation resolver synthesises an IMPLICIT value-set from
+	//     graph structure (e.g. DRF action codenames = @action method names). This
+	//     is opt-in so it never fires silently; a miss is a hard error (the caller
+	//     explicitly asked to derive). It outranks auto-locate so an implicit side
+	//     can be paired with a declared set on the other side. (#4665 part b)
+	//  2. *_source — a hard pin to a specific declared value-set entity; a miss is
+	//     a real error (the caller asked for a specific entity).
+	//  3. auto-locate by alias / enum:<Name>. This may fail to find a SEMANTIC
+	//     counterpart on one side; we then return verdict:"unresolved" with that
+	//     side's *_source null and a note (NEVER a silent wrong-set comparison).
+	oracleEnt, oErr := resolveSide(lgOracle, set, oracleID, oracleDerive, viewset)
+	if oErr != "" && (oracleID != "" || oracleDerive != "") {
 		return mcpapi.NewToolResultError("oracle: " + oErr), nil
 	}
-	v3Ent, vErr := locateValueSet(lgV3, set, v3ID)
-	if vErr != "" && v3ID != "" {
+	v3Ent, vErr := resolveSide(lgV3, set, v3ID, v3Derive, viewset)
+	if vErr != "" && (v3ID != "" || v3Derive != "") {
 		return mcpapi.NewToolResultError("v3: " + vErr), nil
 	}
 	if oErr != "" || vErr != "" {
@@ -170,6 +189,18 @@ func unresolvedResult(set string, oracleEnt, v3Ent *graph.Entity, oErr, vErr str
 		"oracle_source/v3_source to compare. Refusing to compare a mismatched set.")
 	out["note"] = strings.Join(notes, " | ")
 	return jsonResult(out)
+}
+
+// resolveSide resolves one side's value-set with the precedence derive > pin >
+// auto-locate. derive (when non-empty) synthesises an implicit set from graph
+// structure scoped by viewset; sourceID (when non-empty) hard-pins a declared
+// entity; otherwise the set alias / enum:<Name> drives auto-locate. Returns a
+// non-empty error string on failure.
+func resolveSide(lg *LoadedGroup, set, sourceID, derive, viewset string) (*graph.Entity, string) {
+	if derive != "" {
+		return deriveValueSet(lg, derive, viewset)
+	}
+	return locateValueSet(lg, set, sourceID)
 }
 
 // locateValueSet resolves the SCOPE.Enum value-set entity for a `set` within a

--- a/internal/mcp/literal_parity_tool_test.go
+++ b/internal/mcp/literal_parity_tool_test.go
@@ -213,3 +213,153 @@ func TestLiteralParity_E2E_ExplicitOverrideResolvesImplicit(t *testing.T) {
 		t.Errorf("sources = %v / %v", out["oracle_source"], out["v3_source"])
 	}
 }
+
+// drfActionMethod builds a DRF @action-decorated method entity, optionally with
+// an explicit url_path (empty → codename defaults to the bare method name).
+func drfActionMethod(id, name, urlPath string) graph.Entity {
+	props := map[string]string{"drf_action": "true"}
+	if urlPath != "" {
+		props["url_path"] = urlPath
+	}
+	return graph.Entity{
+		ID:         id,
+		Name:       name,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "method",
+		Properties: props,
+	}
+}
+
+// twoGroupServerDoc is like twoGroupServer but takes whole Documents so a side
+// can carry relationships (CONTAINS) for viewset-scoped derivation.
+func twoGroupServerDoc(t *testing.T, oracleDoc, v3Doc *graph.Document) *Server {
+	t.Helper()
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"oracle": {Repos: map[string]RegistryRepo{"r": {Path: t.TempDir()}}},
+		"v3":     {Repos: map[string]RegistryRepo{"r": {Path: t.TempDir()}}},
+	}}
+	st := NewState(reg)
+	st.mu.Lock()
+	st.groups["oracle"] = &LoadedGroup{
+		Name:  "oracle",
+		Repos: map[string]*LoadedRepo{"r": {Repo: "r", Doc: oracleDoc}},
+	}
+	st.groups["v3"] = &LoadedGroup{
+		Name:  "v3",
+		Repos: map[string]*LoadedRepo{"r": {Repo: "r", Doc: v3Doc}},
+	}
+	st.mu.Unlock()
+	return &Server{State: st, Tel: NewTelemetry(0)}
+}
+
+// BUG B (#4665 part b): the DERIVATION RESOLVER yields the implicit oracle set
+// (DRF action codenames = @action method names / url_paths) and diffs it against
+// a declared v3 set — turning an otherwise-unresolved comparison into a real one.
+// Here the oracle has NO declared enum, only @action methods; v3 has a declared
+// ActionCodename enum that drifts (missing 'cancel'). Expect a real drift verdict.
+func TestLiteralParity_E2E_DerivationResolver(t *testing.T) {
+	oracleDoc := &graph.Document{Repo: "r", Entities: []graph.Entity{
+		drfActionMethod("m1", "ProposalViewSet.lite", ""),
+		drfActionMethod("m2", "ProposalViewSet.send_proposals", "send_proposals"),
+		drfActionMethod("m3", "ProposalViewSet.cancel", ""),
+	}}
+	v3Doc := &graph.Document{Repo: "r", Entities: []graph.Entity{
+		// v3 declared the codenames but DROPPED 'cancel' (membership drift).
+		enumEntity("v1", "PermissionAction",
+			`[{"key":"LITE","value":"lite"},{"key":"SEND_PROPOSALS","value":"send_proposals"}]`),
+	}}
+	s := twoGroupServerDoc(t, oracleDoc, v3Doc)
+
+	out := callLiteralParity(t, s, map[string]any{
+		"group_oracle": "oracle", "group_v3": "v3", "set": "action_codenames",
+		"oracle_derive": "drf_action_codenames", "v3_source": "v1",
+	})
+	if out["verdict"] != "drift" {
+		t.Fatalf("verdict = %v, want drift; out=%+v", out["verdict"], out)
+	}
+	// The derived oracle set has 'cancel' which v3 lacks.
+	oo, _ := out["only_in_oracle"].([]any)
+	foundCancel := false
+	for _, v := range oo {
+		if v == "cancel" {
+			foundCancel = true
+		}
+	}
+	if !foundCancel {
+		t.Errorf("expected derived oracle codename 'cancel' in only_in_oracle, got %v", out["only_in_oracle"])
+	}
+	if out["v3_source"] != "v1" {
+		t.Errorf("v3_source = %v, want v1", out["v3_source"])
+	}
+}
+
+// BUG B (#4665 part b): when BOTH sides are derived and reconciled, the verdict
+// is equivalent. Also exercises the explicit url_path override (DRF non-default).
+func TestLiteralParity_E2E_DerivationBothSidesEquivalent(t *testing.T) {
+	mk := func() *graph.Document {
+		return &graph.Document{Repo: "r", Entities: []graph.Entity{
+			drfActionMethod("a1", "VS.lite", ""),
+			drfActionMethod("a2", "VS.send", "send_proposals"),
+		}}
+	}
+	s := twoGroupServerDoc(t, mk(), mk())
+	out := callLiteralParity(t, s, map[string]any{
+		"group_oracle": "oracle", "group_v3": "v3", "set": "action_codenames",
+		"oracle_derive": "drf_action_codenames", "v3_derive": "drf_action_codenames",
+	})
+	if out["verdict"] != "equivalent" {
+		t.Fatalf("verdict = %v, want equivalent; out=%+v", out["verdict"], out)
+	}
+}
+
+// BUG B (#4665 part b): a `viewset` scope restricts the derived set to ONE
+// ViewSet's @action methods, so an unrelated ViewSet's actions don't leak in.
+func TestLiteralParity_E2E_DerivationViewsetScope(t *testing.T) {
+	oracleDoc := &graph.Document{Repo: "r",
+		Entities: []graph.Entity{
+			{ID: "vsA", Name: "ProposalViewSet", Kind: "SCOPE.Component", Subtype: "class"},
+			{ID: "vsB", Name: "DeviceViewSet", Kind: "SCOPE.Component", Subtype: "class"},
+			drfActionMethod("mA", "ProposalViewSet.lite", ""),
+			drfActionMethod("mB", "DeviceViewSet.reboot", ""), // unrelated — must be excluded
+		},
+		Relationships: []graph.Relationship{
+			{ID: "c1", FromID: "vsA", ToID: "mA", Kind: "CONTAINS"},
+			{ID: "c2", FromID: "vsB", ToID: "mB", Kind: "CONTAINS"},
+		},
+	}
+	v3Doc := &graph.Document{Repo: "r", Entities: []graph.Entity{
+		enumEntity("v1", "PermissionAction", `[{"key":"LITE","value":"lite"}]`),
+	}}
+	s := twoGroupServerDoc(t, oracleDoc, v3Doc)
+	out := callLiteralParity(t, s, map[string]any{
+		"group_oracle": "oracle", "group_v3": "v3", "set": "action_codenames",
+		"oracle_derive": "drf_action_codenames", "viewset": "ProposalViewSet",
+		"v3_source": "v1",
+	})
+	if out["verdict"] != "equivalent" {
+		t.Fatalf("verdict = %v, want equivalent (reboot must be scoped out); out=%+v", out["verdict"], out)
+	}
+}
+
+// BUG B (#4665 part b): an unknown derivation kind is a hard error (the caller
+// explicitly asked to derive), not a silent unresolved.
+func TestLiteralParity_E2E_DerivationUnknownKind(t *testing.T) {
+	s := twoGroupServerDoc(t,
+		&graph.Document{Repo: "r"},
+		&graph.Document{Repo: "r", Entities: []graph.Entity{
+			enumEntity("v1", "PermissionAction", `[{"key":"LITE","value":"lite"}]`)}},
+	)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Name = "archigraph_literal_parity"
+	req.Params.Arguments = map[string]any{
+		"group_oracle": "oracle", "group_v3": "v3", "set": "action_codenames",
+		"oracle_derive": "bogus_kind", "v3_source": "v1",
+	}
+	res, err := s.handleLiteralParity(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected tool error for unknown derivation kind")
+	}
+}

--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -173,6 +173,9 @@ var intentionalGaps = []intentionalGap{
 	// is insufficient.
 	{"archigraph_literal_parity", "oracle_source", "#4421 token ceiling pattern — optional oracle value-set entity pin"},
 	{"archigraph_literal_parity", "v3_source", "#4421 token ceiling pattern — optional v3 value-set entity pin"},
+	{"archigraph_literal_parity", "oracle_derive", "#4665 token ceiling pattern — optional oracle derivation resolver (e.g. drf_action_codenames)"},
+	{"archigraph_literal_parity", "v3_derive", "#4665 token ceiling pattern — optional v3 derivation resolver"},
+	{"archigraph_literal_parity", "viewset", "#4665 token ceiling pattern — optional ViewSet scope for a derivation"},
 
 	// archigraph_auth_posture_diff: optional narrowing args undeclared for token
 	// budget (#4422 / #1639 pattern). The two required args (group_oracle,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -611,7 +611,9 @@ func (s *Server) registerTools() {
 	// #4421 (epic #4419) — cross-group ConstantSet / SCOPE.Enum value-set
 	// parity. Diffs an oracle group's value-set against its v3-rewrite mirror
 	// keyed off members_json. Required: group_oracle, group_v3, set (alias or
-	// enum:<Name>). Optional (undeclared per #1639): oracle_source, v3_source.
+	// enum:<Name>). Optional (undeclared per #1639): oracle_source, v3_source,
+	// oracle_derive, v3_derive (derivation resolver e.g. drf_action_codenames),
+	// viewset (scope a derivation to one ViewSet).
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_literal_parity",
 		mcpapi.WithDescription("Cross-group ConstantSet/enum value-set parity diff (oracle vs v3)."),
 		mcpapi.WithString("group_oracle", mcpapi.Required()),


### PR DESCRIPTION
## Summary

Wave-2 rewrite-agent feedback flagged two `literal_parity` accuracy bugs (#4664, #4665). The core of both already landed under #4532; this PR adds the one remaining piece — the **derivation resolver** for sets implicit on one side (#4665 part b).

### #4664 — align by VALUE not key-name (already fixed in #4532, verified)
ConstantSets were aligned by raw key name, so oracle `CORE_ADMIN` never aligned with v3 `CoreAdmin` and real value drift (`core_admin` vs `core-admin`) was dumped into `only_in_*` instead of `value_mismatches`. `#4532` introduced `CanonicalKey` (folds SCREAMING_SNAKE / PascalCase / camelCase → canonical) for alignment **and** a value-multiset membership diff (value is the parity contract). Regressions `TestDiff_CrossFrameworkKeyAlignment` / `...ReconciledEquivalent` are green.

### #4665 — unresolved-set handling + derivation resolver
**Part (a)** (already fixed in #4532, verified): substring auto-locate was removed; an alias with no exact **semantic** counterpart now returns `verdict:"unresolved"` with that side's source `null` and a note, instead of silently comparing a substring-matched wrong set (`SyncActionStatus` ↔ `OutboxAction`). Regressions `TestLiteralParity_E2E_UnresolvedBothSides` / `...NoSubstringWrongSet` are green.

**Part (b) — NEW here:** a derivation resolver for value-sets that are implicit on one side. DRF action codenames have no declared enum on the oracle (they are the lowercased `@action` method names / `url_path`s), so auto-locate correctly returns unresolved — but the set is real and derivable.

- New opt-in params (token-ceiling pattern, read off the request map): `oracle_derive` / `v3_derive = "drf_action_codenames"` synthesise a `members_json` value-set from `@action` methods (`Properties["drf_action"]=="true"`; codename = `url_path` else lowercased method name), fed straight into the existing `Diff` core.
- `viewset` param scopes a derivation to one ViewSet's `CONTAINS`-owned actions so unrelated ViewSets don't merge.
- Resolution precedence per side: **derive > source-pin > auto-locate**. Derivation is opt-in (never fires silently); an unknown derivation kind is a hard error.

## Alignment strategy
Per #4664, the **value is the contract**. Alignment uses `CanonicalKey` (case + separator + camelCase fold) so cross-framework key spellings align, then `value_mismatches` is populated on aligned keys and membership is reported on the value multiset.

## Regressions added
`internal/mcp/literal_parity_tool_test.go`:
- `TestLiteralParity_E2E_DerivationResolver` — derived oracle set vs declared v3 set surfaces real membership drift (`cancel` dropped).
- `TestLiteralParity_E2E_DerivationBothSidesEquivalent` — both sides derived + reconciled → equivalent.
- `TestLiteralParity_E2E_DerivationViewsetScope` — `viewset` scope excludes an unrelated ViewSet's action.
- `TestLiteralParity_E2E_DerivationUnknownKind` — unknown derivation → tool error.

Schema-contract allowlist updated for the three new args.

## Gates
`go build ./...` ✅ · `go vet ./internal/mcp/...` ✅ · `go test ./internal/mcp/... ./internal/literalparity/...` ✅

Closes #4664
Closes #4665

🤖 Generated with [Claude Code](https://claude.com/claude-code)