### PR TITLE
feat(#4913): swift coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/swift/swift.go
+++ b/internal/extractors/swift/swift.go
@@ -110,6 +110,16 @@ func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRe
 		}
 		classIdx := len(*out)
 		*out = append(*out, rec)
+		// Issue #4913 — Type System: for an `enum` declaration also emit a
+		// SCOPE.Enum value-set node carrying its `case` members (parity with
+		// the dart/python/ts/java enum value-sets) IN ADDITION to the
+		// SCOPE.Component above. The Component models the nominal type; the
+		// value-set answers "what cases can this take?".
+		if subtype == "enum" {
+			if ve, ok := buildEnumValueSet(node, file); ok {
+				*out = append(*out, ve)
+			}
+		}
 		// CONTAINS: every function declared in the class body.
 		body := findClassBody(node)
 		fieldTypes := collectFieldTypes(body, file.Content)
@@ -174,6 +184,17 @@ func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRe
 
 	case "import_declaration":
 		if rec, ok := buildImport(node, file); ok {
+			*out = append(*out, rec)
+		}
+		return
+
+	case "typealias_declaration":
+		// Issue #4913 — Type System: `typealias Name = <type>` →
+		// SCOPE.Schema(subtype=type_alias), parity with the python/rust/go/
+		// dart type_alias shape. Supersedes the loose vapor-only
+		// reSwiftTypealias→Component v1 with a tree-sitter, language-wide,
+		// value-set-grade Schema node carrying the aliased type_body.
+		if rec, ok := buildTypeAlias(node, file); ok {
 			*out = append(*out, rec)
 		}
 		return

--- a/internal/extractors/swift/types.go
+++ b/internal/extractors/swift/types.go
@@ -1,0 +1,166 @@
+// types.go — Swift Type System extraction (#4913).
+//
+// The base swift.go tree-sitter walk recognises class / struct / enum /
+// protocol declarations as SCOPE.Component nodes and `import` as IMPORTS,
+// but it never modelled the Swift *type system* values: every SwiftUI /
+// vapor framework record marks enum_extraction / type_alias_extraction as
+// `missing`, and the only typealias support was the loose vapor-scoped
+// reSwiftTypealias regex (vapor_extended.go) that emitted a bare
+// SCOPE.Component(subtype="typealias") with no aliased-type body.
+//
+// This pass — the highest-value LANGUAGE-CORE gap in #4913 — adds, fixture
+// proven, against the smacker/go-tree-sitter Swift grammar (node shapes
+// confirmed by CST probe):
+//
+//   - enum value-set: an `enum` declaration is parsed (in addition to the
+//     existing SCOPE.Component) into a SCOPE.Enum value-set via the shared
+//     extractor.EnumEntity helper (kind_hint="swift_enum"). Each `enum_entry`
+//     yields one member per `simple_identifier` (so `case south, east` →
+//     two members); a `case x = <literal>` raw value is lifted to the
+//     member value (integer/string/bool literals). Answers "what cases can
+//     this enum take?" for cross-graph enum parity (#3628 / #4420),
+//     matching the dart/python/ts/java value-sets.
+//
+//   - typealias → SCOPE.Schema(subtype="type_alias") with a type_body
+//     property (the aliased type text after `=`), parity with the
+//     python (internal/extractors/python/types.go) / rust / go / dart
+//     type_alias shape. Tree-sitter `typealias_declaration` is used so the
+//     full RHS — including function types `(Int) -> Void` and generic
+//     `Result<T, E>` — is captured, superseding the vapor-only regex v1.
+//
+// Both run inside the existing walkNode dispatch (swift.go), so there is no
+// double-walk and no double-emit: the enum value-set is emitted alongside
+// (not instead of) the nominal Component, and typealias is a node type the
+// base walk previously fell through.
+package swift
+
+import (
+	"strconv"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// buildEnumValueSet parses an `enum` class_declaration into a SCOPE.Enum
+// value-set carrying its case members. Returns false when the enum has no
+// extractable cases (e.g. a generic-parameter-only forward decl).
+func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	name := enumName(node, file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	body := findClassBody(node)
+	if body == nil {
+		return types.EntityRecord{}, false
+	}
+	members := collectEnumCases(body, file.Content)
+	startLine := int(node.StartPoint().Row) + 1
+	endLine := int(node.EndPoint().Row) + 1
+	return extractor.EnumEntity(name, "swift", "swift_enum", file.Path,
+		startLine, endLine, members)
+}
+
+// enumName returns the type_identifier name child of an enum declaration.
+func enumName(node *sitter.Node, src []byte) string {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch.Type() == "type_identifier" {
+			return string(src[ch.StartByte():ch.EndByte()])
+		}
+	}
+	return ""
+}
+
+// collectEnumCases walks the enum_class_body for enum_entry nodes and emits
+// one EnumMember per declared case identifier. A `case a, b` group yields two
+// members; a `case x = <literal>` raw value is lifted to the member value.
+func collectEnumCases(body *sitter.Node, src []byte) []extractor.EnumMember {
+	var members []extractor.EnumMember
+	for i := 0; i < int(body.ChildCount()); i++ {
+		entry := body.Child(i)
+		if entry.Type() != "enum_entry" {
+			continue
+		}
+		line := int(entry.StartPoint().Row) + 1
+		// Within an enum_entry the case identifiers are simple_identifier
+		// children; an `=` introduces the raw value for the *single* preceding
+		// identifier (Swift forbids raw values on comma-grouped cases, so a
+		// grouped `case a, b` carries no `=`).
+		var pending []string
+		var rawValue string
+		sawEq := false
+		for j := 0; j < int(entry.ChildCount()); j++ {
+			c := entry.Child(j)
+			switch c.Type() {
+			case "simple_identifier":
+				pending = append(pending, string(src[c.StartByte():c.EndByte()]))
+			case "=":
+				sawEq = true
+			default:
+				if sawEq && rawValue == "" {
+					rawValue = extractor.StripLiteralQuotes(
+						strings.TrimSpace(string(src[c.StartByte():c.EndByte()])))
+				}
+			}
+		}
+		for _, id := range pending {
+			v := ""
+			// Raw value applies only when there is exactly one case in the
+			// entry (Swift grammar guarantee).
+			if sawEq && len(pending) == 1 {
+				v = rawValue
+			}
+			members = append(members, extractor.EnumMember{Name: id, Value: v, Line: line})
+		}
+	}
+	return members
+}
+
+// buildTypeAlias parses a `typealias_declaration` into a SCOPE.Schema
+// type_alias record carrying the aliased type body.
+func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	var name, body string
+	sawEq := false
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		switch ch.Type() {
+		case "type_identifier":
+			if name == "" {
+				name = string(file.Content[ch.StartByte():ch.EndByte()])
+			}
+		case "=":
+			sawEq = true
+		default:
+			if sawEq && body == "" && ch.Type() != "typealias" {
+				body = strings.TrimSpace(string(file.Content[ch.StartByte():ch.EndByte()]))
+			}
+		}
+	}
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	line := int(node.StartPoint().Row) + 1
+	props := map[string]string{"line": strconv.Itoa(line)}
+	if body != "" && len(body) <= 512 {
+		props["type_body"] = body
+	}
+	sig := "typealias " + name
+	if body != "" {
+		sig += " = " + body
+	}
+	return types.EntityRecord{
+		Name:               name,
+		Kind:               "SCOPE.Schema",
+		Subtype:            "type_alias",
+		Language:           "swift",
+		SourceFile:         file.Path,
+		StartLine:          line,
+		EndLine:            int(node.EndPoint().Row) + 1,
+		Signature:          sig,
+		Properties:         props,
+		EnrichmentRequired: false,
+	}, true
+}

--- a/internal/extractors/swift/types_test.go
+++ b/internal/extractors/swift/types_test.go
@@ -1,0 +1,142 @@
+package swift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractSwift parses src and runs the registered swift extractor.
+func extractSwift(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("swift")
+	if !ok {
+		t.Fatal("swift extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "Types.swift",
+		Content:  []byte(src),
+		Language: "swift",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func findEnumValueSet(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindEnum) && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func findTypeAlias(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Subtype == "type_alias" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestSwiftTypes_PlainEnumValueSet(t *testing.T) {
+	src := `enum Direction {
+    case north
+    case south, east
+    case west
+}`
+	ents := extractSwift(t, src)
+	vs := findEnumValueSet(ents, "Direction")
+	if vs == nil {
+		t.Fatal("no SCOPE.Enum value-set for Direction")
+	}
+	got := vs.Properties["members"]
+	want := "north, south, east, west"
+	if got != want {
+		t.Fatalf("members = %q, want %q", got, want)
+	}
+	if vs.Properties["member_count"] != "4" {
+		t.Fatalf("member_count = %q, want 4", vs.Properties["member_count"])
+	}
+	// The nominal SCOPE.Component(enum) must still be present (no replacement).
+	var comp bool
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "enum" && e.Name == "Direction" {
+			comp = true
+		}
+	}
+	if !comp {
+		t.Fatal("nominal SCOPE.Component(enum) Direction was lost")
+	}
+}
+
+func TestSwiftTypes_RawValueEnum(t *testing.T) {
+	src := `enum HTTPStatus: Int {
+    case ok = 200
+    case notFound = 404
+}`
+	ents := extractSwift(t, src)
+	vs := findEnumValueSet(ents, "HTTPStatus")
+	if vs == nil {
+		t.Fatal("no value-set for HTTPStatus")
+	}
+	if vs.Properties["values"] != "ok=200, notFound=404" {
+		t.Fatalf("values = %q, want ok=200, notFound=404", vs.Properties["values"])
+	}
+}
+
+func TestSwiftTypes_StringRawValueEnum(t *testing.T) {
+	src := `enum Suit: String {
+    case hearts = "♥"
+    case spades = "♠"
+}`
+	ents := extractSwift(t, src)
+	vs := findEnumValueSet(ents, "Suit")
+	if vs == nil {
+		t.Fatal("no value-set for Suit")
+	}
+	// Quotes stripped by StripLiteralQuotes.
+	if vs.Properties["values"] != "hearts=♥, spades=♠" {
+		t.Fatalf("values = %q", vs.Properties["values"])
+	}
+}
+
+func TestSwiftTypes_TypeAlias(t *testing.T) {
+	src := `typealias UserID = Int
+typealias Handler = (Int) -> Void`
+	ents := extractSwift(t, src)
+	uid := findTypeAlias(ents, "UserID")
+	if uid == nil {
+		t.Fatal("no type_alias UserID")
+	}
+	if uid.Properties["type_body"] != "Int" {
+		t.Fatalf("UserID type_body = %q, want Int", uid.Properties["type_body"])
+	}
+	h := findTypeAlias(ents, "Handler")
+	if h == nil {
+		t.Fatal("no type_alias Handler")
+	}
+	if h.Properties["type_body"] != "(Int) -> Void" {
+		t.Fatalf("Handler type_body = %q, want (Int) -> Void", h.Properties["type_body"])
+	}
+}
+
+func TestSwiftTypes_NoTypeAliasNoEmit(t *testing.T) {
+	src := `struct User { var id: Int }`
+	ents := extractSwift(t, src)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "type_alias" {
+			t.Fatalf("unexpected type_alias emitted: %s", e.Name)
+		}
+		if e.Kind == string(types.EntityKindEnum) {
+			t.Fatalf("unexpected enum value-set emitted: %s", e.Name)
+		}
+	}
+}


### PR DESCRIPTION
Coverage-audit #4913 (swift). Deploy-deferred. De-duped vs #3577 (SwiftUI nav/state) / #497 (SwiftPM target extractor already landed). Follows the merged sibling pattern (#4912 dart).

## Documented (registry flips, cites + fixture-proven)
- **lang.swift.base** (NEW base record, was absent): core_extraction / call_line_precision / import_resolution_quality all `full` — documents the previously-undocumented class/struct/enum/protocol/func + IMPORTS/CALLS/CONTAINS + #4854 field-membership/EXTENDS support. Cites swift.go/types.go/field_members.go.
- **pkg.swift-package** manifest_parsing `missing`->`partial`: Package.swift IS fully parsed (package.go/#497) -> swiftpm_target/product + DEPENDS_ON; Podfile/Cartfile honestly still missing (honest split, #3828 retained). Was wrongly fully-missing.
- **Type System enum_extraction + type_alias_extraction** `missing`->`partial` in all 5 swift framework records (alamofire/apollo-ios/swiftui/urlsession/vapor). interface_extraction stays `missing` with a cited NOTE (Swift has no `interface` keyword; protocol is a Component, not a type alias).

## Implemented (highest-value missing extraction — the #4913 HIGH language-core gap)
Swift TYPE SYSTEM (internal/extractors/swift/types.go, tree-sitter; node shapes confirmed by CST probe), wired into the existing walkNode dispatch (no double-walk):
- `enum` -> SCOPE.Enum value-set via extractor.EnumEntity(kind_hint=swift_enum), emitted **alongside** the nominal Component: one member per `case` identifier (comma-grouped `case a, b` -> 2 members); `case x = <literal>` raw values (int/string/bool) lifted via StripLiteralQuotes.
- `typealias Name = <type>` -> SCOPE.Schema(type_alias) with type_body (function-type `(Int)->Void` + generic RHS captured), superseding the loose vapor-only reSwiftTypealias->Component v1.
- Fixture-proven: types_test.go — PlainEnumValueSet / RawValueEnum / StringRawValueEnum / TypeAlias / NoTypeAliasNoEmit.

## Deferred (follow-ups, filed in commit body)
swift-testing (@Test/@Suite/#expect); Quick/Nimble closure-DSL scope-owner (#4680/#4719 style); Combine @Published/.sink data_fetching; Core Data/SwiftData ORM (@NSManaged/NSFetchRequest, @Model/@Query); GRDB/Realm/SQLite.swift; Hummingbird/Kitura/Perfect servers; UIKit UIViewController->UIComponent + segue NAVIGATES_TO; apollo-ios GraphQL operations; alamofire/urlsession outbound endpoint/request shape for cross-repo client->server linking; associated-value enum payload types.

## Gates (sandbox HOME=/tmp/agsbx-4913)
- `go build ./...` ✓, `go vet ./internal/...` ✓
- `go test ./internal/extractors/swift/... ./internal/custom/swift/... ./internal/types/` ✓ (existing vapor typealias suite unaffected)
- `coverage fmt --check` ✓ canonical, `coverage validate` ✓ (692 records)

Closes #4913.

🤖 Generated with [Claude Code](https://claude.com/claude-code)