### PR TITLE
feat(#4858): extract + show DTO field validation constraints (class-validator; chips in ShapeTree)

### DIFF
--- a/internal/dashboard/shape_tree.go
+++ b/internal/dashboard/shape_tree.go
@@ -37,6 +37,12 @@ type v2ShapeRow struct {
 	Name         string   `json:"name"`
 	Type         string   `json:"type"`
 	Annotations  []string `json:"annotations,omitempty"`
+	// Validations are per-field constraint chips (#4858) parsed from the
+	// field entity's `validations` metadata property — e.g. for a NestJS DTO
+	// field `@IsString() @MaxLength(120) @IsOptional() name?: string` this is
+	// ["IsString","MaxLength:120","IsOptional"]. Empty for fields without
+	// validation decorators.
+	Validations  []string `json:"validations,omitempty"`
 	Nullable     bool     `json:"nullable,omitempty"`
 	TypeEntityID string   `json:"type_entity_id,omitempty"`
 	HasChildren  bool     `json:"has_children"`
@@ -270,6 +276,7 @@ func buildShapeRow(grp *DashGroup, field *graph.Entity) v2ShapeRow {
 		Name:        name,
 		Type:        typ,
 		Annotations: annotations,
+		Validations: fieldValidations(field),
 		Nullable:    inferNullable(annotations, typ),
 	}
 	// Resolve the field's element type to a class entity so the frontend
@@ -284,6 +291,32 @@ func buildShapeRow(grp *DashGroup, field *graph.Entity) v2ShapeRow {
 		}
 	}
 	return row
+}
+
+// fieldValidations reads the per-field validation constraints stamped onto a
+// field entity by the extractor (#4858) under Properties["validations"]
+// (comma-joined). Returns nil when the field carries none. The list is rendered
+// by the dashboard as small constraint chips next to the field type — e.g.
+// ["IsString","MaxLength:120","IsOptional"] for a class-validator DTO field.
+func fieldValidations(field *graph.Entity) []string {
+	if field == nil || field.Properties == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(field.Properties["validations"])
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := parts[:0]
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // parseFieldSignature splits a Java field signature like

--- a/internal/dashboard/shape_tree_test.go
+++ b/internal/dashboard/shape_tree_test.go
@@ -375,6 +375,39 @@ func TestShape_InferNullable(t *testing.T) {
 	}
 }
 
+// TestShape_FieldValidationsChips covers #4858 — buildShapeRow surfaces the
+// class-validator constraints stamped on a field entity (Properties["validations"],
+// comma-joined) as the row's Validations slice for the dashboard chips. A field
+// without the property yields an empty (nil) slice.
+func TestShape_FieldValidationsChips(t *testing.T) {
+	grp := &DashGroup{}
+	cases := []struct {
+		name  string
+		props map[string]string
+		want  []string
+	}{
+		{"name", map[string]string{"validations": "IsString,MaxLength:120,IsOptional"},
+			[]string{"IsString", "MaxLength:120", "IsOptional"}},
+		{"email", map[string]string{"validations": "IsEmail"}, []string{"IsEmail"}},
+		{"plain", map[string]string{}, nil},
+		{"sloppy", map[string]string{"validations": " IsInt , Min:0 ,"},
+			[]string{"IsInt", "Min:0"}},
+	}
+	for _, c := range cases {
+		field := &graph.Entity{
+			Name:       "CreateUserDto." + c.name,
+			Kind:       "SCOPE.Schema",
+			Subtype:    "field",
+			Signature:  c.name + ": string",
+			Properties: c.props,
+		}
+		row := buildShapeRow(grp, field)
+		if !reflect.DeepEqual(row.Validations, c.want) {
+			t.Errorf("field %q: Validations=%v want %v", c.name, row.Validations, c.want)
+		}
+	}
+}
+
 // nestMappedTypeFixture models the live upvate-v3 NestJS mapped-type DTO shape:
 // CreateThingBody owns its fields, UpdateThingBody (extends PartialType(...))
 // owns NONE — its field-set is inherited via the EXTENDS edge that #4845's

--- a/internal/extractors/javascript/class_validator_fields.go
+++ b/internal/extractors/javascript/class_validator_fields.go
@@ -1,0 +1,165 @@
+package javascript
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Issue #4858 — per-field validation constraints for DTO fields.
+//
+// NestJS DTOs use class-validator decorators on their properties, e.g.
+//
+//	class CreateUserDto {
+//	  @IsString()
+//	  @MaxLength(120)
+//	  @IsOptional()
+//	  name?: string;
+//	}
+//
+// Each such field already becomes a SCOPE.Schema/field entity (#679/#4845).
+// This pass collects the class-validator decorators attached to a
+// `public_field_definition` and returns them as a compact, terse list such as
+//
+//	["IsString", "MaxLength:120", "IsOptional"]
+//
+// The list is stored on the field entity under Properties["validations"]
+// (comma-joined, since Properties is map[string]string) so the dashboard
+// ShapeTree can surface them as small constraint chips next to the type.
+//
+// Only recognised class-validator decorators are collected; unrelated
+// decorators (`@Type`, `@Transform`, `@ApiProperty`, …) are ignored so the
+// chips stay focused on validation semantics. The order of source decorators
+// is preserved.
+
+// classValidatorDecorators is the set of recognised class-validator property
+// decorators. Sourced from the class-validator public decorator surface
+// (common-validation, type-checks, string/number/date specific, nested).
+// Membership-only: argument values (e.g. the `120` in `@MaxLength(120)`) are
+// folded into the chip text separately for the small number of decorators that
+// carry a single scalar bound.
+var classValidatorDecorators = map[string]bool{
+	// Common
+	"IsDefined": true, "IsOptional": true, "Equals": true, "NotEquals": true,
+	"IsEmpty": true, "IsNotEmpty": true, "IsIn": true, "IsNotIn": true,
+	// Type checks
+	"IsBoolean": true, "IsDate": true, "IsString": true, "IsNumber": true,
+	"IsInt": true, "IsArray": true, "IsEnum": true, "IsObject": true,
+	// Number
+	"IsDivisibleBy": true, "IsPositive": true, "IsNegative": true,
+	"Min": true, "Max": true,
+	// Date
+	"MinDate": true, "MaxDate": true,
+	// String-type
+	"IsBooleanString": true, "IsDateString": true, "IsNumberString": true,
+	// String
+	"Contains": true, "NotContains": true, "IsAlpha": true, "IsAlphanumeric": true,
+	"IsAscii": true, "IsBase64": true, "IsByteLength": true, "IsCreditCard": true,
+	"IsCurrency": true, "IsEmail": true, "IsFQDN": true, "IsFullWidth": true,
+	"IsHalfWidth": true, "IsVariableWidth": true, "IsHexColor": true,
+	"IsHexadecimal": true, "IsMacAddress": true, "IsIP": true, "IsPort": true,
+	"IsISBN": true, "IsISIN": true, "IsISO8601": true, "IsJSON": true,
+	"IsJWT": true, "IsLowercase": true, "IsLatLong": true, "IsLatitude": true,
+	"IsLongitude": true, "IsMobilePhone": true, "IsMongoId": true,
+	"IsMultibyte": true, "IsNumberString2": true, "IsSurrogatePair": true,
+	"IsUrl": true, "IsURL": true, "IsUUID": true, "IsFirebasePushId": true,
+	"IsUppercase": true, "Length": true, "MaxLength": true, "MinLength": true,
+	"Matches": true, "IsPhoneNumber": true, "IsMilitaryTime": true,
+	"IsHash": true, "IsSemVer": true,
+	// Array
+	"ArrayContains": true, "ArrayNotContains": true, "ArrayNotEmpty": true,
+	"ArrayMinSize": true, "ArrayMaxSize": true, "ArrayUnique": true,
+	// Object / nested
+	"IsInstance": true, "ValidateNested": true, "ValidateIf": true,
+	"IsNotEmptyObject": true, "Allow": true,
+}
+
+// scalarArgDecorators are the class-validator decorators whose first argument is
+// a single scalar bound worth folding into the chip text (e.g.
+// `@MaxLength(120)` → "MaxLength:120"). For everything else we keep the bare
+// decorator name to stay terse and avoid rendering regexes / option objects.
+var scalarArgDecorators = map[string]bool{
+	"MaxLength": true, "MinLength": true, "Min": true, "Max": true,
+	"Length": true, "ArrayMinSize": true, "ArrayMaxSize": true,
+	"IsByteLength": true, "MinDate": true, "MaxDate": true,
+}
+
+// fieldValidations walks the decorator children of a `public_field_definition`
+// (or `field_definition`) node and returns the recognised class-validator
+// constraints as a compact, source-ordered list. Returns nil when the field
+// carries no class-validator decorators.
+func (x *extractor) fieldValidations(field *sitter.Node) []string {
+	if field == nil {
+		return nil
+	}
+	var out []string
+	for i := 0; i < int(field.ChildCount()); i++ {
+		c := field.Child(i)
+		if c == nil || c.Type() != "decorator" {
+			continue
+		}
+		name, call := x.decoratorIdent(c)
+		// Strip a namespace prefix (`validator.IsString` → `IsString`).
+		if idx := strings.LastIndex(name, "."); idx >= 0 {
+			name = name[idx+1:]
+		}
+		if name == "" || !classValidatorDecorators[name] {
+			continue
+		}
+		chip := name
+		if scalarArgDecorators[name] && call != nil {
+			if v := firstScalarArg(x, call); v != "" {
+				chip = name + ":" + v
+			}
+		}
+		out = append(out, chip)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// firstScalarArg returns the text of the first argument of a decorator
+// call_expression when it is a simple numeric / string / identifier literal.
+// Compound arguments (objects, arrays, regexes, expressions) yield "" so the
+// caller falls back to the bare decorator name.
+func firstScalarArg(x *extractor, call *sitter.Node) string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	for i := 0; i < int(args.ChildCount()); i++ {
+		a := args.Child(i)
+		if a == nil {
+			continue
+		}
+		switch a.Type() {
+		case "number", "true", "false", "identifier":
+			return x.nodeText(a)
+		case "string":
+			// Drop the surrounding quotes for a tighter chip.
+			return strings.Trim(x.nodeText(a), "'\"`")
+		case "(", ")", ",", "comment":
+			continue
+		default:
+			// First non-trivial argument is non-scalar — bail.
+			return ""
+		}
+	}
+	return ""
+}
+
+// applyFieldValidations stamps the validations list onto a field entity's
+// Properties map (creating it if nil). Stored comma-joined since Properties is
+// map[string]string; the dashboard splits on "," to rebuild the list.
+func applyFieldValidations(props map[string]string, validations []string) map[string]string {
+	if len(validations) == 0 {
+		return props
+	}
+	if props == nil {
+		props = map[string]string{}
+	}
+	props["validations"] = strings.Join(validations, ",")
+	return props
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -1199,7 +1199,17 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 			if typeNode := n.ChildByFieldName("type"); typeNode != nil {
 				sig = name + ": " + x.nodeText(typeNode)
 			}
-			x.emit(emittedName, "SCOPE.Schema", n, "field", sig)
+			// Issue #4858 — attach class-validator constraints (if any) as
+			// structured metadata so the dashboard can render them as chips.
+			if validations := x.fieldValidations(n); len(validations) > 0 {
+				props := applyFieldValidations(map[string]string{
+					"kind":    "SCOPE.Schema",
+					"subtype": "field",
+				}, validations)
+				x.emitWithProps(emittedName, "SCOPE.Schema", n, "field", sig, props, nil)
+			} else {
+				x.emit(emittedName, "SCOPE.Schema", n, "field", sig)
+			}
 		}
 		x.walkChildren(n, parentClass, cb)
 		return

--- a/internal/extractors/javascript/issue4858_field_validations_test.go
+++ b/internal/extractors/javascript/issue4858_field_validations_test.go
@@ -1,0 +1,80 @@
+// Package javascript — issue #4858 per-field validation-constraint extraction.
+//
+// A NestJS DTO field decorated with class-validator decorators
+// (`@IsString() @MaxLength(120) @IsOptional() name?: string`) should carry
+// those constraints as structured metadata on its SCOPE.Schema/field entity
+// (Properties["validations"], comma-joined) so the dashboard ShapeTree can
+// render them as small constraint chips next to the field type.
+package javascript_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// fieldValidationsProp returns the value of Properties["validations"] for the
+// SCOPE.Schema/field entity named "<class>.<field>", or "" when the field or
+// property is absent.
+func fieldValidationsProp(ents []types.EntityRecord, className, field string) string {
+	want := className + "." + field
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && e.Name == want {
+			if e.Properties == nil {
+				return ""
+			}
+			return e.Properties["validations"]
+		}
+	}
+	return ""
+}
+
+func TestDTO_ClassValidatorConstraintsStampedOnField(t *testing.T) {
+	path := "src/user/dto/create-user.dto.ts"
+	src := []byte(`
+import { IsString, IsOptional, MaxLength, MinLength, IsEmail, IsInt, Min, Max } from 'class-validator';
+
+export class CreateUserDto {
+  @IsString()
+  @MinLength(2)
+  @MaxLength(120)
+  @IsOptional()
+  name?: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsInt()
+  @Min(0)
+  @Max(150)
+  age: number;
+
+  // No validation decorators — must carry no validations property.
+  nickname: string;
+}
+`)
+	ents := extractHeritageTS(t, path, src)
+
+	cases := []struct {
+		field string
+		want  []string
+	}{
+		{"name", []string{"IsString", "MinLength:2", "MaxLength:120", "IsOptional"}},
+		{"email", []string{"IsEmail"}},
+		{"age", []string{"IsInt", "Min:0", "Max:150"}},
+	}
+	for _, c := range cases {
+		got := fieldValidationsProp(ents, "CreateUserDto", c.field)
+		want := strings.Join(c.want, ",")
+		if got != want {
+			t.Errorf("field %q validations = %q, want %q", c.field, got, want)
+		}
+	}
+
+	// A field with no class-validator decorators must NOT carry a validations
+	// property (avoid empty chips in the dashboard).
+	if v := fieldValidationsProp(ents, "CreateUserDto", "nickname"); v != "" {
+		t.Errorf("nickname should have no validations, got %q", v)
+	}
+}

--- a/webui-v2/src/components/ShapeTree.tsx
+++ b/webui-v2/src/components/ShapeTree.tsx
@@ -351,6 +351,23 @@ function NestedFieldRow({
         >
           {optional ? "optional" : "required"}
         </span>
+        {field.validations && field.validations.length > 0 && (
+          <span
+            data-testid={`shape-field-validations-${field.name}`}
+            className="flex items-center gap-1 min-w-0 overflow-hidden"
+          >
+            {field.validations.map((v) => (
+              <span
+                key={v}
+                data-testid={`validation-chip-${v}`}
+                className="inline-flex items-center px-1 py-0.5 rounded-sm text-[10px] font-medium font-mono shrink-0 bg-[var(--info-soft)] text-[var(--info)] border border-[var(--info-soft)]"
+                title={v}
+              >
+                {v}
+              </span>
+            ))}
+          </span>
+        )}
         {field.annotations && field.annotations.length > 0 && (
           <span className="text-text-4 truncate font-mono text-[11px]">
             {field.annotations.join(" ")}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -906,6 +906,13 @@ export interface ShapeRow {
   name: string;
   type: string;
   annotations?: string[];
+  /**
+   * Per-field validation constraint chips (#4858), parsed from the field's
+   * validation decorators — e.g. for a NestJS DTO field
+   * `@IsString() @MaxLength(120) @IsOptional() name?: string` this is
+   * ["IsString","MaxLength:120","IsOptional"]. Absent for fields with none.
+   */
+  validations?: string[];
   nullable?: boolean;
   type_entity_id?: string;
   has_children: boolean;


### PR DESCRIPTION
## What

Per-field **validation constraints** for DTO fields, surfaced as small chips in the Params/Response ShapeTree. Starts with the live case — NestJS class-validator.

### Backend (TS extractor)
`internal/extractors/javascript/class_validator_fields.go` (new) walks the `decorator` children of a class `public_field_definition` and collects recognised class-validator decorators (`@IsString`, `@MaxLength`, `@IsOptional`, `@IsEmail`, `@IsEnum`, `@Min`, `@ValidateNested`, …) into a terse, source-ordered list. Scalar-arg decorators (`@MaxLength(120)`, `@Min(0)`) fold the bound into the chip text (`MaxLength:120`). The list is stamped on the existing `SCOPE.Schema/field` entity as `Properties["validations"]` (comma-joined). Fields with no class-validator decorators carry nothing (no empty chips). Interfaces/type-aliases are unchanged — class-validator only applies to classes.

### Shape row + render
- `internal/dashboard/shape_tree.go`: new `v2ShapeRow.Validations []string`, populated from the field entity metadata via `fieldValidations(field)`.
- `webui-v2/src/components/ShapeTree.tsx` + `data/types.ts`: each field's `validations` renders as compact constraint chips next to the type.

### Fixtures
- `TestDTO_ClassValidatorConstraintsStampedOnField` — NestJS DTO with `@IsString/@MinLength/@MaxLength/@IsOptional/@IsEmail/@IsInt/@Min/@Max` asserts the field entity carries the exact validations list; an undecorated field carries none.
- `TestShape_FieldValidationsChips` — `buildShapeRow` exposes the validations slice (incl. sloppy-whitespace trimming).

## Generalize verdict (per the standing rule)

| Framework | Status | Notes |
|---|---|---|
| TS / NestJS class-validator | **Done (this PR)** | field metadata + chips |
| Java Bean Validation (`@NotNull`/`@Size`/`@Pattern`) | **Already surfaces** | encoded in the field signature → already split into the row's `annotations` (visible today, plain text). Migrating to the new chip styling tracked in **#4872**. |
| Python Pydantic (`Field(...)`/`Annotated`), DRF, marshmallow, attrs | **Deferred → #4871** | field entities exist but carry no constraint metadata yet. |

No faked coverage — deferred frameworks get tracking issues.

## Coverage docs
`docs/coverage/registry.json` `lang.jsts.framework.nestjs` → `Validation/dto_extraction` note + cites updated for the per-field `validations` metadata. `go run ./tools/coverage fmt --check` and `validate` both pass.

## Gates
- `go build ./...`, `go vet ./internal/...` clean.
- `go test ./internal/extractors/... ./internal/dashboard/... ./internal/types/` pass.
- `npx tsc --noEmit`, `npm run build`, `npx vitest run` → **143 unit tests pass**; the 12 failed files are pre-existing Playwright e2e specs unrelated to this change.

Deploy-deferred — no live daemon touched.

Closes #4858 (TS class-validator). Follow-ups: #4871 (Python), #4872 (Java chips).