### PR TITLE
feat(#4821): persist conditional effects + loop-effect + cyclomatic complexity (control-flow part a)

### DIFF
--- a/internal/links/dataflow_pass.go
+++ b/internal/links/dataflow_pass.go
@@ -47,6 +47,13 @@ const MethodDataFlow = "data_flow"
 const (
 	DataFlowPropertyKeyFlows = "data_flows"
 	DataFlowPropertyKeyCount = "data_flows_count"
+	// ComplexityPropertyKeyCyclomatic / *BranchCount carry the cheap
+	// per-function control-flow summary (#4821, epic #4820): cyclomatic
+	// complexity (decision points + 1) and the raw branch count. Stamped on the
+	// handler entity so they persist on the graph and are queryable without the
+	// on-demand effects MCP facet.
+	ComplexityPropertyKeyCyclomatic  = "cyclomatic_complexity"
+	ComplexityPropertyKeyBranchCount = "branch_count"
 )
 
 // maxDataFlowSummary bounds the compact per-entity property summary.
@@ -156,7 +163,7 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 					links = append(links, l)
 					summaryFlows = append(summaryFlows, fl.DataFlow)
 				}
-				stampDataFlowSummary(g, fromID, summaryFlows)
+				stampDataFlowSummary(g, fromID, summaryFlows, string(content))
 			}
 		}
 	}
@@ -515,8 +522,14 @@ func lastIdent(s string) string {
 	return s
 }
 
-// stampDataFlowSummary writes the compact per-entity property summary.
-func stampDataFlowSummary(g *repoGraph, entityID string, flows []substrate.DataFlow) {
+// stampDataFlowSummary writes the compact per-entity property summary, plus the
+// #4821 cyclomatic_complexity / branch_count properties derived from the
+// handler's source window (fileContent is the full source of the file the
+// handler lives in; the window is sliced via the entity's StartLine/EndLine).
+// The complexity numbers persist on the graph so they are queryable without the
+// on-demand effects MCP facet; the facet remains the richer surface (it also
+// returns per-effect conditional/loop attribution).
+func stampDataFlowSummary(g *repoGraph, entityID string, flows []substrate.DataFlow, fileContent string) {
 	for ei := range g.Entities {
 		if g.Entities[ei].ID != entityID {
 			continue
@@ -527,8 +540,33 @@ func stampDataFlowSummary(g *repoGraph, entityID string, flows []substrate.DataF
 		}
 		e.Properties[DataFlowPropertyKeyFlows] = formatDataFlowSummary(flows, maxDataFlowSummary)
 		e.Properties[DataFlowPropertyKeyCount] = fmt.Sprintf("%d", len(flows))
+		if win := functionSourceWindow(fileContent, e.StartLine, e.EndLine); win != "" {
+			cx := substrate.ComputeFunctionComplexity(win)
+			e.Properties[ComplexityPropertyKeyCyclomatic] = fmt.Sprintf("%d", cx.Cyclomatic)
+			e.Properties[ComplexityPropertyKeyBranchCount] = fmt.Sprintf("%d", cx.BranchCount)
+		}
 		return
 	}
+}
+
+// functionSourceWindow slices the [start,end] 1-indexed line window out of a
+// file's content. Returns "" when the span is degenerate or out of range. When
+// EndLine is missing/zero it falls back to the rest of the file (the analyzer's
+// keyword count is body-local enough that a modest over-read is harmless, and
+// ComputeFunctionComplexity is monotone — a porting agent reads "≥ this many
+// branches", never fewer).
+func functionSourceWindow(content string, start, end int) string {
+	if content == "" || start <= 0 {
+		return ""
+	}
+	lines := strings.Split(content, "\n")
+	if start > len(lines) {
+		return ""
+	}
+	if end < start || end > len(lines) {
+		end = len(lines)
+	}
+	return strings.Join(lines[start-1:end], "\n")
 }
 
 // formatDataFlowSummary renders up to max flows as

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -625,6 +625,8 @@ type entityNode struct {
 	// real external packages (subtype=package) from bare-name built-in
 	// placeholders (subtype=function). See issue #566 / import_pass.go.
 	SourceFile string            // relative path
+	StartLine  int               // 1-indexed body start (0 when unknown)
+	EndLine    int               // 1-indexed body end (0 when unknown)
 	Properties map[string]string // optional
 }
 
@@ -753,6 +755,8 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 				Kind:       e.Kind,
 				Subtype:    e.Subtype,
 				SourceFile: e.SourceFile,
+				StartLine:  e.StartLine,
+				EndLine:    e.EndLine,
 				Properties: e.Properties,
 			})
 		}

--- a/internal/mcp/effect_contexts_4821_test.go
+++ b/internal/mcp/effect_contexts_4821_test.go
@@ -1,0 +1,157 @@
+package mcp
+
+// effect_contexts_4821_test.go — end-to-end test for the #4821 `effect_contexts`
+// facet (control-flow epic #4820 part a): conditional/loop effect attribution +
+// per-function cyclomatic complexity, surfaced via archigraph_effects
+// include="effect_contexts". Runs the REAL handler against small Python
+// (Django-shaped) and TS (NestJS-shaped) fixtures in testdata/effect_contexts_4821/.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func effectContextsTestServer(t *testing.T, sourceFile string, start, end int) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			{
+				ID: "op_sync", Name: "sync",
+				Kind:          "SCOPE.Operation",
+				QualifiedName: "svc.sync",
+				SourceFile:    sourceFile, StartLine: start, EndLine: end,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "effect_contexts_4821"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["upvate-core"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+func effectContextList(t *testing.T, out map[string]any) []map[string]any {
+	t.Helper()
+	raw, ok := out["effect_contexts"]
+	if !ok {
+		t.Fatalf("no effect_contexts in result: %v", out)
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("effect_contexts not an array: %T", raw)
+	}
+	out2 := make([]map[string]any, 0, len(arr))
+	for _, e := range arr {
+		if m, ok := e.(map[string]any); ok {
+			out2 = append(out2, m)
+		}
+	}
+	return out2
+}
+
+func findEffectCtx(ctxs []map[string]any, effect string) map[string]any {
+	for _, c := range ctxs {
+		if c["effect"] == effect {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestEffectContexts_Python: db_read top-level (unconditional), db_write under
+// an `if` (conditional + condition), http_out inside a `for` (in_loop), plus a
+// cyclomatic_complexity number.
+func TestEffectContexts_Python(t *testing.T) {
+	srv := effectContextsTestServer(t, "sync_service.py", 1, 7)
+	out := callEffects(t, srv, "sync", "effect_contexts")
+
+	if sup, _ := out["effect_contexts_supported"].(bool); !sup {
+		t.Fatalf("effect_contexts_supported should be true for python; got %v", out["effect_contexts_supported"])
+	}
+	if cx, _ := out["cyclomatic_complexity"].(float64); cx < 3 {
+		t.Errorf("cyclomatic_complexity = %v; want >= 3", out["cyclomatic_complexity"])
+	}
+	if _, ok := out["branch_count"]; !ok {
+		t.Errorf("branch_count missing")
+	}
+
+	ctxs := effectContextList(t, out)
+
+	if read := findEffectCtx(ctxs, "db_read"); read == nil {
+		t.Fatalf("no db_read context; got %v", ctxs)
+	} else if cond, _ := read["conditional"].(bool); cond {
+		t.Errorf("db_read should be unconditional, got %v", read)
+	}
+
+	if write := findEffectCtx(ctxs, "db_write"); write == nil {
+		t.Fatalf("no db_write context; got %v", ctxs)
+	} else {
+		if cond, _ := write["conditional"].(bool); !cond {
+			t.Errorf("db_write should be conditional, got %v", write)
+		}
+		if write["condition"] == nil || write["condition"] == "" {
+			t.Errorf("db_write should carry condition, got %v", write)
+		}
+	}
+
+	if http := findEffectCtx(ctxs, "http_out"); http == nil {
+		t.Fatalf("no http_out context; got %v", ctxs)
+	} else if loop, _ := http["in_loop"].(bool); !loop {
+		t.Errorf("http_out should be in_loop, got %v", http)
+	}
+}
+
+// TestEffectContexts_TS: same shape on a NestJS-flavoured TS service.
+func TestEffectContexts_TS(t *testing.T) {
+	srv := effectContextsTestServer(t, "sync.service.ts", 2, 11)
+	out := callEffects(t, srv, "sync", "effect_contexts")
+
+	if sup, _ := out["effect_contexts_supported"].(bool); !sup {
+		t.Fatalf("effect_contexts_supported should be true for jsts; got %v", out["effect_contexts_supported"])
+	}
+	if cx, _ := out["cyclomatic_complexity"].(float64); cx < 3 {
+		t.Errorf("cyclomatic_complexity = %v; want >= 3", out["cyclomatic_complexity"])
+	}
+
+	ctxs := effectContextList(t, out)
+
+	var sawCondWrite, sawLoopHTTP bool
+	for _, c := range ctxs {
+		switch c["effect"] {
+		case "db_write":
+			cond, _ := c["conditional"].(bool)
+			if cond && c["condition"] != nil && c["condition"] != "" {
+				sawCondWrite = true
+			}
+		case "http_out":
+			if loop, _ := c["in_loop"].(bool); loop {
+				sawLoopHTTP = true
+			}
+		}
+	}
+	if !sawCondWrite {
+		t.Errorf("expected conditional db_write with condition; got %v", ctxs)
+	}
+	if !sawLoopHTTP {
+		t.Errorf("expected http_out in_loop; got %v", ctxs)
+	}
+}
+
+// TestEffectContexts_DefaultUnchanged: without include=effect_contexts the
+// payload carries none of the new keys (#2828 opt-in contract).
+func TestEffectContexts_DefaultUnchanged(t *testing.T) {
+	srv := effectContextsTestServer(t, "sync_service.py", 1, 7)
+	out := callEffects(t, srv, "sync", "")
+	for _, k := range []string{"effect_contexts", "effect_contexts_supported", "cyclomatic_complexity", "branch_count"} {
+		if _, ok := out[k]; ok {
+			t.Errorf("key %q must be absent when facet not requested", k)
+		}
+	}
+}

--- a/internal/mcp/effects_tool.go
+++ b/internal/mcp/effects_tool.go
@@ -123,6 +123,10 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 	// #4423 — opt-in branches facet. Only computed when include=branches so
 	// the default effects payload stays byte-identical (no regression).
 	wantBranches := includeWants(req, "branches")
+	// #4821 — opt-in effect_contexts facet (conditional/loop effect attribution
+	// + per-function cyclomatic complexity). Same opt-in contract: default
+	// payload stays byte-identical (#2828 token-reduction respected).
+	wantEffectCtx := includeWants(req, "effect_contexts")
 
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
@@ -130,6 +134,7 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 			if e, ok := r.LabelIndex.ByID[local]; ok {
 				out := buildEffectsPayload(r.Repo, e, sidecar)
 				attachBranchesFacet(out, r, e, wantBranches)
+				attachEffectContextsFacet(out, r, e, wantEffectCtx)
 				return jsonResult(out), nil
 			}
 		}
@@ -168,6 +173,7 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 	}
 	out := buildEffectsPayload(matches[0].repo.Repo, matches[0].ent, sidecar)
 	attachBranchesFacet(out, matches[0].repo, matches[0].ent, wantBranches)
+	attachEffectContextsFacet(out, matches[0].repo, matches[0].ent, wantEffectCtx)
 	return jsonResult(out), nil
 }
 
@@ -229,6 +235,73 @@ func attachBranchesFacet(out map[string]any, lr *LoadedRepo, e *graph.Entity, wa
 	facets := analyzer(src, start)
 	out["branches_supported"] = true
 	out["branches"] = branchFacetsToJSON(facets)
+}
+
+// attachEffectContextsFacet computes and attaches the #4821 `effect_contexts`
+// facet: for each effect the function performs, whether it runs conditionally
+// (and under which condition) and whether it is inside a loop, plus a per-
+// function cyclomatic_complexity + branch_count summary. Opt-in like the
+// branches facet — no-op when not requested, so the default effects payload is
+// byte-identical (#2828 token-reduction respected).
+//
+// Scope: the first increment validates Python (Django/oracle stack) and JS/TS
+// (NestJS) — the upvate-v3 + upvate groups. Other languages are computed when
+// their effect sniffer + block detector exist but are expanded/validated in the
+// per-language generalize follow-ups (see epic #4820).
+func attachEffectContextsFacet(out map[string]any, lr *LoadedRepo, e *graph.Entity, want bool) {
+	if !want || out == nil || lr == nil || e == nil {
+		return
+	}
+	lang := substrate.LanguageForPath(e.SourceFile)
+	start, end := branchSourceSpan(e)
+	if start <= 0 {
+		return
+	}
+	abs := e.SourceFile
+	if !filepath.IsAbs(abs) && lr.Path != "" {
+		abs = filepath.Join(lr.Path, e.SourceFile)
+	}
+	src, err := readRawSourceWindow(abs, start, end)
+	if err != nil || src == "" {
+		return
+	}
+	contexts, complexity := substrate.EffectContextsFor(lang, src, start)
+	// Complexity is always derivable (language-neutral keyword count); surface
+	// it so the caller gets the branch_count/cyclomatic_complexity numbers even
+	// when the language has no effect sniffer.
+	out["cyclomatic_complexity"] = complexity.Cyclomatic
+	out["branch_count"] = complexity.BranchCount
+	if substrate.EffectSnifferFor(lang) == nil {
+		out["effect_contexts_supported"] = false
+		out["effect_contexts_note"] = fmt.Sprintf(
+			"effect-context attribution not yet implemented for language %q (epic #4820); supported: %v",
+			lang, substrate.EffectLanguages())
+		return
+	}
+	out["effect_contexts_supported"] = true
+	out["effect_contexts"] = effectContextsToJSON(contexts)
+}
+
+// effectContextsToJSON converts substrate EffectContexts to the public JSON
+// shape, keeping fields terse + opt-in (omit empties) per #2828.
+func effectContextsToJSON(ctxs []substrate.EffectContext) []map[string]any {
+	out := make([]map[string]any, 0, len(ctxs))
+	for _, c := range ctxs {
+		m := map[string]any{
+			"effect":      c.Effect,
+			"sink":        c.Sink,
+			"line":        c.Line,
+			"conditional": c.Conditional,
+		}
+		if c.Condition != "" {
+			m["condition"] = c.Condition
+		}
+		if c.InLoop {
+			m["in_loop"] = true
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // branchSourceSpan returns the [start,end] line window for an entity's body,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -570,7 +570,7 @@ func (s *Server) registerTools() {
 	// confidence (0..1) and sink primitive tags. Pure functions report
 	// effects=[] with effect_source="pure" and a low confidence floor.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_effects",
-		mcpapi.WithDescription("Effects (db/http/fs/mutation) + confidence + sinks; include=branches for CFG"),
+		mcpapi.WithDescription("Effects + sinks; include=branches|effect_contexts (cond/loop+complexity)"),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithString("include"),
 		mcpapi.WithArray("repo_filter"),

--- a/internal/mcp/testdata/effect_contexts_4821/sync.service.ts
+++ b/internal/mcp/testdata/effect_contexts_4821/sync.service.ts
@@ -1,0 +1,12 @@
+export class SyncService {
+  async sync(req: Request) {
+    const rows = await this.repo.find();
+    if (req.body.force) {
+      await this.repo.save({ name: 'seed' });
+    }
+    for (const row of rows) {
+      await fetch('https://api.example.com/notify', { method: 'POST' });
+    }
+    return { ok: true };
+  }
+}

--- a/internal/mcp/testdata/effect_contexts_4821/sync_service.py
+++ b/internal/mcp/testdata/effect_contexts_4821/sync_service.py
@@ -1,0 +1,7 @@
+def sync(self, request):
+    contacts = Contact.objects.filter(active=True)
+    if request.data.get("force"):
+        Contact.objects.create(name="seed")
+    for contact in contacts:
+        requests.post("https://api.example.com/notify", json={"id": contact.id})
+    return Response({"ok": True})

--- a/internal/substrate/effect_context.go
+++ b/internal/substrate/effect_context.go
@@ -1,0 +1,360 @@
+// Conditional / loop effect attribution + per-function cyclomatic complexity
+// (#4821, control-flow epic #4820 part (a)).
+//
+// The branch facet (branches.go) enumerates the response-affecting CONTROL-FLOW
+// decision points of a function. This file adds the complementary, effect-side
+// view the porting/audit agent needs: for each EFFECT a function performs
+// (db_read/db_write/http_call/message_publish/…), under WHAT CONDITION does it
+// run, and is it inside a LOOP (a fan-out / N+1 signal)?
+//
+// It is a second consumer of the same per-function source window the branch
+// facet walks, reusing the already-registered per-language effect sniffers
+// (EffectSnifferFor) to locate the sink lines, then classifying each sink's
+// enclosing block context:
+//
+//   - conditional = true  → the sink is inside an if/else-if/else, switch/case,
+//     or try/catch branch (vs unconditional/top-level).
+//   - condition          → the nearest enclosing branch predicate text, so the
+//     graph/MCP can answer "under what condition does this write / call?".
+//   - in_loop = true     → the sink is inside a for/while/foreach over a
+//     collection.
+//
+// Plus a cheap per-function summary: cyclomatic_complexity (decision points + 1)
+// and branch_count, persisted as properties on the function/operation entity.
+//
+// Like the branch facet, this is OPT-IN (computed only when the effects MCP tool
+// is asked for include="effect_contexts") so the default effects payload stays
+// byte-for-byte unchanged and the #2828 token-reduction work is respected.
+//
+// Block-scope detection is language-family general: Python keys on significant
+// indentation; brace languages on `{`/`}` depth. The flagship languages for the
+// first increment are Python (Django/oracle stack) and JS/TS (NestJS), matching
+// epic #4820's scope; other languages reuse whichever mechanism their family
+// uses but are validated/expanded in the per-language follow-ups.
+package substrate
+
+import (
+	"regexp"
+	"strings"
+)
+
+// EffectContext is one effect occurrence inside a function, annotated with the
+// control-flow context it runs under. JSON shape is the public contract the
+// effects MCP tool serialises.
+type EffectContext struct {
+	// Effect is the lattice element (db_read / db_write / http_call / …).
+	Effect string `json:"effect"`
+	// Sink is the short primitive tag that matched (e.g. "fetch",
+	// "requests.post", "repo.save"). Mirrors EffectMatch.Sink.
+	Sink string `json:"sink"`
+	// Line is the 1-indexed absolute source line of the sink.
+	Line int `json:"line"`
+	// Conditional is true when the sink is inside any conditional block
+	// (if/else-if/else, switch/case, try/catch). False when it runs
+	// unconditionally at the top level of the function body.
+	Conditional bool `json:"conditional"`
+	// Condition is the nearest enclosing branch predicate text (e.g.
+	// "if user.is_admin", "catch (e)", "if (flag)"). Empty when the sink is
+	// unconditional.
+	Condition string `json:"condition,omitempty"`
+	// InLoop is true when the sink is inside a for/while/foreach loop — a
+	// fan-out / N+1 signal.
+	InLoop bool `json:"in_loop,omitempty"`
+}
+
+// FunctionComplexity is the cheap per-function control-flow summary persisted as
+// entity properties (cyclomatic_complexity, branch_count).
+type FunctionComplexity struct {
+	// Cyclomatic is the cyclomatic complexity: decision points + 1.
+	Cyclomatic int `json:"cyclomatic_complexity"`
+	// BranchCount is the raw number of decision points (Cyclomatic - 1).
+	BranchCount int `json:"branch_count"`
+}
+
+// blockHeader is one enclosing control-flow header discovered while walking a
+// function body, with the source span it scopes and whether it is a loop.
+type blockHeader struct {
+	condition string
+	startLine int // 1-indexed absolute line of the header
+	endLine   int // exclusive absolute line at which the block's scope ends
+	isLoop    bool
+	indent    int // python: header indent; brace: nesting depth at header
+}
+
+// EffectContextsFor computes the conditional/loop attribution for every effect
+// the registered sniffer detects in funcSource, plus the per-function
+// complexity summary. startLine is the 1-indexed absolute file line of the
+// function's first line so emitted Line values are absolute. Returns nil
+// contexts (but a valid complexity) when the language has no effect sniffer or
+// no sinks are present. Pure + deterministic.
+func EffectContextsFor(lang, funcSource string, startLine int) ([]EffectContext, FunctionComplexity) {
+	complexity := ComputeFunctionComplexity(funcSource)
+	if strings.TrimSpace(funcSource) == "" {
+		return nil, complexity
+	}
+	sniffer := EffectSnifferFor(lang)
+	if sniffer == nil {
+		return nil, complexity
+	}
+	// Clamp to the target function's own body so sink lines from trailing
+	// sibling defs (when the window was EndLine-padded) are not mis-attributed.
+	clamped := ClampToFunctionBody(funcSource, lang)
+	matches := sniffer(clamped)
+	if len(matches) == 0 {
+		return nil, complexity
+	}
+	blocks := enclosingBlocks(clamped, lang, startLine)
+	out := make([]EffectContext, 0, len(matches))
+	for _, m := range matches {
+		if m.Line <= 0 {
+			continue
+		}
+		absLine := startLine + m.Line - 1 // EffectMatch.Line is 1-indexed within the window
+		ec := EffectContext{
+			Effect: string(m.Effect),
+			Sink:   m.Sink,
+			Line:   absLine,
+		}
+		if cond, loop, ok := innermostEnclosing(blocks, absLine); ok {
+			ec.Conditional = true
+			ec.Condition = cond
+			ec.InLoop = loop
+		}
+		out = append(out, ec)
+	}
+	return out, complexity
+}
+
+// innermostEnclosing returns the condition text + loop flag of the INNERMOST
+// block that encloses absLine, walking the (source-ordered) block list. The
+// loop flag is sticky: if ANY enclosing block (not just the innermost) is a
+// loop, in_loop is true — a sink nested under `for { if x { write } }` is still
+// a fan-out. The surfaced condition is the nearest enclosing predicate.
+func innermostEnclosing(blocks []blockHeader, absLine int) (cond string, inLoop bool, ok bool) {
+	bestSpan := int(^uint(0) >> 1) // max int
+	for _, b := range blocks {
+		if absLine <= b.startLine || absLine >= b.endLine {
+			continue
+		}
+		ok = true
+		if b.isLoop {
+			inLoop = true
+		}
+		if span := b.endLine - b.startLine; span < bestSpan {
+			bestSpan = span
+			cond = b.condition
+		}
+	}
+	return cond, inLoop, ok
+}
+
+// --- block-scope discovery ------------------------------------------------
+
+// enclosingBlocks enumerates every conditional/loop block header in a function
+// body with the absolute source span it scopes. Dispatches on language family:
+// Python uses indentation; brace languages use `{`/`}` depth.
+func enclosingBlocks(src, lang string, startLine int) []blockHeader {
+	switch {
+	case lang == "python":
+		return pythonBlocks(src, startLine)
+	case braceLangs[lang]:
+		return braceBlocks(src, startLine)
+	default:
+		// No block detector for this family yet — effects are still reported,
+		// just without conditional/loop attribution (honest-partial).
+		return nil
+	}
+}
+
+var (
+	pyCondHeaderRe = regexp.MustCompile(`^(\s*)((?:el)?if\b.*?|else|except\b[^:]*|elif\b.*?|with\b.*?|try)\s*:\s*(?:#.*)?$`)
+	pyLoopHeaderRe = regexp.MustCompile(`^(\s*)((?:async\s+)?for\b.*?|while\b.*?)\s*:\s*(?:#.*)?$`)
+)
+
+// pythonBlocks scopes if/elif/else/except/try/with (conditional) and for/while
+// (loop) blocks by indentation: a block runs from its header to the first
+// following non-blank line indented at or below the header.
+func pythonBlocks(src string, startLine int) []blockHeader {
+	lines := strings.Split(src, "\n")
+	var out []blockHeader
+	for i, raw := range lines {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		var cond string
+		var isLoop bool
+		var indent int
+		if m := pyLoopHeaderRe.FindStringSubmatch(raw); m != nil {
+			indent = len(m[1])
+			cond = strings.TrimSpace(m[2])
+			isLoop = true
+		} else if m := pyCondHeaderRe.FindStringSubmatch(raw); m != nil {
+			indent = len(m[1])
+			cond = strings.TrimSpace(m[2])
+		} else {
+			continue
+		}
+		end := i + 1
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == "" {
+				continue
+			}
+			if leadingWS(lines[j]) <= indent {
+				break
+			}
+			end = j + 1
+		}
+		out = append(out, blockHeader{
+			condition: cond,
+			startLine: startLine + i,
+			endLine:   startLine + end,
+			isLoop:    isLoop,
+			indent:    indent,
+		})
+	}
+	return out
+}
+
+var (
+	braceIfRe     = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\(`)
+	braceElseRe   = regexp.MustCompile(`^\s*\}?\s*else\b`)
+	braceCatchRe  = regexp.MustCompile(`^\s*\}?\s*catch\b`)
+	braceTryRe    = regexp.MustCompile(`^\s*try\b`)
+	braceSwitchRe = regexp.MustCompile(`^\s*switch\s*\(`)
+	braceForRe    = regexp.MustCompile(`^\s*for\s*[(\s]`)
+	braceWhileRe  = regexp.MustCompile(`^\s*}?\s*while\s*\(`)
+	braceForEachRe = regexp.MustCompile(`\.\s*for[Ee]ach\s*\(`)
+)
+
+// braceBlocks scopes brace-delimited conditional/loop blocks. For each header
+// line it finds the `{` that opens the block (K&R same-line or Allman next
+// line) and tracks depth to the matching `}`, recording the absolute span.
+func braceBlocks(src string, startLine int) []blockHeader {
+	lines := strings.Split(src, "\n")
+	var out []blockHeader
+	for i, raw := range lines {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		cond, isLoop, matched := classifyBraceHeader(raw)
+		if !matched {
+			continue
+		}
+		// Find the block span by brace depth from this header.
+		end := braceSpanEnd(lines, i)
+		out = append(out, blockHeader{
+			condition: cond,
+			startLine: startLine + i,
+			endLine:   startLine + end,
+			isLoop:    isLoop,
+		})
+	}
+	return out
+}
+
+// classifyBraceHeader reports whether a line opens a conditional/loop block and
+// returns its condition text + loop flag.
+func classifyBraceHeader(raw string) (cond string, isLoop bool, matched bool) {
+	scan := stripBraceNoise(raw)
+	switch {
+	case braceForRe.MatchString(scan):
+		return trimBraceCond(scan), true, true
+	case braceWhileRe.MatchString(scan):
+		return trimBraceCond(scan), true, true
+	case braceForEachRe.MatchString(scan):
+		return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(scan), "{")), true, true
+	case braceIfRe.MatchString(scan):
+		return trimBraceCond(scan), false, true
+	case braceSwitchRe.MatchString(scan):
+		return trimBraceCond(scan), false, true
+	case braceCatchRe.MatchString(scan):
+		return trimBraceCond(scan), false, true
+	case braceTryRe.MatchString(scan):
+		return "try", false, true
+	case braceElseRe.MatchString(scan):
+		return "else", false, true
+	}
+	return "", false, false
+}
+
+// trimBraceCond returns the header text up to and including its closing `)` (or
+// the trimmed header for paren-less headers like `else`/`try`), dropping a
+// trailing `{` and any leading `} ` closer.
+func trimBraceCond(scan string) string {
+	s := strings.TrimSpace(stripLeadingCloser(scan))
+	if idx := strings.LastIndex(s, ")"); idx >= 0 {
+		return strings.TrimSpace(s[:idx+1])
+	}
+	s = strings.TrimSuffix(strings.TrimSpace(s), "{")
+	return strings.TrimSpace(s)
+}
+
+// braceSpanEnd returns the exclusive line index at which the brace block whose
+// header is lines[headerIdx] closes. It locates the first `{` at/after the
+// header (skipping a leading closer), then tracks depth to the matching `}`.
+// When no opening brace is found within a short lookahead (brace-less
+// single-statement body) the block is treated as spanning just the header +
+// next line.
+func braceSpanEnd(lines []string, headerIdx int) int {
+	depth := 0
+	opened := false
+	for j := headerIdx; j < len(lines); j++ {
+		scan := stripBraceNoise(lines[j])
+		if j == headerIdx {
+			scan = stripLeadingCloser(scan)
+		}
+		for _, r := range scan {
+			switch r {
+			case '{':
+				depth++
+				opened = true
+			case '}':
+				depth--
+			}
+		}
+		if opened && depth <= 0 {
+			return j + 1
+		}
+		if !opened && j-headerIdx > 2 {
+			// Brace-less single-statement body (`if (x) doWrite();`).
+			return j + 2
+		}
+	}
+	return len(lines)
+}
+
+// --- cyclomatic complexity ------------------------------------------------
+
+// decisionPointRe counts the control-flow decision points for cyclomatic
+// complexity: if/elif/else-if, case, catch/except/rescue, ternary, &&/||,
+// for/while/foreach. Mirrors enrichers.ComputeCyclomaticComplexity's keyword set
+// but lives here so the substrate facet has a single, self-contained source of
+// truth for the branch count surfaced alongside effect contexts. Language-
+// neutral keyword set; comments/strings are not stripped (cheap, and the
+// over-count from the rare keyword-in-string is negligible and conservative).
+var decisionPointRe = []*regexp.Regexp{
+	regexp.MustCompile(`\bif\b`),
+	regexp.MustCompile(`\belif\b`),
+	regexp.MustCompile(`\bfor\b`),
+	regexp.MustCompile(`\bwhile\b`),
+	regexp.MustCompile(`\bcase\b`),
+	regexp.MustCompile(`\bcatch\b`),
+	regexp.MustCompile(`\bexcept\b`),
+	regexp.MustCompile(`\brescue\b`),
+	regexp.MustCompile(`\.\s*for[Ee]ach\s*\(`),
+	regexp.MustCompile(`\?[^.:?]`), // ternary `?` (not `?.` optional chain, not `??`)
+	regexp.MustCompile(`&&`),
+	regexp.MustCompile(`\|\|`),
+}
+
+// ComputeFunctionComplexity returns the cyclomatic complexity (decision points
+// + 1) and branch count (decision points) for a function source window.
+// `else`/`else if` is counted via its `if`; a bare `else` adds no new path so
+// it is intentionally NOT counted, matching the standard McCabe definition.
+func ComputeFunctionComplexity(src string) FunctionComplexity {
+	branches := 0
+	for _, re := range decisionPointRe {
+		branches += len(re.FindAllString(src, -1))
+	}
+	return FunctionComplexity{Cyclomatic: branches + 1, BranchCount: branches}
+}

--- a/internal/substrate/effect_context_test.go
+++ b/internal/substrate/effect_context_test.go
@@ -1,0 +1,123 @@
+package substrate
+
+import "testing"
+
+// TestEffectContextsPython proves conditional vs unconditional + loop
+// attribution and the cyclomatic-complexity count on a small Django-shaped
+// sample. The function makes a top-level db_read, a db_write guarded by an
+// `if`, and an http_out inside a `for` loop over a collection.
+func TestEffectContextsPython(t *testing.T) {
+	src := `def sync(self, request):
+    rows = Contact.objects.filter(active=True)
+    if request.data.get("force"):
+        Contact.objects.create(name="x")
+    for row in rows:
+        requests.post("https://api.example.com/notify", json={"id": row.id})
+    return Response({"ok": True})
+`
+	ctxs, cx := EffectContextsFor("python", src, 100)
+
+	if cx.Cyclomatic < 3 { // if + for + (1) at minimum
+		t.Errorf("cyclomatic = %d; want >= 3", cx.Cyclomatic)
+	}
+	if cx.BranchCount != cx.Cyclomatic-1 {
+		t.Errorf("branch_count %d != cyclomatic-1 %d", cx.BranchCount, cx.Cyclomatic-1)
+	}
+
+	byEffect := map[string]EffectContext{}
+	for _, c := range ctxs {
+		// keep the first occurrence per effect for the assertions below
+		if _, ok := byEffect[c.Effect]; !ok {
+			byEffect[c.Effect] = c
+		}
+	}
+
+	read, ok := byEffect["db_read"]
+	if !ok {
+		t.Fatalf("no db_read effect detected; got %+v", ctxs)
+	}
+	if read.Conditional {
+		t.Errorf("db_read should be unconditional (top-level), got %+v", read)
+	}
+
+	write, ok := byEffect["db_write"]
+	if !ok {
+		t.Fatalf("no db_write effect detected; got %+v", ctxs)
+	}
+	if !write.Conditional {
+		t.Errorf("db_write should be conditional, got %+v", write)
+	}
+	if write.Condition == "" {
+		t.Errorf("db_write should carry its guarding condition, got %+v", write)
+	}
+	if write.InLoop {
+		t.Errorf("db_write is not in a loop, got %+v", write)
+	}
+
+	http, ok := byEffect["http_out"]
+	if !ok {
+		t.Fatalf("no http_out effect detected; got %+v", ctxs)
+	}
+	if !http.InLoop {
+		t.Errorf("http_out should be in_loop (fan-out), got %+v", http)
+	}
+	if !http.Conditional {
+		t.Errorf("http_out inside for-loop should be conditional, got %+v", http)
+	}
+}
+
+// TestEffectContextsJSTS proves the same on a small NestJS-shaped TS sample.
+func TestEffectContextsJSTS(t *testing.T) {
+	src := `async function sync(req: Request) {
+  const rows = await this.repo.find();
+  if (req.body.force) {
+    await this.repo.save({ name: 'x' });
+  }
+  for (const row of rows) {
+    await fetch('https://api.example.com/notify', { method: 'POST' });
+  }
+  return { ok: true };
+}
+`
+	ctxs, cx := EffectContextsFor("jsts", src, 50)
+
+	if cx.Cyclomatic < 3 {
+		t.Errorf("cyclomatic = %d; want >= 3", cx.Cyclomatic)
+	}
+
+	var sawCondWrite, sawLoopHTTP bool
+	for _, c := range ctxs {
+		switch c.Effect {
+		case "db_write":
+			if c.Conditional && c.Condition != "" {
+				sawCondWrite = true
+			}
+		case "http_out":
+			if c.InLoop {
+				sawLoopHTTP = true
+			}
+		}
+	}
+	if !sawCondWrite {
+		t.Errorf("expected a conditional db_write with a condition; got %+v", ctxs)
+	}
+	if !sawLoopHTTP {
+		t.Errorf("expected an http_out inside a loop; got %+v", ctxs)
+	}
+}
+
+// TestComputeFunctionComplexity covers the bare counter: a branchless function
+// is complexity 1; decision points each add one.
+func TestComputeFunctionComplexity(t *testing.T) {
+	if got := ComputeFunctionComplexity("return 1").Cyclomatic; got != 1 {
+		t.Errorf("branchless complexity = %d; want 1", got)
+	}
+	src := "if a {} for x {} while y {} a ? b : c"
+	cx := ComputeFunctionComplexity(src)
+	if cx.Cyclomatic != cx.BranchCount+1 {
+		t.Errorf("invariant broken: %+v", cx)
+	}
+	if cx.BranchCount < 4 { // if, for, while, ternary
+		t.Errorf("branch_count = %d; want >= 4", cx.BranchCount)
+	}
+}


### PR DESCRIPTION
## What

Part (a) of control-flow epic #4820 (#4821). Adds the **`effect_contexts`** facet to `archigraph_effects` — the effect-side complement to the existing #4423 effects-branches facet — so the graph/MCP can answer *under what condition does this function write / make this call, and does it fan out in a loop?*

For each effect a function performs (db_read/db_write/http_out/fs_*/mutation), it stamps:
- **`conditional`** — true when the sink is inside an if/else-if/else, switch/case, or try/catch branch (vs top-level/unconditional)
- **`condition`** — the nearest enclosing branch predicate text
- **`in_loop`** — true when the sink is inside a for/while/foreach over a collection (fan-out / N+1 signal)

Plus a cheap per-function summary: **`cyclomatic_complexity`** (decision points + 1) and **`branch_count`**.

## How

- **`internal/substrate/effect_context.go`** (new): `EffectContextsFor(lang, src, startLine)` reuses the already-registered per-language effect sniffers (`EffectSnifferFor`) to locate sink lines, then classifies each sink's enclosing block. Block-scope detection is language-family general — Python keys on significant indentation (`pythonBlocks`), brace languages on `{}` depth (`braceBlocks`). `ComputeFunctionComplexity` is the self-contained McCabe counter. Pure + deterministic.
- **`internal/mcp/effects_tool.go`**: `attachEffectContextsFacet` — **opt-in** (computed only on `include=effect_contexts`), so the default effects payload stays byte-identical (#2828 token-reduction respected). Honest-partial when a language has no effect sniffer; complexity is still surfaced (language-neutral keyword count).
- **`internal/links/{links,dataflow_pass}.go`**: `entityNode` now carries StartLine/EndLine; `stampDataFlowSummary` persists `cyclomatic_complexity`/`branch_count` as **graph properties** for handlers the dataflow pass already binds (so they're queryable without the on-demand facet). Universal persistence for *all* functions is filed as a follow-up (see below).
- **`internal/mcp/server.go`**: terse tool-description bump (kept under the 80-char budget gate).

## Languages covered

Validated **TS/JS + Python** (the upvate-v3 NestJS + upvate Django groups), matching the epic's first-increment scope. Brace-family detectors run for java/go/php/csharp/kotlin/scala/rust but are only fixture-validated for jsts — generalization filed as #4830.

## Tests

- `internal/substrate/effect_context_test.go`: conditional-vs-unconditional + loop + complexity on small Python and TS samples (direct analyzer).
- `internal/mcp/effect_contexts_4821_test.go`: end-to-end through the real `handleEffects` against `testdata/effect_contexts_4821/` fixtures, incl. a default-payload-unchanged regression.

## Gates

`go build ./...`, `go vet`, `go test ./internal/{substrate,links,mcp,types}` all pass. `coverage fmt --check` = canonical (untouched), `coverage validate` = ok (pre-existing warnings only). No registry cells added: like the #4423 branches facet, `effect_contexts` is a cross-cutting MCP surface reusing existing per-language effect sniffers (`db_effect`/`http_effect` cells unchanged), not a new per-language extraction capability.

## Deferred (follow-ups filed)

- **#4830** — generalize conditional/loop attribution beyond TS/JS+Python (per-language fixture validation for the brace family + indentation langs).
- **#4831** — persist cyclomatic_complexity on **all** function entities (dedicated enricher), not just dataflow-bound handlers; consolidate the dead `enrichers.ComputeCyclomaticComplexity` onto the substrate impl.
- **#4832** — conditional-CALL edges (guarded CALLS) carrying the same context.
- On-demand full CFG = part (b) **#4822** (separate).

Deploy-deferred — no daemon restart, no live MCP touched. Closes #4821.