### PR TITLE
feat(#4893): tautological/oracle-blind test detector (contract_test_effectiveness) — stop specs false-greening the parity gate

### DIFF
--- a/internal/mcp/schema_contract_ast_test.go
+++ b/internal/mcp/schema_contract_ast_test.go
@@ -205,6 +205,12 @@ var intentionalGaps = []intentionalGap{
 	// group_oracle) ARE declared; endpoint narrows to one "VERB /path".
 	{"archigraph_stub_detector", "endpoint", "#4425 token ceiling pattern — optional single-endpoint filter"},
 
+	// archigraph_contract_test_effectiveness: optional narrowing args undeclared
+	// for token budget (#4893 / #1639 pattern). entity_id pins one spec;
+	// only_ineffective (default true) omits effective specs from the result.
+	{"archigraph_contract_test_effectiveness", "entity_id", "#4893 token ceiling pattern — optional single-spec filter"},
+	{"archigraph_contract_test_effectiveness", "only_ineffective", "#4893 token ceiling pattern — optional verdict filter (default true)"},
+
 	// archigraph_endpoint_posture: scan-mode pagination undeclared for token
 	// budget (#1639 pattern). entity_id/facet/path_contains/method ARE declared.
 	{"archigraph_endpoint_posture", "limit", "#1639 token ceiling pattern — scan-mode result limit"},

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -678,6 +678,19 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group_v3", mcpapi.Required()),
 	), s.wrap("archigraph_response_shape_diff", s.handleResponseShapeDiff))
 
+	// #4893 (epic #4419) — contract-test EFFECTIVENESS / tautological-spec
+	// detector. The sibling of stub_detector on the SPEC side: flags test
+	// entities whose assertions are oracle-blind and false-green the parity gate
+	// (self-compare expect(x).toBe(x); constant-true expect(true).toBe(true);
+	// same-literal expected==actual; + a low-confidence no_golden_linkage
+	// advisory). Single-group (the spec/v3 group). Optional (undeclared per
+	// #1639): repo_filter, entity_id, only_ineffective.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_contract_test_effectiveness",
+		mcpapi.WithDescription("Tautological-spec detector: assertions that can never fail (oracle-blind)."),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_contract_test_effectiveness", s.handleContractTestEffectiveness))
+
 	// #2772 — Phase 2B taint flow / security findings. Returns
 	// SecurityFinding records emitted by the taint-flow pass:
 	// source→...→sink paths through the CALLS graph that lack an

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -615,6 +615,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_response_shape_diff",
 		// #4822 on-demand per-function CFG (control-flow epic #4820 part b).
 		"archigraph_control_flow",
+		// #4893 tautological/oracle-blind spec detector (contract_test_effectiveness).
+		"archigraph_contract_test_effectiveness",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -715,8 +717,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_response_shape_diff (#4424 cross-group branch-aware response-shape parity).
 	// +1 archigraph_apply_doc_semantics (#4309 doc ingestion L2 apply step).
 	// +1 archigraph_control_flow (#4822 on-demand per-function CFG, control-flow epic #4820 part (b)).
-	if got := len(allRegisteredTools); got != 65 {
-		t.Errorf("expected 65 registered tools, got %d — update this count if tools are added/removed (added archigraph_control_flow #4822 on-demand CFG)", got)
+	// +1 archigraph_contract_test_effectiveness (#4893 tautological/oracle-blind spec detector).
+	if got := len(allRegisteredTools); got != 66 {
+		t.Errorf("expected 66 registered tools, got %d — update this count if tools are added/removed (added archigraph_contract_test_effectiveness #4893)", got)
 	}
 }
 
@@ -3223,7 +3226,7 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		// #2766 Phase 1B reachability + dead-code identification
 		"archigraph_dead_code": {"group": "g"},
 		// #2764 Phase 1A effect classification — entity_id required.
-		"archigraph_effects": {"group": "g", "entity_id": "DashboardScreen"},
+		"archigraph_effects":      {"group": "g", "entity_id": "DashboardScreen"},
 		"archigraph_control_flow": {"group": "g", "entity_id": "DashboardScreen"},
 		// deploy-9 caps surfacing — posture facets. entity_id optional (omitted
 		// here exercises the repo-wide scan path).
@@ -3252,8 +3255,9 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		// test group "g"; with no endpoint definitions in this fixture the handler
 		// returns an empty-results payload, still exercising the wrapper +
 		// elapsed_ms trailer.
-		"archigraph_stub_detector":       {"group_v3": "g", "group_oracle": "g"},
-		"archigraph_response_shape_diff": {"group_oracle": "g", "group_v3": "g"},
+		"archigraph_stub_detector":               {"group_v3": "g", "group_oracle": "g"},
+		"archigraph_response_shape_diff":         {"group_oracle": "g", "group_v3": "g"},
+		"archigraph_contract_test_effectiveness": {"group": "g"},
 	}
 
 	// extractElapsedMS mirrors the bench extraction logic:
@@ -3298,8 +3302,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 65 {
-		t.Errorf("expected 65 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_control_flow #4822 on-demand CFG)", len(tools))
+	if len(tools) != 66 {
+		t.Errorf("expected 66 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_contract_test_effectiveness #4893)", len(tools))
 	}
 
 	for _, st := range tools {

--- a/internal/mcp/tautology_detector_tool.go
+++ b/internal/mcp/tautology_detector_tool.go
@@ -1,0 +1,285 @@
+// archigraph_contract_test_effectiveness MCP tool (#4893, epic #4419).
+//
+// Flags test/spec entities whose assertions are ORACLE-BLIND / tautological and
+// therefore FALSE-GREEN the parity gate: a green spec is taken as a witness that
+// the endpoint behaves, but a spec that asserts a value against ITSELF, asserts
+// a constant true, or codifies the WRONG expected SHAPE as a literal can never
+// fail — it certifies nothing. A real miss this caught: a status_counts dict→
+// array shape drift PASSED because the spec asserted the (wrong) array shape
+// against the handler's array output, an assertion that could never fail.
+//
+// The detector is the sibling of stub_detector (#4425) on the spec side: where
+// stub_detector asks "does the v3 handler COMPUTE?", this asks "does the v3 SPEC
+// actually CHECK?". It is single-group (the spec/v3 group), unlike the cross-
+// group diff tools — a tautological assertion is visible from the spec alone.
+//
+// Signature:
+//
+//	contract_test_effectiveness(
+//	  group:       "<group>",                (optional; resolved like other tools)
+//	  cwd:         "<dir>",                   (optional; resolves group)
+//	  repo_filter: ["repoA", ...],            (optional)
+//	  entity_id:   "<prefixed or label>",     (optional; one spec only)
+//	  only_ineffective: true,                 (optional; default true — omit
+//	                                           effective specs to save tokens)
+//	)
+//
+// Result (per analysed spec):
+//
+//	{
+//	  "spec":          "test/orders.spec.ts::should_return_counts",
+//	  "entity_id":     "orders-v3::abcd1234",
+//	  "file":          "test/orders.spec.ts",
+//	  "language":      "typescript",
+//	  "verdict":       "ineffective"|"effective"|"unknown",
+//	  "findings": [ {"reason":"self_compare","line":42,"snippet":"...","detail":"..."} ],
+//	  "no_golden_linkage": false
+//	}
+//
+// # What it detects (from the spec's own source)
+//
+//   - self_compare  — both sides of an equality assertion are the SAME
+//     expression: expect(x).toEqual(x), assertEquals(x, x),
+//     assertBodyContract(body, body).
+//   - constant_true — expect(true).toBe(true), assert True, assertTrue(true).
+//   - same_literal  — expected and actual are the SAME literal:
+//     expect("ok").toBe("ok"), assertEquals(200, 200).
+//   - no_golden_linkage (advisory, low confidence) — the spec body never
+//     references the symbol(s) it claims to test (its inbound-TESTS targets) nor
+//     the route it covers. Surfaced separately; never on its own ⇒ ineffective.
+//
+// JS/TS (Jest/vitest — the live NestJS spec style) is first-class; the common
+// patterns are generalised across pytest, Go testing/testify, JUnit/AssertJ and
+// RSpec via internal/tautology's per-language vocabularies. The pure detection +
+// per-language vocabularies live in internal/tautology, unit-tested independently.
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/substrate"
+	"github.com/cajasmota/archigraph/internal/tautology"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// tautologyMaxSpecSourceLines bounds the source window read per spec so a
+// pathological entity span can never become a whole-file dump.
+const tautologyMaxSpecSourceLines = 600
+
+// handleContractTestEffectiveness implements archigraph_contract_test_effectiveness.
+func (s *Server) handleContractTestEffectiveness(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	onlyIneffective := true
+	if v := strings.TrimSpace(argString(req, "only_ineffective", "")); v == "false" || v == "0" {
+		onlyIneffective = false
+	}
+	entityFilter := strings.TrimSpace(argString(req, "entity_id", ""))
+
+	type specRec struct {
+		spec     string
+		entityID string
+		file     string
+		language string
+		res      tautology.Result
+	}
+
+	out := make([]specRec, 0)
+	analysed := 0
+	ineffective := 0
+
+	for _, r := range repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		linkage := buildTestLinkageTerms(r)
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isTautologyCandidate(e) {
+				continue
+			}
+			pid := prefixedID(r.Repo, e.ID)
+			if entityFilter != "" && entityFilter != pid && entityFilter != e.Name && entityFilter != e.QualifiedName {
+				continue
+			}
+
+			src, lang := readTautologySource(r, e)
+			if src == "" {
+				continue
+			}
+
+			res := tautology.Analyze(tautology.Input{
+				Language:     lang,
+				Source:       src,
+				StartLine:    specStartLine(e),
+				LinkageTerms: linkage[e.ID],
+			})
+			if !res.Supported {
+				// Unsupported language — skip silently (honest-partial); these add
+				// no signal and would just be noise.
+				continue
+			}
+			tautology.SortFindings(res.Findings)
+			analysed++
+			if res.Verdict == tautology.VerdictIneffective {
+				ineffective++
+			}
+			if onlyIneffective && res.Verdict != tautology.VerdictIneffective && !res.NoGoldenLinkage {
+				continue
+			}
+
+			out = append(out, specRec{
+				spec:     specLabel(e),
+				entityID: pid,
+				file:     e.SourceFile,
+				language: lang,
+				res:      res,
+			})
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		// ineffective first, then by spec label.
+		ii := out[i].res.Verdict == tautology.VerdictIneffective
+		jj := out[j].res.Verdict == tautology.VerdictIneffective
+		if ii != jj {
+			return ii
+		}
+		return out[i].spec < out[j].spec
+	})
+
+	specs := make([]map[string]any, 0, len(out))
+	for _, rec := range out {
+		findings := make([]map[string]any, 0, len(rec.res.Findings))
+		for _, f := range rec.res.Findings {
+			findings = append(findings, map[string]any{
+				"reason":  string(f.Reason),
+				"line":    f.Line,
+				"snippet": f.Snippet,
+				"detail":  f.Detail,
+			})
+		}
+		specs = append(specs, map[string]any{
+			"spec":              rec.spec,
+			"entity_id":         rec.entityID,
+			"file":              rec.file,
+			"language":          rec.language,
+			"verdict":           string(rec.res.Verdict),
+			"findings":          findings,
+			"no_golden_linkage": rec.res.NoGoldenLinkage,
+		})
+	}
+
+	return jsonResult(map[string]any{
+		"group":             lg.Name,
+		"analysed_specs":    analysed,
+		"ineffective_specs": ineffective,
+		"specs":             specs,
+		"detects":           "self_compare | constant_true | same_literal (tautological assertions) + no_golden_linkage advisory",
+		"source":            "per-spec assertion scan over the test entity's file+line span; per-language vocabulary (JS/TS Jest/vitest first-class; pytest/Go/JUnit/RSpec common patterns)",
+	}), nil
+}
+
+// isTautologyCandidate reports whether an entity is a test/spec function worth
+// scanning: a callable operation living in a recognised test file. Mirrors the
+// dead-code test-file convention (isTestFileMCP) + the operation-kind predicate.
+func isTautologyCandidate(e *graph.Entity) bool {
+	if e == nil || !isOperationKind(e) {
+		return false
+	}
+	return isTestFileMCP(e.SourceFile)
+}
+
+// readTautologySource reads the spec entity's source window from disk and
+// resolves its language. Returns ("", "") when the span is degenerate or the
+// file is unreadable.
+func readTautologySource(r *LoadedRepo, e *graph.Entity) (string, string) {
+	start := specStartLine(e)
+	if start <= 0 {
+		return "", ""
+	}
+	end := e.EndLine
+	if end < start {
+		end = start + 40 // degenerate span: read a small window
+	}
+	if end-start+1 > tautologyMaxSpecSourceLines {
+		end = start + tautologyMaxSpecSourceLines - 1
+	}
+	abs := e.SourceFile
+	if !filepath.IsAbs(abs) && r.Path != "" {
+		abs = filepath.Join(r.Path, e.SourceFile)
+	}
+	src, err := readRawSourceWindow(abs, start, end)
+	if err != nil || strings.TrimSpace(src) == "" {
+		return "", ""
+	}
+	lang := strings.ToLower(strings.TrimSpace(e.Language))
+	if lang == "" {
+		lang = substrate.LanguageForPath(e.SourceFile)
+	}
+	return src, lang
+}
+
+// specStartLine returns the 1-based start line of a spec entity, clamped.
+func specStartLine(e *graph.Entity) int {
+	if e.StartLine < 1 {
+		return 0
+	}
+	return e.StartLine
+}
+
+// specLabel renders a stable human label for a spec: <file-base>::<name>.
+func specLabel(e *graph.Entity) string {
+	base := e.SourceFile
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	name := e.Name
+	if name == "" {
+		name = e.QualifiedName
+	}
+	if base == "" {
+		return name
+	}
+	return base + "::" + name
+}
+
+// buildTestLinkageTerms collects, per test entity ID, the case-insensitive terms
+// a genuine spec should reference: the NAMES of the entities it points at over
+// outbound TESTS edges, plus any route path / verb those targets expose. Used to
+// power the no_golden_linkage advisory. A test with no TESTS edges gets no terms
+// (advisory disabled) so we never flag a spec we cannot link.
+func buildTestLinkageTerms(r *LoadedRepo) map[string][]string {
+	byID := r.getByID()
+	terms := map[string][]string{}
+	for i := range r.Doc.Relationships {
+		rel := &r.Doc.Relationships[i]
+		if rel.Kind != "TESTS" {
+			continue
+		}
+		target := byID[rel.ToID]
+		if target == nil {
+			continue
+		}
+		set := terms[rel.FromID]
+		if target.Name != "" {
+			set = appendUniqueStr(set, target.Name)
+		}
+		if p := target.Properties; p != nil {
+			if path := strings.TrimSpace(p["path"]); path != "" {
+				set = appendUniqueStr(set, path)
+			}
+		}
+		terms[rel.FromID] = set
+	}
+	return terms
+}

--- a/internal/mcp/tautology_detector_tool_test.go
+++ b/internal/mcp/tautology_detector_tool_test.go
@@ -1,0 +1,130 @@
+package mcp
+
+// tautology_detector_tool_test.go — end-to-end test for the #4893
+// archigraph_contract_test_effectiveness tool. Runs the REAL handler against a
+// small Jest/NestJS-shaped spec fixture in testdata/tautology_4893/ that holds
+// one tautological `it(...)` (self-compare / constant-true / same-literal) and
+// one real `it(...)`. The tautological spec must be flagged ineffective; the
+// real one must NOT be.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func tautologyTestServer(t *testing.T) *Server {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: "orders-v3",
+		Entities: []graph.Entity{
+			{
+				ID: "spec_bad", Name: "tautological",
+				Kind:          "SCOPE.Operation",
+				QualifiedName: "OrdersController.tautological",
+				Language:      "typescript",
+				SourceFile:    "orders.spec.ts", StartLine: 2, EndLine: 11,
+			},
+			{
+				ID: "spec_good", Name: "real_assertion",
+				Kind:          "SCOPE.Operation",
+				QualifiedName: "OrdersController.real_assertion",
+				Language:      "typescript",
+				SourceFile:    "orders.spec.ts", StartLine: 13, EndLine: 17,
+			},
+		},
+	}
+	srv := newTestServer(t, doc)
+	abs, err := filepath.Abs(filepath.Join("testdata", "tautology_4893"))
+	if err != nil {
+		t.Fatalf("abs testdata: %v", err)
+	}
+	srv.State.mu.Lock()
+	srv.State.groups["test"].Repos["orders-v3"].Path = abs
+	srv.State.mu.Unlock()
+	return srv
+}
+
+func specByID(specs []any, id string) map[string]any {
+	for _, s := range specs {
+		m, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["entity_id"] == id {
+			return m
+		}
+	}
+	return nil
+}
+
+func reasonSet(spec map[string]any) map[string]bool {
+	out := map[string]bool{}
+	fs, _ := spec["findings"].([]any)
+	for _, f := range fs {
+		m, _ := f.(map[string]any)
+		if r, ok := m["reason"].(string); ok {
+			out[r] = true
+		}
+	}
+	return out
+}
+
+func TestContractTestEffectiveness_FlagsTautological(t *testing.T) {
+	srv := tautologyTestServer(t)
+	// only_ineffective default (true): only the tautological spec should appear.
+	out := callToolArgs(t, srv.handleContractTestEffectiveness, map[string]any{
+		"group": "test",
+	})
+
+	specs, ok := out["specs"].([]any)
+	if !ok {
+		t.Fatalf("no specs array: %v", out)
+	}
+	bad := specByID(specs, "orders-v3::spec_bad")
+	if bad == nil {
+		t.Fatalf("tautological spec not flagged; specs=%v", specs)
+	}
+	if bad["verdict"] != "ineffective" {
+		t.Errorf("tautological verdict = %v, want ineffective", bad["verdict"])
+	}
+	rs := reasonSet(bad)
+	for _, want := range []string{"self_compare", "constant_true", "same_literal"} {
+		if !rs[want] {
+			t.Errorf("missing reason %q; got %v", want, rs)
+		}
+	}
+
+	// The real spec must NOT appear when only_ineffective is on.
+	if specByID(specs, "orders-v3::spec_good") != nil {
+		t.Errorf("real spec wrongly flagged ineffective")
+	}
+
+	if ic, _ := out["ineffective_specs"].(float64); ic != 1 {
+		t.Errorf("ineffective_specs = %v, want 1", out["ineffective_specs"])
+	}
+	if an, _ := out["analysed_specs"].(float64); an != 2 {
+		t.Errorf("analysed_specs = %v, want 2", out["analysed_specs"])
+	}
+}
+
+func TestContractTestEffectiveness_RealSpecNotFlagged(t *testing.T) {
+	srv := tautologyTestServer(t)
+	// only_ineffective=false: both specs returned; real one must be effective.
+	out := callToolArgs(t, srv.handleContractTestEffectiveness, map[string]any{
+		"group":            "test",
+		"only_ineffective": "false",
+	})
+	specs, _ := out["specs"].([]any)
+	good := specByID(specs, "orders-v3::spec_good")
+	if good == nil {
+		t.Fatalf("real spec missing when only_ineffective=false; specs=%v", specs)
+	}
+	if good["verdict"] != "effective" {
+		t.Errorf("real spec verdict = %v, want effective", good["verdict"])
+	}
+	if fs, _ := good["findings"].([]any); len(fs) != 0 {
+		t.Errorf("real spec has findings: %v", fs)
+	}
+}

--- a/internal/mcp/testdata/tautology_4893/orders.spec.ts
+++ b/internal/mcp/testdata/tautology_4893/orders.spec.ts
@@ -1,0 +1,18 @@
+describe('OrdersController', () => {
+  it('tautological — false-greens the parity gate', async () => {
+    const res = await request(app).get('/api/orders/1');
+    // self-compare: asserts the body against itself — can never fail.
+    assertBodyContract(res.body, res.body);
+    // constant-true: always passes.
+    expect(true).toBe(true);
+    // same-literal: expected == actual literal.
+    expect('ok').toBe('ok');
+  });
+
+  it('real assertion — genuinely checks behaviour', async () => {
+    const res = await request(app).get('/api/orders/1');
+    expect(res.status).toBe(200);
+    expect(res.body.statusCounts).toEqual(expected.statusCounts);
+    expect(res.body.id).toBe(1);
+  });
+});

--- a/internal/tautology/tautology.go
+++ b/internal/tautology/tautology.go
@@ -1,0 +1,395 @@
+// Package tautology implements the pure detection core for the
+// contract_test_effectiveness MCP tool (#4893, epic #4419).
+//
+// # The problem it solves
+//
+// A greenfield rewrite (group `v3`) is audited READ-ONLY against a behavioral
+// oracle. The parity gate trusts the v3's own test suite as a witness — a green
+// spec is taken as evidence the endpoint behaves. But some specs are
+// ORACLE-BLIND: they assert a value against ITSELF, assert a constant true, or
+// codify the WRONG expected shape as a literal. Such a spec is green no matter
+// what the handler does, so it FALSE-GREENS the parity gate. A real miss: a
+// `status_counts` dict→array shape drift PASSED because the spec asserted the
+// (wrong) array shape against the handler's array output — the assertion could
+// never fail.
+//
+// # The signal model
+//
+// This package takes a test's SOURCE TEXT (read by the caller from disk over
+// the entity's file+line span) and the assertion vocabulary for the test's
+// language/framework, and flags INEFFECTIVE assertions:
+//
+//   - self_compare    — both sides of an equality assertion are the SAME
+//     expression: expect(x).toBe(x), assertEquals(x, x),
+//     assertBodyContract(body, body). The assertion is a tautology.
+//   - constant_true   — a constant-true assertion: expect(true).toBe(true),
+//     assert True, assertTrue(true), expect(1).toBe(1). Always passes.
+//   - same_literal    — expected and actual are the SAME literal:
+//     expect("ok").toBe("ok"), assertEquals(200, 200). Always passes.
+//
+// And, best-effort and LOW confidence, a whole-spec signal:
+//
+//   - no_golden_linkage — the spec body never references the entity / endpoint
+//     it claims to test (no symbol the test is named for, no route literal).
+//     The caller supplies the linkage terms; this package only checks textual
+//     presence. Reported as a low-confidence advisory, never as a hard flag.
+//
+// # Conservatism
+//
+// The detector is regex/token based (no full parser) so it favours precision:
+// it only flags assertion forms it can match UNAMBIGUOUSLY, and it skips lines
+// inside comments. A spec with zero matched ineffective assertions is reported
+// effective. The whole-spec no_golden_linkage advisory never on its own makes a
+// spec "ineffective" — it is surfaced separately so a human can judge.
+package tautology
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Verdict is the per-spec classification.
+type Verdict string
+
+const (
+	// VerdictIneffective — the spec contains at least one tautological /
+	// oracle-blind assertion that cannot fail. The parity gate must NOT trust
+	// this spec as a witness.
+	VerdictIneffective Verdict = "ineffective"
+	// VerdictEffective — no tautological assertion was found; the spec's
+	// assertions can distinguish pass from fail.
+	VerdictEffective Verdict = "effective"
+	// VerdictUnknown — the test's language has no registered assertion
+	// vocabulary, or the source window was unreadable; no judgement made.
+	VerdictUnknown Verdict = "unknown"
+)
+
+// Reason categorises why an individual assertion is ineffective.
+type Reason string
+
+const (
+	ReasonSelfCompare  Reason = "self_compare"
+	ReasonConstantTrue Reason = "constant_true"
+	ReasonSameLiteral  Reason = "same_literal"
+)
+
+// Finding is one ineffective assertion located in a spec.
+type Finding struct {
+	Reason Reason `json:"reason"`
+	// Line is the 1-based source line (absolute, file-relative) of the
+	// assertion, computed by the caller's startLine offset.
+	Line int `json:"line"`
+	// Snippet is the trimmed source line that triggered the finding.
+	Snippet string `json:"snippet"`
+	// Detail is a short human note (e.g. the repeated expression / literal).
+	Detail string `json:"detail,omitempty"`
+}
+
+// Input is the per-spec analysis request.
+type Input struct {
+	// Language is the lowercased graph language (javascript, typescript,
+	// python, go, java, ruby, …). Selects the assertion vocabulary.
+	Language string
+	// Source is the verbatim test source over the entity's file+line span.
+	Source string
+	// StartLine is the 1-based file line of Source's first line, so findings can
+	// carry absolute line numbers. 1 when the whole file was passed.
+	StartLine int
+	// LinkageTerms are case-insensitive substrings the spec SHOULD reference if
+	// it genuinely tests its target (e.g. the tested function name, the route
+	// path "/api/orders"). Empty disables the no_golden_linkage advisory.
+	LinkageTerms []string
+}
+
+// Result is the per-spec verdict.
+type Result struct {
+	Verdict  Verdict   `json:"verdict"`
+	Findings []Finding `json:"findings"`
+	// NoGoldenLinkage is a low-confidence advisory: true when LinkageTerms were
+	// supplied AND none of them appears in the source. Never on its own sets
+	// VerdictIneffective.
+	NoGoldenLinkage bool `json:"no_golden_linkage"`
+	// Supported is false when the language has no assertion vocabulary; verdict
+	// is then Unknown and findings empty (honest-partial).
+	Supported bool `json:"supported"`
+}
+
+// Analyze scans one spec's source and returns its effectiveness verdict.
+func Analyze(in Input) Result {
+	vocab, ok := vocabFor(in.Language)
+	if !ok {
+		return Result{Verdict: VerdictUnknown, Supported: false}
+	}
+
+	start := in.StartLine
+	if start < 1 {
+		start = 1
+	}
+
+	findings := make([]Finding, 0)
+	lines := strings.Split(in.Source, "\n")
+	for i, raw := range lines {
+		line := stripLineComment(raw, vocab.lineComment)
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		abs := start + i
+		if f, ok := vocab.match(line); ok {
+			f.Line = abs
+			f.Snippet = strings.TrimSpace(raw)
+			findings = append(findings, f)
+		}
+	}
+
+	res := Result{Supported: true, Findings: findings}
+	if len(findings) > 0 {
+		res.Verdict = VerdictIneffective
+	} else {
+		res.Verdict = VerdictEffective
+	}
+	res.NoGoldenLinkage = computeNoGoldenLinkage(in.Source, in.LinkageTerms)
+	return res
+}
+
+// computeNoGoldenLinkage reports whether none of the linkage terms textually
+// appears in the source. Empty terms ⇒ false (advisory disabled).
+func computeNoGoldenLinkage(source string, terms []string) bool {
+	if len(terms) == 0 {
+		return false
+	}
+	low := strings.ToLower(source)
+	for _, t := range terms {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t == "" {
+			continue
+		}
+		if strings.Contains(low, t) {
+			return false
+		}
+	}
+	return true
+}
+
+// stripLineComment removes a trailing line comment so an assertion commented out
+// or annotated does not cause false matches. Best-effort: it does not track
+// string literals, so a comment marker inside a string can over-trim — acceptable
+// because that only makes the matcher MORE conservative (fewer flags).
+func stripLineComment(line, marker string) string {
+	if marker == "" {
+		return line
+	}
+	if i := strings.Index(line, marker); i >= 0 {
+		return line[:i]
+	}
+	return line
+}
+
+// ---------------------------------------------------------------------------
+// Assertion vocabularies (per language family)
+// ---------------------------------------------------------------------------
+
+// vocab is the set of compiled matchers for one language family.
+type vocab struct {
+	lineComment string
+	// constTrue matches a whole-line constant-true assertion.
+	constTrue []*regexp.Regexp
+	// pairForms extract the two compared operands of an equality assertion so
+	// the engine can test self-compare / same-literal. Each regexp must expose
+	// two capture groups (left, right).
+	pairForms []*regexp.Regexp
+}
+
+// match runs the vocabulary against one (comment-stripped) line.
+func (v vocab) match(line string) (Finding, bool) {
+	for _, re := range v.constTrue {
+		if re.MatchString(line) {
+			return Finding{Reason: ReasonConstantTrue, Detail: "constant-true assertion always passes"}, true
+		}
+	}
+	for _, re := range v.pairForms {
+		m := re.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		left := normalizeOperand(m[1])
+		right := normalizeOperand(m[2])
+		if left == "" || right == "" {
+			continue
+		}
+		if left == right {
+			if isLiteral(left) {
+				return Finding{Reason: ReasonSameLiteral, Detail: "expected == actual literal " + left}, true
+			}
+			return Finding{Reason: ReasonSelfCompare, Detail: "both sides are the same expression: " + left}, true
+		}
+	}
+	return Finding{}, false
+}
+
+// normalizeOperand trims surrounding whitespace and collapses internal spaces so
+// `foo .bar` and `foo.bar` compare equal, while preserving literal content.
+func normalizeOperand(s string) string {
+	s = strings.TrimSpace(s)
+	// Collapse runs of internal whitespace to a single space.
+	s = whitespaceRun.ReplaceAllString(s, " ")
+	// Remove spaces around member-access dots and call parens to canonicalise
+	// `obj . prop` vs `obj.prop`.
+	s = strings.ReplaceAll(s, " .", ".")
+	s = strings.ReplaceAll(s, ". ", ".")
+	return s
+}
+
+var whitespaceRun = regexp.MustCompile(`\s+`)
+
+// isLiteral reports whether an operand is a primitive literal (string, number,
+// true/false/null/None) rather than an identifier/expression. Used to label a
+// same-value match as same_literal vs self_compare.
+func isLiteral(s string) bool {
+	if s == "" {
+		return false
+	}
+	switch s {
+	case "true", "false", "null", "nil", "None", "True", "False", "undefined":
+		return true
+	}
+	if numberLit.MatchString(s) {
+		return true
+	}
+	if (strings.HasPrefix(s, "\"") && strings.HasSuffix(s, "\"")) ||
+		(strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'")) ||
+		(strings.HasPrefix(s, "`") && strings.HasSuffix(s, "`")) {
+		return true
+	}
+	return false
+}
+
+var numberLit = regexp.MustCompile(`^-?\d+(\.\d+)?$`)
+
+// operand is the regex fragment for one assertion operand inside a `(a, b)`
+// two-argument call: a chunk that does NOT contain a comma or paren, so the two
+// args split cleanly. Nested calls with commas are out of scope (they would not
+// be a self-compare we can prove anyway); a no-arg method call like `body.json`
+// without parens still matches.
+const operand = `([^,()]+?)`
+
+// exprOperand is the fragment for an operand of an infix `==` comparison, where
+// the two sides are NOT separated by a comma. It permits a single level of
+// balanced parens (so `resp.json()` is one operand) but no commas, keeping the
+// split unambiguous for the common `assert a.b() == a.b()` shape.
+const exprOperand = `([\w$.\[\]"'` + "`" + `]+(?:\([^()]*\))?(?:[\w$.\[\]]*)?)`
+
+// callArgs is the fragment for `(left, right)` two-argument assertions.
+const callArgs = `\(\s*` + operand + `\s*,\s*` + operand + `\s*\)`
+
+// vocabFor returns the assertion vocabulary for a graph language. The bool is
+// false for languages without a registered vocabulary (honest-partial).
+func vocabFor(lang string) (vocab, bool) {
+	switch strings.ToLower(strings.TrimSpace(lang)) {
+	case "javascript", "typescript", "js", "ts", "jsx", "tsx":
+		return jstsVocab, true
+	case "python", "py":
+		return pythonVocab, true
+	case "go", "golang":
+		return goVocab, true
+	case "java", "kotlin", "kt":
+		return javaVocab, true
+	case "ruby", "rb":
+		return rubyVocab, true
+	default:
+		return vocab{}, false
+	}
+}
+
+// --- JS/TS (Jest / vitest — the live NestJS spec style) ---
+//
+// expect(LEFT).toBe(RIGHT) / toEqual / toStrictEqual / toMatchObject /
+// toContainEqual. assertBodyContract(LEFT, RIGHT) is the custom contract helper
+// the live suite uses; we treat any `xxx(LEFT, RIGHT)` Contract/Equal helper as
+// a pair form too.
+var jstsVocab = vocab{
+	lineComment: "//",
+	constTrue: []*regexp.Regexp{
+		// expect(true|1|"...").toBe(true|1|"...") where both are the SAME truthy
+		// constant — the canonical no-op. Kept narrow to avoid flagging real
+		// boolean assertions like expect(x.ok).toBe(true).
+		regexp.MustCompile(`expect\(\s*(true|1)\s*\)\s*\.\s*(?:toBe|toEqual|toStrictEqual)\(\s*(true|1)\s*\)`),
+	},
+	pairForms: []*regexp.Regexp{
+		// expect(LEFT).toBe/toEqual/...(RIGHT)
+		regexp.MustCompile(`expect\(\s*` + operand + `\s*\)\s*\.\s*(?:toBe|toEqual|toStrictEqual|toMatchObject|toContainEqual)\(\s*` + operand + `\s*\)`),
+		// assertBodyContract(LEFT, RIGHT) and any *Contract / assertEqual* helper
+		// taking two args.
+		regexp.MustCompile(`(?:assertBodyContract|assertEqual|assertEquals|assertContract|expectEqual)` + callArgs),
+	},
+}
+
+// --- Python (pytest assert + unittest) ---
+var pythonVocab = vocab{
+	lineComment: "#",
+	constTrue: []*regexp.Regexp{
+		regexp.MustCompile(`^\s*assert\s+True\s*(?:#.*)?$`),
+		regexp.MustCompile(`^\s*assert\s+1\s*(?:==\s*1\s*)?$`),
+		regexp.MustCompile(`\bassertTrue\(\s*True\s*\)`),
+		regexp.MustCompile(`\bassertTrue\(\s*1\s*\)`),
+	},
+	pairForms: []*regexp.Regexp{
+		// assert LEFT == RIGHT
+		regexp.MustCompile(`^\s*assert\s+` + exprOperand + `\s*==\s*` + exprOperand + `\s*$`),
+		// self.assertEqual(LEFT, RIGHT)
+		regexp.MustCompile(`assertEqual` + callArgs),
+	},
+}
+
+// --- Go (testing — if got != want style + assert.Equal(t, a, b)) ---
+var goVocab = vocab{
+	lineComment: "//",
+	constTrue: []*regexp.Regexp{
+		regexp.MustCompile(`if\s+true\s*(?:!=\s*true\s*)?\{`),
+	},
+	pairForms: []*regexp.Regexp{
+		// assert.Equal(t, LEFT, RIGHT) / require.Equal(t, LEFT, RIGHT)
+		regexp.MustCompile(`(?:assert|require)\.Equal\(\s*[^,]+,\s*` + operand + `\s*,\s*` + operand + `\s*\)`),
+	},
+}
+
+// --- Java / Kotlin (JUnit / AssertJ) ---
+var javaVocab = vocab{
+	lineComment: "//",
+	constTrue: []*regexp.Regexp{
+		regexp.MustCompile(`assertTrue\(\s*true\s*\)`),
+		regexp.MustCompile(`assertThat\(\s*true\s*\)\s*\.\s*isTrue\(\)`),
+	},
+	pairForms: []*regexp.Regexp{
+		// assertEquals(LEFT, RIGHT)
+		regexp.MustCompile(`assertEquals` + callArgs),
+		// assertThat(LEFT).isEqualTo(RIGHT)
+		regexp.MustCompile(`assertThat\(\s*` + operand + `\s*\)\s*\.\s*isEqualTo\(\s*` + operand + `\s*\)`),
+	},
+}
+
+// --- Ruby (RSpec / minitest) ---
+var rubyVocab = vocab{
+	lineComment: "#",
+	constTrue: []*regexp.Regexp{
+		regexp.MustCompile(`expect\(\s*true\s*\)\s*\.\s*to\s+eq\(\s*true\s*\)`),
+		regexp.MustCompile(`expect\(\s*true\s*\)\s*\.\s*to\s+be_truthy`),
+		regexp.MustCompile(`assert\s+true\s*$`),
+	},
+	pairForms: []*regexp.Regexp{
+		// expect(LEFT).to eq(RIGHT) / to eql(RIGHT)
+		regexp.MustCompile(`expect\(\s*` + operand + `\s*\)\s*\.\s*to\s+eq(?:l)?\(\s*` + operand + `\s*\)`),
+		// assert_equal LEFT, RIGHT
+		regexp.MustCompile(`assert_equal\s+` + operand + `\s*,\s*` + operand + `\s*$`),
+	},
+}
+
+// SortFindings orders findings by line then reason for deterministic output.
+func SortFindings(fs []Finding) {
+	sort.SliceStable(fs, func(i, j int) bool {
+		if fs[i].Line != fs[j].Line {
+			return fs[i].Line < fs[j].Line
+		}
+		return fs[i].Reason < fs[j].Reason
+	})
+}

--- a/internal/tautology/tautology_test.go
+++ b/internal/tautology/tautology_test.go
@@ -1,0 +1,152 @@
+package tautology
+
+import "testing"
+
+func reasons(fs []Finding) map[Reason]int {
+	m := map[Reason]int{}
+	for _, f := range fs {
+		m[f.Reason]++
+	}
+	return m
+}
+
+func TestJSTS_SelfCompare(t *testing.T) {
+	r := Analyze(Input{
+		Language:  "typescript",
+		StartLine: 10,
+		Source:    "expect(body.statusCounts).toEqual(body.statusCounts);",
+	})
+	if r.Verdict != VerdictIneffective {
+		t.Fatalf("verdict = %s, want ineffective", r.Verdict)
+	}
+	if len(r.Findings) != 1 || r.Findings[0].Reason != ReasonSelfCompare {
+		t.Fatalf("findings = %+v, want one self_compare", r.Findings)
+	}
+	if r.Findings[0].Line != 10 {
+		t.Fatalf("line = %d, want 10", r.Findings[0].Line)
+	}
+}
+
+func TestJSTS_ConstantTrue(t *testing.T) {
+	r := Analyze(Input{Language: "javascript", Source: "  expect(true).toBe(true);"})
+	if r.Verdict != VerdictIneffective || reasons(r.Findings)[ReasonConstantTrue] != 1 {
+		t.Fatalf("want constant_true ineffective, got %s %+v", r.Verdict, r.Findings)
+	}
+}
+
+func TestJSTS_SameLiteral(t *testing.T) {
+	r := Analyze(Input{Language: "ts", Source: `expect("ok").toBe("ok");`})
+	if reasons(r.Findings)[ReasonSameLiteral] != 1 {
+		t.Fatalf("want same_literal, got %+v", r.Findings)
+	}
+}
+
+func TestJSTS_AssertBodyContract_SelfCompare(t *testing.T) {
+	r := Analyze(Input{Language: "typescript", Source: "assertBodyContract(res.body, res.body);"})
+	if r.Verdict != VerdictIneffective || reasons(r.Findings)[ReasonSelfCompare] != 1 {
+		t.Fatalf("want self_compare, got %s %+v", r.Verdict, r.Findings)
+	}
+}
+
+func TestJSTS_RealAssertion_NotFlagged(t *testing.T) {
+	src := `
+expect(res.status).toBe(200);
+expect(body.statusCounts).toEqual(expected.statusCounts);
+expect(user.isActive).toBe(true);
+`
+	r := Analyze(Input{Language: "typescript", Source: src})
+	if r.Verdict != VerdictEffective {
+		t.Fatalf("real assertions flagged: %s %+v", r.Verdict, r.Findings)
+	}
+}
+
+func TestJSTS_CommentedOutAssertionIgnored(t *testing.T) {
+	r := Analyze(Input{Language: "typescript", Source: "// expect(true).toBe(true);"})
+	if r.Verdict != VerdictEffective {
+		t.Fatalf("commented assertion flagged: %+v", r.Findings)
+	}
+}
+
+func TestPython_AssertTrue(t *testing.T) {
+	for _, src := range []string{"    assert True", "    self.assertTrue(True)"} {
+		r := Analyze(Input{Language: "python", Source: src})
+		if r.Verdict != VerdictIneffective {
+			t.Fatalf("python %q not flagged: %s", src, r.Verdict)
+		}
+	}
+}
+
+func TestPython_SelfCompareAndReal(t *testing.T) {
+	r := Analyze(Input{Language: "python", Source: "    assert resp.json() == resp.json()"})
+	if reasons(r.Findings)[ReasonSelfCompare] != 1 {
+		t.Fatalf("want self_compare, got %+v", r.Findings)
+	}
+	r2 := Analyze(Input{Language: "python", Source: "    assert resp.status_code == 200"})
+	if r2.Verdict != VerdictEffective {
+		t.Fatalf("real python assert flagged: %+v", r2.Findings)
+	}
+}
+
+func TestGo_AssertEqualSelfCompare(t *testing.T) {
+	r := Analyze(Input{Language: "go", Source: "\tassert.Equal(t, got.Body, got.Body)"})
+	if reasons(r.Findings)[ReasonSelfCompare] != 1 {
+		t.Fatalf("want self_compare, got %+v", r.Findings)
+	}
+}
+
+func TestJava_AssertEqualsSameLiteral(t *testing.T) {
+	r := Analyze(Input{Language: "java", Source: "        assertEquals(200, 200);"})
+	if reasons(r.Findings)[ReasonSameLiteral] != 1 {
+		t.Fatalf("want same_literal, got %+v", r.Findings)
+	}
+}
+
+func TestRuby_SelfCompare(t *testing.T) {
+	r := Analyze(Input{Language: "ruby", Source: "    expect(subject.body).to eq(subject.body)"})
+	if reasons(r.Findings)[ReasonSelfCompare] != 1 {
+		t.Fatalf("want self_compare, got %+v", r.Findings)
+	}
+}
+
+func TestUnsupportedLanguage(t *testing.T) {
+	r := Analyze(Input{Language: "cobol", Source: "anything"})
+	if r.Verdict != VerdictUnknown || r.Supported {
+		t.Fatalf("unsupported lang: %s supported=%v", r.Verdict, r.Supported)
+	}
+}
+
+func TestNoGoldenLinkage(t *testing.T) {
+	// Source references nothing from the linkage terms.
+	r := Analyze(Input{
+		Language:     "typescript",
+		Source:       "expect(res.status).toBe(200);",
+		LinkageTerms: []string{"createOrder", "/api/orders"},
+	})
+	if !r.NoGoldenLinkage {
+		t.Fatalf("expected no_golden_linkage advisory")
+	}
+	if r.Verdict != VerdictEffective {
+		t.Fatalf("no_golden_linkage must not make verdict ineffective: %s", r.Verdict)
+	}
+	// Now referencing one term clears the advisory.
+	r2 := Analyze(Input{
+		Language:     "typescript",
+		Source:       "createOrder(); expect(res.status).toBe(200);",
+		LinkageTerms: []string{"createOrder", "/api/orders"},
+	})
+	if r2.NoGoldenLinkage {
+		t.Fatalf("linkage term present, advisory should be off")
+	}
+}
+
+func TestMultipleFindingsSorted(t *testing.T) {
+	src := "expect(true).toBe(true);\nassertBodyContract(b, b);"
+	r := Analyze(Input{Language: "typescript", StartLine: 5, Source: src})
+	SortFindings(r.Findings)
+	if len(r.Findings) != 2 {
+		t.Fatalf("want 2 findings, got %+v", r.Findings)
+	}
+	if r.Findings[0].Line != 5 || r.Findings[1].Line != 6 {
+		t.Fatalf("lines not absolute/sorted: %+v", r.Findings)
+	}
+}


### PR DESCRIPTION
## What it detects

New MCP tool **`archigraph_contract_test_effectiveness`** — the spec-side sibling of `stub_detector` (#4425). Where stub_detector asks *"does the v3 handler COMPUTE?"*, this asks *"does the v3 SPEC actually CHECK?"*. It flags test/spec entities whose assertions are **oracle-blind / tautological** and therefore can never fail, so a green spec false-greens the parity gate (the `status_counts` dict→array shape drift PASSED because the spec codified the wrong shape).

From each spec's own source (read over its file+line span, comment-stripped):
- **`self_compare`** — both sides of an equality assertion are the same expression: `expect(x).toEqual(x)`, `assertEquals(x, x)`, `assertBodyContract(body, body)`.
- **`constant_true`** — `expect(true).toBe(true)`, `assert True`, `assertTrue(true)`.
- **`same_literal`** — expected == actual literal: `expect("ok").toBe("ok")`, `assertEquals(200, 200)`.
- **`no_golden_linkage`** (low-confidence advisory) — the spec never references its inbound-TESTS targets (their name / route path). Surfaced separately; never on its own makes a spec ineffective.

## How surfaced

A dedicated **MCP tool** mirroring stub_detector. Single-group (the spec/v3 group). Per analysed spec emits `{spec, entity_id, file, language, verdict (ineffective|effective|unknown), findings:[{reason,line,snippet,detail}], no_golden_linkage}`, plus `analysed_specs` / `ineffective_specs` counts. Optional `repo_filter`, `entity_id`, `only_ineffective` (default true — omits effective specs for token budget, allow-listed in the schema-contract gate per #1639). The parity gate / rewrite agent can consult the `ineffective` verdict to refuse to trust a spec as a witness.

Pure, unit-tested detection core lives in **`internal/tautology`** (regex/token based — favours precision, no full parser, skips comments).

## JS/TS first + per-framework generalize verdict

| Framework | Coverage |
|---|---|
| **JS/TS (Jest/vitest)** | first-class — `expect().toBe/toEqual/toStrictEqual/toMatchObject/toContainEqual`, `assertBodyContract`/`assertEqual*`/`*Contract` two-arg helpers, `expect(true).toBe(true)` |
| **Python (pytest/unittest)** | `assert L == R`, `assertEqual(L,R)`, `assert True`, `assertTrue(True)` |
| **Go (testing/testify)** | `assert.Equal(t, L, R)` / `require.Equal` self-compare + same-literal |
| **Java/Kotlin (JUnit/AssertJ)** | `assertEquals(L,R)`, `assertThat(L).isEqualTo(R)`, `assertTrue(true)`, `assertThat(true).isTrue()` |
| **Ruby (RSpec/minitest)** | `expect(L).to eq/eql(R)`, `assert_equal L, R`, `expect(true).to eq(true)/be_truthy` |
| **Other languages** | honest-partial → `verdict=unknown`, `supported=false`; never a false flag |

The common patterns (self-compare, const-true, same-literal) are generalised across the matrix via per-language assertion *vocabularies* in `internal/tautology`. Follow-ups for deeper, framework-specific coverage: PHPUnit/C#/Rust vocabularies; multi-line assertion spans (the scan is line-oriented today); resolving `assertBodyContract` aliases and custom matchers per-suite; wiring the verdict into the parity gate as a hard witness-rejection.

## Fixtures
- `internal/mcp/testdata/tautology_4893/orders.spec.ts` — one tautological `it()` (`assertBodyContract(res.body, res.body)` + `expect(true).toBe(true)` + `expect('ok').toBe('ok')`) flagged **ineffective**; one real `it()` (`expect(res.status).toBe(200)`, `toEqual(expected.statusCounts)`) **not** flagged.
- `internal/tautology/tautology_test.go` — per-language unit tests (self-compare, const-true, same-literal, real-assertion-not-flagged, commented-out ignored, no_golden_linkage advisory).

## Gates (sandbox HOME = `/tmp/agsbx-4893`)
- `go build ./...` ✅
- `go vet ./internal/tautology/ ./internal/mcp/` ✅
- `go test ./internal/mcp/` ✅ (full package — updated tool-count/minimalArgs/wantPresent/intentionalGaps registries)
- `go test ./internal/tautology/ ./internal/types/` ✅

No new entity Kind added (reuses existing operation kinds + the TESTS edge), so the new-extractor-Kind rule does not apply; `./internal/types/` ran clean regardless. No documented extraction capability changed, so no registry.json/coverage-docs update is required.

Closes #4893.

🤖 Generated with [Claude Code](https://claude.com/claude-code)