### PR TITLE
feat(authposture): Go HTTP middleware + Phoenix plug auth-posture resolvers (#4543/#4544)

### DIFF
--- a/internal/authposture/authposture_test.go
+++ b/internal/authposture/authposture_test.go
@@ -243,12 +243,12 @@ func TestRegistry_NestRequireActionDecoratorFallback(t *testing.T) {
 	}
 }
 
-func TestRegistry_StubsRegisteredButDecline(t *testing.T) {
+func TestRegistry_AllFrameworksRegistered(t *testing.T) {
 	reg := NewRegistry()
 	fws := reg.Frameworks()
-	// spring-security (#4708), fastapi (#4709), express (#4710), and now rails
-	// (#4538), flask (#4540), laravel (#4541), aspnet (#4542) are implemented
-	// members; only go-middleware and phoenix stay stubs.
+	// With go-middleware (#4543) and phoenix (#4544) landed, the all-framework
+	// resolver set is COMPLETE — no stubs remain. Every registered framework has
+	// a real resolver.
 	want := []string{"aspnet", "django-drf", "express", "fastapi", "flask", "go-middleware", "laravel", "nestjs", "phoenix", "rails", "spring-security"}
 	if len(fws) != len(want) {
 		t.Fatalf("frameworks=%v, want %v", fws, want)
@@ -258,10 +258,11 @@ func TestRegistry_StubsRegisteredButDecline(t *testing.T) {
 			t.Fatalf("frameworks=%v, want %v", fws, want)
 		}
 	}
-	// A still-unimplemented framework (phoenix plug) signal → unknown / no resolver.
-	p, fw := reg.Resolve(Signal{Props: map[string]string{"phoenix_plug": "EnsureAuth"}})
+	// A signal that matches NO framework's signature → unknown / no resolver
+	// (the diff core reports an honest kind_mismatch rather than false-equivalent).
+	p, fw := reg.Resolve(Signal{Props: map[string]string{"totally_unrelated_prop": "xyz"}})
 	if fw != "" || p.Kind != KindUnknown {
-		t.Fatalf("unimplemented framework resolved as %s/%s, want unknown/none", fw, p.Kind)
+		t.Fatalf("unrecognised signal resolved as %s/%s, want unknown/none", fw, p.Kind)
 	}
 }
 
@@ -931,5 +932,191 @@ func TestAspnet_E2E_PublicVsOracleAuthenticated_Looser(t *testing.T) {
 	}})
 	if d := Diff(v3, oracle); d.Verdict != VerdictLooser {
 		t.Fatalf("verdict=%s detail=%s, want looser ([AllowAnonymous] opened an authenticated endpoint)", d.Verdict, d.Detail)
+	}
+}
+
+// --- #4543: Go HTTP middleware chains (Gin/Echo/Chi/net-http) ----------------
+
+// (A) PROTECTED: a route under `r.Use(AuthMiddleware())` → authenticated.
+func TestGo_RouterUseAuthMiddleware_Authenticated(t *testing.T) {
+	reg := NewRegistry()
+	p, fw := reg.Resolve(Signal{
+		Props: map[string]string{"framework": "gin"},
+		Source: "r := gin.Default()\n" +
+			"r.Use(AuthMiddleware())\n" +
+			"r.GET(\"/me\", profileHandler)",
+	})
+	if fw != "go-middleware" {
+		t.Fatalf("framework=%s, want go-middleware", fw)
+	}
+	if p.Kind != KindAuthenticated {
+		t.Fatalf("got %s, want authenticated (r.Use(AuthMiddleware()))", p.Kind)
+	}
+}
+
+// (A2) Echo group-level JWT middleware → authenticated; Chi inline route auth.
+func TestGo_EchoGroupAndChiRoute_Authenticated(t *testing.T) {
+	reg := NewRegistry()
+	echo, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "echo"},
+		Source: "g := e.Group(\"/api\")\ng.Use(middleware.JWT(secret))\ng.GET(\"/x\", h)"})
+	if echo.Kind != KindAuthenticated {
+		t.Fatalf("echo: got %s, want authenticated (g.Use(middleware.JWT))", echo.Kind)
+	}
+	chi, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "chi"},
+		Source: "r.Group(func(r chi.Router){\n  r.Use(AuthCtx)\n  r.Get(\"/p\", h)\n})"})
+	if chi.Kind != KindAuthenticated {
+		t.Fatalf("chi: got %s, want authenticated (r.Use(AuthCtx))", chi.Kind)
+	}
+	inline, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "gin"},
+		Source: "r.GET(\"/x\", AuthRequired(), handler)"})
+	if inline.Kind != KindAuthenticated {
+		t.Fatalf("inline: got %s, want authenticated (AuthRequired())", inline.Kind)
+	}
+}
+
+// (B) ROLE: RequireRole("admin") → role; RequireRole("superuser") → superuser.
+func TestGo_RequireRole_RoleAndSuperuser(t *testing.T) {
+	reg := NewRegistry()
+	role, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "gin"},
+		Source: "r.GET(\"/admin\", RequireRole(\"admin\"), h)"})
+	if role.Kind != KindRole || role.Literal != "admin" {
+		t.Fatalf("got %s/%q, want role/admin (RequireRole)", role.Kind, role.Literal)
+	}
+	su, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "chi"},
+		Source: "r.Use(RequireRole(\"superuser\"))"})
+	if su.Kind != KindSuperuser {
+		t.Fatalf("got %s, want superuser (RequireRole(superuser))", su.Kind)
+	}
+	perm, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "echo"},
+		Source: "e.GET(\"/export\", RequirePermission(\"export_clients\"), h)"})
+	if perm.Kind != KindAction || perm.Literal != "export_clients" {
+		t.Fatalf("got %s/%q, want action/export_clients (RequirePermission)", perm.Kind, perm.Literal)
+	}
+}
+
+// (C) NO-AUTH GROUP: a route reaching no auth-ish middleware → unknown (HONEST
+// under-claim, never false-public on a name-heuristic).
+func TestGo_NoAuthMiddleware_Unknown(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "gin"},
+		Source: "pub := r.Group(\"/public\")\npub.Use(Logger())\npub.GET(\"/health\", healthHandler)"})
+	if p.Kind != KindUnknown {
+		t.Fatalf("got %s, want unknown (no auth middleware; name-heuristic under-claim)", p.Kind)
+	}
+}
+
+// (C2) EXPLICIT PUBLIC: auth_required=false / a Public middleware → public.
+func TestGo_ExplicitPublic_Public(t *testing.T) {
+	reg := NewRegistry()
+	byProp, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "gin", "auth_required": "false"}})
+	if byProp.Kind != KindPublic {
+		t.Fatalf("got %s, want public (auth_required=false)", byProp.Kind)
+	}
+	byMw, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "chi"},
+		Source: "r.Group(func(r chi.Router){\n  r.Use(AllowAnonymous)\n  r.Get(\"/open\", h)\n})"})
+	if byMw.Kind != KindPublic {
+		t.Fatalf("got %s, want public (AllowAnonymous middleware)", byMw.Kind)
+	}
+}
+
+// (D) E2E: a Go authenticated route vs a Django page oracle is LOOSER.
+func TestGo_E2E_AuthenticatedVsOraclePage_Looser(t *testing.T) {
+	reg := NewRegistry()
+	oracle, _ := reg.Resolve(Signal{
+		Props: map[string]string{"has_get_permissions": "true"}, Source: clientViewSetGetPerms, Action: "approve",
+	}) // → page client_admin
+	v3, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "gin"},
+		Source: "r.Use(AuthMiddleware())\nr.GET(\"/clients\", h)"})
+	if d := Diff(v3, oracle); d.Verdict != VerdictLooser {
+		t.Fatalf("verdict=%s detail=%s, want looser (Go authenticated vs oracle page)", d.Verdict, d.Detail)
+	}
+}
+
+// --- #4544: Phoenix plug pipelines / pipe_through ----------------------------
+
+const phoenixRouterAuth = `
+pipeline :browser do
+  plug :fetch_session
+end
+pipeline :auth do
+  plug :require_authenticated_user
+end
+scope "/dashboard", MyAppWeb do
+  pipe_through [:browser, :auth]
+  get "/", DashboardController, :index
+end
+`
+
+const phoenixRouterPublic = `
+pipeline :browser do
+  plug :fetch_session
+end
+scope "/", MyAppWeb do
+  pipe_through :browser
+  get "/", PageController, :index
+end
+`
+
+// (A) PROTECTED: a route in a scope `pipe_through [:auth]` whose pipeline plugs
+// `:require_authenticated_user` → authenticated.
+func TestPhoenix_PipeThroughAuth_Authenticated(t *testing.T) {
+	reg := NewRegistry()
+	p, fw := reg.Resolve(Signal{
+		Props:  map[string]string{"framework": "phoenix"},
+		Source: phoenixRouterAuth,
+	})
+	if fw != "phoenix" {
+		t.Fatalf("framework=%s, want phoenix", fw)
+	}
+	if p.Kind != KindAuthenticated {
+		t.Fatalf("got %s, want authenticated (pipe_through [:auth] → require_authenticated_user)", p.Kind)
+	}
+}
+
+// (B) PUBLIC: a scope piping through only :browser (no auth pipeline) → public.
+func TestPhoenix_PublicScope_Public(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{
+		Props:  map[string]string{"framework": "phoenix"},
+		Source: phoenixRouterPublic,
+	})
+	if p.Kind != KindPublic {
+		t.Fatalf("got %s, want public (pipe_through :browser only, no auth pipeline)", p.Kind)
+	}
+}
+
+// (C) ROLE: a `:require_admin` plug → superuser; `plug :require_role, :editor` → role.
+func TestPhoenix_RolePlugs(t *testing.T) {
+	reg := NewRegistry()
+	admin, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "phoenix"},
+		Source: "pipeline :admin do\n  plug :require_admin\nend\nscope \"/a\" do\n  pipe_through [:auth, :admin]\n  get \"/\", C, :i\nend"})
+	if admin.Kind != KindSuperuser {
+		t.Fatalf("got %s, want superuser (plug :require_admin)", admin.Kind)
+	}
+	role, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "phoenix", "auth_plugs": "plug :require_role, :editor"}})
+	if role.Kind != KindRole || role.Literal != "editor" {
+		t.Fatalf("got %s/%q, want role/editor (plug :require_role, :editor)", role.Kind, role.Literal)
+	}
+}
+
+// (C2) Guardian.Plug.EnsureAuthenticated → authenticated.
+func TestPhoenix_GuardianEnsureAuthenticated(t *testing.T) {
+	reg := NewRegistry()
+	p, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "phoenix"},
+		Source: "pipeline :auth do\n  plug Guardian.Plug.EnsureAuthenticated\nend\nscope \"/s\" do\n  pipe_through [:auth]\n  get \"/\", C, :i\nend"})
+	if p.Kind != KindAuthenticated {
+		t.Fatalf("got %s, want authenticated (Guardian.Plug.EnsureAuthenticated)", p.Kind)
+	}
+}
+
+// (D) E2E: a Phoenix public scope vs a Django authenticated oracle is LOOSER.
+func TestPhoenix_E2E_PublicVsOracleAuthenticated_Looser(t *testing.T) {
+	reg := NewRegistry()
+	oracle, _ := reg.Resolve(Signal{Props: map[string]string{
+		"framework": "django", "has_permission_classes": "true", "permission_classes": "IsAuthenticated",
+	}})
+	v3, _ := reg.Resolve(Signal{Props: map[string]string{"framework": "phoenix"}, Source: phoenixRouterPublic})
+	if d := Diff(v3, oracle); d.Verdict != VerdictLooser {
+		t.Fatalf("verdict=%s detail=%s, want looser (Phoenix public scope vs oracle authenticated)", d.Verdict, d.Detail)
 	}
 }

--- a/internal/authposture/gomiddleware.go
+++ b/internal/authposture/gomiddleware.go
@@ -1,0 +1,205 @@
+// gomiddleware.go — the Go HTTP middleware auth-posture resolver (#4543;
+// replaces the go-middleware stub).
+//
+// Go HTTP frameworks (Gin / Echo / Chi / net-http) express endpoint
+// authorization through MIDDLEWARE CHAINS rather than structured RBAC
+// decorators. Middleware is attached at three nesting levels:
+//
+//   - ROUTER level — `r.Use(AuthMiddleware())` / `e.Use(middleware.JWT(...))` /
+//     `r.Use(AuthCtx)` applies to every route on the router.
+//   - GROUP level   — `group := r.Group("/api"); group.Use(jwtAuth())` /
+//     `r.Group(func(r chi.Router){ r.Use(Auth); r.Get(...) })` applies to the
+//     routes registered under that group/sub-router.
+//   - ROUTE level   — `r.GET("/x", AuthRequired(), handler)` /
+//     `AuthMiddleware(handler)` (net/http wrapper) applies to that one route.
+//
+// HONEST HEURISTIC LIMIT (#4543): Go middleware carries NO standard auth
+// annotation — a middleware is "auth" only by its IDENTIFIER. This resolver
+// therefore classifies by NAME (auth / jwt / authenticate / requireAuth /
+// bearer / session → authenticated; RequireRole("admin") / permission → role).
+// A route that reaches NO recognisable auth-ish middleware is reported
+// `unknown`, NOT `public`: name-heuristics cannot prove a route is intentionally
+// open, so we UNDER-claim rather than emit a false-public that would mask a real
+// RBAC regression in the diff. An explicit public marker (auth_required=false /
+// a `Public`/`NoAuth`/`Anonymous` middleware) is the only path to `public`.
+//
+// The engine does not yet stamp the reconciled Go middleware chain as structured
+// auth props onto the endpoint (only the gRPC-Go path stamps auth_*; see the
+// prop-stamping follow-up filed alongside this resolver — like #4742-4745). So
+// this resolver reads any generic auth_* props when present and otherwise
+// degrades to scanning the route-registration / handler source. Output
+// normalises into the shared {Kind, Literal} vocabulary so the diff core
+// compares a Go posture against the Django oracle or a NestJS posture directly.
+package authposture
+
+import (
+	"regexp"
+	"strings"
+)
+
+type goMiddlewareResolver struct{}
+
+func (goMiddlewareResolver) Name() string { return "go-middleware" }
+
+var (
+	// RequireRole("admin") / WithRole(`editor`) / RoleRequired("admin") — a role
+	// middleware naming a role literal. Captures the role.
+	goRoleMwRe = regexp.MustCompile(`(?i)(?:Require|With|Has|Check|Ensure)Roles?\s*\(\s*\[?\s*["` + "`" + `]([^"` + "`" + `]+)["` + "`" + `]`)
+	// RequirePermission("export") / WithPermission(`x`) — a permission/ability
+	// middleware naming an action literal.
+	goPermMwRe = regexp.MustCompile(`(?i)(?:Require|With|Has|Check|Ensure)(?:Permission|Ability|Scope)s?\s*\(\s*\[?\s*["` + "`" + `]([^"` + "`" + `]+)["` + "`" + `]`)
+	// RequireAdmin / RequireSuperuser / IsSuperAdmin / AdminOnly — superuser gate.
+	goSuperuserMwRe = regexp.MustCompile(`(?i)(?:Require|Ensure|Is|Must)(?:Admin|Superuser|SuperAdmin)|Admin(?:Only|Required)|SuperuserOnly`)
+	// auth-ish middleware name in a chain (.Use(...) / inline arg). Conservative
+	// name set: auth / authenticate / jwt / bearer / requireAuth / session /
+	// loginRequired / oauth / token. Word-boundary-ish to avoid "author".
+	goAuthMwRe = regexp.MustCompile(`(?i)\b(?:auth(?:enticate(?:d|User)?|Required|Middleware|Ctx|Guard|N)?|jwt(?:Auth|Middleware)?|bearer(?:Auth|Token)?|requireAuth|requireLogin|loginRequired|ensureAuth(?:enticated)?|session(?:Auth)?|oauth2?|verifyToken|tokenAuth)\b`)
+	// explicit PUBLIC / open middleware markers — only these earn a `public`.
+	// Case-SENSITIVE exported-identifier form (Go middleware convention) so a
+	// lowercase path segment like `r.Group("/public")` does NOT count as a public
+	// middleware. Optional package qualifier (e.g. mw.AllowAnonymous).
+	goPublicMwRe = regexp.MustCompile(`\b(?:\w+\.)?(?:Public|NoAuth|Anonymous|AllowAnonymous|SkipAuth|OptionalAuth|Unauthenticated)\b`)
+	// chain-attachment forms we scan inside source: .Use(...) and inline route args.
+	goUseRe = regexp.MustCompile(`\.Use\s*\(`)
+)
+
+// Resolve decodes a Go HTTP middleware auth signal. Recognises the framework
+// when the entity carries a Go-HTTP framework hint OR a recognisable auth/role
+// middleware construct in its props or source. Reconciled props win; source
+// (route registration / handler body) scanning is the fallback.
+func (g goMiddlewareResolver) Resolve(sig Signal) (Posture, bool) {
+	fw := strings.ToLower(firstNonEmpty(sig.Framework, sig.prop("framework")))
+	mw := firstNonEmpty(sig.prop("auth_middleware"), sig.prop("middleware"))
+	roles := sig.prop("auth_roles")
+	perms := firstNonEmpty(sig.prop("auth_permissions"), sig.prop("auth_scopes"))
+	authReq := sig.prop("auth_required")
+	src := sig.Source
+
+	isGo := strings.Contains(fw, "gin") || strings.Contains(fw, "echo") ||
+		strings.Contains(fw, "chi") || strings.Contains(fw, "fiber") ||
+		strings.Contains(fw, "go-middleware") || strings.Contains(fw, "gohttp") ||
+		strings.Contains(fw, "net/http") || strings.Contains(fw, "nethttp") ||
+		strings.Contains(fw, "golang") || fw == "go" ||
+		mw != "" || roles != "" || perms != "" || authReq != "" ||
+		hasGoAuthMiddleware(src) ||
+		(goUseRe.MatchString(src) && goPublicMwRe.MatchString(src))
+	if !isGo {
+		return Posture{}, false
+	}
+
+	// (1) EXPLICIT PUBLIC OVERRIDE — auth_required=false or a public marker
+	// middleware in the chain. Only an explicit signal earns `public`.
+	if authReq == "false" {
+		return Posture{Kind: KindPublic, Detail: "auth_required=false (no auth middleware in chain)"}, true
+	}
+	if src != "" && goPublicMwRe.MatchString(src) && !hasGoAuthMiddleware(src) {
+		return Posture{Kind: KindPublic, Detail: "explicit public/anonymous middleware, no auth in chain"}, true
+	}
+
+	// (2) Reconciled role / permission props — tightest first.
+	if roles != "" {
+		if r := firstCSV(roles); isGoSuperuserName(r) {
+			return Posture{Kind: KindSuperuser, Detail: "auth_roles=" + roles}, true
+		}
+		return Posture{Kind: KindRole, Literal: firstCSV(roles), Detail: "auth_roles=" + roles}, true
+	}
+	if perms != "" {
+		return Posture{Kind: KindAction, Literal: firstCSV(perms), Detail: "auth_permissions=" + perms}, true
+	}
+
+	// (3) Middleware-chain prop — classify the named middleware.
+	if mw != "" {
+		if p, ok := decodeGoMiddleware(mw, "auth_middleware="+mw); ok {
+			return p, true
+		}
+	}
+
+	// (4) Source fallback — scan the router/group/route registration + handler.
+	if src != "" {
+		if p, ok := decodeGoSource(src); ok {
+			return p, true
+		}
+	}
+
+	// (5) Reconciled auth_required=true without a decodable role/permission.
+	if authReq == "true" {
+		return Posture{Kind: KindAuthenticated, Detail: "auth_required=true (auth middleware, no decodable role/permission)"}, true
+	}
+
+	// Recognised as a Go HTTP route but no recognisable auth-ish middleware
+	// reaches it. HONEST under-claim: name-heuristics cannot prove the route is
+	// intentionally open, so report unknown (never false-public).
+	return Posture{Kind: KindUnknown, Detail: "Go HTTP route with no recognisable auth/role middleware in the reconciled chain (name-heuristic limit)"}, true
+}
+
+// decodeGoMiddleware classifies a middleware chain string (a comma/space list of
+// middleware identifiers) in role ▸ permission ▸ superuser ▸ auth priority.
+func decodeGoMiddleware(mw, detail string) (Posture, bool) {
+	if m := goRoleMwRe.FindStringSubmatch(mw); m != nil {
+		role := strings.TrimSpace(m[1])
+		if isGoSuperuserName(role) {
+			return Posture{Kind: KindSuperuser, Detail: detail}, true
+		}
+		return Posture{Kind: KindRole, Literal: role, Detail: detail}, true
+	}
+	if m := goPermMwRe.FindStringSubmatch(mw); m != nil {
+		return Posture{Kind: KindAction, Literal: strings.TrimSpace(m[1]), Detail: detail}, true
+	}
+	if goSuperuserMwRe.MatchString(mw) {
+		return Posture{Kind: KindSuperuser, Detail: detail}, true
+	}
+	if goPublicMwRe.MatchString(mw) && !goAuthMwRe.MatchString(mw) {
+		return Posture{Kind: KindPublic, Detail: detail}, true
+	}
+	if goAuthMwRe.MatchString(mw) {
+		return Posture{Kind: KindAuthenticated, Detail: detail}, true
+	}
+	return Posture{}, false
+}
+
+// decodeGoSource scans a route-registration / handler source body, honouring the
+// router ▸ group ▸ route nesting by simply taking the TIGHTEST recognisable
+// middleware anywhere in the reachable source (role ▸ permission ▸ superuser ▸
+// auth). The engine's source slice for the endpoint already includes the
+// enclosing group/router `.Use(...)` chain when available.
+func decodeGoSource(src string) (Posture, bool) {
+	if m := goRoleMwRe.FindStringSubmatch(src); m != nil {
+		role := strings.TrimSpace(m[1])
+		if isGoSuperuserName(role) {
+			return Posture{Kind: KindSuperuser, Detail: "RequireRole(" + role + ")"}, true
+		}
+		return Posture{Kind: KindRole, Literal: role, Detail: "RequireRole(" + role + ")"}, true
+	}
+	if m := goPermMwRe.FindStringSubmatch(src); m != nil {
+		return Posture{Kind: KindAction, Literal: strings.TrimSpace(m[1]), Detail: "RequirePermission(" + m[1] + ")"}, true
+	}
+	if goSuperuserMwRe.MatchString(src) {
+		return Posture{Kind: KindSuperuser, Detail: "admin/superuser middleware"}, true
+	}
+	if goAuthMwRe.MatchString(src) {
+		return Posture{Kind: KindAuthenticated, Detail: "auth/jwt/session middleware in chain (.Use / inline)"}, true
+	}
+	// A bare `.Use(...)` with no recognisable auth name is not classifiable.
+	return Posture{}, false
+}
+
+// isGoSuperuserName reports whether a role literal denotes a superuser/root role.
+func isGoSuperuserName(role string) bool {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "superuser", "super-admin", "superadmin", "root", "super":
+		return true
+	}
+	return false
+}
+
+// hasGoAuthMiddleware reports whether src carries a recognisable Go auth/role
+// middleware construct.
+func hasGoAuthMiddleware(src string) bool {
+	if src == "" {
+		return false
+	}
+	return goRoleMwRe.MatchString(src) ||
+		goPermMwRe.MatchString(src) ||
+		goSuperuserMwRe.MatchString(src) ||
+		goAuthMwRe.MatchString(src)
+}

--- a/internal/authposture/phoenix.go
+++ b/internal/authposture/phoenix.go
@@ -1,0 +1,283 @@
+// phoenix.go — the Phoenix (Elixir) auth-posture resolver (#4544; replaces the
+// phoenix stub).
+//
+// Phoenix expresses endpoint authorization through PLUG PIPELINES declared in the
+// router and applied to route scopes via `pipe_through`:
+//
+//	pipeline :auth do
+//	  plug :require_authenticated_user      # → authenticated
+//	end
+//	pipeline :admin do
+//	  plug :require_admin                   # → role/superuser
+//	end
+//	scope "/dashboard", MyApp do
+//	  pipe_through [:browser, :auth]        # routes here are authenticated
+//	  get "/", DashboardController, :index
+//	end
+//	scope "/", MyApp do
+//	  pipe_through :browser                 # no auth pipeline → public
+//	  get "/", PageController, :index
+//	end
+//
+// DECODE (#4544): resolve which PIPELINE(S) a route's scope pipes through, then
+// the PLUGS in those pipelines:
+//
+//   - `plug :require_authenticated_user` / `plug MyApp.Auth.Pipeline` /
+//     `plug Guardian.Plug.EnsureAuthenticated` / `plug :ensure_auth`     → authenticated.
+//   - `plug :require_admin` / `plug :require_role, :editor` / Bodyguard  → role.
+//   - `plug :require_superuser` / `:require_root`                        → superuser.
+//   - a scope whose pipe_through names NO auth-bearing pipeline           → public.
+//
+// PRECEDENCE: tightest plug across the route's pipelines wins (role ▸ authenticated);
+// a route in a scope with no auth pipeline is public.
+//
+// HONEST HEURISTIC LIMIT (#4544): like Go middleware, a Phoenix plug is "auth"
+// only by its NAME — there is no standard annotation. We classify by the plug
+// identifier. When the engine has NOT stamped the route's reconciled pipeline /
+// plug chain (it does not today — see the prop-stamping follow-up filed
+// alongside this resolver, like #4742-4745), we degrade to scanning the router
+// source. A route we cannot tie to a recognisable auth plug is reported
+// `unknown` rather than `public` UNLESS an explicit no-auth pipe_through /
+// public scope marker is present — we under-claim rather than false-public.
+//
+// Output normalises into the shared {Kind, Literal} vocabulary so the diff core
+// compares a Phoenix posture against the Django oracle or a NestJS posture directly.
+package authposture
+
+import (
+	"regexp"
+	"strings"
+)
+
+type phoenixResolver struct{}
+
+func (phoenixResolver) Name() string { return "phoenix" }
+
+var (
+	// plug :require_role, :editor  /  plug RequireRole, role: "editor"  → role literal.
+	phoenixRolePlugRe = regexp.MustCompile(`(?i)plug\s+[:\w.]*require_?role\w*\s*,?\s*:?["` + "`" + `]?(\w[\w.-]*)`)
+	// plug :require_admin / :require_superuser / :require_root → role/superuser.
+	phoenixAdminPlugRe = regexp.MustCompile(`(?i)plug\s+:?(require_?(admin|superuser|root|super_?admin)|ensure_?admin)`)
+	// authenticated-bearing plugs: require_authenticated_user, ensure_auth,
+	// Guardian.Plug.EnsureAuthenticated, Pow auth, :authenticate_user, etc.
+	phoenixAuthPlugRe = regexp.MustCompile(`(?i)plug\s+[:\w.]*?(require_?authenticated|ensure_?auth(?:enticated)?|authenticate_?user|require_?login|guardian\.plug\.ensureauthenticated|pow\.plug|require_?user|verify_?session|fetch_?current_?user.*verify)`)
+	// the route's resolved pipeline list (prop) e.g. "browser,auth".
+	// pipe_through [:browser, :auth] / pipe_through :auth.
+	phoenixPipeThroughRe = regexp.MustCompile(`pipe_through\s+\[?\s*([^\]\n]+)`)
+)
+
+// Resolve decodes a Phoenix auth signal. Recognises the framework when the
+// entity carries a Phoenix/Elixir framework hint OR a recognisable plug /
+// pipe_through construct in its props or source. Reconciled props win; router
+// source scanning is the fallback.
+func (ph phoenixResolver) Resolve(sig Signal) (Posture, bool) {
+	fw := strings.ToLower(firstNonEmpty(sig.Framework, sig.prop("framework")))
+	// Reconciled props the engine MAY stamp in future (prop-stamping follow-up):
+	//   auth_pipelines — the route's resolved pipe_through pipeline names.
+	//   auth_plugs     — the plugs across those pipelines.
+	pipelines := firstNonEmpty(sig.prop("auth_pipelines"), sig.prop("pipe_through"), sig.prop("phoenix_pipelines"))
+	plugs := firstNonEmpty(sig.prop("auth_plugs"), sig.prop("phoenix_plugs"), sig.prop("plugs"))
+	roles := sig.prop("auth_roles")
+	authReq := sig.prop("auth_required")
+	src := sig.Source
+
+	isPhoenix := strings.Contains(fw, "phoenix") || strings.Contains(fw, "elixir") ||
+		strings.Contains(fw, "plug") || strings.Contains(fw, "guardian") ||
+		pipelines != "" || plugs != "" || roles != "" || authReq != "" ||
+		hasPhoenixAuthPlug(src) || phoenixPipeThroughRe.MatchString(src)
+	if !isPhoenix {
+		return Posture{}, false
+	}
+
+	// (1) EXPLICIT PUBLIC — auth_required=false, or a route piping through ONLY
+	// non-auth pipelines (no auth plug reachable). Only an explicit/derivable
+	// no-auth signal earns `public`.
+	if authReq == "false" {
+		return Posture{Kind: KindPublic, Detail: "auth_required=false (no auth pipeline in pipe_through)"}, true
+	}
+
+	// (2) Reconciled role prop.
+	if roles != "" {
+		if r := firstCSV(roles); isPhoenixSuperuserName(r) {
+			return Posture{Kind: KindSuperuser, Detail: "auth_roles=" + roles}, true
+		}
+		return Posture{Kind: KindRole, Literal: firstCSV(roles), Detail: "auth_roles=" + roles}, true
+	}
+
+	// (3) Reconciled plugs prop — classify the tightest plug.
+	if plugs != "" {
+		if p, ok := decodePhoenixPlugs(plugs, "auth_plugs="+plugs); ok {
+			return p, true
+		}
+	}
+
+	// (4) Source fallback — scan the router. Resolve the scope's pipe_through to
+	// the named pipelines, then the plugs in those pipelines.
+	if src != "" {
+		if p, ok := decodePhoenixSource(src); ok {
+			return p, true
+		}
+	}
+
+	// (5) Reconciled auth_required=true without a decodable role.
+	if authReq == "true" {
+		return Posture{Kind: KindAuthenticated, Detail: "auth_required=true (auth pipeline, no decodable role)"}, true
+	}
+
+	// Recognised as Phoenix but no auth plug reachable from the route's scope.
+	// HONEST under-claim: report unknown (never false-public on a name-heuristic).
+	return Posture{Kind: KindUnknown, Detail: "Phoenix route with no recognisable auth plug in its pipe_through pipelines (name-heuristic limit)"}, true
+}
+
+// decodePhoenixPlugs classifies a plug list / plug source fragment in
+// superuser/admin ▸ role ▸ authenticated priority.
+func decodePhoenixPlugs(plugs, detail string) (Posture, bool) {
+	if phoenixAdminPlugRe.MatchString(plugs) {
+		// :require_admin etc. — admin is a superuser-class gate in Phoenix idiom,
+		// but a named role plug (require_role, :x) is a plain role; check role first.
+		if m := phoenixRolePlugRe.FindStringSubmatch(plugs); m != nil && !isPhoenixSuperuserName(m[1]) {
+			return Posture{Kind: KindRole, Literal: strings.TrimSpace(m[1]), Detail: detail}, true
+		}
+		return Posture{Kind: KindSuperuser, Detail: detail}, true
+	}
+	if m := phoenixRolePlugRe.FindStringSubmatch(plugs); m != nil {
+		role := strings.TrimSpace(m[1])
+		if isPhoenixSuperuserName(role) {
+			return Posture{Kind: KindSuperuser, Detail: detail}, true
+		}
+		return Posture{Kind: KindRole, Literal: role, Detail: detail}, true
+	}
+	if phoenixAuthPlugRe.MatchString(plugs) {
+		return Posture{Kind: KindAuthenticated, Detail: detail}, true
+	}
+	return Posture{}, false
+}
+
+// decodePhoenixSource resolves a router source: find the route's scope
+// pipe_through pipeline names, then collect the plugs declared in those
+// pipelines, then classify. When the source is a bare plug/pipeline fragment
+// (no full router), it falls back to classifying any auth plug present.
+func decodePhoenixSource(src string) (Posture, bool) {
+	// Determine which pipelines the route pipes through.
+	pipeNames := phoenixPipeThroughPipelines(src)
+
+	// If we resolved a pipe_through, restrict classification to the plug bodies of
+	// the named pipelines (most-precise). Otherwise, scan the whole fragment.
+	scan := src
+	if len(pipeNames) > 0 {
+		bodies := phoenixPipelineBodies(src, pipeNames)
+		if bodies != "" {
+			scan = bodies
+		} else {
+			// pipe_through names pipelines we can't find a body for in this slice:
+			// classify on the pipe names themselves (e.g. an `:auth` / `:admin`
+			// pipe name is a strong signal) and fall back to the whole source.
+			if p, ok := decodePhoenixPipeNames(pipeNames); ok {
+				return p, true
+			}
+		}
+		// A pipe_through that names ONLY clearly-non-auth pipelines (browser/api)
+		// with no auth plug reachable → public.
+		if !hasPhoenixAuthPlug(scan) && onlyNonAuthPipes(pipeNames) {
+			return Posture{Kind: KindPublic, Detail: "pipe_through " + strings.Join(pipeNames, ",") + " (no auth pipeline)"}, true
+		}
+	}
+
+	if p, ok := decodePhoenixPlugs(scan, phoenixPlugDetail(scan)); ok {
+		return p, true
+	}
+	return Posture{}, false
+}
+
+// phoenixPipeThroughPipelines extracts the pipeline names from the first
+// pipe_through in the source (e.g. `pipe_through [:browser, :auth]` → browser,auth).
+func phoenixPipeThroughPipelines(src string) []string {
+	m := phoenixPipeThroughRe.FindStringSubmatch(src)
+	if m == nil {
+		return nil
+	}
+	var out []string
+	for _, tok := range strings.Split(m[1], ",") {
+		tok = strings.TrimSpace(strings.Trim(strings.TrimSpace(tok), "[]:\"`"))
+		if tok != "" {
+			out = append(out, tok)
+		}
+	}
+	return out
+}
+
+// phoenixPipelineBodies returns the concatenated `do ... end` bodies of the named
+// pipelines found in src.
+func phoenixPipelineBodies(src string, names []string) string {
+	var b strings.Builder
+	for _, n := range names {
+		re := regexp.MustCompile(`(?is)pipeline\s+:` + regexp.QuoteMeta(n) + `\s+do(.*?)\bend\b`)
+		if m := re.FindStringSubmatch(src); m != nil {
+			b.WriteString(m[1])
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// decodePhoenixPipeNames classifies on the pipeline NAMES alone, as a fallback
+// when the pipeline bodies aren't in the source slice. An `:auth`/`:admin` pipe
+// name is a recognised convention.
+func decodePhoenixPipeNames(names []string) (Posture, bool) {
+	for _, n := range names {
+		ln := strings.ToLower(n)
+		if strings.Contains(ln, "admin") || strings.Contains(ln, "superuser") {
+			return Posture{Kind: KindSuperuser, Detail: "pipe_through :" + n}, true
+		}
+	}
+	for _, n := range names {
+		ln := strings.ToLower(n)
+		if ln == "auth" || strings.Contains(ln, "authenticated") || strings.Contains(ln, "protected") || strings.Contains(ln, "secure") {
+			return Posture{Kind: KindAuthenticated, Detail: "pipe_through :" + n}, true
+		}
+	}
+	return Posture{}, false
+}
+
+// onlyNonAuthPipes reports whether every named pipeline is a recognised
+// non-auth pipeline (browser / api / static / public).
+func onlyNonAuthPipes(names []string) bool {
+	if len(names) == 0 {
+		return false
+	}
+	for _, n := range names {
+		switch strings.ToLower(n) {
+		case "browser", "api", "static", "public", "open", "graphql":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// phoenixPlugDetail renders a short detail for a classified plug scan.
+func phoenixPlugDetail(scan string) string {
+	if m := regexp.MustCompile(`(?i)plug\s+[:\w.]+`).FindString(scan); m != "" {
+		return strings.TrimSpace(m)
+	}
+	return "phoenix plug"
+}
+
+// isPhoenixSuperuserName reports whether a role literal denotes a superuser role.
+func isPhoenixSuperuserName(role string) bool {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "superuser", "super_admin", "superadmin", "root", "admin", "super":
+		return true
+	}
+	return false
+}
+
+// hasPhoenixAuthPlug reports whether src carries a recognisable Phoenix auth plug.
+func hasPhoenixAuthPlug(src string) bool {
+	if src == "" {
+		return false
+	}
+	return phoenixAuthPlugRe.MatchString(src) ||
+		phoenixRolePlugRe.MatchString(src) ||
+		phoenixAdminPlugRe.MatchString(src)
+}

--- a/internal/authposture/resolvers.go
+++ b/internal/authposture/resolvers.go
@@ -87,10 +87,10 @@ func NewRegistry() *Registry {
 		flaskResolver{},   // #4540 — decorators / before_request
 		laravelResolver{}, // #4541 — middleware / Gates / Policies
 		aspnetResolver{},  // #4542 — [Authorize] / [AllowAnonymous] / policies
-		// Stubs — registry members so the shape is fixed; each returns
-		// ok=false until its follow-up ticket lands. NOT flagship-only.
-		stubResolver{name: "go-middleware"}, // ref #4419 — middleware chains
-		stubResolver{name: "phoenix"},       // ref #4419 — plugs
+		// Implemented (framework auth-resolver wave #4543/#4544) — the LAST two
+		// framework stubs, completing the all-framework resolver set (#4419).
+		goMiddlewareResolver{}, // #4543 — Gin/Echo/Chi/net-http middleware chains
+		phoenixResolver{},      // #4544 — Phoenix plug pipelines / pipe_through
 	}}
 }
 


### PR DESCRIPTION
Replaces the **last two** framework STUBs — **go-middleware** and **phoenix** — in the framework-pluggable `auth_posture_diff` resolver registry (`internal/authposture`) with real resolvers that decode each framework's auth constructs into the shared `{Kind, Literal}` vocabulary, **completing the all-framework resolver set** (#4419) alongside NestJS/DRF/Spring/FastAPI/Express/Rails/Flask/Laravel/ASP.NET (#4708-4710 / #4741). No stubs remain.

## Per-framework decode + precedence
- **Go middleware (#4543)** — router-level `r.Use(AuthMiddleware())`, group-level `g.Use(jwtAuth())` / chi `r.Group(func(r){ r.Use(Auth) })`, inline route `r.GET("/x", AuthRequired(), h)`, and net/http `AuthMiddleware(handler)` wrappers. An auth-ish middleware name (`auth`/`jwt`/`authenticate`/`requireAuth`/`bearer`/`session`) reaching a route -> **authenticated**; `RequireRole("admin")` -> **role**, `RequirePermission("x")` -> **action**; superuser-named role / `RequireAdmin` -> **superuser**. Tightest-wins across the chain.
- **Phoenix (#4544)** — resolves a route's scope `pipe_through [:browser, :auth]` to the named pipelines, then the **plugs in those pipelines**: `plug :require_authenticated_user` / `Guardian.Plug.EnsureAuthenticated` / `:ensure_auth` -> **authenticated**; `plug :require_role, :editor` -> **role**; `plug :require_admin`/`:require_superuser` -> **superuser**; a scope piping through only non-auth pipelines (browser/api) -> **public**.

## Honest heuristic limit (documented + under-claimed)
Both frameworks attach auth via **middleware/plug NAME**, not a standard annotation. So classification is by identifier, and a route reaching **no recognisable auth middleware/plug** with no explicit public marker resolves to **`unknown`**, NOT `public` — we **under-claim** rather than emit a false-public that would mask a real RBAC regression in the diff. Only an explicit signal (`auth_required=false`, an exported `Public`/`NoAuth`/`AllowAnonymous` Go middleware, or a Phoenix scope piping through only non-auth pipelines) earns `public`.

## Notes
- **Scope boundary respected:** does NOT touch `internal/mcp/auth_posture_diff_tool.go` (the #4550 JOIN).
- **Prop-stamping follow-ups filed:** the engine does not yet stamp the reconciled Go middleware chain / Phoenix pipeline+plug props, and the diff tool's `authPostureSignalProps` does not harvest them or a per-framework auth-source body — so the resolvers degrade to source-scan + generic props today. Filed **#4746** (Go) and **#4747** (Phoenix).

## Validation
- Fixtures in `authposture_test.go`: Go — `r.Use(AuthMiddleware())` -> authenticated, echo group / chi sub-router / gin inline -> authenticated, `RequireRole("admin")` -> role / `"superuser"` -> superuser / `RequirePermission` -> action, no-auth group -> **unknown** (under-claim), explicit `auth_required=false` / `AllowAnonymous` -> public, E2E looser-vs-Django-oracle. Phoenix — `pipe_through [:auth]` (pipeline plugs `:require_authenticated_user`) -> authenticated, public scope -> public, `:require_admin` -> superuser / `:require_role, :editor` -> role, Guardian -> authenticated, E2E looser-vs-Django-oracle.
- `go build ./...` + `go vet ./internal/authposture/... ./internal/dashboard/... ./internal/engine/...` clean; `go test` for all three packages green.
- Surgical `Auth`/`auth_coverage` notes for gin/echo/chi + phoenix in `docs/coverage/registry.json`; `coverage fmt --check` canonical.
- `TestRegistry_StubsRegisteredButDecline` -> `TestRegistry_AllFrameworksRegistered` (no stubs remain).

Closes #4543
Closes #4544

🤖 Generated with [Claude Code](https://claude.com/claude-code)