### PR TITLE
feat(coverage-linkage): Playwright/Cypress browser-e2e + Ruby RSpec/Minitest test→subject linkage

### DIFF
--- a/internal/custom/javascript/tests_route_e2e.go
+++ b/internal/custom/javascript/tests_route_e2e.go
@@ -1,0 +1,345 @@
+// tests_route_e2e.go — Playwright / Cypress browser-e2e API-call → endpoint
+// route-hit linkage.
+//
+// #4399 (the TS browser-e2e slice of the coverage-linkage tail epic #4615/#4334;
+// a sibling of the NestJS/supertest #4351, Python-client #4369, Spring #4370 and
+// Go-httptest / Rails-request-spec #4371 slices). Emits ONE test_suite entity
+// per Playwright/Cypress spec file that drives an HTTP endpoint by ROUTE STRING
+// via the browser-e2e API-call idioms, stamping the captured `VERB route` pairs
+// onto the suite's `e2e_route_calls` property (one "VERB route" per line). The
+// shared resolve pass (engine.linkE2ERouteTestsToEndpoints, #4351) then matches
+// each pair against the cross-file http_endpoint_definition index and emits a
+// TESTS edge to the exact endpoint exercised — exactly as every other slice does
+// for its stack. The engine pass is language-agnostic (it fires on any
+// test_suite carrying e2e_route_calls), so the only work here is the
+// Playwright/Cypress route capture.
+//
+// Why a SEPARATE extractor (not the jest.go supertest path): Playwright and
+// Cypress specs do NOT use supertest's `request(app).get('/x')` form (jest.go
+// #4351 already owns that). They drive a live server through a fixture-injected
+// request context (`request`, `page.request`, an `apiContext`) or Cypress's
+// `cy.request` / `cy.intercept`. jest.go also only mints its suite when a
+// describe/it/test is present and reuses Nest-spec subject resolution; the
+// browser-e2e capture is an orthogonal route-string surface that warrants its
+// own one-per-file suite (keyed off the spec path, namespaced to avoid by-name
+// re-orphaning, the #4366/#4343 lesson).
+//
+// Playwright idioms captured (the request-context fixture has many aliases —
+// `request`, `page.request`, a destructured `apiContext`, `ctx`, `api`, … — so
+// we match the VERB METHOD on ANY receiver, gated on the route being a
+// leading-slash literal):
+//   - request.post('/api/users', { data })            → POST   /api/users
+//   - page.request.get('/api/users')                  → GET    /api/users
+//   - apiContext.fetch('/api/users', { method:'PUT' }) → PUT    /api/users
+//   - request.fetch('/api/x', { method: 'DELETE' })   → DELETE /api/x
+//
+// Cypress idioms captured:
+//   - cy.request('POST', '/api/users', body)          → POST   /api/users
+//   - cy.request('GET', '/api/users')                 → GET    /api/users
+//   - cy.request({ method: 'PUT', url: '/api/x' })    → PUT    /api/x
+//   - cy.request('/api/health')                       → GET    /api/health   (default verb)
+//   - cy.intercept('GET', '/api/users')               → GET    /api/users
+//   - cy.intercept({ method:'POST', url:'/api/x' })   → POST   /api/x
+//
+// Honest exclusions (no fabricated edges):
+//   - A built / interpolated URL with no static leading-slash literal
+//     (`request.get(`${base}/users`)`, `cy.request(url)`, `cy.request(apiUrl(id))`)
+//     is dropped — only a single-quote / double-quote leading-slash literal is
+//     captured. (A leading-slash template literal with NO interpolation, e.g.
+//     `request.get(`/api/users`)`, IS captured; a template containing `${…}`
+//     before the path is not.)
+//   - Non-spec files emit no suite.
+//   - The `.fetch(...)` form requires a `method:` in its options object to know
+//     the verb; a bare `.fetch('/x')` with no method is conservatively skipped
+//     (the WHATWG default is GET, but a fetch-without-method on an API context is
+//     ambiguous enough — and rare enough in e2e specs — that we do not guess).
+//
+// Registration key: "custom_js_tests_route_e2e" (the canonical
+// `custom_<lang>_tests_route_e2e` convention shared by every tail slice; the JS
+// dispatch prefix is `custom_js_`, so CustomExtractorsFor("javascript"/"
+// typescript") picks it up — the #4769 dispatch-prefix lesson).
+package javascript
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_tests_route_e2e", &jsTestRouteE2EExtractor{})
+}
+
+type jsTestRouteE2EExtractor struct{}
+
+func (e *jsTestRouteE2EExtractor) Language() string { return "custom_js_tests_route_e2e" }
+
+var (
+	// reBrowserE2EVerbCall matches a Playwright request-context verb call on ANY
+	// receiver whose FIRST argument is a leading-slash string/template literal:
+	// `request.post('/api/users', …)`, `page.request.get('/api/users')`,
+	// `apiContext.delete('/api/x')`. Group 1 = verb, group 2 = the route literal.
+	// The route is captured only when it is a leading-slash literal (single,
+	// double, or non-interpolated backtick) — a `${…}`-built URL never matches
+	// because the opening quote must be immediately followed by `/`.
+	reBrowserE2EVerbCall = regexp.MustCompile(
+		`\.(get|post|put|delete|patch|head|options)\s*\(\s*['"` + "`" + `](/[^'"` + "`" + `$\n\r]*)['"` + "`" + `]`)
+
+	// reBrowserE2EFetch matches a Playwright apiContext `.fetch('/route', { method:
+	// 'VERB' })` call. Group 1 = the route literal, group 2 = the method value.
+	// The route must be a leading-slash literal; the method must appear in the
+	// options object within a bounded window after the route. A `.fetch` with no
+	// `method:` is skipped (see honest exclusions).
+	reBrowserE2EFetch = regexp.MustCompile(
+		`\.fetch\s*\(\s*['"` + "`" + `](/[^'"` + "`" + `$\n\r]*)['"` + "`" + `]\s*,[^)]{0,200}?\bmethod\s*:\s*['"` + "`" + `]([A-Za-z]+)['"` + "`" + `]`)
+
+	// reCyRequestPositional matches the Cypress `cy.request('VERB', '/route', …)`
+	// two-positional form. Group 1 = verb, group 2 = route literal.
+	reCyRequestPositional = regexp.MustCompile(
+		`\bcy\s*\.\s*request\s*\(\s*['"` + "`" + `]([A-Za-z]+)['"` + "`" + `]\s*,\s*['"` + "`" + `](/[^'"` + "`" + `$\n\r]*)['"` + "`" + `]`)
+
+	// reCyRequestSingle matches the Cypress `cy.request('/route')` single-string
+	// form (default verb GET). Group 1 = route literal. Anchored so it does NOT
+	// also fire on the two-positional / options-object forms (the first arg must
+	// be a leading-slash literal, and the next non-space char must close the call
+	// or be a trailing-arg comma — i.e. not another quoted positional, which the
+	// positional regex already owns).
+	reCyRequestSingle = regexp.MustCompile(
+		`\bcy\s*\.\s*request\s*\(\s*['"` + "`" + `](/[^'"` + "`" + `$\n\r]*)['"` + "`" + `]\s*[),]`)
+
+	// reCyIntercept matches the Cypress `cy.intercept('VERB', '/route', …)`
+	// positional form. Group 1 = verb, group 2 = route literal.
+	reCyIntercept = regexp.MustCompile(
+		`\bcy\s*\.\s*intercept\s*\(\s*['"` + "`" + `]([A-Za-z]+)['"` + "`" + `]\s*,\s*['"` + "`" + `](/[^'"` + "`" + `$\n\r]*)['"` + "`" + `]`)
+
+	// reCyObjVerbUrl matches the Cypress object-arg form used by BOTH
+	// `cy.request({ method, url })` and `cy.intercept({ method, url })`:
+	// a `method: 'VERB'` and a `url: '/route'` within the same options object.
+	// Order-tolerant (method-before-url and url-before-method) via two patterns.
+	reCyObjMethodFirst = regexp.MustCompile(
+		`\bcy\s*\.\s*(?:request|intercept)\s*\(\s*\{[^}]{0,400}?\bmethod\s*:\s*['"` + "`" + `]([A-Za-z]+)['"` + "`" + `][^}]{0,400}?\burl\s*:\s*['"` + "`" + `](/[^'"` + "`" + `$\n\r]*)['"` + "`" + `]`)
+	reCyObjURLFirst = regexp.MustCompile(
+		`\bcy\s*\.\s*(?:request|intercept)\s*\(\s*\{[^}]{0,400}?\burl\s*:\s*['"` + "`" + `](/[^'"` + "`" + `$\n\r]*)['"` + "`" + `][^}]{0,400}?\bmethod\s*:\s*['"` + "`" + `]([A-Za-z]+)['"` + "`" + `]`)
+)
+
+func (e *jsTestRouteE2EExtractor) Extract(
+	ctx context.Context,
+	file extreg.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	// TS/JS reuse the same custom prefix; gate to those source languages.
+	switch file.Language {
+	case "javascript", "typescript":
+	default:
+		return nil, nil
+	}
+	if !isBrowserE2ESpecFile(file.Path) {
+		return nil, nil
+	}
+	src := string(file.Content)
+	framework := detectBrowserE2EFramework(file.Path, src)
+	if framework == "" {
+		return nil, nil
+	}
+	routeCalls := collectBrowserE2ERouteCalls(src, framework)
+	if len(routeCalls) == 0 {
+		return nil, nil
+	}
+	rec := types.EntityRecord{
+		Name:       "e2e_route_suite:" + browserE2ESpecBaseName(file.Path),
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: file.Path,
+		Language:   file.Language,
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":       framework,
+			"test_framework":  framework,
+			"provenance":      "INFERRED_FROM_JS_BROWSER_E2E_ROUTE",
+			"e2e_route_calls": strings.Join(routeCalls, "\n"),
+		},
+	}
+	rec.ID = rec.ComputeID()
+	return []types.EntityRecord{rec}, nil
+}
+
+// collectBrowserE2ERouteCalls returns the de-duplicated "VERB route" pairs a
+// Playwright/Cypress spec drives by route string. Both framework idiom families
+// are scanned unconditionally (a file rarely mixes them, and matching the other
+// family's patterns simply finds nothing) so a misclassified framework hint
+// never drops a real route hit.
+func collectBrowserE2ERouteCalls(src, _ string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(verb, rawRoute string) {
+		route := normaliseBrowserE2ERoute(rawRoute)
+		if route == "" {
+			return
+		}
+		v := strings.ToUpper(strings.TrimSpace(verb))
+		if !isBrowserE2EVerb(v) {
+			return
+		}
+		line := v + " " + route
+		if seen[line] {
+			return
+		}
+		seen[line] = true
+		out = append(out, line)
+	}
+
+	// Playwright: request-context verb methods + apiContext.fetch({method}).
+	for _, m := range reBrowserE2EVerbCall.FindAllStringSubmatch(src, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range reBrowserE2EFetch.FindAllStringSubmatch(src, -1) {
+		add(m[2], m[1]) // group 2 = method, group 1 = route
+	}
+
+	// Cypress: cy.request / cy.intercept positional + single + object forms.
+	for _, m := range reCyRequestPositional.FindAllStringSubmatch(src, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range reCyRequestSingle.FindAllStringSubmatch(src, -1) {
+		add("GET", m[1]) // single-string cy.request defaults to GET
+	}
+	for _, m := range reCyIntercept.FindAllStringSubmatch(src, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range reCyObjMethodFirst.FindAllStringSubmatch(src, -1) {
+		add(m[1], m[2])
+	}
+	for _, m := range reCyObjURLFirst.FindAllStringSubmatch(src, -1) {
+		add(m[2], m[1]) // group 1 = url, group 2 = method
+	}
+	return out
+}
+
+// browserE2EVerbs is the set of HTTP verbs the resolve pass understands.
+var browserE2EVerbs = map[string]bool{
+	"GET": true, "POST": true, "PUT": true, "DELETE": true,
+	"PATCH": true, "HEAD": true, "OPTIONS": true,
+}
+
+func isBrowserE2EVerb(v string) bool { return browserE2EVerbs[v] }
+
+// normaliseBrowserE2ERoute reduces a raw route literal to a leading-slash path:
+// strips a scheme+authority prefix (https://app/api/x → /api/x), drops a
+// query/fragment tail, collapses repeated slashes. A literal with no static
+// `/segment` (only scheme/host) is dropped. Path-param placeholders (`/:id`,
+// `/{id}`) and casing are preserved (the resolver wildcards templates and
+// compares case-insensitively).
+func normaliseBrowserE2ERoute(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return ""
+	}
+	if i := strings.Index(p, "://"); i >= 0 {
+		rest := p[i+3:]
+		if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+			p = rest[slash:]
+		} else {
+			return ""
+		}
+	}
+	if q := strings.IndexAny(p, "?#"); q >= 0 {
+		p = p[:q]
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		return ""
+	}
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	if p == "/" {
+		return ""
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// detectBrowserE2EFramework returns "playwright", "cypress", or "" for a spec
+// file. The path is the strongest signal (`*.cy.ts` / a `/cypress/` or
+// `/e2e/`-with-playwright tree), with a content fallback on the framework's
+// signature imports / globals. Returning "" means "not a recognised browser-e2e
+// spec" and the extractor emits nothing.
+func detectBrowserE2EFramework(path, src string) string {
+	lp := strings.ToLower(strings.ReplaceAll(path, "\\", "/"))
+	switch {
+	case strings.Contains(lp, ".cy."), strings.Contains(lp, "/cypress/"):
+		return "cypress"
+	}
+	// Content signals — Cypress's `cy.` global / its config, Playwright's test
+	// import / request fixture.
+	if strings.Contains(src, "cy.request(") || strings.Contains(src, "cy.intercept(") ||
+		strings.Contains(src, "from 'cypress'") || strings.Contains(src, "from \"cypress\"") {
+		return "cypress"
+	}
+	if strings.Contains(src, "@playwright/test") ||
+		strings.Contains(src, "playwright-core") ||
+		strings.Contains(src, "page.request.") ||
+		regexp.MustCompile(`\brequest\.(get|post|put|delete|patch|fetch)\s*\(`).MatchString(src) {
+		return "playwright"
+	}
+	return ""
+}
+
+// isBrowserE2ESpecFile reports whether path looks like a Playwright/Cypress spec
+// — a `*.spec.{ts,js,…}`, `*.test.{ts,js,…}`, `*.cy.{ts,js,…}`, `*.e2e.{ts,js,…}`
+// `*.e2e-spec.ts`, or any file under a `/cypress/`, `/e2e/`, or `/tests/` tree.
+// Keeps the route-hit suite off production code that merely calls an HTTP API.
+func isBrowserE2ESpecFile(path string) bool {
+	lp := strings.ToLower(strings.ReplaceAll(path, "\\", "/"))
+	if !hasJSTSExt(lp) {
+		return false
+	}
+	base := lp
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	for _, marker := range []string{
+		".cy.", ".spec.", ".test.", ".e2e.", ".e2e-spec.",
+	} {
+		if strings.Contains(base, marker) {
+			return true
+		}
+	}
+	return strings.Contains(lp, "/cypress/") ||
+		strings.Contains(lp, "/e2e/") ||
+		strings.Contains(lp, "/tests/") ||
+		strings.Contains(lp, "/__tests__/")
+}
+
+// hasJSTSExt reports whether a lowercased path has a JS/TS source extension.
+func hasJSTSExt(lp string) bool {
+	for _, ext := range []string{".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"} {
+		if strings.HasSuffix(lp, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// browserE2ESpecBaseName derives a stable suite label from the spec path
+// (`e2e/users.spec.ts` → `users.spec`).
+func browserE2ESpecBaseName(path string) string {
+	p := strings.ReplaceAll(path, "\\", "/")
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		p = p[i+1:]
+	}
+	for _, ext := range []string{".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"} {
+		if strings.HasSuffix(p, ext) {
+			return strings.TrimSuffix(p, ext)
+		}
+	}
+	return p
+}

--- a/internal/custom/javascript/tests_route_e2e_test.go
+++ b/internal/custom/javascript/tests_route_e2e_test.go
@@ -1,0 +1,115 @@
+package javascript
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// Issue #4399 (extractor side). The browser-e2e route extractor must capture
+// every Playwright/Cypress API-call route-by-string and stamp the `VERB route`
+// pairs onto a one-per-file test_suite's e2e_route_calls property. Built /
+// interpolated URLs are conservatively skipped.
+
+const playwrightSpec4399 = "import { test, expect } from '@playwright/test';\n" +
+	"\n" +
+	"test.describe('users api', () => {\n" +
+	"  test('creates a user', async ({ request }) => {\n" +
+	"    const res = await request.post('/api/users', { data: { name: 'a' } });\n" +
+	"    expect(res.status()).toBe(201);\n" +
+	"  });\n" +
+	"  test('lists users', async ({ page }) => {\n" +
+	"    await page.request.get('/api/users');\n" +
+	"  });\n" +
+	"  test('updates via fetch', async ({ request: apiContext }) => {\n" +
+	"    await apiContext.fetch('/api/users/1', { method: 'PUT', data: {} });\n" +
+	"  });\n" +
+	"  test('built url is skipped', async ({ request }) => {\n" +
+	"    const base = process.env.BASE;\n" +
+	"    await request.get(`${base}/api/users`);\n" +
+	"  });\n" +
+	"});\n"
+
+const cypressSpec4399 = "describe('users api', () => {\n" +
+	"  it('lists', () => {\n" +
+	"    cy.request('GET', '/api/users').its('status').should('eq', 200);\n" +
+	"  });\n" +
+	"  it('creates', () => {\n" +
+	"    cy.request({ method: 'POST', url: '/api/users', body: { name: 'a' } });\n" +
+	"  });\n" +
+	"  it('health single-arg', () => {\n" +
+	"    cy.request('/api/health');\n" +
+	"  });\n" +
+	"  it('intercepts', () => {\n" +
+	"    cy.intercept('DELETE', '/api/users/9').as('del');\n" +
+	"  });\n" +
+	"  it('built url skipped', () => {\n" +
+	"    const u = apiUrl('users');\n" +
+	"    cy.request(u);\n" +
+	"  });\n" +
+	"});\n"
+
+func extractE2ESuiteCalls(t *testing.T, path, lang, src string) []string {
+	t.Helper()
+	ex := &jsTestRouteE2EExtractor{}
+	ents, err := ex.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: lang, Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			raw := e.Properties["e2e_route_calls"]
+			if raw == "" {
+				return nil
+			}
+			out := strings.Split(raw, "\n")
+			sort.Strings(out)
+			return out
+		}
+	}
+	return nil
+}
+
+func TestPlaywrightE2ERouteCapture4399(t *testing.T) {
+	got := extractE2ESuiteCalls(t, "e2e/users.spec.ts", "typescript", playwrightSpec4399)
+	want := []string{"GET /api/users", "POST /api/users", "PUT /api/users/1"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("playwright route calls = %v, want %v", got, want)
+	}
+}
+
+func TestCypressE2ERouteCapture4399(t *testing.T) {
+	got := extractE2ESuiteCalls(t, "cypress/e2e/users.cy.ts", "typescript", cypressSpec4399)
+	want := []string{
+		"DELETE /api/users/9",
+		"GET /api/health",
+		"GET /api/users",
+		"POST /api/users",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("cypress route calls = %v, want %v", got, want)
+	}
+}
+
+// A pure unit-test spec that hits no route emits no suite.
+func TestBrowserE2E_NoRouteNoSuite4399(t *testing.T) {
+	src := "import { test, expect } from '@playwright/test';\n" +
+		"test('adds', () => { expect(1 + 1).toBe(2); });\n"
+	got := extractE2ESuiteCalls(t, "e2e/math.spec.ts", "typescript", src)
+	if got != nil {
+		t.Fatalf("expected no suite for route-less spec, got %v", got)
+	}
+}
+
+// Non-spec production code that calls an HTTP API is not a test file → no suite.
+func TestBrowserE2E_NonSpecSkipped4399(t *testing.T) {
+	got := extractE2ESuiteCalls(t, "src/api/client.ts", "typescript", cypressSpec4399)
+	if got != nil {
+		t.Fatalf("expected no suite for non-spec file, got %v", got)
+	}
+}

--- a/internal/engine/http_endpoint_e2e_testmap_4399_test.go
+++ b/internal/engine/http_endpoint_e2e_testmap_4399_test.go
@@ -1,0 +1,150 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	// Register the browser-e2e extractor so the suite (with e2e_route_calls)
+	// comes from the REAL extractor, not a hand-built fixture.
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4399 LIVE-REPRO (resolve side, full in-pipeline).
+//
+// Proves end-to-end that a Playwright `request.post('/api/users')` and a Cypress
+// `cy.request('GET', '/api/users')` browser-e2e API call link to the
+// http_endpoint_definition they exercise via the shared
+// linkE2ERouteTestsToEndpoints pass (#4351) — and that an interpolated URL
+// yields NO edge. The suite is produced by the REAL custom_js_tests_route_e2e
+// extractor; only the endpoint definitions are hand-built (the engine pass is
+// framework-agnostic and only needs the definition index).
+func TestIssue4399_BrowserE2ERouteTestsLinkToEndpoints(t *testing.T) {
+	defPost := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:POST:/api/users",
+		SourceFile: "src/users/users.controller.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"verb": "POST", "path": "/api/users", "framework": "nestjs",
+			"pattern_type": "http_endpoint_synthesis",
+		},
+	}
+	defGet := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:GET:/api/users",
+		SourceFile: "src/users/users.controller.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"verb": "GET", "path": "/api/users", "framework": "nestjs",
+			"pattern_type": "http_endpoint_synthesis",
+		},
+	}
+
+	// Real Playwright spec: one literal POST + an interpolated GET that MUST be
+	// dropped.
+	pwSpec := "import { test } from '@playwright/test';\n" +
+		"test('creates', async ({ request }) => {\n" +
+		"  await request.post('/api/users', { data: {} });\n" +
+		"});\n" +
+		"test('built url skipped', async ({ request }) => {\n" +
+		"  await request.get(`${base}/api/users`);\n" +
+		"});\n"
+	// Real Cypress spec: one literal GET.
+	cySpec := "describe('users', () => {\n" +
+		"  it('lists', () => { cy.request('GET', '/api/users'); });\n" +
+		"});\n"
+
+	ext, ok := extreg.Get("custom_js_tests_route_e2e")
+	if !ok {
+		t.Fatal("custom_js_tests_route_e2e not registered (dispatch-prefix regression, #4769)")
+	}
+	pwSuite := extractOneSuite(t, ext, "e2e/users.spec.ts", pwSpec)
+	cySuite := extractOneSuite(t, ext, "cypress/e2e/users.cy.ts", cySpec)
+
+	// The Playwright suite must carry ONLY the literal POST (interpolated GET
+	// dropped — honest exclusion).
+	if calls := pwSuite.Properties["e2e_route_calls"]; calls != "POST /api/users" {
+		t.Fatalf("playwright suite e2e_route_calls=%q, want exactly %q (interpolated URL must be dropped)",
+			calls, "POST /api/users")
+	}
+	if calls := cySuite.Properties["e2e_route_calls"]; calls != "GET /api/users" {
+		t.Fatalf("cypress suite e2e_route_calls=%q, want %q", calls, "GET /api/users")
+	}
+
+	merged := []types.EntityRecord{defPost, defGet, *pwSuite, *cySuite}
+
+	// AFTER: the resolve pass links each suite to exactly its endpoint.
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+	if stats.E2ERouteTestEdges < 2 {
+		t.Fatalf("expected >=2 e2e route TESTS edges (PW POST + Cy GET), got %d", stats.E2ERouteTestEdges)
+	}
+
+	gotPost, gotGet := false, false
+	for _, e := range out {
+		if e.Subtype != "test_suite" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != string(types.RelationshipKindTests) ||
+				r.Properties["match_source"] != "e2e_supertest_route" {
+				continue
+			}
+			switch {
+			case strings.HasPrefix(e.SourceFile, "e2e/") && r.Properties["verb"] == "POST" &&
+				r.Properties["route"] == "/api/users":
+				gotPost = true
+				if fw := r.Properties["framework"]; fw != "playwright" {
+					t.Errorf("playwright suite TESTS edge framework=%q, want playwright", fw)
+				}
+			case strings.Contains(e.SourceFile, "cypress/") && r.Properties["verb"] == "GET" &&
+				r.Properties["route"] == "/api/users":
+				gotGet = true
+				if fw := r.Properties["framework"]; fw != "cypress" {
+					t.Errorf("cypress suite TESTS edge framework=%q, want cypress", fw)
+				}
+			}
+		}
+	}
+	if !gotPost {
+		t.Error("no TESTS edge from the Playwright suite to POST /api/users")
+	}
+	if !gotGet {
+		t.Error("no TESTS edge from the Cypress suite to GET /api/users")
+	}
+
+	// The interpolated GET in the Playwright spec must NOT have produced a GET
+	// edge from the e2e/ suite.
+	for _, e := range out {
+		if e.Subtype != "test_suite" || !strings.HasPrefix(e.SourceFile, "e2e/") {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) && r.Properties["verb"] == "GET" {
+				t.Fatalf("interpolated GET produced a spurious TESTS edge from the Playwright suite")
+			}
+		}
+	}
+
+	t.Logf("#4399 browser-e2e endpoint TESTS edges: %d", stats.E2ERouteTestEdges)
+}
+
+func extractOneSuite(t *testing.T, ext extreg.Extractor, path, src string) *types.EntityRecord {
+	t.Helper()
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path: path, Language: "typescript", Content: []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	for i := range ents {
+		if ents[i].Subtype == "test_suite" {
+			return &ents[i]
+		}
+	}
+	t.Fatalf("extractor emitted no test_suite for %s", path)
+	return nil
+}

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -131,6 +131,18 @@ var extraCustomPrefixesForLanguage = map[string][]string{
 	// extractor. The keySet dedup in CustomExtractorsFor makes the duplicate a
 	// no-op when the primary already matches.
 	"dart": {"custom_dart_"},
+	// javascript/typescript's PRIMARY prefix in customPrefixForLanguage is
+	// ALREADY `custom_js_`, so the #4399 browser-e2e coverage-linkage tail
+	// extractor `custom_js_tests_route_e2e` is selected by
+	// CustomExtractorsFor("javascript"/"typescript") via that primary entry.
+	// This explicit re-listing is the #4769 belt-and-suspenders guard: it
+	// documents and locks the dispatch prefix so a future refactor of the JS
+	// primary entry (the Lua mismatch class of bug, where the framework prefix
+	// and the canonical `custom_<lang>_` tail key diverge) cannot silently drop
+	// the tail extractor. The keySet dedup in CustomExtractorsFor makes the
+	// duplicate a no-op when the primary already matches.
+	"javascript": {"custom_js_"},
+	"typescript": {"custom_js_"},
 }
 
 // CustomExtractorsFor returns all registered custom/framework extractors

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -75,6 +75,13 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// for non-spec files. Route-hit linkage (`get '/api/...'`) stays in the
 	// RSpec custom extractor's e2e_route_calls path (#4371).
 	emitRubyTestScopeOwner(root, file, &entities)
+	// Issue #4398 (epic #4615) — Minitest test-case collapse. A
+	// `class UserTest < Minitest::Test` with `def test_*` examples is collapsed
+	// to one test_suite per class (example count folded to a property) plus a
+	// name-affinity TESTS edge to the subject class under test (`UserTest` →
+	// `User`). Mirrors the JS/Go/Java/Python collapse (#4343/#4358/#4359/#4357).
+	// No-op for non-test files and classes that are not Minitest test cases.
+	emitRubyMinitestSuite(root, file, &entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")

--- a/internal/extractors/ruby/tests.go
+++ b/internal/extractors/ruby/tests.go
@@ -63,8 +63,32 @@ func emitRubyTestScopeOwner(root *sitter.Node, file extractor.FileInput, out *[]
 			rels = append(rels, rel)
 		}
 	}
+	// The test-scope owner is minted ONLY when the spec actually reaches a
+	// production handler (a resolved CALLS edge). A shape-only assertion spec
+	// that exercises no handler stays owner-less — the #4684 honest-exclusion
+	// contract. The #4398 subject edge rides ALONG WITH that owner; it must not
+	// be the sole reason an owner is created, so we gate it on CALLS being
+	// present and append it after this check.
 	if len(rels) == 0 {
 		return
+	}
+	// #4398 — name-affinity TESTS edge to the subject class under test. Resolve
+	// the subject from (in priority order) the spec's `described_class`
+	// (top-level `describe Const`), then the spec-file-stem → class convention
+	// (`user_spec.rb` → `User`). When a subject resolves, append a single TESTS
+	// edge (`Class:<Subject>` stub the resolver binds to the in-repo class).
+	// Honest: no edge when nothing resolves.
+	if subj := resolveRSpecSubject(file.Path, bodies); subj != "" {
+		rels = append(rels, types.RelationshipRecord{
+			ToID: "Class:" + subj,
+			Kind: string(types.RelationshipKindTests),
+			Properties: map[string]string{
+				"framework":    "rspec",
+				"match_source": "spec_subject_affinity",
+				"target_type":  subj,
+			},
+			Confidence: 0.9,
+		})
 	}
 	name := rubyTestScopeName(file.Path)
 	rec := types.EntityRecord{
@@ -84,6 +108,218 @@ func emitRubyTestScopeOwner(root *sitter.Node, file extractor.FileInput, out *[]
 		"description": "test scope " + name,
 	}
 	*out = append(*out, rec)
+}
+
+// resolveRSpecSubject resolves the class under test for an RSpec spec via name
+// affinity (#4398). Priority:
+//
+//  1. `described_class` — the constant of the nearest `RSpec.describe Const`
+//     (collectRSpecBlockBodies already threads this down per block); the
+//     top-level describe's constant is the authoritative subject.
+//  2. The spec-file-stem → class convention: `user_spec.rb` → `User`,
+//     `order_service_spec.rb` → `OrderService` (snake_case stem, `_spec`
+//     stripped, camelized). Used only when no `describe Const` was present —
+//     a string-label `describe 'GET /users'` spec falls through to here.
+//
+// Returns "" when no subject resolves (honest exclusion — no spurious edge).
+func resolveRSpecSubject(path string, bodies []rspecBlock) string {
+	// (1) described_class from a `describe Const` — prefer the constant carried
+	// by the OUTERMOST block (the first collected body threads the top-level
+	// described class). Any non-empty describedClass is a high-confidence subject.
+	for _, b := range bodies {
+		if b.describedClass != "" {
+			return rubyConstBaseName(b.describedClass)
+		}
+	}
+	// (2) Spec-file-stem → class convention.
+	return rubySpecStemToClass(path)
+}
+
+// rubyConstBaseName returns the final constant segment of a possibly
+// `::`-qualified Ruby constant (`Admin::UsersController` → `UsersController`),
+// so the `Class:<Subject>` stub matches the resolver's by-name index (which
+// keys on the bare class name).
+func rubyConstBaseName(c string) string {
+	if i := strings.LastIndex(c, "::"); i >= 0 {
+		return c[i+2:]
+	}
+	return c
+}
+
+// rubySpecStemToClass camelizes a spec file stem into the conventional class
+// name under test: `user_spec.rb` → `User`, `order_service_spec.rb` →
+// `OrderService`. Returns "" when the stem has no `_spec` suffix (so a non-spec
+// path never fabricates a subject) or yields no token.
+func rubySpecStemToClass(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	base = strings.TrimSuffix(base, ".rb")
+	stem := strings.TrimSuffix(base, "_spec")
+	if stem == base || stem == "" {
+		return "" // no `_spec` suffix — not the spec-stem convention
+	}
+	return rubyCamelize(stem)
+}
+
+// rubyCamelize converts a snake_case identifier to PascalCase
+// (`order_service` → `OrderService`). Empty segments are skipped.
+func rubyCamelize(snake string) string {
+	var b strings.Builder
+	for _, part := range strings.Split(snake, "_") {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		b.WriteString(part[1:])
+	}
+	return b.String()
+}
+
+// emitRubyMinitestSuite collapses a Minitest test case into a single
+// test_suite entity per class, folding the `def test_*` example count to a
+// property and emitting a name-affinity TESTS edge to the subject class under
+// test (#4398).
+//
+// Minitest test cases are NAMED classes (`class UserTest < Minitest::Test`)
+// whose `def test_x` examples ARE method declarations — so walk() already mines
+// their bodies for CALLS edges (no anonymous-block orphan problem like RSpec).
+// What was missing is (a) a one-per-class collapsed test_suite the coverage/
+// dashboard surfaces recognise, and (b) the TESTS→subject edge crediting the
+// class the suite exercises. This pass adds both, gated to test files that
+// declare a Minitest/Test::Unit/ActiveSupport test case.
+//
+// Subject affinity: strip the conventional `Test` suffix from the test-case
+// class name (`UserTest` → `User`, `OrderServiceTest` → `OrderService`), else
+// fall back to the spec-file-stem convention. No `Test`-suffix and no stem
+// match → no edge (honest exclusion).
+//
+// The suite Name is namespaced (`minitest_suite:<file>:<Class>`) so the
+// resolver's by-name index never confuses it with the production class of the
+// same base name and re-orphans it (the #4366 MergeWithCustom / #4343 lesson).
+func emitRubyMinitestSuite(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+	if root == nil || !isRubyTestFile(file.Path) {
+		return
+	}
+	for _, cls := range findAllNodes(root, "class") {
+		super := childFieldText(cls, "superclass", file.Content)
+		if !isMinitestSuperclass(super) {
+			continue
+		}
+		className := childFieldText(cls, "name", file.Content)
+		if className == "" {
+			continue
+		}
+		testCount := countMinitestExamples(cls, file.Content)
+		if testCount == 0 {
+			continue // a test-case class with no `def test_*` exercises nothing
+		}
+		base := filepath.Base(filepath.ToSlash(file.Path))
+		base = strings.TrimSuffix(base, ".rb")
+		rec := types.EntityRecord{
+			Name:       "minitest_suite:" + base + ":" + rubyConstBaseName(className),
+			Kind:       "SCOPE.Operation",
+			Subtype:    "test_suite",
+			SourceFile: file.Path,
+			Language:   "ruby",
+			StartLine:  int(cls.StartPoint().Row) + 1,
+			EndLine:    int(cls.EndPoint().Row) + 1,
+			Properties: map[string]string{
+				"framework":      "minitest",
+				"test_framework": "minitest",
+				"provenance":     "INFERRED_FROM_MINITEST_SUITE",
+				"suite_label":    className,
+				"test_count":     strconv.Itoa(testCount),
+			},
+		}
+		if subj := resolveMinitestSubject(file.Path, className); subj != "" {
+			rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+				ToID: "Class:" + subj,
+				Kind: string(types.RelationshipKindTests),
+				Properties: map[string]string{
+					"framework":    "minitest",
+					"match_source": "spec_subject_affinity",
+					"target_type":  subj,
+				},
+				Confidence: 0.9,
+			})
+		}
+		*out = append(*out, rec)
+	}
+}
+
+// isMinitestSuperclass reports whether a class superclass marks a Minitest /
+// Test::Unit / ActiveSupport test case. Tolerates `::`-qualified forms.
+func isMinitestSuperclass(super string) bool {
+	s := strings.TrimSpace(super)
+	if s == "" {
+		return false
+	}
+	switch rubyConstBaseName(s) {
+	case "Test": // Minitest::Test
+		return strings.Contains(s, "Minitest") || strings.Contains(s, "MiniTest")
+	case "TestCase": // ActiveSupport::TestCase, Test::Unit::TestCase, Minitest::Test::Unit::TestCase
+		return true
+	case "Spec": // Minitest::Spec
+		return strings.Contains(s, "Minitest") || strings.Contains(s, "MiniTest")
+	}
+	return false
+}
+
+// countMinitestExamples counts the `def test_*` method declarations directly in
+// a Minitest test-case class body. Only methods whose name starts with `test_`
+// (or is exactly `test`) are Minitest examples; helpers / `setup` / `teardown`
+// are excluded from the count.
+func countMinitestExamples(cls *sitter.Node, src []byte) int {
+	n := 0
+	for _, m := range findAllNodes(cls, "method") {
+		name := childFieldText(m, "name", src)
+		if name == "test" || strings.HasPrefix(name, "test_") {
+			n++
+		}
+	}
+	return n
+}
+
+// resolveMinitestSubject resolves the subject class a Minitest case tests via
+// name affinity (#4398): strip the conventional `Test` suffix from the test-case
+// class name (`UserTest` → `User`), else fall back to the spec-file-stem
+// convention. Returns "" when neither yields a name (honest exclusion).
+func resolveMinitestSubject(path, className string) string {
+	base := rubyConstBaseName(className)
+	if strings.HasSuffix(base, "Test") && len(base) > len("Test") {
+		return strings.TrimSuffix(base, "Test")
+	}
+	// Minitest's file convention is `*_test.rb` (not `*_spec.rb`); reuse the
+	// camelize convention on the `_test`-stripped stem.
+	return rubyTestStemToClass(path)
+}
+
+// rubyTestStemToClass camelizes a `*_test.rb` file stem into the conventional
+// class under test (`user_test.rb` → `User`). Returns "" when the stem has no
+// `_test` suffix.
+func rubyTestStemToClass(path string) string {
+	base := filepath.Base(filepath.ToSlash(path))
+	base = strings.TrimSuffix(base, ".rb")
+	stem := strings.TrimSuffix(base, "_test")
+	if stem == base || stem == "" {
+		return ""
+	}
+	return rubyCamelize(stem)
+}
+
+// isRubyTestFile reports whether path is any Ruby test file — an RSpec spec
+// (`*_spec.rb` / under `/spec/`) OR a Minitest/Test::Unit test (`*_test.rb` /
+// `test_*.rb` / under `/test/`). Broader than isRubySpecFile so the Minitest
+// collapse fires on the `test/` tree.
+func isRubyTestFile(path string) bool {
+	if isRubySpecFile(path) {
+		return true
+	}
+	slashed := "/" + filepath.ToSlash(strings.ToLower(path))
+	if strings.Contains(slashed, "/test/") || strings.Contains(slashed, "/tests/") {
+		return true
+	}
+	base := strings.ToLower(filepath.Base(path))
+	return strings.HasSuffix(base, "_test.rb") || strings.HasPrefix(base, "test_")
 }
 
 // rspecBlock is an RSpec example/hook block body paired with the class constant

--- a/internal/extractors/ruby/tests_subject_4398_test.go
+++ b/internal/extractors/ruby/tests_subject_4398_test.go
@@ -1,0 +1,162 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4398 — RSpec TESTS→subject affinity edge + Minitest test-suite collapse
+// with a TESTS→subject edge. Honest: no spurious edge when no subject resolves.
+
+// findTestsEdge returns the first TESTS edge with the given match_source on any
+// entity of the given subtype, plus its ToID.
+func findTestsEdgeTarget(ents []types.EntityRecord, subtype string) (string, bool) {
+	for _, e := range ents {
+		if subtype != "" && e.Subtype != subtype {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindTests) &&
+				r.Properties["match_source"] == "spec_subject_affinity" {
+				return r.ToID, true
+			}
+		}
+	}
+	return "", false
+}
+
+// RSpec `describe User` in user_spec.rb → TESTS→User (via described_class).
+func TestRSpecSubjectAffinity_DescribedClass4398(t *testing.T) {
+	src := `require 'rails_helper'
+
+RSpec.describe User do
+  it 'is valid' do
+    u = User.new
+    u.activate
+  end
+end
+`
+	ents := extractRuby(t, "spec/models/user_spec.rb", src)
+	got, ok := findTestsEdgeTarget(ents, "test_scope")
+	if !ok {
+		t.Fatal("no RSpec TESTS→subject edge emitted for describe User")
+	}
+	if got != "Class:User" {
+		t.Fatalf("RSpec subject edge ToID=%q, want Class:User", got)
+	}
+}
+
+// RSpec with a string-label describe but a `_spec` filename → stem→class
+// fallback (`order_service_spec.rb` → OrderService).
+func TestRSpecSubjectAffinity_StemFallback4398(t *testing.T) {
+	src := `RSpec.describe 'OrderService behaviour' do
+  it 'places an order' do
+    svc = OrderService.new
+    svc.place_order
+  end
+end
+`
+	ents := extractRuby(t, "spec/services/order_service_spec.rb", src)
+	got, ok := findTestsEdgeTarget(ents, "test_scope")
+	if !ok {
+		t.Fatal("no RSpec TESTS→subject edge via stem fallback")
+	}
+	if got != "Class:OrderService" {
+		t.Fatalf("RSpec stem subject edge ToID=%q, want Class:OrderService", got)
+	}
+}
+
+// Minitest `class UserTest < Minitest::Test` → a test_suite + TESTS→User.
+func TestMinitestSuiteCollapse_Subject4398(t *testing.T) {
+	src := `require 'test_helper'
+
+class UserTest < Minitest::Test
+  def setup
+    @user = User.new
+  end
+
+  def test_activation
+    @user.activate
+    assert @user.active?
+  end
+
+  def test_name
+    assert_equal 'a', User.new('a').name
+  end
+end
+`
+	ents := extractRuby(t, "test/models/user_test.rb", src)
+
+	var suite *types.EntityRecord
+	for i := range ents {
+		if ents[i].Subtype == "test_suite" && ents[i].Properties["framework"] == "minitest" {
+			suite = &ents[i]
+			break
+		}
+	}
+	if suite == nil {
+		t.Fatal("no Minitest test_suite emitted")
+	}
+	if suite.Properties["test_count"] != "2" {
+		t.Fatalf("Minitest test_count=%q, want 2", suite.Properties["test_count"])
+	}
+	got, ok := findTestsEdgeTarget(ents, "test_suite")
+	if !ok {
+		t.Fatal("no Minitest TESTS→subject edge")
+	}
+	if got != "Class:User" {
+		t.Fatalf("Minitest subject edge ToID=%q, want Class:User", got)
+	}
+}
+
+// A Minitest case under ActiveSupport::TestCase also collapses + links.
+func TestMinitestSuiteCollapse_ActiveSupport4398(t *testing.T) {
+	src := `class OrderTest < ActiveSupport::TestCase
+  def test_total
+    assert_equal 0, Order.new.total
+  end
+end
+`
+	ents := extractRuby(t, "test/models/order_test.rb", src)
+	got, ok := findTestsEdgeTarget(ents, "test_suite")
+	if !ok {
+		t.Fatal("no Minitest (ActiveSupport) TESTS→subject edge")
+	}
+	if got != "Class:Order" {
+		t.Fatalf("subject edge ToID=%q, want Class:Order", got)
+	}
+}
+
+// Honest exclusion: an RSpec spec with NO resolvable subject (string-label
+// describe AND a non-`_spec` path) emits no subject edge.
+func TestRSpecSubjectAffinity_NoSubjectNoEdge4398(t *testing.T) {
+	src := `RSpec.describe 'some behaviour' do
+  it 'works' do
+    Helper.do_thing
+  end
+end
+`
+	// Path under /spec/ (so it IS a spec file) but with no `_spec` stem token to
+	// camelize and no described_class → no subject edge.
+	ents := extractRuby(t, "spec/integration/behaviour.rb", src)
+	if got, ok := findTestsEdgeTarget(ents, "test_scope"); ok {
+		t.Fatalf("expected no subject edge for subject-less spec, got %q", got)
+	}
+}
+
+// A non-Minitest plain class in a test file does NOT become a test_suite.
+func TestMinitest_NonTestCaseClassIgnored4398(t *testing.T) {
+	src := `class UserFactory
+  def build
+    User.new
+  end
+end
+`
+	ents := extractRuby(t, "test/support/user_factory.rb", src)
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			t.Fatalf("plain class wrongly collapsed to a test_suite: %+v", e.Name)
+		}
+	}
+}


### PR DESCRIPTION
Two test→endpoint/subject linkage refinements extending the #4615 coverage-linkage epic, in one PR.

## FIX 1 — #4399: Playwright/Cypress browser-e2e API routes → endpoint TESTS edges
New `custom_js_tests_route_e2e` extractor (`internal/custom/javascript/tests_route_e2e.go`) captures browser-e2e route-by-string API calls and stamps `VERB route` pairs onto a one-per-spec `test_suite`'s `e2e_route_calls` property; the shared `engine.linkE2ERouteTestsToEndpoints` pass (#4351) emits the endpoint TESTS edge.

- **Playwright**: `request.post('/api/x')`, `page.request.get('/api/x')`, `apiContext.fetch('/api/x', { method })` (any request-fixture alias).
- **Cypress**: `cy.request('VERB','/api/x')`, `cy.request({ method, url })`, `cy.request('/api/x')` (default GET), `cy.intercept('VERB','/api/x')`, `cy.intercept({ method, url })`.
- Dispatch registered under the canonical `custom_js_` prefix + a #4769 belt-and-suspenders re-listing in `extraCustomPrefixesForLanguage`.
- **Honest exclusion**: built/interpolated URLs (`${base}/x`, `cy.request(url)`) and a method-less `.fetch` are dropped (leading-slash literals only); non-spec files emit no suite.

## FIX 2 — #4398: Ruby RSpec/Minitest test_suite → TESTS→subject + Minitest collapse
`internal/extractors/ruby/tests.go`:
- **(a) RSpec** `emitRubyTestScopeOwner` now appends a name-affinity TESTS→subject edge — `described_class` (top `describe Const`) else the spec-file-stem→class convention (`user_spec.rb`→`User`). Gated on the spec actually reaching a handler (CALLS present), so shape-only specs stay owner-less and edge-less (the #4684 honest-exclusion contract preserved).
- **(b) Minitest** new `emitRubyMinitestSuite` collapses `class XTest < Minitest::Test` / `ActiveSupport::TestCase` / `Test::Unit::TestCase` to one namespaced `test_suite` per class (`def test_*` count folded to `test_count`) + a TESTS→subject edge stripping the conventional `Test` suffix (`UserTest`→`User`) else the `*_test.rb` stem convention.
- **Honest**: no edge when no subject resolves; plain non-test-case classes in a test file are not collapsed; a test case with no `def test_*` emits no suite.

## Validation (RED→GREEN through the real extract+resolve pipeline)
- `http_endpoint_e2e_testmap_4399_test.go`: real PW `request.post('/api/users')` + Cy `cy.request('GET','/api/users')` → TESTS edges to the POST/GET `/api/users` endpoints; interpolated URL → no edge.
- `tests_route_e2e_test.go`: Playwright/Cypress route capture + no-route/non-spec exclusions.
- `tests_subject_4398_test.go`: `describe User`→User (described_class), string-label + `_spec` stem fallback, `UserTest`→User, `OrderTest < ActiveSupport::TestCase`→Order, subject-less spec → no edge, non-test-case class ignored.

## Coverage docs
`tests_linkage` cells updated surgically — jsts (`lang.jsts.framework.nestjs`, covering Jest/supertest + the new Playwright/Cypress browser-e2e) and ruby (`lang.ruby.framework.rails`, covering RSpec subject + Minitest collapse). `coverage fmt --check` canonical, `coverage validate` 0 errors.

## Gates
`go build ./...`, `go vet`, full `go test` (custom/extractors/engine/graph/types) — all green, 0 failures. `coverage fmt --check` + `coverage validate` 0 errors.

Closes #4399
Closes #4398

🤖 Generated with [Claude Code](https://claude.com/claude-code)