### PR TITLE
feat(webui-v2): re-implement flow step-replay + comet + scrubber on React Flow (#4362)

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDag.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDag.tsx
@@ -20,7 +20,7 @@
    without going through the paths hook.
    ============================================================ */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   Background,
@@ -39,8 +39,25 @@ import {
   Plus,
   Loader2,
   AlertTriangle,
+  Play,
+  Pause,
+  Square,
+  SkipBack,
+  SkipForward,
+  Volume2,
+  VolumeX,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  createFlowAnim,
+  useFlowAnim,
+  type FlowAnimController,
+} from "@/lib/flow-animation";
+import {
+  playStepBlip,
+  readFlowAudio,
+  writeFlowAudio,
+} from "@/lib/flow-audio";
 import { useDownstreamDAG } from "@/hooks/use-paths";
 import type { DownstreamDAGNode, DownstreamDAGResponse } from "@/data/types";
 import {
@@ -51,6 +68,7 @@ import {
   FLOW_DAG_EDGE_TYPE,
   type FlowDagDirection,
   type FlowDagNodeData,
+  type FlowDagEdgeData,
 } from "./layout";
 import { routeInstanceIds } from "./route";
 import { FlowDagNode } from "./FlowDagNode";
@@ -82,7 +100,250 @@ export interface FlowDagProps {
   onNodeClick?: (node: DownstreamDAGNode) => void;
   /** Node id to highlight as selected (pairs with `onNodeClick`). */
   selectedNodeId?: string | null;
+  /**
+   * Enable the step-replay overlay (#4362): a play/pause/stop + speed + scrubber
+   * control bar that walks the DAG in topological order, glowing the active
+   * node/edge and riding a comet along each edge. Idle on mount; resets when the
+   * rendered DAG changes. Off by default (Paths modal stays a static canvas).
+   */
+  enableReplay?: boolean;
   className?: string;
+}
+
+// ── Step-replay hook + control bar (#4362) ───────────────────────────────────
+
+const SPEEDS = [0.5, 1, 2] as const;
+// Long flows auto-bump to 2× so they stay smooth (#1922 constraint).
+const AUTO_FAST_STEPS = 80;
+
+interface FlowReplay {
+  /** Whether the replay overlay is engaged (played/scrubbed and not stopped). */
+  active: boolean;
+  snapshot: ReturnType<FlowAnimController["getSnapshot"]>;
+  speed: number;
+  audio: boolean;
+  controls: {
+    toggle: () => void;
+    stop: () => void;
+    stepForward: () => void;
+    stepBack: () => void;
+    scrubTo: (n: number) => void;
+    setSpeed: (s: number) => void;
+    toggleAudio: () => void;
+  };
+  totalSteps: number;
+}
+
+/**
+ * Owns a createFlowAnim controller for the current DAG. Idle on mount; the
+ * controller is rebuilt (and torn down) whenever the sequence length, root, or
+ * orientation changes, so switching flows resets cleanly. `active` flips true
+ * once the user plays/scrubs and false again on stop — so an idle canvas is
+ * never dimmed.
+ */
+function useFlowReplay(
+  edgeCount: number,
+  resetKey: string | null,
+  direction: FlowDagDirection,
+): FlowReplay {
+  const [engaged, setEngaged] = useState(false);
+  const [speed, setSpeedState] = useState(() =>
+    edgeCount + 1 > AUTO_FAST_STEPS ? 2 : 1,
+  );
+  const [audio, setAudio] = useState(() => readFlowAudio());
+  const audioRef = useRef(audio);
+  audioRef.current = audio;
+
+  // Build a controller per (edgeCount, resetKey, direction). totalSteps is the
+  // node count (edgeCount + 1) so the playhead spans entry..last node.
+  const controller = useMemo(() => {
+    const c = createFlowAnim({
+      totalSteps: edgeCount + 1,
+      // We don't distinguish bridge edges in the flow payload here; uniform comet.
+      isBridgeEdge: () => false,
+      reducedMotion:
+        typeof window !== "undefined" &&
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches,
+    });
+    return c;
+    // resetKey/direction force a fresh controller so a flow/layout change resets.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [edgeCount, resetKey, direction]);
+
+  // Reset engagement + re-apply speed/audio wiring when the controller changes.
+  useEffect(() => {
+    setEngaged(false);
+    controller.reset();
+    controller.setSpeed(speed);
+    controller.setOnArrive(() => {
+      if (audioRef.current) playStepBlip();
+    });
+    return () => {
+      controller.stop();
+      controller.setOnArrive(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [controller]);
+
+  const snapshot = useFlowAnim(controller);
+
+  // ESC pauses a running replay (#1922).
+  useEffect(() => {
+    if (!engaged) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && snapshot.running && !snapshot.paused) {
+        controller.pause();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [engaged, controller, snapshot.running, snapshot.paused]);
+
+  const controls = useMemo(
+    () => ({
+      toggle: () => {
+        setEngaged(true);
+        controller.toggle();
+      },
+      stop: () => {
+        controller.reset();
+        setEngaged(false);
+      },
+      stepForward: () => {
+        setEngaged(true);
+        controller.scrubTo(Math.min(edgeCount + 1, controller.getSnapshot().playhead + 1));
+      },
+      stepBack: () => {
+        setEngaged(true);
+        controller.scrubTo(Math.max(0, controller.getSnapshot().playhead - 1));
+      },
+      scrubTo: (n: number) => {
+        setEngaged(true);
+        controller.scrubTo(n);
+      },
+      setSpeed: (s: number) => {
+        setSpeedState(s);
+        controller.setSpeed(s);
+      },
+      toggleAudio: () => {
+        setAudio((prev) => {
+          const next = !prev;
+          writeFlowAudio(next);
+          return next;
+        });
+      },
+    }),
+    [controller, edgeCount],
+  );
+
+  return {
+    active: engaged,
+    snapshot,
+    speed,
+    audio,
+    controls,
+    totalSteps: edgeCount + 1,
+  };
+}
+
+/** The bottom replay control bar — play/pause/stop, step, speed, scrubber. */
+function ReplayBar({ replay }: { replay: FlowReplay }) {
+  const { snapshot, speed, audio, controls, totalSteps } = replay;
+  const lastStep = Math.max(0, totalSteps - 1);
+  const playing = snapshot.running && !snapshot.paused;
+  // playhead counts nodes reached (1-based once started). Map to a 0..lastStep
+  // scrubber position (0 = entry, lastStep = final node).
+  const pos = Math.max(0, Math.min(lastStep, snapshot.playhead - 1 < 0 ? 0 : snapshot.playhead));
+
+  if (totalSteps < 2) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-3 py-1.5 border-t border-border bg-surface">
+      <button
+        type="button"
+        onClick={controls.toggle}
+        className="inline-flex items-center justify-center size-7 rounded-md border border-border bg-surface text-text-2 hover:bg-surface-2 transition-colors"
+        title={playing ? "Pause replay" : "Play replay"}
+      >
+        {playing ? <Pause size={13} /> : <Play size={13} />}
+      </button>
+      <button
+        type="button"
+        onClick={controls.stop}
+        disabled={!replay.active}
+        className="inline-flex items-center justify-center size-7 rounded-md border border-border bg-surface text-text-2 hover:bg-surface-2 transition-colors disabled:opacity-40 disabled:pointer-events-none"
+        title="Stop replay"
+      >
+        <Square size={12} />
+      </button>
+      <button
+        type="button"
+        onClick={controls.stepBack}
+        className="inline-flex items-center justify-center size-7 rounded-md border border-border bg-surface text-text-2 hover:bg-surface-2 transition-colors"
+        title="Step back"
+      >
+        <SkipBack size={13} />
+      </button>
+      <button
+        type="button"
+        onClick={controls.stepForward}
+        className="inline-flex items-center justify-center size-7 rounded-md border border-border bg-surface text-text-2 hover:bg-surface-2 transition-colors"
+        title="Step forward"
+      >
+        <SkipForward size={13} />
+      </button>
+
+      {/* Scrubber — drag to jump (instant, no intermediate animation). */}
+      <input
+        type="range"
+        min={0}
+        max={lastStep}
+        step={1}
+        value={pos}
+        onChange={(e) => controls.scrubTo(Number(e.target.value))}
+        className="flex-1 min-w-[120px] accent-[var(--accent)] cursor-pointer"
+        aria-label="Replay timeline"
+        title={`Step ${pos} of ${lastStep}`}
+      />
+      <span className="text-[11px] tabular-nums text-text-3 w-14 text-center shrink-0">
+        {pos} / {lastStep}
+      </span>
+
+      {/* Speed segmented control */}
+      <div className="inline-flex rounded-md border border-border overflow-hidden shrink-0">
+        {SPEEDS.map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => controls.setSpeed(s)}
+            className={cn(
+              "h-7 px-1.5 text-[11px] tabular-nums transition-colors",
+              s !== SPEEDS[0] && "border-l border-border",
+              speed === s
+                ? "bg-accent text-accent-text"
+                : "bg-surface text-text-3 hover:bg-surface-2",
+            )}
+            title={`${s}× speed`}
+          >
+            {s}×
+          </button>
+        ))}
+      </div>
+
+      {/* Audio toggle — off by default, persisted (#1922). */}
+      <button
+        type="button"
+        onClick={controls.toggleAudio}
+        className={cn(
+          "inline-flex items-center justify-center size-7 rounded-md border border-border transition-colors shrink-0",
+          audio ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+        )}
+        title={audio ? "Mute step blips" : "Enable step blips"}
+      >
+        {audio ? <Volume2 size={13} /> : <VolumeX size={13} />}
+      </button>
+    </div>
+  );
 }
 
 /** Inner view — assumes a ReactFlowProvider is mounted above it. */
@@ -94,6 +355,7 @@ function FlowDagInner({
   enabled = true,
   onNodeClick,
   selectedNodeId,
+  enableReplay = false,
   className,
 }: FlowDagProps) {
   // Controls — fetch params. Changing mode/depth refetches (TanStack caches
@@ -140,7 +402,7 @@ function FlowDagInner({
     return routeInstanceIds(unfold.instances, routeFocus);
   }, [unfold, routeFocus]);
 
-  const { nodes, edges } = useMemo(() => {
+  const { nodes: baseNodes, edges: baseEdges } = useMemo(() => {
     if (!unfold) return { nodes: [], edges: [] };
     const laid = layoutTree(
       unfold.instances,
@@ -167,6 +429,88 @@ function FlowDagInner({
     }
     return laid;
   }, [unfold, direction, expanded, onToggleExpand, selectedNodeId, routeSet]);
+
+  // ── Step-replay (#4362) ──────────────────────────────────────────────────
+  // The replay walks the laid-out tree in topological order. baseEdges are
+  // emitted parent-before-child (BFS), so their natural order already respects
+  // the DAG topology: edge[i] is only reachable after its source's in-edge. We
+  // replay one edge per step; step i (1-based) rides baseEdges[i-1].
+  //
+  // The sequence + controller live behind enableReplay so the Paths modal stays
+  // a static canvas. Everything is keyed on (root_id + edge count + direction)
+  // so the controller resets when the flow — or its layout — changes.
+  const replaySeq = useMemo(
+    () =>
+      enableReplay
+        ? baseEdges.map((e) => ({ id: e.id, source: e.source, target: e.target }))
+        : [],
+    [enableReplay, baseEdges],
+  );
+
+  const replay = useFlowReplay(replaySeq.length, data?.root_id ?? null, direction);
+
+  // Decorate nodes/edges with replay state derived from the controller snapshot.
+  // playhead = number of steps completed (0 = entry only). The comet is riding
+  // edge index `currentTarget - 1`… but our sequence is 1:1 with edges, so the
+  // active edge is index (playhead) when running toward it. The controller's
+  // `currentTarget` is the target STEP index; for our edge-indexed sequence the
+  // in-flight edge is `currentTarget - 1` (0-based into replaySeq), with
+  // edgeProgress 0..1 along it.
+  const { nodes, edges } = useMemo(() => {
+    if (!enableReplay || replaySeq.length === 0 || !replay.active) {
+      return { nodes: baseNodes, edges: baseEdges };
+    }
+    const { playhead, currentTarget, edgeProgress, running, traversedEdges } =
+      replay.snapshot;
+    // Edges already traversed (target step ≤ playhead): tinted trail. The
+    // controller exposes traversedEdges as target-step indices [1..playhead].
+    const traversedSet = new Set(traversedEdges);
+    // The in-flight edge, if the comet is mid-ride (running, between nodes).
+    const activeEdgeIdx = running && currentTarget >= 1 ? currentTarget - 1 : -1;
+
+    // Reached node instance ids: the entry plus every traversed edge's target,
+    // plus the active edge's source (the comet is leaving it).
+    const reached = new Set<string>();
+    if (replaySeq.length > 0) reached.add(replaySeq[0].source);
+    replaySeq.forEach((e, i) => {
+      // replaySeq[i]'s "target step" is i+1.
+      if (traversedSet.has(i + 1)) reached.add(e.target);
+    });
+    const activeEdge = activeEdgeIdx >= 0 ? replaySeq[activeEdgeIdx] : null;
+    if (activeEdge) reached.add(activeEdge.source);
+    const activeNodeId = activeEdge
+      ? edgeProgress >= 1
+        ? activeEdge.target
+        : activeEdge.source
+      : // Idle/scrubbed: the active node is the one the playhead landed on.
+        playhead > 0 && playhead <= replaySeq.length
+        ? replaySeq[playhead - 1].target
+        : replaySeq[0]?.source ?? null;
+
+    const nodes = baseNodes.map((n) => {
+      let st: FlowDagNodeData["replay"] = "pending";
+      if (n.id === activeNodeId) st = "active";
+      else if (reached.has(n.id)) st = "traversed";
+      return { ...n, data: { ...n.data, replay: st } as FlowDagNodeData };
+    });
+
+    const edges = baseEdges.map((e, i) => {
+      let st: FlowDagEdgeData["replay"] = "pending";
+      let prog: number | undefined;
+      if (i === activeEdgeIdx) {
+        st = "active";
+        prog = edgeProgress;
+      } else if (traversedSet.has(i + 1)) {
+        st = "traversed";
+      }
+      return {
+        ...e,
+        data: { ...(e.data ?? { kind: "CALLS" }), replay: st, replayProgress: prog } as FlowDagEdgeData,
+      };
+    });
+
+    return { nodes, edges };
+  }, [enableReplay, replaySeq, replay.active, replay.snapshot, baseNodes, baseEdges]);
 
   const handleNodeClick = useCallback(
     (_: React.MouseEvent, n: RFNode) => {
@@ -326,6 +670,10 @@ function FlowDagInner({
           </ReactFlow>
         )}
       </div>
+
+      {/* Step-replay control bar (#4362) — only when the caller opts in and the
+          DAG has at least one edge to walk. */}
+      {enableReplay && replaySeq.length > 0 && <ReplayBar replay={replay} />}
 
       {/* Legend + truncation/branch stats. Node count reflects the unfolded
           tree (instances), not the deduped payload, so it matches what's drawn. */}

--- a/webui-v2/src/components/flow-dag/FlowDagEdge.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagEdge.tsx
@@ -7,7 +7,7 @@
    small mid-edge label so branches are legible.
    ============================================================ */
 
-import { memo } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -30,8 +30,13 @@ function FlowDagEdgeImpl({
   const ed = data as FlowDagEdgeData | undefined;
   const kind = ed?.kind ?? "CALLS";
   const es = edgeStyle(kind);
+  // Step-replay (#4362): active edge carries the comet; traversed edges stay
+  // tinted; pending edges dim. Falls back to the route-highlight dimming.
+  const replay = ed?.replay;
+  const replayProgress = ed?.replayProgress ?? 0;
   // Click-to-highlight (#4479): off-route edges dim; on-route edges stay full.
-  const dimmed = ed?.onRoute === false;
+  const dimmed = ed?.onRoute === false || replay === "pending";
+  const traversed = replay === "traversed" || replay === "active";
 
   const [path, labelX, labelY] = getBezierPath({
     sourceX,
@@ -42,19 +47,69 @@ function FlowDagEdgeImpl({
     targetPosition,
   });
 
+  // Comet position — sample the exact bezier path via getPointAtLength on a
+  // measured (off-screen) copy of the path. Only the ACTIVE edge re-renders per
+  // frame, so this stays cheap (one DOM measure per frame, one edge at a time).
+  const measureRef = useRef<SVGPathElement | null>(null);
+  const [comet, setComet] = useState<{ x: number; y: number } | null>(null);
+  useEffect(() => {
+    if (replay !== "active" || !measureRef.current) {
+      setComet(null);
+      return;
+    }
+    const el = measureRef.current;
+    let len = 0;
+    try {
+      len = el.getTotalLength();
+    } catch {
+      return;
+    }
+    if (!len) return;
+    const pt = el.getPointAtLength(len * Math.min(1, Math.max(0, replayProgress)));
+    setComet({ x: pt.x, y: pt.y });
+  }, [replay, replayProgress, path]);
+
+  const stroke = traversed ? "var(--accent)" : es.stroke;
+
   return (
     <>
       <BaseEdge
         path={path}
         markerEnd={markerEnd}
         style={{
-          stroke: es.stroke,
-          strokeWidth: kind === "CALLS" ? 1.5 : 1.75,
+          stroke,
+          strokeWidth:
+            replay === "active" ? 2.5 : kind === "CALLS" ? 1.5 : 1.75,
           strokeDasharray: es.dash,
-          opacity: dimmed ? 0.18 : 1,
-          transition: "opacity 150ms",
+          opacity: dimmed ? 0.18 : traversed ? 0.95 : 1,
+          transition: "opacity 150ms, stroke-width 150ms",
         }}
       />
+      {/* Hidden measuring copy of the path so getPointAtLength samples the exact
+          bezier the comet rides. Rendered only while this edge is active. */}
+      {replay === "active" && (
+        <path ref={measureRef} d={path} fill="none" stroke="none" />
+      )}
+      {/* Traveling-light comet (#4362) — a glowing dot at the sampled point with
+          a soft halo. Pure SVG, no per-frame layout thrash. */}
+      {replay === "active" && comet && (
+        <g className="pointer-events-none">
+          <circle
+            cx={comet.x}
+            cy={comet.y}
+            r={6}
+            fill="var(--accent)"
+            opacity={0.25}
+          />
+          <circle
+            cx={comet.x}
+            cy={comet.y}
+            r={3}
+            fill="var(--accent)"
+            style={{ filter: "drop-shadow(0 0 4px var(--accent))" }}
+          />
+        </g>
+      )}
       {/* Only the non-spine semantic edges carry a label, to keep CALLS clean. */}
       {kind !== "CALLS" && (
         <EdgeLabelRenderer>
@@ -63,8 +118,8 @@ function FlowDagEdgeImpl({
             style={{
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
               background: "var(--surface)",
-              color: es.stroke,
-              border: `1px solid color-mix(in srgb, ${es.stroke} 45%, transparent)`,
+              color: stroke,
+              border: `1px solid color-mix(in srgb, ${stroke} 45%, transparent)`,
               opacity: dimmed ? 0.18 : 1,
             }}
           >

--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -47,6 +47,7 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
     isLeaf,
     truncatedHere,
     module: mod,
+    replay,
   } = data as FlowDagNodeData;
   // Taxonomy bucket → tint (#4566): exception=red (#4556), external=muted
   // (#4558/#4564), genuine leaf=Return/finish end-cap (#4561), else role/kind.
@@ -71,7 +72,10 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
   const collapsed = node.collapsed_children ?? [];
   const hasCollapsed = collapsed.length > 0;
   // Click-to-highlight (#4479): when a route is active, off-route nodes dim.
-  const dimmed = onRoute === false;
+  // Step-replay (#4362): a pending (not-yet-reached) node dims like an off-route
+  // node; the active node glows; traversed nodes stay at full opacity (trail).
+  const dimmed = onRoute === false || replay === "pending";
+  const replayActive = replay === "active";
 
   // Incoming relationship label (calls/handler/joins/throws/validates) — from
   // the single in-edge feeding this instance. Absent on the root.
@@ -100,6 +104,9 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
         "rounded-lg border bg-surface shadow-[var(--shadow-2)] text-left cursor-pointer",
         "min-w-[268px] max-w-[268px] transition-opacity",
         dimmed ? "opacity-25" : "opacity-100",
+        // #4362: CSS-only arrival bounce on the active replay node. Cheap
+        // transform animation, respects prefers-reduced-motion via the keyframe.
+        replayActive && "flow-replay-bounce",
       )}
       style={{
         // Role/taxonomy tint as a soft background wash (#4566). The border is a
@@ -108,7 +115,7 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
         // outline reads as a saturated version of the background, never a
         // generic neutral/brown frame. External nodes stay muted.
         background: `color-mix(in srgb, ${rs.bg} ${external ? 12 : 22}%, var(--surface))`,
-        borderColor: selected || onRoute === true
+        borderColor: selected || onRoute === true || replayActive
           ? "var(--accent)"
           : external
             ? "color-mix(in srgb, var(--text-4) 45%, transparent)"
@@ -117,7 +124,9 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
         borderLeft: band ? `3px solid ${band.color}` : undefined,
         // Selected / route-lit (#4479) → accent ring; a genuine terminal
         // end-cap (#4561) or a collection sink → a heavier outline ring.
-        boxShadow: selected || onRoute === true
+        boxShadow: replayActive
+          ? "0 0 0 2px var(--accent), 0 0 16px 2px color-mix(in srgb, var(--accent) 55%, transparent)"
+          : selected || onRoute === true
           ? "0 0 0 2px var(--accent)"
           : terminalCap || node.terminal
             ? `0 0 0 2px color-mix(in srgb, ${rs.border} 60%, var(--text))`

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -71,6 +71,13 @@ export interface FlowDagNodeData extends Record<string, unknown> {
    *  - false     → an active route exists but this instance is off it (dimmed)
    */
   onRoute?: boolean;
+  /**
+   * Step-replay state (#4362). Undefined when no replay is active.
+   *  - "active"    → the comet is arriving on / has just reached this node
+   *  - "traversed" → an earlier step in the replay sequence reached it
+   *  - "pending"   → not yet reached by the current playhead (dimmed)
+   */
+  replay?: "active" | "traversed" | "pending";
 }
 
 /** Data carried on each React Flow edge, consumed by the custom edge renderer. */
@@ -78,6 +85,18 @@ export interface FlowDagEdgeData extends Record<string, unknown> {
   kind: DownstreamDAGEdge["kind"];
   /** Highlight state, mirroring FlowDagNodeData.onRoute (#4479). */
   onRoute?: boolean;
+  /**
+   * Step-replay state (#4362). Undefined when no replay is active.
+   *  - "active"    → the comet is currently riding this edge
+   *  - "traversed" → the replay has already crossed this edge (tinted trail)
+   *  - "pending"   → not yet reached by the playhead (dimmed)
+   */
+  replay?: "active" | "traversed" | "pending";
+  /**
+   * Comet position along the active edge (0..1), only meaningful when
+   * replay === "active". Drives the traveling-light marker (#4362).
+   */
+  replayProgress?: number;
 }
 
 export type FlowDagNode = Node<FlowDagNodeData>;

--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -776,10 +776,14 @@ function ListRail({
 // drive the existing StepInspector; the H/V layout toggle now lives inside the
 // shared controls bar.
 //
-// NOTE (#4354): the replay/comet animation + scrubber (#1922) is NOT carried
-// over — it was welded to the SVG path geometry (edge-geometry pointAt + the
-// per-edge bridge map). Re-implementing it on React Flow is tracked as a
-// follow-up rather than silently dropped.
+// REPLAY (#4362): the step-replay / comet animation + scrubber (originally
+// #1922) — dropped in the #4354 React Flow migration because it was welded to
+// the old SVG path geometry — is re-implemented on React Flow inside the shared
+// <FlowDag enableReplay> component. It reuses the still-present
+// lib/flow-animation.ts controller + lib/flow-audio.ts blip, walks the laid-out
+// tree in topological order, glows the active node/edge, and rides a comet
+// (sampled off the real bezier edge geometry via getPointAtLength) along each
+// edge. Enabled here via the `enableReplay` prop below.
 
 function FlowDag({
   flow,
@@ -830,6 +834,7 @@ function FlowDag({
       payload={payload}
       onNodeClick={handleNodeClick}
       selectedNodeId={selectedNodeId}
+      enableReplay
       className="flex-1 min-h-0"
     />
   );

--- a/webui-v2/src/styles/app.css
+++ b/webui-v2/src/styles/app.css
@@ -150,6 +150,18 @@
   animation: ag-insight-glow 1.4s ease-out infinite;
 }
 
+/* Flow step-replay (#4362) — sub-200ms CSS-only arrival bounce on the active
+   node. transform-only so it never reflows the canvas; the global
+   prefers-reduced-motion rule below collapses it to a no-op. */
+@keyframes flow-replay-bounce {
+  0%   { transform: scale(0.96); }
+  55%  { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+.flow-replay-bounce {
+  animation: flow-replay-bounce 180ms ease-out;
+}
+
 /* Honor reduced-motion globally (per handoff motion rules). */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
## What

Re-implements the flow **step-replay + comet edge animation + timeline scrubber** on the React Flow canvas. The #4354 React Flow migration explicitly dropped this (originally #1922) because it was welded to the old bespoke SVG path geometry (`edge-geometry.ts` `pointAt()` + a per-edge bridge map). This ports the *behavior* onto the shared `<FlowDag>` component.

## How

- **New `enableReplay` prop on `<FlowDag>`** — off by default (the Paths modal stays a static canvas), enabled by the Flows route. A new `useFlowReplay` hook owns a `createFlowAnim` controller (from the still-present `lib/flow-animation.ts`, kept by #4354) and the `lib/flow-audio.ts` blip.
- **Step replay**: walks the laid-out tree in topological (BFS, parent-before-child) order, one edge per step. The active node glows (accent ring + CSS-only arrival bounce); traversed nodes/edges stay tinted as a trail; pending nodes/edges dim — reusing the existing `onRoute` dim-focus mechanism.
- **Comet**: a glowing SVG dot (+ halo) rides the **active** edge, sampled off the *real* bezier geometry via `getPointAtLength` on a hidden copy of the edge path — no SVG polyline math, no per-edge bridge map.
- **Scrubber**: bottom control bar with play/pause, stop, step-forward/back, a draggable timeline slider (step N of M, instant jump), 0.5×/1×/2× speed, and the persisted audio-blip toggle (off by default, `localStorage["archigraph:flows:audio"]`).
- **Lifecycle**: idle on mount; the controller is rebuilt **and torn down** whenever the sequence length / root / orientation changes, so switching the selected flow resets cleanly. ESC pauses a running replay.

## Performance guards

- Only the **single active edge** re-renders per frame (one `getPointAtLength` measure at a time) — the rest of the canvas is untouched, so the graph never wedges (cf. #4618/#4658).
- `prefers-reduced-motion: reduce` collapses the comet + bounce via the existing global media rule.
- Long flows (>80 steps) auto-bump default speed to 2× (the #1922 smoothness constraint).

## Gates

`npm ci` ✅ · `npx tsc --noEmit` ✅ · `npx vite build` ✅ · `flow-to-dag` unit tests ✅

Closes #4362

🤖 Generated with [Claude Code](https://claude.com/claude-code)