### PR TITLE
feat(fsharp): Giraffe/Saturn test→endpoint coverage linkage (#4749)

### DIFF
--- a/internal/custom/fsharp/extractors_test.go
+++ b/internal/custom/fsharp/extractors_test.go
@@ -1,0 +1,129 @@
+package fsharp_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/fsharp"
+)
+
+func fi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestFSharpRouteE2E_Capture proves the TestServer HttpClient route helpers are
+// captured onto a single test_suite's e2e_route_calls property.
+func TestFSharpRouteE2E_Capture(t *testing.T) {
+	src := `module UsersTests
+open Expecto
+
+let tests =
+    testList "Users API" [
+        testCase "lists users" <| fun _ ->
+            let resp = client.GetAsync("/users").Result
+            Expect.equal resp.StatusCode 200 "ok"
+
+        testCase "creates a user" <| fun _ ->
+            let resp = client.PostAsync("/users", content).Result
+            Expect.equal resp.StatusCode 201 "created"
+
+        testCase "deletes a user" <| fun _ ->
+            let resp = client.DeleteAsync($"/users/{id}").Result
+            ignore resp
+    ]
+`
+	e, ok := extreg.Get("custom_fsharp_tests_route_e2e")
+	if !ok {
+		t.Fatal("custom_fsharp_tests_route_e2e not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("tests/UsersTests.fs", "fsharp", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("expected exactly 1 test_suite, got %d", len(ents))
+	}
+	rec := ents[0]
+	if rec.Subtype != "test_suite" {
+		t.Errorf("expected test_suite, got %q", rec.Subtype)
+	}
+	calls := rec.Properties["e2e_route_calls"]
+	for _, want := range []string{"GET /users", "POST /users", "DELETE /users"} {
+		if !strings.Contains(calls, want) {
+			t.Errorf("expected route call %q in %q", want, calls)
+		}
+	}
+}
+
+// TestFSharpRouteE2E_RequestMessageForm covers the
+// HttpRequestMessage(HttpMethod.X, "/path") construction shape.
+func TestFSharpRouteE2E_RequestMessageForm(t *testing.T) {
+	src := `module ApiTests
+open Xunit
+
+[<Fact>]
+let ` + "``gets health``" + ` () =
+    let req = new HttpRequestMessage(HttpMethod.Get, "/health")
+    let resp = client.SendAsync(req).Result
+    Assert.Equal(200, int resp.StatusCode)
+`
+	e, _ := extreg.Get("custom_fsharp_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("tests/ApiTests.fs", "fsharp", src))
+	if len(ents) != 1 {
+		t.Fatalf("expected 1 test_suite, got %d", len(ents))
+	}
+	if !strings.Contains(ents[0].Properties["e2e_route_calls"], "GET /health") {
+		t.Errorf("expected GET /health, got %q", ents[0].Properties["e2e_route_calls"])
+	}
+}
+
+// TestFSharpRouteE2E_NonTestExcluded proves a production route file (not a test)
+// is NOT captured as a test_suite.
+func TestFSharpRouteE2E_NonTestExcluded(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let webApp =
+    choose [
+        GET >=> route "/users" >=> listUsers
+    ]
+`
+	e, _ := extreg.Get("custom_fsharp_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("src/App.fs", "fsharp", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a non-test file, got %d", len(ents))
+	}
+}
+
+// TestFSharpRouteE2E_ShapeOnlyTestExcluded proves a unit test that never hits a
+// route emits no suite.
+func TestFSharpRouteE2E_ShapeOnlyTestExcluded(t *testing.T) {
+	src := `module MathTests
+open Expecto
+
+let tests =
+    testList "Math" [
+        testCase "adds" <| fun _ ->
+            Expect.equal (add 1 2) 3 "sum"
+    ]
+`
+	e, _ := extreg.Get("custom_fsharp_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("tests/MathTests.fs", "fsharp", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a shape-only test, got %d", len(ents))
+	}
+}
+
+// TestFSharpRouteE2E_WrongLanguageNoop proves the extractor gates on
+// language=="fsharp".
+func TestFSharpRouteE2E_WrongLanguageNoop(t *testing.T) {
+	src := `client.GetAsync("/users")`
+	e, _ := extreg.Get("custom_fsharp_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("tests/UsersTests.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-fsharp language, got %d", len(ents))
+	}
+}

--- a/internal/custom/fsharp/tests_route_e2e.go
+++ b/internal/custom/fsharp/tests_route_e2e.go
@@ -1,0 +1,236 @@
+// tests_route_e2e.go — F# test → endpoint route-hit linkage.
+//
+// #4749 (the F# slice of the coverage-linkage tail epic #4749/#4615; mirrors the
+// Crystal/Kemal slice #4760, the Swift/Vapor slice #4755 and the functional
+// Elixir slice #4688).
+//
+// Emits ONE test_suite entity per F# test file that drives an HTTP endpoint by
+// ROUTE STRING through an in-memory `TestServer` HTTP client, stamping the
+// captured `VERB route` pairs onto the suite's `e2e_route_calls` property (one
+// "VERB route" per line). The shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index — which, for F#, is
+// populated by synthesizeGiraffeRoutes (#4749) — and emits a TESTS edge to the
+// exact Giraffe/Saturn endpoint exercised, exactly as the Crystal, Swift, Rust,
+// Java, Ruby, PHP, C# and Elixir slices do for their stacks. The engine pass is
+// language-agnostic (it fires on any test_suite carrying e2e_route_calls), so
+// the only F#-specific work here is the test route capture.
+//
+// F# route-driving idioms captured (the standard Giraffe/Saturn integration-test
+// shape — an ASP.NET Core `TestServer` HttpClient):
+//   - client.GetAsync("/users")            → GET /users
+//   - client.PostAsync("/users", content)  → POST /users
+//   - client.DeleteAsync("/users/1")       → DELETE /users/1
+//   - client.PutAsync("/users/1", c)       → PUT /users/1
+//   - client.PatchAsync("/users/1", c)     → PATCH /users/1
+//   - HttpRequestMessage(HttpMethod.Get, "/users")  → GET /users
+//
+// The HttpClient verb methods (`GetAsync`/`PostAsync`/…) carry a leading
+// string-literal URI argument. An `HttpRequestMessage(HttpMethod.X, "/path")`
+// constructor carries the verb as the first arg and the URI as the second.
+//
+// Test-scope / scope-owner
+// ------------------------
+// F# test DSLs use ANONYMOUS closure blocks for individual cases:
+//   - Expecto: `testCase "name" <| fun _ -> ...` (and `testList "..." [ ... ]`)
+//   - xUnit:   `[<Fact>] let ``test name`` () = ...` (named — but the route hit
+//     is still attributed at suite granularity to match the cross-language pass)
+// The `testCase`/`testList` example body owns no named call-bearing entity (it
+// is a `fun _ -> ...` closure passed to a combinator), so — exactly like the
+// Ruby #4684 / JS #4680 / Crystal #4760 anonymous-block scope-owner — the
+// route-hit signal is carried by the SUITE-LEVEL test_suite entity emitted here.
+// This is the F# analog of those scope-owners: the test_suite is the owner that
+// carries the e2e_route_calls the engine links from.
+//
+// Local-variable / receiver typing (#4749 part a) is N/A for F# coverage
+// linkage: F# is functional — Giraffe handlers are `let`-bound `HttpHandler`
+// values composed with `>=>`, not `obj.method()` receiver calls, and the fsharp
+// base extractor names `let` entities by their BARE name with no class-qualified
+// receiver resolver to consume a `receiver_type` stamp. It would be a dead
+// annotation. The honest, working coverage mechanism for F# is the route-hit →
+// endpoint linkage in THIS file (route dispatch is keyed by the literal route
+// string, not by an `obj.method()` receiver), exactly as for the functional
+// Elixir and Crystal slices. See the coverage-doc note for the recorded N/A
+// rationale.
+//
+// Honest exclusions (no fabricated edges):
+//   - Interpolated / variable routes capture the literal prefix only when a
+//     static string is present; a fully interpolated route (`$"{path}"`) is
+//     dropped.
+//   - Non-request tests (pure unit tests that never hit a route) emit no suite.
+//   - A route helper appearing OUTSIDE a test file is left to the producer-side
+//     synthesizer (synthesizeGiraffeRoutes); this extractor only runs on tests.
+//
+// Registration key: "custom_fsharp_tests_route_e2e".
+package fsharp
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_fsharp_tests_route_e2e", &fsharpTestRouteE2EExtractor{})
+}
+
+type fsharpTestRouteE2EExtractor struct{}
+
+func (e *fsharpTestRouteE2EExtractor) Language() string {
+	return "custom_fsharp_tests_route_e2e"
+}
+
+// fsharpClientVerbRE matches an ASP.NET Core HttpClient verb call with a leading
+// string-literal URI:
+//
+//	client.GetAsync("/users")
+//	client.PostAsync("/users", content)
+//	httpClient.DeleteAsync("/users/1")
+//
+// Capture group 1 is the verb (Get/Post/Put/Delete/Patch/Head/Options); group 2
+// is the route literal.
+var fsharpClientVerbRE = regexp.MustCompile(
+	`\.(Get|Post|Put|Delete|Patch|Head|Options)Async\s*\(\s*\$?"([^"\n\r]*)"`,
+)
+
+// fsharpRequestMessageRE matches an `HttpRequestMessage(HttpMethod.X, "/path")`
+// constructor. Capture group 1 is the verb; group 2 is the route literal.
+var fsharpRequestMessageRE = regexp.MustCompile(
+	`HttpRequestMessage\s*\(\s*HttpMethod\.(Get|Post|Put|Delete|Patch|Head|Options)\s*,\s*\$?"([^"\n\r]*)"`,
+)
+
+func (e *fsharpTestRouteE2EExtractor) Extract(
+	_ context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "fsharp" {
+		return nil, nil
+	}
+	if !isFSharpTestFile(file.Path, string(file.Content)) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectFSharpTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       fsharpTestSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "fsharp",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "fsharp-testserver",
+			"provenance":      "INFERRED_FROM_FSHARP_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	rec.ID = rec.ComputeID()
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectFSharpTestRouteCalls returns the de-duplicated "VERB route" pairs a
+// test file drives by route string. Routes are normalised to a leading-slash
+// path; fully-interpolated routes (no static literal) are dropped.
+func collectFSharpTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verbRaw, rawPath string) {
+		verb := strings.ToUpper(verbRaw)
+		route := normaliseFSharpTestRoute(rawPath)
+		if route == "" {
+			return
+		}
+		line := verb + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	for _, m := range fsharpClientVerbRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range fsharpRequestMessageRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	return out
+}
+
+// normaliseFSharpTestRoute reduces a raw test route literal to a path: ensures a
+// single leading slash, drops a query/fragment tail, collapses repeated slashes.
+// A route whose value begins with a string interpolation (`$"{...}"` / `{...}`)
+// with no static prefix is dropped (returns ""). Path-param placeholders and
+// casing are preserved (the resolver wildcards templates and compares
+// case-insensitively).
+func normaliseFSharpTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return ""
+	}
+	// Truncate at the first interpolation marker — the static prefix is the
+	// only statically-recoverable part. `"users/{id}"` → `/users`.
+	if i := strings.Index(p, "{"); i >= 0 {
+		p = p[:i]
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	// A bare "/" after truncation carries no route identity — drop it.
+	if p == "/" {
+		return ""
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// isFSharpTestFile reports whether path/content looks like an F# test file — a
+// `*Test(s).fs` / `*Spec(s).fs` file, a file under a `/test(s)/` directory, or a
+// file referencing a known F# test framework (Expecto / xUnit / NUnit). Keeps
+// the route-hit suite off production code that merely registers a route.
+func isFSharpTestFile(path, content string) bool {
+	lp := filepath.ToSlash(path)
+	if !strings.HasSuffix(lp, ".fs") && !strings.HasSuffix(lp, ".fsx") {
+		return false
+	}
+	base := strings.ToLower(filepath.Base(lp))
+	if strings.Contains(base, "test") || strings.Contains(base, "spec") {
+		return true
+	}
+	low := strings.ToLower(lp)
+	if strings.Contains(low, "/test/") || strings.Contains(low, "/tests/") ||
+		strings.Contains(low, "/spec/") || strings.Contains(low, "/specs/") {
+		return true
+	}
+	// Framework signal: Expecto / xUnit / NUnit references in the file.
+	return strings.Contains(content, "Expecto") ||
+		strings.Contains(content, "testCase") ||
+		strings.Contains(content, "testList") ||
+		strings.Contains(content, "[<Fact>]") ||
+		strings.Contains(content, "[<Theory>]") ||
+		strings.Contains(content, "Xunit") ||
+		strings.Contains(content, "NUnit")
+}
+
+// fsharpTestSuiteBaseName derives a suite label from the test file path
+// (`.../UsersTests.fs` → `UsersTests`).
+func fsharpTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/engine/http_endpoint_giraffe.go
+++ b/internal/engine/http_endpoint_giraffe.go
@@ -1,0 +1,172 @@
+// http_endpoint_giraffe.go — F# Giraffe / Saturn route registration → canonical
+// http_endpoint_definition synthesis (#4749, the F# slice of the
+// coverage-linkage tail epic #4749/#4615; mirrors the Crystal/Kemal slice #4760
+// and the Swift/Vapor slice #4755).
+//
+// Background
+// ----------
+// The F# base extractor (internal/extractors/fsharp/extractor.go) is a
+// regex-based structural extractor: it mines modules / namespaces / let
+// bindings / members / types and CALLS edges, but has NO web-framework
+// awareness — Giraffe `GET >=> route "/users" >=> handler` combinator chains and
+// Saturn `router { get "/users/:id" handler }` blocks are not recognised as HTTP
+// endpoints, and no `http_endpoint_definition` entity is ever produced for F#.
+// The shared e2e route-test linker (linkE2ERouteTestsToEndpoints, #4351) matches
+// a test's route hit against `http_endpoint_definition` + `path`, so an F# route
+// could never be hit by a route-string test. As with Crystal (#4760) and
+// Swift/Vapor (#4755), the PRODUCER-side gap has to be closed first.
+//
+// This pass emits one canonical http_endpoint_definition per statically-known
+// F# route, in the SAME shape axum / Rocket / Express / Vapor / Kemal emit, so
+// the existing resolver and the language-agnostic e2e route-test linker light up
+// for F# exactly as they do for the flagship stacks.
+//
+// F# route syntax
+// ---------------
+// Giraffe (the dominant F# web framework) composes a route from the verb
+// HttpHandler (`GET`/`POST`/…), the `route`/`routef` path combinator, and the
+// handler, joined by the Kleisli `>=>` operator, typically inside a
+// `choose [ ... ]` list:
+//
+//	GET  >=> route "/users"      >=> listUsers          → GET /users
+//	GET  >=> routef "/users/%i"  getUser                → GET /users/{}  (typed param)
+//	POST >=> route "/users"      >=> createUser         → POST /users
+//	subRoute "/api" (choose [ GET >=> route "/x" ... ]) → (prefix not folded — see exclusions)
+//
+// `route` carries a fully static literal path; `routef` carries printf-style
+// typed placeholders (`%i`/`%s`/`%O`/…) canonicalised to `{}` by
+// FrameworkGiraffe.
+//
+// Saturn (an opinionated MVC layer over Giraffe) registers routes inside a
+// `router { ... }` computation expression with verb operations taking a
+// string-literal path and a handler:
+//
+//	router {
+//	  get  "/users"     listUsers
+//	  getf "/users/%i"  getUser
+//	  post "/users"     createUser
+//	}
+//
+// Saturn paths use the Sinatra/Express-style `:name` colon convention as well as
+// the Giraffe `%fmt` form (getf/postf/…); FrameworkGiraffe handles both.
+//
+// Honest exclusions (no fabricated routes)
+// ----------------------------------------
+//   - Interpolated / variable paths (`route basePath`, `route (prefix + "/x")`)
+//     — not statically recoverable, dropped (only string-literal paths emit).
+//   - `subRoute "/api" (...)` / `forward "/api" (...)` mount prefixes are NOT
+//     folded into the nested child routes here (the nested routes still emit at
+//     their own un-prefixed path). Prefix folding is a documented follow-up; the
+//     resolver/segment-matcher tolerates a missing api-version mount prefix on
+//     either side, so the un-prefixed definition still binds the common case.
+//   - Giraffe `routeCi` / `routeStartsWith` / `routex` (regex) variants beyond
+//     `route`/`routef` are a documented follow-up.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// giraffeRouteRe matches a Giraffe `route`/`routef` combinator preceded (on the
+// same composition line) by an HTTP-verb HttpHandler:
+//
+//	GET >=> route "/users"
+//	POST >=> routef "/users/%i"
+//	GET >=> routeCi "/x"      (routeCi accepted — case-insensitive variant)
+//
+// Capture group 1 is the verb; group 2 is the path literal. The verb and the
+// `route`/`routef` token may be separated by `>=>` and whitespace. Requiring the
+// verb on the same line as the path combinator is what distinguishes a real
+// route registration from an arbitrary `route` helper call.
+var giraffeRouteRe = regexp.MustCompile(
+	`(?m)\b(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)\b\s*>=>\s*` +
+		`route[fxi]?(?:Ci)?\s+"([^"\n\r]*)"`,
+)
+
+// saturnRouteRe matches a Saturn `router { ... }` verb operation taking a
+// leading string-literal path:
+//
+//	get  "/users"     listUsers
+//	getf "/users/%i"  getUser
+//	post "/users"     createUser
+//	delete "/users/:id" deleteUser
+//
+// Anchored at a statement boundary (`^[ \t]*`) so an arbitrary `obj.get "..."`
+// is not captured. The optional trailing `f` (`getf`/`postf`/…) is the
+// format-string variant. Capture group 1 is the verb; group 2 is the path.
+var saturnRouteRe = regexp.MustCompile(
+	`(?m)^[ \t]*(get|post|put|delete|patch|options|head)f?\s+"([^"\n\r]*)"`,
+)
+
+// giraffeHasRoute is a fast pre-filter: the file must reference an F# web marker
+// (Giraffe / Saturn) AND a route token to be worth scanning, so we never misfire
+// on arbitrary F# code.
+func giraffeHasRoute(content string) bool {
+	hasMarker := strings.Contains(content, "Giraffe") ||
+		strings.Contains(content, "giraffe") ||
+		strings.Contains(content, "Saturn") ||
+		strings.Contains(content, "saturn") ||
+		strings.Contains(content, ">=>") ||
+		strings.Contains(content, "router {") ||
+		strings.Contains(content, "HttpHandler") ||
+		strings.Contains(content, "choose [")
+	if !hasMarker {
+		return false
+	}
+	return strings.Contains(content, "route") ||
+		strings.Contains(content, "router {")
+}
+
+// synthesizeGiraffeRoutes scans an F# source file for Giraffe / Saturn route
+// registrations and emits one http_endpoint_definition per statically-known
+// (verb, path).
+func synthesizeGiraffeRoutes(content string, emit emitFn) {
+	if !giraffeHasRoute(content) {
+		return
+	}
+	seen := map[string]bool{}
+	emitRoute := func(verbRaw, rawPath string) {
+		verb := strings.ToUpper(verbRaw)
+		raw := strings.TrimSpace(rawPath)
+		// Drop interpolated / empty literals — not statically recoverable.
+		// F# interpolated strings use `$"..{x}.."`; a `{` in the literal that
+		// is not a `%fmt`-derived token signals interpolation, so drop it.
+		if raw == "" || strings.Contains(raw, "{") {
+			return
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGiraffe, raw)
+		if canonical == "" || canonical == "/" {
+			return
+		}
+		key := verb + "\x00" + canonical
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		// Handler kind "Controller" maps to SCOPE.Operation in the resolver, the
+		// kind F# `let` handlers land as — matching the axum/vapor/kemal
+		// convention so ResolveHTTPEndpointHandlers can bind a handler IMPLEMENTS
+		// edge when a same-named handler exists (no name forces a handler when
+		// absent).
+		emit(verb, canonical, "giraffe", "Controller", "")
+	}
+
+	for _, m := range giraffeRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		emitRoute(m[1], m[2])
+	}
+	for _, m := range saturnRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		emitRoute(m[1], m[2])
+	}
+}

--- a/internal/engine/http_endpoint_giraffe_test.go
+++ b/internal/engine/http_endpoint_giraffe_test.go
@@ -1,0 +1,174 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestGiraffe_BasicRoute covers the canonical Giraffe `choose [ ... ]` route
+// list: `GET >=> route "/users" >=> handler`.
+func TestGiraffe_BasicRoute(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let webApp =
+    choose [
+        GET >=> route "/users" >=> listUsers
+        POST >=> route "/users" >=> createUser
+    ]
+`
+	ids, _ := runDetect(t, "fsharp", "src/App.fs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users",
+		"http:POST:/users",
+	}, "giraffe-basic-route")
+}
+
+// TestGiraffe_RoutefTypedParam covers `routef "/users/%i"` printf-typed params,
+// which canonicalise to the positional `{}` wildcard.
+func TestGiraffe_RoutefTypedParam(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let webApp =
+    choose [
+        GET >=> routef "/users/%i" getUser
+        DELETE >=> routef "/users/%i/posts/%s" deletePost
+    ]
+`
+	ids, _ := runDetect(t, "fsharp", "src/App.fs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users/{}",
+		"http:DELETE:/users/{}/posts/{}",
+	}, "giraffe-routef-typed-param")
+}
+
+// TestGiraffe_SaturnRouter covers the Saturn `router { ... }` computation-
+// expression DSL with both plain and `:name` colon-param paths.
+func TestGiraffe_SaturnRouter(t *testing.T) {
+	src := `module App
+open Saturn
+
+let apiRouter = router {
+    get "/users" listUsers
+    get "/users/:id" getUser
+    post "/users" createUser
+}
+`
+	ids, _ := runDetect(t, "fsharp", "src/Router.fs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users",
+		"http:GET:/users/{id}",
+		"http:POST:/users",
+	}, "saturn-router")
+}
+
+// TestGiraffe_InterpolatedRouteDropped is the honest-exclusion guard: an
+// interpolated path must NOT forge an endpoint.
+func TestGiraffe_InterpolatedRouteDropped(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let webApp =
+    choose [
+        GET >=> route $"/users/{prefix}" >=> handler
+    ]
+`
+	ids, _ := runDetect(t, "fsharp", "src/Dyn.fs", src)
+	for _, id := range ids {
+		if id == "http:GET:/" || id == "http:GET:/users" {
+			t.Fatalf("interpolated route must not synthesize an endpoint; got %v", ids)
+		}
+	}
+}
+
+// TestGiraffe_NonWebFileIgnored is the negative guard: an F# file with no web
+// marker that happens to call a `get`-like function must not be misread.
+func TestGiraffe_NonWebFileIgnored(t *testing.T) {
+	src := `module Cache
+
+let lookup key =
+    store |> Map.tryFind key
+`
+	ids, _ := runDetect(t, "fsharp", "src/Cache.fs", src)
+	for _, id := range ids {
+		if len(id) > 5 && id[:5] == "http:" {
+			t.Fatalf("non-web F# file must not synthesize an endpoint; got %v", ids)
+		}
+	}
+}
+
+// TestGiraffe_CanonicalizeFormat unit-tests the routef `%fmt` → `{}` rewrite.
+func TestGiraffe_CanonicalizeFormat(t *testing.T) {
+	cases := map[string]string{
+		"/users/%i":          "/users/{}",
+		"/x/%s/%i":           "/x/{}/{}",
+		"/g/%O":              "/g/{}",
+		"/users":             "/users",
+		"/users/:id":         "/users/{id}",
+		"/pct/%%/done":       "/pct/%/done",
+	}
+	for in, want := range cases {
+		got := httproutes.Canonicalize(httproutes.FrameworkGiraffe, in)
+		if got != want {
+			t.Errorf("Canonicalize(giraffe, %q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+// TestGiraffe_E2ERouteTestLinkage is the end-to-end RED→GREEN proof (#4749
+// validation). A Giraffe route GET /users is represented as an
+// http_endpoint_definition; an fsharp-testserver test_suite carrying
+// `e2e_route_calls = "GET /users"` must yield a TESTS edge from the suite to
+// that endpoint via the shared linkE2ERouteTestsToEndpoints pass.
+func TestGiraffe_E2ERouteTestLinkage(t *testing.T) {
+	def := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:GET:/users",
+		SourceFile: "src/App.fs",
+		Language:   "fsharp",
+		Properties: map[string]string{
+			"verb":         "GET",
+			"path":         "/users",
+			"framework":    "giraffe",
+			"pattern_type": "http_endpoint_synthesis",
+		},
+	}
+	suite := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		Name:       "UsersTests",
+		SourceFile: "tests/UsersTests.fs",
+		Language:   "fsharp",
+		Properties: map[string]string{
+			"framework":       "fsharp-testserver",
+			"e2e_route_calls": "GET /users",
+		},
+	}
+
+	merged := []types.EntityRecord{def, suite}
+	resolved, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.E2ERouteTestEdges < 1 {
+		t.Fatalf("expected >=1 e2e route-test edge for Giraffe GET /users; got %d", stats.E2ERouteTestEdges)
+	}
+
+	found := false
+	for i := range resolved {
+		if resolved[i].Name != "UsersTests" {
+			continue
+		}
+		for _, r := range resolved[i].Relationships {
+			if r.Kind == string(types.RelationshipKindTests) &&
+				r.Properties["match_source"] == "e2e_supertest_route" &&
+				r.Properties["route"] == "/users" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected TESTS edge from UsersTests suite to GET /users endpoint")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -121,6 +121,13 @@ func synthesisSupportsLanguage(lang string) bool {
 	// verb-macro route are no-ops inside the synthesizer.
 	case "crystal":
 		return true
+	// #4749: F# web producer-side route synthesis — Giraffe
+	// `GET >=> route "/path"` / `routef` combinator chains and Saturn
+	// `router { get "/path" handler }` blocks have no compiled YAML rules, so
+	// allow F# through for synthesizeGiraffeRoutes. Files without an F# web
+	// marker + route token are no-ops inside the synthesizer.
+	case "fsharp":
+		return true
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
@@ -1289,6 +1296,16 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// extractor stays structural-only; this pass adds the canonical
 		// definitions the coverage substrate keys off.
 		synthesizeKemalRoutes(string(content), emit)
+	case "fsharp":
+		// Producer side (#4749): F# web route registrations — Giraffe
+		// (`GET >=> route "/users" >=> handler`, `routef "/users/%i"`) and Saturn
+		// (`router { get "/users/:id" handler }`) → canonical
+		// http_endpoint_definition, in the same shape
+		// axum/Rocket/Express/Vapor/Kemal emit, so the shared resolver and the
+		// e2e route-test linker (#4351) light up for F#. The base fsharp
+		// extractor stays structural-only; this pass adds the canonical
+		// definitions the coverage substrate keys off.
+		synthesizeGiraffeRoutes(string(content), emit)
 	case "yaml", "json":
 		// Producer side (#3628, area #16): OpenAPI 3.x / Swagger 2.0 spec
 		// files declare the HTTP API surface as ground-truth. Each

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -197,6 +197,17 @@ const (
 	// (`get "/files/*path"`), which the colon walker leaves intact (the segment
 	// matcher wildcards it). Canonicalisation reuses canonicalizeColonParams.
 	FrameworkKemal = "kemal"
+	// FrameworkGiraffe (#4749) — F# web frameworks Giraffe and Saturn. Giraffe
+	// composes routes with the `route "/literal"` combinator (a fully static
+	// path, no param syntax) and `routef "/users/%i"` (printf-style typed
+	// placeholders — `%i`/`%d`/`%u`/`%s`/`%b`/`%c`/`%f`/`%O` for int/decimal/
+	// uint/string/bool/char/float/guid). The `routef` placeholders are rewritten
+	// to the canonical `{}` positional-wildcard form so a `routef "/users/%i"`
+	// definition matches a concrete test route `/users/42` segment-for-segment.
+	// Saturn's `router { get "/users/:id" handler }` DSL uses the Sinatra/
+	// Express-style `:name` colon convention, so the same canonicaliser handles
+	// both `%fmt` and `:name`.
+	FrameworkGiraffe = "giraffe"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -248,6 +259,11 @@ func Canonicalize(framework, raw string) string {
 		FrameworkRobyn, FrameworkPlug, FrameworkCowboy,
 		FrameworkLapis, FrameworkOpenResty, FrameworkVapor, FrameworkKemal:
 		out = canonicalizeColonParams(raw)
+	case FrameworkGiraffe:
+		// Giraffe `routef "/users/%i"` printf placeholders → `{}` first, then
+		// the colon walker handles Saturn `:name` params. A plain Giraffe
+		// `route "/users"` has neither and passes through unchanged.
+		out = canonicalizeColonParams(canonicalizeGiraffeFormat(raw))
 	default:
 		// Unknown framework: pass through but still normalise slashes.
 		out = raw
@@ -500,6 +516,45 @@ func canonicalizeColonParams(raw string) string {
 		i = j
 		// Drop trailing `?` (optional marker) without altering the rest.
 		if i < len(raw) && raw[i] == '?' {
+			i++
+		}
+	}
+	return b.String()
+}
+
+// canonicalizeGiraffeFormat rewrites Giraffe `routef` printf-style typed
+// placeholders into the canonical `{}` positional-wildcard form. Giraffe
+// supports `%b` (bool), `%c` (char), `%s` (string), `%i` (int), `%d` (int64),
+// `%u` (uint64), `%f` (float), and `%O` (Guid) — a `%` immediately followed by
+// one of these format characters becomes a single `{}` wildcard segment-token,
+// so `"/users/%i"` → `"/users/{}"` and `"/x/%s/%i"` → `"/x/{}/{}"`. A literal
+// `%%` (escaped percent) collapses to a single `%`. Any other `%X` (not a known
+// format char) is left intact so a stray percent in a static path is not eaten.
+func canonicalizeGiraffeFormat(raw string) string {
+	if !strings.Contains(raw, "%") {
+		return raw
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	i := 0
+	for i < len(raw) {
+		if raw[i] != '%' || i+1 >= len(raw) {
+			b.WriteByte(raw[i])
+			i++
+			continue
+		}
+		n := raw[i+1]
+		if n == '%' {
+			b.WriteByte('%')
+			i += 2
+			continue
+		}
+		switch n {
+		case 'b', 'c', 's', 'i', 'd', 'u', 'f', 'O':
+			b.WriteString("{}")
+			i += 2
+		default:
+			b.WriteByte('%')
 			i++
 		}
 	}

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -76,6 +76,7 @@ var customPrefixForLanguage = map[string]string{
 	"csharp":  "custom_csharp_",
 	"cpp":     "custom_cpp_",
 	"crystal": "custom_crystal_",
+	"fsharp":  "custom_fsharp_",
 	// Protocol Buffers IDL files (.proto) are classified as their own
 	// "protobuf" language but carry message/service definitions parsed by the
 	// C/C++ protobuf custom extractor (which path/language-gates internally and

--- a/internal/extractors/custom_registry.go
+++ b/internal/extractors/custom_registry.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
 	_ "github.com/cajasmota/archigraph/internal/custom/dart"
 	_ "github.com/cajasmota/archigraph/internal/custom/elixir"
+	_ "github.com/cajasmota/archigraph/internal/custom/fsharp"
 	_ "github.com/cajasmota/archigraph/internal/custom/golang"
 	_ "github.com/cajasmota/archigraph/internal/custom/java"
 	_ "github.com/cajasmota/archigraph/internal/custom/javascript"


### PR DESCRIPTION
F# slice of the coverage-linkage tail epic #4749 (mirrors Crystal/Kemal #4760 and Swift/Vapor #4755).

## Probe finding (F# web support level)
The F# base extractor (`internal/extractors/fsharp/extractor.go`) is regex-structural only — modules / namespaces / `let` / `member` / `type` + CALLS edges. It has **NO web-framework awareness**: no `http_endpoint_definition` is produced for F#, and there is no Expecto/xUnit testmap support. Giraffe `route`/`routef` are only recognised as dynamic-dispatch CALLS-suppression patterns (`internal/resolve/dynamic_patterns_fsharp.go`), not endpoint entities. So a route-string test had no endpoint target. As with Crystal/Swift, the producer-side gap is closed first (synthesize the canonical endpoint, not ship a dead extractor).

## What's implemented
- **Producer** — `internal/engine/http_endpoint_giraffe.go`: synthesizes one canonical `http_endpoint_definition` per statically-known F# route — Giraffe `GET >=> route "/users" >=> handler` / `routef "/users/%i"` chains (inside `choose [ ... ]`) and Saturn `router { get "/users/:id" handler }` blocks — in the same shape axum/Rocket/Express/Vapor/Kemal emit. Adds `FrameworkGiraffe` canonicalisation (`routef` printf placeholders `%i/%s/%O/...` → positional `{}` wildcard; Saturn `:name` colon params). Wired into the `fsharp` synthesis case + `synthesisSupportsLanguage` gate.
- **Route-hit linkage** — `internal/custom/fsharp/tests_route_e2e.go`: emits one `test_suite` per F# test file carrying `e2e_route_calls` from ASP.NET Core TestServer HttpClient helpers (`client.GetAsync("/path")` / `PostAsync` / … and `HttpRequestMessage(HttpMethod.X, "/path")`). The shared language-agnostic `engine.linkE2ERouteTestsToEndpoints` pass emits the TESTS edge. New `custom_fsharp_` dispatch prefix + registry blank import.
- **Scope-owner**: F# test DSLs use anonymous closure blocks (Expecto `testCase "..." <| fun _ -> ...` / `testList`; xUnit `[<Fact>]`), so the `test_suite` is the scope-owner carrying route hits (F# analog of Ruby #4684 / JS #4680 / Crystal #4760).

## Honest scope
- **Local-variable/receiver typing (part a) — N/A**: F# is functional; Giraffe handlers are `let`-bound `HttpHandler` values composed with `>=>`, not `obj.method()` receiver calls, and the base extractor names `let` entities bare with no class-qualified receiver resolver to consume a `receiver_type` stamp (mirrors functional Elixir #4688 / Crystal #4760). Route-string linkage is the coverage mechanism.
- Documented follow-ups: interpolated/variable paths, `subRoute`/`forward` mount-prefix folding, Giraffe `routeCi`/`routeStartsWith`/`routex` variants.

## Coverage docs
`lang.fsharp.framework.giraffe` record added (none existed) + `Testing.tests_linkage` → **full**, surgically (**231 insertions, 0 deletions**). `coverage fmt --check` passes; `coverage validate` reports **0 errors**.

## Validation (RED→GREEN)
- Producer/canonicalisation/negatives: `TestGiraffe_BasicRoute` / `_RoutefTypedParam` / `_SaturnRouter` / `_InterpolatedRouteDropped` / `_NonWebFileIgnored` / `_CanonicalizeFormat`
- Full synthesize→resolve→link pipeline: `TestGiraffe_E2ERouteTestLinkage`
- Route capture + exclusions: `TestFSharpRouteE2E_*`

## Gates
`go build ./...`, `go vet` (extractors/custom/graph), `go test` (extractors/custom/engine/graph/types), `coverage fmt --check`, `coverage validate` (0 errors) — all green.

Part of #4749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)