### PR TITLE
fix(go): resolve gin/echo r.Group prefix in HTTP-endpoint synthesis (#4408)

### DIFF
--- a/internal/engine/http_endpoint_go_anon_inline_4382_test.go
+++ b/internal/engine/http_endpoint_go_anon_inline_4382_test.go
@@ -87,13 +87,11 @@ func main() {
 `
 	ents, rels := detectInline(t, "go", "cmd/gin/main.go", src)
 	assertInlineEndpointBridged(t, ents, rels, "GET", "/ping", "gin")
-	// NOTE: the http_endpoint synthesis layer (synthesizeGoRouters) does not
-	// resolve gin r.Group("/v1") prefixes — it emits the route's own path
-	// ("/items"), for BOTH named and inline handlers alike. That group-prefix
-	// gap is pre-existing and handler-shape-INDEPENDENT (see PR follow-up); this
-	// #4382 assertion deliberately tracks the layer's actual (verb,path) so it
-	// isolates the inline-handler regression it is here to guard.
-	assertInlineEndpointBridged(t, ents, rels, "POST", "/items", "gin")
+	// #4408 — synthesizeGoRouters now resolves the enclosing gin
+	// r.Group("/v1") prefix and prepends it, for BOTH named and inline
+	// handlers alike. The inline route registered on the `v1` group therefore
+	// synthesizes at its fully-prefixed path.
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/v1/items", "gin")
 }
 
 // TestInline4382_EchoInlineHandlers covers echo e.GET("/x", func(c echo.Context) error {...}).

--- a/internal/engine/http_endpoint_go_group_prefix_4408_test.go
+++ b/internal/engine/http_endpoint_go_group_prefix_4408_test.go
@@ -1,0 +1,140 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #4408 — gin/echo `r.Group("/v1")` route-group prefixes must be resolved and
+// prepended to every route registered on the group variable, including nested
+// groups. Before this fix synthesizeGoRouters emitted the route's own path
+// (`/items`) without the enclosing group prefix (`/v1/items`).
+//
+// These tests call synthesizeGoRouters directly with a capturing emit so they
+// assert the exact (verb, canonical-path) pairs the synthesis layer produces,
+// independent of the downstream merge/resolve pipeline.
+
+func collectGoRoutes(src string) map[string]string {
+	out := map[string]string{}
+	emit := func(method, canonicalPath, framework, handlerKind, handlerName string) {
+		out[method+" "+canonicalPath] = framework
+	}
+	synthesizeGoRouters(src, emit)
+	return out
+}
+
+func assertRoute(t *testing.T, routes map[string]string, key string) {
+	t.Helper()
+	if _, ok := routes[key]; !ok {
+		keys := make([]string, 0, len(routes))
+		for k := range routes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		t.Errorf("expected route %q, got: [%s]", key, strings.Join(keys, ", "))
+	}
+}
+
+func assertNoRoute(t *testing.T, routes map[string]string, key string) {
+	t.Helper()
+	if _, ok := routes[key]; ok {
+		t.Errorf("did not expect route %q, but it was emitted", key)
+	}
+}
+
+// Fixture A: single group → route prefixed with the group path.
+func TestGroupPrefix4408_SingleGroup(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	v1 := r.Group("/api/v1")
+	v1.GET("/users", listUsers)
+	r.Run()
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /api/v1/users")
+	assertNoRoute(t, routes, "GET /users")
+}
+
+// Fixture B: nested group → route prefixed with the composed parent+child path.
+func TestGroupPrefix4408_NestedGroup(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	v1 := r.Group("/api/v1")
+	admin := v1.Group("/admin")
+	admin.POST("/ban", banUser)
+	r.Run()
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "POST /api/v1/admin/ban")
+	assertNoRoute(t, routes, "POST /ban")
+	assertNoRoute(t, routes, "POST /admin/ban")
+}
+
+// Fixture C: group with extra middleware args → prefix still resolved.
+func TestGroupPrefix4408_GroupWithMiddleware(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func authMW() gin.HandlerFunc { return func(c *gin.Context) {} }
+
+func main() {
+	r := gin.Default()
+	p := r.Group("/p", authMW())
+	p.GET("/x", getX)
+	r.Run()
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /p/x")
+	assertNoRoute(t, routes, "GET /x")
+}
+
+// Regression: a route registered directly on the root router (not a group)
+// keeps its own path unchanged.
+func TestGroupPrefix4408_RootRouteUnchanged(t *testing.T) {
+	src := `package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+	r := gin.Default()
+	r.GET("/health", healthCheck)
+	v1 := r.Group("/v1")
+	v1.GET("/users", listUsers)
+	r.Run()
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /health")
+	assertRoute(t, routes, "GET /v1/users")
+}
+
+// Echo groups use the same `.Group("/x")` spelling and must resolve too.
+func TestGroupPrefix4408_EchoGroup(t *testing.T) {
+	src := `package main
+
+import "github.com/labstack/echo/v4"
+
+func main() {
+	e := echo.New()
+	g := e.Group("/api")
+	g.GET("/ping", pingHandler)
+	e.Start(":1323")
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /api/ping")
+	assertNoRoute(t, routes, "GET /ping")
+}

--- a/internal/engine/response_shape_go.go
+++ b/internal/engine/response_shape_go.go
@@ -31,18 +31,37 @@ import (
 //	r.Get("/users", h.List)            // chi / fiber (idiomatic title-case)
 //	app.Delete("/users/:id", deleteUser)
 //
-// Group 1 is the verb, group 2 is the path, group 3 is the handler
-// identifier (may be qualified, e.g. `h.Create`). The handler is the
-// bare or last-component name so the shape extractor can locate its
-// definition in the same file.
+// Group 1 is the RECEIVER variable (the router or route-group on which the
+// verb method is invoked), group 2 is the verb, group 3 is the path, group 4
+// is the handler identifier (may be qualified, e.g. `h.Create`). The handler
+// is the bare or last-component name so the shape extractor can locate its
+// definition in the same file. The receiver name lets synthesis resolve a
+// `r.Group("/v1")` prefix and prepend it to the route path (#4408).
 //
 // The title-case spelling is matched here (it was previously only matched by
 // the ROUTES_TO-edge pass in go_routes.go) so that idiomatic chi/fiber/echo
 // handlers receive an http_endpoint_definition entity — which the
 // response-codes / pagination enrichment passes (#3920) then stamp.
 var goRouteRe = regexp.MustCompile(
-	`\b\w+\s*\.\s*(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|Get|Post|Put|Patch|Delete|Head|Options)\s*\(\s*` +
+	`\b(\w+)\s*\.\s*(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|Get|Post|Put|Patch|Delete|Head|Options)\s*\(\s*` +
 		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]` + "`" + `?\s*,\s*([\w.]+)`,
+)
+
+// goGroupAssignRe captures a gin/echo/chi route-GROUP assignment so its path
+// prefix can be prepended to every route registered on the group variable
+// (#4408). Recognised shapes:
+//
+//	v1 := r.Group("/api/v1")              // gin / echo
+//	admin := v1.Group("/admin", authMW)   // gin extra-middleware args
+//	g = base.Group("/g")                  // = reassignment
+//
+// Group 1 = the assigned group variable, group 2 = the parent receiver
+// (router or an enclosing group), group 3 = the literal prefix. Echo's
+// `e.Group("/x")` and chi's `r.Route("/x", fn)` use the same `.Group(`
+// spelling for echo; chi's `r.Route(` is captured by goChiRouteAssignRe.
+var goGroupAssignRe = regexp.MustCompile(
+	`\b(\w+)\s*:?=\s*(\w+)\s*\.\s*Group\s*\(\s*` +
+		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]*)["` + "`" + `]` + "`" + `?`,
 )
 
 // goFrameworkFromImports returns the framework name based on package
@@ -96,11 +115,16 @@ func synthesizeGoRouters(content string, emit emitFn) {
 	// (`.GET(`) are router-specific and need no such gate. This keeps the
 	// false-positive rate near zero while unlocking idiomatic chi/fiber/echo.
 	hasRouterImport := goFileImportsHTTPRouter(content)
+	// #4408 — resolve route-group prefixes (`v1 := r.Group("/v1")`, including
+	// nested groups `admin := v1.Group("/admin")`) so a route registered on a
+	// group variable synthesizes at its fully-prefixed path.
+	groupPrefix := goGroupPrefixIndex(content)
 	for _, m := range goRouteRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
+		if len(m) < 5 {
 			continue
 		}
-		rawVerb := m[1]
+		recv := m[1]
+		rawVerb := m[2]
 		// Normalise the verb to upper-case so the endpoint key is canonical
 		// regardless of the title-case (chi/fiber) vs upper-case (gin/echo)
 		// method-name spelling at the call site.
@@ -109,12 +133,18 @@ func synthesizeGoRouters(content string, emit emitFn) {
 		if rawVerb != verb && !hasRouterImport {
 			continue
 		}
-		raw := m[2]
-		handler := m[3]
+		raw := m[3]
+		handler := m[4]
 		// Use the last `.`-separated component so a `h.Create` style
 		// handler resolves to `Create` in the same file's func decls.
 		if i := strings.LastIndex(handler, "."); i >= 0 {
 			handler = handler[i+1:]
+		}
+		// Prepend the enclosing route-group prefix (if the route was registered
+		// on a `r.Group("/v1")` variable). The prefix is already accumulated
+		// across nested groups by goGroupPrefixIndex (#4408).
+		if pfx := groupPrefix[recv]; pfx != "" {
+			raw = joinPathFragments(pfx, raw)
 		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, raw)
 		// #4382 — the handler argument is an ANONYMOUS / INLINE func literal
@@ -131,6 +161,72 @@ func synthesizeGoRouters(content string, emit emitFn) {
 		}
 		emit(verb, canonical, framework, refKind, handler)
 	}
+}
+
+// goGroupPrefixIndex scans a Go file for gin/echo route-group assignments
+// (`v1 := r.Group("/v1")`, `admin := v1.Group("/admin")`) and returns a map
+// from each group VARIABLE to its fully-accumulated path prefix, composing
+// nested groups (`admin` → "/v1/admin") via joinPathFragments (#4408).
+//
+// Resolution is order-independent: assignments are collected first, then each
+// variable's prefix is resolved by walking its parent chain. The root router
+// (`r := gin.Default()`) is not a group, so it contributes no prefix and a
+// route on `r` directly is left unprefixed. A cycle guard (bounded by the
+// number of groups) prevents pathological self-referential bindings from
+// looping. Best-effort: a group whose prefix is built from a non-literal
+// (a `RouterGroup` passed into a setup func, a computed string) is not
+// statically recoverable and is simply omitted — the route then synthesizes
+// at its own path, the pre-#4408 behaviour, rather than a wrong path.
+func goGroupPrefixIndex(content string) map[string]string {
+	if !strings.Contains(content, ".Group(") {
+		return nil
+	}
+	type binding struct {
+		parent string // receiver the group was derived from
+		seg    string // this group's own (normalized) path segment
+	}
+	bindings := map[string]binding{}
+	for _, m := range goGroupAssignRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		varName := m[1]
+		parent := m[2]
+		seg := normalizeMountPrefix(m[3])
+		// A later assignment to the same variable wins (mirrors Go's last-write
+		// semantics in linear setup code). Self-assignment (`g = g.Group(...)`)
+		// keeps the earlier binding as the parent via the recorded parent name.
+		bindings[varName] = binding{parent: parent, seg: seg}
+	}
+	if len(bindings) == 0 {
+		return nil
+	}
+	resolved := map[string]string{}
+	var resolve func(name string, depth int) string
+	resolve = func(name string, depth int) string {
+		if p, ok := resolved[name]; ok {
+			return p
+		}
+		b, ok := bindings[name]
+		if !ok {
+			// `name` is the root router (or an unknown receiver): no prefix.
+			return ""
+		}
+		if depth > len(bindings) {
+			// Cycle guard: stop accumulating and treat as root-relative.
+			return b.seg
+		}
+		full := joinPathFragments(resolve(b.parent, depth+1), b.seg)
+		if full == "/" {
+			full = ""
+		}
+		resolved[name] = full
+		return full
+	}
+	for name := range bindings {
+		resolve(name, 0)
+	}
+	return resolved
 }
 
 // goFuncOpenRe locates the brace that opens a Go function or method


### PR DESCRIPTION
## Summary
`synthesizeGoRouters` emitted a gin/echo route's own path **without** its enclosing `r.Group("/v1")` prefix, so `v1.GET("/items")` synthesized as `GET /items` instead of `GET /v1/items`. The gap was handler-shape-independent (named and inline handlers both affected).

## Fix
- `goRouteRe` now captures the **receiver variable** of the verb call.
- New `goGroupPrefixIndex` builds a `group-var -> accumulated-prefix` map from `x := r.Group(p)` / `y := x.Group(q)` assignments, composing **nested** groups via `joinPathFragments`.
- At synthesis the route path is joined with the group's resolved prefix.
- Handles extra middleware args (`r.Group("/p", authMW)`) and `=` reassignment; root-router routes stay unprefixed.
- **Echo** uses the same `.Group(` spelling and is fixed in the same pass.

### Where synthesis lives
`internal/engine/response_shape_go.go` — `synthesizeGoRouters` (the http_endpoint synthesis layer, distinct from the `go_routes.go` ROUTES_TO-edge pass).

### Best-effort limits (documented)
- A `RouterGroup` passed into a setup func, or a computed/non-literal prefix, is not statically recoverable → route falls back to its own path (never a *wrong* prefix).
- chi `r.Route("/api", fn)` closure-based nesting is a **distinct mechanism** (not `.Group(`); left as a follow-up.

## Validation (RED -> GREEN)
New `http_endpoint_go_group_prefix_4408_test.go`:
- A: `v1 := r.Group("/api/v1"); v1.GET("/users")` -> `GET /api/v1/users`
- B: nested -> `POST /api/v1/admin/ban`
- C: `r.Group("/p", authMW())` -> `GET /p/x`
- echo: `e.Group("/api")` -> `GET /api/ping`
- regression: `r.GET("/health")` -> `GET /health` unchanged

Also updated the `#4382` gin inline assertion to the now-correct `/v1/items`.

## Gates
- `go build ./...`, `go vet ./internal/engine/...` clean
- `go test ./internal/custom/... ./internal/engine/... ./internal/graph/... ./cmd/archigraph/ -run 'Gin|Group|Endpoint'` green; full `internal/engine` suite green
- Coverage: gin + echo `endpoint_synthesis` cells updated surgically; `coverage fmt --check` canonical, `coverage validate` **0 errors**

Closes #4408

🤖 Generated with [Claude Code](https://claude.com/claude-code)