### PR TITLE
fix(resolve): Python external pip packages must not count as fidelity bugs (#4699)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -184,6 +184,26 @@ func Synthesize(doc *graph.Document) Stats {
 		}
 	}
 
+	// #4699 — internal Python module roots. The Python catch-all in
+	// classifyExternal (pyExternalPackageRoot) needs to distinguish a
+	// genuinely-internal same-repo import that failed to resolve (still a
+	// fidelity bug) from a third-party pip package (NOT a bug). We derive
+	// the set of top-level package roots owned by this repo from the
+	// SourceFile of every indexed Python entity, applying the same
+	// source-root stripping the Python extractor's filePathToModule uses
+	// (src/, lib/, app/). An unresolved non-relative import whose root is
+	// NOT in this set is, by construction, an external pip dependency.
+	internalPyRoots := make(map[string]bool)
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.Language != "python" || e.SourceFile == "" {
+			continue
+		}
+		if root := pythonFileRoot(e.SourceFile); root != "" {
+			internalPyRoots[root] = true
+		}
+	}
+
 	// First pass — collect every unique external name we want to
 	// synthesise. The placeholder carries a subtype hint
 	// ("package"/"function") but the language field is left empty:
@@ -243,7 +263,7 @@ func Synthesize(doc *graph.Document) Stats {
 			continue
 		}
 
-		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, lang, entityFile[rel.FromID], fileImports[entityFile[rel.FromID]], rel.Properties)
+		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, lang, entityFile[rel.FromID], fileImports[entityFile[rel.FromID]], rel.Properties, internalPyRoots)
 		if !ok {
 			continue
 		}
@@ -500,7 +520,7 @@ func SynthesizeDBEntities(doc *graph.Document) Stats {
 // Returns ("", "", false) when the stub doesn't look external — those
 // are left untouched and continue to count as "unmatched" in the
 // resolver stats.
-func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[string]bool, relProps map[string]string) (canonical, subtype string, ok bool) {
+func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[string]bool, relProps map[string]string, internalPyRoots map[string]bool) (canonical, subtype string, ok bool) {
 	if stub == "" {
 		return "", "", false
 	}
@@ -1208,6 +1228,37 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 	// as follow-ups.
 	if (lang == "javascript" || lang == "typescript") && relKind == string(types.RelationshipKindImports) {
 		if pkg, ok := jsExternalPackageRoot(stub, relProps); ok {
+			return pkg, "package", true
+		}
+	}
+
+	// #4699 — Python bare-root external (pip) packages. The Python instance
+	// of the cross-ecosystem program started by #4695 (TS/JS). By the time a
+	// Python IMPORTS edge reaches this point its ToID is a raw dotted-module
+	// stub: the in-tree resolver (which binds internal imports to hex IDs via
+	// the source_module + imported_name reverse index BEFORE ext-synthesis)
+	// has already had its chance, and the Python extractor's static allowlist
+	// (pythonKnownExternalRoots) didn't fire. A non-relative import whose
+	// top-level package root is NOT a module owned by this repo is — by
+	// construction — a third-party pip dependency (pendulum, structlog,
+	// rest_framework, celery, pydantic, …). pip packages are correctly NOT
+	// indexed, so route them to an ext:<root> placeholder (external_package
+	// disposition) instead of leaving a bug-extractor stub that inflates the
+	// import-bug count and depresses the fidelity badge.
+	//
+	// Crucially, this does NOT mask a genuinely-internal unresolved import: a
+	// same-repo module path (root ∈ internalPyRoots) is rejected here and
+	// keeps counting as a fidelity bug, so real under-linking still surfaces.
+	// The internalPyRoots set is derived in Synthesize from the SourceFile of
+	// every indexed Python entity. The static pythonKnownExternalRoots
+	// allowlist can never keep pace with PyPI; this branch is the catch-all
+	// that trusts the in-tree resolver's "didn't resolve internally" signal,
+	// gated to IMPORTS (so it never swallows ambiguous bare CALLS/REFERENCES
+	// targets) and to lang=="python". Mirrors jsExternalPackageRoot (#4695);
+	// per-language siblings: #4700 (Java), #4701 (Ruby), #4702 (Go), #4703
+	// (Rust), #4704 (.NET).
+	if lang == "python" && relKind == string(types.RelationshipKindImports) {
+		if pkg, ok := pyExternalPackageRoot(stub, relProps, internalPyRoots); ok {
 			return pkg, "package", true
 		}
 	}
@@ -2066,6 +2117,138 @@ func isNpmSegment(s string) bool {
 		case c >= 'A' && c <= 'Z':
 		case c >= '0' && c <= '9':
 		case c == '_' || c == '-' || c == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// pythonFileRoot returns the top-level package root for a Python source
+// file path, applying the same source-root stripping the Python
+// extractor's filePathToModule uses (src/, lib/, app/). Used by
+// Synthesize to build the set of internal module roots owned by the repo.
+//
+//	"shop/order/views.py"     → "shop"
+//	"src/api/handlers.py"     → "api"
+//	"manage.py"               → "manage"
+//
+// Returns "" for an empty or non-Python-looking path.
+func pythonFileRoot(path string) string {
+	s := strings.TrimSpace(path)
+	if s == "" {
+		return ""
+	}
+	// Normalise to forward slashes (archigraph entity refs already do this,
+	// but be defensive for Windows-shaped inputs).
+	s = strings.ReplaceAll(s, "\\", "/")
+	// Strip well-known source-root prefixes (mirrors filePathToModule /
+	// resolve.sourceRootPrefixes). Only one prefix is stripped, matching
+	// the extractor.
+	for _, prefix := range []string{"src/", "lib/", "app/"} {
+		if strings.HasPrefix(s, prefix) {
+			s = strings.TrimPrefix(s, prefix)
+			break
+		}
+	}
+	// Leading "./" or "/" — drop so the first real segment is the root.
+	s = strings.TrimPrefix(s, "./")
+	s = strings.TrimPrefix(s, "/")
+	if s == "" {
+		return ""
+	}
+	root := s
+	if i := strings.IndexByte(root, '/'); i > 0 {
+		root = root[:i]
+	}
+	// Strip a trailing ".py" when the file sits at the repo root (no
+	// directory), e.g. "manage.py" → "manage".
+	root = strings.TrimSuffix(root, ".py")
+	return root
+}
+
+// pyExternalPackageRoot derives the canonical pip package root for a
+// Python IMPORTS edge that survived in-tree resolution, returning
+// (root, true) when the import's top-level package is a third-party pip
+// dependency rather than a same-repo module (#4699).
+//
+// The raw dotted module is read from relProps["source_module"] when present
+// (the Python extractor stamps it there) and falls back to the dotted stub
+// (the IMPORTS edge ToID is the module path) otherwise.
+//
+// Resolution:
+//   - "" / "." / relative (".foo", "..pkg")  → reject (relative imports are
+//     resolved to absolute form upstream; any residual dot-prefix is
+//     in-tree and must keep its bug disposition).
+//   - root segment ∈ internalPyRoots          → reject (genuinely-internal
+//     module that failed to resolve — STILL a fidelity bug, never masked).
+//   - otherwise                                → first dot-segment, lowercased
+//     ("celery.app.task" → "celery", "rest_framework" → "rest_framework").
+//
+// The root must be a legal Python identifier segment; anything else
+// (whitespace, path separators, structural-ref residue) is rejected so
+// malformed stubs still surface as bugs.
+func pyExternalPackageRoot(stub string, relProps map[string]string, internalPyRoots map[string]bool) (string, bool) {
+	spec := stub
+	if relProps != nil {
+		if sm := strings.TrimSpace(relProps["source_module"]); sm != "" {
+			spec = sm
+		}
+	}
+	spec = strings.TrimSpace(spec)
+	if spec == "" {
+		return "", false
+	}
+	// Relative imports (`from . import x`, `from ..pkg import y`) are
+	// resolved to absolute dotted form by the extractor, but defend against
+	// any residual dot-prefix — those are in-tree, never external.
+	if strings.HasPrefix(spec, ".") {
+		return "", false
+	}
+	// Path/namespace separators or structural-ref residue mean this isn't a
+	// clean Python dotted module — leave it as a bug.
+	if strings.ContainsAny(spec, "/\\:") {
+		return "", false
+	}
+	root := spec
+	if i := strings.IndexByte(root, '.'); i > 0 {
+		root = root[:i]
+	}
+	if !isPyImportSegment(root) {
+		return "", false
+	}
+	// Genuinely-internal module that failed to resolve — keep it a bug.
+	// Match on the lowercased root too, so a case-variant internal package
+	// can't slip through as external.
+	if internalPyRoots != nil {
+		if internalPyRoots[root] || internalPyRoots[strings.ToLower(root)] {
+			return "", false
+		}
+	}
+	// Parity with the Python extractor's ext: convention (pythonKnownExternalRoots
+	// lookup is case-folded) and the lowercase ext:<pkg> placeholder used
+	// across ecosystems.
+	return strings.ToLower(root), true
+}
+
+// isPyImportSegment reports whether s is a legal top-level Python package
+// identifier segment: starts with a letter or underscore, followed by
+// letters, digits, or underscores. Hyphens (legal in PyPI distribution
+// names but NOT in import names) are rejected — the import root is always a
+// valid Python identifier.
+func isPyImportSegment(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '_':
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false
+			}
 		default:
 			return false
 		}

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -8,6 +8,24 @@ import (
 	"github.com/cajasmota/archigraph/internal/resolve"
 )
 
+// isBugEdgeToID mirrors internal/mcp.isBugEdgeToID for #4699 fixtures: a
+// ToID that is neither a 16-char hex entity ID nor an ext:-prefixed external
+// reference is an unresolved stub that counts as a fidelity bug. Duplicated
+// here because internal/mcp can't be imported from internal/external tests
+// (import-cycle risk); kept in lockstep with the canonical definition.
+func isBugEdgeToID(toID string) bool {
+	if toID == "" {
+		return false
+	}
+	if len(toID) == 16 && isHexID(toID) {
+		return false
+	}
+	if strings.HasPrefix(toID, "ext:") {
+		return false
+	}
+	return true
+}
+
 // assertCrossLangGate is the canonical structural assertion for the
 // per-language gate at classification time (issue #516). For each
 // (name, otherLang) pair it verifies the gate's actual runtime
@@ -421,6 +439,100 @@ func TestSynthesize_JSRelativeImportNotExternal(t *testing.T) {
 		Relationships: []graph.Relationship{
 			{ID: "rel-1", FromID: "aaaaaaaaaaaaaaaa", ToID: "src.b", Kind: "IMPORTS",
 				Properties: map[string]string{"language": "typescript", "import_path": "./b"}},
+		},
+	}
+	Synthesize(doc)
+	for _, r := range doc.Relationships {
+		if strings.HasPrefix(r.ToID, "ext:") {
+			t.Errorf("relative import wrongly externalised: ToID=%q", r.ToID)
+		}
+	}
+}
+
+// TestSynthesize_PyExternalPackages_Fixture is Fixture A for #4699: a Python
+// file importing third-party pip packages whose roots are NOT on the static
+// pythonKnownExternalRoots allowlist (rest_framework, celery, pydantic) must be
+// routed to ext:<package> placeholders (disposition external_package) rather
+// than left as bug-extractor stubs. The only indexed Python entity lives under
+// the "shop" package, so none of these roots are internal — they are pip deps.
+func TestSynthesize_PyExternalPackages_Fixture(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "aaaaaaaaaaaaaaaa", Name: "shop/views.py", Language: "python", SourceFile: "shop/views.py"},
+		},
+		Relationships: []graph.Relationship{
+			// from rest_framework import serializers
+			{ID: "rel-1", FromID: "aaaaaaaaaaaaaaaa", ToID: "rest_framework.serializers", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "python", "source_module": "rest_framework", "imported_name": "serializers"}},
+			// from celery import shared_task
+			{ID: "rel-2", FromID: "aaaaaaaaaaaaaaaa", ToID: "celery.shared_task", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "python", "source_module": "celery", "imported_name": "shared_task"}},
+			// import pydantic
+			{ID: "rel-3", FromID: "aaaaaaaaaaaaaaaa", ToID: "pydantic", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "python", "source_module": "pydantic", "imported_name": "pydantic"}},
+		},
+	}
+	Synthesize(doc)
+
+	want := map[string]string{
+		"rel-1": "ext:rest_framework",
+		"rel-2": "ext:celery",
+		"rel-3": "ext:pydantic",
+	}
+	for _, r := range doc.Relationships {
+		if exp, ok := want[r.ID]; ok && r.ToID != exp {
+			t.Errorf("%s ToID=%q, want %q", r.ID, r.ToID, exp)
+		}
+	}
+	// Control: none of these may remain a bug-extractor stub.
+	for _, r := range doc.Relationships {
+		if isBugEdgeToID(r.ToID) {
+			t.Errorf("%s wrongly counts as a fidelity bug: ToID=%q", r.ID, r.ToID)
+		}
+	}
+}
+
+// TestSynthesize_PyInternalUnresolvedStillBug is Fixture B for #4699 (the
+// control): a genuinely-internal same-repo import that failed to resolve must
+// STILL count as a fidelity bug — the external-package catch-all must NOT mask
+// real under-linking. Here "shop" is an indexed internal package, so an
+// unresolved `from shop.missing import Thing` keeps its bug disposition.
+func TestSynthesize_PyInternalUnresolvedStillBug(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "aaaaaaaaaaaaaaaa", Name: "shop/views.py", Language: "python", SourceFile: "shop/views.py"},
+			{ID: "bbbbbbbbbbbbbbbb", Name: "shop/models.py", Language: "python", SourceFile: "shop/models.py"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "aaaaaaaaaaaaaaaa", ToID: "shop.missing.Thing", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "python", "source_module": "shop.missing", "imported_name": "Thing"}},
+		},
+	}
+	Synthesize(doc)
+	for _, r := range doc.Relationships {
+		if r.ID != "rel-1" {
+			continue
+		}
+		if strings.HasPrefix(r.ToID, "ext:") {
+			t.Errorf("internal unresolved import wrongly externalised: ToID=%q", r.ToID)
+		}
+		if !isBugEdgeToID(r.ToID) {
+			t.Errorf("internal unresolved import should remain a fidelity bug, ToID=%q", r.ToID)
+		}
+	}
+}
+
+// TestSynthesize_PyRelativeImportNotExternal confirms the #4699 branch does
+// NOT externalise a residual relative-import source_module — a dot-prefixed
+// module is project-internal and must keep its bug disposition.
+func TestSynthesize_PyRelativeImportNotExternal(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "aaaaaaaaaaaaaaaa", Name: "shop/views.py", Language: "python", SourceFile: "shop/views.py"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "aaaaaaaaaaaaaaaa", ToID: ".sibling.helper", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "python", "source_module": ".sibling", "imported_name": "helper"}},
 		},
 	}
 	Synthesize(doc)


### PR DESCRIPTION
Python instance of the cross-ecosystem program started by #4695 (TS/JS): an external pip dependency import must never count as a fidelity bug.

## Problem
A bare `import X` / `from X.y import z` whose top-level package root is a third-party pip dependency (not a same-repo module, not relative) was left as a bug-extractor stub whenever `X` wasn't on the static `pythonKnownExternalRoots` allowlist (e.g. `pendulum`, `structlog`, or any of the long PyPI tail). These inflate `fidelity_import_bug` and depress the fidelity badge on the upvate Django ORACLE group (which imports `django`, `rest_framework`, `celery`, `pydantic`, …).

## Fix
New Python catch-all in `internal/external/synth.go` `classifyExternal` (`pyExternalPackageRoot`), gated to `IMPORTS` + `lang=="python"`, mirroring the JS/TS `jsExternalPackageRoot` branch added in #4706.

By the time a Python IMPORTS edge reaches ext-synthesis, the in-tree resolver (`source_module` + `imported_name` reverse index) has already bound internal imports to hex IDs. A non-relative import whose root is **not** a module owned by this repo is, by construction, an external pip dependency → routed to `ext:<root>` (`external_package` disposition), excluded from `fidelity_import_bug` via `isBugEdgeToID`.

### Internal-vs-external rule
`Synthesize` derives `internalPyRoots` from the `SourceFile` of every indexed Python entity (`pythonFileRoot` applies the same `src/`/`lib/`/`app/` source-root stripping as the extractor's `filePathToModule`). A root in `internalPyRoots` is a genuinely-internal unresolved import and **STILL** counts as a bug — the catch-all never masks real under-linking. The static allowlist can never keep pace with PyPI; this branch trusts the resolver's "didn't resolve internally" signal. Relative imports (any residual dot-prefix) are rejected.

## Fixtures (`internal/external/synth_test.go`)
- **A**: `rest_framework` + `celery` + `pydantic` imports → each `ext:<pkg>`, none counted as a fidelity bug.
- **B (control)**: an unresolved `from shop.missing import Thing` where `shop` is an indexed internal package → STILL a fidelity bug, not externalised.
- **Relative control**: a residual dot-prefixed `source_module` is not externalised.

## Coverage docs
Surgically updated the `django-drf` `import_resolution_quality` cell in `docs/coverage/registry.json` to cite `internal/external/synth.go` + issue 4699 (status stays `partial`). `coverage fmt --check` passes. Single-cell diff, no re-serialization.

## Gates
`go build ./...`, `go vet`, and `go test` green on `internal/external/...`, `internal/mcp/...`, `internal/extractors/...`; `coverage fmt --check` canonical.

## Generalize
Per-language siblings: #4700 (Java/maven), #4701 (Ruby/gems), #4702 (Go/module), #4703 (Rust/crates), #4704 (.NET/nuget).

Closes #4699

🤖 Generated with [Claude Code](https://claude.com/claude-code)