### PR TITLE
feat(ruby): RSpec test-scope owner + local-variable receiver typing for test→endpoint coverage linkage (#4684)

### DIFF
--- a/internal/extractors/ruby/issue4684_localvar_receiver_test.go
+++ b/internal/extractors/ruby/issue4684_localvar_receiver_test.go
@@ -1,0 +1,158 @@
+package ruby
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tsruby "github.com/smacker/go-tree-sitter/ruby"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4684 (Ruby slice of epic #4615 / #4672): local-variable receiver typing
+// + an RSpec test-scope owner so test→CALLS→handler coverage credits the
+// endpoint. Mirrors the TS/JS (#4680/#4671), Python (#4681) and Go (#4683)
+// slices.
+//
+// RSpec example logic lives in anonymous `it ... do … end` blocks (not named
+// methods), so before this slice the base extractor emitted ZERO CALLS edges for
+// a spec file — the handler the spec exercises stayed uncovered. The new
+// emitRubyTestScopeOwner mines the example/hook blocks, types local-variable
+// receivers from their constructor bindings (`c = ProposalsController.new`,
+// `instance = described_class.new`), and emits one SCOPE.Operation owner per
+// spec file carrying the resolved `Class.method` CALLS edges.
+
+func parseRubyFixture(t *testing.T, path, src string) extractor.FileInput {
+	t.Helper()
+	p := sitter.NewParser()
+	p.SetLanguage(tsruby.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return extractor.FileInput{Path: path, Language: "ruby", Content: []byte(src), Tree: tree}
+}
+
+func extractRuby(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ents, err := (&Extractor{}).Extract(context.Background(), parseRubyFixture(t, path, src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+// testScopeRels returns the CALLS targets owned by the per-file RSpec test-scope
+// owner entity (Subtype="test_scope"), or nil when none was emitted.
+func testScopeCalls(ents []types.EntityRecord) map[string]bool {
+	for _, e := range ents {
+		if e.Subtype == "test_scope" {
+			out := map[string]bool{}
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" {
+					out[r.ToID] = true
+				}
+			}
+			return out
+		}
+	}
+	return nil
+}
+
+// A — explicit constructor local + described_class.new: `c.get_counts` /
+// `instance.get_counts` resolve to ProposalsController.get_counts, owned by the
+// it-block test scope.
+func TestRubyTestScope_LocalReceiverTyping(t *testing.T) {
+	const src = `require 'rails_helper'
+
+RSpec.describe ProposalsController, type: :controller do
+  it 'returns counts via explicit construction' do
+    c = ProposalsController.new
+    c.get_counts('2025')
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns counts via described_class' do
+    instance = described_class.new
+    instance.get_counts('2025')
+  end
+end
+`
+	calls := testScopeCalls(extractRuby(t, "spec/controllers/proposals_controller_spec.rb", src))
+	if calls == nil {
+		t.Fatal("no RSpec test-scope owner emitted (expected CALLS-bearing scope)")
+	}
+	if !calls["ProposalsController.get_counts"] {
+		t.Errorf("missing typed CALLS to ProposalsController.get_counts; got %v", calls)
+	}
+	// The DSL matchers must NOT leak as CALLS edges.
+	for k := range calls {
+		if k == "expect" || k == "have_http_status" || k == "get_counts" {
+			t.Errorf("unexpected bare/matcher CALLS edge leaked: %q", k)
+		}
+	}
+}
+
+// Direct PascalCase-constant call (`ProposalsController.create`) types without a
+// local binding.
+func TestRubyTestScope_ConstantReceiver(t *testing.T) {
+	const src = `RSpec.describe ProposalsController do
+  it 'creates' do
+    ProposalsController.create(params)
+  end
+end
+`
+	calls := testScopeCalls(extractRuby(t, "spec/controllers/proposals_controller_spec.rb", src))
+	if !calls["ProposalsController.create"] {
+		t.Errorf("missing typed CALLS to ProposalsController.create; got %v", calls)
+	}
+}
+
+// Negative — a factory-helper local (`x = make_thing()`) stays untyped, so its
+// method call yields no `Class.method` edge; a shape-only assertion spec emits
+// no test-scope owner at all.
+func TestRubyTestScope_HonestExclusion(t *testing.T) {
+	const factorySrc = `RSpec.describe Thing do
+  it 'uses a factory helper' do
+    x = make_thing
+    x.do_work
+  end
+end
+`
+	calls := testScopeCalls(extractRuby(t, "spec/models/thing_spec.rb", factorySrc))
+	for k := range calls {
+		if k == "Thing.do_work" || k == "make_thing.do_work" {
+			t.Errorf("factory-helper receiver must stay untyped, got edge %q", k)
+		}
+	}
+
+	const shapeOnlySrc = `RSpec.describe 'JSON shape' do
+  it 'has the right keys' do
+    expect(payload).to include(:id, :name)
+    expect(payload[:id]).to be_a(Integer)
+  end
+end
+`
+	ents := extractRuby(t, "spec/requests/shape_spec.rb", shapeOnlySrc)
+	if scope := testScopeCalls(ents); scope != nil {
+		t.Errorf("shape-only spec must emit no test-scope owner, got CALLS %v", scope)
+	}
+}
+
+// Non-spec Ruby files must never get a test-scope owner.
+func TestRubyTestScope_NonSpecFileSkipped(t *testing.T) {
+	const src = `class ProposalsController
+  def get_counts(year)
+    Proposal.where(year: year).count
+  end
+end
+`
+	ents := extractRuby(t, "app/controllers/proposals_controller.rb", src)
+	for _, e := range ents {
+		if e.Subtype == "test_scope" {
+			t.Errorf("non-spec file emitted a test-scope owner: %q", e.Name)
+		}
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -66,6 +66,15 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// string raise, and bare re-raise are dropped (precision-first). Mirrors the
 	// flagship convergence-node shape (internal/extractor/exception_flow.go).
 	emitExceptionFlowEdges(root, file.Content, &entities)
+	// Issue #4684 (epic #4615) — RSpec test-scope owner. RSpec example/hook
+	// blocks (`it`/`describe`/`before` …) are anonymous `do ... end` callbacks,
+	// not method declarations, so walk() never mined their CALLS edges. Emit one
+	// SCOPE.Operation per spec file owning the receiver-typed CALLS edges to the
+	// production handlers the spec exercises, so ComputeCoverage credits them
+	// (test→CALLS→handler→endpoint). Mirrors javascript/tests.go (#4680). No-op
+	// for non-spec files. Route-hit linkage (`get '/api/...'`) stays in the
+	// RSpec custom extractor's e2e_route_calls path (#4371).
+	emitRubyTestScopeOwner(root, file, &entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")
@@ -138,6 +147,22 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				child := &(*out)[k]
 				if child.Kind != "SCOPE.Operation" {
 					continue
+				}
+				// Issue #4684 (epic #4615) — class-qualify each method with a
+				// QualifiedName ("<Class>.<method>") WITHOUT touching its bare
+				// Name (existing CONTAINS structural-refs and Rails route
+				// resolution rely on the bare Name). The resolver indexes
+				// QualifiedName globally (byQualifiedName, #100), so a
+				// receiver-typed CALLS target like `ProposalsController.
+				// get_counts` — emitted by the RSpec test-scope owner once a
+				// local is typed from `ProposalsController.new` — resolves
+				// cross-file to this method. Mirrors the dotted Name Python
+				// (#4681) / Java (#4682) carry; Ruby keeps the bare Name and
+				// adds the qualifier as metadata only. First (innermost) class
+				// wins: a nested class stamps its own methods before this outer
+				// loop runs, so we never overwrite an already-qualified child.
+				if child.QualifiedName == "" {
+					child.QualifiedName = rec.Name + "." + child.Name
 				}
 				// Issue #140 — bare-name CONTAINS targets are 100%
 				// ambiguous in Rails apps where dozens of controllers

--- a/internal/extractors/ruby/tests.go
+++ b/internal/extractors/ruby/tests.go
@@ -1,0 +1,392 @@
+package ruby
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitRubyTestScopeOwner emits a single SCOPE.Operation entity per RSpec spec
+// file that owns every CALLS edge reachable from the spec's example / hook
+// blocks (`it`/`specify`/`example`/`describe`/`context`/`before`/`after` etc.).
+//
+// Issue #4684 (the Ruby slice of epic #4615 / #4672). RSpec spec logic lives in
+// anonymous `do ... end` callback blocks passed to `it`/`describe` — those
+// blocks are NOT method declarations, so walk() (which only mines `method` /
+// `singleton_method` bodies for CALLS) produced no owner for the
+// `c.get_counts(...)` / `instance.action` calls inside them. The whole spec
+// file therefore emitted zero CALLS edges, and ComputeCoverage saw every
+// controller/handler reached only by a spec as untested — the exact symptom the
+// TS/JS slice (#4680, javascript/tests.go::emitTestScopeOwner) fixed for
+// anonymous `it()` arrow callbacks. Minitest's `def test_x` ARE named methods,
+// already mined by walk(); only the RSpec anonymous-block case is RED, so this
+// pass is gated to RSpec block-bearing spec files.
+//
+// Local-variable receiver typing (issue #4684 gap 1) is folded in here:
+// withRubyLocalReceiverTypes scans each block body once for constructor
+// bindings (`c = ProposalsController.new`, `instance = described_class.new`) so
+// a subsequent `c.get_counts(...)` resolves to the dotted `ProposalsController.
+// get_counts` target the resolver binds cross-file to the controller method —
+// instead of an unresolvable bare `get_counts`. Mirrors the Python (#4681) and
+// TS/JS (#4671) local-receiver typing.
+//
+// Scope discipline (mirrors #4680): only the example/hook block callbacks are
+// mined. Calls inside named methods already have owners from walk(), so this
+// pass never descends into a `method` / `singleton_method` declaration (no
+// double-emit). Route-hit linkage (`get '/api/...'`) is handled separately by
+// the RSpec custom extractor's e2e_route_calls path (#4371) and is unchanged.
+//
+// No-op for non-spec files and for spec files whose blocks resolve no CALLS.
+func emitRubyTestScopeOwner(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+	if root == nil || !isRubySpecFile(file.Path) {
+		return
+	}
+	// The class constant of the nearest enclosing `RSpec.describe X` —
+	// `described_class.new` / an implicit `subject` types from it.
+	bodies := collectRSpecBlockBodies(root, file.Content)
+	if len(bodies) == 0 {
+		return
+	}
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, b := range bodies {
+		for _, rel := range extractTestScopeCallRelationships(b.body, file.Content, b.describedClass) {
+			if rel.ToID == "" || seen[rel.ToID] {
+				continue
+			}
+			seen[rel.ToID] = true
+			rels = append(rels, rel)
+		}
+	}
+	if len(rels) == 0 {
+		return
+	}
+	name := rubyTestScopeName(file.Path)
+	rec := types.EntityRecord{
+		Name:          name,
+		Kind:          "SCOPE.Operation",
+		Subtype:       "test_scope",
+		SourceFile:    file.Path,
+		Language:      "ruby",
+		StartLine:     1,
+		EndLine:       1,
+		Relationships: rels,
+	}
+	rec.Properties = map[string]string{
+		"framework":   "rspec",
+		"provenance":  "INFERRED_FROM_RSPEC_TEST_SCOPE",
+		"test_scope":  "true",
+		"description": "test scope " + name,
+	}
+	*out = append(*out, rec)
+}
+
+// rspecBlock is an RSpec example/hook block body paired with the class constant
+// of the nearest enclosing `describe`/`context` (for `described_class` typing).
+type rspecBlock struct {
+	body           *sitter.Node
+	describedClass string
+}
+
+// rspecBlockMethods is the set of RSpec DSL block methods whose `do ... end`
+// callback hosts spec logic that may call into production code. Mirrors
+// javascript/tests.go::testBlockCallNames.
+var rspecBlockMethods = map[string]bool{
+	"it": true, "specify": true, "example": true, "scenario": true,
+	"describe": true, "context": true, "feature": true,
+	"before": true, "after": true, "around": true,
+}
+
+// collectRSpecBlockBodies returns the `do_block` body of every RSpec DSL block
+// (it/specify/describe/context/before/after/...) in the file, each paired with
+// the class constant of the nearest enclosing `describe`/`context` so
+// `described_class` can be typed. Blocks nest (describe → it); we recurse into a
+// matched block's body so inner `it` bodies are mined too, threading the
+// described-class down. We do NOT descend into `method`/`singleton_method`
+// declarations — walk() already owns their CALLS edges.
+func collectRSpecBlockBodies(root *sitter.Node, src []byte) []rspecBlock {
+	var out []rspecBlock
+	walkRSpecBlocks(root, src, "", &out)
+	return out
+}
+
+func walkRSpecBlocks(n *sitter.Node, src []byte, describedClass string, out *[]rspecBlock) {
+	if n == nil {
+		return
+	}
+	switch n.Type() {
+	case "method", "singleton_method":
+		// Named methods already have owners from walk(); never double-mine.
+		return
+	case "call":
+		if mname := rspecBlockMethodName(n, src); mname != "" {
+			body := rubyDoBlockBody(n)
+			if body != nil {
+				dc := describedClass
+				// `describe`/`context` with a constant first argument sets the
+				// described class for any `described_class` inside.
+				if mname == "describe" || mname == "context" || mname == "feature" {
+					if c := rspecConstantArg(n, src); c != "" {
+						dc = c
+					}
+				}
+				*out = append(*out, rspecBlock{body: body, describedClass: dc})
+				// Recurse into the block body to find nested it()/before() blocks,
+				// carrying the (possibly updated) described class.
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walkRSpecBlocks(body.Child(i), src, dc, out)
+				}
+				return
+			}
+		}
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		walkRSpecBlocks(n.Child(i), src, describedClass, out)
+	}
+}
+
+// rspecBlockMethodName returns the RSpec DSL block method name (it/describe/...)
+// of a `call` node when it is one of rspecBlockMethods, or "" otherwise. Handles
+// both the bare form (`it 'x' do`) and the `RSpec.describe X do` receiver form.
+func rspecBlockMethodName(call *sitter.Node, src []byte) string {
+	m := call.ChildByFieldName("method")
+	if m == nil {
+		// Bare `it 'x' do` parses with the method as the first identifier child.
+		for i := 0; i < int(call.ChildCount()); i++ {
+			ch := call.Child(i)
+			if ch.Type() == "identifier" {
+				name := string(src[ch.StartByte():ch.EndByte()])
+				if rspecBlockMethods[name] {
+					return name
+				}
+				return ""
+			}
+		}
+		return ""
+	}
+	name := string(src[m.StartByte():m.EndByte()])
+	if rspecBlockMethods[name] {
+		return name
+	}
+	return ""
+}
+
+// rubyDoBlockBody returns the body_statement of a call's trailing `do ... end`
+// block (or `{ ... }` brace block), or nil when the call has no block.
+func rubyDoBlockBody(call *sitter.Node) *sitter.Node {
+	for i := 0; i < int(call.ChildCount()); i++ {
+		ch := call.Child(i)
+		if ch.Type() == "do_block" || ch.Type() == "block" {
+			if b := ch.ChildByFieldName("body"); b != nil {
+				return b
+			}
+			for j := 0; j < int(ch.ChildCount()); j++ {
+				if ch.Child(j).Type() == "body_statement" {
+					return ch.Child(j)
+				}
+			}
+			return ch
+		}
+	}
+	return nil
+}
+
+// rspecConstantArg returns the first constant argument of a `describe X`/
+// `context X` call (e.g. `RSpec.describe ProposalsController` → "ProposalsController"),
+// or "" when the first argument is a string label / not a constant.
+func rspecConstantArg(call *sitter.Node, src []byte) string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		for i := 0; i < int(call.ChildCount()); i++ {
+			if call.Child(i).Type() == "argument_list" {
+				args = call.Child(i)
+				break
+			}
+		}
+	}
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		switch a.Type() {
+		case "constant", "scope_resolution":
+			return string(src[a.StartByte():a.EndByte()])
+		case "string":
+			return ""
+		}
+	}
+	return ""
+}
+
+// extractTestScopeCallRelationships mines a single RSpec block body for CALLS
+// edges, typing local-variable receivers from constructor bindings (issue
+// #4684). describedClass is the class constant of the nearest enclosing
+// `describe`, used to type `described_class.new` locals.
+//
+// Only receiver-typed method calls (`local.method` where `local` is a typed
+// constructor binding) and explicit-constant calls (`Const.method`) yield a
+// CALLS edge here; bare unresolvable calls (DSL matchers like `expect`,
+// `have_http_status`) are dropped — the test-scope owner exists to credit the
+// production handler the spec exercises, not to enumerate matcher noise.
+func extractTestScopeCallRelationships(body *sitter.Node, src []byte, describedClass string) []types.RelationshipRecord {
+	if body == nil {
+		return nil
+	}
+	locals := rubyLocalReceiverTypes(body, src, describedClass)
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, call := range findAllNodes(body, "call") {
+		target := rubyTypedCallTarget(call, src, locals)
+		if target == "" || seen[target] {
+			continue
+		}
+		seen[target] = true
+		line := strconv.Itoa(int(call.StartPoint().Row) + 1)
+		rels = append(rels, types.RelationshipRecord{
+			ToID:       target,
+			Kind:       "CALLS",
+			Properties: map[string]string{"line": line},
+		})
+	}
+	return rels
+}
+
+// rubyLocalReceiverTypes scans a block body for local-variable constructor
+// bindings and returns a `localName → ClassName` map so a subsequent
+// `localName.method(...)` types to `ClassName.method` (issue #4684, mirrors the
+// Python #4681 / TS/JS #4671 local-receiver typing).
+//
+// Recognised binding shapes (conservative — a guess risks mis-binding):
+//
+//	c        = ProposalsController.new      # explicit constant constructor
+//	instance = described_class.new          # implicit subject construction
+//
+// The RHS must be a `.new` call whose receiver is a PascalCase constant (or the
+// `described_class` keyword, typed from the enclosing describe). A factory
+// helper (`x = make_thing()`), a namespaced/unknown receiver, or a non-`.new`
+// RHS yields no entry — honest exclusion. First binding wins on re-assign.
+func rubyLocalReceiverTypes(body *sitter.Node, src []byte, describedClass string) map[string]string {
+	var locals map[string]string
+	for _, a := range findAllNodes(body, "assignment") {
+		lhs := a.ChildByFieldName("left")
+		if lhs == nil || lhs.Type() != "identifier" {
+			continue
+		}
+		rhs := a.ChildByFieldName("right")
+		if rhs == nil || rhs.Type() != "call" {
+			continue
+		}
+		cls := rubyConstructedClass(rhs, src, describedClass)
+		if cls == "" {
+			continue
+		}
+		name := string(src[lhs.StartByte():lhs.EndByte()])
+		if name == "" {
+			continue
+		}
+		if locals == nil {
+			locals = map[string]string{}
+		}
+		if _, ok := locals[name]; !ok {
+			locals[name] = cls
+		}
+	}
+	return locals
+}
+
+// rubyConstructedClass returns the class name a `.new` constructor call yields,
+// or "" when the RHS is not a recognised user-class construction. Handles
+// `ProposalsController.new` (PascalCase constant receiver) and
+// `described_class.new` (typed from the enclosing describe constant).
+func rubyConstructedClass(call *sitter.Node, src []byte, describedClass string) string {
+	method := call.ChildByFieldName("method")
+	if method == nil || string(src[method.StartByte():method.EndByte()]) != "new" {
+		return ""
+	}
+	recv := call.ChildByFieldName("receiver")
+	if recv == nil {
+		return ""
+	}
+	switch recv.Type() {
+	case "constant", "scope_resolution":
+		name := string(src[recv.StartByte():recv.EndByte()])
+		if isRubyPascalConstant(name) {
+			return name
+		}
+	case "identifier":
+		if string(src[recv.StartByte():recv.EndByte()]) == "described_class" && describedClass != "" {
+			return describedClass
+		}
+	}
+	return ""
+}
+
+// rubyTypedCallTarget resolves a `call` node to a dotted `Class.method` CALLS
+// target using the local-receiver type map, or "" when the receiver is not a
+// typed local / known constant. A receiver that is a PascalCase constant
+// (`ProposalsController.create`) types directly. The `.new` constructor itself
+// and DSL/bare calls without a typed receiver are dropped.
+func rubyTypedCallTarget(call *sitter.Node, src []byte, locals map[string]string) string {
+	method := call.ChildByFieldName("method")
+	if method == nil {
+		return ""
+	}
+	mname := string(src[method.StartByte():method.EndByte()])
+	if mname == "" || mname == "new" {
+		return ""
+	}
+	recv := call.ChildByFieldName("receiver")
+	if recv == nil {
+		return ""
+	}
+	switch recv.Type() {
+	case "identifier":
+		rname := string(src[recv.StartByte():recv.EndByte()])
+		if cls := locals[rname]; cls != "" {
+			return cls + "." + mname
+		}
+	case "constant", "scope_resolution":
+		rname := string(src[recv.StartByte():recv.EndByte()])
+		if isRubyPascalConstant(rname) {
+			return rname + "." + mname
+		}
+	}
+	return ""
+}
+
+// isRubyPascalConstant reports whether name is a Ruby constant beginning with an
+// uppercase letter (a class/module name), tolerating `::`-qualified forms.
+func isRubyPascalConstant(name string) bool {
+	if name == "" {
+		return false
+	}
+	r := rune(name[0])
+	return r >= 'A' && r <= 'Z'
+}
+
+// isRubySpecFile reports whether path is an RSpec spec file (`*_spec.rb`, or any
+// `.rb` under a `/spec/` directory). Matches the coverage classifier's Ruby
+// test-file convention (internal/graph/coverage.go::isTestFile).
+func isRubySpecFile(path string) bool {
+	slashed := "/" + filepath.ToSlash(strings.ToLower(path))
+	if strings.Contains(slashed, "/spec/") {
+		return true
+	}
+	base := strings.ToLower(filepath.Base(path))
+	return strings.HasSuffix(base, "_spec.rb")
+}
+
+// rubyTestScopeName derives a stable per-file name for the test-scope owner from
+// the spec path: the base filename with `.rb` stripped, suffixed with
+// "::testScope" so it never collides with a production symbol.
+func rubyTestScopeName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	base = strings.TrimSuffix(base, ".rb")
+	return base + "::testScope"
+}


### PR DESCRIPTION
Ruby slice of epic **#4615** (all-framework test→endpoint coverage linkage). Generalises the TS/JS (#4680), Python (#4716), Java (#4717) and Go (#4718) wins to Ruby/RSpec.

## Probe findings (pre-state)
- Route-string linkage was **already done** (#4371): RSpec request specs `get '/api/...'` stamp `e2e_route_calls` → endpoint `TESTS` edge. No change needed.
- Genuine **RED**: RSpec example logic lives in anonymous `it … do … end` blocks (not method declarations), so `walk()` — which only mines `method`/`singleton_method` bodies — emitted **zero CALLS edges** for a spec file. A controller reached only by a controller spec stayed uncovered.
- Minitest `def test_x` ARE named methods (already mined); only the RSpec anonymous-block case was RED. So Ruby **needed the test-scope-owner treatment** (like TS/JS, unlike Python/Java/Go).

## Changes
- **`internal/extractors/ruby/tests.go` (new)** — `emitRubyTestScopeOwner` mines the `it`/`specify`/`describe`/`context`/`before`/`after` do-blocks of each `*_spec.rb` and emits ONE `SCOPE.Operation` (subtype `test_scope`) per file owning the receiver-typed CALLS edges. The Ruby mirror of `javascript/tests.go::emitTestScopeOwner` (#4680). Never descends into named methods (no double-emit).
- **Local-variable receiver typing** — `c = ProposalsController.new` and `instance = described_class.new` (resolved from the enclosing `describe` constant) type `c.get_counts(...)` → dotted `ProposalsController.get_counts`. Factory-helper locals (`x = make_thing`) stay untyped (honest exclusion).
- **`ruby.go`** — each class method now carries a class-qualified `QualifiedName` (`<Class>.<method>`) **without** changing its bare `Name` (existing CONTAINS structural-refs + Rails route resolution depend on the bare Name). The resolver indexes `QualifiedName` globally (`byQualifiedName`, #100), so the dotted CALLS target resolves cross-file (`spec/` → `app/`). Mirrors the dotted method Name Python/Java already carry. Verified end-to-end via `BuildIndex.LookupStatusHint` → `statusRewritten`.

`coverage.go` is unchanged — it already credits test→CALLS→handler→endpoint once the resolved edge exists.

## Fixtures (`issue4684_localvar_receiver_test.go`, RED→GREEN)
- A: `c = ProposalsController.new; c.get_counts(...)` + `described_class.new` variant → CALLS `ProposalsController.get_counts` owned by the it-block scope.
- constant receiver: `ProposalsController.create(...)` types directly.
- negatives: factory-helper local stays untyped; shape-only spec → no scope owner; non-spec `.rb` file → no scope owner.

## Coverage docs
Surgically updated `lang.ruby.framework.rails` `Testing.tests_linkage` cell in `docs/coverage/registry.json` (canonical; `coverage fmt --check` passes).

## Gates
`go build ./...`, `go vet`, `go test ./internal/extractors/... ./internal/custom/... ./internal/graph/... ./internal/engine/... ./internal/types/`, `coverage fmt --check` — all green.

Closes #4684
Part of #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)