### PR TITLE
feat(elixir): Phoenix ConnTest test→endpoint route-hit coverage linkage (#4688)

### DIFF
--- a/internal/custom/elixir/tests_route_e2e.go
+++ b/internal/custom/elixir/tests_route_e2e.go
@@ -1,0 +1,184 @@
+// Package elixir — Elixir/Phoenix test→endpoint route-hit linkage.
+//
+// #4688 (the Elixir/Phoenix slice of epic #4615, all-framework test→endpoint
+// coverage linkage; CLOSES #4688). Emits ONE test_suite entity per Elixir
+// ExUnit test file that drives an HTTP endpoint by ROUTE STRING via Phoenix
+// ConnTest, stamping the captured `VERB route` pairs onto the suite's
+// `e2e_route_calls` property. The shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index and emits a TESTS edge
+// to the exact endpoint exercised — exactly as the Java junit5, Kotlin, Ruby,
+// PHP and C# slices do for their stacks. The engine pass is language-agnostic
+// (it fires on any test_suite carrying e2e_route_calls), so the only
+// Elixir-specific work is the route capture.
+//
+// Phoenix ConnTest route-driving idioms captured:
+//   - Piped form:     conn |> get("/api/v1/x") / conn |> post("/api/v1/x", %{})
+//   - Direct form:    get(conn, "/api/v1/x") / post(conn, "/api/v1/x", params)
+//     for the verbs get/post/put/patch/delete (the ConnTest request macros).
+//
+// Elixir is FUNCTIONAL: there are no OO receiver objects, so the
+// "local-variable receiver typing" gap (#4680/#4681) does NOT apply — Phoenix
+// dispatch is keyed by the literal route string, not by an `obj.method()`
+// receiver. The route-hit → endpoint linkage IS the coverage mechanism here.
+//
+// Honest exclusion (matches the negative acceptance of #4688):
+//   - Router-helper form `get(conn, Routes.x_path(conn, :action))` — the path
+//     is not a string literal and is not statically recoverable here, so it is
+//     dropped (router-helper-form limit noted in the coverage registry).
+//   - Interpolated / variable routes (`get(conn, "/x/#{id}")`, `get(conn, path)`)
+//     are dropped — no static route to match.
+//   - Shape-only tests (assert on a struct, never hit a route) emit no suite.
+//
+// Registration key: "custom_elixir_tests_route_e2e".
+package elixir
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_elixir_tests_route_e2e", &elixirTestRouteE2EExtractor{})
+}
+
+type elixirTestRouteE2EExtractor struct{}
+
+func (e *elixirTestRouteE2EExtractor) Language() string {
+	return "custom_elixir_tests_route_e2e"
+}
+
+var (
+	// Direct ConnTest macro form: get(conn, "/api/v1/x") /
+	// post(conn, "/api/v1/x", params). The first arg is the conn, the second a
+	// string-literal route. Anchored on a word boundary so it is not confused
+	// with a piped `|> get(...)` (which has the route as its FIRST arg).
+	elxConnTestDirectRE = regexp.MustCompile(
+		`\b(get|post|put|patch|delete)\s*\(\s*conn\s*,\s*"([^"\n\r]*)"`)
+
+	// Piped ConnTest form: conn |> get("/api/v1/x") / |> post("/api/v1/x", %{}).
+	// The route is the first string-literal argument after the verb. Anchored on
+	// the pipe operator so the production router macro `get "/x", Ctrl, :act`
+	// (no parenthesis, no pipe) is never captured.
+	elxConnTestPipedRE = regexp.MustCompile(
+		`\|>\s*(get|post|put|patch|delete)\s*\(\s*"([^"\n\r]*)"`)
+)
+
+func (e *elixirTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "elixir" {
+		return nil, nil
+	}
+	if !isElixirTestFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectElixirTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       elixirTestSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "elixir",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "phoenix",
+			"provenance":      "INFERRED_FROM_ELIXIR_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectElixirTestRouteCalls returns the de-duplicated "VERB route" pairs a
+// Phoenix ConnTest test file drives by route string (direct and piped forms).
+// Routes are normalised to a leading-slash path; interpolated / variable /
+// router-helper routes (non-path literals) are dropped (honest exclusion).
+func collectElixirTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		route := normaliseElixirTestRoute(rawRoute)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		// Drop interpolated routes — `#{...}` is not statically recoverable.
+		if strings.Contains(route, "#{") {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	for _, m := range elxConnTestDirectRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range elxConnTestPipedRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	return out
+}
+
+// normaliseElixirTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix, drops query/fragment, collapses repeated slashes.
+// Phoenix path-param placeholders (`:id`) and casing are preserved (the
+// resolver wildcards templates and compares case-insensitively).
+func normaliseElixirTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		// A bare `#` (fragment) truncates; `#{` interpolation is caught by the
+		// caller's contains check, which runs on the pre-truncation form only
+		// when the `#` is the interpolation sigil. Guard: keep `#{` intact so
+		// the caller can drop it.
+		if !strings.HasPrefix(p[q:], "#{") {
+			p = p[:q]
+		}
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
+}
+
+// isElixirTestFile reports whether path looks like an ExUnit test source — an
+// `*_test.exs` file or a file under a `/test/` directory. Keeps the route-hit
+// suite off production controllers/routers that merely mention a route.
+func isElixirTestFile(path string) bool {
+	lp := strings.ToLower(filepath.ToSlash(path))
+	if strings.HasSuffix(lp, "_test.exs") {
+		return true
+	}
+	if strings.Contains(lp, "/test/") && strings.HasSuffix(lp, ".exs") {
+		return true
+	}
+	return false
+}
+
+// elixirTestSuiteBaseName derives a suite label from the test file path
+// (`.../count_controller_test.exs` → `count_controller_test`).
+func elixirTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/custom/elixir/tests_route_e2e_test.go
+++ b/internal/custom/elixir/tests_route_e2e_test.go
@@ -1,0 +1,133 @@
+package elixir
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4688 — Phoenix ConnTest route-hit capture unit tests (extractor side).
+
+func extractElixirRouteSuite(t *testing.T, path, src string) (types.EntityRecord, bool) {
+	t.Helper()
+	ex := &elixirTestRouteE2EExtractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path: path, Language: "elixir", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			return e, true
+		}
+	}
+	return types.EntityRecord{}, false
+}
+
+func routeCallSet(e types.EntityRecord) map[string]bool {
+	out := map[string]bool{}
+	for _, l := range strings.Split(e.Properties["e2e_route_calls"], "\n") {
+		if l != "" {
+			out[l] = true
+		}
+	}
+	return out
+}
+
+func TestElixirRouteE2E_PipedAndDirect(t *testing.T) {
+	src := `defmodule MyAppWeb.XControllerTest do
+  use MyAppWeb.ConnCase
+  test "a", %{conn: conn} do
+    conn = conn |> get("/api/v1/x/get_counts")
+    conn = post(conn, "/api/v1/x", %{a: 1})
+    conn = conn |> put("/api/v1/x/1")
+    conn = patch(conn, "/api/v1/x/1")
+    conn = conn |> delete("/api/v1/x/1")
+  end
+end
+`
+	e, ok := extractElixirRouteSuite(t, "test/x_controller_test.exs", src)
+	if !ok {
+		t.Fatal("expected a test_suite")
+	}
+	got := routeCallSet(e)
+	for _, want := range []string{
+		"GET /api/v1/x/get_counts",
+		"POST /api/v1/x",
+		"PUT /api/v1/x/1",
+		"PATCH /api/v1/x/1",
+		"DELETE /api/v1/x/1",
+	} {
+		if !got[want] {
+			t.Errorf("missing route call %q; got %v", want, got)
+		}
+	}
+	if e.Properties["framework"] != "phoenix" {
+		t.Errorf("framework = %q, want phoenix", e.Properties["framework"])
+	}
+}
+
+func TestElixirRouteE2E_ShapeOnlyNoSuite(t *testing.T) {
+	// Asserts on a struct, never hits a route → no suite (honest exclusion).
+	src := `defmodule MyApp.UserTest do
+  use ExUnit.Case
+  test "builds a user struct" do
+    user = %User{name: "x"}
+    assert user.name == "x"
+  end
+end
+`
+	if _, ok := extractElixirRouteSuite(t, "test/user_test.exs", src); ok {
+		t.Fatal("shape-only test must NOT emit a route-hit suite")
+	}
+}
+
+func TestElixirRouteE2E_InterpolatedAndHelperDropped(t *testing.T) {
+	// Interpolated route + router-helper form are not statically recoverable.
+	src := `defmodule MyAppWeb.XControllerTest do
+  use MyAppWeb.ConnCase
+  test "dynamic", %{conn: conn} do
+    id = 1
+    conn = conn |> get("/api/v1/x/#{id}")
+    conn = get(conn, Routes.x_path(conn, :show, id))
+    conn = conn |> get(path)
+  end
+  test "static control", %{conn: conn} do
+    conn = conn |> get("/api/v1/x/static")
+  end
+end
+`
+	e, ok := extractElixirRouteSuite(t, "test/x_controller_test.exs", src)
+	if !ok {
+		t.Fatal("expected a test_suite from the static control call")
+	}
+	got := routeCallSet(e)
+	if !got["GET /api/v1/x/static"] {
+		t.Errorf("expected the static route to survive; got %v", got)
+	}
+	for bad := range got {
+		if strings.Contains(bad, "#{") || strings.Contains(bad, "Routes.") {
+			t.Errorf("dynamic/helper route leaked: %q", bad)
+		}
+	}
+	if len(got) != 1 {
+		t.Errorf("expected exactly 1 captured route, got %d: %v", len(got), got)
+	}
+}
+
+func TestElixirRouteE2E_NonTestFileIgnored(t *testing.T) {
+	// A production controller that mentions a route string must not be a suite.
+	src := `defmodule MyAppWeb.XController do
+  def index(conn, _params) do
+    get(conn, "/api/v1/x")
+  end
+end
+`
+	if _, ok := extractElixirRouteSuite(t, "lib/my_app_web/controllers/x_controller.ex", src); ok {
+		t.Fatal("non-test file must not emit a route-hit suite")
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4688_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4688_test.go
@@ -1,0 +1,102 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Elixir route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/elixir"
+)
+
+// Issue #4688 LIVE-REPRO (resolve side) — Phoenix ConnTest tests.
+//
+// Proves end-to-end that an Elixir/Phoenix ExUnit test calling a route by
+// string — direct `get(conn, "/api/v1/...")` and piped `conn |> get("/...")` —
+// links to the http_endpoint_definition it exercises. The Elixir slice of the
+// all-language program (#4615), generalizing #4351 / #4369 / #4370 / #4371 /
+// #4684 / #4685 / #4686 / #4687. The shared linkE2ERouteTestsToEndpoints pass
+// is language-agnostic; only the Elixir route capture is new. Elixir is
+// functional (no OO receiver objects) so receiver typing does not apply; the
+// route-string → endpoint linkage is the coverage mechanism.
+
+const elxPipedTestSrc4688 = `defmodule MyAppWeb.ProposalControllerTest do
+  use MyAppWeb.ConnCase
+
+  test "lists counts", %{conn: conn} do
+    conn = conn |> get("/api/v1/proposals/get_counts")
+    assert json_response(conn, 200)
+  end
+
+  test "creates a proposal", %{conn: conn} do
+    conn = conn |> post("/api/v1/proposals", %{name: "x"})
+    assert json_response(conn, 201)
+  end
+end
+`
+
+const elxDirectTestSrc4688 = `defmodule MyAppWeb.XControllerTest do
+  use MyAppWeb.ConnCase
+
+  test "gets counts", %{conn: conn} do
+    conn = get(conn, "/api/v1/proposals/get_counts")
+    assert json_response(conn, 200)
+  end
+
+  test "creates", %{conn: conn} do
+    conn = post(conn, "/api/v1/proposals", %{name: "x"})
+    assert json_response(conn, 201)
+  end
+end
+`
+
+func TestIssue4688_ElixirPhoenixPipedE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/proposals/get_counts"),
+		def("POST", "/api/v1/proposals"),
+	}
+	suite := realSuite(t, "custom_elixir_tests_route_e2e",
+		"test/my_app_web/controllers/proposal_controller_test.exs", "elixir", elxPipedTestSrc4688)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertElxRouteEdges(t, edgeTargets(afterOut))
+}
+
+func TestIssue4688_ElixirPhoenixDirectE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/proposals/get_counts"),
+		def("POST", "/api/v1/proposals"),
+	}
+	suite := realSuite(t, "custom_elixir_tests_route_e2e",
+		"test/my_app_web/controllers/x_controller_test.exs", "elixir", elxDirectTestSrc4688)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertElxRouteEdges(t, edgeTargets(afterOut))
+}
+
+func assertElxRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/proposals/get_counts") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/proposals") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /api/v1/proposals/get_counts; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /api/v1/proposals; targets=%v", targets)
+	}
+}


### PR DESCRIPTION
## Summary
Elixir/Phoenix slice of the all-framework **test→endpoint coverage linkage** epic (#4615) — the final language in the matrix after TS/JS (#4680), Python (#4716), Java (#4717), Go (#4718), Ruby (#4719), C# (#4720), PHP (#4721), Kotlin (#4723). **Closes #4688.**

## What was RED vs already covered
Probe found Elixir already had a `Testing.tests_linkage` cell (status `full`, #3473) for **ExUnit unit-test→subject** linkage via the cross testmap. The genuinely RED dimension was the **Phoenix ConnTest e2e route-hit → http_endpoint_definition** linkage — there was **no** Elixir producer of `e2e_route_calls` (grep confirmed: every other language had one, Elixir did not).

## The route-hit producer (new)
`internal/custom/elixir/tests_route_e2e.go` (registration key `custom_elixir_tests_route_e2e`; the `internal/custom/elixir` package is already blank-imported in `custom_registry.go`). Emits **one `test_suite` per ExUnit test file** that drives an endpoint by route string, stamping `VERB route` pairs onto `e2e_route_calls`. The shared, language-agnostic `engine.linkE2ERouteTestsToEndpoints` pass (#4351/#4369) then matches each pair to the cross-file endpoint index and emits the `TESTS` edge — exactly as the Java/Kotlin/Ruby/PHP/C# slices do.

Captured Phoenix ConnTest idioms:
- **Direct:** `get(conn, "/p")` / `post`/`put`/`patch`/`delete(conn, "/p", params)`
- **Piped:** `conn |> get("/p")` / `conn |> post("/p", %{})`

## Why receiver typing does NOT apply
Elixir is **functional** — calls are module-qualified `Module.function(...)` or piped, not `obj.method()`. There are no OO receiver objects, so the local-variable receiver typing generalized for TS/JS in #4680 has no analogue here. Phoenix dispatch is keyed by the **literal route string**, so the route-hit→endpoint linkage IS the coverage mechanism.

## ExUnit scope-owner?
**Not needed.** The per-file `test_suite` already owns its route calls via the `e2e_route_calls` property (the engine reads the property off the suite). This mirrors every prior non-anonymous-block slice (Java/Kotlin/Ruby/PHP/C#). No zero-call-bearing-entity gap to fill for the route-hit mechanism.

## Honest exclusion
- Interpolated routes `"/x/#{id}"` — dropped (not statically recoverable)
- Variable routes `get(conn, path)` — dropped
- Router-helper form `get(conn, Routes.x_path(conn, :act))` — dropped (path not a string literal; limit noted in the registry)
- Shape-only tests (assert on a struct, never hit a route) — no suite
- Non-test files (`lib/.../*.ex` controllers mentioning a route) — ignored

## Coverage registry
Surgical canonical edit to the Elixir `phoenix` `Testing.tests_linkage` cell (3 lines): added the two new cites + an addendum documenting the ConnTest route-hit linkage and the router-helper-form limit; `verified_at` bumped. `go run ./tools/coverage fmt --check` → canonical.

## Fixtures (exact-mirror, RED→GREEN)
- Engine `internal/engine/http_endpoint_e2e_testmap_4688_test.go`: piped + direct forms, control strips `e2e_route_calls` → 0 edges, AFTER → `TESTS` edge to exact `GET /api/v1/proposals/get_counts` + `POST /api/v1/proposals`.
- Extractor `internal/custom/elixir/tests_route_e2e_test.go`: all 5 verbs (piped+direct); shape-only → no suite; interpolated + router-helper + variable route dropped while the static control survives; non-test file ignored.

## Gates
`go build ./...`, `go vet ./internal/extractors/... ./internal/custom/... ./internal/graph/...`, full `go test` over extractors/custom/graph/engine/types, and `coverage fmt --check` — all green.

Part of #4615

🤖 Generated with [Claude Code](https://claude.com/claude-code)