### PR TITLE
feat(stub_detector): field-level partial-stub analyzers for Java/Go/Ruby/PHP/C# (#4728)

### DIFF
--- a/internal/mcp/field_stub_4669_test.go
+++ b/internal/mcp/field_stub_4669_test.go
@@ -154,7 +154,7 @@ func TestStubDetector_PartialStubFields_unsupportedLanguage(t *testing.T) {
 	dir := t.TempDir()
 	handler := graph.Entity{
 		ID: "h1", Name: "h", Kind: "SCOPE.Operation",
-		SourceFile: "handler.rb", StartLine: 1, EndLine: 3,
+		SourceFile: "handler.kt", StartLine: 1, EndLine: 3,
 		Properties: map[string]string{"effects": "db_read"},
 	}
 	v3 := &graph.Document{Repo: "r",
@@ -171,7 +171,7 @@ func TestStubDetector_PartialStubFields_unsupportedLanguage(t *testing.T) {
 	out := callStubDetector(t, s, map[string]any{"group_v3": "v3", "group_oracle": "oracle"})
 	r := resultFor(t, out, "GET /x")
 	if r["partial_stub_supported"] != false {
-		t.Fatalf("ruby handler: partial_stub_supported = %v, want false", r["partial_stub_supported"])
+		t.Fatalf("kotlin handler: partial_stub_supported = %v, want false", r["partial_stub_supported"])
 	}
 	if _, ok := r["partial_stub_fields"]; ok {
 		t.Fatalf("unsupported language must not emit partial_stub_fields")

--- a/internal/substrate/field_literals_4728_test.go
+++ b/internal/substrate/field_literals_4728_test.go
@@ -1,0 +1,267 @@
+package substrate
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// field_literals_4728_test.go — #4728 field-level partial-stub analyzers for
+// Java/Spring, Go, Ruby/Rails, PHP/Laravel, C#/.NET.
+//
+// Each language is validated with the issue's two fixtures, mirroring the #4669
+// flagship cases:
+//   - A: {count: <derived>, tbd: 0, all: 5}  → flags tbd, all; NOT count.
+//   - negative: {success: true, data: <derived>} → flags nothing (data derived,
+//     success excluded as envelope flag).
+// Plus a part_id:null case and conditional-derived guard where instructive.
+
+func names4728(t *testing.T, facets []FieldFacet) []string {
+	t.Helper()
+	flagged := PartialStubFields(facets)
+	out := make([]string, 0, len(flagged))
+	for _, f := range flagged {
+		out = append(out, f.Field)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- Go -----------------------------------------------------------------
+
+func TestFieldLiteralsGo_CaseA_ginH(t *testing.T) {
+	src := `func GetSummary(c *gin.Context) {
+	n := repo.Count()
+	c.JSON(200, gin.H{
+		"count": n,
+		"tbd":   0,
+		"all":   5,
+	})
+}`
+	facets := analyzeFieldLiteralsGo(src, 1)
+	got := names4728(t, facets)
+	want := []string{"all", "tbd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Go Case A: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsGo_Negative_envelope(t *testing.T) {
+	src := `func List(c *gin.Context) {
+	data := repo.All()
+	c.JSON(200, gin.H{"success": true, "data": data})
+}`
+	facets := analyzeFieldLiteralsGo(src, 1)
+	if got := names4728(t, facets); len(got) != 0 {
+		t.Fatalf("Go negative: expected no flags, got %v (facets=%+v)", got, facets)
+	}
+}
+
+func TestFieldLiteralsGo_structLiteral(t *testing.T) {
+	src := `func GetItem(c *gin.Context) {
+	item := svc.Get()
+	c.JSON(200, ItemResp{PartID: nil, Name: item.Name})
+}`
+	facets := analyzeFieldLiteralsGo(src, 1)
+	got := names4728(t, facets)
+	want := []string{"PartID"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Go struct: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsGo_mapStringAny(t *testing.T) {
+	src := `func H(w http.ResponseWriter) {
+	json.NewEncoder(w).Encode(map[string]any{"part_id": nil, "name": user.Name})
+}`
+	facets := analyzeFieldLiteralsGo(src, 1)
+	got := names4728(t, facets)
+	want := []string{"part_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Go map[string]any: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+// --- Ruby ---------------------------------------------------------------
+
+func TestFieldLiteralsRuby_CaseA_renderJson(t *testing.T) {
+	src := `def summary
+	n = Thing.count
+	render json: {
+		count: n,
+		tbd: 0,
+		all: 5,
+	}
+end`
+	facets := analyzeFieldLiteralsRuby(src, 1)
+	got := names4728(t, facets)
+	want := []string{"all", "tbd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Ruby Case A: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsRuby_Negative_envelope(t *testing.T) {
+	src := `def list
+	data = Thing.all
+	render json: { success: true, data: data }
+end`
+	facets := analyzeFieldLiteralsRuby(src, 1)
+	if got := names4728(t, facets); len(got) != 0 {
+		t.Fatalf("Ruby negative: expected no flags, got %v (facets=%+v)", got, facets)
+	}
+}
+
+func TestFieldLiteralsRuby_partIdNil(t *testing.T) {
+	src := `def show
+	item = find_item
+	render json: { part_id: nil, name: item.name }
+end`
+	facets := analyzeFieldLiteralsRuby(src, 1)
+	got := names4728(t, facets)
+	want := []string{"part_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Ruby part_id: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+// --- PHP ----------------------------------------------------------------
+
+func TestFieldLiteralsPHP_CaseA_responseJson(t *testing.T) {
+	src := `public function summary() {
+	$n = Thing::count();
+	return response()->json([
+		'count' => $n,
+		'tbd' => 0,
+		'all' => 5,
+	]);
+}`
+	facets := analyzeFieldLiteralsPHP(src, 1)
+	got := names4728(t, facets)
+	want := []string{"all", "tbd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PHP Case A: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsPHP_Negative_envelope(t *testing.T) {
+	src := `public function list() {
+	$data = Thing::all();
+	return response()->json(['success' => true, 'data' => $data]);
+}`
+	facets := analyzeFieldLiteralsPHP(src, 1)
+	if got := names4728(t, facets); len(got) != 0 {
+		t.Fatalf("PHP negative: expected no flags, got %v (facets=%+v)", got, facets)
+	}
+}
+
+func TestFieldLiteralsPHP_partIdNull(t *testing.T) {
+	src := `public function show() {
+	$item = $this->find();
+	return ['part_id' => null, 'name' => $item->name];
+}`
+	facets := analyzeFieldLiteralsPHP(src, 1)
+	got := names4728(t, facets)
+	want := []string{"part_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PHP part_id: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+// --- C# -----------------------------------------------------------------
+
+func TestFieldLiteralsCSharp_CaseA_anonObject(t *testing.T) {
+	src := `public IActionResult Summary() {
+	var n = _repo.Count();
+	return Ok(new {
+		count = n,
+		tbd = 0,
+		all = 5,
+	});
+}`
+	facets := analyzeFieldLiteralsCSharp(src, 1)
+	got := names4728(t, facets)
+	want := []string{"all", "tbd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("C# Case A: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsCSharp_Negative_envelope(t *testing.T) {
+	src := `public IActionResult List() {
+	var data = _repo.All();
+	return Ok(new { success = true, data = data });
+}`
+	facets := analyzeFieldLiteralsCSharp(src, 1)
+	if got := names4728(t, facets); len(got) != 0 {
+		t.Fatalf("C# negative: expected no flags, got %v (facets=%+v)", got, facets)
+	}
+}
+
+func TestFieldLiteralsCSharp_recordInit(t *testing.T) {
+	src := `public IActionResult Show() {
+	var item = _svc.Get();
+	return Ok(new ItemResponse { PartId = null, Name = item.Name });
+}`
+	facets := analyzeFieldLiteralsCSharp(src, 1)
+	got := names4728(t, facets)
+	want := []string{"PartId"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("C# record init: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+// --- Java ---------------------------------------------------------------
+
+func TestFieldLiteralsJava_CaseA_mapOf(t *testing.T) {
+	src := `public ResponseEntity<?> summary() {
+	long n = repo.count();
+	return ResponseEntity.ok(Map.of(
+		"count", n,
+		"tbd", 0,
+		"all", 5
+	));
+}`
+	facets := analyzeFieldLiteralsJava(src, 1)
+	got := names4728(t, facets)
+	want := []string{"all", "tbd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Java Case A: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+func TestFieldLiteralsJava_Negative_envelope(t *testing.T) {
+	src := `public ResponseEntity<?> list() {
+	var data = repo.all();
+	return ResponseEntity.ok(Map.of("success", true, "data", data));
+}`
+	facets := analyzeFieldLiteralsJava(src, 1)
+	if got := names4728(t, facets); len(got) != 0 {
+		t.Fatalf("Java negative: expected no flags, got %v (facets=%+v)", got, facets)
+	}
+}
+
+func TestFieldLiteralsJava_objectNodePut(t *testing.T) {
+	src := `public ObjectNode build() {
+	ObjectNode node = mapper.createObjectNode();
+	node.put("part_id", null);
+	node.put("name", item.getName());
+	return node;
+}`
+	facets := analyzeFieldLiteralsJava(src, 1)
+	got := names4728(t, facets)
+	want := []string{"part_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Java ObjectNode.put: flagged=%v want=%v (facets=%+v)", got, want, facets)
+	}
+}
+
+// --- registry -----------------------------------------------------------
+
+func TestFieldLiteralRegistry_4728_languagesRegistered(t *testing.T) {
+	for _, lang := range []string{"java", "go", "ruby", "php", "csharp"} {
+		if FieldLiteralAnalyzerFor(lang) == nil {
+			t.Fatalf("expected field-literal analyzer registered for %q", lang)
+		}
+	}
+}

--- a/internal/substrate/field_literals_csharp.go
+++ b/internal/substrate/field_literals_csharp.go
@@ -1,0 +1,77 @@
+// C#/.NET field-literal analyzer (#4728, follow-up to #4669) — anonymous-object
+// / object-initializer response literals.
+//
+// Target: ASP.NET Core controller actions that return a response object —
+// `return Ok(new { k = literal })`, `return Ok(new XResponse { Field = literal
+// })`, or a returned object-initializer / record-init `new FooDto { Field =
+// literal }`. C# object initializers and anonymous objects are brace-delimited
+// with `=` member assignments and bare-identifier member names. We locate each
+// `new ... { ... }` brace literal and classify every `Field = value` entry. A
+// value that is a bare literal (number / quoted string / true|false|null) is
+// literal-bound; a value naming a variable, method call, property access
+// (item.Name), index, or expression is derived.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterFieldLiteralAnalyzer("csharp", analyzeFieldLiteralsCSharp) }
+
+var (
+	// csharpObjTriggerRe finds the start of an object/anonymous-object literal:
+	// a `{` following `new` (optionally with a type name) — `new {`, `new Foo {`,
+	// `new Foo() {`, `new Foo<T> {`. We then balance-scan from the `{`.
+	csharpObjTriggerRe = regexp.MustCompile(
+		`\bnew\b\s*(?:[A-Za-z_][\w\.]*\s*(?:<[^>{]*>)?\s*(?:\([^){]*\))?\s*)?\{`,
+	)
+	// csharpMemberRe matches an initializer entry `Field = rhs` (bare-identifier
+	// member name, `=` separator). Distinguished from `==` by requiring a single
+	// `=` not followed by another `=`.
+	csharpMemberRe = regexp.MustCompile(`^\s*([A-Za-z_][\w]*)\s*=\s*([^=].*|)$`)
+)
+
+func analyzeFieldLiteralsCSharp(funcSource string, startLine int) []FieldFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	src := ClampToFunctionBody(funcSource, "csharp")
+	var out []FieldFacet
+	idx := 0
+	for {
+		loc := csharpObjTriggerRe.FindStringIndex(src[idx:])
+		if loc == nil {
+			break
+		}
+		open := idx + loc[1] - 1 // position of the `{`
+		body, closeIdx := balancedBrace(src, open)
+		if closeIdx < 0 {
+			break
+		}
+		openLine := startLine + strings.Count(src[:open], "\n")
+		out = append(out, classifyCSharpObjectFields(body, openLine)...)
+		idx = closeIdx + 1
+	}
+	return out
+}
+
+func classifyCSharpObjectFields(body string, openLine int) []FieldFacet {
+	var out []FieldFacet
+	for _, seg := range topLevelDictEntries(body) {
+		m := csharpMemberRe.FindStringSubmatch(seg.text)
+		if m == nil {
+			continue
+		}
+		field, rhs := m[1], m[2]
+		binding, lit := classifyFieldRHS(rhs)
+		line := openLine + strings.Count(body[:seg.offset], "\n")
+		ff := FieldFacet{Field: field, Binding: binding, Line: line}
+		if binding == BindingLiteral {
+			ff.LiteralValue = lit
+			ff.Envelope = isEnvelopeField(field, lit)
+		}
+		out = append(out, ff)
+	}
+	return out
+}

--- a/internal/substrate/field_literals_go.go
+++ b/internal/substrate/field_literals_go.go
@@ -1,0 +1,90 @@
+// Go field-literal analyzer (#4728, follow-up to #4669) — gin.H / map / struct
+// response literals.
+//
+// Target: Go HTTP handlers that construct a response payload as a composite
+// literal — `c.JSON(200, gin.H{"k": v})`, `json.NewEncoder(w).Encode(map[string]
+// any{"k": v})`, a bare `gin.H{...}` / `map[string]any{...}`, or a returned
+// struct literal `FooResp{Field: 0}`. We locate each such brace literal and
+// classify every top-level entry:
+//
+//   - map/gin.H form: `"k": value` (quoted-string key, colon, value).
+//   - struct form:    `Field: value` (bare identifier key, colon, value).
+//
+// A value that is a bare literal (number / quoted string / true|false|nil) is
+// literal-bound; a value naming an identifier, call, selector (item.Name), index
+// expression, or composite is derived. Honest-partial: only constructs we can
+// key+classify produce facets.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterFieldLiteralAnalyzer("go", analyzeFieldLiteralsGo) }
+
+var (
+	// goRespLitTriggerRe finds the start of a response composite literal: a `{`
+	// following `gin.H`, `map[...]...`, a struct type name `FooResp`/`pkg.Foo`,
+	// or a `Render`/`Encode`/`JSON` call's brace. We then balance-scan from `{`.
+	// The leading `]` alternative catches `map[string]any{` (the `{` directly
+	// after the closing `]` of the value-type-less map element type).
+	goRespLitTriggerRe = regexp.MustCompile(
+		`(?:\bgin\.H\s*|` + // gin.H{...}
+			`\bmap\s*\[[^\]]*\][\w\.\*\[\]]*\s*|` + // map[K]V{...}
+			`\b[A-Z][\w]*\s*|` + // exported struct type FooResp{...}
+			`\b[a-z][\w]*\.[A-Z][\w]*\s*` + // pkg.FooResp{...}
+			`)\{`,
+	)
+	// goMapKeyRe matches a map/gin.H entry `"key": rhs`.
+	goMapKeyRe = regexp.MustCompile(`^\s*["` + "`" + `]([A-Za-z_][\w]*)["` + "`" + `]\s*:\s*(.*)$`)
+	// goStructKeyRe matches a struct entry `Field: rhs` (bare-identifier key).
+	goStructKeyRe = regexp.MustCompile(`^\s*([A-Za-z_][\w]*)\s*:\s*(.*)$`)
+)
+
+func analyzeFieldLiteralsGo(funcSource string, startLine int) []FieldFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	src := ClampToFunctionBody(funcSource, "go")
+	var out []FieldFacet
+	idx := 0
+	for {
+		loc := goRespLitTriggerRe.FindStringIndex(src[idx:])
+		if loc == nil {
+			break
+		}
+		open := idx + loc[1] - 1 // position of the `{`
+		body, closeIdx := balancedBrace(src, open)
+		if closeIdx < 0 {
+			break
+		}
+		openLine := startLine + strings.Count(src[:open], "\n")
+		out = append(out, classifyGoLiteralFields(body, openLine)...)
+		idx = closeIdx + 1
+	}
+	return out
+}
+
+func classifyGoLiteralFields(body string, openLine int) []FieldFacet {
+	var out []FieldFacet
+	for _, seg := range topLevelDictEntries(body) {
+		var field, rhs string
+		if m := goMapKeyRe.FindStringSubmatch(seg.text); m != nil {
+			field, rhs = m[1], m[2]
+		} else if m := goStructKeyRe.FindStringSubmatch(seg.text); m != nil {
+			field, rhs = m[1], m[2]
+		} else {
+			continue
+		}
+		binding, lit := classifyFieldRHS(rhs)
+		line := openLine + strings.Count(body[:seg.offset], "\n")
+		ff := FieldFacet{Field: field, Binding: binding, Line: line}
+		if binding == BindingLiteral {
+			ff.LiteralValue = lit
+			ff.Envelope = isEnvelopeField(field, lit)
+		}
+		out = append(out, ff)
+	}
+	return out
+}

--- a/internal/substrate/field_literals_java.go
+++ b/internal/substrate/field_literals_java.go
@@ -1,0 +1,203 @@
+// Java/Spring field-literal analyzer (#4728, follow-up to #4669) — Map.of(...)
+// response maps & Jackson ObjectNode.put(...) chains.
+//
+// Target: Spring controller methods that build a response body — `return
+// ResponseEntity.ok(Map.of("k", literal, ...))`, a bare `Map.of("k", literal)`,
+// or a Jackson `ObjectNode` built with chained `.put("k", literal)` calls. Both
+// forms key a field name to a value expression positionally (not via a brace
+// `key: value`), so they need bespoke argument parsing rather than the shared
+// brace splitter:
+//
+//   - Map.of("k1", v1, "k2", v2, ...) — even args are string keys, odd args are
+//     the corresponding values. We balance-scan the call's argument list and
+//     pair them up.
+//   - node.put("k", v) — each call contributes one (key, value) facet.
+//
+// A value that is a bare literal (number / quoted string / true|false|null) is
+// literal-bound; a value naming a variable, method call, field access
+// (item.getName()), or expression is derived. Builder DTOs and POJO setters are
+// intentionally NOT classified here (their key→value binding is not statically
+// recoverable from a single window without type info) — honest-partial:
+// unrecognised constructs simply produce no facet.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterFieldLiteralAnalyzer("java", analyzeFieldLiteralsJava) }
+
+var (
+	// javaMapOfTriggerRe finds the start of a `Map.of(` / `Map.ofEntries(`-less
+	// immutable-map constructor's argument list `(`. We balance-scan from `(`.
+	javaMapOfTriggerRe = regexp.MustCompile(`\bMap\s*\.\s*of\s*\(`)
+	// javaPutCallRe matches a single Jackson `.put("k", rhs)` call, capturing the
+	// key and the value-arg text (up to the call's closing paren — value args
+	// here are simple, no nested parens needed for the common literal case; a
+	// nested-call value is captured greedily-minimally and classified derived).
+	javaPutCallRe = regexp.MustCompile(`\.\s*put\s*\(\s*"([A-Za-z_][\w]*)"\s*,\s*([^;]*?)\s*\)`)
+)
+
+func analyzeFieldLiteralsJava(funcSource string, startLine int) []FieldFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	src := ClampToFunctionBody(funcSource, "java")
+	var out []FieldFacet
+	out = append(out, javaMapOfFacets(src, startLine)...)
+	out = append(out, javaPutFacets(src, startLine)...)
+	return out
+}
+
+// javaMapOfFacets parses every `Map.of(...)` call's argument list into
+// (key, value) pairs and classifies each value.
+func javaMapOfFacets(src string, startLine int) []FieldFacet {
+	var out []FieldFacet
+	idx := 0
+	for {
+		loc := javaMapOfTriggerRe.FindStringIndex(src[idx:])
+		if loc == nil {
+			break
+		}
+		open := idx + loc[1] - 1 // position of the `(`
+		args, closeIdx := balancedParen(src, open)
+		if closeIdx < 0 {
+			break
+		}
+		openLine := startLine + strings.Count(src[:open], "\n")
+		entries := topLevelParenArgs(args)
+		// Pair even (key) / odd (value) arguments.
+		for i := 0; i+1 < len(entries); i += 2 {
+			keyText := strings.TrimSpace(entries[i].text)
+			if len(keyText) < 2 || keyText[0] != '"' {
+				continue // key must be a string literal to name a field
+			}
+			field := strings.Trim(keyText, `"`)
+			if field == "" || !isJavaIdent(field) {
+				continue
+			}
+			rhs := entries[i+1].text
+			binding, lit := classifyFieldRHS(rhs)
+			line := openLine + strings.Count(args[:entries[i].offset], "\n")
+			ff := FieldFacet{Field: field, Binding: binding, Line: line}
+			if binding == BindingLiteral {
+				ff.LiteralValue = lit
+				ff.Envelope = isEnvelopeField(field, lit)
+			}
+			out = append(out, ff)
+		}
+		idx = closeIdx + 1
+	}
+	return out
+}
+
+// javaPutFacets classifies each Jackson `.put("k", v)` call as one facet.
+func javaPutFacets(src string, startLine int) []FieldFacet {
+	var out []FieldFacet
+	for _, m := range javaPutCallRe.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		rhs := src[m[4]:m[5]]
+		binding, lit := classifyFieldRHS(rhs)
+		line := startLine + strings.Count(src[:m[0]], "\n")
+		ff := FieldFacet{Field: field, Binding: binding, Line: line}
+		if binding == BindingLiteral {
+			ff.LiteralValue = lit
+			ff.Envelope = isEnvelopeField(field, lit)
+		}
+		out = append(out, ff)
+	}
+	return out
+}
+
+func isJavaIdent(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '_' || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(i > 0 && c >= '0' && c <= '9') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// topLevelParenArgs splits a call's argument-list body (text strictly between
+// the outer parens) into its TOP-LEVEL comma-separated arguments, ignoring
+// commas nested inside (), {}, [], or string literals. Each argument keeps its
+// offset within the body. The paren analogue of topLevelDictEntries.
+func topLevelParenArgs(body string) []dictEntry {
+	var out []dictEntry
+	depth := 0
+	start := 0
+	var quote byte
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if quote != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			quote = c
+		case '(', '{', '[':
+			depth++
+		case ')', '}', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				out = append(out, dictEntry{text: body[start:i], offset: start})
+				start = i + 1
+			}
+		}
+	}
+	if start < len(body) {
+		out = append(out, dictEntry{text: body[start:], offset: start})
+	}
+	return out
+}
+
+// balancedParen returns the substring strictly BETWEEN the paren at openIdx and
+// its matching close paren, and the index of the close paren. String literals
+// are skipped. closeIdx is -1 when no match. The paren analogue of
+// balancedBrace, used by the Java Map.of analyzer.
+func balancedParen(s string, openIdx int) (string, int) {
+	if openIdx < 0 || openIdx >= len(s) || s[openIdx] != '(' {
+		return "", -1
+	}
+	depth := 0
+	var quote byte
+	for i := openIdx; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			quote = c
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[openIdx+1 : i], i
+			}
+		}
+	}
+	return "", -1
+}

--- a/internal/substrate/field_literals_php.go
+++ b/internal/substrate/field_literals_php.go
@@ -1,0 +1,116 @@
+// PHP/Laravel field-literal analyzer (#4728, follow-up to #4669) — response()
+// ->json([...]) / array literals.
+//
+// Target: Laravel controller actions that return a response array — `return
+// response()->json([...])`, `return response()->json([...], 200)`, or a bare
+// returned array `return [...]`. PHP arrays are bracket-delimited (`[ ... ]`)
+// with `=>` key/value separators. We locate each top-level array literal and
+// classify every `'key' => value` entry. A value that is a bare literal
+// (number / quoted string / true|false|null) is literal-bound; a value naming a
+// variable (`$x`), method/function call, property access (`$item->name`),
+// constant, or index is derived.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterFieldLiteralAnalyzer("php", analyzeFieldLiteralsPHP) }
+
+var (
+	// phpArrayTriggerRe finds the start of a response array literal: a `[`
+	// following `json(` / `->json(`, a `return`, an `=`, or a `(`. We then
+	// balance-scan from the `[`.
+	phpArrayTriggerRe = regexp.MustCompile(
+		`(?:\bjson\s*\(\s*|` + // ->json([
+			`\breturn\b\s*|` + // return [
+			`=\s*|` + // $x = [
+			`\(\s*` + // foo([
+			`)\[`,
+	)
+	// phpArrayKeyRe matches an array entry `'key' => rhs` / `"key" => rhs`.
+	phpArrayKeyRe = regexp.MustCompile(`^\s*['"]([A-Za-z_][\w]*)['"]\s*=>\s*(.*)$`)
+)
+
+func analyzeFieldLiteralsPHP(funcSource string, startLine int) []FieldFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	src := ClampToFunctionBody(funcSource, "php")
+	var out []FieldFacet
+	idx := 0
+	for {
+		loc := phpArrayTriggerRe.FindStringIndex(src[idx:])
+		if loc == nil {
+			break
+		}
+		open := idx + loc[1] - 1 // position of the `[`
+		body, closeIdx := balancedBracket(src, open)
+		if closeIdx < 0 {
+			break
+		}
+		openLine := startLine + strings.Count(src[:open], "\n")
+		out = append(out, classifyPHPArrayFields(body, openLine)...)
+		idx = closeIdx + 1
+	}
+	return out
+}
+
+func classifyPHPArrayFields(body string, openLine int) []FieldFacet {
+	var out []FieldFacet
+	for _, seg := range topLevelDictEntries(body) {
+		m := phpArrayKeyRe.FindStringSubmatch(seg.text)
+		if m == nil {
+			continue
+		}
+		field, rhs := m[1], m[2]
+		binding, lit := classifyFieldRHS(rhs)
+		line := openLine + strings.Count(body[:seg.offset], "\n")
+		ff := FieldFacet{Field: field, Binding: binding, Line: line}
+		if binding == BindingLiteral {
+			ff.LiteralValue = lit
+			ff.Envelope = isEnvelopeField(field, lit)
+		}
+		out = append(out, ff)
+	}
+	return out
+}
+
+// balancedBracket returns the substring strictly BETWEEN the bracket at openIdx
+// and its matching close bracket, and the index of the close bracket. String
+// literals are skipped so brackets inside strings don't unbalance the scan.
+// closeIdx is -1 when no match (truncated window). The bracket analogue of
+// balancedBrace, used by the PHP array-literal analyzer.
+func balancedBracket(s string, openIdx int) (string, int) {
+	if openIdx < 0 || openIdx >= len(s) || s[openIdx] != '[' {
+		return "", -1
+	}
+	depth := 0
+	var quote byte
+	for i := openIdx; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			quote = c
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return s[openIdx+1 : i], i
+			}
+		}
+	}
+	return "", -1
+}

--- a/internal/substrate/field_literals_ruby.go
+++ b/internal/substrate/field_literals_ruby.go
@@ -1,0 +1,94 @@
+// Ruby/Rails field-literal analyzer (#4728, follow-up to #4669) — render json /
+// hash literals.
+//
+// Target: Rails controller actions that render a response hash — `render json:
+// { ... }`, `render json: { ... }, status: :ok`, or a returned hash literal
+// `{ ... }`. We locate each brace hash literal and classify every top-level
+// entry. Ruby hash keys come in three syntaxes:
+//
+//   - symbol shorthand:  `k: value`
+//   - hash-rocket symbol: `:k => value`
+//   - hash-rocket string: `"k" => value`
+//
+// A value that is a bare literal (number / quoted string / true|false|nil) is
+// literal-bound; a value naming a variable, method call, attribute (item.name),
+// index, symbol (`:active`), or interpolation is derived.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+func init() { RegisterFieldLiteralAnalyzer("ruby", analyzeFieldLiteralsRuby) }
+
+var (
+	// rubyHashTriggerRe finds the start of a response hash literal: a `{`
+	// following `render json:` / `render :json =>`, a bare `render` arg, or an
+	// assignment / return `= {` / `json.merge!({`. The most general trigger is
+	// `json:`/`json =>` immediately preceding the `{`, plus a `=`/`return`/`(`
+	// brace. We balance-scan from `{`.
+	rubyHashTriggerRe = regexp.MustCompile(
+		`(?:\bjson\s*:\s*|` + // render json: {
+			`:json\s*=>\s*|` + // render :json => {
+			`\breturn\b\s*|` + // return {
+			`=\s*|` + // x = {
+			`\(\s*` + // render({  / foo({
+			`)\{`,
+	)
+	// rubySymbolKeyRe matches `k: rhs` (symbol shorthand).
+	rubySymbolKeyRe = regexp.MustCompile(`^\s*([A-Za-z_][\w]*)\s*:\s*(.*)$`)
+	// rubyRocketSymKeyRe matches `:k => rhs`.
+	rubyRocketSymKeyRe = regexp.MustCompile(`^\s*:([A-Za-z_][\w]*)\s*=>\s*(.*)$`)
+	// rubyRocketStrKeyRe matches `"k" => rhs` / `'k' => rhs`.
+	rubyRocketStrKeyRe = regexp.MustCompile(`^\s*['"]([A-Za-z_][\w]*)['"]\s*=>\s*(.*)$`)
+)
+
+func analyzeFieldLiteralsRuby(funcSource string, startLine int) []FieldFacet {
+	if strings.TrimSpace(funcSource) == "" {
+		return nil
+	}
+	src := ClampToFunctionBody(funcSource, "ruby")
+	var out []FieldFacet
+	idx := 0
+	for {
+		loc := rubyHashTriggerRe.FindStringIndex(src[idx:])
+		if loc == nil {
+			break
+		}
+		open := idx + loc[1] - 1 // position of the `{`
+		body, closeIdx := balancedBrace(src, open)
+		if closeIdx < 0 {
+			break
+		}
+		openLine := startLine + strings.Count(src[:open], "\n")
+		out = append(out, classifyRubyHashFields(body, openLine)...)
+		idx = closeIdx + 1
+	}
+	return out
+}
+
+func classifyRubyHashFields(body string, openLine int) []FieldFacet {
+	var out []FieldFacet
+	for _, seg := range topLevelDictEntries(body) {
+		var field, rhs string
+		if m := rubyRocketSymKeyRe.FindStringSubmatch(seg.text); m != nil {
+			field, rhs = m[1], m[2]
+		} else if m := rubyRocketStrKeyRe.FindStringSubmatch(seg.text); m != nil {
+			field, rhs = m[1], m[2]
+		} else if m := rubySymbolKeyRe.FindStringSubmatch(seg.text); m != nil {
+			field, rhs = m[1], m[2]
+		} else {
+			continue
+		}
+		binding, lit := classifyFieldRHS(rhs)
+		line := openLine + strings.Count(body[:seg.offset], "\n")
+		ff := FieldFacet{Field: field, Binding: binding, Line: line}
+		if binding == BindingLiteral {
+			ff.LiteralValue = lit
+			ff.Envelope = isEnvelopeField(field, lit)
+		}
+		out = append(out, ff)
+	}
+	return out
+}


### PR DESCRIPTION
Follow-up to #4669, which shipped the field-level `partial_stub_fields` signal on `stub_detector` with a pluggable per-language analyzer registry (`RegisterFieldLiteralAnalyzer`) and the two flagship analyzers (Python/DRF, JS/TS/NestJS). This adds analyzers for the five remaining stacks. Each registers one `FieldLiteralAnalyzerFn` that emits per-object `FieldFacet`s; the shared `PartialStubFields` roll-up, envelope heuristic, and `classifyFieldRHS` literal detector are reused unchanged.

## Response-construction detection per language
- **Go** (`field_literals_go.go`): `c.JSON(200, gin.H{"k": lit})`, `json.NewEncoder(w).Encode(map[string]any{"k": lit})`, returned struct literal `FooResp{Field: lit}`. Map (`"k":`) and struct (`Field:`) keying both handled via the shared brace splitter.
- **Ruby/Rails** (`field_literals_ruby.go`): `render json: { k: lit, ... }` / returned hash literal. All three key syntaxes: symbol shorthand `k:`, `:sym =>`, `"str" =>`.
- **PHP/Laravel** (`field_literals_php.go`): `response()->json(['k' => lit])` / `return ['k' => lit]`. Bracket-delimited (`[...]`, `=>` separator) — adds a `balancedBracket` companion to `balancedBrace`.
- **C#/.NET** (`field_literals_csharp.go`): `Ok(new { k = lit })` anonymous object / `new FooResponse { Field = lit }` object-initializer. Brace-delimited, `=` member assignment.
- **Java/Spring** (`field_literals_java.go`): `ResponseEntity.ok(Map.of("k", lit, ...))` — positional even-key/odd-value pairs parsed from the balanced argument list; Jackson `ObjectNode.put("k", lit)` chains — one facet per call. Builder DTOs / POJO setters are intentionally **not** classified (their key→value binding is not statically recoverable from a single source window without type info) — honest-partial: unrecognised constructs simply emit no facet. Adds `balancedParen` + `topLevelParenArgs` helpers.

## Honesty
Only UNCONDITIONALLY-literal DATA fields are flagged (a field derived in any constructed object is excluded by the shared roll-up). Envelope flags (`success`/`ok`/`status`/`error`/`message`/…) are recorded with `envelope=true` but excluded from the partial-stub set. Under-flag rather than over-flag throughout.

## Registry note
`partial_stub_fields` is an MCP audit-tool signal, **not** a per-language extraction-capability registry cell — #4669 did not touch `docs/coverage/registry.json`, and neither does this PR. `coverage fmt --check` confirms the registry stays canonical (`ok: docs/coverage/registry.json is canonical`).

## Validation
`internal/substrate/field_literals_4728_test.go` — per language: the issue's Case A (`{count: <derived>, tbd: 0, all: 5}` → flags `tbd`/`all`, not `count`), the envelope negative (`{success: true, data: <derived>}` → flags nothing), plus `part_id: null/nil` literal cases and the alternate construction forms (struct literal, `map[string]any`, `ObjectNode.put`, record-init). All 16 new + 8 flagship #4669 tests pass.

Adjusted `field_stub_4669_test.go`'s honest-partial test to use a kotlin (`.kt`) handler, since ruby (`.rb`) is now supported.

## Gates
- `go build ./...` ✅
- `go vet ./internal/substrate/... ./internal/mcp/...` ✅
- `go test ./internal/substrate/... ./internal/mcp/... ./internal/types/` ✅
- `coverage fmt --check` ✅ (canonical, unchanged)

Closes #4728

🤖 Generated with [Claude Code](https://claude.com/claude-code)