### PR TITLE
fix(#4854): general primary-pass field membership for C#/PHP/Ruby/Rust/Swift/C/C++ (completes the matrix)

### DIFF
--- a/internal/extractors/cpp/extractor.go
+++ b/internal/extractors/cpp/extractor.go
@@ -131,6 +131,10 @@ func (e *CppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 	// may have been declared above or below the definition.
 	attachOutOfLineContains(&records, file.Path, lang)
 
+	// Issue #4854 — class→field CONTAINS + in-file base-class EXTENDS for the
+	// SCOPE.Schema/field members emitted in the structural walk.
+	records = attachCppFieldMembership(records, file.Path, lang)
+
 	// Issue #3628 — error-flow: scan throw / typed-catch sites and emit
 	// THROWS / CATCHES edges to a shared SCOPE.ExceptionType convergence node
 	// (records[0] is the file entity required by EmitExceptionEdges).
@@ -205,6 +209,28 @@ func walkStructural(n *sitter.Node, src []byte, path, lang, container string, ou
 						ToID: toID,
 						Kind: "CONTAINS",
 					})
+			}
+			// Issue #4854 — emit one SCOPE.Schema/field per data member so a
+			// plain C++ data class has field children (class→field CONTAINS is
+			// wired in a post-pass once every in-file type name is known).
+			fieldEnts := emitClassFieldMembers(body, src, rec.Name, path, lang)
+			*out = append(*out, fieldEnts...)
+		}
+		// Issue #4854 — stash candidate base-class names on the owner so the
+		// post-pass can emit EXTENDS edges restricted to bases declared in
+		// this same file (mirrors the Go embedded-field EXTENDS policy).
+		if bases := cppBaseClasses(n, src); len(bases) > 0 {
+			var baseNames []string
+			for _, b := range bases {
+				if nm, _ := b["name"].(string); nm != "" {
+					baseNames = append(baseNames, nm)
+				}
+			}
+			if len(baseNames) > 0 {
+				if (*out)[idx].Metadata == nil {
+					(*out)[idx].Metadata = map[string]interface{}{}
+				}
+				(*out)[idx].Metadata["base_candidates"] = baseNames
 			}
 		}
 		return

--- a/internal/extractors/cpp/issue4854_field_membership_test.go
+++ b/internal/extractors/cpp/issue4854_field_membership_test.go
@@ -1,0 +1,155 @@
+// Package cpp — issue #4854 general struct/class field-membership tests.
+//
+// Root cause: C/C++ data members were only stashed in the owner Component's
+// Metadata; they were never emitted as graph entities, so a plain C++ data
+// class resolved to a SCOPE.Component with ZERO field children and the
+// dashboard shape endpoint returned rows:[] — the same gap #4850/#4855 closed
+// for Go and #4845/#4851 for JS/TS.
+//
+// After #4854 every data member gets a SCOPE.Schema/field entity AND a
+// class→field CONTAINS edge (via BuildSchemaFieldStructuralRef), and a C++
+// base class declared in the same file emits an EXTENDS edge so the shape
+// walker recurses into inherited members.
+package cpp_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func cppFieldEntityExists(ents []types.EntityRecord, owner, field string) bool {
+	want := owner + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func cppHasContainsField(ents []types.EntityRecord, lang, path, owner, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef(lang, path, owner+"."+field)
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func cppHasExtends(ents []types.EntityRecord, owner, base string) bool {
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "EXTENDS" && r.ToID == base {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestCppDataClassFieldsAreContained proves a plain (non-ORM, non-endpoint)
+// C++ data class with several members — including pointer / array decorated
+// declarators and a multi-name declaration — emits one SCOPE.Schema/field
+// entity per member AND a class→field CONTAINS edge for each. Member functions
+// must NOT be emitted as fields.
+func TestCppDataClassFieldsAreContained(t *testing.T) {
+	path := "model/user.hpp"
+	src := `
+struct User {
+	int id;
+	std::string name;
+	double balance;
+	char* token;
+	int scores[8];
+	bool a, b;
+	void greet() { return; }
+};
+`
+	ents, err := extractCPP(src, path)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, f := range []string{"id", "name", "balance", "token", "scores", "a", "b"} {
+		if !cppFieldEntityExists(ents, "User", f) {
+			t.Errorf("expected SCOPE.Schema/field entity User.%s", f)
+		}
+		if !cppHasContainsField(ents, "cpp", path, "User", f) {
+			t.Errorf("expected CONTAINS edge from User to field %q", f)
+		}
+	}
+	if cppFieldEntityExists(ents, "User", "greet") {
+		t.Errorf("member function greet must not be a field entity")
+	}
+}
+
+// TestCppBaseClassEmitsExtends proves a derived class whose base is declared
+// in the same file emits an EXTENDS edge (so the shape walker recurses into
+// inherited fields) and that both classes carry their own field members.
+func TestCppBaseClassEmitsExtends(t *testing.T) {
+	path := "model/account.hpp"
+	src := `
+class Base {
+public:
+	int id;
+	long createdAt;
+};
+
+class Account : public Base {
+public:
+	std::string owner;
+};
+`
+	ents, err := extractCPP(src, path)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, f := range []string{"id", "createdAt"} {
+		if !cppFieldEntityExists(ents, "Base", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Base.%s", f)
+		}
+	}
+	if !cppFieldEntityExists(ents, "Account", "owner") {
+		t.Errorf("expected SCOPE.Schema/field entity Account.owner")
+	}
+	if !cppHasContainsField(ents, "cpp", path, "Account", "owner") {
+		t.Errorf("expected CONTAINS edge from Account to field owner")
+	}
+	if !cppHasExtends(ents, "Account", "Base") {
+		t.Errorf("expected EXTENDS edge from Account to in-file base Base")
+	}
+}
+
+// TestCFieldsAreContained proves the same field-membership works for a plain C
+// struct (language key "c").
+func TestCFieldsAreContained(t *testing.T) {
+	path := "model/point.h"
+	src := `
+struct Point {
+	int x;
+	int y;
+};
+`
+	ents, err := extractC(src, path)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, f := range []string{"x", "y"} {
+		if !cppFieldEntityExists(ents, "Point", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Point.%s", f)
+		}
+		if !cppHasContainsField(ents, "c", path, "Point", f) {
+			t.Errorf("expected CONTAINS edge from Point to field %q", f)
+		}
+	}
+}

--- a/internal/extractors/cpp/struct_fields.go
+++ b/internal/extractors/cpp/struct_fields.go
@@ -1,0 +1,237 @@
+package cpp
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitClassFieldMembers returns one SCOPE.Schema/field EntityRecord per data
+// member of the class/struct/union named ownerName, plus EXTENDS
+// RelationshipRecords (second result, to be attached to the OWNER component)
+// for each base class.
+//
+// Issue #4854 — before this pass C/C++ struct/class members were only stashed
+// in the owner Component's Metadata["fields"]; they were never emitted as graph
+// entities. A plain (non-ORM, non-endpoint-bound) C++ data class therefore
+// resolved to a SCOPE.Component with ZERO field children, so the dashboard
+// shape endpoint returned rows:[] and classHasFieldChildren was false — the
+// same gap #4850/#4851/#4855 closed for Go/JS-TS DTOs.
+//
+// The field entity shape mirrors the Go (#4855) / Java (#690) emitters so the
+// shared dashboard shape walker parses them uniformly:
+//
+//	Kind      = "SCOPE.Schema"
+//	Subtype   = "field"
+//	Name      = "<Owner>.<member>"   (dotted, file-scoped resolver key)
+//	Signature = "<type> <member>"
+//
+// The class→field CONTAINS edge is attached by the caller via
+// extractor.BuildSchemaFieldStructuralRef keyed on the same dotted Name + file.
+//
+// Member functions (field_declaration carrying a function_declarator) are NOT
+// fields and are excluded — cppMemberFieldName returns "" for them. A data
+// member whose declarator is wrapped in pointer/array/reference decoration
+// (`int* p;`, `char buf[8];`, `T& ref;`) still resolves to its inner
+// field_identifier.
+func emitClassFieldMembers(
+	body *sitter.Node,
+	src []byte,
+	ownerName, filePath, lang string,
+) []types.EntityRecord {
+	if body == nil || ownerName == "" {
+		return nil
+	}
+
+	var fields []types.EntityRecord
+	seen := make(map[string]bool)
+
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch.Type() != "field_declaration" {
+			continue
+		}
+		// A function_declarator child ⇒ inline method, not a data member.
+		if cppFirstChildOfType(ch, "function_declarator") != nil {
+			continue
+		}
+		typeNode := ch.ChildByFieldName("type")
+		typeText := ""
+		if typeNode != nil {
+			typeText = strings.TrimSpace(nodeText(typeNode, src))
+		}
+		// A field_declaration may declare several members sharing one type
+		// (`int a, b;`). Collect every field_identifier reachable through the
+		// declarator decoration.
+		for _, fname := range cppFieldNames(ch, src) {
+			fname = strings.TrimSpace(fname)
+			if fname == "" || seen[fname] {
+				continue
+			}
+			seen[fname] = true
+			startLine := int(ch.StartPoint().Row) + 1
+			endLine := int(ch.EndPoint().Row) + 1
+			dotted := ownerName + "." + fname
+			sig := fname
+			if typeText != "" {
+				sig = typeText + " " + fname
+			}
+			fields = append(fields, types.EntityRecord{
+				Name:               dotted,
+				QualifiedName:      dotted,
+				Kind:               "SCOPE.Schema",
+				Subtype:            "field",
+				SourceFile:         filePath,
+				StartLine:          startLine,
+				EndLine:            endLine,
+				Language:           lang,
+				Signature:          sig,
+				QualityScore:       1.0,
+				Properties: map[string]string{
+					"field_name":   fname,
+					"field_type":   typeText,
+					"parent_class": ownerName,
+				},
+				Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
+				EnrichmentRequired: false,
+			})
+		}
+	}
+
+	return fields
+}
+
+// cppFieldNames returns every member name declared by a field_declaration,
+// descending through pointer/array/reference declarator decoration to the
+// inner field_identifier(s). Returns nil for a member function declaration.
+func cppFieldNames(fieldDecl *sitter.Node, src []byte) []string {
+	var names []string
+	for i := 0; i < int(fieldDecl.ChildCount()); i++ {
+		ch := fieldDecl.Child(i)
+		switch ch.Type() {
+		case "field_identifier":
+			names = append(names, nodeText(ch, src))
+		case "pointer_declarator", "array_declarator", "reference_declarator",
+			"init_declarator":
+			if id := cppDescendantFieldIdentifier(ch); id != nil {
+				names = append(names, nodeText(id, src))
+			}
+		}
+	}
+	return names
+}
+
+// cppDescendantFieldIdentifier returns the first field_identifier reachable
+// from n (used to unwrap pointer/array/reference/init declarator decoration).
+func cppDescendantFieldIdentifier(n *sitter.Node) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Type() == "field_identifier" {
+		return n
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if r := cppDescendantFieldIdentifier(n.Child(i)); r != nil {
+			return r
+		}
+	}
+	return nil
+}
+
+// cppLeafTypeName strips template/namespace decoration from a base-class name
+// to the bare leaf identifier used as the intra-file EXTENDS target.
+// `ns::Base<T>` → "Base".
+func cppLeafTypeName(name string) string {
+	name = strings.TrimSpace(name)
+	if i := strings.IndexByte(name, '<'); i >= 0 {
+		name = strings.TrimSpace(name[:i])
+	}
+	if i := strings.LastIndex(name, "::"); i >= 0 {
+		name = name[i+2:]
+	}
+	return strings.TrimSpace(name)
+}
+
+// attachCppFieldMembership wires, in one post-walk pass:
+//
+//   - class→field CONTAINS edges for every SCOPE.Schema/field member emitted
+//     by emitClassFieldMembers (mirrors the Go #4855 attachClassContains field
+//     loop). Without this edge a C++ data class has zero field children and the
+//     dashboard shape tree returns rows:[].
+//   - class→base EXTENDS edges from each owner's stashed Metadata
+//     "base_candidates", restricted to base types declared in this same file so
+//     the shape walker can recurse into inherited members (mirrors the Go
+//     embedded-field EXTENDS policy).
+func attachCppFieldMembership(records []types.EntityRecord, filePath, lang string) []types.EntityRecord {
+	// In-file component name set (for conservative EXTENDS).
+	known := make(map[string]bool)
+	for i := range records {
+		if records[i].Kind == "SCOPE.Component" {
+			known[records[i].Name] = true
+		}
+	}
+
+	// Index components by name for edge attachment.
+	compIdx := make(map[string]int)
+	for i := range records {
+		if records[i].Kind == "SCOPE.Component" {
+			if _, dup := compIdx[records[i].Name]; !dup {
+				compIdx[records[i].Name] = i
+			}
+		}
+	}
+
+	hasEdge := func(rels []types.RelationshipRecord, toID, kind string) bool {
+		for _, ex := range rels {
+			if ex.ToID == toID && ex.Kind == kind {
+				return true
+			}
+		}
+		return false
+	}
+
+	// class→field CONTAINS.
+	for _, r := range records {
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		owner, _ := r.Metadata["owner"].(string)
+		i, ok := compIdx[owner]
+		if owner == "" || !ok {
+			continue
+		}
+		toID := extractor.BuildSchemaFieldStructuralRef(lang, filePath, r.Name)
+		if !hasEdge(records[i].Relationships, toID, "CONTAINS") {
+			records[i].Relationships = append(records[i].Relationships,
+				types.RelationshipRecord{ToID: toID, Kind: "CONTAINS"})
+		}
+	}
+
+	// class→base EXTENDS (in-file bases only).
+	for i := range records {
+		if records[i].Kind != "SCOPE.Component" || records[i].Metadata == nil {
+			continue
+		}
+		cands, _ := records[i].Metadata["base_candidates"].([]string)
+		if len(cands) == 0 {
+			continue
+		}
+		owner := records[i].Name
+		for _, raw := range cands {
+			base := cppLeafTypeName(raw)
+			if base == "" || base == owner || !known[base] {
+				continue
+			}
+			if !hasEdge(records[i].Relationships, base, "EXTENDS") {
+				records[i].Relationships = append(records[i].Relationships,
+					types.RelationshipRecord{FromID: owner, ToID: base, Kind: "EXTENDS"})
+			}
+		}
+		delete(records[i].Metadata, "base_candidates")
+	}
+
+	return records
+}

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -84,6 +84,8 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// THROWS / CATCHES edges to a shared SCOPE.ExceptionType node, matching the
 	// Java / Python / Go / JS flagship error_flow model.
 	emitExceptionFlowEdges(root, file.Content, &entities)
+	// Issue #4854 — in-file base-class EXTENDS for field-membership recursion.
+	entities = attachCsharpExtends(entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "csharp")
 	extractor.TagEntitiesLanguage(entities, "csharp")
@@ -176,6 +178,24 @@ func walk(
 						Kind: "CONTAINS",
 					})
 			}
+		}
+		// Issue #4854 — general field membership: one SCOPE.Schema/field per
+		// property / public field / record positional parameter, plus a
+		// class→field CONTAINS edge so a plain data class has field children
+		// (dedups by Name with the endpoint-bound DTO members in #4715).
+		fieldEnts, baseNames := emitFieldMembers(node, body, file.Content, rec.Name, file.Path)
+		for _, fe := range fieldEnts {
+			toID := extractor.BuildSchemaFieldStructuralRef("csharp", file.Path, fe.Name)
+			(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
+				types.RelationshipRecord{ToID: toID, Kind: "CONTAINS"})
+		}
+		*out = append(*out, fieldEnts...)
+		// Stash base-type candidates for the in-file EXTENDS post-pass.
+		if len(baseNames) > 0 {
+			if (*out)[classIdx].Metadata == nil {
+				(*out)[classIdx].Metadata = map[string]interface{}{}
+			}
+			(*out)[classIdx].Metadata["base_candidates"] = baseNames
 		}
 		return
 

--- a/internal/extractors/csharp/field_members.go
+++ b/internal/extractors/csharp/field_members.go
@@ -1,0 +1,199 @@
+package csharp
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitFieldMembers returns one SCOPE.Schema/field EntityRecord per property,
+// public field, and record positional parameter of the type named ownerName,
+// plus the bare base-type names declared in the type's base_list (for EXTENDS,
+// resolved against in-file types by the caller).
+//
+// Issue #4854 — before this pass C# class/record/struct members were consumed
+// for receiver resolution (collectFieldTypes) but only the endpoint/DTO-bound
+// subset emitted field entities (internal/custom/csharp/dto_field_members.go,
+// #4715). A plain data class therefore resolved to a SCOPE.Component with ZERO
+// field children, so the dashboard shape endpoint returned rows:[] — the same
+// gap #4850/#4855 closed for Go and #4845/#4851 for JS/TS.
+//
+// Field Name is "<Owner>.<Property>" (the C# member name, NOT a wire name) so
+// it dedups by Name against the custom DTO field members in MergeWithCustom —
+// the richer custom entity (validators, library, optionality) wins.
+//
+//	Kind      = "SCOPE.Schema"
+//	Subtype   = "field"
+//	Name      = "<Owner>.<member>"
+//	Signature = "<type> <member>"
+func emitFieldMembers(
+	node *sitter.Node,
+	body *sitter.Node,
+	src []byte,
+	ownerName, filePath string,
+) ([]types.EntityRecord, []string) {
+	if ownerName == "" {
+		return nil, nil
+	}
+
+	var fields []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, typ string, startNode *sitter.Node) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		startLine := int(startNode.StartPoint().Row) + 1
+		endLine := int(startNode.EndPoint().Row) + 1
+		dotted := ownerName + "." + name
+		sig := name
+		if typ != "" {
+			sig = typ + " " + name
+		}
+		fields = append(fields, types.EntityRecord{
+			Name:               dotted,
+			QualifiedName:      dotted,
+			Kind:               "SCOPE.Schema",
+			Subtype:            "field",
+			SourceFile:         filePath,
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Language:           "csharp",
+			Signature:          sig,
+			QualityScore:       1.0,
+			Properties: map[string]string{
+				"field_name":   name,
+				"field_type":   typ,
+				"parent_class": ownerName,
+			},
+			Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
+			EnrichmentRequired: false,
+		})
+	}
+
+	// Record positional parameters: `record Foo(int Id, string Name)`. The
+	// parameter_list is a direct child of the record_declaration node.
+	if node != nil && node.Type() == "record_declaration" {
+		if pl := findChildByType(node, "parameter_list"); pl != nil {
+			for i := 0; i < int(pl.ChildCount()); i++ {
+				p := pl.Child(i)
+				if p == nil || p.Type() != "parameter" {
+					continue
+				}
+				typ := leafTypeName(p.ChildByFieldName("type"), src)
+				name := childFieldText(p, "name", src)
+				add(name, typ, p)
+			}
+		}
+	}
+
+	if body != nil {
+		for i := 0; i < int(body.ChildCount()); i++ {
+			ch := body.Child(i)
+			if ch == nil {
+				continue
+			}
+			switch ch.Type() {
+			case "property_declaration":
+				typ := leafTypeName(ch.ChildByFieldName("type"), src)
+				name := childFieldText(ch, "name", src)
+				add(name, typ, ch)
+			case "field_declaration":
+				vd := findChildByType(ch, "variable_declaration")
+				if vd == nil {
+					continue
+				}
+				typ := leafTypeName(vd.ChildByFieldName("type"), src)
+				for j := 0; j < int(vd.ChildCount()); j++ {
+					d := vd.Child(j)
+					if d == nil || d.Type() != "variable_declarator" {
+						continue
+					}
+					name := childFieldText(d, "name", src)
+					if name == "" {
+						for k := 0; k < int(d.ChildCount()); k++ {
+							cc := d.Child(k)
+							if cc != nil && cc.Type() == "identifier" {
+								name = string(src[cc.StartByte():cc.EndByte()])
+								break
+							}
+						}
+					}
+					add(name, typ, ch)
+				}
+			}
+		}
+	}
+
+	return fields, csBaseTypeNames(node, src)
+}
+
+// csBaseTypeNames returns the bare base-type names from a class/record/struct
+// declaration's base_list (used for EXTENDS, restricted to in-file types by the
+// caller). C# does not distinguish base class from implemented interfaces in
+// the grammar's base_list, so we return all of them; the in-file filter keeps
+// only types we actually modeled.
+func csBaseTypeNames(node *sitter.Node, src []byte) []string {
+	if node == nil {
+		return nil
+	}
+	bl := findChildByType(node, "base_list")
+	if bl == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(bl.ChildCount()); i++ {
+		ch := bl.Child(i)
+		if ch == nil {
+			continue
+		}
+		if name := leafTypeName(ch, src); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// attachCsharpExtends emits class→base EXTENDS edges from each owner's stashed
+// Metadata "base_candidates", restricted to base types declared in this same
+// file so the dashboard shape walker can recurse into inherited members
+// (mirrors the Go embedded-field / cpp base-class EXTENDS policy). Interfaces
+// the class merely implements are dropped automatically — only in-file types we
+// actually modeled survive the filter.
+func attachCsharpExtends(records []types.EntityRecord) []types.EntityRecord {
+	known := make(map[string]bool)
+	for i := range records {
+		if records[i].Kind == "SCOPE.Component" {
+			known[records[i].Name] = true
+		}
+	}
+	for i := range records {
+		if records[i].Kind != "SCOPE.Component" || records[i].Metadata == nil {
+			continue
+		}
+		cands, _ := records[i].Metadata["base_candidates"].([]string)
+		if len(cands) == 0 {
+			continue
+		}
+		owner := records[i].Name
+		for _, base := range cands {
+			if base == "" || base == owner || !known[base] {
+				continue
+			}
+			dup := false
+			for _, ex := range records[i].Relationships {
+				if ex.Kind == "EXTENDS" && ex.ToID == base {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				records[i].Relationships = append(records[i].Relationships,
+					types.RelationshipRecord{FromID: owner, ToID: base, Kind: "EXTENDS"})
+			}
+		}
+		delete(records[i].Metadata, "base_candidates")
+	}
+	return records
+}

--- a/internal/extractors/csharp/issue4854_field_membership_test.go
+++ b/internal/extractors/csharp/issue4854_field_membership_test.go
@@ -1,0 +1,160 @@
+// Package csharp — issue #4854 general class/record/struct field-membership.
+//
+// Root cause: only the endpoint/DTO-bound subset of C# members emitted field
+// entities (internal/custom/csharp/dto_field_members.go, #4715). A plain data
+// class resolved to a SCOPE.Component with ZERO field children, so the
+// dashboard shape endpoint returned rows:[] — the same gap #4850/#4855 closed
+// for Go and #4845/#4851 for JS/TS.
+//
+// After #4854 every property / public field / record positional parameter gets
+// a SCOPE.Schema/field entity AND a class→field CONTAINS edge, and an in-file
+// base class emits an EXTENDS edge.
+package csharp_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func csExtract(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extreg.Get("csharp")
+	if !ok {
+		t.Fatal("csharp extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "csharp",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return got
+}
+
+func csFieldEntityExists(ents []types.EntityRecord, owner, field string) bool {
+	want := owner + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func csHasContainsField(ents []types.EntityRecord, path, owner, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("csharp", path, owner+"."+field)
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func csHasExtends(ents []types.EntityRecord, owner, base string) bool {
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "EXTENDS" && r.ToID == base {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestCsharpDataClassFieldsAreContained proves a plain (non-endpoint) C# data
+// class with auto-properties and a public field emits one SCOPE.Schema/field
+// entity per member AND a class→field CONTAINS edge for each.
+func TestCsharpDataClassFieldsAreContained(t *testing.T) {
+	path := "Models/User.cs"
+	src := `
+namespace App.Models
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public bool Active;
+        public void Touch() { }
+    }
+}
+`
+	ents := csExtract(t, src, path)
+	for _, f := range []string{"Id", "Name", "Active"} {
+		if !csFieldEntityExists(ents, "User", f) {
+			t.Errorf("expected SCOPE.Schema/field entity User.%s", f)
+		}
+		if !csHasContainsField(ents, path, "User", f) {
+			t.Errorf("expected CONTAINS edge from User to field %q", f)
+		}
+	}
+	if csFieldEntityExists(ents, "User", "Touch") {
+		t.Errorf("method Touch must not be a field entity")
+	}
+}
+
+// TestCsharpRecordPositionalParamsAreContained proves a positional record's
+// parameters become field members.
+func TestCsharpRecordPositionalParamsAreContained(t *testing.T) {
+	path := "Models/Point.cs"
+	src := `
+namespace App.Models
+{
+    public record Point(int X, int Y);
+}
+`
+	ents := csExtract(t, src, path)
+	for _, f := range []string{"X", "Y"} {
+		if !csFieldEntityExists(ents, "Point", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Point.%s", f)
+		}
+		if !csHasContainsField(ents, path, "Point", f) {
+			t.Errorf("expected CONTAINS edge from Point to field %q", f)
+		}
+	}
+}
+
+// TestCsharpBaseClassEmitsExtends proves an in-file base class emits an EXTENDS
+// edge while a merely-implemented interface does not.
+func TestCsharpBaseClassEmitsExtends(t *testing.T) {
+	path := "Models/Account.cs"
+	src := `
+namespace App.Models
+{
+    public class BaseEntity
+    {
+        public int Id { get; set; }
+    }
+
+    public class Account : BaseEntity
+    {
+        public string Owner { get; set; }
+    }
+}
+`
+	ents := csExtract(t, src, path)
+	if !csFieldEntityExists(ents, "BaseEntity", "Id") {
+		t.Errorf("expected SCOPE.Schema/field entity BaseEntity.Id")
+	}
+	if !csHasContainsField(ents, path, "Account", "Owner") {
+		t.Errorf("expected CONTAINS edge from Account to field Owner")
+	}
+	if !csHasExtends(ents, "Account", "BaseEntity") {
+		t.Errorf("expected EXTENDS edge from Account to in-file base BaseEntity")
+	}
+}

--- a/internal/extractors/php/field_members.go
+++ b/internal/extractors/php/field_members.go
@@ -1,0 +1,197 @@
+package php
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitPhpFieldMembers returns one SCOPE.Schema/field EntityRecord per typed
+// class property and per promoted constructor parameter of the class named
+// ownerName, plus the bare base-class name from the class's base_clause (for
+// EXTENDS, resolved against in-file types by the caller).
+//
+// Issue #4854 — before this pass PHP class properties were not emitted as field
+// entities outside the framework/ORM-bound custom emitters
+// (internal/custom/php, #4613). A plain PHP data class therefore resolved to a
+// SCOPE.Component with ZERO field children, so the dashboard shape endpoint
+// returned rows:[] — the same gap #4850/#4855 closed for Go and #4845/#4851
+// for JS/TS.
+//
+// Property/param Name is "<Owner>.<prop>" (the PHP member name with the leading
+// `$` stripped) so it dedups by Name in MergeWithCustom against the framework
+// DTO field members.
+//
+//	Kind      = "SCOPE.Schema"
+//	Subtype   = "field"
+//	Name      = "<Owner>.<member>"
+//	Signature = "<type> $<member>"
+func emitPhpFieldMembers(
+	node *sitter.Node,
+	body *sitter.Node,
+	src []byte,
+	ownerName, filePath string,
+) ([]types.EntityRecord, string) {
+	if ownerName == "" {
+		return nil, ""
+	}
+
+	var fields []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(name, typ string, at *sitter.Node) {
+		name = strings.TrimPrefix(name, "$")
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		startLine := int(at.StartPoint().Row) + 1
+		endLine := int(at.EndPoint().Row) + 1
+		dotted := ownerName + "." + name
+		sig := "$" + name
+		if typ != "" {
+			sig = typ + " $" + name
+		}
+		fields = append(fields, types.EntityRecord{
+			Name:               dotted,
+			QualifiedName:      dotted,
+			Kind:               "SCOPE.Schema",
+			Subtype:            "field",
+			SourceFile:         filePath,
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Language:           "php",
+			Signature:          sig,
+			QualityScore:       1.0,
+			Properties: map[string]string{
+				"field_name":   name,
+				"field_type":   typ,
+				"parent_class": ownerName,
+			},
+			Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
+			EnrichmentRequired: false,
+		})
+	}
+
+	if body != nil {
+		for i := 0; i < int(body.ChildCount()); i++ {
+			ch := body.Child(i)
+			if ch == nil {
+				continue
+			}
+			switch ch.Type() {
+			case "property_declaration":
+				typ := phpDeclaredType(ch, src)
+				for j := 0; j < int(ch.ChildCount()); j++ {
+					el := ch.Child(j)
+					if el == nil || el.Type() != "property_element" {
+						continue
+					}
+					if vn := findFirstChildOfType(el, "variable_name"); vn != nil {
+						add(phpVariableName(vn, src), typ, ch)
+					}
+				}
+			case "method_declaration":
+				// Constructor-promoted parameters: a formal_parameters child
+				// whose entries carry a visibility_modifier.
+				if !strings.EqualFold(childFieldText(ch, "name", src), "__construct") {
+					continue
+				}
+				fp := findFirstChildOfType(ch, "formal_parameters")
+				if fp == nil {
+					continue
+				}
+				for j := 0; j < int(fp.ChildCount()); j++ {
+					p := fp.Child(j)
+					if p == nil || p.Type() != "property_promotion_parameter" {
+						continue
+					}
+					typ := phpDeclaredType(p, src)
+					if vn := findFirstChildOfType(p, "variable_name"); vn != nil {
+						add(phpVariableName(vn, src), typ, p)
+					}
+				}
+			}
+		}
+	}
+
+	return fields, phpBaseClassName(node, src)
+}
+
+// phpVariableName returns the bare identifier of a variable_name node
+// (`$name` → "name").
+func phpVariableName(vn *sitter.Node, src []byte) string {
+	if id := findFirstChildOfType(vn, "name"); id != nil {
+		return string(src[id.StartByte():id.EndByte()])
+	}
+	return strings.TrimPrefix(string(src[vn.StartByte():vn.EndByte()]), "$")
+}
+
+// phpDeclaredType returns the textual type annotation that precedes the
+// property_element / variable_name in a property_declaration or
+// property_promotion_parameter. Returns "" for untyped members.
+func phpDeclaredType(n *sitter.Node, src []byte) string {
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		switch ch.Type() {
+		case "primitive_type", "named_type", "optional_type", "union_type",
+			"intersection_type", "type_list":
+			return strings.TrimSpace(string(src[ch.StartByte():ch.EndByte()]))
+		}
+	}
+	return ""
+}
+
+// phpBaseClassName returns the bare parent-class name from a class
+// declaration's base_clause (`class A extends B` → "B"), or "" for none.
+// Interfaces appear under class_interface_clause and are intentionally
+// excluded.
+func phpBaseClassName(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	bc := findFirstChildOfType(node, "base_clause")
+	if bc == nil {
+		return ""
+	}
+	if nm := findFirstChildOfType(bc, "name"); nm != nil {
+		return strings.TrimSpace(string(src[nm.StartByte():nm.EndByte()]))
+	}
+	return ""
+}
+
+// attachPhpExtends emits class→base EXTENDS edges from each owner's stashed
+// Metadata "base_candidate", restricted to base classes declared in this same
+// file so the dashboard shape walker can recurse into inherited members.
+func attachPhpExtends(records []types.EntityRecord) []types.EntityRecord {
+	known := make(map[string]bool)
+	for i := range records {
+		if records[i].Kind == "SCOPE.Component" {
+			known[records[i].Name] = true
+		}
+	}
+	for i := range records {
+		if records[i].Kind != "SCOPE.Component" || records[i].Metadata == nil {
+			continue
+		}
+		base, _ := records[i].Metadata["base_candidate"].(string)
+		owner := records[i].Name
+		if base != "" && base != owner && known[base] {
+			dup := false
+			for _, ex := range records[i].Relationships {
+				if ex.Kind == "EXTENDS" && ex.ToID == base {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				records[i].Relationships = append(records[i].Relationships,
+					types.RelationshipRecord{FromID: owner, ToID: base, Kind: "EXTENDS"})
+			}
+		}
+		delete(records[i].Metadata, "base_candidate")
+	}
+	return records
+}

--- a/internal/extractors/php/issue4854_field_membership_test.go
+++ b/internal/extractors/php/issue4854_field_membership_test.go
@@ -1,0 +1,142 @@
+// Package php — issue #4854 general class field-membership tests.
+//
+// Root cause: PHP class properties were only emitted as field entities by the
+// framework/ORM-bound custom emitters (internal/custom/php, #4613). A plain PHP
+// data class resolved to a SCOPE.Component with ZERO field children, so the
+// dashboard shape endpoint returned rows:[] — the same gap #4850/#4855 closed
+// for Go and #4845/#4851 for JS/TS.
+//
+// After #4854 every typed property + promoted constructor parameter gets a
+// SCOPE.Schema/field entity AND a class→field CONTAINS edge, and an in-file
+// parent class emits an EXTENDS edge.
+package php_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func phpExtract(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extreg.Get("php")
+	if !ok {
+		t.Fatal("php extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "php",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return got
+}
+
+func phpFieldEntityExists(ents []types.EntityRecord, owner, field string) bool {
+	want := owner + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func phpHasContainsField(ents []types.EntityRecord, path, owner, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("php", path, owner+"."+field)
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func phpHasExtends(ents []types.EntityRecord, owner, base string) bool {
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "EXTENDS" && r.ToID == base {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestPhpTypedPropertiesAndPromotedParamsAreContained proves a plain data class
+// with typed properties AND constructor-promoted params emits one
+// SCOPE.Schema/field entity per member AND a class→field CONTAINS edge.
+func TestPhpTypedPropertiesAndPromotedParamsAreContained(t *testing.T) {
+	path := "src/Model/User.php"
+	src := `<?php
+namespace App\Model;
+
+class User {
+    public int $id;
+    protected string $name = "x";
+    public ?float $balance;
+
+    public function __construct(public readonly string $email, private int $age) {}
+
+    public function greet(): void {}
+}
+`
+	ents := phpExtract(t, src, path)
+	for _, f := range []string{"id", "name", "balance", "email", "age"} {
+		if !phpFieldEntityExists(ents, "User", f) {
+			t.Errorf("expected SCOPE.Schema/field entity User.%s", f)
+		}
+		if !phpHasContainsField(ents, path, "User", f) {
+			t.Errorf("expected CONTAINS edge from User to field %q", f)
+		}
+	}
+	if phpFieldEntityExists(ents, "User", "greet") {
+		t.Errorf("method greet must not be a field entity")
+	}
+}
+
+// TestPhpBaseClassEmitsExtends proves an in-file parent class emits EXTENDS
+// while an implemented interface does not.
+func TestPhpBaseClassEmitsExtends(t *testing.T) {
+	path := "src/Model/Account.php"
+	src := `<?php
+namespace App\Model;
+
+interface Stringable {}
+
+class BaseEntity {
+    public int $id;
+}
+
+class Account extends BaseEntity implements Stringable {
+    public string $owner;
+}
+`
+	ents := phpExtract(t, src, path)
+	if !phpFieldEntityExists(ents, "BaseEntity", "id") {
+		t.Errorf("expected SCOPE.Schema/field entity BaseEntity.id")
+	}
+	if !phpHasContainsField(ents, path, "Account", "owner") {
+		t.Errorf("expected CONTAINS edge from Account to field owner")
+	}
+	if !phpHasExtends(ents, "Account", "BaseEntity") {
+		t.Errorf("expected EXTENDS edge from Account to in-file base BaseEntity")
+	}
+	if phpHasExtends(ents, "Account", "Stringable") {
+		t.Errorf("implemented interface Stringable must not be an EXTENDS target")
+	}
+}

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -98,6 +98,8 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// `function test_x()` methods are already mined by walk() (named methods), so
 	// this pass touches only the anonymous-closure case (no double-emit).
 	emitPHPTestScopeOwner(root, file, &entities)
+	// Issue #4854 — in-file base-class EXTENDS for field-membership recursion.
+	entities = attachPhpExtends(entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")
 	extractor.TagEntitiesLanguage(entities, "php")
@@ -152,6 +154,23 @@ func walk(node *sitter.Node, file extractor.FileInput, parentClass string, out *
 						Kind: "CONTAINS",
 					})
 			}
+		}
+		// Issue #4854 — general field membership: one SCOPE.Schema/field per
+		// typed property + promoted constructor param, plus a class→field
+		// CONTAINS edge so a plain data class has field children (dedups by
+		// Name with the framework DTO members in #4613).
+		fieldEnts, baseName := emitPhpFieldMembers(node, body, file.Content, className, file.Path)
+		for _, fe := range fieldEnts {
+			toID := extractor.BuildSchemaFieldStructuralRef("php", file.Path, fe.Name)
+			(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
+				types.RelationshipRecord{ToID: toID, Kind: "CONTAINS"})
+		}
+		*out = append(*out, fieldEnts...)
+		if baseName != "" {
+			if (*out)[classIdx].Metadata == nil {
+				(*out)[classIdx].Metadata = map[string]interface{}{}
+			}
+			(*out)[classIdx].Metadata["base_candidate"] = baseName
 		}
 		return
 

--- a/internal/extractors/ruby/field_members.go
+++ b/internal/extractors/ruby/field_members.go
@@ -1,0 +1,225 @@
+package ruby
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitRubyAttrFields returns one SCOPE.Schema/field EntityRecord per symbol
+// declared by an attr_accessor / attr_reader / attr_writer call directly inside
+// the body of the class named ownerName, plus a class→field CONTAINS edge
+// attached to the owner at ownerIdx.
+//
+// Issue #4854 — Ruby has no static field declarations; the declaratively
+// present members of a plain data class are its attr_* accessors (and
+// Struct.new / Data.define members, handled separately). Before this pass those
+// were only surfaced by the framework-bound custom validation emitter
+// (internal/custom/ruby/validation.go) as orphan SCOPE.Schema/dto_field nodes
+// with no CONTAINS edge, so a plain Ruby model resolved to a SCOPE.Component
+// with ZERO field children and the dashboard shape endpoint returned rows:[].
+//
+//	Kind      = "SCOPE.Schema"
+//	Subtype   = "field"
+//	Name      = "<Owner>.<attr>"
+//	Signature = "attr <attr>"
+func emitRubyAttrFields(
+	records *[]types.EntityRecord,
+	ownerIdx int,
+	body *sitter.Node,
+	src []byte,
+	ownerName, filePath string,
+) {
+	if body == nil || ownerName == "" {
+		return
+	}
+	seen := make(map[string]bool)
+	for i := 0; i < int(body.ChildCount()); i++ {
+		call := body.Child(i)
+		if call == nil || call.Type() != "call" {
+			continue
+		}
+		mname := rubyCallIdentifier(call, src)
+		if mname != "attr_accessor" && mname != "attr_reader" && mname != "attr_writer" {
+			continue
+		}
+		for _, sym := range rubyCallSymbolArgs(call, src) {
+			if sym == "" || seen[sym] {
+				continue
+			}
+			seen[sym] = true
+			fe := rubyFieldEntity(ownerName, sym, "attr", filePath, call)
+			toID := extractor.BuildSchemaFieldStructuralRef("ruby", filePath, fe.Name)
+			(*records)[ownerIdx].Relationships = append((*records)[ownerIdx].Relationships,
+				types.RelationshipRecord{ToID: toID, Kind: "CONTAINS"})
+			*records = append(*records, fe)
+		}
+	}
+}
+
+// emitRubyStructDefine handles a top-level / nested `Const = Struct.new(:a, :b)`
+// or `Const = Data.define(:a, :b)` assignment: it synthesises a SCOPE.Component
+// (subtype "struct") named after the constant and one SCOPE.Schema/field per
+// member, with class→field CONTAINS edges, mirroring the data-class shape the
+// shape walker expects. Returns nil when the assignment is not a Struct.new /
+// Data.define form.
+func emitRubyStructDefine(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+	if node == nil || node.Type() != "assignment" {
+		return nil
+	}
+	// LHS constant name.
+	lhs := node.ChildByFieldName("left")
+	if lhs == nil || lhs.Type() != "constant" {
+		return nil
+	}
+	name := nodeText(lhs, file.Content)
+	// RHS call: Struct.new(...) / Data.define(...).
+	rhs := node.ChildByFieldName("right")
+	if rhs == nil || rhs.Type() != "call" {
+		return nil
+	}
+	recv := rhs.ChildByFieldName("receiver")
+	meth := rubyCallIdentifier(rhs, file.Content)
+	if recv == nil {
+		return nil
+	}
+	recvName := nodeText(recv, file.Content)
+	if !((recvName == "Struct" && meth == "new") || (recvName == "Data" && meth == "define")) {
+		return nil
+	}
+	syms := rubyCallSymbolArgs(rhs, file.Content)
+	if name == "" || len(syms) == 0 {
+		return nil
+	}
+
+	comp := types.EntityRecord{
+		Name:               name,
+		QualifiedName:      name,
+		Kind:               "SCOPE.Component",
+		Subtype:            "struct",
+		SourceFile:         file.Path,
+		StartLine:          int(node.StartPoint().Row) + 1,
+		EndLine:            int(node.EndPoint().Row) + 1,
+		Language:           "ruby",
+		Signature:          name + " = " + recvName + "." + meth,
+		EnrichmentRequired: false,
+	}
+	out := []types.EntityRecord{comp}
+	seen := make(map[string]bool)
+	for _, sym := range syms {
+		if sym == "" || seen[sym] {
+			continue
+		}
+		seen[sym] = true
+		fe := rubyFieldEntity(name, sym, recvName, file.Path, node)
+		toID := extractor.BuildSchemaFieldStructuralRef("ruby", file.Path, fe.Name)
+		out[0].Relationships = append(out[0].Relationships,
+			types.RelationshipRecord{ToID: toID, Kind: "CONTAINS"})
+		out = append(out, fe)
+	}
+	return out
+}
+
+// rubyFieldEntity builds a SCOPE.Schema/field entity for member `field` of
+// owner `owner`, positioned at `at`.
+func rubyFieldEntity(owner, field, source, filePath string, at *sitter.Node) types.EntityRecord {
+	dotted := owner + "." + field
+	return types.EntityRecord{
+		Name:               dotted,
+		QualifiedName:      dotted,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "field",
+		SourceFile:         filePath,
+		StartLine:          int(at.StartPoint().Row) + 1,
+		EndLine:            int(at.EndPoint().Row) + 1,
+		Language:           "ruby",
+		Signature:          source + " " + field,
+		QualityScore:       1.0,
+		Properties: map[string]string{
+			"field_name":   field,
+			"parent_class": owner,
+			"source":       source,
+		},
+		Metadata:           map[string]interface{}{"subtype": "field", "owner": owner},
+		EnrichmentRequired: false,
+	}
+}
+
+// rubyCallIdentifier returns the bare method name of a `call` node, whether it
+// carries an explicit "method" field (receiver.method form) or a leading
+// identifier child (bare attr_accessor form).
+func rubyCallIdentifier(call *sitter.Node, src []byte) string {
+	if m := call.ChildByFieldName("method"); m != nil {
+		return nodeText(m, src)
+	}
+	for i := 0; i < int(call.ChildCount()); i++ {
+		if c := call.Child(i); c != nil && c.Type() == "identifier" {
+			return nodeText(c, src)
+		}
+	}
+	return ""
+}
+
+// rubyCallSymbolArgs returns the bare names of the simple_symbol arguments of a
+// `call` node (`attr_accessor :a, :b` → ["a","b"]).
+func rubyCallSymbolArgs(call *sitter.Node, src []byte) []string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		for i := 0; i < int(call.ChildCount()); i++ {
+			if c := call.Child(i); c != nil && c.Type() == "argument_list" {
+				args = c
+				break
+			}
+		}
+	}
+	if args == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(args.ChildCount()); i++ {
+		a := args.Child(i)
+		if a == nil || a.Type() != "simple_symbol" {
+			continue
+		}
+		out = append(out, strings.TrimPrefix(nodeText(a, src), ":"))
+	}
+	return out
+}
+
+// attachRubyExtends emits a class→superclass EXTENDS edge from each owner's
+// stashed Metadata "base_candidate", restricted to superclasses declared in
+// this same file so the dashboard shape walker can recurse into inherited
+// attr fields.
+func attachRubyExtends(records []types.EntityRecord) []types.EntityRecord {
+	known := make(map[string]bool)
+	for i := range records {
+		if records[i].Kind == "SCOPE.Component" {
+			known[records[i].Name] = true
+		}
+	}
+	for i := range records {
+		if records[i].Kind != "SCOPE.Component" || records[i].Metadata == nil {
+			continue
+		}
+		base, _ := records[i].Metadata["base_candidate"].(string)
+		owner := records[i].Name
+		if base != "" && base != owner && known[base] {
+			dup := false
+			for _, ex := range records[i].Relationships {
+				if ex.Kind == "EXTENDS" && ex.ToID == base {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				records[i].Relationships = append(records[i].Relationships,
+					types.RelationshipRecord{FromID: owner, ToID: base, Kind: "EXTENDS"})
+			}
+		}
+		delete(records[i].Metadata, "base_candidate")
+	}
+	return records
+}

--- a/internal/extractors/ruby/issue4854_field_membership_test.go
+++ b/internal/extractors/ruby/issue4854_field_membership_test.go
@@ -1,0 +1,159 @@
+// Package ruby — issue #4854 general class field-membership tests.
+//
+// Root cause: Ruby has no static field declarations, so a plain data class's
+// declaratively-present members (attr_accessor/reader/writer symbols and
+// Struct.new/Data.define members) were never emitted as graph field entities by
+// the primary pass — only the framework-bound custom validation emitter surfaced
+// some as ORPHAN dto_field nodes with no CONTAINS edge. A plain Ruby model
+// therefore resolved to a SCOPE.Component with ZERO field children, so the
+// dashboard shape endpoint returned rows:[] — the same gap #4850/#4855 closed
+// for Go and #4845/#4851 for JS/TS.
+//
+// After #4854 every attr_* symbol gets a SCOPE.Schema/field entity + class→field
+// CONTAINS edge, a `Const = Struct.new(:a,:b)` / `Data.define` synthesises a
+// data-class Component with field members, and an in-file superclass emits an
+// EXTENDS edge.
+package ruby_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func rbExtract(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extreg.Get("ruby")
+	if !ok {
+		t.Fatal("ruby extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "ruby",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return got
+}
+
+func rbFieldEntityExists(ents []types.EntityRecord, owner, field string) bool {
+	want := owner + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func rbHasContainsField(ents []types.EntityRecord, path, owner, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("ruby", path, owner+"."+field)
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func rbHasExtends(ents []types.EntityRecord, owner, base string) bool {
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "EXTENDS" && r.ToID == base {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestRubyAttrAccessorFieldsAreContained proves a plain class with attr_* calls
+// emits one SCOPE.Schema/field entity per symbol AND a class→field CONTAINS edge.
+func TestRubyAttrAccessorFieldsAreContained(t *testing.T) {
+	path := "app/models/user.rb"
+	src := `
+class User
+  attr_accessor :name, :email
+  attr_reader :id
+
+  def greet
+    "hi"
+  end
+end
+`
+	ents := rbExtract(t, src, path)
+	for _, f := range []string{"name", "email", "id"} {
+		if !rbFieldEntityExists(ents, "User", f) {
+			t.Errorf("expected SCOPE.Schema/field entity User.%s", f)
+		}
+		if !rbHasContainsField(ents, path, "User", f) {
+			t.Errorf("expected CONTAINS edge from User to field %q", f)
+		}
+	}
+}
+
+// TestRubyStructDefineFieldsAreContained proves Struct.new / Data.define
+// synthesise a data-class Component carrying its members as field children.
+func TestRubyStructDefineFieldsAreContained(t *testing.T) {
+	path := "app/values.rb"
+	src := `
+Point = Struct.new(:x, :y)
+Coord = Data.define(:lat, :lng)
+`
+	ents := rbExtract(t, src, path)
+	for _, f := range []string{"x", "y"} {
+		if !rbFieldEntityExists(ents, "Point", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Point.%s", f)
+		}
+		if !rbHasContainsField(ents, path, "Point", f) {
+			t.Errorf("expected CONTAINS edge from Point to field %q", f)
+		}
+	}
+	for _, f := range []string{"lat", "lng"} {
+		if !rbFieldEntityExists(ents, "Coord", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Coord.%s", f)
+		}
+		if !rbHasContainsField(ents, path, "Coord", f) {
+			t.Errorf("expected CONTAINS edge from Coord to field %q", f)
+		}
+	}
+}
+
+// TestRubySuperclassEmitsExtends proves an in-file superclass emits an EXTENDS
+// edge so the shape walker recurses into inherited attr fields.
+func TestRubySuperclassEmitsExtends(t *testing.T) {
+	path := "app/models/account.rb"
+	src := `
+class BaseEntity
+  attr_accessor :id
+end
+
+class Account < BaseEntity
+  attr_accessor :owner
+end
+`
+	ents := rbExtract(t, src, path)
+	if !rbFieldEntityExists(ents, "BaseEntity", "id") {
+		t.Errorf("expected SCOPE.Schema/field entity BaseEntity.id")
+	}
+	if !rbHasContainsField(ents, path, "Account", "owner") {
+		t.Errorf("expected CONTAINS edge from Account to field owner")
+	}
+	if !rbHasExtends(ents, "Account", "BaseEntity") {
+		t.Errorf("expected EXTENDS edge from Account to in-file base BaseEntity")
+	}
+}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -82,6 +82,8 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// `User`). Mirrors the JS/Go/Java/Python collapse (#4343/#4358/#4359/#4357).
 	// No-op for non-test files and classes that are not Minitest test cases.
 	emitRubyMinitestSuite(root, file, &entities)
+	// Issue #4854 — in-file superclass EXTENDS for field-membership recursion.
+	entities = attachRubyExtends(entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "ruby")
@@ -185,6 +187,20 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 						Kind: "CONTAINS",
 					})
 			}
+			// Issue #4854 — general field membership: one SCOPE.Schema/field per
+			// attr_accessor/attr_reader/attr_writer symbol + a class→field
+			// CONTAINS edge so a plain Ruby data class has field children (these
+			// are the only declaratively-present members; Ruby has no static
+			// field declarations otherwise).
+			emitRubyAttrFields(out, classIdx, body, file.Content, rec.Name, file.Path)
+		}
+		// Issue #4854 — stash the in-file superclass for the EXTENDS post-pass
+		// so the shape walker can recurse into inherited attr fields.
+		if sc := classSuperclass(node, file.Content); sc != "" {
+			if (*out)[classIdx].Metadata == nil {
+				(*out)[classIdx].Metadata = map[string]interface{}{}
+			}
+			(*out)[classIdx].Metadata["base_candidate"] = sc
 		}
 		return
 
@@ -219,6 +235,12 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		// continues below so we never miss a deeper assignment.
 		if vs, vok := buildConstCollectionValueSet(node, file); vok {
 			*out = append(*out, vs)
+		}
+		// Issue #4854 — `Const = Struct.new(:a, :b)` / `Data.define(:a, :b)`
+		// synthesises a SCOPE.Component data class + one field member per
+		// declared accessor, with class→field CONTAINS edges.
+		if sd := emitRubyStructDefine(node, file); len(sd) > 0 {
+			*out = append(*out, sd...)
 		}
 	}
 

--- a/internal/extractors/rust/issue4854_field_membership_test.go
+++ b/internal/extractors/rust/issue4854_field_membership_test.go
@@ -1,0 +1,93 @@
+// Package rust — issue #4854 general struct/enum field-membership tests.
+//
+// Root cause: Rust struct fields were only emitted as field entities by the
+// serde/utoipa/ORM-bound custom emitters (internal/custom/rust, #4635). A plain
+// data struct resolved to a SCOPE.Component with ZERO field children, so the
+// dashboard shape endpoint returned rows:[] — the same gap #4850/#4855 closed
+// for Go and #4845/#4851 for JS/TS.
+//
+// After #4854 every named struct field gets a SCOPE.Schema/field entity AND a
+// struct→field CONTAINS edge, honouring serde rename (wire name) and skip;
+// named fields of struct-style enum variants become "<Enum>.<Variant>.<field>".
+// Rust has no inheritance, so there is no EXTENDS.
+package rust_test
+
+import (
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func rsFieldEntityExists(ents []types.EntityRecord, owner, field string) bool {
+	want := owner + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func rsHasContainsField(ents []types.EntityRecord, owner, dottedField string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("rust", "test.rs", dottedField)
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestRustStructFieldsAreContained proves a plain data struct with serde
+// rename/skip emits one SCOPE.Schema/field entity per named field (wire name
+// honoured, skip excluded) AND a struct→field CONTAINS edge for each.
+func TestRustStructFieldsAreContained(t *testing.T) {
+	src := `
+struct User {
+    id: u64,
+    #[serde(rename = "userName")]
+    name: String,
+    #[serde(skip)]
+    secret: String,
+}
+`
+	ents := runRust(t, src)
+	// id is untagged; name uses the serde wire name "userName".
+	for _, f := range []string{"id", "userName"} {
+		if !rsFieldEntityExists(ents, "User", f) {
+			t.Errorf("expected SCOPE.Schema/field entity User.%s", f)
+		}
+		if !rsHasContainsField(ents, "User", "User."+f) {
+			t.Errorf("expected CONTAINS edge from User to field %q", f)
+		}
+	}
+	if rsFieldEntityExists(ents, "User", "secret") {
+		t.Errorf("#[serde(skip)] field secret must be excluded")
+	}
+}
+
+// TestRustEnumVariantFieldsAreContained proves named fields of struct-style
+// enum variants become "<Enum>.<Variant>.<field>" members with CONTAINS edges.
+func TestRustEnumVariantFieldsAreContained(t *testing.T) {
+	src := `
+enum Event {
+    Click { x: i32, y: i32 },
+    Key(char),
+}
+`
+	ents := runRust(t, src)
+	for _, f := range []string{"Click.x", "Click.y"} {
+		if !rsFieldEntityExists(ents, "Event", f) {
+			t.Errorf("expected SCOPE.Schema/field entity Event.%s", f)
+		}
+		if !rsHasContainsField(ents, "Event", "Event."+f) {
+			t.Errorf("expected CONTAINS edge from Event to field %q", f)
+		}
+	}
+}

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -89,12 +89,26 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 	switch node.Type() {
 	case "struct_item":
 		if rec, ok := buildComponent(node, file, "struct"); ok {
+			idx := len(*out)
 			*out = append(*out, rec)
+			// Issue #4854 — general field membership: one SCOPE.Schema/field
+			// per named struct field (serde wire name / skip honoured) + a
+			// struct→field CONTAINS edge, so a plain data struct has field
+			// children (dedups by Name with the serde DTO members in #4635).
+			fieldEnts := emitRustStructFields(node, file, rec.Name)
+			attachRustFieldContains(*out, idx, file.Path, fieldEnts)
+			*out = append(*out, fieldEnts...)
 		}
 
 	case "enum_item":
 		if rec, ok := buildComponent(node, file, "enum"); ok {
+			idx := len(*out)
 			*out = append(*out, rec)
+			// Issue #4854 — named fields of struct-style enum variants become
+			// "<Enum>.<Variant>.<field>" field members.
+			fieldEnts := emitRustEnumVariantFields(node, file, rec.Name)
+			attachRustFieldContains(*out, idx, file.Path, fieldEnts)
+			*out = append(*out, fieldEnts...)
 		}
 
 	case "type_item":

--- a/internal/extractors/rust/struct_fields.go
+++ b/internal/extractors/rust/struct_fields.go
@@ -1,0 +1,226 @@
+package rust
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitRustStructFields returns one SCOPE.Schema/field EntityRecord per named
+// field of the struct named ownerName, honouring serde wire-name/skip
+// attributes, plus a class→field CONTAINS edge attached to the owner.
+//
+// Issue #4854 — before this pass Rust struct fields were only emitted by the
+// serde/utoipa/ORM-bound custom emitters (internal/custom/rust, #4635). A plain
+// data struct therefore resolved to a SCOPE.Component with ZERO field children,
+// so the dashboard shape endpoint returned rows:[] — the same gap #4850/#4855
+// closed for Go and #4845/#4851 for JS/TS. Rust has no inheritance, so there is
+// NO EXTENDS pass.
+//
+// Field Name is "<Owner>.<wire>" where <wire> is the serde rename target if
+// present (else the Rust field name) so it dedups by Name in MergeWithCustom
+// against the serde DTO field members; `#[serde(skip)]` fields are excluded.
+//
+//	Kind      = "SCOPE.Schema"
+//	Subtype   = "field"
+//	Name      = "<Owner>.<wire>"
+//	Signature = "<type> <wire>"
+func emitRustStructFields(
+	node *sitter.Node,
+	file extractor.FileInput,
+	ownerName string,
+) []types.EntityRecord {
+	body := findRustFieldList(node)
+	if body == nil || ownerName == "" {
+		return nil
+	}
+	return rustFieldsFromList(body, file, ownerName)
+}
+
+// emitRustEnumVariantFields returns SCOPE.Schema/field entities for the named
+// fields of struct-style enum variants (`Variant { x: i32 }`), keyed
+// "<Enum>.<Variant>.<field>". Tuple/unit variants carry no named fields and
+// contribute none (best-effort: Rust has no field name to model).
+func emitRustEnumVariantFields(
+	node *sitter.Node,
+	file extractor.FileInput,
+	ownerName string,
+) []types.EntityRecord {
+	if ownerName == "" {
+		return nil
+	}
+	vl := node.ChildByFieldName("body")
+	if vl == nil {
+		vl = findChildOfType(node, "enum_variant_list")
+	}
+	if vl == nil {
+		return nil
+	}
+	var out []types.EntityRecord
+	for i := 0; i < int(vl.ChildCount()); i++ {
+		v := vl.Child(i)
+		if v == nil || v.Type() != "enum_variant" {
+			continue
+		}
+		vname := childFieldText(v, "name", file.Content)
+		if vname == "" {
+			if id := findChildOfType(v, "identifier"); id != nil {
+				vname = string(file.Content[id.StartByte():id.EndByte()])
+			}
+		}
+		fl := findChildOfType(v, "field_declaration_list")
+		if fl == nil || vname == "" {
+			continue
+		}
+		out = append(out, rustFieldsFromList(fl, file, ownerName+"."+vname)...)
+	}
+	return out
+}
+
+// rustFieldsFromList builds field entities for every field_declaration in a
+// field_declaration_list, applying the serde rename/skip attribute that
+// immediately precedes each field.
+func rustFieldsFromList(
+	body *sitter.Node,
+	file extractor.FileInput,
+	owner string,
+) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	var pendingRename string
+	var pendingSkip bool
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		switch ch.Type() {
+		case "attribute_item":
+			rename, skip := rustSerdeAttr(ch, file.Content)
+			if rename != "" {
+				pendingRename = rename
+			}
+			if skip {
+				pendingSkip = true
+			}
+			continue
+		case "field_declaration":
+		default:
+			continue
+		}
+		skip := pendingSkip
+		rename := pendingRename
+		pendingSkip = false
+		pendingRename = ""
+		if skip {
+			continue
+		}
+		nameNode := ch.ChildByFieldName("name")
+		if nameNode == nil {
+			nameNode = findChildOfType(ch, "field_identifier")
+		}
+		if nameNode == nil {
+			continue
+		}
+		fname := string(file.Content[nameNode.StartByte():nameNode.EndByte()])
+		wire := fname
+		if rename != "" {
+			wire = rename
+		}
+		if wire == "" || seen[wire] {
+			continue
+		}
+		seen[wire] = true
+		typ := childFieldText(ch, "type", file.Content)
+		dotted := owner + "." + wire
+		sig := wire
+		if typ != "" {
+			sig = typ + " " + wire
+		}
+		out = append(out, types.EntityRecord{
+			Name:               dotted,
+			QualifiedName:      dotted,
+			Kind:               "SCOPE.Schema",
+			Subtype:            "field",
+			SourceFile:         file.Path,
+			StartLine:          int(ch.StartPoint().Row) + 1,
+			EndLine:            int(ch.EndPoint().Row) + 1,
+			Language:           "rust",
+			Signature:          sig,
+			QualityScore:       1.0,
+			Properties: map[string]string{
+				"field_name":   fname,
+				"field_type":   typ,
+				"wire_name":    wire,
+				"parent_class": owner,
+			},
+			Metadata:           map[string]interface{}{"subtype": "field", "owner": owner},
+			EnrichmentRequired: false,
+		})
+	}
+	return out
+}
+
+// rustSerdeAttr parses an attribute_item, returning the serde rename target
+// (if any) and whether the field is serde-skipped. Mirrors the regex logic in
+// internal/custom/rust/fw_validation.go so the wire names align for dedup.
+func rustSerdeAttr(attr *sitter.Node, src []byte) (rename string, skip bool) {
+	text := string(src[attr.StartByte():attr.EndByte()])
+	if !strings.Contains(text, "serde") {
+		return "", false
+	}
+	if strings.Contains(text, "skip") {
+		skip = true
+	}
+	if i := strings.Index(text, "rename"); i >= 0 {
+		rest := text[i+len("rename"):]
+		if q := strings.IndexByte(rest, '"'); q >= 0 {
+			rest = rest[q+1:]
+			if e := strings.IndexByte(rest, '"'); e >= 0 {
+				rename = rest[:e]
+			}
+		}
+	}
+	return rename, skip
+}
+
+// findRustFieldList returns the field_declaration_list child of a struct_item,
+// or nil for a tuple/unit struct (no named fields).
+func findRustFieldList(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	if b := node.ChildByFieldName("body"); b != nil && b.Type() == "field_declaration_list" {
+		return b
+	}
+	return findChildOfType(node, "field_declaration_list")
+}
+
+// findChildOfType returns the first direct child of n with the given type.
+func findChildOfType(n *sitter.Node, typ string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if c := n.Child(i); c != nil && c.Type() == typ {
+			return c
+		}
+	}
+	return nil
+}
+
+// attachRustFieldContains attaches a struct/enum→field CONTAINS edge to the
+// owner Component (at componentIdx) for each SCOPE.Schema/field member emitted
+// for it (including enum-variant fields keyed "<Enum>.<Variant>.<field>").
+func attachRustFieldContains(
+	records []types.EntityRecord,
+	componentIdx int,
+	filePath string,
+	fieldEnts []types.EntityRecord,
+) {
+	for _, fe := range fieldEnts {
+		toID := extractor.BuildSchemaFieldStructuralRef("rust", filePath, fe.Name)
+		records[componentIdx].Relationships = append(records[componentIdx].Relationships,
+			types.RelationshipRecord{ToID: toID, Kind: "CONTAINS"})
+	}
+}

--- a/internal/extractors/swift/field_members.go
+++ b/internal/extractors/swift/field_members.go
@@ -1,0 +1,177 @@
+package swift
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// emitSwiftFieldMembers returns one SCOPE.Schema/field EntityRecord per stored
+// property (let/var) of the struct/class named ownerName, plus the bare base /
+// protocol type names from the declaration's inheritance_specifier (for
+// EXTENDS, resolved against in-file types by the caller).
+//
+// Issue #4854 — before this pass Swift had no general field-membership pass at
+// all (the custom Swift emitters cover SwiftUI/Vapor routes, not Codable data
+// model fields). A plain Swift data struct therefore resolved to a
+// SCOPE.Component with ZERO field children, so the dashboard shape endpoint
+// returned rows:[] — the same gap #4850/#4855 closed for Go and #4845/#4851 for
+// JS/TS.
+//
+// Computed properties (with a `computed_property { get … }` body) are NOT
+// stored members and are excluded.
+//
+//	Kind      = "SCOPE.Schema"
+//	Subtype   = "field"
+//	Name      = "<Owner>.<prop>"
+//	Signature = "<type> <prop>"
+func emitSwiftFieldMembers(
+	node, body *sitter.Node,
+	src []byte,
+	ownerName, filePath string,
+) ([]types.EntityRecord, []string) {
+	if ownerName == "" {
+		return nil, nil
+	}
+
+	var fields []types.EntityRecord
+	seen := make(map[string]bool)
+
+	if body != nil {
+		for i := 0; i < int(body.ChildCount()); i++ {
+			ch := body.Child(i)
+			if ch == nil || ch.Type() != "property_declaration" {
+				continue
+			}
+			// Stored properties only: a computed_property child marks a
+			// get/set-only computed property (no backing storage).
+			if firstChildOfType(ch, "computed_property") != nil {
+				continue
+			}
+			name := swiftPropertyName(ch, src)
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			typ := ""
+			if ta := firstChildOfType(ch, "type_annotation"); ta != nil {
+				typ = firstDescendantText(ta, src, "type_identifier")
+			}
+			dotted := ownerName + "." + name
+			sig := name
+			if typ != "" {
+				sig = typ + " " + name
+			}
+			fields = append(fields, types.EntityRecord{
+				Name:               dotted,
+				QualifiedName:      dotted,
+				Kind:               "SCOPE.Schema",
+				Subtype:            "field",
+				SourceFile:         filePath,
+				StartLine:          int(ch.StartPoint().Row) + 1,
+				EndLine:            int(ch.EndPoint().Row) + 1,
+				Language:           "swift",
+				Signature:          sig,
+				QualityScore:       1.0,
+				Properties: map[string]string{
+					"field_name":   name,
+					"field_type":   typ,
+					"parent_class": ownerName,
+				},
+				Metadata:           map[string]interface{}{"subtype": "field", "owner": ownerName},
+				EnrichmentRequired: false,
+			})
+		}
+	}
+
+	return fields, swiftInheritedTypeNames(node, src)
+}
+
+// swiftPropertyName returns the bound identifier of a property_declaration's
+// `pattern` child (the first simple_identifier). Tuple bindings
+// (`let (a, b)`) yield only the first identifier — best-effort.
+func swiftPropertyName(prop *sitter.Node, src []byte) string {
+	pat := firstChildOfType(prop, "pattern")
+	if pat == nil {
+		return ""
+	}
+	if id := firstDescendantText(pat, src, "simple_identifier"); id != "" {
+		return id
+	}
+	return ""
+}
+
+// swiftInheritedTypeNames returns the bare type names from a class/struct
+// declaration's inheritance_specifier list. The Swift grammar does not
+// distinguish a superclass from adopted protocols, so all are returned; the
+// caller's in-file filter keeps only types we actually modeled (a struct's
+// `: Codable` thus drops out, while `class B: A` keeps the in-file A).
+func swiftInheritedTypeNames(node *sitter.Node, src []byte) []string {
+	if node == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch == nil || ch.Type() != "inheritance_specifier" {
+			continue
+		}
+		if name := firstDescendantText(ch, src, "type_identifier"); name != "" {
+			out = append(out, strings.TrimSpace(name))
+		}
+	}
+	return out
+}
+
+// firstChildOfType returns the first direct child of n with the given type.
+func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if c := n.Child(i); c != nil && c.Type() == typ {
+			return c
+		}
+	}
+	return nil
+}
+
+// attachSwiftExtends emits class→base EXTENDS edges from each owner's stashed
+// Metadata "base_candidates", restricted to base types declared in this same
+// file so the dashboard shape walker can recurse into inherited members.
+// Adopted protocols and external superclasses drop out via the in-file filter.
+func attachSwiftExtends(records []types.EntityRecord) []types.EntityRecord {
+	known := make(map[string]bool)
+	for i := range records {
+		if records[i].Kind == "SCOPE.Component" {
+			known[records[i].Name] = true
+		}
+	}
+	for i := range records {
+		if records[i].Kind != "SCOPE.Component" || records[i].Metadata == nil {
+			continue
+		}
+		cands, _ := records[i].Metadata["base_candidates"].([]string)
+		owner := records[i].Name
+		for _, base := range cands {
+			if base == "" || base == owner || !known[base] {
+				continue
+			}
+			dup := false
+			for _, ex := range records[i].Relationships {
+				if ex.Kind == "EXTENDS" && ex.ToID == base {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				records[i].Relationships = append(records[i].Relationships,
+					types.RelationshipRecord{FromID: owner, ToID: base, Kind: "EXTENDS"})
+			}
+		}
+		delete(records[i].Metadata, "base_candidates")
+	}
+	return records
+}

--- a/internal/extractors/swift/issue4854_field_membership_test.go
+++ b/internal/extractors/swift/issue4854_field_membership_test.go
@@ -1,0 +1,135 @@
+// Package swift — issue #4854 general struct/class field-membership tests.
+//
+// Root cause: Swift had no general field-membership pass at all (the custom
+// Swift emitters cover SwiftUI/Vapor routes, not Codable data model fields). A
+// plain Swift data struct resolved to a SCOPE.Component with ZERO field
+// children, so the dashboard shape endpoint returned rows:[] — the same gap
+// #4850/#4855 closed for Go and #4845/#4851 for JS/TS.
+//
+// After #4854 every stored property (let/var) gets a SCOPE.Schema/field entity
+// AND a type→field CONTAINS edge; an in-file superclass emits an EXTENDS edge;
+// computed properties are excluded.
+package swift_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func swExtract(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extreg.Get("swift")
+	if !ok {
+		t.Fatal("swift extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "swift",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return got
+}
+
+func swFieldEntityExists(ents []types.EntityRecord, owner, field string) bool {
+	want := owner + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
+func swHasContainsField(ents []types.EntityRecord, path, owner, field string) bool {
+	want := extreg.BuildSchemaFieldStructuralRef("swift", path, owner+"."+field)
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func swHasExtends(ents []types.EntityRecord, owner, base string) bool {
+	for _, e := range ents {
+		if e.Name != owner || e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "EXTENDS" && r.ToID == base {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestSwiftStoredPropertiesAreContained proves a plain Codable struct emits one
+// SCOPE.Schema/field entity per stored property AND a struct→field CONTAINS
+// edge, while a computed property is excluded.
+func TestSwiftStoredPropertiesAreContained(t *testing.T) {
+	path := "Models/User.swift"
+	src := `
+struct User: Codable {
+    let id: Int
+    var name: String
+    var balance: Double = 0
+    var full: String { return name }
+}
+`
+	ents := swExtract(t, src, path)
+	for _, f := range []string{"id", "name", "balance"} {
+		if !swFieldEntityExists(ents, "User", f) {
+			t.Errorf("expected SCOPE.Schema/field entity User.%s", f)
+		}
+		if !swHasContainsField(ents, path, "User", f) {
+			t.Errorf("expected CONTAINS edge from User to field %q", f)
+		}
+	}
+	if swFieldEntityExists(ents, "User", "full") {
+		t.Errorf("computed property full must not be a field entity")
+	}
+	// A struct adopting only a protocol (Codable) must NOT get an EXTENDS edge.
+	if swHasExtends(ents, "User", "Codable") {
+		t.Errorf("adopted protocol Codable must not be an in-file EXTENDS target")
+	}
+}
+
+// TestSwiftSuperclassEmitsExtends proves an in-file superclass emits an EXTENDS
+// edge so the shape walker recurses into inherited stored properties.
+func TestSwiftSuperclassEmitsExtends(t *testing.T) {
+	path := "Models/Account.swift"
+	src := `
+class BaseEntity {
+    let id: Int
+    var createdAt: Double
+}
+
+class Account: BaseEntity {
+    let owner: String
+}
+`
+	ents := swExtract(t, src, path)
+	if !swFieldEntityExists(ents, "BaseEntity", "id") {
+		t.Errorf("expected SCOPE.Schema/field entity BaseEntity.id")
+	}
+	if !swHasContainsField(ents, path, "Account", "owner") {
+		t.Errorf("expected CONTAINS edge from Account to field owner")
+	}
+	if !swHasExtends(ents, "Account", "BaseEntity") {
+		t.Errorf("expected EXTENDS edge from Account to in-file base BaseEntity")
+	}
+}

--- a/internal/extractors/swift/swift.go
+++ b/internal/extractors/swift/swift.go
@@ -65,6 +65,8 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
 	walkNode(file.Tree.RootNode(), file, &entities)
+	// Issue #4854 — in-file base-class EXTENDS for field-membership recursion.
+	entities = attachSwiftExtends(entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "swift")
 	extractor.TagEntitiesLanguage(entities, "swift")
@@ -130,6 +132,22 @@ func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRe
 						Kind: "CONTAINS",
 					})
 			}
+		}
+		// Issue #4854 — general field membership: one SCOPE.Schema/field per
+		// stored property (let/var) + a type→field CONTAINS edge so a plain
+		// Swift data struct/class has field children.
+		fieldEnts, baseNames := emitSwiftFieldMembers(node, body, file.Content, rec.Name, file.Path)
+		for _, fe := range fieldEnts {
+			toID := extractor.BuildSchemaFieldStructuralRef("swift", file.Path, fe.Name)
+			(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
+				types.RelationshipRecord{ToID: toID, Kind: "CONTAINS"})
+		}
+		*out = append(*out, fieldEnts...)
+		if len(baseNames) > 0 {
+			if (*out)[classIdx].Metadata == nil {
+				(*out)[classIdx].Metadata = map[string]interface{}{}
+			}
+			(*out)[classIdx].Metadata["base_candidates"] = baseNames
 		}
 		return
 


### PR DESCRIPTION
Completes the all-language DTO field-membership matrix (Go #4855, JS/TS #4851; Java/Python/Kotlin/Scala/COBOL already fine). Each of the 6 remaining languages had only framework/endpoint-gated custom field emitters (`internal/custom/<lang>`, from #4715/#4613/#4635) that fired ONLY for HTTP-bound DTOs / specific serializers, so plain data classes/structs got NO field children and the dashboard `/shape` endpoint returned `rows:[]` for non-endpoint classes. The general primary-pass now emits a `SCOPE.Schema`/field entity + class→field `CONTAINS` per declared member, mirroring the Go/JS-TS pattern.

## Per-language

| Lang | What was added | Embedded/base | Fixtures | Status |
|---|---|---|---|---|
| C# | class/record/struct properties + public fields + record positional params | in-file base class → EXTENDS (interfaces dropped by in-file filter) | `TestCsharpDataClassFieldsAreContained` / `…RecordPositionalParams…` / `…BaseClassEmitsExtends` | done |
| PHP | typed properties + promoted constructor params (`$` stripped) | in-file parent class → EXTENDS (interfaces in `class_interface_clause` excluded) | `TestPhpTypedPropertiesAndPromotedParamsAreContained` / `…BaseClassEmitsExtends` | done |
| Ruby | `attr_accessor`/`attr_reader`/`attr_writer` symbols + synthesised data-class Component for `Const = Struct.new(:a,:b)` / `Data.define(:a,:b)` | in-file superclass → EXTENDS | `TestRubyAttrAccessorFieldsAreContained` / `…StructDefine…` / `…SuperclassEmitsExtends` | done |
| Rust | named struct fields (serde `rename` wire name honoured, `skip` excluded) + struct-style enum-variant fields `<Enum>.<Variant>.<field>` | none — Rust has no inheritance (no EXTENDS) | `TestRustStructFieldsAreContained` / `…EnumVariantFields…` | done |
| Swift | stored properties (`let`/`var`; computed properties excluded) | in-file superclass → EXTENDS (adopted protocols dropped by in-file filter) | `TestSwiftStoredPropertiesAreContained` / `…SuperclassEmitsExtends` | done |
| C/C++ | struct/class/union data members (pointer/array/reference declarators unwrapped, member functions excluded), both `c` and `cpp` keys | in-file base class → EXTENDS | `TestCppDataClassFieldsAreContained` / `…BaseClassEmitsExtends` / `TestCFieldsAreContained` | done |

No honest residual deferrals — all 6 implemented and fixture-proven.

## Dedup with the custom emitters
Field `Name` is `<Class>.<member>` (the language member name, or the serde wire name for Rust) — the same key the endpoint-gated custom DTO members use — so `MergeWithCustom` supersedes by `Name` and the richer endpoint-bound member wins. No double fields on HTTP-bound DTOs.

## Embedded/base handling
In-file base/superclass → `EXTENDS` (so the shape walker recurses into inherited members), restricted to types declared in the same file via a post-walk pass (mirrors the Go embedded-field policy). Rust has no inheritance → skipped per spec. Implemented interfaces / adopted protocols are dropped by the in-file filter.

## Registry / coverage
`docs/coverage/registry.json` `Validation/dto_extraction` cells for the 6 languages (52 cells across their framework/ORM dictionaries) note the new general primary-pass capability and cite the new `field_members.go` / `struct_fields.go` + tests. `coverage fmt --check` canonical, `coverage validate` ok. (Generated `.md` docs are stale relative to the current generator across the whole repo, so — as in Go #4850 — only `registry.json` is touched.)

## Gates
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/... ./internal/dashboard/... ./internal/types/` all pass; `tools/coverage` tests pass.

Deploy-deferred. Closes #4854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)