### PR TITLE
feat(#4906): fsharp coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -2346,6 +2346,24 @@ var frameworkOrder = []frameworkEntry{
 		},
 		detect: detectNimUnittest,
 	},
+	// F# — Expecto (testList/testCase) + xUnit/NUnit ([<Fact>]/[<Theory>]/[<Test>])
+	// (#4906). F# uses `open` (not `import`) so importTokenRE cannot gate it;
+	// detection is filename/path-hint gated on the standard F# test conventions
+	// and the detector self-confirms (a non-test .fs file yields zero cases and
+	// is dropped downstream, like the rust_test entry). Off-side-rule bodies are
+	// scanned via the shared indentation block extractor.
+	{
+		name: "fsharp-expecto",
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`Tests?\.fs$`),
+			regexp.MustCompile(`^Test.*\.fs$`),
+			regexp.MustCompile(`_test\.fs$`),
+		},
+		pathHints: []*regexp.Regexp{
+			regexp.MustCompile(`/tests?/.*\.fs$`),
+		},
+		detect: detectFSharpExpecto,
+	},
 	// ---------------------------------------------------------------------
 	// C/C++ — gtest, catch2, doctest, boost.test, cppunit, cpputest (#3495).
 	//

--- a/internal/extractors/cross/testmap/frameworks_fsharp.go
+++ b/internal/extractors/cross/testmap/frameworks_fsharp.go
@@ -1,0 +1,218 @@
+// Package testmap — F# test-framework detection and call resolution.
+//
+// #4906 (the F# slice of the coverage-linkage tail epic #4749/#4615; mirrors the
+// Nim slice #4749 in frameworks_nim.go). Deep linkage for the two dominant F#
+// test runners:
+//
+//	Expecto (the de-facto F# test framework):
+//	  testList "Subject" [
+//	    testCase "does y" <| fun _ -> ...
+//	    testCaseAsync "does z async" <| async { ... }
+//	  ]
+//	  Each `testCase`/`testCaseAsync`/`ptestCase`/`ftestCase` leaf is a test case;
+//	  its body — the `fun _ -> ...` / `async { ... }` lambda that follows the `<|`
+//	  pipe-left — is the off-side-rule (indentation-delimited) block scanned for
+//	  direct production calls. The enclosing `testList "Subject"` is carried as a
+//	  naming-convention subject-under-test fallback (the F# analog of the Nim
+//	  `suite "..."` / RSpec `describe` subject path).
+//
+//	xUnit (and the structurally-identical NUnit `[<Test>]`) in F#:
+//	  [<Fact>]
+//	  let ``returns 200 for a known user`` () =
+//	      let svc = UserService()
+//	      ...
+//	  The attribute-decorated `let`-binding is a named test case; its body is the
+//	  indentation-delimited run that follows the `=`.
+//
+// F# blocks are OFF-SIDE-RULE (indentation) delimited — no braces, no `end`
+// keyword — so this file reuses the Nim block-body extractor (extractNimBlockBody)
+// and the Nim test-case-name normaliser (nimTestCaseName); both are pure
+// indentation/identifier helpers that are not Nim-specific.
+//
+// F# uses `open` (not `import`) for module imports, which the shared
+// importTokenRE does not capture, so the F# framework entries are FILENAME/PATH
+// gated (the standard `*Test.fs` / `*Tests.fs` / `Test*.fs` / `/tests?/` /
+// `/test/` conventions) and the detector self-confirms: a non-test `.fs` file
+// yields zero test cases and is dropped by the Extract-level empty-result filter,
+// exactly like the rust_test entry.
+package testmap
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Expecto — testList "..." / testCase "..." <| fun _ -> …
+// ---------------------------------------------------------------------------
+
+// fsharpExpectoCaseRE matches an Expecto leaf case header:
+//
+//	testCase "description" <| fun _ ->
+//	testCaseAsync "description" <| async {
+//	ptestCase "pending" <| fun _ ->      (pending/skipped — still a case)
+//	ftestCase "focused" <| fun _ ->      (focused)
+//
+// Group 1 is the description literal. The header may end with the lambda opener
+// (`fun _ ->` / `async {`) on the same line; the body is the indented run that
+// follows (extractNimBlockBody).
+var fsharpExpectoCaseRE = regexp.MustCompile(
+	`(?m)^([ \t]*)(?:p|f)?testCase(?:Async)?\s+"([^"\n\r]{1,200})"`,
+)
+
+// fsharpExpectoListRE matches an Expecto container: `testList "Subject" [`. The
+// first list whose subject is identifier-shaped seeds the subject-under-test
+// fallback (mirrors nimUnittestSuiteRE).
+var fsharpExpectoListRE = regexp.MustCompile(
+	`(?m)^[ \t]*(?:p|f)?testList\s+"([^"\n\r]{1,200})"`,
+)
+
+// fsharpSubjectIdentRE recognises a list/fixture subject that names a code symbol
+// (CamelCase / dotted), so a prose subject ("returns 200 on GET") is rejected.
+var fsharpSubjectIdentRE = regexp.MustCompile(`^[A-Za-z_][\w']*(?:[.][A-Za-z_][\w']*)*$`)
+
+// ---------------------------------------------------------------------------
+// xUnit / NUnit — [<Fact>] / [<Theory>] / [<Test>] let ``name`` () = …
+// ---------------------------------------------------------------------------
+
+// fsharpAttrTestRE matches an attribute-decorated F# test binding. F# allows the
+// attribute and the `let` on separate lines, so this is anchored at the `let`
+// and we confirm a preceding test attribute by a cheap look-back (see detector).
+// It matches both the double-backtick name form (`` `name with spaces` ``) and a
+// plain identifier name.
+//
+//	let ``returns 200`` () =
+//	let getUserReturnsOk () =
+//
+// Group 1 = backtick name (may be empty); group 2 = plain identifier name.
+var fsharpLetNameRE = regexp.MustCompile(
+	"(?m)^[ \\t]*let\\s+(?:``([^`\\n\\r]{1,200})``|([A-Za-z_][A-Za-z0-9_']*))\\s*\\(",
+)
+
+// fsharpTestAttrRE matches an xUnit/NUnit test attribute on its own or inline.
+var fsharpTestAttrRE = regexp.MustCompile(`\[<\s*(?:Fact|Theory|Test|TestCase|Property)\b`)
+
+// fsharpModuleRE captures the F# `module Foo.BarTests` declaration so a pure
+// xUnit/NUnit file (no testList container) can fall back to a module-derived
+// subject: a `XxxTests` / `XxxTest` module names the `Xxx` subject under test
+// (the standard F# test-module naming convention). Group 1 = module name tail.
+var fsharpModuleRE = regexp.MustCompile(`(?m)^[ \t]*module(?:\s+rec)?\s+(?:[\w']+\.)*([\w']+)`)
+
+// fsharpModuleSubject returns the subject implied by a `XxxTests` test-module
+// name (strips a trailing `Tests`/`Test`), or "" when the module is not test-
+// named or the strip leaves nothing.
+func fsharpModuleSubject(source string) string {
+	m := fsharpModuleRE.FindStringSubmatch(source)
+	if len(m) < 2 {
+		return ""
+	}
+	name := m[1]
+	for _, suf := range []string{"Tests", "Test"} {
+		if strings.HasSuffix(name, suf) && len(name) > len(suf) {
+			return name[:len(name)-len(suf)]
+		}
+	}
+	return ""
+}
+
+// fsharpListSubject returns the first identifier-shaped testList subject, or "".
+func fsharpListSubject(source string) string {
+	for _, m := range fsharpExpectoListRE.FindAllStringSubmatch(source, -1) {
+		subj := strings.TrimSpace(m[1])
+		subj = strings.TrimSuffix(subj, "()")
+		if fsharpSubjectIdentRE.MatchString(subj) {
+			if idx := strings.LastIndexByte(subj, '.'); idx >= 0 {
+				if tail := subj[idx+1:]; tail != "" {
+					return tail
+				}
+			}
+			return subj
+		}
+	}
+	return ""
+}
+
+// detectFSharpExpecto detects Expecto + xUnit/NUnit test cases in an F# source.
+func detectFSharpExpecto(source string) []testFunction {
+	subject := fsharpListSubject(source)
+	if subject == "" {
+		// Pure xUnit/NUnit files (and Expecto files whose testList carries a
+		// prose name) fall back to the test-module naming convention.
+		subject = fsharpModuleSubject(source)
+	}
+
+	var out []testFunction
+	seen := map[string]bool{}
+
+	// Expecto testCase / testCaseAsync leaves.
+	for _, m := range fsharpExpectoCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		desc := source[m[4]:m[5]]
+		name := nimTestCaseName(desc)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		body := extractNimBlockBody(source, m[0])
+		out = append(out, testFunction{qname: name, body: body, describeSubject: subject})
+	}
+
+	// xUnit / NUnit attribute-decorated `let` bindings. We require a test
+	// attribute somewhere in the file to gate (else a plain `.fs` with named
+	// lets would over-match), then attach the body of each attributed binding.
+	if fsharpTestAttrRE.MatchString(source) {
+		for _, m := range fsharpLetNameRE.FindAllStringSubmatchIndex(source, -1) {
+			// Confirm THIS binding is attributed: scan the few lines above the
+			// `let` for a test attribute (attributes may sit on their own line).
+			if !precededByTestAttr(source, m[0]) {
+				continue
+			}
+			var raw string
+			if m[2] >= 0 { // backtick name
+				raw = source[m[2]:m[3]]
+			} else if m[4] >= 0 { // plain identifier
+				raw = source[m[4]:m[5]]
+			}
+			name := nimTestCaseName(raw)
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			body := extractNimBlockBody(source, m[0])
+			out = append(out, testFunction{qname: name, body: body, describeSubject: subject})
+		}
+	}
+
+	return out
+}
+
+// precededByTestAttr reports whether a test attribute ([<Fact>], [<Theory>],
+// [<Test>], …) appears on the `let` header line itself or on the (whitespace-only
+// gap of) up to two non-blank lines immediately above it. This binds the
+// attribute to its `let` without a full parser.
+func precededByTestAttr(source string, letStart int) bool {
+	// Look back up to ~200 bytes / a handful of lines.
+	from := letStart - 200
+	if from < 0 {
+		from = 0
+	}
+	window := source[from:letStart]
+	// Only consider the tail: the lines directly above the `let`. We accept an
+	// attribute that is the last non-blank content before the binding.
+	lines := strings.Split(window, "\n")
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-3; i-- {
+		t := strings.TrimSpace(lines[i])
+		if t == "" {
+			continue
+		}
+		if fsharpTestAttrRE.MatchString(t) {
+			return true
+		}
+		// A non-blank, non-attribute line breaks the binding chain unless it is
+		// itself another attribute (e.g. [<Trait>] above [<Fact>]).
+		if strings.HasPrefix(t, "[<") {
+			continue
+		}
+		return false
+	}
+	return false
+}

--- a/internal/extractors/cross/testmap/frameworks_fsharp_test.go
+++ b/internal/extractors/cross/testmap/frameworks_fsharp_test.go
@@ -1,0 +1,133 @@
+// Package testmap — value-asserting tests for the F# Expecto + xUnit/NUnit
+// detector (#4906). Mirrors the Nim std/unittest tests; reuses the shared
+// off-side-rule block-body extractor.
+//
+// HONEST SCOPE: the shared resolver's directCallRE captures PAREN-style call
+// sites (`UserService()`, `Account.create()`) and the describe-subject from a
+// `testList "Subject"` container. F#'s SPACE-APPLIED application (`createUser
+// "ada"`) is the dominant functional call idiom and is NOT paren-captured — it
+// is a documented follow-up (see the coverage-doc note + #4906 follow-up). These
+// tests assert only the genuinely-working signals.
+package testmap
+
+import (
+	"testing"
+)
+
+// TestFSharpExpecto_SubjectLinkage proves an Expecto `testList "User"` container
+// seeds a describe-subject TESTS edge for each leaf `testCase`, attributed to the
+// fsharp-expecto framework.
+func TestFSharpExpecto_SubjectLinkage(t *testing.T) {
+	src := `
+module UserTests
+
+open Expecto
+open User
+
+let tests =
+    testList "User" [
+        testCase "creates a user" <| fun _ ->
+            let u = makeUser "ada"
+            Expect.equal u.name "ada" "name"
+    ]
+`
+	recs := runExtract(t, "tests/UserTests.fs", "fsharp", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 testmap entity for fsharp-expecto")
+	}
+	rec := findByTested(t, recs, "creates_a_user", "User")
+	if rec.Properties["test_framework"] != "fsharp-expecto" {
+		t.Errorf("framework=%q, want fsharp-expecto", rec.Properties["test_framework"])
+	}
+	if !hasEdge(recs, "creates_a_user", "User") {
+		t.Errorf("missing TESTS edge creates_a_user -> User (testList subject)")
+	}
+}
+
+// TestFSharpExpecto_ParenCallHighConfidence proves a PAREN-style .NET-interop
+// call inside a `testCase` body is captured as a direct (high-confidence) TESTS
+// edge — the F# constructor/interop call idiom.
+func TestFSharpExpecto_ParenCallHighConfidence(t *testing.T) {
+	src := `
+module SvcTests
+
+open Expecto
+open Svc
+
+let tests =
+    testList "Svc" [
+        testCase "alpha" <| fun _ ->
+            let svc = OrderService()
+            let r = svc.PlaceOrder(42)
+            Expect.isTrue r "ok"
+        testCase "beta" <| fun _ ->
+            let q = QueryRunner()
+            Expect.isTrue (q.RunBeta()) "b"
+    ]
+`
+	recs := runExtract(t, "tests/SvcTests.fs", "fsharp", src)
+	if !hasEdgeAny(recs, "alpha", "OrderService") {
+		t.Errorf("expected alpha -> OrderService paren-call edge")
+	}
+	// Block-body scoping: QueryRunner (from beta) must not leak into alpha.
+	if hasEdgeAny(recs, "alpha", "QueryRunner") {
+		t.Errorf("QueryRunner leaked into the alpha case body — block-body scoping failed")
+	}
+	if !hasEdgeAny(recs, "beta", "QueryRunner") {
+		t.Errorf("expected beta -> QueryRunner paren-call edge")
+	}
+}
+
+// TestFSharpXUnit_AttributedLetBinding proves an xUnit [<Fact>]-decorated `let`
+// binding is detected as a test case and its paren-call body is scanned.
+func TestFSharpXUnit_AttributedLetBinding(t *testing.T) {
+	src := `
+module AccountTests
+
+open Xunit
+open Account
+
+[<Fact>]
+let ` + "``creates an account``" + ` () =
+    let svc = AccountService()
+    let acc = svc.Open("savings")
+    Assert.NotNull acc
+`
+	recs := runExtract(t, "tests/AccountTests.fs", "fsharp", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 testmap entity for fsharp xUnit")
+	}
+	if !hasEdgeAny(recs, "creates_an_account", "AccountService") {
+		t.Errorf("expected creates_an_account -> AccountService edge")
+	}
+}
+
+// TestFSharp_NonTestFileNoop proves a plain production .fs file (no test
+// attribute, no Expecto case) is not detected as a test file.
+func TestFSharp_NonTestFileNoop(t *testing.T) {
+	src := `
+module User
+
+let createUser (name: string) : User =
+    { name = name }
+`
+	recs := runExtract(t, "src/User.fs", "fsharp", src)
+	if len(recs) != 0 {
+		t.Fatalf("expected no testmap entities for a production file, got %d", len(recs))
+	}
+}
+
+// TestFSharp_TestFilenameButNoCasesNoop proves a test-named .fs file that
+// contains no Expecto case and no test attribute yields zero entities (the
+// self-confirming detector, like rust_test).
+func TestFSharp_TestFilenameButNoCasesNoop(t *testing.T) {
+	src := `
+module Helpers
+
+let buildFixture () = ()
+`
+	recs := runExtract(t, "tests/HelpersTests.fs", "fsharp", src)
+	if len(recs) != 0 {
+		t.Fatalf("expected no entities for a test-named file with no cases, got %d", len(recs))
+	}
+}

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -455,6 +455,25 @@ var stopwords = map[string]bool{
 	"strcmp_equal": true, "strcmp_nocase_equal": true, "strncmp_equal": true,
 	"strcmp_contains": true, "test_exit": true, "fail_test": true,
 	"mock": true, "mock_c": true, "checkequal": true,
+	// F# — Expecto / Unquote / FsUnit / xUnit / NUnit assertion & DSL surface
+	// (#4906). These are test-harness identifiers (the case combinators, the
+	// Expecto `Expect.*` assertion family, FsUnit `should`, xUnit `Assert.*`)
+	// and must never surface as the F# production subject under test. The
+	// directCall scanner captures both the bare combinator (`testCase`) and the
+	// dotted assertion (`expect.equal`). Lower-cased (resolver lowercases first).
+	"testcase": true, "testcaseasync": true, "testlist": true, "testfixture": true,
+	"testtask": true, "ptestcase": true, "ftestcase": true, "testproperty": true,
+	"testpropertywithconfig": true, "testtheory": true, "tests": true,
+	"expect.equal": true, "expect.notequal": true, "expect.istrue": true,
+	"expect.isfalse": true, "expect.issome": true, "expect.isnone": true,
+	"expect.isok": true, "expect.iserror": true, "expect.isnull": true,
+	"expect.isnotnull": true, "expect.isempty": true, "expect.isnonempty": true,
+	"expect.throws": true, "expect.throwst": true, "expect.containsall": true,
+	"expect.sequenceequal": true, "expect.isgreaterthan": true, "expect.islessthan": true,
+	"expect.equals": true, "expect.all": true, "expect.exists": true,
+	// xUnit / NUnit (F# usage) — FsUnit `should` combinator (the Assert.* family
+	// is already covered by the C# xUnit denylist block above).
+	"should": true,
 	// Common language keywords that end up in call-like positions
 	"if": true, "for": true, "while": true, "switch": true, "return": true,
 	"func": true, "def": true, "class": true, "struct": true, "new": true,

--- a/internal/extractors/fsharp/fsharp_test.go
+++ b/internal/extractors/fsharp/fsharp_test.go
@@ -177,6 +177,45 @@ type IService =
 	}
 }
 
+// TestFSharp_TypeSubtypes proves classifyTypeSubtype distinguishes the F# type
+// kinds (#4906): record (`= {`), discriminated_union (`= |`), interface. This is
+// the evidence behind the lang.fsharp.core / Giraffe Type-System coverage cells.
+func TestFSharp_TypeSubtypes(t *testing.T) {
+	src := `module Types
+
+type Person = {
+    Name: string
+    Age: int
+}
+
+type Shape =
+    | Circle of float
+    | Rectangle of float * float
+
+type IService =
+    interface
+        abstract member Process: string -> string
+    end
+`
+	ents := runFSharp(t, src, "types.fs")
+	got := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			got[e.Name] = e.Subtype
+		}
+	}
+	want := map[string]string{
+		"Person":   "record",
+		"Shape":    "discriminated_union",
+		"IService": "interface",
+	}
+	for name, sub := range want {
+		if got[name] != sub {
+			t.Errorf("type %q subtype=%q, want %q", name, got[name], sub)
+		}
+	}
+}
+
 // TestFSharp_OpenStatements — open statements emit IMPORTS edges.
 func TestFSharp_OpenStatements(t *testing.T) {
 	src := `module App


### PR DESCRIPTION
Audit of the F# extractor surface (internal/extractors/fsharp/extractor.go, internal/engine/http_endpoint_giraffe.go, internal/resolve/dynamic_patterns_fsharp.go, internal/substrate/fsharp.go) vs docs/coverage/registry.json. Before this PR F# had ONLY `lang.fsharp.framework.giraffe` and most of it was wrongly marked `missing`.

## Documented (cites + proving tests — honest)
**NEW base record `lang.fsharp.core`:**
- `core_extraction` **full** — moduleRE/namespaceRE → Component(module/namespace); letRE/memberRE → Operation(let/member, dedup); typeRE + classifyTypeSubtype → record/discriminated_union/interface/class/struct; type CONTAINS members. Cites extractor.go + fsharp_test.go.
- `import_resolution_quality` **partial** — collectOpenStatements/buildImportEntities `open`→IMPORTS + substrate constant sniffer.
- `call_line_precision` **partial** — collectCalls paren/pipe(`|>`)/compose(`>>`) CALLS + string/comment scrub + keyword denylist; quality sharpened by dynamic_patterns_fsharp.go.

**Giraffe routing flips (were wrongly `missing`):**
- `endpoint_synthesis` **full**, `route_extraction` **partial**, `handler_attribution` **partial** — http_endpoint_giraffe.go fully extracts Giraffe `GET >=> route/routef/routeCi` + Saturn `router { get }` → canonical http_endpoint_definition via FrameworkGiraffe. Proven by existing TestGiraffe_*.

**Giraffe Type-System cells** flipped to **partial** (type/enum/interface/alias), backed by NEW `TestFSharp_TypeSubtypes` proving record/discriminated_union/interface subtypes.

## Implemented (new extraction + fixtures)
- **F# Expecto + xUnit/NUnit test→SUT detection** in the cross-language testmap extractor — NEW `internal/extractors/cross/testmap/frameworks_fsharp.go`: Expecto `testList "Subject" [ testCase "..." <| fun _ -> ... ]` / testCaseAsync / p/f variants AND `[<Fact>]/[<Theory>]/[<Test>] let \`\`name\`\` () = ...` attributed bindings; off-side-rule body scan (shared extractNimBlockBody); paren-call high-confidence + testList/`XxxTests`-module subject linkage; filename/path gated + self-confirming (like rust_test). NEW registry record `test.fsharp-expecto`.
- F#/Expecto/Unquote/FsUnit assertion+combinator DSL denylisted in resolver.go (never surfaces as production subject).
- 5 testmap fixtures + 1 base-extractor subtype fixture; all green.

## Deferred (follow-ups filed)
- #4939 — SPACE-APPLIED application (`f arg`, dominant F# idiom) not captured by paren-anchored regex + per-call line stamping.
- #4940 — Giraffe subRoute/forward prefix folding + routex/routeStartsWith + named-handler IMPLEMENTS.
- #4941 — db_effect (EF Core/Dapper.FSharp/SQLProvider/Npgsql.FSharp) + FsCheck/Unquote/FsUnit + Falco/Suave/Oxpecker.
- #4942 — DU cases/record fields as sub-entities + computation-expressions/active-patterns + Fable/Serilog/Validus.

## Gates (sandbox HOME=/tmp/agsbx-4906)
- `go build ./...` OK, `go vet ./internal/...` OK
- `go test ./internal/extractors/fsharp/... ./internal/custom/fsharp/... ./internal/extractors/cross/testmap/... ./internal/types/ ./internal/engine/` all PASS
- `coverage fmt --check`: canonical ✅ · `coverage validate`: pass (exit 0)
- registry diff touches ONLY fsharp records (no stale `gen` markdown sweep).

Closes #4906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)