### PR TITLE
feat(stub_detector): field-level partial-stub signal (#4669)

### DIFF
--- a/internal/mcp/field_stub.go
+++ b/internal/mcp/field_stub.go
@@ -1,0 +1,115 @@
+// Field-level partial-stub signal for stub_detector (#4669, epic #4493).
+//
+// stub_detector is endpoint-level: it contrasts the v3 endpoint's side-effect
+// profile against its oracle counterpart, so an endpoint with SOME db_read
+// reads as "implemented" even when individual response FIELDS are hardcoded
+// (GET /clients/get_extras cat1/cat5 #763; checklists part_id:null #831). This
+// file adds the complementary field-level signal: for a v3 endpoint's
+// handler(s), classify each constructed response-object field as derived vs
+// literal-bound and surface the UNCONDITIONALLY literal-bound DATA fields as
+// `partial_stub_fields`. It COMPLEMENTS the endpoint verdict — a fully
+// "implemented" endpoint can still carry partial-stub fields.
+//
+// The literal-vs-derived classification is the per-language substrate analyzer
+// (internal/substrate/field_literals*.go), fed the same single-function source
+// window the effects/branches facets walk. Python (DRF) + JS/TS (NestJS) ship;
+// other languages register their own analyzer (honest-partial otherwise).
+package mcp
+
+import (
+	"path/filepath"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/stubdetector"
+	"github.com/cajasmota/archigraph/internal/substrate"
+)
+
+// partialStubFieldsForEndpoint computes the partial-stub fields for a v3
+// endpoint definition by analysing the source of every handler that implements
+// it. It unions each handler's per-object field facets and runs the
+// language-general PartialStubFields roll-up (a field flagged only when EVERY
+// occurrence across all handlers is literal-bound, and not an envelope flag).
+//
+// supported reports whether ANY analysed handler's language has a registered
+// field analyzer — so the tool can honest-partial (a v3 stack with no analyzer
+// is "unknown", never "no literal fields"). fields is nil/empty when supported
+// but nothing is unconditionally literal.
+func partialStubFieldsForEndpoint(
+	r *LoadedRepo,
+	def *graph.Entity,
+	hres *stubHandlerResolution,
+	byID map[string]*graph.Entity,
+) (fields []stubdetector.PartialStubField, supported bool) {
+	roots := hres.resolveStubHandlers(def)
+	var all []substrate.FieldFacet
+	for _, id := range roots {
+		h := byID[id]
+		if h == nil {
+			continue
+		}
+		lang := substrate.LanguageForPath(h.SourceFile)
+		analyzer := substrate.FieldLiteralAnalyzerFor(lang)
+		if analyzer == nil {
+			continue
+		}
+		supported = true
+		src := readHandlerSource(r, h)
+		if src == "" {
+			continue
+		}
+		all = append(all, analyzer(src, handlerStartLine(h))...)
+	}
+	if !supported {
+		return nil, false
+	}
+	flagged := substrate.PartialStubFields(all)
+	out := make([]stubdetector.PartialStubField, 0, len(flagged))
+	for _, f := range flagged {
+		out = append(out, stubdetector.PartialStubField{
+			Field:        f.Field,
+			LiteralValue: f.LiteralValue,
+			Line:         f.Line,
+		})
+	}
+	return out, true
+}
+
+// readHandlerSource reads a handler entity's source window from disk, mirroring
+// attachBranchesFacet's resolution (abs path under repo, degenerate-span pad).
+func readHandlerSource(r *LoadedRepo, h *graph.Entity) string {
+	start, end := branchSourceSpan(h)
+	if start <= 0 {
+		return ""
+	}
+	abs := h.SourceFile
+	if !filepath.IsAbs(abs) && r != nil && r.Path != "" {
+		abs = filepath.Join(r.Path, h.SourceFile)
+	}
+	src, err := readRawSourceWindow(abs, start, end)
+	if err != nil {
+		return ""
+	}
+	return src
+}
+
+func handlerStartLine(h *graph.Entity) int {
+	if h.StartLine > 0 {
+		return h.StartLine
+	}
+	return 1
+}
+
+// partialStubFieldsToJSON renders the flagged fields into the public JSON shape
+// surfaced on each stub_detector endpoint record.
+func partialStubFieldsToJSON(fields []stubdetector.PartialStubField) []map[string]any {
+	out := make([]map[string]any, 0, len(fields))
+	for _, f := range fields {
+		m := map[string]any{
+			"field":         f.Field,
+			"literal_value": f.LiteralValue,
+			"line":          f.Line,
+		}
+		out = append(out, m)
+	}
+	return out
+}

--- a/internal/mcp/field_stub_4669_test.go
+++ b/internal/mcp/field_stub_4669_test.go
@@ -1,0 +1,179 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// field_stub_4669_test.go — #4669 field-level partial-stub signal surfaced on
+// the stub_detector endpoint record. Exercises the real handleStubDetector
+// end-to-end with an on-disk handler source so the partial_stub_fields facet is
+// computed from actual source (fixtures lie at merge → drive the real handler).
+//
+// The marquee upvate cases the rewrite agent flagged:
+//   - get_extras: reads data but hardcodes cat1/cat5 fields → those flagged.
+//   - checklists: part_id:null → part_id flagged.
+
+// stubFieldServer builds a two-group server where the v3 repo's LoadedRepo
+// Path points at dir (so handler source reads resolve), with the given v3/oracle
+// docs. Mirrors stubTwoGroupServer but wires the on-disk Path.
+func stubFieldServer(t *testing.T, dir string, v3, oracle *graph.Document) *Server {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"v3":     {Repos: map[string]RegistryRepo{"r": {Path: dir}}},
+		"oracle": {Repos: map[string]RegistryRepo{"r": {Path: dir}}},
+	}}
+	st := NewState(reg)
+	st.mu.Lock()
+	st.groups["v3"] = &LoadedGroup{
+		Name:  "v3",
+		Repos: map[string]*LoadedRepo{"r": {Repo: "r", Doc: v3, Path: dir}},
+	}
+	st.groups["oracle"] = &LoadedGroup{
+		Name:  "oracle",
+		Repos: map[string]*LoadedRepo{"r": {Repo: "r", Doc: oracle, Path: dir}},
+	}
+	st.mu.Unlock()
+	return &Server{State: st, Tel: NewTelemetry(0)}
+}
+
+func TestStubDetector_PartialStubFields_getExtras(t *testing.T) {
+	dir := t.TempDir()
+	// A DRF handler that reads (db_read) but hardcodes cat1/cat5 scheduling
+	// fields — the #763 get_extras shape.
+	src := `class ClientViewSet:
+    def get_extras(self, request):
+        client = Client.objects.get(pk=request.GET["id"])
+        return Response({
+            "client_name": client.name,
+            "cat1": 0,
+            "cat5": 0,
+            "count": Extra.objects.filter(client=client).count(),
+        })
+`
+	srcPath := filepath.Join(dir, "client_viewset.py")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	handler := graph.Entity{
+		ID: "h1", Name: "ClientViewSet.get_extras",
+		Kind: "SCOPE.Operation", SourceFile: "client_viewset.py",
+		StartLine: 2, EndLine: 9,
+		Properties: map[string]string{"effects": "db_read"},
+	}
+	v3 := &graph.Document{Repo: "r",
+		Entities:      []graph.Entity{endpointDef("d1", "GET", "/clients/get_extras"), handler},
+		Relationships: []graph.Relationship{implementsEdge("h1", "d1")},
+	}
+	oracle := &graph.Document{Repo: "r",
+		Entities:      []graph.Entity{endpointDef("od1", "GET", "/clients/get_extras"), handlerFn("oh1", "oracle.get_extras", "db_read")},
+		Relationships: []graph.Relationship{implementsEdge("oh1", "od1")},
+	}
+	s := stubFieldServer(t, dir, v3, oracle)
+	writeEffectsSidecar(t, "v3", map[string][]string{"r::h1": {"db_read"}})
+	writeEffectsSidecar(t, "oracle", map[string][]string{"r::oh1": {"db_read"}})
+
+	out := callStubDetector(t, s, map[string]any{"group_v3": "v3", "group_oracle": "oracle"})
+	r := resultFor(t, out, "GET /clients/get_extras")
+
+	if r["partial_stub_supported"] != true {
+		t.Fatalf("partial_stub_supported = %v, want true", r["partial_stub_supported"])
+	}
+	fields, _ := r["partial_stub_fields"].([]any)
+	got := map[string]string{}
+	for _, f := range fields {
+		m := f.(map[string]any)
+		got[m["field"].(string)] = m["literal_value"].(string)
+	}
+	if _, ok := got["cat1"]; !ok {
+		t.Errorf("expected cat1 flagged; got %v", got)
+	}
+	if _, ok := got["cat5"]; !ok {
+		t.Errorf("expected cat5 flagged; got %v", got)
+	}
+	if _, ok := got["count"]; ok {
+		t.Errorf("count is derived (db count) and must NOT be flagged; got %v", got)
+	}
+	if _, ok := got["client_name"]; ok {
+		t.Errorf("client_name is derived (model attr) and must NOT be flagged; got %v", got)
+	}
+	// The endpoint-level verdict still classifies it implemented (it has
+	// db_read on both sides) — the field signal COMPLEMENTS, doesn't replace.
+	if r["verdict"] == "likely_stub" {
+		t.Errorf("endpoint verdict should not be likely_stub here (has db_read); got %v", r["verdict"])
+	}
+}
+
+func TestStubDetector_PartialStubFields_checklistsPartId(t *testing.T) {
+	dir := t.TempDir()
+	src := `class ChecklistViewSet:
+    def list(self, request):
+        items = Checklist.objects.all()
+        return Response({"part_id": None, "name": items[0].name})
+`
+	if err := os.WriteFile(filepath.Join(dir, "checklist.py"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	handler := graph.Entity{
+		ID: "h1", Name: "ChecklistViewSet.list",
+		Kind: "SCOPE.Operation", SourceFile: "checklist.py",
+		StartLine: 2, EndLine: 5,
+		Properties: map[string]string{"effects": "db_read"},
+	}
+	v3 := &graph.Document{Repo: "r",
+		Entities:      []graph.Entity{endpointDef("d1", "GET", "/checklists"), handler},
+		Relationships: []graph.Relationship{implementsEdge("h1", "d1")},
+	}
+	oracle := &graph.Document{Repo: "r",
+		Entities:      []graph.Entity{endpointDef("od1", "GET", "/checklists"), handlerFn("oh1", "oracle.list", "db_read")},
+		Relationships: []graph.Relationship{implementsEdge("oh1", "od1")},
+	}
+	s := stubFieldServer(t, dir, v3, oracle)
+	writeEffectsSidecar(t, "v3", map[string][]string{"r::h1": {"db_read"}})
+	writeEffectsSidecar(t, "oracle", map[string][]string{"r::oh1": {"db_read"}})
+
+	out := callStubDetector(t, s, map[string]any{"group_v3": "v3", "group_oracle": "oracle"})
+	r := resultFor(t, out, "GET /checklists")
+	fields, _ := r["partial_stub_fields"].([]any)
+	if len(fields) != 1 {
+		t.Fatalf("expected exactly 1 flagged field (part_id), got %+v", fields)
+	}
+	m := fields[0].(map[string]any)
+	if m["field"] != "part_id" || m["literal_value"] != "None" {
+		t.Fatalf("expected part_id=None, got %+v", m)
+	}
+}
+
+// A non-flagship language with no field analyzer reports supported=false rather
+// than "no literal fields" (honest-partial).
+func TestStubDetector_PartialStubFields_unsupportedLanguage(t *testing.T) {
+	dir := t.TempDir()
+	handler := graph.Entity{
+		ID: "h1", Name: "h", Kind: "SCOPE.Operation",
+		SourceFile: "handler.rb", StartLine: 1, EndLine: 3,
+		Properties: map[string]string{"effects": "db_read"},
+	}
+	v3 := &graph.Document{Repo: "r",
+		Entities:      []graph.Entity{endpointDef("d1", "GET", "/x"), handler},
+		Relationships: []graph.Relationship{implementsEdge("h1", "d1")},
+	}
+	oracle := &graph.Document{Repo: "r",
+		Entities:      []graph.Entity{endpointDef("od1", "GET", "/x"), handlerFn("oh1", "o", "db_read")},
+		Relationships: []graph.Relationship{implementsEdge("oh1", "od1")},
+	}
+	s := stubFieldServer(t, dir, v3, oracle)
+	writeEffectsSidecar(t, "v3", map[string][]string{"r::h1": {"db_read"}})
+	writeEffectsSidecar(t, "oracle", map[string][]string{"r::oh1": {"db_read"}})
+	out := callStubDetector(t, s, map[string]any{"group_v3": "v3", "group_oracle": "oracle"})
+	r := resultFor(t, out, "GET /x")
+	if r["partial_stub_supported"] != false {
+		t.Fatalf("ruby handler: partial_stub_supported = %v, want false", r["partial_stub_supported"])
+	}
+	if _, ok := r["partial_stub_fields"]; ok {
+		t.Fatalf("unsupported language must not emit partial_stub_fields")
+	}
+}

--- a/internal/mcp/stub_detector_tool.go
+++ b/internal/mcp/stub_detector_tool.go
@@ -169,7 +169,7 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 
 			v3Eff := computeEndpointEffects(r.Repo, e, hres, callsAdj, byID, v3Effs, v3HasEffectData)
 
-			results = append(results, stubdetector.Score(stubdetector.Input{
+			res := stubdetector.Score(stubdetector.Input{
 				Endpoint:      label,
 				V3Effects:     v3Eff,
 				OracleEffects: oracleEntry,
@@ -180,7 +180,18 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 				// next increment on this tool.
 				ReturnsLiteral: stubdetector.Unknown,
 				NoInputUse:     stubdetector.Unknown,
-			}))
+			})
+
+			// #4669 field-level partial-stub signal — complements the endpoint
+			// verdict: classify the v3 handler's response-object fields and
+			// surface the unconditionally literal-bound DATA fields. Independent
+			// of the effects contrast, so a fully "implemented" endpoint can
+			// still carry partial-stub fields.
+			fields, supported := partialStubFieldsForEndpoint(r, e, hres, byID)
+			res.PartialStubFields = fields
+			res.PartialStubSupported = supported
+
+			results = append(results, res)
 		}
 	}
 
@@ -222,7 +233,7 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 func resultsToJSON(results []stubdetector.Result) []map[string]any {
 	out := make([]map[string]any, 0, len(results))
 	for _, r := range results {
-		out = append(out, map[string]any{
+		rec := map[string]any{
 			"endpoint": r.Endpoint,
 			"signals": map[string]any{
 				"returns_literal":    r.Signals.ReturnsLiteral.String(),
@@ -235,7 +246,18 @@ func resultsToJSON(results []stubdetector.Result) []map[string]any {
 			"v3_effects":     r.V3Effects,
 			"oracle_effects": r.OracleEffects,
 			"rationale":      r.Rationale,
-		})
+		}
+		// #4669 field-level partial-stub signal. Only surfaced when the handler
+		// language has a registered analyzer (honest-partial otherwise): a
+		// non-empty list flags the unconditionally literal-bound DATA fields; an
+		// empty list under supported=true means "analysed, none hardcoded".
+		if r.PartialStubSupported {
+			rec["partial_stub_fields"] = partialStubFieldsToJSON(r.PartialStubFields)
+			rec["partial_stub_supported"] = true
+		} else {
+			rec["partial_stub_supported"] = false
+		}
+		out = append(out, rec)
 	}
 	return out
 }

--- a/internal/stubdetector/stubdetector.go
+++ b/internal/stubdetector/stubdetector.go
@@ -141,6 +141,21 @@ type Input struct {
 	NoInputUse     Tristate
 }
 
+// PartialStubField is one response-object field that is unconditionally bound
+// to a literal/constant rather than derived from read/computed data — the
+// field-level partial-stub signal (#4669). It COMPLEMENTS the endpoint verdict:
+// a fully "implemented" endpoint can still carry these. The caller computes
+// these from the per-language field-literal analyzer (internal/substrate); this
+// package only carries the plain data so it stays pure (no substrate import).
+type PartialStubField struct {
+	// Field is the response key name.
+	Field string `json:"field"`
+	// LiteralValue is the verbatim hardcoded value (e.g. "null", "0", `"tbd"`).
+	LiteralValue string `json:"literal_value,omitempty"`
+	// Line is the 1-indexed source line of the field assignment.
+	Line int `json:"line,omitempty"`
+}
+
 // Result is one scored endpoint.
 type Result struct {
 	Endpoint      string   `json:"endpoint"`
@@ -151,6 +166,14 @@ type Result struct {
 	OracleEffects []string `json:"oracle_effects"`
 	// Rationale is a short human explanation of the verdict.
 	Rationale string `json:"rationale"`
+	// PartialStubFields are the unconditionally literal-bound DATA fields of the
+	// v3 handler's response object — the field-level partial-stub signal (#4669),
+	// independent of the endpoint verdict. Nil/empty when none.
+	PartialStubFields []PartialStubField `json:"partial_stub_fields,omitempty"`
+	// PartialStubSupported reports whether the field-level analysis ran for this
+	// endpoint's handler language. False ⇒ "unknown" (honest-partial: no
+	// analyzer for the language), never read as "no literal fields".
+	PartialStubSupported bool `json:"-"`
 }
 
 // Scoring weights. The effects CONTRAST is the dominant term; the supporting

--- a/internal/substrate/field_literals.go
+++ b/internal/substrate/field_literals.go
@@ -1,0 +1,236 @@
+// Field-level partial-stub facet (#4669, epic #4493 / #4419 capability F).
+//
+// The endpoint-level stub_detector (internal/stubdetector + the MCP tool)
+// classifies a handler as a stub by its SIDE-EFFECT PROFILE: an endpoint with
+// SOME db_read reads as "implemented". That misses PARTIAL stubs — a handler
+// that genuinely reads data but HARDCODES specific response fields:
+//
+//	GET /clients/get_extras → reads the client row, but returns the cat1/cat5
+//	  scheduling fields as constants (#763);
+//	checklists → returns part_id: null (#831).
+//
+// Both have a real db_read, so the any-effect contrast says "implemented" while
+// individual response FIELDS are stubbed. This file adds the complementary,
+// field-level signal: for a handler's return/response construction, classify
+// each field of the constructed object/dict as DERIVED (its value flows from a
+// read variable, a call result, request input, or a model attribute) vs
+// LITERAL-BOUND (a constant/string/number/bool/null hardcode). The
+// literal-bound DATA fields are the partial-stub fields.
+//
+// Design mirrors the branches facet (branches.go): a per-language analyzer
+// registered in a registry, fed the same single-function source window the
+// effect sniffers / branch analyzer walk. Python (DRF Response dicts /
+// serializer-style dict literals) and JS/TS (NestJS response object literals)
+// ship first as the flagship stacks; other languages register their own
+// classifier as they land (FieldLiteralAnalyzerFor → honest-partial when none).
+//
+// Honesty/precision rules (under-flag rather than over-flag):
+//   - A field is flagged ONLY when it is UNCONDITIONALLY literal: in a handler
+//     with multiple return objects, a field that is literal in one and derived
+//     in another is NOT flagged (it is conditionally derived). A field is
+//     flagged only when EVERY constructed object that contains it binds it to a
+//     literal.
+//   - Envelope flags (`success: true`, `ok: true`, `error: null`, `status:
+//     "ok"`, `message: "..."`, …) are recognised as transport envelope, not
+//     DATA, and excluded from the partial-stub set by default — they are
+//     legitimately constant. They are still recorded (with envelope=true) so a
+//     caller can see them, but the partial-stub roll-up excludes them.
+package substrate
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// FieldBinding classifies how a single response-object field's value is
+// produced.
+type FieldBinding string
+
+const (
+	// BindingLiteral — the field is bound to a literal/constant: a quoted
+	// string, a numeric literal, a bool (true/false/True/False), or
+	// null/None/nil. The partial-stub signal.
+	BindingLiteral FieldBinding = "literal"
+	// BindingDerived — the field's value flows from a variable, a call result,
+	// an attribute/member access, request input, or any non-constant
+	// expression. NOT a stub.
+	BindingDerived FieldBinding = "derived"
+)
+
+// FieldFacet is one field of a constructed response object. It is the unit the
+// field-literals facet returns. JSON shape is the public contract consumed by
+// the stub_detector tool.
+type FieldFacet struct {
+	// Field is the response key name (dict key / object property name).
+	Field string `json:"field"`
+	// Binding is literal vs derived.
+	Binding FieldBinding `json:"binding"`
+	// LiteralValue is the verbatim literal text when Binding==literal
+	// (e.g. `null`, `0`, `5`, `"tbd"`, `true`). Empty for derived fields.
+	LiteralValue string `json:"literal_value,omitempty"`
+	// Envelope is true when the field is recognised as a transport-envelope
+	// flag (success/ok/error/status/message/…) rather than a DATA field — so a
+	// constant binding is legitimate and the field is excluded from the
+	// partial-stub roll-up. Heuristic; documented at envelopeFieldNames.
+	Envelope bool `json:"envelope,omitempty"`
+	// Line is the 1-indexed source line of the field assignment, absolute to
+	// the file the function lives in (so callers can cross-reference
+	// get_source output).
+	Line int `json:"line"`
+}
+
+// FieldLiteralAnalyzerFn is the per-language contract: given a single
+// function's source window and the absolute 1-indexed line it starts at, return
+// every response-object field with its binding classification. Stateless and
+// pure — identical input yields identical output (deterministic MCP output).
+type FieldLiteralAnalyzerFn func(funcSource string, startLine int) []FieldFacet
+
+var fieldLiteralRegistry = map[string]FieldLiteralAnalyzerFn{}
+
+// RegisterFieldLiteralAnalyzer installs a per-language field-literal analyzer.
+// Mirrors RegisterBranchAnalyzer so a language can ship field classification
+// independently.
+func RegisterFieldLiteralAnalyzer(lang string, fn FieldLiteralAnalyzerFn) {
+	if lang == "" || fn == nil {
+		return
+	}
+	fieldLiteralRegistry[lang] = fn
+}
+
+// FieldLiteralAnalyzerFor returns the per-language analyzer, or nil when none
+// is registered (honest-partial: absence of a classifier is reported as "not
+// yet supported", never as "no literal fields").
+func FieldLiteralAnalyzerFor(lang string) FieldLiteralAnalyzerFn {
+	return fieldLiteralRegistry[lang]
+}
+
+// FieldLiteralLanguages returns the slugs of every registered analyzer, sorted.
+func FieldLiteralLanguages() []string {
+	out := make([]string, 0, len(fieldLiteralRegistry))
+	for k := range fieldLiteralRegistry {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// PartialStubFields is the public roll-up: from a flat list of per-object field
+// facets (possibly spanning several constructed objects in one handler), return
+// the DATA fields that are UNCONDITIONALLY literal-bound — the partial-stub
+// fields. A field is included only when EVERY occurrence of it across the
+// handler's constructed objects is literal-bound (a field derived anywhere is
+// excluded) AND it is not an envelope flag. Deterministic (sorted by field).
+//
+// This is the language-general honesty gate; each language analyzer only has to
+// emit per-object facets, and this composes them safely.
+func PartialStubFields(facets []FieldFacet) []FieldFacet {
+	type agg struct {
+		facet      FieldFacet
+		allLiteral bool
+		seen       bool
+	}
+	byField := map[string]*agg{}
+	for _, f := range facets {
+		a := byField[f.Field]
+		if a == nil {
+			a = &agg{allLiteral: true}
+			byField[f.Field] = a
+		}
+		if !a.seen {
+			a.facet = f
+			a.seen = true
+		}
+		if f.Binding != BindingLiteral {
+			a.allLiteral = false
+		}
+	}
+	out := make([]FieldFacet, 0, len(byField))
+	for _, a := range byField {
+		if !a.allLiteral || a.facet.Envelope {
+			continue
+		}
+		out = append(out, a.facet)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Field < out[j].Field })
+	return out
+}
+
+// envelopeFieldNames is the heuristic set of transport-envelope flag keys that
+// are legitimately constant and so excluded from the partial-stub roll-up.
+// Kept deliberately small + high-precision: only universally-recognised
+// envelope keys, never DATA-looking names. A field named here with a literal
+// binding is recorded (Envelope=true) but not flagged. When a name could be
+// either envelope OR data we err toward DATA (NOT in this set) so we under-flag
+// envelopes rather than over-suppress real stubs — except where the value shape
+// confirms envelope (see isEnvelopeField).
+var envelopeFieldNames = map[string]bool{
+	"success": true,
+	"ok":      true,
+	"status":  true,
+	"error":   true,
+	"errors":  true,
+	"message": true,
+	"msg":     true,
+	"code":    true,
+	"detail":  true,
+}
+
+// isEnvelopeField reports whether (name, literalValue) names a transport
+// envelope flag rather than a DATA field. The name must be a known envelope key
+// AND the literal must be a "flag-shaped" value (bool, a short status string, a
+// null error) — a numeric DATA field that merely happens to be named "code"
+// with value 5 is NOT treated as envelope. This keeps precision high: we only
+// suppress when both the name and the value shape say envelope.
+func isEnvelopeField(name, literalValue string) bool {
+	if !envelopeFieldNames[strings.ToLower(name)] {
+		return false
+	}
+	v := strings.TrimSpace(literalValue)
+	lv := strings.ToLower(v)
+	switch lv {
+	case "true", "false", "null", "none", "nil", "":
+		return true
+	}
+	// Quoted string status/message (e.g. "ok", "success") — envelope.
+	if len(v) >= 2 && (v[0] == '"' || v[0] == '\'') {
+		return true
+	}
+	return false
+}
+
+// --- shared literal classification --------------------------------------
+
+// literalRHSRe matches a right-hand-side expression that is a bare literal:
+// a number, bool, null/None/nil, or a single quoted string with nothing else.
+// Anchored and whitespace-tolerant. Used by all language analyzers so the
+// literal-vs-derived decision is uniform.
+var literalRHSRe = regexp.MustCompile(
+	`^\s*(` +
+		`-?\d+(?:\.\d+)?` + // number
+		`|true|false|True|False` + // bool
+		`|null|None|nil|undefined` + // null-ish
+		`|"(?:[^"\\]|\\.)*"` + // double-quoted string
+		`|'(?:[^'\\]|\\.)*'` + // single-quoted string
+		`|` + "`" + `(?:[^` + "`" + `\\$]|\\.)*` + "`" + // template literal w/o interpolation
+		`)\s*$`,
+)
+
+// classifyFieldRHS classifies a field's right-hand-side expression text as a
+// literal (returning its trimmed verbatim value) or derived. A value is literal
+// ONLY when the WHOLE RHS is a single bare literal — any variable, call,
+// attribute access, operator, or interpolation makes it derived. This is the
+// conservative core: when in doubt, derived (no flag).
+func classifyFieldRHS(rhs string) (FieldBinding, string) {
+	t := strings.TrimSpace(rhs)
+	// Strip a trailing comma the field-extraction left on.
+	t = strings.TrimRight(t, ", \t")
+	// Template literal containing ${...} interpolation is derived.
+	if strings.HasPrefix(t, "`") && strings.Contains(t, "${") {
+		return BindingDerived, ""
+	}
+	if literalRHSRe.MatchString(t) {
+		return BindingLiteral, t
+	}
+	return BindingDerived, ""
+}

--- a/internal/substrate/field_literals_4669_test.go
+++ b/internal/substrate/field_literals_4669_test.go
@@ -1,0 +1,184 @@
+package substrate
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// field_literals_4669_test.go — #4669 field-level partial-stub analyzer.
+//
+// Validates the literal-vs-derived classification + the PartialStubFields
+// roll-up + the envelope heuristic, across the two flagship languages
+// (Python/DRF, JS/TS/NestJS), with the issue's concrete cases:
+//   - A: {count: qs.count(), tbd: 0, all: 5} → flags tbd, all NOT count.
+//   - B: {part_id: null, name: item.name}    → flags part_id.
+//   - negative: {success: true, data: <derived>} → does NOT flag data;
+//     success is recorded but excluded as an envelope flag.
+
+func flaggedFieldNames(t *testing.T, facets []FieldFacet) []string {
+	t.Helper()
+	flagged := PartialStubFields(facets)
+	names := make([]string, 0, len(flagged))
+	for _, f := range flagged {
+		names = append(names, f.Field)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestFieldLiteralsPython_CaseA_countDerived(t *testing.T) {
+	// DRF Response dict: count derived, tbd/all hardcoded.
+	src := `def get_summary(self, request):
+    qs = Thing.objects.filter(active=True)
+    return Response({
+        "count": qs.count(),
+        "tbd": 0,
+        "all": 5,
+    }, status=200)
+`
+	facets := analyzeFieldLiteralsPython(src, 1)
+	got := flaggedFieldNames(t, facets)
+	want := []string{"all", "tbd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Case A: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsPython_CaseB_partIdNull(t *testing.T) {
+	src := `def get_item(self, request):
+    item = self.get_object()
+    return Response({"part_id": None, "name": item.name})
+`
+	facets := analyzeFieldLiteralsPython(src, 1)
+	got := flaggedFieldNames(t, facets)
+	want := []string{"part_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Case B: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+	// literal_value must be the verbatim None.
+	for _, f := range PartialStubFields(facets) {
+		if f.Field == "part_id" && f.LiteralValue != "None" {
+			t.Fatalf("Case B: part_id literal_value=%q want None", f.LiteralValue)
+		}
+	}
+}
+
+func TestFieldLiteralsPython_Negative_envelope(t *testing.T) {
+	src := `def list_things(self, request):
+    qs = Thing.objects.all()
+    return Response({"success": True, "data": ThingSerializer(qs, many=True).data})
+`
+	facets := analyzeFieldLiteralsPython(src, 1)
+	got := flaggedFieldNames(t, facets)
+	if len(got) != 0 {
+		t.Fatalf("negative: expected no flags, got %v (facets=%+v)", got, facets)
+	}
+	// success must be RECORDED as envelope (not flagged); data must be derived.
+	var sawSuccessEnvelope, sawDataDerived bool
+	for _, f := range facets {
+		if f.Field == "success" {
+			if f.Binding != BindingLiteral || !f.Envelope {
+				t.Fatalf("success: binding=%v envelope=%v want literal+envelope", f.Binding, f.Envelope)
+			}
+			sawSuccessEnvelope = true
+		}
+		if f.Field == "data" {
+			if f.Binding != BindingDerived {
+				t.Fatalf("data: binding=%v want derived", f.Binding)
+			}
+			sawDataDerived = true
+		}
+	}
+	if !sawSuccessEnvelope || !sawDataDerived {
+		t.Fatalf("negative: success-envelope=%v data-derived=%v", sawSuccessEnvelope, sawDataDerived)
+	}
+}
+
+func TestFieldLiteralsPython_conditionalFieldNotFlagged(t *testing.T) {
+	// part_id literal in one return, derived in another → NOT unconditionally
+	// literal → must NOT be flagged.
+	src := `def maybe(self, request):
+    if request.GET.get("x"):
+        return Response({"part_id": None})
+    return Response({"part_id": item.part_id})
+`
+	facets := analyzeFieldLiteralsPython(src, 1)
+	got := flaggedFieldNames(t, facets)
+	if len(got) != 0 {
+		t.Fatalf("conditional: expected no flags (part_id derived in one branch), got %v", got)
+	}
+}
+
+func TestFieldLiteralsJSTS_CaseA_and_shorthand(t *testing.T) {
+	// NestJS response object: count derived (call), tbd/all hardcoded,
+	// shorthand name derived.
+	src := `getSummary() {
+  const qs = this.repo.find();
+  return {
+    count: qs.length,
+    tbd: 0,
+    all: 5,
+    name,
+  };
+}`
+	facets := analyzeFieldLiteralsJSTS(src, 1)
+	got := flaggedFieldNames(t, facets)
+	want := []string{"all", "tbd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSTS Case A: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsJSTS_CaseB_partIdNull(t *testing.T) {
+	src := `getItem() {
+  const item = this.svc.get();
+  return { part_id: null, name: item.name };
+}`
+	facets := analyzeFieldLiteralsJSTS(src, 1)
+	got := flaggedFieldNames(t, facets)
+	want := []string{"part_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("JSTS Case B: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsJSTS_Negative_envelope(t *testing.T) {
+	src := `list() {
+  const data = this.svc.all();
+  return { success: true, data };
+}`
+	facets := analyzeFieldLiteralsJSTS(src, 1)
+	got := flaggedFieldNames(t, facets)
+	if len(got) != 0 {
+		t.Fatalf("JSTS negative: expected no flags, got %v (facets=%+v)", got, facets)
+	}
+}
+
+func TestFieldLiteralsJSTS_templateInterpolationDerived(t *testing.T) {
+	src := "build() {\n  return { label: `id-${item.id}`, tag: `static` };\n}"
+	facets := analyzeFieldLiteralsJSTS(src, 1)
+	var label, tag *FieldFacet
+	for i := range facets {
+		switch facets[i].Field {
+		case "label":
+			label = &facets[i]
+		case "tag":
+			tag = &facets[i]
+		}
+	}
+	if label == nil || label.Binding != BindingDerived {
+		t.Fatalf("label (interpolated template) should be derived: %+v", label)
+	}
+	if tag == nil || tag.Binding != BindingLiteral {
+		t.Fatalf("tag (static template) should be literal: %+v", tag)
+	}
+}
+
+func TestFieldLiteralRegistry_flagshipsRegistered(t *testing.T) {
+	for _, lang := range []string{"python", "jsts"} {
+		if FieldLiteralAnalyzerFor(lang) == nil {
+			t.Fatalf("expected field-literal analyzer registered for %q", lang)
+		}
+	}
+}

--- a/internal/substrate/field_literals_jsts.go
+++ b/internal/substrate/field_literals_jsts.go
@@ -1,0 +1,90 @@
+// JS/TS field-literal analyzer (#4669) — NestJS response object literals.
+//
+// Flagship target: NestJS controller/service methods that build a response
+// object literal — `return { ... }`, `return res.json({ ... })`, or an
+// assignment `const dto = { ... }` later returned. We locate each object
+// literal and classify every top-level property: a value that is a bare literal
+// (number / quoted string / non-interpolated template / true|false|null|
+// undefined) is literal-bound; a property naming an identifier, call,
+// member-access (item.name), or shorthand (`{ name }`) is derived.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterFieldLiteralAnalyzer("jsts", analyzeFieldLiteralsJSTS) }
+
+var (
+	// jstsObjTriggerRe finds the start of a response object literal: a `{`
+	// following `return `, `res.json(` / `.send(` / `.status(n).json(`, or an
+	// assignment `= {`. We then balance-scan from the `{`.
+	jstsObjTriggerRe = regexp.MustCompile(
+		`(?:\breturn\b\s*|` +
+			`\.(?:json|send)\s*\(\s*|` +
+			`=\s*)\{`,
+	)
+	// jstsPropKeyRe matches an object property header `key:` / `"key":` /
+	// `'key':` capturing the key and RHS. Shorthand (`name` with no colon) does
+	// not match here and is handled separately as derived.
+	jstsPropKeyRe = regexp.MustCompile(`^\s*(?:['"]?)([A-Za-z_$][\w$]*)(?:['"]?)\s*:\s*(.*)$`)
+	// jstsShorthandRe matches a shorthand property `name` (bare identifier, no
+	// colon) — always derived (it aliases a variable).
+	jstsShorthandRe = regexp.MustCompile(`^\s*([A-Za-z_$][\w$]*)\s*$`)
+)
+
+func analyzeFieldLiteralsJSTS(funcSource string, startLine int) []FieldFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	src := ClampToFunctionBody(funcSource, "jsts")
+	var out []FieldFacet
+	idx := 0
+	for {
+		loc := jstsObjTriggerRe.FindStringIndex(src[idx:])
+		if loc == nil {
+			break
+		}
+		open := idx + loc[1] - 1 // position of the `{`
+		body, closeIdx := balancedBrace(src, open)
+		if closeIdx < 0 {
+			break
+		}
+		openLine := startLine + strings.Count(src[:open], "\n")
+		out = append(out, classifyJSTSObjectFields(body, openLine)...)
+		idx = closeIdx + 1
+	}
+	return out
+}
+
+func classifyJSTSObjectFields(objBody string, openLine int) []FieldFacet {
+	var out []FieldFacet
+	for _, seg := range topLevelDictEntries(objBody) {
+		// Shorthand `{ name }` → derived, no facet value to flag.
+		if m := jstsShorthandRe.FindStringSubmatch(seg.text); m != nil {
+			line := openLine + strings.Count(objBody[:seg.offset], "\n")
+			out = append(out, FieldFacet{Field: m[1], Binding: BindingDerived, Line: line})
+			continue
+		}
+		// Spread (`...rest`) carries no single field name — skip.
+		if strings.HasPrefix(strings.TrimSpace(seg.text), "...") {
+			continue
+		}
+		m := jstsPropKeyRe.FindStringSubmatch(seg.text)
+		if m == nil {
+			continue
+		}
+		field := m[1]
+		rhs := m[2]
+		binding, lit := classifyFieldRHS(rhs)
+		line := openLine + strings.Count(objBody[:seg.offset], "\n")
+		ff := FieldFacet{Field: field, Binding: binding, Line: line}
+		if binding == BindingLiteral {
+			ff.LiteralValue = lit
+			ff.Envelope = isEnvelopeField(field, lit)
+		}
+		out = append(out, ff)
+	}
+	return out
+}

--- a/internal/substrate/field_literals_python.go
+++ b/internal/substrate/field_literals_python.go
@@ -1,0 +1,172 @@
+// Python field-literal analyzer (#4669) — DRF Response dicts & dict literals.
+//
+// Flagship target: Django/DRF handlers that construct a response payload as a
+// dict literal — `return Response({...})`, `return JsonResponse({...})`,
+// `return Response(data)` where `data = {...}`, or a bare `return {...}`. We
+// locate each such dict literal in the function body and classify every
+// top-level `key: value` pair: a value that is a bare literal (number / string
+// / bool / None) is literal-bound; anything that names a variable, call,
+// attribute (item.name), subscript, or expression is derived.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterFieldLiteralAnalyzer("python", analyzeFieldLiteralsPython) }
+
+var (
+	// pyResponseDictOpenRe finds the start of a response dict literal. Matches a
+	// `{` that follows `return `, a `Response(`/`JsonResponse(`/`Response(data=`
+	// wrapper, or an assignment `<name> = {` / `data = {`. We then balance-scan
+	// from that `{`.
+	pyRespDictTriggerRe = regexp.MustCompile(
+		`(?:\breturn\b\s*|` +
+			`\b(?:Response|JsonResponse|JSONResponse)\s*\(\s*(?:data\s*=\s*)?|` +
+			`\b\w+\s*=\s*)\{`,
+	)
+	// pyFieldKeyRe matches a dict entry header `"key":` or `'key':` at the start
+	// of a (trimmed) line, capturing the key name and the remaining RHS text.
+	pyFieldKeyRe = regexp.MustCompile(`^\s*['"]([A-Za-z_][\w]*)['"]\s*:\s*(.*)$`)
+)
+
+func analyzeFieldLiteralsPython(funcSource string, startLine int) []FieldFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	src := ClampToFunctionBody(funcSource, "python")
+	var out []FieldFacet
+	// Scan for every response dict literal in the body; classify each one's
+	// top-level fields. Multiple dicts (e.g. several return branches) all
+	// contribute facets; PartialStubFields composes them safely.
+	idx := 0
+	for {
+		loc := pyRespDictTriggerRe.FindStringIndex(src[idx:])
+		if loc == nil {
+			break
+		}
+		open := idx + loc[1] - 1 // position of the `{`
+		body, closeIdx := balancedBrace(src, open)
+		if closeIdx < 0 {
+			break
+		}
+		// Line of the opening brace, absolute.
+		openLine := startLine + strings.Count(src[:open], "\n")
+		out = append(out, classifyPyDictFields(body, src, open, openLine)...)
+		idx = closeIdx + 1
+	}
+	return out
+}
+
+// classifyPyDictFields parses the TOP-LEVEL `key: value` pairs of a dict body
+// (the text between the outer braces, exclusive) and classifies each. Nested
+// braces/brackets/parens are skipped so an inner dict's keys aren't mistaken
+// for top-level fields. fullSrc/open are used only to compute absolute lines.
+func classifyPyDictFields(dictBody, fullSrc string, open, openLine int) []FieldFacet {
+	var out []FieldFacet
+	for _, seg := range topLevelDictEntries(dictBody) {
+		m := pyFieldKeyRe.FindStringSubmatch(seg.text)
+		if m == nil {
+			continue
+		}
+		field := m[1]
+		rhs := m[2]
+		binding, lit := classifyFieldRHS(rhs)
+		line := openLine + strings.Count(dictBody[:seg.offset], "\n")
+		ff := FieldFacet{Field: field, Binding: binding, Line: line}
+		if binding == BindingLiteral {
+			ff.LiteralValue = lit
+			ff.Envelope = isEnvelopeField(field, lit)
+		}
+		out = append(out, ff)
+	}
+	return out
+}
+
+// dictEntry is one top-level comma-separated entry of a dict/object body.
+type dictEntry struct {
+	text   string
+	offset int // byte offset of the entry within the dict body
+}
+
+// topLevelDictEntries splits a dict/object body (text between the outer braces)
+// into its TOP-LEVEL comma-separated entries, ignoring commas nested inside
+// {}, [], (), or string literals. Each returned entry keeps its offset within
+// the body so callers can recover absolute line numbers. Reused by the JS/TS
+// analyzer (object literals split identically).
+func topLevelDictEntries(body string) []dictEntry {
+	var out []dictEntry
+	depth := 0
+	start := 0
+	var quote byte
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if quote != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			quote = c
+		case '{', '[', '(':
+			depth++
+		case '}', ']', ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				out = append(out, dictEntry{text: body[start:i], offset: start})
+				start = i + 1
+			}
+		}
+	}
+	if start < len(body) {
+		out = append(out, dictEntry{text: body[start:], offset: start})
+	}
+	return out
+}
+
+// balancedBrace returns the substring strictly BETWEEN the brace at openIdx and
+// its matching close brace, and the index of the close brace. String literals
+// are skipped so braces inside strings don't unbalance the scan. closeIdx is -1
+// when no match (truncated window).
+func balancedBrace(s string, openIdx int) (string, int) {
+	if openIdx < 0 || openIdx >= len(s) || s[openIdx] != '{' {
+		return "", -1
+	}
+	depth := 0
+	var quote byte
+	for i := openIdx; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			quote = c
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[openIdx+1 : i], i
+			}
+		}
+	}
+	return "", -1
+}


### PR DESCRIPTION
## What

Adds a **field-level** partial-stub signal that complements the endpoint-level \`stub_detector\`. Closes #4669 (epic #4493).

\`stub_detector\` is endpoint-level — it contrasts the v3 vs oracle side-effect profile, so an endpoint with SOME \`db_read\` reads as \`implemented\` even when individual response **fields** are hardcoded. The rewrite agent flagged the misses: \`GET /clients/get_extras\` reads the client row but hardcodes the cat1/cat5 scheduling fields (#763); checklists return \`part_id: null\` (#831). Both have a real read, so the any-effect contrast says "implemented" while specific DATA fields are stubbed.

## How literal-vs-derived classification works

For a handler's response-object construction (dict/object literal), each top-level \`key: value\` is classified:
- **derived** — the value flows from a variable, call result (\`qs.count()\`), member/attribute access (\`item.name\`), subscript, request input, shorthand (\`{ name }\`), or interpolated template (\`\` \`id-\${x}\` \`\`).
- **literal-bound** — the WHOLE RHS is a single bare literal: number / quoted string / non-interpolated template / \`true|false|True|False\` / \`null|None|nil|undefined\`. Conservative core: any non-constant token ⇒ derived (no flag).

### Honesty / precision (under-flag rather than over-flag)
- A field is flagged **only when UNCONDITIONALLY literal** — \`PartialStubFields\` rolls up per-object facets and includes a field only when EVERY occurrence across the handler's constructed objects is literal-bound (literal in one branch + derived in another ⇒ not flagged).
- **Envelope heuristic**: keys \`success / ok / status / error(s) / message / msg / code / detail\` with a *flag-shaped* value (bool, null/None, short quoted string) are recorded with \`envelope=true\` and **excluded** from the partial-stub roll-up — \`{success: true, data: <derived>}\` flags nothing. The name+value-shape double-gate keeps a DATA field that merely happens to be named \`code\` with value \`5\` from being suppressed.

## Where it surfaces

Each \`stub_detector\` endpoint record gains \`partial_stub_fields: [{field, literal_value, line}]\` plus \`partial_stub_supported\` (honest-partial: \`false\` when the handler language has no analyzer — never read as "no literal fields"). Independent of the endpoint verdict: a fully \`implemented\` endpoint can still carry partial-stub fields.

## Structure / generalization

\`internal/substrate/field_literals.go\` defines the language-neutral \`FieldFacet\` schema and a pluggable \`RegisterFieldLiteralAnalyzer\` registry (mirrors the branches facet). Flagship analyzers ship for **python** (DRF \`Response({...})\` / dict literals) and **jsts** (NestJS response object literals). Other frameworks (Java/Spring, Go, Ruby/Rails, PHP, C#) plug in via the registry — tracked in **#4728**.

## Fixtures (RED→GREEN)

Both languages, the issue's exact cases:
- **A**: \`{count: qs.count(), tbd: 0, all: 5}\` → flags \`tbd\`, \`all\`, NOT \`count\`.
- **B**: \`{part_id: null, name: item.name}\` → flags \`part_id\`.
- **negative**: \`{success: true, data: <derived>}\` → flags nothing (\`success\` recorded as envelope, \`data\` derived).
- conditional-field, template-interpolation, shorthand, and the end-to-end \`get_extras\`/\`checklists\`/unsupported-language MCP integration tests.

## Coverage docs
\`registry.json\` not touched — this is an MCP audit-tool signal, not a per-language extraction capability cell.

## Gates
\`go build ./...\`, \`go vet ./internal/mcp/... ./internal/extractors/... ./internal/custom/...\`, \`go test ./internal/mcp/... ./internal/extractors/... ./internal/custom/... ./internal/types/\` + \`./internal/stubdetector/ ./internal/substrate/\` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)