### PR TITLE
feat(#4830): generalize control-flow extraction to brace-family + ruby/swift (validated per language)

### DIFF
--- a/internal/substrate/cfg.go
+++ b/internal/substrate/cfg.go
@@ -242,7 +242,7 @@ func BuildControlFlowGraph(lang, funcSource string, startLine int) *ControlFlowG
 // hasBlockDetector reports whether a language family has a block detector wired
 // (so a branchless function is reported Supported=true, not "unsupported").
 func hasBlockDetector(lang string) bool {
-	return lang == "python" || braceLangs[lang]
+	return lang == "python" || lang == "ruby" || braceLangs[lang] || braceCFGLangs[lang]
 }
 
 func sortBlocks(blocks []blockHeader) []blockHeader {

--- a/internal/substrate/cfg_multilang_test.go
+++ b/internal/substrate/cfg_multilang_test.go
@@ -1,0 +1,369 @@
+package substrate
+
+import "testing"
+
+// Control-flow extraction generalized from the JS/TS + Python validated set to
+// the remaining brace-family languages plus Ruby and Swift (#4830, epic #4820).
+//
+// Part (b) (cfg_test.go) validated Python and JS/TS. The brace-family detectors
+// (java/go/php/csharp/kotlin/scala/rust) and the non-brace families (ruby/swift)
+// previously "ran but were only jsts-validated" — and several had real per-
+// language quirks the C/Java baseline missed (Go's no-paren `if cond {`, Rust's
+// `match`/`loop`, PHP's `elseif`/`foreach`, Ruby's `end`-blocks, Swift's
+// `guard`/no-paren `switch`). This file flips each from "runs" to "validated"
+// with a small real-shaped fixture: an if/else + loop + effect function whose
+// CFG must contain a decision node carrying condition text, a loop node with a
+// loop_back edge, a terminal wired to the exit, an effect-annotated node, and a
+// non-trivial cyclomatic complexity.
+
+// assertValidatedCFG runs the shared per-language validation contract.
+func assertValidatedCFG(t *testing.T, lang, src string, wantLoopBack bool) {
+	t.Helper()
+	g := BuildControlFlowGraph(lang, src, 100)
+
+	if !g.Supported {
+		t.Fatalf("%s: CFG should be Supported (block detector wired); nodes=%+v", lang, g.Nodes)
+	}
+	if g.Cyclomatic < 2 {
+		t.Errorf("%s: cyclomatic = %d; want >= 2 (non-trivial)", lang, g.Cyclomatic)
+	}
+	if g.BranchCount != g.Cyclomatic-1 {
+		t.Errorf("%s: branch_count %d != cyclomatic-1 %d", lang, g.BranchCount, g.Cyclomatic-1)
+	}
+
+	// A decision node carrying condition text.
+	decs := nodesByShape(g, ShapeDecision)
+	if len(decs) == 0 {
+		t.Fatalf("%s: no decision node; nodes=%+v", lang, g.Nodes)
+	}
+	hasCond := false
+	for _, d := range decs {
+		if d.Condition != "" {
+			hasCond = true
+		}
+	}
+	if !hasCond {
+		t.Errorf("%s: no decision carried condition text; decisions=%+v", lang, decs)
+	}
+
+	// A loop node + (where the loop body has a tail) a back-edge.
+	if len(nodesByShape(g, ShapeLoop)) == 0 {
+		t.Errorf("%s: no loop node; nodes=%+v", lang, g.Nodes)
+	}
+	if wantLoopBack && !hasEdgeKind(g, EdgeBack) {
+		t.Errorf("%s: no loop back-edge; edges=%+v", lang, g.Edges)
+	}
+
+	// An effect-annotated process node (db_read/db_write/http_out).
+	gotEffect := false
+	for _, n := range g.Nodes {
+		if len(n.Effects) > 0 {
+			gotEffect = true
+		}
+	}
+	if !gotEffect {
+		t.Errorf("%s: expected an effect-annotated node; nodes=%+v", lang, g.Nodes)
+	}
+
+	// Exactly one start + one end bookend.
+	if len(nodesByShape(g, ShapeStart)) != 1 || len(nodesByShape(g, ShapeEnd)) != 1 {
+		t.Errorf("%s: want exactly one start and one end; nodes=%+v", lang, g.Nodes)
+	}
+}
+
+// TestCFGGoValidated — Go: no-paren `if force {`, `for rows.Next() {`, an
+// explicit `return`, db/http effects.
+func TestCFGGoValidated(t *testing.T) {
+	assertValidatedCFG(t, "go", `func Sync(ctx context.Context, force bool) error {
+	rows, _ := db.Query(ctx, "SELECT * FROM contacts")
+	if force {
+		db.Exec(ctx, "INSERT INTO log VALUES (1)")
+	}
+	for rows.Next() {
+		http.Post("https://api.example.com/notify", "application/json", nil)
+	}
+	return nil
+}
+`, true)
+}
+
+// TestCFGRustValidated — Rust: no-paren `if force {`, `for row in rows {`, `?`
+// early-exit (modeled as effect lines), db/http effects.
+func TestCFGRustValidated(t *testing.T) {
+	assertValidatedCFG(t, "rust", `fn sync(force: bool) -> Result<(), Error> {
+    let rows = client.query("SELECT * FROM contacts", &[])?;
+    if force {
+        client.execute("INSERT INTO log VALUES (1)", &[])?;
+    }
+    for row in rows {
+        reqwest::blocking::Client::new().post("https://api.example.com/notify").send()?;
+    }
+    Ok(())
+}
+`, true)
+}
+
+// TestCFGKotlinValidated — Kotlin: paren `if (force)`, `for (row in rows)`.
+func TestCFGKotlinValidated(t *testing.T) {
+	assertValidatedCFG(t, "kotlin", `fun sync(force: Boolean) {
+    val rows = repository.findAll()
+    if (force) {
+        repository.save(Log(1))
+    }
+    for (row in rows) {
+        httpClient.post("https://api.example.com/notify")
+    }
+    return
+}
+`, true)
+}
+
+// TestCFGScalaValidated — Scala: paren `if (force)`, `for (row <- rows)`.
+func TestCFGScalaValidated(t *testing.T) {
+	assertValidatedCFG(t, "scala", `def sync(force: Boolean): Unit = {
+    val rows = sql"SELECT * FROM contacts".query[Contact].to[List]
+    if (force) {
+      em.persist(new Log(1))
+    }
+    for (row <- rows) {
+      requests.post("https://api.example.com/notify")
+    }
+  }
+`, true)
+}
+
+// TestCFGCSharpValidated — C#: paren `if (force)`, `foreach (var row in rows)`.
+func TestCFGCSharpValidated(t *testing.T) {
+	assertValidatedCFG(t, "csharp", `public async Task Sync(bool force) {
+    var rows = await _db.Contacts.ToListAsync();
+    if (force) {
+        await _db.Logs.AddAsync(new Log());
+    }
+    foreach (var row in rows) {
+        await _http.PostAsync("https://api.example.com/notify", null);
+    }
+    return;
+}
+`, true)
+}
+
+// TestCFGPHPValidated — PHP: `elseif` (second decision) and `foreach` (loop),
+// which the C/Java baseline previously missed entirely.
+func TestCFGPHPValidated(t *testing.T) {
+	g := BuildControlFlowGraph("php", `function sync($force) {
+    $rows = DB::table('contacts')->get();
+    if ($force) {
+        DB::table('log')->insert(['id' => 1]);
+    } elseif ($other) {
+        DB::table('log')->insert(['id' => 2]);
+    }
+    foreach ($rows as $row) {
+        Http::post("https://api.example.com/notify");
+    }
+    return null;
+}
+`, 100)
+	if !g.Supported {
+		t.Fatalf("php CFG should be supported; nodes=%+v", g.Nodes)
+	}
+	// elseif must be its OWN decision (regression: previously eaten as bare else
+	// without a condition).
+	sawElseIf := false
+	for _, d := range nodesByShape(g, ShapeDecision) {
+		if d.Condition == "elseif ($other)" {
+			sawElseIf = true
+		}
+	}
+	if !sawElseIf {
+		t.Errorf("php elseif not surfaced as its own conditioned decision; decisions=%+v", nodesByShape(g, ShapeDecision))
+	}
+	// foreach must be a loop with a back-edge.
+	if len(nodesByShape(g, ShapeLoop)) == 0 {
+		t.Errorf("php foreach not surfaced as a loop; nodes=%+v", g.Nodes)
+	}
+	if !hasEdgeKind(g, EdgeBack) {
+		t.Errorf("php foreach has no loop back-edge; edges=%+v", g.Edges)
+	}
+	if !hasEdgeKind(g, EdgeExit) {
+		t.Errorf("php no exit edge; edges=%+v", g.Edges)
+	}
+}
+
+// TestCFGRubyValidated — Ruby (`end`-delimited, NOT brace): `if force … end`
+// block + `.each do |row| … end` iterator block (a loop). Previously returned
+// supported=false.
+func TestCFGRubyValidated(t *testing.T) {
+	assertValidatedCFG(t, "ruby", `def sync(force)
+  rows = Contact.where(active: true)
+  if force
+    Contact.create(name: "x")
+  end
+  rows.each do |row|
+    Net::HTTP.post(URI("https://api.example.com/notify"), "")
+  end
+  nil
+end
+`, true)
+}
+
+// TestCFGSwiftValidated — Swift: no-paren `if force {`, `for row in rows {`,
+// explicit `return`. Previously returned supported=false.
+func TestCFGSwiftValidated(t *testing.T) {
+	assertValidatedCFG(t, "swift", `func sync(force: Bool) {
+    let rows = try! context.fetch(request)
+    if force {
+        context.insert(Log())
+    }
+    for row in rows {
+        URLSession.shared.dataTask(with: url).resume()
+    }
+    return
+}
+`, true)
+}
+
+// TestCFGGoSwitchSelect — Go-specific: `switch x {` and `select {` are decision
+// nodes (no-paren), and `case` bodies carry effects.
+func TestCFGGoSwitchSelect(t *testing.T) {
+	g := BuildControlFlowGraph("go", `func route(kind string) error {
+	switch kind {
+	case "write":
+		db.Exec(ctx, "INSERT INTO a VALUES (1)")
+	default:
+		return nil
+	}
+	return nil
+}
+`, 10)
+	if !g.Supported {
+		t.Fatalf("go switch CFG should be supported")
+	}
+	sawSwitch := false
+	for _, d := range nodesByShape(g, ShapeDecision) {
+		if d.Condition == "switch kind" {
+			sawSwitch = true
+		}
+	}
+	if !sawSwitch {
+		t.Errorf("go `switch` not surfaced as a decision; decisions=%+v", nodesByShape(g, ShapeDecision))
+	}
+}
+
+// TestCFGRustMatchLoop — Rust-specific: `match x {` decision + `loop {` loop.
+func TestCFGRustMatchLoop(t *testing.T) {
+	g := BuildControlFlowGraph("rust", `fn poll(kind: &str) {
+    match kind {
+        "a" => { client.execute("INSERT INTO a", &[]); }
+        _ => {}
+    }
+    loop {
+        reqwest::get("https://x").unwrap();
+        break;
+    }
+}
+`, 10)
+	sawMatch, sawLoop := false, false
+	for _, d := range nodesByShape(g, ShapeDecision) {
+		if d.Condition == "match kind" {
+			sawMatch = true
+		}
+	}
+	for _, n := range nodesByShape(g, ShapeLoop) {
+		if n.Condition == "loop" {
+			sawLoop = true
+		}
+	}
+	if !sawMatch {
+		t.Errorf("rust `match` not surfaced as a decision; decisions=%+v", nodesByShape(g, ShapeDecision))
+	}
+	if !sawLoop {
+		t.Errorf("rust `loop` not surfaced as a loop; loops=%+v", nodesByShape(g, ShapeLoop))
+	}
+}
+
+// TestCFGKotlinWhen — Kotlin-specific: `when (x) {` is a decision.
+func TestCFGKotlinWhen(t *testing.T) {
+	g := BuildControlFlowGraph("kotlin", `fun route(kind: String) {
+    when (kind) {
+        "a" -> repository.save(A())
+        else -> {}
+    }
+}
+`, 10)
+	saw := false
+	for _, d := range nodesByShape(g, ShapeDecision) {
+		if d.Condition == "when (kind)" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("kotlin `when` not surfaced as a decision; decisions=%+v", nodesByShape(g, ShapeDecision))
+	}
+}
+
+// TestCFGScalaMatch — Scala-specific: infix `x match {` is a decision.
+func TestCFGScalaMatch(t *testing.T) {
+	g := BuildControlFlowGraph("scala", `def route(kind: String): Unit = {
+    kind match {
+      case "a" => repo.save(A())
+      case _ =>
+    }
+  }
+`, 10)
+	saw := false
+	for _, d := range nodesByShape(g, ShapeDecision) {
+		if d.Condition == "kind match" {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Errorf("scala infix `match` not surfaced as a decision; decisions=%+v", nodesByShape(g, ShapeDecision))
+	}
+}
+
+// TestCFGSwiftGuardSwitch — Swift-specific: `guard … else {` and no-paren
+// `switch x {` are decisions.
+func TestCFGSwiftGuardSwitch(t *testing.T) {
+	g := BuildControlFlowGraph("swift", `func route(kind: String) {
+    guard kind != "" else {
+        return
+    }
+    switch kind {
+    case "a":
+        context.insert(A())
+    default:
+        break
+    }
+}
+`, 10)
+	sawGuard, sawSwitch := false, false
+	for _, d := range nodesByShape(g, ShapeDecision) {
+		if len(d.Condition) >= 5 && d.Condition[:5] == "guard" {
+			sawGuard = true
+		}
+		if d.Condition == "switch kind" {
+			sawSwitch = true
+		}
+	}
+	if !sawGuard {
+		t.Errorf("swift `guard` not surfaced as a decision; decisions=%+v", nodesByShape(g, ShapeDecision))
+	}
+	if !sawSwitch {
+		t.Errorf("swift `switch` not surfaced as a decision; decisions=%+v", nodesByShape(g, ShapeDecision))
+	}
+}
+
+// TestCFGUnsupportedLanguagesDocumented pins WHICH languages remain
+// supported=false (no validated block detector) so the honest-partial contract
+// is explicit and a future regression that silently flips them is caught.
+func TestCFGUnsupportedLanguagesDocumented(t *testing.T) {
+	for _, lang := range []string{"cobol", "elixir", "crystal", "lua", "dart", "solidity", "zig", "nim", "clojure"} {
+		g := BuildControlFlowGraph(lang, "x = 1\n", 1)
+		if g.Supported {
+			t.Errorf("%s has no validated block detector; Supported should be false (update the deferred list + docs if intentionally added)", lang)
+		}
+		if len(nodesByShape(g, ShapeStart)) != 1 || len(nodesByShape(g, ShapeEnd)) != 1 {
+			t.Errorf("%s: degenerate CFG must still have start+end; nodes=%+v", lang, g.Nodes)
+		}
+	}
+}

--- a/internal/substrate/effect_context.go
+++ b/internal/substrate/effect_context.go
@@ -157,13 +157,24 @@ func enclosingBlocks(src, lang string, startLine int) []blockHeader {
 	switch {
 	case lang == "python":
 		return pythonBlocks(src, startLine)
-	case braceLangs[lang]:
-		return braceBlocks(src, startLine)
+	case lang == "ruby":
+		return rubyBlocks(src, startLine)
+	case braceLangs[lang] || braceCFGLangs[lang]:
+		return braceBlocks(src, lang, startLine)
 	default:
 		// No block detector for this family yet — effects are still reported,
 		// just without conditional/loop attribution (honest-partial).
 		return nil
 	}
+}
+
+// braceCFGLangs is the set of brace-delimited languages that are NOT in the
+// ClampToFunctionBody braceLangs set (so their function body is not source-level
+// clamped) but DO have a validated control-flow / effect-context block detector.
+// Swift's `{}`-delimited bodies are classified the same way as the braceLangs
+// family for control-flow purposes (#4830).
+var braceCFGLangs = map[string]bool{
+	"swift": true,
 }
 
 var (
@@ -215,28 +226,193 @@ func pythonBlocks(src string, startLine int) []blockHeader {
 	return out
 }
 
+// --- ruby (`end`-delimited) block discovery -------------------------------
+
 var (
-	braceIfRe     = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\(`)
-	braceElseRe   = regexp.MustCompile(`^\s*\}?\s*else\b`)
-	braceCatchRe  = regexp.MustCompile(`^\s*\}?\s*catch\b`)
-	braceTryRe    = regexp.MustCompile(`^\s*try\b`)
-	braceSwitchRe = regexp.MustCompile(`^\s*switch\s*\(`)
-	braceForRe    = regexp.MustCompile(`^\s*for\s*[(\s]`)
-	braceWhileRe  = regexp.MustCompile(`^\s*}?\s*while\s*\(`)
-	braceForEachRe = regexp.MustCompile(`\.\s*for[Ee]ach\s*\(`)
+	// rubyCondBlockRe — a leading-keyword conditional block: `if`, `unless`,
+	// `case`, `begin`. (Trailing-modifier `x if y` is NOT a block; it has code
+	// before the keyword and is excluded by isRubyModifierLine.)
+	rubyCondBlockRe = regexp.MustCompile(`^\s*(if|unless|case|begin)\b(.*?)\s*(?:then)?\s*$`)
+	// rubyLoopBlockRe — keyword loop forms: `while`/`until`/`for … in …`.
+	rubyLoopBlockRe = regexp.MustCompile(`^\s*(while|until|for)\b(.*?)\s*(?:do)?\s*$`)
+	// rubyDoBlockRe — an iterator block tail `…each do |x|` / `…do` opening a
+	// `do…end` block (a loop / fan-out over a collection).
+	rubyDoBlockRe = regexp.MustCompile(`\bdo\b(\s*\|[^|]*\|)?\s*$`)
+	// rubyElsifRe — `elsif`/`else`/`rescue`/`ensure`/`when` continuation clauses
+	// (do not open a new `end`-block).
+	rubyElsifRe    = regexp.MustCompile(`^\s*(elsif|else|rescue|ensure|when)\b`)
+	rubyDefBlockRe = regexp.MustCompile(`^\s*(def|class|module)\b`)
 )
+
+// rubyBlocks scopes Ruby `end`-delimited conditional/loop blocks by keyword
+// depth: an opener (`if`/`unless`/`case`/`begin`/`while`/`until`/`for`, or a
+// trailing `do`) increments depth, an `end` decrements it; the block runs from
+// its header to the matching `end`. Iterator `do…end` (and `.each do`) blocks
+// are treated as loops (a fan-out / N+1 signal), mirroring the brace-family
+// `.forEach`. Modifier guards (`return x if y`) are not blocks and are skipped.
+func rubyBlocks(src string, startLine int) []blockHeader {
+	lines := strings.Split(src, "\n")
+	var out []blockHeader
+	for i, raw := range lines {
+		scan := strings.TrimSpace(raw)
+		if scan == "" {
+			continue
+		}
+		var cond string
+		var isLoop bool
+		switch {
+		case rubyLoopBlockRe.MatchString(raw):
+			m := rubyLoopBlockRe.FindStringSubmatch(raw)
+			cond = strings.TrimSpace(m[1] + " " + strings.TrimSpace(m[2]))
+			isLoop = true
+		case rubyDoBlockRe.MatchString(raw) && !rubyCondBlockRe.MatchString(raw):
+			// `collection.each do |x|` — iterator block (loop).
+			cond = strings.TrimSpace(rubyDoBlockRe.ReplaceAllString(scan, ""))
+			if cond == "" {
+				cond = "do"
+			}
+			isLoop = true
+		case rubyCondBlockRe.MatchString(raw) && !isRubyModifierLine(raw):
+			m := rubyCondBlockRe.FindStringSubmatch(raw)
+			cond = strings.TrimSpace(m[1] + " " + strings.TrimSpace(m[2]))
+		default:
+			continue
+		}
+		end := rubyBlockSpanEnd(lines, i)
+		out = append(out, blockHeader{
+			condition: cond,
+			startLine: startLine + i,
+			endLine:   startLine + end,
+			isLoop:    isLoop,
+		})
+	}
+	return out
+}
+
+// isRubyModifierLine reports whether a line is a trailing-modifier guard
+// (`return x if cond`) rather than a block opener — i.e. there is code before
+// the leading conditional keyword.
+func isRubyModifierLine(raw string) bool {
+	trimmed := strings.TrimSpace(raw)
+	for _, kw := range []string{"if", "unless", "case", "begin"} {
+		if strings.HasPrefix(trimmed, kw+" ") || trimmed == kw {
+			return false
+		}
+	}
+	return true
+}
+
+// rubyBlockSpanEnd returns the exclusive line index of the matching `end` for
+// the Ruby block whose header is lines[headerIdx], tracking keyword-open /
+// `end`-close depth. Inline modifier guards do not open a block.
+func rubyBlockSpanEnd(lines []string, headerIdx int) int {
+	depth := 0
+	for j := headerIdx; j < len(lines); j++ {
+		if strings.TrimSpace(lines[j]) == "" {
+			continue
+		}
+		if j == headerIdx {
+			depth++
+		} else if rubyElsifRe.MatchString(lines[j]) {
+			// continuation clause — no depth change
+		} else if (rubyCondBlockRe.MatchString(lines[j]) && !isRubyModifierLine(lines[j])) ||
+			rubyLoopBlockRe.MatchString(lines[j]) ||
+			rubyDefBlockRe.MatchString(lines[j]) ||
+			rubyDoBlockRe.MatchString(lines[j]) {
+			depth++
+		}
+		if rubyEndRe.MatchString(lines[j]) {
+			depth--
+			if depth <= 0 {
+				return j + 1
+			}
+		}
+	}
+	return len(lines)
+}
+
+var (
+	// Paren-form headers — the C/Java family always parenthesises conditions.
+	braceIfRe      = regexp.MustCompile(`^\s*(?:\}\s*else\s+)?if\s*\(`)
+	braceElseRe    = regexp.MustCompile(`^\s*\}?\s*else\b`)
+	braceElseIfRe  = regexp.MustCompile(`^\s*\}?\s*else\s*if\b`)
+	braceCatchRe   = regexp.MustCompile(`^\s*\}?\s*catch\b`)
+	braceTryRe     = regexp.MustCompile(`^\s*try\b`)
+	braceSwitchRe  = regexp.MustCompile(`^\s*switch\s*\(`)
+	braceForRe     = regexp.MustCompile(`^\s*for\s*[(\s]`)
+	braceWhileRe   = regexp.MustCompile(`^\s*}?\s*while\s*\(`)
+	braceForEachRe = regexp.MustCompile(`\.\s*for[Ee]ach\s*\(`)
+	// foreachStmtRe — the statement-form `foreach (…)` loop header used by C#
+	// and PHP (distinct from the `.forEach(` method-call form above).
+	foreachStmtRe = regexp.MustCompile(`^\s*foreach\s*\(`)
+
+	// PHP-specific keyword forms (`elseif`, `foreach`).
+	phpElseIfRe  = regexp.MustCompile(`^\s*\}?\s*else\s*if\b`)
+	phpForEachRe = regexp.MustCompile(`^\s*foreach\s*\(`)
+
+	// No-paren / keyword-condition forms used by Go, Rust, Kotlin, Scala and
+	// Swift, where a header reads `if cond {`, `for x := range … {`, `for {`,
+	// `match x {`, `when {`, `loop {`, `guard … else {`. The trailing `{`
+	// anchors them so a plain `if (…)` paren form is still preferred.
+	noParenIfRe     = regexp.MustCompile(`^\s*(?:\}\s*)?if\b`)
+	noParenElseIfRe = regexp.MustCompile(`^\s*\}?\s*else\s+if\b`)
+	noParenForRe    = regexp.MustCompile(`^\s*for\b`)
+	noParenWhileRe  = regexp.MustCompile(`^\s*\}?\s*while\b`)
+	goSwitchRe      = regexp.MustCompile(`^\s*(?:\w+\s*:?=\s*)?switch\b`)
+	goSelectRe      = regexp.MustCompile(`^\s*select\s*\{`)
+	rustMatchRe     = regexp.MustCompile(`^\s*(?:\w+\s*=\s*)?match\b`)
+	rustLoopRe      = regexp.MustCompile(`^\s*(?:'\w+:\s*)?loop\b`)
+	kotlinWhenRe    = regexp.MustCompile(`^\s*(?:\w+\s*=\s*)?when\b`)
+	scalaMatchRe    = regexp.MustCompile(`\bmatch\s*\{`) // scala infix `expr match {`
+	swiftGuardRe    = regexp.MustCompile(`^\s*guard\b`)
+	swiftSwitchRe   = regexp.MustCompile(`^\s*switch\b`) // swift no-paren `switch x {`
+)
+
+// braceDialect captures the per-language header forms that differ from the
+// C/Java baseline (no-paren conditions, keyword loops/matches, etc.).
+type braceDialect struct {
+	noParen bool // accept `if cond {`, `for cond {`, `while cond {` (Go/Rust/Kotlin/Scala/Swift)
+	php     bool // accept `foreach`, `elseif`
+	goExtra bool // accept `switch`/`select` (Go)
+	rust    bool // accept `match`, `loop`
+	kotlin  bool // accept `when`
+	scala   bool // accept `match`
+	swift   bool // accept `guard`, `switch` (no-paren)
+}
+
+func braceDialectFor(lang string) braceDialect {
+	switch lang {
+	case "go":
+		return braceDialect{noParen: true, goExtra: true}
+	case "rust":
+		return braceDialect{noParen: true, rust: true}
+	case "kotlin":
+		return braceDialect{noParen: true, kotlin: true}
+	case "scala":
+		return braceDialect{noParen: true, scala: true}
+	case "swift":
+		return braceDialect{noParen: true, swift: true}
+	case "php":
+		return braceDialect{php: true}
+	default: // jsts, java, csharp — C/Java baseline (paren conditions)
+		return braceDialect{}
+	}
+}
 
 // braceBlocks scopes brace-delimited conditional/loop blocks. For each header
 // line it finds the `{` that opens the block (K&R same-line or Allman next
-// line) and tracks depth to the matching `}`, recording the absolute span.
-func braceBlocks(src string, startLine int) []blockHeader {
+// line) and tracks depth to the matching `}`, recording the absolute span. The
+// dialect for `lang` decides which header forms are recognised (no-paren
+// conditions for Go/Rust/Kotlin/Scala/Swift, `foreach`/`elseif` for PHP, etc.).
+func braceBlocks(src, lang string, startLine int) []blockHeader {
+	dia := braceDialectFor(lang)
 	lines := strings.Split(src, "\n")
 	var out []blockHeader
 	for i, raw := range lines {
 		if strings.TrimSpace(raw) == "" {
 			continue
 		}
-		cond, isLoop, matched := classifyBraceHeader(raw)
+		cond, isLoop, matched := classifyBraceHeader(raw, dia)
 		if !matched {
 			continue
 		}
@@ -253,10 +429,22 @@ func braceBlocks(src string, startLine int) []blockHeader {
 }
 
 // classifyBraceHeader reports whether a line opens a conditional/loop block and
-// returns its condition text + loop flag.
-func classifyBraceHeader(raw string) (cond string, isLoop bool, matched bool) {
+// returns its condition text + loop flag, applying the language dialect.
+func classifyBraceHeader(raw string, dia braceDialect) (cond string, isLoop bool, matched bool) {
 	scan := stripBraceNoise(raw)
+	// --- PHP keyword forms first (foreach/elseif) ------------------------
+	if dia.php {
+		switch {
+		case phpForEachRe.MatchString(scan):
+			return trimBraceCond(scan), true, true
+		case phpElseIfRe.MatchString(scan):
+			return trimBraceCond(scan), false, true
+		}
+	}
+	// --- paren baseline (C/Java/jsts/csharp/php) -------------------------
 	switch {
+	case foreachStmtRe.MatchString(scan): // C# / PHP `foreach (…)`
+		return trimBraceCond(scan), true, true
 	case braceForRe.MatchString(scan):
 		return trimBraceCond(scan), true, true
 	case braceWhileRe.MatchString(scan):
@@ -271,10 +459,56 @@ func classifyBraceHeader(raw string) (cond string, isLoop bool, matched bool) {
 		return trimBraceCond(scan), false, true
 	case braceTryRe.MatchString(scan):
 		return "try", false, true
+	}
+	// --- no-paren / keyword dialects (Go/Rust/Kotlin/Scala/Swift) --------
+	if dia.swift && (swiftGuardRe.MatchString(scan) || swiftSwitchRe.MatchString(scan)) {
+		return trimNoParenCond(scan), false, true
+	}
+	if dia.goExtra && (goSwitchRe.MatchString(scan) || goSelectRe.MatchString(scan)) {
+		return trimNoParenCond(scan), false, true
+	}
+	if dia.rust && (rustMatchRe.MatchString(scan) || rustLoopRe.MatchString(scan)) {
+		isLoop := rustLoopRe.MatchString(scan)
+		return trimNoParenCond(scan), isLoop, true
+	}
+	if dia.kotlin && kotlinWhenRe.MatchString(scan) {
+		return trimNoParenCond(scan), false, true
+	}
+	if dia.scala && scalaMatchRe.MatchString(scan) { // scala infix `x match {`
+		return trimNoParenCond(scan), false, true
+	}
+	if dia.noParen {
+		switch {
+		case noParenForRe.MatchString(scan): // `for x := range … {`, `for x in … {`, `for {`
+			return trimNoParenCond(scan), true, true
+		case noParenWhileRe.MatchString(scan):
+			return trimNoParenCond(scan), true, true
+		case noParenElseIfRe.MatchString(scan):
+			return trimNoParenCond(scan), false, true
+		case noParenIfRe.MatchString(scan): // `if cond {`, `if let … {`
+			return trimNoParenCond(scan), false, true
+		}
+	}
+	// --- else / fallthrough (all brace dialects) -------------------------
+	switch {
+	case braceElseIfRe.MatchString(scan):
+		return trimBraceCond(scan), false, true
 	case braceElseRe.MatchString(scan):
 		return "else", false, true
 	}
 	return "", false, false
+}
+
+// trimNoParenCond returns the header text up to (excluding) the opening `{` for
+// a no-paren / keyword-condition header (`if force {`, `for row in rows {`,
+// `match x {`, `when {`, `guard … else {`). It keeps the keyword + predicate so
+// the surfaced condition reads naturally.
+func trimNoParenCond(scan string) string {
+	s := strings.TrimSpace(stripLeadingCloser(scan))
+	if idx := strings.Index(s, "{"); idx >= 0 {
+		s = s[:idx]
+	}
+	return strings.TrimSpace(s)
 }
 
 // trimBraceCond returns the header text up to and including its closing `)` (or
@@ -342,7 +576,8 @@ var decisionPointRe = []*regexp.Regexp{
 	regexp.MustCompile(`\bexcept\b`),
 	regexp.MustCompile(`\brescue\b`),
 	regexp.MustCompile(`\.\s*for[Ee]ach\s*\(`),
-	regexp.MustCompile(`\?[^.:?]`), // ternary `?` (not `?.` optional chain, not `??`)
+	regexp.MustCompile(`\bdo\s*\|[^|]*\|`), // ruby/crystal iterator block `each do |x|`
+	regexp.MustCompile(`\?[^.:?]`),         // ternary `?` (not `?.` optional chain, not `??`)
 	regexp.MustCompile(`&&`),
 	regexp.MustCompile(`\|\|`),
 }

--- a/internal/substrate/effect_context_test.go
+++ b/internal/substrate/effect_context_test.go
@@ -106,6 +106,88 @@ func TestEffectContextsJSTS(t *testing.T) {
 	}
 }
 
+// assertEffectCtxCondLoop is the shared effect-context contract for the
+// multi-language generalization (#4830): the source has a top-level db_read, a
+// db_write guarded by a conditional, and an http_out inside a loop. It proves
+// conditional/loop attribution works for the newly-validated families.
+func assertEffectCtxCondLoop(t *testing.T, lang, src string) {
+	t.Helper()
+	ctxs, cx := EffectContextsFor(lang, src, 100)
+	if cx.Cyclomatic < 3 {
+		t.Errorf("%s: cyclomatic = %d; want >= 3", lang, cx.Cyclomatic)
+	}
+	var sawCondWrite, sawLoopHTTP, sawUncondRead bool
+	for _, c := range ctxs {
+		switch c.Effect {
+		case "db_read":
+			if !c.Conditional {
+				sawUncondRead = true
+			}
+		case "db_write":
+			if c.Conditional && c.Condition != "" {
+				sawCondWrite = true
+			}
+		case "http_out":
+			if c.InLoop {
+				sawLoopHTTP = true
+			}
+		}
+	}
+	if !sawUncondRead {
+		t.Errorf("%s: expected an unconditional (top-level) db_read; got %+v", lang, ctxs)
+	}
+	if !sawCondWrite {
+		t.Errorf("%s: expected a conditional db_write carrying a condition; got %+v", lang, ctxs)
+	}
+	if !sawLoopHTTP {
+		t.Errorf("%s: expected an http_out inside a loop (fan-out); got %+v", lang, ctxs)
+	}
+}
+
+// TestEffectContextsGo — Go no-paren `if force {` + `for rows.Next() {`.
+func TestEffectContextsGo(t *testing.T) {
+	assertEffectCtxCondLoop(t, "go", `func Sync(ctx context.Context, force bool) error {
+	rows, _ := db.Query(ctx, "SELECT * FROM contacts")
+	if force {
+		db.Exec(ctx, "INSERT INTO log VALUES (1)")
+	}
+	for rows.Next() {
+		http.Post("https://api.example.com/notify", "application/json", nil)
+	}
+	return nil
+}
+`)
+}
+
+// TestEffectContextsRuby — Ruby `end`-delimited `if … end` + `.each do … end`.
+func TestEffectContextsRuby(t *testing.T) {
+	assertEffectCtxCondLoop(t, "ruby", `def sync(force)
+  rows = Contact.where(active: true)
+  if force
+    Contact.create(name: "x")
+  end
+  rows.each do |row|
+    Net::HTTP.post(URI("https://api.example.com/notify"), "")
+  end
+  nil
+end
+`)
+}
+
+// TestEffectContextsSwift — Swift no-paren `if force {` + `for row in rows {`.
+func TestEffectContextsSwift(t *testing.T) {
+	assertEffectCtxCondLoop(t, "swift", `func sync(force: Bool) {
+    let rows = try! context.fetch(request)
+    if force {
+        context.insert(Log())
+    }
+    for row in rows {
+        URLSession.shared.dataTask(with: url).resume()
+    }
+}
+`)
+}
+
 // TestComputeFunctionComplexity covers the bare counter: a branchless function
 // is complexity 1; decision points each add one.
 func TestComputeFunctionComplexity(t *testing.T) {


### PR DESCRIPTION
Generalizes the control-flow extraction (effect-context classification + on-demand CFG) from the part-(a)/(b) validated set (Python + JS/TS) to the remaining languages, per the standing generalize-everything rule. **Deploy-deferred** — no daemon/MCP touched.

## Languages flipped runs -> validated

| Language | Family | Before | After | Per-language quirks handled |
|---|---|---|---|---|
| Go | brace (no-paren) | ran, jsts-only | ✅ validated | no-paren `if cond {`; `switch x {` / `select {` decisions; `for {` |
| Rust | brace (no-paren) | ran, jsts-only | ✅ validated | no-paren `if`; `match x {`; `loop {` |
| Kotlin | brace (no-paren) | ran, jsts-only | ✅ validated | `when (x) {`; no-paren `if`/`for` |
| Scala | brace (no-paren) | ran, jsts-only | ✅ validated | infix `x match {`; paren if/for |
| C# | brace (paren) | ran, jsts-only | ✅ validated | statement-form `foreach (…)` (was only the `.forEach(` method form) |
| PHP | brace (paren) | ran, jsts-only | ✅ validated | `elseif` as its own conditioned decision; `foreach` loop (both previously eaten/dropped) |
| Java | brace (paren) | jsts-validated | ✅ validated (regression-pinned) | baseline already correct; fixture added |
| Swift | brace | **supported=false** | ✅ validated | block detector wired; no-paren `if`/`for`/`switch`; `guard … else` |
| Ruby | `end`-delimited | **supported=false** | ✅ validated | `end`-block detector wired; `if/unless/case/while/until/for … end` + `.each do |x| … end` iterator (loop / fan-out); ruby do-block counted toward cyclomatic |

## Implementation
- `enclosingBlocks` now dispatches `python | ruby | brace(lang-dialect)`.
- `braceBlocks` / `classifyBraceHeader` are language-aware via `braceDialectFor` (no-paren conditions, keyword loops/matches, PHP `foreach`/`elseif`, Go `switch`/`select`, Rust `match`/`loop`, Kotlin `when`, Scala infix `match`, Swift `guard`/`switch`).
- New `rubyBlocks` (`end`-keyword-depth walker, iterator `do…end` = loop).
- `hasBlockDetector` + `ControlFlowGraph.Supported` flip Ruby/Swift on; `braceCFGLangs` adds Swift (brace-classified but outside the ClampToFunctionBody set).

## Still supported=false (honest-partial, documented + regression-pinned)
`cobol, elixir, crystal, lua, dart, solidity, zig, nim, clojure` — no validated block detector yet; pinned by `TestCFGUnsupportedLanguagesDocumented` so a silent flip is caught. They still return a valid degenerate start→end CFG.

## Registry decision (consistent with part a/b)
Control-flow extraction is a **cross-cutting MCP facet** (the `effect_contexts` facet on `archigraph_effects` + the `archigraph_control_flow` tool), NOT a per-language registry capability cell. Neither #4821 (part a) nor #4822 (part b) touched `registry.json` / coverage docs — this PR is consistent and makes no registry/coverage-doc changes, so `coverage fmt --check` / `coverage validate` are N/A.

## Fixtures added
Per newly-validated language: an if/else + loop + effect function asserting a decision node + condition text + `loop_back` edge + terminal exit + non-trivial cyclomatic complexity (`cfg_multilang_test.go`), plus language-quirk tests (Go switch/select, Rust match/loop, Kotlin when, Scala match, Swift guard/switch) and effect-context conditional/loop attribution fixtures for Go/Ruby/Swift (`effect_context_test.go`).

## Gates
`go build ./...`, `go vet ./internal/...`, `go test ./internal/{substrate,mcp,types}` — all pass. gofmt-clean.

Deploy-deferred. Closes #4830. Part of #4820.