### PR TITLE
feat(go): local-var receiver typing for user-defined constructors — test→CALLS coverage linkage (#4683)

### DIFF
--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -535,7 +535,7 @@ func mergeVarTypes(outer, inner map[string]string) map[string]string {
 // Pointer types are stripped (`*Mux` → `Mux`) and generic type parameter
 // lists (`[T]`) are dropped so the synth lookup table can use a single
 // key per package type.
-func collectBodyVarTypes(body *sitter.Node, src []byte) map[string]string {
+func collectBodyVarTypes(body *sitter.Node, src []byte, ctorReturns map[string]string) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -580,7 +580,7 @@ func collectBodyVarTypes(body *sitter.Node, src []byte) map[string]string {
 		}
 		name := nodeText(firstChildOfType(left, "identifier"), src)
 		expr := firstNamedChild(right)
-		if typ := typeOfExpression(expr, src); typ != "" {
+		if typ := typeOfExpression(expr, src, ctorReturns); typ != "" {
 			record(name, typ)
 		}
 	}
@@ -613,7 +613,7 @@ func collectBodyVarTypes(body *sitter.Node, src []byte) map[string]string {
 			if typeNode != nil {
 				typ = nodeText(typeNode, src)
 			} else if valueNode != nil {
-				typ = typeOfExpression(valueNode, src)
+				typ = typeOfExpression(valueNode, src, ctorReturns)
 			}
 			if typ != "" {
 				record(names[0], typ)
@@ -629,7 +629,7 @@ func collectBodyVarTypes(body *sitter.Node, src []byte) map[string]string {
 // typeOfExpression returns a textual type representation for an expression
 // AST node when it's recognisable as a static type, or "" otherwise. Used
 // by collectBodyVarTypes to type short/var declarations.
-func typeOfExpression(expr *sitter.Node, src []byte) string {
+func typeOfExpression(expr *sitter.Node, src []byte, ctorReturns map[string]string) string {
 	if expr == nil {
 		return ""
 	}
@@ -643,7 +643,7 @@ func typeOfExpression(expr *sitter.Node, src []byte) string {
 	case "unary_expression":
 		// `&Foo{}` or `&pkg.Foo{}` — drill into the operand.
 		if op := expr.ChildByFieldName("operand"); op != nil {
-			return typeOfExpression(op, src)
+			return typeOfExpression(op, src, ctorReturns)
 		}
 	case "type_assertion_expression":
 		if t := expr.ChildByFieldName("type"); t != nil {
@@ -675,8 +675,19 @@ func typeOfExpression(expr *sitter.Node, src []byte) string {
 					}
 				}
 			case "identifier":
-				if t, ok := goSamePackageConstructorReturnTypes[nodeText(fn, src)]; ok {
+				fnName := nodeText(fn, src)
+				if t, ok := goSamePackageConstructorReturnTypes[fnName]; ok {
 					return t
+				}
+				// Issue #4683 / #4615: file-local user-defined constructors.
+				// `svc := NewProposalService(); svc.GetCounts()` — type `svc`
+				// from NewProposalService's same-package named return type so
+				// the downstream method call gets a receiver_type stamp and
+				// the test→CALLS→handler coverage edge is credited.
+				if ctorReturns != nil {
+					if t, ok := ctorReturns[fnName]; ok {
+						return t
+					}
 				}
 			}
 		}
@@ -876,6 +887,139 @@ func unwrapGenericType(node *sitter.Node, src []byte) string {
 	return ""
 }
 
+// collectFileConstructorReturns scans top-level function_declaration nodes and
+// returns a (funcName -> canonical return type) map for functions that look
+// like constructors: a single result whose type is a same-package named type
+// (a bare type_identifier, optionally behind a leading `*`). This generalises
+// the hardcoded goSamePackageConstructorReturnTypes allowlist (#364) to ANY
+// user-defined `func NewFoo(...) *Foo` / `func MakeBar(...) Bar` declared in
+// the file, so `x := NewFoo(); x.Method()` types `x` as `Foo` and the
+// downstream method call acquires a receiver_type stamp (issue #4683 / #4615:
+// test→CALLS→handler coverage crediting for Go).
+//
+// Conservatism (mirrors prior-slice rules):
+//   - Only a SINGLE, unnamed result is accepted. Functions returning
+//     `(T, error)`, multiple values, or named results are skipped — pairing
+//     a `:=` LHS with the right tuple slot is out of scope (same limitation
+//     as the multi-LHS short_var_declaration skip).
+//   - The result type must be a bare same-package named type (type_identifier
+//     or pointer_type→type_identifier). Qualified types (`pkg.T`), interface
+//     results, slices, maps, generics, funcs and channels are skipped: a
+//     constructor returning an interface is ambiguous (the negative case —
+//     factory-returning-interface receiver stays bare).
+//   - The canonical return type is stored as a BARE type name (pointer
+//     stripped) so the resolver's same-package member lookup binds it directly
+//     — identical to the goSamePackageConstructorReturnTypes contract.
+func collectFileConstructorReturns(nodes []*sitter.Node, src []byte) map[string]string {
+	// Only constructors whose declared return type is a same-file STRUCT are
+	// accepted. A constructor declared to return an interface
+	// (`func NewCounter() Counter`) is intentionally excluded — the concrete
+	// type behind the interface is a runtime decision, so `c := NewCounter();
+	// c.Method()` must stay bare (the negative case from #4683). Interface and
+	// non-struct named types are therefore filtered out here.
+	structTypes := collectFileStructTypeNames(nodes, src)
+	if len(structTypes) == 0 {
+		return nil
+	}
+	out := map[string]string{}
+	for _, n := range nodes {
+		if n.Type() != "function_declaration" {
+			continue
+		}
+		nameNode := n.ChildByFieldName("name")
+		resultNode := n.ChildByFieldName("result")
+		if nameNode == nil || resultNode == nil {
+			continue
+		}
+		name := nodeText(nameNode, src)
+		if name == "" {
+			continue
+		}
+		// Accept only a single, unnamed, same-package named result that is a
+		// STRUCT declared in this file (interface returns stay bare).
+		ret := samePackageNamedResultType(resultNode, src)
+		if ret == "" || !structTypes[ret] {
+			continue
+		}
+		if existing, ok := out[name]; ok && existing != ret {
+			// Two same-named constructors with different return types in one
+			// file (extremely rare) — drop rather than guess.
+			delete(out, name)
+			continue
+		}
+		out[name] = ret
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// collectFileStructTypeNames returns the set of type names whose declaration
+// body is a struct_type in the file's node slice. Used by
+// collectFileConstructorReturns to restrict constructor-return typing to
+// concrete structs — interface / alias / func / primitive named types are
+// excluded so an interface-returning factory stays bare (#4683 negative).
+//
+// The input slice is the file's function/method declaration list; type
+// declarations are elsewhere in the tree, so we recover the file root from the
+// first node's parentage and scan every type_spec once. A type_spec whose
+// `type` field is a `struct_type` is recorded; interfaces, aliases, funcs and
+// primitives are skipped.
+func collectFileStructTypeNames(nodes []*sitter.Node, src []byte) map[string]bool {
+	out := map[string]bool{}
+	if len(nodes) == 0 {
+		return out
+	}
+	// Recover the file root from any node (walk up to the top).
+	root := nodes[0]
+	for root.Parent() != nil {
+		root = root.Parent()
+	}
+	for _, spec := range findAll(root, "type_spec") {
+		nameNode := spec.ChildByFieldName("name")
+		typeNode := spec.ChildByFieldName("type")
+		if nameNode == nil || typeNode == nil {
+			continue
+		}
+		if typeNode.Type() != "struct_type" {
+			continue
+		}
+		if name := nodeText(nameNode, src); name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// samePackageNamedResultType returns the canonical bare type name of a
+// function `result` node when (and only when) it is a single, unnamed result
+// that is a same-package named type: a `type_identifier` or a `pointer_type`
+// wrapping one. Anything else (multiple results, named results, qualified
+// types, interfaces, slices, maps, generics, funcs, channels) returns "".
+//
+// The Go tree-sitter `result` field is either the bare type node itself (for
+// a single unnamed result like `*Foo`) or a `parameter_list` (for `(T, error)`
+// or named results). We only accept the bare-node form, which guarantees a
+// single unnamed result.
+func samePackageNamedResultType(result *sitter.Node, src []byte) string {
+	if result == nil {
+		return ""
+	}
+	switch result.Type() {
+	case "type_identifier":
+		return nodeText(result, src)
+	case "pointer_type":
+		for i := 0; i < int(result.ChildCount()); i++ {
+			c := result.Child(i)
+			if c.Type() == "type_identifier" {
+				return nodeText(c, src)
+			}
+		}
+	}
+	return ""
+}
+
 // collectIntraFileFuncNames returns the set of bare names of all top-level
 // functions (function_declaration, NOT method_declaration) in the node slice.
 // Only nodes of type "function_declaration" are included; method_declaration
@@ -928,6 +1072,12 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string, structFiel
 	// cross-file resolution depends on byPackageOperation being unambiguous
 	// for the target name in the package directory).
 	intraFileFuncs := collectIntraFileFuncNames(nodes, src)
+
+	// Issue #4683 / #4615 — file-local constructor return-type table. Lets
+	// `x := NewFoo(); x.Method()` type `x` as Foo (Foo declared in this file)
+	// so the method call acquires a receiver_type stamp → test→CALLS→handler
+	// coverage crediting. Built once per file; nil when no constructor exists.
+	ctorReturns := collectFileConstructorReturns(nodes, src)
 
 	// Issue #3628 area #11 — non-OTel observability (ddtrace/Sentry/Prometheus).
 	// Build the file-level Prometheus metric registry once so `reqs.Inc()` body
@@ -1047,7 +1197,7 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string, structFiel
 		paramTypes := collectParamTypes(paramsNode, src)
 		// Body-derived var types do NOT include closure-param shadowing — the
 		// per-call walker below maintains its own scope stack to disambiguate.
-		paramTypes = mergeVarTypes(paramTypes, collectBodyVarTypes(bodyOrNode, src))
+		paramTypes = mergeVarTypes(paramTypes, collectBodyVarTypes(bodyOrNode, src, ctorReturns))
 		relationships := extractCallRelationships(bodyOrNode, src, nameText, recvVarName, receiverType, paramTypes, filePath, structFields, intraFileFuncs, inTreeQualifiers)
 		// Rewrite FromID on each CALLS edge to the qualified Name so the
 		// edge source matches the entity ID downstream.

--- a/internal/extractors/golang/issue4683_localvar_receiver_test.go
+++ b/internal/extractors/golang/issue4683_localvar_receiver_test.go
@@ -1,0 +1,166 @@
+// issue4683_localvar_receiver_test.go — Go local-variable receiver typing for
+// test→CALLS coverage crediting (issue #4683, part of epic #4615/#4672).
+//
+// Generalises the TS/JS (#4680), Python (#4716) and Java (#4717) local-receiver
+// wins to Go. A Go unit test binds a local from a constructor and then calls a
+// method on it; the call must resolve to the type's method so ComputeCoverage
+// credits the endpoint through test→CALLS→handler.
+//
+// Go already typed several receiver-local shapes (collectBodyVarTypes /
+// collectParamTypes, #364/#1840): composite literals (`x := &Foo{}`), declared
+// `var x T`, method receivers/params, and a hardcoded constructor allowlist
+// (`r := chi.NewRouter()`). The genuine RED this child closes is the
+// USER-DEFINED same-package constructor: `svc := NewProposalService();
+// svc.GetCounts()`. `NewProposalService` is not in the allowlist, so the local
+// was left untyped and the method call carried no receiver_type stamp.
+//
+// collectFileConstructorReturns now scans the file's `func NewX(...) *X` /
+// `func NewX(...) X` declarations and types the local from the constructor's
+// same-file STRUCT return type. Conservatism mirrors the prior slices:
+//   - single, unnamed result only (`(T, error)` / multi-return → skipped);
+//   - the return type must be a same-file struct (interface-returning factories
+//     stay bare — the runtime concrete type is ambiguous);
+//   - qualified/slice/map/generic/func return types → skipped.
+//
+// Route-hit test-client linkage (httptest NewRequest/ServeHTTP/NewServer,
+// fixture B in the epic) is already covered by the e2e_route_calls path — see
+// internal/custom/golang/httptest_e2e.go and
+// internal/engine/http_endpoint_e2e_testmap*. Direct `handler.ServeHTTP(...)`
+// calls credit via the test→handler CALLS edge in coverage.go.
+
+package golang_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// callsEdge returns the CALLS edge to method `to` on entity `from` in records,
+// or nil.
+func callsEdge4683(records []types.EntityRecord, from, to string) *types.RelationshipRecord {
+	e := findEntity(records, from)
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "CALLS" && r.ToID == to {
+			return r
+		}
+	}
+	return nil
+}
+
+// Fixture A — user-defined constructor local resolves the method call.
+// `svc := NewProposalService(); svc.GetCounts()` inside a Test* func must stamp
+// receiver_type=ProposalService on the CALLS→GetCounts edge so coverage credits
+// the handler/endpoint through test→CALLS→handler.
+func TestIssue4683_ConstructorLocalPointerReturn(t *testing.T) {
+	src := `package svc
+
+type ProposalService struct{}
+
+func NewProposalService() *ProposalService { return &ProposalService{} }
+
+func (s *ProposalService) GetCounts() int { return 0 }
+
+func TestGetCounts(t *T) {
+	svc := NewProposalService()
+	svc.GetCounts()
+}
+`
+	records := extractRecords(t, src, "svc_test.go")
+	hit := callsEdge4683(records, "TestGetCounts", "GetCounts")
+	if hit == nil {
+		t.Fatalf("expected CALLS edge to GetCounts on TestGetCounts")
+	}
+	if hit.Properties == nil || hit.Properties["receiver_type"] != "ProposalService" {
+		t.Errorf("expected receiver_type=ProposalService, got %+v", hit.Properties)
+	}
+}
+
+// Value-return constructor (`func NewX() X`) is also typed.
+func TestIssue4683_ConstructorLocalValueReturn(t *testing.T) {
+	src := `package svc
+
+type Handler struct{}
+
+func NewHandler() Handler { return Handler{} }
+
+func (h *Handler) Serve() {}
+
+func TestServe(t *T) {
+	h := NewHandler()
+	h.Serve()
+}
+`
+	records := extractRecords(t, src, "h_test.go")
+	hit := callsEdge4683(records, "TestServe", "Serve")
+	if hit == nil {
+		t.Fatalf("expected CALLS edge to Serve on TestServe")
+	}
+	if hit.Properties == nil || hit.Properties["receiver_type"] != "Handler" {
+		t.Errorf("expected receiver_type=Handler, got %+v", hit.Properties)
+	}
+}
+
+// Negative — a factory declared to return an INTERFACE must leave the local
+// bare. The concrete type behind `Counter` is a runtime choice, so
+// `c := NewCounter(); c.GetCounts()` must NOT carry a receiver_type stamp.
+func TestIssue4683_InterfaceFactoryStaysBare(t *testing.T) {
+	src := `package svc
+
+type Counter interface { GetCounts() int }
+
+type impl struct{}
+
+func (i *impl) GetCounts() int { return 0 }
+
+func NewCounter() Counter { return &impl{} }
+
+func TestCounter(t *T) {
+	c := NewCounter()
+	c.GetCounts()
+}
+`
+	records := extractRecords(t, src, "c_test.go")
+	hit := callsEdge4683(records, "TestCounter", "GetCounts")
+	if hit == nil {
+		t.Fatalf("expected CALLS edge to GetCounts on TestCounter")
+	}
+	if hit.Properties != nil && hit.Properties["receiver_type"] != "" {
+		t.Errorf("interface-factory local must stay bare; got receiver_type=%q",
+			hit.Properties["receiver_type"])
+	}
+}
+
+// Negative — a multi-return constructor (`func NewX() (*X, error)`) is NOT a
+// single unnamed result, so the local stays bare (tuple-slot pairing is out of
+// scope, matching the multi-LHS short-var-decl skip).
+func TestIssue4683_MultiReturnConstructorStaysBare(t *testing.T) {
+	src := `package svc
+
+type Repo struct{}
+
+func NewRepo() (*Repo, error) { return &Repo{}, nil }
+
+func (r *Repo) Find() {}
+
+func TestFind(t *T) {
+	r, _ := NewRepo()
+	r.Find()
+}
+`
+	records := extractRecords(t, src, "r_test.go")
+	hit := callsEdge4683(records, "TestFind", "Find")
+	if hit == nil {
+		// multi-LHS short-var-decl may not produce a resolvable CALLS at all;
+		// that's an acceptable honest exclusion.
+		return
+	}
+	if hit.Properties != nil && hit.Properties["receiver_type"] != "" {
+		t.Errorf("multi-return constructor local must stay bare; got receiver_type=%q",
+			hit.Properties["receiver_type"])
+	}
+}

--- a/internal/extractors/golang/references.go
+++ b/internal/extractors/golang/references.go
@@ -280,6 +280,12 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 	type edgeKey struct{ from, to string }
 	seen := make(map[edgeKey]bool)
 
+	// #4683 — file-local constructor return-type table, shared by every
+	// per-function var-type table so `x := NewFoo()` types `x` as Foo for the
+	// REFERENCES selector pass too (parity with the CALLS pass).
+	ctorReturns := collectFileConstructorReturns(
+		findAll(root, "function_declaration", "method_declaration"), file.Content)
+
 	// emit appends a REFERENCES edge from the top-of-stack function to
 	// the resolved symbol. When viaReceiverType is non-empty, it's
 	// stamped on the edge's Properties as a diagnostic so #1840's
@@ -360,7 +366,7 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 				funcLeafName:    leaf,
 				receiverType:    recvType,
 				receiverVar:     recvVar,
-				varTypes:        buildFunctionVarTypes(n, file.Content),
+				varTypes:        buildFunctionVarTypes(n, file.Content, ctorReturns),
 			}
 			newStack := fstack
 			if emitted != "" {

--- a/internal/extractors/golang/type_table.go
+++ b/internal/extractors/golang/type_table.go
@@ -84,7 +84,7 @@ type goVarTypes map[string]string
 // adapter that lets the references pass share them.
 //
 // Passing nil for funcOrMethodNode is safe and returns nil.
-func buildFunctionVarTypes(funcOrMethodNode *sitter.Node, src []byte) goVarTypes {
+func buildFunctionVarTypes(funcOrMethodNode *sitter.Node, src []byte, ctorReturns map[string]string) goVarTypes {
 	if funcOrMethodNode == nil {
 		return nil
 	}
@@ -103,7 +103,7 @@ func buildFunctionVarTypes(funcOrMethodNode *sitter.Node, src []byte) goVarTypes
 	paramMap := collectParamTypes(paramsNode, src)
 
 	bodyNode := funcOrMethodNode.ChildByFieldName("body")
-	bodyMap := collectBodyVarTypes(bodyNode, src)
+	bodyMap := collectBodyVarTypes(bodyNode, src, ctorReturns)
 
 	// Merge in scope order: receiver → params → body. mergeVarTypes
 	// drops names with conflicting types (the conservative choice from


### PR DESCRIPTION
## What

Go slice of the all-framework test→endpoint coverage-linkage epic — generalises the TS/JS (#4680), Python (#4716) and Java (#4717) local-variable receiver-typing wins to Go.

## Genuine RED closed

A same-package **user-defined constructor** local was left untyped:

```go
func NewProposalService() *ProposalService { ... }
func (s *ProposalService) GetCounts() int { ... }

func TestGetCounts(t *testing.T) {
    svc := NewProposalService()
    svc.GetCounts()   // <- no receiver_type stamp → coverage couldn't credit the endpoint
}
```

`NewProposalService` is not in the existing hardcoded constructor allowlist (`chi.NewRouter` etc., #364), so the downstream method CALLS edge carried no `receiver_type` and `ComputeCoverage` couldn't credit the handler/endpoint via test→CALLS→handler.

## Fix

`collectFileConstructorReturns` scans the file's `func NewX(...) *X` / `func NewX(...) X` declarations and types `:=`/`var` locals from the constructor's **same-file struct** return type. Threaded through both:
- the **CALLS** pass (`collectBodyVarTypes` → `typeOfExpression`), and
- the **REFERENCES** pass (`buildFunctionVarTypes`).

`internal/graph/coverage.go` is **unchanged** — it already credits test→CALLS→handler→endpoint once the edge exists.

## Already covered (no change)
- **Route-hit httptest linkage** (`httptest.NewRequest` / `http.NewRequest`+`ServeHTTP` / `httptest.NewServer`+`http.Get`) → `e2e_route_calls` resolved by the shared engine route-map pass (#4371).
- Direct `handler.ServeHTTP(...)` calls credit via the existing test→handler CALLS edge.
- Composite-literal (`x := &Foo{}`), `var x T`, receiver/param typing (#364/#1840).

## Conservatism (mirrors prior slices)
- Single, unnamed result only — `(T, error)` / multi-return stay bare.
- Same-file **struct** returns only — interface-returning factories stay bare (runtime concrete type is ambiguous).
- Qualified / slice / map / generic / func returns skipped.

## Coverage docs
Updated `docs/coverage/registry.json` `Testing.tests_linkage` for **net-http / gin / echo / chi / fiber** (honest **partial** — framework-specific test clients like `gin.CreateTestContext`, `echo.NewContext`, `fiber app.Test` and non-literal routes are not yet linked). `coverage fmt --check` passes.

## Fixtures (`issue4683_localvar_receiver_test.go`)
- pointer-return constructor → `receiver_type=ProposalService` (GREEN)
- value-return constructor → `receiver_type=Handler` (GREEN)
- interface-returning factory → stays bare (negative)
- multi-return constructor → stays bare (negative)

## Gates
`go build ./...`, `go vet`, and `go test` across `internal/extractors/... internal/graph/... internal/engine/... internal/types/ internal/custom/golang/ tools/coverage/` — all green (83 pkgs). `coverage fmt --check` canonical.

Closes #4683
Part of #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)