### PR TITLE
fix(uninstall): keep binary by default; --remove-binary opt-in (so reinstall works) (#4478)

### DIFF
--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -65,19 +65,24 @@ func newUninstallCmd() *cobra.Command {
 		claudeConfigDirs []string
 		skipSkillUnlink  bool
 		purge            bool
+		removeBinary     bool
 		yes              bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Remove the archigraph install (daemon, MCP, skills)",
-		Long: `Uninstall removes the archigraph install:
+		Long: `Uninstall tears down the archigraph install:
 
   - Removes copied/linked skills from ~/.claude/skills/ (only those in install.json)
   - Deregisters the archigraph MCP entry from all detected .claude.json files
-  - Stops the archigraph daemon (OS service)
-  - Removes the CLI binary (with confirmation unless --yes)
-  - Removes ~/.archigraph/install.json
+  - Stops the daemon and removes its OS service unit (launchd/systemd/schtasks),
+    socket, and pidfile
+
+Default: leaves the installed CLI binary in place so a subsequent
+'archigraph install'/'archigraph start' works without re-downloading or
+rebuilding it. Use --remove-binary to also delete the binary (with
+confirmation unless --yes).
 
 Default: leaves ~/.archigraph/store/ (your graphs) intact.
 Use --purge to also remove store/ and docs/.
@@ -91,8 +96,9 @@ Idempotent: if archigraph is not installed the command exits 0.`,
 			// no install.json — in that case all fields are zero and we fall through
 			// to the legacy path.
 			result, err := install.RunUninstall(install.UninstallOptions{
-				Purge: purge,
-				Yes:   yes,
+				Purge:        purge,
+				RemoveBinary: removeBinary,
+				Yes:          yes,
 			})
 			if err != nil {
 				return fmt.Errorf("uninstall: %w", err)
@@ -149,7 +155,9 @@ Idempotent: if archigraph is not installed the command exits 0.`,
 		"skip removing skills from Claude Code's skills/ directories")
 	cmd.Flags().BoolVar(&purge, "purge", false,
 		"also remove ~/.archigraph/store/ and ~/.archigraph/docs/ (user graphs and docs)")
+	cmd.Flags().BoolVar(&removeBinary, "remove-binary", false,
+		"also delete the installed CLI binary (default: keep it so a reinstall/start needs no re-download)")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false,
-		"assume yes / non-interactive: skip the binary-removal confirmation prompt (auto-enabled when stdin is not a TTY)")
+		"assume yes / non-interactive: skip the binary-removal confirmation prompt for --remove-binary (auto-enabled when stdin is not a TTY)")
 	return cmd
 }

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -4,8 +4,12 @@
 //  1. Read install.json for the list of owned skills and MCP paths.
 //  2. Remove copied/linked skills from ~/.claude/skills/<name>/ (only those in install.json).
 //  3. Deregister archigraph from MCP in every registered .claude.json.
-//  4. Stop the daemon gracefully via service.Uninstall.
-//  5. Remove the CLI binary (with confirmation prompt unless --yes).
+//  4. Stop the daemon and tear down the OS service (launchd/systemd/schtasks
+//     unit, socket, pidfile) via service.Uninstall.
+//  5. Default: leave the installed CLI binary in place so a subsequent
+//     install/start works without re-downloading or rebuilding (#4478).
+//     --remove-binary: also remove the CLI binary (with confirmation prompt
+//     unless --yes).
 //  6. Remove ~/.archigraph/install.json.
 //  7. Default: leave ~/.archigraph/store/ intact.
 //     --purge: also remove ~/.archigraph/store/ and ~/.archigraph/docs/.
@@ -36,7 +40,15 @@ type UninstallOptions struct {
 	// ~/.archigraph/docs/ in addition to the install artifacts.
 	Purge bool
 
+	// RemoveBinary, when true, removes the installed CLI binary as part of
+	// uninstall. The default (false) leaves the binary in place so a
+	// subsequent `install`/`start` works without re-downloading or
+	// rebuilding it (#4478). Service artifacts (unit/socket/pidfile) are torn
+	// down regardless of this flag.
+	RemoveBinary bool
+
 	// Yes skips the confirmation prompt before removing the CLI binary.
+	// It only has an effect when RemoveBinary is true.
 	Yes bool
 
 	// DryRun prints actions without writing anything.
@@ -184,8 +196,10 @@ func RunUninstall(opts UninstallOptions) (*UninstallResult, error) {
 		result.DaemonStopped = opts.DryRun
 	}
 
-	// ── Step 4: Remove CLI binary (with confirmation) ─────────────────────────
-	if state.CLI.Path != "" {
+	// ── Step 4: Remove CLI binary (opt-in, with confirmation) ─────────────────
+	// By default the binary is KEPT so a subsequent install/start works without
+	// re-downloading or rebuilding (#4478). Only --remove-binary deletes it.
+	if opts.RemoveBinary && state.CLI.Path != "" {
 		if _, err := os.Stat(state.CLI.Path); err == nil {
 			removeIt := opts.Yes || opts.DryRun
 			if !removeIt {

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -40,9 +40,10 @@ func TestRunUninstall_HappyPath(t *testing.T) {
 		}
 	}
 
-	// Run uninstall.
+	// Run uninstall (explicit --remove-binary to exercise the removal path).
 	result, err := install.RunUninstall(install.UninstallOptions{
 		StatePath:      env.statePath,
+		RemoveBinary:   true,
 		Yes:            true, // skip confirmation
 		SkipDaemonStop: true,
 	})
@@ -224,6 +225,7 @@ func TestRunUninstall_ConfirmNo(t *testing.T) {
 	// Inject a "No" confirmation.
 	result, err := install.RunUninstall(install.UninstallOptions{
 		StatePath:      env.statePath,
+		RemoveBinary:   true,
 		Yes:            false,
 		SkipDaemonStop: true,
 		ConfirmFn: func(string) (bool, error) {
@@ -277,6 +279,7 @@ func TestRunUninstall_NonTTYAutoYes(t *testing.T) {
 
 	result, err := install.RunUninstall(install.UninstallOptions{
 		StatePath:      env.statePath,
+		RemoveBinary:   true,
 		SkipDaemonStop: true,
 	})
 	if err != nil {
@@ -287,6 +290,186 @@ func TestRunUninstall_NonTTYAutoYes(t *testing.T) {
 	}
 	if _, err := os.Stat(env.fakeBin); err == nil {
 		t.Error("binary should be removed under non-interactive auto-yes")
+	}
+}
+
+// TestRunUninstall_KeepsBinaryByDefault is the core #4478 regression test:
+// a default uninstall (and --yes) tears down the service/install state but
+// LEAVES the CLI binary on disk, so a subsequent install/start needs no
+// re-download or rebuild. It models a faked install layout in temp dirs and
+// asserts the binary file survives while the service unit/socket/pidfile and
+// install.json are gone.
+func TestRunUninstall_KeepsBinaryByDefault(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Simulate the service artifacts that a real install would have created.
+	// service.Uninstall (which actually removes these) is OS-permission gated,
+	// so the unit test stands them up as plain files and removes them here to
+	// model the desired post-uninstall state: artifacts gone, binary present.
+	svcDir := t.TempDir()
+	unitFile := filepath.Join(svcDir, "com.archigraph.daemon.plist")
+	socketFile := filepath.Join(svcDir, "daemon.sock")
+	pidFile := filepath.Join(svcDir, "daemon.pid")
+	for _, p := range []string{unitFile, socketFile, pidFile} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("create service artifact %s: %v", p, err)
+		}
+	}
+
+	if _, err := install.RunCopy(install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	}); err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+
+	// Default uninstall (no --remove-binary) with --yes.
+	result, err := install.RunUninstall(install.UninstallOptions{
+		StatePath:      env.statePath,
+		Yes:            true,
+		SkipDaemonStop: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUninstall: %v", err)
+	}
+
+	// Model the service teardown that service.Uninstall performs in production.
+	for _, p := range []string{unitFile, socketFile, pidFile} {
+		_ = os.Remove(p)
+	}
+
+	// Binary must survive a default uninstall — this is the #4478 fix.
+	if result.BinaryRemoved {
+		t.Error("BinaryRemoved should be false by default (#4478)")
+	}
+	if _, err := os.Stat(env.fakeBin); err != nil {
+		t.Errorf("CLI binary should still exist after default uninstall: %v", err)
+	}
+
+	// Service artifacts must be gone (unit/socket/pidfile).
+	for _, p := range []string{unitFile, socketFile, pidFile} {
+		if _, err := os.Stat(p); err == nil {
+			t.Errorf("service artifact %s should be gone after uninstall", p)
+		}
+	}
+
+	// install.json must be gone.
+	if !result.StateRemoved {
+		t.Error("StateRemoved should be true")
+	}
+	if _, err := os.Stat(env.statePath); err == nil {
+		t.Error("install.json still exists after uninstall")
+	}
+}
+
+// TestRunUninstall_RemoveBinaryFlag verifies that --remove-binary additionally
+// deletes the CLI binary.
+func TestRunUninstall_RemoveBinaryFlag(t *testing.T) {
+	env := newTestEnv(t)
+
+	if _, err := install.RunCopy(install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	}); err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+
+	result, err := install.RunUninstall(install.UninstallOptions{
+		StatePath:      env.statePath,
+		RemoveBinary:   true,
+		Yes:            true,
+		SkipDaemonStop: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUninstall --remove-binary: %v", err)
+	}
+
+	if !result.BinaryRemoved {
+		t.Error("BinaryRemoved should be true with --remove-binary")
+	}
+	if _, err := os.Stat(env.fakeBin); err == nil {
+		t.Error("CLI binary should be removed with --remove-binary")
+	}
+}
+
+// TestRunUninstall_ReinstallAfterUninstall verifies the release-blocker path
+// (#4457): a default uninstall followed by a fresh install succeeds and leaves
+// consistent state — no stale install.json from the first run, binary still
+// present (so install does not need to re-download/rebuild), and skills/MCP
+// re-registered.
+func TestRunUninstall_ReinstallAfterUninstall(t *testing.T) {
+	env := newTestEnv(t)
+
+	copyOpts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	}
+
+	// 1. Install.
+	if _, err := install.RunCopy(copyOpts); err != nil {
+		t.Fatalf("first RunCopy: %v", err)
+	}
+
+	// 2. Default uninstall (keeps binary).
+	if _, err := install.RunUninstall(install.UninstallOptions{
+		StatePath:      env.statePath,
+		Yes:            true,
+		SkipDaemonStop: true,
+	}); err != nil {
+		t.Fatalf("RunUninstall: %v", err)
+	}
+
+	// install.json must be gone, binary must still be present — a reinstall
+	// must not need to re-fetch the binary.
+	if _, err := os.Stat(env.statePath); err == nil {
+		t.Fatal("install.json should be gone after uninstall")
+	}
+	if _, err := os.Stat(env.fakeBin); err != nil {
+		t.Fatalf("binary must survive uninstall so reinstall works: %v", err)
+	}
+
+	// 3. Reinstall — should succeed cleanly with no leftover/partial state and
+	// without --force (no stale install.json blocking it). RunCopy returns a
+	// non-nil result + nil error only on a fully-applied install; on failure it
+	// rolls back and returns an error.
+	if _, err := install.RunCopy(copyOpts); err != nil {
+		t.Fatalf("reinstall after uninstall: %v", err)
+	}
+
+	// Fresh install.json present and not flagged partial/rolled-back.
+	if _, err := os.Stat(env.statePath); err != nil {
+		t.Errorf("install.json should exist after reinstall: %v", err)
+	}
+	reState, err := install.ReadState(env.statePath)
+	if err != nil {
+		t.Fatalf("ReadState after reinstall: %v", err)
+	}
+	if reState == nil {
+		t.Fatal("install.json missing after reinstall")
+	}
+	if reState.PartialInstall {
+		t.Error("reinstall produced a partial install state")
+	}
+	if reState.RollbackFromStep != 0 {
+		t.Errorf("reinstall rolled back from step %d", reState.RollbackFromStep)
+	}
+	destSkillsDir := filepath.Join(filepath.Dir(env.claudeJSON), "skills")
+	for _, name := range skilllink.SkillNames {
+		if _, err := os.Stat(filepath.Join(destSkillsDir, name)); err != nil {
+			t.Errorf("skill %s should be present after reinstall: %v", name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #4478 (release-blocker, epic #4457). `uninstall`/`uninstall --yes` now tears down only the service (daemon stop + launchd/systemd/schtasks unit + socket + pidfile via the cross-platform ServiceManager) and LEAVES the installed binary in place, so a subsequent install/start works without re-fetch. Binary deletion is opt-in via new `--remove-binary`. Unit tests: keeps-binary-by-default, remove-binary-flag, reinstall-after-uninstall consistent. Gates green (build/vet/test on cmd+daemon+install+cli). Live uninstall/reinstall validation deferred (authorization-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)