### PR TITLE
feat(#4926): c/c++ coverage — document extracted capabilities + new extraction

### DIFF
--- a/internal/custom/cpp/cpphttplib_routes.go
+++ b/internal/custom/cpp/cpphttplib_routes.go
@@ -1,0 +1,138 @@
+package cpp
+
+// cpphttplib_routes.go — cpp-httplib (yhirose/cpp-httplib) HTTP server
+// route/handler extractor.
+//
+// cpp-httplib is a header-only C++11 HTTP/HTTPS library (~13k★). Servers are
+// declared by registering verb-named member functions on an httplib::Server (or
+// httplib::SSLServer) instance:
+//
+//	httplib::Server svr;
+//	svr.Get("/hi", handler);
+//	svr.Post("/users", handler);
+//	svr.Put("/users/(\\d+)", handler);     // regex path
+//	svr.Delete("/users/:id", handler);     // (rare, but accepted)
+//	svr.Patch("/x", handler);
+//	svr.Options("/x", handler);
+//
+// Each matched route emits one SCOPE.Operation/endpoint entity with provenance
+// INFERRED_FROM_CPPHTTPLIB_ROUTE. The handler token (lambda → "<lambda>", named
+// function/method → its identifier) is stamped in handler_name to support
+// handler_attribution.
+//
+// Outbound httplib::Client calls (svr is a Client) are NOT route declarations
+// and are intentionally not matched here — see follow-up for client http_effect.
+//
+// Status: partial (regex/heuristic; no AST).
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_cpphttplib", &cppHttplibExtractor{})
+}
+
+type cppHttplibExtractor struct{}
+
+func (e *cppHttplibExtractor) Language() string { return "custom_cpp_cpphttplib" }
+
+// <recv>.Get("/path", <handler...>) for the six routable verbs.
+//
+//	group 1: receiver identifier (server instance, e.g. svr / server)
+//	group 2: HTTP verb (Get/Post/Put/Delete/Patch/Options)
+//	group 3: route path string literal
+//	group 4: handler token start (first token after the comma)
+var reCppHttplibRoute = regexp.MustCompile(
+	`(?m)\b([A-Za-z_]\w*)\s*\.\s*(Get|Post|Put|Delete|Patch|Options)\s*\(\s*` +
+		`(?:R?"[^"(]*\(([^)]*)\)[^"]*"|"((?:[^"\\]|\\.)*)")` +
+		`\s*,\s*([A-Za-z_&\[]?[A-Za-z0-9_:&]*)`,
+)
+
+// cppHttplibVerb maps a member-function name to its canonical HTTP method.
+func cppHttplibVerb(fn string) string {
+	return strings.ToUpper(fn)
+}
+
+func (e *cppHttplibExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.cpphttplib_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "cpp-httplib"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	// Cheap signal gate: require a cpp-httplib marker so we do not misattribute
+	// `obj.Get("...")` calls in unrelated C++ code.
+	if !strings.Contains(src, "httplib::") && !strings.Contains(src, "httplib.h") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	for _, m := range reCppHttplibRoute.FindAllStringSubmatchIndex(src, -1) {
+		fn := src[m[4]:m[5]]
+		verb := cppHttplibVerb(fn)
+		// Path comes from either the raw-string group (m[6:7]) or the plain
+		// string-literal group (m[8:9]).
+		var path string
+		if m[6] >= 0 {
+			path = src[m[6]:m[7]]
+		} else if m[8] >= 0 {
+			path = src[m[8]:m[9]]
+		}
+		path = cppNormalizeRoutePath(path)
+
+		handler := "<lambda>"
+		if m[10] >= 0 {
+			raw := strings.TrimSpace(src[m[10]:m[11]])
+			raw = strings.TrimLeft(raw, "&")
+			// A lambda capture `[` or empty token means an inline lambda.
+			if raw != "" && !strings.HasPrefix(raw, "[") {
+				handler = raw
+			}
+		}
+
+		name := verb + " " + path
+		key := "SCOPE.Operation:" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "cpp-httplib",
+			"provenance", "INFERRED_FROM_CPPHTTPLIB_ROUTE",
+			"http_method", verb,
+			"route_path", path,
+			"handler_name", handler,
+			"dsl", "Server."+fn,
+		)
+		entities = append(entities, ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/cpp/cpphttplib_routes_test.go
+++ b/internal/custom/cpp/cpphttplib_routes_test.go
@@ -1,0 +1,77 @@
+package cpp_test
+
+// cpphttplib_routes_test.go — golden fixture tests for cpphttplib_routes.go.
+
+import "testing"
+
+func TestCppHttplibBasicVerbs(t *testing.T) {
+	src := `
+#include <httplib.h>
+int main() {
+    httplib::Server svr;
+    svr.Get("/hi", [](const httplib::Request&, httplib::Response& res) {
+        res.set_content("Hello", "text/plain");
+    });
+    svr.Post("/users", createUser);
+    svr.Put("/users/:id", updateUser);
+    svr.Delete("/users/:id", deleteUser);
+    svr.listen("0.0.0.0", 8080);
+}
+`
+	ents := extract(t, "custom_cpp_cpphttplib", fi("server.cc", "cpp", src))
+	assertEndpoint(t, ents, "GET", "/hi", "<lambda>")
+	assertEndpoint(t, ents, "POST", "/users", "createUser")
+	assertEndpoint(t, ents, "PUT", "/users/{id}", "updateUser")
+	assertEndpoint(t, ents, "DELETE", "/users/{id}", "deleteUser")
+}
+
+func TestCppHttplibHandlerAttribution(t *testing.T) {
+	src := `
+#include <httplib.h>
+httplib::Server svr;
+void wire() { svr.Get("/health", healthHandler); }
+`
+	ents := extract(t, "custom_cpp_cpphttplib", fi("wire.cc", "cpp", src))
+	assertEndpoint(t, ents, "GET", "/health", "healthHandler")
+}
+
+func TestCppHttplibLambdaHandler(t *testing.T) {
+	src := `
+#include <httplib.h>
+httplib::Server svr;
+void w() { svr.Get("/x", [&](const httplib::Request&, httplib::Response& r){ r.status = 200; }); }
+`
+	ents := extract(t, "custom_cpp_cpphttplib", fi("x.cc", "cpp", src))
+	assertEndpoint(t, ents, "GET", "/x", "<lambda>")
+}
+
+func TestCppHttplibSSLServer(t *testing.T) {
+	src := `
+#include <httplib.h>
+httplib::SSLServer svr("./cert.pem", "./key.pem");
+void w() { svr.Patch("/cfg", patchCfg); svr.Options("/cfg", optsCfg); }
+`
+	ents := extract(t, "custom_cpp_cpphttplib", fi("ssl.cc", "cpp", src))
+	assertEndpoint(t, ents, "PATCH", "/cfg", "patchCfg")
+	assertEndpoint(t, ents, "OPTIONS", "/cfg", "optsCfg")
+}
+
+func TestCppHttplibNoMarkerNoMatch(t *testing.T) {
+	// Without an httplib marker, obj.Get("...") must NOT be misattributed.
+	src := `
+struct Cache { std::string Get(const std::string& k); };
+void f(Cache& c) { c.Get("/not-a-route"); }
+`
+	ents := extract(t, "custom_cpp_cpphttplib", fi("cache.cc", "cpp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without httplib marker, got %d: %v", len(ents), ents)
+	}
+}
+
+func TestCppHttplibWrongLanguage(t *testing.T) {
+	src := `httplib::Server svr; void w() { svr.Get("/x", h); }`
+	ents := extract(t, "custom_cpp_cpphttplib", fi("x.c", "c", src))
+	if len(ents) != 0 {
+		t.Errorf("wrong language should return no entities, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## #4926 — C/C++ coverage audit

### New extraction (fixture-proven)
- **`custom_cpp_cpphttplib`** (`internal/custom/cpp/cpphttplib_routes.go`) — cpp-httplib (~13k★, header-only) server routes. `Server.Get/Post/Put/Delete/Patch/Options("/path", handler)` → `SCOPE.Operation/endpoint` carrying `http_method`, `route_path` (canonicalised via `cppNormalizeRoutePath`), `handler_name` (named fn → identifier, inline lambda → `<lambda>`). Plain- and raw-string regex paths; `httplib::`/`httplib.h` marker gate prevents misattributing unrelated `obj.Get(...)` calls. Auto-wires through `custom_cpp_` dispatch. **6 golden, value-asserting tests** (verb/path/handler exact-match + no-marker + wrong-language negatives).

### Documented (records, honest, cited)
- **`lang.c-cpp.framework.cpp-httplib`** — `endpoint_synthesis` + `handler_attribution` = **full** (cite the new extractor + test).
- **3 detection-only ORM records** — `nanodbc`, `SQLiteCpp`, `sqlite-direct-c-api` — cite the existing engine YAMLs (`internal/engine/rules/cpp/orms/*.yaml`). These are DETECTION-ONLY today (no Go extractor emits query/model/schema), following the clojure `orms/*.yaml` detection-only precedent: `query_attribution`/model/schema/lifecycle/migration-ops = **missing** (#4978); relationship/FK/lazy-loading/migration-parsing = **not_applicable** (thin SQL/ODBC wrappers, not data-mappers).
- `coverage backfill --language c-cpp` seeded the remaining taxonomy lane cells.

### Deferred (follow-ups filed)
- **#4978** — deepen detection-only C/C++ ORMs (nanodbc / SQLiteCpp / sqlite_direct_c_api) to real query+schema attribution.
- **#4979** — GUI/CV/game framework detection records (opencv, dear_imgui, cocos2d_x, juce, wxwidgets): the capability-dictionary has no `computer_vision`/`game` subcategory and immediate-mode/audio GUIs map poorly to `ui_frontend`; needs a taxonomy decision before honest records can land.

### Audit corrections vs ticket
- **sqlpp11 is NOT an orphan** — it is backed by a real Go extractor (`internal/custom/cpp/orm.go`, `custom_cpp_sqlpp11`); the missing YAML is fine (YAML detection is not required when a Go extractor produces the entities). Left intact.

### Gates (sandbox HOME=/tmp/agsbx-4926)
- `go build ./...` ✅  `go vet` ✅ (cpp/types)
- `go test ./internal/custom/cpp/... ./internal/extractors/cpp/... ./internal/types/... ./tools/coverage/...` ✅
- `coverage fmt --check` ✅ (canonical)  `coverage validate` ✅ (exit 0)

Deploy-deferred. Closes #4926.