### PR TITLE
feat(install): per-host pre-tool hooks for agent hosts that support them

### DIFF
--- a/internal/install/agenthooks/claudecode.go
+++ b/internal/install/agenthooks/claudecode.go
@@ -1,18 +1,18 @@
 // Package agenthooks installs OPT-IN agent-host hooks that actively
 // reinforce the "query the graph, don't grep your way around it" standing
-// directive (#4238) at the moment a structural grep is about to run.
+// directive (#4238, #4276) at the moment a structural grep is about to run.
 //
-// Scope — CLAUDE CODE ONLY.
+// The package is a PER-HOST registry (see host.go): each supported agent host
+// declares whether it exposes a real pre-tool / pre-shell hook surface and, if
+// so, installs a host-native hook that runs the SHARED advisory nudge script
+// (nudge.go). Hosts without a hook surface are honest, documented no-ops — the
+// cross-host rules block (internal/install/rulesfiles) carries the guidance for
+// them. This complements — does not replace — the rules-block directive.
 //
-// Unlike the cross-host rules block written by internal/install/rulesfiles
-// (which every IDE coding agent reads as project context), this package
-// targets a mechanism that ONLY Claude Code exposes: a PreToolUse hook.
-// A PreToolUse hook is a JSON entry in `.claude/settings.json` with a
-// `matcher` (which tool it fires on) and a `command` (a shell command that
-// receives the tool call as JSON on stdin and may emit advisory output).
-// Other agent hosts (Cursor, Windsurf, Codex, Continue, Zed, …) have no
-// equivalent surface, so this installer is explicitly Claude-Code-only and
-// COMPLEMENTS — does not replace — the cross-host rules-block directive.
+// This file is the CLAUDE CODE host. Claude Code's pre-tool surface is a
+// PreToolUse hook: a JSON entry in `.claude/settings.json` with a `matcher`
+// (which tool it fires on) and a `command` (a shell command that receives the
+// tool call as JSON on stdin and may emit advisory output).
 //
 // Design constraints (all enforced here and in the embedded nudge script):
 //
@@ -44,6 +44,22 @@ import (
 	"path/filepath"
 )
 
+// claudeCodeHost is the Claude Code implementation of Host. Its pre-tool
+// surface is the `.claude/settings.json` PreToolUse hook.
+type claudeCodeHost struct{}
+
+func (claudeCodeHost) Name() string         { return "Claude Code" }
+func (claudeCodeHost) SupportsHook() bool   { return true }
+func (claudeCodeHost) NoHookReason() string { return "" }
+
+func (claudeCodeHost) InstallHook(repoRoot string) (string, error) {
+	return installClaudeCode(repoRoot)
+}
+func (claudeCodeHost) UninstallHook(repoRoot string) error { return uninstallClaudeCode(repoRoot) }
+func (claudeCodeHost) IsHookInstalled(repoRoot string) bool {
+	return claudeCodeInstalled(repoRoot)
+}
+
 // Marker is the stable identifier embedded in the managed PreToolUse hook
 // command so install/update/uninstall can find exactly our entry among any
 // other user-authored hooks. Bumping the trailing version causes an older
@@ -66,14 +82,14 @@ var SettingsRelPath = filepath.Join(".claude", "settings.json")
 // keeps the settings.json entry small and lets users read/audit it.
 var NudgeScriptRelPath = filepath.Join(".claude", "archigraph-grep-nudge.sh")
 
-// Install upserts the marker-identified PreToolUse nudge hook into the
-// project's .claude/settings.json (creating the file and the nudge script
+// installClaudeCode upserts the marker-identified PreToolUse nudge hook into
+// the project's .claude/settings.json (creating the file and the nudge script
 // if absent) and returns the absolute settings path that was touched.
 //
 // It is safe to call repeatedly: an existing managed entry is replaced in
 // place, all other settings and unmanaged hooks are preserved, and the
 // nudge script is rewritten to the current version.
-func Install(repoRoot string) (string, error) {
+func installClaudeCode(repoRoot string) (string, error) {
 	settingsPath := filepath.Join(repoRoot, SettingsRelPath)
 	scriptPath := filepath.Join(repoRoot, NudgeScriptRelPath)
 
@@ -97,11 +113,11 @@ func Install(repoRoot string) (string, error) {
 	return settingsPath, nil
 }
 
-// Uninstall removes the marker-identified managed PreToolUse entry and
-// deletes the nudge script, leaving every other setting and any unmanaged
+// uninstallClaudeCode removes the marker-identified managed PreToolUse entry
+// and deletes the nudge script, leaving every other setting and any unmanaged
 // hooks untouched. It is idempotent: a missing file or missing entry is a
 // no-op.
-func Uninstall(repoRoot string) error {
+func uninstallClaudeCode(repoRoot string) error {
 	settingsPath := filepath.Join(repoRoot, SettingsRelPath)
 	scriptPath := filepath.Join(repoRoot, NudgeScriptRelPath)
 	_ = os.Remove(scriptPath)
@@ -119,9 +135,9 @@ func Uninstall(repoRoot string) error {
 	return writeSettings(settingsPath, doc)
 }
 
-// IsInstalled reports whether the project's .claude/settings.json already
-// contains the marker-identified managed PreToolUse entry.
-func IsInstalled(repoRoot string) bool {
+// claudeCodeInstalled reports whether the project's .claude/settings.json
+// already contains the marker-identified managed PreToolUse entry.
+func claudeCodeInstalled(repoRoot string) bool {
 	settingsPath := filepath.Join(repoRoot, SettingsRelPath)
 	doc, err := readSettings(settingsPath)
 	if err != nil {

--- a/internal/install/agenthooks/claudecode_test.go
+++ b/internal/install/agenthooks/claudecode_test.go
@@ -49,14 +49,14 @@ func managedCount(doc map[string]any) int {
 // (a) fresh .claude/settings.json gets the marker-wrapped PreToolUse entry.
 func TestInstall_Fresh(t *testing.T) {
 	root := t.TempDir()
-	path, err := Install(root)
+	path, err := installClaudeCode(root)
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 	if path != filepath.Join(root, SettingsRelPath) {
 		t.Fatalf("unexpected settings path: %s", path)
 	}
-	if !IsInstalled(root) {
+	if !claudeCodeInstalled(root) {
 		t.Fatal("IsInstalled = false after Install")
 	}
 	doc := readDoc(t, root)
@@ -113,7 +113,7 @@ func TestInstall_Idempotent(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		if _, err := Install(root); err != nil {
+		if _, err := installClaudeCode(root); err != nil {
 			t.Fatalf("Install #%d: %v", i, err)
 		}
 	}
@@ -151,7 +151,7 @@ func TestInstall_Idempotent(t *testing.T) {
 // (c) an existing managed block is replaced in place (not appended).
 func TestInstall_ReplacesExistingManaged(t *testing.T) {
 	root := t.TempDir()
-	if _, err := Install(root); err != nil {
+	if _, err := installClaudeCode(root); err != nil {
 		t.Fatal(err)
 	}
 
@@ -169,7 +169,7 @@ func TestInstall_ReplacesExistingManaged(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := Install(root); err != nil {
+	if _, err := installClaudeCode(root); err != nil {
 		t.Fatal(err)
 	}
 	doc2 := readDoc(t, root)
@@ -199,13 +199,13 @@ func TestUninstall(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, SettingsRelPath), seed, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Install(root); err != nil {
+	if _, err := installClaudeCode(root); err != nil {
 		t.Fatal(err)
 	}
-	if err := Uninstall(root); err != nil {
+	if err := uninstallClaudeCode(root); err != nil {
 		t.Fatalf("Uninstall: %v", err)
 	}
-	if IsInstalled(root) {
+	if claudeCodeInstalled(root) {
 		t.Fatal("still installed after Uninstall")
 	}
 	if _, err := os.Stat(filepath.Join(root, NudgeScriptRelPath)); !os.IsNotExist(err) {
@@ -221,7 +221,7 @@ func TestUninstall(t *testing.T) {
 		t.Fatalf("user hook not preserved on uninstall: %v", pre)
 	}
 	// Idempotent second uninstall.
-	if err := Uninstall(root); err != nil {
+	if err := uninstallClaudeCode(root); err != nil {
 		t.Fatalf("second Uninstall: %v", err)
 	}
 }

--- a/internal/install/agenthooks/cursor.go
+++ b/internal/install/agenthooks/cursor.go
@@ -1,0 +1,191 @@
+package agenthooks
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// cursor.go is the CURSOR host implementation of Host.
+//
+// Cursor exposes a real programmable pre-tool surface via Agent Hooks:
+// `.cursor/hooks.json` declares lifecycle hooks, and the `beforeShellExecution`
+// event fires immediately before the agent runs a shell command. The hook is a
+// `{ "command": "<script>" }` entry under `hooks.beforeShellExecution`; the
+// script receives the pending shell command as JSON on stdin and may emit
+// advisory output / a permission decision on stdout.
+//
+// We reuse the SHARED advisory nudge script (nudge.go) verbatim: it reads the
+// payload on stdin, applies the structural-grep heuristic, and prints a
+// one-line advisory to stderr at most once per session. It never blocks (it
+// exits 0 and the Cursor entry does not deny), preserving the advisory-only
+// contract. Cursor's payload JSON differs in shape from Claude Code's, but the
+// heuristic scans the raw payload text, so the same script works for both.
+//
+// Idempotency mirrors the Claude Code host: the managed entry carries the
+// stable Marker (embedded as a leading shell comment in the command), so
+// re-install upserts in place and any user-authored Cursor hooks plus every
+// other key in hooks.json are preserved on the JSON round-trip.
+
+// cursorHost is the Cursor implementation of Host.
+type cursorHost struct{}
+
+func (cursorHost) Name() string         { return "Cursor" }
+func (cursorHost) SupportsHook() bool   { return true }
+func (cursorHost) NoHookReason() string { return "" }
+
+func (cursorHost) InstallHook(repoRoot string) (string, error) {
+	return installCursor(repoRoot)
+}
+func (cursorHost) UninstallHook(repoRoot string) error  { return uninstallCursor(repoRoot) }
+func (cursorHost) IsHookInstalled(repoRoot string) bool { return cursorInstalled(repoRoot) }
+
+// CursorHooksRelPath is the project-relative path to Cursor's hooks config.
+var CursorHooksRelPath = filepath.Join(".cursor", "hooks.json")
+
+// CursorNudgeScriptRelPath is where the advisory nudge script is written for
+// Cursor. It is a separate copy from the Claude Code script so each host owns
+// its sidecar and uninstalling one host never deletes another's script.
+var CursorNudgeScriptRelPath = filepath.Join(".cursor", "archigraph-grep-nudge.sh")
+
+// CursorHookEvent is the Cursor Agent Hooks lifecycle event we attach to:
+// it fires before the agent executes a shell command (the surface where a
+// structural grep is about to run).
+const CursorHookEvent = "beforeShellExecution"
+
+func installCursor(repoRoot string) (string, error) {
+	hooksPath := filepath.Join(repoRoot, CursorHooksRelPath)
+	scriptPath := filepath.Join(repoRoot, CursorNudgeScriptRelPath)
+
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0o755); err != nil {
+		return "", fmt.Errorf("agenthooks(cursor): mkdir: %w", err)
+	}
+	if err := writeNudgeScript(scriptPath); err != nil {
+		return "", err
+	}
+
+	doc, err := readSettings(hooksPath)
+	if err != nil {
+		return "", err
+	}
+	upsertCursorHook(doc, scriptPath)
+	if err := writeSettings(hooksPath, doc); err != nil {
+		return "", err
+	}
+	return hooksPath, nil
+}
+
+func uninstallCursor(repoRoot string) error {
+	hooksPath := filepath.Join(repoRoot, CursorHooksRelPath)
+	scriptPath := filepath.Join(repoRoot, CursorNudgeScriptRelPath)
+	_ = os.Remove(scriptPath)
+
+	doc, err := readSettings(hooksPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if !removeCursorHook(doc) {
+		return nil
+	}
+	return writeSettings(hooksPath, doc)
+}
+
+func cursorInstalled(repoRoot string) bool {
+	hooksPath := filepath.Join(repoRoot, CursorHooksRelPath)
+	doc, err := readSettings(hooksPath)
+	if err != nil {
+		return false
+	}
+	return findCursorHookIdx(doc) >= 0
+}
+
+// ── .cursor/hooks.json document surgery ──────────────────────────────────
+//
+// The Cursor hooks.json shape is:
+//
+//	{
+//	  "hooks": {
+//	    "beforeShellExecution": [
+//	      { "command": "# <marker>\nsh \"<script>\"" }
+//	    ]
+//	  }
+//	}
+//
+// We operate on map[string]any so every key we do not understand is preserved
+// verbatim on the round-trip.
+
+func cursorManagedEntry(scriptPath string) map[string]any {
+	return map[string]any{
+		// The Marker is embedded as a leading shell comment so it is inert at
+		// runtime and reliably greppable for idempotent upsert.
+		"command": fmt.Sprintf("# %s\nsh %q", Marker, scriptPath),
+	}
+}
+
+func upsertCursorHook(doc map[string]any, scriptPath string) {
+	entry := cursorManagedEntry(scriptPath)
+
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+	}
+	evt, _ := hooks[CursorHookEvent].([]any)
+
+	if idx := findCursorHookInArr(evt); idx >= 0 {
+		evt[idx] = entry
+	} else {
+		evt = append(evt, entry)
+	}
+	hooks[CursorHookEvent] = evt
+	doc["hooks"] = hooks
+}
+
+func removeCursorHook(doc map[string]any) bool {
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		return false
+	}
+	evt, _ := hooks[CursorHookEvent].([]any)
+	idx := findCursorHookInArr(evt)
+	if idx < 0 {
+		return false
+	}
+	evt = append(evt[:idx], evt[idx+1:]...)
+	if len(evt) == 0 {
+		delete(hooks, CursorHookEvent)
+	} else {
+		hooks[CursorHookEvent] = evt
+	}
+	if len(hooks) == 0 {
+		delete(doc, "hooks")
+	}
+	return true
+}
+
+func findCursorHookIdx(doc map[string]any) int {
+	hooks, _ := doc["hooks"].(map[string]any)
+	if hooks == nil {
+		return -1
+	}
+	evt, _ := hooks[CursorHookEvent].([]any)
+	return findCursorHookInArr(evt)
+}
+
+// findCursorHookInArr scans a beforeShellExecution array for the entry whose
+// command carries our Marker. Returns its index, or -1.
+func findCursorHookInArr(evt []any) int {
+	for i, raw := range evt {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cmd, _ := m["command"].(string); cmdHasMarker(cmd) {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/install/agenthooks/host.go
+++ b/internal/install/agenthooks/host.go
@@ -1,0 +1,174 @@
+package agenthooks
+
+// This file defines the per-host capability model for the opt-in "query the
+// graph, don't grep your way around it" pre-tool nudge (#4238, #4276, #4297).
+//
+// BACKGROUND
+// ----------
+// The cross-host rules block (internal/install/rulesfiles) writes the standing
+// directive into every IDE's project-context file (CLAUDE.md, .cursorrules,
+// .windsurfrules, .codeium/instructions.md, .github/copilot-instructions.md).
+// Every supported host therefore ALREADY carries the guidance as passive
+// context.
+//
+// This package adds the ACTIVE reinforcement: a pre-tool hook that fires the
+// moment a structural grep is about to run and nudges toward the archigraph
+// MCP. A pre-tool hook is only possible on hosts that expose a programmable
+// pre-tool / pre-shell lifecycle surface. Most agent hosts do NOT. Rather than
+// fabricate a hook API for a host that lacks one, each host honestly declares
+// whether it supports a real pre-tool hook:
+//
+//   - SupportsHook() == true  → InstallHook writes a real, host-native hook.
+//   - SupportsHook() == false → InstallHook is a documented no-op; the rules
+//     file (written separately) carries the guidance. NoHookReason explains
+//     why, so `doctor`/reporting can be honest about the gap.
+//
+// PER-HOST CAPABILITY MATRIX (honest, researched)
+// -----------------------------------------------
+//
+//	Host          Pre-tool hook surface                         Hook?
+//	-----------   -------------------------------------------   -----
+//	Claude Code   .claude/settings.json PreToolUse (Bash/Grep)   YES
+//	Cursor        .cursor/hooks.json beforeShellExecution        YES
+//	Windsurf      rules + workflows, no pre-tool/-shell hook      no
+//	Codeium       no programmable pre-tool hook API               no
+//	Copilot       no programmable pre-tool hook API               no
+//
+// Adding a new host = implement Host and append it to Registry(). The shared
+// NudgeScript (nudge.go) is reused verbatim by every hooking host so the
+// behaviour (advisory-only, structural-heuristic, once-per-session) is
+// identical across hosts.
+
+// Host is one agent host's pre-tool-hook capability + installer. It mirrors
+// the ServiceManager / rulesfiles per-target pattern: a small interface with
+// one implementation per host and a deterministic registry.
+type Host interface {
+	// Name is the stable human-readable host name (e.g. "Claude Code").
+	Name() string
+
+	// SupportsHook reports whether this host exposes a real, programmable
+	// pre-tool / pre-shell hook surface. When false, InstallHook is a
+	// documented no-op and NoHookReason explains the gap.
+	SupportsHook() bool
+
+	// NoHookReason returns a one-line explanation of why this host has no
+	// pre-tool hook. Empty for hosts where SupportsHook() == true.
+	NoHookReason() string
+
+	// InstallHook upserts this host's pre-tool hook under repoRoot and
+	// returns the absolute path that was written. For a no-hook host it is a
+	// no-op returning ("", nil). Safe to call repeatedly (idempotent upsert).
+	InstallHook(repoRoot string) (string, error)
+
+	// UninstallHook removes this host's managed pre-tool hook (and any
+	// sidecar script) under repoRoot. A no-hook host is a no-op. Idempotent:
+	// a missing file or missing entry is not an error.
+	UninstallHook(repoRoot string) error
+
+	// IsHookInstalled reports whether this host's managed pre-tool hook is
+	// present under repoRoot. Always false for a no-hook host.
+	IsHookInstalled(repoRoot string) bool
+}
+
+// Registry returns the supported agent hosts in deterministic order. The
+// order is also the order in which install/uninstall iterate and in which
+// reporting lists them, so output is stable across runs.
+func Registry() []Host {
+	return []Host{
+		claudeCodeHost{},
+		cursorHost{},
+		// No-hook hosts: the rules file carries the guidance; the pre-tool
+		// hook is a documented no-op because the host has no hook surface.
+		instructionOnlyHost{
+			name:   "Windsurf",
+			reason: "Windsurf exposes rules (.windsurfrules) + workflows but no programmable pre-tool/pre-shell hook API; guidance is carried by the rules file.",
+		},
+		instructionOnlyHost{
+			name:   "Codeium",
+			reason: "Codeium has no programmable pre-tool hook API; guidance is carried by the .codeium/instructions.md rules file.",
+		},
+		instructionOnlyHost{
+			name:   "GitHub Copilot",
+			reason: "GitHub Copilot has no programmable pre-tool hook API; guidance is carried by the .github/copilot-instructions.md rules file.",
+		},
+	}
+}
+
+// HostCapability is a flat, reportable view of one host's hook capability,
+// produced by Capabilities(). Used by doctor/reporting to print an honest
+// per-host matrix without depending on the Host interface internals.
+type HostCapability struct {
+	// Name is the host name.
+	Name string
+	// SupportsHook is true when the host has a real pre-tool hook.
+	SupportsHook bool
+	// NoHookReason explains the gap when SupportsHook is false.
+	NoHookReason string
+}
+
+// Capabilities returns the per-host hook-capability matrix in registry order.
+func Capabilities() []HostCapability {
+	hosts := Registry()
+	out := make([]HostCapability, 0, len(hosts))
+	for _, h := range hosts {
+		out = append(out, HostCapability{
+			Name:         h.Name(),
+			SupportsHook: h.SupportsHook(),
+			NoHookReason: h.NoHookReason(),
+		})
+	}
+	return out
+}
+
+// ── package-level convenience API (back-compat with the single-host caller) ──
+
+// Install installs every supported host's pre-tool hook under repoRoot. Hosts
+// without a real hook surface are skipped (no-op). It returns the absolute
+// paths that were written (one per hooking host) and the first error
+// encountered.
+//
+// Back-compat: the previous single-host API returned one path; callers that
+// ignore the path (the installer) are unaffected. The Claude Code path is
+// always element 0 when present, preserving the historical "settings path"
+// expectation for any caller that reads paths[0].
+func Install(repoRoot string) ([]string, error) {
+	var written []string
+	for _, h := range Registry() {
+		if !h.SupportsHook() {
+			continue
+		}
+		p, err := h.InstallHook(repoRoot)
+		if err != nil {
+			return written, err
+		}
+		if p != "" {
+			written = append(written, p)
+		}
+	}
+	return written, nil
+}
+
+// Uninstall removes every supported host's managed pre-tool hook under
+// repoRoot. No-hook hosts are no-ops. It is idempotent and returns the first
+// error encountered (continuing past per-host no-ops).
+func Uninstall(repoRoot string) error {
+	var firstErr error
+	for _, h := range Registry() {
+		if err := h.UninstallHook(repoRoot); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// IsInstalled reports whether ANY supported host's managed pre-tool hook is
+// present under repoRoot. (Claude Code is the historical answer; a hook on any
+// hooking host now counts.)
+func IsInstalled(repoRoot string) bool {
+	for _, h := range Registry() {
+		if h.IsHookInstalled(repoRoot) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/install/agenthooks/host_test.go
+++ b/internal/install/agenthooks/host_test.go
@@ -1,0 +1,258 @@
+package agenthooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// hostByName fetches a registered host by display name, failing the test if
+// it is absent.
+func hostByName(t *testing.T, name string) Host {
+	t.Helper()
+	for _, h := range Registry() {
+		if h.Name() == name {
+			return h
+		}
+	}
+	t.Fatalf("host %q not in registry", name)
+	return nil
+}
+
+// TestRegistry_CapabilityMatrix asserts the honest per-host hook-capability
+// matrix: which hosts have a real pre-tool hook vs documented instruction-only.
+func TestRegistry_CapabilityMatrix(t *testing.T) {
+	want := map[string]bool{
+		"Claude Code":    true,
+		"Cursor":         true,
+		"Windsurf":       false,
+		"Codeium":        false,
+		"GitHub Copilot": false,
+	}
+	got := map[string]bool{}
+	for _, c := range Capabilities() {
+		got[c.Name] = c.SupportsHook
+		// No-hook hosts must explain why; hooking hosts must not.
+		if c.SupportsHook && c.NoHookReason != "" {
+			t.Errorf("%s supports a hook but has a NoHookReason: %q", c.Name, c.NoHookReason)
+		}
+		if !c.SupportsHook && c.NoHookReason == "" {
+			t.Errorf("%s has no hook but no NoHookReason explaining the gap", c.Name)
+		}
+	}
+	for name, sup := range want {
+		if got[name] != sup {
+			t.Errorf("host %q SupportsHook = %v, want %v", name, got[name], sup)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("registry hosts = %v, want exactly %v", got, want)
+	}
+}
+
+// TestClaudeCodeHost_HookInstalled verifies the existing Claude Code behavior
+// is preserved through the Host interface: a real hook file is written.
+func TestClaudeCodeHost_HookInstalled(t *testing.T) {
+	root := t.TempDir()
+	h := hostByName(t, "Claude Code")
+
+	p, err := h.InstallHook(root)
+	if err != nil {
+		t.Fatalf("InstallHook: %v", err)
+	}
+	if p != filepath.Join(root, SettingsRelPath) {
+		t.Fatalf("hook path = %q, want %q", p, filepath.Join(root, SettingsRelPath))
+	}
+	if !h.IsHookInstalled(root) {
+		t.Fatal("IsHookInstalled = false after InstallHook")
+	}
+	if _, err := os.Stat(filepath.Join(root, NudgeScriptRelPath)); err != nil {
+		t.Fatalf("nudge script not written: %v", err)
+	}
+}
+
+// TestCursorHost_RealHookWritten verifies a host with a real hook mechanism
+// writes its hook file (.cursor/hooks.json) into a faked install layout, with
+// the shared nudge script and the once-per-host marker. Also covers idempotent
+// re-install (no duplicate) and user-content preservation.
+func TestCursorHost_RealHookWritten(t *testing.T) {
+	root := t.TempDir()
+	h := hostByName(t, "Cursor")
+
+	// Seed a user-authored Cursor hook + an unrelated key that must survive.
+	seed := map[string]any{
+		"version": 1,
+		"hooks": map[string]any{
+			"beforeShellExecution": []any{
+				map[string]any{"command": "echo user-cursor-hook"},
+			},
+			"afterFileEdit": []any{
+				map[string]any{"command": "echo unrelated"},
+			},
+		},
+	}
+	seedBytes, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.MkdirAll(filepath.Join(root, ".cursor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, CursorHooksRelPath), seedBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install three times — must be idempotent.
+	var p string
+	for i := 0; i < 3; i++ {
+		var err error
+		p, err = h.InstallHook(root)
+		if err != nil {
+			t.Fatalf("InstallHook #%d: %v", i, err)
+		}
+	}
+	if p != filepath.Join(root, CursorHooksRelPath) {
+		t.Fatalf("hook path = %q, want %q", p, filepath.Join(root, CursorHooksRelPath))
+	}
+	if !h.IsHookInstalled(root) {
+		t.Fatal("IsHookInstalled = false after InstallHook")
+	}
+	// Shared nudge script written for Cursor.
+	if _, err := os.Stat(filepath.Join(root, CursorNudgeScriptRelPath)); err != nil {
+		t.Fatalf("cursor nudge script not written: %v", err)
+	}
+
+	doc := readCursorDoc(t, root)
+	hooks := doc["hooks"].(map[string]any)
+	evt := hooks[CursorHookEvent].([]any)
+
+	// Exactly one managed entry (no duplication across 3 installs) + the user's.
+	managed, user := 0, 0
+	for _, raw := range evt {
+		m := raw.(map[string]any)
+		cmd, _ := m["command"].(string)
+		if containsMarker(cmd) {
+			managed++
+		} else if cmd == "echo user-cursor-hook" {
+			user++
+		}
+	}
+	if managed != 1 {
+		t.Fatalf("managed cursor entries = %d, want 1", managed)
+	}
+	if user != 1 {
+		t.Fatalf("user cursor hook preserved = %d, want 1", user)
+	}
+	// Unrelated keys + events preserved.
+	if doc["version"] != float64(1) {
+		t.Fatalf("unrelated version key lost: %v", doc["version"])
+	}
+	if _, ok := hooks["afterFileEdit"]; !ok {
+		t.Fatal("unrelated afterFileEdit event dropped")
+	}
+
+	// Uninstall removes our entry + script, leaves the user's hook.
+	if err := h.UninstallHook(root); err != nil {
+		t.Fatalf("UninstallHook: %v", err)
+	}
+	if h.IsHookInstalled(root) {
+		t.Fatal("still installed after UninstallHook")
+	}
+	if _, err := os.Stat(filepath.Join(root, CursorNudgeScriptRelPath)); !os.IsNotExist(err) {
+		t.Fatalf("cursor nudge script not removed: %v", err)
+	}
+	doc2 := readCursorDoc(t, root)
+	evt2 := doc2["hooks"].(map[string]any)[CursorHookEvent].([]any)
+	if len(evt2) != 1 || evt2[0].(map[string]any)["command"] != "echo user-cursor-hook" {
+		t.Fatalf("user cursor hook not preserved on uninstall: %v", evt2)
+	}
+	// Idempotent second uninstall.
+	if err := h.UninstallHook(root); err != nil {
+		t.Fatalf("second UninstallHook: %v", err)
+	}
+}
+
+// TestInstructionOnlyHost_NoHookFile verifies a no-hook host writes NO hook
+// file and never errors — the rules file (written elsewhere) carries the
+// guidance. We assert the absence of any host-specific hook artifacts.
+func TestInstructionOnlyHost_NoHookFile(t *testing.T) {
+	for _, name := range []string{"Windsurf", "Codeium", "GitHub Copilot"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			h := hostByName(t, name)
+
+			p, err := h.InstallHook(root)
+			if err != nil {
+				t.Fatalf("InstallHook: %v", err)
+			}
+			if p != "" {
+				t.Fatalf("no-hook host wrote a hook path %q, want empty", p)
+			}
+			if h.IsHookInstalled(root) {
+				t.Fatal("no-hook host reports IsHookInstalled = true")
+			}
+			// No hook files of any kind were created.
+			entries, _ := os.ReadDir(root)
+			if len(entries) != 0 {
+				t.Fatalf("no-hook host created files %v, want none", entries)
+			}
+			// Honest gap is documented.
+			if h.NoHookReason() == "" {
+				t.Fatal("no-hook host missing NoHookReason")
+			}
+			// Uninstall is a no-op (no error).
+			if err := h.UninstallHook(root); err != nil {
+				t.Fatalf("UninstallHook no-op errored: %v", err)
+			}
+		})
+	}
+}
+
+// TestPackageInstall_AllHosts verifies the package-level Install installs every
+// hooking host (Claude Code + Cursor) and skips no-hook hosts, idempotently.
+func TestPackageInstall_AllHosts(t *testing.T) {
+	root := t.TempDir()
+
+	for i := 0; i < 2; i++ {
+		paths, err := Install(root)
+		if err != nil {
+			t.Fatalf("Install #%d: %v", i, err)
+		}
+		// Two hooking hosts → two written paths (Claude Code first for
+		// back-compat with callers that read paths[0]).
+		if len(paths) != 2 {
+			t.Fatalf("Install wrote %d paths, want 2: %v", len(paths), paths)
+		}
+		if paths[0] != filepath.Join(root, SettingsRelPath) {
+			t.Fatalf("paths[0] = %q, want Claude Code settings path", paths[0])
+		}
+	}
+
+	if !IsInstalled(root) {
+		t.Fatal("IsInstalled = false after Install")
+	}
+	// Both host hook files exist.
+	for _, rel := range []string{SettingsRelPath, CursorHooksRelPath} {
+		if _, err := os.Stat(filepath.Join(root, rel)); err != nil {
+			t.Fatalf("expected hook file %s: %v", rel, err)
+		}
+	}
+
+	if err := Uninstall(root); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if IsInstalled(root) {
+		t.Fatal("IsInstalled = true after Uninstall")
+	}
+}
+
+func readCursorDoc(t *testing.T, root string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, CursorHooksRelPath))
+	if err != nil {
+		t.Fatalf("read cursor hooks: %v", err)
+	}
+	doc := map[string]any{}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("parse cursor hooks: %v", err)
+	}
+	return doc
+}

--- a/internal/install/agenthooks/instructiononly.go
+++ b/internal/install/agenthooks/instructiononly.go
@@ -1,0 +1,34 @@
+package agenthooks
+
+// instructiononly.go is the Host implementation for agent hosts that have NO
+// programmable pre-tool / pre-shell hook surface (Windsurf, Codeium, GitHub
+// Copilot, …).
+//
+// For these hosts the honest answer is: the pre-tool hook is a documented
+// no-op. The "query the graph, don't grep" guidance still reaches the agent —
+// it is written into the host's project-context rules file by
+// internal/install/rulesfiles (.windsurfrules, .codeium/instructions.md,
+// .github/copilot-instructions.md). We deliberately do NOT fabricate a hook
+// API for a host that lacks one; InstallHook returns ("", nil) and
+// NoHookReason explains the gap for honest reporting.
+
+// instructionOnlyHost is a Host with no real pre-tool hook surface. All hook
+// operations are no-ops; the rules file (written elsewhere) carries the
+// guidance.
+type instructionOnlyHost struct {
+	name   string
+	reason string
+}
+
+func (h instructionOnlyHost) Name() string         { return h.name }
+func (instructionOnlyHost) SupportsHook() bool     { return false }
+func (h instructionOnlyHost) NoHookReason() string { return h.reason }
+
+// InstallHook is a documented no-op: no hook file is written.
+func (instructionOnlyHost) InstallHook(string) (string, error) { return "", nil }
+
+// UninstallHook is a no-op: there is nothing to remove.
+func (instructionOnlyHost) UninstallHook(string) error { return nil }
+
+// IsHookInstalled is always false: this host never has a pre-tool hook.
+func (instructionOnlyHost) IsHookInstalled(string) bool { return false }


### PR DESCRIPTION
## What

Completes #4297: broadens the opt-in "query the graph, don't grep" pre-tool HOOK beyond Claude Code. The per-host instruction/rules files were already done; this fills the pre-tool-hook gap, honestly, per host.

Refactors `internal/install/agenthooks` from a Claude-Code-only PreToolUse installer into a **per-host capability registry** (mirrors the ServiceManager / rulesfiles per-target pattern). Each host declares whether it exposes a real pre-tool / pre-shell hook surface and, if so, installs a host-native hook that runs the **shared** advisory nudge script. Hosts without a hook surface are honest, documented no-ops — the rules file carries the guidance.

## Per-host hook-capability matrix (honest, researched)

| Host | Pre-tool surface | Result |
|---|---|---|
| Claude Code | `.claude/settings.json` PreToolUse | **real hook** (existing, preserved) |
| Cursor | `.cursor/hooks.json` `beforeShellExecution` | **real hook** (new) |
| Windsurf | rules + workflows, no pre-tool hook API | instruction-file-only (documented no-op) |
| Codeium | no programmable pre-tool hook API | instruction-file-only (documented no-op) |
| GitHub Copilot | no programmable pre-tool hook API | instruction-file-only (documented no-op) |

No hook API was fabricated for a host that lacks one — `NoHookReason()` documents each gap for honest reporting.

## Changes
- `host.go` — `Host` interface, deterministic `Registry()`, `Capabilities()` matrix, package-level `Install`/`Uninstall`/`IsInstalled` iterating hosts.
- `claudecode.go` — existing JSON surgery preserved verbatim, wrapped as the Claude Code `Host` (behaviour unchanged).
- `cursor.go` — real `beforeShellExecution` hook with the same marker-based idempotent JSON round-trip; reuses the shared nudge script.
- `instructiononly.go` — documented no-op host for hosts lacking a hook API.

## Idempotency
Marker-tagged managed entries are upserted in place; re-install never duplicates, and user-authored hooks + unrelated keys are preserved on the JSON round-trip. Verified for both hooking hosts.

## Tests
`host_test.go` covers the capability matrix, Claude Code hook preserved, Cursor real hook written to a faked layout (+ idempotent re-install + user-content preservation + uninstall), no-hook hosts write no file / no error, and package-level all-hosts install. All agenthooks tests pass.

## Gates
- `go build ./...` ✅
- `go vet ./internal/install/... ./cmd/...` ✅
- `go test ./internal/install/... ./cmd/...` ✅ (one timing-flaky `TestColdLoadTiming` full-package blip; passes in isolation and on rerun)
- `coverage fmt --check` ✅ (no registry change — not a per-language extraction capability)

Closes #4297

🤖 Generated with [Claude Code](https://claude.com/claude-code)