### PR TITLE
fix(webui): theme-token sweep for hardcoded chart/badge/legend colors (#4575, #4578)

### DIFF
--- a/webui-v2/src/routes/pending.tsx
+++ b/webui-v2/src/routes/pending.tsx
@@ -67,12 +67,12 @@ const ENRICHMENT_LABEL: Record<EnrichmentType, string> = {
 
 // Pastel color map for entity type dots (matches prototype TYPE_DOT).
 const TYPE_COLOR: Record<string, string> = {
-  function:      "var(--pastel-6, #7ba7bc)",
-  component:     "var(--pastel-1, #e88c8c)",
-  hook:          "var(--pastel-2, #d4a96a)",
-  class:         "var(--pastel-3, #8cc98c)",
-  method:        "var(--pastel-4, #a08cd4)",
-  http_endpoint: "var(--pastel-5, #e8c46a)",
+  function:      "var(--pastel-6)",
+  component:     "var(--pastel-1)",
+  hook:          "var(--pastel-2)",
+  class:         "var(--pastel-3)",
+  method:        "var(--pastel-4)",
+  http_endpoint: "var(--pastel-5)",
 };
 
 const AGENTS = [

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -1262,7 +1262,7 @@ function Sparkline({ points, lowerIsBetter }: { points: { v: number }[]; lowerIs
   const first = vals[0];
   const last = vals[vals.length - 1];
   const improved = lowerIsBetter ? last < first : last > first;
-  const stroke = last === first ? "var(--color-text-4, #888)" : improved ? "#22c55e" : "#ef4444";
+  const stroke = last === first ? "var(--color-text-4, #888)" : improved ? "var(--color-success)" : "var(--color-danger)";
   return (
     <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} className="overflow-visible">
       <polyline

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -1525,7 +1525,7 @@ function OrphanPublisherTab({
                 <span className="text-xs text-text-3">+{(e.producers?.length ?? 0) - 3}</span>
               )}
             </div>
-            <span className="text-xs px-2 py-0.5 rounded-full bg-amber-950/30 text-amber-300 border border-amber-700/40 shrink-0">
+            <span className="text-xs px-2 py-0.5 rounded-full bg-warning/10 text-warning border border-warning/40 shrink-0">
               no subscriber found
             </span>
             <LocalRepoChip repo={e.repo} />
@@ -1607,8 +1607,8 @@ function OrphanSubscriberTab({
               className={cn(
                 "text-xs px-2 py-0.5 rounded-full shrink-0",
                 e.reason === "publisher_only_in_external_lib"
-                  ? "bg-slate-900/30 text-slate-400 border border-dashed border-slate-600"
-                  : "bg-amber-950/30 text-amber-300 border border-amber-700/40",
+                  ? "bg-surface-2 text-text-3 border border-dashed border-border-strong"
+                  : "bg-warning/10 text-warning border border-warning/40",
               )}
             >
               {e.reason === "publisher_only_in_external_lib"


### PR DESCRIPTION
## Summary
Replaces dark-only hardcoded chart/badge/legend colors with the existing semantic theme tokens so they render correctly in BOTH light and dark themes. Non-canvas only (per #4578); canvas/graph-internal viz palettes untouched.

### #4575 — Topology tab-badges (`routes/topology.tsx`)
- "no subscriber found" badge (~L1528): `bg-amber-950/30 text-amber-300 border-amber-700/40` -> `bg-warning/10 text-warning border-warning/40`
- publisher tab-badge (~L1611): same amber -> warning token mapping
- adjacent "publisher in external lib" muted variant (~L1610): dark-only `bg-slate-900/30 text-slate-400 border-slate-600` -> `bg-surface-2 text-text-3 border-border-strong` (matches existing precedent in `paths.tsx`)

### #4578 — Chart/legend colors
- `routes/quality.tsx` sparkline (~L1265): `#22c55e`/`#ef4444` -> `var(--color-success)`/`var(--color-danger)`
- `routes/pending.tsx` type-dot pastels (~L70-75): dropped stale raw-hex fallbacks (e.g. `--pastel-6` butter had a blue `#7ba7bc` fallback); the `--pastel-N` vars are already defined for both themes in `tokens.css`

## Tokens used
`--warning` / `--success` / `--danger` (via Tailwind `warning`/`success`/`danger` utilities and `var(--color-*)`), plus neutral `surface-2`/`text-3`/`border-strong`. All pre-existing in `src/styles/tokens.css` (light @ top, dark override block) and `src/styles/app.css` `@theme`. No new tokens added.

## Gates
- `npm ci` ✓
- `npx tsc --noEmit` ✓
- `npx vite build` ✓
- residual grep for `amber-950`/`#22c55e`/`#ef4444` in touched files: none

Closes #4575
Closes #4578

🤖 Generated with [Claude Code](https://claude.com/claude-code)