### PR TITLE
fix(paths): respect selected verb in detail pane + expand query/response DTOs (#4813 #4814)

### DIFF
--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -869,11 +869,19 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
     path: rawDetail.path ?? "",
     outbound: rawDetail.outbound ?? {},
   } as PathDetail;
-  // Default to the verb selected in the list row (from URL), fall back to "all".
-  const [verbFilter] = useState<string>(() => {
+  // #4813 — resolve the active verb from the selected list row / `verb` URL
+  // param. The path-detail query is keyed by path-hash ONLY, so the same
+  // `detail` (and this same DetailPane instance) is reused across verbs of one
+  // path. A frozen `useState(() => …)` initializer captured only the verb that
+  // was selected on first mount, so clicking POST after viewing GET kept
+  // showing GET's contract. Derive it reactively instead so the header,
+  // Parameters, Response, Defined-in, Posture and downstream-DAG verb all track
+  // the CURRENTLY selected verb. Falls back to "all" only for legacy hash-only
+  // deep-links (no verb) or a verb the payload doesn't actually expose.
+  const verbFilter = useMemo<string>(() => {
     if (initialVerb && (rawDetail.verbs ?? []).includes(initialVerb as HttpVerb)) return initialVerb;
     return "all";
-  });
+  }, [initialVerb, rawDetail.verbs]);
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     description: true,
     auth: true,
@@ -2276,7 +2284,16 @@ export default function PathsScreen() {
                   <p className="text-sm text-text-3">Route detail not found.</p>
                 </div>
               ) : (
-                <DetailPane detail={detail} initialVerb={selectedVerb} groupId={groupId} />
+                <DetailPane
+                  // #4813 — key on (hash, verb) so switching verbs of the same
+                  // path remounts the pane with fresh per-verb child state
+                  // (status-code tab, ShapeTree expand state) rather than
+                  // reusing the previously-selected verb's view.
+                  key={`${selectedHash}:${selectedVerb ?? "all"}`}
+                  detail={detail}
+                  initialVerb={selectedVerb}
+                  groupId={groupId}
+                />
               )}
             </div>
           </div>


### PR DESCRIPTION
## Bugs

### #4813 — verb not respected in detail panel
Selecting POST /x showed the GET endpoint's contract (header, Parameters, Response, Posture, Defined-in). The path-detail query is keyed by **path-hash only**, so a single `DetailPane` instance is reused across all verbs of a path — and `verbFilter` was frozen by a `useState(() => …)` initializer that only runs on first mount. Clicking POST after viewing GET kept rendering GET's verb-scoped slices.

**Fix:** derive `verbFilter` reactively via `useMemo(initialVerb, rawDetail.verbs)`, and key `DetailPane` on `${hash}:${verb}` at the call site so a verb switch remounts the pane with fresh per-verb child state (status-code tab, ShapeTree expand state). Now the header, Parameters, Response, Defined-in, Posture and the downstream-DAG verb all track the selected verb. Clicking each verb row (GET/POST/PUT/PATCH/DELETE) for the same path updates the panel to that verb's contract.

### #4814 — query-DTO + response DTO not expandable
The query/path/header object-DTO params and the response DTO are **already wired end-to-end** as expandable ShapeTree rows: the backend stamps `type_entity_id` + `has_children` for object-valued params and the response shape (#4606 / #4635, at parity with `@Body`), the frontend projects them through `paramToShapeTreeRow` / `responseToShapeTreeRows`, and `ShapeTree` renders the expand chevron for any row with `has_children`.

The reported "flat type name" (`query: ListAlternateAddressesQuery`) was the **stale GET query DTO shown on a POST selection** — the #4813 verb mismatch, not a missing ShapeTree wiring. With the verb resolved correctly, the selected verb's DTO params and response DTO expand to their fields as expected. No backend payload gap found.

## Gates
- `npm ci` ✅
- `npx tsc --noEmit` ✅ (exit 0)
- `npx vite build` ✅ (exit 0)

Closes #4813
Closes #4814

🤖 Generated with [Claude Code](https://claude.com/claude-code)