### PR TITLE
feat(dashboard): stamp records with monorepo module_path for scope filtering (#4698)

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -196,6 +196,14 @@ type CrossRepoLink struct {
 	TargetQualifiedName string `json:"target_qualified_name,omitempty"`
 	TargetFile          string `json:"target_file,omitempty"`
 	TargetLine          int    `json:"target_line,omitempty"`
+
+	// Module sub-paths owning each endpoint within its repo (#4698), derived
+	// from the source/target file and the repo's configured monorepo module
+	// roots. Empty for single-repo groups or files under no module root. Let the
+	// scope selector keep a link at module precision when either endpoint lives
+	// in the scoped module.
+	SourceModulePath string `json:"source_module_path,omitempty"`
+	TargetModulePath string `json:"target_module_path,omitempty"`
 }
 
 // UnmarshalJSON handles the "relation" field used by the link pass as a
@@ -576,23 +584,34 @@ func normalizeLinkEndpoints(links []CrossRepoLink, repos map[string]*DashRepo) [
 // entity (e.g. a synthetic scope.operation node #4554 or a bare-external
 // target #4558 that has no source-derived name) simply leaves its enrichment
 // fields empty, and the frontend falls back to the graph deep-link.
-func enrichLinkEndpoints(grp *DashGroup, links []CrossRepoLink) []CrossRepoLink {
+// enrichLinkEndpoints resolves each link's source/target entity for readable
+// rendering and source-peek (#4596) and stamps each endpoint's monorepo
+// module_path (#4698) using moduleRoots (parent-repo slug → configured module
+// roots). moduleRoots may be nil for single-repo / non-monorepo groups, in
+// which case module paths stay empty.
+func enrichLinkEndpoints(grp *DashGroup, links []CrossRepoLink, moduleRoots map[string][]string) []CrossRepoLink {
 	if grp == nil || len(links) == 0 {
 		return links
 	}
 	out := make([]CrossRepoLink, len(links))
 	for i, l := range links {
-		if _, e := findEntity(grp, l.Source); e != nil {
+		if rp, e := findEntity(grp, l.Source); e != nil {
 			l.SourceName = e.Name
 			l.SourceQualifiedName = e.QualifiedName
 			l.SourceFile = e.SourceFile
 			l.SourceLine = e.StartLine
+			if rp != nil {
+				l.SourceModulePath = modulePathFor(rp.Slug, e.SourceFile, moduleRoots)
+			}
 		}
-		if _, e := findEntity(grp, l.Target); e != nil {
+		if rp, e := findEntity(grp, l.Target); e != nil {
 			l.TargetName = e.Name
 			l.TargetQualifiedName = e.QualifiedName
 			l.TargetFile = e.SourceFile
 			l.TargetLine = e.StartLine
+			if rp != nil {
+				l.TargetModulePath = modulePathFor(rp.Slug, e.SourceFile, moduleRoots)
+			}
 		}
 		out[i] = l
 	}

--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -813,6 +813,13 @@ func (s *Server) handleGroupLinks(w http.ResponseWriter, r *http.Request) {
 	// Resolve each link's source/target entity so the /links page can render
 	// readable names and open a real source-peek (#4596). Additive and
 	// best-effort: unresolved endpoints leave the enrichment fields empty.
-	links = enrichLinkEndpoints(grp, links)
+	// #4698 — resolve per-repo monorepo module roots so each link endpoint can
+	// carry its module_path. Best-effort: on config-load failure we pass nil and
+	// module paths stay empty (links still render, scoped at repo-level).
+	var moduleRoots map[string][]string
+	if repoRefs, rerr := repoPathsForGroup(group); rerr == nil {
+		moduleRoots = moduleRootsByRepo(repoRefs)
+	}
+	links = enrichLinkEndpoints(grp, links, moduleRoots)
 	writeJSON(w, http.StatusOK, map[string]any{"links": links})
 }

--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -118,6 +118,11 @@ type IaCRelation struct {
 type IaCResource struct {
 	EntityID string `json:"entity_id"`
 	Repo     string `json:"repo"`
+	// ModulePath is the monorepo module sub-path owning this resource's source
+	// file (#4698), derived from the repo's configured module roots. Distinct
+	// from Module below (a source-dir grouping heuristic): ModulePath is the
+	// scope-selector key. Empty for single-repo groups / files under no root.
+	ModulePath string `json:"module_path,omitempty"`
 	// Name is the logical id / resource name.
 	Name string `json:"name"`
 	// Tool is the normalized iac_tool (aws-cdk/pulumi/bicep/cloudformation/sam/
@@ -460,6 +465,9 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 		CountsByCategory: map[string]int{},
 	}
 
+	// #4698 — module roots per repo so each resource can carry its module_path.
+	moduleRoots := moduleRootsByRepo(repoPaths)
+
 	// resources keyed by entity ID so relationship attachment is O(1).
 	byID := map[string]*IaCResource{}
 	// resource display name by entity ID, for resolving relation targets.
@@ -575,6 +583,7 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 			res := &IaCResource{
 				EntityID:      rp.Slug + "/" + id,
 				Repo:          rp.Slug,
+				ModulePath:    modulePathFor(rp.Slug, sourceFile, moduleRoots),
 				Name:          name,
 				Tool:          tool,
 				ResourceType:  rtype,

--- a/internal/dashboard/handlers_quality.go
+++ b/internal/dashboard/handlers_quality.go
@@ -571,10 +571,13 @@ func (s *Server) handleQualityRecall(w http.ResponseWriter, r *http.Request) {
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-// repoRef is a (slug, path) pair.
+// repoRef is a (slug, path) pair, plus the repo's configured monorepo module
+// roots (#4698) so handlers can stamp per-record module_path without re-loading
+// the group config.
 type repoRef struct {
-	Slug string
-	Path string
+	Slug    string
+	Path    string
+	Modules []string
 }
 
 // repoPathsForGroup resolves every repo path for the named group by loading
@@ -594,7 +597,7 @@ func repoPathsForGroup(groupName string) ([]repoRef, error) {
 		}
 		out := make([]repoRef, 0, len(cfg.Repos))
 		for _, r := range cfg.Repos {
-			out = append(out, repoRef{Slug: r.Slug, Path: r.Path})
+			out = append(out, repoRef{Slug: r.Slug, Path: r.Path, Modules: r.Modules})
 		}
 		return out, nil
 	}

--- a/internal/dashboard/handlers_security.go
+++ b/internal/dashboard/handlers_security.go
@@ -33,6 +33,11 @@ type AuthEndpointFinding struct {
 	EntityID     string `json:"entity_id"`
 	Name         string `json:"name"`
 	Repo         string `json:"repo"`
+	// ModulePath is the monorepo module sub-path owning this finding's source
+	// file (#4698), derived from the repo's configured module roots. Empty for
+	// single-repo groups or files under no module root. Lets the scope selector
+	// filter at module precision instead of falling back to repo-level.
+	ModulePath   string `json:"module_path,omitempty"`
 	SourceFile   string `json:"source_file,omitempty"`
 	StartLine    int    `json:"start_line,omitempty"`
 	Method       string `json:"method,omitempty"`
@@ -79,6 +84,9 @@ type SecuritySecretFinding struct {
 	EntityID   string `json:"entity_id"`
 	Name       string `json:"name"`
 	Repo       string `json:"repo"`
+	// ModulePath is the monorepo module sub-path owning this finding's source
+	// file (#4698). See AuthEndpointFinding.ModulePath.
+	ModulePath string `json:"module_path,omitempty"`
 	SourceFile string `json:"source_file,omitempty"`
 	StartLine  int    `json:"start_line,omitempty"`
 	Language   string `json:"language,omitempty"`
@@ -368,6 +376,9 @@ func (s *Server) handleSecurityAuthCoverage(w http.ResponseWriter, r *http.Reque
 
 	result := GroupAuthCoverageReport{Group: groupName}
 
+	// #4698 — module roots per repo so each finding can carry its module_path.
+	moduleRoots := moduleRootsByRepo(repoPaths)
+
 	// S8 (#2159): prefer the pre-loaded cached group so we don't call
 	// LoadGraphFromDir per-request. Fall back to a direct load when the
 	// cache is cold (first request after daemon start).
@@ -491,6 +502,7 @@ func (s *Server) handleSecurityAuthCoverage(w http.ResponseWriter, r *http.Reque
 				EntityID:     rp.Slug + "/" + id,
 				Name:         name,
 				Repo:         rp.Slug,
+				ModulePath:   modulePathFor(rp.Slug, sourceFile, moduleRoots),
 				SourceFile:   sourceFile,
 				StartLine:    startLine,
 				Method:       method,
@@ -559,6 +571,9 @@ func (s *Server) handleSecuritySecrets(w http.ResponseWriter, r *http.Request) {
 		Group:      groupName,
 		ByCategory: make(map[string]int),
 	}
+
+	// #4698 — module roots per repo so each finding can carry its module_path.
+	moduleRoots := moduleRootsByRepo(repoPaths)
 
 	sevOrder := map[string]int{"error": 0, "warn": 1, "info": 2}
 
@@ -643,6 +658,7 @@ func (s *Server) handleSecuritySecrets(w http.ResponseWriter, r *http.Request) {
 				EntityID:    rp.Slug + "/" + id,
 				Name:        name,
 				Repo:        rp.Slug,
+				ModulePath:  modulePathFor(rp.Slug, sourceFile, moduleRoots),
 				SourceFile:  sourceFile,
 				StartLine:   startLine,
 				Language:    language,

--- a/internal/dashboard/links_enrich_test.go
+++ b/internal/dashboard/links_enrich_test.go
@@ -47,7 +47,7 @@ func TestEnrichLinkEndpoints_PopulatesNameAndFile(t *testing.T) {
 		}},
 	}
 
-	out := enrichLinkEndpoints(grp, grp.Links)
+	out := enrichLinkEndpoints(grp, grp.Links, nil)
 	if len(out) != 1 {
 		t.Fatalf("links len = %d; want 1", len(out))
 	}
@@ -113,7 +113,7 @@ func TestEnrichLinkEndpoints_UnresolvedSourceLeftEmpty(t *testing.T) {
 		}},
 	}
 
-	out := enrichLinkEndpoints(grp, grp.Links)
+	out := enrichLinkEndpoints(grp, grp.Links, nil)
 	l := out[0]
 
 	if l.SourceName != "" || l.SourceFile != "" || l.SourceLine != 0 {

--- a/internal/dashboard/module_path.go
+++ b/internal/dashboard/module_path.go
@@ -1,0 +1,106 @@
+package dashboard
+
+// module_path.go — monorepo module-path attribution for dashboard payloads (#4698).
+//
+// The WebUI v2 scope selector (#4637) derives module options from the group's
+// `monorepos` config (parent-repo slug → list of module sub-paths) and filters
+// records with `matchesScope(repo, modulePath?)`. For module-precision filtering
+// to work, each dashboard record must carry the module sub-path it belongs to —
+// not just its repo slug. Without it the selector degrades to repo-level for any
+// module scope (the TODO in the client `matchesScope`).
+//
+// `modulePathFor` derives that sub-path from a record's repo-relative source
+// file and the repo's configured module roots, using a longest-prefix match:
+//
+//	roots = ["packages/api", "packages/worker"]
+//	"packages/api/src/x.ts" → "packages/api"   (longest matching root)
+//	"tools/build.ts"        → ""                (under no root)
+//
+// The derivation is layout-agnostic (Nx / Turbo / Gradle multi-module / Go
+// workspaces / Python monorepo): it relies solely on the configured roots, never
+// on framework heuristics. Single-repo / non-monorepo groups configure no module
+// roots, so every record yields "" and behaviour is unchanged.
+
+import (
+	"path"
+	"strings"
+)
+
+// moduleRootsByRepo builds the parent-repo-slug → module-roots map (the same
+// shape as Group.monorepos) from the resolved repoRefs for a group. Repos with
+// no configured modules are omitted, so the result is empty for single-repo /
+// non-monorepo groups and modulePathFor short-circuits to "".
+func moduleRootsByRepo(repos []repoRef) map[string][]string {
+	var m map[string][]string
+	for _, r := range repos {
+		if len(r.Modules) == 0 {
+			continue
+		}
+		if m == nil {
+			m = make(map[string][]string, len(repos))
+		}
+		m[r.Slug] = r.Modules
+	}
+	return m
+}
+
+// modulePathFor returns the configured module sub-path that owns sourceFile
+// within repo, or "" when the file is under no configured module root.
+//
+//   - repo:           the record's repo slug.
+//   - sourceFile:     the record's repo-relative source path (forward slashes;
+//                     a leading "./" or "/" is tolerated).
+//   - modulesByRepo:  parent-repo slug → configured module roots (the same map
+//                     that populates Group.monorepos). nil / missing repo ⇒ "".
+//
+// Matching rules:
+//   - Roots are normalised (slashes, trailing "/" stripped) before comparison.
+//   - A file matches a root when it equals the root or sits beneath it
+//     ("packages/api" matches "packages/api" and "packages/api/src/x.ts" but NOT
+//     "packages/apiv2/x.ts").
+//   - On overlapping roots the LONGEST matching root wins ("packages/api" over
+//     "packages"), so nested modules attribute to their most-specific module.
+func modulePathFor(repo, sourceFile string, modulesByRepo map[string][]string) string {
+	if repo == "" || sourceFile == "" || len(modulesByRepo) == 0 {
+		return ""
+	}
+	roots := modulesByRepo[repo]
+	if len(roots) == 0 {
+		return ""
+	}
+	file := normalizeModuleRel(sourceFile)
+	if file == "" {
+		return ""
+	}
+	best := ""
+	for _, r := range roots {
+		root := normalizeModuleRel(r)
+		if root == "" {
+			continue
+		}
+		if file == root || strings.HasPrefix(file, root+"/") {
+			if len(root) > len(best) {
+				best = root
+			}
+		}
+	}
+	return best
+}
+
+// normalizeModuleRel cleans a repo-relative path for prefix matching: forward
+// slashes, no leading "./" or "/", no trailing "/". Returns "" for paths that
+// escape the repo root ("..") or are empty after cleaning.
+func normalizeModuleRel(p string) string {
+	p = strings.ReplaceAll(p, "\\", "/")
+	p = strings.TrimPrefix(p, "./")
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return ""
+	}
+	// path.Clean collapses "a//b", "a/./b", and resolves interior "..".
+	cleaned := path.Clean(p)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return ""
+	}
+	return strings.TrimSuffix(cleaned, "/")
+}

--- a/internal/dashboard/module_path_test.go
+++ b/internal/dashboard/module_path_test.go
@@ -1,0 +1,133 @@
+package dashboard
+
+import "testing"
+
+// Mirrors the #4698 acceptance fixture: a monorepo group config with module
+// roots (packages/api, packages/worker) attributes records to their longest
+// matching module root, and files outside any root get an empty module_path.
+func TestModulePathFor(t *testing.T) {
+	mono := map[string][]string{
+		"mono": {"packages/api", "packages/worker", "packages"},
+	}
+
+	cases := []struct {
+		name       string
+		repo       string
+		sourceFile string
+		roots      map[string][]string
+		want       string
+	}{
+		{
+			name:       "file under module root → module sub-path",
+			repo:       "mono",
+			sourceFile: "packages/api/src/x.ts",
+			roots:      mono,
+			want:       "packages/api",
+		},
+		{
+			name:       "file at the module root itself",
+			repo:       "mono",
+			sourceFile: "packages/worker",
+			roots:      mono,
+			want:       "packages/worker",
+		},
+		{
+			name:       "longest-prefix wins over a broader root",
+			repo:       "mono",
+			sourceFile: "packages/api/handler.ts",
+			roots:      mono,
+			want:       "packages/api", // not "packages"
+		},
+		{
+			name:       "broader root still matches when no deeper root does",
+			repo:       "mono",
+			sourceFile: "packages/shared/util.ts",
+			roots:      mono,
+			want:       "packages",
+		},
+		{
+			name:       "file outside any module root → empty",
+			repo:       "mono",
+			sourceFile: "tools/build.ts",
+			roots:      map[string][]string{"mono": {"packages/api", "packages/worker"}},
+			want:       "",
+		},
+		{
+			name:       "sibling-prefix is NOT a match (apiv2 vs api)",
+			repo:       "mono",
+			sourceFile: "packages/apiv2/src/x.ts",
+			roots:      map[string][]string{"mono": {"packages/api"}},
+			want:       "",
+		},
+		{
+			name:       "leading ./ and interior // are tolerated",
+			repo:       "mono",
+			sourceFile: "./packages/api//src/x.ts",
+			roots:      map[string][]string{"mono": {"packages/api"}},
+			want:       "packages/api",
+		},
+		{
+			name:       "backslash paths are normalised",
+			repo:       "mono",
+			sourceFile: `packages\worker\job.ts`,
+			roots:      map[string][]string{"mono": {"packages/worker"}},
+			want:       "packages/worker",
+		},
+		{
+			name:       "single-repo / non-monorepo group → empty (no roots)",
+			repo:       "solo",
+			sourceFile: "src/x.ts",
+			roots:      nil,
+			want:       "",
+		},
+		{
+			name:       "repo not in the monorepo map → empty",
+			repo:       "other",
+			sourceFile: "packages/api/src/x.ts",
+			roots:      mono,
+			want:       "",
+		},
+		{
+			name:       "empty source file → empty",
+			repo:       "mono",
+			sourceFile: "",
+			roots:      mono,
+			want:       "",
+		},
+		{
+			name:       "path escaping the repo root is rejected",
+			repo:       "mono",
+			sourceFile: "../outside/x.ts",
+			roots:      map[string][]string{"mono": {"packages/api"}},
+			want:       "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := modulePathFor(tc.repo, tc.sourceFile, tc.roots)
+			if got != tc.want {
+				t.Fatalf("modulePathFor(%q, %q) = %q; want %q", tc.repo, tc.sourceFile, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModuleRootsByRepo(t *testing.T) {
+	repos := []repoRef{
+		{Slug: "api", Path: "/p/api", Modules: nil},                              // single-repo: omitted
+		{Slug: "mono", Path: "/p/mono", Modules: []string{"packages/api", "packages/worker"}},
+	}
+	got := moduleRootsByRepo(repos)
+	if _, ok := got["api"]; ok {
+		t.Fatalf("repo with no modules should be omitted; got %v", got)
+	}
+	if want := []string{"packages/api", "packages/worker"}; len(got["mono"]) != len(want) {
+		t.Fatalf("mono roots = %v; want %v", got["mono"], want)
+	}
+
+	// All-single-repo group → nil map → modulePathFor short-circuits to "".
+	if m := moduleRootsByRepo([]repoRef{{Slug: "solo", Modules: nil}}); m != nil {
+		t.Fatalf("expected nil map for non-monorepo group; got %v", m)
+	}
+}


### PR DESCRIPTION
## What

The WebUI v2 scope selector (#4637, shipped) derives module options from the group's `monorepos` config (parent-repo → module sub-paths) and filters records with `matchesScope(repo, modulePath?)`. But the dashboard payloads only carried `repo`, so any **module-scope** selection silently degraded to repo-level (the TODO already noted in the client `matchesScope`).

This wires per-record module attribution end-to-end on the backend.

## How

- **Shared helper** `modulePathFor(repo, sourceFile, modulesByRepo)` (`internal/dashboard/module_path.go`): derives a record's module sub-path from its repo-relative `source_file` and the repo's configured module roots via **longest-prefix match** (empty when the file is under no root). `moduleRootsByRepo([]repoRef)` builds the parent-repo→roots map (same shape as `Group.monorepos`).
- **Layout-agnostic**: derivation relies solely on the configured roots (the same `registry.Repo.Modules` that populates `Group.monorepos`), never framework heuristics — works for Nx/Turbo/Gradle-multimodule/Go-workspaces/Python monorepo.
- `repoRef` now carries the repo's `Modules` so every handler computes module_path identically without re-loading the group config.

## Payloads now carrying `module_path` (selector consumers today)

| Payload | Field | Handler |
|---|---|---|
| Security auth-coverage findings | `module_path` | `handleSecurityAuthCoverage` |
| Security secrets findings | `module_path` | `handleSecuritySecrets` |
| IaC resources | `module_path` (distinct from the existing source-dir `Module` heuristic) | `handleIaC` |
| Cross-repo links | `source_module_path` / `target_module_path` | `enrichLinkEndpoints` |

`repo` is never removed or renamed.

## Single-repo / non-monorepo groups

No configured module roots ⇒ `moduleRootsByRepo` returns nil ⇒ every record yields `""`. Zero behaviour change.

## Deferred (not current selector consumers client-side)

- v2 **paths** route rows — a route may span multiple repos/handlers, so a single module_path is ambiguous at the route level; paths.tsx does not yet call `matchesScope`.
- **coverage** rows — no scope-filtered client route yet.
- Import-**cycle** findings span multiple members with no single source file → stay repo-level.

## Validation

`internal/dashboard/module_path_test.go`: monorepo config with roots `packages/api`, `packages/worker` → `packages/api/src/x.ts` ⇒ `packages/api`; longest-prefix wins over a broader `packages` root; sibling-prefix (`apiv2` vs `api`) does NOT match; file outside any root ⇒ `""`; single-repo group ⇒ `""`. Plus `moduleRootsByRepo` omits no-module repos.

## Gates

```
go build ./...                                                   OK
go vet ./internal/dashboard/... ./internal/graph/...             OK
go test ./internal/dashboard/... ./internal/graph/...            ok (all pass)
```

Closes #4698

🤖 Generated with [Claude Code](https://claude.com/claude-code)