### PR TITLE
fix(jsts-coverage): type local-variable receivers + index test-scope callbacks (#4671)

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -411,6 +411,21 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	// mobile 0 across ~2500 test entities). emitTestsEdgesForTestFile is
 	// a no-op for non-test files (cheap filename check) so the hot path
 	// stays cheap.
+	//
+	// Issue #4671 — index test-scope callbacks (it/test/describe/beforeEach)
+	// as call-bearing SCOPE.Operation entities so the production calls made
+	// inside them (e.g. `controller.getCounts(...)` in a controller UNIT
+	// spec) are extracted at all. Without this the dominant unit-spec shape
+	// produced ZERO call-bearing entities — only the file entity with its
+	// IMPORTS — so no test→handler CALLS edge ever existed and ComputeCoverage
+	// marked the endpoint untested (the live-proven ~4x undercount). Must run
+	// BEFORE emitTestsEdgesForTestFile so the new Operations' CALLS edges get
+	// promoted to TESTS edges. No-op for non-test files.
+	func() {
+		defer func() { _ = recover() }()
+		x.extractTestScopeOperations(root)
+	}()
+
 	x.emitTestsEdgesForTestFile()
 
 	if extractErr != nil {
@@ -2359,6 +2374,14 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 	}
 	seen := make(map[string]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
+
+	// Issue #4671 — local-variable receiver typing. Scan this body for
+	// `const c = new ClassName(...)` / `const c = module.get(ClassName)`
+	// bindings and merge them into a per-body frame so callTarget can
+	// resolve `c.method()` to ClassName.method (the dominant controller/
+	// service UNIT-spec shape). We clone the incoming frame to avoid
+	// mutating the shared class-field frame across sibling method bodies.
+	frame = x.frameWithLocalVarTypes(body, frame)
 
 	// Issue #2625 — build the per-body destructure-binding table so that
 	// bare callee identifiers introduced by object-pattern destructuring of

--- a/internal/extractors/javascript/issue4671_localvar_receiver_test.go
+++ b/internal/extractors/javascript/issue4671_localvar_receiver_test.go
@@ -1,0 +1,198 @@
+package javascript_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractSpec runs the real extractor over a TypeScript spec file at the given
+// path and returns the entities.
+func extractSpec(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseTS(t, []byte(src))
+	e := javascript.New()
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// findTestOpCallingHandler returns the first SCOPE.Operation/test entity that
+// carries a CALLS edge whose ToID is the handler structural-ref for `method`
+// in `controllerFile`. Returns nil when none is found.
+func findTestOpCallingHandler(ents []types.EntityRecord, controllerFile, method string) *types.EntityRecord {
+	want := "scope:operation:method:typescript:" + controllerFile + ":" + method
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind != "SCOPE.Operation" || e.Properties["subtype"] != "test" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" && r.ToID == want {
+				return e
+			}
+		}
+	}
+	return nil
+}
+
+func hasEdge(e *types.EntityRecord, kind, toID string) bool {
+	if e == nil {
+		return false
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == kind && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestIssue4671_NewClassReceiver_UnitSpec is the EXACT-MIRROR fixture for the
+// live root cause: a controller UNIT spec constructs the controller with
+// `new XController(mockSvc)` and calls `controller.getCounts('2025')` inside an
+// it() block. Before #4671 the spec produced ZERO call-bearing entities, so no
+// test→handler CALLS edge existed. After #4671 a test Operation must own a
+// CALLS edge (and a derived TESTS edge) to XController.getCounts.
+func TestIssue4671_NewClassReceiver_UnitSpec(t *testing.T) {
+	const src = `
+import { XController } from './x.controller';
+import { XService } from './x.service';
+
+describe('XController', () => {
+  let controller;
+  let mockSvc;
+  beforeEach(() => {
+    mockSvc = new XService();
+    controller = new XController(mockSvc);
+  });
+  it('counts', () => {
+    const r = controller.getCounts('2025');
+  });
+});
+`
+	ents := extractSpec(t, "src/x.controller.spec.ts", src)
+	const handlerRef = "scope:operation:method:typescript:src/x.controller.ts:getCounts"
+
+	op := findTestOpCallingHandler(ents, "src/x.controller.ts", "getCounts")
+	if op == nil {
+		t.Fatalf("no test Operation with CALLS -> %s; got entities: %s", handlerRef, dumpEnts(ents))
+	}
+	if !hasEdge(op, "TESTS", handlerRef) {
+		t.Errorf("test Operation %q missing TESTS -> %s", op.Name, handlerRef)
+	}
+}
+
+// TestIssue4671_ConstructionAtModuleScope covers the variant where the
+// controller is constructed at module scope (top of the file) rather than in a
+// beforeEach hook.
+func TestIssue4671_ConstructionAtModuleScope(t *testing.T) {
+	const src = `
+import { XController } from './x.controller';
+import { XService } from './x.service';
+
+const controller = new XController(new XService());
+
+describe('XController', () => {
+  it('counts', () => {
+    controller.getCounts('2025');
+  });
+});
+`
+	ents := extractSpec(t, "src/x.controller.spec.ts", src)
+	if findTestOpCallingHandler(ents, "src/x.controller.ts", "getCounts") == nil {
+		t.Fatalf("module-scope construction: no test Operation with CALLS to handler; got: %s", dumpEnts(ents))
+	}
+}
+
+// TestIssue4671_NestJSModuleGet covers the NestJS DI variant: the controller is
+// obtained via `module.get(XController)` after compiling a TestingModule.
+func TestIssue4671_NestJSModuleGet(t *testing.T) {
+	const src = `
+import { Test } from '@nestjs/testing';
+import { XController } from './x.controller';
+import { XService } from './x.service';
+
+describe('XController', () => {
+  let controller;
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [XController],
+      providers: [XService],
+    }).compile();
+    controller = module.get(XController);
+  });
+  it('counts', () => {
+    controller.getCounts('2025');
+  });
+});
+`
+	ents := extractSpec(t, "src/x.controller.spec.ts", src)
+	if findTestOpCallingHandler(ents, "src/x.controller.ts", "getCounts") == nil {
+		t.Fatalf("module.get(XController): no test Operation with CALLS to handler; got: %s", dumpEnts(ents))
+	}
+}
+
+// TestIssue4671_LocalVarReceiverInProductionMethod is the GENERAL (non-test)
+// benefit: a plain production function that constructs a class locally and
+// calls a method on it must now bind the call to the class method. This proves
+// the local-var typing is not test-file-specific.
+func TestIssue4671_LocalVarReceiverInProductionMethod(t *testing.T) {
+	const src = `
+import { XService } from './x.service';
+
+export function run() {
+  const svc = new XService();
+  return svc.doWork();
+}
+`
+	tree := parseTS(t, []byte(src))
+	e := javascript.New()
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     "src/runner.ts",
+		Content:  []byte(src),
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const ref = "scope:operation:method:typescript:src/x.service.ts:doWork"
+	run := findByName(ents, "run")
+	if run == nil {
+		t.Fatalf("run() not extracted; got: %s", dumpEnts(ents))
+	}
+	if !hasEdge(run, "CALLS", ref) {
+		t.Errorf("run() missing CALLS -> %s (local-var receiver typing); rels: %v", ref, run.Relationships)
+	}
+}
+
+func dumpEnts(ents []types.EntityRecord) string {
+	var b strings.Builder
+	for _, e := range ents {
+		b.WriteString("\n  ")
+		b.WriteString(e.Kind)
+		b.WriteString("/")
+		b.WriteString(e.Properties["subtype"])
+		b.WriteString(" ")
+		b.WriteString(e.Name)
+		for _, r := range e.Relationships {
+			b.WriteString("\n      ")
+			b.WriteString(r.Kind)
+			b.WriteString(" -> ")
+			b.WriteString(r.ToID)
+		}
+	}
+	return b.String()
+}

--- a/internal/extractors/javascript/localvar_receiver.go
+++ b/internal/extractors/javascript/localvar_receiver.go
@@ -1,0 +1,257 @@
+// Package javascript — issue #4671 local-variable receiver typing.
+//
+// The receiver binder in receiver.go types `this.<field>.method()` and bare
+// `<param>.method()` shapes via the enclosing class's fields and the caller's
+// typed parameters (issue #421). It does NOT type LOCAL VARIABLES that are
+// assigned from a constructor call (`const c = new XController(svc)`) or a
+// NestJS DI lookup (`const c = module.get(XController)`).
+//
+// That local-variable form is the DOMINANT shape in controller/service UNIT
+// specs:
+//
+//	const controller = new XController(mockSvc);
+//	describe('XController', () => {
+//	  it('counts', () => { controller.getCounts('2025'); });
+//	});
+//
+// Without local-var typing the `controller.getCounts(...)` call falls back to
+// a bare trailing-method-name CALLS edge that never binds to the handler, so
+// the test→handler CALLS edge is missing and ComputeCoverage marks the
+// endpoint untested — the live-proven ~4x coverage undercount (graph 18.2%
+// vs real ~80%) on upvate-v3.
+//
+// This file adds collectLocalVarTypes: a body-scoped scan that records every
+// `<local> = new ClassName(...)` and `<local> = <di>.get(ClassName)` binding
+// into a classBindings frame, so receiverTypedTarget resolves
+// `<local>.method()` to `ClassName.method` exactly as it already does for
+// constructor-injected fields. The recorded type is resolved to its declaring
+// file via importByLocal (same path the field binder uses), so the structural
+// ref binds cross-file in the resolver.
+//
+// Scope discipline: the scan is conservative — it only records a binding when
+// the RHS is a recognised construction form. The receiver binder
+// (receiverTypedTarget) still gates the final structural-ref emission on the
+// class resolving through importByLocal, so an unimported / external class
+// never misresolves. The scan is whole-subtree (it descends into nested
+// blocks) because spec bodies place the construction in a `beforeEach`/
+// `describe` scope and the call in a sibling `it` block; collecting across the
+// subtree lets the per-`it` frame see the construction. Same-name collisions
+// follow last-write-wins, mirroring runtime reassignment semantics.
+//
+// GENERALIZE (issue #4671, standing rule): the local-variable receiver-typing
+// gap is identical in Java (`new XController(); c.method()`, Mockito
+// @InjectMocks), Python (`c = XViewSet(); c.method()`), Go, Ruby, etc. TS/JS
+// is implemented here; per-language follow-ups are filed separately.
+
+package javascript
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// diLookupMethods is the set of trailing method names on a NestJS / DI
+// container that return a typed instance when called with a class token:
+//
+//	module.get(XController)
+//	app.get(XController)
+//	moduleRef.get(XController)
+//	moduleRef.resolve(XController)        // request-scoped providers
+//	TestBed.inject(XController)            // Angular testing
+//
+// The receiver of the lookup (module / app / moduleRef / TestBed) is not
+// type-checked — any `<recv>.get(ClassToken)` / `<recv>.inject(ClassToken)` /
+// `<recv>.resolve(ClassToken)` whose sole argument is a bare class identifier
+// is treated as producing an instance of that class. This deliberately covers
+// the dominant DI idioms without requiring us to model the container's own
+// type.
+var diLookupMethods = map[string]bool{
+	"get":     true,
+	"resolve": true,
+	"inject":  true,
+}
+
+// frameWithLocalVarTypes returns a frame that carries the incoming frame's
+// bindings PLUS every local-variable construction binding found in body.
+// The incoming frame is never mutated — class-field frames are shared across
+// sibling method bodies, so mutating in place would leak one method's locals
+// into another. When body has no class-construction locals the incoming
+// frame is returned unchanged (no allocation on the hot non-test path).
+func (x *extractor) frameWithLocalVarTypes(body *sitter.Node, base *classBindings) *classBindings {
+	if body == nil {
+		return base
+	}
+	// Pre-scan to avoid cloning when there's nothing to add. We only clone
+	// on a hit so the hot non-test path stays allocation-free.
+	locals := &classBindings{fields: map[string]string{}}
+	x.collectLocalVarTypes(body, locals)
+	if len(locals.fields) == 0 {
+		return base
+	}
+	merged := &classBindings{fields: map[string]string{}}
+	if base != nil {
+		merged.className = base.className
+		for k, v := range base.fields {
+			merged.fields[k] = v
+		}
+	}
+	// Local constructions win over inherited field/param bindings of the
+	// same name — the local is closer to the call site.
+	for k, v := range locals.fields {
+		merged.fields[k] = v
+	}
+	return merged
+}
+
+// collectLocalVarTypes scans body (whole subtree) for local-variable
+// declarations whose initialiser is a class-construction form, recording each
+// `<localName> -> <ClassName>` binding into frame.fields. frame must be
+// non-nil; collisions follow last-write-wins.
+//
+// Recognised initialiser shapes:
+//
+//	const c = new ClassName(...)              // direct construction
+//	let  c = new ClassName()                  // (var / let / const all fine)
+//	const c = module.get(ClassName)           // NestJS DI container lookup
+//	const c = moduleRef.resolve(ClassName)    // request-scoped DI
+//	const c = TestBed.inject(ClassName)       // Angular DI
+//
+// Plain `c = expr` assignment statements (no declarator keyword) are also
+// scanned so `beforeEach(() => { controller = new X(svc); })` rebinds an
+// outer `let controller;` — the construction commonly lives in a setup
+// callback while the declaration is a bare `let` in the describe scope.
+func (x *extractor) collectLocalVarTypes(body *sitter.Node, frame *classBindings) {
+	if body == nil || frame == nil || frame.fields == nil {
+		return
+	}
+	// variable_declarator covers `const/let/var c = <init>`; the
+	// assignment_expression covers a later bare `c = <init>` rebinding.
+	decls := findAllNodes(body, "variable_declarator", "assignment_expression")
+	for _, d := range decls {
+		name, className := x.localVarConstruction(d)
+		if name == "" || className == "" {
+			continue
+		}
+		frame.fields[name] = className
+	}
+}
+
+// localVarConstruction returns the (localName, className) pair when node is a
+// variable_declarator or assignment_expression whose target is a plain
+// identifier and whose initialiser is a recognised class-construction form.
+// Returns ("","") on any miss.
+func (x *extractor) localVarConstruction(node *sitter.Node) (string, string) {
+	if node == nil {
+		return "", ""
+	}
+	var nameNode, initNode *sitter.Node
+	switch node.Type() {
+	case "variable_declarator":
+		nameNode = node.ChildByFieldName("name")
+		initNode = node.ChildByFieldName("value")
+	case "assignment_expression":
+		nameNode = node.ChildByFieldName("left")
+		initNode = node.ChildByFieldName("right")
+	default:
+		return "", ""
+	}
+	if nameNode == nil || initNode == nil {
+		return "", ""
+	}
+	// Only plain-identifier targets — destructuring (`const { a } = ...`)
+	// and member targets (`this.x = ...`) are out of scope here.
+	if nameNode.Type() != "identifier" {
+		return "", ""
+	}
+	className := x.constructionClassName(initNode)
+	if className == "" {
+		return "", ""
+	}
+	return x.nodeText(nameNode), className
+}
+
+// constructionClassName extracts the constructed class name from an
+// initialiser expression. Handles:
+//
+//   - new_expression:        `new ClassName(...)`  → "ClassName"
+//   - call_expression DI:    `module.get(ClassName)` / `.resolve(...)` /
+//     `.inject(...)`         → "ClassName" (sole bare-identifier argument)
+//
+// Awaited DI lookups (`await moduleRef.resolve(ClassName)`) are unwrapped.
+// Returns "" for any other shape.
+func (x *extractor) constructionClassName(init *sitter.Node) string {
+	if init == nil {
+		return ""
+	}
+	switch init.Type() {
+	case "await_expression":
+		// `await module.resolve(ClassName)` — unwrap and recurse.
+		for i := 0; i < int(init.ChildCount()); i++ {
+			ch := init.Child(i)
+			if ch == nil || ch.Type() == "await" {
+				continue
+			}
+			return x.constructionClassName(ch)
+		}
+		return ""
+	case "new_expression":
+		ctor := init.ChildByFieldName("constructor")
+		if ctor == nil {
+			return ""
+		}
+		switch ctor.Type() {
+		case "identifier", "type_identifier":
+			return x.nodeText(ctor)
+		}
+		return ""
+	case "call_expression":
+		return x.diLookupClassName(init)
+	}
+	return ""
+}
+
+// diLookupClassName returns the class-token argument of a DI container lookup
+// call (`<recv>.get(ClassName)` / `.resolve(ClassName)` / `.inject(ClassName)`)
+// when the call has exactly one argument and that argument is a bare class
+// identifier. Returns "" otherwise.
+func (x *extractor) diLookupClassName(call *sitter.Node) string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_expression" {
+		return ""
+	}
+	prop := fn.ChildByFieldName("property")
+	if prop == nil {
+		return ""
+	}
+	if !diLookupMethods[x.nodeText(prop)] {
+		return ""
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	// Find the single class-identifier argument. Skip punctuation; bail if
+	// there is more than one value argument (a generic `get(token, opts)`
+	// shape is not a class-instance lookup we can type confidently).
+	var classArg *sitter.Node
+	valueArgs := 0
+	for i := 0; i < int(args.ChildCount()); i++ {
+		a := args.Child(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "(", ")", ",":
+			continue
+		}
+		valueArgs++
+		classArg = a
+	}
+	if valueArgs != 1 || classArg == nil {
+		return ""
+	}
+	switch classArg.Type() {
+	case "identifier", "type_identifier":
+		return x.nodeText(classArg)
+	}
+	return ""
+}

--- a/internal/extractors/javascript/tests.go
+++ b/internal/extractors/javascript/tests.go
@@ -51,11 +51,34 @@
 package javascript
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
+	sitter "github.com/smacker/go-tree-sitter"
+
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// testBlockCallees is the set of test-framework block functions whose final
+// argument is a callback containing test-body code. `describe`/`suite`/
+// `context` are grouping blocks (their body holds setup/teardown + nested
+// it() blocks, handled recursively); `it`/`test`/`specify` are the leaf test
+// blocks that own the production CALLS edges.
+var testBlockCallees = map[string]bool{
+	"describe": true, "suite": true, "context": true,
+	"it": true, "test": true, "specify": true,
+}
+
+// testHookCallees is the set of setup/teardown hook functions whose callback
+// bodies commonly construct the system-under-test (`beforeEach(() => {
+// controller = new XController(svc); })`). Their bodies are scanned for
+// local-variable construction bindings that the sibling it() blocks reuse,
+// but they are not emitted as test Operations themselves.
+var testHookCallees = map[string]bool{
+	"beforeeach": true, "beforeall": true, "aftereach": true, "afterall": true,
+	"before": true, "after": true, "setup": true, "teardown": true,
+}
 
 // jsTestFileExts is the set of file extensions that may host JS/TS test
 // code under the `.test.` / `.spec.` naming convention. Mirrors
@@ -300,6 +323,243 @@ func (x *extractor) emitTestsEdgesForTestFile() {
 			ent.Relationships = append(ent.Relationships, add...)
 		}
 	}
+}
+
+// extractTestScopeOperations indexes test-framework block callbacks
+// (describe/it/test/...) in a test file as call-bearing SCOPE.Operation
+// entities, so the production calls inside them yield CALLS edges (which
+// emitTestsEdgesForTestFile then promotes to TESTS edges). Issue #4671.
+//
+// Why this pass is needed: the generic walk emits Operation entities only for
+// NAMED functions / methods / arrow-const declarations. A controller UNIT spec
+// has none of those — its bodies are anonymous callbacks passed to
+// `describe(...)` / `it(...)`. Before this pass such a spec produced ZERO
+// call-bearing entities (only the file entity + IMPORTS), so the handler call
+// `controller.getCounts(...)` was never extracted and the test→handler CALLS
+// edge never existed — the live-proven dominant cause of the ~4x coverage
+// undercount on upvate-v3.
+//
+// Each leaf test block (it/test/specify) becomes one SCOPE.Operation
+// (subtype "test") whose CALLS edges come from extractCallRelationships over
+// the callback body. Receiver typing for `<localVar>.method()` is seeded from
+// local-variable construction bindings (`const c = new XController(svc)` /
+// `module.get(XController)`) collected across the ENCLOSING describe subtree,
+// so a system-under-test constructed in a `beforeEach` hook is visible to the
+// it() blocks that call it.
+//
+// No-op for non-test files (cheap filename check).
+func (x *extractor) extractTestScopeOperations(root *sitter.Node) {
+	if root == nil || !isJSTestFile(x.filePath) {
+		return
+	}
+	// Seed an empty file-scope frame; describe blocks accumulate local-var
+	// construction bindings as we descend. Top-level (module-scope)
+	// constructions outside any describe are collected here too.
+	fileScope := &classBindings{fields: map[string]string{}}
+	x.collectModuleLevelConstructions(root, fileScope)
+	x.walkTestScope(root, fileScope)
+}
+
+// collectModuleLevelConstructions records construction bindings declared at
+// module scope (outside any describe/it block) — e.g.
+// `const controller = new XController(mockSvc);` written at the top of the
+// spec file rather than inside a beforeEach. These are visible to every test
+// block in the file.
+func (x *extractor) collectModuleLevelConstructions(root *sitter.Node, scope *classBindings) {
+	for i := 0; i < int(root.ChildCount()); i++ {
+		ch := root.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "lexical_declaration", "variable_declaration", "expression_statement":
+			x.collectLocalVarTypes(ch, scope)
+		}
+	}
+}
+
+// walkTestScope descends the CST looking for test-framework block calls.
+// inherited carries local-variable construction bindings collected from
+// enclosing describe scopes (so beforeEach-constructed instances flow down to
+// nested it() blocks). It is never mutated — each describe scope clones it and
+// adds its own hook/body constructions.
+func (x *extractor) walkTestScope(n *sitter.Node, inherited *classBindings) {
+	if n == nil {
+		return
+	}
+	if n.Type() == "call_expression" {
+		callee := strings.ToLower(x.testBlockCalleeName(n))
+		switch {
+		case testBlockCallees[callee]:
+			x.handleTestBlock(n, callee, inherited)
+			return
+		case testHookCallees[callee]:
+			// Hooks are scanned for construction bindings at the describe
+			// level (see handleTestBlock); a hook body has no nested it()
+			// blocks, so descend no further for block detection.
+			return
+		}
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		x.walkTestScope(n.Child(i), inherited)
+	}
+}
+
+// handleTestBlock processes a describe/it/test call. A grouping block
+// (describe/suite/context) collects local-var construction bindings from its
+// direct setup hooks + statements into a child frame, then recurses into the
+// callback body to reach nested it() blocks. A leaf test block (it/test/
+// specify) emits one SCOPE.Operation carrying the CALLS edges extracted from
+// the callback body, with receiver typing seeded by the inherited +
+// block-local construction bindings.
+func (x *extractor) handleTestBlock(call *sitter.Node, callee string, inherited *classBindings) {
+	cbBody := x.testBlockCallbackBody(call)
+	if cbBody == nil {
+		return
+	}
+	if callee == "describe" || callee == "suite" || callee == "context" {
+		// Clone the inherited frame and add this describe scope's own
+		// construction bindings: those declared directly in the describe
+		// body AND those inside its setup/teardown hooks (where the
+		// system-under-test is typically `new`-ed up).
+		scope := cloneBindings(inherited)
+		x.collectLocalVarTypes(cbBody, scope)
+		for i := 0; i < int(cbBody.ChildCount()); i++ {
+			x.collectHookConstructions(cbBody.Child(i), scope)
+		}
+		for i := 0; i < int(cbBody.ChildCount()); i++ {
+			x.walkTestScope(cbBody.Child(i), scope)
+		}
+		return
+	}
+	// Leaf test block: build the frame (inherited construction bindings +
+	// any locals declared inside this it() body) and extract the calls.
+	frame := cloneBindings(inherited)
+	name := x.testBlockName(call, callee)
+	rels := x.extractCallRelationships(cbBody, name, frame)
+	if len(rels) == 0 {
+		return
+	}
+	sig := fmt.Sprintf("%s(%q)", callee, name)
+	x.emitWithRels(name, "SCOPE.Operation", call, "test", sig, rels)
+}
+
+// cloneBindings returns a deep copy of b's field map (b may be nil).
+func cloneBindings(b *classBindings) *classBindings {
+	out := &classBindings{fields: map[string]string{}}
+	if b != nil {
+		out.className = b.className
+		for k, v := range b.fields {
+			out.fields[k] = v
+		}
+	}
+	return out
+}
+
+// collectHookConstructions records local-variable construction bindings from
+// a setup/teardown hook callback body into scope. A no-op for non-hook nodes.
+func (x *extractor) collectHookConstructions(n *sitter.Node, scope *classBindings) {
+	if n == nil {
+		return
+	}
+	// Hooks appear as `expression_statement(call_expression)` or a bare
+	// call_expression. Descend through the statement wrapper to find the call.
+	call := n
+	if call.Type() == "expression_statement" && call.ChildCount() > 0 {
+		call = call.Child(0)
+	}
+	if call == nil || call.Type() != "call_expression" {
+		return
+	}
+	if !testHookCallees[strings.ToLower(x.testBlockCalleeName(call))] {
+		return
+	}
+	if body := x.testBlockCallbackBody(call); body != nil {
+		x.collectLocalVarTypes(body, scope)
+	}
+}
+
+// testBlockCalleeName returns the callee identifier of a call_expression,
+// handling bare `it(...)` and dotted `it.each(...)` / `describe.only(...)`
+// shapes (returns the leading identifier "it" / "describe"). Returns "" when
+// the callee is not a plain-identifier shape.
+func (x *extractor) testBlockCalleeName(call *sitter.Node) string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return ""
+	}
+	switch fn.Type() {
+	case "identifier":
+		return x.nodeText(fn)
+	case "member_expression":
+		// `it.only` / `describe.skip` / `it.each` — the grouping/leaf
+		// identity is the object identifier.
+		obj := fn.ChildByFieldName("object")
+		if obj != nil && obj.Type() == "identifier" {
+			return x.nodeText(obj)
+		}
+	case "call_expression":
+		// `it.each(table)(name, cb)` — the inner call's callee is
+		// `it.each`; recurse to recover "it".
+		return x.testBlockCalleeName(fn)
+	}
+	return ""
+}
+
+// testBlockCallbackBody returns the statement_block body of the LAST
+// function/arrow argument of a test-block call. Returns nil when the final
+// argument is not a function with a block body (e.g. an it() with only a name,
+// or an arrow with an expression body — no statements to scan).
+func (x *extractor) testBlockCallbackBody(call *sitter.Node) *sitter.Node {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	var fn *sitter.Node
+	for i := 0; i < int(args.ChildCount()); i++ {
+		a := args.Child(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "arrow_function", "function_expression", "function":
+			fn = a // last function-typed arg wins
+		}
+	}
+	if fn == nil {
+		return nil
+	}
+	body := fn.ChildByFieldName("body")
+	if body == nil || body.Type() != "statement_block" {
+		return nil
+	}
+	return body
+}
+
+// testBlockName derives a stable entity name for a test block from its first
+// string-literal argument (the test description), falling back to the callee
+// when no literal description is present. The line suffix avoids collisions
+// when two it() blocks share a description.
+func (x *extractor) testBlockName(call *sitter.Node, callee string) string {
+	args := call.ChildByFieldName("arguments")
+	desc := ""
+	if args != nil {
+		for i := 0; i < int(args.ChildCount()); i++ {
+			a := args.Child(i)
+			if a == nil {
+				continue
+			}
+			if a.Type() == "string" || a.Type() == "template_string" {
+				desc = strings.Trim(x.nodeText(a), "`'\"")
+				break
+			}
+		}
+	}
+	if desc == "" {
+		desc = callee
+	}
+	line := int(call.StartPoint().Row) + 1
+	return fmt.Sprintf("%s:%s@%d", callee, desc, line)
 }
 
 // detectTestFramework returns a best-guess framework name from the file

--- a/internal/graph/coverage_4671_test.go
+++ b/internal/graph/coverage_4671_test.go
@@ -1,0 +1,86 @@
+package graph
+
+import "testing"
+
+// TestComputeCoverage_4671_UnitSpecCreditsEndpoint mirrors the RESOLVED graph
+// shape that the JS/TS extractor (after issue #4671) + resolver produce for a
+// NestJS controller UNIT spec:
+//
+//	x.controller.ts:    class XController { @Get('get_counts') getCounts(y){...} }
+//	x.controller.spec.ts:
+//	    const controller = new XController(mockSvc);
+//	    describe('XController', () => { it('counts', () => controller.getCounts('2025')) })
+//
+// After #4671 the spec's it() block is a test Operation that CALLS the handler
+// (the structural-ref the extractor emits is bound by the resolver to the
+// handler entity ID before ComputeCoverage runs). ComputeCoverage must then:
+//   - credit the handler via the synthetic test→CALLS→handler edge (phase 2),
+//   - credit the http_endpoint_definition the handler backs (phase 4).
+//
+// This is the live-proven path that was missing (graph 18.2% vs real ~80%).
+func TestComputeCoverage_4671_UnitSpecCreditsEndpoint(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		// Production: handler method + the endpoint definition it backs.
+		{ID: "handler", Name: "getCounts", Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "src/x.controller.ts"},
+		{ID: "endpoint", Name: "GET /v1/proposals/get_counts", Kind: "http_endpoint_definition", SourceFile: "src/x.controller.ts"},
+		// Test: the it() block Operation emitted by the #4671 pass.
+		{ID: "spec_it", Name: "it:counts@2", Kind: "SCOPE.Operation", Subtype: "test", SourceFile: "src/x.controller.spec.ts"},
+	}
+	rels := []Relationship{
+		// handler backs the endpoint (resolver-emitted IMPLEMENTS).
+		{ID: "impl", FromID: "handler", ToID: "endpoint", Kind: "IMPLEMENTS"},
+		// the #4671 test→handler CALLS edge (resolved to the handler entity ID).
+		{ID: "calls", FromID: "spec_it", ToID: "handler", Kind: "CALLS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+
+	covered := map[string]bool{}
+	for _, e := range entities {
+		covered[e.ID] = true
+	}
+	for _, u := range report.UncoveredEntities {
+		covered[u.EntityID] = false
+	}
+	if !covered["handler"] {
+		t.Error("handler getCounts should be covered via test→CALLS→handler (phase 2)")
+	}
+	if !covered["endpoint"] {
+		t.Error("endpoint should be credited via handler (phase 4)")
+	}
+	if report.TotalProduction != 2 {
+		t.Errorf("TotalProduction want 2 (handler + endpoint), got %d", report.TotalProduction)
+	}
+	if report.CoveredProduction != 2 {
+		t.Errorf("CoveredProduction want 2, got %d", report.CoveredProduction)
+	}
+}
+
+// TestComputeCoverage_4671_OfflineContractSpecNotCredited is the honest-
+// exclusion guard: an OFFLINE contract spec asserts constants and never
+// invokes the handler, so it emits NO CALLS edge to the handler. Such a spec
+// must NOT credit the endpoint (the 279 upvate-v3 contract specs correctly
+// stay uncredited). Ref #4662.
+func TestComputeCoverage_4671_OfflineContractSpecNotCredited(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		{ID: "handler", Name: "getCounts", Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "src/x.controller.ts"},
+		{ID: "endpoint", Name: "GET /v1/proposals/get_counts", Kind: "http_endpoint_definition", SourceFile: "src/x.controller.ts"},
+		// Contract spec: a test Operation that calls only an assertion helper —
+		// no CALLS edge to the handler.
+		{ID: "contract_it", Name: "it:contract@2", Kind: "SCOPE.Operation", Subtype: "test", SourceFile: "src/x.contract.spec.ts"},
+	}
+	rels := []Relationship{
+		{ID: "impl", FromID: "handler", ToID: "endpoint", Kind: "IMPLEMENTS"},
+		// No CALLS edge from contract_it to handler.
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	for _, u := range report.UncoveredEntities {
+		if u.EntityID == "handler" {
+			// good — handler stays uncovered.
+		}
+	}
+	if report.CoveredProduction != 0 {
+		t.Errorf("CoveredProduction want 0 (offline contract spec credits nothing), got %d", report.CoveredProduction)
+	}
+}


### PR DESCRIPTION
## The live root cause (issue #4671)

The upvate-v3 coverage undercount — graph `test_coverage` **18.2%** vs real execution coverage **~80%** (a ~4x miss) — is caused by two TS/JS extractor gaps that together meant **controller/service UNIT specs emitted no test→handler CALLS edge**, so `ComputeCoverage` marked the handler and its endpoint untested.

Worked example: `GET /v1/proposals/get_counts` → `ProposalController.getCounts`. The handler's incoming CALLS were ZERO even though `proposal.controller.spec.ts` does `const controller = new ProposalController(svc)` then `controller.getCounts('2025')`.

## Fix (two parts)

**1. Local-variable receiver typing** (`internal/extractors/javascript/localvar_receiver.go`)
The call resolver already typed `this.<field>.method()` (constructor-injected fields, #421) but not local variables. New `collectLocalVarTypes` / `frameWithLocalVarTypes` bind a local assigned from:
- `new ClassName(...)` (incl. module-scope and `beforeEach`)
- DI lookup `<recv>.get|resolve|inject(ClassName)` (NestJS `module.get` / `moduleRef.resolve` / Angular `TestBed.inject`), `await`-unwrapped

…to `ClassName`, so `<var>.method()` resolves to `ClassName.method` via the existing `receiverTypedTarget` structural-ref path. Benefits **all** bodies, not just tests.

**2. Index test-scope callbacks** (`internal/extractors/javascript/tests.go`)
A controller UNIT spec has no named functions/methods — its bodies are anonymous `describe`/`it` callbacks — so it previously produced ZERO call-bearing entities (only the file entity + IMPORTS). New `extractTestScopeOperations` indexes each leaf `it`/`test` block as a `SCOPE.Operation`/`test` and runs the call extractor over its body, seeding receiver types from constructions collected across the enclosing `describe` scope (a SUT built in `beforeEach` is visible to the `it` blocks). `emitTestsEdgesForTestFile` then promotes those CALLS to TESTS edges.

**ComputeCoverage** (`internal/graph/coverage.go`) already credits the chain: phase 2 (synthetic test→CALLS→handler) covers the handler; phase 4 (endpoint-via-handler IMPLEMENTS/ROUTES_TO/SERVES) credits the `http_endpoint_definition`. Verified by exact-mirror graph fixtures. The 279 offline contract specs that never invoke the handler correctly stay uncredited.

## Validation — exact-live-mirror (fixtures lied 4x before)

`internal/extractors/javascript/issue4671_localvar_receiver_test.go`:
- `new XController(mockSvc)` in `beforeEach` + `controller.getCounts(...)` in `it()` → asserts CALLS + TESTS edge to `...:x.controller.ts:getCounts`. (RED before, GREEN after.)
- module-scope construction variant
- **NestJS `module.get(XController)` variant**
- non-test production-method case (proves it's not test-specific)

`internal/graph/coverage_4671_test.go`:
- test→CALLS→handler credits handler (phase 2) **and** endpoint (phase 4)
- offline contract spec (no CALLS edge) credits nothing — honest exclusion (ref #4662)

This is validated against exact-mirror fixtures; the **coordinator live-validates on upvate-v3 at the next deploy window** (expects 18%→~80% and the spec→handler CALLS edge to appear on `24dc94ed127c22e5`).

## Generalize (standing rule)
Local-var receiver typing applies to all langs where tests construct the SUT locally. Implemented TS/JS here; follow-ups filed: Python #4677, Java (Mockito @InjectMocks) #4678, Go/Ruby/C#/PHP/Kotlin #4679.

## Gates
`go build ./...` ✅ · `go vet` ✅ · `go test ./internal/custom/... ./internal/engine/... ./internal/graph/ ./internal/resolve/ ./internal/extractors/javascript/ ./internal/types/` ✅ (all ok, no regressions)

Closes #4671 · Epic #4493

🤖 Generated with [Claude Code](https://claude.com/claude-code)