### PR TITLE
Preserve QualifiedName + union edges in the production dedup-by-ID path (#4406)

### DIFF
--- a/cmd/archigraph/dedup_qname_edges_4406_test.go
+++ b/cmd/archigraph/dedup_qname_edges_4406_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4406 — the production dedup-by-ID path in buildDocument. When two
+// EntityRecords collapse to the same graph.EntityID (same kind/name/source-file),
+// the first wins and later duplicates are dropped. Before this fix the dropped
+// duplicate's QualifiedName was lost (breaking byQualifiedName resolution +
+// cross-repo joins) even when the survivor's was empty. The fix mirrors #4405's
+// supersedeBase gap-fill: the survivor inherits the duplicate's QualifiedName
+// (and other base-only fields) where it left them empty, and every edge of the
+// dropped duplicate is unioned onto the survivor with no dangling reference.
+
+func dedup4406Indexer() *Indexer {
+	return &Indexer{repoTag: "test_repo"}
+}
+
+// findEntity returns the (single) entity with the given graph ID, failing if
+// it is absent or duplicated.
+func findEntity(t *testing.T, ents []graph.Entity, id string) graph.Entity {
+	t.Helper()
+	var found *graph.Entity
+	count := 0
+	for k := range ents {
+		if ents[k].ID == id {
+			found = &ents[k]
+			count++
+		}
+	}
+	if count == 0 {
+		t.Fatalf("entity %s not found in document", id)
+	}
+	if count > 1 {
+		t.Fatalf("entity %s present %d times — dedup did not collapse it", id, count)
+	}
+	return *found
+}
+
+// TestDedup4406_QNameAndEdgesSurviveDedup is the core production-shape case:
+// two records dedupe to one survivor. The base/dropped record carries a
+// QualifiedName plus incoming + outgoing edges. After buildDocument the survivor
+// must keep a non-empty QualifiedName and ALL edges (deduped) must be present,
+// with no edge dangling to a node that is not in the document.
+func TestDedup4406_QNameAndEdgesSurviveDedup(t *testing.T) {
+	const (
+		srcFile = "core/models/contract.py"
+		name    = "Contract"
+	)
+
+	id := graph.EntityID("test_repo", "Class", name, srcFile)
+	fieldID := graph.EntityID("test_repo", "Field", "status", srcFile)
+	callerID := graph.EntityID("test_repo", "Function", "save_contract", "core/services.py")
+
+	// Survivor (first-seen) — the framework/custom node: bare Name, NO
+	// QualifiedName, and one outgoing edge.
+	survivor := types.EntityRecord{
+		Kind:       "Class",
+		Name:       name,
+		SourceFile: srcFile,
+		Subtype:    "model",
+		StartLine:  10,
+		Properties: map[string]string{"framework": "django"},
+		Relationships: []types.RelationshipRecord{
+			// outgoing CONTAINS class → field (anchored to the survivor)
+			{FromID: "", ToID: fieldID, Kind: "CONTAINS"},
+		},
+	}
+
+	// Duplicate (second-seen) — the base tree-sitter node: carries the
+	// module-qualified QualifiedName and BOTH an incoming edge (caller →
+	// class) and a distinct outgoing edge that the survivor lacks.
+	duplicate := types.EntityRecord{
+		Kind:          "Class",
+		Name:          name,
+		SourceFile:    srcFile,
+		QualifiedName: "core.models.contract.Contract",
+		StartLine:     10,
+		EndLine:       42,
+		Language:      "python",
+		Tags:          []string{"persisted"},
+		Relationships: []types.RelationshipRecord{
+			// incoming REFERENCES caller → class (explicit FromID)
+			{FromID: callerID, ToID: id, Kind: "REFERENCES"},
+			// extra outgoing CONTAINS (different target) anchored to the dup
+			{FromID: id, ToID: fieldID, Kind: "DEFINES"},
+		},
+	}
+
+	// Two referenced endpoints so no edge dangles.
+	field := types.EntityRecord{Kind: "Field", Name: "status", SourceFile: srcFile, StartLine: 12}
+	caller := types.EntityRecord{Kind: "Function", Name: "save_contract", SourceFile: "core/services.py", StartLine: 3}
+
+	idx := dedup4406Indexer()
+	doc := idx.buildDocument(
+		[]types.EntityRecord{survivor, duplicate, field, caller},
+		nil, nil, nil,
+	)
+
+	got := findEntity(t, doc.Entities, id)
+
+	// (1) QualifiedName preserved from the dropped duplicate.
+	if got.QualifiedName != "core.models.contract.Contract" {
+		t.Fatalf("survivor QualifiedName = %q; want it inherited from the dropped duplicate (core.models.contract.Contract)", got.QualifiedName)
+	}
+	// gap-filled base-only fields.
+	if got.EndLine != 42 {
+		t.Errorf("survivor EndLine = %d; want 42 inherited from duplicate", got.EndLine)
+	}
+	if got.Language != "python" {
+		t.Errorf("survivor Language = %q; want python inherited from duplicate", got.Language)
+	}
+	if got.Subtype != "model" {
+		t.Errorf("survivor Subtype = %q; want survivor's own 'model' preserved", got.Subtype)
+	}
+	var hasTag bool
+	for _, tg := range got.Tags {
+		if tg == "persisted" {
+			hasTag = true
+		}
+	}
+	if !hasTag {
+		t.Errorf("survivor Tags = %v; want 'persisted' unioned from duplicate", got.Tags)
+	}
+
+	// (2) Edge union — all three distinct edges present, none dangling.
+	entIDs := make(map[string]bool, len(doc.Entities))
+	for _, e := range doc.Entities {
+		entIDs[e.ID] = true
+	}
+	want := map[[3]string]bool{
+		{id, fieldID, "CONTAINS"}:    false, // survivor's own (empty FromID anchored to id)
+		{callerID, id, "REFERENCES"}: false, // incoming from duplicate
+		{id, fieldID, "DEFINES"}:     false, // outgoing from duplicate
+	}
+	for _, r := range doc.Relationships {
+		k := [3]string{r.FromID, r.ToID, r.Kind}
+		if _, ok := want[k]; ok {
+			want[k] = true
+		}
+		// no edge may reference an entity absent from the document
+		if r.FromID != "" && !entIDs[r.FromID] {
+			t.Errorf("edge %v has dangling FromID %s (not in document)", k, r.FromID)
+		}
+		if r.ToID != "" && !entIDs[r.ToID] {
+			t.Errorf("edge %v has dangling ToID %s (not in document)", k, r.ToID)
+		}
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("expected edge %v missing after dedup (orphaned by the merge)", k)
+		}
+	}
+}
+
+// TestDedup4406_SurvivorQNameNotOverridden — when the survivor already has a
+// QualifiedName, a duplicate's different value must NOT override it (gap-fill
+// only, never clobber a value the survivor provided). Mirrors #4405's
+// "non-empty custom QName is never overridden".
+func TestDedup4406_SurvivorQNameNotOverridden(t *testing.T) {
+	const srcFile = "app/user.go"
+	id := graph.EntityID("test_repo", "Class", "User", srcFile)
+
+	survivor := types.EntityRecord{
+		Kind: "Class", Name: "User", SourceFile: srcFile,
+		QualifiedName: "app.User",
+	}
+	duplicate := types.EntityRecord{
+		Kind: "Class", Name: "User", SourceFile: srcFile,
+		QualifiedName: "WRONG.User",
+	}
+
+	idx := dedup4406Indexer()
+	doc := idx.buildDocument([]types.EntityRecord{survivor, duplicate}, nil, nil, nil)
+	got := findEntity(t, doc.Entities, id)
+	if got.QualifiedName != "app.User" {
+		t.Fatalf("survivor QualifiedName = %q; want survivor's own app.User preserved (not overridden by duplicate)", got.QualifiedName)
+	}
+}
+
+// TestDedup4406_NonDuplicateUnchanged — regression: a non-duplicate entity's
+// QualifiedName and edges pass through buildDocument unchanged.
+func TestDedup4406_NonDuplicateUnchanged(t *testing.T) {
+	const srcFile = "lib/order.rb"
+	id := graph.EntityID("test_repo", "Class", "Order", srcFile)
+	otherID := graph.EntityID("test_repo", "Class", "Line", srcFile)
+
+	ent := types.EntityRecord{
+		Kind: "Class", Name: "Order", SourceFile: srcFile,
+		QualifiedName: "Lib::Order",
+		StartLine:     1, EndLine: 9, Language: "ruby",
+		Relationships: []types.RelationshipRecord{
+			{FromID: "", ToID: otherID, Kind: "CONTAINS"},
+		},
+	}
+	other := types.EntityRecord{Kind: "Class", Name: "Line", SourceFile: srcFile, StartLine: 20}
+
+	idx := dedup4406Indexer()
+	doc := idx.buildDocument([]types.EntityRecord{ent, other}, nil, nil, nil)
+
+	got := findEntity(t, doc.Entities, id)
+	if got.QualifiedName != "Lib::Order" {
+		t.Errorf("QualifiedName = %q; want unchanged Lib::Order", got.QualifiedName)
+	}
+	if got.EndLine != 9 || got.Language != "ruby" {
+		t.Errorf("entity fields mutated: EndLine=%d Language=%q; want 9/ruby", got.EndLine, got.Language)
+	}
+	var found bool
+	for _, r := range doc.Relationships {
+		if r.FromID == id && r.ToID == otherID && r.Kind == "CONTAINS" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("CONTAINS edge Order → Line missing for non-duplicate entity")
+	}
+}

--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -4217,6 +4217,10 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	relationships := make([]graph.Relationship, 0)
 
 	seenEntity := make(map[string]bool, len(merged))
+	// entityPos maps a survivor's graph ID → its index in `entities` so that a
+	// later duplicate (same EntityID) can gap-fill base-only state onto the
+	// already-emitted survivor instead of being dropped wholesale (issue #4406).
+	entityPos := make(map[string]int, len(merged))
 	seenRel := make(map[string]bool)
 
 	for k := range merged {
@@ -4258,6 +4262,75 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 				Properties:    r.Properties,
 				Confidence:    r.Confidence, // Phase 1C (#2769).
 			})
+			entityPos[id] = len(entities) - 1
+		} else if pos, ok := entityPos[id]; ok {
+			// Issue #4406 — the production dedup-by-ID path. When two
+			// EntityRecords collapse to the same graph.EntityID (same
+			// kind/name/source-file), the first wins and every later
+			// duplicate is dropped. The dropped duplicate is frequently the
+			// carrier of base-only state the survivor lacks — most critically
+			// the module-qualified QualifiedName that drives byQualifiedName
+			// resolution and cross-repo joins (the live-graph half of #4402,
+			// the same bug #4405 fixed at the MergeWithCustom boundary).
+			//
+			// Mirror #4405's supersedeBase gap-fill semantics: carry the
+			// duplicate's value onto the survivor ONLY where the survivor left
+			// the field empty — never override a value the survivor already
+			// provided. The duplicate's edges are unioned by the relationship
+			// loop below (it runs for every record, survivor or duplicate, and
+			// anchors empty-FromID edges to this same id), so no edge is
+			// orphaned by the dedup.
+			surv := &entities[pos]
+			if surv.QualifiedName == "" && r.QualifiedName != "" {
+				surv.QualifiedName = r.QualifiedName
+			}
+			if surv.Subtype == "" && r.Subtype != "" {
+				surv.Subtype = r.Subtype
+			}
+			if surv.Signature == "" && r.Signature != "" {
+				surv.Signature = r.Signature
+			}
+			if surv.Language == "" && r.Language != "" {
+				surv.Language = r.Language
+			}
+			if surv.StartLine == 0 && r.StartLine != 0 {
+				surv.StartLine = r.StartLine
+			}
+			if surv.EndLine == 0 && r.EndLine != 0 {
+				surv.EndLine = r.EndLine
+			}
+			if len(r.Tags) > 0 {
+				seenTag := make(map[string]bool, len(surv.Tags)+len(r.Tags))
+				for _, t := range surv.Tags {
+					seenTag[t] = true
+				}
+				for _, t := range r.Tags {
+					if !seenTag[t] {
+						seenTag[t] = true
+						surv.Tags = append(surv.Tags, t)
+					}
+				}
+			}
+			if len(r.Properties) > 0 {
+				if surv.Properties == nil {
+					surv.Properties = make(map[string]string, len(r.Properties))
+				}
+				for pk, pv := range r.Properties {
+					if _, exists := surv.Properties[pk]; !exists {
+						surv.Properties[pk] = pv
+					}
+				}
+			}
+			if len(r.Metadata) > 0 {
+				if surv.Metadata == nil {
+					surv.Metadata = make(map[string]interface{}, len(r.Metadata))
+				}
+				for mk, mv := range r.Metadata {
+					if _, exists := surv.Metadata[mk]; !exists {
+						surv.Metadata[mk] = mv
+					}
+				}
+			}
 		}
 
 		for j := range r.Relationships {


### PR DESCRIPTION
## Summary

#4406 is the **live-graph half of #4402**. #4405 fixed the `MergeWithCustom` boundary via the `supersedeBase` helper, but that boundary is only invoked by repro/unit harnesses. The production daemon emits base + custom entities independently and dedups them **downstream** in `buildDocument` (`cmd/archigraph/index.go`), so the live re-orphaning was not covered by #4405.

### Where the production dedup is

`(*Indexer).buildDocument` assembles pass1+pass2+pass3, stamps IDs, then collapses every `EntityRecord` that computes the same `graph.EntityID` (kind/name/source-file) into the **first-seen** survivor:

```go
id := graph.EntityID(i.repoTag, r.Kind, r.Name, r.SourceFile)
if !seenEntity[id] { ... append survivor ... }  // every later duplicate dropped
```

The dropped duplicate is frequently the carrier of base-only state the survivor lacks — most critically the module-qualified `QualifiedName` that drives `byQualifiedName` resolution and cross-repo joins. The survivor stayed empty-QName, which is the root cause the per-language workarounds (#4366 / #4379 / #4328 analog) compensate for by re-emitting before this dedup.

### The fix

Mirror #4405's `supersedeBase` gap-fill at the dedup site. When a duplicate ID is seen, carry its value onto the already-emitted survivor **only where the survivor left the field empty** — never overriding a value the survivor provided:

- **QualifiedName** inherited when survivor's is empty (the #4406 core).
- `Subtype` / `Signature` / `Language` / `StartLine` / `EndLine` gap-filled.
- `Tags` unioned; `Properties` / `Metadata` gap-filled key-by-key (survivor keys win).

**Edges** were already unioned: the relationship loop runs for *every* record (survivor and duplicate) and anchors empty-`FromID` edges to the same `id`, so the duplicate's incoming + outgoing edges already re-point onto the survivor and dedupe via `seenRel`. No edge is orphaned by the dedup; the fix adds an `entityPos` index so the survivor's *fields* can be backfilled too.

### Shared helper note

The two paths do **not** yet share one helper — `supersedeBase` operates on `types.EntityRecord` at the merge boundary, while this dedup operates on the already-emitted `graph.Entity` slice (post-stamp). The gap-fill semantics are deliberately kept identical (gap-fill only, never clobber, union tags/edges) so both paths produce the same survivor shape. A future refactor could extract a shared field-merge helper.

## Tests

`cmd/archigraph/dedup_qname_edges_4406_test.go` drives the real `buildDocument`:

- **`TestDedup4406_QNameAndEdgesSurviveDedup`** — two records dedupe to one; the dropped record carries a `QualifiedName` + incoming (`REFERENCES`) and outgoing (`DEFINES`) edges. After dedup the survivor has the inherited non-empty QName and all three distinct edges (deduped), with an explicit assertion that no edge dangles to an entity absent from the document.
- **`TestDedup4406_SurvivorQNameNotOverridden`** — a survivor's own non-empty QName is never overridden by a duplicate's different value.
- **`TestDedup4406_NonDuplicateUnchanged`** — regression: a non-duplicate entity's QName + edges pass through unchanged.

## Gates

- `go build ./...` ✅
- `go vet ./internal/graph/... ./cmd/archigraph/` ✅
- `go test ./internal/graph/... ./cmd/archigraph/ -run 'Dedup|Merge|QName|Qualified'` ✅
- merge/supersede + determinism/fold regression tests ✅
- `coverage fmt --check` (canonical) + `coverage validate` (0 errors; pre-existing warnings only) ✅

Per-language workarounds are intentionally **left in place** until the coordinator live-validates on `upvate-v3` at a deploy window (fewer empty-QName entities + no dedup-orphaned edges), per #4406.

Closes #4406

🤖 Generated with [Claude Code](https://claude.com/claude-code)