### PR TITLE
feat(ingest): doc-ingestion L2 — agent-driven semantic emit + apply (#4308, #4309)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1362,6 +1362,29 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				"ingest-docs: %d markdown files → %d documents, %d sections, %d mentions (deterministic, no LLM)\n",
 				ingRes.FilesRead, ingRes.Documents, ingRes.Sections, ingRes.Mentions)
 		}
+
+		// #4308 (Layer 2 of epic #4294): emit per-Section semantic-extraction
+		// prompt bundles for the agent-driven path. STILL DETERMINISTIC — no LLM
+		// call, no network: this writes self-contained bundle artifacts an
+		// EXTERNAL agent picks up (runs its own LLM) and feeds back via
+		// archigraph_apply_doc_semantics. Persisted under the per-repo state dir,
+		// mirroring the docgen run-dir/artifact convention. Best-effort: a write
+		// failure never fails the index.
+		bundles := ingest.EmitSemanticBundles(absRepo, i.repoTag, mdFiles, doc.Entities)
+		if len(bundles) > 0 {
+			runDir := filepath.Join(daemon.StateDirForRepo(absRepo), "doc-semantics")
+			written := 0
+			for _, b := range bundles {
+				if _, err := ingest.WriteBundle(runDir, b); err == nil {
+					written++
+				}
+			}
+			if verbose() {
+				fmt.Fprintf(os.Stderr,
+					"ingest-docs-l2: emitted %d semantic prompt bundles → %s (agent-driven, no LLM)\n",
+					written, runDir)
+			}
+		}
 	}
 	// Drop the per-pass record slices now that buildDocument has produced
 	// the merged + deduped graph.Entity / graph.Relationship slices. These

--- a/internal/ingest/semantic.go
+++ b/internal/ingest/semantic.go
@@ -1,0 +1,363 @@
+// Package ingest — Layer 2 (agent-driven semantic) doc ingestion: the EMIT step
+// (issue #4308, epic #4294).
+//
+// Layer 1 (markdown.go / ingest.go) is fully deterministic: it produces
+// Document/Section nodes and exact-match MENTIONS edges with NO LLM call. Layer
+// 2 is the OPT-IN, agent-driven semantic enrichment on top of those Sections,
+// and it preserves the same core invariant: archigraph makes ZERO LLM calls.
+//
+// This file is the EMIT half. For each L1 Section it produces a serialisable
+// SemanticBundle carrying the section's prose, grounding context (the code
+// entities the section MENTIONS), and an extraction SCHEMA telling an EXTERNAL
+// agent what semantic nodes/edges to extract (classify the section as a
+// DesignDecision / Rationale / Spec, and extract rationale relationships to the
+// code entities it references). archigraph EMITS the bundle only; the external
+// agent (a Claude Code skill, not this code) runs the LLM and writes back a
+// SemanticRunResult, which the APPLY half (semantic_apply.go, #4309) validates
+// and merges into the graph.
+//
+// This mirrors the docgen --llm-mode=emit pattern (internal/docgen/llm_bundle.go:
+// LLMPromptBundle / LLMRunResult) and the archigraph_enrichments emit→submit
+// candidate pattern. No LLM calls, no network, no API keys.
+package ingest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// SemanticBundleVersion is the schema version embedded in every bundle and
+// echoed back in the result. Bumped on breaking changes. Mirrors
+// docgen.LLMBundleVersion.
+const SemanticBundleVersion = "1"
+
+// SemanticClass is one of the closed set of section classifications an agent is
+// allowed to assign. Keeping this a closed set (rather than free-form) is what
+// lets the apply step reject hallucinated classes deterministically.
+type SemanticClass string
+
+const (
+	// SemanticClassDesignDecision — the section records a design decision (a
+	// choice made, with the alternatives or trade-offs).
+	SemanticClassDesignDecision SemanticClass = "DesignDecision"
+	// SemanticClassRationale — the section explains WHY something is the way it
+	// is (justification/reasoning) without necessarily recording a decision.
+	SemanticClassRationale SemanticClass = "Rationale"
+	// SemanticClassSpec — the section states a specification / requirement /
+	// contract that code must satisfy.
+	SemanticClassSpec SemanticClass = "Spec"
+	// SemanticClassConstraint — the section states a constraint / invariant /
+	// limitation.
+	SemanticClassConstraint SemanticClass = "Constraint"
+	// SemanticClassNone — the section carries no extractable semantic claim
+	// (narrative, boilerplate, TOC, etc.). An agent returning None for a section
+	// is the honest "nothing here" answer and yields no semantic node.
+	SemanticClassNone SemanticClass = "None"
+)
+
+// allSemanticClasses is the closed set the apply step validates against.
+var allSemanticClasses = map[SemanticClass]bool{
+	SemanticClassDesignDecision: true,
+	SemanticClassRationale:      true,
+	SemanticClassSpec:           true,
+	SemanticClassConstraint:     true,
+	SemanticClassNone:           true,
+}
+
+// IsValidSemanticClass reports whether c is one of the closed-set classes.
+func IsValidSemanticClass(c SemanticClass) bool { return allSemanticClasses[c] }
+
+// SemanticBundle is the top-level emit artifact for ONE document's worth of
+// sections. It is self-contained: an external agent needs nothing but this JSON
+// to run its LLM and produce a SemanticRunResult. Mirrors the envelope shape of
+// docgen.LLMPromptBundle.
+type SemanticBundle struct {
+	// Version is the schema version ("1").
+	Version string `json:"version"`
+	// RepoTag is the per-repo slug stamped into entity IDs (matches the IDs in
+	// SectionID / candidate target IDs).
+	RepoTag string `json:"repo_tag"`
+	// DocumentID is the SCOPE.MarkdownDocument entity ID these sections belong to.
+	DocumentID string `json:"document_id"`
+	// DocRelPath is the repo-relative slash path of the source markdown file.
+	DocRelPath string `json:"doc_rel_path"`
+	// Sections holds one prompt entry per L1 Section in the document.
+	Sections []SemanticSectionPrompt `json:"sections"`
+	// Schema is the extraction instruction set (closed-set classes + the edge
+	// kind + agent-facing guidance). Repeated in the bundle so the artifact is
+	// self-describing for an agent that has never seen archigraph.
+	Schema SemanticExtractionSchema `json:"schema"`
+	// PromptHash is the bundle-level cache key (sha256 over per-section hashes).
+	// The result must echo it so apply can detect a stale/mismatched result.
+	PromptHash string `json:"prompt_hash"`
+	// GeneratedAt is the RFC3339 timestamp when the bundle was built.
+	GeneratedAt string `json:"generated_at"`
+}
+
+// SemanticSectionPrompt is the per-section payload an agent classifies.
+type SemanticSectionPrompt struct {
+	// SectionID is the SCOPE.Section entity ID. The result references it so the
+	// produced DesignDecision node can be anchored back (CONTAINS) to it.
+	SectionID string `json:"section_id"`
+	// Heading is the section's heading text (or anchor for headingless spans).
+	Heading string `json:"heading"`
+	// Depth is the ATX heading depth (1..6).
+	Depth int `json:"depth"`
+	// StartLine / EndLine locate the section in the source file (for the agent's
+	// context and for get_source-style quoting).
+	StartLine int `json:"start_line"`
+	EndLine   int `json:"end_line"`
+	// Body is the section's OWN direct prose (no nested subsection text), the
+	// text the agent classifies and reasons over.
+	Body string `json:"body"`
+	// MentionTargets are the code entities this section already MENTIONS (from
+	// L1 exact-match linking). These are the ONLY entity IDs an agent may cite
+	// as rationale targets — grounding the agent to entities the section
+	// demonstrably references keeps the apply step's "target must exist + be
+	// referenced" validation tight and prevents invented edges.
+	MentionTargets []SemanticTarget `json:"mention_targets"`
+	// PromptHash is the per-section cache key (sha256). Additive; omitted empty.
+	PromptHash string `json:"prompt_hash,omitempty"`
+}
+
+// SemanticTarget is one grounded code-entity reference an agent may use as a
+// rationale target.
+type SemanticTarget struct {
+	// ID is the code entity's graph ID (the RATIONALE_FOR edge will point here).
+	ID string `json:"id"`
+	// Name is the entity's short name (for the agent's readability).
+	Name string `json:"name"`
+	// Kind is the entity kind (e.g. "function", "class").
+	Kind string `json:"kind"`
+}
+
+// SemanticExtractionSchema is the agent-facing instruction set embedded in the
+// bundle. It is intentionally declarative + closed-set so the apply step can
+// validate against the exact same constants.
+type SemanticExtractionSchema struct {
+	// Classes is the closed set of allowed classifications.
+	Classes []SemanticClass `json:"classes"`
+	// EdgeKind is the relationship kind a rationale link becomes (RATIONALE_FOR).
+	EdgeKind string `json:"edge_kind"`
+	// Guidance is human/agent-readable prose telling the agent what to do.
+	Guidance string `json:"guidance"`
+	// MaxSummaryWords bounds the agent's distilled summary per section.
+	MaxSummaryWords int `json:"max_summary_words"`
+}
+
+// defaultSemanticSchema is the single, deterministic extraction schema embedded
+// in every bundle. Kept here (not config) so emit + apply share one source of
+// truth, mirroring docgen.defaultSectionGuidance.
+func defaultSemanticSchema() SemanticExtractionSchema {
+	return SemanticExtractionSchema{
+		Classes: []SemanticClass{
+			SemanticClassDesignDecision,
+			SemanticClassRationale,
+			SemanticClassSpec,
+			SemanticClassConstraint,
+			SemanticClassNone,
+		},
+		EdgeKind:        "RATIONALE_FOR",
+		MaxSummaryWords: 60,
+		Guidance: "For each section, classify its prose as exactly one of `classes`. " +
+			"Choose `None` when the section states no design decision, rationale, spec, or constraint " +
+			"(e.g. a table of contents, narrative intro, or changelog) — returning None is the correct, " +
+			"honest answer and produces no node. For any non-None class, write a `summary` (<= " +
+			"max_summary_words words) distilling the decision/rationale/spec/constraint in your own words, " +
+			"and list `rationale_target_ids`: the subset of this section's `mention_targets` IDs that the " +
+			"claim actually justifies or constrains. You MUST NOT invent target IDs — only IDs present in " +
+			"this section's mention_targets are permitted; any other ID will be rejected. Each accepted " +
+			"non-None classification becomes a SCOPE.DesignDecision node anchored to the section, with one " +
+			"RATIONALE_FOR edge to each cited target. archigraph runs NO LLM — you (the calling agent) run " +
+			"the model; archigraph only validates and applies what you return.",
+	}
+}
+
+// EmitSemanticBundles runs the L1 markdown pipeline over mdRelPaths and emits
+// one SemanticBundle per document (the #4308 emit step). It mirrors Ingest's
+// parse → section-ID-stamp → exact-mention-link sequence so the bundles carry
+// EXACTLY the section IDs and MENTIONS targets that L1 produced — keeping emit
+// and the deterministic graph in lockstep. archigraph makes NO LLM call here.
+//
+// repoRoot/repoTag/codeEntities have the same meaning as in Ingest. Bundles for
+// documents with no sections are skipped. Output is deterministic (files sorted,
+// sections in source order).
+func EmitSemanticBundles(repoRoot, repoTag string, mdRelPaths []string, codeEntities []graph.Entity) []SemanticBundle {
+	// Build the same name index Ingest uses for exact-match linking.
+	tuples := make([]NameTuple, 0, len(codeEntities))
+	idByID := make(map[string]*graph.Entity, len(codeEntities))
+	for i := range codeEntities {
+		e := &codeEntities[i]
+		idByID[e.ID] = e
+		tuples = append(tuples, NameTuple{Name: e.Name, QualifiedName: e.QualifiedName, ID: e.ID, Kind: e.Kind})
+	}
+	nameIdx := IndexNames(tuples)
+
+	paths := append([]string(nil), mdRelPaths...)
+	sort.Strings(paths)
+
+	var bundles []SemanticBundle
+	for _, rel := range paths {
+		rel = filepath.ToSlash(rel)
+		abs := filepath.Join(repoRoot, filepath.FromSlash(rel))
+		content, err := readBoundedFile(abs, maxDocBytes)
+		if err != nil {
+			continue
+		}
+		doc, sections := ParseDocument(rel, content)
+		if len(sections) == 0 {
+			continue
+		}
+
+		// Stamp section IDs identically to Ingest so the bundle references the
+		// SAME SCOPE.Section entity IDs present in the graph.
+		docID := graph.EntityID(repoTag, string(types.EntityKindMarkdownDocument), rel, rel)
+		sectionIDs := make([]string, len(sections))
+		for k := range sections {
+			s := &sections[k]
+			name := fmt.Sprintf("%s#L%d", rel, s.StartLine)
+			sectionIDs[k] = graph.EntityID(repoTag, string(types.EntityKindSection), name, rel)
+		}
+
+		// L1 mentions → grounded per-section targets.
+		mentionsBySection := map[int][]SemanticTarget{}
+		for _, m := range LinkMentions(sections, nameIdx) {
+			name, kind := m.Token, m.TargetKind
+			if e := idByID[m.TargetID]; e != nil {
+				name = e.Name
+			}
+			mentionsBySection[m.SectionIndex] = append(mentionsBySection[m.SectionIndex], SemanticTarget{
+				ID: m.TargetID, Name: name, Kind: kind,
+			})
+		}
+
+		_ = doc // Title not needed in the bundle; ParseDocument shares the parse.
+		bundles = append(bundles, EmitDocumentBundle(repoTag, docID, rel, sections, sectionIDs, mentionsBySection))
+	}
+	return bundles
+}
+
+// EmitDocumentBundle builds a SemanticBundle for one document's sections.
+//
+// docID is the SCOPE.MarkdownDocument entity ID; docRelPath its repo-relative
+// slash path; sectionIDs[k] is the SCOPE.Section entity ID for sections[k] (as
+// stamped by Ingest). mentionsBySection maps a section index to the code
+// entities that section MENTIONS (from L1 linking) — these become the bundle's
+// grounded targets. repoTag is stamped into the artifact for traceability.
+//
+// Fully deterministic given identical inputs: the same graph state always
+// yields the same PromptHash. No LLM call, no network.
+func EmitDocumentBundle(repoTag, docID, docRelPath string, sections []Section, sectionIDs []string, mentionsBySection map[int][]SemanticTarget) SemanticBundle {
+	b := SemanticBundle{
+		Version:     SemanticBundleVersion,
+		RepoTag:     repoTag,
+		DocumentID:  docID,
+		DocRelPath:  docRelPath,
+		Schema:      defaultSemanticSchema(),
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	for k := range sections {
+		s := &sections[k]
+		secID := ""
+		if k < len(sectionIDs) {
+			secID = sectionIDs[k]
+		}
+		targets := append([]SemanticTarget(nil), mentionsBySection[k]...)
+		// Deterministic target ordering.
+		sort.SliceStable(targets, func(a, c int) bool { return targets[a].ID < targets[c].ID })
+
+		sp := SemanticSectionPrompt{
+			SectionID:      secID,
+			Heading:        headingOrAnchor(s.HeadingText, s.StartLine),
+			Depth:          s.Depth,
+			StartLine:      s.StartLine,
+			EndLine:        s.EndLine,
+			Body:           s.Body,
+			MentionTargets: targets,
+		}
+		sp.PromptHash = sectionPromptHash(repoTag, secID, sp.Body, targets)
+		b.Sections = append(b.Sections, sp)
+	}
+
+	b.PromptHash = bundlePromptHash(&b)
+	return b
+}
+
+// sectionPromptHash is the per-section cache key: a stable sha256 over the
+// identity + content that determines the agent's task. Mirrors docgen's
+// per-section prompt_hash design.
+func sectionPromptHash(repoTag, sectionID, body string, targets []SemanticTarget) string {
+	h := sha256.New()
+	h.Write([]byte(SemanticBundleVersion))
+	h.Write([]byte{0})
+	h.Write([]byte(repoTag))
+	h.Write([]byte{0})
+	h.Write([]byte(sectionID))
+	h.Write([]byte{0})
+	h.Write([]byte(body))
+	for _, t := range targets {
+		h.Write([]byte{0})
+		h.Write([]byte(t.ID))
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// bundlePromptHash is the bundle-level cache key: sha256 over the per-section
+// hashes in order. Mirrors docgen's bundle-hash design.
+func bundlePromptHash(b *SemanticBundle) string {
+	h := sha256.New()
+	for i := range b.Sections {
+		h.Write([]byte(b.Sections[i].PromptHash))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// WriteBundle serialises a SemanticBundle as indented JSON to
+// <runDir>/<documentID>.bundle.json, creating runDir if needed. Mirrors the
+// docgen run-dir artifact convention (one bundle file per unit of work).
+// Returns the written path.
+func WriteBundle(runDir string, b SemanticBundle) (string, error) {
+	if runDir == "" {
+		return "", fmt.Errorf("ingest: WriteBundle: empty run dir")
+	}
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return "", fmt.Errorf("ingest: create run dir %q: %w", runDir, err)
+	}
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("ingest: marshal bundle: %w", err)
+	}
+	name := b.DocumentID
+	if name == "" {
+		name = "document"
+	}
+	path := filepath.Join(runDir, name+".bundle.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("ingest: write bundle %q: %w", path, err)
+	}
+	return path, nil
+}
+
+// ReadBundle reads and unmarshals a SemanticBundle from disk.
+func ReadBundle(path string) (SemanticBundle, error) {
+	var b SemanticBundle
+	data, err := os.ReadFile(path) //nolint:gosec // path from a run-dir listing
+	if err != nil {
+		return b, fmt.Errorf("ingest: read bundle %q: %w", path, err)
+	}
+	if err := json.Unmarshal(data, &b); err != nil {
+		return b, fmt.Errorf("ingest: unmarshal bundle %q: %w", path, err)
+	}
+	return b, nil
+}

--- a/internal/ingest/semantic_apply.go
+++ b/internal/ingest/semantic_apply.go
@@ -1,0 +1,289 @@
+// Package ingest — Layer 2 (agent-driven semantic) doc ingestion: the APPLY
+// step (issue #4309, epic #4294).
+//
+// This is the apply half of the emit→apply candidate pattern begun in
+// semantic.go. An EXTERNAL agent read a SemanticBundle (emitted by
+// EmitDocumentBundle), ran its own LLM, and wrote back a SemanticRunResult. THIS
+// file reads that result, VALIDATES it against the closed-set schema and the
+// current graph (rejecting malformed or unfounded results — honest partial),
+// and produces the SCOPE.DesignDecision nodes + CONTAINS/RATIONALE_FOR edges to
+// splice into the graph.
+//
+// archigraph makes NO LLM call here — it only validates and applies what the
+// agent produced, exactly like docgen.ApplyResult and
+// enrichment.ApplyDocgenRepairsToResolutions.
+//
+// IDEMPOTENCY: node and edge IDs are derived deterministically from stable
+// identity (section ID + decision class + summary for nodes; from/to/kind for
+// edges, via graph.RelationshipID), so re-applying the same result produces the
+// same IDs and a caller that dedups by ID never doubles up.
+package ingest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// SemanticRunResult is the envelope an external agent writes back after
+// classifying a bundle's sections. Its Version + PromptHash must match the
+// bundle it was produced from so the apply step can reject a stale/mismatched
+// result. Mirrors docgen.LLMRunResult.
+type SemanticRunResult struct {
+	// Version must equal the bundle's SemanticBundleVersion.
+	Version string `json:"version"`
+	// PromptHash must equal SemanticBundle.PromptHash.
+	PromptHash string `json:"prompt_hash"`
+	// DocumentID echoes the bundle's DocumentID.
+	DocumentID string `json:"document_id"`
+	// SectionResults holds one result per classified section. A section the
+	// agent classified as None may be omitted or included with class None; both
+	// are accepted and produce no node.
+	SectionResults []SemanticSectionResult `json:"section_results"`
+	// FilledAt is the RFC3339 timestamp the agent finished (informational).
+	FilledAt string `json:"filled_at"`
+}
+
+// SemanticSectionResult is the agent's classification of one section.
+type SemanticSectionResult struct {
+	// SectionID must match a SemanticSectionPrompt.SectionID in the bundle.
+	SectionID string `json:"section_id"`
+	// Class is the agent's chosen classification (closed set).
+	Class SemanticClass `json:"class"`
+	// Summary is the agent's distilled claim (required for non-None classes).
+	Summary string `json:"summary"`
+	// RationaleTargetIDs are the code-entity IDs this claim justifies. Each MUST
+	// be one of the section's bundle MentionTargets (grounding) AND exist in the
+	// current graph; unfounded IDs are rejected.
+	RationaleTargetIDs []string `json:"rationale_target_ids"`
+}
+
+// ApplyStats summarises an apply run. Mirrors the per-repo accounting returned
+// by enrichment.ApplyDocgenRepairsToResolutions.
+type ApplyStats struct {
+	// DecisionsCreated is the number of SCOPE.DesignDecision nodes produced.
+	DecisionsCreated int `json:"decisions_created"`
+	// RationaleEdges is the number of RATIONALE_FOR edges produced.
+	RationaleEdges int `json:"rationale_edges"`
+	// AnchorEdges is the number of Section→DesignDecision CONTAINS edges.
+	AnchorEdges int `json:"anchor_edges"`
+	// SectionsClassified is the number of non-None sections accepted.
+	SectionsClassified int `json:"sections_classified"`
+	// SectionsNone is the number of sections the agent classified as None.
+	SectionsNone int `json:"sections_none"`
+	// RejectedTargets is the number of cited target IDs dropped because they
+	// were not grounded mention-targets or did not exist in the graph. A
+	// non-zero value is an HONEST PARTIAL: the decision node is still created,
+	// but the unfounded edge is omitted rather than corrupting the graph.
+	RejectedTargets int `json:"rejected_targets"`
+}
+
+// ApplyResult is the validated output of an apply run, ready to splice into the
+// graph document (append entities + relationships; a caller that dedups by ID
+// gets idempotency for free).
+type SemanticApplyResult struct {
+	Entities      []graph.Entity
+	Relationships []graph.Relationship
+	Stats         ApplyStats
+}
+
+// codeEntityRef is the minimal projection of a graph entity the apply step needs
+// to confirm a cited rationale target exists.
+type codeEntityRef struct {
+	ID   string
+	Name string
+	Kind string
+}
+
+// ApplySemanticResult validates a SemanticRunResult against its bundle and the
+// set of code entities currently in the graph, then produces the semantic
+// nodes/edges. It returns an error ONLY for envelope-level corruption (version
+// mismatch, stale prompt hash, unknown section, malformed class) — those reject
+// the WHOLE result with a clear message and produce nothing (no partial
+// corruption). Per-target grounding failures are NOT fatal: they are dropped
+// and counted in Stats.RejectedTargets (honest partial), so one bad target ID
+// does not sink an otherwise-valid decision.
+//
+// codeEntities is the current graph entity set (used to confirm cited targets
+// exist). Doc/Section/DesignDecision nodes are NOT valid rationale targets — a
+// rationale edge always points at a CODE entity — so they are excluded.
+//
+// Idempotent: identical (bundle, result) inputs yield identical entity/edge IDs.
+func ApplySemanticResult(bundle SemanticBundle, result SemanticRunResult, codeEntities []graph.Entity) (SemanticApplyResult, error) {
+	var out SemanticApplyResult
+
+	// Envelope validation 1: version.
+	if result.Version != bundle.Version {
+		return out, fmt.Errorf("ingest: semantic apply: result version %q != bundle version %q", result.Version, bundle.Version)
+	}
+	// Envelope validation 2: prompt hash (stale/mismatched result).
+	if result.PromptHash != bundle.PromptHash {
+		return out, fmt.Errorf("ingest: semantic apply: stale result: prompt_hash %q != bundle %q", result.PromptHash, bundle.PromptHash)
+	}
+
+	// Index the bundle's sections by ID, and each section's grounded targets.
+	type secInfo struct {
+		prompt  SemanticSectionPrompt
+		targets map[string]bool // grounded mention-target IDs for this section
+	}
+	bySection := make(map[string]secInfo, len(bundle.Sections))
+	for _, sp := range bundle.Sections {
+		tg := make(map[string]bool, len(sp.MentionTargets))
+		for _, t := range sp.MentionTargets {
+			tg[t.ID] = true
+		}
+		bySection[sp.SectionID] = secInfo{prompt: sp, targets: tg}
+	}
+
+	// Index code entities for existence checks. Exclude doc-layer nodes: a
+	// rationale edge must point at code, never at another doc/section/decision.
+	code := make(map[string]codeEntityRef, len(codeEntities))
+	for i := range codeEntities {
+		e := &codeEntities[i]
+		switch e.Kind {
+		case string(types.EntityKindMarkdownDocument),
+			string(types.EntityKindSection),
+			string(types.EntityKindDesignDecision):
+			continue
+		}
+		code[e.ID] = codeEntityRef{ID: e.ID, Name: e.Name, Kind: e.Kind}
+	}
+
+	// Process section results in a deterministic order.
+	results := append([]SemanticSectionResult(nil), result.SectionResults...)
+	sort.SliceStable(results, func(a, b int) bool { return results[a].SectionID < results[b].SectionID })
+
+	seenSection := map[string]bool{}
+	for _, sr := range results {
+		si, ok := bySection[sr.SectionID]
+		if !ok {
+			// Envelope-level: the agent referenced a section not in the bundle.
+			return SemanticApplyResult{}, fmt.Errorf("ingest: semantic apply: result section_id %q not in bundle", sr.SectionID)
+		}
+		if seenSection[sr.SectionID] {
+			return SemanticApplyResult{}, fmt.Errorf("ingest: semantic apply: duplicate section_id %q in result", sr.SectionID)
+		}
+		seenSection[sr.SectionID] = true
+
+		// Class must be in the closed set.
+		if !IsValidSemanticClass(sr.Class) {
+			return SemanticApplyResult{}, fmt.Errorf("ingest: semantic apply: section %q has invalid class %q", sr.SectionID, sr.Class)
+		}
+		if sr.Class == SemanticClassNone {
+			out.Stats.SectionsNone++
+			continue
+		}
+
+		// Non-None requires a summary.
+		summary := strings.TrimSpace(sr.Summary)
+		if summary == "" {
+			return SemanticApplyResult{}, fmt.Errorf("ingest: semantic apply: section %q class %q requires a non-empty summary", sr.SectionID, sr.Class)
+		}
+
+		// Build the DesignDecision node. Identity is deterministic for
+		// idempotency: repo + kind + (sectionID|class) + sourceFile.
+		decName := fmt.Sprintf("%s:%s", sr.SectionID, sr.Class)
+		decID := graph.EntityID(
+			bundle.RepoTag,
+			string(types.EntityKindDesignDecision),
+			decName,
+			bundle.DocRelPath,
+		)
+		out.Entities = append(out.Entities, graph.Entity{
+			ID:            decID,
+			Name:          string(sr.Class),
+			QualifiedName: bundle.RepoTag + "::" + decName,
+			Kind:          string(types.EntityKindDesignDecision),
+			SourceFile:    bundle.DocRelPath,
+			StartLine:     si.prompt.StartLine,
+			EndLine:       si.prompt.EndLine,
+			Language:      "markdown",
+			Properties: map[string]string{
+				"class":      string(sr.Class),
+				"summary":    summary,
+				"section_id": sr.SectionID,
+				"heading":    si.prompt.Heading,
+			},
+		})
+		out.Stats.DecisionsCreated++
+		out.Stats.SectionsClassified++
+
+		// Anchor edge: Section → DesignDecision (CONTAINS), mirroring how L1
+		// anchors sections under their document.
+		out.Relationships = append(out.Relationships, semRel(
+			sr.SectionID, decID, string(types.RelationshipKindContains), nil,
+		))
+		out.Stats.AnchorEdges++
+
+		// Rationale edges: DesignDecision → each VALID cited target. A target is
+		// valid iff it was a grounded mention-target for THIS section AND exists
+		// in the code graph. Invalid targets are dropped (honest partial), not
+		// fatal. Dedup per decision.
+		seenTarget := map[string]bool{}
+		tids := append([]string(nil), sr.RationaleTargetIDs...)
+		sort.Strings(tids)
+		for _, tid := range tids {
+			if seenTarget[tid] {
+				continue
+			}
+			seenTarget[tid] = true
+			if !si.targets[tid] {
+				out.Stats.RejectedTargets++ // not a grounded mention-target
+				continue
+			}
+			ce, exists := code[tid]
+			if !exists {
+				out.Stats.RejectedTargets++ // not in the code graph
+				continue
+			}
+			out.Relationships = append(out.Relationships, semRel(
+				decID, tid, string(types.RelationshipKindRationaleFor),
+				map[string]string{"target_kind": ce.Kind},
+			))
+			out.Stats.RationaleEdges++
+		}
+	}
+
+	// Deterministic output ordering (mirrors Ingest).
+	sort.SliceStable(out.Entities, func(a, b int) bool { return out.Entities[a].ID < out.Entities[b].ID })
+	sort.SliceStable(out.Relationships, func(a, b int) bool {
+		ra, rb := out.Relationships[a], out.Relationships[b]
+		if ra.FromID != rb.FromID {
+			return ra.FromID < rb.FromID
+		}
+		if ra.ToID != rb.ToID {
+			return ra.ToID < rb.ToID
+		}
+		return ra.Kind < rb.Kind
+	})
+	return out, nil
+}
+
+// semRel mirrors ingest.mkRel for the semantic edges.
+func semRel(from, to, kind string, props map[string]string) graph.Relationship {
+	return graph.Relationship{
+		ID:         graph.RelationshipID(from, to, kind),
+		FromID:     from,
+		ToID:       to,
+		Kind:       kind,
+		Properties: props,
+	}
+}
+
+// ReadResult reads and unmarshals a SemanticRunResult from disk.
+func ReadResult(path string) (SemanticRunResult, error) {
+	var r SemanticRunResult
+	data, err := os.ReadFile(path) //nolint:gosec // path from a run-dir listing
+	if err != nil {
+		return r, fmt.Errorf("ingest: read result %q: %w", path, err)
+	}
+	if err := json.Unmarshal(data, &r); err != nil {
+		return r, fmt.Errorf("ingest: unmarshal result %q: %w", path, err)
+	}
+	return r, nil
+}

--- a/internal/ingest/semantic_apply_test.go
+++ b/internal/ingest/semantic_apply_test.go
@@ -1,0 +1,255 @@
+package ingest
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// placingSection returns the "Placing an order" prompt (which has grounded
+// targets placeOrder + validateOrder).
+func placingSection(t *testing.T, b SemanticBundle) SemanticSectionPrompt {
+	t.Helper()
+	for _, sp := range b.Sections {
+		if sp.Heading == "Placing an order" {
+			return sp
+		}
+	}
+	t.Fatal("missing 'Placing an order' section")
+	return SemanticSectionPrompt{}
+}
+
+func TestApplySemanticResult_ValidCreatesNodesAndEdges(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	bundles := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)
+	b := bundles[0]
+	placing := placingSection(t, b)
+
+	result := SemanticRunResult{
+		Version:    b.Version,
+		PromptHash: b.PromptHash,
+		DocumentID: b.DocumentID,
+		SectionResults: []SemanticSectionResult{
+			{
+				SectionID:          placing.SectionID,
+				Class:              SemanticClassDesignDecision,
+				Summary:            "placeOrder validates the cart via validateOrder before persisting.",
+				RationaleTargetIDs: targetIDs(placing.MentionTargets),
+			},
+		},
+	}
+
+	out, err := ApplySemanticResult(b, result, code)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if out.Stats.DecisionsCreated != 1 {
+		t.Fatalf("decisions = %d, want 1", out.Stats.DecisionsCreated)
+	}
+	if len(out.Entities) != 1 {
+		t.Fatalf("entities = %d, want 1", len(out.Entities))
+	}
+	dec := out.Entities[0]
+	if dec.Kind != string(types.EntityKindDesignDecision) {
+		t.Errorf("decision kind = %q, want %q", dec.Kind, types.EntityKindDesignDecision)
+	}
+	if dec.Properties["section_id"] != placing.SectionID {
+		t.Errorf("decision not anchored to section: %q", dec.Properties["section_id"])
+	}
+
+	// Edges: 1 anchor (Section→Decision CONTAINS) + 2 rationale (Decision→target).
+	var anchors, rationale int
+	for _, rel := range out.Relationships {
+		switch rel.Kind {
+		case string(types.RelationshipKindContains):
+			anchors++
+			if rel.FromID != placing.SectionID || rel.ToID != dec.ID {
+				t.Errorf("anchor edge mis-linked: %s -> %s", rel.FromID, rel.ToID)
+			}
+		case string(types.RelationshipKindRationaleFor):
+			rationale++
+			if rel.FromID != dec.ID {
+				t.Errorf("rationale edge not from decision: from=%s", rel.FromID)
+			}
+		}
+	}
+	if anchors != 1 {
+		t.Errorf("anchor edges = %d, want 1", anchors)
+	}
+	if rationale != 2 {
+		t.Errorf("rationale edges = %d, want 2 (placeOrder + validateOrder)", rationale)
+	}
+	if out.Stats.RejectedTargets != 0 {
+		t.Errorf("rejected_targets = %d, want 0", out.Stats.RejectedTargets)
+	}
+}
+
+func TestApplySemanticResult_NoneProducesNothing(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	b := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)[0]
+	placing := placingSection(t, b)
+
+	result := SemanticRunResult{
+		Version:    b.Version,
+		PromptHash: b.PromptHash,
+		SectionResults: []SemanticSectionResult{
+			{SectionID: placing.SectionID, Class: SemanticClassNone},
+		},
+	}
+	out, err := ApplySemanticResult(b, result, code)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(out.Entities) != 0 || len(out.Relationships) != 0 {
+		t.Errorf("None must produce no nodes/edges, got %d/%d", len(out.Entities), len(out.Relationships))
+	}
+	if out.Stats.SectionsNone != 1 {
+		t.Errorf("sections_none = %d, want 1", out.Stats.SectionsNone)
+	}
+}
+
+func TestApplySemanticResult_RejectsStaleAndMalformed(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	b := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)[0]
+	placing := placingSection(t, b)
+
+	cases := []struct {
+		name   string
+		result SemanticRunResult
+	}{
+		{
+			name: "version mismatch",
+			result: SemanticRunResult{Version: "999", PromptHash: b.PromptHash,
+				SectionResults: []SemanticSectionResult{{SectionID: placing.SectionID, Class: SemanticClassNone}}},
+		},
+		{
+			name: "stale prompt hash",
+			result: SemanticRunResult{Version: b.Version, PromptHash: "deadbeef",
+				SectionResults: []SemanticSectionResult{{SectionID: placing.SectionID, Class: SemanticClassNone}}},
+		},
+		{
+			name: "unknown section id",
+			result: SemanticRunResult{Version: b.Version, PromptHash: b.PromptHash,
+				SectionResults: []SemanticSectionResult{{SectionID: "not-a-section", Class: SemanticClassSpec, Summary: "x"}}},
+		},
+		{
+			name: "invalid class",
+			result: SemanticRunResult{Version: b.Version, PromptHash: b.PromptHash,
+				SectionResults: []SemanticSectionResult{{SectionID: placing.SectionID, Class: "Hallucinated", Summary: "x"}}},
+		},
+		{
+			name: "non-None without summary",
+			result: SemanticRunResult{Version: b.Version, PromptHash: b.PromptHash,
+				SectionResults: []SemanticSectionResult{{SectionID: placing.SectionID, Class: SemanticClassSpec}}},
+		},
+		{
+			name: "duplicate section",
+			result: SemanticRunResult{Version: b.Version, PromptHash: b.PromptHash,
+				SectionResults: []SemanticSectionResult{
+					{SectionID: placing.SectionID, Class: SemanticClassNone},
+					{SectionID: placing.SectionID, Class: SemanticClassNone},
+				}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := ApplySemanticResult(b, tc.result, code)
+			if err == nil {
+				t.Fatalf("expected rejection, got nil error")
+			}
+			// No partial corruption: a rejected result produces nothing.
+			if len(out.Entities) != 0 || len(out.Relationships) != 0 {
+				t.Errorf("rejected result must produce nothing, got %d/%d", len(out.Entities), len(out.Relationships))
+			}
+		})
+	}
+}
+
+func TestApplySemanticResult_UnfoundedTargetIsHonestPartial(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	b := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)[0]
+	placing := placingSection(t, b)
+
+	// One valid grounded target + one invented (not a mention-target) ID.
+	valid := placing.MentionTargets[0].ID
+	result := SemanticRunResult{
+		Version:    b.Version,
+		PromptHash: b.PromptHash,
+		SectionResults: []SemanticSectionResult{
+			{
+				SectionID:          placing.SectionID,
+				Class:              SemanticClassRationale,
+				Summary:            "why",
+				RationaleTargetIDs: []string{valid, "ffffffffffffffff"},
+			},
+		},
+	}
+	out, err := ApplySemanticResult(b, result, code)
+	if err != nil {
+		t.Fatalf("apply should not fail on a bad target (honest partial): %v", err)
+	}
+	if out.Stats.DecisionsCreated != 1 {
+		t.Errorf("decision still created, got %d", out.Stats.DecisionsCreated)
+	}
+	if out.Stats.RationaleEdges != 1 {
+		t.Errorf("rationale edges = %d, want 1 (only the grounded target)", out.Stats.RationaleEdges)
+	}
+	if out.Stats.RejectedTargets != 1 {
+		t.Errorf("rejected_targets = %d, want 1", out.Stats.RejectedTargets)
+	}
+}
+
+func TestApplySemanticResult_Idempotent(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	b := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)[0]
+	placing := placingSection(t, b)
+
+	result := SemanticRunResult{
+		Version:    b.Version,
+		PromptHash: b.PromptHash,
+		SectionResults: []SemanticSectionResult{
+			{
+				SectionID:          placing.SectionID,
+				Class:              SemanticClassDesignDecision,
+				Summary:            "stable summary",
+				RationaleTargetIDs: targetIDs(placing.MentionTargets),
+			},
+		},
+	}
+	a1, err := ApplySemanticResult(b, result, code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a2, err := ApplySemanticResult(b, result, code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a1.Entities) != len(a2.Entities) || len(a1.Relationships) != len(a2.Relationships) {
+		t.Fatalf("non-idempotent counts: %d/%d vs %d/%d",
+			len(a1.Entities), len(a1.Relationships), len(a2.Entities), len(a2.Relationships))
+	}
+	for i := range a1.Entities {
+		if a1.Entities[i].ID != a2.Entities[i].ID {
+			t.Errorf("entity ID drift at %d: %q vs %q", i, a1.Entities[i].ID, a2.Entities[i].ID)
+		}
+	}
+	for i := range a1.Relationships {
+		if a1.Relationships[i].ID != a2.Relationships[i].ID {
+			t.Errorf("rel ID drift at %d: %q vs %q", i, a1.Relationships[i].ID, a2.Relationships[i].ID)
+		}
+	}
+}
+
+func targetIDs(ts []SemanticTarget) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = t.ID
+	}
+	return out
+}

--- a/internal/ingest/semantic_test.go
+++ b/internal/ingest/semantic_test.go
@@ -1,0 +1,121 @@
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// --- #4308 emit -------------------------------------------------------------
+
+func TestEmitSemanticBundles_PerDocumentWellFormed(t *testing.T) {
+	repoRoot, err := filepath.Abs("testdata/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoTag := "repo"
+	code := codeEntitiesFixture(repoTag)
+
+	bundles := EmitSemanticBundles(repoRoot, repoTag, []string{"docs/orders.md"}, code)
+	if len(bundles) != 1 {
+		t.Fatalf("bundles = %d, want 1 (one per document)", len(bundles))
+	}
+	b := bundles[0]
+
+	if b.Version != SemanticBundleVersion {
+		t.Errorf("version = %q, want %q", b.Version, SemanticBundleVersion)
+	}
+	if b.RepoTag != repoTag {
+		t.Errorf("repo_tag = %q, want %q", b.RepoTag, repoTag)
+	}
+	wantDocID := graph.EntityID(repoTag, string(types.EntityKindMarkdownDocument), "docs/orders.md", "docs/orders.md")
+	if b.DocumentID != wantDocID {
+		t.Errorf("document_id = %q, want %q", b.DocumentID, wantDocID)
+	}
+	if b.PromptHash == "" {
+		t.Error("bundle prompt_hash is empty")
+	}
+
+	// N sections → N prompts; the markdown has 5 headings (# Orders, ## Placing,
+	// ### Validation, ## Refunds), i.e. 4 sections.
+	if len(b.Sections) != 4 {
+		t.Fatalf("sections = %d, want 4", len(b.Sections))
+	}
+
+	// Schema is self-describing: closed-set classes + RATIONALE_FOR edge kind.
+	if b.Schema.EdgeKind != string(types.RelationshipKindRationaleFor) {
+		t.Errorf("schema edge_kind = %q, want %q", b.Schema.EdgeKind, types.RelationshipKindRationaleFor)
+	}
+	if len(b.Schema.Classes) == 0 || b.Schema.Guidance == "" {
+		t.Error("schema must carry classes + guidance")
+	}
+
+	// Each section prompt is well-formed and carries section text + a section ID.
+	for _, sp := range b.Sections {
+		if sp.SectionID == "" {
+			t.Errorf("section %q has empty section_id", sp.Heading)
+		}
+		if sp.PromptHash == "" {
+			t.Errorf("section %q has empty prompt_hash", sp.Heading)
+		}
+	}
+
+	// Grounding: the "Placing an order" section body mentions placeOrder +
+	// validateOrder, so its prompt must carry those as mention targets.
+	var placing *SemanticSectionPrompt
+	for i := range b.Sections {
+		if b.Sections[i].Heading == "Placing an order" {
+			placing = &b.Sections[i]
+		}
+	}
+	if placing == nil {
+		t.Fatal("missing 'Placing an order' section")
+	}
+	gotTargets := map[string]bool{}
+	for _, tgt := range placing.MentionTargets {
+		gotTargets[tgt.Name] = true
+	}
+	if !gotTargets["placeOrder"] || !gotTargets["validateOrder"] {
+		t.Errorf("placing.mention_targets = %+v, want placeOrder + validateOrder", placing.MentionTargets)
+	}
+}
+
+func TestEmitSemanticBundles_Deterministic(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	a := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)
+	b := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("want 1 bundle each, got %d/%d", len(a), len(b))
+	}
+	if a[0].PromptHash != b[0].PromptHash {
+		t.Errorf("non-deterministic prompt_hash: %q vs %q", a[0].PromptHash, b[0].PromptHash)
+	}
+}
+
+func TestWriteReadBundle_Roundtrip(t *testing.T) {
+	repoRoot, _ := filepath.Abs("testdata/repo")
+	code := codeEntitiesFixture("repo")
+	bundles := EmitSemanticBundles(repoRoot, "repo", []string{"docs/orders.md"}, code)
+	if len(bundles) != 1 {
+		t.Fatalf("want 1 bundle, got %d", len(bundles))
+	}
+	dir := t.TempDir()
+	path, err := WriteBundle(dir, bundles[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("bundle not written: %v", err)
+	}
+	got, err := ReadBundle(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PromptHash != bundles[0].PromptHash {
+		t.Errorf("roundtrip prompt_hash mismatch: %q vs %q", got.PromptHash, bundles[0].PromptHash)
+	}
+}

--- a/internal/mcp/doc_semantics_tools.go
+++ b/internal/mcp/doc_semantics_tools.go
@@ -1,0 +1,238 @@
+package mcp
+
+// archigraph_apply_doc_semantics — MCP submit/apply tool for Layer-2 (agent-
+// driven semantic) doc ingestion (#4309, epic #4294).
+//
+// This is the apply-path companion to the emit step (internal/ingest:
+// EmitSemanticBundles / WriteBundle). The agent-driven loop is:
+//
+//  1. (emit)  the indexer/CLI writes per-document SemanticBundle artifacts under
+//             <stateDir>/doc-semantics/<documentID>.bundle.json.
+//  2. (fill)  the EXTERNAL calling agent reads each bundle, runs its OWN LLM to
+//             classify sections, and writes <documentID>.result.json back beside
+//             the bundle. archigraph makes NO LLM call.
+//  3. (apply) THIS tool reads each (bundle, result) pair, validates + applies via
+//             ingest.ApplySemanticResult, and writes the produced
+//             SCOPE.DesignDecision nodes + CONTAINS/RATIONALE_FOR edges to
+//             <stateDir>/doc-semantics/applied-nodes.json (the splice sidecar,
+//             mirroring enrichment-resolutions.json). dry_run validates without
+//             writing.
+//
+// Mirrors archigraph_apply_docgen_repairs (docgen_repair_tools.go): per-repo
+// summary, repo_filter + dry_run params, deterministic ordering, honest partial.
+//
+// IDEMPOTENCY: ApplySemanticResult derives node/edge IDs deterministically, and
+// the sidecar is rewritten (not appended) deduped-by-ID on every apply, so
+// re-running over the same artifacts never duplicates.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/ingest"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// docSemanticsSubdir is the per-repo state-dir subdirectory holding the L2
+// emit/apply artifacts.
+const docSemanticsSubdir = "doc-semantics"
+
+// docSemanticsAppliedFile is the splice sidecar written by a successful apply.
+const docSemanticsAppliedFile = "applied-nodes.json"
+
+// docSemanticsSidecar is the on-disk shape of the applied-nodes sidecar: the
+// validated semantic nodes/edges ready to splice into the graph at load time.
+type docSemanticsSidecar struct {
+	Entities      []graph.Entity       `json:"entities"`
+	Relationships []graph.Relationship `json:"relationships"`
+}
+
+// handleApplyDocSemantics implements archigraph_apply_doc_semantics.
+//
+// Parameters (all optional):
+//
+//	repo_filter []string — restrict to named repos; empty/["*"] = all
+//	dry_run bool — validate + report, but do not write the sidecar
+func (s *Server) handleApplyDocSemantics(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+
+	dryRun := argBool(req, "dry_run", false)
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	sort.Slice(repos, func(i, j int) bool { return repos[i].Repo < repos[j].Repo })
+
+	type repoResult struct {
+		Repo               string   `json:"repo"`
+		BundlesProcessed   int      `json:"bundles_processed"`
+		DecisionsCreated   int      `json:"decisions_created"`
+		RationaleEdges     int      `json:"rationale_edges"`
+		AnchorEdges        int      `json:"anchor_edges"`
+		SectionsClassified int      `json:"sections_classified"`
+		SectionsNone       int      `json:"sections_none"`
+		RejectedTargets    int      `json:"rejected_targets"`
+		Errors             []string `json:"errors,omitempty"`
+		SidecarPath        string   `json:"sidecar_path,omitempty"`
+	}
+
+	results := make([]repoResult, 0, len(repos))
+	totalDecisions, totalEdges := 0, 0
+
+	for _, r := range repos {
+		res := repoResult{Repo: r.Repo}
+		dir := filepath.Join(daemon.StateDirForRepo(r.Path), docSemanticsSubdir)
+
+		pairs, listErr := listBundleResultPairs(dir)
+		if listErr != nil {
+			res.Errors = append(res.Errors, listErr.Error())
+			results = append(results, res)
+			continue
+		}
+
+		// Current code entities for target-existence validation.
+		var codeEntities []graph.Entity
+		if r.Doc != nil {
+			codeEntities = r.Doc.Entities
+		}
+
+		var sidecar docSemanticsSidecar
+		entSeen := map[string]bool{}
+		relSeen := map[string]bool{}
+
+		for _, p := range pairs {
+			bundle, bErr := ingest.ReadBundle(p.bundlePath)
+			if bErr != nil {
+				res.Errors = append(res.Errors, bErr.Error())
+				continue
+			}
+			result, rErr := ingest.ReadResult(p.resultPath)
+			if rErr != nil {
+				res.Errors = append(res.Errors, rErr.Error())
+				continue
+			}
+			applied, aErr := ingest.ApplySemanticResult(bundle, result, codeEntities)
+			if aErr != nil {
+				// Envelope-level rejection: report, skip this pair, no corruption.
+				res.Errors = append(res.Errors, aErr.Error())
+				continue
+			}
+			res.BundlesProcessed++
+			res.DecisionsCreated += applied.Stats.DecisionsCreated
+			res.RationaleEdges += applied.Stats.RationaleEdges
+			res.AnchorEdges += applied.Stats.AnchorEdges
+			res.SectionsClassified += applied.Stats.SectionsClassified
+			res.SectionsNone += applied.Stats.SectionsNone
+			res.RejectedTargets += applied.Stats.RejectedTargets
+
+			// Idempotent merge: dedup by ID across all bundles in the repo.
+			for _, e := range applied.Entities {
+				if entSeen[e.ID] {
+					continue
+				}
+				entSeen[e.ID] = true
+				sidecar.Entities = append(sidecar.Entities, e)
+			}
+			for _, rel := range applied.Relationships {
+				if relSeen[rel.ID] {
+					continue
+				}
+				relSeen[rel.ID] = true
+				sidecar.Relationships = append(sidecar.Relationships, rel)
+			}
+		}
+
+		// Deterministic sidecar ordering.
+		sort.SliceStable(sidecar.Entities, func(i, j int) bool { return sidecar.Entities[i].ID < sidecar.Entities[j].ID })
+		sort.SliceStable(sidecar.Relationships, func(i, j int) bool { return sidecar.Relationships[i].ID < sidecar.Relationships[j].ID })
+
+		if !dryRun && (len(sidecar.Entities) > 0 || len(sidecar.Relationships) > 0) {
+			path, wErr := writeDocSemanticsSidecar(dir, sidecar)
+			if wErr != nil {
+				res.Errors = append(res.Errors, wErr.Error())
+			} else {
+				res.SidecarPath = path
+			}
+		}
+
+		totalDecisions += res.DecisionsCreated
+		totalEdges += res.RationaleEdges
+		results = append(results, res)
+	}
+
+	return jsonResult(map[string]any{
+		"dry_run":          dryRun,
+		"repos":            results,
+		"total_decisions":  totalDecisions,
+		"total_rationale":  totalEdges,
+		"artifacts_subdir": docSemanticsSubdir,
+	}), nil
+}
+
+// bundleResultPair locates a bundle and its sibling result file.
+type bundleResultPair struct {
+	bundlePath string
+	resultPath string
+}
+
+// listBundleResultPairs scans dir for *.bundle.json files that have a matching
+// *.result.json sibling (same <documentID> stem). Bundles without a result are
+// silently skipped (the agent has not filled them yet). Returns a deterministic,
+// stem-sorted list. A missing dir is not an error (no artifacts yet).
+func listBundleResultPairs(dir string) ([]bundleResultPair, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read doc-semantics dir %q: %w", dir, err)
+	}
+	have := map[string]bool{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			have[e.Name()] = true
+		}
+	}
+	var out []bundleResultPair
+	for name := range have {
+		if !strings.HasSuffix(name, ".bundle.json") {
+			continue
+		}
+		stem := strings.TrimSuffix(name, ".bundle.json")
+		resultName := stem + ".result.json"
+		if !have[resultName] {
+			continue
+		}
+		out = append(out, bundleResultPair{
+			bundlePath: filepath.Join(dir, name),
+			resultPath: filepath.Join(dir, resultName),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].bundlePath < out[j].bundlePath })
+	return out, nil
+}
+
+// writeDocSemanticsSidecar writes the applied semantic nodes/edges sidecar as
+// indented JSON. The whole file is rewritten (not appended) so a re-apply is
+// idempotent. Returns the written path.
+func writeDocSemanticsSidecar(dir string, sc docSemanticsSidecar) (string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create doc-semantics dir %q: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(sc, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal doc-semantics sidecar: %w", err)
+	}
+	path := filepath.Join(dir, docSemanticsAppliedFile)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return "", fmt.Errorf("write doc-semantics sidecar %q: %w", path, err)
+	}
+	return path, nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -803,6 +803,19 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_apply_docgen_repairs", s.handleApplyDocgenRepairs))
 
+	// archigraph_apply_doc_semantics — Layer-2 doc ingestion apply step
+	// (#4309, epic #4294). Reads agent-produced (bundle, result) pairs from each
+	// repo's <stateDir>/doc-semantics/, validates + applies them into
+	// SCOPE.DesignDecision nodes + RATIONALE_FOR edges. archigraph makes NO LLM
+	// call — it only validates and applies what the calling agent returned.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_apply_doc_semantics",
+		mcpapi.WithDescription("Doc L2: apply agent-produced DesignDecision nodes + RATIONALE_FOR edges."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithBoolean("dry_run"),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_apply_doc_semantics", s.handleApplyDocSemantics))
+
 	// archigraph_get_telemetry dropped (dashboard-only; use HTTP /api/telemetry instead).
 
 	// archigraph_patterns — ADR-0018. action=query|record.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -562,6 +562,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_auth_coverage",
 		// #1659 docgen→graph repair feedback loop
 		"archigraph_apply_docgen_repairs",
+		// #4309 doc ingestion L2: apply agent-produced semantic doc nodes/edges
+		"archigraph_apply_doc_semantics",
 		// #2442 re-wired agent-facing tools (restored from ≤3k budget cut)
 		"archigraph_save_finding",
 		"archigraph_list_findings",
@@ -709,8 +711,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_auth_posture_diff (#4422 cross-group auth-posture parity).
 	// +1 archigraph_stub_detector (#4425 cross-group stub effects-contrast heuristic).
 	// +1 archigraph_response_shape_diff (#4424 cross-group branch-aware response-shape parity).
-	if got := len(allRegisteredTools); got != 63 {
-		t.Errorf("expected 63 registered tools, got %d — update this count if tools are added/removed (added archigraph_response_shape_diff #4424 cross-group response-shape diff)", got)
+	// +1 archigraph_apply_doc_semantics (#4309 doc ingestion L2 apply step).
+	if got := len(allRegisteredTools); got != 64 {
+		t.Errorf("expected 64 registered tools, got %d — update this count if tools are added/removed (added archigraph_apply_doc_semantics #4309 doc ingestion L2)", got)
 	}
 }
 
@@ -3168,6 +3171,7 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_enrichments":          {"group": "g", "action": "list"},
 		"archigraph_repairs":              {"group": "g", "action": "list"},
 		"archigraph_apply_docgen_repairs": {"group": "g"},
+		"archigraph_apply_doc_semantics":  {"group": "g"},
 		"archigraph_patterns":             {"group": "g", "action": "query", "text": "test"},
 		"archigraph_topology":             {"group": "g", "action": "orphan_publishers"},
 		"archigraph_flows":                {"group": "g", "action": "dead_ends"},
@@ -3290,8 +3294,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 63 {
-		t.Errorf("expected 63 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_response_shape_diff #4424 cross-group response-shape diff)", len(tools))
+	if len(tools) != 64 {
+		t.Errorf("expected 64 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_apply_doc_semantics #4309 doc ingestion L2)", len(tools))
 	}
 
 	for _, st := range tools {

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -316,6 +316,21 @@ const (
 	// hierarchy/span contract.
 	EntityKindMarkdownDocument EntityKind = "SCOPE.MarkdownDocument"
 	EntityKindSection          EntityKind = "SCOPE.Section"
+
+	// #4308/#4309 (Layer 2 of epic #4294): agent-driven semantic doc ingestion.
+	// archigraph EMITS a per-Section prompt bundle; an EXTERNAL agent runs its
+	// own LLM and returns structured results; archigraph VALIDATES + APPLIES
+	// them. archigraph itself makes NO LLM call (emit→apply candidate pattern,
+	// mirroring docgen --llm-mode and archigraph_enrichments).
+	//
+	// EntityKindDesignDecision represents ONE agent-classified semantic node
+	// distilled from a Section — a design decision, rationale, spec, or
+	// constraint stated in prose. It is anchored to its source Section via a
+	// CONTAINS edge (Section → DesignDecision) and links to the code entities
+	// it justifies via RATIONALE_FOR (DesignDecision → code entity). Distinct
+	// from the deterministic SCOPE.Section node (which carries verbatim prose);
+	// a DesignDecision is the agent's distilled claim ABOUT that prose.
+	EntityKindDesignDecision EntityKind = "SCOPE.DesignDecision"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -402,6 +417,8 @@ func AllEntityKinds() []EntityKind {
 		// #4306 deterministic markdown doc ingestion (opt-in):
 		EntityKindMarkdownDocument,
 		EntityKindSection,
+		// #4308/#4309 agent-driven semantic doc ingestion (opt-in, emit/apply):
+		EntityKindDesignDecision,
 	}
 }
 
@@ -1257,6 +1274,17 @@ const (
 	// directory it instantiates (e.g. modules/worker-service). Connects the
 	// env stacks to the shared module definitions in the IaC architecture view.
 	RelationshipKindInstantiates RelationshipKind = "INSTANTIATES"
+
+	// #4308/#4309 (Layer 2 of epic #4294): agent-driven semantic doc ingestion.
+	//   RATIONALE_FOR : SCOPE.DesignDecision → code entity. Emitted by the
+	//                   apply step when an external agent classifies a Section
+	//                   as stating a design decision / rationale / spec that
+	//                   justifies a referenced code entity. archigraph only
+	//                   VALIDATES (the target entity must exist in the current
+	//                   graph) and APPLIES what the agent produced — no LLM
+	//                   call. The DesignDecision→Section anchoring uses the
+	//                   existing CONTAINS edge; no new hierarchy kind. OPT-IN.
+	RelationshipKindRationaleFor RelationshipKind = "RATIONALE_FOR"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1415,6 +1443,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #4657 IaC module instantiation: env stack's module instance →
 		// the module definition directory it instantiates.
 		RelationshipKindInstantiates,
+		// #4308/#4309 agent-driven semantic doc ingestion (opt-in, emit/apply):
+		RelationshipKindRationaleFor,
 	}
 }
 


### PR DESCRIPTION
Layer 2 of epic #4294 (opt-in, agent-driven semantic doc ingestion), built on L1 (#4306/#4307: `internal/ingest`, Document/Section/MENTIONS). Preserves the core invariant: **archigraph makes ZERO LLM calls** — it EMITS prompt bundles and VALIDATES + APPLIES what an external agent returns, mirroring the docgen `--llm-mode=emit/apply` and `archigraph_enrichments` candidate pattern.

## #4308 — emit (no LLM call)
`internal/ingest/semantic.go`:
- `EmitSemanticBundles` reuses the L1 `ParseDocument` → section-ID-stamp → `LinkMentions` pipeline so each bundle carries **exactly** the `SCOPE.Section` IDs and MENTIONS targets that L1 produced (emit and the deterministic graph stay in lockstep).
- Each `SemanticBundle` is a self-contained, deterministic artifact: per-section prose + grounded mention-targets + a **closed-set** extraction schema (`DesignDecision`/`Rationale`/`Spec`/`Constraint`/`None`, edge kind `RATIONALE_FOR`, agent guidance). Stable `prompt_hash` cache key (per-section + bundle), mirroring docgen's hash design.
- Persisted under `<stateDir>/doc-semantics/<docID>.bundle.json` at index time (gated behind the existing `--ingest-docs` flag), mirroring the docgen run-dir/artifact convention.

## #4309 — apply (validate + submit, still no LLM call)
`internal/ingest/semantic_apply.go`:
- `ApplySemanticResult` validates the agent's `SemanticRunResult` against the bundle (version + `prompt_hash`) and the closed-set schema. **Envelope-level corruption** (version/hash mismatch, unknown/duplicate section, invalid class, missing summary) rejects the whole result with a clear error and **no partial corruption**. **Per-target grounding failures** (a cited ID that isn't a grounded mention-target for that section, or doesn't exist in the code graph) are dropped + counted (`RejectedTargets`) — **honest partial**, not fatal.
- Produces `SCOPE.DesignDecision` nodes + Section→Decision `CONTAINS` anchor + Decision→code `RATIONALE_FOR` edges. **Idempotent**: deterministic node/edge IDs (re-apply yields identical IDs).
- `archigraph_apply_doc_semantics` MCP tool mirrors `archigraph_apply_docgen_repairs`: reads `(*.bundle.json, *.result.json)` pairs from the repo state dir, validates + applies, and writes a deduped `applied-nodes.json` splice sidecar (`dry_run` supported).

## Types
Registered `SCOPE.DesignDecision` (entity) + `RATIONALE_FOR` (relationship), both producer-kind-valid.

## Live-only (deploy-deferred)
The `applied-nodes.json` → live-graph splice at load time is left for a follow-on daemon-wiring step. The pure **emit** + **apply/validate** library and the MCP **submit** entrypoint are complete and unit-tested here.

## Remaining epic #4294 axes (not closed)
- L1 #SUBB discovery/traversal surfacing of the new L2 nodes.
- Follow-ons: PDF input, embeddings-based linking.

## Tests
- emit: a document with N sections → N well-formed bundles carrying section text + grounded targets + the extraction schema; determinism; write/read roundtrip.
- apply: valid result → DesignDecision + anchor + rationale edges correctly linked; `None` → nothing; 6 malformed-envelope cases → rejected with no corruption; unfounded target → honest partial; re-apply → idempotent.

## Gates
`go build ./...`, `go vet ./internal/ingest/... ./internal/mcp/...`, `go test ./internal/ingest/... ./internal/mcp/...`, `coverage fmt --check` — all green. No coverage registry change (not a per-language extraction capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)