### PR TITLE
fix(#4844): graph view spreads on first load (reload truly === Reset, ignore collapsed cache)

### DIFF
--- a/webui-v2/src/lib/graph-layout-cache.test.ts
+++ b/webui-v2/src/lib/graph-layout-cache.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { isDegenerateLayout, isLayoutHealthy } from "./graph-layout-cache";
+
+/**
+ * Build a Float32Array of [x0,y0,x1,y1,...] for `n` nodes spread uniformly on a
+ * square grid of side `span` (so the bbox is exactly span×span). Used to model a
+ * settled layout at a chosen density.
+ */
+function gridLayout(n: number, spanX: number, spanY = spanX): Float32Array {
+  const out = new Float32Array(n * 2);
+  const cols = Math.max(1, Math.ceil(Math.sqrt(n)));
+  const rows = Math.max(1, Math.ceil(n / cols));
+  const stepX = cols > 1 ? spanX / (cols - 1) : 0;
+  const stepY = rows > 1 ? spanY / (rows - 1) : 0;
+  for (let i = 0; i < n; i++) {
+    const c = i % cols;
+    const r = Math.floor(i / cols);
+    out[i * 2] = c * stepX;
+    out[i * 2 + 1] = r * stepY;
+  }
+  return out;
+}
+
+describe("isDegenerateLayout", () => {
+  it("does not flag tiny graphs (<2 nodes)", () => {
+    expect(isDegenerateLayout(new Float32Array([0, 0]))).toBe(false);
+    expect(isDegenerateLayout(new Float32Array([]))).toBe(false);
+  });
+
+  it("flags a fully collapsed layout (all nodes near one point)", () => {
+    const n = 1000;
+    const out = new Float32Array(n * 2);
+    for (let i = 0; i < n; i++) {
+      out[i * 2] = Math.random() * 5; // 5-unit span — far below the floor
+      out[i * 2 + 1] = Math.random() * 5;
+    }
+    expect(isDegenerateLayout(out)).toBe(true);
+  });
+
+  it("flags any non-finite coordinate as degenerate", () => {
+    const bad = gridLayout(100, 1000);
+    bad[10] = NaN;
+    expect(isDegenerateLayout(bad)).toBe(true);
+    const inf = gridLayout(100, 1000);
+    inf[11] = Infinity;
+    expect(isDegenerateLayout(inf)).toBe(true);
+  });
+
+  it("accepts a healthy, well-spread large layout", () => {
+    // 14k nodes spread across a wide canvas: area/node ≈ (12000²)/14233 ≈ 10117 — a
+    // genuinely spread settle is never rejected.
+    const layout = gridLayout(14233, 12000);
+    expect(isDegenerateLayout(layout)).toBe(false);
+    expect(isLayoutHealthy(layout, 14233 * 2)).toBe(true);
+  });
+
+  // Fix #4844 — the regression this fix targets: a DENSE HAIRBALL on a large graph
+  // whose WIDEST-axis span clears the span floor (sqrt(n)×6 ≈ 716 for 14233 nodes)
+  // but packs all the nodes into a small box. The old span-only check accepted it,
+  // so reload PINNED the collapsed cache while Reset spread it. The area-per-node
+  // gate now flags it as degenerate so the caller re-settles (reload === Reset).
+  it("flags a dense hairball whose span clears the span floor (#4844)", () => {
+    const n = 14233;
+    // Model an elongated hairball: widest axis (spanX) clears the span floor
+    // (sqrt(n)×6 ≈ 716) so the OLD span-only check accepted it, but the bbox AREA
+    // (spanX×spanY) is below the density floor (n×25 ≈ 355,825), so the new
+    // area-per-node gate flags it. spanX=1000 (>716) × spanY=300 → area 300,000.
+    const spanX = 1000;
+    const spanY = 300;
+    const hairball = gridLayout(n, spanX, spanY);
+    // sanity: widest-axis span must clear the span floor so we're exercising the
+    // NEW density gate, not the old span gate.
+    expect(Math.max(spanX, spanY)).toBeGreaterThan(Math.sqrt(n) * 6);
+    expect(spanX * spanY).toBeLessThan(n * 25);
+    expect(isDegenerateLayout(hairball)).toBe(true);
+    expect(isLayoutHealthy(hairball, n * 2)).toBe(false);
+  });
+
+  it("does not engage the density gate below the 500-node guard", () => {
+    // A small graph with a modest-but-valid span is governed by the span floor only;
+    // the density gate must not fire and wrongly reject it.
+    const n = 400;
+    const span = Math.sqrt(n) * 8; // clears sqrt(n)×6 span floor
+    const layout = gridLayout(n, span);
+    expect(isDegenerateLayout(layout)).toBe(false);
+  });
+});

--- a/webui-v2/src/lib/graph-layout-cache.ts
+++ b/webui-v2/src/lib/graph-layout-cache.ts
@@ -179,7 +179,34 @@ export function isDegenerateLayout(positions: Float32Array): boolean {
   // ball trips it and the caller re-settles (matching Reset). The absolute floor
   // (60) catches the fully-collapsed case on tiny graphs.
   const minHealthySpan = Math.max(60, Math.sqrt(n) * 6);
-  return span < minHealthySpan;
+  if (span < minHealthySpan) return true;
+
+  // Fix #4844: the span check alone is a MAX-DIMENSION test, so it is fooled by a
+  // dense HAIRBALL on a large graph. On upvate-v3 (~14k rendered nodes) a collapsed
+  // cache can still span a couple thousand units along its WIDEST axis — clearing
+  // minHealthySpan (sqrt(14233)×6 ≈ 716) — while packing all 14k nodes into a small
+  // box, rendering as the reported hairball. Reload PINNED that cache (the doSettle
+  // cache path, no sim) while Reset re-ran kickFreshSettle and spread it, so reload
+  // ≠ Reset. Add a DENSITY (area-per-node) gate so a too-dense bbox also trips as
+  // degenerate. We compute the EXPECTED span of a healthy settle from the same law
+  // the span floor uses (a real ~584-span/3000-node settle ≈ sqrt(n)×~10), square it
+  // for the expected area, and require the cached layout to occupy at least a small
+  // FRACTION of that area per node. A genuinely spread layout sits well above this
+  // fraction (a good spread is at/above the expected area), while a hairball — many
+  // nodes mushed into a small box — falls far below it, so it re-settles to match
+  // Reset. The fraction is deliberately conservative (a real spread is never
+  // rejected) and the gate only engages on non-trivially sized graphs; small graphs
+  // are already covered by the span floor above.
+  const area = spanX * spanY;
+  // Expected healthy bbox area for n nodes ≈ (sqrt(n) × 10)² = n × 100, i.e. ~100 sq
+  // units of bbox per node at the reference settle. Require ≥ 25% of that (~25 sq
+  // units/node) — far below any real spread, but a dense hairball (area/node in the
+  // single digits to low tens) trips it.
+  const HEALTHY_AREA_PER_NODE = 100;
+  const MIN_AREA_FRACTION = 0.25;
+  if (n >= 500 && area < n * HEALTHY_AREA_PER_NODE * MIN_AREA_FRACTION) return true;
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Cause (which path ran on load vs Reset)

On first load the mount effect (`graph-canvas.tsx`) trusts a cached layout when `isLayoutHealthy(saved)` passes and PINS it via `doSettle` — **no simulation runs**. The **Reset** button always routes through `kickFreshSettle` (reseed → start → mid-settle re-heat → cap → doSettle), which re-runs the sim and spreads the graph. So when a *collapsed* cache slips past the health check, load ≠ Reset.

The health check is fooled because `isDegenerateLayout` only tested the **absolute max-axis span** (`sqrt(n)*6`). On upvate-v3 (~14k rendered nodes, LOD HIGH 14,233/21,355) a collapsed *hairball* can span ~1000 units along its widest axis — clearing the ~716 floor — while packing all 14k nodes into a small box. It passed `isLayoutHealthy`, got pinned static, and only spread after a manual Reset. The same blind spot disarmed the `#4654` live-positions auto-correct controller (it bails early when `isLayoutHealthy(saved)` is true).

## Fix (degenerate-cache detection / unified settle)

Add a **density (bbox-area-per-node) gate** to `isDegenerateLayout`: when `n >= 500` and the bbox area per node is below a conservative floor (~25 sq units/node, i.e. < 25% of a healthy ~100-area/node settle), the layout is flagged degenerate. Because both the cache-trust path (`isLayoutHealthy`) and the auto-correct controller call `isDegenerateLayout`, a hairball cache is now rejected on load and the canvas runs the **exact same `kickFreshSettle` Reset runs** — reload === Reset.

## Fast-reload preserved for good caches

A genuinely spread layout runs ~100+ area/node, far above the floor, so it is never rejected — a valid spread cache still pins+fits instantly with no re-settle. The existing span floor still covers small/collapsed graphs, the gate is guarded to `n >= 500`, and the Reset path + divergence-clamping safety are untouched.

## Tests / gates

- New `webui-v2/src/lib/graph-layout-cache.test.ts`: collapse, non-finite, healthy large spread, the #4844 dense-hairball case, and the small-graph (no-gate) guard — 6 tests, all pass.
- `npx tsc --noEmit` — clean
- `npm run build` — OK
- `npx vitest run` — 113 unit tests pass (the 12 `e2e/*.spec.ts` Playwright failures are pre-existing/unrelated)
- Frontend-only; no registry/coverage changes.

Deploy-deferred. Closes #4844.