### PR TITLE
feat(authposture): wire framework auth-posture resolvers into the live cross-group diff (#4734, #4742-#4747)

### DIFF
--- a/internal/custom/golang/route_auth.go
+++ b/internal/custom/golang/route_auth.go
@@ -62,6 +62,12 @@ func (a goRouteAuth) stamp(props map[string]string) {
 	props["auth_confidence"] = a.Confidence
 	if a.Guard != "" {
 		props["auth_guard"] = a.Guard
+		// Also stamp the recognised middleware symbol as the reconciled chain
+		// (auth_middleware) so the cross-group auth-posture resolver
+		// (internal/authposture/gomiddleware.go) decodes role/superuser from a
+		// named guard like RequireAdmin / RequireRole("editor") in the LIVE diff
+		// instead of degrading to a bare authenticated posture (#4746).
+		props["auth_middleware"] = a.Guard
 	}
 	if a.Kind != "" {
 		props["auth_kind"] = a.Kind

--- a/internal/mcp/auth_posture_diff_harvest_test.go
+++ b/internal/mcp/auth_posture_diff_harvest_test.go
@@ -1,0 +1,249 @@
+package mcp
+
+// auth_posture_diff_harvest_test.go — LIVE-PATH harvest tests for #4734 + #4742..
+// #4747. These assert that the framework auth-posture resolvers
+// (Spring/Rails/Flask/Laravel/ASP.NET/Go/Phoenix) surface a NON-unknown posture
+// when fed an endpoint shaped as the engine ACTUALLY produces it (the structured
+// props the extractor stamps and/or a handler/controller/router SOURCE body) —
+// i.e. the props flow through authPostureSignalProps / authPostureSourceProps in
+// buildAuthSignal into the resolver, NOT only through the unit tests in
+// internal/authposture that construct a Signal directly.
+//
+// The contract under test is the SIGNAL PLUMBING: before this change the harvest
+// list dropped every framework-specific prop and hard-wired Signal.Source to the
+// Django get_permissions body, so a clearly-guarded Spring/Rails/Flask/Laravel/
+// ASP.NET/Go/Phoenix endpoint resolved to `unknown` in the live diff. The #4550
+// JOIN keying is unchanged.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/authposture"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// resolvedV3Posture runs the full harvest → resolver path on a single v3
+// endpoint entity (the same buildAuthSignal the live tool uses) and returns the
+// resolved posture. It mirrors collectAuthEndpoints' per-endpoint harvest.
+func resolvedV3Posture(t *testing.T, props map[string]string) authposture.Posture {
+	t.Helper()
+	e := endpointEntity("v1", "GET", "/x", props)
+	sig := buildAuthSignal(&e)
+	p, _ := authposture.NewRegistry().Resolve(sig)
+	return p
+}
+
+// assertGuardedSurfaces asserts a clearly-guarded endpoint resolves to a known,
+// non-public posture (the resolver SAW the auth signal through the harvest).
+func assertGuardedSurfaces(t *testing.T, framework string, props map[string]string, wantKind authposture.Kind) {
+	t.Helper()
+	p := resolvedV3Posture(t, props)
+	if p.Kind == authposture.KindUnknown {
+		t.Fatalf("%s: guarded endpoint resolved to UNKNOWN through the harvest — "+
+			"props did not reach the resolver: posture=%+v props=%+v", framework, p, props)
+	}
+	if wantKind != "" && p.Kind != wantKind {
+		t.Fatalf("%s: posture kind=%s, want %s; posture=%+v", framework, p.Kind, wantKind, p)
+	}
+}
+
+// --- Spring (#4734): method/class @PreAuthorize + global SecurityFilterChain ---
+
+func TestHarvest_Spring_ClassPreAuthorize_Surfaces(t *testing.T) {
+	// A controller with a class-level @PreAuthorize("hasRole('ADMIN')") and no
+	// method override — the engine stamps spring_class_pre_authorize on the
+	// endpoint. Before the harvest fix this key was dropped → unknown.
+	assertGuardedSurfaces(t, "spring", map[string]string{
+		"framework":                  "spring",
+		"spring_class_pre_authorize": "hasRole('ADMIN')",
+	}, authposture.KindRole)
+}
+
+func TestHarvest_Spring_GlobalFilterChain_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "spring", map[string]string{
+		"framework":                   "spring",
+		"spring_global_authorization": `requestMatchers("/api/**").authenticated()`,
+	}, authposture.KindAuthenticated)
+}
+
+// --- Rails (#4742): reconciled before_action + Pundit literal ---
+
+func TestHarvest_Rails_BeforeAction_Surfaces(t *testing.T) {
+	// ruby/auth.go stamps auth_required/auth_guard for a before_action chain.
+	assertGuardedSurfaces(t, "rails", map[string]string{
+		"framework":     "rails",
+		"auth_required": "true",
+		"auth_guard":    "require_admin",
+	}, authposture.KindRole)
+}
+
+func TestHarvest_Rails_PunditPolicy_Surfaces(t *testing.T) {
+	// pundit_policy/pundit_action literals (harvested for the first time here).
+	assertGuardedSurfaces(t, "rails", map[string]string{
+		"framework":      "rails",
+		"pundit_policy":  "PostPolicy",
+		"pundit_action":  "update",
+	}, authposture.KindAction)
+}
+
+func TestHarvest_Rails_ControllerSource_Surfaces(t *testing.T) {
+	// No structured props — only a controller_source body. The per-framework
+	// source fallback in buildAuthSignal must populate Signal.Source so the
+	// resolver source-scans it.
+	assertGuardedSurfaces(t, "rails", map[string]string{
+		"framework": "rails",
+		"controller_source": "class PostsController < ApplicationController\n" +
+			"  before_action :authenticate_user!\n  def index; end\nend",
+	}, authposture.KindAuthenticated)
+}
+
+// --- Flask (#4743): reconciled login_required + decorator/page ---
+
+func TestHarvest_Flask_LoginRequired_Surfaces(t *testing.T) {
+	// python/flask.go stamps framework=flask + auth_required=true for a
+	// login_required view.
+	assertGuardedSurfaces(t, "flask", map[string]string{
+		"framework":     "flask",
+		"auth_required": "true",
+	}, authposture.KindAuthenticated)
+}
+
+func TestHarvest_Flask_RolesDecorator_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "flask", map[string]string{
+		"framework":      "flask",
+		"auth_decorator": "roles_required",
+		"auth_roles":     "admin",
+	}, authposture.KindRole)
+}
+
+// --- Laravel (#4744): route/group middleware ---
+
+func TestHarvest_Laravel_AuthMiddleware_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "laravel", map[string]string{
+		"framework":       "laravel",
+		"auth_required":   "true",
+		"auth_middleware": "auth",
+	}, authposture.KindAuthenticated)
+}
+
+func TestHarvest_Laravel_RoleMiddleware_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "laravel", map[string]string{
+		"framework":  "laravel",
+		"middleware": "role:admin",
+		"auth_roles": "admin",
+	}, authposture.KindRole)
+}
+
+// --- ASP.NET Core (#4745): [Authorize]/policy/[AllowAnonymous] ---
+
+func TestHarvest_Aspnet_Authorize_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "aspnet", map[string]string{
+		"framework":     "aspnet",
+		"auth_required": "true",
+	}, authposture.KindAuthenticated)
+}
+
+func TestHarvest_Aspnet_ClassAuthorizeRoles_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "aspnet", map[string]string{
+		"framework":               "aspnet",
+		"aspnet_class_authorize":  "true",
+		"aspnet_class_roles":      "Admin",
+	}, authposture.KindRole)
+}
+
+func TestHarvest_Aspnet_AllowAnonymous_Surfaces(t *testing.T) {
+	// AllowAnonymous is an explicit public marker — must resolve to public, not
+	// unknown. Verifies allow_anonymous flows through the harvest.
+	p := resolvedV3Posture(t, map[string]string{
+		"framework":       "aspnet",
+		"allow_anonymous": "true",
+	})
+	if p.Kind != authposture.KindPublic {
+		t.Fatalf("aspnet AllowAnonymous: kind=%s, want public; posture=%+v", p.Kind, p)
+	}
+}
+
+// --- Go HTTP middleware (#4746): reconciled middleware chain ---
+
+func TestHarvest_Go_AuthMiddleware_Surfaces(t *testing.T) {
+	// route_auth.go now stamps auth_middleware (the guard symbol) in addition to
+	// auth_required; an admin guard must resolve to superuser, not bare
+	// authenticated.
+	assertGuardedSurfaces(t, "go", map[string]string{
+		"framework":       "go",
+		"auth_required":   "true",
+		"auth_middleware": "RequireAdmin",
+	}, authposture.KindSuperuser)
+}
+
+func TestHarvest_Go_AuthRequiredOnly_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "go", map[string]string{
+		"framework":     "gin",
+		"auth_required": "true",
+	}, authposture.KindAuthenticated)
+}
+
+// --- Phoenix (#4747): pipeline/plug + router source fallback ---
+
+func TestHarvest_Phoenix_AuthPipelines_Surfaces(t *testing.T) {
+	assertGuardedSurfaces(t, "phoenix", map[string]string{
+		"framework":      "phoenix",
+		"auth_pipelines": "browser -> auth",
+		"auth_plugs":     "plug Guardian.Plug.EnsureAuthenticated",
+	}, authposture.KindAuthenticated)
+}
+
+func TestHarvest_Phoenix_RouterSource_Surfaces(t *testing.T) {
+	// Only a router_source body — the per-framework source fallback must feed it
+	// to the Phoenix resolver's router-source scan.
+	assertGuardedSurfaces(t, "phoenix", map[string]string{
+		"framework": "phoenix",
+		"router_source": "pipeline :auth do\n  plug Guardian.Plug.EnsureAuthenticated\nend\n" +
+			"scope \"/\" do\n  pipe_through [:browser, :auth]\n  get \"/x\", PageController, :index\nend",
+	}, "")
+}
+
+// TestHarvest_AllFrameworkPropsReachResolver is a guard: every framework-specific
+// prop key a resolver reads must be present in authPostureSignalProps, else it is
+// silently dropped before the resolver sees it (the #4734/#4742-#4747 bug class).
+func TestHarvest_AllFrameworkPropsReachResolver(t *testing.T) {
+	must := []string{
+		// Spring.
+		"spring_class_pre_authorize", "spring_class_secured", "spring_class_roles_allowed",
+		"spring_global_authorization", "auth_expression",
+		// Rails.
+		"pundit_policy", "pundit_action", "cancancan_ability",
+		// Flask.
+		"auth_decorator", "auth_page",
+		// Laravel.
+		"auth_middleware", "middleware", "auth_permissions",
+		// ASP.NET.
+		"auth_policy", "allow_anonymous", "aspnet_class_authorize", "aspnet_class_roles",
+		"aspnet_class_policy", "aspnet_class_allow_anonymous", "aspnet_fallback_policy",
+		// Phoenix.
+		"auth_pipelines", "auth_plugs", "pipe_through", "plugs",
+	}
+	set := map[string]bool{}
+	for _, k := range authPostureSignalProps {
+		set[k] = true
+	}
+	for _, k := range must {
+		if !set[k] {
+			t.Errorf("authPostureSignalProps is missing framework prop %q — it will be "+
+				"dropped before the resolver sees it", k)
+		}
+	}
+}
+
+// TestHarvest_SourceFallbackPopulatesSignal verifies buildAuthSignal fills
+// Signal.Source from a per-framework source-body prop, not just the Django
+// get_permissions key.
+func TestHarvest_SourceFallbackPopulatesSignal(t *testing.T) {
+	for _, k := range authPostureSourceProps {
+		e := graph.Entity{Properties: map[string]string{"verb": "GET", "path": "/x", k: "BODY"}}
+		sig := buildAuthSignal(&e)
+		if sig.Source != "BODY" {
+			t.Errorf("source prop %q did not populate Signal.Source (got %q)", k, sig.Source)
+		}
+	}
+}

--- a/internal/mcp/auth_posture_diff_tool.go
+++ b/internal/mcp/auth_posture_diff_tool.go
@@ -49,6 +49,13 @@ import (
 // may read. Harvested into the framework-neutral Signal; each resolver picks
 // the keys its framework stamps. Kept explicit so the Signal carries exactly the
 // auth surface and nothing else.
+//
+// This is the SIGNAL-PLUMBING allow-list (the keys copied onto the resolver
+// Signal), NOT the cross-group JOIN keying — the #4550 boundary was about the
+// join algorithm, which is untouched here. The framework-specific blocks below
+// were added in #4734/#4742-#4747 so every registered resolver
+// (Spring/Rails/Flask/Laravel/ASP.NET/Go/Phoenix) reads its STRUCTURED posture
+// signal in the LIVE diff path instead of degrading to source-scan/unknown.
 var authPostureSignalProps = []string{
 	// Django DRF.
 	"has_get_permissions", "has_permission_classes", "permission_classes",
@@ -56,8 +63,54 @@ var authPostureSignalProps = []string{
 	// NestJS reconciled posture + @Require* literals.
 	"require_page", "require_action", "require_superuser", "is_public",
 	"auth_required", "auth_method", "auth_guard", "auth_roles", "auth_scopes",
+	// Generic reconciled posture shared across framework extractors (Rails/Flask/
+	// Laravel/ASP.NET/Go/Phoenix all stamp some subset of these via the #3734
+	// flat-contract convention).
+	"auth_kind", "auth_permissions", "auth_middleware", "auth_policy",
+	"middleware", "allow_anonymous",
+	// Spring (#4734) — method/class/global @PreAuthorize/@Secured/@RolesAllowed
+	// + SecurityFilterChain. The resolver reads both the bare and spring_*-prefixed
+	// class/global forms.
+	"auth_expression", "pre_authorize", "preauthorize", "post_authorize",
+	"secured", "roles_allowed",
+	"class_pre_authorize", "class_secured", "class_roles_allowed",
+	"spring_class_pre_authorize", "spring_class_post_authorize",
+	"spring_class_secured", "spring_class_roles_allowed", "spring_global_authorization",
+	// Rails (#4742) — Pundit / CanCanCan literals.
+	"pundit_policy", "pundit_action", "cancancan_ability",
+	// Flask (#4743) — Flask-Principal permission / decorator name + page.
+	"auth_decorator", "auth_page",
+	// Laravel (#4744) — middleware / permission already covered above (auth_middleware,
+	// middleware, auth_permissions, auth_page).
+	// ASP.NET Core (#4745) — policy + class-level / global [Authorize]/[AllowAnonymous].
+	"aspnet_class_authorize", "aspnet_class_roles", "aspnet_class_policy",
+	"aspnet_class_allow_anonymous", "aspnet_fallback_policy",
+	// Phoenix (#4747) — resolved pipeline list + per-pipeline plug list.
+	"auth_pipelines", "auth_plugs", "phoenix_pipelines", "phoenix_plugs",
+	"pipe_through", "plugs",
 	// Cross-framework action context.
 	"effective_action", "action", "framework",
+}
+
+// authPostureSourceProps are the endpoint property keys that may carry the raw
+// auth-bearing SOURCE body a resolver source-scans when its structured props are
+// absent. Tried in order; the first non-empty one populates Signal.Source. The
+// Django get_permissions body comes first (the flagship path); the per-framework
+// handler/controller/route/router source bodies (#4742-#4747) follow so each
+// resolver's source-scan fallback works in the LIVE diff path, not just unit
+// tests. Engine stamping of these bodies is tracked per-framework; this harvest
+// is forward-compatible — it picks up whichever body the extractor stamps.
+var authPostureSourceProps = []string{
+	"get_permissions_source", // Django DRF (flagship).
+	"auth_source",            // generic reconciled auth-source body.
+	"handler_source",         // flat handler body (Flask/FastAPI/Go).
+	"controller_source",      // Rails / Laravel / ASP.NET controller body.
+	"action_source",          // ASP.NET / DRF action body.
+	"view_source",            // Flask view / Django view body.
+	"route_source",           // Laravel / Go route-registration body.
+	"router_source",          // Phoenix / Go router body.
+	"guard_source",           // NestJS guard / middleware body.
+	"middleware_source",      // middleware-chain body.
 }
 
 // authPostureRecord is one joined endpoint's diff record.
@@ -228,7 +281,15 @@ func buildAuthSignal(e *graph.Entity) authposture.Signal {
 			}
 		}
 		sig.Framework = e.Properties["framework"]
-		sig.Source = e.Properties["get_permissions_source"]
+		// Source fallback: try the framework-neutral source-body props in priority
+		// order so a resolver's source-scan path works in the LIVE diff, not only
+		// the Django get_permissions case (#4742-#4747).
+		for _, k := range authPostureSourceProps {
+			if v := strings.TrimSpace(e.Properties[k]); v != "" {
+				sig.Source = v
+				break
+			}
+		}
 		if a := strings.TrimSpace(e.Properties["effective_action"]); a != "" {
 			sig.Action = a
 		} else {


### PR DESCRIPTION
Wires the seven framework auth-posture resolvers (Spring/Rails/Flask/Laravel/ASP.NET/Go/Phoenix, landed in #4732/#4741/#4748) end-to-end into the LIVE \`archigraph_auth_posture_diff\`. They decoded correctly in unit tests but degraded to \`unknown\` on a real graph because the harvest dropped their structured props and hard-wired \`Signal.Source\` to the Django get_permissions body.

## Harvest — the shared unblock (`internal/mcp/auth_posture_diff_tool.go`)
- `authPostureSignalProps` now carries **every** prop the seven resolvers read (grepped from each resolver in `internal/authposture/`): Spring class/global (`spring_class_*`, `spring_global_authorization`, `auth_expression`/`pre_authorize`/`secured`/`roles_allowed`), Rails (`pundit_policy`/`pundit_action`/`cancancan_ability`), Flask (`auth_decorator`/`auth_page`), Laravel (`auth_middleware`/`middleware`/`auth_permissions`), ASP.NET (`auth_policy`/`allow_anonymous`/`aspnet_class_*`/`aspnet_fallback_policy`), Phoenix (`auth_pipelines`/`auth_plugs`/`pipe_through`/`plugs`), plus the shared reconciled set.
- `buildAuthSignal` populates `Signal.Source` from an **ordered per-framework source-body list** (`get_permissions_source` → controller/view/route/router/handler/guard/middleware source) so each resolver's source-scan fallback works in the live path.
- The **#4550 JOIN keying is unchanged** — this is signal plumbing onto the resolver Signal, not the join algorithm.

## Engine stamping (tractable)
- **Go (#4746):** `internal/custom/golang/route_auth.go` now also stamps `auth_middleware` = the recognised guard symbol, so the Go resolver decodes role/superuser from a named guard (`RequireAdmin`/`RequireRole`) live instead of a bare authenticated posture.
- The non-trivial endpoint-level class/global/pipeline reconciliation (Spring class/global, ASP.NET method▸class▸global, Rails Pundit literals, Phoenix pipe_through resolution, Flask roles, Laravel route-middleware, an endpoint source body for the scan fallback) is **deferred to follow-ups #4750/#4751/#4752**. The harvest makes those props/source flow the instant an extractor stamps them.

## Live-path tests (`internal/mcp/auth_posture_diff_harvest_test.go`)
Per-framework tests feed an endpoint shaped as the engine produces it (structured props and/or a source body) through `buildAuthSignal` → resolver and assert a clearly-guarded endpoint surfaces a **non-unknown** posture; plus guards that every framework prop is in the harvest list and the source fallback populates `Signal.Source`.

## Gates
- `go build ./...` ✅
- `go vet ./internal/mcp/... ./internal/authposture/... ./internal/engine/... ./internal/custom/...` ✅
- `go test ./internal/mcp/... ./internal/authposture/... ./internal/engine/...` ✅ (+ `./internal/custom/...` ✅)
- `coverage fmt --check` ✅ (no registry change — no documented Auth capability cell flipped; structured-cell elevation is in the deferred follow-ups)

Closes #4734
Closes #4742
Closes #4743
Closes #4744
Closes #4745
Closes #4746
Closes #4747

🤖 Generated with [Claude Code](https://claude.com/claude-code)