### PR TITLE
feat(#4923): go coverage — document extracted capabilities + new extraction

### DIFF
--- a/internal/engine/scheduled_jobs_edges.go
+++ b/internal/engine/scheduled_jobs_edges.go
@@ -137,6 +137,16 @@ func applyScheduledJobEdges(args DetectorPassArgs) DetectorPassResult {
 		synthesizeQuarkusScheduled(src, path, lang, emitJob)
 	case "go":
 		synthesizeGoCron(src, path, emitJob)
+		// #4923: asynq (hibiken/asynq) — the de-facto Redis-backed Go task
+		// queue. A `mux.HandleFunc("task:type", handler)` registration on an
+		// asynq.ServeMux IS the consumer: we emit a SCOPE.ScheduledJob keyed
+		// by the literal task type (stable across files) with a TRIGGERS edge
+		// to the handler. synthesizeGoAsynqEnqueueEdges then resolves
+		// `asynq.NewTask("task:type", ...)` producer sites — typically wrapped
+		// in a `client.Enqueue(...)` — to an ENQUEUES edge from the enclosing
+		// function, so producer and consumer converge on the task-type node.
+		synthesizeGoAsynq(src, path, emitJob)
+		relationships = synthesizeGoAsynqEnqueueEdges(src, seenJob, relationships)
 	case "ruby":
 		// #3700: Sidekiq worker jobs + sidekiq-cron scheduled jobs, plus
 		// ENQUEUES edges from `Worker.perform_async/in/at` dispatch sites to
@@ -806,6 +816,106 @@ func synthesizeSidekiqEnqueueEdges(
 				"pattern_type":    "sidekiq_enqueue_synthesis",
 				"worker_class":    workerClass,
 				"dispatch_method": src[idx[4]:idx[5]],
+			},
+		})
+	}
+	return relationships
+}
+
+// ---------------------------------------------------------------------------
+// Go — asynq (hibiken/asynq) task queue (#4923)
+// ---------------------------------------------------------------------------
+//
+// asynq is the de-facto Redis-backed background-job library for Go. Its
+// producer/consumer rendezvous is the literal *task type* string:
+//
+//	Consumer: mux.HandleFunc("email:send", handleEmail)            (registration)
+//	          mux.Handle("email:send", asynq.HandlerFunc(handle))   (registration)
+//	Producer: client.Enqueue(asynq.NewTask("email:send", payload)) (dispatch)
+//
+// We model the registered handler as a SCOPE.ScheduledJob entity keyed by the
+// task type (no path → stable across files so a NewTask producer in one file
+// resolves to the handler registered in another), with a TRIGGERS edge to the
+// handler function, and emit ENQUEUES edges from the enclosing function of each
+// asynq.NewTask producer site to that job. Same join shape as Ruby Sidekiq.
+
+// goAsynqJobID is the canonical job-entity ID for an asynq task type. Stable
+// across files (no path) so a NewTask producer resolves to the handler.
+func goAsynqJobID(taskType string) string {
+	return "asynq:" + taskType
+}
+
+// goAsynqHandleRe captures `mux.HandleFunc("type", handler)` and
+// `mux.Handle("type", ...)` registrations on an asynq ServeMux.
+// Group 1 = task type, group 2 = handler identifier (may be empty for
+// asynq.HandlerFunc(...) / inline wrappers).
+var goAsynqHandleRe = regexp.MustCompile(`\.Handle(?:Func)?\s*\(\s*"([^"\n\r]+)"\s*,\s*([\w.]+)?`)
+
+// goAsynqNewTaskRe captures `asynq.NewTask("type", ...)` producer sites.
+// Group 1 = task type.
+var goAsynqNewTaskRe = regexp.MustCompile(`asynq\.NewTask\s*\(\s*"([^"\n\r]+)"`)
+
+// synthesizeGoAsynq emits a SCOPE.ScheduledJob per asynq HandleFunc/Handle
+// registration with a TRIGGERS edge to the handler. Registers every job ID
+// into the caller's seenJob map (via emitJob) so the enqueue pass can resolve
+// NewTask producer sites to those IDs.
+func synthesizeGoAsynq(
+	src, path string,
+	emitJob func(jobID, handler, schedule, framework string, extra map[string]string),
+) {
+	if !strings.Contains(src, "asynq") {
+		return
+	}
+	for _, m := range goAsynqHandleRe.FindAllStringSubmatch(src, -1) {
+		taskType := m[1]
+		handler := m[2]
+		// asynq.HandlerFunc(...) / inline wrappers leave the handler ident
+		// unresolved — emit the job node without a TRIGGERS target (honest;
+		// the producer side still converges on the task-type node).
+		if handler == "asynq.HandlerFunc" || handler == "asynq" {
+			handler = ""
+		}
+		emitJob(goAsynqJobID(taskType), handler, "", "asynq", map[string]string{
+			"task_type": taskType,
+			"job_type":  "queue",
+		})
+	}
+}
+
+// synthesizeGoAsynqEnqueueEdges emits ENQUEUES edges from the enclosing Go
+// function of each `asynq.NewTask("type", ...)` producer site to the task-type
+// job entity. Only emits when the job ID is present in knownJobs (the seenJob
+// map) so a NewTask whose handler lives in an un-indexed file does not create a
+// phantom node. Dedupes on (caller, jobID).
+func synthesizeGoAsynqEnqueueEdges(
+	src string,
+	knownJobs map[string]bool,
+	relationships []types.RelationshipRecord,
+) []types.RelationshipRecord {
+	if !strings.Contains(src, "asynq.NewTask") {
+		return relationships
+	}
+	seenEdge := map[string]bool{}
+	for _, idx := range goAsynqNewTaskRe.FindAllStringSubmatchIndex(src, -1) {
+		taskType := src[idx[2]:idx[3]]
+		jobID := goAsynqJobID(taskType)
+		if !knownJobs[jobID] {
+			continue
+		}
+		caller := findEnclosingGoFunctionName(src, idx[0])
+		key := caller + "|" + jobID
+		if seenEdge[key] {
+			continue
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: "SCOPE.Operation:" + caller,
+			ToID:   scheduledJobKind + ":" + jobID,
+			Kind:   string(types.RelationshipKindEnqueues),
+			Properties: map[string]string{
+				"framework":    "asynq",
+				"pattern_type": "asynq_enqueue_synthesis",
+				"task_type":    taskType,
 			},
 		})
 	}

--- a/internal/engine/scheduled_jobs_edges_test.go
+++ b/internal/engine/scheduled_jobs_edges_test.go
@@ -301,6 +301,91 @@ func main() {
 }
 
 // ---------------------------------------------------------------------------
+// Go — asynq (hibiken/asynq) task queue (#4923)
+// ---------------------------------------------------------------------------
+
+func TestScheduledJobs_GoAsynq_HandlerAndEnqueueConverge(t *testing.T) {
+	src := `package main
+
+import "github.com/hibiken/asynq"
+
+func registerHandlers(mux *asynq.ServeMux) {
+    mux.HandleFunc("email:send", handleEmailSend)
+    mux.Handle("image:resize", asynq.HandlerFunc(handleResize))
+}
+
+func DispatchWelcomeEmail() error {
+    task := asynq.NewTask("email:send", payload)
+    _, err := client.Enqueue(task)
+    return err
+}
+`
+	ents, rels := runScheduledDetect(t, "go", "tasks.go", src)
+
+	jobs := scheduledJobsByFramework(ents, "asynq")
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 asynq ScheduledJob entities (email:send, image:resize), got %d", len(jobs))
+	}
+	byType := map[string]types.EntityRecord{}
+	for _, j := range jobs {
+		byType[j.Properties["task_type"]] = j
+	}
+	if _, ok := byType["email:send"]; !ok {
+		t.Fatalf("missing asynq job for task_type email:send")
+	}
+	if _, ok := byType["image:resize"]; !ok {
+		t.Fatalf("missing asynq job for task_type image:resize")
+	}
+
+	// TRIGGERS edge: HandleFunc handler is resolved to handleEmailSend.
+	trig := triggersEdges(rels)
+	foundTrigger := false
+	for _, e := range trig {
+		if e.ToID == "Function:handleEmailSend" && e.Properties["framework"] == "asynq" {
+			foundTrigger = true
+		}
+	}
+	if !foundTrigger {
+		t.Errorf("expected TRIGGERS edge asynq job -> Function:handleEmailSend, got %+v", trig)
+	}
+
+	// ENQUEUES edge: producer (asynq.NewTask) converges on the same task-type
+	// node from its enclosing function.
+	enq := enqueuesEdges(rels)
+	foundEnqueue := false
+	for _, e := range enq {
+		if e.ToID == scheduledJobKind+":asynq:email:send" &&
+			e.FromID == "SCOPE.Operation:DispatchWelcomeEmail" &&
+			e.Properties["framework"] == "asynq" {
+			foundEnqueue = true
+		}
+	}
+	if !foundEnqueue {
+		t.Errorf("expected ENQUEUES edge DispatchWelcomeEmail -> asynq:email:send, got %+v", enq)
+	}
+}
+
+func TestScheduledJobs_GoAsynq_NoPhantomWhenHandlerUnknown(t *testing.T) {
+	// A NewTask producer for a task type that has no HandleFunc registration in
+	// any indexed file must NOT emit a phantom ENQUEUES edge.
+	src := `package main
+
+import "github.com/hibiken/asynq"
+
+func Dispatch() {
+    task := asynq.NewTask("unregistered:type", nil)
+    client.Enqueue(task)
+}
+`
+	_, rels := runScheduledDetect(t, "go", "producer.go", src)
+	for _, e := range enqueuesEdges(rels) {
+		if e.Properties["framework"] == "asynq" {
+			t.Errorf("expected no asynq ENQUEUES edge for unregistered task type, got %+v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Kubernetes CronJob YAML
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Coverage-audit ticket #4923 (go). Audited the Go extractor / engine messaging+scheduler+CLI passes vs the registry; documented genuinely-extracted-but-invisible capabilities and implemented one high-value missing extraction. **Deploy-deferred.** Sandbox HOME=`/tmp/agsbx-4923`.

## New extraction (fixture-proven)
**hibiken/asynq** — Go's de-facto Redis-backed task queue, previously **zero handling**. Added `synthesizeGoAsynq` + `synthesizeGoAsynqEnqueueEdges` to `internal/engine/scheduled_jobs_edges.go` (inside the already-wired `case "go"`):
- `mux.HandleFunc("task:type", h)` / `mux.Handle("task:type", asynq.HandlerFunc(...))` → `SCOPE.ScheduledJob` (`asynq:<task_type>`) + TRIGGERS edge to the handler.
- `asynq.NewTask("task:type", ...)` producer sites → ENQUEUES edge from the enclosing Go func; producer & consumer converge on the task-type node (same join shape as Ruby Sidekiq).
- No-phantom guard: ENQUEUES only when a matching handler registration was seen.
- Tests: `TestScheduledJobs_GoAsynq_HandlerAndEnqueueConverge`, `TestScheduledJobs_GoAsynq_NoPhantomWhenHandlerUnknown`.

## Documented (new Go-language records — de-dupe of `multi` records that hid Go visibility; #3736)
The engine genuinely handles Go for these (`case "go"` synthesis funcs) but no Go record existed, so Go topology was invisible to a Go auditor. Each cell cites the real synthesis func + verified_at:
- `msg.asynq` (new extraction above).
- `msg.broker.kafka-go` — `synthesizeGoKafka` (Sarama + segmentio/kafka-go).
- `msg.broker.nats-go` — `synthesizeGoNATS` (nats.go / JetStream).
- `msg.broker.rabbitmq-go` — `synthesizeGoRabbitMQ` (amqp091-go).
- `msg.go-cron` — `synthesizeGoCron` (robfig/cron).

## Audited — already honestly documented (gap inflated, NOT re-flipped)
- **cobra CLI**: `cli.command-extraction` (multi) already carries Go-specific cites + `TestCLI_GoCobra_*`. Left as-is.
- **Go HTTP outbound client** (net/http, fasthttp, resty, imroc/req): already documented as `client_consumes_api` on `lang.go.framework.net-http` + `lang.go.framework.fasthttp` (cites `http_endpoint_go_client.go`). No separate http-client category exists in the schema. Left as-is.

## Deferred (follow-ups, honestly-missing stays missing)
- asynq cron-scheduled tasks (`asynqcron` / periodic-task scheduler), retry/queue-priority options — task-type extraction only this PR.
- Go-native task queues NSQ / machinery / watermill (#4923 backlog).
- View rendering (html/template + a-h/templ + Buffalo plush), sqlboiler ORM, Wails desktop (#4923 med).
- asynq HandleFunc direction heuristic shares the generic `.HandleFunc(` regex; file-level `asynq` guard scopes it (same belt as synthesizeGoCron's `cron` guard).

## Gates (sandbox HOME=/tmp/agsbx-4923)
- `go build ./...` ✅  `go vet ./internal/...` ✅
- `go test ./internal/engine/ ./internal/custom/golang/ ./internal/extractors/golang/... ./internal/types/ ./tools/coverage/` ✅
- `coverage fmt --check` → canonical ✅   `coverage validate` → **0 errors** ✅
- Docs follow sibling-PR convention (registry-only; markdown regen is a separate, pre-existing drift handled by the gen workflow).

Closes #4923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)