### PR TITLE
feat(http): Grape + Roda block routes → endpoint + inline-handler bridge (#4417)

### DIFF
--- a/internal/engine/http_endpoint_graperoda_inline_4417_test.go
+++ b/internal/engine/http_endpoint_graperoda_inline_4417_test.go
@@ -1,0 +1,155 @@
+package engine
+
+import (
+	"testing"
+)
+
+// #4417 — Grape (`get ':id' do ... end` inside `resource :users do ... end`) and
+// Roda (`r.get Integer do |id| ... end` inside `r.on "users" do ... end`) route
+// blocks are inherently anonymous: the handler is ALWAYS a block, never a named
+// method — exactly like Sinatra (#4385). Each route must signal
+// refKind=inlineHandlerRefKind so makeEmit synthesizes a stable
+// `<inline VERB /path>` handler entity + a same-file IMPLEMENTS bridge, instead
+// of leaving the endpoint a handler-less graph island.
+//
+// These tests run the REAL extract+synthesis+merge+resolve pipeline (via
+// detectInline / assertInlineEndpointBridged from the #4324 test file) on
+// faithful Grape and Roda fixtures and prove the endpoints are present AND
+// handler-linked.
+
+// TestInline4417_GrapeResourceNesting covers a Grape API class with
+// resource/namespace prefix nesting. `resource :users do ... end` contributes
+// "/users"; nested `namespace :v1 do ... end` composes "/v1"; the verb block's
+// own `:id`/`'/profile'` path is joined at the leaf. `:id` → `{id}`.
+func TestInline4417_GrapeResourceNesting(t *testing.T) {
+	src := `require 'grape'
+
+class API < Grape::API
+  format :json
+
+  resource :users do
+    get do
+      User.all
+    end
+
+    get ':id' do
+      User.find(params[:id])
+    end
+
+    post '/invite' do
+      User.invite(params)
+    end
+
+    namespace :v1 do
+      get do
+        User.legacy
+      end
+    end
+  end
+end
+`
+	ents, rels := detectInline(t, "ruby", "app/api.rb", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/users", "grape")
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/users/{id}", "grape")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/users/invite", "grape")
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/users/v1", "grape")
+}
+
+// TestInline4417_GrapeNoDoubleEmit guards that a route inside a resource block is
+// NOT also emitted at the un-prefixed parent scope.
+func TestInline4417_GrapeNoDoubleEmit(t *testing.T) {
+	src := `require 'grape'
+
+class API < Grape::API
+  resource :things do
+    get ':id' do
+      Thing.find(params[:id])
+    end
+  end
+end
+`
+	ents, _ := detectInline(t, "ruby", "app/things_api.rb", src)
+	if endpointByVerbPath(ents, "GET", "/things/{id}") == nil {
+		t.Fatal("nested route GET /things/{id} missing")
+	}
+	if endpointByVerbPath(ents, "GET", "/{id}") != nil {
+		t.Error("nested route must NOT also be emitted un-prefixed as GET /{id}")
+	}
+}
+
+// TestInline4417_RodaRoutingTree covers a Roda routing-tree app. `r.on "users"
+// do ... end` contributes "/users"; the leaf `r.get`/`r.post` verbs emit there.
+// A class-matcher capture (`r.get Integer do |id|`) → "/users/{param}"; a nested
+// `r.is "profile" do r.get do ... end end` → "/users/profile".
+func TestInline4417_RodaRoutingTree(t *testing.T) {
+	src := `require 'roda'
+
+class App < Roda
+  route do |r|
+    r.on "users" do
+      r.get do
+        User.all
+      end
+
+      r.get Integer do |id|
+        User.find(id)
+      end
+
+      r.is "profile" do
+        r.post do
+          User.update_profile(r.params)
+        end
+      end
+    end
+  end
+end
+`
+	ents, rels := detectInline(t, "ruby", "app/roda_app.rb", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/users", "roda")
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/users/{param}", "roda")
+	assertInlineEndpointBridged(t, ents, rels, "POST", "/users/profile", "roda")
+}
+
+// TestInline4417_RodaInlineVerbMatcher covers the `r.get Integer do |id| ... end`
+// leaf-with-inline-capture form directly at the routing-tree root.
+func TestInline4417_RodaInlineVerbMatcher(t *testing.T) {
+	src := `require 'roda'
+
+class App < Roda
+  route do |r|
+    r.on "items" do
+      r.get String do |slug|
+        Item.by_slug(slug)
+      end
+    end
+  end
+end
+`
+	ents, rels := detectInline(t, "ruby", "app/items.rb", src)
+	assertInlineEndpointBridged(t, ents, rels, "GET", "/items/{param}", "roda")
+}
+
+// TestInline4417_NonRouteRubyUnaffected is the regression guard: a plain Ruby
+// class with ordinary methods (no Grape::API / Roda superclass, no route DSL)
+// must NOT yield any synthesized endpoints.
+func TestInline4417_NonRouteRubyUnaffected(t *testing.T) {
+	src := `class Calculator
+  def add(a, b)
+    a + b
+  end
+
+  def get(key)
+    @store[key]
+  end
+end
+`
+	ents, _ := detectInline(t, "ruby", "lib/calculator.rb", src)
+	for _, e := range ents {
+		if e.Kind == httpEndpointDefinitionKind {
+			p := e.Properties
+			if p != nil && (p["framework"] == "grape" || p["framework"] == "roda") {
+				t.Errorf("non-route Ruby produced a grape/roda endpoint: %v", p)
+			}
+		}
+	}
+}

--- a/internal/engine/http_endpoint_ruby_graperoda_producer.go
+++ b/internal/engine/http_endpoint_ruby_graperoda_producer.go
@@ -1,0 +1,444 @@
+// http_endpoint_ruby_graperoda_producer.go — Grape + Roda block-route DSLs →
+// http_endpoint_definition synthesis with inline-handler IMPLEMENTS bridge (#4417).
+//
+// Follow-up to the Sinatra inline-handler work (#4385). Two more Ruby web
+// frameworks attach their handler as an ANONYMOUS block — there is no named
+// handler method — so each route must be signalled as an inline handler
+// (refKind=inlineHandlerRefKind) so makeEmit synthesizes a stable
+// `<inline VERB /path>` handler entity + a same-file IMPLEMENTS bridge, instead
+// of leaving the endpoint a handler-less graph island (the #4324/#4385 mechanism
+// is framework-general — #4319).
+//
+//   - Grape  (`class API < Grape::API`)
+//
+//     resource :users do
+//     get do ... end            → GET  /users
+//     get ':id' do ... end      → GET  /users/{id}
+//     post '/x' do ... end      → POST /users/x
+//     namespace :v1 do
+//     get do ... end          → GET  /users/v1
+//     end
+//     end
+//
+//     `resource`/`resources`/`namespace`/`group`/`segment` blocks compose a
+//     path prefix (`:users` → `/users`); the verb block at the leaf contributes
+//     the (optional) trailing path. Grape path parameters use the Sinatra/
+//     Express `:name` colon convention, so `:id` → `{id}`.
+//
+//   - Roda  (`class App < Roda`)
+//
+//     route do |r|
+//     r.on "users" do
+//     r.get do ... end        → GET  /users
+//     r.get Integer do |id|   → GET  /users/{id}
+//     ... end
+//     r.is "x" do
+//     r.post do ... end       → POST /users/x
+//     ... end
+//     end
+//     end
+//
+//     Roda is a routing TREE: `r.on`/`r.is` branch openers contribute path
+//     segments, and the terminal verb (`r.get`/`r.post`/...) sits at the leaf.
+//     A branch matcher that is a class (`String`/`Integer`/`Float`) or a symbol
+//     (`:id`) is a dynamic capture — normalised to the `:param` colon form so
+//     canonicalisation yields `{param}`. This is best-effort over the dynamic
+//     tree: only string-literal / class / symbol branch matchers are composed;
+//     regexp and array matchers are skipped (the leaf verb still emits at the
+//     prefix accumulated so far).
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Grape
+// ---------------------------------------------------------------------------
+
+// grapeGateRe matches a Grape API class definition — the entry-point signal for
+// a Grape source. We require `< Grape::API` so the synthesizer no-ops on
+// arbitrary Ruby (a bare `get do ... end` would otherwise false-positive).
+var grapeGateRe = regexp.MustCompile(`(?m)<\s*Grape::API\b`)
+
+// grapeResourceOpenRe matches a Grape resource/namespace/group prefix block:
+//
+//	resource :users do
+//	resources :widgets do
+//	namespace :v1 do
+//	group :admin do
+//	segment :books do
+//	resource 'users' do        (string form)
+//
+// Capture group 1 = the symbol/string body (the path fragment).
+var grapeResourceOpenRe = regexp.MustCompile(
+	`(?m)^\s*(?:resources?|namespace|group|segment)\s+` +
+		`(?::(\w+)|['"]([^'"\n\r]{1,200})['"])\s+do\b`,
+)
+
+// grapeVerbBlockRe matches a Grape verb registration inside an API class:
+//
+//	get do
+//	get ':id' do
+//	post '/items' do
+//	put ':id' do |id|
+//	delete ':id', requirements: { id: /\d+/ } do
+//
+// The path literal is OPTIONAL (a bare `get do` registers the resource root).
+// Capture group 1 = verb, group 2 = path literal (may be empty/absent).
+var grapeVerbBlockRe = regexp.MustCompile(
+	`(?m)^\s*(get|post|put|patch|delete|head|options)\b` +
+		`(?:\s+['"]([^'"\n\r]{0,500})['"])?` +
+		`[^\n\r]*?\bdo\b`,
+)
+
+// synthesizeGrape scans a Ruby file for Grape verb-block registrations and emits
+// one inline-handler endpoint per route. Grape route handlers are ALWAYS
+// anonymous blocks, so every route is signalled as an inline handler (#4417,
+// mirroring Sinatra #4385). resource/namespace/group prefixes compose onto the
+// route path.
+func synthesizeGrape(content, path string, emit emitFileFn) {
+	if !grapeGateRe.MatchString(content) {
+		return
+	}
+	walkGrapeBlocks(content, "", path, emit)
+}
+
+// walkGrapeBlocks recursively emits verb routes at the current pathPrefix, then
+// descends into nested resource/namespace/group blocks composing their fragment
+// onto the prefix. Routes inside nested prefix blocks are stripped from the body
+// scanned at this level so they emit exactly once with the correct prefix
+// (mirrors walkSinatraBlocks).
+func walkGrapeBlocks(content, pathPrefix, path string, emit emitFileFn) {
+	flat := stripGrapeResourceBlocks(content)
+	emitGrapeVerbRoutes(flat, pathPrefix, path, emit)
+	for _, blk := range findGrapeResourceBlocks(content) {
+		childPrefix := joinPathFragments(pathPrefix, "/"+blk.name)
+		walkGrapeBlocks(blk.body, childPrefix, path, emit)
+	}
+}
+
+// emitGrapeVerbRoutes emits one inline-handler endpoint for each verb-block route
+// in content, prefixing with pathPrefix before canonicalization.
+func emitGrapeVerbRoutes(content, pathPrefix, path string, emit emitFileFn) {
+	for _, idx := range grapeVerbBlockRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		raw := ""
+		if idx[4] >= 0 {
+			raw = content[idx[4]:idx[5]]
+		}
+		full := pathPrefix
+		if raw != "" {
+			full = joinPathFragments(pathPrefix, ensureLeadingSlash(raw))
+		}
+		if full == "" {
+			full = "/"
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGrape, full)
+		// #4417 — a Grape route handler is ALWAYS an anonymous block; signal
+		// refKind=inlineHandlerRefKind (empty refName) so makeEmit synthesizes a
+		// stable `<inline VERB /path>` handler + a same-file IMPLEMENTS bridge.
+		// handlerFile is left empty (same-file by construction).
+		defLine := lineOfOffset(content, idx[2])
+		emit(verb, canonical, "grape", inlineHandlerRefKind, "", "", defLine)
+	}
+}
+
+// grapeBlock describes one resource/namespace/group prefix block.
+type grapeBlock struct {
+	name      string // path fragment, e.g. "users" / "v1"
+	body      string
+	bodyStart int
+	bodyEnd   int
+}
+
+// findGrapeResourceBlocks returns every top-level resource/namespace/group block
+// in content, pairing each opener with its matching `end` via the shared
+// do/end balancer (extractRailsBlockBody).
+func findGrapeResourceBlocks(content string) []grapeBlock {
+	var out []grapeBlock
+	i := 0
+	for i < len(content) {
+		m := grapeResourceOpenRe.FindStringSubmatchIndex(content[i:])
+		if m == nil {
+			break
+		}
+		name := ""
+		if m[2] >= 0 {
+			name = content[i+m[2] : i+m[3]]
+		} else if m[4] >= 0 {
+			name = content[i+m[4] : i+m[5]]
+		}
+		bodyStart := i + m[1]
+		body, after, ok := extractRubyBlockBody(content, bodyStart)
+		if !ok {
+			i = i + m[1]
+			continue
+		}
+		out = append(out, grapeBlock{
+			name:      name,
+			body:      body,
+			bodyStart: bodyStart,
+			bodyEnd:   bodyStart + len(body),
+		})
+		i = after
+	}
+	return out
+}
+
+// stripGrapeResourceBlocks blanks the bodies of top-level resource/namespace
+// blocks (preserving newlines for line-offset stability) so verb routes inside
+// them aren't double-emitted at the un-prefixed parent scope.
+func stripGrapeResourceBlocks(content string) string {
+	out := []byte(content)
+	for _, blk := range findGrapeResourceBlocks(content) {
+		for j := blk.bodyStart; j < blk.bodyEnd && j < len(out); j++ {
+			if out[j] != '\n' && out[j] != '\r' {
+				out[j] = ' '
+			}
+		}
+	}
+	return string(out)
+}
+
+// ---------------------------------------------------------------------------
+// Roda
+// ---------------------------------------------------------------------------
+
+// rodaGateRe matches a Roda app class definition. We require `< Roda` so the
+// synthesizer no-ops on arbitrary Ruby.
+var rodaGateRe = regexp.MustCompile(`(?m)<\s*Roda\b`)
+
+// rodaBranchOpenRe matches a Roda routing-tree branch opener:
+//
+//	r.on "users" do
+//	r.on "api", "v1" do          (multiple string segments)
+//	r.is "users", Integer do     (terminal segment + capture)
+//	r.on Integer do |id|
+//	r.on :id do |id|
+//
+// The matcher argument list (group 1) is parsed by parseRodaMatchers into path
+// segments. The receiver name is flexible (`r`, `req`, ...). Capture group 1 =
+// the raw matcher argument list (everything between the method and `do`).
+var rodaBranchOpenRe = regexp.MustCompile(
+	`(?m)^\s*\w+\.(?:on|is)\b([^\n\r]*?)\bdo\b`,
+)
+
+// rodaVerbRe matches a Roda terminal verb at a leaf:
+//
+//	r.get do
+//	r.post do
+//	r.get Integer do |id|
+//	r.get "x" do
+//	r.is "y"; r.get do
+//
+// Capture group 1 = verb, group 2 = the matcher argument list (may be empty).
+var rodaVerbRe = regexp.MustCompile(
+	`(?m)\b\w+\.(get|post|put|patch|delete|head|options)\b([^\n\r]*?)\bdo\b`,
+)
+
+// synthesizeRoda scans a Ruby file for Roda routing-tree verb registrations and
+// emits one inline-handler endpoint per leaf verb. Roda handlers are ALWAYS
+// anonymous blocks (#4417). r.on/r.is branch segments compose onto the path;
+// the verb sits at the leaf. Best-effort over the dynamic tree.
+func synthesizeRoda(content, path string, emit emitFileFn) {
+	if !rodaGateRe.MatchString(content) {
+		return
+	}
+	walkRodaBranches(content, "", path, emit)
+}
+
+// walkRodaBranches recursively emits leaf verbs at the current pathPrefix, then
+// descends into nested r.on/r.is branches composing their segments onto the
+// prefix. Branch bodies are stripped from the level-scan so leaf verbs inside
+// them emit exactly once at the correct prefix.
+func walkRodaBranches(content, pathPrefix, path string, emit emitFileFn) {
+	flat := stripRodaBranchBlocks(content)
+	emitRodaVerbs(flat, pathPrefix, path, emit)
+	for _, blk := range findRodaBranchBlocks(content) {
+		childPrefix := joinPathFragments(pathPrefix, blk.segments)
+		walkRodaBranches(blk.body, childPrefix, path, emit)
+	}
+}
+
+// emitRodaVerbs emits one inline-handler endpoint per leaf verb in content. A
+// verb may itself carry an inline matcher (`r.get Integer do |id|`) which
+// contributes a trailing path segment.
+func emitRodaVerbs(content, pathPrefix, path string, emit emitFileFn) {
+	for _, idx := range rodaVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[2]:idx[3]])
+		args := ""
+		if idx[4] >= 0 {
+			args = content[idx[4]:idx[5]]
+		}
+		seg := parseRodaMatchers(args)
+		full := joinPathFragments(pathPrefix, seg)
+		if full == "" {
+			full = "/"
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkRoda, full)
+		defLine := lineOfOffset(content, idx[2])
+		emit(verb, canonical, "roda", inlineHandlerRefKind, "", "", defLine)
+	}
+}
+
+// rodaBranch describes one r.on/r.is branch block.
+type rodaBranch struct {
+	segments  string // composed path fragment, e.g. "/users" or "/users/:param"
+	body      string
+	bodyStart int
+	bodyEnd   int
+}
+
+// findRodaBranchBlocks returns every top-level r.on/r.is branch block in
+// content, pairing each opener with its matching `end` via the shared do/end
+// balancer. Branch matchers are parsed into a path fragment.
+func findRodaBranchBlocks(content string) []rodaBranch {
+	var out []rodaBranch
+	i := 0
+	for i < len(content) {
+		m := rodaBranchOpenRe.FindStringSubmatchIndex(content[i:])
+		if m == nil {
+			break
+		}
+		args := ""
+		if m[2] >= 0 {
+			args = content[i+m[2] : i+m[3]]
+		}
+		bodyStart := i + m[1]
+		body, after, ok := extractRubyBlockBody(content, bodyStart)
+		if !ok {
+			i = i + m[1]
+			continue
+		}
+		out = append(out, rodaBranch{
+			segments:  parseRodaMatchers(args),
+			body:      body,
+			bodyStart: bodyStart,
+			bodyEnd:   bodyStart + len(body),
+		})
+		i = after
+	}
+	return out
+}
+
+// stripRodaBranchBlocks blanks the bodies of top-level r.on/r.is branch blocks
+// (preserving newlines) so leaf verbs inside them aren't double-emitted at the
+// parent prefix.
+func stripRodaBranchBlocks(content string) string {
+	out := []byte(content)
+	for _, blk := range findRodaBranchBlocks(content) {
+		for j := blk.bodyStart; j < blk.bodyEnd && j < len(out); j++ {
+			if out[j] != '\n' && out[j] != '\r' {
+				out[j] = ' '
+			}
+		}
+	}
+	return string(out)
+}
+
+// rubyBlockOpenerRe detects a line that OPENS a `do` block. Unlike the Rails
+// endsWithDo helper (which only recognises a `do` token at end-of-line, with an
+// optional `|args|` suffix and no preceding identifier), this handles the Grape/
+// Roda forms that carry tokens before `do` AND a block-param list after it:
+//
+//	get ':id' do                  → opener
+//	r.get Integer do |id|         → opener  (endsWithDo misses this)
+//	resource :users do
+//	r.on "users" do
+//
+// It requires the `do` to be a standalone token (word-bounded) followed only by
+// optional whitespace, an optional `|params|` list, optional whitespace, and
+// (optionally) a trailing comment — i.e. the block body starts on the NEXT line.
+// A `do` followed by other code on the same line (`x do y end`) is intentionally
+// NOT treated as a multi-line opener here (rare in route DSLs; the inline form is
+// handled by the body never being entered).
+var rubyBlockOpenerRe = regexp.MustCompile(`\bdo\b(?:\s*\|[^|]*\|)?\s*(?:#.*)?$`)
+
+// extractRubyBlockBody returns the text between the `do` token at start and its
+// matching `end` line, plus the byte offset just past the `end`. It is a
+// do/end balancer for the Grape/Roda block DSLs that correctly counts openers
+// carrying a `do |args|` block-parameter list (which the shared Rails
+// extractRailsBlockBody / endsWithDo misses). Comments are stripped before
+// opener/closer detection.
+func extractRubyBlockBody(content string, start int) (body string, after int, ok bool) {
+	depth := 1
+	pos := start
+	for pos < len(content) {
+		newline := strings.IndexByte(content[pos:], '\n')
+		var line string
+		var lineEnd int
+		if newline < 0 {
+			line = content[pos:]
+			lineEnd = len(content)
+		} else {
+			line = content[pos : pos+newline]
+			lineEnd = pos + newline + 1
+		}
+		trimmed := strings.TrimSpace(line)
+		if hashIdx := strings.IndexByte(trimmed, '#'); hashIdx >= 0 {
+			trimmed = strings.TrimSpace(trimmed[:hashIdx])
+		}
+		if trimmed != "" {
+			if rubyBlockOpenerRe.MatchString(trimmed) {
+				depth++
+			}
+			if trimmed == "end" {
+				depth--
+				if depth == 0 {
+					return content[start:pos], lineEnd, true
+				}
+			}
+		}
+		pos = lineEnd
+		if newline < 0 {
+			break
+		}
+	}
+	return "", 0, false
+}
+
+// rodaMatcherArgRe pulls individual matcher arguments out of a Roda branch /
+// verb argument list. Recognised tokens:
+//   - "literal" / 'literal'        → static path segment
+//   - String / Integer / Float     → dynamic capture (→ :param)
+//   - :symbol                      → dynamic capture (→ :param)
+//
+// Block params, hashes, regexps and array matchers are deliberately ignored
+// (best-effort over the dynamic tree).
+var rodaMatcherArgRe = regexp.MustCompile(
+	`['"]([^'"\n\r]+)['"]` + // 1: string literal
+		`|\b(String|Integer|Float)\b` + // 2: class matcher
+		`|:(\w+)`, // 3: symbol matcher
+)
+
+// parseRodaMatchers turns a Roda matcher argument list into a composed path
+// fragment, e.g. `"users", Integer` → "/users/:param", `"api", "v1"` →
+// "/api/v1". Class/symbol captures collapse to the Express `:param` colon form
+// so canonicalization yields `{param}`. Returns "" when no matchers are present
+// (a bare `r.get do` leaf).
+func parseRodaMatchers(args string) string {
+	// Stop at a block-param pipe (`do |id|`) — params are not path segments.
+	if p := strings.IndexByte(args, '|'); p >= 0 {
+		args = args[:p]
+	}
+	var seg strings.Builder
+	for _, m := range rodaMatcherArgRe.FindAllStringSubmatch(args, -1) {
+		switch {
+		case m[1] != "":
+			seg.WriteString("/" + strings.Trim(m[1], "/"))
+		case m[2] != "" || m[3] != "":
+			seg.WriteString("/:param")
+		}
+	}
+	return seg.String()
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1185,6 +1185,17 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// StartLine on the synthetic so the audit2678 attribution lands on the
 		// verb block's line in app.rb.
 		synthesizeSinatra(string(content), path, emitFile)
+		// Producer side (#4417): Grape (`class API < Grape::API` with
+		// resource/namespace prefix nesting + verb blocks) and Roda (routing-tree
+		// `r.on`/`r.is` branch prefixes + leaf verbs). Both attach their handler
+		// as an anonymous block — same-file by construction — so each route is
+		// signalled as an inline handler (refKind=inlineHandlerRefKind) and
+		// emitFile stamps StartLine on the synthetic + a same-file IMPLEMENTS
+		// bridge (mirrors Sinatra #4385). Each synthesizer is gated on its own
+		// class signal (`< Grape::API` / `< Roda`) so it no-ops on every other
+		// Ruby file.
+		synthesizeGrape(string(content), path, emitFile)
+		synthesizeRoda(string(content), path, emitFile)
 		// Producer side (#3621): graphql-ruby GraphQL server. Maps each
 		// `field :<name>` on a root operation type class (QueryType /
 		// MutationType / SubscriptionType, subclasses of *BaseObject) to the

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -259,6 +259,21 @@ const (
 	// and required ones as `:id`. canonicalizeConduitParams drops the optional
 	// `[ ]` wrapper and rewrites `:name` → `{name}`.
 	FrameworkConduit = "conduit"
+	// FrameworkGrape (#4417) — Ruby Grape API (`class API < Grape::API`) declares
+	// routes with verb blocks (`get ':id' do ... end`) nested inside `resource`/
+	// `namespace`/`group` blocks. The synthesizer composes the resource/namespace
+	// prefixes onto the verb path. Grape path parameters use the Sinatra/Express-
+	// style `:name` colon-prefixed convention (`/users/:id` → `/users/{id}`), so
+	// canonicalisation reuses canonicalizeColonParams.
+	FrameworkGrape = "grape"
+	// FrameworkRoda (#4417) — Ruby Roda routing tree (`route do |r| r.on "users"
+	// do r.get Integer do |id| ... end end end`). The synthesizer composes the
+	// `r.on`/`r.is` branch segments into the path with the verb at the leaf. Roda
+	// captures are NORMALISED by the synthesizer before canonicalisation: a
+	// `String`/`Integer`/`Float`/`:sym` class-matcher or symbol-capture branch
+	// segment is rewritten to the Express-style `:param` form, so canonicalisation
+	// reuses canonicalizeColonParams.
+	FrameworkRoda = "roda"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -319,7 +334,7 @@ func Canonicalize(framework, raw string) string {
 		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails,
 		FrameworkRobyn, FrameworkPlug, FrameworkCowboy,
 		FrameworkLapis, FrameworkOpenResty, FrameworkVapor, FrameworkClojure,
-		FrameworkKemal, FrameworkRatpack:
+		FrameworkKemal, FrameworkRatpack, FrameworkGrape, FrameworkRoda:
 		out = canonicalizeColonParams(raw)
 	case FrameworkGiraffe:
 		// Giraffe `routef "/users/%i"` printf placeholders → `{}` first, then


### PR DESCRIPTION
Follow-up to the Sinatra inline-handler work (#4385, ref epic #4334). Two more Ruby web-route DSLs attach their handler as an ANONYMOUS block (no named method), so each route must signal the framework-general inline-handler mechanism (#4324/#4385, confirmed general by #4319) to avoid leaving the endpoint a handler-less graph island.

## What

- **Grape** (`class API < Grape::API`): `synthesizeGrape` walks `resource`/`resources`/`namespace`/`group`/`segment` prefix blocks, composing each prefix onto the verb-block path. `resource :users do get ':id' do ... end end` → `GET /users/{id}`. Bare `get do` registers the resource root. `:id` → `{id}` (colon canonicalize).
- **Roda** (`class App < Roda`): `synthesizeRoda` walks the `r.on`/`r.is` routing tree, composing branch segments into the path with the verb at the leaf. `r.on "users" do r.get Integer do |id| ... end end` → `GET /users/{id}`. String literals are static segments; `String`/`Integer`/`Float` class matchers and `:sym` captures normalize to `{param}`. Best-effort over the dynamic tree (regexp / array matchers skipped; documented in code).
- **Inline-handler bridge**: each verb block signals `refKind=inlineHandlerRefKind` so `makeEmit` synthesizes a stable `<inline VERB /path>` handler Operation + a same-file IMPLEMENTS bridge — reusing the exact Sinatra #4385 path (`emitFile`, `synthesisHandlerStructuralRef`).
- `FrameworkGrape` / `FrameworkRoda` consts added in `httproutes/canonicalize.go` and wired into the colon-param canonicalize case; synthesis cases wired append-only into the `ruby` branch of `http_endpoint_synthesis.go`.
- New `extractRubyBlockBody` do/end balancer correctly counts `do |args|` openers (the shared Rails `endsWithDo` misses `r.get Integer do |id|`, which previously closed the enclosing branch early).

## Coverage docs

Ruby `grape` + `roda` `endpoint_synthesis`, `handler_attribution`, `route_extraction` cells updated surgically via `tools/coverage update`. `coverage fmt --check` ok, `coverage validate` 0 errors.

## Validation (fixtures RED→GREEN, real extract+synthesis+merge+resolve pipeline)

- `TestInline4417_GrapeResourceNesting` — `/users`, `/users/{id}`, `/users/invite`, nested `/users/v1`, all IMPLEMENTS-bridged
- `TestInline4417_GrapeNoDoubleEmit` — nested route not double-emitted un-prefixed
- `TestInline4417_RodaRoutingTree` — `/users`, `/users/{param}`, `/users/profile`, all bridged
- `TestInline4417_RodaInlineVerbMatcher` — `r.get String do |slug|` leaf capture
- `TestInline4417_NonRouteRubyUnaffected` — regression: plain Ruby class (incl. a method literally named `get`) yields no grape/roda endpoints

## Gates

`go build ./...`, `go vet` (engine/custom/extractors), full `go test` (engine/custom/extractors/graph/types) all green; `coverage fmt --check` ok; `coverage validate` 0 errors.

Closes #4417

🤖 Generated with [Claude Code](https://claude.com/claude-code)