### PR TITLE
fix(#4874): direction-aware centered edge handles in flow-dag + flowchart (no more side-escaping edges)

### DIFF
--- a/webui-v2/src/components/flow-dag/Flowchart.tsx
+++ b/webui-v2/src/components/flow-dag/Flowchart.tsx
@@ -177,6 +177,9 @@ function FlowchartInner({
       edgeRouting: "ORTHOGONAL",
       nodeSpacing: 34,
       layerSpacing: 64,
+      // #4874: centered leading/trailing-face ports so ELK's routed endpoints
+      // line up with the direction-aware centered handles (no side-escaping).
+      centeredPorts: true,
     })
       .then(({ nodes: positions, edges: routes }) => {
         if (cancelled || myRun !== runId.current) return;

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -621,6 +621,11 @@ export async function layoutTreeElk(
     layerSpacing: shape?.layerSpacing ?? 90,
     defaultNodeWidth: w,
     defaultNodeHeight: h,
+    // #4874: pin one centered source/target port per node on the leading/trailing
+    // face for the active direction, so ELK's routed endpoints coincide with the
+    // centered React Flow handles (no side-escaping edges; the many outgoing edges
+    // leave from one centered trunk and split via the orthogonal bus).
+    centeredPorts: true,
   });
 
   // ELK positions are top-left already (flat graph → parent-relative == absolute).

--- a/webui-v2/src/lib/elk-layout.test.ts
+++ b/webui-v2/src/lib/elk-layout.test.ts
@@ -111,6 +111,86 @@ describe("layoutWithElk", () => {
   });
 });
 
+describe("centeredPorts (#4874)", () => {
+  // With centered ports the edge route must START at the source node's centered
+  // LEADING-face point and END at the target node's centered TRAILING-face point,
+  // so ELK's bendPoints coincide with React Flow's centered handles.
+  it("anchors the route at the centered right/left faces for RIGHT", async () => {
+    const nodes: ElkLayoutNode[] = [
+      { id: "a", width: 120, height: 40, lane: 0 },
+      { id: "b", width: 120, height: 40, lane: 1 },
+    ];
+    const edges: ElkLayoutEdge[] = [{ id: "e1", source: "a", target: "b" }];
+
+    const { nodes: pos, edges: routes } = await layoutWithElk(nodes, edges, {
+      direction: "RIGHT",
+      centeredPorts: true,
+    });
+    const a = pos.get("a")!;
+    const b = pos.get("b")!;
+    const route = routes.get("e1")!;
+    const start = route.points[0];
+    const end = route.points[route.points.length - 1];
+
+    // Source leaves the RIGHT-edge center of a; target enters the LEFT-edge
+    // center of b. (1px tolerance for ELK's float coords.)
+    expect(start.x).toBeCloseTo(a.x + a.width, 1);
+    expect(start.y).toBeCloseTo(a.y + a.height / 2, 1);
+    expect(end.x).toBeCloseTo(b.x, 1);
+    expect(end.y).toBeCloseTo(b.y + b.height / 2, 1);
+  });
+
+  it("anchors the route at the centered bottom/top faces for DOWN", async () => {
+    const nodes: ElkLayoutNode[] = [
+      { id: "a", width: 120, height: 40, lane: 0 },
+      { id: "b", width: 120, height: 40, lane: 1 },
+    ];
+    const edges: ElkLayoutEdge[] = [{ id: "e1", source: "a", target: "b" }];
+
+    const { nodes: pos, edges: routes } = await layoutWithElk(nodes, edges, {
+      direction: "DOWN",
+      centeredPorts: true,
+    });
+    const a = pos.get("a")!;
+    const b = pos.get("b")!;
+    const route = routes.get("e1")!;
+    const start = route.points[0];
+    const end = route.points[route.points.length - 1];
+
+    // Source leaves the BOTTOM-edge center of a; target enters the TOP-edge
+    // center of b (horizontally centered).
+    expect(start.x).toBeCloseTo(a.x + a.width / 2, 1);
+    expect(start.y).toBeCloseTo(a.y + a.height, 1);
+    expect(end.x).toBeCloseTo(b.x + b.width / 2, 1);
+    expect(end.y).toBeCloseTo(b.y, 1);
+  });
+
+  it("shares ONE centered source trunk for multiple outgoing edges (DOWN)", async () => {
+    // a → b and a → c: both must leave from a's single bottom-center port.
+    const nodes: ElkLayoutNode[] = [
+      { id: "a", width: 120, height: 40, lane: 0 },
+      { id: "b", width: 120, height: 40, lane: 1 },
+      { id: "c", width: 120, height: 40, lane: 1 },
+    ];
+    const edges: ElkLayoutEdge[] = [
+      { id: "e1", source: "a", target: "b" },
+      { id: "e2", source: "a", target: "c" },
+    ];
+    const { nodes: pos, edges: routes } = await layoutWithElk(nodes, edges, {
+      direction: "DOWN",
+      centeredPorts: true,
+    });
+    const a = pos.get("a")!;
+    const s1 = routes.get("e1")!.points[0];
+    const s2 = routes.get("e2")!.points[0];
+    // Both outgoing edges start at the SAME centered bottom-center trunk point.
+    expect(s1.x).toBeCloseTo(a.x + a.width / 2, 1);
+    expect(s1.y).toBeCloseTo(a.y + a.height, 1);
+    expect(s2.x).toBeCloseTo(s1.x, 1);
+    expect(s2.y).toBeCloseTo(s1.y, 1);
+  });
+});
+
 describe("orthogonalPath", () => {
   it("returns null for <2 points (caller falls back to smoothstep)", () => {
     expect(orthogonalPath([])).toBeNull();

--- a/webui-v2/src/lib/elk-layout.ts
+++ b/webui-v2/src/lib/elk-layout.ts
@@ -121,6 +121,19 @@ export interface ElkLayoutOptions {
   defaultNodeWidth?: number;
   defaultNodeHeight?: number;
   /**
+   * #4874: pin every node's edge endpoints to a SINGLE centered port on its
+   * leading (outgoing) / trailing (incoming) face, chosen by `direction`:
+   *   - RIGHT → source on the right-edge center, target on the left-edge center
+   *   - DOWN  → source on the bottom-edge center, target on the top-edge center
+   *   - LEFT/UP → mirror images of the above
+   * Every node gets exactly one fixed source port and one fixed target port
+   * (FIXED_POS), so ELK's routed bendPoints start/end at the same centered point
+   * React Flow draws its <Handle> at — no diagonal stub from handle to route, and
+   * a node's many outgoing edges all leave from the one centered trunk and split
+   * via the orthogonal bus instead of fanning from offset side points.
+   */
+  centeredPorts?: boolean;
+  /**
    * Optional tier-lane ordering hint. Given a node id, return its lane rank
    * (lower ⇒ earlier along `direction`). Nodes are pinned into ordered lanes so
    * e.g. client·edge·auth·compute·data·messaging·external read left→right. When
@@ -135,7 +148,7 @@ export interface ElkLayoutOptions {
 }
 
 const DEFAULTS: Required<
-  Omit<ElkLayoutOptions, "laneOf" | "extraLayoutOptions" | "padding">
+  Omit<ElkLayoutOptions, "laneOf" | "extraLayoutOptions" | "padding" | "centeredPorts">
 > & { padding: NonNullable<ElkLayoutOptions["padding"]> } = {
   direction: "RIGHT",
   algorithm: "layered",
@@ -221,11 +234,69 @@ export function orthogonalPath(
  * the nested ElkNode tree ELK expects. Edges are attached at the lowest common
  * ancestor of their endpoints so cross-container edges route correctly.
  */
+/**
+ * Centered source/target port coordinates (relative to a node's top-left) for a
+ * given flow direction (#4874). The SOURCE port sits on the node's LEADING face
+ * (where the flow exits) and the TARGET port on its TRAILING face (where the flow
+ * enters), each at the face's midpoint — matching React Flow's centered handles.
+ */
+function centeredPortGeom(
+  direction: ElkDirection,
+  width: number,
+  height: number,
+): { source: { x: number; y: number }; target: { x: number; y: number } } {
+  switch (direction) {
+    case "RIGHT":
+      return {
+        source: { x: width, y: height / 2 }, // right-edge center
+        target: { x: 0, y: height / 2 }, // left-edge center
+      };
+    case "LEFT":
+      return {
+        source: { x: 0, y: height / 2 }, // left-edge center
+        target: { x: width, y: height / 2 }, // right-edge center
+      };
+    case "UP":
+      return {
+        source: { x: width / 2, y: 0 }, // top-edge center
+        target: { x: width / 2, y: height }, // bottom-edge center
+      };
+    case "DOWN":
+    default:
+      return {
+        source: { x: width / 2, y: height }, // bottom-edge center
+        target: { x: width / 2, y: 0 }, // top-edge center
+      };
+  }
+}
+
+/**
+ * ELK port `side` for the source/target port under a given flow direction. The
+ * source leaves on the leading face, the target enters on the trailing face.
+ */
+function portSideFor(direction: ElkDirection, role: "source" | "target"): string {
+  const leading: Record<ElkDirection, string> = {
+    RIGHT: "EAST",
+    LEFT: "WEST",
+    DOWN: "SOUTH",
+    UP: "NORTH",
+  };
+  const trailing: Record<ElkDirection, string> = {
+    RIGHT: "WEST",
+    LEFT: "EAST",
+    DOWN: "NORTH",
+    UP: "SOUTH",
+  };
+  return role === "source" ? leading[direction] : trailing[direction];
+}
+
 function buildElkTree(
   nodes: ElkLayoutNode[],
   edges: ElkLayoutEdge[],
   opts: Required<Pick<ElkLayoutOptions, "defaultNodeWidth" | "defaultNodeHeight">> & {
     laneOf?: ElkLayoutOptions["laneOf"];
+    centeredPorts?: boolean;
+    direction: ElkDirection;
   },
 ): ElkNode {
   const byId = new Map<string, ElkLayoutNode>();
@@ -235,16 +306,13 @@ function buildElkTree(
   const elkById = new Map<string, ElkNode>();
   for (const n of nodes) {
     const isContainer = n.isContainer ?? false;
+    const width = finite(n.width, opts.defaultNodeWidth);
+    const height = finite(n.height, opts.defaultNodeHeight);
     const shell: ElkNode = {
       id: n.id,
       children: [],
       edges: [],
-      ...(isContainer
-        ? {}
-        : {
-            width: finite(n.width, opts.defaultNodeWidth),
-            height: finite(n.height, opts.defaultNodeHeight),
-          }),
+      ...(isContainer ? {} : { width, height }),
     };
     // Per-node lane hint → ELK position constraint within its layer.
     const lane = opts.laneOf?.(n.id) ?? n.lane;
@@ -254,6 +322,35 @@ function buildElkTree(
         // Pins the node's layer (rank) so lanes stay ordered along direction.
         "elk.layered.layering.layerChoiceConstraint": String(lane),
       };
+    }
+    // #4874: pin a single centered source + target port per leaf node so ELK's
+    // routed endpoints land exactly where React Flow draws the centered handle.
+    if (opts.centeredPorts && !isContainer) {
+      const g = centeredPortGeom(opts.direction, width, height);
+      shell.layoutOptions = {
+        ...shell.layoutOptions,
+        // FIXED_POS honours the explicit port (x,y) we set below verbatim.
+        "elk.portConstraints": "FIXED_POS",
+      };
+      shell.ports = [
+        {
+          id: `${n.id}__src`,
+          x: g.source.x,
+          y: g.source.y,
+          width: 0,
+          height: 0,
+          // Direction the port faces, so the router leaves/arrives cleanly.
+          layoutOptions: { "elk.port.side": portSideFor(opts.direction, "source") },
+        },
+        {
+          id: `${n.id}__tgt`,
+          x: g.target.x,
+          y: g.target.y,
+          width: 0,
+          height: 0,
+          layoutOptions: { "elk.port.side": portSideFor(opts.direction, "target") },
+        },
+      ] as ElkNode["ports"];
     }
     elkById.set(n.id, shell);
   }
@@ -286,6 +383,13 @@ function buildElkTree(
     return undefined;
   };
 
+  // #4874: when ports are pinned, anchor edges to the centered source/target
+  // PORT id (not the node id) so ELK routes from/to the exact centered point.
+  const srcRef = (id: string): string =>
+    opts.centeredPorts && !(byId.get(id)?.isContainer ?? false) ? `${id}__src` : id;
+  const tgtRef = (id: string): string =>
+    opts.centeredPorts && !(byId.get(id)?.isContainer ?? false) ? `${id}__tgt` : id;
+
   for (const e of edges) {
     if (!byId.has(e.source) || !byId.has(e.target)) continue;
     const common = lca(e.source, e.target);
@@ -298,13 +402,13 @@ function buildElkTree(
       // Walk up from the source to the first common container, else root.
       const target: ElkExtendedEdge = {
         id: e.id,
-        sources: [e.source],
-        targets: [e.target],
+        sources: [srcRef(e.source)],
+        targets: [tgtRef(e.target)],
       };
       root.edges!.push(target);
       continue;
     }
-    host.edges!.push({ id: e.id, sources: [e.source], targets: [e.target] });
+    host.edges!.push({ id: e.id, sources: [srcRef(e.source)], targets: [tgtRef(e.target)] });
   }
 
   return root;
@@ -417,6 +521,8 @@ export async function layoutWithElk(
     defaultNodeWidth: o.defaultNodeWidth,
     defaultNodeHeight: o.defaultNodeHeight,
     laneOf: options.laneOf,
+    centeredPorts: options.centeredPorts,
+    direction: o.direction,
   });
   root.layoutOptions = graphLayoutOptions(o, options.extraLayoutOptions);
 


### PR DESCRIPTION
## What

Edges in the flow-dag Tree view and the Flowchart view now anchor at the **center of each node's leading/trailing face**, direction-aware, so the flow reads cleanly top→down (vertical) or left→right (horizontal). No more 2nd-outgoing-edge "escaping sideways".

## Root cause

The shared ELK layout (`lib/elk-layout.ts`) ran with **FREE** port constraints — the default. ELK was free to place edge endpoints at offset points along a node's side, so a node's many outgoing edges fanned from different side points. React Flow drew its `<Handle>`s centered on the leading/trailing face, so the rendered ELK route (`elkPoints`) disagreed with the handle → the diagonal/side-escape look.

## Fix

- **`lib/elk-layout.ts`**: new `centeredPorts` option. Per leaf node it pins **one** source port on the LEADING-face center and **one** target port on the TRAILING-face center with `elk.portConstraints: FIXED_POS`, plus `elk.port.side`. Direction → face mapping:
  - **RIGHT (LR):** source = right-edge center `(w, h/2)`, target = left-edge center `(0, h/2)`
  - **DOWN (TB):** source = bottom center `(w/2, h)`, target = top center `(w/2, 0)`
  - **LEFT / UP:** mirror images
  Edges anchor to the port ids (`<id>__src` / `<id>__tgt`), so ELK's routed bendPoints START/END exactly at the centered handle coords. Containers are unaffected (ports only on leaf nodes).
- **`flow-dag/layout.ts` (`layoutTreeElk`)** and **`flow-dag/Flowchart.tsx`**: pass `centeredPorts: true`. The existing direction-aware handle positions (`Position.Right/Left` for LR, `Bottom/Top` for TB) already matched these faces — now the ELK route matches them too.

## Behavior

- Many outgoing edges from one node share the single centered source trunk and split via the orthogonal bus (verified by test).
- H/V toggle preserved: `direction` drives both handle sides and ELK port sides, so switching re-anchors + re-routes.
- Node content / colors / data untouched — geometry + edge anchoring only.

## Gates (frontend-only)

- `npx tsc --noEmit` — clean
- `npm run build` — ok
- `npx vitest run` — 152 unit tests pass (the 12 failing files are pre-existing Playwright e2e specs that error under the vitest runner, unrelated)
- Added `centeredPorts` layout tests: route endpoints land on the centered right/left faces (RIGHT) and bottom/top faces (DOWN), and two outgoing edges share one centered trunk.

No Go / registry / coverage changes. Deploy-deferred.

Closes #4874.