### PR TITLE
fix(#4890): get_source returns real method-override source for DRF ViewSet (not inherited-mixin synthesis); generalize

### DIFF
--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -343,8 +343,28 @@ func resolveInheritedEndpoint(lr *LoadedRepo, e *graph.Entity) (memberResolution
 // from an entity. Returns empty member when the entity is not a class member.
 func classifyMember(e *graph.Entity) (member, owning string, bodyless bool) {
 	// DRF synthetic implicit method: the engine stamps the origin verb and the
-	// owning ViewSet explicitly. These are bodyless by construction.
-	if e.Properties["pattern_type"] == "drf_viewset_implicit_method" {
+	// owning ViewSet explicitly. The engine emits this synthetic ONLY for a
+	// CRUD method the ViewSet does NOT override (emitViewSetMethodEntities skips
+	// explicitMethods), so it is bodyless by construction.
+	//
+	// #4890 — but the marker can LEAK onto a REAL override node: the
+	// explicit-method detector (drfExplicitMethodRe) misses some override forms
+	// (e.g. `async def create(self`), and the synthetic shares (Kind, Name,
+	// SourceFile) with the extractor's real method node, so a property merge can
+	// stamp pattern_type onto the override. An override carries its OWN real
+	// source span; reporting it bodyless forced resolveMember up the EXTENDS
+	// walk and get_source returned the synthesized inherited-mixin contract
+	// instead of the override's body (~14 false rewrite-agent findings).
+	//
+	// A real source span IS an override: report bodyless=false so the explicit
+	// gate in resolveMember keeps the node's own body. The synthesis is
+	// preserved only for a genuinely bodyless synthetic (no override).
+	//
+	// Django class-based views (django_cbv_implicit_method, cbv_method_origin /
+	// cbv_class) carry the same shape and the same leak risk, so they share the
+	// override-aware bodyless logic.
+	switch e.Properties["pattern_type"] {
+	case "drf_viewset_implicit_method":
 		m := e.Properties["drf_method_origin"]
 		o := e.Properties["viewset_class"]
 		if m == "" {
@@ -354,7 +374,17 @@ func classifyMember(e *graph.Entity) (member, owning string, bodyless bool) {
 		if o == "" {
 			o = prefixBeforeDot(e.Name)
 		}
-		return m, o, true
+		return m, o, !hasRealBody(e)
+	case "django_cbv_implicit_method":
+		m := e.Properties["cbv_method_origin"]
+		o := e.Properties["cbv_class"]
+		if m == "" {
+			m = leafAfterDot(e.Name)
+		}
+		if o == "" {
+			o = prefixBeforeDot(e.Name)
+		}
+		return m, o, !hasRealBody(e)
 	}
 
 	// A general method entity: name is "Owner.member" (qualified) — split it.

--- a/internal/mcp/mro_method_override_4890_test.go
+++ b/internal/mcp/mro_method_override_4890_test.go
@@ -1,0 +1,180 @@
+package mcp
+
+// mro_method_override_4890_test.go — value-asserting coverage for the
+// method/Operation-node override path (#4890).
+//
+// #3973 fixed get_source on the inherited ENDPOINT node (http_endpoint). But
+// the rewrite agent ALSO navigates to the METHOD/Operation node itself
+// (SCOPE.Operation:ViewSet.create), and there the regression persists: a DRF
+// CRUD method that the ViewSet OVERRIDES (its own `def create(self, ...)` body)
+// still resolved as INHERITED and get_source returned the synthesized
+// inherited-mixin contract — the base class's behaviour — instead of the
+// override's own source span. That produced ~14 FALSE rewrite-agent audit
+// findings (clients/schedule/groups/inspections/document-templates/jurisdictions).
+//
+// Root cause: classifyMember reported bodyless=true UNCONDITIONALLY for any
+// entity carrying pattern_type=drf_viewset_implicit_method. When that marker
+// leaks onto a REAL override node (regex miss on `async def`, an ID collision
+// between the engine synthetic and the extractor's real method merging
+// properties, etc.), the explicit-body gate in resolveMember was skipped and
+// the node was walked up EXTENDS to the external mixin and synthesized.
+//
+// The fix: a node with a REAL source span is an OVERRIDE and resolves as
+// EXPLICIT regardless of the synthetic marker — get_source returns its own
+// body. The synthesis is preserved ONLY for a truly inherited, bodyless node.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// overriddenMethodDoc builds a ClientViewSet(ModelViewSet) whose `create`
+// method is OVERRIDDEN in the class body (a real SCOPE.Operation node with a
+// real span). To model the upstream property-leak that caused #4890, the
+// override node ALSO carries pattern_type=drf_viewset_implicit_method — the
+// marker that previously forced it down the inherited-synthesis path. The
+// external ModelViewSet/CreateModelMixin base is known to the baseknowledge
+// pack, so a mis-resolution would synthesize the mixin contract.
+func overriddenMethodDoc(t *testing.T, dir string) *graph.Document {
+	t.Helper()
+	src := "" +
+		"class ClientViewSet(ModelViewSet):\n" +
+		"    def create(self, request, *args, **kwargs):\n" +
+		"        # OVERRIDE_CREATE_MARKER: custom client-creation logic\n" +
+		"        return super().create(request, *args, **kwargs)\n"
+	if err := os.WriteFile(filepath.Join(dir, "clients.py"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write clients.py: %v", err)
+	}
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "vs", Name: "ClientViewSet", QualifiedName: "ClientViewSet",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "clients.py",
+				StartLine: 1, EndLine: 4, Language: "python"},
+			// The OVERRIDE method node: real body at lines 2-4, but carrying the
+			// implicit-method marker (the leak under test).
+			{ID: "op_create", Name: "ClientViewSet.create", QualifiedName: "ClientViewSet.create",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "clients.py",
+				StartLine: 2, EndLine: 4, Language: "python",
+				Signature: "def create(self, request, *args, **kwargs)",
+				Properties: map[string]string{
+					"pattern_type":      "drf_viewset_implicit_method",
+					"viewset_class":     "ClientViewSet",
+					"inherited_from":    "rest_framework",
+					"drf_method_origin": "create",
+				}},
+			{ID: "ext_modelviewset", Name: "ModelViewSet", Kind: "SCOPE.External", Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "vs", ToID: "ext_modelviewset", Kind: "EXTENDS",
+				Properties: map[string]string{
+					"language":  "python",
+					"base_name": "rest_framework.viewsets.ModelViewSet",
+				}},
+		},
+	}
+}
+
+// TestGetSource_OverriddenMethod_ReturnsOwnBody — #4890 primary case.
+// get_source on the overridden create method MUST return the override's own
+// source span (OVERRIDE_CREATE_MARKER), NOT the synthesized inherited mixin
+// contract.
+func TestGetSource_OverriddenMethod_ReturnsOwnBody(t *testing.T) {
+	dir := t.TempDir()
+	srv := newTestServer(t, overriddenMethodDoc(t, dir))
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "op_create"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source tool error: %v", res.Content)
+	}
+	text := extractResultText(t, res)
+
+	// Must return the override's own real body.
+	if !strings.Contains(text, "OVERRIDE_CREATE_MARKER") {
+		t.Errorf("expected the override's own body (OVERRIDE_CREATE_MARKER), got:\n%s", text)
+	}
+	// Must NOT synthesize an inherited mixin contract.
+	if strings.Contains(text, "INHERITED") || strings.Contains(text, "NOT subclass source") ||
+		strings.Contains(text, "CreateModelMixin") || strings.Contains(text, "default_status") {
+		t.Errorf("overridden method must NOT be redirected to a mixin synthesis:\n%s", text)
+	}
+}
+
+// TestResolveMember_OverriddenMethod_IsExplicit — unit-level guard: a real-body
+// node resolves provExplicit even with the implicit-method marker.
+func TestResolveMember_OverriddenMethod_IsExplicit(t *testing.T) {
+	dir := t.TempDir()
+	srv := newTestServer(t, overriddenMethodDoc(t, dir))
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+	lr := srv.State.groups["test"].Repos["repo1"]
+
+	e := lr.LabelIndex.ByID["op_create"]
+	if e == nil {
+		t.Fatal("op_create entity not found")
+	}
+	res := resolveMember(lr, e)
+	if res.IsInherited() {
+		t.Errorf("overridden method (real body) must resolve as explicit, got provenance=%q", res.Provenance)
+	}
+}
+
+// trulyInheritedMethodDoc builds a ProductViewSet(ModelViewSet) whose `create`
+// is NOT overridden — the engine emits a BODYLESS implicit-method synthetic
+// (no StartLine span). This is the genuinely-inherited case the synthesis is
+// preserved for.
+func trulyInheritedMethodDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "vs", Name: "ProductViewSet", QualifiedName: "ProductViewSet",
+				Kind: "SCOPE.Component", Subtype: "class", SourceFile: "products.py",
+				StartLine: 1, EndLine: 2, Language: "python"},
+			// Bodyless synthetic: NO StartLine/EndLine span — truly inherited.
+			{ID: "op_create", Name: "ProductViewSet.create", QualifiedName: "ProductViewSet.create",
+				Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "products.py",
+				Language: "python",
+				Signature: "def create(self, request, *args, **kwargs)",
+				Properties: map[string]string{
+					"pattern_type":      "drf_viewset_implicit_method",
+					"viewset_class":     "ProductViewSet",
+					"inherited_from":    "rest_framework",
+					"drf_method_origin": "create",
+				}},
+			{ID: "ext_modelviewset", Name: "ModelViewSet", Kind: "SCOPE.External", Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "e1", FromID: "vs", ToID: "ext_modelviewset", Kind: "EXTENDS",
+				Properties: map[string]string{
+					"language":  "python",
+					"base_name": "rest_framework.viewsets.ModelViewSet",
+				}},
+		},
+	}
+}
+
+// TestResolveMember_TrulyInheritedMethod_StaysInherited — NEGATIVE guard: a
+// bodyless synthetic (no override) must STILL resolve as inherited so the
+// mixin-synthesis path is preserved. The fix must not break the genuine case.
+func TestResolveMember_TrulyInheritedMethod_StaysInherited(t *testing.T) {
+	srv := newTestServer(t, trulyInheritedMethodDoc())
+	lr := srv.State.groups["test"].Repos["repo1"]
+
+	e := lr.LabelIndex.ByID["op_create"]
+	if e == nil {
+		t.Fatal("op_create entity not found")
+	}
+	res := resolveMember(lr, e)
+	if !res.IsInherited() {
+		t.Errorf("truly-inherited bodyless method must resolve as inherited, got provenance=%q", res.Provenance)
+	}
+}


### PR DESCRIPTION
## Root cause

The rewrite agent navigates to the **method/Operation node** (`SCOPE.Operation:ViewSet.create`), not just the endpoint. `classifyMember` reported `bodyless=true` **unconditionally** for any node carrying `pattern_type=drf_viewset_implicit_method`. The engine emits that synthetic only for non-overridden CRUD methods (`emitViewSetMethodEntities` skips `explicitMethods`), but the marker **leaks onto a REAL override node**:

- `drfExplicitMethodRe` (`def <m>(self`) misses forms like `async def create(self`, so an override is not marked explicit and a synthetic is emitted;
- the engine synthetic shares `(Kind, Name, SourceFile)` → the same stamped ID as the extractor's real method node, so a property merge can stamp `pattern_type` onto the override.

With `bodyless=true`, the explicit-body gate in `resolveMember` (`!isBodyless && hasRealBody(e)`) was **skipped**, the node was walked up `EXTENDS` to the external mixin, and `get_source` synthesized the inherited-mixin contract (the base class behaviour) instead of the override's own source span → ~14 FALSE rewrite-agent audit findings (clients/schedule/groups/inspections/document-templates/jurisdictions).

**#3973 vs this**: #3973 fixed only the `http_endpoint`-node path via the endpoint→mixin bridge (which runs *before* `classifyMember`). The method/Operation-node path routes *through* `classifyMember`, so it still regressed.

## The fix

`internal/mcp/mro.go` — the implicit-method branch of `classifyMember` now reports `bodyless = !hasRealBody(e)`. A node with a real source span **is** an override → resolves `provExplicit` → `get_source` returns its own body. The inherited-mixin synthesis is preserved **only** for a genuinely bodyless synthetic (no override).

## Override vs truly-inherited

- **Override** (real `StartLine`/`EndLine` span) → `provExplicit`, own body. ✅ fixed.
- **Truly inherited** (bodyless synthetic, no span) → still `provInheritedExternal`/`provInheritedInRepo`, synthesis/base-body preserved. ✅ negative test guards this.

## Generalize verdict

`drf_viewset_implicit_method` was the **only** `classifyMember` branch hardcoding `bodyless=true`. Every other inheritance-heavy framework — **Spring base controllers, NestJS base services, Rails inherited actions, Go embedded methods** — routes its method nodes through the general dotted-name path with `bodyless=false`, so the line-152 `!isBodyless && hasRealBody` gate already keeps their overrides explicit; **they were never affected**. **Django CBV** (`django_cbv_implicit_method`) shares the exact DRF synthetic shape and the same leak risk, so it is folded into this fix (same override-aware logic). **No per-framework follow-up needed.**

## Fixture

`internal/mcp/mro_method_override_4890_test.go`:
- overridden `create` with a real body + leaked implicit marker → `get_source` returns `OVERRIDE_CREATE_MARKER`, not the `CreateModelMixin` synthesis;
- `resolveMember` on it is `provExplicit`;
- NEGATIVE: a truly-inherited bodyless synthetic still resolves inherited.

Confirmed the test FAILS on `main` (returns the synthesized `CreateModelMixin` contract) and PASSES with the fix.

## Gates (under sandbox HOME `/var/folders/.../T/...`)

- `go build ./...` ✅
- `go vet ./internal/mcp/... ./internal/engine/...` ✅
- `go test ./internal/mcp/... ./internal/extractors/python/... ./internal/engine/... ./internal/types/` ✅ all green

Closes #4890.