### PR TITLE
fix(authposture): Spring effective-guard precedence (method ▸ class ▸ global) (#4674)

### DIFF
--- a/internal/authposture/authposture_test.go
+++ b/internal/authposture/authposture_test.go
@@ -495,3 +495,148 @@ func TestDRF_ClassOverridesGlobalDefault(t *testing.T) {
 		t.Fatalf("got %s, want public (class permission_classes=[AllowAny] overrides global IsAuthenticated)", p.Kind)
 	}
 }
+
+// --- #4674: Spring EFFECTIVE-guard precedence (method ▸ class ▸ global) --------
+//
+// The Spring analog of the NestJS effective-guard fix and the DRF method▸class▸
+// global fix. The resolver must resolve the most-specific posture: a method-level
+// @PreAuthorize/@Secured/@RolesAllowed/@PermitAll ▸ the controller-class
+// annotation ▸ a SecurityFilterChain/HttpSecurity rule matched to the route.
+
+// (A) class @PreAuthorize("hasRole('USER')") with a method @PreAuthorize("permitAll()").
+// The annotated method resolves PUBLIC (method wins) while a sibling that carries
+// only the class annotation resolves to the USER role.
+func TestSpring_MethodPermitAll_OverridesClassRole(t *testing.T) {
+	reg := NewRegistry()
+	// The method-level @PreAuthorize("permitAll()") override endpoint.
+	m, fw := reg.Resolve(Signal{Props: map[string]string{
+		"framework":                  "spring",
+		"auth_expression":            "permitAll()",
+		"spring_class_pre_authorize": "hasRole('USER')",
+	}})
+	if fw != "spring-security" {
+		t.Fatalf("framework=%s, want spring-security", fw)
+	}
+	if m.Kind != KindPublic {
+		t.Fatalf("method: got %s, want public (method @PreAuthorize(permitAll()) overrides class)", m.Kind)
+	}
+	// A sibling handler with NO method annotation inherits the class @PreAuthorize.
+	sib, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework":                  "spring",
+		"spring_class_pre_authorize": "hasRole('USER')",
+	}})
+	if sib.Kind != KindRole || sib.Literal != "USER" {
+		t.Fatalf("sibling: got %s/%q, want role/USER (inherited class @PreAuthorize)", sib.Kind, sib.Literal)
+	}
+}
+
+// (B) No method/class annotation, but a SecurityFilterChain
+// `.requestMatchers("/admin/**").hasRole("ADMIN")` rule the engine matched to the
+// route → resolves the ADMIN role via the global level.
+func TestSpring_GlobalFilterChain_AppliesWhenNoMethodOrClass(t *testing.T) {
+	reg := NewRegistry()
+	p, fw := reg.Resolve(Signal{Props: map[string]string{
+		"framework":                   "spring",
+		"spring_global_authorization": `requestMatchers("/admin/**").hasRole("ADMIN")`,
+	}})
+	if fw != "spring-security" {
+		t.Fatalf("framework=%s, want spring-security", fw)
+	}
+	if p.Kind != KindRole || p.Literal != "ADMIN" {
+		t.Fatalf("got %s/%q, want role/ADMIN (global SecurityFilterChain rule)", p.Kind, p.Literal)
+	}
+}
+
+// (B2) A global permitAll() rule resolves PUBLIC; a global authenticated() rule
+// resolves authenticated — the rest of the HttpSecurity DSL vocabulary.
+func TestSpring_GlobalFilterChain_PermitAllAndAuthenticated(t *testing.T) {
+	reg := NewRegistry()
+	pub, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework":                   "spring",
+		"spring_global_authorization": `antMatchers("/public/**").permitAll()`,
+	}})
+	if pub.Kind != KindPublic {
+		t.Fatalf("got %s, want public (global permitAll())", pub.Kind)
+	}
+	authed, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework":                   "spring",
+		"spring_global_authorization": `requestMatchers("/api/**").authenticated()`,
+	}})
+	if authed.Kind != KindAuthenticated {
+		t.Fatalf("got %s, want authenticated (global authenticated())", authed.Kind)
+	}
+}
+
+// (C) Method @Secured("ROLE_X") over class @RolesAllowed("ROLE_Y") → the method
+// annotation wins (X), the class is shadowed.
+func TestSpring_MethodSecured_OverridesClassRolesAllowed(t *testing.T) {
+	reg := NewRegistry()
+	p, fw := reg.Resolve(Signal{Props: map[string]string{
+		"framework":                  "spring",
+		"secured":                    "ROLE_X",
+		"spring_class_roles_allowed": "ROLE_Y",
+	}})
+	if fw != "spring-security" {
+		t.Fatalf("framework=%s, want spring-security", fw)
+	}
+	if p.Kind != KindRole || p.Literal != "X" {
+		t.Fatalf("got %s/%q, want role/X (method @Secured wins over class @RolesAllowed)", p.Kind, p.Literal)
+	}
+}
+
+// Class wins over global (precedence level 2 > 3): a class @PreAuthorize role
+// shadows a matching SecurityFilterChain permitAll() rule.
+func TestSpring_ClassOverridesGlobal(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework":                   "spring",
+		"spring_class_pre_authorize":  "hasRole('MANAGER')",
+		"spring_global_authorization": `requestMatchers("/**").permitAll()`,
+	}})
+	if p.Kind != KindRole || p.Literal != "MANAGER" {
+		t.Fatalf("got %s/%q, want role/MANAGER (class @PreAuthorize overrides global permitAll())", p.Kind, p.Literal)
+	}
+}
+
+// A recognised Spring handler with no decodable method/class/global grant →
+// unknown (never false-public).
+func TestSpring_NoDecodableGrant_IsUnknownNotPublic(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework":   "spring",
+		"auth_method": "spring-security",
+	}})
+	if p.Kind == KindPublic {
+		t.Fatalf("recognised-but-undecodable Spring handler resolved PUBLIC; must be unknown")
+	}
+	if p.Kind != KindUnknown {
+		t.Fatalf("got %s, want unknown", p.Kind)
+	}
+}
+
+// End-to-end: a Spring class-role handler vs a Django role oracle is EQUIVALENT,
+// and a Spring method permitAll() override vs the same oracle is LOOSER (the
+// override opened the endpoint).
+func TestSpring_E2E_ClassRoleVsOracle_AndMethodOverrideLooser(t *testing.T) {
+	reg := NewRegistry()
+	// Oracle: a DRF class with permission_classes naming a role-equivalent gate.
+	oracle, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "django", "has_permission_classes": "true",
+		"permission_classes": "IsAuthenticated",
+	}})
+	// Sibling Spring handler inherits the class @PreAuthorize → authenticated-or-stricter.
+	sib, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "spring", "spring_class_pre_authorize": "isAuthenticated()",
+	}})
+	if d := Diff(sib, oracle); d.Verdict != VerdictEquivalent {
+		t.Fatalf("sibling verdict=%s detail=%s, want equivalent (both authenticated)", d.Verdict, d.Detail)
+	}
+	// The method override opens it → looser than the authenticated oracle.
+	over, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "spring", "auth_expression": "permitAll()",
+		"spring_class_pre_authorize": "isAuthenticated()",
+	}})
+	if d := Diff(over, oracle); d.Verdict != VerdictLooser {
+		t.Fatalf("override verdict=%s detail=%s, want looser (permitAll opened an authenticated endpoint)", d.Verdict, d.Detail)
+	}
+}

--- a/internal/authposture/spring.go
+++ b/internal/authposture/spring.go
@@ -1,5 +1,7 @@
 // spring.go — the Spring Security auth-posture resolver (#4708; replaces the
-// spring-security stub).
+// spring-security stub) plus the EFFECTIVE-GUARD PRECEDENCE ladder (#4674 — the
+// Spring analog of the NestJS effective-guard fix #4667/#4676 and the DRF
+// method▸class▸global fix #4675).
 //
 // Spring expresses method/class authorization through annotations the engine
 // stamps onto the handler/controller, with a raw-source fallback:
@@ -13,11 +15,37 @@
 //   - @RolesAllowed("ADMIN")                   → role grant (JSR-250).
 //   - @PreAuthorize("hasRole('SUPERUSER') ...) → superuser when the role names it.
 //
+// EFFECTIVE PRECEDENCE (most-specific wins, mirroring how Spring Security itself
+// evaluates a request — #4674):
+//
+//	1. METHOD level — a @PreAuthorize/@PostAuthorize/@Secured/@RolesAllowed/
+//	   @PermitAll/@DenyAll annotation on the HANDLER method. Applies to THAT
+//	   endpoint only; siblings without their own annotation inherit the class
+//	   one. Read from the method-level props the engine stamps (auth_expression /
+//	   pre_authorize / secured / roles_allowed / auth_roles) or the engine's
+//	   already-resolved effective auth_guard stamp, with a handler-source
+//	   fallback.
+//	2. CLASS level — the same annotations on the @Controller/@RestController
+//	   class. Applies to handlers WITHOUT their own method annotation. Read from
+//	   the spring_class_* props the engine stamps from the controller annotation
+//	   block (spring_class_pre_authorize / spring_class_secured /
+//	   spring_class_roles_allowed).
+//	3. GLOBAL level — a Spring Security SecurityFilterChain / HttpSecurity
+//	   `authorizeHttpRequests` rule (`.requestMatchers("/path").hasRole(...) /
+//	   .authenticated() / .permitAll()`) or a legacy WebSecurityConfigurerAdapter
+//	   `antMatchers(...)` rule whose ant-pattern matches THIS route. Applies only
+//	   when NEITHER a method nor a class annotation covers the handler. The engine
+//	   matches the route's ant-pattern (where statically recoverable) and stamps
+//	   the winning rule's authorization expression into spring_global_authorization.
+//	   GLOBAL matching is best-effort: dynamically-built matchers, regex matchers,
+//	   and SpEL access() rules the engine cannot statically resolve are NOT
+//	   matched (documented gap) — the resolver then reports KindUnknown rather
+//	   than false-public.
+//
 // The annotation literal is read first from the reconciled props the engine
-// stamps (auth_expression / auth_roles / pre_authorize / secured / roles_allowed)
-// and falls back to scanning the handler source. Output normalises into the
-// shared {Kind, Literal} vocabulary so the diff core compares a Spring posture
-// against the Django oracle or a NestJS posture directly.
+// stamps and falls back to scanning the handler source. Output normalises into
+// the shared {Kind, Literal} vocabulary so the diff core compares a Spring
+// posture against the Django oracle or a NestJS posture directly.
 package authposture
 
 import (
@@ -34,76 +62,237 @@ var (
 	springHasAuthorityRe = regexp.MustCompile(`has(?:Any)?Authority\s*\(\s*["']([^"']+)["']`)
 	springPermitAllRe    = regexp.MustCompile(`\bpermitAll\b`)
 	springDenyAllRe      = regexp.MustCompile(`\bdenyAll\b`)
-	springIsAuthRe       = regexp.MustCompile(`\bisAuthenticated\s*\(\s*\)|\bisFullyAuthenticated\s*\(\s*\)`)
+	// Authenticated-only: the SpEL forms isAuthenticated()/isFullyAuthenticated()
+	// AND the HttpSecurity DSL form `.authenticated()` / `.fullyAuthenticated()`
+	// (the global filter-chain vocabulary, #4674).
+	springIsAuthRe = regexp.MustCompile(`\bis(?:Fully)?Authenticated\s*\(\s*\)|\.\s*(?:fully)?[aA]uthenticated\s*\(\s*\)`)
 	springAnonymousRe    = regexp.MustCompile(`\bisAnonymous\s*\(\s*\)|\bpermitAll\b`)
 
 	// Annotation forms on raw source.
-	springPreAuthorizeRe = regexp.MustCompile(`@PreAuthorize\s*\(\s*["']([^"']+)["']`)
+	springPreAuthorizeRe = regexp.MustCompile(`@(?:Pre|Post)Authorize\s*\(\s*["']([^"']+)["']`)
 	springSecuredRe      = regexp.MustCompile(`@Secured\s*\(\s*(?:\{\s*)?["']([^"']+)["']`)
 	springRolesAllowedRe = regexp.MustCompile(`@RolesAllowed\s*\(\s*(?:\{\s*)?["']([^"']+)["']`)
+	springPermitAllAnnRe = regexp.MustCompile(`@PermitAll\b`)
+	springDenyAllAnnRe   = regexp.MustCompile(`@DenyAll\b`)
 )
 
 // Resolve decodes a Spring Security auth signal. Recognises the framework when
 // the entity carries a Spring auth prop OR a @PreAuthorize/@Secured/@RolesAllowed
-// annotation in its source. Reconciled props win; source annotations are the
-// fallback.
+// annotation in its source. It then resolves the EFFECTIVE posture down the
+// most-specific-wins ladder (method ▸ class ▸ global, #4674).
 func (s springSecurityResolver) Resolve(sig Signal) (Posture, bool) {
-	expr := firstNonEmpty(
-		sig.prop("auth_expression"),
-		sig.prop("pre_authorize"),
-		sig.prop("preauthorize"),
-	)
-	secured := firstNonEmpty(sig.prop("secured"), sig.prop("roles_allowed"))
-	roles := sig.prop("auth_roles")
-
-	hasAnyProp := expr != "" || secured != "" || roles != "" ||
-		sig.prop("auth_method") == "spring-security"
-	hasSource := hasSpringAnnotation(sig.Source)
-	if !hasAnyProp && !hasSource {
+	if !s.recognises(sig) {
 		return Posture{}, false
 	}
 
-	// (1) Reconciled @PreAuthorize expression — richest signal.
-	if expr != "" {
+	// (1) METHOD level — most specific, wins over class + global.
+	if p, ok := s.methodPosture(sig); ok {
+		return p, true
+	}
+	// (2) CLASS level — applies to handlers without their own method annotation.
+	if p, ok := s.classPosture(sig); ok {
+		return p, true
+	}
+	// (3) GLOBAL level — SecurityFilterChain / HttpSecurity rule matched to the
+	// route (best-effort; absent when no statically-recoverable matcher applies).
+	if p, ok := s.globalPosture(sig); ok {
+		return p, true
+	}
+
+	// Recognised as Spring-secured but no method/class/global grant decodable →
+	// unknown (never false-public).
+	return Posture{Kind: KindUnknown, Detail: "Spring handler with no decodable auth annotation or matching filter-chain rule"}, true
+}
+
+// recognises reports whether the signal belongs to the Spring resolver: it
+// carries a Spring auth prop (method, class, or global) or a Spring annotation
+// in the handler source.
+func (s springSecurityResolver) recognises(sig Signal) bool {
+	return s.methodExpr(sig) != "" ||
+		s.methodSecured(sig) != "" ||
+		sig.prop("auth_roles") != "" ||
+		sig.prop("auth_guard") != "" ||
+		sig.prop("auth_method") == "spring-security" ||
+		s.classExpr(sig) != "" || s.classSecured(sig) != "" ||
+		sig.prop("spring_global_authorization") != "" ||
+		hasSpringAnnotation(sig.Source)
+}
+
+// --- (1) METHOD level -------------------------------------------------------
+
+func (s springSecurityResolver) methodExpr(sig Signal) string {
+	return firstNonEmpty(
+		sig.prop("auth_expression"),
+		sig.prop("pre_authorize"),
+		sig.prop("preauthorize"),
+		sig.prop("post_authorize"),
+	)
+}
+
+func (s springSecurityResolver) methodSecured(sig Signal) string {
+	return firstNonEmpty(sig.prop("secured"), sig.prop("roles_allowed"))
+}
+
+// methodPosture resolves the method-level (handler) posture: reconciled
+// @PreAuthorize expression ▸ @Secured/@RolesAllowed role literal ▸ bare
+// auth_roles ▸ the engine's effective auth_guard stamp ▸ a handler-source
+// annotation. Returns ok=false when the handler carries no method-level signal
+// (the caller then falls to class, then global).
+func (s springSecurityResolver) methodPosture(sig Signal) (Posture, bool) {
+	// (1a) Reconciled @PreAuthorize expression — richest signal.
+	if expr := s.methodExpr(sig); expr != "" {
 		if p, ok := postureFromSpringExpression(expr, "auth_expression="+expr); ok {
 			return p, true
 		}
 	}
-	// (2) @Secured / @RolesAllowed reconciled role literal.
-	if secured != "" {
+	// (1b) @Secured / @RolesAllowed reconciled role literal.
+	if secured := s.methodSecured(sig); secured != "" {
 		return Posture{Kind: KindRole, Literal: stripRolePrefix(firstCSV(secured)),
 			Detail: "secured/roles_allowed=" + secured}, true
 	}
-	// (3) Bare auth_roles list.
-	if roles != "" {
+	// (1c) Bare auth_roles list (engine-flattened @PreAuthorize/@Secured roles).
+	if roles := sig.prop("auth_roles"); roles != "" {
 		return Posture{Kind: KindRole, Literal: stripRolePrefix(firstCSV(roles)),
 			Detail: "auth_roles=" + roles}, true
 	}
-
-	// (4) Source-annotation fallback — same priority order.
-	if src := sig.Source; src != "" {
-		if m := springPreAuthorizeRe.FindStringSubmatch(src); m != nil {
-			if p, ok := postureFromSpringExpression(m[1], "@PreAuthorize("+m[1]+")"); ok {
-				return p, true
-			}
-		}
-		if m := springSecuredRe.FindStringSubmatch(src); m != nil {
-			return Posture{Kind: KindRole, Literal: stripRolePrefix(m[1]),
-				Detail: "@Secured(" + m[1] + ")"}, true
-		}
-		if m := springRolesAllowedRe.FindStringSubmatch(src); m != nil {
-			return Posture{Kind: KindRole, Literal: stripRolePrefix(m[1]),
-				Detail: "@RolesAllowed(" + m[1] + ")"}, true
+	// (1d) EFFECTIVE auth_guard stamp. When the engine resolves the most-specific
+	// (method ▸ class) Spring annotation it can stamp the winning annotation text
+	// into auth_guard; decode it the same way (mirrors the NestJS effective-guard
+	// decode #4667). This carries the SpEL/annotation text, NOT a guard class.
+	if guard := sig.prop("auth_guard"); guard != "" {
+		if p, ok := decodeSpringGuardText(guard, "auth_guard="+guard); ok {
+			return p, true
 		}
 	}
+	// (1e) Source-annotation fallback on the HANDLER body — same priority order.
+	if p, ok := decodeSpringSource(sig.Source, "method"); ok {
+		return p, true
+	}
+	return Posture{}, false
+}
 
-	// Recognised as Spring-secured but no decodable grant → unknown (never
-	// false-public).
-	return Posture{Kind: KindUnknown, Detail: "Spring handler with no decodable auth annotation"}, true
+// --- (2) CLASS level --------------------------------------------------------
+
+func (s springSecurityResolver) classExpr(sig Signal) string {
+	return firstNonEmpty(
+		sig.prop("spring_class_pre_authorize"),
+		sig.prop("spring_class_post_authorize"),
+		sig.prop("class_pre_authorize"),
+	)
+}
+
+func (s springSecurityResolver) classSecured(sig Signal) string {
+	return firstNonEmpty(
+		sig.prop("spring_class_secured"),
+		sig.prop("spring_class_roles_allowed"),
+		sig.prop("class_secured"),
+		sig.prop("class_roles_allowed"),
+	)
+}
+
+// classPosture resolves the controller-class-level posture, applied to handlers
+// that carry no method-level annotation of their own. Read from the spring_class_*
+// props the engine stamps from the @Controller/@RestController annotation block.
+func (s springSecurityResolver) classPosture(sig Signal) (Posture, bool) {
+	if expr := s.classExpr(sig); expr != "" {
+		if p, ok := postureFromSpringExpression(expr, "class @PreAuthorize("+expr+")"); ok {
+			return p, true
+		}
+	}
+	if secured := s.classSecured(sig); secured != "" {
+		return Posture{Kind: KindRole, Literal: stripRolePrefix(firstCSV(secured)),
+			Detail: "class @Secured/@RolesAllowed=" + secured}, true
+	}
+	return Posture{}, false
+}
+
+// --- (3) GLOBAL level -------------------------------------------------------
+
+// globalPosture resolves the Spring Security HttpSecurity / SecurityFilterChain
+// authorization rule the engine matched to THIS route (by ant-pattern, where
+// statically recoverable). The matched rule's authorization expression is
+// stamped into spring_global_authorization, e.g.:
+//
+//	spring_global_authorization = `requestMatchers("/admin/**").hasRole("ADMIN")`
+//	spring_global_authorization = `antMatchers("/public/**").permitAll()`
+//	spring_global_authorization = `requestMatchers("/api/**").authenticated()`
+//
+// Best-effort by design (#4674): the engine only matches statically-recoverable
+// ant-patterns; dynamic/regex matchers and SpEL access() rules are not matched,
+// in which case the prop is absent and this returns ok=false (the caller then
+// reports KindUnknown — never false-public).
+func (s springSecurityResolver) globalPosture(sig Signal) (Posture, bool) {
+	rule := sig.prop("spring_global_authorization")
+	if rule == "" {
+		return Posture{}, false
+	}
+	if p, ok := decodeSpringGuardText(rule, "global filter-chain rule: "+rule); ok {
+		return p, true
+	}
+	// A matched global rule we recognise as Spring but cannot decode (e.g. a
+	// custom .access(beanRef) rule) is at minimum an authenticated gate, but we
+	// classify it unknown so the diff never false-equivalents a custom rule.
+	return Posture{Kind: KindUnknown, Detail: "global filter-chain rule matched but uninterpreted: " + rule}, true
+}
+
+// --- shared decoders --------------------------------------------------------
+
+// decodeSpringGuardText decodes an engine-stamped annotation/rule text into the
+// shared vocabulary. It accepts both the @PreAuthorize SpEL body forms
+// (hasRole/hasAuthority/permitAll/...) AND the HttpSecurity DSL fluent forms
+// (.hasRole("X")/.permitAll()/.authenticated()/.denyAll()), since both express
+// the same authorization vocabulary. Returns ok=false when no token is found.
+func decodeSpringGuardText(text, detail string) (Posture, bool) {
+	// Explicit @PreAuthorize/@Secured annotation forms embedded in the text.
+	if m := springPreAuthorizeRe.FindStringSubmatch(text); m != nil {
+		return postureFromSpringExpression(m[1], detail)
+	}
+	if m := springSecuredRe.FindStringSubmatch(text); m != nil {
+		return Posture{Kind: KindRole, Literal: stripRolePrefix(m[1]), Detail: detail}, true
+	}
+	if m := springRolesAllowedRe.FindStringSubmatch(text); m != nil {
+		return Posture{Kind: KindRole, Literal: stripRolePrefix(m[1]), Detail: detail}, true
+	}
+	if springPermitAllAnnRe.MatchString(text) {
+		return Posture{Kind: KindPublic, Detail: detail}, true
+	}
+	if springDenyAllAnnRe.MatchString(text) {
+		return Posture{Kind: KindSuperuser, Detail: detail}, true
+	}
+	// SpEL / HttpSecurity-DSL expression body (shared vocabulary).
+	return postureFromSpringExpression(text, detail)
+}
+
+// decodeSpringSource scans a raw handler/controller source body for a Spring
+// annotation in @PreAuthorize ▸ @Secured ▸ @RolesAllowed ▸ @PermitAll ▸ @DenyAll
+// priority order. tier is "method" or "class" (for the detail string only).
+func decodeSpringSource(src, tier string) (Posture, bool) {
+	if src == "" {
+		return Posture{}, false
+	}
+	if m := springPreAuthorizeRe.FindStringSubmatch(src); m != nil {
+		return postureFromSpringExpression(m[1], tier+" @PreAuthorize("+m[1]+")")
+	}
+	if m := springSecuredRe.FindStringSubmatch(src); m != nil {
+		return Posture{Kind: KindRole, Literal: stripRolePrefix(m[1]),
+			Detail: tier + " @Secured(" + m[1] + ")"}, true
+	}
+	if m := springRolesAllowedRe.FindStringSubmatch(src); m != nil {
+		return Posture{Kind: KindRole, Literal: stripRolePrefix(m[1]),
+			Detail: tier + " @RolesAllowed(" + m[1] + ")"}, true
+	}
+	if springPermitAllAnnRe.MatchString(src) {
+		return Posture{Kind: KindPublic, Detail: tier + " @PermitAll"}, true
+	}
+	if springDenyAllAnnRe.MatchString(src) {
+		return Posture{Kind: KindSuperuser, Detail: tier + " @DenyAll"}, true
+	}
+	return Posture{}, false
 }
 
 // postureFromSpringExpression decodes a Spring Security SpEL expression
-// (@PreAuthorize body) into the shared vocabulary.
+// (@PreAuthorize body) — or an equivalent HttpSecurity DSL fragment — into the
+// shared vocabulary.
 func postureFromSpringExpression(expr, detail string) (Posture, bool) {
 	// denyAll is the tightest — treat as superuser-equivalent (nothing short of
 	// the strongest grant passes).
@@ -141,7 +330,9 @@ func hasSpringAnnotation(src string) bool {
 	}
 	return springPreAuthorizeRe.MatchString(src) ||
 		springSecuredRe.MatchString(src) ||
-		springRolesAllowedRe.MatchString(src)
+		springRolesAllowedRe.MatchString(src) ||
+		springPermitAllAnnRe.MatchString(src) ||
+		springDenyAllAnnRe.MatchString(src)
 }
 
 // stripRolePrefix folds the conventional Spring "ROLE_" authority prefix so a


### PR DESCRIPTION
Adds the most-specific-wins **precedence ladder** to the spring-security auth-posture resolver (added by #4708), completing the cross-framework effective-guard set alongside NestJS (#4667/#4676) and DRF (#4675). Scope is the Spring posture resolver only — `internal/mcp/auth_posture_diff_tool.go` (the #4550 JOIN) is untouched.

## Precedence ladder
The resolver resolves a Spring endpoint's EFFECTIVE grant down three levels:

1. **METHOD** — `@PreAuthorize`/`@PostAuthorize`/`@Secured`/`@RolesAllowed`/`@PermitAll`/`@DenyAll` on the handler (read from `auth_expression`/`pre_authorize`/`post_authorize`/`secured`/`roles_allowed`/`auth_roles` props, the engine's effective `auth_guard` stamp, or a handler-source fallback).
2. **CLASS** — the same annotations on the `@Controller`/`@RestController`, applied to handlers without their own (`spring_class_pre_authorize`/`spring_class_secured`/`spring_class_roles_allowed`).
3. **GLOBAL** — a `SecurityFilterChain`/`HttpSecurity` `authorizeHttpRequests` rule (`requestMatchers(...).hasRole/.authenticated/.permitAll/.denyAll`) or legacy `antMatchers(...)` matched to the route (`spring_global_authorization`), applied only when neither method nor class annotation covers the handler.

Decodes into the shared `{Kind,Literal}` vocabulary the other resolvers emit (`hasRole`→role, `hasAuthority`→action, `permitAll`→public, `authenticated`→authenticated, `denyAll`→superuser, SUPERUSER/ROOT role→superuser), so cross-group diff is uniform.

## Global matching limits (honest-partial)
GLOBAL matching is best-effort: the engine only matches statically-recoverable ant-patterns. Dynamically-built/regex matchers and custom `.access(beanRef)` SpEL rules are NOT matched and resolve to `KindUnknown` rather than false-public.

## Fixtures (RED→GREEN)
- **A**: class `@PreAuthorize("hasRole('USER')")` + method `@PreAuthorize("permitAll()")` → method PUBLIC, sibling USER role.
- **B**: no method/class annotation + `SecurityFilterChain` `.requestMatchers("/admin/**").hasRole("ADMIN")` → ADMIN via global (plus a permitAll/authenticated DSL variant).
- **C**: method `@Secured("ROLE_X")` over class `@RolesAllowed("ROLE_Y")` → method wins (X).
- Plus: class-over-global, unknown-not-public, and an end-to-end diff (class-role equivalent / method-override looser vs a Django oracle).

A and B fail on the pre-change resolver (verified); all green after.

## Coverage
spring-boot Auth cell updated surgically; `coverage fmt --check` clean.

## Gates
`go build ./...`, `go vet ./internal/authposture/... ./internal/dashboard/... ./internal/engine/...`, `go test ./internal/authposture/... ./internal/dashboard/... ./internal/engine/...`, `coverage fmt --check` — all pass.

Closes #4674

🤖 Generated with [Claude Code](https://claude.com/claude-code)