### PR TITLE
feat(#4819): Flowchart view for endpoints (Tree|Flowchart toggle + Detail slider, branch-level CFG)

### DIFF
--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -751,6 +751,10 @@ func (s *Server) routes() http.Handler {
 	// #4349 (epic #4348) — endpoint downstream-DAG for the endpoint-flow modal:
 	// branching call tree rooted at the endpoint (depth/collapse/semantic).
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths/{hash}/downstream-dag", s.handleV2PathDownstreamDAG)
+	// #4819 (epic #4820) — endpoint handler control-flow (CFG) for the
+	// Downstream-flow Flowchart view: on-demand flowchart of the handler function
+	// (reuses the internal/substrate CFG builder; detail = outline|decisions|data|full).
+	mux.HandleFunc("GET /api/v2/groups/{id}/paths/{hash}/control-flow", s.handleV2PathControlFlow)
 	// #1935 Phase 1 — ShapeTree subtree resolution (lazy class-field walk).
 	mux.HandleFunc("GET /api/v2/groups/{id}/shape", s.handleV2Shape)
 	// #4499 — shared "source peek": window of source for any file:line ref.

--- a/internal/dashboard/v2_paths_control_flow.go
+++ b/internal/dashboard/v2_paths_control_flow.go
@@ -1,0 +1,361 @@
+// v2_paths_control_flow.go — endpoint handler control-flow (CFG) surface for
+// WebUI v2 (#4819, control-flow epic #4820).
+//
+// Route:
+//
+//	GET /api/v2/groups/:id/paths/:hash/control-flow?verb=&detail= → v2ControlFlowResponse
+//
+// Given an HTTP endpoint (resolved from the path hash + optional ?verb), this
+// returns the ON-DEMAND control-flow graph (CFG) of the endpoint's HANDLER
+// function — the flowchart the Downstream-flow modal renders when the user
+// flips the View toggle from Tree to Flowchart.
+//
+// It is the dashboard sibling of the archigraph_control_flow MCP tool
+// (internal/mcp/control_flow_tool.go): both REUSE the one CFG builder in
+// internal/substrate (BuildControlFlowGraphCached) — no basic-block entities are
+// ever written to the graph (the graph stays lean, per #4822). The CFG is built
+// for the one handler function at request time and cached in-memory by
+// (entity id, source hash).
+//
+// Handler resolution mirrors the downstream-DAG (#4349): the endpoint root is
+// resolved by (path hash, verb) and the handler is the far side of the reversed
+// `handler --IMPLEMENTS--> http_endpoint_definition` continuation edge. The CFG
+// is built from THAT handler's source window.
+//
+// Detail levels (token control, #2828) parameterise the payload exactly like the
+// MCP tool so the frontend slider maps 1:1:
+//
+//	outline    → node shapes + lines + complexity, no conditions/effects/labels
+//	decisions  → outline + condition text on decision/loop nodes (default)
+//	data       → decisions + effect annotations on process nodes
+//	full       → data + node labels (the trimmed source line per node)
+//
+// Languages: Python + JS/TS first (the validated set). Other languages return
+// supported=false with a degenerate start→process→end graph so the frontend can
+// show a graceful "flowchart not available for this language" state. Read-only,
+// deterministic.
+
+package dashboard
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/substrate"
+)
+
+// ---------------------------------------------------------------------------
+// Wire types — the contract the Downstream-flow flowchart view (#4819) consumes.
+// ---------------------------------------------------------------------------
+
+// v2CFGEffect is a terse effect annotation on a process node.
+type v2CFGEffect struct {
+	Effect string `json:"effect"`
+	Sink   string `json:"sink,omitempty"`
+}
+
+// v2CFGNode is one basic block / decision / terminal in the handler's CFG. The
+// shape drives the flowchart glyph: start/end terminals (rounded), decision
+// (diamond, carries Condition), loop (carries Condition + is a back-edge
+// target), process (rectangle, carries Effects), return/throw (terminals).
+type v2CFGNode struct {
+	ID    string `json:"id"`
+	Shape string `json:"shape"`
+	Line  int    `json:"line,omitempty"`
+	// Label is the trimmed source line (full detail only).
+	Label string `json:"label,omitempty"`
+	// Condition is the predicate text on decision/loop nodes (decisions detail+).
+	Condition string `json:"condition,omitempty"`
+	// Effects annotate a process node (data detail+).
+	Effects []v2CFGEffect `json:"effects,omitempty"`
+}
+
+// v2CFGEdge is one directed control-flow edge between two node IDs. Kind is one
+// of seq / branch_true / branch_false / loop_back / exit so the renderer can
+// label and route the flowchart edges (the true/false branches off a diamond,
+// the loop back-edge, the early return/throw exits).
+type v2CFGEdge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+	Kind string `json:"kind"`
+}
+
+// v2ControlFlowResponse is the payload for
+// GET /api/v2/groups/:id/paths/:hash/control-flow.
+type v2ControlFlowResponse struct {
+	Path string `json:"path"`
+	Verb string `json:"verb"`
+	// Detail echoes the resolved detail level (outline|decisions|data|full).
+	Detail string `json:"detail"`
+	// Language is the resolved handler language slug ("python","jsts",…).
+	Language string `json:"language"`
+	// Supported is false when no block detector exists for the language (the CFG
+	// degenerates to start→process→end). The frontend shows a graceful
+	// "flowchart not available for this language" state when false.
+	Supported bool `json:"supported"`
+	// Note carries a human explanation when Supported is false (or the handler
+	// could not be resolved / read).
+	Note string `json:"note,omitempty"`
+	// Handler describes the resolved handler function the CFG was built from, so
+	// the modal can title the flowchart. Empty when no handler resolved.
+	Handler *v2CFGHandler `json:"handler,omitempty"`
+	// Cyclomatic is the McCabe cyclomatic complexity of the handler.
+	Cyclomatic int `json:"cyclomatic_complexity"`
+	// BranchCount is the raw decision-point count (Cyclomatic - 1).
+	BranchCount int         `json:"branch_count"`
+	Nodes       []v2CFGNode `json:"nodes"`
+	Edges       []v2CFGEdge `json:"edges"`
+}
+
+// v2CFGHandler describes the handler function the CFG was built from.
+type v2CFGHandler struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	File string `json:"file,omitempty"`
+	Line int    `json:"line,omitempty"`
+	Repo string `json:"repo"`
+}
+
+// cfgBodyFallbackSpan mirrors the MCP branchSourceSpan fallback: an entity whose
+// recorded EndLine is degenerate (<= StartLine) gets a generous window; the
+// CFG builder self-bounds by indentation / brace depth.
+const cfgBodyFallbackSpan = 400
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// handleV2PathControlFlow — GET /api/v2/groups/:id/paths/:hash/control-flow
+//
+// Query params:
+//
+//	verb   — disambiguate when a path has multiple verb endpoints (optional;
+//	         default = first verb by deterministic ID order — same as the DAG).
+//	detail — outline | decisions (default) | data | full.
+func (s *Server) handleV2PathControlFlow(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	pathHash := r.PathValue("hash")
+	if id == "" || pathHash == "" {
+		writeV2Err(w, http.StatusBadRequest, "params_required", "group id and path hash required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(id)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "group_not_found", err.Error())
+		return
+	}
+
+	q := r.URL.Query()
+	detail := normalizeCFGDetail(q.Get("detail"))
+	wantVerb := strings.ToUpper(strings.TrimSpace(q.Get("verb")))
+
+	// Resolve the endpoint root for (path hash, verb) — same resolver the
+	// downstream-DAG uses so the two surfaces never drift on which endpoint a
+	// hash maps to.
+	root := resolveDAGRoot(grp, pathHash, wantVerb)
+	if root == nil {
+		writeV2Err(w, http.StatusNotFound, "path_not_found", "no endpoint found for path hash: "+pathHash)
+		return
+	}
+
+	resp := v2ControlFlowResponse{
+		Path:   root.path,
+		Verb:   root.verb,
+		Detail: detail,
+		Nodes:  []v2CFGNode{},
+		Edges:  []v2CFGEdge{},
+	}
+
+	// Cross the HTTP boundary: the handler is the far side of the reversed
+	// `handler --IMPLEMENTS--> endpoint def` continuation edge.
+	handler := resolveCFGHandler(root)
+	if handler == nil {
+		resp.Supported = false
+		resp.Note = "no handler function is linked to this endpoint (no IMPLEMENTS edge); cannot build a flowchart."
+		writeV2JSON(w, http.StatusOK, v2OK(resp))
+		return
+	}
+	resp.Handler = &v2CFGHandler{
+		ID:   dashPrefixedID(root.repo.Slug, handler.ID),
+		Name: handler.Name,
+		Kind: dashStripScopePrefix(handler.Kind),
+		File: handler.SourceFile,
+		Line: handler.StartLine,
+		Repo: root.repo.Slug,
+	}
+
+	lang := substrate.LanguageForPath(handler.SourceFile)
+	resp.Language = lang
+
+	src, start, ok := readCFGHandlerSource(grp, root.repo, handler)
+	if !ok {
+		resp.Supported = false
+		resp.Note = "handler source window unreadable; cannot build a flowchart."
+		writeV2JSON(w, http.StatusOK, v2OK(resp))
+		return
+	}
+
+	// REUSE the one CFG builder (internal/substrate) — never reimplemented here.
+	g := substrate.BuildControlFlowGraphCached(dashPrefixedID(root.repo.Slug, handler.ID), lang, src, start)
+	resp.Supported = g.Supported
+	resp.Cyclomatic = g.Cyclomatic
+	resp.BranchCount = g.BranchCount
+	if !g.Supported {
+		resp.Note = "flowchart not available for this language yet (validated: python, jsts); showing a degenerate graph."
+	}
+	resp.Nodes = cfgNodesToWire(g.Nodes, detail)
+	resp.Edges = cfgEdgesToWire(g.Edges)
+
+	writeV2JSON(w, http.StatusOK, v2OK(resp))
+}
+
+// ---------------------------------------------------------------------------
+// Handler resolution + source read
+// ---------------------------------------------------------------------------
+
+// resolveCFGHandler finds the handler function entity for an endpoint root by
+// reversing the `handler --IMPLEMENTS--> http_endpoint_definition` edge — the
+// same HTTP-boundary crossing the downstream-DAG uses. When several handlers
+// implement the same endpoint (rare) the first by entity ID wins, deterministic.
+func resolveCFGHandler(root *dagRoot) *graph.Entity {
+	if root == nil || root.repo == nil || root.repo.Doc == nil {
+		return nil
+	}
+	doc := root.repo.Doc
+	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		byID[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+	var best *graph.Entity
+	for i := range doc.Relationships {
+		rel := &doc.Relationships[i]
+		if rel.Kind != "IMPLEMENTS" || rel.ToID != root.ent.ID || rel.FromID == rel.ToID {
+			continue
+		}
+		h := byID[rel.FromID]
+		if h == nil {
+			continue
+		}
+		if best == nil || h.ID < best.ID {
+			best = h
+		}
+	}
+	return best
+}
+
+// readCFGHandlerSource reads the handler's source window (raw, no line-number
+// prefix — the CFG builder regexes over verbatim source) and returns it with the
+// 1-indexed absolute start line. Resolves the on-disk path through the group's
+// repo roots (path-traversal guarded by resolveSourcePath).
+func readCFGHandlerSource(grp *DashGroup, repo *DashRepo, e *graph.Entity) (src string, start int, ok bool) {
+	start = e.StartLine
+	if start <= 0 {
+		return "", 0, false
+	}
+	end := e.EndLine
+	if end <= start {
+		end = start + cfgBodyFallbackSpan // builder self-bounds by indent/brace.
+	}
+
+	abs, _, _, found := resolveSourcePath(grp, e.SourceFile, repo.Slug)
+	if !found {
+		return "", 0, false
+	}
+	all, err := readAllLines(abs)
+	if err != nil || len(all) == 0 {
+		return "", 0, false
+	}
+	if start > len(all) {
+		return "", 0, false
+	}
+	if end > len(all) {
+		end = len(all)
+	}
+	var b strings.Builder
+	for i := start; i <= end; i++ {
+		b.WriteString(all[i-1])
+		b.WriteByte('\n')
+	}
+	out := b.String()
+	if strings.TrimSpace(out) == "" {
+		return "", 0, false
+	}
+	return out, start, true
+}
+
+// ---------------------------------------------------------------------------
+// Detail-level serialisation (mirrors the MCP tool's cfgNodesToJSON, #2828)
+// ---------------------------------------------------------------------------
+
+// normalizeCFGDetail clamps the detail query param to a known level, defaulting
+// to "decisions" (the same default as the MCP tool + the frontend slider).
+func normalizeCFGDetail(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "outline":
+		return "outline"
+	case "data":
+		return "data"
+	case "full":
+		return "full"
+	case "", "decisions":
+		return "decisions"
+	default:
+		return "decisions"
+	}
+}
+
+// cfgDetailRank gives a numeric ordering so the serialiser can gate fields by
+// "at least this level": outline < decisions < data < full.
+func cfgDetailRank(detail string) int {
+	switch detail {
+	case "outline":
+		return 0
+	case "decisions":
+		return 1
+	case "data":
+		return 2
+	case "full":
+		return 3
+	default:
+		return 1
+	}
+}
+
+// cfgNodesToWire serialises CFG nodes, including only the fields the detail
+// level asks for (token control, #2828) — identical gating to the MCP tool so
+// the two surfaces produce the same shapes at the same level.
+func cfgNodesToWire(nodes []substrate.CFGNode, detail string) []v2CFGNode {
+	rank := cfgDetailRank(detail)
+	out := make([]v2CFGNode, 0, len(nodes))
+	for _, n := range nodes {
+		w := v2CFGNode{ID: n.ID, Shape: string(n.Shape), Line: n.Line}
+		if rank >= 1 && n.Condition != "" { // decisions+
+			w.Condition = n.Condition
+		}
+		if rank >= 2 && len(n.Effects) > 0 { // data+
+			effs := make([]v2CFGEffect, 0, len(n.Effects))
+			for _, ef := range n.Effects {
+				effs = append(effs, v2CFGEffect{Effect: ef.Effect, Sink: ef.Sink})
+			}
+			w.Effects = effs
+		}
+		if rank >= 3 && n.Label != "" { // full
+			w.Label = n.Label
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+// cfgEdgesToWire serialises the control-flow edges (kind preserved for the
+// flowchart edge labelling/routing).
+func cfgEdgesToWire(edges []substrate.CFGEdge) []v2CFGEdge {
+	out := make([]v2CFGEdge, 0, len(edges))
+	for _, e := range edges {
+		out = append(out, v2CFGEdge{From: e.From, To: e.To, Kind: string(e.Kind)})
+	}
+	return out
+}

--- a/internal/dashboard/v2_paths_control_flow_test.go
+++ b/internal/dashboard/v2_paths_control_flow_test.go
@@ -1,0 +1,261 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// makeControlFlowFixture writes a real handler source file to a temp repo root
+// (the CFG builder reads verbatim source from disk) and returns a DashGroup
+// wired:
+//
+//	http_endpoint_definition (GET /inspections)
+//	  <--IMPLEMENTS-- InspectionController.list (handler, the CFG target)
+//
+// The handler body has a decision (if), a loop (for), an early return, a throw,
+// and a db_write effect line so the CFG exercises every shape + detail level.
+func makeControlFlowFixture(t *testing.T) *DashGroup {
+	t.Helper()
+	root := t.TempDir()
+	handlerSrc := `async list(req, res) {
+  const user = req.user;
+  if (!user) {
+    throw new ForbiddenError("no user");
+  }
+  const rows = await this.repo.find(req.query);
+  for (const row of rows) {
+    await this.repo.save(row);
+  }
+  return res.json(rows);
+}
+`
+	file := "inspection.controller.ts"
+	if err := os.WriteFile(filepath.Join(root, file), []byte(handlerSrc), 0o644); err != nil {
+		t.Fatalf("write handler src: %v", err)
+	}
+
+	ent := func(id, name, kind string, start, end int) graph.Entity {
+		return graph.Entity{ID: id, Name: name, Kind: kind, SourceFile: file, StartLine: start, EndLine: end}
+	}
+	epEnt := graph.Entity{
+		ID: "ep", Name: "GET /inspections", Kind: "http_endpoint_definition",
+		SourceFile: "routers.ts", StartLine: 1,
+		Properties: map[string]string{"verb": "GET", "path": "/inspections"},
+	}
+	// Handler spans lines 1..11 of the file written above.
+	handler := ent("handler", "InspectionController.list", "Operation", 1, 11)
+
+	doc := &graph.Document{
+		Repo:     "api",
+		Entities: []graph.Entity{epEnt, handler},
+		Relationships: []graph.Relationship{
+			{FromID: "handler", ToID: "ep", Kind: "IMPLEMENTS"},
+		},
+	}
+	return &DashGroup{
+		Name:  "testgrp",
+		Repos: map[string]*DashRepo{"api": {Slug: "api", Path: root, Doc: doc}},
+	}
+}
+
+// fetchControlFlow issues the control-flow request and decodes the payload.
+func fetchControlFlow(t *testing.T, ts *httptest.Server, query string) v2ControlFlowResponse {
+	t.Helper()
+	pathHash := hashStr("/inspections")
+	url := ts.URL + "/api/v2/groups/testgrp/paths/" + pathHash + "/control-flow"
+	if query != "" {
+		url += "?" + query
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET control-flow: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool                  `json:"ok"`
+		Data v2ControlFlowResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Fatalf("ok: want true")
+	}
+	return body.Data
+}
+
+func cfgShapes(nodes []v2CFGNode, shape string) []v2CFGNode {
+	var out []v2CFGNode
+	for _, n := range nodes {
+		if n.Shape == shape {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func cfgHasEdgeKind(edges []v2CFGEdge, kind string) bool {
+	for _, e := range edges {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestControlFlow_HandlerResolvedAndCFGBuilt asserts the endpoint→handler→CFG
+// pipeline: the handler is resolved via the reversed IMPLEMENTS edge, the CFG is
+// JS/TS-supported, and it carries the start/end terminals, a decision, a loop, a
+// throw, and a return — plus the branch/loop/exit edge kinds.
+func TestControlFlow_HandlerResolvedAndCFGBuilt(t *testing.T) {
+	ts := newPathsTestServer(t, makeControlFlowFixture(t))
+	defer ts.Close()
+
+	cf := fetchControlFlow(t, ts, "") // default detail=decisions.
+
+	if cf.Path != "/inspections" || cf.Verb != "GET" {
+		t.Errorf("path/verb: got %q %q", cf.Path, cf.Verb)
+	}
+	if cf.Detail != "decisions" {
+		t.Errorf("detail: want decisions, got %q", cf.Detail)
+	}
+	if cf.Language != "jsts" {
+		t.Errorf("language: want jsts, got %q", cf.Language)
+	}
+	if !cf.Supported {
+		t.Fatalf("supported: want true for jsts; note=%q", cf.Note)
+	}
+	if cf.Handler == nil || cf.Handler.Name != "InspectionController.list" {
+		t.Fatalf("handler not resolved: %+v", cf.Handler)
+	}
+	if cf.Handler.ID != "api::handler" {
+		t.Errorf("handler id: want api::handler, got %q", cf.Handler.ID)
+	}
+
+	if len(cfgShapes(cf.Nodes, "start")) != 1 {
+		t.Errorf("want exactly one start node")
+	}
+	if len(cfgShapes(cf.Nodes, "end")) != 1 {
+		t.Errorf("want exactly one end node")
+	}
+	if len(cfgShapes(cf.Nodes, "decision")) < 1 {
+		t.Errorf("want a decision node for the `if`")
+	}
+	if len(cfgShapes(cf.Nodes, "loop")) < 1 {
+		t.Errorf("want a loop node for the `for`")
+	}
+	if len(cfgShapes(cf.Nodes, "throw")) < 1 {
+		t.Errorf("want a throw terminal")
+	}
+	if len(cfgShapes(cf.Nodes, "return")) < 1 {
+		t.Errorf("want a return terminal")
+	}
+	if !cfgHasEdgeKind(cf.Edges, "loop_back") {
+		t.Errorf("want a loop_back edge")
+	}
+	if !cfgHasEdgeKind(cf.Edges, "exit") {
+		t.Errorf("want an exit edge (early return/throw)")
+	}
+	if cf.Cyclomatic < 2 {
+		t.Errorf("cyclomatic: want >= 2 (if + for), got %d", cf.Cyclomatic)
+	}
+}
+
+// TestControlFlow_DetailLevels asserts the detail slider maps to progressively
+// richer payloads: outline drops conditions, decisions adds them, data adds
+// effects, full adds labels. Identical gating to the MCP tool (#2828).
+func TestControlFlow_DetailLevels(t *testing.T) {
+	ts := newPathsTestServer(t, makeControlFlowFixture(t))
+	defer ts.Close()
+
+	anyCondition := func(ns []v2CFGNode) bool {
+		for _, n := range ns {
+			if n.Condition != "" {
+				return true
+			}
+		}
+		return false
+	}
+	anyEffect := func(ns []v2CFGNode) bool {
+		for _, n := range ns {
+			if len(n.Effects) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+	anyLabel := func(ns []v2CFGNode) bool {
+		for _, n := range ns {
+			if n.Label != "" {
+				return true
+			}
+		}
+		return false
+	}
+
+	outline := fetchControlFlow(t, ts, "detail=outline")
+	if outline.Detail != "outline" {
+		t.Errorf("detail echo: got %q", outline.Detail)
+	}
+	if anyCondition(outline.Nodes) {
+		t.Errorf("outline must not carry conditions")
+	}
+	if anyEffect(outline.Nodes) || anyLabel(outline.Nodes) {
+		t.Errorf("outline must not carry effects/labels")
+	}
+
+	decisions := fetchControlFlow(t, ts, "detail=decisions")
+	if !anyCondition(decisions.Nodes) {
+		t.Errorf("decisions must carry condition text")
+	}
+	if anyEffect(decisions.Nodes) || anyLabel(decisions.Nodes) {
+		t.Errorf("decisions must not carry effects/labels")
+	}
+
+	data := fetchControlFlow(t, ts, "detail=data")
+	if !anyCondition(data.Nodes) {
+		t.Errorf("data must carry conditions")
+	}
+	if !anyEffect(data.Nodes) {
+		t.Errorf("data must carry effect annotations (db_write on save)")
+	}
+	if anyLabel(data.Nodes) {
+		t.Errorf("data must not carry labels")
+	}
+
+	full := fetchControlFlow(t, ts, "detail=full")
+	if !anyLabel(full.Nodes) {
+		t.Errorf("full must carry node labels")
+	}
+}
+
+// TestControlFlow_NoHandler asserts a graceful supported=false when no handler
+// implements the endpoint (no IMPLEMENTS edge).
+func TestControlFlow_NoHandler(t *testing.T) {
+	grp := makeControlFlowFixture(t)
+	// Drop the IMPLEMENTS edge so no handler resolves.
+	grp.Repos["api"].Doc.Relationships = nil
+
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	cf := fetchControlFlow(t, ts, "")
+	if cf.Supported {
+		t.Errorf("supported: want false with no handler")
+	}
+	if cf.Handler != nil {
+		t.Errorf("handler: want nil, got %+v", cf.Handler)
+	}
+	if cf.Note == "" {
+		t.Errorf("want an explanatory note when no handler resolves")
+	}
+}

--- a/webui-v2/src/components/flow-dag/Flowchart.tsx
+++ b/webui-v2/src/components/flow-dag/Flowchart.tsx
@@ -1,0 +1,328 @@
+/* ============================================================
+   components/flow-dag/Flowchart.tsx — the Flowchart VIEW of the Downstream-flow
+   modal (#4819, control-flow epic #4820).
+
+   Where <FlowDag> renders the endpoint's downstream CALL TREE, <Flowchart>
+   renders the on-demand CONTROL-FLOW GRAPH (CFG) of the endpoint's HANDLER
+   function as a classic flowchart: rounded start/end terminals, diamond decision
+   nodes (carrying the condition text), rectangle process steps (badged with
+   their effects at the +Data / Full detail levels), loop-back edges, and labelled
+   branch_true/false / return / throw exit edges.
+
+   It REUSES the same flow canvas + ELK orthogonal layout the tree view uses
+   (`layoutWithElk` from lib/elk-layout, the shared `layered` backend), with
+   flowchart-specific node shapes (FlowchartNode) and edge labels (FlowchartEdge).
+
+   Data source: GET /api/v2/groups/:id/paths/:hash/control-flow (#4819 backend),
+   parameterised by the `detail` slider. When the backend reports
+   `supported=false` (a language without a CFG block detector, or an
+   unresolved/unreadable handler) we render a graceful "flowchart not available"
+   state instead of a degenerate diagram.
+
+   The View toggle (Tree | Flowchart) and the Detail slider live in the parent
+   modal (paths.tsx); this component is driven purely by (detail, direction) +
+   its own fetch, so the Tree view keeps its own controls untouched.
+   ============================================================ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlowProvider,
+  Position,
+  MarkerType,
+  type Node as RFNode,
+  type Edge as RFEdge,
+  type NodeTypes,
+  type EdgeTypes,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import {
+  ArrowRight,
+  ArrowDown,
+  Loader2,
+  AlertTriangle,
+  GitBranch,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  layoutWithElk,
+  type ElkLayoutNode,
+  type ElkLayoutEdge,
+} from "@/lib/elk-layout";
+import { useControlFlow } from "@/hooks/use-paths";
+import type {
+  ControlFlowDetail,
+  ControlFlowResponse,
+} from "@/data/types";
+import type { FlowDagDirection } from "./layout";
+import { FlowchartNode, type FlowchartNodeData } from "./FlowchartNode";
+import { FlowchartEdge, type FlowchartEdgeData } from "./FlowchartEdge";
+import { boxFor, defaultCaption } from "./flowchart-shapes";
+
+const FLOWCHART_NODE_TYPE = "flowchart";
+const FLOWCHART_EDGE_TYPE = "flowchart";
+
+const nodeTypes: NodeTypes = { [FLOWCHART_NODE_TYPE]: FlowchartNode };
+const edgeTypes: EdgeTypes = { [FLOWCHART_EDGE_TYPE]: FlowchartEdge };
+
+function handlePositions(direction: FlowDagDirection): {
+  source: Position;
+  target: Position;
+} {
+  return direction === "LR"
+    ? { source: Position.Right, target: Position.Left }
+    : { source: Position.Bottom, target: Position.Top };
+}
+
+export interface FlowchartProps {
+  groupId: string;
+  pathHash?: string | null;
+  verb?: string;
+  detail: ControlFlowDetail;
+  /** Whether the internal fetch is enabled (only when modal open + view active). */
+  enabled?: boolean;
+  className?: string;
+}
+
+interface LaidOut {
+  nodes: RFNode<FlowchartNodeData>[];
+  edges: RFEdge<FlowchartEdgeData>[];
+}
+
+const EMPTY: LaidOut = { nodes: [], edges: [] };
+
+function FlowchartInner({
+  groupId,
+  pathHash,
+  verb,
+  detail,
+  enabled = true,
+  className,
+}: FlowchartProps) {
+  const [direction, setDirection] = useState<FlowDagDirection>("TB");
+
+  const query = useControlFlow(groupId, pathHash ?? null, detail, verb, enabled);
+  const data: ControlFlowResponse | undefined = query.data;
+  const isLoading = query.isLoading;
+  const error = query.error;
+
+  // Build the React Flow nodes/edges (data only) from the CFG payload, then run
+  // ELK to position them with orthogonal routing — same engine as the tree view.
+  const built = useMemo(() => {
+    if (!data || data.nodes.length === 0) return null;
+    const handles = handlePositions(direction);
+    const nodes: RFNode<FlowchartNodeData>[] = data.nodes.map((n) => {
+      const box = boxFor(n.shape);
+      return {
+        id: n.id,
+        type: FLOWCHART_NODE_TYPE,
+        position: { x: 0, y: 0 },
+        width: box.w,
+        height: box.h,
+        sourcePosition: handles.source,
+        targetPosition: handles.target,
+        data: {
+          shape: n.shape,
+          caption: defaultCaption(n),
+          condition: n.condition,
+          effects: n.effects,
+          line: n.line,
+          sourcePos: handles.source,
+          targetPos: handles.target,
+        },
+      };
+    });
+    const edges: RFEdge<FlowchartEdgeData>[] = data.edges.map((e, i) => ({
+      id: `cfe_${i}_${e.from}_${e.to}_${e.kind}`,
+      source: e.from,
+      target: e.to,
+      type: FLOWCHART_EDGE_TYPE,
+      markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14 },
+      data: { kind: e.kind },
+    }));
+    return { nodes, edges };
+  }, [data, direction]);
+
+  const [laidOut, setLaidOut] = useState<LaidOut>(EMPTY);
+  const [layingOut, setLayingOut] = useState(false);
+  const runId = useRef(0);
+
+  useEffect(() => {
+    if (!built) {
+      setLaidOut(EMPTY);
+      setLayingOut(false);
+      return;
+    }
+    const myRun = ++runId.current;
+    let cancelled = false;
+    setLayingOut(true);
+
+    const elkNodes: ElkLayoutNode[] = built.nodes.map((n) => ({
+      id: n.id,
+      width: n.width,
+      height: n.height,
+    }));
+    const elkEdges: ElkLayoutEdge[] = built.edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      target: e.target,
+    }));
+
+    layoutWithElk(elkNodes, elkEdges, {
+      direction: direction === "LR" ? "RIGHT" : "DOWN",
+      algorithm: "layered",
+      edgeRouting: "ORTHOGONAL",
+      nodeSpacing: 34,
+      layerSpacing: 64,
+    })
+      .then(({ nodes: positions, edges: routes }) => {
+        if (cancelled || myRun !== runId.current) return;
+        const positioned = built.nodes.map((n) => {
+          const p = positions.get(n.id);
+          return p ? { ...n, position: { x: p.x, y: p.y } } : n;
+        });
+        const routed = built.edges.map((e) => {
+          const route = routes.get(e.id);
+          if (route && route.points.length >= 2) {
+            return { ...e, data: { ...(e.data as FlowchartEdgeData), elkPoints: route.points } };
+          }
+          return e;
+        });
+        setLaidOut({ nodes: positioned, edges: routed });
+        setLayingOut(false);
+      })
+      .catch(() => {
+        if (cancelled || myRun !== runId.current) return;
+        // ELK failure → render with un-positioned (0,0) nodes rather than blank;
+        // smooth-step edges still connect them.
+        setLaidOut({ nodes: built.nodes, edges: built.edges });
+        setLayingOut(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [built, direction]);
+
+  const unsupported = data && !data.supported;
+
+  return (
+    <div className={cn("flex flex-col h-full min-h-0", className)}>
+      {/* Controls bar — orientation toggle + handler/complexity label. The View
+          toggle + Detail slider live in the parent modal. */}
+      <div className="flex flex-wrap items-center gap-2 px-3 py-2 border-b border-border bg-surface">
+        <div className="inline-flex rounded-md border border-border overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setDirection("TB")}
+            className={cn(
+              "inline-flex items-center gap-1 h-7 px-2 text-xs transition-colors",
+              direction === "TB" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+            )}
+            title="Vertical layout (top → bottom) — classic flowchart"
+          >
+            <ArrowDown size={12} /> V
+          </button>
+          <button
+            type="button"
+            onClick={() => setDirection("LR")}
+            className={cn(
+              "inline-flex items-center gap-1 h-7 px-2 text-xs transition-colors border-l border-border",
+              direction === "LR" ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+            )}
+            title="Horizontal layout (left → right)"
+          >
+            <ArrowRight size={12} /> H
+          </button>
+        </div>
+
+        {(isLoading || layingOut) && (
+          <span className="inline-flex items-center gap-1 text-xs text-text-4">
+            <Loader2 size={12} className="animate-spin" />
+            {isLoading ? "loading…" : "laying out…"}
+          </span>
+        )}
+
+        {data && data.supported && (
+          <span
+            className="inline-flex items-center gap-1 text-xs text-text-3"
+            title="McCabe cyclomatic complexity of the handler"
+          >
+            <GitBranch size={12} className="text-text-4" />
+            <span className="font-semibold text-text-2 tabular-nums">{data.cyclomatic_complexity}</span>
+            <span className="text-text-4">complexity</span>
+          </span>
+        )}
+
+        {data?.handler && (
+          <span
+            className="ml-auto inline-flex items-center gap-1.5 text-xs text-text-3 font-mono truncate max-w-[45%]"
+            title={`${data.handler.name}${data.handler.file ? ` — ${data.handler.file}:${data.handler.line ?? ""}` : ""}`}
+          >
+            <span className="font-semibold text-text-2 truncate">{data.handler.name}</span>
+          </span>
+        )}
+      </div>
+
+      {/* Canvas */}
+      <div className="relative flex-1 min-h-0">
+        {error ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-text-3">
+            <AlertTriangle size={20} className="text-[var(--danger)]" />
+            <p className="text-sm">Couldn't load the flowchart.</p>
+            <p className="text-xs text-text-4">{error instanceof Error ? error.message : "Unknown error"}</p>
+          </div>
+        ) : unsupported ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-center px-6 text-text-3">
+            <GitBranch size={20} className="text-text-4" />
+            <p className="text-sm">Flowchart not available for this handler.</p>
+            <p className="text-xs text-text-4 max-w-[480px]">
+              {data?.note ||
+                (data?.language
+                  ? `Control-flow extraction isn't supported for ${data.language} yet.`
+                  : "The handler could not be resolved for this endpoint.")}
+            </p>
+          </div>
+        ) : data && data.nodes.length === 0 ? (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-text-4">
+            No control flow to show for this handler.
+          </div>
+        ) : (
+          <ReactFlow
+            nodes={laidOut.nodes}
+            edges={laidOut.edges}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
+            fitView
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable={false}
+            proOptions={{ hideAttribution: true }}
+            minZoom={0.15}
+            fitViewOptions={{ padding: 0.2 }}
+          >
+            <Background gap={18} size={1} color="var(--border)" />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable className="!bg-surface !border !border-border" />
+          </ReactFlow>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Flowchart — the control-flow / flowchart view of the Downstream-flow modal.
+ * Wraps the inner view in a ReactFlowProvider so it is a drop-in sibling of
+ * <FlowDag> in the modal (the parent toggles which one is mounted).
+ */
+export function Flowchart(props: FlowchartProps) {
+  return (
+    <ReactFlowProvider>
+      <FlowchartInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/webui-v2/src/components/flow-dag/FlowchartEdge.tsx
+++ b/webui-v2/src/components/flow-dag/FlowchartEdge.tsx
@@ -1,0 +1,114 @@
+/* ============================================================
+   components/flow-dag/FlowchartEdge.tsx — custom React Flow edge for the
+   Flowchart view (#4819).
+
+   Draws a control-flow edge styled + labelled by its kind:
+     - branch_true   → "yes"  (green-ish), the taken branch off a diamond
+     - branch_false  → "no"   (muted),     the not-taken branch
+     - loop_back     → "loop" (amber, dashed), the body-tail → header back-edge
+     - exit          → "exit" (danger, dashed), an early return/throw → end
+     - seq           → unlabelled neutral fall-through
+
+   Follows ELK's orthogonal route (right-angle H/V segments) when present, else
+   falls back to a smooth-step path — never a diagonal bezier, so the diagram
+   reads like a classic flowchart.
+   ============================================================ */
+
+import { memo } from "react";
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  getSmoothStepPath,
+  type EdgeProps,
+} from "@xyflow/react";
+import { orthogonalPath } from "@/lib/elk-layout";
+import type { ControlFlowEdgeKind } from "@/data/types";
+
+export interface FlowchartEdgeData extends Record<string, unknown> {
+  kind: ControlFlowEdgeKind;
+  elkPoints?: { x: number; y: number }[];
+}
+
+interface EdgeStyle {
+  label: string;
+  stroke: string;
+  dash?: string;
+}
+
+function edgeStyleFor(kind: ControlFlowEdgeKind): EdgeStyle {
+  switch (kind) {
+    case "branch_true":
+      return { label: "yes", stroke: "var(--success, #2ea043)" };
+    case "branch_false":
+      return { label: "no", stroke: "var(--text-3)" };
+    case "loop_back":
+      return { label: "loop", stroke: "var(--warning, #d4a72c)", dash: "4 3" };
+    case "exit":
+      return { label: "exit", stroke: "var(--danger)", dash: "4 3" };
+    default:
+      return { label: "", stroke: "var(--border)" };
+  }
+}
+
+function FlowchartEdgeImpl({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  markerEnd,
+  data,
+}: EdgeProps) {
+  const ed = data as FlowchartEdgeData | undefined;
+  const kind = ed?.kind ?? "seq";
+  const es = edgeStyleFor(kind);
+
+  const elk = orthogonalPath(ed?.elkPoints ?? []);
+  let path: string;
+  let labelX: number;
+  let labelY: number;
+  if (elk) {
+    ({ path, labelX, labelY } = elk);
+  } else {
+    [path, labelX, labelY] = getSmoothStepPath({
+      sourceX,
+      sourceY,
+      targetX,
+      targetY,
+      sourcePosition,
+      targetPosition,
+    });
+  }
+
+  return (
+    <>
+      <BaseEdge
+        path={path}
+        markerEnd={markerEnd}
+        style={{
+          stroke: es.stroke,
+          strokeWidth: kind === "seq" ? 1.5 : 1.75,
+          strokeDasharray: es.dash,
+        }}
+      />
+      {es.label && (
+        <EdgeLabelRenderer>
+          <div
+            className="absolute pointer-events-none rounded px-1 py-px text-[9px] font-semibold leading-none"
+            style={{
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+              background: "var(--surface)",
+              color: es.stroke,
+              border: `1px solid color-mix(in srgb, ${es.stroke} 45%, transparent)`,
+            }}
+          >
+            {es.label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+
+export const FlowchartEdge = memo(FlowchartEdgeImpl);

--- a/webui-v2/src/components/flow-dag/FlowchartNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowchartNode.tsx
@@ -1,0 +1,169 @@
+/* ============================================================
+   components/flow-dag/FlowchartNode.tsx — custom React Flow node for the
+   Flowchart view (#4819).
+
+   Renders a CFG node with its CLASSIC flowchart glyph:
+     - start / end      → rounded "terminal" pill (entry / exit)
+     - return / throw    → rounded exit terminal, tinted (throw = danger)
+     - decision / loop   → DIAMOND carrying the predicate/condition text
+     - process           → rectangle, optionally badged with its effects
+
+   The layout box is a fixed rectangle (ELK lays the graph out on these boxes);
+   the diamond is drawn INSIDE that box as a rotated square so edges still dock to
+   the box's mid-sides cleanly. Handle positions follow the layout direction
+   (TB → top/bottom, LR → left/right) so connectors leave/enter the right faces.
+   ============================================================ */
+
+import { memo } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Database, Globe, FileCog, Mail, HardDrive } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ControlFlowShape, ControlFlowEffect } from "@/data/types";
+
+export interface FlowchartNodeData extends Record<string, unknown> {
+  shape: ControlFlowShape;
+  /** Short caption (label at full detail, else a shape-derived default). */
+  caption: string;
+  /** Predicate text for decision/loop nodes. */
+  condition?: string;
+  /** Effect annotations for process nodes (data detail+). */
+  effects?: ControlFlowEffect[];
+  /** 1-indexed source line, surfaced as a small corner ref. */
+  line?: number;
+  /** Handle faces for the active layout direction. */
+  sourcePos: Position;
+  targetPos: Position;
+}
+
+/** Small icon per effect family so a process step badges "DB write" etc. */
+function effectIcon(effect: string) {
+  const e = effect.toLowerCase();
+  if (e.startsWith("db")) return <Database size={10} />;
+  if (e.startsWith("http") || e.startsWith("net")) return <Globe size={10} />;
+  if (e.startsWith("fs") || e.startsWith("file")) return <HardDrive size={10} />;
+  if (e.startsWith("queue") || e.startsWith("event") || e.startsWith("mail"))
+    return <Mail size={10} />;
+  return <FileCog size={10} />;
+}
+
+function EffectBadge({ effect }: { effect: ControlFlowEffect }) {
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 rounded px-1 py-px text-[9px] font-medium leading-none border"
+      style={{
+        color: "var(--accent)",
+        borderColor: "color-mix(in srgb, var(--accent) 40%, transparent)",
+        background: "color-mix(in srgb, var(--accent) 8%, transparent)",
+      }}
+      title={effect.sink ? `${effect.effect} → ${effect.sink}` : effect.effect}
+    >
+      {effectIcon(effect.effect)}
+      {effect.effect}
+    </span>
+  );
+}
+
+function FlowchartNodeImpl({ data }: NodeProps) {
+  const d = data as FlowchartNodeData;
+  const isDiamond = d.shape === "decision" || d.shape === "loop";
+  const isTerminal =
+    d.shape === "start" ||
+    d.shape === "end" ||
+    d.shape === "return" ||
+    d.shape === "throw";
+  const isThrow = d.shape === "throw";
+
+  // Terminal palette: start/end neutral, return accented, throw danger.
+  const terminalColor = isThrow
+    ? "var(--danger)"
+    : d.shape === "return"
+      ? "var(--accent)"
+      : "var(--text-3)";
+
+  return (
+    <div className="relative w-full h-full flex items-center justify-center">
+      <Handle
+        type="target"
+        position={d.targetPos}
+        className="!w-1.5 !h-1.5 !border-0 !bg-[var(--border)]"
+      />
+
+      {isDiamond ? (
+        // Diamond: a rotated square sized to fit inside the layout box, with the
+        // condition text laid OVER it (un-rotated) so it stays readable.
+        <>
+          <div
+            className="absolute rotate-45 rounded-[3px] border-2"
+            style={{
+              width: "62%",
+              height: "62%",
+              borderColor:
+                d.shape === "loop" ? "var(--warning, #d4a72c)" : "var(--accent)",
+              background: "var(--surface)",
+            }}
+          />
+          <div className="relative z-10 max-w-[78%] text-center px-1">
+            <div className="text-[9px] uppercase tracking-wide text-text-4 leading-none mb-0.5">
+              {d.shape === "loop" ? "loop" : "if"}
+            </div>
+            <div
+              className="text-[10px] font-mono text-text leading-tight line-clamp-3 break-words"
+              title={d.condition || d.caption}
+            >
+              {d.condition || d.caption}
+            </div>
+          </div>
+        </>
+      ) : isTerminal ? (
+        <div
+          className="flex items-center justify-center w-full h-full rounded-full border-2 px-3 text-center"
+          style={{
+            borderColor: terminalColor,
+            background: "var(--surface)",
+            color: terminalColor,
+          }}
+        >
+          <span className="text-[11px] font-semibold uppercase tracking-wide truncate">
+            {d.caption}
+          </span>
+        </div>
+      ) : (
+        // Process: a plain rectangle with the caption + optional effect badges.
+        <div className="flex flex-col items-center justify-center w-full h-full rounded-md border border-border bg-surface px-2 py-1 gap-1">
+          <span
+            className="text-[10px] font-mono text-text-2 leading-tight line-clamp-2 text-center break-words"
+            title={d.caption}
+          >
+            {d.caption}
+          </span>
+          {d.effects && d.effects.length > 0 && (
+            <div className="flex flex-wrap items-center justify-center gap-0.5">
+              {d.effects.slice(0, 3).map((ef, i) => (
+                <EffectBadge key={`${ef.effect}-${i}`} effect={ef} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Source-line corner ref (omitted for the synthetic start/end). */}
+      {d.line ? (
+        <span
+          className={cn(
+            "absolute -bottom-4 right-0 text-[8px] tabular-nums text-text-4 pointer-events-none",
+          )}
+        >
+          L{d.line}
+        </span>
+      ) : null}
+
+      <Handle
+        type="source"
+        position={d.sourcePos}
+        className="!w-1.5 !h-1.5 !border-0 !bg-[var(--border)]"
+      />
+    </div>
+  );
+}
+
+export const FlowchartNode = memo(FlowchartNodeImpl);

--- a/webui-v2/src/components/flow-dag/flowchart-shapes.ts
+++ b/webui-v2/src/components/flow-dag/flowchart-shapes.ts
@@ -1,0 +1,51 @@
+/* ============================================================
+   components/flow-dag/flowchart-shapes.ts — pure shape/caption helpers for the
+   Flowchart view (#4819), split out so they're unit-testable without React Flow.
+
+   These map a CFG node to its layout box and a human caption. The actual glyph
+   drawing lives in FlowchartNode.tsx; this is just the deterministic geometry +
+   label logic the layout pass and tests share.
+   ============================================================ */
+
+import type { ControlFlowNode } from "@/data/types";
+
+/** Per-shape layout box (fed to ELK). Diamonds get a squarer box so the rotated
+ *  inner square reads as a diamond; terminals are short pills; process boxes are
+ *  wider rectangles to fit a source line + effect badges. */
+export function boxFor(shape: ControlFlowNode["shape"]): { w: number; h: number } {
+  switch (shape) {
+    case "decision":
+    case "loop":
+      return { w: 150, h: 96 };
+    case "start":
+    case "end":
+    case "return":
+    case "throw":
+      return { w: 132, h: 48 };
+    default:
+      return { w: 180, h: 64 };
+  }
+}
+
+/** A short caption per node. Prefers the source label (full detail), else a
+ *  shape-derived default — so outline/decisions levels (which ship no label)
+ *  still read clearly. Decisions/loops fall back to their condition text. */
+export function defaultCaption(n: ControlFlowNode): string {
+  if (n.label) return n.label;
+  switch (n.shape) {
+    case "start":
+      return "Start";
+    case "end":
+      return "End";
+    case "return":
+      return "Return";
+    case "throw":
+      return "Throw";
+    case "decision":
+      return n.condition || "decision";
+    case "loop":
+      return n.condition || "loop";
+    default:
+      return n.line ? `line ${n.line}` : "step";
+  }
+}

--- a/webui-v2/src/components/flow-dag/flowchart.test.ts
+++ b/webui-v2/src/components/flow-dag/flowchart.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the Flowchart view (#4819):
+ *   - the pure shape/caption helpers (boxFor / defaultCaption), and
+ *   - the api `detail` mapping (the Detail slider → backend `detail=` param).
+ *
+ * Run with: npx vitest run src/components/flow-dag/flowchart.test.ts
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { boxFor, defaultCaption } from "./flowchart-shapes";
+import { api } from "@/lib/api";
+import type { ControlFlowDetail, ControlFlowNode } from "@/data/types";
+
+function cfgNode(partial: Partial<ControlFlowNode> & { shape: ControlFlowNode["shape"] }): ControlFlowNode {
+  return { id: "n0", ...partial };
+}
+
+describe("flowchart shapes", () => {
+  it("gives decisions and loops a squarer diamond box", () => {
+    const dec = boxFor("decision");
+    const loop = boxFor("loop");
+    // Squarer than the process rectangle so the rotated inner square reads as a diamond.
+    expect(dec).toEqual(loop);
+    expect(dec.h).toBeGreaterThan(boxFor("process").h);
+  });
+
+  it("gives terminals a short pill box and process a wide rectangle", () => {
+    expect(boxFor("start")).toEqual(boxFor("end"));
+    expect(boxFor("start").h).toBeLessThan(boxFor("process").h);
+    expect(boxFor("process").w).toBeGreaterThan(boxFor("start").w);
+  });
+
+  it("prefers a source label, else a shape-derived caption", () => {
+    expect(defaultCaption(cfgNode({ shape: "process", label: "await repo.save(x)" }))).toBe(
+      "await repo.save(x)",
+    );
+    expect(defaultCaption(cfgNode({ shape: "start" }))).toBe("Start");
+    expect(defaultCaption(cfgNode({ shape: "throw" }))).toBe("Throw");
+  });
+
+  it("falls back to the condition text for unlabelled decisions/loops", () => {
+    expect(defaultCaption(cfgNode({ shape: "decision", condition: "if !user" }))).toBe("if !user");
+    expect(defaultCaption(cfgNode({ shape: "loop", condition: "for row in rows" }))).toBe(
+      "for row in rows",
+    );
+  });
+});
+
+describe("control-flow api detail mapping", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockFetch() {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ ok: true, data: { nodes: [], edges: [] } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("maps the detail slider value into the control-flow query param", async () => {
+    for (const detail of ["outline", "decisions", "data", "full"] as ControlFlowDetail[]) {
+      const fetchMock = mockFetch();
+      await api.getPathControlFlow("grp", "abc123", { detail });
+      const url = String(fetchMock.mock.calls[0][0]);
+      expect(url).toContain("/groups/grp/paths/abc123/control-flow");
+      expect(url).toContain(`detail=${detail}`);
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("includes the verb when given and omits it otherwise", async () => {
+    let fetchMock = mockFetch();
+    await api.getPathControlFlow("grp", "abc123", { detail: "decisions", verb: "POST" });
+    expect(String(fetchMock.mock.calls[0][0])).toContain("verb=POST");
+    vi.restoreAllMocks();
+
+    fetchMock = mockFetch();
+    await api.getPathControlFlow("grp", "abc123", { detail: "decisions" });
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("verb=");
+  });
+});

--- a/webui-v2/src/components/flow-dag/index.ts
+++ b/webui-v2/src/components/flow-dag/index.ts
@@ -3,3 +3,6 @@
 export { FlowDag } from "./FlowDag";
 export type { FlowDagProps } from "./FlowDag";
 export type { FlowDagDirection } from "./layout";
+// Flowchart view (#4819) — the control-flow / flowchart sibling of <FlowDag>.
+export { Flowchart } from "./Flowchart";
+export type { FlowchartProps } from "./Flowchart";

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2611,6 +2611,103 @@ export interface DownstreamDAGResponse {
 }
 
 // ---------------------------------------------------------------------------
+// Control-flow / flowchart (#4819, epic #4820) —
+// GET /api/v2/groups/:id/paths/:hash/control-flow
+//
+// The Flowchart view of the Downstream-flow modal: an on-demand control-flow
+// graph (CFG) of the endpoint's HANDLER function, rendered with classic
+// flowchart glyphs on the shared ELK canvas. Built server-side from the same
+// internal/substrate CFG builder the archigraph_control_flow MCP tool uses.
+// ---------------------------------------------------------------------------
+
+/** Detail level for the flowchart — maps 1:1 to the backend `detail` param and
+ *  the modal's Detail slider. Each level is a superset of the previous:
+ *   outline    → shapes + lines + complexity only
+ *   decisions  → + condition text on decision/loop nodes (default)
+ *   data       → + effect annotations on process nodes
+ *   full       → + node labels (the trimmed source line) */
+export type ControlFlowDetail = "outline" | "decisions" | "data" | "full";
+
+/** Flowchart node glyph. start/end are rounded terminals, decision is a
+ *  diamond, loop is a (back-edge target) diamond, process is a rectangle,
+ *  return/throw are exit terminals. */
+export type ControlFlowShape =
+  | "start"
+  | "end"
+  | "return"
+  | "throw"
+  | "decision"
+  | "loop"
+  | "process";
+
+/** Control-flow edge kind — drives edge labelling/routing on the flowchart:
+ *  the true/false branches off a decision, the loop back-edge, the early
+ *  return/throw exits, and plain sequential fall-through. */
+export type ControlFlowEdgeKind =
+  | "seq"
+  | "branch_true"
+  | "branch_false"
+  | "loop_back"
+  | "exit";
+
+/** A terse effect annotation on a process node (data detail+). */
+export interface ControlFlowEffect {
+  effect: string;
+  sink?: string;
+}
+
+/** One basic block / decision / terminal in the handler's CFG. */
+export interface ControlFlowNode {
+  id: string;
+  shape: ControlFlowShape;
+  line?: number;
+  /** Trimmed source line — full detail only. */
+  label?: string;
+  /** Predicate text on decision/loop nodes — decisions detail and up. */
+  condition?: string;
+  /** Side-effect annotations on process nodes — data detail and up. */
+  effects?: ControlFlowEffect[];
+}
+
+/** One directed control-flow edge between two node ids. */
+export interface ControlFlowEdge {
+  from: string;
+  to: string;
+  kind: ControlFlowEdgeKind;
+}
+
+/** The resolved handler function the CFG was built from. */
+export interface ControlFlowHandler {
+  id: string;
+  name: string;
+  kind: string;
+  file?: string;
+  line?: number;
+  repo: string;
+}
+
+/** GET /api/v2/groups/:id/paths/:hash/control-flow → the Flowchart-view payload. */
+export interface ControlFlowResponse {
+  path: string;
+  verb: string;
+  detail: ControlFlowDetail;
+  /** Resolved handler language slug ("python","jsts",…). */
+  language: string;
+  /** False when no block detector exists for the language (degenerate graph),
+   *  no handler resolved, or the source was unreadable — the modal then shows a
+   *  graceful "flowchart not available" state. */
+  supported: boolean;
+  /** Human explanation when supported is false. */
+  note?: string;
+  /** The handler function the CFG was built from (absent when unresolved). */
+  handler?: ControlFlowHandler;
+  cyclomatic_complexity: number;
+  branch_count: number;
+  nodes: ControlFlowNode[];
+  edges: ControlFlowEdge[];
+}
+
+// ---------------------------------------------------------------------------
 // Source peek (#4499) — GET /api/v2/groups/:id/source
 // ---------------------------------------------------------------------------
 

--- a/webui-v2/src/hooks/use-paths.ts
+++ b/webui-v2/src/hooks/use-paths.ts
@@ -11,7 +11,7 @@ import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useAuthCoverage } from "@/hooks/use-security";
-import type { AuthEndpointFinding } from "@/data/types";
+import type { AuthEndpointFinding, ControlFlowDetail } from "@/data/types";
 
 export const pathsQueryKey = (groupId: string) =>
   ["paths", groupId] as const;
@@ -82,6 +82,42 @@ export function useDownstreamDAG(
         semantic: params.semantic,
         verb: params.verb,
       }),
+    enabled: !!groupId && !!pathHash && enabled,
+    staleTime: 60_000,
+  });
+}
+
+/* ============================================================
+   Control-flow / flowchart for the Downstream-flow modal (#4819, backend #4820)
+
+   The Flowchart VIEW of the modal. Parameterised by (detail, verb): moving the
+   Detail slider (outline→decisions→data→full) refetches with a new query key;
+   TanStack caches each detail level so sliding back is instant. Fetched lazily
+   (only when the modal is open AND the Flowchart view is selected).
+   ============================================================ */
+
+export const controlFlowQueryKey = (
+  groupId: string,
+  hash: string,
+  detail: ControlFlowDetail,
+  verb?: string,
+) => ["paths", groupId, "control-flow", hash, detail, verb ?? ""] as const;
+
+/**
+ * Fetch the endpoint handler's control-flow graph for the Flowchart view.
+ * Enabled only when the modal is open and the Flowchart view is selected, so the
+ * Tree view never pays for a CFG it isn't showing.
+ */
+export function useControlFlow(
+  groupId: string,
+  pathHash: string | null,
+  detail: ControlFlowDetail,
+  verb: string | undefined,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: controlFlowQueryKey(groupId, pathHash ?? "", detail, verb),
+    queryFn: () => api.getPathControlFlow(groupId, pathHash!, { detail, verb }),
     enabled: !!groupId && !!pathHash && enabled,
     staleTime: 60_000,
   });

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -75,6 +75,8 @@ import type {
   DIReport,
   ErrorFlowReport,
   DownstreamDAGResponse,
+  ControlFlowResponse,
+  ControlFlowDetail,
   SourceReply,
 } from "@/data/types";
 
@@ -541,6 +543,28 @@ export const api = {
     const suffix = qs.toString() ? `?${qs.toString()}` : "";
     return requestV2<DownstreamDAGResponse>(
       `/groups/${encodeURIComponent(groupId)}/paths/${encodeURIComponent(pathHash)}/downstream-dag${suffix}`,
+    );
+  },
+
+  /**
+   * GET /api/v2/groups/:id/paths/:hash/control-flow — the Flowchart view of the
+   * Downstream-flow modal (#4819). Returns the on-demand control-flow graph
+   * (CFG) of the endpoint's handler function, parameterised by `detail`
+   * (outline|decisions|data|full — the Detail slider). `verb` disambiguates a
+   * multi-verb path hash. Fetched lazily (only when the modal is open and the
+   * Flowchart view is selected) so the main paths payload stays lean.
+   */
+  getPathControlFlow: (
+    groupId: string,
+    pathHash: string,
+    params?: { detail?: ControlFlowDetail; verb?: string },
+  ) => {
+    const qs = new URLSearchParams();
+    if (params?.detail) qs.set("detail", params.detail);
+    if (params?.verb) qs.set("verb", params.verb);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return requestV2<ControlFlowResponse>(
+      `/groups/${encodeURIComponent(groupId)}/paths/${encodeURIComponent(pathHash)}/control-flow${suffix}`,
     );
   },
 

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -32,7 +32,8 @@ import {
 } from "@/components/ui";
 import { TabCount, useSetInsight } from "@/components/ui";
 import type { InsightValue } from "@/components/ui";
-import { FlowDag } from "@/components/flow-dag";
+import { FlowDag, Flowchart } from "@/components/flow-dag";
+import type { ControlFlowDetail } from "@/data/types";
 import { RefLine } from "@/components/RefLine";
 import { getRepoColor } from "@/lib/repo-color";
 import { effectBadge } from "@/lib/effect-badge";
@@ -850,6 +851,55 @@ function responseToShapeTreeRows(s: ResponseShape, idx: number): ShapeTreeRow[] 
   });
 }
 
+/** The ordered detail levels for the Flowchart Detail slider (#4819). Each is a
+ *  superset of the previous; the label reads as the "+" it adds. */
+const CFG_DETAIL_LEVELS: { value: ControlFlowDetail; label: string; hint: string }[] = [
+  { value: "outline", label: "Outline", hint: "Shapes only — start/decision/loop/process/end" },
+  { value: "decisions", label: "+Decisions", hint: "Adds the condition text on decisions & loops" },
+  { value: "data", label: "+Data", hint: "Adds effect annotations (db_write, http_call, …)" },
+  { value: "full", label: "Full", hint: "Adds the source line label on every node" },
+];
+
+/** DetailSlider — the Flowchart-view Detail slider (#4819). A discrete 4-stop
+ *  slider mapping Outline → +Decisions → +Data → Full to the backend `detail`
+ *  param. Independent of the Tree view's depth control. */
+function DetailSlider({
+  value,
+  onChange,
+}: {
+  value: ControlFlowDetail;
+  onChange: (d: ControlFlowDetail) => void;
+}) {
+  const idx = Math.max(
+    0,
+    CFG_DETAIL_LEVELS.findIndex((l) => l.value === value),
+  );
+  const active = CFG_DETAIL_LEVELS[idx];
+  return (
+    <div className="inline-flex items-center gap-2">
+      <span className="text-[11px] text-text-4 uppercase tracking-wide">Detail</span>
+      <input
+        type="range"
+        min={0}
+        max={CFG_DETAIL_LEVELS.length - 1}
+        step={1}
+        value={idx}
+        onChange={(e) => onChange(CFG_DETAIL_LEVELS[Number(e.target.value)].value)}
+        className="w-28 accent-[var(--accent)] cursor-pointer"
+        aria-label="Flowchart detail level"
+        title={active.hint}
+        list="cfg-detail-stops"
+      />
+      <span
+        className="text-xs font-medium text-text-2 w-[88px] tabular-nums"
+        title={active.hint}
+      >
+        {active.label}
+      </span>
+    </div>
+  );
+}
+
 function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathDetail; initialVerb?: string; groupId: string }) {
   const authForDetail = useAuthFor();
   // Real polyglot data can omit array/object fields entirely. Normalize once so
@@ -907,6 +957,11 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
   // Fullscreen / maximize toggle for the downstream-flow modal (#4479). Persists
   // within the session so re-opening the modal keeps the user's last choice.
   const [dagMaximized, setDagMaximized] = useState(false);
+  // View toggle (#4819): Tree = the downstream call DAG (<FlowDag>), Flowchart =
+  // the handler's control-flow graph (<Flowchart>). The Detail slider only
+  // affects the Flowchart view (independent of the Tree's own depth control).
+  const [flowView, setFlowView] = useState<"tree" | "flowchart">("tree");
+  const [cfgDetail, setCfgDetail] = useState<ControlFlowDetail>("decisions");
   const dagVerb = verbFilter !== "all" ? verbFilter : detail.verbs[0];
 
   // Filter verb-scoped data. Backend slice fields can arrive as JSON null, so
@@ -1324,8 +1379,58 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
               Downstream flow
             </DialogTitle>
             <DialogDescription>
-              {detail.path} — the endpoint's downstream as a branching tree.
+              {flowView === "tree"
+                ? `${detail.path} — the endpoint's downstream as a branching tree.`
+                : `${detail.path} — the handler's control flow as a flowchart.`}
             </DialogDescription>
+
+            {/* View toggle (Tree | Flowchart) + Detail slider (#4819). The
+                toggle swaps the renderer/data source; the Detail slider only
+                drives the Flowchart's CFG detail level (independent of the
+                Tree's own depth control, which lives in <FlowDag>). */}
+            <div className="mt-2 flex flex-wrap items-center gap-3">
+              <div
+                className="inline-flex rounded-md border border-border overflow-hidden"
+                role="tablist"
+                aria-label="Flow view"
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={flowView === "tree"}
+                  onClick={() => setFlowView("tree")}
+                  className={cn(
+                    "h-7 px-3 text-xs transition-colors",
+                    flowView === "tree"
+                      ? "bg-accent text-accent-text"
+                      : "bg-surface text-text-3 hover:bg-surface-2",
+                  )}
+                  title="Tree — the downstream call DAG"
+                >
+                  Tree
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={flowView === "flowchart"}
+                  onClick={() => setFlowView("flowchart")}
+                  className={cn(
+                    "h-7 px-3 text-xs transition-colors border-l border-border",
+                    flowView === "flowchart"
+                      ? "bg-accent text-accent-text"
+                      : "bg-surface text-text-3 hover:bg-surface-2",
+                  )}
+                  title="Flowchart — the handler's control flow (decisions, loops, effects)"
+                >
+                  Flowchart
+                </button>
+              </div>
+
+              {/* Detail slider — only meaningful for the Flowchart view. */}
+              {flowView === "flowchart" && (
+                <DetailSlider value={cfgDetail} onChange={setCfgDetail} />
+              )}
+            </div>
             {/* Maximize / restore toggle (#4479). Sits left of the Dialog's own
                 close button (which is absolute-positioned top-right). */}
             <button
@@ -1339,12 +1444,22 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
             </button>
           </div>
           <div className="flex-1 min-h-0">
-            {dagOpen && (
+            {dagOpen && flowView === "tree" && (
               <FlowDag
                 groupId={groupId}
                 pathHash={detail.path_hash}
                 verb={dagVerb}
                 enabled={dagOpen}
+                className="h-full"
+              />
+            )}
+            {dagOpen && flowView === "flowchart" && (
+              <Flowchart
+                groupId={groupId}
+                pathHash={detail.path_hash}
+                verb={dagVerb}
+                detail={cfgDetail}
+                enabled={dagOpen && flowView === "flowchart"}
                 className="h-full"
               />
             )}


### PR DESCRIPTION
## What

Adds a **Flowchart** view to the endpoint Downstream-flow modal, alongside the existing **Tree** (downstream call DAG) view, with a `View: Tree | Flowchart` toggle and a separate `Detail` slider. Branch-level granularity, reusing what the CFG engine already extracts. Closes #4819. Completes epic #4820.

## Backend

- New dashboard endpoint **`GET /api/v2/groups/{id}/paths/{hash}/control-flow?verb=&detail=`** (`internal/dashboard/v2_paths_control_flow.go`).
- Resolves endpoint → handler via the reversed `IMPLEMENTS` continuation edge (same HTTP-boundary crossing as the downstream-DAG), reads the handler's raw source window through the group's repo roots (path-traversal guarded), and builds the CFG by **REUSING `substrate.BuildControlFlowGraphCached`** — the same builder `archigraph_control_flow` uses. No basic-block entities are persisted.
- Returns nodes (shapes/lines/conditions/effects/labels) + edges (seq/branch_true/branch_false/loop_back/exit) + cyclomatic complexity + branch count.
- **Detail levels** map 1:1 to the MCP tool (#2828): `outline` (shapes only) → `decisions` (+condition text, default) → `data` (+effect annotations) → `full` (+source-line labels). Same field gating.
- `supported=false` + a `note` for languages without a block detector / unresolved / unreadable handler → the UI shows a graceful "flowchart not available" state.

## Frontend

- **View toggle + Detail slider** in the modal header (`webui-v2/src/routes/paths.tsx`). The toggle swaps the renderer/data source; the discrete 4-stop Detail slider drives only the Flowchart's CFG detail level — **independent of the Tree's depth control, which is untouched**.
- New **`<Flowchart>`** (`webui-v2/src/components/flow-dag/Flowchart.tsx`) reuses the shared **ELK orthogonal layout** (`layoutWithElk`) on the same React Flow canvas with classic flowchart glyphs:
  - rounded **start/end** terminals; **return** (accent) / **throw** (danger) exit terminals
  - **diamond** decision/loop nodes carrying the condition text
  - rectangle **process** steps, badged with their effects (db_write/http_call/…) at +Data / Full
  - labelled edges: branch_true→"yes", branch_false→"no", loop_back→"loop" (dashed amber), exit→"exit" (dashed danger)
  - V/H orientation toggle (defaults to **V**, classic top→bottom flowchart)
- New `getPathControlFlow` api method + `useControlFlow` hook (lazy: only fetches when the modal is open AND Flowchart is selected) + `ControlFlow*` types.

## How the flowchart consumes detail levels

The Detail slider value (`outline`/`decisions`/`data`/`full`) is passed straight through `useControlFlow` → `api.getPathControlFlow` → the `?detail=` query param. The backend gates exactly which fields ship; the renderer reads condition text on diamonds (decisions+), effect badges on process rects (data+), and source-line labels (full). Sliding back is instant (TanStack caches each level).

## Gates

- `go build ./...`, `go vet ./internal/...`, `go test ./internal/{substrate,dashboard,mcp,types}` — pass, incl. a new endpoint→handler→CFG test (resolution, all 4 detail levels, no-handler graceful state).
- `webui-v2`: `tsc --noEmit`, `npm run build`, `vitest run` — pass (149 unit tests, incl. 6 new flowchart tests for shape/caption helpers + the detail→query mapping). The ~12 Playwright e2e specs fail pre-existing under vitest (they're not vitest tests).

Branch-level only for now (deeper conditional extraction is a future pass). Deploy-deferred — not validated against a live render; shapes/layout described above for post-rebuild validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)