### PR TITLE
fix(coverage): repair registry/map INTEGRITY so coverage validate passes (#4722, #4754 dup-keys)

### DIFF
--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -8077,6 +8077,16 @@ records:
 
   lang.rust.framework.axum:
     capabilities:
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         error_flow:
           status: full
@@ -8134,15 +8144,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -8756,6 +8757,16 @@ records:
 
   lang.rust.framework.actix:
     capabilities:
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -8801,15 +8812,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -9036,6 +9038,16 @@ records:
             - file: internal/custom/rust/minor_fw_routing_test.go
           issues_implemented: ["3410"]
           verified_at: "2026-05-30"
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -9081,15 +9093,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -9282,6 +9285,16 @@ records:
             - file: internal/custom/rust/minor_fw_routing_test.go
           issues_implemented: ["3410"]
           verified_at: "2026-05-30"
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -9327,15 +9340,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -9527,6 +9531,16 @@ records:
             - file: internal/custom/rust/minor_fw_routing_test.go
           issues_implemented: ["3410"]
           verified_at: "2026-05-30"
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -9572,15 +9586,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -9760,6 +9765,16 @@ records:
 
   lang.rust.framework.rocket:
     capabilities:
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -9805,15 +9820,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -10032,6 +10038,16 @@ records:
             - file: internal/custom/rust/minor_fw_routing_test.go
           issues_implemented: ["3410"]
           verified_at: "2026-05-30"
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -10077,15 +10093,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -10277,6 +10284,16 @@ records:
             - file: internal/custom/rust/minor_fw_routing_test.go
           issues_implemented: ["3410"]
           verified_at: "2026-05-30"
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -10322,15 +10339,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -10523,6 +10531,16 @@ records:
             - file: internal/custom/rust/minor_fw_routing_test.go
           issues_implemented: ["3410"]
           verified_at: "2026-05-30"
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -10568,15 +10586,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -10768,6 +10777,16 @@ records:
             - file: internal/custom/rust/minor_fw_routing_test.go
           issues_implemented: ["3410"]
           verified_at: "2026-05-30"
+      Data:
+        db_effect:
+          status: partial
+          symbols:
+            - file: internal/substrate/effect_sinks_rust.go
+              functions: [sniffEffectsRust, appendRustMatches]
+            - file: internal/links/effect_propagation.go
+              functions: [runEffectPropagationPass, stampEffectProperties]
+          issues_implemented: ["2765"]
+          verified_at: "2026-05-28"
       Substrate:
         constant_propagation:
           status: full
@@ -10813,15 +10832,6 @@ records:
             - file: internal/mcp/dead_code.go
               functions: [handleDeadCode, computeDeadCodeLive, computeDeadCodeFromEntry, bfsLive]
           issues_implemented: ["2767"]
-          verified_at: "2026-05-28"
-        db_effect:
-          status: partial
-          symbols:
-            - file: internal/substrate/effect_sinks_rust.go
-              functions: [sniffEffectsRust, appendRustMatches]
-            - file: internal/links/effect_propagation.go
-              functions: [runEffectPropagationPass, stampEffectProperties]
-          issues_implemented: ["2765"]
           verified_at: "2026-05-28"
         http_effect:
           status: partial
@@ -16843,7 +16853,7 @@ records:
           status: full
           symbols:
             - file: internal/custom/python/pytest.go
-              functions: [Extract, extractTestFuncBody]
+              functions: [Extract]
           tests:
             - file: internal/custom/python/extractors_test.go
               functions: [TestCelery_TestsEdges, TestCelery_TestsEdges_Apply, TestCelery_TestsEdges_NoFalsePositive]


### PR DESCRIPTION
## Summary

`coverage validate` errored on `main` with 11 INTEGRITY errors. This PR drives it to **0 errors** with surgical, no-data-loss edits.

### 1. Rust `db_effect` duplicate-key (regression from #4754)
#4754 added `db_effect` under the **Data** group (carrying the richer #4737 cross-ORM read-gating note + the extra `effect_sinks_cross_orm_read_4692_test.go` cite, `verified_at: 2026-06-11`) to 10 Rust web-framework records, while the older `db_effect` under **Substrate** (`verified_at: 2026-05-28`) was left in place. JSON duplicate keys across groups → the per-record unique-capability validator tripped (silent data loss risk):

```
error: records[488] (lang.rust.framework.actix).capabilities[Substrate].db_effect: capability key "db_effect" already declared under group "Data"
... axum, gotham, hyper, poem, rocket, salvo, tide, tower, warp (10 total)
```

**Merge, no data loss:** the Data copy is a *strict superset* of the Substrate copy (cites ⊇, adds the #4737 note, newer `verified_at`), so the merge = drop the stale Substrate copy. Verified byte-identical across all 10 records before removing.

Then moved the matching `capability-map.yaml` `db_effect` mapping from the **Substrate** group into a new **Data** group for the same 10 records — matching the canonical `lang.jsts.framework.*` pattern (db_effect lives under `Data`) so the map's group lines up with the registry.

`lang.rust.framework.tauri` (db_effect still under Substrate in the registry, never moved by #4754) is intentionally **left untouched**.

### 2. Celery cite (#4722)
`capability-map.yaml` → `lang.python.framework.celery` / `tests_edges_via_delay_apply` cited a non-existent `extractTestFuncBody` in `pytest.go`:

```
error: capability-map: records[lang.python.framework.celery].Uncategorized.tests_edges_via_delay_apply: function "extractTestFuncBody" not found in internal/custom/python/pytest.go
```

The #3346 celery `.delay()/.apply()/.apply_async()` TESTS-edge logic was **inlined into `Extract`** during the #4357 test-orphan-collapse refactor (`ptCeleryCallRe` scan, pytest.go). Dropped the stale symbol, leaving `functions: [Extract]`. Covered by `TestCelery_TestsEdges*`.

## Before / After
- **Before:** `coverage validate` → `validation failed: 11 error(s)`
- **After:** `ok: 658 record(s), 9259 warning(s); mapping: 215 record(s)...` — **0 errors**

(The remaining ~9.2k are pre-existing `partial capability has no tracking issue` / `error_flow has no mapping entry` warnings, unrelated to this fix.)

## Gates
- `go build ./...` — OK
- `go test ./tools/coverage/...` — OK
- `coverage fmt --check` — registry.json canonical (re-running `fmt` produces no further diff; no re-serialization blowup)
- `coverage validate` — 0 errors

Diffstat: `registry.json` -50 lines (10×5 stale Substrate blocks), `capability-map.yaml` group move + celery cite.

Closes #4722

🤖 Generated with [Claude Code](https://claude.com/claude-code)