### PR TITLE
fix(#4857): undirected ego BFS so sink nodes (endpoints) show neighbors in focus view

### DIFF
--- a/webui-v2/src/lib/ego-bfs.test.ts
+++ b/webui-v2/src/lib/ego-bfs.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the undirected ego-subgraph BFS (lib/ego-bfs).
+ *
+ * #4857 — the regression these guard against: a directional (from → to) BFS
+ * from a SINK node (e.g. an HTTP endpoint, where handler `IMPLEMENTS →
+ * endpoint` and module `CONTAINS → endpoint` but the endpoint emits nothing)
+ * finds ZERO neighbors at any hop count. The undirected adjacency must reach
+ * those inbound neighbors.
+ *
+ * Run with: npx vitest run src/lib/ego-bfs.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import { buildUndirectedAdjacency, bfsEgo, type EgoEdge } from "./ego-bfs";
+
+// The canonical #4857 shape: `endpoint` is a pure sink — only inbound edges.
+const SINK_EDGES: EgoEdge[] = [
+  { source: "handler", target: "endpoint" }, // IMPLEMENTS
+  { source: "module", target: "endpoint" }, // CONTAINS
+];
+
+describe("buildUndirectedAdjacency", () => {
+  it("links both directions for every edge", () => {
+    const adj = buildUndirectedAdjacency(SINK_EDGES);
+    expect(adj.get("endpoint")).toEqual(new Set(["handler", "module"]));
+    expect(adj.get("handler")).toEqual(new Set(["endpoint"]));
+    expect(adj.get("module")).toEqual(new Set(["endpoint"]));
+  });
+
+  it("skips edges whose endpoints are not both in the allow-set", () => {
+    // `module` is NOT rendered → its CONTAINS edge is dropped, but the
+    // handler↔endpoint link survives.
+    const rendered = new Set(["endpoint", "handler"]);
+    const adj = buildUndirectedAdjacency(SINK_EDGES, rendered);
+    expect(adj.get("endpoint")).toEqual(new Set(["handler"]));
+    expect(adj.get("module")).toBeUndefined();
+  });
+});
+
+describe("bfsEgo (undirected)", () => {
+  it("reaches the inbound neighbors of a sink node (the #4857 bug)", () => {
+    const adj = buildUndirectedAdjacency(SINK_EDGES);
+    const ego = bfsEgo(adj, "endpoint", 1);
+    expect(ego).toEqual(new Set(["endpoint", "handler", "module"]));
+  });
+
+  it("a directional adjacency would have returned only the sink (regression contrast)", () => {
+    // Build a DIRECTIONAL adjacency to prove the old behaviour was broken.
+    const directional = new Map<string, Set<string>>();
+    for (const e of SINK_EDGES) {
+      if (!directional.has(e.source)) directional.set(e.source, new Set());
+      directional.get(e.source)!.add(e.target);
+    }
+    const ego = bfsEgo(directional, "endpoint", 6);
+    expect(ego).toEqual(new Set(["endpoint"])); // 0 neighbors even at 6 hops
+  });
+
+  it("expands outward N hops and stops early when the frontier is exhausted", () => {
+    const chain: EgoEdge[] = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+      { source: "c", target: "d" },
+    ];
+    const adj = buildUndirectedAdjacency(chain);
+    expect(bfsEgo(adj, "a", 1)).toEqual(new Set(["a", "b"]));
+    expect(bfsEgo(adj, "a", 2)).toEqual(new Set(["a", "b", "c"]));
+    // Undirected: from the middle node both sides are reachable.
+    expect(bfsEgo(adj, "c", 1)).toEqual(new Set(["b", "c", "d"]));
+    // More hops than the graph is deep → still terminates with the component.
+    expect(bfsEgo(adj, "a", 99)).toEqual(new Set(["a", "b", "c", "d"]));
+  });
+
+  it("returns just the root for an isolated node", () => {
+    const adj = buildUndirectedAdjacency(SINK_EDGES);
+    expect(bfsEgo(adj, "orphan", 3)).toEqual(new Set(["orphan"]));
+  });
+});

--- a/webui-v2/src/lib/ego-bfs.ts
+++ b/webui-v2/src/lib/ego-bfs.ts
@@ -1,0 +1,88 @@
+/* ============================================================
+   lib/ego-bfs.ts — undirected N-hop ego-subgraph BFS for the Graph screen.
+
+   #4857 — the click-to-focus ego view must reach a node's INBOUND neighbors,
+   not just outbound ones. HTTP endpoint nodes (http_endpoint_definition) are
+   pure SINKS: a handler `IMPLEMENTS → endpoint` and a module `CONTAINS →
+   endpoint`, while the endpoint itself emits no edges. A directional
+   (from → to) BFS from such a sink therefore finds ZERO neighbors at any hop
+   count, so the focus view shows just the single node even though the entity
+   API reports neighbors.
+
+   The fix: traverse edges UNDIRECTED. We build the adjacency from BOTH
+   `from → to` AND `to → from` so an ego BFS from a sink reaches its inbound
+   handler/module.
+
+   This lives in its own module (pure, dependency-free) so the BFS is unit
+   testable without mounting the React route.
+   ============================================================ */
+
+/** Minimal edge shape the BFS needs — a directed (source → target) pair. */
+export interface EgoEdge {
+  source: string;
+  target: string;
+}
+
+/**
+ * Build an UNDIRECTED adjacency map from a directed edge list.
+ *
+ * Every edge `a → b` contributes both `a ↔ b` so the ego BFS reaches inbound
+ * neighbors. Optionally restrict the adjacency to a `nodeIds` allow-set: edges
+ * whose endpoints are not both in the set are skipped, so the ego subgraph
+ * never reaches a node that is not in the rendered graph (e.g. a hub-pruned or
+ * min-degree-hidden node). When `nodeIds` is omitted, all edges are used.
+ *
+ * O(E) once; cheap to memoize against the edge set.
+ */
+export function buildUndirectedAdjacency(
+  edges: readonly EgoEdge[],
+  nodeIds?: ReadonlySet<string>,
+): Map<string, Set<string>> {
+  const m = new Map<string, Set<string>>();
+  const link = (a: string, b: string) => {
+    let s = m.get(a);
+    if (!s) {
+      s = new Set<string>();
+      m.set(a, s);
+    }
+    s.add(b);
+  };
+  for (const e of edges) {
+    if (nodeIds && (!nodeIds.has(e.source) || !nodeIds.has(e.target))) continue;
+    link(e.source, e.target);
+    link(e.target, e.source);
+  }
+  return m;
+}
+
+/**
+ * N-hop ego BFS over an undirected adjacency map.
+ *
+ * Returns the set of node ids within `hops` of `id` (inclusive of `id`).
+ * Because `adjacency` is undirected (see buildUndirectedAdjacency), sink nodes
+ * such as HTTP endpoints expand to their inbound handler/module neighbors.
+ */
+export function bfsEgo(
+  adjacency: Map<string, Set<string>>,
+  id: string,
+  hops: number,
+): Set<string> {
+  const set = new Set<string>([id]);
+  let frontier = [id];
+  for (let h = 0; h < hops; h++) {
+    const next: string[] = [];
+    for (const f of frontier) {
+      const nbrs = adjacency.get(f);
+      if (!nbrs) continue;
+      for (const nb of nbrs) {
+        if (!set.has(nb)) {
+          set.add(nb);
+          next.push(nb);
+        }
+      }
+    }
+    if (next.length === 0) break;
+    frontier = next;
+  }
+  return set;
+}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -39,6 +39,7 @@ import { MCPActivityOverlay } from "@/components/graph/mcp-activity-overlay";
 import { GraphJarvisOverlay } from "@/components/graph/graph-jarvis-overlay";
 import { useGraphHighlight } from "@/hooks/use-graph-highlight";
 import { useGraphJarvisReplay } from "@/hooks/use-graph-jarvis-replay";
+import { buildUndirectedAdjacency, bfsEgo as bfsEgoOver } from "@/lib/ego-bfs";
 
 /**
  * #1386 — derive the entity-level "module key" from a node's source file.
@@ -367,39 +368,35 @@ export default function GraphScreen() {
     return nodes.filter((n) => n.label.toLowerCase().includes(q));
   }, [nodes, s.search]);
 
-  // Click-to-focus N-hop ego-graph (1 hop).
-  const adjacency = useMemo(() => {
-    const m = new Map<string, Set<string>>();
-    for (const e of edges) {
-      if (!m.has(e.source)) m.set(e.source, new Set());
-      if (!m.has(e.target)) m.set(e.target, new Set());
-      m.get(e.source)!.add(e.target);
-      m.get(e.target)!.add(e.source);
-    }
-    return m;
-  }, [edges]);
+  // Click-to-focus N-hop ego-graph.
+  //
+  // #4857 — the ego adjacency MUST be undirected AND built from the FULL edge
+  // set, restricted to the rendered node ids. Two bugs hid inbound neighbors:
+  //   1. Sinks: HTTP endpoint nodes are pure sinks (handler `IMPLEMENTS →
+  //      endpoint`, module `CONTAINS → endpoint`; the endpoint emits nothing).
+  //      The adjacency below links both directions so an ego BFS from a sink
+  //      reaches its inbound handler/module — see lib/ego-bfs.
+  //   2. Filtered connectors: the rendered `edges` set is kind-filtered /
+  //      hub-pruned / min-degree-pruned. Building adjacency from the FULL
+  //      `data.edges` (intersected with the rendered node ids) means a focus
+  //      neighbor that IS rendered stays reachable even when the edge that
+  //      connects it was dropped from the global view. We never reach a node
+  //      that is not rendered (the nodeIds allow-set guarantees that).
+  const renderedNodeIds = useMemo(() => new Set(nodes.map((n) => n.id)), [nodes]);
+  const adjacency = useMemo(
+    () => buildUndirectedAdjacency(data?.edges ?? [], renderedNodeIds),
+    [data?.edges, renderedNodeIds],
+  );
 
   // Fix #1548-3 / #1564-4: focus builds a NEW ego sub-graph = the node +
-  // neighbors up to N hops (BFS over the edge set). We render ONLY that
-  // sub-graph (see `egoNodes`/`egoEdges` below) and fit the camera to it. N is
-  // the store's egoHops, driven LIVE by the hops slider in the focus banner.
-  const bfsEgo = (id: string, hops: number): Set<string> => {
-    const set = new Set<string>([id]);
-    let frontier = [id];
-    for (let h = 0; h < hops; h++) {
-      const next: string[] = [];
-      for (const f of frontier) {
-        for (const nb of adjacency.get(f) ?? []) {
-          if (!set.has(nb)) {
-            set.add(nb);
-            next.push(nb);
-          }
-        }
-      }
-      frontier = next;
-    }
-    return set;
-  };
+  // neighbors up to N hops (undirected BFS over the edge set). We render ONLY
+  // that sub-graph (see `egoNodes`/`egoEdges` below) and fit the camera to it.
+  // N is the store's egoHops, driven LIVE by the hops slider in the focus
+  // banner.
+  const bfsEgo = useCallback(
+    (id: string, hops: number): Set<string> => bfsEgoOver(adjacency, id, hops),
+    [adjacency],
+  );
   const focusEgo = (id: string) => {
     // Snapshot the current camera so EXIT can restore it exactly (#1548-3).
     canvasRef.current?.snapshotCamera();


### PR DESCRIPTION
## Problem
The graph click-to-focus **ego view** showed **zero neighbors** for HTTP endpoint nodes at any hop count, even though the entity API reports neighbors for them. Verified live: the entity API returns 2 neighbors for an endpoint, but focus rendered just the 1 node.

HTTP endpoint nodes (`http_endpoint_definition`) are pure **SINKS**: a handler `IMPLEMENTS → endpoint` and a module `CONTAINS → endpoint`, while the endpoint itself emits no edges.

## Root cause (two issues, both fixed)
1. **Directional reachability** — an ego walk that only follows `from → to` from a sink finds 0 neighbors. (The route's `adjacency` map was already undirected, but the BFS was not extracted/tested and the reachability story was fragile.)
2. **Filtered connectors** — the adjacency was built from the *rendered* `edges` set, which is kind-filtered / hub-pruned / min-degree-pruned. A focus neighbor that **is** rendered could become unreachable because the edge connecting it was dropped from the global view.

## Fix
- New pure, dependency-free `webui-v2/src/lib/ego-bfs.ts`:
  - `buildUndirectedAdjacency(edges, nodeIds?)` — links **both** `from→to` and `to→from`, optionally restricted to an allow-set of rendered node ids (skips any edge whose endpoints aren't both rendered).
  - `bfsEgo(adjacency, id, hops)` — N-hop BFS, terminates early when the frontier is exhausted.
- `routes/graph.tsx` now builds the ego adjacency **undirected from the FULL `data.edges`**, intersected with the rendered node-id set (`renderedNodeIds`). Endpoints now expand to their inbound handler/module in focus. We never reach a node that is not rendered (the allow-set guarantees it); the global graph's node/edge set is unchanged.

## Gates (frontend-only)
- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `npx vitest run` — **132 real unit tests pass** (incl. 6 new `ego-bfs` tests). The ~12 e2e Playwright `.spec.ts` files fail pre-existing/unrelated (Playwright-under-vitest harness mismatch).

No Go / daemon / registry / coverage changes. Visual-only, deploy-deferred.

Closes #4857.