### PR TITLE
fix(resolve,golang): module-root/alias resolution — Java source roots, Python src/namespace/Django roots, Go go.mod replace (#4705)

### DIFF
--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -118,7 +118,7 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 	// so cross-package selector calls (`resolve.BuildIndex()`) can be stamped
 	// with the importing package directory and bound by the resolver instead
 	// of collapsing to an ambiguity-prone bare name.
-	inTreeQualifiers := buildGoInTreeQualifiers(root, file.Content, goModuleRoot(file.RepoRoot))
+	inTreeQualifiers := buildGoInTreeQualifiers(root, file.Content, goModuleRoot(file.RepoRoot), goModuleReplaces(file.RepoRoot))
 	funcEntities, fCount := extractFunctions(root, file.Content, file.Path, structFields, inTreeQualifiers)
 	records = append(records, funcEntities...)
 	funcs = fCount
@@ -148,7 +148,7 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 	//    EntityRecord entries (one per import path). Not fanned out to
 	// every function/type entity.
 	// ----------------------------------------------------------------
-	importRecords := extractImportEntities(root, file.Content, file.Path, goModuleRoot(file.RepoRoot))
+	importRecords := extractImportEntities(root, file.Content, file.Path, goModuleRoot(file.RepoRoot), goModuleReplaces(file.RepoRoot))
 	records = append(records, importRecords...)
 
 	// ----------------------------------------------------------------
@@ -2303,7 +2303,7 @@ func appendRelationshipTo(records []types.EntityRecord, target string, rel types
 // Properties["go_pkg_dir"] so the resolver's ResolveGoInTreeImports pass
 // can map them to the correct file-level SCOPE.Component entities. External
 // imports are left for the resolveImportToIDs pass to rewrite to ext: form.
-func extractImportEntities(root *sitter.Node, src []byte, filePath, moduleRoot string) []types.EntityRecord {
+func extractImportEntities(root *sitter.Node, src []byte, filePath, moduleRoot string, replaces []goReplace) []types.EntityRecord {
 	var records []types.EntityRecord
 
 	for _, spec := range findAll(root, "import_spec") {
@@ -2376,6 +2376,15 @@ func extractImportEntities(root *sitter.Node, src []byte, filePath, moduleRoot s
 		}
 		if moduleRoot != "" && strings.HasPrefix(importPath, moduleRoot+"/") {
 			pkgDir := importPath[len(moduleRoot)+1:]
+			rel.Properties = map[string]string{
+				"go_module_root": moduleRoot,
+				"go_pkg_dir":     pkgDir,
+			}
+		} else if pkgDir, ok := goReplacePkgDir(importPath, replaces); ok {
+			// #4705c: a local-path `replace` directive redirects this import
+			// to an in-repo directory. Stamp go_pkg_dir so the resolver's
+			// ResolveGoInTreeImports pass binds it to the local file entity
+			// BEFORE it falls through to external_package.
 			rel.Properties = map[string]string{
 				"go_module_root": moduleRoot,
 				"go_pkg_dir":     pkgDir,

--- a/internal/extractors/golang/gomod.go
+++ b/internal/extractors/golang/gomod.go
@@ -29,7 +29,24 @@ import (
 var (
 	goModCacheMu sync.RWMutex
 	goModCache   = make(map[string]string) // repoRoot → module name (or "")
+
+	goModReplaceCacheMu sync.RWMutex
+	// repoRoot → ordered list of local-path replace directives. Cached
+	// alongside goModCache; populated lazily on first access.
+	goModReplaceCache = make(map[string][]goReplace)
 )
+
+// goReplace captures a single go.mod `replace` directive that points at a
+// LOCAL filesystem path (`=> ./internal/x`, `=> ../sibling`). Network
+// replacements (`=> example.com/fork v1.2.3`) are NOT recorded — they
+// resolve to a different external module, not an in-tree directory, so
+// they keep their external disposition. LocalDir is repo-relative,
+// slash-normalised, and may be "" when the replacement targets the repo
+// root itself (`=> .`).
+type goReplace struct {
+	OldPath  string // the module path being replaced, e.g. "example.com/x"
+	LocalDir string // repo-relative dir of the replacement, e.g. "internal/x"
+}
 
 // goModuleRoot returns the Go module name declared in <repoRoot>/go.mod.
 // Returns "" when repoRoot is empty, go.mod is absent, or the module line
@@ -54,6 +71,77 @@ func goModuleRoot(repoRoot string) string {
 	goModCacheMu.Unlock()
 
 	return name
+}
+
+// goModuleReplaces returns the local-path `replace` directives declared in
+// <repoRoot>/go.mod, with each replacement's local path normalised to a
+// repo-relative, slash-separated directory. Network/version replacements
+// (those whose right-hand side is not a `./` or `../` filesystem path) are
+// excluded — they redirect to a different external module and must keep
+// their external disposition. Results are cached per repoRoot.
+//
+// Honoring these is the Go half of #4705: an `import "example.com/x"`
+// backed by `replace example.com/x => ./internal/x` is an INTERNAL import
+// (its source lives under internal/x) and must resolve to the local file
+// entity BEFORE falling through to external_package.
+func goModuleReplaces(repoRoot string) []goReplace {
+	if repoRoot == "" {
+		return nil
+	}
+
+	goModReplaceCacheMu.RLock()
+	if reps, ok := goModReplaceCache[repoRoot]; ok {
+		goModReplaceCacheMu.RUnlock()
+		return reps
+	}
+	goModReplaceCacheMu.RUnlock()
+
+	reps := parseGoModReplaces(filepath.Join(repoRoot, "go.mod"))
+
+	goModReplaceCacheMu.Lock()
+	goModReplaceCache[repoRoot] = reps
+	goModReplaceCacheMu.Unlock()
+
+	return reps
+}
+
+// goReplacePkgDir maps an import path to the repo-relative package
+// directory implied by a local-path `replace` directive, or returns
+// ("", false) when no replacement applies. An import path resolves through
+// a replacement when it equals the replaced module path exactly OR is a
+// sub-package of it (`old/sub` → `<localDir>/sub`). The longest matching
+// OldPath wins so nested replacements stay deterministic.
+func goReplacePkgDir(importPath string, replaces []goReplace) (string, bool) {
+	best := goReplace{}
+	bestLen := -1
+	for _, rp := range replaces {
+		if rp.OldPath == "" {
+			continue
+		}
+		if importPath == rp.OldPath || strings.HasPrefix(importPath, rp.OldPath+"/") {
+			if len(rp.OldPath) > bestLen {
+				best = rp
+				bestLen = len(rp.OldPath)
+			}
+		}
+	}
+	if bestLen < 0 {
+		return "", false
+	}
+	suffix := strings.TrimPrefix(importPath, best.OldPath)
+	suffix = strings.TrimPrefix(suffix, "/")
+	switch {
+	case best.LocalDir == "" && suffix == "":
+		// `replace old => .` of the repo root itself: the package dir is
+		// the repo root, which has no dotted form. Nothing to bind.
+		return "", false
+	case best.LocalDir == "":
+		return suffix, true // `replace old => .` + sub-package
+	case suffix == "":
+		return best.LocalDir, true
+	default:
+		return best.LocalDir + "/" + suffix, true
+	}
 }
 
 // parseGoModModule reads path and returns the module name from the first
@@ -86,4 +174,114 @@ func parseGoModModule(path string) string {
 		}
 	}
 	return ""
+}
+
+// parseGoModReplaces reads path and returns every local-path `replace`
+// directive. Both the single-line form
+//
+//	replace example.com/x => ./internal/x
+//
+// and the block form
+//
+//	replace (
+//	    example.com/x => ./internal/x
+//	    example.com/y v1.0.0 => ../y
+//	)
+//
+// are supported. Only replacements whose right-hand side is a filesystem
+// path (begins with "./", "../", "/", or is exactly ".") are recorded;
+// version/network replacements are skipped. Returns nil on any read error.
+func parseGoModReplaces(path string) []goReplace {
+	f, err := os.Open(filepath.FromSlash(path))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var out []goReplace
+	inBlock := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := stripGoModComment(strings.TrimSpace(scanner.Text()))
+		if line == "" {
+			continue
+		}
+		switch {
+		case inBlock && line == ")":
+			inBlock = false
+			continue
+		case !inBlock && line == "replace (":
+			inBlock = true
+			continue
+		case !inBlock && strings.HasPrefix(line, "replace "):
+			line = strings.TrimSpace(strings.TrimPrefix(line, "replace "))
+		case inBlock:
+			// directive line inside the block — fall through to parse.
+		default:
+			continue
+		}
+		if rp, ok := parseGoModReplaceDirective(line); ok {
+			out = append(out, rp)
+		}
+	}
+	return out
+}
+
+// parseGoModReplaceDirective parses a single `old [v..] => new [v..]`
+// directive body (the `replace` keyword and any block indentation already
+// stripped). It returns a goReplace only when the right-hand side is a
+// LOCAL filesystem path; version/network replacements yield ok=false.
+func parseGoModReplaceDirective(line string) (goReplace, bool) {
+	arrow := strings.Index(line, "=>")
+	if arrow < 0 {
+		return goReplace{}, false
+	}
+	lhs := strings.Fields(strings.TrimSpace(line[:arrow]))
+	rhs := strings.Fields(strings.TrimSpace(line[arrow+2:]))
+	if len(lhs) == 0 || len(rhs) == 0 {
+		return goReplace{}, false
+	}
+	oldPath := lhs[0]
+	target := rhs[0]
+	dir, ok := cleanGoLocalReplaceDir(target)
+	if !ok {
+		// Network/version replacement, or a path that escapes the indexed
+		// tree (absolute, or a `../` sibling outside the repo). Either way
+		// it cannot bind to an in-repo entity — keep external disposition.
+		return goReplace{}, false
+	}
+	return goReplace{OldPath: oldPath, LocalDir: dir}, true
+}
+
+// cleanGoLocalReplaceDir normalises a local replace target into a
+// repo-relative, slash-separated directory. Returns ok=false when the
+// target is NOT an in-repo local path:
+//   - module+version replacements (no leading "./", "../", "/", or ".");
+//   - absolute paths and `../` escapes that leave the indexed tree.
+//
+// "." (the repo root) yields ("", true): a sub-package import still binds
+// via the path suffix. A leading "./" is stripped and trailing slashes
+// trimmed.
+func cleanGoLocalReplaceDir(target string) (string, bool) {
+	switch {
+	case target == ".":
+		return "", true
+	case strings.HasPrefix(target, "/"):
+		return "", false // absolute path — outside the indexed tree
+	case target == ".." || strings.HasPrefix(target, "../"):
+		return "", false // escapes the repo root
+	case strings.HasPrefix(target, "./"):
+		return strings.TrimRight(strings.TrimPrefix(target, "./"), "/"), true
+	default:
+		return "", false // module+version replacement — keep external
+	}
+}
+
+// stripGoModComment removes a trailing `// ...` line comment from a go.mod
+// line, preserving the directive body.
+func stripGoModComment(line string) string {
+	if idx := strings.Index(line, "//"); idx >= 0 {
+		return strings.TrimSpace(line[:idx])
+	}
+	return line
 }

--- a/internal/extractors/golang/gomod_test.go
+++ b/internal/extractors/golang/gomod_test.go
@@ -83,3 +83,86 @@ func TestGoModuleRoot_RealModule(t *testing.T) {
 		t.Errorf("goModuleRoot cached = %q, want %q", got2, got)
 	}
 }
+
+// --- #4705c: local-path replace directives ---
+
+func TestParseGoModReplaces_SingleLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "go.mod")
+	content := "module example.com/app\n\ngo 1.22\n\nreplace example.com/x => ./internal/x\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	reps := parseGoModReplaces(path)
+	if len(reps) != 1 {
+		t.Fatalf("want 1 replace, got %d (%+v)", len(reps), reps)
+	}
+	if reps[0].OldPath != "example.com/x" || reps[0].LocalDir != "internal/x" {
+		t.Errorf("replace = %+v, want {example.com/x internal/x}", reps[0])
+	}
+}
+
+func TestParseGoModReplaces_Block(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "go.mod")
+	content := "module example.com/app\n\nreplace (\n\texample.com/x => ./internal/x\n\texample.com/y v1.0.0 => ../y // sibling outside repo\n\texample.com/z v1.2.3 => example.com/zfork v1.4.0\n)\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	reps := parseGoModReplaces(path)
+	// Only the local in-repo replacement survives: ../y escapes, zfork is a
+	// network/version replacement.
+	if len(reps) != 1 {
+		t.Fatalf("want 1 in-repo replace, got %d (%+v)", len(reps), reps)
+	}
+	if reps[0].OldPath != "example.com/x" || reps[0].LocalDir != "internal/x" {
+		t.Errorf("replace = %+v, want {example.com/x internal/x}", reps[0])
+	}
+}
+
+func TestGoReplacePkgDir(t *testing.T) {
+	reps := []goReplace{
+		{OldPath: "example.com/x", LocalDir: "internal/x"},
+		{OldPath: "example.com/rootmod", LocalDir: ""}, // replace => .
+	}
+	cases := []struct {
+		in       string
+		wantDir  string
+		wantOK   bool
+	}{
+		{"example.com/x", "internal/x", true},
+		{"example.com/x/sub/pkg", "internal/x/sub/pkg", true},
+		{"example.com/rootmod/pkg", "pkg", true},
+		{"example.com/rootmod", "", false}, // repo root itself, no dotted form
+		{"example.com/other", "", false},
+		{"github.com/stretchr/testify", "", false},
+	}
+	for _, c := range cases {
+		dir, ok := goReplacePkgDir(c.in, reps)
+		if dir != c.wantDir || ok != c.wantOK {
+			t.Errorf("goReplacePkgDir(%q) = (%q,%v), want (%q,%v)", c.in, dir, ok, c.wantDir, c.wantOK)
+		}
+	}
+}
+
+func TestCleanGoLocalReplaceDir(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantDir string
+		wantOK  bool
+	}{
+		{"./internal/x", "internal/x", true},
+		{"./internal/x/", "internal/x", true},
+		{".", "", true},
+		{"../sibling", "", false},
+		{"..", "", false},
+		{"/abs/path", "", false},
+		{"example.com/fork", "", false},
+	}
+	for _, c := range cases {
+		dir, ok := cleanGoLocalReplaceDir(c.in)
+		if dir != c.wantDir || ok != c.wantOK {
+			t.Errorf("cleanGoLocalReplaceDir(%q) = (%q,%v), want (%q,%v)", c.in, dir, ok, c.wantDir, c.wantOK)
+		}
+	}
+}

--- a/internal/extractors/golang/imports.go
+++ b/internal/extractors/golang/imports.go
@@ -74,8 +74,8 @@ import (
 // package qualifier so the resolver can bind a cross-package call back to the
 // imported package's directory (issue #4332) instead of dropping the
 // package qualifier and emitting an ambiguity-prone bare name.
-func buildGoInTreeQualifiers(root *sitter.Node, src []byte, moduleRoot string) map[string]string {
-	if moduleRoot == "" || root == nil {
+func buildGoInTreeQualifiers(root *sitter.Node, src []byte, moduleRoot string, replaces []goReplace) map[string]string {
+	if root == nil || (moduleRoot == "" && len(replaces) == 0) {
 		return nil
 	}
 	out := make(map[string]string)
@@ -98,10 +98,15 @@ func buildGoInTreeQualifiers(root *sitter.Node, src []byte, moduleRoot string) m
 		if importPath == "" {
 			continue
 		}
-		if !strings.HasPrefix(importPath, moduleRoot+"/") {
+		var pkgDir string
+		if moduleRoot != "" && strings.HasPrefix(importPath, moduleRoot+"/") {
+			pkgDir = importPath[len(moduleRoot)+1:]
+		} else if dir, ok := goReplacePkgDir(importPath, replaces); ok {
+			// #4705c: local-path `replace` redirect to an in-repo package.
+			pkgDir = dir
+		} else {
 			continue // external or the module root itself — not an in-tree subpackage
 		}
-		pkgDir := importPath[len(moduleRoot)+1:]
 		if pkgDir == "" {
 			continue
 		}

--- a/internal/extractors/golang/issue4705_replace_test.go
+++ b/internal/extractors/golang/issue4705_replace_test.go
@@ -1,0 +1,111 @@
+// issue4705_replace_test.go — end-to-end validation that go.mod local-path
+// `replace` directives make a replaced import resolve to the in-repo package
+// (#4705c). Mirrors the #4332 cross-package harness but writes a go.mod that
+// carries a `replace example.com/x => ./internal/x` directive.
+package golang
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractGoModuleWithGoMod(t *testing.T, goMod string, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	// Caches are keyed by repoRoot (a fresh TempDir each run) so no isolation
+	// reset is needed.
+	ex := &GoExtractor{}
+	var merged []types.EntityRecord
+	for rel, src := range files {
+		ents, err := ex.Extract(context.Background(), extractor.FileInput{
+			Path: rel, Language: "go", Content: []byte(src), RepoRoot: dir,
+		})
+		if err != nil {
+			t.Fatalf("extract %s: %v", rel, err)
+		}
+		merged = append(merged, ents...)
+	}
+	for k := range merged {
+		if merged[k].Name == "" {
+			continue
+		}
+		merged[k].ID = graph.EntityID("acme/widgets", merged[k].Kind, merged[k].Name, merged[k].SourceFile)
+	}
+	return merged
+}
+
+// TestIssue4705_ReplaceImportResolvesInternal: `import "example.com/x"` backed by
+// `replace example.com/x => ./internal/x` binds to the in-repo file entity
+// rather than falling through to external_package.
+func TestIssue4705_ReplaceImportResolvesInternal(t *testing.T) {
+	const module = "github.com/acme/widgets"
+	goMod := "module " + module + "\n\ngo 1.22\n\nreplace example.com/x => ./internal/x\n"
+	files := map[string]string{
+		"internal/x/x.go":           "package x\nfunc Helper() int { return 0 }\n",
+		"internal/engine/engine.go": "package engine\nimport \"example.com/x\"\nfunc Run() int { return x.Helper() }\n",
+	}
+	merged := extractGoModuleWithGoMod(t, goMod, files)
+
+	// The extractor must stamp go_pkg_dir = "internal/x" on the replaced import.
+	stamped := false
+	for k := range merged {
+		for j := range merged[k].Relationships {
+			r := merged[k].Relationships[j]
+			if r.Kind == "IMPORTS" && r.ToID == "example.com/x" {
+				if r.Properties["go_pkg_dir"] == "internal/x" {
+					stamped = true
+				}
+			}
+		}
+	}
+	if !stamped {
+		t.Fatal("replaced import example.com/x was not stamped go_pkg_dir=internal/x")
+	}
+
+	// Identify the in-repo internal/x file entity IDs.
+	xFileIDs := map[string]bool{}
+	for k := range merged {
+		e := merged[k]
+		if e.Kind == "SCOPE.Component" && e.Subtype == "file" &&
+			filepath.Dir(e.SourceFile) == "internal/x" {
+			xFileIDs[e.ID] = true
+		}
+	}
+	if len(xFileIDs) == 0 {
+		t.Fatal("no internal/x file entity found")
+	}
+
+	// Count IMPORTS edges whose ToID now points at an internal/x file entity.
+	connected := func() int {
+		n := 0
+		for k := range merged {
+			for j := range merged[k].Relationships {
+				r := merged[k].Relationships[j]
+				if r.Kind == "IMPORTS" && xFileIDs[r.ToID] {
+					n++
+				}
+			}
+		}
+		return n
+	}
+
+	if c := connected(); c != 0 {
+		t.Fatalf("precondition: expected 0 resolved importers pre-pass, got %d", c)
+	}
+
+	n := resolve.ResolveGoInTreeImports(merged)
+	t.Logf("ResolveGoInTreeImports rewrote %d edges; connected after=%d", n, connected())
+	if connected() < 1 {
+		t.Errorf("replaced import did not resolve to internal/x (#4705c)")
+	}
+}

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -703,7 +703,43 @@ func modulesForPythonFile(p string) []string {
 			break
 		}
 	}
+	// #4705a: src-layout / Django source roots nested under a project
+	// container. Many Django repos place apps under `src/`, `app/`, or a
+	// Django `apps/` package one or more directories below the repo root
+	// (e.g. `backend/src/core/models.py`, `server/apps/users/views.py`).
+	// The leading-prefix strip above misses these because the source-root
+	// marker is interior. Strip ONE recognised source-root segment found
+	// anywhere on a segment boundary so `from core.models import X` /
+	// `from users.views import V` bind to the internal file. This is the
+	// dominant under-linking pattern for the Django oracle. The markers
+	// are conventional package roots (`apps.`, `src.`, `app.`, `lib.`),
+	// matched with the same single-strip, boundary-anchored discipline as
+	// the Java source-root strip to avoid monorepo tail collisions.
+	for _, prefix := range pythonInteriorSourceRoots {
+		if tail, ok := stripAfterSourceRoot(out[0], prefix); ok && tail != "" {
+			out = appendUnique(out, tail)
+			break
+		}
+	}
 	return out
+}
+
+// pythonInteriorSourceRoots lists conventional Python/Django source-root
+// package segments that modulesForPythonFile may strip once when found on
+// an interior segment boundary (#4705a). Dotted, trailing-dot form. Kept
+// deliberately small to avoid monorepo collisions.
+var pythonInteriorSourceRoots = []string{"apps.", "src.", "app."}
+
+// appendUnique appends s to out only when not already present. Keeps the
+// dotted-module alias slices free of duplicates when multiple strip rules
+// converge on the same tail.
+func appendUnique(out []string, s string) []string {
+	for _, e := range out {
+		if e == s {
+			return out
+		}
+	}
+	return append(out, s)
 }
 
 // modulesForJavaFile derives the dotted package path of a Java source
@@ -731,14 +767,19 @@ func modulesForJavaFile(p string) []string {
 	}
 	dotted := strings.ReplaceAll(dir, "/", ".")
 	out := []string{dotted}
-	// Strip well-known Java source-root prefixes once. Keep the
-	// pre-strip form too so an in-corpus class indexed under its
-	// repo-relative dotted form continues to resolve. The strip is
-	// conservative — only the canonical Maven/Gradle layouts, plus
-	// the same generic prefixes used by Python.
+	// Strip the canonical Maven/Gradle source root. #4705b: the source
+	// root is matched ANYWHERE in the dotted path (anchored on segment
+	// boundaries), not only as a leading prefix, so Gradle multi-module
+	// layouts — `lib/src/main/java/com/acme/Bar.java`,
+	// `app/src/main/java/...` — strip their leading module-container
+	// segment and the import `com.acme.Bar` binds to the internal class.
+	// The canonical `src.main.java.`-style markers are specific enough
+	// that an interior match is safe (a real package would not contain
+	// the literal `src.main.java` triple). The pre-strip form is kept too
+	// so a corpus indexed at the source root still resolves.
 	for _, prefix := range javaSourceRootPrefixes {
-		if strings.HasPrefix(dotted, prefix) {
-			out = append(out, strings.TrimPrefix(dotted, prefix))
+		if tail, ok := stripAfterSourceRoot(dotted, prefix); ok {
+			out = append(out, tail)
 			break
 		}
 	}
@@ -749,6 +790,23 @@ func modulesForJavaFile(p string) []string {
 		}
 	}
 	return out
+}
+
+// stripAfterSourceRoot returns the dotted-path tail that follows the
+// canonical source-root marker `root` (a dotted, trailing-dot form such
+// as "src.main.java."), matched as a leading prefix OR anchored at a
+// segment boundary anywhere in `dotted`. Returns (tail, true) on a match,
+// ("", false) otherwise. Used to honor Gradle/Maven multi-module layouts
+// where a module-container segment precedes the source root (#4705b).
+func stripAfterSourceRoot(dotted, root string) (string, bool) {
+	if strings.HasPrefix(dotted, root) {
+		return strings.TrimPrefix(dotted, root), true
+	}
+	// Interior match must sit on a segment boundary: ".<root>".
+	if idx := strings.Index(dotted, "."+root); idx >= 0 {
+		return dotted[idx+1+len(root):], true
+	}
+	return "", false
 }
 
 // modulesForScalaFile derives the dotted-package forms of a Scala source

--- a/internal/resolve/module_root_alias_4705_test.go
+++ b/internal/resolve/module_root_alias_4705_test.go
@@ -1,0 +1,101 @@
+// module_root_alias_4705_test.go — #4705: module-root / source-root alias
+// resolution so rooted internal imports bind to the internal target BEFORE
+// falling through to external_package.
+//
+//   - Python (#4705a): src-layout, namespace packages, and Django source
+//     roots nested under a project container (`server/apps/users/...`).
+//   - Java   (#4705b): canonical Maven/Gradle source roots, including
+//     Gradle multi-module layouts where a container segment precedes the
+//     source root (`lib/src/main/java/...`, `app/src/main/java/...`).
+//
+// The Go half (#4705c, go.mod local-path `replace`) is validated end-to-end
+// in internal/extractors/golang/issue4705_replace_test.go.
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func resolveDotted(t *testing.T, recs []types.EntityRecord, dotted string) (string, bool) {
+	t.Helper()
+	return BuildImportTable(recs).ResolveDottedImportTarget(dotted)
+}
+
+func TestModuleRootAlias4705_PythonSrcLayout(t *testing.T) {
+	// src/myapp/models.py defines X; import `from myapp.models import X`.
+	recs := []types.EntityRecord{
+		{ID: "x", Name: "X", Kind: "SCOPE.Operation", SourceFile: "src/myapp/models.py", Language: "python"},
+	}
+	if id, ok := resolveDotted(t, recs, "myapp.models.X"); !ok || id != "x" {
+		t.Errorf("src-layout: myapp.models.X => (%q,%v), want (x,true)", id, ok)
+	}
+}
+
+func TestModuleRootAlias4705_PythonNamespacePackage(t *testing.T) {
+	// Namespace package (no __init__.py) under src/.
+	recs := []types.EntityRecord{
+		{ID: "t", Name: "Thing", Kind: "SCOPE.Operation", SourceFile: "src/myns/sub/mod.py", Language: "python"},
+	}
+	if id, ok := resolveDotted(t, recs, "myns.sub.mod.Thing"); !ok || id != "t" {
+		t.Errorf("namespace pkg: myns.sub.mod.Thing => (%q,%v), want (t,true)", id, ok)
+	}
+}
+
+func TestModuleRootAlias4705_PythonDjangoAppsContainer(t *testing.T) {
+	// Django apps under a nested `apps/` package: `from users.views import V`.
+	recs := []types.EntityRecord{
+		{ID: "v", Name: "V", Kind: "SCOPE.Operation", SourceFile: "server/apps/users/views.py", Language: "python"},
+	}
+	if id, ok := resolveDotted(t, recs, "users.views.V"); !ok || id != "v" {
+		t.Errorf("django apps/: users.views.V => (%q,%v), want (v,true)", id, ok)
+	}
+}
+
+func TestModuleRootAlias4705_JavaSourceRoot(t *testing.T) {
+	recs := []types.EntityRecord{
+		{ID: "bar", Name: "Bar", Kind: "SCOPE.Component", SourceFile: "src/main/java/com/acme/Bar.java", Language: "java"},
+	}
+	if id, ok := resolveDotted(t, recs, "com.acme.Bar"); !ok || id != "bar" {
+		t.Errorf("java src root: com.acme.Bar => (%q,%v), want (bar,true)", id, ok)
+	}
+}
+
+func TestModuleRootAlias4705_JavaGradleMultiModule(t *testing.T) {
+	// Gradle multi-module: container segment precedes the source root.
+	recs := []types.EntityRecord{
+		{ID: "j1", Name: "Bar", Kind: "SCOPE.Component", SourceFile: "lib/src/main/java/com/acme/Bar.java", Language: "java"},
+		{ID: "j2", Name: "Baz", Kind: "SCOPE.Component", SourceFile: "app/src/main/java/com/acme/Baz.java", Language: "java"},
+	}
+	tbl := BuildImportTable(recs)
+	if id, ok := tbl.ResolveDottedImportTarget("com.acme.Bar"); !ok || id != "j1" {
+		t.Errorf("gradle lib module: com.acme.Bar => (%q,%v), want (j1,true)", id, ok)
+	}
+	if id, ok := tbl.ResolveDottedImportTarget("com.acme.Baz"); !ok || id != "j2" {
+		t.Errorf("gradle app module: com.acme.Baz => (%q,%v), want (j2,true)", id, ok)
+	}
+}
+
+// stripAfterSourceRoot unit coverage: interior match must respect segment
+// boundaries (a substring that is not segment-aligned must NOT match).
+func TestStripAfterSourceRoot(t *testing.T) {
+	cases := []struct {
+		dotted, root, wantTail string
+		wantOK                 bool
+	}{
+		{"src.main.java.com.acme", "src.main.java.", "com.acme", true},
+		{"lib.src.main.java.com.acme", "src.main.java.", "com.acme", true},
+		{"app.src.main.java.com.acme", "src.main.java.", "com.acme", true},
+		{"com.acme.foo", "src.main.java.", "", false},
+		// not segment-aligned: "xsrc.main.java" must not match "src.main.java."
+		{"xsrc.main.java.com", "src.main.java.", "", false},
+	}
+	for _, c := range cases {
+		tail, ok := stripAfterSourceRoot(c.dotted, c.root)
+		if tail != c.wantTail || ok != c.wantOK {
+			t.Errorf("stripAfterSourceRoot(%q,%q) = (%q,%v), want (%q,%v)",
+				c.dotted, c.root, tail, ok, c.wantTail, c.wantOK)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4705.

Internal-resolution complement to the TS tsconfig `baseUrl`/`paths` fix (#4696/#4706). Resolves rooted/aliased **internal** imports to internal targets BEFORE falling through to `external_package`, reducing under-linking (the Python part helps the Django ORACLE).

**Precedence (mirrors TS):** relative → module-root/alias (internal) → external_package → unresolved-bug.

## Per-language mechanism honored
- **Python (#4705a)** — `modulesForPythonFile` strips a leading `src.`/`lib.`/`app.` root (existing) AND, new, a recognised source-root segment (`apps.`/`src.`/`app.`) found on an interior segment boundary (single-strip, boundary-anchored). So Django apps nested under a project container — `server/apps/users/views.py` — resolve `from users.views import V` internal. src-layout (`src/myapp/models.py`) and namespace packages (no `__init__.py`) resolve via the existing prefix strip; both are now covered by tests. Bare containers with no convention marker (e.g. `backend/`) deliberately stay unresolved (honest — avoids monorepo tail collisions).
- **Java (#4705b)** — `modulesForJavaFile` matches the canonical Maven/Gradle source root (`src.main.java.`, `src.test.java.`, kotlin variants) anywhere on a segment boundary, not only as a leading prefix, via the new `stripAfterSourceRoot`. Gradle multi-module layouts (`lib/src/main/java/...`, `app/src/main/java/...`) strip the container segment and `com.acme.Bar` binds to the internal class.
- **Go (#4705c)** — parse go.mod local-path `replace old => ./dir` directives (`gomod.go`: `goModuleReplaces`/`parseGoModReplaces`/`goReplacePkgDir`). The Go extractor stamps `go_pkg_dir` for a replaced import and its sub-packages so `ResolveGoInTreeImports` binds it to the in-repo file entity. Network/version replacements and `../`-escape/absolute targets keep external disposition.

## Fixtures (RED→GREEN)
- `internal/resolve/module_root_alias_4705_test.go` — Python src-layout, namespace pkg, Django `apps/` container; Java source root + Gradle multi-module; `stripAfterSourceRoot` boundary unit.
- `internal/extractors/golang/issue4705_replace_test.go` — end-to-end: `import "example.com/x"` + `replace example.com/x => ./internal/x` stamps `go_pkg_dir=internal/x` and resolves to the internal file (rewrote=1, connected=1).
- `internal/extractors/golang/gomod_test.go` — single-line + block replace parsing, `goReplacePkgDir`, `cleanGoLocalReplaceDir`.

## Coverage
`import_resolution_quality` cells updated surgically (via `coverage update`, canonical) for python(django/django-drf), java(spring-boot), go(net-http). `coverage fmt --check`: ok.

## Gates
`go build ./...` ✅ · `go vet ./internal/extractors/... ./internal/external/...` ✅ · `go test ./internal/extractors/... ./internal/external/... ./internal/mcp/... ./internal/resolve/...` ✅ (no FAIL/panic) · `coverage fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)