### PR TITLE
feat(mcp): framework-pluggable effective_contract + NestJS resolver (#4601)

### DIFF
--- a/internal/mcp/effective_contract.go
+++ b/internal/mcp/effective_contract.go
@@ -76,6 +76,60 @@ type effectiveContract struct {
 	// AuthRequired is true when a non-AllowAny permission or any authentication
 	// class is in effect on the route.
 	AuthRequired bool `json:"auth_required,omitempty"`
+
+	// --- Cross-framework contract fields (#4601) ---------------------------
+	//
+	// The DRF projection above leaves these zero/empty (DRF callers consume the
+	// flat status/serializer fields). The NestJS resolver (and future Spring /
+	// FastAPI / Express resolvers) populate them so the cross-group
+	// response_shape_diff / parity tools can consume a structured request +
+	// per-branch response contract for ANY framework.
+
+	// RequestFields are the resolved request-shape members for this endpoint:
+	// the @Body / @Query / @Param DTO field members (CONTAINS → SCOPE.Schema/
+	// field) and scalar params. Empty when no request shape is resolvable
+	// (honest-partial). Sorted for stable output.
+	RequestFields []contractField `json:"request_fields,omitempty"`
+
+	// ResponseBranches are the per-branch response outcomes the handler can
+	// produce — one {status, shape} per detected return/throw branch (from the
+	// effects-branches facet). Empty when no branching response is resolvable.
+	// Sorted by status for stable output.
+	ResponseBranches []contractResponseBranch `json:"response_branches,omitempty"`
+
+	// AuthKind is the resolved auth posture vocabulary term (public /
+	// authenticated / page / action / role / scope / superuser / unknown), and
+	// AuthLiteral the page-slug / action-codename / role / scope it carries.
+	// Populated by the framework resolver from the effective guard (#4667).
+	AuthKind    string `json:"auth_kind,omitempty"`
+	AuthLiteral string `json:"auth_literal,omitempty"`
+	// Framework is the resolver that produced this contract ("django-drf",
+	// "nestjs", …), for cross-group provenance.
+	Framework string `json:"framework,omitempty"`
+}
+
+// contractField is one resolved request-shape member: its name, the location
+// it arrives in (body / query / param), the declared type when known, and the
+// DTO it belongs to. Source is the signal it was composed from (dto_field /
+// scalar_param) for provenance.
+type contractField struct {
+	Name     string `json:"name"`
+	In       string `json:"in,omitempty"`       // body | query | param
+	Type     string `json:"type,omitempty"`     // declared TS type when known
+	DTO      string `json:"dto,omitempty"`      // owning DTO type, when a DTO field
+	Required bool   `json:"required,omitempty"` // false when the field is optional (`?`)
+	Source   string `json:"source,omitempty"`   // dto_field | scalar_param
+}
+
+// contractResponseBranch is one per-branch response outcome: the HTTP status
+// the branch produces and a short shape descriptor of its payload. Mirrors the
+// DRF default_status + error_statuses split but per concrete branch, so a
+// 200/201/409-branching handler surfaces all three.
+type contractResponseBranch struct {
+	Status int    `json:"status,omitempty"`
+	Shape  string `json:"shape,omitempty"`
+	// Outcome is the branch disposition ("return_value" / "raise") for context.
+	Outcome string `json:"outcome,omitempty"`
 }
 
 // isRouterExpandedRoute reports whether e is a DRF router-expanded route entity

--- a/internal/mcp/effective_contract_nestjs.go
+++ b/internal/mcp/effective_contract_nestjs.go
@@ -1,0 +1,483 @@
+package mcp
+
+// effective_contract_nestjs.go — the NestJS effective-contract resolver
+// (#4601). Composes the per-endpoint full contract for a NestJS controller from
+// signals that ALREADY exist on the graph — it re-extracts nothing:
+//
+//   - REQUEST SHAPE: the handler's @Body/@Query/@Param DTO (the VALIDATES edge
+//     the JS extractor emits to `dto:<TypeName>`, via=dto_extraction, carrying
+//     the decorator in `method` — #4623/#4635) plus the DTO's FIELD members
+//     (SCOPE.Schema subtype=field named "<DTO>.<field>", CONTAINS-linked from
+//     the DTO class). The endpoint's `request_body_type` prop is a fallback
+//     when the handler entity is unresolved.
+//
+//   - RESPONSE SHAPE + PER-BRANCH STATUS: the effects-branches facet
+//     (#4423/#4666) — the per-language branch analyzer run over the handler
+//     body, yielding {status, shape} per return/throw branch. NestJS named
+//     exceptions (`throw new ConflictException()` → 409) and `HttpStatus.NAME`
+//     are decoded by the analyzer (this ticket extended jstsStatusFromBody).
+//
+//   - AUTH POSTURE: the effective guard (#4667) — decoded by the shared
+//     authposture registry's NestJS resolver from the engine-reconciled
+//     auth_guard / require_page / … props on the handler/endpoint.
+//
+// The emitted effectiveContract is the SAME structure the DRF resolver returns
+// (status set via ResponseBranches, request fields, auth), so the cross-group
+// response_shape_diff / parity tools consume both DRF and NestJS contracts.
+
+import (
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/authposture"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/substrate"
+)
+
+// nestJSContractResolver composes effective contracts for NestJS controllers.
+type nestJSContractResolver struct{}
+
+func (nestJSContractResolver) Name() string { return "nestjs" }
+
+// Resolve gathers every NestJS http_endpoint_definition whose owning controller
+// leaf matches wantLeaf, composes each endpoint's request/response/auth
+// contract, and groups them by (repo, controller). ok=false when no NestJS
+// endpoint is attributed to the target (so the registry tries the next
+// resolver).
+func (n nestJSContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string) ([]effectiveContractGroup, bool) {
+	type groupKey struct{ repo, class string }
+	groups := map[groupKey]*effectiveContractGroup{}
+	var order []groupKey
+
+	for _, r := range reposToConsider(lg, nil) {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isServerEndpointDefinition(e) {
+				continue
+			}
+			if !isNestJSEndpoint(e) {
+				continue
+			}
+			handler := nestHandlerEntity(r, e)
+			controller := nestControllerLeaf(e, handler)
+			if controller == "" || strings.ToLower(controller) != wantLeaf {
+				continue
+			}
+			c := composeNestContract(r, e, handler)
+			key := groupKey{repo: r.Repo, class: controller}
+			g, exists := groups[key]
+			if !exists {
+				g = &effectiveContractGroup{
+					Class:     controller,
+					Framework: "nestjs",
+					Repo:      r.Repo,
+				}
+				groups[key] = g
+				order = append(order, key)
+			}
+			g.Handlers = append(g.Handlers, c)
+		}
+	}
+	if len(groups) == 0 {
+		return nil, false
+	}
+
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].repo != order[j].repo {
+			return order[i].repo < order[j].repo
+		}
+		return order[i].class < order[j].class
+	})
+	out := make([]effectiveContractGroup, 0, len(order))
+	for _, key := range order {
+		g := groups[key]
+		sortEffectiveContracts(g.Handlers)
+		out = append(out, *g)
+	}
+	return out, true
+}
+
+// isNestJSEndpoint reports whether an endpoint definition belongs to NestJS.
+// Recognised by an explicit framework prop OR by the NestJS auth-decorator /
+// guard property signature the metadata pass stamps.
+func isNestJSEndpoint(e *graph.Entity) bool {
+	fw := endpointFramework(e)
+	if strings.Contains(fw, "nest") {
+		return true
+	}
+	// A TS endpoint carrying any Nest-characteristic prop is NestJS even when the
+	// framework hint was not stamped (graphs frequently omit it).
+	if fw == "typescript" || fw == "javascript" || fw == "ts" || fw == "js" {
+		p := e.Properties
+		if p["require_page"] != "" || p["require_action"] != "" || p["auth_guard"] != "" ||
+			p["request_body_type"] != "" || p["operation_id"] != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// nestHandlerEntity resolves the controller-method entity backing a NestJS
+// endpoint definition. It follows the inbound IMPLEMENTS edge the endpoint
+// resolution pass emits (handler → endpoint). nil when the handler is
+// unresolved (honest-partial: the resolver degrades to endpoint props).
+func nestHandlerEntity(r *LoadedRepo, ep *graph.Entity) *graph.Entity {
+	adj := r.getAdjacency()
+	byID := r.getByID()
+	for _, ed := range adj.Incoming(ep.ID) {
+		if !strings.EqualFold(ed.kind, "IMPLEMENTS") {
+			continue
+		}
+		if h := byID[ed.target]; h != nil {
+			return h
+		}
+	}
+	return nil
+}
+
+// nestControllerLeaf returns the controller leaf name an endpoint belongs to —
+// the prefix of the handler's qualified name ("UsersController.create" →
+// "UsersController"), falling back to the endpoint's own controller attribution
+// props.
+func nestControllerLeaf(ep *graph.Entity, handler *graph.Entity) string {
+	if handler != nil {
+		qn := handler.QualifiedName
+		if qn == "" {
+			qn = handler.Name
+		}
+		if owning := prefixBeforeDot(qn); owning != "" {
+			return leafAfterDot(owning)
+		}
+	}
+	if c := ep.Properties["controller"]; c != "" {
+		return leafAfterDot(c)
+	}
+	// source_handler is "<HandlerKind>:<Controller.method>" or "<Controller.method>".
+	if sh := ep.Properties["source_handler"]; sh != "" {
+		if i := strings.LastIndex(sh, ":"); i >= 0 {
+			sh = sh[i+1:]
+		}
+		if owning := prefixBeforeDot(sh); owning != "" {
+			return leafAfterDot(owning)
+		}
+	}
+	return ""
+}
+
+// composeNestContract builds the effectiveContract for one NestJS endpoint from
+// its request DTO fields, per-branch response shapes, and auth posture.
+func composeNestContract(r *LoadedRepo, ep *graph.Entity, handler *graph.Entity) effectiveContract {
+	c := effectiveContract{
+		Framework: "nestjs",
+		Verb:      strings.ToUpper(ep.Properties["verb"]),
+		Path:      ep.Properties["path"],
+		Kind:      "explicit",
+	}
+	if handler != nil {
+		hq := handler.QualifiedName
+		if hq == "" {
+			hq = handler.Name
+		}
+		c.Handler = leafAfterDot(prefixBeforeDot(hq)) + "." + leafAfterDot(hq)
+		c.SourceClass = leafAfterDot(prefixBeforeDot(hq))
+	}
+
+	c.RequestFields = composeNestRequestFields(r, ep, handler)
+	c.ResponseBranches = composeNestResponseBranches(r, handler)
+	applyNestAuthPosture(r, ep, handler, &c)
+
+	// Mirror the DRF status split so the flat status fields stay populated for
+	// consumers that read them: the lowest 2xx branch is the default success,
+	// every >=400 branch is an error status.
+	for _, b := range c.ResponseBranches {
+		switch {
+		case b.Status >= 200 && b.Status < 300:
+			if c.DefaultStatus == 0 || b.Status < c.DefaultStatus {
+				c.DefaultStatus = b.Status
+			}
+		case b.Status >= 400:
+			c.ErrorStatuses = appendIntUnique(c.ErrorStatuses, b.Status)
+		}
+	}
+	sort.Ints(c.ErrorStatuses)
+	return c
+}
+
+// composeNestRequestFields resolves the endpoint's request-shape members: the
+// handler's @Body/@Query/@Param DTO field members plus the DTO type fallback.
+func composeNestRequestFields(r *LoadedRepo, ep *graph.Entity, handler *graph.Entity) []contractField {
+	var fields []contractField
+	seen := map[string]bool{}
+
+	add := func(f contractField) {
+		k := f.In + "\x00" + f.Name
+		if f.Name == "" || seen[k] {
+			return
+		}
+		seen[k] = true
+		fields = append(fields, f)
+	}
+
+	// Handler VALIDATES edges → dto:<Type>, decorator in the edge's `method`.
+	if handler != nil {
+		adj := r.getAdjacency()
+		for _, ed := range adj.Outgoing(handler.ID) {
+			if !strings.EqualFold(ed.kind, "VALIDATES") {
+				continue
+			}
+			rel := relPropsFor(r, ed.relIdx)
+			dtoType := rel["dto"]
+			if dtoType == "" {
+				dtoType = strings.TrimPrefix(ed.target, "dto:")
+			}
+			in := decoratorToIn(rel["method"])
+			for _, mf := range nestDTOFields(r, dtoType) {
+				mf.In = in
+				mf.DTO = dtoType
+				mf.Source = "dto_field"
+				add(mf)
+			}
+		}
+	}
+
+	// Fallback: the endpoint's request_body_type prop names the @Body DTO even
+	// when the handler entity was unresolved — surface its fields if findable.
+	if len(fields) == 0 {
+		if dtoType := ep.Properties["request_body_type"]; dtoType != "" {
+			for _, mf := range nestDTOFields(r, dtoType) {
+				mf.In = "body"
+				mf.DTO = dtoType
+				mf.Source = "dto_field"
+				add(mf)
+			}
+		}
+	}
+
+	sort.Slice(fields, func(i, j int) bool {
+		if fields[i].In != fields[j].In {
+			return fields[i].In < fields[j].In
+		}
+		return fields[i].Name < fields[j].Name
+	})
+	return fields
+}
+
+// nestDTOFields returns the FIELD members of a DTO type — the SCOPE.Schema
+// subtype=field entities named "<DTO>.<field>" the JS extractor emits for each
+// class-validator field. The type annotation is lifted from the field's
+// signature, and a trailing "?" on the field name marks it optional.
+func nestDTOFields(r *LoadedRepo, dtoType string) []contractField {
+	if r.Doc == nil || dtoType == "" {
+		return nil
+	}
+	prefix := dtoType + "."
+	var out []contractField
+	for i := range r.Doc.Entities {
+		e := &r.Doc.Entities[i]
+		if !strings.EqualFold(e.Kind, "SCOPE.Schema") || e.Subtype != "field" {
+			continue
+		}
+		if !strings.HasPrefix(e.Name, prefix) {
+			continue
+		}
+		name := strings.TrimPrefix(e.Name, prefix)
+		required := true
+		if strings.HasSuffix(name, "?") {
+			name = strings.TrimSuffix(name, "?")
+			required = false
+		}
+		out = append(out, contractField{
+			Name:     name,
+			Type:     fieldTypeFromSignature(e.Signature),
+			Required: required,
+		})
+	}
+	return out
+}
+
+// fieldTypeFromSignature lifts the declared type from a field signature of the
+// form "name: Type" (the form handlePublicFieldDefinition emits). Empty when
+// the signature carries no annotation.
+func fieldTypeFromSignature(sig string) string {
+	if i := strings.Index(sig, ":"); i >= 0 {
+		return strings.TrimSpace(sig[i+1:])
+	}
+	return ""
+}
+
+// decoratorToIn maps a NestJS DTO decorator ("@Body()", "@Query()", "@Param()")
+// to the request location it binds.
+func decoratorToIn(decorator string) string {
+	d := strings.ToLower(decorator)
+	switch {
+	case strings.Contains(d, "query"):
+		return "query"
+	case strings.Contains(d, "param"):
+		return "param"
+	case strings.Contains(d, "body"):
+		return "body"
+	default:
+		return "body"
+	}
+}
+
+// composeNestResponseBranches runs the per-language branch analyzer (the #4423
+// effects-branches facet) over the handler body and projects each return/throw
+// branch into a {status, shape} response branch.
+func composeNestResponseBranches(r *LoadedRepo, handler *graph.Entity) []contractResponseBranch {
+	if handler == nil || handler.StartLine <= 0 {
+		return nil
+	}
+	lang := substrate.LanguageForPath(handler.SourceFile)
+	analyzer := substrate.BranchAnalyzerFor(lang)
+	if analyzer == nil {
+		return nil
+	}
+	start, end := branchSourceSpan(handler)
+	if start <= 0 {
+		return nil
+	}
+	abs := handler.SourceFile
+	if !filepath.IsAbs(abs) && r.Path != "" {
+		abs = filepath.Join(r.Path, handler.SourceFile)
+	}
+	src, err := readRawSourceWindow(abs, start, end)
+	if err != nil || src == "" {
+		return nil
+	}
+	src = substrate.ClampToFunctionBody(src, lang)
+	facets := analyzer(src, start)
+
+	var out []contractResponseBranch
+	seen := map[int]bool{}
+	for _, f := range facets {
+		if f.Returns == nil {
+			continue
+		}
+		status := 0
+		if f.Returns.Status != "" {
+			status, _ = strconv.Atoi(f.Returns.Status)
+		}
+		if status == 0 && f.Returns.Shape == "" {
+			continue
+		}
+		if status != 0 {
+			if seen[status] {
+				continue
+			}
+			seen[status] = true
+		}
+		out = append(out, contractResponseBranch{
+			Status:  status,
+			Shape:   f.Returns.Shape,
+			Outcome: string(f.Outcome),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Status != out[j].Status {
+			return out[i].Status < out[j].Status
+		}
+		return out[i].Shape < out[j].Shape
+	})
+	return out
+}
+
+// applyNestAuthPosture decodes the endpoint's effective guard (#4667) via the
+// shared authposture NestJS resolver and stamps the posture onto the contract.
+// The handler's source (when resolvable) is supplied as the decorator fallback.
+func applyNestAuthPosture(r *LoadedRepo, ep *graph.Entity, handler *graph.Entity, c *effectiveContract) {
+	sig := authposture.Signal{
+		Framework: "nestjs",
+		Props:     mergedAuthProps(ep, handler),
+		Source:    nestHandlerSource(r, handler),
+	}
+	p, _ := authposture.NewRegistry().Resolve(sig)
+	if p.Kind == "" {
+		return
+	}
+	c.AuthKind = string(p.Kind)
+	c.AuthLiteral = p.Literal
+	c.AuthRequired = p.Kind != authposture.KindPublic && p.Kind != authposture.KindUnknown
+	if p.Literal != "" {
+		c.Permissions = appendStringUnique(c.Permissions, p.Literal)
+	}
+}
+
+// mergedAuthProps merges the endpoint's auth props with the handler's (handler
+// props win — they are the most-specific decorator metadata) into one bag for
+// the authposture Signal.
+func mergedAuthProps(ep *graph.Entity, handler *graph.Entity) map[string]string {
+	out := map[string]string{}
+	for k, v := range ep.Properties {
+		out[k] = v
+	}
+	if handler != nil {
+		for k, v := range handler.Properties {
+			if v != "" {
+				out[k] = v
+			}
+		}
+	}
+	return out
+}
+
+// nestHandlerSource reads the handler's source window (for the auth-decorator
+// fallback). Empty when unresolvable — the resolver degrades to props-only.
+func nestHandlerSource(r *LoadedRepo, handler *graph.Entity) string {
+	if handler == nil || handler.StartLine <= 0 {
+		return ""
+	}
+	start, end := branchSourceSpan(handler)
+	if start <= 0 {
+		return ""
+	}
+	abs := handler.SourceFile
+	if !filepath.IsAbs(abs) && r.Path != "" {
+		abs = filepath.Join(r.Path, handler.SourceFile)
+	}
+	// Reach a few lines above the signature to capture method decorators.
+	if start > 6 {
+		start -= 6
+	} else {
+		start = 1
+	}
+	src, _ := readRawSourceWindow(abs, start, end)
+	return src
+}
+
+// relPropsFor returns the Properties map of the relationship at relIdx in r's
+// Doc, or nil when relIdx is synthetic (-1) or out of range.
+func relPropsFor(r *LoadedRepo, relIdx int) map[string]string {
+	if r.Doc == nil || relIdx < 0 || relIdx >= len(r.Doc.Relationships) {
+		return nil
+	}
+	return r.Doc.Relationships[relIdx].Properties
+}
+
+// appendIntUnique appends v to s only when absent.
+func appendIntUnique(s []int, v int) []int {
+	for _, x := range s {
+		if x == v {
+			return s
+		}
+	}
+	return append(s, v)
+}
+
+// appendStringUnique appends v to s only when absent and non-empty.
+func appendStringUnique(s []string, v string) []string {
+	if v == "" {
+		return s
+	}
+	for _, x := range s {
+		if x == v {
+			return s
+		}
+	}
+	return append(s, v)
+}

--- a/internal/mcp/effective_contract_nestjs_4601_test.go
+++ b/internal/mcp/effective_contract_nestjs_4601_test.go
@@ -1,0 +1,204 @@
+package mcp
+
+// effective_contract_nestjs_4601_test.go — value-asserting coverage for the
+// NestJS effective-contract resolver (#4601).
+//
+// The fixture is a NestJS controller endpoint with:
+//   - a @Body() CreateXDto whose class-validator fields are on the graph as
+//     SCOPE.Schema subtype=field entities,
+//   - a branching handler returning 201 on success and throwing
+//     ConflictException (409) and NotFoundException (404),
+//   - a @RequirePage("client_admin") guard.
+//
+// It asserts effective_contract returns the request fields (composed from the
+// VALIDATES → dto:CreateXDto edge + the DTO field members), the per-branch
+// response shapes+statuses (composed from the effects-branches facet over the
+// handler body), and the auth posture (composed from the effective guard) —
+// the SAME effectiveContract structure the DRF resolver emits.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// nestControllerSource is the on-disk handler body the branch analyzer reads.
+// Line 1 is blank so line numbers below are 1-indexed against this string.
+const nestControllerSource = `
+@Controller('users')
+export class UsersController {
+  @Post()
+  @RequirePage("client_admin")
+  async create(@Body() dto: CreateXDto): Promise<UserDto> {
+    const existing = await this.repo.findByEmail(dto.email);
+    if (existing) {
+      throw new ConflictException('email taken');
+    }
+    if (!dto.name) {
+      throw new NotFoundException('missing');
+    }
+    return this.repo.create(dto);
+  }
+}
+`
+
+// buildNestContractServer writes the controller source to a temp repo dir and
+// builds a Server whose graph models the endpoint, its handler, the DTO, and
+// the DTO's class-validator fields — the signals the resolver composes.
+func buildNestContractServer(t *testing.T) *Server {
+	t.Helper()
+	repoDir := t.TempDir()
+	srcRel := "src/users/users.controller.ts"
+	abs := filepath.Join(repoDir, srcRel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, []byte(nestControllerSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc := &graph.Document{
+		Repo: "v3",
+		Entities: []graph.Entity{
+			// The endpoint definition.
+			{
+				ID: "ep:post:/users", Name: "http:POST:/users",
+				Kind: "http_endpoint_definition", Language: "typescript",
+				SourceFile: srcRel,
+				Properties: map[string]string{
+					"framework":         "nestjs",
+					"verb":              "POST",
+					"path":              "/users",
+					"request_body_type": "CreateXDto",
+					"require_page":      "client_admin",
+					"auth_required":     "true",
+				},
+			},
+			// The handler method (controller leaf = UsersController).
+			{
+				ID: "op:UsersController.create", Name: "create",
+				QualifiedName: "UsersController.create",
+				Kind:          "SCOPE.Operation", Subtype: "method",
+				Language: "typescript", SourceFile: srcRel,
+				StartLine: 6, EndLine: 15,
+				Properties: map[string]string{"require_page": "client_admin"},
+			},
+			// The DTO class + its class-validator fields (SCOPE.Schema/field).
+			{ID: "dto:CreateXDto", Name: "CreateXDto", Kind: "SCOPE.Component", Subtype: "class", Language: "typescript", SourceFile: "src/users/dto/create-x.dto.ts"},
+			{ID: "f:email", Name: "CreateXDto.email", Kind: "SCOPE.Schema", Subtype: "field", Signature: "email: string", Language: "typescript"},
+			{ID: "f:name", Name: "CreateXDto.name", Kind: "SCOPE.Schema", Subtype: "field", Signature: "name: string", Language: "typescript"},
+			{ID: "f:age", Name: "CreateXDto.age?", Kind: "SCOPE.Schema", Subtype: "field", Signature: "age?: number", Language: "typescript"},
+		},
+		Relationships: []graph.Relationship{
+			// handler IMPLEMENTS endpoint (the resolution-pass bridge).
+			{FromID: "op:UsersController.create", ToID: "ep:post:/users", Kind: "IMPLEMENTS"},
+			// handler VALIDATES dto:CreateXDto (the @Body() DTO extraction edge).
+			{FromID: "op:UsersController.create", ToID: "dto:CreateXDto", Kind: "VALIDATES",
+				Properties: map[string]string{"via": "dto_extraction", "method": "@Body()", "dto": "CreateXDto"}},
+		},
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"v3": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	st.mu.Lock()
+	lg := &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{
+		"v3": {Repo: "v3", Path: repoDir, Doc: doc, LabelIndex: BuildLabelIndex(doc), BM25: BuildBM25(doc)},
+	}}
+	st.groups["test"] = lg
+	st.mu.Unlock()
+	return &Server{State: st, Tel: NewTelemetry(0)}
+}
+
+func TestEffectiveContract_NestJS_FullContract(t *testing.T) {
+	srv := buildNestContractServer(t)
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "UsersController"}
+	res, err := srv.handleEffectiveContract(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleEffectiveContract error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("handleEffectiveContract IsError: %s", resultText(res))
+	}
+	var out effectiveContractResult
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, resultText(res))
+	}
+
+	if len(out.Groups) != 1 {
+		t.Fatalf("want 1 group, got %d: %+v", len(out.Groups), out.Groups)
+	}
+	g := out.Groups[0]
+	if g.Class != "UsersController" {
+		t.Errorf("class = %q, want UsersController", g.Class)
+	}
+	if g.Framework != "nestjs" {
+		t.Errorf("framework = %q, want nestjs", g.Framework)
+	}
+	if len(g.Handlers) != 1 {
+		t.Fatalf("want 1 handler, got %d: %+v", len(g.Handlers), g.Handlers)
+	}
+	h := g.Handlers[0]
+
+	if h.Verb != "POST" || h.Path != "/users" {
+		t.Errorf("verb/path = %q %q, want POST /users", h.Verb, h.Path)
+	}
+
+	// --- request fields: composed from VALIDATES → DTO field members. ---
+	gotFields := map[string]contractField{}
+	for _, f := range h.RequestFields {
+		gotFields[f.Name] = f
+	}
+	for _, want := range []string{"email", "name", "age"} {
+		if _, ok := gotFields[want]; !ok {
+			t.Errorf("missing request field %q; got %+v", want, h.RequestFields)
+		}
+	}
+	if f := gotFields["email"]; f.In != "body" || f.DTO != "CreateXDto" || f.Type != "string" {
+		t.Errorf("email field = %+v; want in=body dto=CreateXDto type=string", f)
+	}
+	if f := gotFields["age"]; f.Required {
+		t.Errorf("age should be optional (age?), got required=%v", f.Required)
+	}
+	if f := gotFields["email"]; !f.Required {
+		t.Errorf("email should be required, got %+v", f)
+	}
+
+	// --- per-branch response shapes + statuses: from the effects-branches facet. ---
+	gotStatuses := map[int]bool{}
+	for _, b := range h.ResponseBranches {
+		gotStatuses[b.Status] = true
+	}
+	for _, want := range []int{404, 409} {
+		if !gotStatuses[want] {
+			t.Errorf("missing response branch status %d; got %+v", want, h.ResponseBranches)
+		}
+	}
+	// Error statuses mirrored into the DRF-style flat field.
+	errSet := map[int]bool{}
+	for _, s := range h.ErrorStatuses {
+		errSet[s] = true
+	}
+	if !errSet[409] || !errSet[404] {
+		t.Errorf("error_statuses = %v; want to include 404 and 409", h.ErrorStatuses)
+	}
+
+	// --- auth posture: from the effective guard (@RequirePage). ---
+	if h.AuthKind != "page" {
+		t.Errorf("auth_kind = %q, want page", h.AuthKind)
+	}
+	if h.AuthLiteral != "client_admin" {
+		t.Errorf("auth_literal = %q, want client_admin", h.AuthLiteral)
+	}
+	if !h.AuthRequired {
+		t.Errorf("auth_required = false, want true")
+	}
+}

--- a/internal/mcp/effective_contract_registry.go
+++ b/internal/mcp/effective_contract_registry.go
@@ -1,0 +1,101 @@
+package mcp
+
+// effective_contract_registry.go — the framework-PLUGGABLE effective-contract
+// resolver registry (#4601).
+//
+// archigraph_effective_contract was DRF-only: computeEffectiveContract found a
+// ViewSet's drf_router_expanded routes and projected the engine-stamped
+// effective_* props (effective_contract.go / effective_contract_tool.go). For
+// any non-DRF stack — notably the NestJS upvate-v3 rewrite — it returned an
+// empty result, so the rewrite agent could not get a per-endpoint full contract
+// from the tool and fell back to scraping the dashboard.
+//
+// This file generalises the tool into a registry of per-framework resolvers.
+// Each resolver composes the SAME contract structure (status set, request
+// fields, per-branch response shapes, auth) from signals that ALREADY exist on
+// the graph for its framework — nothing is re-extracted. The DRF path is
+// preserved BYTE-FOR-BYTE: computeEffectiveContract still runs the DRF
+// router-expanded + class-fallback synthesis first, and the registry resolvers
+// only run when that produced nothing for the target (so an index that already
+// resolves under DRF is unchanged).
+//
+// Adding Spring / FastAPI / Express / … is a matter of registering one more
+// contractResolver (follow-up tickets ref #4601); the diff/parity consumers
+// downstream never change because every resolver emits the shared
+// effectiveContract shape.
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// contractResolver composes the per-endpoint effective contract for ONE
+// framework from graph signals that already exist. Resolve scans lg for
+// endpoints attributed to the target controller/group and returns one
+// effectiveContractGroup per (repo, controller). ok=false ⇒ this resolver does
+// not recognise the target as belonging to its framework (so the registry tries
+// the next one).
+type contractResolver interface {
+	// Name is the framework slug ("nestjs", "spring", …).
+	Name() string
+	// Resolve composes the contract groups for the target within lg. wantLeaf is
+	// the lower-cased controller/group leaf name the caller resolved the target
+	// to. Returns (groups, true) when this framework owns the target, else
+	// (nil, false).
+	Resolve(lg *LoadedGroup, target, wantLeaf string) ([]effectiveContractGroup, bool)
+}
+
+// contractResolverRegistry is the ordered set of non-DRF resolvers tried (in
+// order) when the DRF path yields no groups. NewContractResolverRegistry wires
+// the flagship NestJS resolver; every other framework is a follow-up ticket.
+type contractResolverRegistry struct {
+	resolvers []contractResolver
+}
+
+// newContractResolverRegistry builds the default registry. NestJS is the
+// flagship non-DRF resolver (#4601); Spring / FastAPI / Express / … land via
+// their own follow-up tickets and slot in here without touching any consumer.
+func newContractResolverRegistry() *contractResolverRegistry {
+	return &contractResolverRegistry{resolvers: []contractResolver{
+		nestJSContractResolver{},
+	}}
+}
+
+// resolve runs the registry over the target, returning the first resolver's
+// groups that recognised it.
+func (r *contractResolverRegistry) resolve(lg *LoadedGroup, target, wantLeaf string) ([]effectiveContractGroup, bool) {
+	for _, res := range r.resolvers {
+		if groups, ok := res.Resolve(lg, target, wantLeaf); ok && len(groups) > 0 {
+			return groups, true
+		}
+	}
+	return nil, false
+}
+
+// isServerEndpointDefinition reports whether e is a server-side HTTP endpoint
+// definition a framework resolver should consider: an http_endpoint definition
+// kind (reusing the shared isHTTPEndpointDefinition predicate) that is neither a
+// router-expanded DRF route (handled by the DRF projection path) nor a generated
+// client stub.
+func isServerEndpointDefinition(e *graph.Entity) bool {
+	if e == nil || isRouterExpandedRoute(e) {
+		return false
+	}
+	if e.Properties["pattern_type"] == patternTypeHTTPEndpointClientSynthesis {
+		return false
+	}
+	return isHTTPEndpointDefinition(e)
+}
+
+// endpointFramework returns the lower-cased framework hint for an endpoint
+// entity, from its `framework` property, falling back to the entity Language.
+func endpointFramework(e *graph.Entity) string {
+	if e == nil {
+		return ""
+	}
+	if fw := strings.ToLower(strings.TrimSpace(e.Properties["framework"])); fw != "" {
+		return fw
+	}
+	return strings.ToLower(strings.TrimSpace(e.Language))
+}

--- a/internal/mcp/effective_contract_tool.go
+++ b/internal/mcp/effective_contract_tool.go
@@ -265,6 +265,20 @@ func computeEffectiveContract(lg *LoadedGroup, target string) effectiveContractR
 		out.Groups = append(out.Groups, *g)
 	}
 
+	// FRAMEWORK REGISTRY (#4601): when the DRF projection + class-fallback
+	// synthesis produced nothing (a non-DRF stack — e.g. the NestJS upvate-v3
+	// rewrite), try the pluggable per-framework contract resolvers. They compose
+	// the SAME effectiveContract structure (status set, request fields, per-branch
+	// response shapes, auth) from signals that already exist on the graph, so the
+	// cross-group response_shape_diff / parity tools consume DRF and non-DRF
+	// contracts uniformly. DRF behaviour is unchanged: this runs ONLY when DRF
+	// resolved nothing.
+	if len(out.Groups) == 0 {
+		if rgroups, ok := newContractResolverRegistry().resolve(lg, target, wantVS); ok {
+			out.Groups = rgroups
+		}
+	}
+
 	if len(out.Groups) == 0 {
 		out.Note = "no effective contract resolvable for \"" + target + "\": no " +
 			"router-expanded routes are attributed to this ViewSet, and its class " +

--- a/internal/substrate/branches_jsts_java_go.go
+++ b/internal/substrate/branches_jsts_java_go.go
@@ -233,6 +233,17 @@ var (
 	jstsStatusCallRe = regexp.MustCompile(`\.\s*(?:status|code|sendStatus)\s*\(\s*(\d{3})\b`)
 	jstsHTTPExcRe    = regexp.MustCompile(`HttpException\s*\([^)]*?\b(\d{3})\b`)
 	jstsStatusNumRe  = regexp.MustCompile(`statusCode\s*[:=]\s*(\d{3})\b`)
+
+	// jstsHTTPStatusEnumRe — NestJS `HttpStatus.CONFLICT` / `HttpStatus.CREATED`
+	// (the enum form, mapped via httpStatusNameToCode — shared with the Java/Go
+	// analyzers so the status vocabulary stays one source of truth).
+	jstsHTTPStatusEnumRe = regexp.MustCompile(`HttpStatus\s*\.\s*([A-Z_]+)`)
+
+	// jstsNestExcRe — NestJS built-in HTTP exception classes
+	// (`throw new ConflictException(...)`). Nest maps each to a fixed status, so
+	// a branching handler that throws one declares that branch's status without
+	// any numeric literal. Mapped via nestExceptionStatus.
+	jstsNestExcRe = regexp.MustCompile(`\bnew\s+([A-Z][A-Za-z]*Exception)\b`)
 )
 
 func analyzeBranchesJSTS(funcSource string, startLine int) []BranchFacet {
@@ -293,7 +304,76 @@ func jstsStatusFromBody(joined string) string {
 	if m := jstsStatusNumRe.FindStringSubmatch(joined); m != nil {
 		return m[1]
 	}
+	// NestJS `HttpStatus.CONFLICT` enum reference (e.g.
+	// `throw new HttpException(msg, HttpStatus.CONFLICT)`).
+	if m := jstsHTTPStatusEnumRe.FindStringSubmatch(joined); m != nil {
+		if code := httpStatusNameToCode(m[1]); code != "" {
+			return code
+		}
+	}
+	// NestJS built-in exception class (`throw new ConflictException()` → 409).
+	if m := jstsNestExcRe.FindStringSubmatch(joined); m != nil {
+		if code := nestExceptionStatus(m[1]); code != "" {
+			return code
+		}
+	}
 	return ""
+}
+
+// nestExceptionStatus maps a NestJS built-in HTTP exception class name to its
+// fixed HTTP status code (the framework hard-codes these in
+// @nestjs/common/exceptions). Conservative — only the built-in classes; an
+// unknown / user-defined *Exception yields "" (honest-partial: no fabricated
+// status). Shared by the response-branch status derivation.
+func nestExceptionStatus(class string) string {
+	switch class {
+	case "BadRequestException":
+		return "400"
+	case "UnauthorizedException":
+		return "401"
+	case "PaymentRequiredException":
+		return "402"
+	case "ForbiddenException":
+		return "403"
+	case "NotFoundException":
+		return "404"
+	case "MethodNotAllowedException":
+		return "405"
+	case "NotAcceptableException":
+		return "406"
+	case "RequestTimeoutException":
+		return "408"
+	case "ConflictException":
+		return "409"
+	case "GoneException":
+		return "410"
+	case "PreconditionFailedException":
+		return "412"
+	case "PayloadTooLargeException":
+		return "413"
+	case "UnsupportedMediaTypeException":
+		return "415"
+	case "ImATeapotException":
+		return "418"
+	case "UnprocessableEntityException":
+		return "422"
+	case "TooManyRequestsException":
+		return "429"
+	case "InternalServerErrorException":
+		return "500"
+	case "NotImplementedException":
+		return "501"
+	case "BadGatewayException":
+		return "502"
+	case "ServiceUnavailableException":
+		return "503"
+	case "GatewayTimeoutException":
+		return "504"
+	case "HttpVersionNotSupportedException":
+		return "505"
+	default:
+		return ""
+	}
 }
 
 // --- Java analyzer -------------------------------------------------------

--- a/internal/substrate/branches_jsts_java_go_test.go
+++ b/internal/substrate/branches_jsts_java_go_test.go
@@ -212,3 +212,55 @@ func TestBranchAnalyzerRegistry_BraceLangs(t *testing.T) {
 		}
 	}
 }
+
+// TestAnalyzeBranchesJSTS_NestExceptionStatus verifies NestJS built-in HTTP
+// exception classes and HttpStatus enum references decode to their fixed status
+// in the response-branch facet (#4601 — so a 409/404-branching Nest handler
+// surfaces those statuses without a numeric literal).
+func TestAnalyzeBranchesJSTS_NestExceptionStatus(t *testing.T) {
+	src := `async create(dto) {
+    if (existing) {
+        throw new ConflictException('taken');
+    }
+    if (!dto.name) {
+        throw new NotFoundException('missing');
+    }
+    if (bad) {
+        throw new HttpException('x', HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+    return this.repo.create(dto);
+}`
+	br := analyzeBranchesJSTS(src, 1)
+	want := map[string]bool{"409": false, "404": false, "422": false}
+	for _, b := range br {
+		if b.Returns != nil {
+			if _, ok := want[b.Returns.Status]; ok {
+				want[b.Returns.Status] = true
+			}
+		}
+	}
+	for status, seen := range want {
+		if !seen {
+			t.Errorf("expected a branch with status %s; got %+v", status, br)
+		}
+	}
+}
+
+// TestNestExceptionStatus_Mapping spot-checks the NestJS exception → status map.
+func TestNestExceptionStatus_Mapping(t *testing.T) {
+	cases := map[string]string{
+		"BadRequestException":         "400",
+		"UnauthorizedException":       "401",
+		"ForbiddenException":          "403",
+		"NotFoundException":           "404",
+		"ConflictException":           "409",
+		"UnprocessableEntityException": "422",
+		"InternalServerErrorException": "500",
+		"SomeUserDefinedException":    "",
+	}
+	for class, want := range cases {
+		if got := nestExceptionStatus(class); got != want {
+			t.Errorf("nestExceptionStatus(%q) = %q, want %q", class, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`archigraph_effective_contract` was DRF-only. It projected the engine-stamped `effective_*` props of a ViewSet's `drf_router_expanded` routes and returned an **empty result for any non-DRF stack** — notably the NestJS upvate-v3 rewrite — so the rewrite agent couldn't get a per-endpoint full contract from the tool and fell back to scraping the dashboard.

## What this does

Generalises the tool into a **registry of per-framework contract resolvers** (`effective_contract_registry.go`) and adds a flagship **NestJS resolver**. Each resolver composes the **same `effectiveContract` structure** (status set, request fields, per-branch response shapes, auth posture) from signals that **already exist on the graph — nothing is re-extracted** — so the cross-group `response_shape_diff` / parity tools consume DRF and non-DRF contracts uniformly.

**DRF behaviour is unchanged**: the registry runs ONLY when the DRF router-expanded + class-fallback synthesis produced nothing for the target.

### NestJS resolver — graph signals composed
- **Request shape**: the handler's `VALIDATES -> dto:<Type>` edge (the `@Body`/`@Query`/`@Param` decorator is on the edge's `method` prop, #4623/#4635) + the DTO's `SCOPE.Schema`/`field` members. `request_body_type` prop as a fallback. Optional fields (trailing `?`) marked `Required=false`.
- **Response shape + per-branch status**: the effects-branches facet (#4423/#4666) — the substrate branch analyzer over the handler body, `{status, shape}` per return/throw branch. Mirrored into the DRF-style `default_status` + `error_statuses` split.
- **Auth posture**: the effective guard (#4667), decoded via the shared `authposture` NestJS resolver into `{kind, literal}`.

### Substrate: NestJS exception → status
Extended the JS/TS branch analyzer to decode NestJS built-in HTTP exception classes (`throw new ConflictException()` → 409) and `HttpStatus.NAME` enum refs, so a branching Nest handler surfaces its statuses without a numeric literal. Also benefits `archigraph_effects`' branches facet.

## Registry / generalisation
Structured as a `contractResolver` registry so Spring / FastAPI / Express slot in without touching consumers. Follow-up issues with concrete signal sources filed:
- Spring: #4708
- FastAPI: #4709
- Express/Fastify: #4710

## Tests
- `effective_contract_nestjs_4601_test.go`: a NestJS controller endpoint with `@Body CreateXDto` (class-validator fields), a 201/409/404-branching handler, and `@RequirePage("client_admin")` — asserts request fields (+ optionality + type + `in`), per-branch response statuses, the mirrored error-status set, and the page/client_admin auth posture.
- `branches_jsts_java_go_test.go`: NestJS exception/HttpStatus status decode + the mapping table.

## Gates
- `go build ./...` ✅
- `go vet ./internal/mcp/...` ✅
- `go test ./internal/mcp/...` ✅ (and `./internal/substrate/...` ✅)

Closes #4601

🤖 Generated with [Claude Code](https://claude.com/claude-code)