### PR TITLE
feat(#4868,#4869): real field types + nullable, drop redundant required, column layout, click type→source

### DIFF
--- a/internal/dashboard/shape_tree.go
+++ b/internal/dashboard/shape_tree.go
@@ -34,9 +34,9 @@ import (
 // `nullable` come from the field entity's signature; `type_entity_id`
 // + `has_children` indicate whether the frontend can drill further.
 type v2ShapeRow struct {
-	Name         string   `json:"name"`
-	Type         string   `json:"type"`
-	Annotations  []string `json:"annotations,omitempty"`
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Annotations []string `json:"annotations,omitempty"`
 	// Validations are per-field constraint chips (#4858) parsed from the
 	// field entity's `validations` metadata property — e.g. for a NestJS DTO
 	// field `@IsString() @MaxLength(120) @IsOptional() name?: string` this is
@@ -45,7 +45,14 @@ type v2ShapeRow struct {
 	Validations  []string `json:"validations,omitempty"`
 	Nullable     bool     `json:"nullable,omitempty"`
 	TypeEntityID string   `json:"type_entity_id,omitempty"`
-	HasChildren  bool     `json:"has_children"`
+	// TypeSourceFile / TypeSourceLine locate the field TYPE's definition so the
+	// frontend can open it in the source-peek modal when the user clicks the
+	// type-name link (#4869) — independent of the row-body expand/collapse
+	// click. Populated only when the type resolves to an in-group entity.
+	TypeSourceFile string `json:"type_source_file,omitempty"`
+	TypeSourceLine int    `json:"type_source_line,omitempty"`
+	TypeRepo       string `json:"type_repo,omitempty"`
+	HasChildren    bool   `json:"has_children"`
 }
 
 // v2ShapeResponse is the wire shape of GET /api/v2/groups/{id}/shape.
@@ -270,14 +277,14 @@ func buildShapeRow(grp *DashGroup, field *graph.Entity) v2ShapeRow {
 	if idx := strings.LastIndex(name, "."); idx >= 0 {
 		name = name[idx+1:]
 	}
-	annotations, typ := parseFieldSignature(field.Signature, name)
+	annotations, typ, optional := parseFieldSignature(field.Signature, name)
 
 	row := v2ShapeRow{
 		Name:        name,
 		Type:        typ,
 		Annotations: annotations,
 		Validations: fieldValidations(field),
-		Nullable:    inferNullable(annotations, typ),
+		Nullable:    optional || inferNullable(annotations, typ, field),
 	}
 	// Resolve the field's element type to a class entity so the frontend
 	// can render the expansion glyph. Container element types (List<X>,
@@ -288,6 +295,11 @@ func buildShapeRow(grp *DashGroup, field *graph.Entity) v2ShapeRow {
 			tgtSlug, _ := findRepoForEntity(grp, target.ID)
 			row.TypeEntityID = dashPrefixedID(tgtSlug, target.ID)
 			row.HasChildren = true
+			// Carry the type's definition location so the frontend can open
+			// the type's source on a type-name click (#4869).
+			row.TypeSourceFile = target.SourceFile
+			row.TypeSourceLine = target.StartLine
+			row.TypeRepo = tgtSlug
 		}
 	}
 	return row
@@ -319,13 +331,32 @@ func fieldValidations(field *graph.Entity) []string {
 	return out
 }
 
-// parseFieldSignature splits a Java field signature like
-// `@NotBlank @Min(0) BigDecimal qty` into ([@NotBlank, @Min(0)], "BigDecimal")
-// using the field name as the right-anchor token.
-func parseFieldSignature(sig, fieldName string) (annotations []string, typ string) {
+// parseFieldSignature splits a field signature into ([annotations], type,
+// optional). It handles two conventions:
+//
+//   - JS/TS "name[?]: type" — emitted by handlePublicFieldDefinition (class
+//     fields) and emitSchemaMemberFields (interface / type-alias members). The
+//     leading token is the field name, an optional "?" marks a TS-optional
+//     field, and everything after the ":" is the type (`string`, `number`,
+//     `Date`, `number | null`, …). This is the path that was previously parsed
+//     as if it were Java `Type name`, yielding a garbage type and "unknown"
+//     in the UI (#4868).
+//   - Java "[@anno ...] Type name" — the annotation-prefixed, type-first
+//     convention emitted by the Java/JVM extractors.
+//
+// `optional` is true only for the TS-optional `?` marker; union nullability
+// (`| null` / `| undefined`) is folded into nullability by the caller via
+// inferNullable so it composes with annotation/Optional signals.
+func parseFieldSignature(sig, fieldName string) (annotations []string, typ string, optional bool) {
 	sig = strings.TrimSpace(sig)
 	if sig == "" {
-		return nil, ""
+		return nil, "", false
+	}
+	// JS/TS convention: "name[?]: type". Detect by a leading `name` (optionally
+	// followed by `?`) immediately before a top-level colon. This is
+	// unambiguous vs the Java `Type name` form, which carries no colon.
+	if annos, t, opt, ok := parseColonFieldSignature(sig, fieldName); ok {
+		return annos, t, opt
 	}
 	// Walk left-to-right collecting @Annotation tokens (with optional
 	// (...) argument lists). Stop at the first non-annotation token —
@@ -377,7 +408,72 @@ func parseFieldSignature(sig, fieldName string) (annotations []string, typ strin
 			typ = rest
 		}
 	}
-	return annotations, typ
+	return annotations, typ, false
+}
+
+// parseColonFieldSignature parses a JS/TS field signature of the form
+// `name[?]: type` into (annotations=nil, type, optional, ok=true). It returns
+// ok=false when the signature is not in this convention (no top-level colon
+// preceded by the field name), so the caller can fall back to the Java parser.
+//
+// Examples:
+//
+//	"email?: string"          → ("string", optional=true)
+//	"createdAt: Date | null"  → ("Date | null", optional=false)
+//	"count: number"           → ("number", optional=false)
+//	"id: string"              → ("string", optional=false)
+func parseColonFieldSignature(sig, fieldName string) (annotations []string, typ string, optional, ok bool) {
+	// Find the first top-level colon (depth 0 outside <…>, (…), […], {…}).
+	colon := topLevelColon(sig)
+	if colon < 0 {
+		return nil, "", false, false
+	}
+	head := strings.TrimSpace(sig[:colon])
+	typ = strings.TrimSpace(sig[colon+1:])
+	if typ == "" {
+		return nil, "", false, false
+	}
+	// head is the field name, optionally suffixed with `?` (and possibly a
+	// `readonly ` modifier prefix the extractor may include).
+	head = strings.TrimPrefix(head, "readonly ")
+	head = strings.TrimSpace(head)
+	if strings.HasSuffix(head, "?") {
+		optional = true
+		head = strings.TrimSpace(strings.TrimSuffix(head, "?"))
+	}
+	// The head must be the field name (when known) for this to be a
+	// `name: type` field signature and not, say, a Java `Map<K, V> name`
+	// whose generic args contain a colon (they don't, but be conservative).
+	if fieldName != "" && head != fieldName {
+		return nil, "", false, false
+	}
+	if fieldName == "" && head == "" {
+		return nil, "", false, false
+	}
+	return nil, typ, optional, true
+}
+
+// topLevelColon returns the byte index of the first colon at bracket-nesting
+// depth zero, or -1. Generic/paren/array/object brackets are tracked so a
+// colon inside `Record<string, number>` or `{ a: b }` is not mistaken for the
+// `name: type` separator.
+func topLevelColon(s string) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<', '(', '[', '{':
+			depth++
+		case '>', ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ':':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 // isIdentChar reports whether b is a valid Java identifier character.
@@ -387,11 +483,17 @@ func isIdentChar(b byte) bool {
 }
 
 // inferNullable returns true when the type or annotation set indicates
-// the field accepts null. `@Nullable` is the explicit signal; Optional<X>
-// is the structural signal. `@NotNull`/`@NotBlank`/`@NotEmpty` are
-// explicit non-null markers (returns false even if the type looks
-// nullable). Primitive types (lowercase) are non-nullable in Java.
-func inferNullable(annotations []string, typ string) bool {
+// the field accepts null. Signals, in precedence order:
+//
+//   - explicit non-null Java annotations (`@NotNull`/`@NotBlank`/`@NotEmpty`)
+//     force false even if the type looks nullable.
+//   - explicit nullable: `@Nullable` (Java), an explicit `nullable=true`
+//     Property stamped by an extractor, Java `Optional<X>`, or a TS union that
+//     admits `null`/`undefined` (`Date | null`, `string | undefined`).
+//
+// The TS-optional `?` marker is folded in by the caller (it lives on the field
+// name, not the type), so it is intentionally not re-checked here.
+func inferNullable(annotations []string, typ string, field *graph.Entity) bool {
 	for _, a := range annotations {
 		if strings.HasPrefix(a, "@NotNull") ||
 			strings.HasPrefix(a, "@NotBlank") ||
@@ -404,7 +506,25 @@ func inferNullable(annotations []string, typ string) bool {
 			return true
 		}
 	}
+	// Extractor-stamped explicit nullability, if any.
+	if field != nil && field.Properties != nil {
+		switch strings.TrimSpace(strings.ToLower(field.Properties["nullable"])) {
+		case "true":
+			return true
+		case "false":
+			return false
+		}
+	}
 	if strings.HasPrefix(typ, "Optional<") {
+		return true
+	}
+	// Python typing.Optional[X] is structurally nullable.
+	if strings.HasPrefix(typ, "Optional[") && strings.HasSuffix(typ, "]") {
+		return true
+	}
+	// TS union admitting null/undefined (`Date | null`, `string | undefined`)
+	// or Python union admitting None (`datetime | None`).
+	if typeUnionAdmitsNull(typ) {
 		return true
 	}
 	// Lowercase primitive (byte/short/int/long/float/double/boolean/char).
@@ -413,6 +533,47 @@ func inferNullable(annotations []string, typ string) bool {
 		return false
 	}
 	return false
+}
+
+// typeUnionAdmitsNull reports whether a TS type is a union with a `null` or
+// `undefined` member (`Date | null`, `string | null | undefined`). Only
+// top-level union members are considered.
+func typeUnionAdmitsNull(typ string) bool {
+	if !strings.Contains(typ, "|") {
+		return false
+	}
+	for _, part := range splitTopLevelUnion(typ) {
+		switch strings.TrimSpace(part) {
+		case "null", "undefined", "None":
+			return true
+		}
+	}
+	return false
+}
+
+// splitTopLevelUnion splits a TS type on `|` at bracket-nesting depth zero so
+// `A<B | C> | null` yields ["A<B | C>", "null"].
+func splitTopLevelUnion(s string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<', '(', '[', '{':
+			depth++
+		case '>', ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case '|':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
 }
 
 // unwrapElementType returns the inner reference type from a Java
@@ -426,9 +587,31 @@ func unwrapElementType(t string) string {
 	if t == "" {
 		return ""
 	}
+	// TS union: drop null/undefined members and unwrap a single remaining
+	// reference member (`Foo | null` → `Foo`). Mixed/multi-member unions
+	// (`Foo | Bar`) are left as-is — they have no single element type.
+	if strings.Contains(t, "|") {
+		var keep []string
+		for _, part := range splitTopLevelUnion(t) {
+			p := strings.TrimSpace(part)
+			if p == "null" || p == "undefined" || p == "" {
+				continue
+			}
+			keep = append(keep, p)
+		}
+		if len(keep) == 1 {
+			t = keep[0]
+		}
+	}
+	// TS array sugar `Foo[]` → `Foo`.
+	if strings.HasSuffix(t, "[]") {
+		return strings.TrimSpace(t[:len(t)-2])
+	}
 	for _, w := range []string{
 		"List", "Set", "Collection", "Iterable", "Optional", "Stream",
 		"ArrayList", "LinkedList", "HashSet", "TreeSet",
+		// TS/JS containers + async wrappers.
+		"Array", "ReadonlyArray", "Promise", "Observable",
 	} {
 		prefix := w + "<"
 		if strings.HasPrefix(t, prefix) && strings.HasSuffix(t, ">") {

--- a/internal/dashboard/shape_tree_test.go
+++ b/internal/dashboard/shape_tree_test.go
@@ -166,6 +166,11 @@ func TestShape_TransferRequestResolvesFields(t *testing.T) {
 	if !strings.Contains(got["items"].TypeEntityID, "cls_item_dto") {
 		t.Errorf("items.type_entity_id: want suffix cls_item_dto, got %q", got["items"].TypeEntityID)
 	}
+	// #4869 — the resolved type's source location flows to the row so the
+	// frontend can open the type's source on a type-name click.
+	if got["items"].TypeSourceFile != "src/ItemDTO.java" {
+		t.Errorf("items.type_source_file: want src/ItemDTO.java, got %q", got["items"].TypeSourceFile)
+	}
 }
 
 // TestShape_NestedExpansion verifies that requesting LoginResponse and
@@ -221,6 +226,119 @@ func TestShape_NestedExpansion(t *testing.T) {
 	}
 	if len(body2.Data.Rows) != 1 || body2.Data.Rows[0].Name != "id" {
 		t.Errorf("UserDTO rows: want [id], got %+v", body2.Data.Rows)
+	}
+}
+
+// tsFieldShapeFixture models TS DTOs whose field entities carry the JS/TS
+// `name[?]: type` signature convention. CreateAlternateAddressBody is a class
+// DTO (handlePublicFieldDefinition path); AlternateAddressResponse is an
+// interface DTO (emitSchemaMemberFields path). It is the upvate-v3 shape that
+// surfaced #4868 — the field TYPE came out ” (→ "unknown") and everything was
+// marked required because the Java parser misread `name: type`.
+func tsFieldShapeFixture() *DashGroup {
+	const cfile = "src/address/dto/create-alternate-address.body.ts"
+	const ifile = "src/address/dto/alternate-address.response.ts"
+	entities := []graph.Entity{
+		// Class DTO with three fields: a plain string, a TS-optional string,
+		// and a nullable Date union.
+		{
+			ID: "cls_body", Name: "CreateAlternateAddressBody",
+			Kind: "SCOPE.Component", Subtype: "class",
+			SourceFile: cfile, Language: "typescript",
+		},
+		{
+			ID: "fld_body_line1", Name: "CreateAlternateAddressBody.line1",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: cfile, Language: "typescript", Signature: "line1: string",
+		},
+		{
+			ID: "fld_body_line2", Name: "CreateAlternateAddressBody.line2",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: cfile, Language: "typescript", Signature: "line2?: string",
+		},
+		{
+			ID: "fld_body_effective", Name: "CreateAlternateAddressBody.effectiveAt",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: cfile, Language: "typescript", Signature: "effectiveAt: Date | null",
+		},
+		// Interface DTO with one required + one nullable-union field.
+		{
+			ID: "iface_resp", Name: "AlternateAddressResponse",
+			Kind: "SCOPE.Schema", Subtype: "interface",
+			SourceFile: ifile, Language: "typescript",
+		},
+		{
+			ID: "fld_resp_id", Name: "AlternateAddressResponse.id",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: ifile, Language: "typescript", Signature: "id: string",
+		},
+		{
+			ID: "fld_resp_archived", Name: "AlternateAddressResponse.archivedAt",
+			Kind: "SCOPE.Schema", Subtype: "field",
+			SourceFile: ifile, Language: "typescript", Signature: "archivedAt: Date | null",
+		},
+	}
+	rels := []graph.Relationship{
+		{FromID: "cls_body", ToID: "fld_body_line1", Kind: "CONTAINS"},
+		{FromID: "cls_body", ToID: "fld_body_line2", Kind: "CONTAINS"},
+		{FromID: "cls_body", ToID: "fld_body_effective", Kind: "CONTAINS"},
+		{FromID: "iface_resp", ToID: "fld_resp_id", Kind: "CONTAINS"},
+		{FromID: "iface_resp", ToID: "fld_resp_archived", Kind: "CONTAINS"},
+	}
+	return makePathsTestGroup(entities, rels)
+}
+
+// TestShape_TSFieldTypesAndNullable is the #4868 regression: a TS class DTO and
+// a TS interface DTO must surface real field types (not ”) and correct
+// nullability — TS-optional `?` and `Date | null` unions both → nullable=true,
+// while required fields stay nullable=false.
+func TestShape_TSFieldTypesAndNullable(t *testing.T) {
+	grp := tsFieldShapeFixture()
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	get := func(typeName string) map[string]v2ShapeRow {
+		resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/shape?type=" + typeName)
+		if err != nil {
+			t.Fatalf("GET %s: %v", typeName, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s: want 200, got %d", typeName, resp.StatusCode)
+		}
+		var body struct {
+			OK   bool            `json:"ok"`
+			Data v2ShapeResponse `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode %s: %v", typeName, err)
+		}
+		out := map[string]v2ShapeRow{}
+		for _, r := range body.Data.Rows {
+			out[r.Name] = r
+		}
+		return out
+	}
+
+	// Class DTO.
+	cls := get("CreateAlternateAddressBody")
+	if r := cls["line1"]; r.Type != "string" || r.Nullable {
+		t.Errorf("class line1: want type=string nullable=false, got %+v", r)
+	}
+	if r := cls["line2"]; r.Type != "string" || !r.Nullable {
+		t.Errorf("class line2 (TS-optional): want type=string nullable=true, got %+v", r)
+	}
+	if r := cls["effectiveAt"]; r.Type != "Date | null" || !r.Nullable {
+		t.Errorf("class effectiveAt: want type=Date | null nullable=true, got %+v", r)
+	}
+
+	// Interface DTO.
+	iface := get("AlternateAddressResponse")
+	if r := iface["id"]; r.Type != "string" || r.Nullable {
+		t.Errorf("iface id: want type=string nullable=false, got %+v", r)
+	}
+	if r := iface["archivedAt"]; r.Type != "Date | null" || !r.Nullable {
+		t.Errorf("iface archivedAt: want type=Date | null nullable=true, got %+v", r)
 	}
 }
 
@@ -312,24 +430,36 @@ func TestShape_MissingTypeParam(t *testing.T) {
 // (including args), nullability inference, and primitive detection.
 func TestShape_ParseFieldSignature_Annotations(t *testing.T) {
 	cases := []struct {
-		sig       string
-		fieldName string
-		wantType  string
-		wantAnnos []string
+		sig          string
+		fieldName    string
+		wantType     string
+		wantAnnos    []string
+		wantOptional bool
 	}{
-		{"@NotBlank String email", "email", "String", []string{"@NotBlank"}},
-		{"@Min(0) @NotNull BigDecimal qty", "qty", "BigDecimal", []string{"@Min(0)", "@NotNull"}},
-		{"int count", "count", "int", nil},
-		{"@Email @NotNull String addr", "addr", "String", []string{"@Email", "@NotNull"}},
-		{"List<String> roles", "roles", "List<String>", nil},
+		{"@NotBlank String email", "email", "String", []string{"@NotBlank"}, false},
+		{"@Min(0) @NotNull BigDecimal qty", "qty", "BigDecimal", []string{"@Min(0)", "@NotNull"}, false},
+		{"int count", "count", "int", nil, false},
+		{"@Email @NotNull String addr", "addr", "String", []string{"@Email", "@NotNull"}, false},
+		{"List<String> roles", "roles", "List<String>", nil, false},
+		// #4868 — JS/TS `name[?]: type` convention. Previously parsed as
+		// Java `Type name`, yielding a garbage type ("email?:") → "unknown".
+		{"email?: string", "email", "string", nil, true},
+		{"count: number", "count", "number", nil, false},
+		{"createdAt: Date | null", "createdAt", "Date | null", nil, false},
+		{"id: string", "id", "string", nil, false},
+		{"meta: Record<string, number>", "meta", "Record<string, number>", nil, false},
+		{"readonly name?: string", "name", "string", nil, true},
 	}
 	for _, c := range cases {
-		annos, typ := parseFieldSignature(c.sig, c.fieldName)
+		annos, typ, optional := parseFieldSignature(c.sig, c.fieldName)
 		if typ != c.wantType {
 			t.Errorf("sig=%q: type want %q got %q", c.sig, c.wantType, typ)
 		}
 		if !reflect.DeepEqual(annos, c.wantAnnos) {
 			t.Errorf("sig=%q: annos want %v got %v", c.sig, c.wantAnnos, annos)
+		}
+		if optional != c.wantOptional {
+			t.Errorf("sig=%q: optional want %v got %v", c.sig, c.wantOptional, optional)
 		}
 	}
 }
@@ -367,9 +497,14 @@ func TestShape_InferNullable(t *testing.T) {
 		{nil, "Optional<Foo>", true},
 		{nil, "int", false},
 		{nil, "String", false},
+		// #4868 — TS union nullability.
+		{nil, "Date | null", true},
+		{nil, "string | undefined", true},
+		{nil, "string | number", false},
+		{nil, "Array<Foo> | null", true},
 	}
 	for _, c := range cases {
-		if got := inferNullable(c.annos, c.typ); got != c.want {
+		if got := inferNullable(c.annos, c.typ, nil); got != c.want {
 			t.Errorf("inferNullable(%v,%q)=%v want %v", c.annos, c.typ, got, c.want)
 		}
 	}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -1854,6 +1854,19 @@ func importRecord(modulePath string, file extractor.FileInput, props map[string]
 // blocks (`if X: y = ...`) is intentionally skipped — those are not
 // stable class attributes a resolver can rely on, and emitting them would
 // risk over-eager binding.
+// pyFieldSignature builds a class-field signature for the dashboard shape
+// resolver. When a PEP-526 annotation is present it emits the `name: type`
+// convention (e.g. `effectiveAt: datetime | None`) the shape parser
+// understands; otherwise it emits the bare name (no inferred type). A trailing
+// `| None` / `Optional[...]` annotation lets the resolver mark the field
+// nullable. (#4868)
+func pyFieldSignature(name, typeAnn string) string {
+	if typeAnn = strings.TrimSpace(typeAnn); typeAnn == "" {
+		return name
+	}
+	return name + ": " + typeAnn
+}
+
 func extractClassFields(
 	body *sitter.Node,
 	file extractor.FileInput,
@@ -1879,9 +1892,18 @@ func extractClassFields(
 				continue
 			}
 			var lhs *sitter.Node
+			var typeAnn string
 			switch expr.Type() {
 			case "assignment":
 				lhs = expr.ChildByFieldName("left")
+				// #4868 — capture the PEP-526 annotation on `x: int = 0` (the
+				// assignment's "type" field) so the dashboard shape row shows
+				// the real field type (and `| None` nullability) instead of
+				// "unknown". The shape parser reads the `name: type` convention
+				// emitted in the Signature below.
+				if tn := expr.ChildByFieldName("type"); tn != nil {
+					typeAnn = strings.TrimSpace(nodeText(tn, file.Content))
+				}
 			case "augmented_assignment":
 				// `count += 1` at class scope doesn't introduce a new
 				// attribute — skip.
@@ -1914,7 +1936,7 @@ func extractClassFields(
 					SourceFile:    file.Path,
 					StartLine:     int(stmt.StartPoint().Row) + 1,
 					EndLine:       int(stmt.EndPoint().Row) + 1,
-					Signature:     name,
+					Signature:     pyFieldSignature(name, typeAnn),
 				})
 			}
 		}

--- a/internal/extractors/python/field_type_4868_test.go
+++ b/internal/extractors/python/field_type_4868_test.go
@@ -1,0 +1,70 @@
+// field_type_4868_test.go — #4868: PEP-526 annotated class fields must carry a
+// `name: type` Signature so the dashboard shape resolver shows the real type
+// (and nullability for `| None` / `Optional[...]`) instead of "unknown".
+package python_test
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tspython "github.com/smacker/go-tree-sitter/python"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+)
+
+func TestExtract_AnnotatedFieldSignature_4868(t *testing.T) {
+	src := []byte(`
+class CreateAddressBody:
+    line1: str = ""
+    effective_at: datetime | None = None
+    count = 0
+`)
+	p := sitter.NewParser()
+	p.SetLanguage(tspython.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	fi := extractor.FileInput{
+		Path:     "core/dto/address.py",
+		Content:  src,
+		Language: "python",
+		Tree:     tree,
+	}
+	ext, _ := extractor.Get("python")
+	ents, err := ext.Extract(context.Background(), fi)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	sig := map[string]string{}
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" {
+			name := e.Name
+			if i := lastDot(name); i >= 0 {
+				name = name[i+1:]
+			}
+			sig[name] = e.Signature
+		}
+	}
+	if got := sig["line1"]; got != "line1: str" {
+		t.Errorf("line1 signature: want %q, got %q", "line1: str", got)
+	}
+	if got := sig["effective_at"]; got != "effective_at: datetime | None" {
+		t.Errorf("effective_at signature: want %q, got %q", "effective_at: datetime | None", got)
+	}
+	// Unannotated field keeps the bare-name signature (no fabricated type).
+	if got := sig["count"]; got != "count" {
+		t.Errorf("count signature: want %q, got %q", "count", got)
+	}
+}
+
+func lastDot(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '.' {
+			return i
+		}
+	}
+	return -1
+}

--- a/webui-v2/src/components/ShapeTree.tsx
+++ b/webui-v2/src/components/ShapeTree.tsx
@@ -22,10 +22,16 @@
    site reimplementing the expansion logic.
    ============================================================ */
 
-import { useState, type ReactNode } from "react";
+import {
+  useState,
+  type ReactNode,
+  type MouseEvent as ReactMouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { ChevronRight, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useShape } from "@/hooks/use-paths";
+import { useSourcePeek } from "@/components/SourcePeek/SourcePeekProvider";
 import {
   indentForDepth,
   fieldTypeLabel,
@@ -292,6 +298,17 @@ function TreeGuide({ depth, children }: { depth: number; children: ReactNode }) 
   );
 }
 
+/**
+ * One nested field row, laid out as aligned COLUMNS (#4868):
+ *
+ *   [chevron] name… | type | constraints(optional? + validation/annotation chips)
+ *
+ * Click interactions are split (#4869):
+ *   - clicking the row body or the chevron toggles expand/collapse (only when
+ *     the field's type is itself expandable);
+ *   - clicking the TYPE-NAME link opens that type's SOURCE in the peek modal —
+ *     it stops propagation so it never also toggles the row.
+ */
 function NestedFieldRow({
   groupId,
   field,
@@ -302,8 +319,25 @@ function NestedFieldRow({
   depth: number;
 }) {
   const [open, setOpen] = useState(false);
+  const { openSourcePeek } = useSourcePeek();
   const expandable = field.has_children;
+  // A field is "optional" when nullable (TS `?`, `| null`/`| undefined`,
+  // Optional<…>, Python `| None`). Required is the implied default, so we
+  // render an indicator ONLY for the optional case (#4868) — no "required"
+  // chip clutter.
   const optional = !!field.nullable;
+  // The type-name link opens source when we know where the type is defined.
+  const canPeekType = !!field.type_source_file;
+  const openType = (e: ReactMouseEvent | ReactKeyboardEvent) => {
+    e.stopPropagation();
+    if (!canPeekType) return;
+    openSourcePeek({
+      groupId,
+      file: field.type_source_file as string,
+      line: field.type_source_line ?? 1,
+      repo: field.type_repo,
+    });
+  };
   return (
     <div>
       <div
@@ -326,53 +360,77 @@ function NestedFieldRow({
           }
         }}
       >
-        <ExpandGlyph expandable={expandable} open={open} />
-        <span className="font-mono text-text shrink-0">{field.name}</span>
+        {/* Col: chevron + name (indented). Fixed width so types align. */}
         <span
-          className={cn(
-            "font-mono shrink-0",
-            expandable
-              ? "text-accent underline decoration-dotted underline-offset-2"
-              : "text-text-3",
-          )}
-          title={expandable ? `${field.type} — click to expand fields` : field.type}
+          className="flex items-center gap-1 shrink-0 min-w-0"
+          style={{ width: 180 }}
         >
-          {fieldTypeLabel(field.type, field.nullable)}
-        </span>
-        <span
-          data-testid={`shape-field-optionality-${field.name}`}
-          className={cn(
-            "inline-flex items-center px-1 py-0.5 rounded-sm text-[10px] font-medium font-sans shrink-0",
-            optional
-              ? "bg-surface-2 text-text-4 border border-border"
-              : "bg-[var(--success-soft)] text-[var(--success)] border border-[var(--success-soft)]",
-          )}
-          title={fieldOptionality(field.nullable)}
-        >
-          {optional ? "optional" : "required"}
-        </span>
-        {field.validations && field.validations.length > 0 && (
+          <ExpandGlyph expandable={expandable} open={open} />
           <span
-            data-testid={`shape-field-validations-${field.name}`}
-            className="flex items-center gap-1 min-w-0 overflow-hidden"
+            className="font-mono text-text overflow-hidden text-ellipsis whitespace-nowrap"
+            title={field.name}
           >
-            {field.validations.map((v) => (
-              <span
-                key={v}
-                data-testid={`validation-chip-${v}`}
-                className="inline-flex items-center px-1 py-0.5 rounded-sm text-[10px] font-medium font-mono shrink-0 bg-[var(--info-soft)] text-[var(--info)] border border-[var(--info-soft)]"
-                title={v}
-              >
-                {v}
-              </span>
-            ))}
+            {field.name}
           </span>
-        )}
-        {field.annotations && field.annotations.length > 0 && (
-          <span className="text-text-4 truncate font-mono text-[11px]">
-            {field.annotations.join(" ")}
-          </span>
-        )}
+        </span>
+
+        {/* Col: type. A type-name LINK (own click → source peek) when the
+            type's definition location is known; plain text otherwise. */}
+        <span className="shrink-0 font-mono overflow-hidden text-ellipsis whitespace-nowrap" style={{ width: 200 }}>
+          {canPeekType ? (
+            <button
+              type="button"
+              data-testid={`shape-field-type-link-${field.name}`}
+              onClick={openType}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") openType(e);
+              }}
+              title={`${field.type} — click to open type source`}
+              className="text-accent underline decoration-dotted underline-offset-2 hover:decoration-solid bg-transparent p-0 border-0 cursor-pointer font-mono text-left max-w-full overflow-hidden text-ellipsis whitespace-nowrap"
+            >
+              {fieldTypeLabel(field.type, field.nullable)}
+            </button>
+          ) : (
+            <span className="text-text-3" title={field.type}>
+              {fieldTypeLabel(field.type, field.nullable)}
+            </span>
+          )}
+        </span>
+
+        {/* Col: constraints — optional indicator (only when optional) + chips. */}
+        <span className="flex items-center gap-1 min-w-0 overflow-hidden flex-1">
+          {optional && (
+            <span
+              data-testid={`shape-field-optionality-${field.name}`}
+              className="inline-flex items-center px-1 py-0.5 rounded-sm text-[10px] font-medium font-sans shrink-0 bg-surface-2 text-text-4 border border-border"
+              title={fieldOptionality(field.nullable)}
+            >
+              optional
+            </span>
+          )}
+          {field.validations && field.validations.length > 0 && (
+            <span
+              data-testid={`shape-field-validations-${field.name}`}
+              className="flex items-center gap-1 min-w-0 overflow-hidden"
+            >
+              {field.validations.map((v) => (
+                <span
+                  key={v}
+                  data-testid={`validation-chip-${v}`}
+                  className="inline-flex items-center px-1 py-0.5 rounded-sm text-[10px] font-medium font-mono shrink-0 bg-[var(--info-soft)] text-[var(--info)] border border-[var(--info-soft)]"
+                  title={v}
+                >
+                  {v}
+                </span>
+              ))}
+            </span>
+          )}
+          {field.annotations && field.annotations.length > 0 && (
+            <span className="text-text-4 truncate font-mono text-[11px]">
+              {field.annotations.join(" ")}
+            </span>
+          )}
+        </span>
       </div>
       {open && expandable && (
         <NestedFieldRows

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -915,6 +915,15 @@ export interface ShapeRow {
   validations?: string[];
   nullable?: boolean;
   type_entity_id?: string;
+  /**
+   * Definition location of the field's TYPE (#4869) — lets the UI open the
+   * type's source in the peek modal when the user clicks the type-name link,
+   * independent of the row-body expand/collapse click. Present only when the
+   * type resolves to an in-group entity.
+   */
+  type_source_file?: string;
+  type_source_line?: number;
+  type_repo?: string;
   has_children: boolean;
 }
 


### PR DESCRIPTION
## Root cause (#4868)

On upvate-v3 the shape endpoint returned `type=''` (→ "unknown") and `nullable=None` for **every** TS DTO field. The field-membership extractors (#4845/#4856) emit field signatures in the JS/TS `name[?]: type` convention (e.g. `email?: string`, `effectiveAt: Date | null`), but `parseFieldSignature` in `internal/dashboard/shape_tree.go` only understood the **Java** `Type name` order — so it misread `email?: string` and produced a garbage/empty type, and never saw the optional `?` or `| null`.

## Backend (#4868)

- `parseFieldSignature` now detects the `name[?]: type` convention (top-level colon, name-anchored, bracket-aware) and returns `(annotations, type, optional)`; falls back to the Java parser otherwise.
- Nullability folds in: TS-optional `?`, `| null` / `| undefined` unions, Python `| None` / `Optional[...]`, plus existing Java `@Nullable` / `Optional<>` and an extractor-stamped `nullable` property.
- `unwrapElementType` now handles TS containers (`Array<X>`, `X[]`, `Promise<X>`, `Observable<X>`) and strips nullable union members so the type-link resolves to the child entity.
- `ShapeRow` carries `type_source_file` / `type_source_line` / `type_repo` (the resolved type's definition location) so the UI can open the type's source.
- **Generalisation:** the Python extractor now captures the PEP-526 annotation on class fields, emitting `name: type` signatures (so Python DTO fields get real types + `| None` nullability too). Java was already type-first. Languages that need richer capture can follow the same convention.

## Frontend (#4868 / #4869)

- Real field type rendered (no more "unknown").
- **Column layout**: `name | type | constraints`, with the tree indent + connectors (#4860) kept on the name column.
- **Redundant "required" chip dropped** — an `optional` chip renders only for optional/nullable fields; required is the implied default.
- **Click split (#4869)**: row body / chevron = expand/collapse; the **type-name link** opens the type's source via the shared `useSourcePeek` modal and `stopPropagation`s so it never toggles the row.

## Fixtures

- `internal/dashboard`: TS class field + interface field shape rows assert non-empty `type` and correct `nullable` (incl. `Date | null` → nullable=true, TS-optional `?` → nullable=true, required → false); `parseFieldSignature` / `inferNullable` table cases for the TS/Python forms; `type_source_file` flow.
- `internal/extractors/python`: annotated class-field signature (`line1: str`, `effective_at: datetime | None`) vs bare unannotated field.

## Gates

- `go build ./...`, `go vet`, `go test ./internal/extractors/... ./internal/dashboard/... ./internal/types/` — green.
- `npx tsc --noEmit`, `npm run build`, `npx vitest run` — 143 real tests pass; the 12 failing files are the pre-existing Playwright e2e specs (wrong runner under vitest), unchanged by this PR.

Deploy-deferred.

Closes #4868 #4869.