### PR TITLE
feat(dart): server-side http_endpoint producer + package:test coverage-linkage (#4758)

### DIFF
--- a/internal/custom/dart/tests_route_e2e.go
+++ b/internal/custom/dart/tests_route_e2e.go
@@ -1,0 +1,214 @@
+// tests_route_e2e.go — Dart package:test → endpoint route-hit linkage.
+//
+// #4758 (the Dart slice of the coverage-linkage tail epic #4749; closes the
+// #4757 N/A now that the Dart producer exists). Emits ONE test_suite entity per
+// Dart test file that drives an HTTP endpoint by ROUTE STRING, stamping the
+// captured `VERB route` pairs onto the suite's `e2e_route_calls` property (one
+// "VERB route" per line). The shared resolve pass
+// (engine.linkE2ERouteTestsToEndpoints, #4351/#4369) then matches each pair
+// against the cross-file http_endpoint_definition index — which, for Dart, is
+// populated by synthesizeShelfRoutes / synthesizeDartFrogRoutes /
+// synthesizeConduitRoutes (#4758, internal/engine/http_endpoint_dart.go) — and
+// emits a TESTS edge to the exact shelf/dart_frog/conduit endpoint exercised,
+// exactly as the Nim, Crystal, Swift, Java, Ruby, PHP and C# slices do. The
+// engine pass is language-agnostic (it fires on any test_suite carrying
+// e2e_route_calls), so the only Dart-specific work here is the route capture.
+//
+// Route-driving idioms captured (shelf / dart_frog / package:http test utils):
+//   - await handler(Request('GET', Uri.parse('/todos')))      → GET    /todos
+//   - handler(Request('POST', Uri.parse('http://x/todos')))   → POST   /todos
+//   - await router.call(Request('DELETE', Uri.parse('/x/1'))) → DELETE /x/1
+//   - http.get(Uri.parse('http://localhost:8080/health'))     → GET    /health
+//   - client.post(Uri.parse('/users'), body: …)               → POST   /users
+//
+// package:test's DSL uses `test('description', () { … })` closures (and `group(
+// '…', () { … })` containers). The description is PROSE, not a code symbol, and
+// the closure body carries no callable entity name the production-symbol
+// resolver can bind to. So, like the JS #4680 / Ruby #4719 / Nim #4758
+// anonymous-closure case, the route-hit signal is carried by the SUITE-LEVEL
+// test_suite entity emitted here (the scope-owner role): the test_suite is the
+// owner that carries the e2e_route_calls the engine links from.
+//
+// Local-variable / receiver typing (#4749 part a) is N/A for Dart coverage
+// linkage: shelf route dispatch is keyed by the literal route string carried in
+// the `Request('VERB', Uri.parse('/path'))` constructor, not by an
+// `obj.method()` receiver call, so a `receiver_type` stamp would be a dead
+// annotation. The honest, working coverage mechanism for Dart is the route-hit
+// → endpoint linkage in THIS file, exactly as for Nim and Crystal.
+//
+// Honest exclusions (no fabricated edges):
+//   - A route built from interpolation/concatenation with no static `/segment`
+//     literal is dropped.
+//   - Non-request test files (pure unit tests that never hit a route) emit no
+//     suite.
+//
+// Registration key: "custom_dart_tests_route_e2e".
+package dart
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_dart_tests_route_e2e", &dartTestRouteE2EExtractor{})
+}
+
+type dartTestRouteE2EExtractor struct{}
+
+func (e *dartTestRouteE2EExtractor) Language() string {
+	return "custom_dart_tests_route_e2e"
+}
+
+var (
+	// dartRequestRouteRE matches a shelf/dart_frog test handler hit constructed
+	// as `Request('VERB', Uri.parse('/path'))`: capture group 1 is the verb
+	// literal, group 2 is the URL/path string inside `Uri.parse(...)`. Both
+	// quote styles are accepted on each literal.
+	dartRequestRouteRE = regexp.MustCompile(
+		`Request\s*\(\s*(?:'([^'\n\r]*)'|"([^"\n\r]*)")\s*,\s*Uri\.parse\s*\(\s*(?:'([^'\n\r]*)'|"([^"\n\r]*)")`)
+
+	// dartHTTPVerbCallRE matches a package:http / shelf client verb call whose
+	// first argument is `Uri.parse('…')`: `http.get(Uri.parse('/health'))`,
+	// `client.post(Uri.parse('http://x/users'), body: …)`. Capture group 1 is
+	// the verb; groups 2/3 are the URL/path literal.
+	dartHTTPVerbCallRE = regexp.MustCompile(
+		`\.(get|post|put|delete|patch|head|options)\s*\(\s*Uri\.parse\s*\(\s*(?:'([^'\n\r]*)'|"([^"\n\r]*)")`)
+)
+
+func (e *dartTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "dart" {
+		return nil, nil
+	}
+	if !isDartTestFile(file.Path) {
+		return nil, nil
+	}
+	source := string(file.Content)
+	routeCalls := collectDartTestRouteCalls(source)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       dartTestSuiteBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   "dart",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       "package:test",
+			"provenance":      "INFERRED_FROM_DART_TEST_ROUTE_E2E",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	rec.ID = rec.ComputeID()
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectDartTestRouteCalls returns the de-duplicated "VERB route" pairs a Dart
+// test file drives by route string, from both the `Request('VERB',
+// Uri.parse('/x'))` handler-hit form and the `client.get(Uri.parse('/x'))`
+// http-client form. Routes are normalised to a leading-slash path; a route with
+// no static `/segment` literal is dropped.
+func collectDartTestRouteCalls(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawURL string) {
+		route := normaliseDartTestRoute(rawURL)
+		if route == "" {
+			return
+		}
+		line := strings.ToUpper(verb) + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+	for _, m := range dartRequestRouteRE.FindAllStringSubmatch(source, -1) {
+		verb := firstNonEmpty(m[1], m[2])
+		url := firstNonEmpty(m[3], m[4])
+		add(verb, url)
+	}
+	for _, m := range dartHTTPVerbCallRE.FindAllStringSubmatch(source, -1) {
+		add(m[1], firstNonEmpty(m[2], m[3]))
+	}
+	return out
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// normaliseDartTestRoute reduces a raw URL/path literal to a path: strips a
+// scheme+authority prefix (http://127.0.0.1:8080/x → /x), drops a query/fragment
+// tail, ensures a single leading slash, collapses repeated slashes. A literal
+// that is only a host/scheme with no path, that has no static `/segment`, or
+// that is interpolated (`$`) is dropped (returns "").
+func normaliseDartTestRoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" || strings.Contains(p, "$") {
+		return ""
+	}
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	if p == "/" {
+		return ""
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// isDartTestFile reports whether path looks like a Dart test — a `*_test.dart`
+// file (the package:test convention is `test/foo_test.dart`) or any file under
+// a `/test/` directory. Keeps the route-hit suite off production code that
+// merely registers a route.
+func isDartTestFile(path string) bool {
+	lp := filepath.ToSlash(path)
+	base := filepath.Base(lp)
+	if !strings.HasSuffix(base, ".dart") {
+		return false
+	}
+	stem := strings.TrimSuffix(base, ".dart")
+	if strings.HasSuffix(stem, "_test") {
+		return true
+	}
+	return strings.Contains(lp, "/test/") || strings.Contains(lp, "/integration_test/")
+}
+
+// dartTestSuiteBaseName derives a suite label from the test file path
+// (`.../todos_test.dart` → `todos_test`).
+func dartTestSuiteBaseName(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/engine/http_endpoint_dart.go
+++ b/internal/engine/http_endpoint_dart.go
@@ -1,0 +1,281 @@
+// http_endpoint_dart.go — Dart server-side route registration → canonical
+// http_endpoint_definition synthesis (#4758, the Dart producer slice of the
+// coverage-linkage tail epic #4749; mirrors the Crystal/Kemal, Swift/Vapor and
+// Nim/Jester producer slices).
+//
+// Background
+// ----------
+// The Dart base extractor is structural-only and the existing Dart engine
+// passes are CONSUMER-side (http_endpoint_dart_client.go — Dio / package:http
+// outbound calls). No verb+path http_endpoint_definition was ever produced for
+// the SERVER side, so Dart backends were invisible as producers in the endpoint
+// graph and the shared e2e route-test linker
+// (engine.linkE2ERouteTestsToEndpoints, #4351) had no target to bind a Dart
+// route-hit test to. internal/substrate/entry_points_dart.go already classifies
+// dart_frog `onRequest` and shelf `Response handler(Request …)` functions as
+// reachability entry-points, but that signal produces no endpoint entity.
+//
+// This pass emits one canonical http_endpoint_definition per statically-known
+// Dart route, in the SAME shape axum / Vapor / Kemal / Jester emit, so the
+// existing resolver and the language-agnostic e2e route-test linker light up for
+// Dart exactly as they do for the flagship stacks.
+//
+// Dart server route syntax
+// ------------------------
+// shelf_router (the dominant Dart router) registers routes with a verb method
+// on a `Router()` taking a string-literal path and a handler, using ANGLE-
+// bracket path params with an optional inline regex (`<id>`, `<id|[0-9]+>`):
+//
+//	final router = Router()
+//	  ..get('/users/<id>', getUser)
+//	  ..post('/users', createUser);
+//	router.get('/health', (Request r) => Response.ok('ok'));   → GET /health
+//	  → GET /users/{id}, POST /users
+//
+// dart_frog uses FILE-BASED routing: a file under `routes/` maps to a path
+// derived from its location (`routes/users/[id]/index.dart` → `/users/{id}`),
+// and exports an `onRequest(RequestContext context)` handler. The HTTP verb is
+// derived from the handler's `switch (context.request.method)` /
+// `context.request.method == HttpMethod.get` dispatch when statically present,
+// else ANY (the handler accepts every verb).
+//
+//	// routes/users/[id]/index.dart
+//	Response onRequest(RequestContext context) { ... }      → ANY /users/{id}
+//
+// conduit registers routes on a `Router` with `route("/users/[:id]")` (optional
+// `[:id]`, required `:id`) linked to a `Controller`:
+//
+//	router.route("/users/[:id]").link(() => UserController());  → ANY /users/{id}
+//
+// Honest exclusions (no fabricated routes)
+// ----------------------------------------
+//   - Interpolated / variable paths (`router.get(pathVar, h)`, `'/x' + id`) —
+//     not statically recoverable, dropped.
+//   - A dart_frog route whose verb dispatch is built dynamically is emitted as
+//     ANY (the handler is reachable under every verb — not a fabrication).
+//   - conduit `@Operation`-annotated controller methods (verb-precise) are left
+//     to a producer follow-up; the router-level route still yields an ANY
+//     endpoint here so the path is visible.
+package engine
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+var (
+	// shelfRouteRe matches a shelf_router verb registration on a Router:
+	// `..get('/users/<id>', handler)` (cascade) or `router.post('/x', h)`
+	// (method-call). The receiver/cascade operator (`..` or `<ident>.`) precedes
+	// the `verb(` call. Capture group 1 is the verb; group 2 is the path literal
+	// (single- or double-quoted, handled by the alternation).
+	shelfRouteRe = regexp.MustCompile(
+		`(?m)(?:\.\.|[A-Za-z_$][\w$]*\.)(get|post|put|delete|patch|options|head|all)\s*\(\s*(?:'([^'\n\r]*)'|"([^"\n\r]*)")`)
+
+	// conduitRouteRe matches a Conduit router route registration:
+	// `router.route("/users/[:id]")`. Capture group 1 is the path literal.
+	conduitRouteRe = regexp.MustCompile(
+		`(?m)\.route\s*\(\s*(?:"([^"\n\r]*)"|'([^'\n\r]*)')`)
+
+	// dartFrogVerbRe matches a dart_frog handler's static verb dispatch so the
+	// file-route endpoint can carry a precise verb instead of ANY. It recognises
+	// both `case HttpMethod.get` (switch dispatch) and
+	// `context.request.method == HttpMethod.post` (equality dispatch). Capture
+	// group 1 / group 2 is the verb tail (`get`/`post`/…).
+	dartFrogVerbRe = regexp.MustCompile(
+		`HttpMethod\.(get|post|put|delete|patch|head|options)\b`)
+)
+
+// shelfHasRoute is a fast pre-filter: the file must reference a shelf_router
+// marker (`Router(` or `shelf_router`) to be worth scanning.
+func shelfHasRoute(content string) bool {
+	return strings.Contains(content, "Router(") ||
+		strings.Contains(content, "shelf_router") ||
+		strings.Contains(content, "shelf/shelf")
+}
+
+// conduitHasRoute is a fast pre-filter for Conduit route files.
+func conduitHasRoute(content string) bool {
+	return strings.Contains(content, ".route(") &&
+		(strings.Contains(content, "conduit") ||
+			strings.Contains(content, "Controller") ||
+			strings.Contains(content, ".link("))
+}
+
+// synthesizeShelfRoutes scans a Dart source file for shelf_router verb
+// registrations and emits one http_endpoint_definition per statically-known
+// (verb, path). A `.all(` registration is emitted as ANY.
+func synthesizeShelfRoutes(content string, emit emitFn) {
+	if !shelfHasRoute(content) {
+		return
+	}
+	for _, m := range shelfRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		verb := strings.ToUpper(m[1])
+		if verb == "ALL" {
+			verb = "ANY"
+		}
+		raw := m[2]
+		if raw == "" {
+			raw = m[3]
+		}
+		raw = strings.TrimSpace(raw)
+		if !staticDartPath(raw) {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkShelf, raw)
+		if canonical == "" {
+			continue
+		}
+		emit(verb, canonical, "shelf_router", "Controller", "")
+	}
+}
+
+// synthesizeConduitRoutes scans a Dart source file for Conduit router route
+// registrations and emits one ANY http_endpoint_definition per statically-known
+// path (verb-precise `@Operation` methods are a follow-up).
+func synthesizeConduitRoutes(content string, emit emitFn) {
+	if !conduitHasRoute(content) {
+		return
+	}
+	for _, m := range conduitRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		raw := m[1]
+		if raw == "" {
+			raw = m[2]
+		}
+		raw = strings.TrimSpace(raw)
+		if !staticDartPath(raw) {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkConduit, raw)
+		if canonical == "" {
+			continue
+		}
+		emit("ANY", canonical, "conduit", "Controller", "")
+	}
+}
+
+// synthesizeDartFrogRoutes derives a dart_frog file-based route from the source
+// file's location under a `routes/` directory and emits one
+// http_endpoint_definition for it, but only when the file actually exports an
+// `onRequest` handler (so non-route Dart files under a `routes/` path are not
+// fabricated into endpoints). The verb is read from the handler's static method
+// dispatch when present, else ANY.
+func synthesizeDartFrogRoutes(content, filePath string, emit emitFn) {
+	if !strings.Contains(content, "onRequest") {
+		return
+	}
+	route, ok := dartFrogRouteFromPath(filePath)
+	if !ok {
+		return
+	}
+	canonical := httproutes.Canonicalize(httproutes.FrameworkDartFrog, route)
+	if canonical == "" {
+		return
+	}
+	verbs := dartFrogVerbs(content)
+	if len(verbs) == 0 {
+		emit("ANY", canonical, "dart_frog", "Controller", "")
+		return
+	}
+	for _, v := range verbs {
+		emit(v, canonical, "dart_frog", "Controller", "")
+	}
+}
+
+// dartFrogVerbs returns the distinct uppercased HTTP verbs a dart_frog handler
+// dispatches on statically (`HttpMethod.get` / `case HttpMethod.post`). Returns
+// nil when the handler does not branch on the method (→ ANY).
+func dartFrogVerbs(content string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range dartFrogVerbRe.FindAllStringSubmatch(content, -1) {
+		v := strings.ToUpper(m[1])
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+// dartFrogRouteFromPath converts a dart_frog route file path into its canonical
+// route path. The path under the `routes/` directory maps directly: each
+// directory/file segment is a path segment, `index.dart` collapses to its
+// parent directory, a `[name].dart` / `[name]` segment is a dynamic param
+// (rewritten to `{name}`), and a `[...rest]` catch-all becomes `{rest}`. Returns
+// (route, false) when the file is not under a `routes/` directory.
+func dartFrogRouteFromPath(filePath string) (string, bool) {
+	p := filepath.ToSlash(filePath)
+	idx := strings.LastIndex(p, "/routes/")
+	var rel string
+	switch {
+	case idx >= 0:
+		rel = p[idx+len("/routes/"):]
+	case strings.HasPrefix(p, "routes/"):
+		rel = p[len("routes/"):]
+	default:
+		return "", false
+	}
+	rel = strings.TrimSuffix(rel, ".dart")
+	segs := strings.Split(rel, "/")
+	var out []string
+	for _, s := range segs {
+		if s == "" || s == "index" {
+			continue
+		}
+		out = append(out, dartFrogSegment(s))
+	}
+	if len(out) == 0 {
+		return "/", true
+	}
+	return "/" + strings.Join(out, "/"), true
+}
+
+// dartFrogSegment converts a single dart_frog path segment to canonical form:
+// `[id]` → `{id}`, `[...rest]` (catch-all) → `{rest}`, a literal segment passes
+// through. Only a fully-bracketed dynamic segment is treated as a param.
+func dartFrogSegment(seg string) string {
+	if strings.HasPrefix(seg, "[") && strings.HasSuffix(seg, "]") {
+		name := strings.TrimSuffix(strings.TrimPrefix(seg, "["), "]")
+		name = strings.TrimPrefix(name, "...") // catch-all `[...rest]`
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return "{}"
+		}
+		return "{" + name + "}"
+	}
+	return seg
+}
+
+// staticDartPath reports whether a captured Dart route literal is a
+// statically-recoverable path. The capture regexes already pull the path from a
+// SINGLE quoted literal, so cross-literal `+`/`&` concatenation can never appear
+// inside `raw`; the only non-recoverable construct that survives inside one
+// literal is `$`/`${…}` string interpolation (a `+` here is a legitimate regex
+// quantifier in a shelf `<id|[0-9]+>` constraint, not concatenation). Reject an
+// interpolated literal; accept everything else.
+func staticDartPath(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	if strings.Contains(raw, "$") {
+		return false
+	}
+	return true
+}

--- a/internal/engine/http_endpoint_dart_test.go
+++ b/internal/engine/http_endpoint_dart_test.go
@@ -1,0 +1,125 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestShelf_BasicRoute covers the common shelf_router cascade shape:
+// Router()..get('/todos', h)..post('/todos', h).
+func TestShelf_BasicRoute(t *testing.T) {
+	src := `
+import 'package:shelf_router/shelf_router.dart';
+
+final router = Router()
+  ..get('/todos', listTodos)
+  ..post('/todos', createTodo);
+`
+	ids, _ := runDetect(t, "dart", "lib/routes.dart", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos",
+		"http:POST:/todos",
+	}, "shelf-basic-route")
+}
+
+// TestShelf_PathParam covers shelf_router `<id>` and `<id|regex>` angle-bracket
+// dynamic segments → /todos/{id}.
+func TestShelf_PathParam(t *testing.T) {
+	src := `
+import 'package:shelf_router/shelf_router.dart';
+
+final router = Router();
+router.get('/todos/<id>', getTodo);
+router.delete('/todos/<id|[0-9]+>', deleteTodo);
+`
+	ids, _ := runDetect(t, "dart", "lib/todos.dart", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos/{id}",
+		"http:DELETE:/todos/{id}",
+	}, "shelf-path-param")
+}
+
+// TestDartFrog_FileRoute covers dart_frog file-based routing: a
+// routes/users/[id]/index.dart with onRequest → ANY /users/{id}, and a static
+// verb switch yields the precise verb.
+func TestDartFrog_FileRoute(t *testing.T) {
+	src := `
+import 'package:dart_frog/dart_frog.dart';
+
+Response onRequest(RequestContext context) {
+  return Response(body: 'user');
+}
+`
+	ids, _ := runDetect(t, "dart", "routes/users/[id]/index.dart", src)
+	requireContains(t, ids, []string{
+		"http:ANY:/users/{id}",
+	}, "dart-frog-file-route")
+}
+
+// TestDartFrog_VerbSwitch covers a dart_frog handler whose verb is statically
+// dispatched via HttpMethod → the precise verb is emitted.
+func TestDartFrog_VerbSwitch(t *testing.T) {
+	src := `
+import 'package:dart_frog/dart_frog.dart';
+
+Response onRequest(RequestContext context) {
+  if (context.request.method == HttpMethod.post) {
+    return Response(body: 'created');
+  }
+  return Response(body: 'ok');
+}
+`
+	ids, _ := runDetect(t, "dart", "routes/items/index.dart", src)
+	requireContains(t, ids, []string{
+		"http:POST:/items",
+	}, "dart-frog-verb-switch")
+}
+
+// TestConduit_Route covers Conduit `router.route("/users/[:id]")` → ANY
+// /users/{id} (optional `[:id]` param).
+func TestConduit_Route(t *testing.T) {
+	src := `
+import 'package:conduit/conduit.dart';
+
+void setupRouter(Router router) {
+  router.route("/users/[:id]").link(() => UserController());
+}
+`
+	ids, _ := runDetect(t, "dart", "lib/channel.dart", src)
+	requireContains(t, ids, []string{
+		"http:ANY:/users/{id}",
+	}, "conduit-route")
+}
+
+// TestShelf_InterpolatedRouteDropped asserts a non-static (interpolated) shelf
+// path is NOT synthesized — no fabricated endpoint.
+func TestShelf_InterpolatedRouteDropped(t *testing.T) {
+	src := `
+import 'package:shelf_router/shelf_router.dart';
+
+final router = Router();
+router.get('/api/$version/x', handler);
+`
+	ids, _ := runDetect(t, "dart", "lib/dyn.dart", src)
+	for _, id := range ids {
+		if id == "http:GET:/api/x" || id == "http:GET:/api/$version/x" {
+			t.Fatalf("interpolated route should not synthesize an endpoint; got %q", id)
+		}
+	}
+}
+
+// TestShelf_NonWebFileIgnored asserts a plain Dart file with a `.get(` call but
+// no shelf/dart_frog/conduit web marker produces no endpoints.
+func TestShelf_NonWebFileIgnored(t *testing.T) {
+	src := `
+void handle() {
+  final x = cache.get('key');
+  print(x);
+}
+`
+	ids, _ := runDetect(t, "dart", "lib/util.dart", src)
+	for _, id := range ids {
+		if len(id) >= 5 && id[:5] == "http:" {
+			t.Fatalf("non-web Dart file should synthesize no endpoint; got %q", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4758_dart_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4758_dart_test.go
@@ -1,0 +1,71 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the Dart route-hit extractor so the test_suite (carrying
+	// e2e_route_calls) comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/dart"
+)
+
+// Issue #4758 LIVE-REPRO (resolve side) — Dart package:test route-hit tests.
+// Proves end-to-end that a Dart test calling a shelf route by string
+// (`handler(Request('GET', Uri.parse('/todos')))`,
+// `Request('POST', Uri.parse('/todos'))`) links to the
+// http_endpoint_definition it exercises — closing the #4757 N/A. The shared
+// linkE2ERouteTestsToEndpoints pass is language-agnostic; only the Dart route
+// capture is new.
+
+const dartTestHTTPSrc4758 = `
+import 'package:test/test.dart';
+import 'package:shelf/shelf.dart';
+
+void main() {
+  test('lists todos', () async {
+    final res = await handler(Request('GET', Uri.parse('http://localhost:8080/todos')));
+    expect(res.statusCode, 200);
+  });
+
+  test('creates a todo', () async {
+    final res = await handler(Request('POST', Uri.parse('http://localhost:8080/todos')));
+    expect(res.statusCode, 201);
+  });
+}
+`
+
+func TestIssue4758_DartTestE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defs := []types.EntityRecord{
+		def("GET", "/todos"),
+		def("POST", "/todos"),
+	}
+	suite := realSuite(t, "custom_dart_tests_route_e2e",
+		"test/todos_test.dart", "dart", dartTestHTTPSrc4758)
+
+	afterOut, edges := runE2ERouteResolve(t, defs, suite)
+	if edges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (GET + POST), got %d", edges)
+	}
+	assertDartRouteEdges(t, edgeTargets(afterOut))
+}
+
+func assertDartRouteEdges(t *testing.T, targets map[string]bool) {
+	t.Helper()
+	wantGet, wantPost := false, false
+	for to := range targets {
+		if strings.Contains(to, "GET:/todos") {
+			wantGet = true
+		}
+		if strings.Contains(to, "POST:/todos") {
+			wantPost = true
+		}
+	}
+	if !wantGet {
+		t.Errorf("expected a TESTS edge to GET /todos; targets=%v", targets)
+	}
+	if !wantPost {
+		t.Errorf("expected a TESTS edge to POST /todos; targets=%v", targets)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1321,6 +1321,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// producer side is handled by the custom_scala_* framework extractors.
 		synthesizeScalaClientWithRuntime(string(content), emitClientRuntime)
 	case "dart":
+		// Producer side (#4758): Dart server route registrations — shelf_router
+		// (`Router()..get('/users/<id>', h)`), dart_frog file-based routes
+		// (`routes/users/[id]/index.dart` + `onRequest`) and Conduit
+		// (`router.route("/users/[:id]")`) → canonical http_endpoint_definition,
+		// in the same shape axum/Vapor/Kemal/Jester emit, so the shared resolver
+		// and the e2e route-test linker (#4351) light up for Dart. The base dart
+		// extractor stays structural-only; this pass adds the canonical
+		// definitions the coverage substrate keys off. Closes the #4757 N/A.
+		synthesizeShelfRoutes(string(content), emit)
+		synthesizeConduitRoutes(string(content), emit)
+		synthesizeDartFrogRoutes(string(content), path, emit)
 		// Consumer side (#3574, epic #3571): Flutter mobile HTTP clients —
 		// Dio (`dio.get("/path")`) and package:http
 		// (`http.get(Uri.parse("..."))`). Emits outbound http_endpoint_call

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -241,6 +241,24 @@ const (
 	// `{name}` convention identical to FastAPI/Spring, so canonicalisation
 	// reuses canonicalizeCurlyBraces.
 	FrameworkPrologue = "prologue"
+	// FrameworkShelf (#4758) — Dart's shelf_router (`Router()..get('/users/<id>',
+	// handler)`, `router.post('/x', h)`) uses ANGLE-bracket path parameters with
+	// an OPTIONAL inline regex constraint after a `|` pipe: `<id>` and
+	// `<id|[0-9]+>` both name a single param `id`. Canonicalisation strips the
+	// `|regex` tail and rewrites `<name>` → `{name}` via canonicalizeShelfParams.
+	FrameworkShelf = "shelf"
+	// FrameworkDartFrog (#4758) — Dart Frog's file-based routing derives the path
+	// from the route file location under `routes/`: a directory/file segment
+	// `[id]` is a dynamic path parameter and `index.dart` collapses to its parent
+	// directory. The synthesizer pre-derives the route path from the file path,
+	// pre-rewriting `[name]` → `{name}`, so canonicalisation here is the shared
+	// curly-brace pass (defensive — handles any residual `[name]`).
+	FrameworkDartFrog = "dart_frog"
+	// FrameworkConduit (#4758) — Dart's Conduit (`router.route("/users/[:id]")`)
+	// declares OPTIONAL path parameters as `[:id]` (square-bracketed colon param)
+	// and required ones as `:id`. canonicalizeConduitParams drops the optional
+	// `[ ]` wrapper and rewrites `:name` → `{name}`.
+	FrameworkConduit = "conduit"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -279,8 +297,15 @@ func Canonicalize(framework, raw string) string {
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum,
 		FrameworkStarlette, FrameworkPyramid, FrameworkASPNetCore, FrameworkHapi,
 		FrameworkLitestar, FrameworkAiohttp, FrameworkFalcon, FrameworkHug,
-		FrameworkJavalin, FrameworkVertx, FrameworkGrails, FrameworkPrologue:
+		FrameworkJavalin, FrameworkVertx, FrameworkGrails, FrameworkPrologue,
+		FrameworkDartFrog:
 		out = canonicalizeCurlyBraces(raw)
+	case FrameworkShelf:
+		// Dart shelf_router `<id>` / `<id|[0-9]+>` angle-bracket params → `{id}`.
+		out = canonicalizeShelfParams(raw)
+	case FrameworkConduit:
+		// Dart Conduit `[:id]` optional + `:id` required params → `{id}`.
+		out = canonicalizeConduitParams(raw)
 	case FrameworkJester:
 		// Nim Jester `@name` AT-prefixed path params → `{name}`.
 		out = canonicalizeJesterParams(raw)
@@ -593,6 +618,60 @@ func canonicalizeJesterParams(raw string) string {
 		i = j
 	}
 	return b.String()
+}
+
+// canonicalizeShelfParams rewrites Dart shelf_router `<name>` / `<name|regex>`
+// angle-bracket path parameters to the shared `{name}` form. shelf_router
+// supports an optional inline regex constraint after a `|` pipe
+// (`<id|[0-9]+>`); the constraint is dropped and only the parameter name is
+// kept (`/users/<id|[0-9]+>` → `/users/{id}`). A lone `<` with no matching `>`
+// is left verbatim; an empty `<>` becomes `{}`.
+func canonicalizeShelfParams(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw))
+	i := 0
+	for i < len(raw) {
+		c := raw[i]
+		if c != '<' {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		end := strings.IndexByte(raw[i+1:], '>')
+		if end < 0 {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		inner := raw[i+1 : i+1+end]
+		// Drop a `|regex` constraint tail (shelf_router's inline regex syntax).
+		if idx := strings.IndexByte(inner, '|'); idx >= 0 {
+			inner = inner[:idx]
+		}
+		inner = strings.TrimSpace(inner)
+		if inner == "" {
+			b.WriteString("{}")
+		} else {
+			b.WriteByte('{')
+			b.WriteString(inner)
+			b.WriteByte('}')
+		}
+		i += 1 + end + 1
+	}
+	return b.String()
+}
+
+// canonicalizeConduitParams rewrites Dart Conduit path parameters to the shared
+// `{name}` form. Conduit declares a REQUIRED param as `:name` and an OPTIONAL
+// param as `[:name]` (square-bracket wrapped). The optional `[ ]` wrapper is
+// dropped first, then the colon walker rewrites every `:name` → `{name}`
+// (`/users/[:id]` → `/users/{id}`, `/a/:b` → `/a/{b}`). Bare `[`/`]` that do not
+// wrap a colon param are removed (Conduit uses them only for optionality).
+func canonicalizeConduitParams(raw string) string {
+	// Strip the optional-segment square brackets; the param shape that remains
+	// (`:name`) is handled by the shared colon walker.
+	cleaned := strings.NewReplacer("[", "", "]", "").Replace(raw)
+	return canonicalizeColonParams(cleaned)
 }
 
 // canonicalizeGiraffeFormat rewrites Giraffe `routef` printf-style typed

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -121,6 +121,16 @@ var extraCustomPrefixesForLanguage = map[string][]string{
 	// Dispatch both namespaces so the legacy lua_* framework extractors AND the
 	// custom_lua_* tail extractor are picked up.
 	"lua": {"custom_lua_"},
+	// dart's PRIMARY prefix in customPrefixForLanguage is ALREADY `custom_dart_`,
+	// so the #4758 coverage-linkage tail extractor `custom_dart_tests_route_e2e`
+	// is selected by CustomExtractorsFor("dart") via that primary entry. This
+	// explicit re-listing is the #4769 belt-and-suspenders guard: it documents
+	// and locks the dispatch prefix so a future refactor of dart's primary entry
+	// (the Lua mismatch class of bug, where the framework prefix and the
+	// canonical `custom_<lang>_` tail key diverge) cannot silently drop the tail
+	// extractor. The keySet dedup in CustomExtractorsFor makes the duplicate a
+	// no-op when the primary already matches.
+	"dart": {"custom_dart_"},
 }
 
 // CustomExtractorsFor returns all registered custom/framework extractors

--- a/internal/extractors/custom_dispatch_tail_test.go
+++ b/internal/extractors/custom_dispatch_tail_test.go
@@ -35,6 +35,7 @@ func TestTailCoverageLinkageExtractorsDispatch(t *testing.T) {
 		{"elixir", "custom_elixir_tests_route_e2e"},
 		{"lua", "custom_lua_tests_route_e2e"}, // the confirmed-broken case (#4749 tail)
 		{"nim", "custom_nim_tests_route_e2e"},
+		{"dart", "custom_dart_tests_route_e2e"}, // #4758 — primary prefix is already custom_dart_
 		{"kotlin", "custom_kotlin_tests_route_e2e"}, // #4723
 		{"csharp", "custom_csharp_integration_e2e"}, // #4720
 		{"php", "custom_php_phpunit_pest"},          // #4721


### PR DESCRIPTION
## Summary
Adds the missing **Dart server-side `http_endpoint_definition` producer** and the **package:test coverage-linkage** that PR #4757 had to record N/A for lack of endpoints — closing the one remaining N/A in the #4749 coverage-linkage tail. Mirrors the Crystal/Kemal, Swift/Vapor and Nim/Jester producer-first precedents.

## Part 1 — producer (`internal/engine/http_endpoint_dart.go`)
Synthesizes canonical `http_endpoint_definition` for the statically-recoverable Dart server frameworks, in the same shape axum/Vapor/Kemal/Jester emit:
- **shelf_router** — `Router()..get('/users/<id>', h)` / `router.post('/x', h)`; `<id>` / `<id|[0-9]+>` → `{id}` (`FrameworkShelf`, `|regex` constraint dropped).
- **dart_frog** — file-based routing: `routes/users/[id]/index.dart` + `onRequest` → `/users/{id}` (`[id]`→`{id}`, `index.dart`→parent path); verb derived from the handler's `HttpMethod.*` dispatch when static, else `ANY` (`FrameworkDartFrog`).
- **conduit** — `router.route("/users/[:id]")` → `{id}` (`[:id]` optional + `:id` required, `FrameworkConduit`), emitted `ANY`.

Wired into the `case "dart"` synthesis dispatch + three new canonicalisers in `httproutes/canonicalize.go`. Reuses the `entry_points_dart.go` `onRequest`/shelf-handler signal (the producer requires an `onRequest` export before deriving a dart_frog route, so non-route files under `routes/` are not fabricated).

## Part 2 — coverage-linkage (`internal/custom/dart/tests_route_e2e.go`)
- Captures package:test route hits — `handler(Request('GET', Uri.parse('/x')))` and `client.get(Uri.parse('/x'))` — into `e2e_route_calls` on a one-per-file `test_suite` **scope-owner** (`test('...', () {})` closures carry prose, not symbols — the #4680/#4719 anonymous-closure pattern). The shared language-agnostic `engine.linkE2ERouteTestsToEndpoints` pass then binds the TESTS edge to the exercised endpoint.
- **Dispatch registration:** `custom_dart_tests_route_e2e` is selected by `CustomExtractorsFor("dart")` via dart's primary `custom_dart_` prefix; additionally locked into `extraCustomPrefixesForLanguage["dart"]` (the #4769 belt-and-suspenders guard — dart's primary already matches, so this documents/locks against a future Lua-style divergence) and asserted by `TestTailCoverageLinkageExtractorsDispatch/dart`.
- Local-var/receiver typing is honestly N/A for Dart (route dispatch is keyed by the literal route string, not an `obj.method()` receiver).

## Coverage docs
- New `lang.dart.framework.shelf` entry: `Routing.endpoint_synthesis` / `route_extraction` and `Testing.tests_linkage` all **full** (shelf/dart_frog/conduit).
- Flipped the #4757 N/A note on `lang.dart.framework.flutter` to point at the new server entry.
- `coverage fmt --check`: canonical. `coverage validate`: **0 errors**.

## Validation (fixtures RED→GREEN)
- Producer: `TestShelf_*` / `TestDartFrog_*` / `TestConduit_*` (basic, path-param, verb-switch, interpolated-dropped, non-web-ignored).
- Linkage: `TestIssue4758_DartTestE2ERouteTestsLinkToEndpoints` (shelf `Request('GET'/'POST', Uri.parse('/todos'))` → TESTS edge).
- Dispatch guard: extended `custom_dispatch_tail_test.go` with the `dart` case.

## Gates
`go build ./...` ✅ · `go vet` (extractors/custom/engine/graph) ✅ · `go test` (extractors/custom/engine/graph/types) ✅ 0 failures · `coverage fmt --check` ✅ · `coverage validate` ✅ 0 errors.

Closes #4758
Part of #4749

🤖 Generated with [Claude Code](https://claude.com/claude-code)
