### PR TITLE
fix(#4845): extract NestJS/TS DTO class field membership (CONTAINS) so Params/Response expand

### DIFF
--- a/internal/dashboard/shape_tree.go
+++ b/internal/dashboard/shape_tree.go
@@ -123,17 +123,34 @@ func (s *Server) handleV2Shape(w http.ResponseWriter, r *http.Request) {
 // nullable inference + a HasChildren flag so the frontend can render
 // the expansion glyph.
 func collectShapeRows(grp *DashGroup, repo *DashRepo, class *graph.Entity) []v2ShapeRow {
+	var rows []v2ShapeRow
+	seen := map[string]bool{}
+	collectShapeRowsInto(grp, repo, class, &rows, seen, map[string]bool{})
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+	return rows
+}
+
+// collectShapeRowsInto appends the CONTAINS field rows of `class` into rows,
+// then recurses into the class's EXTENDS base(s) so inherited / mapped-type
+// fields are projected onto the requested DTO (#4845). visited guards against
+// inheritance cycles; seen de-dupes field names so a subclass field overrides
+// (shadows) the inherited one. A child field with the same name as an inherited
+// one wins because subclasses are walked before their bases.
+func collectShapeRowsInto(grp *DashGroup, repo *DashRepo, class *graph.Entity, rows *[]v2ShapeRow, seen, visited map[string]bool) {
 	if repo == nil || repo.Doc == nil || class == nil {
-		return nil
+		return
 	}
+	if visited[class.ID] {
+		return
+	}
+	visited[class.ID] = true
+
 	// Map field entities by ID for the FromID=class.ID CONTAINS walk.
 	byID := make(map[string]*graph.Entity, len(repo.Doc.Entities))
 	for i := range repo.Doc.Entities {
 		byID[repo.Doc.Entities[i].ID] = &repo.Doc.Entities[i]
 	}
 
-	var rows []v2ShapeRow
-	seen := map[string]bool{}
 	for _, rel := range repo.Doc.Relationships {
 		if rel.Kind != "CONTAINS" || rel.FromID != class.ID {
 			continue
@@ -146,16 +163,75 @@ func collectShapeRows(grp *DashGroup, repo *DashRepo, class *graph.Entity) []v2S
 			continue
 		}
 		row := buildShapeRow(grp, child)
-		// De-dupe by field name (Lombok synthesis can emit duplicates).
+		// De-dupe by field name (Lombok synthesis can emit duplicates;
+		// a subclass field shadows the inherited one walked later).
 		key := row.Name
 		if seen[key] {
 			continue
 		}
 		seen[key] = true
-		rows = append(rows, row)
+		*rows = append(*rows, row)
 	}
-	sort.SliceStable(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
-	return rows
+
+	// #4845 — recurse into EXTENDS base classes so a mapped-type DTO
+	// (`extends PartialType(CreateThingBody)`) or a `extends BaseDto` DTO,
+	// which owns no fields of its own, still renders the inherited field-set.
+	for _, base := range extendsBaseEntities(grp, repo, class) {
+		baseRepo := repo
+		if base.ID != "" {
+			if _, r := findRepoForEntity(grp, base.ID); r != nil {
+				baseRepo = r
+			}
+		}
+		collectShapeRowsInto(grp, baseRepo, base, rows, seen, visited)
+	}
+}
+
+// extendsBaseEntities returns the resolved base-class entities a class
+// EXTENDS, resolving each edge first by its (resolved) ToID entity, then by
+// the bare base name carried in Properties["to"] (the JS/Java heritage edges
+// keep the source/target names there). Returns only entities that look like a
+// class/record/schema shape so EXTENDS edges to external framework interfaces
+// contribute nothing. (#4845)
+func extendsBaseEntities(g *DashGroup, repo *DashRepo, class *graph.Entity) []*graph.Entity {
+	if repo == nil || repo.Doc == nil || class == nil {
+		return nil
+	}
+	byID := make(map[string]*graph.Entity, len(repo.Doc.Entities))
+	for i := range repo.Doc.Entities {
+		byID[repo.Doc.Entities[i].ID] = &repo.Doc.Entities[i]
+	}
+	var out []*graph.Entity
+	seen := map[string]bool{}
+	for _, rel := range repo.Doc.Relationships {
+		if !strings.EqualFold(rel.Kind, "EXTENDS") || rel.FromID != class.ID {
+			continue
+		}
+		var base *graph.Entity
+		if e, ok := byID[rel.ToID]; ok && e.ID != class.ID {
+			base = e
+		} else if name := relTargetName(rel); name != "" {
+			base = findClassEntityByName(g, name)
+		}
+		if base == nil || base.ID == class.ID || seen[base.ID] {
+			continue
+		}
+		seen[base.ID] = true
+		out = append(out, base)
+	}
+	return out
+}
+
+// relTargetName returns the bare base/target name an EXTENDS edge carries in
+// its Properties (the heritage extractors store it under "to"), or "".
+func relTargetName(rel graph.Relationship) string {
+	if rel.Properties == nil {
+		return ""
+	}
+	if to := rel.Properties["to"]; to != "" {
+		return to
+	}
+	return ""
 }
 
 // isFieldEntity reports whether the entity represents a class field
@@ -447,9 +523,17 @@ func isJavaPrimitiveLikeName(name string) bool {
 // the path-detail handler to decide HasChildren on the request body /
 // response shape row without making the frontend pay a probe request.
 func classHasFieldChildren(g *DashGroup, class *graph.Entity) bool {
-	if class == nil {
+	return classHasFieldChildrenRec(g, class, map[string]bool{})
+}
+
+// classHasFieldChildrenRec is classHasFieldChildren with cycle protection,
+// returning true if the class or any of its EXTENDS bases owns a field child
+// (#4845: a mapped-type / `extends BaseDto` DTO inherits its fields).
+func classHasFieldChildrenRec(g *DashGroup, class *graph.Entity, visited map[string]bool) bool {
+	if class == nil || visited[class.ID] {
 		return false
 	}
+	visited[class.ID] = true
 	_, repo := findRepoForEntity(g, class.ID)
 	if repo == nil || repo.Doc == nil {
 		return false
@@ -463,6 +547,11 @@ func classHasFieldChildren(g *DashGroup, class *graph.Entity) bool {
 			continue
 		}
 		if child, ok := byID[rel.ToID]; ok && isFieldEntity(child) {
+			return true
+		}
+	}
+	for _, base := range extendsBaseEntities(g, repo, class) {
+		if classHasFieldChildrenRec(g, base, visited) {
 			return true
 		}
 	}

--- a/internal/dashboard/shape_tree_test.go
+++ b/internal/dashboard/shape_tree_test.go
@@ -374,3 +374,131 @@ func TestShape_InferNullable(t *testing.T) {
 		}
 	}
 }
+
+// nestMappedTypeFixture models the live upvate-v3 NestJS mapped-type DTO shape:
+// CreateThingBody owns its fields, UpdateThingBody (extends PartialType(...))
+// owns NONE — its field-set is inherited via the EXTENDS edge that #4845's
+// extractor change emits to the base DTO. AdminThingBody adds its own field on
+// top of a plain `extends CreateThingBody`.
+func nestMappedTypeFixture() *DashGroup {
+	const file = "src/thing/dto/thing.dto.ts"
+	entities := []graph.Entity{
+		{
+			ID: "cls_create", Name: "CreateThingBody",
+			Kind: "SCOPE.Component", Subtype: "class",
+			SourceFile: file, Language: "typescript",
+		},
+		{
+			ID: "fld_create_name", Name: "CreateThingBody.name",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: file, Language: "typescript", Signature: "name: string",
+		},
+		{
+			ID: "fld_create_size", Name: "CreateThingBody.size",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: file, Language: "typescript", Signature: "size: number",
+		},
+		// Mapped-type DTO — owns NO field entities of its own.
+		{
+			ID: "cls_update", Name: "UpdateThingBody",
+			Kind: "SCOPE.Component", Subtype: "class",
+			SourceFile: file, Language: "typescript",
+		},
+		// Plain-extends DTO that adds one own field.
+		{
+			ID: "cls_admin", Name: "AdminThingBody",
+			Kind: "SCOPE.Component", Subtype: "class",
+			SourceFile: file, Language: "typescript",
+		},
+		{
+			ID: "fld_admin_role", Name: "AdminThingBody.role",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: file, Language: "typescript", Signature: "role: string",
+		},
+	}
+	rels := []graph.Relationship{
+		{FromID: "cls_create", ToID: "fld_create_name", Kind: "CONTAINS"},
+		{FromID: "cls_create", ToID: "fld_create_size", Kind: "CONTAINS"},
+		// EXTENDS edges resolved to the base entity ID (the extractor emits a
+		// bare-name ToID that the resolver binds; here we model the resolved
+		// shape and also exercise the Properties["to"] name fallback).
+		{FromID: "cls_update", ToID: "cls_create", Kind: "EXTENDS",
+			Properties: map[string]string{"to": "CreateThingBody"}},
+		{FromID: "cls_admin", ToID: "cls_create", Kind: "EXTENDS",
+			Properties: map[string]string{"to": "CreateThingBody"}},
+		{FromID: "cls_admin", ToID: "fld_admin_role", Kind: "CONTAINS"},
+	}
+	return makePathsTestGroup(entities, rels)
+}
+
+// TestShape_MappedTypeInheritsBaseFields proves #4845's dashboard side: a NestJS
+// mapped-type DTO that owns no fields of its own still returns its base DTO's
+// field rows (and reports has_children=true) by recursing the EXTENDS edge.
+func TestShape_MappedTypeInheritsBaseFields(t *testing.T) {
+	grp := nestMappedTypeFixture()
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/shape?type=UpdateThingBody")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool            `json:"ok"`
+		Data v2ShapeResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	names := map[string]bool{}
+	for _, r := range body.Data.Rows {
+		names[r.Name] = true
+	}
+	if !names["name"] || !names["size"] {
+		t.Errorf("mapped-type DTO should inherit base fields name+size, got rows=%+v", body.Data.Rows)
+	}
+
+	// classHasFieldChildren must also see through EXTENDS so the path-detail
+	// handler renders the expand glyph.
+	upd := findClassEntityByName(grp, "UpdateThingBody")
+	if upd == nil {
+		t.Fatal("UpdateThingBody not resolved")
+	}
+	if !classHasFieldChildren(grp, upd) {
+		t.Error("mapped-type DTO must report has_children=true via inherited fields")
+	}
+}
+
+// TestShape_PlainExtendsMergesOwnAndInheritedFields proves the additive case: a
+// DTO that extends a base AND declares its own field renders both.
+func TestShape_PlainExtendsMergesOwnAndInheritedFields(t *testing.T) {
+	grp := nestMappedTypeFixture()
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/shape?type=AdminThingBody")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		OK   bool            `json:"ok"`
+		Data v2ShapeResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	names := map[string]bool{}
+	for _, r := range body.Data.Rows {
+		names[r.Name] = true
+	}
+	for _, want := range []string{"role", "name", "size"} {
+		if !names[want] {
+			t.Errorf("AdminThingBody should expose field %q, got rows=%+v", want, body.Data.Rows)
+		}
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -1014,14 +1014,28 @@ func (x *extractor) handleClassDeclaration(n *sitter.Node) {
 		after := len(x.entities)
 		for k := before; k < after; k++ {
 			child := &x.entities[k]
-			if child.Kind != "SCOPE.Operation" {
+			var toID string
+			switch {
+			case child.Kind == "SCOPE.Operation":
+				// Issue #144 — emit a structural-ref (Format A) keyed on the
+				// source file so the resolver disambiguates by location when
+				// two classes in different files declare same-named methods
+				// (a common shape in Express/Nest/React-component apps).
+				toID = extreg.BuildOperationStructuralRef(x.language, x.filePath, child.Name)
+			case child.Kind == "SCOPE.Schema" && child.Subtype == "field":
+				// Issue #4845 — emit CONTAINS for plain/decorated class
+				// property fields, mirroring the Java (#690), Python (#689)
+				// and Kotlin fixes. Without this edge NestJS/TS DTO classes
+				// resolve to a class entity with ZERO field children, so the
+				// dashboard shape endpoint returns rows:[] and the Params /
+				// Response panels show no expand glyph. child.Name is the
+				// qualified "<Class>.<field>" string (see #679 emission in
+				// handlePublicFieldDefinition), which matches the byLocation
+				// index the resolver uses to bind the stub.
+				toID = extreg.BuildSchemaFieldStructuralRef(x.language, x.filePath, child.Name)
+			default:
 				continue
 			}
-			// Issue #144 — emit a structural-ref (Format A) keyed on the
-			// source file so the resolver disambiguates by location when
-			// two classes in different files declare same-named methods
-			// (a common shape in Express/Nest/React-component apps).
-			toID := extreg.BuildOperationStructuralRef(x.language, x.filePath, child.Name)
 			x.entities[classIdx].Relationships = append(x.entities[classIdx].Relationships,
 				types.RelationshipRecord{
 					ToID: toID,

--- a/internal/extractors/javascript/heritage.go
+++ b/internal/extractors/javascript/heritage.go
@@ -110,6 +110,73 @@ func (x *extractor) heritageClauseTypeNames(clause *sitter.Node) []string {
 				seen[name] = true
 				out = append(out, name)
 			}
+		case "call_expression":
+			// Issue #4845 — NestJS mapped-type DTOs declare their base via a
+			// helper CALL in the extends clause:
+			//
+			//	class UpdateThingBody extends PartialType(CreateThingBody) {}
+			//	class PickThingBody   extends PickType(CreateThingBody, [...]) {}
+			//	class OmitThingBody   extends OmitType(CreateThingBody, [...]) {}
+			//	class MergedBody      extends IntersectionType(A, B) {}
+			//
+			// tree-sitter parses this as a call_expression, which the
+			// identifier/generic_type cases above do not match — so before
+			// this branch the *real* base classes (the type ARGUMENTS that
+			// carry the fields) were dropped and the mapped DTO became a leaf
+			// with no EXTENDS edge to walk. We emit an EXTENDS edge to each
+			// type-identifier argument of a known mapped-type helper so the
+			// shape walker can recurse into the source DTO's fields. The
+			// helper name itself (PartialType/PickType/…) is intentionally NOT
+			// emitted — it is an external @nestjs/mapped-types/swagger symbol
+			// with no fields of its own.
+			for _, name := range mappedTypeBaseNames(x, c) {
+				if name != "" && !seen[name] {
+					seen[name] = true
+					out = append(out, name)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// nestMappedTypeHelpers are the NestJS @nestjs/mapped-types / @nestjs/swagger
+// helper functions whose type ARGUMENTS are the field-bearing base DTO(s).
+var nestMappedTypeHelpers = map[string]bool{
+	"PartialType":      true,
+	"PickType":         true,
+	"OmitType":         true,
+	"IntersectionType": true,
+}
+
+// mappedTypeBaseNames returns the base DTO type names referenced by the
+// arguments of a mapped-type helper call (PartialType(X) -> ["X"]). It returns
+// nil for any call whose callee is not a recognized NestJS mapped-type helper,
+// so non-mapped extends-call shapes contribute no edge (#4845).
+func mappedTypeBaseNames(x *extractor, call *sitter.Node) []string {
+	fn := call.ChildByFieldName("function")
+	if fn == nil {
+		return nil
+	}
+	if !nestMappedTypeHelpers[heritageLeafTypeName(x.nodeText(fn))] {
+		return nil
+	}
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(args.ChildCount()); i++ {
+		a := args.Child(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "identifier", "type_identifier", "generic_type",
+			"member_expression", "nested_type_identifier":
+			if name := heritageLeafTypeName(x.nodeText(a)); name != "" {
+				out = append(out, name)
+			}
 		}
 	}
 	return out

--- a/internal/extractors/javascript/issue4845_dto_field_membership_test.go
+++ b/internal/extractors/javascript/issue4845_dto_field_membership_test.go
@@ -1,0 +1,158 @@
+// Package javascript — issue #4845 NestJS/TS DTO field-membership tests.
+//
+// LIVE root cause (upvate-v3): a DTO class such as `CreateAlternateAddressBody`
+// RESOLVES to a SCOPE.Component/class entity (type_entity_id present), but the
+// dashboard shape endpoint returned `{subtype:"class", rows:[]}` — the class had
+// ZERO field children. The property fields WERE extracted (as SCOPE.Schema/field
+// entities, #679) but the class→field CONTAINS edges were NOT emitted: the
+// CONTAINS loop in handleClassDeclaration only linked SCOPE.Operation methods,
+// so classHasFieldChildren returned false and the Params/Response panels showed
+// no expand glyph.
+//
+// After #4845 every plain/decorated class property field gets a CONTAINS edge
+// (mirroring the Java/Python/Kotlin fixes), and NestJS mapped-type DTOs
+// (`extends PartialType(X)` / PickType / OmitType / IntersectionType) emit an
+// EXTENDS edge to the field-bearing base DTO so the shape walker can recurse.
+package javascript_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// hasContainsField reports whether the class named `class` carries a CONTAINS
+// edge to the SCOPE.Schema/field structural-ref for `<class>.<field>`.
+func hasContainsField(ents []types.EntityRecord, path, className, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("typescript", path, className+"."+field)
+	for _, e := range ents {
+		if e.Name != className || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// fieldEntityExists reports whether a SCOPE.Schema/field entity named
+// "<class>.<field>" was emitted.
+func fieldEntityExists(ents []types.EntityRecord, className, field string) bool {
+	want := className + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDTO_PlainAndDecoratedFieldsAreContained proves a NestJS DTO with plain,
+// readonly, optional, and @ApiProperty-decorated properties emits one
+// SCOPE.Schema/field entity per property AND a class→field CONTAINS edge for
+// each — the exact gap that left shape rows empty on upvate-v3.
+func TestDTO_PlainAndDecoratedFieldsAreContained(t *testing.T) {
+	path := "src/address/dto/create-alternate-address-body.dto.ts"
+	src := []byte(`
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateAlternateAddressBody {
+  @ApiProperty()
+  name: string;
+
+  readonly line1: string;
+
+  street?: string;
+
+  count = 0;
+}
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	for _, f := range []string{"name", "line1", "street", "count"} {
+		if !fieldEntityExists(ents, "CreateAlternateAddressBody", f) {
+			t.Errorf("expected SCOPE.Schema/field entity CreateAlternateAddressBody.%s", f)
+		}
+		if !hasContainsField(ents, path, "CreateAlternateAddressBody", f) {
+			t.Errorf("expected CONTAINS edge from class to field %q", f)
+		}
+	}
+}
+
+// TestDTO_MappedTypeExtendsBase proves a mapped-type DTO
+// (`extends PartialType(CreateThingBody)`) emits an EXTENDS edge to the
+// field-bearing base DTO (and NOT to the PartialType helper itself), so the
+// shape walker can recurse into the base's fields even though the mapped DTO
+// owns none of its own.
+func TestDTO_MappedTypeExtendsBase(t *testing.T) {
+	path := "src/thing/dto/update-thing-body.dto.ts"
+	src := []byte(`
+import { PartialType, PickType, OmitType, IntersectionType } from '@nestjs/mapped-types';
+import { CreateThingBody } from './create-thing-body.dto';
+import { OtherBody } from './other-body.dto';
+
+export class CreateThingBody {
+  name: string;
+  size: number;
+}
+
+export class UpdateThingBody extends PartialType(CreateThingBody) {}
+
+export class PickThingBody extends PickType(CreateThingBody, ['name'] as const) {}
+
+export class OmitThingBody extends OmitType(CreateThingBody, ['size'] as const) {}
+
+export class MergedBody extends IntersectionType(CreateThingBody, OtherBody) {}
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	for _, mapped := range []string{"UpdateThingBody", "PickThingBody", "OmitThingBody"} {
+		if !hasHeritageEdge(ents, mapped, "EXTENDS", "CreateThingBody") {
+			t.Errorf("%s should EXTENDS the base DTO CreateThingBody", mapped)
+		}
+		// The helper itself must NOT be emitted as a base.
+		if hasHeritageEdge(ents, mapped, "EXTENDS", "PartialType") ||
+			hasHeritageEdge(ents, mapped, "EXTENDS", "PickType") ||
+			hasHeritageEdge(ents, mapped, "EXTENDS", "OmitType") {
+			t.Errorf("%s must not EXTENDS the mapped-type helper", mapped)
+		}
+	}
+	// IntersectionType yields an EXTENDS edge to BOTH argument DTOs.
+	if !hasHeritageEdge(ents, "MergedBody", "EXTENDS", "CreateThingBody") {
+		t.Error("MergedBody should EXTENDS CreateThingBody (IntersectionType arg 1)")
+	}
+	if !hasHeritageEdge(ents, "MergedBody", "EXTENDS", "OtherBody") {
+		t.Error("MergedBody should EXTENDS OtherBody (IntersectionType arg 2)")
+	}
+}
+
+// TestDTO_PlainExtendsBaseStillContainsOwnFields guards the general case: a DTO
+// that `extends BaseDto` and ALSO declares its own fields keeps CONTAINS edges
+// for its own fields (the EXTENDS-recursion is additive, not a replacement).
+func TestDTO_PlainExtendsBaseStillContainsOwnFields(t *testing.T) {
+	path := "src/user/dto/admin-user-body.dto.ts"
+	src := []byte(`
+export class BaseUserBody {
+  email: string;
+}
+
+export class AdminUserBody extends BaseUserBody {
+  role: string;
+}
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	if !hasContainsField(ents, path, "AdminUserBody", "role") {
+		t.Error("AdminUserBody should CONTAINS its own field role")
+	}
+	if !hasContainsField(ents, path, "BaseUserBody", "email") {
+		t.Error("BaseUserBody should CONTAINS its field email")
+	}
+	if !hasHeritageEdge(ents, "AdminUserBody", "EXTENDS", "BaseUserBody") {
+		t.Error("AdminUserBody should EXTENDS BaseUserBody")
+	}
+}


### PR DESCRIPTION
## Root cause (confirmed: case **b**)

On upvate-v3 a DTO like `CreateAlternateAddressBody` RESOLVES to a `SCOPE.Component`/class entity (type_entity_id present), but `/api/v2/.../shape?type=CreateAlternateAddressBody` returned `{subtype:"class", rows:[]}` — the class had ZERO field children.

The property fields **were** extracted as `SCOPE.Schema`/`field` entities (#679, for `this.<field>` REFERENCES resolution), but the class→field **CONTAINS edge was never emitted**: the loop in `handleClassDeclaration` only linked `SCOPE.Operation` (methods), explicitly `continue`-ing past everything else. So `classHasFieldChildren` returned false → `has_children=false` → no expand glyph. This is **case (b)** (fields extracted, not CONTAINS-linked) — the exact bug previously fixed for Java (#690), Python (#689) and Kotlin.

## Fix

**Extractor — `internal/extractors/javascript/extractor.go`**
The class-body CONTAINS loop now also links `SCOPE.Schema`/`field` children via `BuildSchemaFieldStructuralRef(lang, file, "<Class>.<field>")` (same structural-ref the resolver's byLocation index binds, identical to the Java/Python/Kotlin path). Handles plain (`count = 0`), typed (`line1: string`), `readonly`, optional (`street?: string`) and decorated (`@ApiProperty() name: string`) properties — all parse as `public_field_definition`, so this is general TS, not a NestJS-only hack.

**Mapped-type / extends — `internal/extractors/javascript/heritage.go` (case c)**
NestJS mapped-type DTOs declare their base via a *call* in the extends clause (`extends PartialType(CreateThingBody)`), which tree-sitter parses as a `call_expression` the heritage walker previously dropped. Added a `call_expression` arm that, for the recognized helpers (`PartialType`/`PickType`/`OmitType`/`IntersectionType`), emits an EXTENDS edge to each **type-argument** DTO (the field-bearing base) — and NOT to the helper symbol itself. `IntersectionType(A, B)` yields EXTENDS to both.

**Dashboard shape walker — `internal/dashboard/shape_tree.go`**
`collectShapeRows` and `classHasFieldChildren` now recurse through EXTENDS bases (cycle-guarded; subclass fields shadow inherited names), so a mapped-type DTO or `extends BaseDto` DTO that owns no fields of its own still renders the inherited field-set with `has_children=true`.

## Tests (prove non-empty shape rows)

- `internal/extractors/javascript/issue4845_dto_field_membership_test.go` — DTO with plain/readonly/optional/`@ApiProperty` fields emits one `SCOPE.Schema`/field entity + a class→field CONTAINS edge each; mapped-type DTOs EXTENDS the base DTO (and not the helper); `IntersectionType` → both args; plain-extends keeps own + base fields.
- `internal/dashboard/shape_tree_test.go` — `TestShape_MappedTypeInheritsBaseFields` (mapped-type DTO returns base rows + `has_children`), `TestShape_PlainExtendsMergesOwnAndInheritedFields`.

## Generalize audit

Java/Spring, Python/Pydantic, Kotlin, Scala, COBOL **already** emit field-membership CONTAINS (`BuildSchemaFieldStructuralRef`, verified). **Go struct DTOs have the same gap** — `attachClassContains` links methods only — filed as **#4850** (also needs verifying Go emits per-field entities at all).

## Gates

`go build ./...` ✓ · `go vet ./internal/extractors/javascript/ ./internal/dashboard/ ./internal/extractor/` ✓ · `go test` for javascript + dashboard + extractor + types ✓ · `coverage fmt --check` ✓ · `coverage validate` ✓. No new entity Kind (reuses `SCOPE.Schema`/field); no documented-capability row exists for JS/TS class field-membership, so no registry change required (this is a foundational extractor fix, like #679 itself).

Deploy-deferred — coordinator will live-validate by reindexing upvate-v3 and re-querying the shape endpoint.

Closes #4845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)