### PR TITLE
feat(python): local-variable receiver typing for test→endpoint coverage linkage (#4681)

### DIFF
--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -1105,6 +1105,16 @@ func extractCallRelationships(
 	type seenKey struct{ target, alias string }
 	seen := make(map[seenKey]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
+
+	// Issue #4681 — local-variable receiver typing. Scan the body once for
+	// `localName = ClassName(...)` constructor bindings so a subsequent
+	// `localName.method()` resolves to `ClassName.method` instead of an
+	// unresolvable bare leaf. This is the dominant unit-test shape
+	// (`v = ProposalViewSet(); v.get_counts(...)` / `view = XView()` /
+	// `obj = XSerializer(...)`) — without it ComputeCoverage undercounts
+	// controller/view coverage because the test→handler CALLS edge never
+	// forms. The map mirrors the TS/JS local-receiver typing in #4671.
+	localRecv := localReceiverTypes(body, src)
 	for _, call := range calls {
 		// Issue #2806 — subprocess / exec calls invoke an OS binary, not an
 		// indexed Python symbol. `subprocess.run(['libreoffice', ...])`,
@@ -1137,7 +1147,7 @@ func extractCallRelationships(
 			// (run/Popen/system/...) must NOT flow to the bare-name resolver.
 			continue
 		}
-		target, ambiguous := callTarget(call, src, parentClass)
+		target, ambiguous := callTarget(call, src, parentClass, localRecv)
 		if target == "" {
 			continue
 		}
@@ -1422,7 +1432,74 @@ func pyStringLiteralValue(n *sitter.Node, src []byte) string {
 //
 // parentClass is the dotted enclosing class path of the caller, or "" when
 // the caller is module-level. It is consulted only for `self.<x>` resolution.
-func callTarget(call *sitter.Node, src []byte, parentClass string) (string, bool) {
+// localReceiverTypes scans a function/method body for local-variable
+// constructor bindings and returns a `localName → ClassName` map so a
+// subsequent `localName.method()` call types through receiverClass to
+// `ClassName.method` (issue #4681). It mirrors the TS/JS local-receiver
+// typing landed in #4671 for the dominant unit-test shape:
+//
+//	v   = ProposalViewSet()       # DRF ViewSet unit spec
+//	view = ArticleView()          # Django CBV unit spec
+//	obj = ArticleSerializer(data) # DRF serializer unit spec
+//	v.get_counts('2025')          # → ProposalViewSet.get_counts
+//
+// Recognised binding shape: an `assignment` whose left side is a single
+// bare identifier and whose right side is a `call` expression whose
+// function is a bare PascalCase class identifier (the same conservative
+// class-name heuristic receiverClass already uses for `User.save(...)`).
+// Namespaced constructors (`pkg.Thing()`), keyword/typed assignments, and
+// non-construction RHS shapes are intentionally skipped — a guess there
+// risks binding edges to the wrong class.
+//
+// Precedence/conservatism mirrors #4671: first binding wins on a re-assign
+// collision (bias to miss rather than mis-bind to a later reassignment of a
+// different type), and a non-PascalCase RHS constructor (factory function,
+// lowercased helper) yields no entry. Returns nil for bodies with no
+// qualifying binding so the hot path allocates nothing.
+func localReceiverTypes(body *sitter.Node, src []byte) map[string]string {
+	if body == nil {
+		return nil
+	}
+	assigns := findAll(body, "assignment")
+	if len(assigns) == 0 {
+		return nil
+	}
+	var locals map[string]string
+	for _, a := range assigns {
+		lhs := a.ChildByFieldName("left")
+		if lhs == nil || lhs.Type() != "identifier" {
+			// Tuple/subscript/attribute targets don't name a single receiver.
+			continue
+		}
+		rhs := a.ChildByFieldName("right")
+		if rhs == nil || rhs.Type() != "call" {
+			continue
+		}
+		ctor := rhs.ChildByFieldName("function")
+		if ctor == nil || ctor.Type() != "identifier" {
+			// `pkg.Thing()` (attribute) and other non-bare constructors are
+			// left to the resolver; we only bind unambiguous local classes.
+			continue
+		}
+		clsName := nodeText(ctor, src)
+		if !isPascalCaseClassName(clsName) {
+			continue
+		}
+		name := nodeText(lhs, src)
+		if name == "" {
+			continue
+		}
+		if locals == nil {
+			locals = map[string]string{}
+		}
+		if _, seen := locals[name]; !seen {
+			locals[name] = clsName
+		}
+	}
+	return locals
+}
+
+func callTarget(call *sitter.Node, src []byte, parentClass string, localRecv map[string]string) (string, bool) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return "", false
@@ -1444,7 +1521,7 @@ func callTarget(call *sitter.Node, src []byte, parentClass string) (string, bool
 		if recv == nil {
 			return leaf, true
 		}
-		if cls := receiverClass(recv, src, parentClass); cls != "" {
+		if cls := receiverClass(recv, src, parentClass, localRecv); cls != "" {
 			return cls + "." + leaf, false
 		}
 		return leaf, true
@@ -1479,7 +1556,7 @@ func callTarget(call *sitter.Node, src []byte, parentClass string) (string, bool
 // deliberately left unresolved here: making a guess would risk binding edges
 // to the wrong class. The resolver's name-collision logic is a safer place
 // to disambiguate those cases.
-func receiverClass(recv *sitter.Node, src []byte, parentClass string) string {
+func receiverClass(recv *sitter.Node, src []byte, parentClass string, localRecv map[string]string) string {
 	if recv == nil {
 		return ""
 	}
@@ -1488,6 +1565,13 @@ func receiverClass(recv *sitter.Node, src []byte, parentClass string) string {
 		text := nodeText(recv, src)
 		if text == "self" || text == "cls" {
 			return parentClass
+		}
+		// Issue #4681 — local-variable receiver typing. A local bound from a
+		// constructor (`v = ProposalViewSet()`) is a lowercase identifier the
+		// PascalCase heuristic below never matches; consult the per-body local
+		// map first so `v.get_counts()` resolves to `ProposalViewSet.get_counts`.
+		if cls := localRecv[text]; cls != "" {
+			return cls
 		}
 		// Issue #557 — bare PascalCase/CamelCase identifier as receiver, e.g.
 		// `User.save(...)`, `Article.objects.create(...)`.  Python convention
@@ -1514,7 +1598,7 @@ func receiverClass(recv *sitter.Node, src []byte, parentClass string) string {
 		for i := 0; i < int(recv.ChildCount()); i++ {
 			ch := recv.Child(i)
 			if ch.IsNamed() {
-				return receiverClass(ch, src, parentClass)
+				return receiverClass(ch, src, parentClass, localRecv)
 			}
 		}
 	}

--- a/internal/extractors/python/issue4681_localvar_receiver_test.go
+++ b/internal/extractors/python/issue4681_localvar_receiver_test.go
@@ -1,0 +1,123 @@
+// issue4681_localvar_receiver_test.go — Python local-variable receiver typing
+// for test→CALLS coverage crediting (issue #4681, part of epic #4615/#4672).
+//
+// Mirrors the TS/JS local-receiver typing landed in #4671. A unit test binds
+// a local from a constructor and then calls a method on it:
+//
+//	def test_get_counts():
+//	    v = ProposalViewSet()
+//	    v.get_counts('2025')
+//
+// Before #4681 the receiver `v` was a lowercase identifier the PascalCase
+// heuristic never matched, so `v.get_counts()` emitted a bare, unresolvable
+// leaf — no test→handler CALLS edge — and ComputeCoverage saw the endpoint as
+// untested. After #4681 the per-body local map types `v → ProposalViewSet`,
+// so the edge resolves to `ProposalViewSet.get_counts`.
+//
+// Route-hit test-client linkage (DRF `self.client.get(url)`, fixture B in the
+// epic) is already covered by the e2e_route_calls path —
+// see internal/engine/http_endpoint_e2e_testmap_4369_test.go.
+
+package python
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// hasCallTo reports whether any CALLS relationship in rels targets toID.
+func hasCallTo(rels []types.RelationshipRecord, toID string) bool {
+	for _, r := range rels {
+		if r.Kind == "CALLS" && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// FIXTURE A — local var assigned from a ViewSet constructor inside a named
+// test function; the subsequent method call must resolve to the class method.
+func TestIssue4681_LocalVarReceiver_ViewSetUnitSpec(t *testing.T) {
+	src := `
+class ProposalViewSet:
+    def get_counts(self, year):
+        return year
+
+
+def test_get_counts():
+    v = ProposalViewSet()
+    v.get_counts('2025')
+`
+	ents := extractEntities(t, "tests/test_proposals.py", src)
+	calls := findCallsFrom(ents, "test_get_counts")
+	if !hasCallTo(calls, "ProposalViewSet.get_counts") {
+		t.Fatalf("expected CALLS edge to ProposalViewSet.get_counts (local-var receiver typing #4681); got %+v", calls)
+	}
+}
+
+// Variant: Django CBV and DRF serializer local-var receivers also type.
+func TestIssue4681_LocalVarReceiver_CBVAndSerializer(t *testing.T) {
+	src := `
+class ArticleView:
+    def get(self, request):
+        return request
+
+
+class ArticleSerializer:
+    def is_valid(self):
+        return True
+
+
+def test_view_and_serializer():
+    view = ArticleView()
+    view.get(None)
+    obj = ArticleSerializer()
+    obj.is_valid()
+`
+	ents := extractEntities(t, "tests/test_articles.py", src)
+	calls := findCallsFrom(ents, "test_view_and_serializer")
+	if !hasCallTo(calls, "ArticleView.get") {
+		t.Fatalf("expected CALLS edge to ArticleView.get; got %+v", calls)
+	}
+	if !hasCallTo(calls, "ArticleSerializer.is_valid") {
+		t.Fatalf("expected CALLS edge to ArticleSerializer.is_valid; got %+v", calls)
+	}
+}
+
+// Negative control 1: a factory-function (non-PascalCase) RHS must NOT bind —
+// `make_thing()` is not a class construction, so `t.run()` stays ambiguous and
+// no `<Class>.run` edge is forged.
+func TestIssue4681_LocalVarReceiver_NegativeFactory(t *testing.T) {
+	src := `
+def test_factory():
+    obj = make_thing()
+    obj.run()
+`
+	ents := extractEntities(t, "tests/test_factory.py", src)
+	calls := findCallsFrom(ents, "test_factory")
+	for _, r := range calls {
+		if r.Kind == "CALLS" && r.ToID == "make_thing.run" {
+			t.Fatalf("factory-function receiver must not type to make_thing.run; got %+v", calls)
+		}
+	}
+}
+
+// FIXTURE C — shape-only assertion test: never constructs a handler class and
+// never calls a production method. No `<Class>.method` CALLS edge must form, so
+// ComputeCoverage leaves the endpoint uncovered (honest exclusion, #4662/#4671).
+func TestIssue4681_ShapeOnlyAssertion_NoEdge(t *testing.T) {
+	src := `
+def test_shape_only():
+    payload = {'count': 0}
+    assert 'count' in payload
+    assert isinstance(payload['count'], int)
+`
+	ents := extractEntities(t, "tests/test_shape.py", src)
+	calls := findCallsFrom(ents, "test_shape_only")
+	for _, r := range calls {
+		if r.Kind == "CALLS" && (r.ToID == "ProposalViewSet.get_counts" || r.ToID == "get_counts") {
+			t.Fatalf("shape-only assertion must not credit any handler; got %+v", calls)
+		}
+	}
+}


### PR DESCRIPTION
Generalizes the TS/JS local-receiver-typing win (#4671 / PR #4680) to **Python** — the Python slice of epic **#4615** (all-framework test→endpoint coverage linkage).

## Problem
The Python call resolver (`callTarget` → `receiverClass`) typed `self`/`cls` and bare PascalCase receivers (`User.save()`), but NOT a **local variable bound from a constructor** — the dominant DRF/Django/FastAPI unit-spec shape:

```python
def test_get_counts():
    v = ProposalViewSet()
    v.get_counts('2025')
```

`v` is lowercase, so the PascalCase heuristic never matched; `v.get_counts()` emitted a bare, unresolvable `get_counts` (ambiguous) — no test→handler CALLS edge — and ComputeCoverage undercounted the endpoint as untested.

## Fix
- **Local-variable receiver typing** (`internal/extractors/python/extractor.go`): new `localReceiverTypes` scans each body once for `localName = ClassName(...)` constructor bindings (single-identifier LHS, bare PascalCase constructor RHS) and folds a per-body `localName → ClassName` map that `receiverClass` consults before the PascalCase fallback → `v.get_counts()` resolves to `ProposalViewSet.get_counts`. Conservatism mirrors #4671 (first binding wins; factory functions / namespaced constructors stay bare).
- **No synthetic test-scope owner needed.** Python `test_*` functions / `TestCase` methods are already named, call-bearing entities, so the enclosing named function owns the resolved CALLS edge (confirmed — unlike the anonymous `it()` callbacks that required `emitTestScopeOwner` for TS/JS in #4680).
- **Route-hit test-client linkage already lands** (DRF `self.client.get(url)` / `APIClient().post` / FastAPI `TestClient(app).get` / Flask `app.test_client().get` / pytest `client.get`) via `pytest.go`'s `e2e_route_calls` → `http_endpoint_e2e_testmap.go` (#4369) — verified & reused, no change required.
- **Coverage side unchanged**: ComputeCoverage's existing test→CALLS→handler crediting (+ handler↔definition hop) does the rest once the edge exists.
- **Honest exclusion** preserved (#4662/#4671): shape-only assertion specs that never call a handler or hit a route get NO edge.

## Fixtures (RED→GREEN verified) — `issue4681_localvar_receiver_test.go`
- **A** `v = ProposalViewSet(); v.get_counts(...)` → CALLS to `ProposalViewSet.get_counts` (+ Django CBV `ArticleView.get` / DRF `ArticleSerializer.is_valid` variant).
- **C** shape-only assertion test → no `<Class>.method` edge.
- negative control: factory-function receiver (`obj = make_thing()`) stays bare.
- **B** (DRF route-hit linkage) already covered by `internal/engine/http_endpoint_e2e_testmap_4369_test.go`.

RED confirmed: without the fix, fixture A emits `get_counts` with `disposition_hint: ambiguous` and no resolved edge.

## Coverage docs (gate)
Updated the Python `django` / `django-drf` / `fastapi` / `flask` / `starlette` `Testing.tests_linkage` cells in `docs/coverage/registry.json` with the #4681 capability + cites (surgical 5-cell edit). `coverage fmt --check` passes.

## Gates
`go build ./...` ✅ · `go vet ./internal/custom/... ./internal/graph/...` ✅ · `go test ./internal/custom/... ./internal/graph/... ./internal/types/` ✅ (+ `internal/extractors/python` + `internal/engine`) · `coverage fmt --check` ✅. DEPLOY-DEFERRED.

Closes #4681
Part of #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)