### PR TITLE
perf(mcp): get_source precise slicing + visible truncation signal (#2828)

### DIFF
--- a/internal/mcp/get_source_2828_test.go
+++ b/internal/mcp/get_source_2828_test.go
@@ -1,0 +1,199 @@
+package mcp
+
+// get_source_2828_test.go — #2828 token-cost controls for archigraph_get_source
+// (the single busiest MCP tool, ~45% of live tool-call token spend).
+//
+// Coverage:
+//   - a default call on a LARGE entity returns a bounded slice (the hard
+//     200-line ceiling) AND a visible "truncated — request lines X-Y" marker so
+//     the caller can fetch the rest precisely ([no-silent-caps]);
+//   - an explicit start_line/end_line returns exactly that range (no marker);
+//   - max_lines heads the emitted line count and signals truncation;
+//   - the explicit-range payload is materially smaller than the full-span
+//     default, while line-number facts survive;
+//   - computeSourceSpan unit cases for the span/truncation policy.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// build2828SourceServer writes an N-line source file on disk and returns a
+// server whose single entity spans [start,end].
+func build2828SourceServer(t *testing.T, nLines, start, end int) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	lines := make([]string, 0, nLines)
+	for i := 1; i <= nLines; i++ {
+		lines = append(lines, fmt.Sprintf("statement_%d := compute(%d)", i, i))
+	}
+	srcPath := dir + "/big.go"
+	if err := os.WriteFile(srcPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "big", Name: "Big", Kind: "Function", SourceFile: "big.go", StartLine: start, EndLine: end},
+		},
+	}
+	srv := newTestServer(t, doc)
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+	return srv
+}
+
+func callGetSource(t *testing.T, s *Server, args map[string]any) string {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := s.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("unexpected error result: %+v", res)
+	}
+	return extractResultText(t, res)
+}
+
+func TestGetSource_2828_DefaultLargeEntityTruncatesWithSignal(t *testing.T) {
+	t.Parallel()
+	// Entity spans 600 lines — well past the 200-line hard ceiling.
+	s := build2828SourceServer(t, 700, 5, 605)
+	out := callGetSource(t, s, map[string]any{"group": "test", "entity_id": "big", "context_lines": 0})
+
+	// Bounded: emitted source lines must not exceed the hard ceiling.
+	srcLines := 0
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, "statement_") {
+			srcLines++
+		}
+	}
+	if srcLines > getSourceHardMaxLines {
+		t.Fatalf("emitted %d source lines, exceeds hard cap %d", srcLines, getSourceHardMaxLines)
+	}
+	// Visible truncation marker with a precise continuation hint.
+	if !strings.Contains(out, "archigraph: truncated") {
+		t.Fatalf("missing truncation marker:\n%s", tail(out))
+	}
+	if !strings.Contains(out, "start_line=") || !strings.Contains(out, "end_line=") {
+		t.Errorf("truncation marker lacks precise continuation range:\n%s", tail(out))
+	}
+}
+
+func TestGetSource_2828_ExplicitRangeExactAndSmaller(t *testing.T) {
+	t.Parallel()
+	s := build2828SourceServer(t, 700, 5, 605)
+
+	full := callGetSource(t, s, map[string]any{"group": "test", "entity_id": "big", "context_lines": 0})
+	ranged := callGetSource(t, s, map[string]any{
+		"group": "test", "entity_id": "big", "start_line": 10, "end_line": 14,
+	})
+
+	// Exactly the requested 5 lines (10..14), no others, no truncation marker.
+	for _, want := range []int{10, 11, 12, 13, 14} {
+		if !strings.Contains(ranged, fmt.Sprintf("statement_%d ", want)) {
+			t.Errorf("explicit range missing line %d:\n%s", want, ranged)
+		}
+	}
+	if strings.Contains(ranged, "statement_9 ") || strings.Contains(ranged, "statement_15 ") {
+		t.Errorf("explicit range leaked lines outside [10,14]:\n%s", ranged)
+	}
+	if strings.Contains(ranged, "archigraph: truncated") {
+		t.Errorf("explicit range should not be marked truncated:\n%s", ranged)
+	}
+	if len(ranged) >= len(full) {
+		t.Fatalf("explicit range (%d B) not smaller than full-span default (%d B)", len(ranged), len(full))
+	}
+	t.Logf("get_source bytes: range=%d default=%d (%.1f%% smaller)",
+		len(ranged), len(full), 100*float64(len(full)-len(ranged))/float64(len(full)))
+}
+
+func TestGetSource_2828_MaxLinesHeadsAndSignals(t *testing.T) {
+	t.Parallel()
+	s := build2828SourceServer(t, 700, 5, 605)
+	out := callGetSource(t, s, map[string]any{
+		"group": "test", "entity_id": "big", "context_lines": 0, "max_lines": 12,
+	})
+	srcLines := strings.Count(out, "statement_")
+	// statement_ also appears inside the marker text once (in the hint), so allow
+	// a small slack; the body itself must be <= 12.
+	if srcLines > 14 {
+		t.Fatalf("max_lines=12 emitted ~%d source lines", srcLines)
+	}
+	if !strings.Contains(out, "archigraph: truncated") {
+		t.Fatalf("max_lines truncation not signaled:\n%s", tail(out))
+	}
+}
+
+func TestComputeSourceSpan_2828_Policy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name               string
+		e                  graph.Entity
+		opts               sourceWindowOpts
+		wantStart, wantEnd int
+		wantTrunc          bool
+	}{
+		{
+			name:      "small span no truncation",
+			e:         graph.Entity{StartLine: 10, EndLine: 20},
+			opts:      sourceWindowOpts{contextLines: 2},
+			wantStart: 8, wantEnd: 22, wantTrunc: false,
+		},
+		{
+			name:      "huge span hard-capped + truncated",
+			e:         graph.Entity{StartLine: 1, EndLine: 1000},
+			opts:      sourceWindowOpts{contextLines: 0},
+			wantStart: 1, wantEnd: getSourceHardMaxLines, wantTrunc: true,
+		},
+		{
+			name:      "explicit range literal no padding",
+			e:         graph.Entity{StartLine: 1, EndLine: 1000},
+			opts:      sourceWindowOpts{contextLines: 8, startLine: 50, endLine: 60},
+			wantStart: 50, wantEnd: 60, wantTrunc: false,
+		},
+		{
+			name:      "max_lines caps below hard ceiling",
+			e:         graph.Entity{StartLine: 1, EndLine: 1000},
+			opts:      sourceWindowOpts{contextLines: 0, maxLines: 30},
+			wantStart: 1, wantEnd: 30, wantTrunc: true,
+		},
+		{
+			name:      "degenerate span uses fallback window",
+			e:         graph.Entity{StartLine: 0, EndLine: 0},
+			opts:      sourceWindowOpts{contextLines: 0},
+			wantStart: 1, wantEnd: 1 + getSourceFallbackSpan, wantTrunc: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sp := computeSourceSpan(&tc.e, tc.opts)
+			if sp.start != tc.wantStart || sp.end != tc.wantEnd {
+				t.Errorf("span = [%d,%d], want [%d,%d]", sp.start, sp.end, tc.wantStart, tc.wantEnd)
+			}
+			if sp.truncated != tc.wantTrunc {
+				t.Errorf("truncated = %v, want %v", sp.truncated, tc.wantTrunc)
+			}
+			if tc.wantTrunc && sp.truncationMarker("X") == "" {
+				t.Error("expected non-empty truncation marker")
+			}
+			if !tc.wantTrunc && sp.truncationMarker("X") != "" {
+				t.Error("expected empty truncation marker")
+			}
+		})
+	}
+}
+
+// tail returns the last ~400 chars of s for compact failure output.
+func tail(s string) string {
+	if len(s) <= 400 {
+		return s
+	}
+	return "..." + s[len(s)-400:]
+}

--- a/internal/mcp/get_source_window.go
+++ b/internal/mcp/get_source_window.go
@@ -1,0 +1,161 @@
+package mcp
+
+// get_source_window.go — #2828 token-cost policy for archigraph_get_source.
+//
+// get_source is the single busiest MCP tool (~45% of live tool-call token
+// spend). Two cost levers, both ESSENTIAL-data-preserving (less-by-default,
+// opt-in for more, every truncation SIGNALED — the [no-silent-caps] rule):
+//
+//  1. Precise slicing. Callers can pass an explicit line range
+//     (start_line/end_line) or a head cap (max_lines) so they pay only for the
+//     slice they need instead of the whole entity span + padding. The legacy
+//     entity-span behaviour is unchanged when none are passed.
+//  2. Visible truncation. The pre-#2828 handler silently clamped any span to a
+//     hard 200-line cap with NO signal — a caller reading a 600-line class got
+//     the first 200 lines and could not tell it was cut nor how to get the
+//     rest. computeSourceSpan now reports whether the emitted window was capped
+//     and the full available range, so the handler can append a precise
+//     "request lines X-Y" continuation hint.
+//
+// These params are read off the request map (not declared in the tool schema)
+// per the #1639 token-ceiling pattern and are allow-listed in
+// schema_contract_ast_test.go. They are pure opt-in: the default call shape is
+// byte-for-byte identical to the pre-#2828 behaviour apart from the appended
+// truncation marker, which only appears WHEN a window is actually clamped.
+
+import (
+	"fmt"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+const (
+	// getSourceFallbackSpan is the window used when an entity records a
+	// degenerate span (end<=start or either bound 0) — common for synthetic /
+	// shadow / route entities.
+	getSourceFallbackSpan = 60
+	// getSourceHardMaxLines is the absolute ceiling on emitted source lines so a
+	// single get_source can never become a whole-file dump regardless of the
+	// recorded span or an over-large caller max_lines.
+	getSourceHardMaxLines = 200
+)
+
+// sourceSpan is the resolved emit window plus the metadata needed to signal a
+// truncation to the caller without silently dropping data.
+type sourceSpan struct {
+	start int // first line emitted (1-based, inclusive)
+	end   int // last line emitted (1-based, inclusive)
+
+	// truncated is true when the emitted [start,end] window is a strict prefix
+	// of the entity's available span because a cap (hard ceiling or caller
+	// max_lines) fired. When true, fullEnd is the last line of the available
+	// span so the caller can request the remainder precisely.
+	truncated bool
+	fullEnd   int
+}
+
+// sourceWindowOpts carries the caller's opt-in slicing controls. Zero values
+// mean "use the entity span" (legacy behaviour).
+type sourceWindowOpts struct {
+	contextLines int // padding lines on each side of the entity span (default 8)
+	startLine    int // explicit window start; 0 = derive from entity
+	endLine      int // explicit window end; 0 = derive from entity
+	maxLines     int // head cap on emitted lines; 0 = use hard ceiling only
+}
+
+// computeSourceSpan resolves the line window to emit for entity e under opts,
+// applying the degenerate-span clamp, an optional explicit range, an optional
+// caller max_lines head cap, and the absolute hard-max ceiling — and records
+// whether the result was truncated plus the full available end so the caller
+// can be told how to fetch the rest.
+//
+// Precedence:
+//   - explicit start_line/end_line (either or both) override the entity span;
+//   - context_lines padding is applied to the (derived) entity span only, not
+//     to an explicit range (an explicit range is taken literally);
+//   - max_lines (capped at the hard ceiling) bounds the emitted line count;
+//   - the hard ceiling always applies last.
+func computeSourceSpan(e *graph.Entity, opts sourceWindowOpts) sourceSpan {
+	contextLines := opts.contextLines
+
+	// Derive the base entity span, clamping a degenerate record.
+	startLine := e.StartLine
+	endLine := e.EndLine
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine <= startLine || e.StartLine == 0 || e.EndLine == 0 {
+		endLine = startLine + getSourceFallbackSpan
+	}
+
+	var start, end int
+	explicit := opts.startLine > 0 || opts.endLine > 0
+	if explicit {
+		// Explicit range: taken literally (no context padding). Fill an omitted
+		// bound from the entity span so start_line-only / end_line-only work.
+		start = opts.startLine
+		if start < 1 {
+			start = startLine
+		}
+		end = opts.endLine
+		if end < 1 {
+			end = endLine
+		}
+		if end < start {
+			end = start
+		}
+	} else {
+		start = startLine - contextLines
+		if start < 1 {
+			start = 1
+		}
+		end = endLine + contextLines
+	}
+
+	// The full available span end, BEFORE any line-count cap — used to tell the
+	// caller how to request the remainder.
+	fullEnd := end
+
+	// Effective per-call line cap: the smaller of the hard ceiling and a
+	// caller-supplied max_lines (when positive).
+	cap := getSourceHardMaxLines
+	if opts.maxLines > 0 && opts.maxLines < cap {
+		cap = opts.maxLines
+	}
+	truncated := false
+	if end-start+1 > cap {
+		end = start + cap - 1
+		truncated = true
+	}
+
+	return sourceSpan{start: start, end: end, truncated: truncated, fullEnd: fullEnd}
+}
+
+// truncationMarker renders the continuation hint appended to a truncated
+// get_source body. Returns "" when nothing was truncated (no marker on the
+// common case, so the default payload is unchanged).
+func (sp sourceSpan) truncationMarker(entityID string) string {
+	if !sp.truncated {
+		return ""
+	}
+	nextStart := sp.end + 1
+	return fmt.Sprintf(
+		"\n# archigraph: truncated — emitted lines %d-%d of %d-%d. "+
+			"Request the rest with get_source(entity_id=%q, start_line=%d, end_line=%d).\n",
+		sp.start, sp.end, sp.start, sp.fullEnd, entityID, nextStart, sp.fullEnd,
+	)
+}
+
+// readSourceWindowOpts reads the #2828 opt-in slicing controls off the request
+// map. They are intentionally undeclared in the tool schema per the #1639
+// token-ceiling pattern (allow-listed in schema_contract_ast_test.go).
+func readSourceWindowOpts(req mcpapi.CallToolRequest, contextLines int) sourceWindowOpts {
+	return sourceWindowOpts{
+		contextLines: contextLines,
+		startLine:    argInt(req, "start_line", 0),
+		endLine:      argInt(req, "end_line", 0),
+		maxLines:     argInt(req, "max_lines", 0),
+	}
+}

--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -111,6 +111,13 @@ var intentionalGaps = []intentionalGap{
 
 	// archigraph_get_source: legacy alias node_id — deprecated, intentionally undeclared.
 	{"archigraph_get_source", "node_id", "deprecated alias for entity_id, intentionally undeclared"},
+	// archigraph_get_source: #2828 opt-in precise-slicing controls — read off the
+	// request map per the #1639 token-ceiling pattern (declaring them would bloat
+	// the handshake). start_line/end_line take an explicit range; max_lines heads
+	// the emitted line count. All optional; absence = legacy entity-span behaviour.
+	{"archigraph_get_source", "start_line", "#2828 / #1639 token-ceiling: opt-in explicit line range, undeclared"},
+	{"archigraph_get_source", "end_line", "#2828 / #1639 token-ceiling: opt-in explicit line range, undeclared"},
+	{"archigraph_get_source", "max_lines", "#2828 / #1639 token-ceiling: opt-in head cap, undeclared"},
 
 	// archigraph_patterns: action-specific args for sub-actions (query, record, get,
 	// reject, promote) that are undeclared in the schema to stay under the token-ceiling
@@ -234,6 +241,7 @@ var sharedHelpers = map[string]bool{
 	"emitActivity":           true,
 	"argMinConfidence":       true, // #2769 Phase 1C — shared min_confidence reader
 	"includeWants":           true, // #4423 — shared opt-in facet reader (include declared on archigraph_effects)
+	"readSourceWindowOpts":   true, // #2828 — get_source slicing reader; start_line/end_line/max_lines allow-listed under archigraph_get_source
 }
 
 // argFuncNames is the set of arg-reader function names to match in the AST.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -451,7 +451,7 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_whoami", s.handleWhoami))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_source",
-		mcpapi.WithDescription("Return source for a node; accepts id, qualified_name, or label."),
+		mcpapi.WithDescription("Source for a node (id/qname/label). Opt-in: start_line/end_line/max_lines."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("context_lines", mcpapi.DefaultNumber(8)), // #2828: was 20
 		mcpapi.WithAny("group"),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2309,33 +2309,17 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 		abs = filepath.Join(lr.Path, e.SourceFile)
 	}
 
-	// Bound the requested span (#1614). Synthetic / shadow / route entities
-	// frequently carry end_line<=start_line or start_line==0, which previously
-	// caused get_source to emit the entire file. Clamp a degenerate span to a
-	// fixed fallback window, and ALWAYS apply a hard max-lines cap so the
-	// returned chunk can never be a whole-file dump regardless of the recorded
-	// span.
-	const fallbackSpan = 60  // lines, when end<=start or either is 0
-	const hardMaxLines = 200 // absolute cap on emitted source lines
-
-	startLine := e.StartLine
-	endLine := e.EndLine
-	if startLine < 1 {
-		startLine = 1
-	}
-	if endLine <= startLine || e.StartLine == 0 || e.EndLine == 0 {
-		endLine = startLine + fallbackSpan
-	}
-
-	start := startLine - contextLines
-	if start < 1 {
-		start = 1
-	}
-	end := endLine + contextLines
-	// Hard cap: never emit more than hardMaxLines.
-	if end-start+1 > hardMaxLines {
-		end = start + hardMaxLines - 1
-	}
+	// #2828 / #1614 — bound the requested span and SIGNAL any truncation.
+	// computeSourceSpan clamps a degenerate span (synthetic/shadow/route
+	// entities frequently carry end<=start or a 0 bound, which previously
+	// emitted the whole file), applies the caller's opt-in start_line/end_line
+	// range and max_lines head cap, and enforces the absolute hard-max ceiling
+	// so a single call can never be a whole-file dump. The returned sourceSpan
+	// records whether the emitted window is a strict prefix of the available
+	// span so we can append a precise "request lines X-Y" continuation hint
+	// instead of the pre-#2828 SILENT 200-line clamp ([no-silent-caps]).
+	sp := computeSourceSpan(e, readSourceWindowOpts(req, contextLines))
+	start, end := sp.start, sp.end
 
 	// #1678: bound the file I/O with a hard deadline. The daemon owns fsnotify
 	// watchers on every indexed source tree; under certain macOS conditions a
@@ -2367,7 +2351,10 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 		if out.err != nil {
 			return mcpapi.NewToolResultError(out.err.Error()), nil
 		}
-		return mcpapi.NewToolResultText(out.text), nil
+		// #2828: append the continuation hint only when a window was actually
+		// clamped (truncationMarker returns "" otherwise, so the common-case
+		// payload is unchanged).
+		return mcpapi.NewToolResultText(out.text + sp.truncationMarker(prefixedID(lr.Repo, e.ID))), nil
 	case <-readCtx.Done():
 		return mcpapi.NewToolResultError(fmt.Sprintf(
 			"get_source: read timed out after 5s on %s (file may be on a stalled filesystem or watched-path kernel stall); node_id=%s",
@@ -2381,25 +2368,13 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 // main get_source path) and returns the body text. Used by the #3833 MRO
 // redirect to read an in-repo base class's defining body.
 func readInheritedBody(ctx context.Context, abs string, e *graph.Entity, contextLines int) (string, error) {
-	const fallbackSpan = 60
-	const hardMaxLines = 200
-
-	startLine := e.StartLine
-	endLine := e.EndLine
-	if startLine < 1 {
-		startLine = 1
-	}
-	if endLine <= startLine || e.StartLine == 0 || e.EndLine == 0 {
-		endLine = startLine + fallbackSpan
-	}
-	start := startLine - contextLines
-	if start < 1 {
-		start = 1
-	}
-	end := endLine + contextLines
-	if end-start+1 > hardMaxLines {
-		end = start + hardMaxLines - 1
-	}
+	// #2828: reuse the shared span policy (degenerate-span clamp + hard ceiling)
+	// for the inherited-body redirect. The inherited path does not accept the
+	// per-call start_line/end_line/max_lines opt-ins (the caller targeted the
+	// subclass member, not the resolved base span), so only context_lines is
+	// passed.
+	sp := computeSourceSpan(e, sourceWindowOpts{contextLines: contextLines})
+	start, end := sp.start, sp.end
 
 	readCtx, readCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer readCancel()


### PR DESCRIPTION
## #2828 — reduce MCP billed-token cost on the heaviest tool

`archigraph_get_source` is the single busiest MCP tool (~45% of live tool-call token spend per the iter9 quality bench). This PR adds the two remaining token levers it lacked, both **essential-data-preserving** (less-by-default, opt-in for more, every truncation **signaled** — the `[no-silent-caps]` rule):

### 1. Precise slicing (opt-in)
- `start_line` / `end_line` — return exactly that literal range (no context padding), so a caller reading one method out of a 600-line class pays for ~10 lines, not 200.
- `max_lines` — head cap on emitted line count.
- All read off the request map per the **#1639 token-ceiling pattern** (no handshake bloat) and allow-listed in `schema_contract_ast_test.go`. Absence = **unchanged** legacy entity-span behaviour.

### 2. Visible truncation
The pre-#2828 handler silently clamped any span to a hard 200-line ceiling with **no signal** — a caller reading a long entity got the first 200 lines and could not tell it was cut nor how to get the rest. `computeSourceSpan` now reports whether the emitted window is a strict prefix of the available span and the handler appends a precise hint:

```
# archigraph: truncated — emitted lines 5-204 of 5-613. Request the rest with get_source(entity_id="repo::big", start_line=205, end_line=613).
```

The marker appears **only when a window is actually clamped**, so the common-case default payload is byte-identical to before.

### Estimated savings
- A precise `start_line/end_line` slice on a large entity is materially smaller than the full-span default (asserted in tests). On the upvate bench, get_source dominated billed tokens via 40 lines of surrounding padding + whole-entity spans; agents can now request the exact slice once they've oriented, and when they do hit the 200-line cap they get a precise continuation instead of re-fetching blind.
- `find` (the #2 spender) already carries `token_budget` (default 800) + `verbose`/`fields` opt-ins from prior #2828 work (PR #3364); `search_entities`/`auth_coverage` terse+budget also already landed. This PR closes the remaining get_source gap.

### Shared policy
`computeSourceSpan` centralizes the degenerate-span clamp + hard ceiling and is reused by the #3833 inherited-body redirect, replacing the two duplicated inline span blocks.

### Safety / schema contract
- Tool **count unchanged** — only opt-in params added (undeclared per #1639).
- `schema_contract_ast_test.go`: `start_line`/`end_line`/`max_lines` added to the `intentionalGaps` allowlist; `readSourceWindowOpts` registered in `sharedHelpers`.
- No tool semantics changed: callers get **less-by-default-with-opt-in-for-more**, never wrong data; every truncation is signaled.

### Tests
`get_source_2828_test.go`:
- default call on a large entity returns a bounded slice **and** the truncation marker with a precise continuation range;
- explicit `start_line`/`end_line` returns exactly that range, no marker, and a smaller payload than the full-span default;
- `max_lines` heads the line count and signals truncation;
- `computeSourceSpan` policy units (small/huge/explicit/max_lines/degenerate).

### Gates
- `go build ./...` ✅
- `go vet ./internal/mcp/...` ✅
- `go test ./internal/mcp/...` ✅ (incl. schema-contract + budget/ceiling + the new 2828 assertions)
- `coverage fmt --check` ✅ (no registry change — not a per-language capability)

### Deploy-deferred
The live MCP (the rewrite agent's) is **unaffected** until an authorized daemon rebuild + restart.

Closes #2828

🤖 Generated with [Claude Code](https://claude.com/claude-code)