### PR TITLE
feat(#4862): IaC diagram nests resources inside their instantiating module (ownership-as-containment)

### DIFF
--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -160,6 +160,17 @@ type IaCResource struct {
 	// (e.g. `../../modules/worker-service`, or a registry/git source).
 	ModuleSource string `json:"module_source,omitempty"`
 
+	// ParentID (#4862 — ownership-as-containment): the slug-prefixed entity id of
+	// the module INSTANCE that INSTANTIATES this resource, when one exists. The
+	// architecture diagram, in Module group-by mode, nests this resource INSIDE
+	// the instantiating module's container box (compound layout) rather than
+	// fanning an `instantiates` edge out from the module to it. A resource
+	// instantiated by several module instances is contained by the first
+	// (a containment box has a single parent); the remaining instantiation links
+	// are still surfaced as relations. Empty for resources not instantiated by
+	// any module instance (they keep their source-directory grouping).
+	ParentID string `json:"parent_id,omitempty"`
+
 	// Properties — curated typed config props (empty when none stamped).
 	Properties []IaCProperty `json:"properties"`
 	// Relations — grants / event-sources / dependencies / topology / triggers /
@@ -422,6 +433,93 @@ func mergeEnv(existing, add string) string {
 	}
 	sort.Strings(out)
 	return strings.Join(out, ",")
+}
+
+// joinModuleInstantiations resolves module instantiation by DIRECTORY (#4657)
+// for one repo's resources in byID, in place. The INSTANTIATES edge emitted by
+// the edge pass targets `tfmodule-def:<dir>`, which is not itself a rendered
+// resource (a Terraform module definition is a directory of .tf files, not one
+// entity). Here we join each module INSTANCE's DefinitionDir to the definition's
+// resources — every resource whose Module (source-file directory) equals that
+// dir — and:
+//
+//  1. draw an INSTANTIATES relation between the instance node and each of the
+//     definition's resources (so dev/staging/prod connect to the worker-service
+//     / sqs-queue definitions as rendered nodes),
+//  2. propagate the instance's env onto those definition resources so the env
+//     tabs can scope to "this env's instances + what they instantiate" even
+//     though the shared definition files carry no env, and
+//  3. (#4862) record the instantiating instance as each definition resource's
+//     ParentID — the ownership-as-containment key the diagram nests on, so the
+//     instance's box wraps the resources it instantiates rather than fanning an
+//     edge out to each. The FIRST instance to instantiate a definition wins the
+//     containment (a node has one parent); the rest still surface as relations.
+//
+// This is the directory-join the resolver cannot do (no entity to bind a
+// directory to) and is what clears the bulk of the unresolved relations.
+func joinModuleInstantiations(byID map[string]*IaCResource, slug string) {
+	defByDir := map[string][]*IaCResource{}
+	for _, r := range byID {
+		if r.Repo != slug || r.Module == "" {
+			continue
+		}
+		defByDir[r.Module] = append(defByDir[r.Module], r)
+	}
+	// Deterministic instance order so the FIRST-wins ParentID is stable across
+	// runs (map iteration order is randomized in Go).
+	insts := make([]*IaCResource, 0, len(byID))
+	for _, inst := range byID {
+		if inst.Repo != slug || inst.DefinitionDir == "" {
+			continue
+		}
+		insts = append(insts, inst)
+	}
+	sort.SliceStable(insts, func(i, j int) bool {
+		return insts[i].EntityID < insts[j].EntityID
+	})
+	for _, inst := range insts {
+		defs := defByDir[inst.DefinitionDir]
+		if len(defs) == 0 {
+			continue
+		}
+		for _, def := range defs {
+			if def == inst {
+				continue
+			}
+			// Propagate env onto the (env-less) shared definition resource so it
+			// surfaces under the instantiating env's tab. A definition
+			// instantiated by multiple envs accumulates a comma-joined list.
+			if inst.Env != "" {
+				def.Env = mergeEnv(def.Env, inst.Env)
+			}
+			// #4862 — ownership-as-containment: record the instantiating module
+			// instance as the definition resource's container parent so the
+			// diagram nests it inside the module box (vs an instantiates edge).
+			if def.ParentID == "" {
+				def.ParentID = inst.EntityID
+			}
+			inst.Relations = append(inst.Relations, IaCRelation{
+				Facet:          "instantiates",
+				Kind:           "INSTANTIATES",
+				Direction:      "out",
+				Target:         def.Name,
+				TargetResolved: true,
+				TargetID:       def.EntityID,
+				TargetEntityID: def.EntityID,
+				Detail:         inst.DefinitionDir,
+			})
+			def.Relations = append(def.Relations, IaCRelation{
+				Facet:          "instantiates",
+				Kind:           "INSTANTIATES",
+				Direction:      "in",
+				Target:         inst.Name,
+				TargetResolved: true,
+				TargetID:       inst.EntityID,
+				TargetEntityID: inst.EntityID,
+				Detail:         inst.DefinitionDir,
+			})
+		}
+	}
 }
 
 // idTail returns the last path segment of a graph entity ID (Kind:Name or
@@ -692,53 +790,7 @@ func (s *Server) handleIaC(w http.ResponseWriter, r *http.Request) {
 		//
 		// This is the directory-join the resolver cannot do (no entity to bind
 		// a directory to) and is what clears the bulk of the unresolved relations.
-		defByDir := map[string][]*IaCResource{}
-		for _, r := range byID {
-			if r.Repo != rp.Slug || r.Module == "" {
-				continue
-			}
-			defByDir[r.Module] = append(defByDir[r.Module], r)
-		}
-		for _, inst := range byID {
-			if inst.Repo != rp.Slug || inst.DefinitionDir == "" {
-				continue
-			}
-			defs := defByDir[inst.DefinitionDir]
-			if len(defs) == 0 {
-				continue
-			}
-			for _, def := range defs {
-				if def == inst {
-					continue
-				}
-				// Propagate env onto the (env-less) shared definition resource so
-				// it surfaces under the instantiating env's tab. A definition
-				// instantiated by multiple envs accumulates a comma-joined list.
-				if inst.Env != "" {
-					def.Env = mergeEnv(def.Env, inst.Env)
-				}
-				inst.Relations = append(inst.Relations, IaCRelation{
-					Facet:          "instantiates",
-					Kind:           "INSTANTIATES",
-					Direction:      "out",
-					Target:         def.Name,
-					TargetResolved: true,
-					TargetID:       def.EntityID,
-					TargetEntityID: def.EntityID,
-					Detail:         inst.DefinitionDir,
-				})
-				def.Relations = append(def.Relations, IaCRelation{
-					Facet:          "instantiates",
-					Kind:           "INSTANTIATES",
-					Direction:      "in",
-					Target:         inst.Name,
-					TargetResolved: true,
-					TargetID:       inst.EntityID,
-					TargetEntityID: inst.EntityID,
-					Detail:         inst.DefinitionDir,
-				})
-			}
-		}
+		joinModuleInstantiations(byID, rp.Slug)
 	}
 
 	// Collect the env set across all module instances (post-projection so

--- a/internal/dashboard/handlers_iac_test.go
+++ b/internal/dashboard/handlers_iac_test.go
@@ -165,6 +165,88 @@ func TestSplitEnv(t *testing.T) {
 	}
 }
 
+// TestJoinModuleInstantiations_ContainmentAndEnv covers #4862 + #4657: each
+// definition resource gets ParentID = its instantiating module instance, env is
+// propagated onto the (env-less) definition, and INSTANTIATES relations are
+// drawn both directions. The FIRST instance (by entity id) wins containment.
+func TestJoinModuleInstantiations_ContainmentAndEnv(t *testing.T) {
+	// Two env instances of the same worker-service definition.
+	prod := &IaCResource{
+		EntityID:      "infra/inst-prod",
+		Repo:          "infra",
+		Name:          "module.worker_prod",
+		DefinitionDir: "modules/worker-service",
+		Env:           "prod",
+	}
+	dev := &IaCResource{
+		EntityID:      "infra/inst-dev",
+		Repo:          "infra",
+		Name:          "module.worker_dev",
+		DefinitionDir: "modules/worker-service",
+		Env:           "dev",
+	}
+	// Definition resources live under the definition directory (Module == dir).
+	task := &IaCResource{
+		EntityID: "infra/def-task",
+		Repo:     "infra",
+		Name:     "aws_ecs_task_definition.worker",
+		Module:   "modules/worker-service",
+	}
+	queue := &IaCResource{
+		EntityID: "infra/def-queue",
+		Repo:     "infra",
+		Name:     "aws_sqs_queue.work",
+		Module:   "modules/worker-service",
+	}
+
+	byID := map[string]*IaCResource{
+		prod.EntityID:  prod,
+		dev.EntityID:   dev,
+		task.EntityID:  task,
+		queue.EntityID: queue,
+	}
+
+	joinModuleInstantiations(byID, "infra")
+
+	// FIRST instance by entity id ("infra/inst-dev" < "infra/inst-prod") wins
+	// containment of both definition resources.
+	if task.ParentID != dev.EntityID {
+		t.Fatalf("task.ParentID = %q, want %q", task.ParentID, dev.EntityID)
+	}
+	if queue.ParentID != dev.EntityID {
+		t.Fatalf("queue.ParentID = %q, want %q", queue.ParentID, dev.EntityID)
+	}
+
+	// Env propagated from BOTH instantiating envs onto the shared definitions.
+	if task.Env != "dev,prod" {
+		t.Fatalf("task.Env = %q, want dev,prod", task.Env)
+	}
+
+	// Each instance gained an outbound INSTANTIATES relation per definition
+	// resource; each definition gained an inbound one per instance.
+	countFacet := func(r *IaCResource, dir string) int {
+		n := 0
+		for _, rel := range r.Relations {
+			if rel.Facet == "instantiates" && rel.Direction == dir {
+				n++
+			}
+		}
+		return n
+	}
+	if got := countFacet(dev, "out"); got != 2 {
+		t.Fatalf("dev out instantiates = %d, want 2", got)
+	}
+	if got := countFacet(task, "in"); got != 2 { // from dev + prod
+		t.Fatalf("task in instantiates = %d, want 2", got)
+	}
+
+	// An instance does not instantiate itself, and a resource with no
+	// instantiation keeps an empty ParentID.
+	if dev.ParentID != "" {
+		t.Fatalf("instance dev.ParentID = %q, want empty", dev.ParentID)
+	}
+}
+
 func TestIDTail(t *testing.T) {
 	if got := idTail("SCOPE.InfraResource:DataBucket"); got != "DataBucket" {
 		t.Fatalf("idTail = %q, want DataBucket", got)

--- a/webui-v2/src/components/iac-diagram/layout.test.ts
+++ b/webui-v2/src/components/iac-diagram/layout.test.ts
@@ -116,6 +116,125 @@ describe("layoutIaCDiagram (dagre fallback)", () => {
   });
 });
 
+/** #4862 — ownership-as-containment fixture: a module INSTANCE that
+ *  instantiates two definition resources (which carry parent_id = the instance),
+ *  plus a real resource→resource architectural edge to keep. */
+function instantiationFixture(): IaCReport {
+  const inst = res({
+    entity_id: "infra/inst",
+    name: "module.worker_prod",
+    category: "module",
+    module: "envs/prod",
+    relations: [
+      // instantiates edges fan out from the instance to each definition resource.
+      rel({
+        facet: "instantiates",
+        kind: "INSTANTIATES",
+        target_entity_id: "infra/task",
+        target: "task",
+      }),
+      rel({
+        facet: "instantiates",
+        kind: "INSTANTIATES",
+        target_entity_id: "infra/queue",
+        target: "queue",
+      }),
+    ],
+  });
+  const task = res({
+    entity_id: "infra/task",
+    name: "aws_ecs_task.worker",
+    module: "modules/worker-service",
+    category: "compute",
+    parent_id: "infra/inst",
+    relations: [
+      // a real resource→resource architectural edge (task → queue) — KEEP it.
+      rel({
+        facet: "dependency",
+        kind: "USES",
+        target_entity_id: "infra/queue",
+        target: "queue",
+      }),
+    ],
+  });
+  const queue = res({
+    entity_id: "infra/queue",
+    name: "aws_sqs_queue.work",
+    module: "modules/worker-service",
+    category: "queue",
+    parent_id: "infra/inst",
+    relations: [],
+  });
+  return {
+    group: "g",
+    total_resources: 3,
+    total_grants: 0,
+    total_event_sources: 0,
+    total_dependencies: 1,
+    total_outputs: 0,
+    with_props_count: 0,
+    tools: ["terraform"],
+    envs: ["prod"],
+    counts_by_category: {},
+    groups: [{ tool: "terraform", count: 3, resources: [inst, task, queue] }],
+  };
+}
+
+describe("ownership-as-containment (#4862)", () => {
+  it("nests instantiated resources inside their module instance and drops instantiates edges", () => {
+    const { nodes, edges, unresolvedEdges } = layoutIaCDiagram(
+      instantiationFixture(),
+      "LR",
+      "module",
+    );
+    const groups = nodes.filter((n) => n.type === IAC_GROUP_TYPE);
+    const resources = nodes.filter((n) => n.type === IAC_NODE_TYPE);
+
+    // One owner-instance container holds the instance + both definitions.
+    expect(groups.length).toBe(1);
+    expect(resources.length).toBe(3);
+    const owner = groups[0];
+    // All three resource nodes share the single owner container as their parent.
+    for (const r of resources) expect(r.parentId).toBe(owner.id);
+
+    // The two redundant instantiates edges are dropped (nesting expresses them);
+    // only the real task→queue architectural edge remains.
+    expect(edges.length).toBe(1);
+    expect(edges[0].source).toBe("infra/task");
+    expect(edges[0].target).toBe("infra/queue");
+    expect((edges[0].data as { facet: string }).facet).toBe("dependency");
+
+    // Dropped instantiates edges are NOT counted as unresolved.
+    expect(unresolvedEdges).toBe(0);
+  });
+
+  it("ELK backend produces the same nested containment plan", async () => {
+    const { nodes, edges, unresolvedEdges } = await layoutIaCDiagramElk(
+      instantiationFixture(),
+      "LR",
+      "module",
+    );
+    const groups = nodes.filter((n) => n.type === IAC_GROUP_TYPE);
+    const resources = nodes.filter((n) => n.type === IAC_NODE_TYPE);
+    expect(groups.length).toBe(1);
+    expect(resources.length).toBe(3);
+    expect(edges.length).toBe(1);
+    expect(unresolvedEdges).toBe(0);
+  });
+
+  it("does not nest by instance in tier mode (parent_id ignored)", () => {
+    const { nodes } = layoutIaCDiagram(instantiationFixture(), "LR", "tier");
+    const groupIds = nodes
+      .filter((n) => n.type === IAC_GROUP_TYPE)
+      .map((n) => n.id);
+    // tier mode buckets by cloud tier: module→Compute, compute→Compute,
+    // queue→Messaging — never an instance: bucket.
+    expect(groupIds.some((id) => id.includes("instance:"))).toBe(false);
+    expect(groupIds).toContain("group:Compute");
+    expect(groupIds).toContain("group:Messaging");
+  });
+});
+
 describe("layoutIaCDiagramElk (#4826 — ELK backend)", () => {
   it("produces the same nested-group render plan as dagre with finite positions", async () => {
     const { nodes, edges, unresolvedEdges } = await layoutIaCDiagramElk(

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -175,6 +175,12 @@ interface IaCPlan {
   modules: Map<string, IaCResource[]>;
   /** group bucket key for a resource (module path or cloud tier). */
   moduleOf: (r: IaCResource) => string;
+  /**
+   * Display label for a group bucket key, when it is not just the key itself.
+   * Owner-instance containers (#4862) are keyed `instance:<entityId>` but
+   * labelled by the module name; map carries that override.
+   */
+  groupLabels: Map<string, string>;
   /** Unresolved relation count for a single resource (for its node chip). */
   unresolvedCountFor: (r: IaCResource) => number;
   rawEdges: RawEdge[];
@@ -204,12 +210,55 @@ function planIaCDiagram(
   const byEntityId = new Map<string, IaCResource>();
   for (const r of resources) byEntityId.set(r.entity_id, r);
 
+  // #4862 — ownership-as-containment (Module mode only). A resource whose
+  // backend `parent_id` points at a RENDERED module instance is nested INSIDE
+  // that module's container box: its bucket is that instance's entity id rather
+  // than its source-file directory. The instance node itself is placed in the
+  // SAME bucket so the box visually wraps the module + everything it
+  // instantiates. The synthetic group is keyed by the instance entity id and
+  // labelled by the module name. Outside Module mode this is inert. We only
+  // honour a parent_id that resolves to a rendered node (else fall back to
+  // directory grouping so nothing disappears).
+  const containedBy = (r: IaCResource): string | undefined => {
+    if (groupMode !== "module") return undefined;
+    const pid = r.parent_id;
+    if (pid && byEntityId.has(pid)) return pid;
+    return undefined;
+  };
+  // Module instances that own at least one contained resource become containers.
+  const ownerInstances = new Set<string>();
+  for (const r of resources) {
+    const owner = containedBy(r);
+    if (owner) ownerInstances.add(owner);
+  }
+  // Label for an owner-instance container bucket: the module name (falls back to
+  // its directory / entity id). Used by materialize via the modules map key.
+  const ownerLabel = new Map<string, string>();
+  for (const id of ownerInstances) {
+    const inst = byEntityId.get(id);
+    ownerLabel.set(
+      id,
+      (inst?.name && inst.name.trim()) ||
+        (inst?.module && inst.module.trim()) ||
+        id,
+    );
+  }
+
   // Assign each resource a container bucket. In "module" mode that is the
-  // module/stack directory ("" → "(ungrouped)"); in "tier" mode it is the cloud
-  // architecture tier derived from resource_category (#4625). Either way every
-  // node gets a parent container so the compound layout stays uniform.
-  const moduleOf = (r: IaCResource) =>
-    groupMode === "tier" ? cloudTier(r.category) : r.module || "(ungrouped)";
+  // instantiating module instance (ownership containment, #4862) when present,
+  // else the module/stack directory ("" → "(ungrouped)"); in "tier" mode it is
+  // the cloud architecture tier derived from resource_category (#4625). Either
+  // way every node gets a parent container so the compound layout stays uniform.
+  const moduleOf = (r: IaCResource): string => {
+    if (groupMode === "tier") return cloudTier(r.category);
+    // A contained resource (or an owner instance itself) buckets under the
+    // owner-instance container, keyed distinctly so it can't collide with a
+    // directory bucket of the same name.
+    const owner = containedBy(r);
+    if (owner) return `instance:${owner}`;
+    if (ownerInstances.has(r.entity_id)) return `instance:${r.entity_id}`;
+    return r.module || "(ungrouped)";
+  };
   const modules = new Map<string, IaCResource[]>();
   for (const r of resources) {
     const m = moduleOf(r);
@@ -234,6 +283,19 @@ function planIaCDiagram(
         unresolvedEdges++;
         continue;
       }
+      // #4862 — drop the redundant `instantiates` fan-out edge when the target
+      // resource is now CONTAINED inside this module instance's box (the
+      // module→resource ownership is expressed by nesting, not an edge). Only
+      // applies in Module mode; the target must be a real instantiates edge into
+      // a resource contained by THIS module (r is the owner instance). We do NOT
+      // count these as unresolved — they are intentionally elided, not missing.
+      if (
+        groupMode === "module" &&
+        rel.facet === "instantiates" &&
+        containedBy(byEntityId.get(targetEntity)!) === r.entity_id
+      ) {
+        continue;
+      }
       const key = `${r.entity_id}|${targetEntity}|${rel.kind}`;
       if (seen.has(key)) continue;
       seen.add(key);
@@ -252,12 +314,19 @@ function planIaCDiagram(
       (rel) => !rel.target_entity_id || !byEntityId.has(rel.target_entity_id),
     ).length;
 
+  // Owner-instance container labels (#4862), keyed by their bucket id.
+  const groupLabels = new Map<string, string>();
+  for (const [id, label] of ownerLabel) {
+    groupLabels.set(`instance:${id}`, label);
+  }
+
   return {
     capped,
     unresolvedEdges,
     resources,
     modules,
     moduleOf,
+    groupLabels,
     unresolvedCountFor,
     rawEdges,
   };
@@ -282,7 +351,7 @@ function materialize(
   /** Optional ELK orthogonal routes per rawEdge index (absolute flow coords). */
   edgeRoutes?: Map<number, ElkPoint2D[]>,
 ): IaCLayoutResult {
-  const { resources, modules, unresolvedCountFor, rawEdges, capped, unresolvedEdges } = plan;
+  const { resources, modules, groupLabels, unresolvedCountFor, rawEdges, capped, unresolvedEdges } = plan;
 
   const sourcePos = direction === "LR" ? Position.Right : Position.Bottom;
   const targetPos = direction === "LR" ? Position.Left : Position.Top;
@@ -317,10 +386,14 @@ function materialize(
       gh = maxY - minY + GROUP_PAD_TOP + GROUP_PAD_BOTTOM;
     }
 
+    // #4862 — an owner-instance container is keyed `instance:<entityId>` but
+    // labelled by the module name (carried in groupLabels).
+    const ownerLabel = groupLabels.get(module);
     const groupData: IaCGroupData = {
-      module,
-      shortLabel:
-        module === "(ungrouped)"
+      module: ownerLabel ?? module,
+      shortLabel: ownerLabel
+        ? shortModuleLabel(ownerLabel)
+        : module === "(ungrouped)"
           ? "ungrouped"
           : groupMode === "tier"
             ? module

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2263,6 +2263,14 @@ export interface IaCResource {
   definition_dir?: string;
   /** For a module INSTANCE only (#4657): the raw `source` value. */
   module_source?: string;
+  /**
+   * Slug-prefixed entity id of the module INSTANCE that instantiates this
+   * resource (#4862). In Module group-by mode the diagram nests this resource
+   * INSIDE that module's container box (ownership-as-containment) instead of
+   * drawing an `instantiates` fan-out edge to it. Empty for resources not
+   * instantiated by any module instance.
+   */
+  parent_id?: string;
   /** Curated typed config props; [] when none stamped. */
   properties: IaCProperty[];
   /** Grants / event-sources / dependencies / topology / triggers; [] when none. */


### PR DESCRIPTION
## What & why
The IaC architecture diagram, in **Module** group-by mode, fanned `instantiates` edges out from one module node to every resource it instantiates → hub-and-spoke clutter. This switches to **ownership-as-containment**: resources nest INSIDE their instantiating module's box (the ELK compound layout #4824/#4826 already supports nesting), and the now-redundant `instantiates` edges are dropped.

Closes #4862.

## Backend (`internal/dashboard/handlers_iac.go`)
- New `IaCResource.ParentID` (`json:"parent_id"`) = slug-prefixed entity id of the module INSTANCE that INSTANTIATES the resource.
- Extracted the Pass-3 directory-join into `joinModuleInstantiations()`. It now also stamps `ParentID` on each definition resource. Iteration is sorted by entity id so the **first** instance deterministically wins containment (a node has a single parent); the remaining instantiation links still surface as relations. Env propagation and the INSTANTIATES relations are unchanged.

## Frontend (`webui-v2/src/components/iac-diagram/layout.ts`, `data/types.ts`)
- **Module mode only:** a resource whose `parent_id` resolves to a rendered module instance buckets under that instance's container (keyed `instance:<entityId>`, labelled by the module name); the instance node shares the box so it wraps everything it instantiates.
- The redundant `instantiates` edges are dropped when the target is contained in that module — **not** counted as unresolved (intentionally elided, not missing).
- **All resource→resource architectural edges (uses/reads/writes/depends_on/references) are kept.**
- **Tier mode is untouched** (`parent_id` ignored); the **dagre fallback** flag is preserved; the **H/V** and **Module/Tier** toggles, the **category legend**, and the **unresolved-targets footer** all preserved.

## Tests
- Backend: `TestJoinModuleInstantiations_ContainmentAndEnv` — asserts definition resources get `ParentID` = first instantiating instance, env propagates from all envs, and INSTANTIATES relations are drawn both directions.
- Frontend: `ownership-as-containment (#4862)` suite — instantiated resources nest under one owner container, instantiates edges dropped while the real resource→resource edge survives, `unresolvedEdges === 0`, ELK parity, and a tier-mode guard (no `instance:` buckets).

## Gates (sandboxed daemon env throughout)
- `go build ./...` ✓ · `go vet ./internal/dashboard/...` ✓ · `go test ./internal/dashboard/...` ✓
- `npx tsc --noEmit` ✓ · `npm run build` ✓ · `npx vitest run` → **143 unit tests pass**; the 12 `e2e/*.spec.ts` Playwright files fail pre-existing/unrelated (Playwright `test.describe` under vitest).
- No registry/coverage change (dashboard rendering, not extraction capability).

## Follow-up
Filed #4864 — resolve the "N relation targets could not be resolved" footer (the real resource→resource architectural edges: ECS task→CloudWatch, ECS service→SQS/IAM, etc.). Out of scope here.

Deploy-deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)