### PR TITLE
feat(coverage): Clojure test→endpoint coverage-linkage (#4749 child)

### DIFF
--- a/internal/custom/clojure/tests_route_e2e.go
+++ b/internal/custom/clojure/tests_route_e2e.go
@@ -1,0 +1,198 @@
+// Package clojure — Clojure test→endpoint route-hit linkage.
+//
+// #4749 (the Clojure slice of epic #4615, all-framework test→endpoint coverage
+// linkage). Emits ONE test_suite entity per Clojure clojure.test test file that
+// drives an HTTP endpoint by ROUTE STRING via a Ring handler, stamping the
+// captured `VERB route` pairs onto the suite's `e2e_route_calls` property. The
+// shared resolve pass (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then
+// matches each pair against the cross-file http_endpoint_definition index
+// (produced for Clojure by engine.synthesizeClojureRoutes) and emits a TESTS
+// edge to the exact endpoint exercised — exactly as the Elixir/Phoenix, Ruby,
+// PHP, C# and Swift slices do for their stacks. The engine pass is
+// language-agnostic (it fires on any test_suite carrying e2e_route_calls), so
+// the only Clojure-specific work is the route capture.
+//
+// Ring route-driving idioms captured (clojure.test + ring-mock / ring core):
+//
+//	(app (mock/request :get "/todos"))
+//	(app (ring.mock.request/request :post "/users" {...}))
+//	(handler (mock/request :delete "/users/1"))
+//	(app (-> (mock/request :get "/todos")))      ; threaded request builder
+//
+// The first arg to ring-mock's `request` is the HTTP-verb KEYWORD (`:get`,
+// `:post`, …); the second is the string-literal route. peridot/kerodon drive the
+// app the same way under the hood (`(request app "/path" :request-method :get)`)
+// and are captured by the peridot form below.
+//
+// Clojure is FUNCTIONAL: there are no OO receiver objects, so the
+// "local-variable receiver typing" gap (#4680/#4681) does NOT apply — a Ring
+// handler is dispatched by the literal route string carried on the mock request
+// map, not by an `obj.method()` receiver. The route-hit → endpoint linkage IS
+// the coverage mechanism here (mirrors the Elixir #4688 documented N/A).
+//
+// Test scope: clojure.test `(deftest name ...)` forms are NAMED top-level
+// functions already mined by the base extractor's CALLS graph, and `(testing
+// "..." ...)` blocks nest inside them — the route-hit calls live inside the
+// deftest body, so the suite is keyed to the FILE (one suite per test file) the
+// same way the Jest/ExUnit one-suite-per-file model works; no synthetic
+// anonymous-test-block scope owner is needed.
+//
+// Honest exclusion (matches the negative acceptance of the slice):
+//   - Interpolated / built routes (`(mock/request :get (str "/x/" id))`,
+//     `(mock/request :get path)`) — the route is not a string literal and is not
+//     statically recoverable here, so it is dropped.
+//   - Shape-only tests (assert on a value, never hit a route) emit no suite.
+//
+// Registration key: "custom_clojure_tests_route_e2e".
+package clojure
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_clojure_tests_route_e2e", &clojureTestRouteE2EExtractor{})
+}
+
+type clojureTestRouteE2EExtractor struct{}
+
+func (e *clojureTestRouteE2EExtractor) Language() string {
+	return "custom_clojure_tests_route_e2e"
+}
+
+var (
+	// ring-mock / ring.mock.request request builder:
+	//   (mock/request :get "/todos")
+	//   (ring.mock.request/request :post "/users" {...})
+	//   (request :delete "/users/1")
+	// Capture group 1 is the verb keyword (without the leading colon); group 2 is
+	// the string-literal route. The `request` symbol may be namespace-qualified.
+	cljRingMockRequestRE = regexp.MustCompile(
+		`\(\s*(?:[\w.\-]+/)?request\s+:([a-z]+)\s+"([^"\n\r]*)"`)
+
+	// peridot / kerodon session form. The session is threaded in via `->`, so
+	// the `request` call takes the route literal as its FIRST arg (threaded
+	// form) or after an explicit session arg (direct form):
+	//   (-> (session app) (request "/path" :request-method :get))
+	//   (request session "/path" :request-method :get)
+	// The route literal is the first string literal; the verb is the
+	// `:request-method` keyword. An optional non-string session arg is tolerated
+	// before the route literal.
+	cljPeridotRequestRE = regexp.MustCompile(
+		`\(\s*request\s+(?:[\w.\-]+\s+)?"([^"\n\r]*)"[^)]*:request-method\s+:([a-z]+)`)
+)
+
+func (e *clojureTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "clojure" {
+		return nil, nil
+	}
+	if !isClojureTestFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectClojureTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       clojureTestSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "clojure",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "ring",
+			"provenance":      "INFERRED_FROM_CLOJURE_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectClojureTestRouteCalls returns the de-duplicated "VERB route" pairs a
+// clojure.test test file drives by route string (ring-mock and peridot forms).
+// Routes are normalised to a leading-slash path; interpolated / variable /
+// non-literal routes are dropped (honest exclusion).
+func collectClojureTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		route := normaliseClojureTestRoute(rawRoute)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	for _, m := range cljRingMockRequestRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range cljPeridotRequestRE.FindAllStringSubmatch(source, -1) {
+		// peridot capture order is (route, verb).
+		add(m[2], m[1])
+	}
+	return out
+}
+
+// normaliseClojureTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix, drops query/fragment, collapses repeated slashes.
+// Ring path-param placeholders (`:id`) and casing are preserved (the resolver
+// wildcards templates and compares case-insensitively).
+func normaliseClojureTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
+}
+
+// isClojureTestFile reports whether path looks like a clojure.test source — a
+// `*_test.clj`/`*_test.cljc` file or a file under a `/test/` directory. Keeps
+// the route-hit suite off production handlers/routers that merely mention a
+// route. Mirrors the Clojure convention `src/my/ns.clj → test/my/ns_test.clj`.
+func isClojureTestFile(path string) bool {
+	lp := strings.ToLower(filepath.ToSlash(path))
+	if strings.HasSuffix(lp, "_test.clj") || strings.HasSuffix(lp, "_test.cljc") ||
+		strings.HasSuffix(lp, "_test.cljs") {
+		return true
+	}
+	if strings.Contains(lp, "/test/") &&
+		(strings.HasSuffix(lp, ".clj") || strings.HasSuffix(lp, ".cljc") ||
+			strings.HasSuffix(lp, ".cljs")) {
+		return true
+	}
+	return false
+}
+
+// clojureTestSuiteBaseName derives a suite label from the test file path
+// (`.../todo_handler_test.clj` → `todo_handler_test`).
+func clojureTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/custom/clojure/tests_route_e2e_test.go
+++ b/internal/custom/clojure/tests_route_e2e_test.go
@@ -1,0 +1,107 @@
+package clojure
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// #4749 — the Clojure route-hit extractor emits one test_suite per clojure.test
+// file carrying the captured `VERB route` pairs on e2e_route_calls.
+
+func runClojureTestRouteE2E(t *testing.T, path, src string) []string {
+	t.Helper()
+	ext := &clojureTestRouteE2EExtractor{}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Language: "clojure",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	if len(ents) == 0 {
+		return nil
+	}
+	if len(ents) != 1 {
+		t.Fatalf("expected exactly one test_suite, got %d", len(ents))
+	}
+	e := ents[0]
+	if e.Subtype != "test_suite" {
+		t.Fatalf("expected Subtype=test_suite, got %q", e.Subtype)
+	}
+	raw := e.Properties["e2e_route_calls"]
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\n")
+}
+
+func TestClojureTestRouteE2E_RingMock(t *testing.T) {
+	src := `(ns myapp.handler-test
+  (:require [clojure.test :refer [deftest is]]
+            [ring.mock.request :as mock]
+            [myapp.handler :refer [app]]))
+
+(deftest routes
+  (let [r (app (mock/request :get "/todos"))] (is (= 200 (:status r))))
+  (let [r (app (ring.mock.request/request :post "/todos" {:t 1}))] (is (= 201 (:status r))))
+  (let [r (app (mock/request :delete "/todos/:id"))] (is (= 204 (:status r)))))
+`
+	got := runClojureTestRouteE2E(t, "test/myapp/handler_test.clj", src)
+	want := map[string]bool{"GET /todos": true, "POST /todos": true, "DELETE /todos/:id": true}
+	for _, line := range got {
+		delete(want, line)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing route calls %v; got %v", want, got)
+	}
+}
+
+func TestClojureTestRouteE2E_Peridot(t *testing.T) {
+	src := `(ns myapp.session-test
+  (:require [clojure.test :refer [deftest is]]
+            [peridot.core :refer [session request]]))
+
+(deftest health
+  (-> (session app)
+      (request "/health" :request-method :get)))
+`
+	got := runClojureTestRouteE2E(t, "test/myapp/session_test.clj", src)
+	found := false
+	for _, line := range got {
+		if line == "GET /health" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected GET /health from peridot form; got %v", got)
+	}
+}
+
+// Interpolated / built routes are dropped; a non-test file emits nothing.
+func TestClojureTestRouteE2E_HonestExclusion(t *testing.T) {
+	// Built route via (str ...) — not a string literal, dropped.
+	src := `(ns myapp.h-test
+  (:require [clojure.test :refer [deftest is]]
+            [ring.mock.request :as mock]))
+(deftest dyn
+  (let [id 1
+        r (app (mock/request :get (str "/todos/" id)))]
+    (is (= 200 (:status r)))))
+`
+	if got := runClojureTestRouteE2E(t, "test/myapp/h_test.clj", src); len(got) != 0 {
+		t.Fatalf("expected no route calls for built route, got %v", got)
+	}
+	// Non-test file (production handler) must not emit a suite even if it
+	// contains a request literal.
+	prod := `(ns myapp.handler
+  (:require [ring.mock.request :as mock]))
+(def x (mock/request :get "/todos"))
+`
+	if got := runClojureTestRouteE2E(t, "src/myapp/handler.clj", prod); got != nil {
+		t.Fatalf("expected no suite for non-test file, got %v", got)
+	}
+}

--- a/internal/engine/http_endpoint_clojure.go
+++ b/internal/engine/http_endpoint_clojure.go
@@ -1,0 +1,155 @@
+// http_endpoint_clojure.go — Clojure web route registration → canonical
+// http_endpoint_definition synthesis (#4749, the Clojure slice of the
+// coverage-linkage tail epic #4749/#4615).
+//
+// Background
+// ----------
+// The Clojure base extractor (internal/extractors/clojure/clojure.go) emits
+// namespaces, `defn` functions, `deftype` and IMPORTS/CALLS/CONTAINS edges,
+// and the Clojure framework rule manifests (internal/engine/rules/clojure/
+// frameworks/{compojure,reitit,ring,pedestal}.yaml) DETECT that a web framework
+// is present — but neither produces `http_endpoint_definition` entities. So the
+// shared endpoint resolver (ResolveHTTPEndpointHandlers) and, in particular, the
+// language-agnostic e2e route-test linker (linkE2ERouteTestsToEndpoints, #4351)
+// had no Clojure endpoint to bind a route-string test call to.
+//
+// This pass closes the PRODUCER-side gap: it emits one canonical
+// http_endpoint_definition per statically-known Clojure route, in the SAME shape
+// the axum / Rocket / Vapor / Express synthesizers emit, so the existing
+// resolver and the e2e route-test linker light up for Clojure exactly as they
+// do for the flagship stacks. The route-hit `e2e_route_calls` test side is
+// emitted by the custom_clojure_tests_route_e2e extractor.
+//
+// Clojure web route syntax
+// ------------------------
+// Clojure is FUNCTIONAL — routes are data/macros, not OO controllers:
+//
+//   - Compojure macros:  (GET  "/users/:id" [] handler)
+//                        (POST "/users"     req (create req))
+//                        (defroutes app (GET "/todos" [] list-todos) ...)
+//     The verb is the leading macro symbol (GET/POST/PUT/DELETE/PATCH/...),
+//     the path is the FIRST string literal, the handler is the trailing form.
+//
+//   - Reitit data routes: ["/users/:id" {:get  get-user
+//                                        :post create-user}]
+//     A route is a vector whose FIRST element is a string-literal path and whose
+//     SECOND element is a map of `:verb handler` pairs.
+//
+// Both use Ring's Express-style `:name` colon path-parameter convention, so the
+// canonicaliser (FrameworkClojure → canonicalizeColonParams) folds `:id` to
+// `{id}` — the shape every other framework's endpoints share.
+//
+// Honest exclusions (no fabricated routes)
+// ----------------------------------------
+//   - Interpolated / variable / `(str ...)`-built paths — the path must be a
+//     STRING LITERAL; a non-literal first arg is dropped (not recoverable).
+//   - Compojure `(context "/prefix" [] ...)` prefix nesting is NOT threaded onto
+//     the inner routes (single-form scan); the inner routes are still emitted at
+//     their own path. Context-prefix threading is a documented follow-up.
+//   - Reitit `:handler`-style single-handler maps (`{:handler h}` with no verb)
+//     emit an ANY endpoint; verb-keyed maps emit one endpoint per verb.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// cljCompojureRouteRe matches a Compojure verb macro:
+//
+//	(GET "/users/:id" [] handler)
+//	(POST "/users" req (create req))
+//
+// Capture group 1 is the verb macro symbol; group 2 is the string-literal path.
+// The macro must be the first symbol after an open paren so a verb-named local
+// or a string elsewhere is never misread.
+var cljCompojureRouteRe = regexp.MustCompile(
+	`\(\s*(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|ANY)\s+"([^"\n\r]*)"`,
+)
+
+// cljReititRouteRe matches the head of a Reitit route vector:
+//
+//	["/users/:id" {:get get-user :post create-user}]
+//	["/health" {:get health}]
+//
+// Capture group 1 is the string-literal path; group 2 is the verb-map body up to
+// the closing brace. The path must be the FIRST element of the vector (a string
+// literal immediately after `[`).
+var cljReititRouteRe = regexp.MustCompile(
+	`\[\s*"(/[^"\n\r]*)"\s*\{([^}]*)\}`,
+)
+
+// cljReititVerbRe extracts each `:verb` keyword from a Reitit route-data map.
+var cljReititVerbRe = regexp.MustCompile(
+	`:(get|post|put|delete|patch|head|options)\b`,
+)
+
+// cljHasWebRoutes is a fast pre-filter: the file must reference a Compojure verb
+// macro or a Reitit/Ring router marker to be worth scanning.
+func cljHasWebRoutes(content string) bool {
+	if strings.Contains(content, "(GET ") || strings.Contains(content, "(GET\"") ||
+		strings.Contains(content, "(POST ") || strings.Contains(content, "(PUT ") ||
+		strings.Contains(content, "(DELETE ") || strings.Contains(content, "(PATCH ") ||
+		strings.Contains(content, "(ANY ") || strings.Contains(content, "defroutes") {
+		return true
+	}
+	// Reitit data routes are framework-marked by a ring/router or reitit require.
+	return strings.Contains(content, "reitit") &&
+		(strings.Contains(content, "ring/router") || strings.Contains(content, ":get") ||
+			strings.Contains(content, ":post"))
+}
+
+// synthesizeClojureRoutes scans a Clojure source file for Compojure macro routes
+// and Reitit data routes and emits one http_endpoint_definition per
+// statically-known (verb, path).
+func synthesizeClojureRoutes(content string, emit emitFn) {
+	if !cljHasWebRoutes(content) {
+		return
+	}
+
+	emitRoute := func(verb, rawPath, framework string) {
+		rawPath = strings.TrimSpace(rawPath)
+		if rawPath == "" || !strings.HasPrefix(rawPath, "/") {
+			return
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkClojure, rawPath)
+		if canonical == "" {
+			return
+		}
+		// Handler kind "Controller" maps to SCOPE.Operation in the resolver — the
+		// kind Clojure `defn` handlers land as — matching the axum/Vapor
+		// convention so ResolveHTTPEndpointHandlers can bind a handler IMPLEMENTS
+		// edge when a same-named handler exists (no name forces one when absent).
+		emit(strings.ToUpper(verb), canonical, framework, "Controller", "")
+	}
+
+	// Compojure verb macros.
+	for _, m := range cljCompojureRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		emitRoute(m[1], m[2], "compojure")
+	}
+
+	// Reitit data routes — one endpoint per verb declared in the route-data map.
+	for _, m := range cljReititRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		path := m[1]
+		verbs := cljReititVerbRe.FindAllStringSubmatch(m[2], -1)
+		if len(verbs) == 0 {
+			// A verb-less route-data map (`{:handler h}` / `{:name ::x}`) is an ANY
+			// mount — emit a single catch-all endpoint so the route still surfaces.
+			if strings.Contains(m[2], ":handler") {
+				emitRoute("ANY", path, "reitit")
+			}
+			continue
+		}
+		for _, vm := range verbs {
+			emitRoute(vm[1], path, "reitit")
+		}
+	}
+}

--- a/internal/engine/http_endpoint_clojure_test.go
+++ b/internal/engine/http_endpoint_clojure_test.go
@@ -1,0 +1,70 @@
+package engine
+
+import (
+	"testing"
+)
+
+// #4749 — Clojure producer-side route synthesis. Proves Compojure macro routes
+// and Reitit data routes emit canonical http_endpoint_definition entities
+// (`http:<VERB>:<canonical-path>`) in the same shape axum/Vapor/Express emit, so
+// the shared resolver and the e2e route-test linker can bind to them.
+
+// TestClojure_CompojureRoutes covers the Compojure verb-macro shape, including
+// `:id` colon path params folded to `{id}`.
+func TestClojure_CompojureRoutes(t *testing.T) {
+	src := `(ns myapp.routes
+  (:require [compojure.core :refer [defroutes GET POST PUT DELETE]]))
+
+(defroutes app
+  (GET    "/todos"      []  list-todos)
+  (POST   "/todos"      req (create-todo req))
+  (GET    "/todos/:id"  [id] (get-todo id))
+  (DELETE "/todos/:id"  [id] (delete-todo id)))
+`
+	ids, _ := runDetect(t, "clojure", "routes.clj", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos",
+		"http:POST:/todos",
+		"http:GET:/todos/{id}",
+		"http:DELETE:/todos/{id}",
+	}, "compojure-routes")
+}
+
+// TestClojure_ReititRoutes covers the Reitit data-route shape — a vector whose
+// head is a string path and whose second element is a verb→handler map.
+func TestClojure_ReititRoutes(t *testing.T) {
+	src := `(ns myapp.handler
+  (:require [reitit.ring :as ring]))
+
+(def app
+  (ring/ring-handler
+    (ring/router
+      [["/users"      {:get list-users :post create-user}]
+       ["/users/:id"  {:get get-user :delete delete-user}]])))
+`
+	ids, _ := runDetect(t, "clojure", "handler.clj", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users",
+		"http:POST:/users",
+		"http:GET:/users/{id}",
+		"http:DELETE:/users/{id}",
+	}, "reitit-routes")
+}
+
+// TestClojure_NonRouteStringIgnored is the negative guard: a verb-named local or
+// a bare string elsewhere must not forge an endpoint.
+func TestClojure_NonRouteStringIgnored(t *testing.T) {
+	src := `(ns myapp.util)
+
+(defn greet [name]
+  (str "/hello " name))
+
+(def label "POST something")
+`
+	ids, _ := runDetect(t, "clojure", "util.clj", src)
+	for _, id := range ids {
+		if id == "http:POST:/hello" || id == "http:GET:/hello" {
+			t.Fatalf("non-route string forged an endpoint: %s", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4749_clojure_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4749_clojure_test.go
@@ -1,0 +1,98 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Clojure route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/clojure"
+)
+
+// Issue #4749 LIVE-REPRO (resolve side) — Clojure clojure.test / Ring tests.
+//
+// Proves end-to-end that a Clojure clojure.test test calling a route by string
+// via ring-mock — `(app (mock/request :get "/todos"))` — links to the
+// http_endpoint_definition it exercises. The Clojure slice of the all-language
+// program (#4615 tail #4749), generalizing the shared
+// linkE2ERouteTestsToEndpoints pass (#4351). The pass is language-agnostic; only
+// the Clojure route capture (custom_clojure_tests_route_e2e) and the Clojure
+// producer (synthesizeClojureRoutes) are new. Clojure is functional (no OO
+// receiver objects) so receiver typing does not apply; the route-string →
+// endpoint linkage is the coverage mechanism.
+
+const cljRingMockTestSrc4749 = `(ns myapp.todo-handler-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [ring.mock.request :as mock]
+            [myapp.handler :refer [app]]))
+
+(deftest todo-routes
+  (testing "lists todos"
+    (let [resp (app (mock/request :get "/todos"))]
+      (is (= 200 (:status resp)))))
+  (testing "creates a todo"
+    (let [resp (app (mock/request :post "/todos"))]
+      (is (= 201 (:status resp))))))
+`
+
+func TestIssue4749_ClojureRingMockE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/todos"),
+		def("POST", "/todos"),
+	}
+	suite := realSuite(t, "custom_clojure_tests_route_e2e",
+		"test/myapp/todo_handler_test.clj", "clojure", cljRingMockTestSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertCljRouteEdges(t, edgeTargets(afterOut))
+}
+
+// Path-param variant: `(app (mock/request :get "/todos/1"))` matches the
+// templated GET /todos/{id} definition via the resolver's concrete-vs-template
+// segment matcher.
+const cljRingMockParamTestSrc4749 = `(ns myapp.todo-handler-test
+  (:require [clojure.test :refer [deftest is]]
+            [ring.mock.request :as mock]
+            [myapp.handler :refer [app]]))
+
+(deftest get-one
+  (let [resp (app (mock/request :get "/todos/1"))]
+    (is (= 200 (:status resp)))))
+`
+
+func TestIssue4749_ClojureRingMockPathParamLinks(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/todos/{id}"),
+	}
+	suite := realSuite(t, "custom_clojure_tests_route_e2e",
+		"test/myapp/todo_handler_test.clj", "clojure", cljRingMockParamTestSrc4749)
+
+	_, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 1 {
+		t.Fatalf("expected a TESTS edge to GET /todos/{id}, got %d", edges)
+	}
+}
+
+func assertCljRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/todos") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/todos") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /todos; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /todos; targets=%v", targets)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1246,6 +1246,15 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Producer side (#3484): OpenResty nginx `location` stanzas (in
 		// lua-classified config-driver files) + lua-resty-router DSL routes.
 		synthesizeOpenResty(string(content), emit)
+	case "clojure":
+		// Producer side (#4749, epic #4615 tail): Compojure macro routes
+		// (`(GET "/users/:id" [] handler)`, `(defroutes app ...)`) and Reitit
+		// data routes (`["/users/:id" {:get get-user}]`) → canonical
+		// http_endpoint_definition, in the same shape axum/Vapor/Express emit, so
+		// the shared resolver and the e2e route-test linker (#4351) light up for
+		// Clojure. The clojure framework rule manifests stay for detection; this
+		// pass adds the canonical definitions the coverage substrate keys off.
+		synthesizeClojureRoutes(string(content), emit)
 	case "scala":
 		// Consumer side (#3554): sttp (basicRequest/quickRequest verb
 		// combinators with uri"..." literals) outbound HTTP client. The Scala

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -190,6 +190,11 @@ const (
 	// synthesizer joins with `/` before canonicalisation. Canonicalisation
 	// reuses canonicalizeColonParams.
 	FrameworkVapor = "vapor"
+	// FrameworkClojure (#4749) — Clojure web routes (Compojure
+	// `(GET "/users/:id" [] handler)`, Reitit `["/users/:id" {:get handler}]`,
+	// Ring/Pedestal) use the Express-style `:name` colon-prefixed path-parameter
+	// convention. Canonicalisation reuses canonicalizeColonParams.
+	FrameworkClojure = "clojure"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -239,7 +244,7 @@ func Canonicalize(framework, raw string) string {
 	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi, FrameworkPhoenix,
 		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails,
 		FrameworkRobyn, FrameworkPlug, FrameworkCowboy,
-		FrameworkLapis, FrameworkOpenResty, FrameworkVapor:
+		FrameworkLapis, FrameworkOpenResty, FrameworkVapor, FrameworkClojure:
 		out = canonicalizeColonParams(raw)
 	default:
 		// Unknown framework: pass through but still normalise slashes.

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -73,6 +73,7 @@ var customPrefixForLanguage = map[string]string{
 	"swift":   "custom_swift_",
 	"dart":    "custom_dart_",
 	"elixir":  "custom_elixir_",
+	"clojure": "custom_clojure_",
 	"csharp":  "custom_csharp_",
 	"cpp":     "custom_cpp_",
 	// Protocol Buffers IDL files (.proto) are classified as their own

--- a/internal/extractors/custom_registry.go
+++ b/internal/extractors/custom_registry.go
@@ -6,6 +6,7 @@
 package extractors
 
 import (
+	_ "github.com/cajasmota/archigraph/internal/custom/clojure"
 	_ "github.com/cajasmota/archigraph/internal/custom/cpp"
 	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
 	_ "github.com/cajasmota/archigraph/internal/custom/dart"


### PR DESCRIPTION
Clojure slice of the coverage-linkage tail epic (#4749, child of #4615 / pattern #4688).

## Probe finding (web-support level)
The Clojure base extractor (`internal/extractors/clojure`) + the framework rule manifests (`rules/clojure/frameworks/{compojure,reitit,ring,pedestal}.yaml`) are **detection / structural only** — they extract namespaces, `defn`, `deftype`, IMPORTS/CALLS/CONTAINS and *detect* that a web framework is present, but **no `http_endpoint_definition` was ever produced**, and there was no test-route linkage. There were **zero Clojure records** in the coverage registry. So this slice had to add the missing **producer** as well as the test side — exactly the Swift (#4749) precedent (`synthesizeVaporRoutes` + `tests_route_e2e`).

## Producer — synthesised the canonical endpoint first
`engine.synthesizeClojureRoutes` (new `case "clojure"` in `http_endpoint_synthesis.go`):
- **Compojure** verb macros: `(GET "/users/:id" [] handler)`, inside `(defroutes app ...)`
- **Reitit** data routes: `["/users/:id" {:get h :post h}]` — one endpoint per `:verb`; verb-less `{:handler h}` → ANY
- `FrameworkClojure` canonicalisation (`:id` → `{id}`, `canonicalizeColonParams`)

## Route-hit test linkage
`custom_clojure_tests_route_e2e` emits one `test_suite` per `clojure.test` file carrying `e2e_route_calls` for **ring-mock** (`(app (mock/request :get "/path"))`) and **peridot/kerodon** route hits; the language-agnostic `engine.linkE2ERouteTestsToEndpoints` pass (#4351) emits the TESTS edge to the synthesised endpoint.

## N/A documented honestly
Clojure is **functional** — local-variable/receiver typing (#4680/#4681) is **N/A** (a Ring handler is dispatched by the literal route string, not an `obj.method()` receiver); route-string linkage is the coverage mechanism (mirrors Elixir #4688). `(deftest …)` are named fns already mined and route hits live in the deftest body, so the suite is keyed per-file — **no synthetic anonymous-block scope-owner needed**. Honest exclusion: interpolated/built/variable routes dropped.

## Coverage docs (surgical, never re-serialised)
New `lang.clojure.framework.{compojure,reitit}` records via the `coverage` CLI (`add` + `backfill` → full taxonomy seeded honest-`missing`); then `endpoint_synthesis` / `route_extraction` / `tests_linkage` → **full**, `handler_attribution` → **partial**. `coverage fmt --check` ✅ canonical.

## Fixtures RED→GREEN
- Producer: `TestClojure_{Compojure,Reitit}Routes`, `TestClojure_NonRouteStringIgnored`
- E2E TESTS edges: `TestIssue4749_ClojureRingMock*` (GET+POST + path-param)
- Extractor units: `internal/custom/clojure/tests_route_e2e_test.go` (ring-mock, peridot, honest-exclusion)

## Gates
`go build ./...` ✅ · `go vet` (extractors/custom/graph/engine) ✅ · `go test` (extractors/custom/engine/graph/types) ✅ 0 failures · `coverage fmt --check` ✅. `coverage validate` shows only pre-existing unrelated Rust/Python errors (present on base; none Clojure).

Part of #4749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)