### PR TITLE
feat(lua): busted/lapis.spec test→endpoint coverage linkage (#4749)

### DIFF
--- a/internal/custom/lua/tests_route_e2e.go
+++ b/internal/custom/lua/tests_route_e2e.go
@@ -1,0 +1,235 @@
+// tests_route_e2e.go — Lua busted / lapis.spec → endpoint route-hit linkage.
+//
+// #4749 (the Lua slice of the coverage-linkage tail epic #4749/#4615; mirrors
+// the Crystal/Kemal slice #4760 and the Swift/Vapor slice #4755). Emits ONE
+// test_suite entity per Lua spec file that drives an HTTP endpoint by ROUTE
+// STRING via the lapis.spec request helpers, stamping the captured
+// `VERB route` pairs onto the suite's `e2e_route_calls` property (one
+// "VERB route" per line). The shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index — which, for Lua, is
+// populated by synthesizeLapis (#3484, internal/engine/lua_routes.go) — and
+// emits a TESTS edge to the exact Lapis endpoint exercised, exactly as the
+// Crystal, Swift, Rust, Java, Ruby, PHP, C# and Elixir slices do for their
+// stacks. The engine pass is language-agnostic (it fires on any test_suite
+// carrying e2e_route_calls), so the only Lua-specific work here is the
+// lapis.spec route capture.
+//
+// lapis.spec route-driving idioms captured (lapis.spec.request / mock_request):
+//   - request(app, "/users")                            → GET  /users
+//   - request(app, "/users", { method = "POST" })       → POST /users
+//   - request("/users/" .. id)                          → GET  /users
+//   - mock_request(app, "/users", { method = "DELETE" })→ DELETE /users
+//
+// The request helper is a top-level call whose FIRST string-literal argument is
+// the route path; the optional `{ method = "VERB" }` options table carries the
+// HTTP verb (GET when absent). busted's test DSL
+// (`describe("...", function() it("...", function() ... end) end)`) uses
+// ANONYMOUS function closures (like JS/Ruby) — the `it` example body owns no
+// named, call-bearing entity — so the route-hit signal is carried by the
+// SUITE-LEVEL test_suite entity emitted here (the scope-owner role), NOT by a
+// per-example operation. This is the Lua analog of the Ruby #4684 / JS #4680
+// anonymous-block scope-owner: the test_suite is the owner that carries the
+// e2e_route_calls the engine links from.
+//
+// Local-variable / receiver typing (#4749 part a) is N/A for Lua coverage
+// linkage: Lapis handlers are anonymous functions / table methods, and the lua
+// base extractor does not produce a class-qualified receiver resolver that could
+// consume a `receiver_type` stamp on a Lua CALLS edge — it would be a dead
+// annotation. The honest, working coverage mechanism for Lua is the route-hit →
+// endpoint linkage in THIS file (route dispatch is keyed by the literal route
+// string, not by an `obj.method()` receiver), exactly as for the functional
+// Elixir, Crystal and Swift slices. See the coverage-doc note for the recorded
+// N/A rationale.
+//
+// Honest exclusions (no fabricated edges):
+//   - Concatenated / variable routes capture the literal prefix only when a
+//     static string is present; a fully dynamic route (`request(app, path)`) is
+//     dropped.
+//   - Non-request specs (pure unit specs that never hit a route) emit no suite.
+//   - A `request(...)` appearing OUTSIDE a spec file is ignored; this extractor
+//     only runs on busted/lapis spec files.
+//
+// Registration key: "custom_lua_tests_route_e2e".
+package lua
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_lua_tests_route_e2e", &luaTestRouteE2EExtractor{})
+}
+
+type luaTestRouteE2EExtractor struct{}
+
+func (e *luaTestRouteE2EExtractor) Language() string {
+	return "custom_lua_tests_route_e2e"
+}
+
+// luaSpecRequestRE matches a lapis.spec request helper call whose first
+// argument resolves to a string-literal route path. Two shapes are supported:
+//
+//	request(app, "/users", { method = "POST" })   — app + path form
+//	request("/users")                             — path-only form
+//	mock_request(app, "/users")                   — mock alias
+//
+// Capture group 1 is an optional first string argument (path-only form);
+// group 2 is the string argument after a non-string first arg (app + path
+// form). The optional `{ method = "VERB" }` table is matched separately on the
+// same line.
+var (
+	// request(app, "/path", ...) / mock_request(app, "/path", ...) — the path
+	// is the SECOND argument (after a non-string `app` identifier).
+	luaSpecReqAppPathRE = regexp.MustCompile(
+		`(?m)\b(?:mock_)?request\s*\(\s*[A-Za-z_][\w.]*\s*,\s*["']([^"'\n\r]*)["']`)
+
+	// request("/path", ...) — path is the FIRST argument (a string literal).
+	luaSpecReqPathOnlyRE = regexp.MustCompile(
+		`(?m)\b(?:mock_)?request\s*\(\s*["']([^"'\n\r]*)["']`)
+
+	// { method = "POST" } / { method = 'post' } options-table verb.
+	luaSpecMethodRE = regexp.MustCompile(
+		`method\s*=\s*["']([A-Za-z]+)["']`)
+)
+
+func (e *luaTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "lua" {
+		return nil, nil
+	}
+	if !isLuaSpecFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectLuaSpecRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       luaSpecSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "lua",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "lapis.spec",
+			"provenance":      "INFERRED_FROM_LUA_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	rec.ID = rec.ComputeID()
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectLuaSpecRouteCalls returns the de-duplicated "VERB route" pairs a spec
+// file drives by route string. The verb is read from a sibling
+// `{ method = "VERB" }` options table on the same call line; GET is the
+// lapis.spec default when no method is given. Fully dynamic routes (no static
+// literal) are dropped.
+func collectLuaSpecRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(rawPath, line string) {
+		route := normaliseLuaSpecRoute(rawPath)
+		if route == "" {
+			return
+		}
+		verb := luaSpecLineVerb(line)
+		key := verb + " " + route
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	for _, line := range strings.Split(source, "\n") {
+		// app + path form takes precedence (first arg is the app identifier).
+		if m := luaSpecReqAppPathRE.FindStringSubmatch(line); m != nil {
+			add(m[1], line)
+			continue
+		}
+		if m := luaSpecReqPathOnlyRE.FindStringSubmatch(line); m != nil {
+			add(m[1], line)
+		}
+	}
+	return out
+}
+
+// luaSpecLineVerb extracts the HTTP verb from a `{ method = "VERB" }` options
+// table on the request line; defaults to GET (the lapis.spec default).
+func luaSpecLineVerb(line string) string {
+	if m := luaSpecMethodRE.FindStringSubmatch(line); m != nil {
+		return strings.ToUpper(m[1])
+	}
+	return "GET"
+}
+
+// normaliseLuaSpecRoute reduces a raw lapis.spec route literal to a path:
+// ensures a single leading slash, drops a query/fragment tail, truncates at a
+// Lua string-concatenation marker (`..`) so a concatenated route keeps only its
+// static prefix, collapses repeated slashes. A route whose value has no static
+// prefix is dropped (returns ""). Path-param placeholders (`:id`) and casing are
+// preserved (the resolver wildcards templates and compares case-insensitively).
+func normaliseLuaSpecRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return ""
+	}
+	// Truncate at a Lua concatenation marker — the static prefix is the only
+	// statically-recoverable part. `"/users/" .. id` is captured as the literal
+	// `/users/` before the closing quote, so this is mostly defensive.
+	if i := strings.Index(p, ".."); i >= 0 {
+		p = p[:i]
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	// A bare "/" after truncation carries no route identity — drop it.
+	if p == "/" {
+		return ""
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// isLuaSpecFile reports whether path looks like a Lua spec — a `*_spec.lua`
+// file or a file under a `/spec/` directory. Keeps the route-hit suite off
+// production code that merely registers a route.
+func isLuaSpecFile(path string) bool {
+	lp := filepath.ToSlash(path)
+	base := filepath.Base(lp)
+	if strings.HasSuffix(base, "_spec.lua") {
+		return true
+	}
+	if strings.Contains(lp, "/spec/") && strings.HasSuffix(lp, ".lua") {
+		return true
+	}
+	return false
+}
+
+// luaSpecSuiteBaseName derives a suite label from the spec file path
+// (`.../users_spec.lua` → `users_spec`).
+func luaSpecSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/custom/lua/tests_route_e2e_test.go
+++ b/internal/custom/lua/tests_route_e2e_test.go
@@ -1,0 +1,125 @@
+package lua_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/lua"
+)
+
+func luaFI(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestLuaRouteE2E_Capture proves the lapis.spec request helpers are captured
+// onto a single test_suite's e2e_route_calls property, with verbs read from the
+// { method = "..." } options table (GET default).
+func TestLuaRouteE2E_Capture(t *testing.T) {
+	src := `
+local request = require("lapis.spec.request").request
+
+describe("Users", function()
+  it("lists users", function()
+    local status = request(app, "/users")
+    assert.same(200, status)
+  end)
+
+  it("shows one", function()
+    request(app, "/users/" .. id)
+  end)
+
+  it("creates", function()
+    request(app, "/users", { method = "POST" })
+  end)
+
+  it("deletes", function()
+    mock_request(app, "/users/1", { method = "DELETE" })
+  end)
+end)
+`
+	e, ok := extreg.Get("custom_lua_tests_route_e2e")
+	if !ok {
+		t.Fatal("custom_lua_tests_route_e2e not registered")
+	}
+	ents, err := e.Extract(context.Background(), luaFI("spec/users_spec.lua", "lua", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("expected exactly 1 test_suite, got %d", len(ents))
+	}
+	rec := ents[0]
+	if rec.Subtype != "test_suite" {
+		t.Errorf("expected test_suite, got %q", rec.Subtype)
+	}
+	calls := rec.Properties["e2e_route_calls"]
+	for _, want := range []string{"GET /users", "POST /users", "DELETE /users/1"} {
+		if !strings.Contains(calls, want) {
+			t.Errorf("expected route call %q in %q", want, calls)
+		}
+	}
+}
+
+// TestLuaRouteE2E_PathOnly proves the path-only request("/x") form is captured.
+func TestLuaRouteE2E_PathOnly(t *testing.T) {
+	src := `
+describe("Health", function()
+  it("ok", function()
+    request("/health")
+  end)
+end)
+`
+	e, _ := extreg.Get("custom_lua_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), luaFI("spec/health_spec.lua", "lua", src))
+	if len(ents) != 1 {
+		t.Fatalf("expected 1 test_suite, got %d", len(ents))
+	}
+	if !strings.Contains(ents[0].Properties["e2e_route_calls"], "GET /health") {
+		t.Errorf("expected GET /health, got %q", ents[0].Properties["e2e_route_calls"])
+	}
+}
+
+// TestLuaRouteE2E_NonSpecExcluded proves a non-spec file (production route
+// registration) is NOT captured as a test_suite.
+func TestLuaRouteE2E_NonSpecExcluded(t *testing.T) {
+	src := `
+local lapis = require("lapis")
+local app = lapis.Application()
+app:get("/users", function(self) end)
+`
+	e, _ := extreg.Get("custom_lua_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), luaFI("app.lua", "lua", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a non-spec file, got %d", len(ents))
+	}
+}
+
+// TestLuaRouteE2E_ShapeOnlySpecExcluded proves a unit spec that never hits a
+// route emits no suite.
+func TestLuaRouteE2E_ShapeOnlySpecExcluded(t *testing.T) {
+	src := `
+describe("Validator", function()
+  it("rejects empty", function()
+    assert.is_false(validate(""))
+  end)
+end)
+`
+	e, _ := extreg.Get("custom_lua_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), luaFI("spec/validator_spec.lua", "lua", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a shape-only spec, got %d", len(ents))
+	}
+}
+
+// TestLuaRouteE2E_WrongLanguageNoop proves the extractor gates on language=="lua".
+func TestLuaRouteE2E_WrongLanguageNoop(t *testing.T) {
+	src := `request(app, "/users")`
+	e, _ := extreg.Get("custom_lua_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), luaFI("spec/users_spec.lua", "ruby", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-lua language, got %d", len(ents))
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4749_lua_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4749_lua_test.go
@@ -1,0 +1,69 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Lua route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/lua"
+)
+
+// Issue #4749 LIVE-REPRO (resolve side) — Lua lapis.spec route-hit tests.
+// Proves end-to-end that a Lua busted/lapis spec calling a route by string
+// (`request(app, "/path", { method = "POST" })`) links to the
+// http_endpoint_definition it exercises — the Lua slice of the all-language
+// program (#4615/#4749). The shared linkE2ERouteTestsToEndpoints pass is
+// language-agnostic; only the Lua route capture is new (the Lapis producer
+// already exists, #3484).
+
+const luaSpecLapisSrc4749 = `
+local request = require("lapis.spec.request").request
+
+describe("Todos", function()
+  it("lists todos", function()
+    local status = request(app, "/api/v1/todos")
+    assert.same(200, status)
+  end)
+
+  it("creates a todo", function()
+    request(app, "/api/v1/todos", { method = "POST" })
+  end)
+end)
+`
+
+func TestIssue4749_LuaSpecLapisE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/todos"),
+		def("POST", "/api/v1/todos"),
+	}
+	suite := realSuite(t, "custom_lua_tests_route_e2e",
+		"spec/requests/todos_spec.lua", "lua", luaSpecLapisSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertLuaRouteEdges(t, edgeTargets(afterOut))
+}
+
+func assertLuaRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/todos") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/todos") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /api/v1/todos; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /api/v1/todos; targets=%v", targets)
+	}
+}


### PR DESCRIPTION
## Lua slice of coverage-linkage tail epic #4749

Test→endpoint route-hit linkage for Lua web frameworks (Lapis + busted/lapis.spec).

### Probe finding: producer already exists
Lua web support is solid — `synthesizeLapis` (#3484, `internal/engine/lua_routes.go`) already synthesizes canonical `http_endpoint_definition` entities from Lapis route registrations (`app:get/post/...`, named/unnamed `app:match`, `respond_to` verb tables) with `:id`→`{id}` canonicalisation via `httproutes.FrameworkLapis`. **No producer work needed** — the only gap was the test-side route-hit capture.

(OpenResty `location` blocks are nginx-config, out of scope; Sailor/Pegasus are marginal and have no graph support.)

### What this adds — route-hit linkage
- `internal/custom/lua/tests_route_e2e.go` — new `custom_lua_tests_route_e2e` extractor. Emits ONE `test_suite` per busted/lapis `*_spec.lua` carrying `e2e_route_calls` captured from lapis.spec request helpers:
  - `request(app, "/path", { method = "POST" })` (app+path form)
  - `request("/path")` (path-only, GET default)
  - `mock_request(app, "/path", ...)`
  - verb read from the `{ method = "VERB" }` options table; GET default.
- The shared language-agnostic `engine.linkE2ERouteTestsToEndpoints` pass (#4351/#4369) then emits the TESTS edge to the Lapis endpoint exercised. Zero engine changes — it fires on any `test_suite` carrying `e2e_route_calls`.

### Scope-owner
busted uses anonymous `describe`/`it` function closures (JS/Ruby-like), so the `test_suite` is the scope-owner carrying the route hits — Lua analog of Ruby #4684 / JS #4680.

### N/A (honest)
- Local-var/receiver typing (#4749 part a): Lapis handlers are anonymous functions / table methods; the lua base extractor has no class-qualified receiver resolver to consume a `receiver_type` stamp — route-string linkage is the working coverage mechanism (mirrors functional Elixir #4688 / Crystal #4760).
- Honest exclusions: fully-dynamic/concatenated routes (no static literal) and non-request unit specs emit no suite.

### Validation (RED→GREEN)
- `TestIssue4749_LuaSpecLapisE2ERouteTestsLinkToEndpoints` — control strips `e2e_route_calls` → 0 edges; full run → ≥2 TESTS edges to GET/POST `/api/v1/todos`.
- `TestLuaRouteE2E_*` — capture (app+path, path-only, verb table), non-spec exclusion, shape-only exclusion, wrong-language no-op.

### Coverage docs
Surgically augmented the lua/lapis `Testing.tests_linkage` cell (already `full` via the testmap extractor) with the new route-hit cites + note. `coverage fmt --check` ✅ canonical, `coverage validate` ✅ 0 errors (pre-existing warnings only).

### Gates
`go build ./...` ✅ · `go vet ./internal/extractors/... ./internal/custom/... ./internal/graph/...` ✅ · `go test ./internal/extractors/... ./internal/custom/... ./internal/engine/... ./internal/graph/... ./internal/types/` ✅ all pass · `coverage fmt --check` ✅ · `coverage validate` ✅ (ok, 0 errors).

Part of #4749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)