### PR TITLE
feat(#4827): migrate flow-dag to elkjs layered (cleaner routing; flowchart-ready)

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDag.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDag.tsx
@@ -6,8 +6,16 @@
    JOINS_COLLECTION / THROWS / VALIDATES side-branches). Backed by
    GET /api/v2/groups/:id/paths/:hash/downstream-dag (#4349).
 
+   Layout engine (#4827): the default backend is ELK's `layered` algorithm with
+   orthogonal edge routing, via the shared `layoutWithElk` helper
+   (lib/elk-layout.ts) — cleaner right-angle connectors and a flowchart-ready
+   layout call. The legacy tidy-tree pack (Reingold–Tilford) is KEPT as a
+   synchronous fallback behind `VITE_FLOWDAG_LAYOUT_ENGINE=dagre` for a visual
+   revert. The node/edge DATA is built by the same helpers for both engines, so
+   only positions differ.
+
    Controls:
-     - H/V toggle        → tidy-tree main axis LR (horizontal) / TB (vertical).
+     - H/V toggle        → layout main axis LR (horizontal) / TB (vertical).
      - depth stepper     → refetches with &depth= (clamped server-side to 1..24).
      - spine / full      → refetches with mode=spine (default; collapses
                            builder/predicate noise) / mode=full (every node).
@@ -63,10 +71,14 @@ import type { DownstreamDAGNode, DownstreamDAGResponse } from "@/data/types";
 import {
   unfoldTree,
   layoutTree,
+  layoutTreeElk,
+  defaultFlowDagEngine,
   MAX_TREE_NODES,
   FLOW_DAG_NODE_TYPE,
   FLOW_DAG_EDGE_TYPE,
   type FlowDagDirection,
+  type FlowDagNode as FlowDagRFNode,
+  type FlowDagEdge as FlowDagRFEdge,
   type FlowDagNodeData,
   type FlowDagEdgeData,
 } from "./layout";
@@ -402,33 +414,96 @@ function FlowDagInner({
     return routeInstanceIds(unfold.instances, routeFocus);
   }, [unfold, routeFocus]);
 
-  const { nodes: baseNodes, edges: baseEdges } = useMemo(() => {
-    if (!unfold) return { nodes: [], edges: [] };
-    const laid = layoutTree(
+  // Layout engine: ELK (default, async layered routing) or the legacy tidy-tree
+  // fallback (sync). Stable for the component lifetime — flip via the env flag
+  // VITE_FLOWDAG_LAYOUT_ENGINE=dagre (#4827).
+  const engine = useMemo(() => defaultFlowDagEngine(), []);
+
+  // Positioned-but-undecorated layout. The tidy-tree backend is synchronous; the
+  // ELK backend is async (last-write-wins) so we run it in an effect and surface
+  // a `layingOut` flag for the loading state. Selection / route highlighting is
+  // applied ON TOP of this result in the memo below, so re-layout only happens
+  // when the actual layout inputs (tree shape / direction / inline-expand) change
+  // — not on every hover/selection.
+  const EMPTY = useMemo<{ nodes: FlowDagRFNode[]; edges: FlowDagRFEdge[] }>(
+    () => ({ nodes: [], edges: [] }),
+    [],
+  );
+
+  const tidyLaid = useMemo(() => {
+    if (engine !== "dagre" || !unfold) return EMPTY;
+    return layoutTree(
       unfold.instances,
       direction,
       expanded,
       onToggleExpand,
       unfold.hasOutEdge,
     );
-    for (const n of laid.nodes) {
+  }, [engine, unfold, direction, expanded, onToggleExpand, EMPTY]);
+
+  const [elkLaid, setElkLaid] = useState<{ nodes: FlowDagRFNode[]; edges: FlowDagRFEdge[] }>(EMPTY);
+  const [elkLaidOut, setElkLaidOut] = useState(false);
+  const elkRunId = useRef(0);
+  useEffect(() => {
+    if (engine !== "elk") return;
+    if (!unfold) {
+      setElkLaid(EMPTY);
+      setElkLaidOut(true);
+      return;
+    }
+    const myRun = ++elkRunId.current;
+    let cancelled = false;
+    setElkLaidOut(false);
+    layoutTreeElk(
+      unfold.instances,
+      direction,
+      expanded,
+      onToggleExpand,
+      unfold.hasOutEdge,
+    )
+      .then((res) => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        setElkLaid(res);
+        setElkLaidOut(true);
+      })
+      .catch(() => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        // Fall back to the tidy-tree on ELK failure so the canvas still renders.
+        setElkLaid(
+          layoutTree(unfold.instances, direction, expanded, onToggleExpand, unfold.hasOutEdge),
+        );
+        setElkLaidOut(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [engine, unfold, direction, expanded, onToggleExpand, EMPTY]);
+
+  const laidOut = engine === "dagre" ? tidyLaid : elkLaid;
+  // True while ELK is still computing its first layout for the current inputs.
+  const layingOut = engine === "elk" && !!unfold && !elkLaidOut;
+
+  // Apply selection + route highlighting on top of the positioned layout. This
+  // is engine-agnostic and cheap (no re-layout) — a fresh shallow copy per node
+  // so React Flow sees the data change.
+  const { nodes: baseNodes, edges: baseEdges } = useMemo(() => {
+    const nodes = laidOut.nodes.map((n) => {
+      const data: FlowDagNodeData = { ...(n.data as FlowDagNodeData) };
       // Selection is driven by the ORIGINAL node id so the caller's contract
       // (Flows step inspector, #4354) is unchanged across the tree unfold; all
       // instances of a selected node light up.
-      if (selectedNodeId != null) {
-        n.data.selected = (n.data as FlowDagNodeData).node.id === selectedNodeId;
-      }
-      if (routeSet) n.data.onRoute = routeSet.has(n.id);
-    }
-    if (routeSet) {
-      for (const e of laid.edges) {
-        // An edge is on the route iff BOTH its endpoints are (the tree's single
-        // in-edge per node makes this exact).
-        e.data = { ...e.data, kind: e.data?.kind ?? "CALLS", onRoute: routeSet.has(e.source) && routeSet.has(e.target) };
-      }
-    }
-    return laid;
-  }, [unfold, direction, expanded, onToggleExpand, selectedNodeId, routeSet]);
+      data.selected = selectedNodeId != null ? data.node.id === selectedNodeId : undefined;
+      data.onRoute = routeSet ? routeSet.has(n.id) : undefined;
+      return { ...n, data };
+    });
+    const edges = laidOut.edges.map((e) => {
+      // An edge is on the route iff BOTH its endpoints are (the tree's single
+      // in-edge per node makes this exact).
+      const onRoute = routeSet ? routeSet.has(e.source) && routeSet.has(e.target) : undefined;
+      return { ...e, data: { ...e.data, kind: e.data?.kind ?? "CALLS", onRoute } as FlowDagEdgeData };
+    });
+    return { nodes, edges };
+  }, [laidOut, selectedNodeId, routeSet]);
 
   // ── Step-replay (#4362) ──────────────────────────────────────────────────
   // The replay walks the laid-out tree in topological order. baseEdges are
@@ -618,10 +693,11 @@ function FlowDagInner({
           </button>
         </div>
 
-        {/* Fetch status */}
-        {isLoading && (
+        {/* Fetch / layout status */}
+        {(isLoading || layingOut) && (
           <span className="inline-flex items-center gap-1 text-xs text-text-4">
-            <Loader2 size={12} className="animate-spin" /> loading…
+            <Loader2 size={12} className="animate-spin" />
+            {isLoading ? "loading…" : "laying out…"}
           </span>
         )}
 

--- a/webui-v2/src/components/flow-dag/layout.test.ts
+++ b/webui-v2/src/components/flow-dag/layout.test.ts
@@ -4,7 +4,7 @@
  * Run with: npx vitest run src/components/flow-dag/layout.test.ts
  */
 import { describe, it, expect } from "vitest";
-import { unfoldTree, layoutTree } from "./layout";
+import { unfoldTree, layoutTree, layoutTreeElk } from "./layout";
 import { routeInstanceIds } from "./route";
 import {
   nodeBucket,
@@ -326,6 +326,70 @@ describe("layoutTree subtree contiguity (#4622)", () => {
     // deeper nodes are strictly further along the main (x) axis.
     expect(x.get("a")!).toBeLessThan(x.get("a/b")!);
     expect(x.get("a/b")!).toBeLessThan(x.get("a/b/c")!);
+  });
+});
+
+describe("layoutTreeElk (#4827)", () => {
+  it("emits the SAME node ids, edge ids, and data as the tidy-tree backend", async () => {
+    const nodes = [n("a"), n("b"), n("c"), n("d")];
+    const edges = [e("a", "b"), e("a", "c"), e("b", "d")];
+    const { instances, hasOutEdge } = unfoldTree("a", nodes, edges);
+
+    const tidy = layoutTree(instances, "LR", new Set(), () => {}, hasOutEdge);
+    const elk = await layoutTreeElk(instances, "LR", new Set(), () => {}, hasOutEdge);
+
+    // Same instances + edges (engine swap only changes positions).
+    expect(elk.nodes.map((x) => x.id).sort()).toEqual(
+      tidy.nodes.map((x) => x.id).sort(),
+    );
+    expect(elk.edges.map((x) => x.id).sort()).toEqual(
+      tidy.edges.map((x) => x.id).sort(),
+    );
+
+    // Same leaf-vs-truncated + module data per node (the displayed payload).
+    const tidyById = new Map(tidy.nodes.map((x) => [x.id, x.data]));
+    for (const node of elk.nodes) {
+      const td = tidyById.get(node.id)!;
+      expect(node.data.isLeaf).toBe(td.isLeaf);
+      expect(node.data.truncatedHere).toBe(td.truncatedHere);
+      expect(node.data.module?.key).toBe(td.module?.key);
+      expect(node.data.edgeKind).toBe(td.edgeKind);
+    }
+  });
+
+  it("produces finite positions and ranks depth along the main axis (LR→x)", async () => {
+    const { instances, hasOutEdge } = unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c")],
+      [e("a", "b"), e("b", "c")],
+    );
+    const { nodes: rf } = await layoutTreeElk(instances, "LR", new Set(), () => {}, hasOutEdge);
+    for (const node of rf) {
+      expect(Number.isFinite(node.position.x)).toBe(true);
+      expect(Number.isFinite(node.position.y)).toBe(true);
+    }
+    const x = new Map(rf.map((node) => [node.id, node.position.x]));
+    // Deeper nodes are strictly further along the main (x) axis under "layered".
+    expect(x.get("a")!).toBeLessThan(x.get("a/b")!);
+    expect(x.get("a/b")!).toBeLessThan(x.get("a/b/c")!);
+  });
+
+  it("ranks depth along y for the vertical (TB→DOWN) orientation", async () => {
+    const { instances, hasOutEdge } = unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c")],
+      [e("a", "b"), e("b", "c")],
+    );
+    const { nodes: rf } = await layoutTreeElk(instances, "TB", new Set(), () => {}, hasOutEdge);
+    const y = new Map(rf.map((node) => [node.id, node.position.y]));
+    expect(y.get("a")!).toBeLessThan(y.get("a/b")!);
+    expect(y.get("a/b")!).toBeLessThan(y.get("a/b/c")!);
+  });
+
+  it("returns empty for an empty instance list", async () => {
+    const { nodes, edges } = await layoutTreeElk([], "LR", new Set(), () => {});
+    expect(nodes).toEqual([]);
+    expect(edges).toEqual([]);
   });
 });
 

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -28,6 +28,12 @@ import type {
   DownstreamDAGEdgeKind,
   DownstreamDAGNode,
 } from "@/data/types";
+import {
+  layoutWithElk,
+  type ElkDirection,
+  type ElkLayoutEdge,
+  type ElkLayoutNode,
+} from "@/lib/elk-layout";
 import { nodeModule, type NodeModule } from "./style";
 
 /** Orientation toggle → which screen axis is the tree's main (depth) axis. */
@@ -344,10 +350,88 @@ function tidyTreeCross(
   return cross;
 }
 
+/** Handle (source/target) positions for the two orientations. */
+function handlePositions(direction: FlowDagDirection): {
+  source: Position;
+  target: Position;
+} {
+  return direction === "LR"
+    ? { source: Position.Right, target: Position.Left }
+    : { source: Position.Bottom, target: Position.Top };
+}
+
 /**
- * Build positioned React Flow nodes + edges from the unfolded tree.
+ * buildFlowDagNode constructs ONE React Flow node from an unfolded instance —
+ * its data payload (kind/role/badges/leaf-vs-truncated/module), sizing, and
+ * handle positions — but WITHOUT a final layout position (placed at 0,0). Both
+ * the tidy-tree and the ELK backends call this so the rendered DATA is byte-for-
+ * byte identical regardless of engine; only the `position` differs afterwards.
  *
- * Positioning is a tidy-tree pack (#4622): depth maps to the main axis and a
+ * The terminal-vs-truncated logic (#4561) lives here so it never drifts between
+ * engines: a genuine leaf gets the end-cap, a depth/cap-cut branch keeps its
+ * bucket + a 'more downstream' affordance.
+ */
+function buildFlowDagNode(
+  inst: TreeInstance,
+  ctx: {
+    renderedParents: Set<string>;
+    hasOutEdge?: Set<string>;
+    expanded: Set<string>;
+    onToggle: (instanceId: string) => void;
+    handles: { source: Position; target: Position };
+  },
+): FlowDagNode {
+  // #4561: this instance emitted no children here.
+  const childlessHere = !ctx.renderedParents.has(inst.id);
+  // The source node has downstream edges in the DAG.
+  const sourceHasChildren = ctx.hasOutEdge?.has(inst.node.id) ?? false;
+  // A genuine terminal: the backend marked it terminal, OR it's childless AND
+  // the source node truly has no out-edges (a real leaf / return).
+  const isLeaf = childlessHere && (inst.node.terminal === true || !sourceHasChildren);
+  // Cut by the depth/node cap: childless HERE but the source DID have children.
+  const truncatedHere = childlessHere && sourceHasChildren && inst.node.terminal !== true;
+  return {
+    id: inst.id,
+    type: NODE_TYPE,
+    position: { x: 0, y: 0 },
+    data: {
+      node: inst.node,
+      edgeKind: inst.edgeKind,
+      expanded: ctx.expanded.has(inst.id),
+      onToggleExpand: ctx.onToggle,
+      isLeaf,
+      truncatedHere,
+      module: nodeModule(inst.node),
+    },
+    sourcePosition: ctx.handles.source,
+    targetPosition: ctx.handles.target,
+    width: NODE_W,
+    height: NODE_H,
+  };
+}
+
+/** The tree's single in-edge per non-root instance → one React Flow edge each. */
+function buildFlowDagEdges(instances: TreeInstance[]): FlowDagEdge[] {
+  return instances
+    .filter((inst) => inst.parentId != null)
+    .map((inst) => ({
+      // One edge per non-root instance (the tree's single in-edge). The
+      // instance id is unique, so the edge id is too.
+      id: `e__${inst.id}`,
+      source: inst.parentId!,
+      target: inst.id,
+      type: EDGE_TYPE,
+      data: { kind: inst.edgeKind ?? "CALLS" },
+    }));
+}
+
+/**
+ * Build positioned React Flow nodes + edges from the unfolded tree, using the
+ * legacy tidy-tree pack (#4622). This is the synchronous fallback backend, kept
+ * behind the `VITE_FLOWDAG_LAYOUT_ENGINE=dagre` flag (see `defaultFlowDagEngine`)
+ * for a visual revert; the ELK backend (`layoutTreeElk`) is the default.
+ *
+ * Positioning is a tidy-tree pack: depth maps to the main axis and a
  * subtree-contiguous tidy layout maps to the cross axis, so each branch is one
  * visually-contiguous cluster. `direction` chooses which screen axis is main:
  * "LR" (horizontal, depth→x) or "TB" (vertical, depth→y).
@@ -395,61 +479,165 @@ export function layoutTree(
   const branchGap = isLR ? BRANCH_GAP_LR : BRANCH_GAP_TB;
 
   const crossById = tidyTreeCross(instances, crossStep, branchGap);
-
-  const sourcePos = isLR ? Position.Right : Position.Bottom;
-  const targetPos = isLR ? Position.Left : Position.Top;
+  const handles = handlePositions(direction);
 
   const rfNodes: FlowDagNode[] = instances.map((inst) => {
+    const node = buildFlowDagNode(inst, {
+      renderedParents,
+      hasOutEdge,
+      expanded,
+      onToggle,
+      handles,
+    });
     const depth = depthById.get(inst.id) ?? 0;
     const crossCenter = crossById.get(inst.id) ?? 0;
     // Center coordinates along each axis, then convert to top-left for RF.
     const mainCenter = MARGIN + depth * mainStep + mainNode / 2;
     const x = isLR ? mainCenter : MARGIN + crossCenter + crossNode / 2;
     const y = isLR ? MARGIN + crossCenter + crossNode / 2 : mainCenter;
-    const pos = { x, y };
-    // #4561: this instance emitted no children here.
-    const childlessHere = !renderedParents.has(inst.id);
-    // The source node has downstream edges in the DAG.
-    const sourceHasChildren = hasOutEdge?.has(inst.node.id) ?? false;
-    // A genuine terminal: the backend marked it terminal, OR it's childless AND
-    // the source node truly has no out-edges (a real leaf / return).
-    const isLeaf = childlessHere && (inst.node.terminal === true || !sourceHasChildren);
-    // Cut by the depth/node cap: childless HERE but the source DID have children.
-    const truncatedHere = childlessHere && sourceHasChildren && inst.node.terminal !== true;
-    return {
-      id: inst.id,
-      type: NODE_TYPE,
-      // pos is the node center; React Flow positions by top-left corner.
-      position: { x: pos.x - NODE_W / 2, y: pos.y - NODE_H / 2 },
-      data: {
-        node: inst.node,
-        edgeKind: inst.edgeKind,
-        expanded: expanded.has(inst.id),
-        onToggleExpand: onToggle,
-        isLeaf,
-        truncatedHere,
-        module: nodeModule(inst.node),
-      },
-      sourcePosition: sourcePos,
-      targetPosition: targetPos,
-      width: NODE_W,
-      height: NODE_H,
-    };
+    // (x, y) is the node center; React Flow positions by top-left corner.
+    node.position = { x: x - NODE_W / 2, y: y - NODE_H / 2 };
+    return node;
   });
 
-  const rfEdges: FlowDagEdge[] = instances
-    .filter((inst) => inst.parentId != null)
-    .map((inst) => ({
-      // One edge per non-root instance (the tree's single in-edge). The
-      // instance id is unique, so the edge id is too.
-      id: `e__${inst.id}`,
-      source: inst.parentId!,
-      target: inst.id,
-      type: EDGE_TYPE,
-      data: { kind: inst.edgeKind ?? "CALLS" },
-    }));
+  return { nodes: rfNodes, edges: buildFlowDagEdges(instances) };
+}
+
+/* ============================================================
+   ELK backend (default) — shared elkjs layered layout via lib/elk-layout.ts.
+
+   Part of the elkjs adoption epic (#4824/#4827). The unfolded pure tree is a
+   layered DAG, so we run ELK's `layered` algorithm with orthogonal edge routing
+   for clean right-angle connectors. Direction follows the H/V toggle: "LR" →
+   RIGHT (depth left→right), "TB" → DOWN (depth top→bottom). The tree has no
+   compound containment (every instance is a root-level node), so we pass a flat
+   node list and a `lane` = tree depth to keep the layered ranks pinned to tree
+   depth (so the layout reads strictly outward from the endpoint, matching the
+   tidy-tree's main-axis semantics).
+
+   The DATA on each node/edge is built by the same `buildFlowDagNode` /
+   `buildFlowDagEdges` helpers the tidy-tree backend uses, so the displayed
+   graph is identical across engines — only the positions differ.
+
+   `shape` is a forward hook for the flowchart view (#4819): a future flowchart
+   mode can pass different node dimensions/spacing without touching this call.
+   ============================================================ */
+
+/** Per-engine knobs the ELK backend exposes so a future flowchart mode (#4819)
+ *  can pass different node shapes/spacing without forking the layout call. */
+export interface FlowDagElkShape {
+  /** Layout box width fed to ELK (defaults to the card NODE_W). */
+  nodeWidth?: number;
+  /** Layout box height fed to ELK (defaults to the card NODE_H). */
+  nodeHeight?: number;
+  /** Spacing between siblings within a layer. */
+  nodeSpacing?: number;
+  /** Spacing between depth layers (ranks). */
+  layerSpacing?: number;
+}
+
+function elkDirection(direction: FlowDagDirection): ElkDirection {
+  return direction === "LR" ? "RIGHT" : "DOWN";
+}
+
+/**
+ * layoutTreeElk lays the unfolded tree out with ELK's layered algorithm via the
+ * shared helper, returning the same positioned React Flow nodes/edges the
+ * tidy-tree backend would — just with ELK's coordinates. Async (ELK layout is
+ * Promise-based); call from an effect and store the result.
+ *
+ * @param instances  unfolded tree instances (from unfoldTree)
+ * @param direction  "LR" (horizontal → RIGHT) | "TB" (vertical → DOWN)
+ * @param expanded   set of INSTANCE ids whose collapsed_children show inline
+ * @param onToggle   inline-expand toggle handler (keyed by instance id)
+ * @param hasOutEdge source ids with ≥1 out-edge (leaf-vs-truncated, #4561)
+ * @param shape      optional node-shape/spacing overrides (flowchart-ready, #4819)
+ */
+export async function layoutTreeElk(
+  instances: TreeInstance[],
+  direction: FlowDagDirection,
+  expanded: Set<string>,
+  onToggle: (instanceId: string) => void,
+  hasOutEdge?: Set<string>,
+  shape?: FlowDagElkShape,
+): Promise<{ nodes: FlowDagNode[]; edges: FlowDagEdge[] }> {
+  const renderedParents = new Set<string>();
+  for (const inst of instances) {
+    if (inst.parentId != null) renderedParents.add(inst.parentId);
+  }
+  const handles = handlePositions(direction);
+
+  const rfNodes = instances.map((inst) =>
+    buildFlowDagNode(inst, {
+      renderedParents,
+      hasOutEdge,
+      expanded,
+      onToggle,
+      handles,
+    }),
+  );
+  const rfEdges = buildFlowDagEdges(instances);
+
+  if (rfNodes.length === 0) return { nodes: rfNodes, edges: rfEdges };
+
+  // Tree depth per instance → layered rank lane, so the layout reads strictly
+  // outward from the endpoint (matching the tidy-tree's main-axis semantics).
+  const depthById = new Map<string, number>();
+  for (const inst of instances) {
+    depthById.set(
+      inst.id,
+      inst.parentId == null ? 0 : (depthById.get(inst.parentId) ?? 0) + 1,
+    );
+  }
+
+  const w = shape?.nodeWidth ?? NODE_W;
+  const h = shape?.nodeHeight ?? NODE_H;
+
+  // Flat node list — the unfolded tree has no compound containment.
+  const elkNodes: ElkLayoutNode[] = instances.map((inst) => ({
+    id: inst.id,
+    width: w,
+    height: h,
+    lane: depthById.get(inst.id) ?? 0,
+  }));
+  const elkEdges: ElkLayoutEdge[] = rfEdges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+  }));
+
+  const positions = await layoutWithElk(elkNodes, elkEdges, {
+    direction: elkDirection(direction),
+    algorithm: "layered",
+    edgeRouting: "ORTHOGONAL",
+    nodeSpacing: shape?.nodeSpacing ?? 28,
+    layerSpacing: shape?.layerSpacing ?? 90,
+    defaultNodeWidth: w,
+    defaultNodeHeight: h,
+  });
+
+  // ELK positions are top-left already (flat graph → parent-relative == absolute).
+  for (const node of rfNodes) {
+    const p = positions.get(node.id);
+    if (p) node.position = { x: p.x, y: p.y };
+  }
 
   return { nodes: rfNodes, edges: rfEdges };
+}
+
+/**
+ * Layout engine selection. Defaults to ELK (#4827); set the env flag
+ * `VITE_FLOWDAG_LAYOUT_ENGINE=dagre` to use the legacy tidy-tree fallback for a
+ * visual revert. (The fallback is the classic tidy-tree pack, historically a
+ * dagre replacement — the flag name mirrors `VITE_CT_LAYOUT_ENGINE`.)
+ */
+export type FlowDagLayoutEngine = "elk" | "dagre";
+export function defaultFlowDagEngine(): FlowDagLayoutEngine {
+  const env =
+    typeof import.meta !== "undefined"
+      ? (import.meta as { env?: Record<string, string | undefined> }).env
+      : undefined;
+  return env?.VITE_FLOWDAG_LAYOUT_ENGINE === "dagre" ? "dagre" : "elk";
 }
 
 export const FLOW_DAG_NODE_TYPE = NODE_TYPE;


### PR DESCRIPTION
## What

Migrate the **flow-dag** component (the Downstream-flow / Paths call DAG) to the shared **elkjs** layout util as the default backend.

The pre-existing flow-dag layout was a custom **tidy-tree** pack (Reingold–Tilford, #4622 — historically a dagre replacement); the legacy `VITE_CT_LAYOUT_ENGINE` flag name is mirrored here as `VITE_FLOWDAG_LAYOUT_ENGINE`.

## Changes

- **Consumes the shared util** `lib/elk-layout.ts` via new async `layoutTreeElk`, following the `compound-topology` / `iac-diagram` pattern (PR #4826/#4834).
- **Direction / routing:** `algorithm: 'layered'`, direction follows the H/V toggle (**LR→RIGHT**, **TB→DOWN**), `edgeRouting: 'ORTHOGONAL'` for clean right-angle connectors. Tree depth is passed as the layered `lane` so the layout reads strictly outward from the endpoint (matching the tidy-tree's main-axis semantics).
- **Engine swap only — data identical.** Extracted shared `buildFlowDagNode` / `buildFlowDagEdges` so BOTH engines emit byte-identical node/edge data: preserves the **#4817 2-row node header + NODE_H sizing**, node badges, edge styling/kinds, #4561 leaf-vs-truncated end-caps, #4557 module band, selection + #4479 route highlight, #4362 step-replay, depth/spine controls, theming.
- **Async lifecycle:** ELK runs in an effect (last-write-wins via run-id), with a `laying out…` loading state and a tidy-tree fallback on layout failure. Selection/route highlight is applied on top of the positioned layout so re-layout only fires on real layout-input changes (not on hover/select).
- **dagre fallback kept** behind `VITE_FLOWDAG_LAYOUT_ENGINE=dagre` (the synchronous tidy-tree path); not deleted.
- **Flowchart-ready (#4819):** `layoutTreeElk` takes an optional `FlowDagElkShape` (node width/height, node/layer spacing) so a future flowchart mode can pass different shapes/spacing without touching the layout call. No flowchart painted in here.

## Visual diff vs tidy-tree

- Connectors are now orthogonal right-angle elbows (ELK ORTHOGONAL) instead of the tidy-tree's straight/curved edges.
- Layer ranks still follow tree depth (lane-pinned), so the outward-from-endpoint reading is preserved; ELK packs the cross-axis with its own crossing-minimization (sibling subtrees no longer guaranteed strictly contiguous as in #4622, but layered ordering is cleaner for wide fans). Flip the env flag to revert visually.

## Gates

- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `npx vitest run` — 102 real unit tests pass (incl. updated `flow-dag/layout.test.ts` with 4 new ELK parity tests). The ~12 `e2e/*.spec.ts` Playwright failures are PRE-EXISTING/unrelated (vitest collecting Playwright specs).
- No registry/coverage changes (frontend only).

Deploy-deferred. Closes #4827. Part of #4824.