### PR TITLE
fix(effects): Python queryset read-reach via receiver typing (#4691)

### DIFF
--- a/internal/substrate/effect_sinks_python.go
+++ b/internal/substrate/effect_sinks_python.go
@@ -86,6 +86,70 @@ var pyDBReadRe = regexp.MustCompile(
 		`|\bsession\s*\.\s*(?:query|execute|scalar|scalars|get)\s*\(`,
 )
 
+// pyDBReadHelperRe matches the Django shortcut read helpers that fetch a row /
+// list and 404 otherwise. These are distinctive names with no builtin/collection
+// collision, so they are safe to bare-match anywhere (#4691).
+var pyDBReadHelperRe = regexp.MustCompile(
+	`\bget_object_or_404\s*\(|\bget_list_or_404\s*\(`,
+)
+
+// --- #4691 queryset-receiver typing (ambiguous read terminals) ---
+//
+// #4694 (pyDBReadRe) bare-matched the DISTINCTIVE queryset read verbs
+// (filter/exclude/annotate/...) but kept the builtin-colliding terminals
+// (.get/.first/.last/.all/.exists/.count/.values/.values_list) gated to the
+// `.objects.<verb>` manager form, because `d.get("k")` (dict) and
+// `m.count()` (list/Mock) would otherwise be mis-credited as db_read.
+//
+// #4691 closes that gap with lightweight, content-local receiver typing: we
+// learn which local/attribute names hold a QuerySet/Manager (assigned from a
+// queryset-producing expression, or the inherent `self.queryset` /
+// `self.get_queryset()` handles), then credit the ambiguous read terminals
+// ONLY when the receiver is one of those typed names. A read terminal on an
+// untyped receiver (a dict, a Mock, a generic object) stays non-read — the
+// false-positive guard #4694 introduced is preserved exactly.
+
+// pyQSAssignRe captures `<name> = <rhs>` assignments whose RHS is a
+// queryset-producing expression. Group 1 is the assigned (now queryset-typed)
+// name. The RHS alternatives:
+//   - `<recv>.objects.<verb>(` / `<recv>.objects`            (Django manager)
+//   - `<recv>.filter|exclude|annotate|...(`                  (chained queryset op)
+//   - `self.get_queryset(` / `self.queryset`                 (DRF/CBV handles)
+//   - `<typedName>.filter|...` chains feed back via the iterative pass below.
+var pyQSAssignRe = regexp.MustCompile(
+	`(?m)^\s*([A-Za-z_]\w*)\s*=\s*` +
+		`(?:[A-Za-z_][\w.]*\s*\.\s*objects\b` +
+		`|[A-Za-z_][\w.]*\s*\.\s*(?:filter|exclude|annotate|select_related|prefetch_related|values_list|only|defer|distinct|order_by|get_queryset)\s*\(` +
+		`|self\s*\.\s*get_queryset\s*\(` +
+		`|self\s*\.\s*queryset\b)`,
+)
+
+// pyQSChainAssignRe captures `<name> = <knownQS>.<op>(...)` — a reassignment
+// whose RHS receiver is an already-queryset-typed name. Group 1 = assigned
+// name, group 2 = source receiver name. Used to propagate typing across
+// `qs = qs.filter(...)` style chains in a fixpoint loop.
+var pyQSChainAssignRe = regexp.MustCompile(
+	`(?m)^\s*([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\s*\.\s*` +
+		`(?:filter|exclude|annotate|select_related|prefetch_related|values_list|only|defer|distinct|order_by|all|none|union|intersection|difference|reverse)\s*\(`,
+)
+
+// pyQSAmbiguousVerbs are the read terminals that collide with Python builtins
+// on dict/list/etc., so they are credited db_read ONLY on a queryset-typed
+// receiver (see querysetReadMatches).
+const pyQSAmbiguousVerbs = `get|first|last|all|exists|count|values|values_list`
+
+// pyInherentQSReadRe credits the ambiguous read terminals when chained
+// DIRECTLY off an inherent queryset handle — `self.get_queryset().first()`,
+// `self.queryset.count()`, `Model.objects.filter(...).get(...)` — without
+// needing an intermediate assignment. The `.objects` chain form is already
+// covered by pyDBReadRe's manager alternative; here we add the
+// `self.get_queryset()` / `self.queryset` handles, whose terminal read verb
+// would otherwise be missed.
+var pyInherentQSReadRe = regexp.MustCompile(
+	`self\s*\.\s*get_queryset\s*\(\s*\)\s*\.\s*(?:` + pyQSAmbiguousVerbs + `)\s*\(` +
+		`|self\s*\.\s*queryset\s*\.\s*(?:` + pyQSAmbiguousVerbs + `)\s*\(`,
+)
+
 // pyCursorSelectRe matches `cursor.execute("SELECT ...")` style raw reads.
 // Case-insensitive on the SQL keyword. Quote-agnostic.
 var pyCursorSelectRe = regexp.MustCompile(
@@ -188,6 +252,9 @@ func sniffEffectsPython(content string) []EffectMatch {
 	var out []EffectMatch
 	out = appendPyMatches(out, content, headers, pyHTTPRe, EffectHTTPOut, "requests/httpx", 1.0)
 	out = appendPyMatches(out, content, headers, pyDBReadRe, EffectDBRead, "orm.read", 0.85)
+	out = appendPyMatches(out, content, headers, pyDBReadHelperRe, EffectDBRead, "orm.read.shortcut", 0.9)
+	out = appendPyMatches(out, content, headers, pyInherentQSReadRe, EffectDBRead, "orm.read.queryset", 0.85)
+	out = append(out, querysetReadMatches(content, headers)...)
 	out = appendPyMatches(out, content, headers, pyCursorSelectRe, EffectDBRead, "cursor.execute(SELECT)", 1.0)
 	out = appendPyMatches(out, content, headers, pyDBConnectRe, EffectDBRead, "db.connect/cursor", 0.8)
 	out = appendPyMatches(out, content, headers, pyDBWriteRe, EffectDBWrite, "orm.write", 0.85)
@@ -199,6 +266,71 @@ func sniffEffectsPython(content string) []EffectMatch {
 	out = appendPyMatches(out, content, headers, pyMutationRe, EffectMutation, "self.field=", 0.7)
 	out = appendPyMatches(out, content, headers, pyEnvReadRe, EffectEnvRead, "os.environ/getenv", 1.0)
 	return out
+}
+
+// querysetReadMatches implements the #4691 receiver-typed read credit. It
+// (1) collects the set of local/attribute names known to hold a QuerySet/
+// Manager (assigned from a queryset-producing RHS, propagated across chained
+// reassignments to a fixpoint), then (2) emits a db_read EffectMatch for each
+// ambiguous read terminal (.get/.first/.last/.all/.exists/.count/.values/
+// .values_list) invoked on one of those typed receiver names. A read terminal
+// on an UNTYPED receiver (a dict, a Mock, a generic object) yields nothing —
+// the #4694 false-positive guard is preserved: only queryset-typed receivers
+// earn the credit. Module/function scope is not segmented (the sniffer is a
+// flat content scan, like every other sink here); typing is conservative
+// enough that cross-scope name reuse is a non-issue in practice.
+func querysetReadMatches(content string, headers []funcHeader) []EffectMatch {
+	typed := collectQuerysetTypedNames(content)
+	if len(typed) == 0 {
+		return nil
+	}
+	var out []EffectMatch
+	for name := range typed {
+		// `<name> . <ambiguous-verb> (` — receiver is the typed queryset name.
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*\.\s*(?:` + pyQSAmbiguousVerbs + `)\s*\(`)
+		for _, m := range re.FindAllStringIndex(content, -1) {
+			line := lineOfOffset(content, m[0])
+			out = append(out, EffectMatch{
+				Function:   nearestHeader(headers, line),
+				Line:       line,
+				Effect:     EffectDBRead,
+				Sink:       "orm.read.queryset",
+				Confidence: 0.85,
+			})
+		}
+	}
+	return out
+}
+
+// collectQuerysetTypedNames returns the set of names that hold a QuerySet /
+// Manager. Seeds from queryset-producing assignments (pyQSAssignRe), then
+// iterates pyQSChainAssignRe to a fixpoint so `qs = base.filter(...)` followed
+// by `qs2 = qs.exclude(...)` types both names.
+func collectQuerysetTypedNames(content string) map[string]bool {
+	typed := map[string]bool{}
+	for _, m := range pyQSAssignRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 && m[1] != "" {
+			typed[m[1]] = true
+		}
+	}
+	chains := pyQSChainAssignRe.FindAllStringSubmatch(content, -1)
+	for {
+		changed := false
+		for _, m := range chains {
+			if len(m) < 3 {
+				continue
+			}
+			dst, srcName := m[1], m[2]
+			if dst != "" && srcName != "" && typed[srcName] && !typed[dst] {
+				typed[dst] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return typed
 }
 
 func scanPyFuncHeaders(content string) []funcHeader {

--- a/internal/substrate/effect_sinks_python_queryset_read_4691_test.go
+++ b/internal/substrate/effect_sinks_python_queryset_read_4691_test.go
@@ -1,0 +1,83 @@
+package substrate
+
+// effect_sinks_python_queryset_read_4691_test.go — receiver-typed read reach
+// for the Python effect sniffer (#4691, follow-up to #4668/#4694).
+//
+// #4694 bare-matched the DISTINCTIVE queryset read verbs (filter/exclude/...)
+// but kept the builtin-colliding terminals (.get/.first/.all/.count/.values/...)
+// gated to the `.objects.<verb>` manager form to avoid dict.get/list.count
+// false positives. #4691 closes that gap with lightweight receiver typing:
+// when a receiver is known to hold a QuerySet/Manager, its ambiguous read
+// terminals ARE db_read; on an untyped receiver they STAY non-read.
+
+import "testing"
+
+// A: a queryset bound to a local, then a `.get(pk=...)` terminal on it.
+func TestPythonQuerysetTypedGet_4691(t *testing.T) {
+	src := `
+def fetch(pk):
+    qs = Article.objects.filter(active=True)
+    obj = qs.get(pk=pk)
+    return obj
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustHave(t, by, EffectDBRead, "fetch")
+}
+
+// B: inherent queryset handle chained directly to an ambiguous terminal.
+func TestPythonGetQuerysetFirst_4691(t *testing.T) {
+	src := `
+class ContractRepository:
+    def latest(self):
+        return self.get_queryset().first()
+    def head(self):
+        return self.queryset.count()
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustHave(t, by, EffectDBRead, "latest")
+	mustHave(t, by, EffectDBRead, "head")
+}
+
+// C (negative, MUST stay pure): builtin .get on a dict and .count on a Mock/
+// list — receivers that are NOT queryset-typed — earn no db_read credit.
+func TestPythonAmbiguousVerbsNoFalsePositive_4691(t *testing.T) {
+	src := `
+def lookup(key):
+    d = {}
+    return d.get(key)
+
+def tally(items):
+    m = Mock()
+    return m.count()
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustNotHave(t, by, EffectDBRead, "lookup")
+	mustNotHave(t, by, EffectDBRead, "tally")
+}
+
+// D: chained reassignment propagates typing; terminal read on the reassigned
+// name is still credited (feeds the controller→service propagation).
+func TestPythonChainedQuerysetReassign_4691(t *testing.T) {
+	src := `
+def search(active, ids):
+    qs = Article.objects.all()
+    qs = qs.exclude(id__in=ids)
+    return qs.exists()
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustHave(t, by, EffectDBRead, "search")
+}
+
+// get_object_or_404 / get_list_or_404 are distinctive shortcut reads.
+func TestPythonShortcutReadHelpers_4691(t *testing.T) {
+	src := `
+def detail(pk):
+    return get_object_or_404(Article, pk=pk)
+
+def listing():
+    return get_list_or_404(Article)
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustHave(t, by, EffectDBRead, "detail")
+	mustHave(t, by, EffectDBRead, "listing")
+}


### PR DESCRIPTION
## What

Closes #4691 — the piece #4668 (PR #4694) deferred.

#4694 bare-matched the **distinctive** Django queryset read verbs (`.filter`/`.exclude`/`.annotate`/`.select_related`/...) on any receiver, but kept the **builtin-colliding** read terminals (`.get`/`.first`/`.all`/`.count`/`.values`/`.values_list`/`.exists`) gated to the `.objects.<verb>` manager form to avoid `dict.get`/`list.count` false positives. A repository whose only read is `self.queryset.get(pk=pk)` therefore still resolved **pure**.

This closes that gap with lightweight, content-local **receiver typing** in `internal/substrate/effect_sinks_python.go`:

- **`collectQuerysetTypedNames`** — learns which local/attribute names hold a QuerySet/Manager: assigned from a queryset-producing expr (`qs = Model.objects.filter(...)`, `qs = self.get_queryset()`, `qs = self.queryset`), with chained reassignments (`qs = qs.exclude(...)`) propagated to a fixpoint.
- **`querysetReadMatches`** — credits the ambiguous read terminals (`.get`/`.first`/`.last`/`.all`/`.exists`/`.count`/`.values`/`.values_list`) as `db_read` **only** when invoked on a queryset-typed receiver.
- **`pyInherentQSReadRe`** — credits the inherent `self.get_queryset()` / `self.queryset` handles chained directly to a terminal.
- **`pyDBReadHelperRe`** — credits `get_object_or_404` / `get_list_or_404`.

## False-positive guard (preserved exactly)

A read terminal on an **untyped** receiver (a dict, a `Mock`, a generic object) earns no `db_read` credit. The credit fires *only* for queryset-typed receivers — exactly why #4694 gated these verbs.

## Fixtures (RED→GREEN)

`internal/substrate/effect_sinks_python_queryset_read_4691_test.go`:
- **A** `qs = Article.objects.filter(...); obj = qs.get(pk=pk)` → `db_read`
- **B** `self.get_queryset().first()` / `self.queryset.count()` → `db_read`
- **C** (negative) `d = {}; d.get(k)` and `m = Mock(); m.count()` → NOT `db_read`
- **D** chained `qs = Article.objects.all(); qs = qs.exclude(...); qs.exists()` → `db_read`
- shortcut helpers `get_object_or_404` / `get_list_or_404` → `db_read`

Existing #4668 read/write symmetry + dict false-positive tests stay green. The propagation up the controller→service→repo CALLS chain is handled by the existing effects union in `internal/graph/coverage.go` once the sink is stamped.

## Coverage docs

`docs/coverage/registry.json` — django `Data/db_effect` + django-drf `Substrate/db_effect` notes updated surgically. `go run ./tools/coverage fmt --check` clean (diff is exactly 2 cells, no whole-file re-serialization).

## Gates

`go build ./...`, `go vet`, and `go test ./internal/extractors/... ./internal/engine/... ./internal/graph/... ./internal/custom/... ./internal/types/ ./internal/substrate/...` all green; `coverage fmt --check` clean.

DEPLOY-DEFERRED (live-daemon reindex is a separate coordinated step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)