### PR TITLE
feat(auth): engine-side structured auth-posture stamping (Spring/ASP.NET/Rails/Phoenix/Flask/Laravel) — #4750/#4751/#4752

### DIFF
--- a/internal/custom/elixir/phoenix.go
+++ b/internal/custom/elixir/phoenix.go
@@ -81,7 +81,11 @@ var (
 type elixirPipeline struct {
 	name  string
 	plugs []string
-	line  int
+	// plugLines holds the full trimmed plug source line for each plug (parallel
+	// to plugs), so role/option literals (`plug :require_role, :editor`) survive
+	// for the #4751 auth-stamping role extraction.
+	plugLines []string
+	line      int
 }
 
 // authPlugMethod classifies a plug name/module into an auth method.
@@ -148,6 +152,30 @@ func (e *phoenixExtractor) Extract(ctx context.Context, file extractor.FileInput
 	var entities []types.EntityRecord
 	seen := make(map[string]bool)
 
+	// #4751 — resolve scope ▸ pipe_through ▸ pipeline ▸ plug so each route can be
+	// stamped with its effective auth_pipelines + auth_plugs (+ role literal). The
+	// router source is also stamped as router_source for the source-scan fallback.
+	pipelinesByName := map[string]elixirPipeline{}
+	for _, pl := range parsePhoenixPipelines(src) {
+		pipelinesByName[pl.name] = pl
+	}
+	scopeSpans := parsePhoenixScopeSpans(src)
+	stampRouteAuth := func(ent *types.EntityRecord, routeOff int) {
+		res := resolvePhoenixRouteAuth(routeOff, scopeSpans, pipelinesByName)
+		if len(res.pipelines) > 0 {
+			ent.Properties["auth_pipelines"] = strings.Join(res.pipelines, ",")
+		}
+		if len(res.plugs) > 0 {
+			ent.Properties["auth_plugs"] = strings.Join(res.plugs, ",")
+		}
+		if res.role != "" {
+			ent.Properties["auth_roles"] = res.role
+		}
+		// router_source — the resolver's source-scan fallback reads this when the
+		// structured pipeline/plug props above don't resolve (dynamic pipe_through).
+		ent.Properties["router_source"] = phoenixRouterSlice(src, routeOff)
+	}
+
 	add := func(ent types.EntityRecord) {
 		key := ent.Kind + ":" + ent.Name
 		if seen[key] {
@@ -165,6 +193,7 @@ func (e *phoenixExtractor) Extract(ctx context.Context, file extractor.FileInput
 		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "phoenix", "provenance", "INFERRED_FROM_PHOENIX_ROUTE",
 			"http_method", method, "route_path", path)
+		stampRouteAuth(&ent, m[0])
 		add(ent)
 	}
 
@@ -174,6 +203,7 @@ func (e *phoenixExtractor) Extract(ctx context.Context, file extractor.FileInput
 		ent := makeEntity("LIVE "+path, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "phoenix", "provenance", "INFERRED_FROM_PHOENIX_LIVE_ROUTE",
 			"route_path", path, "route_type", "live")
+		stampRouteAuth(&ent, m[0])
 		add(ent)
 	}
 
@@ -187,6 +217,7 @@ func (e *phoenixExtractor) Extract(ctx context.Context, file extractor.FileInput
 			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, ln)
 			setProps(&ent, "framework", "phoenix", "provenance", "INFERRED_FROM_PHOENIX_RESOURCES",
 				"http_method", cr.method, "route_path", routePath)
+			stampRouteAuth(&ent, m[0])
 			add(ent)
 		}
 	}
@@ -390,11 +421,132 @@ func parsePhoenixPipelines(src string) []elixirPipeline {
 			}
 			if pm := rePhoenixPlugLine.FindStringSubmatch(ln); pm != nil {
 				pl.plugs = append(pl.plugs, pm[1])
+				pl.plugLines = append(pl.plugLines, strings.TrimSpace(ln))
 			}
 		}
 		out = append(out, pl)
 	}
 	return out
+}
+
+// phoenixScopeSpan is one `scope "/path" do ... end` block with its byte span
+// and the pipeline names its (first) pipe_through resolves to. Spans may nest;
+// the innermost enclosing scope's pipe_through wins for a route.
+type phoenixScopeSpan struct {
+	start    int // byte offset of the scope header
+	end      int // byte offset of the matching `end`
+	pipeline []string
+}
+
+// rePhoenixScopeHeader matches a `scope ... do` header (with or without a path).
+var rePhoenixScopeHeader = regexp.MustCompile(`(?m)^\s*scope\b.*\bdo\s*$`)
+
+// parsePhoenixScopeSpans returns every scope block with its byte span and the
+// pipeline names of the FIRST pipe_through declared directly in the scope body
+// (#4751). Spans are line-scanned by indentation, matching parsePhoenixPipelines.
+func parsePhoenixScopeSpans(src string) []phoenixScopeSpan {
+	var out []phoenixScopeSpan
+	lines := strings.Split(src, "\n")
+	// Precompute the byte offset of each line start.
+	offsets := make([]int, len(lines)+1)
+	off := 0
+	for i, ln := range lines {
+		offsets[i] = off
+		off += len(ln) + 1 // +1 for the split newline
+	}
+	offsets[len(lines)] = off
+	for i := 0; i < len(lines); i++ {
+		if !rePhoenixScopeHeader.MatchString(lines[i]) {
+			continue
+		}
+		headerIndent := indentWidth(lines[i])
+		span := phoenixScopeSpan{start: offsets[i], end: len(src)}
+		for j := i + 1; j < len(lines); j++ {
+			ln := lines[j]
+			trimmed := strings.TrimSpace(ln)
+			if trimmed == "end" && indentWidth(ln) <= headerIndent {
+				span.end = offsets[j]
+				break
+			}
+			if span.pipeline == nil {
+				if pm := rePhoenixPipeThrough.FindStringSubmatch(ln); pm != nil {
+					span.pipeline = parsePipeThroughList(pm[1])
+				}
+			}
+		}
+		out = append(out, span)
+	}
+	return out
+}
+
+// phoenixRouteAuth is the resolved auth context for one route: the pipeline names
+// it pipes through, the auth plugs across those pipelines, and a role literal
+// (from `plug :require_role, :editor`) when present.
+type phoenixRouteAuth struct {
+	pipelines []string
+	plugs     []string
+	role      string
+}
+
+// rePhoenixRolePlug matches a role-bearing plug `plug :require_role, :editor` /
+// `plug RequireRole, role: "editor"`; group 1 = the role literal.
+var rePhoenixRolePlug = regexp.MustCompile(`(?i)plug\s+[:\w.]*require_?role\w*\s*,?\s*(?:role:\s*)?:?["` + "`" + `]?(\w[\w.-]*)`)
+
+// resolvePhoenixRouteAuth finds the innermost scope enclosing the route at
+// routeOff, resolves its pipe_through pipeline names to the named pipelines, and
+// collects the auth plugs (and any role literal) across those pipelines (#4751).
+func resolvePhoenixRouteAuth(routeOff int, scopes []phoenixScopeSpan, pipelines map[string]elixirPipeline) phoenixRouteAuth {
+	var res phoenixRouteAuth
+	// Innermost (smallest, latest-starting) enclosing scope with a pipe_through.
+	best := -1
+	for i, s := range scopes {
+		if routeOff < s.start || routeOff >= s.end || len(s.pipeline) == 0 {
+			continue
+		}
+		if best < 0 || s.start > scopes[best].start {
+			best = i
+		}
+	}
+	if best < 0 {
+		return res
+	}
+	res.pipelines = scopes[best].pipeline
+	for _, name := range res.pipelines {
+		pl, ok := pipelines[name]
+		if !ok {
+			continue
+		}
+		for idx, pg := range pl.plugs {
+			if prov, _ := authPlugMethod(pg); prov != "" {
+				res.plugs = append(res.plugs, pg)
+			}
+			// Role literal from the FULL plug line (`plug :require_role, :editor`),
+			// since pg is only the plug name token.
+			if res.role == "" && idx < len(pl.plugLines) {
+				if m := rePhoenixRolePlug.FindStringSubmatch(pl.plugLines[idx]); m != nil {
+					res.role = m[1]
+				}
+			}
+		}
+	}
+	return res
+}
+
+// phoenixRouterSlice returns a bounded source slice around a route registration
+// for the router_source source-scan fallback (#4751/#4752). It includes a window
+// before the route (to carry the enclosing scope's pipe_through) and after.
+func phoenixRouterSlice(src string, routeOff int) string {
+	const before = 512
+	const after = 256
+	start := routeOff - before
+	if start < 0 {
+		start = 0
+	}
+	end := routeOff + after
+	if end > len(src) {
+		end = len(src)
+	}
+	return strings.TrimSpace(src[start:end])
 }
 
 // parsePipeThroughList normalises `pipe_through :api` or

--- a/internal/custom/elixir/phoenix_auth_4751_test.go
+++ b/internal/custom/elixir/phoenix_auth_4751_test.go
@@ -1,0 +1,84 @@
+package elixir_test
+
+// phoenix_auth_4751_test.go — #4751 Phoenix scope ▸ pipe_through ▸ pipeline ▸ plug
+// resolution: the extractor now stamps auth_pipelines/auth_plugs (+ role literal)
+// and router_source onto each route SCOPE.Operation/endpoint, so the authposture
+// phoenix resolver decodes the route's effective posture structurally.
+
+import "testing"
+
+func phoenixEndpoint(t *testing.T, ents []entitySummary, name string) map[string]string {
+	t.Helper()
+	for _, e := range ents {
+		if e.Name == name && e.Subtype == "endpoint" {
+			return e.Props
+		}
+	}
+	t.Fatalf("no endpoint %q; got %+v", name, ents)
+	return nil
+}
+
+func TestPhoenixAuth_PipeThroughResolved_4751(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  use MyAppWeb, :router
+
+  pipeline :browser do
+    plug :fetch_session
+  end
+
+  pipeline :auth do
+    plug Guardian.Plug.EnsureAuthenticated
+  end
+
+  scope "/dashboard", MyAppWeb do
+    pipe_through [:browser, :auth]
+    get "/", DashboardController, :index
+  end
+
+  scope "/", MyAppWeb do
+    pipe_through :browser
+    get "/about", PageController, :about
+  end
+end
+`
+	ents := extract(t, "custom_elixir_phoenix", fi("lib/my_app_web/router.ex", "elixir", src))
+
+	protectedEp := phoenixEndpoint(t, ents, "GET /")
+	if protectedEp["auth_pipelines"] != "browser,auth" {
+		t.Errorf("auth_pipelines=%q, want browser,auth", protectedEp["auth_pipelines"])
+	}
+	if protectedEp["auth_plugs"] == "" {
+		t.Errorf("auth_plugs not stamped on protected route")
+	}
+	if protectedEp["router_source"] == "" {
+		t.Errorf("router_source not stamped")
+	}
+
+	// The /about route pipes only through :browser (no auth pipeline) — it should
+	// carry the browser pipeline but no auth plug.
+	publicEp := phoenixEndpoint(t, ents, "GET /about")
+	if publicEp["auth_plugs"] != "" {
+		t.Errorf("public route should have no auth_plugs, got %q", publicEp["auth_plugs"])
+	}
+}
+
+func TestPhoenixAuth_RolePlugLiteral_4751(t *testing.T) {
+	src := `
+defmodule MyAppWeb.Router do
+  pipeline :editor do
+    plug :require_role, :editor
+  end
+
+  scope "/posts", MyAppWeb do
+    pipe_through [:editor]
+    post "/", PostController, :create
+  end
+end
+`
+	ents := extract(t, "custom_elixir_phoenix", fi("lib/my_app_web/router.ex", "elixir", src))
+	ep := phoenixEndpoint(t, ents, "POST /")
+	if ep["auth_roles"] != "editor" {
+		t.Errorf("auth_roles=%q, want editor", ep["auth_roles"])
+	}
+}

--- a/internal/custom/python/auth_endpoint.go
+++ b/internal/custom/python/auth_endpoint.go
@@ -55,8 +55,13 @@ type pyEndpointAuth struct {
 	Roles       []string
 	Permissions []string // fine-grained permission strings (DRF/Flask args)
 	Confidence  string   // "high" | "medium" | "low"
-	found       bool     // an explicit auth signal was recognised
-	publicSet   bool     // an explicit public marker was recognised (AllowAny)
+	// Decorator is the Flask auth-decorator name (`roles_required`,
+	// `permission_required`, …). Stamped as `auth_decorator` (#4752) so the flask
+	// resolver can decode admin/superuser-by-decorator-name (e.g.
+	// `@admin_required`) even when the decorator carries no explicit role arg.
+	Decorator string
+	found     bool // an explicit auth signal was recognised
+	publicSet bool // an explicit public marker was recognised (AllowAny)
 }
 
 // stamp writes the resolved posture onto an endpoint Properties map, mirroring
@@ -91,6 +96,16 @@ func (a pyEndpointAuth) stamp(props map[string]string) {
 			p := append([]string(nil), a.Permissions...)
 			sort.Strings(p)
 			props["auth_permissions"] = strings.Join(p, ",")
+			// #4752 — the flask resolver reads `auth_page` as a permission alias;
+			// mirror the permission into it so a Flask-Principal
+			// `@permission_required('export')` decodes structurally.
+			props["auth_page"] = props["auth_permissions"]
+		}
+		// #4752 — stamp the decorator name so the flask resolver decodes
+		// admin/superuser-by-name (`@admin_required` / `@superuser_required`) where
+		// the decorator carries no explicit role/permission arg.
+		if a.Decorator != "" {
+			props["auth_decorator"] = a.Decorator
 		}
 		return
 	}
@@ -210,7 +225,7 @@ func faDependenciesKwargAuth(decoratorArgs string) (string, bool) {
 var flAuthDecoratorRe = regexp.MustCompile(
 	`@(login_required|fresh_login_required|roles_required|roles_accepted|` +
 		`permission_required|auth_required|auth\.login_required|token_required|jwt_required|` +
-		`admin_required|requires_auth)\b\s*(?:\(([^)]*)\))?`)
+		`admin_required|superuser_required|staff_required|requires_auth)\b\s*(?:\(([^)]*)\))?`)
 
 // resolveFlaskDecoratorAuth scans the decorator block preceding a Flask route
 // handler for a recognised auth decorator. `decoratorBlock` is the text between
@@ -225,6 +240,7 @@ func resolveFlaskDecoratorAuth(decoratorBlock string) pyEndpointAuth {
 	a.Method = "decorator"
 	a.Confidence = "high"
 	a.Guard = m[1]
+	a.Decorator = m[1]
 	if len(m) > 2 && m[2] != "" {
 		// `@roles_required('admin')` / `@roles_accepted(...)` name roles;
 		// `@permission_required('app.delete_order')` names a fine-grained

--- a/internal/custom/python/flask.go
+++ b/internal/custom/python/flask.go
@@ -84,6 +84,10 @@ func (e *FlaskExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		// django-ratelimit `@ratelimit(rate='5/m')` may be stacked above the
 		// route decorator, so widen to the full preceding decorator block.
 		resolvePyEndpointRateLimit(decoratorWindow(source, idx[0], idx[1]), source).stamp(props)
+		// #4752 — stamp the view source (decorator block through the handler body)
+		// so the flask resolver's source-scan fallback fires in the LIVE diff for
+		// any decorator shape the structured props above don't cover.
+		props["view_source"] = flViewSource(source, idx[0])
 		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 
@@ -97,6 +101,7 @@ func (e *FlaskExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		props := map[string]string{"framework": "flask", "pattern_type": "route", "path": path, "http_methods": httpMethod, "blueprint": appVar}
 		resolveFlaskDecoratorAuth(source[idx[0]:idx[1]]).stamp(props)
 		resolvePyEndpointRateLimit(decoratorWindow(source, idx[0], idx[1]), source).stamp(props)
+		props["view_source"] = flViewSource(source, idx[0])
 		out = append(out, entity(funcName, "SCOPE.Operation", "endpoint", file.Path, line, props))
 	}
 
@@ -224,6 +229,19 @@ func (e *FlaskExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// flViewSource returns the view source slice starting at the route decorator
+// (offset `start`) bounded to a small window — enough to carry the stacked auth
+// decorators and the handler signature for the flask resolver's source-scan
+// fallback (#4752) while keeping the graph payload small.
+func flViewSource(source string, start int) string {
+	const maxSource = 2048
+	end := start + maxSource
+	if end > len(source) {
+		end = len(source)
+	}
+	return strings.TrimSpace(source[start:end])
 }
 
 func parseHTTPMethods(raw string) string {

--- a/internal/custom/python/flask_auth_4752_test.go
+++ b/internal/custom/python/flask_auth_4752_test.go
@@ -1,0 +1,84 @@
+package python
+
+// flask_auth_4752_test.go — #4752 Flask roles/permission decorator stamping +
+// view_source fallback: the engine now stamps auth_roles/auth_permissions/
+// auth_page/auth_decorator + view_source so the authposture flask resolver
+// decodes role/permission/admin postures structurally (not just unknown).
+
+import "testing"
+
+func TestFlaskAuth_RolesRequired_4752(t *testing.T) {
+	src := `
+from flask import Flask
+from flask_security import roles_required
+
+app = Flask(__name__)
+
+@app.route('/admin')
+@roles_required('admin')
+def admin():
+    return 'ok'
+`
+	eps := pyEndpointProps(t, &FlaskExtractor{}, "app.py", src)
+	e, ok := eps["admin"]
+	if !ok {
+		t.Fatalf("no admin endpoint; got %+v", eps)
+	}
+	if e.Properties["auth_roles"] != "admin" {
+		t.Errorf("auth_roles=%q, want admin", e.Properties["auth_roles"])
+	}
+	if e.Properties["auth_decorator"] != "roles_required" {
+		t.Errorf("auth_decorator=%q, want roles_required", e.Properties["auth_decorator"])
+	}
+	if e.Properties["view_source"] == "" {
+		t.Errorf("view_source not stamped")
+	}
+}
+
+func TestFlaskAuth_PermissionRequired_4752(t *testing.T) {
+	src := `
+from flask import Flask
+from flask_principal import permission_required
+
+app = Flask(__name__)
+
+@app.route('/export')
+@permission_required('export')
+def export():
+    return 'ok'
+`
+	eps := pyEndpointProps(t, &FlaskExtractor{}, "app.py", src)
+	e, ok := eps["export"]
+	if !ok {
+		t.Fatalf("no export endpoint; got %+v", eps)
+	}
+	if e.Properties["auth_permissions"] != "export" {
+		t.Errorf("auth_permissions=%q, want export", e.Properties["auth_permissions"])
+	}
+	if e.Properties["auth_page"] != "export" {
+		t.Errorf("auth_page=%q, want export", e.Properties["auth_page"])
+	}
+}
+
+func TestFlaskAuth_AdminDecorator_4752(t *testing.T) {
+	// A bare @admin_required (no role arg) — decoded by decorator NAME.
+	src := `
+from flask import Flask
+from .auth import admin_required
+
+app = Flask(__name__)
+
+@app.route('/dashboard')
+@admin_required
+def dashboard():
+    return 'ok'
+`
+	eps := pyEndpointProps(t, &FlaskExtractor{}, "app.py", src)
+	e, ok := eps["dashboard"]
+	if !ok {
+		t.Fatalf("no dashboard endpoint; got %+v", eps)
+	}
+	if e.Properties["auth_decorator"] != "admin_required" {
+		t.Errorf("auth_decorator=%q, want admin_required", e.Properties["auth_decorator"])
+	}
+}

--- a/internal/custom/ruby/controller_auth.go
+++ b/internal/custom/ruby/controller_auth.go
@@ -93,6 +93,10 @@ var (
 	// per-action Pundit authorize call inside a method body: authorize @post
 	caPunditAuthorizeRe = regexp.MustCompile(`(?m)^\s*authorize\s+[@a-z_]`)
 
+	// Pundit `authorize @post` — capture the authorized record symbol so we can
+	// derive the policy literal (`@post` → `Post` policy). Group 1 = bare name.
+	caPunditRecordRe = regexp.MustCompile(`(?m)^\s*authorize\s+@?([A-Za-z_][\w]*)`)
+
 	// Pundit `authorize @post, :destroy?` — the trailing symbol is the explicit
 	// policy method. Group 1 = the policy-method name (without the `?`).
 	caPunditActionRe = regexp.MustCompile(`(?m)^\s*authorize\s+[@A-Za-z_][\w.]*\s*,\s*:([a-z_]+)\??`)
@@ -179,6 +183,12 @@ func (e *railsControllerAuthExtractor) Extract(ctx context.Context, file extract
 				"controller_action", handler,
 				"action", act.name)
 			posture.stamp(ent.Properties)
+			// #4752 — stamp the controller source body so the rails resolver's
+			// source-scan fallback fires in the LIVE diff for any guard shape the
+			// structured props above don't cover (custom before_action symbols, etc.).
+			if body := caSourceSlice(body); body != "" {
+				ent.Properties["controller_source"] = body
+			}
 			add(ent)
 		}
 	}
@@ -197,6 +207,17 @@ type caActionPosture struct {
 	// action checks (`authorize @post, :destroy?` → "destroy"). Empty when the
 	// guard is a coarse authenticate before_action (authn, not authz).
 	permission string
+	// punditPolicy is the Pundit policy class literal the resolver decodes the
+	// exact action grant from (`authorize @post` → "Post"). Empty for non-Pundit.
+	punditPolicy string
+	// punditAction is the explicit Pundit policy method (`authorize @post,
+	// :destroy?` → "destroy"). Empty when the action defaults to the controller
+	// action name.
+	punditAction string
+	// cancancanAbility is the CanCanCan ability literal (`authorize! :destroy` →
+	// "destroy" / `load_and_authorize_resource` → the controller action). Empty
+	// for non-CanCanCan.
+	cancancanAbility string
 }
 
 func (p caActionPosture) stamp(props map[string]string) {
@@ -213,6 +234,18 @@ func (p caActionPosture) stamp(props map[string]string) {
 	// archigraph_auth_coverage answers "what permission does this route require?".
 	if p.permission != "" {
 		props["auth_permissions"] = p.permission
+	}
+	// #4751 — stamp the Pundit policy/action and CanCanCan ability LITERALS so the
+	// rails resolver decodes the exact action grant (KindAction with the policy
+	// codename) instead of degrading to a coarse posture from the source scan.
+	if p.punditPolicy != "" {
+		props["pundit_policy"] = p.punditPolicy
+	}
+	if p.punditAction != "" {
+		props["pundit_action"] = p.punditAction
+	}
+	if p.cancancanAbility != "" {
+		props["cancancan_ability"] = p.cancancanAbility
 	}
 }
 
@@ -303,10 +336,17 @@ func caResolveAction(level caControllerLevelAuth, body, action string) caActionP
 			protected = false
 		}
 		if protected {
-			return caActionPosture{
+			p := caActionPosture{
 				required: true, guard: level.guard,
 				method: level.method, confidence: level.confidence,
 			}
+			// #4751 — a controller-level `load_and_authorize_resource` (CanCanCan)
+			// authorizes the controller action; stamp the action name as the ability
+			// literal so the resolver decodes the exact grant.
+			if level.method == "cancancan" {
+				p.cancancanAbility = action
+			}
+			return p
 		}
 	}
 
@@ -320,17 +360,27 @@ func caResolveAction(level caControllerLevelAuth, body, action string) caActionP
 			if m := caPunditActionRe.FindStringSubmatch(actionBody); m != nil {
 				perm = m[1]
 			}
+			// #4751 — derive the Pundit policy class literal from the authorized
+			// record (`authorize @post` → "Post"); the resolver reads pundit_policy
+			// + pundit_action to decode the exact action grant.
+			policy := ""
+			if m := caPunditRecordRe.FindStringSubmatch(actionBody); m != nil {
+				policy = caPunditPolicyClass(m[1])
+			}
 			return caActionPosture{
 				required: true, guard: "authorize",
 				method: "pundit", confidence: "medium",
-				permission: perm,
+				permission:   perm,
+				punditPolicy: policy,
+				punditAction: perm,
 			}
 		}
 		if m := caCanCanActionRe.FindStringSubmatch(actionBody); m != nil {
 			return caActionPosture{
 				required: true, guard: "authorize!",
 				method: "cancancan", confidence: "medium",
-				permission: m[1],
+				permission:       m[1],
+				cancancanAbility: m[1],
 			}
 		}
 	}
@@ -395,6 +445,44 @@ func caClassBody(src string, from int) string {
 		return rest[:nxt[0]]
 	}
 	return rest
+}
+
+// caPunditPolicyClass maps an authorized-record symbol to its Pundit policy class
+// literal: `post` / `@post` → "Post"; an already-capitalised constant is kept.
+// Pundit infers the policy from the record's class, so we Camelize the bare name.
+func caPunditPolicyClass(record string) string {
+	record = strings.TrimPrefix(strings.TrimSpace(record), "@")
+	if record == "" {
+		return ""
+	}
+	// Camelize a snake_case / lower record name (`blog_post` → "BlogPost").
+	var b strings.Builder
+	upNext := true
+	for _, r := range record {
+		if r == '_' {
+			upNext = true
+			continue
+		}
+		if upNext && r >= 'a' && r <= 'z' {
+			b.WriteRune(r - ('a' - 'A'))
+		} else {
+			b.WriteRune(r)
+		}
+		upNext = false
+	}
+	return b.String()
+}
+
+// caSourceSlice bounds a controller body for stamping as controller_source — the
+// resolver only needs the auth-bearing region, so cap the slice to keep the graph
+// payload small while still carrying every before_action / authorize call.
+func caSourceSlice(body string) string {
+	const maxSource = 4096
+	body = strings.TrimSpace(body)
+	if len(body) > maxSource {
+		return body[:maxSource]
+	}
+	return body
 }
 
 // caControllerResource maps a controller class name to the routes.rb resource

--- a/internal/custom/ruby/controller_auth_test.go
+++ b/internal/custom/ruby/controller_auth_test.go
@@ -325,3 +325,50 @@ func keysOf(m map[string]types.EntityRecord) []string {
 	}
 	return out
 }
+
+// TestControllerAuthPunditLiteral_4751 — a per-action `authorize @post, :update?`
+// stamps pundit_policy/pundit_action so the rails resolver decodes the exact
+// action grant (#4751).
+func TestControllerAuthPunditLiteral_4751(t *testing.T) {
+	src := `class PostsController < ApplicationController
+  def update
+    @post = Post.find(params[:id])
+    authorize @post, :update?
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e, ok := eps["posts#update"]
+	if !ok {
+		t.Fatalf("no posts#update endpoint; got %+v", eps)
+	}
+	if e.Properties["pundit_policy"] != "Post" {
+		t.Errorf("pundit_policy=%q, want Post", e.Properties["pundit_policy"])
+	}
+	if e.Properties["pundit_action"] != "update" {
+		t.Errorf("pundit_action=%q, want update", e.Properties["pundit_action"])
+	}
+	if e.Properties["controller_source"] == "" {
+		t.Errorf("controller_source not stamped")
+	}
+}
+
+// TestControllerAuthCanCanLiteral_4751 — controller-level
+// load_and_authorize_resource stamps cancancan_ability = the action name (#4751).
+func TestControllerAuthCanCanLiteral_4751(t *testing.T) {
+	src := `class WidgetsController < ApplicationController
+  load_and_authorize_resource
+
+  def destroy
+  end
+end
+`
+	eps := runControllerAuth(t, src)
+	e, ok := eps["widgets#destroy"]
+	if !ok {
+		t.Fatalf("no widgets#destroy endpoint; got %+v", eps)
+	}
+	if e.Properties["cancancan_ability"] != "destroy" {
+		t.Errorf("cancancan_ability=%q, want destroy", e.Properties["cancancan_ability"])
+	}
+}

--- a/internal/engine/aspnet_core_auth.go
+++ b/internal/engine/aspnet_core_auth.go
@@ -1,0 +1,202 @@
+// aspnet_core_auth.go — ASP.NET Core [Authorize]/[AllowAnonymous] posture
+// stamping onto the synthesized http_endpoint_definition entities (#4750).
+//
+// synthesizeASPNetCore (aspnet_core_routes.go) emits the route endpoints but
+// DISCARDS the [Authorize]/[AllowAnonymous]/policy/roles attributes in the
+// intervening-attribute stack, so the authposture aspnet resolver had NO props
+// to decode and honestly reported unknown. This post-pass re-parses the C# file
+// and stamps the STRUCTURED method ▸ class ▸ global posture the resolver reads
+// (internal/authposture/aspnet.go):
+//
+//	method  → auth_required / auth_roles / auth_policy / allow_anonymous
+//	class   → aspnet_class_authorize / aspnet_class_roles / aspnet_class_policy /
+//	          aspnet_class_allow_anonymous
+//	global  → aspnet_fallback_policy (a Program.cs FallbackPolicy in the same file
+//	          — the cross-file Startup case stays the documented source-scan gap)
+//
+// It mirrors the in-place post-pass pattern applyHotChocolateAuthShapes /
+// applyLaravelRateLimit use: it only mutates Properties on the aspnet_core
+// endpoints this file just produced; it never adds or removes entities.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+var (
+	// [Authorize(Roles = "Admin,Mgr")] — first role captured by the resolver.
+	aspnetAuthRolesRe = regexp.MustCompile(`\[\s*Authorize\s*\([^)]*Roles\s*=\s*"([^"]+)"`)
+	// [Authorize(Policy = "CanEdit")].
+	aspnetAuthPolicyRe = regexp.MustCompile(`\[\s*Authorize\s*\([^)]*Policy\s*=\s*"([^"]+)"`)
+	// A bare [Authorize] / [Authorize(AuthenticationSchemes=...)] (no Roles/Policy).
+	aspnetAuthBareRe = regexp.MustCompile(`\[\s*Authorize\b`)
+	// [AllowAnonymous].
+	aspnetAllowAnonAttrRe = regexp.MustCompile(`\[\s*AllowAnonymous\s*\]`)
+
+	// A method declaration with its preceding attribute stack. Group 1 = the
+	// attribute block (may be empty), group 2 = the method name. Anchored on the
+	// HTTP verb attribute so we only scan action methods.
+	aspnetActionBlockRe = regexp.MustCompile(
+		`((?:[ \t]*\[[^\]\r\n]+\][ \t]*[\r\n]+)+)[ \t]*` +
+			`(?:public|protected|private|internal|static|virtual|override|sealed|async|\s)+` +
+			`[\w<>\[\],.\s?]+?\s+([A-Za-z_]\w*)\s*\(`)
+
+	// class-level attribute stack + the controller class declaration.
+	aspnetClassBlockRe = regexp.MustCompile(
+		`((?:[ \t]*\[[^\]\r\n]+\][ \t]*[\r\n]+)+)[ \t]*` +
+			`(?:public|internal|sealed|abstract|partial|static|\s)*` +
+			`class\s+([A-Za-z_]\w*Controller)\b`)
+
+	// Program.cs FallbackPolicy: `o.FallbackPolicy = new
+	// AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();`
+	aspnetFallbackPolicyRe = regexp.MustCompile(`FallbackPolicy\s*=`)
+)
+
+// aspnetAttrPosture is the resolved attribute posture for one block.
+type aspnetAttrPosture struct {
+	allowAnon bool
+	authorize bool
+	roles     string
+	policy    string
+}
+
+// resolveAspnetAttrBlock decodes an attribute block into a posture.
+func resolveAspnetAttrBlock(block string) aspnetAttrPosture {
+	var p aspnetAttrPosture
+	if aspnetAllowAnonAttrRe.MatchString(block) {
+		p.allowAnon = true
+	}
+	if m := aspnetAuthRolesRe.FindStringSubmatch(block); m != nil {
+		p.authorize = true
+		p.roles = m[1]
+	}
+	if m := aspnetAuthPolicyRe.FindStringSubmatch(block); m != nil {
+		p.authorize = true
+		p.policy = m[1]
+	}
+	if aspnetAuthBareRe.MatchString(block) {
+		p.authorize = true
+	}
+	return p
+}
+
+// applyAspnetCoreAuth stamps the method ▸ class ▸ global [Authorize] posture onto
+// the aspnet_core endpoints emitted for `path` (#4750). Cheap-gated on the file
+// carrying an [Authorize]/[AllowAnonymous] attribute or a FallbackPolicy.
+func applyAspnetCoreAuth(content, path string, entities []types.EntityRecord, before int) {
+	if before >= len(entities) {
+		return
+	}
+	if !strings.Contains(content, "[Authorize") && !strings.Contains(content, "[AllowAnonymous") &&
+		!aspnetFallbackPolicyRe.MatchString(content) {
+		return
+	}
+
+	// Per-action attribute postures, keyed by method name.
+	methodPosture := map[string]aspnetAttrPosture{}
+	// The action source block (attributes + signature) for the source-scan
+	// fallback (#4752), keyed by method name.
+	methodSource := map[string]string{}
+	for _, m := range aspnetActionBlockRe.FindAllStringSubmatch(content, -1) {
+		block := m[1]
+		name := m[2]
+		methodPosture[name] = resolveAspnetAttrBlock(block)
+		methodSource[name] = strings.TrimSpace(m[0])
+	}
+
+	// Class-level posture (first controller class wins — one per file is the norm).
+	var classPosture aspnetAttrPosture
+	if m := aspnetClassBlockRe.FindStringSubmatch(content); m != nil {
+		classPosture = resolveAspnetAttrBlock(m[1])
+	}
+
+	// Global FallbackPolicy declared in this file (best-effort; same-file only).
+	fallback := ""
+	if aspnetFallbackPolicyRe.MatchString(content) {
+		if strings.Contains(content, "RequireAuthenticatedUser") {
+			fallback = "RequireAuthenticatedUser"
+		} else {
+			fallback = "FallbackPolicy"
+		}
+	}
+
+	for i := before; i < len(entities); i++ {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path || e.Properties == nil {
+			continue
+		}
+		if e.Properties["framework"] != "aspnet_core" {
+			continue
+		}
+		method := aspnetEndpointMethodName(e.Properties["source_handler"])
+
+		// (1) METHOD level — the per-action attribute block.
+		if mp, ok := methodPosture[method]; ok {
+			stampAspnetMethodPosture(e.Properties, mp)
+		}
+		if src, ok := methodSource[method]; ok && src != "" {
+			e.Properties["action_source"] = src
+		}
+		// (2) CLASS level — stamped as aspnet_class_* (the resolver applies them
+		// only when no method attribute covers the action).
+		stampAspnetClassPosture(e.Properties, classPosture)
+		// (3) GLOBAL level — the same-file FallbackPolicy.
+		if fallback != "" {
+			e.Properties["aspnet_fallback_policy"] = fallback
+		}
+	}
+}
+
+// stampAspnetMethodPosture writes the method-level attribute posture: an
+// [AllowAnonymous] override (allow_anonymous=true / auth_required=false) wins;
+// otherwise [Authorize(Roles/Policy)] → auth_roles/auth_policy + auth_required.
+func stampAspnetMethodPosture(props map[string]string, p aspnetAttrPosture) {
+	if p.allowAnon {
+		props["allow_anonymous"] = "true"
+		props["auth_required"] = "false"
+		return
+	}
+	if !p.authorize {
+		return
+	}
+	props["auth_required"] = "true"
+	if p.roles != "" {
+		props["auth_roles"] = p.roles
+	}
+	if p.policy != "" {
+		props["auth_policy"] = p.policy
+	}
+}
+
+// stampAspnetClassPosture writes the class-level attribute posture as the
+// aspnet_class_* props the resolver reads for actions without their own attribute.
+func stampAspnetClassPosture(props map[string]string, p aspnetAttrPosture) {
+	if p.allowAnon {
+		props["aspnet_class_allow_anonymous"] = "true"
+	}
+	if p.roles != "" {
+		props["aspnet_class_roles"] = p.roles
+	}
+	if p.policy != "" {
+		props["aspnet_class_policy"] = p.policy
+	}
+	if p.authorize && p.roles == "" && p.policy == "" {
+		props["aspnet_class_authorize"] = "true"
+	}
+}
+
+// aspnetEndpointMethodName extracts the action method name from a
+// `SCOPE.Operation:<Class>.<Method>` source_handler.
+func aspnetEndpointMethodName(sourceHandler string) string {
+	op := sourceHandler
+	if c := strings.LastIndexByte(op, ':'); c >= 0 {
+		op = op[c+1:]
+	}
+	if d := strings.LastIndexByte(op, '.'); d >= 0 {
+		op = op[d+1:]
+	}
+	return op
+}

--- a/internal/engine/auth_engine_stamping_4750_test.go
+++ b/internal/engine/auth_engine_stamping_4750_test.go
@@ -1,0 +1,261 @@
+package engine
+
+// auth_engine_stamping_4750_test.go — LIVE-PATH tests for #4750/#4751/#4752: the
+// engine now stamps the STRUCTURED auth-posture props the authposture resolvers
+// read, so a guarded endpoint resolves to the correct structured posture in the
+// live diff (not just source-scan/unknown). Each test feeds source as the engine
+// receives it, asserts the props the extractor stamps, then resolves them through
+// the authposture registry exactly as the MCP auth_posture_diff tool does.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/authposture"
+)
+
+// resolveEndpointProps runs an endpoint's stamped props through the authposture
+// registry the same way the MCP diff tool harvests them (the prop keys are the
+// shared contract; this mirrors mcp.buildAuthSignal without the import cycle).
+func resolveEndpointProps(props map[string]string) authposture.Posture {
+	sig := authposture.Signal{Props: map[string]string{}}
+	for k, v := range props {
+		sig.Props[k] = v
+	}
+	sig.Framework = props["framework"]
+	for _, k := range []string{
+		"action_source", "handler_source", "controller_source", "view_source",
+		"route_source", "router_source",
+	} {
+		if v := props[k]; v != "" {
+			sig.Source = v
+			break
+		}
+	}
+	sig.Action = props["action"]
+	p, _ := authposture.NewRegistry().Resolve(sig)
+	return p
+}
+
+// endpointWithProps finds the synthesized http_endpoint_definition entity for
+// (verb, path) and returns its properties.
+func endpointWithProps(t *testing.T, res *DetectResult, verb, path string) map[string]string {
+	t.Helper()
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointDefinitionKind || e.Properties == nil {
+			continue
+		}
+		if e.Properties["verb"] == verb && e.Properties["path"] == path {
+			return e.Properties
+		}
+	}
+	t.Fatalf("no endpoint %s %s found in result", verb, path)
+	return nil
+}
+
+// --- #4750 ASP.NET Core: method ▸ class ▸ global [Authorize] precedence ---
+
+func TestStamp_Aspnet_MethodRoles(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+
+[ApiController]
+[Route("/api/widgets")]
+public class WidgetsController : ControllerBase
+{
+    [HttpGet]
+    [Authorize(Roles = "Admin")]
+    public IActionResult List() { return Ok(); }
+}
+`
+	_, res := runDetect(t, "csharp", "WidgetsController.cs", src)
+	props := endpointWithProps(t, res, "GET", "/api/widgets")
+	if props["auth_roles"] != "Admin" {
+		t.Fatalf("expected auth_roles=Admin, got props=%+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindRole || p.Literal != "Admin" {
+		t.Fatalf("aspnet method roles: want role/Admin, got %+v", p)
+	}
+}
+
+func TestStamp_Aspnet_ClassAuthorize(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+
+[ApiController]
+[Authorize]
+[Route("/api/orders")]
+public class OrdersController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult List() { return Ok(); }
+}
+`
+	_, res := runDetect(t, "csharp", "OrdersController.cs", src)
+	props := endpointWithProps(t, res, "GET", "/api/orders")
+	if props["aspnet_class_authorize"] != "true" {
+		t.Fatalf("expected aspnet_class_authorize=true, got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindAuthenticated {
+		t.Fatalf("aspnet class authorize: want authenticated, got %+v", p)
+	}
+}
+
+func TestStamp_Aspnet_MethodAllowAnonymousOverride(t *testing.T) {
+	src := `
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+
+[ApiController]
+[Authorize]
+[Route("/api/public")]
+public class PublicController : ControllerBase
+{
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult Ping() { return Ok(); }
+}
+`
+	_, res := runDetect(t, "csharp", "PublicController.cs", src)
+	props := endpointWithProps(t, res, "GET", "/api/public")
+	if props["allow_anonymous"] != "true" {
+		t.Fatalf("expected allow_anonymous=true, got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindPublic {
+		t.Fatalf("aspnet allow-anonymous override: want public, got %+v", p)
+	}
+}
+
+// --- #4750 Spring: class @PreAuthorize + method @PreAuthorize + global ---
+
+func TestStamp_Spring_ClassPreAuthorize(t *testing.T) {
+	src := `
+package demo;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@RestController
+@RequestMapping("/api/admin")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+    @GetMapping("/users")
+    public String users() { return ""; }
+}
+`
+	_, res := runDetect(t, "java", "AdminController.java", src)
+	props := endpointWithProps(t, res, "GET", "/api/admin/users")
+	if props["spring_class_pre_authorize"] != "hasRole('ADMIN')" {
+		t.Fatalf("expected spring_class_pre_authorize, got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindRole || p.Literal != "ADMIN" {
+		t.Fatalf("spring class @PreAuthorize: want role/ADMIN, got %+v", p)
+	}
+}
+
+func TestStamp_Spring_MethodPreAuthorize(t *testing.T) {
+	src := `
+package demo;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportController {
+    @GetMapping("/export")
+    @PreAuthorize("hasAuthority('reports:export')")
+    public String export() { return ""; }
+}
+`
+	_, res := runDetect(t, "java", "ReportController.java", src)
+	props := endpointWithProps(t, res, "GET", "/api/reports/export")
+	if props["auth_expression"] != "hasAuthority('reports:export')" {
+		t.Fatalf("expected auth_expression, got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindAction || p.Literal != "reports:export" {
+		t.Fatalf("spring method @PreAuthorize: want action/reports:export, got %+v", p)
+	}
+}
+
+func TestStamp_Spring_GlobalFilterChain(t *testing.T) {
+	// Controller + a same-file SecurityFilterChain whose requestMatchers covers
+	// the controller's /api/secure prefix → spring_global_authorization stamped.
+	src := `
+package demo;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RestController
+@RequestMapping("/api/secure")
+public class SecureController {
+    @GetMapping("/data")
+    public String data() { return ""; }
+
+    @Bean
+    public SecurityFilterChain chain(org.springframework.security.config.annotation.web.builders.HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(a -> a.requestMatchers("/api/secure/**").authenticated());
+        return http.build();
+    }
+}
+`
+	_, res := runDetect(t, "java", "SecureController.java", src)
+	props := endpointWithProps(t, res, "GET", "/api/secure/data")
+	if props["spring_global_authorization"] == "" {
+		t.Fatalf("expected spring_global_authorization, got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindAuthenticated {
+		t.Fatalf("spring global filter-chain: want authenticated, got %+v", p)
+	}
+}
+
+// --- #4752 Laravel: reconciled route + group auth middleware ---
+
+func TestStamp_Laravel_RouteAuthMiddleware(t *testing.T) {
+	src := `<?php
+use Illuminate\Support\Facades\Route;
+Route::get('/profile', 'ProfileController@show')->middleware('auth');
+`
+	_, res := runDetect(t, "php", "routes/web.php", src)
+	props := endpointWithProps(t, res, "GET", "/profile")
+	if props["auth_required"] != "true" {
+		t.Fatalf("expected auth_required=true, got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindAuthenticated {
+		t.Fatalf("laravel route auth middleware: want authenticated, got %+v", p)
+	}
+}
+
+func TestStamp_Laravel_GroupRoleMiddleware(t *testing.T) {
+	src := `<?php
+use Illuminate\Support\Facades\Route;
+Route::group(['middleware' => ['auth', 'role:admin']], function () {
+    Route::get('/admin/dashboard', 'AdminController@index');
+});
+`
+	_, res := runDetect(t, "php", "routes/web.php", src)
+	props := endpointWithProps(t, res, "GET", "/admin/dashboard")
+	if props["auth_roles"] != "admin" {
+		t.Fatalf("expected auth_roles=admin, got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindRole || p.Literal != "admin" {
+		t.Fatalf("laravel group role middleware: want role/admin, got %+v", p)
+	}
+}
+
+func TestStamp_Laravel_WithoutMiddlewareOverride(t *testing.T) {
+	src := `<?php
+use Illuminate\Support\Facades\Route;
+Route::group(['middleware' => ['auth']], function () {
+    Route::get('/health', 'HealthController@check')->withoutMiddleware('auth');
+});
+`
+	_, res := runDetect(t, "php", "routes/web.php", src)
+	props := endpointWithProps(t, res, "GET", "/health")
+	if props["auth_required"] != "false" {
+		t.Fatalf("expected auth_required=false (withoutMiddleware), got %+v", props)
+	}
+	if p := resolveEndpointProps(props); p.Kind != authposture.KindPublic {
+		t.Fatalf("laravel withoutMiddleware override: want public, got %+v", p)
+	}
+}

--- a/internal/engine/http_endpoint_php_auth.go
+++ b/internal/engine/http_endpoint_php_auth.go
@@ -1,0 +1,324 @@
+// http_endpoint_php_auth.go — Laravel reconciled auth-middleware posture stamping
+// onto the synthesized http_endpoint_definition entities (#4752).
+//
+// synthesizeLaravel (http_endpoint_php_producer.go) parses route + group
+// middleware only for PREFIX synthesis; it never stamps the reconciled AUTH
+// posture, so the authposture laravel resolver had nothing to decode for classic
+// route/controller middleware (only api-platform endpoints carried auth props).
+// This post-pass reconciles a route's own `->middleware(...)` chain with its
+// enclosing `Route::group(['middleware'=>[...]])` middleware (resolving
+// `auth` / `role:` / `can:`/`permission:` tokens and a `->withoutMiddleware('auth')`
+// override) and stamps the flat auth contract the resolver reads:
+//
+//	auth_required   — "true" | "false" (withoutMiddleware override)
+//	auth_middleware — the reconciled middleware chain string the resolver decodes
+//	auth_roles      — the role: literal (spatie/permission)
+//	auth_permissions— the can:/permission: ability literal
+//	auth_method     — "middleware" | "without"
+//	route_source    — the route registration slice for the source-scan fallback
+//
+// Mirrors the in-place post-pass pattern applyLaravelRateLimit uses: it only
+// mutates Properties on the laravel endpoints this file just produced and reuses
+// the same group-span keying so route↔group reconciliation matches the producer.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+var (
+	// A route/controller `->middleware('auth')` / `->middleware(['auth','role:admin'])`
+	// chain. Group 1 = the raw middleware argument (string or array body).
+	lrAuthMwArgRe = regexp.MustCompile(`->\s*middleware\s*\(\s*(\[[^\]]*\]|'[^']*'|"[^"]*")`)
+	// `->withoutMiddleware('auth')` → per-route public override.
+	lrWithoutAuthRe = regexp.MustCompile(`->\s*withoutMiddleware\s*\(\s*\[?\s*['"]auth(?::[\w.-]+)?['"]`)
+	// Individual middleware tokens: 'auth', 'auth:sanctum', 'role:admin', 'can:update'.
+	lrMwTokenRe = regexp.MustCompile(`['"]([\w:., -]+)['"]`)
+)
+
+// lrAuthSite is one route's reconciled auth posture keyed by canonical (verb, path).
+type lrAuthSite struct {
+	verb string
+	path string
+	auth lrAuthPosture
+}
+
+// lrAuthPosture is the resolved auth posture for a Laravel route.
+type lrAuthPosture struct {
+	required   bool
+	publicSet  bool // explicit withoutMiddleware('auth')
+	middleware string
+	roles      string
+	perms      string
+	method     string // "middleware" | "without"
+}
+
+func (p lrAuthPosture) stamp(props map[string]string) {
+	if p.publicSet {
+		props["auth_required"] = "false"
+		props["auth_method"] = "without"
+		return
+	}
+	if !p.required {
+		return
+	}
+	props["auth_required"] = "true"
+	props["auth_method"] = "middleware"
+	if p.middleware != "" {
+		props["auth_middleware"] = p.middleware
+	}
+	if p.roles != "" {
+		props["auth_roles"] = p.roles
+	}
+	if p.perms != "" {
+		props["auth_permissions"] = p.perms
+	}
+}
+
+// resolveLaravelMiddlewareTokens classifies a list of middleware tokens into an
+// auth posture: an `auth`/`auth:guard` token → authenticated; `role:admin` →
+// role; `can:update` / `permission:edit` → permission/ability.
+func resolveLaravelMiddlewareTokens(tokens []string) lrAuthPosture {
+	var p lrAuthPosture
+	var mw []string
+	for _, t := range tokens {
+		t = strings.TrimSpace(t)
+		low := strings.ToLower(t)
+		switch {
+		case low == "auth" || strings.HasPrefix(low, "auth:"):
+			p.required = true
+			mw = append(mw, t)
+		case strings.HasPrefix(low, "role:") || strings.HasPrefix(low, "hasrole:"):
+			p.required = true
+			p.roles = firstLaravelArg(t)
+			mw = append(mw, t)
+		case strings.HasPrefix(low, "can:") || strings.HasPrefix(low, "permission:"):
+			p.required = true
+			p.perms = firstLaravelArg(t)
+			mw = append(mw, t)
+		}
+	}
+	p.middleware = strings.Join(mw, ",")
+	return p
+}
+
+// firstLaravelArg returns the first colon-arg of a middleware token, dropping a
+// trailing CSV tail: `role:admin,editor` → "admin", `can:update,post` → "update".
+func firstLaravelArg(token string) string {
+	if c := strings.IndexByte(token, ':'); c >= 0 {
+		arg := token[c+1:]
+		if comma := strings.IndexByte(arg, ','); comma >= 0 {
+			arg = arg[:comma]
+		}
+		return strings.TrimSpace(arg)
+	}
+	return ""
+}
+
+// lrMwTokens extracts the quoted middleware tokens from a `->middleware(...)`
+// argument region (handles both the single-string and array forms).
+func lrMwTokens(arg string) []string {
+	var out []string
+	for _, m := range lrMwTokenRe.FindAllStringSubmatch(arg, -1) {
+		if t := strings.TrimSpace(m[1]); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// indexLaravelRouteAuth pairs each `Route::<verb>(` registration with its own
+// `->middleware(...)` / `->withoutMiddleware('auth')` chain plus the middleware of
+// every enclosing group, keyed by the SAME canonical (verb, path) the producer
+// stamps. Per-route middleware reconciles WITH (adds to) the group middleware;
+// a `->withoutMiddleware('auth')` override opens the route.
+func indexLaravelRouteAuth(content string, groupSpans []lrGroupSpan, groupMw map[int][]string) []lrAuthSite {
+	verbMatches := lrRouteVerbRe.FindAllStringSubmatchIndex(content, -1)
+	if len(verbMatches) == 0 {
+		return nil
+	}
+	var out []lrAuthSite
+	for i, m := range verbMatches {
+		spanEnd := len(content)
+		if i+1 < len(verbMatches) {
+			spanEnd = verbMatches[i+1][0]
+		}
+		if semi := strings.IndexByte(content[m[0]:spanEnd], ';'); semi >= 0 {
+			spanEnd = m[0] + semi
+		}
+		span := content[m[0]:spanEnd]
+
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := ""
+		if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			raw = content[m[6]:m[7]]
+		}
+		if raw == "" {
+			continue
+		}
+		prefix := ""
+		var tokens []string
+		for gi, gs := range groupSpans {
+			if m[0] >= gs.bodyStart && m[0] < gs.bodyEnd {
+				prefix = prefix + "/" + strings.Trim(gs.prefix, "/")
+				tokens = append(tokens, groupMw[gi]...)
+			}
+		}
+		if prefix != "" {
+			raw = prefix + "/" + strings.TrimLeft(raw, "/")
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+
+		// Per-route ->middleware(...) tokens reconcile with the group middleware.
+		for _, am := range lrAuthMwArgRe.FindAllStringSubmatch(span, -1) {
+			tokens = append(tokens, lrMwTokens(am[1])...)
+		}
+		posture := resolveLaravelMiddlewareTokens(tokens)
+		// A per-route withoutMiddleware('auth') opens the route (highest precedence).
+		if lrWithoutAuthRe.MatchString(span) {
+			posture = lrAuthPosture{publicSet: true, method: "without"}
+		}
+		if !posture.required && !posture.publicSet {
+			continue
+		}
+		out = append(out, lrAuthSite{verb: verb, path: canonical, auth: posture})
+	}
+	return out
+}
+
+// indexLaravelGroupMiddleware returns the middleware token list of each group
+// span (keyed by its index in groupSpans), so a route can union its enclosing
+// groups' middleware. Group spans whose options carry no middleware key map to
+// an empty list.
+func indexLaravelGroupMiddleware(content string, groupSpans []lrGroupSpan) map[int][]string {
+	out := make(map[int][]string, len(groupSpans))
+	for gi, gs := range groupSpans {
+		// Scan a bounded window before the group body for its middleware key.
+		winStart := gs.bodyStart - 600
+		if winStart < 0 {
+			winStart = 0
+		}
+		win := content[winStart:gs.bodyStart]
+		if m := lrRouteGroupMwRe.FindStringSubmatch(win); m != nil {
+			// The whole options array may carry a list; re-scan the window for all
+			// quoted tokens after the `middleware` key.
+			mwIdx := strings.LastIndex(win, "middleware")
+			if mwIdx >= 0 {
+				out[gi] = lrMwTokens(win[mwIdx:])
+			} else {
+				out[gi] = lrMwTokens(strings.Join(m[1:], " "))
+			}
+		}
+	}
+	return out
+}
+
+// indexLaravelGroupAuthRoutes scans Route::group(['middleware'=>[...]]) calls
+// (prefix-LESS auth groups that lrExtractGroupSpans does not return), enumerates
+// the Route::<verb>( registrations nested in each group body, and returns them as
+// path-keyed auth sites. Mirrors indexLaravelGroupThrottles so a
+// `Route::group(['middleware'=>['auth']], fn)` with no prefix still protects its
+// inner routes.
+func indexLaravelGroupAuthRoutes(content string, groupSpans []lrGroupSpan) []lrAuthSite {
+	var out []lrAuthSite
+	for _, m := range lrRouteGroupMwRe.FindAllStringSubmatchIndex(content, -1) {
+		winEnd := m[1] + 400
+		if winEnd > len(content) {
+			winEnd = len(content)
+		}
+		tokens := lrMwTokens(content[m[0]:winEnd])
+		posture := resolveLaravelMiddlewareTokens(tokens)
+		if !posture.required {
+			continue
+		}
+		bodyOpen := -1
+		for i := m[1]; i < len(content) && i < m[1]+1000; i++ {
+			if content[i] == '{' {
+				bodyOpen = i
+				break
+			}
+		}
+		if bodyOpen < 0 {
+			continue
+		}
+		bodyEnd := lrFindMatchingBrace(content, bodyOpen)
+		if bodyEnd < 0 {
+			continue
+		}
+		for _, vm := range lrRouteVerbRe.FindAllStringSubmatchIndex(content, -1) {
+			if len(vm) < 8 || vm[0] < bodyOpen+1 || vm[0] >= bodyEnd {
+				continue
+			}
+			verb := strings.ToUpper(content[vm[2]:vm[3]])
+			raw := ""
+			if vm[4] >= 0 {
+				raw = content[vm[4]:vm[5]]
+			} else if vm[6] >= 0 {
+				raw = content[vm[6]:vm[7]]
+			}
+			if raw == "" {
+				continue
+			}
+			prefix := ""
+			for _, gs := range groupSpans {
+				if vm[0] >= gs.bodyStart && vm[0] < gs.bodyEnd {
+					prefix = prefix + "/" + strings.Trim(gs.prefix, "/")
+				}
+			}
+			if prefix != "" {
+				raw = prefix + "/" + strings.TrimLeft(raw, "/")
+			}
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+			out = append(out, lrAuthSite{verb: verb, path: canonical, auth: posture})
+		}
+	}
+	return out
+}
+
+// applyLaravelAuth resolves and stamps the reconciled auth posture on every
+// Laravel synthetic backend endpoint synthesizeLaravel emitted (#4752). It mutates
+// Properties in place and never adds or removes entities. `before` is the
+// entity-slice length captured before the PHP synthesizers ran.
+func applyLaravelAuth(content, path string, entities []types.EntityRecord, before int) {
+	if len(content) == 0 || before >= len(entities) {
+		return
+	}
+	if !strings.Contains(content, "middleware") {
+		return
+	}
+	groupSpans := lrExtractGroupSpans(content)
+	groupMw := indexLaravelGroupMiddleware(content, groupSpans)
+	groupSites := indexLaravelGroupAuthRoutes(content, groupSpans)
+	routeSites := indexLaravelRouteAuth(content, groupSpans, groupMw)
+	if len(groupSites) == 0 && len(routeSites) == 0 {
+		return
+	}
+	// Group sites first, then overlay per-route sites (per-route middleware /
+	// withoutMiddleware override takes precedence for the same key).
+	byKey := make(map[string]lrAuthPosture, len(groupSites)+len(routeSites))
+	for _, s := range groupSites {
+		byKey[s.verb+" "+s.path] = s.auth
+	}
+	for _, s := range routeSites {
+		byKey[s.verb+" "+s.path] = s.auth
+	}
+	for i := before; i < len(entities); i++ {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path || e.Properties == nil {
+			continue
+		}
+		if e.Properties["framework"] != "laravel" {
+			continue
+		}
+		key := e.Properties["verb"] + " " + e.Properties["path"]
+		if a, ok := byKey[key]; ok {
+			a.stamp(e.Properties)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -800,6 +800,11 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeSpringFromComposed(entities, path, emit)
 		// JAX-RS: scan the file directly.
 		synthesizeJAXRS(string(content), emit)
+		// Producer side (#4750): stamp the method ▸ class ▸ global Spring-Security
+		// posture (@PreAuthorize/@Secured + matched SecurityFilterChain rule + the
+		// handler source body, #4752) onto the Spring endpoints emitted above, so
+		// the authposture spring resolver decodes class/global postures live.
+		applySpringCoreAuth(string(content), path, entities, javaMWBefore)
 		// Javalin (#3085): lambda DSL `app.get("/path", handler)` routing.
 		synthesizeJavalin(string(content), emit)
 		// Vert.x (#3086): lambda DSL `router.get("/path").handler(...)` routing.
@@ -1162,7 +1167,13 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	case "csharp":
 		// Producer side (#2692): ASP.NET Core attribute routing —
 		// [HttpGet/Post/...] + class-level [Route("/api/[controller]")].
+		aspnetBefore := len(entities)
 		synthesizeASPNetCore(string(content), emit)
+		// Producer side (#4750): stamp the method ▸ class ▸ global
+		// [Authorize]/[AllowAnonymous]/Roles/Policy posture (and the action source
+		// body for the source-scan fallback, #4752) onto the ASP.NET endpoints
+		// emitted above, so the authposture aspnet resolver decodes them live.
+		applyAspnetCoreAuth(string(content), path, entities, aspnetBefore)
 		// Producer side (#3617): HotChocolate GraphQL server. Maps the three
 		// root types ([QueryType]/[MutationType]/[SubscriptionType] markers,
 		// [ExtendObjectType(...)] extensions, or fluent .AddQueryType<T>()
@@ -1209,6 +1220,10 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		phpRLBefore := len(entities)
 		// Producer side (#1419): Laravel Route::verb/resource/apiResource.
 		synthesizeLaravel(string(content), emit, emitResource)
+		// Producer side (#4752): reconcile route + group auth middleware
+		// (auth / role: / can: / withoutMiddleware) into the flat auth posture the
+		// authposture laravel resolver decodes live, over the endpoints emitted above.
+		applyLaravelAuth(string(content), path, entities, phpRLBefore)
 		// #3628 → #4073 rate-limit child — stamp the flat rate-limit contract
 		// (rate_limited/rate_limit/rate_limit_scope/rate_limit_source) on the
 		// Laravel endpoints emitted above: per-route

--- a/internal/engine/java_auth_policy.go
+++ b/internal/engine/java_auth_policy.go
@@ -401,6 +401,178 @@ func parsePreAuthorizeExpr(spel string) (roles, perms, scopes []string) {
 	return roles, perms, scopes
 }
 
+// SpringAuthStamps are the STRUCTURED Spring-Security auth props the authposture
+// spring resolver reads to decode the method ▸ class ▸ global precedence ladder
+// LIVE (#4750), distinct from the coarse auth_required/auth_roles flat companion.
+// Each field maps 1:1 to a prop key the resolver consults
+// (internal/authposture/spring.go).
+type SpringAuthStamps struct {
+	// MethodExpression is a method-level @PreAuthorize/@PostAuthorize SpEL body
+	// (stamped as auth_expression). The resolver decodes hasRole/hasAuthority/
+	// permitAll/isAuthenticated from it.
+	MethodExpression string
+	// MethodSecured is a method-level @Secured/@RolesAllowed role literal
+	// (stamped as secured).
+	MethodSecured string
+	// ClassPreAuthorize is the controller-class @PreAuthorize SpEL body (stamped
+	// as spring_class_pre_authorize); applies to handlers without their own.
+	ClassPreAuthorize string
+	// ClassSecured is the controller-class @Secured/@RolesAllowed role literal
+	// (stamped as spring_class_secured).
+	ClassSecured string
+	// GlobalAuthorization is the SecurityFilterChain/HttpSecurity authorization
+	// rule matched to THIS route, when statically recoverable (stamped as
+	// spring_global_authorization). Best-effort; empty when no matcher applies.
+	GlobalAuthorization string
+}
+
+// springPreAuthorizeAnyRe captures the SpEL body of a @PreAuthorize OR
+// @PostAuthorize annotation (the method/class authorization expression).
+var springPreAuthorizeAnyRe = regexp.MustCompile(`@(?:Pre|Post)Authorize\s*\(\s*"([^"]*)"\s*\)`)
+
+// ResolveSpringAuthStamps extracts the structured Spring-Security props from the
+// method-level and class-level annotation blocks. It is the engine-side half of
+// the #4750 stamping: the authposture spring resolver reads these exact prop keys
+// to decode the effective posture in the LIVE diff instead of degrading to a
+// source scan. The global SecurityFilterChain rule is passed in pre-matched
+// (globalAuthorization) — matching a route to a filter-chain requestMatcher is a
+// cross-file concern resolved by the caller where statically recoverable; this
+// resolver only threads it through. Returns the zero value (all-empty) when the
+// controller carries no Spring-Security annotation.
+func ResolveSpringAuthStamps(methodAnnoText, classAnnoText, globalAuthorization string) SpringAuthStamps {
+	var s SpringAuthStamps
+	// Method-level @PreAuthorize/@PostAuthorize SpEL body.
+	if m := springPreAuthorizeAnyRe.FindStringSubmatch(methodAnnoText); m != nil {
+		s.MethodExpression = m[1]
+	}
+	// Method-level @Secured / @RolesAllowed role literal (first quoted token).
+	if m := javaSecuredRe.FindStringSubmatch(methodAnnoText); m != nil {
+		s.MethodSecured = firstQuotedToken(m[1])
+	} else if m := javaRolesAllowedRe.FindStringSubmatch(methodAnnoText); m != nil {
+		s.MethodSecured = firstQuotedToken(m[1])
+	}
+	// Class-level @PreAuthorize/@PostAuthorize SpEL body.
+	if m := springPreAuthorizeAnyRe.FindStringSubmatch(classAnnoText); m != nil {
+		s.ClassPreAuthorize = m[1]
+	}
+	// Class-level @Secured / @RolesAllowed role literal.
+	if m := javaSecuredRe.FindStringSubmatch(classAnnoText); m != nil {
+		s.ClassSecured = firstQuotedToken(m[1])
+	} else if m := javaRolesAllowedRe.FindStringSubmatch(classAnnoText); m != nil {
+		s.ClassSecured = firstQuotedToken(m[1])
+	}
+	s.GlobalAuthorization = strings.TrimSpace(globalAuthorization)
+	return s
+}
+
+// Stamp writes the resolved Spring structured props onto an endpoint Properties
+// map. Only non-empty props are written, so an endpoint with only a method
+// annotation does not gain phantom class/global props.
+func (s SpringAuthStamps) Stamp(props map[string]string) {
+	if props == nil {
+		return
+	}
+	if s.MethodExpression != "" {
+		props["auth_expression"] = s.MethodExpression
+	}
+	if s.MethodSecured != "" {
+		props["secured"] = s.MethodSecured
+	}
+	if s.ClassPreAuthorize != "" {
+		props["spring_class_pre_authorize"] = s.ClassPreAuthorize
+	}
+	if s.ClassSecured != "" {
+		props["spring_class_secured"] = s.ClassSecured
+	}
+	if s.GlobalAuthorization != "" {
+		props["spring_global_authorization"] = s.GlobalAuthorization
+	}
+}
+
+// springFilterChainRule is one parsed SecurityFilterChain authorization rule:
+// the ant-pattern its requestMatchers/antMatchers names and the full rule text
+// (e.g. `requestMatchers("/admin/**").hasRole("ADMIN")`).
+type springFilterChainRule struct {
+	pattern string // the ant-pattern, e.g. "/admin/**"
+	rule    string // the full rule fragment the resolver decodes
+}
+
+// springFilterChainMatcherRe captures a SecurityFilterChain authorization rule
+// of the form `requestMatchers("/admin/**").hasRole("ADMIN")` /
+// `antMatchers("/public/**").permitAll()` / `.requestMatchers("/api/**").authenticated()`.
+// Group 1 = the ant-pattern; the whole match (group 0) is the rule text.
+var springFilterChainMatcherRe = regexp.MustCompile(
+	`(?:requestMatchers|antMatchers|mvcMatchers)\s*\(\s*"([^"]+)"\s*\)\s*\.\s*(?:hasRole|hasAnyRole|hasAuthority|hasAnyAuthority|permitAll|denyAll|authenticated|fullyAuthenticated|anonymous)\s*\([^)]*\)`)
+
+// parseSpringFilterChainRules extracts every SecurityFilterChain authorization
+// rule from a Java source file (#4750). Only fires when the file actually
+// declares a SecurityFilterChain / HttpSecurity authorize block, so a plain
+// controller file yields no rules.
+func parseSpringFilterChainRules(src string) []springFilterChainRule {
+	if !strings.Contains(src, "SecurityFilterChain") && !strings.Contains(src, "authorizeHttpRequests") && !strings.Contains(src, "authorizeRequests") {
+		return nil
+	}
+	var out []springFilterChainRule
+	for _, loc := range springFilterChainMatcherRe.FindAllStringSubmatchIndex(src, -1) {
+		full := src[loc[0]:loc[1]]
+		pattern := src[loc[2]:loc[3]]
+		out = append(out, springFilterChainRule{pattern: pattern, rule: full})
+	}
+	return out
+}
+
+// matchSpringFilterChainRule returns the authorization rule text whose ant-pattern
+// covers the given controller route prefix, or "" when none match. Matching is
+// best-effort over the statically-recoverable ant-pattern vocabulary (exact, `/**`
+// and `/*` suffix wildcards); dynamic/regex matchers are not matched (the
+// resolver then reports KindUnknown rather than false-public — #4750).
+func matchSpringFilterChainRule(rules []springFilterChainRule, prefix string) string {
+	if len(rules) == 0 || prefix == "" {
+		return ""
+	}
+	for _, r := range rules {
+		if antPatternMatchesPrefix(r.pattern, prefix) {
+			return r.rule
+		}
+	}
+	return ""
+}
+
+// antPatternMatchesPrefix reports whether a Spring ant-pattern covers a route
+// prefix: an exact match, or a `/**`/`/*` suffix-wildcard whose static head is a
+// prefix of the route. A leading `/**` (match-all) covers everything.
+func antPatternMatchesPrefix(pattern, prefix string) bool {
+	pattern = strings.TrimSpace(pattern)
+	prefix = strings.TrimSpace(prefix)
+	if pattern == "" || prefix == "" {
+		return false
+	}
+	if pattern == prefix {
+		return true
+	}
+	if pattern == "/**" || pattern == "/*" {
+		return true
+	}
+	for _, suffix := range []string{"/**", "/*"} {
+		if strings.HasSuffix(pattern, suffix) {
+			head := strings.TrimSuffix(pattern, suffix)
+			if head == "" || prefix == head || strings.HasPrefix(prefix, head+"/") || strings.HasPrefix(prefix, head) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// firstQuotedToken returns the first quoted token in an annotation argument list
+// (`{"ROLE_ADMIN","ROLE_USER"}` → `ROLE_ADMIN`), or "" when none is present.
+func firstQuotedToken(s string) string {
+	if m := authRoleArgRe.FindStringSubmatch(s); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
 // quarkusPermMatches reports whether any of the permission's path patterns
 // covers `endpointPath`. The grammar matches Quarkus's documented behaviour:
 //   - exact match

--- a/internal/engine/spring_core_auth.go
+++ b/internal/engine/spring_core_auth.go
@@ -1,0 +1,141 @@
+// spring_core_auth.go — Spring Security [@PreAuthorize/@Secured/@RolesAllowed]
+// method ▸ class ▸ global posture stamping onto the synthesized Spring
+// http_endpoint_definition entities (#4750).
+//
+// synthesizeSpringFromComposed (http_endpoint_synthesis.go) re-emits the AST-
+// composed Spring Routes as endpoints but carries only the route path — none of
+// the class/method @PreAuthorize/@Secured annotations nor the SecurityFilterChain
+// rule, so the authposture spring resolver had nothing structured to decode for
+// class/global Spring postures (only method-level flat auth_roles flowed). This
+// post-pass re-parses the controller file, reconstructs each handler's composed
+// route path, and stamps the STRUCTURED props the resolver reads
+// (internal/authposture/spring.go):
+//
+//	method  → auth_expression / secured
+//	class   → spring_class_pre_authorize / spring_class_secured
+//	global  → spring_global_authorization (a same-file SecurityFilterChain rule
+//	          whose requestMatcher ant-pattern covers the route — the cross-file
+//	          config case stays the documented source-scan gap)
+//	          + handler_source for the source-scan fallback (#4752).
+//
+// Mirrors the in-place post-pass pattern applyAspnetCoreAuth / applyLaravelAuth
+// use: it only mutates Properties on the spring_mvc/spring endpoints this file
+// produced; it never adds or removes entities.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// springHandlerAuth is one handler's annotation context, keyed by composed route
+// path so a path-only endpoint (the composed-Routes case) can be matched.
+type springHandlerAuth struct {
+	methodAnno string
+	classAnno  string
+}
+
+// springClassDeclScanRe matches a controller class declaration line.
+var springClassDeclScanRe = regexp.MustCompile(`\bclass\s+([A-Za-z_]\w*)\b`)
+
+// springVerbMappingScanRe matches a Spring verb mapping annotation and its
+// optional inline path arg. Group 1 = the path (may be empty).
+var springVerbMappingScanRe = regexp.MustCompile(
+	`@(?:Get|Post|Put|Delete|Patch|Request)Mapping\s*(?:\(\s*(?:value\s*=\s*|path\s*=\s*)?"([^"]*)"|)`)
+
+// springClassRequestMappingRe captures a class-level @RequestMapping prefix.
+var springClassRequestMappingRe = regexp.MustCompile(
+	`@RequestMapping\s*\(\s*(?:value\s*=\s*|path\s*=\s*)?"([^"]*)"`)
+
+// parseSpringHandlerAuth re-scans a Java controller file and returns, per composed
+// route path, the method-level and class-level annotation blocks. It reproduces
+// the prefix+method-path composition synthesizeSpringFromComposed relies on so
+// the endpoint (which carries only the path) can be keyed back to its handler.
+func parseSpringHandlerAuth(src string) (map[string]springHandlerAuth, []springFilterChainRule) {
+	lines := strings.Split(src, "\n")
+	out := map[string]springHandlerAuth{}
+
+	classPrefix := ""
+	classAnno := ""
+	var annoBuf []string
+	flush := func() []string { b := annoBuf; annoBuf = nil; return b }
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "@") || trimmed == "" {
+			annoBuf = append(annoBuf, trimmed)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") || strings.HasPrefix(trimmed, "/*") {
+			continue
+		}
+		// Class declaration: capture the class-level annotation block + @RequestMapping prefix.
+		if springClassDeclScanRe.MatchString(line) && strings.Contains(line, "class ") {
+			block := strings.Join(flush(), "\n")
+			classAnno = block
+			classPrefix = ""
+			if m := springClassRequestMappingRe.FindStringSubmatch(block); m != nil {
+				classPrefix = m[1]
+			}
+			continue
+		}
+		// Method declaration: a line carrying a verb-mapping in the annotation
+		// block + a method signature. We treat any non-class declaration with a
+		// pending annotation block carrying a verb mapping as a handler.
+		block := strings.Join(annoBuf, "\n")
+		if m := springVerbMappingScanRe.FindStringSubmatch(block); m != nil {
+			methodPath := m[1]
+			composed := joinPathFragments(classPrefix, methodPath)
+			out[composed] = springHandlerAuth{methodAnno: block, classAnno: classAnno}
+		}
+		annoBuf = nil
+	}
+
+	return out, parseSpringFilterChainRules(src)
+}
+
+// applySpringCoreAuth stamps the structured Spring-Security posture onto the
+// Spring endpoints emitted for `path` (#4750). Cheap-gated on the file carrying a
+// Spring authorization annotation or a SecurityFilterChain.
+func applySpringCoreAuth(content, path string, entities []types.EntityRecord, before int) {
+	if before >= len(entities) {
+		return
+	}
+	if !strings.Contains(content, "@PreAuthorize") && !strings.Contains(content, "@PostAuthorize") &&
+		!strings.Contains(content, "@Secured") && !strings.Contains(content, "@RolesAllowed") &&
+		!strings.Contains(content, "SecurityFilterChain") {
+		return
+	}
+	handlers, filterChain := parseSpringHandlerAuth(content)
+
+	for i := before; i < len(entities); i++ {
+		e := &entities[i]
+		if e.Kind != httpEndpointDefinitionKind || e.SourceFile != path || e.Properties == nil {
+			continue
+		}
+		fw := e.Properties["framework"]
+		if fw != "spring_mvc" && fw != "spring" {
+			continue
+		}
+		ha, ok := handlers[e.Properties["path"]]
+		if !ok {
+			// Fall back: the resolver's source-scan still fires off any same-file
+			// global rule matched to the route prefix.
+			if rule := matchSpringFilterChainRule(filterChain, e.Properties["path"]); rule != "" {
+				e.Properties["spring_global_authorization"] = rule
+			}
+			continue
+		}
+		stamps := ResolveSpringAuthStamps(ha.methodAnno, ha.classAnno,
+			matchSpringFilterChainRule(filterChain, e.Properties["path"]))
+		stamps.Stamp(e.Properties)
+		// #4752 — the handler annotation block as a source body so the spring
+		// resolver's source-scan fallback fires live for any annotation shape the
+		// structured stamps above don't cover.
+		if ha.methodAnno != "" {
+			e.Properties["handler_source"] = ha.methodAnno
+		}
+	}
+}


### PR DESCRIPTION
Completes the deeper ENGINE-side stamping so the framework auth-posture resolvers produce **STRUCTURED postures LIVE** (not just source-scan fallback). The harvest plumbing landed in #4753; this is the cross-entity reconciliation that fills the prop keys those resolvers already read.

## What each framework now stamps (structured) vs source-scan

| Framework | New structured props (engine) | Reconciliation | Source-scan body |
|---|---|---|---|
| **Spring** (#4750) | `auth_expression`, `spring_class_pre_authorize`, `spring_class_secured`, `spring_global_authorization` | class @PreAuthorize→handler; same-file SecurityFilterChain `requestMatchers(...)`→route (ant-pattern) | `handler_source` |
| **ASP.NET** (#4750) | method `auth_required`/`auth_roles`/`auth_policy`/`allow_anonymous`; `aspnet_class_*`; `aspnet_fallback_policy` | method▸class▸global ([AllowAnonymous] wins) | `action_source` |
| **Rails** (#4751) | `pundit_policy`/`pundit_action` (derived from authorized record), `cancancan_ability` | per-action authorize → policy literal | `controller_source` |
| **Phoenix** (#4751) | `auth_pipelines`, `auth_plugs`, `auth_roles` (require_role literal) | scope `pipe_through`→named pipelines→plugs | `router_source` |
| **Flask** (#4752) | `auth_decorator`, `auth_page` (perm alias); recognises `@admin_required`/`@superuser_required` | decorator name | `view_source` |
| **Laravel** (#4752) | `auth_required`/`auth_middleware`/`auth_roles`/`auth_permissions` | route+group middleware (`auth`/`role:`/`can:`/`withoutMiddleware`), route▸group precedence | (route registration) |

## Documented gaps (kept honest, source-scan fallback)
- Spring **cross-file** SecurityConfig (only same-file SecurityFilterChain matched, best-effort over statically-recoverable ant-patterns).
- ASP.NET **cross-file** FallbackPolicy (same-file Program.cs only).
- Phoenix dynamic `pipe_through` / role literal not in a `require_role` plug → `router_source` fallback.

## Implementation
Mirrors the existing in-place post-pass pattern (`applyHotChocolateAuthShapes`/`applyLaravelRateLimit`): each pass mutates Properties on the just-emitted endpoints, never adds/removes entities. New: `spring_core_auth.go`, `aspnet_core_auth.go`, `http_endpoint_php_auth.go`; extended `phoenix.go`, `controller_auth.go`, `flask.go`/`auth_endpoint.go`, `java_auth_policy.go` (`ResolveSpringAuthStamps` + filter-chain matcher).

**SCOPE BOUNDARY:** does NOT alter the #4550 JOIN keying in `auth_posture_diff_tool.go` (relies on the existing #4753 harvest).

## Live-path tests
Per framework, an endpoint is shaped as the engine NOW produces it (run through the real extractor/synthesis) and resolved through the authposture registry, asserting the correct structured posture (role/action/public/authenticated):
- `internal/engine/auth_engine_stamping_4750_test.go` — Spring (class/method/global), ASP.NET (method roles / class / AllowAnonymous override), Laravel (route / group role / withoutMiddleware override)
- `internal/custom/ruby/controller_auth_test.go` — Pundit + CanCanCan literals
- `internal/custom/python/flask_auth_4752_test.go` — roles / permission / admin-decorator
- `internal/custom/elixir/phoenix_auth_4751_test.go` — pipe_through resolution + role-plug literal

## Coverage docs
Surgically appended an "ENGINE STAMPING" clause to the 6 framework Auth cells in `docs/coverage/registry.json` (elevated source-scan→structured). `coverage fmt --check` canonical; `coverage validate` 0 errors.

## Gates
`go build ./...`, `go vet`, `go test ./internal/engine/... ./internal/authposture/... ./internal/mcp/... ./internal/custom/...` all green.

Closes #4750
Closes #4751
Closes #4752

🤖 Generated with [Claude Code](https://claude.com/claude-code)