### PR TITLE
feat(reqresp): handler→DTO ACCEPTS_INPUT/RETURNS edges for Django/DRF, Spring, FastAPI (#4474 #4475 #4476)

### DIFF
--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -228,6 +228,73 @@ public class OrderController {
 	}
 }
 
+// #4475 — @ModelAttribute command object → ACCEPTS_INPUT, plus return type
+// → RETURNS, with no duplicate DTO node.
+func TestSpringReqResp_ModelAttributeCommandObject(t *testing.T) {
+	source := `
+@RestController
+public class SearchController {
+    @GetMapping("/search")
+    public ResponseEntity<SearchResult> search(@ModelAttribute SearchQuery query) { return null; }
+}
+`
+	r := ExtractSpringRequestResponse(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "SearchController.java"})
+	var accepts, returns int
+	dtoCount := map[string]int{}
+	for _, e := range r.Entities {
+		dtoCount[e.Name]++
+	}
+	for _, rel := range r.Relationships {
+		switch rel.RelationshipType {
+		case "ACCEPTS_INPUT":
+			accepts++
+			if rel.Properties["dto_type"] != "SearchQuery" {
+				t.Errorf("ACCEPTS_INPUT dto_type = %q, want SearchQuery", rel.Properties["dto_type"])
+			}
+			if rel.Properties["match_source"] != "model_attribute_annotation" {
+				t.Errorf("match_source = %q, want model_attribute_annotation", rel.Properties["match_source"])
+			}
+		case "RETURNS":
+			returns++
+			if rel.Properties["dto_type"] != "SearchResult" {
+				t.Errorf("RETURNS dto_type = %q, want SearchResult", rel.Properties["dto_type"])
+			}
+		}
+	}
+	if accepts != 1 {
+		t.Errorf("expected 1 ACCEPTS_INPUT, got %d", accepts)
+	}
+	if returns != 1 {
+		t.Errorf("expected 1 RETURNS, got %d", returns)
+	}
+	if dtoCount["SearchQuery"] != 1 {
+		t.Errorf("expected exactly 1 SearchQuery DTO node, got %d", dtoCount["SearchQuery"])
+	}
+}
+
+// #4475 — a bare command-object param (no binding annotation) is the implicit
+// Spring command object and gets an ACCEPTS_INPUT edge; @RequestParam scalars
+// and primitives do NOT.
+func TestSpringReqResp_BareCommandObject(t *testing.T) {
+	source := `
+@RestController
+public class ReportController {
+    @GetMapping("/report")
+    public ResponseEntity<ReportDto> report(ReportFilter filter, @RequestParam String fmt, int page) { return null; }
+}
+`
+	r := ExtractSpringRequestResponse(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "ReportController.java"})
+	var acceptsDTOs []string
+	for _, rel := range r.Relationships {
+		if rel.RelationshipType == "ACCEPTS_INPUT" {
+			acceptsDTOs = append(acceptsDTOs, rel.Properties["dto_type"])
+		}
+	}
+	if len(acceptsDTOs) != 1 || acceptsDTOs[0] != "ReportFilter" {
+		t.Errorf("expected exactly ReportFilter ACCEPTS_INPUT, got %v", acceptsDTOs)
+	}
+}
+
 func TestSpringReqResp_NoController(t *testing.T) {
 	source := `public class PlainClass { public void foo() {} }`
 	r := ExtractSpringRequestResponse(PatternContext{Source: source, Language: "java", Framework: "spring_boot", FilePath: "X.java"})

--- a/internal/custom/java/spring_request_response.go
+++ b/internal/custom/java/spring_request_response.go
@@ -1,6 +1,35 @@
 package java
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
+
+// srrSplitParams splits a Java handler parameter list at top-level commas,
+// respecting `<>` generic args and `()` annotation args so a param like
+// `Map<String,Object> m` or `@RequestParam(value="x") String x` stays intact.
+func srrSplitParams(paramsBlock string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(paramsBlock); i++ {
+		switch paramsBlock[i] {
+		case '<', '(', '[':
+			depth++
+		case '>', ')', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, paramsBlock[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, paramsBlock[start:])
+	return parts
+}
 
 // Spring Request/Response extractor: ACCEPTS_INPUT and RETURNS relationships.
 // Ported from: spring_request_response_extractor.py
@@ -20,6 +49,18 @@ var (
 			`(?:<[^>]*>\s*)?([\w<>\[\], ]+?)\s+(\w+)\s*\(([^)]*)`)
 	srrRequestBodyRE = regexp.MustCompile(
 		`@RequestBody\b(?:\s*@\w+(?:\s*\([^)]*\))?\s*)*\s+(\w+)(?:\s*<[^>]*>)?\s+\w+`)
+	// #4475 — Spring's GET-side request DTO: a command/form object bound via
+	// `@ModelAttribute FooQuery foo`. Group 1 is the DTO type. The leading
+	// `@ModelAttribute` may itself carry args (`@ModelAttribute("cmd")`).
+	srrModelAttributeRE = regexp.MustCompile(
+		`@ModelAttribute\b(?:\s*\([^)]*\))?(?:\s*@\w+(?:\s*\([^)]*\))?\s*)*\s+(\w+)(?:\s*<[^>]*>)?\s+\w+`)
+	// srrParamSplitRE splits a handler param list at top-level commas so each
+	// param can be classified (annotated vs bare command object). Generic
+	// commas (`Map<K,V>`) are handled by srrSplitParams, not this RE.
+	srrAnnotatedParamRE = regexp.MustCompile(`@(\w+)\b`)
+	// srrBareParamRE matches a `Type name` param with no annotation. Group 1 is
+	// the type (ignoring generic args), group 2 the identifier.
+	srrBareParamRE = regexp.MustCompile(`^([A-Z]\w*)(?:\s*<[^>]*>)?\s+(\w+)\s*$`)
 	srrResponseEntityRE = regexp.MustCompile(`ResponseEntity\s*<\s*([\w<>, ]+?)\s*>`)
 	srrGenericWrapperRE = regexp.MustCompile(`(?:Optional|Mono|Flux|Publisher)\s*<\s*([\w<>, ]+?)\s*>`)
 	srrBaseGenericRE    = regexp.MustCompile(`^(\w+)(?:\s*<([^>]+)>)?$`)
@@ -119,6 +160,53 @@ func ExtractSpringRequestResponse(ctx PatternContext) PatternResult {
 					Properties:       map[string]string{"match_source": "request_body_annotation", "dto_type": dtoName},
 				})
 			}
+		}
+
+		// #4475 — ACCEPTS_INPUT for command/form objects: the Spring GET-side
+		// request DTO. Two forms, both the analog of the NestJS @Query() DTO:
+		//   (1) `@ModelAttribute FooQuery foo` — explicitly bound command object.
+		//   (2) a bare command-object param (`FooQuery foo`) with no binding
+		//       annotation — Spring binds these to request params implicitly.
+		// Skip primitives / @RequestParam-/@PathVariable-bound scalars and the
+		// framework injection types in srrSkipTypes. Conservative: only when the
+		// type resolves to a known user DTO.
+		for _, mam := range srrModelAttributeRE.FindAllStringSubmatch(paramsBlock, -1) {
+			dtoName := mam[1]
+			if srrSkipTypes[dtoName] {
+				continue
+			}
+			dtoRef := ensureDTO(dtoName, lineNo)
+			addRel(&result, seenRels, Relationship{
+				SourceRef: endpointRef, TargetRef: dtoRef,
+				RelationshipType: "ACCEPTS_INPUT",
+				Properties:       map[string]string{"match_source": "model_attribute_annotation", "dto_type": dtoName},
+			})
+		}
+		for _, param := range srrSplitParams(paramsBlock) {
+			param = strings.TrimSpace(param)
+			if param == "" {
+				continue
+			}
+			// Annotated params are handled by their dedicated passes
+			// (@RequestBody / @ModelAttribute above) or are scalar bindings
+			// (@RequestParam/@PathVariable/@RequestHeader) we deliberately skip.
+			if srrAnnotatedParamRE.MatchString(param) {
+				continue
+			}
+			bm := srrBareParamRE.FindStringSubmatch(param)
+			if bm == nil {
+				continue
+			}
+			dtoName := bm[1]
+			if srrSkipTypes[dtoName] {
+				continue
+			}
+			dtoRef := ensureDTO(dtoName, lineNo)
+			addRel(&result, seenRels, Relationship{
+				SourceRef: endpointRef, TargetRef: dtoRef,
+				RelationshipType: "ACCEPTS_INPUT",
+				Properties:       map[string]string{"match_source": "command_object_param", "dto_type": dtoName},
+			})
 		}
 
 		// RETURNS: method return type

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -43,6 +43,27 @@ var (
 		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*(?:viewsets\.)?(?:ModelViewSet|ReadOnlyModelViewSet|ViewSet|GenericViewSet|ViewSetMixin)[^)]*\)\s*:`)
 	djangoRouterRegRe = regexp.MustCompile(
 		`(?m)router\.register\s*\(\s*(?:r)?["']([^"']*)["']\s*,\s*(\w+)`)
+
+	// #4474 — DRF view↔serializer DTO linkage. A GenericAPIView/ViewSet resolves
+	// its request/response DTO via `serializer_class = FooSerializer` (class
+	// attribute) or per-action `get_serializer_class()`/inline overrides. We
+	// resolve the serializer class name and emit ACCEPTS_INPUT (request) /
+	// RETURNS (response) edges from the view to the serializer entity.
+	//
+	// (a) class-level `serializer_class = FooSerializer` (4-space body indent).
+	djangoSerializerClassAttrRe = regexp.MustCompile(
+		`(?m)^\s{4,}serializer_class\s*=\s*([A-Z][A-Za-z0-9_]*)\b`)
+	// (b) inline serializer construction inside an action:
+	//     `FooSerializer(data=request.data)` (request — ACCEPTS_INPUT)
+	//     `FooSerializer(obj)` / `FooSerializer(qs, many=True)` (response — RETURNS)
+	// Group 1 = serializer class name, group 2 = the call arg head.
+	djangoSerializerCallRe = regexp.MustCompile(
+		`([A-Z][A-Za-z0-9_]*Serializer)\s*\(\s*(data\s*=)?`)
+	// (c) drf-yasg `@swagger_auto_schema(request_body=FooSerializer, responses={...: BarSerializer})`.
+	djangoSwaggerRequestBodyRe = regexp.MustCompile(
+		`request_body\s*=\s*([A-Z][A-Za-z0-9_]*)\b`)
+	djangoSwaggerResponsesSerRe = regexp.MustCompile(
+		`([A-Z][A-Za-z0-9_]*Serializer)\b`)
 	djangoMiddlewareClassRe  = regexp.MustCompile(`(?m)^class\s+([A-Z][A-Za-z0-9_]*Middleware)\s*(?:\([^)]*\))?\s*:`)
 	djangoMiddlewareMethodRe = regexp.MustCompile(
 		`(?m)^\s{4,}def\s+(process_(?:request|response|view|exception|template_response))\s*\(`)
@@ -183,13 +204,24 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		// #1411: Skip the CBV class entity if section 5b will emit this class
 		// as a DRF ViewSet (SCOPE.Component/viewset). HTTP method children are
 		// still emitted for both ViewSet and non-ViewSet CBVs.
+		// Extract class body once — used for HTTP-method children and (for DRF
+		// APIView/GenericAPIView CBVs) the #4474 view↔serializer DTO edges.
+		body := extractClassBody(source, idx[0])
+
 		if !drfViewsetNames[className] {
-			out = append(out, entity(className, "SCOPE.Operation", "endpoint", file.Path, classLine,
-				map[string]string{"framework": "django", "pattern_type": "cbv", "base_classes": bases}))
+			cbvEnt := entity(className, "SCOPE.Operation", "endpoint", file.Path, classLine,
+				map[string]string{"framework": "django", "pattern_type": "cbv", "base_classes": bases})
+			// #4474 — a DRF APIView/GenericAPIView CBV resolves its request/
+			// response DTO via serializer_class / inline serializer calls, exactly
+			// like a ViewSet. Attach the edges in-place (no duplicate view node).
+			if strings.Contains(bases, "APIView") || strings.Contains(bases, "GenericAPIView") ||
+				strings.Contains(body, "serializer_class") || djangoSerializerCallRe.MatchString(body) {
+				appendDRFSerializerEdges(&cbvEnt, body)
+			}
+			out = append(out, cbvEnt)
 		}
 
-		// Extract class body and find HTTP methods
-		body := extractClassBody(source, idx[0])
+		// Find HTTP methods
 		for _, mIdx := range allMatchesIndex(djangoCBVMethodRe, body) {
 			httpMethod := body[mIdx[2]:mIdx[3]]
 			methodName := className + "." + httpMethod
@@ -423,13 +455,10 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		out = append(out, serEnt)
 	}
 
-	// 5b. DRF viewsets
-	for _, idx := range allMatchesIndex(djangoDRFViewsetRe, source) {
-		className := source[idx[2]:idx[3]]
-		line := lineOf(source, idx[0])
-		out = append(out, entity(className, "SCOPE.Component", "", file.Path, line,
-			map[string]string{"framework": "drf", "pattern_type": "viewset", "component_kind": "viewset"}))
-	}
+	// 5b. DRF viewsets — the ViewSet entity (carrying the #4474 view↔serializer
+	// edges) is emitted by section 5d below so the edges hang off a single
+	// canonical viewset node. (Pre-collected as drfViewsetNames above so the CBV
+	// pass already skips re-emitting these as endpoints.)
 
 	// 5c. DRF router.register()
 	for _, idx := range allMatchesIndex(djangoRouterRegRe, source) {
@@ -438,6 +467,28 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		line := lineOf(source, idx[0])
 		out = append(out, entity("router:"+prefix, "SCOPE.Component", "", file.Path, line,
 			map[string]string{"framework": "drf", "pattern_type": "router_entry", "prefix": prefix, "viewset": viewsetName}))
+	}
+
+	// 5d. #4474 — DRF view↔serializer DTO linkage. For each DRF view class
+	// (GenericAPIView/APIView CBV or ViewSet), resolve its request/response
+	// serializer and emit ACCEPTS_INPUT (request) / RETURNS (response) edges
+	// from the view to the serializer entity, mirroring the NestJS handler→DTO
+	// edge kind/shape so cross-framework request/response-shape diffs join
+	// uniformly. The serializer entities already exist (section 5); these edges
+	// connect the floating view to them. Conservative: only when the serializer
+	// resolves to a `XSerializer`-shaped class name (Class:<name> resolver stub,
+	// bound merge-stably post-merge — no duplicate DTO nodes created here).
+	// Emit the ViewSet entities here (carrying the view↔serializer edges) so the
+	// edges hang off a single canonical viewset node (section 5b no longer emits
+	// them). APIView/GenericAPIView CBVs get the same edges attached in-place in
+	// section 2, so no duplicate view node is created.
+	for _, idx := range allMatchesIndex(djangoDRFViewsetRe, source) {
+		className := source[idx[2]:idx[3]]
+		line := lineOf(source, idx[0])
+		ent := entity(className, "SCOPE.Component", "", file.Path, line,
+			map[string]string{"framework": "drf", "pattern_type": "viewset", "component_kind": "viewset"})
+		appendDRFSerializerEdges(&ent, extractClassBody(source, idx[0]))
+		out = append(out, ent)
 	}
 
 	// NOTE: Celery tasks (@shared_task / @app.task) and apply_async/delay call
@@ -843,6 +894,68 @@ func isOnlyWhitespaceAndComments(text string) bool {
 // passes connect to the same canonical model node.
 func djangoModelRef(modelName string) string {
 	return fmt.Sprintf("Class:%s", modelName)
+}
+
+// appendDRFSerializerEdges resolves a DRF view's request/response serializer
+// from its class body and hangs ACCEPTS_INPUT (request) / RETURNS (response)
+// edges off the view entity (#4474). It mirrors the NestJS handler→DTO edge
+// kind/shape (RelationshipKindAcceptsInput / RelationshipKindReturns, ToID
+// `Class:<serializer>`) so cross-framework request/response-shape diffs join
+// uniformly. The serializer entity already exists (django section 5); this only
+// adds the EDGE — no duplicate DTO node. Conservative: only serializer names
+// that resolve to a real `XSerializer`-shaped class.
+func appendDRFSerializerEdges(ent *types.EntityRecord, body string) {
+	seen := map[string]bool{} // dedup (kind+serializer)
+	addEdge := func(serializer, kind, matchSource string) {
+		if serializer == "" {
+			return
+		}
+		key := kind + ":" + serializer
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: pyClassRef(serializer),
+			Kind: kind,
+			Properties: map[string]string{
+				"framework":    "drf",
+				"language":     "python",
+				"dto_type":     serializer,
+				"match_source": matchSource,
+				"provenance":   "INFERRED_FROM_DRF_VIEW_SERIALIZER",
+			},
+		})
+	}
+
+	// (a) class-level `serializer_class = FooSerializer` — the canonical DRF
+	// request+response DTO. It shapes both the deserialized request body and the
+	// serialized response, so emit BOTH edges (NestJS treats a @Body DTO and a
+	// Promise<DTO> return symmetrically; DRF's serializer_class is both).
+	for _, m := range djangoSerializerClassAttrRe.FindAllStringSubmatch(body, -1) {
+		ser := m[1]
+		addEdge(ser, string(types.RelationshipKindAcceptsInput), "serializer_class_attr")
+		addEdge(ser, string(types.RelationshipKindReturns), "serializer_class_attr")
+	}
+
+	// (b) inline serializer construction inside an action method:
+	//   FooSerializer(data=request.data)    → request  (ACCEPTS_INPUT)
+	//   FooSerializer(obj) / (qs, many=True) → response (RETURNS)
+	for _, m := range djangoSerializerCallRe.FindAllStringSubmatch(body, -1) {
+		ser := m[1]
+		if m[2] != "" { // had `data=` → request deserialization
+			addEdge(ser, string(types.RelationshipKindAcceptsInput), "serializer_data_call")
+		} else { // positional instance/queryset → response serialization
+			addEdge(ser, string(types.RelationshipKindReturns), "serializer_response_call")
+		}
+	}
+
+	// (c) drf-yasg `@swagger_auto_schema(request_body=FooSerializer, responses=...)`.
+	if rb := djangoSwaggerRequestBodyRe.FindStringSubmatch(body); rb != nil {
+		if strings.HasSuffix(rb[1], "Serializer") {
+			addEdge(rb[1], string(types.RelationshipKindAcceptsInput), "swagger_request_body")
+		}
+	}
 }
 
 // extractClassBody returns the class body text from class_start to the next

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -63,6 +63,83 @@ func extract(t *testing.T, key, content string) []extractResult {
 // Django tests
 // ============================================================================
 
+// #4474 — a DRF ViewSet with serializer_class gets ACCEPTS_INPUT + RETURNS
+// edges to the serializer, and the serializer entity is not duplicated.
+func TestDRF_ViewSetSerializerClassEdges(t *testing.T) {
+	src := `from rest_framework import viewsets, serializers
+
+class OrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+        fields = ["id", "sku"]
+
+class OrderViewSet(viewsets.ModelViewSet):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+`
+	ents := extract(t, "python_django", src)
+	if !hasEntRel(ents, "ACCEPTS_INPUT", "Class:OrderSerializer") {
+		t.Error("expected ACCEPTS_INPUT -> Class:OrderSerializer from OrderViewSet")
+	}
+	if !hasEntRel(ents, "RETURNS", "Class:OrderSerializer") {
+		t.Error("expected RETURNS -> Class:OrderSerializer from OrderViewSet")
+	}
+	// No duplicate serializer node, and exactly one viewset node.
+	var serCount, viewCount int
+	for _, e := range ents {
+		switch e.Name {
+		case "OrderSerializer":
+			serCount++
+		case "OrderViewSet":
+			viewCount++
+		}
+	}
+	if serCount != 1 {
+		t.Errorf("expected exactly 1 OrderSerializer node, got %d", serCount)
+	}
+	if viewCount != 1 {
+		t.Errorf("expected exactly 1 OrderViewSet node, got %d", viewCount)
+	}
+}
+
+// #4474 — a DRF APIView with inline serializer calls: `XSerializer(data=...)`
+// → ACCEPTS_INPUT, `XSerializer(obj)` → RETURNS.
+func TestDRF_APIViewInlineSerializerCalls(t *testing.T) {
+	src := `from rest_framework.views import APIView
+from rest_framework.response import Response
+
+class OrderCreateView(APIView):
+    def post(self, request):
+        ser = OrderInputSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        obj = ser.save()
+        return Response(OrderOutputSerializer(obj).data)
+`
+	ents := extract(t, "python_django", src)
+	if !hasEntRel(ents, "ACCEPTS_INPUT", "Class:OrderInputSerializer") {
+		t.Error("expected ACCEPTS_INPUT -> Class:OrderInputSerializer (data= call)")
+	}
+	if !hasEntRel(ents, "RETURNS", "Class:OrderOutputSerializer") {
+		t.Error("expected RETURNS -> Class:OrderOutputSerializer (positional call)")
+	}
+}
+
+// #4474 — drf-yasg @swagger_auto_schema(request_body=) → ACCEPTS_INPUT.
+func TestDRF_SwaggerRequestBodyEdge(t *testing.T) {
+	src := `from rest_framework.views import APIView
+from drf_yasg.utils import swagger_auto_schema
+
+class OrderView(APIView):
+    @swagger_auto_schema(request_body=OrderRequestSerializer)
+    def post(self, request):
+        pass
+`
+	ents := extract(t, "python_django", src)
+	if !hasEntRel(ents, "ACCEPTS_INPUT", "Class:OrderRequestSerializer") {
+		t.Error("expected ACCEPTS_INPUT -> Class:OrderRequestSerializer from swagger_auto_schema")
+	}
+}
+
 func TestDjango_URLPattern(t *testing.T) {
 	src := `from django.urls import path
 from . import views
@@ -2064,6 +2141,63 @@ def create_user(user: UserCreate):
 	}
 }
 
+// #4476: a Pydantic model injected via Depends() as a query model gets an
+// ACCEPTS_INPUT edge (the FastAPI analog of the NestJS @Query() DTO).
+func TestFastAPIReqResp_DependsQueryModelEdge(t *testing.T) {
+	src := `@app.get("/items", response_model=ItemOut)
+def list_items(q: FilterParams = Depends()):
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	if !hasEntRel(ents, "ACCEPTS_INPUT", "Class:FilterParams") {
+		t.Fatal("expected ACCEPTS_INPUT -> Class:FilterParams from Depends() query model")
+	}
+	if !hasEntRel(ents, "RETURNS", "Class:ItemOut") {
+		t.Fatal("expected RETURNS -> Class:ItemOut")
+	}
+}
+
+// #4476: `Depends(FilterParams)` (explicit model arg) gets ACCEPTS_INPUT.
+func TestFastAPIReqResp_DependsExplicitModelEdge(t *testing.T) {
+	src := `@app.get("/items")
+def list_items(q = Depends(FilterParams)):
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	if !hasEntRel(ents, "ACCEPTS_INPUT", "Class:FilterParams") {
+		t.Fatal("expected ACCEPTS_INPUT -> Class:FilterParams from Depends(FilterParams)")
+	}
+}
+
+// #4476: an `Annotated[Model, Query()]` query model gets ACCEPTS_INPUT.
+func TestFastAPIReqResp_AnnotatedQueryModelEdge(t *testing.T) {
+	src := `@app.get("/items")
+def list_items(q: Annotated[FilterParams, Query()]):
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	if !hasEntRel(ents, "ACCEPTS_INPUT", "Class:FilterParams") {
+		t.Fatal("expected ACCEPTS_INPUT -> Class:FilterParams from Annotated[..., Query()]")
+	}
+}
+
+// #4476: a Depends() resolving to a provider FUNCTION (not a model) must NOT
+// emit an ACCEPTS_INPUT edge — conservative.
+func TestFastAPIReqResp_DependsProviderNoEdge(t *testing.T) {
+	src := `@app.get("/items")
+def list_items(db = Depends(get_db), user = Depends(get_current_user)):
+    pass
+`
+	ents := extract(t, "python_fastapi_reqresp", src)
+	for _, e := range ents {
+		for _, r := range e.Rels {
+			if r.Kind == "ACCEPTS_INPUT" {
+				t.Fatalf("unexpected ACCEPTS_INPUT edge for provider dependency: %s", r.ToID)
+			}
+		}
+	}
+}
+
 // #3629: FastAPI response_model= emits a RETURNS edge to the response DTO.
 func TestFastAPIReqResp_ReturnsEdgeResponseModel(t *testing.T) {
 	src := `@app.get("/users", response_model=UserOut)
@@ -2207,6 +2341,21 @@ func TestFastAPIReqResp_FullFixture(t *testing.T) {
 	}
 	if !foundUpdate {
 		t.Error("expected accepts_input entity with dto_type=UpdateOrderRequest (update_order endpoint)")
+	}
+
+	// #4476 — list_orders accepts OrderFilterParams via Depends() query model,
+	// and the get_current_user provider dependency yields NO edge.
+	foundQueryModel := false
+	for _, e := range acceptsInput {
+		if e.Props["dto_type"] == "OrderFilterParams" && e.Props["match_source"] == "dependency_query_model" {
+			foundQueryModel = true
+		}
+		if e.Props["dto_type"] == "get_current_user" || e.Props["dto_type"] == "user" {
+			t.Errorf("provider dependency must not yield an accepts_input edge: %v", e.Props)
+		}
+	}
+	if !foundQueryModel {
+		t.Error("expected accepts_input entity with dto_type=OrderFilterParams (Depends() query model, #4476)")
 	}
 
 	// create_order returns OrderResponse via response_model=

--- a/internal/custom/python/fastapi_reqresp.go
+++ b/internal/custom/python/fastapi_reqresp.go
@@ -48,6 +48,13 @@ var farrSkipTypes = map[string]bool{
 
 var farrInjectionRe = regexp.MustCompile(`(?:Depends|Query|Path|Header|Cookie|Body|File|Form|Security)\s*\(`)
 
+// farrInjectedParamRe captures a param whose initializer is a Depends()/Query()
+// injection (#4476). Group 1 = param name, group 2 = the (optional) type
+// annotation. Only Depends/Query carry whole-object Pydantic DTOs; Path/Header/
+// Cookie/File/Form bind scalars, so they're excluded here.
+var farrInjectedParamRe = regexp.MustCompile(
+	`\b(\w+)\s*(?::\s*([\w\[\], |.]+?))?\s*=\s*(?:Depends|Query)\s*\(`)
+
 func (e *FastAPIReqRespExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("custom.python_fastapi_reqresp")
 	_, span := tracer.Start(ctx, "custom.python_fastapi_reqresp")
@@ -79,7 +86,35 @@ func (e *FastAPIReqRespExtractor) Extract(ctx context.Context, file extractor.Fi
 		// Extract params block via balanced parens
 		paramsBlock, closeOffset := extractParamsBlock(source, idx[1])
 
-		// ACCEPTS_INPUT: body parameters
+		// ACCEPTS_INPUT — accumulate request DTOs from this handler's params.
+		// emitAccepts is idempotent per (param,dto) within the handler.
+		seenAccept := make(map[string]bool)
+		emitAccepts := func(paramName, dtoName, matchSource string) {
+			if dtoName == "" {
+				return
+			}
+			key := paramName + ":" + dtoName
+			if seenAccept[key] {
+				return
+			}
+			seenAccept[key] = true
+			emitDTO(dtoName, line, "dto")
+			ep := entity(handlerName+":accepts:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
+				map[string]string{"framework": "fastapi", "pattern_type": "accepts_input", "param_name": paramName, "dto_type": dtoName, "match_source": matchSource})
+			// ACCEPTS_INPUT edge: endpoint -> request DTO type (#3629/#4476).
+			// FromID is left empty so graph assembly binds it to this endpoint
+			// entity; ToID is the structural ref to the real Pydantic class.
+			ep.Relationships = append(ep.Relationships, types.RelationshipRecord{
+				ToID:       "Class:" + dtoName,
+				Kind:       string(types.RelationshipKindAcceptsInput),
+				Properties: map[string]string{"framework": "fastapi", "match_source": matchSource, "param_name": paramName, "dto_type": dtoName},
+			})
+			out = append(out, ep)
+		}
+
+		// (1) Plain body params: `payload: CreateRequest`. Skip params that are
+		// injected (`= Depends()/Query()/...`) — those are handled by pass (2) as
+		// the FastAPI analog of the NestJS @Query() DTO (#4476).
 		for _, pm := range farrParamAnnotRe.FindAllStringSubmatch(paramsBlock, -1) {
 			paramName := pm[1]
 			typeRaw := pm[2]
@@ -89,22 +124,30 @@ func (e *FastAPIReqRespExtractor) Extract(ctx context.Context, file extractor.Fi
 			if paramIsInjected(paramName, paramsBlock) {
 				continue
 			}
-			dtoName := unwrapType(typeRaw)
-			if dtoName == "" {
+			emitAccepts(paramName, unwrapType(typeRaw), "body_param_annotation")
+		}
+
+		// (2) #4476 — query-model / dependency Pydantic DTOs. These are bound via
+		// `= Depends(Model)`, `: Model = Depends()`, `= Query(...)` (whole-object)
+		// or `Annotated[Model, Query()]`. They previously had NO inbound edge.
+		// Conservative: only when the dependency/annotation resolves to a real
+		// PascalCase model class (a provider function like `Depends(get_db)` is
+		// skipped). The annotated-`Annotated[...]` form is also covered by pass
+		// (1) when it carries no `=` initializer (unwrapType strips Annotated);
+		// emitAccepts dedups so double-coverage is harmless.
+		for _, im := range farrInjectedParamRe.FindAllStringSubmatch(paramsBlock, -1) {
+			paramName := im[1]
+			annot := strings.TrimSpace(im[2])
+			if paramName == "self" || paramName == "cls" {
 				continue
 			}
-			emitDTO(dtoName, line, "dto")
-			ep := entity(handlerName+":accepts:"+dtoName, "SCOPE.Operation", "endpoint", file.Path, line,
-				map[string]string{"framework": "fastapi", "pattern_type": "accepts_input", "param_name": paramName, "dto_type": dtoName})
-			// ACCEPTS_INPUT edge: endpoint -> request DTO type (#3629).
-			// FromID is left empty so graph assembly binds it to this endpoint
-			// entity; ToID is the structural ref to the real Pydantic class.
-			ep.Relationships = append(ep.Relationships, types.RelationshipRecord{
-				ToID:       "Class:" + dtoName,
-				Kind:       string(types.RelationshipKindAcceptsInput),
-				Properties: map[string]string{"framework": "fastapi", "match_source": "body_param_annotation", "param_name": paramName, "dto_type": dtoName},
-			})
-			out = append(out, ep)
+			// Prefer the dependency callee's explicit model arg; fall back to the
+			// param's type annotation (e.g. `q: FilterParams = Depends()`).
+			dto := farrDependencyDTO(paramName, paramsBlock)
+			if dto == "" && annot != "" {
+				dto = unwrapType(annot)
+			}
+			emitAccepts(paramName, dto, "dependency_query_model")
 		}
 
 		// RETURNS: response_model= kwarg
@@ -169,13 +212,61 @@ func paramIsInjected(paramName, paramsBlock string) bool {
 	return pattern.MatchString(paramsBlock)
 }
 
+// farrDependencyDTO resolves the Pydantic DTO a query-model / dependency param
+// binds (#4476). It inspects the `= Depends(...)` / `= Query(...)` initializer
+// for an explicit model argument — `Depends(FilterParams)` — returning that
+// class name when it resolves to a real DTO (not a primitive/builtin and not a
+// bare `Depends()`/`Query()`). When the initializer carries no class argument
+// (e.g. `q: FilterParams = Depends()`) the caller falls back to the param's
+// type annotation. Returns "" when no DTO can be resolved.
+var farrDependsArgRe = regexp.MustCompile(`(?:Depends|Query)\s*\(\s*([\w.]+)?`)
+
+func farrDependencyDTO(paramName, paramsBlock string) string {
+	// Capture the initializer expression for this param: everything after `=`
+	// up to the next top-level comma or the end of the block.
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(paramName) + `\s*(?::[^,=]+)?\s*=\s*((?:Depends|Query)\s*\([^)]*\))`)
+	m := re.FindStringSubmatch(paramsBlock)
+	if m == nil {
+		return ""
+	}
+	am := farrDependsArgRe.FindStringSubmatch(m[1])
+	if am == nil || am[1] == "" {
+		return "" // bare Depends()/Query() — fall back to annotation
+	}
+	// Strip a dotted prefix (module.Model → Model) and apply the same
+	// primitive/builtin filtering used for body params.
+	arg := am[1]
+	if i := strings.LastIndex(arg, "."); i >= 0 {
+		arg = arg[i+1:]
+	}
+	if farrSkipTypes[arg] {
+		return ""
+	}
+	// A dependency that resolves to a lowercase identifier is conventionally a
+	// provider function (get_db, get_current_user), not a model class. DTO
+	// models are PascalCase; gate on that to stay conservative.
+	if arg == "" || arg[0] < 'A' || arg[0] > 'Z' {
+		return ""
+	}
+	return arg
+}
+
 var (
 	unwrapGenericRe = regexp.MustCompile(`^(?:List|Optional|Set|Tuple|Sequence|Union)\[(.+)\]$`)
 	unwrapPipeOptRe = regexp.MustCompile(`^(\w+)\s*\|\s*None$`)
+	// #4476 — `Annotated[FilterParams, Query()]` (query-model dependency form):
+	// the first type argument is the real DTO; the rest are FastAPI markers.
+	unwrapAnnotatedRe = regexp.MustCompile(`^Annotated\[\s*([\w.]+)`)
 )
 
 func unwrapType(raw string) string {
 	raw = strings.TrimSpace(raw)
+	if m := unwrapAnnotatedRe.FindStringSubmatch(raw); m != nil {
+		raw = m[1]
+		if i := strings.LastIndex(raw, "."); i >= 0 {
+			raw = raw[i+1:]
+		}
+	}
 	if m := unwrapPipeOptRe.FindStringSubmatch(raw); m != nil {
 		raw = m[1]
 	}

--- a/internal/custom/python/testdata/fastapi_reqresp_fixture.py
+++ b/internal/custom/python/testdata/fastapi_reqresp_fixture.py
@@ -36,6 +36,13 @@ class UpdateOrderRequest(BaseModel):
     notes: Optional[str] = None
 
 
+# --- Query-model DTO (#4476: Depends() request shape) ---
+
+class OrderFilterParams(BaseModel):
+    status: Optional[str] = None
+    min_total_cents: Optional[int] = None
+
+
 # --- Dependency ---
 
 def get_current_user(token: str = ""):
@@ -58,6 +65,14 @@ async def update_order(order_id: str, body: UpdateOrderRequest, user=Depends(get
 @router.get("/{order_id}", response_model=OrderResponse)
 async def get_order(order_id: str):
     return {"order_id": order_id, "status": "pending", "total_cents": 0}
+
+
+# #4476: a Pydantic model bound as a query model via Depends() — the FastAPI
+# analog of the NestJS @Query() DTO. Must get an ACCEPTS_INPUT edge; the
+# get_current_user provider dependency above must NOT.
+@router.get("", response_model=OrderResponse)
+async def list_orders(filters: OrderFilterParams = Depends(), user=Depends(get_current_user)):
+    return {"order_id": "1", "status": "pending", "total_cents": 0}
 
 
 # --- Middleware ---


### PR DESCRIPTION
Generalizes the NestJS (#4464/#4587) handler→DTO linkage across **Django/DRF, Spring, and FastAPI** so cross-graph request/response-shape diffs (`effective_contract` / `response_shape_diff`) can join a handler to its DTO uniformly across frameworks.

## Edge kind reused
The exact NestJS shape: `ACCEPTS_INPUT` (request) / `RETURNS` (response), `ToID = "Class:<DTO>"` — the merge-stable resolver stub. The existing DTO entities (#4613 serializer/Pydantic/Spring fields) are **reused**, never duplicated.

## Per-framework request/response detection
- **Django/DRF (#4474)** — `appendDRFSerializerEdges` hangs the edges off the **ViewSet / APIView / GenericAPIView** view:
  - `serializer_class = XSerializer` → both `ACCEPTS_INPUT` + `RETURNS`
  - inline `XSerializer(data=request.data)` → `ACCEPTS_INPUT`; positional `XSerializer(obj)` / `(qs, many=True)` → `RETURNS`
  - `@swagger_auto_schema(request_body=XSerializer)` → `ACCEPTS_INPUT`
  - The ViewSet entity is now emitted **once** (carrying the edges) and APIView CBVs get edges in-place — no duplicate view node.
- **Spring (#4475)** — in addition to `@RequestBody` / return type: `@ModelAttribute FooQuery` command objects (`model_attribute_annotation`) and **bare command-object params** (`command_object_param`, the Spring analog of the NestJS `@Query()` DTO) → `ACCEPTS_INPUT`. `@RequestParam`/`@PathVariable` scalars + primitives skipped via a top-level param split.
- **FastAPI (#4476)** — query-model & dependency Pydantic DTOs now get `ACCEPTS_INPUT`: `q: X = Depends()`, `Depends(X)`, `Query(...)` whole-object, `Annotated[X, Query()]` (`dependency_query_model`). Provider-function dependencies (`Depends(get_db)`) stay edge-free (conservative).

## Fixtures (RED→GREEN per framework)
- DRF: `TestDRF_ViewSetSerializerClassEdges` (asserts both edges + no dup serializer/view node), `TestDRF_APIViewInlineSerializerCalls`, `TestDRF_SwaggerRequestBodyEdge`
- Spring: `TestSpringReqResp_ModelAttributeCommandObject` (no dup DTO node), `TestSpringReqResp_BareCommandObject`
- FastAPI: `TestFastAPIReqResp_DependsQueryModelEdge`, `TestFastAPIReqResp_DependsExplicitModelEdge`, `TestFastAPIReqResp_AnnotatedQueryModelEdge`, `TestFastAPIReqResp_DependsProviderNoEdge`, plus the extended `…_FullFixture`

## Registry cells
`Validation.dto_extraction` updated surgically for `django-drf`, `spring-boot`, `fastapi` (notes/cites/issue/verified_at). `coverage fmt --check` canonical; `coverage validate` 0 errors.

## Gates
`go build ./...` ✓ · `go vet ./internal/custom/... ./internal/engine/...` ✓ · `go test ./internal/custom/... ./internal/engine/... ./internal/graph/... ./internal/types/` ✓ · `coverage fmt --check` ✓ · `coverage validate` (0 errors) ✓

Closes #4474
Closes #4475
Closes #4476

🤖 Generated with [Claude Code](https://claude.com/claude-code)