### PR TITLE
fix(#4866): clearer container/group/zone boxes in compound diagrams (border + tint + label + nesting)

### DIFF
--- a/webui-v2/src/components/compound-topology/CTZone.tsx
+++ b/webui-v2/src/components/compound-topology/CTZone.tsx
@@ -1,6 +1,12 @@
 /* CTZone.tsx — a containment zone box. Click the header to collapse/expand.
    A collapsed zone renders as one solid leaf box (with a member count) and the
-   diagram aggregates its members' cross-zone edges into summary edges. */
+   diagram aggregates its members' cross-zone edges into summary edges.
+
+   #4866 — the zone box reads clearly as a grouping frame: a solid,
+   higher-contrast border (heavier than the leaf node cards), a faint per-kind
+   background tint, and a prominent header chip. Nesting depth is distinguished
+   by a stronger tint/border on outer zones so a nested zone stays legible. All
+   colors come from the theme tone palette (CSS vars) so light + dark track. */
 
 import { memo } from "react";
 import { ChevronDown, ChevronRight, Box, Cloud, Network, Boxes, Server } from "lucide-react";
@@ -22,18 +28,50 @@ function zoneIcon(kind: string) {
   }
 }
 
+/** Per-kind accent hue (theme tone vars) so each zone reads on-theme (#4866). */
+function zoneColor(kind: string): string {
+  switch (kind) {
+    case "cloud":
+      return "var(--info)";
+    case "network":
+      return "var(--success)";
+    case "repo":
+      return "var(--accent)";
+    case "service":
+      return "var(--warning)";
+    default:
+      return "var(--text-3)";
+  }
+}
+
 function CTZoneImpl({ data }: NodeProps) {
   const d = data as CTZoneData;
   const Icon = zoneIcon(d.kind);
   const Chevron = d.collapsed ? ChevronRight : ChevronDown;
+  const color = zoneColor(d.kind);
+
+  // Outer zones get a marginally stronger frame so a nested box stays legible
+  // inside its parent (#4866). depth 0 = outermost.
+  const outer = (d.depth ?? 0) === 0;
+  const fill = `color-mix(in srgb, ${color} ${outer ? 6 : 10}%, transparent)`;
+  const borderColor = `color-mix(in srgb, ${color} ${outer ? 55 : 70}%, var(--border-strong))`;
 
   return (
     <div
       className={
         d.collapsed
-          ? "flex h-full w-full flex-col rounded-lg border border-border bg-surface-2/80 shadow-sm"
-          : "h-full w-full rounded-lg border border-dashed border-border bg-surface-2/30"
+          ? "flex h-full w-full flex-col rounded-lg border-2 shadow-sm"
+          : "h-full w-full rounded-lg border-2"
       }
+      style={{
+        borderColor,
+        backgroundColor: d.collapsed
+          ? `color-mix(in srgb, ${color} 14%, var(--surface-2))`
+          : fill,
+        boxShadow: d.collapsed
+          ? undefined
+          : "inset 0 0 0 1px color-mix(in srgb, var(--surface) 55%, transparent)",
+      }}
       title={`${d.label} (${d.kind}) · ${d.nodeCount} node${d.nodeCount === 1 ? "" : "s"}`}
     >
       {d.collapsed && (
@@ -48,14 +86,20 @@ function CTZoneImpl({ data }: NodeProps) {
           e.stopPropagation();
           d.onToggle(d.zoneId);
         }}
-        className="flex w-full items-center gap-1.5 rounded-t-lg px-2.5 py-1.5 text-text-3 transition-colors hover:bg-surface-2"
+        className="m-1 flex w-[calc(100%-0.5rem)] items-center gap-1.5 rounded-md px-2 py-1 text-text-2 transition-colors hover:brightness-95"
+        style={{ backgroundColor: `color-mix(in srgb, ${color} 16%, var(--surface))` }}
       >
-        <Chevron size={12} className="shrink-0 text-text-4" />
-        <Icon size={11} className="shrink-0 text-text-4" />
-        <span className="truncate font-mono text-[10px] font-medium" title={d.label}>
+        <Chevron size={13} className="shrink-0 text-text-3" />
+        <Icon size={12} className="shrink-0" style={{ color }} />
+        <span className="truncate font-mono text-[11px] font-semibold tracking-tight" title={d.label}>
           {d.label}
         </span>
-        <span className="ml-auto shrink-0 text-[10px] tabular-nums text-text-4">{d.nodeCount}</span>
+        <span
+          className="ml-auto shrink-0 rounded-full px-1.5 text-[10px] font-medium tabular-nums text-text-3"
+          style={{ backgroundColor: "color-mix(in srgb, var(--surface-2) 80%, transparent)" }}
+        >
+          {d.nodeCount}
+        </span>
       </button>
       {d.collapsed && (
         <div className="flex flex-1 items-center justify-center px-2 pb-2 text-[10px] text-text-4">

--- a/webui-v2/src/components/compound-topology/layout.ts
+++ b/webui-v2/src/components/compound-topology/layout.ts
@@ -99,6 +99,11 @@ export interface CTZoneData {
   collapsed: boolean;
   /** Member node count (direct + transitive) — shown when collapsed. */
   nodeCount: number;
+  /**
+   * Container nesting depth (0 = outermost). Drives a stronger tint/border at
+   * outer levels so a nested zone box stays legible inside its parent (#4866).
+   */
+  depth: number;
   /** Toggles collapse for this zone id. */
   onToggle: (zoneId: string) => void;
   [key: string]: unknown;
@@ -407,6 +412,7 @@ function materialize(
       zoneId: zid,
       collapsed: collapsedRendered,
       nodeCount: z.node_count,
+      depth: depthOf(zid),
       onToggle,
     };
     out.push({

--- a/webui-v2/src/components/iac-diagram/IaCGroupNode.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCGroupNode.tsx
@@ -7,26 +7,58 @@
    flattened resources back by `module` reconstructs the stack structure as
    labelled boxes. Header shows the short module label + the resource count;
    the full module path is on hover.
+
+   #4866 — the container box now reads clearly as a grouping frame: a solid,
+   higher-contrast border (heavier than the surrounding resource cards), a faint
+   per-category background tint, and a prominent header chip. Nesting depth is
+   distinguished by a stronger tint/border at outer levels. All colors come from
+   the theme tone palette (categoryStyle / CSS vars) so light + dark both track.
    ============================================================ */
 
 import { memo } from "react";
-import { Layers } from "lucide-react";
 import type { NodeProps } from "@xyflow/react";
 import type { IaCGroupData } from "./layout";
+import { categoryStyle } from "./categoryStyle";
 
 function IaCGroupNodeImpl({ data }: NodeProps) {
-  const { module, shortLabel, count } = data as IaCGroupData;
+  const { module, shortLabel, count, categoryKey, depth } = data as IaCGroupData;
+  const style = categoryStyle(categoryKey);
+  const Icon = style.Icon;
+
+  // Outer containers get a marginally stronger frame so a nested box stays
+  // legible inside its parent (#4866). depth 0 = outermost.
+  const outer = (depth ?? 0) === 0;
+  // Faint fill distinct from the canvas, tinted by the dominant category.
+  const fill = `color-mix(in srgb, ${style.color} ${outer ? 7 : 11}%, transparent)`;
+  const borderColor = `color-mix(in srgb, ${style.color} ${outer ? 55 : 70}%, var(--border-strong))`;
+
   return (
     <div
-      className="h-full w-full rounded-lg border border-dashed border-border bg-surface-2/40"
+      className="h-full w-full rounded-lg border-2"
+      style={{
+        borderColor,
+        backgroundColor: fill,
+        boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--surface) 55%, transparent)",
+      }}
       title={module}
     >
-      <div className="flex items-center gap-1.5 px-2.5 pt-1.5 text-text-3">
-        <Layers size={11} className="shrink-0 text-text-4" />
-        <span className="truncate font-mono text-[10px] font-medium" title={module}>
+      <div
+        className="m-1 flex items-center gap-1.5 rounded-md px-2 py-1 text-text-2"
+        style={{ backgroundColor: `color-mix(in srgb, ${style.color} 16%, var(--surface))` }}
+      >
+        <Icon size={12} className="shrink-0" style={{ color: style.color }} />
+        <span
+          className="truncate font-mono text-[11px] font-semibold tracking-tight"
+          title={module}
+        >
           {shortLabel}
         </span>
-        <span className="ml-auto shrink-0 text-[10px] tabular-nums text-text-4">{count}</span>
+        <span
+          className="ml-auto shrink-0 rounded-full px-1.5 text-[10px] font-medium tabular-nums text-text-3"
+          style={{ backgroundColor: "color-mix(in srgb, var(--surface-2) 80%, transparent)" }}
+        >
+          {count}
+        </span>
       </div>
     </div>
   );

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -131,6 +131,20 @@ export interface IaCGroupData {
   /** Short trailing segment of the module path, for the header label. */
   shortLabel: string;
   count: number;
+  /**
+   * Category key (resource_category) used to tint the container box so it reads
+   * as a grouping frame on-theme (#4866). In "tier" mode it is the dominant
+   * category for the tier; in "module" mode it is the dominant category among
+   * the module's resources. Resolved via categoryStyle().
+   */
+  categoryKey: string;
+  /**
+   * Container nesting depth (0 = outermost). Drives a slightly stronger
+   * tint/border at outer levels so nested boxes stay legible (#4866). IaC
+   * containers are single-level today, so this is 0 unless an owner-instance
+   * box wraps another container.
+   */
+  depth: number;
   [key: string]: unknown;
 }
 
@@ -158,6 +172,27 @@ function shortModuleLabel(module: string): string {
   const cleaned = module.replace(/\/+$/, "");
   const i = cleaned.lastIndexOf("/");
   return i >= 0 ? cleaned.slice(i + 1) : cleaned;
+}
+
+/**
+ * dominantCategory returns the most common resource_category among a container's
+ * members (case-insensitive, "" → "other"), used to tint the container box with
+ * a light per-category hue (#4866). Ties break by first-seen for stability.
+ */
+function dominantCategory(members: IaCResource[]): string {
+  const counts = new Map<string, number>();
+  let best = "other";
+  let bestN = 0;
+  for (const r of members) {
+    const key = (r.category || "other").toLowerCase();
+    const n = (counts.get(key) ?? 0) + 1;
+    counts.set(key, n);
+    if (n > bestN) {
+      bestN = n;
+      best = key;
+    }
+  }
+  return best;
 }
 
 interface RawEdge { from: string; to: string; facet: string; kind: string; detail?: string }
@@ -389,6 +424,9 @@ function materialize(
     // #4862 — an owner-instance container is keyed `instance:<entityId>` but
     // labelled by the module name (carried in groupLabels).
     const ownerLabel = groupLabels.get(module);
+    // #4866 — pick a dominant resource_category for the container so its box can
+    // be tinted with a light per-category hue (containers frame, not dominate).
+    const categoryKey = dominantCategory(members);
     const groupData: IaCGroupData = {
       module: ownerLabel ?? module,
       shortLabel: ownerLabel
@@ -399,6 +437,8 @@ function materialize(
             ? module
             : shortModuleLabel(module),
       count: members.length,
+      categoryKey,
+      depth: 0,
     };
     nodes.push({
       id: groupId,


### PR DESCRIPTION
## What
Container/group/zone boxes in the two compound diagrams were faint near-white dashed outlines, hard to read as grouping frames. This makes them clearly visible — pure visual styling of the container nodes, frontend-only, deploy-deferred.

## iac-diagram (`IaCGroupNode` / module + tier containers)
- **Border**: thin dashed `border-border` → **solid `border-2`** in a per-category hue mixed with `--border-strong` (heavier than the resource node cards).
- **Tint**: faint per-category background via `color-mix` on the resource_category tone color (categoryStyle), plus an inset `--surface` ring so the box frames without overpowering the cards inside.
- **Label**: header is now a tinted chip — category icon in accent hue, **semibold mono** module label, count in a pill, `text-text-2` (was `text-text-3`/`text-4`).
- New `IaCGroupData.categoryKey` = dominant `resource_category` among the container's members (ties break first-seen); `IaCGroupData.depth`.

## compound-topology (`CTZone`)
- Same treatment: dashed `border-border` → solid `border-2` in a **per-kind** hue (cloud/network/repo/service → info/success/accent/warning) mixed with `--border-strong`; faint per-kind tint + inset ring; prominent tinted header chip with semibold mono label. Collapsed zones keep their solid look (stronger tinted fill).
- New `CTZoneData.depth` (from the existing `depthOf`).

## Nesting depth
Outer containers (`depth === 0`) get a **lighter** tint (~6–7%) and a **softer** border (~55% hue / 45% `--border-strong`); inner/nested containers get a **stronger** tint (~10–11%) and **stronger** border (~70% hue) so a module box inside a zone, or a zone inside a zone, stays distinct from its parent.

## Theme
All colors come from the theme tone palette / CSS vars (`--info`/`--accent`/`--success`/`--warning`, `--surface*`, `--border-strong`) via `color-mix` — no hardcoded hex, so **light + dark mode** both track. Containers frame, they don't dominate.

## Preserved
Layout, H/V + Module/Tier + Group-by toggles, legend, and collapse/expand interactions are unchanged. No Go / registry / coverage changes.

## Gates
- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npx vitest run` ✅ 143 unit tests pass (the 12 e2e Playwright spec files fail pre-existing/unrelated — Playwright `test.describe` under vitest).

Closes #4866.