### PR TITLE
fix(agentpatterns): de-flake TestDecayScheduler_RunAndCancel under parallel load

### DIFF
--- a/internal/agentpatterns/confidence_test.go
+++ b/internal/agentpatterns/confidence_test.go
@@ -158,19 +158,33 @@ func TestApplyTimeDecayFromUnix_FloorAt02(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDecayScheduler_RunAndCancel(t *testing.T) {
+	// Deterministic tick assertion: rather than counting how many ticks land
+	// inside a wall-clock deadline (which is flaky under parallel CPU
+	// contention because time.Ticker coalesces/drops ticks when the receiving
+	// goroutine is starved), we cancel from inside the job once we've observed
+	// the target number of ticks. The scheduler is therefore guaranteed to run
+	// at least wantTicks times before Run returns, regardless of scheduling
+	// pressure. Run executes the job inline, so calls is not racy.
+	const wantTicks = 3
 	calls := 0
-	job := func(nowUnix int64) {
-		calls++
-	}
-	sched := agentpatterns.NewDecayScheduler(10*time.Millisecond, job)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	job := func(nowUnix int64) {
+		calls++
+		if calls >= wantTicks {
+			cancel()
+		}
+	}
+	// A short interval keeps the test fast; correctness no longer depends on
+	// it being short relative to any deadline.
+	sched := agentpatterns.NewDecayScheduler(1*time.Millisecond, job)
+
 	sched.Run(ctx)
-	// After ~50 ms with 10 ms interval, we expect ≥ 3 ticks (conservative).
-	if calls < 3 {
-		t.Errorf("expected >= 3 scheduler ticks, got %d", calls)
+
+	if calls < wantTicks {
+		t.Errorf("expected >= %d scheduler ticks, got %d", wantTicks, calls)
 	}
 }
 


### PR DESCRIPTION
## Problem

`internal/agentpatterns` intermittently fails (~1 in 2) under `go test -p 4 ./...` full-suite load but is consistently green in isolation (#4104). No `--- FAIL` assertion line — a wall-clock timing flake under parallel CPU contention.

## Root cause

`TestDecayScheduler_RunAndCancel` started a 10ms `time.Ticker` and asserted that `>= 3` ticks fired inside a 50ms `context.WithTimeout` deadline. Under `-p 4` contention the scheduler's `Run` goroutine is starved and `time.Ticker` coalesces/drops ticks (its channel is buffered to 1), so fewer than 3 ticks were observed before the 50ms deadline — intermittent failure.

## Fix

Make the assertion independent of the wall clock: cancel the context from inside the job once the target number of ticks is observed. `Run` is then guaranteed to execute the job at least `wantTicks` times before returning, regardless of scheduling pressure. `Run` invokes the job inline, so `calls` is not racy. Test-only change — no production code touched, no registry change.

## Evidence

- `go build ./...` OK, `go vet ./internal/agentpatterns/...` OK
- `go test -p 4 -count 50 ./internal/agentpatterns/...` green
- `go test -race ./internal/agentpatterns/...` green
- `go test -run TestDecayScheduler -p 4 -count 200 -race` green
- `GOMAXPROCS=1 -count 100` (max-contention repro of the original failure mode) green
- `coverage fmt --check`: canonical (no registry change)

Closes #4104

🤖 Generated with [Claude Code](https://claude.com/claude-code)