### PR TITLE
fix: remove redundant inner show/hide toggle from InsightButton popover (#4812)

### DIFF
--- a/webui-v2/src/components/chrome/insight-button.tsx
+++ b/webui-v2/src/components/chrome/insight-button.tsx
@@ -63,6 +63,7 @@ export function InsightButton() {
             human={insight.human}
             agent={insight.agent}
             storageKey={insight.storageKey}
+            alwaysExpanded
           />
         </div>
       </PopoverContent>

--- a/webui-v2/src/components/ui/insight-banner.tsx
+++ b/webui-v2/src/components/ui/insight-banner.tsx
@@ -25,6 +25,13 @@ export interface InsightBannerProps {
    * key so a user who collapses one banner sees them collapsed everywhere.
    */
   storageKey?: string;
+  /**
+   * When true, the banner always renders its two-column content with no
+   * collapse/show-insight toggle. Used where an outer control (e.g. the
+   * breadcrumb InsightButton popover) is already the sole show/hide toggle,
+   * so an inner one would be redundant.
+   */
+  alwaysExpanded?: boolean;
 }
 
 const STORAGE_PREFIX = "ag.insightBanner.collapsed";
@@ -57,8 +64,8 @@ function writeCollapsed(storageKey: string | undefined, collapsed: boolean) {
  * in localStorage) so power users can reclaim vertical space. Replaces the
  * separate {@link ScreenDescription} + {@link AgentUsage} pair.
  */
-export function InsightBanner({ human, agent, storageKey }: InsightBannerProps) {
-  const [collapsed, setCollapsed] = useState(() => readCollapsed(storageKey));
+export function InsightBanner({ human, agent, storageKey, alwaysExpanded = false }: InsightBannerProps) {
+  const [collapsed, setCollapsed] = useState(() => !alwaysExpanded && readCollapsed(storageKey));
 
   const setAndPersist = useCallback(
     (next: boolean) => {
@@ -68,7 +75,7 @@ export function InsightBanner({ human, agent, storageKey }: InsightBannerProps) 
     [storageKey],
   );
 
-  if (collapsed) {
+  if (collapsed && !alwaysExpanded) {
     return (
       <div className="mb-3 max-w-4xl">
         <button
@@ -86,15 +93,17 @@ export function InsightBanner({ human, agent, storageKey }: InsightBannerProps) 
 
   return (
     <div className="relative mb-3 w-full overflow-hidden rounded-lg border border-border bg-surface">
-      <button
-        type="button"
-        onClick={() => setAndPersist(true)}
-        aria-label="Collapse insight banner"
-        title="Collapse"
-        className="absolute right-1.5 top-1.5 z-10 rounded-md p-1 text-text-4 transition-colors hover:bg-surface-2 hover:text-text-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
-      >
-        <X size={14} />
-      </button>
+      {!alwaysExpanded && (
+        <button
+          type="button"
+          onClick={() => setAndPersist(true)}
+          aria-label="Collapse insight banner"
+          title="Collapse"
+          className="absolute right-1.5 top-1.5 z-10 rounded-md p-1 text-text-4 transition-colors hover:bg-surface-2 hover:text-text-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]"
+        >
+          <X size={14} />
+        </button>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2">
         {/* LEFT — human */}


### PR DESCRIPTION
## Problem
The breadcrumb **Insights** button is already the show/hide toggle for its popover. The popover rendered an `InsightBanner` that, in its collapsed state, showed a redundant inner **Show insight** button — and its collapse-X would empty the popover. Two toggles for one popover.

## Fix
- Add an `alwaysExpanded` prop to `InsightBanner` (`webui-v2/src/components/ui/insight-banner.tsx`). When set, the banner always renders its two-column human/agent content directly — no inner collapsed "Show insight" trigger and no collapse-X.
- `InsightButton` popover (`webui-v2/src/components/chrome/insight-button.tsx`) passes `alwaysExpanded`, so it opens straight to content.

The breadcrumb button itself and the glow-on-navigate behavior are unchanged. Existing inline banner usages (without the prop) keep their collapse behavior.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅
- `npx vite build` ✅

Closes #4812

🤖 Generated with [Claude Code](https://claude.com/claude-code)