### PR TITLE
fix(#4858 frontend): ShapeTree tree indentation + field type/optional in Params/Response

### DIFF
--- a/webui-v2/src/components/ShapeTree.tsx
+++ b/webui-v2/src/components/ShapeTree.tsx
@@ -22,10 +22,15 @@
    site reimplementing the expansion logic.
    ============================================================ */
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useShape } from "@/hooks/use-paths";
+import {
+  indentForDepth,
+  fieldTypeLabel,
+  fieldOptionality,
+} from "@/lib/shape-tree-indent";
 
 /**
  * A top-level row consumed by ShapeTree. Both PathParameter and
@@ -233,28 +238,30 @@ function NestedFieldRows({
   );
   if (isLoading) {
     return (
-      <div className="py-1 text-text-4" style={{ paddingLeft: depth * 16 + 16 }}>
-        loading…
-      </div>
+      <TreeGuide depth={depth}>
+        <div className="py-1 px-2 text-text-4">loading…</div>
+      </TreeGuide>
     );
   }
   if (isError) {
     return (
-      <div className="py-1 text-danger" style={{ paddingLeft: depth * 16 + 16 }}>
-        Failed to load: {(error as Error)?.message ?? "unknown"}
-      </div>
+      <TreeGuide depth={depth}>
+        <div className="py-1 px-2 text-danger">
+          Failed to load: {(error as Error)?.message ?? "unknown"}
+        </div>
+      </TreeGuide>
     );
   }
   const rows = data?.rows ?? [];
   if (rows.length === 0) {
     return (
-      <div className="py-1 text-text-4" style={{ paddingLeft: depth * 16 + 16 }}>
-        (no fields)
-      </div>
+      <TreeGuide depth={depth}>
+        <div className="py-1 px-2 text-text-4">(no fields)</div>
+      </TreeGuide>
     );
   }
   return (
-    <div>
+    <TreeGuide depth={depth}>
       {rows.map((field) => (
         <NestedFieldRow
           key={field.name}
@@ -263,6 +270,24 @@ function NestedFieldRows({
           depth={depth}
         />
       ))}
+    </TreeGuide>
+  );
+}
+
+/**
+ * Indents one nesting level and draws the vertical tree-guide rail so a
+ * field list reads as a hierarchy under its parent row rather than as a
+ * flat, left-aligned block (#4858). The left border is the rail; each
+ * child row paints its own horizontal "elbow" connector.
+ */
+function TreeGuide({ depth, children }: { depth: number; children: ReactNode }) {
+  return (
+    <div
+      data-testid="shape-tree-guide"
+      className="border-l border-border-soft"
+      style={{ marginLeft: indentForDepth(depth) + 4 }}
+    >
+      {children}
     </div>
   );
 }
@@ -278,11 +303,16 @@ function NestedFieldRow({
 }) {
   const [open, setOpen] = useState(false);
   const expandable = field.has_children;
+  const optional = !!field.nullable;
   return (
     <div>
       <div
+        data-testid={`shape-field-${field.name}`}
+        data-depth={depth}
         className={cn(
-          "flex items-start gap-2 py-1 border-b border-border-soft last:border-0",
+          "flex items-center gap-2 py-1 pl-3 pr-2 border-b border-border-soft last:border-0 min-w-0",
+          // horizontal elbow connecting the rail to the row content
+          "before:content-[''] before:w-2 before:h-px before:bg-border-soft before:shrink-0 before:-ml-3",
           expandable && "cursor-pointer hover:bg-surface-2/40",
         )}
         onClick={() => expandable && setOpen((v) => !v)}
@@ -295,16 +325,36 @@ function NestedFieldRow({
             setOpen((v) => !v);
           }
         }}
-        style={{ paddingLeft: depth * 16 }}
       >
         <ExpandGlyph expandable={expandable} open={open} />
-        <span className="font-mono text-text shrink-0">
-          {field.name}
-          {field.nullable && <span className="text-text-4 ml-0.5">?</span>}
+        <span className="font-mono text-text shrink-0">{field.name}</span>
+        <span
+          className={cn(
+            "font-mono shrink-0",
+            expandable
+              ? "text-accent underline decoration-dotted underline-offset-2"
+              : "text-text-3",
+          )}
+          title={expandable ? `${field.type} — click to expand fields` : field.type}
+        >
+          {fieldTypeLabel(field.type, field.nullable)}
         </span>
-        <span className="font-mono text-text-3 shrink-0">{field.type}</span>
+        <span
+          data-testid={`shape-field-optionality-${field.name}`}
+          className={cn(
+            "inline-flex items-center px-1 py-0.5 rounded-sm text-[10px] font-medium font-sans shrink-0",
+            optional
+              ? "bg-surface-2 text-text-4 border border-border"
+              : "bg-[var(--success-soft)] text-[var(--success)] border border-[var(--success-soft)]",
+          )}
+          title={fieldOptionality(field.nullable)}
+        >
+          {optional ? "optional" : "required"}
+        </span>
         {field.annotations && field.annotations.length > 0 && (
-          <span className="text-text-4 truncate">{field.annotations.join(" ")}</span>
+          <span className="text-text-4 truncate font-mono text-[11px]">
+            {field.annotations.join(" ")}
+          </span>
         )}
       </div>
       {open && expandable && (

--- a/webui-v2/src/lib/shape-tree-indent.test.ts
+++ b/webui-v2/src/lib/shape-tree-indent.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  SHAPE_INDENT_STEP,
+  indentForDepth,
+  fieldTypeLabel,
+  fieldOptionality,
+} from "./shape-tree-indent";
+
+describe("indentForDepth", () => {
+  it("returns 0 for the top level", () => {
+    expect(indentForDepth(0)).toBe(0);
+  });
+
+  it("indents one step per depth level", () => {
+    expect(indentForDepth(1)).toBe(SHAPE_INDENT_STEP);
+    expect(indentForDepth(2)).toBe(SHAPE_INDENT_STEP * 2);
+    expect(indentForDepth(3)).toBe(SHAPE_INDENT_STEP * 3);
+  });
+
+  it("clamps negative depths to 0", () => {
+    expect(indentForDepth(-5)).toBe(0);
+  });
+});
+
+describe("fieldTypeLabel", () => {
+  it("returns the bare type when required", () => {
+    expect(fieldTypeLabel("string", false)).toBe("string");
+    expect(fieldTypeLabel("string", undefined)).toBe("string");
+  });
+
+  it("annotates nullable types with | null", () => {
+    expect(fieldTypeLabel("number", true)).toBe("number | null");
+  });
+
+  it("does not double-annotate types that already advertise null", () => {
+    expect(fieldTypeLabel("string | null", true)).toBe("string | null");
+    expect(fieldTypeLabel("string?", true)).toBe("string?");
+  });
+
+  it("falls back to unknown when type is missing", () => {
+    expect(fieldTypeLabel(undefined, false)).toBe("unknown");
+    expect(fieldTypeLabel("  ", false)).toBe("unknown");
+  });
+});
+
+describe("fieldOptionality", () => {
+  it("maps nullable to optional/required", () => {
+    expect(fieldOptionality(true)).toBe("optional");
+    expect(fieldOptionality(false)).toBe("required");
+    expect(fieldOptionality(undefined)).toBe("required");
+  });
+});

--- a/webui-v2/src/lib/shape-tree-indent.ts
+++ b/webui-v2/src/lib/shape-tree-indent.ts
@@ -1,0 +1,40 @@
+/* ============================================================
+   lib/shape-tree-indent.ts — pure geometry + label helpers for
+   the ShapeTree component (#4858).
+
+   Expanding a DTO row reveals its fields, but prior to #4858 the
+   children rendered flat (no indentation/hierarchy) and showed no
+   type. These helpers centralise the depth→indent math and the
+   field type/optionality label logic so the rendering stays a
+   thin, testable layer and the visual contract is unit-checked
+   without a DOM.
+   ============================================================ */
+
+/** px of horizontal indent per nesting level. */
+export const SHAPE_INDENT_STEP = 16;
+
+/**
+ * Horizontal indent (in px) for a nested field row at the given depth.
+ * Top-level rows are depth 0; their direct fields are depth 1, etc.
+ */
+export function indentForDepth(depth: number): number {
+  return Math.max(0, depth) * SHAPE_INDENT_STEP;
+}
+
+/**
+ * Compact type token shown next to a field name, e.g. `string` or
+ * `number | null` for an optional/nullable field. Falls back to the
+ * bare type when no type string is available.
+ */
+export function fieldTypeLabel(type: string | undefined, nullable: boolean | undefined): string {
+  const base = (type ?? "").trim() || "unknown";
+  if (!nullable) return base;
+  // Don't double-annotate a type that already advertises nullability.
+  if (/\bnull\b/.test(base) || base.endsWith("?")) return base;
+  return `${base} | null`;
+}
+
+/** Optionality marker for a field — `optional` when nullable, else `required`. */
+export function fieldOptionality(nullable: boolean | undefined): "optional" | "required" {
+  return nullable ? "optional" : "required";
+}


### PR DESCRIPTION
## What

Frontend-only fix for the Params/Response **ShapeTree**. After #4845, expanding a DTO row (`body`) revealed its fields, but they rendered **flat / left-aligned** (visually disconnected from the parent) and showed **only the name, no type**.

This PR:
- **Tree indentation + guides:** each nesting level is wrapped in a `TreeGuide` that indents by depth and draws a subtle vertical rail (left border); every nested field row paints a horizontal elbow connector off that rail, so `body → address/building/group` (and deeper nested DTOs) read as a hierarchy.
- **Field type:** each field renders its `type` next to the name, with `| null` appended for nullable types (and no double-annotation when the type already advertises null). Expandable object types keep the accented dotted-underline affordance.
- **Optional / required indicator:** a compact chip (`optional` for nullable, `required` otherwise) consistent with the existing chip styling.
- Geometry + label logic extracted to `lib/shape-tree-indent.ts` and **unit tested** (`shape-tree-indent.test.ts`, 8 cases).

Expand/drill behavior, the per-status Response tabs, and the param `in` tone chips are unchanged.

## Scope

Visual-only, frontend-only. The **validations** part of #4858 (class-validator / Pydantic / Bean-Validation constraint extraction) is **backend** and is intentionally **not** touched here — it remains open as a backend follow-up.

## Gates
- `npx tsc --noEmit` — clean
- `npm run build` — passes
- `npx vitest run src/lib` — 93 passed (incl. 8 new)

Deploy-deferred. Partially addresses #4858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)