### PR TITLE
fix(mcp): project JOINS_COLLECTION + sibling DB-access graph edges as db sinks in data_flows (#4299)

### DIFF
--- a/internal/mcp/data_flows_db_edge_4299_test.go
+++ b/internal/mcp/data_flows_db_edge_4299_test.go
@@ -1,0 +1,138 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// docWithJoinEdge builds a one-repo Document whose DataAccess node reaches a
+// joined collection ONLY via a JOINS_COLLECTION graph edge (the #4299 repro:
+// a Mongo $lookup recorded on the graph but absent from the taint sidecar).
+func docWithJoinEdge(repo, kind string) *graph.Document {
+	return &graph.Document{
+		Repo: repo,
+		Entities: []graph.Entity{
+			{ID: "da1", Name: "scheduleLookup", Kind: "DataAccess", SourceFile: "schedule_viewset.py"},
+			{ID: "Class:Inspection", Name: "Inspection", Kind: "Class", SourceFile: "models.py"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "edge1", FromID: "da1", ToID: "Class:Inspection", Kind: kind, Confidence: 0.9},
+		},
+	}
+}
+
+// TestDataFlows_JoinsCollectionProjectedAsDBSink is the #4299 RED→GREEN: a flow
+// whose only DB signal is a JOINS_COLLECTION graph edge must appear under
+// data_flows(sink_kind=db). Before the fix handleDataFlows read only the taint
+// sidecar, so this returned 0.
+func TestDataFlows_JoinsCollectionProjectedAsDBSink(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no sidecar — pure graph-edge projection
+	srv := newTestServer(t, docWithJoinEdge("repo-a", "JOINS_COLLECTION"))
+
+	out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db"})
+
+	flows, ok := out["data_flows"].([]any)
+	if !ok || len(flows) != 1 {
+		t.Fatalf("data_flows = %v, want exactly one JOINS_COLLECTION db sink", out["data_flows"])
+	}
+	rec := flows[0].(map[string]any)
+	if rec["from"] != "repo-a::da1" {
+		t.Errorf("from = %v, want repo-a::da1", rec["from"])
+	}
+	if rec["to"] != "repo-a::Class:Inspection" {
+		t.Errorf("to = %v, want repo-a::Class:Inspection", rec["to"])
+	}
+	if rec["relation"] != "JOINS_COLLECTION" {
+		t.Errorf("relation = %v, want JOINS_COLLECTION", rec["relation"])
+	}
+	if rec["sink_kind"] != "db_read" {
+		t.Errorf("sink_kind = %v, want db_read", rec["sink_kind"])
+	}
+	if rec["sink"] != "Inspection" {
+		t.Errorf("sink = %v, want Inspection (target entity name)", rec["sink"])
+	}
+	if rec["source"] != "graph-edge" {
+		t.Errorf("flow source = %v, want graph-edge", rec["source"])
+	}
+	if src, _ := out["source"].(string); src != "graph-edge" {
+		t.Errorf("envelope source = %v, want graph-edge", src)
+	}
+}
+
+// TestDataFlows_DBEdgeSiblingsProjected covers the sibling DB-access edge kinds
+// added alongside JOINS_COLLECTION, each mapped to the right db_read/db_write
+// effect sink_kind.
+func TestDataFlows_DBEdgeSiblingsProjected(t *testing.T) {
+	cases := []struct {
+		kind     string
+		sinkKind string
+	}{
+		{"READS_FROM", "db_read"},
+		{"WRITES_TO", "db_write"},
+		{"QUERIES", "db_read"},
+		{"ACCESSES_TABLE", "db_read"},
+		{"MODIFIES_TABLE", "db_write"},
+		{"GRAPH_RELATES", "db_read"},
+	}
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			srv := newTestServer(t, docWithJoinEdge("repo-a", c.kind))
+			out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db"})
+			flows, _ := out["data_flows"].([]any)
+			if len(flows) != 1 {
+				t.Fatalf("%s: data_flows len = %d, want 1", c.kind, len(flows))
+			}
+			if sk := flows[0].(map[string]any)["sink_kind"]; sk != c.sinkKind {
+				t.Errorf("%s: sink_kind = %v, want %v", c.kind, sk, c.sinkKind)
+			}
+		})
+	}
+}
+
+// TestDataFlows_NonDBEdgeNotProjected is the negative: a non-DB semantic edge of
+// the same node shape (THROWS) must NOT be projected as a db sink.
+func TestDataFlows_NonDBEdgeNotProjected(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := newTestServer(t, docWithJoinEdge("repo-a", "THROWS"))
+	out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db"})
+	flows, _ := out["data_flows"].([]any)
+	if len(flows) != 0 {
+		t.Fatalf("THROWS must not be a db sink; got %d flows: %v", len(flows), flows)
+	}
+	// With no sidecar and no DB edges, the envelope reports the honest missing
+	// contract rather than fabricating a flow.
+	if src, _ := out["source"].(string); src != "missing" {
+		t.Errorf("source = %v, want missing", src)
+	}
+}
+
+// TestDataFlows_NonDBSinkKindFilterExcludesGraphEdges asserts a non-db sink_kind
+// filter (http) excludes the graph-edge DB projection entirely.
+func TestDataFlows_NonDBSinkKindFilterExcludesGraphEdges(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := newTestServer(t, docWithJoinEdge("repo-a", "JOINS_COLLECTION"))
+	out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "http"})
+	flows, _ := out["data_flows"].([]any)
+	if len(flows) != 0 {
+		t.Fatalf("sink_kind=http must exclude graph DB edges; got %d: %v", len(flows), flows)
+	}
+}
+
+// TestDataFlows_DBReadFilterMatchesProjectedKind asserts the concrete effect
+// filter db_read selects the JOINS_COLLECTION projection (which maps to db_read)
+// and db_write excludes it.
+func TestDataFlows_DBReadFilterMatchesProjectedKind(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := newTestServer(t, docWithJoinEdge("repo-a", "JOINS_COLLECTION"))
+
+	got := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db_read"})
+	if f, _ := got["data_flows"].([]any); len(f) != 1 {
+		t.Fatalf("db_read filter: want 1 flow, got %d", len(f))
+	}
+	got = callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db_write"})
+	if f, _ := got["data_flows"].([]any); len(f) != 0 {
+		t.Fatalf("db_write filter: JOINS_COLLECTION maps to db_read, want 0, got %d", len(f))
+	}
+}

--- a/internal/mcp/phase3_tools.go
+++ b/internal/mcp/phase3_tools.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/types"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -393,8 +394,53 @@ func dataFlowEndpointRepo(key string) string {
 	return ""
 }
 
+// dbSinkEdgeKinds is the set of live-graph DB-access relationship kinds that
+// represent a node reaching a database sink. handleDataFlows projects edges of
+// these kinds as `sink_kind=db` data flows so that DB access surfaced ONLY as a
+// graph edge — never picked up by the request-input→sink taint sniffer that
+// fills the data-flow sidecar — still appears under `data_flows(sink_kind=db)`
+// (#4299, follow-up to #4288).
+//
+// The set mirrors the DB-access subset of semanticEdgeKinds (internal/mcp/
+// tools.go) — every kind here is a genuine read/write/query/join against a
+// table or collection, NOT structural scaffolding and NOT a non-DB semantic
+// edge (THROWS, RENDERS, PUBLISHES_TO, …):
+//
+//	READS_FROM / WRITES_TO         — explicit DB read/write access edges
+//	QUERIES                        — ORM query call-site → model/table (#723)
+//	ACCESSES_TABLE / MODIFIES_TABLE — relational table read / mutation
+//	JOINS_COLLECTION               — Mongo $lookup / cross-collection join (#3426)
+//	GRAPH_RELATES                  — Neo4j graph-DB join analogue of the above (#3611)
+//
+// The map value is the synthesised effect-style `sink_kind` reported for the
+// projected flow — db_read for pure reads, db_write for writes/mutations, and
+// the join kinds default to db_read (a $lookup/relationship traversal reads the
+// joined collection). All match the `db` sink_kind filter (see sinkKindMatchesDB).
+var dbSinkEdgeKinds = map[string]string{
+	string(types.RelationshipKindReadsFrom):       "db_read",
+	string(types.RelationshipKindWritesTo):        "db_write",
+	string(types.RelationshipKindQueries):         "db_read",
+	string(types.RelationshipKindAccessesTable):   "db_read",
+	string(types.RelationshipKindModifiesTable):   "db_write",
+	string(types.RelationshipKindJoinsCollection): "db_read",
+	string(types.RelationshipKindGraphRelates):    "db_read",
+}
+
+// sinkKindMatchesDB reports whether a `sink_kind` filter value should include
+// graph-edge-projected DB sinks. An empty filter (no narrowing) and the generic
+// "db" both match; the concrete effect kinds db_read / db_write match their own
+// projected flows. Any other filter (http, queue, …) excludes them.
+func sinkKindMatchesDB(filter, projected string) bool {
+	switch filter {
+	case "", "db":
+		return true
+	default:
+		return filter == projected
+	}
+}
+
 func (s *Server) handleDataFlows(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	groupName, _, errRes := s.resolveAndGroup(req)
+	groupName, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
 	}
@@ -408,15 +454,7 @@ func (s *Server) handleDataFlows(_ context.Context, req mcpapi.CallToolRequest) 
 
 	var doc dataFlowSidecarDoc
 	path := sidecarPath(groupName, "data-flow")
-	if !loadSidecar(path, &doc) {
-		return jsonResult(map[string]any{
-			"data_flows": []any{},
-			"count":      0,
-			"total":      0,
-			"source":     "missing",
-			"note":       "Data-flow sidecar absent — run the link passes to generate it (#3867).",
-		}), nil
-	}
+	sidecarPresent := loadSidecar(path, &doc)
 
 	out := make([]map[string]any, 0, len(doc.Links))
 	for _, l := range doc.Links {
@@ -455,6 +493,78 @@ func (s *Server) handleDataFlows(_ context.Context, req mcpapi.CallToolRequest) 
 		}
 		out = append(out, rec)
 	}
+
+	// #4299: project live-graph DB-access edges (JOINS_COLLECTION and siblings)
+	// as db sinks. The taint sidecar only carries request-input→sink flows the
+	// sniffer could follow; a node whose only DB signal is a graph edge (e.g. a
+	// Mongo $lookup recorded as JOINS_COLLECTION) never appears there. Surface
+	// those edges so `data_flows(sink_kind=db)` is consistent with how
+	// db_read/db_write sinks are reported and with inspect().semantic_edges.
+	// Only runs when the sink_kind filter could include db sinks.
+	graphProjected := 0
+	if sinkKindMatchesDB(sinkKindFilter, "db_read") || sinkKindMatchesDB(sinkKindFilter, "db_write") {
+		for _, r := range reposToConsider(lg, argStringSlice(req, "repo_filter")) {
+			if r == nil || r.Doc == nil {
+				continue
+			}
+			repo := r.Doc.Repo
+			if len(repoFilter) > 0 && !repoFilter[repo] {
+				continue
+			}
+			byID := r.getByID()
+			for i := range r.Doc.Relationships {
+				rel := &r.Doc.Relationships[i]
+				sinkKind, ok := dbSinkEdgeKinds[strings.ToUpper(rel.Kind)]
+				if !ok {
+					continue
+				}
+				if !sinkKindMatchesDB(sinkKindFilter, sinkKind) {
+					continue
+				}
+				fromID := prefixedID(repo, rel.FromID)
+				if entityFilter != "" && fromID != entityFilter {
+					continue
+				}
+				toID := rel.ToID
+				if rprefix, _ := splitPrefixed(toID); rprefix == "" {
+					// Bare local id (graph ToIDs are local, e.g. "Class:Inspection")
+					// — repo-prefix it so the projected `to` matches the sidecar's
+					// "<repo>::<localId>" endpoint shape.
+					toID = prefixedID(repo, rel.ToID)
+				}
+				sink := toID
+				if tgt := byID[rel.ToID]; tgt != nil && tgt.Name != "" {
+					sink = tgt.Name
+				}
+				rec := map[string]any{
+					"id":         rel.ID,
+					"from":       fromID,
+					"to":         toID,
+					"relation":   rel.Kind,
+					"confidence": types.EffectiveConfidence(rel.Confidence),
+					"sink_kind":  sinkKind,
+					"sink":       sink,
+					"source":     "graph-edge",
+				}
+				if v := rel.Properties["field"]; v != "" {
+					rec["field"] = v
+				}
+				out = append(out, rec)
+				graphProjected++
+			}
+		}
+	}
+
+	if !sidecarPresent && graphProjected == 0 {
+		return jsonResult(map[string]any{
+			"data_flows": []any{},
+			"count":      0,
+			"total":      0,
+			"source":     "missing",
+			"note":       "Data-flow sidecar absent and no DB-access graph edges — run the link passes to generate it (#3867).",
+		}), nil
+	}
+
 	// Stable order: by from-endpoint, then sink, then id.
 	sort.SliceStable(out, func(i, j int) bool {
 		fi, fj := fmt.Sprint(out[i]["from"]), fmt.Sprint(out[j]["from"])
@@ -471,16 +581,25 @@ func (s *Server) handleDataFlows(_ context.Context, req mcpapi.CallToolRequest) 
 	if limit > 0 && len(out) > limit {
 		out = out[:limit]
 	}
+	source := "sidecar"
+	switch {
+	case sidecarPresent && graphProjected > 0:
+		source = "sidecar+graph-edge"
+	case !sidecarPresent && graphProjected > 0:
+		source = "graph-edge"
+	}
 	return jsonResult(map[string]any{
 		"data_flows": out,
 		"count":      len(out),
 		"total":      total,
 		"truncated":  total > len(out),
-		"source":     "sidecar",
+		"source":     source,
 		"note": "Request-input → sink DATA_FLOWS_TO edges (intra-function + bounded inter-procedural hops). " +
 			"`from` is the request handler, `to` the resolved sink entity (or a synthetic sink: residue), " +
 			"`field` the tainted request field, `hop_path` the inter-procedural chain. " +
-			"Precision-first: a flow the sniffer did not soundly follow is never fabricated (#3867).",
+			"Precision-first: a flow the sniffer did not soundly follow is never fabricated (#3867). " +
+			"db sinks reached only via live-graph DB-access edges (JOINS_COLLECTION/READS_FROM/WRITES_TO/" +
+			"QUERIES/ACCESSES_TABLE/MODIFIES_TABLE/GRAPH_RELATES) are also projected with source=graph-edge (#4299).",
 	}), nil
 }
 


### PR DESCRIPTION
## Problem
`data_flows(sink_kind=db)` returned **0** for a node whose only DB signal was a live-graph DB-access edge — e.g. the DataAccess node `upvate-core::37a62b82500fcaa4` with an outbound `JOINS_COLLECTION` to `Class:Inspection` (a Mongo `$lookup`). `handleDataFlows` (`internal/mcp/phase3_tools.go`) read **only** the request-input→sink taint sidecar (#3867), which has no entry for graph-edge-only DB access. This was the third leg of #4288, deferred here.

## Fix (MCP read layer)
Add a live-graph projection to `handleDataFlows`. Edges of the DB-access kinds are surfaced as `db` sinks alongside the sidecar flows:

| edge kind | projected sink_kind |
|---|---|
| `READS_FROM`, `QUERIES`, `ACCESSES_TABLE` | `db_read` |
| `WRITES_TO`, `MODIFIES_TABLE` | `db_write` |
| `JOINS_COLLECTION`, `GRAPH_RELATES` (Neo4j join analogue) | `db_read` |

This set is exactly the DB-access subset of `semanticEdgeKinds` (`internal/mcp/tools.go`), so the projection is consistent with `inspect().semantic_edges` and `neighbors` (#4288).

Each projected flow carries `source=graph-edge`; the envelope `source` becomes `graph-edge` or `sidecar+graph-edge` as appropriate. The projection runs **only** when the `sink_kind` filter could include db sinks (empty, `db`, `db_read`, `db_write`) — non-DB edges (`THROWS`, `RENDERS`, …) and non-db filters (`http`, …) are excluded. No non-DB edge is over-included.

## Tests (`internal/mcp/data_flows_db_edge_4299_test.go`, RED→GREEN)
- `JOINS_COLLECTION`-only flow now appears under `sink_kind=db` (the #4299 repro).
- All sibling DB-access kinds project with the correct `db_read`/`db_write` sink_kind.
- Negative: `THROWS` is **not** projected; `sink_kind=http` excludes graph DB edges.
- `db_read` filter selects the join; `db_write` excludes it.

## Gates
`go build ./...`, `go vet ./internal/mcp/... ./internal/engine/...`, `go test ./internal/mcp/... ./internal/engine/... ./internal/graph/...` all green. `coverage fmt --check` canonical; `coverage validate` 0 errors (pre-existing capability-map warnings only). No per-language registry cell applies — this is an MCP read-layer change.

Closes #4299

🤖 Generated with [Claude Code](https://claude.com/claude-code)