### PR TITLE
feat(#4910): clojure coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/clojure/clojure.go
+++ b/internal/extractors/clojure/clojure.go
@@ -2,6 +2,7 @@
 //
 // Extracted entities:
 //   - defn / defn-      → Kind="SCOPE.Operation", Subtype="function"
+//   - defmacro          → Kind="SCOPE.Operation", Subtype="macro"
 //   - defrecord / defprotocol / deftype / defmulti / definterface
 //     → Kind="SCOPE.Component", Subtype="class"
 //   - ns                → Kind="SCOPE.Component", Subtype="namespace"
@@ -57,6 +58,12 @@ var (
 	// (defn name [...] ...) or (defn- name ...)
 	defnRE = regexp.MustCompile(
 		`(?m)^\s*\(defn-?\s+([\w\-\?!\*'+]+)\s*(?:\[[^\]]*\]|\()`,
+	)
+	// (defmacro name [...] ...) — macros are first-class operations in
+	// Clojure (most libraries ship core behaviour as macros). Treated like
+	// defn but stamped Subtype="macro" so callers can distinguish them.
+	defmacroRE = regexp.MustCompile(
+		`(?m)^\s*\(defmacro\s+([\w\-\?!\*'+]+)\s*(?:\[[^\]]*\]|\()`,
 	)
 	// Top-level type declarations.
 	deftypeRE = regexp.MustCompile(
@@ -171,6 +178,36 @@ func extractClojure(src, filePath string) []types.EntityRecord {
 			StartLine:          startLine,
 			EndLine:            endLine,
 			Signature:          "(defn " + name + " [...])",
+			EnrichmentRequired: false,
+			Properties: map[string]string{
+				"imports": importsCSV,
+			},
+			Relationships: calls,
+		}
+		ops = append(ops, opOffset{idx: len(entities), name: name})
+		entities = append(entities, rec)
+	}
+
+	// 2b. defmacro → operations (subtype=macro), with CALLS edges. Macros
+	// are the primary extension mechanism in Clojure; modelling them as
+	// operations gives them call-graph edges and CONTAINS membership like
+	// any defn.
+	for _, m := range defmacroRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		endLine := findFormEnd(src, m[0])
+		body := extractFormBody(src, m[0])
+		calls := collectCalls(body, name)
+
+		rec := types.EntityRecord{
+			Name:               name,
+			Kind:               "SCOPE.Operation",
+			Subtype:            "macro",
+			SourceFile:         filePath,
+			Language:           "clojure",
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Signature:          "(defmacro " + name + " [...])",
 			EnrichmentRequired: false,
 			Properties: map[string]string{
 				"imports": importsCSV,

--- a/internal/extractors/clojure/clojure_test.go
+++ b/internal/extractors/clojure/clojure_test.go
@@ -89,6 +89,66 @@ func TestClojureExtractor_TypeDefinitions(t *testing.T) {
 	}
 }
 
+func TestClojureExtractor_Macros(t *testing.T) {
+	src := `(ns myapp.macros)
+
+(defmacro unless [test & body]
+  ` + "`" + `(if (not ~test) (do ~@body)))
+
+(defmacro with-timing [& body]
+  ` + "`" + `(let [start (now)]
+     (log "start")
+     ~@body))
+`
+	ext, _ := extractor.Get("clojure")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "macros.clj",
+		Content:  []byte(src),
+		Language: "clojure",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	macros := make(map[string]bool)
+	var contains int
+	for _, e := range entities {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "macro" {
+			macros[e.Name] = true
+			if e.Language != "clojure" {
+				t.Errorf("macro %q: expected Language=clojure, got %q", e.Name, e.Language)
+			}
+		}
+		if e.Kind == "SCOPE.Component" && e.Subtype == "namespace" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CONTAINS" {
+					contains++
+				}
+			}
+		}
+	}
+	for _, want := range []string{"unless", "with-timing"} {
+		if !macros[want] {
+			t.Errorf("expected macro %q to be extracted as Subtype=macro", want)
+		}
+	}
+	// Macros must be members of the namespace via CONTAINS, like defn.
+	if contains < 2 {
+		t.Errorf("expected namespace to CONTAIN both macros, got %d CONTAINS edges", contains)
+	}
+	// with-timing calls (now)/(log ...) — verify CALLS edges are mined from
+	// a macro body just like a defn body.
+	var withTimingCalls int
+	for _, e := range entities {
+		if e.Name == "with-timing" {
+			withTimingCalls = len(e.Relationships)
+		}
+	}
+	if withTimingCalls == 0 {
+		t.Errorf("expected CALLS edges mined from macro body, got 0")
+	}
+}
+
 func TestClojureExtractor_EmptyInput(t *testing.T) {
 	ext, _ := extractor.Get("clojure")
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{


### PR DESCRIPTION
Closes #4910.

## Documented (cited, honest)
- **`lang.clojure.base`** — NEW base-language record (`language` category, fixed cells). `core_extraction` / `call_line_precision` / `import_resolution_quality` all **full**, citing `internal/extractors/clojure/clojure.go`: defn/defn-, **defmacro**, defrecord/defprotocol/deftype/defmulti/definterface (these ARE the Type-System constructs — noted, not invented cells), ns + IMPORTS (`:require`/`:use`/`:import` incl. java `[pkg Class…]` vector form), CALLS (special-form filtered, line props), CONTAINS.
- **Build tools** — `build.leiningen`, `build.tools-deps`, `build.boot`, `build.shadow-cljs` (`build_system`, **partial**, cited to `build_tools.yaml`; manifest detection works, build-graph extraction is the #3828 tail). cf. Elixir `build.hex` partial.
- **http_framework** — `lang.clojure.framework.ring` (Ring is the foundational substrate; bare Ring has no static route table — routes surface via the Compojure/Reitit/Pedestal routers layered on top; `wrap-*` middleware_coverage flagged as the top Middleware follow-up) and `lang.clojure.framework.pedestal` (detected via `pedestal.yaml`; table/terse interceptor routes not yet synthesised — only Compojure verb-macros + Reitit data-routes are).
- **ORM drivers** — `next-jdbc`, `honeysql`, `datomic`, `datascript`, `clojure-java-jdbc` (`orm`/`orm_mapper`, detection-only via `orms/*.yaml`; SQL/Datalog query + transaction attribution is the #4910 tail).

## Implemented (fixture-proven)
- **`defmacro` extraction** — `(defmacro name …)` → `SCOPE.Operation(subtype=macro)` with CALLS edges mined from its body and CONTAINS from the namespace, mirroring `defn`. Macros are Clojure's primary extension mechanism and were previously only in the special-form drop list. Proven by `TestClojureExtractor_Macros`.

## Deferred (honest follow-ups, #4910 tail)
Top-level `(def …)` vars → SCOPE.Constant; Ring `wrap-*` middleware_coverage; Pedestal route synthesis; ORM query/transaction attribution; #3828 build-graph target extraction.

## Gates
`go build ./...` rc=0, `go vet ./internal/...` rc=0, `go test ./internal/extractors/clojure/... ./internal/custom/clojure/... ./internal/types/ ./tools/coverage/...` all ok. **`coverage fmt --check` canonical**, **`coverage validate` ok (689 records)**. Backfilled 143 grouped cells under issue 4910 (surgical edits + fmt canonicalize, no unrelated record churn). Sandbox `HOME=/tmp/agsbx-4910` confirmed (`ARCHIGRAPH_TEST_REQUIRE_ISOLATED_HOME=1`). Deploy-deferred.