### PR TITLE
feat(dto): DTO/serializer field-as-members for Python + Java (#4613)

### DIFF
--- a/internal/custom/java/patterns_dispatch.go
+++ b/internal/custom/java/patterns_dispatch.go
@@ -95,6 +95,7 @@ var allPatternExtractors = []patternFn{
 	ExtractSpringBoot,
 	ExtractSpringDIDeepen,
 	ExtractSpringDIGraph,
+	ExtractSpringDTOFields,
 	ExtractSpringEcosystem,
 	ExtractSpringGlobalWiring,
 	ExtractSpringGraphQL,

--- a/internal/custom/java/spring_dto_fields.go
+++ b/internal/custom/java/spring_dto_fields.go
@@ -1,0 +1,423 @@
+package java
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// spring_dto_fields.go — Java Spring DTO FIELD-as-member indexing (issue #4613),
+// generalizing the NestJS / JS-TS model (#4635,
+// javascript/validation_schema.go::emitSchemaFieldMembers) to Spring request/
+// query/response DTOs.
+//
+// The existing bean_validation.go emits per-field `SCOPE.Schema`/field members
+// ONLY for fields that carry a Bean Validation annotation (@NotNull, @Size, …).
+// A Spring DTO whose POJO fields / record components have NO constraints (a
+// plain `@RequestBody CreateUserRequest` carrying `String name; int age;`, or a
+// `record CreateUser(String name, int age)`) therefore had ZERO field members,
+// so request/response FIELD-level diffs were limited. This extractor closes that
+// gap by emitting a member for EVERY field/record-component of a DTO-shaped
+// class, carrying the SAME property shape as the JS/Python field members:
+//
+//	field_name, field_type, parent_class, optional, validators, provenance,
+//	library="spring"
+//
+// plus a CONTAINS edge to the owning class. Bean-validation annotations present
+// on a field are surfaced as the `validators` set; `@NotNull`/`@NotEmpty`/
+// `@NotBlank`/primitive types mark a field required, `Optional<T>`/`@Nullable`
+// mark it optional.
+//
+// To avoid double-emitting members already produced by bean_validation.go (for
+// annotated fields), the dedup is by entity Ref (`scope:schema:
+// bean_validation_field:<fp>:<Owner>.<field>`), shared with that extractor — the
+// dispatcher dedups by Ref so whichever fires first wins and the membership edge
+// is identical.
+
+var springDtoFrameworks = map[string]bool{
+	"spring_boot": true, "spring-boot": true, "springboot": true,
+	"spring_mvc": true, "spring-mvc": true, "springmvc": true,
+	"spring_webflux": true, "spring-webflux": true, "springwebflux": true,
+}
+
+var (
+	// sdfClassRE matches a (non-controller) class header. Group 1 = class name,
+	// group 2 = the byte just past `{`. We capture the brace to delimit the body.
+	sdfClassRE = regexp.MustCompile(
+		`(?m)(?:public\s+)?(?:(?:abstract|final|static)\s+)*class\s+(\w+)\b[^{;]*\{`)
+	// sdfRecordRE matches a Java record declaration and its component list.
+	// Group 1 = record name, group 2 = the raw component list.
+	sdfRecordRE = regexp.MustCompile(
+		`(?m)(?:public\s+)?(?:(?:final|static)\s+)*record\s+(\w+)\s*\(([\s\S]*?)\)`)
+	// sdfControllerAnnRE detects an @…Controller / @Service / @Repository /
+	// @Configuration class we should NOT treat as a DTO.
+	sdfControllerAnnRE = regexp.MustCompile(
+		`@(?:RestController|Controller|Service|Repository|Configuration|Component|ControllerAdvice|RestControllerAdvice)\b`)
+	// sdfFieldRE matches a POJO field declaration (one per line). Group 1 = type,
+	// group 2 = name. Annotations are recovered from a preceding window.
+	sdfFieldRE = regexp.MustCompile(
+		`(?m)^[ \t]*(?:private|protected|public)\s+(?:final\s+)?` +
+			`([A-Za-z_][\w.]*(?:\s*<[^>]*>)?(?:\[\])?)\s+(\w+)\s*[;=]`)
+)
+
+// sdfDtoNameRE recognizes a DTO-shaped class name by the conventional suffixes.
+var sdfDtoNameRE = regexp.MustCompile(`(?:Dto|DTO|Request|Response|Payload|Form|Command|Query|Resource|Model|Body|View|Input|Output)$`)
+
+// sdfScalarKind normalizes a Java type to a scalar type, parity with the JS
+// schemaScalarKind / Python pyScalarKind maps.
+var sdfScalarKind = map[string]string{
+	"String": "string", "char": "string", "Character": "string",
+	"CharSequence": "string", "UUID": "string",
+	"int": "integer", "Integer": "integer", "long": "integer", "Long": "integer",
+	"short": "integer", "Short": "integer", "byte": "integer", "Byte": "integer",
+	"BigInteger": "integer",
+	"float": "number", "Float": "number", "double": "number", "Double": "number",
+	"BigDecimal": "number",
+	"boolean": "boolean", "Boolean": "boolean",
+	"LocalDate": "date", "LocalDateTime": "date", "Instant": "date",
+	"Date": "date", "OffsetDateTime": "date", "ZonedDateTime": "date",
+	"List": "array", "Set": "array", "Collection": "array", "Iterable": "array",
+	"Map": "object", "Object": "any",
+}
+
+// normalizeJavaType strips generics / array suffixes and maps to a scalar type.
+func normalizeJavaType(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if strings.HasSuffix(raw, "[]") {
+		return "array"
+	}
+	base := raw
+	if i := strings.IndexAny(base, "<["); i >= 0 {
+		base = strings.TrimSpace(base[:i])
+	}
+	if i := strings.LastIndex(base, "."); i >= 0 {
+		base = base[i+1:]
+	}
+	if base == "Optional" {
+		return "object" // Optional<T> wrapper — element handled separately for optionality
+	}
+	if k, ok := sdfScalarKind[base]; ok {
+		return k
+	}
+	return base
+}
+
+// sdfPrimitiveRequired reports whether a Java type is a non-null primitive
+// (cannot be null → required by construction).
+var sdfPrimitiveRequired = map[string]bool{
+	"int": true, "long": true, "double": true, "float": true,
+	"boolean": true, "char": true, "byte": true, "short": true,
+}
+
+// ExtractSpringDTOFields emits FIELD-as-member sub-entities for Spring DTO
+// POJOs and records. Fires for Spring frameworks only.
+func ExtractSpringDTOFields(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" || !springDtoFrameworks[ctx.Framework] {
+		return result
+	}
+	source := ctx.Source
+	fp := ctx.FilePath
+	seenRefs := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// ── records: every component is a member ────────────────────────────────
+	for _, m := range sdfRecordRE.FindAllStringSubmatchIndex(source, -1) {
+		name := source[m[2]:m[3]]
+		compBlob := source[m[4]:m[5]]
+		line := lineOf(source, m[0])
+		for _, c := range parseRecordComponents(compBlob) {
+			emitSpringField(&result, seenRefs, seenRels, fp, name, c, line, ctx.Framework)
+		}
+	}
+
+	// ── POJO classes: skip Spring stereotypes; require DTO-shaped name OR the
+	// class is referenced by a @RequestBody/@ModelAttribute in the file ───────
+	requestTypes := springRequestBodyTypes(source)
+	for _, m := range sdfClassRE.FindAllStringSubmatchIndex(source, -1) {
+		name := source[m[2]:m[3]]
+		headerStart := m[0]
+		// Skip stereotype-annotated classes (controllers/services/etc.). Only the
+		// annotation block immediately preceding THIS class header counts — bound
+		// the lookback at the previous `}`/`;`/`{` so a sibling controller's
+		// annotations earlier in the file don't spuriously skip a later DTO class.
+		annWindow := classAnnotationWindow(source, headerStart)
+		if sdfControllerAnnRE.MatchString(annWindow) {
+			continue
+		}
+		isDTO := sdfDtoNameRE.MatchString(name) || requestTypes[name]
+		if !isDTO {
+			continue
+		}
+		bodyStart := m[1] - 1 // index of `{`
+		body := braceBody(source, bodyStart)
+		line := lineOf(source, headerStart)
+		for _, fm := range sdfFieldRE.FindAllStringSubmatchIndex(body, -1) {
+			rawType := strings.TrimSpace(body[fm[2]:fm[3]])
+			fieldName := body[fm[4]:fm[5]]
+			// Recover annotations from the preceding window within the body.
+			annWin := body[maxInt(0, fm[0]-300):fm[0]]
+			c := javaFieldComp{
+				name:        fieldName,
+				rawType:     rawType,
+				annotations: fieldAnnotsInWindow(annWin),
+			}
+			emitSpringField(&result, seenRefs, seenRels, fp, name, c, line, ctx.Framework)
+		}
+	}
+
+	return result
+}
+
+// javaFieldComp is a captured DTO field / record component.
+type javaFieldComp struct {
+	name        string
+	rawType     string
+	annotations []string
+}
+
+// emitSpringField appends a `SCOPE.Schema`/field member + CONTAINS edge for one
+// DTO field, deduping on the bean_validation-shared ref so annotated fields are
+// not double-emitted.
+func emitSpringField(result *PatternResult, seenRefs map[string]bool, seenRels map[relKey]bool,
+	fp, ownerClass string, c javaFieldComp, line int, framework string) {
+	if c.name == "" || ownerClass == "" {
+		return
+	}
+	ref := "scope:schema:bean_validation_field:" + fp + ":" + ownerClass + "." + c.name
+
+	typ := normalizeJavaType(c.rawType)
+	optional, required := springFieldOptionality(c.rawType, c.annotations)
+
+	props := map[string]any{
+		"kind":         "SCOPE.Schema",
+		"subtype":      "field",
+		"library":      "spring",
+		"pattern_type": "field",
+		"field_name":   c.name,
+		"field_type":   typ,
+		"parent_class": ownerClass,
+		"owner_class":  ownerClass,
+		"provenance":   "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP",
+		"framework":    framework,
+	}
+	if len(c.annotations) > 0 {
+		props["validators"] = strings.Join(c.annotations, " ")
+		props["constraints"] = strings.Join(stripAt(c.annotations), ",")
+	}
+	if optional {
+		props["optional"] = "true"
+	}
+	if required {
+		props["required"] = "true"
+	}
+
+	// Java-style signature: `[@Ann ...] Type name`.
+	var sb strings.Builder
+	for _, a := range c.annotations {
+		sb.WriteString(a)
+		sb.WriteByte(' ')
+	}
+	sb.WriteString(typ)
+	sb.WriteByte(' ')
+	sb.WriteString(c.name)
+
+	emitted := addEntity(result, seenRefs, SecondaryEntity{
+		Name: ownerClass + "." + c.name, Kind: "SCOPE.Schema", Subtype: "field",
+		SourceFile: fp, LineStart: line, LineEnd: line,
+		Provenance: "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP", Ref: ref,
+		Properties: props,
+	})
+	if emitted {
+		addRel(result, seenRels, containsFieldRel(ownerClass, ref, c.name, framework))
+	}
+}
+
+// springFieldOptionality infers whether a Spring DTO field is optional/required
+// from its type and bean-validation annotations.
+func springFieldOptionality(rawType string, annots []string) (optional, required bool) {
+	base := strings.TrimSpace(rawType)
+	if i := strings.IndexAny(base, "<["); i >= 0 {
+		base = strings.TrimSpace(base[:i])
+	}
+	if i := strings.LastIndex(base, "."); i >= 0 {
+		base = base[i+1:]
+	}
+	for _, a := range annots {
+		switch a {
+		case "@NotNull", "@NotEmpty", "@NotBlank":
+			required = true
+		case "@Nullable":
+			optional = true
+		}
+	}
+	if base == "Optional" {
+		optional = true
+	}
+	if sdfPrimitiveRequired[base] {
+		required = true
+	}
+	return optional, required
+}
+
+// springRequestBodyTypes returns the set of types referenced by a
+// @RequestBody / @ModelAttribute parameter in the file — these are request
+// DTOs whose field membership we always emit (even without a DTO-suffix name).
+var sdfReqBodyParamRE = regexp.MustCompile(
+	`@(?:RequestBody|ModelAttribute)\b(?:\s*@\w+(?:\s*\([^)]*\))?\s*)*\s+([A-Za-z_][\w.]*)(?:\s*<[^>]*>)?\s+\w+`)
+
+func springRequestBodyTypes(source string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range sdfReqBodyParamRE.FindAllStringSubmatch(source, -1) {
+		t := m[1]
+		if i := strings.LastIndex(t, "."); i >= 0 {
+			t = t[i+1:]
+		}
+		out[t] = true
+	}
+	return out
+}
+
+// parseRecordComponents splits a record component list `@Ann Type a, Type b`
+// into individual components with their annotations.
+func parseRecordComponents(blob string) []javaFieldComp {
+	var out []javaFieldComp
+	for _, part := range splitTopLevelCommas(blob) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		annots := fieldAnnotsInWindow(part)
+		// Remove annotations to isolate `Type name`.
+		clean := regexp.MustCompile(`@\w+(?:\([^)]*\))?\s*`).ReplaceAllString(part, "")
+		clean = strings.TrimSpace(clean)
+		toks := strings.Fields(collapseGenerics(clean))
+		if len(toks) < 2 {
+			continue
+		}
+		out = append(out, javaFieldComp{
+			name:        toks[len(toks)-1],
+			rawType:     strings.Join(toks[:len(toks)-1], " "),
+			annotations: annots,
+		})
+	}
+	return out
+}
+
+// splitTopLevelCommas splits on commas not nested inside <...> or (...).
+func splitTopLevelCommas(s string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i, r := range s {
+		switch r {
+		case '<', '(', '[':
+			depth++
+		case '>', ')', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// collapseGenerics removes whitespace inside generic brackets so `List < X >`
+// tokenizes as one type token.
+func collapseGenerics(s string) string {
+	var sb strings.Builder
+	depth := 0
+	for _, r := range s {
+		switch r {
+		case '<':
+			depth++
+		case '>':
+			if depth > 0 {
+				depth--
+			}
+		}
+		if (r == ' ' || r == '\t') && depth > 0 {
+			continue
+		}
+		sb.WriteRune(r)
+	}
+	return sb.String()
+}
+
+// fieldAnnotsInWindow extracts `@Annotation` heads from a text window.
+var sdfAnnHeadRE = regexp.MustCompile(`@(\w+)`)
+
+func fieldAnnotsInWindow(window string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range sdfAnnHeadRE.FindAllStringSubmatch(window, -1) {
+		a := "@" + m[1]
+		if seen[a] {
+			continue
+		}
+		seen[a] = true
+		out = append(out, a)
+	}
+	return out
+}
+
+// stripAt removes the leading `@` from annotation heads.
+func stripAt(annots []string) []string {
+	out := make([]string, 0, len(annots))
+	for _, a := range annots {
+		out = append(out, strings.TrimPrefix(a, "@"))
+	}
+	return out
+}
+
+// braceBody returns the substring inside the braces beginning at openBraceIdx
+// (the index of `{`), reading balanced `{`/`}`.
+func braceBody(s string, openBraceIdx int) string {
+	if openBraceIdx < 0 || openBraceIdx >= len(s) || s[openBraceIdx] != '{' {
+		return ""
+	}
+	depth := 0
+	for i := openBraceIdx; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[openBraceIdx+1 : i]
+			}
+		}
+	}
+	return s[openBraceIdx+1:]
+}
+
+// classAnnotationWindow returns the text from the nearest preceding `}`, `{`,
+// or `;` up to the class header — i.e. only this declaration's own leading
+// annotations/modifiers, not unrelated earlier code.
+func classAnnotationWindow(source string, headerStart int) string {
+	start := headerStart
+	for start > 0 {
+		c := source[start-1]
+		if c == '}' || c == '{' || c == ';' {
+			break
+		}
+		start--
+	}
+	return source[start:headerStart]
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+var _ = types.RelationshipKindContains // keep types import anchored

--- a/internal/custom/java/spring_dto_fields_test.go
+++ b/internal/custom/java/spring_dto_fields_test.go
@@ -1,0 +1,160 @@
+package java
+
+import (
+	"strings"
+	"testing"
+)
+
+// spring_dto_fields_test.go — tests for Spring DTO FIELD-as-member indexing
+// (#4613). Mirrors the JS/TS (#4635) and Python (#4613) field-membership model:
+// each POJO field / record component of a Spring DTO becomes a
+// SCOPE.Schema/field member carrying name/type/optional/validators + a CONTAINS
+// edge to the owning class.
+
+func sdfCtx(source, filePath string) PatternContext {
+	return PatternContext{
+		Source: source, Language: "java", Framework: "spring_boot", FilePath: filePath,
+	}
+}
+
+func fieldMember(res PatternResult, name string) *SecondaryEntity {
+	for i := range res.Entities {
+		if res.Entities[i].Name == name &&
+			res.Entities[i].Kind == "SCOPE.Schema" &&
+			res.Entities[i].Subtype == "field" {
+			return &res.Entities[i]
+		}
+	}
+	return nil
+}
+
+func hasContainsRel(res PatternResult, ownerStub, targetRefSuffix string) bool {
+	for _, r := range res.Relationships {
+		if r.RelationshipType == "CONTAINS" &&
+			r.FromName == ownerStub &&
+			strings.HasSuffix(r.TargetRef, targetRefSuffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSpringDTO_PojoFieldMembers(t *testing.T) {
+	src := `package com.example;
+
+public class CreateUserRequest {
+    @NotBlank
+    private String name;
+    private int age;
+    private Optional<String> nickname;
+}`
+	res := ExtractSpringDTOFields(sdfCtx(src, "CreateUserRequest.java"))
+
+	name := fieldMember(res, "CreateUserRequest.name")
+	if name == nil {
+		t.Fatal("expected field member CreateUserRequest.name")
+	}
+	if name.Properties["field_type"] != "string" {
+		t.Errorf("name type = %v, want string", name.Properties["field_type"])
+	}
+	if name.Properties["required"] != "true" {
+		t.Errorf("name (@NotBlank) should be required, props=%v", name.Properties)
+	}
+	if v, _ := name.Properties["validators"].(string); !strings.Contains(v, "@NotBlank") {
+		t.Errorf("name should carry @NotBlank validator, props=%v", name.Properties)
+	}
+
+	age := fieldMember(res, "CreateUserRequest.age")
+	if age == nil || age.Properties["field_type"] != "integer" {
+		t.Fatalf("expected CreateUserRequest.age:integer, got %+v", age)
+	}
+	if age.Properties["required"] != "true" {
+		t.Errorf("primitive int age should be required, props=%v", age.Properties)
+	}
+
+	nick := fieldMember(res, "CreateUserRequest.nickname")
+	if nick == nil {
+		t.Fatal("expected CreateUserRequest.nickname")
+	}
+	if nick.Properties["optional"] != "true" {
+		t.Errorf("Optional<String> nickname should be optional, props=%v", nick.Properties)
+	}
+
+	// CONTAINS membership edges (FromName = Class:owner).
+	if !hasContainsRel(res, "Class:CreateUserRequest", "CreateUserRequest.name") {
+		t.Error("expected CONTAINS edge Class:CreateUserRequest -> CreateUserRequest.name")
+	}
+}
+
+func TestSpringDTO_RecordComponents(t *testing.T) {
+	src := `package com.example;
+
+public record CreateOrder(@NotNull Long productId, int quantity, String note) {}`
+	res := ExtractSpringDTOFields(sdfCtx(src, "CreateOrder.java"))
+
+	pid := fieldMember(res, "CreateOrder.productId")
+	if pid == nil || pid.Properties["field_type"] != "integer" {
+		t.Fatalf("expected CreateOrder.productId:integer, got %+v", pid)
+	}
+	if pid.Properties["required"] != "true" {
+		t.Errorf("productId (@NotNull) should be required, props=%v", pid.Properties)
+	}
+	qty := fieldMember(res, "CreateOrder.quantity")
+	if qty == nil || qty.Properties["field_type"] != "integer" {
+		t.Fatalf("expected CreateOrder.quantity:integer, got %+v", qty)
+	}
+	note := fieldMember(res, "CreateOrder.note")
+	if note == nil || note.Properties["field_type"] != "string" {
+		t.Fatalf("expected CreateOrder.note:string, got %+v", note)
+	}
+	if !hasContainsRel(res, "Class:CreateOrder", "CreateOrder.productId") {
+		t.Error("expected CONTAINS edge to CreateOrder.productId")
+	}
+}
+
+// A class referenced by @RequestBody but without a DTO-suffix name still gets
+// field members.
+func TestSpringDTO_RequestBodyTypeWithoutSuffix(t *testing.T) {
+	src := `package com.example;
+
+@RestController
+class C {
+    @PostMapping("/p")
+    public void create(@RequestBody Payload p) {}
+}
+
+class Payload {
+    private String title;
+}`
+	res := ExtractSpringDTOFields(sdfCtx(src, "C.java"))
+	if fieldMember(res, "Payload.title") == nil {
+		t.Fatal("expected @RequestBody Payload.title field member")
+	}
+}
+
+// Stereotype-annotated classes (controllers/services) must NOT get DTO members.
+func TestSpringDTO_SkipsStereotypes(t *testing.T) {
+	src := `package com.example;
+
+@Service
+public class UserService {
+    private final UserRepo repo;
+}`
+	res := ExtractSpringDTOFields(sdfCtx(src, "UserService.java"))
+	for _, e := range res.Entities {
+		if strings.HasPrefix(e.Name, "UserService.") {
+			t.Errorf("@Service class must not emit DTO field members, got %s", e.Name)
+		}
+	}
+}
+
+// Non-spring framework → no-op.
+func TestSpringDTO_FrameworkGate(t *testing.T) {
+	src := `public class FooRequest { private String x; }`
+	res := ExtractSpringDTOFields(PatternContext{
+		Source: src, Language: "java", Framework: "quarkus", FilePath: "F.java",
+	})
+	if len(res.Entities) != 0 {
+		t.Errorf("non-spring framework should emit nothing, got %d", len(res.Entities))
+	}
+}

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -386,6 +386,40 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 					referencesClassEdge(className+"."+attr, callee, "drf", attr))
 			}
 		}
+
+		// (c) Issue #4613 — FIELD-as-member sub-entities. Mirror the JS/TS DTO
+		// field-membership model (#4635): each explicitly-declared serializer
+		// field becomes a `SCOPE.Schema`/field child carrying name/type/optional/
+		// validators, so request/response DRF FIELD-level diffs are no longer
+		// limited. The CONTAINS edges from (a) already bind these names to the
+		// owner; here we emit the child entities those edges point at.
+		explicitFields := extractDRFSerializerFields(body)
+		out = append(out, emitPyDTOFieldMembers(
+			className, explicitFields, "drf", file.Path, line, nil)...)
+
+		// (d) ModelSerializer Meta.fields. `fields = [...]` → emit the enumerated
+		// names as field members (type unknown — model-derived). `fields =
+		// "__all__"` → mark the serializer as model-derived/unenumerated with a
+		// flag rather than silently emitting nothing.
+		meta := extractDRFMetaFields(body)
+		switch {
+		case meta.isAll:
+			serEnt.Properties["fields_source"] = "model_all"
+			serEnt.Properties["fields_unenumerated"] = "true"
+		case len(meta.names) > 0:
+			serEnt.Properties["fields_source"] = "meta_list"
+			var metaFields []pyDTOField
+			for _, fn := range meta.names {
+				if seenSerMember[fn] {
+					continue // already emitted as an explicit field
+				}
+				metaFields = append(metaFields, pyDTOField{name: fn, typ: "unknown"})
+				serEnt.Relationships = append(serEnt.Relationships,
+					containsFieldEdge(className, className+"."+fn, fn, "drf"))
+			}
+			out = append(out, emitPyDTOFieldMembers(
+				className, metaFields, "drf", file.Path, line, nil)...)
+		}
 		out = append(out, serEnt)
 	}
 

--- a/internal/custom/python/dto_field_members.go
+++ b/internal/custom/python/dto_field_members.go
@@ -1,0 +1,408 @@
+package python
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// dto_field_members.go — Python DTO/serializer FIELD-as-member indexing,
+// generalizing the NestJS / JS-TS model (issue #4635,
+// javascript/validation_schema.go::emitSchemaFieldMembers) to Pydantic models
+// and DRF serializers (issue #4613).
+//
+// Each request/query/response DTO's fields become `SCOPE.Schema` subtype=field
+// sub-entities named `<Owner>.<field>`, carrying the SAME property shape as the
+// JS field members so the cross-framework field-level diff tools + the
+// dashboard /shape ShapeTree resolver treat all frameworks uniformly:
+//
+//	field_name   — the field's name
+//	field_type   — normalized scalar/declared type ("string"/"integer"/...)
+//	parent_class — the owning DTO/serializer class name
+//	optional     — "true" when the field is optional / not required
+//	validators   — space-joined constraint/validator markers (when any)
+//	provenance   — INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP
+//	library      — "pydantic" / "drf"
+//
+// The child's Signature is the Java-style `[@Validators ...] <type> <name>` so
+// the shape resolver's parseFieldSignature recovers (annotations, type, name)
+// exactly as it does for the JS/Java DTO fields. A CONTAINS edge binds each
+// field to its owner. This file owns ONLY the field-member emission; the owner
+// class entities are emitted by pydantic.go / django.go.
+
+// pyDTOField is a captured DTO/serializer field: name, normalized type,
+// validators/constraints, and optionality.
+type pyDTOField struct {
+	name       string
+	typ        string
+	validators []string
+	optional   bool
+}
+
+// emitPyDTOFieldMembers emits one `SCOPE.Schema`/field sub-entity per field of a
+// DTO/serializer. Each child carries its own CONTAINS membership edge whose
+// FromID resolves to the owning class via the `Class:<owner>` byName fallback
+// (see containsFieldEdge) — so NO class-named carrier entity is emitted (issue
+// #1501 discipline). When ownerRels is non-nil the edge is ALSO appended there
+// (used by callers that already own the serializer entity and want the edge on
+// it instead); when nil, the edge lives only on the child. Mirrors the JS/Java
+// field-membership model (#4635/#4367).
+func emitPyDTOFieldMembers(
+	ownerClass string,
+	fields []pyDTOField,
+	library, filePath string,
+	ownerLine int,
+	ownerRels *[]types.RelationshipRecord,
+) []types.EntityRecord {
+	if ownerClass == "" || len(fields) == 0 {
+		return nil
+	}
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	for _, f := range fields {
+		if f.name == "" || seen[f.name] {
+			continue
+		}
+		seen[f.name] = true
+
+		annots := append([]string(nil), f.validators...)
+		typ := f.typ
+		if typ == "" {
+			typ = "unknown"
+		}
+
+		// Java-style field signature: `[@Ann ...] Type name`.
+		var sb strings.Builder
+		for _, a := range annots {
+			sb.WriteString(a)
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(typ)
+		sb.WriteByte(' ')
+		sb.WriteString(f.name)
+
+		childName := ownerClass + "." + f.name
+		props := map[string]string{
+			"kind":         "SCOPE.Schema",
+			"subtype":      "field",
+			"library":      library,
+			"pattern_type": "field",
+			"field_name":   f.name,
+			"field_type":   typ,
+			"parent_class": ownerClass,
+			"provenance":   "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP",
+		}
+		if f.optional {
+			props["optional"] = "true"
+		}
+		if len(annots) > 0 {
+			props["validators"] = strings.Join(annots, " ")
+		}
+		child := entity(childName, "SCOPE.Schema", "field", filePath, ownerLine, props)
+		child.Signature = sb.String()
+		edge := containsFieldEdge(ownerClass, childName, f.name, library)
+		if ownerRels != nil {
+			// Caller owns the serializer entity and wants the edge on it.
+			*ownerRels = append(*ownerRels, edge)
+		} else {
+			// No class carrier (Pydantic / DRF): the child carries its own
+			// membership edge; FromID `Class:<owner>` resolves to the real class.
+			child.Relationships = append(child.Relationships, edge)
+		}
+		out = append(out, child)
+	}
+	return out
+}
+
+// ── Pydantic model field parsing ─────────────────────────────────────────────
+
+// pydModelFieldRe matches a Pydantic model body field declaration. Group 1 =
+// leading indent, group 2 = field name, group 3 = the type annotation (up to
+// `=` or EOL), group 4 = the RHS default expression (may be empty). Only
+// annotated assignments are fields; bare `x = 1` class vars without an
+// annotation are not Pydantic fields. The captured indent lets the caller keep
+// only the model's direct-body fields (skip method-local annotated locals).
+var pydModelFieldRe = regexp.MustCompile(
+	`(?m)^([ \t]+)([a-zA-Z_]\w*)\s*:\s*([^=\n]+?)\s*(?:=\s*(.+))?$`)
+
+// pyOptionalTypeRe detects `Optional[...]` / `... | None` / `Union[..., None]`.
+var pyOptionalTypeRe = regexp.MustCompile(`(?:^|[\[,\s])None(?:[\],\s]|$)`)
+
+// extractPydanticModelFields parses the body of a Pydantic model class into its
+// field members. `bodyOffsetLine` is the line of the class header so child
+// entities can be attributed near the model.
+func extractPydanticModelFields(body string) []pyDTOField {
+	var fields []pyDTOField
+	seen := make(map[string]bool)
+	// Determine the model's direct-body indent (the minimal indent of a matched
+	// declaration) so deeper-indented method-local annotated assignments are not
+	// mistaken for model fields.
+	baseIndent := -1
+	for _, m := range pydModelFieldRe.FindAllStringSubmatch(body, -1) {
+		if n := len(m[1]); baseIndent < 0 || n < baseIndent {
+			baseIndent = n
+		}
+	}
+	for _, m := range pydModelFieldRe.FindAllStringSubmatch(body, -1) {
+		if len(m[1]) != baseIndent {
+			continue // not a direct model-body field (nested in a method/inner class)
+		}
+		name := m[2]
+		annot := strings.TrimSpace(m[3])
+		rhs := strings.TrimSpace(m[4])
+		if name == "" || seen[name] {
+			continue
+		}
+		// Skip the inner `class Config:` / `model_config` / method defs and
+		// dunder declarations — these are not model fields.
+		if name == "model_config" || strings.HasPrefix(name, "__") {
+			continue
+		}
+		// A reserved-word annotation (e.g. the line was actually `def f(self):`)
+		// will not reach here because the regex requires `name : type`.
+		seen[name] = true
+
+		optional := pydIsOptional(annot)
+		var validators []string
+		// A field with no `= ...` default and not Optional is required.
+		if rhs == "" && !optional {
+			// required — no explicit marker; leave validators empty.
+		} else if rhs != "" && strings.HasPrefix(rhs, "Field(") {
+			// Field(...) — capture recognized constraints as validator markers and
+			// detect `default=`/`...` (Ellipsis = required).
+			validators = pydFieldConstraintMarkers(rhs)
+			if strings.Contains(rhs, "Field(...)") || regexp.MustCompile(`Field\(\s*\.\.\.`).MatchString(rhs) {
+				// required sentinel
+			} else {
+				optional = true // has a default
+			}
+		} else if rhs != "" {
+			// Has a literal default value → optional.
+			optional = true
+		}
+
+		fields = append(fields, pyDTOField{
+			name:       name,
+			typ:        normalizePyType(annot),
+			validators: validators,
+			optional:   optional,
+		})
+	}
+	return fields
+}
+
+// pydIsOptional reports whether a type annotation denotes an optional field.
+func pydIsOptional(annot string) bool {
+	if strings.HasPrefix(annot, "Optional[") || strings.HasPrefix(annot, "typing.Optional[") {
+		return true
+	}
+	// `X | None` or `Union[X, None]`.
+	if strings.Contains(annot, "|") && pyOptionalTypeRe.MatchString(annot) {
+		return true
+	}
+	if strings.HasPrefix(annot, "Union[") && pyOptionalTypeRe.MatchString(annot) {
+		return true
+	}
+	return false
+}
+
+// pydConstraintMarkerKeys are Field() kwargs surfaced as validator markers on a
+// field member (parity with class-validator `@IsX`).
+var pydConstraintMarkerKeys = []string{
+	"gt", "ge", "lt", "le", "min_length", "max_length",
+	"min_items", "max_items", "multiple_of", "max_digits",
+	"decimal_places", "pattern", "regex",
+}
+
+// pydFieldConstraintMarkers maps recognized Field() constraints to `@key`
+// markers, in deterministic order.
+func pydFieldConstraintMarkers(rhs string) []string {
+	var out []string
+	for _, k := range pydConstraintMarkerKeys {
+		if regexp.MustCompile(`\b` + regexp.QuoteMeta(k) + `\s*=`).MatchString(rhs) {
+			out = append(out, "@"+k)
+		}
+	}
+	return out
+}
+
+// pyScalarKind normalizes a Python type token to a scalar type, parity with the
+// JS schemaScalarKind map.
+var pyScalarKind = map[string]string{
+	"str": "string", "string": "string",
+	"int": "integer", "integer": "integer",
+	"float": "number", "Decimal": "number", "complex": "number",
+	"bool": "boolean", "boolean": "boolean",
+	"datetime": "date", "date": "date", "time": "date",
+	"list": "array", "List": "array", "tuple": "array", "set": "array",
+	"dict": "object", "Dict": "object",
+	"bytes": "string", "UUID": "string", "EmailStr": "string",
+	"Any": "any", "None": "null",
+}
+
+// normalizePyType strips Optional/Union wrappers and generics, returning a
+// normalized scalar type.
+func normalizePyType(annot string) string {
+	annot = strings.TrimSpace(annot)
+	// Unwrap Optional[X] / typing.Optional[X].
+	if i := strings.Index(annot, "Optional["); i >= 0 {
+		inner := annot[i+len("Optional["):]
+		if j := strings.LastIndex(inner, "]"); j >= 0 {
+			inner = inner[:j]
+		}
+		annot = strings.TrimSpace(inner)
+	}
+	// `X | None` → X.
+	if strings.Contains(annot, "|") {
+		parts := strings.Split(annot, "|")
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "None" && p != "" {
+				annot = p
+				break
+			}
+		}
+	}
+	// Strip generic subscripts: List[str] → list, Dict[...] → dict.
+	if i := strings.IndexAny(annot, "[ "); i >= 0 {
+		annot = annot[:i]
+	}
+	// Strip dotted path: typing.List → List.
+	if i := strings.LastIndex(annot, "."); i >= 0 {
+		annot = annot[i+1:]
+	}
+	if k, ok := pyScalarKind[annot]; ok {
+		return k
+	}
+	return annot
+}
+
+// ── DRF serializer field parsing ─────────────────────────────────────────────
+
+// drfFieldDeclRe matches an explicit DRF serializer field declaration:
+//
+//	name = serializers.CharField(required=False, allow_null=True)
+//	name = CharField(...)
+//	items = ItemSerializer(many=True)
+//
+// Group 1 = field name, group 2 = the field-class callee (dotted allowed),
+// group 3 = the call argument blob (best-effort, single-line / shallow).
+var drfFieldDeclRe = regexp.MustCompile(
+	`(?m)^[ \t]+(\w+)\s*=\s*([\w.]*(?:Field|Serializer))\s*\(([^)]*)`)
+
+// drfFieldTypeKind maps a DRF field class to a normalized scalar type.
+var drfFieldTypeKind = map[string]string{
+	"CharField": "string", "EmailField": "string", "SlugField": "string",
+	"URLField": "string", "UUIDField": "string", "RegexField": "string",
+	"FilePathField": "string", "IPAddressField": "string",
+	"IntegerField": "integer", "FloatField": "number", "DecimalField": "number",
+	"BooleanField": "boolean", "NullBooleanField": "boolean",
+	"DateField": "date", "DateTimeField": "date", "TimeField": "date",
+	"DurationField": "date",
+	"ListField": "array", "MultipleChoiceField": "array",
+	"DictField": "object", "JSONField": "object", "HStoreField": "object",
+	"ChoiceField": "enum",
+	"SerializerMethodField": "any", "ReadOnlyField": "any", "HiddenField": "any",
+	"PrimaryKeyRelatedField": "integer", "HyperlinkedRelatedField": "string",
+	"SlugRelatedField": "string", "StringRelatedField": "string",
+}
+
+// drfFieldType normalizes a DRF field/serializer callee to a scalar type.
+func drfFieldType(callee string) string {
+	short := callee
+	if i := strings.LastIndex(short, "."); i >= 0 {
+		short = short[i+1:]
+	}
+	if k, ok := drfFieldTypeKind[short]; ok {
+		return k
+	}
+	// A nested serializer field → its target shape is an object.
+	if strings.HasSuffix(short, "Serializer") {
+		return "object"
+	}
+	return strings.ToLower(strings.TrimSuffix(short, "Field"))
+}
+
+// extractDRFSerializerFields parses an explicit-declared DRF serializer body
+// into field members. `required=False`, `allow_null=True`, `read_only=True`,
+// and `default=` mark a field optional.
+func extractDRFSerializerFields(body string) []pyDTOField {
+	var fields []pyDTOField
+	seen := make(map[string]bool)
+	for _, m := range drfFieldDeclRe.FindAllStringSubmatch(body, -1) {
+		name := m[1]
+		callee := m[2]
+		args := m[3]
+		if name == "" || seen[name] || strings.HasPrefix(name, "__") {
+			continue
+		}
+		seen[name] = true
+
+		optional := false
+		if regexp.MustCompile(`required\s*=\s*False`).MatchString(args) ||
+			regexp.MustCompile(`allow_null\s*=\s*True`).MatchString(args) ||
+			regexp.MustCompile(`read_only\s*=\s*True`).MatchString(args) ||
+			regexp.MustCompile(`\bdefault\s*=`).MatchString(args) {
+			optional = true
+		}
+
+		var validators []string
+		for _, kw := range []string{"required", "allow_null", "read_only", "write_only",
+			"max_length", "min_length", "max_value", "min_value"} {
+			if regexp.MustCompile(`\b` + kw + `\s*=`).MatchString(args) {
+				validators = append(validators, "@"+kw)
+			}
+		}
+
+		fields = append(fields, pyDTOField{
+			name:       name,
+			typ:        drfFieldType(callee),
+			validators: validators,
+			optional:   optional,
+		})
+	}
+	return fields
+}
+
+// ── DRF ModelSerializer Meta.fields parsing ──────────────────────────────────
+
+// drfMetaFieldsListRe matches a `fields = [...]` / `fields = (...)` declaration
+// inside a serializer's inner `class Meta:`. Group 1 = the bracketed list body.
+var drfMetaFieldsListRe = regexp.MustCompile(
+	`(?m)^[ \t]+fields\s*=\s*[\[\(]([^\]\)]*)[\]\)]`)
+
+// drfMetaFieldsAllRe matches `fields = "__all__"` / `fields = '__all__'`.
+var drfMetaFieldsAllRe = regexp.MustCompile(
+	`(?m)^[ \t]+fields\s*=\s*["']__all__["']`)
+
+// drfMetaResult carries the result of statically reading a ModelSerializer's
+// Meta.fields. When isAll is true the field set is model-derived and not
+// statically enumerable; names holds the explicit Meta list otherwise.
+type drfMetaResult struct {
+	names []string
+	isAll bool
+	found bool
+}
+
+// extractDRFMetaFields reads a serializer body's inner `class Meta:` `fields`
+// declaration. `fields = "__all__"` → isAll (model-derived, unenumerated);
+// `fields = [...]` → the enumerated name list.
+func extractDRFMetaFields(body string) drfMetaResult {
+	if drfMetaFieldsAllRe.MatchString(body) {
+		return drfMetaResult{isAll: true, found: true}
+	}
+	if m := drfMetaFieldsListRe.FindStringSubmatch(body); m != nil {
+		var names []string
+		for _, q := range regexp.MustCompile(`["']([^"']+)["']`).FindAllStringSubmatch(m[1], -1) {
+			names = append(names, q[1])
+		}
+		if len(names) > 0 {
+			sort.Strings(names)
+			return drfMetaResult{names: names, found: true}
+		}
+		return drfMetaResult{found: true}
+	}
+	return drfMetaResult{}
+}

--- a/internal/custom/python/dto_field_members_test.go
+++ b/internal/custom/python/dto_field_members_test.go
@@ -1,0 +1,221 @@
+package python_test
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// findFieldChild locates a SCOPE.Schema/field child entity by qualified name.
+func findFieldChild(rs []extractResult, name string) *extractResult {
+	for i := range rs {
+		if rs[i].Name == name && rs[i].Kind == "SCOPE.Schema" && rs[i].Subtype == "field" {
+			return &rs[i]
+		}
+	}
+	return nil
+}
+
+// hasContainsTo reports whether any emitted entity carries a CONTAINS edge to
+// the given qualified field name.
+func hasContainsTo(rs []extractResult, fieldName string) bool {
+	for _, r := range rs {
+		for _, rel := range r.Rels {
+			if rel.Kind == "CONTAINS" && rel.ToID == fieldName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ── Pydantic model field membership (#4613) ──────────────────────────────────
+
+func TestPydantic_FieldMembers(t *testing.T) {
+	src := `from pydantic import BaseModel, Field
+from typing import Optional
+
+class CreateUser(BaseModel):
+    name: str
+    age: int = 0
+    nickname: Optional[str] = None
+    score: float = Field(..., gt=0, le=100)
+`
+	rs := extract(t, "python_pydantic", src)
+
+	name := findFieldChild(rs, "CreateUser.name")
+	if name == nil {
+		t.Fatal("expected field sub-entity CreateUser.name")
+	}
+	if name.Props["field_type"] != "string" {
+		t.Errorf("name type = %q, want string", name.Props["field_type"])
+	}
+	if name.Props["optional"] == "true" {
+		t.Errorf("name (no default, not Optional) should be required, props=%v", name.Props)
+	}
+
+	age := findFieldChild(rs, "CreateUser.age")
+	if age == nil || age.Props["field_type"] != "integer" {
+		t.Fatalf("expected CreateUser.age:integer, got %+v", age)
+	}
+	if age.Props["optional"] != "true" {
+		t.Errorf("age (has default 0) should be optional, props=%v", age.Props)
+	}
+
+	nick := findFieldChild(rs, "CreateUser.nickname")
+	if nick == nil {
+		t.Fatal("expected CreateUser.nickname")
+	}
+	if nick.Props["optional"] != "true" {
+		t.Errorf("nickname (Optional) should be optional, props=%v", nick.Props)
+	}
+	if nick.Props["field_type"] != "string" {
+		t.Errorf("nickname type = %q, want string", nick.Props["field_type"])
+	}
+
+	score := findFieldChild(rs, "CreateUser.score")
+	if score == nil {
+		t.Fatal("expected CreateUser.score")
+	}
+	if score.Props["validators"] == "" {
+		t.Errorf("score (Field gt/le) should carry validators, props=%v", score.Props)
+	}
+	// Field(...) ellipsis = required.
+	if score.Props["optional"] == "true" {
+		t.Errorf("score (Field(...)) should be required, props=%v", score.Props)
+	}
+
+	// CONTAINS membership edges.
+	if !hasContainsTo(rs, "CreateUser.name") {
+		t.Error("expected CONTAINS edge to CreateUser.name")
+	}
+	if !hasContainsTo(rs, "CreateUser.score") {
+		t.Error("expected CONTAINS edge to CreateUser.score")
+	}
+}
+
+// Signature must be present so the shape resolver can parse it. Verified via the
+// raw extractor (the shared `extract` helper drops Signature).
+func TestPydantic_FieldSignature(t *testing.T) {
+	src := `from pydantic import BaseModel
+class P(BaseModel):
+    title: str
+`
+	ext, ok := extractor.Get("python_pydantic")
+	if !ok {
+		t.Fatal("python_pydantic not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "p.py", Content: []byte(src), Language: "python",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, e := range ents {
+		if e.Name == "P.title" && e.Subtype == "field" {
+			found = true
+			if e.Signature == "" {
+				t.Error("P.title must carry a Signature for the shape resolver")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected P.title field member")
+	}
+}
+
+// ── DRF serializer field membership (#4613) ──────────────────────────────────
+
+func TestDRF_ExplicitSerializerFieldMembers(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class UserSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=100)
+    email = serializers.EmailField(required=False)
+    age = serializers.IntegerField(allow_null=True)
+`
+	rs := extract(t, "python_django", src)
+
+	name := findFieldChild(rs, "UserSerializer.name")
+	if name == nil || name.Props["field_type"] != "string" {
+		t.Fatalf("expected UserSerializer.name:string, got %+v", name)
+	}
+	if name.Props["optional"] == "true" {
+		t.Errorf("name (required default) should not be optional, props=%v", name.Props)
+	}
+	email := findFieldChild(rs, "UserSerializer.email")
+	if email == nil || email.Props["optional"] != "true" {
+		t.Fatalf("email (required=False) should be optional, got %+v", email)
+	}
+	age := findFieldChild(rs, "UserSerializer.age")
+	if age == nil || age.Props["field_type"] != "integer" || age.Props["optional"] != "true" {
+		t.Fatalf("age (IntegerField, allow_null) wrong: %+v", age)
+	}
+
+	if !hasContainsTo(rs, "UserSerializer.name") {
+		t.Error("expected CONTAINS edge to UserSerializer.name")
+	}
+}
+
+func TestDRF_ModelSerializerMetaFieldsList(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = ["id", "title", "price"]
+`
+	rs := extract(t, "python_django", src)
+
+	for _, fn := range []string{"id", "title", "price"} {
+		if findFieldChild(rs, "ProductSerializer."+fn) == nil {
+			t.Errorf("expected Meta field member ProductSerializer.%s", fn)
+		}
+		if !hasContainsTo(rs, "ProductSerializer."+fn) {
+			t.Errorf("expected CONTAINS edge to ProductSerializer.%s", fn)
+		}
+	}
+	// Serializer node should be flagged as meta-list sourced.
+	var ser *extractResult
+	for i := range rs {
+		if rs[i].Name == "ProductSerializer" && rs[i].Props["pattern_type"] == "serializer" {
+			ser = &rs[i]
+		}
+	}
+	if ser == nil {
+		t.Fatal("expected ProductSerializer component")
+	}
+	if ser.Props["fields_source"] != "meta_list" {
+		t.Errorf("fields_source = %q, want meta_list", ser.Props["fields_source"])
+	}
+}
+
+func TestDRF_ModelSerializerAllFieldsFlagged(t *testing.T) {
+	src := `from rest_framework import serializers
+
+class OrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+        fields = "__all__"
+`
+	rs := extract(t, "python_django", src)
+	var ser *extractResult
+	for i := range rs {
+		if rs[i].Name == "OrderSerializer" && rs[i].Props["pattern_type"] == "serializer" {
+			ser = &rs[i]
+		}
+	}
+	if ser == nil {
+		t.Fatal("expected OrderSerializer component")
+	}
+	// __all__ must be FLAGGED, not silently empty.
+	if ser.Props["fields_source"] != "model_all" {
+		t.Errorf("fields_source = %q, want model_all", ser.Props["fields_source"])
+	}
+	if ser.Props["fields_unenumerated"] != "true" {
+		t.Errorf("__all__ serializer must be flagged unenumerated, props=%v", ser.Props)
+	}
+}

--- a/internal/custom/python/pydantic.go
+++ b/internal/custom/python/pydantic.go
@@ -56,6 +56,12 @@ var (
 	// model_config = ConfigDict(...) (v2) or `class Config:` inner class (v1).
 	pydModelConfigRe = regexp.MustCompile(`(?m)^[ \t]+model_config\s*=\s*ConfigDict\s*\(([^)]*)\)`)
 	pydConfigClassRe = regexp.MustCompile(`(?m)^[ \t]+class\s+Config\s*:`)
+
+	// pydModelClassRe matches a Pydantic model class header — a class whose base
+	// list includes BaseModel / BaseSettings (directly or as a known alias).
+	// Issue #4613: each model's annotated fields become CONTAINS field members.
+	pydModelClassRe = regexp.MustCompile(
+		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*\b(?:BaseModel|BaseSettings)\b[^)]*\)\s*:`)
 )
 
 // pydConstraintKeys are the Field() keyword constraints we surface. Order is
@@ -189,8 +195,57 @@ func (e *PydanticExtractor) Extract(ctx context.Context, file extractor.FileInpu
 		out = append(out, configEntity("v1", "Config", body, file.Path, line))
 	}
 
+	// 5. Field-as-member sub-entities (issue #4613). Each `class X(BaseModel)`
+	// model's annotated fields become `SCOPE.Schema`/field child entities with a
+	// CONTAINS edge from the model — parity with the JS/TS class-validator DTO
+	// field members (#4635) so cross-framework request/response FIELD-level diffs
+	// work. The owner class node itself is emitted by the base Python extractor;
+	// here we hang the CONTAINS membership off a lightweight owner carrier so the
+	// edge binds to the real class via the `Class:<name>` byName fallback.
+	for _, idx := range allMatchesIndex(pydModelClassRe, source) {
+		className := source[idx[2]:idx[3]]
+		line := lineOf(source, idx[0])
+		body := pydModelBody(source, idx[0])
+		fields := extractPydanticModelFields(body)
+		if len(fields) == 0 {
+			continue
+		}
+		// Each field child carries its own CONTAINS edge (FromID `Class:<name>`
+		// resolves to the base-extractor model node). We do NOT emit a class-named
+		// carrier entity (issue #1501 discipline).
+		out = append(out, emitPyDTOFieldMembers(className, fields, "pydantic", file.Path, line, nil)...)
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// pydModelBody returns the indented body of a Pydantic model class starting at
+// the class header byte offset, up to the first dedent. Mirrors the Django
+// extractClassBody scan but is local to keep the pydantic extractor standalone.
+func pydModelBody(source string, classStart int) string {
+	lines := strings.Split(source[classStart:], "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+	classIndent := len(lines[0]) - len(strings.TrimLeft(lines[0], " \t"))
+	var body []string
+	for i, ln := range lines {
+		if i == 0 {
+			continue
+		}
+		stripped := strings.TrimSpace(ln)
+		if stripped == "" {
+			body = append(body, ln)
+			continue
+		}
+		indent := len(ln) - len(strings.TrimLeft(ln, " \t"))
+		if indent <= classIndent {
+			break
+		}
+		body = append(body, ln)
+	}
+	return strings.Join(body, "\n")
 }
 
 // configEntity builds the model-config / coercion pattern entity from a config


### PR DESCRIPTION
Extends the NestJS / JS-TS DTO **field-as-member** model (`javascript/validation_schema.go::emitSchemaFieldMembers`, #4635) to **Python** and **Java**, so request/query/response DTOs carry their fields as `SCOPE.Schema`/`field` member sub-entities for field-level parity diffs. Closes the rewrite-agent limit: *"Pydantic / DRF-serializer / Spring DTO field membership not yet emitted, so DRF request/response FIELD-level diff is still limited."*

Same Kind / SCOPE / `CONTAINS` edge shape as #4635 so the diff tools + ShapeTree expand treat all frameworks uniformly. Each field sub-entity carries `field_name`, `field_type`, `parent_class`, `optional`, `validators`, `provenance` + a Java-style `Signature` for `parseFieldSignature`.

### Python (`internal/custom/python/dto_field_members.go`)
- **Pydantic** `class X(BaseModel)`: annotated fields → members; optionality from `Optional[...]` / `X | None` / default / `Field(...)`; recognized `Field()` constraints (`gt`/`le`/`max_length`/`pattern`/…) as validators. No class-named carrier entity (issue #1501) — each child carries its own `CONTAINS` edge whose `FromID` resolves via `Class:<name>`.
- **DRF serializers** (`django.go`): explicit `field = serializers.XField(required=, allow_null=, read_only=, default=…)` → members; `ModelSerializer` `Meta.fields = [...]` → enumerated members (`fields_source=meta_list`); `fields = "__all__"` → **flagged** model-derived/unenumerated (`fields_source=model_all`, `fields_unenumerated=true`) rather than silently empty.

### Java (`internal/custom/java/spring_dto_fields.go`)
- **Spring DTOs**: POJO fields + record components of DTO-shaped / `@RequestBody` / `@ModelAttribute` types → members; optional/required from type + bean-validation annotations (`@NotNull`/`@NotBlank`/`Optional<T>`/primitives); constraints as validators. Closes the gap where `bean_validation.go` only emitted members for constraint-annotated fields (a plain `record CreateUser(String name, int age)` previously had zero members). Deduped on the shared bean-validation field ref. Registered in `patterns_dispatch.go`.

### Tests (RED→GREEN)
Pydantic model; DRF explicit fields + `Meta.fields` list + `__all__` flag; Spring POJO + record + `@RequestBody`-without-suffix + stereotype-skip + framework-gate.

### Gates
`go build ./...`, `go vet ./internal/custom/...`, `go test ./internal/custom/... ./internal/types/` — all green.

### Follow-ups filed
Other DTO/serializer frameworks (marshmallow, attrs/dataclasses, Go struct tags, C#/.NET DataAnnotations, Ruby AMS) tracked separately rather than silently skipped.

Closes #4613

🤖 Generated with [Claude Code](https://claude.com/claude-code)