### PR TITLE
feat(sql): column metadata flags on offline DDL schema extraction (part of #4295)

### DIFF
--- a/internal/extractors/sql/sql.go
+++ b/internal/extractors/sql/sql.go
@@ -3,6 +3,8 @@
 // Extracted entities:
 //   - CREATE TABLE        → Kind="SCOPE.Datastore", Subtype="table"
 //   - column              → Kind="SCOPE.Schema",    Subtype="column" (one per column inside a CREATE TABLE)
+//                           Properties: col_type, nullable, is_primary_key,
+//                           is_unique, default (Issue #4295)
 //   - CREATE VIEW         → Kind="SCOPE.Datastore", Subtype="view"
 //   - CREATE INDEX        → Kind="SCOPE.Datastore", Subtype="index"
 //   - CREATE FUNCTION     → Kind="SCOPE.Datastore", Subtype="function"
@@ -807,6 +809,22 @@ var (
 	// at the top level — used to filter constraint clauses.
 	columnIdentRE = regexp.MustCompile(`^\s*([A-Za-z_][A-Za-z0-9_]*)\b`)
 
+	// Issue #4295: column metadata flag parsing.
+	// notNullRE matches an explicit NOT NULL (word-boundary tolerant).
+	notNullRE = regexp.MustCompile(`(?i)\bNOT\s+NULL\b`)
+	// defaultRE captures the DEFAULT expression — a parenthesized group, a
+	// quoted literal, or a single bare token (function call / literal).
+	defaultRE = regexp.MustCompile(`(?i)\bDEFAULT\s+('(?:[^']|'')*'|"(?:[^"]|"")*"|\([^)]*\)|[^\s,]+)`)
+	// columnTypeRE captures the SQL type immediately following the column
+	// identifier: a type word, optional schema qualifier, optional length /
+	// precision parens, and trailing array brackets (Postgres). It is applied
+	// to the post-identifier remainder of a column definition.
+	columnTypeRE = regexp.MustCompile(`^\s*((?:\w+\.)?\w+(?:\s*\([^)]*\))?(?:\s*\[\s*\])*)`)
+	// table-level PRIMARY KEY (col, ...) and UNIQUE (col, ...) constraint
+	// clauses. Applied to the uppercased entry text.
+	tableLevelPKRE     = regexp.MustCompile(`^(?:CONSTRAINT\s+\w+\s+)?PRIMARY\s+KEY\s*\(\s*([^)]+?)\s*\)`)
+	tableLevelUniqueRE = regexp.MustCompile(`^(?:CONSTRAINT\s+\w+\s+)?UNIQUE\s*\(\s*([^)]+?)\s*\)`)
+
 	// Issue #389 (PORT-RELS-SQL): DML target detection inside view / function
 	// bodies. We attach READS_FROM / WRITES_TO edges from the surrounding
 	// scope entity (view or function) to each referenced table.
@@ -875,8 +893,28 @@ func parseTableBody(body, tableName, filePath string, tableStartLine int) ([]col
 	var cols []columnEntry
 	var fks []fkEntry
 
+	// Issue #4295: table-level PRIMARY KEY / UNIQUE constraint clauses name
+	// columns that are not flagged inline. Collect them in a first pass so the
+	// flags can be stamped onto the matching column entities below.
+	tablePKCols := map[string]bool{}
+	tableUniqueCols := map[string]bool{}
+
 	// Split top-level by commas (depth-aware: don't split inside parens).
 	entries := splitTopLevelCommas(body)
+
+	for _, raw := range entries {
+		upper := strings.ToUpper(strings.TrimSpace(raw))
+		if m := tableLevelPKRE.FindStringSubmatch(upper); m != nil {
+			for _, c := range splitAndTrim(m[1], ",") {
+				tablePKCols[strings.ToLower(unquoteIdent(c))] = true
+			}
+		} else if m := tableLevelUniqueRE.FindStringSubmatch(upper); m != nil {
+			for _, c := range splitAndTrim(m[1], ",") {
+				tableUniqueCols[strings.ToLower(unquoteIdent(c))] = true
+			}
+		}
+	}
+
 	lineCursor := tableStartLine
 	consumed := 0
 
@@ -944,6 +982,39 @@ func parseTableBody(body, tableName, filePath string, tableStartLine int) ([]col
 		// short column name is preserved in Properties["column"] for
 		// downstream consumers that need it without re-parsing.
 		qualName := tableName + "." + colName
+		props := map[string]string{
+			"table":  tableName,
+			"column": colName,
+		}
+
+		// Issue #4295: parse column metadata flags (type, nullable, PK,
+		// unique, default) from the remainder of the column definition.
+		// `rest` is the definition with the leading identifier stripped.
+		rest := strings.TrimSpace(entry[len(idMatch[0]):])
+		restUpper := strings.ToUpper(rest)
+
+		if colType := parseColumnType(rest); colType != "" {
+			props["col_type"] = colType
+		}
+
+		isPK := strings.Contains(restUpper, "PRIMARY KEY") || tablePKCols[strings.ToLower(colName)]
+		if isPK {
+			props["is_primary_key"] = "true"
+		}
+		if strings.Contains(restUpper, "UNIQUE") || tableUniqueCols[strings.ToLower(colName)] {
+			props["is_unique"] = "true"
+		}
+		// Nullability: a PK is implicitly NOT NULL. Otherwise honour an
+		// explicit NOT NULL; default to nullable when unspecified.
+		if isPK || notNullRE.MatchString(rest) {
+			props["nullable"] = "false"
+		} else {
+			props["nullable"] = "true"
+		}
+		if m := defaultRE.FindStringSubmatch(rest); m != nil {
+			props["default"] = strings.TrimSpace(m[1])
+		}
+
 		colEntity := types.EntityRecord{
 			Name:               qualName,
 			Kind:               "SCOPE.Schema",
@@ -955,10 +1026,7 @@ func parseTableBody(body, tableName, filePath string, tableStartLine int) ([]col
 			QualifiedName:      qualName,
 			Signature:          strings.TrimSpace(entry),
 			EnrichmentRequired: false,
-			Properties: map[string]string{
-				"table":  tableName,
-				"column": colName,
-			},
+			Properties:         props,
 		}
 		cols = append(cols, colEntity)
 	}
@@ -1004,6 +1072,45 @@ func splitAndTrim(s, sep string) []string {
 		}
 	}
 	return out
+}
+
+// parseColumnType extracts the SQL data type from the remainder of a column
+// definition (the text after the column identifier). It returns "" when the
+// leading token is a constraint keyword (i.e. the column has no explicit type,
+// e.g. "id PRIMARY KEY") rather than a real type.
+func parseColumnType(rest string) string {
+	m := columnTypeRE.FindStringSubmatch(rest)
+	if m == nil {
+		return ""
+	}
+	t := strings.TrimSpace(m[1])
+	// First word of the candidate type — reject when it is a constraint
+	// keyword so "id PRIMARY KEY" does not yield col_type="PRIMARY".
+	firstWord := strings.ToUpper(t)
+	if i := strings.IndexAny(firstWord, " ([\t"); i >= 0 {
+		firstWord = firstWord[:i]
+	}
+	switch firstWord {
+	case "PRIMARY", "FOREIGN", "CONSTRAINT", "UNIQUE", "CHECK", "REFERENCES",
+		"NOT", "NULL", "DEFAULT", "GENERATED", "COLLATE":
+		return ""
+	}
+	// Normalize internal whitespace (e.g. "VARCHAR (255)" -> "VARCHAR(255)").
+	t = strings.Join(strings.Fields(t), " ")
+	t = strings.ReplaceAll(t, " (", "(")
+	return t
+}
+
+// unquoteIdent strips surrounding double quotes or backticks from an SQL
+// identifier so column-name matching is quote-insensitive.
+func unquoteIdent(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '`' && s[len(s)-1] == '`') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }
 
 // isConstraintClause returns true when an entry (uppercased) is a top-level

--- a/internal/extractors/sql/sql_4295_test.go
+++ b/internal/extractors/sql/sql_4295_test.go
@@ -1,0 +1,143 @@
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findColumn returns the column entity for table.col, or nil.
+func findColumn(entities []types.EntityRecord, table, col string) *types.EntityRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "column" &&
+			e.Properties["table"] == table && e.Properties["column"] == col {
+			return e
+		}
+	}
+	return nil
+}
+
+// TestSQL4295_ColumnFlagsAndFK validates the offline DDL slice of #4295:
+// two tables + a FK -> two model entities, column field members carrying
+// type/nullable/PK/unique/default flags, and the users.org_id -> orgs FK edge.
+func TestSQL4295_ColumnFlagsAndFK(t *testing.T) {
+	src := loadFixture(t, "schema_4295_flags.sql")
+	entities := extractSQLBytes(t, src, "db/schema_4295_flags.sql")
+
+	// Two table model entities.
+	for _, tbl := range []string{"orgs", "users"} {
+		e := findEntity(entities, "SCOPE.Datastore", tbl)
+		if e == nil {
+			t.Fatalf("missing table entity %q", tbl)
+		}
+		if e.Subtype != "table" {
+			t.Errorf("table %q: subtype = %q, want table", tbl, e.Subtype)
+		}
+	}
+
+	// orgs.id: PK, not nullable, type present.
+	if c := findColumn(entities, "orgs", "id"); c == nil {
+		t.Fatal("missing orgs.id column")
+	} else {
+		if c.Properties["is_primary_key"] != "true" {
+			t.Errorf("orgs.id is_primary_key = %q, want true", c.Properties["is_primary_key"])
+		}
+		if c.Properties["nullable"] != "false" {
+			t.Errorf("orgs.id nullable = %q, want false (PK implies NOT NULL)", c.Properties["nullable"])
+		}
+		if c.Properties["col_type"] == "" {
+			t.Errorf("orgs.id col_type empty, want a type")
+		}
+	}
+
+	// orgs.name: NOT NULL + UNIQUE, type VARCHAR(255).
+	if c := findColumn(entities, "orgs", "name"); c == nil {
+		t.Fatal("missing orgs.name column")
+	} else {
+		if c.Properties["nullable"] != "false" {
+			t.Errorf("orgs.name nullable = %q, want false", c.Properties["nullable"])
+		}
+		if c.Properties["is_unique"] != "true" {
+			t.Errorf("orgs.name is_unique = %q, want true", c.Properties["is_unique"])
+		}
+		if c.Properties["col_type"] != "VARCHAR(255)" {
+			t.Errorf("orgs.name col_type = %q, want VARCHAR(255)", c.Properties["col_type"])
+		}
+	}
+
+	// users.email: NOT NULL, not PK, type TEXT, nullable=false.
+	if c := findColumn(entities, "users", "email"); c == nil {
+		t.Fatal("missing users.email column")
+	} else {
+		if c.Properties["nullable"] != "false" {
+			t.Errorf("users.email nullable = %q, want false", c.Properties["nullable"])
+		}
+		if c.Properties["is_primary_key"] == "true" {
+			t.Errorf("users.email wrongly flagged primary key")
+		}
+		if c.Properties["col_type"] != "TEXT" {
+			t.Errorf("users.email col_type = %q, want TEXT", c.Properties["col_type"])
+		}
+	}
+
+	// users.org_id: nullable (no NOT NULL), carries the FK.
+	if c := findColumn(entities, "users", "org_id"); c == nil {
+		t.Fatal("missing users.org_id column")
+	} else if c.Properties["nullable"] != "true" {
+		t.Errorf("users.org_id nullable = %q, want true", c.Properties["nullable"])
+	}
+
+	// users.status: DEFAULT 'active'.
+	if c := findColumn(entities, "users", "status"); c == nil {
+		t.Fatal("missing users.status column")
+	} else if c.Properties["default"] != "'active'" {
+		t.Errorf("users.status default = %q, want 'active'", c.Properties["default"])
+	}
+
+	// users.created_at: DEFAULT now() (function call captured whole).
+	if c := findColumn(entities, "users", "created_at"); c == nil {
+		t.Fatal("missing users.created_at column")
+	} else if c.Properties["default"] != "now()" {
+		t.Errorf("users.created_at default = %q, want now()", c.Properties["default"])
+	}
+
+	// The FK edge users.org_id -> orgs (REFERENCES). The relationship lives on
+	// the column entity; from_table/to(table+column) are carried as properties.
+	var foundFK bool
+	for i := range entities {
+		for _, rel := range entities[i].Relationships {
+			if rel.Kind == "REFERENCES" &&
+				rel.Properties["from_table"] == "users" &&
+				rel.ToID == "orgs" {
+				foundFK = true
+				if rel.Properties["to_column"] != "id" {
+					t.Errorf("FK to_column = %q, want id", rel.Properties["to_column"])
+				}
+				if c := findColumn(entities, "users", "org_id"); c != nil &&
+					entities[i].Name != c.Name {
+					t.Errorf("FK relationship on %q, want it on the org_id column", entities[i].Name)
+				}
+			}
+		}
+	}
+	if !foundFK {
+		t.Error("missing REFERENCES edge users.org_id -> orgs")
+	}
+}
+
+// TestSQL4295_SelectOnlyNoTable is the negative fixture: a query-only .sql
+// file emits no table model entity.
+func TestSQL4295_SelectOnlyNoTable(t *testing.T) {
+	src := loadFixture(t, "select_only_4295.sql")
+	entities := extractSQLBytes(t, src, "queries/select_only_4295.sql")
+
+	for i := range entities {
+		if entities[i].Kind == "SCOPE.Datastore" && entities[i].Subtype == "table" {
+			t.Errorf("SELECT-only file produced table entity %q", entities[i].Name)
+		}
+		if entities[i].Kind == "SCOPE.Schema" && entities[i].Subtype == "column" {
+			t.Errorf("SELECT-only file produced column entity %q", entities[i].Name)
+		}
+	}
+}

--- a/internal/extractors/sql/testdata/schema_4295_flags.sql
+++ b/internal/extractors/sql/testdata/schema_4295_flags.sql
@@ -1,0 +1,13 @@
+-- Issue #4295: two tables with a FK, exercising column metadata flags.
+CREATE TABLE orgs (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE
+);
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    email TEXT NOT NULL,
+    org_id INT REFERENCES orgs(id),
+    status VARCHAR(20) DEFAULT 'active',
+    created_at TIMESTAMP DEFAULT now()
+);

--- a/internal/extractors/sql/testdata/select_only_4295.sql
+++ b/internal/extractors/sql/testdata/select_only_4295.sql
@@ -1,0 +1,6 @@
+-- Issue #4295 negative fixture: a query-only file (no DDL) must not emit
+-- any table model entity.
+SELECT u.id, u.email, o.name
+FROM users u
+JOIN orgs o ON o.id = u.org_id
+WHERE u.status = 'active';


### PR DESCRIPTION
## Summary

Implements the **offline DDL slice of #4295** — column-level metadata extraction for the SQL relational-schema extractor. `Part of #4295` (live `information_schema` introspection stays a follow-up).

### Probe finding
`internal/extractors/sql/sql.go` already extracts the structural shape: `CREATE TABLE` → `SCOPE.Datastore`(table) + `SCOPE.Schema`(column) members via `CONTAINS`, plus FK `REFERENCES` edges in all three forms (inline `REFERENCES`, table-level `FOREIGN KEY`, and `ALTER TABLE ... ADD CONSTRAINT`), views/indexes/functions/triggers/dbt, and migration-file metadata stamping. The **gap** was column entities carrying only `table`/`column` props — no type/nullable/PK/unique/default. No new extractor or Kind needed; this fills the column-flag gap.

### What changed
`parseTableBody` now stamps each column entity with:
- `col_type` — SQL type (length/precision parens, Postgres array `[]`, schema-qualified), rejecting constraint keywords mis-read as types
- `nullable` — `false` for explicit `NOT NULL` or a PK (implicit NOT NULL), else `true`
- `is_primary_key`, `is_unique` — from inline flags **and** table-level `PRIMARY KEY (...)` / `UNIQUE (...)` constraint clauses stamped onto the named columns
- `default` — the `DEFAULT` expression (quoted literal, parenthesized group, or bare token / function call e.g. `now()`)

Dialect-tolerant (Postgres / MySQL / SQLite). No new graph Kind (reuses `SCOPE.Schema` column + `CONTAINS`/`REFERENCES`).

### Deferred (follow-ups under #4295)
- **LIVE `information_schema` introspection** (needs a DB connection) — the original #4295 scope; remains open.
- **Migration DSLs**: Rails `create_table`, Django `CreateModel` (Python/Ruby AST forms). Raw `.sql` DDL + `ALTER TABLE` are covered today; Flyway/Liquibase `.sql` flow through the raw-DDL path.

### Validation (fixtures RED→GREEN)
- `testdata/schema_4295_flags.sql` — two tables + FK → two table entities, column members with PK/NOT NULL/UNIQUE/type/default flags reflected, and the `users.org_id → orgs` `REFERENCES` edge (`TestSQL4295_ColumnFlagsAndFK`).
- `testdata/select_only_4295.sql` — a query-only `.sql` mints **no** table/column entity (`TestSQL4295_SelectOnlyNoTable`, negative).

### Coverage docs
`db.postgres` / `db.mysql` / `db.sqlite` `resource_extraction` cells updated surgically (the valid capability key for the `databases` category — `schema_extraction` is not permitted there) citing the new code + tests and noting the deferred live-introspection / migration-DSL axes. `coverage fmt --check` canonical, `coverage validate` 0 errors.

### Gates
`go build ./...`, `go vet ./internal/extractors/... ./internal/custom/...`, `go test ./internal/extractors/... ./internal/custom/... ./internal/graph/... ./internal/types/`, `coverage fmt --check`, `coverage validate` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
