### PR TITLE
fix(resolve): TS/JS external packages + root-baseUrl alias resolution (#4695, #4696)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -1185,6 +1185,33 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 		return root, "package", true
 	}
 
+	// #4695 — JS/TS bare-specifier external packages. By the time an
+	// IMPORTS edge from a JS/TS file reaches this point its ToID is a raw
+	// stub: the JS/TS extractor (internal/extractors/javascript/imports.go)
+	// already exhausted relative-path resolution AND tsconfig path-alias /
+	// baseUrl resolution before leaving the spec unresolved. A specifier
+	// that is neither relative (`./`, `../`) nor an internal alias, whose
+	// root is a legal npm package name, is by construction a third-party
+	// dependency (class-validator, typeorm, mongoose, reflect-metadata,
+	// @nestjs/common, …). Third-party packages are correctly NOT indexed,
+	// so they must be routed to an ext:<package> placeholder (disposition
+	// external_package) rather than left as a bug-extractor stub that
+	// inflates the import-bug count and depresses the fidelity badge.
+	//
+	// The static isKnownExternalPackage allowlist above can never keep pace
+	// with the npm ecosystem; this branch is the catch-all that trusts the
+	// extractor's "didn't resolve internally" signal. Gated to IMPORTS so
+	// it never swallows ambiguous bare CALLS/REFERENCES targets (which may
+	// still be local symbols), and to javascript/typescript so other
+	// ecosystems keep their existing safer-bias behaviour. Per-language
+	// equivalents (pip, maven, gems, cargo, go-module, nuget) are tracked
+	// as follow-ups.
+	if (lang == "javascript" || lang == "typescript") && relKind == string(types.RelationshipKindImports) {
+		if pkg, ok := jsExternalPackageRoot(stub, relProps); ok {
+			return pkg, "package", true
+		}
+	}
+
 	// Issue #120 — receiver-typed Java/Kotlin call where the leading
 	// segment is the simple name of an imported external class.
 	// `MockMvc.perform`, `RedirectAttributes.addFlashAttribute` etc.
@@ -1951,6 +1978,79 @@ func scopedNpmRoot(s string) (string, bool) {
 		return "", false
 	}
 	return "@" + scope + "/" + pkg, true
+}
+
+// jsExternalPackageRoot derives the canonical npm package root for a
+// JS/TS IMPORTS edge that survived relative + alias resolution, returning
+// (root, true) when the specifier is a legal third-party npm package
+// (#4695). The raw import specifier is read from relProps["import_path"]
+// when present (the extractor stamps the verbatim spec there) and falls
+// back to the dotted-module stub otherwise.
+//
+// Resolution:
+//   - "./x", "../x", "/x"        → not external (relative/absolute), reject.
+//   - "@scope/pkg[/sub]"         → "@scope/pkg".
+//   - "node:fs", "fs/promises"   → leading segment ("node:fs" kept whole,
+//     "fs" for the slash form) — Node builtins are external too.
+//   - "lodash/fp", "lodash.debounce" → "lodash".
+//   - "class-validator"          → "class-validator".
+//
+// The spec must canonicalise to a legal npm name segment; anything that
+// isn't (whitespace, control chars, structural-ref residue) is rejected so
+// genuinely malformed stubs still surface as bugs.
+func jsExternalPackageRoot(stub string, relProps map[string]string) (string, bool) {
+	spec := stub
+	if relProps != nil {
+		if ip := strings.TrimSpace(relProps["import_path"]); ip != "" {
+			spec = ip
+		}
+	}
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", false
+	}
+	// Relative / absolute specifiers are project-internal (or out-of-repo
+	// file paths) — never external npm packages.
+	if strings.HasPrefix(spec, "./") || strings.HasPrefix(spec, "../") ||
+		strings.HasPrefix(spec, "/") || spec == "." || spec == ".." {
+		return "", false
+	}
+	// Node builtins of the explicit `node:<mod>` form — keep the prefix so
+	// the placeholder is distinct from a same-named npm package.
+	if strings.HasPrefix(spec, "node:") {
+		mod := spec[len("node:"):]
+		if i := strings.IndexByte(mod, '/'); i > 0 {
+			mod = mod[:i]
+		}
+		if mod != "" && isNodeBuiltinIdent(mod) {
+			return "node:" + mod, true
+		}
+		return "", false
+	}
+	// Scoped npm packages: "@scope/pkg[/sub]" → "@scope/pkg".
+	if scope, ok := scopedNpmRoot(spec); ok {
+		return scope, true
+	}
+	// A leading '@' that did NOT match the scoped form is malformed.
+	if strings.HasPrefix(spec, "@") {
+		return "", false
+	}
+	// Unscoped: take the first path segment ("lodash/fp" → "lodash"). When
+	// the spec arrived in dotted-module form (the extractor's fallback for
+	// bare specifiers), take the first dot segment instead.
+	root := spec
+	if i := strings.IndexByte(root, '/'); i > 0 {
+		root = root[:i]
+	} else if i := strings.IndexByte(root, '.'); i > 0 {
+		// Dotted-module fallback form (e.g. "lodash.debounce"); the leading
+		// segment is the package. Note legitimate package names never start
+		// with '.' (caught by the relative reject above).
+		root = root[:i]
+	}
+	if !isNpmSegment(root) {
+		return "", false
+	}
+	return root, true
 }
 
 // isNpmSegment reports whether s is a valid scope or package segment

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -370,6 +370,67 @@ func TestSynthesize_ScopeExternalRejectsPathSeparator(t *testing.T) {
 	}
 }
 
+// TestSynthesize_JSExternalPackages_Fixture is Fixture A for #4695: a JS/TS
+// file importing bare third-party npm packages that are NOT on the static
+// isKnownExternalPackage allowlist (class-validator, typeorm) must be
+// routed to ext:<package> placeholders (disposition external_package) rather
+// than left as bug-extractor stubs that inflate the import-bug count and
+// depress the fidelity badge.
+func TestSynthesize_JSExternalPackages_Fixture(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "aaaaaaaaaaaaaaaa", Name: "src/user.dto.ts", Language: "typescript", SourceFile: "src/user.dto.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "aaaaaaaaaaaaaaaa", ToID: "class-validator", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "typescript", "import_path": "class-validator"}},
+			{ID: "rel-2", FromID: "aaaaaaaaaaaaaaaa", ToID: "typeorm", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "typescript", "import_path": "typeorm"}},
+			// Scoped package NOT on the static allowlist — exercises the
+			// #4695 catch-all via import_path (collapses to "@scope/pkg").
+			{ID: "rel-3", FromID: "aaaaaaaaaaaaaaaa", ToID: "@acme.widgets", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "typescript", "import_path": "@acme/widgets/sub"}},
+			// Subpath import collapses to the package root.
+			{ID: "rel-4", FromID: "aaaaaaaaaaaaaaaa", ToID: "class-transformer.plainToClass", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "typescript", "import_path": "class-transformer/plain"}},
+		},
+	}
+	Synthesize(doc)
+
+	want := map[string]string{
+		"rel-1": "ext:class-validator",
+		"rel-2": "ext:typeorm",
+		"rel-3": "ext:@acme/widgets",
+		"rel-4": "ext:class-transformer",
+	}
+	for _, r := range doc.Relationships {
+		if exp, ok := want[r.ID]; ok && r.ToID != exp {
+			t.Errorf("%s ToID=%q, want %q", r.ID, r.ToID, exp)
+		}
+	}
+}
+
+// TestSynthesize_JSRelativeImportNotExternal confirms the #4695 branch does
+// NOT swallow relative imports as external packages — a `./` specifier is
+// project-internal and must not be routed to an ext: placeholder.
+func TestSynthesize_JSRelativeImportNotExternal(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "aaaaaaaaaaaaaaaa", Name: "src/a.ts", Language: "typescript", SourceFile: "src/a.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "aaaaaaaaaaaaaaaa", ToID: "src.b", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "typescript", "import_path": "./b"}},
+		},
+	}
+	Synthesize(doc)
+	for _, r := range doc.Relationships {
+		if strings.HasPrefix(r.ToID, "ext:") {
+			t.Errorf("relative import wrongly externalised: ToID=%q", r.ToID)
+		}
+	}
+}
+
 // TestSynthesize_KindNameForm covers the "Kind:Name" stub shape, e.g.
 // "Module:django" or "Function:Println" — the leading kind hint is
 // stripped and the bare Name is classified.

--- a/internal/extractors/javascript/aliases.go
+++ b/internal/extractors/javascript/aliases.go
@@ -115,8 +115,19 @@ type AliasMap struct {
 	// BaseURL is the repo-relative path of tsconfig compilerOptions.baseUrl
 	// when the tsconfig has no paths{} entries. Empty when paths{} are
 	// declared (paths take precedence and the baseUrl-only fallback is not
-	// needed) or when no tsconfig is present.
+	// needed), when no tsconfig is present, OR when baseUrl is the repo root
+	// (`.` / `./`) — in which case BaseURLSet is true and BaseURL is "".
 	BaseURL string
+	// BaseURLSet (#4696) records whether tsconfig declared ANY baseUrl —
+	// including the repo-root form (`baseUrl: "."`). The root form is the
+	// common TS path-alias-free convention `import { X } from 'src/modules/...'`
+	// where every bare specifier rooted at a real top-level source dir
+	// (`src`, `app`, `lib`, ...) is project-internal, resolved against the
+	// repo root. BaseURL stays "" for the root form so callers concatenate
+	// the bare specifier directly; BaseURLSet distinguishes it from the
+	// "no baseUrl at all" case (where BaseURLSet is false and the bare
+	// specifier is treated as an npm package).
+	BaseURLSet bool
 }
 
 // Resolve returns the repo-relative POSIX path the import specifier
@@ -270,18 +281,27 @@ func LoadAliasMap(repoRoot string) AliasMap {
 	// that happen to share a name (e.g. "react") are not misclassified when
 	// no matching file exists under baseUrl.
 	var baseURL string
+	var baseURLSet bool
 	if len(tsEntries) == 0 {
-		baseURL = parseTsconfigBaseURL(repoRoot)
+		baseURL, baseURLSet = parseTsconfigBaseURL(repoRoot)
 	}
 
-	return AliasMap{entries: dedupAliasEntries(entries), BaseURL: baseURL}
+	return AliasMap{entries: dedupAliasEntries(entries), BaseURL: baseURL, BaseURLSet: baseURLSet}
 }
 
 // parseTsconfigBaseURL reads the tsconfig.json / jsconfig.json at configDir
-// and returns the repo-relative baseUrl value, or "" when none is set or
-// the file cannot be parsed. Used by LoadAliasMap to populate AliasMap.BaseURL
-// when no paths{} entries are present.
-func parseTsconfigBaseURL(configDir string) string {
+// and returns (baseURL, set). set is true when a compilerOptions.baseUrl is
+// declared at all — including the repo-root forms `.` / `./` (#4696), which
+// resolve bare specifiers against the repo root and yield baseURL == "". A
+// non-root baseUrl (e.g. "src") yields that repo-relative path. When no
+// baseUrl is declared (or the file cannot be parsed) set is false and
+// baseURL is "".
+//
+// Distinguishing "baseUrl: '.'" (set, root) from "no baseUrl" (unset) is the
+// crux of #4696: the root form is the dominant `import { X } from
+// 'src/modules/...'` convention where every bare specifier rooted at a real
+// top-level source directory is project-internal, not an npm package.
+func parseTsconfigBaseURL(configDir string) (string, bool) {
 	for _, name := range []string{"tsconfig.json", "jsconfig.json"} {
 		configPath := filepath.Join(configDir, name)
 		data, err := os.ReadFile(configPath)
@@ -297,12 +317,18 @@ func parseTsconfigBaseURL(configDir string) string {
 		if err := json.Unmarshal(cleaned, &raw); err != nil {
 			continue
 		}
-		bu := strings.TrimPrefix(strings.TrimPrefix(raw.CompilerOptions.BaseURL, "./"), "/")
-		if bu != "" && bu != "." {
-			return bu
+		if raw.CompilerOptions.BaseURL == "" {
+			continue
 		}
+		bu := strings.TrimPrefix(strings.TrimPrefix(raw.CompilerOptions.BaseURL, "./"), "/")
+		// Root baseUrl (`.` / `./`): set, but resolves against the repo
+		// root with no directory prefix.
+		if bu == "" || bu == "." {
+			return "", true
+		}
+		return bu, true
 	}
-	return ""
+	return "", false
 }
 
 // loadSubdirAliasMap parses configs found under a specific subdirectory

--- a/internal/extractors/javascript/imports.go
+++ b/internal/extractors/javascript/imports.go
@@ -240,13 +240,22 @@ func (x *extractor) collectFromImportStatement(n *sitter.Node, out *[]importBind
 			// external-synth (external-unknown) — honest disposition and
 			// keeps RN/Expo bug-extractor counts off the floor.
 			aliasResolved = exists
-		} else if x.aliases.BaseURL != "" && x.repoRoot != "" {
-			// Synthetic baseUrl fallback (#2576): when tsconfig has baseUrl
-			// but no paths{}, resolve bare imports relative to baseUrl only
-			// when the candidate file actually exists on disk. npm package
-			// imports (e.g. "react") that have no matching file under baseUrl
-			// are left unresolved here and fall through to external treatment.
-			candidate := x.aliases.BaseURL + "/" + source
+		} else if x.aliases.BaseURLSet && x.repoRoot != "" {
+			// Synthetic baseUrl fallback (#2576 / #4696): when tsconfig has a
+			// baseUrl but no paths{}, resolve bare imports relative to baseUrl
+			// only when the candidate file actually exists on disk. npm
+			// package imports (e.g. "react") that have no matching file under
+			// baseUrl are left unresolved here and fall through to external
+			// treatment — the on-disk existence check is what keeps this safe.
+			//
+			// #4696: BaseURL == "" with BaseURLSet == true is the repo-root
+			// form (`baseUrl: "."`), the dominant `import 'src/modules/...'`
+			// convention. The candidate is the bare specifier resolved
+			// directly against the repo root (no directory prefix).
+			candidate := source
+			if x.aliases.BaseURL != "" {
+				candidate = x.aliases.BaseURL + "/" + source
+			}
 			if found := firstExistingJSPath(x.repoRoot, candidate); found != "" {
 				resolved = found
 				aliasResolved = true

--- a/internal/extractors/javascript/tsconfig_paths_test.go
+++ b/internal/extractors/javascript/tsconfig_paths_test.go
@@ -393,6 +393,97 @@ func TestTSExtractor_TsconfigBaseUrlAndPaths_PathsWins(t *testing.T) {
 	}
 }
 
+// TestTSExtractor_TsconfigRootBaseUrl_ResolvesSrcImport is Fixture B for
+// #4696: a tsconfig with `baseUrl: "."` (repo root, no paths{}) and an import
+// rooted at a real top-level source dir — `import { X } from 'src/modules/x'`
+// — must resolve to the internal target file under the repo root, NOT be
+// left unresolved (which previously surfaced as 91 `src`-rooted
+// external_unknown edges on upvate-v3).
+func TestTSExtractor_TsconfigRootBaseUrl_ResolvesSrcImport(t *testing.T) {
+	resetAliasMapCache()
+	dir := t.TempDir()
+
+	// Root baseUrl, no paths{}. This is the exact upvate-v3 shape.
+	writeTsconfigAliasFile(t, dir, `{
+		"compilerOptions": {
+			"baseUrl": "."
+		}
+	}`)
+
+	// AliasMap must record BaseURLSet=true even though BaseURL is "" (root).
+	m := LoadAliasMap(dir)
+	if !m.BaseURLSet {
+		t.Fatalf("expected BaseURLSet=true for baseUrl: '.'")
+	}
+	if m.BaseURL != "" {
+		t.Errorf("expected BaseURL=='' for root baseUrl, got %q", m.BaseURL)
+	}
+
+	// Target file under src/modules/.
+	modDir := filepath.Join(dir, "src", "modules")
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writePlainFile(t, modDir, "x.ts", `export class X {}`)
+
+	src := []byte(`import { X } from 'src/modules/x';`)
+	tree := parseTSForAlias(t, src)
+	entities := extractWithRepo(t, dir, "src/app.ts", src, tree)
+
+	paths := importsEdgePaths2572(entities)
+	if len(paths) == 0 {
+		t.Fatal("no IMPORTS edges emitted")
+	}
+	// The import must resolve to the internal target file under src/modules,
+	// not remain a bare external spec rooted at "src".
+	found := false
+	for p := range paths {
+		if (strings.Contains(p, "src") && strings.Contains(p, "modules") && strings.Contains(p, "x")) ||
+			p == "src/modules/x.ts" || p == "src/modules/x" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected resolved internal edge for 'src/modules/x'; got %v", paths)
+	}
+}
+
+// TestTSExtractor_TsconfigRootBaseUrl_ExternalStillFallsThrough confirms the
+// #4696 root-baseUrl branch only resolves specifiers that actually exist on
+// disk: a bare npm import with no matching file under the repo root must NOT
+// be misclassified as project-internal.
+func TestTSExtractor_TsconfigRootBaseUrl_ExternalStillFallsThrough(t *testing.T) {
+	resetAliasMapCache()
+	dir := t.TempDir()
+
+	writeTsconfigAliasFile(t, dir, `{
+		"compilerOptions": {
+			"baseUrl": "."
+		}
+	}`)
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// No file matches 'class-validator' under the repo root.
+	src := []byte(`import { IsString } from 'class-validator';`)
+	tree := parseTSForAlias(t, src)
+	entities := extractWithRepo(t, dir, "src/dto.ts", src, tree)
+
+	paths := importsEdgePaths2572(entities)
+	if !paths["class-validator"] {
+		t.Errorf("expected raw external import_path 'class-validator'; got %v", paths)
+	}
+	for p := range paths {
+		if strings.HasPrefix(p, "class-validator.") {
+			t.Errorf("'class-validator' must not resolve via root baseUrl; got %q", p)
+		}
+	}
+}
+
 // --- test helpers -----------------------------------------------------------
 
 func writeTsconfigAliasFile(t *testing.T, dir, body string) {


### PR DESCRIPTION
Fixes two TS/JS import-resolution accuracy bugs found via live MCP audit of upvate-v3 (fidelity stuck at 0.901 warning; 91 `src`-rooted unresolved imports).

## #4695 — external npm packages mislabeled as import bugs
704 of upvate-v3's 807 "unresolved import bugs" were third-party npm packages (class-validator 289, typeorm 192, class-transformer 108, mongoose 95, reflect-metadata 13, aws 6). These are correctly not indexed, but were counted as `fidelity_import_bug`, holding the fidelity badge at warning.

**Fix:** new JS/TS catch-all in `internal/external/synth.go` `classifyExternal` (`jsExternalPackageRoot`). A bare IMPORTS specifier on a `javascript`/`typescript` edge that survived relative + tsconfig alias/baseUrl resolution is — by construction — a third-party package. It's routed to an `ext:<package>` placeholder (`external_package` disposition), so it gets a resolved `ext:` ToID and is excluded from `fidelity_import_bug` (counted in `countEdgesForFidelity` via `isBugEdgeToID`). The static `isKnownExternalPackage` allowlist can never keep pace with npm; this branch trusts the extractor's "didn't resolve internally" signal. Reads the raw `import_path` property; handles scoped (`@scope/pkg`), subpath (`lodash/fp`), and `node:<mod>` forms. Relative/absolute specifiers are rejected.

## #4696 — TS root-baseUrl path-alias imports unresolved
91 imports rooted at `src` were `tsconfig` root-baseUrl imports (`import { X } from 'src/modules/...'` with `baseUrl: "."`). `parseTsconfigBaseURL` returned `""` for both `baseUrl: "."` and "no baseUrl", so the baseUrl fallback never ran and these surfaced as `src`-rooted `external_unknown` — real internal imports resolving to nothing (under-linking).

**Fix:** add `AliasMap.BaseURLSet` to record that a baseUrl was declared, including the repo-root form (`.`/`./`). The JS extractor now resolves bare specifiers directly against the repo root (no directory prefix) with an on-disk existence check. npm packages with no matching file still fall through to external treatment.

**Precedence (unchanged):** relative → tsconfig path-alias/baseUrl (internal) → external_package → unresolved.

## Fixtures
- **A** (`internal/external/synth_test.go`): `class-validator` + `typeorm` (+ unlisted `@acme/widgets`, subpath collapse) → `external_package`, not bug; relative import not externalised.
- **B** (`internal/extractors/javascript/tsconfig_paths_test.go`): `baseUrl: "."` + `import 'src/modules/x'` → resolves to internal target; `class-validator` with no on-disk file still falls through to external.

## Generalize (standing rule)
Per-language follow-ups filed: #4699 (Python/pip), #4700 (Java/maven), #4701 (Ruby/gems), #4702 (Go/module), #4703 (Rust/crates), #4704 (.NET/nuget), #4705 (module-root/alias: Java source roots, Python PYTHONPATH, Go replace).

## Gates
`go build ./...` clean; `go vet` + `go test` green on `internal/resolve/...`, `internal/external/...`, `internal/extractors/javascript/...` (plus `internal/graph/...`, `internal/mcp/...` for the fidelity-counting path). DEPLOY-DEFERRED; coordinator live-validates upvate-v3 fidelity↑ and `src`-unresolved↓ at next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)