### PR TITLE
feat(#4908): cobol coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/cobol/depth.go
+++ b/internal/extractors/cobol/depth.go
@@ -426,6 +426,140 @@ func extractCICSTransfers(body string) []cicsCmd {
 	return out
 }
 
+// ---------------------------------------------------------------------------
+// FILE-CONTROL / VSAM file-control extraction — #4908
+//
+// ENVIRONMENT DIVISION ▸ INPUT-OUTPUT SECTION ▸ FILE-CONTROL declares the
+// mapping from a logical COBOL file (the name used by OPEN/READ/WRITE in the
+// PROCEDURE DIVISION) to a physical dataset / VSAM cluster via
+//
+//	SELECT <logical-file> ASSIGN TO <ddname-or-dataset>
+//	    ORGANIZATION IS {SEQUENTIAL|INDEXED|RELATIVE|LINE SEQUENTIAL}
+//	    ACCESS MODE IS {SEQUENTIAL|RANDOM|DYNAMIC}
+//	    RECORD KEY IS <field>   (VSAM KSDS).
+//
+// Until now the extractor emitted abstract fs_read / fs_write effects but no
+// resolvable file entity, so `READ EMP-FILE` could not be bound to a physical
+// dataset and shared-VSAM coupling between programs (and the JCL DD that
+// allocates the same dataset) was invisible. We emit one SCOPE.Datastore/file
+// entity per SELECT. Its `assign_to` is upper-cased so it matches the JCL DD
+// name (the cross-language coupling key), mirroring the jcl extractor's
+// SCOPE.Datastore/dataset naming so the by-name resolver can bridge them.
+// ---------------------------------------------------------------------------
+
+var (
+	// fileControlRe marks the FILE-CONTROL paragraph that opens the SELECT
+	// declarations within INPUT-OUTPUT SECTION.
+	fileControlRe = regexp.MustCompile(`(?i)^\s*FILE-CONTROL\s*\.`)
+
+	// selectAssignRe captures `SELECT <logical> ASSIGN TO <target>`. The
+	// OPTIONAL keyword and a leading TO are tolerated; the target may be a
+	// quoted literal, a DDname, or an environment-variable style name.
+	selectAssignRe = regexp.MustCompile(
+		`(?i)\bSELECT\s+(?:OPTIONAL\s+)?([A-Za-z0-9][A-Za-z0-9-]*)\s+ASSIGN\s+(?:TO\s+)?` +
+			`['"]?([A-Za-z0-9$#@./_-]+)['"]?`,
+	)
+
+	// fileOrgRe / fileAccessRe / fileKeyRe capture the VSAM-relevant clauses
+	// that may follow a SELECT across continuation lines (the SELECT statement
+	// is buffered to its terminating period before these are scanned).
+	fileOrgRe    = regexp.MustCompile(`(?i)\bORGANIZATION\s+(?:IS\s+)?(LINE\s+SEQUENTIAL|SEQUENTIAL|INDEXED|RELATIVE)`)
+	fileAccessRe = regexp.MustCompile(`(?i)\bACCESS\s+(?:MODE\s+)?(?:IS\s+)?(SEQUENTIAL|RANDOM|DYNAMIC)`)
+	fileKeyRe    = regexp.MustCompile(`(?i)\bRECORD\s+KEY\s+(?:IS\s+)?([A-Za-z0-9][A-Za-z0-9-]*)`)
+)
+
+var (
+	// fileOpenRe captures `OPEN <mode> <file>...` — the mode governs whether
+	// subsequent traffic reads or writes; we record per-file open intent.
+	fileOpenRe = regexp.MustCompile(`(?i)\bOPEN\s+(INPUT|OUTPUT|I-O|EXTEND)\s+([A-Za-z][A-Za-z0-9-\s]*)`)
+	// fileReadRe / fileWriteRe capture record-level I/O verbs on a logical file
+	// (READ <file>; WRITE/REWRITE <record>; START/DELETE <file>). The operand
+	// is resolved against the FILE-CONTROL logical-file set, so a WRITE of an
+	// FD record name won't match (only file handles do).
+	fileReadRe  = regexp.MustCompile(`(?i)\b(READ|START)\s+([A-Za-z][A-Za-z0-9-]*)`)
+	fileWriteRe = regexp.MustCompile(`(?i)\b(WRITE|REWRITE|DELETE)\s+([A-Za-z][A-Za-z0-9-]*)`)
+)
+
+// fileSelect is one parsed SELECT ... ASSIGN clause.
+type fileSelect struct {
+	logical  string // logical file name (the OPEN/READ/WRITE handle)
+	assignTo string // physical DDname / dataset (upper-cased coupling key)
+	org      string // SEQUENTIAL | INDEXED | RELATIVE | LINE SEQUENTIAL
+	access   string // SEQUENTIAL | RANDOM | DYNAMIC
+	key      string // RECORD KEY (VSAM KSDS), when present
+	line     int    // 1-based line of the SELECT
+}
+
+// fileResourceRef builds a stable identity for a COBOL file SCOPE.Datastore so
+// READS_FROM / WRITES_TO edges from paragraphs resolve to it, and so the
+// physical-dataset coupling key (assign_to) is recoverable.
+func fileResourceRef(filePath, logical string) string {
+	return "scope:datastore:cobol:" + filepath.ToSlash(filePath) + "#file:" + strings.ToUpper(logical)
+}
+
+// parseFileSelect extracts a SELECT ... ASSIGN clause (with any VSAM clauses
+// gathered from the buffered statement body). Returns ok=false when the body
+// is not a SELECT or carries no ASSIGN target.
+func parseFileSelect(body string, line int) (fileSelect, bool) {
+	m := selectAssignRe.FindStringSubmatch(body)
+	if m == nil {
+		return fileSelect{}, false
+	}
+	fs := fileSelect{
+		logical:  m[1],
+		assignTo: strings.ToUpper(strings.TrimRight(m[2], ".")),
+		line:     line,
+	}
+	if om := fileOrgRe.FindStringSubmatch(body); om != nil {
+		fs.org = strings.ToUpper(strings.Join(strings.Fields(om[1]), " "))
+	}
+	if am := fileAccessRe.FindStringSubmatch(body); am != nil {
+		fs.access = strings.ToUpper(am[1])
+	}
+	if km := fileKeyRe.FindStringSubmatch(body); km != nil {
+		fs.key = km[1]
+	}
+	return fs, true
+}
+
+// buildFileResourceEntity turns a SELECT clause into a SCOPE.Datastore/file
+// entity. The org distinguishes a VSAM cluster (INDEXED/RELATIVE) from a flat
+// sequential dataset; the presence of a RECORD KEY marks a KSDS.
+func buildFileResourceEntity(filePath string, fs fileSelect) types.EntityRecord {
+	props := map[string]string{
+		"logical_file": fs.logical,
+		"assign_to":    fs.assignTo,
+	}
+	if fs.org != "" {
+		props["organization"] = fs.org
+	}
+	if fs.access != "" {
+		props["access_mode"] = fs.access
+	}
+	if fs.key != "" {
+		props["record_key"] = fs.key
+	}
+	// Classify the physical storage layer: VSAM for keyed/relative
+	// organizations, sequential dataset otherwise.
+	storage := "sequential"
+	if fs.org == "INDEXED" || fs.org == "RELATIVE" || fs.key != "" {
+		storage = "vsam"
+	}
+	props["storage"] = storage
+	return types.EntityRecord{
+		Name:          fs.logical,
+		Kind:          "SCOPE.Datastore",
+		Subtype:       "file",
+		QualifiedName: fileResourceRef(filePath, fs.logical),
+		SourceFile:    filePath,
+		Language:      "cobol",
+		StartLine:     fs.line,
+		EndLine:       fs.line,
+		Signature:     "SELECT " + fs.logical + " ASSIGN TO " + fs.assignTo,
+		Properties:    props,
+	}
+}
+
 // cicsCallEdge builds the CALLS relationship for a CICS program/transaction
 // transfer. external=true (cross-program); via=EXEC-CICS-<VERB>.
 func cicsCallEdge(c cicsCmd, line int) types.RelationshipRecord {

--- a/internal/extractors/cobol/extractor.go
+++ b/internal/extractors/cobol/extractor.go
@@ -261,6 +261,18 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 	// span many lines; we buffer its body until END-EXEC, then extract.
 	var execBuf *execBlock
 
+	// FILE-CONTROL / SELECT tracking (#4908). When inside FILE-CONTROL we
+	// buffer each SELECT statement to its terminating period (the VSAM
+	// ORGANIZATION / ACCESS / RECORD KEY clauses usually trail on continuation
+	// lines) and then emit a SCOPE.Datastore/file resource. fileEntityIdx maps
+	// the upper-cased logical file name → its entity index so PROCEDURE-DIVISION
+	// OPEN/READ/WRITE verbs can attach READS_FROM / WRITES_TO edges that bind to
+	// a resolvable physical dataset / VSAM cluster.
+	inFileControl := false
+	var selectBuf strings.Builder
+	selectStartLine := 0
+	fileEntityIdx := map[string]int{}
+
 	// Data-hierarchy tracking: a stack of (level, entity index) so 05/10 items
 	// can record their parent group via a CONTAINS edge and a parent property.
 	type dataScope struct {
@@ -282,6 +294,35 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 			return currentParagraphName
 		}
 		return programName
+	}
+
+	// flushSelect emits the SCOPE.Datastore/file resource for a buffered
+	// SELECT ... ASSIGN statement (FILE-CONTROL, #4908) and records its index
+	// so file-I/O verbs can wire data-flow edges to it.
+	flushSelect := func() {
+		body := selectBuf.String()
+		selectBuf.Reset()
+		if strings.TrimSpace(body) == "" {
+			return
+		}
+		fs, ok := parseFileSelect(body, selectStartLine)
+		if !ok {
+			return
+		}
+		key := strings.ToUpper(fs.logical)
+		if _, dup := fileEntityIdx[key]; dup {
+			return
+		}
+		idx := len(entities)
+		ent := buildFileResourceEntity(filePath, fs)
+		entities = append(entities, ent)
+		fileEntityIdx[key] = idx
+		// CONTAINS: program → file resource (keep it from being an orphan).
+		if programIdx >= 0 {
+			entities[programIdx].Relationships = append(entities[programIdx].Relationships,
+				types.RelationshipRecord{ToID: ent.QualifiedName, Kind: "CONTAINS",
+					Properties: map[string]string{"file": fs.logical}})
+		}
 	}
 
 	// flushExecBlock processes a completed EXEC SQL / CICS block: SQL blocks
@@ -355,6 +396,8 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 		// ── DIVISION ──────────────────────────────────────────────────────
 		if m := divisionRe.FindStringSubmatch(ln.code); m != nil {
 			div := strings.ToUpper(m[1])
+			flushSelect()
+			inFileControl = false
 			inProcedureDivision = div == "PROCEDURE"
 			inDataItemArea = false
 			currentParagraphIdx = -1
@@ -384,6 +427,40 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 			inDataItemArea = true
 		} else if hasSectionKeyword(ln.upper, "FILE") && strings.Contains(ln.upper, "SECTION") {
 			inDataItemArea = true
+		}
+
+		// ── FILE-CONTROL / SELECT (#4908) ────────────────────────────────
+		// A SELECT statement may span continuation lines; buffer it until its
+		// terminating period, then emit the file resource. FILE-CONTROL opens
+		// the region; any DATA DIVISION marker closes it (handled below via the
+		// divisionRe branch above, which resets inFileControl indirectly —
+		// guarded here for the common case).
+		if fileControlRe.MatchString(ln.code) {
+			flushSelect()
+			inFileControl = true
+			continue
+		}
+		if inFileControl {
+			up := strings.TrimSpace(ln.upper)
+			// A SELECT begins a new clause; flush any prior buffered one first.
+			if strings.HasPrefix(up, "SELECT ") {
+				flushSelect()
+				selectStartLine = ln.num
+			}
+			if selectBuf.Len() > 0 || strings.HasPrefix(up, "SELECT ") {
+				selectBuf.WriteByte(' ')
+				selectBuf.WriteString(ln.code)
+				// A period terminates the SELECT entry (clauses use IS, not '.').
+				if strings.Contains(ln.code, ".") {
+					flushSelect()
+				}
+				continue
+			}
+			// I-O-CONTROL / DATA DIVISION ends the FILE-CONTROL region.
+			if strings.HasPrefix(up, "I-O-CONTROL") {
+				flushSelect()
+				inFileControl = false
+			}
 		}
 
 		// ── SECTION ───────────────────────────────────────────────────────
@@ -596,12 +673,55 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 					attachCall(entities, currentParagraphIdx, programIdx, rel)
 				}
 			}
+
+			// File I/O verbs (#4908): bind OPEN/READ/WRITE on a FILE-CONTROL
+			// logical file to its SCOPE.Datastore/file resource with a
+			// READS_FROM / WRITES_TO edge from the enclosing paragraph (else the
+			// program). This turns the abstract fs_read/fs_write effect into a
+			// resolvable data-flow edge to a physical dataset / VSAM cluster.
+			ioIdx := currentParagraphIdx
+			if ioIdx < 0 {
+				ioIdx = programIdx
+			}
+			if ioIdx >= 0 {
+				attachFileIO := func(logical, kind string) {
+					if fi, ok := fileEntityIdx[strings.ToUpper(logical)]; ok {
+						entities[ioIdx].Relationships = append(entities[ioIdx].Relationships,
+							types.RelationshipRecord{
+								ToID: entities[fi].QualifiedName,
+								Kind: kind,
+								Properties: map[string]string{
+									"line": strconv.Itoa(ln.num),
+									"file": logical,
+								},
+							})
+					}
+				}
+				for _, om := range fileOpenRe.FindAllStringSubmatch(ln.code, -1) {
+					mode := strings.ToUpper(om[1])
+					kind := "READS_FROM"
+					if mode == "OUTPUT" || mode == "EXTEND" {
+						kind = "WRITES_TO"
+					}
+					// OPEN may list several files after one mode keyword.
+					for _, f := range strings.Fields(om[2]) {
+						attachFileIO(f, kind)
+					}
+				}
+				for _, rm := range fileReadRe.FindAllStringSubmatch(ln.code, -1) {
+					attachFileIO(rm[2], "READS_FROM")
+				}
+				for _, wm := range fileWriteRe.FindAllStringSubmatch(ln.code, -1) {
+					attachFileIO(wm[2], "WRITES_TO")
+				}
+			}
 		}
 	}
 
 	// Flush a trailing EXEC block that lacked a closing END-EXEC (tolerant of
 	// malformed / truncated source).
 	flushExecBlock()
+	flushSelect()
 
 	_ = programName
 	return entities

--- a/internal/extractors/cobol/extractor_test.go
+++ b/internal/extractors/cobol/extractor_test.go
@@ -517,6 +517,100 @@ func TestExtractor_DataRedefinesOccurs(t *testing.T) {
 	}
 }
 
+// TestExtractor_FileControlSelect proves FILE-CONTROL SELECT...ASSIGN clauses
+// emit a resolvable SCOPE.Datastore/file resource whose assign_to is the
+// JCL-DD-matching coupling key (#4908).
+func TestExtractor_FileControlSelect(t *testing.T) {
+	src := loadFixture(t, "payroll.cbl")
+	recs := run(t, "payroll.cbl", src)
+
+	files := findByKind(recs, "SCOPE.Datastore", "file")
+	if len(files) != 2 {
+		t.Fatalf("expected 2 file resources, got %d", len(files))
+	}
+	want := map[string]string{"EMP-FILE": "EMPIN", "PAY-FILE": "PAYOUT"}
+	for _, f := range files {
+		exp, ok := want[f.Name]
+		if !ok {
+			t.Errorf("unexpected file resource %q", f.Name)
+			continue
+		}
+		if f.Properties["assign_to"] != exp {
+			t.Errorf("%s assign_to = %q, want %q", f.Name, f.Properties["assign_to"], exp)
+		}
+		if f.Properties["organization"] != "SEQUENTIAL" {
+			t.Errorf("%s organization = %q, want SEQUENTIAL", f.Name, f.Properties["organization"])
+		}
+		if f.Properties["storage"] != "sequential" {
+			t.Errorf("%s storage = %q, want sequential", f.Name, f.Properties["storage"])
+		}
+	}
+}
+
+// TestExtractor_FileIODataFlow proves OPEN/READ/WRITE on a logical file wire
+// READS_FROM / WRITES_TO edges to the file resource (#4908).
+func TestExtractor_FileIODataFlow(t *testing.T) {
+	src := loadFixture(t, "payroll.cbl")
+	recs := run(t, "payroll.cbl", src)
+
+	reads := relationsByKind(recs, "READS_FROM")
+	writes := relationsByKind(recs, "WRITES_TO")
+	hasFile := func(rels []types.RelationshipRecord, file string) bool {
+		for _, r := range rels {
+			if r.Properties["file"] == file {
+				return true
+			}
+		}
+		return false
+	}
+	// OPEN INPUT EMP-FILE + READ EMP-FILE → READS_FROM.
+	if !hasFile(reads, "EMP-FILE") {
+		t.Error("expected READS_FROM edge for EMP-FILE")
+	}
+	// OPEN OUTPUT PAY-FILE → WRITES_TO.
+	if !hasFile(writes, "PAY-FILE") {
+		t.Error("expected WRITES_TO edge for PAY-FILE")
+	}
+}
+
+// TestExtractor_VSAMKsds proves an INDEXED ORGANIZATION with a RECORD KEY is
+// classified as VSAM storage and captures access mode + key (#4908).
+func TestExtractor_VSAMKsds(t *testing.T) {
+	src := "       ENVIRONMENT DIVISION.\n" +
+		"       INPUT-OUTPUT SECTION.\n" +
+		"       FILE-CONTROL.\n" +
+		"           SELECT CUST-MASTER ASSIGN TO CUSTVS\n" +
+		"               ORGANIZATION IS INDEXED\n" +
+		"               ACCESS MODE IS DYNAMIC\n" +
+		"               RECORD KEY IS CM-CUST-ID.\n" +
+		"       DATA DIVISION.\n"
+	recs := run(t, "vsam.cbl", src)
+
+	files := findByKind(recs, "SCOPE.Datastore", "file")
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file resource, got %d", len(files))
+	}
+	f := files[0]
+	if f.Name != "CUST-MASTER" {
+		t.Errorf("file name = %q, want CUST-MASTER", f.Name)
+	}
+	if f.Properties["assign_to"] != "CUSTVS" {
+		t.Errorf("assign_to = %q, want CUSTVS", f.Properties["assign_to"])
+	}
+	if f.Properties["storage"] != "vsam" {
+		t.Errorf("storage = %q, want vsam", f.Properties["storage"])
+	}
+	if f.Properties["organization"] != "INDEXED" {
+		t.Errorf("organization = %q, want INDEXED", f.Properties["organization"])
+	}
+	if f.Properties["access_mode"] != "DYNAMIC" {
+		t.Errorf("access_mode = %q, want DYNAMIC", f.Properties["access_mode"])
+	}
+	if f.Properties["record_key"] != "CM-CUST-ID" {
+		t.Errorf("record_key = %q, want CM-CUST-ID", f.Properties["record_key"])
+	}
+}
+
 func loadFixture(t *testing.T, name string) string {
 	t.Helper()
 	b, err := os.ReadFile(filepath.Join("testdata", name))


### PR DESCRIPTION
Coverage-audit ticket #4908 for **COBOL**. Documents extracted-but-undocumented capabilities, adds the missing base-language record, and implements the highest-value missing extraction (FILE-CONTROL / VSAM). Deploy-deferred.

## Documented (registry.json — cites added, notes, verified_at 2026-06-12)
- **NEW base record `lang.cobol.core`** (was absent — COBOL only had runtime/embedded records). Canonical language keys: `call_line_precision`, `core_extraction`, `import_resolution_quality`. Notes cite the previously-undocumented:
  - **Data hierarchy / field extraction** (under core_extraction) — 01/05/10/77/66/88 level items → `SCOPE.Schema/field` with parent-level stack, CONTAINS group→field, pic/redefines/occurs/group props (`extractor.go` dataItemRe + dataStack). Proven by `TestExtractor_DataHierarchy` / `_DataRedefinesOccurs`.
  - **Copybook resolution depth** (under import_resolution_quality) — multi-dir/multi-ext/case-variant `resolveCopybook`, REPLACING `==a==BY==b==` drift pairs.
- **`lang.cobol.embedded.db2-sql`** — db_effect note now documents `extractSQLEntities` table/cursor `SCOPE.DataAccess` + `ACCESSES_TABLE`/`REFERENCES` edges + OPEN/FETCH/CLOSE traffic (was `db_effect=full` only).
- **`lang.cobol.embedded.cics`** — added `call_line_precision` cell: `extractCICSTransfers` LINK/XCTL/START → cross-program CALLS (was only fs/http_effect).
- **`lang.cobol.runtime.ibm-enterprise`** — fs_effect note documents the new FILE-CONTROL extraction; db_effect flags the IMS gap.

## Implemented (new extraction — FILE-CONTROL / VSAM, #4908)
`SELECT <logical> ASSIGN TO <ddname> [ORGANIZATION/ACCESS/RECORD KEY]` now emits a resolvable **`SCOPE.Datastore/file`** entity (`parseFileSelect`/`buildFileResourceEntity` in depth.go; FILE-CONTROL state machine + SELECT buffering in extractor.go):
- `assign_to` upper-cased to match the JCL DD **coupling key**, so shared-VSAM cross-program/cross-job coupling becomes visible.
- `organization` / `access_mode` / `record_key` props; `storage=vsam` for INDEXED/RELATIVE/keyed clusters, else `sequential`.
- PROCEDURE-DIVISION OPEN/READ/WRITE on the logical file wire **READS_FROM / WRITES_TO** edges to the file resource — abstract fs effects now bind to a physical dataset.
- CONTAINS program→file keeps it non-orphan.
- Tests: `TestExtractor_FileControlSelect`, `_FileIODataFlow`, `_VSAMKsds` (exercises the existing `payroll.cbl` SELECT/ASSIGN + an inline VSAM KSDS).

## Deferred (precise follow-ups filed)
- **#4948** — IMS DB/DC (DL/I): EXEC DLI + CBLTDLI/AIBTDLI segment I/O (2nd mainframe data layer).
- **#4947** — CICS TS/TD queue datastore entities + BMS/MFS screen maps + Micro Focus/ACUCOBOL dialects.
- **#4946** — PERFORM THRU range, GO TO control flow, expanded mutation effect (ADD..GIVING/STRING/INITIALIZE/INSPECT), dynamic CALL target resolution.

## Gates (all under sandbox HOME=/tmp/agsbx-4908)
- `go build ./...` ✅  ·  `go vet ./internal/...` ✅  ·  `go test ./internal/extractors/cobol/... ./internal/types/` ✅
- `coverage fmt --check` ✅ canonical  ·  `coverage validate` ✅ ok 676 records, 0 errors
- No `coverage gen` markdown committed (registry + extractor + tests only).

Closes #4908.