### PR TITLE
fix(#4856): TS interface + type-alias field membership (response DTOs expand)

### DIFF
--- a/internal/dashboard/shape_tree_test.go
+++ b/internal/dashboard/shape_tree_test.go
@@ -502,3 +502,128 @@ func TestShape_PlainExtendsMergesOwnAndInheritedFields(t *testing.T) {
 		}
 	}
 }
+
+// nestInterfaceResponseFixture models a NestJS response DTO declared as a
+// TypeScript `interface` (SCOPE.Schema/interface owner) that extends a base
+// interface — the #4856 shape. AlternateAddressResponse owns one field and
+// inherits one from BaseResponse via EXTENDS.
+func nestInterfaceResponseFixture() *DashGroup {
+	const file = "src/address/dto/alternate-address-response.dto.ts"
+	entities := []graph.Entity{
+		{
+			ID: "iface_base", Name: "BaseResponse",
+			Kind: "SCOPE.Schema", Subtype: "interface",
+			SourceFile: file, Language: "typescript",
+		},
+		{
+			ID: "fld_base_id", Name: "BaseResponse.id",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: file, Language: "typescript", Signature: "id: string",
+		},
+		{
+			ID: "iface_resp", Name: "AlternateAddressResponse",
+			Kind: "SCOPE.Schema", Subtype: "interface",
+			SourceFile: file, Language: "typescript",
+		},
+		{
+			ID: "fld_resp_line1", Name: "AlternateAddressResponse.line1",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: file, Language: "typescript", Signature: "line1: string",
+		},
+		// An object-shaped type alias owner, to prove it expands too.
+		{
+			ID: "alias_pet", Name: "Pet",
+			Kind: "SCOPE.Schema", Subtype: "type_alias",
+			SourceFile: file, Language: "typescript",
+		},
+		{
+			ID: "fld_pet_name", Name: "Pet.name",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: file, Language: "typescript", Signature: "name: string",
+		},
+	}
+	rels := []graph.Relationship{
+		{FromID: "iface_base", ToID: "fld_base_id", Kind: "CONTAINS"},
+		{FromID: "iface_resp", ToID: "fld_resp_line1", Kind: "CONTAINS"},
+		{FromID: "iface_resp", ToID: "iface_base", Kind: "EXTENDS",
+			Properties: map[string]string{"to": "BaseResponse"}},
+		{FromID: "alias_pet", ToID: "fld_pet_name", Kind: "CONTAINS"},
+	}
+	return makePathsTestGroup(entities, rels)
+}
+
+// TestShape_InterfaceResponseExpandsWithInheritedFields proves #4856's dashboard
+// side: a NestJS response DTO declared as an `interface` returns non-empty shape
+// rows for both its own field and the field inherited via EXTENDS, and reports
+// has_children=true. This is the upvate-v3 AlternateAddressResponse case that
+// previously returned rows:[] / has_children=None.
+func TestShape_InterfaceResponseExpandsWithInheritedFields(t *testing.T) {
+	grp := nestInterfaceResponseFixture()
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/shape?type=AlternateAddressResponse")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool            `json:"ok"`
+		Data v2ShapeResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data.Rows) == 0 {
+		t.Fatal("interface response DTO returned empty shape rows (the #4856 bug)")
+	}
+	names := map[string]bool{}
+	for _, r := range body.Data.Rows {
+		names[r.Name] = true
+	}
+	if !names["line1"] {
+		t.Errorf("interface DTO should expose its own field line1, got rows=%+v", body.Data.Rows)
+	}
+	if !names["id"] {
+		t.Errorf("interface DTO should inherit base field id via EXTENDS, got rows=%+v", body.Data.Rows)
+	}
+
+	resolved := findClassEntityByName(grp, "AlternateAddressResponse")
+	if resolved == nil {
+		t.Fatal("AlternateAddressResponse interface not resolved")
+	}
+	if !classHasFieldChildren(grp, resolved) {
+		t.Error("interface response DTO must report has_children=true")
+	}
+}
+
+// TestShape_TypeAliasObjectExpands proves an object-shaped type alias renders
+// its field rows in the dashboard shape endpoint.
+func TestShape_TypeAliasObjectExpands(t *testing.T) {
+	grp := nestInterfaceResponseFixture()
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/shape?type=Pet")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		OK   bool            `json:"ok"`
+		Data v2ShapeResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	names := map[string]bool{}
+	for _, r := range body.Data.Rows {
+		names[r.Name] = true
+	}
+	if !names["name"] {
+		t.Errorf("object type alias Pet should expose field name, got rows=%+v", body.Data.Rows)
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -1343,34 +1343,39 @@ func (x *extractor) handleInterfaceDeclaration(n *sitter.Node) {
 		props["extends"] = strings.Join(extendsList, ", ")
 	}
 
-	// Body fields: collect property_signature and method_signature names
+	// Body fields: collect property_signature names for the summary property,
+	// and (issue #4856) emit one SCOPE.Schema/field child entity per member
+	// plus an interface→field CONTAINS edge so the dashboard shape endpoint
+	// projects the interface's field-set. Mirrors the class fix (#4845):
+	// without these edges a NestJS response DTO declared as an `interface`
+	// (e.g. AlternateAddressResponse) resolves to a field-less node and the
+	// Response panel shows no expand glyph.
 	var fields []string
+	var fieldRels []types.RelationshipRecord
 	if body := n.ChildByFieldName("body"); body != nil {
-		for i := 0; i < int(body.ChildCount()); i++ {
-			member := body.Child(i)
-			if member == nil {
-				continue
-			}
-			switch member.Type() {
-			case "property_signature", "method_signature", "index_signature":
-				if fn := member.ChildByFieldName("name"); fn != nil {
-					fields = append(fields, x.nodeText(fn))
-				}
-			}
-		}
+		fields, fieldRels = x.emitSchemaMemberFields(body, name)
 	}
 	if len(fields) > 0 {
 		props["fields"] = strings.Join(fields, ", ")
 	}
 
-	// Build EXTENDS edges for each base interface
+	// Build EXTENDS edges for each base interface. The Properties["to"]/["from"]
+	// shape mirrors the class heritage edges (#4322) so the dashboard shape
+	// walker's extendsBaseEntities resolver can bind the bare base name and
+	// project inherited members (the walker recurses EXTENDS, #4845).
 	var rels []types.RelationshipRecord
 	for _, base := range extendsList {
 		rels = append(rels, types.RelationshipRecord{
 			ToID: base,
 			Kind: "EXTENDS",
+			Properties: map[string]string{
+				"subtype": "extends",
+				"from":    name,
+				"to":      base,
+			},
 		})
 	}
+	rels = append(rels, fieldRels...)
 
 	sig := fmt.Sprintf("interface %s", name)
 	if len(generics) > 0 {
@@ -1435,11 +1440,25 @@ func (x *extractor) handleTypeAliasDeclaration(n *sitter.Node) {
 		props["generics"] = strings.Join(generics, ", ")
 	}
 
-	// RHS type body — capture raw text for union/intersection visibility
+	// RHS type body — capture raw text for union/intersection visibility.
+	// Issue #4856 — when the RHS is an object type literal
+	// (`type X = { a: string; b?: number }`) emit one SCOPE.Schema/field
+	// child entity per member plus an alias→field CONTAINS edge, so an
+	// object-shaped type-alias DTO expands in the dashboard exactly like a
+	// class/interface DTO. Non-object RHS (unions, primitives, mapped types)
+	// carries no member fields and is left as-is.
+	var fieldRels []types.RelationshipRecord
 	if valueNode := n.ChildByFieldName("value"); valueNode != nil {
 		body := x.nodeText(valueNode)
 		if body != "" && len(body) <= 512 {
 			props["type_body"] = body
+		}
+		if valueNode.Type() == "object_type" {
+			var fields []string
+			fields, fieldRels = x.emitSchemaMemberFields(valueNode, name)
+			if len(fields) > 0 {
+				props["fields"] = strings.Join(fields, ", ")
+			}
 		}
 	}
 
@@ -1462,6 +1481,7 @@ func (x *extractor) handleTypeAliasDeclaration(n *sitter.Node) {
 		Properties:       props,
 		EnrichmentStatus: types.StatusPending,
 		QualityScore:     1.0,
+		Relationships:    fieldRels,
 	}
 	e.ID = e.ComputeID()
 	x.entities = append(x.entities, e)
@@ -1469,6 +1489,97 @@ func (x *extractor) handleTypeAliasDeclaration(n *sitter.Node) {
 	// A string/number literal-union alias (`type Role = 'admin' | 'user'`) is an
 	// enumerated value-set; emit a SCOPE.Enum node alongside (data-model #3628).
 	x.emitTSLiteralUnionValueSet(n, name)
+}
+
+// emitSchemaMemberFields walks the body of an interface (interface_body) or
+// object type literal (object_type) and, for each property member, emits a
+// SCOPE.Schema/field child entity named "<owner>.<field>" and returns a
+// CONTAINS structural-ref edge for it. It mirrors the class field-membership
+// fix (#4845): the class path emits "<Class>.<field>" SCOPE.Schema/field
+// entities in handlePublicFieldDefinition and a CONTAINS edge keyed by
+// BuildSchemaFieldStructuralRef; interfaces and object-type aliases go through
+// a different AST path (property_signature, not public_field_definition) and so
+// emitted no field children — leaving NestJS response DTOs that are declared as
+// `interface` (or `type X = {...}`) with rows:[] in the dashboard shape
+// endpoint (#4856).
+//
+// It returns the ordered list of member field names (for the owner's "fields"
+// summary property) and the owner→field CONTAINS relationships (the caller is
+// responsible for attaching them to the owner entity's Relationships, since the
+// owner record is constructed inline rather than via x.emit).
+//
+// Member handling:
+//   - property_signature (`name: Type`, optional `?`, `readonly`) → field child.
+//   - method_signature   (`greet(): void`) → field child (named like the method;
+//     callers that want behaviour can still read the body text, but a member is
+//     a member — modelling it as a field keeps the shape complete and avoids a
+//     crash). Type annotation, when present, is captured in the signature.
+//   - index_signature (`[key: string]: any`) and call/construct signatures have
+//     no member name and are skipped (gracefully, no crash) — they describe the
+//     container, not an addressable field.
+func (x *extractor) emitSchemaMemberFields(body *sitter.Node, owner string) ([]string, []types.RelationshipRecord) {
+	if body == nil || owner == "" {
+		return nil, nil
+	}
+	var fields []string
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+	for i := 0; i < int(body.ChildCount()); i++ {
+		member := body.Child(i)
+		if member == nil {
+			continue
+		}
+		switch member.Type() {
+		case "property_signature", "method_signature":
+			// Both expose the member name via the "name" field
+			// (property_identifier). index_signature / call_signature /
+			// construct_signature have no "name" field and fall through.
+		default:
+			continue
+		}
+		fn := member.ChildByFieldName("name")
+		if fn == nil {
+			continue
+		}
+		fieldName := x.nodeText(fn)
+		if fieldName == "" || seen[fieldName] {
+			continue
+		}
+		seen[fieldName] = true
+		fields = append(fields, fieldName)
+
+		// Signature mirrors the class field convention ("name: type"), with an
+		// optional-marker "?" when the property_signature carries one, so the
+		// dashboard parses type / nullability identically to class DTO fields.
+		sig := fieldName
+		optional := false
+		for j := 0; j < int(member.ChildCount()); j++ {
+			if ch := member.Child(j); ch != nil && ch.Type() == "?" {
+				optional = true
+				break
+			}
+		}
+		if optional {
+			sig += "?"
+		}
+		if typeNode := member.ChildByFieldName("type"); typeNode != nil {
+			// type_annotation text includes the leading ": " — fold it in.
+			ann := strings.TrimSpace(x.nodeText(typeNode))
+			ann = strings.TrimPrefix(ann, ":")
+			ann = strings.TrimSpace(ann)
+			if ann != "" {
+				sig += ": " + ann
+			}
+		}
+
+		emittedName := owner + "." + fieldName
+		x.emit(emittedName, "SCOPE.Schema", member, "field", sig)
+		rels = append(rels, types.RelationshipRecord{
+			ToID: extreg.BuildSchemaFieldStructuralRef(x.language, x.filePath, emittedName),
+			Kind: "CONTAINS",
+		})
+	}
+	return fields, rels
 }
 
 // handleEnumDeclaration handles TypeScript enum declarations: enum Direction { Up, Down }

--- a/internal/extractors/javascript/issue4856_interface_field_membership_test.go
+++ b/internal/extractors/javascript/issue4856_interface_field_membership_test.go
@@ -1,0 +1,172 @@
+// Package javascript — issue #4856 TS interface + type-alias field-membership.
+//
+// Follow-up to #4845 (which fixed only `class`). LIVE root cause (upvate-v3):
+// a NestJS response DTO declared as `export interface AlternateAddressResponse`
+// resolved to a field-less node — the dashboard shape endpoint returned
+// rows:[] / has_children=None — because interface_declaration and
+// type_alias_declaration go through a different AST path (property_signature,
+// not public_field_definition) and emitted NO SCOPE.Schema/field child
+// entities nor owner→field CONTAINS edges. Class-based responses already
+// expanded after #4845.
+//
+// After #4856:
+//   - interface_declaration members (property/method signatures) each get a
+//     SCOPE.Schema/field entity + interface→field CONTAINS edge.
+//   - type_alias_declaration with an object-type RHS (`type X = {a; b}`) gets
+//     the same field children + alias→field CONTAINS edges.
+//   - interface `extends` edges carry Properties["to"]/["from"] so the
+//     dashboard shape walker resolves the base and projects inherited members.
+package javascript_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// hasSchemaContainsField reports whether the SCOPE.Schema owner named `owner`
+// carries a CONTAINS edge to the field structural-ref for `<owner>.<field>`.
+// Mirrors hasContainsField (#4845) but matches the SCOPE.Schema owner kind
+// used for interfaces and type aliases.
+func hasSchemaContainsField(ents []types.EntityRecord, path, owner, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("typescript", path, owner+"."+field)
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Schema" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestInterfaceDTO_FieldsAreContained proves a NestJS response interface emits
+// one SCOPE.Schema/field entity per property AND an interface→field CONTAINS
+// edge for each — the exact gap that left shape rows empty for interface DTOs.
+func TestInterfaceDTO_FieldsAreContained(t *testing.T) {
+	path := "src/address/dto/alternate-address-response.dto.ts"
+	src := []byte(`
+export interface AlternateAddressResponse {
+  readonly line1: string;
+  street?: string;
+  count: number;
+  greet(): void;
+  [key: string]: any;
+}
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	for _, f := range []string{"line1", "street", "count", "greet"} {
+		if !fieldEntityExists(ents, "AlternateAddressResponse", f) {
+			t.Errorf("expected SCOPE.Schema/field entity AlternateAddressResponse.%s", f)
+		}
+		if !hasSchemaContainsField(ents, path, "AlternateAddressResponse", f) {
+			t.Errorf("expected CONTAINS edge from interface to field %q", f)
+		}
+	}
+	// Index signature has no member name → must be skipped gracefully (no crash,
+	// no bogus field entity).
+	if fieldEntityExists(ents, "AlternateAddressResponse", "key") {
+		t.Error("index signature must not produce a field entity")
+	}
+}
+
+// TestInterfaceExtends_CarriesResolvableBase proves interface `extends` emits an
+// EXTENDS edge whose Properties["to"] carries the base name, so the dashboard
+// shape walker can resolve the base and project inherited members. An interface
+// can extend multiple bases.
+func TestInterfaceExtends_CarriesResolvableBase(t *testing.T) {
+	path := "src/address/dto/extended-response.dto.ts"
+	src := []byte(`
+export interface BaseResponse {
+  id: string;
+}
+export interface AuditResponse {
+  createdAt: string;
+}
+export interface AlternateAddressResponse extends BaseResponse, AuditResponse {
+  line1: string;
+}
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	// Own field is contained.
+	if !hasSchemaContainsField(ents, path, "AlternateAddressResponse", "line1") {
+		t.Error("AlternateAddressResponse should CONTAINS its own field line1")
+	}
+	// Base fields are contained by their own interfaces.
+	if !hasSchemaContainsField(ents, path, "BaseResponse", "id") {
+		t.Error("BaseResponse should CONTAINS field id")
+	}
+	if !hasSchemaContainsField(ents, path, "AuditResponse", "createdAt") {
+		t.Error("AuditResponse should CONTAINS field createdAt")
+	}
+	// EXTENDS edges to BOTH bases, with the resolvable name in Properties["to"]
+	// (the SCOPE.Schema-owner shape the dashboard's relTargetName reads).
+	for _, base := range []string{"BaseResponse", "AuditResponse"} {
+		if !hasResolvableExtends(ents, "AlternateAddressResponse", base) {
+			t.Errorf("AlternateAddressResponse should EXTENDS %s with Properties[\"to\"]=%q", base, base)
+		}
+	}
+}
+
+// hasResolvableExtends reports whether the entity `from` has an EXTENDS edge
+// carrying Properties["to"]==to (the shape the dashboard's relTargetName reads).
+func hasResolvableExtends(ents []types.EntityRecord, from, to string) bool {
+	for _, e := range ents {
+		if e.Name != from {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "EXTENDS" && r.ToID == to &&
+				r.Properties != nil && r.Properties["to"] == to {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestTypeAliasObjectDTO_FieldsAreContained proves an object-shaped type alias
+// (`type X = { a: string; b?: number }`) emits field children + CONTAINS edges
+// exactly like a class/interface DTO.
+func TestTypeAliasObjectDTO_FieldsAreContained(t *testing.T) {
+	path := "src/address/dto/pet.dto.ts"
+	src := []byte(`
+export type Pet = {
+  name: string;
+  age?: number;
+};
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	for _, f := range []string{"name", "age"} {
+		if !fieldEntityExists(ents, "Pet", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Pet.%s", f)
+		}
+		if !hasSchemaContainsField(ents, path, "Pet", f) {
+			t.Errorf("expected CONTAINS edge from type alias to field %q", f)
+		}
+	}
+}
+
+// TestTypeAliasNonObject_NoFields guards the negative case: a union / primitive
+// alias has no object members and must emit NO field children.
+func TestTypeAliasNonObject_NoFields(t *testing.T) {
+	path := "src/address/dto/role.dto.ts"
+	src := []byte(`
+export type Role = 'admin' | 'user';
+export type Id = string;
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" {
+			t.Errorf("non-object type alias must not emit field entity %q", e.Name)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #4845 (which fixed only `class`). Completes JS/TS DTO expandability.

## Root cause (live, upvate-v3)
A NestJS response DTO declared as `export interface AlternateAddressResponse` resolved to a field-less node — the dashboard shape endpoint returned `rows:[]` / `has_children=None`. `interface_declaration` and `type_alias_declaration` go through a different AST path (`property_signature`, not `public_field_definition`) and emitted **no** `SCOPE.Schema/field` child entities nor owner→field `CONTAINS` edges. Class-based responses (EquipmentTypeResponse) already expanded after #4845.

## AST paths added (`internal/extractors/javascript/extractor.go`)
- **New `emitSchemaMemberFields` helper** — walks an `interface_body` / `object_type` body; per `property_signature`/`method_signature` emits a `SCOPE.Schema/field` entity named `<owner>.<field>` (sig `name[?]: type`, mirroring the class convention) + an owner→field `CONTAINS` edge via the **same** `BuildSchemaFieldStructuralRef` helper #4845 used for classes (so `MergeWithCustom` dedup + shape tree just work).
- **`interface_declaration`** — attaches field children + `CONTAINS`; interface `extends` edges now carry `Properties["to"]/["from"]` (the #4322 class-heritage shape) so the dashboard `extendsBaseEntities` resolver binds the base and projects inherited members. Handles multiple `extends` bases.
- **`type_alias_declaration`** — when RHS is an `object_type` literal (`type X = { a; b }`), emits the same field children + `CONTAINS`. Non-object RHS (unions, primitives, mapped types) left as-is / no children.
- Index/call/construct signatures (no member name) are skipped gracefully (no crash, no bogus field).

No dashboard code change: the shape walker (`shape_tree.go`) already resolves `SCOPE.Schema` owners, walks `CONTAINS` to fields, and recurses `EXTENDS` (#4845) — it only needed the extractor to emit the edges.

## Generics handling / deferral
`PagedResponse<T>` / `interface Foo<T> { items: T[] }` do **not** regress — member fields (`items`) are still contained and expand. Resolving the concrete `T` to a class entity for *nested* expansion is **deferred** (stretch goal noted in #4856).

## Fixture / tests
- `issue4856_interface_field_membership_test.go`: interface fields contained; index signature skipped; multi-base interface `extends` carries resolvable base; object type-alias fields contained; non-object alias has no fields.
- `shape_tree_test.go`: interface response DTO returns non-empty rows incl. the `EXTENDS`-inherited field + `has_children=true` (the upvate-v3 AlternateAddressResponse case); object type-alias expands.

## Gates
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/javascript/... ./internal/dashboard/... ./internal/types/` — all pass.

## Capability
Foundational extractor fix completing JS/TS DTO field-membership — same class as #4845, which touched no coverage docs. No registry.json / coverage-doc change.

Deploy-deferred. Closes #4856. Completes JS/TS DTO expandability with #4845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)