### PR TITLE
feat(#4909): assembly coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/assembly/extractor.go
+++ b/internal/extractors/assembly/extractor.go
@@ -11,7 +11,8 @@
 // extractors).
 //
 // A SINGLE "assembly" language token covers every dialect; the dialect
-// (x86/x86-64, ARM, ARM64/AArch64, m68k) and syntax (AT&T vs Intel/NASM) are
+// (x86/x86-64, ARM, ARM64/AArch64, RISC-V, m68k) and syntax (AT&T vs
+// Intel/NASM) are
 // recorded as entity *attributes*, never as separate languages — the same
 // taxonomy decision made for vue/svelte/astro = jsts (#2821) and for the
 // COBOL/legacy wave.
@@ -44,7 +45,8 @@
 //     Properties["locality"]="external".
 //   - IMPORTS — `.include "file"` / `%include "file"` (NASM).
 //   - syscall effect — `syscall`/`int 0x80` (x86), `svc`/`swi` (ARM),
-//     `trap #0` (m68k) emit a CALLS edge to the synthetic `__syscall` target
+//     `ecall` (RISC-V), `trap #0` (m68k) emit a CALLS edge to the synthetic
+//     `__syscall` target
 //     with Properties["effect"]="syscall" and stamp Properties["has_syscall"]
 //     on the enclosing procedure. This is the meaningful OS-boundary effect
 //     surface for assembly (#2744 Phase 1A).
@@ -176,6 +178,14 @@ var branchMnemonics = map[string]bool{
 	"dbra": true, "dbf": true, "dbeq": true, "dbne": true, "dbcc": true,
 	"dbcs": true, "dbhi": true, "dbls": true, "dbge": true, "dblt": true,
 	"dbgt": true, "dble": true, "dbpl": true, "dbmi": true,
+	// RISC-V branches. `j` is the unconditional jump (pseudo for `jal x0`);
+	// the b-family compares two registers then a label (beq/bne/blt/bge/bltu/
+	// bgeu) and the *z pseudos compare against x0 (beqz/bnez/blez/bgez/bltz/
+	// bgtz). beq/bne/blt/bge/ble overlap the ARM/m68k names already present
+	// above and are covered there; only the RISC-V-unique tokens are added.
+	"j": true, "beqz": true, "bnez": true, "blez": true, "bgez": true,
+	"bltz": true, "bgtz": true, "bltu": true, "bgeu": true, "bgtu": true,
+	"bleu": true,
 }
 
 // syscallMnemonics triggers a syscall effect. `int` and `trap` are
@@ -186,9 +196,13 @@ var branchMnemonics = map[string]bool{
 //	x86:    syscall, sysenter, int 0x80
 //	ARM:    svc, swi (legacy 32-bit gate)
 //	m68k:   trap #0 (Linux), and the unconditional trap variants
+//	RISC-V: ecall (the environment-call instruction — the RISC-V OS/EE
+//	        boundary gate; ebreak is the debugger trap, not an OS syscall,
+//	        so it is intentionally excluded)
 var syscallMnemonics = map[string]bool{
 	"syscall": true, "sysenter": true,
 	"svc": true, "swi": true,
+	"ecall": true,
 }
 
 // registerOperand reports whether an operand is a CPU register (so a
@@ -269,6 +283,16 @@ func detectDialect(src string) (dialect, syntax string) {
 	case strings.Contains(lower, "%eax") || strings.Contains(lower, "int 0x80") ||
 		strings.Contains(lower, "int 80h"):
 		dialect = "x86"
+	case strings.Contains(lower, "ecall") || strings.Contains(lower, "riscv") ||
+		regexp.MustCompile(`(?m)^\s*\.option\b`).MatchString(lower) ||
+		regexp.MustCompile(`\b(?:jal|jalr)\b[^\n]*\bra\b`).MatchString(lower) ||
+		regexp.MustCompile(`\b(?:lw|sw|ld|sd|addi|li|mv)\b[^\n]*\b(?:ra|sp|gp|tp|[at][0-7]|s[0-9]|s1[01])\b`).MatchString(lower):
+		// RISC-V shares x-registers with AArch64 but is uniquely identified by
+		// the ecall gate, the .option directive, the jal/jalr+ra return-address
+		// idiom, or its ABI register file (ra/sp/gp/tp/a0-a7/t0-t6/s0-s11)
+		// appearing as an instruction operand. Must precede the arm64 case below
+		// (which would otherwise claim the shared `x[0-9]` register shape).
+		dialect = "riscv"
 	case regexp.MustCompile(`\bx[0-9]{1,2}\b`).MatchString(lower) ||
 		strings.Contains(lower, "aarch64") || strings.Contains(lower, "blr") ||
 		strings.Contains(lower, "\tsvc") || strings.Contains(lower, " svc "):
@@ -630,7 +654,7 @@ func buildProcedureEntities(lines []string, filePath, lang, dialect string, expo
 		// procedure (not a local label, not self) is a tail call — control
 		// transfers without a return frame.
 		if isBranch && !localLabels[target] && target != out[curIdx].Name &&
-			(lower == "jmp" || lower == "jmpq" || lower == "bra" || lower == "b") {
+			(lower == "jmp" || lower == "jmpq" || lower == "bra" || lower == "b" || lower == "j") {
 			props["tail_call"] = "true"
 		}
 

--- a/internal/extractors/assembly/extractor_test.go
+++ b/internal/extractors/assembly/extractor_test.go
@@ -397,6 +397,69 @@ func TestExtractM68k(t *testing.T) {
 	}
 }
 
+// RISC-V -------------------------------------------------------------------
+
+func TestExtractRISCV(t *testing.T) {
+	src := loadFixture(t, "riscv.s.fixture")
+	recs := extractAssembly(src, "boot_rv.s", "assembly")
+
+	file := byName(recs, "boot_rv.s")
+	if file == nil || file.Properties["dialect"] != "riscv" {
+		t.Fatalf("dialect=%v want riscv", file)
+	}
+
+	start := byName(recs, "_start")
+	setup := byName(recs, "setup")
+	if start == nil || setup == nil {
+		t.Fatalf("procedures missing: _start=%v setup=%v", start, setup)
+	}
+
+	sc := callTargets(start)
+	// jal ra, setup → intra-file call (label is the LAST operand, ra skipped).
+	if e, ok := sc["setup"]; !ok {
+		t.Errorf("_start should jal→CALL setup; got %v", sc)
+	} else if e.Properties["edge_kind"] != "call" {
+		t.Errorf("setup edge_kind=%q want call", e.Properties["edge_kind"])
+	}
+	// jal ra, memcpy → external call.
+	if e, ok := sc["memcpy"]; !ok {
+		t.Error("_start should jal→CALL memcpy (external)")
+	} else if e.Properties["locality"] != "external" {
+		t.Errorf("memcpy locality=%q want external", e.Properties["locality"])
+	}
+	// beqz a0, .Ldone → branch to local label (label is LAST operand).
+	doneStub := localLabelStub("assembly", "boot_rv.s", ".Ldone")
+	if e, ok := sc[doneStub]; !ok {
+		t.Errorf("_start should beqz→branch .Ldone via stub %q; got %v", doneStub, sc)
+	} else if e.Properties["edge_kind"] != "branch" {
+		t.Errorf(".Ldone edge_kind=%q want branch", e.Properties["edge_kind"])
+	}
+	// bnez a0, .Lloop → branch to local label.
+	loopStub := localLabelStub("assembly", "boot_rv.s", ".Lloop")
+	if _, ok := sc[loopStub]; !ok {
+		t.Errorf("_start should bnez→branch .Lloop via stub %q; got %v", loopStub, sc)
+	}
+	// ecall → syscall effect.
+	if start.Properties["has_syscall"] != "true" {
+		t.Error("_start ecall should be a syscall effect")
+	}
+	if _, ok := sc[syntheticSyscallTarget]; !ok {
+		t.Error("_start should CALL __syscall via ecall")
+	}
+
+	// Local-label anchors emitted.
+	if a := byName(recs, ".Lloop"); a == nil || a.Kind != "SCOPE.CodeBlock" {
+		t.Error("missing .Lloop anchor")
+	}
+	// Constant (.equ) + section.
+	if byName(recs, "SYS_exit") == nil {
+		t.Error("missing RISC-V constant SYS_exit")
+	}
+	if byName(recs, ".text") == nil {
+		t.Error("missing .text section")
+	}
+}
+
 // trap #N gate selectivity ----------------------------------------------------
 
 func TestTrapSyscallGate(t *testing.T) {

--- a/internal/extractors/assembly/testdata/riscv.s.fixture
+++ b/internal/extractors/assembly/testdata/riscv.s.fixture
@@ -1,0 +1,28 @@
+# RISC-V (RV64) GNU as fixture — labels, jal call, j/beqz branch, ecall syscall.
+# Demonstrates: RISC-V procedures, jal call, j tail call, beqz branch to local
+# label, the ecall OS boundary, and the .equ equate constant.
+
+	.equ	SYS_exit, 93
+
+	.extern	memcpy
+
+	.text
+	.option	norvc
+	.global	_start
+_start:
+	jal	ra, setup           # intra-file call (return addr in ra)
+	jal	ra, memcpy          # external call
+	beqz	a0, .Ldone          # conditional branch to local label
+.Lloop:
+	addi	a0, a0, -1
+	bnez	a0, .Lloop          # conditional branch
+.Ldone:
+	li	a7, SYS_exit
+	ecall                       # OS boundary effect
+	j	.Ldone              # tail branch
+	ret
+
+	.global	setup
+setup:
+	li	a0, 0
+	ret


### PR DESCRIPTION
Closes #4909.

## Documented (cited notes, surgical 2-space edits — `coverage fmt --check` canonical)
The assembly extractor was rich but only `core_extraction`/`call_line_precision`/`import_resolution_quality` were recorded with no notes. The `language` category has a FIXED capability-key allow-list, so per the cobol/fsharp precedent the rich behaviour is documented as **cited notes on the three valid cells**, not invented cells:
- **gnu-as** (reference dialect): documented the **syscall/OS-boundary effect** (`syscallMnemonics` + `isSyscall` → synthetic `CALLS→__syscall`, `has_syscall`/`syscall_count`), **constant/equate** extraction (`buildConstantEntities`: gas `.equ/.set`, NASM `%define`, MASM `EQU`, `NAME=val`), **branch vs call classification** (`edge_kind`, `recursion=self`, `tail_call`, `locality=external`, intra-file local-label stub #2836), **section** extraction, and **dialect/syntax** detection. Cites extractor.go line ranges + the proving tests. Note #2839 unregistered-Kind history called out.
- **MASM** + **ARM armasm**: the `partial` cells now carry **cited WEAK notes** explaining the real gaps (PROC/ENDP/STRUCT/SEGMENT, AREA, PUBLIC/EXTERN/EXPORT/IMPORT, INCLUDE/GET not matched by the gas-spelling regexes) — was previously partial with NO notes.

## Implemented (RISC-V — the HIGH missing-framework)
- `detectDialect`: new **RISC-V** case, ordered ahead of arm64 (both use x-registers), keyed on `ecall` / `.option` / the `jal|jalr ... ra` idiom / the RISC-V ABI register file (ra/sp/gp/tp/a0-a7/t0-t6/s0-s11). File entity stamped `dialect=riscv`.
- `syscallMnemonics`: add `ecall` (RISC-V OS/EE boundary gate; `ebreak` deliberately excluded). `branchMnemonics`: add `j` (unconditional jump pseudo, treated as a tail-call branch) + `beqz`/`bnez`/`blez`/`bgez`/`bltz`/`bgtz` and the unsigned `bltu`/`bgeu`/`bgtu`/`bleu`.
- New **`lang.assembly.toolchain.riscv`** record (full ×3, cited) + **`riscv.s.fixture`** + **`TestExtractRISCV`** asserting dialect, `jal` call (last-operand label past `ra`), `ecall` syscall effect, `beqz`/`bnez` branches, the `.equ` constant and the `.text` section.

## Deferred (follow-ups filed)
- **#4950** — MASM/armasm structured-directive deepening (PROC/ENDP/AREA/SEGMENT/STRUCT, PUBLIC/EXTERN/EXPORT/IMPORT, INCLUDE/GET) to flip those cells to full.
- LLVM-mc / YASM / FASM / TASM toolchain records and the macro / conditional-assembly / data-definition (`.byte`/`db`/`DCD`) structural gap remain in #4909's scope for a later wave (documented as not-yet-recorded; no fabricated cells).

## Gates (all under sandbox HOME=/tmp/agsbx-4909, ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1)
`go build ./...` OK · `go vet ./internal/...` OK · `go test ./internal/extractors/assembly/...` ok · `go test ./internal/types/` ok · `coverage fmt --check` canonical · `coverage validate` ok (pre-existing repo-wide warnings only). No `coverage gen` markdown committed.