### PR TITLE
feat(#4891): get_source explicit from/to line-range param (read distal method internals without grep fallback)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -833,15 +833,31 @@ above and below the entity's recorded `[start_line, end_line]` range.
 **Span guard (#1614):** when `end_line <= start_line` or either is `0` (common
 for synthetic / shadow / route entities), the span is clamped to a fixed
 fallback window (`start_line + 60`). A **hard cap of 200 emitted lines** is then
-applied unconditionally, so `get_source` can never dump an entire file no matter
-what span the entity records.
+applied so `get_source` can never accidentally dump an entire file from the
+symbol-anchored span.
+
+**Explicit window (#4891):** pass **both** `from_line` and `to_line` to read
+*exactly* that line range of the resolved entity's source file, clamped to the
+file's real bounds. An explicit window **bypasses the symbol-anchored 200-line
+cap** — the caller has named exact bounds and owns the token budget. This is the
+intended way to read **distal method internals** (e.g. lines 200-240 of a long
+function whose recorded entity span starts much earlier) without falling back to
+`grep`. A one-sided range (only `from_line` or only `to_line`) fills the missing
+bound from the entity span and keeps the hard cap. `start_line` / `end_line` are
+accepted as legacy aliases of `from_line` / `to_line`. The optional `max_lines`
+heads the emitted line count and signals truncation. Every truncation is
+signalled with a precise `from_line` / `to_line` continuation hint
+([no-silent-caps]).
 
 **Inputs**
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `entity_id` | string | yes | — | Entity ID, prefixed ID, qname, or label. |
-| `context_lines` | number | no | `20` | Lines of context above/below the entity. |
+| `context_lines` | number | no | `8` | Lines of context above/below the entity span (ignored for an explicit window). |
+| `from_line` | number | no | — | Explicit window start (1-based, inclusive). With `to_line`, bypasses the 200-line cap. |
+| `to_line` | number | no | — | Explicit window end (1-based, inclusive). Clamped to the file's last line. |
+| `max_lines` | number | no | — | Head cap on emitted lines (opt-in; undeclared, #1639 token-ceiling). |
 | `group`, `cwd` | string | no | — | Common args. |
 
 **Output** — text, line-numbered:

--- a/internal/mcp/get_source_2828_test.go
+++ b/internal/mcp/get_source_2828_test.go
@@ -81,7 +81,7 @@ func TestGetSource_2828_DefaultLargeEntityTruncatesWithSignal(t *testing.T) {
 	if !strings.Contains(out, "archigraph: truncated") {
 		t.Fatalf("missing truncation marker:\n%s", tail(out))
 	}
-	if !strings.Contains(out, "start_line=") || !strings.Contains(out, "end_line=") {
+	if !strings.Contains(out, "from_line=") || !strings.Contains(out, "to_line=") {
 		t.Errorf("truncation marker lacks precise continuation range:\n%s", tail(out))
 	}
 }
@@ -187,6 +187,93 @@ func TestComputeSourceSpan_2828_Policy(t *testing.T) {
 				t.Error("expected empty truncation marker")
 			}
 		})
+	}
+}
+
+// TestGetSource_4891_ExplicitWindowBypassesHardCap verifies the #4891 explicit
+// from_line/to_line window: a named range larger than the 200-line symbol-anchored
+// hard cap is returned VERBATIM (the caller owns the budget), so distal method
+// internals are readable without a grep fallback. It also confirms from_line/to_line
+// are honoured identically to the legacy start_line/end_line aliases, and that the
+// default (no window) call is unchanged (still hard-capped + signalled).
+func TestGetSource_4891_ExplicitWindowBypassesHardCap(t *testing.T) {
+	t.Parallel()
+	// Entity span starts at line 5; the body we want is "distal" (lines 210-260),
+	// a 51-line window inside a 600-line span — and the window itself is fine, but
+	// to prove the cap bypass we also request a 300-line window (> 200 hard cap).
+	s := build2828SourceServer(t, 700, 5, 605)
+
+	// (a) A 300-line explicit window (250..549) MUST come back in full — the
+	// pre-#4891 200-line hard cap would have clipped it to 250..449.
+	wide := callGetSource(t, s, map[string]any{
+		"group": "test", "entity_id": "big", "from_line": 250, "to_line": 549,
+	})
+	for _, want := range []int{250, 449, 450, 549} { // includes lines past the old 200-cap
+		if !strings.Contains(wide, fmt.Sprintf("statement_%d ", want)) {
+			t.Errorf("explicit 300-line window missing line %d (hard cap not bypassed):\n%s", want, tail(wide))
+		}
+	}
+	if strings.Contains(wide, "statement_249 ") || strings.Contains(wide, "statement_550 ") {
+		t.Errorf("explicit window leaked lines outside [250,549]:\n%s", tail(wide))
+	}
+	if strings.Contains(wide, "archigraph: truncated") {
+		t.Errorf("explicit window honoured verbatim must NOT be marked truncated:\n%s", tail(wide))
+	}
+
+	// (b) from_line/to_line are identical to the legacy start_line/end_line aliases.
+	viaNew := callGetSource(t, s, map[string]any{
+		"group": "test", "entity_id": "big", "from_line": 300, "to_line": 320,
+	})
+	viaLegacy := callGetSource(t, s, map[string]any{
+		"group": "test", "entity_id": "big", "start_line": 300, "end_line": 320,
+	})
+	if viaNew != viaLegacy {
+		t.Errorf("from_line/to_line must match start_line/end_line aliases\nnew:\n%s\nlegacy:\n%s", viaNew, viaLegacy)
+	}
+
+	// (c) to_line past EOF is clamped to the file's real bounds (700 lines on disk).
+	clamped := callGetSource(t, s, map[string]any{
+		"group": "test", "entity_id": "big", "from_line": 695, "to_line": 999,
+	})
+	if !strings.Contains(clamped, "statement_700 ") {
+		t.Errorf("window past EOF should include the last real line 700:\n%s", clamped)
+	}
+	if strings.Contains(clamped, "statement_701 ") {
+		t.Errorf("window past EOF leaked a nonexistent line:\n%s", clamped)
+	}
+
+	// (d) NO-REGRESSION: a default call (no window) is still hard-capped + signalled.
+	def := callGetSource(t, s, map[string]any{"group": "test", "entity_id": "big", "context_lines": 0})
+	if !strings.Contains(def, "archigraph: truncated") {
+		t.Errorf("default call must still signal the symbol-anchored hard cap:\n%s", tail(def))
+	}
+}
+
+// TestComputeSourceSpan_4891_ExplicitWindow unit-tests the cap-bypass policy.
+func TestComputeSourceSpan_4891_ExplicitWindow(t *testing.T) {
+	t.Parallel()
+	// Explicit window of 300 lines on a 1000-line span: returned verbatim, no cap.
+	sp := computeSourceSpan(&graph.Entity{StartLine: 5, EndLine: 605},
+		sourceWindowOpts{startLine: 250, endLine: 549, explicitWindow: true})
+	if sp.start != 250 || sp.end != 549 {
+		t.Errorf("explicit window span = [%d,%d], want [250,549]", sp.start, sp.end)
+	}
+	if sp.truncated {
+		t.Error("explicit window honoured verbatim must not be truncated")
+	}
+
+	// max_lines still heads an explicit window when the caller opts back into a cap.
+	sp2 := computeSourceSpan(&graph.Entity{StartLine: 5, EndLine: 605},
+		sourceWindowOpts{startLine: 250, endLine: 549, explicitWindow: true, maxLines: 40})
+	if sp2.end != 250+40-1 || !sp2.truncated {
+		t.Errorf("max_lines on explicit window: span=[%d,%d] trunc=%v, want end=289 trunc=true", sp2.start, sp2.end, sp2.truncated)
+	}
+
+	// A one-sided range (no explicitWindow) still respects the hard cap.
+	sp3 := computeSourceSpan(&graph.Entity{StartLine: 1, EndLine: 1000},
+		sourceWindowOpts{startLine: 1, explicitWindow: false})
+	if sp3.end != getSourceHardMaxLines || !sp3.truncated {
+		t.Errorf("one-sided range must keep hard cap: span=[%d,%d] trunc=%v", sp3.start, sp3.end, sp3.truncated)
 	}
 }
 

--- a/internal/mcp/get_source_window.go
+++ b/internal/mcp/get_source_window.go
@@ -63,6 +63,18 @@ type sourceWindowOpts struct {
 	startLine    int // explicit window start; 0 = derive from entity
 	endLine      int // explicit window end; 0 = derive from entity
 	maxLines     int // head cap on emitted lines; 0 = use hard ceiling only
+
+	// explicitWindow is true when the caller passed BOTH bounds of an explicit
+	// line range (from_line/to_line, or the legacy start_line/end_line). #4891:
+	// an explicit window bypasses the symbol-anchored 200-line hard cap — the
+	// caller has named exact bounds and owns the token budget, so distal method
+	// internals (e.g. lines 200-240 of a long function whose entity span starts
+	// at line 5) are readable without a grep fallback. The clamp to the file's
+	// actual line count still applies in readSourceWindow. A one-sided range
+	// (only from_line or only to_line) is NOT a full explicit window: it still
+	// derives the missing bound from the entity span and keeps the hard cap so a
+	// `from_line`-only call can't accidentally request a whole-file dump.
+	explicitWindow bool
 }
 
 // computeSourceSpan resolves the line window to emit for entity e under opts,
@@ -118,9 +130,16 @@ func computeSourceSpan(e *graph.Entity, opts sourceWindowOpts) sourceSpan {
 	// caller how to request the remainder.
 	fullEnd := end
 
-	// Effective per-call line cap: the smaller of the hard ceiling and a
-	// caller-supplied max_lines (when positive).
+	// #4891 — a fully-explicit from/to window bypasses the symbol-anchored hard
+	// cap. The caller has named both bounds and owns the token budget, so we
+	// honour the range verbatim (the clamp to the file's real line count still
+	// happens in readSourceWindow). max_lines, when also passed, still heads the
+	// emitted count even on an explicit window so a caller can opt back into a
+	// cap. Without an explicit window, the hard ceiling applies as before.
 	cap := getSourceHardMaxLines
+	if opts.explicitWindow {
+		cap = end - start + 1 // honour the named range; no symbol-anchored ceiling
+	}
 	if opts.maxLines > 0 && opts.maxLines < cap {
 		cap = opts.maxLines
 	}
@@ -143,19 +162,36 @@ func (sp sourceSpan) truncationMarker(entityID string) string {
 	nextStart := sp.end + 1
 	return fmt.Sprintf(
 		"\n# archigraph: truncated — emitted lines %d-%d of %d-%d. "+
-			"Request the rest with get_source(entity_id=%q, start_line=%d, end_line=%d).\n",
+			"Request the rest with get_source(entity_id=%q, from_line=%d, to_line=%d).\n",
 		sp.start, sp.end, sp.start, sp.fullEnd, entityID, nextStart, sp.fullEnd,
 	)
 }
 
-// readSourceWindowOpts reads the #2828 opt-in slicing controls off the request
-// map. They are intentionally undeclared in the tool schema per the #1639
-// token-ceiling pattern (allow-listed in schema_contract_ast_test.go).
+// readSourceWindowOpts reads the opt-in slicing controls off the request map.
+//
+// #4891: from_line/to_line are the canonical, schema-declared (discoverable in
+// the handshake) names for an explicit line window. start_line/end_line remain
+// accepted as legacy aliases (undeclared, allow-listed in
+// schema_contract_ast_test.go) so existing callers and the #2828 truncation
+// hint keep working. max_lines is the #2828 head cap, also an undeclared opt-in.
+//
+// When BOTH bounds of the window are supplied (via either naming), the window is
+// "explicit" and bypasses the symbol-anchored hard cap (see computeSourceSpan).
 func readSourceWindowOpts(req mcpapi.CallToolRequest, contextLines int) sourceWindowOpts {
+	// from_line/to_line take precedence; fall back to the legacy aliases.
+	start := argInt(req, "from_line", 0)
+	if start == 0 {
+		start = argInt(req, "start_line", 0)
+	}
+	end := argInt(req, "to_line", 0)
+	if end == 0 {
+		end = argInt(req, "end_line", 0)
+	}
 	return sourceWindowOpts{
-		contextLines: contextLines,
-		startLine:    argInt(req, "start_line", 0),
-		endLine:      argInt(req, "end_line", 0),
-		maxLines:     argInt(req, "max_lines", 0),
+		contextLines:   contextLines,
+		startLine:      start,
+		endLine:        end,
+		maxLines:       argInt(req, "max_lines", 0),
+		explicitWindow: start > 0 && end > 0,
 	}
 }

--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -111,12 +111,14 @@ var intentionalGaps = []intentionalGap{
 
 	// archigraph_get_source: legacy alias node_id — deprecated, intentionally undeclared.
 	{"archigraph_get_source", "node_id", "deprecated alias for entity_id, intentionally undeclared"},
-	// archigraph_get_source: #2828 opt-in precise-slicing controls — read off the
-	// request map per the #1639 token-ceiling pattern (declaring them would bloat
-	// the handshake). start_line/end_line take an explicit range; max_lines heads
-	// the emitted line count. All optional; absence = legacy entity-span behaviour.
-	{"archigraph_get_source", "start_line", "#2828 / #1639 token-ceiling: opt-in explicit line range, undeclared"},
-	{"archigraph_get_source", "end_line", "#2828 / #1639 token-ceiling: opt-in explicit line range, undeclared"},
+	// archigraph_get_source: #2828 opt-in precise-slicing controls. The canonical
+	// explicit-window params from_line/to_line ARE declared in the schema (#4891 —
+	// discoverable in the handshake so callers reach for the window instead of a
+	// grep fallback). start_line/end_line remain accepted as legacy aliases and
+	// max_lines is the #2828 head cap; all three stay undeclared per the #1639
+	// token-ceiling pattern. All optional; absence = legacy entity-span behaviour.
+	{"archigraph_get_source", "start_line", "#2828 / #1639 token-ceiling: legacy alias of from_line, undeclared"},
+	{"archigraph_get_source", "end_line", "#2828 / #1639 token-ceiling: legacy alias of to_line, undeclared"},
 	{"archigraph_get_source", "max_lines", "#2828 / #1639 token-ceiling: opt-in head cap, undeclared"},
 
 	// archigraph_patterns: action-specific args for sub-actions (query, record, get,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -451,9 +451,11 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_whoami", s.handleWhoami))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_source",
-		mcpapi.WithDescription("Source for a node (id/qname/label). Opt-in: start_line/end_line/max_lines."),
+		mcpapi.WithDescription("Source for a node (id/qname/label). from_line+to_line: exact range, no cap."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("context_lines", mcpapi.DefaultNumber(8)), // #2828: was 20
+		mcpapi.WithNumber("from_line"),                              // #4891: explicit window start (1-based, inclusive)
+		mcpapi.WithNumber("to_line"),                                // #4891: explicit window end (1-based, inclusive)
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_get_source", s.handleGetNodeSource))


### PR DESCRIPTION
## What

Adds first-class **`from_line` / `to_line`** params to `archigraph_get_source`. When **both** are supplied, the tool returns **exactly** that line range of the resolved entity's source file (clamped to the file's real bounds) and **bypasses the symbol-anchored 200-line hard cap** — the caller has named exact bounds and owns the token budget.

## Why (rewrite-agent feedback, #4891)

The symbol-anchored cap (~60-200 lines, anchored at the entity's recorded `start_line`) blocked reading **distal method internals** — e.g. changelog-engine L200-240 or deficiencies L90-118 of a long function whose entity span begins much earlier. The agent was forced into a `grep` fallback. The explicit window makes those lines directly addressable. The params are now **declared in the tool schema**, so they are discoverable in the MCP handshake (previously the slicing controls were undeclared per the #1639 token-ceiling pattern, so callers never found them).

## Behaviour

- **`from_line` + `to_line`** → exact range, no symbol-anchored cap; clamped to file bounds (a `to_line` past EOF stops at the last real line).
- **One-sided** (`from_line` only / `to_line` only) → fills the missing bound from the entity span and **keeps** the hard cap (can't accidentally request a whole-file dump).
- **`max_lines`** still heads the emitted count even on an explicit window, so a caller can opt back into a cap.
- **No window** → byte-for-byte the pre-change symbol-anchored behaviour (no regression).
- `start_line` / `end_line` retained as **legacy aliases**; the `[no-silent-caps]` truncation hint now suggests `from_line` / `to_line`.

## Terse payload (#2828)

The explicit window is the caller's responsibility to size; the default call shape and token budget are unchanged. Tool description kept ≤80 chars (handshake budget gate).

## Language-agnostic

This is a tool param on the entity's resolved source file, so it covers the **entire language/framework matrix automatically** — no per-extractor work.

## Docs + inventory

- Tool description + `SCHEMA.md` `archigraph_get_source` section document the explicit window, the cap bypass, file-bounds clamping, and the legacy aliases.
- `schema_contract_ast_test.go` allow-list updated: `from_line`/`to_line` are now declared; `start_line`/`end_line`/`max_lines` remain undeclared opt-ins.
- Tool-inventory count (65) unchanged — only params were added.

## Tests

- `TestGetSource_4891_ExplicitWindowBypassesHardCap`: a 300-line `from_line`/`to_line` window returns in full (old 200-cap would clip); `from_line`/`to_line` == legacy aliases; `to_line` past EOF clamped; default call still hard-capped + signalled.
- `TestComputeSourceSpan_4891_ExplicitWindow`: unit cases for verbatim window, `max_lines` re-cap, and one-sided range keeping the hard cap.
- Existing `TestGetSource_2828_*` updated for the new `from_line`/`to_line` continuation-hint wording.

## Gates (under isolated sandbox HOME=/tmp/agsbx-4891)

```
HOME=/tmp/agsbx-4891
BUILD_OK   (go build ./...)
VET_OK     (go vet ./internal/...)
ok  github.com/cajasmota/archigraph/internal/mcp            56.855s
ok  github.com/cajasmota/archigraph/internal/mcp/transport  (cached)
ok  github.com/cajasmota/archigraph/internal/types          2.295s
```

Deploy-deferred. Closes #4891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)