### PR TITLE
feat(#4918): python coverage — add gRPC base record (extracted-but-undocumented) + python gRPC streaming inference

### DIFF
--- a/internal/engine/grpc_edges.go
+++ b/internal/engine/grpc_edges.go
@@ -60,7 +60,10 @@
 //     the edge records the appropriate streaming kind.
 //   - Java: if the handler parameter is StreamObserver<Req> (not just
 //     StreamObserver<Resp>), it is bidi or client-streaming.
-//   - Python / Node: not currently distinguished (default "unary").
+//   - Python: server methods infer the shape from the request parameter
+//     (`request_iterator` => client-streaming) and a `yield` in the body
+//     (=> server-streaming); both => bidi. See pyGrpcStreaming.
+//   - Node: not currently distinguished (default "unary").
 //
 // gRPC-Gateway: when a Go server method carries `// @grpc-gateway:` or
 // `gateway.RegisterServiceHandlerServer` call, the service is also
@@ -779,12 +782,49 @@ var pyClassDefRe = regexp.MustCompile(
 	`(?m)^class\s+(\w+)\s*\(([^)]*)\)\s*:`)
 
 // pyDefMethodRe captures `def method(self, ...)` in a class body.
-// Group 1: method name.
+// Group 1: method name. Group 2: the first non-self parameter name (the
+// gRPC request parameter), used to infer the streaming shape — a
+// `request_iterator` parameter signals client-streaming.
 var pyDefMethodRe = regexp.MustCompile(
-	`(?m)^\s{4,}def\s+(\w+)\s*\(self`)
+	`(?m)^\s{4,}def\s+(\w+)\s*\(\s*self\s*,\s*(\w+)`)
 
 // pyServicerBaseRe checks that a base class name contains "Servicer".
 var pyServicerBaseRe = regexp.MustCompile(`(\w+)Servicer`)
+
+// pyGrpcStreaming infers the gRPC streaming shape of a python servicer
+// method from its request-parameter name and whether its body yields.
+//
+// Conventions (grpcio-generated servicers):
+//   - client-streaming: the request parameter is named `request_iterator`
+//     (the generated stub passes an iterator, not a single message).
+//   - server-streaming: the handler `yield`s response messages rather than
+//     `return`ing a single one.
+//   - bidi: both of the above.
+//
+// reqParam is the first non-self parameter name; body is the method's
+// source slice (from `def` up to the next sibling `def`/class end).
+func pyGrpcStreaming(reqParam, body string) string {
+	clientStream := reqParam == "request_iterator"
+	serverStream := pyYieldRe.MatchString(body)
+	switch {
+	case clientStream && serverStream:
+		return "bidi_streaming"
+	case clientStream:
+		return "client_streaming"
+	case serverStream:
+		return "server_streaming"
+	default:
+		return "unary"
+	}
+}
+
+// pyYieldRe matches a `yield` statement on its own logical line (server
+// streaming), avoiding substring false positives like `yielded = ...`.
+var pyYieldRe = regexp.MustCompile(`(?m)^\s+yield\b`)
+
+// pyNextDefRe finds the start of the next method/class definition, used to
+// bound a method body when inferring server-streaming.
+var pyNextDefRe = regexp.MustCompile(`(?m)^\s{1,8}(?:async\s+)?(?:def|class)\s`)
 
 func synthesizePythonGRPC(
 	src, path string,
@@ -841,17 +881,25 @@ func synthesizePythonGRPC(
 			bodyEnd = len(src)
 		}
 		body := src[idx[1]:bodyEnd]
-		for _, mm := range pyDefMethodRe.FindAllStringSubmatch(body, -1) {
-			if len(mm) < 2 {
-				continue
-			}
-			methodName := mm[1]
+		for _, mm := range pyDefMethodRe.FindAllStringSubmatchIndex(body, -1) {
+			methodName := body[mm[2]:mm[3]]
 			if methodName == "__init__" || methodName == "__str__" {
 				continue
 			}
-			emitMethod(serviceName, methodName, "grpc_python_server", map[string]string{"streaming": "unary"})
+			reqParam := ""
+			if mm[4] >= 0 {
+				reqParam = body[mm[4]:mm[5]]
+			}
+			// Bound the method body at the next sibling def/class so a
+			// later method's `yield` is not mis-attributed to this one.
+			methodBody := body[mm[1]:]
+			if loc := pyNextDefRe.FindStringIndex(methodBody); loc != nil {
+				methodBody = methodBody[:loc[0]]
+			}
+			streaming := pyGrpcStreaming(reqParam, methodBody)
+			emitMethod(serviceName, methodName, "grpc_python_server", map[string]string{"streaming": streaming})
 			handlerQualified := implClass + "." + methodName
-			emitImplementsEdge(handlerQualified, serviceName, methodName, "unary", "grpc_python_server")
+			emitImplementsEdge(handlerQualified, serviceName, methodName, streaming, "grpc_python_server")
 		}
 	}
 

--- a/internal/engine/grpc_edges_test.go
+++ b/internal/engine/grpc_edges_test.go
@@ -374,6 +374,65 @@ def serve():
 	requireGRPCImplements(t, rels, "UserService", "CreateUser", "python-server")
 }
 
+// TestGRPC_Python_Server_StreamingDetection verifies that the python servicer
+// streaming shape is inferred (issue #4918): a `yield`ing handler is
+// server_streaming, a `request_iterator` parameter is client_streaming, both
+// is bidi_streaming, and a plain (request, context) handler stays unary.
+func TestGRPC_Python_Server_StreamingDetection(t *testing.T) {
+	src := `import grpc
+import chat_pb2
+import chat_pb2_grpc
+
+class ChatServiceServicer(chat_pb2_grpc.ChatServiceServicer):
+    def GetMessage(self, request, context):
+        return chat_pb2.Message(text="hi")
+
+    def StreamMessages(self, request, context):
+        for m in store:
+            yield chat_pb2.Message(text=m)
+
+    def Upload(self, request_iterator, context):
+        for chunk in request_iterator:
+            save(chunk)
+        return chat_pb2.Ack()
+
+    def Chat(self, request_iterator, context):
+        for chunk in request_iterator:
+            yield chat_pb2.Message(text=chunk.text)
+
+def serve():
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    chat_pb2_grpc.add_ChatServiceServicer_to_server(ChatServiceServicer(), server)
+    server.start()
+`
+	_, rels := runGRPCDetect(t, "python", "chat_service.py", src)
+
+	want := map[string]string{
+		"GetMessage":     "unary",
+		"StreamMessages": "server_streaming",
+		"Upload":         "client_streaming",
+		"Chat":           "bidi_streaming",
+	}
+	seen := map[string]string{}
+	for _, r := range rels {
+		if r.Kind != grpcImplementsEdgeKind {
+			continue
+		}
+		for method := range want {
+			if strings.Contains(r.ToID, "/"+method) || strings.HasSuffix(r.ToID, method) {
+				seen[method] = r.Properties["streaming"]
+			}
+		}
+	}
+	for method, exp := range want {
+		if got, ok := seen[method]; !ok {
+			t.Errorf("no GRPC_IMPLEMENTS edge found for method %s", method)
+		} else if got != exp {
+			t.Errorf("method %s: expected streaming=%s, got %q", method, exp, got)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Python — client side
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Coverage-audit **#4918 (python)**. Deploy-deferred. Follows the merged sibling pattern (erlang → java #4917).

**The ticket's HIGH premise is mostly STALE at the extractor level.** Audit of the actual code shows gRPC/Kafka/AMQP all DO handle python: `synthesizePythonGRPC` (grpc_edges.go), `pyProduceRe`/`pySendRe`/`pyConsumerCtorRe` (kafka_edges.go), pika `basic_publish`/`basic_consume` (rabbitmq_edges.go) — all fixture-proven. What was genuinely missing is the **python gRPC registry record** (Kafka/AMQP live as `multi` broker records, not per-language).

## Documented — new base record `lang.python.framework.grpc`
Added via `add` + `backfill` (full lane seeded) + `update` (gRPC-accurate cells), all cite-backed + fixture-verified:
- **transport_binding / procedure_extraction / client_codegen** → `partial` — cite `grpc_edges.go` + `grpc_edges_test.go`. Server `add_XServicer_to_server` + Servicer-base classes → `SCOPE.GrpcService` + `GrpcMethod` + `GRPC_IMPLEMENTS`; stub clients (module-qualified / direct-import / bare) → `GRPC_HANDLES`. Fixtures: `TestGRPC_Python_Server_AddServicer`, `_Client_Stub`/`_DirectImportStub`/`_ModuleQualifiedStub`.
- **import_resolution_quality** → `partial` — framework-blind python resolver (`internal/substrate/python.go` + `constant_propagation.go`), parity with the other python framework records.
- HTTP/GraphQL/View cells → `not_applicable` with cited rationale (mirrors `lang.java.framework.grpc`); substrate/type-system left honestly `missing`.

## Implemented — python gRPC streaming-shape inference (#4918 gap)
Previously hardcoded `"unary"`. `pyGrpcStreaming` in `grpc_edges.go` now infers `server_streaming` (yielding body), `client_streaming` (`request_iterator` param), `bidi_streaming` (both), else `unary` — canonical vocab shared with the Go/Java sides. `pyDefMethodRe` captures the request param; method bodies bounded at the next sibling def/class so a later `yield` isn't mis-attributed. Fixture-proven: `TestGRPC_Python_Server_StreamingDetection` (all 4 shapes).

## Deferred (precise follow-ups — too big for one PR)
- **Kafka/AMQP python attribution as per-language framework records** (faust `@app.agent`, kombu, aio-pika) — extractors partially exist; needs its own record-modelling PR.
- **Substrate deepening across all python frameworks** (taint/effect/reachability/dead-code) — framework-blind, the dedicated epic the ticket calls for.
- **Prefect/Dagster/Luigi, Huey/arq/taskiq, LangGraph/LlamaIndex, Connexion/Django-Ninja** — genuinely missing, out of scope.

## Verified stale (no change needed)
langchain `tool_use_detection` already cites `lcToolConsRe` (`Tool()` ctor) + `@tool`/`BaseTool`/`StructuredTool`; dependency-injector DI `BINDS` edges already in `di_graph.go`.

## Gates (sandbox HOME=/tmp/agsbx-4918)
`go build ./...` ✅ · `go vet` ✅ · `go test` engine + extractors/python + custom/python + types + tools/coverage ✅ · `coverage fmt --check` = canonical ✅ · `coverage validate` = ok exit 0 (pre-existing soft warnings only) ✅

Closes #4918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)