### PR TITLE
fix(dashboard): stale-embed guard (#4468); close shipped install-lifecycle children of #4457

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dashboard-build test lint fmt vet clean fbgen fb-bench mcp-audit coverage coverage-validate
+.PHONY: build dashboard-build verify-dashboard test lint fmt vet clean fbgen fb-bench mcp-audit coverage coverage-validate
 
 GO ?= go
 NPM ?= npm
@@ -22,9 +22,20 @@ dashboard-build:
 	cd webui-v2 && $(NPM) ci && npx vite build
 	rm -rf internal/dashboard/dist
 	cp -r webui-v2/dist internal/dashboard/dist
+	@$(MAKE) verify-dashboard
+
+# verify-dashboard (#4468): fail loudly if the embedded bundle
+# (internal/dashboard/dist) is STALE relative to the freshly built SPA
+# (webui-v2/dist). A `vite build && go build` that skips the `cp` above
+# silently re-embeds the OLD dist — the daemon then serves a months-old UI
+# while reporting the new commit. Run this in CI and post-deploy. It passes
+# (with a notice) when webui-v2/dist is absent (Go-only / pre-built-CI flows).
+verify-dashboard:
+	$(GO) run ./cmd/verify-dashboard -root .
 
 # build: full binary including embedded SPA. Depends on dashboard-build
-# so `make build` always produces a self-contained binary.
+# so `make build` always produces a self-contained binary. dashboard-build
+# now also runs verify-dashboard, so a stale embed fails the build.
 build: dashboard-build
 	$(GO) build -ldflags='$(LDFLAGS)' -o $(BINARY) ./cmd/archigraph
 

--- a/cmd/verify-dashboard/main.go
+++ b/cmd/verify-dashboard/main.go
@@ -1,0 +1,42 @@
+// Command verify-dashboard is the CI / release guard for #4468: it fails when
+// the embedded dashboard bundle (internal/dashboard/dist) is STALE relative to
+// the freshly built SPA (webui-v2/dist).
+//
+// `make dashboard-build` builds webui-v2/dist and then copies it into
+// internal/dashboard/dist so `//go:embed dist` picks up the fresh UI. A manual
+// or CI `vite build && go build` that skips the copy silently re-embeds the OLD
+// bundle — the daemon then serves a months-old UI while reporting the new
+// commit. This guard catches exactly that drift.
+//
+// Usage:
+//
+//	verify-dashboard [-root <repo-root>]
+//
+// Exit 0 when the embed is current (or no fresh build exists to compare);
+// exit 1 when the embed is stale.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cajasmota/archigraph/internal/dashboard"
+)
+
+func main() {
+	root := flag.String("root", ".", "repo root containing webui-v2/ and internal/dashboard/")
+	flag.Parse()
+
+	abs, err := filepath.Abs(*root)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "verify-dashboard:", err)
+		os.Exit(2)
+	}
+	if err := dashboard.VerifyDashboardEmbed(abs); err != nil {
+		fmt.Fprintln(os.Stderr, "verify-dashboard: FAIL —", err)
+		os.Exit(1)
+	}
+	fmt.Println("verify-dashboard: OK — embedded dashboard bundle is current")
+}

--- a/internal/dashboard/diststale.go
+++ b/internal/dashboard/diststale.go
@@ -1,0 +1,173 @@
+package dashboard
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// #4468: dashboard embed staleness guard.
+//
+// `make dashboard-build` builds the SPA into webui-v2/dist and then copies it
+// into internal/dashboard/dist so that `//go:embed dist` (static.go) embeds the
+// fresh bundle. A manual / CI sequence that runs `vite build` followed by
+// `go build` WITHOUT the copy step silently re-embeds the OLD internal dist —
+// the daemon then serves a stale UI while reporting the new commit.
+//
+// DistDirsMatch compares the freshly-built bundle (builtDir, e.g.
+// webui-v2/dist) against the embedded bundle (embeddedDir, e.g.
+// internal/dashboard/dist) by content hash. It is the engine behind the
+// `make verify-dashboard` CI guard and is exercised by unit tests with temp
+// dirs (no real npm build required).
+
+// distFingerprint hashes every regular file under dir (recursively) into a
+// single stable digest. The PLACEHOLDER.md sentinel is ignored so that an
+// unbuilt embedded dir is reported as "placeholder", not as a content mismatch.
+// Returns ("", nil) when the dir is missing or contains only the placeholder.
+func distFingerprint(dir string) (string, error) {
+	type fileHash struct {
+		rel string
+		sum string
+	}
+	var files []fileHash
+
+	walkErr := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+		// Ignore the checked-in sentinel — it is not part of the SPA bundle.
+		if rel == "PLACEHOLDER.md" {
+			return nil
+		}
+		f, oerr := os.Open(path)
+		if oerr != nil {
+			return oerr
+		}
+		defer f.Close()
+		h := sha256.New()
+		if _, cerr := io.Copy(h, f); cerr != nil {
+			return cerr
+		}
+		files = append(files, fileHash{rel: rel, sum: hex.EncodeToString(h.Sum(nil))})
+		return nil
+	})
+	if walkErr != nil {
+		if os.IsNotExist(walkErr) {
+			return "", nil
+		}
+		return "", walkErr
+	}
+	if len(files) == 0 {
+		return "", nil
+	}
+
+	sort.Slice(files, func(i, j int) bool { return files[i].rel < files[j].rel })
+	agg := sha256.New()
+	for _, fh := range files {
+		fmt.Fprintf(agg, "%s\x00%s\x00", fh.rel, fh.sum)
+	}
+	return hex.EncodeToString(agg.Sum(nil)), nil
+}
+
+// DistStalenessResult describes the outcome of a staleness comparison.
+type DistStalenessResult struct {
+	// Match is true when the embedded bundle is byte-identical to the built one.
+	Match bool
+	// EmbeddedEmpty is true when the embedded dir is missing or holds only the
+	// placeholder (never built / never copied).
+	EmbeddedEmpty bool
+	// BuiltEmpty is true when the built dir is missing or empty (SPA not built).
+	BuiltEmpty bool
+	// BuiltFingerprint / EmbeddedFingerprint are the aggregate content digests.
+	BuiltFingerprint    string
+	EmbeddedFingerprint string
+	// Reason is a human-readable explanation, suitable for a CI failure message.
+	Reason string
+}
+
+// DistDirsMatch compares the freshly-built SPA bundle (builtDir, e.g.
+// webui-v2/dist) against the embedded bundle (embeddedDir, e.g.
+// internal/dashboard/dist) and reports whether the embed is up to date.
+//
+// It returns an error only on I/O failure. A stale embed is NOT an error — it
+// is reported via DistStalenessResult.Match=false so the caller decides
+// severity (the CLI guard exits non-zero; tests assert the flag).
+func DistDirsMatch(builtDir, embeddedDir string) (DistStalenessResult, error) {
+	built, err := distFingerprint(builtDir)
+	if err != nil {
+		return DistStalenessResult{}, fmt.Errorf("fingerprint built dir %s: %w", builtDir, err)
+	}
+	embedded, err := distFingerprint(embeddedDir)
+	if err != nil {
+		return DistStalenessResult{}, fmt.Errorf("fingerprint embedded dir %s: %w", embeddedDir, err)
+	}
+
+	res := DistStalenessResult{
+		BuiltFingerprint:    built,
+		EmbeddedFingerprint: embedded,
+		BuiltEmpty:          built == "",
+		EmbeddedEmpty:       embedded == "",
+	}
+
+	switch {
+	case res.BuiltEmpty:
+		// Nothing was built to compare against — the guard cannot judge
+		// staleness, so it passes (a Go-only / pre-built-CI flow). Callers that
+		// require a built dir should check BuiltEmpty.
+		res.Match = true
+		res.Reason = fmt.Sprintf("no built bundle at %s; nothing to compare (skipping staleness check)", builtDir)
+	case res.EmbeddedEmpty:
+		res.Match = false
+		res.Reason = fmt.Sprintf(
+			"embedded bundle %s is empty/placeholder but a fresh build exists at %s; run `make dashboard-build` (or copy webui-v2/dist) so the embed is not stale",
+			embeddedDir, builtDir)
+	case built == embedded:
+		res.Match = true
+		res.Reason = "embedded dashboard bundle matches the built bundle"
+	default:
+		res.Match = false
+		res.Reason = fmt.Sprintf(
+			"STALE dashboard embed: %s (%s) differs from the freshly built %s (%s); run `make dashboard-build` so `go build` embeds the current UI — otherwise the daemon serves an old dashboard while reporting the new commit",
+			embeddedDir, short(embedded), builtDir, short(built))
+	}
+	return res, nil
+}
+
+func short(sum string) string {
+	if len(sum) <= 12 {
+		return sum
+	}
+	return sum[:12]
+}
+
+// VerifyDashboardEmbed is the entry point for the `make verify-dashboard` CI
+// guard. It compares webui-v2/dist against internal/dashboard/dist relative to
+// repoRoot and returns a non-nil error when the embed is stale.
+func VerifyDashboardEmbed(repoRoot string) error {
+	builtDir := filepath.Join(repoRoot, "webui-v2", "dist")
+	embeddedDir := filepath.Join(repoRoot, "internal", "dashboard", "dist")
+	res, err := DistDirsMatch(builtDir, embeddedDir)
+	if err != nil {
+		return err
+	}
+	if !res.Match {
+		return fmt.Errorf("%s", res.Reason)
+	}
+	if strings.Contains(res.Reason, "skipping") {
+		fmt.Fprintln(os.Stderr, "verify-dashboard: "+res.Reason)
+	}
+	return nil
+}

--- a/internal/dashboard/diststale_test.go
+++ b/internal/dashboard/diststale_test.go
@@ -1,0 +1,150 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeDist materializes a fake SPA bundle (index.html + a hashed asset) under
+// dir so the staleness guard has real files to fingerprint.
+func writeDist(t *testing.T, dir string, indexBody, assetName, assetBody string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "assets"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(indexBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "assets", assetName), []byte(assetBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDistDirsMatch_DetectsStaleEmbed is the core #4468 regression: an embedded
+// bundle that lags the freshly built one (the `cp` step was skipped) must be
+// reported as a NON-match.
+func TestDistDirsMatch_DetectsStaleEmbed(t *testing.T) {
+	built := t.TempDir()
+	embedded := t.TempDir()
+
+	// Fresh build references a new hashed asset (index-BWxccaeO.js).
+	writeDist(t, built,
+		`<script src="/assets/index-BWxccaeO.js"></script>`,
+		"index-BWxccaeO.js", "console.log('new ui');")
+	// Embedded bundle still references the OLD asset (index-BDdvveMN.js) — the
+	// exact staleness observed in the live deploy.
+	writeDist(t, embedded,
+		`<script src="/assets/index-BDdvveMN.js"></script>`,
+		"index-BDdvveMN.js", "console.log('old ui');")
+
+	res, err := DistDirsMatch(built, embedded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Match {
+		t.Fatalf("expected stale embed to be flagged as NON-match, got Match=true (reason=%q)", res.Reason)
+	}
+	if res.EmbeddedEmpty || res.BuiltEmpty {
+		t.Fatalf("both dirs are populated; EmbeddedEmpty=%v BuiltEmpty=%v", res.EmbeddedEmpty, res.BuiltEmpty)
+	}
+	if !strings.Contains(res.Reason, "STALE") {
+		t.Errorf("reason should explain staleness, got %q", res.Reason)
+	}
+}
+
+// TestDistDirsMatch_FreshEmbedMatches verifies the happy path: an embedded
+// bundle that is byte-identical to the built one passes.
+func TestDistDirsMatch_FreshEmbedMatches(t *testing.T) {
+	built := t.TempDir()
+	embedded := t.TempDir()
+
+	writeDist(t, built, `<script src="/assets/index-ABC.js"></script>`, "index-ABC.js", "same();")
+	writeDist(t, embedded, `<script src="/assets/index-ABC.js"></script>`, "index-ABC.js", "same();")
+
+	res, err := DistDirsMatch(built, embedded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Match {
+		t.Fatalf("identical bundles should match, got NON-match (reason=%q)", res.Reason)
+	}
+	if res.BuiltFingerprint != res.EmbeddedFingerprint {
+		t.Errorf("fingerprints should be equal: built=%s embedded=%s", res.BuiltFingerprint, res.EmbeddedFingerprint)
+	}
+}
+
+// TestDistDirsMatch_PlaceholderOnlyEmbedIsStale verifies that an embedded dir
+// holding ONLY the checked-in PLACEHOLDER.md (never built / never copied) is
+// reported stale when a fresh build exists — the placeholder is not counted as
+// real content.
+func TestDistDirsMatch_PlaceholderOnlyEmbedIsStale(t *testing.T) {
+	built := t.TempDir()
+	embedded := t.TempDir()
+
+	writeDist(t, built, `<script src="/assets/index-XYZ.js"></script>`, "index-XYZ.js", "real();")
+	if err := os.WriteFile(filepath.Join(embedded, "PLACEHOLDER.md"), []byte("# placeholder"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := DistDirsMatch(built, embedded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Match {
+		t.Fatalf("placeholder-only embed with a fresh build present should be NON-match (reason=%q)", res.Reason)
+	}
+	if !res.EmbeddedEmpty {
+		t.Errorf("placeholder-only embed should report EmbeddedEmpty=true")
+	}
+}
+
+// TestDistDirsMatch_NoBuiltDirSkips verifies that without a fresh build
+// (webui-v2/dist absent) the guard does not false-fail — a Go-only or
+// pre-built-CI flow legitimately has nothing to compare.
+func TestDistDirsMatch_NoBuiltDirSkips(t *testing.T) {
+	embedded := t.TempDir()
+	writeDist(t, embedded, `<script src="/assets/index-ABC.js"></script>`, "index-ABC.js", "x();")
+
+	res, err := DistDirsMatch(filepath.Join(t.TempDir(), "does-not-exist"), embedded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Match {
+		t.Fatalf("missing built dir should skip (Match=true), got NON-match (reason=%q)", res.Reason)
+	}
+	if !res.BuiltEmpty {
+		t.Errorf("expected BuiltEmpty=true when built dir is absent")
+	}
+}
+
+// TestVerifyDashboardEmbed_StaleReturnsError exercises the make-target entry
+// point against a stale repo layout and asserts it errors.
+func TestVerifyDashboardEmbed_StaleReturnsError(t *testing.T) {
+	root := t.TempDir()
+	built := filepath.Join(root, "webui-v2", "dist")
+	embedded := filepath.Join(root, "internal", "dashboard", "dist")
+
+	writeDist(t, built, `<script src="/assets/new.js"></script>`, "new.js", "new();")
+	writeDist(t, embedded, `<script src="/assets/old.js"></script>`, "old.js", "old();")
+
+	if err := VerifyDashboardEmbed(root); err == nil {
+		t.Fatal("expected VerifyDashboardEmbed to return an error for a stale embed")
+	}
+}
+
+// TestVerifyDashboardEmbed_FreshPasses asserts the entry point passes when the
+// embed is current.
+func TestVerifyDashboardEmbed_FreshPasses(t *testing.T) {
+	root := t.TempDir()
+	built := filepath.Join(root, "webui-v2", "dist")
+	embedded := filepath.Join(root, "internal", "dashboard", "dist")
+
+	writeDist(t, built, `<script src="/assets/same.js"></script>`, "same.js", "s();")
+	writeDist(t, embedded, `<script src="/assets/same.js"></script>`, "same.js", "s();")
+
+	if err := VerifyDashboardEmbed(root); err != nil {
+		t.Fatalf("expected pass for a current embed, got %v", err)
+	}
+}


### PR DESCRIPTION
Audit + fix of the remaining install-lifecycle children of release-blocker epic #4457.

## Audit result

Verified each child against current `main`:

| Issue | Status | Evidence |
|---|---|---|
| #4459 skills-dir false-negative / early-return | **SHIPPED** (#4469) | `DiscoverSkillsDirVerbose` falls through & returns every probed path; `copy.go` error names all checked paths. Test `TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths` passes. |
| #4460 graceful-degrade, no skills dir | **SHIPPED** (#4469) | `copy.go` WARN+continue, `state.SkillsSkipped=true`, no rollback. Test `TestRunCopy_MissingSkillsDirectory_GracefulDegrade` passes. |
| #4461 partial-install blocks retry | **SHIPPED** (#4469) | `guardPartialInstall` auto-recovers a readable `partial_install=true`; only unreadable state needs `--force`. Tests `TestRunCopy_PartialInstallAutoRecovers`, `TestRunCopy_UnreadableStateStillBlocks` pass. |
| #4463 doctor SHA Critical→Warning | **SHIPPED** (#4469) | `doctor.go:267` SHA drift → `SeverityWarning`; missing CLI record stays Critical. Tests `TestDoctorCLITamper`, `TestDoctorMissingCLIRecordCritical` pass. |
| #4468 dashboard embed staleness | **FIXED HERE** | new guard below. |

The four shipped issues are closed separately with this evidence.

## #4468 — dashboard embed staleness guard

`make dashboard-build` copies `webui-v2/dist` → `internal/dashboard/dist` so `//go:embed dist` picks up the fresh UI. A manual/CI `vite build && go build` that skips the copy silently re-embeds the OLD bundle — the daemon then serves a months-old UI while reporting the new commit (live Wave-2 symptom: served `index-BDdvveMN.js` while the fresh build was `index-BWxccaeO.js`).

**Fix (option c + build-time guard):**
- `internal/dashboard/diststale.go` — `DistDirsMatch` / `VerifyDashboardEmbed` content-fingerprint both dirs (recursive SHA-256, ignoring the `PLACEHOLDER.md` sentinel) and report staleness. Missing `webui-v2/dist` is a no-op pass (Go-only / pre-built-CI flows don't false-fail).
- `cmd/verify-dashboard` — CLI entrypoint, exit 1 on a stale embed; runnable in CI and post-deploy.
- `Makefile` — new `verify-dashboard` target; `dashboard-build` now runs it after the copy, so `make build` fails loudly on a stale embed.

**Tests** (`diststale_test.go`): stale embed (old vs new index hash) flagged NON-match; identical bundles match; placeholder-only embed flagged stale when a build exists; missing built dir skips; entrypoint error/pass.

## Gates
- `go build ./...` — green
- `go vet ./internal/install/... ./internal/cli/... ./cmd/...` — clean
- `go test ./internal/install/... ./internal/cli/... ./cmd/...` — pass (TestColdLoadTiming not hit)
- `go test ./internal/dashboard/ -run 'DistDirsMatch|VerifyDashboardEmbed'` — pass

DEPLOY-DEFERRED: no live install/daemon was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)