### PR TITLE
fix(#4843): consume ELK orthogonal edge routing across diagrams (H/V lines, no more bezier spaghetti)

### DIFF
--- a/webui-v2/src/components/_shared/useElkLayout.ts
+++ b/webui-v2/src/components/_shared/useElkLayout.ts
@@ -19,6 +19,7 @@ import {
   type ElkLayoutEdge,
   type ElkLayoutOptions,
   type ElkLayoutPosition,
+  type ElkLayoutEdgeRoute,
 } from "@/lib/elk-layout";
 
 export interface UseElkLayoutInput<N, E> {
@@ -46,15 +47,19 @@ export interface UseElkLayoutResult<N, E> {
 /**
  * useElkLayout runs ELK asynchronously and returns positioned nodes.
  *
- * @param build  produces the render nodes/edges + ELK layout inputs. Recomputed
- *               when `deps` change.
- * @param apply  maps an ELK position onto a render node (set position + size).
- * @param deps   dependency list that retriggers the build + layout.
+ * @param build      produces the render nodes/edges + ELK layout inputs.
+ *                   Recomputed when `deps` change.
+ * @param apply      maps an ELK position onto a render node (set position + size).
+ * @param deps       dependency list that retriggers the build + layout.
+ * @param applyEdge  optional: maps an ELK orthogonal route (bendPoints, absolute
+ *                   flow coords) onto a render edge, so its component can follow
+ *                   ELK's route instead of a bezier (#4843). Edges keyed by id.
  */
-export function useElkLayout<N extends { id: string }, E>(
+export function useElkLayout<N extends { id: string }, E extends { id: string }>(
   build: () => UseElkLayoutInput<N, E>,
   apply: (node: N, pos: ElkLayoutPosition | undefined) => N,
   deps: DependencyList,
+  applyEdge?: (edge: E, route: ElkLayoutEdgeRoute | undefined) => E,
 ): UseElkLayoutResult<N, E> {
   const [state, setState] = useState<{ nodes: N[]; edges: E[]; laidOut: boolean }>({
     nodes: [],
@@ -74,10 +79,13 @@ export function useElkLayout<N extends { id: string }, E>(
 
     let cancelled = false;
     layoutWithElk(elkNodes, elkEdges, options)
-      .then((positions) => {
+      .then(({ nodes: positions, edges: routes }) => {
         if (cancelled || myRun !== runId.current) return;
         const placed = nodes.map((n) => apply(n, positions.get(n.id)));
-        setState({ nodes: placed, edges, laidOut: true });
+        const routed = applyEdge
+          ? edges.map((e) => applyEdge(e, routes.get(e.id)))
+          : edges;
+        setState({ nodes: placed, edges: routed, laidOut: true });
       })
       .catch(() => {
         if (cancelled || myRun !== runId.current) return;

--- a/webui-v2/src/components/compound-topology/CTEdge.tsx
+++ b/webui-v2/src/components/compound-topology/CTEdge.tsx
@@ -5,9 +5,10 @@ import { memo } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
-  getBezierPath,
+  getSmoothStepPath,
   type EdgeProps,
 } from "@xyflow/react";
+import { orthogonalPath } from "@/lib/elk-layout";
 import type { CTEdgeData } from "./layout";
 import { edgeStroke } from "./tierStyle";
 
@@ -23,14 +24,23 @@ function CTEdgeImpl({
   markerEnd,
 }: EdgeProps) {
   const d = (data ?? { type: "depends", label: "depends", count: 1, summary: false }) as CTEdgeData;
-  const [path, labelX, labelY] = getBezierPath({
-    sourceX,
-    sourceY,
-    sourcePosition,
-    targetX,
-    targetY,
-    targetPosition,
-  });
+  // Follow ELK's orthogonal route when available (#4843); else smoothstep (H/V).
+  const elk = orthogonalPath(d.elkPoints ?? []);
+  let path: string;
+  let labelX: number;
+  let labelY: number;
+  if (elk) {
+    ({ path, labelX, labelY } = elk);
+  } else {
+    [path, labelX, labelY] = getSmoothStepPath({
+      sourceX,
+      sourceY,
+      sourcePosition,
+      targetX,
+      targetY,
+      targetPosition,
+    });
+  }
   const stroke = edgeStroke(d.type);
 
   return (

--- a/webui-v2/src/components/compound-topology/layout.ts
+++ b/webui-v2/src/components/compound-topology/layout.ts
@@ -42,6 +42,7 @@ import {
   layoutWithElk,
   type ElkLayoutNode,
   type ElkLayoutEdge,
+  type ElkPoint2D,
 } from "@/lib/elk-layout";
 
 export const CT_NODE_TYPE = "ctNode";
@@ -110,6 +111,12 @@ export interface CTEdgeData {
   count: number;
   /** True when this is a zone-level summary edge (a collapse aggregate). */
   summary: boolean;
+  /**
+   * ELK's orthogonal route (absolute flow coords). When present the edge draws
+   * an H/V polyline through these points instead of a bezier (#4843). Absent
+   * under the dagre fallback.
+   */
+  elkPoints?: ElkPoint2D[];
   [key: string]: unknown;
 }
 
@@ -312,6 +319,8 @@ function materialize(
   plan: CTPlan,
   abs: Map<string, { x: number; y: number; w: number; h: number }>,
   onToggle: (zoneId: string) => void,
+  /** Optional ELK routes keyed by folded-edge key "from to type" (abs coords). */
+  edgeRoutes?: Map<string, ElkPoint2D[]>,
 ): CTLayoutResult {
   const {
     visibleNodes,
@@ -455,6 +464,7 @@ function materialize(
       label: fe.count > 1 ? `${fe.type} ×${fe.count}` : fe.type,
       count: fe.count,
       summary: fe.summary,
+      elkPoints: edgeRoutes?.get(`${fe.from} ${fe.to} ${fe.type}`),
     };
     edges.push({
       id: `cte:${fe.from}->${fe.to}:${fe.type}:${i++}`,
@@ -519,16 +529,20 @@ export async function layoutCompoundTopologyElk(
     });
   }
 
-  // Folded edges between laid-out endpoints only.
+  // Folded edges between laid-out endpoints only. Track each elk edge id → its
+  // folded key so we can re-attach ELK's route to the right React Flow edge.
   const elkEdges: ElkLayoutEdge[] = [];
+  const elkEdgeKeyById = new Map<string, string>();
   let ei = 0;
   for (const fe of folded.values()) {
     if (plan.layoutable(fe.from) && plan.layoutable(fe.to)) {
-      elkEdges.push({ id: `elk-e:${ei++}`, source: fe.from, target: fe.to });
+      const id = `elk-e:${ei++}`;
+      elkEdges.push({ id, source: fe.from, target: fe.to });
+      elkEdgeKeyById.set(id, `${fe.from} ${fe.to} ${fe.type}`);
     }
   }
 
-  const positions = await layoutWithElk(elkNodes, elkEdges, {
+  const { nodes: positions, edges: routes } = await layoutWithElk(elkNodes, elkEdges, {
     direction: "RIGHT",
     edgeRouting: "ORTHOGONAL",
     nodeSpacing: 22,
@@ -585,7 +599,17 @@ export async function layoutCompoundTopologyElk(
     });
   }
 
-  return materialize(plan, absById, onToggle);
+  // Re-key ELK routes by folded-edge key for materialize. ELK already returns
+  // points in absolute flow coords (cross-zone edges live on the LCA container
+  // and lib/elk-layout adds the container's absolute offset), so they line up
+  // with the absolute node boxes materialize positions against.
+  const edgeRoutes = new Map<string, ElkPoint2D[]>();
+  for (const [elkId, key] of elkEdgeKeyById) {
+    const route = routes.get(elkId);
+    if (route && route.points.length >= 2) edgeRoutes.set(key, route.points);
+  }
+
+  return materialize(plan, absById, onToggle, edgeRoutes);
 }
 
 /* ============================================================

--- a/webui-v2/src/components/flow-dag/FlowDagEdge.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagEdge.tsx
@@ -11,9 +11,10 @@ import { memo, useEffect, useRef, useState } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
-  getBezierPath,
+  getSmoothStepPath,
   type EdgeProps,
 } from "@xyflow/react";
+import { orthogonalPath } from "@/lib/elk-layout";
 import { edgeStyle } from "./style";
 import type { FlowDagEdgeData } from "./layout";
 
@@ -38,16 +39,26 @@ function FlowDagEdgeImpl({
   const dimmed = ed?.onRoute === false || replay === "pending";
   const traversed = replay === "traversed" || replay === "active";
 
-  const [path, labelX, labelY] = getBezierPath({
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
-  });
+  // Follow ELK's orthogonal route when available (#4843); else smoothstep (H/V).
+  // Never a diagonal bezier — the comet rides whichever path we render.
+  const elk = orthogonalPath(ed?.elkPoints ?? []);
+  let path: string;
+  let labelX: number;
+  let labelY: number;
+  if (elk) {
+    ({ path, labelX, labelY } = elk);
+  } else {
+    [path, labelX, labelY] = getSmoothStepPath({
+      sourceX,
+      sourceY,
+      targetX,
+      targetY,
+      sourcePosition,
+      targetPosition,
+    });
+  }
 
-  // Comet position — sample the exact bezier path via getPointAtLength on a
+  // Comet position — sample the exact path via getPointAtLength on a
   // measured (off-screen) copy of the path. Only the ACTIVE edge re-renders per
   // frame, so this stays cheap (one DOM measure per frame, one edge at a time).
   const measureRef = useRef<SVGPathElement | null>(null);

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -33,6 +33,7 @@ import {
   type ElkDirection,
   type ElkLayoutEdge,
   type ElkLayoutNode,
+  type ElkPoint2D,
 } from "@/lib/elk-layout";
 import { nodeModule, type NodeModule } from "./style";
 
@@ -103,6 +104,12 @@ export interface FlowDagEdgeData extends Record<string, unknown> {
    * replay === "active". Drives the traveling-light marker (#4362).
    */
   replayProgress?: number;
+  /**
+   * ELK's orthogonal route (absolute flow coords). When present the edge draws
+   * an H/V polyline through these points instead of a bezier (#4843). Absent
+   * under the tidy-tree (dagre) fallback engine.
+   */
+  elkPoints?: ElkPoint2D[];
 }
 
 export type FlowDagNode = Node<FlowDagNodeData>;
@@ -606,7 +613,7 @@ export async function layoutTreeElk(
     target: e.target,
   }));
 
-  const positions = await layoutWithElk(elkNodes, elkEdges, {
+  const { nodes: positions, edges: routes } = await layoutWithElk(elkNodes, elkEdges, {
     direction: elkDirection(direction),
     algorithm: "layered",
     edgeRouting: "ORTHOGONAL",
@@ -620,6 +627,16 @@ export async function layoutTreeElk(
   for (const node of rfNodes) {
     const p = positions.get(node.id);
     if (p) node.position = { x: p.x, y: p.y };
+  }
+
+  // Attach ELK's orthogonal route to each edge (#4843). The flat tree puts every
+  // edge at the root, so ELK points are already absolute flow coords. The elk
+  // edge id == the React Flow edge id, so the lookup is direct.
+  for (const edge of rfEdges) {
+    const route = routes.get(edge.id);
+    if (route && route.points.length >= 2) {
+      edge.data = { ...(edge.data ?? { kind: "CALLS" }), elkPoints: route.points };
+    }
   }
 
   return { nodes: rfNodes, edges: rfEdges };

--- a/webui-v2/src/components/iac-diagram/IaCEdge.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCEdge.tsx
@@ -11,9 +11,10 @@ import { memo } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
-  getBezierPath,
+  getSmoothStepPath,
   type EdgeProps,
 } from "@xyflow/react";
+import { orthogonalPath } from "@/lib/elk-layout";
 import type { IaCEdgeData } from "./layout";
 
 interface FacetStyle {
@@ -71,14 +72,24 @@ function IaCEdgeImpl({
   const ed = data as IaCEdgeData | undefined;
   const fs = facetStyle(ed?.facet ?? "dependency");
 
-  const [path, labelX, labelY] = getBezierPath({
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
-  });
+  // Follow ELK's orthogonal route when available (#4843); else fall back to a
+  // smoothstep (H/V) path — never a diagonal bezier.
+  const elk = orthogonalPath(ed?.elkPoints ?? []);
+  let path: string;
+  let labelX: number;
+  let labelY: number;
+  if (elk) {
+    ({ path, labelX, labelY } = elk);
+  } else {
+    [path, labelX, labelY] = getSmoothStepPath({
+      sourceX,
+      sourceY,
+      targetX,
+      targetY,
+      sourcePosition,
+      targetPosition,
+    });
+  }
 
   return (
     <>

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -34,6 +34,7 @@ import {
   layoutWithElk,
   type ElkLayoutNode,
   type ElkLayoutEdge,
+  type ElkPoint2D,
 } from "@/lib/elk-layout";
 
 export type IaCDiagramDirection = "LR" | "TB";
@@ -109,6 +110,12 @@ export interface IaCEdgeData {
   facet: string;
   kind: string;
   detail?: string;
+  /**
+   * ELK's orthogonal route for this edge (absolute flow coords). When present
+   * the edge component draws an H/V polyline through these points instead of a
+   * bezier/smoothstep curve (#4843). Absent under the dagre fallback.
+   */
+  elkPoints?: ElkPoint2D[];
   [key: string]: unknown;
 }
 
@@ -272,6 +279,8 @@ function materialize(
   /** Optional engine-provided absolute group box; else derived from members. */
   groupAbs: Map<string, { x: number; y: number; w: number; h: number }> | undefined,
   direction: IaCDiagramDirection,
+  /** Optional ELK orthogonal routes per rawEdge index (absolute flow coords). */
+  edgeRoutes?: Map<number, ElkPoint2D[]>,
 ): IaCLayoutResult {
   const { resources, modules, unresolvedCountFor, rawEdges, capped, unresolvedEdges } = plan;
 
@@ -356,7 +365,12 @@ function materialize(
   }
 
   const edges: Edge[] = rawEdges.map((e, i) => {
-    const data: IaCEdgeData = { facet: e.facet, kind: e.kind, detail: e.detail };
+    const data: IaCEdgeData = {
+      facet: e.facet,
+      kind: e.kind,
+      detail: e.detail,
+      elkPoints: edgeRoutes?.get(i),
+    };
     return {
       id: `e:${e.from}->${e.to}:${e.kind}:${i}`,
       source: e.from,
@@ -426,7 +440,7 @@ export async function layoutIaCDiagramElk(
     target: e.to,
   }));
 
-  const positions = await layoutWithElk(elkNodes, elkEdges, {
+  const { nodes: positions, edges: routes } = await layoutWithElk(elkNodes, elkEdges, {
     direction: direction === "LR" ? "RIGHT" : "DOWN",
     edgeRouting: "ORTHOGONAL",
     nodeSpacing: direction === "LR" ? 26 : 40,
@@ -439,6 +453,15 @@ export async function layoutIaCDiagramElk(
     },
     defaultNodeWidth: NODE_W,
     defaultNodeHeight: NODE_H,
+  });
+
+  // ELK routes are keyed by the elk edge id ("elk-e:<i>"); re-key by rawEdge
+  // index so materialize can attach each route to its React Flow edge. ELK
+  // points are already in absolute flow coords (lib/elk-layout translates them).
+  const edgeRoutes = new Map<number, ElkPoint2D[]>();
+  rawEdges.forEach((_e, i) => {
+    const route = routes.get(`elk-e:${i}`);
+    if (route && route.points.length >= 2) edgeRoutes.set(i, route.points);
   });
 
   // ELK positions are parent-relative. Resources nest exactly one level under
@@ -470,7 +493,7 @@ export async function layoutIaCDiagramElk(
     }
   }
 
-  return materialize(plan, groupMode, resourceAbs, groupAbs, direction);
+  return materialize(plan, groupMode, resourceAbs, groupAbs, direction, edgeRoutes);
 }
 
 /* ============================================================

--- a/webui-v2/src/lib/elk-layout.test.ts
+++ b/webui-v2/src/lib/elk-layout.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "vitest";
 import {
   layoutWithElk,
+  orthogonalPath,
   type ElkLayoutNode,
   type ElkLayoutEdge,
 } from "./elk-layout";
@@ -23,7 +24,7 @@ describe("layoutWithElk", () => {
       { id: "e2", source: "b", target: "c" },
     ];
 
-    const pos = await layoutWithElk(nodes, edges, { direction: "RIGHT" });
+    const { nodes: pos } = await layoutWithElk(nodes, edges, { direction: "RIGHT" });
 
     for (const id of ["A", "a", "b", "c"]) {
       const p = pos.get(id);
@@ -50,7 +51,7 @@ describe("layoutWithElk", () => {
       { id: "n1", width: 100, height: 40, lane: 1 },
       { id: "n2", width: 100, height: 40, lane: 2 },
     ];
-    const pos = await layoutWithElk(nodes, [], { direction: "RIGHT" });
+    const { nodes: pos } = await layoutWithElk(nodes, [], { direction: "RIGHT" });
     const x0 = pos.get("n0")!.x;
     const x1 = pos.get("n1")!.x;
     const x2 = pos.get("n2")!.x;
@@ -58,8 +59,74 @@ describe("layoutWithElk", () => {
     expect(x1).toBeLessThanOrEqual(x2);
   });
 
-  it("returns an empty map for no nodes", async () => {
-    const pos = await layoutWithElk([], []);
-    expect(pos.size).toBe(0);
+  it("returns an empty result for no nodes", async () => {
+    const { nodes, edges } = await layoutWithElk([], []);
+    expect(nodes.size).toBe(0);
+    expect(edges.size).toBe(0);
+  });
+
+  it("returns ELK orthogonal edge routes (bendPoints) per edge (#4843)", async () => {
+    // A simple 2-node graph yields a route with ≥2 points (start + end).
+    const nodes: ElkLayoutNode[] = [
+      { id: "a", width: 120, height: 40, lane: 0 },
+      { id: "b", width: 120, height: 40, lane: 1 },
+    ];
+    const edges: ElkLayoutEdge[] = [{ id: "e1", source: "a", target: "b" }];
+
+    const { nodes: pos, edges: routes } = await layoutWithElk(nodes, edges, {
+      direction: "RIGHT",
+    });
+
+    const route = routes.get("e1");
+    expect(route, "route for e1").toBeDefined();
+    expect(route!.points.length).toBeGreaterThanOrEqual(2);
+    for (const pt of route!.points) {
+      expect(Number.isFinite(pt.x)).toBe(true);
+      expect(Number.isFinite(pt.y)).toBe(true);
+    }
+    // The route runs from near node a to near node b (RIGHT direction → x grows).
+    const a = pos.get("a")!;
+    const b = pos.get("b")!;
+    const start = route!.points[0];
+    const end = route!.points[route!.points.length - 1];
+    expect(start.x).toBeGreaterThanOrEqual(a.x - 1);
+    expect(end.x).toBeLessThanOrEqual(b.x + b.width + 1);
+    expect(end.x).toBeGreaterThan(start.x);
+  });
+
+  it("translates routes of a cross-container edge into absolute flow coords", async () => {
+    // group A contains a; standalone c. Edge a→c is a cross-container edge ELK
+    // stores at the root → its points must already be absolute.
+    const nodes: ElkLayoutNode[] = [
+      { id: "A", isContainer: true },
+      { id: "a", parentId: "A", width: 120, height: 40, lane: 0 },
+      { id: "c", width: 120, height: 40, lane: 1 },
+    ];
+    const edges: ElkLayoutEdge[] = [{ id: "e1", source: "a", target: "c" }];
+
+    const { edges: routes } = await layoutWithElk(nodes, edges, { direction: "RIGHT" });
+    const route = routes.get("e1");
+    expect(route).toBeDefined();
+    expect(route!.points.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("orthogonalPath", () => {
+  it("returns null for <2 points (caller falls back to smoothstep)", () => {
+    expect(orthogonalPath([])).toBeNull();
+    expect(orthogonalPath([{ x: 0, y: 0 }])).toBeNull();
+  });
+
+  it("builds a path with a mid-length label for a routed polyline", () => {
+    const res = orthogonalPath([
+      { x: 0, y: 0 },
+      { x: 50, y: 0 },
+      { x: 50, y: 40 },
+      { x: 100, y: 40 },
+    ]);
+    expect(res).not.toBeNull();
+    expect(res!.path.startsWith("M 0,0")).toBe(true);
+    expect(Number.isFinite(res!.labelX)).toBe(true);
+    expect(Number.isFinite(res!.labelY)).toBe(true);
   });
 });

--- a/webui-v2/src/lib/elk-layout.ts
+++ b/webui-v2/src/lib/elk-layout.ts
@@ -69,6 +69,39 @@ export interface ElkLayoutPosition {
   height: number;
 }
 
+/** A single 2D point in React-Flow ABSOLUTE flow coordinates. */
+export interface ElkPoint2D {
+  x: number;
+  y: number;
+}
+
+/**
+ * ELK's computed orthogonal route for one edge, as a polyline of ABSOLUTE flow
+ * coordinates: [startPoint, ...bendPoints, endPoint]. ELK stores edge section
+ * points RELATIVE to the container the edge is attached to (its endpoints' LCA);
+ * we translate them to absolute flow space by adding that container's absolute
+ * offset, so consumers can build the SVG path directly (no further offsetting).
+ *
+ * The edge component should draw a polyline through these points (right-angle
+ * H/V segments — ELK routes orthogonally) and fall back to getSmoothStepPath
+ * when no route is present for an edge.
+ */
+export interface ElkLayoutEdgeRoute {
+  id: string;
+  /** ≥2 points: start, optional bends, end — absolute flow coordinates. */
+  points: ElkPoint2D[];
+}
+
+/**
+ * Full ELK layout result: node positions/sizes AND per-edge orthogonal routes.
+ * `nodes` keeps the original parent-relative position contract; `edges` carries
+ * ELK's routed bendPoints translated to absolute flow coords (#4843).
+ */
+export interface ElkLayoutResult {
+  nodes: Map<string, ElkLayoutPosition>;
+  edges: Map<string, ElkLayoutEdgeRoute>;
+}
+
 export type ElkDirection = "RIGHT" | "LEFT" | "DOWN" | "UP";
 
 export interface ElkLayoutOptions {
@@ -116,6 +149,72 @@ const DEFAULTS: Required<
 
 const finite = (v: number | undefined, fallback = 0): number =>
   typeof v === "number" && Number.isFinite(v) ? v : fallback;
+
+/**
+ * orthogonalPath builds an SVG path string through an ELK-routed polyline,
+ * rounding each corner by up to `radius` px for polish (the segments stay
+ * orthogonal H/V; only the corners are filleted). Returns "" for <2 points so
+ * the caller can fall back to getSmoothStepPath. Also returns a sensible
+ * mid-point for label placement (the polyline's mid-length vertex).
+ *
+ * Consumers pass ELK's absolute-flow-coord points (ElkLayoutEdgeRoute.points)
+ * straight in — they're already in the diagram's coordinate space (#4843).
+ */
+export function orthogonalPath(
+  points: ElkPoint2D[],
+  radius = 8,
+): { path: string; labelX: number; labelY: number } | null {
+  if (!points || points.length < 2) return null;
+  // Drop consecutive duplicate points (ELK can emit zero-length segments).
+  const pts: ElkPoint2D[] = [];
+  for (const p of points) {
+    const last = pts[pts.length - 1];
+    if (!last || last.x !== p.x || last.y !== p.y) pts.push(p);
+  }
+  if (pts.length < 2) return null;
+
+  let d = `M ${pts[0].x},${pts[0].y}`;
+  for (let i = 1; i < pts.length - 1; i++) {
+    const prev = pts[i - 1];
+    const cur = pts[i];
+    const next = pts[i + 1];
+    // Approach/leave lengths, capped so radius never overshoots a short segment.
+    const inLen = Math.hypot(cur.x - prev.x, cur.y - prev.y);
+    const outLen = Math.hypot(next.x - cur.x, next.y - cur.y);
+    const r = Math.max(0, Math.min(radius, inLen / 2, outLen / 2));
+    if (r < 0.5) {
+      d += ` L ${cur.x},${cur.y}`;
+      continue;
+    }
+    const ix = cur.x - (cur.x - prev.x) * (r / (inLen || 1));
+    const iy = cur.y - (cur.y - prev.y) * (r / (inLen || 1));
+    const ox = cur.x + (next.x - cur.x) * (r / (outLen || 1));
+    const oy = cur.y + (next.y - cur.y) * (r / (outLen || 1));
+    d += ` L ${ix},${iy} Q ${cur.x},${cur.y} ${ox},${oy}`;
+  }
+  const end = pts[pts.length - 1];
+  d += ` L ${end.x},${end.y}`;
+
+  // Label at the polyline's mid-length point.
+  let total = 0;
+  for (let i = 1; i < pts.length; i++) {
+    total += Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y);
+  }
+  let acc = 0;
+  let labelX = pts[0].x;
+  let labelY = pts[0].y;
+  for (let i = 1; i < pts.length; i++) {
+    const seg = Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y);
+    if (acc + seg >= total / 2) {
+      const t = seg === 0 ? 0 : (total / 2 - acc) / seg;
+      labelX = pts[i - 1].x + (pts[i].x - pts[i - 1].x) * t;
+      labelY = pts[i - 1].y + (pts[i].y - pts[i - 1].y) * t;
+      break;
+    }
+    acc += seg;
+  }
+  return { path: d, labelX, labelY };
+}
 
 /**
  * buildElkTree turns the flat React-Flow node list (with `parentId` links) into
@@ -219,6 +318,11 @@ function graphLayoutOptions(o: typeof DEFAULTS, extra?: LayoutOptions): LayoutOp
     "elk.edgeRouting": o.edgeRouting,
     "elk.layered.spacing.nodeNodeBetweenLayers": String(o.layerSpacing),
     "elk.spacing.nodeNode": String(o.nodeSpacing),
+    // Keep clean lanes: edges leave/enter on consistent sides and reserve
+    // gutter so orthogonal segments route in channels rather than overlapping
+    // nodes (#4843). Ports are fixed to the layout direction sides.
+    "elk.layered.spacing.edgeNodeBetweenLayers": String(Math.round(o.nodeSpacing * 0.6)),
+    "elk.spacing.edgeNode": String(Math.round(o.nodeSpacing * 0.6)),
     "elk.padding": `[top=${o.padding.top},left=${o.padding.left},bottom=${o.padding.bottom},right=${o.padding.right}]`,
     "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
     ...extra,
@@ -226,24 +330,53 @@ function graphLayoutOptions(o: typeof DEFAULTS, extra?: LayoutOptions): LayoutOp
 }
 
 /**
- * collectPositions flattens ELK's laid-out tree back into per-node positions.
- * ELK positions children relative to their parent already — which is exactly the
- * React-Flow `parentId` convention — so we return x/y as-is.
+ * collectLayout flattens ELK's laid-out tree back into per-node positions AND
+ * per-edge orthogonal routes.
+ *
+ * - Node positions: ELK positions children relative to their parent already —
+ *   exactly the React-Flow `parentId` convention — so x/y are returned as-is.
+ * - Edge routes: ELK stores each edge under its endpoints' lowest-common-ancestor
+ *   container, with section points RELATIVE to that container's content box.
+ *   We walk the tree carrying each container's ABSOLUTE offset (sum of its and
+ *   its ancestors' relative positions) and translate every edge point into
+ *   absolute flow space, so consumers can draw the polyline directly.
  */
-function collectPositions(root: ElkNode, out: Map<string, ElkLayoutPosition>): void {
-  const visit = (node: ElkNode) => {
+function collectLayout(
+  root: ElkNode,
+  outNodes: Map<string, ElkLayoutPosition>,
+  outEdges: Map<string, ElkLayoutEdgeRoute>,
+): void {
+  // Visit carries the ABSOLUTE offset of `node`'s content origin. The root's
+  // own x/y are layout origin (0,0); children are relative to that origin.
+  const visit = (node: ElkNode, absX: number, absY: number) => {
+    // Edges declared on THIS container route in this container's coordinate
+    // space → translate each point by the container's absolute offset.
+    for (const edge of node.edges ?? []) {
+      const points: ElkPoint2D[] = [];
+      for (const sec of edge.sections ?? []) {
+        points.push({ x: absX + finite(sec.startPoint.x), y: absY + finite(sec.startPoint.y) });
+        for (const bp of sec.bendPoints ?? []) {
+          points.push({ x: absX + finite(bp.x), y: absY + finite(bp.y) });
+        }
+        points.push({ x: absX + finite(sec.endPoint.x), y: absY + finite(sec.endPoint.y) });
+      }
+      if (edge.id && points.length >= 2) {
+        outEdges.set(edge.id, { id: edge.id, points });
+      }
+    }
     for (const child of node.children ?? []) {
-      out.set(child.id, {
+      outNodes.set(child.id, {
         id: child.id,
         x: finite(child.x),
         y: finite(child.y),
         width: finite(child.width, 0),
         height: finite(child.height, 0),
       });
-      visit(child);
+      // A child container's content origin is its own absolute top-left.
+      visit(child, absX + finite(child.x), absY + finite(child.y));
     }
   };
-  visit(root);
+  visit(root, 0, 0);
 }
 
 /**
@@ -254,20 +387,25 @@ function collectPositions(root: ElkNode, out: Map<string, ElkLayoutPosition>): v
  *
  * Async: ELK layout is Promise-based. Call from an effect and store the result.
  *
+ * Returns BOTH node positions (`.nodes`) and ELK's orthogonal edge routes
+ * (`.edges`, bendPoints in absolute flow coords) — see ElkLayoutResult (#4843).
+ *
  * @example
- *   const pos = await layoutWithElk(nodes, edges, {
+ *   const { nodes: pos, edges: routes } = await layoutWithElk(nodes, edges, {
  *     direction: "RIGHT",
  *     laneOf: (id) => tierRankById.get(id),
  *   });
  *   const placed = nodes.map(n => ({ ...n, position: { x: pos.get(n.id)!.x, y: pos.get(n.id)!.y } }));
+ *   const route = routes.get(edgeId)?.points; // [{x,y}, …] orthogonal polyline
  */
 export async function layoutWithElk(
   nodes: ElkLayoutNode[],
   edges: ElkLayoutEdge[],
   options: ElkLayoutOptions = {},
-): Promise<Map<string, ElkLayoutPosition>> {
-  const out = new Map<string, ElkLayoutPosition>();
-  if (nodes.length === 0) return out;
+): Promise<ElkLayoutResult> {
+  const outNodes = new Map<string, ElkLayoutPosition>();
+  const outEdges = new Map<string, ElkLayoutEdgeRoute>();
+  if (nodes.length === 0) return { nodes: outNodes, edges: outEdges };
 
   const o = {
     ...DEFAULTS,
@@ -283,6 +421,6 @@ export async function layoutWithElk(
   root.layoutOptions = graphLayoutOptions(o, options.extraLayoutOptions);
 
   const laid = await elk.layout(root);
-  collectPositions(laid, out);
-  return out;
+  collectLayout(laid, outNodes, outEdges);
+  return { nodes: outNodes, edges: outEdges };
 }


### PR DESCRIPTION
## What changed

ELK diagrams set `elk.edgeRouting: ORTHOGONAL` but threw away ELK's computed route and drew `getBezierPath` curves — diagonal spaghetti. This consumes the routing.

**`lib/elk-layout.ts`**
- New return shape: `layoutWithElk` now resolves to `{ nodes: Map<id, ElkLayoutPosition>, edges: Map<edgeId, { id, points: {x,y}[] }> }` (`ElkLayoutResult`).
- Captures each edge's `sections[].startPoint / bendPoints / endPoint` and translates them to **absolute React-Flow flow coords**: ELK stores edge points relative to the container the edge is attached to (the endpoints' LCA), so `collectLayout` walks the tree carrying each container's absolute offset and adds it to every point — exactly mirroring how node positions nest.
- Added `orthogonalPath(points, radius)`: builds an SVG polyline through the bendPoints with slightly rounded corners + a mid-length label point. Returns `null` for <2 points so callers fall back.
- Kept `elk.edgeRouting: ORTHOGONAL`; added `elk.spacing.edgeNode` / `elk.layered.spacing.edgeNodeBetweenLayers` gutters so edges route in clean lanes.

**All 3 consumers updated to the new shape and thread routes onto `edge.data.elkPoints`:**
- `iac-diagram/layout.ts` (`IaCEdgeData.elkPoints`)
- `compound-topology/layout.ts` (`CTEdgeData.elkPoints`, re-keyed by folded-edge key)
- `flow-dag/layout.ts` (`FlowDagEdgeData.elkPoints`, elk edge id == RF edge id)
- `_shared/useElkLayout.ts` hook gains an optional `applyEdge` mapper and the new destructured shape.

**Edge components — follow ELK route, smoothstep fallback (no `getBezierPath`):**
- `IaCEdge.tsx`, `CTEdge.tsx`, `FlowDagEdge.tsx` now draw `orthogonalPath(elkPoints)` when present, else `getSmoothStepPath` (H/V). Markers, labels, hover/selection, edge colors, and the flow-dag replay comet (rides the rendered path) all preserved.

## Coord-translation gotcha
ELK edge `sections` are **container-relative**, not absolute. A cross-container/cross-zone edge lives on the LCA container, so its raw points are offset by that container's position. `collectLayout` adds the container's accumulated absolute offset to every point; flat graphs (flow-dag) and root-level edges get a zero offset and pass through unchanged.

## Gates
- `npx tsc --noEmit` clean
- `npm run build` clean
- `npx vitest run` — 111 unit tests pass; only the ~12 `e2e/*.spec.ts` Playwright files fail (pre-existing, can't run under vitest). Updated layout tests for the new shape + added tests asserting a 2-node graph returns a route with ≥2 finite points and `orthogonalPath` behavior.
- Frontend-only; no registry/coverage changes.

Deploy-deferred. Closes #4843.