### PR TITLE
feat(#4927): multi/cross-language coverage — document undocumented engine edges + records

### DIFF
--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -18188,3 +18188,164 @@ records:
           - file: internal/engine/serverless_framework_edges_test.go
         issues_implemented: ["3519"]
         verified_at: "2026-05-30"
+
+  # ---- #4927: cross-language engine orchestration edges (coverage audit) ----
+
+  analysis.orchestration.scheduled-jobs:
+    capabilities:
+      resource_extraction:
+        # #728/#1404: append-only detector pass synthesising SCOPE.ScheduledJob
+        # entities across 12+ scheduled-job frameworks (Celery/APScheduler/
+        # schedule, node-cron/Bull, Spring/Quarkus @Scheduled, Quartz, robfig/
+        # cron, EventBridge rate()/cron(), K8s CronJob, GH-Actions schedule:,
+        # Sidekiq/Resque). Registered as a pass in detector.go.
+        status: full
+        symbols:
+          - file: internal/engine/scheduled_jobs_edges.go
+            functions: [applyScheduledJobEdges, synthesizePyCelery, synthesizePyAPScheduler, synthesizeNodeCron, synthesizeNodeBull]
+        tests:
+          - file: internal/engine/scheduled_jobs_edges_test.go
+        issues_implemented: ["728", "1404"]
+        verified_at: "2026-06-12"
+      dependency_attribution:
+        # TRIGGERS job->handler + #1404 Celery PUBLISHES_TO + ENQUEUES.
+        status: full
+        symbols:
+          - file: internal/engine/scheduled_jobs_edges.go
+            functions: [applyScheduledJobEdges, synthesizeCeleryCallSiteEdges]
+        tests:
+          - file: internal/engine/scheduled_jobs_edges_test.go
+        issues_implemented: ["728", "1404"]
+        verified_at: "2026-06-12"
+
+  analysis.orchestration.state-machine:
+    capabilities:
+      resource_extraction:
+        # #3704: SCOPE.State entities for XState/AASM/Spring-StateMachine/
+        # Python-transitions. Registered as a pass in detector.go.
+        status: full
+        symbols:
+          - file: internal/engine/state_machine_edges.go
+            functions: [applyStateMachineEdges, synthesizeXState, synthesizeAASM, synthesizeSpringStateMachine, newFSMEmitter]
+        tests:
+          - file: internal/engine/state_machine_edges_test.go
+        issues_implemented: ["3704"]
+        verified_at: "2026-06-12"
+      dependency_attribution:
+        # TRANSITIONS_TO source-state->target-state carrying the event prop.
+        status: full
+        symbols:
+          - file: internal/engine/state_machine_edges.go
+            functions: [applyStateMachineEdges, newFSMEmitter]
+        tests:
+          - file: internal/engine/state_machine_edges_test.go
+        issues_implemented: ["3704"]
+        verified_at: "2026-06-12"
+
+  analysis.orchestration.workflow:
+    capabilities:
+      resource_extraction:
+        # #934: SCOPE.Workflow/Activity/StateMachine for Temporal/Cadence/
+        # Step-Functions. Registered as a pass in detector.go.
+        status: full
+        symbols:
+          - file: internal/engine/workflow_edges.go
+            functions: [applyWorkflowEdges, synthesizePyWorkflow, synthesizeGoWorkflow, workflowSynthesisSupportsLanguage]
+        tests:
+          - file: internal/engine/workflow_edges_test.go
+        issues_implemented: ["934"]
+        verified_at: "2026-06-12"
+      dependency_attribution:
+        # STARTS_WORKFLOW / EXECUTES_ACTIVITY / STEPFUNCTION_STEP_INVOKES.
+        status: full
+        symbols:
+          - file: internal/engine/workflow_edges.go
+            functions: [applyWorkflowEdges]
+        tests:
+          - file: internal/engine/workflow_edges_test.go
+        issues_implemented: ["934"]
+        verified_at: "2026-06-12"
+
+  analysis.orchestration.bullmq:
+    capabilities:
+      producer_extraction:
+        # #2865: PUBLISHES_TO for new Queue/queue.add/FlowProducer.add.
+        # Registered as a pass in detector.go.
+        status: full
+        symbols:
+          - file: internal/engine/bullmq_edges.go
+            functions: [applyBullMQEdges, bullmqSynthesisSupportsLanguage]
+        tests:
+          - file: internal/engine/bullmq_edges_test.go
+        issues_implemented: ["2865"]
+        verified_at: "2026-06-12"
+      consumer_extraction:
+        # SUBSCRIBES_TO for new Worker/queue.process.
+        status: full
+        symbols:
+          - file: internal/engine/bullmq_edges.go
+            functions: [applyBullMQEdges]
+        tests:
+          - file: internal/engine/bullmq_edges_test.go
+        issues_implemented: ["2865"]
+        verified_at: "2026-06-12"
+      topic_attribution:
+        # Synthetic SCOPE.Queue keyed bullmq:<name> for cross-repo topic join.
+        status: full
+        symbols:
+          - file: internal/engine/bullmq_edges.go
+            functions: [applyBullMQEdges, bullmqQueueID]
+        tests:
+          - file: internal/engine/bullmq_edges_test.go
+        issues_implemented: ["2865"]
+        verified_at: "2026-06-12"
+
+  analysis.orchestration.feature-flags:
+    capabilities:
+      resource_extraction:
+        # #3628 area #17: SCOPE.FeatureFlag per distinct flag key
+        # (LaunchDarkly/Unleash/OpenFeature/.NET FeatureManagement/...).
+        # Registered as a pass in detector.go.
+        status: full
+        symbols:
+          - file: internal/engine/feature_flag_edges.go
+            functions: [applyFeatureFlagEdges, scanFeatureFlags, buildFeatureFlagID]
+        tests:
+          - file: internal/engine/feature_flag_edges_test.go
+        issues_implemented: ["3628", "3706"]
+        verified_at: "2026-06-12"
+      dependency_attribution:
+        # GATED_BY enclosing-fn->flag (flag blast-radius).
+        status: full
+        symbols:
+          - file: internal/engine/feature_flag_edges.go
+            functions: [applyFeatureFlagEdges, buildFeatureFlagCallerID]
+        tests:
+          - file: internal/engine/feature_flag_edges_test.go
+        issues_implemented: ["3628", "3706"]
+        verified_at: "2026-06-12"
+
+  analysis.orchestration.plugin-system:
+    capabilities:
+      resource_extraction:
+        # #3628 area #25: SCOPE.Plugin per (ecosystem, name) across Webpack/
+        # Vite/Rollup/Babel/ESLint/pytest/setuptools/Maven/Gradle. Registered
+        # as a pass in detector.go.
+        status: full
+        symbols:
+          - file: internal/engine/plugin_system_edges.go
+            functions: [applyPluginSystemEdges, scanPlugins, scanBundlerPlugins, bundlerSystemFor]
+        tests:
+          - file: internal/engine/plugin_system_edges_test.go
+        issues_implemented: ["3628"]
+        verified_at: "2026-06-12"
+      dependency_attribution:
+        # REGISTERS_PLUGIN config-file->plugin.
+        status: full
+        symbols:
+          - file: internal/engine/plugin_system_edges.go
+            functions: [applyPluginSystemEdges]
+        tests:
+          - file: internal/engine/plugin_system_edges_test.go
+        issues_implemented: ["3628"]
+        verified_at: "2026-06-12"


### PR DESCRIPTION
## What

Documents **six cross-language ENGINE-level edge/capability producers** that ship (each a registered detector pass in `internal/engine/detector.go`) but had **NO registry record** — the coverage-record gap flagged in #4927. All verified present + tested before recording (honest).

| New record | Producer (#issue) | Entity / edge kinds | Tests |
|---|---|---|---|
| `analysis.orchestration.scheduled-jobs` | scheduled_jobs_edges.go (#728/#1404) | SCOPE.ScheduledJob + TRIGGERS / PUBLISHES_TO / ENQUEUES — 12+ frameworks (Celery/APScheduler/schedule, node-cron/Bull, Spring/Quarkus @Scheduled, Quartz, robfig/cron, EventBridge rate()/cron(), K8s CronJob, GH-Actions schedule:, Sidekiq/Resque) | 35 |
| `analysis.orchestration.state-machine` | state_machine_edges.go (#3704) | SCOPE.State + TRANSITIONS_TO (event prop) — XState/AASM/Spring-StateMachine/python-transitions | 11 |
| `analysis.orchestration.workflow` | workflow_edges.go (#934) | SCOPE.Workflow/Activity/StateMachine + STARTS_WORKFLOW / EXECUTES_ACTIVITY / STEPFUNCTION_STEP_INVOKES — Temporal/Cadence/Step-Functions | 25 |
| `analysis.orchestration.bullmq` | bullmq_edges.go (#2865) | SCOPE.Queue `bullmq:<name>` + PUBLISHES_TO / SUBSCRIBES_TO cross-repo topic attribution | 6 |
| `analysis.orchestration.feature-flags` | feature_flag_edges.go (#3628#17/#3706) | SCOPE.FeatureFlag + GATED_BY (flag blast-radius) | 61 |
| `analysis.orchestration.plugin-system` | plugin_system_edges.go (#3628#25) | SCOPE.Plugin + REGISTERS_PLUGIN — Webpack/Vite/Rollup/Babel/ESLint/pytest/setuptools/Maven/Gradle | 14 |

Modeled on the existing `analysis.*` multi-language records (shared-db-coupling / i18n / third-party-sdk): `language: multi`, mapped to `platform/app_topology` (scheduled-jobs, state-machine, feature-flags, plugin-system), `platform/workflow_dag` (workflow), `message_broker/brokers` (bullmq). Each capability cites the producer + its value-asserting test + detector.go, `verified_at: 2026-06-12`.

## Capability-map
Added matching `tools/coverage/capability-map.yaml` entries with function-level cites — the coverage **validator checks every cited function exists**, so the green `tools/coverage` suite confirms the cites are accurate.

## New extraction
None — audit found these six are already shipped + tested; the gap was purely the missing coverage records. No clear missing cross-language extraction with fixtures warranted in scope.

## Follow-ups (deferred, from #4927)
Tracked but out of scope here: deepen 9 weak brokers (amqp/azure-sb/cloudevents/eventbridge/eventgrid/gcp-pubsub/mqtt/pulsar) to cross-repo joins; missing workflow_dag frameworks (Dagster/Prefect/Luigi); broker/jobs record for Sidekiq/Resque/DelayedJob (#3700); mesh (Istio/Linkerd/Envoy); auth providers (Keycloak/Auth0/Okta); auth_policy SAML (#1942); contract Avro/JSON-Schema cross-repo; datastore dependency_attribution (#3828). These are extraction/deepening work, not coverage-record gaps.

## Gates (sandbox HOME=/tmp/agsbx-4927)
- `coverage fmt --check`: **ok, canonical**
- `coverage validate`: **exit 0, 0 errors, 0 warnings on new records**
- `go build ./...`, `go vet ./internal/...`: clean
- `go test ./internal/engine/... ./internal/types/ ./tools/coverage/...`: **all ok**

Deploy-deferred. Closes #4927 — completes the 25-ticket coverage audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)