### PR TITLE
fix(#4884): IaC nesting actually takes effect — instance→resource parent_id stamped + frontend nests + fan-out dropped

### DIFF
--- a/internal/dashboard/handlers_iac.go
+++ b/internal/dashboard/handlers_iac.go
@@ -477,6 +477,28 @@ func joinModuleInstantiations(byID map[string]*IaCResource, slug string) {
 	sort.SliceStable(insts, func(i, j int) bool {
 		return insts[i].EntityID < insts[j].EntityID
 	})
+	// #4884 — track, per definition resource, the distinct envs that instantiate
+	// it and the FIRST instance (by entity id) that does. A single ParentID field
+	// can only name ONE instance, but the diagram is scoped to one ENV tab at a
+	// time (#4657) and each env renders only its OWN instances. If we lock
+	// ParentID to (say) the dev instance while the def also belongs to prod, then
+	// on the prod tab the def survives (env propagation) but its parent — the dev
+	// instance — is filtered out, so the frontend cannot resolve the container and
+	// the resource falls back to its definition zone with the fan-out edge intact
+	// (the live #4862 regression). So we only stamp ParentID when the def is
+	// instantiated within a SINGLE env (the parent is then guaranteed to render
+	// alongside it on that env's tab); for cross-env definitions we leave ParentID
+	// empty and let the frontend nest per-env from each rendered instance's
+	// instantiates edges (which DO survive env scoping). The instantiates relations
+	// below are emitted unconditionally so that per-env resolution always has the
+	// ownership data it needs.
+	type parentCand struct {
+		instID string
+		envs   map[string]struct{}
+		single bool // false once a second distinct env is seen → ambiguous
+	}
+	parentByDef := map[*IaCResource]*parentCand{}
+
 	for _, inst := range insts {
 		defs := defByDir[inst.DefinitionDir]
 		if len(defs) == 0 {
@@ -492,11 +514,19 @@ func joinModuleInstantiations(byID map[string]*IaCResource, slug string) {
 			if inst.Env != "" {
 				def.Env = mergeEnv(def.Env, inst.Env)
 			}
-			// #4862 — ownership-as-containment: record the instantiating module
-			// instance as the definition resource's container parent so the
-			// diagram nests it inside the module box (vs an instantiates edge).
-			if def.ParentID == "" {
-				def.ParentID = inst.EntityID
+			// #4884 — record candidate containment; resolved after the loop.
+			cand := parentByDef[def]
+			if cand == nil {
+				cand = &parentCand{instID: inst.EntityID, envs: map[string]struct{}{}, single: true}
+				parentByDef[def] = cand
+			}
+			for _, e := range splitEnv(inst.Env) {
+				if _, seen := cand.envs[e]; !seen {
+					if len(cand.envs) > 0 {
+						cand.single = false
+					}
+					cand.envs[e] = struct{}{}
+				}
 			}
 			inst.Relations = append(inst.Relations, IaCRelation{
 				Facet:          "instantiates",
@@ -518,6 +548,19 @@ func joinModuleInstantiations(byID map[string]*IaCResource, slug string) {
 				TargetEntityID: inst.EntityID,
 				Detail:         inst.DefinitionDir,
 			})
+		}
+	}
+
+	// #4884 — stamp ParentID only for single-env (unambiguous) containment so it
+	// never points at an instance that the active env tab filters out. Cross-env
+	// definitions keep ParentID empty and nest per-env via instantiates edges in
+	// the frontend.
+	for def, cand := range parentByDef {
+		if def.ParentID != "" {
+			continue
+		}
+		if cand.single {
+			def.ParentID = cand.instID
 		}
 	}
 }

--- a/internal/dashboard/handlers_iac_test.go
+++ b/internal/dashboard/handlers_iac_test.go
@@ -208,13 +208,18 @@ func TestJoinModuleInstantiations_ContainmentAndEnv(t *testing.T) {
 
 	joinModuleInstantiations(byID, "infra")
 
-	// FIRST instance by entity id ("infra/inst-dev" < "infra/inst-prod") wins
-	// containment of both definition resources.
-	if task.ParentID != dev.EntityID {
-		t.Fatalf("task.ParentID = %q, want %q", task.ParentID, dev.EntityID)
+	// #4884 — a definition instantiated across MORE THAN ONE env (dev + prod) is
+	// CROSS-ENV: a single ParentID cannot serve both env tabs (the diagram is
+	// env-scoped and each env renders only its own instances), so ParentID is left
+	// EMPTY and the frontend nests it per-env from each rendered instance's
+	// instantiates edges. (Before #4884 it locked to the first instance by entity
+	// id — "infra/inst-dev" — which the prod tab then filtered out, leaving the
+	// resource un-nested in its definition zone with the fan-out edge intact.)
+	if task.ParentID != "" {
+		t.Fatalf("task.ParentID = %q, want empty for cross-env def", task.ParentID)
 	}
-	if queue.ParentID != dev.EntityID {
-		t.Fatalf("queue.ParentID = %q, want %q", queue.ParentID, dev.EntityID)
+	if queue.ParentID != "" {
+		t.Fatalf("queue.ParentID = %q, want empty for cross-env def", queue.ParentID)
 	}
 
 	// Env propagated from BOTH instantiating envs onto the shared definitions.
@@ -244,6 +249,66 @@ func TestJoinModuleInstantiations_ContainmentAndEnv(t *testing.T) {
 	// instantiation keeps an empty ParentID.
 	if dev.ParentID != "" {
 		t.Fatalf("instance dev.ParentID = %q, want empty", dev.ParentID)
+	}
+
+	// #4884 — each env instance keeps an OUTBOUND instantiates edge to every def
+	// it instantiates, so the frontend can resolve containment per-env even when
+	// ParentID is empty. On the prod tab, only the prod instance + the (env=prod-
+	// inclusive) defs render; prod's instantiates edges name task + queue.
+	if got := countFacet(prod, "out"); got != 2 {
+		t.Fatalf("prod out instantiates = %d, want 2", got)
+	}
+	prodTargets := map[string]bool{}
+	for _, rel := range prod.Relations {
+		if rel.Facet == "instantiates" && rel.Direction == "out" {
+			prodTargets[rel.TargetEntityID] = true
+		}
+	}
+	if !prodTargets[task.EntityID] || !prodTargets[queue.EntityID] {
+		t.Fatalf("prod instantiates targets = %v, want both %q and %q",
+			prodTargets, task.EntityID, queue.EntityID)
+	}
+}
+
+// TestJoinModuleInstantiations_SingleEnvKeepsParentID is the #4884 control: a
+// definition instantiated within a SINGLE env DOES keep a ParentID (the parent
+// instance is guaranteed to render alongside it on that env's tab), so the
+// simple one-env stack still nests via the direct parent_id path. This mirrors
+// the live upvate-v3 shape where the directory-join (resolveModuleSourceDir →
+// iacModuleOf) produces matching dirs (e.g. infra/terraform/modules/worker-
+// service) so the join fires; the regression was purely the cross-env ParentID
+// pointing at a filtered-out instance.
+func TestJoinModuleInstantiations_SingleEnvKeepsParentID(t *testing.T) {
+	// Module dir as iacModuleOf would derive it for a real upvate-v3 def file
+	// infra/terraform/modules/worker-service/main.tf, and the matching
+	// definition_dir resolveModuleSourceDir derives from
+	// infra/terraform/envs/prod/main.tf + source ../../modules/worker-service.
+	const defDir = "infra/terraform/modules/worker-service"
+	prod := &IaCResource{
+		EntityID:      "infra/inst-prod",
+		Repo:          "infra",
+		Name:          "module.worker",
+		DefinitionDir: defDir,
+		Env:           "prod",
+	}
+	task := &IaCResource{
+		EntityID: "infra/def-task",
+		Repo:     "infra",
+		Name:     "aws_ecs_task_definition.worker",
+		Module:   defDir,
+	}
+	byID := map[string]*IaCResource{
+		prod.EntityID: prod,
+		task.EntityID: task,
+	}
+
+	joinModuleInstantiations(byID, "infra")
+
+	if task.ParentID != prod.EntityID {
+		t.Fatalf("single-env task.ParentID = %q, want %q", task.ParentID, prod.EntityID)
+	}
+	if task.Env != "prod" {
+		t.Fatalf("single-env task.Env = %q, want prod", task.Env)
 	}
 }
 

--- a/webui-v2/src/components/iac-diagram/layout.test.ts
+++ b/webui-v2/src/components/iac-diagram/layout.test.ts
@@ -235,6 +235,129 @@ describe("ownership-as-containment (#4862)", () => {
   });
 });
 
+/** #4884 — env-scoped containment fixture mirroring the live upvate-v3 prod tab:
+ *  ONE prod module instance whose definition resources are SHARED across envs, so
+ *  the backend left their parent_id EMPTY (cross-env). Only the prod instance is
+ *  rendered (the dev/staging instances were filtered out by the env tab). The
+ *  resources must still nest under the rendered prod instance — resolved from its
+ *  `instantiates` edges, NOT parent_id — and the fan-out must drop. */
+function crossEnvScopedFixture(): IaCReport {
+  const prod = res({
+    entity_id: "infra/inst-prod",
+    name: "module.worker",
+    category: "module",
+    module: "infra/terraform/envs/prod",
+    relations: [
+      rel({
+        facet: "instantiates",
+        kind: "INSTANTIATES",
+        target_entity_id: "infra/task",
+        target: "task",
+      }),
+      rel({
+        facet: "instantiates",
+        kind: "INSTANTIATES",
+        target_entity_id: "infra/queue",
+        target: "queue",
+      }),
+    ],
+  });
+  // Cross-env shared definitions: backend stamped NO parent_id (#4884).
+  const task = res({
+    entity_id: "infra/task",
+    name: "aws_ecs_task.worker",
+    module: "infra/terraform/modules/worker-service",
+    category: "compute",
+    relations: [
+      // mirror inbound instantiates edge from the instance.
+      rel({
+        facet: "instantiates",
+        kind: "INSTANTIATES",
+        direction: "in",
+        target_entity_id: "infra/inst-prod",
+        target: "module.worker",
+      }),
+      // a real resource→resource architectural edge — KEEP it.
+      rel({
+        facet: "dependency",
+        kind: "USES",
+        target_entity_id: "infra/queue",
+        target: "queue",
+      }),
+    ],
+  });
+  const queue = res({
+    entity_id: "infra/queue",
+    name: "aws_sqs_queue.work",
+    module: "infra/terraform/modules/worker-service",
+    category: "queue",
+    relations: [
+      rel({
+        facet: "instantiates",
+        kind: "INSTANTIATES",
+        direction: "in",
+        target_entity_id: "infra/inst-prod",
+        target: "module.worker",
+      }),
+    ],
+  });
+  return {
+    group: "g",
+    total_resources: 3,
+    total_grants: 0,
+    total_event_sources: 0,
+    total_dependencies: 1,
+    total_outputs: 0,
+    with_props_count: 0,
+    tools: ["terraform"],
+    envs: ["prod"],
+    counts_by_category: {},
+    groups: [{ tool: "terraform", count: 3, resources: [prod, task, queue] }],
+  };
+}
+
+describe("env-scoped containment (#4884)", () => {
+  it("nests cross-env definitions under the rendered instance via instantiates edges (no parent_id)", () => {
+    const { nodes, edges, unresolvedEdges } = layoutIaCDiagram(
+      crossEnvScopedFixture(),
+      "LR",
+      "module",
+    );
+    const groups = nodes.filter((n) => n.type === IAC_GROUP_TYPE);
+    const resources = nodes.filter((n) => n.type === IAC_NODE_TYPE);
+
+    // The defs carry NO parent_id, yet they still nest: one owner-instance
+    // container holds the prod instance + both definitions (resolved from the
+    // instance's instantiates edges).
+    expect(groups.length).toBe(1);
+    expect(resources.length).toBe(3);
+    const owner = groups[0];
+    expect(owner.id).toBe("group:instance:infra/inst-prod");
+    for (const r of resources) expect(r.parentId).toBe(owner.id);
+
+    // The two redundant instantiates fan-out edges are dropped; only the real
+    // task→queue architectural edge remains.
+    expect(edges.length).toBe(1);
+    expect(edges[0].source).toBe("infra/task");
+    expect(edges[0].target).toBe("infra/queue");
+    expect(unresolvedEdges).toBe(0);
+  });
+
+  it("ELK backend nests the same cross-env containment", async () => {
+    const { nodes, edges, unresolvedEdges } = await layoutIaCDiagramElk(
+      crossEnvScopedFixture(),
+      "LR",
+      "module",
+    );
+    const groups = nodes.filter((n) => n.type === IAC_GROUP_TYPE);
+    const resources = nodes.filter((n) => n.type === IAC_NODE_TYPE);
+    expect(groups.length).toBe(1);
+    expect(resources.length).toBe(3);
+    expect(edges.length).toBe(1);
+    expect(unresolvedEdges).toBe(0);
+  });
+});
+
 describe("layoutIaCDiagramElk (#4826 — ELK backend)", () => {
   it("produces the same nested-group render plan as dagre with finite positions", async () => {
     const { nodes, edges, unresolvedEdges } = await layoutIaCDiagramElk(

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -245,17 +245,46 @@ function planIaCDiagram(
   const byEntityId = new Map<string, IaCResource>();
   for (const r of resources) byEntityId.set(r.entity_id, r);
 
-  // #4862 — ownership-as-containment (Module mode only). A resource whose
-  // backend `parent_id` points at a RENDERED module instance is nested INSIDE
-  // that module's container box: its bucket is that instance's entity id rather
-  // than its source-file directory. The instance node itself is placed in the
-  // SAME bucket so the box visually wraps the module + everything it
-  // instantiates. The synthetic group is keyed by the instance entity id and
-  // labelled by the module name. Outside Module mode this is inert. We only
-  // honour a parent_id that resolves to a rendered node (else fall back to
-  // directory grouping so nothing disappears).
+  // #4884 — per-(rendered)-instance ownership map. The backend `parent_id`
+  // (#4862) names ONE instance, but the diagram is scoped to one ENV tab at a
+  // time and a shared module definition is instantiated by SEVERAL envs' module
+  // instances. On the prod tab the def survives (env-propagated) while its
+  // backend parent — e.g. the dev instance — is filtered out, so parent_id alone
+  // resolves to nothing and the resource falls back to its definition zone with
+  // the fan-out edge intact (the live #4862 regression). The cross-env case
+  // therefore stamps NO parent_id; instead each rendered module instance keeps an
+  // `instantiates` out-relation to every resource it instantiates, and those edges
+  // survive env scoping. We build the containment map from those edges so a
+  // definition nests under whichever instance is actually rendered on this tab.
+  // parent_id is honoured as a fallback for the single-env case (where it points
+  // at a co-rendered instance).
+  const ownerByResource = new Map<string, string>(); // resource entity_id → instance entity_id
+  if (groupMode === "module") {
+    for (const inst of resources) {
+      for (const rel of inst.relations) {
+        if (rel.direction !== "out" || rel.facet !== "instantiates") continue;
+        const target = rel.target_entity_id;
+        // Only the FIRST rendered instance to claim a resource owns it (a box has
+        // a single parent); later instances still surface their instantiates edge.
+        if (target && byEntityId.has(target) && !ownerByResource.has(target)) {
+          ownerByResource.set(target, inst.entity_id);
+        }
+      }
+    }
+  }
+  // #4862 — ownership-as-containment (Module mode only). A resource nested INSIDE
+  // its instantiating module's container box buckets under that instance's entity
+  // id rather than its source-file directory. The instance node itself is placed
+  // in the SAME bucket so the box visually wraps the module + everything it
+  // instantiates. We resolve the owner from the rendered instantiates edges
+  // (#4884, env-robust) and fall back to a parent_id that resolves to a rendered
+  // node (single-env case). Outside Module mode this is inert. We only honour an
+  // owner that resolves to a rendered node (else fall back to directory grouping
+  // so nothing disappears).
   const containedBy = (r: IaCResource): string | undefined => {
     if (groupMode !== "module") return undefined;
+    const owner = ownerByResource.get(r.entity_id);
+    if (owner && byEntityId.has(owner)) return owner;
     const pid = r.parent_id;
     if (pid && byEntityId.has(pid)) return pid;
     return undefined;


### PR DESCRIPTION
## Root cause (a vs b)

A frontend-resolution flavour of hypothesis **(b)**: **parent_id doesn't match a rendered module-instance node after the env tab filters the instance set.**

`#4862`'s `joinModuleInstantiations` stamped each shared module-**definition** resource's `parent_id` to the **first instance by entity id**. But the IaC diagram is scoped to **one env tab at a time** (`#4657`, `prod` auto-selected on load) and each env renders only its OWN instances. A definition instantiated across `dev` + `staging` + `prod` gets its env list propagated (so it survives the prod filter) but its `parent_id` points at the **dev** instance — which the prod tab filters OUT. The frontend's `byEntityId.has(parent_id)` then fails → the resource falls back to its definition zone and the redundant `instantiates` fan-out stays. That is exactly the live upvate-v3 prod regression: resources in def-zones, fan-out intact. The directory-join itself (`resolveModuleSourceDir` → `iacModuleOf`, both repo-relative, e.g. `infra/terraform/modules/worker-service`) was firing correctly — which is why the fan-out edges were drawn at all.

## The fix

**Backend** (`internal/dashboard/handlers_iac.go`): `joinModuleInstantiations` now stamps `parent_id` ONLY when a definition is instantiated within a **single env** (the parent is then guaranteed to co-render on that env's tab). For **cross-env** definitions `parent_id` is left **empty** — a single field cannot serve every env tab — and containment is deferred to the frontend. The `instantiates` relations (which survive env scoping) are emitted unconditionally so per-env resolution always has the ownership data.

**Frontend** (`iac-diagram/layout.ts`): Module mode resolves containment from each **rendered** instance's `instantiates` out-edges (env-robust), falling back to `parent_id` for the single-env case. A cross-env definition therefore nests under whichever instance is actually on screen for the active env, and its fan-out edge drops. The id format/prefix already matched (slug-prefixed `entity_id` both sides); the gap was the filtered-out parent.

## Live-shaped fixtures (fail on main, pass with fix)

- Backend `TestJoinModuleInstantiations_ContainmentAndEnv` updated to assert cross-env defs get **empty** `parent_id` — **fails on main** (`task.ParentID = "infra/inst-dev"`). New `TestJoinModuleInstantiations_SingleEnvKeepsParentID` control + a prod-instantiates-edge assertion mirroring the real `infra/terraform/{envs,modules}/...` upvate-v3 shape.
- Frontend `env-scoped containment (#4884)` suite: cross-env defs with **no** `parent_id` nest under the rendered prod instance via instantiates edges and the fan-out drops (dagre + ELK). Both new tests **fail without the layout fix**.

Does not touch Tier mode, `#4866` container styling, `#4887` centered handles, or `#4864` arch-edge resolution.

## Gates (sandbox HOME for go = `/tmp/agsbx-4884`, real HOME for npm)

```
HOME=/tmp/agsbx-4884   (confirmed via echo inside every go call)
go build ./...                          BUILD_OK
go vet ./internal/dashboard/...         VET_OK
go test ./internal/dashboard/...        ok (25.1s)
  fail-on-main verified by reverting handler: task.ParentID = "infra/inst-dev"
webui-v2 npx tsc --noEmit               TSC_OK
webui-v2 npm run build                  ✓ built
webui-v2 npx vitest run                 160 unit tests pass (12 e2e/*.spec Playwright
                                        collection failures pre-exist, unrelated)
  iac layout: 12 pass (+2 new); fail-on-main verified by reverting layout.ts
```

Closes #4884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)