### PR TITLE
feat(#4885): richer provider-agnostic IaC resource category catalog (Security/Observability/Messaging/…) + Tier legend

### DIFF
--- a/internal/engine/iac_resource_category_consistency_test.go
+++ b/internal/engine/iac_resource_category_consistency_test.go
@@ -74,8 +74,30 @@ func TestIaCCategory_Classifier_ValueTable(t *testing.T) {
 		// compute
 		{"aws_instance", types.IaCCategoryCompute},
 		{"AWS::ECS::Cluster", types.IaCCategoryCompute},
-		// other
-		{"aws_iam_policy_attachment_unknownthing", types.IaCCategoryOther},
+		{"AWS::ECS::Service", types.IaCCategoryCompute},
+		// security / identity (#4885) — IAM/KMS/ACM/Cognito across dialects
+		{"aws_iam_role", types.IaCCategorySecurity},
+		{"AWS::IAM::Role", types.IaCCategorySecurity},
+		{"iam.Role", types.IaCCategorySecurity},
+		{"aws_kms_key", types.IaCCategorySecurity},
+		{"AWS::KMS::Key", types.IaCCategorySecurity},
+		{"aws_acm_certificate", types.IaCCategorySecurity},
+		{"AWS::Cognito::UserPool", types.IaCCategorySecurity},
+		{"google_kms_crypto_key", types.IaCCategorySecurity},
+		// observability (#4885) — CloudWatch / X-Ray / GCP logging
+		{"aws_cloudwatch_log_group", types.IaCCategoryObservability},
+		{"AWS::Logs::LogGroup", types.IaCCategoryObservability},
+		{"aws_cloudwatch_metric_alarm", types.IaCCategoryObservability},
+		{"AWS::CloudWatch::Dashboard", types.IaCCategoryObservability},
+		{"aws_xray_sampling_rule", types.IaCCategoryObservability},
+		{"google_logging_metric", types.IaCCategoryObservability},
+		// Kubernetes samples — provider-agnostic catalog coverage
+		{"apps/v1/Deployment", types.IaCCategoryCompute},
+		{"v1/Service", types.IaCCategoryNetwork},
+		{"v1/Secret", types.IaCCategorySecret},
+		// other — genuine fallback only
+		{"aws_glue_crawler", types.IaCCategoryOther},
+		{"some_totally_unknown_resource", types.IaCCategoryOther},
 	}
 	for _, c := range cases {
 		if got := types.IaCResourceCategory(c.typeString); got != c.want {

--- a/internal/types/iac_resource_category.go
+++ b/internal/types/iac_resource_category.go
@@ -4,7 +4,8 @@ import "strings"
 
 // IaC resource categorization — the ONE shared classifier used by every IaC
 // extractor/detector in archigraph (Terraform/HCL, AWS CDK TS+JS+Python,
-// Pulumi TS+JS+Python, CloudFormation/SAM, and Azure Bicep). #3549, epic #3512.
+// Pulumi TS+JS+Python, CloudFormation/SAM, Serverless Framework, Kubernetes,
+// and Azure Bicep). #3549, #4885, epic #3512.
 //
 // # The consistency model (decided, applied everywhere)
 //
@@ -40,97 +41,158 @@ import "strings"
 //     changing the Kind would break edge resolution. The `resource_category`
 //     property gives uniform cross-tool semantics WITHOUT that risk.
 //
-// So: ONE classifier, ONE property name, applied to ALL FOUR tools; the CFN
-// entity Kind stays aligned because it is derived from the same classifier.
+// So: ONE classifier, ONE property name, applied to ALL tools; the CFN entity
+// Kind stays aligned because it is derived from the same classifier.
+//
+// # The catalog (#4885)
+//
+// The classifier is a DECLARATIVE, ORDERED CATALOG (iacCategoryCatalog below) —
+// a data table of {category, substrings} rules, not a giant switch. Each rule
+// lists provider-agnostic substrings (Terraform/Bicep/CDK/Pulumi/CFN/Serverless/
+// Kubernetes shapes) that map a resource-type string to a category. The first
+// rule whose substrings match (case-insensitive) wins, so ordering encodes
+// specificity. Adding a provider or a new resource type is a one-line table
+// edit; adding a category means a new constant + a catalog entry (+ its
+// frontend style/legend). "other" is the genuine fallback only.
 
 // IaC resource category constants — the closed set returned by
 // IaCResourceCategory. "other" is the fallback for anything unrecognised.
 const (
-	IaCCategoryDatastore = "datastore"
-	IaCCategoryQueue     = "queue"
-	IaCCategoryTopic     = "topic"
-	IaCCategoryStream    = "stream"
-	IaCCategoryFunction  = "function"
-	IaCCategoryCache     = "cache"
-	IaCCategorySecret    = "secret"
-	IaCCategoryNetwork   = "network"
-	IaCCategoryCompute   = "compute"
-	IaCCategoryStorage   = "storage"
-	IaCCategoryOther     = "other"
+	IaCCategoryDatastore     = "datastore"
+	IaCCategoryQueue         = "queue"
+	IaCCategoryTopic         = "topic"
+	IaCCategoryStream        = "stream"
+	IaCCategoryFunction      = "function"
+	IaCCategoryCache         = "cache"
+	IaCCategorySecret        = "secret"
+	IaCCategorySecurity      = "security"      // IAM / KMS / ACM / Cognito / security groups (#4885)
+	IaCCategoryObservability = "observability" // CloudWatch / X-Ray / GCP logging+monitoring (#4885)
+	IaCCategoryNetwork       = "network"
+	IaCCategoryCompute       = "compute"
+	IaCCategoryStorage       = "storage"
+	IaCCategoryOther         = "other"
 )
 
-// IaCResourceCategory maps an IaC resource type string — in ANY of the tool
-// dialects below — to one of the IaCCategory* constants. It is provider-aware
-// and matches case-insensitively on substrings so it tolerates the differing
-// shapes the tools use for the "same" resource:
+// iacCategoryRule is one declarative entry of the catalog: a category and the
+// provider-agnostic substrings that classify a resource-type string into it.
+type iacCategoryRule struct {
+	category string
+	// any returns the category when the (lower-cased) type contains ANY of these.
+	any []string
+}
+
+// iacCategoryCatalog is the ORDERED declarative catalog. Order encodes
+// specificity: more specific categories (cache/secret/security/observability/
+// stream/topic/queue/function) are listed BEFORE the broad datastore/storage/
+// compute/network buckets so e.g. an ElastiCache resource is `cache` not
+// `datastore`, an IAM role is `security` not `network`, and a CloudWatch alarm
+// is `observability` not `compute`.
+//
+// Each rule's substrings span the IaC dialects archigraph extracts:
 //
 //   - Terraform / OpenTofu:  aws_db_instance, azurerm_storage_account, google_sql_database_instance
 //   - Azure Bicep:           Microsoft.Sql/servers, Microsoft.ServiceBus/namespaces/queues
 //   - AWS CDK construct type: s3.Bucket, dynamodb.Table, sqs.Queue, lambda.Function, CfnDBInstance
 //   - Pulumi resource type:   aws.s3.Bucket, aws.rds.Instance, aws.sns.Topic, azure.storage.Account
 //   - CloudFormation/SAM:     AWS::RDS::DBInstance, AWS::SQS::Queue, AWS::Lambda::Function
-//
-// Ordering matters: more specific categories (cache/secret/stream/topic/queue/
-// function) are tested before the broad datastore/storage/compute/network
-// buckets so e.g. an ElastiCache resource is `cache`, not `datastore`, and an
-// SNS topic is `topic`, not `queue`.
-func IaCResourceCategory(typeString string) string {
-	t := strings.ToLower(typeString)
-	switch {
-	// --- cache (before datastore: elasticache/redis/memcached) ------------
-	case containsAny(t,
+//   - Serverless Framework:   AWS::* (CFN shapes) — covered by the CFN substrings
+//   - Kubernetes:             apps/v1/Deployment, v1/Service, v1/Secret, networking.k8s.io/Ingress
+var iacCategoryCatalog = []iacCategoryRule{
+	// --- cache (before datastore: elasticache/redis/memcached) ---------------
+	{IaCCategoryCache, []string{
 		"elasticache", "elasti_cache", "memorydb", "dax",
 		"aws_dax_", "::elasticache::", "::dax::", "::memorydb::",
 		"elasticache.", ".dax.", "memorydb.",
 		"microsoft.cache/", "/rediscache", "rediscache",
-		"google_redis_", "redis.", "memcache"):
-		return IaCCategoryCache
+		"google_redis_", "redis.", "memcache",
+	}},
 
-	// --- secret -----------------------------------------------------------
-	case containsAny(t,
+	// --- secret (vaults / managed secrets) -----------------------------------
+	{IaCCategorySecret, []string{
 		"secretsmanager", "secrets_manager", "::secretsmanager::",
 		"secretsmanager.", "aws_ssm_parameter",
 		"microsoft.keyvault/", "keyvault", "key_vault",
-		"google_secret_manager", "secretmanager.", ".secret"):
-		return IaCCategorySecret
+		"google_secret_manager", "secretmanager.", ".secret",
+		// Kubernetes Secret object.
+		"v1/secret", "/secret/", "core/v1/secret",
+	}},
 
-	// --- stream (kinesis / event hubs / pubsub streams) -------------------
-	case containsAny(t,
+	// --- security / identity (#4885: IAM / KMS / ACM / Cognito / SGs) ---------
+	{IaCCategorySecurity, []string{
+		// IAM (roles / policies / users / groups / attachments / instance profiles).
+		"aws_iam_", "::iam::", "iam.role", "iam.policy", "iam.user", "iam.group",
+		".iam.", "iamrole", "iampolicy", "iaminstanceprofile",
+		"managedpolicy", "policystatement", "rolepolicy",
+		// KMS (encryption keys).
+		"aws_kms_", "::kms::", "kms.key", "kms.alias", ".kms.", "kmskey",
+		// ACM (certificates).
+		"aws_acm_", "::certificatemanager::", "acm.certificate", "certificatemanager.",
+		"::acmpca::", "acm_certificate",
+		// Cognito (identity / user pools).
+		"aws_cognito_", "::cognito::", "cognito.", "userpool", "identitypool",
+		// WAF / Shield / GuardDuty / Inspector (perimeter security).
+		"aws_wafv2_", "aws_waf_", "::wafv2::", "::waf::", "wafv2.", "::guardduty::",
+		"guardduty.", "::inspector", "::shield::",
+		// Azure / GCP identity + key services.
+		"microsoft.authorization/", "microsoft.managedidentity/",
+		"google_kms_", "google_service_account", "google_project_iam",
+		"google_iam_", "serviceaccount.", "cryptokey",
+		// Kubernetes RBAC / ServiceAccount.
+		"rbac.authorization.k8s.io", "/role", "/rolebinding",
+		"/clusterrole", "/serviceaccount", "/networkpolicy",
+	}},
+
+	// --- observability (#4885: CloudWatch / X-Ray / logging / monitoring) -----
+	{IaCCategoryObservability, []string{
+		// CloudWatch log group / alarm / dashboard / metric / event rule.
+		"aws_cloudwatch", "::cloudwatch::", "cloudwatch.", ".cloudwatch.",
+		"loggroup", "log_group", "metricalarm", "::logs::", "logs.loggroup",
+		// X-Ray distributed tracing.
+		"aws_xray_", "::xray::", "xray.", "_xray", "samplingrule",
+		// Azure / GCP logging + monitoring.
+		"microsoft.insights/", "applicationinsights", "loganalytics",
+		"microsoft.operationalinsights/",
+		"google_logging_", "google_monitoring_", "logging.", "monitoring.",
+		"stackdriver",
+	}},
+
+	// --- stream (kinesis / event hubs / pubsub streams) ----------------------
+	{IaCCategoryStream, []string{
 		"kinesis", "::kinesis::", "kinesis.",
 		"aws_kinesis", "msk", "managedstreaming", "::msk::",
 		"microsoft.eventhub/", "eventhub",
-		"google_pubsub_lite", "kafka"):
-		return IaCCategoryStream
+		"google_pubsub_lite", "kafka",
+	}},
 
-	// --- topic (pub/sub fan-out) ------------------------------------------
-	case containsAny(t,
+	// --- topic (pub/sub fan-out) ---------------------------------------------
+	{IaCCategoryTopic, []string{
 		"aws_sns_topic", "::sns::", "sns.topic", "sns_topic",
 		".sns.", "snstopic",
 		"microsoft.eventgrid/", "eventgrid",
 		"/topics", "servicebustopic",
-		"google_pubsub_topic", "pubsub.topic"):
-		return IaCCategoryTopic
+		"google_pubsub_topic", "pubsub.topic",
+	}},
 
-	// --- queue ------------------------------------------------------------
-	case containsAny(t,
+	// --- queue ---------------------------------------------------------------
+	{IaCCategoryQueue, []string{
 		"aws_sqs_queue", "::sqs::", "sqs.queue", "sqs_queue", ".sqs.", "sqsqueue",
 		"aws_mq_", "::mq::", "amazonmq",
 		"microsoft.servicebus/", "servicebus", "/queues", "storagequeue",
 		"google_cloud_tasks", "cloudtasks",
-		"::events::eventbus", "eventbus", "google_pubsub_subscription"):
-		return IaCCategoryQueue
+		"::events::eventbus", "eventbus", "google_pubsub_subscription",
+	}},
 
-	// --- function (serverless) --------------------------------------------
-	case containsAny(t,
+	// --- function (serverless) -----------------------------------------------
+	{IaCCategoryFunction, []string{
 		"aws_lambda_function", "::lambda::function", "::serverless::function",
 		"lambda.function", "lambda_function", ".lambda.", "lambdafunction",
 		"cfnfunction",
 		"microsoft.web/sites/functions", "functionapp", "azurerm_function_app",
-		"google_cloudfunctions", "cloudfunction"):
-		return IaCCategoryFunction
+		"google_cloudfunctions", "cloudfunction",
+	}},
 
-	// --- datastore (databases + tables; tested before generic storage) ----
-	case containsAny(t,
+	// --- datastore (databases + tables; before generic storage) --------------
+	{IaCCategoryDatastore, []string{
 		"aws_db_instance", "aws_rds", "aws_db_cluster", "::rds::",
 		"aws_dynamodb", "::dynamodb::", "dynamodb.", "dynamodbtable",
 		"aws_redshift", "::redshift::", "redshift.",
@@ -145,46 +207,67 @@ func IaCResourceCategory(typeString string) string {
 		"google_sql_", "google_spanner", "google_bigtable", "google_firestore",
 		"sql.", "spanner.", "bigtable.", "firestore.",
 		"rds.databaseinstance", "rds.databasecluster",
-		"sql_database", "cosmosdb_account"):
-		return IaCCategoryDatastore
+		"sql_database", "cosmosdb_account",
+	}},
 
-	// --- storage (object/file/block; after datastore so DB tables win) ----
-	case containsAny(t,
+	// --- storage (object/file/block; after datastore so DB tables win) -------
+	{IaCCategoryStorage, []string{
 		"aws_s3_bucket", "::s3::bucket", "s3.bucket", "s3_bucket", ".s3.", "s3bucket",
 		"aws_efs", "::efs::", "efs.", "aws_fsx", "::fsx::",
 		"aws_ebs_volume", "::ec2::volume",
 		"microsoft.storage/", "storageaccount", "storage_account",
 		"google_storage_bucket", "storage.bucket",
-		"azurerm_storage", "blobcontainer", "/blobservices"):
-		return IaCCategoryStorage
+		"azurerm_storage", "blobcontainer", "/blobservices",
+		// Kubernetes persistent storage.
+		"persistentvolume", "/persistentvolumeclaim",
+	}},
 
-	// --- network ----------------------------------------------------------
-	case containsAny(t,
+	// --- network -------------------------------------------------------------
+	{IaCCategoryNetwork, []string{
 		"aws_vpc", "::ec2::vpc", "aws_subnet", "::ec2::subnet",
 		"aws_security_group", "::ec2::securitygroup",
 		"aws_route", "aws_internet_gateway", "aws_nat_gateway",
 		"aws_lb", "aws_alb", "aws_elb", "::elasticloadbalancing",
 		"aws_route53", "::route53::", "aws_api_gateway", "::apigateway",
+		"aws_cloudfront", "::cloudfront::", "cloudfront.",
 		"ec2.vpc", "ec2.subnet", "ec2.securitygroup", ".vpc.", "vpc.",
 		"microsoft.network/", "google_compute_network",
 		"google_compute_subnetwork", "google_compute_firewall",
-		"loadbalancer", "load_balancer"):
-		return IaCCategoryNetwork
+		"loadbalancer", "load_balancer",
+		// Kubernetes networking objects.
+		"networking.k8s.io", "/ingress", "/service", "v1/service",
+	}},
 
-	// --- compute (catch-all for VMs/containers/clusters; last) ------------
-	case containsAny(t,
+	// --- compute (catch-all for VMs/containers/clusters; last) ---------------
+	{IaCCategoryCompute, []string{
 		"aws_instance", "::ec2::instance", "ec2.instance",
 		"aws_ecs", "::ecs::", "ecs.", "aws_eks", "::eks::", "eks.",
 		"aws_autoscaling", "aws_batch", "::batch::",
 		"microsoft.compute/", "microsoft.containerservice/", "microsoft.app/",
 		"microsoft.web/sites", "appservice",
 		"google_compute_instance", "google_container_cluster",
-		"compute.instance", "fargate", "virtualmachine"):
-		return IaCCategoryCompute
+		"google_cloud_run", "cloudrun", "run.",
+		"compute.instance", "fargate", "virtualmachine",
+		// Kubernetes workloads.
+		"apps/v1", "/deployment", "/statefulset", "/daemonset",
+		"/replicaset", "/pod", "batch/v1", "/job", "/cronjob",
+	}},
+}
 
-	default:
-		return IaCCategoryOther
+// IaCResourceCategory maps an IaC resource type string — in ANY of the tool
+// dialects the catalog covers — to one of the IaCCategory* constants. It walks
+// the declarative iacCategoryCatalog in order and returns the first matching
+// rule's category; "other" if none match. Matching is case-insensitive on
+// substrings, tolerating the differing shapes the tools use for the "same"
+// resource.
+func IaCResourceCategory(typeString string) string {
+	t := strings.ToLower(typeString)
+	for i := range iacCategoryCatalog {
+		if containsAny(t, iacCategoryCatalog[i].any...) {
+			return iacCategoryCatalog[i].category
+		}
 	}
+	return IaCCategoryOther
 }
 
 // IaCKindForCategory maps a resource_category to the semantic SCOPE.* entity

--- a/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
@@ -59,10 +59,15 @@ const edgeTypes: EdgeTypes = { [IAC_EDGE_TYPE]: IaCEdge };
 const LEGEND_CATEGORIES = [
   "compute",
   "datastore",
+  "storage",
   "queue",
+  "topic",
   "function",
   "network",
+  "security",
+  "observability",
   "secret",
+  "cache",
   "other",
 ];
 

--- a/webui-v2/src/components/iac-diagram/categoryStyle.test.ts
+++ b/webui-v2/src/components/iac-diagram/categoryStyle.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { categoryStyle } from "./categoryStyle";
+
+// Mirrors the backend catalog (#4885): the richer provider-agnostic categories
+// must each resolve to a distinct, on-theme style; unknowns fall back to "other".
+describe("categoryStyle (#4885 richer catalog)", () => {
+  it("resolves the new Security/Identity category", () => {
+    const s = categoryStyle("security");
+    expect(s.key).toBe("security");
+    expect(s.label).toBe("Security");
+    expect(s.color).toContain("var(");
+  });
+
+  it("resolves the new Observability category", () => {
+    const s = categoryStyle("observability");
+    expect(s.key).toBe("observability");
+    expect(s.label).toBe("Observability");
+    expect(s.color).toContain("var(");
+  });
+
+  it("is case-insensitive and trims empties to other", () => {
+    expect(categoryStyle("SECURITY").key).toBe("security");
+    expect(categoryStyle("").key).toBe("other");
+    expect(categoryStyle(undefined).key).toBe("other");
+  });
+
+  it("falls back to Other for an unknown category", () => {
+    const s = categoryStyle("totally_unknown");
+    expect(s.key).toBe("totally_unknown");
+    expect(s.label).toBe("Other");
+  });
+
+  it("keeps the established categories intact", () => {
+    expect(categoryStyle("datastore").label).toBe("Datastore");
+    expect(categoryStyle("compute").label).toBe("Compute");
+    expect(categoryStyle("messaging").label).toBe("Other"); // not a backend category name
+  });
+});

--- a/webui-v2/src/components/iac-diagram/categoryStyle.ts
+++ b/webui-v2/src/components/iac-diagram/categoryStyle.ts
@@ -2,8 +2,9 @@
    components/iac-diagram/categoryStyle.ts — resource_category styling.
 
    The single cross-tool join key every IaC tool emits is resource_category
-   (datastore/queue/topic/stream/function/cache/secret/network/compute/
-   storage/other — see internal/types/iac_resource_category.go). The
+   (datastore/queue/topic/stream/function/cache/secret/security/observability/
+   network/compute/storage/other — see internal/types/iac_resource_category.go).
+   The catalog (#4885) is provider-agnostic; this table mirrors its categories. The
    architecture diagram (#4526) colors + icons each resource node by that
    category so a modularized stack reads at a glance. Colors reference the
    theme CSS vars (tone palette) used elsewhere in the dashboard rather than
@@ -22,6 +23,8 @@ import {
   Boxes,
   KeyRound,
   Package,
+  ShieldCheck,
+  Activity,
   type LucideIcon,
 } from "lucide-react";
 
@@ -48,6 +51,10 @@ const STYLES: Record<string, Omit<CategoryStyle, "key">> = {
   stream: { label: "Stream", Icon: Waves, color: "var(--warning)", tint: "var(--warning-bg, rgba(210,153,34,0.12))" },
   function: { label: "Function", Icon: Zap, color: "var(--accent)", tint: "var(--accent-bg, rgba(124,108,255,0.14))" },
   secret: { label: "Secret", Icon: KeyRound, color: "var(--danger)", tint: "var(--danger-bg, rgba(248,81,73,0.12))" },
+  // #4885 — Security/Identity (IAM/KMS/ACM/Cognito/SGs) shares the danger tone with secret.
+  security: { label: "Security", Icon: ShieldCheck, color: "var(--danger)", tint: "var(--danger-bg, rgba(248,81,73,0.12))" },
+  // #4885 — Observability (CloudWatch/X-Ray/logging+monitoring) on the accent tone.
+  observability: { label: "Observability", Icon: Activity, color: "var(--accent)", tint: "var(--accent-bg, rgba(124,108,255,0.14))" },
   network: { label: "Network", Icon: Network, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
   compute: { label: "Compute", Icon: Cpu, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },
   storage: { label: "Storage", Icon: HardDrive, color: "var(--success)", tint: "var(--success-bg, rgba(63,185,80,0.12))" },


### PR DESCRIPTION
## What & why

Replaces the coarse IaC `resource_category` derivation with a **richer, declarative, provider-agnostic CATALOG** so IAM→**Security/Identity**, CloudWatch→**Observability**, etc. show up distinctly in the Tier view + legend instead of collapsing into **Other**. Deploy-deferred. Closes #4885.

## The declarative catalog (where it lives + how extensible)

`internal/types/iac_resource_category.go` — the ONE shared classifier used by every IaC extractor/detector (HCL/Terraform, CDK, Pulumi, CFN/SAM, Serverless, Bicep, Kubernetes).

`IaCResourceCategory` was a giant `switch`. It's now a **data table** — `iacCategoryCatalog []iacCategoryRule{ category, any []string }` — walked in order; the first rule whose substrings match (case-insensitive) wins. **Order encodes specificity.** Adding a provider/type = a one-line edit to a rule's `any` slice; adding a category = a new constant + one catalog entry (+ a frontend style/legend row). No switch to grow.

### New categories (#4885)
- **security** — IAM role/policy/user/group/attachment/instance-profile, KMS, ACM/PCA, Cognito user/identity pools, WAF/Shield/GuardDuty/Inspector; Azure `Microsoft.Authorization`/`ManagedIdentity`, GCP `google_kms_*`/`google_*_iam_*`/service accounts; K8s RBAC Role/RoleBinding/ClusterRole/ServiceAccount/NetworkPolicy.
- **observability** — CloudWatch log group/alarm/dashboard/metric, X-Ray; Azure `Microsoft.Insights`/AppInsights/LogAnalytics, GCP `google_logging_*`/`google_monitoring_*`/stackdriver.

Specificity ordering ensures IAM→security (not network), CloudWatch→observability (not compute), ElastiCache→cache (not datastore). Existing fine-grained messaging categories (queue/topic/stream) are kept (more granular than a single "Messaging" bucket and backward-compatible). **Other** remains the genuine fallback only.

### Providers covered
AWS via Terraform/HCL, AWS CDK (TS/JS/Py), Pulumi (TS/JS/Py), CloudFormation/SAM, Serverless Framework (CFN shapes), Azure Bicep, GCP (Terraform google_*), and Kubernetes object kinds.

## Consumers updated
- **Tier grouping** — derives from `resource_category` (engine/dashboard) → new categories flow through automatically.
- **Legend** (`webui-v2/src/components/iac-diagram/IaCDiagram.tsx`) — broadened to include security/observability/storage/topic/cache.
- **#4866 per-category container tint** + **#4862 categoryKey** — both go through `categoryStyle.ts`, now with `security` (ShieldCheck, danger tone) and `observability` (Activity, accent tone) styles. `dominantCategory` is data-driven so it picks up new categories with no change.
- H/V + Module/Tier toggles, nesting (#4884), centered handles (#4887) untouched.

## Tests
- Backend value table (`internal/engine/iac_resource_category_consistency_test.go`): `aws_iam_role`→security, `aws_cloudwatch_log_group`→observability, `aws_ecs_service`→compute, `aws_sqs_queue`→queue; GCP `google_kms_crypto_key`→security, `google_logging_metric`→observability; **Kubernetes** `apps/v1/Deployment`→compute, `v1/Service`→network, `v1/Secret`→secret; unknown→other.
- New `webui-v2/src/components/iac-diagram/categoryStyle.test.ts` asserts security/observability styles, case-insensitivity, and Other fallback.

## Gates (sandbox HOME for go; real HOME for npm)
Sandbox HOME confirmed: `echo "$HOME"` → `/tmp/agsbx-4885`.
- `go build ./...` → BUILD_OK
- `go vet ./internal/{types,engine,dashboard}/...` → VET_OK
- `go test ./internal/{types,engine,dashboard}/...` → all ok
- `cd webui-v2 && tsc --noEmit` → exit 0; `npm run build` → built; `vitest run src/components/iac-diagram` → 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)