### PR TITLE
feat(groovy): Grails/Ratpack test→endpoint coverage linkage (#4749)

### DIFF
--- a/internal/custom/groovy/tests_route_e2e.go
+++ b/internal/custom/groovy/tests_route_e2e.go
@@ -1,0 +1,255 @@
+// Package groovy — Groovy test→endpoint route-hit linkage.
+//
+// #4749 (the Groovy slice of the coverage-linkage tail epic #4749/#4615; the JVM
+// analog of the Java junit5 and Kotlin #4687 slices). Emits ONE test_suite
+// entity per Groovy test file that drives an HTTP endpoint by ROUTE STRING,
+// stamping the captured `VERB route` pairs onto the suite's `e2e_route_calls`
+// property (one "VERB route" per line). The shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index — which, for Groovy, is
+// populated by synthesizeGroovyRoutes (#4749, Grails/Ratpack) — and emits a TESTS
+// edge to the exact endpoint exercised, exactly as the Java/Kotlin/Crystal slices
+// do. The engine pass is language-agnostic (it fires on any test_suite carrying
+// e2e_route_calls), so the only Groovy-specific work here is the route capture.
+//
+// Route-driving idioms captured
+// ------------------------------
+//   - Spring on Groovy (Spock + Spring Boot Test): MockMvc
+//     `mockMvc.perform(get("/path"))` and WebTestClient
+//     `webTestClient.get().uri("/path")` — identical syntax to Java/Kotlin Spring.
+//   - Grails functional/integration: the Grails REST client DSL and the
+//     low-level `controller.request` form drive a route by string. The common
+//     statically-recoverable shape is `get "/path"` / `post "/path"` (the Grails
+//     RestBuilder / functional-test `get "$baseUrl/books"` idiom) and
+//     `restBuilder.get("/path")`.
+//   - Ratpack test harness: `testHttpClient.get("path")` /
+//     `client.post("path")` (the EmbeddedApp / GroovyRatpackMainApplicationUnderTest
+//     test client).
+//
+// Scope-owner (anonymous-block) note
+// ----------------------------------
+// A Spock feature method is declared `def "lists books"() { … }` with a STRING
+// name. The Groovy tree-sitter grammar does NOT parse that string-named method as
+// a normal method_definition (it surfaces as an ERROR/function_call node), so the
+// base extractor emits NO method entity for it and any route hit inside its
+// `when:` / `expect:` block would be orphaned. Therefore — exactly like the
+// Crystal #4760 / Ruby #4684 / JS #4680 anonymous-block case — the route-hit
+// signal is carried by the SUITE-LEVEL test_suite entity emitted here (the
+// scope-owner role), not by a per-feature operation.
+//
+// Honest exclusions (no fabricated edges)
+// ---------------------------------------
+//   - Interpolated / variable routes — a fully `"${path}"` route is dropped; a
+//     `"$baseUrl/books"` route keeps the static `/books` suffix only when a
+//     static path segment is statically recoverable (leading-interpolation is
+//     stripped to its trailing static path).
+//   - Non-request specs (pure unit/model specs that never hit a route) emit no
+//     suite.
+//
+// Registration key: "custom_groovy_tests_route_e2e".
+package groovy
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_groovy_tests_route_e2e", &groovyTestRouteE2EExtractor{})
+}
+
+type groovyTestRouteE2EExtractor struct{}
+
+func (e *groovyTestRouteE2EExtractor) Language() string {
+	return "custom_groovy_tests_route_e2e"
+}
+
+var (
+	// Spring MockMvc: mockMvc.perform(get("/api/v1/x"))
+	gvMockMvcRE = regexp.MustCompile(
+		`\.perform\s*\(\s*(get|post|put|delete|patch)\s*\(\s*"([^"\n\r]+)"`)
+
+	// Spring WebTestClient: webTestClient.get().uri("/api/v1/x").exchange()
+	gvWebTestClientRE = regexp.MustCompile(
+		`(?s)\.(get|post|put|delete|patch)\s*\(\s*\)\s*\.uri\s*\(\s*"([^"\n\r]+)"`)
+
+	// Test-client receiver call: testHttpClient.get("path") / restBuilder.post("/x")
+	// / client.put("path"). Anchored on a `.` receiver so a bare static helper
+	// `get("/x")` (the Spring MockMvc factory, handled above) is not double-counted.
+	gvClientRE = regexp.MustCompile(
+		`\.(get|post|put|delete|patch)\s*\(\s*"([^"\n\r]*)"`)
+
+	// Grails RestBuilder / functional-test top-level form: `get "/books"` /
+	// `post "$baseUrl/books"`. Anchored at a statement boundary so an
+	// `obj.get("...")` receiver call is not captured here.
+	gvBareVerbRE = regexp.MustCompile(
+		`(?m)(?:^|[={(]|\bwhen:|\bexpect:|\bthen:)\s*(get|post|put|delete|patch)\s+"([^"\n\r]*)"`)
+)
+
+func (e *groovyTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "groovy" {
+		return nil, nil
+	}
+	if !isGroovyTestFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectGroovyTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	framework := groovyTestFramework(source)
+	rec := types.EntityRecord{
+		Name:       groovyTestSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "groovy",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       framework,
+			"provenance":      "INFERRED_FROM_GROOVY_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	rec.ID = rec.ComputeID()
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectGroovyTestRouteCalls returns the de-duplicated "VERB route" pairs a
+// Groovy test file drives by route string (Spring MockMvc / WebTestClient,
+// receiver test-clients, and the Grails bare-verb form). Routes are normalised to
+// a leading-slash path; non-path / fully-variable literals are dropped.
+func collectGroovyTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		route := normaliseGroovyTestRoute(rawRoute)
+		if route == "" || !strings.HasPrefix(route, "/") {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	for _, m := range gvMockMvcRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range gvWebTestClientRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range gvClientRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range gvBareVerbRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	return out
+}
+
+// normaliseGroovyTestRoute reduces a raw route literal to a path: strips a
+// scheme+authority prefix, drops a Groovy string-interpolation prefix
+// (`"$baseUrl/books"` → `/books`), drops query/fragment, collapses repeated
+// slashes. A route with NO static path (`"${url}"`) is dropped. Path-param
+// placeholders ({id}) and casing are preserved (the resolver wildcards templates
+// and compares case-insensitively).
+func normaliseGroovyTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return ""
+	}
+	// Strip a scheme://authority prefix.
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	// A leading Groovy interpolation (`$baseUrl/books` or `${baseUrl}/books`) —
+	// keep from the first `/` after the interpolation token. A trailing
+	// interpolation (`/books/${id}`) keeps the static prefix.
+	if strings.HasPrefix(p, "$") {
+		if slash := strings.IndexByte(p, '/'); slash >= 0 {
+			p = p[slash:]
+		} else {
+			return ""
+		}
+	}
+	// Truncate at any remaining interpolation marker — only the static prefix is
+	// statically recoverable.
+	if i := strings.Index(p, "${"); i >= 0 {
+		p = p[:i]
+	}
+	if i := strings.Index(p, "$"); i >= 0 {
+		// A bare `$id` Grails-style param inside the path: keep the prefix.
+		p = p[:i]
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" || p == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// groovyTestFramework labels the suite by the dominant test-client signal.
+func groovyTestFramework(source string) string {
+	switch {
+	case strings.Contains(source, "mockMvc") || strings.Contains(source, "MockMvc") ||
+		strings.Contains(source, "WebTestClient") || strings.Contains(source, "webTestClient"):
+		return "spring"
+	case strings.Contains(source, "testHttpClient") || strings.Contains(source, "EmbeddedApp") ||
+		strings.Contains(source, "ratpack") || strings.Contains(source, "Ratpack"):
+		return "ratpack"
+	case strings.Contains(source, "RestBuilder") || strings.Contains(source, "grails") ||
+		strings.Contains(source, "Grails"):
+		return "grails"
+	case strings.Contains(source, "spock") || strings.Contains(source, "Specification"):
+		return "spock"
+	default:
+		return "spock"
+	}
+}
+
+// isGroovyTestFile reports whether path looks like a Groovy test/spec source —
+// under a test source set (`src/test/`, `src/integration-test/`, `/test/`) or a
+// *Spec/*Test/*IT named file. Keeps the route-hit suite off production code.
+func isGroovyTestFile(path string) bool {
+	lp := strings.ToLower(filepath.ToSlash(path))
+	if strings.Contains(lp, "/src/test/") || strings.Contains(lp, "/src/integration-test/") ||
+		strings.Contains(lp, "/test/") || strings.Contains(lp, "/spec/") {
+		return true
+	}
+	base := strings.TrimSuffix(filepath.Base(lp), ".groovy")
+	return strings.HasSuffix(base, "spec") || strings.HasSuffix(base, "test") ||
+		strings.HasSuffix(base, "tests") || strings.HasSuffix(base, "it")
+}
+
+// groovyTestSuiteBaseName derives a suite label from the test file path
+// (`.../BookControllerSpec.groovy` → `BookControllerSpec`).
+func groovyTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/custom/groovy/tests_route_e2e_test.go
+++ b/internal/custom/groovy/tests_route_e2e_test.go
@@ -1,0 +1,160 @@
+package groovy_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/groovy"
+)
+
+func fi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+func extractSuite(t *testing.T, path, src string) (string, bool) {
+	t.Helper()
+	e, ok := extreg.Get("custom_groovy_tests_route_e2e")
+	if !ok {
+		t.Fatal("custom_groovy_tests_route_e2e not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi(path, "groovy", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) == 0 {
+		return "", false
+	}
+	if len(ents) != 1 {
+		t.Fatalf("expected exactly 1 test_suite, got %d", len(ents))
+	}
+	if ents[0].Subtype != "test_suite" {
+		t.Errorf("expected test_suite, got %q", ents[0].Subtype)
+	}
+	return ents[0].Properties["e2e_route_calls"], true
+}
+
+// Spock + Spring MockMvc route hits are captured onto a single test_suite.
+func TestGroovyRouteE2E_SpockMockMvc(t *testing.T) {
+	src := `
+import spock.lang.Specification
+
+class BookControllerSpec extends Specification {
+  def "lists books"() {
+    when:
+    def result = mockMvc.perform(get("/api/v1/books"))
+    then:
+    result.andExpect(status().isOk())
+  }
+
+  def "creates a book"() {
+    expect:
+    mockMvc.perform(post("/api/v1/books"))
+  }
+}
+`
+	calls, ok := extractSuite(t, "src/test/groovy/BookControllerSpec.groovy", src)
+	if !ok {
+		t.Fatal("expected a test_suite")
+	}
+	for _, want := range []string{"GET /api/v1/books", "POST /api/v1/books"} {
+		if !strings.Contains(calls, want) {
+			t.Errorf("expected route call %q in %q", want, calls)
+		}
+	}
+}
+
+// Ratpack test-client route hits are captured.
+func TestGroovyRouteE2E_RatpackClient(t *testing.T) {
+	src := `
+import ratpack.test.embed.EmbeddedApp
+
+class HealthSpec extends Specification {
+  def "health is ok"() {
+    when:
+    def resp = testHttpClient.get("api/health")
+    then:
+    resp.statusCode == 200
+  }
+}
+`
+	calls, ok := extractSuite(t, "src/test/groovy/HealthSpec.groovy", src)
+	if !ok {
+		t.Fatal("expected a test_suite")
+	}
+	if !strings.Contains(calls, "GET /api/health") {
+		t.Errorf("expected GET /api/health in %q", calls)
+	}
+}
+
+// Grails RestBuilder bare-verb form (`get "$baseUrl/books"`) keeps the static path.
+func TestGroovyRouteE2E_GrailsBareVerb(t *testing.T) {
+	src := `
+class BookFunctionalSpec extends Specification {
+  def "fetches books"() {
+    when:
+    def resp = get "$baseUrl/books"
+    then:
+    resp.status == 200
+  }
+}
+`
+	calls, ok := extractSuite(t, "src/integration-test/groovy/BookFunctionalSpec.groovy", src)
+	if !ok {
+		t.Fatal("expected a test_suite")
+	}
+	if !strings.Contains(calls, "GET /books") {
+		t.Errorf("expected GET /books in %q", calls)
+	}
+}
+
+// A pure unit spec with no route hit emits NO suite (honest exclusion).
+func TestGroovyRouteE2E_NoRouteNoSuite(t *testing.T) {
+	src := `
+class CalculatorSpec extends Specification {
+  def "adds"() {
+    expect:
+    1 + 1 == 2
+  }
+}
+`
+	if _, ok := extractSuite(t, "src/test/groovy/CalculatorSpec.groovy", src); ok {
+		t.Error("expected no test_suite for a routeless spec")
+	}
+}
+
+// A non-test file is never turned into a suite (the route-string would be a
+// production route, not a test hit).
+func TestGroovyRouteE2E_NonTestFileSkipped(t *testing.T) {
+	src := `class BookController { def index() { get "/books" } }`
+	if _, ok := extractSuite(t, "grails-app/controllers/BookController.groovy", src); ok {
+		t.Error("expected no test_suite for a non-test file")
+	}
+}
+
+// A fully-interpolated route (`"${url}"`) is dropped — no static path.
+func TestGroovyRouteE2E_InterpolatedDropped(t *testing.T) {
+	src := `
+class XSpec extends Specification {
+  def "x"() {
+    when:
+    mockMvc.perform(get("/api/books"))
+    def r = testHttpClient.get("${dynamicPath}")
+    then:
+    true
+  }
+}
+`
+	calls, ok := extractSuite(t, "src/test/groovy/XSpec.groovy", src)
+	if !ok {
+		t.Fatal("expected a test_suite (the static /api/books hit)")
+	}
+	if !strings.Contains(calls, "GET /api/books") {
+		t.Errorf("expected GET /api/books in %q", calls)
+	}
+	if strings.Contains(calls, "${") {
+		t.Errorf("interpolated route must be dropped; got %q", calls)
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4749_groovy_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4749_groovy_test.go
@@ -1,0 +1,104 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Groovy route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/groovy"
+)
+
+// Issue #4749 LIVE-REPRO (resolve side) — Groovy Spock + Spring MockMvc route-hit
+// tests. Proves end-to-end that a Groovy spec calling a route by string
+// (`mockMvc.perform(get("/path"))`) links to the http_endpoint_definition it
+// exercises — the Groovy slice of the all-language program (#4615/#4749). The
+// shared linkE2ERouteTestsToEndpoints pass is language-agnostic; only the Groovy
+// route capture + the Grails/Ratpack producer synthesis are new.
+
+const groovySpockMockMvcSrc4749 = `
+import spock.lang.Specification
+
+class BookControllerSpec extends Specification {
+  def "lists books"() {
+    when:
+    def result = mockMvc.perform(get("/api/v1/books"))
+    then:
+    result.andExpect(status().isOk())
+  }
+
+  def "creates a book"() {
+    expect:
+    mockMvc.perform(post("/api/v1/books"))
+  }
+}
+`
+
+func TestIssue4749_GroovySpockE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/books"),
+		def("POST", "/api/v1/books"),
+	}
+	suite := realSuite(t, "custom_groovy_tests_route_e2e",
+		"src/test/groovy/BookControllerSpec.groovy", "groovy", groovySpockMockMvcSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertGroovyRouteEdges(t, edgeTargets(afterOut))
+}
+
+func assertGroovyRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/books") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/books") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /api/v1/books; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /api/v1/books; targets=%v", targets)
+	}
+}
+
+// Grails-convention endpoints synthesize verb ANY; a Spock integration test that
+// hits the route by string (any verb) must still link via verbsMatchCompat(ANY).
+func TestIssue4749_GroovyGrailsAnyVerbE2ELink(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("ANY", "/book/show"),
+	}
+	src := `
+class BookFunctionalSpec extends Specification {
+  def "fetches a book"() {
+    when:
+    def resp = get "$baseUrl/book/show"
+    then:
+    resp.status == 200
+  }
+}
+`
+	suite := realSuite(t, "custom_groovy_tests_route_e2e",
+		"src/integration-test/groovy/BookFunctionalSpec.groovy", "groovy", src)
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 1 {
+		t.Fatalf("expected >=1 TESTS edge to the ANY-verb Grails endpoint, got %d", edges)
+	}
+	found := false
+	for to := range edgeTargets(afterOut) {
+		if strings.Contains(to, ":/book/show") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a TESTS edge to /book/show; targets=%v", edgeTargets(afterOut))
+	}
+}

--- a/internal/engine/http_endpoint_grails.go
+++ b/internal/engine/http_endpoint_grails.go
@@ -1,0 +1,307 @@
+// http_endpoint_grails.go — Groovy Grails / Ratpack route registration →
+// canonical http_endpoint_definition synthesis (#4749, the Groovy slice of the
+// coverage-linkage tail epic #4749/#4615; mirrors the Crystal/Kemal #4760 and
+// Swift/Vapor #4755 producer-first slices).
+//
+// Background
+// ----------
+// The Groovy base extractor (internal/extractors/groovy/groovy.go) is a
+// tree-sitter structural extractor: it mines classes / methods / CALLS edges and
+// Gradle DSL, but has NO web-framework awareness — Grails controller actions and
+// Ratpack handler-DSL routes are not recognised as HTTP endpoints, and no
+// http_endpoint_definition entity is ever produced for Groovy (the Grails YAML
+// rule set is framework-DETECTION only; spring_routes.go is gated `lang=="java"`).
+// The shared e2e route-test linker (linkE2ERouteTestsToEndpoints, #4351) matches
+// a test's route hit against http_endpoint_definition + path, so a Groovy route
+// could never be hit by a route-string test. As with Crystal/Swift, the
+// PRODUCER-side gap has to be closed first.
+//
+// This pass emits one canonical http_endpoint_definition per statically-known
+// Groovy route, in the SAME shape axum / Express / Vapor / Kemal emit, so the
+// existing resolver and the language-agnostic e2e route-test linker light up for
+// Groovy exactly as for the flagship stacks.
+//
+// Grails (convention)
+// -------------------
+// Grails maps a controller class + action methods to `/<controller>/<action>`
+// by convention (the controller's leaf name minus the `Controller` suffix,
+// lower-cased; each action method/closure becomes an action segment):
+//
+//	// grails-app/controllers/com/x/BookController.groovy
+//	class BookController {
+//	  def index() { ... }              → /book/index
+//	  def show() { ... }               → /book/show
+//	  def save() { ... }               → /book/save
+//	}
+//
+// A Grails action responds to whatever HTTP method the URL mapping permits
+// (GET by default, but `static allowedMethods` can widen it and the convention
+// surface is method-agnostic), so the synthesized verb is ANY — the honest
+// statically-recoverable contract. The shared linker's verbsMatchCompat treats
+// ANY as matching every test verb, so a `GET "/book/index"` or
+// `POST "/book/save"` integration test still links.
+//
+// Grails (explicit UrlMappings.groovy)
+// ------------------------------------
+// An explicit mapping declares a path with Grails dollar-prefixed parameters:
+//
+//	// grails-app/controllers/UrlMappings.groovy
+//	"/book/$id"(controller: "book", action: "show")   → /book/{id}
+//
+// The synthesizer rewrites `$name` → `{name}` and canonicalises through
+// FrameworkGrails (curly-brace pass). The verb is ANY unless a `method:` is set.
+//
+// Ratpack (handler DSL)
+// ---------------------
+// Ratpack registers routes with a verb-DSL handler taking a string-literal path:
+//
+//	get("api/books") { ... }            → GET /api/books
+//	get("api/book/:id") { ... }         → GET /api/book/{id}
+//	post("api/books") { ... }           → POST /api/books
+//	path("health") { ... }              → (path() is verb-agnostic — ANY)
+//
+// Ratpack paths are declared WITHOUT a leading slash and use the Express-style
+// `:name` colon parameter; canonicalised through FrameworkRatpack.
+//
+// Honest exclusions (no fabricated routes)
+// ----------------------------------------
+//   - Interpolated / variable paths (`get("${prefix}/x")`) — dropped.
+//   - A controller class with NO action methods emits nothing.
+//   - Ratpack `get(...)` WITHOUT a string-literal path (chain delegation) — dropped.
+//   - Spring-on-Groovy `@GetMapping` controllers are already covered by the
+//     shared annotation route surface where Groovy is treated as a JVM language;
+//     this pass focuses on the Grails-convention + Ratpack idioms that have no
+//     other producer.
+package engine
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ratpackRouteRe matches a Ratpack verb-DSL handler with a leading
+// string-literal path: `get("api/books") { ... }`, `post("books", handler)`.
+// The verb is a method-call identifier at a statement boundary (the chain DSL
+// puts each verb at the start of its segment), followed by `("path"`.
+var ratpackRouteRe = regexp.MustCompile(
+	`\b(get|post|put|delete|patch|options)\s*\(\s*"([^"\n\r]*)"`,
+)
+
+// ratpackPathRe matches the verb-agnostic `path("x") { … }` registration.
+var ratpackPathRe = regexp.MustCompile(
+	`\bpath\s*\(\s*"([^"\n\r]*)"`,
+)
+
+// grailsActionRe matches a Grails controller action declaration inside a
+// controller class body — `def index() { … }`, `def show(Long id) { … }`,
+// `def save = { … }` (closure-style action). Capture group 1 is the action name.
+var grailsActionRe = regexp.MustCompile(
+	`(?m)^\s*def\s+([a-zA-Z_]\w*)\s*(?:\([^)]*\)\s*\{|=\s*\{)`,
+)
+
+// grailsUrlMappingRe matches an explicit UrlMappings.groovy entry:
+// `"/book/$id"(controller: "book", action: "show")`. Capture group 1 is the
+// path, group 2 the trailing parenthesised config (controller/action/method).
+var grailsUrlMappingRe = regexp.MustCompile(
+	`(?m)^\s*"(/[^"\n\r]*)"\s*\(([^)]*)\)`,
+)
+
+// grailsControllerNameRe extracts the controller class name from a
+// `class FooController { … }` declaration.
+var grailsControllerNameRe = regexp.MustCompile(
+	`\bclass\s+([A-Z]\w*Controller)\b`,
+)
+
+// synthesizeGroovyRoutes scans a Groovy source file for Grails controller
+// conventions, Grails UrlMappings, and Ratpack handler-DSL routes, and emits one
+// http_endpoint_definition per statically-known (verb, path).
+func synthesizeGroovyRoutes(content, path string, emit emitFn) {
+	src := content
+	slashed := filepath.ToSlash(path)
+	base := filepath.Base(slashed)
+
+	// Grails explicit URL mappings (UrlMappings.groovy) take priority — they are
+	// the authoritative route table when present.
+	if strings.EqualFold(base, "UrlMappings.groovy") {
+		synthesizeGrailsUrlMappings(src, emit)
+		return
+	}
+
+	// Grails convention: a *Controller.groovy under grails-app/controllers/ (or
+	// any file declaring a `class FooController`) maps each action to
+	// `/<controller>/<action>`.
+	if isGrailsControllerFile(slashed, src) {
+		synthesizeGrailsConventionRoutes(src, emit)
+	}
+
+	// Ratpack handler DSL can appear in any Groovy file (ratpack.groovy, a
+	// Handlers chain). The pre-filter keeps it off arbitrary Groovy.
+	if ratpackLikely(src) {
+		synthesizeRatpackRoutes(src, emit)
+	}
+}
+
+// isGrailsControllerFile reports whether path/src looks like a Grails controller
+// — under grails-app/controllers/ OR a file declaring a `class *Controller`.
+func isGrailsControllerFile(slashed, src string) bool {
+	if strings.Contains(slashed, "grails-app/controllers/") {
+		return true
+	}
+	return grailsControllerNameRe.MatchString(src)
+}
+
+// synthesizeGrailsConventionRoutes emits `/<controller>/<action>` endpoints for
+// each controller class + its action methods. Verb is ANY (Grails actions are
+// method-agnostic by convention).
+func synthesizeGrailsConventionRoutes(src string, emit emitFn) {
+	m := grailsControllerNameRe.FindStringSubmatch(src)
+	if m == nil {
+		return
+	}
+	controller := grailsControllerSlug(m[1])
+	if controller == "" {
+		return
+	}
+	seen := map[string]bool{}
+	for _, a := range grailsActionRe.FindAllStringSubmatch(src, -1) {
+		action := a[1]
+		if action == "" || grailsNonActionDef[action] {
+			continue
+		}
+		if seen[action] {
+			continue
+		}
+		seen[action] = true
+		raw := "/" + controller + "/" + action
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGrails, raw)
+		if canonical == "" {
+			continue
+		}
+		// refKind=Controller, refName=action → same-file handler bridge binds to
+		// the action method the Groovy base extractor emits.
+		emit("ANY", canonical, "grails", "Controller", action)
+	}
+}
+
+// synthesizeGrailsUrlMappings emits endpoints from explicit UrlMappings.groovy
+// entries (`"/book/$id"(controller: "book", action: "show", method: "GET")`).
+func synthesizeGrailsUrlMappings(src string, emit emitFn) {
+	for _, m := range grailsUrlMappingRe.FindAllStringSubmatch(src, -1) {
+		rawPath := m[1]
+		cfg := m[2]
+		// Drop interpolated paths.
+		if strings.Contains(rawPath, "${") {
+			continue
+		}
+		// Rewrite Grails dollar-params `$id` → `{id}` before canonicalisation.
+		rewritten := grailsDollarParamsToCurly(rawPath)
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGrails, rewritten)
+		if canonical == "" {
+			continue
+		}
+		verb := "ANY"
+		if mv := grailsMappingMethod(cfg); mv != "" {
+			verb = mv
+		}
+		action := grailsMappingAction(cfg)
+		refName := ""
+		if action != "" {
+			refName = action
+		}
+		emit(verb, canonical, "grails", "Controller", refName)
+	}
+}
+
+// synthesizeRatpackRoutes emits endpoints for Ratpack verb-DSL handlers.
+func synthesizeRatpackRoutes(src string, emit emitFn) {
+	seen := map[string]bool{}
+	add := func(verb, raw string) {
+		raw = strings.TrimSpace(raw)
+		if raw == "" || strings.Contains(raw, "${") {
+			return
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkRatpack, raw)
+		if canonical == "" || canonical == "/" {
+			return
+		}
+		key := verb + " " + canonical
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		emit(verb, canonical, "ratpack", inlineHandlerRefKind, "")
+	}
+	for _, m := range ratpackRouteRe.FindAllStringSubmatch(src, -1) {
+		add(strings.ToUpper(m[1]), m[2])
+	}
+	for _, m := range ratpackPathRe.FindAllStringSubmatch(src, -1) {
+		add("ANY", m[1])
+	}
+}
+
+// ratpackLikely is a fast pre-filter: the file must reference a Ratpack marker
+// AND a verb-DSL call to be worth scanning, so we never misfire on arbitrary
+// Groovy that happens to call a `get`/`post` method.
+func ratpackLikely(src string) bool {
+	if !strings.Contains(src, "ratpack") && !strings.Contains(src, "Ratpack") &&
+		!strings.Contains(src, "Handlers") && !strings.Contains(src, "RatpackServer") &&
+		!strings.Contains(src, "GroovyChainAction") {
+		return false
+	}
+	return ratpackRouteRe.MatchString(src) || ratpackPathRe.MatchString(src)
+}
+
+// grailsControllerSlug turns `BookController` → `book`, `UserAccountController`
+// → `userAccount` (Grails lower-cases the first letter of the de-suffixed name).
+func grailsControllerSlug(className string) string {
+	name := strings.TrimSuffix(className, "Controller")
+	if name == "" {
+		return ""
+	}
+	return strings.ToLower(name[:1]) + name[1:]
+}
+
+// grailsNonActionDef is the set of `def` names inside a Grails controller that
+// are NOT request actions (lifecycle / interceptor hooks). Excluding them keeps
+// phantom endpoints out of the catalogue.
+var grailsNonActionDef = map[string]bool{
+	"beforeInterceptor": true,
+	"afterInterceptor":  true,
+}
+
+// grailsDollarParamsToCurly rewrites Grails dollar-prefixed path parameters
+// (`/book/$id`, `/book/$author/$title`) to the canonical curly form
+// (`/book/{id}`). A `$` not followed by an identifier is left intact.
+func grailsDollarParamsToCurly(p string) string {
+	return grailsDollarParamRe.ReplaceAllString(p, "{$1}")
+}
+
+var grailsDollarParamRe = regexp.MustCompile(`\$([a-zA-Z_]\w*)`)
+
+// grailsMappingMethod extracts an explicit `method: "POST"` from a UrlMappings
+// config fragment, upper-cased, or "" when absent.
+func grailsMappingMethod(cfg string) string {
+	if m := grailsMappingMethodRe.FindStringSubmatch(cfg); m != nil {
+		return strings.ToUpper(m[1])
+	}
+	return ""
+}
+
+var grailsMappingMethodRe = regexp.MustCompile(`method\s*:\s*"([A-Za-z]+)"`)
+
+// grailsMappingAction extracts `action: "show"` from a UrlMappings config
+// fragment, or "" when absent (or a map-of-methods form we don't bind).
+func grailsMappingAction(cfg string) string {
+	if m := grailsMappingActionRe.FindStringSubmatch(cfg); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+var grailsMappingActionRe = regexp.MustCompile(`action\s*:\s*"([a-zA-Z_]\w*)"`)

--- a/internal/engine/http_endpoint_grails_test.go
+++ b/internal/engine/http_endpoint_grails_test.go
@@ -1,0 +1,92 @@
+package engine
+
+import "testing"
+
+// TestGrails_ConventionRoutes covers the Grails controller convention: each
+// action method maps to `/<controller>/<action>` with verb ANY.
+func TestGrails_ConventionRoutes(t *testing.T) {
+	src := `
+package com.x
+
+class BookController {
+    def index() { render Book.list() }
+    def show(Long id) { render Book.get(id) }
+    def save() { new Book(params).save() }
+
+    def beforeInterceptor = { log.info("before") }
+}
+`
+	ids, _ := runDetect(t, "groovy", "grails-app/controllers/com/x/BookController.groovy", src)
+	requireContains(t, ids, []string{
+		"http:ANY:/book/index",
+		"http:ANY:/book/show",
+		"http:ANY:/book/save",
+	}, "grails-convention")
+	// beforeInterceptor is a lifecycle hook, NOT an action — must not synthesize.
+	for _, id := range ids {
+		if id == "http:ANY:/book/beforeInterceptor" {
+			t.Fatalf("grails: lifecycle hook beforeInterceptor must not be an endpoint; ids=%v", ids)
+		}
+	}
+}
+
+// TestGrails_UrlMappings covers explicit UrlMappings.groovy with dollar-params
+// and an explicit method.
+func TestGrails_UrlMappings(t *testing.T) {
+	src := `
+class UrlMappings {
+    static mappings = {
+        "/book/$id"(controller: "book", action: "show")
+        "/book"(controller: "book", action: "save", method: "POST")
+        "/author/$name/books"(controller: "author", action: "books")
+    }
+}
+`
+	ids, _ := runDetect(t, "groovy", "grails-app/controllers/UrlMappings.groovy", src)
+	requireContains(t, ids, []string{
+		"http:ANY:/book/{id}",
+		"http:POST:/book",
+		"http:ANY:/author/{name}/books",
+	}, "grails-urlmappings")
+}
+
+// TestRatpack_HandlerDSL covers the Ratpack verb-DSL handler routes.
+func TestRatpack_HandlerDSL(t *testing.T) {
+	src := `
+import ratpack.server.RatpackServer
+
+RatpackServer.start { server ->
+    server.handlers { chain ->
+        chain.get("api/books") { ctx -> ctx.render("books") }
+        chain.get("api/book/:id") { ctx -> ctx.render("book") }
+        chain.post("api/books") { ctx -> ctx.render("created") }
+    }
+}
+`
+	ids, _ := runDetect(t, "groovy", "src/ratpack/ratpack.groovy", src)
+	requireContains(t, ids, []string{
+		"http:GET:/api/books",
+		"http:GET:/api/book/{id}",
+		"http:POST:/api/books",
+	}, "ratpack-handler-dsl")
+}
+
+// TestRatpack_InterpolatedDropped is the honest-exclusion guard.
+func TestRatpack_InterpolatedDropped(t *testing.T) {
+	src := `
+import ratpack.server.RatpackServer
+RatpackServer.start { server ->
+    server.handlers { chain ->
+        chain.get("api/static") { ctx -> ctx.render("ok") }
+        chain.get("${dynamicPrefix}/x") { ctx -> ctx.render("dyn") }
+    }
+}
+`
+	ids, _ := runDetect(t, "groovy", "src/ratpack/ratpack.groovy", src)
+	requireContains(t, ids, []string{"http:GET:/api/static"}, "ratpack-static")
+	for _, id := range ids {
+		if id == "http:GET:/${dynamicPrefix}/x" || id == "http:GET:/{dynamicPrefix}/x" {
+			t.Fatalf("ratpack: interpolated route must be dropped; ids=%v", ids)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -128,6 +128,14 @@ func synthesisSupportsLanguage(lang string) bool {
 	// marker + route token are no-ops inside the synthesizer.
 	case "fsharp":
 		return true
+	// #4749: Groovy Grails (convention `/controller/action` + UrlMappings.groovy)
+	// and Ratpack handler-DSL producer-side route synthesis — no compiled YAML
+	// rules emit http_endpoint_definition for Groovy (the Grails rule set is
+	// detection-only; spring_routes.go is gated lang=="java"), so allow Groovy
+	// through for synthesizeGroovyRoutes. Files without a Grails/Ratpack marker
+	// are no-ops inside the synthesizer.
+	case "groovy":
+		return true
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
@@ -1315,6 +1323,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// extractor stays structural-only; this pass adds the canonical
 		// definitions the coverage substrate keys off.
 		synthesizeGiraffeRoutes(string(content), emit)
+	case "groovy":
+		// Producer side (#4749): Groovy web route registrations — Grails
+		// convention controllers (`class BookController { def show() {…} }` →
+		// `ANY /book/show`), explicit UrlMappings.groovy (`"/book/$id"(...)` →
+		// `/book/{id}`), and Ratpack handler DSL (`get("api/books") {…}`) →
+		// canonical http_endpoint_definition, in the same shape
+		// axum/Express/Vapor/Kemal emit, so the shared resolver and the e2e
+		// route-test linker (#4351) light up for Groovy. The base groovy
+		// extractor stays structural-only; this pass adds the canonical
+		// definitions the coverage substrate keys off.
+		synthesizeGroovyRoutes(string(content), path, emit)
 	case "yaml", "json":
 		// Producer side (#3628, area #16): OpenAPI 3.x / Swagger 2.0 spec
 		// files declare the HTTP API surface as ground-truth. Each

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -213,6 +213,20 @@ const (
 	// Express-style `:name` colon convention, so the same canonicaliser handles
 	// both `%fmt` and `:name`.
 	FrameworkGiraffe = "giraffe"
+	// FrameworkGrails (#4749) — Groovy Grails. Grails has two route surfaces:
+	// (1) the convention `/<controller>/<action>` mapping derived from a
+	// `FooController` class in grails-app/controllers + its action methods, and
+	// (2) explicit `UrlMappings.groovy` mappings which use Grails dollar-prefixed
+	// path parameters (`/book/$id`, `/book/$author/$title`). The synthesizer
+	// pre-rewrites `$name` → `{name}`, so canonicalisation is the shared
+	// curly-brace pass.
+	FrameworkGrails = "grails"
+	// FrameworkRatpack (#4749) — Groovy/JVM Ratpack handler DSL
+	// (`get("path") { … }`, `path("api/:id") { … }`). Ratpack uses the
+	// Express-style `:name` colon-prefixed path-parameter convention and
+	// declares paths WITHOUT a leading slash (the synthesizer adds it).
+	// Canonicalisation reuses canonicalizeColonParams.
+	FrameworkRatpack = "ratpack"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -251,7 +265,7 @@ func Canonicalize(framework, raw string) string {
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
 		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi,
 		FrameworkLitestar, FrameworkAiohttp, FrameworkFalcon, FrameworkHug,
-		FrameworkJavalin, FrameworkVertx:
+		FrameworkJavalin, FrameworkVertx, FrameworkGrails:
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkTornado:
 		// Tornado paths arrive already pre-processed by the synthesizer
@@ -263,7 +277,7 @@ func Canonicalize(framework, raw string) string {
 		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails,
 		FrameworkRobyn, FrameworkPlug, FrameworkCowboy,
 		FrameworkLapis, FrameworkOpenResty, FrameworkVapor, FrameworkClojure,
-		FrameworkKemal:
+		FrameworkKemal, FrameworkRatpack:
 		out = canonicalizeColonParams(raw)
 	case FrameworkGiraffe:
 		// Giraffe `routef "/users/%i"` printf placeholders → `{}` first, then

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -52,6 +52,11 @@ var customPrefixForLanguage = map[string]string{
 	"sql":    "custom_js_",
 	"java":   "custom_java_",
 	"kotlin": "custom_kotlin_",
+	// Groovy framework extractors (#4749 Grails/Ratpack test→endpoint route-hit
+	// linkage). The base "groovy" tree-sitter extractor key is shorter than this
+	// prefix, so the `len(k) > len(prefix)` guard in CustomExtractorsFor excludes
+	// it and only the custom_groovy_* framework extractors match.
+	"groovy": "custom_groovy_",
 	// Lua framework extractors (OpenResty, Lapis, Kong, APISIX) register under
 	// the bare `lua_` prefix (lua_routing, lua_middleware, lua_kong, …) rather
 	// than `custom_lua_`. The base "lua" tree-sitter extractor key is shorter

--- a/internal/extractors/custom_registry.go
+++ b/internal/extractors/custom_registry.go
@@ -14,6 +14,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/custom/elixir"
 	_ "github.com/cajasmota/archigraph/internal/custom/fsharp"
 	_ "github.com/cajasmota/archigraph/internal/custom/golang"
+	_ "github.com/cajasmota/archigraph/internal/custom/groovy"
 	_ "github.com/cajasmota/archigraph/internal/custom/java"
 	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
 	_ "github.com/cajasmota/archigraph/internal/custom/kotlin"

--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -647,10 +647,28 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 	if len(calls) == 0 {
 		return nil
 	}
+	// #4749 (Groovy slice of the coverage-linkage tail epic #4749/#4615; the JVM
+	// analog of Java #4682). Build a local-variable → constructed-type map from
+	// `def c = new FooController(...)` / `FooController c = new FooController()`
+	// declarations in this body so a later `c.index()` receiver call resolves to
+	// the class method `FooController.index` (test→CALLS crediting) instead of
+	// degrading to the bare leaf `index`. Only a DIRECT `new ClassName(...)`
+	// initialiser types the local — a factory/builder RHS (`def c =
+	// MyFactory.create()`) leaves the local UNtyped (no fabricated edge),
+	// mirroring the Java #4682 conservatism.
+	localVarTypes := collectGroovyLocalVarTypes(body, src)
+	// #4749 — the `function_call` that is the operand of a `new` unary_op is a
+	// CONSTRUCTOR (`new FooController()`), not an outbound method call; emitting
+	// it as a bare `FooController` CALLS edge is a phantom. Collect those nodes
+	// so they can be skipped (the type is already lifted into localVarTypes).
+	ctorCalls := groovyConstructorCalls(body)
 	seen := make(map[string]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
 	for _, call := range calls {
-		target, recv := groovyCallTarget(call, src)
+		if ctorCalls[call] {
+			continue
+		}
+		target, recv := groovyCallTargetWithLocals(call, src, localVarTypes)
 		if target == "" {
 			continue
 		}
@@ -691,8 +709,20 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 
 // groovyCallTarget resolves the callee target of a function_call node.
 // Returns (target, receiverType). receiverType is non-empty only when a
-// dotted_identifier receiver looks like a PascalCase type.
+// dotted_identifier receiver looks like a PascalCase type. This is the
+// no-locals convenience wrapper retained for callers that don't carry a
+// local-variable type table.
 func groovyCallTarget(call *sitter.Node, src []byte) (string, string) {
+	return groovyCallTargetWithLocals(call, src, nil)
+}
+
+// groovyCallTargetWithLocals is groovyCallTarget extended with a
+// local-variable → type table (#4749). When the receiver of an `obj.method()`
+// call is a local whose type was inferred from a `new ClassName(...)`
+// initialiser, the target is resolved to `<Type>.<method>` (with
+// receiver_type=<Type>), exactly as a PascalCase static-receiver call is. The
+// table may be nil.
+func groovyCallTargetWithLocals(call *sitter.Node, src []byte, localVarTypes map[string]string) (string, string) {
 	if call == nil || call.ChildCount() == 0 {
 		return "", ""
 	}
@@ -738,12 +768,164 @@ func groovyCallTarget(call *sitter.Node, src []byte) (string, string) {
 		if isPascalCase(receiver) {
 			return receiver + "." + method, receiver
 		}
+		// #4749 — local-variable receiver typing: `def c = new FooController();
+		// c.index()` → FooController.index. Only fires when the local was typed
+		// from a DIRECT `new ClassName(...)` initialiser (factory/builder RHS
+		// stays untyped), so no class edge is ever forged.
+		if typ, ok := localVarTypes[receiver]; ok && typ != "" {
+			return typ + "." + method, typ
+		}
 		return method, ""
 	case "function_call":
 		// Curried call — recurse.
-		return groovyCallTarget(first, src)
+		return groovyCallTargetWithLocals(first, src, localVarTypes)
 	}
 	return "", ""
+}
+
+// groovyConstructorCalls returns the set of function_call nodes that are the
+// operand of a `new` unary_op (i.e. constructor calls `new ClassName(...)`).
+// These are object instantiations, not outbound method CALLS, so they are
+// excluded from the CALLS edge set (#4749).
+func groovyConstructorCalls(body *sitter.Node) map[*sitter.Node]bool {
+	if body == nil {
+		return nil
+	}
+	out := map[*sitter.Node]bool{}
+	for _, uo := range findAllNodes(body, "unary_op") {
+		hasNew := false
+		for j := 0; j < int(uo.ChildCount()); j++ {
+			if c := uo.Child(j); c != nil && c.Type() == "new" {
+				hasNew = true
+				break
+			}
+		}
+		if !hasNew {
+			continue
+		}
+		for j := 0; j < int(uo.ChildCount()); j++ {
+			if c := uo.Child(j); c != nil && c.Type() == "function_call" {
+				out[c] = true
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// collectGroovyLocalVarTypes scans a method/function body for local-variable
+// declarations whose right-hand side is a DIRECT constructor call
+// (`new ClassName(...)`) and returns a varName → ClassName map (#4749).
+//
+// Two declaration shapes are recognised (both confirmed against the smacker
+// groovy grammar):
+//
+//	def c = new FooController(svc)         → declaration[def, id(c), =, unary_op[new, function_call[id(FooController)]]]
+//	FooController c = new FooController()  → declaration[id(FooController), id(c), =, unary_op[new, function_call[id(FooController)]]]
+//
+// The variable name is the `identifier` immediately preceding the `=`; the type
+// is the leading identifier of the `function_call` inside the `new` unary_op.
+// A declaration with no `new` unary_op (factory/builder RHS) types nothing —
+// the local is left out of the map, so its later receiver calls degrade to the
+// bare leaf and no spurious `<Class>.method` edge is forged (the Java #4682
+// negative-case guarantee).
+func collectGroovyLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
+	if body == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for _, decl := range findAllNodes(body, "declaration") {
+		varName, typeName := groovyDeclVarAndNewType(decl, src)
+		if varName == "" || typeName == "" {
+			continue
+		}
+		// PascalCase-only: a constructed type is a class name. Guards against
+		// edge-cases where the RHS leading identifier is not a type.
+		if !isPascalCase(typeName) {
+			continue
+		}
+		out[varName] = typeName
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// groovyDeclVarAndNewType returns (varName, ClassName) for a `declaration` node
+// whose RHS is a `new ClassName(...)` constructor, or ("","") otherwise.
+func groovyDeclVarAndNewType(decl *sitter.Node, src []byte) (string, string) {
+	// Find the `=` position; the var name is the identifier just before it.
+	eqIdx := -1
+	for i := 0; i < int(decl.ChildCount()); i++ {
+		if ch := decl.Child(i); ch != nil && ch.Type() == "=" {
+			eqIdx = i
+			break
+		}
+	}
+	if eqIdx <= 0 {
+		return "", ""
+	}
+	var varNode *sitter.Node
+	for i := eqIdx - 1; i >= 0; i-- {
+		if ch := decl.Child(i); ch != nil && ch.Type() == "identifier" {
+			varNode = ch
+			break
+		}
+	}
+	if varNode == nil {
+		return "", ""
+	}
+	varName := nodeText(varNode, src)
+	if varName == "" {
+		return "", ""
+	}
+	// The RHS (child after `=`) must be a `new` unary_op wrapping the
+	// constructor function_call.
+	typeName := groovyNewTypeFromRHS(decl, eqIdx)
+	if typeName == nil {
+		return "", ""
+	}
+	return varName, nodeText(typeName, src)
+}
+
+// groovyNewTypeFromRHS returns the type-name identifier node of a
+// `new ClassName(...)` RHS that follows the `=` at eqIdx in decl, or nil when
+// the RHS is not a direct constructor call.
+func groovyNewTypeFromRHS(decl *sitter.Node, eqIdx int) *sitter.Node {
+	for i := eqIdx + 1; i < int(decl.ChildCount()); i++ {
+		ch := decl.Child(i)
+		if ch == nil || ch.Type() != "unary_op" {
+			continue
+		}
+		hasNew := false
+		var ctorCall *sitter.Node
+		for j := 0; j < int(ch.ChildCount()); j++ {
+			c := ch.Child(j)
+			if c == nil {
+				continue
+			}
+			switch c.Type() {
+			case "new":
+				hasNew = true
+			case "function_call":
+				ctorCall = c
+			}
+		}
+		if !hasNew || ctorCall == nil {
+			return nil
+		}
+		// The constructor's leading identifier is the class name.
+		for j := 0; j < int(ctorCall.ChildCount()); j++ {
+			if c := ctorCall.Child(j); c != nil && c.Type() == "identifier" {
+				return c
+			}
+		}
+		return nil
+	}
+	return nil
 }
 
 // isPascalCase reports whether s starts with an uppercase ASCII letter

--- a/internal/extractors/groovy/localvar_receiver_4749_test.go
+++ b/internal/extractors/groovy/localvar_receiver_4749_test.go
@@ -1,0 +1,118 @@
+// localvar_receiver_4749_test.go — Groovy local-variable receiver typing for
+// test→CALLS coverage crediting (#4749, the Groovy slice of the coverage-linkage
+// tail epic #4749/#4615; the JVM analog of Java #4682 / Kotlin).
+//
+// A Groovy unit test binds a local from a constructor and then calls a method on
+// it; the call must resolve to the CLASS method so ComputeCoverage credits the
+// endpoint through test→CALLS→handler. Without local-var typing the receiver `c`
+// is a bare lowercase identifier and `c.index()` degrades to the unresolvable
+// leaf `index`.
+//
+// Conservatism mirrors Java #4682: ONLY a direct `new ClassName(...)`
+// initialiser types the local — a factory/builder RHS stays untyped and forges
+// no class edge.
+
+package groovy_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// hasCall reports whether e carries a CALLS edge to toID. When recv is non-empty
+// it also requires receiver_type == recv.
+func hasCall(e *types.EntityRecord, toID, recv string) bool {
+	for _, r := range e.Relationships {
+		if r.Kind != "CALLS" || r.ToID != toID {
+			continue
+		}
+		if recv == "" {
+			return true
+		}
+		if r.Properties["receiver_type"] == recv {
+			return true
+		}
+	}
+	return false
+}
+
+// FIXTURE A — `def c = new FooController(); c.index()` → CALLS FooController.index.
+func TestIssue4749_GroovyLocalVarReceiver_DefNew(t *testing.T) {
+	src := `class FooController { def index() { return "ok" } }
+class FooControllerTest {
+    def testIndex() {
+        def c = new FooController()
+        c.index()
+    }
+}`
+	ents := runGroovy(t, src)
+	caller := gFind(ents, "testIndex", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected operation testIndex")
+	}
+	if !hasCall(caller, "FooController.index", "FooController") {
+		t.Fatalf("A: expected CALLS testIndex→FooController.index (receiver_type=FooController); got %+v", caller.Relationships)
+	}
+	// The `new FooController()` constructor must NOT leak a bare `FooController`
+	// CALLS edge.
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "FooController" {
+			t.Fatalf("A: constructor call must not emit a bare FooController CALLS edge; got %+v", caller.Relationships)
+		}
+	}
+	// And it must NOT leave a bare `index` leaf alongside the typed edge.
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "index" {
+			t.Fatalf("A: typed receiver must replace the bare leaf `index`; got %+v", caller.Relationships)
+		}
+	}
+}
+
+// FIXTURE A' — explicit declared type `FooController c = new FooController()`.
+func TestIssue4749_GroovyLocalVarReceiver_DeclaredType(t *testing.T) {
+	src := `class FooController { def index() { return "ok" } }
+class FooControllerTest {
+    def testIndex() {
+        FooController c = new FooController()
+        c.index()
+    }
+}`
+	ents := runGroovy(t, src)
+	caller := gFind(ents, "testIndex", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected operation testIndex")
+	}
+	if !hasCall(caller, "FooController.index", "FooController") {
+		t.Fatalf("A': expected CALLS testIndex→FooController.index; got %+v", caller.Relationships)
+	}
+}
+
+// NEGATIVE — a factory/builder receiver must NOT forge a class edge. `def c =
+// MyFactory.create()` leaves the local untyped, so `c.index()` is a bare leaf
+// `index` and no `<Class>.index` edge is emitted.
+func TestIssue4749_GroovyLocalVarReceiver_NegativeFactory(t *testing.T) {
+	src := `class FooControllerTest {
+    def testBuilder() {
+        def c = MyFactory.create()
+        c.index()
+    }
+}`
+	ents := runGroovy(t, src)
+	caller := gFind(ents, "testBuilder", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected operation testBuilder")
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if r.ToID == "FooController.index" || r.ToID == "MyFactory.index" {
+			t.Fatalf("negative: factory receiver must not forge a typed index edge; got %+v", caller.Relationships)
+		}
+	}
+	// The bare leaf `index` is the honest unresolved result.
+	if !hasCall(caller, "index", "") {
+		t.Fatalf("negative: expected bare CALLS testBuilder→index; got %+v", caller.Relationships)
+	}
+}


### PR DESCRIPTION
## Groovy slice of coverage-linkage tail epic (#4749/#4615)

JVM analog of Java junit5 + Kotlin #4687; producer-first like Crystal/Kemal #4760.

### Probe
Groovy had **no `http_endpoint_definition` producer** — the Grails YAML rule set is framework-*detection* only, and `spring_routes.go` is gated `lang=="java"`. So the producer side is **synthesized first** (like Crystal #4760 / Swift #4755), then route-hit linkage is layered on.

### What landed
- **Producer** (`internal/engine/http_endpoint_grails.go`): canonical `http_endpoint_definition` synthesis from
  - Grails **convention** controllers: `class BookController { def show() {…} }` → `ANY /book/show` (verb ANY — Grails actions are method-agnostic; lifecycle hooks like `beforeInterceptor` excluded)
  - Grails explicit **UrlMappings.groovy**: `"/book/$id"(controller:"book",action:"show")` → `/book/{id}` (dollar-params → curly; explicit `method:` honored)
  - **Ratpack** handler DSL: `get("api/books"){…}` → `GET /api/books`, `path("x")` → ANY
  - New `FrameworkGrails` (curly-brace) + `FrameworkRatpack` (colon) canonicalisation; wired into `applyHTTPEndpointSynthesis` + `synthesisSupportsLanguage`.
- **Route-hit linkage** (`internal/custom/groovy/tests_route_e2e.go`): one `test_suite` per Groovy `*Spec`/`*Test` carrying `e2e_route_calls` from Spring MockMvc / WebTestClient, Ratpack `testHttpClient`, and the Grails RestBuilder bare-verb form (`get "$baseUrl/books"`). The shared language-agnostic `linkE2ERouteTestsToEndpoints` pass emits the TESTS edge. Registered in `custom_registry.go` + `custom_dispatch.go`.
- **Scope-owner**: Spock feature methods `def "name"()` do **not** parse as methods in the groovy grammar (surface as ERROR nodes), so route hits inside `when:`/`expect:` blocks are carried by the **suite-level** `test_suite` (Ruby #4684 / Crystal #4760 analog), not a per-feature operation.
- **Receiver typing** (`internal/extractors/groovy/groovy.go`, part a): local-var typing for `def c = new FooController(); c.index()` → `CALLS FooController.index`, plus constructor-call phantom suppression and a factory/builder-RHS negative-case guard (Java #4682 conservatism).
- **Coverage docs**: new `lang.groovy.framework.grails` record, `Testing.tests_linkage=full`. Surgical registry add via the `coverage` tool (231 additions, 0 deletions, canonical).

### Validation (RED→GREEN)
- **Fixture A**: `TestIssue4749_GroovyLocalVarReceiver_{DefNew,DeclaredType,NegativeFactory}`
- **Fixture B**: `TestGroovyRouteE2E_*` (capture) + `TestIssue4749_GroovySpockE2ERouteTestsLinkToEndpoints` + `TestIssue4749_GroovyGrailsAnyVerbE2ELink` (end-to-end TESTS edge) + `TestGrails_*`/`TestRatpack_*` (producer)

### Gates
`go build ./...` ✅ · `go vet` ✅ · `go test ./internal/{extractors,custom,engine,graph,types}/...` ✅ · `coverage fmt --check` canonical ✅ · `coverage validate` **0 new errors** (the 20 pre-existing errors are unmerged F#/Clojure #4749 sibling slices citing not-yet-landed files; all groovy cites exist on disk) ✅

Part of #4749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)