### PR TITLE
feat(#4331): wire M5 BuildIndexFromModules behind a default-OFF flag + edge-parity harness

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -3871,6 +3871,19 @@ func (i *Indexer) foldFileComponentDuplicates(
 	return out, pass2Rels, stats
 }
 
+// useModuleResolveIndex reports whether the M5 per-module resolver index
+// (resolve.BuildIndexFromModulesOrdered) should be used in place of the flat
+// resolve.BuildIndex. Controlled by ARCHIGRAPH_RESOLVE_MODULE_INDEX; DEFAULT
+// OFF (#4331). Truthy values: "1", "true", "yes", "on" (case-insensitive).
+func useModuleResolveIndex() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ARCHIGRAPH_RESOLVE_MODULE_INDEX"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 // buildDocument merges entity records from every pass, dedupes by stable
 // graph-entity ID, resolves cross-file CALLS edges, then assembles the
 // final on-disk document.
@@ -4052,21 +4065,29 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		indexEntities = append(indexEntities, merged...)
 		indexEntities = append(indexEntities, i.incrementalCarryForwardEntities...)
 	}
-	// NOTE (#4331): we intentionally call BuildIndex here, NOT the M5
-	// per-module path resolve.BuildIndexFromModules (#2182/#2184). M5 is a
-	// scale-only speed optimisation (pre-sized maps for big monorepos) and was
-	// built to be edge-set-identical to BuildIndex, but the #4331
-	// investigation found a CONCRETE divergence: M5 re-sorts entities by ID
-	// within a module, and the platform-variant merge (#1818) in
-	// byPackageOperation/byPackageComponent is order-sensitive for 3+
-	// mutually-exclusive GOOS variants of the same (pkgDir, name). That yields
-	// a different PlatformVariants fan-out topology, which clones a different
-	// set of CALLS edges downstream (refs.go ReferencesEmbeddedWithAllowlist).
-	// The guard test is TestM5_PlatformVariantParity_KnownDivergence in
-	// internal/resolve/symbol_index_parity_test.go. Until M5 preserves
-	// extraction order (or the variant merge is made order-independent) and
-	// that test asserts parity, BuildIndex stays the production resolver.
-	idx := resolve.BuildIndex(indexEntities)
+	// #4331 — resolver index construction. The production default is the
+	// flat O(N×M) resolve.BuildIndex. The M5 per-module path
+	// (resolve.BuildIndexFromModulesOrdered, #2182/#2184) is a scale-only
+	// speed optimisation for large monorepos: it partitions entities by
+	// package directory and pre-sizes the global maps in one shot. It is
+	// edge-set-identical to BuildIndex (the original sort-by-ID divergence on
+	// the platform-variant merge #1818, and the missing namespace/kotlin index
+	// tables, are both fixed in the ordered path — see
+	// internal/resolve/symbol_index.go and the full-Index parity harness in
+	// symbol_index_parity_test.go).
+	//
+	// It is wired BEHIND A DEFAULT-OFF FLAG: ARCHIGRAPH_RESOLVE_MODULE_INDEX=1
+	// routes through the M5 path; unset/anything-else keeps BuildIndex, so the
+	// default is a zero-behaviour-change no-op. Flipping the default to ON
+	// requires a live-graph edge-parity diff (reindex a real repo both ways and
+	// diff edges) in a deploy window — tracked as follow-up #4901.
+	var idx resolve.Index
+	if useModuleResolveIndex() {
+		fmt.Fprintln(os.Stderr, "resolver: using M5 per-module index (ARCHIGRAPH_RESOLVE_MODULE_INDEX=1)")
+		idx = resolve.BuildIndexFromModulesOrdered(indexEntities, resolve.ModuleKeyByPkgDir)
+	} else {
+		idx = resolve.BuildIndex(indexEntities)
+	}
 	// #2049 — Django string-FK late-binding: rewrite scope:component:ref:python:*
 	// stubs on REFERENCES edges with django_rel set, using app-label-aware
 	// byPackageComponent lookup. Runs after BuildIndex (needs the component

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -29,21 +29,41 @@
 //     register stubs they know will appear frequently, and the set resolves
 //     them in one pass rather than paying per-edge lookup cost.
 //
-// PRODUCTION STATUS (#4331): this module is UNWIRED — the production index
-// pipeline (cmd/archigraph/index.go) still calls BuildIndex, not
-// BuildIndexFromModules. M5 was designed as an edge-set-identical, scale-only
-// speed optimisation, but the #4331 investigation found it is NOT yet parity-
-// safe: BuildModuleSymbols sorts a module's entities by ID, whereas BuildIndex
-// preserves extraction order, and the platform-variant merge (#1818) in
-// byPackageOperation/byPackageComponent is order-sensitive for 3+ mutually-
-// exclusive GOOS variants of one (pkgDir, name). The differing iteration order
-// produces a different PlatformVariants fan-out topology, which clones a
-// different set of CALLS edges in ReferencesEmbeddedWithAllowlist (refs.go).
-// See TestM5_PlatformVariantParity_KnownDivergence (symbol_index_parity_test.go)
-// for the pinned divergence. To wire M5: preserve extraction order for the
-// platform-variant side-tables (or make that merge order-independent), flip the
-// guard test to assert parity, then update cmd/archigraph/index.go. M5 only
-// helps large monorepos; for small/medium codebases BuildIndex is already fine.
+// PRODUCTION STATUS (#4331): M5 is now WIRED BEHIND A DEFAULT-OFF FLAG
+// (ARCHIGRAPH_RESOLVE_MODULE_INDEX=1). cmd/archigraph/index.go still calls
+// BuildIndex by default; when the flag is set it routes through
+// BuildIndexFromModulesOrdered instead. Default = old path = zero behaviour
+// change, so merging is safe.
+//
+// THE ORIGINAL DIVERGENCE (and how it was fixed):
+// The first M5 design re-sorted each module's entities by ID
+// (BuildModuleSymbols' sort step) for O(N) collision detection. BuildIndex,
+// by contrast, preserves extraction order, and the platform-variant merge
+// (#1818) in byPackageOperation/byPackageComponent is ORDER-SENSITIVE for 3+
+// mutually-exclusive GOOS variants of one (pkgDir, name): pairwise canonical-
+// chaining produces a different PlatformVariants fan-out depending on which
+// variant is seen first. That fan-out is consumed by
+// ReferencesEmbeddedWithAllowlist (refs.go) to clone CALLS edges, so a
+// different topology = a different output edge set. A second gap: the original
+// insertModuleEntry did NOT populate byNamespaceMember (#4374, C#),
+// byKotlinPkgMember / byKotlinPkgFunc (#4375, Kotlin) — three index tables
+// BuildIndex fills.
+//
+// BOTH are fixed for the wired path:
+//   - BuildModuleSymbolsOrdered preserves extraction order (no ID sort), so
+//     the order-sensitive platform-variant merge sees variants in the same
+//     order BuildIndex does (variants of one (pkgDir,name) are always in the
+//     same module, so per-module extraction order is sufficient).
+//   - insertModuleEntry now populates byNamespaceMember / byKotlinPkgMember /
+//     byKotlinPkgFunc, matching BuildIndex.
+//
+// TestM5_PlatformVariantParity_Ordered (symbol_index_parity_test.go) now
+// asserts FULL Index parity (including PlatformVariants) for the ordered path,
+// and TestM5_OrderedFullIndexParity_Representative diffs the entire Index on a
+// representative multi-language fixture. The legacy sort-by-ID
+// BuildIndexFromModules is retained for the scale benchmarks and still carries
+// the pinned divergence guard. Flipping the default to ON requires a live-graph
+// edge-parity diff (reindex a real repo both ways) — tracked as follow-up #4901.
 package resolve
 
 import (
@@ -239,6 +259,9 @@ func MergeModuleBatch(si *SymbolIndex, offset, batchSize int) (Index, int) {
 		byPackageMember:    make(map[string]map[string]map[string]string),
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
+		byNamespaceMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgFunc:    make(map[string]map[string]string),
 		byQualifiedName:    make(map[string]string, total/4+1),
 		PlatformVariants:   make(map[string][]string),
 	}
@@ -329,6 +352,106 @@ func BuildIndexFromModules(modules map[ModuleKey][]types.EntityRecord, batchSize
 	return acc
 }
 
+// BuildModuleSymbolsOrdered is the parity-safe sibling of BuildModuleSymbols:
+// it preserves the caller's extraction order instead of re-sorting entries by
+// ID. Extraction order matters because the platform-variant merge (#1818) in
+// byPackageOperation/byPackageComponent is order-sensitive for 3+ mutually-
+// exclusive GOOS variants of the same (pkgDir, name). Variants of one
+// (pkgDir, name) always live in the same module, so preserving per-module
+// extraction order is sufficient to reproduce BuildIndex's PlatformVariants
+// topology exactly.
+func BuildModuleSymbolsOrdered(key ModuleKey, entities []types.EntityRecord) *ModuleSymbols {
+	ms := &ModuleSymbols{
+		Key:         key,
+		entityCount: len(entities),
+		entries:     make([]moduleEntry, 0, len(entities)),
+	}
+	for k := range entities {
+		e := &entities[k]
+		if e.ID == "" || e.Name == "" {
+			continue
+		}
+		sf := normalizePath(e.SourceFile)
+		trimmed := strings.TrimPrefix(e.Kind, scopeKindPrefix)
+		if trimmed == e.Kind {
+			trimmed = ""
+		}
+		me := moduleEntry{
+			id:            e.ID,
+			name:          e.Name,
+			kind:          e.Kind,
+			kindTrimmed:   trimmed,
+			sourceFile:    sf,
+			qualifiedName: e.QualifiedName,
+			refProp:       extractIndexableRef(e),
+			dotName:       strings.IndexByte(e.Name, dottedNameSep) >= 0,
+			properties:    e.Properties,
+		}
+		ms.entries = append(ms.entries, me)
+	}
+	// NOTE: deliberately NO sort — extraction order is preserved for parity.
+	return ms
+}
+
+// BuildIndexFromModulesOrdered is the parity-safe, production-wired entry point
+// for M5 (#4331). Unlike BuildIndexFromModules it does NOT sort entities by ID
+// (BuildModuleSymbolsOrdered), and it processes modules in first-seen extraction
+// order rather than sorted-key order. Combined with the namespace/kotlin index
+// tables now populated by insertModuleEntry, this produces an Index that is
+// edge-set-identical to BuildIndex on the same entity set — verified by the
+// full-Index parity harness in symbol_index_parity_test.go.
+//
+// moduleKeyOf decides which module an entity belongs to (typically its package
+// directory). The only correctness requirement is that all platform-variant
+// siblings of one (pkgDir, name) map to the SAME module — using pkgDir (or any
+// finer-than-pkgDir partition that keeps a directory whole) satisfies that.
+func BuildIndexFromModulesOrdered(entities []types.EntityRecord, moduleKeyOf func(types.EntityRecord) ModuleKey) Index {
+	if len(entities) == 0 {
+		return emptyIndex()
+	}
+	// Partition preserving extraction order within and across modules. We track
+	// first-seen module order so the merge visits modules in a deterministic,
+	// extraction-faithful order (matters for cross-module first-writer-wins on
+	// byQualifiedName refProps).
+	buckets := make(map[ModuleKey][]types.EntityRecord)
+	order := make([]ModuleKey, 0)
+	for k := range entities {
+		key := moduleKeyOf(entities[k])
+		if _, seen := buckets[key]; !seen {
+			order = append(order, key)
+		}
+		buckets[key] = append(buckets[key], entities[k])
+	}
+
+	si := &SymbolIndex{}
+	for _, key := range order {
+		si.Add(BuildModuleSymbolsOrdered(key, buckets[key]))
+	}
+
+	total := len(entities)
+	acc := accumulatorIndex(total)
+	pkgOpTag := make(map[string]map[string]string)
+	pkgCompTag := make(map[string]map[string]string)
+	pkgOpSrc := make(map[string]map[string]string)
+	pkgCompSrc := make(map[string]map[string]string)
+	for _, ms := range si.modules {
+		for i := range ms.entries {
+			me := &ms.entries[i]
+			insertModuleEntry(&acc, me, pkgOpTag, pkgCompTag, pkgOpSrc, pkgCompSrc)
+		}
+	}
+	return acc
+}
+
+// ModuleKeyByPkgDir is the default module-partition function for
+// BuildIndexFromModulesOrdered: it groups entities by the directory of their
+// (slash-normalised) SourceFile. Entities with no SourceFile fall into a single
+// "" bucket, matching how BuildIndex treats them (their location-keyed indexes
+// are skipped anyway).
+func ModuleKeyByPkgDir(e types.EntityRecord) ModuleKey {
+	return ModuleKey(pkgDirOf(normalizePath(e.SourceFile)))
+}
+
 // accumulatorIndex returns a pre-sized Index suitable for the multi-batch
 // accumulator path.
 func accumulatorIndex(totalEntities int) Index {
@@ -349,6 +472,9 @@ func accumulatorIndex(totalEntities int) Index {
 		byPackageMember:    make(map[string]map[string]map[string]string),
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
+		byNamespaceMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgFunc:    make(map[string]map[string]string),
 		byQualifiedName:    make(map[string]string, cap4),
 		PlatformVariants:   make(map[string][]string),
 	}
@@ -371,6 +497,9 @@ func emptyIndex() Index {
 		byPackageMember:    make(map[string]map[string]map[string]string),
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
+		byNamespaceMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgMember:  make(map[string]map[string]map[string]string),
+		byKotlinPkgFunc:    make(map[string]map[string]string),
 		byQualifiedName:    make(map[string]string),
 		PlatformVariants:   make(map[string][]string),
 	}
@@ -562,6 +691,65 @@ func insertModuleEntry(
 					} else {
 						pkgScopeBucket[member] = me.id
 					}
+				}
+
+				// byNamespaceMember (#4374, C#) — namespace-scoped member
+				// index. Mirrors BuildIndex: index "<Type>.<member>" entities
+				// that carry csharp_namespace under [namespace][Type][member].
+				if me.properties != nil {
+					if nsName := me.properties["csharp_namespace"]; nsName != "" {
+						nsBucket := idx.byNamespaceMember[nsName]
+						if nsBucket == nil {
+							nsBucket = make(map[string]map[string]string)
+							idx.byNamespaceMember[nsName] = nsBucket
+						}
+						nsScopeBucket := nsBucket[scope]
+						if nsScopeBucket == nil {
+							nsScopeBucket = make(map[string]string)
+							nsBucket[scope] = nsScopeBucket
+						}
+						if existing, ok := nsScopeBucket[member]; ok && existing != me.id {
+							nsScopeBucket[member] = ""
+						} else {
+							nsScopeBucket[member] = me.id
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Kotlin package-scoped indexes (#4375). Mirrors BuildIndex: Kotlin
+	// function entities carry a BARE Name plus kotlin_package /
+	// kotlin_enclosing_type properties.
+	if me.properties != nil && isOperationKind(me.kind) {
+		if pkg := me.properties["kotlin_package"]; pkg != "" && me.name != "" {
+			if typ := me.properties["kotlin_enclosing_type"]; typ != "" {
+				pkgBucket := idx.byKotlinPkgMember[pkg]
+				if pkgBucket == nil {
+					pkgBucket = make(map[string]map[string]string)
+					idx.byKotlinPkgMember[pkg] = pkgBucket
+				}
+				typeBucket := pkgBucket[typ]
+				if typeBucket == nil {
+					typeBucket = make(map[string]string)
+					pkgBucket[typ] = typeBucket
+				}
+				if existing, ok := typeBucket[me.name]; ok && existing != me.id {
+					typeBucket[me.name] = ""
+				} else {
+					typeBucket[me.name] = me.id
+				}
+			} else {
+				funcBucket := idx.byKotlinPkgFunc[pkg]
+				if funcBucket == nil {
+					funcBucket = make(map[string]string)
+					idx.byKotlinPkgFunc[pkg] = funcBucket
+				}
+				if existing, ok := funcBucket[me.name]; ok && existing != me.id {
+					funcBucket[me.name] = ""
+				} else {
+					funcBucket[me.name] = me.id
 				}
 			}
 		}

--- a/internal/resolve/symbol_index_parity_test.go
+++ b/internal/resolve/symbol_index_parity_test.go
@@ -1,30 +1,27 @@
-// Package resolve — M5 production-parity guard.
+// Package resolve — M5 production-parity guard + harness (#4331).
 //
-// Issue #4331 investigated wiring BuildIndexFromModules (M5, #2182/#2184)
-// into the production index pipeline (cmd/archigraph/index.go) in place of
-// BuildIndex. The investigation found a CONCRETE edge-set divergence on the
-// platform-variant code path, so M5 was NOT wired. This file is the
-// regression guard: it pins the known divergence so any future wiring attempt
-// must first make this test assert parity (not divergence) before flipping the
-// production call site.
+// Issue #4331 wired BuildIndexFromModulesOrdered (M5, #2182/#2184) into the
+// production index pipeline (cmd/archigraph/index.go) BEHIND A DEFAULT-OFF flag
+// (ARCHIGRAPH_RESOLVE_MODULE_INDEX=1). This file is the parity contract for
+// that wiring.
 //
-// # THE DIVERGENCE
+// # TWO M5 ENTRY POINTS, TWO BEHAVIOURS
 //
-// BuildIndex consumes entities in production extraction order (the order of the
-// `merged` slice). BuildIndexFromModules re-sorts: modules by ModuleKey, then
-// entities WITHIN each module by entity ID (BuildModuleSymbols sorts by ID for
-// O(N) collision detection). The platform-variant merge in byPackageOperation /
-// byPackageComponent (issue #1818) is ORDER-SENSITIVE for 3+ mutually-exclusive
-// variants of the same (pkgDir, name): the pairwise canonical-chaining produces
-// a different PlatformVariants topology depending on which variant is seen
-// first. PlatformVariants is consumed by ReferencesEmbeddedWithAllowlist
-// (refs.go) to CLONE CALLS edges onto every non-canonical sibling, so a
-// different topology = a different output edge set. This is a correctness
-// divergence, not just a speed difference.
+//   - BuildIndexFromModules (legacy): sorts each module's entities by ID for
+//     O(N) collision detection. The platform-variant merge (#1818) in
+//     byPackageOperation/byPackageComponent is ORDER-SENSITIVE for 3+ mutually-
+//     exclusive variants of one (pkgDir, name), so the sort produces a DIFFERENT
+//     PlatformVariants topology than BuildIndex. TestM5_PlatformVariantParity_
+//     LegacySortDiverges pins that (it is the original #4331 divergence) and
+//     keeps the legacy path out of production.
 //
-// The pre-existing TestBuildIndexFromModules_Parity does NOT catch this: its
-// synthetic fixture uses globally-unique names, so no collision — and therefore
-// no platform-variant merge — ever fires.
+//   - BuildIndexFromModulesOrdered (production-wired): preserves extraction
+//     order (no ID sort) and partitions by package directory, so the order-
+//     sensitive variant merge sees variants in the same order BuildIndex does.
+//     It also populates byNamespaceMember / byKotlinPkgMember / byKotlinPkgFunc,
+//     which the original insertModuleEntry omitted. The result is a FULL-Index
+//     match with BuildIndex — asserted by indexParityDiff over every index
+//     table, including the platform-variant fan-out.
 package resolve
 
 import (
@@ -37,8 +34,8 @@ import (
 
 // platformVariantTriple builds three mutually-exclusive GOOS variants of one
 // top-level operation "Run" in package dir "svc/". Entity IDs are deliberately
-// NOT in source-file order, so BuildModuleSymbols' sort-by-ID reorders them
-// relative to the production extraction order used by the returned `merged`.
+// NOT in source-file order, so the legacy BuildModuleSymbols' sort-by-ID
+// reorders them relative to the production extraction order used by `merged`.
 func platformVariantTriple() (merged []types.EntityRecord, modules map[ModuleKey][]types.EntityRecord) {
 	eDarwin := types.EntityRecord{ID: "cccccccccccccccc", Kind: "SCOPE.Operation", Name: "Run",
 		SourceFile: "svc/run_darwin.go", Properties: map[string]string{"build_tag": "darwin"}}
@@ -64,38 +61,220 @@ func normalizePV(m map[string][]string) map[string][]string {
 	return out
 }
 
-// TestM5_PlatformVariantParity_KnownDivergence pins the #4331 finding: on a
-// 3-way platform-variant collision, BuildIndex and BuildIndexFromModules
-// produce DIFFERENT PlatformVariants topologies. While this asserts divergence,
-// M5 must remain UNWIRED.
-//
-// TO WIRE M5: make BuildModuleSymbols / the merge preserve production
-// extraction order for the platform-variant side-tables (or make the
-// platform-variant merge order-independent), then flip the two asserts below
-// from NotEqual to Equal and update cmd/archigraph/index.go.
-func TestM5_PlatformVariantParity_KnownDivergence(t *testing.T) {
+// TestM5_PlatformVariantParity_LegacySortDiverges pins the original #4331
+// finding: the LEGACY sort-by-ID BuildIndexFromModules produces a DIFFERENT
+// PlatformVariants topology than BuildIndex on a 3-way platform-variant
+// collision. The legacy path therefore stays out of production; only the
+// extraction-order-preserving BuildIndexFromModulesOrdered is wired.
+func TestM5_PlatformVariantParity_LegacySortDiverges(t *testing.T) {
 	merged, modules := platformVariantTriple()
 
 	flat := BuildIndex(merged)
 	mod := BuildIndexFromModules(modules, 0)
 
-	// Canonical winner DOES agree (chosen by lexicographic SourceFile, which is
-	// order-independent): both pick svc/run_darwin.go's entity.
-	flatWinner := flat.byPackageOperation["svc"]["Run"]
-	modWinner := mod.byPackageOperation["svc"]["Run"]
-	if flatWinner != modWinner {
-		t.Errorf("unexpected: byPackageOperation winner already diverges (flat=%q mod=%q)",
-			flatWinner, modWinner)
+	// Canonical winner agrees (chosen by lexicographic SourceFile, order-
+	// independent): both pick svc/run_darwin.go's entity.
+	if flat.byPackageOperation["svc"]["Run"] != mod.byPackageOperation["svc"]["Run"] {
+		t.Errorf("unexpected: byPackageOperation winner diverges (flat=%q mod=%q)",
+			flat.byPackageOperation["svc"]["Run"], mod.byPackageOperation["svc"]["Run"])
 	}
 
-	// But the PlatformVariants fan-out topology DIVERGES. This is the blocker.
 	flatPV := normalizePV(flat.PlatformVariants)
 	modPV := normalizePV(mod.PlatformVariants)
 	if reflect.DeepEqual(flatPV, modPV) {
-		t.Fatalf("EXPECTED DIVERGENCE IS GONE — M5 may now be parity-safe to wire.\n"+
-			"flat=%v mod=%v\nIf so: flip this assert to require equality and proceed with wiring (#4331).",
+		t.Fatalf("LEGACY divergence is gone — the sort-by-ID path now matches BuildIndex.\n"+
+			"flat=%v mod=%v\nIf intended, retire BuildIndexFromModules in favour of the ordered path.",
 			flatPV, modPV)
 	}
-	t.Logf("confirmed #4331 divergence (M5 stays unwired):\n  BuildIndex          PlatformVariants=%v\n  BuildIndexFromModules PlatformVariants=%v",
+	t.Logf("confirmed legacy sort-by-ID divergence (legacy path stays unwired):\n"+
+		"  BuildIndex            PlatformVariants=%v\n  BuildIndexFromModules PlatformVariants=%v",
 		flat.PlatformVariants, mod.PlatformVariants)
+}
+
+// TestM5_PlatformVariantParity_OrderedMatches is the inverse: the production-
+// wired BuildIndexFromModulesOrdered reproduces BuildIndex's PlatformVariants
+// topology EXACTLY on the same 3-way collision. If this ever fails, the wired
+// M5 path has started cloning a different CALLS edge set — do NOT ship.
+func TestM5_PlatformVariantParity_OrderedMatches(t *testing.T) {
+	merged, _ := platformVariantTriple()
+
+	flat := BuildIndex(merged)
+	mod := BuildIndexFromModulesOrdered(merged, ModuleKeyByPkgDir)
+
+	flatPV := normalizePV(flat.PlatformVariants)
+	modPV := normalizePV(mod.PlatformVariants)
+	if !reflect.DeepEqual(flatPV, modPV) {
+		t.Fatalf("ordered M5 path diverges on PlatformVariants — NOT parity-safe.\n"+
+			"BuildIndex=%v\nBuildIndexFromModulesOrdered=%v", flatPV, modPV)
+	}
+}
+
+// indexParityDiff compares every index table of two Index values and returns a
+// slice of human-readable mismatch descriptions (empty == identical). It is the
+// core of the both-paths-identical harness: any (from,to,kind) edge difference
+// downstream is ultimately rooted in one of these tables, so a full-table match
+// guarantees an identical resolved edge set.
+//
+// PlatformVariants is order-normalised (the fan-out slice is a set, not a
+// sequence). All other tables are compared verbatim via reflect.DeepEqual.
+func indexParityDiff(a, b Index) []string {
+	var diffs []string
+	cmp := func(name string, x, y interface{}) {
+		if !reflect.DeepEqual(x, y) {
+			diffs = append(diffs, name)
+		}
+	}
+	cmp("byKind", a.byKind, b.byKind)
+	cmp("ambigKind", a.ambigKind, b.ambigKind)
+	cmp("byName", a.byName, b.byName)
+	cmp("ambigName", a.ambigName, b.ambigName)
+	cmp("nameKinds", a.nameKinds, b.nameKinds)
+	cmp("nameKindsReal", a.nameKindsReal, b.nameKindsReal)
+	cmp("byLocation", a.byLocation, b.byLocation)
+	cmp("ambigLocation", a.ambigLocation, b.ambigLocation)
+	cmp("byLocationKind", a.byLocationKind, b.byLocationKind)
+	cmp("byLocationKindReal", a.byLocationKindReal, b.byLocationKindReal)
+	cmp("byQualifiedName", a.byQualifiedName, b.byQualifiedName)
+	cmp("byMember", a.byMember, b.byMember)
+	cmp("byPackageMember", a.byPackageMember, b.byPackageMember)
+	cmp("byPackageOperation", a.byPackageOperation, b.byPackageOperation)
+	cmp("byPackageComponent", a.byPackageComponent, b.byPackageComponent)
+	cmp("byNamespaceMember", a.byNamespaceMember, b.byNamespaceMember)
+	cmp("byKotlinPkgMember", a.byKotlinPkgMember, b.byKotlinPkgMember)
+	cmp("byKotlinPkgFunc", a.byKotlinPkgFunc, b.byKotlinPkgFunc)
+	cmp("PlatformVariants", normalizePV(a.PlatformVariants), normalizePV(b.PlatformVariants))
+	return diffs
+}
+
+// assertFullIndexParity runs BuildIndex and BuildIndexFromModulesOrdered on the
+// SAME entity slice and fails on ANY index-table difference. This is the
+// both-paths-identical parity harness mandated by #4331.
+func assertFullIndexParity(t *testing.T, entities []types.EntityRecord) {
+	t.Helper()
+	flat := BuildIndex(entities)
+	mod := BuildIndexFromModulesOrdered(entities, ModuleKeyByPkgDir)
+	if diffs := indexParityDiff(flat, mod); len(diffs) != 0 {
+		t.Fatalf("FULL-INDEX PARITY FAILURE — BuildIndexFromModulesOrdered diverges from BuildIndex in tables: %v\n"+
+			"flat=%+v\nmod=%+v", diffs, flat, mod)
+	}
+}
+
+// representativeFixture exercises every index table BuildIndex populates across
+// several languages and the order-sensitive edge cases #4331 cares about:
+//   - 3-way platform-variant operations AND components in one pkgDir;
+//   - dotted-name members (byMember / byPackageMember);
+//   - C# namespace members (byNamespaceMember, #4374);
+//   - Kotlin package members + top-level funcs (byKotlinPkgMember/Func, #4375);
+//   - QualifiedName + Properties["ref"] qname indexing (endpoint/interface);
+//   - cross-file same-package operations and name/kind collisions;
+//   - entities with no SourceFile.
+//
+// Entity IDs are deliberately scrambled relative to source order so any
+// surviving sort-by-ID bug in the wired path surfaces as a divergence.
+func representativeFixture() []types.EntityRecord {
+	return []types.EntityRecord{
+		// 3-way platform-variant operation in svc/.
+		{ID: "0000000000000003", Kind: "SCOPE.Operation", Name: "Run", SourceFile: "svc/run_windows.go",
+			Properties: map[string]string{"build_tag": "windows"}},
+		{ID: "0000000000000001", Kind: "SCOPE.Operation", Name: "Run", SourceFile: "svc/run_darwin.go",
+			Properties: map[string]string{"build_tag": "darwin"}},
+		{ID: "0000000000000002", Kind: "SCOPE.Operation", Name: "Run", SourceFile: "svc/run_linux.go",
+			Properties: map[string]string{"build_tag": "linux"}},
+		// 3-way platform-variant component in svc/.
+		{ID: "00000000000000b3", Kind: "SCOPE.Component", Name: "Server", SourceFile: "svc/srv_windows.go",
+			Properties: map[string]string{"build_tag": "windows"}},
+		{ID: "00000000000000b1", Kind: "SCOPE.Component", Name: "Server", SourceFile: "svc/srv_darwin.go",
+			Properties: map[string]string{"build_tag": "darwin"}},
+		{ID: "00000000000000b2", Kind: "SCOPE.Component", Name: "Server", SourceFile: "svc/srv_linux.go",
+			Properties: map[string]string{"build_tag": "linux"}},
+
+		// Cross-file same-package Go operations (byPackageOperation).
+		{ID: "00000000000000c2", Kind: "SCOPE.Operation", Name: "Greet", SourceFile: "pkg/b.go"},
+		{ID: "00000000000000c1", Kind: "SCOPE.Operation", Name: "Hello", SourceFile: "pkg/a.go"},
+
+		// Dotted-name member (byMember + byPackageMember).
+		{ID: "00000000000000d1", Kind: "SCOPE.Operation", Name: "Mux.handle", SourceFile: "chi/mux.go"},
+		{ID: "00000000000000d2", Kind: "SCOPE.Operation", Name: "Mux.serve", SourceFile: "chi/tree.go"},
+
+		// C# namespace member (byNamespaceMember, #4374).
+		{ID: "00000000000000e1", Kind: "SCOPE.Operation", Name: "Repo.Save", SourceFile: "cs/Repo.cs",
+			Properties: map[string]string{"csharp_namespace": "App.Data"}},
+
+		// Kotlin package member + top-level func (byKotlinPkgMember/Func, #4375).
+		{ID: "00000000000000f1", Kind: "SCOPE.Operation", Name: "load", SourceFile: "kt/Loader.kt",
+			Properties: map[string]string{"kotlin_package": "app.kt", "kotlin_enclosing_type": "Loader"}},
+		{ID: "00000000000000f2", Kind: "SCOPE.Operation", Name: "main", SourceFile: "kt/Main.kt",
+			Properties: map[string]string{"kotlin_package": "app.kt"}},
+
+		// QualifiedName + endpoint/interface ref qname indexing.
+		{ID: "0000000000000a01", Kind: "SCOPE.Endpoint", Name: "GetUser", SourceFile: "api/users.py",
+			QualifiedName: "api.users.GetUser",
+			Properties:    map[string]string{"ref": "scope:endpoint:api/users.py#GET:/users"}},
+		{ID: "0000000000000a02", Kind: "SCOPE.Component", Name: "Handler", SourceFile: "rs/handler.rs",
+			Properties: map[string]string{"ref": "scope:component:interface:rust:Handler"}},
+
+		// Name/kind collision flips byName ambiguous but keeps byKind unique.
+		{ID: "0000000000000b01", Kind: "SCOPE.Component", Name: "Config", SourceFile: "x/conf.go"},
+		{ID: "0000000000000b02", Kind: "SCOPE.Operation", Name: "Config", SourceFile: "y/conf.go"},
+
+		// Entity with no SourceFile (location indexes skipped).
+		{ID: "0000000000000c99", Kind: "SCOPE.Operation", Name: "Floating", SourceFile: ""},
+	}
+}
+
+// TestM5_OrderedFullIndexParity_Representative is the headline #4331 harness:
+// it runs BOTH index-build paths on a representative multi-language fixture and
+// asserts EVERY index table is byte-identical. A failure means the wired M5
+// path would resolve a different edge set than production — block the merge.
+func TestM5_OrderedFullIndexParity_Representative(t *testing.T) {
+	assertFullIndexParity(t, representativeFixture())
+}
+
+// TestM5_OrderedFullIndexParity_Synthetic reuses the existing scale fixture
+// (10 modules × 20 entities) and asserts full-Index parity there too, so the
+// large-input shape is covered in addition to the hand-crafted edge cases.
+func TestM5_OrderedFullIndexParity_Synthetic(t *testing.T) {
+	modules, _ := syntheticModules(10, 20)
+	assertFullIndexParity(t, flattenModules(modules))
+}
+
+// TestM5_OrderedResolutionParity_Representative is the edge-level companion to
+// the table-level harness: it resolves a set of cross-cutting stubs under both
+// indexes and fails on any resolved-ToID difference, proving the table parity
+// translates to identical downstream edge resolution.
+func TestM5_OrderedResolutionParity_Representative(t *testing.T) {
+	entities := representativeFixture()
+	flat := BuildIndex(entities)
+	mod := BuildIndexFromModulesOrdered(entities, ModuleKeyByPkgDir)
+
+	stubs := []string{
+		"SCOPE.Operation:Hello",
+		"SCOPE.Operation:Greet",
+		"SCOPE.Component:Server",
+		"SCOPE.Endpoint:GetUser",
+		"scope:endpoint:api/users.py#GET:/users",
+		"scope:component:interface:rust:Handler",
+		"SCOPE.Operation:Config", // ambiguous → both leave unresolved
+		"SCOPE.Operation:DoesNotExist",
+	}
+	for _, kind := range []string{"CALLS", "REFERENCES", "EXTENDS"} {
+		mk := func(stub string) []types.RelationshipRecord {
+			out := make([]types.RelationshipRecord, len(stubs))
+			for i, s := range stubs {
+				out[i] = types.RelationshipRecord{FromID: "0000000000000c99", ToID: s, Kind: kind}
+			}
+			_ = stub
+			return out
+		}
+		rf := mk("")
+		rm := mk("")
+		References(rf, flat)
+		References(rm, mod)
+		for i := range rf {
+			if rf[i].ToID != rm[i].ToID {
+				t.Errorf("kind=%s stub=%q: flat resolved %q, ordered M5 resolved %q",
+					kind, stubs[i], rf[i].ToID, rm[i].ToID)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary
The M5 per-module symbol index (`resolve.BuildIndexFromModules`, #2182/#2184) shipped with parity/rate/scale tests but **zero production callers** — `cmd/archigraph/index.go` still used the flat O(N×M) `resolve.BuildIndex`. This PR wires a **parity-safe** M5 path into the production resolver **behind a default-OFF flag**, so merging changes nothing by default.

## Why it was never wired (investigation finding)
Two concrete divergences (not "deferred" — actual correctness gaps):

1. **Order-sensitive platform-variant merge.** `BuildModuleSymbols` re-sorts each module's entities by ID for O(N) collision detection. `BuildIndex` preserves extraction order. The platform-variant merge (#1818) in `byPackageOperation`/`byPackageComponent` is order-sensitive for 3+ mutually-exclusive GOOS variants of one `(pkgDir, name)`: pairwise canonical-chaining yields a different `PlatformVariants` fan-out depending on first-seen order. That fan-out is consumed by `ReferencesEmbeddedWithAllowlist` to **clone CALLS edges**, so a different topology = a different output edge set. This was pinned by the prior guard test.
2. **Missing index tables.** The original `insertModuleEntry` never populated `byNamespaceMember` (#4374, C#), `byKotlinPkgMember` / `byKotlinPkgFunc` (#4375, Kotlin) — three tables `BuildIndex` fills — and `emptyIndex`/`accumulatorIndex` didn't even initialise them.

## The fix
- **`BuildIndexFromModulesOrdered`** (new, production-wired): preserves extraction order (no ID sort), partitions by package directory via `ModuleKeyByPkgDir`. Variants of one `(pkgDir, name)` always live in the same module, so per-module extraction order is sufficient to reproduce `BuildIndex`'s topology exactly.
- `insertModuleEntry` now populates the C#-namespace and Kotlin-package tables; all three Index initialisers seed them.
- The legacy sort-by-ID `BuildIndexFromModules` is **retained for the scale benchmarks only** and still carries its pinned divergence guard (`TestM5_PlatformVariantParity_LegacySortDiverges`). It stays unwired.

## The flag (default OFF = no behaviour change)
`ARCHIGRAPH_RESOLVE_MODULE_INDEX=1` (truthy: `1`/`true`/`yes`/`on`) routes the production resolver through `BuildIndexFromModulesOrdered`; unset/anything-else keeps `BuildIndex`. The two code paths are cleanly separated at the single call site in `index.go`.

## Both-paths-identical parity harness
`internal/resolve/symbol_index_parity_test.go`:
- `indexParityDiff` compares **every** index table (incl. order-normalised `PlatformVariants` and the new namespace/kotlin tables) between the two indexes.
- `TestM5_OrderedFullIndexParity_Representative` — runs BOTH paths on a representative multi-language fixture (3-way platform-variant ops *and* components, dotted members, C# namespace, Kotlin pkg member + top-level func, QualifiedName + endpoint/interface ref qname indexing, name/kind collision, no-SourceFile entity; IDs scrambled vs source order to catch any sort bug) and fails on ANY table difference.
- `TestM5_OrderedFullIndexParity_Synthetic` — same assertion on the 10×20 scale fixture.
- `TestM5_OrderedResolutionParity_Representative` — edge-level companion: resolves cross-cutting stubs under both indexes and fails on any resolved-ToID difference.
- `TestM5_PlatformVariantParity_OrderedMatches` — asserts the ordered path reproduces `BuildIndex`'s `PlatformVariants` exactly.

## Follow-up (default flip is NOT done here)
Flipping the default to ON requires a **live-graph edge-parity diff** (reindex a real repo both ways, diff the edge multiset) in a deploy window — a coordinator/user task. Filed as **#4901**, referenced from the code.

## Gates (sandbox HOME = `/tmp/agsbx-4331`)
```
HOME=/tmp/agsbx-4331
go build ./...                                          → OK
go vet ./internal/resolve/... ./cmd/archigraph/...      → OK
go test ./internal/resolve/...                          → ok
go test ./cmd/archigraph/...                            → ok (29s)
```
All M5 parity tests pass, including the full-Index harness. No registry/coverage change.

Closes #4331 (wiring); flip tracked in #4901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)