### PR TITLE
feat(#4904): nim coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/custom/nim/extractors_test.go
+++ b/internal/custom/nim/extractors_test.go
@@ -102,3 +102,148 @@ func TestNimRouteE2E_WrongLanguageNoop(t *testing.T) {
 		t.Fatalf("expected no entities for non-nim language, got %d", len(ents))
 	}
 }
+
+// --- Norm ORM (#4904) -------------------------------------------------------
+
+// TestNimNormORM_ModelTableColumns proves a Norm `ref object of Model`
+// declaration synthesises model + table + column SCOPE.Schema entities and an
+// FK edge for a field typed as another model.
+func TestNimNormORM_ModelTableColumns(t *testing.T) {
+	src := `
+import norm/model
+import norm/sqlite
+
+type
+  User* = ref object of Model
+    name*: string
+    email*: string
+    age*: int
+
+  Post* = ref object of Model
+    title*: string
+    body*: string
+    author*: User
+`
+	e, ok := extreg.Get("custom_nim_norm_orm")
+	if !ok {
+		t.Fatal("custom_nim_norm_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("src/models.nim", "nim", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	type key struct{ name, sub string }
+	got := map[key]bool{}
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+			continue
+		}
+		if en.Properties["framework"] != "norm" {
+			t.Errorf("entity %q missing framework=norm", en.Name)
+		}
+		got[key{en.Name, en.Subtype}] = true
+	}
+
+	// Models + tables.
+	for _, m := range []string{"User", "Post"} {
+		if !got[key{m, "model"}] {
+			t.Errorf("expected SCOPE.Schema/model %q", m)
+		}
+		if !got[key{m, "table"}] {
+			t.Errorf("expected SCOPE.Schema/table %q", m)
+		}
+	}
+	// Columns.
+	for _, c := range []string{"name", "email", "age", "title", "body", "author"} {
+		if !got[key{c, "column"}] {
+			t.Errorf("expected SCOPE.Schema/column %q", c)
+		}
+	}
+
+	// FK edge: Post.author → User.
+	fkFound := false
+	authorFKCol := false
+	for _, en := range ents {
+		if en.Name == "Post" && en.Subtype == "model" {
+			for _, r := range en.Relationships {
+				if r.Kind == "REFERENCES" && r.ToID == "User" && r.Properties["fk_field"] == "author" {
+					fkFound = true
+				}
+			}
+		}
+		if en.Name == "author" && en.Subtype == "column" {
+			if en.Properties["foreign_key"] == "true" && en.Properties["column_type"] == "User" {
+				authorFKCol = true
+			}
+		}
+	}
+	if !fkFound {
+		t.Error("expected REFERENCES edge Post→User (fk_field=author)")
+	}
+	if !authorFKCol {
+		t.Error("expected author column stamped foreign_key=true column_type=User")
+	}
+}
+
+// TestNimNormORM_NonModelNoop proves a plain (non-Model) object is ignored.
+func TestNimNormORM_NonModelNoop(t *testing.T) {
+	src := `
+type
+  Config = object
+    host: string
+    port: int
+`
+	e, _ := extreg.Get("custom_nim_norm_orm")
+	ents, _ := e.Extract(context.Background(), fi("src/config.nim", "nim", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no schema entities for a non-Model object, got %d", len(ents))
+	}
+}
+
+// TestNimNormORM_WrongLanguageNoop gates on language=="nim".
+func TestNimNormORM_WrongLanguageNoop(t *testing.T) {
+	src := `type User* = ref object of Model
+  name*: string`
+	e, _ := extreg.Get("custom_nim_norm_orm")
+	ents, _ := e.Extract(context.Background(), fi("src/models.nim", "go", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-nim language, got %d", len(ents))
+	}
+}
+
+// TestNimNormORM_OptionWrappedFK proves an Option[Model]/seq[Model] field is
+// unwrapped and recognised as a foreign key.
+func TestNimNormORM_OptionWrappedFK(t *testing.T) {
+	src := `
+import norm/model
+import std/options
+
+type
+  User* = ref object of Model
+    name*: string
+
+  Comment* = ref object of Model
+    text*: string
+    author*: Option[User]
+`
+	e, _ := extreg.Get("custom_nim_norm_orm")
+	ents, err := e.Extract(context.Background(), fi("src/models.nim", "nim", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	fk := false
+	for _, en := range ents {
+		if en.Name == "Comment" && en.Subtype == "model" {
+			for _, r := range en.Relationships {
+				if r.Kind == "REFERENCES" && r.ToID == "User" {
+					fk = true
+				}
+			}
+		}
+	}
+	if !fk {
+		t.Error("expected Option[User] field to yield REFERENCES Comment→User")
+	}
+}

--- a/internal/custom/nim/norm_orm.go
+++ b/internal/custom/nim/norm_orm.go
@@ -1,0 +1,284 @@
+// norm_orm.go — Nim Norm ORM model → table/column schema synthesis (#4904).
+//
+// Norm (https://norm.nim.town) is the de-facto Nim ORM. A persisted model is a
+// plain Nim `ref object` that inherits from Norm's `Model` base type; Norm maps
+// the object to a database table whose name is, by default, the snake_case
+// pluralisation of the type name (Norm lowercases the type name and appends
+// nothing structural at the Nim level — the runtime applies the table naming —
+// so we record the TYPE NAME as the table identity, which is what the model
+// object is keyed by). Each public object field becomes a column; a field typed
+// as another Model subtype (or carrying an `{.fk: Other.}` pragma) is a foreign
+// key to that model.
+//
+// Norm model shape:
+//
+//	import norm/model
+//
+//	type
+//	  User* = ref object of Model
+//	    name*: string
+//	    email*: string
+//	    age*: int
+//
+//	  Post* = ref object of Model
+//	    title*: string
+//	    body*: string
+//	    author*: User          # FK → User (field typed as a Model subtype)
+//
+// What this extractor emits (mirrors the PHP/Eloquent + Scala ORM shape —
+// SCOPE.Schema entities carrying framework+provenance props):
+//   - one SCOPE.Schema/model per `T* = ref object of Model` declaration
+//   - one SCOPE.Schema/table per model (table identity = the model type name)
+//   - one SCOPE.Schema/column per public object field, with column_type stamped
+//   - a REFERENCES edge model → referenced model for a field typed as another
+//     model type in the same file (the FK signal), keyed by model name
+//
+// Honest exclusions / follow-ups (no fabricated schema):
+//   - cross-file FK targets (a field typed as a model declared in another file)
+//     are recorded as a REFERENCES edge to the bare type name but not resolved
+//     to the concrete entity here — the shared resolver handles binding.
+//   - `{.tableName: "x".}` / `{.dbName.}` pragma table-name overrides, index
+//     pragmas, `db.select/insert/update` query attribution, and Norm migrations
+//     (createTables/dropTables) are deferred to follow-up #4932.
+//   - Allographer / ormin / Debby model→table mapping is deferred to #4933.
+//
+// Registration key: "custom_nim_norm_orm".
+package nim
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_nim_norm_orm", &nimNormORMExtractor{})
+}
+
+type nimNormORMExtractor struct{}
+
+func (e *nimNormORMExtractor) Language() string { return "custom_nim_norm_orm" }
+
+var (
+	// nimNormModelRe matches a Norm model declaration: a type that is a
+	// `ref object of Model`. Capture group 1 is the model type name (export
+	// marker stripped by the caller). Accepts an optional pragma block before
+	// the `=` (e.g. `User* {.tableName: "users".} = ref object of Model`).
+	nimNormModelRe = regexp.MustCompile(
+		`(?m)^[ \t]*([A-Z][A-Za-z0-9_]*)\*?\s*(?:\{[^}]*\})?\s*=\s*ref\s+object\s+of\s+Model\b`)
+
+	// nimNormFieldRe matches a single object field inside a model body:
+	// `name*: string`, `author*: User`, `age: int`. Capture group 1 is the
+	// field name (export marker stripped), group 2 the field type (first type
+	// token, generics/option wrappers trimmed by normaliseNimFieldType).
+	nimNormFieldRe = regexp.MustCompile(
+		`(?m)^[ \t]+([a-z_][A-Za-z0-9_]*)\*?\s*:\s*([A-Za-z_][A-Za-z0-9_\[\], ]*)`)
+)
+
+// nimNormHasModel is a fast pre-filter: the file must reference Norm's Model
+// base type to be worth scanning, so we never misfire on arbitrary Nim objects.
+func nimNormHasModel(content string) bool {
+	return strings.Contains(content, "of Model") &&
+		(strings.Contains(content, "norm") || strings.Contains(content, "Model"))
+}
+
+func (e *nimNormORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "nim" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !nimNormHasModel(src) {
+		return nil, nil
+	}
+
+	models := collectNormModels(src)
+	if len(models) == 0 {
+		return nil, nil
+	}
+	// Set of known model names in this file — used to recognise a field whose
+	// type is another model as a foreign key.
+	modelNames := make(map[string]bool, len(models))
+	for _, m := range models {
+		modelNames[m.name] = true
+	}
+
+	var out []types.EntityRecord
+	for _, m := range models {
+		// 1. model entity
+		model := newNormSchema(m.name, "model", file.Path, m.line,
+			"INFERRED_FROM_NORM_MODEL")
+		// FK edges → referenced models (fields typed as another model type).
+		var rels []types.RelationshipRecord
+		for _, f := range m.fields {
+			if modelNames[f.typ] && f.typ != m.name {
+				rels = append(rels, types.RelationshipRecord{
+					ToID: f.typ,
+					Kind: "REFERENCES",
+					Properties: map[string]string{
+						"fk_field": f.name,
+						"to_model": f.typ,
+					},
+				})
+			}
+		}
+		model.Relationships = rels
+		model.ID = model.ComputeID()
+		out = append(out, model)
+
+		// 2. table entity (table identity = the model type name).
+		table := newNormSchema(m.name, "table", file.Path, m.line,
+			"INFERRED_FROM_NORM_TABLE")
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 3. column entities (one per public object field).
+		colSeen := make(map[string]bool)
+		for _, f := range m.fields {
+			if colSeen[f.name] {
+				continue
+			}
+			colSeen[f.name] = true
+			col := newNormSchema(f.name, "column", file.Path, f.line,
+				"INFERRED_FROM_NORM_FIELD")
+			col.Properties["column_type"] = f.typ
+			col.Properties["model"] = m.name
+			if modelNames[f.typ] && f.typ != m.name {
+				col.Properties["foreign_key"] = "true"
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+	}
+	return out, nil
+}
+
+// normModel is a parsed Norm model with its fields.
+type normModel struct {
+	name   string
+	line   int
+	fields []normField
+}
+
+type normField struct {
+	name string
+	typ  string
+	line int
+}
+
+// collectNormModels finds every `T = ref object of Model` declaration and the
+// fields in its indented body.
+func collectNormModels(src string) []normModel {
+	idx := nimNormModelRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	lines := strings.Split(src, "\n")
+	var models []normModel
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		modelIndent := leadingIndent(lineAt(lines, startLine))
+		fields := collectNormFields(lines, startLine, modelIndent)
+		models = append(models, normModel{name: name, line: startLine, fields: fields})
+	}
+	return models
+}
+
+// collectNormFields scans the indented body following a model header for object
+// fields. A field line is more indented than the model header; the body ends at
+// the first non-blank line indented at or below the model header.
+func collectNormFields(lines []string, headerLine, modelIndent int) []normField {
+	var fields []normField
+	seen := make(map[string]bool)
+	for ln := headerLine + 1; ln <= len(lines); ln++ {
+		raw := lineAt(lines, ln)
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		if leadingIndent(raw) <= modelIndent {
+			break // dedent — model body ended
+		}
+		fm := nimNormFieldRe.FindStringSubmatch(raw)
+		if fm == nil {
+			continue
+		}
+		fname := fm[1]
+		ftyp := normaliseNimFieldType(fm[2])
+		if ftyp == "" || seen[fname] {
+			continue
+		}
+		seen[fname] = true
+		fields = append(fields, normField{name: fname, typ: ftyp, line: ln})
+	}
+	return fields
+}
+
+// normaliseNimFieldType reduces a field type expression to its core type name:
+// `Option[User]` → `User`, `seq[Post]` → `Post`, `string` → `string`. The
+// wrapper (Option/seq) is unwrapped so a wrapped model reference is still
+// recognised as a foreign key.
+func normaliseNimFieldType(raw string) string {
+	t := strings.TrimSpace(raw)
+	// Unwrap Option[...] / seq[...] generics to the inner type.
+	for {
+		open := strings.IndexByte(t, '[')
+		if open < 0 {
+			break
+		}
+		close := strings.LastIndexByte(t, ']')
+		if close <= open {
+			break
+		}
+		t = strings.TrimSpace(t[open+1 : close])
+	}
+	// Take the first whitespace-delimited token (drops trailing pragmas/comments).
+	if sp := strings.IndexAny(t, " \t"); sp >= 0 {
+		t = t[:sp]
+	}
+	return strings.TrimSpace(t)
+}
+
+// newNormSchema builds a SCOPE.Schema entity with the Norm framework + the given
+// provenance stamp.
+func newNormSchema(name, subtype, path string, line int, provenance string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       name,
+		Kind:       "SCOPE.Schema",
+		Subtype:    subtype,
+		SourceFile: path,
+		Language:   "nim",
+		StartLine:  line,
+		EndLine:    line,
+		Properties: map[string]string{
+			"framework":  "norm",
+			"provenance": provenance,
+		},
+	}
+}
+
+// leadingIndent counts leading spaces/tabs of a line (tab counts as 1).
+func leadingIndent(line string) int {
+	n := 0
+	for _, ch := range line {
+		if ch == ' ' || ch == '\t' {
+			n++
+		} else {
+			break
+		}
+	}
+	return n
+}
+
+// lineAt returns the 1-based line ln from lines, or "" when out of range.
+func lineAt(lines []string, ln int) string {
+	if ln < 1 || ln > len(lines) {
+		return ""
+	}
+	return lines[ln-1]
+}


### PR DESCRIPTION
## #4904 — Nim coverage audit

Nim had ONLY `lang.nim.framework.jester`; no base-language record despite a working base extractor, and zero ORM coverage. This closes those gaps.

### Documented (base-language record `lang.nim.core`, with cites + fixture proof)
- **core_extraction** (full) — `internal/extractors/nim/nim.go`: proc/func/method/template/macro/iterator/converter → SCOPE.Operation (subtype-distinguished, export-marker stripped); object/ref object/enum/tuple/distinct → SCOPE.Component; type→method CONTAINS (documented WEAK — param-substring receiver heuristic). Cites TestNim_ProcDiscovery / TestNim_TypeDiscovery / TestNim_ContainsEdges.
- **call_line_precision** (full) — CALLS edges carry `Properties["line"]`; string/comment scrub + nimKeywords denylist; self-recursion filtered + deduped. Cites TestNim_CallsEdges / TestNim_SelfRecursionExcluded / TestNim_CallsDeduped.
- **import_resolution_quality** (partial, honest) — `import a,b` / `std/strutils` / `include` / `from X import Y` → IMPORTS edges with importDisplayName normalisation; honest exclusion: from-import records module only, not symbols. Cites TestNim_ImportEdges.

The Type System / enum / type-alias cells the ticket flagged on the **jester** record are intentionally NOT moved onto that http_framework record — those are base-language concerns and are now captured by `lang.nim.core.core_extraction` (the `language` category's allow-list does not include type_extraction/enum_extraction; this mirrors the just-merged `lang.erlang.core` model).

### Implemented (new extraction + fixture + registry record)
- **`internal/custom/nim/norm_orm.go`** (`custom_nim_norm_orm`) — **Norm**, the de-facto Nim ORM. A `T* = ref object of Model` declaration → one SCOPE.Schema/model + SCOPE.Schema/table + one SCOPE.Schema/column per field (column_type stamped, Option[T]/seq[T] unwrapped). A field typed as another model in the same file → `REFERENCES` FK edge + foreign_key column stamp. Pre-filtered so plain objects are ignored.
- **`lang.nim.orm.norm`** record: model_extraction **full**, schema_extraction + foreign_key_extraction **partial** (honest: pragmas/table-name overrides/cross-file FK resolution deferred), association_extraction/lazy_loading_recognition **not_applicable** (Norm relations are plain typed fields), queries/migrations/lifecycle/txn **missing** with follow-up refs.
- Tests: TestNimNormORM_ModelTableColumns, _NonModelNoop, _WrongLanguageNoop, _OptionWrappedFK.

### Deferred (precise follow-ups filed)
- **#4932** — Norm deepening: column/table-name pragmas, `db.select/insert/update` query attribution, createTables/dropTables migrations, transaction stamping, cross-file FK resolution.
- **#4933** — Allographer / ormin / Debby model→table mapping.
- HappyX route synthesis is already covered by `synthesizePrologue` (shared curly-brace convention); Mummy/httpbeast/asynchttpserver and Norm-sibling deepening remain in the above follow-ups.

### Gates (sandbox HOME = `/tmp/agsbx-4904`)
- `go build ./...` ✅ (only a pre-existing vendored tree-sitter/lua C warning)
- `go vet ./internal/...` ✅
- `go test ./internal/custom/nim/... ./internal/extractors/nim/... ./internal/types/` ✅
- `coverage fmt --check` ✅ canonical · `coverage validate` ✅ 671 records
- No `coverage gen` markdown swept — registry + extractor + tests only (3 files).

Closes #4904.