### PR TITLE
fix(coverage): re-key testable-denominator exclusion on read-layer-persisted fields, not Subtype (#4534)

### DIFF
--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -404,9 +404,44 @@ func isNonTestableFile(path string) bool {
 // Matching is case-insensitive on the entity Name suffix. The list is kept
 // conservative to avoid excluding real services that happen to end in a noun.
 var nonTestableNameSuffixes = []string{
-	"dto",       // Data Transfer Object
-	"dtos",      // pluralised barrel
-	"decorator", // cross-cutting annotation, not behaviour
+	"dto",        // Data Transfer Object
+	"dtos",       // pluralised barrel
+	"decorator",  // cross-cutting annotation, not behaviour
+	"decorators", // pluralised barrel
+	"annotation", // cross-cutting annotation, not behaviour
+}
+
+// nonTestableKinds are entity kinds that are type-only / data-shape contracts
+// with no executable body, so they are never testable production code even when
+// they slip into coverageEntityKinds-adjacent territory. These are matched on
+// the PERSISTED `Kind` field (round-trips through the flatbuffer read layer via
+// load.go fbEntityToGraphEntity), which is reliably set by every extractor —
+// unlike `Subtype`, which most extractors leave empty (#4534).
+//
+// Matching is case-insensitive on the bare kind and on the `SCOPE.<X>` tail, so
+// both raw kinds ("Interface", "TypeAlias") and namespaced kinds
+// ("SCOPE.Interface") are caught language-agnostically.
+var nonTestableKinds = map[string]bool{
+	"interface":   true, // type-only contract, no body
+	"typealias":   true, // alias, no body
+	"type_alias":  true,
+	"type":        true, // bare type declaration
+	"enum":        true, // value enumeration, no behaviour
+	"enummember":  true,
+	"enum_member": true,
+	"annotation":  true, // decorator/annotation declaration
+	"decorator":   true,
+}
+
+// kindTail returns the lower-cased, namespace-stripped kind for matching
+// against nonTestableKinds: "SCOPE.Interface" → "interface", "Interface" →
+// "interface". Operates purely on the persisted Kind field.
+func kindTail(kind string) string {
+	k := strings.ToLower(kind)
+	if i := strings.LastIndex(k, "."); i >= 0 {
+		k = k[i+1:]
+	}
+	return k
 }
 
 // isNonTestableEntity returns true when an in-scope-kind entity should still be
@@ -414,19 +449,27 @@ var nonTestableNameSuffixes = []string{
 // (DTO/decorator/type-only) or because it lives in a non-testable file.
 //
 // This is the single principled definition of "NOT testable production code"
-// (#4510). It is intentionally kind-/path-/name-driven (no language-specific
-// hacks) so it generalises across every extractor.
+// (#4510/#4534). It is keyed STRICTLY on read-layer-PERSISTED fields — the
+// source-file path (isNonTestableFile), the entity Kind, and the entity Name —
+// never on `Subtype`. Subtype round-trips through the flatbuffer writer/reader
+// but most extractors never populate it with role tags (dto/decorator/
+// annotation/enum_member are emitted by ZERO extractors today), so a
+// Subtype-keyed exclusion silently no-ops on the live reindexed graph even
+// though it passes against an in-memory fixture that hand-sets Subtype (#4534).
+// Path/Kind/Name are guaranteed present on the read layer, so the exclusion
+// fires identically in-pipeline and live.
 func isNonTestableEntity(e *Entity) bool {
 	if isNonTestableFile(e.SourceFile) {
 		return true
 	}
-	// Subtype-driven exclusions: extractors tag DTOs/decorators/type-only
-	// entities via Subtype on several languages. Treat the well-known data /
-	// annotation subtypes as non-testable.
-	switch strings.ToLower(e.Subtype) {
-	case "dto", "decorator", "annotation", "type_alias", "typealias", "enum_member":
+	// Kind-driven exclusions: type-only / data-shape contracts have no
+	// executable body. Keyed on the persisted Kind field (not Subtype).
+	if nonTestableKinds[kindTail(e.Kind)] {
 		return true
 	}
+	// Name-convention exclusions: DTOs, decorators and annotations whose
+	// concrete kind (Class/Struct) would otherwise count. Keyed on the
+	// persisted Name field, framework-agnostic.
 	lname := strings.ToLower(e.Name)
 	for _, suf := range nonTestableNameSuffixes {
 		if strings.HasSuffix(lname, suf) {
@@ -476,7 +519,15 @@ func isTestEntity(e *Entity) bool {
 	if testEntityKinds[e.Kind] {
 		return true
 	}
-	// One-per-file suite marker emitted by the non-JS test extractors.
+	// One-per-file suite marker emitted by the non-JS test extractors. The
+	// persisted `pattern_type` Property is checked first because it survives
+	// the flatbuffer read layer reliably (load.go copies all Properties); the
+	// Subtype/Kind checks are kept as compatible fallbacks (#4534). All three
+	// are read-layer-persisted, but pattern_type is the signal extractors set
+	// most consistently.
+	if e.Properties != nil && e.Properties["pattern_type"] == "test_suite" {
+		return true
+	}
 	return e.Subtype == "test_suite" || e.Kind == "test_suite"
 }
 

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -644,6 +644,113 @@ func TestComputeCoverage_4510_DenominatorAndAffinity(t *testing.T) {
 	}
 }
 
+// TestComputeCoverage_4534_DenominatorReadLayerShape pins the #4534 fix: the
+// testable-denominator exclusion must key on READ-LAYER-PERSISTED fields
+// (SourceFile path + Kind + Name), never on Subtype. The live flatbuffer read
+// layer round-trips Subtype but most extractors leave it EMPTY, so a
+// Subtype-keyed exclusion silently no-ops on the reindexed graph even though it
+// passes against an in-memory fixture that hand-sets Subtype.
+//
+// Every entity here is shaped exactly as the read layer presents it: Subtype is
+// EMPTY on all of them; only Kind / SourceFile / Name (and one persisted
+// Property for the suite) are set. The old Subtype-keyed switch
+// ("dto"/"decorator"/"annotation"/"enum_member"/"type_alias") would have
+// excluded NOTHING here (all Subtypes empty) and inflated the denominator with
+// the DTO, the enum and the type alias. The new path/Kind/Name-keyed logic must
+// drop them.
+func TestComputeCoverage_4534_DenominatorReadLayerShape(t *testing.T) {
+	t.Parallel()
+	entities := []Entity{
+		// Real, testable production code — MUST count. Subtype EMPTY.
+		{ID: "svc", Name: "OrderService", Kind: "Class", SourceFile: "src/orders/order_service.ts"},
+		{ID: "ctrl", Name: "OrderController", Kind: "SCOPE.Operation", SourceFile: "src/orders/order.controller.ts"},
+
+		// DTO whose CONCRETE kind is Class (slips past coverageEntityKinds) —
+		// excluded by NAME suffix, not Subtype. Subtype EMPTY (read-layer shape).
+		{ID: "dto", Name: "CreateOrderDto", Kind: "Class", SourceFile: "src/orders/dto/create-order.ts"},
+		// Decorator class — excluded by name suffix. Subtype EMPTY.
+		{ID: "dec", Name: "RolesDecorator", Kind: "Class", SourceFile: "src/auth/roles.ts"},
+		// Annotation class — excluded by the new name suffix (#4534). Subtype EMPTY.
+		{ID: "ann", Name: "AuditAnnotation", Kind: "Class", SourceFile: "src/audit/audit.ts"},
+
+		// Type-only / data-shape KINDS — excluded by Kind (persisted), not
+		// Subtype. These previously relied on a Subtype tag the extractor never
+		// sets. Subtype EMPTY.
+		{ID: "iface", Name: "IOrder", Kind: "SCOPE.Interface", SourceFile: "src/orders/order.types.ts"},
+		{ID: "alias", Name: "OrderId", Kind: "TypeAlias", SourceFile: "src/orders/ids.ts"},
+		{ID: "enm", Name: "OrderStatus", Kind: "Enum", SourceFile: "src/orders/status.ts"},
+
+		// Non-testable PATH — migration in a behaviour-bearing kind. Excluded by
+		// path. Subtype EMPTY.
+		{ID: "mig", Name: "up", Kind: "SCOPE.Operation", SourceFile: "src/common/database/migrations/0001_init.ts"},
+		// scripts/ dir — excluded by path. Subtype EMPTY.
+		{ID: "scr", Name: "seed", Kind: "Function", SourceFile: "scripts/seed.ts"},
+
+		// A read-layer-shaped pytest suite: SCOPE.Pattern with the PERSISTED
+		// pattern_type Property (Subtype intentionally EMPTY to prove the
+		// persisted-Property fallback fires). It lives in a test file and TESTS
+		// the service. Must be classified as a TEST entity (so it does not pad
+		// the production denominator) and credit the service.
+		{ID: "suite", Name: "pytest_suite:order", Kind: "SCOPE.Pattern",
+			SourceFile: "src/orders/__tests__/order_service.spec.ts",
+			Properties: map[string]string{"pattern_type": "test_suite"}},
+	}
+	rels := []Relationship{
+		{ID: "t1", FromID: "suite", ToID: "svc", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+
+	// Only the two real production entities count: OrderService + OrderController.
+	if report.TotalProduction != 2 {
+		t.Fatalf("TotalProduction want 2 (OrderService+OrderController only); the DTO/decorator/interface/alias/enum/migration/script must drop out via persisted path/Kind/Name. got %d", report.TotalProduction)
+	}
+	// The persisted-Property suite must be recognised as a test and credit svc.
+	if report.CoveredProduction != 1 {
+		t.Errorf("CoveredProduction want 1 (suite TESTS OrderService via pattern_type-persisted suite), got %d", report.CoveredProduction)
+	}
+	// Guard: none of the excluded entities leaked into the uncovered list.
+	for _, u := range report.UncoveredEntities {
+		switch u.EntityID {
+		case "dto", "dec", "ann", "iface", "alias", "enm", "mig", "scr", "suite":
+			t.Errorf("entity %q (%s) must be excluded from the denominator, but appears in uncovered list", u.EntityID, u.Kind)
+		}
+	}
+}
+
+// TestIsNonTestableEntity_PersistedFieldsOnly is a focused unit test that the
+// exclusion predicate reads ONLY persisted fields. It pairs each case with an
+// EMPTY Subtype (read-layer shape) so a regression that reintroduces a
+// Subtype dependency fails here.
+func TestIsNonTestableEntity_PersistedFieldsOnly(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		e    Entity
+		want bool
+	}{
+		{"service-class", Entity{Name: "OrderService", Kind: "Class", SourceFile: "src/order_service.ts"}, false},
+		{"controller-op", Entity{Name: "list", Kind: "SCOPE.Operation", SourceFile: "src/order.controller.ts"}, false},
+		{"dto-by-name", Entity{Name: "CreateOrderDto", Kind: "Class", SourceFile: "src/create.ts"}, true},
+		{"decorator-by-name", Entity{Name: "RolesDecorator", Kind: "Class", SourceFile: "src/roles.ts"}, true},
+		{"annotation-by-name", Entity{Name: "AuditAnnotation", Kind: "Class", SourceFile: "src/audit.ts"}, true},
+		{"interface-by-kind", Entity{Name: "IOrder", Kind: "Interface", SourceFile: "src/order.ts"}, true},
+		{"scope-interface-by-kind", Entity{Name: "IOrder", Kind: "SCOPE.Interface", SourceFile: "src/order.ts"}, true},
+		{"typealias-by-kind", Entity{Name: "OrderId", Kind: "TypeAlias", SourceFile: "src/ids.ts"}, true},
+		{"enum-by-kind", Entity{Name: "Status", Kind: "Enum", SourceFile: "src/status.ts"}, true},
+		{"migration-by-path", Entity{Name: "up", Kind: "SCOPE.Operation", SourceFile: "db/migrations/1.ts"}, true},
+		{"script-by-path", Entity{Name: "seed", Kind: "Function", SourceFile: "scripts/seed.ts"}, true},
+	}
+	for _, tc := range cases {
+		// Subtype is EMPTY on every case (read-layer shape).
+		if tc.e.Subtype != "" {
+			t.Fatalf("%s: test must use read-layer shape (empty Subtype)", tc.name)
+		}
+		if got := isNonTestableEntity(&tc.e); got != tc.want {
+			t.Errorf("isNonTestableEntity(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // #4553: endpoint crediting via handler (read-layer shape)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -758,7 +865,7 @@ func TestIsContractSpecFile(t *testing.T) {
 	}{
 		{"test/contract/proposals.contract.spec.ts", true},
 		{"src/clients/clients.contract.spec.ts", true},
-		{"test/contract/foo.spec.ts", true},     // dir segment
+		{"test/contract/foo.spec.ts", true},      // dir segment
 		{"api/pact/consumer.pact.test.ts", true}, // pact dir + infix
 		{"src/user.contract.test.js", true},
 		// Plain specs / unit specs are NOT contract specs.


### PR DESCRIPTION
Closes #4534. Refs #4520, #4510, #4493.

## Problem
`isNonTestableEntity` (the testable-production denominator exclusion in `internal/graph/coverage.go`) keyed its DTO/decorator/type-only exclusions on `Entity.Subtype` values:

```go
switch strings.ToLower(e.Subtype) {
case "dto", "decorator", "annotation", "type_alias", "typealias", "enum_member":
    return true
}
```

`Subtype` round-trips through the flatbuffer writer/reader (`load.go::fbEntityToGraphEntity`), but a Subtype-value audit shows **ZERO extractors emit `dto`/`decorator`/`annotation`/`enum_member`** and only `type_alias`/`typealias` are set (those kinds already fail the `coverageEntityKinds` gate, so the switch was dead for them too). On the **live reindexed graph** the switch silently no-ops → the denominator stays inflated. A unit test that hand-sets `Subtype` on an in-memory graph passes — the classic fixture-pass/live-fail bug #4534 calls out.

## Fix
Re-key the exclusion strictly onto fields **guaranteed present on the flatbuffer read layer**:

- **Kind** (`nonTestableKinds` + `kindTail` to strip the `SCOPE.` namespace): `interface`/`typealias`/`type`/`enum`/`enum_member`/`annotation`/`decorator` excluded by persisted Kind, catching both bare (`Interface`) and namespaced (`SCOPE.Interface`) kinds.
- **Name conventions** (`nonTestableNameSuffixes`): DTO/decorator/annotation classes whose concrete kind (`Class`/`Struct`) passes `coverageEntityKinds` excluded by name suffix; added `decorators`/`annotation`.
- **SourceFile path** (unchanged `isNonTestableFile`): scripts/migrations/generated/config/barrel.

Also hardened `isTestEntity`'s one-per-file suite marker to check the persisted `Properties["pattern_type"] == "test_suite"` first (the signal every non-JS test extractor sets reliably), keeping the `Subtype`/`Kind == "test_suite"` checks as fallbacks.

No `Subtype` read remains in the denominator path.

## Validation (read-layer shape — `Subtype` EMPTY on every entity)
- `TestComputeCoverage_4534_DenominatorReadLayerShape` — entities shaped as the read layer presents them (only Kind/SourceFile/Name + one persisted Property); asserts DTO/decorator/annotation/interface/typealias/enum/migration/script drop out and a real service stays counted + credited.
- `TestIsNonTestableEntity_PersistedFieldsOnly` — focused predicate; **RED before** the fix on the Kind/name-keyed cases (interface/scope-interface/typealias/enum/annotation), GREEN after.

## Gates
- `go build ./...` ✅
- `go vet ./internal/graph/... ./internal/dashboard/...` ✅
- `go test ./internal/graph/... ./internal/dashboard/...` ✅
- `coverage fmt --check` ✅ (canonical) · `coverage validate` ✅ (0 errors; pre-existing capability-map warnings only)

No per-language coverage cell applies (internal coverage-algorithm logic, not an extractor capability).

**DEPLOY-DEFERRED**: the denominator shift on live upvate-v3 requires a reindex; coordinator live-validates `test_coverage group=upvate-v3` at next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)