### PR TITLE
fix(dashboard): emit [] not null for empty slice fields (root cause of null.length crashes) — #4516

### DIFF
--- a/internal/dashboard/handlers_coverage.go
+++ b/internal/dashboard/handlers_coverage.go
@@ -18,7 +18,6 @@ package dashboard
 //	limit=<n>      — cap UncoveredEntities to n items (default 200)
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -337,8 +336,5 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 		return result.ByModule[i].Module < result.ByModule[j].Module
 	})
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(result)
+	writeReportJSON(w, result)
 }

--- a/internal/dashboard/handlers_dataflow.go
+++ b/internal/dashboard/handlers_dataflow.go
@@ -479,10 +479,7 @@ func (s *Server) handleDataflow(w http.ResponseWriter, r *http.Request) {
 
 	report.ConfidenceFloor = dataflowConfidenceFloor
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(report)
+	writeReportJSON(w, report)
 }
 
 // dataflowConfidenceFloor mirrors links.TaintFindingFloor() — the taint pass

--- a/internal/dashboard/handlers_di.go
+++ b/internal/dashboard/handlers_di.go
@@ -43,7 +43,6 @@ package dashboard
 // state on the client.
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -399,8 +398,5 @@ func (s *Server) handleDI(w http.ResponseWriter, r *http.Request) {
 
 	report := acc.assemble(groupName)
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(report)
+	writeReportJSON(w, report)
 }

--- a/internal/dashboard/handlers_errorflow.go
+++ b/internal/dashboard/handlers_errorflow.go
@@ -52,7 +52,6 @@ package dashboard
 // empty `exceptions` list and a clean empty state on the client.
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -412,8 +411,5 @@ func (s *Server) handleErrorFlow(w http.ResponseWriter, r *http.Request) {
 
 	report := acc.assemble(groupName)
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(report)
+	writeReportJSON(w, report)
 }

--- a/internal/dashboard/handlers_graphql.go
+++ b/internal/dashboard/handlers_graphql.go
@@ -48,7 +48,6 @@ package dashboard
 // the sibling /api/security/* and /api/groups/* routes.
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -399,10 +398,7 @@ func (s *Server) handleGraphQL(w http.ResponseWriter, r *http.Request) {
 		return report.SchemaTypes[i].Name < report.SchemaTypes[j].Name
 	})
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(report)
+	writeReportJSON(w, report)
 }
 
 // firstNonEmpty returns the first non-empty string argument, or "" if none.

--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -56,7 +56,6 @@ package dashboard
 // relationships via the mmap reader when available; raw-JSON envelope.
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -794,8 +793,5 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Strings(report.Tools)
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(report)
+	writeReportJSON(w, report)
 }

--- a/internal/dashboard/handlers_nplus1.go
+++ b/internal/dashboard/handlers_nplus1.go
@@ -19,7 +19,6 @@ package dashboard
 // Wire format is JSON (application/json).
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -138,8 +137,5 @@ func (s *Server) handleNPlusOne(w http.ResponseWriter, r *http.Request) {
 
 	result.TotalFindings = len(result.Findings)
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(result)
+	writeReportJSON(w, result)
 }

--- a/internal/dashboard/handlers_security.go
+++ b/internal/dashboard/handlers_security.go
@@ -12,7 +12,6 @@ package dashboard
 // graph document, run the graph-package detector, aggregate, return JSON.
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -30,9 +29,9 @@ import (
 
 // AuthEndpointFinding is a single HTTP endpoint finding.
 type AuthEndpointFinding struct {
-	EntityID     string `json:"entity_id"`
-	Name         string `json:"name"`
-	Repo         string `json:"repo"`
+	EntityID string `json:"entity_id"`
+	Name     string `json:"name"`
+	Repo     string `json:"repo"`
 	// ModulePath is the monorepo module sub-path owning this finding's source
 	// file (#4698), derived from the repo's configured module roots. Empty for
 	// single-repo groups or files under no module root. Lets the scope selector
@@ -81,9 +80,9 @@ type GroupAuthCoverageReport struct {
 // SecuritySecretFinding is a single secret-related finding returned by
 // GET /api/security/secrets/{group}.
 type SecuritySecretFinding struct {
-	EntityID   string `json:"entity_id"`
-	Name       string `json:"name"`
-	Repo       string `json:"repo"`
+	EntityID string `json:"entity_id"`
+	Name     string `json:"name"`
+	Repo     string `json:"repo"`
 	// ModulePath is the monorepo module sub-path owning this finding's source
 	// file (#4698). See AuthEndpointFinding.ModulePath.
 	ModulePath string `json:"module_path,omitempty"`
@@ -536,10 +535,7 @@ func (s *Server) handleSecurityAuthCoverage(w http.ResponseWriter, r *http.Reque
 		return result.Findings[i].Name < result.Findings[j].Name
 	})
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(result)
+	writeReportJSON(w, result)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -685,10 +681,7 @@ func (s *Server) handleSecuritySecrets(w http.ResponseWriter, r *http.Request) {
 		return result.Findings[i].Name < result.Findings[j].Name
 	})
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(result)
+	writeReportJSON(w, result)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -809,8 +802,5 @@ func (s *Server) handleSecurityCycles(w http.ResponseWriter, r *http.Request) {
 		return result.Findings[i].Repo < result.Findings[j].Repo
 	})
 
-	w.Header().Set("Content-Type", "application/json")
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	_ = enc.Encode(result)
+	writeReportJSON(w, result)
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -848,7 +848,22 @@ func (s *Server) withAuth(next http.Handler) http.Handler {
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	// Wire contract (#4516): emit `[]` not `null` for empty array-typed fields
+	// so the webui-v2 TS report types (which call .length/.map/.filter) don't
+	// crash. The frontend null-guards (#4514) remain as belt-and-suspenders.
+	_ = json.NewEncoder(w).Encode(normalizeNilSlices(v))
+}
+
+// writeReportJSON writes an indented JSON report with the dashboard wire
+// contract applied (nil slices -> []). This is the shared write path for the
+// report handlers (graphql, errorflow, di, dataflow, iac, coverage, security,
+// nplus1, …) which previously constructed a json.Encoder inline and emitted
+// `null` for empty slice fields.
+func writeReportJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(normalizeNilSlices(v))
 }
 
 // writeErr emits a uniform { "error": "..." } body.

--- a/internal/dashboard/v2_helpers.go
+++ b/internal/dashboard/v2_helpers.go
@@ -123,7 +123,8 @@ func parsePagination(q url.Values, total int) V2Pagination {
 func writeV2JSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	// Wire contract (#4516): nil slice fields serialize as `[]`, not `null`.
+	_ = json.NewEncoder(w).Encode(normalizeNilSlices(v))
 }
 
 // writeV2Err writes a v2 error response.

--- a/internal/dashboard/wire_normalize.go
+++ b/internal/dashboard/wire_normalize.go
@@ -1,0 +1,128 @@
+// wire_normalize.go — JSON wire-contract normalization for dashboard responses.
+//
+// Problem (#4516): the dashboard report structs declare many []T fields
+// WITHOUT `,omitempty`. In Go a nil slice marshals to JSON `null`, but the
+// webui-v2 TypeScript report types declare these fields as non-nullable arrays
+// and call `.length` / `.map` / `.filter` on them directly. An empty result
+// therefore arrives as `null` and the frontend crashes on `null.length`.
+//
+// Rather than sprinkle `,omitempty` (which would DROP the field entirely —
+// the frontend wants `[]`, not a missing key) or hand-initialize every slice
+// field in every handler, we normalize at the marshal boundary: a single
+// reflection pass walks the payload and replaces every nil slice with a
+// non-nil empty slice of the same element type. One fix covers all current and
+// future fields, and the on-wire shape becomes `[]` instead of `null`.
+//
+// Scope of the walk:
+//   - nil slices            -> empty slice ([]T{})  (the fix)
+//   - populated slices      -> recursed into, elements normalized
+//   - structs / *structs    -> recursed into addressable copies
+//   - arrays                -> recursed into elements
+//   - maps                  -> recursed into VALUES (keys untouched). Map nil
+//     itself is left as `null`: a nil map is semantically "absent" and the
+//     frontend does not call array methods on object-typed fields. Only the
+//     values are normalized so nested slices inside map values still become [].
+//   - pointers              -> followed when non-nil; nil pointers untouched
+//     (null is semantically meaningful for an optional object).
+//
+// The function operates on a deep, addressable copy so the caller's value is
+// never mutated — important because handlers often share/cache report structs.
+
+package dashboard
+
+import "reflect"
+
+// normalizeNilSlices returns a copy of v in which every nil slice reachable
+// through exported, settable fields has been replaced by an empty (non-nil)
+// slice of the same element type. The input is not mutated.
+//
+// Returns the normalized value as an `any` suitable for json.Marshal /
+// Encoder.Encode. If v is nil it is returned unchanged.
+func normalizeNilSlices(v any) any {
+	if v == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(v)
+	out := normalizeValue(rv)
+	if !out.IsValid() {
+		return v
+	}
+	return out.Interface()
+}
+
+// normalizeValue returns a normalized copy of rv. It allocates a fresh
+// addressable value, copies rv into it, walks it, and returns it.
+func normalizeValue(rv reflect.Value) reflect.Value {
+	if !rv.IsValid() {
+		return rv
+	}
+	// Allocate a settable copy we can mutate freely.
+	cp := reflect.New(rv.Type()).Elem()
+	cp.Set(rv)
+	walk(cp)
+	return cp
+}
+
+// walk mutates v in place, replacing nil slices with empty slices and
+// recursing into nested structs, slices, arrays, maps and pointers.
+// v must be addressable/settable.
+func walk(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Slice:
+		if v.IsNil() {
+			// nil slice -> empty (non-nil) slice of the same element type.
+			v.Set(reflect.MakeSlice(v.Type(), 0, 0))
+			return
+		}
+		for i := 0; i < v.Len(); i++ {
+			walk(v.Index(i))
+		}
+
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			walk(v.Index(i))
+		}
+
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			// Skip unexported fields — not settable, not marshaled.
+			if t.Field(i).PkgPath != "" {
+				continue
+			}
+			walk(v.Field(i))
+		}
+
+	case reflect.Ptr:
+		if v.IsNil() {
+			return // nil pointer stays null — semantically meaningful.
+		}
+		walk(v.Elem())
+
+	case reflect.Map:
+		if v.IsNil() {
+			return // nil map stays null; object-typed, not iterated as array.
+		}
+		// Normalize map VALUES (keys are immutable map index values). We build
+		// a normalized copy of each value and write it back.
+		for _, k := range v.MapKeys() {
+			ev := v.MapIndex(k)
+			nv := reflect.New(ev.Type()).Elem()
+			nv.Set(ev)
+			walk(nv)
+			v.SetMapIndex(k, nv)
+		}
+
+	case reflect.Interface:
+		if v.IsNil() {
+			return
+		}
+		// The dynamic value inside an interface is not addressable, so make a
+		// settable copy, walk it, and store it back into the interface slot.
+		elem := v.Elem()
+		nv := reflect.New(elem.Type()).Elem()
+		nv.Set(elem)
+		walk(nv)
+		v.Set(nv)
+	}
+}

--- a/internal/dashboard/wire_normalize_test.go
+++ b/internal/dashboard/wire_normalize_test.go
@@ -1,0 +1,211 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// marshalNormalized is a tiny helper mirroring what writeJSON/writeReportJSON
+// do on the wire: normalize nil slices, then JSON-encode.
+func marshalNormalized(t *testing.T, v any) string {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(normalizeNilSlices(v)); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	return buf.String()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reflection helper unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestNormalizeNilSlices_TopLevelNilSlice(t *testing.T) {
+	type T struct {
+		Items []string `json:"items"`
+	}
+	got := marshalNormalized(t, T{}) // Items is nil
+	if strings.Contains(got, "null") {
+		t.Fatalf("nil slice marshaled to null: %s", got)
+	}
+	if !strings.Contains(got, `"items":[]`) {
+		t.Fatalf("expected items:[] got %s", got)
+	}
+}
+
+func TestNormalizeNilSlices_PopulatedSliceUnchanged(t *testing.T) {
+	type T struct {
+		Items []string `json:"items"`
+	}
+	got := marshalNormalized(t, T{Items: []string{"a", "b"}})
+	if !strings.Contains(got, `"items":["a","b"]`) {
+		t.Fatalf("populated slice altered: %s", got)
+	}
+}
+
+func TestNormalizeNilSlices_NestedStructsAndSlices(t *testing.T) {
+	type Inner struct {
+		Tags []string `json:"tags"`
+	}
+	type Outer struct {
+		Rows  []Inner `json:"rows"`  // nil at top level
+		One   Inner   `json:"one"`   // nested struct with nil slice
+		Ptr   *Inner  `json:"ptr"`   // non-nil pointer with nil slice
+		NilP  *Inner  `json:"nil_p"` // nil pointer — stays null
+		Items []Inner `json:"items"` // populated; element has nil slice
+	}
+	v := Outer{
+		Ptr:   &Inner{},
+		Items: []Inner{{Tags: []string{"x"}}, {}},
+	}
+	got := marshalNormalized(t, v)
+
+	// Top-level nil slice -> []
+	if !strings.Contains(got, `"rows":[]`) {
+		t.Errorf("rows not normalized: %s", got)
+	}
+	// Nested struct's nil slice -> []
+	if !strings.Contains(got, `"one":{"tags":[]}`) {
+		t.Errorf("nested struct slice not normalized: %s", got)
+	}
+	// Non-nil pointer's nil slice -> []
+	if !strings.Contains(got, `"ptr":{"tags":[]}`) {
+		t.Errorf("pointer-target slice not normalized: %s", got)
+	}
+	// Nil pointer stays null (semantically meaningful optional object).
+	if !strings.Contains(got, `"nil_p":null`) {
+		t.Errorf("nil pointer should stay null: %s", got)
+	}
+	// Populated element keeps data; empty element's slice -> [].
+	if !strings.Contains(got, `"items":[{"tags":["x"]},{"tags":[]}]`) {
+		t.Errorf("slice-of-struct normalization wrong: %s", got)
+	}
+}
+
+func TestNormalizeNilSlices_MapsAndPointersUntouchedButValuesWalked(t *testing.T) {
+	type Inner struct {
+		Tags []string `json:"tags"`
+	}
+	type T struct {
+		NilMap  map[string]int    `json:"nil_map"`   // stays null
+		Counts  map[string]int    `json:"counts"`    // populated, untouched
+		ByName  map[string]Inner  `json:"by_name"`   // values have nil slices -> []
+		ByNameP map[string]*Inner `json:"by_name_p"` // pointer values walked
+	}
+	v := T{
+		Counts:  map[string]int{"a": 1},
+		ByName:  map[string]Inner{"k": {}},
+		ByNameP: map[string]*Inner{"p": {}},
+	}
+	got := marshalNormalized(t, v)
+
+	if !strings.Contains(got, `"nil_map":null`) {
+		t.Errorf("nil map should stay null: %s", got)
+	}
+	if !strings.Contains(got, `"counts":{"a":1}`) {
+		t.Errorf("populated map altered: %s", got)
+	}
+	// Map VALUE's nil slice should be normalized to [].
+	if !strings.Contains(got, `"by_name":{"k":{"tags":[]}}`) {
+		t.Errorf("map value slice not normalized: %s", got)
+	}
+	if !strings.Contains(got, `"by_name_p":{"p":{"tags":[]}}`) {
+		t.Errorf("map pointer value slice not normalized: %s", got)
+	}
+}
+
+func TestNormalizeNilSlices_DoesNotMutateInput(t *testing.T) {
+	type T struct {
+		Items []string `json:"items"`
+	}
+	in := T{}
+	_ = normalizeNilSlices(in)
+	if in.Items != nil {
+		t.Fatalf("input was mutated: Items=%v", in.Items)
+	}
+}
+
+func TestNormalizeNilSlices_NilInput(t *testing.T) {
+	if got := normalizeNilSlices(nil); got != nil {
+		t.Fatalf("nil input should return nil, got %v", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Representative dashboard report payloads — every array-typed field the
+// frontend iterates must serialize as [] not null when empty.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestDashboardReports_EmptySlicesSerializeAsArray(t *testing.T) {
+	// Each payload is constructed with ALL slice fields left nil (the empty /
+	// not-yet-indexed case that triggered the null.length crashes #4516).
+	payloads := []struct {
+		name    string
+		payload any
+		// jsonFields are the JSON keys whose value must be [] (never null).
+		jsonFields []string
+	}{
+		{
+			name:       "coverage",
+			payload:    GroupCoverageReport{Group: "g"},
+			jsonFields: []string{"uncovered_entities", "by_directory", "by_file", "by_module"},
+		},
+		{
+			name:       "security_auth",
+			payload:    GroupAuthCoverageReport{Group: "g"},
+			jsonFields: []string{"findings"},
+		},
+		{
+			name:       "security_secrets",
+			payload:    GroupSecretsReport{Group: "g"},
+			jsonFields: []string{"findings"},
+		},
+		{
+			name:       "security_cycles",
+			payload:    GroupCyclesReport{Group: "g"},
+			jsonFields: []string{"findings"},
+		},
+		{
+			name:       "nplus1",
+			payload:    GroupNPlusOneReport{Group: "g"},
+			jsonFields: []string{"findings"},
+		},
+	}
+
+	for _, p := range payloads {
+		t.Run(p.name, func(t *testing.T) {
+			got := marshalNormalized(t, p.payload)
+			for _, f := range p.jsonFields {
+				nullPat := `"` + f + `":null`
+				arrPat := `"` + f + `":[]`
+				if strings.Contains(got, nullPat) {
+					t.Errorf("%s: field %q serialized as null (frontend crashes on .length): %s", p.name, f, got)
+				}
+				if !strings.Contains(got, arrPat) {
+					t.Errorf("%s: field %q not emitted as []: %s", p.name, f, got)
+				}
+			}
+		})
+	}
+}
+
+// TestDashboardReports_NestedCycleEdges proves nested slice fields (CycleFinding
+// has its own Members/Edges []) are normalized when a finding is present.
+func TestDashboardReports_NestedCycleEdges(t *testing.T) {
+	v := GroupCyclesReport{
+		Group: "g",
+		Findings: []CycleFinding{
+			{Repo: "r"}, // Members and Edges are nil
+		},
+	}
+	got := marshalNormalized(t, v)
+	if strings.Contains(got, `"members":null`) || strings.Contains(got, `"edges":null`) {
+		t.Fatalf("nested cycle slices serialized as null: %s", got)
+	}
+	if !strings.Contains(got, `"members":[]`) || !strings.Contains(got, `"edges":[]`) {
+		t.Fatalf("nested cycle slices not emitted as []: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Root-cause fix for the dashboard `null.length` / `.map` crashes (epic #4493, follow-up to #4494/#4514).

The Go dashboard report structs declare many `[]T` fields **without** `omitempty`, so a nil slice marshals to JSON `null`. The webui-v2 TypeScript report types declare these as non-nullable arrays and call `.length` / `.map` / `.filter` on them — so an empty / not-yet-indexed group arrives as `null` and the frontend crashes. #4514 hardened the frontend defensively; this is the principled wire-contract fix on the backend.

## Approach — central reflection normalizer (systematic, future-proof)

Rather than sprinkle `,omitempty` (which would *drop* the key — the frontend wants `[]`, not a missing field) or hand-initialize every slice in every handler, a single reflection pass runs at the marshal boundary:

- `internal/dashboard/wire_normalize.go` — `normalizeNilSlices(v)` deep-copies the payload and replaces **every nil slice** reachable through exported fields (top-level, nested structs, `*struct`, array elements, slice elements, **map values**) with a non-nil empty slice of the same element type. One fix covers all current **and future** fields.
- Semantically-meaningful nulls are preserved: **nil maps** and **nil pointers** stay `null` (object-typed, not iterated as arrays) — but their contents are still walked so nested slices inside them become `[]`.
- The caller's value is never mutated (handlers cache report structs).

Wired into the dashboard JSON write path:
- `writeJSON` / `writeV2JSON` normalize before encoding (covers all `writeJSON`-based report routes: paths, event-flows, graph, quality, topology, pending…).
- New `writeReportJSON` shared helper replaces the inline `json.Encoder` blocks in the direct-encoder report handlers: `graphql`, `errorflow`, `di`, `dataflow`, `iac`, `coverage`, `security` (×3), `nplus1`.

`omitempty` is intentionally **not** added — the frontend wants `[]`.

## Tests

`internal/dashboard/wire_normalize_test.go`:
- Reflection helper units: nil slice → `[]`, populated slice unchanged, nested structs / `*struct` / slice-of-struct, **maps & nil pointers untouched but their values/targets walked**, input-not-mutated, nil input.
- Representative report payloads (coverage / security-auth / secrets / cycles / nplus1) constructed with all-nil slices assert every frontend-iterated field serializes as `[]` not `null`, including nested `CycleFinding.Members`/`Edges`.

## Gates

- `go build ./...` ✅
- `go vet ./internal/dashboard/...` ✅
- `go test ./internal/dashboard/...` ✅
- `coverage fmt --check` ✅ (no registry change — not a per-language extraction capability)

This lets the #4514 frontend null-guards become belt-and-suspenders rather than load-bearing.

Closes #4516

🤖 Generated with [Claude Code](https://claude.com/claude-code)