### PR TITLE
feat(#4883): flowchart depth-controlled interprocedural inlined CFG + endpoint verb/url header

### DIFF
--- a/internal/dashboard/v2_paths_control_flow.go
+++ b/internal/dashboard/v2_paths_control_flow.go
@@ -69,6 +69,15 @@ type v2CFGNode struct {
 	Condition string `json:"condition,omitempty"`
 	// Effects annotate a process node (data detail+).
 	Effects []v2CFGEffect `json:"effects,omitempty"`
+	// Func is the inlined-function frame this node belongs to (#4883), keyed by
+	// the per-hop frame id ("f0" = the handler, "f1"…= inlined callees). The
+	// frontend uses it to draw a group box / labelled divider per inlined hop.
+	// Empty/"f0" for the handler's own nodes (depth 1).
+	Func string `json:"func,omitempty"`
+	// External marks a call node whose in-repo callee could not be resolved /
+	// recursed into (a third-party / library / cross-repo call); it is a leaf
+	// terminal of the interprocedural CFG (#4883). The frontend badges these.
+	External bool `json:"external,omitempty"`
 }
 
 // v2CFGEdge is one directed control-flow edge between two node IDs. Kind is one
@@ -106,6 +115,30 @@ type v2ControlFlowResponse struct {
 	BranchCount int         `json:"branch_count"`
 	Nodes       []v2CFGNode `json:"nodes"`
 	Edges       []v2CFGEdge `json:"edges"`
+	// Depth echoes the resolved inline depth (#4883): 1 = handler CFG only,
+	// >=2 = callee CFGs inlined at in-repo call sites to that hop count.
+	Depth int `json:"depth"`
+	// Functions are the inlined-function frames (#4883), in inline order, so the
+	// UI can label each group box / divider. f0 is always the handler.
+	Functions []v2CFGFunction `json:"functions,omitempty"`
+}
+
+// v2CFGFunction describes one inlined-function frame in the interprocedural CFG
+// (#4883) so the renderer can delineate the boundary of each inlined hop.
+type v2CFGFunction struct {
+	// Func is the frame id ("f0","f1",…) matching v2CFGNode.Func.
+	Func string `json:"func"`
+	// Name is the function/method name.
+	Name string `json:"name"`
+	// Kind is the (scope-stripped) entity kind.
+	Kind string `json:"kind,omitempty"`
+	// File / Line locate the function definition.
+	File string `json:"file,omitempty"`
+	Line int    `json:"line,omitempty"`
+	// Depth is the inline hop this frame was spliced at (0 = handler).
+	Depth int `json:"depth"`
+	// Cyclomatic is this frame's own cyclomatic complexity.
+	Cyclomatic int `json:"cyclomatic_complexity,omitempty"`
 }
 
 // v2CFGHandler describes the handler function the CFG was built from.
@@ -150,6 +183,7 @@ func (s *Server) handleV2PathControlFlow(w http.ResponseWriter, r *http.Request)
 
 	q := r.URL.Query()
 	detail := normalizeCFGDetail(q.Get("detail"))
+	depth := normalizeCFGDepth(q.Get("depth"))
 	wantVerb := strings.ToUpper(strings.TrimSpace(q.Get("verb")))
 
 	// Resolve the endpoint root for (path hash, verb) — same resolver the
@@ -165,6 +199,7 @@ func (s *Server) handleV2PathControlFlow(w http.ResponseWriter, r *http.Request)
 		Path:   root.path,
 		Verb:   root.verb,
 		Detail: detail,
+		Depth:  depth,
 		Nodes:  []v2CFGNode{},
 		Edges:  []v2CFGEdge{},
 	}
@@ -198,16 +233,23 @@ func (s *Server) handleV2PathControlFlow(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// REUSE the one CFG builder (internal/substrate) — never reimplemented here.
-	g := substrate.BuildControlFlowGraphCached(dashPrefixedID(root.repo.Slug, handler.ID), lang, src, start)
-	resp.Supported = g.Supported
-	resp.Cyclomatic = g.Cyclomatic
-	resp.BranchCount = g.BranchCount
-	if !g.Supported {
+	// Build the INTERPROCEDURAL (inlined) CFG (#4883): the handler's own CFG at
+	// depth 1, then at each in-repo CALL site splice the callee's CFG, recursing
+	// to `depth`. The inliner REUSES the one substrate CFG builder per frame and
+	// the downstream-DAG's controller→service→repo CALLS resolution so the two
+	// surfaces never drift. depth==1 collapses to exactly the old single-function
+	// CFG.
+	in := newCFGInliner(grp, root.repo, depth)
+	combined := in.build(handler, lang, src, start, detail)
+	resp.Supported = combined.Supported
+	resp.Cyclomatic = combined.Cyclomatic
+	resp.BranchCount = combined.BranchCount
+	if !combined.Supported {
 		resp.Note = "flowchart not available for this language yet (validated: python, jsts); showing a degenerate graph."
 	}
-	resp.Nodes = cfgNodesToWire(g.Nodes, detail)
-	resp.Edges = cfgEdgesToWire(g.Edges)
+	resp.Nodes = combined.Nodes
+	resp.Edges = combined.Edges
+	resp.Functions = combined.Functions
 
 	writeV2JSON(w, http.StatusOK, v2OK(resp))
 }
@@ -305,6 +347,25 @@ func normalizeCFGDetail(s string) string {
 	default:
 		return "decisions"
 	}
+}
+
+// cfgMaxInlineDepth bounds the interprocedural inlining (#4883) so a deep /
+// recursive call graph can never blow the payload or the request budget. The
+// cycle-guard (visited-set) already prevents infinite recursion; this is the
+// belt-and-braces hop cap, matching the downstream-DAG's depth ceiling spirit.
+const cfgMaxInlineDepth = 8
+
+// normalizeCFGDepth clamps the inline-depth query param to [1, cfgMaxInlineDepth],
+// defaulting to 1 (handler-only CFG — the pre-#4883 behaviour).
+func normalizeCFGDepth(s string) int {
+	n := atoiSafe(strings.TrimSpace(s))
+	if n < 1 {
+		return 1
+	}
+	if n > cfgMaxInlineDepth {
+		return cfgMaxInlineDepth
+	}
+	return n
 }
 
 // cfgDetailRank gives a numeric ordering so the serialiser can gate fields by

--- a/internal/dashboard/v2_paths_control_flow_inline.go
+++ b/internal/dashboard/v2_paths_control_flow_inline.go
@@ -1,0 +1,447 @@
+// v2_paths_control_flow_inline.go — DEPTH-controlled INTERPROCEDURAL (inlined)
+// CFG for the Flowchart view (#4883, control-flow epic #4820).
+//
+// #4819 shipped the per-HANDLER CFG (one function's basic blocks). #4883 turns
+// the Flowchart into ONE continuous control-flow story from the HTTP entry down
+// the call chain:
+//
+//	Depth 1 — the endpoint handler's own CFG.
+//	Depth 2 — at each in-repo CALL site inside the handler, INLINE the callee's
+//	          CFG (the service method spliced in at the call node).
+//	Depth 3..n — keep following CALLS and inlining to the chosen depth.
+//
+// This is the flowchart sibling of the downstream-DAG's depth slider, and it
+// REUSES that surface's controller→service→repo CALLS resolution (the forward
+// adjacency over CALLS + the in-repo / external classification) so the two views
+// never disagree on which callee a call site binds to. Each frame's blocks come
+// from the SAME substrate.BuildControlFlowGraph builder #4819 uses — never a
+// reimplementation.
+//
+// Inlining mechanics. For a frame's CFG, each `process` node whose source line
+// invokes an in-repo callee is a SPLICE point: the callee's CFG is built and its
+// entry…exit is wired in place of the call node — the call node's predecessors
+// flow into the callee's start, and the callee's exit(s) flow on to the call
+// node's successors (continuation). Node ids are namespaced per frame ("f1:n3")
+// so frames never collide, and every node carries its frame id (Func) so the UI
+// can draw a group box / labelled divider per inlined hop.
+//
+// Boundaries / safety:
+//   - External, cross-repo, or library calls have no in-repo source → they are
+//     LEAF terminals (marked External), never recursed into.
+//   - A cycle-guard (visited entity-id set down the current spine) + the depth
+//     cap stop infinite / runaway recursion (recursive or mutually-recursive
+//     methods inline once on the path, then stop).
+//   - Detail gating is applied per frame exactly as the single-function CFG did.
+//
+// Branch-level granularity only (we do not extract deeper internal conditionals
+// than #4819 already does). Read-only, deterministic.
+
+package dashboard
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/substrate"
+)
+
+// cfgInlineResult is the assembled interprocedural CFG: wire nodes/edges (with
+// per-frame Func tags + External leaves), the combined complexity, and the
+// ordered inlined-function frames for boundary rendering.
+type cfgInlineResult struct {
+	Supported   bool
+	Cyclomatic  int
+	BranchCount int
+	Nodes       []v2CFGNode
+	Edges       []v2CFGEdge
+	Functions   []v2CFGFunction
+}
+
+// cfgInliner builds the inlined CFG, reusing the downstream-DAG's CALLS
+// resolution against the endpoint's own repo (the handler + its service/repo
+// chain live in the same repo as the endpoint, like the DAG walk).
+type cfgInliner struct {
+	grp      *DashGroup
+	repo     *DashRepo
+	maxDepth int
+
+	byID   map[string]*graph.Entity
+	byName map[string][]*graph.Entity // lower-cased in-repo name → defining entities
+	// callsOut maps an entity id → the in-repo callee entities it CALLS, in
+	// deterministic id order. External / unresolved callees are kept separately
+	// in extCallsOut so a call site to them renders as an External leaf.
+	callsOut map[string][]*graph.Entity
+	// extCallsOut maps an entity id → the short callee names it CALLS that are
+	// external / library / unresolved (no in-repo frame to descend into).
+	extCallsOut map[string][]string
+
+	detail string
+
+	frameSeq  int             // next frame id suffix
+	functions []v2CFGFunction // frames in inline order
+}
+
+// newCFGInliner indexes the endpoint repo's entities + CALLS adjacency once.
+func newCFGInliner(grp *DashGroup, repo *DashRepo, maxDepth int) *cfgInliner {
+	in := &cfgInliner{
+		grp:      grp,
+		repo:     repo,
+		maxDepth: maxDepth,
+		byID:        map[string]*graph.Entity{},
+		byName:      map[string][]*graph.Entity{},
+		callsOut:    map[string][]*graph.Entity{},
+		extCallsOut: map[string][]string{},
+	}
+	if repo == nil || repo.Doc == nil {
+		return in
+	}
+	for i := range repo.Doc.Entities {
+		e := &repo.Doc.Entities[i]
+		in.byID[e.ID] = e
+		if !isExternalEntity(e) {
+			if nm := strings.ToLower(strings.TrimSpace(e.Name)); nm != "" {
+				in.byName[nm] = append(in.byName[nm], e)
+			}
+		}
+	}
+	// Forward CALLS adjacency restricted to in-repo callees (the spine the
+	// inliner can actually descend into). Mirrors the downstream-DAG's CALLS
+	// edge harvest, minus the semantic side-edges (a CFG follows control flow,
+	// not data joins).
+	seen := map[string]map[string]bool{}
+	for i := range repo.Doc.Relationships {
+		r := &repo.Doc.Relationships[i]
+		if r.Kind != "CALLS" || r.FromID == r.ToID {
+			continue
+		}
+		callee := in.byID[r.ToID]
+		if callee == nil || isExternalEntity(callee) {
+			// External / unresolved → record its short name so the call site
+			// renders as an External leaf, but never descend into it.
+			nm := cfgShortCalleeName(recoverExternalName(r.ToID, dagOutEdge{kind: "CALLS", props: r.Properties}))
+			if nm != "" {
+				in.extCallsOut[r.FromID] = append(in.extCallsOut[r.FromID], nm)
+			}
+			continue
+		}
+		if seen[r.FromID] == nil {
+			seen[r.FromID] = map[string]bool{}
+		}
+		if seen[r.FromID][r.ToID] {
+			continue
+		}
+		seen[r.FromID][r.ToID] = true
+		in.callsOut[r.FromID] = append(in.callsOut[r.FromID], callee)
+	}
+	for k := range in.callsOut {
+		es := in.callsOut[k]
+		sort.Slice(es, func(i, j int) bool { return es[i].ID < es[j].ID })
+	}
+	for k := range in.extCallsOut {
+		sort.Strings(in.extCallsOut[k])
+	}
+	return in
+}
+
+// build assembles the interprocedural CFG rooted at the handler. src/start are
+// the handler's already-read source window (the caller did the path resolution
+// + read). detail gates each frame's node fields exactly as the single-function
+// CFG did. At depth 1 the result is the old single-function CFG (one frame).
+func (in *cfgInliner) build(handler *graph.Entity, lang, src string, start int, detail string) cfgInlineResult {
+	in.detail = detail
+	root := substrate.BuildControlFlowGraphCached(dashPrefixedID(in.repo.Slug, handler.ID), lang, src, start)
+
+	res := cfgInlineResult{Supported: root.Supported}
+	visited := map[string]bool{handler.ID: true}
+	frame := in.inline(handler, root, lang, 0, visited)
+
+	res.Nodes = frame.nodes
+	res.Edges = frame.edges
+	res.Functions = in.functions
+	// Combined complexity: sum the per-frame cyclomatic numbers minus the
+	// double-counted "+1" of every inlined frame beyond the first, so the
+	// number reads as the McCabe complexity of the flattened super-graph
+	// (decision points across all frames + 1).
+	totalBranches := 0
+	for _, f := range in.functions {
+		totalBranches += f.Cyclomatic - 1
+	}
+	res.BranchCount = totalBranches
+	res.Cyclomatic = totalBranches + 1
+	return res
+}
+
+// cfgFrame is one inlined function's contribution to the combined graph: its
+// (re-namespaced) nodes/edges, plus the frame's entry/exit ids so a parent call
+// site can wire predecessors→entry and exit→continuation.
+type cfgFrame struct {
+	nodes   []v2CFGNode
+	edges   []v2CFGEdge
+	entryID string   // the frame's start node id (namespaced)
+	exitIDs []string // node ids that flow OUT of the frame (the exit node)
+}
+
+// inline builds frame `g` for entity `ent` at `depth`, splicing every in-repo
+// call site (to depth maxDepth) with the callee's frame. visited guards cycles
+// down the current spine.
+func (in *cfgInliner) inline(ent *graph.Entity, g *substrate.ControlFlowGraph, lang string, depth int, visited map[string]bool) cfgFrame {
+	frameID := in.nextFrameID()
+	in.functions = append(in.functions, v2CFGFunction{
+		Func:       frameID,
+		Name:       ent.Name,
+		Kind:       dashStripScopePrefix(ent.Kind),
+		File:       ent.SourceFile,
+		Line:       ent.StartLine,
+		Depth:      depth,
+		Cyclomatic: g.Cyclomatic,
+	})
+
+	// Namespace this frame's node ids so frames never collide.
+	ns := func(id string) string { return frameID + ":" + id }
+	wireNodes := cfgNodesToWire(g.Nodes, in.detail)
+
+	// Index the substrate nodes by their (un-namespaced) id for call-site lookup.
+	rawByID := map[string]substrate.CFGNode{}
+	for _, n := range g.Nodes {
+		rawByID[n.ID] = n
+	}
+
+	// Resolve which call sites this frame can descend into: a process node whose
+	// source line invokes one of the entity's in-repo callees. callee resolution
+	// reuses the downstream-DAG adjacency (callsOut), matched to the call node by
+	// the callee name appearing in the node's source label.
+	callees := in.callsOut[ent.ID]
+	type spliceTarget struct {
+		nodeID string // namespaced call-node id being replaced
+		callee *graph.Entity
+	}
+	var splices []spliceTarget
+	// Splice only while a deeper hop remains (depth is 0-indexed: the handler is
+	// depth 0, so maxDepth=1 means handler-only, maxDepth=2 inlines one hop, …).
+	canRecurse := depth+1 < in.maxDepth
+	if canRecurse && len(callees) > 0 {
+		for _, n := range g.Nodes {
+			if n.Shape != substrate.ShapeProcess || n.Label == "" {
+				continue
+			}
+			callee := in.matchCallee(n.Label, callees, visited)
+			if callee == nil {
+				continue
+			}
+			splices = append(splices, spliceTarget{nodeID: n.ID, callee: callee})
+		}
+	}
+	spliceAt := map[string]*graph.Entity{}
+	for _, s := range splices {
+		spliceAt[s.nodeID] = s.callee
+	}
+
+	frame := cfgFrame{}
+	// Successor index (un-namespaced) for continuation wiring.
+	succ := map[string][]substrate.CFGEdge{}
+	for _, e := range g.Edges {
+		succ[e.From] = append(succ[e.From], e)
+	}
+
+	// Emit this frame's nodes, tagging Func; a spliced call node is replaced by
+	// the callee frame (we DON'T emit the call node itself — its inbound edges
+	// retarget to the callee entry and its outbound edges originate from the
+	// callee exits).
+	childFrames := map[string]cfgFrame{} // call-node id → built callee frame
+	for i, wn := range wireNodes {
+		raw := g.Nodes[i]
+		if callee, ok := spliceAt[raw.ID]; ok {
+			cf := in.buildCallee(callee, lang, depth+1, visited)
+			if cf == nil {
+				// Source unreadable / unsupported → keep the call node as an
+				// External leaf rather than dropping the flow.
+				wn.Func = frameID
+				wn.External = true
+				wn.ID = ns(wn.ID)
+				frame.nodes = append(frame.nodes, wn)
+				continue
+			}
+			childFrames[raw.ID] = *cf
+			frame.nodes = append(frame.nodes, cf.nodes...)
+			frame.edges = append(frame.edges, cf.edges...)
+			continue
+		}
+		wn.Func = frameID
+		wn.ID = ns(wn.ID)
+		if raw.Shape == substrate.ShapeProcess && in.isExternalCall(raw.Label, ent) {
+			wn.External = true
+		}
+		frame.nodes = append(frame.nodes, wn)
+	}
+
+	// Rewrite this frame's edges, redirecting endpoints that landed on a spliced
+	// call node to the corresponding callee entry (as a `to`) or exits (as a
+	// `from`).
+	resolveFrom := func(id string) []string {
+		if cf, ok := childFrames[id]; ok {
+			return cf.exitIDs
+		}
+		return []string{ns(id)}
+	}
+	resolveTo := func(id string) string {
+		if cf, ok := childFrames[id]; ok {
+			return cf.entryID
+		}
+		return ns(id)
+	}
+	for _, e := range g.Edges {
+		for _, from := range resolveFrom(e.From) {
+			frame.edges = append(frame.edges, v2CFGEdge{
+				From: from,
+				To:   resolveTo(e.To),
+				Kind: string(e.Kind),
+			})
+		}
+	}
+
+	// Frame entry/exit for the PARENT to wire to. The substrate start node is
+	// always "n0"; the end node is the ShapeEnd node. If n0 was itself spliced
+	// (cannot happen — start is never a process node) we'd fall back to its
+	// callee entry via resolveTo.
+	frame.entryID = resolveTo("n0")
+	for _, n := range g.Nodes {
+		if n.Shape == substrate.ShapeEnd {
+			frame.exitIDs = append(frame.exitIDs, resolveFrom(n.ID)...)
+		}
+	}
+	if len(frame.exitIDs) == 0 {
+		frame.exitIDs = []string{frame.entryID}
+	}
+	return frame
+}
+
+// buildCallee builds the callee's frame, reading its source window + building
+// its CFG, then recursing. Returns nil when the callee source is unreadable or
+// the language is unsupported (the caller then keeps the call node as a leaf).
+func (in *cfgInliner) buildCallee(callee *graph.Entity, lang string, depth int, visited map[string]bool) *cfgFrame {
+	if visited[callee.ID] {
+		return nil // cycle-guard: already on the spine.
+	}
+	src, start, ok := readCFGHandlerSource(in.grp, in.repo, callee)
+	if !ok {
+		return nil
+	}
+	cLang := substrate.LanguageForPath(callee.SourceFile)
+	g := substrate.BuildControlFlowGraphCached(dashPrefixedID(in.repo.Slug, callee.ID), cLang, src, start)
+	if !g.Supported {
+		return nil
+	}
+	visited[callee.ID] = true
+	frame := in.inline(callee, g, cLang, depth, visited)
+	delete(visited, callee.ID) // allow the callee to appear on a sibling path.
+	return &frame
+}
+
+// matchCallee returns the in-repo callee a process node's source line invokes,
+// or nil. A line "invokes" a callee when the callee's (short) name appears as a
+// call token in the line. Already-visited callees (cycle) are skipped so a
+// recursive call inlines once on the path, then stops. When several callees
+// match, the longest-named (most specific) wins, id-tiebroken — deterministic.
+func (in *cfgInliner) matchCallee(label string, callees []*graph.Entity, visited map[string]bool) *graph.Entity {
+	var best *graph.Entity
+	for _, c := range callees {
+		if visited[c.ID] {
+			continue
+		}
+		short := cfgShortCalleeName(c.Name)
+		if short == "" {
+			continue
+		}
+		if !cfgLabelInvokes(label, short) {
+			continue
+		}
+		if best == nil ||
+			len(short) > len(cfgShortCalleeName(best.Name)) ||
+			(len(short) == len(cfgShortCalleeName(best.Name)) && c.ID < best.ID) {
+			best = c
+		}
+	}
+	return best
+}
+
+// isExternalCall reports whether a process node's source line invokes a callee
+// that is NOT an in-repo definition this frame can descend into — a library /
+// builtin / cross-repo call recorded in extCallsOut. It must never mark an
+// in-repo call external (that would hide a real frame), so an in-repo callee on
+// the same line wins.
+func (in *cfgInliner) isExternalCall(label string, ent *graph.Entity) bool {
+	if !strings.Contains(label, "(") {
+		return false
+	}
+	for _, c := range in.callsOut[ent.ID] {
+		if cfgLabelInvokes(label, cfgShortCalleeName(c.Name)) {
+			return false // an in-repo callee is on this line — not external.
+		}
+	}
+	for _, nm := range in.extCallsOut[ent.ID] {
+		if cfgLabelInvokes(label, nm) {
+			return true
+		}
+	}
+	return false
+}
+
+// cfgShortCalleeName reduces a (possibly scoped) callee name to the bare method
+// token used at the call site: "InspectionRepo.find" → "find",
+// "svc::handle" → "handle".
+func cfgShortCalleeName(name string) string {
+	n := strings.TrimSpace(name)
+	if sc := strings.LastIndex(n, "::"); sc >= 0 && sc < len(n)-2 {
+		n = n[sc+2:]
+	}
+	if dot := strings.LastIndex(n, "."); dot >= 0 && dot < len(n)-1 {
+		n = n[dot+1:]
+	}
+	return n
+}
+
+// cfgLabelInvokes reports whether a source line invokes `name` as a call: the
+// name appears immediately followed by `(` (allowing whitespace), with a
+// non-identifier char (or start) before it so "find" does not match "refind".
+func cfgLabelInvokes(label, name string) bool {
+	if name == "" {
+		return false
+	}
+	idx := 0
+	for {
+		i := strings.Index(label[idx:], name)
+		if i < 0 {
+			return false
+		}
+		pos := idx + i
+		// Boundary before.
+		if pos > 0 && cfgIsIdentChar(label[pos-1]) {
+			idx = pos + len(name)
+			continue
+		}
+		// `(` after (skipping spaces).
+		j := pos + len(name)
+		for j < len(label) && (label[j] == ' ' || label[j] == '\t') {
+			j++
+		}
+		if j < len(label) && label[j] == '(' {
+			return true
+		}
+		idx = pos + len(name)
+	}
+}
+
+func cfgIsIdentChar(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}
+
+// nextFrameID returns the next per-hop frame id ("f0","f1",…).
+func (in *cfgInliner) nextFrameID() string {
+	id := "f" + itoa(in.frameSeq)
+	in.frameSeq++
+	return id
+}

--- a/internal/dashboard/v2_paths_control_flow_test.go
+++ b/internal/dashboard/v2_paths_control_flow_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -236,6 +237,168 @@ func TestControlFlow_DetailLevels(t *testing.T) {
 	if !anyLabel(full.Nodes) {
 		t.Errorf("full must carry node labels")
 	}
+}
+
+// makeInlineCFGFixture wires an endpoint whose handler CALLS an in-repo service
+// method, so the depth-controlled interprocedural inliner (#4883) has a callee
+// to splice:
+//
+//	GET /orders
+//	  <--IMPLEMENTS-- OrderController.list (handler)
+//	         --CALLS--> OrderService.fetch  (the callee, its own CFG)
+//
+// The handler body invokes `this.service.fetch(...)`; the callee body has its
+// own decision + return so the splice is observable (callee-only nodes appear).
+func makeInlineCFGFixture(t *testing.T) *DashGroup {
+	t.Helper()
+	root := t.TempDir()
+
+	handlerSrc := `async list(req, res) {
+  const rows = await this.service.fetch(req.query);
+  return res.json(rows);
+}
+`
+	// Callee lives lower in the same file. Its first line is line 6 (1-indexed):
+	// blank line 5 separates them.
+	calleeSrc := `
+async fetch(query) {
+  if (!query) {
+    throw new BadRequest("missing");
+  }
+  const rows = await this.repo.find(query);
+  return rows;
+}
+`
+	full := handlerSrc + calleeSrc
+	file := "order.controller.ts"
+	if err := os.WriteFile(filepath.Join(root, file), []byte(full), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	ent := func(id, name, kind string, start, end int) graph.Entity {
+		return graph.Entity{ID: id, Name: name, Kind: kind, SourceFile: file, StartLine: start, EndLine: end}
+	}
+	epEnt := graph.Entity{
+		ID: "ep", Name: "GET /orders", Kind: "http_endpoint_definition",
+		SourceFile: "routers.ts", StartLine: 1,
+		Properties: map[string]string{"verb": "GET", "path": "/orders"},
+	}
+	// Handler spans lines 1..4; callee `fetch` starts at line 6 (after the
+	// handler's 4 lines + 1 blank).
+	handler := ent("handler", "OrderController.list", "Operation", 1, 4)
+	callee := ent("callee", "OrderService.fetch", "Operation", 6, 13)
+
+	doc := &graph.Document{
+		Repo:     "api",
+		Entities: []graph.Entity{epEnt, handler, callee},
+		Relationships: []graph.Relationship{
+			{FromID: "handler", ToID: "ep", Kind: "IMPLEMENTS"},
+			{FromID: "handler", ToID: "callee", Kind: "CALLS"},
+		},
+	}
+	return &DashGroup{
+		Name:  "testgrp",
+		Repos: map[string]*DashRepo{"api": {Slug: "api", Path: root, Doc: doc}},
+	}
+}
+
+func fetchOrdersControlFlow(t *testing.T, ts *httptest.Server, query string) v2ControlFlowResponse {
+	t.Helper()
+	pathHash := hashStr("/orders")
+	url := ts.URL + "/api/v2/groups/testgrp/paths/" + pathHash + "/control-flow"
+	if query != "" {
+		url += "?" + query
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET control-flow: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool                  `json:"ok"`
+		Data v2ControlFlowResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return body.Data
+}
+
+// TestControlFlow_DepthInlining asserts the #4883 interprocedural behaviour:
+// depth=1 yields the handler-only CFG (one function frame, no callee nodes),
+// while depth>=2 splices the callee's CFG at the in-repo call site — the
+// callee's own decision/throw nodes appear and a second function frame is
+// reported with its boundary label.
+func TestControlFlow_DepthInlining(t *testing.T) {
+	ts := newPathsTestServer(t, makeInlineCFGFixture(t))
+	defer ts.Close()
+
+	// Depth 1 — handler only.
+	d1 := fetchOrdersControlFlow(t, ts, "depth=1&detail=full")
+	if !d1.Supported {
+		t.Fatalf("depth1: want supported; note=%q", d1.Note)
+	}
+	if d1.Depth != 1 {
+		t.Errorf("depth1: echo want 1, got %d", d1.Depth)
+	}
+	if len(d1.Functions) != 1 {
+		t.Errorf("depth1: want exactly one function frame, got %d", len(d1.Functions))
+	}
+	// The callee's `throw new BadRequest` line must NOT be present at depth 1.
+	if cfgAnyLabelContains(d1.Nodes, "BadRequest") {
+		t.Errorf("depth1: callee body must not be inlined")
+	}
+
+	// Depth 2 — callee spliced at the call site.
+	d2 := fetchOrdersControlFlow(t, ts, "depth=2&detail=full")
+	if !d2.Supported {
+		t.Fatalf("depth2: want supported; note=%q", d2.Note)
+	}
+	if d2.Depth != 2 {
+		t.Errorf("depth2: echo want 2, got %d", d2.Depth)
+	}
+	if len(d2.Functions) != 2 {
+		t.Fatalf("depth2: want two function frames (handler+callee), got %d: %+v", len(d2.Functions), d2.Functions)
+	}
+	// A frame for the inlined callee, tagged at depth 1.
+	var calleeFrame *v2CFGFunction
+	for i := range d2.Functions {
+		if d2.Functions[i].Name == "OrderService.fetch" {
+			calleeFrame = &d2.Functions[i]
+		}
+	}
+	if calleeFrame == nil {
+		t.Fatalf("depth2: no inlined frame for OrderService.fetch: %+v", d2.Functions)
+	}
+	if calleeFrame.Depth != 1 {
+		t.Errorf("depth2: callee frame depth want 1, got %d", calleeFrame.Depth)
+	}
+	// Callee body nodes must now appear (its throw), tagged with the callee frame.
+	var sawCalleeNode bool
+	for _, n := range d2.Nodes {
+		if n.Func == calleeFrame.Func && strings.Contains(n.Label, "BadRequest") {
+			sawCalleeNode = true
+		}
+	}
+	if !sawCalleeNode {
+		t.Errorf("depth2: callee body (throw BadRequest) not inlined under frame %q", calleeFrame.Func)
+	}
+	// Combined complexity must reflect BOTH frames' decision points.
+	if d2.Cyclomatic <= d1.Cyclomatic {
+		t.Errorf("depth2: combined cyclomatic (%d) must exceed handler-only (%d)", d2.Cyclomatic, d1.Cyclomatic)
+	}
+}
+
+func cfgAnyLabelContains(nodes []v2CFGNode, sub string) bool {
+	for _, n := range nodes {
+		if strings.Contains(n.Label, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // TestControlFlow_NoHandler asserts a graceful supported=false when no handler

--- a/webui-v2/src/components/flow-dag/Flowchart.tsx
+++ b/webui-v2/src/components/flow-dag/Flowchart.tsx
@@ -82,6 +82,9 @@ export interface FlowchartProps {
   pathHash?: string | null;
   verb?: string;
   detail: ControlFlowDetail;
+  /** #4883 — interprocedural inline depth (1 = handler CFG only; >=2 splices
+   *  callee CFGs at in-repo call sites). */
+  depth?: number;
   /** Whether the internal fetch is enabled (only when modal open + view active). */
   enabled?: boolean;
   className?: string;
@@ -99,12 +102,20 @@ function FlowchartInner({
   pathHash,
   verb,
   detail,
+  depth = 1,
   enabled = true,
   className,
 }: FlowchartProps) {
   const [direction, setDirection] = useState<FlowDagDirection>("TB");
 
-  const query = useControlFlow(groupId, pathHash ?? null, detail, verb, enabled);
+  const query = useControlFlow(
+    groupId,
+    pathHash ?? null,
+    detail,
+    depth,
+    verb,
+    enabled,
+  );
   const data: ControlFlowResponse | undefined = query.data;
   const isLoading = query.isLoading;
   const error = query.error;
@@ -114,8 +125,30 @@ function FlowchartInner({
   const built = useMemo(() => {
     if (!data || data.nodes.length === 0) return null;
     const handles = handlePositions(direction);
+
+    // #4883 — map each inlined-function frame id ("f0","f1",…) to a stable color
+    // index + its boundary label, so a node knows which hop it belongs to and the
+    // FIRST node of each inlined (non-handler) frame can show the divider label.
+    const frames = data.functions ?? [];
+    const frameIndexOf = new Map<string, number>();
+    const frameNameOf = new Map<string, string>();
+    frames.forEach((f, i) => {
+      frameIndexOf.set(f.func, i);
+      frameNameOf.set(f.func, f.name);
+    });
+    const seenFrame = new Set<string>();
+
     const nodes: RFNode<FlowchartNodeData>[] = data.nodes.map((n) => {
       const box = boxFor(n.shape);
+      const fid = n.func ?? "";
+      const frameIndex = frameIndexOf.get(fid) ?? 0;
+      // Label the boundary on the first node we encounter of each inlined frame
+      // (frame index > 0 = a spliced callee, not the handler).
+      let frameLabel: string | undefined;
+      if (fid && frameIndex > 0 && !seenFrame.has(fid)) {
+        seenFrame.add(fid);
+        frameLabel = frameNameOf.get(fid);
+      }
       return {
         id: n.id,
         type: FLOWCHART_NODE_TYPE,
@@ -132,6 +165,10 @@ function FlowchartInner({
           line: n.line,
           sourcePos: handles.source,
           targetPos: handles.target,
+          func: n.func,
+          frameIndex,
+          frameLabel,
+          external: n.external,
         },
       };
     });
@@ -260,12 +297,24 @@ function FlowchartInner({
           </span>
         )}
 
-        {data?.handler && (
+        {data && (data.path || data.verb) && (
           <span
-            className="ml-auto inline-flex items-center gap-1.5 text-xs text-text-3 font-mono truncate max-w-[45%]"
-            title={`${data.handler.name}${data.handler.file ? ` — ${data.handler.file}:${data.handler.line ?? ""}` : ""}`}
+            className="ml-auto inline-flex items-baseline gap-1.5 text-xs font-mono truncate max-w-[55%]"
+            title={
+              data.handler
+                ? `handler: ${data.handler.name}${data.handler.file ? ` — ${data.handler.file}:${data.handler.line ?? ""}` : ""}`
+                : `${data.verb} ${data.path}`
+            }
           >
-            <span className="font-semibold text-text-2 truncate">{data.handler.name}</span>
+            {/* #4883 — the header shows the ENDPOINT verb + path (like the Tree
+                view), with the handler function name as a subtitle. */}
+            {data.verb && (
+              <span className="font-semibold uppercase text-accent">{data.verb}</span>
+            )}
+            <span className="font-semibold text-text-2 truncate">{data.path}</span>
+            {data.handler && (
+              <span className="text-text-4 truncate">· {data.handler.name}</span>
+            )}
           </span>
         )}
       </div>

--- a/webui-v2/src/components/flow-dag/FlowchartNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowchartNode.tsx
@@ -33,6 +33,33 @@ export interface FlowchartNodeData extends Record<string, unknown> {
   /** Handle faces for the active layout direction. */
   sourcePos: Position;
   targetPos: Position;
+  /** #4883 — inlined-function frame id this node belongs to ("f0"=handler). */
+  func?: string;
+  /** #4883 — a 0-based color index for the node's frame (0 = handler, no tint). */
+  frameIndex?: number;
+  /** #4883 — set on the FIRST node of an inlined (non-handler) frame so the
+   *  renderer can label the boundary (e.g. "↳ OrderService.fetch"). */
+  frameLabel?: string;
+  /** #4883 — a call node whose callee is external/library (a leaf terminal). */
+  external?: boolean;
+}
+
+/** Per-frame accent colors for inlined-function boundaries (#4883). Index 0 is
+ *  the handler (no tint); inlined frames cycle through these. */
+const FRAME_COLORS = [
+  "transparent",
+  "var(--accent)",
+  "#7c9cff",
+  "#d4a72c",
+  "#3fb27f",
+  "#c678dd",
+  "#e06c75",
+  "#56b6c2",
+];
+
+function frameColor(idx: number | undefined): string {
+  if (!idx || idx <= 0) return "transparent";
+  return FRAME_COLORS[idx % FRAME_COLORS.length] || "var(--accent)";
 }
 
 /** Small icon per effect family so a process step badges "DB write" etc. */
@@ -80,8 +107,42 @@ function FlowchartNodeImpl({ data }: NodeProps) {
       ? "var(--accent)"
       : "var(--text-3)";
 
+  // #4883 — inlined-function frame tint: a colored left rail + optional boundary
+  // label on the frame's entry node, so a hop's nodes read as one group.
+  const fColor = frameColor(d.frameIndex);
+  const tinted = fColor !== "transparent";
+
   return (
     <div className="relative w-full h-full flex items-center justify-center">
+      {tinted && (
+        <span
+          className="absolute left-0 top-0 bottom-0 w-[3px] rounded-l"
+          style={{ background: fColor }}
+          aria-hidden
+        />
+      )}
+      {d.frameLabel && (
+        <span
+          className="absolute -top-4 left-0 inline-flex items-center gap-0.5 text-[8px] font-medium uppercase tracking-wide truncate max-w-[140%] pointer-events-none"
+          style={{ color: fColor }}
+          title={`inlined: ${d.frameLabel}`}
+        >
+          ↳ {d.frameLabel}
+        </span>
+      )}
+      {d.external && (
+        <span
+          className="absolute -top-3.5 right-0 rounded px-1 text-[8px] font-semibold uppercase tracking-wide border pointer-events-none"
+          style={{
+            color: "var(--text-4)",
+            borderColor: "var(--border)",
+            background: "var(--surface-2)",
+          }}
+          title="External / library call — control flow stops here"
+        >
+          ext
+        </span>
+      )}
       <Handle
         type="target"
         position={d.targetPos}

--- a/webui-v2/src/components/flow-dag/flowchart.test.ts
+++ b/webui-v2/src/components/flow-dag/flowchart.test.ts
@@ -83,4 +83,17 @@ describe("control-flow api detail mapping", () => {
     await api.getPathControlFlow("grp", "abc123", { detail: "decisions" });
     expect(String(fetchMock.mock.calls[0][0])).not.toContain("verb=");
   });
+
+  it("maps the inline depth into the control-flow query param (#4883)", async () => {
+    // depth=1 is the default (handler-only) → param omitted to keep the URL terse.
+    let fetchMock = mockFetch();
+    await api.getPathControlFlow("grp", "abc123", { detail: "decisions", depth: 1 });
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("depth=");
+    vi.restoreAllMocks();
+
+    // depth>=2 (inline callee CFGs) is sent.
+    fetchMock = mockFetch();
+    await api.getPathControlFlow("grp", "abc123", { detail: "decisions", depth: 3 });
+    expect(String(fetchMock.mock.calls[0][0])).toContain("depth=3");
+  });
 });

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -2676,6 +2676,25 @@ export interface ControlFlowNode {
   condition?: string;
   /** Side-effect annotations on process nodes — data detail and up. */
   effects?: ControlFlowEffect[];
+  /** Inlined-function frame this node belongs to (#4883), keyed by frame id
+   *  ("f0" = the handler, "f1"…= inlined callees). Drives the per-hop boundary
+   *  box / divider. Absent for a depth-1 (handler-only) graph. */
+  func?: string;
+  /** A call node whose in-repo callee couldn't be resolved/recursed into — an
+   *  external/library/cross-repo call rendered as a leaf terminal (#4883). */
+  external?: boolean;
+}
+
+/** One inlined-function frame in the interprocedural CFG (#4883) — lets the
+ *  renderer delineate each inlined hop's boundary. f0 is always the handler. */
+export interface ControlFlowFunction {
+  func: string;
+  name: string;
+  kind?: string;
+  file?: string;
+  line?: number;
+  depth: number;
+  cyclomatic_complexity?: number;
 }
 
 /** One directed control-flow edge between two node ids. */
@@ -2714,6 +2733,12 @@ export interface ControlFlowResponse {
   branch_count: number;
   nodes: ControlFlowNode[];
   edges: ControlFlowEdge[];
+  /** Resolved inline depth (#4883): 1 = handler CFG only, >=2 = callee CFGs
+   *  inlined at in-repo call sites to that hop count. */
+  depth?: number;
+  /** Inlined-function frames in inline order (#4883); f0 is the handler. Present
+   *  when depth >= 2 (or always at depth 1 as a single frame). */
+  functions?: ControlFlowFunction[];
 }
 
 // ---------------------------------------------------------------------------

--- a/webui-v2/src/hooks/use-paths.ts
+++ b/webui-v2/src/hooks/use-paths.ts
@@ -100,24 +100,29 @@ export const controlFlowQueryKey = (
   groupId: string,
   hash: string,
   detail: ControlFlowDetail,
+  depth: number,
   verb?: string,
-) => ["paths", groupId, "control-flow", hash, detail, verb ?? ""] as const;
+) => ["paths", groupId, "control-flow", hash, detail, depth, verb ?? ""] as const;
 
 /**
  * Fetch the endpoint handler's control-flow graph for the Flowchart view.
  * Enabled only when the modal is open and the Flowchart view is selected, so the
- * Tree view never pays for a CFG it isn't showing.
+ * Tree view never pays for a CFG it isn't showing. The #4883 `depth` param
+ * controls interprocedural inlining (1 = handler-only); TanStack caches each
+ * (detail, depth) pair so sliding either control back is instant.
  */
 export function useControlFlow(
   groupId: string,
   pathHash: string | null,
   detail: ControlFlowDetail,
+  depth: number,
   verb: string | undefined,
   enabled: boolean,
 ) {
   return useQuery({
-    queryKey: controlFlowQueryKey(groupId, pathHash ?? "", detail, verb),
-    queryFn: () => api.getPathControlFlow(groupId, pathHash!, { detail, verb }),
+    queryKey: controlFlowQueryKey(groupId, pathHash ?? "", detail, depth, verb),
+    queryFn: () =>
+      api.getPathControlFlow(groupId, pathHash!, { detail, depth, verb }),
     enabled: !!groupId && !!pathHash && enabled,
     staleTime: 60_000,
   });

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -557,11 +557,13 @@ export const api = {
   getPathControlFlow: (
     groupId: string,
     pathHash: string,
-    params?: { detail?: ControlFlowDetail; verb?: string },
+    params?: { detail?: ControlFlowDetail; verb?: string; depth?: number },
   ) => {
     const qs = new URLSearchParams();
     if (params?.detail) qs.set("detail", params.detail);
     if (params?.verb) qs.set("verb", params.verb);
+    // #4883: inline depth (call-hops to splice). 1 = handler CFG only.
+    if (params?.depth && params.depth > 1) qs.set("depth", String(params.depth));
     const suffix = qs.toString() ? `?${qs.toString()}` : "";
     return requestV2<ControlFlowResponse>(
       `/groups/${encodeURIComponent(groupId)}/paths/${encodeURIComponent(pathHash)}/control-flow${suffix}`,

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -900,6 +900,51 @@ function DetailSlider({
   );
 }
 
+/** The inline-depth range for the Flowchart Depth control (#4883). Depth 1 is
+ *  the handler CFG only; each step inlines one more hop of in-repo callees. The
+ *  ceiling mirrors the backend cfgMaxInlineDepth. */
+const CFG_MIN_DEPTH = 1;
+const CFG_MAX_DEPTH = 8;
+
+/** DepthSlider — the Flowchart-view Depth control (#4883). A discrete slider
+ *  mapping the inline call-hop count to the backend `depth` param. Independent
+ *  of the Detail slider (within-function granularity) and the Tree's own depth
+ *  control: this one inlines callee CFGs at each in-repo call site. */
+function DepthSlider({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (d: number) => void;
+}) {
+  const hint =
+    value <= 1
+      ? "Handler control flow only"
+      : `Inlines callee control flow ${value - 1} call-hop${value - 1 > 1 ? "s" : ""} deep`;
+  return (
+    <div className="inline-flex items-center gap-2">
+      <span className="text-[11px] text-text-4 uppercase tracking-wide">Depth</span>
+      <input
+        type="range"
+        min={CFG_MIN_DEPTH}
+        max={CFG_MAX_DEPTH}
+        step={1}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-28 accent-[var(--accent)] cursor-pointer"
+        aria-label="Flowchart inline depth"
+        title={hint}
+      />
+      <span
+        className="text-xs font-medium text-text-2 w-[88px] tabular-nums"
+        title={hint}
+      >
+        {value === 1 ? "Handler" : `Depth ${value}`}
+      </span>
+    </div>
+  );
+}
+
 function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathDetail; initialVerb?: string; groupId: string }) {
   const authForDetail = useAuthFor();
   // Real polyglot data can omit array/object fields entirely. Normalize once so
@@ -962,6 +1007,10 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
   // affects the Flowchart view (independent of the Tree's own depth control).
   const [flowView, setFlowView] = useState<"tree" | "flowchart">("tree");
   const [cfgDetail, setCfgDetail] = useState<ControlFlowDetail>("decisions");
+  // #4883 — interprocedural inline depth for the Flowchart view (1 = handler
+  // CFG only; >=2 splices callee CFGs at in-repo call sites). Separate control
+  // from cfgDetail (within-function granularity).
+  const [cfgDepth, setCfgDepth] = useState<number>(1);
   const dagVerb = verbFilter !== "all" ? verbFilter : detail.verbs[0];
 
   // Filter verb-scoped data. Backend slice fields can arrive as JSON null, so
@@ -1426,9 +1475,14 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
                 </button>
               </div>
 
-              {/* Detail slider — only meaningful for the Flowchart view. */}
+              {/* Depth + Detail sliders — only meaningful for the Flowchart
+                  view. Depth (#4883) inlines callee CFGs hop-by-hop; Detail
+                  (#4819) controls within-function granularity. */}
               {flowView === "flowchart" && (
-                <DetailSlider value={cfgDetail} onChange={setCfgDetail} />
+                <>
+                  <DepthSlider value={cfgDepth} onChange={setCfgDepth} />
+                  <DetailSlider value={cfgDetail} onChange={setCfgDetail} />
+                </>
               )}
             </div>
             {/* Maximize / restore toggle (#4479). Sits left of the Dialog's own
@@ -1459,6 +1513,7 @@ function DetailPane({ detail: rawDetail, initialVerb, groupId }: { detail: PathD
                 pathHash={detail.path_hash}
                 verb={dagVerb}
                 detail={cfgDetail}
+                depth={cfgDepth}
                 enabled={dagOpen && flowView === "flowchart"}
                 className="h-full"
               />


### PR DESCRIPTION
## What

Turns the Flowchart view into a **depth-controlled INTERPROCEDURAL (inlined) CFG** and fixes the header to show the endpoint verb/url. Deploy-deferred.

### Backend (`internal/dashboard`)
- New `depth` query param on `GET …/paths/{hash}/control-flow` (default 1). depth=1 → handler-only CFG (unchanged); depth>=2 inlines callee CFGs at each in-repo CALL site, recursing to the chosen hop count (cap 8).
- New `cfgInliner` (`v2_paths_control_flow_inline.go`) **reuses the downstream-DAG's controller→service→repo CALLS resolution** + in-repo/external classification, and the **one substrate CFG builder** per frame. For each `process` call-site whose source line invokes an in-repo callee, it splices the callee's `entry…exit` in place of the call node, wiring predecessors→entry and exit(s)→continuation.
- **Cycle handling:** a visited entity-id set down the current spine + the depth cap stop runaway / mutual recursion (a recursive call inlines once on the path, then stops). **External handling:** external/library/cross-repo/unreadable callees are leaf terminals (marked `external`), never recursed into.
- Response gains `depth`, per-frame `functions` (boundary labels + per-frame cyclomatic), per-node `func`/`external`, and a **combined** cyclomatic complexity for the flattened super-graph. Detail gating preserved per frame.

### Frontend (`webui-v2`)
- **Header:** now shows the endpoint **VERB + PATH** (like the Tree view); the handler function name is a subtitle.
- **Depth control:** new Depth slider, separate from the existing Detail slider, wired to the backend `depth` param; **TanStack-cached per (depth, detail)**.
- **Boundaries:** inlined frames delineated by a per-frame color rail + a `↳ <name>` boundary label on each frame's first node; external call leaves badged `ext`. Existing ELK canvas / diamond-terminal-loop shapes / centered handles unchanged; graceful `supported=false` state kept.

Branch-level granularity only.

### Gates
- Backend (sandbox HOME=/tmp/agsbx-4883, confirmed via `echo $HOME`): `go build ./...` ✅, `go vet ./internal/...` ✅, `go test ./internal/{substrate,dashboard,mcp,types}` ✅. New test `TestControlFlow_DepthInlining`: depth=1 → handler-only (one frame, callee body absent); depth=2 → callee CFG inlined at the call node (callee nodes present under a second frame, combined complexity rises).
- Frontend (real HOME): `tsc --noEmit` ✅, `npm run build` ✅, `vitest run` ✅ (159 unit tests pass; the 12 Playwright e2e specs fail to load under vitest pre-existing). New api test asserts the depth→param mapping.

Closes #4883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)