### PR TITLE
feat(#4922): csharp coverage — document extracted capabilities + new extraction

### DIFF
--- a/internal/custom/csharp/mediatr.go
+++ b/internal/custom/csharp/mediatr.go
@@ -1,0 +1,236 @@
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_mediatr", &mediatrExtractor{})
+}
+
+// mediatrExtractor detects MediatR in-process CQRS / mediator patterns, the
+// de-facto messaging backbone of modern ASP.NET Core applications.
+//
+// Producers (the dispatch / send side):
+//   - _mediator.Send(new FooQuery(...))            → request → handler
+//   - _mediator.Publish(new BarNotification(...))  → notification → handler(s)
+//
+// Consumers (the handler side):
+//   - class XHandler : IRequestHandler<FooQuery, Result>      (request handler)
+//   - class XHandler : IRequestHandler<FooCommand>            (void-request handler)
+//   - class XHandler : INotificationHandler<BarNotification>  (notification handler)
+//
+// Pipeline:
+//   - class L : IPipelineBehavior<TReq, TResp>     (cross-cutting middleware)
+//
+// Message contracts:
+//   - class/record FooQuery : IRequest<Result>     (request message)
+//   - class/record FooCommand : IRequest           (void request)
+//   - class/record BarNotification : INotification  (notification message)
+//
+// Each request/notification name is normalised to a task_id so the dispatch
+// (PRODUCES) site and the handler (CONSUMES) site converge by message type.
+type mediatrExtractor struct{}
+
+func (e *mediatrExtractor) Language() string { return "custom_csharp_mediatr" }
+
+var (
+	// _mediator.Send(new FooQuery(...))  /  Mediator.Send(new FooQuery())
+	mtSendRe = regexp.MustCompile(
+		`(?m)\b\w+\.Send\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// _mediator.Publish(new BarNotification(...))
+	mtPublishRe = regexp.MustCompile(
+		`(?m)\b\w+\.Publish\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// class XHandler : IRequestHandler<FooQuery, Result>  /  IRequestHandler<FooCommand>
+	mtRequestHandlerRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bIRequestHandler\s*<\s*(\w+)`,
+	)
+	// class XHandler : INotificationHandler<BarNotification>
+	mtNotificationHandlerRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bINotificationHandler\s*<\s*(\w+)`,
+	)
+	// class L : IPipelineBehavior<TRequest, TResponse>
+	mtPipelineRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bIPipelineBehavior\s*<`,
+	)
+	// class/record FooQuery : IRequest<Result>  or  : IRequest
+	mtRequestMsgRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:\([^)]*\))?\s*:\s*[^{};]*\bIRequest\b`,
+	)
+	// class/record BarNotification : INotification
+	mtNotificationMsgRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:\([^)]*\))?\s*:\s*[^{};]*\bINotification\b`,
+	)
+	// Guards so handler declarations are not mis-claimed as message contracts.
+	mtRequestHandlerWordRe      = regexp.MustCompile(`\bIRequestHandler\b`)
+	mtNotificationHandlerWordRe = regexp.MustCompile(`\bINotificationHandler\b`)
+)
+
+func (e *mediatrExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.mediatr_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "mediatr"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name + ":" + ent.Subtype
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// 1. Producer: _mediator.Send(new FooQuery(...)) — request dispatch
+	for _, idx := range mtSendRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		taskID := "mediatr:request:" + msgType
+		ent := makeEntity("Send "+msgType, "SCOPE.Operation", "request_dispatch", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mediatr",
+			"pattern_type", "send",
+			"message_type", msgType,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_MEDIATR_SEND",
+		)
+		add(ent)
+	}
+
+	// 2. Producer: _mediator.Publish(new BarNotification(...)) — notification dispatch
+	for _, idx := range mtPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		taskID := "mediatr:notification:" + msgType
+		ent := makeEntity("Publish "+msgType, "SCOPE.Operation", "notification_dispatch", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mediatr",
+			"pattern_type", "publish",
+			"message_type", msgType,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_MEDIATR_PUBLISH",
+		)
+		add(ent)
+	}
+
+	// 3. Consumer: class XHandler : IRequestHandler<FooQuery, ...>
+	for _, idx := range mtRequestHandlerRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		msgType := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		taskID := "mediatr:request:" + msgType
+		ent := makeEntity(className, "SCOPE.Service", "request_handler", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mediatr",
+			"pattern_type", "request_handler",
+			"message_type", msgType,
+			"task_id", taskID,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_MEDIATR_REQUEST_HANDLER",
+		)
+		add(ent)
+	}
+
+	// 4. Consumer: class XHandler : INotificationHandler<BarNotification>
+	for _, idx := range mtNotificationHandlerRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		msgType := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		taskID := "mediatr:notification:" + msgType
+		ent := makeEntity(className, "SCOPE.Service", "notification_handler", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mediatr",
+			"pattern_type", "notification_handler",
+			"message_type", msgType,
+			"task_id", taskID,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_MEDIATR_NOTIFICATION_HANDLER",
+		)
+		add(ent)
+	}
+
+	// 5. Pipeline behavior: class L : IPipelineBehavior<TReq, TResp>
+	for _, idx := range mtPipelineRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity(className, "SCOPE.Pattern", "pipeline_behavior", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mediatr",
+			"pattern_type", "pipeline_behavior",
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_MEDIATR_PIPELINE_BEHAVIOR",
+		)
+		add(ent)
+	}
+
+	// 6. Message contract: class/record FooQuery : IRequest<Result>
+	for _, idx := range mtRequestMsgRe.FindAllStringSubmatchIndex(src, -1) {
+		msgName := src[idx[2]:idx[3]]
+		// IRequestHandler also matches IRequest substring word boundary? No — \bIRequest\b
+		// does not match "IRequestHandler" (Handler follows without boundary at 't'->'H'
+		// there IS a boundary). Guard: skip handler/pipeline declarations.
+		full := src[idx[0]:idx[1]]
+		if mtRequestHandlerWordRe.MatchString(full) {
+			continue
+		}
+		line := lineOf(src, idx[0])
+		taskID := "mediatr:request:" + msgName
+		ent := makeEntity(msgName, "SCOPE.Schema", "request_message", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mediatr",
+			"pattern_type", "request_message",
+			"message_type", msgName,
+			"task_id", taskID,
+			"provenance", "INFERRED_FROM_MEDIATR_REQUEST_MESSAGE",
+		)
+		add(ent)
+	}
+
+	// 7. Message contract: class/record BarNotification : INotification
+	for _, idx := range mtNotificationMsgRe.FindAllStringSubmatchIndex(src, -1) {
+		msgName := src[idx[2]:idx[3]]
+		full := src[idx[0]:idx[1]]
+		if mtNotificationHandlerWordRe.MatchString(full) {
+			continue
+		}
+		line := lineOf(src, idx[0])
+		taskID := "mediatr:notification:" + msgName
+		ent := makeEntity(msgName, "SCOPE.Schema", "notification_message", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mediatr",
+			"pattern_type", "notification_message",
+			"message_type", msgName,
+			"task_id", taskID,
+			"provenance", "INFERRED_FROM_MEDIATR_NOTIFICATION_MESSAGE",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/csharp/mediatr_test.go
+++ b/internal/custom/csharp/mediatr_test.go
@@ -1,0 +1,167 @@
+package csharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// MediatR in-process CQRS / mediator coverage (#4922). Value-asserting:
+// dispatch (PRODUCES) and handler (CONSUMES) must converge by task_id, and
+// message contracts must be recovered as schemas.
+
+const mediatrSrc = `
+using MediatR;
+
+public record GetUserQuery(int Id) : IRequest<UserDto>;
+
+public class CreateUserCommand : IRequest
+{
+    public string Name { get; set; }
+}
+
+public record UserCreatedNotification(int Id) : INotification;
+
+public class GetUserHandler : IRequestHandler<GetUserQuery, UserDto>
+{
+    public Task<UserDto> Handle(GetUserQuery request, CancellationToken ct) => default;
+}
+
+public class CreateUserHandler : IRequestHandler<CreateUserCommand>
+{
+    public Task Handle(CreateUserCommand request, CancellationToken ct) => Task.CompletedTask;
+}
+
+public class SendWelcomeEmail : INotificationHandler<UserCreatedNotification>
+{
+    public Task Handle(UserCreatedNotification n, CancellationToken ct) => Task.CompletedTask;
+}
+
+public class LoggingBehavior<TReq, TResp> : IPipelineBehavior<TReq, TResp>
+{
+    public Task<TResp> Handle(TReq r, RequestHandlerDelegate<TResp> next, CancellationToken ct) => next();
+}
+
+public class UsersController
+{
+    private readonly IMediator _mediator;
+
+    public async Task<UserDto> Get(int id)
+    {
+        var user = await _mediator.Send(new GetUserQuery(id));
+        await _mediator.Send(new CreateUserCommand { Name = "x" });
+        await _mediator.Publish(new UserCreatedNotification(id));
+        return user;
+    }
+}
+`
+
+func findBy(ents []types.EntityRecord, subtype, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == subtype && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestMediatRSendPublishHandlersConverge(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_mediatr", fi("Users.cs", "csharp", mediatrSrc))
+
+	// --- Producer: Send(new GetUserQuery) ---
+	send := findBy(ents, "request_dispatch", "Send GetUserQuery")
+	if send == nil {
+		t.Fatal("expected request_dispatch 'Send GetUserQuery'")
+	}
+	if send.Properties["edge_kind"] != "PRODUCES" {
+		t.Errorf("Send edge_kind = %q, want PRODUCES", send.Properties["edge_kind"])
+	}
+	if send.Properties["task_id"] != "mediatr:request:GetUserQuery" {
+		t.Errorf("Send task_id = %q, want mediatr:request:GetUserQuery", send.Properties["task_id"])
+	}
+
+	// void-request command dispatch
+	if findBy(ents, "request_dispatch", "Send CreateUserCommand") == nil {
+		t.Error("expected request_dispatch 'Send CreateUserCommand'")
+	}
+
+	// --- Producer: Publish(new UserCreatedNotification) ---
+	pub := findBy(ents, "notification_dispatch", "Publish UserCreatedNotification")
+	if pub == nil {
+		t.Fatal("expected notification_dispatch 'Publish UserCreatedNotification'")
+	}
+	if pub.Properties["task_id"] != "mediatr:notification:UserCreatedNotification" {
+		t.Errorf("Publish task_id = %q", pub.Properties["task_id"])
+	}
+
+	// --- Consumer: request handler converges with Send via task_id ---
+	rh := findBy(ents, "request_handler", "GetUserHandler")
+	if rh == nil {
+		t.Fatal("expected request_handler 'GetUserHandler'")
+	}
+	if rh.Properties["edge_kind"] != "CONSUMES" {
+		t.Errorf("handler edge_kind = %q, want CONSUMES", rh.Properties["edge_kind"])
+	}
+	if rh.Properties["task_id"] != send.Properties["task_id"] {
+		t.Errorf("request handler task_id %q != dispatch task_id %q",
+			rh.Properties["task_id"], send.Properties["task_id"])
+	}
+	if rh.Properties["message_type"] != "GetUserQuery" {
+		t.Errorf("handler message_type = %q, want GetUserQuery", rh.Properties["message_type"])
+	}
+
+	// void-request handler recovered
+	if findBy(ents, "request_handler", "CreateUserHandler") == nil {
+		t.Error("expected request_handler 'CreateUserHandler' (IRequestHandler<CreateUserCommand>)")
+	}
+
+	// --- Consumer: notification handler converges with Publish ---
+	nh := findBy(ents, "notification_handler", "SendWelcomeEmail")
+	if nh == nil {
+		t.Fatal("expected notification_handler 'SendWelcomeEmail'")
+	}
+	if nh.Properties["task_id"] != pub.Properties["task_id"] {
+		t.Errorf("notification handler task_id %q != publish task_id %q",
+			nh.Properties["task_id"], pub.Properties["task_id"])
+	}
+
+	// --- Pipeline behavior ---
+	if findBy(ents, "pipeline_behavior", "LoggingBehavior") == nil {
+		t.Error("expected pipeline_behavior 'LoggingBehavior'")
+	}
+}
+
+func TestMediatRMessageContractsAreSchemas(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_mediatr", fi("Users.cs", "csharp", mediatrSrc))
+
+	q := findBy(ents, "request_message", "GetUserQuery")
+	if q == nil {
+		t.Fatal("expected request_message schema 'GetUserQuery'")
+	}
+	if q.Kind != "SCOPE.Schema" {
+		t.Errorf("request_message kind = %q, want SCOPE.Schema", q.Kind)
+	}
+	if q.Properties["task_id"] != "mediatr:request:GetUserQuery" {
+		t.Errorf("request_message task_id = %q", q.Properties["task_id"])
+	}
+
+	if findBy(ents, "request_message", "CreateUserCommand") == nil {
+		t.Error("expected request_message 'CreateUserCommand' (IRequest void form)")
+	}
+
+	n := findBy(ents, "notification_message", "UserCreatedNotification")
+	if n == nil {
+		t.Fatal("expected notification_message schema 'UserCreatedNotification'")
+	}
+	if n.Kind != "SCOPE.Schema" {
+		t.Errorf("notification_message kind = %q, want SCOPE.Schema", n.Kind)
+	}
+
+	// Negative: a handler class must NOT be mis-claimed as a message contract.
+	if findBy(ents, "request_message", "GetUserHandler") != nil {
+		t.Error("GetUserHandler (IRequestHandler) must not be a request_message")
+	}
+	if findBy(ents, "notification_message", "SendWelcomeEmail") != nil {
+		t.Error("SendWelcomeEmail (INotificationHandler) must not be a notification_message")
+	}
+}


### PR DESCRIPTION
## #4922 csharp coverage-audit (deploy-deferred)

Follows the merged sibling pattern (rust #4921 → php #4920 → ruby #4919). De-dups gRPC tracker #3963 (left open).

### Documented (audited at the extractor — real gaps, fixture-backed code)
- **Quartz.NET** — `quartz_net.go` (custom_csharp_quartz_net) was fully implemented + init-registered + tested but had **no registry record** ('quartz' search was empty). Added `msg.quartz-net`: consumer_extraction + producer_extraction **full** (IJob→job_class; JobBuilder.Create<T>/TriggerBuilder/ScheduleJob→PRODUCES), topic_attribution **partial** (trigger identity recovered; cron/interval strings are the #3628 schedule-string gap).
- **Hangfire** — `msg.hangfire-recurring` only cited `scheduled_jobs_edges.go` + only consumer_extraction. `hangfire.go` ALSO emits BackgroundJob.Enqueue/Schedule + typed enqueues + IJob/[AutomaticRetry] consumers, all unreflected. Broadened: added **producer_extraction (partial)** + `hangfire.go` cite on consumer_extraction.

### Implemented (new extraction, fixture-proven) — MediatR
Top HIGH MISSING-FRAMEWORK item; de-facto .NET in-process CQRS/mediator, previously invisible.
- `internal/custom/csharp/mediatr.go` (custom_csharp_mediatr, prefix-dispatched):
  - **Producer**: `_mediator.Send(new FooQuery())`→SCOPE.Operation(request_dispatch); `_mediator.Publish(new BarNotification())`→notification_dispatch (PRODUCES).
  - **Consumer**: `IRequestHandler<TReq[,TResp]>`→SCOPE.Service(request_handler); `INotificationHandler<T>`→notification_handler (CONSUMES). Converge with dispatch by `task_id mediatr:request:<T>` / `mediatr:notification:<T>`.
  - **Pipeline**: `IPipelineBehavior<TReq,TResp>`→SCOPE.Pattern(pipeline_behavior).
  - **Contracts**: `class/record FooQuery : IRequest[<T>]`→SCOPE.Schema(request_message); `: INotification`→notification_message (handler declarations guarded out).
  - 2 value-asserting tests: task_id convergence, edge_kind, schema kinds, + negative (a handler is never a message contract).
- Registry `msg.mediatr`: consumer/producer/topic_attribution **full** (cites + verified_at).

### Deferred (follow-ups filed)
- **#4967** — MassTransit/Wolverine/Rebus/NServiceBus message-buses + native broker clients (RabbitMQ.Client/Confluent.Kafka/Azure.Messaging). HIGH.
- **#4968** — SignalR Hub / WCF ServiceContract / Moq-NSubstitute-Testcontainers / Refit-RestSharp-Flurl. med.
- **#4969** — Quartz cron/interval schedule parse, Hangfire dynamic args, redis pub/sub-as-broker, AutoMapper/Polly. 

### Gates
`coverage fmt --check` (canonical) + `coverage validate` (exit 0, warnings-only) pass. `go build ./...`, `go vet ./internal/...`, `go test ./internal/custom/csharp/... ./internal/extractors/csharp/... ./internal/types/` all green. Run in isolated sandbox HOME=/tmp/agsbx-4922.

Closes #4922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)