### PR TITLE
feat(#4912): dart coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/dart/dart.go
+++ b/internal/extractors/dart/dart.go
@@ -234,6 +234,11 @@ func extractDart(src, filePath string) []types.EntityRecord {
 		_ = methodEntityIdx
 	}
 
+	// Type System (#4912): enum / typedef / Dart3 modified-class constructs
+	// the base walk drops. Appended as a post-pass — never mutates the
+	// class/method records above.
+	entities = append(entities, extractDartTypes(src, filePath)...)
+
 	return entities
 }
 

--- a/internal/extractors/dart/types.go
+++ b/internal/extractors/dart/types.go
@@ -1,0 +1,248 @@
+// types.go — Dart Type System extraction (#4912).
+//
+// The base dart.go walk recognises only `class` / `abstract class` /
+// `mixin` / `extension` declarations. The single highest-value LANGUAGE-CORE
+// gap called out in #4912 is the Dart *type system*: all three Dart framework
+// records (flutter, graphql-flutter, shelf) mark enum_extraction /
+// type_alias_extraction / interface_extraction as `missing`, and dart.go
+// actively pushes `enum` into skipKeywords so enums are dropped entirely.
+//
+// This pass adds the three missing constructs, fixture-proven:
+//
+//   - enum (plain + Dart 2.17 "enhanced" enums with members/methods) →
+//     SCOPE.Enum value-set node via the shared extractor.EnumEntity helper
+//     (kind_hint="dart_enum"), so the graph answers "what values can this
+//     field take?" for cross-graph enum parity (parity with python/ts/java
+//     enum value-sets, #3628/#4420). Enhanced-enum bodies (`enum X { a, b;
+//     final int n; ... }`) keep only the constant identifiers before the
+//     first `;` as members — method/field noise after the `;` is dropped.
+//
+//   - typedef → SCOPE.Schema(subtype=type_alias), matching the python
+//     (internal/extractors/python/types.go) and rust/go type_alias shape.
+//     Both spellings are handled: the modern `typedef Name = <type>;` and
+//     the legacy function-type `typedef ReturnT Name(params);`.
+//
+//   - Dart 3 class modifiers (sealed / base / interface / final / mixin
+//     class) → the same SCOPE.Component(subtype=class) the base walk emits,
+//     but carrying a `class_modifier` property and a `dart_sealed` /
+//     `dart_interface` etc. hint so the resolver / dashboard can distinguish
+//     a `sealed class` (exhaustive-switch root) from a plain class. The base
+//     classRE does not match these (its leading group only allows an
+//     optional `abstract`), so they were invisible.
+//
+// Regex-based to match dart.go (no tree-sitter Dart grammar is bundled in
+// smacker/go-tree-sitter). Runs as a post-pass appended to the base entity
+// slice — it never mutates the base class/method records, it only adds the
+// previously-dropped type entities. The base extractor's skipKeywords still
+// excludes enum/typedef/sealed from the method/call passes, so there is no
+// double-emit.
+package dart
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+var (
+	// `enum Name {` head — plain or enhanced. The optional leading `@anno`
+	// / whitespace is tolerated; the body (up to the matching `}`) is parsed
+	// for members separately.
+	dartEnumRE = regexp.MustCompile(`(?m)^[ \t]*enum\s+(\w+)\s*(?:with\s+[\w,\s<>]+)?(?:implements\s+[\w,\s<>]+)?\{`)
+
+	// Modern `typedef Name = <type>;` (Dart 2.13+). Submatch 1 = name,
+	// 2 = the aliased type body (up to the `;`).
+	dartTypedefAliasRE = regexp.MustCompile(`(?m)^[ \t]*typedef\s+(\w+)(?:<[^>]*>)?\s*=\s*([^;]+);`)
+
+	// Legacy function-type `typedef ReturnType Name(params);` — no `=`.
+	// Submatch 1 = name (the identifier immediately before the `(`).
+	dartTypedefFuncRE = regexp.MustCompile(`(?m)^[ \t]*typedef\s+(?:[\w<>\[\]?,\s]+?\s+)?(\w+)\s*\([^;{]*\)\s*;`)
+
+	// Dart 3 class modifiers: `sealed|base|interface|final|mixin` (or pairs
+	// like `abstract interface`, `base mixin`) preceding `class Name`.
+	// Submatch 1 = modifier run, 2 = class name.
+	dartModifiedClassRE = regexp.MustCompile(
+		`(?m)^[ \t]*((?:abstract\s+|sealed\s+|base\s+|interface\s+|final\s+|mixin\s+)+)class\s+(\w+)`)
+)
+
+// extractDartTypes parses Dart type-system constructs (enum / typedef /
+// modified class) the base walk drops, returning the extra entity records.
+func extractDartTypes(src, filePath string) []types.EntityRecord {
+	var out []types.EntityRecord
+	out = append(out, dartEnums(src, filePath)...)
+	out = append(out, dartTypedefs(src, filePath)...)
+	out = append(out, dartModifiedClasses(src, filePath)...)
+	return out
+}
+
+// dartEnums emits one SCOPE.Enum value-set per `enum` declaration.
+func dartEnums(src, filePath string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, m := range dartEnumRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		braceOpen := m[1] - 1
+		braceEnd := findBraceEndByte(src, braceOpen)
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		endLine := strings.Count(src[:braceEnd], "\n") + 1
+
+		body := ""
+		if braceOpen+1 <= braceEnd {
+			body = src[braceOpen+1 : braceEnd]
+		}
+		members := dartEnumMembers(body)
+		if e, ok := extractor.EnumEntity(name, "dart", "dart_enum", filePath,
+			startLine, endLine, members); ok {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// dartEnumMembers parses the constant identifiers of an enum body. For an
+// enhanced enum the constants come before the first top-level `;`; everything
+// after it (fields/methods/const ctor) is dropped.
+func dartEnumMembers(body string) []extractor.EnumMember {
+	// Enhanced-enum: keep only up to the first `;`.
+	if semi := strings.IndexByte(body, ';'); semi >= 0 {
+		body = body[:semi]
+	}
+	var members []extractor.EnumMember
+	for _, raw := range strings.Split(body, ",") {
+		tok := strings.TrimSpace(raw)
+		if tok == "" {
+			continue
+		}
+		// A member may carry a constructor call: `apple(1)` / `red('#f00')`.
+		// Keep the bare identifier as the member name; capture the literal
+		// arg as the value when it is a single literal.
+		name := tok
+		value := ""
+		if p := strings.IndexByte(tok, '('); p >= 0 {
+			name = strings.TrimSpace(tok[:p])
+			arg := strings.TrimSuffix(strings.TrimSpace(tok[p+1:]), ")")
+			arg = strings.TrimSpace(strings.TrimSuffix(arg, ")"))
+			if arg != "" && !strings.ContainsAny(arg, ",") {
+				value = extractor.StripLiteralQuotes(arg)
+			}
+		}
+		// Reject non-identifier leading tokens (annotations, comments).
+		if name == "" || !isDartIdent(name) {
+			continue
+		}
+		members = append(members, extractor.EnumMember{Name: name, Value: value})
+	}
+	return members
+}
+
+// dartTypedefs emits SCOPE.Schema(type_alias) per typedef directive.
+func dartTypedefs(src, filePath string) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+	for _, m := range dartTypedefAliasRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		bodyTxt := strings.TrimSpace(src[m[4]:m[5]])
+		line := strings.Count(src[:m[0]], "\n") + 1
+		out = append(out, dartTypeAlias(name, bodyTxt, filePath, line))
+		seen[name] = true
+	}
+	for _, m := range dartTypedefFuncRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		if seen[name] {
+			continue
+		}
+		line := strings.Count(src[:m[0]], "\n") + 1
+		out = append(out, dartTypeAlias(name, "", filePath, line))
+	}
+	return out
+}
+
+func dartTypeAlias(name, body, filePath string, line int) types.EntityRecord {
+	props := map[string]string{"line": strconv.Itoa(line)}
+	if body != "" && len(body) <= 512 {
+		props["type_body"] = body
+	}
+	return types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "type_alias",
+		Language:           "dart",
+		SourceFile:         filePath,
+		StartLine:          line,
+		EndLine:            line,
+		Signature:          "typedef " + name,
+		Properties:         props,
+		EnrichmentRequired: false,
+	}
+}
+
+// dartModifiedClasses emits the SCOPE.Component(class) records the base
+// classRE drops because of a leading Dart 3 modifier (sealed/base/interface/
+// final/mixin class). The base walk already covers `class` / `abstract class`.
+func dartModifiedClasses(src, filePath string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, m := range dartModifiedClassRE.FindAllStringSubmatchIndex(src, -1) {
+		mods := strings.Fields(strings.TrimSpace(src[m[2]:m[3]]))
+		// `abstract class` alone is already handled by the base classRE — skip
+		// when the only modifier is abstract (no Dart 3 modifier present).
+		if len(mods) == 1 && mods[0] == "abstract" {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		// Find the class body brace for end line (best-effort).
+		endLine := startLine
+		if bracePos := strings.IndexByte(src[m[0]:], '{'); bracePos >= 0 {
+			endByte := findBraceEndByte(src, m[0]+bracePos)
+			endLine = strings.Count(src[:endByte], "\n") + 1
+		}
+		modifier := strings.Join(mods, " ")
+		props := map[string]string{
+			"class_modifier": modifier,
+		}
+		if hasMod(mods, "sealed") {
+			props["dart_sealed"] = "true"
+		}
+		if hasMod(mods, "interface") {
+			props["dart_interface"] = "true"
+		}
+		out = append(out, types.EntityRecord{
+			Name:               name,
+			Kind:               "SCOPE.Component",
+			Subtype:            "class",
+			SourceFile:         filePath,
+			Language:           "dart",
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Signature:          modifier + " class " + name,
+			EnrichmentRequired: false,
+			Properties:         props,
+		})
+	}
+	return out
+}
+
+func hasMod(mods []string, want string) bool {
+	for _, m := range mods {
+		if m == want {
+			return true
+		}
+	}
+	return false
+}
+
+func isDartIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		ok := r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(i > 0 && r >= '0' && r <= '9')
+		if !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/extractors/dart/types_test.go
+++ b/internal/extractors/dart/types_test.go
@@ -1,0 +1,166 @@
+package dart_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/dart"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractDartFixture(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ext, _ := extractor.Get("dart")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "types.dart",
+		Content:  []byte(src),
+		Language: "dart",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return ents
+}
+
+func findByKind(ents []types.EntityRecord, kind, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestDartTypes_PlainEnum(t *testing.T) {
+	src := `enum Color {
+  red,
+  green,
+  blue,
+}
+`
+	ents := extractDartFixture(t, src)
+	en := findByKind(ents, "SCOPE.Enum", "Color")
+	if en == nil {
+		t.Fatal("expected SCOPE.Enum:Color")
+	}
+	if en.Subtype != "enum" {
+		t.Errorf("Subtype = %q, want enum", en.Subtype)
+	}
+	if en.Properties["kind_hint"] != "dart_enum" {
+		t.Errorf("kind_hint = %q, want dart_enum", en.Properties["kind_hint"])
+	}
+	if got := en.Properties["members"]; got != "red, green, blue" {
+		t.Errorf("members = %q, want \"red, green, blue\"", got)
+	}
+	if en.Language != "dart" {
+		t.Errorf("Language = %q, want dart", en.Language)
+	}
+}
+
+func TestDartTypes_EnhancedEnum(t *testing.T) {
+	// Dart 2.17 enhanced enum: constants with ctor args, then fields/methods.
+	src := `enum Planet {
+  mercury(3.3e23),
+  earth(5.97e24);
+
+  const Planet(this.mass);
+  final double mass;
+
+  double surfaceGravity() => mass;
+}
+`
+	ents := extractDartFixture(t, src)
+	en := findByKind(ents, "SCOPE.Enum", "Planet")
+	if en == nil {
+		t.Fatal("expected SCOPE.Enum:Planet")
+	}
+	if got := en.Properties["members"]; got != "mercury, earth" {
+		t.Errorf("members = %q, want \"mercury, earth\" (post-`;` noise must be dropped)", got)
+	}
+	if got := en.Properties["member_count"]; got != "2" {
+		t.Errorf("member_count = %q, want 2", got)
+	}
+}
+
+func TestDartTypes_TypedefAlias(t *testing.T) {
+	src := `typedef JsonMap = Map<String, dynamic>;
+typedef IntList = List<int>;
+`
+	ents := extractDartFixture(t, src)
+	ta := findByKind(ents, "SCOPE.Schema", "JsonMap")
+	if ta == nil {
+		t.Fatal("expected SCOPE.Schema:JsonMap")
+	}
+	if ta.Subtype != "type_alias" {
+		t.Errorf("Subtype = %q, want type_alias", ta.Subtype)
+	}
+	if got := ta.Properties["type_body"]; got != "Map<String, dynamic>" {
+		t.Errorf("type_body = %q, want \"Map<String, dynamic>\"", got)
+	}
+	if findByKind(ents, "SCOPE.Schema", "IntList") == nil {
+		t.Error("expected SCOPE.Schema:IntList")
+	}
+}
+
+func TestDartTypes_TypedefFunc(t *testing.T) {
+	// Legacy function-type typedef (no `=`).
+	src := `typedef int Comparator(Object a, Object b);
+`
+	ents := extractDartFixture(t, src)
+	ta := findByKind(ents, "SCOPE.Schema", "Comparator")
+	if ta == nil {
+		t.Fatal("expected SCOPE.Schema:Comparator (function-type typedef)")
+	}
+	if ta.Subtype != "type_alias" {
+		t.Errorf("Subtype = %q, want type_alias", ta.Subtype)
+	}
+}
+
+func TestDartTypes_SealedClass(t *testing.T) {
+	src := `sealed class Shape {}
+
+final class Circle extends Shape {}
+
+interface class Drawable {}
+`
+	ents := extractDartFixture(t, src)
+	shape := findByKind(ents, "SCOPE.Component", "Shape")
+	if shape == nil {
+		t.Fatal("expected SCOPE.Component:Shape (sealed class)")
+	}
+	if shape.Subtype != "class" {
+		t.Errorf("Subtype = %q, want class", shape.Subtype)
+	}
+	if shape.Properties["dart_sealed"] != "true" {
+		t.Errorf("dart_sealed = %q, want true", shape.Properties["dart_sealed"])
+	}
+	if shape.Properties["class_modifier"] != "sealed" {
+		t.Errorf("class_modifier = %q, want sealed", shape.Properties["class_modifier"])
+	}
+	if findByKind(ents, "SCOPE.Component", "Circle") == nil {
+		t.Error("expected SCOPE.Component:Circle (final class)")
+	}
+	draw := findByKind(ents, "SCOPE.Component", "Drawable")
+	if draw == nil || draw.Properties["dart_interface"] != "true" {
+		t.Error("expected SCOPE.Component:Drawable with dart_interface=true")
+	}
+}
+
+func TestDartTypes_PlainClassNotDoubleEmitted(t *testing.T) {
+	// A plain `class` / `abstract class` must NOT be emitted by the modified-
+	// class pass (the base walk owns them) — guard against double-emit.
+	src := `class Plain {}
+abstract class Base {}
+`
+	ents := extractDartFixture(t, src)
+	plainCount := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Name == "Plain" {
+			plainCount++
+		}
+	}
+	if plainCount != 1 {
+		t.Errorf("Plain emitted %d times, want exactly 1 (no double-emit)", plainCount)
+	}
+}


### PR DESCRIPTION
## #4912 — dart coverage audit

### Documented (cites, no behavior change)
- **NEW `lang.dart.base` record** (category=language) — Dart had 3 framework rows (flutter, graphql-flutter, shelf) + pubspec but **no base-language record**. Adds it with all three language-category caps **full**, cited to `internal/extractors/dart/dart.go` + `types.go` + tests:
  - `core_extraction` — class/abstract/mixin/extension → Component; top-level fns + methods → Operation; CONTAINS; + the new type-system extraction.
  - `call_line_precision` — CALLS edges with line + receiver_root, keyword/return-type-tail filtering.
  - `import_resolution_quality` — IMPORTS one-per-directive, local_name/source_module/imported_name/alias (java #120 / python #93 contract).

### Implemented (fixture-proven) — the #4912 HIGH language-core gap
`internal/extractors/dart/types.go` (+ `types_test.go`): the Dart **Type System**, previously dropped (`enum` was in `skipKeywords`; no typedef/sealed regex):
- **enum** (plain + Dart-2.17 enhanced) → `SCOPE.Enum` value-set via `extractor.EnumEntity` (kind_hint=dart_enum); enhanced-enum members kept to the constants before the first `;`.
- **typedef** (modern `= <type>;` + legacy fn-type) → `SCOPE.Schema(type_alias)` with type_body (parity with python/rust/go).
- **Dart-3 class modifiers** sealed/base/interface/final/mixin-class → `SCOPE.Component(class)` with class_modifier/dart_sealed/dart_interface props (base classRE only matched plain/abstract → invisible).
- Appended post-walk; **no double-emit** of plain/abstract classes (guarded by test).

Tests: PlainEnum, EnhancedEnum, TypedefAlias, TypedefFunc, SealedClass, PlainClassNotDoubleEmitted. Flipped the Type System cells (enum/interface/type_alias_extraction) **missing→partial** with cites in all 3 dart framework records.

### Deferred (follow-ups, scoped for size)
serverpod Endpoint→http_endpoint_definition; drift/floor/isar/objectbox/sqflite ORM db_effect producers + records; retrofit/chopper typed HTTP-client outbound edges; get/GetX routing+state+DI; auto_route/beamer; flutter component_extraction (ConsumerWidget/HookWidget/StreamBuilder); flutter_test testmap (testWidgets→widget TESTS edges); gql query/mutation extraction.

### Gates
`go build ./...` ✓ · `go vet ./internal/...` ✓ · `go test` dart/custom-dart/types/coverage ✓ · `coverage fmt --check` canonical ✓ · `coverage validate` ok (691 records) ✓. Sandbox HOME=/tmp/agsbx-4912. Deploy-deferred.

Closes #4912.