### PR TITLE
fix: chi Route prefix (#4782) + Ruby/Rust import contract (#4783) + Django imperative signals (#4789)

### DIFF
--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -35,6 +35,15 @@ var (
 	djangoCBVMethodRe     = regexp.MustCompile(`(?m)^\s{4,}def\s+(get|post|put|patch|delete|head|options|trace)\s*\(\s*self`)
 	djangoReceiverRe      = regexp.MustCompile(`(?m)@receiver\s*\(\s*([\w.]+)(?:\s*,\s*sender\s*=\s*(\w+))?[^)]*\)\s*\n\s*(?:async\s+)?def\s+(\w+)\s*\(`)
 	djangoReceiverOnlyRe  = regexp.MustCompile(`(?m)@receiver\s*\(\s*([\w.]+)(?:\s*,\s*sender\s*=\s*(\w+))?[^)]*\)`)
+	// #4789 — imperative signal wiring registered in AppConfig.ready() (or
+	// anywhere): `post_save.connect(my_receiver, sender=Foo)`, the dotted
+	// `signals.post_delete.connect(handler)` form, and the bare
+	// `<signal>.connect(<receiver>)` (no sender). Group 1 = the signal
+	// expression (possibly dotted, e.g. `signals.post_save`), group 2 = the
+	// receiver callable, group 3 = the optional `sender=` model. The receiver
+	// and sender may be dotted; the leaf is used for entity / model resolution.
+	djangoSignalConnectRe = regexp.MustCompile(
+		`([\w.]+)\.connect\s*\(\s*([\w.]+)\s*(?:,\s*sender\s*=\s*([\w.]+))?[^)]*\)`)
 	djangoAdminRegRe      = regexp.MustCompile(`(?m)admin\.site\.register\s*\(\s*(\w+)(?:\s*,\s*(\w+))?\s*\)`)
 	djangoAdminDecorRe    = regexp.MustCompile(`(?m)@admin\.register\s*\(\s*(\w+)\s*\)\s*\n\s*class\s+(\w+)\s*\(`)
 	djangoDRFSerializerRe = regexp.MustCompile(
@@ -341,6 +350,72 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 			}
 		}
 
+		out = append(out, ent)
+	}
+
+	// 3b. Imperative signal wiring (#4789).
+	// `post_save.connect(my_receiver, sender=Foo)` registered in an AppConfig
+	// `ready()` method (or anywhere in the module) wires the receiver→signal the
+	// same way the `@receiver` decorator does, but through a runtime call rather
+	// than a decorator — so the decorator pass above never sees it. Emit the same
+	// HANDLES_SIGNAL edge shape: a handler entity (the receiver function) with a
+	// HANDLES_SIGNAL edge to the sender model, carrying signal_type. Marked
+	// di_role=signal_handler so the binding is distinguishable from the
+	// decorator form. The receiver's leaf name resolves structurally to the real
+	// function entity via the QualifiedName/name index. A `connect()` whose first
+	// arg is not a plausible callable name (e.g. a lambda) is skipped.
+	for _, m := range djangoSignalConnectRe.FindAllStringSubmatchIndex(source, -1) {
+		signalExpr := source[m[2]:m[3]]
+		receiver := source[m[4]:m[5]]
+		var senderModel string
+		if m[6] != -1 {
+			senderModel = source[m[6]:m[7]]
+		}
+		// The `.connect(` method also appears on non-signal objects (sockets,
+		// DB connections). Gate on the signal expression's leaf being a known
+		// Django signal name so we don't wire unrelated `.connect()` calls.
+		signalType := djangoLeafName(signalExpr)
+		if !djangoKnownSignals[signalType] {
+			continue
+		}
+		handlerName := djangoLeafName(receiver)
+		if handlerName == "" {
+			continue
+		}
+		// Skip an already-emitted decorator-wired handler so the same function
+		// isn't double-listed (the decorator path is authoritative for it).
+		if handledFuncs[handlerName] {
+			continue
+		}
+		props := map[string]string{
+			"framework":    "django",
+			"language":     "python",
+			"pattern_type": "signal",
+			"signal_type":  signalType,
+			"di_role":      "signal_handler",
+			"provenance":   "INFERRED_FROM_DJANGO_SIGNAL_CONNECT",
+		}
+		if senderModel != "" {
+			props["sender"] = djangoLeafName(senderModel)
+		}
+		ent := entity(handlerName, "SCOPE.Operation", "function", file.Path, lineOf(source, m[0]), props)
+		// Emit the HANDLES_SIGNAL edge. With a sender, target the model; without
+		// one, target the signal itself so the wiring is still represented.
+		edgeProps := map[string]string{"signal_type": signalType, "framework": "django", "di_role": "signal_handler"}
+		if senderModel != "" {
+			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+				ToID:       djangoModelRef(djangoLeafName(senderModel)),
+				Kind:       string(types.RelationshipKindHandlesSignal),
+				Properties: edgeProps,
+			})
+		} else {
+			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+				ToID:       signalType,
+				Kind:       string(types.RelationshipKindHandlesSignal),
+				Properties: edgeProps,
+			})
+		}
+		handledFuncs[handlerName] = true
 		out = append(out, ent)
 	}
 
@@ -894,6 +969,47 @@ func isOnlyWhitespaceAndComments(text string) bool {
 // passes connect to the same canonical model node.
 func djangoModelRef(modelName string) string {
 	return fmt.Sprintf("Class:%s", modelName)
+}
+
+// djangoLeafName returns the trailing dotted segment of an expression
+// ("signals.post_save" → "post_save", "post_save" → "post_save"). Used to
+// normalise both the signal and the receiver/sender names in the imperative
+// signal-connect form (#4789).
+func djangoLeafName(expr string) string {
+	expr = strings.TrimSpace(expr)
+	if i := strings.LastIndex(expr, "."); i >= 0 && i+1 < len(expr) {
+		return expr[i+1:]
+	}
+	return expr
+}
+
+// djangoKnownSignals is the set of Django signal names whose `.connect(...)`
+// call is a signal registration (#4789). Gating on this set keeps the
+// `<x>.connect(...)` matcher from wiring unrelated `.connect()` calls (DB
+// connections, sockets, custom non-signal objects). Covers the built-in
+// model/request/migration/auth signals plus the generic `Signal()` convention
+// names; custom signals declared as `Signal()` are commonly suffixed
+// `_signal`/`_done`/`_started` but cannot be enumerated, so only the built-ins
+// (the overwhelmingly common case) are recognised — a conservative gate.
+var djangoKnownSignals = map[string]bool{
+	"pre_init":              true,
+	"post_init":             true,
+	"pre_save":              true,
+	"post_save":             true,
+	"pre_delete":            true,
+	"post_delete":           true,
+	"m2m_changed":           true,
+	"pre_migrate":           true,
+	"post_migrate":          true,
+	"request_started":       true,
+	"request_finished":      true,
+	"got_request_exception": true,
+	"setting_changed":       true,
+	"template_rendered":     true,
+	"connection_created":    true,
+	"user_logged_in":        true,
+	"user_logged_out":       true,
+	"user_login_failed":     true,
 }
 
 // appendDRFSerializerEdges resolves a DRF view's request/response serializer

--- a/internal/custom/python/django_signal_connect_4789_test.go
+++ b/internal/custom/python/django_signal_connect_4789_test.go
@@ -1,0 +1,119 @@
+package python_test
+
+import "testing"
+
+// #4789 — imperative Django signal wiring registered in AppConfig.ready():
+// `post_save.connect(my_receiver, sender=Foo)`. Before this fix only the
+// `@receiver` decorator form emitted a HANDLES_SIGNAL edge; the imperative
+// `.connect()` form produced none.
+
+func findHandler(res []extractResult, name string) *extractResult {
+	for i := range res {
+		if res[i].Name == name {
+			return &res[i]
+		}
+	}
+	return nil
+}
+
+// RED→GREEN: a handler wired via `post_save.connect(handler, sender=Foo)` inside
+// AppConfig.ready() gets a HANDLES_SIGNAL edge to Class:Foo with signal_type and
+// di_role=signal_handler.
+func TestDjango_SignalConnect_ReadyMethod(t *testing.T) {
+	src := `from django.apps import AppConfig
+from django.db.models.signals import post_save
+
+class FooConfig(AppConfig):
+    def ready(self):
+        post_save.connect(my_handler, sender=Foo)
+`
+	res := extract(t, "python_django", src)
+	h := findHandler(res, "my_handler")
+	if h == nil {
+		t.Fatalf("expected signal-handler entity 'my_handler'; got %+v", res)
+	}
+	if h.Props["signal_type"] != "post_save" {
+		t.Errorf("signal_type=%q, want post_save", h.Props["signal_type"])
+	}
+	if h.Props["di_role"] != "signal_handler" {
+		t.Errorf("di_role=%q, want signal_handler", h.Props["di_role"])
+	}
+	if h.Props["sender"] != "Foo" {
+		t.Errorf("sender=%q, want Foo", h.Props["sender"])
+	}
+	found := false
+	for _, r := range h.Rels {
+		if r.Kind == "HANDLES_SIGNAL" && r.ToID == "Class:Foo" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected HANDLES_SIGNAL → Class:Foo; got rels %+v", h.Rels)
+	}
+}
+
+// Dotted signal form `signals.post_delete.connect(other_handler, sender=Bar)`
+// resolves the signal leaf and the sender model.
+func TestDjango_SignalConnect_DottedSignal(t *testing.T) {
+	src := `from django.db.models import signals
+
+def wire():
+    signals.post_delete.connect(other_handler, sender=Bar)
+`
+	res := extract(t, "python_django", src)
+	h := findHandler(res, "other_handler")
+	if h == nil {
+		t.Fatalf("expected handler 'other_handler'; got %+v", res)
+	}
+	if h.Props["signal_type"] != "post_delete" {
+		t.Errorf("signal_type=%q, want post_delete", h.Props["signal_type"])
+	}
+	found := false
+	for _, r := range h.Rels {
+		if r.Kind == "HANDLES_SIGNAL" && r.ToID == "Class:Bar" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected HANDLES_SIGNAL → Class:Bar; got rels %+v", h.Rels)
+	}
+}
+
+// Bare `<signal>.connect(<receiver>)` (no sender) wires the handler to the
+// signal itself.
+func TestDjango_SignalConnect_NoSender(t *testing.T) {
+	src := `from django.core.signals import request_started
+
+def setup():
+    request_started.connect(on_start)
+`
+	res := extract(t, "python_django", src)
+	h := findHandler(res, "on_start")
+	if h == nil {
+		t.Fatalf("expected handler 'on_start'; got %+v", res)
+	}
+	if _, ok := h.Props["sender"]; ok {
+		t.Errorf("expected no sender prop, got %q", h.Props["sender"])
+	}
+	found := false
+	for _, r := range h.Rels {
+		if r.Kind == "HANDLES_SIGNAL" && r.ToID == "request_started" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected HANDLES_SIGNAL → request_started; got rels %+v", h.Rels)
+	}
+}
+
+// Gate: a non-signal `.connect()` (e.g. a DB connection or socket) must NOT be
+// wired as a signal handler.
+func TestDjango_SignalConnect_NonSignalIgnored(t *testing.T) {
+	src := `def setup(conn):
+    conn.connect(on_message, sender=Thing)
+`
+	res := extract(t, "python_django", src)
+	if h := findHandler(res, "on_message"); h != nil {
+		t.Errorf("non-signal .connect() must not be wired; got %+v", h)
+	}
+}

--- a/internal/engine/http_endpoint_go_chi_route_prefix_4782_test.go
+++ b/internal/engine/http_endpoint_go_chi_route_prefix_4782_test.go
@@ -1,0 +1,115 @@
+package engine
+
+import "testing"
+
+// #4782 — chi `r.Route("/api", func(r chi.Router){ ... })` is a CLOSURE-based
+// sub-router prefix mount (distinct from gin/echo `.Group(`). Before this fix
+// synthesizeGoRouters dropped the chi sub-router prefix and emitted the route's
+// own path (`/users`) instead of the fully-nested `/api/v1/users`.
+//
+// These tests reuse the collectGoRoutes / assertRoute helpers from the #4408
+// group-prefix test file (same package).
+
+// Fixture A: single chi Route closure → route prefixed with the mount path.
+func TestChiRoutePrefix4782_SingleRoute(t *testing.T) {
+	src := `package main
+
+import "github.com/go-chi/chi/v5"
+
+func setup() {
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/users", listUsers)
+	})
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /api/users")
+	assertNoRoute(t, routes, "GET /users")
+}
+
+// Fixture B: nested chi Route closures → transitively composed prefix.
+func TestChiRoutePrefix4782_NestedRoute(t *testing.T) {
+	src := `package main
+
+import "github.com/go-chi/chi/v5"
+
+func setup() {
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Route("/v1", func(r chi.Router) {
+			r.Get("/users", listUsers)
+		})
+	})
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /api/v1/users")
+	assertNoRoute(t, routes, "GET /users")
+	assertNoRoute(t, routes, "GET /v1/users")
+}
+
+// Fixture C: a route OUTSIDE the Route closure keeps its own (unprefixed) path,
+// while a sibling route inside is prefixed — proves the prefix is scoped to the
+// closure body span, not the whole file.
+func TestChiRoutePrefix4782_ScopedToClosure(t *testing.T) {
+	src := `package main
+
+import "github.com/go-chi/chi/v5"
+
+func setup() {
+	r := chi.NewRouter()
+	r.Get("/health", healthCheck)
+	r.Route("/api", func(r chi.Router) {
+		r.Post("/login", loginHandler)
+	})
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /health")
+	assertRoute(t, routes, "POST /api/login")
+	assertNoRoute(t, routes, "POST /login")
+}
+
+// Fixture D: sibling (non-nested) Route closures do not bleed prefixes into
+// each other.
+func TestChiRoutePrefix4782_SiblingClosures(t *testing.T) {
+	src := `package main
+
+import "github.com/go-chi/chi/v5"
+
+func setup() {
+	r := chi.NewRouter()
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/users", listUsers)
+	})
+	r.Route("/admin", func(r chi.Router) {
+		r.Get("/stats", adminStats)
+	})
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /api/users")
+	assertRoute(t, routes, "GET /admin/stats")
+	assertNoRoute(t, routes, "GET /api/stats")
+	assertNoRoute(t, routes, "GET /admin/users")
+}
+
+// Fixture E: arbitrary (non-`r`) closure param name still resolves, since the
+// prefix is positional, not name-keyed.
+func TestChiRoutePrefix4782_ArbitraryParamName(t *testing.T) {
+	src := `package main
+
+import "github.com/go-chi/chi/v5"
+
+func setup() {
+	router := chi.NewRouter()
+	router.Route("/api", func(sub chi.Router) {
+		sub.Get("/ping", pingHandler)
+	})
+}
+`
+	routes := collectGoRoutes(src)
+	assertRoute(t, routes, "GET /api/ping")
+	assertNoRoute(t, routes, "GET /ping")
+}

--- a/internal/engine/response_shape_go.go
+++ b/internal/engine/response_shape_go.go
@@ -57,11 +57,34 @@ var goRouteRe = regexp.MustCompile(
 //
 // Group 1 = the assigned group variable, group 2 = the parent receiver
 // (router or an enclosing group), group 3 = the literal prefix. Echo's
-// `e.Group("/x")` and chi's `r.Route("/x", fn)` use the same `.Group(`
-// spelling for echo; chi's `r.Route(` is captured by goChiRouteAssignRe.
+// `e.Group("/x")` and chi's `r.Route("/x", fn)` differ — echo uses this
+// `.Group(` spelling; chi's closure-based `r.Route(` is captured by
+// goChiRouteHeadRe and resolved positionally (#4782).
 var goGroupAssignRe = regexp.MustCompile(
 	`\b(\w+)\s*:?=\s*(\w+)\s*\.\s*Group\s*\(\s*` +
 		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]*)["` + "`" + `]` + "`" + `?`,
+)
+
+// goChiRouteHeadRe captures the HEAD of a chi closure-based sub-router mount:
+//
+//	r.Route("/api", func(r chi.Router) {        // canonical
+//	router.Route("/v1", func(sub chi.Router) {  // arbitrary param name
+//	r.Route("/admin", func(r chi.Router) { ... })
+//
+// chi sub-routers nest via a closure (NOT the `.Group(` spelling): the
+// `Route(prefix, fn)` mounts `fn`'s body under `prefix`, and the router
+// param passed into `fn` (often `r`, shadowing the outer router) is the
+// receiver every route inside the closure registers on. Because the param
+// is commonly re-`r`, a name-keyed prefix map (as goGroupPrefixIndex uses)
+// would be ambiguous — so chi prefixes are resolved POSITIONALLY instead:
+// the closure body's byte span carries the prefix, and a route's prefix is
+// the concatenation of every enclosing Route-span's segment (#4782).
+//
+// Group 1 = the literal mount prefix. The trailing `{` anchors the closure
+// body so we can brace-match its extent.
+var goChiRouteHeadRe = regexp.MustCompile(
+	`\b\w+\s*\.\s*Route\s*\(\s*` +
+		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]*)["` + "`" + `]` + "`" + `?\s*,\s*func\s*\([^)]*\)\s*\{`,
 )
 
 // goFrameworkFromImports returns the framework name based on package
@@ -119,10 +142,19 @@ func synthesizeGoRouters(content string, emit emitFn) {
 	// nested groups `admin := v1.Group("/admin")`) so a route registered on a
 	// group variable synthesizes at its fully-prefixed path.
 	groupPrefix := goGroupPrefixIndex(content)
-	for _, m := range goRouteRe.FindAllStringSubmatch(content, -1) {
+	// #4782 — resolve chi closure-based sub-router prefixes (`r.Route("/api",
+	// func(r chi.Router){ ... })`), accumulated transitively across nesting.
+	// Unlike gin/echo groups these are keyed by the closure body's byte span
+	// (the router param is commonly re-`r`, shadowing the parent), so a route
+	// at byte offset P inherits every enclosing Route-span's prefix.
+	chiSpans := goChiRouteSpans(content)
+	locs := goRouteRe.FindAllStringSubmatchIndex(content, -1)
+	for _, loc := range locs {
+		m := groupSubmatchStrings(content, loc)
 		if len(m) < 5 {
 			continue
 		}
+		routePos := loc[0]
 		recv := m[1]
 		rawVerb := m[2]
 		// Normalise the verb to upper-case so the endpoint key is canonical
@@ -144,6 +176,13 @@ func synthesizeGoRouters(content string, emit emitFn) {
 		// on a `r.Group("/v1")` variable). The prefix is already accumulated
 		// across nested groups by goGroupPrefixIndex (#4408).
 		if pfx := groupPrefix[recv]; pfx != "" {
+			raw = joinPathFragments(pfx, raw)
+		}
+		// Prepend the accumulated chi closure-router prefix for any `r.Route(...)`
+		// closures enclosing this route's call site (#4782). Independent of the
+		// gin/echo group resolution above — a route can be inside a chi Route
+		// closure whose param was reassigned, so we key off byte position.
+		if pfx := chiEnclosingPrefix(chiSpans, routePos); pfx != "" {
 			raw = joinPathFragments(pfx, raw)
 		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, raw)
@@ -227,6 +266,99 @@ func goGroupPrefixIndex(content string) map[string]string {
 		resolve(name, 0)
 	}
 	return resolved
+}
+
+// groupSubmatchStrings extracts the submatch strings for one match location
+// (produced by FindAllStringSubmatchIndex) from content. Returns a slice
+// parallel to FindStringSubmatch where index 0 is the whole match. Unmatched
+// optional groups (offset -1) yield "".
+func groupSubmatchStrings(content string, loc []int) []string {
+	out := make([]string, len(loc)/2)
+	for i := 0; i < len(loc)/2; i++ {
+		s, e := loc[2*i], loc[2*i+1]
+		if s < 0 || e < 0 {
+			out[i] = ""
+			continue
+		}
+		out[i] = content[s:e]
+	}
+	return out
+}
+
+// chiRouteSpan is a chi `r.Route(prefix, func(...){ … })` closure body, located
+// by its byte extent so enclosing prefixes can be accumulated positionally.
+type chiRouteSpan struct {
+	start int    // byte offset of the closure body open brace `{`
+	end   int    // byte offset just past the matching close brace `}`
+	seg   string // this Route's own (normalized) mount prefix segment
+}
+
+// goChiRouteSpans scans a Go file for chi closure-based sub-router mounts
+// (`r.Route("/api", func(r chi.Router){ ... })`) and returns one span per
+// closure, each carrying its mount prefix segment and the byte extent of its
+// body. Spans nest naturally (a child Route closure's span lies inside its
+// parent's), so chiEnclosingPrefix composes them transitively. A closure whose
+// body brace is unbalanced (truncated source) is skipped. Returns nil when the
+// file uses no chi `.Route(` mounts so the common path stays allocation-free.
+func goChiRouteSpans(content string) []chiRouteSpan {
+	if !strings.Contains(content, ".Route(") {
+		return nil
+	}
+	var spans []chiRouteSpan
+	for _, loc := range goChiRouteHeadRe.FindAllStringSubmatchIndex(content, -1) {
+		// loc[1] is the offset just past the head match, i.e. just past the
+		// opening `{` of the closure body. The body open brace is the last
+		// char of the head match.
+		open := loc[1] - 1
+		seg := normalizeMountPrefix(content[loc[2]:loc[3]])
+		if close, ok := goMatchBrace(content, open); ok {
+			spans = append(spans, chiRouteSpan{start: open, end: close + 1, seg: seg})
+		}
+	}
+	return spans
+}
+
+// goMatchBrace returns the byte offset of the `}` that closes the `{` at
+// open, accounting for nested braces. It is brace-counting only (it does not
+// skip braces inside strings/comments) — adequate for route-setup code, where
+// brace-bearing string literals in a router DSL are vanishingly rare and a
+// mismatch merely degrades to the pre-#4782 (unprefixed) behaviour via ok=false.
+func goMatchBrace(content string, open int) (int, bool) {
+	depth := 0
+	for i := open; i < len(content); i++ {
+		switch content[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// chiEnclosingPrefix composes the mount prefixes of every chi Route closure
+// whose body span encloses byte offset pos, outermost-first, so a route nested
+// `r.Route("/api", …r.Route("/v1", …r.Get("/users")))` resolves to
+// `/api/v1/users` (#4782). Spans are emitted in source order, so an enclosing
+// (parent) Route head always precedes its children — sorting by start offset
+// yields outermost-to-innermost composition.
+func chiEnclosingPrefix(spans []chiRouteSpan, pos int) string {
+	if len(spans) == 0 {
+		return ""
+	}
+	prefix := ""
+	for _, s := range spans {
+		if pos > s.start && pos < s.end {
+			prefix = joinPathFragments(prefix, s.seg)
+		}
+	}
+	if prefix == "/" {
+		return ""
+	}
+	return prefix
 }
 
 // goFuncOpenRe locates the brace that opens a Go function or method

--- a/internal/external/synth_named_imports_ruby_rust_4783_test.go
+++ b/internal/external/synth_named_imports_ruby_rust_4783_test.go
@@ -1,0 +1,174 @@
+package external
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// #4783 — once the Ruby + Rust extractors stamp the `imported_name`/`local_name`
+// (+ `wildcard`) IMPORTS-edge contract, the existing per-symbol external-node
+// synthesis (#4515) mints a stable `ext:<pkg>:<Symbol>` node for Ruby/Rust with
+// NO change in internal/external/. These tests exercise the synth layer directly
+// with hand-built IMPORTS+reference edges that mirror exactly what the extractors
+// now emit, proving the end-to-end resolution.
+
+func rbFileEntity(id, file string) graph.Entity {
+	return graph.Entity{ID: id, Name: "mod", Kind: "SCOPE.Component", SourceFile: file, Language: "ruby"}
+}
+
+func rsFileEntity(id, file string) graph.Entity {
+	return graph.Entity{ID: id, Name: "mod", Kind: "SCOPE.Component", SourceFile: file, Language: "rust"}
+}
+
+func langMethodEntity(id, file, lang string) graph.Entity {
+	return graph.Entity{ID: id, Name: "handler", Kind: "SCOPE.Function", SourceFile: file, Language: lang}
+}
+
+// Rust: `use tokio::sync::Mutex;` → the IMPORTS ToID is `tokio::sync::Mutex`
+// with imported_name/local_name=Mutex; a bare `Mutex` reference in the file
+// resolves to ext:tokio:Mutex. This is the exact end-to-end case named in #4783.
+func TestSynthesize_Rust_PerSymbolNode_4783(t *testing.T) {
+	const file = "src/main.rs"
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			rsFileEntity("aaaaaaaaaaaaaaa0", file),
+			langMethodEntity("bbbbbbbbbbbbbbb0", file, "rust"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "imp-1", FromID: "aaaaaaaaaaaaaaa0", ToID: "tokio::sync::Mutex", Kind: "IMPORTS",
+				Properties: map[string]string{
+					"language": "rust", "import_path": "tokio::sync::Mutex",
+					"source_module": "tokio::sync::Mutex",
+					"local_name":    "Mutex", "imported_name": "Mutex",
+				}},
+			{ID: "call-1", FromID: "bbbbbbbbbbbbbbb0", ToID: "Mutex", Kind: "CALLS",
+				Properties: map[string]string{"language": "rust"}},
+		},
+	}
+	Synthesize(doc)
+
+	const want = "ext:tokio:Mutex"
+	if doc.Relationships[1].ToID != want {
+		t.Fatalf("CALLS ToID=%q, want %q", doc.Relationships[1].ToID, want)
+	}
+	e := findEntity(doc, want)
+	if e == nil {
+		t.Fatalf("per-symbol node %q not synthesised; entities=%+v", want, doc.Entities)
+	}
+	if e.Kind != KindExternal || e.Name != "Mutex" || e.Subtype != "symbol" {
+		t.Fatalf("node mismatch kind=%q name=%q subtype=%q", e.Kind, e.Name, e.Subtype)
+	}
+}
+
+// Rust alias-converge: `use tokio::sync::Mutex as M;` — the reference uses the
+// LOCAL alias `M` but binds to the imported-keyed ext:tokio:Mutex node.
+func TestSynthesize_Rust_AliasConverge_4783(t *testing.T) {
+	const file = "src/lib.rs"
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			rsFileEntity("aaaaaaaaaaaaaaa1", file),
+			langMethodEntity("bbbbbbbbbbbbbbb1", file, "rust"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "imp-1", FromID: "aaaaaaaaaaaaaaa1", ToID: "tokio::sync::Mutex", Kind: "IMPORTS",
+				Properties: map[string]string{
+					"language": "rust", "import_path": "tokio::sync::Mutex",
+					"local_name": "M", "imported_name": "Mutex",
+				}},
+			{ID: "call-1", FromID: "bbbbbbbbbbbbbbb1", ToID: "M", Kind: "CALLS",
+				Properties: map[string]string{"language": "rust"}},
+		},
+	}
+	Synthesize(doc)
+	const want = "ext:tokio:Mutex"
+	if doc.Relationships[1].ToID != want {
+		t.Fatalf("aliased CALLS ToID=%q, want %q", doc.Relationships[1].ToID, want)
+	}
+}
+
+// Ruby: `require 'active_record'` → ext:active_record:ActiveRecord; a bare
+// `ActiveRecord` reference resolves to the per-symbol node.
+func TestSynthesize_Ruby_PerSymbolNode_4783(t *testing.T) {
+	const file = "app/models/user.rb"
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			rbFileEntity("aaaaaaaaaaaaaaa2", file),
+			langMethodEntity("bbbbbbbbbbbbbbb2", file, "ruby"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "imp-1", FromID: "aaaaaaaaaaaaaaa2", ToID: "active_record", Kind: "IMPORTS",
+				Properties: map[string]string{
+					"language": "ruby", "require_kind": "require",
+					"local_name": "ActiveRecord", "imported_name": "ActiveRecord",
+				}},
+			{ID: "call-1", FromID: "bbbbbbbbbbbbbbb2", ToID: "ActiveRecord", Kind: "CALLS",
+				Properties: map[string]string{"language": "ruby"}},
+		},
+	}
+	Synthesize(doc)
+	// The reference resolves to a per-symbol node keyed by the imported leaf
+	// `ActiveRecord` (the package canon may come from either the classifier's
+	// direct disposition of the bare ref or the import index — both share the
+	// `ext:<pkg>:ActiveRecord` shape with a distinct symbol leaf).
+	got := doc.Relationships[1].ToID
+	if !strings.HasPrefix(got, "ext:") || !strings.HasSuffix(got, ":ActiveRecord") {
+		t.Fatalf("CALLS ToID=%q, want ext:<gem>:ActiveRecord", got)
+	}
+	if e := findEntity(doc, got); e == nil || e.Name != "ActiveRecord" || e.Subtype != "symbol" {
+		t.Fatalf("ruby per-symbol node missing/mismatched: %+v", e)
+	}
+}
+
+// Ruby require_relative must NOT mint a per-symbol external node (intra-project).
+func TestSynthesize_Ruby_RequireRelative_NoExtNode_4783(t *testing.T) {
+	const file = "app/services/foo.rb"
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			rbFileEntity("aaaaaaaaaaaaaaa3", file),
+			langMethodEntity("bbbbbbbbbbbbbbb3", file, "ruby"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "imp-1", FromID: "aaaaaaaaaaaaaaa3", ToID: "./helper", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "ruby", "require_kind": "require_relative"}},
+			{ID: "call-1", FromID: "bbbbbbbbbbbbbbb3", ToID: "Helper", Kind: "CALLS",
+				Properties: map[string]string{"language": "ruby"}},
+		},
+	}
+	Synthesize(doc)
+	if e := findEntity(doc, "ext:helper:Helper"); e != nil {
+		t.Fatalf("require_relative must not synthesise an external per-symbol node, got %+v", e)
+	}
+}
+
+// Cross-package no-collision: the same symbol name from two crates yields two
+// distinct per-symbol nodes.
+func TestSynthesize_Rust_CrossCrateNoCollision_4783(t *testing.T) {
+	const fileA, fileB = "src/a.rs", "src/b.rs"
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			rsFileEntity("aaaaaaaaaaaaaaa4", fileA),
+			langMethodEntity("bbbbbbbbbbbbbbb4", fileA, "rust"),
+			rsFileEntity("aaaaaaaaaaaaaaa5", fileB),
+			langMethodEntity("bbbbbbbbbbbbbbb5", fileB, "rust"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "impA", FromID: "aaaaaaaaaaaaaaa4", ToID: "serde::Error", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "rust", "import_path": "serde::Error", "local_name": "Error", "imported_name": "Error"}},
+			{ID: "callA", FromID: "bbbbbbbbbbbbbbb4", ToID: "Error", Kind: "CALLS",
+				Properties: map[string]string{"language": "rust"}},
+			{ID: "impB", FromID: "aaaaaaaaaaaaaaa5", ToID: "tokio::Error", Kind: "IMPORTS",
+				Properties: map[string]string{"language": "rust", "import_path": "tokio::Error", "local_name": "Error", "imported_name": "Error"}},
+			{ID: "callB", FromID: "bbbbbbbbbbbbbbb5", ToID: "Error", Kind: "CALLS",
+				Properties: map[string]string{"language": "rust"}},
+		},
+	}
+	Synthesize(doc)
+	if doc.Relationships[1].ToID != "ext:serde:Error" {
+		t.Fatalf("fileA Error → %q, want ext:serde:Error", doc.Relationships[1].ToID)
+	}
+	if doc.Relationships[3].ToID != "ext:tokio:Error" {
+		t.Fatalf("fileB Error → %q, want ext:tokio:Error", doc.Relationships[3].ToID)
+	}
+}

--- a/internal/extractors/ruby/import_contract_4783_test.go
+++ b/internal/extractors/ruby/import_contract_4783_test.go
@@ -1,0 +1,79 @@
+package ruby_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4783 — Ruby IMPORTS edges must stamp imported_name/local_name (where
+// statically recoverable) + require_kind so #4515's per-symbol external-node
+// synthesis can mint ext:<gem>:<Const>.
+
+func rbImportRels(ents []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func rbFindImport(rels []types.RelationshipRecord, toID string) *types.RelationshipRecord {
+	for i := range rels {
+		if rels[i].ToID == toID {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+// `require 'active_record'` → imported_name=local_name=ActiveRecord (CamelCased
+// leaf, the gem-constant convention) + require_kind=require.
+func TestRuby_ImportContract_RequireGem(t *testing.T) {
+	src := `require 'active_record'
+`
+	rels := rbImportRels(runRuby(t, src))
+	r := rbFindImport(rels, "active_record")
+	if r == nil {
+		t.Fatalf("no IMPORTS edge for active_record; got %+v", rels)
+	}
+	if r.Properties["require_kind"] != "require" {
+		t.Fatalf("require_kind=%q, want require", r.Properties["require_kind"])
+	}
+	if r.Properties["imported_name"] != "ActiveRecord" || r.Properties["local_name"] != "ActiveRecord" {
+		t.Fatalf("props=%v, want imported_name=local_name=ActiveRecord", r.Properties)
+	}
+}
+
+// `require 'json'` → Json (single-segment camelize).
+func TestRuby_ImportContract_RequireSimple(t *testing.T) {
+	src := `require 'json'
+`
+	rels := rbImportRels(runRuby(t, src))
+	r := rbFindImport(rels, "json")
+	if r == nil || r.Properties["imported_name"] != "Json" {
+		t.Fatalf("json import props wrong: %+v", r)
+	}
+}
+
+// `require_relative 'helper'` is intra-project: stamps require_kind but no
+// imported_name (so the external synth correctly skips it).
+func TestRuby_ImportContract_RequireRelative(t *testing.T) {
+	src := `require_relative 'helper'
+`
+	rels := rbImportRels(runRuby(t, src))
+	r := rbFindImport(rels, "helper")
+	if r == nil {
+		t.Fatalf("no IMPORTS edge for require_relative helper; got %+v", rels)
+	}
+	if r.Properties["require_kind"] != "require_relative" {
+		t.Fatalf("require_kind=%q, want require_relative", r.Properties["require_kind"])
+	}
+	if _, ok := r.Properties["imported_name"]; ok {
+		t.Fatalf("require_relative must NOT stamp imported_name, got %v", r.Properties)
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -335,6 +335,22 @@ func buildRequireImport(node *sitter.Node, file extractor.FileInput) (types.Enti
 		if raw == "" {
 			continue
 		}
+		props := map[string]string{"require_kind": mname}
+		// #4783 — stamp the `imported_name`/`local_name` contract so the
+		// per-symbol external-node synthesis (#4515) can mint a stable
+		// `ext:<gem>:<Const>` node. Only meaningful for gem requires (NOT
+		// `require_relative`/`load`, which are intra-project file loads).
+		// A required gem conventionally exposes a top-level constant that is the
+		// CamelCased leaf of its require path (`require 'active_record'` → the
+		// `ActiveRecord` constant; `require 'json'` → `JSON`-by-convention via
+		// `Json`). `autoload :Const, 'path'` carries the symbol explicitly and is
+		// handled below.
+		if mname == "require" || mname == "autoload" {
+			if c := rubyRequireConstant(node, file, mname, raw); c != "" {
+				props["imported_name"] = c
+				props["local_name"] = c
+			}
+		}
 		return types.EntityRecord{
 			Name:       raw,
 			Kind:       "SCOPE.Component",
@@ -343,14 +359,105 @@ func buildRequireImport(node *sitter.Node, file extractor.FileInput) (types.Enti
 			Language:   "ruby",
 			Relationships: []types.RelationshipRecord{
 				{
-					FromID: file.Path,
-					ToID:   raw,
-					Kind:   "IMPORTS",
+					FromID:     file.Path,
+					ToID:       raw,
+					Kind:       "IMPORTS",
+					Properties: props,
 				},
 			},
 		}, true
 	}
 	return types.EntityRecord{}, false
+}
+
+// rubyRequireConstant derives the top-level constant a require/autoload binds,
+// where statically recoverable (#4783):
+//
+//   - `autoload :Foo, 'foo/bar'`  → "Foo" (explicit symbol — authoritative).
+//   - `require 'active_record'`   → "ActiveRecord" (CamelCased leaf — the Ruby
+//     gem convention that the require's leaf path segment names the exposed
+//     constant).
+//
+// Returns "" when no constant is recoverable (e.g. a leaf that isn't a legal
+// constant stem). The synth layer keys the per-symbol node by this name; an
+// over-eager guess merely mints an extra node, so we stay conservative.
+func rubyRequireConstant(node *sitter.Node, file extractor.FileInput, mname, raw string) string {
+	if mname == "autoload" {
+		// `autoload :Const, 'path'` — first argument is the explicit symbol.
+		if args := node.ChildByFieldName("arguments"); args != nil {
+			for i := 0; i < int(args.NamedChildCount()); i++ {
+				a := args.NamedChild(i)
+				if a.Type() == "simple_symbol" {
+					sym := strings.TrimPrefix(string(file.Content[a.StartByte():a.EndByte()]), ":")
+					sym = strings.TrimSpace(sym)
+					if rubyIsConstantStem(sym) {
+						return sym
+					}
+				}
+			}
+		}
+		return ""
+	}
+	// require: CamelCase the leaf path segment.
+	leaf := raw
+	if i := strings.LastIndexByte(leaf, '/'); i >= 0 {
+		leaf = leaf[i+1:]
+	}
+	return rubyCamelizeConstant(leaf)
+}
+
+// rubyIsConstantStem reports whether s is a legal Ruby constant name
+// (begins with an upper-case letter, contains only word characters).
+func rubyIsConstantStem(s string) bool {
+	if s == "" || !(s[0] >= 'A' && s[0] <= 'Z') {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// rubyCamelizeConstant converts a snake/lower require leaf into the conventional
+// Ruby constant name (`active_record` → "ActiveRecord", `json` → "Json"),
+// returning "" when the leaf has no constant-able characters.
+func rubyCamelizeConstant(leaf string) string {
+	leaf = strings.TrimSpace(leaf)
+	if leaf == "" {
+		return ""
+	}
+	var b strings.Builder
+	upNext := true
+	for i := 0; i < len(leaf); i++ {
+		c := leaf[i]
+		switch {
+		case c == '_' || c == '-':
+			upNext = true
+		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
+			if upNext {
+				if c >= 'a' && c <= 'z' {
+					c -= 32
+				}
+				upNext = false
+			}
+			b.WriteByte(c)
+		case c >= '0' && c <= '9':
+			if b.Len() == 0 {
+				return "" // constants cannot start with a digit
+			}
+			b.WriteByte(c)
+		default:
+			// Non-identifier char (e.g. a leftover extension dot) — stop.
+		}
+	}
+	out := b.String()
+	if !rubyIsConstantStem(out) {
+		return ""
+	}
+	return out
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.

--- a/internal/extractors/rust/import_contract_4783_test.go
+++ b/internal/extractors/rust/import_contract_4783_test.go
@@ -1,0 +1,80 @@
+package rust_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// #4783 — Rust IMPORTS edges must stamp imported_name/local_name (and wildcard)
+// so the per-symbol external-node synthesis (#4515) mints ext:<crate>:<Symbol>.
+
+// importRels collects every IMPORTS edge from the extracted entities.
+func importRels(ents []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func findImport(rels []types.RelationshipRecord, toID string) *types.RelationshipRecord {
+	for i := range rels {
+		if rels[i].ToID == toID {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
+// RED→GREEN: `use tokio::sync::Mutex;` stamps imported_name/local_name=Mutex,
+// and the ToID keeps the crate root so the external synth resolves ext:tokio:Mutex.
+func TestRust_ImportContract_SingleNamed(t *testing.T) {
+	src := `use tokio::sync::Mutex;
+fn main() {}
+`
+	rels := importRels(runRust(t, src))
+	r := findImport(rels, "tokio::sync::Mutex")
+	if r == nil {
+		t.Fatalf("no IMPORTS edge for tokio::sync::Mutex; got %+v", rels)
+	}
+	if r.Properties["imported_name"] != "Mutex" || r.Properties["local_name"] != "Mutex" {
+		t.Fatalf("props=%v, want imported_name=local_name=Mutex", r.Properties)
+	}
+}
+
+// Brace group fans out to one edge per symbol, each leaf-stamped; `as` aliases
+// keep imported=leaf, local=alias.
+func TestRust_ImportContract_BraceGroupAndAlias(t *testing.T) {
+	src := `use serde::{Serialize, Deserialize as De};
+fn main() {}
+`
+	rels := importRels(runRust(t, src))
+	ser := findImport(rels, "serde::Serialize")
+	if ser == nil || ser.Properties["imported_name"] != "Serialize" || ser.Properties["local_name"] != "Serialize" {
+		t.Fatalf("Serialize edge wrong: %+v", ser)
+	}
+	de := findImport(rels, "serde::Deserialize")
+	if de == nil || de.Properties["imported_name"] != "Deserialize" || de.Properties["local_name"] != "De" {
+		t.Fatalf("aliased Deserialize edge wrong: %+v", de)
+	}
+}
+
+// Glob import stamps wildcard=1 with the namespace local.
+func TestRust_ImportContract_Wildcard(t *testing.T) {
+	src := `use std::collections::*;
+fn main() {}
+`
+	rels := importRels(runRust(t, src))
+	r := findImport(rels, "std::collections")
+	if r == nil {
+		t.Fatalf("no IMPORTS edge for std::collections glob; got %+v", rels)
+	}
+	if r.Properties["wildcard"] != "1" || r.Properties["local_name"] != "collections" {
+		t.Fatalf("glob props=%v, want wildcard=1 local_name=collections", r.Properties)
+	}
+}

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -868,19 +868,179 @@ func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 		top = raw[:idx]
 	}
 
+	// #4783 — expand the `use` path into one IMPORTS edge per imported symbol,
+	// stamping the `imported_name`/`local_name`(/`wildcard`) contract that the
+	// per-symbol external-node synthesis (#4515) reads to mint a stable
+	// `ext:<crate>:<Symbol>` node. Brace groups (`use a::{B, C as D}`) fan out;
+	// a glob (`use a::*`) stamps wildcard with the namespace local. A plain
+	// `use a::B` keeps its historical single-edge ToID `a::B`.
+	syms := parseRustUsePath(raw)
+	rels := make([]types.RelationshipRecord, 0, len(syms))
+	for _, s := range syms {
+		props := map[string]string{
+			"import_path":   s.path,
+			"source_module": s.path,
+		}
+		if s.wildcard {
+			props["wildcard"] = "1"
+			// The namespace local is the last concrete path segment (`use a::b::*`
+			// → namespace local `b`); the per-symbol synth resolves `b.<member>`.
+			if s.local != "" {
+				props["local_name"] = s.local
+			}
+		} else {
+			props["imported_name"] = s.imported
+			props["local_name"] = s.local
+		}
+		rels = append(rels, types.RelationshipRecord{
+			FromID:     file.Path,
+			ToID:       s.path,
+			Kind:       "IMPORTS",
+			Properties: props,
+		})
+	}
+	if len(rels) == 0 {
+		rels = []types.RelationshipRecord{{FromID: file.Path, ToID: raw, Kind: "IMPORTS"}}
+	}
+
 	return types.EntityRecord{
-		Name:       top,
-		Kind:       "SCOPE.Component",
-		SourceFile: file.Path,
-		Language:   "rust",
-		Relationships: []types.RelationshipRecord{
-			{
-				FromID: file.Path,
-				ToID:   raw,
-				Kind:   "IMPORTS",
-			},
-		},
+		Name:          top,
+		Kind:          "SCOPE.Component",
+		SourceFile:    file.Path,
+		Language:      "rust",
+		Relationships: rels,
 	}, true
+}
+
+// rustUseSym is one resolved symbol from a `use` declaration: its full
+// `crate::path::Leaf` reference path (the IMPORTS ToID, which keeps the crate
+// root as its leading `::`-segment so rustExternalPackageRoot resolves it), the
+// imported (source) name, the local (possibly `as`-aliased) name, and whether
+// it is a glob `*` namespace import.
+type rustUseSym struct {
+	path     string
+	imported string
+	local    string
+	wildcard bool
+}
+
+// parseRustUsePath parses the text AFTER `use ` (and trailing `;`) into one
+// entry per imported symbol. It handles the common static shapes:
+//
+//	a::b::C            → {path:a::b::C, imported:C, local:C}
+//	a::b::C as D       → {path:a::b::C, imported:C, local:D}
+//	a::b::{C, D as E}  → two entries, prefixed with `a::b::`
+//	a::b::*            → {path:a::b, wildcard, local:b}
+//	a                  → {path:a, imported:a, local:a}  (crate root binding)
+//
+// Nested brace groups are flattened recursively. Whitespace and `self` group
+// members (`a::{self, B}` — the `self` re-exports the module `a` itself) are
+// handled: `self` binds the trailing path segment as its local name.
+func parseRustUsePath(raw string) []rustUseSym {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	// Find a top-level `{ ... }` group (brace not nested inside an earlier one).
+	open := strings.IndexByte(raw, '{')
+	if open < 0 {
+		return []rustUseSym{rustUseLeaf(raw)}
+	}
+	prefix := strings.TrimSpace(raw[:open])
+	prefix = strings.TrimSuffix(prefix, "::")
+	// Locate the matching close brace for this group.
+	close := rustMatchBrace(raw, open)
+	if close < 0 {
+		return []rustUseSym{rustUseLeaf(strings.TrimSuffix(raw, "{"))}
+	}
+	inner := raw[open+1 : close]
+	var out []rustUseSym
+	for _, member := range splitRustTopLevel(inner) {
+		member = strings.TrimSpace(member)
+		if member == "" {
+			continue
+		}
+		full := member
+		if prefix != "" {
+			if member == "self" {
+				full = prefix // `a::{self}` re-binds module `a` itself.
+			} else {
+				full = prefix + "::" + member
+			}
+		}
+		out = append(out, parseRustUsePath(full)...)
+	}
+	return out
+}
+
+// rustUseLeaf resolves a brace-free `use` path fragment into a single symbol.
+func rustUseLeaf(path string) rustUseSym {
+	path = strings.TrimSpace(path)
+	// `as` alias: `a::b::C as D`.
+	imported, local := path, ""
+	if i := strings.Index(path, " as "); i >= 0 {
+		imported = strings.TrimSpace(path[:i])
+		local = strings.TrimSpace(path[i+4:])
+		path = imported
+	}
+	// Glob namespace import: `a::b::*`.
+	if strings.HasSuffix(path, "::*") || path == "*" {
+		ns := strings.TrimSuffix(path, "::*")
+		ns = strings.TrimSuffix(ns, "*")
+		ns = strings.TrimSuffix(ns, "::")
+		nsLeaf := ns
+		if i := strings.LastIndex(ns, "::"); i >= 0 {
+			nsLeaf = ns[i+2:]
+		}
+		return rustUseSym{path: ns, wildcard: true, local: strings.TrimSpace(nsLeaf)}
+	}
+	leaf := imported
+	if i := strings.LastIndex(imported, "::"); i >= 0 {
+		leaf = imported[i+2:]
+	}
+	if local == "" {
+		local = leaf
+	}
+	return rustUseSym{path: path, imported: leaf, local: local}
+}
+
+// rustMatchBrace returns the index of the `}` matching the `{` at open, or -1.
+func rustMatchBrace(s string, open int) int {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// splitRustTopLevel splits a brace-group body on top-level commas (commas not
+// nested inside a deeper `{ ... }`).
+func splitRustTopLevel(s string) []string {
+	var out []string
+	depth, start := 0, 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
 }
 
 // stripRustVisibility removes a leading Rust visibility modifier from a


### PR DESCRIPTION
Endgame board-cleanup: three independent, bounded #4334-epic follow-ups, each independently tested.

## #4782 — chi `r.Route("/api", func(r chi.Router){...})` closure prefix
`synthesizeGoRouters` now resolves chi's **closure-based** sub-router prefix mount — distinct from the gin/echo `.Group("/v1")` form (#4408). The closure router param commonly re-shadows the parent (`r`), so prefixes are tracked **positionally** (by closure byte-span via `goChiRouteSpans`/`chiEnclosingPrefix`) and accumulate **transitively** across nested Route closures: `r.Route("/api", …r.Route("/v1", …r.Get("/users")))` → `GET /api/v1/users`.
- Tests: `TestChiRoutePrefix4782_SingleRoute/_NestedRoute/_ScopedToClosure/_SiblingClosures/_ArbitraryParamName`

## #4783 — stamp `imported_name`/`local_name` on Ruby + Rust IMPORTS edges
#4515's per-symbol external-node synth reads the `local_name`/`imported_name`(/`wildcard`) IMPORTS contract; Ruby + Rust extractors didn't stamp it. Now:
- **Rust**: `use` decls fan brace groups (`use serde::{Serialize, Deserialize as De}`) out to one leaf-stamped edge each; `as` aliases (imported=leaf, local=alias) and globs (`use x::*` → `wildcard`) handled; intra-crate `crate::/self::/super::` stay unstamped. End-to-end: `use tokio::sync::Mutex` → `ext:tokio:Mutex` with **no** `internal/external/` change.
- **Ruby**: `require`/`autoload` stamp the conventional gem constant (`require 'active_record'` → `ActiveRecord`; `autoload :Foo` explicit), plus `require_kind`; `require_relative` stamps kind only (not externalised).
- Tests: extractor-level `TestRust_ImportContract_*` / `TestRuby_ImportContract_*` + end-to-end `TestSynthesize_Rust_PerSymbolNode_4783`/`_AliasConverge`/`_CrossCrateNoCollision`, `TestSynthesize_Ruby_PerSymbolNode_4783`/`_RequireRelative_NoExtNode`

## #4789 — Django imperative signal wiring in `AppConfig.ready()`
`post_save.connect(receiver, sender=Model)` (plus dotted `signals.post_delete.connect(...)` and bare no-sender form) now emits the same `HANDLES_SIGNAL` edge shape as the `@receiver` decorator, with `di_role=signal_handler` + `signal_type`. Gated on `djangoKnownSignals` so an unrelated `<obj>.connect()` is not mis-wired.
- Tests: `TestDjango_SignalConnect_ReadyMethod/_DottedSignal/_NoSender` + negative `_NonSignalIgnored`

## Coverage docs
Surgical cell updates: go chi `route_extraction`, ruby/rust `import_resolution_quality`, python django `signal_handler_attribution`. `coverage fmt --check` canonical, `coverage validate` 0 errors.

## Gates
`go build ./...`, `go vet`, full target test suite (engine/extractors/custom/external/graph/types) all green; no cross-interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)