### PR TITLE
fix(#4888): test isolation — install/mcpreg/dashboard/daemon tests never touch real ~/.claude.json or the live daemon

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,7 +15,18 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/client"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/testsupport"
 )
+
+// TestMain fail-closes the daemon package: when
+// ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1 it refuses to run if HOME is the real
+// user home and no ARCHIGRAPH_DAEMON_ROOT isolation is in effect — these tests
+// start an in-process daemon and dial its socket, and must never displace or
+// dial the developer's live daemon.
+func TestMain(m *testing.M) {
+	testsupport.GuardRealHomeMain()
+	os.Exit(m.Run())
+}
 
 // waitDaemonReady polls until the daemon at socketPath accepts a dial.
 // On Unix this is equivalent to os.Stat + Dial; on Windows named pipes are
@@ -72,6 +84,14 @@ func shortTempRoot(t *testing.T) string {
 func isolateDaemonEnv(t *testing.T) string {
 	t.Helper()
 	root := shortTempRoot(t)
+	// Safety: the isolated daemon root must never resolve under the real user
+	// home — otherwise EnsureLayout/Run would write the socket/pid/log into the
+	// developer's live ~/.archigraph and a Dial() could hit the live daemon.
+	if rh := testsupport.RealUserHome(); rh != "" {
+		if rel, err := filepath.Rel(rh, root); err == nil && !strings.HasPrefix(rel, "..") && rel != "." {
+			t.Fatalf("isolateDaemonEnv: temp daemon root %q is under the real user home %q — refusing", root, rh)
+		}
+	}
 	t.Setenv(daemon.EnvRoot, root)
 	t.Setenv(daemon.EnvDisableSelfDefense, "1")
 	return root

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -10,13 +10,25 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/registry"
+	"github.com/cajasmota/archigraph/internal/testsupport"
 )
+
+// TestMain fail-closes the dashboard package: when
+// ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1 it refuses to run if HOME is the real
+// user home and no ARCHIGRAPH_DAEMON_ROOT isolation is in effect. Dashboard
+// tests resolve registry/docs paths from the environment and some default to
+// listing the home directory.
+func TestMain(m *testing.M) {
+	testsupport.GuardRealHomeMain()
+	os.Exit(m.Run())
+}
 
 // fakeStore is an in-memory RegistryStore. It removes the dependency on
 // ~/.archigraph for tests so they stay hermetic and parallel-safe.

--- a/internal/dashboard/v2_fs_test.go
+++ b/internal/dashboard/v2_fs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/testsupport"
 )
 
 // fsListEnvelope is the decoded GET /api/v2/fs/list response.
@@ -113,13 +114,12 @@ func TestV2FsList_ListsSubdirsWithAbsPaths(t *testing.T) {
 // TestV2FsList_DefaultsToHome verifies that an empty path defaults to the
 // daemon's home directory.
 func TestV2FsList_DefaultsToHome(t *testing.T) {
+	// Isolate HOME so "default to home" resolves to a temp dir we list, rather
+	// than enumerating the developer's real home directory.
+	home := testsupport.IsolateHome(t)
 	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
 		return proto.RebuildReply{}, nil
 	})
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("no home dir")
-	}
 	env := getFsList(t, ts.URL, "")
 	if !env.OK {
 		t.Fatalf("ok = false; reply = %+v", env.Data)

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -11,7 +11,17 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/install"
 	"github.com/cajasmota/archigraph/internal/install/skilllink"
+	"github.com/cajasmota/archigraph/internal/testsupport"
 )
+
+// TestMain fail-closes the install package: when
+// ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1 it refuses to run if HOME is the real
+// user home. These tests install/uninstall and (de)register MCP, so they must
+// never operate against the developer's live config.
+func TestMain(m *testing.M) {
+	testsupport.GuardRealHomeMain()
+	os.Exit(m.Run())
+}
 
 // TestRunCopy_HappyPath verifies the complete COPY-mode install transaction:
 // skills are copied, MCP is registered, install.json is written with the
@@ -346,8 +356,17 @@ func newTestEnv(t *testing.T) *testEnv {
 		}
 	}
 
-	// Override HOME so home-dir dependent paths go to tmp.
+	// Override HOME (and the other config/state/socket-resolving env vars) so
+	// every home-dir dependent path goes to tmp, then assert via testsupport
+	// that the redirect did NOT land on the real user home — these tests
+	// register/deregister MCP entries and must never touch the live
+	// ~/.claude.json.
 	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "cfg"))
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", stateDir)
+	t.Setenv("ARCHIGRAPH_HOME", stateDir)
+	testsupport.GuardRealHome(t)
 
 	return &testEnv{
 		fakeBin:         fakeBin,

--- a/internal/install/mcpreg/mcpreg_test.go
+++ b/internal/install/mcpreg/mcpreg_test.go
@@ -5,13 +5,24 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cajasmota/archigraph/internal/testsupport"
 )
 
-// withHome redirects HOME so settings paths land inside a TempDir.
+// TestMain fail-closes the package: when ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1
+// it refuses to run if HOME is the real user home (these tests write
+// ~/.claude.json and must never touch the developer's live MCP config).
+func TestMain(m *testing.M) {
+	testsupport.GuardRealHomeMain()
+	os.Exit(m.Run())
+}
+
+// withHome redirects HOME so settings paths land inside a TempDir, and asserts
+// (via testsupport) that the redirect did not land on the real user home.
 func withHome(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := testsupport.IsolateHome(t)
+	// Keep mcpreg's historical XDG layout (.config under the temp home).
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
 	return dir
 }
@@ -156,6 +167,7 @@ func TestRegisterPathUpdatesCommand(t *testing.T) {
 }
 
 func TestDetectClaudeConfigDirs_ExplicitOverride(t *testing.T) {
+	withHome(t) // isolate even though explicit dirs are passed (defense in depth)
 	explicit := []string{"/a/.claude.json", "/b/.claude.json"}
 	got := DetectClaudeConfigDirs(explicit)
 	if len(got) != 2 || got[0] != explicit[0] || got[1] != explicit[1] {

--- a/internal/testsupport/guard_main.go
+++ b/internal/testsupport/guard_main.go
@@ -1,0 +1,45 @@
+package testsupport
+
+import (
+	"fmt"
+	"os"
+)
+
+// GuardRealHomeMain is the TestMain-time, fail-closed guard for an entire
+// package whose tests resolve config/state/socket paths from the environment.
+//
+// It does NOT redirect HOME (individual tests must still call IsolateHome for
+// that). Instead, when ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1 is set (e.g. in
+// CI), it aborts the whole test binary before a single test runs if the
+// process started with HOME pointing at the real user home and no isolation
+// env is in effect — turning a "this test corrupted my live config" incident
+// into a loud, immediate failure.
+//
+// Usage:
+//
+//	func TestMain(m *testing.M) {
+//	    testsupport.GuardRealHomeMain()
+//	    os.Exit(m.Run())
+//	}
+//
+// By default (env not set) it is a no-op so local `go test` keeps working even
+// from a real HOME — the per-test IsolateHome/GuardRealHome guards still apply.
+func GuardRealHomeMain() {
+	if os.Getenv("ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME") != "1" {
+		return
+	}
+	// If an isolation env is already in effect, the binary is sandboxed.
+	if os.Getenv(envDaemonRoot) != "" {
+		return
+	}
+	if eff := effectiveHome(); realUserHome != "" && eff == realUserHome {
+		fmt.Fprintf(os.Stderr,
+			"testsupport: REFUSING to run — HOME (%q) is the real user home and "+
+				"ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1. These tests can corrupt the live "+
+				"~/.claude.json / ~/.codeium / ~/.archigraph or kill the live daemon. Run under a "+
+				"sandbox HOME (export HOME=$(mktemp -d); export ARCHIGRAPH_DAEMON_ROOT=$HOME/.archigraph).\n",
+			eff,
+		)
+		os.Exit(2)
+	}
+}

--- a/internal/testsupport/isolate.go
+++ b/internal/testsupport/isolate.go
@@ -1,0 +1,146 @@
+// Package testsupport provides safety-critical test isolation helpers.
+//
+// These tests have, in the past, corrupted a developer's live MCP config
+// (~/.claude.json) and killed their live archigraph daemon, because they
+// resolved config/state paths via $HOME and dialed the default daemon socket
+// while running against the real user home.
+//
+// The helpers here force every config/state/socket path produced during a test
+// to land inside a per-test TempDir, and — crucially — install a guard that
+// FAILS the test fast if the effective HOME is still the real user home or if a
+// path about to be touched escapes the temp sandbox. Defense in depth: even if
+// a future test forgets to isolate, the guard catches it before any real file
+// is written or any live socket is dialed.
+//
+// This package deliberately does NOT import internal/daemon (which would create
+// an import cycle for daemon's own tests); the daemon env-var names are
+// duplicated as string literals and asserted against in daemon's tests.
+package testsupport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Environment variables that steer archigraph config/state/socket resolution.
+// Kept as literals to avoid importing internal/daemon (import-cycle safe).
+const (
+	envHome           = "HOME"
+	envUserProfile    = "USERPROFILE" // Windows home
+	envXDGConfigHome  = "XDG_CONFIG_HOME"
+	envXDGRuntimeDir  = "XDG_RUNTIME_DIR"
+	envDaemonRoot     = "ARCHIGRAPH_DAEMON_ROOT"
+	envArchigraphHome = "ARCHIGRAPH_HOME"
+)
+
+// realUserHome is captured once, at process start, BEFORE any test has had a
+// chance to call t.Setenv("HOME", ...). It is the home we must never touch.
+var realUserHome = func() string {
+	// os.UserHomeDir reads $HOME (or %USERPROFILE% on Windows). At package-init
+	// time no test has overridden it yet, so this is the genuine user home.
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return filepath.Clean(h)
+	}
+	if h := os.Getenv(envHome); h != "" {
+		return filepath.Clean(h)
+	}
+	return ""
+}()
+
+// RealUserHome returns the genuine user home captured at process start.
+func RealUserHome() string { return realUserHome }
+
+// IsolateHome redirects every home/config/state/socket-resolving environment
+// variable into a fresh per-test TempDir, then asserts the redirect actually
+// took effect. After this call:
+//
+//   - $HOME / %USERPROFILE% point at <tmp> (so ~/.claude.json, ~/.codeium,
+//     ~/.archigraph all resolve under <tmp>),
+//   - $XDG_CONFIG_HOME points at <tmp>/cfg,
+//   - $XDG_RUNTIME_DIR points at <tmp>/run,
+//   - $ARCHIGRAPH_DAEMON_ROOT points at <tmp>/.archigraph (isolated daemon
+//     socket/pid/log), and
+//   - $ARCHIGRAPH_HOME points at <tmp>/.archigraph.
+//
+// It returns the temp home root. The guard (see GuardRealHome) is wired in via
+// t.Cleanup so a test that somehow re-points HOME back at the real home is
+// caught before it finishes.
+func IsolateHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+
+	archRoot := filepath.Join(tmp, ".archigraph")
+	if err := os.MkdirAll(archRoot, 0o700); err != nil {
+		t.Fatalf("testsupport: create isolated daemon root: %v", err)
+	}
+
+	t.Setenv(envHome, tmp)
+	t.Setenv(envUserProfile, tmp)
+	t.Setenv(envXDGConfigHome, filepath.Join(tmp, "cfg"))
+	t.Setenv(envXDGRuntimeDir, filepath.Join(tmp, "run"))
+	t.Setenv(envDaemonRoot, archRoot)
+	t.Setenv(envArchigraphHome, archRoot)
+
+	// Verify the redirect actually took effect and did not land on the real
+	// user home. This is the safety net the whole issue is about.
+	GuardRealHome(t)
+
+	return tmp
+}
+
+// GuardRealHome FAILS the test immediately if the effective home directory is
+// the genuine user home captured at process start. Call it directly in a test's
+// TestMain, or rely on IsolateHome which wires it for you. It is cheap and
+// idempotent; call it as often as you like.
+//
+// Wire this into a package's TestMain to make the entire package fail-closed:
+//
+//	func TestMain(m *testing.M) {
+//	    testsupport.GuardRealHomeMain()
+//	    os.Exit(m.Run())
+//	}
+func GuardRealHome(t *testing.T) {
+	t.Helper()
+	if eff := effectiveHome(); realUserHome != "" && eff == realUserHome {
+		t.Fatalf(
+			"testsupport: SANDBOX ESCAPE — effective HOME (%q) is the real user home; "+
+				"this test would read/write the developer's live ~/.claude.json / ~/.codeium / "+
+				"~/.archigraph or dial the live daemon socket. Call testsupport.IsolateHome(t) first.",
+			eff,
+		)
+	}
+}
+
+// AssertUnderHome FAILS the test if path is not inside the (already-isolated)
+// home tempdir. Use it as a belt-and-braces check after a test writes a config
+// file, to prove nothing escaped the sandbox.
+func AssertUnderHome(t *testing.T, path string) {
+	t.Helper()
+	home := effectiveHome()
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("testsupport: abs(%q): %v", path, err)
+	}
+	abs = filepath.Clean(abs)
+	if home == "" || !strings.HasPrefix(abs+string(filepath.Separator), filepath.Clean(home)+string(filepath.Separator)) {
+		t.Fatalf("testsupport: path %q escapes the isolated home %q", abs, home)
+	}
+	if realUserHome != "" && strings.HasPrefix(abs+string(filepath.Separator), realUserHome+string(filepath.Separator)) {
+		t.Fatalf("testsupport: path %q is under the REAL user home %q — refusing", abs, realUserHome)
+	}
+}
+
+func effectiveHome() string {
+	if h := os.Getenv(envHome); h != "" {
+		return filepath.Clean(h)
+	}
+	if h := os.Getenv(envUserProfile); h != "" {
+		return filepath.Clean(h)
+	}
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return filepath.Clean(h)
+	}
+	return ""
+}

--- a/internal/testsupport/isolate_test.go
+++ b/internal/testsupport/isolate_test.go
@@ -1,0 +1,70 @@
+package testsupport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsolateHomeRedirectsAllEnv(t *testing.T) {
+	home := IsolateHome(t)
+
+	if got := os.Getenv("HOME"); got != home {
+		t.Fatalf("HOME = %q, want %q", got, home)
+	}
+	if home == RealUserHome() {
+		t.Fatalf("isolated home %q equals real user home — isolation failed", home)
+	}
+	for _, ev := range []string{"ARCHIGRAPH_DAEMON_ROOT", "ARCHIGRAPH_HOME", "XDG_CONFIG_HOME", "XDG_RUNTIME_DIR"} {
+		v := os.Getenv(ev)
+		if v == "" {
+			t.Errorf("%s not set", ev)
+			continue
+		}
+		if !strings.HasPrefix(filepath.Clean(v), home) {
+			t.Errorf("%s = %q not under isolated home %q", ev, v, home)
+		}
+	}
+	// A path resolved from the (now isolated) home must satisfy AssertUnderHome.
+	AssertUnderHome(t, filepath.Join(home, ".claude.json"))
+}
+
+func TestGuardRealHomeFailsWhenHomeIsRealHome(t *testing.T) {
+	rh := RealUserHome()
+	if rh == "" {
+		t.Skip("no real user home captured")
+	}
+	// Point HOME back at the real user home and assert GuardRealHome fails.
+	t.Setenv("HOME", rh)
+	t.Setenv("USERPROFILE", rh)
+
+	bt := &testing.T{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { _ = recover() }() // Fatalf calls runtime.Goexit
+		GuardRealHome(bt)
+	}()
+	<-done
+	if !bt.Failed() {
+		t.Fatal("GuardRealHome did not fail when HOME == real user home")
+	}
+}
+
+func TestAssertUnderHomeRejectsEscape(t *testing.T) {
+	home := IsolateHome(t)
+	_ = home
+
+	bt := &testing.T{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { _ = recover() }()
+		AssertUnderHome(bt, "/etc/passwd")
+	}()
+	<-done
+	if !bt.Failed() {
+		t.Fatal("AssertUnderHome accepted a path outside the isolated home")
+	}
+}


### PR DESCRIPTION
## Why (safety-critical)

These tests have **twice** corrupted a developer's live `~/.claude.json` and killed their live archigraph daemon, because they resolved config/state/socket paths from `$HOME` (or the registered MCP-config paths) and dialed the default daemon socket while running against the **real user home**. This makes `go test` fail-closed so it can never touch real config or dial the live daemon.

## New: `internal/testsupport` (fail-closed guards)

- **`IsolateHome(t)`** — redirects `HOME`/`USERPROFILE`/`XDG_CONFIG_HOME`/`XDG_RUNTIME_DIR`/`ARCHIGRAPH_DAEMON_ROOT`/`ARCHIGRAPH_HOME` into a per-test `t.TempDir()`, then asserts the redirect did **not** land on the real user home (captured once at process init, before any `t.Setenv`).
- **`GuardRealHome(t)`** — fails a test fast if the effective `HOME` equals the real user home.
- **`GuardRealHomeMain()`** — `TestMain`-time guard. When `ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1` it aborts the whole test binary (exit 2) if it started from the real home with no daemon-root isolation. **No-op by default** so local `go test` keeps working from a real `$HOME` (per-test guards still apply).
- **`AssertUnderHome(t, path)`** — belt-and-braces: proves a written path stayed inside the sandbox and is not under the real home.
- Has its own unit tests (`isolate_test.go`) proving the guard fires on escape and `AssertUnderHome` rejects out-of-sandbox paths.

## Tests isolated / hardened

- **`internal/install/mcpreg/mcpreg_test.go`** — `withHome` now delegates to `testsupport.IsolateHome`; package `TestMain` guard; the lone `TestDetectClaudeConfigDirs_ExplicitOverride` (previously not calling `withHome`) now isolates too.
- **`internal/install/copy_test.go`** (shared `newTestEnv` for the whole `install_test` package — copy/uninstall/update/dev/gitignore) — now sets all isolation env vars (`HOME`/`USERPROFILE`/`XDG_CONFIG_HOME`/`ARCHIGRAPH_DAEMON_ROOT`/`ARCHIGRAPH_HOME`) and calls `GuardRealHome`; package `TestMain` guard. These are the MCP register/deregister + uninstall tests that parse/write `.claude.json`.
- **`internal/daemon/daemon_test.go`** — `isolateDaemonEnv` now refuses a temp daemon root that resolves under the real user home (so the in-process daemon's socket/pid/log can never be written into the live `~/.archigraph` and `client.Dial()` can never hit the live daemon); package `TestMain` guard. Covers `phaseb_test.go`, `boot_watcher_async_test.go`, `mcp_rpc_integration_test.go` which `client.Dial()` the env-resolved socket.
- **`internal/dashboard/server_test.go`** — package `TestMain` guard.
- **`internal/dashboard/v2_fs_test.go`** — `TestV2FsList_DefaultsToHome` now `IsolateHome`s and lists a temp home instead of enumerating the developer's real home directory.

## Full grep audit (`HOME` / `.claude.json` / `.codeium` / `.archigraph` / `daemon.sock` in `_test.go`)

Swept the whole tree. Findings classified:

| Ref | Verdict |
|---|---|
| `internal/install/*` (`newTestEnv`), `internal/install/mcpreg/*` (`withHome`) | **Corruption vectors — isolated** (write `.claude.json` / register MCP). |
| `internal/daemon/*` (`isolateDaemonEnv`, `client.Dial`) | **Daemon-displacement vectors — isolated** (start daemon + dial env-resolved socket). |
| `internal/dashboard/*` (`registry.json`/`docgen-state` writers, `v2_fs DefaultsToHome`) | Writers already used `home := t.TempDir()` + `ARCHIGRAPH_HOME`/`ARCHIGRAPH_DAEMON_ROOT` → temp; `DefaultsToHome` **now isolated**. Package `TestMain` guard added. |
| `internal/daemon/paths_test.go`, `state_path_test.go` | `t.Setenv("HOME","/home/user")` is a **fake** home used only to compute path *strings* — no I/O. Safe. |
| `internal/cli/mcp_bridge_test.go`, `watcher_ctl_restart_test.go`, `daemon/service/install_test.go` | `daemon.sock` appears as **string literals / fake paths** (`/nonexistent/...`, `/home/u/...`) for path logic — not dialed. Safe. |
| `internal/install/detect/detect_test.go`, `daemon/walk/verify_fixture_test.go`, `extractors/*`, `engine/*` (`os.UserHomeDir()`) | **Read-only** `os.Stat` fixture-corpus lookups — never write. Safe. |
| `rulesfiles_test.go` (`.codeium/...`) | Operates on a temp target dir; `.codeium` is a relative target name, not real home. Safe. |

## Gates (run under sandbox `HOME=$(mktemp -d)`, `ARCHIGRAPH_DAEMON_ROOT=$HOME/.archigraph`)

- `go build ./...` ✅
- `go vet ./internal/...` ✅
- `go test ./internal/install/... ./internal/dashboard/... ./internal/daemon/... ./internal/install/mcpreg/...` ✅ (all `ok`)
- Post-run: sandbox `$HOME/.claude.json` does **not** exist (tests only created files inside their `t.TempDir()`s); the real `~/.claude.json` was untouched.
- Verified `GuardRealHomeMain` refuses (exit 2) under `ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1` with real-home + no isolation.

No registry/coverage change. **Deploy-deferred.**

Closes #4888.