### PR TITLE
fix(reachability,testmap): tighten over-broad entry_points + TESTS-edge fallbacks (#4466)

### DIFF
--- a/internal/extractors/cross/testmap/extractor.go
+++ b/internal/extractors/cross/testmap/extractor.go
@@ -630,10 +630,25 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// edge) so the entity is never degree-0 in the graph regardless of how
 	// many @pytest.mark.parametrize parameter sets the test function has.
 	out := make([]types.EntityRecord, 0, len(tests))
+	// #4466: cap the file-name-convention LOW fallback to ONE edge per
+	// test FILE. Every test function in a spec that has no resolvable
+	// call previously emitted its own low-confidence edge to the SAME
+	// convention subject (e.g. 30 it() blocks -> 30 edges to user.service),
+	// inflating TESTS edges toward one-per-entity. The first such function
+	// records the coverage; later pure-fallback functions are skipped (a
+	// real call/mock/describe-subject in any function is unaffected — only
+	// the bare naming-convention fallback is throttled).
+	lowFallbackEmitted := false
 	for _, tf := range tests {
 		called := resolveCalls(tf, prodFile, prodSymbol, importedSyms)
 		if len(called) == 0 {
 			continue
+		}
+		if isPureLowConventionFallback(called) {
+			if lowFallbackEmitted {
+				continue
+			}
+			lowFallbackEmitted = true
 		}
 		out = append(out, buildCollapsedEntity(file.Path, file.Language, fw.name, testType, tf.qname, called))
 	}
@@ -643,6 +658,24 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		attribute.Int("tests_found", len(out)),
 	)
 	return out, nil
+}
+
+// isPureLowConventionFallback reports whether a resolved call set is nothing
+// more than the single naming-convention LOW fallback edge (#4466).
+//
+// resolveCalls only ever emits a "low"-confidence call from Pass 3b (the
+// file-name / stripped-test-name fallback) and only when NOTHING else
+// resolved — so a single low-confidence call is, by construction, the pure
+// fallback. Those edges carry no per-function signal; they are identical for
+// every fallback-only test function in the file. Capping them to the first
+// per file collapses the previous one-per-test-function flood. The moment any
+// real (high/medium) direct call, mock target, or describe-subject is present
+// the call set is not "pure low" and is never throttled.
+func isPureLowConventionFallback(called []testedCall) bool {
+	if len(called) != 1 {
+		return false
+	}
+	return called[0].confidence == "low"
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -3837,3 +3837,59 @@ end`
 		t.Errorf("assert macro must be stop-worded, not a tested target")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #4466 — over-broad TESTS-edge fallback regression guards
+// ---------------------------------------------------------------------------
+
+// countTestsEdges returns the total number of TESTS relationship edges across
+// all entity records.
+func countTestsEdges(recs []types.EntityRecord) int {
+	n := 0
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "TESTS" {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestTestsEdges_FallbackCappedPerFile is the #4466 fixture: a spec with many
+// co-located fallback-only tests (no resolvable call) must produce at most ONE
+// naming-convention TESTS edge for the whole file, not one per test function.
+// Previously every it() block emitted its own identical low-confidence edge to
+// the same convention subject, driving TESTS edges toward one-per-entity.
+func TestTestsEdges_FallbackCappedPerFile(t *testing.T) {
+	src := `import { describe, it } from 'vitest';
+describe('UserService', () => {
+  it('does a', () => { expect(1).toBe(1); });
+  it('does b', () => { expect(2).toBe(2); });
+  it('does c', () => { expect(3).toBe(3); });
+  it('does d', () => { expect(4).toBe(4); });
+});`
+	recs := runExtract(t, "src/user.service.spec.ts", "typescript", src)
+	edges := countTestsEdges(recs)
+	if edges > 1 {
+		t.Errorf("pure naming-convention fallback should emit ≤1 TESTS edge per file, got %d", edges)
+	}
+}
+
+// TestTestsEdges_RealCallNotThrottled guards that the per-file fallback cap
+// never suppresses a genuine high/medium-confidence subject: a test with a
+// real direct call still gets its own TESTS edge even when other co-located
+// tests are pure fallbacks.
+func TestTestsEdges_RealCallNotThrottled(t *testing.T) {
+	src := `import { describe, it } from 'vitest';
+import { OrderService } from './order.service';
+describe('OrderService', () => {
+  it('placebo a', () => { expect(1).toBe(1); });
+  it('places an order', () => { OrderService.placeOrder(payload); });
+  it('placebo b', () => { expect(2).toBe(2); });
+});`
+	recs := runExtract(t, "src/order.service.spec.ts", "typescript", src)
+	if !hasEdgeAny(recs, "it_places_an_order", "OrderService.placeOrder") {
+		t.Errorf("real direct-call subject must keep its TESTS edge; recs=%d", len(recs))
+	}
+}

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -266,6 +266,27 @@ var stopwords = map[string]bool{
 	"tohavekey": true, "tobeempty": true, "tobeaninstanceof": true,
 	"tobestring": true, "tobefloat": true, "tobeinf": true, "tobenan": true,
 	"tobebetween": true, "tothrow": true, "tobegreaterhan": true,
+	// JS/TS — Jest / Vitest / Jasmine matcher verbs captured in BARE form
+	// (#4466). `expect(x).toBe(y)` yields a bare `toBe(` token because the
+	// `)` after the subject breaks the dotted chain (directCallRE then sees
+	// `toBe` alone — the `.tobe` SUFFIX filter never fires). Mirrors the
+	// AssertJ/Mockito bare-form handling added in #3855. Without these the
+	// resolver emits a medium-confidence TESTS edge to `toBe`/`toEqual`/…
+	// for nearly every assertion, driving TESTS edges toward one-per-entity.
+	"tobe": true, "tobedefined": true, "tobeundefined": true,
+	"tobecloseto": true, "tobegreaterthan": true,
+	"tobegreaterthanorequal": true, "tobelessthan": true,
+	"tobelessthanorequal": true, "tobeinstanceof": true,
+	"tomatch": true, "tomatchobject": true, "tomatchsnapshot": true,
+	"tomatchinlinesnapshot": true, "tocontainequal": true,
+	"tohavelength": true, "tohaveproperty": true,
+	"tohavebeencalled": true, "tohavebeencalledwith": true,
+	"tohavebeencalledtimes": true, "tohavebeencalledonce": true,
+	"tohavebeenlastcalledwith": true, "tohavebeennthcalledwith": true,
+	"tohavereturned": true, "tohavereturnedwith": true,
+	"toreturn": true, "tostrictequal": true, "tothrowerror": true,
+	"toresolve": true, "toreject": true, "tobetruthy": true,
+	"tobefalsy": true, "tohavebeencalledbefore": true,
 	// PHP — Laravel feature test HTTP helpers (test infrastructure, not prod calls)
 	// $this->get/post/put/patch/delete/json/getJson/postJson/putJson/patchJson/deleteJson
 	"$this->get": true, "$this->post": true, "$this->put": true,
@@ -688,6 +709,17 @@ func resolveCalls(tf testFunction, prodFile, convSymbol string, importedSyms map
 	}
 
 	// Pass 3b: naming convention fallback when no call/mock was found.
+	//
+	// #4466: this fallback is a last resort with NO per-function signal —
+	// the file-anchored convention symbol (convSymbol, from the test FILE
+	// name) or, when that is empty, the stripped test-function name. The
+	// previous behaviour emitted one such edge for EVERY test function with
+	// no resolvable call, so a spec with 30 it() blocks produced 30
+	// identical low-confidence edges, driving TESTS edges toward one per
+	// entity. The edge is still emitted (it preserves directory-convention
+	// coverage, e.g. e2e/ and tests/ files with no stem convention), but
+	// the Extract caller now caps the pure-fallback edge to ONCE per file
+	// via isPureLowConventionFallback.
 	if len(seen) == 0 {
 		sym := convSymbol
 		if sym == "" {

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -237,7 +237,23 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 				continue
 			}
 			fileNames := nameByFile[file]
+			// #4466: library_export entries are only genuine entry-point
+			// ROOTS when they form the package's public API surface — a
+			// barrel / index / explicit package entry file. In an
+			// application repo virtually every internal module re-exports
+			// its symbols (services, controllers, DTOs, every type), so
+			// honouring every export as a seed made ~65% of entities
+			// "entry points" and falsely marked unconsumed exports
+			// reachable. Internal-module exports that are actually used
+			// are still reached transitively via the IMPORTS edge, so
+			// dropping them as SEEDS does not lose live code — it only
+			// stops masking genuinely dead exports.
+			publicAPI := isPublicAPIFile(file)
 			for _, ep := range eps {
+				// Library exports from non-public-API files are not roots.
+				if ep.Kind == EntryKindLibraryExport && !publicAPI {
+					continue
+				}
 				// Match the sniffed ident against entities declared
 				// in the same file. Three lookup keys:
 				//   1. the ident as-is (covers function/class names)
@@ -378,6 +394,34 @@ func firstKey(m map[string]bool) string {
 		return k
 	}
 	return ""
+}
+
+// isPublicAPIFile reports whether a repo-relative source path is part of
+// the package's public API surface — the set of files whose exports are
+// genuine externally-invocable entry-point roots (#4466).
+//
+// Recognised as public API:
+//   - barrel / package-entry files: index.{ts,tsx,js,jsx,mjs,cjs}
+//   - explicit public-api / public_api files (Angular library convention)
+//   - mod.ts (Deno) and lib.rs / mod.rs entry roots
+//
+// Everything else is an internal module: its exports are wiring consumed
+// via IMPORTS edges, not external entry points. Internal exports that are
+// actually used stay reachable transitively; unused ones correctly fall
+// out as dead-code candidates rather than being masked as "entry points".
+func isPublicAPIFile(file string) bool {
+	base := strings.ToLower(file)
+	if i := strings.LastIndexAny(base, "/\\"); i >= 0 {
+		base = base[i+1:]
+	}
+	switch base {
+	case "index.ts", "index.tsx", "index.js", "index.jsx",
+		"index.mjs", "index.cjs",
+		"public-api.ts", "public_api.ts", "public-api.js", "public_api.js",
+		"mod.ts", "lib.rs", "mod.rs":
+		return true
+	}
+	return false
 }
 
 // keysOf returns the sorted keys of m.

--- a/internal/links/reachability_test.go
+++ b/internal/links/reachability_test.go
@@ -126,3 +126,32 @@ func TestReachabilityNoSniffableFiles(t *testing.T) {
 		t.Errorf("expected at least 1 unreachable (z)")
 	}
 }
+
+// TestIsPublicAPIFile is the #4466 entry-point fixture: only package-entry /
+// barrel files form the public API surface whose exports are genuine
+// entry-point roots. Internal-module exports are reached via IMPORTS edges,
+// not seeded — so they no longer inflate the entry_points count nor mask
+// genuinely-dead exports.
+func TestIsPublicAPIFile(t *testing.T) {
+	public := []string{
+		"index.ts", "src/index.ts", "src/index.tsx",
+		"lib/index.js", "pkg/index.mjs",
+		"projects/ui/src/public-api.ts", "src/public_api.ts",
+		"deno/mod.ts", "crate/src/lib.rs", "crate/src/foo/mod.rs",
+	}
+	for _, p := range public {
+		if !isPublicAPIFile(p) {
+			t.Errorf("isPublicAPIFile(%q) = false, want true (public API surface)", p)
+		}
+	}
+	internal := []string{
+		"src/user/user.service.ts", "src/order/order.controller.ts",
+		"src/dto/user.dto.ts", "src/helpers/format.ts",
+		"src/auth/auth.module.ts", "components/Button.tsx",
+	}
+	for _, p := range internal {
+		if isPublicAPIFile(p) {
+			t.Errorf("isPublicAPIFile(%q) = true, want false (internal module, reached via IMPORTS)", p)
+		}
+	}
+}

--- a/internal/substrate/entry_points_jsts.go
+++ b/internal/substrate/entry_points_jsts.go
@@ -2,7 +2,9 @@
 //
 // Recognises:
 //   - `export function <name>` / `export const <name>` / `export class
-//     <Name>` / `export default …` → library_export.
+//     <Name>` / `export default …` → library_export. Type-only exports
+//     (interface/type/enum) are excluded — they are compile-time-erased
+//     and never runtime entry roots (#4466).
 //   - `function main(` at module scope → cli_main.
 //   - `it(` / `test(` / `describe(` at module scope → test_entry (one
 //     entry per call site; the test runner invokes each).
@@ -20,8 +22,13 @@ func init() { RegisterEntryPoints("jsts", sniffJSTSEntryPoints) }
 
 // jstsExportNamedRe matches `export function|class|const|let|var <name>`.
 // Capture 1 = name.
+//
+// Type-only exports (`interface`, `type`, `enum`) are intentionally NOT
+// matched (#4466): they are compile-time-erased and can never be invoked
+// by the runtime, so they are never genuine entry-point roots. A type is
+// reachable iff something REFERENCES it (a graph edge), never as a seed.
 var jstsExportNamedRe = regexp.MustCompile(
-	`(?m)^export\s+(?:async\s+)?(?:function\*?|class|const|let|var|interface|type|enum)\s+([A-Za-z_$][\w$]*)`,
+	`(?m)^export\s+(?:async\s+)?(?:function\*?|class|const|let|var)\s+([A-Za-z_$][\w$]*)`,
 )
 
 // jstsExportDefaultFnRe matches `export default function <name>(` and

--- a/internal/substrate/entry_points_test.go
+++ b/internal/substrate/entry_points_test.go
@@ -182,6 +182,35 @@ export { internalThing as renamedThing };
 	}
 }
 
+// TestSniffJSTSEntryPoints_TypeExportsExcluded is the #4466 fixture: type-only
+// exports (interface/type/enum) are compile-time-erased and can never be
+// invoked by the runtime, so they must NOT be emitted as library_export entry
+// points. Value exports (function/class/const) and the genuine roots stay.
+func TestSniffJSTSEntryPoints_TypeExportsExcluded(t *testing.T) {
+	src := `export function handler() {}
+export class Service {}
+export const helper = () => {};
+export interface UserDto { id: string }
+export type UserId = string;
+export enum Role { Admin, User }
+`
+	eps := sniffJSTSEntryPoints(src)
+	idents := map[string]EntryKind{}
+	for _, e := range eps {
+		idents[e.Ident] = e.Kind
+	}
+	for _, name := range []string{"handler", "Service", "helper"} {
+		if idents[name] != EntryKindLibraryExport {
+			t.Errorf("%q (value export) should be library_export, got %v", name, idents[name])
+		}
+	}
+	for _, name := range []string{"UserDto", "UserId", "Role"} {
+		if _, ok := idents[name]; ok {
+			t.Errorf("%q (type-only export) must NOT be an entry point (#4466), got %v", name, idents[name])
+		}
+	}
+}
+
 func TestSniffJSTSEntryPointsEmptyInput(t *testing.T) {
 	if eps := sniffJSTSEntryPoints(""); eps != nil {
 		t.Errorf("empty content should yield nil, got %v", eps)


### PR DESCRIPTION
## Problem (#4466)

On the fresh upvate-v3 index two metrics were implausible and eroded graph trust:

- **`entry_points: 13,000 / 20,073` (65%)** — entry-point detection treated almost every entity as a root.
- **`tests_edges: 19,849 ≈ entity_count 20,073`** (~1 TESTS edge per entity).

Both were caused by over-broad **inference** rules, not real structure. Three independent over-emissions are fixed here.

## entry_points

**Root cause:** the reachability seed pass honoured the jsts sniffer's `library_export` for **every** named export. In a NestJS/TS application repo virtually every internal module exports its symbols (services, controllers, DTOs, every interface/type), so 65% of entities became "entry points" — and unconsumed exports were falsely marked *reachable*, masking real dead code.

**Fix:**
- `internal/links/reachability.go` — only honour sniffed `library_export` entries from **public-API / barrel files** (`index.*`, `public-api.*`, `mod.ts`, `lib.rs`/`mod.rs`) as BFS seeds (new `isPublicAPIFile`). Internal-module exports that are actually used stay reachable transitively via the `IMPORTS` edge (already a reachability-propagating edge), so no live code is lost — unused internal exports correctly fall out as dead-code candidates instead of being masked.
- `internal/substrate/entry_points_jsts.go` — drop type-only exports (`interface`/`type`/`enum`) from `library_export`; they are compile-time-erased and can never be runtime roots.

## tests_edges (the over-broad fallback — NOT the #4615 route-hit edges)

The legitimate route-hit + receiver-typed handler `CALLS→TESTS` coverage edges (`ApplyTestsMultiHopViaHTTP`, tests-walkup) are correct and **left untouched**. Two separate over-broad fallbacks are fixed:

- `internal/extractors/cross/testmap/resolver.go` — add bare Jest/Vitest matcher verbs (`toBe`, `toEqual`, `toHaveBeenCalledWith`, …) to the stopword set. `expect(x).toBe(y)` breaks the dotted chain at `)`, so `directCallRE` captured the **bare** `toBe` and the `.tobe` suffix filter never fired — emitting a medium-confidence TESTS edge for nearly every assertion. Mirrors the AssertJ/Mockito bare-form fix (#3855).
- `internal/extractors/cross/testmap/extractor.go` — cap the naming-convention **LOW** fallback to **once per test file**. Previously every `it()`/`test()` block with no resolvable call emitted its own identical low-confidence edge to the same convention subject (a 30-`it` spec → 30 edges), pushing TESTS toward one-per-entity. Real high/medium direct calls, mock targets and describe-subjects are never throttled.

## Fixtures

- entry_points: type-export exclusion (`entry_points_test.go`) + `isPublicAPIFile` public-vs-internal (`reachability_test.go`).
- tests_edges: per-file fallback cap (≤1 edge for a fallback-only spec) + real-call-not-throttled (`extractor_test.go`).

## Remaining for coordinator live-validation

These tighten the clear over-broad rules; the exact post-fix counts need a live upvate-v3 reindex. At next deploy, verify:
- `entry_points` drops from ~13k toward the genuine-root set (HTTP endpoints/handlers via graph edges + barrel exports + lifecycle/CLI + test roots).
- `tests_edges` drops from ~19.8k toward per-suite/per-subject (hundreds–low-thousands), with the #4615 route-hit edges preserved.

## Gates
- `go build ./...` ✅, `go vet` (substrate/engine/graph/links/testmap) ✅
- `go test` substrate, engine, graph, types, links, testmap, mcp ✅
- `coverage fmt --check` → canonical ✅; `coverage validate` → 0 errors ✅ (no per-language registry cell changed — logic-only fix)

Closes #4466

🤖 Generated with [Claude Code](https://claude.com/claude-code)