### PR TITLE
feat(#4826): migrate iac-diagram to elkjs (native nested groups + orthogonal routing)

### DIFF
--- a/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
@@ -18,7 +18,7 @@
    chip on the owning node and in the legend footer.
    ============================================================ */
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -34,12 +34,15 @@ import { cn } from "@/lib/utils";
 import type { IaCReport } from "@/data/types";
 import {
   layoutIaCDiagram,
+  layoutIaCDiagramElk,
+  defaultLayoutEngine,
   IAC_NODE_TYPE,
   IAC_GROUP_TYPE,
   IAC_EDGE_TYPE,
   MAX_DIAGRAM_NODES,
   type IaCDiagramDirection,
   type IaCGroupMode,
+  type IaCLayoutResult,
 } from "./layout";
 import { IaCNode } from "./IaCNode";
 import { IaCGroupNode } from "./IaCGroupNode";
@@ -72,10 +75,51 @@ function IaCDiagramInner({ report, className }: IaCDiagramProps) {
   const [direction, setDirection] = useState<IaCDiagramDirection>("LR");
   const [groupMode, setGroupMode] = useState<IaCGroupMode>("module");
 
-  const { nodes, edges, capped, unresolvedEdges } = useMemo(
-    () => layoutIaCDiagram(report, direction, groupMode),
-    [report, direction, groupMode],
+  // Layout engine: ELK (default, async) or the legacy dagre fallback (sync).
+  // Stable for the component lifetime — flip via VITE_IAC_LAYOUT_ENGINE.
+  const engine = useMemo(() => defaultLayoutEngine(), []);
+
+  const EMPTY: IaCLayoutResult = useMemo(
+    () => ({ nodes: [], edges: [], capped: false, unresolvedEdges: 0 }),
+    [],
   );
+
+  // dagre path is synchronous — compute inline.
+  const dagreResult = useMemo(
+    () => (engine === "dagre" ? layoutIaCDiagram(report, direction, groupMode) : EMPTY),
+    [engine, report, direction, groupMode, EMPTY],
+  );
+
+  // ELK path is async — run in an effect, last-write-wins, with a layout flag.
+  const [elkResult, setElkResult] = useState<IaCLayoutResult>(EMPTY);
+  const [elkLaidOut, setElkLaidOut] = useState(false);
+  const elkRunId = useRef(0);
+  useEffect(() => {
+    if (engine !== "elk") return;
+    const myRun = ++elkRunId.current;
+    let cancelled = false;
+    setElkLaidOut(false);
+    layoutIaCDiagramElk(report, direction, groupMode)
+      .then((res) => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        setElkResult(res);
+        setElkLaidOut(true);
+      })
+      .catch(() => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        // Fall back to dagre on ELK failure so the canvas still renders.
+        setElkResult(layoutIaCDiagram(report, direction, groupMode));
+        setElkLaidOut(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [engine, report, direction, groupMode]);
+
+  const { nodes, edges, capped, unresolvedEdges } =
+    engine === "dagre" ? dagreResult : elkResult;
+  // True while ELK is still computing its first layout for the current inputs.
+  const layingOut = engine === "elk" && !elkLaidOut;
 
   const moduleCount = useMemo(
     () => nodes.filter((n) => n.type === IAC_GROUP_TYPE).length,
@@ -172,23 +216,29 @@ function IaCDiagramInner({ report, className }: IaCDiagramProps) {
 
       {/* Canvas */}
       <div className="relative min-h-0 flex-1">
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          nodeTypes={nodeTypes}
-          edgeTypes={edgeTypes}
-          fitView
-          nodesDraggable={false}
-          nodesConnectable={false}
-          elementsSelectable
-          proOptions={{ hideAttribution: true }}
-          minZoom={0.1}
-          fitViewOptions={{ padding: 0.16 }}
-        >
-          <Background gap={18} size={1} color="var(--border)" />
-          <Controls showInteractive={false} />
-          <MiniMap pannable zoomable className="!border !border-border !bg-surface" />
-        </ReactFlow>
+        {layingOut ? (
+          <div className="flex h-full items-center justify-center text-sm text-text-4">
+            Laying out…
+          </div>
+        ) : (
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
+            fitView
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable
+            proOptions={{ hideAttribution: true }}
+            minZoom={0.1}
+            fitViewOptions={{ padding: 0.16 }}
+          >
+            <Background gap={18} size={1} color="var(--border)" />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable className="!border !border-border !bg-surface" />
+          </ReactFlow>
+        )}
       </div>
 
       {/* Footer: unresolved-target honesty note (#4495). */}

--- a/webui-v2/src/components/iac-diagram/layout.test.ts
+++ b/webui-v2/src/components/iac-diagram/layout.test.ts
@@ -1,0 +1,153 @@
+/* layout.test.ts — IaC architecture-diagram layout: nested module/tier group
+   mapping + resolved-vs-unresolved edges, across the dagre and ELK (#4826)
+   backends. */
+
+import { describe, it, expect } from "vitest";
+import {
+  layoutIaCDiagram,
+  layoutIaCDiagramElk,
+  IAC_NODE_TYPE,
+  IAC_GROUP_TYPE,
+} from "./layout";
+import type { IaCReport, IaCResource, IaCRelation } from "@/data/types";
+
+function rel(partial: Partial<IaCRelation>): IaCRelation {
+  return {
+    facet: "dependency",
+    kind: "DEPENDS_ON",
+    direction: "out",
+    target: "",
+    target_resolved: true,
+    target_id: "",
+    ...partial,
+  };
+}
+
+function res(partial: Partial<IaCResource> & { entity_id: string }): IaCResource {
+  return {
+    repo: "infra",
+    name: partial.entity_id,
+    tool: "terraform",
+    category: "compute",
+    properties: [],
+    relations: [],
+    ...partial,
+  };
+}
+
+/** Two modules: `net` (1 resource) and `app` (2 resources); app→net edge,
+ *  plus one unresolved relation target. */
+function fixture(): IaCReport {
+  const lb = res({
+    entity_id: "infra/lb",
+    module: "modules/network",
+    category: "network",
+    relations: [],
+  });
+  const svc = res({
+    entity_id: "infra/svc",
+    module: "modules/app",
+    category: "compute",
+    relations: [
+      rel({ target_entity_id: "infra/lb", target: "lb", kind: "USES" }),
+      // Unresolved: target not a rendered resource.
+      rel({ target_entity_id: "", target: "external", target_resolved: false }),
+    ],
+  });
+  const db = res({
+    entity_id: "infra/db",
+    module: "modules/app",
+    category: "datastore",
+    relations: [],
+  });
+  return {
+    group: "g",
+    total_resources: 3,
+    total_grants: 0,
+    total_event_sources: 0,
+    total_dependencies: 1,
+    total_outputs: 0,
+    with_props_count: 0,
+    tools: ["terraform"],
+    envs: [],
+    counts_by_category: {},
+    groups: [{ tool: "terraform", count: 3, resources: [lb, svc, db] }],
+  };
+}
+
+describe("layoutIaCDiagram (dagre fallback)", () => {
+  it("maps resources into module group containers with finite positions", () => {
+    const { nodes, edges, unresolvedEdges } = layoutIaCDiagram(fixture(), "LR", "module");
+    const groups = nodes.filter((n) => n.type === IAC_GROUP_TYPE);
+    const resources = nodes.filter((n) => n.type === IAC_NODE_TYPE);
+    expect(groups.length).toBe(2); // modules/network + modules/app
+    expect(resources.length).toBe(3);
+
+    // Every resource node is parented to a rendered group container.
+    for (const r of resources) {
+      expect(r.parentId).toBeDefined();
+      expect(groups.some((g) => g.id === r.parentId)).toBe(true);
+    }
+    for (const n of nodes) {
+      expect(Number.isFinite(n.position.x)).toBe(true);
+      expect(Number.isFinite(n.position.y)).toBe(true);
+    }
+
+    // Only the resolved svc→lb edge is drawn; the external one is unresolved.
+    expect(edges.length).toBe(1);
+    expect(edges[0].source).toBe("infra/svc");
+    expect(edges[0].target).toBe("infra/lb");
+    expect(unresolvedEdges).toBe(1);
+  });
+
+  it("groups by cloud tier in tier mode", () => {
+    const { nodes } = layoutIaCDiagram(fixture(), "LR", "tier");
+    const groupIds = nodes.filter((n) => n.type === IAC_GROUP_TYPE).map((n) => n.id);
+    // network → Network, compute → Compute, datastore → Data.
+    expect(groupIds).toContain("group:Network");
+    expect(groupIds).toContain("group:Compute");
+    expect(groupIds).toContain("group:Data");
+  });
+
+  it("returns empty for an empty report", () => {
+    const { nodes, edges } = layoutIaCDiagram(undefined, "LR", "module");
+    expect(nodes).toEqual([]);
+    expect(edges).toEqual([]);
+  });
+});
+
+describe("layoutIaCDiagramElk (#4826 — ELK backend)", () => {
+  it("produces the same nested-group render plan as dagre with finite positions", async () => {
+    const { nodes, edges, unresolvedEdges } = await layoutIaCDiagramElk(
+      fixture(),
+      "LR",
+      "module",
+    );
+    const groups = nodes.filter((n) => n.type === IAC_GROUP_TYPE);
+    const resources = nodes.filter((n) => n.type === IAC_NODE_TYPE);
+    expect(groups.length).toBe(2);
+    expect(resources.length).toBe(3);
+
+    // Native nested mapping: each resource is a child of its group container,
+    // and ELK sizes the container to fit its children.
+    for (const r of resources) {
+      const parent = groups.find((g) => g.id === r.parentId);
+      expect(parent).toBeDefined();
+      expect(Number(parent!.width)).toBeGreaterThan(0);
+      expect(Number(parent!.height)).toBeGreaterThan(0);
+    }
+    for (const n of nodes) {
+      expect(Number.isFinite(n.position.x)).toBe(true);
+      expect(Number.isFinite(n.position.y)).toBe(true);
+    }
+
+    expect(edges.length).toBe(1);
+    expect(unresolvedEdges).toBe(1);
+  });
+
+  it("returns empty for an empty report", async () => {
+    const { nodes, edges } = await layoutIaCDiagramElk(undefined, "LR", "module");
+    expect(nodes).toEqual([]);
+    expect(edges).toEqual([]);
+  });
+});

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -15,16 +15,26 @@
                 ask — archigraph flattens modules to the resolved resource
                 graph, so grouping by module reconstructs the stack structure.
 
-   Layout uses dagre as a COMPOUND graph (setParent) so children cluster under
-   their module; we then derive each group node's bounding box from its laid-out
-   children. Unresolved edge targets (#4495 target_resolved=false, or a target
-   that is not itself a rendered node) are NOT drawn as dead edges — the caller
-   surfaces them separately as external/unresolved chips on the node.
+   Layout engine: as of the elkjs epic (#4824/#4826) the default backend is ELK
+   (elk.hierarchyHandling INCLUDE_CHILDREN + orthogonal routing) via the shared
+   `layoutWithElk` helper (lib/elk-layout.ts) — it lays out the nested module/
+   tier groups NATIVELY rather than dagre's faked compound (setParent + manual
+   bounding boxes). The legacy dagre compound pass is KEPT as a synchronous
+   fallback behind `VITE_IAC_LAYOUT_ENGINE=dagre` for a visual revert.
+
+   The "planning" stage (which resources render, which group each belongs to,
+   the drawn vs unresolved edges) is engine-agnostic and shared by both
+   backends; only the positioning differs.
    ============================================================ */
 
 import dagre from "dagre";
 import { Position, type Node, type Edge } from "@xyflow/react";
 import type { IaCReport, IaCResource } from "@/data/types";
+import {
+  layoutWithElk,
+  type ElkLayoutNode,
+  type ElkLayoutEdge,
+} from "@/lib/elk-layout";
 
 export type IaCDiagramDirection = "LR" | "TB";
 
@@ -37,6 +47,20 @@ export type IaCDiagramDirection = "LR" | "TB";
  *                layered cloud-architecture view regardless of module layout.
  */
 export type IaCGroupMode = "module" | "tier";
+
+/**
+ * Layout engine selection. Defaults to ELK (#4826); set the env flag
+ * `VITE_IAC_LAYOUT_ENGINE=dagre` (or pass engine="dagre") to use the legacy
+ * dagre fallback for a visual revert.
+ */
+export type IaCLayoutEngine = "elk" | "dagre";
+export function defaultLayoutEngine(): IaCLayoutEngine {
+  const env =
+    typeof import.meta !== "undefined"
+      ? (import.meta as { env?: Record<string, string | undefined> }).env
+      : undefined;
+  return env?.VITE_IAC_LAYOUT_ENGINE === "dagre" ? "dagre" : "elk";
+}
 
 /**
  * cloudTier maps a resource_category to a coarse cloud-architecture tier used by
@@ -69,7 +93,7 @@ export const IAC_NODE_TYPE = "iacResource";
 export const IAC_GROUP_TYPE = "iacModule";
 export const IAC_EDGE_TYPE = "iacRelation";
 
-/** Resource-node box fed to dagre (the renderer matches these dims). */
+/** Resource-node box fed to the layout engine (the renderer matches these dims). */
 const NODE_W = 220;
 const NODE_H = 64;
 
@@ -129,24 +153,45 @@ function shortModuleLabel(module: string): string {
   return i >= 0 ? cleaned.slice(i + 1) : cleaned;
 }
 
+interface RawEdge { from: string; to: string; facet: string; kind: string; detail?: string }
+
 /**
- * Build a positioned, module-grouped React Flow graph from the IaC report.
- *
- * @param report     the IaCReport (already fetched)
- * @param direction  "LR" (horizontal) | "TB" (vertical) → dagre rankdir
+ * IaCPlan is the engine-agnostic intermediate produced from the report: the
+ * rendered resources, their group bucket, the group order/labels, and the drawn
+ * (resolved) edges. Both the dagre and ELK positioners consume this identically.
  */
-export function layoutIaCDiagram(
+interface IaCPlan {
+  capped: boolean;
+  unresolvedEdges: number;
+  resources: IaCResource[];
+  /** Insertion-ordered group id → members. */
+  modules: Map<string, IaCResource[]>;
+  /** group bucket key for a resource (module path or cloud tier). */
+  moduleOf: (r: IaCResource) => string;
+  /** Unresolved relation count for a single resource (for its node chip). */
+  unresolvedCountFor: (r: IaCResource) => number;
+  rawEdges: RawEdge[];
+}
+
+/** group id for a module/tier bucket name (the React Flow parent node id). */
+function groupIdFor(module: string): string {
+  return `group:${module}`;
+}
+
+/**
+ * planIaCDiagram computes the engine-agnostic render plan: capped resource set,
+ * group buckets, and resolved (drawn) vs unresolved edges. This is the
+ * IaC-specific logic shared by both the ELK and dagre backends.
+ */
+function planIaCDiagram(
   report: IaCReport | undefined,
-  direction: IaCDiagramDirection,
-  groupMode: IaCGroupMode = "module",
-): IaCLayoutResult {
+  groupMode: IaCGroupMode,
+): IaCPlan | undefined {
   const all = flattenResources(report);
   const capped = all.length > MAX_DIAGRAM_NODES;
   const resources = capped ? all.slice(0, MAX_DIAGRAM_NODES) : all;
 
-  if (resources.length === 0) {
-    return { nodes: [], edges: [], capped, unresolvedEdges: 0 };
-  }
+  if (resources.length === 0) return undefined;
 
   // Index rendered resources by their slug-prefixed entity id so edges can join.
   const byEntityId = new Map<string, IaCResource>();
@@ -170,7 +215,6 @@ export function layoutIaCDiagram(
   // (from,to,kind). We follow the "out" direction so each edge is drawn once;
   // unresolved targets (no target_entity_id, or not a rendered node) are
   // counted, not drawn. ────────────────────────────────────────────────────
-  interface RawEdge { from: string; to: string; facet: string; kind: string; detail?: string }
   const rawEdges: RawEdge[] = [];
   const seen = new Set<string>();
   let unresolvedEdges = 0;
@@ -196,63 +240,74 @@ export function layoutIaCDiagram(
     }
   }
 
-  // ── Compound dagre layout: children grouped under their module cluster. ───
-  const g = new dagre.graphlib.Graph({ compound: true });
-  g.setGraph({
-    rankdir: direction,
-    nodesep: direction === "LR" ? 26 : 40,
-    ranksep: direction === "LR" ? 80 : 64,
-    marginx: 20,
-    marginy: 20,
-  });
-  g.setDefaultEdgeLabel(() => ({}));
+  const unresolvedCountFor = (r: IaCResource) =>
+    r.relations.filter(
+      (rel) => !rel.target_entity_id || !byEntityId.has(rel.target_entity_id),
+    ).length;
 
-  for (const [module, members] of modules) {
-    const groupId = `group:${module}`;
-    // Cluster node — dagre sizes it to fit children; we recompute the box below.
-    g.setNode(groupId, { label: module });
-    for (const r of members) {
-      g.setNode(r.entity_id, { width: NODE_W, height: NODE_H });
-      g.setParent(r.entity_id, groupId);
-    }
-  }
-  for (const e of rawEdges) g.setEdge(e.from, e.to);
+  return {
+    capped,
+    unresolvedEdges,
+    resources,
+    modules,
+    moduleOf,
+    unresolvedCountFor,
+    rawEdges,
+  };
+}
 
-  dagre.layout(g);
+/**
+ * materialize turns an IaCPlan + absolute boxes for every laid-out resource and
+ * group into the final React-Flow node/edge lists (parent-relative positions,
+ * derived group boxes). Engine-agnostic: both dagre and ELK feed it their
+ * absolute boxes. `groupBox` is optional per group — when an engine sizes the
+ * container natively (ELK) it is passed through; otherwise the box is derived
+ * from member bounding boxes (dagre).
+ */
+function materialize(
+  plan: IaCPlan,
+  groupMode: IaCGroupMode,
+  /** Absolute top-left position + size of each rendered resource. */
+  resourceAbs: Map<string, { x: number; y: number }>,
+  /** Optional engine-provided absolute group box; else derived from members. */
+  groupAbs: Map<string, { x: number; y: number; w: number; h: number }> | undefined,
+  direction: IaCDiagramDirection,
+): IaCLayoutResult {
+  const { resources, modules, unresolvedCountFor, rawEdges, capped, unresolvedEdges } = plan;
 
   const sourcePos = direction === "LR" ? Position.Right : Position.Bottom;
   const targetPos = direction === "LR" ? Position.Left : Position.Top;
 
-  // Resource node absolute positions (dagre centers; RF uses top-left).
-  const absPos = new Map<string, { x: number; y: number }>();
-  for (const r of resources) {
-    const n = g.node(r.entity_id);
-    absPos.set(r.entity_id, {
-      x: (n?.x ?? 0) - NODE_W / 2,
-      y: (n?.y ?? 0) - NODE_H / 2,
-    });
-  }
-
-  // Group bounding boxes derived from member positions (padded). React Flow
-  // child positions are RELATIVE to the parent, so we offset each child by its
-  // group's top-left.
   const nodes: Node[] = [];
 
   for (const [module, members] of modules) {
-    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    for (const r of members) {
-      const p = absPos.get(r.entity_id)!;
-      minX = Math.min(minX, p.x);
-      minY = Math.min(minY, p.y);
-      maxX = Math.max(maxX, p.x + NODE_W);
-      maxY = Math.max(maxY, p.y + NODE_H);
-    }
-    const gx = minX - GROUP_PAD_X;
-    const gy = minY - GROUP_PAD_TOP;
-    const gw = maxX - minX + GROUP_PAD_X * 2;
-    const gh = maxY - minY + GROUP_PAD_TOP + GROUP_PAD_BOTTOM;
+    const groupId = groupIdFor(module);
 
-    const groupId = `group:${module}`;
+    // Group bounding box: engine-provided (ELK) or derived from members (dagre).
+    let gx: number, gy: number, gw: number, gh: number;
+    const provided = groupAbs?.get(groupId);
+    if (provided) {
+      gx = provided.x;
+      gy = provided.y;
+      gw = provided.w;
+      gh = provided.h;
+    } else {
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      for (const r of members) {
+        const p = resourceAbs.get(r.entity_id);
+        if (!p) continue;
+        minX = Math.min(minX, p.x);
+        minY = Math.min(minY, p.y);
+        maxX = Math.max(maxX, p.x + NODE_W);
+        maxY = Math.max(maxY, p.y + NODE_H);
+      }
+      if (!Number.isFinite(minX)) continue; // empty container → skip.
+      gx = minX - GROUP_PAD_X;
+      gy = minY - GROUP_PAD_TOP;
+      gw = maxX - minX + GROUP_PAD_X * 2;
+      gh = maxY - minY + GROUP_PAD_TOP + GROUP_PAD_BOTTOM;
+    }
+
     const groupData: IaCGroupData = {
       module,
       shortLabel:
@@ -277,11 +332,12 @@ export function layoutIaCDiagram(
     });
 
     for (const r of members) {
-      const p = absPos.get(r.entity_id)!;
-      const unresolvedCount = r.relations.filter(
-        (rel) => !rel.target_entity_id || !byEntityId.has(rel.target_entity_id),
-      ).length;
-      const nodeData: IaCNodeData = { resource: r, unresolvedCount };
+      const p = resourceAbs.get(r.entity_id);
+      if (!p) continue;
+      const nodeData: IaCNodeData = {
+        resource: r,
+        unresolvedCount: unresolvedCountFor(r),
+      };
       nodes.push({
         id: r.entity_id,
         type: IAC_NODE_TYPE,
@@ -311,5 +367,176 @@ export function layoutIaCDiagram(
     };
   });
 
+  // resources param kept referenced for clarity/parity with the plan.
+  void resources;
+
   return { nodes, edges, capped, unresolvedEdges };
+}
+
+/* ============================================================
+   ELK backend (default, async) — #4826.
+   ============================================================ */
+
+/**
+ * layoutIaCDiagramElk builds a positioned, module-grouped React Flow graph using
+ * the shared ELK helper. ELK lays out the nested group containers NATIVELY
+ * (hierarchyHandling INCLUDE_CHILDREN, handled inside layoutWithElk) and routes
+ * edges orthogonally (the architecture-diagram look). Async — ELK layout is
+ * Promise-based.
+ *
+ * @param report     the IaCReport (already fetched)
+ * @param direction  "LR" (horizontal) | "TB" (vertical) → ELK direction
+ * @param groupMode  module vs cloud-tier container buckets
+ */
+export async function layoutIaCDiagramElk(
+  report: IaCReport | undefined,
+  direction: IaCDiagramDirection,
+  groupMode: IaCGroupMode = "module",
+): Promise<IaCLayoutResult> {
+  const plan = planIaCDiagram(report, groupMode);
+  if (!plan) {
+    return {
+      nodes: [],
+      edges: [],
+      capped: flattenResources(report).length > MAX_DIAGRAM_NODES,
+      unresolvedEdges: 0,
+    };
+  }
+
+  const { modules, rawEdges } = plan;
+
+  // ── Build ELK inputs: one container per group, resources as its children. ──
+  const elkNodes: ElkLayoutNode[] = [];
+  for (const [module, members] of modules) {
+    const groupId = groupIdFor(module);
+    elkNodes.push({ id: groupId, isContainer: true });
+    for (const r of members) {
+      elkNodes.push({
+        id: r.entity_id,
+        parentId: groupId,
+        width: NODE_W,
+        height: NODE_H,
+      });
+    }
+  }
+
+  const elkEdges: ElkLayoutEdge[] = rawEdges.map((e, i) => ({
+    id: `elk-e:${i}`,
+    source: e.from,
+    target: e.to,
+  }));
+
+  const positions = await layoutWithElk(elkNodes, elkEdges, {
+    direction: direction === "LR" ? "RIGHT" : "DOWN",
+    edgeRouting: "ORTHOGONAL",
+    nodeSpacing: direction === "LR" ? 26 : 40,
+    layerSpacing: direction === "LR" ? 80 : 64,
+    padding: {
+      top: GROUP_PAD_TOP,
+      right: GROUP_PAD_X,
+      bottom: GROUP_PAD_BOTTOM,
+      left: GROUP_PAD_X,
+    },
+    defaultNodeWidth: NODE_W,
+    defaultNodeHeight: NODE_H,
+  });
+
+  // ELK positions are parent-relative. Resources nest exactly one level under
+  // their group, so a resource's absolute position = group pos + resource pos.
+  const finite = (v: number | undefined) =>
+    Number.isFinite(v) ? (v as number) : 0;
+
+  const groupAbs = new Map<string, { x: number; y: number; w: number; h: number }>();
+  for (const module of modules.keys()) {
+    const groupId = groupIdFor(module);
+    const gp = positions.get(groupId);
+    groupAbs.set(groupId, {
+      x: finite(gp?.x),
+      y: finite(gp?.y),
+      w: finite(gp?.width),
+      h: finite(gp?.height),
+    });
+  }
+
+  const resourceAbs = new Map<string, { x: number; y: number }>();
+  for (const [module, members] of modules) {
+    const g = groupAbs.get(groupIdFor(module))!;
+    for (const r of members) {
+      const rp = positions.get(r.entity_id);
+      resourceAbs.set(r.entity_id, {
+        x: g.x + finite(rp?.x),
+        y: g.y + finite(rp?.y),
+      });
+    }
+  }
+
+  return materialize(plan, groupMode, resourceAbs, groupAbs, direction);
+}
+
+/* ============================================================
+   dagre backend (legacy fallback, synchronous) — kept for visual revert.
+   ============================================================ */
+
+/**
+ * layoutIaCDiagram builds a positioned, module-grouped React Flow graph using
+ * the legacy dagre compound pass (setParent + member bounding boxes). Kept as a
+ * synchronous fallback (see defaultLayoutEngine / VITE_IAC_LAYOUT_ENGINE=dagre).
+ *
+ * @param report     the IaCReport (already fetched)
+ * @param direction  "LR" (horizontal) | "TB" (vertical) → dagre rankdir
+ */
+export function layoutIaCDiagram(
+  report: IaCReport | undefined,
+  direction: IaCDiagramDirection,
+  groupMode: IaCGroupMode = "module",
+): IaCLayoutResult {
+  const plan = planIaCDiagram(report, groupMode);
+  if (!plan) {
+    return {
+      nodes: [],
+      edges: [],
+      capped: flattenResources(report).length > MAX_DIAGRAM_NODES,
+      unresolvedEdges: 0,
+    };
+  }
+
+  const { resources, modules, rawEdges } = plan;
+
+  // ── Compound dagre layout: children grouped under their module cluster. ───
+  const g = new dagre.graphlib.Graph({ compound: true });
+  g.setGraph({
+    rankdir: direction,
+    nodesep: direction === "LR" ? 26 : 40,
+    ranksep: direction === "LR" ? 80 : 64,
+    marginx: 20,
+    marginy: 20,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const [module, members] of modules) {
+    const groupId = groupIdFor(module);
+    // Cluster node — dagre sizes it to fit children; we recompute the box below.
+    g.setNode(groupId, { label: module });
+    for (const r of members) {
+      g.setNode(r.entity_id, { width: NODE_W, height: NODE_H });
+      g.setParent(r.entity_id, groupId);
+    }
+  }
+  for (const e of rawEdges) g.setEdge(e.from, e.to);
+
+  dagre.layout(g);
+
+  // Resource node absolute positions (dagre centers; RF uses top-left).
+  const resourceAbs = new Map<string, { x: number; y: number }>();
+  for (const r of resources) {
+    const n = g.node(r.entity_id);
+    resourceAbs.set(r.entity_id, {
+      x: (n?.x ?? 0) - NODE_W / 2,
+      y: (n?.y ?? 0) - NODE_H / 2,
+    });
+  }
+
+  // dagre doesn't give us reliable padded group boxes; let materialize derive
+  // them from member bounding boxes (pass groupAbs = undefined).
+  return materialize(plan, groupMode, resourceAbs, undefined, direction);
 }


### PR DESCRIPTION
## What changed

Migrate the IaC architecture diagram (`src/components/iac-diagram/`) from dagre's faked compound layout to the shared **elkjs** util (`src/lib/elk-layout.ts` / `useElkLayout` foundation, #4825).

- **layout.ts refactor** — split into an engine-agnostic `planIaCDiagram` (capped resource set, module/tier group buckets, resolved-vs-unresolved edges) + a shared `materialize()` + two positioners:
  - `layoutIaCDiagramElk` (async, **default**) — maps each module/tier bucket to an `isContainer` group node and its resources to `parentId` children, so ELK lays out the **nested groups natively** (`hierarchyHandling: INCLUDE_CHILDREN`, handled inside the util) and sizes the container boxes itself. `edgeRouting: 'ORTHOGONAL'` gives clean right-angle connectors. Direction LR→RIGHT / TB→DOWN.
  - `layoutIaCDiagram` (dagre, sync) — the legacy compound pass, **kept as a fallback** behind `VITE_IAC_LAYOUT_ENGINE=dagre` (mirrors the `VITE_CT_LAYOUT_ENGINE` pattern).
- **IaCDiagram.tsx** — awaits the async ELK layout in an effect with a last-write-wins run guard + a "Laying out…" loading state, mirroring `compound-topology`. Falls back to dagre if ELK throws so the canvas always mounts.
- **All existing behavior preserved** — IaCNode / IaCGroupNode / IaCEdge renderers, H/V direction toggle, Module/Tier grouping toggle, unresolved-edge footer chip, node capping, theming. Engine swap only; the displayed data is unchanged.
- **layout.test.ts** added — covers the nested module/tier group mapping + resolved-vs-unresolved edge handling for **both** backends.

## Visual notes vs dagre
ELK sizes group containers natively (vs dagre's member-bbox + manual padding), and orthogonal routing replaces dagre's spline edges — both intentional and matching the architecture-diagram look already adopted by compound-topology. No behavioral regressions.

## Gates
- `npx tsc --noEmit` — clean
- `npm run build` — vite green
- `npx vitest run` — **103/103** unit tests pass (incl. 5 new). The 12 `e2e/*.spec.ts` Playwright files vitest can't collect are **pre-existing, unrelated** failures.
- Frontend only — no `registry.json` / coverage changes.

Deploy-deferred (no daemon started).

Closes #4826. Part of #4824.