### PR TITLE
feat(#4921): rust coverage — document extracted capabilities + new extraction

### DIFF
--- a/internal/custom/rust/actix_web.go
+++ b/internal/custom/rust/actix_web.go
@@ -156,10 +156,23 @@ func (e *actixWebExtractor) Extract(ctx context.Context, file extractor.FileInpu
 		add(ent)
 	}
 
-	// 5. web::Json<T>/Path<T>/Query<T>/Form<T>/Data<T> extractors -> SCOPE.Schema
+	// 5. web::Json<T>/Path<T>/Query<T>/Form<T> request-shape extractors -> SCOPE.Schema.
+	//    web::Data<T> is special-cased: it is actix's application-data DI
+	//    container (registered via App::app_data(web::Data::new(T))) injected
+	//    into the handler, so it is emitted as a di_injection_point pattern
+	//    (mechanism=data) rather than a request-shape schema.
 	for _, m := range reActixExtractor.FindAllStringSubmatchIndex(src, -1) {
 		extKind := src[m[2]:m[3]]
 		typeParam := src[m[4]:m[5]]
+		if extKind == "Data" {
+			ent := makeEntity("data:"+typeParam, "SCOPE.Pattern", "di_injection_point", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "actix_web", "di_framework", "actix_web",
+				"provenance", "INFERRED_FROM_ACTIX_DATA",
+				"extractor_kind", extKind, "type_param", typeParam,
+				"injected_type", typeParam, "mechanism", "data")
+			add(ent)
+			continue
+		}
 		name := extKind + "<" + typeParam + ">"
 		ent := makeEntity(name, "SCOPE.Schema", "", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "actix_web", "provenance", "INFERRED_FROM_ACTIX_EXTRACTOR",

--- a/internal/custom/rust/axum.go
+++ b/internal/custom/rust/axum.go
@@ -175,21 +175,30 @@ func (e *axumExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 		add(ent)
 	}
 
-	// 4. State<T> -> SCOPE.Pattern
+	// 4. State<T> -> SCOPE.Pattern(di_injection_point)
+	// axum State<T> is a DI extractor: the shared application state T is
+	// injected into the handler from the Router's .with_state(T). Stamp it as a
+	// di_injection_point so DI tooling surfaces it (mechanism=state), keeping
+	// the legacy state_type prop for back-compat.
 	for _, m := range reAxumState.FindAllStringSubmatchIndex(src, -1) {
 		stateType := src[m[2]:m[3]]
-		ent := makeEntity("state:"+stateType, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "axum", "provenance", "INFERRED_FROM_AXUM_STATE",
-			"state_type", stateType)
+		ent := makeEntity("state:"+stateType, "SCOPE.Pattern", "di_injection_point", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "axum", "di_framework", "axum",
+			"provenance", "INFERRED_FROM_AXUM_STATE",
+			"state_type", stateType, "injected_type", stateType, "mechanism", "state")
 		add(ent)
 	}
 
-	// 5. Extension<T> -> SCOPE.Pattern
+	// 5. Extension<T> -> SCOPE.Pattern(di_injection_point)
+	// axum Extension<T> injects a request-scoped value placed by an
+	// Extension/AddExtensionLayer middleware into the handler — a DI injection
+	// point (mechanism=extension), legacy extension_type prop retained.
 	for _, m := range reAxumExtension.FindAllStringSubmatchIndex(src, -1) {
 		extType := src[m[2]:m[3]]
-		ent := makeEntity("extension:"+extType, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent, "framework", "axum", "provenance", "INFERRED_FROM_AXUM_EXTENSION",
-			"extension_type", extType)
+		ent := makeEntity("extension:"+extType, "SCOPE.Pattern", "di_injection_point", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "axum", "di_framework", "axum",
+			"provenance", "INFERRED_FROM_AXUM_EXTENSION",
+			"extension_type", extType, "injected_type", extType, "mechanism", "extension")
 		add(ent)
 	}
 

--- a/internal/custom/rust/extractors_test.go
+++ b/internal/custom/rust/extractors_test.go
@@ -313,3 +313,69 @@ rocket::build().mount("/api", routes![get_user, create_user]);
 		t.Error("expected POST /api/users (data= kwarg tolerated, mount composed)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DI injection points (#4921): axum State<T>/Extension<T>, actix web::Data<T>
+// ---------------------------------------------------------------------------
+
+// axum State<T> and Extension<T> handler args are DI injection points.
+func TestAxumStateExtensionDIInjection(t *testing.T) {
+	src := `
+async fn handler(
+    State(pool): State<AppState>,
+    Extension(user): Extension<CurrentUser>,
+) -> String { String::new() }
+`
+	ents := extract(t, "custom_rust_axum", fi("h.rs", "rust", src))
+
+	st, ok := findEntity(ents, "SCOPE.Pattern", "state:AppState")
+	if !ok {
+		t.Fatal("expected state:AppState injection-point entity")
+	}
+	if st.Subtype != "di_injection_point" {
+		t.Errorf("State subtype = %q, want di_injection_point", st.Subtype)
+	}
+	if st.Props["injected_type"] != "AppState" || st.Props["mechanism"] != "state" || st.Props["di_framework"] != "axum" {
+		t.Errorf("State props = %v", st.Props)
+	}
+
+	ex, ok := findEntity(ents, "SCOPE.Pattern", "extension:CurrentUser")
+	if !ok {
+		t.Fatal("expected extension:CurrentUser injection-point entity")
+	}
+	if ex.Subtype != "di_injection_point" {
+		t.Errorf("Extension subtype = %q, want di_injection_point", ex.Subtype)
+	}
+	if ex.Props["injected_type"] != "CurrentUser" || ex.Props["mechanism"] != "extension" {
+		t.Errorf("Extension props = %v", ex.Props)
+	}
+}
+
+// actix web::Data<T> is a DI injection point; web::Json<T> stays a request shape.
+func TestActixDataDIInjection(t *testing.T) {
+	src := `
+async fn handler(db: web::Data<DbPool>, body: web::Json<CreateUser>) -> impl Responder {
+    HttpResponse::Ok()
+}
+`
+	ents := extract(t, "custom_rust_actix_web", fi("h.rs", "rust", src))
+
+	d, ok := findEntity(ents, "SCOPE.Pattern", "data:DbPool")
+	if !ok {
+		t.Fatal("expected data:DbPool injection-point entity")
+	}
+	if d.Subtype != "di_injection_point" {
+		t.Errorf("Data subtype = %q, want di_injection_point", d.Subtype)
+	}
+	if d.Props["injected_type"] != "DbPool" || d.Props["mechanism"] != "data" || d.Props["di_framework"] != "actix_web" {
+		t.Errorf("Data props = %v", d.Props)
+	}
+
+	// Json stays a request-shape schema, NOT a DI injection point.
+	if _, ok := findEntity(ents, "SCOPE.Pattern", "data:CreateUser"); ok {
+		t.Error("web::Json must not be emitted as a DI injection point")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "Json<CreateUser>") {
+		t.Error("expected Json<CreateUser> request-shape schema")
+	}
+}


### PR DESCRIPTION
## #4921 rust coverage audit

### Implemented (new extraction, fixture-proven)
**DI injection points** — the systemic HIGH/WEAK gap (di_injection_point missing 13/13 across rust HTTP frameworks). The extractors already emitted State/Extension/Data as generic Pattern/Schema entities; now stamped as DI:
- **axum** `State<T>` / `Extension<T>` → `SCOPE.Pattern(di_injection_point)`, props `di_framework=axum`, `injected_type`, `mechanism=state|extension` (legacy `state_type`/`extension_type` retained).
- **actix-web** `web::Data<T>` → split out of request-shape extractors → `di_injection_point`, `mechanism=data`; `web::Json/Path/Query/Form` stay request-shape `SCOPE.Schema`.
- Tests: `TestAxumStateExtensionDIInjection`, `TestActixDataDIInjection` (value-assert subtype + injected_type + mechanism; Json-stays-schema negative).

### Documented (cites + verified_at, canonical `coverage update`)
- `di_injection_point`: **missing → full** for axum + actix.
- `route_extraction` (axum + actix): notes now document the **already-produced WebSocket synthesis** (reAxumWebSocket / reActixWebSocket → `SCOPE.Operation/websocket`). No `websocket_route_extraction` key exists in the `http_backend` taxonomy, so documented in-cell — taxonomy follow-up #4965.

### Deferred (follow-ups filed)
- **#4963** — di_binding_extraction + di_scope_resolution (registration sites: `.with_state`/`app_data`).
- **#4964** — MISSING-FRAMEWORK: juniper, connection pools (deadpool/bb8/r2d2/mobc), async-nats, ntex/Loco/Shuttle, test libs.
- **#4965** — WEAK: config_consumption/feature_flag_gating, endpoint_response_codes/pagination, transaction_function_stamping, migrations, Tauri IPC, + ws taxonomy key.

### Gates (sandbox HOME=/tmp/agsbx-4921)
`go build ./...` ✓, `go vet ./internal/...` ✓, `go test ./internal/custom/rust/... ./internal/extractors/rust/... ./internal/types/` ✓, `coverage fmt --check` ✓ (canonical), `coverage validate` ✓ (0 errors; pre-existing warnings only).

Deploy-deferred. Closes #4921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)