### PR TITLE
fix(dispatch): wire custom_lua_ tail extractor into lua production dispatch

### DIFF
--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -110,6 +110,17 @@ var customPrefixForLanguage = map[string]string{
 // so it no-ops on Lighthouse (custom_php_) GraphQL schemas and vice-versa.
 var extraCustomPrefixesForLanguage = map[string][]string{
 	"graphql": {"custom_js_"},
+	// lua's PRIMARY prefix is the bare `lua_` namespace used by its framework
+	// extractors (lua_routing, lua_middleware, lua_kong, …). The coverage-linkage
+	// tail extractor (#4749) however registered under the canonical
+	// `custom_lua_tests_route_e2e` key — matching every other language's
+	// `custom_<lang>_` convention — which does NOT share the `lua_` prefix
+	// (`custom_lua_…` starts with "custom", not "lua"). Without this extra
+	// prefix CustomExtractorsFor("lua") silently never returned the e2e
+	// extractor in production (only its direct-registration unit test passed).
+	// Dispatch both namespaces so the legacy lua_* framework extractors AND the
+	// custom_lua_* tail extractor are picked up.
+	"lua": {"custom_lua_"},
 }
 
 // CustomExtractorsFor returns all registered custom/framework extractors

--- a/internal/extractors/custom_dispatch_tail_test.go
+++ b/internal/extractors/custom_dispatch_tail_test.go
@@ -1,0 +1,62 @@
+package extractors
+
+import "testing"
+
+// TestTailCoverageLinkageExtractorsDispatch is a table-driven guard against a
+// class of latent bug surfaced by the #4749 coverage-linkage tail: a new
+// custom_<lang>_* extractor (tests_route_e2e / integration_e2e / phpunit_pest)
+// may register under a key prefix that the language's dispatch entry does not
+// point to, so CustomExtractorsFor(<lang>) silently never selects it in
+// PRODUCTION even though its direct-registration unit test passes.
+//
+// Concrete instance this test locks down: Lua. Its framework extractors use the
+// bare `lua_` prefix, but the tail extractor registered as
+// `custom_lua_tests_route_e2e` — which does NOT share the `lua_` prefix. The fix
+// adds `custom_lua_` to extraCustomPrefixesForLanguage["lua"]. This test fails
+// if that (or any analogous) dispatch wiring regresses.
+//
+// For each language, it asserts that the REAL dispatch path
+// (CustomExtractorsFor → prefix selection over the live registry populated by
+// custom_registry.go) returns an extractor whose registration key is the
+// expected coverage-linkage key.
+func TestTailCoverageLinkageExtractorsDispatch(t *testing.T) {
+	cases := []struct {
+		language    string
+		expectedKey string
+	}{
+		{"scala", "custom_scala_tests_route_e2e"},
+		{"rust", "custom_rust_tests_route_e2e"},
+		{"swift", "custom_swift_tests_route_e2e"},
+		{"crystal", "custom_crystal_tests_route_e2e"},
+		{"clojure", "custom_clojure_tests_route_e2e"},
+		{"fsharp", "custom_fsharp_tests_route_e2e"},
+		{"groovy", "custom_groovy_tests_route_e2e"},
+		{"erlang", "custom_erlang_tests_route_e2e"},
+		{"elixir", "custom_elixir_tests_route_e2e"},
+		{"lua", "custom_lua_tests_route_e2e"}, // the confirmed-broken case (#4749 tail)
+		{"nim", "custom_nim_tests_route_e2e"},
+		{"kotlin", "custom_kotlin_tests_route_e2e"}, // #4723
+		{"csharp", "custom_csharp_integration_e2e"}, // #4720
+		{"php", "custom_php_phpunit_pest"},          // #4721
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.language, func(t *testing.T) {
+			exts := CustomExtractorsFor(tc.language)
+			found := false
+			keys := make([]string, 0, len(exts))
+			for _, e := range exts {
+				k := e.Language()
+				keys = append(keys, k)
+				if k == tc.expectedKey {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("CustomExtractorsFor(%q) did not return %q via production dispatch; "+
+					"the extractor registers but its key prefix is not wired into the dispatch map. "+
+					"Selected keys: %v", tc.language, tc.expectedKey, keys)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The #4749 coverage-linkage tail registered each language's `tests_route_e2e` / `integration_e2e` / `phpunit_pest` extractor under the canonical `custom_<lang>_` key. **Lua** dispatches its framework extractors under the bare `lua_` prefix, so `CustomExtractorsFor("lua")` never selected `custom_lua_tests_route_e2e` in **production** — the key does not share the `lua_` prefix (it starts with `custom`). Only the extractor's direct-registration unit test exercised it; the live dispatch path silently dropped it (the latent class of bug surfaced by the Nim slice).

## Audit

Audited every tail language — scala, rust, swift, crystal, clojure, fsharp, groovy, erlang, lua, nim, elixir, csharp (#4720), php (#4721), kotlin (#4723):

| Lang | Registered key | Dispatch prefix | Status |
|---|---|---|---|
| **lua** | `custom_lua_tests_route_e2e` | `lua_` | **BROKEN** (fixed) |
| all others | `custom_<lang>_…` | `custom_<lang>_` | OK |

Lua was the **only** mismatch. Every other tail language both registers and dispatches under `custom_<lang>_`.

## Fix

Add `custom_lua_` to `extraCustomPrefixesForLanguage["lua"]` so both the legacy `lua_*` framework extractors AND the `custom_lua_*` tail extractor are dispatched — matching the established convention without disturbing the bare-`lua_` framework set.

## Guard

Adds a table-driven test `custom_dispatch_tail_test.go` asserting `CustomExtractorsFor(lang)` returns the expected coverage-linkage key for all 14 languages via the real registry + dispatch path. Verified it **fails** without the fix (selecting the `lua_*` framework extractors but not `custom_lua_tests_route_e2e`) and passes with it.

## Gates

- `go build ./...` ✅
- `go vet ./internal/extractors/... ./internal/custom/...` ✅
- `go test ./internal/extractors/... ./internal/custom/... ./internal/engine/...` ✅
- `coverage fmt --check` ✅ (registry untouched, stays canonical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)