### PR TITLE
fix(#4850): class/struct field-membership CONTAINS across ALL languages (Go + matrix audit)

### DIFF
--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -1834,6 +1834,10 @@ func extractTypes(root *sitter.Node, src []byte, filePath string) ([]types.Entit
 			var signature string
 			var kind string
 			var relationships []types.RelationshipRecord
+			// Issue #4850 — SCOPE.Schema/field entities for struct members,
+			// appended after the owning struct record so the resolver's
+			// byLocation index can bind the CONTAINS structural-refs.
+			var fieldEntities []types.EntityRecord
 			switch entitySubtype {
 			case "struct":
 				tags := findAll(typeBody, "raw_string_literal")
@@ -1853,6 +1857,12 @@ func extractTypes(root *sitter.Node, src []byte, filePath string) ([]types.Entit
 				// the graph conservative: no edges to primitives, no edges
 				// to unresolved identifiers (which could be package-external).
 				relationships = extractStructFieldDependencies(typeBody, src, name, knownTypeNames)
+				// Issue #4850 — emit a field entity per named member and an
+				// EXTENDS edge per embedded field, so the struct (a DTO/data
+				// class) projects field children in the dashboard shape tree.
+				var embedExtends []types.RelationshipRecord
+				fieldEntities, embedExtends = extractStructFieldEntities(typeBody, src, name, filePath, knownTypeNames)
+				relationships = append(relationships, embedExtends...)
 			case "interface":
 				methodNodes := findAll(typeBody, "method_elem", "method_spec")
 				signature = fmt.Sprintf("type %s interface // %d method(s)", name, len(methodNodes))
@@ -1903,6 +1913,8 @@ func extractTypes(root *sitter.Node, src []byte, filePath string) ([]types.Entit
 				EnrichmentRequired: false,
 			}
 			records = append(records, rec)
+			// Issue #4850 — struct field members follow their owning struct.
+			records = append(records, fieldEntities...)
 		}
 	}
 
@@ -2250,6 +2262,27 @@ func attachClassContains(records []types.EntityRecord, filePath string) []types.
 		}
 		toID := extractor.BuildOperationStructuralRef("go", filePath, r.Name)
 		records = appendRelationshipTo(records, recv, types.RelationshipRecord{
+			ToID: toID,
+			Kind: "CONTAINS",
+		})
+	}
+	// Issue #4850 — class→field CONTAINS. For every SCOPE.Schema/field member
+	// emitted by extractStructFieldEntities, attach a CONTAINS edge from its
+	// owning struct Component (Metadata["owner"]) to a Format-A field
+	// structural-ref keyed on the dotted Name + file (mirrors the Java #690,
+	// Python #689, Kotlin and JS/TS #4851 emitters). Without this edge a Go
+	// struct DTO has zero field children and the dashboard shape tree returns
+	// rows:[] (classHasFieldChildren false → no expand glyph).
+	for _, r := range records {
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		owner, _ := r.Metadata["owner"].(string)
+		if owner == "" {
+			continue
+		}
+		toID := extractor.BuildSchemaFieldStructuralRef("go", filePath, r.Name)
+		records = appendRelationshipTo(records, owner, types.RelationshipRecord{
 			ToID: toID,
 			Kind: "CONTAINS",
 		})

--- a/internal/extractors/golang/extractor_test.go
+++ b/internal/extractors/golang/extractor_test.go
@@ -253,18 +253,32 @@ type User struct {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	results = stripFileEntity(results)
-	if len(results) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(results))
+	// Issue #4850 — the struct now also emits a SCOPE.Schema/field entity per
+	// field (ID, Name), so the expected set is: struct Component + 2 fields.
+	if len(results) != 3 {
+		t.Fatalf("expected 3 entities (struct + 2 fields), got %d", len(results))
 	}
-	r := results[0]
-	if r.Kind != "SCOPE.Component" {
-		t.Errorf("expected Kind=SCOPE.Component, got %q", r.Kind)
+	var r *types.EntityRecord
+	fieldNames := map[string]bool{}
+	for i := range results {
+		switch {
+		case results[i].Kind == "SCOPE.Component":
+			r = &results[i]
+		case results[i].Kind == "SCOPE.Schema" && results[i].Subtype == "field":
+			fieldNames[results[i].Name] = true
+		}
+	}
+	if r == nil {
+		t.Fatalf("expected a SCOPE.Component struct entity")
 	}
 	if r.Subtype != "struct" {
 		t.Errorf("expected Subtype=struct, got %q", r.Subtype)
 	}
 	if r.Name != "User" {
 		t.Errorf("expected Name=User, got %q", r.Name)
+	}
+	if !fieldNames["User.ID"] || !fieldNames["User.Name"] {
+		t.Errorf("expected User.ID and User.Name field entities, got %v", fieldNames)
 	}
 }
 
@@ -324,17 +338,20 @@ func NewConfig(host string, port int) *Config {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	results = stripFileEntity(results)
-	if len(results) != 2 {
-		t.Fatalf("expected 2 entities (struct + function), got %d", len(results))
+	// Issue #4850 — Config struct now also emits a SCOPE.Schema/field entity
+	// per field (Host, Port): struct Component + 2 fields + NewConfig func.
+	if len(results) != 4 {
+		t.Fatalf("expected 4 entities (struct + 2 fields + function), got %d", len(results))
 	}
 
 	kinds := map[string]bool{}
 	for _, r := range results {
 		kinds[r.Kind] = true
 	}
-	// Config struct must emit SCOPE.Component; NewConfig emits SCOPE.Operation.
-	if !kinds["SCOPE.Component"] || !kinds["SCOPE.Operation"] {
-		t.Errorf("expected both SCOPE.Component and SCOPE.Operation, got kinds: %v", kinds)
+	// Config struct must emit SCOPE.Component; NewConfig emits SCOPE.Operation;
+	// the struct fields emit SCOPE.Schema.
+	if !kinds["SCOPE.Component"] || !kinds["SCOPE.Operation"] || !kinds["SCOPE.Schema"] {
+		t.Errorf("expected SCOPE.Component, SCOPE.Operation and SCOPE.Schema, got kinds: %v", kinds)
 	}
 }
 

--- a/internal/extractors/golang/issue4850_struct_field_membership_test.go
+++ b/internal/extractors/golang/issue4850_struct_field_membership_test.go
@@ -1,0 +1,189 @@
+// Package golang — issue #4850 struct field-membership (CONTAINS) tests.
+//
+// Root cause: Go struct fields were only consumed for DEPENDS_ON edges and
+// call-dispatch stamping; they were never emitted as graph entities, and the
+// attachClassContains loop linked SCOPE.Operation methods only. So a Go DTO
+// struct resolved to a SCOPE.Component with ZERO field children, the dashboard
+// shape endpoint returned rows:[] and classHasFieldChildren was false — the
+// same gap #4845/#4851 closed for JS/TS DTOs.
+//
+// After #4850 every named struct field gets a SCOPE.Schema/field entity AND a
+// struct→field CONTAINS edge (via BuildSchemaFieldStructuralRef), and embedded
+// fields emit an EXTENDS edge to the in-file base struct so the shape walker
+// recurses into promoted fields.
+package golang_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// goFieldEntityExists reports whether a SCOPE.Schema/field entity named
+// "<struct>.<field>" was emitted.
+func goFieldEntityExists(ents []types.EntityRecord, structName, field string) bool {
+	want := structName + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+// goHasContainsField reports whether the struct Component named structName
+// carries a CONTAINS edge to the SCOPE.Schema/field structural-ref for
+// "<struct>.<field>".
+func goHasContainsField(ents []types.EntityRecord, path, structName, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("go", path, structName+"."+field)
+	for _, e := range ents {
+		if e.Name != structName || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// goHasExtends reports whether the struct Component named structName carries an
+// EXTENDS edge to base.
+func goHasExtends(ents []types.EntityRecord, structName, base string) bool {
+	for _, e := range ents {
+		if e.Name != structName || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "EXTENDS" && r.ToID == base {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestStructFieldsAreContained proves a Go DTO struct with ≥2 named fields
+// (including grouped `A, B int` and tagged fields) emits one SCOPE.Schema/field
+// entity per field AND a struct→field CONTAINS edge for each.
+func TestStructFieldsAreContained(t *testing.T) {
+	path := "dto/create_user.go"
+	src := `package dto
+
+type CreateUserRequest struct {
+	Name     string ` + "`json:\"name\"`" + `
+	Email    string ` + "`json:\"email\"`" + `
+	Age      int
+	Verified bool
+	internal string ` + "`json:\"-\"`" + `
+}
+`
+	ents := extractRecords(t, src, path)
+
+	// json-tagged fields use the wire name; untagged fields keep the Go name.
+	for _, f := range []string{"name", "email", "Age", "Verified"} {
+		if !goFieldEntityExists(ents, "CreateUserRequest", f) {
+			t.Errorf("expected SCOPE.Schema/field entity CreateUserRequest.%s", f)
+		}
+		if !goHasContainsField(ents, path, "CreateUserRequest", f) {
+			t.Errorf("expected CONTAINS edge from struct to field %q", f)
+		}
+	}
+	// json:"-" fields are excluded from the wire shape (parity with custom DTO
+	// field members), so no entity for the bare Go name either.
+	if goFieldEntityExists(ents, "CreateUserRequest", "internal") {
+		t.Errorf("json:\"-\" field must be excluded from field membership")
+	}
+}
+
+// TestStructGroupedFieldsAreContained proves grouped same-type fields
+// (`X, Y int`) each get their own field entity + CONTAINS edge.
+func TestStructGroupedFieldsAreContained(t *testing.T) {
+	path := "geo/point.go"
+	src := `package geo
+
+type Point struct {
+	X, Y int
+}
+`
+	ents := extractRecords(t, src, path)
+	for _, f := range []string{"X", "Y"} {
+		if !goFieldEntityExists(ents, "Point", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Point.%s", f)
+		}
+		if !goHasContainsField(ents, path, "Point", f) {
+			t.Errorf("expected CONTAINS edge from Point to field %q", f)
+		}
+	}
+}
+
+// TestStructNestedAnonymousNotMisattributed proves a field whose type is a
+// nested anonymous struct contributes only the OUTER field, not the inner
+// struct's fields (membership must not leak across nesting).
+func TestStructNestedAnonymousNotMisattributed(t *testing.T) {
+	path := "model/envelope.go"
+	src := `package model
+
+type Envelope struct {
+	Meta struct {
+		Total int
+	}
+	OK bool
+}
+`
+	ents := extractRecords(t, src, path)
+	if !goHasContainsField(ents, path, "Envelope", "Meta") {
+		t.Errorf("expected CONTAINS edge from Envelope to field Meta")
+	}
+	if !goHasContainsField(ents, path, "Envelope", "OK") {
+		t.Errorf("expected CONTAINS edge from Envelope to field OK")
+	}
+	// The inner anonymous struct's "Total" must NOT be a field of Envelope.
+	if goFieldEntityExists(ents, "Envelope", "Total") {
+		t.Errorf("nested anonymous struct field Total must not be an Envelope member")
+	}
+}
+
+// TestStructEmbeddedFieldEmitsExtends proves an embedded (anonymous) field of
+// an in-file base struct emits an EXTENDS edge to the base (so the shape walker
+// recurses into promoted fields) and NOT a bogus field entity.
+func TestStructEmbeddedFieldEmitsExtends(t *testing.T) {
+	path := "model/user.go"
+	src := `package model
+
+type Base struct {
+	ID        string
+	CreatedAt int64
+}
+
+type User struct {
+	Base
+	Username string
+}
+`
+	ents := extractRecords(t, src, path)
+
+	// Base's own fields are contained.
+	for _, f := range []string{"ID", "CreatedAt"} {
+		if !goFieldEntityExists(ents, "Base", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Base.%s", f)
+		}
+		if !goHasContainsField(ents, path, "Base", f) {
+			t.Errorf("expected CONTAINS edge from Base to field %q", f)
+		}
+	}
+	// User's own field is contained.
+	if !goHasContainsField(ents, path, "User", "Username") {
+		t.Errorf("expected CONTAINS edge from User to field Username")
+	}
+	// User embeds Base → EXTENDS, and Base must NOT be a field entity of User.
+	if !goHasExtends(ents, "User", "Base") {
+		t.Errorf("expected EXTENDS edge from User to embedded Base")
+	}
+	if goFieldEntityExists(ents, "User", "Base") {
+		t.Errorf("embedded Base must not be emitted as a User field entity")
+	}
+}

--- a/internal/extractors/golang/struct_fields.go
+++ b/internal/extractors/golang/struct_fields.go
@@ -1,0 +1,229 @@
+package golang
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractStructFieldEntities returns one SCOPE.Schema/field EntityRecord per
+// named field of the struct named ownerName, plus EXTENDS RelationshipRecords
+// (returned as the second result, to be attached to the OWNER struct record)
+// for each embedded/anonymous field.
+//
+// Issue #4850 — before this pass Go struct fields were only consumed for
+// DEPENDS_ON edges (extractStructFieldDependencies) and call-dispatch stamping
+// (collectStructFieldTypes); they were never emitted as graph entities. A Go
+// DTO/struct therefore resolved to a SCOPE.Component with ZERO field children,
+// so the dashboard shape endpoint returned rows:[] and classHasFieldChildren
+// was false — exactly the gap #4845/#4851 closed for JS/TS DTOs.
+//
+// Field entity shape mirrors the Java (#690), Python (#689), Kotlin and Scala
+// field-membership emitters so the shared dashboard shape walker
+// (internal/dashboard/shape_tree.go) parses them uniformly:
+//
+//	Kind       = "SCOPE.Schema"
+//	Subtype    = "field"
+//	Name       = "<Struct>.<field>"          (dotted, file-scoped resolver key)
+//	Signature  = "<type> <field>"            (parseFieldSignature contract)
+//
+// The CONTAINS edge from the struct to each field entity is emitted later by
+// attachClassContains via extractor.BuildSchemaFieldStructuralRef, keyed on the
+// same dotted Name + file path.
+//
+// Embedded fields:
+//
+//	type Base struct { ID string }
+//	type User struct { Base; Name string }   // Base is embedded (promoted)
+//
+// An embedded field has a type but no field_identifier. We model it as an
+// EXTENDS edge from the embedding struct to the embedded type (mirroring the
+// JS/TS `extends Base` handling in heritage.go), so the shape walker recurses
+// into the base struct's fields (cycle-guarded, subclass fields shadow
+// inherited). Only embedded types declared in this file (knownTypeNames) get
+// an EXTENDS edge, keeping the graph conservative — package-external embeds
+// resolve cross-file is out of scope for this pass.
+func extractStructFieldEntities(
+	typeBody *sitter.Node,
+	src []byte,
+	ownerName, filePath string,
+	knownTypeNames map[string]bool,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if typeBody == nil || ownerName == "" {
+		return nil, nil
+	}
+
+	var fields []types.EntityRecord
+	var extends []types.RelationshipRecord
+	seenField := make(map[string]bool)
+	seenExtends := make(map[string]bool)
+
+	for _, field := range topLevelFieldDeclarations(typeBody) {
+		typeNode := field.ChildByFieldName("type")
+		if typeNode == nil {
+			continue
+		}
+		typeText := nodeText(typeNode, src)
+		if typeText == "" {
+			continue
+		}
+		startLine, endLine := nodeLines(field)
+
+		// Collect every leading identifier before the type and the optional
+		// struct tag. A field_declaration carries either field_identifier(s)
+		// (`A, B int` → two fields sharing one type) or no name node at all
+		// (embedded/anonymous field). The trailing raw_string_literal is the
+		// `json:"..." validate:"..."` tag, if present.
+		var names []string
+		var tag string
+		for k := 0; k < int(field.ChildCount()); k++ {
+			ch := field.Child(k)
+			switch ch.Type() {
+			case "field_identifier":
+				names = append(names, nodeText(ch, src))
+			case "raw_string_literal", "interpreted_string_literal":
+				tag = strings.Trim(nodeText(ch, src), "`\"")
+			}
+		}
+		jsonName, jsonSkip := goJSONWireName(tag)
+
+		if len(names) == 0 {
+			// Embedded/anonymous field — model as EXTENDS to the embedded
+			// type if it is declared in this file.
+			base := innermostTypeName(typeText)
+			if base != "" && base != ownerName && knownTypeNames[base] && !seenExtends[base] {
+				seenExtends[base] = true
+				extends = append(extends, types.RelationshipRecord{
+					FromID: ownerName,
+					ToID:   base,
+					Kind:   "EXTENDS",
+				})
+			}
+			continue
+		}
+
+		for _, fname := range names {
+			if fname == "" {
+				continue
+			}
+			// Wire name: prefer the json tag name (matching the endpoint-bound
+			// DTO field members emitted by internal/custom/golang so the two
+			// passes dedup by Name in MergeWithCustom and the richer custom
+			// entity wins). Only single-name fields carry a meaningful tag.
+			wire := fname
+			if len(names) == 1 {
+				if jsonSkip {
+					continue // json:"-" — excluded from the wire shape
+				}
+				if jsonName != "" {
+					wire = jsonName
+				}
+			}
+			if wire == "" || seenField[wire] {
+				continue
+			}
+			seenField[wire] = true
+			dotted := ownerName + "." + wire
+			fields = append(fields, types.EntityRecord{
+				Name:               dotted,
+				QualifiedName:      dotted,
+				Kind:               "SCOPE.Schema",
+				Subtype:            "field",
+				SourceFile:         filePath,
+				StartLine:          startLine,
+				EndLine:            endLine,
+				Language:           "go",
+				Signature:          typeText + " " + wire,
+				QualityScore:       1.0,
+				Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
+				EnrichmentRequired: false,
+			})
+		}
+	}
+
+	return fields, extends
+}
+
+// goJSONWireName parses a raw struct tag (e.g. `json:"name,omitempty" validate:"required"`)
+// and returns the json wire name and whether the field is json-excluded
+// (`json:"-"`). It mirrors the wire-name logic in internal/custom/golang so the
+// primary-pass field entity Name matches the endpoint-bound DTO field member and
+// the two dedup in MergeWithCustom. Returns ("", false) when there is no json
+// tag or only a bare `json:"...,opts"` with an empty name part (keep Go name).
+func goJSONWireName(tag string) (name string, skip bool) {
+	const key = "json:"
+	i := strings.Index(tag, key)
+	if i < 0 {
+		return "", false
+	}
+	rest := tag[i+len(key):]
+	// The value is quoted: json:"<value>".
+	if len(rest) == 0 || rest[0] != '"' {
+		return "", false
+	}
+	rest = rest[1:]
+	if j := strings.IndexByte(rest, '"'); j >= 0 {
+		rest = rest[:j]
+	}
+	first := rest
+	if c := strings.IndexByte(rest, ','); c >= 0 {
+		first = rest[:c]
+	}
+	if first == "-" {
+		return "", true
+	}
+	return first, false
+}
+
+// topLevelFieldDeclarations returns the field_declaration nodes that are DIRECT
+// members of the struct (children of its field_declaration_list), NOT the
+// fields of a nested anonymous struct type (`Inner struct { ... }`). A naive
+// recursive findAll would mis-attribute nested-struct fields to the outer
+// struct; iterating only the immediate field_declaration_list children keeps
+// membership correct.
+func topLevelFieldDeclarations(structType *sitter.Node) []*sitter.Node {
+	var list *sitter.Node
+	for i := 0; i < int(structType.ChildCount()); i++ {
+		if c := structType.Child(i); c.Type() == "field_declaration_list" {
+			list = c
+			break
+		}
+	}
+	if list == nil {
+		return nil
+	}
+	var out []*sitter.Node
+	for i := 0; i < int(list.ChildCount()); i++ {
+		if c := list.Child(i); c.Type() == "field_declaration" {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// innermostTypeName strips Go pointer / qualifier decoration from an embedded
+// field's verbatim type text to recover the bare type name used as the
+// intra-file EXTENDS target. `*Base` → "Base"; `pkg.Base` → "" (package-
+// external, not an intra-file embed we can resolve); `Base` → "Base".
+func innermostTypeName(typeText string) string {
+	t := typeText
+	for len(t) > 0 && (t[0] == '*' || t[0] == ' ') {
+		t = t[1:]
+	}
+	// A package-qualified embed (pkg.Base) is cross-package; we only emit
+	// EXTENDS for intra-file base types, so reject any dotted form.
+	for i := 0; i < len(t); i++ {
+		c := t[i]
+		if c == '.' {
+			return ""
+		}
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') || c == '_') {
+			// Generic/array/map decoration — not a bare embedded named type.
+			return ""
+		}
+	}
+	return t
+}


### PR DESCRIPTION
## What
Closes #4850. Completes the all-matrix DTO/struct field-membership coverage started in #4845/#4851. The dashboard shape-tree (and MCP /shape) can only expand an object's fields when its class/struct entity emits its members as `SCOPE.Schema`/`field` entities AND a class->field `CONTAINS` edge to each. This PR lands the **Go** general-primary-pass fix (the headline) and audits every other language honestly.

## Per-language verdict

| Language | Verdict | Detail |
|---|---|---|
| **Go** | **was BROKEN -> FIXED** | Struct fields were never emitted as entities (only DEPENDS_ON + call-dispatch); `attachClassContains` linked methods only. Now every struct's named members get a field entity + struct->field CONTAINS. |
| Java | confirmed FINE | general primary pass emits field + CONTAINS (existing tests green) |
| Python | confirmed FINE | `extractClassFields` + CONTAINS (existing tests green) |
| Kotlin | confirmed FINE | `buildProperty`/primary-ctor fields + CONTAINS (existing tests green) |
| Scala | confirmed FINE | case-class fields + CONTAINS (existing tests green) |
| COBOL | confirmed FINE | record fields + CONTAINS (existing tests green) |
| JS/TS | already fixed | #4851 |
| **C#** | **deferred -> #4854** | primary pass has no field entities (methods-only CONTAINS); only endpoint/DataAnnotations DTOs covered via `custom/csharp/dto_field_members.go` |
| **PHP** | **deferred -> #4854** | no field entities; methods-only |
| **Ruby** | **deferred -> #4854** | no field entities; methods-only (serializer/validation custom only) |
| **Rust** | **deferred -> #4854** | struct fields in Properties only, not entities; methods-only (utoipa/validation custom only) |
| **Swift** | **deferred -> #4854** | no field entities; methods-only |
| **C/C++** | **deferred -> #4854** | no field entities; methods-only (nlohmann/protobuf custom only) |

The 6 deferred languages have **only framework/endpoint-gated** field members (the #4715/#4613/#4635 custom emitters), which fire solely for DTOs bound to an HTTP endpoint or a specific serializer/validation lib — NOT general data classes. Their **general primary-pass** field membership is genuinely unmodeled, so per the standing rule they are filed honestly as **#4854** rather than faked.

## The Go fix (`internal/extractors/golang/struct_fields.go`)
- `extractStructFieldEntities` emits one `SCOPE.Schema`/`field` entity per named struct member — Name `<Struct>.<field>`, Signature `<type> <field>` (the `parseFieldSignature` contract the dashboard shape walker already uses for Java/Python/etc).
- **json-tag wire name** preferred (e.g. `Name string \`json:"name"\`` -> `Struct.name`), and `json:"-"` excluded — so field Names align with the endpoint-bound DTO field members from #4715 and `MergeWithCustom` dedups them (the richer custom entity wins on framework-bound DTOs).
- **Embedded/anonymous fields** -> `EXTENDS` edge to the in-file base struct (mirrors JS/TS `heritage.go`) so the shape walker recurses into promoted fields; the embed is NOT emitted as a bogus field.
- **Nested anonymous struct** fields are not mis-attributed (iterates the top-level `field_declaration_list`, not recursive `findAll`).
- `attachClassContains` now also emits struct->field `CONTAINS` via `BuildSchemaFieldStructuralRef` (existing-but-broken capability extended — not a new Kind).

## Fixtures
- `internal/extractors/golang/issue4850_struct_field_membership_test.go`: fields contained (incl. grouped `A, B int`); json wire name + `json:"-"` exclusion; embedded->EXTENDS with base own-fields contained; nested-anonymous isolation.
- Updated `TestExtractStruct` / `TestExtractFunctionAndStruct` entity counts for the new field entities.
- Spot-confirmed Java/Python/Kotlin/Scala/COBOL suites pass (the "FINE" claims).

## Coverage docs
`docs/coverage/registry.json` Go `Validation/dto_extraction` cells note the new general primary-pass capability and cite `struct_fields.go` + the test. `coverage fmt --check` canonical, `coverage validate` ok. (Existing-but-broken capability extended for Go + new doc note; the 6 deferred langs gain no cell.)

## Gates (all pass)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/... ./internal/dashboard/... ./internal/types/`.

Deploy-deferred.