### PR TITLE
feat(java/junit): disambiguate SUT among multiple injected fields (#4390)

### DIFF
--- a/internal/custom/java/issue4390_livedrepro_test.go
+++ b/internal/custom/java/issue4390_livedrepro_test.go
@@ -1,0 +1,121 @@
+package java_test
+
+import (
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/java"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4390 LIVE-REPRO — SUT disambiguation through the REAL registered Java
+// custom extractor.
+//
+// A multi-collaborator Spring/Mockito test injects the SUT plus several
+// @Mock/@MockBean collaborators. The TESTS edge must point at the ONE SUT and at
+// NO collaborator. Extends the #4359/#4615 coverage linkage.
+
+// testsTargets returns the set of `Class:<X>` targets of every TESTS edge.
+func testsTargets(ents []types.EntityRecord) map[string]bool {
+	out := map[string]bool{}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) {
+				out[r.ToID] = true
+			}
+		}
+	}
+	return out
+}
+
+func TestIssue4390_Live_InjectMocks_OnlySUTLinked_NotCollaborators(t *testing.T) {
+	const src = `
+package com.example.order;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+    @InjectMocks OrderService sut;
+    @Mock PaymentClient pay;
+    @Mock InventoryRepo inv;
+
+    @Test
+    void places() {
+        assertNotNull(sut);
+    }
+}
+`
+	ents := javaCustomExtract(t, "src/test/java/com/example/order/OrderServiceTest.java", src)
+	targets := testsTargets(ents)
+
+	if !targets["Class:OrderService"] {
+		t.Fatalf("expected TESTS→Class:OrderService; got targets=%v", targets)
+	}
+	for _, collab := range []string{"Class:PaymentClient", "Class:InventoryRepo"} {
+		if targets[collab] {
+			t.Errorf("mock collaborator wrongly linked: %s (#4390)", collab)
+		}
+	}
+}
+
+func TestIssue4390_Live_StemMatch_AmongAutowired(t *testing.T) {
+	const src = `
+package com.example.order;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OrderServiceTest {
+
+    @Autowired OrderService svc;
+    @Autowired java.time.Clock clock;
+
+    @Test
+    void runs() {}
+}
+`
+	ents := javaCustomExtract(t, "src/test/java/com/example/order/OrderServiceTest.java", src)
+	targets := testsTargets(ents)
+	if !targets["Class:OrderService"] {
+		t.Fatalf("expected stem-match TESTS→Class:OrderService; got %v", targets)
+	}
+	if targets["Class:Clock"] {
+		t.Errorf("collaborator Clock wrongly linked (#4390)")
+	}
+}
+
+func TestIssue4390_Live_Ambiguous_NoEdge(t *testing.T) {
+	const src = `
+package com.example.order;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class CheckoutFlowTest {
+
+    @Autowired OrderService svc;
+    @Autowired PaymentClient pay;
+
+    @Test
+    void runs() {}
+}
+`
+	ents := javaCustomExtract(t, "src/test/java/com/example/order/CheckoutFlowTest.java", src)
+	targets := testsTargets(ents)
+	for tgt := range targets {
+		// Only the SUT-class TESTS edges are in scope here (no route calls).
+		if tgt == "Class:OrderService" || tgt == "Class:PaymentClient" {
+			t.Errorf("ambiguous test wrongly linked SUT %s (#4390)", tgt)
+		}
+	}
+}

--- a/internal/custom/java/issue4390_sut_disambiguation_test.go
+++ b/internal/custom/java/issue4390_sut_disambiguation_test.go
@@ -1,0 +1,151 @@
+package java
+
+import "testing"
+
+// issue4390_sut_disambiguation_test.go — proving tests for issue #4390.
+//
+// When a Java test class injects MULTIPLE candidate fields (the SUT plus
+// @Mock/@MockBean collaborators, or several @Autowired beans), the TESTS→subject
+// resolver must pick the ONE system-under-test and exclude the collaborators.
+//
+// Disambiguation priority (resolveJavaTestSubjectDetail):
+//
+//	@InjectMocks ▸ stem-match ▸ single non-mock field ▸ none
+//
+// Cite: internal/custom/java/junit5.go (resolveJavaTestSubject /
+// resolveJavaTestSubjectDetail).
+
+func TestIssue4390_InjectMocks_PicksSUT_ExcludesMockCollaborators(t *testing.T) {
+	const src = `
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+    @InjectMocks OrderService sut;
+    @Mock PaymentClient pay;
+    @Mock InventoryRepo inv;
+
+    @Test void places() {}
+}
+`
+	res := resolveJavaTestSubjectDetail(src, "OrderServiceTest")
+	if res.subject != "OrderService" {
+		t.Fatalf("@InjectMocks SUT: got %q, want OrderService", res.subject)
+	}
+	if res.tier != "injectmocks" {
+		t.Errorf("tier: got %q, want injectmocks", res.tier)
+	}
+	// Collaborators must NOT be linkable subjects.
+	for _, collab := range []string{"PaymentClient", "InventoryRepo"} {
+		if res.subject == collab {
+			t.Errorf("collaborator %q wrongly selected as SUT", collab)
+		}
+	}
+}
+
+// @InjectMocks overrides stem affinity: even when the test-class stem matches a
+// MOCK collaborator's type, the @InjectMocks field is the SUT.
+func TestIssue4390_InjectMocks_OverridesStemMatchingCollaborator(t *testing.T) {
+	const src = `
+class PaymentClientTest {
+    @InjectMocks OrderService sut;
+    @Mock PaymentClient pay;
+
+    @Test void t() {}
+}
+`
+	// Stem "PaymentClient" matches the @Mock collaborator's type, but it is a
+	// mock → excluded. @InjectMocks OrderService is the SUT.
+	res := resolveJavaTestSubjectDetail(src, "PaymentClientTest")
+	if res.subject != "OrderService" {
+		t.Fatalf("got %q, want OrderService (@InjectMocks overrides mock-stem)", res.subject)
+	}
+}
+
+// No @InjectMocks: stem-affinity disambiguates among multiple @Autowired fields.
+func TestIssue4390_StemMatch_AmongMultipleAutowired(t *testing.T) {
+	const src = `
+@SpringBootTest
+class OrderServiceTest {
+    @Autowired OrderService svc;
+    @Autowired Clock clock;
+
+    @Test void t() {}
+}
+`
+	res := resolveJavaTestSubjectDetail(src, "OrderServiceTest")
+	if res.subject != "OrderService" {
+		t.Fatalf("stem-match: got %q, want OrderService", res.subject)
+	}
+	if res.tier != "stem_match" {
+		t.Errorf("tier: got %q, want stem_match", res.tier)
+	}
+}
+
+// Ambiguous: two equally-plausible @Autowired candidates, no @InjectMocks, and
+// the stem matches NEITHER → emit no spurious SUT edge.
+func TestIssue4390_Ambiguous_NoSpuriousEdge(t *testing.T) {
+	const src = `
+@SpringBootTest
+class CheckoutFlowTest {
+    @Autowired OrderService svc;
+    @Autowired PaymentClient pay;
+
+    @Test void t() {}
+}
+`
+	res := resolveJavaTestSubjectDetail(src, "CheckoutFlowTest")
+	if res.subject != "" {
+		t.Fatalf("ambiguous case wrongly produced SUT %q (tier=%s)", res.subject, res.tier)
+	}
+}
+
+// Single non-mock injected field, no stem affinity → that lone field is the SUT.
+func TestIssue4390_SingleField_NoStem(t *testing.T) {
+	const src = `
+class CheckoutFlowSpec {
+    @Autowired OrderService svc;
+    @Mock PaymentClient pay;
+
+    @Test void t() {}
+}
+`
+	// "CheckoutFlowSpec" yields no Test/Tests/IT stem; OrderService is the only
+	// non-mock candidate → single_field.
+	res := resolveJavaTestSubjectDetail(src, "CheckoutFlowSpec")
+	if res.subject != "OrderService" {
+		t.Fatalf("single-field: got %q, want OrderService", res.subject)
+	}
+	if res.tier != "single_field" {
+		t.Errorf("tier: got %q, want single_field", res.tier)
+	}
+}
+
+// A @Mock field whose type matches the stem must NOT be linked (collaborator
+// exclusion), even when it is the only injected field.
+func TestIssue4390_MockMatchingStem_NotLinked(t *testing.T) {
+	const src = `
+class OrderServiceTest {
+    @Mock OrderService svc;
+
+    @Test void t() {}
+}
+`
+	res := resolveJavaTestSubjectDetail(src, "OrderServiceTest")
+	if res.subject != "" {
+		t.Fatalf("mock matching stem wrongly linked as SUT: %q", res.subject)
+	}
+}
+
+// Backwards-compatible: the classic single @InjectMocks + stem case still links.
+func TestIssue4390_ClassicInjectMocks_StillLinks(t *testing.T) {
+	const src = `
+class OrderServiceTest {
+    @Mock OrderRepository repo;
+    @InjectMocks OrderService subject;
+
+    @Test void t() {}
+}
+`
+	if got := resolveJavaTestSubject(src, "OrderServiceTest"); got != "OrderService" {
+		t.Fatalf("classic InjectMocks: got %q, want OrderService", got)
+	}
+}

--- a/internal/custom/java/junit5.go
+++ b/internal/custom/java/junit5.go
@@ -293,17 +293,28 @@ func ExtractJUnit5(ctx PatternContext) PatternResult {
 		suite.Properties["e2e_route_calls"] = strings.Join(routeCalls, "\n")
 	}
 
-	// ── TESTS edge to the production class under test (name affinity + ref) ──
-	if subject := resolveJavaTestSubject(source, outerClassName); subject != "" {
-		suite.Properties["tests_target"] = subject
+	// ── TESTS edge to the production class under test (SUT disambiguation) ──
+	// #4390: when the test class injects MULTIPLE candidate fields, pick the ONE
+	// system-under-test (@InjectMocks ▸ stem-match ▸ single non-mock field ▸
+	// none) and exclude @Mock/@MockBean/@Spy collaborators. match_source records
+	// which tier selected the subject.
+	if res := resolveJavaTestSubjectDetail(source, outerClassName); res.subject != "" {
+		matchSource := "java_test_name_affinity"
+		switch res.tier {
+		case "injectmocks":
+			matchSource = "java_injectmocks_sut"
+		case "single_field":
+			matchSource = "java_single_injected_field"
+		}
+		suite.Properties["tests_target"] = res.subject
 		result.Relationships = append(result.Relationships, Relationship{
 			SourceRef:        suiteRef,
-			TargetRef:        "Class:" + subject,
+			TargetRef:        "Class:" + res.subject,
 			RelationshipType: "TESTS",
 			Properties: map[string]string{
 				"framework":    "junit5",
-				"match_source": "java_test_name_affinity",
-				"target_type":  subject,
+				"match_source": matchSource,
+				"target_type":  res.subject,
 			},
 		})
 	}
@@ -372,51 +383,154 @@ func subjectFromTestClassName(cls string) string {
 }
 
 var (
-	// @InjectMocks OrderService subject;  /  @Autowired OrderService subject;
-	// Captures the injected field's *type*, which (for a single such field) is
-	// the strongest SUT signal Mockito/Spring give us.
-	reJavaInjectField = regexp.MustCompile(
-		`@(?:InjectMocks|Autowired)\b(?:\s*\([^)]*\))?\s+(?:private\s+|public\s+|protected\s+|final\s+)*([A-Z][A-Za-z0-9_]*)\b`)
+	// @InjectMocks OrderService subject; — Mockito's explicit "this is the
+	// system under test" marker. The strongest possible SUT signal: Mockito
+	// injects all @Mock/@Spy collaborators INTO this one field.
+	reJavaInjectMocksField = regexp.MustCompile(
+		`@InjectMocks\b(?:\s*\([^)]*\))?\s+(?:private\s+|public\s+|protected\s+|final\s+|static\s+)*([A-Z][A-Za-z0-9_]*)\b`)
+	// @Autowired OrderService subject; — Spring-injected field. May be the SUT
+	// (an @SpringBootTest pulling the real bean) OR a collaborator (a clock, a
+	// repository). Disambiguated by stem-affinity against the field-type set.
+	reJavaAutowiredField = regexp.MustCompile(
+		`@Autowired\b(?:\s*\([^)]*\))?\s+(?:private\s+|public\s+|protected\s+|final\s+|static\s+)*([A-Z][A-Za-z0-9_]*)\b`)
+	// @Mock / @MockBean / @Spy / @SpyBean — Mockito/Spring collaborator markers.
+	// A field carrying any of these is a stubbed COLLABORATOR, never the SUT;
+	// its type is excluded from SUT candidacy regardless of name affinity.
+	reJavaMockField = regexp.MustCompile(
+		`@(?:Mock|MockBean|Spy|SpyBean)\b(?:\s*\([^)]*\))?\s+(?:private\s+|public\s+|protected\s+|final\s+|static\s+)*([A-Z][A-Za-z0-9_]*)\b`)
 	// new OrderService(...) — direct construction of the SUT in the test body.
 	reJavaNew = regexp.MustCompile(`\bnew\s+([A-Z][A-Za-z0-9_]*)\s*\(`)
 )
 
-// referencedJavaTypes returns the set of class names that are referenced in the
-// test file via the high-confidence SUT signals: @InjectMocks / @Autowired
-// field types and `new X(` construction. Only names in this set are eligible to
-// become a TESTS subject, keeping the edge pointed at an in-repo production
-// entity rather than a fixture/util/JDK type.
-func referencedJavaTypes(src string) map[string]bool {
+// eligibleType reports whether a captured type name is a usable in-repo class
+// name (capitalised identifier, not a Java primitive box / pseudo-type).
+func eligibleType(name string) bool {
+	return javaIdentRE.MatchString(name) && !primitiveTypes[name]
+}
+
+// collectTypes runs a single-capture regex over src and returns the set of
+// eligible captured type names.
+func collectTypes(re *regexp.Regexp, src string) map[string]bool {
 	out := map[string]bool{}
-	for _, m := range reJavaInjectField.FindAllStringSubmatch(src, -1) {
-		if javaIdentRE.MatchString(m[1]) && !primitiveTypes[m[1]] {
-			out[m[1]] = true
-		}
-	}
-	for _, m := range reJavaNew.FindAllStringSubmatch(src, -1) {
-		if javaIdentRE.MatchString(m[1]) && !primitiveTypes[m[1]] {
+	for _, m := range re.FindAllStringSubmatch(src, -1) {
+		if eligibleType(m[1]) {
 			out[m[1]] = true
 		}
 	}
 	return out
 }
 
+// referencedJavaTypes returns the set of class names that are referenced in the
+// test file via the high-confidence SUT signals: @InjectMocks / @Autowired
+// field types and `new X(` construction. Only names in this set are eligible to
+// become a TESTS subject, keeping the edge pointed at an in-repo production
+// entity rather than a fixture/util/JDK type. Mock/Spy collaborator types are
+// NOT included here — they are never SUT candidates (#4390).
+func referencedJavaTypes(src string) map[string]bool {
+	out := collectTypes(reJavaInjectMocksField, src)
+	for t := range collectTypes(reJavaAutowiredField, src) {
+		out[t] = true
+	}
+	for t := range collectTypes(reJavaNew, src) {
+		out[t] = true
+	}
+	return out
+}
+
 // resolveJavaTestSubject determines the unique production class under test for a
-// Java test-class file. A subject is emitted ONLY when it is both (a) derivable
-// by name affinity from the test class name, AND (b) actually referenced
-// (@InjectMocks / @Autowired / `new X(`) in the file. Requiring BOTH keeps the
-// TESTS edge conservative and unique — name affinity alone would over-link a
-// renamed/wrapper class, and a referenced type alone would link a collaborator
-// or fixture. Returns "" when no confident unique subject exists.
+// Java test-class file, disambiguating the SUT from its collaborators when the
+// test class injects MULTIPLE candidate fields (#4390, extending #4359/#4615).
+//
+// A Spring/Mockito test such as
+//
+//	class OrderServiceTest {
+//	    @InjectMocks OrderService sut;
+//	    @Mock PaymentClient pay;
+//	    @Mock InventoryRepo inv;
+//	}
+//
+// injects three fields but exercises exactly ONE production class. Emitting a
+// TESTS edge to PaymentClient/InventoryRepo would be a mis-link. The
+// disambiguation priority is:
+//
+//  1. @InjectMocks — Mockito's explicit SUT marker. If a single such field
+//     exists, its type IS the subject (the @Mock/@MockBean fields are the
+//     collaborators injected into it). Strongest signal; overrides stem.
+//  2. stem-match — strip Test/Tests/IT/… from the test-class name and match the
+//     stem against the injected/constructed (non-mock) field TYPE set; the
+//     member equal to the stem is the SUT (OrderServiceTest ▸ OrderService).
+//  3. single non-mock injected field — when exactly one @Autowired/`new X(`
+//     candidate remains after excluding mocks and there is no stem, that lone
+//     field is the SUT.
+//  4. none — ambiguous (multiple equally-plausible candidates, no @InjectMocks,
+//     no stem match) → emit NO SUT edge rather than guess among equals.
+//
+// Mock/Spy collaborator types (@Mock/@MockBean/@Spy/@SpyBean) are excluded from
+// candidacy at every tier, so a collaborator is never linked even when its name
+// matches the test-class stem.
 func resolveJavaTestSubject(src, testClassName string) string {
-	subject := subjectFromTestClassName(testClassName)
-	if subject == "" {
-		return ""
+	return resolveJavaTestSubjectDetail(src, testClassName).subject
+}
+
+// sutResolution carries the disambiguated subject plus the priority tier that
+// selected it, for diagnostics / edge provenance.
+type sutResolution struct {
+	subject string // "" when no confident unique SUT
+	tier    string // injectmocks | stem_match | single_field | "" (none)
+}
+
+func resolveJavaTestSubjectDetail(src, testClassName string) sutResolution {
+	mocks := collectTypes(reJavaMockField, src)
+
+	// candidates = injected/constructed types that are NOT mock collaborators.
+	candidates := map[string]bool{}
+	for t := range referencedJavaTypes(src) {
+		if !mocks[t] {
+			candidates[t] = true
+		}
 	}
-	if referencedJavaTypes(src)[subject] {
-		return subject
+
+	// Tier 1 — @InjectMocks is the explicit SUT marker (overrides stem). When
+	// exactly one @InjectMocks field exists, its (non-mock) type is the SUT.
+	injectMocks := collectTypes(reJavaInjectMocksField, src)
+	for t := range injectMocks {
+		if mocks[t] {
+			delete(injectMocks, t)
+		}
 	}
-	return ""
+	if len(injectMocks) == 1 {
+		for t := range injectMocks {
+			return sutResolution{subject: t, tier: "injectmocks"}
+		}
+	}
+
+	// Tier 2 — stem-affinity: the candidate type equal to the test-class stem.
+	if stem := subjectFromTestClassName(testClassName); stem != "" {
+		// Honour the original conservatism: stem must also be referenced (i.e.
+		// be a non-mock candidate) to be linked.
+		if candidates[stem] {
+			return sutResolution{subject: stem, tier: "stem_match"}
+		}
+		// If @InjectMocks disagreed (multiple) but the stem is among them, the
+		// stem still wins as the explicit named SUT.
+		if injectMocks[stem] {
+			return sutResolution{subject: stem, tier: "stem_match"}
+		}
+		// Stem derivable but not referenced as a non-mock candidate → no edge
+		// (conservative: do not link a renamed/wrapper or a mocked-out type).
+		return sutResolution{}
+	}
+
+	// Tier 3 — no stem: a single non-mock injected/constructed candidate is the
+	// SUT unambiguously.
+	if len(candidates) == 1 {
+		for t := range candidates {
+			return sutResolution{subject: t, tier: "single_field"}
+		}
+	}
+
+	// Tier 4 — ambiguous: do not guess among equals.
+	return sutResolution{}
 }
 
 // collectSpringTestRouteCalls extracts every Spring integration-test


### PR DESCRIPTION
## Summary

Follow-up to #4359 (ref epic #4334), extending the #4615 coverage linkage. When a Java test class injects **multiple** candidate fields (the SUT plus `@Mock`/`@MockBean` collaborators, or several `@Autowired` beans), the JUnit/TestNG `TESTS→subject` resolver in `internal/custom/java/junit5.go` previously relied on loose name-affinity gated on any referencing field. This is a precision/recall enrichment that picks the **one** system-under-test by explicit priority and excludes mock collaborators.

## Disambiguation priority (`resolveJavaTestSubjectDetail`)

1. **`@InjectMocks`** — Mockito's explicit SUT marker; its type is the SUT and **overrides** stem affinity (the `@Mock`/`@MockBean` fields are the collaborators injected into it).
2. **stem-match** — strip `Test`/`Tests`/`IT`/`ITCase`/`TestCase` (and leading `Test`) from the class name, match the stem against the injected/constructed **non-mock** field-type set (`OrderServiceTest`→`OrderService`).
3. **single field** — exactly one non-mock injected/constructed candidate, no stem.
4. **none** — ambiguous equals → emit **no** SUT edge (no guessing).

`@Mock`/`@MockBean`/`@Spy`/`@SpyBean` collaborator types are excluded at **every** tier, so a stubbed collaborator is never linked even when its name matches the test-class stem. The `match_source` edge property records the selecting tier. Route-hit / MockMvc e2e `TESTS` edges (`collectSpringTestRouteCalls` #4370) are untouched — those are endpoint-level and separate.

## Validation (RED→GREEN)

- `@InjectMocks OrderService sut; @Mock PaymentClient pay; @Mock InventoryRepo inv;` → `TESTS→OrderService` only (not the collaborators).
- `@Autowired OrderService svc; @Autowired Clock clock;` in `OrderServiceTest` (no `@InjectMocks`) → stem-match picks `OrderService`.
- Ambiguous (two equally-plausible `@Autowired`, no `@InjectMocks`, no stem match) → no spurious SUT edge.

Unit tiers + collaborator exclusion in `issue4390_sut_disambiguation_test.go`; through the **registered** extractor in `issue4390_livedrepro_test.go`.

## Coverage docs

Java spring-boot/junit `tests_linkage` cells updated surgically (notes + cites). `coverage fmt --check` canonical; `coverage validate` 0 errors.

## Gates

`go build ./...`, `go vet ./internal/custom/... ./internal/extractors/...`, `go test ./internal/custom/... ./internal/extractors/... ./internal/graph/... ./internal/types/` all green.

Closes #4390

🤖 Generated with [Claude Code](https://claude.com/claude-code)