### PR TITLE
feat(global-wiring): Django TEMPLATES/INSTALLED_APPS + Spring Security filter chain (#4403, #4410)

### DIFF
--- a/internal/custom/java/issue4410_livedrepro_test.go
+++ b/internal/custom/java/issue4410_livedrepro_test.go
@@ -1,0 +1,168 @@
+package java_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4410 LIVE-REPRO — Spring Security global filter-chain wiring.
+//
+// #4377 covered WebMvcConfigurer interceptors, servlet @Component filters, and
+// @ControllerAdvice. Spring Security registers its OWN global filter chain that
+// #4377 did not wire. #4410 adds it via extractSpringSecurityWiring:
+//
+//   - modern @Bean SecurityFilterChain filterChain(HttpSecurity http) with
+//     http.addFilterBefore(new JwtAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+//     → SecurityConfig → JwtAuthFilter USES
+//       (global, di_role=security_filter, relative_order=before,
+//        relative_to=UsernamePasswordAuthenticationFilter).
+//   - legacy class extends WebSecurityConfigurerAdapter with the same idiom.
+//   - @EnableMethodSecurity posture + AuthenticationProvider/UserDetailsService
+//     @Bean providers wired into the chain.
+//
+// Pre-fix: the custom security filter class had no inbound edge — it was a
+// structural orphan and the security chain was invisible to the graph.
+
+const springSecurityFilterChainSrc = `package com.example.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.addFilterBefore(new JwtAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+            .addFilterAfter(new AuditFilter(), JwtAuthFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return new CustomUserDetailsService();
+    }
+}
+`
+
+const springLegacyAdapterSrc = `package com.example.security;
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class LegacySecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.addFilterBefore(new TenantAuthFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
+}
+`
+
+// Faithful target classes so the Class:<X> USES stubs resolve, mirroring the
+// #4377 live-repro convention.
+const springSecurityTargetsSrc = `package com.example.security;
+
+import jakarta.servlet.Filter;
+
+class JwtAuthFilter implements Filter {}
+class AuditFilter implements Filter {}
+class TenantAuthFilter implements Filter {}
+class CustomUserDetailsService {}
+`
+
+func TestIssue4410_SpringSecurityFilterChain_Wired(t *testing.T) {
+	var all []types.EntityRecord
+	all = append(all, javaExtract4377(t, "src/SecurityConfig.java", springSecurityFilterChainSrc)...)
+	all = append(all, javaExtract4377(t, "src/LegacySecurityConfig.java", springLegacyAdapterSrc)...)
+	all = append(all, javaExtract4377(t, "src/SecurityTargets.java", springSecurityTargetsSrc)...)
+
+	uses := collectGlobalUses4377(all)
+	if len(uses) == 0 {
+		t.Fatalf("Spring Security global-wiring USES edges = 0 (orphan filter chain); want > 0 (#4410)")
+	}
+	for _, u := range uses {
+		t.Logf("  -> %s  role=%s from=%s", u.to, u.role, u.from)
+	}
+
+	// Helper: find a security_filter edge for a target and assert its relative
+	// position metadata.
+	findFilter := func(to string) (types.RelationshipRecord, bool) {
+		for _, e := range all {
+			for _, r := range e.Relationships {
+				if r.ToID == to && r.Properties["di_role"] == "security_filter" &&
+					r.Properties["global"] == "true" {
+					return r, true
+				}
+			}
+		}
+		return types.RelationshipRecord{}, false
+	}
+
+	// --- modern @Bean SecurityFilterChain: addFilterBefore + addFilterAfter ---
+	if r, ok := findFilter("Class:JwtAuthFilter"); !ok {
+		t.Error("missing security_filter USES edge -> Class:JwtAuthFilter (#4410)")
+	} else {
+		if r.Properties["relative_order"] != "before" {
+			t.Errorf("JwtAuthFilter: relative_order=%q, want before", r.Properties["relative_order"])
+		}
+		if r.Properties["relative_to"] != "UsernamePasswordAuthenticationFilter" {
+			t.Errorf("JwtAuthFilter: relative_to=%q, want UsernamePasswordAuthenticationFilter", r.Properties["relative_to"])
+		}
+	}
+	if r, ok := findFilter("Class:AuditFilter"); !ok {
+		t.Error("missing security_filter USES edge -> Class:AuditFilter (#4410)")
+	} else if r.Properties["relative_order"] != "after" {
+		t.Errorf("AuditFilter: relative_order=%q, want after", r.Properties["relative_order"])
+	}
+
+	// --- legacy WebSecurityConfigurerAdapter ---
+	if r, ok := findFilter("Class:TenantAuthFilter"); !ok {
+		t.Error("missing security_filter USES edge -> Class:TenantAuthFilter (legacy adapter) (#4410)")
+	} else if r.Properties["relative_to"] != "UsernamePasswordAuthenticationFilter" {
+		t.Errorf("TenantAuthFilter: relative_to=%q", r.Properties["relative_to"])
+	}
+
+	// --- @EnableMethodSecurity posture ---
+	foundMethodSec := false
+	// --- UserDetailsService provider bean ---
+	foundProvider := false
+	for _, e := range all {
+		for _, r := range e.Relationships {
+			if r.Properties["di_role"] == "method_security" {
+				foundMethodSec = true
+			}
+			if r.Properties["di_role"] == "security_provider" && r.ToID == "Class:UserDetailsService" {
+				foundProvider = true
+			}
+		}
+	}
+	if !foundMethodSec {
+		t.Error("missing method_security USES edge for @EnableMethodSecurity (#4410)")
+	}
+	if !foundProvider {
+		t.Error("missing security_provider USES edge for UserDetailsService @Bean (#4410)")
+	}
+
+	// The security_filter edges must be owned by a security_config carrier (one
+	// stable owner per security config), not a colliding duplicate.
+	var carrierRefs = map[string]bool{}
+	for _, e := range all {
+		if e.Subtype == "security_config" {
+			carrierRefs[e.Name] = true
+		}
+	}
+	if !carrierRefs["SecurityConfig"] {
+		t.Error("expected a security_config carrier entity named SecurityConfig (#4410)")
+	}
+	if !carrierRefs["LegacySecurityConfig"] {
+		t.Error("expected a security_config carrier entity named LegacySecurityConfig (#4410)")
+	}
+}

--- a/internal/custom/java/spring_global_wiring.go
+++ b/internal/custom/java/spring_global_wiring.go
@@ -44,8 +44,9 @@ import (
 // entity owns the edge so it is retained even when nothing else references it.
 //
 // Spring Security's SecurityFilterChain @Bean / WebSecurityConfigurerAdapter
-// filter wiring is a deliberate follow-up (epic #4334) — see the note at the
-// bottom of this file.
+// filter wiring is handled in extractSpringSecurityWiring (#4410):
+// http.addFilterBefore/After/At(new X(), Y.class) → security-config → X USES,
+// di_role=security_filter.
 
 var (
 	// springWebMvcConfigClassRE matches a class implementing WebMvcConfigurer,
@@ -111,6 +112,42 @@ var (
 	// springDotClassRE pulls each `Foo.class` token out of an exception-handler
 	// argument list, capturing the exception class name (group 1).
 	springDotClassRE = regexp.MustCompile(`([A-Z]\w*)\s*\.\s*class\b`)
+
+	// ---- Spring Security global filter-chain wiring (#4410) ----------------
+
+	// springSecurityFilterChainBeanRE matches a `@Bean SecurityFilterChain
+	// name(HttpSecurity http)` method declaration, capturing the bean-method
+	// name (group 1). `(?s)` lets the annotation + signature span lines. This is
+	// the modern (component-based) Spring Security entry point.
+	springSecurityFilterChainBeanRE = regexp.MustCompile(
+		`(?s)SecurityFilterChain\s+(\w+)\s*\([^)]*HttpSecurity`)
+
+	// springWebSecurityAdapterRE matches the legacy
+	// `class X extends WebSecurityConfigurerAdapter`, capturing the config class
+	// name (group 1). Its `configure(HttpSecurity)` override carries the same
+	// addFilter* idioms.
+	springWebSecurityAdapterRE = regexp.MustCompile(
+		`(?s)class\s+(\w+)\b[^{]*?\bextends\b[^{]*?\bWebSecurityConfigurerAdapter\b`)
+
+	// springAddFilterRE matches http.addFilterBefore / addFilterAfter /
+	// addFilterAt(new X(...), Y.class) — and the bare-bean-reference form
+	// addFilterBefore(jwtFilter, Y.class). Group 1 = the relative position verb
+	// (Before/After/At). Group 2 = the added filter class (from `new X` or a
+	// PascalCase bean identifier). Group 3 = the reference filter class Y.
+	springAddFilterRE = regexp.MustCompile(
+		`\.addFilter(Before|After|At)\s*\(\s*(?:new\s+)?([A-Za-z]\w*)\b[^,]*,\s*([A-Z]\w*)\s*\.\s*class`)
+
+	// springEnableMethodSecurityRE matches @EnableGlobalMethodSecurity /
+	// @EnableMethodSecurity, capturing the annotation name (group 1) so the
+	// posture flag can be recorded on the security config carrier.
+	springEnableMethodSecurityRE = regexp.MustCompile(
+		`@(EnableGlobalMethodSecurity|EnableMethodSecurity)\b`)
+
+	// springSecurityBeanProviderRE matches a `@Bean` method returning an
+	// AuthenticationProvider / UserDetailsService, capturing the return type
+	// (group 1) and method name (group 2). These are wired into the chain.
+	springSecurityBeanProviderRE = regexp.MustCompile(
+		`(?s)\b(AuthenticationProvider|UserDetailsService|AuthenticationManager)\s+(\w+)\s*\(`)
 )
 
 // springGlobalWiringFrameworks gates the Spring frameworks for which global
@@ -345,7 +382,180 @@ func ExtractSpringGlobalWiring(ctx PatternContext) PatternResult {
 		}
 	}
 
+	// ---- 5. Spring Security global filter-chain wiring (#4410) --------------
+	// Spring Security registers its own global servlet filter chain that the MVC
+	// passes above do not cover. Two entry-point shapes carry it:
+	//   (a) modern: @Bean SecurityFilterChain filterChain(HttpSecurity http) in a
+	//       @Configuration class.
+	//   (b) legacy: class X extends WebSecurityConfigurerAdapter
+	//       { configure(HttpSecurity http) }.
+	// Both configure the chain with http.addFilterBefore/After/At(new X(),
+	// Y.class). Each such call binds the custom filter X app-wide, relative to a
+	// reference filter Y. The owning security-config class carries the edge
+	// (di_role=security_filter, global=true), recording the relative position and
+	// the reference filter.
+	extractSpringSecurityWiring(source, fp, &result, seenRefs, seenRels, ensureApp)
+
 	return result
+}
+
+// extractSpringSecurityWiring emits the global=true USES edges for the Spring
+// Security filter chain (issue #4410): http.addFilterBefore/After/At custom
+// filters owned by the security config carrier, plus method-security posture and
+// AuthenticationProvider/UserDetailsService beans wired into the chain.
+func extractSpringSecurityWiring(
+	source, fp string,
+	result *PatternResult,
+	seenRefs map[string]bool,
+	seenRels map[relKey]bool,
+	ensureApp func() string,
+) {
+	// Detect a Spring Security configuration carrier in this file:
+	//   - a @Bean SecurityFilterChain method (modern), or
+	//   - a class extending WebSecurityConfigurerAdapter (legacy).
+	// Both are owned by the nearest @Configuration class (modern) or the adapter
+	// class itself (legacy). We collect carrier (name, offset, ref) records so an
+	// addFilter* call can attribute to the nearest preceding one.
+	type secCarrier struct {
+		name   string
+		offset int
+		ref    string
+	}
+	var carriers []secCarrier
+
+	emitCarrier := func(name string, offset int, legacy bool) string {
+		ref := "scope:pattern:spring_security_config:" + fp + ":" + name
+		props := map[string]any{"framework": "spring_boot", "scope": "application"}
+		if legacy {
+			props["security_style"] = "websecurityconfigureradapter"
+		} else {
+			props["security_style"] = "securityfilterchain_bean"
+		}
+		if addEntity(result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern", Subtype: "security_config",
+			SourceFile: fp, LineStart: lineOf(source, offset), LineEnd: lineOf(source, offset),
+			Provenance: "INFERRED_FROM_SPRING_SECURITY_WIRING", Ref: ref,
+			Properties: props,
+		}) {
+			carriers = append(carriers, secCarrier{name, offset, ref})
+		} else {
+			// Already emitted (same ref): still record it for ownership lookup.
+			carriers = append(carriers, secCarrier{name, offset, ref})
+		}
+		return ref
+	}
+
+	// Modern: @Bean SecurityFilterChain method → owned by the nearest preceding
+	// @Configuration class (its enclosing config carrier).
+	for _, m := range springSecurityFilterChainBeanRE.FindAllStringSubmatchIndex(source, -1) {
+		// The carrier name is the enclosing @Configuration class when present;
+		// fall back to the bean-method name so the chain still has a stable owner.
+		name := ""
+		bestOff := -1
+		for _, cm := range sbConfigurationClassRE.FindAllStringSubmatchIndex(source, -1) {
+			if cm[0] <= m[0] && cm[0] > bestOff {
+				name = source[cm[2]:cm[3]]
+				bestOff = cm[0]
+			}
+		}
+		off := m[0]
+		if name == "" {
+			name = source[m[2]:m[3]] // bean-method name
+		} else {
+			off = bestOff
+		}
+		emitCarrier(name, off, false)
+	}
+
+	// Legacy: class extends WebSecurityConfigurerAdapter.
+	for _, m := range springWebSecurityAdapterRE.FindAllStringSubmatchIndex(source, -1) {
+		emitCarrier(source[m[2]:m[3]], m[0], true)
+	}
+
+	// Nearest preceding security carrier for an offset; falls back to the
+	// synthetic spring_app entity when no carrier was detected (defensive: an
+	// addFilter* on an HttpSecurity passed in from elsewhere).
+	ownerSecCarrier := func(offset int) string {
+		bestRef := ""
+		bestOff := -1
+		for _, c := range carriers {
+			if c.offset <= offset && c.offset > bestOff {
+				bestRef, bestOff = c.ref, c.offset
+			}
+		}
+		if bestRef == "" {
+			return ensureApp()
+		}
+		return bestRef
+	}
+
+	// http.addFilterBefore/After/At(new X(), Y.class) → config → X USES.
+	for _, m := range springAddFilterRE.FindAllStringSubmatchIndex(source, -1) {
+		position := source[m[2]:m[3]] // Before / After / At
+		filterCls := source[m[4]:m[5]]
+		refCls := source[m[6]:m[7]]
+		if filterCls == "" || primitiveTypes[filterCls] {
+			continue
+		}
+		addRel(result, seenRels, Relationship{
+			SourceRef:        ownerSecCarrier(m[0]),
+			TargetRef:        classStub(filterCls),
+			RelationshipType: string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"framework":      "spring_boot",
+				"di_role":        "security_filter",
+				"di_scope":       "global",
+				"global":         "true",
+				"relative_to":    refCls,
+				"relative_order": strings.ToLower(position), // before / after / at
+				"via":            "spring_security_add_filter",
+			},
+		})
+	}
+
+	// @EnableGlobalMethodSecurity / @EnableMethodSecurity posture: record on the
+	// nearest security carrier (or the app entity) so the method-security stance
+	// is queryable from the chain.
+	for _, m := range springEnableMethodSecurityRE.FindAllStringSubmatchIndex(source, -1) {
+		annotation := source[m[2]:m[3]]
+		addRel(result, seenRels, Relationship{
+			SourceRef:        ownerSecCarrier(m[0]),
+			TargetRef:        classStub(annotation),
+			RelationshipType: string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"framework":  "spring_boot",
+				"di_role":    "method_security",
+				"di_scope":   "global",
+				"global":     "true",
+				"annotation": annotation,
+				"via":        "spring_enable_method_security",
+			},
+		})
+	}
+
+	// AuthenticationProvider / UserDetailsService / AuthenticationManager @Bean
+	// methods wired into the chain. Only emit when a @Bean annotation precedes
+	// the method (so we don't link the interface declaration itself).
+	for _, m := range springSecurityBeanProviderRE.FindAllStringSubmatchIndex(source, -1) {
+		win := windowBefore(source, m[0], 120)
+		if !strings.Contains(win, "@Bean") {
+			continue
+		}
+		retType := source[m[2]:m[3]]
+		addRel(result, seenRels, Relationship{
+			SourceRef:        ownerSecCarrier(m[0]),
+			TargetRef:        classStub(retType),
+			RelationshipType: string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"framework": "spring_boot",
+				"di_role":   "security_provider",
+				"di_scope":  "global",
+				"global":    "true",
+				"bean_type": retType,
+				"via":       "spring_security_provider_bean",
+			},
+		})
+	}
 }
 
 // springInterceptorPathPatterns returns the comma-joined path patterns chained
@@ -434,12 +644,10 @@ func windowAfter(source string, offset, n int) string {
 	return source[offset:end]
 }
 
-// NOTE (deferred, epic #4334): Spring Security global wiring —
-// @EnableGlobalMethodSecurity and the SecurityFilterChain @Bean /
-// WebSecurityConfigurerAdapter.configure(HttpSecurity) graph (entry points,
-// custom filters added via http.addFilterBefore(new X(), ...)) — is a tight
-// follow-up. The carrier/edge convention here (config/app → Class:<X> USES,
-// global=true, di_role) extends directly to it: emit, for each
-// http.addFilterBefore/After/At(new X(), Y.class), a security-config → X USES
-// edge with di_role=security_filter. Filed separately to keep this PR scoped to
-// the MVC interceptor / servlet filter / controller-advice shapes.
+// Spring Security global wiring (#4410) is implemented in
+// extractSpringSecurityWiring above: for each
+// http.addFilterBefore/After/At(new X(), Y.class) it emits a security-config → X
+// USES edge (global=true, di_role=security_filter, relative_to/relative_order),
+// covering both the modern @Bean SecurityFilterChain and the legacy
+// WebSecurityConfigurerAdapter entry points, plus @EnableMethodSecurity posture
+// and AuthenticationProvider/UserDetailsService chain beans.

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -97,12 +97,12 @@ var (
 		`(?m)^MIDDLEWARE\s*(?:\+?=)\s*\[`)
 	djangoMiddlewareItemRe = regexp.MustCompile(`["']([A-Za-z][\w.]+)["']`)
 
-	// Anchor for the global-wiring pass (issue #4379): fires when the file is a
-	// settings module declaring any of the supported cross-cutting lists. The
-	// matched offset positions the synthetic django_settings entity on the
-	// first such assignment.
+	// Anchor for the global-wiring pass (issue #4379, extended #4403): fires
+	// when the file is a settings module declaring any of the supported
+	// cross-cutting lists. The matched offset positions the synthetic
+	// django_settings entity on the first such assignment.
 	djangoSettingsAnchorRe = regexp.MustCompile(
-		`(?m)^(?:MIDDLEWARE|AUTHENTICATION_BACKENDS|REST_FRAMEWORK)\s*(?:\+?=)\s*[\[({]`)
+		`(?m)^(?:MIDDLEWARE|AUTHENTICATION_BACKENDS|REST_FRAMEWORK|TEMPLATES|INSTALLED_APPS)\s*(?:\+?=)\s*[\[({]`)
 
 	// DRF SerializerMethodField return-type inference (issue #3346).
 	// class FooSerializer → field = SerializerMethodField() → def get_field(self) -> ReturnType

--- a/internal/custom/python/django_global_wiring.go
+++ b/internal/custom/python/django_global_wiring.go
@@ -57,6 +57,21 @@ var (
 
 	// A single dotted-path string literal item inside a settings list/tuple.
 	djangoDottedPathItemRe = regexp.MustCompile(`["']([A-Za-z_][\w.]*\.[A-Za-z_]\w*)["']`)
+
+	// Issue #4403 — TEMPLATES[...]['OPTIONS']['context_processors'] = [dotted, …].
+	// The TEMPLATES setting is a list of backend dicts; each may carry an
+	// OPTIONS.context_processors list of dotted-path callables bound app-wide.
+	// We locate the `"context_processors": [ … ]` key (single or double quoted)
+	// anywhere inside the TEMPLATES block and read its balanced list body.
+	djangoTemplatesSettingRe     = regexp.MustCompile(`(?m)^TEMPLATES\s*(?:\+?=)\s*([\[(])`)
+	djangoContextProcessorsKeyRe = regexp.MustCompile(`["']context_processors["']\s*:\s*([\[(])`)
+
+	// Issue #4403 — INSTALLED_APPS = [ "app", "app.apps.AppConfig", … ]. Entries
+	// are either a bare app-package label ("rest_framework") or a dotted path to
+	// an AppConfig subclass ("core.apps.CoreConfig"). Only the dotted-path
+	// AppConfig form resolves to a real class entity, so we wire those; bare
+	// labels carry no in-repo target and are skipped.
+	djangoInstalledAppsSettingRe = regexp.MustCompile(`(?m)^INSTALLED_APPS\s*(?:\+?=)\s*([\[(])`)
 )
 
 // djangoDRFKeyRole maps a REST_FRAMEWORK default-class bucket key to the
@@ -137,6 +152,35 @@ func extractDjangoGlobalWiring(source, filePath string, line int) *types.EntityR
 			for _, im := range djangoDottedPathItemRe.FindAllStringSubmatch(body, -1) {
 				add(role, im[1], -1)
 			}
+		}
+	}
+
+	// TEMPLATES[...]['OPTIONS']['context_processors'] — dotted-path callables
+	// bound app-wide for template rendering (issue #4403). Each TEMPLATES
+	// backend dict may declare its own context_processors list; we scan every
+	// "context_processors": [...] / (...) key found inside the TEMPLATES block.
+	for _, m := range djangoTemplatesSettingRe.FindAllStringSubmatchIndex(source, -1) {
+		open := m[len(m)-2] // captured opening delimiter of the TEMPLATES container
+		tplBlock := djangoBalancedDelim(source, open)
+		for _, km := range djangoContextProcessorsKeyRe.FindAllStringSubmatchIndex(tplBlock, -1) {
+			cpOpen := km[len(km)-2] // opening delimiter of the context_processors list
+			body := djangoStripPyComments(djangoBalancedDelim(tplBlock, cpOpen))
+			for _, im := range djangoDottedPathItemRe.FindAllStringSubmatch(body, -1) {
+				add("context_processor", im[1], -1)
+			}
+		}
+	}
+
+	// INSTALLED_APPS — dotted-path AppConfig entries bound app-wide (issue
+	// #4403). Bare package labels (e.g. "rest_framework") carry no in-repo
+	// target and are skipped by djangoDottedPathItemRe (which requires at least
+	// one interior dot); the "core.apps.CoreConfig" form resolves to the real
+	// AppConfig subclass via the QualifiedName index.
+	for _, m := range djangoInstalledAppsSettingRe.FindAllStringSubmatchIndex(source, -1) {
+		open := m[len(m)-2]
+		body := djangoStripPyComments(djangoBalancedDelim(source, open))
+		for _, im := range djangoDottedPathItemRe.FindAllStringSubmatch(body, -1) {
+			add("app_config", im[1], -1)
 		}
 	}
 

--- a/internal/custom/python/issue4403_livedrepro_test.go
+++ b/internal/custom/python/issue4403_livedrepro_test.go
@@ -1,0 +1,110 @@
+package python_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+)
+
+// Issue #4403 LIVE-REPRO — Django global wiring, remaining settings shapes.
+//
+// #4379 wired MIDDLEWARE / AUTHENTICATION_BACKENDS / REST_FRAMEWORK
+// DEFAULT_*_CLASSES. #4403 extends the same synthetic `django_settings` carrier
+// to the two remaining *settings-list* shapes:
+//
+//   - TEMPLATES[...]['OPTIONS']['context_processors'] — dotted-path callables
+//     bound app-wide (di_role=context_processor).
+//   - INSTALLED_APPS — dotted-path AppConfig entries (di_role=app_config); bare
+//     package labels carry no in-repo target and are skipped.
+//
+// The imperative `AppConfig.ready()` `post_save.connect(...)` signal axis is a
+// separate (non-settings) shape tracked by its own follow-up; the `@receiver`
+// decorator form is already handled in django.go (HANDLES_SIGNAL).
+//
+// The same real upvate_core settings.py fixture (testdata/issue4379) declares
+// both TEMPLATES context_processors and an INSTALLED_APPS AppConfig
+// ("core.apps.CoreConfig"); core/apps.py supplies the real class so the edge
+// resolves.
+
+// TestIssue4403_TemplatesContextProcessors asserts the four standard Django
+// context_processors are wired as global USES edges (di_role=context_processor).
+func TestIssue4403_TemplatesContextProcessors(t *testing.T) {
+	settings := loadRepro4379(t, "settings.py", "upvate_core/settings.py")
+	settingsEnts := runMerged4379(t, settings)
+
+	want := []string{
+		"django.template.context_processors.debug",
+		"django.template.context_processors.request",
+		"django.contrib.auth.context_processors.auth",
+		"django.contrib.messages.context_processors.messages",
+	}
+	for _, dotted := range want {
+		r, ok := hasGlobalUses(settingsEnts, dotted, "context_processor")
+		if !ok {
+			t.Errorf("expected global context_processor USES edge for %s", dotted)
+			continue
+		}
+		if r.Properties["framework"] != "django" {
+			t.Errorf("%s: expected framework=django, got %q", dotted, r.Properties["framework"])
+		}
+		if r.Properties["dotted_path"] != dotted {
+			t.Errorf("%s: dotted_path mismatch %q", dotted, r.Properties["dotted_path"])
+		}
+	}
+}
+
+// TestIssue4403_InstalledAppsAppConfig asserts the dotted-path AppConfig entry
+// is wired (di_role=app_config) and that bare package labels are NOT emitted as
+// edges (no in-repo target).
+func TestIssue4403_InstalledAppsAppConfig(t *testing.T) {
+	settings := loadRepro4379(t, "settings.py", "upvate_core/settings.py")
+	settingsEnts := runMerged4379(t, settings)
+
+	// The dotted-path AppConfig is wired.
+	if _, ok := hasGlobalUses(settingsEnts, "core.apps.CoreConfig", "app_config"); !ok {
+		t.Error("expected global app_config USES edge for core.apps.CoreConfig")
+	}
+
+	// Bare package labels (no interior dot, or a stdlib/3p package with no
+	// in-repo class) must NOT produce an app_config edge. "rest_framework" has
+	// no dot so it is skipped entirely.
+	for _, e := range settingsEnts {
+		for _, r := range e.Relationships {
+			if r.Properties["di_role"] == "app_config" && r.ToID == "rest_framework" {
+				t.Errorf("bare package label rest_framework should not be wired, got edge %+v", r)
+			}
+		}
+	}
+}
+
+// TestIssue4403_AppConfigResolves checks the AppConfig dotted path binds to the
+// real CoreConfig class entity once core/apps.py is in the graph and the
+// late-binding pass runs (same machinery #4379 uses for middleware).
+func TestIssue4403_AppConfigResolves(t *testing.T) {
+	settings := loadRepro4379(t, "settings.py", "upvate_core/settings.py")
+	apps := loadRepro4379(t, "core/apps.py", "core/apps.py")
+
+	var all []types.EntityRecord
+	settingsEnts := runMerged4379(t, settings)
+	all = append(all, settingsEnts...)
+	all = append(all, runMerged4379(t, apps)...)
+
+	if _, ok := hasGlobalUses(settingsEnts, "core.apps.CoreConfig", "app_config"); !ok {
+		t.Fatal("no app_config USES edge for core.apps.CoreConfig")
+	}
+
+	// Confirm the CoreConfig class entity is present in the merged graph.
+	found := false
+	for _, e := range all {
+		if e.Name == "CoreConfig" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a CoreConfig class entity from core/apps.py")
+	}
+}

--- a/internal/custom/python/testdata/issue4379/core/apps.py
+++ b/internal/custom/python/testdata/issue4379/core/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"
+
+    def ready(self):
+        # Imperative signal wiring lives here in real apps; covered by a
+        # follow-up ticket for the `post_save.connect(...)` form.
+        import core.signals  # noqa: F401


### PR DESCRIPTION
Closes the open shapes in the global cross-cutting-wiring cluster.

## #4403 — Django TEMPLATES context_processors + INSTALLED_APPS AppConfig
`#4379` wired MIDDLEWARE / AUTHENTICATION_BACKENDS / REST_FRAMEWORK DEFAULT_*_CLASSES off the synthetic `django_settings` carrier. This extends `extractDjangoGlobalWiring` to the two remaining settings-list shapes:
- `TEMPLATES[...]['OPTIONS']['context_processors']` dotted paths → USES, `di_role=context_processor`, `global=true`.
- `INSTALLED_APPS` dotted-path AppConfig entries (e.g. `core.apps.CoreConfig`) → USES, `di_role=app_config`. Bare package labels (`rest_framework`) carry no in-repo target and are skipped.
- The settings anchor now also fires on TEMPLATES/INSTALLED_APPS-only modules.

Imperative `AppConfig.ready()` `post_save.connect(...)` signal wiring is a separate (non-settings) axis tracked by a follow-up; the `@receiver` decorator form is already handled in `django.go` (HANDLES_SIGNAL).

## #4410 — Spring Security global filter chain
`#4377` covered WebMvcConfigurer interceptors, servlet filters, and `@ControllerAdvice`, and explicitly deferred Spring Security. New `extractSpringSecurityWiring`:
- Carriers: `@Bean SecurityFilterChain(HttpSecurity)` (modern) and legacy `class … extends WebSecurityConfigurerAdapter` → `security_config` SCOPE.Pattern entity.
- `http.addFilterBefore/After/At(new X(), Y.class)` → security-config → `X` USES (`global=true`, `di_role=security_filter`, `relative_order`, `relative_to`).
- `@EnableMethodSecurity`/`@EnableGlobalMethodSecurity` posture (`di_role=method_security`) and `AuthenticationProvider`/`UserDetailsService`/`AuthenticationManager` `@Bean` providers (`di_role=security_provider`) on the chain carrier.

## #4412 — synthetic 'app' owner de-collision
Audited, no code change required. The synthetic owners already satisfy "one stable owner per app": `EntityRecord.ComputeID` hashes `SourceFile+Kind+Name`, so the Express `app` and NestJS `app` SCOPE.Pattern owners in one file compute the **same ID** and dedup to a single node; a normal user `const app = …` has a different Kind → different ID and never merges. Spring (`spring_app`) and Django (`django_settings`) owners are already distinctly named. The optional uniform `__app_global__:<file>` rename remains a low-priority nicety. Closing per the ticket's own "no wrong edges" framing.

## Tests / gates
- New live-repro tests: `issue4403_livedrepro_test.go` (TEMPLATES + INSTALLED_APPS, AppConfig resolution), `issue4410_livedrepro_test.go` (modern + legacy chain, relative order, method-security, provider beans).
- `go build ./...`, `go vet ./internal/custom/... ./internal/engine/...`, and `go test ./internal/custom/... ./internal/engine/... ./internal/graph/... ./internal/types/` all pass.
- `coverage fmt --check` canonical; `coverage validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)