### PR TITLE
feat(#4919): ruby coverage — document extracted capabilities + new extraction

### DIFF
--- a/internal/custom/ruby/activejob_test.go
+++ b/internal/custom/ruby/activejob_test.go
@@ -1,0 +1,122 @@
+package ruby_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/ruby"
+)
+
+// findEntity locates a record by kind+name so ActiveJob queue/job_class
+// attribution can be asserted on Properties (extractFull lives in
+// observability_test.go).
+func findEntity(ents []types.EntityRecord, kind, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestActiveJobClassAndQueue: a `class SendWelcomeEmailJob < ApplicationJob`
+// with `queue_as :mailers` yields a SCOPE.Service consumer carrying the queue
+// attribution and job base, plus the perform handler tagged with the queue.
+func TestActiveJobClassAndQueue(t *testing.T) {
+	src := `class SendWelcomeEmailJob < ApplicationJob
+  queue_as :mailers
+
+  def perform(user_id)
+    user = User.find(user_id)
+    UserMailer.welcome(user).deliver_now
+  end
+end`
+	ents := extractFull(t, "custom_ruby_rails", fi("app/jobs/send_welcome_email_job.rb", "ruby", src))
+
+	svc := findEntity(ents, "SCOPE.Service", "SendWelcomeEmailJob")
+	if svc == nil {
+		t.Fatal("expected SCOPE.Service SendWelcomeEmailJob (ActiveJob consumer)")
+	}
+	if got := svc.Properties["framework"]; got != "activejob" {
+		t.Errorf("framework = %q, want activejob", got)
+	}
+	if got := svc.Properties["queue"]; got != "mailers" {
+		t.Errorf("queue = %q, want mailers", got)
+	}
+	if got := svc.Properties["job_base"]; got != "ApplicationJob" {
+		t.Errorf("job_base = %q, want ApplicationJob", got)
+	}
+
+	perform := findEntity(ents, "SCOPE.Operation", "perform")
+	if perform == nil {
+		t.Fatal("expected perform SCOPE.Operation (consumer handler)")
+	}
+	if got := perform.Properties["queue"]; got != "mailers" {
+		t.Errorf("perform queue = %q, want mailers", got)
+	}
+}
+
+// TestActiveJobBaseClass: ActiveJob::Base (non-Rails-generated base) is also a
+// recognised job class.
+func TestActiveJobBaseClass(t *testing.T) {
+	src := `class ReportJob < ActiveJob::Base
+  queue_as "reports"
+  def perform; end
+end`
+	ents := extractFull(t, "custom_ruby_rails", fi("app/jobs/report_job.rb", "ruby", src))
+	svc := findEntity(ents, "SCOPE.Service", "ReportJob")
+	if svc == nil {
+		t.Fatal("expected SCOPE.Service ReportJob")
+	}
+	if got := svc.Properties["job_base"]; got != "ActiveJob::Base" {
+		t.Errorf("job_base = %q, want ActiveJob::Base", got)
+	}
+	if got := svc.Properties["queue"]; got != "reports" {
+		t.Errorf("queue = %q, want reports", got)
+	}
+}
+
+// TestActiveJobProducerDispatch: `FooJob.perform_later(...)` and the
+// `.set(...).perform_later` deferred form are the producer side that was
+// previously missing entirely. Constant receiver => job_class attribution.
+func TestActiveJobProducerDispatch(t *testing.T) {
+	src := `class UsersController < ApplicationController
+  def create
+    user = User.create!(params)
+    SendWelcomeEmailJob.perform_later(user.id)
+    AuditJob.set(wait: 5.minutes).perform_later(user.id)
+    ReportJob.perform_now
+  end
+end`
+	ents := extractFull(t, "custom_ruby_rails", fi("app/controllers/users_controller.rb", "ruby", src))
+
+	later := findEntity(ents, "SCOPE.Operation", "SendWelcomeEmailJob.perform_later")
+	if later == nil {
+		t.Fatal("expected SendWelcomeEmailJob.perform_later producer")
+	}
+	if got := later.Properties["job_class"]; got != "SendWelcomeEmailJob" {
+		t.Errorf("job_class = %q, want SendWelcomeEmailJob", got)
+	}
+	if got := later.Properties["provenance"]; got != "INFERRED_FROM_ACTIVEJOB_DISPATCH" {
+		t.Errorf("provenance = %q, want INFERRED_FROM_ACTIVEJOB_DISPATCH", got)
+	}
+
+	if findEntity(ents, "SCOPE.Operation", "AuditJob.perform_later") == nil {
+		t.Error("expected AuditJob.perform_later (deferred .set(...) form)")
+	}
+	if findEntity(ents, "SCOPE.Operation", "ReportJob.perform_now") == nil {
+		t.Error("expected ReportJob.perform_now producer")
+	}
+}
+
+// TestActiveJobIgnoresLowercaseReceiver: a lowercase receiver is NOT an
+// ActiveJob dispatch (it is a Sidekiq worker instance or local var); the
+// activejob producer pass must not claim it.
+func TestActiveJobIgnoresLowercaseReceiver(t *testing.T) {
+	src := `worker.perform_later(1)`
+	ents := extractFull(t, "custom_ruby_rails", fi("x.rb", "ruby", src))
+	if findEntity(ents, "SCOPE.Operation", "worker.perform_later") != nil {
+		t.Error("lowercase receiver must not be an ActiveJob dispatch")
+	}
+}

--- a/internal/custom/ruby/rails.go
+++ b/internal/custom/ruby/rails.go
@@ -50,6 +50,24 @@ var (
 	reRailsActiveJobPerform = regexp.MustCompile(
 		`(?m)^\s*def\s+(perform)\s*\(`,
 	)
+	// ActiveJob job class declaration: `class FooJob < ApplicationJob` or
+	// `class FooJob < ActiveJob::Base`. ApplicationJob is the Rails-generated
+	// base; ActiveJob::Base is the framework primitive.
+	reRailsJobClass = regexp.MustCompile(
+		`(?m)^\s*class\s+([A-Z][A-Za-z0-9_:]*)\s*<\s*(ApplicationJob|ActiveJob::Base)\b`,
+	)
+	// `queue_as :mailers` / `queue_as "mailers"` queue attribution inside a job.
+	reRailsQueueAs = regexp.MustCompile(
+		`(?m)^\s*queue_as\s+(?::([a-z_][a-z0-9_]*)|['"]([^'"]+)['"])`,
+	)
+	// ActiveJob producer dispatch: `FooJob.perform_later(args)` /
+	// `FooJob.perform_now(args)` / `FooJob.set(...).perform_later`. The leading
+	// receiver is a CONSTANT (job class), distinguishing it from Sidekiq's
+	// `worker.perform_async` (lowercase receiver, handled by the sidekiq
+	// extractor).
+	reRailsJobDispatch = regexp.MustCompile(
+		`(?m)\b([A-Z][A-Za-z0-9_:]*)(?:\.set\([^)]*\))?\.(perform_later|perform_now)\b`,
+	)
 	reRailsMailerMethod = regexp.MustCompile(
 		`(?m)^\s*def\s+([a-z_]+)\s*(?:\()?`,
 	)
@@ -200,10 +218,52 @@ func (e *railsExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		add(ent)
 	}
 
-	// 9. ActiveJob perform -> SCOPE.Operation/function
+	// 9a. ActiveJob job class declaration -> SCOPE.Service (the queue consumer).
+	//     Capture an optional `queue_as` for queue attribution so the graph can
+	//     answer "which jobs run on the :mailers queue?".
+	jobClassMatches := reRailsJobClass.FindAllStringSubmatchIndex(src, -1)
+	queueAs := ""
+	if qm := reRailsQueueAs.FindStringSubmatch(src); qm != nil {
+		if qm[1] != "" {
+			queueAs = qm[1]
+		} else {
+			queueAs = qm[2]
+		}
+	}
+	for _, m := range jobClassMatches {
+		name := src[m[2]:m[3]]
+		base := src[m[4]:m[5]]
+		ent := makeEntity(name, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "activejob", "provenance", "INFERRED_FROM_ACTIVEJOB_CLASS",
+			"job_base", base)
+		if queueAs != "" {
+			setProps(&ent, "queue", queueAs)
+		}
+		add(ent)
+	}
+
+	// 9b. ActiveJob perform -> SCOPE.Operation/function (the consumer handler).
 	for _, m := range reRailsActiveJobPerform.FindAllStringSubmatchIndex(src, -1) {
 		ent := makeEntity("perform", "SCOPE.Operation", "function", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "rails", "provenance", "INFERRED_FROM_RAILS_JOB_PERFORM")
+		if queueAs != "" && len(jobClassMatches) > 0 {
+			setProps(&ent, "queue", queueAs)
+		}
+		add(ent)
+	}
+
+	// 9c. ActiveJob producer dispatch -> SCOPE.Operation/function. A
+	//     `FooJob.perform_later(args)` enqueue is the producer side that was
+	//     previously entirely missing (only Sidekiq's lowercase-receiver
+	//     `perform_async` was modelled). The constant receiver names the target
+	//     job class so producer and consumer converge by name.
+	for _, m := range reRailsJobDispatch.FindAllStringSubmatchIndex(src, -1) {
+		jobClass := src[m[2]:m[3]]
+		dispatchMethod := src[m[4]:m[5]]
+		name := jobClass + "." + dispatchMethod
+		ent := makeEntity(name, "SCOPE.Operation", "function", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "activejob", "provenance", "INFERRED_FROM_ACTIVEJOB_DISPATCH",
+			"job_class", jobClass, "dispatch_method", dispatchMethod)
 		add(ent)
 	}
 


### PR DESCRIPTION
Coverage-audit **#4919 (ruby)**. Deploy-deferred. Follows the merged sibling pattern (erlang → python #4918). De-dups #3342/#4398 (TESTS-edge) and #3700 (Sidekiq topology) — those remain open; this PR is ActiveJob + docs.

## Audited, not flipped blindly
The top HIGH "MISSING-FRAMEWORK" item (ActiveJob) was REAL at the extractor level: `rails.go` modelled only a generic `def perform` SCOPE.Operation; the producer side and queue/job-class identity were entirely missing, and there was no `message_broker` record.

## Implemented (fixture-proven) — `internal/custom/ruby/rails.go`
- **Consumer**: `class XJob < ApplicationJob` / `< ActiveJob::Base` → SCOPE.Service (`reRailsJobClass`, `INFERRED_FROM_ACTIVEJOB_CLASS`, `job_base` prop); `def perform` handler now also carries the queue.
- **Producer (was MISSING)**: CONSTANT-receiver `FooJob.perform_later(...)` / `perform_now`, incl. the deferred `FooJob.set(...).perform_later` form → SCOPE.Operation `<JobClass>.<method>` (`reRailsJobDispatch`, `INFERRED_FROM_ACTIVEJOB_DISPATCH`, `job_class`+`dispatch_method`) so producer/consumer converge by job-class name. Lowercase receivers excluded (left to the sidekiq extractor — no double-claim).
- **Queue attribution**: `queue_as :name`/`"name"` (`reRailsQueueAs`) → `queue` prop on the job SCOPE.Service + perform handler.
- 4 value-asserting tests (`internal/custom/ruby/activejob_test.go`).

## Documented (cited)
- **NEW record `msg.broker.activejob`** (message_broker / task_queues / ruby) — `consumer_extraction` / `producer_extraction` / `topic_attribution` all `partial`, cited to `rails.go` + tests, `verified_at 2026-06-12`.
- **`test.minitest.target_extraction`** re-cited + noted: the Minitest/Test::Unit/ActiveSupport::TestCase suite collapse + TESTS→subject edge (`emitRubyMinitestSuite` in `internal/extractors/ruby/tests.go`) is more than a build_system dependency — now cited to the real extractor + `tests_subject_4398_test.go`.

## Deferred (follow-ups, per ticket)
Karafka/ruby-kafka; outbound HTTP clients (Faraday/HTTParty/Net::HTTP, builds on #3736); ActionMailer dead no-op; Bunny/amqp; GoodJob/DelayedJob/Shoryuken/Que records; graphql-ruby Type-System; auth/observability gem enumeration; ORM Migrations+Transactions.

## Gates (sandbox `HOME=/tmp/agsbx-4919`)
`go build ./...`, `go vet`, `go test` (extractors/ruby + custom/ruby + types + tools/coverage) all pass; `coverage fmt --check` canonical; `coverage validate` exits 0 (warnings only). Deploy-deferred (daemon not rebuilt).

Closes #4919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)