### PR TITLE
fix(authposture): DRF effective permission precedence (method ▸ class ▸ global) (#4675)

### DIFF
--- a/internal/authposture/authposture_test.go
+++ b/internal/authposture/authposture_test.go
@@ -384,3 +384,112 @@ func TestNest_EffectiveGuard_ExplicitPublic(t *testing.T) {
 		t.Fatalf("got %s/%s, want nestjs/public", fw, p.Kind)
 	}
 }
+
+// --- #4675: DRF EFFECTIVE permission precedence (method ▸ class ▸ global) -----
+//
+// The DRF analog of the NestJS effective-guard fix. The resolver must resolve
+// the most-specific permission: a per-action `@action(permission_classes=…)`
+// override or a `get_permissions` per-action arm ▸ the class permission_classes
+// ▸ the global REST_FRAMEWORK DEFAULT_PERMISSION_CLASSES.
+
+// (A) ViewSet class permission_classes=[IsAuthenticated] with an
+// @action(permission_classes=[AllowAny]). The extractor stamps the per-action
+// `permission_classes` onto the action endpoint, so the action resolves PUBLIC
+// while a sibling (carrying the inherited class value) resolves authenticated.
+func TestDRF_ActionPermissionClasses_OverridesClass(t *testing.T) {
+	reg := NewRegistry()
+	// The @action override endpoint: permission_classes=[AllowAny] (per-action).
+	action, fw := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "django", "permission_classes": "AllowAny",
+	}, Action: "ping"})
+	if fw != "django-drf" {
+		t.Fatalf("framework=%s, want django-drf", fw)
+	}
+	if action.Kind != KindPublic {
+		t.Fatalf("action: got %s, want public (@action(permission_classes=[AllowAny]) overrides class)", action.Kind)
+	}
+	// A sibling action that inherits the class default: the extractor stamps the
+	// CLASS permission_classes onto its endpoint (=[IsAuthenticated]).
+	sib, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "django", "has_permission_classes": "true", "permission_classes": "IsAuthenticated",
+	}, Action: "list"})
+	if sib.Kind != KindAuthenticated {
+		t.Fatalf("sibling: got %s, want authenticated (inherited class default)", sib.Kind)
+	}
+}
+
+// (B) get_permissions with `if self.action == 'x': return [AllowAny()]` else the
+// class default → action x is public (method-level arm), others get the else
+// class/default arm.
+func TestDRF_GetPermissions_PerActionPublic_ElseClass(t *testing.T) {
+	src := `
+def get_permissions(self):
+    if self.action == "open":
+        return [AllowAny()]
+    else:
+        return [IsAuthenticated()]
+`
+	reg := NewRegistry()
+	open, fw := reg.Resolve(Signal{
+		Props:  map[string]string{"has_get_permissions": "true"},
+		Source: src, Action: "open",
+	})
+	if fw != "django-drf" {
+		t.Fatalf("framework=%s, want django-drf", fw)
+	}
+	if open.Kind != KindPublic {
+		t.Fatalf("action open: got %s, want public (per-action arm)", open.Kind)
+	}
+	other, _ := reg.Resolve(Signal{
+		Props:  map[string]string{"has_get_permissions": "true"},
+		Source: src, Action: "list",
+	})
+	if other.Kind != KindAuthenticated {
+		t.Fatalf("action list: got %s, want authenticated (else/class arm)", other.Kind)
+	}
+}
+
+// (C) No class permission_classes and no get_permissions, but a global
+// REST_FRAMEWORK DEFAULT_PERMISSION_CLASSES=[IsAuthenticated] → endpoints resolve
+// authenticated via the global default.
+func TestDRF_GlobalDefault_AppliesWhenNoMethodOrClass(t *testing.T) {
+	reg := NewRegistry()
+	p, fw := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "django", "drf_default_permission_classes": "IsAuthenticated",
+	}})
+	if fw != "django-drf" {
+		t.Fatalf("framework=%s, want django-drf", fw)
+	}
+	if p.Kind != KindAuthenticated {
+		t.Fatalf("got %s, want authenticated (global DEFAULT_PERMISSION_CLASSES fallback)", p.Kind)
+	}
+}
+
+// Empty `permission_classes=[]` (extractor stamps NO prop) must fall through to
+// the global default, NOT resolve public — the empty-vs-AllowAny distinction.
+func TestDRF_EmptyPermissionClasses_FallsToGlobal(t *testing.T) {
+	reg := NewRegistry()
+	// No permission_classes prop (empty list ⇒ absent), only a global default.
+	p, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "django", "drf_default_permission_classes": "IsAuthenticated",
+	}, Action: "list"})
+	if p.Kind == KindPublic {
+		t.Fatalf("empty permission_classes=[] resolved PUBLIC; §4675 says it falls to the global default")
+	}
+	if p.Kind != KindAuthenticated {
+		t.Fatalf("got %s, want authenticated (global default)", p.Kind)
+	}
+}
+
+// Class permission_classes wins over the global default (precedence level 2 > 3).
+func TestDRF_ClassOverridesGlobalDefault(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "django", "has_permission_classes": "true",
+		"permission_classes":             "AllowAny",
+		"drf_default_permission_classes": "IsAuthenticated",
+	}})
+	if p.Kind != KindPublic {
+		t.Fatalf("got %s, want public (class permission_classes=[AllowAny] overrides global IsAuthenticated)", p.Kind)
+	}
+}

--- a/internal/authposture/django.go
+++ b/internal/authposture/django.go
@@ -1,5 +1,32 @@
 // django.go — the Django DRF auth-posture resolver, encoding the §10
-// get_permissions DECODE CONTRACT (ticket #4422) exactly.
+// get_permissions DECODE CONTRACT (ticket #4422) exactly, plus the EFFECTIVE
+// permission precedence (ticket #4675 — the DRF analog of the NestJS
+// effective-guard fix #4667/#4676).
+//
+// EFFECTIVE PERMISSION PRECEDENCE (most-specific wins, mirroring how DRF itself
+// resolves a request's permissions — #4675):
+//
+//	1. METHOD/ACTION level — a `@action(detail=…, permission_classes=[X])`
+//	   decorator on a ViewSet extra-action, OR the per-action arm of a branchy
+//	   `get_permissions(self)` keyed on `self.action`. Applies to THAT action
+//	   only; siblings keep the class default. (DRF resolves `get_permissions`
+//	   per request, and the @action kwarg overrides the class attribute for that
+//	   route.) NOTE the framework asymmetry: an APIView `get`/`post` method
+//	   CANNOT carry its own `permission_classes` (APIView is class-scoped), so for
+//	   an APIView the class value is already the effective one — only ViewSet
+//	   @action carries a method-level override.
+//	2. CLASS level — the ViewSet/APIView `permission_classes = [...]` attribute
+//	   (or the else/default arm of `get_permissions`). Applies to actions without
+//	   their own override.
+//	3. GLOBAL default — REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"], harvested as
+//	   the `drf_default_permission_classes` Signal prop. Applies when NEITHER a
+//	   method nor a class permission is specified.
+//
+// The empty-vs-AllowAny distinction is load-bearing for the precedence:
+//   - `permission_classes=[AllowAny]` ▸ PUBLIC, overriding the global default.
+//   - `permission_classes=[]` (empty) ▸ NO explicit grant → falls through to the
+//     GLOBAL default (NOT public). The extractor stamps no `permission_classes`
+//     prop for an empty list, so "absent prop" naturally means "fall to global".
 //
 // The oracle's authorization for a ViewSet action lives in a branchy
 // get_permissions(self) override that returns a different permission list per
@@ -79,30 +106,53 @@ func (d djangoDRFResolver) Resolve(sig Signal) (Posture, bool) {
 		sig.hasProp("has_permission_classes") ||
 		sig.prop("permission_classes") != "" ||
 		sig.prop("get_permissions_classes") != "" ||
+		sig.prop("drf_default_permission_classes") != "" ||
 		looksLikeGetPermissions(sig.Source)
 	if !isDRF {
 		return Posture{}, false
 	}
 
-	// Prefer the §10 branch decode when we have a get_permissions body AND an
-	// action to resolve for — that is the precise, branch-aware path.
+	// (1) METHOD/ACTION level — most specific, wins over class + global (#4675).
+	//
+	// (1a) The branchy `get_permissions(self)` per-action decode IS a method-level
+	// override (it returns a different list per self.action). The §10 decoder
+	// attributes the effective grant to sig.Action; its else/default arm is the
+	// CLASS-level fallthrough for un-named actions.
 	if looksLikeGetPermissions(sig.Source) {
 		if p, ok := decodeGetPermissions(sig.Source, sig.Action); ok {
 			return p, true
 		}
 	}
-
-	// Fallback: class-attribute permission_classes (no branchy override). This
-	// is the flat DRF posture, decoded from the comma-joined class list the
-	// extractor stamps (get_permissions_classes or permission_classes).
-	return decodePermissionClasses(d.classList(sig)), true
-}
-
-func (djangoDRFResolver) classList(sig Signal) string {
-	if v := sig.prop("get_permissions_classes"); v != "" {
-		return v
+	// (1b) An `@action(..., permission_classes=[X])` decorator override. The
+	// action endpoint entity carries the per-action `permission_classes` the
+	// extractor stamped from the decorator kwarg; it overrides the class default
+	// for THAT action only. (Siblings without the decorator carry no
+	// `permission_classes` prop and fall through to class/global below.) An empty
+	// `permission_classes=[]` stamps NO prop, so it correctly does NOT match here
+	// and falls to the global default — the empty-vs-AllowAny distinction.
+	if v := sig.prop("permission_classes"); v != "" {
+		return decodePermissionClasses(v), true
 	}
-	return sig.prop("permission_classes")
+
+	// (2) CLASS level — the ViewSet/APIView class-attribute permission list the
+	// extractor stamps (get_permissions_classes when a non-branchy get_permissions
+	// referenced classes, else the class permission_classes attribute, already
+	// handled at (1b)).
+	if v := sig.prop("get_permissions_classes"); v != "" {
+		return decodePermissionClasses(v), true
+	}
+
+	// (3) GLOBAL default — REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"]. Applies
+	// only when neither a method (1) nor a class (2) permission was specified.
+	if v := sig.prop("drf_default_permission_classes"); v != "" {
+		p := decodePermissionClasses(v)
+		p.Detail = "global DEFAULT_PERMISSION_CLASSES: " + v + " (" + string(p.Kind) + ")"
+		return p, true
+	}
+
+	// Recognised as DRF but no method/class/global permission resolved → unknown
+	// (never false-public).
+	return Posture{Kind: KindUnknown, Detail: "DRF endpoint with no resolvable permission_classes / get_permissions / global default"}, true
 }
 
 // looksLikeGetPermissions reports whether src is a get_permissions method body.


### PR DESCRIPTION
Follow-up to the NestJS effective-guard fix (#4667/#4676), generalized to Django DRF per the all-framework mandate (epic #4419). Sharpens the upvate Django ORACLE's per-endpoint auth posture that feeds the rewrite agent's `auth_posture_diff` parity (#4550).

## What changed
The DRF auth-posture resolver (`internal/authposture/django.go`) now computes the EFFECTIVE permission with **most-specific-wins** precedence:

1. **Method/action level** — `@action(..., permission_classes=[X])` per-action override, or a `get_permissions` per-action arm keyed on `self.action`. Applies to THAT action only.
2. **Class level** — the ViewSet/APIView `permission_classes` attribute (or the `else`/default `get_permissions` arm). Applies to actions without their own override.
3. **Global default** — `REST_FRAMEWORK["DEFAULT_PERMISSION_CLASSES"]` (`drf_default_permission_classes`), applied only when neither method nor class specifies a permission.

APIView asymmetry documented: a `get`/`post` method cannot carry its own `permission_classes` (APIView is class-scoped), so only ViewSet `@action` carries a method-level override.

## Decode mapping (unchanged §10 vocabulary)
`AllowAny`→public, `IsAuthenticated`→authenticated, `CustomPagePermissionCheck(PAGE)`→page grant, `CustomActionPermissionCheck`→action grant, superuser checks→superuser. Emits the same `Posture {Kind, Literal}` the NestJS resolver emits, so cross-group diff stays uniform.

**Empty-vs-AllowAny:** `permission_classes=[AllowAny]` → public (overrides global); `permission_classes=[]` (extractor stamps no prop) → falls through to the global default, NOT public.

## Scope boundary
Edits the DRF posture RESOLVER only. The cross-group JOIN (`internal/mcp/auth_posture_diff_tool.go`, #4550) is untouched.

## Fixtures (RED→GREEN)
- A — class `[IsAuthenticated]` + `@action([AllowAny])` → action PUBLIC, sibling authenticated.
- B — `get_permissions` `if self.action=='open': [AllowAny()]` else class → action public, others class.
- C — no class perms + global `DEFAULT_PERMISSION_CLASSES=[IsAuthenticated]` → authenticated via global.
- Plus: empty `[]`→global, class-over-global precedence.

## Coverage docs
`docs/coverage/registry.json` django-drf Auth cell updated surgically (cite the resolver + precedence note); `coverage fmt --check` passes (canonical).

## Gates
`go build ./...` ✅, `go vet ./internal/authposture/... ./internal/dashboard/...` ✅, `go test ./internal/authposture/... ./internal/dashboard/... ./internal/engine/...` ✅, `coverage fmt --check` ✅.

Closes #4675

🤖 Generated with [Claude Code](https://claude.com/claude-code)