### PR TITLE
feat(#4914): groovy coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -149,6 +149,23 @@ func walkGroovyWithContext(node *sitter.Node, file extractor.FileInput, imports 
 		}
 	}
 
+	// #4914 — Groovy enum value-set. The grammar has no dedicated enum node:
+	// `enum X {…}` parses as a `declaration[enum, X]` header whose body is the
+	// following `closure` sibling. Detect enum headers among THIS node's
+	// children (where the header/closure sibling pair lives) and emit one
+	// SCOPE.Enum value-set each. Done here rather than in the `declaration`
+	// case because the case handler only receives the header node, not its
+	// parent/sibling context. See types.go.
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch == nil || ch.Type() != "declaration" {
+			continue
+		}
+		if rec, ok := buildGroovyEnumValueSet(node, i, file); ok {
+			*out = append(*out, rec)
+		}
+	}
+
 	for i := range node.ChildCount() {
 		walkGroovyWithContext(node.Child(int(i)), file, imports, out, inClass)
 	}

--- a/internal/extractors/groovy/types.go
+++ b/internal/extractors/groovy/types.go
@@ -1,0 +1,227 @@
+// types.go — Groovy Type System extraction (#4914).
+//
+// The base groovy.go tree-sitter walk recognises class_declaration /
+// class_definition (which also covers `interface`, since the smacker grammar
+// parses `interface X {…}` as a class_definition) as SCOPE.Component nodes,
+// `def`/typed methods as SCOPE.Operation, and `import` as IMPORTS — but it
+// never modelled the Groovy *enum value set*. Every Groovy framework record
+// (lang.groovy.framework.grails) marked enum_extraction `missing`, and there
+// was no base language record at all.
+//
+// This pass — the highest-value LANGUAGE-CORE gap in #4914 — adds, fixture
+// proven against the smacker/go-tree-sitter Groovy grammar (node shapes
+// confirmed by CST probe), an enum value-set per `enum` declaration via the
+// shared extractor.EnumEntity helper (kind_hint="groovy_enum"), matching the
+// swift (#4913) / dart / python / java value-sets so a downstream cross-graph
+// parity audit (#4420 / #3628) can diff the literal members without re-parsing
+// source.
+//
+// Grammar shape (the smacker grammar does NOT have a dedicated enum node):
+//
+//	enum Color { RED, GREEN, BLUE }
+//	  → declaration[ identifier("enum"), identifier("Color") ]   (the header)
+//	    closure[ "{", ERROR[ parameter_list[ parameter[identifier]… ] ], "}" ]
+//
+//	enum Status { ACTIVE(1), INACTIVE(0) }
+//	  → declaration[ identifier("enum"), identifier("Status") ]
+//	    closure[ "{", function_call[ identifier("ACTIVE"), argument_list[…] ]… ]
+//
+// The header `declaration` and the body `closure` are SIBLINGS in the CST, so
+// the walk pairs an `enum`-headed declaration with its immediately following
+// `closure` sibling. Members are collected from the closure in two forms:
+//
+//   - parameter_list > parameter > identifier   (bare constants RED, GREEN)
+//   - function_call  > identifier + argument_list  (valued constants ACTIVE(1),
+//     HEARTS('red')) — the single literal argument (int/float/string/bool) is
+//     lifted to the member value (StripLiteralQuotes).
+//
+// To separate enum CONSTANTS from enum BODY members (fields / constructors —
+// e.g. `double mass; Planet(double m){…}`), member collection STOPS at the
+// first `declaration` (field) child of the closure: in valid Groovy every
+// constant precedes any field/method/constructor, so the trailing
+// constructor `function_call` (`Planet(...)`) is never mis-counted as a value.
+package groovy
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// buildGroovyEnumValueSet pairs an `enum`-headed declaration node with its
+// following `closure` sibling and emits a SCOPE.Enum value-set entity. Returns
+// ok=false when the node is not an enum header, has no following closure, or
+// yields zero parseable constants.
+//
+// parent is the node whose child list contains both `decl` (at index declIdx)
+// and the body closure — i.e. the enum's lexical container (source_file, a
+// class closure for a nested enum, …).
+func buildGroovyEnumValueSet(parent *sitter.Node, declIdx int, file extractor.FileInput) (types.EntityRecord, bool) {
+	decl := parent.Child(declIdx)
+	if decl == nil {
+		return types.EntityRecord{}, false
+	}
+	name := enumHeaderName(decl, file.Content)
+	if name == "" {
+		return types.EntityRecord{}, false
+	}
+	body := nextClosureSibling(parent, declIdx)
+	if body == nil {
+		return types.EntityRecord{}, false
+	}
+	members := collectGroovyEnumMembers(body, file.Content)
+	if len(members) == 0 {
+		return types.EntityRecord{}, false
+	}
+	return extractor.EnumEntity(
+		name, "groovy", "groovy_enum", file.Path,
+		int(decl.StartPoint().Row)+1, int(body.EndPoint().Row)+1,
+		members,
+	)
+}
+
+// enumHeaderName returns the enum type name when decl is an `enum X` header
+// (`declaration[ identifier("enum"), identifier("X") ]`), or "" otherwise.
+func enumHeaderName(decl *sitter.Node, src []byte) string {
+	if decl == nil || decl.Type() != "declaration" {
+		return ""
+	}
+	var ids []string
+	for i := 0; i < int(decl.ChildCount()); i++ {
+		ch := decl.Child(i)
+		if ch != nil && ch.Type() == "identifier" {
+			ids = append(ids, nodeText(ch, src))
+		}
+	}
+	if len(ids) < 2 || ids[0] != "enum" {
+		return ""
+	}
+	return ids[1]
+}
+
+// nextClosureSibling returns the first `closure` node that follows declIdx in
+// parent's child list, skipping anonymous separators, or nil.
+func nextClosureSibling(parent *sitter.Node, declIdx int) *sitter.Node {
+	for i := declIdx + 1; i < int(parent.ChildCount()); i++ {
+		ch := parent.Child(i)
+		if ch == nil {
+			continue
+		}
+		if ch.Type() == "closure" {
+			return ch
+		}
+		// A non-closure declaration/statement before any closure means this
+		// enum header has no body block — bail.
+		if ch.Type() == "declaration" || ch.Type() == "class_definition" {
+			return nil
+		}
+	}
+	return nil
+}
+
+// collectGroovyEnumMembers walks the enum body closure for constant members.
+// Collection stops at the first `declaration` (an enum field like
+// `double mass`), so the trailing constructor `function_call` is never counted.
+func collectGroovyEnumMembers(body *sitter.Node, src []byte) []extractor.EnumMember {
+	var members []extractor.EnumMember
+	seen := map[string]bool{}
+	add := func(name, value string, line int) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		members = append(members, extractor.EnumMember{Name: name, Value: value, Line: line})
+	}
+
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "declaration":
+			// First enum-body field/constructor declaration → constants are done.
+			return members
+		case "function_call":
+			// Valued constant: identifier(NAME) argument_list[ literal ].
+			name, value := groovyEnumValuedConst(ch, src)
+			if name != "" {
+				add(name, value, int(ch.StartPoint().Row)+1)
+			}
+		case "ERROR":
+			// Bare constants surface inside an ERROR node as a parameter_list.
+			collectEnumBareConsts(ch, src, add)
+		case "parameter_list":
+			collectEnumBareConsts(ch, src, add)
+		}
+	}
+	return members
+}
+
+// groovyEnumValuedConst extracts (name, value) from a `function_call` enum
+// constant such as `ACTIVE(1)` or `HEARTS('red')`. The value is the single
+// leading literal argument (number/string/bool); multi-arg or non-literal
+// constructors keep the constant but drop the value.
+func groovyEnumValuedConst(fc *sitter.Node, src []byte) (string, string) {
+	nameNode := childByType(fc, "identifier")
+	if nameNode == nil {
+		return "", ""
+	}
+	name := nodeText(nameNode, src)
+	if name == "" {
+		return "", ""
+	}
+	argList := childByType(fc, "argument_list")
+	if argList == nil {
+		return name, ""
+	}
+	for i := 0; i < int(argList.ChildCount()); i++ {
+		ch := argList.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "number_literal":
+			return name, nodeText(ch, src)
+		case "string":
+			return name, groovyStringLiteralContent(ch, src)
+		case "true", "false":
+			return name, nodeText(ch, src)
+		}
+	}
+	return name, ""
+}
+
+// collectEnumBareConsts walks a parameter_list (possibly the direct node or a
+// descendant of an ERROR node) collecting bare constant identifiers.
+func collectEnumBareConsts(node *sitter.Node, src []byte, add func(name, value string, line int)) {
+	for _, pl := range findAllNodes(node, "parameter_list") {
+		for i := 0; i < int(pl.ChildCount()); i++ {
+			p := pl.Child(i)
+			if p == nil || p.Type() != "parameter" {
+				continue
+			}
+			id := childByType(p, "identifier")
+			if id == nil {
+				continue
+			}
+			add(nodeText(id, src), "", int(id.StartPoint().Row)+1)
+		}
+	}
+}
+
+// groovyStringLiteralContent returns the inner content of a `string` node,
+// stripping the surrounding quote tokens.
+func groovyStringLiteralContent(node *sitter.Node, src []byte) string {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch != nil && ch.Type() == "string_content" {
+			return nodeText(ch, src)
+		}
+	}
+	return strings.Trim(nodeText(node, src), `'"`)
+}

--- a/internal/extractors/groovy/types_test.go
+++ b/internal/extractors/groovy/types_test.go
@@ -1,0 +1,107 @@
+package groovy
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tsgroovy "github.com/smacker/go-tree-sitter/groovy"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractGroovy parses src and runs the Groovy extractor, returning all records.
+func extractGroovy(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	parser := sitter.NewParser()
+	parser.SetLanguage(tsgroovy.GetLanguage())
+	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	recs, err := (&Extractor{}).Extract(context.Background(), extractor.FileInput{
+		Path:    "Sample.groovy",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return recs
+}
+
+// findEnum returns the SCOPE.Enum record with the given enum_name, or nil.
+func findEnum(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == string(types.EntityKindEnum) && recs[i].Properties["enum_name"] == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func TestGroovyTypes_PlainEnumValueSet(t *testing.T) {
+	recs := extractGroovy(t, "enum Color {\n  RED, GREEN, BLUE\n}\n")
+	e := findEnum(recs, "Color")
+	if e == nil {
+		t.Fatalf("no SCOPE.Enum for Color; got %d records", len(recs))
+	}
+	if got := e.Properties["members"]; got != "RED, GREEN, BLUE" {
+		t.Fatalf("members = %q, want RED, GREEN, BLUE", got)
+	}
+	if got := e.Properties["member_count"]; got != "3" {
+		t.Fatalf("member_count = %q, want 3", got)
+	}
+	if got := e.Properties["kind_hint"]; got != "groovy_enum" {
+		t.Fatalf("kind_hint = %q, want groovy_enum", got)
+	}
+}
+
+func TestGroovyTypes_ValuedEnum(t *testing.T) {
+	recs := extractGroovy(t, "enum Status {\n  ACTIVE(1), INACTIVE(0)\n}\n")
+	e := findEnum(recs, "Status")
+	if e == nil {
+		t.Fatalf("no SCOPE.Enum for Status")
+	}
+	if got := e.Properties["values"]; got != "ACTIVE=1, INACTIVE=0" {
+		t.Fatalf("values = %q, want ACTIVE=1, INACTIVE=0", got)
+	}
+}
+
+func TestGroovyTypes_StringValuedEnum(t *testing.T) {
+	recs := extractGroovy(t, "enum Suit {\n  HEARTS('red'), SPADES('black')\n}\n")
+	e := findEnum(recs, "Suit")
+	if e == nil {
+		t.Fatalf("no SCOPE.Enum for Suit")
+	}
+	// String literals are quote-stripped to the inner content.
+	if got := e.Properties["values"]; got != "HEARTS=red, SPADES=black" {
+		t.Fatalf("values = %q, want HEARTS=red, SPADES=black", got)
+	}
+}
+
+func TestGroovyTypes_EnumWithBodyExcludesFieldsAndCtor(t *testing.T) {
+	// Planet has valued constants, then a field + constructor; only the two
+	// constants should be members — NOT `mass` or the `Planet(...)` ctor.
+	src := "enum Planet {\n  MERCURY(3.3e23), VENUS(4.8e24)\n\n  double mass\n  Planet(double m) { mass = m }\n}\n"
+	recs := extractGroovy(t, src)
+	e := findEnum(recs, "Planet")
+	if e == nil {
+		t.Fatalf("no SCOPE.Enum for Planet")
+	}
+	if got := e.Properties["members"]; got != "MERCURY, VENUS" {
+		t.Fatalf("members = %q, want MERCURY, VENUS", got)
+	}
+	if got := e.Properties["member_count"]; got != "2" {
+		t.Fatalf("member_count = %q, want 2", got)
+	}
+}
+
+func TestGroovyTypes_NoEnumNoEmit(t *testing.T) {
+	// A plain class must not produce any SCOPE.Enum record.
+	recs := extractGroovy(t, "class Book {\n  def read() {}\n}\n")
+	if e := findEnum(recs, "Book"); e != nil {
+		t.Fatalf("unexpected SCOPE.Enum emitted for a plain class")
+	}
+}


### PR DESCRIPTION
Coverage-audit #4914 (groovy). Deploy-deferred. Follows the merged sibling pattern (swift #4913 / dart #4912).

## Documented (registry flips, cites + fixture-proven)
- **lang.groovy.base** (NEW base record, was absent): core_extraction / call_line_precision / import_resolution_quality all `full` — documents the previously-undocumented class/interface SCOPE.Component + def/method SCOPE.Operation + CONTAINS + IMPORTS (#93 contract: local_name/source_module/imported_name/wildcard/import_kind=static/aliased) + CALLS (PascalCase static-receiver + #4749 local-var receiver typing + line precision) + Gradle DSL (apply plugin→plugin_id, task decls). Cites groovy.go/types.go/relationships_test.go/localvar_receiver_4749_test.go.
- **Grails Routing** route_extraction/handler_attribution/endpoint_synthesis `missing`→`full`: synthesizeGroovyRoutes (internal/engine/http_endpoint_grails.go) actively synthesizes http_endpoint_definition for Grails convention controllers, UrlMappings.groovy, and Ratpack handler DSL — was wrongly fully-missing while the existing tests_linkage TESTS edges depend on these endpoints.
- **Type System** enum_extraction `missing`→`partial`, interface_extraction `missing`→`partial` (interface IS extracted as a Component via class_definition), type_extraction `missing`→`partial`; type_alias_extraction stays `missing` with a cited NOTE (Groovy has no typealias/typedef; `import X as Y` is the only alias idiom, captured as an aliased IMPORTS edge).

## Implemented (highest-value missing extraction — the #4914 language-core gap)
Groovy **enum value-set** (internal/extractors/groovy/types.go, tree-sitter; node shapes confirmed by CST probe), wired into walkGroovyWithContext (no double-walk). The smacker grammar has no enum node — `enum X {…}` parses as a `declaration[enum, X]` header whose body is the following `closure` **sibling** — so buildGroovyEnumValueSet pairs them and emits a SCOPE.Enum value-set via extractor.EnumEntity(kind_hint=groovy_enum): bare constants (ERROR>parameter_list) + valued constants (function_call+argument_list, single literal lifted & quote-stripped); member collection stops at the first enum-body field decl so trailing fields/constructors are not mis-counted. Fixture-proven: types_test.go (PlainEnumValueSet / ValuedEnum / StringValuedEnum / EnumWithBodyExcludesFieldsAndCtor / NoEnumNoEmit).

## Deferred (follow-ups)
`trait` and `@interface` (annotation) type decls; interface Component subtype distinction; multi-arg/computed enum constant values; GORM ORM (domain classes/dynamic finders/criteria); Micronaut-Groovy (@Controller/@Get); Spring Boot Groovy record; Ratpack as own record; Geb functional testing; Spock feature-method/given-when-then (#3828, blocked by tree-sitter ERROR nodes on string-named feature methods).

## Gates (sandbox HOME=/tmp/agsbx-4914)
- `go build ./...` ✓, `go vet ./internal/...` ✓
- `go test ./internal/extractors/groovy/... ./internal/custom/groovy/... ./internal/types/` ✓
- `coverage fmt --check` ✓ canonical, `coverage validate` ✓ (693 records)

Closes #4914.

🤖 Generated with [Claude Code](https://claude.com/claude-code)