### PR TITLE
feat(coverage): distinguish contract-covered from reach-coverage (#4662)

### DIFF
--- a/internal/dashboard/handlers_coverage.go
+++ b/internal/dashboard/handlers_coverage.go
@@ -39,9 +39,15 @@ type GroupCoverageReport struct {
 	TotalProduction   int     `json:"total_production"`
 	CoveredProduction int     `json:"covered_production"`
 	CoveragePct       float64 `json:"coverage_pct"`
-	TotalTests        int     `json:"total_tests"`
-	TotalTestsEdges   int     `json:"total_tests_edges"`
-	Repos             int     `json:"repos"`
+	// ContractCoveredOnly / ContractCoveredPct expose the secondary
+	// contract-covered band (#4662): endpoints whose shape is asserted by an
+	// offline contract spec but which no test executes. They are NEVER folded
+	// into CoveredProduction/CoveragePct, which stay pure reach-coverage.
+	ContractCoveredOnly int     `json:"contract_covered_only"`
+	ContractCoveredPct  float64 `json:"contract_covered_pct"`
+	TotalTests          int     `json:"total_tests"`
+	TotalTestsEdges     int     `json:"total_tests_edges"`
+	Repos               int     `json:"repos"`
 	// UncoveredEntities is sorted by severity (high first) and capped by
 	// the ?limit query parameter (default 200).
 	UncoveredEntities []graph.UncoveredEntity `json:"uncovered_entities"`
@@ -113,11 +119,11 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 	result := GroupCoverageReport{Group: groupName}
 
 	// Accumulate per-directory and per-module maps for aggregation.
-	type dirAccum struct{ total, covered int }
+	type dirAccum struct{ total, covered, contractOnly int }
 	type modAccum struct{ total, covered int }
 	type fileAccum struct {
-		dir            string
-		total, covered int
+		dir                          string
+		total, covered, contractOnly int
 	}
 	dirAcc := make(map[string]*dirAccum)
 	modAcc := make(map[string]*modAccum)
@@ -147,6 +153,7 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 		result.Repos++
 		result.TotalProduction += report.TotalProduction
 		result.CoveredProduction += report.CoveredProduction
+		result.ContractCoveredOnly += report.ContractCoveredOnly
 		result.TotalTests += report.TotalTests
 		result.TotalTestsEdges += report.TotalTestsEdges
 
@@ -166,6 +173,7 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 			}
 			dirAcc[d.Dir].total += d.Total
 			dirAcc[d.Dir].covered += d.Covered
+			dirAcc[d.Dir].contractOnly += d.ContractOnly
 		}
 
 		// Merge per-file stats.
@@ -175,6 +183,7 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 			}
 			fileAcc[f.File].total += f.Total
 			fileAcc[f.File].covered += f.Covered
+			fileAcc[f.File].contractOnly += f.ContractOnly
 		}
 
 		// Merge per-module stats.
@@ -188,8 +197,12 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// ── compute group-level coverage % ───────────────────────────────────────
+	// CoveragePct stays pure reach-coverage; ContractCoveredPct is the union
+	// band (reach + contract-covered-only) the UI renders behind it (#4662).
 	if result.TotalProduction > 0 {
 		result.CoveragePct = 100.0 * float64(result.CoveredProduction) / float64(result.TotalProduction)
+		result.ContractCoveredPct = 100.0 *
+			float64(result.CoveredProduction+result.ContractCoveredOnly) / float64(result.TotalProduction)
 	}
 
 	// ── apply severity filter and cap UncoveredEntities ──────────────────────
@@ -271,10 +284,11 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 			covPct = 100.0 * float64(acc.covered) / float64(acc.total)
 		}
 		result.ByDirectory = append(result.ByDirectory, graph.DirCoverage{
-			Dir:         d,
-			Total:       acc.total,
-			Covered:     acc.covered,
-			CoveragePct: covPct,
+			Dir:          d,
+			Total:        acc.total,
+			Covered:      acc.covered,
+			ContractOnly: acc.contractOnly,
+			CoveragePct:  covPct,
 		})
 	}
 	sort.Slice(result.ByDirectory, func(i, j int) bool {
@@ -291,11 +305,12 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 			covPct = 100.0 * float64(acc.covered) / float64(acc.total)
 		}
 		result.ByFile = append(result.ByFile, graph.FileCoverage{
-			File:        f,
-			Dir:         acc.dir,
-			Total:       acc.total,
-			Covered:     acc.covered,
-			CoveragePct: covPct,
+			File:         f,
+			Dir:          acc.dir,
+			Total:        acc.total,
+			Covered:      acc.covered,
+			ContractOnly: acc.contractOnly,
+			CoveragePct:  covPct,
 		})
 	}
 	sort.Slice(result.ByFile, func(i, j int) bool {

--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -52,7 +52,26 @@ type CoverageReport struct {
 	CoveredProduction int `json:"covered_production"`
 	// CoveragePct is CoveredProduction/TotalProduction*100 (0 when no
 	// production entities exist).
+	//
+	// NOTE (#4662): this is the REACH-coverage % — production entities a test
+	// actually executes (CALLS the handler / executing TESTS edge / endpoint
+	// credited via a reached handler). It deliberately does NOT include
+	// contract-covered-only endpoints (see ContractCoveredOnly), so the headline
+	// figure stays honest about what is structurally exercised by a test.
 	CoveragePct float64 `json:"coverage_pct"`
+
+	// ContractCoveredOnly is the count of production endpoints that are NOT
+	// reach-covered but ARE contract-covered: an OFFLINE contract spec references
+	// the endpoint's route (asserts its shape) without any test executing the
+	// handler (#4662). These read as "contract-covered" rather than "untested".
+	//
+	// This is a SEPARATE, secondary band — it is never added into
+	// CoveredProduction / CoveragePct (which remain pure reach-coverage).
+	ContractCoveredOnly int `json:"contract_covered_only"`
+	// ContractCoveredPct is (CoveredProduction+ContractCoveredOnly)/TotalProduction
+	// *100 — the union band the UI renders behind the reach-coverage bar so the
+	// gap between "executed by a test" and "shape-asserted offline" is visible.
+	ContractCoveredPct float64 `json:"contract_covered_pct"`
 
 	// TotalTests is the number of test entities found.
 	TotalTests int `json:"total_tests"`
@@ -101,25 +120,52 @@ type UncoveredEntity struct {
 	Repo string `json:"repo,omitempty"`
 	// Severity is "high" | "medium" | "low".
 	Severity string `json:"severity"`
+	// State is the coverage state of this entity (#4662). For entities in this
+	// (not-reach-covered) list it is either:
+	//
+	//	"contract-only" — an offline contract spec asserts the endpoint's shape
+	//	                  but no test executes the handler. NOT dangerously
+	//	                  untested; severity is downgraded accordingly.
+	//	"uncovered"     — neither reach-covered nor contract-covered.
+	//
+	// (Reach-covered entities never appear in this list, so the value is never
+	// "reach" here; the three-state vocabulary is reach | contract-only |
+	// uncovered, and "reach" lives on the covered side of the report.)
+	State string `json:"state"`
 }
+
+// Coverage-state string constants (#4662). The full three-state vocabulary is
+// reach | contract-only | uncovered; only the latter two appear in
+// UncoveredEntity.State (reach-covered entities are not listed as uncovered).
+const (
+	CoverageStateReach        = "reach"
+	CoverageStateContractOnly = "contract-only"
+	CoverageStateUncovered    = "uncovered"
+)
 
 // DirCoverage is per-directory coverage statistics.
 type DirCoverage struct {
-	Dir         string  `json:"dir"`
-	Total       int     `json:"total"`
-	Covered     int     `json:"covered"`
-	CoveragePct float64 `json:"coverage_pct"`
+	Dir     string `json:"dir"`
+	Total   int    `json:"total"`
+	Covered int    `json:"covered"`
+	// ContractOnly is the count of entities in this directory that are
+	// contract-covered-only (shape-asserted offline, not reach-covered) (#4662).
+	ContractOnly int     `json:"contract_only"`
+	CoveragePct  float64 `json:"coverage_pct"`
 }
 
 // FileCoverage is per-file coverage statistics. File is the full source path
 // (forward-slash normalised); Dir is its parent directory (matching the keys
 // in ByDirectory) so the frontend can nest files under directories.
 type FileCoverage struct {
-	File        string  `json:"file"`
-	Dir         string  `json:"dir"`
-	Total       int     `json:"total"`
-	Covered     int     `json:"covered"`
-	CoveragePct float64 `json:"coverage_pct"`
+	File    string `json:"file"`
+	Dir     string `json:"dir"`
+	Total   int    `json:"total"`
+	Covered int    `json:"covered"`
+	// ContractOnly is the count of entities in this file that are
+	// contract-covered-only (shape-asserted offline, not reach-covered) (#4662).
+	ContractOnly int     `json:"contract_only"`
+	CoveragePct  float64 `json:"coverage_pct"`
 }
 
 // ModuleCoverage is per-module coverage statistics.
@@ -173,6 +219,57 @@ var testEntityKinds = map[string]bool{
 	"SCOPE.Operation": true, // canonical: all language extractors
 	"Function":        true, // compat / future
 	"Method":          true, // compat / future
+}
+
+// contractSpecPathSegments are slash-normalised path segments that mark a test
+// file as an OFFLINE CONTRACT spec — a spec that asserts an endpoint's
+// request/response SHAPE against an oracle/fixture but does NOT invoke the
+// handler (no CALLS/execution edge). These are the dominant test mechanism on
+// contract-first backends (upvate-v3: test/contract/*.contract.spec.ts) and the
+// reason a large slice of endpoints read "untested" under pure reach-coverage
+// even though their shape is asserted (#4662, follow-on to #4671).
+var contractSpecPathSegments = []string{
+	"/contract/",  // test/contract/… (NestJS, generic)
+	"/contracts/", // pluralised variant
+	"/pact/",      // Pact consumer/provider contract tests
+	"/pacts/",     // pluralised variant
+}
+
+// contractSpecNameInfixes are case-insensitive base-name infixes that mark a
+// contract spec regardless of directory (`*.contract.spec.ts`, `*.pact.test.ts`,
+// `foo.contract.test.js`, …). Matched on the lower-cased base name.
+var contractSpecNameInfixes = []string{
+	".contract.spec.", ".contract.test.",
+	".pact.spec.", ".pact.test.",
+	".contract.", // e.g. foo.contract.ts when it is itself a spec dir resident
+}
+
+// isContractSpecFile reports whether path is an OFFLINE contract spec file — a
+// test file (it must already satisfy isTestFile for the caller's purposes) that
+// asserts endpoint shapes against an oracle and does not execute the handler.
+//
+// Detection is path-/name-driven and framework-agnostic: a `/contract/`-style
+// directory segment OR a `*.contract.spec.*` / `*.pact.*` base-name infix. It is
+// intentionally conservative — a plain `foo.spec.ts` is NOT a contract spec; the
+// "contract"/"pact" marker must be explicit, so we never mistake an executing
+// unit/e2e spec for an offline contract spec (#4662).
+func isContractSpecFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	slashed := "/" + filepath.ToSlash(strings.ToLower(path))
+	for _, seg := range contractSpecPathSegments {
+		if strings.Contains(slashed, seg) {
+			return true
+		}
+	}
+	base := strings.ToLower(filepath.Base(path))
+	for _, infix := range contractSpecNameInfixes {
+		if strings.Contains(base, infix) {
+			return true
+		}
+	}
+	return false
 }
 
 // isTestFile returns true when the source file path matches a recognised test
@@ -435,6 +532,7 @@ func pct(covered, total int) float64 {
 
 const kindTests = "TESTS"
 const kindCalls = "CALLS"
+const kindReferences = "REFERENCES"
 
 // handlerEndpointEdgeKinds are the producer-side edge kinds that link a backend
 // handler (controller method / view function / Operation) to its
@@ -520,6 +618,57 @@ func creditEndpointsViaHandlers(
 	return credited
 }
 
+// creditContractRefViaHandlers propagates a contract route-reference one hop
+// along the handler↔endpoint edge (IMPLEMENTS/ROUTES_TO/SERVES, either
+// direction), so that whichever side a contract spec references — the synthetic
+// http_endpoint_definition (via a route-literal match) OR the backing handler
+// method (via a describe-label) — the OTHER side is also marked
+// contract-referenced. This mirrors creditEndpointsViaHandlers but for the
+// contractRef map, and is framework-agnostic (#4662).
+//
+// Unlike the reach-coverage hop it is unconditional on the partner's reach
+// state: contract coverage and reach coverage are orthogonal bands, and the
+// final contract-covered-only set subtracts reach-covered entities afterwards.
+// It mutates contractRef in place.
+func creditContractRefViaHandlers(
+	entByID map[string]*Entity,
+	rels []Relationship,
+	prodIDs map[string]bool,
+	contractRef map[string]int,
+) {
+	for i := range rels {
+		r := &rels[i]
+		if !handlerEndpointEdgeKinds[strings.ToUpper(r.Kind)] {
+			continue
+		}
+		from := entByID[r.FromID]
+		to := entByID[r.ToID]
+		if from == nil || to == nil {
+			continue
+		}
+		var defID, handlerID string
+		switch {
+		case isEndpointKind(to.Kind) && !isEndpointKind(from.Kind):
+			defID, handlerID = to.ID, from.ID
+		case isEndpointKind(from.Kind) && !isEndpointKind(to.Kind):
+			defID, handlerID = from.ID, to.ID
+		default:
+			continue
+		}
+		// Propagate a reference from whichever side has one to the other, as
+		// long as both sit in the production denominator.
+		if !prodIDs[defID] || !prodIDs[handlerID] {
+			continue
+		}
+		if contractRef[handlerID] > 0 && contractRef[defID] == 0 {
+			contractRef[defID]++
+		}
+		if contractRef[defID] > 0 && contractRef[handlerID] == 0 {
+			contractRef[handlerID]++
+		}
+	}
+}
+
 // endpointHandlerIDs returns the handler entity IDs that back the
 // http_endpoint_definition defID, resolving the handler↔definition edge in
 // both directions (IMPLEMENTS/ROUTES_TO/SERVES). Framework-agnostic; used by the
@@ -560,6 +709,13 @@ type EntityCoverageResult struct {
 	Tested           bool     `json:"tested"`
 	CoveringTests    []string `json:"covering_tests"`
 	CoverageFraction float64  `json:"coverage_fraction"`
+	// State is the three-state coverage classification (#4662):
+	// "reach" (a test executes it), "contract-only" (an offline contract spec
+	// asserts its shape but nothing executes it), or "uncovered".
+	State string `json:"state"`
+	// ContractCovered is true when a contract spec references this entity's
+	// route (shape-asserted) regardless of reach state.
+	ContractCovered bool `json:"contract_covered"`
 }
 
 // ComputeEntityCoverage returns coverage details for a single entity ID within
@@ -587,6 +743,7 @@ func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResul
 	// ── index all entities needed for the two-phase algorithm ─────────────────
 	prodIDs := make(map[string]bool)
 	testIDs := make(map[string]bool)
+	contractTestIDs := make(map[string]bool) // contract-spec test entities (#4662)
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
 		switch {
@@ -594,6 +751,9 @@ func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResul
 			prodIDs[e.ID] = true
 		case isTestEntity(e):
 			testIDs[e.ID] = true
+			if isContractSpecFile(e.SourceFile) {
+				contractTestIDs[e.ID] = true
+			}
 		}
 	}
 
@@ -604,6 +764,7 @@ func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResul
 		SourceFile: target.SourceFile,
 		StartLine:  target.StartLine,
 		Severity:   entitySeverity(target),
+		State:      CoverageStateUncovered,
 	}
 
 	if !prodIDs[entityID] {
@@ -616,13 +777,25 @@ func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResul
 	coveringSet := make(map[string]bool)
 	// testCallsTo: sets of production entity IDs each test entity calls.
 	testCallsToTarget := make(map[string]bool) // test entity IDs that CALL entityID
+	// contractRefSeen: a contract spec references this entity's route without
+	// executing it (#4662) — the contract-covered signal, separate from reach.
+	contractRefSeen := false
 
 	for i := range doc.Relationships {
 		rel := &doc.Relationships[i]
 		switch strings.ToUpper(rel.Kind) {
 		case kindTests:
 			if rel.ToID == entityID && testIDs[rel.FromID] {
+				if contractTestIDs[rel.FromID] {
+					// Offline contract spec: shape reference, not a reach signal.
+					contractRefSeen = true
+					continue
+				}
 				coveringSet[rel.FromID] = true
+			}
+		case kindReferences:
+			if rel.ToID == entityID && contractTestIDs[rel.FromID] {
+				contractRefSeen = true
 			}
 		case kindCalls:
 			if rel.ToID == entityID && testIDs[rel.FromID] {
@@ -655,7 +828,15 @@ func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResul
 				switch strings.ToUpper(rel.Kind) {
 				case kindTests:
 					if rel.ToID == hID && testIDs[rel.FromID] {
+						if contractTestIDs[rel.FromID] {
+							contractRefSeen = true
+							continue
+						}
 						coveringSet[rel.FromID] = true
+					}
+				case kindReferences:
+					if rel.ToID == hID && contractTestIDs[rel.FromID] {
+						contractRefSeen = true
 					}
 				case kindCalls:
 					if rel.ToID == hID && testIDs[rel.FromID] {
@@ -682,6 +863,15 @@ func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResul
 	result.Tested = tested
 	result.CoveringTests = coveringTests
 	result.CoverageFraction = fraction
+	result.ContractCovered = contractRefSeen
+	switch {
+	case tested:
+		result.State = CoverageStateReach
+	case contractRefSeen:
+		result.State = CoverageStateContractOnly
+	default:
+		result.State = CoverageStateUncovered
+	}
 	return result, true
 }
 
@@ -822,8 +1012,9 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 	}
 
 	// Classify entities.
-	prodIDs := make(map[string]bool) // production entity IDs
-	testIDs := make(map[string]bool) // test entity IDs
+	prodIDs := make(map[string]bool)         // production entity IDs
+	testIDs := make(map[string]bool)         // test entity IDs (all)
+	contractTestIDs := make(map[string]bool) // test entities that live in an OFFLINE contract spec (#4662)
 
 	for id, e := range entByID {
 		switch {
@@ -831,14 +1022,25 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 			prodIDs[id] = true
 		case isTestEntity(e):
 			testIDs[id] = true
+			if isContractSpecFile(e.SourceFile) {
+				contractTestIDs[id] = true
+			}
 		}
 	}
 	report.TotalProduction = len(prodIDs)
 	report.TotalTests = len(testIDs)
 
 	// ── phase 1: collect TESTS edges ─────────────────────────────────────────
-	// covered maps production-entity-ID → count of TESTS inbound.
+	// covered maps production-entity-ID → count of REACH-coverage signals
+	// (a test that actually executes the entity). To keep the headline %
+	// honest (#4671/#4662), a TESTS edge that originates from an OFFLINE
+	// contract spec is NOT a reach signal — it is a route REFERENCE (shape
+	// assertion) only. Those feed contractRef instead, never covered.
 	covered := make(map[string]int, len(prodIDs))
+	// contractRef maps production-entity-ID → count of contract-spec route
+	// references (TESTS or REFERENCES edges from a contract-spec test entity)
+	// with NO execution. Used to compute the contract-covered-only band (#4662).
+	contractRef := make(map[string]int, len(prodIDs))
 	// testCallsTo: per test-entity-ID, the set of CALLS target IDs.
 	testCallsTo := make(map[string][]string)
 
@@ -846,9 +1048,25 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 		rel := &doc.Relationships[i]
 		switch strings.ToUpper(rel.Kind) {
 		case kindTests:
-			if prodIDs[rel.ToID] {
-				covered[rel.ToID]++
-				report.TotalTestsEdges++
+			if !prodIDs[rel.ToID] {
+				continue
+			}
+			if contractTestIDs[rel.FromID] {
+				// Offline contract spec asserting the endpoint's shape via a
+				// route reference (route-literal / describe('VERB /route') label
+				// match). NOT a reach signal — record it as a contract reference.
+				contractRef[rel.ToID]++
+				continue
+			}
+			covered[rel.ToID]++
+			report.TotalTestsEdges++
+		case kindReferences:
+			// A REFERENCES edge from a contract-spec test entity to a production
+			// endpoint/handler is the explicit route-reference form (some
+			// extractors record the route literal as REFERENCES rather than
+			// TESTS). It is a shape assertion, never an execution (#4662).
+			if prodIDs[rel.ToID] && contractTestIDs[rel.FromID] {
+				contractRef[rel.ToID]++
 			}
 		case kindCalls:
 			if testIDs[rel.FromID] {
@@ -893,9 +1111,29 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 		report.TotalTestsEdges += ep
 	}
 
+	// ── phase 5: contract-covered band (#4662) ───────────────────────────────
+	// Propagate contract references one hop along the handler↔endpoint edge so
+	// a contract spec that references the handler method credits the endpoint it
+	// backs (and vice versa) — mirroring the reach-coverage endpoint hop. This
+	// uses the SAME edge kinds (IMPLEMENTS/ROUTES_TO/SERVES) and never touches
+	// `covered`, so the reach-coverage % is unaffected.
+	creditContractRefViaHandlers(entByID, doc.Relationships, prodIDs, contractRef)
+
+	// contractCoveredOnly: production entities that are NOT reach-covered but
+	// DO carry a contract route-reference. This is the honest second band — the
+	// endpoint's shape is asserted offline though no test executes it.
+	contractCoveredOnly := make(map[string]bool)
+	for id := range contractRef {
+		if covered[id] == 0 && prodIDs[id] {
+			contractCoveredOnly[id] = true
+		}
+	}
+
 	// ── compute totals ────────────────────────────────────────────────────────
 	report.CoveredProduction = len(covered)
 	report.CoveragePct = pct(report.CoveredProduction, report.TotalProduction)
+	report.ContractCoveredOnly = len(contractCoveredOnly)
+	report.ContractCoveredPct = pct(report.CoveredProduction+report.ContractCoveredOnly, report.TotalProduction)
 
 	// ── build uncovered list ──────────────────────────────────────────────────
 	for id := range prodIDs {
@@ -907,6 +1145,18 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 		if e.Properties != nil {
 			mod = e.Properties["module"]
 		}
+		// State + severity: a contract-covered-only entity is shape-asserted
+		// offline, so it is NOT dangerously untested — downgrade a "high"
+		// (endpoint) severity to "medium" and tag the state so the UI renders it
+		// in the contract band rather than the alarming uncovered band (#4662).
+		sev := entitySeverity(e)
+		state := CoverageStateUncovered
+		if contractCoveredOnly[id] {
+			state = CoverageStateContractOnly
+			if sev == "high" {
+				sev = "medium"
+			}
+		}
 		report.UncoveredEntities = append(report.UncoveredEntities, UncoveredEntity{
 			EntityID:   id,
 			Name:       e.Name,
@@ -915,7 +1165,8 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 			StartLine:  e.StartLine,
 			Language:   e.Language,
 			Module:     mod,
-			Severity:   entitySeverity(e),
+			Severity:   sev,
+			State:      state,
 		})
 	}
 
@@ -936,11 +1187,11 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 	// ── per-directory & per-file breakdown ────────────────────────────────────
 	// Files are the deepest grouping; directory rollups are the sums of the
 	// files that live under them.
-	type covStat struct{ total, covered int }
+	type covStat struct{ total, covered, contractOnly int }
 	dirStats := make(map[string]*covStat)
 	type fileStat struct {
-		dir            string
-		total, covered int
+		dir                          string
+		total, covered, contractOnly int
 	}
 	fileStats := make(map[string]*fileStat)
 
@@ -960,18 +1211,23 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 		}
 		fileStats[f].total++
 
-		if covered[id] > 0 {
+		switch {
+		case covered[id] > 0:
 			dirStats[d].covered++
 			fileStats[f].covered++
+		case contractCoveredOnly[id]:
+			dirStats[d].contractOnly++
+			fileStats[f].contractOnly++
 		}
 	}
 
 	for d, s := range dirStats {
 		report.ByDirectory = append(report.ByDirectory, DirCoverage{
-			Dir:         d,
-			Total:       s.total,
-			Covered:     s.covered,
-			CoveragePct: pct(s.covered, s.total),
+			Dir:          d,
+			Total:        s.total,
+			Covered:      s.covered,
+			ContractOnly: s.contractOnly,
+			CoveragePct:  pct(s.covered, s.total),
 		})
 	}
 	sort.Slice(report.ByDirectory, func(i, j int) bool {
@@ -980,11 +1236,12 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 
 	for f, s := range fileStats {
 		report.ByFile = append(report.ByFile, FileCoverage{
-			File:        f,
-			Dir:         s.dir,
-			Total:       s.total,
-			Covered:     s.covered,
-			CoveragePct: pct(s.covered, s.total),
+			File:         f,
+			Dir:          s.dir,
+			Total:        s.total,
+			Covered:      s.covered,
+			ContractOnly: s.contractOnly,
+			CoveragePct:  pct(s.covered, s.total),
 		})
 	}
 	sort.Slice(report.ByFile, func(i, j int) bool {

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -742,3 +742,149 @@ func TestComputeCoverage_EndpointCreditedViaRoutesTo(t *testing.T) {
 		t.Errorf("CoveredProduction want 2 (handler + endpoint via ROUTES_TO), got %d", report.CoveredProduction)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Contract-covered band (#4662)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIsContractSpecFile covers the offline-contract-spec detection: directory
+// segments (/contract/, /pact/) and base-name infixes (*.contract.spec.*,
+// *.pact.*), while plain specs are NOT contract specs.
+func TestIsContractSpecFile(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"test/contract/proposals.contract.spec.ts", true},
+		{"src/clients/clients.contract.spec.ts", true},
+		{"test/contract/foo.spec.ts", true},     // dir segment
+		{"api/pact/consumer.pact.test.ts", true}, // pact dir + infix
+		{"src/user.contract.test.js", true},
+		// Plain specs / unit specs are NOT contract specs.
+		{"src/app.controller.spec.ts", false},
+		{"src/user.test.ts", false},
+		{"handler_test.go", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isContractSpecFile(tc.path); got != tc.want {
+			t.Errorf("isContractSpecFile(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestComputeCoverage_ThreeStateBands is the headline #4662 fixture mirroring the
+// live upvate-v3 shape. Three endpoints:
+//
+//	epReach   — a UNIT spec CALLS its handler        → reach-covered
+//	epCon     — only an OFFLINE contract spec TESTS  → contract-covered-only
+//	epNone    — neither                              → uncovered
+//
+// Asserts: reach % counts only epReach's handler+endpoint, contract band counts
+// epCon (handler+endpoint) separately, and the contract endpoint is NOT folded
+// into the reach %.
+func TestComputeCoverage_ThreeStateBands(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		// Reach-covered endpoint: handler executed by a unit spec.
+		{ID: "hReach", Name: "getReach", Kind: "SCOPE.Operation", SourceFile: "src/reach.controller.ts", StartLine: 10},
+		{ID: "epReach", Name: "GET /reach", Kind: "http_endpoint_definition", SourceFile: "src/reach.controller.ts", StartLine: 10},
+		{ID: "unitSpec", Name: "ReachController", Kind: "SCOPE.Operation", SourceFile: "src/reach.controller.spec.ts"},
+
+		// Contract-covered-only endpoint: handler referenced by an OFFLINE
+		// contract spec via a route-reference TESTS edge (no execution).
+		{ID: "hCon", Name: "getCounts", Kind: "SCOPE.Operation", SourceFile: "src/proposal.controller.ts", StartLine: 90},
+		{ID: "epCon", Name: "GET /proposals/get_counts", Kind: "http_endpoint_definition", SourceFile: "src/proposal.controller.ts", StartLine: 90},
+		{ID: "contractSpec", Name: "GET /proposals/get_counts", Kind: "SCOPE.Operation", SourceFile: "test/contract/proposals.contract.spec.ts"},
+
+		// Uncovered endpoint: nothing references it.
+		{ID: "hNone", Name: "getNone", Kind: "SCOPE.Operation", SourceFile: "src/none.controller.ts", StartLine: 5},
+		{ID: "epNone", Name: "GET /none", Kind: "http_endpoint_definition", SourceFile: "src/none.controller.ts", StartLine: 5},
+	}
+	rels := []Relationship{
+		{ID: "i1", FromID: "hReach", ToID: "epReach", Kind: "IMPLEMENTS"},
+		{ID: "i2", FromID: "hCon", ToID: "epCon", Kind: "IMPLEMENTS"},
+		{ID: "i3", FromID: "hNone", ToID: "epNone", Kind: "IMPLEMENTS"},
+		// Unit spec EXECUTES the reach handler (CALLS).
+		{ID: "c1", FromID: "unitSpec", ToID: "hReach", Kind: "CALLS"},
+		// Contract spec REFERENCES the route (TESTS, route-literal match) — no CALLS.
+		{ID: "t1", FromID: "contractSpec", ToID: "hCon", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+
+	// 6 production entities (3 handlers + 3 endpoints).
+	if report.TotalProduction != 6 {
+		t.Fatalf("TotalProduction want 6, got %d", report.TotalProduction)
+	}
+	// Reach: hReach + epReach only (contract endpoint NOT folded in).
+	if report.CoveredProduction != 2 {
+		t.Errorf("CoveredProduction (reach) want 2, got %d", report.CoveredProduction)
+	}
+	// Contract-only band: hCon + epCon (via handler hop).
+	if report.ContractCoveredOnly != 2 {
+		t.Errorf("ContractCoveredOnly want 2 (handler+endpoint), got %d", report.ContractCoveredOnly)
+	}
+	// Reach % must NOT include the contract endpoints.
+	wantReach := pct(2, 6)
+	if report.CoveragePct != wantReach {
+		t.Errorf("CoveragePct want %.2f (reach only), got %.2f", wantReach, report.CoveragePct)
+	}
+	// Union band = reach + contract-only.
+	wantUnion := pct(4, 6)
+	if report.ContractCoveredPct != wantUnion {
+		t.Errorf("ContractCoveredPct want %.2f, got %.2f", wantUnion, report.ContractCoveredPct)
+	}
+
+	// State assertions per entity in the uncovered list.
+	stateByID := map[string]string{}
+	for _, u := range report.UncoveredEntities {
+		stateByID[u.EntityID] = u.State
+	}
+	if stateByID["epCon"] != CoverageStateContractOnly {
+		t.Errorf("epCon state want %q, got %q", CoverageStateContractOnly, stateByID["epCon"])
+	}
+	if stateByID["hCon"] != CoverageStateContractOnly {
+		t.Errorf("hCon state want %q, got %q", CoverageStateContractOnly, stateByID["hCon"])
+	}
+	if stateByID["epNone"] != CoverageStateUncovered {
+		t.Errorf("epNone state want %q, got %q", CoverageStateUncovered, stateByID["epNone"])
+	}
+	// Reach-covered entities must NOT appear in the uncovered list at all.
+	if _, listed := stateByID["epReach"]; listed {
+		t.Errorf("epReach is reach-covered and must not be in the uncovered list")
+	}
+
+	// Single-entity path must agree on the three states.
+	doc := makeDoc(entities, rels)
+	if r, _ := ComputeEntityCoverage(doc, "epReach"); r.State != CoverageStateReach || !r.Tested {
+		t.Errorf("ComputeEntityCoverage(epReach) want reach/tested, got state=%q tested=%v", r.State, r.Tested)
+	}
+	if r, _ := ComputeEntityCoverage(doc, "epCon"); r.State != CoverageStateContractOnly || r.Tested || !r.ContractCovered {
+		t.Errorf("ComputeEntityCoverage(epCon) want contract-only/!tested/contractCovered, got state=%q tested=%v contract=%v", r.State, r.Tested, r.ContractCovered)
+	}
+	if r, _ := ComputeEntityCoverage(doc, "epNone"); r.State != CoverageStateUncovered || r.ContractCovered {
+		t.Errorf("ComputeEntityCoverage(epNone) want uncovered/!contractCovered, got state=%q contract=%v", r.State, r.ContractCovered)
+	}
+}
+
+// TestComputeCoverage_ContractSpecNeverInflatesReach guards the honesty rule:
+// an endpoint reachable ONLY by an offline contract spec must NOT count toward
+// the reach % even though a TESTS edge exists (the #4671/#4662 distinction).
+func TestComputeCoverage_ContractSpecNeverInflatesReach(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		{ID: "h", Name: "getCounts", Kind: "SCOPE.Operation", SourceFile: "src/p.controller.ts", StartLine: 1},
+		{ID: "spec", Name: "GET /counts", Kind: "SCOPE.Operation", SourceFile: "test/contract/p.contract.spec.ts"},
+	}
+	rels := []Relationship{
+		{ID: "t1", FromID: "spec", ToID: "h", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	if report.CoveredProduction != 0 {
+		t.Errorf("reach CoveredProduction want 0 (contract spec only), got %d", report.CoveredProduction)
+	}
+	if report.ContractCoveredOnly != 1 {
+		t.Errorf("ContractCoveredOnly want 1, got %d", report.ContractCoveredOnly)
+	}
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1834,6 +1834,15 @@ export interface UncoveredEntity {
   repo?: string;
   /** "high" | "medium" | "low". */
   severity: string;
+  /**
+   * Coverage state (#4662). For entities in the (not-reach-covered) uncovered
+   * list this is either:
+   *   "contract-only" — an offline contract spec asserts this endpoint's shape,
+   *                     but no test calls it. NOT dangerously untested.
+   *   "uncovered"     — neither reach-covered nor contract-covered.
+   * Reach-covered entities never appear here. Absent on older backends.
+   */
+  state?: "reach" | "contract-only" | "uncovered";
 }
 
 /** Per-directory coverage statistics. */
@@ -1841,6 +1850,8 @@ export interface DirCoverage {
   dir: string;
   total: number;
   covered: number;
+  /** Entities that are contract-covered-only (shape-asserted, not executed) (#4662). */
+  contract_only?: number;
   coverage_pct: number;
 }
 
@@ -1850,6 +1861,8 @@ export interface FileCoverage {
   dir: string;
   total: number;
   covered: number;
+  /** Entities that are contract-covered-only (shape-asserted, not executed) (#4662). */
+  contract_only?: number;
   coverage_pct: number;
 }
 
@@ -1879,6 +1892,15 @@ export interface GroupCoverageReport {
   total_production: number;
   covered_production: number;
   coverage_pct: number;
+  /**
+   * Secondary contract-covered band (#4662). `contract_covered_only` counts
+   * endpoints whose shape an offline contract spec asserts but which no test
+   * executes; `contract_covered_pct` is the union (reach + contract-only) band.
+   * Neither is folded into `coverage_pct`, which stays pure reach-coverage.
+   * Absent on older backends.
+   */
+  contract_covered_only?: number;
+  contract_covered_pct?: number;
   total_tests: number;
   total_tests_edges: number;
   repos: number;

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -40,6 +40,7 @@ import {
   Folder,
   FolderOpen,
   FileCode2,
+  FileText,
   Box,
   Braces,
   Hexagon,
@@ -246,17 +247,71 @@ function CoverageBar({ pct }: { pct: number }) {
   );
 }
 
+/**
+ * TwoBandCoverageBar renders REACH coverage (executed by a test) as the solid
+ * primary band and, behind it, the CONTRACT-covered-only slice (shape-asserted
+ * offline but never executed) as a hatched secondary band (#4662). The two are
+ * honestly distinct: reach is the headline %, contract-only is the extra slice
+ * an offline contract spec asserts the shape of without calling the handler.
+ */
+function TwoBandCoverageBar({
+  reachPct,
+  contractPct,
+}: {
+  reachPct: number;
+  contractPct: number;
+}) {
+  const tone =
+    reachPct >= 80 ? "bg-success" : reachPct >= 50 ? "bg-warning" : "bg-danger";
+  // The contract band is the extra width beyond reach (the union minus reach),
+  // clamped so the two never exceed 100%.
+  const reachW = Math.min(reachPct, 100);
+  const contractW = Math.max(0, Math.min(contractPct, 100) - reachW);
+  return (
+    <div
+      className="relative h-2 w-full rounded-full overflow-hidden bg-surface-2 border border-border"
+      role="img"
+      aria-label={`${reachPct.toFixed(0)}% reach-covered, ${contractPct.toFixed(0)}% including contract-covered`}
+    >
+      {/* secondary contract-covered band (hatched, behind, starts after reach) */}
+      {contractW > 0 && (
+        <div
+          className="absolute inset-y-0 bg-info/40"
+          style={{
+            left: `${reachW}%`,
+            width: `${contractW}%`,
+            backgroundImage:
+              "repeating-linear-gradient(45deg, transparent, transparent 3px, rgba(255,255,255,0.25) 3px, rgba(255,255,255,0.25) 6px)",
+          }}
+        />
+      )}
+      {/* primary reach band (solid) */}
+      <div
+        className={cn("absolute inset-y-0 left-0 transition-all", tone)}
+        style={{ width: `${reachW}%` }}
+      />
+    </div>
+  );
+}
+
 function CoverageGauge({
   covered,
   total,
   pct,
   totalTests,
+  contractOnly,
+  contractPct,
 }: {
   covered: number;
   total: number;
   pct: number;
   totalTests: number;
+  /** Endpoints shape-asserted by an offline contract spec but not executed (#4662). */
+  contractOnly: number;
+  /** Union (reach + contract-only) % — drives the secondary band (#4662). */
+  contractPct: number;
 }) {
+  const trulyUncovered = Math.max(0, total - covered - contractOnly);
   return (
     <Card>
       <CardHeader className="flex items-center justify-between">
@@ -265,10 +320,17 @@ function CoverageGauge({
           <MetricInfo
             hint={
               <>
-                <strong>Test coverage</strong> = % of production entities reached
-                by at least one TESTS edge (covered ÷ production entities). Measures
-                how much of the indexed code a test exercises structurally, not
+                <strong>Reach coverage</strong> = % of production entities a test
+                actually <em>executes</em> (a test CALLS the handler), covered ÷
+                production entities. This is the headline figure — structural, not
                 line coverage. Goal 80%+.
+                <br />
+                <br />
+                <strong>Contract-covered</strong> (hatched band) = endpoints whose
+                shape an <em>offline contract spec asserts</em> but{" "}
+                <em>no test calls</em>. These are not dangerously untested; they
+                are shape-verified offline. The band is shown behind reach so the
+                gap between "executed" and "shape-asserted" is honest and visible.
               </>
             }
           />
@@ -278,13 +340,22 @@ function CoverageGauge({
         </span>
       </CardHeader>
       <CardBody className="space-y-3">
-        <CoverageBar pct={pct} />
+        <TwoBandCoverageBar reachPct={pct} contractPct={contractPct} />
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-md">
           <span className="flex items-center gap-1.5 text-text-2">
             <CheckCircle2 size={13} className="text-success" />
-            {covered} covered
+            {covered} reach-covered
           </span>
-          <span className="text-text-2">{total - covered} uncovered</span>
+          {contractOnly > 0 && (
+            <span
+              className="flex items-center gap-1.5 text-text-2"
+              title="An offline contract spec asserts these endpoints' shape, but no test calls them."
+            >
+              <FileText size={13} className="text-info" />
+              {contractOnly} contract-covered ({contractPct.toFixed(1)}% incl.)
+            </span>
+          )}
+          <span className="text-text-2">{trulyUncovered} uncovered</span>
           <span className="text-text-4">· {total} production entities</span>
           <span className="text-text-4">· {totalTests} tests</span>
         </div>
@@ -488,6 +559,15 @@ function UncoveredLeafRow({
       <span className="font-mono text-xs text-text-2 truncate min-w-0 flex-1" title={u.name}>
         {u.name}
       </span>
+      {u.state === "contract-only" && (
+        <span
+          className="shrink-0 inline-flex items-center gap-0.5 rounded px-1 py-px text-[9px] font-medium uppercase tracking-wide text-info bg-info/10"
+          title="An offline contract spec asserts this endpoint's shape, but no test calls it."
+        >
+          <FileText size={9} />
+          contract
+        </span>
+      )}
       <span
         className={cn("h-1.5 w-1.5 rounded-full shrink-0", COV_SEVERITY_DOT[u.severity] ?? "bg-text-4")}
         title={`${u.severity} severity`}
@@ -672,6 +752,16 @@ function UncoveredRow({ u, repo }: { u: UncoveredEntity; repo: string }) {
           {u.name}
         </span>
         <div className="ml-auto flex items-center gap-1.5 shrink-0">
+          {u.state === "contract-only" && (
+            <Badge
+              tone="info"
+              className="shrink-0 inline-flex items-center gap-0.5"
+              title="An offline contract spec asserts this endpoint's shape, but no test calls it."
+            >
+              <FileText size={11} />
+              contract-covered
+            </Badge>
+          )}
           <Badge tone="neutral" className="shrink-0">
             {u.kind}
           </Badge>
@@ -754,6 +844,8 @@ function CoverageTab({ groupId }: { groupId: string }) {
         total={data.total_production}
         pct={data.coverage_pct}
         totalTests={data.total_tests}
+        contractOnly={data.contract_covered_only ?? 0}
+        contractPct={data.contract_covered_pct ?? data.coverage_pct}
       />
 
       {(data.by_directory?.length ?? 0) > 0 && (
@@ -1395,19 +1487,23 @@ const QUALITY_INSIGHTS: Record<QualityTab, InsightValue> = {
     storageKey: "quality.coverage",
     human: (
       <>
-        Structural test coverage — which production entities (functions,
-        classes, endpoints) are reached by a test via a{" "}
+        Structural test coverage in two honest bands. The headline{" "}
+        <strong>reach coverage</strong> = which production entities a test
+        actually executes (a test CALLS the handler) via a{" "}
         <DefTerm
-          term="TESTS edge"
-          def="A graph edge linking a test entity to the production entity it exercises. Coverage here is reachability over these edges, not executed-line coverage."
+          term="TESTS/CALLS edge"
+          def="A graph edge linking a test entity to the production entity it executes. Reach coverage is reachability over these edges, not executed-line coverage."
         />
-        . This is graph reachability, not line coverage.
+        . The secondary <strong>contract-covered</strong> band marks endpoints
+        whose shape an offline contract spec asserts but which no test calls —
+        shape-verified, not dangerously untested. This is graph reachability,
+        not line coverage.
       </>
     ),
     agent: {
       tool: "archigraph_test_coverage",
       example:
-        "Before writing tests for a payments module, an agent calls archigraph_test_coverage to list production endpoints with no inbound TESTS edge, then generates tests targeting exactly those gaps instead of duplicating existing ones.",
+        "Before writing tests for a payments module, an agent calls archigraph_test_coverage to list endpoints with no reach-coverage, distinguishes the contract-covered-only ones (shape already asserted offline) from the truly uncovered, and generates execution tests targeting exactly the real gaps instead of duplicating existing contract specs.",
     },
   },
   dependencies: {


### PR DESCRIPTION
## What & why
Follow-on to #4671 (which made reach-coverage honest). upvate-v3's dominant tests are OFFLINE contract specs (`test/contract/*.contract.spec.ts`) that assert an endpoint's oracle-derived request/response shape but never call the handler — so they correctly produce no execution edge. Under pure reach-coverage those endpoints read as "dangerously untested". This PR adds a separate, honest **contract-covered** band so they read as "shape-asserted offline, not executed".

## Three-state classification
Per production entity:
- **reach** — a test executes the handler (CALLS / executing TESTS edge / endpoint credited via a reached handler). Headline %.
- **contract-only** — an offline contract spec references the endpoint's route (asserts its shape) but nothing executes it.
- **uncovered** — neither.

## How contract-reference is detected WITHOUT an execution edge
- `isContractSpecFile` flags offline contract specs framework-agnostically: `/contract/` & `/pact/` path segments, or `*.contract.spec.*` / `*.pact.*` base-name infixes. A plain `*.spec.ts` is NOT a contract spec.
- A `TESTS`/`REFERENCES` edge **from a contract-spec test entity** is treated as a route REFERENCE (shape assertion), routed into a separate `contractRef` map and **never** into the reach `covered` map — so the headline reach % is never inflated.
- `creditContractRefViaHandlers` propagates a contract reference one hop along `IMPLEMENTS`/`ROUTES_TO`/`SERVES`.
- `contractCoveredOnly = contractRef AND NOT reach-covered`.

## Payload (separate band)
`contract_covered_only` + `contract_covered_pct` on the report; per-file/dir `contract_only` counts; `UncoveredEntity.State`; `ComputeEntityCoverage` gains `State` + `ContractCovered`.

## UI band
`TwoBandCoverageBar` renders reach (solid) with the contract-covered slice as a hatched secondary band behind it. Plain-language legend; per-entity rows tag the contract-only state; InsightButton framing updated to the two-band model.

## Fixtures
- `TestComputeCoverage_ThreeStateBands` — unit-spec CALL → reach; offline-contract route-ref → contract-only; neither → uncovered; reach % excludes contract endpoints; single-entity path agrees.
- `TestComputeCoverage_ContractSpecNeverInflatesReach` — contract-spec TESTS edge → reach=0, contract-only=1.
- `TestIsContractSpecFile`.

## Gates
- `go build` / `go vet` / `go test` (graph + dashboard) — green.
- `coverage fmt --check` + `coverage validate` — 0 errors; registry.json unchanged (language-agnostic reporting change, no new tracked extraction capability).
- `npx tsc --noEmit` + `npx vite build` — green.

Coordinator live-validates on upvate-v3 at next deploy.

Closes #4662

🤖 Generated with [Claude Code](https://claude.com/claude-code)