### PR TITLE
feat(java): `var` local receiver typing for test→CALLS coverage linkage (#4682)

### DIFF
--- a/internal/extractors/java/issue4682_localvar_receiver_test.go
+++ b/internal/extractors/java/issue4682_localvar_receiver_test.go
@@ -1,0 +1,161 @@
+// issue4682_localvar_receiver_test.go — Java local-variable receiver typing
+// for test→CALLS coverage crediting (issue #4682, part of epic #4615/#4672).
+//
+// Generalises the TS/JS (#4680) and Python (#4716) local-receiver wins to Java.
+// A JUnit unit test binds a local from a constructor and then calls a method on
+// it; the call must resolve to the class method so ComputeCoverage credits the
+// endpoint through test→CALLS→handler.
+//
+// Java already typed the EXPLICIT-DECLARED-TYPE form
+// (`XController c = new XController(svc); c.getCounts()`) via
+// collectLocalVarTypes + collectFieldTypes (so fixtures A and B below were
+// already green from #120/#2062/#4359). The genuine RED this child closes is the
+// modern `var` idiom: `var c = new XController(svc); c.getCounts()` — `var`
+// carries no declared leaf type, so the local was left bare and `c.getCounts()`
+// fell through to an unresolvable `var.getCounts` leaf. We now infer the type
+// from a DIRECT `new ClassName(...)` initialiser (and only that shape), mirroring
+// the #4680/#4716 conservatism: factory/builder/chain RHS receivers stay
+// unresolved.
+//
+// Route-hit test-client linkage (MockMvc / WebTestClient / TestRestTemplate /
+// REST Assured, fixture C in the epic) is already covered by the e2e_route_calls
+// path — see internal/custom/java/issue4370_spring_e2e_route_tests_test.go and
+// internal/engine/http_endpoint_e2e_testmap*.
+
+package java_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/java"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func jcovExtract(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("java")
+	if !ok {
+		t.Fatal("java extractor not registered")
+	}
+	out, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "java",
+		Tree: parseForTest(t, src),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return out
+}
+
+func jcovCalls(t *testing.T, out []types.EntityRecord, name string) []types.RelationshipRecord {
+	t.Helper()
+	for i := range out {
+		if out[i].Name == name {
+			return out[i].Relationships
+		}
+	}
+	var have []string
+	for i := range out {
+		have = append(have, out[i].Name)
+	}
+	t.Fatalf("no entity named %q; have: %v", name, have)
+	return nil
+}
+
+func jcovHasCall(rels []types.RelationshipRecord, to string) bool {
+	for _, r := range rels {
+		if r.Kind == "CALLS" && r.ToID == to {
+			return true
+		}
+	}
+	return false
+}
+
+// FIXTURE A — explicit-declared-type local from a constructor.
+// `XController c = new XController(svc); c.getCounts()` → CALLS XController.getCounts.
+func TestIssue4682_LocalVarReceiver_DeclaredType(t *testing.T) {
+	src := `package com.x;
+class XController { public int getCounts() { return 1; } }
+class XControllerTest {
+  @Test
+  void testGetCounts() {
+    XController c = new XController(svc);
+    c.getCounts();
+  }
+}
+`
+	out := jcovExtract(t, "com/x/XControllerTest.java", src)
+	rels := jcovCalls(t, out, "XControllerTest.testGetCounts")
+	if !jcovHasCall(rels, "XController.getCounts") {
+		t.Fatalf("A: expected CALLS XController.getCounts; got %+v", rels)
+	}
+}
+
+// FIXTURE A' — the `var` form is the genuine #4682 win. `var c = new XController(...)`
+// must infer the local's type from the constructor so c.getCounts() resolves.
+func TestIssue4682_LocalVarReceiver_VarNew(t *testing.T) {
+	src := `package com.x;
+class XController { public int getCounts() { return 1; } }
+class XControllerTest {
+  @Test
+  void testGetCounts() {
+    var c = new XController(svc);
+    c.getCounts();
+  }
+}
+`
+	out := jcovExtract(t, "com/x/XControllerTest.java", src)
+	rels := jcovCalls(t, out, "XControllerTest.testGetCounts")
+	if !jcovHasCall(rels, "XController.getCounts") {
+		t.Fatalf("A': expected CALLS XController.getCounts for `var` + new RHS; got %+v", rels)
+	}
+}
+
+// FIXTURE B — Mockito @InjectMocks field injection. The field carries a declared
+// type, so controller.getCounts() resolves via collectFieldTypes/cc.fields.
+func TestIssue4682_InjectMocksField(t *testing.T) {
+	src := `package com.x;
+class XController { public int getCounts() { return 1; } }
+class XControllerTest {
+  @InjectMocks XController controller;
+  @Test
+  void testGetCounts() {
+    controller.getCounts();
+  }
+}
+`
+	out := jcovExtract(t, "com/x/XControllerTest.java", src)
+	rels := jcovCalls(t, out, "XControllerTest.testGetCounts")
+	if !jcovHasCall(rels, "XController.getCounts") {
+		t.Fatalf("B: expected CALLS XController.getCounts via @InjectMocks field; got %+v", rels)
+	}
+}
+
+// NEGATIVE — a factory/builder receiver must NOT forge a class edge. A `var`
+// local bound from `MyFactory.create()` (not a `new`) stays unresolved, so
+// `c.getCounts()` is a bare leaf and no `XController.getCounts` (or any
+// fabricated `<Class>.getCounts`) edge is emitted.
+func TestIssue4682_NegativeFactoryReceiver(t *testing.T) {
+	src := `package com.x;
+class XControllerTest {
+  @Test
+  void testBuilder() {
+    var c = MyFactory.create();
+    c.getCounts();
+  }
+}
+`
+	out := jcovExtract(t, "com/x/XControllerTest.java", src)
+	rels := jcovCalls(t, out, "XControllerTest.testBuilder")
+	for _, r := range rels {
+		if r.Kind == "CALLS" && r.ToID == "XController.getCounts" {
+			t.Fatalf("negative: factory receiver must not forge XController.getCounts; got %+v", rels)
+		}
+		// And it must not type to the factory name either (MyFactory.getCounts).
+		if r.Kind == "CALLS" && r.ToID == "MyFactory.getCounts" {
+			t.Fatalf("negative: factory receiver must not type to MyFactory.getCounts; got %+v", rels)
+		}
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -1125,10 +1125,18 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 	}
 	out := map[string]string{}
 	for _, decl := range findAllNodes(body, "local_variable_declaration") {
-		typ := leafTypeName(decl.ChildByFieldName("type"), src)
-		if typ == "" {
-			continue
-		}
+		declType := leafTypeName(decl.ChildByFieldName("type"), src)
+		// `var` (Java 10+) carries no declared leaf type. Mirror the TS/JS
+		// (#4680) and Python (#4716) local-receiver wins: when the
+		// initialiser is a direct `new ClassName(...)` we infer the local's
+		// type from the constructed class so a follow-up `localName.method()`
+		// in a `@Test` method resolves to the class method (the dominant
+		// modern-JUnit idiom `var controller = new XController(mock);`).
+		// Any other RHS — a factory/builder call (`MyFactory.create()`), a
+		// method chain, a cast, a literal — leaves the `var` local
+		// unresolved (declared-type-or-`new` conservatism; first-binding
+		// wins per declarator).
+		isVar := declType == "var" || declType == ""
 		for i := 0; i < int(decl.ChildCount()); i++ {
 			ch := decl.Child(i)
 			if ch == nil || ch.Type() != "variable_declarator" {
@@ -1136,6 +1144,16 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 			}
 			name := childFieldText(ch, "name", src)
 			if name == "" {
+				continue
+			}
+			typ := declType
+			if isVar {
+				typ = newExprClassName(ch.ChildByFieldName("value"), src)
+				if typ == "" {
+					continue
+				}
+			}
+			if typ == "" || typ == "var" {
 				continue
 			}
 			out[name] = typ
@@ -1155,6 +1173,29 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 		}
 	}
 	return out
+}
+
+// newExprClassName returns the constructed class name when value is a direct
+// `new ClassName(...)` object_creation_expression, or "" for any other
+// initialiser shape. Used to type `var` locals (#4682, mirroring TS/JS #4680
+// and Python #4716): only a bare construction is trusted; factory/builder
+// calls, casts, chains, ternaries and literals stay unresolved so a `var`
+// receiver never types to a non-constructed class. The rightmost
+// type_identifier is taken (so `new com.x.XController(...)` → "XController",
+// matching javaCallTarget's object-creation handling).
+func newExprClassName(value *sitter.Node, src []byte) string {
+	if value == nil || value.Type() != "object_creation_expression" {
+		return ""
+	}
+	typ := value.ChildByFieldName("type")
+	if typ == nil {
+		return ""
+	}
+	if ids := findAllNodes(typ, "type_identifier"); len(ids) > 0 {
+		n := ids[len(ids)-1]
+		return string(src[n.StartByte():n.EndByte()])
+	}
+	return strings.TrimSpace(string(src[typ.StartByte():typ.EndByte()]))
 }
 
 // leafTypeName returns the leaf type identifier of a Java type node,


### PR DESCRIPTION
## Java slice of #4615 (all-framework test→endpoint coverage linkage)

Generalises the TS/JS (#4680) and Python (#4716) local-variable receiver-typing wins to **Java**, closing the local-variable-receiver child #4682.

### What was already covered (prior Java work — verified green)
- **Explicit-declared-type local**: `XController c = new XController(svc); c.getCounts()` → `collectLocalVarTypes` types `c` from the declared type → CALLS `XController.getCounts` (#120/#2062).
- **Mockito `@InjectMocks` / `@Autowired` field**: `@InjectMocks XController controller; controller.getCounts()` → typed via `collectFieldTypes`/`cc.fields` → CALLS resolves.
- **Spring route-hit linkage**: `mockMvc.perform(get("/path"))`, `WebTestClient`, `TestRestTemplate`, REST-assured → `e2e_route_calls` → `engine.linkE2ERouteTestsToEndpoints` TESTS edge to `http_endpoint_definition` (#4370).

### The genuine RED this closes
The modern `var` idiom: `var c = new XController(svc); c.getCounts()`. `var` carries no declared leaf type, so `collectLocalVarTypes` left the local bare and `c.getCounts()` fell through to an unresolvable `var.getCounts` leaf — the endpoint stayed uncredited by `ComputeCoverage`.

### Fix
`collectLocalVarTypes` now infers a `var` local's type from a **direct** `new ClassName(...)` initialiser (new `newExprClassName` helper), mirroring the #4680/#4716 conservatism. Factory/builder/chain/cast/literal RHS receivers stay unresolved (honest exclusion). No coverage-side change needed — the existing test→CALLS→handler→endpoint crediting picks up the new edge.

### Fixtures (`internal/extractors/java/issue4682_localvar_receiver_test.go`)
- **A** declared-type local from constructor → CALLS `XController.getCounts`
- **A'** `var c = new XController(svc)` → CALLS `XController.getCounts` (the new win)
- **B** `@InjectMocks` field → CALLS `XController.getCounts`
- **negative** `var c = MyFactory.create()` → no `XController.getCounts` / `MyFactory.getCounts` edge forged

### Coverage docs
`docs/coverage/registry.json` Java `spring-boot` / `spring-webflux` / `jaxrs` `Testing.tests_linkage` notes updated (var-receiver win + route-hit attribution now in scope); `coverage fmt --check` ✅ canonical.

### Gates
`go build ./...` ✅ · `go vet ./internal/custom/... ./internal/extractors/... ./internal/graph/...` ✅ · `go test ./internal/custom/... ./internal/extractors/... ./internal/graph/... ./internal/engine/... ./internal/types/` ✅ · `coverage fmt --check` ✅

Closes #4682
Part of #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)