### PR TITLE
feat(dto-fields): FIELD-as-member indexing for marshmallow/attrs/dataclasses + Go tags + C# DataAnnotations + Ruby AMS (#4714, #4715)

### DIFF
--- a/internal/custom/csharp/dto_field_members.go
+++ b/internal/custom/csharp/dto_field_members.go
@@ -1,0 +1,292 @@
+package csharp
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// dto_field_members.go — C#/.NET DTO FIELD-as-member indexing (issue #4715),
+// generalizing the uniform DTO field-member model from the JS
+// (javascript/validation_schema.go::emitSchemaFieldMembers, #4635), Python
+// (python/dto_field_members.go, #4613), Java (java/spring_dto_fields.go, #4613)
+// and Go (golang/dto_field_members.go, #4715) emitters.
+//
+// Each DataAnnotations-bearing DTO/record class's properties become
+// `SCOPE.Schema` subtype=field sub-entities named `<Class>.<Property>`, carrying
+// the SAME property shape as the other frameworks so the cross-framework
+// field-level diff tools + the dashboard /shape ShapeTree resolver treat all
+// frameworks uniformly:
+//
+//	field_name   — the property name
+//	field_type   — normalized scalar/declared type ("string"/"integer"/...)
+//	parent_class — the owning DTO/record class name
+//	optional     — "true" when the property is nullable (`string?`) and not [Required]
+//	validators   — space-joined `@Attr` markers from DataAnnotation attributes
+//	provenance   — INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP
+//	library      — "data-annotations"
+//
+// The child's Signature is the Java-style `[@Attr ...] <type> <name>` so the
+// shape resolver's parseFieldSignature recovers (annotations, type, name)
+// exactly as it does for the JS/Java/Python/Go DTO fields. A CONTAINS edge binds
+// each field to its owner class via the `Class:<Class>` byName fallback.
+
+// csDTOProperty is a captured property: name, normalized type, optionality, and
+// DataAnnotation validator markers.
+type csDTOProperty struct {
+	name       string
+	typ        string
+	validators []string
+	optional   bool
+}
+
+// reCsProperty matches an auto-property declaration inside a class body:
+//
+//	public string Name { get; set; }
+//	public int? Age { get; init; }
+//	public required string Email { get; set; }
+//
+// Group 1 = the declared type (with optional `?`), group 2 = the property name.
+var reCsProperty = regexp.MustCompile(
+	`(?m)^\s*public\s+(?:required\s+|virtual\s+|override\s+|new\s+)*([A-Za-z_][\w<>,.\[\]?]*)\s+([A-Za-z_]\w*)\s*\{\s*(?:get|set|init)`)
+
+// reCsAttrName extracts the bare attribute name from a `[Attr(...)]` block.
+var reCsAttrName = regexp.MustCompile(`[A-Za-z_]\w*`)
+
+// csScalarKind normalizes a C# type token to a scalar type, parity with the
+// JS/Python/Go scalar maps.
+var csScalarKind = map[string]string{
+	"string": "string", "String": "string", "char": "string", "Char": "string",
+	"Guid": "string", "Uri": "string",
+	"int": "integer", "Int32": "integer", "long": "integer", "Int64": "integer",
+	"short": "integer", "Int16": "integer", "byte": "integer", "uint": "integer",
+	"ulong": "integer", "ushort": "integer", "sbyte": "integer",
+	"float": "number", "double": "number", "decimal": "number",
+	"Single": "number", "Double": "number", "Decimal": "number",
+	"bool": "boolean", "Boolean": "boolean",
+	"DateTime": "date", "DateTimeOffset": "date", "DateOnly": "date", "TimeOnly": "date",
+	"object": "any", "dynamic": "any",
+}
+
+// normalizeCsType strips the nullable `?`, generic args, and array markers, then
+// normalizes via csScalarKind. List<T>/IEnumerable<T>/arrays → "array";
+// Dictionary<K,V> → "object".
+func normalizeCsType(typ string) string {
+	typ = strings.TrimSpace(typ)
+	typ = strings.TrimSuffix(typ, "?")
+	if strings.HasSuffix(typ, "[]") {
+		return "array"
+	}
+	// Generic collections.
+	if i := strings.IndexByte(typ, '<'); i >= 0 {
+		head := typ[:i]
+		switch head {
+		case "List", "IList", "IEnumerable", "ICollection", "HashSet", "IReadOnlyList", "Collection":
+			return "array"
+		case "Dictionary", "IDictionary", "IReadOnlyDictionary":
+			return "object"
+		}
+		typ = head
+	}
+	if k, ok := csScalarKind[typ]; ok {
+		return k
+	}
+	return typ
+}
+
+// csDataAnnotationNames are the DataAnnotation attributes surfaced as validator
+// markers on a field member (parity with class-validator `@IsX`).
+var csDataAnnotationNames = map[string]bool{
+	"Required": true, "StringLength": true, "Range": true, "MinLength": true,
+	"MaxLength": true, "RegularExpression": true, "EmailAddress": true,
+	"Phone": true, "Url": true, "Compare": true, "CreditCard": true,
+	"DataType": true, "EnumDataType": true,
+}
+
+// extractCsharpDTOFields parses a C# class body into its annotated property
+// members. `body` is the source between the class's opening and closing brace.
+// A property is required when it carries a `[Required]` attribute or the
+// `required` modifier; it is optional when its type is nullable (`T?`) and not
+// required.
+func extractCsharpDTOFields(body string) []csDTOProperty {
+	var fields []csDTOProperty
+	seen := make(map[string]bool)
+	for _, m := range reCsProperty.FindAllStringSubmatchIndex(body, -1) {
+		typ := strings.TrimSpace(body[m[2]:m[3]])
+		name := body[m[4]:m[5]]
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		// Collect the DataAnnotation attributes attached to this property: scan
+		// the lines immediately preceding the declaration for `[Attr...]` blocks.
+		decl := body[m[0]:m[1]]
+		hasRequiredModifier := regexp.MustCompile(`\brequired\b`).MatchString(decl)
+		attrs := csPropertyAttributes(body, m[0])
+
+		var validators []string
+		hasRequiredAttr := false
+		for _, a := range attrs {
+			if csDataAnnotationNames[a] {
+				validators = append(validators, "@"+a)
+			}
+			if a == "Required" {
+				hasRequiredAttr = true
+			}
+		}
+
+		nullable := strings.HasSuffix(typ, "?")
+		optional := nullable && !hasRequiredAttr && !hasRequiredModifier
+
+		fields = append(fields, csDTOProperty{
+			name:       name,
+			typ:        normalizeCsType(typ),
+			validators: validators,
+			optional:   optional,
+		})
+	}
+	return fields
+}
+
+// csPropertyAttributes returns the DataAnnotation attribute names attached to a
+// property whose declaration starts at byte offset `declStart`, by scanning the
+// contiguous block of `[...]` attribute lines immediately above it.
+func csPropertyAttributes(body string, declStart int) []string {
+	// Walk back over the preceding attribute / blank lines.
+	start := declStart
+	for start > 0 {
+		lineEnd := start - 1
+		if body[lineEnd] != '\n' {
+			break
+		}
+		lineStart := strings.LastIndexByte(body[:lineEnd], '\n') + 1
+		line := strings.TrimSpace(body[lineStart:lineEnd])
+		if line == "" || strings.HasPrefix(line, "[") {
+			start = lineStart
+			continue
+		}
+		break
+	}
+	block := body[start:declStart]
+	var names []string
+	for _, m := range regexp.MustCompile(`\[([^\]]*)\]`).FindAllStringSubmatch(block, -1) {
+		// An attribute block may hold multiple comma-separated attributes.
+		for _, part := range strings.Split(m[1], ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if nm := reCsAttrName.FindString(part); nm != "" {
+				names = append(names, nm)
+			}
+		}
+	}
+	return names
+}
+
+// csContainsFieldEdge builds the structural CONTAINS membership edge from an
+// owning DTO class to one of its property field members. FromID names the owner
+// class (`Class:<owner>`) so the resolver binds it to the real class entity;
+// ToID is the field entity's own ID.
+func csContainsFieldEdge(ownerClass, memberID, fieldName string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: "Class:" + ownerClass,
+		ToID:   memberID,
+		Kind:   string(types.RelationshipKindContains),
+		Properties: map[string]string{
+			"framework":  "data-annotations",
+			"language":   "csharp",
+			"member":     "field",
+			"field_name": fieldName,
+			"provenance": "INFERRED_FROM_MODEL_FIELD_MEMBERSHIP",
+		},
+	}
+}
+
+// emitCsharpDTOFieldMembers emits one `SCOPE.Schema`/field sub-entity per
+// property of a DTO class, each carrying its own CONTAINS membership edge.
+// Mirrors the JS/Python/Java/Go field-membership model.
+func emitCsharpDTOFieldMembers(
+	className string,
+	fields []csDTOProperty,
+	filePath string,
+	ownerLine int,
+) []types.EntityRecord {
+	if className == "" || len(fields) == 0 {
+		return nil
+	}
+	const library = "data-annotations"
+	var out []types.EntityRecord
+	for _, f := range fields {
+		typ := f.typ
+		if typ == "" {
+			typ = "unknown"
+		}
+		// Java-style field signature: `[@Attr ...] Type name`.
+		var sb strings.Builder
+		for _, a := range f.validators {
+			sb.WriteString(a)
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(typ)
+		sb.WriteByte(' ')
+		sb.WriteString(f.name)
+
+		childName := className + "." + f.name
+		child := makeEntity(childName, "SCOPE.Schema", "field", filePath, "csharp", ownerLine)
+		child.Signature = sb.String()
+		setProps(&child,
+			"library", library,
+			"pattern_type", "field",
+			"field_name", f.name,
+			"field_type", typ,
+			"parent_class", className,
+			"provenance", "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP")
+		if f.optional {
+			setProps(&child, "optional", "true")
+		}
+		if len(f.validators) > 0 {
+			setProps(&child, "validators", strings.Join(f.validators, " "))
+		}
+		child.Relationships = append(child.Relationships,
+			csContainsFieldEdge(className, child.ID, f.name))
+		out = append(out, child)
+	}
+	return out
+}
+
+// csClassBody returns the body between the class's opening `{` and its matching
+// `}`, given the byte offset of the class declaration keyword. Quote-aware so
+// braces inside string literals are ignored.
+func csClassBody(src string, classDeclStart int) string {
+	open := strings.IndexByte(src[classDeclStart:], '{')
+	if open < 0 {
+		return ""
+	}
+	open += classDeclStart
+	depth := 0
+	var quote byte
+	for i := open; i < len(src); i++ {
+		c := src[i]
+		if quote != 0 {
+			if c == quote && src[i-1] != '\\' {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			quote = c
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[open+1 : i]
+			}
+		}
+	}
+	return src[open+1:]
+}

--- a/internal/custom/csharp/dto_field_members_test.go
+++ b/internal/custom/csharp/dto_field_members_test.go
@@ -1,0 +1,107 @@
+package csharp_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
+)
+
+// Issue #4715 — C#/.NET DataAnnotations DTO FIELD-as-member indexing. A DTO
+// class's properties + DataAnnotation attributes must be emitted as
+// SCOPE.Schema/field members with name, normalized type, optional, validators,
+// AND a CONTAINS edge back to the class — the SAME shape as the JS/Python/Java/Go
+// DTO field members.
+
+func TestCsharpDTO_FieldMembers(t *testing.T) {
+	src := `
+using System.ComponentModel.DataAnnotations;
+
+public class CreateUserRequest
+{
+    [Required]
+    [StringLength(100)]
+    public string Name { get; set; }
+
+    [EmailAddress]
+    public string? Email { get; set; }
+
+    [Range(0, 130)]
+    public int Age { get; set; }
+
+    public string? Bio { get; set; }
+}
+`
+	e, ok := extreg.Get("custom_csharp_validation")
+	if !ok {
+		t.Fatal("custom_csharp_validation not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "CreateUserRequest.cs", Language: "csharp", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	field := func(name string) *types.EntityRecord {
+		for i := range ents {
+			if ents[i].Name == name && ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "field" {
+				return &ents[i]
+			}
+		}
+		return nil
+	}
+	containsTo := func(id string) bool {
+		for _, e := range ents {
+			for _, r := range e.Relationships {
+				if r.Kind == string(types.RelationshipKindContains) && r.ToID == id {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	name := field("CreateUserRequest.Name")
+	if name == nil {
+		t.Fatal("expected CreateUserRequest.Name field member")
+	}
+	if name.Properties["field_type"] != "string" {
+		t.Errorf("Name type = %q, want string", name.Properties["field_type"])
+	}
+	if name.Properties["optional"] == "true" {
+		t.Errorf("Name ([Required], non-nullable) should not be optional, props=%v", name.Properties)
+	}
+	if name.Properties["validators"] == "" {
+		t.Errorf("Name should carry @Required/@StringLength validators, props=%v", name.Properties)
+	}
+	if name.Signature == "" {
+		t.Error("Name field must carry a Signature for the shape resolver")
+	}
+	if !containsTo(name.ID) {
+		t.Error("expected CONTAINS edge to CreateUserRequest.Name")
+	}
+
+	email := field("CreateUserRequest.Email")
+	if email == nil || email.Properties["field_type"] != "string" {
+		t.Fatalf("expected CreateUserRequest.Email:string, got %+v", email)
+	}
+	if email.Properties["optional"] != "true" {
+		t.Errorf("Email (string?, no [Required]) should be optional, props=%v", email.Properties)
+	}
+
+	age := field("CreateUserRequest.Age")
+	if age == nil || age.Properties["field_type"] != "integer" {
+		t.Fatalf("expected CreateUserRequest.Age:integer, got %+v", age)
+	}
+	if age.Properties["optional"] == "true" {
+		t.Errorf("Age (non-nullable int) should not be optional, props=%v", age.Properties)
+	}
+
+	bio := field("CreateUserRequest.Bio")
+	if bio == nil || bio.Properties["optional"] != "true" {
+		t.Fatalf("Bio (string?) should be optional, got %+v", bio)
+	}
+}

--- a/internal/custom/csharp/validation.go
+++ b/internal/custom/csharp/validation.go
@@ -229,6 +229,16 @@ func (e *csharpValidationExtractor) Extract(ctx context.Context, file extractor.
 				"provenance", "INFERRED_FROM_DATA_ANNOTATION",
 			)
 			add(dtoEnt)
+
+			// Field-as-member sub-entities (#4715): each annotated DTO property
+			// becomes a `SCOPE.Schema`/field child with a CONTAINS edge to the
+			// class, the SAME shape as the JS/Python/Java/Go DTO field members so
+			// cross-framework FIELD-level diffs stay uniform.
+			body := csClassBody(src, m[0])
+			for _, child := range emitCsharpDTOFieldMembers(
+				className, extractCsharpDTOFields(body), file.Path, line) {
+				add(child)
+			}
 		}
 	}
 

--- a/internal/custom/golang/dto.go
+++ b/internal/custom/golang/dto.go
@@ -167,16 +167,19 @@ type dtoStruct struct {
 type dtoField struct {
 	Name string
 	Type string
+	Tag  string // the raw struct-tag backtick contents (json/validate/binding…)
 }
 
 // reDtoStructHead locates a `type <Name> struct {` opening.
 var reDtoStructHead = regexp.MustCompile(`type\s+(\w+)\s+struct\s*\{`)
 
 // reDtoStructField matches one exported/unexported field line inside a struct
-// body: a leading identifier and a type token. Embedded fields (a bare type) and
-// blank lines are skipped by requiring two tokens. Best-effort; complex types
-// (maps/funcs) are captured as their leading token.
-var reDtoStructField = regexp.MustCompile(`(?m)^\s*([A-Za-z_]\w*)\s+([\w\.\*\[\]]+)`)
+// body: a leading identifier, a type token, and an optional backtick struct tag.
+// Embedded fields (a bare type) and blank lines are skipped by requiring two
+// tokens. Best-effort; complex types (maps/funcs) are captured as their leading
+// token. Group 3 (when present) is the tag's backtick-delimited contents.
+var reDtoStructField = regexp.MustCompile(
+	"(?m)^\\s*([A-Za-z_]\\w*)\\s+([\\w\\.\\*\\[\\]]+)[^`\\n]*(?:`([^`]*)`)?")
 
 // catalogStructs parses every `type T struct {...}` in src into a name→struct
 // map, capturing each struct's field list by scanning to the matching closing
@@ -198,7 +201,11 @@ func catalogStructs(src string) map[string]dtoStruct {
 			if fname == "struct" || fname == "func" {
 				continue
 			}
-			fields = append(fields, dtoField{Name: fname, Type: fm[2]})
+			tag := ""
+			if len(fm) > 3 {
+				tag = fm[3]
+			}
+			fields = append(fields, dtoField{Name: fname, Type: fm[2], Tag: tag})
 		}
 		out[name] = dtoStruct{
 			Name:   name,
@@ -302,6 +309,9 @@ func (e *dtoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 
 	var entities []types.EntityRecord
 	seen := make(map[string]bool)
+	// Track which resolved DTO structs have had their field members emitted so a
+	// struct bound at several call sites yields exactly one member set (#4715).
+	fieldMembersEmitted := make(map[string]bool)
 	add := func(ent types.EntityRecord) {
 		key := ent.Kind + ":" + ent.Name
 		if seen[key] {
@@ -378,6 +388,17 @@ func (e *dtoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 						"binding_subtype": sig.subtype,
 					},
 				})
+				// Field-as-member sub-entities (#4715): each struct field becomes a
+				// `SCOPE.Schema`/field child with a CONTAINS edge to the struct, the
+				// SAME shape as the JS/Python/Java DTO field members so cross-framework
+				// FIELD-level diffs stay uniform. Emitted once per resolved struct.
+				if !fieldMembersEmitted[structName] {
+					fieldMembersEmitted[structName] = true
+					for _, child := range emitGoDTOFieldMembers(
+						structName, st.Fields, file.Path, file.Language, st.Line) {
+						add(child)
+					}
+				}
 			} else {
 				setProps(&ent, "resolved", "false")
 			}

--- a/internal/custom/golang/dto_field_members.go
+++ b/internal/custom/golang/dto_field_members.go
@@ -1,0 +1,220 @@
+package golang
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// dto_field_members.go — Go struct-tag DTO FIELD-as-member indexing (issue
+// #4715), generalizing the uniform DTO field-member model from the JS
+// (javascript/validation_schema.go::emitSchemaFieldMembers, #4635), Python
+// (python/dto_field_members.go, #4613) and Java (java/spring_dto_fields.go,
+// #4613) emitters.
+//
+// Each request/response DTO struct's fields become `SCOPE.Schema` subtype=field
+// sub-entities named `<Struct>.<field>`, carrying the SAME property shape as the
+// other frameworks so the cross-framework field-level diff tools + the dashboard
+// /shape ShapeTree resolver treat all frameworks uniformly:
+//
+//	field_name   — the wire name (json tag name when present, else the Go field)
+//	field_type   — normalized scalar/declared type ("string"/"integer"/...)
+//	parent_class — the owning DTO struct name
+//	optional     — "true" when the field is optional (omitempty / pointer /
+//	               no `required` validate/binding rule)
+//	validators   — space-joined `@rule` markers from validate:/binding: tags
+//	provenance   — INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP
+//	library      — "go-struct-tags"
+//
+// The child's Signature is the Java-style `[@Validators ...] <type> <name>` so
+// the shape resolver's parseFieldSignature recovers (annotations, type, name)
+// exactly as it does for the JS/Java/Python DTO fields. A CONTAINS edge binds
+// each field to its owner struct via the `Class:<Struct>` byName fallback.
+
+// goScalarKind normalizes a Go type token to a scalar type, parity with the
+// JS/Python scalar maps.
+var goScalarKind = map[string]string{
+	"string": "string", "rune": "string", "byte": "string",
+	"int": "integer", "int8": "integer", "int16": "integer", "int32": "integer",
+	"int64": "integer", "uint": "integer", "uint8": "integer", "uint16": "integer",
+	"uint32": "integer", "uint64": "integer", "uintptr": "integer",
+	"float32": "number", "float64": "number",
+	"complex64": "number", "complex128": "number",
+	"bool":      "boolean",
+	"time.Time": "date", "Time": "date",
+	"interface{}": "any", "any": "any",
+}
+
+// normalizeGoType strips pointer/slice/map markers and returns a normalized
+// scalar type. A slice `[]T` → "array"; a map `map[K]V` → "object"; otherwise the
+// element type is normalized via goScalarKind (falling back to the bare token).
+func normalizeGoType(typ string) string {
+	typ = strings.TrimSpace(typ)
+	if strings.HasPrefix(typ, "map[") {
+		return "object"
+	}
+	if strings.HasPrefix(typ, "[]") {
+		return "array"
+	}
+	typ = strings.TrimPrefix(typ, "*")
+	if k, ok := goScalarKind[typ]; ok {
+		return k
+	}
+	// A dotted type like `pkg.Type` → its short name (best-effort).
+	if i := strings.LastIndex(typ, "."); i >= 0 {
+		short := typ[i+1:]
+		if k, ok := goScalarKind[typ]; ok {
+			return k
+		}
+		return short
+	}
+	return typ
+}
+
+// goTagValueRe extracts a `<key>:"<value>"` pair from a struct tag's raw body.
+func goTagValue(tag, key string) string {
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(key) + `:"([^"]*)"`)
+	if m := re.FindStringSubmatch(tag); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// goValidatorMarkers maps the comma-separated rules in a `validate:"..."` /
+// `binding:"..."` tag value to `@rule` markers (parity with class-validator
+// `@IsX`). Bare flags (`required`, `email`) and parameterized rules
+// (`min=3`, `max=255`) are both surfaced; the rule name is the marker.
+func goValidatorMarkers(ruleSpec string) []string {
+	var out []string
+	for _, raw := range strings.Split(ruleSpec, ",") {
+		r := strings.TrimSpace(raw)
+		if r == "" || r == "-" {
+			continue
+		}
+		// `min=3` → marker `@min`; `oneof=a b c` → `@oneof`.
+		name := r
+		if i := strings.IndexAny(name, "= "); i >= 0 {
+			name = name[:i]
+		}
+		if name == "" {
+			continue
+		}
+		out = append(out, "@"+name)
+	}
+	return out
+}
+
+// goDTORequired reports whether a struct field is required, given its parsed
+// validate/binding rule list. A field is required when its rules contain a bare
+// `required` rule.
+func goDTORequired(rules []string) bool {
+	for _, r := range rules {
+		if strings.TrimSpace(r) == "required" {
+			return true
+		}
+	}
+	return false
+}
+
+// emitGoDTOFieldMembers emits one `SCOPE.Schema`/field sub-entity per field of a
+// DTO struct, plus a CONTAINS edge from the owning struct to each child. Mirrors
+// the JS/Python/Java field-membership model so cross-framework FIELD-level diffs
+// are uniform. The owner struct node is `Class:<Struct>` (resolved via the
+// byName fallback); each child carries its own CONTAINS membership edge.
+func emitGoDTOFieldMembers(
+	structName string,
+	fields []dtoField,
+	filePath, language string,
+	ownerLine int,
+) []types.EntityRecord {
+	if structName == "" || len(fields) == 0 {
+		return nil
+	}
+	const library = "go-struct-tags"
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	for _, f := range fields {
+		// Embedded base structs (gorm.Model) and skip-marked fields aren't DTO
+		// wire fields; the json tag `-` excludes a field from serialization.
+		if f.Name == "" || f.Name == "struct" {
+			continue
+		}
+
+		jsonTag := goTagValue(f.Tag, "json")
+		wireName := f.Name
+		if jsonTag != "" {
+			parts := strings.Split(jsonTag, ",")
+			if parts[0] == "-" {
+				continue // explicitly excluded from the wire shape
+			}
+			if parts[0] != "" {
+				wireName = parts[0]
+			}
+		}
+		if seen[wireName] {
+			continue
+		}
+		seen[wireName] = true
+
+		// Rules come from validate: or binding: (gin) tags.
+		ruleSpec := goTagValue(f.Tag, "validate")
+		if ruleSpec == "" {
+			ruleSpec = goTagValue(f.Tag, "binding")
+		}
+		var ruleList []string
+		for _, r := range strings.Split(ruleSpec, ",") {
+			if r = strings.TrimSpace(r); r != "" {
+				ruleList = append(ruleList, r)
+			}
+		}
+		validators := goValidatorMarkers(ruleSpec)
+
+		// Optionality: a field is optional unless it carries a `required` rule.
+		// A pointer type or json `omitempty` independently marks it optional.
+		required := goDTORequired(ruleList)
+		optional := !required
+		if strings.HasPrefix(strings.TrimSpace(f.Type), "*") {
+			optional = true
+		}
+		if jsonTag != "" && strings.Contains(jsonTag, "omitempty") {
+			optional = true
+		}
+
+		typ := normalizeGoType(f.Type)
+		if typ == "" {
+			typ = "unknown"
+		}
+
+		// Java-style field signature: `[@Ann ...] Type name`.
+		var sb strings.Builder
+		for _, a := range validators {
+			sb.WriteString(a)
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(typ)
+		sb.WriteByte(' ')
+		sb.WriteString(wireName)
+
+		childName := structName + "." + wireName
+		child := makeEntity(childName, "SCOPE.Schema", "field", filePath, language, ownerLine)
+		child.Signature = sb.String()
+		setProps(&child,
+			"library", library,
+			"pattern_type", "field",
+			"field_name", wireName,
+			"field_type", typ,
+			"parent_class", structName,
+			"provenance", "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP")
+		if optional {
+			setProps(&child, "optional", "true")
+		}
+		if len(validators) > 0 {
+			setProps(&child, "validators", strings.Join(validators, " "))
+		}
+		child.Relationships = append(child.Relationships,
+			containsFieldEdge(structName, child.ID, wireName, library))
+		out = append(out, child)
+	}
+	return out
+}

--- a/internal/custom/golang/dto_field_members_test.go
+++ b/internal/custom/golang/dto_field_members_test.go
@@ -1,0 +1,101 @@
+package golang_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+)
+
+// Issue #4715 — Go struct-tag DTO FIELD-as-member indexing. A request-bound DTO
+// struct's fields must be emitted as SCOPE.Schema/field members with name (from
+// the json tag), normalized type, optional, validators, AND a CONTAINS edge back
+// to the owning struct — the SAME shape as the JS/Python/Java DTO field members.
+
+func TestGoDTO_FieldMembers(t *testing.T) {
+	src := "package api\n\n" +
+		"import \"github.com/gin-gonic/gin\"\n\n" +
+		"type CreateUserReq struct {\n" +
+		"\tName  string `json:\"name\" validate:\"required\"`\n" +
+		"\tEmail string `json:\"email\" binding:\"required,email\"`\n" +
+		"\tAge   int    `json:\"age,omitempty\"`\n" +
+		"\tBio   *string `json:\"bio\"`\n" +
+		"}\n\n" +
+		"func handler(c *gin.Context) {\n" +
+		"\tvar req CreateUserReq\n" +
+		"\tc.ShouldBindJSON(&req)\n" +
+		"}\n"
+
+	e, ok := extreg.Get("custom_go_dto")
+	if !ok {
+		t.Fatal("custom_go_dto not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "user.go", Language: "go", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	field := func(name string) *types.EntityRecord {
+		for i := range ents {
+			if ents[i].Name == name && ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "field" {
+				return &ents[i]
+			}
+		}
+		return nil
+	}
+	containsTo := func(id string) bool {
+		for _, e := range ents {
+			for _, r := range e.Relationships {
+				if r.Kind == string(types.RelationshipKindContains) && r.ToID == id {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	name := field("CreateUserReq.name")
+	if name == nil {
+		t.Fatal("expected CreateUserReq.name field member")
+	}
+	if name.Properties["field_type"] != "string" {
+		t.Errorf("name type = %q, want string", name.Properties["field_type"])
+	}
+	if name.Properties["optional"] == "true" {
+		t.Errorf("name (validate:required) should not be optional, props=%v", name.Properties)
+	}
+	if name.Properties["validators"] == "" {
+		t.Errorf("name should carry @required validator, props=%v", name.Properties)
+	}
+	if name.Signature == "" {
+		t.Error("name field must carry a Signature for the shape resolver")
+	}
+	if !containsTo(name.ID) {
+		t.Error("expected CONTAINS edge to CreateUserReq.name")
+	}
+
+	email := field("CreateUserReq.email")
+	if email == nil || email.Properties["field_type"] != "string" {
+		t.Fatalf("expected CreateUserReq.email:string, got %+v", email)
+	}
+	if email.Properties["optional"] == "true" {
+		t.Errorf("email (binding:required) should not be optional, props=%v", email.Properties)
+	}
+
+	age := field("CreateUserReq.age")
+	if age == nil || age.Properties["field_type"] != "integer" {
+		t.Fatalf("expected CreateUserReq.age:integer, got %+v", age)
+	}
+	if age.Properties["optional"] != "true" {
+		t.Errorf("age (omitempty, no required) should be optional, props=%v", age.Properties)
+	}
+
+	bio := field("CreateUserReq.bio")
+	if bio == nil || bio.Properties["optional"] != "true" || bio.Properties["field_type"] != "string" {
+		t.Fatalf("bio (*string) should be optional string, got %+v", bio)
+	}
+}

--- a/internal/custom/python/attrs.go
+++ b/internal/custom/python/attrs.go
@@ -42,6 +42,14 @@ var (
 			`(?:[ \t]*@\w[\w.]*\s*(?:\([^)]*\))?\s*\n)*` +
 			`[ \t]*class\s+(\w+)\s*`)
 
+	// @dataclass / @dataclasses.dataclass / @dataclass(frozen=True) — stdlib
+	// dataclasses share the annotated-field body shape with attrs, so the same
+	// DTO field-member emission applies (issue #4714).
+	dataclassDecoratorRe = regexp.MustCompile(
+		`(?m)^[ \t]*@(?:dataclasses\.)?dataclass\s*(?:\([^)]*\))?\s*\n` +
+			`(?:[ \t]*@\w[\w.]*\s*(?:\([^)]*\))?\s*\n)*` +
+			`[ \t]*class\s+(\w+)\s*`)
+
 	// x = attr.ib() / x = attrib() / x = attr.attrib() / x = field()
 	attrsAttribRe = regexp.MustCompile(
 		`(?m)^[ \t]+(\w+)\s*(?::\s*\S+\s*)?=\s*(?:attr\.ib|attrib|attr\.attrib|field|attrs\.field)\s*\(([^)]*)\)`)
@@ -70,8 +78,12 @@ var (
 	attrsAndRe        = regexp.MustCompile(`(?:attr(?:s)?\.)?validators\.and_\(`)
 )
 
-// attrsReferenced reports whether the source likely uses the attrs library.
+// attrsReferenced reports whether the source likely uses the attrs library or
+// stdlib dataclasses (both share the annotated-field DTO body shape, #4714).
 func attrsReferenced(source string) bool {
+	if strings.Contains(source, "dataclass") {
+		return true
+	}
 	return strings.Contains(source, "attrs") ||
 		strings.Contains(source, "attr") && (strings.Contains(source, "attr.s") ||
 			strings.Contains(source, "attr.ib") ||
@@ -212,6 +224,31 @@ func (e *AttrsExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			file.Path, line, props,
 		))
 	}
+
+	// 5. Field-as-member sub-entities (issue #4714). Each attrs/dataclass class's
+	// annotated attributes become `SCOPE.Schema`/field children with a CONTAINS
+	// edge to the class, the SAME shape as the Pydantic/DRF/marshmallow/JS DTO
+	// field members so cross-framework FIELD-level diffs stay uniform. The owner
+	// class node is emitted by the base Python extractor; we hang only members.
+	emitDataclassFields := func(re *regexp.Regexp, library string) {
+		for _, idx := range allMatchesIndex(re, source) {
+			className := source[idx[2]:idx[3]]
+			// The decorator regex's match start is the `@…` line; locate the
+			// `class` header so the body scan dedents from the class indent.
+			classStart := strings.Index(source[idx[0]:idx[1]], "class ")
+			if classStart < 0 {
+				continue
+			}
+			classStart += idx[0]
+			line := lineOf(source, classStart)
+			body := pydModelBody(source, classStart)
+			fields := extractAttrsDataclassFields(body)
+			out = append(out, emitPyDTOFieldMembers(
+				className, fields, library, file.Path, line, nil)...)
+		}
+	}
+	emitDataclassFields(attrsClassDecoratorRe, "attrs")
+	emitDataclassFields(dataclassDecoratorRe, "dataclasses")
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil

--- a/internal/custom/python/dto_field_members.go
+++ b/internal/custom/python/dto_field_members.go
@@ -279,6 +279,162 @@ func normalizePyType(annot string) string {
 	return annot
 }
 
+// ── marshmallow Schema field parsing (#4714) ─────────────────────────────────
+
+// mmDTOFieldRe matches a marshmallow declared field inside a Schema body:
+//
+//	name = fields.Str(required=True, allow_none=False)
+//	email = ma.fields.Email()
+//	items = fields.Nested(ItemSchema, many=True)
+//
+// Group 1 = field name, group 2 = the marshmallow field class (e.g. Str, Email,
+// Nested), group 3 = the (possibly truncated at first `)`) argument blob.
+var mmDTOFieldRe = regexp.MustCompile(
+	`(?m)^[ \t]+(\w+)\s*=\s*(?:\w+\.)?fields\.(\w+)\s*\(([^)]*)`)
+
+// mmFieldTypeKind maps a marshmallow field class to a normalized scalar type
+// (parity with the JS/DRF scalar maps).
+var mmFieldTypeKind = map[string]string{
+	"Str": "string", "String": "string", "Email": "string", "URL": "string",
+	"Url": "string", "UUID": "string", "Uuid": "string", "Constant": "string",
+	"Int": "integer", "Integer": "integer",
+	"Float": "number", "Decimal": "number", "Number": "number",
+	"Bool": "boolean", "Boolean": "boolean",
+	"Date": "date", "DateTime": "date", "Time": "date", "NaiveDateTime": "date",
+	"AwareDateTime": "date", "TimeDelta": "date",
+	"List": "array", "Tuple": "array",
+	"Dict": "object", "Mapping": "object", "Nested": "object", "Pluck": "object",
+	"Raw": "any", "Field": "any", "Function": "any", "Method": "any",
+}
+
+// mmFieldType normalizes a marshmallow field class name to a scalar type.
+func mmFieldType(fieldClass string) string {
+	if k, ok := mmFieldTypeKind[fieldClass]; ok {
+		return k
+	}
+	return strings.ToLower(fieldClass)
+}
+
+// extractMarshmallowSchemaFields parses a marshmallow Schema body into field
+// members. A field is optional when `required=True` is absent, or when
+// `allow_none=True` / `load_default=` / `missing=` / `dump_only=True` is set.
+func extractMarshmallowSchemaFields(body string) []pyDTOField {
+	var fields []pyDTOField
+	seen := make(map[string]bool)
+	for _, m := range mmDTOFieldRe.FindAllStringSubmatch(body, -1) {
+		name := m[1]
+		fieldClass := m[2]
+		args := m[3]
+		if name == "" || seen[name] || strings.HasPrefix(name, "__") {
+			continue
+		}
+		seen[name] = true
+
+		required := regexp.MustCompile(`\brequired\s*=\s*True`).MatchString(args)
+		optional := !required
+		if regexp.MustCompile(`\ballow_none\s*=\s*True`).MatchString(args) ||
+			regexp.MustCompile(`\bdump_only\s*=\s*True`).MatchString(args) ||
+			regexp.MustCompile(`\b(?:load_default|missing|default)\s*=`).MatchString(args) {
+			optional = true
+		}
+
+		var validators []string
+		if required {
+			validators = append(validators, "@required")
+		}
+		for _, kw := range []string{"allow_none", "load_only", "dump_only",
+			"validate", "data_key"} {
+			if regexp.MustCompile(`\b` + kw + `\s*=`).MatchString(args) {
+				validators = append(validators, "@"+kw)
+			}
+		}
+
+		fields = append(fields, pyDTOField{
+			name:       name,
+			typ:        mmFieldType(fieldClass),
+			validators: validators,
+			optional:   optional,
+		})
+	}
+	return fields
+}
+
+// ── attrs / dataclasses field parsing (#4714) ────────────────────────────────
+
+// dcAnnotatedFieldRe matches an annotated class-body attribute, the shape both
+// dataclasses and attrs-with-annotations use:
+//
+//	name: str
+//	age: int = 0
+//	tags: list[str] = field(default_factory=list)
+//	nickname: Optional[str] = None
+//	count: int = attr.ib(default=0)
+//
+// Group 1 = leading indent, group 2 = name, group 3 = type annotation, group 4
+// = RHS default expression (may be empty). Shares the direct-body-indent
+// discipline with the Pydantic field regex.
+var dcAnnotatedFieldRe = regexp.MustCompile(
+	`(?m)^([ \t]+)([a-zA-Z_]\w*)\s*:\s*([^=\n]+?)\s*(?:=\s*(.+))?$`)
+
+// extractAttrsDataclassFields parses a @dataclass / @attr.s / @define class body
+// into field members. A field is optional when it has any default — a literal,
+// `field(default=...)` / `field(default_factory=...)`, `attr.ib(default=...)` /
+// `attr.ib(factory=...)`, or an `Optional[...]` / `X | None` annotation.
+func extractAttrsDataclassFields(body string) []pyDTOField {
+	var fields []pyDTOField
+	seen := make(map[string]bool)
+	baseIndent := -1
+	for _, m := range dcAnnotatedFieldRe.FindAllStringSubmatch(body, -1) {
+		if n := len(m[1]); baseIndent < 0 || n < baseIndent {
+			baseIndent = n
+		}
+	}
+	for _, m := range dcAnnotatedFieldRe.FindAllStringSubmatch(body, -1) {
+		if len(m[1]) != baseIndent {
+			continue // nested in a method / inner class — not a direct field
+		}
+		name := m[2]
+		annot := strings.TrimSpace(m[3])
+		rhs := strings.TrimSpace(m[4])
+		if name == "" || seen[name] || strings.HasPrefix(name, "__") {
+			continue
+		}
+		if name == "model_config" {
+			continue
+		}
+		seen[name] = true
+
+		optional := pydIsOptional(annot)
+		var validators []string
+		if rhs != "" {
+			// Any RHS is a default → optional. Recognize field()/attr.ib() shapes
+			// and surface their validator/constraint kwargs as markers.
+			optional = true
+			if regexp.MustCompile(`^(?:attr\.ib|attrib|attr\.attrib|field|attrs\.field)\s*\(`).MatchString(rhs) {
+				// A field()/attr.ib() with no default and not Optional is required
+				// unless it carries default=/factory=/default_factory=.
+				hasDefault := regexp.MustCompile(`\b(?:default|factory|default_factory)\s*=`).MatchString(rhs)
+				if !hasDefault && !pydIsOptional(annot) {
+					optional = false
+				}
+				for _, kw := range []string{"validator", "converter"} {
+					if regexp.MustCompile(`\b` + kw + `\s*=`).MatchString(rhs) {
+						validators = append(validators, "@"+kw)
+					}
+				}
+			}
+		}
+
+		fields = append(fields, pyDTOField{
+			name:       name,
+			typ:        normalizePyType(annot),
+			validators: validators,
+			optional:   optional,
+		})
+	}
+	return fields
+}
+
 // ── DRF serializer field parsing ─────────────────────────────────────────────
 
 // drfFieldDeclRe matches an explicit DRF serializer field declaration:

--- a/internal/custom/python/dto_field_members_test.go
+++ b/internal/custom/python/dto_field_members_test.go
@@ -193,6 +193,122 @@ class ProductSerializer(serializers.ModelSerializer):
 	}
 }
 
+// ── marshmallow Schema field membership (#4714) ──────────────────────────────
+
+func TestMarshmallow_FieldMembers(t *testing.T) {
+	src := `from marshmallow import Schema, fields
+
+class UserSchema(Schema):
+    name = fields.Str(required=True)
+    email = fields.Email()
+    age = fields.Int(allow_none=True)
+    bio = fields.Str(load_default="")
+`
+	rs := extract(t, "python_marshmallow", src)
+
+	name := findFieldChild(rs, "UserSchema.name")
+	if name == nil || name.Props["field_type"] != "string" {
+		t.Fatalf("expected UserSchema.name:string, got %+v", name)
+	}
+	if name.Props["optional"] == "true" {
+		t.Errorf("name (required=True) should not be optional, props=%v", name.Props)
+	}
+	if name.Props["validators"] == "" {
+		t.Errorf("name (required=True) should carry @required, props=%v", name.Props)
+	}
+
+	email := findFieldChild(rs, "UserSchema.email")
+	if email == nil || email.Props["field_type"] != "string" {
+		t.Fatalf("expected UserSchema.email:string, got %+v", email)
+	}
+	if email.Props["optional"] != "true" {
+		t.Errorf("email (no required=True) should be optional, props=%v", email.Props)
+	}
+
+	age := findFieldChild(rs, "UserSchema.age")
+	if age == nil || age.Props["field_type"] != "integer" || age.Props["optional"] != "true" {
+		t.Fatalf("age (Int, allow_none) wrong: %+v", age)
+	}
+
+	bio := findFieldChild(rs, "UserSchema.bio")
+	if bio == nil || bio.Props["optional"] != "true" {
+		t.Fatalf("bio (load_default) should be optional: %+v", bio)
+	}
+
+	if !hasContainsTo(rs, "UserSchema.name") {
+		t.Error("expected CONTAINS edge to UserSchema.name")
+	}
+}
+
+// ── dataclass / attrs field membership (#4714) ───────────────────────────────
+
+func TestDataclass_FieldMembers(t *testing.T) {
+	src := `from dataclasses import dataclass, field
+from typing import Optional
+
+@dataclass
+class CreateUser:
+    name: str
+    age: int = 0
+    nickname: Optional[str] = None
+    tags: list = field(default_factory=list)
+`
+	rs := extract(t, "python_attrs", src)
+
+	name := findFieldChild(rs, "CreateUser.name")
+	if name == nil || name.Props["field_type"] != "string" {
+		t.Fatalf("expected CreateUser.name:string, got %+v", name)
+	}
+	if name.Props["optional"] == "true" {
+		t.Errorf("name (no default) should be required, props=%v", name.Props)
+	}
+
+	age := findFieldChild(rs, "CreateUser.age")
+	if age == nil || age.Props["field_type"] != "integer" || age.Props["optional"] != "true" {
+		t.Fatalf("age (default 0) wrong: %+v", age)
+	}
+
+	nick := findFieldChild(rs, "CreateUser.nickname")
+	if nick == nil || nick.Props["optional"] != "true" || nick.Props["field_type"] != "string" {
+		t.Fatalf("nickname (Optional) wrong: %+v", nick)
+	}
+
+	tags := findFieldChild(rs, "CreateUser.tags")
+	if tags == nil || tags.Props["optional"] != "true" {
+		t.Fatalf("tags (field default_factory) should be optional: %+v", tags)
+	}
+
+	if !hasContainsTo(rs, "CreateUser.name") {
+		t.Error("expected CONTAINS edge to CreateUser.name")
+	}
+}
+
+func TestAttrs_FieldMembers(t *testing.T) {
+	src := `import attr
+
+@attr.s
+class Point:
+    x: int = attr.ib()
+    y: int = attr.ib(default=0)
+`
+	rs := extract(t, "python_attrs", src)
+
+	x := findFieldChild(rs, "Point.x")
+	if x == nil || x.Props["field_type"] != "integer" {
+		t.Fatalf("expected Point.x:integer, got %+v", x)
+	}
+	if x.Props["optional"] == "true" {
+		t.Errorf("x (attr.ib() no default) should be required, props=%v", x.Props)
+	}
+	y := findFieldChild(rs, "Point.y")
+	if y == nil || y.Props["optional"] != "true" {
+		t.Fatalf("y (attr.ib default=0) should be optional: %+v", y)
+	}
+	if !hasContainsTo(rs, "Point.x") {
+		t.Error("expected CONTAINS edge to Point.x")
+	}
+}
+
 func TestDRF_ModelSerializerAllFieldsFlagged(t *testing.T) {
 	src := `from rest_framework import serializers
 

--- a/internal/custom/python/marshmallow.go
+++ b/internal/custom/python/marshmallow.go
@@ -121,6 +121,17 @@ func (e *MarshmallowExtractor) Extract(ctx context.Context, file extractor.FileI
 				"schema_name":  schemaName,
 			},
 		))
+
+		// Field-as-member sub-entities (issue #4714). Each declared field on the
+		// Schema becomes a `SCOPE.Schema`/field child with a CONTAINS edge back to
+		// the schema class (resolved via the `Class:<name>` byName fallback), the
+		// SAME shape as the Pydantic/DRF/JS DTO field members so cross-framework
+		// FIELD-level diffs are uniform. The owner class node is emitted by the
+		// base Python extractor; here we hang only the membership + child fields.
+		body := pydModelBody(source, idx[0])
+		fields := extractMarshmallowSchemaFields(body)
+		out = append(out, emitPyDTOFieldMembers(
+			schemaName, fields, "marshmallow", file.Path, line, nil)...)
 	}
 
 	// 2. Field declarations — capture field name + marshmallow field type.

--- a/internal/custom/ruby/ams_serializer.go
+++ b/internal/custom/ruby/ams_serializer.go
@@ -1,0 +1,201 @@
+package ruby
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ams_serializer.go — Ruby ActiveModel::Serializer (AMS) DTO FIELD-as-member
+// indexing (issue #4715), generalizing the uniform DTO field-member model from
+// the JS (javascript/validation_schema.go::emitSchemaFieldMembers, #4635),
+// Python (python/dto_field_members.go, #4613), Java (java/spring_dto_fields.go,
+// #4613), Go (golang/dto_field_members.go) and C# (csharp/dto_field_members.go)
+// emitters.
+//
+// An `ActiveModel::Serializer` subclass declares its serialized shape via
+// `attributes :a, :b, :c` and `attribute :x` macros. Each declared attribute
+// becomes a `SCOPE.Schema` subtype=field sub-entity named `<Serializer>.<attr>`,
+// carrying the SAME property shape as the other frameworks so the cross-framework
+// field-level diff tools + the dashboard /shape ShapeTree resolver treat all
+// frameworks uniformly:
+//
+//	field_name   — the attribute name
+//	field_type   — "any" (AMS attributes are dynamically typed; best-effort)
+//	parent_class — the owning serializer class name
+//	provenance   — INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP
+//	library      — "active_model_serializer"
+//
+// The child's Signature is the Java-style `<type> <name>` so the shape resolver's
+// parseFieldSignature recovers (type, name) uniformly. A CONTAINS edge binds each
+// field to its owner serializer via the `Class:<Serializer>` byName fallback.
+//
+// Also emits a SCOPE.Schema (subtype=dto) node per serializer class so the dto
+// node exists for the membership edge to resolve against.
+
+func init() {
+	extractor.Register("custom_ruby_ams_serializer", &amsSerializerExtractor{})
+}
+
+type amsSerializerExtractor struct{}
+
+func (e *amsSerializerExtractor) Language() string { return "custom_ruby_ams_serializer" }
+
+var (
+	// class FooSerializer < ActiveModel::Serializer
+	// Also matches the common base `< ApplicationSerializer` only when the class
+	// name ends in `Serializer` (conservative — avoids false positives).
+	reAmsSerializerClass = regexp.MustCompile(
+		`(?m)^\s*class\s+([A-Z][A-Za-z0-9_:]*Serializer)\s*<\s*([A-Z][A-Za-z0-9_:]*)`)
+
+	// attributes :a, :b, :c   (one declaration, comma-separated symbols)
+	reAmsAttributes = regexp.MustCompile(
+		`(?m)^\s*attributes\s+(:[A-Za-z_]\w*(?:\s*,\s*:[A-Za-z_]\w*)*)`)
+
+	// attribute :x   /   attribute :x, key: :y
+	reAmsAttribute = regexp.MustCompile(
+		`(?m)^\s*attribute\s+:([A-Za-z_]\w*)`)
+
+	// :symbol token inside an attributes list.
+	reAmsSymbol = regexp.MustCompile(`:([A-Za-z_]\w*)`)
+)
+
+// amsSerializerReferenced reports whether the source likely declares an AMS
+// serializer.
+func amsSerializerReferenced(src string) bool {
+	return strings.Contains(src, "ActiveModel::Serializer") ||
+		(strings.Contains(src, "Serializer") &&
+			(strings.Contains(src, "attributes ") || strings.Contains(src, "attribute ")))
+}
+
+func (e *amsSerializerExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/ruby")
+	_, span := tracer.Start(ctx, "indexer.ruby_ams_serializer_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "ruby" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !amsSerializerReferenced(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, m := range reAmsSerializerClass.FindAllStringSubmatchIndex(src, -1) {
+		className := src[m[2]:m[3]]
+		baseClass := src[m[4]:m[5]]
+		// Only treat `< X` as an AMS serializer when the base is ActiveModel's
+		// serializer or an application serializer base.
+		if baseClass != "ActiveModel::Serializer" &&
+			!strings.HasSuffix(baseClass, "Serializer") {
+			continue
+		}
+		line := lineOf(src, m[0])
+
+		// The serializer class node (so the membership edge resolves).
+		dto := makeEntity(className, "SCOPE.Schema", "dto", file.Path, file.Language, line)
+		setProps(&dto,
+			"framework", "active_model_serializer",
+			"provenance", "INFERRED_FROM_AMS_SERIALIZER",
+			"base_class", baseClass)
+		add(dto)
+
+		body := amsClassBody(src, m[0])
+		ownerLine := line
+
+		var attrNames []string
+		// attributes :a, :b, :c
+		for _, am := range reAmsAttributes.FindAllStringSubmatch(body, -1) {
+			for _, s := range reAmsSymbol.FindAllStringSubmatch(am[1], -1) {
+				attrNames = append(attrNames, s[1])
+			}
+		}
+		// attribute :x
+		for _, am := range reAmsAttribute.FindAllStringSubmatch(body, -1) {
+			attrNames = append(attrNames, am[1])
+		}
+
+		fieldSeen := make(map[string]bool)
+		for _, attr := range attrNames {
+			if attr == "" || fieldSeen[attr] {
+				continue
+			}
+			fieldSeen[attr] = true
+
+			childName := className + "." + attr
+			child := makeEntity(childName, "SCOPE.Schema", "field", file.Path, file.Language, ownerLine)
+			// Java-style signature `<type> <name>`; AMS attrs are untyped → "any".
+			child.Signature = "any " + attr
+			setProps(&child,
+				"library", "active_model_serializer",
+				"pattern_type", "field",
+				"field_name", attr,
+				"field_type", "any",
+				"parent_class", className,
+				"provenance", "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP")
+			child.Relationships = append(child.Relationships,
+				containsFieldEdge(className, child.ID, attr, "active_model_serializer"))
+			add(child)
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// amsClassBody returns the source of the serializer class body, from the class
+// declaration up to its matching `end`. Ruby has no braces, so this is a
+// best-effort scan: it tracks block-opening keywords (def/do/if/class/...) and
+// `end` tokens at line granularity, returning the body up to the class's closing
+// `end`. Good enough to scope `attributes`/`attribute` declarations to a class.
+func amsClassBody(src string, classDeclStart int) string {
+	// Start after the class declaration line.
+	nl := strings.IndexByte(src[classDeclStart:], '\n')
+	if nl < 0 {
+		return src[classDeclStart:]
+	}
+	bodyStart := classDeclStart + nl + 1
+	lines := strings.Split(src[bodyStart:], "\n")
+	depth := 1 // we are inside the class
+	var body []string
+	openRe := regexp.MustCompile(`^\s*(?:class|module|def|if|unless|case|while|until|begin)\b|\bdo\s*(?:\|[^|]*\|)?\s*$`)
+	endRe := regexp.MustCompile(`^\s*end\b`)
+	for _, ln := range lines {
+		if endRe.MatchString(ln) {
+			depth--
+			if depth == 0 {
+				break
+			}
+			body = append(body, ln)
+			continue
+		}
+		if openRe.MatchString(ln) {
+			depth++
+		}
+		body = append(body, ln)
+	}
+	return strings.Join(body, "\n")
+}

--- a/internal/custom/ruby/ams_serializer_test.go
+++ b/internal/custom/ruby/ams_serializer_test.go
@@ -1,0 +1,86 @@
+package ruby_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/ruby"
+)
+
+// Issue #4715 — Ruby ActiveModel::Serializer (AMS) DTO FIELD-as-member indexing.
+// A serializer's `attributes :a, :b` / `attribute :c` declarations must be
+// emitted as SCOPE.Schema/field members with name AND a CONTAINS edge back to
+// the serializer — the SAME shape as the JS/Python/Java/Go/C# DTO field members.
+
+func TestRubyAMS_FieldMembers(t *testing.T) {
+	src := `class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+  attribute :full_name
+
+  def full_name
+    "#{object.first} #{object.last}"
+  end
+end
+`
+	e, ok := extreg.Get("custom_ruby_ams_serializer")
+	if !ok {
+		t.Fatal("custom_ruby_ams_serializer not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: "user_serializer.rb", Language: "ruby", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	field := func(name string) *types.EntityRecord {
+		for i := range ents {
+			if ents[i].Name == name && ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "field" {
+				return &ents[i]
+			}
+		}
+		return nil
+	}
+	containsTo := func(id string) bool {
+		for _, e := range ents {
+			for _, r := range e.Relationships {
+				if r.Kind == string(types.RelationshipKindContains) && r.ToID == id {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, attr := range []string{"id", "name", "email", "full_name"} {
+		f := field("UserSerializer." + attr)
+		if f == nil {
+			t.Fatalf("expected UserSerializer.%s field member", attr)
+		}
+		if f.Properties["field_name"] != attr {
+			t.Errorf("%s field_name = %q, want %q", attr, f.Properties["field_name"], attr)
+		}
+		if f.Properties["parent_class"] != "UserSerializer" {
+			t.Errorf("%s parent_class = %q, want UserSerializer", attr, f.Properties["parent_class"])
+		}
+		if f.Signature == "" {
+			t.Errorf("%s field must carry a Signature", attr)
+		}
+		if !containsTo(f.ID) {
+			t.Errorf("expected CONTAINS edge to UserSerializer.%s", attr)
+		}
+	}
+
+	// The serializer DTO node must exist for the membership edge to resolve.
+	var dtoFound bool
+	for i := range ents {
+		if ents[i].Name == "UserSerializer" && ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "dto" {
+			dtoFound = true
+		}
+	}
+	if !dtoFound {
+		t.Error("expected UserSerializer SCOPE.Schema dto node")
+	}
+}


### PR DESCRIPTION
Follow-up to #4613 / #4635. Extends the uniform DTO/serializer FIELD-as-member model to five more frameworks, emitting the **same** `SCOPE.Schema`/field sub-entity shape (`field_name`/`field_type`/`parent_class`/`optional`/`validators` + parseable Signature + `CONTAINS` edge) as the Pydantic/DRF/Spring (#4613) and NestJS (#4635) emitters, so the cross-framework field-level diff tools and the dashboard ShapeTree resolver treat all frameworks uniformly.

## #4714 — Python
- **marshmallow** `class X(Schema)`: `name = fields.<T>(required=, allow_none=, load_default=, ...)` → field members. Type from `fields.<T>`, optional from `required=`/`allow_none=`/`load_default=`/`missing=`. (`extractMarshmallowSchemaFields` + `emitPyDTOFieldMembers`)
- **attrs / dataclasses** `@dataclass` / `@attr.s` / `@define`: annotated attributes `name: type = field(...)` / `attr.ib(...)` → members. Optional from any default / `Optional[...]`; `field()`/`attr.ib()` with no default and not Optional stays required. (`extractAttrsDataclassFields`, reuses the #4613 Pydantic emitter path)

## #4715
- **Go struct tags** — request/response DTO struct fields → members. `field_name` from the `json` tag, type normalized from the Go type, optional from `omitempty` / pointer / non-`required` `validate:`|`binding:` rule, validators as `@rule` markers. (`emitGoDTOFieldMembers`, struct-tag capture added to the existing `custom_go_dto` scanner)
- **C# / .NET DataAnnotations** — DTO/record properties + `[Required]`/`[StringLength]`/`[Range]`/`[EmailAddress]`/… → members. Optional from nullable `T?` unless `[Required]`/`required`. (`extractCsharpDTOFields` + `emitCsharpDTOFieldMembers`)
- **Ruby ActiveModel::Serializer (AMS)** — `attributes :a, :b` / `attribute :c` → members; emits a serializer `dto` node + field members. (new `custom_ruby_ams_serializer` extractor)

## Validation (RED→GREEN fixtures)
A marshmallow Schema, a dataclass, an attrs class, a Go tagged struct, a C# POCO+DataAnnotations, and a Ruby AMS serializer — each asserts CONTAINS → field members with name/type/optional matching source: `TestMarshmallow_FieldMembers`, `TestDataclass_FieldMembers`, `TestAttrs_FieldMembers`, `TestGoDTO_FieldMembers`, `TestCsharpDTO_FieldMembers`, `TestRubyAMS_FieldMembers`.

## Coverage docs
Surgically updated the `schema_extraction`/`dto_extraction` cells for marshmallow, attrs, all 15 Go HTTP frameworks, all 6 C# frameworks citing `validation.go`, and Rails (AMS), honest partial/full preserved. `coverage fmt --check` passes (registry stays canonical). Generic cells updated via `coverage update`; marshmallow/attrs notes edited surgically.

## Gates
- `go build ./...` ✅
- `go vet ./internal/custom/... ./internal/extractors/...` ✅
- `go test ./internal/custom/... ./internal/extractors/... ./internal/types/` ✅
- `coverage fmt --check` ✅
- `coverage validate` — only the pre-existing, unrelated `lang.python.framework.celery` `extractTestFuncBody` error remains (present on origin/main).

Closes #4714
Closes #4715

🤖 Generated with [Claude Code](https://claude.com/claude-code)