### PR TITLE
feat(#4920): php coverage — document extracted capabilities + new extraction

### DIFF
--- a/internal/custom/php/laravel.go
+++ b/internal/custom/php/laravel.go
@@ -41,6 +41,22 @@ var (
 	reLaravelJobHandle = regexp.MustCompile(
 		`(?m)public\s+function\s+(handle)\s*\(`,
 	)
+	// reLaravelQueueProp matches a `public $queue = 'name';` / `protected $queue = "name";`
+	// property on a queued Job class (Laravel queue attribution). #4920.
+	reLaravelQueueProp = regexp.MustCompile(
+		`(?m)(?:public|protected|private)\s+\$queue\s*=\s*['"]([^'"]+)['"]`,
+	)
+	// reLaravelJobDispatchStatic matches a CONSTANT-receiver static dispatch
+	// `FooJob::dispatch(...)` / `::dispatchSync(...)` / `::dispatchAfterResponse(...)`
+	// (the dominant Laravel producer idiom). #4920.
+	reLaravelJobDispatchStatic = regexp.MustCompile(
+		`(?m)\b([A-Z]\w*)::(dispatch|dispatchSync|dispatchNow|dispatchAfterResponse|dispatchIf|dispatchUnless)\s*\(`,
+	)
+	// reLaravelJobDispatchHelper matches the `dispatch(new FooJob(...))` global-helper
+	// and `Bus::dispatch(new FooJob(...))` facade producer forms. #4920.
+	reLaravelJobDispatchHelper = regexp.MustCompile(
+		`(?m)(?:\bdispatch|\bBus::dispatch(?:Sync|Now)?)\s*\(\s*new\s+([A-Z]\w*)`,
+	)
 	reLaravelObserver = regexp.MustCompile(
 		`(?m)public\s+function\s+(creating|created|updating|updated|deleting|deleted|saving|saved|restoring|restored)\s*\(`,
 	)
@@ -149,19 +165,57 @@ func (e *laravelExtractor) Extract(ctx context.Context, file extractor.FileInput
 		add(ent)
 	}
 
-	// 5. Job classes -> SCOPE.Service
+	// 5. Job classes (queue consumer) -> SCOPE.Service
+	// A queued job is `class FooJob ... implements ShouldQueue`. Attribute its
+	// queue from a `public $queue = '...'` property (file-scoped; honest-partial:
+	// a single $queue per file is attributed to every job class in that file —
+	// the dominant one-class-per-file Laravel convention). #4920.
+	queueName := ""
+	if qm := reLaravelQueueProp.FindStringSubmatch(src); qm != nil {
+		queueName = qm[1]
+	}
 	for _, m := range reLaravelJobClass.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "laravel", "provenance", "INFERRED_FROM_LARAVEL_JOB")
+		setProps(&ent, "framework", "laravel", "provenance", "INFERRED_FROM_LARAVEL_JOB",
+			"job_class", name)
+		if queueName != "" {
+			setProps(&ent, "queue", queueName)
+		}
 		add(ent)
 	}
 
-	// 6. Job handle() -> SCOPE.Operation/function
+	// 6. Job handle() -> SCOPE.Operation/function (consumer entrypoint)
 	for _, m := range reLaravelJobHandle.FindAllStringSubmatchIndex(src, -1) {
 		ent := makeEntity("handle", "SCOPE.Operation", "function", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "laravel", "provenance", "INFERRED_FROM_LARAVEL_JOB")
+		if queueName != "" {
+			setProps(&ent, "queue", queueName)
+		}
 		add(ent)
+	}
+
+	// 6b. Job dispatch (queue PRODUCER, previously MISSING) -> SCOPE.Operation.
+	// `FooJob::dispatch(...)` (incl. dispatchSync/dispatchNow/dispatchAfterResponse/
+	// dispatchIf/dispatchUnless), `dispatch(new FooJob(...))`, and
+	// `Bus::dispatch(new FooJob(...))`. Emits `<JobClass>.dispatch` so the producer
+	// converges with the consumer SCOPE.Service by job-class name, letting the graph
+	// answer "who enqueues SendInvoice?". #4920.
+	emitJobDispatch := func(jobClass, method string, off int) {
+		// `Bus`/`Job` are facades/base names, never a concrete job target.
+		if jobClass == "Bus" {
+			return
+		}
+		ent := makeEntity(jobClass+".dispatch", "SCOPE.Operation", "function", file.Path, file.Language, lineOf(src, off))
+		setProps(&ent, "framework", "laravel", "provenance", "INFERRED_FROM_LARAVEL_JOB_DISPATCH",
+			"job_class", jobClass, "dispatch_method", method)
+		add(ent)
+	}
+	for _, m := range reLaravelJobDispatchStatic.FindAllStringSubmatchIndex(src, -1) {
+		emitJobDispatch(src[m[2]:m[3]], src[m[4]:m[5]], m[0])
+	}
+	for _, m := range reLaravelJobDispatchHelper.FindAllStringSubmatchIndex(src, -1) {
+		emitJobDispatch(src[m[2]:m[3]], "dispatch", m[0])
 	}
 
 	// 7. Observer hooks -> SCOPE.Pattern

--- a/internal/custom/php/laravel_queue_test.go
+++ b/internal/custom/php/laravel_queue_test.go
@@ -1,0 +1,148 @@
+package php_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/php"
+)
+
+// extractFull returns the full EntityRecords (with properties) for prop-asserting
+// tests of the Laravel queue producer/consumer extraction (#4920).
+func extractFull(t *testing.T, name string, file extreg.FileInput) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("extractor %q not registered", name)
+	}
+	ents, err := e.Extract(context.Background(), file)
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+func findEntity(ents []types.EntityRecord, kind, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == kind && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestLaravelQueueConsumerAttribution: a queued Job class carries job_class +
+// the file-scoped $queue attribution on both the SCOPE.Service and its handle().
+func TestLaravelQueueConsumerAttribution(t *testing.T) {
+	src := `<?php
+class SendInvoice implements ShouldQueue
+{
+    public $queue = 'invoices';
+
+    public function handle()
+    {
+        // ...
+    }
+}
+`
+	ents := extractFull(t, "custom_php_laravel", fi("SendInvoice.php", "php", src))
+
+	job := findEntity(ents, "SCOPE.Service", "SendInvoice")
+	if job == nil {
+		t.Fatal("expected SCOPE.Service SendInvoice job class")
+	}
+	if job.Properties["job_class"] != "SendInvoice" {
+		t.Errorf("job_class = %q, want SendInvoice", job.Properties["job_class"])
+	}
+	if job.Properties["queue"] != "invoices" {
+		t.Errorf("queue = %q, want invoices", job.Properties["queue"])
+	}
+
+	handle := findEntity(ents, "SCOPE.Operation", "handle")
+	if handle == nil {
+		t.Fatal("expected SCOPE.Operation handle")
+	}
+	if handle.Properties["queue"] != "invoices" {
+		t.Errorf("handle queue = %q, want invoices", handle.Properties["queue"])
+	}
+}
+
+// TestLaravelQueueProducerStatic: the static-dispatch producer idiom converges
+// with the consumer by job-class name.
+func TestLaravelQueueProducerStatic(t *testing.T) {
+	src := `<?php
+class OrderController
+{
+    public function store()
+    {
+        SendInvoice::dispatch($order);
+        ProcessPayment::dispatchSync($payment);
+    }
+}
+`
+	ents := extractFull(t, "custom_php_laravel", fi("OrderController.php", "php", src))
+
+	d1 := findEntity(ents, "SCOPE.Operation", "SendInvoice.dispatch")
+	if d1 == nil {
+		t.Fatal("expected SendInvoice.dispatch producer op")
+	}
+	if d1.Properties["job_class"] != "SendInvoice" || d1.Properties["dispatch_method"] != "dispatch" {
+		t.Errorf("got job_class=%q dispatch_method=%q", d1.Properties["job_class"], d1.Properties["dispatch_method"])
+	}
+	if d1.Properties["provenance"] != "INFERRED_FROM_LARAVEL_JOB_DISPATCH" {
+		t.Errorf("provenance = %q", d1.Properties["provenance"])
+	}
+
+	d2 := findEntity(ents, "SCOPE.Operation", "ProcessPayment.dispatch")
+	if d2 == nil {
+		t.Fatal("expected ProcessPayment.dispatch producer op")
+	}
+	if d2.Properties["dispatch_method"] != "dispatchSync" {
+		t.Errorf("dispatch_method = %q, want dispatchSync", d2.Properties["dispatch_method"])
+	}
+}
+
+// TestLaravelQueueProducerHelper: the dispatch(new Job) helper and Bus::dispatch
+// facade forms both resolve to the job class (and Bus is never a target).
+func TestLaravelQueueProducerHelper(t *testing.T) {
+	src := `<?php
+dispatch(new SendInvoice($order));
+Bus::dispatch(new ProcessPayment($payment));
+`
+	ents := extractFull(t, "custom_php_laravel", fi("helper.php", "php", src))
+
+	if findEntity(ents, "SCOPE.Operation", "SendInvoice.dispatch") == nil {
+		t.Error("expected SendInvoice.dispatch from dispatch(new ...) helper")
+	}
+	if findEntity(ents, "SCOPE.Operation", "ProcessPayment.dispatch") == nil {
+		t.Error("expected ProcessPayment.dispatch from Bus::dispatch(new ...)")
+	}
+	if findEntity(ents, "SCOPE.Operation", "Bus.dispatch") != nil {
+		t.Error("Bus facade must not be emitted as a dispatch target")
+	}
+}
+
+// TestLaravelQueueProducerConverges: producer dispatch and consumer service share
+// the job-class identity (the value of the extraction).
+func TestLaravelQueueProducerConverges(t *testing.T) {
+	src := `<?php
+class SendInvoice implements ShouldQueue {
+    public function handle() {}
+}
+SendInvoice::dispatch($order);
+`
+	ents := extractFull(t, "custom_php_laravel", fi("mixed.php", "php", src))
+
+	svc := findEntity(ents, "SCOPE.Service", "SendInvoice")
+	prod := findEntity(ents, "SCOPE.Operation", "SendInvoice.dispatch")
+	if svc == nil || prod == nil {
+		t.Fatalf("expected both consumer service and producer op, got svc=%v prod=%v", svc != nil, prod != nil)
+	}
+	if svc.Properties["job_class"] != prod.Properties["job_class"] {
+		t.Errorf("producer/consumer job_class mismatch: %q vs %q",
+			prod.Properties["job_class"], svc.Properties["job_class"])
+	}
+}


### PR DESCRIPTION
Coverage-audit **#4920 (php)**. Deploy-deferred. Follows merged sibling pattern (erlang → python #4918 → ruby #4919).

## Audited, not flipped blindly
Two HIGH ticket items were already covered at the extractor level — documented, not re-claimed:
- **i18n** (`translation_key.go`) is ALREADY cited under the multi-lang record `analysis.localization.i18n-keys/translation_key_usage`. Only real gap: the note omitted PHP's `trans_choice()` pluralization helper → **corrected in place** (cite + Symfony/gettext flagged as a future lane).
- **Redis pub/sub + streams** (`redis.go` PUBLISHES_TO/SUBSCRIBES_TO/WRITES_TO/READS_FROM) is ALREADY documented under `lang.php.driver.redis` Queries.query_attribution. A duplicate `message_topic` cell re-citing the same code would be doc-thrash → left as is.

## Implemented (fixture-proven) — Laravel Queue
The top HIGH MISSING item was real: `laravel.go` modelled only the **consumer** (ShouldQueue Job class + `handle()`) with no queue attribution and **no producer**, and there was no PHP `message_broker` record.
- **Producer (was MISSING):** `FooJob::dispatch(...)` (+ dispatchSync/Now/AfterResponse/If/Unless), `dispatch(new FooJob(...))`, `Bus::dispatch(new FooJob(...))` → SCOPE.Operation `<JobClass>.dispatch` (`INFERRED_FROM_LARAVEL_JOB_DISPATCH`, job_class + dispatch_method) so producer/consumer converge by job-class name. Bus facade never emitted as a target.
- **Consumer:** ShouldQueue Job class now carries `job_class`.
- **Queue attribution:** `public/protected $queue = "name"` → `queue` prop on the job Service + `handle()`.
- 4 value-asserting tests in `internal/custom/php/laravel_queue_test.go`.

## Documented
- **NEW record `msg.broker.laravel-queue`** (message_broker / task_queues / php) — consumer/producer/topic_attribution all `partial`, cited to `laravel.go` + tests, verified_at 2026-06-12. Parity with ruby `msg.broker.activejob`.
- i18n `translation_key_usage` note updated for `trans_choice`.

## Deferred (follow-ups in ticket)
Symfony Messenger producer/message-class link (consumer `#[AsMessageHandler]` already extracted); Laravel Horizon config; queued mailables/notifications + per-call `->onQueue()`; Symfony `trans()`/gettext i18n lane; non-flagship HTTP framework deepening (Yii/CakePHP/Drupal/WordPress); Livewire/Inertia; Twig RENDERS.

## Gates (sandbox HOME=/tmp/agsbx-4920)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/php/... ./internal/custom/php/... ./internal/types/ ./tools/coverage/...` all pass. `coverage fmt --check` canonical; `coverage validate` exits 0 (pre-existing warnings only). Deploy-deferred (daemon not rebuilt).

Closes #4920.

🤖 Generated with [Claude Code](https://claude.com/claude-code)