### PR TITLE
feat(angular): route-config guard/resolver → guard class USES edges (#4415)

### DIFF
--- a/internal/extractors/javascript/angular_route_guards.go
+++ b/internal/extractors/javascript/angular_route_guards.go
@@ -1,0 +1,283 @@
+// angular_route_guards.go — Angular route-config guard/resolver wiring
+// (issue #4415, follow-up to the global-DI pass #4378; epic #4334).
+//
+// Angular binds guard and resolver CLASSES to a route declaratively in the
+// route-config array:
+//
+//	const routes: Routes = [{
+//	  path: 'admin',
+//	  component: AdminComponent,
+//	  canActivate: [AuthGuard, RoleGuard],   // array-of-class form
+//	  canActivateChild: [ChildGuard],
+//	  canDeactivate: [UnsavedGuard],
+//	  canMatch: [FeatureGuard],
+//	  canLoad: [LazyGuard],
+//	  resolve: { user: UserResolver },        // object-map form
+//	}];
+//
+// #4378 covered NgModule / standalone-bootstrap providers but explicitly
+// deferred route guards because route extraction lives on a separate path. This
+// pass closes that gap: for each route object it emits a route → guard/resolver
+// CLASS USES edge tagged di_role=guard|resolver. The guard interfaces
+// (CanActivate / Resolve / …) already give the class an IMPLEMENTS edge via
+// guard_interceptor_recognition (#2874); the NEW edge here is the
+// route→guard USES wiring that connects the route declaration to the class.
+//
+// Edge target is a bare class identifier; it resolves to the declaring entity
+// through resolve.BuildIndex's symbol table (the same convention the global-DI
+// USES edges use). The edge hangs off the entity that owns the route table —
+// the enclosing class entity when the route array sits inside a class body
+// (e.g. an @NgModule with RouterModule.forRoot([...])), otherwise the file
+// entity (entities[0]) for a top-level `const routes: Routes = [...]`.
+//
+// The modern FUNCTIONAL-guard form (`canActivate: [() => inject(Auth).ok()]`)
+// is handled best-effort: when the arrow body statically references an injected
+// service via `inject(ServiceClass)`, a USES edge to that service is emitted
+// (di_role=guard, functional=true). When no service is statically recoverable
+// (e.g. a free function reference resolved elsewhere) the entry is skipped
+// honestly rather than guessed.
+//
+// No new entity Kind or relationship Kind is introduced — USES is reused, so
+// internal/types stays exhaustive (the #2839 lesson).
+package javascript
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// angularGuardArrayKeys are the route-config keys whose value is an array of
+// guard classes (or functional guards). Each referenced class becomes a
+// route → guard USES edge with di_role=guard.
+var angularGuardArrayKeys = map[string]bool{
+	"canActivate":      true,
+	"canActivateChild": true,
+	"canDeactivate":    true,
+	"canMatch":         true,
+	"canLoad":          true,
+}
+
+// angularRouteGuards is a program-level pass (invoked from Extract after the AST
+// walk) that scans every route-config object literal for guard/resolver bindings
+// and emits route → guard/resolver CLASS USES edges. It is a no-op on files with
+// no Angular route config.
+func (x *extractor) angularRouteGuards(root *sitter.Node) {
+	if root == nil {
+		return
+	}
+	for _, obj := range findAllNodes(root, "object") {
+		if !x.angularLooksLikeRoute(obj) {
+			continue
+		}
+		route := x.angularRoutePathLabel(obj)
+		owner, ownerIdx := x.angularRouteOwner(obj)
+		for _, edge := range x.angularRouteGuardEdges(obj, route, owner) {
+			x.entities[ownerIdx].Relationships = append(x.entities[ownerIdx].Relationships, edge)
+		}
+	}
+}
+
+// angularLooksLikeRoute reports whether an object literal is an Angular route
+// config: it must carry at least one guard/resolver key (canActivate / resolve /
+// …). Requiring a guard key — not merely `path` — keeps the pass tightly scoped
+// to routes that actually bind a guard, so a plain `{ path, component }` route
+// emits no spurious USES edge (the regression invariant).
+func (x *extractor) angularLooksLikeRoute(obj *sitter.Node) bool {
+	for _, key := range x.angularObjectKeys(obj) {
+		if angularGuardArrayKeys[key] || key == "resolve" {
+			return true
+		}
+	}
+	return false
+}
+
+// angularObjectKeys returns the property-key names of an object literal's direct
+// `pair` children (shorthand/spread entries are skipped).
+func (x *extractor) angularObjectKeys(obj *sitter.Node) []string {
+	var keys []string
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		pair := obj.Child(i)
+		if pair == nil || pair.Type() != "pair" {
+			continue
+		}
+		k := strings.Trim(x.nodeText(pair.ChildByFieldName("key")), `"'`)
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// angularRoutePathLabel returns a stable label for the route — its `path`
+// segment, normalised so an empty default path renders as "<index>". When the
+// route object has no `path` (a pathless layout route) it falls back to
+// "<route>" so the edge still carries an anchor.
+func (x *extractor) angularRoutePathLabel(obj *sitter.Node) string {
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		pair := obj.Child(i)
+		if pair == nil || pair.Type() != "pair" {
+			continue
+		}
+		if strings.Trim(x.nodeText(pair.ChildByFieldName("key")), `"'`) != "path" {
+			continue
+		}
+		val := strings.Trim(strings.TrimSpace(x.nodeText(pair.ChildByFieldName("value"))), `"'`)
+		if val == "" {
+			return "<index>"
+		}
+		return val
+	}
+	return "<route>"
+}
+
+// angularRouteOwner returns the name and entity index of the entity that should
+// own the route's guard USES edges: the nearest enclosing class entity when the
+// route array sits in a class body, otherwise the file entity (index 0). The
+// index is guaranteed valid (the file entity always exists).
+func (x *extractor) angularRouteOwner(obj *sitter.Node) (string, int) {
+	for n := obj.Parent(); n != nil; n = n.Parent() {
+		if n.Type() != "class_declaration" {
+			continue
+		}
+		name := x.nodeText(n.ChildByFieldName("name"))
+		if name == "" {
+			break
+		}
+		if idx := x.entityIndexByName(name); idx >= 0 {
+			return name, idx
+		}
+		break
+	}
+	return x.entities[0].Name, 0
+}
+
+// angularRouteGuardEdges builds the route → guard/resolver USES edges for one
+// route object: the array-of-class guard keys (di_role=guard), the resolve
+// object-map (di_role=resolver) and best-effort functional guards (the
+// inject(Service) target). Duplicate (target, role) pairs within a route are
+// de-duplicated.
+func (x *extractor) angularRouteGuardEdges(obj *sitter.Node, route, owner string) []types.RelationshipRecord {
+	var edges []types.RelationshipRecord
+	seen := map[string]bool{}
+
+	add := func(target, role, key string) {
+		if target == "" {
+			return
+		}
+		dedup := target + "|" + role
+		if seen[dedup] {
+			return
+		}
+		seen[dedup] = true
+		edges = append(edges, types.RelationshipRecord{
+			FromID: owner,
+			ToID:   target,
+			Kind:   string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"framework": "angular",
+				"di_role":   role,
+				"route":     route,
+				"route_key": key,
+				"owner":     owner,
+				"via":       "angular_route_config",
+			},
+		})
+	}
+
+	for i := 0; i < int(obj.ChildCount()); i++ {
+		pair := obj.Child(i)
+		if pair == nil || pair.Type() != "pair" {
+			continue
+		}
+		key := strings.Trim(x.nodeText(pair.ChildByFieldName("key")), `"'`)
+		val := pair.ChildByFieldName("value")
+		if val == nil {
+			continue
+		}
+		switch {
+		case angularGuardArrayKeys[key]:
+			for _, t := range x.angularGuardArrayTargets(val) {
+				add(t.name, "guard", key)
+			}
+		case key == "resolve":
+			// resolve: { dataKey: ResolverClass, ... } — object-map form.
+			if val.Type() != "object" {
+				continue
+			}
+			for j := 0; j < int(val.ChildCount()); j++ {
+				rp := val.Child(j)
+				if rp == nil || rp.Type() != "pair" {
+					continue
+				}
+				resolver := angularLeafTypeName(strings.TrimSpace(x.nodeText(rp.ChildByFieldName("value"))))
+				add(resolver, "resolver", key)
+			}
+		}
+	}
+	return edges
+}
+
+// angularGuardTarget is one resolved entry of a guard array: either a class
+// identifier (functional=false) or the injected service of a functional guard
+// (functional=true). A functional guard with no statically recoverable service
+// yields no target and is skipped by the caller.
+type angularGuardTarget struct {
+	name       string
+	functional bool
+}
+
+// angularGuardArrayTargets returns the guard targets of an array value. A bare
+// identifier element is a class guard. An arrow-function element is a functional
+// guard — best-effort resolved to the first `inject(Service)` class referenced
+// in its body; if none is statically recoverable the element is dropped.
+func (x *extractor) angularGuardArrayTargets(arr *sitter.Node) []angularGuardTarget {
+	if arr == nil || arr.Type() != "array" {
+		return nil
+	}
+	var out []angularGuardTarget
+	for i := 0; i < int(arr.ChildCount()); i++ {
+		el := arr.Child(i)
+		if el == nil {
+			continue
+		}
+		switch el.Type() {
+		case "identifier":
+			name := strings.TrimSpace(x.nodeText(el))
+			if name != "" {
+				out = append(out, angularGuardTarget{name: name})
+			}
+		case "arrow_function", "function", "function_expression":
+			if svc := x.angularFunctionalGuardService(el); svc != "" {
+				out = append(out, angularGuardTarget{name: svc, functional: true})
+			}
+		}
+	}
+	return out
+}
+
+// angularFunctionalGuardService best-effort recovers the injected service class
+// of an inline functional guard: the first-argument identifier of an
+// `inject(ServiceClass)` call inside the arrow body. Returns "" when no static
+// inject(...) target is present (the honest-skip path).
+func (x *extractor) angularFunctionalGuardService(fn *sitter.Node) string {
+	for _, call := range findAllNodes(fn, "call_expression") {
+		callee := call.ChildByFieldName("function")
+		if callee == nil || x.nodeText(callee) != "inject" {
+			continue
+		}
+		args := call.ChildByFieldName("arguments")
+		if args == nil {
+			continue
+		}
+		for i := 0; i < int(args.ChildCount()); i++ {
+			a := args.Child(i)
+			if a != nil && a.Type() == "identifier" {
+				return strings.TrimSpace(x.nodeText(a))
+			}
+		}
+	}
+	return ""
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -285,6 +285,15 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		// (generalises the NestJS global-DI fix #4329). Runs after walk so the
 		// @NgModule entity already exists.
 		x.angularGlobalProviders(root)
+		// Issue #4415 — Angular route-config guard/resolver wiring. The route
+		// array binds guard/resolver CLASSES declaratively
+		// ({ path, canActivate:[Guard], resolve:{x:Res}, canMatch:[...] }) on a
+		// separate path from the provider passes above. Emit route → guard
+		// class USES edges (di_role=guard|resolver) — array form, resolve
+		// object-map and best-effort functional guards (inject(Service)) — so
+		// the guard/resolver class is connected and resolves through the symbol
+		// table. Follow-up to #4378; runs after walk so owner entities exist.
+		x.angularRouteGuards(root)
 		// Issue #742 — snapshot length before collectImports so we can
 		// identify which entities were added by it (the import-placeholder
 		// SCOPE.Component/import entities). After collectImports we call

--- a/internal/extractors/javascript/issue4415_angular_route_guards_test.go
+++ b/internal/extractors/javascript/issue4415_angular_route_guards_test.go
@@ -1,0 +1,192 @@
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/resolve"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4415 LIVE-REPRO — Angular route-config guard/resolver wiring.
+//
+// Angular binds guard and resolver CLASSES to a route declaratively in the
+// route-config array ({ path, canActivate:[Guard], resolve:{x:Res}, canMatch:
+// [...] }). #4378 covered NgModule / standalone-bootstrap providers but
+// deferred route guards because route extraction lives on a separate path.
+//
+// PRE-FIX: the route-config guard/resolver classes had NO inbound edge from the
+// route declaration — only their IMPLEMENTS edge to the guard interface — so a
+// "what does this route guard with?" query returned nothing and the classes
+// looked disconnected from their use site.
+//
+// POST-FIX: each route emits a route → guard/resolver CLASS USES edge
+// (di_role=guard|resolver, via=angular_route_config). Array form, resolve
+// object-map and best-effort functional guards (inject(Service)) are all
+// covered. Every target resolves to the real class entity through
+// resolve.BuildIndex.
+//
+// The test runs the REAL JSExtractor.Extract pipeline (AST walk + the new
+// program-level pass) and the REAL resolver over faithful Angular fixtures.
+
+func extractTS4415(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseTS(t, []byte(src))
+	e := javascript.New()
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Language: "typescript",
+		Content:  []byte(src),
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return ents
+}
+
+// routeUsesRole returns the di_role of the first USES edge to target, or "".
+func routeUsesRole(ents []types.EntityRecord, target string) string {
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindUses) && r.ToID == target &&
+				r.Properties["via"] == "angular_route_config" {
+				return r.Properties["di_role"]
+			}
+		}
+	}
+	return ""
+}
+
+const ngRouteGuardsFixture = `
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: 'admin',
+    component: AdminComponent,
+    canActivate: [AuthGuard, RoleGuard],
+    canActivateChild: [ChildGuard],
+    canDeactivate: [UnsavedGuard],
+    canMatch: [FeatureGuard],
+    resolve: { user: UserResolver, prefs: PrefsResolver },
+  },
+  {
+    path: 'public',
+    component: PublicComponent,
+  },
+];
+
+@Injectable() export class AuthGuard {}
+@Injectable() export class RoleGuard {}
+@Injectable() export class ChildGuard {}
+@Injectable() export class UnsavedGuard {}
+@Injectable() export class FeatureGuard {}
+@Injectable() export class UserResolver {}
+@Injectable() export class PrefsResolver {}
+
+@NgModule({ imports: [RouterModule.forRoot(routes)] })
+export class AppRoutingModule {}
+`
+
+// TestIssue4415_RouteGuardsAndResolvers proves the core fix: a route with
+// canActivate + resolve emits USES edges to each guard (di_role=guard) and each
+// resolver (di_role=resolver), and every target resolves to its real class.
+func TestIssue4415_RouteGuardsAndResolvers(t *testing.T) {
+	ents := extractTS4415(t, "src/app/app-routing.module.ts", ngRouteGuardsFixture)
+
+	wantGuards := []string{"AuthGuard", "RoleGuard", "ChildGuard", "UnsavedGuard", "FeatureGuard"}
+	for _, g := range wantGuards {
+		if role := routeUsesRole(ents, g); role != "guard" {
+			t.Errorf("guard %s: want route USES di_role=guard, got %q", g, role)
+		}
+	}
+	for _, r := range []string{"UserResolver", "PrefsResolver"} {
+		if role := routeUsesRole(ents, r); role != "resolver" {
+			t.Errorf("resolver %s: want route USES di_role=resolver, got %q", r, role)
+		}
+	}
+
+	// Every guard/resolver target resolves to its real declaring class entity.
+	idx := resolve.BuildIndex(ents)
+	for _, name := range append(append([]string{}, wantGuards...), "UserResolver", "PrefsResolver") {
+		if _, ok := idx.Lookup(name); !ok {
+			t.Errorf("route guard/resolver target %s failed to resolve", name)
+		}
+	}
+}
+
+// TestIssue4415_MultipleGuardsArray asserts each class in a canActivate array
+// gets its own edge (not just the first).
+func TestIssue4415_MultipleGuardsArray(t *testing.T) {
+	ents := extractTS4415(t, "src/app/app-routing.module.ts", ngRouteGuardsFixture)
+	count := 0
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindUses) &&
+				r.Properties["via"] == "angular_route_config" &&
+				r.Properties["route_key"] == "canActivate" {
+				count++
+			}
+		}
+	}
+	if count != 2 {
+		t.Errorf("canActivate:[AuthGuard, RoleGuard] should yield 2 USES edges, got %d", count)
+	}
+}
+
+// TestIssue4415_NoGuardsNoSpuriousEdge is the regression invariant: a route with
+// no guard/resolver keys ({path, component}) emits no route-config USES edge.
+func TestIssue4415_NoGuardsNoSpuriousEdge(t *testing.T) {
+	const fixture = `
+import { Routes } from '@angular/router';
+const routes: Routes = [
+  { path: 'home', component: HomeComponent },
+  { path: 'about', component: AboutComponent },
+];
+`
+	ents := extractTS4415(t, "src/app/routes.ts", fixture)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindUses) &&
+				r.Properties["via"] == "angular_route_config" {
+				t.Fatalf("guard-free route emitted a spurious USES edge to %s", r.ToID)
+			}
+		}
+	}
+}
+
+// TestIssue4415_FunctionalGuard covers the modern functional-guard form: an
+// inline `() => inject(AuthService).isLoggedIn()` best-effort links to the
+// injected service (di_role=guard, functional). A functional guard with no
+// statically recoverable inject() target is skipped honestly.
+func TestIssue4415_FunctionalGuard(t *testing.T) {
+	const fixture = `
+import { Routes } from '@angular/router';
+import { inject } from '@angular/core';
+
+const routes: Routes = [
+  {
+    path: 'secure',
+    canActivate: [() => inject(AuthService).isLoggedIn()],
+    canMatch: [() => true],
+  },
+];
+
+@Injectable() export class AuthService { isLoggedIn() { return true; } }
+`
+	ents := extractTS4415(t, "src/app/secure.routes.ts", fixture)
+
+	if role := routeUsesRole(ents, "AuthService"); role != "guard" {
+		t.Errorf("functional guard should link to injected AuthService (di_role=guard), got %q", role)
+	}
+	// The `() => true` functional guard has no inject() target → no edge, and no
+	// crash. Confirm AuthService resolves (it is declared in-file).
+	idx := resolve.BuildIndex(ents)
+	if _, ok := idx.Lookup("AuthService"); !ok {
+		t.Errorf("functional-guard injected service AuthService failed to resolve")
+	}
+}


### PR DESCRIPTION
## What

Closes #4415 (follow-up to global-DI #4378, epic #4334).

Angular binds guard/resolver **classes** to a route declaratively in the route-config array (`{ path, canActivate:[Guard], resolve:{x:Res}, canMatch:[...] }`). #4378 covered NgModule / standalone-bootstrap providers but explicitly deferred route guards because route extraction lives on a separate path (see the deferral note in `angular_global_di.go`).

This PR closes that gap.

## How

New program-level pass `angularRouteGuards(root)` (in `internal/extractors/javascript/angular_route_guards.go`, wired into `Extract` after `angularGlobalProviders`) scans every route object literal and emits a **route → guard/resolver CLASS USES edge** (`di_role=guard|resolver`, `via=angular_route_config`, `route=<path>`):

- **Array-of-class form** — `canActivate` / `canActivateChild` / `canDeactivate` / `canMatch` / `canLoad`: one USES edge per class.
- **resolve object-map form** — `resolve: { key: ResolverClass }`: `di_role=resolver`.
- **Functional guards (best-effort)** — `canActivate: [() => inject(Service).ok()]`: links USES to the statically-recoverable injected `Service`; when no `inject()` target is recoverable (e.g. `() => true`) the entry is **skipped honestly** rather than guessed.

The USES edge hangs off the entity that owns the route table — the enclosing class entity when the array sits in a class body (`RouterModule.forRoot([...])` inside an `@NgModule`), otherwise the file entity for a top-level `const routes: Routes = [...]`. Targets are bare class identifiers that resolve through `resolve.BuildIndex`'s symbol table (the same convention the global-DI USES edges use). Guard classes already get their `IMPLEMENTS` edge to the guard interface via `guard_interceptor_recognition` (#2874) — the new edge is the route→guard wiring.

No new entity or relationship Kind — USES is reused (`internal/types` stays exhaustive).

## How routes are modeled

Routes are not standalone entities in the graph — `angularRouteTableRels` emits `NAVIGATES_TO route:<path>` edges off the declaring class. Matching that "route ⇒ its owning class/file" convention, the new guard USES edges anchor on the route-table owner and carry the `route` path as an edge property.

## Validation (RED→GREEN, real extract+resolve pipeline)

`internal/extractors/javascript/issue4415_angular_route_guards_test.go`:
- route with `canActivate:[AuthGuard,RoleGuard]` + `resolve:{u:UserResolver}` → USES edges to each guard (`di_role=guard`) and each resolver (`di_role=resolver`); all targets resolve.
- `canActivate:[X,Y]` → an edge per class (asserts count == 2).
- **regression**: guard-free `{path,component}` route → no spurious USES edge.
- functional guard `() => inject(AuthService)...` → USES `AuthService`; `() => true` → no edge, no crash.

## Coverage docs

`guard_interceptor_recognition` cell in `docs/coverage/registry.json` extended surgically (cites + notes). `coverage fmt --check` canonical, `coverage validate` 0 errors.

## Gates
`go build ./...`, `go vet ./internal/custom/... ./internal/extractors/...`, `go test ./internal/custom/... ./internal/extractors/... ./internal/graph/... ./internal/types/`, `coverage fmt --check`, `coverage validate` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)