### PR TITLE
feat(#4872): Java Bean Validation constraints → unified validations chips (javax + jakarta)

### DIFF
--- a/internal/extractors/java/field_validations.go
+++ b/internal/extractors/java/field_validations.go
@@ -1,0 +1,384 @@
+// field_validations.go — Issue #4872. Per-field Bean Validation constraints for
+// Java DTO/record/class fields, stamped onto the SCOPE.Schema/field entity under
+// Properties["validations"] (comma-joined) so the dashboard ShapeTree surfaces
+// them as small constraint chips — mirroring the TS class-validator support in
+// #4858 (internal/extractors/javascript/class_validator_fields.go) and the
+// Python field-validation support in #4871
+// (internal/extractors/python/field_validations.go).
+//
+// The dashboard side already exists: internal/dashboard/shape_tree.go reads
+// Properties["validations"] (comma-split) into v2ShapeRow.Validations, and
+// webui-v2/src/components/ShapeTree.tsx renders the chips. This pass only has
+// to populate that property on the Java field entities.
+//
+// Java DTO fields carry Bean Validation annotations from BOTH the legacy
+// javax.validation.constraints.* package and the modern
+// jakarta.validation.constraints.* package, e.g.
+//
+//	public class CreateUserDto {
+//	    @NotNull
+//	    @Size(max = 120)
+//	    @Email
+//	    private String email;
+//	}
+//
+// These annotations are already preserved in the field signature (buildField
+// keeps the raw declaration), but they were NOT routed into the unified
+// `validations` property that drives the chips. This pass reuses the same
+// tree-sitter `modifiers` → annotation children that javaFieldHasInjectAnnotation
+// already walks, classifies each recognised Bean Validation annotation, and
+// stamps the terse chip list.
+//
+// Covered Bean Validation annotations (javax.* and jakarta.*):
+//
+//   - @NotNull → Required; @NotEmpty → NotEmpty; @NotBlank → NotBlank;
+//     @Null → Null.
+//   - @Size(min=, max=) → Size:min..max (or MinLength:/MaxLength: when only one
+//     bound is present).
+//   - @Min / @DecimalMin → Min:value; @Max / @DecimalMax → Max:value.
+//   - @Pattern(regexp=) → Pattern; @Email → Email.
+//   - @Positive → Positive; @PositiveOrZero → PositiveOrZero; @Negative →
+//     Negative; @NegativeOrZero → NegativeOrZero; @Digits → Digits.
+//   - @Past → Past; @PastOrPresent → PastOrPresent; @Future → Future;
+//     @FutureOrPresent → FutureOrPresent.
+//   - @AssertTrue → AssertTrue; @AssertFalse → AssertFalse.
+//   - @Valid → Valid (nested validation marker).
+//
+// Chip text is kept terse and comma-free (Properties is comma-joined and the
+// dashboard splits on ","): bounds fold their scalar value (`Max:120`,
+// `Min:0`), @Size folds into `Size:0..120` / `MaxLength:120`; the rest render
+// as a bare marker (`Required`, `Email`, `Pattern`). Only stamped when at least
+// one constraint is found; existing Properties are preserved.
+
+package java
+
+import (
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// javaBeanValidationMarkers maps a Bean Validation annotation's simple name to
+// the bare marker chip it produces. These carry no scalar bound worth folding
+// (their arguments, if any, are messages/groups/regexes that would corrupt the
+// comma-joined property), so only the annotation identity is recorded.
+//
+// @NotNull renders as `Required` to match the TS/Python required marker.
+var javaBeanValidationMarkers = map[string]string{
+	"NotNull":         "Required",
+	"NotEmpty":        "NotEmpty",
+	"NotBlank":        "NotBlank",
+	"Null":            "Null",
+	"Email":           "Email",
+	"Pattern":         "Pattern",
+	"Positive":        "Positive",
+	"PositiveOrZero":  "PositiveOrZero",
+	"Negative":        "Negative",
+	"NegativeOrZero":  "NegativeOrZero",
+	"Digits":          "Digits",
+	"Past":            "Past",
+	"PastOrPresent":   "PastOrPresent",
+	"Future":          "Future",
+	"FutureOrPresent": "FutureOrPresent",
+	"AssertTrue":      "AssertTrue",
+	"AssertFalse":     "AssertFalse",
+	"Valid":           "Valid",
+}
+
+// javaBeanValidationScalar maps a Bean Validation annotation whose `value`
+// (single-element) or default argument is a scalar bound to the chip prefix it
+// folds into (`@Min(0)` → "Min:0"). @DecimalMin / @DecimalMax carry their bound
+// as a string literal but fold identically.
+var javaBeanValidationScalar = map[string]string{
+	"Min":        "Min",
+	"Max":        "Max",
+	"DecimalMin": "Min",
+	"DecimalMax": "Max",
+}
+
+// emitJavaFieldValidations walks every field entity emitted for one class/record
+// (in the [before, after) window of out) and stamps Properties["validations"]
+// with the Bean Validation chips collected from the matching declaration's
+// annotations.
+//
+// fieldNodes maps the field/record-component leaf name to the AST node carrying
+// its annotations (a field_declaration's `modifiers`, or a record
+// formal_parameter). It is built by the caller while it walks the class body so
+// this pass does not re-traverse the tree.
+func emitJavaFieldValidations(
+	parentType string,
+	before, after int,
+	fieldNodes map[string]*sitter.Node,
+	src []byte,
+	out *[]types.EntityRecord,
+) {
+	if parentType == "" || out == nil || len(fieldNodes) == 0 {
+		return
+	}
+	prefix := parentType + "."
+	for k := before; k < after; k++ {
+		if k < 0 || k >= len(*out) {
+			continue
+		}
+		e := &(*out)[k]
+		if e.Kind != "SCOPE.Schema" || e.Subtype != "field" {
+			continue
+		}
+		if !strings.HasPrefix(e.Name, prefix) {
+			continue
+		}
+		leaf := e.Name[len(prefix):]
+		if leaf == "" || strings.Contains(leaf, ".") {
+			continue
+		}
+		node, ok := fieldNodes[leaf]
+		if !ok || node == nil {
+			continue
+		}
+		chips := javaFieldValidationChips(node, src)
+		if len(chips) == 0 {
+			continue
+		}
+		(*out)[k].Properties = applyJavaValidations((*out)[k].Properties, chips)
+	}
+}
+
+// javaFieldValidationChips collects the Bean Validation chips from the
+// annotations on a field declaration or record component. `node` may be a
+// field_declaration, a formal_parameter (record component) or any node whose
+// direct/`modifiers` children include annotation nodes — the helper finds the
+// annotation nodes either way.
+func javaFieldValidationChips(node *sitter.Node, src []byte) []string {
+	if node == nil {
+		return nil
+	}
+	var chips []string
+	for _, ann := range javaAnnotationNodes(node) {
+		nameNode := ann.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		name := simpleAnnotationName(string(src[nameNode.StartByte():nameNode.EndByte()]))
+		if name == "" {
+			continue
+		}
+		if name == "Size" {
+			if c := javaSizeChip(ann, src); c != "" {
+				chips = appendJavaChip(chips, c)
+			}
+			continue
+		}
+		if prefix, ok := javaBeanValidationScalar[name]; ok {
+			if v := javaAnnotationScalarArg(ann, src); v != "" {
+				chips = appendJavaChip(chips, prefix+":"+v)
+			} else {
+				chips = appendJavaChip(chips, prefix)
+			}
+			continue
+		}
+		if marker, ok := javaBeanValidationMarkers[name]; ok {
+			chips = appendJavaChip(chips, marker)
+			continue
+		}
+	}
+	return dedupeJavaChips(chips)
+}
+
+// javaAnnotationNodes returns the annotation / marker_annotation nodes attached
+// to a declaration. For a field_declaration / formal_parameter the annotations
+// live under a `modifiers` child; for nodes that themselves are `modifiers`
+// they are direct children. Both shapes are handled.
+func javaAnnotationNodes(node *sitter.Node) []*sitter.Node {
+	var out []*sitter.Node
+	collect := func(parent *sitter.Node) {
+		for i := 0; i < int(parent.NamedChildCount()); i++ {
+			ch := parent.NamedChild(i)
+			if ch == nil {
+				continue
+			}
+			if ch.Type() == "marker_annotation" || ch.Type() == "annotation" {
+				out = append(out, ch)
+			}
+		}
+	}
+	if node.Type() == "modifiers" {
+		collect(node)
+		return out
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		ch := node.NamedChild(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "modifiers":
+			collect(ch)
+		case "marker_annotation", "annotation":
+			out = append(out, ch)
+		}
+	}
+	return out
+}
+
+// simpleAnnotationName strips a fully-qualified annotation name to its leaf
+// (`jakarta.validation.constraints.NotNull` → "NotNull").
+func simpleAnnotationName(name string) string {
+	name = strings.TrimSpace(name)
+	if dot := strings.LastIndexByte(name, '.'); dot >= 0 {
+		name = name[dot+1:]
+	}
+	return name
+}
+
+// javaSizeChip folds a @Size annotation into a chip. With both bounds it yields
+// `Size:0..120`; with only max it yields `MaxLength:120`; with only min it
+// yields `MinLength:1`. Returns "" when neither bound is a scalar.
+func javaSizeChip(ann *sitter.Node, src []byte) string {
+	pairs := javaAnnotationArgPairs(ann, src)
+	minV, hasMin := pairs["min"]
+	maxV, hasMax := pairs["max"]
+	switch {
+	case hasMin && hasMax:
+		return "Size:" + minV + ".." + maxV
+	case hasMax:
+		return "MaxLength:" + maxV
+	case hasMin:
+		return "MinLength:" + minV
+	}
+	return ""
+}
+
+// javaAnnotationScalarArg returns the scalar bound of a single-value annotation
+// like @Min(0) / @Max(120) / @DecimalMin("0.0"). It accepts both the implicit
+// `value` form (`@Min(0)`) and the named form (`@Min(value = 0)`). String
+// literals (DecimalMin/DecimalMax) are unquoted. Returns "" for non-scalar args.
+func javaAnnotationScalarArg(ann *sitter.Node, src []byte) string {
+	args := ann.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	// Named form: value = N.
+	if pairs := javaAnnotationArgPairs(ann, src); len(pairs) > 0 {
+		if v, ok := pairs["value"]; ok {
+			return v
+		}
+	}
+	// Implicit single positional form: @Min(0).
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		if a.Type() == "element_value_pair" {
+			continue // handled by the pairs path above
+		}
+		return javaValidationScalar(a, src)
+	}
+	return ""
+}
+
+// javaAnnotationArgPairs returns the named element_value_pair arguments of an
+// annotation as a key→scalar map (`@Size(min = 1, max = 120)` →
+// {"min":"1","max":"120"}). Non-scalar values are dropped.
+func javaAnnotationArgPairs(ann *sitter.Node, src []byte) map[string]string {
+	args := ann.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for i := 0; i < int(args.NamedChildCount()); i++ {
+		p := args.NamedChild(i)
+		if p == nil || p.Type() != "element_value_pair" {
+			continue
+		}
+		keyNode := p.ChildByFieldName("key")
+		valNode := p.ChildByFieldName("value")
+		if keyNode == nil || valNode == nil {
+			continue
+		}
+		key := string(src[keyNode.StartByte():keyNode.EndByte()])
+		if v := javaValidationScalar(valNode, src); v != "" {
+			out[strings.TrimSpace(key)] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// javaValidationScalar returns the folded text of a scalar annotation argument
+// (integer / decimal / string / boolean / bare identifier), unquoting string
+// literals and rejecting anything containing a comma (which would corrupt the
+// comma-joined property). String literals are kept only when numeric
+// (@DecimalMin("0.0")). Compound expressions yield "". Reuses javaLiteralText
+// for the literal kinds it recognises.
+func javaValidationScalar(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	if n.Type() == "identifier" {
+		t := strings.TrimSpace(string(src[n.StartByte():n.EndByte()]))
+		if strings.ContainsAny(t, ", ") {
+			return ""
+		}
+		return t
+	}
+	lit, ok := javaLiteralText(n, src)
+	if !ok {
+		return ""
+	}
+	lit = strings.TrimSpace(lit)
+	if strings.ContainsAny(lit, ", ") {
+		return ""
+	}
+	// string_literal bounds (DecimalMin/DecimalMax) must be numeric.
+	if n.Type() == "string_literal" {
+		if _, err := strconv.ParseFloat(lit, 64); err != nil {
+			return ""
+		}
+	}
+	return lit
+}
+
+// appendJavaChip appends a chip if non-empty.
+func appendJavaChip(chips []string, c string) []string {
+	if c == "" {
+		return chips
+	}
+	return append(chips, c)
+}
+
+// dedupeJavaChips removes duplicate chips while preserving first-seen order.
+func dedupeJavaChips(chips []string) []string {
+	if len(chips) <= 1 {
+		return chips
+	}
+	seen := make(map[string]bool, len(chips))
+	out := chips[:0]
+	for _, c := range chips {
+		if c == "" || seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}
+
+// applyJavaValidations stamps the chips onto a field entity's Properties map
+// (comma-joined), preserving any existing properties. Mirrors the TS
+// applyFieldValidations / Python applyValidations helpers.
+func applyJavaValidations(props map[string]string, chips []string) map[string]string {
+	if len(chips) == 0 {
+		return props
+	}
+	if props == nil {
+		props = map[string]string{}
+	}
+	props["validations"] = strings.Join(chips, ",")
+	return props
+}

--- a/internal/extractors/java/field_validations_test.go
+++ b/internal/extractors/java/field_validations_test.go
@@ -1,0 +1,172 @@
+package java_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #4872 — Java Bean Validation annotations (javax.* + jakarta.*) on DTO
+// fields must surface in the unified Properties["validations"] property so the
+// dashboard ShapeTree renders them as constraint chips (parity with TS #4858
+// and Python #4871).
+
+// chips splits the comma-joined validations property into a set for assertions.
+func valSet(props map[string]string) map[string]bool {
+	out := map[string]bool{}
+	if props == nil {
+		return out
+	}
+	for _, c := range strings.Split(props["validations"], ",") {
+		c = strings.TrimSpace(c)
+		if c != "" {
+			out[c] = true
+		}
+	}
+	return out
+}
+
+func TestJava_BeanValidation_ClassDTO_jakarta(t *testing.T) {
+	src := `
+package com.example;
+
+import jakarta.validation.constraints.*;
+
+public class CreateUserDto {
+    @NotNull
+    @Size(max = 120)
+    @Email
+    private String email;
+
+    @NotBlank
+    @Size(min = 2, max = 50)
+    private String name;
+
+    @Min(0)
+    @Max(150)
+    private int age;
+
+    @Positive
+    private long credits;
+
+    @Pattern(regexp = "[A-Z]{3}")
+    private String code;
+
+    private String untouched;
+}
+`
+	ents := runJava(t, src)
+
+	email := javaFind(ents, "CreateUserDto.email", "SCOPE.Schema")
+	if email == nil {
+		t.Fatal("expected field CreateUserDto.email")
+	}
+	got := valSet(email.Properties)
+	for _, want := range []string{"Required", "MaxLength:120", "Email"} {
+		if !got[want] {
+			t.Errorf("email validations missing %q; got %v", want, got)
+		}
+	}
+
+	name := javaFind(ents, "CreateUserDto.name", "SCOPE.Schema")
+	if name == nil {
+		t.Fatal("expected field CreateUserDto.name")
+	}
+	gotName := valSet(name.Properties)
+	for _, want := range []string{"NotBlank", "Size:2..50"} {
+		if !gotName[want] {
+			t.Errorf("name validations missing %q; got %v", want, gotName)
+		}
+	}
+
+	age := javaFind(ents, "CreateUserDto.age", "SCOPE.Schema")
+	gotAge := valSet(age.Properties)
+	for _, want := range []string{"Min:0", "Max:150"} {
+		if !gotAge[want] {
+			t.Errorf("age validations missing %q; got %v", want, gotAge)
+		}
+	}
+
+	credits := javaFind(ents, "CreateUserDto.credits", "SCOPE.Schema")
+	if !valSet(credits.Properties)["Positive"] {
+		t.Errorf("credits should carry Positive; got %v", valSet(credits.Properties))
+	}
+
+	code := javaFind(ents, "CreateUserDto.code", "SCOPE.Schema")
+	if !valSet(code.Properties)["Pattern"] {
+		t.Errorf("code should carry Pattern; got %v", valSet(code.Properties))
+	}
+
+	// A field with no Bean Validation annotations must not get a validations
+	// property at all.
+	untouched := javaFind(ents, "CreateUserDto.untouched", "SCOPE.Schema")
+	if untouched == nil {
+		t.Fatal("expected field CreateUserDto.untouched")
+	}
+	if _, ok := untouched.Properties["validations"]; ok {
+		t.Errorf("untouched field should have no validations; got %v", untouched.Properties)
+	}
+}
+
+func TestJava_BeanValidation_javaxAndDecimal(t *testing.T) {
+	src := `
+package com.example;
+
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.NotEmpty;
+
+public class PriceDto {
+    @NotEmpty
+    private String label;
+
+    @DecimalMin("0.0")
+    @DecimalMax("9999.99")
+    private java.math.BigDecimal amount;
+}
+`
+	ents := runJava(t, src)
+
+	label := javaFind(ents, "PriceDto.label", "SCOPE.Schema")
+	if !valSet(label.Properties)["NotEmpty"] {
+		t.Errorf("label should carry NotEmpty; got %v", valSet(label.Properties))
+	}
+
+	amount := javaFind(ents, "PriceDto.amount", "SCOPE.Schema")
+	got := valSet(amount.Properties)
+	for _, want := range []string{"Min:0.0", "Max:9999.99"} {
+		if !got[want] {
+			t.Errorf("amount validations missing %q; got %v", want, got)
+		}
+	}
+}
+
+func TestJava_BeanValidation_RecordComponents(t *testing.T) {
+	src := `
+package com.example;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+    @NotNull @Size(max = 64) String username,
+    @NotNull String password
+) {}
+`
+	ents := runJava(t, src)
+
+	user := javaFind(ents, "SignupRequest.username", "SCOPE.Schema")
+	if user == nil {
+		t.Fatal("expected field SignupRequest.username")
+	}
+	got := valSet(user.Properties)
+	for _, want := range []string{"Required", "MaxLength:64"} {
+		if !got[want] {
+			t.Errorf("username validations missing %q; got %v", want, got)
+		}
+	}
+
+	pw := javaFind(ents, "SignupRequest.password", "SCOPE.Schema")
+	if !valSet(pw.Properties)["Required"] {
+		t.Errorf("password should carry Required; got %v", valSet(pw.Properties))
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -403,6 +403,12 @@ func walk(
 		// parameters via a `formal_parameters` child on
 		// record_declaration; each child is a `formal_parameter`
 		// with `type` + `name` named children.
+		// Issue #4872 — collect the AST node carrying each field's
+		// annotations (record component or class field_declaration) so the
+		// Bean Validation pass can stamp Properties["validations"] without
+		// re-traversing the tree.
+		recBefore := len(*out)
+		fieldNodes := map[string]*sitter.Node{}
 		if node.Type() == "record_declaration" {
 			if params := node.ChildByFieldName("parameters"); params != nil {
 				for i := range params.ChildCount() {
@@ -420,6 +426,7 @@ func walk(
 					if fieldName == "" || typeName == "" {
 						continue
 					}
+					fieldNodes[fieldName] = p
 					emittedName := rec.Name + "." + fieldName
 					// Preserve any annotations on the record
 					// component by replaying the raw source span.
@@ -458,6 +465,23 @@ func walk(
 			// class because Java field resolution at a call site uses the
 			// member-type rules, not lexical scope.
 			localCtx := &classCtx{fields: collectFieldTypes(body, file.Content)}
+			// Issue #4872 — record each class field_declaration's node by leaf
+			// name so the Bean Validation pass can read its annotations.
+			for i := range body.ChildCount() {
+				ch := body.Child(int(i))
+				if ch == nil || ch.Type() != "field_declaration" {
+					continue
+				}
+				for j := range ch.ChildCount() {
+					vd := ch.Child(int(j))
+					if vd == nil || vd.Type() != "variable_declarator" {
+						continue
+					}
+					if fn := childFieldText(vd, "name", file.Content); fn != "" {
+						fieldNodes[fn] = ch
+					}
+				}
+			}
 			before := len(*out)
 			for i := range body.ChildCount() {
 				// Members of this type are qualified by rec.Name (the
@@ -502,6 +526,13 @@ func walk(
 					})
 			}
 		}
+
+		// Issue #4872 — route Bean Validation annotations (javax.* + jakarta.*)
+		// on this type's fields/record-components into Properties["validations"]
+		// so the dashboard ShapeTree renders them as constraint chips, matching
+		// TS (#4858) and Python (#4871). Covers the whole [recBefore, now)
+		// window — both record components and class field_declarations.
+		emitJavaFieldValidations(rec.Name, recBefore, len(*out), fieldNodes, file.Content, out)
 
 		// Issue #793 — Lombok annotation-driven entity synthesis.
 		// Synthesize SCOPE.Operation / SCOPE.Component entities for every


### PR DESCRIPTION
Routes field-level Bean Validation annotations on Java DTO/record/class fields into the unified `Properties["validations"]` property that drives the dashboard ShapeTree constraint chips — completing the validation-chip matrix alongside TS class-validator (#4858) and Python (#4871).

## What changed
- New `internal/extractors/java/field_validations.go`: classifies Bean Validation annotations on each field/record-component and stamps the terse, comma-free chip list.
- Wired into `java.go` `walk`: collects each field's annotation-bearing AST node (class `field_declaration` + record `formal_parameter`) and runs the validation pass over the emitted field-entity window after CONTAINS wiring.
- Dashboard side already generic (`shape_tree.go` `fieldValidations` reads `Properties["validations"]`) — no dashboard change needed.

## Reused existing parsing
Yes — no signature/string re-parsing. It walks the same tree-sitter `modifiers` → `annotation`/`marker_annotation` children that the existing `javaFieldHasInjectAnnotation` pass uses, and reuses the package's `javaLiteralText` helper for scalar-bound folding.

## Annotations covered (javax.* AND jakarta.*)
- `@NotNull`→Required, `@NotEmpty`, `@NotBlank`, `@Null`
- `@Size(min,max)`→`Size:min..max` / `MaxLength:` / `MinLength:`
- `@Min`/`@Max`/`@DecimalMin`/`@DecimalMax`→`Min:`/`Max:` (scalar bounds folded; DecimalMin/Max numeric strings unquoted)
- `@Pattern`, `@Email`
- `@Positive`/`@PositiveOrZero`/`@Negative`/`@NegativeOrZero`/`@Digits`
- `@Past`/`@PastOrPresent`/`@Future`/`@FutureOrPresent`
- `@AssertTrue`/`@AssertFalse`, `@Valid`

Fully-qualified annotation names are stripped to their leaf, so both `javax.validation.constraints.NotNull` and the bare `@NotNull` import form work.

## Tests
`field_validations_test.go` — value-asserting fixtures:
- `TestJava_BeanValidation_ClassDTO_jakarta` (@NotNull/@Size/@Email/@Min/@Max/@Positive/@Pattern + untouched-field negative)
- `TestJava_BeanValidation_javaxAndDecimal` (javax import + @DecimalMin/@DecimalMax)
- `TestJava_BeanValidation_RecordComponents` (record-component constraints)

## Capability registry
`docs/coverage/registry.json` `lang.java.validation.bean-validation` → `constraint_extraction` cell updated (field-level chip support, new cites, issue #4872). `coverage fmt --check` and `coverage validate` pass.

## Gates (sandbox env)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/java/... ./internal/dashboard/... ./internal/types/ ./tools/coverage/...` — all passing.

Deploy-deferred. Closes #4872. Completes the validation-chip matrix (TS #4858, Python #4871, Java #4872).