### PR TITLE
feat(graphql): Python gql client GraphQL ops → cross-repo http_endpoint_call (#3608)

### DIFF
--- a/internal/engine/http_endpoint_python_graphql_client.go
+++ b/internal/engine/http_endpoint_python_graphql_client.go
@@ -1,0 +1,212 @@
+// Python GraphQL client-side (consumer) operation synthesis
+// (epic #3607, issue #3608; mirrors the JS/TS pass in
+// http_endpoint_graphql_client.go and the Dart pass in
+// http_endpoint_dart_graphql_client.go).
+//
+// The dominant GraphQL client for Python is the `gql` package
+// (graphql-python/gql). A GraphQL operation document is built by wrapping a
+// document string in the `gql(...)` parser function, then executed against a
+// transport-backed client/session:
+//
+//	from gql import gql, Client
+//	GET_USER = gql("""query GetUser { user { id name } }""")
+//	result = client.execute(GET_USER)
+//
+//	await session.execute(
+//	    gql('''mutation AddUser { createUser(name: "x") { id } }''')
+//	)
+//
+//	client.execute(gql("{ users { id } }"))   # anonymous shorthand
+//
+// Before this pass these produced no operation entity and no cross-repo link:
+// the Python REST client pass (http_endpoint_python_client.go) only recognises
+// requests / httpx / aiohttp / urllib verb calls, so a Python service or script
+// talking to a GraphQL backend was invisible at the operation level. (Some gql
+// clients POST to `/graphql` via httpx under the hood, but that single mount can
+// never link to the per-field server endpoints.)
+//
+// This pass recognises the `gql(<string-literal>)` parser call — whether bound
+// to a module-level/local constant and referenced by name, or inlined directly
+// at the `execute(...)` call site — parses its operation type
+// (query/mutation/subscription) and ROOT FIELD(s) via the shared
+// gqlRootFieldsFromDoc parser, and emits one synthetic http_endpoint_call per
+// (operation, root field) keyed to EXACTLY match the GraphQL server endpoint
+// shape produced by every archigraph GraphQL server synthesizer
+// (http_endpoint_synthesis.go, the Strawberry / Graphene / Ariadne / gqlgen /
+// graphql-ruby / HotChocolate / Spring-GraphQL / caliban / async-graphql / …
+// passes):
+//
+//	gql("query { users { id } }")  →  http_endpoint_call  http:GRAPHQL:/graphql/Query/users
+//
+// Because the id is identical to the server-side definition's id, the existing
+// Name-based cross-repo HTTP linker joins them on reindex with NO new linker
+// code — exactly like every other consumer pass (REST, Dart-GraphQL,
+// Swift-GraphQL).
+//
+// FETCHES edge: the enclosing function at the gql(...) site is recorded as the
+// `source_caller` (Function:<name>). For a TOP-LEVEL constant (whose gql site
+// has no enclosing function) the caller is resolved from the function that
+// REFERENCES the const (`client.execute(GET_USER)`) — the real consumer of the
+// operation — mirroring the Dart pass.
+//
+// Honest-partial: a gql doc whose body cannot be parsed into a top-level
+// selection set (e.g. fragment-only documents, or dynamically-composed query
+// strings) emits nothing rather than a wrong endpoint. Documents imported from
+// another module and referenced only by name (no gql(...) body in this file)
+// are not resolved here — they are picked up in the file that defines them.
+
+package engine
+
+import (
+	"regexp"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// pyGqlDocRe matches a `gql(<string-literal>)` call in Python and captures the
+// document body. Python string literals come in several flavours, all handled
+// by the alternation below (optional `r`/`f`/`b` string prefix in every case,
+// case-insensitive, so `r"""..."""` and `f'...'` are tolerated):
+//
+//	gql("""query { ... }""")   triple-quoted double (the dominant gql form)
+//	gql('''query { ... }''')   triple-quoted single
+//	gql("query { ... }")       double-quoted
+//	gql('query { ... }')       single-quoted
+//
+// Capture groups (mutually exclusive, exactly one is non-empty):
+//
+//	1 = triple-double body, 2 = triple-single body,
+//	3 = double-quote body,  4 = single-quote body.
+//
+// (?s) so the `.`-equivalents span newlines inside a multi-line document.
+var pyGqlDocRe = regexp.MustCompile(
+	`(?s)\bgql\s*\(\s*[rRfFbB]?(?:"""(.*?)"""|'''(.*?)'''|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)')`,
+)
+
+// pyGqlConstDefRe captures a Python assignment whose initializer is a gql(...)
+// document, capturing the constant NAME (group 1). The gql body is re-parsed
+// from the same span via pyGqlDocRe; this regex only anchors the name so a
+// TOP-LEVEL const (whose gql site has no enclosing function) can have its
+// FETCHES caller resolved from the REFERENCE site instead. A leading type
+// annotation (`GET_USER: DocumentNode = gql(...)`) is tolerated.
+var pyGqlConstDefRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_]\w*)(?:[ \t]*:[ \t]*[\w.\[\], ]+)?[ \t]*=[ \t]*gql\s*\(`,
+)
+
+// synthesizePyGraphQLClient scans a Python file for `gql` package GraphQL
+// operations and emits one http_endpoint_call per (operation, root field),
+// keyed to match the server endpoint shape http:GRAPHQL:/graphql/<RootType>/
+// <field>, plus a FETCHES edge from the enclosing Python function.
+//
+// It is dispatched from the `case "python":` block of applyHTTPEndpointSynthesis
+// alongside the REST client pass, using the same runtime-aware emitter so it
+// produces the identical http_endpoint_call entity + FETCHES edge as every
+// other consumer pass.
+func synthesizePyGraphQLClient(content string, emit pyClientEmitFn) {
+	// File-signal gate: require the `gql(` parser marker so this is a no-op on
+	// ordinary REST/script Python files. (`gql(` is the parser-call form unique
+	// to the gql package; the REST Python pass keys off requests/httpx/aiohttp
+	// instead, so the two passes never collide.)
+	if !regexp.MustCompile(`\bgql\s*\(`).MatchString(content) {
+		return
+	}
+
+	funcs := indexPyEnclosingFunctions(content)
+
+	// emitDoc emits one client-call per resolved root field for a gql document.
+	emitDoc := func(rt string, fields []string, caller string) {
+		for _, f := range fields {
+			path := "/graphql/" + rt + "/" + f
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+			// runtimeDynamic=false: the operation root field is statically
+			// resolved from the literal gql document, so the endpoint is concrete.
+			emit(gqlVerb, canonical, "graphql_client", "Function", caller, false)
+		}
+	}
+
+	// pyGqlDocBody returns the document body from a pyGqlDocRe submatch
+	// (exactly one of the four quote-flavour groups is populated).
+	pyGqlDocBody := func(m []string) string {
+		for g := 1; g <= 4; g++ {
+			if m[g] != "" {
+				return m[g]
+			}
+		}
+		return ""
+	}
+
+	// Record each gql const-definition span → the const NAME, so a gql site that
+	// resolves to an empty enclosing function (a top-level const) can have its
+	// FETCHES caller resolved from a reference site below. pyGqlConstDefRe spans
+	// from the line start through the `(` of `gql(`, so the gql token sits inside
+	// [start, end).
+	type constSpan struct {
+		start, end int
+		name       string
+	}
+	var constSpans []constSpan
+	for _, dm := range pyGqlConstDefRe.FindAllStringSubmatchIndex(content, -1) {
+		constSpans = append(constSpans, constSpan{start: dm[0], end: dm[1], name: content[dm[2]:dm[3]]})
+	}
+	constNameForGqlSite := func(gqlOff int) string {
+		for _, cs := range constSpans {
+			if cs.start <= gqlOff && gqlOff < cs.end {
+				return cs.name
+			}
+		}
+		return ""
+	}
+
+	// refCallerForConst returns the enclosing function of the FIRST reference to
+	// `name` (`client.execute(GET_USER)` or a bare `GET_USER` argument) that
+	// lands inside some function, so a top-level gql const is attributed to its
+	// consumer.
+	refCallerForConst := func(name string) string {
+		if name == "" {
+			return ""
+		}
+		ref := regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+		for _, loc := range ref.FindAllStringIndex(content, -1) {
+			// Skip the definition site itself (it sits inside a const span).
+			inDef := false
+			for _, cs := range constSpans {
+				if cs.start <= loc[0] && loc[0] < cs.end {
+					inDef = true
+					break
+				}
+			}
+			if inDef {
+				continue
+			}
+			if c := enclosingPyFuncAt(funcs, loc[0]); c != "" {
+				return c
+			}
+		}
+		return ""
+	}
+
+	// Every gql(...) site, in source order, handled exactly once. The caller is
+	// the enclosing Python function; for a top-level const def (no enclosing
+	// function) the caller is resolved from the const's reference site.
+	for _, m := range pyGqlDocRe.FindAllStringSubmatchIndex(content, -1) {
+		bodyGroups := pyGqlDocRe.FindStringSubmatch(content[m[0]:m[1]])
+		if bodyGroups == nil {
+			continue
+		}
+		doc := pyGqlDocBody(bodyGroups)
+		if doc == "" {
+			continue
+		}
+		rt, fields, ok := gqlRootFieldsFromDoc(doc)
+		if !ok || len(fields) == 0 {
+			continue
+		}
+		caller := enclosingPyFuncAt(funcs, m[0])
+		if caller == "" {
+			// Top-level gql site: if it is a const definition, attribute the
+			// operation to the function that references the const.
+			caller = refCallerForConst(constNameForGqlSite(m[0]))
+		}
+		emitDoc(rt, fields, caller)
+	}
+}

--- a/internal/engine/http_endpoint_python_graphql_client_test.go
+++ b/internal/engine/http_endpoint_python_graphql_client_test.go
@@ -1,0 +1,120 @@
+package engine
+
+import "testing"
+
+// TestPyGraphQLClient_QueryConstRef covers the canonical gql-package idiom:
+// a gql doc bound to a module-level const (triple-quoted), referenced by a
+// client.execute() call inside a function. Asserts the SPECIFIC operation
+// root field (`user`) mapped to the server endpoint shape
+// http:GRAPHQL:/graphql/Query/user, plus the FETCHES edge attributed to the
+// referencing function.
+func TestPyGraphQLClient_QueryConstRef(t *testing.T) {
+	src := `
+from gql import gql, Client
+
+GET_USER = gql("""
+  query GetUser {
+    user { id name }
+  }
+""")
+
+def load_user(client):
+    return client.execute(GET_USER)
+`
+	ids, rels := runDetectWithRels(t, "python", "app/users.py", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Query/user",
+	}, "py-gql-query-const")
+	requireFetches(t, rels, "http:GRAPHQL:/graphql/Query/user", "py-gql-query-const")
+}
+
+// TestPyGraphQLClient_InlineMutation covers an inline gql mutation passed
+// straight into session.execute(gql('''...''')), asserting the Mutation root
+// field `createUser` → http:GRAPHQL:/graphql/Mutation/createUser, with the
+// FETCHES edge attributed to the enclosing async function.
+func TestPyGraphQLClient_InlineMutation(t *testing.T) {
+	src := `
+from gql import gql
+
+async def submit(session):
+    await session.execute(gql('''
+        mutation AddUser {
+            createUser(input: {name: "x"}) { id }
+        }
+    '''))
+`
+	ids, rels := runDetectWithRels(t, "python", "app/add_user.py", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Mutation/createUser",
+	}, "py-gql-inline-mutation")
+	requireFetches(t, rels, "http:GRAPHQL:/graphql/Mutation/createUser", "py-gql-inline-mutation")
+}
+
+// TestPyGraphQLClient_MultiField covers a single-quoted inline gql doc with
+// MULTIPLE root fields, asserting BOTH server endpoints are emitted.
+func TestPyGraphQLClient_MultiField(t *testing.T) {
+	src := `
+from gql import gql
+
+def dashboard(client):
+    return client.execute(gql('query Dashboard { stats { count } alerts { id } }'))
+`
+	ids, _ := runDetectWithRels(t, "python", "app/dashboard.py", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Query/stats",
+		"http:GRAPHQL:/graphql/Query/alerts",
+	}, "py-gql-multi-field")
+}
+
+// TestPyGraphQLClient_Subscription covers a subscription gql doc, asserting
+// the Subscription root-type mapping.
+func TestPyGraphQLClient_Subscription(t *testing.T) {
+	src := `
+from gql import gql
+
+SUB = gql("""
+  subscription OnMessage {
+    messageAdded { id body }
+  }
+""")
+
+def watch(client):
+    return client.subscribe(SUB)
+`
+	ids, _ := runDetectWithRels(t, "python", "app/watch.py", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Subscription/messageAdded",
+	}, "py-gql-subscription")
+}
+
+// TestPyGraphQLClient_AnonShorthand covers the anonymous shorthand
+// `{ users { id } }` (no operation keyword) → Query root type.
+func TestPyGraphQLClient_AnonShorthand(t *testing.T) {
+	src := `
+from gql import gql
+
+def list_users(client):
+    return client.execute(gql("{ users { id } }"))
+`
+	ids, _ := runDetectWithRels(t, "python", "app/list.py", src)
+	requireContains(t, ids, []string{
+		"http:GRAPHQL:/graphql/Query/users",
+	}, "py-gql-anon-shorthand")
+}
+
+// TestPyGraphQLClient_NegativeNoGql asserts a plain Python file with no gql(...)
+// parser call emits NO GraphQL operation endpoint (the pass is a no-op).
+func TestPyGraphQLClient_NegativeNoGql(t *testing.T) {
+	src := `
+import requests
+
+def fetch():
+    return requests.get("https://api.example.com/users")
+`
+	ids, _ := runDetectWithRels(t, "python", "app/rest.py", src)
+	for _, id := range ids {
+		if len(id) >= 13 && id[:13] == "http:GRAPHQL:/" {
+			t.Fatalf("py-gql-negative: unexpected GraphQL endpoint emitted: %s", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -950,6 +950,13 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// aiohttp / urllib / session-style HTTP client calls.
 		// Now emits FETCHES edges at extraction time.
 		synthesizePyClientWithRuntime(string(content), emitClientRuntime)
+		// Consumer side (#3608, epic #3607): Python `gql` package GraphQL
+		// operations. Maps each `gql("query/mutation/subscription { <field> }")`
+		// document to the canonical http:GRAPHQL:/graphql/<Root>/<field> shape so
+		// it cross-links to the GraphQL server records via the Name-based HTTP
+		// linker — mirroring the JS/TS, Dart and Swift GraphQL client passes.
+		// Gated on a `gql(` marker so it no-ops on every other Python file.
+		synthesizePyGraphQLClient(string(content), emitClientRuntime)
 		// SOAP + JSON-RPC (epic #3628): zeep `client.service.<Op>()` SOAP calls
 		// and xmlrpc/jsonrpc `register_function` producers + `ServerProxy(...)`
 		// client calls, keyed http:SOAP:/soap/... and http:JSONRPC:/jsonrpc/...


### PR DESCRIPTION
## Slice (epic #3607)

Closes the **Python GraphQL-client cross-link gap** — the epic's #1-ranked, highest-value axis (client GraphQL operations → server ops cross-repo). A PROBE of the existing GraphQL extraction showed the epic's matrix is badly stale: JS/TS, Dart and Swift GraphQL **clients** already emit operation-level `http_endpoint_call`s; gqlgen/Graphene/Ariadne/HotChocolate/graphql-ruby/Spring-GraphQL/caliban/async-graphql/Strawberry **servers** are all implemented; federation `@key`/FEDERATES and DataLoader (JS/TS + Python) exist. The single biggest **bounded** remaining gap on the highest-value axis was the **Python client**, where the dominant `gql` package produced nothing at the operation level.

## What this does

The Python `gql` package builds operations via `gql("...")`. This pass parses each `gql(<string-literal>)` document and emits one synthetic `http_endpoint_call` (consumer) per (operation, root field), keyed to **exactly** match the server endpoint shape every archigraph GraphQL server synthesizer produces:

```
gql("query { users { id } }")  →  http_endpoint_call  http:GRAPHQL:/graphql/Query/users
```

Because the id is identical to the server-side definition, the existing **Name-based cross-repo HTTP linker joins the Python consumer to the backend resolver on reindex with NO new linker code** — mirroring the JS/TS (`http_endpoint_graphql_client.go`), Dart and Swift passes. Root type + fields come from the shared `gqlRootFieldsFromDoc` parser; the FETCHES edge is attributed to the enclosing function (top-level const resolved from its reference site). Dispatched from `case "python":` in `applyHTTPEndpointSynthesis`, gated on a `gql(` marker so it no-ops on every other Python file.

## Tests (RED→GREEN, value-asserting)
- const-ref query → `http:GRAPHQL:/graphql/Query/user` + FETCHES
- inline mutation → `Mutation/createUser` + FETCHES
- multi-field query → `Query/stats` + `Query/alerts`
- subscription → `Subscription/messageAdded`
- anonymous shorthand `{ users { id } }` → `Query/users`
- negative: plain `requests.get` (no `gql()`) emits no GraphQL endpoint

## Coverage
New record `lang.python.framework.gql-client` (additive, surgical 170-line insert; `fmt --check` clean, `validate` 0 errors) with `Substrate/http_effect = full`.

## Deferred (follow-ups to file under #3607)
- Python: cross-file imported `gql` consts referenced by name only; dynamically-composed query strings; `sgqlc` / `python-graphql-client` idioms
- Other client languages: Go (`machinebox/graphql`, `hasura/go-graphql-client`), Kotlin/Java (Apollo-Kotlin/-Android)
- DataLoader (#3624) for Go / Java / Kotlin (currently JS/TS + Python only)

Part of #3607

🤖 Generated with [Claude Code](https://claude.com/claude-code)