### PR TITLE
feat(kotlin): test->endpoint coverage linkage — receiver typing + Kotest scope owner + Spring/Ktor route-hit (#4687)

### DIFF
--- a/internal/custom/kotlin/tests_route_e2e.go
+++ b/internal/custom/kotlin/tests_route_e2e.go
@@ -1,0 +1,182 @@
+// Package kotlin — Kotlin test→endpoint route-hit linkage.
+//
+// #4687 (the Kotlin slice of epic #4615, all-framework test→endpoint coverage
+// linkage). Emits ONE test_suite entity per Kotlin test file that drives an HTTP
+// endpoint by ROUTE STRING, stamping the captured `VERB route` pairs onto the
+// suite's `e2e_route_calls` property. The shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index and emits a TESTS edge
+// to the exact endpoint exercised — exactly as the Java junit5 extractor
+// (internal/custom/java/junit5.go) does for JVM-Java Spring tests. The engine
+// pass is language-agnostic (it fires on any test_suite carrying
+// e2e_route_calls), so the only Kotlin-specific work is the route capture.
+//
+// Two route-driving idioms are captured:
+//   - Spring on Kotlin (MockMvc `mockMvc.perform(get("/path"))`, WebTestClient
+//     `webTestClient.get().uri("/path")`) — identical syntax to Java Spring.
+//   - Ktor test (`testApplication { client.get("/path") }` and the legacy
+//     `handleRequest(HttpMethod.Get, "/path")`) — Ktor-specific.
+//
+// Registration key: "custom_kotlin_tests_route_e2e".
+package kotlin
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_kotlin_tests_route_e2e", &kotlinTestRouteE2EExtractor{})
+}
+
+type kotlinTestRouteE2EExtractor struct{}
+
+func (e *kotlinTestRouteE2EExtractor) Language() string {
+	return "custom_kotlin_tests_route_e2e"
+}
+
+var (
+	// Spring MockMvc: mockMvc.perform(get("/api/v1/x/get_counts"))
+	ktMockMvcRE = regexp.MustCompile(
+		`\.perform\s*\(\s*(get|post|put|delete|patch)\s*\(\s*"([^"\n\r]+)"`)
+
+	// Spring WebTestClient: webTestClient.get().uri("/api/v1/x").exchange()
+	ktWebTestClientRE = regexp.MustCompile(
+		`(?s)\.(get|post|put|delete|patch)\s*\(\s*\)\s*\.uri\s*\(\s*"([^"\n\r]+)"`)
+
+	// Ktor testApplication client: client.get("/api/v1/x") / httpClient.post("/x")
+	// (also matches the bare `client.get("/x")` inside `testApplication { … }`).
+	// The verb is the method on the client; the route its first string argument.
+	// Anchored on a `.` receiver so a bare static helper `get("/x")` is not
+	// captured here (that form is the Spring MockMvc factory, handled above).
+	ktKtorClientRE = regexp.MustCompile(
+		`\.(get|post|put|delete|patch)\s*(?:<[^>(]*>)?\s*\(\s*"(/[^"\n\r]*)"`)
+
+	// Ktor legacy handleRequest(HttpMethod.Get, "/api/v1/x").
+	ktKtorHandleRequestRE = regexp.MustCompile(
+		`\bhandleRequest\s*\(\s*HttpMethod\.(Get|Post|Put|Delete|Patch)\s*,\s*"([^"\n\r]+)"`)
+)
+
+func (e *kotlinTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "kotlin" {
+		return nil, nil
+	}
+	if !isKotlinTestFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectKotlinTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	name := kotlinTestSuiteBaseName(file.Path)
+	framework := "kotest"
+	if strings.Contains(source, "mockMvc") || strings.Contains(source, "MockMvc") ||
+		strings.Contains(source, "WebTestClient") || strings.Contains(source, "webTestClient") {
+		framework = "spring"
+	} else if strings.Contains(source, "testApplication") ||
+		strings.Contains(source, "handleRequest") || strings.Contains(source, "io.ktor") {
+		framework = "ktor"
+	}
+	rec := types.EntityRecord{
+		Name:       name,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "kotlin",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       framework,
+			"provenance":      "INFERRED_FROM_KOTLIN_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectKotlinTestRouteCalls returns the de-duplicated "VERB route" pairs a
+// Kotlin test file drives by route string (Spring MockMvc / WebTestClient and
+// Ktor client / handleRequest). Routes are normalised to a leading-slash path;
+// non-path / variable-route literals are dropped (honest exclusion).
+func collectKotlinTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		route := normaliseKotlinTestRoute(rawRoute)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	for _, m := range ktMockMvcRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range ktWebTestClientRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range ktKtorClientRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range ktKtorHandleRequestRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	return out
+}
+
+// normaliseKotlinTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix, drops query/fragment, collapses repeated slashes.
+// Path-param placeholders ({id}) and casing are preserved (the resolver
+// wildcards templates and compares case-insensitively).
+func normaliseKotlinTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
+}
+
+// isKotlinTestFile reports whether path looks like a Kotlin test source — under a
+// test source set (`src/test/`, `/test/`) or a *Test/*Spec/*IT named file. Keeps
+// the route-hit suite off production controllers that merely mention a route.
+func isKotlinTestFile(path string) bool {
+	lp := strings.ToLower(filepath.ToSlash(path))
+	if strings.Contains(lp, "/src/test/") || strings.Contains(lp, "/test/") ||
+		strings.Contains(lp, "/androidtest/") {
+		return true
+	}
+	base := strings.TrimSuffix(filepath.Base(lp), ".kt")
+	return strings.HasSuffix(base, "test") || strings.HasSuffix(base, "spec") ||
+		strings.HasSuffix(base, "it") || strings.HasSuffix(base, "tests")
+}
+
+// kotlinTestSuiteBaseName derives a suite label from the test file path
+// (`.../CountControllerTest.kt` → `CountControllerTest`).
+func kotlinTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/custom/kotlin/tests_route_e2e_test.go
+++ b/internal/custom/kotlin/tests_route_e2e_test.go
@@ -1,0 +1,86 @@
+package kotlin
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+func runKtRouteE2E(t *testing.T, path, src string) string {
+	t.Helper()
+	e := &kotlinTestRouteE2EExtractor{}
+	ents, err := e.Extract(context.Background(), extractor.FileInput{
+		Path: path, Language: "kotlin", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) == 0 {
+		return ""
+	}
+	if ents[0].Subtype != "test_suite" {
+		t.Fatalf("expected test_suite, got %q", ents[0].Subtype)
+	}
+	return ents[0].Properties["e2e_route_calls"]
+}
+
+func TestKotlinRouteE2E_SpringMockMvc(t *testing.T) {
+	src := "package t\n" +
+		"class XControllerTest {\n" +
+		"    @Test fun a() { mockMvc.perform(get(\"/api/v1/x/get_counts\")) }\n" +
+		"    @Test fun b() { mockMvc.perform(post(\"/api/v1/x/items\")) }\n" +
+		"}\n"
+	got := runKtRouteE2E(t, "src/test/kotlin/XControllerTest.kt", src)
+	if !strings.Contains(got, "GET /api/v1/x/get_counts") || !strings.Contains(got, "POST /api/v1/x/items") {
+		t.Fatalf("MockMvc routes not captured: %q", got)
+	}
+}
+
+func TestKotlinRouteE2E_WebTestClient(t *testing.T) {
+	src := "package t\n" +
+		"class XControllerTest {\n" +
+		"    @Test fun a() { webTestClient.get().uri(\"/api/v1/x/get_counts\").exchange() }\n" +
+		"}\n"
+	got := runKtRouteE2E(t, "src/test/kotlin/XControllerTest.kt", src)
+	if !strings.Contains(got, "GET /api/v1/x/get_counts") {
+		t.Fatalf("WebTestClient route not captured: %q", got)
+	}
+}
+
+func TestKotlinRouteE2E_KtorClient(t *testing.T) {
+	src := "package t\n" +
+		"import io.ktor.client.request.*\n" +
+		"class XRoutesTest {\n" +
+		"    @Test fun a() = testApplication { client.get(\"/api/v1/x/get_counts\") }\n" +
+		"    @Test fun b() = testApplication { client.post(\"/api/v1/x/items\") }\n" +
+		"}\n"
+	got := runKtRouteE2E(t, "src/test/kotlin/XRoutesTest.kt", src)
+	if !strings.Contains(got, "GET /api/v1/x/get_counts") || !strings.Contains(got, "POST /api/v1/x/items") {
+		t.Fatalf("Ktor client routes not captured: %q", got)
+	}
+}
+
+func TestKotlinRouteE2E_KtorHandleRequest(t *testing.T) {
+	src := "package t\n" +
+		"class XRoutesTest {\n" +
+		"    @Test fun a() { handleRequest(HttpMethod.Get, \"/api/v1/x/get_counts\") }\n" +
+		"}\n"
+	got := runKtRouteE2E(t, "src/test/kotlin/XRoutesTest.kt", src)
+	if !strings.Contains(got, "GET /api/v1/x/get_counts") {
+		t.Fatalf("Ktor handleRequest route not captured: %q", got)
+	}
+}
+
+// Non-test production controller mentioning a route must NOT mint a suite.
+func TestKotlinRouteE2E_ProductionFileSkipped(t *testing.T) {
+	src := "package t\n" +
+		"class XController {\n" +
+		"    fun reg() { get(\"/api/v1/x\") }\n" +
+		"}\n"
+	got := runKtRouteE2E(t, "src/main/kotlin/XController.kt", src)
+	if got != "" {
+		t.Fatalf("production file must not produce e2e_route_calls, got %q", got)
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4687_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4687_test.go
@@ -1,0 +1,97 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Kotlin route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/kotlin"
+)
+
+// Issue #4687 LIVE-REPRO (resolve side) — Kotlin Spring MockMvc + Ktor tests.
+//
+// Proves end-to-end that a Kotlin test calling a route by string
+// (`mockMvc.perform(get("/api/v1/..."))` / Ktor `client.get("/api/v1/...")`)
+// links to the http_endpoint_definition it exercises — the Kotlin slice of the
+// all-language program (#4615), generalizing #4351 / #4369 / #4370 / #4371 /
+// #4684 / #4685 / #4686. The shared linkE2ERouteTestsToEndpoints pass is
+// language-agnostic; only the Kotlin route capture is new.
+
+const ktSpringTestSrc4687 = `package com.app.test
+import org.springframework.test.web.servlet.MockMvc
+class XControllerTest {
+    lateinit var mockMvc: MockMvc
+    @Test fun getCounts() {
+        mockMvc.perform(get("/api/v1/x/get_counts"))
+    }
+    @Test fun createItem() {
+        mockMvc.perform(post("/api/v1/x/items"))
+    }
+}
+`
+
+const ktKtorTestSrc4687 = `package com.app.test
+import io.ktor.client.request.*
+class XRoutesTest {
+    @Test fun getCounts() = testApplication {
+        client.get("/api/v1/x/get_counts")
+    }
+    @Test fun createItem() = testApplication {
+        client.post("/api/v1/x/items")
+    }
+}
+`
+
+func TestIssue4687_KotlinSpringE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/x/get_counts"),
+		def("POST", "/api/v1/x/items"),
+	}
+	suite := realSuite(t, "custom_kotlin_tests_route_e2e",
+		"src/test/kotlin/com/app/XControllerTest.kt", "kotlin", ktSpringTestSrc4687)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	targets := edgeTargets(afterOut)
+	assertKtRouteEdges(t, targets)
+}
+
+func TestIssue4687_KotlinKtorE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/x/get_counts"),
+		def("POST", "/api/v1/x/items"),
+	}
+	suite := realSuite(t, "custom_kotlin_tests_route_e2e",
+		"src/test/kotlin/com/app/XRoutesTest.kt", "kotlin", ktKtorTestSrc4687)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	targets := edgeTargets(afterOut)
+	assertKtRouteEdges(t, targets)
+}
+
+func assertKtRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/x/get_counts") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/x/items") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /api/v1/x/get_counts; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /api/v1/x/items; targets=%v", targets)
+	}
+}

--- a/internal/extractors/kotlin/crosspath.go
+++ b/internal/extractors/kotlin/crosspath.go
@@ -78,6 +78,16 @@ type kotlinCrossCtx struct {
 	// call under an active star import is conservatively NOT stamped — the
 	// star-import case is a documented follow-up (#4334).
 	hasStarImport bool
+
+	// classRecvTypes maps a CLASS-LEVEL property name to the concrete class it
+	// is statically constructed as — the MockK `@InjectMockKs val controller =
+	// XController()` / `val controller = mockk<XController>()` field idiom
+	// (#4687, the Kotlin slice of epic #4615). Set transiently while a class
+	// body is walked so each test method's CALLS extractor can type a receiver
+	// declared as a class field, then restored on exit. The per-method body
+	// locals (collected in extractCallRelationships) take precedence over these
+	// — a same-named local shadows the field within the method scope.
+	classRecvTypes map[string]string
 }
 
 // buildKotlinCrossCtx scans the compilation unit for the package header and
@@ -198,10 +208,17 @@ type qualifiedKotlinCall struct {
 // localNames is the set of in-scope value names (parameters, properties, locals)
 // whose head segment marks an INSTANCE receiver — those are left to the base
 // extractor, never stamped as a cross-package static qualifier.
+// recvTypes maps an in-scope value name (local or class field) to the concrete
+// class it was statically constructed as (`val c = XController()` /
+// `@InjectMockKs val c = XController()` / `val c = mockk<XController>()`). A
+// navigation call whose head is such a typed receiver (`c.getCounts()`) is bound
+// to the class method via a (package, Type=that class, leaf) stamp — the #4687
+// local-variable / MockK receiver-typing path. Empty/nil → no typed-local path.
 func (c *kotlinCrossCtx) resolveKotlinQualifiedCall(
 	call *sitter.Node,
 	src []byte,
 	localNames map[string]bool,
+	recvTypes map[string]string,
 ) *qualifiedKotlinCall {
 	if c == nil || call == nil || call.ChildCount() == 0 {
 		return nil
@@ -226,7 +243,7 @@ func (c *kotlinCrossCtx) resolveKotlinQualifiedCall(
 		return nil
 
 	case "navigation_expression":
-		return c.resolveKotlinNavigationCall(first, src, localNames)
+		return c.resolveKotlinNavigationCall(first, src, localNames, recvTypes)
 	}
 	return nil
 }
@@ -238,6 +255,7 @@ func (c *kotlinCrossCtx) resolveKotlinNavigationCall(
 	nav *sitter.Node,
 	src []byte,
 	localNames map[string]bool,
+	recvTypes map[string]string,
 ) *qualifiedKotlinCall {
 	segs, ok := flattenKotlinNavigation(nav, src)
 	if !ok || len(segs) < 2 {
@@ -249,6 +267,20 @@ func (c *kotlinCrossCtx) resolveKotlinNavigationCall(
 		return nil
 	}
 	head := recv[0]
+	// #4687 — typed-local / typed-field receiver. A plain `c.method()` whose
+	// receiver `c` was statically typed to a concrete class via a constructor
+	// call, an explicit type annotation, or a `mockk<T>()` builder resolves to
+	// that class's method (the test→CALLS→handler coverage path). Only the
+	// single-segment receiver form `c.method()` is bound here — `c.field.m()`
+	// would need field-type tracking and falls through. This branch runs BEFORE
+	// the instance-receiver guard so a typed local is upgraded rather than
+	// dropped; an untyped local (factory/`mockk()` receiver) still falls to the
+	// guard and stays bare (honest exclusion).
+	if len(recv) == 1 {
+		if typ, ok := recvTypes[head]; ok && typ != "" {
+			return c.buildTypedReceiverCall(leaf, typ)
+		}
+	}
 	// Instance-receiver guard: a head that is a known local/param/property is
 	// an instance call (`order.place()`), owned by the base extractor — not a
 	// static cross-package qualifier.
@@ -295,6 +327,223 @@ func (c *kotlinCrossCtx) resolveKotlinNavigationCall(
 	// Resolve an alias `Svc` to its real imported type name `OrderService` for
 	// the index lookup (the package mapping is keyed on the alias, but the
 	// callee entity's enclosing type is the real name).
+	if real, ok := c.aliasRealType[typ]; ok && real != "" {
+		b.typ = real
+	}
+	if len(b.pkgCandidates) == 0 {
+		return nil
+	}
+	return b
+}
+
+// kotlinLocalReceiverTypes scans a function/lambda body and returns a map of
+// local value name → the concrete class it is statically constructed as, for
+// the local-variable receiver-typing path (#4687, the Kotlin slice of epic
+// #4615 — the analogue of Java #4682 collectLocalVarTypes/newExprClassName,
+// TS/JS #4680, Python #4716, Go #4683). Three trusted shapes:
+//
+//   - Constructor call (Kotlin has NO `new` keyword):
+//     `val c = XController(svc)` → c : XController. The initializer is a
+//     call_expression whose callee is a bare PascalCase simple_identifier and
+//     which has a call_suffix (real invocation). This is the dominant modern
+//     test idiom for the SUT.
+//   - Explicit type annotation: `val c: XController = makeIt()` → c : XController
+//     (the declared user_type wins regardless of the RHS shape).
+//   - MockK local: `val c = mockk<XController>()` → c : XController (the type
+//     argument of the `mockk`/`spyk` builder), the Kotlin mirror of Java's
+//     Mockito `@InjectMocks` and the C# DI `GetRequiredService<T>` cases.
+//
+// Honest exclusion (no entry, receiver stays bare): a factory/builder/`make()`
+// call (`val c = makeController()`), a method chain, a non-PascalCase callee, a
+// `mockk()` with no static type argument, a literal, a cast — anything whose
+// class is not statically recoverable. First binding per name wins.
+func kotlinLocalReceiverTypes(body *sitter.Node, src []byte) map[string]string {
+	if body == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for _, decl := range findAllNodes(body, "property_declaration") {
+		name, vd := kotlinPropertyVarNameNode(decl, src)
+		if name == "" {
+			continue
+		}
+		if _, taken := out[name]; taken {
+			continue // first binding wins
+		}
+		// 1. Explicit declared type (`val c: XController = …`).
+		if typ := kotlinUserTypeLeaf(vd, src); typ != "" && isKotlinPascalType(typ) {
+			out[name] = typ
+			continue
+		}
+		// 2 / 3. Infer from the initializer call_expression (ctor or mockk<T>()).
+		if init := kotlinPropertyInitCall(decl); init != nil {
+			if typ := kotlinConstructedOrMockType(init, src); typ != "" {
+				out[name] = typ
+			}
+		}
+	}
+	return out
+}
+
+// kotlinPropertyVarNameNode returns the declared value name and its
+// variable_declaration node from a property_declaration
+// (`val a: T = …` / `var a = …`). Returns ("", nil) when no variable_declaration
+// child is present (multi-declaration / destructuring shapes are skipped).
+func kotlinPropertyVarNameNode(decl *sitter.Node, src []byte) (string, *sitter.Node) {
+	for i := 0; i < int(decl.ChildCount()); i++ {
+		ch := decl.Child(i)
+		if ch.Type() != "variable_declaration" {
+			continue
+		}
+		for j := 0; j < int(ch.ChildCount()); j++ {
+			id := ch.Child(j)
+			if id.Type() == "simple_identifier" {
+				return string(src[id.StartByte():id.EndByte()]), ch
+			}
+		}
+	}
+	return "", nil
+}
+
+// kotlinUserTypeLeaf returns the leaf type_identifier of a variable_declaration's
+// explicit type annotation (`a: XController` → "XController"), stripping any
+// package/generic wrapping by taking the first type_identifier descendant of the
+// user_type. Returns "" when the declaration has no explicit type.
+func kotlinUserTypeLeaf(vd *sitter.Node, src []byte) string {
+	if vd == nil {
+		return ""
+	}
+	var ut *sitter.Node
+	for i := 0; i < int(vd.ChildCount()); i++ {
+		if vd.Child(i).Type() == "user_type" {
+			ut = vd.Child(i)
+			break
+		}
+	}
+	if ut == nil {
+		return ""
+	}
+	ids := findAllNodes(ut, "type_identifier")
+	if len(ids) == 0 {
+		return ""
+	}
+	// The declared type is the FIRST type_identifier (`com.x.XController<T>` →
+	// the outer type, not a generic argument). findAllNodes is pre-order so the
+	// leftmost/outermost user_type's identifier comes first for the common
+	// unqualified `XController` shape.
+	n := ids[0]
+	return string(src[n.StartByte():n.EndByte()])
+}
+
+// kotlinPropertyInitCall returns the initializer call_expression of a
+// property_declaration (`val c = XController(svc)` → the `XController(svc)`
+// call_expression), or nil when the RHS is not a direct call expression.
+func kotlinPropertyInitCall(decl *sitter.Node) *sitter.Node {
+	// The RHS is the child following the `=` token. Find `=`, then the next
+	// non-trivial sibling.
+	sawEq := false
+	for i := 0; i < int(decl.ChildCount()); i++ {
+		ch := decl.Child(i)
+		if ch.Type() == "=" {
+			sawEq = true
+			continue
+		}
+		if !sawEq {
+			continue
+		}
+		if ch.Type() == "call_expression" {
+			return ch
+		}
+		// Any other RHS node (literal, navigation, when, etc.) — not a ctor/mockk.
+		return nil
+	}
+	return nil
+}
+
+// kotlinConstructedOrMockType returns the class a property initializer call
+// constructs, for the two trusted shapes:
+//   - `XController(...)` — a Kotlin constructor call: callee is a bare PascalCase
+//     simple_identifier with a call_suffix. Returns "XController".
+//   - `mockk<XController>()` / `spyk<XController>()` — a MockK builder whose
+//     single type argument names the mocked class. Returns "XController".
+//
+// Returns "" for any other call (factory/`make()`, lowercase callee, `mockk()`
+// with no type argument, navigation chains) so the receiver stays bare.
+func kotlinConstructedOrMockType(call *sitter.Node, src []byte) string {
+	if call == nil || call.ChildCount() == 0 {
+		return ""
+	}
+	callee := call.Child(0)
+	if callee.Type() != "simple_identifier" {
+		return ""
+	}
+	name := string(src[callee.StartByte():callee.EndByte()])
+	// MockK builder: `mockk<T>()` / `spyk<T>()` — read the type argument.
+	if name == "mockk" || name == "spyk" {
+		if t := kotlinCallSuffixTypeArg(call, src); t != "" && isKotlinPascalType(t) {
+			return t
+		}
+		return ""
+	}
+	// Constructor call: a PascalCase callee invoked with a call_suffix.
+	if isKotlinPascalType(name) && hasCallSuffix(call) {
+		return name
+	}
+	return ""
+}
+
+// kotlinCallSuffixTypeArg returns the leaf type_identifier of the first
+// type_arguments projection on a call_expression's call_suffix
+// (`mockk<XController>()` → "XController"), or "" when absent.
+func kotlinCallSuffixTypeArg(call *sitter.Node, src []byte) string {
+	for i := 0; i < int(call.ChildCount()); i++ {
+		cs := call.Child(i)
+		if cs.Type() != "call_suffix" {
+			continue
+		}
+		for j := 0; j < int(cs.ChildCount()); j++ {
+			ta := cs.Child(j)
+			if ta.Type() != "type_arguments" {
+				continue
+			}
+			ids := findAllNodes(ta, "type_identifier")
+			if len(ids) > 0 {
+				n := ids[0]
+				return string(src[n.StartByte():n.EndByte()])
+			}
+		}
+	}
+	return ""
+}
+
+// isKotlinPascalType reports whether name is a non-empty identifier whose first
+// rune is an uppercase letter — the Kotlin class-name convention. Mirrors Java's
+// isPascalCase used by receiverTypeName.
+func isKotlinPascalType(name string) bool {
+	if name == "" {
+		return false
+	}
+	r := rune(name[0])
+	return r >= 'A' && r <= 'Z'
+}
+
+// buildTypedReceiverCall constructs the (package candidates, type, leaf) binding
+// for a typed-local / typed-field receiver call `c.leaf()` where `c` is known to
+// be of class `typ` (#4687). The candidate packages are the imported-type
+// package for `typ` (an `import com.x.XController` brings the class into scope
+// from another package) and the file's own package (a same-file SUT), most
+// specific first — mirroring the lone-`Type.method()` resolution path. An alias
+// (`import ... as Svc`) is resolved to the real type name for the index lookup.
+// Returns nil when no candidate package can be recovered (then the receiver
+// stays bare — honest exclusion).
+func (c *kotlinCrossCtx) buildTypedReceiverCall(leaf, typ string) *qualifiedKotlinCall {
+	b := &qualifiedKotlinCall{leaf: leaf, typ: typ}
+	if pkg, ok := c.importedTypes[typ]; ok && pkg != "" {
+		b.pkgCandidates = appendUniqueKt(b.pkgCandidates, pkg)
+	}
+	if c.filePackage != "" {
+		b.pkgCandidates = appendUniqueKt(b.pkgCandidates, c.filePackage)
+	}
 	if real, ok := c.aliasRealType[typ]; ok && real != "" {
 		b.typ = real
 	}

--- a/internal/extractors/kotlin/issue4375_crosspkg_test.go
+++ b/internal/extractors/kotlin/issue4375_crosspkg_test.go
@@ -362,10 +362,48 @@ func TestIssue4375_SamePackageObjectMember(t *testing.T) {
 	}
 }
 
-// TestIssue4375_NegativeInstanceReceiver — an instance receiver
-// (`order.place()` where `order` is a local val) must NOT be stamped as a
-// cross-package static qualifier (no false bind).
+// TestIssue4375_NegativeInstanceReceiver — an instance receiver whose type is
+// NOT statically recoverable must NOT be stamped as a cross-package static
+// qualifier (no false bind).
+//
+// NOTE (#4687): the original form of this test used `val order = OrderService();
+// order.place()` and asserted NO stamp. That case is now DELIBERATELY upgraded —
+// a local constructed via a ctor call IS receiver-typed (the test→endpoint
+// coverage-linkage win, validated in TestIssue4375_LocalCtorReceiverNowTyped and
+// issue4687_localvar_receiver_test.go). The genuine negative is a receiver whose
+// class can't be statically recovered: a factory-returned local stays bare.
 func TestIssue4375_NegativeInstanceReceiver(t *testing.T) {
+	files := ktCollidingCalleeFiles()
+	files["src/app/Caller.kt"] = "" +
+		"package com.app.app\n" +
+		"\n" +
+		"import com.app.services.OrderService\n" +
+		"\n" +
+		"class Caller {\n" +
+		"    fun run() {\n" +
+		"        val order = makeOrder()\n" +
+		"        order.place()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	if !ok {
+		t.Fatal("CALLS edge to place not found")
+	}
+	if props["kotlin_call_pkg"] != "" || props["kotlin_call_type"] != "" {
+		t.Fatalf("factory-returned instance receiver must NOT be stamped, got pkg=%q type=%q",
+			props["kotlin_call_pkg"], props["kotlin_call_type"])
+	}
+}
+
+// TestIssue4375_LocalCtorReceiverNowTyped — #4687: a local constructed via a
+// Kotlin ctor call (`val order = OrderService(); order.place()`) IS now
+// receiver-typed and binds to the imported OrderService's method (the
+// com.app.services one, NOT the colliding com.app.billing one). This is the
+// instance-receiver case the original #4375 negative test guarded — deliberately
+// upgraded for the test→CALLS→handler→endpoint coverage-linkage program.
+func TestIssue4375_LocalCtorReceiverNowTyped(t *testing.T) {
 	files := ktCollidingCalleeFiles()
 	files["src/app/Caller.kt"] = "" +
 		"package com.app.app\n" +
@@ -384,9 +422,14 @@ func TestIssue4375_NegativeInstanceReceiver(t *testing.T) {
 	if !ok {
 		t.Fatal("CALLS edge to place not found")
 	}
-	if props["kotlin_call_pkg"] != "" || props["kotlin_call_type"] != "" {
-		t.Fatalf("instance receiver must NOT be stamped, got pkg=%q type=%q",
-			props["kotlin_call_pkg"], props["kotlin_call_type"])
+	if props["kotlin_call_type"] != "OrderService" {
+		t.Fatalf("ctor-local receiver should be typed OrderService, got type=%q", props["kotlin_call_type"])
+	}
+	runKotlinResolve(merged)
+	toID, _, _ := ktCallEdge(merged, "src/app/Caller.kt", "run", "place")
+	want := ktEntID(merged, "src/services/OrderService.kt", "place")
+	if toID != want || !ktIs16Hex(toID) {
+		t.Fatalf("ctor-local receiver did not bind to com.app.services OrderService.place: got %q want %q", toID, want)
 	}
 }
 

--- a/internal/extractors/kotlin/issue4687_localvar_receiver_test.go
+++ b/internal/extractors/kotlin/issue4687_localvar_receiver_test.go
@@ -1,0 +1,223 @@
+// issue4687_localvar_receiver_test.go — exact-mirror fixtures for the Kotlin
+// slice of epic #4615 (all-framework test→endpoint coverage linkage).
+//
+// Generalises the TS/JS (#4680), Python (#4716), Java (#4682/#4717), Go
+// (#4683/#4718), Ruby (#4719), C# (#4720) and PHP (#4721) local-variable
+// receiver-typing + test→CALLS→handler coverage wins to Kotlin.
+//
+// PROBE pre-state (RED): `val c = XController(svc); c.getCounts()` in a `@Test
+// fun` emitted a CALLS edge carrying NO kotlin_call_type — the navigation
+// resolver's instance-receiver guard dropped the typed local, so the bare
+// `getCounts` could not bind cross-file and the controller stayed uncovered.
+// Kotest specs (`class FooSpec : StringSpec({ … })`) emitted ZERO CALLS for the
+// whole spec because the example logic lives in an anonymous constructor lambda,
+// not a `@Test fun`. JUnit5 `@Test fun` ARE named operations already mined by
+// walk(), so only the typed-receiver binding (gap 1/2) and the Kotest
+// anonymous-lambda owner (gap 3) were RED.
+//
+// These tests drive the REAL extraction + resolver passes (the same sequence
+// cmd/archigraph/index.go runs) on a faithful multi-package project that
+// reproduces a cross-file SUT call WITH a same-named method collision in two
+// packages — so a globally-unique name cannot false-pass through the bare-name
+// fallback.
+package kotlin_test
+
+import "testing"
+
+// Two controllers in different packages both declare getCounts() — only the
+// receiver TYPE picks the right one.
+func ktTwoControllerFiles() map[string]string {
+	return map[string]string{
+		"src/web/XController.kt": "" +
+			"package com.app.web\n" +
+			"class XController(val svc: Svc) {\n" +
+			"    fun getCounts(): Int { return 1 }\n" +
+			"}\n",
+		"src/admin/XController.kt": "" +
+			"package com.app.admin\n" +
+			"class XController {\n" +
+			"    fun getCounts(): Int { return 2 }\n" +
+			"}\n",
+	}
+}
+
+// A: `val c = XController(svc); c.getCounts()` in a @Test fun → CALLS to the
+// imported web controller's getCounts (NOT the admin one).
+func TestIssue4687_LocalVarCtorReceiver(t *testing.T) {
+	files := ktTwoControllerFiles()
+	files["src/test/XControllerTest.kt"] = "" +
+		"package com.app.test\n" +
+		"import com.app.web.XController\n" +
+		"class XControllerTest {\n" +
+		"    @Test fun getCountsWorks() {\n" +
+		"        val c = XController(Svc())\n" +
+		"        c.getCounts()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	_, props, ok := ktCallEdge(merged, "src/test/XControllerTest.kt", "getCountsWorks", "getCounts")
+	if !ok {
+		t.Fatal("CALLS edge to getCounts not found")
+	}
+	if props["kotlin_call_type"] != "XController" {
+		t.Fatalf("expected typed receiver XController, got type=%q", props["kotlin_call_type"])
+	}
+	runKotlinResolve(merged)
+	toID, _, _ := ktCallEdge(merged, "src/test/XControllerTest.kt", "getCountsWorks", "getCounts")
+	want := ktEntID(merged, "src/web/XController.kt", "getCounts")
+	if toID != want || !ktIs16Hex(toID) {
+		t.Fatalf("CALLS did not bind to web XController.getCounts: got %q want %q", toID, want)
+	}
+}
+
+// A': explicit type annotation `val c: XController = makeIt()` types the same way.
+func TestIssue4687_LocalVarTypeAnnotationReceiver(t *testing.T) {
+	files := ktTwoControllerFiles()
+	files["src/test/XControllerTest.kt"] = "" +
+		"package com.app.test\n" +
+		"import com.app.web.XController\n" +
+		"class XControllerTest {\n" +
+		"    @Test fun getCountsWorks() {\n" +
+		"        val c: XController = makeIt()\n" +
+		"        c.getCounts()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+	runKotlinResolve(merged)
+	toID, _, _ := ktCallEdge(merged, "src/test/XControllerTest.kt", "getCountsWorks", "getCounts")
+	want := ktEntID(merged, "src/web/XController.kt", "getCounts")
+	if toID != want {
+		t.Fatalf("type-annotation receiver did not bind: got %q want %q", toID, want)
+	}
+}
+
+// MockK: `@InjectMockKs val controller = XController()` field + `val c =
+// mockk<XController>()` local both type the receiver to the controller class.
+func TestIssue4687_MockKReceiverTyping(t *testing.T) {
+	files := ktTwoControllerFiles()
+	files["src/test/XControllerTest.kt"] = "" +
+		"package com.app.test\n" +
+		"import com.app.web.XController\n" +
+		"class XControllerTest {\n" +
+		"    @InjectMockKs val controller = XController(Svc())\n" +
+		"    @Test fun fieldReceiver() {\n" +
+		"        controller.getCounts()\n" +
+		"    }\n" +
+		"    @Test fun mockkLocal() {\n" +
+		"        val c = mockk<XController>()\n" +
+		"        c.getCounts()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+	runKotlinResolve(merged)
+	want := ktEntID(merged, "src/web/XController.kt", "getCounts")
+
+	fieldID, _, _ := ktCallEdge(merged, "src/test/XControllerTest.kt", "fieldReceiver", "getCounts")
+	if fieldID != want {
+		t.Fatalf("@InjectMockKs field receiver did not bind: got %q want %q", fieldID, want)
+	}
+	mockID, _, _ := ktCallEdge(merged, "src/test/XControllerTest.kt", "mockkLocal", "getCounts")
+	if mockID != want {
+		t.Fatalf("mockk<XController>() local receiver did not bind: got %q want %q", mockID, want)
+	}
+}
+
+// Kotest StringSpec: example logic in the anonymous constructor lambda is owned
+// by a test_scope SCOPE.Operation; its receiver-typed CALLS bind cross-file.
+func TestIssue4687_KotestScopeOwner(t *testing.T) {
+	files := ktTwoControllerFiles()
+	files["src/test/CountSpec.kt"] = "" +
+		"package com.app.test\n" +
+		"import io.kotest.core.spec.style.StringSpec\n" +
+		"import com.app.web.XController\n" +
+		"class CountSpec : StringSpec({\n" +
+		"    \"getCounts works\" {\n" +
+		"        val c = XController(Svc())\n" +
+		"        c.getCounts()\n" +
+		"    }\n" +
+		"})\n"
+	merged := extractKotlinProjectForTest(t, files)
+
+	var owner bool
+	for _, e := range merged {
+		if e.Subtype == "test_scope" && e.Name == "CountSpec" {
+			owner = true
+			if e.Properties["framework"] != "kotest" {
+				t.Errorf("expected framework=kotest, got %q", e.Properties["framework"])
+			}
+		}
+	}
+	if !owner {
+		t.Fatal("no Kotest test_scope owner emitted")
+	}
+	runKotlinResolve(merged)
+	toID, _, _ := ktCallEdge(merged, "src/test/CountSpec.kt", "CountSpec", "getCounts")
+	want := ktEntID(merged, "src/web/XController.kt", "getCounts")
+	if toID != want {
+		t.Fatalf("Kotest scope CALLS did not bind to web XController.getCounts: got %q want %q", toID, want)
+	}
+}
+
+// NEGATIVE: a factory-returning receiver (`val c = makeController()`) whose class
+// is not statically recoverable stays BARE — no kotlin_call_type stamp, honest
+// exclusion (the resolver must not guess a type).
+func TestIssue4687_FactoryReceiverStaysBare(t *testing.T) {
+	files := ktTwoControllerFiles()
+	files["src/test/XControllerTest.kt"] = "" +
+		"package com.app.test\n" +
+		"import com.app.web.XController\n" +
+		"class XControllerTest {\n" +
+		"    @Test fun viaFactory() {\n" +
+		"        val c = makeController()\n" +
+		"        c.getCounts()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+	_, props, ok := ktCallEdge(merged, "src/test/XControllerTest.kt", "viaFactory", "getCounts")
+	if !ok {
+		t.Fatal("CALLS edge to getCounts not found")
+	}
+	if props["kotlin_call_type"] != "" {
+		t.Fatalf("factory receiver must NOT be typed, got type=%q", props["kotlin_call_type"])
+	}
+}
+
+// NEGATIVE: a bare `mockk()` with no static type argument stays bare.
+func TestIssue4687_UntypedMockkStaysBare(t *testing.T) {
+	files := ktTwoControllerFiles()
+	files["src/test/XControllerTest.kt"] = "" +
+		"package com.app.test\n" +
+		"import com.app.web.XController\n" +
+		"class XControllerTest {\n" +
+		"    @Test fun viaUntypedMock() {\n" +
+		"        val c = mockk()\n" +
+		"        c.getCounts()\n" +
+		"    }\n" +
+		"}\n"
+	merged := extractKotlinProjectForTest(t, files)
+	_, props, _ := ktCallEdge(merged, "src/test/XControllerTest.kt", "viaUntypedMock", "getCounts")
+	if props["kotlin_call_type"] != "" {
+		t.Fatalf("untyped mockk() receiver must NOT be typed, got type=%q", props["kotlin_call_type"])
+	}
+}
+
+// NEGATIVE: a shape-only Kotest spec (no production calls) emits NO scope owner.
+func TestIssue4687_ShapeOnlyKotestNoOwner(t *testing.T) {
+	files := map[string]string{
+		"src/test/EmptySpec.kt": "" +
+			"package com.app.test\n" +
+			"import io.kotest.core.spec.style.StringSpec\n" +
+			"class EmptySpec : StringSpec({\n" +
+			"    \"adds\" {\n" +
+			"        (1 + 1) shouldBe 2\n" +
+			"    }\n" +
+			"})\n",
+	}
+	merged := extractKotlinProjectForTest(t, files)
+	for _, e := range merged {
+		if e.Subtype == "test_scope" {
+			t.Fatalf("shape-only spec must not emit a test_scope owner, got %q", e.Name)
+		}
+	}
+}

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -185,9 +185,25 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		// These are structural properties, not just formal parameters, so they
 		// must appear as field entities with CONTAINS edges to the class.
 		emitPrimaryConstructorFields(node, file, rec.Name, classIdx, out)
+		// #4687 — Kotest spec classes carry their example logic in an anonymous
+		// constructor lambda (`class FooSpec : StringSpec({ … })`), not in
+		// `@Test fun` methods, so emit a test_scope owner for the receiver-typed
+		// CALLS mined from that lambda. No-op for non-spec classes.
+		emitKotestTestScopeOwner(node, file, rec.Name, ctx, out)
 		// CONTAINS: every function AND property declared in the class body.
 		body := findClassBody(node)
 		if body != nil {
+			// #4687 — collect class-level typed receiver fields (MockK
+			// `@InjectMockKs val controller = XController()` / `val c =
+			// mockk<XController>()`) so every test method's CALLS extractor can
+			// type a receiver declared as a class field. Set transiently for the
+			// duration of this class body, restored on exit (nested classes save
+			// and replace their own).
+			var savedRecv map[string]string
+			if ctx != nil {
+				savedRecv = ctx.classRecvTypes
+				ctx.classRecvTypes = kotlinLocalReceiverTypes(body, file.Content)
+			}
 			before := len(*out)
 			for i := range body.ChildCount() {
 				ch := body.Child(int(i))
@@ -242,6 +258,9 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 						ToID: toID,
 						Kind: "CONTAINS",
 					})
+			}
+			if ctx != nil {
+				ctx.classRecvTypes = savedRecv // restore enclosing scope (#4687)
 			}
 		}
 		return
@@ -398,6 +417,21 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string, 
 	// Instance-receiver guard inputs: names whose head segment marks an
 	// instance receiver (`order.place()`) rather than a static type qualifier.
 	localNames := kotlinLocalValueNames(body, src)
+	// #4687 — typed-local / typed-field receiver map. Body locals
+	// (`val c = XController()`) take precedence over class-level fields
+	// (`@InjectMockKs val c = XController()`); a same-named local shadows the
+	// field within the method scope.
+	recvTypes := kotlinLocalReceiverTypes(body, src)
+	if ctx != nil && len(ctx.classRecvTypes) > 0 {
+		merged := make(map[string]string, len(ctx.classRecvTypes)+len(recvTypes))
+		for k, v := range ctx.classRecvTypes {
+			merged[k] = v
+		}
+		for k, v := range recvTypes {
+			merged[k] = v // body local wins over class field
+		}
+		recvTypes = merged
+	}
 	seen := make(map[string]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
 	for _, call := range calls {
@@ -421,7 +455,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string, 
 		props := map[string]string{"line": callLine}
 		// #4375 — stamp the cross-package qualifier when statically resolvable.
 		if ctx != nil {
-			if q := ctx.resolveKotlinQualifiedCall(call, src, localNames); q != nil &&
+			if q := ctx.resolveKotlinQualifiedCall(call, src, localNames, recvTypes); q != nil &&
 				q.leaf == target && len(q.pkgCandidates) > 0 {
 				props["kotlin_call_pkg"] = strings.Join(q.pkgCandidates, ";")
 				props["call_leaf"] = q.leaf

--- a/internal/extractors/kotlin/tests.go
+++ b/internal/extractors/kotlin/tests.go
@@ -1,0 +1,174 @@
+package kotlin
+
+import (
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// kotestSpecBaseTypes is the set of Kotest spec-style base classes whose
+// constructor-lambda body hosts the test DSL (`"name" { ... }`, `describe/it`,
+// `given/when/then`, `feature/scenario`, …). A `class FooSpec : <base>({ … })`
+// declaration carries ALL of its example logic inside that anonymous
+// constructor lambda — there is NO `@Test fun`, so the generic walk() (which
+// mines `function_declaration` bodies for CALLS) produces ZERO CALLS edges for
+// the whole spec. The receiver-typed `c.getCounts()` call inside the lambda is
+// therefore orphaned and ComputeCoverage sees every controller reached only by
+// a Kotest spec as untested.
+//
+// #4687 (the Kotlin slice of epic #4615): emit ONE SCOPE.Operation
+// (subtype=test_scope) per Kotest spec class owning the receiver-typed CALLS
+// edges mined from the spec lambda — the Kotlin mirror of the TS/JS
+// (javascript/tests.go::emitTestScopeOwner, #4680), Ruby (#4719) and PHP (#4721)
+// test-scope owners. JUnit5 `@Test fun` are NAMED operations already mined by
+// walk(), so ONLY the Kotest anonymous-lambda case needs this pass.
+var kotestSpecBaseTypes = map[string]bool{
+	"StringSpec": true, "FunSpec": true, "DescribeSpec": true,
+	"BehaviorSpec": true, "ShouldSpec": true, "WordSpec": true,
+	"FeatureSpec": true, "ExpectSpec": true, "FreeSpec": true,
+	"AnnotationSpec": true,
+}
+
+// emitKotestTestScopeOwner inspects a class_declaration. When the class extends a
+// Kotest spec base type, it mines the constructor-lambda body for CALLS (with
+// the #4687 local/field receiver typing applied, since extractCallRelationships
+// finds every call_expression descendant) and appends a single test_scope
+// SCOPE.Operation that owns them. No-op for non-spec classes and for spec
+// classes whose lambda resolves no CALLS (shape-only specs → no owner, honest
+// exclusion).
+func emitKotestTestScopeOwner(
+	node *sitter.Node,
+	file extractor.FileInput,
+	className string,
+	ctx *kotlinCrossCtx,
+	out *[]types.EntityRecord,
+) {
+	if node == nil || className == "" {
+		return
+	}
+	lambda, base := kotestSpecLambdaBody(node, file.Content)
+	if lambda == nil {
+		return
+	}
+	// The spec lambda body owns the scope. The receiver-typing map combines any
+	// class-level fields (rare in Kotest, but supported) with the lambda's own
+	// locals (handled inside extractCallRelationships).
+	rels := extractCallRelationships(lambda, file.Content, className, ctx)
+	// Drop the Kotest DSL scaffolding calls (the `"name" { … }`, describe/it/…
+	// receivers) — they are not calls into production code and would resolve to
+	// nothing. They are bare leaf targets matching the DSL method names.
+	filtered := rels[:0]
+	for _, r := range rels {
+		if r.ToID != "" && kotestDSLScaffolding[r.ToID] {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	if len(filtered) == 0 {
+		return // shape-only spec — no production calls, no scope owner.
+	}
+	name := kotlinTestScopeName(file.Path, className)
+	rec := types.EntityRecord{
+		Name:          name,
+		Kind:          "SCOPE.Operation",
+		Subtype:       "test_scope",
+		SourceFile:    file.Path,
+		Language:      "kotlin",
+		StartLine:     int(node.StartPoint().Row) + 1,
+		EndLine:       int(node.EndPoint().Row) + 1,
+		Relationships: filtered,
+		Properties: map[string]string{
+			"framework":   "kotest",
+			"provenance":  "INFERRED_FROM_KOTEST_TEST_SCOPE",
+			"test_scope":  "true",
+			"spec_style":  base,
+			"test_class":  className,
+			"description": "test scope " + name,
+		},
+	}
+	*out = append(*out, rec)
+}
+
+// kotestDSLScaffolding lists the Kotest DSL block functions that structure a spec
+// (and would otherwise surface as bare CALLS targets from the lambda body). They
+// are filtered from the test_scope owner's edges.
+var kotestDSLScaffolding = map[string]bool{
+	"describe": true, "context": true, "it": true, "should": true,
+	"given": true, "when": true, "then": true, "and": true,
+	"feature": true, "scenario": true, "expect": true, "xdescribe": true,
+	"xit": true, "test": true, "Given": true, "When": true, "Then": true,
+	"And": true,
+}
+
+// kotestSpecLambdaBody returns the body of the constructor-lambda passed to a
+// Kotest spec base type in a class declaration's delegation, plus the base type
+// name. Returns (nil, "") when the class does not extend a known Kotest spec or
+// the delegation has no constructor lambda. Shape:
+//
+//	class FooSpec : StringSpec({ … })
+//	  └ delegation_specifier → constructor_invocation
+//	       ├ user_type → type_identifier  (the base spec type)
+//	       └ value_arguments → value_argument → lambda_literal → <body>
+func kotestSpecLambdaBody(node *sitter.Node, src []byte) (*sitter.Node, string) {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ds := node.Child(i)
+		if ds.Type() != "delegation_specifier" {
+			continue
+		}
+		ci := firstChildOfTypeNode(ds, "constructor_invocation")
+		if ci == nil {
+			continue
+		}
+		ut := firstChildOfTypeNode(ci, "user_type")
+		if ut == nil {
+			continue
+		}
+		baseIDs := findAllNodes(ut, "type_identifier")
+		if len(baseIDs) == 0 {
+			continue
+		}
+		base := string(src[baseIDs[0].StartByte():baseIDs[0].EndByte()])
+		if !kotestSpecBaseTypes[base] {
+			continue
+		}
+		va := firstChildOfTypeNode(ci, "value_arguments")
+		if va == nil {
+			continue
+		}
+		// value_arguments → value_argument → lambda_literal.
+		if lams := findAllNodes(va, "lambda_literal"); len(lams) > 0 {
+			return lams[0], base
+		}
+	}
+	return nil, ""
+}
+
+// firstChildOfTypeNode returns the first direct child of n whose Type() == kind,
+// or nil.
+func firstChildOfTypeNode(n *sitter.Node, kind string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if ch := n.Child(i); ch.Type() == kind {
+			return ch
+		}
+	}
+	return nil
+}
+
+// kotlinTestScopeName derives a stable scope-owner name from the spec file path
+// and class name, e.g. `CountSpec@CountSpec.kt`. Keeps it unique per
+// (file, class) so two specs in one file get distinct owners.
+func kotlinTestScopeName(path, className string) string {
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, filepath.Ext(base))
+	if base == className {
+		return className
+	}
+	return className + "@" + base
+}


### PR DESCRIPTION
The Kotlin slice of epic #4615 (all-framework test→endpoint coverage linkage). Generalises the TS/JS (#4680), Python (#4716), Java (#4682/#4717), Go (#4683/#4718), Ruby (#4719), C# (#4720) and PHP (#4721) local-variable receiver-typing + test→CALLS→handler→endpoint coverage wins to Kotlin.

## Probe findings (pre-state)
- Kotlin shares the JVM with Java, but the Java junit5 route-hit producer is gated `ctx.Language != "java"`, so **nothing** produced a `test_suite` / `e2e_route_calls` for Kotlin — route-hit was genuinely RED.
- **Local-variable receiver typing was RED**: `val c = XController(svc); c.getCounts()` in a `@Test fun` emitted a CALLS edge with **no** `kotlin_call_type` — the navigation resolver's instance-receiver guard dropped the typed local, so the bare `getCounts` couldn't bind cross-file and the controller stayed uncovered.
- **JUnit5 `@Test fun` are already named SCOPE.Operation entities** mined by `walk()` — no scope-owner needed. **Kotest specs** (`class FooSpec : StringSpec({ … })`) emitted **zero** CALLS for the whole spec (example logic lives in an anonymous constructor lambda), so — like TS/JS, Ruby, PHP — Kotest needed a test-scope owner.

## Changes
- **`internal/extractors/kotlin/crosspath.go`** — `kotlinLocalReceiverTypes` types a local/field from a Kotlin ctor call `val c = XController(svc)` (no `new` keyword: PascalCase callee + `call_suffix`), an explicit `val c: XController` annotation, and a MockK `mockk<XController>()` / `spyk<T>()` builder. The navigation resolver upgrades a typed-local/field `c.method()` to a `(package, type, leaf)` stamp **before** the instance-receiver guard, so the existing `ResolveKotlinCrossPackageCalls` pass binds it to the class method. No `coverage.go` change — it already credits test→CALLS→handler→endpoint.
- **`internal/extractors/kotlin/kotlin.go`** — thread the typed-receiver map through `extractCallRelationships`; collect class-level `@InjectMockKs`/`mockk` fields transiently per class body so every test method's receiver can be typed.
- **`internal/extractors/kotlin/tests.go`** — `emitKotestTestScopeOwner` emits one `test_scope` SCOPE.Operation per Kotest spec class owning the receiver-typed CALLS mined from the constructor-lambda body (StringSpec/FunSpec/DescribeSpec/BehaviorSpec/ShouldSpec/WordSpec/FeatureSpec/ExpectSpec/FreeSpec/AnnotationSpec). DSL scaffolding (describe/it/should/given/when/then/…) is filtered; shape-only specs emit no owner.
- **`internal/custom/kotlin/tests_route_e2e.go`** — new `custom_kotlin_tests_route_e2e` extractor emits a one-per-file `test_suite` carrying `e2e_route_calls` for Spring MockMvc/WebTestClient and Ktor (`testApplication { client.get("/path") }` + `handleRequest(HttpMethod.Get, "/path")`). The shared (language-agnostic) `engine.linkE2ERouteTestsToEndpoints` pass emits the endpoint TESTS edge — no engine change.

**Honest exclusion preserved**: factory-/`make()`-/untyped-`mockk()`-returning receivers and shape-only specs stay bare.

The original #4375 negative test (`val order = OrderService(); order.place()` stays bare) is **deliberately upgraded** — it now binds to the imported `OrderService` (not the colliding billing one); the test is updated with a factory-returned receiver as the genuine negative plus a new positive for ctor-local typing.

## Coverage docs
Updated the Kotlin `Testing.tests_linkage` cells (spring-boot, ktor, kotest and the shared JVM-framework cell) with the #4687 capability + cites. Surgical edit; `coverage fmt --check` passes (canonical).

## Validation (RED→GREEN exact-mirror fixtures)
- `issue4687_localvar_receiver_test.go` — ctor / type-annotation / `@InjectMockKs` / `mockk<T>()` receivers resolve to the class method; Kotest scope owner; negatives (factory receiver, untyped `mockk()`, shape-only spec).
- `tests_route_e2e_test.go` — MockMvc / WebTestClient / Ktor client / `handleRequest` capture + production-file skip.
- `http_endpoint_e2e_testmap_4687_test.go` — Spring + Ktor route hits link to the endpoint end-to-end.

## Gates
`go build ./...`, `go vet`, `go test ./internal/extractors/... ./internal/custom/... ./internal/graph/... ./internal/engine/... ./internal/types/ ./internal/resolve/...` (97 ok, 0 fail), `coverage fmt --check` — all green.

Closes #4687
Part of #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)