### PR TITLE
feat(#4917): java coverage — document the wrongly-missing Observability/AOP/DI cells (extracted-but-undocumented) + Quarkus printf logging

### DIFF
--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -3909,6 +3909,46 @@ public class OrderService {
 	}
 }
 
+// TestObservability_QuarkusPrintfLogging proves the JBoss Logging / Quarkus
+// static `Log` facade printf-style level methods (infof/errorf/debugf) are
+// recognised as log statements, folded onto the canonical log_level, and
+// stamped log_style=printf. Previously `Log.infof(...)` was missed because the
+// level matcher had no trailing-`f` form (#4917).
+func TestObservability_QuarkusPrintfLogging_Issue4917(t *testing.T) {
+	source := `
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class OrderResource {
+    public void place(Order o) {
+        Log.infof("placing order %s", o.getId());
+        Log.debugf("ctx %s", ctx);
+        if (o.isInvalid()) {
+            Log.errorf("invalid order %s", o.getId());
+        }
+        Log.info("plain standard call");
+    }
+}
+`
+	r := ExtractObservability(PatternContext{Source: source, Language: "java", Framework: "quarkus", FilePath: "OrderResource.java"})
+
+	if n := countObsSubtype(r, "log_statement"); n != 4 {
+		t.Fatalf("[#4917 log] expected 4 log statements (3 printf + 1 standard), got %d: %v", n, entityNames(r.Entities))
+	}
+	// printf-style infof must fold onto log_level=info with log_style=printf.
+	printf := findObsEntity(r, "log_statement", map[string]string{"log_level": "info", "log_style": "printf"})
+	if printf == nil {
+		t.Errorf("[#4917 log] missing Log.infof printf statement (log_level=info, log_style=printf)")
+	}
+	if findObsEntity(r, "log_statement", map[string]string{"log_level": "error", "log_style": "printf"}) == nil {
+		t.Errorf("[#4917 log] missing Log.errorf printf statement")
+	}
+	// the plain standard call must still be log_style=standard.
+	if findObsEntity(r, "log_statement", map[string]string{"log_level": "info", "log_style": "standard"}) == nil {
+		t.Errorf("[#4917 log] missing standard Log.info statement (log_style=standard)")
+	}
+}
+
 // TestObservability_LoggerFactoryVariants proves SLF4J / Log4j2 / JUL logger
 // factories are recognised with the right backing library.
 func TestObservability_LoggerFactoryVariants_Issue3006(t *testing.T) {

--- a/internal/custom/java/observability.go
+++ b/internal/custom/java/observability.go
@@ -76,10 +76,14 @@ var (
 
 	// obsLogStmtRE matches a log statement call: a receiver identifier ending in
 	// a log level method. We anchor on a small set of receiver names commonly
-	// used for loggers (log, logger, LOG, LOGGER, <Class>.log) to avoid matching
-	// unrelated `.error(` style calls. Group 1 = receiver, group 2 = level.
+	// used for loggers (log, logger, LOG, LOGGER, <Class>.log, and the Quarkus
+	// static `Log` facade from io.quarkus.logging.Log) to avoid matching
+	// unrelated `.error(` style calls. The level may carry a trailing `f`
+	// (JBoss Logging / Quarkus printf-style: infof/errorf/debugf/warnf/tracef/
+	// fatalf) which we capture in group 3 and fold into the canonical level.
+	// Group 1 = receiver, group 2 = base level, group 3 = optional `f` suffix.
 	obsLogStmtRE = regexp.MustCompile(
-		`\b([lL][oO][gG](?:[gG][eE][rR])?)\s*\.\s*(trace|debug|info|warn|error|fatal)\s*\(`)
+		`\b([lL][oO][gG](?:[gG][eE][rR])?)\s*\.\s*(trace|debug|info|warn|error|fatal)(f?)\s*\(`)
 
 	// --- metric_extraction ---
 
@@ -253,6 +257,13 @@ func extractLogging(result *PatternResult, seen map[string]bool, source, fp, fw 
 	for _, m := range obsLogStmtRE.FindAllStringSubmatchIndex(source, -1) {
 		receiver := source[m[2]:m[3]]
 		level := source[m[4]:m[5]]
+		// group 3 is the optional `f` printf-style suffix (JBoss Logging /
+		// Quarkus: infof/errorf/...). Fold it into the canonical log_level so
+		// `info` and `infof` converge, and record the call style.
+		logStyle := "standard"
+		if m[6] >= 0 && m[7] > m[6] && source[m[6]:m[7]] == "f" {
+			logStyle = "printf"
+		}
 		line := lineOf(source, m[0])
 		// Distinguish multiple statements on the same logger by line number.
 		ref := "scope:pattern:obs_log_statement:" + fp + ":" + receiver + ":" + level + ":" + itoa(line)
@@ -265,6 +276,7 @@ func extractLogging(result *PatternResult, seen map[string]bool, source, fp, fw 
 				"kind":      "log_statement",
 				"signal":    "log",
 				"log_level": level,
+				"log_style": logStyle,
 				"receiver":  receiver,
 				"framework": fw,
 			},


### PR DESCRIPTION
## What

Coverage-audit **#4917 (java)**. Deploy-deferred. Follows the merged sibling pattern (scala #4915 → elixir #4916).

**The ticket premise is largely STALE.** Audit found the registry was NOT all-None — subsequent waves backfilled most Java cells (current java distribution: 351 full / 478 partial / 325 missing across ~52 records). This PR closes the cells that are *genuinely still wrong*: extractors that demonstrably produce output (wired in `patterns_dispatch.go`, with passing tests) but whose cells were left `missing`.

## Documented — 60 registry cells flipped (54 missing→partial, 6 missing→full), all cite-backed + fixture-verified
- **Observability (39 cells)**: log/metric/trace × 13 `obsFrameworks`-gated records (spring-boot, spring-webflux, quarkus, micronaut, microprofile, jakarta-ee, jaxrs, dropwizard, helidon, javalin, vertx, akka-http, struts) → `partial`. `ExtractObservability` (observability.go, tested `TestObservability_*_Issue3006`) emits logger/log_statement (SLF4J/@Slf4j/Log4j/JUL), metric (Micrometer + MicroProfile), trace_span (OTel + Micrometer Tracing). Honest-partial: regex/file-local per the extractor's own design note.
- **AOP (9 cells)**: jakarta-ee/quarkus/microprofile aspect+advice → `full`, pointcut → `partial`. CDI `@Interceptor`/`@AroundInvoke`/`@InterceptorBinding` via `ExtractCDIInterceptors` (`cdiFrameworks`-gated, tested `TestCDI_*_Issue3082/3175`) — the same extractor already crediting jaxrs full.
- **DI (12 cells)**: jakarta-ee/microprofile/helidon/dropwizard binding+injection+scope → `partial`. CDI `@Produces`, `@Inject`/`@EJB`/`@Resource`, CDI scopes via `ExtractJakartaEEAdvanced` (`jakartaEEAdvFrameworks`-gated, tested `TestJakartaEE_EJB`/`TestJakartaEEAdv_*`) — same extractor crediting jaxrs full.

## Implemented — new extraction (#4917 Quarkus logging gap)
`observability.go` `obsLogStmtRE` now captures the JBoss Logging / Quarkus printf-style `*f` variants (`Log.infof/errorf/debugf/warnf/tracef` — the `io.quarkus.logging.Log` static facade), folds the level onto canonical `log_level`, stamps `log_style=standard|printf`. Previously `Log.infof(...)` (idiomatic Quarkus) was silently missed. Fixture-proven: `TestObservability_QuarkusPrintfLogging_Issue4917`.

## Deferred (precise follow-ups — too big for one PR)
- **Spring @Scheduled / Quartz Scheduling capability + record**: `ExtractQuartzJava` exists + wired but UNTESTED, and there is no `Scheduling` capability in the capability-map taxonomy (taxonomy add out of scope).
- **capability-map.yaml mapping entries** for the flipped DI/AOP cells — `validate` emits soft *warnings* (pre-existing for already-credited jaxrs/guice/micronaut/spring-webflux too), backfill-gate epic #4707.
- **View rendering** for non-Spring frameworks (Thymeleaf/JSP/JSF) — genuinely no extractor; stays honestly `missing` outside spring-boot.
- Caching / Spring Cloud OpenFeign / Resilience4j capabilities.

De-dupes Java AOP tracker #3004 (CDI interceptor AOP now documented, not re-filed).

## Gates (sandbox HOME=/tmp/agsbx-4917)
`go build ./...` ✅ · `go vet ./internal/custom/java/... ./internal/types/` ✅ · `go test ./internal/extractors/java/... ./internal/custom/java/... ./internal/types/` ✅ · `coverage fmt --check` = canonical ✅ · `coverage validate` = ok (exit 0) ✅

Narrows #4917 (genuine wrongly-missing cells closed; remaining gaps tracked above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)