### PR TITLE
feat(#4903): erlang coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/erlang/extractor.go
+++ b/internal/extractors/erlang/extractor.go
@@ -2,7 +2,9 @@
 //
 // Extracted entities:
 //   - module attributes (-module(foo).)           → Kind="SCOPE.Component", Subtype="module"
+//   - OTP modules (-behaviour(gen_server).)        → Subtype refined to gen_server_module / supervisor_module / application_module / otp_module; Properties["otp_behaviour"], Tags ["otp", "otp:gen_server", ...]
 //   - function clauses (name(Args) -> body.)       → Kind="SCOPE.Operation", Subtype="function" / "exported_function"
+//   - OTP callbacks (handle_call/3, init/1, ...)   → Subtype="otp_callback", Properties["otp_callback_of"]
 //   - record attributes (-record(Foo, {...}).)     → Kind="SCOPE.Component", Subtype="record"
 //   - include attributes (-include("foo.hrl").)   → IMPORTS relationships
 //
@@ -92,7 +94,47 @@ var (
 	exportItemRE = regexp.MustCompile(
 		`([a-z_][a-zA-Z0-9_@]*)\s*/\s*(\d+)`,
 	)
+
+	// behaviourRE matches -behaviour(gen_server). / -behavior(gen_server).
+	// (both British and American spellings are valid Erlang). Group 1: the
+	// behaviour atom (e.g. gen_server, supervisor, application, gen_statem,
+	// gen_event, gen_fsm).
+	behaviourRE = regexp.MustCompile(
+		`(?m)^-behaviou?r\s*\(\s*([a-z][a-zA-Z0-9_@]*)\s*\)\s*\.`,
+	)
 )
+
+// otpCallbacks maps each OTP behaviour to the canonical callback function
+// names it requires. Functions whose name is a known callback of a behaviour
+// the module implements are tagged so supervision-tree / message-dispatch
+// analysis can find them. Source: OTP design principles (gen_server,
+// gen_statem, gen_event, supervisor, application, gen_fsm).
+var otpCallbacks = map[string]map[string]bool{
+	"gen_server": {
+		"init": true, "handle_call": true, "handle_cast": true,
+		"handle_info": true, "terminate": true, "code_change": true,
+		"format_status": true,
+	},
+	"gen_statem": {
+		"init": true, "callback_mode": true, "handle_event": true,
+		"terminate": true, "code_change": true, "format_status": true,
+	},
+	"gen_event": {
+		"init": true, "handle_event": true, "handle_call": true,
+		"handle_info": true, "terminate": true, "code_change": true,
+		"format_status": true,
+	},
+	"gen_fsm": {
+		"init": true, "handle_event": true, "handle_sync_event": true,
+		"handle_info": true, "terminate": true, "code_change": true,
+	},
+	"supervisor": {
+		"init": true,
+	},
+	"application": {
+		"start": true, "stop": true, "prep_stop": true, "config_change": true,
+	},
+}
 
 // erlangKeywords are tokens that match funcHead or call patterns but are NOT
 // real function names or call targets.
@@ -151,6 +193,33 @@ type clauseMatch struct {
 func extractErlang(src, filePath string) []types.EntityRecord {
 	var entities []types.EntityRecord
 
+	// ── 0. OTP behaviours ──────────────────────────────────────────────────
+	// -behaviour(gen_server). attributes declare the module as an OTP process.
+	// Collect them so the module entity (and its callbacks) can be stamped.
+	var behaviours []string
+	behaviourSet := make(map[string]bool)
+	for _, m := range behaviourRE.FindAllStringSubmatch(src, -1) {
+		b := m[1]
+		if behaviourSet[b] {
+			continue
+		}
+		behaviourSet[b] = true
+		behaviours = append(behaviours, b)
+	}
+	sort.Strings(behaviours)
+
+	// callbackOf maps a function name to the behaviour(s) it is a callback of
+	// for the behaviours this module actually implements.
+	callbackOf := make(map[string][]string)
+	for _, b := range behaviours {
+		for cb := range otpCallbacks[b] {
+			callbackOf[cb] = append(callbackOf[cb], b)
+		}
+	}
+	for cb := range callbackOf {
+		sort.Strings(callbackOf[cb])
+	}
+
 	// ── 1. Module declaration ──────────────────────────────────────────────
 	moduleName := ""
 	moduleIdx := -1
@@ -158,7 +227,7 @@ func extractErlang(src, filePath string) []types.EntityRecord {
 		moduleName = src[m[2]:m[3]]
 		startLine := strings.Count(src[:m[0]], "\n") + 1
 		moduleIdx = len(entities)
-		entities = append(entities, types.EntityRecord{
+		modRec := types.EntityRecord{
 			Name:               moduleName,
 			Kind:               "SCOPE.Component",
 			Subtype:            "module",
@@ -168,7 +237,24 @@ func extractErlang(src, filePath string) []types.EntityRecord {
 			EndLine:            strings.Count(src, "\n") + 1,
 			Signature:          "-module(" + moduleName + ").",
 			EnrichmentRequired: false,
-		})
+		}
+		if len(behaviours) > 0 {
+			// Stamp the OTP behaviour(s) so supervision-tree / dispatch
+			// analysis can identify gen_server/supervisor/application modules
+			// without re-parsing. The module subtype is refined to the most
+			// specific OTP role (preferring a single behaviour) and the full
+			// list is preserved in Properties + Tags.
+			modRec.Subtype = otpModuleSubtype(behaviours)
+			if modRec.Properties == nil {
+				modRec.Properties = map[string]string{}
+			}
+			modRec.Properties["otp_behaviour"] = strings.Join(behaviours, ",")
+			modRec.Tags = append(modRec.Tags, "otp")
+			for _, b := range behaviours {
+				modRec.Tags = append(modRec.Tags, "otp:"+b)
+			}
+		}
+		entities = append(entities, modRec)
 	}
 
 	// ── 2. Record declarations ─────────────────────────────────────────────
@@ -277,6 +363,17 @@ func extractErlang(src, filePath string) []types.EntityRecord {
 			EnrichmentRequired: false,
 			Relationships:      callRels,
 		}
+
+		// Tag OTP callback functions (handle_call/2-3, init/1, ...) so message
+		// dispatch (call/cast/info) and supervision callbacks are discoverable.
+		if bs := callbackOf[fi.name]; len(bs) > 0 {
+			rec.Subtype = "otp_callback"
+			if rec.Properties == nil {
+				rec.Properties = map[string]string{}
+			}
+			rec.Properties["otp_callback_of"] = strings.Join(bs, ",")
+			rec.Tags = append(rec.Tags, "otp_callback")
+		}
 		opIdx := len(entities)
 		entities = append(entities, rec)
 
@@ -298,6 +395,25 @@ func extractErlang(src, filePath string) []types.EntityRecord {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+// otpModuleSubtype refines a module's subtype based on the OTP behaviour(s)
+// it implements. A module with a single behaviour gets the canonical role
+// subtype (e.g. gen_server → "gen_server_module"); a module implementing
+// multiple behaviours is tagged generically as "otp_module" (the precise
+// list is preserved in Properties["otp_behaviour"]).
+func otpModuleSubtype(behaviours []string) string {
+	if len(behaviours) == 1 {
+		switch behaviours[0] {
+		case "gen_server", "gen_statem", "gen_event", "gen_fsm":
+			return behaviours[0] + "_module"
+		case "supervisor":
+			return "supervisor_module"
+		case "application":
+			return "application_module"
+		}
+	}
+	return "otp_module"
+}
 
 // isInsideAttribute returns true when the match at matchStart is preceded
 // (on the same logical source context) by a '-' attribute marker. Since

--- a/internal/extractors/erlang/extractor_test.go
+++ b/internal/extractors/erlang/extractor_test.go
@@ -501,6 +501,121 @@ func TestErlangExtractor_HrlFile(t *testing.T) {
 	}
 }
 
+// TestErlangExtractor_OTPBehaviour verifies that -behaviour(gen_server). is
+// detected: the module entity is refined to gen_server_module, stamped with
+// Properties["otp_behaviour"]="gen_server" and tagged "otp"/"otp:gen_server".
+func TestErlangExtractor_OTPBehaviour(t *testing.T) {
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "cache_server.erl",
+		Content:  []byte(genServerFixture),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var mod bool
+	for _, rec := range got {
+		if rec.Name == "cache_server" && rec.Kind == "SCOPE.Component" {
+			mod = true
+			if rec.Subtype != "gen_server_module" {
+				t.Errorf("expected module subtype gen_server_module, got %q", rec.Subtype)
+			}
+			if rec.Properties["otp_behaviour"] != "gen_server" {
+				t.Errorf("expected otp_behaviour=gen_server, got %q", rec.Properties["otp_behaviour"])
+			}
+			if !hasTag(rec.Tags, "otp") || !hasTag(rec.Tags, "otp:gen_server") {
+				t.Errorf("expected otp tags, got %v", rec.Tags)
+			}
+		}
+	}
+	if !mod {
+		t.Fatal("module entity cache_server not found")
+	}
+}
+
+// TestErlangExtractor_OTPCallbacks verifies gen_server callbacks are tagged.
+func TestErlangExtractor_OTPCallbacks(t *testing.T) {
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "cache_server.erl",
+		Content:  []byte(genServerFixture),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantCallbacks := map[string]bool{
+		"init": false, "handle_call": false, "handle_cast": false,
+		"handle_info": false, "terminate": false, "code_change": false,
+	}
+	for _, rec := range got {
+		if rec.Kind != "SCOPE.Operation" {
+			continue
+		}
+		if _, want := wantCallbacks[rec.Name]; want {
+			if rec.Subtype != "otp_callback" {
+				t.Errorf("%s: expected subtype otp_callback, got %q", rec.Name, rec.Subtype)
+			}
+			if rec.Properties["otp_callback_of"] != "gen_server" {
+				t.Errorf("%s: expected otp_callback_of=gen_server, got %q", rec.Name, rec.Properties["otp_callback_of"])
+			}
+			if !hasTag(rec.Tags, "otp_callback") {
+				t.Errorf("%s: expected otp_callback tag, got %v", rec.Name, rec.Tags)
+			}
+			wantCallbacks[rec.Name] = true
+		}
+	}
+	for cb, seen := range wantCallbacks {
+		if !seen {
+			t.Errorf("callback %q not found / not tagged", cb)
+		}
+	}
+}
+
+// TestErlangExtractor_SupervisorBehaviour verifies the supervisor role + that
+// a non-OTP module keeps the plain "module" subtype.
+func TestErlangExtractor_SupervisorBehaviour(t *testing.T) {
+	src := `-module(my_sup).
+-behavior(supervisor).
+-export([start_link/0, init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    {ok, {{one_for_one, 5, 10}, []}}.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "my_sup.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, rec := range got {
+		if rec.Name == "my_sup" && rec.Kind == "SCOPE.Component" {
+			if rec.Subtype != "supervisor_module" {
+				t.Errorf("expected supervisor_module (American spelling -behavior), got %q", rec.Subtype)
+			}
+		}
+		if rec.Name == "init" && rec.Properties["otp_callback_of"] != "supervisor" {
+			t.Errorf("init should be a supervisor callback, got %q", rec.Properties["otp_callback_of"])
+		}
+	}
+}
+
+func hasTag(tags []string, want string) bool {
+	for _, t := range tags {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}
+
 func sortedKeys(m map[string]bool) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {


### PR DESCRIPTION
Closes #4903.

## Documented (base-language record — was entirely missing)
Added **`lang.erlang.core`** (category `language`), flipping cells the extractor genuinely produces, all with code cites:
- **core_extraction → full** — -module/-record/function-clause entities, exported_function subtype, CONTAINS-only-for-exported, multi-clause collapse, .hrl record parsing. Cites `internal/extractors/erlang/extractor.go` + `extractor_test.go`.
- **call_line_precision → full** — CALLS edges (qualified `mod:fn` + bare) carry `Properties["line"]`; comments/strings/atoms scrubbed.
- **import_resolution_quality → partial** — -include/-include_lib emit IMPORTS; not yet resolved to the .hrl entity, -import not extracted (honest partial).

## Implemented (new extraction — the #1 semantic gap)
**OTP behaviour detection** in the extractor:
- `-behaviour`/`-behavior(gen_server|gen_statem|gen_event|gen_fsm|supervisor|application)` (both spellings) refines the module Subtype (`gen_server_module`/`supervisor_module`/`application_module`/`otp_module`), stamps `Properties["otp_behaviour"]` + Tags `otp`/`otp:<b>`.
- Behaviour callbacks (handle_call/cast/info, init, terminate, code_change, start/stop, …) re-typed `Subtype="otp_callback"` with `Properties["otp_callback_of"]`.
- New record **`lang.erlang.runtime.otp`** documents it (core_extraction partial).
- New tests: `TestErlangExtractor_OTPBehaviour`, `_OTPCallbacks`, `_SupervisorBehaviour` (+ existing gen_server recall test still green).
- **No new Kind** added (module stays SCOPE.Component; uses Subtype/Properties/Tags), so no types-registry change required.

## Deferred (follow-ups filed)
- **#4929** — OTP supervision-tree child_spec edges + gen_server per-message-tag dispatch (this PR is the prerequisite: behaviours + callbacks now identified).
- **#4930** — function arity in identity (foo/1 vs foo/2 collapse), rebar3/erlang.mk build+package records, eunit/common_test as first-class test frameworks, -spec/-type/-callback type system, macro expansion.

## Gates (all under sandbox `HOME=/tmp/agsbx-4903`)
- `go build ./...` ✅  `go vet ./internal/...` ✅
- `go test ./internal/extractors/erlang/... ./internal/types/` ✅
- `coverage fmt --check` → `ok: canonical` ✅ (registry diff is +44 lines, surgical — no whole-file reserialization)
- `coverage validate` → `ok: 669 record(s)` ✅ (the only erlang lines are the pre-existing capability-map "no mapping entry" warning class shared by cowboy; no errors)

Note: `coverage gen` was intentionally **not** committed — the committed markdown docs are pervasively stale on `main` (templates changed since last regen; `gen` rewrites 156 unrelated files). Kept this PR to registry+extractor only to avoid sweeping in pre-existing drift; the coverage-docs workflow regenerates docs separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)