### PR TITLE
feat(scala): complete ScalaTest/specs2 TESTS-edge linkage + drop scaffolding orphans (#4360)

### DIFF
--- a/internal/custom/scala/frameworks.go
+++ b/internal/custom/scala/frameworks.go
@@ -433,41 +433,17 @@ var (
 
 // ---------------------------------------------------------------------------
 // Testing regexes
+//
+// #4360 — the per-file `SCOPE.Test`/`test_suite` orphan that this extractor
+// previously emitted for every detected test file has been removed. It carried
+// no edges and no consumer (it was never wired into the route-hit e2e linker —
+// that uses the dedicated SCOPE.Operation/test_suite entity in
+// tests_route_e2e.go — nor into any other pass), so it only added orphan noise.
+// Subject-aware test→SUT TESTS edges for ScalaTest/specs2/MUnit leaves come
+// from the deep testmap linker (internal/extractors/cross/testmap,
+// detectScalaTest). The ScalaTest-detection regexes that only fed the dropped
+// orphan were removed with it.
 // ---------------------------------------------------------------------------
-
-var (
-	// ScalaTest: extends FlatSpec / WordSpec / AnyFlatSpec / FunSuite
-	reScalaTest = regexp.MustCompile(
-		`\b(?:extends\s+(?:AnyFlatSpec|FlatSpec|WordSpec|AnyWordSpec|FunSpec|AnyFunSpec|FunSuite|AnyFunSuite|FeatureSpec|PropSpec))\b`)
-
-	// Specs2: extends Specification
-	reSpecs2 = regexp.MustCompile(
-		`\bextends\s+(?:Specification|mutable\.Specification)\b`)
-
-	// MUnit (cats-effect, http4s): extends munit.FunSuite / munit.CatsEffectSuite
-	reMUnit = regexp.MustCompile(
-		`\bextends\s+(?:munit\.FunSuite|munit\.CatsEffectSuite|CatsEffectSuite)\b`)
-
-	// Akka TestKit: extends TestKit / extends ActorSpec
-	reAkkaTestKit = regexp.MustCompile(
-		`\bextends\s+(?:TestKit|ActorSpec|AkkaSpec|PekkoSpec|ScalaTestWithActorTestKit)\b`)
-
-	// http4s: Http4sClientDsl / Http4sMunitCirceSuite
-	reHttp4sTest = regexp.MustCompile(
-		`\bextends\s+(?:Http4sClientDsl|Http4sMunitCirceSuite|Http4sSuite)\b`)
-
-	// Cask: requests.get in test context
-	reCaskTest = regexp.MustCompile(
-		`\bTestServer\b|requests\.(get|post|put|delete)\s*\(`)
-
-	// ZIO Test: extends ZIOSpec / ZIOSpecDefault
-	reZioTest = regexp.MustCompile(
-		`\bextends\s+(?:ZIOSpec|ZIOSpecDefault|ZIOSpecAbstract)\b`)
-
-	// Finatra: extends HttpTest / FeatureTest
-	reFinatraTest = regexp.MustCompile(
-		`\bextends\s+(?:HttpTest|FeatureTest|TwitterServer|EmbeddedTwitterServer)\b`)
-)
 
 // ---------------------------------------------------------------------------
 // Extract
@@ -824,17 +800,14 @@ func (e *scalaFrameworksExtractor) Extract(ctx context.Context, file extractor.F
 	}
 
 	// ---------------------------------------------------------------------------
-	// Testing linkage
+	// Testing linkage — #4360
+	//
+	// The per-file `test_suite` orphan that used to be emitted here has been
+	// dropped (see the "Testing regexes" note above). Subject-aware test→SUT
+	// TESTS edges are produced by the deep testmap linker (detectScalaTest);
+	// route-hit e2e TESTS edges by tests_route_e2e.go. Nothing test-related is
+	// emitted from this extractor any more.
 	// ---------------------------------------------------------------------------
-	isTest := reScalaTest.MatchString(src) || reSpecs2.MatchString(src) || reMUnit.MatchString(src) ||
-		reAkkaTestKit.MatchString(src) || reHttp4sTest.MatchString(src) || reCaskTest.MatchString(src) ||
-		reZioTest.MatchString(src) || reFinatraTest.MatchString(src)
-
-	if isTest {
-		ent := makeEntity("test:"+fileBaseName(file.Path), "SCOPE.Test", "test_suite", file.Path, file.Language, 1)
-		setProps(&ent, "framework", framework, "provenance", "SCALA_TEST_SUITE")
-		add(ent)
-	}
 
 	return entities, nil
 }

--- a/internal/custom/scala/frameworks_test.go
+++ b/internal/custom/scala/frameworks_test.go
@@ -434,15 +434,14 @@ class UserServiceSpec extends AnyFlatSpec {
 }
 `
 	ents := extract(t, "custom_scala_frameworks", fi("UserServiceSpec.scala", "scala", src))
-	found := false
+	// #4360 — the per-file SCOPE.Test/test_suite orphan is no longer emitted
+	// from this extractor. It carried no edges and had no consumer. Subject-aware
+	// test→SUT TESTS edges now come solely from the deep testmap linker
+	// (detectScalaTest), and route-hit e2e edges from tests_route_e2e.go.
 	for _, e := range ents {
 		if e.Kind == "SCOPE.Test" && e.Subtype == "test_suite" {
-			found = true
-			break
+			t.Errorf("scaffolding orphan test_suite must not be emitted (#4360); got %q", e.Name)
 		}
-	}
-	if !found {
-		t.Error("expected test_suite entity for ScalaTest")
 	}
 }
 

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -1666,22 +1666,108 @@ func scalaFirstSpecType(source string) string {
 	return ""
 }
 
+// scalaFlatSpecSubjectRE captures the leading string-literal subject of a
+// ScalaTest FlatSpec / specs2 block: the quoted phrase immediately before the
+// `should` / `must` / `can` / `when` / `in` chaining verb that opens a spec
+// behaviour group. For `"OrderService" should "place an order" in { … }` group
+// 1 is `OrderService`. specs2's `"OrderService" should { … }` block form is
+// caught by the same shape. #4360 — Tier-2 subject affinity.
+var scalaFlatSpecSubjectRE = regexp.MustCompile(
+	`(?m)"([A-Za-z_][\w]*)"\s+(?:should|must|can|when)\b`,
+)
+
+// scalaNewSubjectRE captures a locally-constructed system-under-test:
+// `new OrderService(...)` / `new OrderService`. Group 1 is the type. #4360 —
+// Tier-3 subject affinity (instantiated SUT).
+var scalaNewSubjectRE = regexp.MustCompile(
+	`\bnew\s+([A-Z][\w]*)\b`,
+)
+
+// scalaMockSubjectRE captures a mockito-scala / scalamock SUT-shaped target:
+// `mock[OrderService]` / `mock[OrderService](...)`. Group 1 is the mocked type.
+// #4360 — Tier-3 subject affinity (mocked SUT).
+var scalaMockSubjectRE = regexp.MustCompile(
+	`\bmock\s*\[\s*([A-Z][\w]*)\s*\]`,
+)
+
+// scalaSubjectStopwords are common ScalaTest / specs2 / library type names that
+// the leading-literal (Tier 2) and `new`/`mock` (Tier 3) passes must never
+// surface as the production subject under test — they are test-harness or
+// stdlib constructs, not the SUT. Lower-cased for case-insensitive lookup is
+// not needed (these are exact type names), so they are matched verbatim.
+var scalaSubjectStopwords = map[string]bool{
+	// ScalaTest / specs2 fixtures & matchers commonly instantiated in a body.
+	"TestKit": true, "TestProbe": true, "ActorSystem": true, "Scheduler": true,
+	"FakeRequest": true, "TestData": true, "FixtureParam": true,
+	// stdlib / collection constructors that appear as `new X` but are never SUTs.
+	"String": true, "StringBuilder": true, "Array": true, "Exception": true,
+	"RuntimeException": true, "Throwable": true, "Random": true, "Date": true,
+}
+
+// scalaSubjectFromBody resolves a Tier-2/Tier-3 subject from a single leaf
+// body / spec source slice: a leading string-literal subject (`"X" should`),
+// then a locally-constructed `new X(...)`, then a `mock[X]`. Returns "" when no
+// honest subject is found (never a spurious guess). Stopword-filtered so
+// test-harness constructs are not mistaken for the SUT.
+func scalaSubjectFromBody(s string) string {
+	if m := scalaFlatSpecSubjectRE.FindStringSubmatch(s); m != nil {
+		if cand := m[1]; !scalaSubjectStopwords[cand] {
+			return cand
+		}
+	}
+	if m := scalaNewSubjectRE.FindStringSubmatch(s); m != nil {
+		if cand := m[1]; !scalaSubjectStopwords[cand] {
+			return cand
+		}
+	}
+	if m := scalaMockSubjectRE.FindStringSubmatch(s); m != nil {
+		if cand := m[1]; !scalaSubjectStopwords[cand] {
+			return cand
+		}
+	}
+	return ""
+}
+
 // detectScalaTest detects ScalaTest (FunSuite/FlatSpec/WordSpec/FunSpec),
 // specs2, MUnit and ZIO Test leaf cases. Every leaf is annotated with the
 // subject derived from the spec type name, so a TESTS edge is emitted even for
 // pure-naming-convention cases; leaves whose body contains a production call are
 // promoted by the resolver to high confidence.
 func detectScalaTest(source string) []testFunction {
-	subject := scalaSubjectFromSpecName(scalaFirstSpecType(source))
+	// Subject affinity — three honest tiers (#4360), most-trusted first:
+	//   Tier 1: spec-class stem convention (OrderServiceSpec → OrderService).
+	//   Tier 2: leading string-literal subject ("OrderService" should …).
+	//   Tier 3: a locally-constructed SUT (new OrderService(…) / mock[OrderService]).
+	// The file-level subject is the fallback (describeSubject) the resolver uses
+	// only when a leaf body has no direct production call; a per-leaf body SUT
+	// (Tier 2/3 inside the leaf) overrides it so each leaf links to the symbol it
+	// actually exercises. Empty subject ⇒ honest no fallback edge.
+	fileSubject := scalaSubjectFromSpecName(scalaFirstSpecType(source))
+	if fileSubject == "" {
+		fileSubject = scalaSubjectFromBody(source)
+	}
 
 	var out []testFunction
 	seen := map[string]bool{}
+	// flatSpecLeafEnds records the byte offset of the `{` that opens each
+	// FlatSpec `"subj" should "verb" in {` leaf. The WordSpec / specs2 leaf
+	// scan (`"…" in {`) overlaps the same `in {` token, so without this the
+	// finer FlatSpec leaf and a redundant `"verb" in {` leaf are both emitted
+	// for one test — a scaffolding duplicate (#4360). Tracking the consumed
+	// brace lets the WordSpec pass skip leaves already claimed by FlatSpec.
+	flatSpecLeafEnds := map[int]bool{}
 	add := func(rawName, body string) {
 		name := jestCaseQName(rawName)
 		if name == "" || seen[name] {
 			return
 		}
 		seen[name] = true
+		// Per-leaf subject: a SUT named/instantiated inside this leaf body wins
+		// over the file-level fallback; otherwise inherit the file subject.
+		subject := scalaSubjectFromBody(body)
+		if subject == "" {
+			subject = fileSubject
+		}
 		out = append(out, testFunction{qname: name, body: body, describeSubject: subject})
 	}
 
@@ -1698,6 +1784,9 @@ func detectScalaTest(source string) []testFunction {
 	// FlatSpec: "subject" should "verb" in { … }
 	for _, m := range scalaFlatSpecCaseRE.FindAllStringSubmatchIndex(source, -1) {
 		desc := source[m[2]:m[3]] + "_" + source[m[4]:m[5]]
+		// m[1] is the index just past the matched `{`; record the brace offset
+		// so the WordSpec leaf pass below can skip this same leaf.
+		flatSpecLeafEnds[m[1]-1] = true
 		add(desc, extractBraceBody(source, m[1]-1))
 	}
 	// FunSpec: it("…") { … }
@@ -1706,8 +1795,13 @@ func detectScalaTest(source string) []testFunction {
 	}
 	// WordSpec / specs2 leaf: "…" in { … } / "…" >> { … }. Scanned last so that
 	// the more specific FlatSpec/FunSpec forms claim their descriptions first
-	// (jestCaseQName de-dupes identical leaf names via `seen`).
+	// (jestCaseQName de-dupes identical leaf names via `seen`). A leaf whose
+	// opening `{` was already consumed by the FlatSpec pass is skipped so the
+	// same test is not emitted twice under a shorter, verb-only name (#4360).
 	for _, m := range scalaWordSpecLeafRE.FindAllStringSubmatchIndex(source, -1) {
+		if flatSpecLeafEnds[m[1]-1] {
+			continue
+		}
 		add(source[m[2]:m[3]], extractBraceBody(source, m[1]-1))
 	}
 

--- a/internal/extractors/cross/testmap/scala_subject_affinity_4360_test.go
+++ b/internal/extractors/cross/testmap/scala_subject_affinity_4360_test.go
@@ -1,0 +1,136 @@
+package testmap
+
+import "testing"
+
+// #4360 — ScalaTest / specs2 subject-affinity tiers + scaffolding-orphan drop.
+//
+// detectScalaTest resolves the production system-under-test (the TESTS-edge
+// target) via three honest tiers, most-trusted first:
+//
+//	Tier 1: spec-class stem convention (OrderServiceSpec → OrderService).
+//	Tier 2: leading string-literal subject ("OrderService" should …).
+//	Tier 3: a locally-constructed SUT (new OrderService(…) / mock[OrderService]).
+//
+// A leaf body's own direct production call always outranks the tiered fallback
+// (the resolver promotes it to high confidence); the tiers supply the
+// describeSubject the resolver falls back to when a leaf has no direct call.
+// When no tier resolves an in-repo subject, NO spurious subject edge is emitted.
+
+// Tier 1 — spec-class stem convention. FunSuite whose only body content is an
+// assertion still links to the SUT via the OrderServiceTest → OrderService stem.
+func TestScala4360_Tier1_SpecNameStem(t *testing.T) {
+	src := `import org.scalatest.funsuite.AnyFunSuite
+class OrderServiceTest extends AnyFunSuite {
+    test("places order") {
+        val sut = new OrderService(repo)
+        assert(true)
+    }
+}`
+	recs := runExtract(t, "OrderServiceTest.scala", "scala", src)
+	if !hasEdgeAny(recs, "it_places_order", "OrderService") {
+		t.Fatalf("Tier1: expected TESTS edge to OrderService (spec-name stem); recs=%+v", recs)
+	}
+}
+
+// Tier 2 — leading string-literal subject. The spec class name (OrderBehaviours)
+// has no Spec/Test suffix, and the leaf body contains only an assertion, so the
+// only SUT signal is the leading literal `"OrderService" should`.
+func TestScala4360_Tier2_LeadingLiteralSubject(t *testing.T) {
+	src := `import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+class OrderBehaviours extends AnyFlatSpec with Matchers {
+    "OrderService" should "place an order" in {
+        result shouldBe ok
+    }
+}`
+	recs := runExtract(t, "OrderBehaviours.scala", "scala", src)
+	if !hasEdgeAny(recs, "it_OrderService_place_an_order", "OrderService") {
+		t.Fatalf("Tier2: expected TESTS edge to OrderService (leading literal); recs=%+v", recs)
+	}
+}
+
+// Tier 3 — locally-constructed SUT. No Spec/Test suffix, no leading literal; the
+// only SUT signal is `new PaymentGateway(...)` in the body.
+func TestScala4360_Tier3_NewSubject(t *testing.T) {
+	src := `import org.scalatest.funsuite.AnyFunSuite
+class GatewayChecks extends AnyFunSuite {
+    test("charges the card") {
+        val sut = new PaymentGateway(cfg)
+        assert(sut != null)
+    }
+}`
+	recs := runExtract(t, "GatewayChecks.scala", "scala", src)
+	if !hasEdgeAny(recs, "it_charges_the_card", "PaymentGateway") {
+		t.Fatalf("Tier3: expected TESTS edge to PaymentGateway (new SUT); recs=%+v", recs)
+	}
+}
+
+// Tier 3 mock — `mock[InventoryService]`. The mocked type is the SUT; the body
+// call on the mock receiver resolves the production method.
+func TestScala4360_Tier3_MockSubject(t *testing.T) {
+	src := `import org.scalatest.funsuite.AnyFunSuite
+class StockChecks extends AnyFunSuite {
+    test("reserves stock") {
+        val svc = mock[InventoryService]
+        when(svc.reserve()).thenReturn(true)
+        assert(true)
+    }
+}`
+	recs := runExtract(t, "StockChecks.scala", "scala", src)
+	if !hasEdgeAny(recs, "it_reserves_stock", "svc.reserve") &&
+		!hasEdgeAny(recs, "it_reserves_stock", "InventoryService") {
+		t.Fatalf("Tier3-mock: expected TESTS edge to the mocked SUT; recs=%+v", recs)
+	}
+}
+
+// Scaffolding-orphan drop — a single FlatSpec leaf must yield exactly ONE test
+// entity, not a finer FlatSpec leaf PLUS a redundant verb-only WordSpec leaf for
+// the same `in {` block. Before #4360 the same test surfaced twice
+// (it_Subject_verb AND it_verb).
+func TestScala4360_NoDuplicateFlatSpecLeaf(t *testing.T) {
+	src := `import org.scalatest.flatspec.AnyFlatSpec
+class OrderBehaviours extends AnyFlatSpec {
+    "OrderService" should "place an order" in {
+        placeIt()
+    }
+}`
+	recs := runExtract(t, "OrderBehaviours.scala", "scala", src)
+	if len(recs) != 1 {
+		var names []string
+		for _, r := range recs {
+			names = append(names, r.Name)
+		}
+		t.Fatalf("expected exactly 1 test entity (no FlatSpec/WordSpec duplicate); got %d: %v", len(recs), names)
+	}
+	// The verb-only shorthand leaf must NOT appear as its own entity.
+	for _, r := range recs {
+		if r.Properties["test_function"] == "it_place_an_order" {
+			t.Errorf("redundant verb-only WordSpec leaf must be suppressed; got %q", r.Name)
+		}
+	}
+}
+
+// Negative — a spec with no in-repo SUT signal (no stem subject, no leading
+// literal, no new/mock) must not fabricate a high/medium subject edge from the
+// new tiers. (The pre-existing #4466 low-confidence naming-convention fallback
+// is unrelated to the tier work and is intentionally retained.)
+func TestScala4360_Negative_NoSpuriousSubject(t *testing.T) {
+	src := `import org.scalatest.funsuite.AnyFunSuite
+class RandomThings extends AnyFunSuite {
+    test("does stuff") {
+        assert(1 == 1)
+    }
+}`
+	recs := runExtract(t, "RandomThings.scala", "scala", src)
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind != "TESTS" {
+				continue
+			}
+			if c := rel.Properties["confidence"]; c == "high" || c == "medium" {
+				t.Errorf("no high/medium subject edge expected for an unresolvable spec; got %s -> %s [%s]",
+					r.Name, rel.ToID, c)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implements the **Scala axis** of #4360 — completing ScalaTest/specs2/MUnit TESTS-edge linkage (test→subject) and dropping test-DSL scaffolding orphans. The **RSpec/Minitest (Ruby) axis of #4360 was delivered separately via #4398** — this PR is Scala-only and touches no Ruby.

## 1. Subject-affinity tiers (`internal/extractors/cross/testmap/frameworks.go`, `detectScalaTest`)
When the spec-class stem yields no subject, the system-under-test is resolved via three honest tiers, most-trusted first:

| Tier | Signal | Example |
|------|--------|---------|
| 1 (existing) | spec-class stem convention | `OrderServiceSpec` / `OrderServiceTest` → `OrderService` |
| 2 (new) | leading string-literal subject | `"OrderService" should "…"` → `OrderService` |
| 3 (new) | locally-constructed SUT | `new OrderService(…)` / `mock[OrderService]` → `OrderService` |

- A per-leaf body SUT (Tier 2/3 *inside* the leaf) overrides the file-level fallback, so each leaf links to the symbol it actually exercises.
- A leaf body's own direct production call still wins (resolver promotes to high confidence); the tiers supply the medium-confidence `describeSubject` fallback used only when a leaf has no direct call.
- Stopword-filtered so test-harness / stdlib constructs (`TestKit`, `FakeRequest`, `String`, …) never masquerade as the SUT.
- **Unresolved ⇒ honest no subject edge.** (The pre-existing #4466 low-confidence naming-convention fallback is unrelated to the tiers and is intentionally retained.)

## 2. Scaffolding-orphan drop
- **Duplicate FlatSpec/WordSpec leaf**: `"subj" should "verb" in {` was emitted both as the finer FlatSpec leaf *and* a redundant verb-only specs2/WordSpec `"verb" in {` leaf for the same `in {` block. The FlatSpec brace offsets are now tracked so the WordSpec pass skips already-claimed leaves → **one entity per test**.
- **Edgeless per-file `test_suite` orphan**: `internal/custom/scala/frameworks.go` emitted a `SCOPE.Test`/`test_suite` entity (provenance `SCALA_TEST_SUITE`) for every test file. It carried no edges and had **no consumer anywhere** in the codebase. Removed (along with the now-dead ScalaTest-detection regexes that only fed it). The route-hit e2e linkage uses the **separate** `SCOPE.Operation`/`test_suite` in `tests_route_e2e.go` (#4756) and is **preserved** untouched.

## Validation (RED→GREEN)
New fixtures in `internal/extractors/cross/testmap/scala_subject_affinity_4360_test.go`: Tier-1/2/3 (incl. `mock[]`), the no-duplicate-leaf assertion, and the negative no-spurious-subject case. Confirmed the Tier-2 and dedup fixtures fail on `origin/main` and pass with this change. Existing `frameworks_test.go` ScalaTest test flipped to assert the orphan is **not** emitted.

## Coverage docs
Scala `tests_linkage` cell (`akka-http` / `http4s` / `pekko-http` / `play`) updated surgically via `coverage update` (notes + new cite + verified_at) — 8-line registry diff, no whole-file reserialize. `coverage fmt --check` ✅ and `coverage validate` ✅ (0 errors).

## Gates
`go build ./...` ✅ · `go vet ./internal/extractors/... ./internal/custom/...` ✅ · `go test ./internal/extractors/... ./internal/custom/... ./internal/engine/... ./internal/graph/... ./internal/types/` ✅ (95 packages, 0 failures) · `coverage fmt --check` ✅ · `coverage validate` ✅ (0 errors).

Closes #4360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)