### PR TITLE
feat(#4905): crystal coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/custom/crystal/granite_orm.go
+++ b/internal/custom/crystal/granite_orm.go
@@ -1,0 +1,325 @@
+// granite_orm.go — Crystal Granite ORM model → table/column/association
+// schema synthesis (#4905).
+//
+// Granite (https://amberframework.github.io/granite/) is one of the most widely
+// used Crystal ORMs (the default ORM for the Amber web framework). A persisted
+// model is a class that inherits from `Granite::Base` and declares its mapping
+// with a macro DSL:
+//
+//	require "granite/adapter/pg"
+//
+//	class User < Granite::Base
+//	  connection pg
+//	  table users
+//
+//	  column id : Int64, primary: true
+//	  column name : String
+//	  column email : String
+//
+//	  has_many :posts
+//	end
+//
+//	class Post < Granite::Base
+//	  table posts
+//
+//	  column id : Int64, primary: true
+//	  column title : String
+//
+//	  belongs_to :user
+//	end
+//
+// What this extractor emits (mirrors the Ruby/Rails + Nim/Norm ORM shape —
+// SCOPE.Schema entities carrying framework+provenance props):
+//   - one SCOPE.Schema/model per `class T < Granite::Base` declaration
+//   - one SCOPE.Schema/table per model. The table identity is the explicit
+//     `table <name>` macro argument when present, otherwise the model class
+//     name (Granite's runtime default is the snake_case pluralisation; we record
+//     the declared name so the explicit-override case is exact and the implicit
+//     case is keyed by the class name).
+//   - one SCOPE.Schema/column per `column <name> : <Type>[, primary: true]`
+//     macro, stamping column_type, the owning model, and primary_key=true on the
+//     primary column.
+//   - a REFERENCES edge model → referenced model for each `belongs_to :other`
+//     association (the FK signal), keyed by the CamelCased association name.
+//   - an association SCOPE.Schema/association entity per belongs_to/has_many/
+//     has_one carrying assoc_kind + target, so the association DSL is recorded
+//     even when the target model lives in another file.
+//
+// Honest exclusions / follow-ups (no fabricated schema — #4935):
+//   - `column` macro options beyond `primary: true` (converters, nilable `?`
+//     handling, defaults), the `timestamps` helper, and `table`-less implicit
+//     pluralisation are not deepened here.
+//   - Granite query DSL (`Model.all/find/where`) query_attribution, Granite
+//     migrations, and transaction stamping are deferred to #4935.
+//   - Jennifer / Clear / Avram / Crecto ORMs are deferred to #4936.
+//
+// Registration key: "custom_crystal_granite_orm".
+package crystal
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_crystal_granite_orm", &graniteORMExtractor{})
+}
+
+type graniteORMExtractor struct{}
+
+func (e *graniteORMExtractor) Language() string { return "custom_crystal_granite_orm" }
+
+var (
+	// graniteModelRe matches a Granite model class declaration: a class that
+	// inherits from `Granite::Base`. Capture group 1 is the model class name.
+	graniteModelRe = regexp.MustCompile(
+		`(?m)^[ \t]*(?:abstract\s+)?class\s+([A-Z]\w*)\s*<\s*Granite::Base\b`)
+
+	// graniteTableRe matches the `table <name>` macro (name may be a bare
+	// identifier or a symbol/string literal). Capture group 1 is the table name.
+	graniteTableRe = regexp.MustCompile(
+		`(?m)^[ \t]*table\s+:?["']?([A-Za-z_]\w*)["']?`)
+
+	// graniteColumnRe matches a `column <name> : <Type>[, primary: true]` macro.
+	// Group 1 = column name; group 2 = column type (`?` nilable marker trimmed
+	// by the caller); group 3 = the trailing options (scanned for `primary`).
+	graniteColumnRe = regexp.MustCompile(
+		`(?m)^[ \t]*column\s+([a-z_]\w*)\s*:\s*([A-Za-z_][\w:]*\??)\s*(,.*)?$`)
+
+	// graniteAssocRe matches a belongs_to / has_many / has_one association macro.
+	// Group 1 = association kind; group 2 = association name (symbol/string).
+	graniteAssocRe = regexp.MustCompile(
+		`(?m)^[ \t]*(belongs_to|has_many|has_one)\s+:?["']?([a-z_]\w*)["']?`)
+)
+
+// graniteHasModel is a fast pre-filter: the file must reference Granite's base
+// type to be worth scanning, so we never misfire on arbitrary Crystal classes.
+func graniteHasModel(content string) bool {
+	return strings.Contains(content, "Granite::Base")
+}
+
+func (e *graniteORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "crystal" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !graniteHasModel(src) {
+		return nil, nil
+	}
+
+	models := collectGraniteModels(src)
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	for _, m := range models {
+		// 1. model entity.
+		model := newGraniteSchema(m.name, "model", file.Path, m.line,
+			"INFERRED_FROM_GRANITE_MODEL")
+		var rels []types.RelationshipRecord
+		for _, a := range m.assocs {
+			if a.kind != "belongs_to" {
+				continue
+			}
+			// belongs_to :user → REFERENCES User (CamelCased singular target).
+			target := camelize(a.name)
+			rels = append(rels, types.RelationshipRecord{
+				ToID: target,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"fk_field": a.name,
+					"to_model": target,
+				},
+			})
+		}
+		model.Relationships = rels
+		model.ID = model.ComputeID()
+		out = append(out, model)
+
+		// 2. table entity (explicit `table <name>` or the class name).
+		tableName := m.table
+		if tableName == "" {
+			tableName = m.name
+		}
+		table := newGraniteSchema(tableName, "table", file.Path, m.line,
+			"INFERRED_FROM_GRANITE_TABLE")
+		table.Properties["model"] = m.name
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 3. column entities.
+		colSeen := make(map[string]bool)
+		for _, c := range m.columns {
+			if colSeen[c.name] {
+				continue
+			}
+			colSeen[c.name] = true
+			col := newGraniteSchema(c.name, "column", file.Path, c.line,
+				"INFERRED_FROM_GRANITE_COLUMN")
+			col.Properties["column_type"] = c.typ
+			col.Properties["model"] = m.name
+			if c.primary {
+				col.Properties["primary_key"] = "true"
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+
+		// 4. association entities (one per belongs_to/has_many/has_one).
+		assocSeen := make(map[string]bool)
+		for _, a := range m.assocs {
+			key := a.kind + ":" + a.name
+			if assocSeen[key] {
+				continue
+			}
+			assocSeen[key] = true
+			assoc := newGraniteSchema(a.name, "association", file.Path, a.line,
+				"INFERRED_FROM_GRANITE_ASSOCIATION")
+			assoc.Properties["assoc_kind"] = a.kind
+			assoc.Properties["model"] = m.name
+			assoc.Properties["target"] = camelize(a.name)
+			assoc.ID = assoc.ComputeID()
+			out = append(out, assoc)
+		}
+	}
+	return out, nil
+}
+
+// graniteModel is a parsed Granite model with its table, columns, associations.
+type graniteModel struct {
+	name    string
+	table   string
+	line    int
+	columns []graniteColumn
+	assocs  []graniteAssoc
+}
+
+type graniteColumn struct {
+	name    string
+	typ     string
+	primary bool
+	line    int
+}
+
+type graniteAssoc struct {
+	kind string // belongs_to / has_many / has_one
+	name string
+	line int
+}
+
+// collectGraniteModels finds every `class T < Granite::Base` declaration and the
+// table/column/association macros in its `end`-terminated body.
+func collectGraniteModels(src string) []graniteModel {
+	idx := graniteModelRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	var models []graniteModel
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		bodyEnd := graniteClassEnd(src, m[1])
+		body := src[m[1]:bodyEnd]
+		bodyStartLine := startLine // body offsets converted to absolute lines below
+
+		gm := graniteModel{name: name, line: startLine}
+
+		if tm := graniteTableRe.FindStringSubmatch(body); tm != nil {
+			gm.table = tm[1]
+		}
+		for _, cm := range graniteColumnRe.FindAllStringSubmatchIndex(body, -1) {
+			cname := body[cm[2]:cm[3]]
+			ctyp := strings.TrimSuffix(body[cm[4]:cm[5]], "?")
+			opts := ""
+			if cm[6] >= 0 {
+				opts = body[cm[6]:cm[7]]
+			}
+			primary := strings.Contains(opts, "primary")
+			cline := bodyStartLine + strings.Count(body[:cm[0]], "\n")
+			gm.columns = append(gm.columns, graniteColumn{
+				name: cname, typ: ctyp, primary: primary, line: cline,
+			})
+		}
+		for _, am := range graniteAssocRe.FindAllStringSubmatchIndex(body, -1) {
+			akind := body[am[2]:am[3]]
+			aname := body[am[4]:am[5]]
+			aline := bodyStartLine + strings.Count(body[:am[0]], "\n")
+			gm.assocs = append(gm.assocs, graniteAssoc{
+				kind: akind, name: aname, line: aline,
+			})
+		}
+		models = append(models, gm)
+	}
+	return models
+}
+
+// graniteBlockRe matches Crystal block openers and the `end` closer so a class
+// body can be delimited by tracking nesting depth.
+var graniteBlockRe = regexp.MustCompile(
+	`\b(class|module|struct|def|macro|lib|enum|annotation|begin|do|if|unless|case|while|until|for|end)\b`)
+
+// graniteClassEnd scans forward from fromByte (just past the class header)
+// tracking nested block openers and returns the byte offset just before the
+// matching `end` that closes the class. Falls back to len(src) when malformed.
+func graniteClassEnd(src string, fromByte int) int {
+	sub := src[fromByte:]
+	depth := 1
+	pos := 0
+	for pos < len(sub) {
+		loc := graniteBlockRe.FindStringIndex(sub[pos:])
+		if loc == nil {
+			break
+		}
+		tok := sub[pos+loc[0] : pos+loc[1]]
+		if tok == "end" {
+			depth--
+			if depth == 0 {
+				return fromByte + pos + loc[0]
+			}
+		} else {
+			depth++
+		}
+		pos += loc[1]
+	}
+	return len(src)
+}
+
+// camelize converts a snake_case association name to a CamelCase model name:
+// `user` → `User`, `blog_post` → `BlogPost`. Used to map a belongs_to symbol to
+// its target model class.
+func camelize(s string) string {
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
+}
+
+// newGraniteSchema builds a SCOPE.Schema entity with the Granite framework + the
+// given provenance stamp.
+func newGraniteSchema(name, subtype, path string, line int, provenance string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       name,
+		Kind:       "SCOPE.Schema",
+		Subtype:    subtype,
+		SourceFile: path,
+		Language:   "crystal",
+		StartLine:  line,
+		EndLine:    line,
+		Properties: map[string]string{
+			"framework":  "granite",
+			"provenance": provenance,
+		},
+	}
+}

--- a/internal/custom/crystal/granite_orm_test.go
+++ b/internal/custom/crystal/granite_orm_test.go
@@ -1,0 +1,183 @@
+package crystal_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
+)
+
+// gfi builds a Granite-test FileInput (a distinct helper from extractors_test.go's
+// fi to avoid a redeclaration in the same package).
+func gfi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestCrystalGraniteORM_ModelTableColumns proves a `class T < Granite::Base`
+// model synthesises model + table + column + association SCOPE.Schema entities,
+// honours an explicit `table` name, stamps the primary column, and emits a
+// belongs_to FK edge.
+func TestCrystalGraniteORM_ModelTableColumns(t *testing.T) {
+	src := `
+require "granite/adapter/pg"
+
+class User < Granite::Base
+  connection pg
+  table users
+
+  column id : Int64, primary: true
+  column name : String
+  column email : String
+
+  has_many :posts
+end
+
+class Post < Granite::Base
+  table posts
+
+  column id : Int64, primary: true
+  column title : String
+  column body : String?
+
+  belongs_to :user
+end
+`
+	e, ok := extreg.Get("custom_crystal_granite_orm")
+	if !ok {
+		t.Fatal("custom_crystal_granite_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), gfi("src/models.cr", "crystal", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	type key struct{ name, sub string }
+	got := map[key]bool{}
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+			continue
+		}
+		if en.Properties["framework"] != "granite" {
+			t.Errorf("entity %q missing framework=granite", en.Name)
+		}
+		got[key{en.Name, en.Subtype}] = true
+	}
+
+	// Models.
+	for _, m := range []string{"User", "Post"} {
+		if !got[key{m, "model"}] {
+			t.Errorf("expected SCOPE.Schema/model %q", m)
+		}
+	}
+	// Explicit table names (table users / table posts).
+	for _, tbl := range []string{"users", "posts"} {
+		if !got[key{tbl, "table"}] {
+			t.Errorf("expected SCOPE.Schema/table %q (explicit table macro)", tbl)
+		}
+	}
+	// Columns.
+	for _, c := range []string{"id", "name", "email", "title", "body"} {
+		if !got[key{c, "column"}] {
+			t.Errorf("expected SCOPE.Schema/column %q", c)
+		}
+	}
+	// Associations.
+	if !got[key{"posts", "association"}] {
+		t.Error("expected SCOPE.Schema/association posts (has_many)")
+	}
+	if !got[key{"user", "association"}] {
+		t.Error("expected SCOPE.Schema/association user (belongs_to)")
+	}
+
+	// Primary-key column stamp + nilable type trim + FK edge.
+	primaryStamped := false
+	bodyTypeTrimmed := false
+	fkFound := false
+	assocKind := ""
+	for _, en := range ents {
+		if en.Name == "id" && en.Subtype == "column" && en.Properties["primary_key"] == "true" {
+			primaryStamped = true
+		}
+		if en.Name == "body" && en.Subtype == "column" && en.Properties["column_type"] == "String" {
+			bodyTypeTrimmed = true // `String?` nilable marker trimmed
+		}
+		if en.Name == "Post" && en.Subtype == "model" {
+			for _, r := range en.Relationships {
+				if r.Kind == "REFERENCES" && r.ToID == "User" && r.Properties["fk_field"] == "user" {
+					fkFound = true
+				}
+			}
+		}
+		if en.Name == "user" && en.Subtype == "association" {
+			assocKind = en.Properties["assoc_kind"]
+		}
+	}
+	if !primaryStamped {
+		t.Error("expected id column stamped primary_key=true")
+	}
+	if !bodyTypeTrimmed {
+		t.Error("expected body column column_type=String (nilable `?` trimmed)")
+	}
+	if !fkFound {
+		t.Error("expected REFERENCES edge Post→User (fk_field=user) from belongs_to :user")
+	}
+	if assocKind != "belongs_to" {
+		t.Errorf("expected user association assoc_kind=belongs_to, got %q", assocKind)
+	}
+}
+
+// TestCrystalGraniteORM_ImplicitTableName proves a model without an explicit
+// `table` macro keys the table by the class name.
+func TestCrystalGraniteORM_ImplicitTableName(t *testing.T) {
+	src := `
+class Widget < Granite::Base
+  column id : Int64, primary: true
+  column label : String
+end
+`
+	e, _ := extreg.Get("custom_crystal_granite_orm")
+	ents, err := e.Extract(context.Background(), gfi("src/widget.cr", "crystal", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	tableByName := false
+	for _, en := range ents {
+		if en.Subtype == "table" && en.Name == "Widget" {
+			tableByName = true
+		}
+	}
+	if !tableByName {
+		t.Error("expected table keyed by class name Widget when no explicit table macro")
+	}
+}
+
+// TestCrystalGraniteORM_NonModelNoop proves a plain (non-Granite) class is
+// ignored.
+func TestCrystalGraniteORM_NonModelNoop(t *testing.T) {
+	src := `
+class Config
+  def initialize(@host : String, @port : Int32)
+  end
+end
+`
+	e, _ := extreg.Get("custom_crystal_granite_orm")
+	ents, _ := e.Extract(context.Background(), gfi("src/config.cr", "crystal", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no schema entities for a non-Granite class, got %d", len(ents))
+	}
+}
+
+// TestCrystalGraniteORM_WrongLanguageNoop gates on language=="crystal".
+func TestCrystalGraniteORM_WrongLanguageNoop(t *testing.T) {
+	src := `class User < Granite::Base
+  column id : Int64, primary: true
+end`
+	e, _ := extreg.Get("custom_crystal_granite_orm")
+	ents, _ := e.Extract(context.Background(), gfi("src/models.cr", "ruby", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-crystal language, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Crystal coverage audit (#4905)

Crystal previously had ONLY `lang.crystal.framework.kemal` with almost everything marked `missing`, despite a large extracted-but-undocumented surface. This documents it honestly, adds the base record, and implements the highest-value missing ORM extraction.

### Documented (registry flips, code cites + fixture/test proof)
**New base record `lang.crystal.core`** (`internal/extractors/crystal/extractor.go`):
- `core_extraction` **full** — class/abstract class/struct/module/lib SCOPE.Component, def/macro SCOPE.Operation, CONTAINS + EXTENDS inheritance edges.
- `call_line_precision` **partial** — `extractCallRelationships` + skipKeywords denylist (no per-call line stamp yet → #4937).
- `import_resolution_quality` **partial** — `require`/`require_relative` IMPORTS edges to path placeholders.

**`lang.crystal.framework.kemal` flips:**
- Routing: `route_extraction` + `endpoint_synthesis` **full** (`internal/engine/http_endpoint_kemal.go` synthesizeKemalRoutes — Kemal/Amber/Lucky with colon-param canonicalisation), `handler_attribution` **partial**.
- Type System: `type_extraction` **full**, `type_graph_extraction` **partial** (EXTENDS spine). enum/interface/alias → #4937.
- DI cells → **not_applicable** (Crystal has no DI-container idiom).
- Data `db_effect` + full **Substrate** suite flipped with producer cites: `substrate/crystal.go` (constant/config/env-fallback), `effect_sinks_crystal.go` (http/db/fs/mutation effects), `taint_sites_crystal.go` (taint source/sink/sanitizer/request-sink), `def_use_crystal.go` (def-use chains), `template_pattern_crystal.go` (template-pattern catalog + log).

### Implemented (new extraction + fixture)
- `internal/custom/crystal/granite_orm.go` (`custom_crystal_granite_orm`): Granite `class T < Granite::Base` → SCOPE.Schema model + table (explicit `table` macro or class name) + per-`column` (column_type, primary_key) + belongs_to/has_many/has_one association entities; REFERENCES FK edge for belongs_to (CamelCased target). Pre-filtered on the `Granite::Base` marker; nilable `?` trimmed; self-contained nesting-aware class-body scanner.
- `lang.crystal.orm.granite` record: model/association/relationship_extraction **full**, schema/foreign_key **partial**, lazy_loading **not_applicable**, queries/migrations/transactions → #4935.
- Tests (`granite_orm_test.go`): ModelTableColumns, ImplicitTableName, NonModelNoop, WrongLanguageNoop.

### Deferred (follow-ups filed)
- **#4935** Granite deepening (column options/timestamps, query DSL, migrations, transactions, through/polymorphic).
- **#4936** other Crystal ORMs (Jennifer/Clear/Avram/Crecto).
- **#4937** base extractor depth (enum/alias/generics/Type.method receivers/macro-gen methods/Spectator tests + Lucky/Amber first-class framework records).

### Gates (sandbox HOME = `/tmp/agsbx-4905`)
- `coverage fmt --check`: **ok, canonical**
- `coverage validate`: **ok, 673 records** (warnings pre-existing/unrelated)
- `go build ./...`, `go vet`, `go test ./internal/extractors/crystal/... ./internal/custom/crystal/... ./internal/types/`: **green**
- Registry-only diff (187 ins / 49 del, crystal records only); no `coverage gen` markdown swept.

Closes #4905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
