### PR TITLE
feat(nim): Jester/Prologue test→endpoint coverage linkage (closes #4749)

### DIFF
--- a/internal/custom/nim/extractors_test.go
+++ b/internal/custom/nim/extractors_test.go
@@ -1,0 +1,104 @@
+package nim_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/nim"
+)
+
+func fi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestNimRouteE2E_Capture proves the std/httpclient route helpers are captured
+// onto a single test_suite's e2e_route_calls property.
+func TestNimRouteE2E_Capture(t *testing.T) {
+	src := `
+import std/unittest
+import std/httpclient
+
+suite "Todos":
+  test "lists":
+    let client = newHttpClient()
+    discard client.get("http://localhost:8080/todos")
+  test "shows one":
+    let client = newHttpClient()
+    discard client.get(baseUrl & "/todos/42")
+  test "creates":
+    let client = newHttpClient()
+    discard client.post("http://localhost:8080/todos", body = "{}")
+  test "replaces":
+    let client = newHttpClient()
+    discard client.request("http://localhost:8080/todos/42", httpMethod = HttpPut)
+`
+	e, ok := extreg.Get("custom_nim_tests_route_e2e")
+	if !ok {
+		t.Fatal("custom_nim_tests_route_e2e not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("tests/tTodos.nim", "nim", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(ents) != 1 {
+		t.Fatalf("expected exactly 1 test_suite, got %d", len(ents))
+	}
+	rec := ents[0]
+	if rec.Subtype != "test_suite" {
+		t.Errorf("expected test_suite, got %q", rec.Subtype)
+	}
+	calls := rec.Properties["e2e_route_calls"]
+	for _, want := range []string{"GET /todos", "GET /todos/42", "POST /todos", "PUT /todos/42"} {
+		if !strings.Contains(calls, want) {
+			t.Errorf("expected route call %q in %q", want, calls)
+		}
+	}
+}
+
+// TestNimRouteE2E_NonTestExcluded proves a non-test file (production route
+// registration) is NOT captured as a test_suite.
+func TestNimRouteE2E_NonTestExcluded(t *testing.T) {
+	src := `
+import jester
+routes:
+  get "/todos":
+    resp "ok"
+`
+	e, _ := extreg.Get("custom_nim_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("src/routes.nim", "nim", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a non-test file, got %d", len(ents))
+	}
+}
+
+// TestNimRouteE2E_ShapeOnlyTestExcluded proves a unit test that never hits a
+// route emits no suite.
+func TestNimRouteE2E_ShapeOnlyTestExcluded(t *testing.T) {
+	src := `
+import std/unittest
+
+suite "Todo":
+  test "validates title":
+    let t = newTodo("")
+    check(not t.valid())
+`
+	e, _ := extreg.Get("custom_nim_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("tests/tTodo.nim", "nim", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no test_suite for a shape-only test, got %d", len(ents))
+	}
+}
+
+// TestNimRouteE2E_WrongLanguageNoop proves the extractor gates on
+// language=="nim".
+func TestNimRouteE2E_WrongLanguageNoop(t *testing.T) {
+	src := `discard client.get("http://localhost/todos")`
+	e, _ := extreg.Get("custom_nim_tests_route_e2e")
+	ents, _ := e.Extract(context.Background(), fi("tests/tTodos.nim", "go", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-nim language, got %d", len(ents))
+	}
+}

--- a/internal/custom/nim/tests_route_e2e.go
+++ b/internal/custom/nim/tests_route_e2e.go
@@ -1,0 +1,227 @@
+// tests_route_e2e.go — Nim unittest → endpoint route-hit linkage.
+//
+// #4749 (the Nim slice of the coverage-linkage tail epic #4749/#4615; the LAST
+// language in the tail; mirrors the Crystal/Kemal slice and the Lua/Lapis
+// slice). Emits ONE test_suite entity per Nim test file that drives an HTTP
+// endpoint by ROUTE STRING via the std/httpclient helpers, stamping the
+// captured `VERB route` pairs onto the suite's `e2e_route_calls` property (one
+// "VERB route" per line). The shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index — which, for Nim, is
+// populated by synthesizeJester / synthesizePrologue (#4749,
+// internal/engine/http_endpoint_jester.go) — and emits a TESTS edge to the
+// exact Jester/Prologue endpoint exercised, exactly as the Crystal, Swift,
+// Rust, Java, Ruby, PHP, C# and Elixir slices do for their stacks. The engine
+// pass is language-agnostic (it fires on any test_suite carrying
+// e2e_route_calls), so the only Nim-specific work here is the httpclient route
+// capture.
+//
+// std/httpclient route-driving idioms captured:
+//   - client.get("http://localhost:8080/users")          → GET    /users
+//   - client.post(baseUrl & "/users", body = ...)         → POST   /users
+//   - client.delete("http://127.0.0.1:5000/users/" & $id) → DELETE /users
+//   - client.request(url & "/users", httpMethod = HttpPut)→ PUT    /users
+//   - newHttpClient().get(addr & "/health")               → GET    /health
+//
+// Nim's `std/unittest` test DSL uses `suite "...":` containers and `test "...":`
+// blocks. A `test "...":` block IS a named, statement-list scope (the
+// description is a string literal, the body a colon-indented block) — but the
+// description is PROSE, not a code symbol, and the block carries no callable
+// entity name the production-symbol resolver can bind to. So, like the JS/Ruby
+// anonymous-closure case, the route-hit signal is carried by the SUITE-LEVEL
+// test_suite entity emitted here (the scope-owner role). This is the Nim analog
+// of the Ruby #4684 / JS #4680 / Crystal #4760 anonymous-block scope-owner: the
+// test_suite is the owner that carries the e2e_route_calls the engine links
+// from. (The named-symbol test→SUT linkage for unittest is handled separately
+// by the shared cross/testmap detector; see frameworks_nim.go.)
+//
+// Local-variable / receiver typing (#4749 part a) is N/A for Nim coverage
+// linkage: the nim base extractor names proc/method entities by their BARE
+// name (with a CONTAINS edge from an attached type, not a `Type.method`
+// qualified id), and there is no class-qualified receiver resolver to consume a
+// `receiver_type` stamp on a Nim CALLS edge — it would be a dead annotation.
+// The honest, working coverage mechanism for Nim is the route-hit → endpoint
+// linkage in THIS file (route dispatch is keyed by the literal route string,
+// not by an `obj.method()` receiver), exactly as for the functional Elixir and
+// Crystal slices. See the coverage-doc note for the recorded N/A rationale.
+//
+// Honest exclusions (no fabricated edges):
+//   - A route built entirely from variables / `&` concatenation with no static
+//     `/segment` literal is dropped; the static prefix is captured when present.
+//   - Non-request test files (pure unit tests that never hit a route) emit no
+//     suite.
+//   - A `client.get(...)` appearing OUTSIDE a test file is left to the
+//     producer-side synthesizers; this extractor only runs on test files.
+//
+// Registration key: "custom_nim_tests_route_e2e".
+package nim
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_nim_tests_route_e2e", &nimTestRouteE2EExtractor{})
+}
+
+type nimTestRouteE2EExtractor struct{}
+
+func (e *nimTestRouteE2EExtractor) Language() string {
+	return "custom_nim_tests_route_e2e"
+}
+
+var (
+	// nimHTTPVerbCallRE matches a std/httpclient verb call whose first argument
+	// contains a string-literal URL/path: `client.get("…")`,
+	// `client.post(base & "/users", …)`, `newHttpClient().delete("…")`. Capture
+	// group 1 is the verb; group 2 is the FIRST string literal in the argument
+	// list (the URL or path fragment).
+	nimHTTPVerbCallRE = regexp.MustCompile(
+		`(?m)\.(get|post|put|delete|patch|options|head)\s*\(\s*(?:[^"(),\n]*&\s*)?"([^"\n\r]*)"`)
+
+	// nimHTTPRequestRE matches the generic `client.request(url, httpMethod =
+	// HttpPost)` form: capture group 1 is the FIRST string literal (URL/path),
+	// group 2 the `Http<Verb>` enum tail.
+	nimHTTPRequestRE = regexp.MustCompile(
+		`(?m)\.request\s*\(\s*(?:[^"(),\n]*&\s*)?"([^"\n\r]*)"[^)\n]*?Http([A-Za-z]+)`)
+)
+
+func (e *nimTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "nim" {
+		return nil, nil
+	}
+	if !isNimTestFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectNimTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       nimTestSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "nim",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "unittest",
+			"provenance":      "INFERRED_FROM_NIM_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	rec.ID = rec.ComputeID()
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectNimTestRouteCalls returns the de-duplicated "VERB route" pairs a Nim
+// test file drives by route string via std/httpclient. The verb is the method
+// name for the `.get/.post/…` form, or the `Http<Verb>` enum for the generic
+// `.request(...)` form. Routes are normalised to a leading-slash path; a route
+// with no static `/segment` literal is dropped.
+func collectNimTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawURL string) {
+		route := normaliseNimTestRoute(rawURL)
+		if route == "" {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	for _, m := range nimHTTPVerbCallRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range nimHTTPRequestRE.FindAllStringSubmatch(source, -1) {
+		add(m[2], m[1])
+	}
+	return out
+}
+
+// normaliseNimTestRoute reduces a raw httpclient URL/path literal to a path:
+// strips a scheme+authority prefix (http://127.0.0.1:8080/x → /x), drops a
+// query/fragment tail, ensures a single leading slash, collapses repeated
+// slashes. A literal that is only a host/scheme with no path, or that has no
+// static `/segment`, is dropped (returns ""). Path-param placeholders (`@id`,
+// `{id}`) and casing are preserved (the resolver wildcards templates and
+// compares case-insensitively).
+func normaliseNimTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return ""
+	}
+	// Strip scheme://authority — keep the path that follows the first slash
+	// after the authority. A literal with scheme but no path (`http://host`)
+	// yields "" (no route identity).
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	if p == "/" {
+		return ""
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// isNimTestFile reports whether path looks like a Nim test — a `t*.nim` /
+// `*_test.nim` / `test_*.nim` file or a file under a `/tests/` directory. The
+// Nim convention (nimble test) is `tests/tFoo.nim`. Keeps the route-hit suite
+// off production code that merely registers a route.
+func isNimTestFile(path string) bool {
+	lp := filepath.ToSlash(path)
+	base := filepath.Base(lp)
+	if !strings.HasSuffix(base, ".nim") {
+		return false
+	}
+	stem := strings.TrimSuffix(base, ".nim")
+	switch {
+	case strings.HasSuffix(stem, "_test"),
+		strings.HasPrefix(stem, "test_"),
+		strings.HasPrefix(stem, "test"),
+		// nimble's `tests/tFoo.nim` convention: a leading lowercase `t`
+		// followed by an uppercase letter.
+		len(stem) >= 2 && stem[0] == 't' && stem[1] >= 'A' && stem[1] <= 'Z':
+		return true
+	}
+	return strings.Contains(lp, "/tests/")
+}
+
+// nimTestSuiteBaseName derives a suite label from the test file path
+// (`.../tUsers.nim` → `tUsers`).
+func nimTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4749_nim_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4749_nim_test.go
@@ -1,0 +1,70 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Nim route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/nim"
+)
+
+// Issue #4749 LIVE-REPRO (resolve side) — Nim std/httpclient route-hit tests.
+// Proves end-to-end that a Nim unittest calling a route by string
+// (`client.get("http://localhost/api/v1/todos")`, `client.post(...)`) links to
+// the http_endpoint_definition it exercises — the Nim slice (LAST in the tail)
+// of the all-language program (#4615/#4749). The shared
+// linkE2ERouteTestsToEndpoints pass is language-agnostic; only the Nim route
+// capture is new.
+
+const nimUnittestHTTPSrc4749 = `
+import std/unittest
+import std/httpclient
+
+suite "Todos":
+  test "lists todos":
+    let client = newHttpClient()
+    let resp = client.get("http://localhost:8080/api/v1/todos")
+    check resp.code == Http200
+
+  test "creates a todo":
+    let client = newHttpClient()
+    let resp = client.post("http://localhost:8080/api/v1/todos", body = "{}")
+    check resp.code == Http201
+`
+
+func TestIssue4749_NimUnittestE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/api/v1/todos"),
+		def("POST", "/api/v1/todos"),
+	}
+	suite := realSuite(t, "custom_nim_tests_route_e2e",
+		"tests/tTodos.nim", "nim", nimUnittestHTTPSrc4749)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertNimRouteEdges(t, edgeTargets(afterOut))
+}
+
+func assertNimRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/api/v1/todos") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/api/v1/todos") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /api/v1/todos; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /api/v1/todos; targets=%v", targets)
+	}
+}

--- a/internal/engine/http_endpoint_jester.go
+++ b/internal/engine/http_endpoint_jester.go
@@ -1,0 +1,190 @@
+// http_endpoint_jester.go — Nim Jester / Prologue / HappyX route registration →
+// canonical http_endpoint_definition synthesis (#4749, the Nim slice of the
+// coverage-linkage tail epic #4749/#4615; mirrors the Crystal/Kemal slice and
+// the Lua/Lapis slice).
+//
+// Background
+// ----------
+// The Nim base extractor (internal/extractors/nim/nim.go) is a regex-based
+// structural extractor: it mines proc/func/method/template/macro declarations,
+// types, imports and CALLS edges, but has NO web-framework awareness. Jester
+// `routes:` blocks, Prologue `app.get("/path", handler)` registrations and
+// HappyX route macros are not recognised as HTTP endpoints, and no
+// `http_endpoint_definition` entity is ever produced for Nim. The shared e2e
+// route-test linker (linkE2ERouteTestsToEndpoints, #4351) matches a test's
+// route hit against `http_endpoint_definition` + `path`, so a Nim route could
+// never be hit by a route-string test. As with Crystal/Kemal and Swift/Vapor,
+// the PRODUCER-side gap has to be closed first.
+//
+// This pass emits one canonical http_endpoint_definition per statically-known
+// Nim route, in the SAME shape axum / Rocket / Express / Kemal / Vapor emit, so
+// the existing resolver and the language-agnostic e2e route-test linker light up
+// for Nim exactly as they do for the flagship stacks.
+//
+// Nim web route syntax
+// --------------------
+// Jester (the dominant Nim web framework, Sinatra-like) declares routes inside a
+// `routes:` block as indented verb entries taking a single string-literal path
+// followed by a colon (block body):
+//
+//	routes:
+//	  get "/":            ...                 → GET /
+//	  get "/users/@id":   resp ...            → GET /users/{id}
+//	  post "/users":      ...                 → POST /users
+//	  delete "/users/@id": ...                → DELETE /users/{id}
+//
+// Jester path parameters use the `@name` AT-prefixed convention, canonicalised
+// through FrameworkJester into the `{param}` form shared with every other
+// framework.
+//
+// Prologue registers routes with a verb method on the app/router taking a
+// string-literal path and a handler reference, using the curly-brace `{name}`
+// path-parameter convention:
+//
+//	app.get("/users/{id}", getUser)          → GET /users/{id}
+//	app.post("/users", createUser)           → POST /users
+//	app.addRoute("/x", handler, HttpGet)     → GET /x   (verb is the 3rd arg)
+//
+// HappyX uses a `/path/{id}` curly-brace convention shared with Prologue and is
+// covered by the same Prologue-shaped synthesis when the route is registered via
+// a verb method.
+//
+// Honest exclusions (no fabricated routes)
+// ----------------------------------------
+//   - Interpolated / variable paths (`get pathVar:`, `get "/x/" & id:`) — not
+//     statically recoverable, dropped.
+//   - Jester `re"…"` regex routes and a method-set route (`get, post "/x":`)
+//     beyond a single leading verb — left to a producer follow-up.
+//   - Prologue grouped/prefixed routers where the mount prefix lives on a
+//     separate `newGroup`/`addGroup` call — the per-verb path is still emitted,
+//     the cross-call prefix join is a documented follow-up.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+var (
+	// jesterRouteRe matches a Jester `routes:`-block verb entry: a verb keyword
+	// at a statement boundary (start of line, after indentation), a
+	// string-literal path, then a `:` introducing the block body. The trailing
+	// `:` after the closing quote distinguishes a Jester route from a Prologue
+	// `app.get("…", …)` call (which has a `(` before the string and `,`/`)`
+	// after it). Capture group 1 is the verb; group 2 is the path literal.
+	jesterRouteRe = regexp.MustCompile(
+		`(?m)^[ \t]*(get|post|put|delete|patch|options|head)\s+"([^"\n\r]*)"\s*:`)
+
+	// prologueVerbRe matches a Prologue verb-method route registration:
+	// `app.get("/users/{id}", handler)` / `router.post("/x", h)`. The receiver
+	// (`app`/`router`/any ident) precedes the `.verb(` call; capture group 1 is
+	// the verb, group 2 the path literal.
+	prologueVerbRe = regexp.MustCompile(
+		`(?m)\b[A-Za-z_]\w*\.(get|post|put|delete|patch|options|head)\s*\(\s*"([^"\n\r]*)"`)
+
+	// prologueAddRouteRe matches Prologue's `addRoute("/path", handler,
+	// HttpGet)` form where the verb is the THIRD argument as an `Http<Verb>`
+	// enum value. Capture group 1 is the path literal, group 2 the verb enum
+	// tail (`Get`/`Post`/…).
+	prologueAddRouteRe = regexp.MustCompile(
+		`(?m)\baddRoute\s*\(\s*"([^"\n\r]*)"\s*,[^,)\n]*,\s*Http([A-Za-z]+)`)
+)
+
+// jesterHasRoute is a fast pre-filter: the file must reference a Jester web
+// marker AND a verb-with-string route to be worth scanning, so we never misfire
+// on arbitrary Nim code.
+func jesterHasRoute(content string) bool {
+	if !strings.Contains(content, "routes:") &&
+		!strings.Contains(content, "import jester") &&
+		!strings.Contains(content, "jester") {
+		return false
+	}
+	return strings.Contains(content, `"`)
+}
+
+// prologueHasRoute is a fast pre-filter for Prologue / HappyX route
+// registration files.
+func prologueHasRoute(content string) bool {
+	return strings.Contains(content, "prologue") ||
+		strings.Contains(content, "Prologue") ||
+		strings.Contains(content, "happyx") ||
+		strings.Contains(content, "addRoute")
+}
+
+// synthesizeJester scans a Nim source file for Jester `routes:`-block verb
+// entries and emits one http_endpoint_definition per statically-known
+// (verb, path).
+func synthesizeJester(content string, emit emitFn) {
+	if !jesterHasRoute(content) {
+		return
+	}
+	for _, m := range jesterRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		raw := strings.TrimSpace(m[2])
+		if raw == "" || strings.Contains(raw, "&") || strings.Contains(raw, "$") {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkJester, raw)
+		if canonical == "" {
+			continue
+		}
+		// Handler kind "Controller" maps to SCOPE.Operation in the resolver,
+		// the kind Nim procs land as — matching the Kemal/axum/vapor convention
+		// so ResolveHTTPEndpointHandlers can bind a handler IMPLEMENTS edge when
+		// a same-named handler exists (no name forces a handler when absent).
+		emit(verb, canonical, "jester", "Controller", "")
+	}
+}
+
+// synthesizePrologue scans a Nim source file for Prologue / HappyX verb-method
+// and addRoute registrations and emits one http_endpoint_definition per
+// statically-known (verb, path).
+func synthesizePrologue(content string, emit emitFn) {
+	if !prologueHasRoute(content) {
+		return
+	}
+	for _, m := range prologueVerbRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		raw := strings.TrimSpace(m[2])
+		if raw == "" || strings.Contains(raw, "&") || strings.Contains(raw, "$") {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkPrologue, raw)
+		if canonical == "" {
+			continue
+		}
+		emit(verb, canonical, "prologue", "Controller", "")
+	}
+	for _, m := range prologueAddRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		raw := strings.TrimSpace(m[1])
+		verb := strings.ToUpper(m[2])
+		if raw == "" || strings.Contains(raw, "&") || strings.Contains(raw, "$") {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkPrologue, raw)
+		if canonical == "" {
+			continue
+		}
+		emit(verb, canonical, "prologue", "Controller", "")
+	}
+}

--- a/internal/engine/http_endpoint_jester_test.go
+++ b/internal/engine/http_endpoint_jester_test.go
@@ -1,0 +1,115 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestJester_BasicRoute covers the common Jester `routes:`-block shape:
+// get "/todos": ... / post "/todos": ...
+func TestJester_BasicRoute(t *testing.T) {
+	src := `
+import jester
+
+routes:
+  get "/todos":
+    resp Todo.all().toJson()
+  post "/todos":
+    resp Todo.create(request.body)
+
+runForever()
+`
+	ids, _ := runDetect(t, "nim", "src/routes.nim", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos",
+		"http:POST:/todos",
+	}, "jester-basic-route")
+}
+
+// TestJester_PathParam covers the Jester `@param` AT-prefixed dynamic segment:
+// get "/todos/@id": → GET /todos/{id}.
+func TestJester_PathParam(t *testing.T) {
+	src := `
+import jester
+
+routes:
+  get "/todos/@id":
+    resp Todo.find(@"id").toJson()
+  delete "/todos/@id":
+    Todo.delete(@"id")
+`
+	ids, _ := runDetect(t, "nim", "src/todos.nim", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos/{id}",
+		"http:DELETE:/todos/{id}",
+	}, "jester-path-param")
+}
+
+// TestPrologue_VerbMethodRoute covers Prologue `app.get("/users/{id}", h)` /
+// `app.post("/users", h)` curly-brace registrations.
+func TestPrologue_VerbMethodRoute(t *testing.T) {
+	src := `
+import prologue
+
+let app = newApp()
+app.get("/users/{id}", getUser)
+app.post("/users", createUser)
+app.run()
+`
+	ids, _ := runDetect(t, "nim", "src/app.nim", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users/{id}",
+		"http:POST:/users",
+	}, "prologue-verb-method")
+}
+
+// TestPrologue_AddRoute covers Prologue's `addRoute("/x", handler, HttpGet)`
+// form where the verb is the third argument as an Http<Verb> enum value.
+func TestPrologue_AddRoute(t *testing.T) {
+	src := `
+import prologue
+
+let app = newApp()
+app.addRoute("/health", healthCheck, HttpGet)
+app.addRoute("/items", createItem, HttpPost)
+`
+	ids, _ := runDetect(t, "nim", "src/routes.nim", src)
+	requireContains(t, ids, []string{
+		"http:GET:/health",
+		"http:POST:/items",
+	}, "prologue-add-route")
+}
+
+// TestJester_InterpolatedRouteDropped asserts a non-static (concatenated /
+// interpolated) Jester path is NOT synthesized — no fabricated endpoint.
+func TestJester_InterpolatedRouteDropped(t *testing.T) {
+	src := `
+import jester
+
+const prefix = "/api"
+routes:
+  get prefix & "/x":
+    resp "dynamic"
+`
+	ids, _ := runDetect(t, "nim", "src/dyn.nim", src)
+	for _, id := range ids {
+		if id == "http:GET:/x" || id == "http:GET:/api/x" {
+			t.Fatalf("interpolated route should not synthesize an endpoint; got %q", id)
+		}
+	}
+}
+
+// TestJester_NonWebFileIgnored asserts a plain Nim file with a `get` proc call
+// but no Jester/Prologue web marker produces no endpoints.
+func TestJester_NonWebFileIgnored(t *testing.T) {
+	src := `
+proc handle() =
+  let x = cache.get("key")
+  echo x
+`
+	ids, _ := runDetect(t, "nim", "src/util.nim", src)
+	for _, id := range ids {
+		if len(id) >= 5 && id[:5] == "http:" {
+			t.Fatalf("non-web Nim file should synthesize no endpoint; got %q", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -136,6 +136,13 @@ func synthesisSupportsLanguage(lang string) bool {
 	// are no-ops inside the synthesizer.
 	case "groovy":
 		return true
+	// #4749 (epic #4615 tail): Nim Jester / Prologue producer-side route
+	// synthesis — Jester `routes:`-block verb entries and Prologue
+	// `app.get("/path", h)` registrations have no compiled YAML rules, so allow
+	// Nim through for synthesizeJester / synthesizePrologue. Files without a Nim
+	// web marker + route are no-ops inside the synthesizers.
+	case "nim":
+		return true
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
@@ -1330,6 +1337,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// extractor stays structural-only; this pass adds the canonical
 		// definitions the coverage substrate keys off.
 		synthesizeKemalRoutes(string(content), emit)
+	case "nim":
+		// Producer side (#4749): Nim web route registrations — Jester
+		// (`routes:` block `get "/users/@id":`) and Prologue
+		// (`app.get("/users/{id}", handler)`, `addRoute("/x", h, HttpGet)`) →
+		// canonical http_endpoint_definition, in the same shape
+		// axum/Rocket/Express/Kemal/Vapor emit, so the shared resolver and the
+		// e2e route-test linker (#4351) light up for Nim. The base nim extractor
+		// stays structural-only; this pass adds the canonical definitions the
+		// coverage substrate keys off.
+		synthesizeJester(string(content), emit)
+		synthesizePrologue(string(content), emit)
 	case "fsharp":
 		// Producer side (#4749): F# web route registrations — Giraffe
 		// (`GET >=> route "/users" >=> handler`, `routef "/users/%i"`) and Saturn

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -227,6 +227,20 @@ const (
 	// declares paths WITHOUT a leading slash (the synthesizer adds it).
 	// Canonicalisation reuses canonicalizeColonParams.
 	FrameworkRatpack = "ratpack"
+	// FrameworkJester (#4749) — Nim's Jester web framework declares routes
+	// inside a `routes:` block with indented verb entries carrying a string
+	// path literal: `get "/users/@id":`, `post "/x":`. Jester path parameters
+	// use the `@name` AT-prefixed convention (`/users/@id` → `{id}`), and a
+	// trailing `@rest` greedy-match or a `re"…"` regex segment is left intact
+	// (the segment matcher wildcards it). Canonicalisation rewrites `@name`
+	// segments to the shared `{name}` form via canonicalizeJesterParams.
+	FrameworkJester = "jester"
+	// FrameworkPrologue (#4749) — Nim's Prologue web framework registers routes
+	// with `app.get("/users/{id}", handler)` / `app.addRoute("/x", handler,
+	// HttpGet)`. Prologue (and HappyX) path parameters use the curly-brace
+	// `{name}` convention identical to FastAPI/Spring, so canonicalisation
+	// reuses canonicalizeCurlyBraces.
+	FrameworkPrologue = "prologue"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -265,8 +279,11 @@ func Canonicalize(framework, raw string) string {
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
 		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi,
 		FrameworkLitestar, FrameworkAiohttp, FrameworkFalcon, FrameworkHug,
-		FrameworkJavalin, FrameworkVertx, FrameworkGrails:
+		FrameworkJavalin, FrameworkVertx, FrameworkGrails, FrameworkPrologue:
 		out = canonicalizeCurlyBraces(raw)
+	case FrameworkJester:
+		// Nim Jester `@name` AT-prefixed path params → `{name}`.
+		out = canonicalizeJesterParams(raw)
 	case FrameworkTornado:
 		// Tornado paths arrive already pre-processed by the synthesizer
 		// (named-group → {name}, bare group → {}). Curly-brace pass
@@ -538,6 +555,42 @@ func canonicalizeColonParams(raw string) string {
 		if i < len(raw) && raw[i] == '?' {
 			i++
 		}
+	}
+	return b.String()
+}
+
+// canonicalizeJesterParams rewrites Nim Jester `@name` AT-prefixed path
+// parameters to the shared `{name}` form (`/users/@id` → `/users/{id}`). It is
+// the AT-prefixed analog of canonicalizeColonParams: a `@` followed by an
+// identifier (`[A-Za-z_][A-Za-z0-9_]*`) becomes `{name}`; a lone `@` or a `@`
+// not followed by an identifier byte is left verbatim. Jester also supports a
+// `re"…"` regex segment and a trailing greedy `@param` that the segment matcher
+// already wildcards, so no special handling is needed here beyond the
+// per-parameter rewrite.
+func canonicalizeJesterParams(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw))
+	i := 0
+	for i < len(raw) {
+		c := raw[i]
+		if c != '@' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(raw) && isIdentChar(raw[j]) {
+			j++
+		}
+		if j == i+1 {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		b.WriteByte('{')
+		b.WriteString(raw[i+1 : j])
+		b.WriteByte('}')
+		i = j
 	}
 	return b.String()
 }

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -2234,6 +2234,24 @@ var frameworkOrder = []frameworkEntry{
 		},
 		detect: detectLuaunit,
 	},
+	// Nim — std/unittest (suite "...": test "...": …). #4749. Detected by the
+	// `std/unittest` / `unittest` import token OR the nimble test conventions
+	// (`tFoo.nim`, `*_test.nim`, `test_*.nim`, files under /tests/). The
+	// `import std/unittest` form yields the `std/unittest` token (and the split
+	// `std`); the older `import unittest` form yields `unittest`.
+	{
+		name:        "nim-unittest",
+		importHints: []string{"std/unittest"},
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`_test\.nim$`),
+			regexp.MustCompile(`^t[A-Z][\w]*\.nim$`),
+			regexp.MustCompile(`^test_.*\.nim$`),
+		},
+		pathHints: []*regexp.Regexp{
+			regexp.MustCompile(`/tests?/.*\.nim$`),
+		},
+		detect: detectNimUnittest,
+	},
 	// ---------------------------------------------------------------------
 	// C/C++ — gtest, catch2, doctest, boost.test, cppunit, cpputest (#3495).
 	//
@@ -2317,6 +2335,18 @@ func selectFramework(tokens map[string]bool, filePath string) *frameworkEntry {
 		pathMatch := len(fe.pathHints) > 0 && matchesAnyPath(filePath, fe.pathHints)
 
 		switch fe.name {
+		case "pytest":
+			// pytest's import hints include the bare `unittest` token, which
+			// also appears in Nim's `import unittest` / `import std/unittest`.
+			// pytest is ordered before the nim-unittest entry, so skip it for
+			// `.nim` files (the nim-unittest entry wins) — the same precedent as
+			// the junit/.kt skip below. (#4749)
+			if strings.HasSuffix(strings.ToLower(filePath), ".nim") {
+				continue
+			}
+			if importMatch || fileMatch || pathMatch {
+				return fe
+			}
 		case "junit":
 			// The Java JUnit entry shares import hints (org.junit / junit.jupiter)
 			// with Kotlin tests, and is listed before kotlin_test. A Kotlin test

--- a/internal/extractors/cross/testmap/frameworks_nim.go
+++ b/internal/extractors/cross/testmap/frameworks_nim.go
@@ -1,0 +1,153 @@
+// Package testmap — Nim test-framework detection and call resolution.
+//
+// #4749 (the Nim slice of the coverage-linkage tail epic #4749/#4615). Deep
+// linkage for Nim's standard test runner:
+//
+//	std/unittest (xUnit/BDD hybrid): suite "Subject": ... test "does y": ...
+//	  Each `test "..."` leaf is a test case; its body (the colon-introduced,
+//	  indentation-delimited statement list that follows) is scanned for direct
+//	  production calls. The enclosing `suite "..."` subject is carried as a
+//	  naming-convention fallback when the leaf body has no resolvable production
+//	  call — mirroring the RSpec/busted describe-subject path.
+//
+// Nim blocks are INDENTATION-delimited (no braces, no `end` keyword), so this
+// file carries a Nim-specific body extractor (extractNimBlockBody) that returns
+// the run of lines indented MORE than the `test` line — quote-aware so a `test`
+// keyword inside a string never opens a block. This is the Nim analog of the
+// Lua keyword-balanced extractor in frameworks_lua.go.
+package testmap
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// std/unittest — suite "..." / test "..."  (xUnit/BDD)
+// ---------------------------------------------------------------------------
+
+// nimUnittestTestRE matches a unittest leaf case: `test "description":`. Group 1
+// is the description. The trailing `:` introduces the block body.
+var nimUnittestTestRE = regexp.MustCompile(
+	`(?m)^([ \t]*)test\s+"([^"\n\r]{1,200})"\s*:`,
+)
+
+// nimUnittestSuiteRE matches a unittest container: `suite "Subject":`. The first
+// suite whose subject looks like a code identifier (CamelCase / dotted /
+// module-ish) is used as the subject-under-test fallback. Group 1 = subject.
+var nimUnittestSuiteRE = regexp.MustCompile(
+	`(?m)^[ \t]*suite\s+"([^"\n\r]{1,200})"\s*:`,
+)
+
+// nimSubjectIdentRE recognises a suite subject that names a code symbol (e.g.
+// "UserService", "users.handler", "Account.create") so it can seed a
+// naming-convention TESTS edge. Plain prose subjects ("returns 200 on GET") are
+// rejected — they have spaces and are not identifier-shaped.
+var nimSubjectIdentRE = regexp.MustCompile(`^[A-Za-z_][\w]*(?:[.][A-Za-z_][\w]*)*$`)
+
+// nimSuiteSubject returns the first suite subject that is identifier-shaped
+// (no spaces), trimming a trailing "()" some authors append. Returns "" when no
+// suite block names a code symbol.
+func nimSuiteSubject(source string) string {
+	for _, m := range nimUnittestSuiteRE.FindAllStringSubmatch(source, -1) {
+		subj := strings.TrimSpace(m[1])
+		subj = strings.TrimSuffix(subj, "()")
+		if nimSubjectIdentRE.MatchString(subj) {
+			// Use the tail of a dotted subject ("users.handler" → "handler").
+			if idx := strings.LastIndexByte(subj, '.'); idx >= 0 {
+				if tail := subj[idx+1:]; tail != "" {
+					return tail
+				}
+			}
+			return subj
+		}
+	}
+	return ""
+}
+
+// indentWidth returns the number of leading space/tab bytes in line (tabs count
+// as one column, sufficient for relative-indent comparison within one file).
+func indentWidth(line string) int {
+	n := 0
+	for n < len(line) && (line[n] == ' ' || line[n] == '\t') {
+		n++
+	}
+	return n
+}
+
+// extractNimBlockBody returns the source slice of the indentation-delimited
+// block whose header line begins at byte offset headerStart. The body is the
+// run of subsequent lines indented STRICTLY MORE than the header line; the
+// block ends at the first non-blank line indented at or below the header
+// indent. Blank lines inside the block are kept. This mirrors the Nim compiler's
+// off-side rule closely enough for call-scanning purposes.
+func extractNimBlockBody(source string, headerStart int) string {
+	// Locate the end of the header line.
+	nl := strings.IndexByte(source[headerStart:], '\n')
+	if nl < 0 {
+		return ""
+	}
+	headerLine := source[headerStart : headerStart+nl]
+	headerIndent := indentWidth(headerLine)
+	bodyStart := headerStart + nl + 1
+	i := bodyStart
+	n := len(source)
+	for i < n {
+		lineEnd := strings.IndexByte(source[i:], '\n')
+		var line string
+		if lineEnd < 0 {
+			line = source[i:]
+		} else {
+			line = source[i : i+lineEnd]
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && indentWidth(line) <= headerIndent {
+			// Dedented to header level or less → block ended before this line.
+			return source[bodyStart:i]
+		}
+		if lineEnd < 0 {
+			return source[bodyStart:]
+		}
+		i += lineEnd + 1
+	}
+	return source[bodyStart:]
+}
+
+// nimTestCaseName normalises a `test "does a thing"` description into a snake
+// case-ish identifier used as the test-case qname (spaces → underscores, only
+// identifier-safe chars kept). Returns "" when nothing usable remains.
+func nimTestCaseName(desc string) string {
+	var b strings.Builder
+	prevUnderscore := false
+	for _, r := range strings.TrimSpace(desc) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevUnderscore = false
+		default:
+			if !prevUnderscore && b.Len() > 0 {
+				b.WriteByte('_')
+				prevUnderscore = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func detectNimUnittest(source string) []testFunction {
+	subject := nimSuiteSubject(source)
+
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range nimUnittestTestRE.FindAllStringSubmatchIndex(source, -1) {
+		desc := source[m[4]:m[5]]
+		name := nimTestCaseName(desc)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		body := extractNimBlockBody(source, m[0])
+		out = append(out, testFunction{qname: name, body: body, describeSubject: subject})
+	}
+	return out
+}

--- a/internal/extractors/cross/testmap/frameworks_nim_test.go
+++ b/internal/extractors/cross/testmap/frameworks_nim_test.go
@@ -1,0 +1,75 @@
+// Package testmap — value-asserting tests for the Nim std/unittest detector and
+// the Nim indentation block-body extractor (#4749).
+package testmap
+
+import (
+	"testing"
+)
+
+// TestNimUnittest_DirectCallHighConfidence proves a direct production call
+// inside a `test "...":` body yields a high-confidence TESTS edge, attributed to
+// the nim-unittest framework.
+func TestNimUnittest_DirectCallHighConfidence(t *testing.T) {
+	src := `
+import std/unittest
+import user
+
+suite "User":
+  test "creates a user":
+    let u = createUser("ada")
+    check u.name == "ada"
+`
+	recs := runExtract(t, "tests/tUser.nim", "nim", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 testmap entity for nim-unittest")
+	}
+	rec := findByTested(t, recs, "creates_a_user", "createUser")
+	if rec.Properties["test_framework"] != "nim-unittest" {
+		t.Errorf("framework=%q, want nim-unittest", rec.Properties["test_framework"])
+	}
+	if !hasEdge(recs, "creates_a_user", "createUser") {
+		t.Errorf("missing TESTS edge creates_a_user -> createUser")
+	}
+}
+
+// TestNimUnittest_BlockBodyScoped proves the indentation block-body extractor
+// only scans the test's own body — a call in a SIBLING test must not leak into
+// another test case's body.
+func TestNimUnittest_BlockBodyScoped(t *testing.T) {
+	src := `
+import std/unittest
+import svc
+
+suite "Svc":
+  test "alpha":
+    let a = runAlpha()
+    check a
+  test "beta":
+    let b = runBeta()
+    check b
+`
+	recs := runExtract(t, "tests/tSvc.nim", "nim", src)
+	if !hasEdgeAny(recs, "alpha", "runAlpha") {
+		t.Errorf("expected alpha -> runAlpha edge")
+	}
+	if !hasEdgeAny(recs, "beta", "runBeta") {
+		t.Errorf("expected beta -> runBeta edge")
+	}
+	// runBeta must NOT appear in the alpha test body (block-body scoping).
+	if hasEdgeAny(recs, "alpha", "runBeta") {
+		t.Errorf("runBeta leaked into the alpha test body — block-body scoping failed")
+	}
+}
+
+// TestNimUnittest_NonTestFileNoop proves a plain production file (no unittest
+// import, no test convention) is not detected as a test file.
+func TestNimUnittest_NonTestFileNoop(t *testing.T) {
+	src := `
+proc createUser(name: string): User =
+  result = User(name: name)
+`
+	recs := runExtract(t, "src/user.nim", "nim", src)
+	if len(recs) != 0 {
+		t.Fatalf("expected no testmap entities for a production file, got %d", len(recs))
+	}
+}

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -84,6 +84,11 @@ var customPrefixForLanguage = map[string]string{
 	"cpp":     "custom_cpp_",
 	"crystal": "custom_crystal_",
 	"fsharp":  "custom_fsharp_",
+	// Nim framework extractors (#4749 Jester/Prologue test→endpoint route-hit
+	// linkage). The base "nim" extractor key is shorter than this prefix, so the
+	// `len(k) > len(prefix)` guard in CustomExtractorsFor excludes it and only
+	// the custom_nim_* framework extractors match.
+	"nim": "custom_nim_",
 	// Protocol Buffers IDL files (.proto) are classified as their own
 	// "protobuf" language but carry message/service definitions parsed by the
 	// C/C++ protobuf custom extractor (which path/language-gates internally and

--- a/internal/extractors/custom_registry.go
+++ b/internal/extractors/custom_registry.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
 	_ "github.com/cajasmota/archigraph/internal/custom/kotlin"
 	_ "github.com/cajasmota/archigraph/internal/custom/lua"
+	_ "github.com/cajasmota/archigraph/internal/custom/nim"
 	_ "github.com/cajasmota/archigraph/internal/custom/php"
 	_ "github.com/cajasmota/archigraph/internal/custom/python"
 	_ "github.com/cajasmota/archigraph/internal/custom/ruby"


### PR DESCRIPTION
Nim slice of the coverage-linkage tail epic **#4749/#4615 — the LAST language in the tail**, so this PR **closes the epic**.

## Probe finding
The Nim base extractor (`internal/extractors/nim/nim.go`) is regex-structural only with **no web-framework awareness** — no `http_endpoint_definition` is ever produced for Nim, so a route-string test could never bind to an endpoint. The producer-side gap is closed first (mirrors Crystal/Kemal + Swift/Vapor).

## What's added
- **Producer** (`internal/engine/http_endpoint_jester.go`): one canonical `http_endpoint_definition` per statically-known Nim route — Jester `routes:`-block verb entries (`get "/users/@id":`, `@id`→`{id}` via new `FrameworkJester`) and Prologue `app.get("/users/{id}", h)` / `addRoute("/x", h, HttpGet)` (curly-brace `{id}`, `FrameworkPrologue`) — same shape axum/Rocket/Express/Kemal/Vapor emit. Wired into the `nim` synthesis case + gate (append-only).
- **Route-hit linkage** (`internal/custom/nim/tests_route_e2e.go`): one `test_suite` per Nim test file (`tFoo.nim` / `*_test.nim` / `tests/`) carrying `e2e_route_calls` from `std/httpclient` helpers (`client.get/post/put/delete/request`, host→path). The shared language-agnostic `engine.linkE2ERouteTestsToEndpoints` pass emits the TESTS edge to the exercised endpoint. New `custom_nim_` dispatch prefix.
- **Named-symbol test→SUT + scope-owner** (`internal/extractors/cross/testmap/frameworks_nim.go`): `std/unittest` `suite "...": test "...":` blocks with a Nim **indentation-aware** block-body extractor — each `test` leaf → TESTS edge via direct-call (high) + suite-subject fallback (medium). `pytest` is skipped for `.nim` files to avoid the shared `unittest` import-token collision (junit/.kt precedent). The `test "...":` description is prose (no callable entity), so — like JS/Ruby/Crystal anonymous closures — the suite-level `test_suite` is the scope-owner (#4684/#4680 analog).

## Honest scope
- **Local-variable/receiver typing (#4749 part a) — N/A**: the nim extractor names procs/methods bare (CONTAINS from an attached type, not `Type.method`) with no class-qualified receiver resolver to consume a `receiver_type` stamp; route-string linkage is the coverage mechanism (mirrors functional Elixir #4688 / Crystal).
- Documented follow-ups: Jester `re"..."` regex routes + multi-verb headers, Prologue cross-call group/prefix mounts, fully dynamic/concatenated routes.

## Coverage docs
`lang.nim.framework.jester` record **added** (none existed); `Testing.tests_linkage` / `Routing.endpoint_synthesis` / `route_extraction` → **full**, `handler_attribution` → **partial**, surgically via the coverage CLI. `coverage fmt --check` passes; `coverage validate` clean (0 errors — only the same capability-map *warning* class the merged Crystal/Lua slices carry).

## Validation (RED→GREEN)
- Producer: `TestJester_BasicRoute` / `_PathParam` / `_InterpolatedRouteDropped` / `_NonWebFileIgnored`, `TestPrologue_VerbMethodRoute` / `_AddRoute`.
- Full pipeline: `TestIssue4749_NimUnittestE2ERouteTestsLinkToEndpoints`.
- Route capture + exclusions: `TestNimRouteE2E_*`.
- Named-symbol detector + block-body scoping: `TestNimUnittest_*`.

## Gates
`go build ./...`, `go vet` (extractors/custom/graph/engine/testmap), `go test ./internal/extractors/... ./internal/custom/... ./internal/engine/... ./internal/graph/... ./internal/types/`, `coverage fmt --check`, `coverage validate` — all green.

## Tail summary (closing #4749)
test→endpoint coverage linkage now reaches every web-capable tail language. **Full route-hit linkage** (producer synthesized where missing): Scala, Rust, Swift/Vapor, Crystal/Kemal, Clojure, F#/Giraffe, Groovy/Grails+Ratpack, Erlang/Cowboy, Lua/Lapis, and **Nim/Jester+Prologue (this PR)**. **N/A**: Dart — recorded N/A with producer follow-up #4758 (no server-side shelf/conduit endpoint extractor yet).

Closes #4749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)