### PR TITLE
fix(substrate): Ruby branch method-boundary clamp (#4693)

### DIFF
--- a/internal/mcp/effects_branches_4693_ruby_test.go
+++ b/internal/mcp/effects_branches_4693_ruby_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+// effects_branches_4693_ruby_test.go — method-boundary scoping regression for
+// the RUBY (`end`-delimited) branch analyzer (#4693, follow-up to #4666, epic
+// #4419).
+//
+// #4666 added substrate.ClampToFunctionBody for python (dedent) and the brace
+// languages (matching `}`). Ruby methods are `def`…`end`-delimited, not brace
+// or dedent, so they fell through the clamp unchanged: a ruby controller method
+// whose entity EndLine is missing/zero gets a padded StartLine+N window that
+// over-captures branches into the NEXT `def`. bodyEndRuby now clamps that
+// window to the `end` closing the method's own `def`.
+//
+// This test pins the fix on a verbatim two-method Rails-style controller
+// (create_contact immediately followed by update_contact): with create_contact
+// given NO EndLine, effects(create_contact, include=branches) must return ONLY
+// create_contact's own branches (400/409 guards + 201/500) and NONE of
+// update_contact's distinct branches (its 422 email conflict, the 503).
+//
+// The negative case asserts an endless/one-liner `def` does NOT over-clamp:
+// the branchy sibling below it is still seen (over-inclusion beats truncation).
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func rubyBranchScopeTestServer(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			{
+				ID: "op_create_contact_rb", Name: "ContractsController.create_contact",
+				Kind:          "SCOPE.Operation",
+				QualifiedName: "contracts_controller.ContractsController.create_contact",
+				// StartLine is the `def create_contact` header (fixture line 2).
+				// EndLine omitted (0) → degenerate span → padded window → would
+				// overshoot into update_contact (fixture line 24+) pre-fix.
+				SourceFile: "contracts_controller_two_methods.rb", StartLine: 2, EndLine: 0,
+			},
+			{
+				ID: "op_ping_rb", Name: "StatusController.ping",
+				Kind:          "SCOPE.Operation",
+				QualifiedName: "status_controller.StatusController.ping",
+				// Endless one-liner `def ping = head(:ok)` (fixture line 5).
+				// EndLine omitted → padded window runs to EOF. bodyEndRuby must
+				// NOT clamp at the header (no separate `end` body) → the branchy
+				// sibling health_check below stays visible (over-inclusion).
+				SourceFile: "oneliner_methods.rb", StartLine: 5, EndLine: 0,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "branches_4693_ruby"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["upvate-core"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+func TestEffectsBranches_RubyMethodScope(t *testing.T) {
+	srv := rubyBranchScopeTestServer(t)
+	out := callEffects(t, srv, "ContractsController.create_contact", "branches")
+
+	if sup, _ := out["branches_supported"].(bool); !sup {
+		t.Fatalf("branches_supported should be true for ruby; got %v", out["branches_supported"])
+	}
+	branches := branchList(t, out)
+	if len(branches) == 0 {
+		t.Fatalf("expected create_contact's own branches, got none")
+	}
+
+	// --- create_contact's OWN branches are present ---
+	if b := findBranch(branches, "contract.client.nil?"); b == nil {
+		t.Fatalf("missing create_contact's 400 guard: %v", branches)
+	} else {
+		assertStatus(t, b, "400")
+	}
+	if b := findBranch(branches, "existing.present?"); b == nil {
+		t.Fatalf("missing create_contact's 409 guard: %v", branches)
+	}
+
+	// --- update_contact's DISTINCT branches must NOT appear (the over-capture) ---
+	for _, b := range branches {
+		cond, _ := b["condition"].(string)
+		if cond == "if conflict.present? && conflict.id != contact.id" {
+			t.Errorf("over-capture: create_contact branch list bled into update_contact's 422 conflict guard (%q)", cond)
+		}
+		if st := branchStatus(b); st == "422" || st == "503" {
+			t.Errorf("over-capture: create_contact branch carries update_contact-only status %s (cond=%v)", st, cond)
+		}
+	}
+
+	// No branch may be reported at/after update_contact's region (fixture line 24).
+	for _, b := range branches {
+		if line := toInt(b["line"]); line >= 24 {
+			t.Errorf("over-capture: branch at line %d is inside/after the sibling update_contact method (cond=%v)", line, b["condition"])
+		}
+	}
+}
+
+// TestEffectsBranches_RubyOneLinerNoOverClamp is the negative case: an
+// endless/one-liner `def ping = head(:ok)` must NOT cause bodyEndRuby to clamp
+// at the header line. health_check (the branchy sibling below it) keeps its own
+// 503 guard — over-inclusion is the conservative direction, never truncation.
+func TestEffectsBranches_RubyOneLinerNoOverClamp(t *testing.T) {
+	srv := rubyBranchScopeTestServer(t)
+	out := callEffects(t, srv, "StatusController.ping", "branches")
+
+	branches := branchList(t, out)
+	if b := findBranch(branches, "Maintenance.active?"); b == nil {
+		t.Fatalf("over-clamp regression: endless `def ping` clamped at its header and dropped the branchy sibling health_check: %v", branches)
+	}
+}

--- a/internal/mcp/testdata/branches_4693_ruby/contracts_controller_two_methods.rb
+++ b/internal/mcp/testdata/branches_4693_ruby/contracts_controller_two_methods.rb
@@ -1,0 +1,39 @@
+class ContractsController < ApplicationController
+  def create_contact
+    contract = Contract.find_by(id: params[:id])
+    return head :not_found if contract.nil?
+    if contract.client.nil?
+      render status: 400, json: { error: "contract has no client" }
+      return
+    end
+    existing = Contact.find_by(email: params[:email])
+    if existing.present?
+      render status: 409, json: { error: "contact already exists" }
+      return
+    end
+    begin
+      contact = contract.contacts.create!(contact_params)
+      render status: 201, json: contact
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error(e)
+      render status: 500, json: { error: "failed to create contact" }
+    end
+  end
+
+  def update_contact
+    contact = Contact.find_by(id: params[:contact_id])
+    return head :unprocessable_entity if contact.nil?
+    conflict = Contact.find_by(email: params[:email])
+    if conflict.present? && conflict.id != contact.id
+      render status: 422, json: { error: "email conflict" }
+      return
+    end
+    begin
+      contact.update!(contact_params)
+      render status: 200, json: contact
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error(e)
+      render status: 503, json: { error: "failed to update contact" }
+    end
+  end
+end

--- a/internal/mcp/testdata/branches_4693_ruby/oneliner_methods.rb
+++ b/internal/mcp/testdata/branches_4693_ruby/oneliner_methods.rb
@@ -1,0 +1,11 @@
+class StatusController < ApplicationController
+  # An endless / one-liner method (Ruby 3.0+) has no separate `end` body, so the
+  # clamp must NOT over-clamp at the header line and drop the branchy sibling
+  # below. Its own branch is the postfix modifier on the next real method.
+  def ping = head(:ok)
+
+  def health_check
+    return head :service_unavailable if Maintenance.active?
+    render status: 200, json: { ok: true }
+  end
+end

--- a/internal/substrate/branches.go
+++ b/internal/substrate/branches.go
@@ -152,9 +152,9 @@ func init() { RegisterBranchAnalyzer("python", analyzeBranchesPython) }
 
 // braceLangs is the set of brace-delimited languages whose function body is
 // bounded by a balanced `{`…`}` block. ClampToFunctionBody uses braceBodyEnd
-// for these; Python uses bodyEndPython. Languages absent here (e.g. ruby,
-// which is `end`-delimited) are not clamped at the source level yet — see
-// ClampToFunctionBody and the #4666 follow-up.
+// for these; Python uses bodyEndPython and ruby (`end`-delimited) uses
+// bodyEndRuby. Languages absent from every family are not clamped at the source
+// level yet — see ClampToFunctionBody.
 var braceLangs = map[string]bool{
 	"jsts": true, "java": true, "go": true, "php": true,
 	"csharp": true, "kotlin": true, "scala": true, "rust": true,
@@ -175,8 +175,10 @@ var braceLangs = map[string]bool{
 // Behaviour by language family:
 //   - Python: clamp to the dedent boundary (bodyEndPython).
 //   - Brace languages: clamp to the matching `}` of the header's own block.
-//   - Anything else (e.g. ruby `end`-delimited): returned unchanged — honest
-//     no-op until a body-end detector is implemented for it (#4666 follow-up).
+//   - Ruby (`end`-delimited): clamp to the `end` closing the method's `def`
+//     (bodyEndRuby).
+//   - Anything else: returned unchanged — honest no-op until a body-end
+//     detector is implemented for it.
 //
 // It is idempotent and safe on an already-tight window: an exact single-method
 // body has no trailing sibling, so the boundary is len(lines) and the source is
@@ -192,6 +194,8 @@ func ClampToFunctionBody(src, lang string) string {
 		end = bodyEndPython(lines)
 	case braceLangs[lang]:
 		end = braceBodyEnd(lines)
+	case lang == "ruby":
+		end = bodyEndRuby(lines)
 	default:
 		return src // no body-end detector for this language yet
 	}

--- a/internal/substrate/branches_ruby.go
+++ b/internal/substrate/branches_ruby.go
@@ -224,6 +224,113 @@ func endBlockBody(lines []string, headerIdx int) []string {
 	return body
 }
 
+// rubyClampDefHeaderRe matches a method-definition header (`def name` / `def
+// self.name` / `def name(args)`), ignoring leading indentation. It anchors the
+// method whose body bodyEndRuby clamps to. (Distinct from payload_shapes_ruby's
+// rubyDefHeaderRe, which is multi-line/`(?m)` and capture-oriented; this one is
+// a cheap per-line predicate.)
+var rubyClampDefHeaderRe = regexp.MustCompile(`^\s*def\s`)
+
+// rubyOneLineDefRe matches a single-line `def`…`end` (`def foo; bar; end` /
+// `def foo = expr`), which opens and closes its body on the same line and
+// therefore has no separate clamp boundary. An endless method (`def foo = x`,
+// Ruby 3.0+) likewise needs no `end`.
+var (
+	rubyOneLineDefEndRe = regexp.MustCompile(`^\s*def\b.*;\s*end\b`)
+	rubyEndlessDefRe    = regexp.MustCompile(`^\s*def\s+[^;]*=`)
+	rubyBeginCommentRe  = regexp.MustCompile(`^=begin\b`)
+	rubyEndCommentRe    = regexp.MustCompile(`^=end\b`)
+)
+
+// bodyEndRuby returns the exclusive line index at which the method whose `def`
+// header is the first `def` line of `lines` ends — the line just AFTER the
+// `end` that closes the method's own `def` block. It is the `end`-delimited
+// analogue of bodyEndPython / braceBodyEnd: it stops a branch walk from
+// bleeding into the sibling `def`s that follow when the effects tool padded the
+// source window because the entity's EndLine was missing/zero (#4488/#4666).
+//
+// Walk model: locate the method header (first `def` line), then walk forward
+// tracking `end`-closed nesting depth. Every block opener
+// (`def`/`do`/`if`/`unless`/`case`/`begin`/`while`/`until`/`for`/`module`/
+// `class`) that is NOT a trailing/postfix modifier (`x if y`, `return z unless
+// w`) increments depth via the same rubyOpensBlock/rubyIsModifierLine helpers
+// the branch analyzer uses; a standalone `end` decrements it. When depth
+// returns to 0 the method's `def` has closed; the boundary is the next line.
+//
+// Conservatism (matches braceBodyEnd's contract — never clamp too SHORT, which
+// would silently drop real branches; the bug being fixed is clamping too LONG):
+//   - No `def` in the window → whole window.
+//   - A single-line `def …; end` or an endless method (`def f = expr`) → whole
+//     window (no separate body to clamp; over-inclusion is harmless because the
+//     window for such a method is already tight or the sibling is the next def).
+//   - `=begin`/`=end` block comments are skipped so a stray `end` or `def`
+//     keyword inside documentation never moves the boundary.
+//   - The `def` block never closes within the window (truncated/ambiguous) →
+//     whole window. Honest over-inclusion beats truncation.
+func bodyEndRuby(lines []string) int {
+	headerIdx := -1
+	inComment := false
+	for i, ln := range lines {
+		trimmed := strings.TrimSpace(ln)
+		if rubyBeginCommentRe.MatchString(trimmed) {
+			inComment = true
+			continue
+		}
+		if inComment {
+			if rubyEndCommentRe.MatchString(trimmed) {
+				inComment = false
+			}
+			continue
+		}
+		if rubyClampDefHeaderRe.MatchString(ln) {
+			// One-line or endless method: no separate `end` body to clamp.
+			if rubyOneLineDefEndRe.MatchString(ln) || rubyEndlessDefRe.MatchString(ln) {
+				return len(lines)
+			}
+			headerIdx = i
+			break
+		}
+	}
+	if headerIdx < 0 {
+		return len(lines) // no method header — honest over-inclusion
+	}
+	depth := 1 // the `def` header opens the first level
+	inComment = false
+	for j := headerIdx + 1; j < len(lines); j++ {
+		ln := lines[j]
+		trimmed := strings.TrimSpace(ln)
+		if trimmed == "" {
+			continue
+		}
+		if rubyBeginCommentRe.MatchString(trimmed) {
+			inComment = true
+			continue
+		}
+		if inComment {
+			if rubyEndCommentRe.MatchString(trimmed) {
+				inComment = false
+			}
+			continue
+		}
+		if rubyEndRe.MatchString(ln) {
+			depth--
+			if depth == 0 {
+				return j + 1 // `def` closes on line j; boundary is the next line
+			}
+			continue
+		}
+		// A one-line `def …; end` nested in the body opens AND closes on the
+		// same line — net-zero depth change, so skip it as an opener.
+		if rubyOneLineDefEndRe.MatchString(ln) {
+			continue
+		}
+		if rubyOpensBlock(ln) && !rubyIsModifierLine(ln) {
+			depth++
+		}
+	}
+	return len(lines) // never closed within the window — over-include
+}
+
 // rubyClauseKw reports whether a trimmed line begins an in-block clause keyword
 // (elsif/else/ensure/when) that does not open a new `end`-scoped level.
 func rubyClauseKw(trimmed string) bool {


### PR DESCRIPTION
## Summary

Follow-up to #4666. `substrate.ClampToFunctionBody` clamps a padded effects source window (entity `EndLine` missing/zero → `StartLine+400`) to the target method's own body before the branch analyzer runs, so `effects(include=branches)` doesn't over-capture into sibling methods. #4666 covered **Python** (dedent boundary) and the **brace languages** (matching `}`), but **Ruby** methods are `def`…`end`-delimited and fell through unclamped — so a Ruby controller method's branch facet bled into the next `def`.

## Fix

- Add `bodyEndRuby(lines)` in `internal/substrate/branches_ruby.go`: locate the method's `def` header, then walk forward tracking `end`-closed nesting depth, reusing the analyzer's existing `rubyOpensBlock` / `rubyIsModifierLine` / `rubyEndRe` helpers. Clamp at the `end` that closes the method's own `def` (boundary = next line).
- Register `ruby` in `ClampToFunctionBody`.

### Ruby end-matching walk
From the `def` header, `depth = 1`; each block opener (`def`/`do`/`if`/`unless`/`case`/`begin`/`while`/`until`/`for`/`module`/`class`) that is **not** a trailing/postfix modifier increments depth; a standalone `end` decrements it. When depth returns to 0 the method's `def` has closed.

### Conservative ambiguity handling (never clamp too SHORT)
Matching `braceBodyEnd`'s contract — the bug is clamping too LONG; under-clamping would silently drop real branches:
- No `def` in the window → whole window.
- One-line `def …; end` or endless method (`def f = expr`) → whole window (no separate `end` body).
- A nested one-line `def …; end` is net-zero depth (skipped as an opener).
- `=begin`/`=end` block comments are skipped so a stray `end`/`def` keyword inside docs never moves the boundary.
- `def` block never closes within the window → whole window.

## Validation (RED→GREEN)
- `internal/mcp/effects_branches_4693_ruby_test.go` + `testdata/branches_4693_ruby/`:
  - **Positive** (`contracts_controller_two_methods.rb`): two-method Rails controller; `create_contact` (EndLine=0) must return only its own 400/409 guards + 201/500, NONE of `update_contact`'s 422/503. **RED today** (bleeds 422/503 + branches at lines 25/27/34); **GREEN** after.
  - **Negative** (`oneliner_methods.rb`): an endless `def ping = head(:ok)` must NOT over-clamp at its header — the branchy sibling `health_check` below stays visible.

## Coverage docs
No surgical `registry.json` update: the effects-`branches` facet (#4423/#4666) is a substrate capability not tracked per-framework. The registry's `branch_conditions` cells are the unrelated Data Flow / Platform capability. Noted, registry untouched.

## Gates
`go build ./...`, `go vet ./internal/substrate/... ./internal/engine/...`, `go test ./internal/substrate/... ./internal/engine/... ./internal/extractors/... ./internal/mcp/...` — all green. `gofmt` clean.

Closes #4693

🤖 Generated with [Claude Code](https://claude.com/claude-code)