### PR TITLE
feat(rust): test→endpoint route-hit linkage (#4749) + Diesel/sea-orm read-sink gating (#4737)

### DIFF
--- a/internal/custom/rust/tests_route_e2e.go
+++ b/internal/custom/rust/tests_route_e2e.go
@@ -1,0 +1,273 @@
+// Package rust — Rust test→endpoint route-hit linkage.
+//
+// #4749 (the Rust slice of epic #4615/#4615-tail #4749, all-framework
+// test→endpoint coverage linkage). Emits ONE test_suite entity per Rust test
+// file that drives an HTTP endpoint by ROUTE STRING, stamping the captured
+// `VERB route` pairs onto the suite's `e2e_route_calls` property. The shared
+// resolve pass (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches
+// each pair against the cross-file http_endpoint_definition index and emits a
+// TESTS edge to the exact endpoint exercised — exactly as the Go httptest
+// (internal/custom/golang/httptest_e2e.go) and Kotlin
+// (internal/custom/kotlin/tests_route_e2e.go) extractors do. The engine pass is
+// language-agnostic (it fires on any test_suite carrying e2e_route_calls), so
+// the only Rust-specific work is the route capture.
+//
+// Rust tests are NAMED functions annotated `#[test]` / `#[tokio::test]` /
+// `#[actix_web::test]` / `#[actix_rt::test]` — there is no closure test DSL, so
+// no anonymous-test-block scope-owner is needed (same as Go/Java). The dominant
+// linkage mechanism for Rust is therefore route-hit linkage; Rust handlers are
+// usually free functions wired into a router by path, so local-variable
+// receiver typing of a constructed handler is not the common shape (recorded
+// N/A — see the issue note). Three route-driving idioms are captured:
+//
+//   - Actix-web test: build a request with `test::TestRequest::get().uri("/p")`
+//     (or `.post()/.put()/.patch()/.delete()/.head()`, or the explicit
+//     `TestRequest::with_uri("/p")` / `.method(Method::POST)` form) and dispatch
+//     via `test::call_service(&app, req)`.
+//   - Axum / tower test: `app.oneshot(Request::get("/p").body(...))` (also
+//     `Request::builder().method(Method::GET).uri("/p")`).
+//   - Rocket test: `client.get("/p").dispatch()` (and the other verb builders).
+//   - reqwest against a spawned test server: `reqwest::Client::new().get(addr +
+//     "/p")` / `client.post(format!("{addr}/p"))` — the literal "/..."-shaped
+//     path suffix is captured; a fully-variable URL is dropped (conservative).
+//
+// Registration key: "custom_rust_tests_route_e2e".
+package rust
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_tests_route_e2e", &rustTestRouteE2EExtractor{})
+}
+
+type rustTestRouteE2EExtractor struct{}
+
+func (e *rustTestRouteE2EExtractor) Language() string {
+	return "custom_rust_tests_route_e2e"
+}
+
+var (
+	// Actix builder: test::TestRequest::get().uri("/api/v1/x")
+	// (also TestRequest::post()/put()/patch()/delete()/head()). The verb is the
+	// builder method; the route the first uri("...") string literal. The receiver
+	// may be bare `TestRequest::` or `test::TestRequest::`.
+	rustActixTestReqVerbRE = regexp.MustCompile(
+		`(?s)\bTestRequest\s*::\s*(get|post|put|patch|delete|head)\s*\(\s*\)\s*\.\s*uri\s*\(\s*"([^"\n\r]+)"`)
+
+	// Actix explicit form: TestRequest::with_uri("/api/v1/x").method(Method::POST)
+	// — verb defaults to GET when no .method() follows. Captured route first; the
+	// verb (if any) is recovered from a following `.method(Method::VERB)`.
+	rustActixWithURIRE = regexp.MustCompile(
+		`(?s)\bTestRequest\s*::\s*with_uri\s*\(\s*"([^"\n\r]+)"\s*\)((?:\s*\.\s*method\s*\(\s*Method\s*::\s*[A-Za-z]+\s*\))?)`)
+	rustActixMethodRE = regexp.MustCompile(
+		`\.\s*method\s*\(\s*Method\s*::\s*([A-Za-z]+)\s*\)`)
+
+	// Axum / hyper Request builder: Request::get("/p") / Request::post("/p"),
+	// also Request::builder().method(Method::GET).uri("/p"). The first form is a
+	// verb-named constructor; the second is captured by rustReqBuilderRE.
+	rustAxumRequestVerbRE = regexp.MustCompile(
+		`\bRequest\s*::\s*(get|post|put|patch|delete|head)\s*\(\s*"([^"\n\r]+)"`)
+	// Bounded non-greedy span (no lookahead — RE2): from the builder() up to the
+	// first .uri("..."), capturing the intervening chain (which may carry a
+	// .method(Method::VERB)). Stops at the first uri literal.
+	rustReqBuilderRE = regexp.MustCompile(
+		`(?s)\bRequest\s*::\s*builder\s*\(\s*\)(.*?)\.\s*uri\s*\(\s*"([^"\n\r]+)"`)
+	rustReqBuilderMethodRE = regexp.MustCompile(
+		`\.\s*method\s*\(\s*Method\s*::\s*([A-Za-z]+)\s*\)`)
+
+	// Rocket client: client.get("/p").dispatch() (and post/put/patch/delete/head).
+	// Anchored on a `.` receiver so a Rocket route-attr factory is not captured.
+	rustRocketClientRE = regexp.MustCompile(
+		`\.\s*(get|post|put|patch|delete|head)\s*\(\s*"(/[^"\n\r]*)"\s*\)`)
+
+	// reqwest client against a test server: client.get(addr + "/p"),
+	// reqwest::Client::new().post(format!("{}/p", addr)). We match the FIRST
+	// "/..."-shaped string literal in a reqwest verb call; a bare base URL with no
+	// literal path suffix yields no route (dropped, conservative).
+	rustReqwestVerbRE = regexp.MustCompile(
+		`\breqwest\s*::\s*(?:Client\s*::\s*(?:new|builder)\s*\([^)]*\)[^;]*?|get|post|put|patch|delete|head)`)
+	// A reqwest verb call: client.get( ... "..."-literal ... ). The route literal
+	// may be a bare "/path" OR a format!("{}/path", addr) / format!("{addr}/path")
+	// where the path suffix follows a `{...}` placeholder. Group 2 captures the
+	// raw literal body; extractReqwestPath then recovers the leading-slash path.
+	rustReqwestCallRE = regexp.MustCompile(
+		`\.\s*(get|post|put|patch|delete|head)\s*\([^)\n]*?"([^"\n\r]*)"`)
+	// rustReqwestPlaceholderPathRE recovers a "/path" suffix that follows a
+	// format! placeholder — `"{}/api/v1/health"` → `/api/v1/health`,
+	// `"{addr}/users/1"` → `/users/1`.
+	rustReqwestPlaceholderPathRE = regexp.MustCompile(`\}(/[^{}\n\r]*)`)
+
+	// rocketVerb / rustVerb canonicalisers reuse strings.ToUpper.
+)
+
+func (e *rustTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+	source := string(file.Content)
+	if !isRustTestFile(file.Path, source) {
+		return nil, nil
+	}
+	routeCalls := collectRustTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	framework := detectRustTestRouteFramework(source)
+	ent := makeEntity(
+		"rust_route_suite:"+rustTestSuiteBaseName(file.Path),
+		"SCOPE.Operation", "test_suite", file.Path, "rust", 1)
+	setProps(&ent,
+		"framework", framework,
+		"provenance", "INFERRED_FROM_RUST_TEST_ROUTE_E2E",
+		"test_framework", framework,
+		"e2e_route_calls", strings.Join(routeCalls, "\n"),
+	)
+	return []types.EntityRecord{ent}, nil
+}
+
+// collectRustTestRouteCalls returns the de-duplicated "VERB route" pairs a Rust
+// test file drives by route string (Actix TestRequest / Axum-tower oneshot /
+// Rocket client / reqwest test-server). Routes are normalised to a leading-slash
+// path; non-path / variable-route literals are dropped (honest exclusion).
+func collectRustTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		route := normaliseRustTestRoute(rawRoute)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		verb = strings.ToUpper(strings.TrimSpace(verb))
+		if verb == "" {
+			return
+		}
+		line := verb + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+
+	for _, m := range rustActixTestReqVerbRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range rustActixWithURIRE.FindAllStringSubmatch(source, -1) {
+		verb := "GET"
+		if mm := rustActixMethodRE.FindStringSubmatch(m[2]); mm != nil {
+			verb = mm[1]
+		}
+		add(verb, m[1])
+	}
+	for _, m := range rustAxumRequestVerbRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range rustReqBuilderRE.FindAllStringSubmatch(source, -1) {
+		verb := "GET"
+		if mm := rustReqBuilderMethodRE.FindStringSubmatch(m[1]); mm != nil {
+			verb = mm[1]
+		}
+		add(verb, m[2])
+	}
+	for _, m := range rustRocketClientRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	if rustReqwestVerbRE.MatchString(source) {
+		for _, m := range rustReqwestCallRE.FindAllStringSubmatch(source, -1) {
+			add(m[1], extractReqwestPath(m[2]))
+		}
+	}
+	return out
+}
+
+// extractReqwestPath recovers the leading-slash path from a reqwest route
+// literal: a bare "/path" is returned as-is; a format!-style literal
+// ("{}/api/v1/health" / "{addr}/users/1") yields the suffix after the last
+// `{...}` placeholder. A literal with no leading-slash path yields "" (dropped).
+func extractReqwestPath(lit string) string {
+	if strings.HasPrefix(lit, "/") {
+		return lit
+	}
+	if m := rustReqwestPlaceholderPathRE.FindStringSubmatch(lit); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// detectRustTestRouteFramework labels the suite by the dominant route-driving
+// idiom present, defaulting to "cargo_test".
+func detectRustTestRouteFramework(source string) string {
+	switch {
+	case strings.Contains(source, "TestRequest") || strings.Contains(source, "actix_web::test"):
+		return "actix-web"
+	case strings.Contains(source, ".oneshot(") || strings.Contains(source, "Request::builder"):
+		return "axum"
+	case strings.Contains(source, ".dispatch("):
+		return "rocket"
+	case strings.Contains(source, "reqwest"):
+		return "reqwest"
+	default:
+		return "cargo_test"
+	}
+}
+
+// normaliseRustTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix (http://127.0.0.1:8080/x → /x), drops query/fragment,
+// collapses repeated slashes. Path-param placeholders ({id}) and casing are
+// preserved (the resolver wildcards templates and compares case-insensitively).
+func normaliseRustTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
+}
+
+// isRustTestFile reports whether path/source looks like a Rust test source — a
+// file under a `tests/` integration dir, or any `.rs` file carrying a recognised
+// test attribute (#[test] / #[tokio::test] / #[actix_web::test] / #[cfg(test)]).
+// Keeps the route-hit suite off production handlers that merely mention a route.
+func isRustTestFile(path, source string) bool {
+	lp := strings.ToLower(filepath.ToSlash(path))
+	if !strings.HasSuffix(lp, ".rs") {
+		return false
+	}
+	if strings.Contains(lp, "/tests/") {
+		return true
+	}
+	return strings.Contains(source, "#[cfg(test)]") ||
+		strings.Contains(source, "#[test]") ||
+		strings.Contains(source, "#[tokio::test]") ||
+		strings.Contains(source, "#[actix_web::test]") ||
+		strings.Contains(source, "#[actix_rt::test]") ||
+		strings.Contains(source, "#[async_std::test]")
+}
+
+// rustTestSuiteBaseName derives a suite label from the test file path
+// (`.../users_api_test.rs` → `users_api_test`).
+func rustTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/custom/rust/tests_route_e2e_test.go
+++ b/internal/custom/rust/tests_route_e2e_test.go
@@ -1,0 +1,163 @@
+package rust
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// runRustRouteE2E runs the extractor and returns the captured e2e_route_calls
+// property (empty string when no suite emitted).
+func runRustRouteE2E(t *testing.T, path, src string) string {
+	t.Helper()
+	e := &rustTestRouteE2EExtractor{}
+	ents, err := e.Extract(context.Background(), extractor.FileInput{
+		Path: path, Language: "rust", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) == 0 {
+		return ""
+	}
+	if ents[0].Subtype != "test_suite" {
+		t.Fatalf("expected test_suite, got %q", ents[0].Subtype)
+	}
+	return ents[0].Properties["e2e_route_calls"]
+}
+
+func TestRustRouteE2E_ActixTestRequest(t *testing.T) {
+	src := `
+#[actix_web::test]
+async fn test_get_counts() {
+    let app = test::init_service(App::new().configure(routes)).await;
+    let req = test::TestRequest::get().uri("/api/v1/x/get_counts").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+}
+
+#[actix_web::test]
+async fn test_create_item() {
+    let app = test::init_service(App::new().configure(routes)).await;
+    let req = test::TestRequest::post().uri("/api/v1/x/items").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+}
+`
+	got := runRustRouteE2E(t, "tests/x_api_test.rs", src)
+	if !strings.Contains(got, "GET /api/v1/x/get_counts") || !strings.Contains(got, "POST /api/v1/x/items") {
+		t.Fatalf("Actix TestRequest routes not captured: %q", got)
+	}
+}
+
+func TestRustRouteE2E_ActixWithURIMethod(t *testing.T) {
+	src := `
+#[actix_web::test]
+async fn test_delete() {
+    let req = test::TestRequest::with_uri("/api/v1/x/1").method(Method::DELETE).to_request();
+    let _ = test::call_service(&app, req).await;
+}
+`
+	got := runRustRouteE2E(t, "tests/x_api_test.rs", src)
+	if !strings.Contains(got, "DELETE /api/v1/x/1") {
+		t.Fatalf("Actix with_uri/method route not captured: %q", got)
+	}
+}
+
+func TestRustRouteE2E_AxumOneshot(t *testing.T) {
+	src := `
+#[tokio::test]
+async fn test_axum() {
+    let app = router();
+    let resp = app
+        .oneshot(Request::get("/api/v1/users/1").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_axum_post() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/users")
+        .body(Body::from(payload))
+        .unwrap();
+    let _ = app.oneshot(req).await.unwrap();
+}
+`
+	got := runRustRouteE2E(t, "tests/users_test.rs", src)
+	if !strings.Contains(got, "GET /api/v1/users/1") || !strings.Contains(got, "POST /api/v1/users") {
+		t.Fatalf("Axum oneshot routes not captured: %q", got)
+	}
+}
+
+func TestRustRouteE2E_RocketDispatch(t *testing.T) {
+	src := `
+#[test]
+fn test_index() {
+    let client = Client::tracked(rocket()).unwrap();
+    let response = client.get("/api/v1/index").dispatch();
+    assert_eq!(response.status(), Status::Ok);
+}
+
+#[test]
+fn test_create() {
+    let client = Client::tracked(rocket()).unwrap();
+    let response = client.post("/api/v1/items").dispatch();
+    assert_eq!(response.status(), Status::Created);
+}
+`
+	got := runRustRouteE2E(t, "tests/rocket_test.rs", src)
+	if !strings.Contains(got, "GET /api/v1/index") || !strings.Contains(got, "POST /api/v1/items") {
+		t.Fatalf("Rocket dispatch routes not captured: %q", got)
+	}
+}
+
+func TestRustRouteE2E_ReqwestTestServer(t *testing.T) {
+	src := `
+#[tokio::test]
+async fn test_reqwest() {
+    let addr = spawn_app().await;
+    let client = reqwest::Client::new();
+    let resp = client.get(format!("{}/api/v1/health", addr)).send().await.unwrap();
+    assert!(resp.status().is_success());
+}
+`
+	got := runRustRouteE2E(t, "tests/health_test.rs", src)
+	if !strings.Contains(got, "GET /api/v1/health") {
+		t.Fatalf("reqwest test-server route not captured: %q", got)
+	}
+}
+
+// Negative: a production handler file (not a test, no test attribute) that
+// merely mentions a route string must NOT emit a suite.
+func TestRustRouteE2E_NonTestFileNoSuite(t *testing.T) {
+	src := `
+async fn handler() -> impl Responder {
+    HttpResponse::Ok().json("/api/v1/x")
+}
+`
+	got := runRustRouteE2E(t, "src/handlers.rs", src)
+	if got != "" {
+		t.Fatalf("expected no suite for production file, got %q", got)
+	}
+}
+
+// Negative: variable-only routes (no literal path) are dropped.
+func TestRustRouteE2E_VariableRouteDropped(t *testing.T) {
+	src := `
+#[tokio::test]
+async fn test_dynamic() {
+    let path = build_path();
+    let resp = client.get(path).send().await.unwrap();
+    let _ = resp;
+}
+`
+	got := runRustRouteE2E(t, "tests/dyn_test.rs", src)
+	if got != "" {
+		t.Fatalf("expected no routes for variable-only URL, got %q", got)
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4749_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4749_test.go
@@ -1,0 +1,97 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Rust route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/rust"
+)
+
+// Issue #4749 LIVE-REPRO (resolve side) — Rust Actix / Axum / Rocket route-hit
+// tests. Proves end-to-end that a Rust test calling a route by string
+// (`test::TestRequest::get().uri("/p")` + call_service, `app.oneshot(Request::
+// get("/p"))`, `client.get("/p").dispatch()`) links to the
+// http_endpoint_definition it exercises — the Rust slice of the all-language
+// program (#4615/#4749). The shared linkE2ERouteTestsToEndpoints pass is
+// language-agnostic; only the Rust route capture is new.
+
+const rustActixTestSrc4749 = `
+#[actix_web::test]
+async fn get_counts() {
+    let app = test::init_service(App::new().configure(routes)).await;
+    let req = test::TestRequest::get().uri("/api/v1/x/get_counts").to_request();
+    let _ = test::call_service(&app, req).await;
+}
+#[actix_web::test]
+async fn create_item() {
+    let app = test::init_service(App::new().configure(routes)).await;
+    let req = test::TestRequest::post().uri("/api/v1/x/items").to_request();
+    let _ = test::call_service(&app, req).await;
+}
+`
+
+const rustAxumTestSrc4749 = `
+#[tokio::test]
+async fn get_counts() {
+    let resp = app.oneshot(Request::get("/api/v1/x/get_counts").body(Body::empty()).unwrap()).await.unwrap();
+    let _ = resp;
+}
+#[tokio::test]
+async fn create_item() {
+    let req = Request::builder().method(Method::POST).uri("/api/v1/x/items").body(Body::empty()).unwrap();
+    let _ = app.oneshot(req).await.unwrap();
+}
+`
+
+func TestIssue4749_RustActixE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/x/get_counts"),
+		def("POST", "/api/v1/x/items"),
+	}
+	suite := realSuite(t, "custom_rust_tests_route_e2e",
+		"tests/x_controller_test.rs", "rust", rustActixTestSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertRustRouteEdges(t, edgeTargets(afterOut))
+}
+
+func TestIssue4749_RustAxumE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/x/get_counts"),
+		def("POST", "/api/v1/x/items"),
+	}
+	suite := realSuite(t, "custom_rust_tests_route_e2e",
+		"tests/x_routes_test.rs", "rust", rustAxumTestSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertRustRouteEdges(t, edgeTargets(afterOut))
+}
+
+func assertRustRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/x/get_counts") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/x/items") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /api/v1/x/get_counts; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /api/v1/x/items; targets=%v", targets)
+	}
+}

--- a/internal/substrate/effect_sinks_cross_orm_read_4692_test.go
+++ b/internal/substrate/effect_sinks_cross_orm_read_4692_test.go
@@ -246,3 +246,70 @@ func (r *OrderRepo) GetOrder(id int) Order {
 	by := groupByEffect(sniffEffectsGo(src))
 	mustHave(t, by, EffectDBRead, "GetOrder")
 }
+
+// ------------------------------------------------------ Rust / Diesel + sea-orm
+
+// A: ambiguous Diesel/sea-orm terminals (.first/.filter/.all/.one/.find) on a
+// query/table/Entity-typed receiver are db_read (#4737). Covers the inline
+// `users::table.filter(...).first(conn)` root form, a query-typed local, a
+// sea-orm `Entity::find()` chain, and a propagated `let q2 = q.filter(...)`.
+func TestRustDieselSeaOrmTypedRead_4737(t *testing.T) {
+	src := `
+impl UserRepository {
+    pub fn get_active(&self, conn: &mut PgConnection) -> Vec<User> {
+        users::table.filter(users::active.eq(true)).load(conn).unwrap()
+    }
+    pub fn newest(&self, conn: &mut PgConnection) -> User {
+        users::table.filter(users::id.eq(1)).first(conn).unwrap()
+    }
+    pub fn list_typed(&self, conn: &mut PgConnection) -> Vec<User> {
+        let q = users::table;
+        let q2 = q.filter(users::active.eq(true));
+        q2.all(conn)
+    }
+    pub async fn seaorm_one(&self, db: &DatabaseConnection) -> Option<User> {
+        let q = User::find();
+        q.filter(user::Column::Active.eq(true)).one(db).await.unwrap()
+    }
+    pub async fn seaorm_inline(&self, db: &DatabaseConnection) -> Vec<User> {
+        User::find().filter(user::Column::Active.eq(true)).all(db).await.unwrap()
+    }
+}
+`
+	by := groupByEffect(sniffEffectsRust(src))
+	mustHave(t, by, EffectDBRead, "get_active")
+	mustHave(t, by, EffectDBRead, "newest")
+	mustHave(t, by, EffectDBRead, "list_typed")
+	mustHave(t, by, EffectDBRead, "seaorm_one")
+	mustHave(t, by, EffectDBRead, "seaorm_inline")
+}
+
+// B (negative): the same verbs on a plain Vec/slice/iterator (Iterator
+// combinators) stay pure — the #4737 over-credit guard.
+func TestRustIteratorNoFalsePositive_4737(t *testing.T) {
+	src := `
+pub fn pick(items: Vec<Item>, names: &[String]) -> Option<Item> {
+    let head = items.first();
+    let found = items.iter().filter(|x| x.ok).find(|x| x.id == 1);
+    let mapped: Vec<_> = items.iter().map(|x| x.id).collect();
+    let any_ok = items.iter().all(|x| x.ok);
+    let one = names.iter().find(|n| n.len() > 0);
+    found.cloned()
+}
+`
+	by := groupByEffect(sniffEffectsRust(src))
+	mustNotHave(t, by, EffectDBRead, "pick")
+}
+
+// C: thin repo read method carries the db_read sink for the CALLS-union to lift.
+func TestRustRepoReadChainSink_4737(t *testing.T) {
+	src := `
+impl OrderRepository {
+    pub fn get_order(&self, conn: &mut PgConnection, id: i32) -> Order {
+        orders::table.filter(orders::id.eq(id)).first(conn).unwrap()
+    }
+}
+`
+	by := groupByEffect(sniffEffectsRust(src))
+	mustHave(t, by, EffectDBRead, "get_order")
+}

--- a/internal/substrate/effect_sinks_rust.go
+++ b/internal/substrate/effect_sinks_rust.go
@@ -7,8 +7,13 @@
 //     ureq::get/post, isahc::<verb>
 //   - db_read   : sqlx `query!` / `query_as!` / `query / query_as`
 //     with SELECT-shaped SQL or fetch_*, Diesel `.load /
-//     .first / .get_result / .get_results / .find / .filter
-//     ... .load`, sea-orm `.find / .find_by_id / .all / .one`
+//     .get_result / .get_results`, sea-orm relation loaders
+//     (`.find_by_id / .find_also_related / .stream / .paginate`);
+//     the AMBIGUOUS terminals (`.first / .find / .filter /
+//     .select / .all / .one`) that collide with `Iterator`
+//     combinators are credited ONLY on a Diesel-query / sea-orm
+//     `Select`-typed receiver (#4737, so `vec.iter().filter(...)`
+//     stays pure) — see rustQueryReadMatches
 //   - db_write  : sqlx `execute / fetch_one` on INSERT/UPDATE/DELETE,
 //     Diesel `.insert_into / .update / .delete / .execute`,
 //     sea-orm `.insert / .update / .delete / .save`
@@ -45,13 +50,68 @@ var rustHTTPRe = regexp.MustCompile(
 		`|\.\s*send\s*\(\s*\)\s*\.\s*await\b`,
 )
 
-// rustDBReadRe matches sqlx / Diesel / sea-orm read primitives.
+// rustDBReadRe matches the DISTINCTIVE sqlx / Diesel / sea-orm read primitives
+// — names that do NOT collide with the Rust `Iterator` combinators on a plain
+// Vec/slice/iterator, so they are safe to bare-match on ANY receiver (#4737):
+//   - sqlx `query!`/`query_as!`/`query_scalar!` macros and the `.fetch_*`
+//     terminals (`fetch_all`/`fetch_one`/`fetch_optional`/`fetch`),
+//   - Diesel `diesel::select`/`diesel::sql_query` and the loader terminals
+//     `.load`/`.get_result`/`.get_results` plus relation helpers,
+//   - sea-orm relation loaders `.find_by_id`/`.find_also_related`/
+//     `.find_with_related`/`.stream`/`.paginate`.
+//
+// The AMBIGUOUS terminals (`.first`/`.find`/`.filter`/`.select`/`.all`/`.one`,
+// the query shapers `.order`/`.group_by`/`.limit`/`.offset`/`.inner_join`/
+// `.left_join`/`.on`) are NOT here — they collide with `Iterator`
+// (`vec.iter().filter(...).find(...)`, `slice.first()`, `it.map(...).all(...)`),
+// which would be a false db_read. They are credited ONLY on a Diesel-query /
+// sea-orm `Select`/`Entity`-typed receiver by rustQueryReadMatches (#4737
+// receiver-typed read credit, mirroring the Python #4691 / C# #4692 model).
 var rustDBReadRe = regexp.MustCompile(
 	`\bsqlx\s*::\s*query(?:_as|_scalar)?(?:_unchecked)?\s*[!\(]` +
 		`|\.\s*(?:fetch_all|fetch_one|fetch_optional|fetch)\s*\(` +
 		`|\bdiesel\s*::\s*(?:select|sql_query)\b` +
-		`|\.\s*(?:load|first|get_result|get_results|find|filter|select|order|group_by|limit|offset|inner_join|left_join|on)\s*\(` +
-		`|\.\s*(?:find_by_id|find_also_related|find_with_related|all|one|stream|paginate)\s*\(`,
+		`|\.\s*(?:load|get_result|get_results)\s*\(` +
+		`|\.\s*(?:find_by_id|find_also_related|find_with_related|stream|paginate)\s*\(`,
+)
+
+// --- #4737 Diesel / sea-orm receiver-typed read credit (ambiguous terminals) ---
+//
+// The terminals below collide with the Rust `Iterator` combinators on a plain
+// Vec/slice/iterator (`vec.iter().filter(...).find(...)`, `slice.first()`,
+// `it.map(...).all(...)`), so they are credited db_read ONLY when the receiver
+// is known to hold a Diesel query (`users::table`, `.into_boxed()`, a
+// `QueryDsl` chain) or a sea-orm `Select`/`Entity` (`User::find()`). On any
+// other receiver they stay pure, preserving the false-positive guard.
+const rustAmbiguousQueryVerbs = `first|find|filter|select|all|one|order|order_by|group_by|limit|offset|inner_join|left_join|on`
+
+// rustQueryTypedRe seeds the set of Diesel-query / sea-orm-typed receiver names
+// from the recurring query-root forms. Group 1 captures the typed local name:
+//   - `let q = users::table;`                       (Diesel schema table root)
+//   - `let q = users::table.filter(...)...;`        (Diesel QueryDsl chain root)
+//   - `let q = posts::table.into_boxed();`          (Diesel boxed query)
+//   - `let q = User::find();` / `let q = User::find().filter(...);`  (sea-orm)
+//   - `let q: Select<User> = ...;` / `let q: BoxedQuery<...> = ...;` (annotation)
+var rustQueryTypedRe = regexp.MustCompile(
+	`(?m)\blet\s+(?:mut\s+)?([A-Za-z_]\w*)\s*` +
+		`(?::\s*(?:Select|SelectTwo|BoxedQuery|BoxedSelectStatement|SelectStatement|FindStatement)\b[^=]*)?` +
+		`=\s*(?:` +
+		`[A-Za-z_]\w*\s*::\s*table\b` + // Diesel: schema::table[. … ]
+		`|[A-Za-z_]\w*\s*::\s*find\s*\(` + // sea-orm: Entity::find(
+		`|[A-Za-z_]\w*\s*::\s*find_by_id\s*\(` + // sea-orm: Entity::find_by_id(
+		`)`,
+)
+
+// rustQueryRootInlineRe credits an ambiguous terminal invoked DIRECTLY off a
+// query root inline — `users::table.filter(...)`, `User::find().all(&db)`,
+// `posts::table.order(id).first(conn)`. The root must be a Diesel `schema::table`
+// or a sea-orm `Entity::find(...)`; the terminal must be the ambiguous set
+// (distinctive terminals are already covered bare by rustDBReadRe). A leading
+// `\b` keeps `something.users::table` (impossible) and plain `vec.filter` out.
+var rustQueryRootInlineRe = regexp.MustCompile(
+	`\b[A-Za-z_]\w*\s*::\s*(?:table\b|find(?:_by_id)?\s*\([^;]*?\))` +
+		`(?:\s*\.\s*[A-Za-z_]\w*\s*\([^;]*?\))*?` +
+		`\s*\.\s*(?:` + rustAmbiguousQueryVerbs + `)\s*\(`,
 )
 
 // rustSqlxSelectRe matches sqlx `query!("SELECT ...")` literals.
@@ -105,6 +165,7 @@ func sniffEffectsRust(content string) []EffectMatch {
 	var out []EffectMatch
 	out = appendRustMatches(out, content, headers, rustHTTPRe, EffectHTTPOut, "reqwest/hyper/surf", 1.0)
 	out = appendRustMatches(out, content, headers, rustDBReadRe, EffectDBRead, "sqlx/diesel/sea-orm.read", 0.85)
+	out = append(out, rustQueryReadMatches(content, headers)...)
 	out = appendRustMatches(out, content, headers, rustSqlxSelectRe, EffectDBRead, "sqlx::query!(SELECT)", 1.0)
 	out = appendRustMatches(out, content, headers, rustDBWriteRe, EffectDBWrite, "sqlx/diesel/sea-orm.write", 0.85)
 	out = appendRustMatches(out, content, headers, rustSqlxWriteRe, EffectDBWrite, "sqlx::query!(WRITE)", 1.0)
@@ -113,6 +174,75 @@ func sniffEffectsRust(content string) []EffectMatch {
 	out = appendRustMatches(out, content, headers, rustProcessRe, EffectFSWrite, "process::Command", 0.9)
 	out = appendRustMatches(out, content, headers, rustMutationRe, EffectMutation, "self.field=", 0.7)
 	return out
+}
+
+// rustQueryReadMatches implements the #4737 receiver-typed read credit for
+// Diesel / sea-orm. It (1) collects the set of Diesel-query / sea-orm-typed
+// receiver names (locals assigned from a `schema::table` root, an `Entity::find`
+// call, or a typed annotation, propagated across `let q2 = q.filter(...)` chains
+// to a fixpoint), then (2) emits db_read for each ambiguous terminal invoked on
+// one of those typed names, AND for ambiguous terminals chained directly off a
+// query root inline (`users::table.filter(...).first(conn)`). An ambiguous
+// terminal on an UNTYPED receiver (a plain Vec/slice/iterator) earns no credit —
+// the Iterator-combinator false-positive guard is preserved.
+func rustQueryReadMatches(content string, headers []funcHeader) []EffectMatch {
+	typed := collectRustQueryTypedNames(content)
+	var out []EffectMatch
+	emit := func(off int) {
+		line := lineOfOffset(content, off)
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     EffectDBRead,
+			Sink:       "diesel/sea-orm.read.query",
+			Confidence: 0.85,
+		})
+	}
+	for name := range typed {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\s*\.\s*(?:` + rustAmbiguousQueryVerbs + `)\s*\(`)
+		for _, m := range re.FindAllStringIndex(content, -1) {
+			emit(m[0])
+		}
+	}
+	for _, m := range rustQueryRootInlineRe.FindAllStringIndex(content, -1) {
+		emit(m[0])
+	}
+	return out
+}
+
+// collectRustQueryTypedNames returns the set of names known to hold a Diesel
+// query / sea-orm Select. Seeds from rustQueryTypedRe (schema::table root,
+// Entity::find call, typed annotation), then iterates the
+// `let <dst> = <src>.<query-op>(...)` form to a fixpoint so a query bound from an
+// already-typed receiver (`let q2 = q.filter(...)`) is itself typed.
+func collectRustQueryTypedNames(content string) map[string]bool {
+	typed := map[string]bool{}
+	for _, m := range rustQueryTypedRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 && m[1] != "" {
+			typed[m[1]] = true
+		}
+	}
+	// Fixpoint: `let <dst> = <src>.<query-op>(...)` where <src> is typed.
+	chainRe := regexp.MustCompile(
+		`(?m)\blet\s+(?:mut\s+)?([A-Za-z_]\w*)\s*=\s*([A-Za-z_]\w*)\s*\.\s*` +
+			`(?:filter|select|order|order_by|group_by|limit|offset|inner_join|left_join|into_boxed|distinct|for_update)\b`)
+	chains := chainRe.FindAllStringSubmatch(content, -1)
+	for {
+		changed := false
+		for _, m := range chains {
+			if len(m) < 3 {
+				continue
+			}
+			if typed[m[2]] && !typed[m[1]] {
+				typed[m[1]] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return typed
 }
 
 func scanRustFuncHeaders(content string) []funcHeader {


### PR DESCRIPTION
Implements the **Rust slice of coverage-linkage (#4749)** and the **Rust Diesel/sea-orm read-sink fix (#4737)** in one PR (both touch Rust extraction).

## PART 1 — coverage-linkage (#4749, Rust slice of epic #4615)
Probe: Rust HAS web-endpoint support in the graph (`internal/custom/rust/{actix_web,axum,rocket}.go` emit `SCOPE.Operation` endpoint entities) AND a test framework (`rustTestRE` in `frameworks.go`: `#[test]`/`#[tokio::test]`/`#[actix_web::test]` NAMED fns). So linkage is **applicable**.

New `custom_rust_tests_route_e2e` extractor (`internal/custom/rust/tests_route_e2e.go`), mirroring Go httptest (#4371) / Kotlin (#4687): emits ONE `test_suite` per Rust test file driving an endpoint by route string, stamping `e2e_route_calls`. The shared language-agnostic `linkE2ERouteTestsToEndpoints` pass (reused unchanged) emits the endpoint TESTS edge. Idioms captured:
- **Actix** `test::TestRequest::<verb>().uri("/p")` + `with_uri("/p").method(Method::X)` → `call_service`
- **Axum/tower** `app.oneshot(Request::<verb>("/p"))` / `Request::builder().method(Method::X).uri("/p")`
- **Rocket** `client.<verb>("/p").dispatch()`
- **reqwest** test-server `client.<verb>(format!("{}/p", addr))` (placeholder-path recovery)

Rust tests are NAMED fns → **no closure scope-owner needed** (like Go/Java). Local-variable handler-receiver typing is recorded **N/A** honestly: Rust handlers are free functions wired into a router by path, not constructed/called in-test, so route-hit linkage is the dominant (and here, sole) mechanism. Variable-only routes dropped (honest exclusion).

## PART 2 — #4737 Diesel/sea-orm read-sink gating
Generalizes the #4691/#4692 receiver-typed read credit. The ambiguous terminals (`.first/.find/.filter/.select/.all/.one` + `.order/.limit/.offset/.*join`) that collide with Rust `Iterator` combinators are split out of bare `rustDBReadRe` and credited `db_read` **only on a query/table/Entity-typed receiver** (Diesel `schema::table` root, `.into_boxed()`/`QueryDsl` chain, sea-orm `Entity::find()`) — propagated across `let q2 = q.filter(...)` chains to a fixpoint, plus inline-root matching (`users::table.filter(...).first(conn)`). The distinctive terminals (`sqlx::query!`, `.fetch_*`, `diesel::select/sql_query`, `.load/.get_result(s)`, `.find_by_id/.stream/.paginate`) stay bare on any receiver.

## Fixtures (RED→GREEN)
- Linkage: Actix + Axum route-hit tests → TESTS edge to the endpoint (`http_endpoint_e2e_testmap_4749_test.go`); extractor unit tests for all 4 idioms + negatives (`tests_route_e2e_test.go`).
- Read: `users::table.filter(...).load(conn)` / sea-orm `User::find().filter(...).all(db)` → `db_read`; `vec.iter().filter(...).find(...)` / `slice.first()` → **pure** (negative). `effect_sinks_cross_orm_read_4692_test.go`.

## Coverage docs (surgical, `coverage fmt --check` ✅)
- `tests_linkage` actix/axum/rocket → **full**
- `db_effect` read-gating note + test cite across all Rust web frameworks (kept **partial** — honest, read precision improved not full coverage)

## Gates (all green)
`go build ./...`, `go vet`, `go test ./internal/{extractors,custom,substrate,engine,graph,types}/...`, `coverage fmt --check`.

Closes #4737
Part of #4749

🤖 Generated with [Claude Code](https://claude.com/claude-code)