### PR TITLE
feat(#4828): migrate flows replay diagram to elkjs layered (animation preserved)

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDag.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDag.tsx
@@ -63,10 +63,14 @@ import type { DownstreamDAGNode, DownstreamDAGResponse } from "@/data/types";
 import {
   unfoldTree,
   layoutTree,
+  layoutTreeElk,
+  defaultFlowLayoutEngine,
   MAX_TREE_NODES,
   FLOW_DAG_NODE_TYPE,
   FLOW_DAG_EDGE_TYPE,
   type FlowDagDirection,
+  type FlowDagNode as FlowDagRFNode,
+  type FlowDagEdge as FlowDagRFEdge,
   type FlowDagNodeData,
   type FlowDagEdgeData,
 } from "./layout";
@@ -402,33 +406,99 @@ function FlowDagInner({
     return routeInstanceIds(unfold.instances, routeFocus);
   }, [unfold, routeFocus]);
 
-  const { nodes: baseNodes, edges: baseEdges } = useMemo(() => {
-    if (!unfold) return { nodes: [], edges: [] };
-    const laid = layoutTree(
+  // ── Layout engine (#4828) ────────────────────────────────────────────────
+  // ELK (layered + orthogonal, the shared lib/elk-layout helper) is the default;
+  // the synchronous tidy-tree is the fallback behind VITE_FLOWS_LAYOUT_ENGINE.
+  // ONLY node POSITIONS differ between engines — node data, ports, edge ids and
+  // source/target are identical (shared builders in layout.ts), so the
+  // replay/comet/scrubber sequence below and the route-highlight set are
+  // engine-agnostic. The selection/route overlay is applied AFTER positioning.
+  const engine = useMemo(() => defaultFlowLayoutEngine(), []);
+
+  // Tidy-tree path — synchronous, computed inline.
+  const tidyLaid = useMemo(() => {
+    if (engine !== "tidy" || !unfold) return null;
+    return layoutTree(
       unfold.instances,
       direction,
       expanded,
       onToggleExpand,
       unfold.hasOutEdge,
     );
-    for (const n of laid.nodes) {
+  }, [engine, unfold, direction, expanded, onToggleExpand]);
+
+  // ELK path — async; run in an effect, last-write-wins, with a layout flag so
+  // the canvas can show a loading state without tearing down the replay controls.
+  const EMPTY_LAID = useMemo(
+    () => ({ nodes: [] as FlowDagRFNode[], edges: [] as FlowDagRFEdge[] }),
+    [],
+  );
+  const [elkLaid, setElkLaid] = useState<{ nodes: FlowDagRFNode[]; edges: FlowDagRFEdge[] }>(
+    EMPTY_LAID,
+  );
+  const [elkReady, setElkReady] = useState(false);
+  const elkRunId = useRef(0);
+  useEffect(() => {
+    if (engine !== "elk") return;
+    if (!unfold) {
+      setElkLaid(EMPTY_LAID);
+      setElkReady(true);
+      return;
+    }
+    const myRun = ++elkRunId.current;
+    let cancelled = false;
+    setElkReady(false);
+    layoutTreeElk(unfold.instances, direction, expanded, onToggleExpand, unfold.hasOutEdge)
+      .then((laid) => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        setElkLaid(laid);
+        setElkReady(true);
+      })
+      .catch(() => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        // On ELK failure, fall back to the synchronous tidy-tree so the canvas
+        // still renders (better than a perpetual spinner).
+        setElkLaid(
+          layoutTree(unfold.instances, direction, expanded, onToggleExpand, unfold.hasOutEdge),
+        );
+        setElkReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [engine, unfold, direction, expanded, onToggleExpand, EMPTY_LAID]);
+
+  // The positioned (but un-overlaid) layout from the active engine.
+  const positioned = engine === "tidy" ? (tidyLaid ?? EMPTY_LAID) : elkLaid;
+  // True while ELK is still computing its first layout for the current inputs.
+  const layingOut = engine === "elk" && unfold != null && !elkReady;
+
+  const { nodes: baseNodes, edges: baseEdges } = useMemo(() => {
+    const nodes = positioned.nodes.map((n) => {
+      const data = { ...(n.data as FlowDagNodeData) };
       // Selection is driven by the ORIGINAL node id so the caller's contract
       // (Flows step inspector, #4354) is unchanged across the tree unfold; all
       // instances of a selected node light up.
       if (selectedNodeId != null) {
-        n.data.selected = (n.data as FlowDagNodeData).node.id === selectedNodeId;
+        data.selected = data.node.id === selectedNodeId;
       }
-      if (routeSet) n.data.onRoute = routeSet.has(n.id);
-    }
-    if (routeSet) {
-      for (const e of laid.edges) {
-        // An edge is on the route iff BOTH its endpoints are (the tree's single
-        // in-edge per node makes this exact).
-        e.data = { ...e.data, kind: e.data?.kind ?? "CALLS", onRoute: routeSet.has(e.source) && routeSet.has(e.target) };
-      }
-    }
-    return laid;
-  }, [unfold, direction, expanded, onToggleExpand, selectedNodeId, routeSet]);
+      if (routeSet) data.onRoute = routeSet.has(n.id);
+      return { ...n, data };
+    });
+    const edges = !routeSet
+      ? positioned.edges
+      : positioned.edges.map((e) => ({
+          ...e,
+          // An edge is on the route iff BOTH its endpoints are (the tree's single
+          // in-edge per node makes this exact).
+          data: {
+            ...e.data,
+            kind: e.data?.kind ?? "CALLS",
+            onRoute: routeSet.has(e.source) && routeSet.has(e.target),
+          } as FlowDagEdgeData,
+        }));
+    return { nodes, edges };
+  }, [positioned, selectedNodeId, routeSet]);
 
   // ── Step-replay (#4362) ──────────────────────────────────────────────────
   // The replay walks the laid-out tree in topological order. baseEdges are
@@ -622,6 +692,14 @@ function FlowDagInner({
         {isLoading && (
           <span className="inline-flex items-center gap-1 text-xs text-text-4">
             <Loader2 size={12} className="animate-spin" /> loading…
+          </span>
+        )}
+
+        {/* Layout status — ELK runs async; surface a quiet hint while it lays
+            out (the replay controls stay mounted, #4828). */}
+        {!isLoading && layingOut && (
+          <span className="inline-flex items-center gap-1 text-xs text-text-4">
+            <Loader2 size={12} className="animate-spin" /> laying out…
           </span>
         )}
 

--- a/webui-v2/src/components/flow-dag/layout.test.ts
+++ b/webui-v2/src/components/flow-dag/layout.test.ts
@@ -4,7 +4,12 @@
  * Run with: npx vitest run src/components/flow-dag/layout.test.ts
  */
 import { describe, it, expect } from "vitest";
-import { unfoldTree, layoutTree } from "./layout";
+import {
+  unfoldTree,
+  layoutTree,
+  layoutTreeElk,
+  defaultFlowLayoutEngine,
+} from "./layout";
 import { routeInstanceIds } from "./route";
 import {
   nodeBucket,
@@ -363,5 +368,64 @@ describe("layoutTree leaf vs truncated (#4561)", () => {
     // b has no out-edge in the DAG → genuine leaf, not truncated.
     expect(byId.get("a/b")?.isLeaf).toBe(true);
     expect(byId.get("a/b")?.truncatedHere).toBe(false);
+  });
+});
+
+describe("layoutTreeElk — ELK backend (#4828)", () => {
+  // a → b → {c, d} ; b also reached terminal e. A small branching tree.
+  const dag = () =>
+    unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c"), n("d"), n("e")],
+      [e("a", "b"), e("b", "c"), e("b", "d"), e("a", "e")],
+    );
+
+  it("produces the SAME node/edge STRUCTURE as the tidy backend (replay-stable)", async () => {
+    const { instances, hasOutEdge } = dag();
+    const tidy = layoutTree(instances, "LR", new Set(), () => {}, hasOutEdge);
+    const elk = await layoutTreeElk(instances, "LR", new Set(), () => {}, hasOutEdge);
+
+    // Same node ids (the replay/route sets key on these).
+    expect(elk.nodes.map((nd) => nd.id).sort()).toEqual(
+      tidy.nodes.map((nd) => nd.id).sort(),
+    );
+    // Same edge ids + source/target — the step-replay comet sequence derives
+    // PURELY from edge source/target, so this must be byte-identical.
+    const edgeKey = (g: typeof tidy) =>
+      g.edges.map((ed) => `${ed.id}|${ed.source}|${ed.target}`).sort();
+    expect(edgeKey(elk)).toEqual(edgeKey(tidy));
+    // Same leaf/truncated classification (engine-agnostic node data).
+    const flags = (g: typeof tidy) =>
+      new Map(g.nodes.map((nd) => [nd.id, `${nd.data.isLeaf}/${nd.data.truncatedHere}`]));
+    expect(flags(elk)).toEqual(flags(tidy));
+  });
+
+  it("assigns finite positions and ranks deeper nodes further along the main axis (LR→x)", async () => {
+    const { instances, hasOutEdge } = dag();
+    const elk = await layoutTreeElk(instances, "LR", new Set(), () => {}, hasOutEdge);
+    const x = new Map(elk.nodes.map((nd) => [nd.id, nd.position.x]));
+    for (const nd of elk.nodes) {
+      expect(Number.isFinite(nd.position.x)).toBe(true);
+      expect(Number.isFinite(nd.position.y)).toBe(true);
+    }
+    // a (depth 0) is left of b (depth 1), which is left of its children.
+    expect(x.get("a")!).toBeLessThan(x.get("a/b")!);
+    expect(x.get("a/b")!).toBeLessThan(x.get("a/b/c")!);
+  });
+
+  it("docks ports on the main axis per direction (LR vs TB)", async () => {
+    const { instances, hasOutEdge } = dag();
+    const lr = await layoutTreeElk(instances, "LR", new Set(), () => {}, hasOutEdge);
+    const tb = await layoutTreeElk(instances, "TB", new Set(), () => {}, hasOutEdge);
+    expect(lr.nodes[0].sourcePosition).toBe("right");
+    expect(lr.nodes[0].targetPosition).toBe("left");
+    expect(tb.nodes[0].sourcePosition).toBe("bottom");
+    expect(tb.nodes[0].targetPosition).toBe("top");
+  });
+});
+
+describe("defaultFlowLayoutEngine (#4828)", () => {
+  it("defaults to elk when the env flag is unset", () => {
+    expect(defaultFlowLayoutEngine()).toBe("elk");
   });
 });

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -28,6 +28,11 @@ import type {
   DownstreamDAGEdgeKind,
   DownstreamDAGNode,
 } from "@/data/types";
+import {
+  layoutWithElk,
+  type ElkLayoutNode,
+  type ElkLayoutEdge,
+} from "@/lib/elk-layout";
 import { nodeModule, type NodeModule } from "./style";
 
 /** Orientation toggle → which screen axis is the tree's main (depth) axis. */
@@ -344,13 +349,121 @@ function tidyTreeCross(
   return cross;
 }
 
+/* ============================================================
+   Engine-agnostic node/edge construction.
+
+   The leaf-vs-truncated classification (#4561), node data wiring, docking
+   ports, sizes, and the one-in-edge-per-instance edge list are IDENTICAL
+   regardless of which engine assigns coordinates. Both the tidy-tree (legacy
+   fallback) and ELK (#4828) positioners build the SAME nodes/edges here and only
+   differ in the final `position`. Keeping edge ids + source/target stable across
+   engines is load-bearing: the step-replay sequence and route-highlight set
+   (FlowDag.tsx) key off them, so the comet/scrubber animation is engine-agnostic.
+   ============================================================ */
+
+/** A node carrying its final data/ports/size but NO position yet. */
+interface UnplacedNode {
+  inst: TreeInstance;
+  data: FlowDagNodeData;
+}
+
 /**
- * Build positioned React Flow nodes + edges from the unfolded tree.
+ * buildNodeData computes the engine-agnostic per-instance node data: the
+ * leaf/truncated flags (#4561), the inline-expand wiring, and the module band.
+ */
+function buildUnplacedNodes(
+  instances: TreeInstance[],
+  expanded: Set<string>,
+  onToggle: (instanceId: string) => void,
+  hasOutEdge?: Set<string>,
+): UnplacedNode[] {
+  // Which instances actually emitted children in this unfold — to tell a real
+  // leaf from a depth-truncated branch (#4561).
+  const renderedParents = new Set<string>();
+  for (const inst of instances) {
+    if (inst.parentId != null) renderedParents.add(inst.parentId);
+  }
+
+  return instances.map((inst) => {
+    // #4561: this instance emitted no children here.
+    const childlessHere = !renderedParents.has(inst.id);
+    // The source node has downstream edges in the DAG.
+    const sourceHasChildren = hasOutEdge?.has(inst.node.id) ?? false;
+    // A genuine terminal: the backend marked it terminal, OR it's childless AND
+    // the source node truly has no out-edges (a real leaf / return).
+    const isLeaf = childlessHere && (inst.node.terminal === true || !sourceHasChildren);
+    // Cut by the depth/node cap: childless HERE but the source DID have children.
+    const truncatedHere = childlessHere && sourceHasChildren && inst.node.terminal !== true;
+    return {
+      inst,
+      data: {
+        node: inst.node,
+        edgeKind: inst.edgeKind,
+        expanded: expanded.has(inst.id),
+        onToggleExpand: onToggle,
+        isLeaf,
+        truncatedHere,
+        module: nodeModule(inst.node),
+      },
+    };
+  });
+}
+
+/** The single in-edge per non-root instance. Engine-agnostic and stable. */
+function buildEdges(instances: TreeInstance[]): FlowDagEdge[] {
+  return instances
+    .filter((inst) => inst.parentId != null)
+    .map((inst) => ({
+      // One edge per non-root instance (the tree's single in-edge). The
+      // instance id is unique, so the edge id is too.
+      id: `e__${inst.id}`,
+      source: inst.parentId!,
+      target: inst.id,
+      type: EDGE_TYPE,
+      data: { kind: inst.edgeKind ?? "CALLS" },
+    }));
+}
+
+/**
+ * assemble joins unplaced nodes + a per-instance top-left position into final
+ * React Flow nodes (ports keyed off direction), and pairs them with the stable
+ * edge list. Both positioners funnel through here so the output shape is
+ * byte-identical apart from coordinates.
+ */
+function assemble(
+  unplaced: UnplacedNode[],
+  instances: TreeInstance[],
+  direction: FlowDagDirection,
+  posOf: (id: string) => { x: number; y: number },
+): { nodes: FlowDagNode[]; edges: FlowDagEdge[] } {
+  const isLR = direction === "LR";
+  const sourcePos = isLR ? Position.Right : Position.Bottom;
+  const targetPos = isLR ? Position.Left : Position.Top;
+
+  const nodes: FlowDagNode[] = unplaced.map((u) => ({
+    id: u.inst.id,
+    type: NODE_TYPE,
+    position: posOf(u.inst.id),
+    data: u.data,
+    sourcePosition: sourcePos,
+    targetPosition: targetPos,
+    width: NODE_W,
+    height: NODE_H,
+  }));
+
+  return { nodes, edges: buildEdges(instances) };
+}
+
+/**
+ * Build positioned React Flow nodes + edges from the unfolded tree, using the
+ * synchronous tidy-tree pack (#4622). This is the legacy/fallback engine,
+ * selected via `VITE_FLOWS_LAYOUT_ENGINE=tidy` (or `=dagre` — same path); ELK is
+ * the default (see `layoutTreeElk` / `defaultFlowLayoutEngine`).
  *
- * Positioning is a tidy-tree pack (#4622): depth maps to the main axis and a
- * subtree-contiguous tidy layout maps to the cross axis, so each branch is one
- * visually-contiguous cluster. `direction` chooses which screen axis is main:
- * "LR" (horizontal, depth→x) or "TB" (vertical, depth→y).
+ * Positioning: depth maps to the main axis and a subtree-contiguous tidy layout
+ * maps to the cross axis, so each branch is one visually-contiguous cluster.
+ * `direction` chooses which screen axis is main: "LR" (horizontal, depth→x) or
+ * "TB" (vertical, depth→y).
  *
  * @param instances  unfolded tree instances (from unfoldTree)
  * @param direction  "LR" (horizontal) | "TB" (vertical)
@@ -364,12 +477,7 @@ export function layoutTree(
   onToggle: (instanceId: string) => void,
   hasOutEdge?: Set<string>,
 ): { nodes: FlowDagNode[]; edges: FlowDagEdge[] } {
-  // Which instances actually emitted children in this unfold — to tell a real
-  // leaf from a depth-truncated branch (#4561).
-  const renderedParents = new Set<string>();
-  for (const inst of instances) {
-    if (inst.parentId != null) renderedParents.add(inst.parentId);
-  }
+  const unplaced = buildUnplacedNodes(instances, expanded, onToggle, hasOutEdge);
 
   // Depth of each instance (along the main axis), derived from the parent chain.
   // instances are emitted parent-before-child (BFS), so a single forward pass
@@ -396,60 +504,92 @@ export function layoutTree(
 
   const crossById = tidyTreeCross(instances, crossStep, branchGap);
 
-  const sourcePos = isLR ? Position.Right : Position.Bottom;
-  const targetPos = isLR ? Position.Left : Position.Top;
-
-  const rfNodes: FlowDagNode[] = instances.map((inst) => {
-    const depth = depthById.get(inst.id) ?? 0;
-    const crossCenter = crossById.get(inst.id) ?? 0;
+  const posOf = (id: string): { x: number; y: number } => {
+    const depth = depthById.get(id) ?? 0;
+    const crossCenter = crossById.get(id) ?? 0;
     // Center coordinates along each axis, then convert to top-left for RF.
     const mainCenter = MARGIN + depth * mainStep + mainNode / 2;
     const x = isLR ? mainCenter : MARGIN + crossCenter + crossNode / 2;
     const y = isLR ? MARGIN + crossCenter + crossNode / 2 : mainCenter;
-    const pos = { x, y };
-    // #4561: this instance emitted no children here.
-    const childlessHere = !renderedParents.has(inst.id);
-    // The source node has downstream edges in the DAG.
-    const sourceHasChildren = hasOutEdge?.has(inst.node.id) ?? false;
-    // A genuine terminal: the backend marked it terminal, OR it's childless AND
-    // the source node truly has no out-edges (a real leaf / return).
-    const isLeaf = childlessHere && (inst.node.terminal === true || !sourceHasChildren);
-    // Cut by the depth/node cap: childless HERE but the source DID have children.
-    const truncatedHere = childlessHere && sourceHasChildren && inst.node.terminal !== true;
-    return {
-      id: inst.id,
-      type: NODE_TYPE,
-      // pos is the node center; React Flow positions by top-left corner.
-      position: { x: pos.x - NODE_W / 2, y: pos.y - NODE_H / 2 },
-      data: {
-        node: inst.node,
-        edgeKind: inst.edgeKind,
-        expanded: expanded.has(inst.id),
-        onToggleExpand: onToggle,
-        isLeaf,
-        truncatedHere,
-        module: nodeModule(inst.node),
-      },
-      sourcePosition: sourcePos,
-      targetPosition: targetPos,
-      width: NODE_W,
-      height: NODE_H,
-    };
+    // posOf returns the node center; convert to React Flow's top-left corner.
+    return { x: x - NODE_W / 2, y: y - NODE_H / 2 };
+  };
+
+  return assemble(unplaced, instances, direction, posOf);
+}
+
+/* ============================================================
+   ELK backend (default, async) — #4828.
+
+   The unfolded tree is laid out by the shared ELK helper (lib/elk-layout.ts)
+   with the layered algorithm + orthogonal edge routing, the same engine the IaC
+   and compound-topology diagrams use (#4824). Unlike those, the flow tree has NO
+   compound containers — every instance is a flat root-level node — so we pass a
+   flat node list and ELK ranks them purely from the tree's single-in-edge
+   structure. `direction` LR→RIGHT / TB→DOWN matches the tidy-tree orientation.
+
+   Node data, ports, edge ids, and source/target are IDENTICAL to the tidy
+   backend (shared via buildUnplacedNodes/assemble), so the replay/comet/scrubber
+   sequence and route-highlight set are unaffected by the engine swap.
+   ============================================================ */
+
+export async function layoutTreeElk(
+  instances: TreeInstance[],
+  direction: FlowDagDirection,
+  expanded: Set<string>,
+  onToggle: (instanceId: string) => void,
+  hasOutEdge?: Set<string>,
+): Promise<{ nodes: FlowDagNode[]; edges: FlowDagEdge[] }> {
+  const unplaced = buildUnplacedNodes(instances, expanded, onToggle, hasOutEdge);
+  const edges = buildEdges(instances);
+
+  const isLR = direction === "LR";
+  const elkNodes: ElkLayoutNode[] = instances.map((inst) => ({
+    id: inst.id,
+    width: NODE_W,
+    height: NODE_H,
+  }));
+  const elkEdges: ElkLayoutEdge[] = edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+  }));
+
+  const positions = await layoutWithElk(elkNodes, elkEdges, {
+    algorithm: "layered",
+    direction: isLR ? "RIGHT" : "DOWN",
+    edgeRouting: "ORTHOGONAL",
+    // Mirror the tidy-tree spacing so the H/V switch reads consistently.
+    nodeSpacing: isLR ? SIBLING_LEAF_GAP_LR : SIBLING_LEAF_GAP_TB,
+    layerSpacing: isLR ? RANK_GAP_LR : RANK_GAP_TB,
+    defaultNodeWidth: NODE_W,
+    defaultNodeHeight: NODE_H,
   });
 
-  const rfEdges: FlowDagEdge[] = instances
-    .filter((inst) => inst.parentId != null)
-    .map((inst) => ({
-      // One edge per non-root instance (the tree's single in-edge). The
-      // instance id is unique, so the edge id is too.
-      id: `e__${inst.id}`,
-      source: inst.parentId!,
-      target: inst.id,
-      type: EDGE_TYPE,
-      data: { kind: inst.edgeKind ?? "CALLS" },
-    }));
+  // Flat graph: ELK positions are already absolute (no parent nesting). Fall
+  // back to origin for any id ELK didn't place so the canvas still mounts.
+  const posOf = (id: string): { x: number; y: number } => {
+    const p = positions.get(id);
+    return { x: p?.x ?? 0, y: p?.y ?? 0 };
+  };
 
-  return { nodes: rfNodes, edges: rfEdges };
+  return assemble(unplaced, instances, direction, posOf);
+}
+
+/**
+ * Layout engine selection for the Flows replay/DAG diagram. Defaults to ELK
+ * (#4828); set `VITE_FLOWS_LAYOUT_ENGINE=dagre` (or `=tidy`) to fall back to the
+ * synchronous tidy-tree positioner for a visual revert. The replay/comet/
+ * scrubber animation is identical under either engine.
+ */
+export type FlowLayoutEngine = "elk" | "tidy";
+export function defaultFlowLayoutEngine(): FlowLayoutEngine {
+  const env =
+    typeof import.meta !== "undefined"
+      ? (import.meta as { env?: Record<string, string | undefined> }).env
+      : undefined;
+  const flag = env?.VITE_FLOWS_LAYOUT_ENGINE;
+  return flag === "dagre" || flag === "tidy" ? "tidy" : "elk";
 }
 
 export const FLOW_DAG_NODE_TYPE = NODE_TYPE;


### PR DESCRIPTION
## What changed

The Flows replay/comet diagram is rendered by the shared `<FlowDag>` component (`components/flow-dag/`), driven from `routes/flows.tsx` via `<SharedFlowDag enableReplay>`. The dagre reference in `flows.tsx` is a historical code comment only; the diagram's node positioning actually used a bespoke synchronous **tidy-tree** (`components/flow-dag/layout.ts`). This PR migrates the default positioner to **elkjs (layered + ORTHOGONAL routing)** via the shared `lib/elk-layout` helper — the same foundation the IaC (#4826) and compound-topology diagrams consume.

### `components/flow-dag/layout.ts`
- Split the **engine-agnostic** node-data/edge construction (`buildUnplacedNodes` / `buildEdges` / `assemble`) from positioning. Leaf-vs-truncated classification (#4561), node data, docking ports, sizes, and the one-in-edge-per-instance edge list are now shared.
- Added the async **`layoutTreeElk`** backend (`algorithm: 'layered'`, `direction` LR→RIGHT / TB→DOWN, `edgeRouting: 'ORTHOGONAL'`, spacing mirrored from the tidy constants). The flow tree has no compound containers, so it passes a flat node list and lets ELK rank from the tree's single-in-edge structure.
- Kept the tidy-tree `layoutTree` as the **synchronous fallback** behind `VITE_FLOWS_LAYOUT_ENGINE=dagre` (or `=tidy`) via `defaultFlowLayoutEngine()`. ELK is the default.

### `components/flow-dag/FlowDag.tsx`
- Engine-aware positioning: ELK runs in an effect (last-write-wins, `elkRunId` guard) with a quiet "laying out…" hint in the controls bar; the tidy path stays inline. On ELK failure it falls back to the tidy positioner so the canvas always mounts.
- The selection + route-highlight overlay is applied **after** positioning, over whichever engine produced the layout.

## Replay / comet / scrubber preserved
ELK changes **only static node positions**. Edge ids + `source`/`target` and node ids/data are byte-identical across engines (shared builders), so:
- the **step-replay sequence** (`replaySeq`, derived purely from edge `source`/`target` in BFS order),
- the **comet** (samples the React Flow bezier `path` `d` at render time via `getPointAtLength` — independent of the positioner),
- the **scrubber, timing, speed, audio blips, ESC-pause**, and the **route-highlight set**

all ride on top unchanged. The async layout uses a loading flag so the replay controls are never torn down mid-layout.

## `src/components/graph` audit — LEFT ALONE
- `graph-canvas.tsx` — GPU **force-directed** graph via **cosmos.gl** (WebGL simulation). Not React Flow, not hierarchical.
- `module-overview.tsx` — hand-rolled **SVG** with a custom **force simulation** + own pan/zoom. Also force-directed.
- Remaining files are UI panels/overlays with no graph layout.

None are layered/hierarchical React-Flow DAGs; ELK's layered algorithm is the wrong tool for force-directed network exploration. Migrating would be a scope regression with visual behavior change, so no migration here. (No follow-up warranted — these are intentionally physics-based views.)

## Gates
- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npx vitest run` — **107 real unit tests pass** (incl. 4 new ELK-backend tests asserting structural parity with tidy / finite+ranked positions / per-direction ports / default engine). The 12 `e2e/*.spec.ts` failures are pre-existing Playwright files that can't run under vitest, unrelated to this change.
- No registry/coverage changes (frontend only).

Deploy-deferred. Closes #4828. Part of #4824.