### PR TITLE
feat(#4916): elixir coverage — document extracted capabilities + base record + new extraction

### DIFF
--- a/internal/substrate/effect_sinks_elixir.go
+++ b/internal/substrate/effect_sinks_elixir.go
@@ -4,7 +4,10 @@
 //
 //   - http_out  : HTTPoison.<get|post|put|patch|delete|head|request>,
 //     Tesla.<verb> / Tesla.Client, Finch.build / Finch.request,
-//     Mint.HTTP, Req.<verb> / Req.new, :httpc.request
+//     Mint.HTTP, Req.<verb> / Req.new, :httpc.request,
+//     WebSockex.<start_link|send_frame|cast> (#4916 — WebSockex is the
+//     dominant Elixir WebSocket client; its connection establishment and
+//     frame sends are outbound network egress, so they belong to http_out)
 //   - db_read   : Ecto `Repo.all / Repo.get / Repo.get_by / Repo.one /
 //     Repo.stream / Repo.preload / Repo.aggregate /
 //     Repo.exists?`, `from(... in ..., select: ...) |> Repo.all`,
@@ -46,7 +49,8 @@ var elixirHTTPRe = regexp.MustCompile(
 		`|\bReq\s*\.\s*(?:get|post|put|patch|delete|head|new|request|request!)\s*\(` +
 		`|\bMint\s*\.\s*HTTP\b` +
 		`|\b:httpc\s*\.\s*request\s*\(` +
-		`|\b:hackney\s*\.\s*request\s*\(`,
+		`|\b:hackney\s*\.\s*request\s*\(` +
+		`|\bWebSockex\s*\.\s*(?:start_link|start|send_frame|cast)\s*\(`,
 )
 
 // elixirDBReadRe matches Ecto read primitives.
@@ -107,7 +111,7 @@ func sniffEffectsElixir(content string) []EffectMatch {
 	}
 	headers := scanElixirFuncHeaders(content)
 	var out []EffectMatch
-	out = appendElixirMatches(out, content, headers, elixirHTTPRe, EffectHTTPOut, "HTTPoison/Tesla/Finch/Req", 1.0)
+	out = appendElixirMatches(out, content, headers, elixirHTTPRe, EffectHTTPOut, "HTTPoison/Tesla/Finch/Req/WebSockex", 1.0)
 	out = appendElixirMatches(out, content, headers, elixirDBReadRe, EffectDBRead, "Repo.read", 0.9)
 	out = appendElixirMatches(out, content, headers, elixirRawSelectRe, EffectDBRead, "SQL.query(SELECT)", 1.0)
 	out = appendElixirMatches(out, content, headers, elixirDBWriteRe, EffectDBWrite, "Repo.write", 0.9)

--- a/internal/substrate/elixir_confidence_overlay_test.go
+++ b/internal/substrate/elixir_confidence_overlay_test.go
@@ -101,3 +101,36 @@ func TestElixirConfidenceOverlay_AllMatchesPositive(t *testing.T) {
 		}
 	}
 }
+
+// websockexSrc — a WebSockex WebSocket-client module. #4916: WebSockex is the
+// dominant Elixir WebSocket client (registry covered Finch/Req/Tesla outbound
+// but WebSockex had zero recognition). Connection establishment and frame
+// sends are outbound network egress -> http_out.
+const websockexSrc = `
+defmodule MyApp.Socket do
+  use WebSockex
+
+  def open(url) do
+    {:ok, pid} = WebSockex.start_link(url, __MODULE__, %{})
+    pid
+  end
+
+  def push(pid, payload) do
+    WebSockex.send_frame(pid, {:text, payload})
+  end
+end
+`
+
+// TestElixirConfidenceOverlay_WebSockex proves the #4916 WebSockex addition to
+// elixirHTTPRe feeds the overlay: WebSockex.start_link -> http_out on open,
+// conf 1.0, and the frame send -> http_out on push.
+func TestElixirConfidenceOverlay_WebSockex(t *testing.T) {
+	m := elixirConfMatch(t, websockexSrc, "open", EffectHTTPOut)
+	if m.Confidence != 1.0 {
+		t.Errorf("websockex open http_out confidence = %v, want 1.0", m.Confidence)
+	}
+	push := elixirConfMatch(t, websockexSrc, "push", EffectHTTPOut)
+	if push.Confidence != 1.0 {
+		t.Errorf("websockex push http_out confidence = %v, want 1.0", push.Confidence)
+	}
+}


### PR DESCRIPTION
Coverage-audit #4916 (elixir). Deploy-deferred. Follows the merged sibling pattern (erlang -> scala #4915).

## Documented (registry flips, cites + fixture-proven)
- **lang.elixir.base** (NEW base record, was absent): `core_extraction` / `call_line_precision` / `import_resolution_quality` all `full` — documents the previously-undocumented tree-sitter walk (`elixir.go`): defmodule/defprotocol -> SCOPE.Component, def/defp -> SCOPE.Operation + CONTAINS (Format-A `scope:operation:method:elixir:<file>:<name>`, #144/#370), Ecto `schema` -> SCOPE.Schema, IMPORTS (#370/#120/#93 contract: local_name/source_module/imported_name/import_kind for alias/import/use/require), CALLS (bare + dotted receiver, line-stamped, self-recursion + keyword/macro stop-list), THROWS/CATCHES (`exception_flow.go` #3628). Also `http_effect`/`db_effect`/`fs_effect` `full` citing `effect_sinks_elixir.go` — **this is where HTTPoison / hackney / Mint outbound (the #4916 HIGH MISSING-FRAMEWORK gap) are honestly DOCUMENTED** (they had no registry record). Cites `elixir.go`/`exception_flow.go`/`effect_sinks_elixir.go` + matching tests.
- **test.mox / test.wallaby / test.bypass / test.faker** (NEW): the four `test_patterns.yaml`-cataloged libs from #4916. Honest status: both caps `missing` with cite to `test_patterns.yaml` + a NOTE — they are DETECTION catalogues only (the language-root yaml is **not** loaded by the framework-rule loader, none are wired into `cross/testmap`), so mock_extraction / http-mock / factory-to-schema target extraction is a documented follow-up, not a silent green.
- **db.nebulex** (NEW): `extras.yaml` caching catalogue entry; both caps `missing` + NOTE (no cache-resource extractor yet).

## Implemented (highest-value MISSING extraction — #4916 HIGH gap)
**WebSockex outbound recognition** in the Elixir effect sniffer (`internal/substrate/effect_sinks_elixir.go`): `elixirHTTPRe` now matches `WebSockex.<start_link|start|send_frame|cast>(` -> `EffectHTTPOut` (conf 1.0). WebSockex is the dominant Elixir WebSocket client and had zero recognition (registry covered Finch/Req/Tesla but not WebSockex). Connection establishment + frame sends are outbound network egress. **Fixture-proven**: `elixir_confidence_overlay_test.go` `TestElixirConfidenceOverlay_WebSockex` (open -> http_out via start_link, push -> http_out via send_frame, conf 1.0) + the existing AllMatchesPositive guard.

## Deferred (follow-ups, filed as registry NOTES on #4916)
- Mox mock_extraction (testmap `expect(Mock,:fun)` -> behaviour-callback TESTS edge)
- Bypass http-mock resolver; Faker/ExMachina factory-to-schema resolver; Wallaby session-to-route attribution
- Nebulex cache-resource extractor (@decorate cacheable attribution)
- GenStage/Flow, Quantum cron, Pow/argon2 — med/low in #4916, out of this PR's scope

## Gates (sandbox HOME=/tmp/agsbx-4916)
`go build ./...`, `go vet ./internal/...`, `go test` elixir/custom-elixir/types/substrate/tools-coverage all green. `coverage fmt --check` (canonical) + `coverage validate` (rc 0 — only pre-existing partial-no-issue warnings + the same `capability-map` warning the merged scala base record carries).

Closes #4916.

🤖 Generated with [Claude Code](https://claude.com/claude-code)