### PR TITLE
feat(effects): data-access from fluent query-builders (TypeORM/Prisma/Mongoose/Knex/SQLAlchemy Core) — #4335 + #4336

### DIFF
--- a/internal/substrate/effect_sinks_jsts.go
+++ b/internal/substrate/effect_sinks_jsts.go
@@ -61,8 +61,13 @@ var jstsHTTPRe = regexp.MustCompile(
 // Includes Mongoose / native MongoDB driver collection reads — `.findById`,
 // `.countDocuments`, `.estimatedDocumentCount`, `.distinct` (#3440 ask 4);
 // `.find`/`.findOne`/`.aggregate`/`.count` were already covered.
+//
+// #4336 adds the Mongoose aggregate-fluent join terminals `.populate(` and
+// `.lookup(` — both are distinctive Mongoose/aggregation read names (a
+// `Model.find().populate('author')` join or a `Model.aggregate().lookup({...})`
+// stage), safe to bare-match. `aggregate` was already covered.
 var jstsDBReadRe = regexp.MustCompile(
-	`\.\s*(findOne|findAll|findMany|findUnique|findFirst|findById|find|aggregate|countDocuments|estimatedDocumentCount|count|distinct|exists|query|select|raw|exec)\s*\(`,
+	`\.\s*(findOne|findAll|findMany|findUnique|findFirst|findById|find|aggregate|lookup|populate|countDocuments|estimatedDocumentCount|count|distinct|exists|query|select|raw|exec)\s*\(`,
 )
 
 // jstsDBWriteRe matches write-flavoured ORM / query-builder primitives.
@@ -87,6 +92,100 @@ var jstsFSWriteRe = regexp.MustCompile(
 	`\b(?:fs|fsp|fs\s*\.\s*promises)\s*\.\s*(writeFile|writeFileSync|appendFile|appendFileSync|mkdir|mkdirSync|rmdir|rmdirSync|unlink|unlinkSync|rm|rmSync|rename|renameSync|copyFile|copyFileSync|createWriteStream|chmod|chmodSync|chown|chownSync|truncate|truncateSync|symlink|symlinkSync)\s*\(`,
 )
 
+// --- #4335 / #4336 fluent query-builder receiver-typed data-access ---
+//
+// The receiver-typed read/write discipline established for Python (#4691),
+// C# (#4692), Rust (#4737) and Scala-Slick (#4736) extended to the JS/TS
+// fluent query builders whose TERMINAL verb determines read vs write but
+// whose terminal NAMES collide with plain array/Promise combinators
+// (`.getMany()` is fine, but `.first()`/`.execute()`/`.pluck()` would
+// false-positive on a non-builder receiver). These ambiguous terminals are
+// credited ONLY when chained off a query-builder-typed receiver:
+//
+//   - TypeORM    `repo.createQueryBuilder('x')` result (#4335)
+//   - Prisma     a `prisma.<model>` delegate (#4335)
+//   - Knex       a `knex('t')` / `knex.table('t')` builder (#4336)
+//
+// Distinctive read/write terminals with no collision (`getMany`, `getRawMany`,
+// `findMany`, `$queryRaw`, ...) are bare-matched by jstsDBReadRe/jstsDBWriteRe;
+// this layer adds the AMBIGUOUS terminals gated to a builder-typed receiver,
+// preserving the collection/Promise false-positive guard.
+
+// jstsBuilderRootRe seeds the set of query-builder-typed local/field names.
+// Group 1 captures the assigned name. RHS alternatives:
+//   - `const qb = repo.createQueryBuilder('u')`        (TypeORM QueryBuilder)
+//   - `const qb = this.repo.createQueryBuilder()`
+//   - `const qb = conn.createQueryBuilder()`
+//   - `const q = knex('users')` / `const q = knex.table('users')`           (Knex)
+//   - `const q = prisma.user`                          (Prisma delegate handle)
+//   - `const q = this.prisma.user`
+var jstsBuilderRootRe = regexp.MustCompile(
+	`(?m)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:await\s+)?(?:` +
+		`[A-Za-z_$][\w$.]*\.createQueryBuilder\s*\(` + // TypeORM QueryBuilder
+		`|[A-Za-z_$][\w$.]*?knex\s*(?:\(|\.\s*table\s*\()` + // Knex builder
+		`|\bknex\s*(?:\(|\.\s*table\s*\()` +
+		`|(?:[A-Za-z_$][\w$]*\.)*prisma\s*\.\s*[A-Za-z_$][\w$]*\s*[;\n]` + // Prisma delegate (no call → handle)
+		`)`,
+)
+
+// jstsBuilderChainAssignRe propagates builder typing across reassignments:
+// `const qb2 = qb.where(...)` where qb is already builder-typed. Group 1 =
+// new name, group 2 = source receiver. The chain ops are the builder shaper
+// verbs (TypeORM/Knex) that RETURN the builder.
+var jstsBuilderChainAssignRe = regexp.MustCompile(
+	`(?m)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:await\s+)?([A-Za-z_$][\w$]*)\s*\.\s*` +
+		`(?:where|andWhere|orWhere|leftJoin|leftJoinAndSelect|innerJoin|innerJoinAndSelect|` +
+		`join|select|addSelect|orderBy|addOrderBy|groupBy|having|limit|offset|skip|take|` +
+		`from|into|whereIn|whereNot|whereNull|distinct|with|returning)\s*\(`,
+)
+
+// jstsBuilderReadVerbs are the read TERMINALS that are ambiguous with plain
+// array/Promise combinators, credited db_read only on a builder-typed receiver.
+//   - TypeORM   getMany/getOne/getRawMany/getRawOne/getManyAndCount/getCount/getRawOne
+//   - Knex      first/pluck/select (select also shapes, but as a terminal it reads)
+const jstsBuilderReadVerbs = `getMany|getOne|getManyAndCount|getRawMany|getRawOne|getRawAndEntities|getCount|getExists|first|pluck|select`
+
+// jstsBuilderWriteVerbs are the write TERMINALS gated to a builder-typed
+// receiver — `.execute()` terminates a TypeORM Insert/Update/Delete builder
+// and is far too generic to bare-match; `.del()`/`.truncate()` are Knex.
+const jstsBuilderWriteVerbs = `execute|del|truncate`
+
+// jstsBuilderInlineReadRe credits an ambiguous read terminal chained DIRECTLY
+// off a builder root inline — `repo.createQueryBuilder('u').where(...).getMany()`,
+// `knex('t').where(...).first()`, `prisma.user.findFirst()` (findFirst already
+// distinctive, but the inline knex/QB forms need this). The root must be a
+// createQueryBuilder() call, a knex(...) builder, or a prisma.<model> delegate.
+var jstsBuilderInlineReadRe = regexp.MustCompile(
+	`(?:[A-Za-z_$][\w$.]*\.createQueryBuilder\s*\([^;]*?\)|` +
+		`\bknex\s*(?:\([^;)]*\)|\.\s*table\s*\([^;)]*\))|` +
+		`(?:[A-Za-z_$][\w$]*\.)*prisma\s*\.\s*[A-Za-z_$][\w$]*)` +
+		`(?:\s*\.\s*[A-Za-z_$][\w$]*\s*\([^;]*?\))*?` +
+		`\s*\.\s*(?:` + jstsBuilderReadVerbs + `)\s*\(`,
+)
+
+// jstsBuilderInlineWriteRe credits an ambiguous write terminal chained inline
+// off a builder root — `repo.createQueryBuilder().update(User).set(...).execute()`,
+// `knex('t').where(...).del()`.
+var jstsBuilderInlineWriteRe = regexp.MustCompile(
+	`(?:[A-Za-z_$][\w$.]*\.createQueryBuilder\s*\([^;]*?\)|` +
+		`\bknex\s*(?:\([^;)]*\)|\.\s*table\s*\([^;)]*\)))` +
+		`(?:\s*\.\s*[A-Za-z_$][\w$]*\s*\([^;]*?\))*?` +
+		`\s*\.\s*(?:` + jstsBuilderWriteVerbs + `)\s*\(`,
+)
+
+// jstsPrismaRawRe matches Prisma raw escape hatches — `$queryRaw`/`$queryRawUnsafe`
+// (db_read) handled here; `$executeRaw`/`$executeRawUnsafe` are db_write
+// (jstsPrismaRawWriteRe). These are distinctive, no-collision names safe to
+// bare-match on any receiver.
+var jstsPrismaRawRe = regexp.MustCompile(
+	`\.\s*\$queryRaw(?:Unsafe)?\s*[\(` + "`" + `]`,
+)
+
+// jstsPrismaRawWriteRe matches Prisma `$executeRaw`/`$executeRawUnsafe` writes.
+var jstsPrismaRawWriteRe = regexp.MustCompile(
+	`\.\s*\$executeRaw(?:Unsafe)?\s*[\(` + "`" + `]`,
+)
+
 // jstsMutationRe matches `this.<field> = ...` — assignment to a receiver
 // field. We require an assignment operator on the same line and reject
 // `this.<field> ==` (comparison) by anchoring on `=` followed by a
@@ -105,6 +204,9 @@ func sniffEffectsJSTS(content string) []EffectMatch {
 	out = appendJSTSMatches(out, content, headers, jstsHTTPRe, EffectHTTPOut, "fetch/axios", 1.0)
 	out = appendJSTSMatches(out, content, headers, jstsDBReadRe, EffectDBRead, "orm.read", 0.8)
 	out = appendJSTSMatches(out, content, headers, jstsDBWriteRe, EffectDBWrite, "orm.write", 0.8)
+	out = appendJSTSMatches(out, content, headers, jstsPrismaRawRe, EffectDBRead, "prisma.$queryRaw", 0.9)
+	out = appendJSTSMatches(out, content, headers, jstsPrismaRawWriteRe, EffectDBWrite, "prisma.$executeRaw", 0.9)
+	out = append(out, jstsBuilderDataAccessMatches(content, headers)...)
 	out = appendJSTSMatches(out, content, headers, jstsFSReadRe, EffectFSRead, "fs.read", 1.0)
 	out = appendJSTSMatches(out, content, headers, jstsFSWriteRe, EffectFSWrite, "fs.write", 1.0)
 	out = appendJSTSMatches(out, content, headers, jstsMutationRe, EffectMutation, "this.field=", 0.7)
@@ -168,6 +270,82 @@ func appendJSTSMatches(out []EffectMatch, content string, headers []funcHeader, 
 		})
 	}
 	return out
+}
+
+// jstsBuilderDataAccessMatches implements the #4335/#4336 receiver-typed
+// fluent query-builder data-access credit. It (1) collects the set of names
+// known to hold a TypeORM QueryBuilder / Knex builder / Prisma delegate
+// (seeded from jstsBuilderRootRe, propagated across builder-shaper
+// reassignments to a fixpoint), then (2) emits db_read for each ambiguous
+// READ terminal and db_write for each ambiguous WRITE terminal invoked on one
+// of those typed names, AND for ambiguous terminals chained directly off a
+// builder root inline. An ambiguous terminal on an UNTYPED receiver (a plain
+// array `.first()`/Promise `.execute()`) earns no credit — the collection /
+// Promise false-positive guard is preserved.
+func jstsBuilderDataAccessMatches(content string, headers []funcHeader) []EffectMatch {
+	typed := collectJSTSBuilderTypedNames(content)
+	var out []EffectMatch
+	emit := func(off int, eff Effect, sink string) {
+		line := lineOfOffset(content, off)
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: 0.85,
+		})
+	}
+	// chainHop matches zero-or-more intermediate fluent shaper calls between
+	// the typed receiver and the terminal — `qb.where(...).leftJoin(...).getMany()`.
+	const chainHop = `(?:\s*\.\s*[A-Za-z_$][\w$]*\s*\([^;]*?\))*?`
+	for name := range typed {
+		q := regexp.QuoteMeta(name)
+		readRe := regexp.MustCompile(`\b` + q + chainHop + `\s*\.\s*(?:` + jstsBuilderReadVerbs + `)\s*\(`)
+		for _, m := range readRe.FindAllStringIndex(content, -1) {
+			emit(m[0], EffectDBRead, "builder.read")
+		}
+		writeRe := regexp.MustCompile(`\b` + q + chainHop + `\s*\.\s*(?:` + jstsBuilderWriteVerbs + `)\s*\(`)
+		for _, m := range writeRe.FindAllStringIndex(content, -1) {
+			emit(m[0], EffectDBWrite, "builder.write")
+		}
+	}
+	for _, m := range jstsBuilderInlineReadRe.FindAllStringIndex(content, -1) {
+		emit(m[0], EffectDBRead, "builder.read")
+	}
+	for _, m := range jstsBuilderInlineWriteRe.FindAllStringIndex(content, -1) {
+		emit(m[0], EffectDBWrite, "builder.write")
+	}
+	return out
+}
+
+// collectJSTSBuilderTypedNames returns the set of names that hold a TypeORM
+// QueryBuilder / Knex builder / Prisma delegate. Seeds from jstsBuilderRootRe,
+// then iterates jstsBuilderChainAssignRe to a fixpoint so a builder bound from
+// an already-typed receiver (`const qb2 = qb.where(...)`) is itself typed.
+func collectJSTSBuilderTypedNames(content string) map[string]bool {
+	typed := map[string]bool{}
+	for _, m := range jstsBuilderRootRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 2 && m[1] != "" {
+			typed[m[1]] = true
+		}
+	}
+	chains := jstsBuilderChainAssignRe.FindAllStringSubmatch(content, -1)
+	for {
+		changed := false
+		for _, m := range chains {
+			if len(m) < 3 {
+				continue
+			}
+			if typed[m[2]] && !typed[m[1]] {
+				typed[m[1]] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return typed
 }
 
 // nearestHeader returns the name of the function header whose Line is

--- a/internal/substrate/effect_sinks_python.go
+++ b/internal/substrate/effect_sinks_python.go
@@ -150,6 +150,32 @@ var pyInherentQSReadRe = regexp.MustCompile(
 		`|self\s*\.\s*queryset\s*\.\s*(?:` + pyQSAmbiguousVerbs + `)\s*\(`,
 )
 
+// --- #4336 SQLAlchemy Core fluent-builder data-access ---
+//
+// SQLAlchemy Core executes a statement object built by select()/insert()/
+// update()/delete() against a Connection/Engine: `conn.execute(select(t))`
+// (db_read) vs `conn.execute(insert(t))` (db_write). The receiver is a plain
+// `conn`/`engine` handle (NOT the `session.` form pyDBReadRe already covers),
+// and the read/write nature is determined by the STATEMENT CONSTRUCTOR passed
+// to `.execute(...)`, not the verb. We disambiguate on that constructor so a
+// Core read isn't mis-credited as a write (or vice-versa), and so a non-SQL
+// `.execute(...)` (e.g. a subprocess) is left alone.
+//
+// pySQLAlchemyCoreReadRe matches `<conn>.execute(select(...))` and
+// `<conn>.execute(text("SELECT ..."))` — the read statement constructors.
+var pySQLAlchemyCoreReadRe = regexp.MustCompile(
+	`\.\s*execute\s*\(\s*(?:select\s*\(` +
+		`|text\s*\(\s*['"](?i:\s*(?:SELECT|WITH)\b))`,
+)
+
+// pySQLAlchemyCoreWriteRe matches `<conn>.execute(insert(...))` /
+// `update(...)` / `delete(...)` and `<conn>.execute(text("INSERT ..."))` — the
+// write statement constructors.
+var pySQLAlchemyCoreWriteRe = regexp.MustCompile(
+	`\.\s*execute\s*\(\s*(?:(?:insert|update|delete)\s*\(` +
+		`|text\s*\(\s*['"](?i:\s*(?:INSERT|UPDATE|DELETE|REPLACE|MERGE|TRUNCATE)\b))`,
+)
+
 // pyCursorSelectRe matches `cursor.execute("SELECT ...")` style raw reads.
 // Case-insensitive on the SQL keyword. Quote-agnostic.
 var pyCursorSelectRe = regexp.MustCompile(
@@ -256,6 +282,8 @@ func sniffEffectsPython(content string) []EffectMatch {
 	out = appendPyMatches(out, content, headers, pyInherentQSReadRe, EffectDBRead, "orm.read.queryset", 0.85)
 	out = append(out, querysetReadMatches(content, headers)...)
 	out = appendPyMatches(out, content, headers, pyCursorSelectRe, EffectDBRead, "cursor.execute(SELECT)", 1.0)
+	out = appendPyMatches(out, content, headers, pySQLAlchemyCoreReadRe, EffectDBRead, "sqlalchemy.core.read", 0.9)
+	out = appendPyMatches(out, content, headers, pySQLAlchemyCoreWriteRe, EffectDBWrite, "sqlalchemy.core.write", 0.9)
 	out = appendPyMatches(out, content, headers, pyDBConnectRe, EffectDBRead, "db.connect/cursor", 0.8)
 	out = appendPyMatches(out, content, headers, pyDBWriteRe, EffectDBWrite, "orm.write", 0.85)
 	out = appendPyMatches(out, content, headers, pyCursorWriteRe, EffectDBWrite, "cursor.execute(WRITE)", 1.0)

--- a/internal/substrate/effect_sinks_querybuilder_4335_4336_test.go
+++ b/internal/substrate/effect_sinks_querybuilder_4335_4336_test.go
@@ -1,0 +1,244 @@
+package substrate
+
+// effect_sinks_querybuilder_4335_4336_test.go — fluent query-builder
+// data-access reach (#4335 TypeORM/Prisma, #4336 Mongoose-aggregate/Knex/
+// SQLAlchemy-Core), generalising the receiver-typed read/write discipline of
+// #4691/#4692/#4320/#4737/#4736.
+//
+// Per builder, three shapes:
+//   A — a builder chain ending in a READ terminal  → db_read
+//   A'— a builder chain ending in a WRITE terminal → db_write
+//   B — (negative) a plain array/Promise/collection chain whose terminal NAME
+//       collides with a builder terminal (.first()/.execute()) → STAYS pure
+//   C — a thin controller→service→builder-read method carries the db_read sink
+//       (the per-method sink the CALLS-union propagates up to the endpoint).
+
+import "testing"
+
+// ----------------------------------------------------- #4335 TypeORM QueryBuilder
+
+// A: createQueryBuilder().where().leftJoin().getMany()/getOne()/getRawMany() → read.
+func TestTypeORMQueryBuilderRead_4335(t *testing.T) {
+	src := `
+class UserRepository {
+  async listActive() {
+    const qb = this.repo.createQueryBuilder('u');
+    return qb.where('u.active = :a', { a: true }).leftJoinAndSelect('u.org', 'o').getMany();
+  }
+  async one(id) {
+    return this.repo.createQueryBuilder('u').where('u.id = :id', { id }).getOne();
+  }
+  async raw() {
+    const qb2 = this.repo.createQueryBuilder('u');
+    return qb2.select('u.name').getRawMany();
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBRead, "listActive")
+	mustHave(t, by, EffectDBRead, "one")
+	mustHave(t, by, EffectDBRead, "raw")
+}
+
+// A': createQueryBuilder().update(...).set(...).execute() / .delete().execute() → write.
+func TestTypeORMQueryBuilderWrite_4335(t *testing.T) {
+	src := `
+class UserRepository {
+  async deactivate(id) {
+    return this.repo.createQueryBuilder()
+      .update(User).set({ active: false }).where('id = :id', { id }).execute();
+  }
+  async purge() {
+    const qb = this.repo.createQueryBuilder();
+    return qb.delete().from(User).where('stale = true').execute();
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBWrite, "deactivate")
+	mustHave(t, by, EffectDBWrite, "purge")
+}
+
+// B (negative): a plain Promise chain ending in .execute() / array ending in
+// .first() stays pure — the builder-typed-receiver gate.
+func TestJSPlainChainNoFalsePositive_4335(t *testing.T) {
+	src := `
+function process(items, task) {
+  const head = items.first;
+  const out = items.map(x => x.id).filter(Boolean);
+  return task.execute(out);
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustNotHave(t, by, EffectDBRead, "process")
+	mustNotHave(t, by, EffectDBWrite, "process")
+}
+
+// C: thin repo read method carries the db_read sink for the CALLS-union.
+func TestTypeORMRepoReadChainSink_4335(t *testing.T) {
+	src := `
+class OrderRepository {
+  async getOrders() {
+    return this.repo.createQueryBuilder('o').where('o.open = true').getMany();
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBRead, "getOrders")
+}
+
+// ----------------------------------------------------------- #4335 Prisma fluent
+
+// A: prisma.<model>.findMany/findUnique/findFirst (distinctive) + $queryRaw.
+func TestPrismaFluentRead_4335(t *testing.T) {
+	src := `
+class UserService {
+  async list() {
+    return this.prisma.user.findMany({ where: { active: true }, include: { org: true } });
+  }
+  async byId(id) {
+    return prisma.user.findUnique({ where: { id } });
+  }
+  async raw() {
+    return this.prisma.$queryRaw` + "`SELECT * FROM users`" + `;
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBRead, "list")
+	mustHave(t, by, EffectDBRead, "byId")
+	mustHave(t, by, EffectDBRead, "raw")
+}
+
+// A': prisma.<model>.create/update/upsert/delete/createMany + $executeRaw.
+func TestPrismaFluentWrite_4335(t *testing.T) {
+	src := `
+class UserService {
+  async add(data) {
+    return this.prisma.user.create({ data });
+  }
+  async bulk(rows) {
+    return prisma.user.createMany({ data: rows });
+  }
+  async rawWrite() {
+    return this.prisma.$executeRaw` + "`UPDATE users SET active = false`" + `;
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBWrite, "add")
+	mustHave(t, by, EffectDBWrite, "bulk")
+	mustHave(t, by, EffectDBWrite, "rawWrite")
+}
+
+// ------------------------------------------------ #4336 Mongoose aggregate/populate
+
+// A: Model.aggregate([...]).lookup(...) and Model.find().populate(...) → read.
+func TestMongooseAggregateRead_4336(t *testing.T) {
+	src := `
+class FeedRepo {
+  async pipeline() {
+    return this.model.aggregate([{ $match: {} }]).lookup({ from: 'authors', as: 'a' });
+  }
+  async withAuthors() {
+    return this.model.find({ active: true }).populate('author');
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBRead, "pipeline")
+	mustHave(t, by, EffectDBRead, "withAuthors")
+}
+
+// ------------------------------------------------------------------ #4336 Knex
+
+// A: knex('t').where().select()/first()/pluck() → read.
+func TestKnexBuilderRead_4336(t *testing.T) {
+	src := `
+class UserDao {
+  async active() {
+    return knex('users').where({ active: true }).select('id', 'name');
+  }
+  async newest() {
+    const q = knex('users');
+    return q.orderBy('created_at', 'desc').first();
+  }
+  async ids() {
+    return knex('users').where('active', true).pluck('id');
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBRead, "active")
+	mustHave(t, by, EffectDBRead, "newest")
+	mustHave(t, by, EffectDBRead, "ids")
+}
+
+// A': knex('t').insert()/update()/del() → write.
+func TestKnexBuilderWrite_4336(t *testing.T) {
+	src := `
+class UserDao {
+  async add(row) {
+    return knex('users').insert(row);
+  }
+  async deactivate(id) {
+    const q = knex('users');
+    return q.where('id', id).del();
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBWrite, "add")
+	mustHave(t, by, EffectDBWrite, "deactivate")
+}
+
+// C: thin Knex repo read method carries db_read.
+func TestKnexRepoReadChainSink_4336(t *testing.T) {
+	src := `
+class OrderDao {
+  async getOrder(id) {
+    return knex('orders').where('id', id).first();
+  }
+}`
+	by := groupByEffect(sniffEffectsJSTS(src))
+	mustHave(t, by, EffectDBRead, "getOrder")
+}
+
+// ---------------------------------------------------- #4336 SQLAlchemy Core (Python)
+
+// A: conn.execute(select(...)) and session.execute(text("SELECT ...")) → read.
+func TestSQLAlchemyCoreRead_4336(t *testing.T) {
+	src := `
+class UserRepo:
+    def active(self):
+        with self.engine.connect() as conn:
+            return conn.execute(select(users).where(users.c.active == True)).fetchall()
+
+    def raw(self):
+        return self.session.execute(text("SELECT * FROM users"))
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustHave(t, by, EffectDBRead, "active")
+	mustHave(t, by, EffectDBRead, "raw")
+}
+
+// A': conn.execute(insert(...))/update(...)/delete(...) and text("INSERT") → write.
+func TestSQLAlchemyCoreWrite_4336(t *testing.T) {
+	src := `
+class UserRepo:
+    def add(self, conn, data):
+        return conn.execute(insert(users).values(**data))
+
+    def deactivate(self, conn, uid):
+        conn.execute(update(users).where(users.c.id == uid).values(active=False))
+
+    def purge(self, conn):
+        conn.execute(text("DELETE FROM users WHERE stale = 1"))
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustHave(t, by, EffectDBWrite, "add")
+	mustHave(t, by, EffectDBWrite, "deactivate")
+	mustHave(t, by, EffectDBWrite, "purge")
+}
+
+// C: thin SQLAlchemy Core repo read method carries db_read.
+func TestSQLAlchemyCoreReadChainSink_4336(t *testing.T) {
+	src := `
+class OrderRepo:
+    def get_order(self, conn, oid):
+        return conn.execute(select(orders).where(orders.c.id == oid)).fetchone()
+`
+	by := groupByEffect(sniffEffectsPython(src))
+	mustHave(t, by, EffectDBRead, "get_order")
+}


### PR DESCRIPTION
Generalizes the receiver-typed read/write effect-sink discipline (#4691/#4692/#4320/#4737/#4736) to **fluent query-builder chains** whose terminal verb decides read vs write, gated to a **builder-typed receiver** so plain array/Promise/collection combinators stay pure.

## #4335 — TypeORM / Prisma (TS/JS, `effect_sinks_jsts.go`)
- **TypeORM**: `createQueryBuilder('x').where().leftJoinAndSelect().getMany()/getOne()/getRawMany()/getCount()` → `db_read`; `.update()/.delete()…execute()` → `db_write`. Ambiguous terminals (`execute`/`first`/`pluck`) credited **only** on a `createQueryBuilder()`-typed receiver — seeded by `jstsBuilderRootRe`, propagated across `.where/.leftJoin/…` shaper reassignments to a fixpoint, plus inline-off-root. Distinctive `getMany`/`getRawMany` are bare-matched.
- **Prisma**: `prisma.<model>.findMany/findUnique/findFirst` → `db_read`; `create/createMany/update/upsert/delete` → `db_write` (distinctive, bare); `$queryRaw`/`$queryRawUnsafe` → `db_read`, `$executeRaw`/`$executeRawUnsafe` → `db_write`.

## #4336 — Mongoose aggregate + Knex + SQLAlchemy Core
- **Mongoose**: `Model.aggregate([…]).lookup({…})` and `Model.find().populate('f')` → `db_read` (`aggregate`/`lookup`/`populate` added to `jstsDBReadRe`).
- **Knex**: `knex('t').where().select()/first()/pluck()` → `db_read`; `.insert()/.update()/.del()/.truncate()` → `db_write`, gated to a `knex('t')`/`knex.table('t')`-typed receiver.
- **SQLAlchemy Core** (`effect_sinks_python.go`): `conn.execute(select(…))` / `session.execute(text("SELECT"))` → `db_read`; `conn.execute(insert()/update()/delete())` / `text("INSERT|UPDATE|DELETE")` → `db_write`. Read/write disambiguated by the **statement constructor** passed to `.execute()`, not the verb.

## Builder-typed-receiver gate (false-positive guard, preserved)
Ambiguous terminal names (`.first()`, `.execute()`, `.pluck()`, `.del()`) are credited **only** when chained off a builder-typed receiver or inline off a builder root. A plain `arr.map().filter()` / `task.execute(...)` / `items.first` chain earns no effect.

## Validation (`effect_sinks_querybuilder_4335_4336_test.go`)
Per builder: a read-terminal chain → `db_read`; a write-terminal chain → `db_write`; a plain array/Promise/collection chain → pure; a thin repo-read method carries the `db_read` sink for the CALLS-union to lift to the endpoint.

## Coverage docs
`query_attribution` cells refreshed (surgical, fmt-canonical) for `typeorm`/`prisma`/`mongoose`/`knex` (jsts) + `sqlalchemy` (python) with the fluent-builder data-access notes + cites. `coverage fmt --check` ok; `coverage validate` 0 errors.

## Gates
`go build ./...` ✅ · `go vet ./internal/substrate/... ./internal/engine/...` ✅ · `go test ./internal/substrate/... ./internal/engine/... ./internal/graph/... ./internal/types/` ✅ · `coverage fmt --check` ✅ · `coverage validate` 0 errors ✅

Closes #4335
Closes #4336

🤖 Generated with [Claude Code](https://claude.com/claude-code)