### PR TITLE
feat(crystal): Kemal/Amber/Lucky test→endpoint coverage linkage (#4749)

### DIFF
--- a/internal/custom/crystal/extractors_test.go
+++ b/internal/custom/crystal/extractors_test.go
@@ -1,0 +1,106 @@
+package crystal_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
+)
+
+func fi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestCrystalRouteE2E_Capture proves the spec-kemal route helpers are captured
+// onto a single test_suite's e2e_route_calls property.
+func TestCrystalRouteE2E_Capture(t *testing.T) {
+	src := `
+require "./spec_helper"
+
+describe "Todos" do
+  it "lists" do
+    get "/todos"
+    response.status_code.should eq 200
+  end
+
+  it "shows one" do
+    get "/todos/#{id}"
+  end
+
+  it "creates" do
+    post "/todos"
+  end
+end
+`
+	e, ok := extreg.Get("custom_crystal_tests_route_e2e")
+	if !ok {
+		t.Fatal("custom_crystal_tests_route_e2e not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("spec/todos_spec.cr", "crystal", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("expected exactly 1 test_suite, got %d", len(ents))
+	}
+	rec := ents[0]
+	if rec.Subtype != "test_suite" {
+		t.Errorf("expected test_suite, got %q", rec.Subtype)
+	}
+	calls := rec.Properties["e2e_route_calls"]
+	for _, want := range []string{"GET /todos", "POST /todos"} {
+		if !strings.Contains(calls, want) {
+			t.Errorf("expected route call %q in %q", want, calls)
+		}
+	}
+	// Interpolated route "/todos/#{id}" is truncated to "/todos" (static prefix),
+	// which dedupes against the existing "GET /todos" — so no extra GET line.
+}
+
+// TestCrystalRouteE2E_NonSpecExcluded proves a non-spec file (production route
+// registration) is NOT captured as a test_suite.
+func TestCrystalRouteE2E_NonSpecExcluded(t *testing.T) {
+	src := `
+require "kemal"
+get "/todos" do |env|
+  Todo.all.to_json
+end
+`
+	e, _ := extreg.Get("custom_crystal_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("src/routes.cr", "crystal", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a non-spec file, got %d", len(ents))
+	}
+}
+
+// TestCrystalRouteE2E_ShapeOnlySpecExcluded proves a unit/model spec that never
+// hits a route emits no suite.
+func TestCrystalRouteE2E_ShapeOnlySpecExcluded(t *testing.T) {
+	src := `
+describe Todo do
+  it "validates title" do
+    todo = Todo.new(title: "")
+    todo.valid?.should be_false
+  end
+end
+`
+	e, _ := extreg.Get("custom_crystal_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("spec/models/todo_spec.cr", "crystal", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a shape-only spec, got %d", len(ents))
+	}
+}
+
+// TestCrystalRouteE2E_WrongLanguageNoop proves the extractor gates on
+// language=="crystal".
+func TestCrystalRouteE2E_WrongLanguageNoop(t *testing.T) {
+	src := `get "/todos"`
+	e, _ := extreg.Get("custom_crystal_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("spec/todos_spec.cr", "ruby", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-crystal language, got %d", len(ents))
+	}
+}

--- a/internal/custom/crystal/tests_route_e2e.go
+++ b/internal/custom/crystal/tests_route_e2e.go
@@ -1,0 +1,198 @@
+// tests_route_e2e.go — Crystal spec → endpoint route-hit linkage.
+//
+// #4749 (the Crystal slice of the coverage-linkage tail epic #4749/#4615;
+// mirrors the Swift/Vapor slice #4755 and the functional Elixir slice #4688).
+// Emits ONE test_suite entity per Crystal spec file that drives an HTTP endpoint
+// by ROUTE STRING via the spec-kemal request helpers (`get "/path"`,
+// `post "/path"`, …), stamping the captured `VERB route` pairs onto the suite's
+// `e2e_route_calls` property (one "VERB route" per line). The shared resolve
+// pass (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index — which, for Crystal, is
+// populated by synthesizeKemalRoutes (#4749) — and emits a TESTS edge to the
+// exact Kemal/Amber/Lucky endpoint exercised, exactly as the Swift, Rust, Java,
+// Ruby, PHP, C# and Elixir slices do for their stacks. The engine pass is
+// language-agnostic (it fires on any test_suite carrying e2e_route_calls), so
+// the only Crystal-specific work here is the spec-kemal route capture.
+//
+// spec-kemal route-driving idioms captured:
+//   - get "/todos"
+//   - post "/todos", body: "...", headers: ...
+//   - delete "/todos/#{id}"
+//
+// The request helper is a top-level verb call with a leading string-literal
+// path. Crystal's `spec` test DSL (`describe "..." do ... it "..." do ... end`)
+// uses ANONYMOUS closure blocks (like Ruby RSpec) — the `it` example body owns
+// no named call-bearing entity — so the route-hit signal is carried by the
+// SUITE-LEVEL test_suite entity emitted here (the scope-owner role), NOT by a
+// per-example operation. This is the Crystal analog of the Ruby #4684 /
+// JS #4680 anonymous-block scope-owner: the test_suite is the owner that carries
+// the e2e_route_calls the engine links from.
+//
+// Local-variable / receiver typing (#4749 part a) is N/A for Crystal coverage
+// linkage: the crystal base extractor names method (def) entities by their BARE
+// name (not `Type.method`), and there is no class-qualified receiver resolver to
+// consume a `receiver_type` stamp on a Crystal CALLS edge — it would be a dead
+// annotation. The honest, working coverage mechanism for Crystal is the
+// route-hit → endpoint linkage in THIS file (route dispatch is keyed by the
+// literal route string, not by an `obj.method()` receiver), exactly as for the
+// functional Elixir and Swift slices. See the coverage-doc note for the recorded
+// N/A rationale.
+//
+// Honest exclusions (no fabricated edges):
+//   - Interpolated / variable routes capture the literal prefix only when a
+//     static string is present; a fully interpolated route (`"#{path}"`) is
+//     dropped.
+//   - Non-request specs (pure model/unit specs that never hit a route) emit no
+//     suite.
+//   - A `get "/x"` appearing OUTSIDE a spec file is left to the producer-side
+//     synthesizer (synthesizeKemalRoutes); this extractor only runs on specs.
+//
+// Registration key: "custom_crystal_tests_route_e2e".
+package crystal
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_crystal_tests_route_e2e", &crystalTestRouteE2EExtractor{})
+}
+
+type crystalTestRouteE2EExtractor struct{}
+
+func (e *crystalTestRouteE2EExtractor) Language() string {
+	return "custom_crystal_tests_route_e2e"
+}
+
+// crystalSpecRouteRE matches a spec-kemal request helper call with a leading
+// string-literal path:
+//
+//	get "/todos"
+//	post "/todos", body: "..."
+//	delete "/todos/#{id}"
+//
+// Anchored at a statement boundary (`^[ \t]*`) so an `obj.get("...")` receiver
+// call is not captured. Capture group 1 is the verb; group 2 is the route
+// literal.
+var crystalSpecRouteRE = regexp.MustCompile(
+	`(?m)^[ \t]*(get|post|put|delete|patch|options|head)\s+"([^"\n\r]*)"`,
+)
+
+func (e *crystalTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "crystal" {
+		return nil, nil
+	}
+	if !isCrystalSpecFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectCrystalSpecRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       crystalSpecSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "crystal",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "spec-kemal",
+			"provenance":      "INFERRED_FROM_CRYSTAL_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	rec.ID = rec.ComputeID()
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectCrystalSpecRouteCalls returns the de-duplicated "VERB route" pairs a
+// spec file drives by route string. Routes are normalised to a leading-slash
+// path; fully-interpolated routes (no static literal) are dropped.
+func collectCrystalSpecRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range crystalSpecRouteRE.FindAllStringSubmatch(source, -1) {
+		verb := strings.ToUpper(m[1])
+		route := normaliseCrystalSpecRoute(m[2])
+		if route == "" {
+			continue
+		}
+		line := verb + " " + route
+		if seen[line] {
+			continue
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	return out
+}
+
+// normaliseCrystalSpecRoute reduces a raw spec-kemal route literal to a path:
+// ensures a single leading slash, drops a query/fragment tail, collapses
+// repeated slashes. A route whose value is entirely a string interpolation
+// (`#{...}`) with no static prefix is dropped (returns ""). Path-param
+// placeholders (`:id`) and casing are preserved (the resolver wildcards
+// templates and compares case-insensitively).
+func normaliseCrystalSpecRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return ""
+	}
+	// Truncate at the first interpolation marker — the static prefix is the
+	// only statically-recoverable part. `"todos/#{id}"` → `/todos`.
+	if i := strings.Index(p, "#{"); i >= 0 {
+		p = p[:i]
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	// A bare "/" after truncation carries no route identity — drop it.
+	if p == "/" {
+		return ""
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// isCrystalSpecFile reports whether path looks like a Crystal spec — a
+// `*_spec.cr` file or a file under a `/spec/` directory. Keeps the route-hit
+// suite off production code that merely registers a route.
+func isCrystalSpecFile(path string) bool {
+	lp := filepath.ToSlash(path)
+	base := filepath.Base(lp)
+	if strings.HasSuffix(base, "_spec.cr") {
+		return true
+	}
+	if strings.Contains(lp, "/spec/") && strings.HasSuffix(lp, ".cr") {
+		return true
+	}
+	return false
+}
+
+// crystalSpecSuiteBaseName derives a suite label from the spec file path
+// (`.../todos_spec.cr` → `todos_spec`).
+func crystalSpecSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4749_crystal_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4749_crystal_test.go
@@ -1,0 +1,69 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Crystal route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
+)
+
+// Issue #4749 LIVE-REPRO (resolve side) — Crystal spec-kemal route-hit tests.
+// Proves end-to-end that a Crystal spec calling a route by string
+// (`get "/path"`, `post "/path"`) links to the http_endpoint_definition it
+// exercises — the Crystal slice of the all-language program (#4615/#4749). The
+// shared linkE2ERouteTestsToEndpoints pass is language-agnostic; only the
+// Crystal route capture is new.
+
+const crystalSpecKemalSrc4749 = `
+require "./spec_helper"
+
+describe "Todos" do
+  it "lists todos" do
+    get "/api/v1/todos"
+    response.status_code.should eq 200
+  end
+
+  it "creates a todo" do
+    post "/api/v1/todos"
+    response.status_code.should eq 201
+  end
+end
+`
+
+func TestIssue4749_CrystalSpecKemalE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/todos"),
+		def("POST", "/api/v1/todos"),
+	}
+	suite := realSuite(t, "custom_crystal_tests_route_e2e",
+		"spec/requests/todos_spec.cr", "crystal", crystalSpecKemalSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertCrystalRouteEdges(t, edgeTargets(afterOut))
+}
+
+func assertCrystalRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/todos") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/todos") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /api/v1/todos; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /api/v1/todos; targets=%v", targets)
+	}
+}

--- a/internal/engine/http_endpoint_kemal.go
+++ b/internal/engine/http_endpoint_kemal.go
@@ -1,0 +1,141 @@
+// http_endpoint_kemal.go — Crystal Kemal / Amber route registration → canonical
+// http_endpoint_definition synthesis (#4749, the Crystal slice of the
+// coverage-linkage tail epic #4749/#4615; mirrors the Swift/Vapor slice #4755).
+//
+// Background
+// ----------
+// The Crystal base extractor (internal/extractors/crystal/extractor.go) is a
+// regex-based structural extractor: it mines classes / modules / defs / macros
+// and CALLS edges, but has NO web-framework awareness — Kemal `get "/path" do`
+// blocks and Amber `routes :web do get "/path", Ctrl, :index end` registrations
+// are not recognised as HTTP endpoints, and no `http_endpoint_definition`
+// entity is ever produced for Crystal. The shared e2e route-test linker
+// (linkE2ERouteTestsToEndpoints, #4351) matches a test's route hit against
+// `http_endpoint_definition` + `path`, so a Crystal route could never be hit by
+// a route-string test. As with Swift/Vapor (#4755), the PRODUCER-side gap has
+// to be closed first.
+//
+// This pass emits one canonical http_endpoint_definition per statically-known
+// Crystal route, in the SAME shape axum / Rocket / Express / Vapor emit, so the
+// existing resolver and the language-agnostic e2e route-test linker light up for
+// Crystal exactly as they do for the flagship stacks.
+//
+// Crystal route syntax
+// --------------------
+// Kemal (the dominant Crystal web framework, Sinatra-like) registers a route
+// with a top-level verb macro taking a single string-literal path and a block:
+//
+//	get "/" do ... end                         → GET /
+//	get "/users/:id" do |env| ... end          → GET /users/{id}
+//	post "/users" do ... end                   → POST /users
+//	delete "/users/:id" { ... }                → DELETE /users/{id}
+//	ws "/socket" do |socket| ... end           → (websocket — not an HTTP verb, skipped)
+//
+// Amber registers routes inside a `routes` pipeline block, mapping a path to a
+// controller + action symbol:
+//
+//	routes :web do
+//	  get "/", HomeController, :index
+//	  post "/users", UsersController, :create
+//	end
+//
+// Both use the Sinatra/Express-style `:name` colon path-parameter convention,
+// canonicalised through FrameworkKemal into the `{param}` form shared with every
+// other framework.
+//
+// Lucky uses one Action CLASS per endpoint with a `route` / `get "/path"` macro
+// DSL inside the class body; the verb+path are statically recoverable from the
+// same top-level-looking `get "/path"` macro the regex below already captures
+// (Lucky's `get "/path"` inside an Action class). The class-scoped Action form
+// without an inline path literal (route derived from the class NAME, e.g.
+// `Users::Index` → `/users`) is NOT statically recoverable here and is a
+// documented honest exclusion.
+//
+// Honest exclusions (no fabricated routes)
+// ----------------------------------------
+//   - Interpolated / variable paths (`get url do`, `get "#{prefix}/x" do`) —
+//     not statically recoverable, dropped.
+//   - `ws "/..."` websocket routes — not an HTTP verb, skipped (the resolver
+//     keys off HTTP verbs; a WS endpoint is a different surface).
+//   - Lucky name-derived Action routes (no inline path literal) — left to the
+//     producer follow-up; route-string linkage covers the inline-path form.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// kemalRouteRe matches a Crystal verb-macro route registration with a leading
+// string-literal path:
+//
+//	get "/users/:id" do ... end
+//	post "/users", UsersController, :create   (Amber controller form)
+//	delete "/users/:id" { ... }
+//
+// The verb macro must appear at a statement boundary (start of line, after
+// optional indentation) so an arbitrary method named `get`/`post` invoked as
+// `obj.get("...")` is NOT misread as a route (that has a `.` receiver before
+// the verb and fails the `^[ \t]*` anchor). Capture group 1 is the verb;
+// group 2 is the path literal.
+var kemalRouteRe = regexp.MustCompile(
+	`(?m)^[ \t]*(get|post|put|delete|patch|options|head)\s+"([^"\n\r]*)"`,
+)
+
+// kemalHasRoute is a fast pre-filter: the file must reference a Crystal web
+// marker (Kemal / Lucky / Amber) AND a verb-macro call to be worth scanning, so
+// we never misfire on arbitrary Crystal code that happens to call a `get`
+// method.
+func kemalHasRoute(content string) bool {
+	if !strings.Contains(content, `get "`) &&
+		!strings.Contains(content, `post "`) &&
+		!strings.Contains(content, `put "`) &&
+		!strings.Contains(content, `delete "`) &&
+		!strings.Contains(content, `patch "`) &&
+		!strings.Contains(content, `options "`) &&
+		!strings.Contains(content, `head "`) {
+		return false
+	}
+	return strings.Contains(content, "Kemal") ||
+		strings.Contains(content, "kemal") ||
+		strings.Contains(content, "Amber") ||
+		strings.Contains(content, "Lucky") ||
+		strings.Contains(content, "Action") ||
+		strings.Contains(content, "routes ") ||
+		strings.Contains(content, "env.") ||
+		strings.Contains(content, "HTTP::")
+}
+
+// synthesizeKemalRoutes scans a Crystal source file for Kemal / Amber / Lucky
+// route registrations and emits one http_endpoint_definition per statically-
+// known (verb, path).
+func synthesizeKemalRoutes(content string, emit emitFn) {
+	if !kemalHasRoute(content) {
+		return
+	}
+	for _, m := range kemalRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		raw := strings.TrimSpace(m[2])
+		// Drop interpolated / empty literals — not statically recoverable.
+		if raw == "" || strings.Contains(raw, "#{") {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkKemal, raw)
+		if canonical == "" {
+			continue
+		}
+		// Handler kind "Controller" maps to SCOPE.Operation in the resolver,
+		// the kind Crystal defs land as — matching the axum/vapor convention so
+		// ResolveHTTPEndpointHandlers can bind a handler IMPLEMENTS edge when a
+		// same-named handler exists (no name forces a handler when absent).
+		emit(verb, canonical, "kemal", "Controller", "")
+	}
+}

--- a/internal/engine/http_endpoint_kemal_test.go
+++ b/internal/engine/http_endpoint_kemal_test.go
@@ -1,0 +1,163 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestKemal_BasicRoute covers the common Kemal controller shape:
+// get "/todos" do ... end / post "/todos" do ... end.
+func TestKemal_BasicRoute(t *testing.T) {
+	src := `
+require "kemal"
+
+get "/todos" do |env|
+  Todo.all.to_json
+end
+
+post "/todos" do |env|
+  Todo.create(env.params.json)
+end
+
+Kemal.run
+`
+	ids, _ := runDetect(t, "crystal", "src/routes.cr", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos",
+		"http:POST:/todos",
+	}, "kemal-basic-route")
+}
+
+// TestKemal_PathParam covers the Sinatra-style `:param` dynamic segment:
+// get "/todos/:id" → GET /todos/{id}.
+func TestKemal_PathParam(t *testing.T) {
+	src := `
+require "kemal"
+
+get "/todos/:id" do |env|
+  Todo.find(env.params.url["id"]).to_json
+end
+
+delete "/todos/:id" do |env|
+  Todo.delete(env.params.url["id"])
+end
+`
+	ids, _ := runDetect(t, "crystal", "src/todos.cr", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos/{id}",
+		"http:DELETE:/todos/{id}",
+	}, "kemal-path-param")
+}
+
+// TestKemal_AmberControllerForm covers the Amber `routes` block registration
+// where the verb macro carries a controller + action after the path literal:
+// get "/users", UsersController, :index → GET /users.
+func TestKemal_AmberControllerForm(t *testing.T) {
+	src := `
+Amber::Server.configure do
+  routes :web do
+    get "/users", UsersController, :index
+    post "/users/:id", UsersController, :update
+  end
+end
+`
+	ids, _ := runDetect(t, "crystal", "config/routes.cr", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users",
+		"http:POST:/users/{id}",
+	}, "amber-controller-form")
+}
+
+// TestKemal_InterpolatedRouteDropped is the honest-exclusion guard: a route
+// whose path is a string interpolation with no static prefix must NOT forge an
+// endpoint.
+func TestKemal_InterpolatedRouteDropped(t *testing.T) {
+	src := `
+require "kemal"
+
+get "#{base_path}" do |env|
+  "dynamic"
+end
+`
+	ids, _ := runDetect(t, "crystal", "src/dynamic.cr", src)
+	for _, id := range ids {
+		if id == "http:GET:/" || id == "http:GET:" {
+			t.Fatalf("interpolated route must not synthesize an endpoint; got %v", ids)
+		}
+	}
+}
+
+// TestKemal_NonWebFileIgnored is the negative guard: a Crystal file that calls a
+// method named `get` on a receiver (a cache/hash) but has NO web marker must not
+// be misread as a route.
+func TestKemal_NonWebFileIgnored(t *testing.T) {
+	src := `
+class Cache
+  def lookup(key)
+    @store.get(key)
+  end
+end
+`
+	ids, _ := runDetect(t, "crystal", "src/cache.cr", src)
+	for _, id := range ids {
+		if id == "http:GET:/key" {
+			t.Fatalf("negative: @store.get(key) must not synthesize an endpoint; got %v", ids)
+		}
+	}
+}
+
+// TestKemal_E2ERouteTestLinkage is the end-to-end RED→GREEN proof (#4749
+// validation). A Kemal route GET /todos is represented as an
+// http_endpoint_definition; a spec-kemal test_suite carrying
+// `e2e_route_calls = "GET /todos"` must yield a TESTS edge from the suite to
+// that endpoint via the shared linkE2ERouteTestsToEndpoints pass.
+func TestKemal_E2ERouteTestLinkage(t *testing.T) {
+	def := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:GET:/todos",
+		SourceFile: "src/todos.cr",
+		Language:   "crystal",
+		Properties: map[string]string{
+			"verb":         "GET",
+			"path":         "/todos",
+			"framework":    "kemal",
+			"pattern_type": "http_endpoint_synthesis",
+		},
+	}
+	suite := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		Name:       "todos_spec",
+		SourceFile: "spec/todos_spec.cr",
+		Language:   "crystal",
+		Properties: map[string]string{
+			"framework":       "spec-kemal",
+			"e2e_route_calls": "GET /todos",
+		},
+	}
+
+	merged := []types.EntityRecord{def, suite}
+	resolved, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.E2ERouteTestEdges < 1 {
+		t.Fatalf("expected >=1 e2e route-test edge for Kemal GET /todos; got %d", stats.E2ERouteTestEdges)
+	}
+
+	found := false
+	for i := range resolved {
+		if resolved[i].Name != "todos_spec" {
+			continue
+		}
+		for _, r := range resolved[i].Relationships {
+			if r.Kind == string(types.RelationshipKindTests) &&
+				r.Properties["match_source"] == "e2e_supertest_route" &&
+				r.Properties["route"] == "/todos" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected TESTS edge from todos_spec suite to GET /todos endpoint")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -115,6 +115,12 @@ func synthesisSupportsLanguage(lang string) bool {
 	// client synthesizers run. Files without client markers are no-ops.
 	case "dart", "swift":
 		return true
+	// #4749: Crystal web producer-side route synthesis — Kemal / Amber / Lucky
+	// `get "/path"` verb macros have no compiled YAML rules, so allow Crystal
+	// through for synthesizeKemalRoutes. Files without a Crystal web marker +
+	// verb-macro route are no-ops inside the synthesizer.
+	case "crystal":
+		return true
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
@@ -1273,6 +1279,16 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// (`AF.request("...", method: .post)`). Emits outbound
 		// http_endpoint_call entities + FETCHES edges.
 		synthesizeSwiftClientWithRuntime(string(content), emitClientRuntime)
+	case "crystal":
+		// Producer side (#4749): Crystal web route registrations — Kemal
+		// (`get "/users/:id" do ... end`), Amber (`get "/users", Ctrl, :action`
+		// inside a `routes` block) and Lucky (`get "/path"` Action-class macro)
+		// → canonical http_endpoint_definition, in the same shape
+		// axum/Rocket/Express/Vapor emit, so the shared resolver and the e2e
+		// route-test linker (#4351) light up for Crystal. The base crystal
+		// extractor stays structural-only; this pass adds the canonical
+		// definitions the coverage substrate keys off.
+		synthesizeKemalRoutes(string(content), emit)
 	case "yaml", "json":
 		// Producer side (#3628, area #16): OpenAPI 3.x / Swagger 2.0 spec
 		// files declare the HTTP API surface as ground-truth. Each

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -190,6 +190,13 @@ const (
 	// synthesizer joins with `/` before canonicalisation. Canonicalisation
 	// reuses canonicalizeColonParams.
 	FrameworkVapor = "vapor"
+	// FrameworkKemal (#4749) — Crystal web frameworks (Kemal `get "/users/:id"`,
+	// Lucky/Amber `get "/users/:id", Controller, :action`) use the Sinatra/
+	// Express-style `:name` colon-prefixed path parameter convention (Crystal
+	// syntax is Ruby-like). Kemal also accepts a trailing `*` wildcard segment
+	// (`get "/files/*path"`), which the colon walker leaves intact (the segment
+	// matcher wildcards it). Canonicalisation reuses canonicalizeColonParams.
+	FrameworkKemal = "kemal"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -239,7 +246,7 @@ func Canonicalize(framework, raw string) string {
 	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi, FrameworkPhoenix,
 		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails,
 		FrameworkRobyn, FrameworkPlug, FrameworkCowboy,
-		FrameworkLapis, FrameworkOpenResty, FrameworkVapor:
+		FrameworkLapis, FrameworkOpenResty, FrameworkVapor, FrameworkKemal:
 		out = canonicalizeColonParams(raw)
 	default:
 		// Unknown framework: pass through but still normalise slashes.

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -75,6 +75,7 @@ var customPrefixForLanguage = map[string]string{
 	"elixir":  "custom_elixir_",
 	"csharp":  "custom_csharp_",
 	"cpp":     "custom_cpp_",
+	"crystal": "custom_crystal_",
 	// Protocol Buffers IDL files (.proto) are classified as their own
 	// "protobuf" language but carry message/service definitions parsed by the
 	// C/C++ protobuf custom extractor (which path/language-gates internally and

--- a/internal/extractors/custom_registry.go
+++ b/internal/extractors/custom_registry.go
@@ -7,6 +7,7 @@ package extractors
 
 import (
 	_ "github.com/cajasmota/archigraph/internal/custom/cpp"
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
 	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
 	_ "github.com/cajasmota/archigraph/internal/custom/dart"
 	_ "github.com/cajasmota/archigraph/internal/custom/elixir"


### PR DESCRIPTION
## Crystal slice of coverage-linkage tail epic #4749

`#4615` generalized test→endpoint linkage to the 9 flagship stacks. This is the **Crystal** child of the tail epic #4749 (mirrors the Swift/Vapor slice #4755).

### Probe finding
The Crystal base extractor (`internal/extractors/crystal/extractor.go`) is **regex-structural only** — classes/modules/defs/CALLS — with **no web-framework awareness**. Kemal `get "/path" do` blocks, Amber `routes` blocks and Lucky Action macros were never recognised as HTTP endpoints, so **no `http_endpoint_definition` was ever produced for Crystal** and the shared e2e route-test linker (`linkE2ERouteTestsToEndpoints`, #4351) had nothing to bind a route-string test to. The producer-side gap had to be closed first (exactly the Swift/Vapor #4755 situation).

### What landed
- **Producer** — `internal/engine/http_endpoint_kemal.go`: synthesizes one canonical `http_endpoint_definition` per statically-known Crystal route — Kemal (`get "/users/:id" do ... end`), Amber (`get "/users", Ctrl, :action` in a routes block) and Lucky inline-path Action macros — in the same shape axum/Rocket/Express/Vapor emit. Adds `FrameworkKemal` colon-param canonicalisation. Wired into the `crystal` synthesis case + `synthesisSupportsLanguage` gate.
- **Route-hit linkage** — `internal/custom/crystal/tests_route_e2e.go`: emits one `test_suite` per `*_spec.cr` carrying `e2e_route_calls` from spec-kemal request helpers (`get "/path"` / `post "/path"`). The language-agnostic engine pass then emits the `TESTS` edge to the exercised endpoint. Registered under a new `custom_crystal_` dispatch prefix.
- **Scope-owner** — Crystal `spec` uses **anonymous** `describe`/`it` closure blocks (Ruby-like), so the `test_suite` is the scope-owner carrying the route hits (Crystal analog of Ruby #4684 / JS #4680).
- **Coverage docs** — `lang.crystal.framework.kemal` record **added** (none existed) + `Testing.tests_linkage` → **full**, surgically; `coverage fmt --check` passes.

### Honest scope
- **Local-variable/receiver typing (part a) — N/A.** The crystal extractor names defs **bare** (not `Type.method`) with no class-qualified receiver resolver to consume a `receiver_type` stamp, so route-string linkage is the coverage mechanism (mirrors functional Elixir #4688 / Swift #4755).
- `ws "/..."` websocket routes and Lucky **name-derived** (no inline path) Action routes are documented follow-ups.

### Validation (RED→GREEN)
- `TestKemal_BasicRoute` / `_PathParam` / `_AmberControllerForm` / `_InterpolatedRouteDropped` / `_NonWebFileIgnored` — producer synthesis + negatives.
- `TestKemal_E2ERouteTestLinkage` + `TestIssue4749_CrystalSpecKemalE2ERouteTestsLinkToEndpoints` — full synthesize→resolve→link pipeline emits the TESTS edge for `GET`/`POST /todos`.
- `TestCrystalRouteE2E_*` — route capture, non-spec / shape-only / wrong-language exclusions.

### Gates
`go build ./...`, `go vet` (extractors/custom/graph/engine), `go test` (extractors/custom/engine/graph/types) all green; `coverage fmt --check` ok. The 11 remaining `coverage validate` errors (10 rust `db_effect` group-dup + 1 python celery #4722) are **pre-existing on main**, not introduced here.

Part of #4749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)