### PR TITLE
feat(#4915): scala coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/custom/scala/anorm.go
+++ b/internal/custom/scala/anorm.go
@@ -1,0 +1,170 @@
+// Package scala — Anorm ORM extractor (#4915).
+//
+// Anorm (org.playframework.anorm) is the SQL data-access layer that ships with
+// the Play Framework — the most common Scala SQL approach in Play apps. Unlike
+// the heavier ORMs it is "just SQL": queries are written as SQL string
+// interpolation and results are mapped to case classes via RowParsers. It was
+// the only mainstream Scala SQL library with NO record/extractor (slick,
+// doobie, quill, scalikejdbc, scanamo, elastic4s were all covered) — the HIGH
+// MISSING-FRAMEWORK gap called out by #4915.
+//
+// This extractor — modelled on the sibling doobie extractor in
+// orm_extractors.go (Anorm and Doobie are both SQL-interpolation, not
+// relationship-declaring ORMs) — emits, fixture-proven against real Anorm
+// idioms:
+//
+//   - SQL("…") / SQL"…" interpolated statements      -> SCOPE.Operation/query
+//     (query_attribution / schema_extraction): the SQL body is mined for its
+//     leading verb (sqlVerb) and primary table (firstSQLTable), reusing the
+//     same shared helpers doobie uses.
+//   - RowParser / ResultSetParser type mappings       -> SCOPE.Schema
+//     `Macro.namedParser[User]`, `Macro.indexedParser[User]`, `.as(User.parser.*)`
+//     name the row model the query hydrates.
+//   - case class row models in Anorm-flavoured files   -> SCOPE.Schema
+//
+// Anorm declares no foreign keys / associations (joins are raw SQL) and owns no
+// migration tooling, so Relationships.* and Migrations.* are not_applicable —
+// matching the doobie record. Honest-partial: an Anorm file that contains no
+// SQL("…"), no parser, and no case class emits nothing.
+package scala
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_scala_anorm", &anormExtractor{})
+}
+
+// anormExtractor extracts Anorm SQL statements, row parsers and row models.
+type anormExtractor struct{}
+
+func (e *anormExtractor) Language() string { return "custom_scala_anorm" }
+
+var (
+	// anormSQLCallRe matches the classic SQL("…") / SQL("""…""") call form.
+	// Group 1 = triple-quote body, group 2 = single-quote body.
+	anormSQLCallRe = regexp.MustCompile(
+		`(?s)\bSQL\s*\(\s*(?:"""(.{0,400}?)"""|"((?:[^"\\]|\\.){0,400}?)")\s*\)`)
+
+	// anormSQLInterpRe matches the interpolated SQL"…" / SQL"""…""" form.
+	// Group 1 = triple-quote body, group 2 = single-quote body.
+	anormSQLInterpRe = regexp.MustCompile(
+		`(?s)\bSQL(?:"""(.{0,400}?)"""|"((?:[^"\\]|\\.){0,400}?)")`)
+
+	// anormMacroParserRe: Macro.namedParser[User] / Macro.indexedParser[User] /
+	// Macro.parser[User](...) — the generated RowParser names its row model.
+	anormMacroParserRe = regexp.MustCompile(
+		`(?m)Macro\.(?:named|indexed)?[Pp]arser\[([A-Za-z_]\w*)\]`)
+
+	// anormCaseClassRe: row models declared in an Anorm-flavoured file.
+	anormCaseClassRe = regexp.MustCompile(
+		`(?m)case\s+class\s+(\w+)\s*\(([^)]*)\)`)
+)
+
+func (e *anormExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/scala")
+	_, span := tracer.Start(ctx, "indexer.anorm_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "anorm"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "scala" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	// Gate: must look like an Anorm file. `import anorm` / `anorm.SQL` /
+	// a bare SQL( call alongside an anorm import are the load-bearing signals;
+	// gating on "anorm" alone avoids colliding with doobie's `sql"…"` (lower
+	// case) interpolator.
+	if !strings.Contains(src, "anorm") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if !seen[key] {
+			seen[key] = true
+			entities = append(entities, ent)
+		}
+	}
+
+	emitSQL := func(body string, offset int) {
+		body = strings.TrimSpace(body)
+		if body == "" {
+			return
+		}
+		preview := body
+		if len(preview) > 60 {
+			preview = preview[:60]
+		}
+		ent := makeEntity("sql:"+preview, "SCOPE.Operation", "query", file.Path, file.Language, lineOf(src, offset))
+		setProps(&ent, "framework", "anorm",
+			"provenance", "INFERRED_FROM_ANORM_SQL",
+			"sql_verb", sqlVerb(body),
+			"table_name", firstSQLTable(body),
+			"pattern_type", "sql_statement")
+		add(ent)
+	}
+
+	// SQL("…") call form.
+	for _, m := range anormSQLCallRe.FindAllStringSubmatchIndex(src, -1) {
+		switch {
+		case m[2] >= 0:
+			emitSQL(src[m[2]:m[3]], m[0])
+		case m[4] >= 0:
+			emitSQL(src[m[4]:m[5]], m[0])
+		}
+	}
+
+	// SQL"…" interpolated form. The call-form regex requires a `(` after SQL,
+	// so the two patterns do not double-count the same site.
+	for _, m := range anormSQLInterpRe.FindAllStringSubmatchIndex(src, -1) {
+		switch {
+		case m[2] >= 0:
+			emitSQL(src[m[2]:m[3]], m[0])
+		case m[4] >= 0:
+			emitSQL(src[m[4]:m[5]], m[0])
+		}
+	}
+
+	// Macro.namedParser[T] / indexedParser[T] — row model the parser builds.
+	for _, m := range anormMacroParserRe.FindAllStringSubmatchIndex(src, -1) {
+		rowType := strings.TrimSpace(src[m[2]:m[3]])
+		ent := makeEntity("row_parser:"+rowType, "SCOPE.Schema", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "anorm",
+			"provenance", "INFERRED_FROM_ANORM_ROW_PARSER",
+			"row_type", rowType,
+			"pattern_type", "row_parser")
+		add(ent)
+	}
+
+	// case class row models.
+	for _, m := range anormCaseClassRe.FindAllStringSubmatchIndex(src, -1) {
+		name := strings.TrimSpace(src[m[2]:m[3]])
+		ent := makeEntity(name, "SCOPE.Schema", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "anorm",
+			"provenance", "INFERRED_FROM_ANORM_CASE_CLASS",
+			"pattern_type", "row_model")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/scala/anorm_test.go
+++ b/internal/custom/scala/anorm_test.go
@@ -1,0 +1,93 @@
+package scala_test
+
+import "testing"
+
+// Anorm extractor (#4915) — SQL("…") / SQL"…" statements, RowParser type
+// mappings, and case-class row models in Anorm-flavoured Play files.
+
+func TestAnormSQLCallStatement(t *testing.T) {
+	src := `
+import anorm._
+import anorm.SqlParser._
+
+def findById(id: Long): Option[User] =
+  DB.withConnection { implicit c =>
+    SQL("SELECT id, name FROM users WHERE id = {id}")
+      .on("id" -> id)
+      .as(User.parser.singleOpt)
+  }
+`
+	ents := extract(t, "custom_scala_anorm", fi("UserRepo.scala", "scala", src))
+	q := findEntity(ents, "SCOPE.Operation", "")
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			found = true
+			if e.Props["sql_verb"] != "select" {
+				t.Errorf("sql_verb = %q, want select", e.Props["sql_verb"])
+			}
+			if e.Props["table_name"] != "users" {
+				t.Errorf("table_name = %q, want users", e.Props["table_name"])
+			}
+			if e.Props["framework"] != "anorm" {
+				t.Errorf("framework = %q, want anorm", e.Props["framework"])
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected SCOPE.Operation/query from SQL(...) call; got %v", q)
+	}
+}
+
+func TestAnormSQLInterpolated(t *testing.T) {
+	src := `
+import anorm._
+
+val q = SQL"""INSERT INTO orders (user_id, total) VALUES (${userId}, ${total})"""
+`
+	ents := extract(t, "custom_scala_anorm", fi("OrderRepo.scala", "scala", src))
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" && e.Props["sql_verb"] == "insert" {
+			found = true
+			if e.Props["table_name"] != "orders" {
+				t.Errorf("table_name = %q, want orders", e.Props["table_name"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected an insert SCOPE.Operation/query from interpolated SQL")
+	}
+}
+
+func TestAnormMacroRowParser(t *testing.T) {
+	src := `
+import anorm._
+
+case class User(id: Long, name: String)
+
+object User {
+  val parser = Macro.namedParser[User]
+}
+`
+	ents := extract(t, "custom_scala_anorm", fi("User.scala", "scala", src))
+	if !containsEntity(ents, "SCOPE.Schema", "row_parser:User") {
+		t.Error("expected row_parser:User SCOPE.Schema from Macro.namedParser[User]")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "User") {
+		t.Error("expected User case-class row model SCOPE.Schema")
+	}
+}
+
+func TestAnormNoMatch(t *testing.T) {
+	// No `anorm` token -> gate closes, nothing emitted (does not poach
+	// doobie's lower-case sql"…" interpolator).
+	src := `
+import doobie._
+val q = sql"SELECT 1".query[Int]
+`
+	ents := extract(t, "custom_scala_anorm", fi("Doobie.scala", "scala", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-anorm file, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
Coverage-audit #4915 (scala). Deploy-deferred. Follows the merged sibling pattern (groovy #4914).

## Documented (registry flips, cites + fixture-proven)
- **lang.scala.base** (NEW base record, was absent): `core_extraction` / `call_line_precision` / `import_resolution_quality` all **full** — documents the previously-undocumented tree-sitter walk: class/case_class/trait/object → SCOPE.Component, function → SCOPE.Operation + CONTAINS (#379 Format-A ref), IMPORTS (#379/#93 contract: local_name/source_module/imported_name/wildcard + selector groups), CALLS (field/param/#4749 local-var receiver typing → receiver_type, line-stamped, #2114 self-recursion guard), Twirl (#501), constant/enum value-sets (constantset.go #4432: Scala-3 `enum`, sealed-trait + case-object ADTs, val=Map/Seq const groups), THROWS/CATCHES (exception_flow.go #3628). Cites scala.go/constantset.go/exception_flow.go + matching tests.

## Implemented (highest-value MISSING extraction — the #4915 HIGH gap)
**Anorm ORM** (`internal/custom/scala/anorm.go`, NEW extractor `custom_scala_anorm`): Anorm was the only mainstream Scala SQL library with no record (slick/doobie/quill/scalikejdbc/scanamo/elastic4s already covered). Modelled on the sibling doobie extractor (both SQL-interpolation, not relationship-declaring). Emits `SQL("…")`/`SQL"…"` statements → SCOPE.Operation/query stamped sql_verb + table_name (shared sqlVerb/firstSQLTable); `Macro.namedParser[T]`/`indexedParser[T]` → SCOPE.Schema row_parser:T; case-class row models → SCOPE.Schema. Gate keys on the `anorm` token so doobie's lower-case `sql"…"` is not poached. Plus **lang.scala.orm.anorm** record (schema_extraction full; model/query partial; relationships/migrations not_applicable matching doobie). Fixture-proven: anorm_test.go (SQLCall / SQLInterpolated / MacroRowParser / NoMatch).

## Deferred (follow-ups for the big ones)
- **Akka/Pekko actor + Alpakka/Kafka Messaging**: akka.go extracts Actor/spawn/tell/ask but there is no `Messaging` capability dimension in the capability dictionary for http_framework records; correct home is a NEW message_broker-category scala record (producer/consumer/topic caps) — too large for this PR.
- **Skunk** ORM + **Mill** build parser (#3828) + **sbt** manifest_parsing (#3828); ScalaCheck/weaver/ZIO-Test/Mockito-Scala test records; **config_consumption** (Typesafe/Lightbend Config, PureConfig, Ciris) — net-new across ALL langs, own program.

## Gates (sandbox HOME=/tmp/agsbx-4915)
- `go build ./...` ✓, `go vet ./internal/...` ✓
- `go test ./internal/extractors/scala/... ./internal/custom/scala/... ./internal/types/` ✓
- `coverage fmt --check` ✓ canonical, `coverage validate` ✓ (695 records)

Closes #4915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)