### PR TITLE
fix(effects): close cross-ORM read-sink reach for the layered-repository pattern (#4692)

### DIFF
--- a/internal/substrate/effect_sinks_cross_orm_read_4692_test.go
+++ b/internal/substrate/effect_sinks_cross_orm_read_4692_test.go
@@ -1,0 +1,248 @@
+package substrate
+
+// effect_sinks_cross_orm_read_4692_test.go — cross-ORM receiver-typed read
+// reach for the layered-repository pattern (#4692, generalization of the Python
+// #4691 / #4668 / #4694 fixes).
+//
+// The recurring bug: write verbs (.save/.create) bare-match and propagate
+// db_write, but READ verbs that collide with builtins / in-memory collection
+// methods (.get/.first/.find/.all/.where/.count) were gated, so layered-repo
+// reads resolved PURE → GET/list handlers falsely looked like stubs.
+//
+// Each language gets three assertions:
+//   A — a repository read on a TYPED receiver  → db_read (RED before #4692)
+//   B — the same ambiguous verb on a plain collection/dict/map → STAYS pure
+//   C — a thin controller→service→repo read chain whose repo method's effects
+//       include db_read (the per-method sink that the CALLS-union propagates up)
+//
+// The propagation union itself (controller→service→repo) is exercised by the
+// link-layer tests; here we assert the SINK is stamped on the repo read method,
+// which is the precondition that was missing.
+
+import "testing"
+
+// ---------------------------------------------------------------- C# / EF Core
+
+// A: ambiguous LINQ terminals on a DbSet/IQueryable-typed receiver are db_read.
+func TestCSharpEFTypedRead_4692(t *testing.T) {
+	src := `
+public class UserRepository {
+    private readonly AppDbContext _context;
+    public User GetById(int id) {
+        return _context.Users.Where(u => u.Id == id).FirstOrDefault();
+    }
+    public List<User> List() {
+        var q = _context.Users.AsNoTracking();
+        return q.ToList();
+    }
+    public User Find(int id) {
+        return _db.Set<User>().Find(id);
+    }
+}`
+	by := groupByEffect(sniffEffectsCSharp(src))
+	mustHave(t, by, EffectDBRead, "GetById")
+	mustHave(t, by, EffectDBRead, "List")
+	mustHave(t, by, EffectDBRead, "Find")
+}
+
+// B (negative): the same LINQ verbs on an in-memory List/array stay pure.
+func TestCSharpInMemoryLinqNoFalsePositive_4692(t *testing.T) {
+	src := `
+public class Calc {
+    public Item Pick(List<Item> items, string[] names) {
+        var x = items.Where(i => i.Active).ToList();
+        var f = items.Find(i => i.Id == 1);
+        var b = names.Any();
+        var n = items.Count;
+        return f;
+    }
+}`
+	by := groupByEffect(sniffEffectsCSharp(src))
+	mustNotHave(t, by, EffectDBRead, "Pick")
+}
+
+// C: thin repo read method carries the db_read sink for the CALLS-union to lift.
+func TestCSharpRepoReadChainSink_4692(t *testing.T) {
+	src := `
+public class OrderRepository {
+    private readonly OrderContext _context;
+    public Order GetOrder(int id) {
+        return _context.Orders.SingleOrDefault(o => o.Id == id);
+    }
+}`
+	by := groupByEffect(sniffEffectsCSharp(src))
+	mustHave(t, by, EffectDBRead, "GetOrder")
+}
+
+// ---------------------------------------------------------- Ruby / ActiveRecord
+
+// A: ambiguous AR terminals on a Model class / relation-typed receiver.
+func TestRubyARTypedRead_4692(t *testing.T) {
+	src := `
+class UserRepository
+  def get(id)
+    User.find(id)
+  end
+
+  def active
+    rel = User.where(active: true)
+    rel.all
+  end
+
+  def newest
+    User.first
+  end
+end
+`
+	by := groupByEffect(sniffEffectsRuby(src))
+	mustHave(t, by, EffectDBRead, "get")
+	mustHave(t, by, EffectDBRead, "active")
+	mustHave(t, by, EffectDBRead, "newest")
+}
+
+// B (negative): the same verbs on a plain Array/Hash stay pure.
+func TestRubyArrayNoFalsePositive_4692(t *testing.T) {
+	src := `
+class Calc
+  def pick(items, h)
+    head = items.first(3)
+    n = items.count { |x| x.odd? }
+    found = h.find { |k, v| v }
+    head
+  end
+end
+`
+	by := groupByEffect(sniffEffectsRuby(src))
+	mustNotHave(t, by, EffectDBRead, "pick")
+}
+
+// C: thin repo read method carries the db_read sink.
+func TestRubyRepoReadChainSink_4692(t *testing.T) {
+	src := `
+class OrderRepository
+  def get_order(id)
+    Order.find(id)
+  end
+end
+`
+	by := groupByEffect(sniffEffectsRuby(src))
+	mustHave(t, by, EffectDBRead, "get_order")
+}
+
+// ------------------------------------------------------------- PHP / Eloquent
+
+// A: ambiguous Eloquent terminals on a Model/Builder-typed variable or the
+// injected `$this->model->` collaborator.
+func TestPHPEloquentTypedRead_4692(t *testing.T) {
+	src := `
+class UserRepository {
+    public function active() {
+        $q = User::query();
+        return $q->where('active', 1)->get();
+    }
+    public function listAll() {
+        return $this->model->where('a', 1)->get();
+    }
+    public function newest() {
+        $base = DB::table('users');
+        return $base->first();
+    }
+}`
+	by := groupByEffect(sniffEffectsPHP(src))
+	mustHave(t, by, EffectDBRead, "active")
+	mustHave(t, by, EffectDBRead, "listAll")
+	mustHave(t, by, EffectDBRead, "newest")
+}
+
+// B (negative): ambiguous terminals on a plain (untyped) collection variable
+// stay pure.
+func TestPHPCollectionNoFalsePositive_4692(t *testing.T) {
+	src := `
+class Calc {
+    public function pick($rows) {
+        $head = $rows->first();
+        $n = $items->count();
+        return $head;
+    }
+}`
+	by := groupByEffect(sniffEffectsPHP(src))
+	mustNotHave(t, by, EffectDBRead, "pick")
+}
+
+// C: thin repo read method carries the db_read sink.
+func TestPHPRepoReadChainSink_4692(t *testing.T) {
+	src := `
+class OrderRepository {
+    public function getOrder($id) {
+        $q = Order::query();
+        return $q->where('id', $id)->first();
+    }
+}`
+	by := groupByEffect(sniffEffectsPHP(src))
+	mustHave(t, by, EffectDBRead, "getOrder")
+}
+
+// ------------------------------------------------------- Go / GORM + sqlx
+
+// A: ambiguous read terminals on a DB-typed handle (field / param).
+func TestGoDBTypedRead_4692(t *testing.T) {
+	src := `
+type Repo struct {
+	db *sqlx.DB
+}
+
+func (r *Repo) Get(ctx context.Context, id int) (User, error) {
+	var u User
+	err := r.db.Get(ctx, id)
+	return u, err
+}
+
+func (r *Repo) List() ([]User, error) {
+	var us []User
+	r.db.Where("active = ?", true).Find(&us)
+	return us, nil
+}
+
+func loadOne(db *gorm.DB, id int) User {
+	var u User
+	db.First(&u, id)
+	return u
+}
+`
+	by := groupByEffect(sniffEffectsGo(src))
+	mustHave(t, by, EffectDBRead, "Get")
+	mustHave(t, by, EffectDBRead, "List")
+	mustHave(t, by, EffectDBRead, "loadOne")
+}
+
+// B (negative): an ambiguous verb on a non-DB receiver (a cache .Get) stays pure.
+func TestGoNonDBReceiverNoFalsePositive_4692(t *testing.T) {
+	src := `
+func lookup(m Cache, key string) string {
+	v, ok := m.Get(key)
+	if !ok {
+		return ""
+	}
+	return v
+}
+`
+	by := groupByEffect(sniffEffectsGo(src))
+	mustNotHave(t, by, EffectDBRead, "lookup")
+}
+
+// C: thin repo read method carries the db_read sink.
+func TestGoRepoReadChainSink_4692(t *testing.T) {
+	src := `
+type OrderRepo struct {
+	db *gorm.DB
+}
+
+func (r *OrderRepo) GetOrder(id int) Order {
+	var o Order
+	r.db.First(&o, id)
+	return o
+}
+`
+	by := groupByEffect(sniffEffectsGo(src))
+	mustHave(t, by, EffectDBRead, "GetOrder")
+}

--- a/internal/substrate/effect_sinks_csharp.go
+++ b/internal/substrate/effect_sinks_csharp.go
@@ -6,12 +6,16 @@
 //     / SendAsync / GetStringAsync / GetStreamAsync, WebClient
 //     .Download* / .Upload*, RestClient (RestSharp) .Execute*,
 //     HttpWebRequest.Create
-//   - db_read   : Entity Framework DbSet `.Find / .FindAsync / .First /
-//     .FirstOrDefault / .Single / .SingleOrDefault / .Where /
-//     .ToList / .ToArray / .Count / .Any / .Include /
-//     .AsQueryable / .FromSqlRaw / .FromSqlInterpolated`,
-//     raw ADO.NET `SqlCommand.ExecuteReader / ExecuteScalar`,
-//     Dapper `Query / QueryAsync / QueryFirst / QuerySingle`
+//   - db_read   : Entity Framework — distinctive terminals bare-matched
+//     (`.FindAsync / .FirstOrDefaultAsync / .Include /
+//     .AsNoTracking / .AsQueryable / .FromSqlRaw / ...`); the
+//     ambiguous synchronous LINQ verbs (`.Where / .First /
+//     .FirstOrDefault / .Single / .ToList / .ToArray / .Any /
+//     .All / .Count / .Find`) credited ONLY on a DbSet/
+//     IQueryable-typed receiver (#4692, so in-memory LINQ on a
+//     plain List stays pure); raw ADO.NET `SqlCommand
+//     .ExecuteReader / ExecuteScalar`, Dapper `Query / QueryAsync
+//     / QueryFirst / QuerySingle`
 //   - db_write  : EF DbSet `.Add / .AddAsync / .AddRange / .Update /
 //     .UpdateRange / .Remove / .RemoveRange / .Attach`, EF
 //     `SaveChanges / SaveChangesAsync / ExecuteSqlRaw /
@@ -63,11 +67,64 @@ var csharpHTTPRe = regexp.MustCompile(
 		`|\b(?:WebClient|HttpClient)\s*\.\s*(?:DownloadString|DownloadData|DownloadFile|UploadString|UploadData|UploadFile)\b`,
 )
 
-// csharpDBReadRe matches EF / Dapper / ADO.NET read primitives.
+// csharpDBReadRe matches the DISTINCTIVE EF / Dapper / ADO.NET read
+// primitives — names that do NOT collide with in-memory LINQ-to-Objects on a
+// plain List/array/IEnumerable, so they are safe to bare-match on any receiver
+// (#4692). This covers the async EF terminals (`...Async`), the EF-only query
+// shapers (`Include`/`AsNoTracking`/`AsQueryable`/`FromSqlRaw`/...), the ADO.NET
+// readers, and the Dapper `Query*` family.
+//
+// The AMBIGUOUS synchronous LINQ verbs (`Where`/`First`/`FirstOrDefault`/
+// `Single`/`SingleOrDefault`/`ToList`/`ToArray`/`Any`/`All`/`Count`/`Find`) are
+// NOT here — they fire on in-memory collections too (`list.Where(...).ToList()`,
+// `names.Any()`, `items.Find(p)`), which would be false db_read. They are
+// credited ONLY on a DbSet/IQueryable-typed receiver by csharpDBSetReadMatches
+// (#4692 receiver-typed read credit, mirroring the Python #4691 model).
 var csharpDBReadRe = regexp.MustCompile(
-	`\.\s*(?:Find|FindAsync|First|FirstAsync|FirstOrDefault|FirstOrDefaultAsync|Single|SingleAsync|SingleOrDefault|SingleOrDefaultAsync|Where|Any|AnyAsync|All|Count|CountAsync|LongCount|LongCountAsync|ToList|ToListAsync|ToArray|ToArrayAsync|ToDictionary|Include|ThenInclude|AsQueryable|AsNoTracking|FromSqlRaw|FromSqlInterpolated|SqlQuery)\s*[\(<]` +
+	`\.\s*(?:FindAsync|FirstAsync|FirstOrDefaultAsync|SingleAsync|SingleOrDefaultAsync|AnyAsync|CountAsync|LongCountAsync|ToListAsync|ToArrayAsync|LongCount|ToDictionary|Include|ThenInclude|AsQueryable|AsNoTracking|FromSqlRaw|FromSqlInterpolated|SqlQuery)\s*[\(<]` +
 		`|\.\s*(?:ExecuteReader|ExecuteReaderAsync|ExecuteScalar|ExecuteScalarAsync)\s*\(` +
 		`|\.\s*(?:Query|QueryAsync|QueryFirst|QueryFirstAsync|QueryFirstOrDefault|QueryFirstOrDefaultAsync|QuerySingle|QuerySingleAsync|QuerySingleOrDefault|QuerySingleOrDefaultAsync|QueryMultiple|QueryMultipleAsync)\s*[\(<]`,
+)
+
+// --- #4692 EF receiver-typed read credit (ambiguous LINQ terminals) ---
+//
+// The synchronous LINQ verbs below collide with LINQ-to-Objects on plain
+// collections, so they are credited db_read ONLY when the receiver is known to
+// be an EF `DbSet<T>` / `IQueryable<T>` (the layered-repository read shape —
+// `_context.Users.Where(...).FirstOrDefault()`, `_db.Set<Order>().ToList()`).
+// On any other receiver they stay pure, preserving the false-positive guard.
+const csharpAmbiguousLinqVerbs = `Where|First|FirstOrDefault|Single|SingleOrDefault|ToList|ToArray|Any|All|Count|Find`
+
+// csharpDBSetTypedRe seeds the set of DbSet/IQueryable-typed receiver names.
+// Group 1 captures the typed name from the recurring EF declarations:
+//   - `public DbSet<User> Users { get; set; }`     (DbContext property)
+//   - `DbSet<User> users = _context.Set<User>();`  (local)
+//   - `IQueryable<User> q = ...;` / `var q = _ctx.Users.Where(...)` chains
+//   - field/property `_context`/`_db`/`Context`/`db` of a DbContext are typed
+//     as roots so `_context.Users` is reachable — handled by csharpDBSetRootRe.
+var csharpDBSetTypedRe = regexp.MustCompile(
+	`(?:DbSet|IQueryable|IOrderedQueryable|DbQuery)\s*<[^>]+>\s+([A-Za-z_]\w*)\b`,
+)
+
+// csharpDBSetLocalRe types a local assigned from a DbSet-producing RHS:
+//   - `... = <root>.Set<T>()`     (DbContext.Set<T>())
+//   - `... = <root>.<Prop>.Where|Include|AsNoTracking|...`  (queryable chain)
+//
+// Group 1 = assigned name, group 2 = the EF root receiver (so chains compose).
+var csharpDBSetLocalRe = regexp.MustCompile(
+	`(?m)\b(?:var|DbSet<[^>]+>|IQueryable<[^>]+>)\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\s*\.\s*` +
+		`(?:Set\s*<[^>]+>\s*\(|[A-Za-z_]\w*\s*\.\s*(?:Where|Include|AsNoTracking|AsQueryable|OrderBy|OrderByDescending|Select)\b)`,
+)
+
+// csharpDBSetRootMemberRe credits an ambiguous verb invoked DIRECTLY off an EF
+// root's navigation property — `_context.Users.Where(...)`, `_db.Orders.ToList()`,
+// `this.Context.Set<T>().FirstOrDefault()`. The root token must look like a
+// DbContext handle (`_context`/`_ctx`/`_db`/`context`/`db`/`Context`/`Db` or a
+// `*Context` name), and the verb must be the ambiguous set; distinctive verbs
+// are already covered bare by csharpDBReadRe.
+var csharpDBSetRootMemberRe = regexp.MustCompile(
+	`\b(?:_?[Cc]ontext|_?[Cc]tx|_?[Dd]b|[A-Za-z_]\w*Context)\s*\.\s*` +
+		`(?:Set\s*<[^>]+>\s*\(\s*\)|[A-Za-z_]\w*)\s*\.\s*(?:` + csharpAmbiguousLinqVerbs + `)\s*[\(<]`,
 )
 
 // csharpDBWriteRe matches EF / Dapper / ADO.NET write primitives.
@@ -112,12 +169,83 @@ func sniffEffectsCSharp(content string) []EffectMatch {
 	var out []EffectMatch
 	out = appendCSharpMatches(out, content, headers, csharpHTTPRe, EffectHTTPOut, "HttpClient/WebClient/RestSharp", 1.0)
 	out = appendCSharpMatches(out, content, headers, csharpDBReadRe, EffectDBRead, "ef/dapper/ado.read", 0.85)
+	out = append(out, csharpDBSetReadMatches(content, headers)...)
 	out = appendCSharpMatches(out, content, headers, csharpDBWriteRe, EffectDBWrite, "ef/dapper/ado.write", 0.85)
 	out = appendCSharpMatches(out, content, headers, csharpFSReadRe, EffectFSRead, "File.Read/Directory.Get", 1.0)
 	out = appendCSharpMatches(out, content, headers, csharpFSWriteRe, EffectFSWrite, "File.Write/Directory.Create", 1.0)
 	out = appendCSharpMatches(out, content, headers, csharpProcessRe, EffectFSWrite, "Process.Start", 0.9)
 	out = appendCSharpMatches(out, content, headers, csharpMutationRe, EffectMutation, "this.field=", 0.7)
 	return out
+}
+
+// csharpDBSetReadMatches implements the #4692 receiver-typed read credit for
+// C#. It (1) collects the set of DbSet/IQueryable-typed receiver names
+// (typed declarations, locals assigned from `.Set<T>()`/queryable chains,
+// propagated to a fixpoint), then (2) emits db_read for each ambiguous LINQ
+// terminal invoked on one of those typed names, AND for ambiguous terminals
+// chained directly off an EF root's navigation property (`_context.Users.Where`).
+// An ambiguous LINQ verb on an UNTYPED receiver (a plain List/array) earns no
+// credit — the in-memory-LINQ false-positive guard is preserved.
+func csharpDBSetReadMatches(content string, headers []funcHeader) []EffectMatch {
+	typed := collectCSharpDBSetNames(content)
+	var out []EffectMatch
+	emit := func(off int) {
+		line := lineOfOffset(content, off)
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     EffectDBRead,
+			Sink:       "ef.read.dbset",
+			Confidence: 0.85,
+		})
+	}
+	for name := range typed {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*\.\s*(?:` + csharpAmbiguousLinqVerbs + `)\s*[\(<]`)
+		for _, m := range re.FindAllStringIndex(content, -1) {
+			emit(m[0])
+		}
+	}
+	for _, m := range csharpDBSetRootMemberRe.FindAllStringIndex(content, -1) {
+		emit(m[0])
+	}
+	return out
+}
+
+// collectCSharpDBSetNames returns the set of names known to hold a DbSet /
+// IQueryable. Seeds from typed declarations and `.Set<T>()`/queryable-chain
+// locals, then iterates the local-from-typed-receiver form to a fixpoint so
+// `var q = users.Where(...)` types `q` when `users` is already a DbSet.
+func collectCSharpDBSetNames(content string) map[string]bool {
+	typed := map[string]bool{}
+	for _, m := range csharpDBSetTypedRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 && m[1] != "" {
+			typed[m[1]] = true
+		}
+	}
+	for _, m := range csharpDBSetLocalRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 && m[1] != "" {
+			typed[m[1]] = true
+		}
+	}
+	// Fixpoint: `var <dst> = <src>.<queryable-op>(...)` where <src> is typed.
+	chainRe := regexp.MustCompile(`(?m)\bvar\s+([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\s*\.\s*(?:Where|Include|ThenInclude|AsNoTracking|AsQueryable|OrderBy|OrderByDescending|Select|Skip|Take)\b`)
+	chains := chainRe.FindAllStringSubmatch(content, -1)
+	for {
+		changed := false
+		for _, m := range chains {
+			if len(m) < 3 {
+				continue
+			}
+			if typed[m[2]] && !typed[m[1]] {
+				typed[m[1]] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return typed
 }
 
 func scanCSharpFuncHeaders(content string) []funcHeader {

--- a/internal/substrate/effect_sinks_golang.go
+++ b/internal/substrate/effect_sinks_golang.go
@@ -46,12 +46,48 @@ var goHTTPRe = regexp.MustCompile(
 		`|\b(?:client|httpClient|c)\s*\.\s*(?:Do|Get|Post|Head|PostForm)\s*\(`,
 )
 
-// goDBReadRe matches database/sql + GORM + sqlx read primitives.
+// goDBReadRe matches the DISTINCTIVE database/sql + GORM + sqlx read
+// primitives — names that don't collide with ordinary method calls on a
+// non-DB receiver, so they're safe to bare-match anywhere. GORM `.Where` is a
+// distinctive query-builder refinement (the layered-repo read entry point —
+// `r.db.Where(...).Find(&xs)`); it's bare-matched here too. The sqlx `.Get(&` /
+// `.Select(&` forms are kept for the canonical destination-pointer shape.
+//
+// The ambiguous sqlx terminals `.Get` / `.Select` / `.Query*` WITHOUT a `&`
+// destination (e.g. a fluent `r.db.Get(ctx, id)` wrapper, or `.Select(cols)` as
+// a column projection) collide with map getters / generic selectors, so they
+// are credited db_read ONLY on a DB-typed receiver by goDBTypedReadMatches
+// (#4692 receiver-typed read credit, mirroring the Python #4691 model).
 var goDBReadRe = regexp.MustCompile(
 	`\.\s*(?:Query|QueryContext|QueryRow|QueryRowContext)\s*\(` +
-		`|\.\s*(?:Find|First|Last|Take|Pluck|Count|Scan|FindInBatches|Distinct|Select)\s*\(` +
+		`|\.\s*(?:Find|First|Last|Take|Pluck|Count|Scan|FindInBatches|Distinct|Where)\s*\(` +
 		`|\.\s*Get\s*\(\s*&` + // sqlx convention: db.Get(&dest, ...)
 		`|\.\s*Select\s*\(\s*&`, // sqlx convention: db.Select(&dest, ...)
+)
+
+// --- #4692 Go DB receiver-typed read credit (ambiguous terminals) ---
+//
+// goDBAmbiguousVerbs collide with non-DB method names (a map/cache `.Get`, a
+// column `.Select`, a builder `.First`), so they are credited db_read ONLY when
+// the receiver is known to be a `*gorm.DB` / `*sqlx.DB` / `*sqlx.Tx` handle —
+// the layered-repository read shape `r.db.First(&u, id)` / `r.db.Get(ctx,id)`.
+const goDBAmbiguousVerbs = `Get|Select|Query|QueryRow|First|Find|Take|Where|Scan|Pluck`
+
+// goDBHandleTypedRe seeds the set of DB-typed names. Group 1 captures the name
+// from the recurring shapes:
+//   - `db *gorm.DB` / `db *sqlx.DB` / `db *sqlx.Tx` / `db *sql.DB`  (params/fields)
+//   - `db := gorm.Open(...)` / `sqlx.Connect(...)` / `sqlx.Open(...)`
+//   - `db.Model(&X{})` chains return *gorm.DB — the receiver `db` is typed
+var goDBHandleTypedRe = regexp.MustCompile(
+	`\b([A-Za-z_]\w*)\s+\*?\s*(?:gorm\.DB|sqlx\.DB|sqlx\.Tx|sql\.DB|sql\.Tx|bun\.DB|ent\.Client)\b` +
+		`|\b([A-Za-z_]\w*)\s*:?=\s*(?:gorm\s*\.\s*Open|sqlx\s*\.\s*(?:Connect|ConnectContext|Open|MustConnect|NewDb)|sql\s*\.\s*Open|bun\s*\.\s*NewDB)\s*\(`,
+)
+
+// goDBStructFieldRe types the struct field a repository holds its handle in —
+// `db *gorm.DB` / `DB *sqlx.DB` inside a struct — so `r.db.First(...)` resolves
+// (the receiver token is the field name). Group 1 = field name.
+var goDBStructFieldRe = regexp.MustCompile(
+	`(?m)^\s*([A-Za-z_]\w*)\s+\*?\s*(?:gorm\.DB|sqlx\.DB|sqlx\.Tx|sql\.DB|sql\.Tx|bun\.DB|ent\.Client)\b`,
 )
 
 // goDBWriteRe matches database/sql + GORM + sqlx write primitives.
@@ -91,11 +127,73 @@ func sniffEffectsGo(content string) []EffectMatch {
 	var out []EffectMatch
 	out = appendGoMatches(out, content, headers, goHTTPRe, EffectHTTPOut, "http.Client.Do/Get/Post", 1.0)
 	out = appendGoMatches(out, content, headers, goDBReadRe, EffectDBRead, "sql.Query/GORM.Find/sqlx.Get", 0.85)
+	out = append(out, goDBTypedReadMatches(content, headers)...)
 	out = appendGoMatches(out, content, headers, goDBWriteRe, EffectDBWrite, "sql.Exec/GORM.Create/Save", 0.85)
 	out = appendGoMatches(out, content, headers, goFSReadRe, EffectFSRead, "os.Open/ReadFile", 1.0)
 	out = appendGoMatches(out, content, headers, goFSWriteRe, EffectFSWrite, "os.Create/WriteFile", 1.0)
 	out = appendGoMatches(out, content, headers, goMutationRe, EffectMutation, "recv.field=", 0.6)
 	return out
+}
+
+// goDBTypedReadMatches implements the #4692 receiver-typed read credit for Go.
+// It collects the set of DB-typed handle names (params/fields/locals declared or
+// assigned as *gorm.DB / *sqlx.DB / sql.DB / ...), then emits db_read for each
+// ambiguous read terminal invoked on one of those handles — either as a bare
+// receiver (`db.Get(ctx,id)`) or as a struct field selector (`r.db.First(&u)`,
+// `s.DB.Select(&xs)`). An ambiguous verb on an untyped receiver (a map's `.Get`,
+// a builder's `.Select`) earns no credit — the false-positive guard is preserved.
+func goDBTypedReadMatches(content string, headers []funcHeader) []EffectMatch {
+	typed := collectGoDBHandleNames(content)
+	if len(typed) == 0 {
+		return nil
+	}
+	var out []EffectMatch
+	seen := map[int]bool{}
+	emit := func(off int) {
+		if seen[off] {
+			return
+		}
+		seen[off] = true
+		line := lineOfOffset(content, off)
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     EffectDBRead,
+			Sink:       "sqlx/gorm.read.typed",
+			Confidence: 0.85,
+		})
+	}
+	for name := range typed {
+		// Bare receiver `<name>.<verb>(` and field selector `.<name>.<verb>(`.
+		re := regexp.MustCompile(`(?:\b|\.)` + regexp.QuoteMeta(name) + `\s*\.\s*(?:` + goDBAmbiguousVerbs + `)\s*\(`)
+		for _, m := range re.FindAllStringIndex(content, -1) {
+			emit(m[0])
+		}
+	}
+	return out
+}
+
+// collectGoDBHandleNames returns the set of names (params, struct fields, locals)
+// known to hold a *gorm.DB / *sqlx.DB / sql.DB / bun.DB / ent.Client handle.
+func collectGoDBHandleNames(content string) map[string]bool {
+	typed := map[string]bool{}
+	add := func(s string) {
+		if s != "" {
+			typed[s] = true
+		}
+	}
+	for _, m := range goDBHandleTypedRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 3 {
+			add(m[1])
+			add(m[2])
+		}
+	}
+	for _, m := range goDBStructFieldRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 {
+			add(m[1])
+		}
+	}
+	return typed
 }
 
 func scanGoFuncHeaders(content string) []funcHeader {

--- a/internal/substrate/effect_sinks_php.go
+++ b/internal/substrate/effect_sinks_php.go
@@ -57,6 +57,42 @@ var phpDBReadRe = regexp.MustCompile(
 		`|\bmysql_query\s*\(\s*['"](?i:\s*(?:SELECT|WITH)\b)`,
 )
 
+// --- #4692 Eloquent builder receiver-typed read credit (instance form) ---
+//
+// phpDBReadRe covers the Eloquent STATIC form (`User::where(...)->get()`) and
+// the DISTINCTIVE Doctrine `->find`/`->findBy` repo reads, but the layered-
+// repository / query-builder INSTANCE form is missed: `$this->model->where(...)
+// ->get()`, `$query->first()`, `$builder->pluck('id')`. The `->get`/`->first`/
+// `->all`/`->where`/`->pluck`/`->value`/`->exists` terminals collide with plain
+// getters/collections on a `->` receiver, so they are credited db_read ONLY
+// when the receiver is a Model/Builder-typed variable (#4692 receiver-typed
+// read credit, mirroring the Python #4691 model). On any other receiver they
+// stay pure, preserving the false-positive guard.
+const phpEloquentAmbiguousVerbs = `where|whereIn|whereHas|orWhere|get|first|firstOrFail|all|pluck|value|exists|count|sole|find|findOrFail`
+
+// phpEloquentTypedRe seeds the set of Model/Builder-typed variable names. Group
+// 1 captures the `$var` (without the leading `$`) from the recurring shapes:
+//   - `$q = Model::query();` / `$q = User::where(...);`     (static builder root)
+//   - `$q = $this->model->newQuery();`                      (repo builder)
+//   - `$q = DB::table('users');`                            (query builder)
+//   - `@var Builder|EloquentBuilder|Model $q` docblock / typed property
+var phpEloquentTypedRe = regexp.MustCompile(
+	`\$([A-Za-z_]\w*)\s*=\s*` +
+		`(?:[A-Za-z_]\w*\s*::\s*(?:query|where|whereIn|with|select|newQuery|on)\s*\(` +
+		`|\$[A-Za-z_][\w]*(?:\s*->\s*[A-Za-z_]\w*)*\s*->\s*(?:newQuery|query|newModelQuery|with|where)\s*\(` +
+		`|DB\s*::\s*table\s*\()`,
+)
+
+// phpEloquentModelPropReadRe credits an ambiguous verb invoked directly off a
+// Model property handle on `$this` — the canonical layered-repository read:
+// `$this->model->where(...)`, `$this->user->first()`, `$this->repository->get()`.
+// The `$this->...->` prefix marks an injected model/builder collaborator; a
+// plain local array (`$rows->...` is not `$this->`) is excluded here and only
+// credited via the typed-variable path when actually builder-typed.
+var phpEloquentModelPropReadRe = regexp.MustCompile(
+	`\$this\s*->\s*[A-Za-z_]\w*\s*->\s*(?:` + phpEloquentAmbiguousVerbs + `)\s*\(`,
+)
+
 // phpDBWriteRe matches Eloquent / Doctrine / PDO / mysqli write
 // primitives.
 var phpDBWriteRe = regexp.MustCompile(
@@ -107,12 +143,75 @@ func sniffEffectsPHP(content string) []EffectMatch {
 	var out []EffectMatch
 	out = appendPHPMatches(out, content, headers, phpHTTPRe, EffectHTTPOut, "curl/Guzzle/wp_remote", 1.0)
 	out = appendPHPMatches(out, content, headers, phpDBReadRe, EffectDBRead, "eloquent/doctrine/pdo.read", 0.85)
+	out = append(out, phpEloquentBuilderReadMatches(content, headers)...)
 	out = appendPHPMatches(out, content, headers, phpDBWriteRe, EffectDBWrite, "eloquent/doctrine/pdo.write", 0.85)
 	out = appendPHPFSReadMatches(out, content, headers)
 	out = appendPHPMatches(out, content, headers, phpFSWriteRe, EffectFSWrite, "file_put_contents/fwrite", 1.0)
 	out = appendPHPMatches(out, content, headers, phpProcessRe, EffectFSWrite, "exec/system/proc_open", 0.9)
 	out = appendPHPMatches(out, content, headers, phpMutationRe, EffectMutation, "$this->prop=", 0.7)
 	return out
+}
+
+// phpEloquentBuilderReadMatches implements the #4692 receiver-typed read credit
+// for PHP. It emits db_read for (a) ambiguous Eloquent terminals on a
+// Model/Builder-typed `$var` (seeded from a static builder root / `newQuery()` /
+// `DB::table()`, propagated across `$q = $q->where(...)` chains to a fixpoint),
+// and (b) ambiguous terminals chained off a `$this->model->` collaborator (the
+// injected-repository read shape). An ambiguous terminal on a plain local array
+// / Collection earns no credit — the false-positive guard is preserved.
+func phpEloquentBuilderReadMatches(content string, headers []funcHeader) []EffectMatch {
+	var out []EffectMatch
+	emit := func(off int) {
+		line := lineOfOffset(content, off)
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     EffectDBRead,
+			Sink:       "eloquent.read.builder",
+			Confidence: 0.85,
+		})
+	}
+	for name := range collectPHPBuilderNames(content) {
+		re := regexp.MustCompile(`\$` + regexp.QuoteMeta(name) + `\s*->\s*(?:` + phpEloquentAmbiguousVerbs + `)\s*\(`)
+		for _, m := range re.FindAllStringIndex(content, -1) {
+			emit(m[0])
+		}
+	}
+	for _, m := range phpEloquentModelPropReadRe.FindAllStringIndex(content, -1) {
+		emit(m[0])
+	}
+	return out
+}
+
+// collectPHPBuilderNames returns the set of `$var` names (sans `$`) known to
+// hold an Eloquent/Query Builder. Seeds from phpEloquentTypedRe, then iterates
+// `$dst = $src->where|...` chains to a fixpoint so `$q = $base->where(...)`
+// types `$q` when `$base` is already a builder.
+func collectPHPBuilderNames(content string) map[string]bool {
+	typed := map[string]bool{}
+	for _, m := range phpEloquentTypedRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 && m[1] != "" {
+			typed[m[1]] = true
+		}
+	}
+	chainRe := regexp.MustCompile(`\$([A-Za-z_]\w*)\s*=\s*\$([A-Za-z_]\w*)\s*->\s*(?:where|whereIn|whereHas|orWhere|with|select|orderBy|groupBy|having|join|leftJoin|limit|offset|newQuery)\s*\(`)
+	chains := chainRe.FindAllStringSubmatch(content, -1)
+	for {
+		changed := false
+		for _, m := range chains {
+			if len(m) < 3 {
+				continue
+			}
+			if typed[m[2]] && !typed[m[1]] {
+				typed[m[1]] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return typed
 }
 
 func scanPHPFuncHeaders(content string) []funcHeader {

--- a/internal/substrate/effect_sinks_ruby.go
+++ b/internal/substrate/effect_sinks_ruby.go
@@ -58,11 +58,55 @@ var rubyHTTPRe = regexp.MustCompile(
 		`|\bopen-uri\b`,
 )
 
-// rubyDBReadRe matches ActiveRecord and raw read primitives.
+// rubyDBReadRe matches the DISTINCTIVE ActiveRecord read terminals plus raw
+// read primitives. These names do NOT collide with Enumerable on a plain
+// Array/Hash (`.where`/`.find_by`/`.pluck`/`.exists?`/`.includes`/... are
+// ActiveRecord-specific), so they are safe to bare-match on any receiver.
+//
+// The AMBIGUOUS Enumerable-colliding terminals (`first`/`last`/`find`/`all`/
+// `count`/`select`/`take`/`any?`/`many?`/`none?`) are NOT here — they fire on
+// plain collections too (`items.first(3)`, `list.select { ... }`,
+// `h.find { ... }`), which would be false db_read. They are credited ONLY on a
+// Model-class / relation-typed receiver by rubyARReadMatches (#4692
+// receiver-typed read credit, mirroring the Python #4691 model).
 var rubyDBReadRe = regexp.MustCompile(
-	`\.\s*(?:where|find|find_by|find_each|find_in_batches|all|first|last|pluck|count|exists\?|any\?|many\?|none\?|take|select|joins|includes|preload|eager_load|references|distinct|order|group|having|limit|offset)\s*[\(.]` +
+	`\.\s*(?:where|find_by|find_each|find_in_batches|pluck|exists\?|joins|includes|preload|eager_load|references|distinct|group|having|offset)\s*[\(.]` +
 		`|\.\s*find\s*\(\s*[A-Za-z_0-9:]` +
 		`|\bconnection\s*\.\s*(?:execute|exec_query|select_all|select_one|select_value|select_values|select_rows)\s*\(`,
+)
+
+// --- #4692 ActiveRecord receiver-typed read credit (ambiguous terminals) ---
+//
+// rubyARAmbiguousVerbs collide with Enumerable, so they are credited db_read
+// ONLY when the receiver is a Model class (capitalised constant followed by a
+// read terminal) or a relation-typed local (assigned from a Model/relation read
+// op). On a plain Array/Hash they stay pure, preserving the false-positive guard.
+const rubyARAmbiguousVerbs = `first|last|find|all|count|select|take|any\?|many\?|none\?`
+
+// rubyARModelReadRe credits the ambiguous terminals when invoked directly on a
+// Model class constant — `User.first`, `Account.find(id)`, `Order.all`,
+// `Invoice.count`. A bare capitalised constant receiver immediately followed by
+// an ambiguous read verb is the canonical ActiveRecord class-method read; plain
+// locals (lowercase) are excluded so `items.first` stays pure.
+var rubyARModelReadRe = regexp.MustCompile(
+	`\b[A-Z][A-Za-z0-9_]*(?:::[A-Z][A-Za-z0-9_]*)*\s*\.\s*(?:` + rubyARAmbiguousVerbs + `)\s*[\(.\s]`,
+)
+
+// rubyARRelationFromModelRe seeds relation-typed locals assigned from a Model
+// CONSTANT read op — `rel = User.where(...)`, `scope = Account.all`. Group 1 =
+// assigned name. (Receiver is a capitalised constant: an unambiguous AR root.)
+var rubyARRelationFromModelRe = regexp.MustCompile(
+	`(?m)^\s*([a-z_]\w*)\s*=\s*[A-Z][A-Za-z0-9_:]*\s*\.\s*` +
+		`(?:where|find_by|joins|includes|preload|eager_load|references|distinct|group|having|order|limit|offset|all|none)\s*[\(.]`,
+)
+
+// rubyARRelationChainRe propagates relation typing across reassignment from an
+// already-typed name — `q = q.where(...)`, `scoped = rel.order(:id)`. Group 1 =
+// assigned name, group 2 = source receiver name (checked against the typed set
+// in a fixpoint loop).
+var rubyARRelationChainRe = regexp.MustCompile(
+	`(?m)^\s*([a-z_]\w*)\s*=\s*([a-z_]\w*)\s*\.\s*` +
+		`(?:where|joins|includes|preload|eager_load|references|distinct|group|having|order|limit|offset|all|none|select|merge)\s*[\(.]`,
 )
 
 // rubyDBWriteRe matches ActiveRecord and raw write primitives.
@@ -161,6 +205,7 @@ func sniffEffectsRuby(content string) []EffectMatch {
 	var out []EffectMatch
 	out = appendRubyMatches(out, content, headers, rubyHTTPRe, EffectHTTPOut, "Net::HTTP/HTTParty/Faraday", 1.0)
 	out = appendRubyMatches(out, content, headers, rubyDBReadRe, EffectDBRead, "activerecord.read", 0.85)
+	out = append(out, rubyARReadMatches(content, headers)...)
 	out = appendRubyMatches(out, content, headers, rubyDBWriteRe, EffectDBWrite, "activerecord.write", 0.85)
 	out = appendRubyRawDriverSQL(out, content, headers)
 	out = appendRubySequelDatasetWrites(out, content, headers)
@@ -169,6 +214,65 @@ func sniffEffectsRuby(content string) []EffectMatch {
 	out = appendRubyMatches(out, content, headers, rubyProcessRe, EffectFSWrite, "Process.spawn/system", 0.9)
 	out = appendRubyMatches(out, content, headers, rubyMutationRe, EffectMutation, "@ivar=", 0.7)
 	return out
+}
+
+// rubyARReadMatches implements the #4692 receiver-typed read credit for Ruby.
+// It emits db_read for (a) ambiguous AR terminals on a Model CONSTANT receiver
+// (`User.first`/`Order.all`) and (b) ambiguous terminals on a relation-typed
+// local (seeded from a Model-constant read op, propagated across reassignment
+// to a fixpoint). An ambiguous terminal on a plain Array/Hash local (untyped)
+// earns no credit — the Enumerable false-positive guard is preserved.
+func rubyARReadMatches(content string, headers []funcHeader) []EffectMatch {
+	var out []EffectMatch
+	emit := func(off int) {
+		line := lineOfOffset(content, off)
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     EffectDBRead,
+			Sink:       "activerecord.read.relation",
+			Confidence: 0.85,
+		})
+	}
+	for _, m := range rubyARModelReadRe.FindAllStringIndex(content, -1) {
+		emit(m[0])
+	}
+	for name := range collectRubyRelationNames(content) {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*\.\s*(?:` + rubyARAmbiguousVerbs + `)\s*[\(.\s]`)
+		for _, m := range re.FindAllStringIndex(content, -1) {
+			emit(m[0])
+		}
+	}
+	return out
+}
+
+// collectRubyRelationNames returns the set of local names known to hold an
+// ActiveRecord relation. Seeds from `<name> = Model.<read-op>(...)` and
+// iterates `<name> = <typed>.<read-op>(...)` to a fixpoint.
+func collectRubyRelationNames(content string) map[string]bool {
+	typed := map[string]bool{}
+	for _, m := range rubyARRelationFromModelRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 && m[1] != "" {
+			typed[m[1]] = true
+		}
+	}
+	chains := rubyARRelationChainRe.FindAllStringSubmatch(content, -1)
+	for {
+		changed := false
+		for _, m := range chains {
+			if len(m) < 3 {
+				continue
+			}
+			if typed[m[2]] && !typed[m[1]] {
+				typed[m[1]] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return typed
 }
 
 func scanRubyFuncHeaders(content string) []funcHeader {


### PR DESCRIPTION
## Summary

Generalizes the Python receiver-typed read-credit model (#4691) and the read/write-symmetry fix (#4668/#4694) across the **Go / C# / Ruby / PHP** effect sniffers. The recurring bug: write verbs (`.save`/`.create`) bare-match and propagate `db_write`, but READ verbs that collide with builtins / in-memory-collection methods (`.get`/`.first`/`.find`/`.all`/`.where`/`.count`) were gated (or over-matched), so layered-repo reads resolved PURE → GET/list handlers falsely looked like stubs (or in-memory collection code falsely looked like a DB read).

Each language now follows the #4691 model: an ambiguous read terminal is credited `db_read` **only on a typed DB receiver**; the same verb on a plain dict/list/map/Collection stays pure.

## Per-language read terminals credited (typed-receiver) + guard

| Lang | Ambiguous terminals credited on a typed receiver | Receiver typing | Guard preserved |
|---|---|---|---|
| **C#** | `Where First FirstOrDefault Single SingleOrDefault ToList ToArray Any All Count Find` | `DbSet<T>`/`IQueryable<T>` decls, `.Set<T>()`/queryable-chain locals, `_context.<Nav>` roots | in-memory LINQ (`items.Where(...).ToList()`, `names.Any()`, `list.Find(p)`) stays pure |
| **Ruby** | `first last find all count select take any? many? none?` | Model-class constant (`User.first`) or relation-typed local (`rel=User.where(...)`) w/ fixpoint | `items.first(3)`, `h.find{...}` on Array/Hash stays pure |
| **PHP** | `where get first all pluck find value exists` (instance `->` form) | Model/Builder-typed `$var` (`User::query()`/`->newQuery()`/`DB::table()`) + `$this->model->` | plain Collection `->first()` stays pure |
| **Go** | `Get Select Query First Find Take Where Scan Pluck` | `*gorm.DB`/`*sqlx.DB` field/param/local handle; GORM `.Where` also bare | cache/map `.Get` on a non-DB receiver stays pure |

The propagation union already lifts `db_read` up the controller→service→repo CALLS chain once the sink is stamped; this PR only stamps the sink.

## Languages done vs deferred

- **Done**: Go, C#, Ruby, PHP.
- **Verified already correct** (reads already gated to the right typed receiver, no change): Kotlin (Exposed `Table.select`, JPA `findBy*`), Elixir (Ecto `Repo.*`).
- **Follow-ups filed** (inverse over-credit problem — bare collection/iterator combinators need typed-receiver gating): Scala/Slick #4736, Rust/Diesel+sea-orm #4737.

## Validation

`internal/substrate/effect_sinks_cross_orm_read_4692_test.go` — per language: **A** repo read on a typed receiver → `db_read`; **B** same ambiguous verb on a plain collection/dict/map → stays pure; **C** thin repo read method carries the `db_read` sink. All 12 pass.

## Coverage docs

Surgically updated the `db_effect` read cell for csharp/go/php/ruby in `docs/coverage/registry.json`; `coverage fmt --check` passes.

## Gates

`go build ./...`, `go vet`, `go test ./internal/substrate/... ./internal/engine/... ./internal/graph/... ./internal/types/`, and `coverage fmt --check` — all green.

Closes #4692

🤖 Generated with [Claude Code](https://claude.com/claude-code)