### PR TITLE
fix(#4829): surgical MCP de-register + backup-before-write (stop wiping shared configs); keep dual codeium write

### DIFF
--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -310,6 +310,15 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 		RegisteredPaths: registeredPaths,
 	}
 	result.MCPPaths = registeredPaths
+	// Step 3 succeeded for every target: discard the pristine backups so the
+	// next install snapshots fresh and a later uninstall won't restore stale
+	// archigraph-containing content. (Rollback only fires on FAILURE, before
+	// this point.)
+	if !opts.DryRun {
+		for _, cfgPath := range registeredPaths {
+			mcpreg.ClearBackup(cfgPath)
+		}
+	}
 	completedSteps = append(completedSteps, 3)
 
 	// ─────────────────────────────────────────────────────────────────────────
@@ -668,10 +677,12 @@ func rollbackSkillsCopy(opts CopyOptions, state *State) {
 	}
 }
 
-// rollbackMCPRegistration removes the archigraph entry from any .claude.json
-// files that were registered during step 3.
+// rollbackMCPRegistration reverses step 3 by RESTORING each touched config
+// file from the pristine backup taken before archigraph's first write. This
+// brings back any foreign mcpServers entries verbatim and deletes files
+// archigraph created — it NEVER resets a shared config to `{}` (see #4829).
 func rollbackMCPRegistration(_ CopyOptions, state *State) {
 	for _, cfgPath := range state.MCP.RegisteredPaths {
-		_ = mcpreg.UnregisterPath(cfgPath)
+		_ = mcpreg.RestorePath(cfgPath)
 	}
 }

--- a/internal/install/dev.go
+++ b/internal/install/dev.go
@@ -249,6 +249,12 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 		RegisteredPaths: registeredPaths,
 	}
 	result.MCPPaths = registeredPaths
+	// Step 3 succeeded: discard pristine backups (see copy.go rationale).
+	if !opts.DryRun {
+		for _, cfgPath := range registeredPaths {
+			mcpreg.ClearBackup(cfgPath)
+		}
+	}
 	completedSteps = append(completedSteps, 3)
 
 	// ─────────────────────────────────────────────────────────────────────────

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -16,16 +16,25 @@
 package mcpreg
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // ServerName is the canonical key used in mcpServers maps.
 const ServerName = "archigraph"
+
+// backupSentinelAbsent is the byte content written into a backup file when the
+// original target did NOT exist before archigraph touched it. On restore this
+// tells us to DELETE the file archigraph created rather than leave an orphan
+// `{}` or `{"mcpServers":{}}` behind.
+const backupSentinelAbsent = "ARCHIGRAPH_BACKUP_ORIGINAL_ABSENT"
 
 // homeDir returns the current user's home directory.
 // On all platforms it checks the HOME environment variable first so
@@ -306,12 +315,94 @@ func Register(tool Tool, binPath, _ string) (string, error) {
 	return RegisterPath(path, binPath)
 }
 
+// backupDir returns ~/.archigraph/backups/mcpreg, creating it on demand.
+func backupDir() (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".archigraph", "backups", "mcpreg")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// sanitizePath turns an absolute config path into a filesystem-safe token used
+// in backup file names (e.g. "/Users/x/.codeium/mcp_config.json" →
+// "Users_x_.codeium_mcp_config.json"). A short hash suffix disambiguates paths
+// that collapse to the same token.
+func sanitizePath(path string) string {
+	cleaned := filepath.ToSlash(path)
+	cleaned = strings.TrimPrefix(cleaned, "/")
+	repl := strings.NewReplacer("/", "_", ":", "_", "\\", "_", " ", "_")
+	token := repl.Replace(cleaned)
+	sum := sha256.Sum256([]byte(path))
+	return token + "-" + hex.EncodeToString(sum[:4])
+}
+
+// sidecarBackupPath is the in-place ".archigraph.bak" sidecar next to the
+// target. It is the file consulted on restore.
+func sidecarBackupPath(path string) string {
+	return path + ".archigraph.bak"
+}
+
+// backupOnce snapshots the original target file BEFORE archigraph's first
+// modification. It is a no-op if a sidecar backup already exists (so repeated
+// RegisterPath calls within one install don't clobber the pristine snapshot).
+//
+// Two copies are written:
+//   - an in-place sidecar `<path>.archigraph.bak` (consulted on restore), and
+//   - a timestamped copy under ~/.archigraph/backups/mcpreg/ (audit trail).
+//
+// If the original file does not exist, a sentinel backup is written instead so
+// that restore knows to DELETE archigraph's file rather than leave an orphan.
+func backupOnce(path string) error {
+	sidecar := sidecarBackupPath(path)
+	if _, err := os.Stat(sidecar); err == nil {
+		// Backup already taken for this install transaction.
+		return nil
+	}
+
+	orig, readErr := os.ReadFile(path)
+	absent := errors.Is(readErr, os.ErrNotExist)
+	if readErr != nil && !absent {
+		return readErr
+	}
+
+	payload := orig
+	if absent {
+		payload = []byte(backupSentinelAbsent)
+	}
+
+	if err := os.WriteFile(sidecar, payload, 0o600); err != nil {
+		return err
+	}
+
+	// Best-effort timestamped audit copy; failure here must not block install.
+	if dir, err := backupDir(); err == nil {
+		stamp := time.Now().UTC().Format(time.RFC3339)
+		stamp = strings.ReplaceAll(stamp, ":", "-")
+		audit := filepath.Join(dir, sanitizePath(path)+"-"+stamp+".json")
+		_ = os.WriteFile(audit, payload, 0o600)
+	}
+	return nil
+}
+
 // RegisterPath writes (or updates) the archigraph entry in an arbitrary
 // .claude.json file. This is the workhorse used by both Register (single
 // path) and the multi-dir install loop.
+//
+// Before its FIRST modification of a given file, RegisterPath snapshots the
+// original (via backupOnce) so a later rollback can restore it exactly — see
+// RestorePath. The merge is surgical: only mcpServers.archigraph is added or
+// updated; every other key and sibling server is preserved.
 func RegisterPath(path, binPath string) (string, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
+	}
+	if err := backupOnce(path); err != nil {
+		return "", fmt.Errorf("backup %s: %w", filepath.Base(path), err)
 	}
 	doc, err := readSettings(path)
 	if err != nil {
@@ -340,8 +431,12 @@ func Unregister(tool Tool) error {
 	return UnregisterPath(path)
 }
 
-// UnregisterPath removes the archigraph entry from an arbitrary config
-// file. Used by the multi-dir uninstall loop.
+// UnregisterPath removes ONLY the archigraph entry from an arbitrary config
+// file, preserving every other key and sibling server. Used by the multi-dir
+// uninstall loop. If removing archigraph leaves mcpServers empty, the empty
+// mcpServers object is dropped too so we never leave an orphan
+// `{"mcpServers":{}}`. Returns nil if the file or entry doesn't exist
+// (idempotent). It NEVER overwrites foreign servers or resets the file to `{}`.
 func UnregisterPath(path string) error {
 	doc, err := readSettings(path)
 	if err != nil {
@@ -355,8 +450,63 @@ func UnregisterPath(path string) error {
 		return nil
 	}
 	delete(servers, ServerName)
-	doc["mcpServers"] = servers
+	if len(servers) == 0 {
+		// Drop the now-empty mcpServers key rather than persisting an
+		// orphan `{"mcpServers":{}}`.
+		delete(doc, "mcpServers")
+	} else {
+		doc["mcpServers"] = servers
+	}
 	return writeSettings(path, doc)
+}
+
+// RestorePath reverses a RegisterPath using the pristine backup taken by
+// backupOnce. This is the rollback/de-register entry point that MUST be used
+// instead of writing `{}`:
+//
+//   - If archigraph CREATED the file (sentinel backup), the file is DELETED so
+//     no orphan `{}` / `{"mcpServers":{}}` is left behind.
+//   - If a real original was backed up, the file is restored byte-for-byte,
+//     bringing back every foreign server and unrelated key exactly.
+//   - If no backup exists (e.g. registration never ran), fall back to the
+//     surgical UnregisterPath so we still only remove archigraph's own entry.
+//
+// The sidecar backup is removed after a successful restore.
+func RestorePath(path string) error {
+	sidecar := sidecarBackupPath(path)
+	b, err := os.ReadFile(sidecar)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// No snapshot — fall back to surgical removal so we never
+			// clobber foreign servers.
+			return UnregisterPath(path)
+		}
+		return err
+	}
+
+	if string(b) == backupSentinelAbsent {
+		// Original did not exist; remove archigraph's file entirely.
+		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+			return rmErr
+		}
+		_ = os.Remove(sidecar)
+		return nil
+	}
+
+	// Restore the original content verbatim.
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return err
+	}
+	_ = os.Remove(sidecar)
+	return nil
+}
+
+// ClearBackup discards the pristine sidecar backup for a path. Call this after
+// a SUCCESSFUL install so the next install can take a fresh snapshot (and so a
+// future uninstall does not "restore" stale archigraph-containing content).
+// Idempotent: missing backups are ignored.
+func ClearBackup(path string) {
+	_ = os.Remove(sidecarBackupPath(path))
 }
 
 func readSettings(path string) (map[string]any, error) {

--- a/internal/install/mcpreg/mcpreg_test.go
+++ b/internal/install/mcpreg/mcpreg_test.go
@@ -659,6 +659,209 @@ func TestInstall_SkipsAbsentZed(t *testing.T) {
 	}
 }
 
+// ── #4829: surgical de-register + backup/restore (no shared-config wipe) ──────
+
+// TestRegisterPreservesForeignServer: registering into a config that already
+// holds a FOREIGN server must add archigraph AND leave the foreign server
+// untouched.
+func TestRegisterPreservesForeignServer(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".codeium", "mcp_config.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pre := `{"mcpServers":{"playwright":{"command":"/bin/playwright","args":["serve"]}}}`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RegisterPath(path, "/bin/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+
+	b, _ := os.ReadFile(path)
+	var doc map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("config not valid JSON after register: %s", b)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["playwright"]; !ok {
+		t.Fatalf("foreign 'playwright' server was wiped: %s", b)
+	}
+	if _, ok := servers[ServerName]; !ok {
+		t.Fatalf("archigraph entry missing: %s", b)
+	}
+}
+
+// TestRestorePreservesForeignServerOnRollback: register into a config holding a
+// foreign server, then roll back via RestorePath. The foreign server must
+// survive and the file must NOT be `{}` — it must equal the original byte-wise.
+func TestRestorePreservesForeignServerOnRollback(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".codeium", "mcp_config.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pre := `{"mcpServers":{"playwright":{"command":"/bin/playwright"}},"other":"keep"}`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RegisterPath(path, "/bin/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RestorePath(path); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file missing after rollback (should be restored, not deleted): %v", err)
+	}
+	if string(b) == "{}" || string(b) == "{}\n" {
+		t.Fatalf("file was reset to empty object — the #4829 wipe regressed: %s", b)
+	}
+	if string(b) != pre {
+		t.Fatalf("rollback did not restore original byte-for-byte:\n got: %s\nwant: %s", b, pre)
+	}
+	var doc map[string]any
+	_ = json.Unmarshal(b, &doc)
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["playwright"]; !ok {
+		t.Fatalf("foreign 'playwright' server lost on rollback: %s", b)
+	}
+	// Backup sidecar should be cleaned up after a successful restore.
+	if _, err := os.Stat(sidecarBackupPath(path)); err == nil {
+		t.Fatalf("sidecar backup not cleaned up after restore")
+	}
+}
+
+// TestRestoreNewFileRemovesOrphan: when archigraph creates a brand-new config
+// file, rollback must DELETE it — never leave an orphan `{}` /
+// `{"mcpServers":{}}`.
+func TestRestoreNewFileRemovesOrphan(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("precondition: file should not exist yet")
+	}
+	if _, err := RegisterPath(path, "/bin/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("register should have created the file: %v", err)
+	}
+
+	if err := RestorePath(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		b, _ := os.ReadFile(path)
+		t.Fatalf("orphan file left after rollback of a created file: %q", b)
+	}
+}
+
+// TestUnregisterDropsEmptyMcpServers: unregistering the sole archigraph entry
+// from a file archigraph created leaves neither an orphan `{"mcpServers":{}}`
+// nor reintroduces foreign keys.
+func TestUnregisterDropsEmptyMcpServers(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".claude.json")
+
+	if _, err := RegisterPath(path, "/bin/archigraph"); err != nil {
+		t.Fatal(err)
+	}
+	if err := UnregisterPath(path); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	var doc map[string]any
+	_ = json.Unmarshal(b, &doc)
+	if _, ok := doc["mcpServers"]; ok {
+		t.Fatalf("empty mcpServers object not dropped: %s", b)
+	}
+}
+
+// TestUnregisterKeepsForeignServers: unregistering archigraph from a file with
+// a foreign sibling server keeps mcpServers and the sibling intact.
+func TestUnregisterKeepsForeignServers(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".claude.json")
+	pre := `{"mcpServers":{"playwright":{"command":"/bin/pw"},"archigraph":{"command":"/old"}}}`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := UnregisterPath(path); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	var doc map[string]any
+	_ = json.Unmarshal(b, &doc)
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["playwright"]; !ok {
+		t.Fatalf("foreign server lost on unregister: %s", b)
+	}
+	if _, ok := servers[ServerName]; ok {
+		t.Fatalf("archigraph entry still present: %s", b)
+	}
+}
+
+// TestDetectWindsurfPaths_BothCodeiumTargets asserts the dual codeium write is
+// preserved: when both ~/.codeium and ~/.codeium/windsurf exist, BOTH the
+// legacy JetBrains path and the desktop path are in the registration set.
+func TestDetectWindsurfPaths_BothCodeiumTargets(t *testing.T) {
+	home := withHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".codeium", "windsurf"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := DetectWindsurfPaths()
+	wantDesktop := filepath.Join(home, ".codeium", "windsurf", "mcp_config.json")
+	wantLegacy := filepath.Join(home, ".codeium", "mcp_config.json")
+
+	var gotDesktop, gotLegacy bool
+	for _, p := range paths {
+		switch p {
+		case wantDesktop:
+			gotDesktop = true
+		case wantLegacy:
+			gotLegacy = true
+		}
+	}
+	if !gotDesktop {
+		t.Errorf("desktop codeium path missing from registration set: %v", paths)
+	}
+	if !gotLegacy {
+		t.Errorf("legacy codeium path missing from registration set: %v", paths)
+	}
+}
+
+// TestRestoreFallsBackToSurgicalWhenNoBackup: if no sidecar backup exists,
+// RestorePath must still remove only archigraph (never wipe foreign servers).
+func TestRestoreFallsBackToSurgicalWhenNoBackup(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".claude.json")
+	pre := `{"mcpServers":{"playwright":{"command":"/bin/pw"},"archigraph":{"command":"/old"}}}`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No RegisterPath call → no sidecar backup.
+	if err := RestorePath(path); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(path)
+	if string(b) == "{}" || string(b) == "{}\n" {
+		t.Fatalf("restore-without-backup wiped the file: %s", b)
+	}
+	var doc map[string]any
+	_ = json.Unmarshal(b, &doc)
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["playwright"]; !ok {
+		t.Fatalf("foreign server lost in fallback restore: %s", b)
+	}
+}
+
 // TestInstall_SkipsAbsentHost is a table-driven test checking that each new
 // host's Detect function returns empty when its parent directory is absent.
 func TestInstall_SkipsAbsentHost(t *testing.T) {


### PR DESCRIPTION
## Problem
A partial install rolled `~/.codeium/mcp_config.json` back to `{}`, wiping ALL `mcpServers` entries (a user lost their Windsurf MCP config). `mcpreg` wrote atomically via `os.Rename` with **no pre-write backup**, and rollback could leave orphan/empty configs.

## Fix
**Backup before first modification**
- `backupOnce()` snapshots the original config before archigraph's FIRST write: an in-place `<path>.archigraph.bak` sidecar (consulted on restore) plus a timestamped audit copy under `~/.archigraph/backups/mcpreg/<sanitized-path>-<RFC3339>.json`. A sentinel marks files that did not previously exist.

**Surgical de-register / restore (never `{}`)**
- `RestorePath()` is the rollback entry point: restores the original **byte-for-byte** (bringing back every foreign server and unrelated key), or **deletes** the file archigraph created — it never writes `{}`. Falls back to surgical `UnregisterPath` when no backup exists.
- `UnregisterPath()` drops an emptied `mcpServers` object so no orphan `{"mcpServers":{}}` remains; still removes ONLY archigraph, never foreign servers.
- `ClearBackup()` discards the pristine snapshot after a successful step 3 (copy.go + dev.go).
- `copy.go` `rollbackMCPRegistration()` now uses `RestorePath` instead of bare `UnregisterPath`.

**Dual codeium write preserved**
- Both `~/.codeium/mcp_config.json` (legacy/JetBrains) AND `~/.codeium/windsurf/mcp_config.json` (desktop) stay in the registration set via `DetectWindsurfPaths`; both get the same surgical-merge + backup treatment.

## Tests added (all pass)
- Register into a config with a FOREIGN `playwright` server → archigraph added, playwright survives.
- Register then rollback → foreign server survives, file is restored (NOT `{}`), sidecar cleaned up.
- New-file case → register creates the file, rollback removes it (no orphan `{}`).
- Empty `mcpServers` dropped on unregister; foreign siblings kept.
- Both codeium target paths present in the registration set.
- No-backup restore stays surgical.

## Gates
`go build ./...`, `go vet ./internal/install/...`, `go test ./internal/install/...` all pass. No capability/registry change. Deploy-deferred.

Closes #4829.