### PR TITLE
fix(#4881): capture JS/TS DTO field type+nullable in extractor (full extract→shape path)

### DIFF
--- a/internal/dashboard/issue4881_field_type_fullpath_test.go
+++ b/internal/dashboard/issue4881_field_type_fullpath_test.go
@@ -1,0 +1,215 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #4881 — FULL-PATH regression: extractor → entity → shape.
+//
+// The #4868 fixture (TestShape_TSFieldTypesAndNullable) hand-built the field
+// SIGNATURE, so it could not catch the real bug: the JS/TS extractor's class
+// field path produced a malformed double-colon signature ("building: : number")
+// — the type_annotation node text already carries the leading ": ", but the
+// emitter prepended another. parseFieldSignature then read back a garbage type,
+// so live DTO fields rendered with type="" on the dashboard. (Interface /
+// type-alias members went through emitSchemaMemberFields, which already stripped
+// the colon, so only class fields regressed.)
+//
+// This test indexes a REAL TS class DTO and a REAL TS interface DTO through the
+// actual javascript extractor, converts the emitted EntityRecords to graph
+// entities (the same fields the indexer's entityRecordToGraphEntity copies),
+// rewires the extractor's CONTAINS structural-ref edges to the resolved field
+// entity IDs (what the resolver does at index time), and asserts the dashboard
+// shape endpoint returns rows with a NON-EMPTY type and correct nullability.
+
+const issue4881ClassSrc = `
+import { IsInt, IsString } from 'class-validator';
+
+class CreateAlternateAddressBody {
+  @IsInt()
+  building: number;
+
+  group: number | null;
+
+  @IsString()
+  name?: string;
+}
+
+interface AlternateAddressResponse {
+  id: string;
+  archivedAt: Date | null;
+  label?: string;
+}
+`
+
+// extractTSEntities runs the real javascript extractor over TS source.
+func extractTSEntities(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	p := sitter.NewParser()
+	p.SetLanguage(tstypescript.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, []byte(src))
+	if err != nil {
+		t.Fatalf("parse TS: %v", err)
+	}
+	ents, err := javascript.New().Extract(context.Background(), extreg.FileInput{
+		Path:     issue4881File,
+		Content:  []byte(src),
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+const issue4881File = "src/address/dto/alternate-address.ts"
+
+// dashGroupFromRecords converts extractor EntityRecords into a DashGroup,
+// resolving the extractor's CONTAINS structural-ref ToIDs to the hex IDs of the
+// matching SCOPE.Schema/field entities (mirroring the resolver's structural-ref
+// binding so collectShapeRows can walk class → field edges).
+func dashGroupFromRecords(recs []types.EntityRecord) *DashGroup {
+	// Map field structural-ref → field entity ID.
+	refToID := map[string]string{}
+	ents := make([]graph.Entity, 0, len(recs))
+	for _, r := range recs {
+		ents = append(ents, graph.Entity{
+			ID:            r.ID,
+			Name:          r.Name,
+			QualifiedName: r.QualifiedName,
+			Kind:          r.Kind,
+			Subtype:       r.Subtype,
+			SourceFile:    r.SourceFile,
+			StartLine:     r.StartLine,
+			EndLine:       r.EndLine,
+			Language:      r.Language,
+			Signature:     r.Signature,
+			Properties:    r.Properties,
+		})
+		if r.Kind == "SCOPE.Schema" && r.Subtype == "field" {
+			ref := extreg.BuildSchemaFieldStructuralRef(r.Language, r.SourceFile, r.Name)
+			refToID[ref] = r.ID
+		}
+	}
+
+	var rels []graph.Relationship
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			to := rel.ToID
+			if id, ok := refToID[to]; ok {
+				to = id
+			}
+			rels = append(rels, graph.Relationship{FromID: r.ID, ToID: to, Kind: rel.Kind})
+		}
+	}
+	return makePathsTestGroup(ents, rels)
+}
+
+func TestShape_Issue4881_FieldTypeFromExtractor(t *testing.T) {
+	recs := extractTSEntities(t, issue4881ClassSrc)
+
+	// Sanity: the FIELD ENTITY itself must carry a non-empty type signature.
+	// This is the extractor → entity half of the assertion.
+	wantSig := map[string]string{
+		"CreateAlternateAddressBody.building": "building: number",
+		"CreateAlternateAddressBody.group":    "group: number | null",
+		"CreateAlternateAddressBody.name":     "name?: string",
+		"AlternateAddressResponse.id":         "id: string",
+		"AlternateAddressResponse.archivedAt": "archivedAt: Date | null",
+		"AlternateAddressResponse.label":      "label?: string",
+	}
+	gotField := map[string]bool{}
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Schema" || r.Subtype != "field" {
+			continue
+		}
+		gotField[r.Name] = true
+		if want, ok := wantSig[r.Name]; ok {
+			if r.Signature != want {
+				t.Errorf("field %s: entity signature = %q, want %q", r.Name, r.Signature, want)
+			}
+			if r.Signature == r.Name || r.Signature == "" {
+				t.Errorf("field %s: entity signature carries no type (%q)", r.Name, r.Signature)
+			}
+		}
+	}
+	for name := range wantSig {
+		if !gotField[name] {
+			t.Errorf("field entity %q was not emitted by the extractor", name)
+		}
+	}
+
+	// entity → shape half: drive the real dashboard shape endpoint.
+	grp := dashGroupFromRecords(recs)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	get := func(typeName string) map[string]v2ShapeRow {
+		t.Helper()
+		resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/shape?type=" + typeName)
+		if err != nil {
+			t.Fatalf("GET %s: %v", typeName, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s: want 200, got %d", typeName, resp.StatusCode)
+		}
+		var body struct {
+			OK   bool            `json:"ok"`
+			Data v2ShapeResponse `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode %s: %v", typeName, err)
+		}
+		out := map[string]v2ShapeRow{}
+		for _, r := range body.Data.Rows {
+			out[r.Name] = r
+		}
+		return out
+	}
+
+	// Class DTO: type must be non-empty; `| null` → nullable, `?` → nullable.
+	cls := get("CreateAlternateAddressBody")
+	if len(cls) == 0 {
+		t.Fatalf("class DTO produced zero shape rows (CONTAINS edges missing?)")
+	}
+	if r := cls["building"]; r.Type != "number" || r.Nullable {
+		t.Errorf("class building: want type=number nullable=false, got %+v", r)
+	}
+	if r := cls["group"]; r.Type != "number | null" || !r.Nullable {
+		t.Errorf("class group: want type='number | null' nullable=true, got %+v", r)
+	}
+	if r := cls["name"]; r.Type != "string" || !r.Nullable {
+		t.Errorf("class name (TS-optional): want type=string nullable=true, got %+v", r)
+	}
+	// Guard the exact #4881 regression: no field type may be empty.
+	for n, r := range cls {
+		if r.Type == "" {
+			t.Errorf("class field %q rendered with empty type (the #4881 bug)", n)
+		}
+	}
+
+	// Interface DTO.
+	iface := get("AlternateAddressResponse")
+	if r := iface["id"]; r.Type != "string" || r.Nullable {
+		t.Errorf("iface id: want type=string nullable=false, got %+v", r)
+	}
+	if r := iface["archivedAt"]; r.Type != "Date | null" || !r.Nullable {
+		t.Errorf("iface archivedAt: want type='Date | null' nullable=true, got %+v", r)
+	}
+	if r := iface["label"]; r.Type != "string" || !r.Nullable {
+		t.Errorf("iface label (TS-optional): want type=string nullable=true, got %+v", r)
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -1194,11 +1194,19 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 		// `this.<field>` REFERENCES edges have a resolvable target.
 		if parentClass != "" {
 			emittedName := parentClass + "." + name
-			sig := name
-			// Include a type annotation in the signature when present.
-			if typeNode := n.ChildByFieldName("type"); typeNode != nil {
-				sig = name + ": " + x.nodeText(typeNode)
-			}
+			// Issue #4881 — build a "name[?]: type" signature so the dashboard
+			// shape walker (internal/dashboard/shape_tree.go parseFieldSignature)
+			// can recover the field TYPE and nullability. Earlier this path
+			// concatenated `name + ": " + x.nodeText(typeNode)`, but the
+			// type_annotation node text already carries the leading ": "
+			// (e.g. ": number"), so the signature came out as "building: : number"
+			// — a malformed double colon that parseFieldSignature read back as an
+			// empty/garbage type, leaving live DTO fields with type="" on the
+			// dashboard. Mirror the interface/object-type emitter
+			// (emitSchemaMemberFields, #4856): strip the leading colon and fold
+			// in the optional `?` marker so all three field paths (class,
+			// interface, object-type-alias) produce the identical convention.
+			sig := schemaFieldSignature(name, x.fieldIsOptional(n), x.fieldTypeAnnotation(n))
 			// Issue #4858 — attach class-validator constraints (if any) as
 			// structured metadata so the dashboard can render them as chips.
 			if validations := x.fieldValidations(n); len(validations) > 0 {
@@ -1527,6 +1535,53 @@ func (x *extractor) handleTypeAliasDeclaration(n *sitter.Node) {
 //   - index_signature (`[key: string]: any`) and call/construct signatures have
 //     no member name and are skipped (gracefully, no crash) — they describe the
 //     container, not an addressable field.
+// schemaFieldSignature renders the canonical SCOPE.Schema/field signature
+// "name[?]: type" shared by every JS/TS field-emission path (class fields,
+// interface property signatures, object-type-alias members). Keeping a single
+// renderer guarantees the dashboard shape walker
+// (internal/dashboard/shape_tree.go parseFieldSignature) reads type and
+// nullability identically regardless of which AST shape produced the field.
+// `ann` is the bare type text (no leading colon); empty `ann` yields a
+// name-only signature.
+func schemaFieldSignature(name string, optional bool, ann string) string {
+	sig := name
+	if optional {
+		sig += "?"
+	}
+	if ann != "" {
+		sig += ": " + ann
+	}
+	return sig
+}
+
+// fieldTypeAnnotation returns the bare type text of a member's `: <type>`
+// annotation (the "type" field, a type_annotation node) with the leading
+// colon and surrounding whitespace stripped, or "" when the member is
+// untyped. Works for public_field_definition, property_signature and
+// method_signature alike.
+func (x *extractor) fieldTypeAnnotation(member *sitter.Node) string {
+	typeNode := member.ChildByFieldName("type")
+	if typeNode == nil {
+		return ""
+	}
+	// type_annotation text includes the leading ": " — fold it out so the
+	// caller can re-add a single canonical ": ".
+	ann := strings.TrimSpace(x.nodeText(typeNode))
+	ann = strings.TrimPrefix(ann, ":")
+	return strings.TrimSpace(ann)
+}
+
+// fieldIsOptional reports whether a member declares the TypeScript optional
+// marker `?` (e.g. `name?: string`) as a direct child token.
+func (x *extractor) fieldIsOptional(member *sitter.Node) bool {
+	for j := 0; j < int(member.ChildCount()); j++ {
+		if ch := member.Child(j); ch != nil && ch.Type() == "?" {
+			return true
+		}
+	}
+	return false
+}
+
 func (x *extractor) emitSchemaMemberFields(body *sitter.Node, owner string) ([]string, []types.RelationshipRecord) {
 	if body == nil || owner == "" {
 		return nil, nil
@@ -1558,29 +1613,10 @@ func (x *extractor) emitSchemaMemberFields(body *sitter.Node, owner string) ([]s
 		seen[fieldName] = true
 		fields = append(fields, fieldName)
 
-		// Signature mirrors the class field convention ("name: type"), with an
-		// optional-marker "?" when the property_signature carries one, so the
-		// dashboard parses type / nullability identically to class DTO fields.
-		sig := fieldName
-		optional := false
-		for j := 0; j < int(member.ChildCount()); j++ {
-			if ch := member.Child(j); ch != nil && ch.Type() == "?" {
-				optional = true
-				break
-			}
-		}
-		if optional {
-			sig += "?"
-		}
-		if typeNode := member.ChildByFieldName("type"); typeNode != nil {
-			// type_annotation text includes the leading ": " — fold it in.
-			ann := strings.TrimSpace(x.nodeText(typeNode))
-			ann = strings.TrimPrefix(ann, ":")
-			ann = strings.TrimSpace(ann)
-			if ann != "" {
-				sig += ": " + ann
-			}
-		}
+		// Signature mirrors the class field convention ("name[?]: type") so the
+		// dashboard parses type / nullability identically to class DTO fields
+		// (#4856 / #4881 — shared renderer keeps all three field paths aligned).
+		sig := schemaFieldSignature(fieldName, x.fieldIsOptional(member), x.fieldTypeAnnotation(member))
 
 		emittedName := owner + "." + fieldName
 		x.emit(emittedName, "SCOPE.Schema", member, "field", sig)

--- a/internal/extractors/python/field_type_4868_test.go
+++ b/internal/extractors/python/field_type_4868_test.go
@@ -20,6 +20,8 @@ class CreateAddressBody:
     line1: str = ""
     effective_at: datetime | None = None
     count = 0
+    building: int
+    group: int | None
 `)
 	p := sitter.NewParser()
 	p.SetLanguage(tspython.GetLanguage())
@@ -57,6 +59,15 @@ class CreateAddressBody:
 	// Unannotated field keeps the bare-name signature (no fabricated type).
 	if got := sig["count"]; got != "count" {
 		t.Errorf("count signature: want %q, got %q", "count", got)
+	}
+	// #4881 generalization — annotation-ONLY fields (PEP-526 declaration with no
+	// default value, the common live DTO shape) must also carry the type so the
+	// dashboard shape row is non-empty, matching the JS/TS extractor fix.
+	if got := sig["building"]; got != "building: int" {
+		t.Errorf("building signature: want %q, got %q", "building: int", got)
+	}
+	if got := sig["group"]; got != "group: int | None" {
+		t.Errorf("group signature: want %q, got %q", "group: int | None", got)
 	}
 }
 


### PR DESCRIPTION
## Root cause

The JS/TS class-field emitter (`handlePublicFieldDefinition`) built the SCOPE.Schema/field signature as `name + ": " + nodeText(typeNode)`, but the tree-sitter `type_annotation` node text already carries the leading `: ` (e.g. `: number`). The signature came out **`building: : number`** — a malformed double colon that `shape_tree.go parseFieldSignature` read back as an empty/garbage type, so live DTO fields rendered with `type=""`. The class path also never captured the TS-optional `?`. The field-entity `signature` was effectively unusable (matching the live `signature: None` / type-empty evidence). #4868 only fixed the **dashboard parser**; the **extractor** still stored no usable type.

## Fix

Where the type is stored: on the **field entity `Signature`**, in the `name[?]: type` convention — the exact property `shape_tree.go buildShapeRow → parseFieldSignature` reads (verified). Introduced a shared `schemaFieldSignature` / `fieldTypeAnnotation` (strips the leading colon) / `fieldIsOptional` renderer so all **three** JS/TS field paths emit the identical convention:
- class fields (`handlePublicFieldDefinition`) — the regressed path, now fixed (colon stripped, `?` captured)
- interface property signatures (`emitSchemaMemberFields`, #4856) — refactored onto the shared renderer (already correct)
- object type-alias members (same emitter)

The `validations` property (#4858) is untouched.

## Full-path validation (not a hand-built signature)

`internal/dashboard/issue4881_field_type_fullpath_test.go` drives **extractor → entity → shape**: it indexes a real TS `class` + `interface` DTO through the actual `javascript` extractor, asserts the emitted field **ENTITY** carries a non-empty type signature (`building: number`, `group: number | null`, `name?: string`, …), then rewires the CONTAINS structural-refs (as the resolver does) and hits the real `/api/v2/groups/{id}/shape` endpoint, asserting rows have **non-empty `type`** and correct `nullable` (`| null` → true, `?` → true).

## Generalize

Python (#4868 PEP-526) re-verified through the same shape: annotation-ONLY fields (`building: int`, `group: int | None`, no default) already capture the type correctly — added regression coverage. No other languages affected.

## Gates
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/javascript/... ./internal/extractors/python/... ./internal/dashboard/... ./internal/types/` all green. No registry change (foundational extractor fix like #4845).

Closes #4881.