### PR TITLE
feat(erlang): Cowboy test→endpoint coverage-linkage (#4749 child)

### DIFF
--- a/internal/custom/erlang/tests_route_e2e.go
+++ b/internal/custom/erlang/tests_route_e2e.go
@@ -1,0 +1,234 @@
+// Package erlang — Erlang test→endpoint route-hit linkage.
+//
+// #4749 (the Erlang slice of epic #4615, all-framework test→endpoint coverage
+// linkage). Emits ONE test_suite entity per Erlang eunit / common_test test
+// file that drives an HTTP endpoint by ROUTE STRING, stamping the captured
+// `VERB route` pairs onto the suite's `e2e_route_calls` property. The shared
+// resolve pass (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches
+// each pair against the cross-file http_endpoint_definition index (produced for
+// Erlang by engine.synthesizeCowboy via the new `case "erlang"` synthesis
+// dispatch) and emits a TESTS edge to the exact endpoint exercised — exactly as
+// the Elixir/Phoenix, Ruby, PHP, C#, Swift and Clojure slices do for their
+// stacks. The engine pass is language-agnostic (it fires on any test_suite
+// carrying e2e_route_calls), so the only Erlang-specific work is the route
+// capture.
+//
+// Route-driving idioms captured (eunit / common_test against a test Cowboy /
+// Elli server, or direct HTTP client calls):
+//
+//	httpc:request(get,  {"http://localhost:8080/users/1", []}, [], [])
+//	httpc:request(post, {"/users", [], "application/json", Body}, [], [])
+//	httpc:request("http://localhost:8080/todos")            % bare GET form
+//	gun:get(Conn,  "/todos")
+//	gun:post(Conn, "/users", Headers, Body)
+//	hackney:request(get,  <<"http://localhost:8080/health">>, ...)
+//	hackney:get(<<"/todos/1">>, ...)
+//
+// httpc's verb is the FIRST argument atom (`get`/`post`/…) and the URL is the
+// first string in the request tuple (or the bare first string arg for the
+// 1-arity GET form). gun/hackney encode the verb in the function name
+// (`gun:get`, `hackney:post`). hackney URLs are frequently binaries
+// (`<<"...">>`), which we unwrap.
+//
+// Erlang is FUNCTIONAL / process-based: there are NO OO receiver objects, so the
+// "local-variable receiver typing" gap (#4680/#4681) does NOT apply — a Cowboy
+// handler is dispatched by the literal route path carried on the request, not by
+// an `obj.method()` receiver. The route-hit → endpoint linkage IS the coverage
+// mechanism here (mirrors the Elixir #4688 / Clojure #4749 documented N/A for
+// receiver typing).
+//
+// Test scope: eunit `name_test() -> ...` / `name_test_() -> ...` generators and
+// common_test `case(Config) -> ...` clauses are NAMED top-level functions
+// already mined by the base extractor's CALLS graph; the route-hit calls live
+// inside those bodies, so the suite is keyed to the FILE (one suite per test
+// file) the same way the Jest / ExUnit / clojure.test one-suite-per-file model
+// works — no synthetic anonymous-test-block scope owner is needed (Erlang test
+// "blocks" are named function clauses, not closures).
+//
+// Honest exclusion (matches the negative acceptance of the slice):
+//   - Built / concatenated URLs (`httpc:request(get, {"http://localhost:" ++
+//     integer_to_list(Port) ++ "/users", []}, ...)`) where the path is not a
+//     single string literal are NOT statically recoverable and are dropped. This
+//     is the COMMON real-world shape (eunit/CT spin a server on an ephemeral
+//     port and build the URL), so Erlang test-route linkage is recorded as
+//     PARTIAL: only fully-literal-path hits link. See the registry note + the
+//     #4749 Erlang follow-up for `++`-built-URL recovery.
+//   - Shape-only tests (assert on a value, never hit a route) emit no suite.
+//
+// Registration key: "custom_erlang_tests_route_e2e".
+package erlang
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_erlang_tests_route_e2e", &erlangTestRouteE2EExtractor{})
+}
+
+type erlangTestRouteE2EExtractor struct{}
+
+func (e *erlangTestRouteE2EExtractor) Language() string {
+	return "custom_erlang_tests_route_e2e"
+}
+
+var (
+	// httpc:request(get, {"url", ...}, ...) — verb-tagged request tuple form.
+	// Group 1 is the verb atom; group 2 is the first string literal in the tuple
+	// (the URL). The URL must be a bare double-quoted string literal.
+	erlHttpcVerbTupleRE = regexp.MustCompile(
+		`httpc\s*:\s*request\s*\(\s*([a-z]+)\s*,\s*\{\s*"([^"\n\r]*)"`)
+
+	// httpc:request("url") / httpc:request("url", ...) — bare 1/2-arity GET form
+	// where the first arg is the URL string literal (verb defaults to GET).
+	// Group 1 is the URL. The negative-lookahead-free regex requires the first
+	// arg to be a string literal (so the verb-tuple form above is not re-matched,
+	// since that starts with an atom not a quote).
+	erlHttpcBareRE = regexp.MustCompile(
+		`httpc\s*:\s*request\s*\(\s*"([^"\n\r]*)"`)
+
+	// gun:get(Conn, "/path") / gun:post(Conn, "/path", ...) — verb in the
+	// function name, path is the SECOND argument string literal.
+	// Group 1 is the verb; group 2 is the path literal.
+	erlGunRE = regexp.MustCompile(
+		`gun\s*:\s*(get|post|put|delete|patch|head|options)\s*\(\s*[^,]+,\s*"([^"\n\r]*)"`)
+
+	// hackney:request(get, <<"url">>, ...) / hackney:request(get, "url", ...).
+	// Group 1 is the verb; group 2 is the URL (binary or string literal).
+	erlHackneyVerbRE = regexp.MustCompile(
+		`hackney\s*:\s*request\s*\(\s*([a-z]+)\s*,\s*(?:<<\s*)?"([^"\n\r]*)"`)
+
+	// hackney:get(<<"url">>, ...) / hackney:post("url", ...) — verb in the
+	// function name, URL is the first argument (binary or string literal).
+	// Group 1 is the verb; group 2 is the URL.
+	erlHackneyVerbFnRE = regexp.MustCompile(
+		`hackney\s*:\s*(get|post|put|delete|patch|head|options)\s*\(\s*(?:<<\s*)?"([^"\n\r]*)"`)
+)
+
+func (e *erlangTestRouteE2EExtractor) Extract(
+	_ context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "erlang" {
+		return nil, nil
+	}
+	if !isErlangTestFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectErlangTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       erlangTestSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "erlang",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "cowboy",
+			"provenance":      "INFERRED_FROM_ERLANG_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectErlangTestRouteCalls returns the de-duplicated "VERB route" pairs an
+// eunit / common_test file drives by route string (httpc, gun, hackney forms).
+// URLs are reduced to their path; built / concatenated / variable URLs are not
+// matched by the string-literal regexes and are dropped (honest exclusion).
+func collectErlangTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawURL string) {
+		route := normaliseErlangTestRoute(rawURL)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+
+	// Track byte ranges already consumed by the verb-tuple form so the bare GET
+	// regex doesn't double-count the same httpc:request call's URL.
+	consumed := map[int]bool{}
+	for _, m := range erlHttpcVerbTupleRE.FindAllStringSubmatchIndex(source, -1) {
+		add(source[m[2]:m[3]], source[m[4]:m[5]])
+		consumed[m[0]] = true
+	}
+	for _, m := range erlHttpcBareRE.FindAllStringSubmatchIndex(source, -1) {
+		if consumed[m[0]] {
+			continue
+		}
+		add("GET", source[m[2]:m[3]])
+	}
+	for _, m := range erlGunRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range erlHackneyVerbRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range erlHackneyVerbFnRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	return out
+}
+
+// normaliseErlangTestRoute reduces a raw URL literal to a path: strips a
+// scheme+authority prefix, drops query/fragment, collapses repeated slashes.
+// Cowboy path-param placeholders (`:id`) and casing are preserved (the resolver
+// wildcards templates and compares case-insensitively).
+func normaliseErlangTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return p
+}
+
+// isErlangTestFile reports whether path looks like an eunit / common_test source
+// — a `*_tests.erl` (eunit) or `*_SUITE.erl` (common_test) file, or any `.erl`
+// under a `/test/` directory. Keeps the route-hit suite off production
+// handlers/routers that merely mention a route.
+func isErlangTestFile(path string) bool {
+	lp := strings.ToLower(filepath.ToSlash(path))
+	if strings.HasSuffix(lp, "_tests.erl") || strings.HasSuffix(lp, "_suite.erl") {
+		return true
+	}
+	if strings.Contains(lp, "/test/") && strings.HasSuffix(lp, ".erl") {
+		return true
+	}
+	return false
+}
+
+// erlangTestSuiteBaseName derives a suite label from the test file path
+// (`.../todo_handler_tests.erl` → `todo_handler_tests`).
+func erlangTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/custom/erlang/tests_route_e2e_test.go
+++ b/internal/custom/erlang/tests_route_e2e_test.go
@@ -1,0 +1,138 @@
+package erlang
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// extract is a small helper that runs the route-hit extractor and returns the
+// captured e2e_route_calls lines (or empty when no suite is emitted).
+func extractRouteCalls(t *testing.T, path, src string) []string {
+	t.Helper()
+	e := &erlangTestRouteE2EExtractor{}
+	out, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Language: "erlang",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected one suite, got %d", len(out))
+	}
+	calls := out[0].Properties["e2e_route_calls"]
+	if calls == "" {
+		return nil
+	}
+	return strings.Split(calls, "\n")
+}
+
+func hasCall(calls []string, want string) bool {
+	for _, c := range calls {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestErlang_HttpcVerbTuple covers the canonical eunit httpc:request verb-tuple
+// form against a test Cowboy server, with the host stripped to a path.
+func TestErlang_HttpcVerbTuple(t *testing.T) {
+	src := `
+-module(todo_handler_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+list_test() ->
+    {ok, {{_, 200, _}, _, _}} =
+        httpc:request(get, {"http://localhost:8080/todos", []}, [], []).
+
+create_test() ->
+    {ok, _} =
+        httpc:request(post, {"http://localhost:8080/todos", [], "application/json", "{}"}, [], []).
+`
+	calls := extractRouteCalls(t, "test/todo_handler_tests.erl", src)
+	if !hasCall(calls, "GET /todos") {
+		t.Errorf("missing GET /todos; got %v", calls)
+	}
+	if !hasCall(calls, "POST /todos") {
+		t.Errorf("missing POST /todos; got %v", calls)
+	}
+}
+
+// TestErlang_HttpcBareGet covers the 1-arity httpc:request("url") GET form and
+// must not also double-count via the verb-tuple regex.
+func TestErlang_HttpcBareGet(t *testing.T) {
+	src := `
+-module(health_SUITE).
+health(_Config) ->
+    {ok, _} = httpc:request("http://localhost:8080/health/live").
+`
+	calls := extractRouteCalls(t, "test/health_SUITE.erl", src)
+	if !hasCall(calls, "GET /health/live") {
+		t.Errorf("missing GET /health/live; got %v", calls)
+	}
+	if len(calls) != 1 {
+		t.Errorf("expected exactly one call (no double-count), got %v", calls)
+	}
+}
+
+// TestErlang_GunAndHackney covers gun:verb and hackney:verb forms, including a
+// hackney binary URL and a path param.
+func TestErlang_GunAndHackney(t *testing.T) {
+	src := `
+-module(api_tests).
+get_one_test() ->
+    gun:get(Conn, "/users/:id").
+post_test() ->
+    gun:post(Conn, "/users", [], <<"{}">>).
+health_test() ->
+    hackney:get(<<"http://localhost:8080/health">>, [], <<>>, []).
+del_test() ->
+    hackney:request(delete, <<"http://localhost:8080/users/1">>, [], <<>>, []).
+`
+	calls := extractRouteCalls(t, "test/api_tests.erl", src)
+	for _, want := range []string{"GET /users/:id", "POST /users", "GET /health", "DELETE /users/1"} {
+		if !hasCall(calls, want) {
+			t.Errorf("missing %q; got %v", want, calls)
+		}
+	}
+}
+
+// TestErlang_BuiltURLExcluded is the honest-exclusion guard: a `++`-built URL
+// (the common eunit/CT ephemeral-port shape) is NOT statically recoverable and
+// must not forge a route hit.
+func TestErlang_BuiltURLExcluded(t *testing.T) {
+	src := `
+-module(built_tests).
+go_test() ->
+    Url = "http://localhost:" ++ integer_to_list(Port) ++ "/users",
+    httpc:request(get, {Url, []}, [], []).
+`
+	calls := extractRouteCalls(t, "test/built_tests.erl", src)
+	if len(calls) != 0 {
+		t.Errorf("built URL should yield no route hits, got %v", calls)
+	}
+}
+
+// TestErlang_NonTestFileIgnored ensures production .erl handlers do not emit a
+// route-hit suite even if they mention an HTTP client call.
+func TestErlang_NonTestFileIgnored(t *testing.T) {
+	src := `
+-module(user_handler).
+init(Req, State) ->
+    httpc:request("http://example.com/upstream"),
+    {ok, Req, State}.
+`
+	calls := extractRouteCalls(t, "src/user_handler.erl", src)
+	if calls != nil {
+		t.Errorf("non-test file should emit no suite, got %v", calls)
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4749_erlang_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4749_erlang_test.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Erlang route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/erlang"
+)
+
+// Issue #4749 LIVE-REPRO (resolve side) — Erlang eunit / common_test tests.
+//
+// Proves end-to-end that an Erlang eunit test calling a route by string via
+// httpc / gun / hackney against a test Cowboy server links to the
+// http_endpoint_definition it exercises. The Erlang slice of the all-language
+// program (#4615 tail #4749), generalizing the shared
+// linkE2ERouteTestsToEndpoints pass (#4351). The pass is language-agnostic; only
+// the Erlang route capture (custom_erlang_tests_route_e2e) and wiring the
+// shared Cowboy producer (synthesizeCowboy) for `case "erlang"` are new. Erlang
+// is functional / process-based (no OO receiver objects) so receiver typing does
+// not apply; the route-string → endpoint linkage is the coverage mechanism.
+
+const erlHttpcTestSrc4749 = `-module(todo_handler_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+list_test() ->
+    {ok, {{_, 200, _}, _, _}} =
+        httpc:request(get, {"http://localhost:8080/todos", []}, [], []).
+
+create_test() ->
+    {ok, _} =
+        httpc:request(post, {"http://localhost:8080/todos", [], "application/json", "{}"}, [], []).
+`
+
+func TestIssue4749_ErlangHttpcE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("ANY", "/todos"),
+	}
+	suite := realSuite(t, "custom_erlang_tests_route_e2e",
+		"test/todo_handler_tests.erl", "erlang", erlHttpcTestSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 1 {
+		t.Fatalf("expected >=1 e2e route TESTS edge to ANY /todos, got %d", edges)
+	}
+	assertErlRouteEdges(t, edgeTargets(afterOut))
+}
+
+// Path-param variant: a gun:get(Conn, "/todos/1") hit matches the templated ANY
+// /todos/{id} definition via the resolver's concrete-vs-template matcher.
+const erlGunParamTestSrc4749 = `-module(todo_handler_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+get_one_test() ->
+    {ok, _} = gun:get(Conn, "/todos/1").
+`
+
+func TestIssue4749_ErlangGunPathParamLinks(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("ANY", "/todos/{id}"),
+	}
+	suite := realSuite(t, "custom_erlang_tests_route_e2e",
+		"test/todo_handler_tests.erl", "erlang", erlGunParamTestSrc4749)
+
+	_, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 1 {
+		t.Fatalf("expected a TESTS edge to ANY /todos/{id}, got %d", edges)
+	}
+}
+
+func assertErlRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	for to := range targets {
+		if strings.Contains(to, ":/todos") {
+			return
+		}
+	}
+	t.Errorf("expected a TESTS edge to /todos; targets=%v", targets)
+}

--- a/internal/engine/http_endpoint_erlang_test.go
+++ b/internal/engine/http_endpoint_erlang_test.go
@@ -1,0 +1,72 @@
+package engine
+
+import (
+	"testing"
+)
+
+// #4749 — Erlang Cowboy producer-side route synthesis. Proves an Erlang
+// `cowboy_router:compile([{'_', [{"/path", handler, []}]}])` dispatch table in
+// an `.erl` file (language="erlang") emits the same canonical
+// http_endpoint_definition the Elixir Cowboy producer emits, now that `case
+// "erlang"` is wired into the synthesis dispatch and Erlang is allowed through
+// synthesisSupportsLanguage. The synthesizer (synthesizeCowboy) is shared with
+// Elixir; this guards that it actually fires for Erlang-classified files.
+
+// TestErlang_CowboyDispatch asserts an ANY endpoint per dispatch-table route,
+// with `:id` colon-param normalisation and handler attribution, skipping the
+// `'_'` host wildcard.
+func TestErlang_CowboyDispatch(t *testing.T) {
+	src := `-module(myapp_app).
+-behaviour(application).
+-export([start/2]).
+
+start(_Type, _Args) ->
+    Dispatch = cowboy_router:compile([
+        {'_', [
+            {"/", index_handler, []},
+            {"/users/:id", user_handler, []},
+            {"/ws", socket_handler, []}
+        ]}
+    ]),
+    {ok, _} = cowboy:start_clear(http, [{port, 8080}],
+        #{env => #{dispatch => Dispatch}}).
+`
+	ids, res := runDetect(t, "erlang", "src/myapp_app.erl", src)
+	want := []string{
+		"http:ANY:/",
+		"http:ANY:/users/{id}",
+		"http:ANY:/ws",
+	}
+	requireContains(t, ids, want, "erlang-cowboy-dispatch")
+
+	var found bool
+	for _, e := range res.Entities {
+		if e.ID != "http:ANY:/users/{id}" {
+			continue
+		}
+		found = true
+		if e.Properties["framework"] != "cowboy" {
+			t.Errorf("erlang cowboy: framework=%q, want cowboy", e.Properties["framework"])
+		}
+	}
+	if !found {
+		t.Errorf("erlang cowboy: missing http:ANY:/users/{id}")
+	}
+}
+
+// TestErlang_NonCowboyTupleIgnored is the negative guard: an Erlang tuple of a
+// string + atom in a file with NO cowboy_router signal must not forge a route.
+func TestErlang_NonCowboyTupleIgnored(t *testing.T) {
+	src := `-module(config).
+-export([routes/0]).
+
+routes() ->
+    [{"/not-a-route", some_atom, []}].
+`
+	ids, _ := runDetect(t, "erlang", "src/config.erl", src)
+	for _, id := range ids {
+		if id == "http:ANY:/not-a-route" {
+			t.Fatalf("non-cowboy tuple forged an endpoint: %s", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -124,6 +124,12 @@ func synthesisSupportsLanguage(lang string) bool {
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
+	// #4749 (epic #4615 tail): Erlang Cowboy producer-side route synthesis —
+	// `cowboy_router:compile([{'_', [{"/path", handler, []}]}])` dispatch tables
+	// have no compiled YAML rules, so allow Erlang through for synthesizeCowboy.
+	// Files without a `cowboy_router` marker are no-ops inside the synthesizer.
+	case "erlang":
+		return true
 	// #1596: Infrastructure-as-Code languages have no compiled YAML rule sets
 	// of their own (Terraform rules live under the `hcl` key; CloudFormation
 	// YAML has none), so without this they would short-circuit out of Detect
@@ -1261,6 +1267,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Clojure. The clojure framework rule manifests stay for detection; this
 		// pass adds the canonical definitions the coverage substrate keys off.
 		synthesizeClojureRoutes(string(content), emit)
+	case "erlang":
+		// Producer side (#4749, epic #4615 tail): Erlang Cowboy dispatch route
+		// tables — `cowboy_router:compile([{'_', [{"/users/:id", user_handler,
+		// []}]}])`. The `{"/path", Handler, _}` triple shape is identical to the
+		// Elixir Cowboy form, so the existing synthesizeCowboy synthesizer (which
+		// gates on a `cowboy_router` signal and reads literal-path/handler triples)
+		// emits the canonical http_endpoint_definition for Erlang too. It was
+		// previously only reached for `case "elixir"` even though Cowboy is the
+		// Erlang HTTP server; this wires the same producer for `.erl` dispatch
+		// tables so the shared resolver + e2e route-test linker (#4351) light up.
+		synthesizeCowboy(string(content), emit)
 	case "scala":
 		// Consumer side (#3554): sttp (basicRequest/quickRequest verb
 		// combinators with uri"..." literals) outbound HTTP client. The Scala

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -74,6 +74,7 @@ var customPrefixForLanguage = map[string]string{
 	"dart":    "custom_dart_",
 	"elixir":  "custom_elixir_",
 	"clojure": "custom_clojure_",
+	"erlang":  "custom_erlang_",
 	"csharp":  "custom_csharp_",
 	"cpp":     "custom_cpp_",
 	"crystal": "custom_crystal_",

--- a/internal/extractors/custom_registry.go
+++ b/internal/extractors/custom_registry.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
 	_ "github.com/cajasmota/archigraph/internal/custom/dart"
 	_ "github.com/cajasmota/archigraph/internal/custom/elixir"
+	_ "github.com/cajasmota/archigraph/internal/custom/erlang"
 	_ "github.com/cajasmota/archigraph/internal/custom/golang"
 	_ "github.com/cajasmota/archigraph/internal/custom/java"
 	_ "github.com/cajasmota/archigraph/internal/custom/javascript"


### PR DESCRIPTION
Erlang slice of the coverage-linkage tail epic (#4749, child of #4615).

## Probe finding
The Erlang base extractor + substrate are structural only — no `http_endpoint_definition` was produced for Erlang and no test-route linkage existed. The shared Cowboy producer (`synthesizeCowboy`, written for #3468) already understood the `{"/path", Handler, _}` dispatch-triple shape but was **only reached for `case "elixir"`**, even though Cowboy is the *Erlang* HTTP server — so Erlang `.erl` dispatch tables were invisible as producers.

## Producer (wire existing synthesizeCowboy for Erlang)
- New `case "erlang"` in `applyHTTPEndpointSynthesis` → `synthesizeCowboy`, and `erlang` allowed through `synthesisSupportsLanguage`.
- `cowboy_router:compile([{'_', [{"/users/:id", user_handler, []}]}])` now emits canonical `http_endpoint_definition` (ANY per route, `:id` → `{id}` via `FrameworkCowboy`). No regex/canonicalize changes needed — Elixir and Erlang dispatch-triple shapes are identical (append-only synthesis case, trivial to rebase against sibling Groovy/F# slices).

## Test route-hit linkage (`custom_erlang_tests_route_e2e`, new)
- One `test_suite` per eunit/common_test file (`*_tests.erl`, `*_SUITE.erl`, `/test/` dir) carrying `e2e_route_calls` for `httpc:request` (verb-tuple + bare GET), `gun:get/post`, and `hackney:get/request` literal-path hits.
- The language-agnostic `engine.linkE2ERouteTestsToEndpoints` pass (#4351) emits the TESTS edge to the synthesised endpoint.

## Receiver typing / scope-owner — N/A
Erlang is functional / process-based: local-variable/receiver typing (#4680/#4681) is N/A — a Cowboy handler is dispatched by the literal route path, not by an `obj.method()` receiver (mirrors Elixir #4688 / Clojure #4749). eunit `name_test()`/CT `case(Config)` are named fn clauses (not closures), so the suite is keyed per-file — no synthetic anonymous-block scope-owner.

## Honest PARTIAL
eunit/CT commonly `++`-build URLs against an ephemeral test-server port; those non-literal paths are dropped (proven by `TestErlang_BuiltURLExcluded`). `++`-built-URL recovery is the documented follow-up.

## Registry
New `lang.erlang.framework.cowboy` record (full taxonomy backfilled honest-missing): `endpoint_synthesis`/`route_extraction` → full, `handler_attribution` → partial (ANY endpoint attributed to handler module; Cowboy verb dispatch lives in `init/2`, no per-verb IMPLEMENTS), `tests_linkage` → partial. Surgical (additive only, +237 lines); `coverage fmt --check` canonical + `coverage validate` 0 errors.

## Fixtures RED→GREEN
- `TestErlang_CowboyDispatch` (+ `TestErlang_NonCowboyTupleIgnored` guard) — producer
- `TestIssue4749_ErlangHttpcE2ERouteTestsLinkToEndpoints`, `TestIssue4749_ErlangGunPathParamLinks` — e2e TESTS edges (real extractor)
- `internal/custom/erlang/tests_route_e2e_test.go` — httpc/gun/hackney capture + built-URL/non-test-file exclusions

## Gates
`go build ./...`, `go vet`, `go test ./internal/{extractors,custom,engine,graph,types}/...`, `coverage fmt --check`, `coverage validate` (0 errors) — all green.

Part of #4749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)