### PR TITLE
fix(effects): bound branch facet to method body across brace langs + reach repo read sinks (#4666, #4668)

### DIFF
--- a/internal/links/effect_propagation_test.go
+++ b/internal/links/effect_propagation_test.go
@@ -71,6 +71,66 @@ def handle(req):
 	}
 }
 
+// TestEffectPropagation_ReadHandlerServiceRepoChain is the #4668 regression:
+// a GET/list controller → service → repository READ chain must propagate
+// db_read to the controller exactly the way the write chain
+// (TestEffectPropagation_HandlerServiceRepoChain) propagates db_write.
+//
+// The repository read is held on a queryset attribute (`self.queryset.filter`),
+// NOT the Django `.objects.<verb>` manager form — the canonical layered-repo
+// shape. Before #4668 the read sniffer only matched the `.objects.` manager
+// form (while the write sniffer matched bare `.save(` on any receiver), so this
+// repo read resolved PURE and the list controller looked like a stub. Asserts
+// the read now reaches the controller; symmetric with the write test above.
+func TestEffectPropagation_ReadHandlerServiceRepoChain(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "repo.py", `
+class ContractRepo:
+    def list_active(self):
+        return self.queryset.filter(active=True)
+`)
+	writeFile(t, root, "svc.py", `
+class ContractService:
+    def __init__(self, r):
+        self.r = r
+    def list_contracts(self):
+        return self.r.list_active()
+`)
+	writeFile(t, root, "controller.py", `
+class ContractViewSet:
+    def list(self, request):
+        return ContractService(ContractRepo()).list_contracts()
+`)
+	graphs := []repoGraph{{
+		Repo:     "upvate-core",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "c1", Name: "ContractViewSet.list", Kind: "SCOPE.Operation", SourceFile: "controller.py"},
+			{ID: "s1", Name: "ContractService.list_contracts", Kind: "SCOPE.Operation", SourceFile: "svc.py"},
+			{ID: "r1", Name: "ContractRepo.list_active", Kind: "SCOPE.Operation", SourceFile: "repo.py"},
+		},
+		Edges: []edgeRef{
+			{FromID: "c1", ToID: "s1", Kind: "CALLS"},
+			{FromID: "s1", ToID: "r1", Kind: "CALLS"},
+		},
+	}}
+	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Repo owns the direct db_read.
+	if got := graphs[0].Entities[2].Properties[EffectPropertyKeySource]; got != "direct" {
+		t.Errorf("repo effect_source=%q; want direct", got)
+	}
+	if effs := graphs[0].Entities[2].Properties[EffectPropertyKeyList]; !strings.Contains(effs, "db_read") {
+		t.Fatalf("repo effects=%q; want db_read (the read sniffer must match self.queryset.filter)", effs)
+	}
+	// Controller inherits db_read transitively — the #4668 reach.
+	cEffs := graphs[0].Entities[0].Properties[EffectPropertyKeyList]
+	if !strings.Contains(cEffs, "db_read") {
+		t.Fatalf("controller effects=%q; want db_read to reach the GET/list handler transitively", cEffs)
+	}
+}
+
 // TestEffectPropagation_PureFunctionLeftUnstamped verifies that
 // functions with no detected sinks (and no transitive callees with
 // sinks) are not stamped — keeps graph noise low.

--- a/internal/mcp/effects_branches_4666_brace_test.go
+++ b/internal/mcp/effects_branches_4666_brace_test.go
@@ -1,0 +1,106 @@
+package mcp
+
+// effects_branches_4666_brace_test.go — method-boundary scoping regression for
+// the BRACE-language branch analyzers (#4666, epic #4419).
+//
+// #4533 fixed the over-capture for Python only (bodyEndPython). But every
+// brace-language analyzer (jsts/java/go/php/csharp/kotlin/scala/rust) walks its
+// WHOLE input window — so when the effects tool pads StartLine+N because the
+// entity's EndLine is missing/zero (#4488), a TS/NestJS controller method's
+// branch list bled into the sibling @Put method that follows it, exactly as the
+// Python case did. ClampToFunctionBody now clamps the padded window to the
+// target method's own `{`…`}` body for all brace languages.
+//
+// This test pins that fix on a verbatim two-method NestJS-style controller
+// (createContact immediately followed by updateContact): with createContact
+// given NO EndLine, effects(createContact, include=branches) must return ONLY
+// createContact's own branches (400/409/500 + its 404) and NONE of
+// updateContact's distinct branches (its own 404 'contact does not exist', the
+// 422 email conflict, the 503).
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func braceBranchScopeTestServer(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_contact_ts", Name: "ContractsController.createContact",
+				Kind:          "SCOPE.Operation",
+				QualifiedName: "contracts.controller.ContractsController.createContact",
+				// StartLine is the @Post decorator (fixture line 1). EndLine omitted
+				// (0) → degenerate span → padded window → would overshoot into
+				// updateContact (fixture line 23+) pre-fix.
+				SourceFile: "contracts_controller_two_methods.ts", StartLine: 1, EndLine: 0,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4666_brace"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["upvate-core"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+func TestEffectsBranches_BraceMethodScope(t *testing.T) {
+	srv := braceBranchScopeTestServer(t)
+	out := callEffects(t, srv, "ContractsController.createContact", "branches")
+
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for jsts; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+	if len(branches) == 0 {
+		t.Fatalf("expected createContact's own branches, got none")
+	}
+
+	// --- createContact's OWN branches are present ---
+	if b := findBranch(branches, "contract.client === null"); b == nil {
+		t.Fatalf("missing createContact's 400 guard: %v", branches)
+	} else {
+		assertStatus(t, b, "400")
+	}
+	if b := findBranch(branches, "existing !== null"); b == nil {
+		t.Fatalf("missing createContact's 409 guard: %v", branches)
+	} else {
+		assertStatus(t, b, "409")
+	}
+
+	// --- updateContact's DISTINCT branches must NOT appear (the over-capture) ---
+	for _, b := range branches {
+		cond, _ := b["condition"].(string)
+		if cond == "if (conflict !== null && conflict.id !== contactId)" {
+			t.Errorf("over-capture: createContact branch list bled into updateContact's 422 conflict guard (%q)", cond)
+		}
+		if st := branchStatus(b); st == "422" || st == "503" {
+			t.Errorf("over-capture: createContact branch carries updateContact-only status %s (cond=%v)", st, cond)
+		}
+	}
+
+	// No branch may be reported at/after updateContact's region (fixture line 23).
+	for _, b := range branches {
+		if line := toInt(b["line"]); line >= 23 {
+			t.Errorf("over-capture: branch at line %d is inside/after the sibling updateContact method (cond=%v)", line, b["condition"])
+		}
+	}
+}
+
+// branchStatus pulls the returns.status off a branch facet, or "".
+func branchStatus(b map[string]any) string {
+	r, ok := b["returns"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	s, _ := r["status"].(string)
+	return s
+}

--- a/internal/mcp/effects_tool.go
+++ b/internal/mcp/effects_tool.go
@@ -220,6 +220,12 @@ func attachBranchesFacet(out map[string]any, lr *LoadedRepo, e *graph.Entity, wa
 	if err != nil || src == "" {
 		return
 	}
+	// Clamp the (possibly EndLine-padded) window to the target method's OWN
+	// body before classifying, so branches never bleed into the sibling defs
+	// that follow it (#4666/#4488). This is language-general: Python clamps on
+	// dedent, brace languages on the matching `}`. The Python analyzer also
+	// self-clamps via bodyEndPython — double-clamping is idempotent and safe.
+	src = substrate.ClampToFunctionBody(src, lang)
 	facets := analyzer(src, start)
 	out["branches_supported"] = true
 	out["branches"] = branchFacetsToJSON(facets)

--- a/internal/mcp/testdata/branches_4666_brace/contracts_controller_two_methods.ts
+++ b/internal/mcp/testdata/branches_4666_brace/contracts_controller_two_methods.ts
@@ -1,0 +1,43 @@
+  @Post(':id/contact')
+  async createContact(@Param('id') id: string, @Body() dto: CreateContactDto) {
+    const contract = await this.contracts.findOne(id);
+    if (contract === null) {
+      throw new NotFoundException('contract not found');
+    }
+    if (contract.client === null) {
+      throw new HttpException('contract has no client', 400);
+    }
+    const existing = await this.contacts.findByEmail(dto.email);
+    if (existing !== null) {
+      throw new HttpException('contact already exists', 409);
+    }
+    try {
+      const contact = await this.contacts.create(contract, dto);
+      return { success: true, contact };
+    } catch (e) {
+      this.logger.error(e);
+      throw new HttpException('failed to create contact', 500);
+    }
+  }
+
+  @Put(':id/contact/:contactId')
+  async updateContact(
+    @Param('id') id: string,
+    @Param('contactId') contactId: string,
+    @Body() dto: UpdateContactDto,
+  ) {
+    const contact = await this.contacts.findOne(contactId);
+    if (contact === null) {
+      throw new NotFoundException('contact does not exist');
+    }
+    const conflict = await this.contacts.findByEmail(dto.email);
+    if (conflict !== null && conflict.id !== contactId) {
+      throw new HttpException('email conflict', 422);
+    }
+    try {
+      return await this.contacts.update(contact, dto);
+    } catch (e) {
+      this.logger.error(e);
+      throw new HttpException('failed to update contact', 503);
+    }
+  }

--- a/internal/substrate/branches.go
+++ b/internal/substrate/branches.go
@@ -150,6 +150,57 @@ func BranchLanguages() []string {
 
 func init() { RegisterBranchAnalyzer("python", analyzeBranchesPython) }
 
+// braceLangs is the set of brace-delimited languages whose function body is
+// bounded by a balanced `{`…`}` block. ClampToFunctionBody uses braceBodyEnd
+// for these; Python uses bodyEndPython. Languages absent here (e.g. ruby,
+// which is `end`-delimited) are not clamped at the source level yet — see
+// ClampToFunctionBody and the #4666 follow-up.
+var braceLangs = map[string]bool{
+	"jsts": true, "java": true, "go": true, "php": true,
+	"csharp": true, "kotlin": true, "scala": true, "rust": true,
+}
+
+// ClampToFunctionBody trims a (possibly padded) source window down to the
+// SINGLE function/method body that begins at its first non-blank header line,
+// so a branch analyzer never bleeds into the sibling defs that follow.
+//
+// This is the language-general companion to the per-analyzer Python clamp
+// (bodyEndPython): the effects MCP tool pads StartLine+N when an entity's
+// EndLine is missing/zero (#4488/#4666), and EVERY brace-language analyzer
+// (jsts/java/go/php/csharp/kotlin/scala/rust) walks its whole input window —
+// so without this clamp the padded tail's sibling methods are mis-attributed
+// to the target method. Clamping ONCE at the source level fixes all current
+// and future analyzers uniformly.
+//
+// Behaviour by language family:
+//   - Python: clamp to the dedent boundary (bodyEndPython).
+//   - Brace languages: clamp to the matching `}` of the header's own block.
+//   - Anything else (e.g. ruby `end`-delimited): returned unchanged — honest
+//     no-op until a body-end detector is implemented for it (#4666 follow-up).
+//
+// It is idempotent and safe on an already-tight window: an exact single-method
+// body has no trailing sibling, so the boundary is len(lines) and the source is
+// returned unchanged.
+func ClampToFunctionBody(src, lang string) string {
+	if strings.TrimSpace(src) == "" {
+		return src
+	}
+	lines := strings.Split(src, "\n")
+	var end int
+	switch {
+	case lang == "python":
+		end = bodyEndPython(lines)
+	case braceLangs[lang]:
+		end = braceBodyEnd(lines)
+	default:
+		return src // no body-end detector for this language yet
+	}
+	if end >= len(lines) {
+		return src
+	}
+	return strings.Join(lines[:end], "\n")
+}
+
 // --- Python branch analyzer ---------------------------------------------
 //
 // Walk model: Python's significant indentation makes a line-oriented walk a

--- a/internal/substrate/branches_jsts_java_go.go
+++ b/internal/substrate/branches_jsts_java_go.go
@@ -32,6 +32,52 @@ func init() {
 	RegisterBranchAnalyzer("go", analyzeBranchesGo)
 }
 
+// --- method-boundary clamp (shared by all brace-language analyzers) -------
+
+// braceBodyEnd returns the exclusive line index at which the function/method
+// whose header is the first non-blank line of `lines` ends — the line just
+// AFTER the `}` that closes the body block the header opens. It is the
+// brace-language analogue of bodyEndPython: it stops a branch walk from
+// bleeding into the sibling methods that follow when the effects tool padded
+// the source window because the entity's EndLine was missing (#4488/#4666).
+//
+// Walk model: find the first `{` at or after the header line (K&R or Allman),
+// then track brace depth — skipping braces inside string/char literals and
+// comments via stripBraceNoise — until depth returns to 0. The line holding
+// that closing `}` is the last line of the body; the boundary is the next
+// index. When no opening brace is found (a brace-less arrow body, or a
+// truncated window), the whole window is returned (len(lines)) so we never
+// drop real branches — honest over-inclusion beats silent truncation.
+func braceBodyEnd(lines []string) int {
+	headerIdx := -1
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) != "" {
+			headerIdx = i
+			break
+		}
+	}
+	if headerIdx < 0 {
+		return len(lines)
+	}
+	depth := 0
+	opened := false
+	for j := headerIdx; j < len(lines); j++ {
+		for _, r := range stripBraceNoise(lines[j]) {
+			switch r {
+			case '{':
+				depth++
+				opened = true
+			case '}':
+				depth--
+			}
+		}
+		if opened && depth <= 0 {
+			return j + 1 // body closes on line j; boundary is the next line
+		}
+	}
+	return len(lines)
+}
+
 // --- shared brace-block helpers -----------------------------------------
 
 // braceBlockBody returns the source lines of the block opened on or after the

--- a/internal/substrate/effect_sinks_python.go
+++ b/internal/substrate/effect_sinks_python.go
@@ -62,8 +62,25 @@ var pyHTTPRe = regexp.MustCompile(
 // pair `cursor.execute(...)` with a SELECT heuristic via a separate
 // regex (pyCursorSelectRe) so we don't double-count execute() as both
 // read and write.
+//
+// #4668 — read/write attribution asymmetry. pyDBWriteRe matches the write
+// verbs (.save/.create/.delete/...) on ANY receiver (a bare `.save(`), so a
+// layered repository's `self.queryset.save(obj)` correctly resolves db_write
+// and propagates up the controller→service→repo CALLS chain. The read side
+// only matched the `.objects.<verb>` MANAGER form, so a repository/query-builder
+// read held on a variable or attribute — `self.queryset.filter(...)`,
+// `qs.exclude(...)`, `self.get_queryset().annotate(...)` — was MISSED, and the
+// GET/list handler that delegates to it resolved PURE (the ~40 false-pure read
+// endpoints stub_detector flagged). We now ALSO match the distinctive Django
+// queryset read terminals as BARE verbs on any receiver, mirroring the write
+// side. Only queryset-distinctive names are bare-matched (filter/exclude/
+// annotate/select_related/...) — names that collide with builtins on dict/list
+// (`.get(`, `.all(`, `.first(`, `.count(`, `.values(`) stay gated to the
+// `.objects.` manager form to avoid false positives. The bare set is the
+// long-term general fix for the read-sink reach gap, not a per-endpoint patch.
 var pyDBReadRe = regexp.MustCompile(
 	`\.\s*objects\s*\.\s*(?:all|filter|exclude|get|first|last|count|exists|values|values_list|annotate|aggregate|raw|none|in_bulk|earliest|latest)\b` +
+		`|\.\s*(?:filter|exclude|annotate|select_related|prefetch_related|values_list|only|defer|distinct|order_by|get_queryset)\s*\(` +
 		`|\.\s*query\s*\(` +
 		`|\.\s*fetchall\s*\(|\.\s*fetchone\s*\(|\.\s*fetchmany\s*\(` +
 		`|\bsession\s*\.\s*(?:query|execute|scalar|scalars|get)\s*\(`,

--- a/internal/substrate/effect_sinks_python_repo_read_4668_test.go
+++ b/internal/substrate/effect_sinks_python_repo_read_4668_test.go
@@ -1,0 +1,61 @@
+package substrate
+
+// effect_sinks_python_repo_read_4668_test.go — read/write attribution symmetry
+// regression for the Python effect sniffer (#4668).
+//
+// The write sniffer matches the write verbs (.save/.create/.delete/...) on ANY
+// receiver, so a layered repository's `self.queryset.save(obj)` resolves
+// db_write and propagates up the controller→service→repo CALLS chain. The read
+// sniffer historically only matched the Django `.objects.<verb>` MANAGER form,
+// so a repository/query-builder read held on an attribute or variable —
+// `self.queryset.filter(...)`, `qs.exclude(...)`, `self.get_queryset()` — was
+// MISSED and the GET/list handler that delegates to it resolved PURE (the ~40
+// false-pure read endpoints stub_detector flagged). pyDBReadRe now also matches
+// the distinctive Django queryset read terminals as BARE verbs, mirroring the
+// write side, WITHOUT flagging dict/list builtins (.get on a dict, etc.).
+
+import "testing"
+
+func TestPythonRepoQuerysetReads_4668(t *testing.T) {
+	src := `
+class ContractRepository:
+    def list_active(self):
+        return self.queryset.filter(active=True)
+    def list_excluding(self, ids):
+        return self.queryset.exclude(id__in=ids)
+    def list_annotated(self):
+        return self.queryset.annotate(n=Count("x"))
+    def list_related(self):
+        return self.queryset.select_related("client").prefetch_related("devices")
+    def get_qs(self):
+        return self.get_queryset()
+    def save_one(self, obj):
+        return self.queryset.save(obj)
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	// Every bare-receiver queryset read must now be attributed db_read.
+	mustHave(t, by, EffectDBRead, "list_active")
+	mustHave(t, by, EffectDBRead, "list_excluding")
+	mustHave(t, by, EffectDBRead, "list_annotated")
+	mustHave(t, by, EffectDBRead, "list_related")
+	mustHave(t, by, EffectDBRead, "get_qs")
+	// The write side stays correct (already matched bare verbs).
+	mustHave(t, by, EffectDBWrite, "save_one")
+}
+
+// TestPythonReadVerbsNoDictFalsePositive_4668 guards the conservative boundary:
+// builtin .get on a dict (the single most common collision) must NOT be read as
+// db_read, so we keep ambiguous names (.get/.all/.first/.count/.values) gated to
+// the `.objects.` manager form rather than bare-matching them.
+func TestPythonReadVerbsNoDictFalsePositive_4668(t *testing.T) {
+	src := `
+def lookup(d, key):
+    return d.get(key)
+
+def first_item(items):
+    return items.count("x")
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustNotHave(t, by, EffectDBRead, "lookup")
+	mustNotHave(t, by, EffectDBRead, "first_item")
+}


### PR DESCRIPTION
Two related effects-engine accuracy bugs in the effects/branch extraction subsystem. One agent owns both to avoid conflict.

## #4666 — branch facet over-captures past the method boundary (generalized to brace langs)

`#4533` fixed the `include=branches` over-capture for **Python only** (`bodyEndPython`). But every brace-language branch analyzer (jsts/java/go/php/csharp/kotlin/scala/rust) walks its **whole** input window — so when the effects tool pads `StartLine+400` because an entity's `EndLine` is missing/zero (`#4488`), a TS/NestJS controller method's branch list bleeds into the sibling method that follows it, exactly the Python case. `response_shape_diff` (`#4424`) consumes this facet, so the bleed mis-attributes sibling branches to the wrong endpoint.

**Fix:** new `substrate.ClampToFunctionBody(src, lang)`, called once in `attachBranchesFacet` **before** any analyzer runs, trims the padded window to the target method's **own** body for every language:
- python → dedent boundary (`bodyEndPython`)
- brace languages → matching `}` of the header's block (new `braceBodyEnd`)

Conservative: an unfound opening brace returns the whole window (honest over-inclusion beats silent truncation). Ruby (`end`-delimited) falls through unchanged — tracked as #4693.

## #4668 — GET/list handlers resolved PURE when they db_read (read-sink reach)

**Root cause:** a read/write attribution asymmetry in the Python effect sniffer. `pyDBWriteRe` matches write verbs (`.save/.create/.delete/...`) on **any** receiver, so a layered repository's `self.queryset.save(obj)` resolves `db_write` and propagates up the controller→service→repo CALLS chain (POST works). The read side only matched the `.objects.<verb>` **manager** form, so a repository / query-builder read held on an attribute/variable — `self.queryset.filter(...)`, `qs.exclude(...)`, `self.get_queryset()` — was **missed**, and the GET/list handler delegating to it resolved PURE (the ~40 false-pure read endpoints stub_detector flagged). The propagation pass + stub/dashboard effect walks are effect-agnostic — `db_read` propagates identically to `db_write` once it's stamped.

**Fix:** `pyDBReadRe` now also bare-matches the distinctive Django queryset read terminals (filter/exclude/annotate/select_related/prefetch_related/values_list/only/defer/distinct/order_by/get_queryset), mirroring the write side. Builtin-colliding names (`.get/.all/.first/.count/.values`) stay gated to the `.objects.` form to avoid dict/list false positives (#4691). jsts (TypeORM/Prisma `.find*`) and java (Spring repo `.findBy*`) already bare-match reads — verified; cross-ORM audit tracked as #4692.

## Fixtures (all RED before fix, GREEN after)
- `effects_branches_4666_brace_test.go` — TS two-method controller; `createContact` branches must not bleed into sibling `updateContact` (lines 30/34/39).
- `effect_sinks_python_repo_read_4668_test.go` — bare queryset reads attributed `db_read`; `dict.get`/`list.count` stay pure.
- `TestEffectPropagation_ReadHandlerServiceRepoChain` — `db_read` reaches the list controller through the service→repo CALLS chain (symmetric with the existing write-chain test).

## Gates
`go build ./...` ✓ · `go vet` ✓ · `go test` ✓ on engine, substrate, links, mcp, stubdetector, dashboard. Live confirmation deferred to coordinator.

## Follow-ups filed
- #4691 — Python bare `.get(`/`.first(`/`.all(` queryset reads (receiver-typed gate)
- #4692 — cross-ORM/lang read-reach audit for the layered-repo pattern
- #4693 — Ruby branch method-boundary clamp

Closes #4666
Closes #4668

🤖 Generated with [Claude Code](https://claude.com/claude-code)