### PR TITLE
fix(#4852): consistent graph edge opacity across zoom + documented link knobs [visual]

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -43,6 +43,7 @@ import {
   pastelAt,
   degreeColor,
   linkPalette,
+  packedLinkAlpha,
   lerpRGBA,
   JARVIS_GLOW,
 } from "@/lib/graph-colors";
@@ -632,25 +633,18 @@ function GraphCanvasInner(
     // so it gets the emphasized treatment but with a gentler gap (cross-module is
     // far more common than cross-repo, so over-brightening it would re-introduce
     // spaghetti).
+    // Fix #4852: tier alphas + the combined-alpha floor now live in one pure,
+    // unit-tested place (graph-colors.packedLinkAlpha). `packedLinkAlpha` returns
+    // the value to bake into color.a such that, AFTER the shader multiplies by the
+    // linkOpacity uniform, the rendered alpha is max(tierAlpha × linkOpacity,
+    // LINK_ALPHA_FLOOR) — so the doubled linkOpacity multiply (tier already scaled
+    // by linkOpacity, then × the uniform again) can no longer compound a faded
+    // link to invisibility at low slider settings. The faded/subtle/emphasized
+    // RELATIONSHIPS (the #1567/#1599 emphasis tuning) are preserved.
     const base = render.linkOpacity;
-    let fadedA: number;
-    let subtleA: number;
-    let emphA: number;
-    if (isMultiRepo) {
-      // Wide gap: bridges pop, intra-repo recedes. The rare cross-repo edges
-      // (376 of 37k on upvate) get a high — but not fully opaque — alpha so they
-      // clearly own the foreground while staying tasteful even when a denser
-      // layout packs them through the center (not a solid cyan mat).
-      fadedA = Math.min(0.32, base * 0.5);
-      subtleA = Math.min(0.42, Math.max(0.3, base * 0.62));
-      emphA = 0.85;
-    } else {
-      // Single-repo: cross-module is the (more common) emphasized tier — a
-      // tasteful gap that still keeps it readable, not blaring.
-      fadedA = Math.min(0.5, base * 0.6);
-      subtleA = Math.min(0.7, Math.max(0.5, base * 0.85));
-      emphA = Math.min(0.85, Math.max(0.65, base * 1.15));
-    }
+    const fadedA = packedLinkAlpha("faded", base, isMultiRepo);
+    const subtleA = packedLinkAlpha("subtle", base, isMultiRepo);
+    const emphA = packedLinkAlpha("emphasized", base, isMultiRepo);
     for (let i = 0; i < states.length; i++) {
       const st = states[i];
       // tier: 0 faded, 1 subtle, 2 emphasized — repo-aware.
@@ -1174,15 +1168,43 @@ function GraphCanvasInner(
       // zoom level, so the long inter-island bridge links never thin out and
       // disappear when the user zooms all the way out.
       scaleLinksOnZoom: false,
-      // Fix #1548-2: cosmos.gl fades links by their ON-SCREEN length
-      // (linkVisibilityDistanceRange, in px) and caps far-link alpha at
-      // linkVisibilityMinTransparency. The defaults ([50,150] / 0.25) made
-      // every link nearly invisible at the fitted (zoomed-out) level — links
-      // only "appeared" after zooming/settling. Widen the visibility floor and
-      // raise the min transparency so links read clearly from the first paint
-      // at any zoom.
+      // ─── HOW THE LINK-VISIBILITY KNOBS WORK (cosmos.gl link frag shader) ───
+      // The shader computes, per link, per frame:
+      //
+      //   visFactor = max(
+      //     linkVisibilityMinTransparency,
+      //     map(linkDistPx, range[1], range[0], 0, 1)   // linear, clamped 0..1
+      //   )
+      //   finalAlpha = color.a * linkOpacity * visFactor   // (× greyout if dimmed)
+      //
+      // where `linkDistPx` is the link's length in ON-SCREEN PIXELS (it grows as
+      // you zoom IN, shrinks as you zoom OUT, because scaleLinksOnZoom is off so
+      // only the *positions* scale, not the width). `map(linkDistPx, hi, lo, 0, 1)`
+      // therefore returns ≈1 for SHORT on-screen links (zoomed out) and falls
+      // toward 0 for LONG on-screen links (zoomed in), then is floored at
+      // linkVisibilityMinTransparency.
+      //
+      // Fix #1548-2: the cosmos defaults ([50,150] / 0.25) made every link nearly
+      // invisible at the fitted (zoomed-out) level — links only "appeared" after
+      // zooming/settling — so the floor was raised to 0.8 and the range widened.
+      //
+      // Fix #4852: that map() is the entire source of the "edges dim when zoomed
+      // IN, over-strong when zoomed OUT" inconsistency: zooming in lengthens links
+      // in px → visFactor sinks toward the floor; zooming out shortens them →
+      // visFactor rides at ~1.0. The previous [1,10000]/0.8 still left a 0.8→1.0
+      // (≈20%) brightness swing tied purely to zoom. We do NOT want any
+      // zoom-coupled alpha here — link emphasis is already fully governed by the
+      // per-link `color.a` tiers (packLinkColors) and the master `linkOpacity`
+      // slider, both zoom-independent. So pin the visibility factor to a CONSTANT
+      // by setting MinTransparency = 1.0: `max(1.0, map(...))` clamps visFactor to
+      // 1.0 at every zoom (map() is ≤1 for any on-screen length within the range),
+      // making finalAlpha = color.a * linkOpacity, independent of zoom. The
+      // distance range is kept wide so the (now-inert) map() can never dip below 1
+      // within the visible pixel range. Net effect: identical, predictable edge
+      // legibility from the fitted zoom-out to deep zoom-in — no near-invisible
+      // links zoomed in, no harsh over-strong mat zoomed out.
       linkVisibilityDistanceRange: [1, 10000],
-      linkVisibilityMinTransparency: 0.8,
+      linkVisibilityMinTransparency: 1.0,
       renderHoveredPointRing: true,
       hoveredPointRingColor: isDark ? "#e2e8f0" : "#1e293b",
       pointSamplingDistance: 120,

--- a/webui-v2/src/lib/graph-colors.test.ts
+++ b/webui-v2/src/lib/graph-colors.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Fix #4852 — link-alpha model tests.
+ *
+ * Covers the pure alpha seam factored out of graph-canvas:
+ *   - linkTierAlpha  : per-tier base alpha (faded < subtle < emphasized).
+ *   - packedLinkAlpha: the value baked into color.a so that, after the shader's
+ *     linkOpacity multiply, the rendered alpha never compounds below the floor.
+ *
+ * The key invariant this guards is the #4852 bug: the cosmos frag shader
+ * multiplies the packed color.a by the linkOpacity uniform AGAIN, and the tier
+ * alpha was ALSO scaled by linkOpacity, so a low slider setting drove faded
+ * links toward invisibility. packedLinkAlpha keeps the rendered product
+ * (color.a × linkOpacity) at or above LINK_ALPHA_FLOOR.
+ *
+ * Run with: npx vitest run src/lib/graph-colors.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import {
+  LINK_ALPHA_FLOOR,
+  linkTierAlpha,
+  packedLinkAlpha,
+  type LinkTier,
+} from "./graph-colors";
+
+const TIERS: LinkTier[] = ["faded", "subtle", "emphasized"];
+
+describe("linkTierAlpha", () => {
+  it("orders faded < subtle <= emphasized in single-repo mode", () => {
+    const f = linkTierAlpha("faded", 0.6, false);
+    const s = linkTierAlpha("subtle", 0.6, false);
+    const e = linkTierAlpha("emphasized", 0.6, false);
+    expect(f).toBeLessThan(s);
+    expect(s).toBeLessThanOrEqual(e);
+  });
+
+  it("orders faded < subtle < emphasized in multi-repo mode", () => {
+    const f = linkTierAlpha("faded", 0.6, true);
+    const s = linkTierAlpha("subtle", 0.6, true);
+    const e = linkTierAlpha("emphasized", 0.6, true);
+    expect(f).toBeLessThan(s);
+    expect(s).toBeLessThan(e);
+  });
+
+  it("stays within [0,1] across the full slider range and both modes", () => {
+    for (const isMulti of [false, true]) {
+      for (let op = 0; op <= 1.0001; op += 0.05) {
+        for (const t of TIERS) {
+          const a = linkTierAlpha(t, op, isMulti);
+          expect(a).toBeGreaterThanOrEqual(0);
+          expect(a).toBeLessThanOrEqual(1);
+        }
+      }
+    }
+  });
+});
+
+describe("packedLinkAlpha — combined-alpha floor (#4852)", () => {
+  it("renders at the floor whenever opacity allows it (op >= floor)", () => {
+    // For op >= FLOOR the packed alpha can reach the floor without exceeding a
+    // valid [0,1] opacity, so rendered = color.a × op must be >= the floor.
+    for (const isMulti of [false, true]) {
+      for (let op = LINK_ALPHA_FLOOR; op <= 1.0001; op += 0.01) {
+        for (const t of TIERS) {
+          const packed = packedLinkAlpha(t, op, isMulti);
+          const rendered = packed * op; // what the shader actually outputs
+          expect(rendered).toBeGreaterThanOrEqual(LINK_ALPHA_FLOOR - 1e-6);
+        }
+      }
+    }
+  });
+
+  it("at very low opacity (op < floor) renders as bright as possible (color.a clamps to 1)", () => {
+    // Below the floor the floor is physically unreachable (can't render > full
+    // opacity); the best we can do is color.a = 1, i.e. rendered ≈ op. Verify we
+    // saturate there rather than silently dropping the link.
+    for (const isMulti of [false, true]) {
+      for (let op = 0.01; op < LINK_ALPHA_FLOOR; op += 0.01) {
+        for (const t of TIERS) {
+          const packed = packedLinkAlpha(t, op, isMulti);
+          const rendered = packed * op;
+          expect(packed).toBeCloseTo(1, 6);
+          expect(rendered).toBeCloseTo(op, 6);
+        }
+      }
+    }
+  });
+
+  it("keeps the packed alpha a valid opacity in [0,1]", () => {
+    for (const isMulti of [false, true]) {
+      for (let op = 0; op <= 1.0001; op += 0.05) {
+        for (const t of TIERS) {
+          const packed = packedLinkAlpha(t, op, isMulti);
+          expect(packed).toBeGreaterThanOrEqual(0);
+          expect(packed).toBeLessThanOrEqual(1);
+        }
+      }
+    }
+  });
+
+  it("preserves tier ORDER after the floor at a healthy default opacity", () => {
+    // At the default 0.55 the floor shouldn't have collapsed the emphasis gaps.
+    const op = 0.55;
+    for (const isMulti of [false, true]) {
+      const f = packedLinkAlpha("faded", op, isMulti) * op;
+      const s = packedLinkAlpha("subtle", op, isMulti) * op;
+      const e = packedLinkAlpha("emphasized", op, isMulti) * op;
+      expect(f).toBeLessThanOrEqual(s);
+      expect(s).toBeLessThanOrEqual(e);
+    }
+  });
+
+  it("the floor only lifts the LOW end — emphasized at full opacity is untouched", () => {
+    // emphasized tier × linkOpacity is already well above the floor, so
+    // packedLinkAlpha should equal the raw tier alpha (no flooring).
+    const raw = linkTierAlpha("emphasized", 1.0, false);
+    const packed = packedLinkAlpha("emphasized", 1.0, false);
+    expect(packed).toBeCloseTo(Math.min(1, raw), 6);
+  });
+
+  it("does not divide-by-zero when links are turned fully off", () => {
+    for (const t of TIERS) {
+      const packed = packedLinkAlpha(t, 0, false);
+      expect(Number.isFinite(packed)).toBe(true);
+      expect(packed).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/webui-v2/src/lib/graph-colors.ts
+++ b/webui-v2/src/lib/graph-colors.ts
@@ -166,6 +166,83 @@ export function linkPalette(isDark: boolean): LinkPalette {
   };
 }
 
+/**
+ * Fix #4852 — LINK ALPHA MODEL (the single source of truth for per-link
+ * opacity, factored out of graph-canvas so it's unit-testable).
+ *
+ * A rendered link's on-screen alpha is the product of several independent
+ * modulators. Before #4852 these were spread across two places and could
+ * silently COMPOUND a link down toward invisibility:
+ *
+ *   1. tier alpha       — packLinkColors picks faded / subtle / emphasized
+ *                         per edge CLASS (intra-module / cross-module /
+ *                         cross-repo). Derived from the master `linkOpacity`.
+ *   2. linkOpacity (×2) — the cosmos `linkOpacity` UNIFORM multiplies the
+ *                         per-link `color.a` AGAIN in the frag shader. Because
+ *                         the tier alpha was ALSO scaled by linkOpacity, the
+ *                         slider acted ~quadratically and a low setting drove
+ *                         faded links to ~0 (e.g. tier 0.36 × uniform 0.6 =
+ *                         0.22 actual — much dimmer than the 0.36 the tier math
+ *                         implied).
+ *   3. zoom visFactor   — see graph-canvas; now pinned to 1.0 so it no longer
+ *                         participates (was a 0.8–1.0 zoom-coupled swing).
+ *
+ * To keep the tier RELATIONSHIPS (faded < subtle < emphasized) while preventing
+ * the double-linkOpacity multiply from collapsing any link to invisible, we
+ * compute the tier alpha here and clamp the COMBINED alpha (tier × uniform
+ * linkOpacity, the value the shader actually renders) to a small floor. The
+ * floor guarantees that even the faintest intra-module link at a low slider
+ * setting stays perceptible, without flattening the emphasis gaps above it.
+ */
+
+/** Effective combined alpha floor: tierAlpha × linkOpacity is never rendered
+ *  below this, so stacked modulators can't multiply a link to invisible. Chosen
+ *  to stay just above the perceptibility threshold on both themes. */
+export const LINK_ALPHA_FLOOR = 0.12;
+
+export type LinkTier = "faded" | "subtle" | "emphasized";
+
+/**
+ * Pure per-tier base alpha as a function of the master `linkOpacity` (`base`)
+ * and whether the group is multi-repo. This is the alpha written into the
+ * per-link color buffer (`color.a`). Mirrors the tiers tuned in #1567/#1599 —
+ * extracted verbatim so the canvas and the tests share one definition.
+ *
+ *   • multi-repo : wide gap so the rare cross-repo bridges pop, intra recedes.
+ *   • single-repo: gentler gap; cross-module is the (commoner) emphasized tier.
+ */
+export function linkTierAlpha(tier: LinkTier, base: number, isMultiRepo: boolean): number {
+  if (isMultiRepo) {
+    if (tier === "emphasized") return 0.85;
+    if (tier === "subtle") return Math.min(0.42, Math.max(0.3, base * 0.62));
+    return Math.min(0.32, base * 0.5); // faded
+  }
+  if (tier === "emphasized") return Math.min(0.85, Math.max(0.65, base * 1.15));
+  if (tier === "subtle") return Math.min(0.7, Math.max(0.5, base * 0.85));
+  return Math.min(0.5, base * 0.6); // faded
+}
+
+/**
+ * The alpha actually rendered for a link = tierAlpha × linkOpacity uniform,
+ * clamped UP to LINK_ALPHA_FLOOR so the doubled linkOpacity multiply can't push
+ * a link to invisibility. We bake this clamped value into `color.a` and the
+ * shader still multiplies by the linkOpacity uniform — so to keep the clamp
+ * meaningful we DIVIDE the uniform back out here, i.e. we store
+ * `max(tierAlpha, FLOOR/linkOpacity)` so that `color.a × linkOpacity` lands at
+ * `max(tierAlpha × linkOpacity, FLOOR)`. The division is guarded against a
+ * zero linkOpacity (the slider allows 0, meaning "links off"); at linkOpacity=0
+ * the shader's `color.a × 0` still renders nothing, so the floor never forces a
+ * hidden link visible — it only protects against the COMPOUNDING dim at low,
+ * non-zero settings.
+ */
+export function packedLinkAlpha(tier: LinkTier, linkOpacity: number, isMultiRepo: boolean): number {
+  const tierA = linkTierAlpha(tier, linkOpacity, isMultiRepo);
+  const op = Math.max(linkOpacity, 1e-3);
+  const flooredTier = Math.max(tierA, LINK_ALPHA_FLOOR / op);
+  // color.a is an opacity → clamp to a valid [0,1] alpha.
+  return Math.min(1, flooredTier);
+}
+
 /** Same-repo edge color — slate, lifted brighter (#1532-2). Retained for
  *  back-compat; the live canvas now uses linkPalette() (#1564). */
 export const SAME_REPO_EDGE: RGBA = [71, 85, 105, 1];

--- a/webui-v2/src/lib/graph-layout-cache.ts
+++ b/webui-v2/src/lib/graph-layout-cache.ts
@@ -54,8 +54,14 @@ const PREFIX = "archigraph.v2.layout";
  * after a manual Reset (which routes through kickFreshSettle). Bumping makes every
  * v5 layout a guaranteed miss → first load runs the unified fresh settle. Reload ===
  * Reset by construction. (Kept in lock-step with DEFAULTS_VERSION = 6.)
+ *
+ * Fix #4852: bump to 7 — kept in lock-step with DEFAULTS_VERSION = 7, which was
+ * bumped to ship the retuned DEFAULT_RENDER.linkOpacity. No layout-producing force
+ * changed (this is a pure render/opacity tweak), so the only effect of this bump is
+ * a harmless one-time re-settle on next load; the lock-step is maintained purely to
+ * honor the documented protocol (the two stamps must move together).
  */
-export const LAYOUT_VERSION = 6;
+export const LAYOUT_VERSION = 7;
 
 function fnv1a32(s: string): string {
   let h = 0x811c9dc5 >>> 0;

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -157,7 +157,14 @@ export const DEFAULT_RENDER: RenderConfig = {
   // Fix #1548-2: edges must read clearly from the FIRST paint (not just after
   // settle). Raise the default same-repo link opacity further so relationships
   // are visible immediately on a light background.
-  linkOpacity: 0.6,
+  // Fix #4852: the zoom-fade (linkVisibilityMinTransparency) is now pinned to 1.0,
+  // so the alpha that USED to apply only at the fitted zoom-out (visFactor≈1.0,
+  // the "over-strong" end) now applies at EVERY zoom. To keep the uniform level
+  // tasteful — between the old over-strong (zoomed-out) and dim (zoomed-in, ×0.8)
+  // extremes — nudge the default down slightly. The combined-alpha floor
+  // (LINK_ALPHA_FLOOR) keeps faded links legible at this setting; the "Link
+  // opacity" slider remains the master control for users who want more/less.
+  linkOpacity: 0.55,
   showLinks: true,
 };
 
@@ -217,7 +224,12 @@ const DEFAULT_ENABLED_EDGE_KINDS: EdgeKind[] = STRUCTURAL_EDGE_KINDS;
 // "graph needs a manual Reset to lay out" bug. No DEFAULT_SIMULATION/sizing value
 // changed here, so persisted tuning is unaffected; this bump exists purely to keep
 // the two version stamps in lock-step per the documented protocol.
-const DEFAULTS_VERSION = 6;
+// Fix #4852: bump to 7 (in lock-step with graph-layout-cache.LAYOUT_VERSION) so the
+// retuned DEFAULT_RENDER.linkOpacity (0.6 → 0.55) reaches users who already have a
+// stored render blob — without it the shipped default would never apply. No
+// layout-producing force changed, so the lock-step layout-cache invalidation only
+// triggers a harmless one-time re-settle on next load.
+const DEFAULTS_VERSION = 7;
 const VERSION_KEY = "ag.v2.graph.defaultsVersion";
 
 function readStoredVersion(): number {


### PR DESCRIPTION
## What was wrong
cosmos.gl's link frag shader fades each link by its **on-screen pixel length**:
\`\`\`
finalAlpha = color.a * linkOpacity * max(MinTransparency, map(linkDistPx, hi, lo, 0, 1))
\`\`\`
With \`scaleLinksOnZoom\` off, \`linkDistPx\` **grows when zoomed IN** and shrinks when zoomed OUT. So the \`map()\` term made edges **dim zoomed in** (clamped to the 0.8 floor) and **over-strong zoomed out** (~1.0) — a ~20% zoom-coupled brightness swing. Separately, the shader multiplies the packed \`color.a\` by the \`linkOpacity\` uniform **again**, while the per-tier alpha was **also** scaled by \`linkOpacity\` — a doubled multiply that drove faded intra-module links toward invisibility at low slider settings.

## Retuned knobs (before → after)
| knob | before | after | why |
|---|---|---|---|
| \`linkVisibilityMinTransparency\` | 0.8 | **1.0** | pins the visibility factor to a constant 1.0 at every zoom (\`map()\` ≤ 1 within range) → no zoom-dependent alpha |
| \`linkVisibilityDistanceRange\` | [1, 10000] | [1, 10000] | unchanged; kept wide so the now-inert \`map()\` never dips below 1 |
| \`DEFAULT_RENDER.linkOpacity\` | 0.6 | **0.55** | the level that previously applied only at the over-strong zoomed-out end now applies everywhere; nudged down to sit between the old extremes |
| \`DEFAULTS_VERSION\` / \`LAYOUT_VERSION\` | 6 | **7** (lock-step) | so the new default reaches users with a stored render blob; only effect is a harmless one-time re-settle |

## Stacked-modulator clamp
Factored the link-alpha math into a **pure, unit-tested seam** in \`graph-colors.ts\` (\`linkTierAlpha\` / \`packedLinkAlpha\` + \`LINK_ALPHA_FLOOR = 0.12\`). \`packedLinkAlpha\` bakes a value into \`color.a\` such that, after the shader's \`linkOpacity\` multiply, the **combined** rendered alpha is \`max(tierAlpha × linkOpacity, FLOOR)\` — so the doubled multiply can no longer compound a faded link to ~0, while the faded < subtle < emphasized emphasis gaps (the #1567/#1599 tuning) are preserved. At \`linkOpacity = 0\` (links off) the shader's \`× 0\` still renders nothing, so the floor never forces a hidden link visible.

## In-code docs
Documented every link-opacity knob (the shader formula, what \`linkDistPx\` means, why each value was chosen) inline in \`graph-canvas.tsx\` and \`graph-colors.ts\` — the "how the knobs work" ask.

## Not regressed
Hover-greyout (\`linkGreyoutOpacity\`), ego-focus, and the divergence/layout safety are untouched. No data/payload/MCP code changed — renderer-only.

## Gates
- \`npx tsc --noEmit\` — clean
- \`npm run build\` — OK
- \`npx vitest run\` — **126 unit tests pass** incl. **9 new** alpha-floor tests (12 e2e Playwright files fail pre-existing/unrelated)

## Visual validation note
I can't see the live render; values were chosen conservatively with the reasoning above so the coordinator can validate visually on upvate-v3 (~21k/44k) after rebuild: edges should read clearly and **consistently** from fitted zoom-out to deep zoom-in, with no near-invisible links zoomed in and no harsh mat zoomed out. If the uniform level reads slightly hot/cold, the single dial is \`DEFAULT_RENDER.linkOpacity\`.

Deploy-deferred. Closes #4852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)