### PR TITLE
fix(flow): kind Mongo/query-builder data-access terminal as db_query, not render (#4337)

### DIFF
--- a/internal/dashboard/handlers_flows_annotation.go
+++ b/internal/dashboard/handlers_flows_annotation.go
@@ -89,7 +89,25 @@ func classifyStepKind(entityKind string, outEdgeKinds map[string]bool, inEdgeKin
 	}
 
 	// ── DB query ─────────────────────────────────────────────────────────────
-	if outEdgeKinds["READS_FROM"] || outEdgeKinds["QUERIES"] {
+	// READS_FROM/QUERIES are the imperative ORM read edges (Model.find()).
+	// JOINS_COLLECTION (Mongo $lookup) and ACCESSES_TABLE are the data-access
+	// topology edges emitted for FUNCTIONAL / fluent query-builder terminals —
+	// a Mongo aggregation-pipeline builder (`mongo<…>().lookupOne(...).…`, #4320),
+	// and the SQL builder family (knex/TypeORM) — whose terminal node carries no
+	// imperative read edge. Without these, that terminal fell through to the
+	// entity-kind substring matchers below and was mis-kinded `render` when the
+	// builder/factory entity Kind happened to contain a view-ish token (#4337).
+	if outEdgeKinds["READS_FROM"] || outEdgeKinds["QUERIES"] ||
+		outEdgeKinds["JOINS_COLLECTION"] || outEdgeKinds["ACCESSES_TABLE"] {
+		return StepKindDBQuery
+	}
+	// A SCOPE.DataAccess terminal is a data-access node even when its join
+	// target is honestly unresolved (a non-static `from:` collection emits the
+	// stage node but no JOINS_COLLECTION edge, #4320). Classify it as a DB query
+	// step BY KIND — and, critically, BEFORE the render/test/validation entity-
+	// kind substring matchers — so a query-builder terminal is never mis-kinded
+	// `render`. Mirrors the db_query kind used for an imperative Model.find().
+	if containsAny(entityKind, "DataAccess") {
 		return StepKindDBQuery
 	}
 

--- a/internal/dashboard/handlers_flows_annotation_test.go
+++ b/internal/dashboard/handlers_flows_annotation_test.go
@@ -54,6 +54,50 @@ func TestClassifyStepKind_DBQuery(t *testing.T) {
 	}
 }
 
+// TestClassifyStepKind_MongoPipelineBuilderTerminal is the #4337 regression: a
+// FUNCTIONAL Mongo aggregation-pipeline builder terminal (a SCOPE.DataAccess
+// node reached via a JOINS_COLLECTION $lookup edge) must classify as db_query —
+// the data-access terminal kind — NOT `render`. Before the fix it fell through
+// to the entity-kind substring matchers and was mis-kinded `render`.
+func TestClassifyStepKind_MongoPipelineBuilderTerminal(t *testing.T) {
+	got := classifyStepKind("SCOPE.DataAccess", map[string]bool{"JOINS_COLLECTION": true}, nil, false)
+	if got != StepKindDBQuery {
+		t.Errorf("Mongo $lookup pipeline-builder terminal: want %q, got %q", StepKindDBQuery, got)
+	}
+}
+
+// TestClassifyStepKind_DataAccessKindUnresolvedJoin covers the honest-unresolved
+// case: a SCOPE.DataAccess stage whose `from:` collection is non-static, so no
+// JOINS_COLLECTION edge is emitted. It must still classify as db_query by KIND,
+// never `render`.
+func TestClassifyStepKind_DataAccessKindUnresolvedJoin(t *testing.T) {
+	got := classifyStepKind("SCOPE.DataAccess", map[string]bool{}, nil, false)
+	if got != StepKindDBQuery {
+		t.Errorf("DataAccess terminal (no edge): want %q, got %q", StepKindDBQuery, got)
+	}
+}
+
+// TestClassifyStepKind_AccessesTableBuilderTerminal generalises #4337 to the SQL
+// fluent-builder family (knex / TypeORM QueryBuilder), whose data-access
+// terminal carries an ACCESSES_TABLE edge rather than an imperative read edge.
+func TestClassifyStepKind_AccessesTableBuilderTerminal(t *testing.T) {
+	got := classifyStepKind("SCOPE.DataAccess", map[string]bool{"ACCESSES_TABLE": true}, nil, false)
+	if got != StepKindDBQuery {
+		t.Errorf("ACCESSES_TABLE builder terminal: want %q, got %q", StepKindDBQuery, got)
+	}
+}
+
+// TestClassifyStepKind_GenuineRenderUnaffected is the #4337 regression guard: an
+// actual UI render terminal (a Component/View entity with no data-access edge or
+// kind) must STILL classify as render — the fix must not over-reach.
+func TestClassifyStepKind_GenuineRenderUnaffected(t *testing.T) {
+	for _, k := range []string{"SCOPE.View", "SCOPE.Component", "ReactComponent", "Widget"} {
+		if got := classifyStepKind(k, map[string]bool{}, nil, false); got != StepKindRender {
+			t.Errorf("genuine render terminal %q: want %q, got %q", k, StepKindRender, got)
+		}
+	}
+}
+
 func TestClassifyStepKind_MessagePublish(t *testing.T) {
 	got := classifyStepKind("Function", map[string]bool{"PUBLISHES_TO": true}, nil, false)
 	if got != StepKindMessagePublish {

--- a/internal/dashboard/handlers_flows_quality.go
+++ b/internal/dashboard/handlers_flows_quality.go
@@ -25,6 +25,14 @@ var usefulSinkEdgeKinds = map[string]bool{
 	"PUBLISHES":    true,
 	"WS_EMITS":     true,
 	"STREAMS_TO":   true,
+	// DB reads / query-builder data access — a read-only flow that terminates
+	// at a data-access node (e.g. a functional Mongo aggregation-pipeline builder
+	// reached via JOINS_COLLECTION, or an ORM read via QUERIES/READS_FROM, or a
+	// SQL builder via ACCESSES_TABLE, #4337) IS a useful sink, not a dead end.
+	"READS_FROM":       true,
+	"QUERIES":          true,
+	"JOINS_COLLECTION": true,
+	"ACCESSES_TABLE":   true,
 	// Test assertions
 	"ASSERTS": true,
 	// State mutation
@@ -39,6 +47,10 @@ var usefulSinkKindSubstrings = []string{
 	"Test",
 	"Assert",
 	"Render",
+	// A SCOPE.DataAccess terminal (functional query-builder pipeline with a
+	// non-static / unresolved join target carries no out-edge) is a useful data
+	// sink by KIND (#4337).
+	"DataAccess",
 }
 
 // flowStepKey identifies a step entity by repo slug and local entity ID.


### PR DESCRIPTION
## Problem (#4337, follow-up to #4320)

In flow synthesis the terminal step of a functional Mongo aggregation pipeline
(`mePageRetrievePipeline → lookupOne → unwind → add → AggregationBuilder`) was
mis-kinded as `render` — a UI kind — instead of a data-access terminal.

#4320 fixed the EXTRACTION gap (the builder terminal is now a `SCOPE.DataAccess`
node with `JOINS_COLLECTION` edges), but the flow step-kind CLASSIFIER was left
to this follow-up to avoid cross-PR conflict.

## Root cause

`classifyStepKind` (internal/dashboard/handlers_flows_annotation.go — the
flow-step taxonomy the modal renders) recognised db_query only via the
imperative ORM read edges `READS_FROM` / `QUERIES`. A functional query-builder
terminal carries neither — its data-access topology is on `JOINS_COLLECTION`
(Mongo `$lookup`) / `ACCESSES_TABLE` (SQL builders). So the terminal fell
through to the entity-kind substring matchers and matched `render` whenever the
builder/factory entity Kind contained a view-ish token.

## Fix

- db_query now also matches `JOINS_COLLECTION` / `ACCESSES_TABLE` out-edges.
- a `SCOPE.DataAccess` terminal classifies as db_query **by KIND**, placed
  **before** the render/test/validation substring matchers, so a data-access
  terminal can never be mis-kinded `render` — including the honest-unresolved
  case (non-static `from:` collection → stage node, no edge).
- **Generalised** to the SQL fluent-builder family (knex / TypeORM QueryBuilder)
  via the same `SCOPE.DataAccess` + `ACCESSES_TABLE` shape — same classifier, no
  per-ORM branch needed.
- Sibling fix in `handlers_flows_quality.go`: a read-only flow terminating at a
  data-access node is now a **useful sink**, not a dead end.

Genuine UI render terminals (Component/View/Widget, no data-access edge/kind)
still classify as `render` — regression-guarded.

## Validation (RED→GREEN)

New tests in `handlers_flows_annotation_test.go`:
- Mongo `$lookup` pipeline-builder terminal → `db_query` (was `render`)
- `SCOPE.DataAccess` kind w/ no edge (unresolved join) → `db_query`
- `ACCESSES_TABLE` builder terminal → `db_query`
- genuine render terminals (View/Component/Widget) → still `render`

## Gates

- `go build ./...` ✅
- `go vet ./internal/engine/...` ✅
- `go test ./internal/engine/... ./internal/graph/... ./internal/mcp/... ./internal/dashboard/...` ✅
- `coverage fmt --check` ✅ canonical · `coverage validate` ✅ 0 errors (pre-existing warnings only; no per-language cell applies to this classifier)

Closes #4337

🤖 Generated with [Claude Code](https://claude.com/claude-code)