### PR TITLE
feat(csharp): local-var/DI receiver typing + WebApplicationFactory route-hit linkage for test→endpoint coverage (#4685)

### DIFF
--- a/internal/custom/csharp/integration_e2e.go
+++ b/internal/custom/csharp/integration_e2e.go
@@ -1,0 +1,251 @@
+package csharp
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// integration_e2e.go — link ASP.NET Core integration-test route-by-string calls
+// to the http_endpoint_definition they exercise (issue #4685, the C#/.NET slice
+// of #4615).
+//
+// Background
+// ----------
+// ASP.NET Core integration tests drive the app in-process through HTTP using
+// WebApplicationFactory<Program> + HttpClient:
+//
+//	var client = _factory.CreateClient();
+//	var resp = await client.GetAsync("/api/v1/inspections/123/items");
+//	await client.PostAsJsonAsync("/api/v1/inspections", dto);
+//	await client.PutAsync("/api/v1/inspections/1", content);
+//
+// but no edge ever connected that route string to the http_endpoint_definition
+// it exercises — so those endpoints looked untested. This generalizes the
+// NestJS/supertest fix #4351, the Python/pytest fix #4369, the Java/Spring fix
+// #4370, the Go/httptest fix #4371, and the Ruby/RSpec fix #4684 to ASP.NET
+// Core's WebApplicationFactory + HttpClient.
+//
+// Extractor side: this extractor emits exactly ONE test_suite entity per C#
+// test file that issues at least one HttpClient route-by-string call, and
+// stamps the `VERB route` pairs onto its `e2e_route_calls` property — the same
+// property every other language's e2e extractor stamps. It is decoupled from
+// any unit-test SUT-affinity suite; the shared resolve pass fires on whatever
+// carries `e2e_route_calls`.
+//
+// Resolve side: the shared pass (engine.linkE2ERouteTestsToEndpoints, #4351) is
+// REUSED UNCHANGED. It already gates on Kind||Subtype=="test_suite", wildcards
+// {id}/:id definition segments, and tolerates the /api/vN mount prefix. No
+// matcher fork, no new producer Kind.
+//
+// Conservatism: only literal "/..."-shaped routes are captured; a route built
+// from a variable / interpolated string ($"/x/{id}") / non-literal expression
+// (no static leading-slash path) is dropped, and the shared resolver emits an
+// edge only on a UNIQUE verb+route match. NB: this is distinct from the
+// consumer-side HttpClient synthesis in engine/http_endpoint_csharp_client.go,
+// which models OUTBOUND calls to OTHER services (FETCHES edge to a synthetic
+// consumer endpoint); here the same HttpClient call in a TEST file is treated
+// as an in-process route hit against the app's OWN endpoints (TESTS edge).
+
+func init() {
+	extractor.Register("custom_csharp_integration_e2e", &csharpIntegrationE2EExtractor{})
+}
+
+type csharpIntegrationE2EExtractor struct{}
+
+func (e *csharpIntegrationE2EExtractor) Language() string {
+	return "custom_csharp_integration_e2e"
+}
+
+var (
+	// HttpClient verb methods whose verb is encoded in the METHOD NAME and whose
+	// FIRST argument is the route. Covers the plain async verbs
+	// (GetAsync/PostAsync/PutAsync/DeleteAsync/PatchAsync), the typed-content
+	// JSON helpers (PostAsJsonAsync/PutAsJsonAsync/PatchAsJsonAsync), and the
+	// string/stream read helpers (GetStringAsync/GetByteArrayAsync/GetStreamAsync).
+	// The route is a plain "..." or verbatim @"..." string literal. Group 1 =
+	// method, group 2 = double-quoted route, group 3 = verbatim route.
+	csE2EHttpClientVerbRe = regexp.MustCompile(
+		`\.\s*(GetAsync|PostAsync|PutAsync|DeleteAsync|PatchAsync|HeadAsync|OptionsAsync|` +
+			`PostAsJsonAsync|PutAsJsonAsync|PatchAsJsonAsync|DeleteFromJsonAsync|` +
+			`GetFromJsonAsync|GetStringAsync|GetByteArrayAsync|GetStreamAsync)\s*` +
+			`(?:<[^>(]*>)?\s*\(\s*(?:"(/[^"\r\n]*)"|@"(/[^"\r\n]*)")`)
+
+	// new HttpRequestMessage(HttpMethod.Get, "/route") — verb is the HttpMethod
+	// member, route the second arg. Group 1 = verb member, group 2/3 = route.
+	csE2EHttpRequestMsgRe = regexp.MustCompile(
+		`new\s+HttpRequestMessage\s*\(\s*HttpMethod\s*\.\s*(Get|Post|Put|Delete|Patch|Head|Options)\s*,\s*` +
+			`(?:"(/[^"\r\n]*)"|@"(/[^"\r\n]*)")`)
+
+	// csE2EVerbFromMethod maps an HttpClient method name to its HTTP verb.
+	csE2EVerbFromMethod = map[string]string{
+		"GetAsync": "GET", "GetStringAsync": "GET", "GetByteArrayAsync": "GET",
+		"GetStreamAsync": "GET", "GetFromJsonAsync": "GET",
+		"PostAsync": "POST", "PostAsJsonAsync": "POST",
+		"PutAsync": "PUT", "PutAsJsonAsync": "PUT",
+		"PatchAsync": "PATCH", "PatchAsJsonAsync": "PATCH",
+		"DeleteAsync": "DELETE", "DeleteFromJsonAsync": "DELETE",
+		"HeadAsync": "HEAD", "OptionsAsync": "OPTIONS",
+	}
+
+	// csE2EVerbFromHttpMethod maps an HttpMethod.X member to its HTTP verb.
+	csE2EVerbFromHttpMethod = map[string]string{
+		"Get": "GET", "Post": "POST", "Put": "PUT", "Delete": "DELETE",
+		"Patch": "PATCH", "Head": "HEAD", "Options": "OPTIONS",
+	}
+
+	// Test-file signals — at least one must be present for the extractor to
+	// fire. xUnit ([Fact]/[Theory]), NUnit ([Test]/[TestFixture]), MSTest
+	// ([TestMethod]/[TestClass]), or the WebApplicationFactory / HttpClient
+	// integration-test harness itself.
+	csE2ETestSignals = []string{
+		"[Fact]", "[Theory]", "[Test]", "[TestFixture]", "[TestMethod]",
+		"[TestClass]", "WebApplicationFactory", "IClassFixture", "HttpClient",
+		"CreateClient",
+	}
+)
+
+func (e *csharpIntegrationE2EExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.csharp_integration_e2e_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "aspnetcore_integration"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "csharp" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Only fire on test files (by name or by a test-framework signal) that
+	// actually issue an HttpClient route-by-string call — a strict no-op
+	// everywhere else.
+	if !csLooksLikeTestFile(file.Path) && !csHasAnyTestSignal(src) {
+		return nil, nil
+	}
+	if !strings.Contains(src, "Async") && !strings.Contains(src, "HttpRequestMessage") {
+		return nil, nil
+	}
+
+	routeCalls := collectCSharpE2ERouteCalls(src)
+	if len(routeCalls) == 0 {
+		span.SetAttributes(attribute.Int("entity_count", 0))
+		return nil, nil
+	}
+
+	ent := makeEntity("aspnetcore_e2e_suite:"+csTestBaseName(file.Path), "SCOPE.Pattern", "test_suite",
+		file.Path, file.Language, 1)
+	setProps(&ent, "framework", "aspnetcore_integration",
+		"provenance", "INFERRED_FROM_ASPNETCORE_INTEGRATION_ROUTE",
+		"test_framework", "aspnetcore_integration",
+		"e2e_route_calls", strings.Join(routeCalls, "\n"),
+		"e2e_route_count", itoa(len(routeCalls)),
+	)
+
+	span.SetAttributes(attribute.Int("entity_count", 1))
+	return []types.EntityRecord{ent}, nil
+}
+
+// collectCSharpE2ERouteCalls extracts every ASP.NET Core HttpClient
+// route-by-string call in a C# test file and returns de-duplicated
+// `VERB route` lines — the exact shape the shared resolve pass consumes
+// (engine.linkE2ERouteTestsToEndpoints). Two shapes are covered:
+//
+//	client.GetAsync("/x/123/items")          (verb in method name)
+//	client.PostAsJsonAsync("/x", dto)        (verb in method name)
+//	new HttpRequestMessage(HttpMethod.Get, "/x/1")  (verb in HttpMethod member)
+//
+// A call whose route is not a literal leading-slash path (interpolated /
+// concatenated / variable route) is dropped — conservative; the resolver
+// wildcards {id}/:id definition segments so concrete ids are fine verbatim.
+func collectCSharpE2ERouteCalls(src string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, route string) {
+		verb = strings.ToUpper(strings.TrimSpace(verb))
+		route = strings.TrimSpace(route)
+		if verb == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		// Drop a query string / fragment; the resolver matches on path only.
+		if q := strings.IndexAny(route, "?#"); q >= 0 {
+			route = route[:q]
+		}
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		line := verb + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+
+	for _, m := range csE2EHttpClientVerbRe.FindAllStringSubmatch(src, -1) {
+		verb := csE2EVerbFromMethod[m[1]]
+		route := m[2]
+		if route == "" {
+			route = m[3] // verbatim @"..."
+		}
+		add(verb, route)
+	}
+	for _, m := range csE2EHttpRequestMsgRe.FindAllStringSubmatch(src, -1) {
+		verb := csE2EVerbFromHttpMethod[m[1]]
+		route := m[2]
+		if route == "" {
+			route = m[3]
+		}
+		add(verb, route)
+	}
+	return out
+}
+
+// csHasAnyTestSignal reports whether the source carries any xUnit/NUnit/MSTest
+// or WebApplicationFactory/HttpClient integration-test marker.
+func csHasAnyTestSignal(src string) bool {
+	for _, sig := range csE2ETestSignals {
+		if strings.Contains(src, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// csLooksLikeTestFile reports whether a path matches the conventional .NET test
+// file naming (Tests.cs / Test.cs / Spec.cs, or under a tests/ directory).
+func csLooksLikeTestFile(path string) bool {
+	lower := strings.ToLower(path)
+	base := lower
+	if i := strings.LastIndexAny(lower, "/\\"); i >= 0 {
+		base = lower[i+1:]
+	}
+	if strings.HasSuffix(base, "tests.cs") || strings.HasSuffix(base, "test.cs") ||
+		strings.HasSuffix(base, "spec.cs") || strings.HasSuffix(base, ".tests.cs") {
+		return true
+	}
+	return strings.Contains(lower, "/tests/") || strings.Contains(lower, "/test/") ||
+		strings.Contains(lower, "\\tests\\") || strings.Contains(lower, "\\test\\")
+}
+
+// csTestBaseName returns the test file's base name without directory or the
+// `.cs` extension — used to namespace the suite entity so it never collides
+// with a production symbol in the resolver's by-name index.
+func csTestBaseName(path string) string {
+	p := path
+	if i := strings.LastIndexAny(p, "/\\"); i >= 0 {
+		p = p[i+1:]
+	}
+	return strings.TrimSuffix(p, ".cs")
+}

--- a/internal/custom/csharp/integration_e2e_test.go
+++ b/internal/custom/csharp/integration_e2e_test.go
@@ -1,0 +1,173 @@
+package csharp_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// e2eSuite runs the C# integration-e2e extractor and returns the single
+// test_suite entity (or nil).
+func e2eSuite(t *testing.T, path, src string) *types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_csharp_integration_e2e")
+	if !ok {
+		t.Fatal("custom_csharp_integration_e2e not registered")
+	}
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: "csharp", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for i := range ents {
+		if ents[i].Subtype == "test_suite" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func routeLines(s *types.EntityRecord) []string {
+	if s == nil || s.Properties == nil {
+		return nil
+	}
+	raw := s.Properties["e2e_route_calls"]
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\n")
+}
+
+func hasRouteLine(s *types.EntityRecord, want string) bool {
+	for _, l := range routeLines(s) {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Validation B: WebApplicationFactory + HttpClient.GetAsync route hit → suite
+// with the VERB route pair stamped (TESTS edge linked downstream by the shared
+// resolve pass).
+func TestCSharpE2E_WebAppFactoryGetAsync(t *testing.T) {
+	src := `
+public class XControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    public XControllerTests(WebApplicationFactory<Program> f) { _factory = f; }
+
+    [Fact]
+    public async Task GetCounts_Returns200()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/api/v1/x/get_counts");
+        resp.EnsureSuccessStatusCode();
+    }
+}
+`
+	s := e2eSuite(t, "tests/XControllerTests.cs", src)
+	if s == nil {
+		t.Fatal("expected a test_suite entity")
+	}
+	if !hasRouteLine(s, "GET /api/v1/x/get_counts") {
+		t.Errorf("expected 'GET /api/v1/x/get_counts'; got %v", routeLines(s))
+	}
+	if s.Properties["framework"] != "aspnetcore_integration" {
+		t.Errorf("framework=%q", s.Properties["framework"])
+	}
+}
+
+// PostAsJsonAsync (typed-content JSON helper) → POST verb.
+func TestCSharpE2E_PostAsJsonAsync(t *testing.T) {
+	src := `
+public class OrdersTests
+{
+    [Fact]
+    public async Task Create()
+    {
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/orders", dto);
+    }
+}
+`
+	s := e2eSuite(t, "OrdersTests.cs", src)
+	if !hasRouteLine(s, "POST /api/v1/orders") {
+		t.Errorf("expected 'POST /api/v1/orders'; got %v", routeLines(s))
+	}
+}
+
+// new HttpRequestMessage(HttpMethod.Put, "/x/1") → PUT verb from member.
+func TestCSharpE2E_HttpRequestMessage(t *testing.T) {
+	src := `
+public class XTests
+{
+    [Fact]
+    public async Task Update()
+    {
+        var req = new HttpRequestMessage(HttpMethod.Put, "/api/v1/x/1");
+        await client.SendAsync(req);
+    }
+}
+`
+	s := e2eSuite(t, "XTests.cs", src)
+	if !hasRouteLine(s, "PUT /api/v1/x/1") {
+		t.Errorf("expected 'PUT /api/v1/x/1'; got %v", routeLines(s))
+	}
+}
+
+// Query string is stripped from the captured route.
+func TestCSharpE2E_QueryStringStripped(t *testing.T) {
+	src := `
+public class XTests
+{
+    [Fact]
+    public async Task List()
+    {
+        await client.GetAsync("/api/v1/x?page=2&size=10");
+    }
+}
+`
+	s := e2eSuite(t, "XTests.cs", src)
+	if !hasRouteLine(s, "GET /api/v1/x") {
+		t.Errorf("expected 'GET /api/v1/x' (query stripped); got %v", routeLines(s))
+	}
+}
+
+// Negative: an interpolated / non-literal route is NOT captured (conservative).
+func TestCSharpE2E_InterpolatedRouteDropped(t *testing.T) {
+	src := `
+public class XTests
+{
+    [Fact]
+    public async Task Get()
+    {
+        var id = 5;
+        await client.GetAsync($"/api/v1/x/{id}");
+        await client.GetAsync(routeVar);
+    }
+}
+`
+	s := e2eSuite(t, "XTests.cs", src)
+	if s != nil && len(routeLines(s)) != 0 {
+		t.Errorf("expected no captured routes for non-literal calls; got %v", routeLines(s))
+	}
+}
+
+// Negative: a non-test file with no test signals and no HttpClient call is a
+// strict no-op.
+func TestCSharpE2E_NonTestNoOp(t *testing.T) {
+	src := `
+public class OrderService
+{
+    public void Process() { }
+}
+`
+	if s := e2eSuite(t, "src/OrderService.cs", src); s != nil {
+		t.Errorf("expected no suite for production file; got %+v", s)
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4685_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4685_test.go
@@ -1,0 +1,90 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	// Register the C# integration-e2e extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
+)
+
+// Issue #4685 LIVE-REPRO (resolve side, full in-pipeline) — ASP.NET Core.
+//
+// Proves end-to-end that an ASP.NET Core integration test calling a route by
+// string through WebApplicationFactory + HttpClient links to the
+// http_endpoint_definition it exercises — the C#/.NET slice of the all-language
+// program (#4615), generalizing #4351 / #4369 / #4370 / #4371 / #4684.
+//
+// Pipeline (all REAL passes):
+//  1. applyHTTPEndpointSynthesis over the controller source → http_endpoint_*.
+//  2. The real custom_csharp_integration_e2e extractor over the test file →
+//     the one-per-file test_suite carrying e2e_route_calls.
+//  3. ResolveHTTPEndpointHandlers over the merged set → the shared
+//     linkE2ERouteTestsToEndpoints pass emits the TESTS→endpoint edges.
+
+const csControllerSrc4685 = `using Microsoft.AspNetCore.Mvc;
+
+[ApiController]
+[Route("api/v1/inspections")]
+public class InspectionsController : ControllerBase
+{
+    [HttpGet("{id}")]
+    public IActionResult GetOne(int id) => Ok();
+
+    [HttpPost("{id}/items")]
+    public IActionResult CreateItem(int id) => Created();
+}
+`
+
+const csIntegrationTestSrc4685 = `using System.Net.Http;
+using System.Net.Http.Json;
+using Xunit;
+
+public class InspectionsControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    public InspectionsControllerTests(WebApplicationFactory<Program> f) { _factory = f; }
+
+    [Fact]
+    public async Task GetOne_Returns200()
+    {
+        var client = _factory.CreateClient();
+        var resp = await client.GetAsync("/api/v1/inspections/123");
+        resp.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task CreateItem_Returns201()
+    {
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync("/api/v1/inspections/123/items", new { name = "x" });
+    }
+}
+`
+
+func TestIssue4685_CSharpIntegrationE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := synthEndpoints(t, "csharp", "src/Controllers/InspectionsController.cs", csControllerSrc4685)
+	suite := realSuite(t, "custom_csharp_integration_e2e",
+		"tests/InspectionsControllerTests.cs", "csharp", csIntegrationTestSrc4685)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	targets := edgeTargets(afterOut)
+
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/inspections/{id}") && !strings.Contains(to, "items") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/inspections/{id}/items") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("no TESTS edge to GET /api/v1/inspections/{id} (targets=%v)", targets)
+	}
+	if !wantPost {
+		t.Errorf("no TESTS edge to POST /api/v1/inspections/{id}/items (targets=%v)", targets)
+	}
+	t.Logf("#4685 ASP.NET Core integration endpoint-level TESTS edges: before=0 after=%d", edges)
+}

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -845,8 +845,19 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 		if vd == nil {
 			continue
 		}
-		typ := leafTypeName(vd.ChildByFieldName("type"), src)
-		if typ == "" {
+		// The declared type. For an implicitly-typed `var` declaration the
+		// leaf is "var" (or ""), which carries no usable type; in that case we
+		// infer the type CONSERVATIVELY from the right-hand-side initialiser
+		// per declarator (see inferImplicitLocalType). #4685 (mirrors Java
+		// #4717 `newExprClassName`): only `new ClassName(...)` and
+		// target-typed `new(...)` (paired with an explicit declared type, which
+		// the non-var path already handles) bind; a factory / method-call /
+		// DI-returning-interface RHS (`var s = factory.Create();`) stays
+		// UNTYPED so the call resolves to its bare leaf rather than a fabricated
+		// receiver type.
+		declType := leafTypeName(vd.ChildByFieldName("type"), src)
+		implicit := isImplicitVarType(declType)
+		if declType == "" && !implicit {
 			continue
 		}
 		for i := 0; i < int(vd.ChildCount()); i++ {
@@ -866,6 +877,13 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 			}
 			if name == "" {
 				continue
+			}
+			typ := declType
+			if implicit {
+				typ = inferImplicitLocalType(ch, src)
+				if typ == "" {
+					continue
+				}
 			}
 			out[name] = typ
 		}
@@ -896,6 +914,132 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 		}
 	}
 	return out
+}
+
+// isImplicitVarType reports whether a declared-type leaf is the implicitly
+// typed `var` keyword. tree-sitter-c-sharp models `var x = …` with an
+// `implicit_type` node whose text is "var"; leafTypeName's last-resort branch
+// returns the raw "var" token for it. We treat that as "no static declared
+// type" and fall back to RHS inference (#4685).
+func isImplicitVarType(declType string) bool {
+	return declType == "var"
+}
+
+// inferImplicitLocalType returns the leaf class name a `var` local is bound to
+// when, and ONLY when, its initialiser is an object-creation expression —
+// `var c = new XController(svc)` → "XController". This mirrors the conservatism
+// of Java #4717 `newExprClassName`: a factory/method-call/DI RHS that returns
+// an interface (`var s = factory.Create();`, `var svc = sp.GetRequiredService<…>()`)
+// yields "" so the receiver stays bare and no fabricated dotted target is
+// emitted. Target-typed `new(...)` is handled on the explicit-declared-type
+// path (the declared type is concrete there), so it is intentionally NOT
+// inferred here (an implicit `var x = new();` does not type-check in C#).
+func inferImplicitLocalType(declarator *sitter.Node, src []byte) string {
+	if declarator == nil {
+		return ""
+	}
+	// The declarator's value child is the initialiser expression. tree-sitter
+	// exposes it as the named child following the `=`; scan named children for
+	// the (single) object_creation_expression or a DI service-resolution call.
+	for i := 0; i < int(declarator.NamedChildCount()); i++ {
+		ch := declarator.NamedChild(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "object_creation_expression":
+			typ := ch.ChildByFieldName("type")
+			if typ == nil {
+				// Fall back to the first identifier/generic_name child.
+				for j := 0; j < int(ch.NamedChildCount()); j++ {
+					c := ch.NamedChild(j)
+					if c != nil && (c.Type() == "identifier" || c.Type() == "generic_name" || c.Type() == "qualified_name") {
+						typ = c
+						break
+					}
+				}
+			}
+			if leaf := leafTypeName(typ, src); leaf != "" && leaf != "var" {
+				return leaf
+			}
+		case "invocation_expression":
+			if leaf := diServiceTypeArg(ch, src); leaf != "" {
+				return leaf
+			}
+		}
+	}
+	return ""
+}
+
+// diServiceTypeArgMethods is the set of .NET dependency-injection resolution
+// methods whose single generic type argument IS the resolved service type.
+// `sp.GetRequiredService<XController>()` / `_factory.Services.GetService<T>()`
+// — the WebApplicationFactory + IServiceProvider idiom (#4685 gap 2). We bind
+// the local to the type argument so a follow-up `c.Method()` resolves to that
+// class. This is fully static (the type argument is a compile-time token), so
+// it is sound; non-DI generic calls don't match the method-name allow-list and
+// stay bare.
+var diServiceTypeArgMethods = map[string]bool{
+	"GetRequiredService": true,
+	"GetService":         true,
+	"GetServices":        true,
+	"GetKeyedService":         true,
+	"GetRequiredKeyedService": true,
+}
+
+// diServiceTypeArg returns the leaf type argument of a DI service-resolution
+// invocation (`...GetRequiredService<XController>()`), or "" when the call is
+// not a recognised single-type-argument resolution method. The method name is
+// taken from the invocation's function node: either a bare `generic_name`
+// (`GetRequiredService<T>()`) or a `member_access_expression` whose `name` is a
+// `generic_name` (`sp.GetRequiredService<T>()`).
+func diServiceTypeArg(call *sitter.Node, src []byte) string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return ""
+	}
+	var gen *sitter.Node
+	switch fn.Type() {
+	case "generic_name":
+		gen = fn
+	case "member_access_expression":
+		if name := fn.ChildByFieldName("name"); name != nil && name.Type() == "generic_name" {
+			gen = name
+		}
+	}
+	if gen == nil {
+		return ""
+	}
+	// Method name is the leading identifier of the generic_name.
+	var methodName string
+	for i := 0; i < int(gen.NamedChildCount()); i++ {
+		c := gen.NamedChild(i)
+		if c != nil && c.Type() == "identifier" {
+			methodName = string(src[c.StartByte():c.EndByte()])
+			break
+		}
+	}
+	if !diServiceTypeArgMethods[methodName] {
+		return ""
+	}
+	// Single type argument → its leaf is the service type.
+	tal := findChildByType(gen, "type_argument_list")
+	if tal == nil {
+		return ""
+	}
+	var args []*sitter.Node
+	for i := 0; i < int(tal.NamedChildCount()); i++ {
+		if c := tal.NamedChild(i); c != nil {
+			args = append(args, c)
+		}
+	}
+	if len(args) != 1 {
+		return "" // multiple/zero type args — ambiguous, stay bare
+	}
+	if leaf := leafTypeName(args[0], src); leaf != "" && leaf != "var" {
+		return leaf
+	}
+	return ""
 }
 
 // leafTypeName returns the leaf type identifier of a C# type node,

--- a/internal/extractors/csharp/relationships_test.go
+++ b/internal/extractors/csharp/relationships_test.go
@@ -225,6 +225,100 @@ public class A
 	}
 }
 
+// TestCSharp_CallsImplicitVarNewReceiver (#4685): an implicitly-typed
+// `var c = new XController(svc)` local binds `c` to XController from its
+// object-creation initialiser so `c.GetCounts()` resolves to the class method
+// — the xUnit/NUnit unit-test idiom. Mirrors Java #4717 newExprClassName.
+func TestCSharp_CallsImplicitVarNewReceiver(t *testing.T) {
+	src := `
+public class XController { public void GetCounts() {} }
+public class T
+{
+    public void Fact() {
+        var c = new XController(svc);
+        c.GetCounts();
+    }
+}
+`
+	ents := runCSharp(t, src)
+	if !csHasRel(ents, "T.Fact", "SCOPE.Operation", "CALLS", "XController.GetCounts") {
+		e := csFind(ents, "T.Fact", "SCOPE.Operation")
+		var rels []types.RelationshipRecord
+		if e != nil {
+			rels = e.Relationships
+		}
+		t.Errorf("expected CALLS Fact→XController.GetCounts from `var c = new XController(...)`; got rels=%+v", rels)
+	}
+}
+
+// TestCSharp_CallsTargetTypedNewReceiver (#4685): target-typed `new(...)`
+// paired with an explicit declared type still types the local.
+func TestCSharp_CallsTargetTypedNewReceiver(t *testing.T) {
+	src := `
+public class XController { public void GetCounts() {} }
+public class T
+{
+    public void Fact() {
+        XController c = new(svc);
+        c.GetCounts();
+    }
+}
+`
+	ents := runCSharp(t, src)
+	if !csHasRel(ents, "T.Fact", "SCOPE.Operation", "CALLS", "XController.GetCounts") {
+		t.Errorf("expected CALLS Fact→XController.GetCounts from target-typed `new(...)`")
+	}
+}
+
+// TestCSharp_CallsDIGetRequiredServiceReceiver (#4685): a DI service-resolution
+// `var c = sp.GetRequiredService<XController>()` binds `c` to the generic type
+// argument — the WebApplicationFactory/IServiceProvider idiom.
+func TestCSharp_CallsDIGetRequiredServiceReceiver(t *testing.T) {
+	src := `
+public class XController { public void GetCounts() {} }
+public class T
+{
+    public void Fact() {
+        var c = _factory.Services.GetRequiredService<XController>();
+        c.GetCounts();
+    }
+}
+`
+	ents := runCSharp(t, src)
+	if !csHasRel(ents, "T.Fact", "SCOPE.Operation", "CALLS", "XController.GetCounts") {
+		e := csFind(ents, "T.Fact", "SCOPE.Operation")
+		var rels []types.RelationshipRecord
+		if e != nil {
+			rels = e.Relationships
+		}
+		t.Errorf("expected CALLS Fact→XController.GetCounts from GetRequiredService<T>(); got rels=%+v", rels)
+	}
+}
+
+// TestCSharp_FactoryReturningInterfaceReceiverStaysBare (#4685, NEGATIVE): a
+// `var svc = factory.Create()` whose RHS is a plain method call (factory /
+// DI-returning-interface) must NOT fabricate a receiver type; the call resolves
+// to its bare leaf.
+func TestCSharp_FactoryReturningInterfaceReceiverStaysBare(t *testing.T) {
+	src := `
+public class T
+{
+    public void Fact() {
+        var svc = factory.Create();
+        svc.DoThing();
+    }
+}
+`
+	ents := runCSharp(t, src)
+	if !csHasRel(ents, "T.Fact", "SCOPE.Operation", "CALLS", "DoThing") {
+		t.Errorf("expected bare CALLS Fact→DoThing for factory-returning receiver")
+	}
+	// And must NOT have fabricated a dotted target off the variable name.
+	if csHasRel(ents, "T.Fact", "SCOPE.Operation", "CALLS", "var.DoThing") {
+		t.Errorf("must not emit fabricated CALLS Fact→var.DoThing")
+	}
+}
+
 // TestCSharp_ImportsCarryProperties (#368): IMPORTS edges carry the
 // metadata the cross-file resolver consumes (mirroring Java #120 /
 // Python #93). For `using X.Y;` we expect:


### PR DESCRIPTION
C#/.NET slice of epic #4615 (all-framework test→endpoint coverage linkage). Generalises the TS/JS (#4680), Python (#4716), Java (#4717), Go (#4718) and Ruby (#4719) local-receiver-typing + test-crediting wins to C#.

## Probe findings (pre-state — several idioms already covered)
- Target-typed `XController c = new(svc)` and ctor-injected fields (`private readonly XController _c`) were ALREADY typed → resolve to `XController.GetCounts`. Not RED.
- xUnit `[Fact]`/`[Theory]` + NUnit `[Test]` are NAMED methods, already mined for CALLS → **no synthetic test-scope owner needed** (unlike TS/JS #4680 / Ruby #4684).
- **RED #1**: implicit `var c = new XController(svc)` bound `c` to literal `"var"` → emitted `var.GetCounts`.
- **RED #2**: `var c = sp.GetRequiredService<XController>()` (WebApplicationFactory/IServiceProvider DI) stayed bare → `GetCounts`.
- **RED #3**: no C# test extractor emitted a `test_suite` with `e2e_route_calls`, so WebApplicationFactory+HttpClient route hits never linked to the `http_endpoint_definition`.

## Changes
- **Receiver typing** (`internal/extractors/csharp/csharp.go`): `collectLocalVarTypes` now infers an implicitly-typed `var` local's type from its RHS, conservatively — `inferImplicitLocalType` binds `new ClassName(...)`; `diServiceTypeArg` binds the single generic type arg of a DI resolution call (`GetRequiredService`/`GetService`/`GetServices`/`GetKeyedService<T>()`). A factory/method-call RHS (`var s = factory.Create()`) stays UNTYPED → bare leaf (honest exclusion, mirrors Java #4717 `newExprClassName`).
- **Route-hit linkage** (`internal/custom/csharp/integration_e2e.go`, new): `custom_csharp_integration_e2e` emits one `test_suite` per C# test file carrying `e2e_route_calls` for WebApplicationFactory+HttpClient route-by-string hits (`client.GetAsync`/`PostAsJsonAsync`/`PutAsync`/… and `new HttpRequestMessage(HttpMethod.X, "/path")`). The shared `engine.linkE2ERouteTestsToEndpoints` pass (#4351) — **unchanged** — emits the TESTS edge. Non-literal/interpolated routes dropped. Distinct from the consumer-side FETCHES synthesis in `http_endpoint_csharp_client.go`.
- `coverage.go` unchanged — already credits test→CALLS→handler→endpoint.

## Validation (RED→GREEN)
- `relationships_test.go`: implicit `var c = new X(...)` and `GetRequiredService<X>()` → `CALLS X.GetCounts`; target-typed `new(...)` green; factory receiver stays bare (negative).
- `integration_e2e_test.go`: GetAsync/PostAsJsonAsync/HttpRequestMessage capture, query-string strip, interpolated-route drop, non-test no-op.
- `http_endpoint_e2e_testmap_4685_test.go`: full in-pipeline ASP.NET Core controller + WebApplicationFactory integration test → **before=0, after=2** endpoint TESTS edges.

## Coverage docs
Updated `lang.csharp.framework.aspnet-core` and `aspnet-mvc` `Testing.tests_linkage` cells (surgical, canonical; `coverage fmt --check` passes).

## Gates
`go build ./...`, `go vet`, `go test` (extractors/custom/graph/engine/types) and `coverage fmt --check` all green.

Closes #4685
Part of #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)