### PR TITLE
feat(#4810): Topology Model 2 — cross-linked infra↔code lenses

### DIFF
--- a/webui-v2/src/components/compound-topology/CTNode.tsx
+++ b/webui-v2/src/components/compound-topology/CTNode.tsx
@@ -8,11 +8,33 @@ import { tierStyle } from "./tierStyle";
 function CTNodeImpl({ data }: NodeProps) {
   const d = data as CTNodeData;
   const s = tierStyle(d.tier);
+
+  // Cross-link highlight (Model 2). "primary" = same entity in the other lens,
+  // "linked" = edge-connected counterpart. Non-matching nodes dim when a
+  // selection is active so the cross-link reads at a glance.
+  const hl = d.highlight;
+  const isPrimary = hl === "primary";
+  const isLinked = hl === "linked";
+  const dim = d.dimmed && hl === "none";
+  const borderColor = isPrimary ? "var(--accent)" : isLinked ? "var(--info)" : s.color;
+
   return (
     <div
-      className="flex h-full w-full flex-col justify-center rounded-md border px-2.5 py-1"
-      style={{ borderColor: s.color, background: s.tint }}
-      title={`${d.label} · ${d.kind} · ${s.label}${d.repo ? ` · ${d.repo}` : ""}`}
+      className="flex h-full w-full flex-col justify-center rounded-md border px-2.5 py-1 transition-opacity"
+      style={{
+        borderColor,
+        borderWidth: isPrimary || isLinked ? 2 : 1,
+        background: s.tint,
+        opacity: dim ? 0.28 : 1,
+        boxShadow: isPrimary
+          ? "0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent)"
+          : isLinked
+            ? "0 0 0 2px color-mix(in srgb, var(--info) 32%, transparent)"
+            : undefined,
+      }}
+      title={`${d.label} · ${d.kind} · ${s.label}${d.repo ? ` · ${d.repo}` : ""}${
+        isPrimary ? " · cross-linked (same entity)" : isLinked ? " · linked by edge" : ""
+      }`}
     >
       <Handle type="target" position={Position.Left} className="!h-1.5 !w-1.5 !border-0 !bg-text-4" />
       <span className="truncate text-[11px] font-medium text-text" style={{ color: s.color }}>

--- a/webui-v2/src/components/compound-topology/CTZone.tsx
+++ b/webui-v2/src/components/compound-topology/CTZone.tsx
@@ -54,7 +54,15 @@ function CTZoneImpl({ data }: NodeProps) {
   // inside its parent (#4866). depth 0 = outermost.
   const outer = (d.depth ?? 0) === 0;
   const fill = `color-mix(in srgb, ${color} ${outer ? 6 : 10}%, transparent)`;
-  const borderColor = `color-mix(in srgb, ${color} ${outer ? 55 : 70}%, var(--border-strong))`;
+  let borderColor = `color-mix(in srgb, ${color} ${outer ? 55 : 70}%, var(--border-strong))`;
+
+  // Cross-link highlight (Model 2): a zone that contains the cross-linked
+  // counterpart of the node selected in the other lens gets an accent frame so
+  // the user can see WHERE in this lens' hierarchy the counterpart lives.
+  const hl = d.highlight;
+  const hlColor = hl === "primary" ? "var(--accent)" : hl === "linked" ? "var(--info)" : "";
+  if (hlColor) borderColor = hlColor;
+  const dim = d.dimmed && (!hl || hl === "none");
 
   return (
     <div
@@ -68,9 +76,13 @@ function CTZoneImpl({ data }: NodeProps) {
         backgroundColor: d.collapsed
           ? `color-mix(in srgb, ${color} 14%, var(--surface-2))`
           : fill,
-        boxShadow: d.collapsed
-          ? undefined
-          : "inset 0 0 0 1px color-mix(in srgb, var(--surface) 55%, transparent)",
+        boxShadow: hlColor
+          ? `0 0 0 2px color-mix(in srgb, ${hlColor} 35%, transparent)`
+          : d.collapsed
+            ? undefined
+            : "inset 0 0 0 1px color-mix(in srgb, var(--surface) 55%, transparent)",
+        opacity: dim ? 0.4 : 1,
+        transition: "opacity 0.15s, border-color 0.15s",
       }}
       title={`${d.label} (${d.kind}) · ${d.nodeCount} node${d.nodeCount === 1 ? "" : "s"}`}
     >

--- a/webui-v2/src/components/compound-topology/CompoundLens.tsx
+++ b/webui-v2/src/components/compound-topology/CompoundLens.tsx
@@ -1,0 +1,207 @@
+/* ============================================================
+   components/compound-topology/CompoundLens.tsx
+
+   A SINGLE compound-topology canvas for ONE fixed `group_by` lens. Extracted
+   from CompoundTopology (Model 1) so Model 2 (#4810, cross-linked lenses) can
+   render two of them side-by-side and drive a SHARED selection across both.
+
+   This is the Model-1 canvas (ELK/dagre layout, #4866 zones, #4887 handles)
+   minus the group-by toggle — plus three Model-2 affordances:
+     - `highlight`   — the cross-link maps (per-node / per-zone) to tint.
+     - `selectedId`  — the node currently selected (anywhere).
+     - `onSelectNode`— bubbles a node click up to the two-lens controller.
+
+   The highlight tinting is injected into each node/zone's data so CTNode /
+   CTZone render it; the layout (positions) is untouched.
+   ============================================================ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MiniMap,
+  type Node,
+  type NodeMouseHandler,
+  type NodeTypes,
+  type EdgeTypes,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { cn } from "@/lib/utils";
+import type { CompoundGroupBy } from "@/data/types";
+import { useCompoundTopology } from "@/hooks/use-topology";
+import {
+  layoutCompoundTopology,
+  layoutCompoundTopologyElk,
+  defaultLayoutEngine,
+  CT_NODE_TYPE,
+  CT_ZONE_TYPE,
+  CT_EDGE_TYPE,
+  type CTLayoutResult,
+} from "./layout";
+import type { CrossLinkHighlight } from "./crossLink";
+import { CTNode } from "./CTNode";
+import { CTZone } from "./CTZone";
+import { CTEdge } from "./CTEdge";
+
+const nodeTypes: NodeTypes = {
+  [CT_NODE_TYPE]: CTNode,
+  [CT_ZONE_TYPE]: CTZone,
+};
+const edgeTypes: EdgeTypes = { [CT_EDGE_TYPE]: CTEdge };
+
+export interface CompoundLensProps {
+  groupId: string;
+  groupBy: CompoundGroupBy;
+  /** Cross-link highlight maps for THIS lens (Model 2). */
+  highlight?: CrossLinkHighlight;
+  /** Currently-selected node id (across both lenses). */
+  selectedId?: string | null;
+  /** Fired when a leaf node is clicked; null clears the selection. */
+  onSelectNode?: (id: string | null) => void;
+  className?: string;
+}
+
+function CompoundLensInner({
+  groupId,
+  groupBy,
+  highlight,
+  selectedId,
+  onSelectNode,
+  className,
+}: CompoundLensProps) {
+  // Per-lens collapse set (independent of the other lens).
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const onToggle = useCallback((zoneId: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(zoneId)) next.delete(zoneId);
+      else next.add(zoneId);
+      return next;
+    });
+  }, []);
+
+  const { data, isLoading, isError } = useCompoundTopology(groupId, groupBy);
+
+  const engine = useMemo(() => defaultLayoutEngine(), []);
+  const EMPTY: CTLayoutResult = useMemo(
+    () => ({ nodes: [], edges: [], capped: false, summaryEdgeCount: 0 }),
+    [],
+  );
+
+  const dagreResult = useMemo(
+    () => (engine === "dagre" ? layoutCompoundTopology(data, collapsed, onToggle) : EMPTY),
+    [engine, data, collapsed, onToggle, EMPTY],
+  );
+
+  const [elkResult, setElkResult] = useState<CTLayoutResult>(EMPTY);
+  const [elkLaidOut, setElkLaidOut] = useState(false);
+  const elkRunId = useRef(0);
+  useEffect(() => {
+    if (engine !== "elk") return;
+    const myRun = ++elkRunId.current;
+    let cancelled = false;
+    setElkLaidOut(false);
+    layoutCompoundTopologyElk(data, collapsed, onToggle)
+      .then((res) => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        setElkResult(res);
+        setElkLaidOut(true);
+      })
+      .catch(() => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        setElkResult(layoutCompoundTopology(data, collapsed, onToggle));
+        setElkLaidOut(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [engine, data, collapsed, onToggle]);
+
+  const base = engine === "dagre" ? dagreResult : elkResult;
+  const layingOut = engine === "elk" && !elkLaidOut;
+
+  // Inject the cross-link highlight into each node/zone's data so CTNode/CTZone
+  // render it. Positions are untouched — this is a cheap per-render remap.
+  const nodes: Node[] = useMemo(() => {
+    if (!highlight?.active) {
+      // No selection — strip any stale highlight flags.
+      return base.nodes.map((n) =>
+        n.data && (n.data as { highlight?: unknown }).highlight !== undefined
+          ? { ...n, data: { ...n.data, highlight: undefined, dimmed: false }, selected: false }
+          : n,
+      );
+    }
+    return base.nodes.map((n) => {
+      const isZone = n.type === CT_ZONE_TYPE;
+      const hl = isZone
+        ? highlight.zones.get(n.id) ?? "none"
+        : highlight.nodes.get(n.id) ?? "none";
+      return {
+        ...n,
+        selected: !isZone && n.id === selectedId,
+        data: { ...n.data, highlight: hl, dimmed: true },
+      };
+    });
+  }, [base.nodes, highlight, selectedId]);
+
+  const onNodeClick: NodeMouseHandler = useCallback(
+    (_evt, node) => {
+      if (node.type === CT_ZONE_TYPE) return; // zone clicks toggle collapse.
+      if (!onSelectNode) return;
+      onSelectNode(node.id === selectedId ? null : node.id);
+    },
+    [onSelectNode, selectedId],
+  );
+
+  const onPaneClick = useCallback(() => onSelectNode?.(null), [onSelectNode]);
+
+  return (
+    <div className={cn("relative h-full min-h-0", className)}>
+      {isLoading || layingOut ? (
+        <div className="flex h-full items-center justify-center text-sm text-text-4">
+          {isLoading ? "Loading…" : "Laying out…"}
+        </div>
+      ) : isError ? (
+        <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+          <p className="text-md font-semibold text-text">Couldn&apos;t load topology</p>
+          <p className="text-sm text-text-3">Make sure the daemon is running.</p>
+        </div>
+      ) : nodes.length === 0 ? (
+        <div className="flex h-full items-center justify-center text-sm text-text-4">
+          No architecturally-significant nodes.
+        </div>
+      ) : (
+        <ReactFlow
+          nodes={nodes}
+          edges={base.edges}
+          nodeTypes={nodeTypes}
+          edgeTypes={edgeTypes}
+          fitView
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable
+          onNodeClick={onNodeClick}
+          onPaneClick={onPaneClick}
+          proOptions={{ hideAttribution: true }}
+          minZoom={0.08}
+          fitViewOptions={{ padding: 0.16 }}
+        >
+          <Background gap={18} size={1} color="var(--border)" />
+          <Controls showInteractive={false} />
+          <MiniMap pannable zoomable className="!border !border-border !bg-surface" />
+        </ReactFlow>
+      )}
+    </div>
+  );
+}
+
+/** A single compound-topology lens (one fixed group_by), wrapped in a provider. */
+export function CompoundLens(props: CompoundLensProps) {
+  return (
+    <ReactFlowProvider>
+      <CompoundLensInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/webui-v2/src/components/compound-topology/CrossLinkedTopology.tsx
+++ b/webui-v2/src/components/compound-topology/CrossLinkedTopology.tsx
@@ -1,0 +1,144 @@
+/* ============================================================
+   components/compound-topology/CrossLinkedTopology.tsx
+
+   Model 2 of the compound-topology epic (#4810) — "cross-linked lenses".
+
+   Two compound-topology canvases side-by-side:
+     - LEFT  = Infra lens   (cloud → vpc/cluster → service, from IaC).
+     - RIGHT = Code lens     (repo → module nesting).
+
+   Both render the SAME entities (the compound payload returns one node set per
+   group_by; only the zone hierarchy changes). Selecting a node in EITHER lens
+   highlights its counterpart in the OTHER:
+     - the SAME entity (identity cross-link — real, the node id is shared), and
+     - any entity joined by a real typed edge (e.g. a service that READS a
+       datastore), and
+     - the containing zone boxes in the other lens, so you can see WHERE the
+       counterpart lives in that hierarchy.
+
+   The cross-link math is the pure, tested `computeCrossLink` helper. Styling
+   matches Model 1 (#4866 zones, #4887 centered handles, ELK layout).
+   ============================================================ */
+
+import { useMemo, useState } from "react";
+import { Cloud, Boxes, Link2, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useCompoundTopology } from "@/hooks/use-topology";
+import { CompoundLens } from "./CompoundLens";
+import { computeCrossLink } from "./crossLink";
+
+interface CrossLinkedTopologyProps {
+  groupId: string;
+  className?: string;
+}
+
+export function CrossLinkedTopology({ groupId, className }: CrossLinkedTopologyProps) {
+  // Shared selection across both lenses (a node id, or null).
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // We need BOTH payloads here (not just inside each lens) to compute the
+  // cross-link — these queries are shared/cached with the lens' own useQuery,
+  // so this is not a duplicate fetch.
+  const { data: infra } = useCompoundTopology(groupId, "infra");
+  const { data: modules } = useCompoundTopology(groupId, "modules");
+
+  const cross = useMemo(
+    () => computeCrossLink(selectedId, infra, modules),
+    [selectedId, infra, modules],
+  );
+
+  // Human-readable label for the selection banner.
+  const selectedLabel = useMemo(() => {
+    if (!selectedId) return null;
+    const n =
+      (infra?.nodes ?? []).find((x) => x.id === selectedId) ??
+      (modules?.nodes ?? []).find((x) => x.id === selectedId);
+    return n?.label ?? selectedId;
+  }, [selectedId, infra, modules]);
+
+  // Count of edge-linked counterparts (same in both lenses) for the banner.
+  const linkedCount = useMemo(() => {
+    if (!selectedId) return 0;
+    let c = 0;
+    for (const hl of cross.infra.nodes.values()) if (hl === "linked") c++;
+    return c;
+  }, [cross, selectedId]);
+
+  return (
+    <div className={cn("flex h-full min-h-0 flex-col", className)}>
+      {/* Cross-link banner */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface px-3 py-2 text-xs">
+        <Link2 size={13} className="text-accent" />
+        <span className="font-medium text-text-2">Cross-linked lenses</span>
+        <span className="text-text-4">
+          select a node in either lens to highlight its counterpart in the other
+        </span>
+        {selectedId && (
+          <div className="ml-auto flex items-center gap-2">
+            <span className="rounded-full bg-accent/15 px-2 py-0.5 text-accent">
+              {selectedLabel}
+            </span>
+            <span className="text-text-4 tabular-nums">
+              {linkedCount} edge-linked{linkedCount === 1 ? " counterpart" : " counterparts"}
+            </span>
+            <button
+              type="button"
+              onClick={() => setSelectedId(null)}
+              className="inline-flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-text-3 hover:bg-surface-2"
+              title="Clear selection"
+            >
+              <X size={11} /> clear
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Two lenses */}
+      <div className="flex min-h-0 flex-1 divide-x divide-border">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-1.5 border-b border-border bg-surface-2 px-3 py-1.5 text-[11px] font-medium text-text-2">
+            <Cloud size={12} className="text-info" /> Infra
+            <span className="text-text-4">cloud · network · service</span>
+          </div>
+          <CompoundLens
+            groupId={groupId}
+            groupBy="infra"
+            highlight={cross.infra}
+            selectedId={selectedId}
+            onSelectNode={setSelectedId}
+            className="flex-1"
+          />
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-1.5 border-b border-border bg-surface-2 px-3 py-1.5 text-[11px] font-medium text-text-2">
+            <Boxes size={12} className="text-accent" /> Code / Modules
+            <span className="text-text-4">repo · module</span>
+          </div>
+          <CompoundLens
+            groupId={groupId}
+            groupBy="modules"
+            highlight={cross.modules}
+            selectedId={selectedId}
+            onSelectNode={setSelectedId}
+            className="flex-1"
+          />
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-3 border-t border-border bg-surface px-3 py-1.5 text-[10px] text-text-4">
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block size-2.5 rounded-sm border-2" style={{ borderColor: "var(--accent)" }} />
+          same entity (identity cross-link)
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block size-2.5 rounded-sm border-2" style={{ borderColor: "var(--info)" }} />
+          linked by a typed edge (reads/writes/invokes…)
+        </span>
+        <span className="text-text-4">
+          links are real graph data (shared node identity + typed edges) — none inferred
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/webui-v2/src/components/compound-topology/crossLink.test.ts
+++ b/webui-v2/src/components/compound-topology/crossLink.test.ts
@@ -1,0 +1,108 @@
+/* crossLink.test.ts — Model 2 (#4810) cross-lens highlight mapping.
+
+   Verifies the identity cross-link (same node id across the infra/modules
+   lenses), the typed-edge "linked" counterparts, and zone-ancestor promotion
+   in each lens. The infra and modules payloads share the SAME node ids — only
+   the zone_path differs per lens — which is exactly the real data the live
+   compound endpoint returns. */
+
+import { describe, it, expect } from "vitest";
+import { computeCrossLink } from "./crossLink";
+import type { CompoundTopologyResponse } from "@/data/types";
+
+// Shared edges (identical across lenses): svc reads db, ep invokes svc.
+const EDGES: CompoundTopologyResponse["edges"] = [
+  { source: "api::svc", target: "api::db", type: "reads", label: "reads", agg_key: "reads api::svc api::db" },
+  { source: "api::ep", target: "api::svc", type: "invokes", label: "invokes", agg_key: "invokes api::ep api::svc" },
+];
+
+// INFRA lens: db sits inside a cloud→service zone; svc/ep fall back to repo.
+function infra(): CompoundTopologyResponse {
+  return {
+    group_by: "infra",
+    tiers: ["client", "edge", "auth", "compute", "data", "messaging", "external"],
+    zones: [
+      { id: "cloud:aws", label: "aws", kind: "cloud", node_count: 1 },
+      { id: "infra:aws:data", label: "data", parent_id: "cloud:aws", kind: "service", node_count: 1 },
+      { id: "repo:api", label: "api", kind: "repo", node_count: 2 },
+    ],
+    nodes: [
+      { id: "api::db", label: "db", kind: "Datastore", tier: "data", repo: "api", zone_path: ["cloud:aws", "infra:aws:data"] },
+      { id: "api::svc", label: "Svc", kind: "Service", tier: "compute", repo: "api", zone_path: ["repo:api"] },
+      { id: "api::ep", label: "GET /x", kind: "HTTPEndpoint", tier: "edge", repo: "api", zone_path: ["repo:api"] },
+    ],
+    edges: EDGES,
+  };
+}
+
+// MODULES lens: SAME node ids, nested by code path instead.
+function modules(): CompoundTopologyResponse {
+  return {
+    group_by: "modules",
+    tiers: ["client", "edge", "auth", "compute", "data", "messaging", "external"],
+    zones: [
+      { id: "repo:api", label: "api", kind: "repo", node_count: 3 },
+      { id: "mod:api/svc", label: "svc", parent_id: "repo:api", kind: "module", node_count: 2 },
+    ],
+    nodes: [
+      { id: "api::db", label: "db", kind: "Datastore", tier: "data", repo: "api", zone_path: ["repo:api", "mod:api/svc"] },
+      { id: "api::svc", label: "Svc", kind: "Service", tier: "compute", repo: "api", zone_path: ["repo:api", "mod:api/svc"] },
+      { id: "api::ep", label: "GET /x", kind: "HTTPEndpoint", tier: "edge", repo: "api", zone_path: ["repo:api"] },
+    ],
+    edges: EDGES,
+  };
+}
+
+describe("computeCrossLink", () => {
+  it("returns inactive maps when nothing is selected", () => {
+    const { infra: i, modules: m } = computeCrossLink(null, infra(), modules());
+    expect(i.active).toBe(false);
+    expect(m.active).toBe(false);
+    expect(i.nodes.size).toBe(0);
+  });
+
+  it("marks the SAME entity primary in BOTH lenses (identity cross-link)", () => {
+    const { infra: i, modules: m } = computeCrossLink("api::db", infra(), modules());
+    expect(i.active).toBe(true);
+    expect(i.nodes.get("api::db")).toBe("primary");
+    expect(m.nodes.get("api::db")).toBe("primary"); // same id, other lens
+  });
+
+  it("marks typed-edge neighbors as linked in both lenses", () => {
+    // db is read BY svc → selecting db links svc (and only svc, not ep).
+    const { infra: i, modules: m } = computeCrossLink("api::db", infra(), modules());
+    expect(i.nodes.get("api::svc")).toBe("linked");
+    expect(m.nodes.get("api::svc")).toBe("linked");
+    expect(i.nodes.get("api::ep")).toBe("none");
+  });
+
+  it("selecting a code node links the infra resources it uses", () => {
+    // svc reads db AND is invoked by ep → both are linked.
+    const { infra: i } = computeCrossLink("api::svc", infra(), modules());
+    expect(i.nodes.get("api::svc")).toBe("primary");
+    expect(i.nodes.get("api::db")).toBe("linked");
+    expect(i.nodes.get("api::ep")).toBe("linked");
+  });
+
+  it("promotes zone ancestors of highlighted nodes (shows WHERE the counterpart lives)", () => {
+    const { infra: i, modules: m } = computeCrossLink("api::db", infra(), modules());
+    // INFRA: db lives in cloud:aws → infra:aws:data, both should be primary.
+    expect(i.zones.get("cloud:aws")).toBe("primary");
+    expect(i.zones.get("infra:aws:data")).toBe("primary");
+    // MODULES: db lives in repo:api → mod:api/svc.
+    expect(m.zones.get("repo:api")).toBe("primary");
+    expect(m.zones.get("mod:api/svc")).toBe("primary");
+  });
+
+  it("primary outranks linked when a zone holds both", () => {
+    // In modules, repo:api holds db(primary) + svc(linked) → primary wins.
+    const { modules: m } = computeCrossLink("api::db", infra(), modules());
+    expect(m.zones.get("repo:api")).toBe("primary");
+  });
+
+  it("ignores a selection id absent from both payloads", () => {
+    const { infra: i, modules: m } = computeCrossLink("ghost::x", infra(), modules());
+    expect(i.active).toBe(false);
+    expect(m.active).toBe(false);
+  });
+});

--- a/webui-v2/src/components/compound-topology/crossLink.ts
+++ b/webui-v2/src/components/compound-topology/crossLink.ts
@@ -1,0 +1,142 @@
+/* ============================================================
+   components/compound-topology/crossLink.ts
+
+   Model 2 of the compound-topology epic (#4810) — "cross-linked lenses".
+
+   The compound payload (topology_compound.go) returns the SAME node set for
+   every `group_by`; only each node's `zone_path` changes per lens. That makes
+   the cross-link between the infra lens and the code/modules lens REAL, not
+   inferred: a node selected in one lens is the *same entity* in the other —
+   we just light up where it lives in the other hierarchy.
+
+   On top of that identity link we add a second REAL link: the typed edges
+   (reads/writes/invokes/consumes/routes/depends) that already join code
+   entities to the IaC resources (datastores/queues/functions) they use. So
+   selecting a code module also highlights the infra resources it talks to, and
+   selecting an infra resource highlights the code that uses it.
+
+   This module is pure (no React / DOM) so the mapping is unit-testable.
+   ============================================================ */
+
+import type {
+  CompoundTopologyResponse,
+  CompoundNode,
+  CompoundEdge,
+} from "@/data/types";
+import type { CTHighlight } from "./layout";
+
+/** The cross-link result for ONE lens, keyed by node id and zone id. */
+export interface CrossLinkHighlight {
+  /** Per-node highlight state for this lens. */
+  nodes: Map<string, CTHighlight>;
+  /** Per-zone highlight state for this lens (a zone that contains a counterpart). */
+  zones: Map<string, CTHighlight>;
+  /** True when there is anything to highlight (a selection is active). */
+  active: boolean;
+}
+
+const EMPTY: CrossLinkHighlight = {
+  nodes: new Map(),
+  zones: new Map(),
+  active: false,
+};
+
+/** A node id that exists in BOTH payloads is a real identity cross-link. */
+function indexNodeIds(data: CompoundTopologyResponse | undefined): Set<string> {
+  const s = new Set<string>();
+  for (const n of data?.nodes ?? []) s.add(n.id);
+  return s;
+}
+
+/**
+ * neighborsOf returns the set of node ids joined to `id` by any typed edge in
+ * `edges`, in either direction. These are REAL relationship edges (e.g. a
+ * service that READS a datastore) — the cross-lens "linked" counterparts.
+ */
+function neighborsOf(id: string, edges: CompoundEdge[]): Set<string> {
+  const out = new Set<string>();
+  for (const e of edges) {
+    if (e.source === id) out.add(e.target);
+    else if (e.target === id) out.add(e.source);
+  }
+  return out;
+}
+
+/**
+ * Promote each highlighted node's zone ancestors so the containing boxes in the
+ * other lens light up too — that is the whole point of Model 2: see WHERE the
+ * counterpart sits in the other hierarchy. "primary" wins over "linked".
+ */
+function highlightZones(
+  nodeHL: Map<string, CTHighlight>,
+  nodeIndex: Map<string, CompoundNode>,
+): Map<string, CTHighlight> {
+  const zones = new Map<string, CTHighlight>();
+  for (const [nodeId, hl] of nodeHL) {
+    if (hl === "none") continue;
+    const n = nodeIndex.get(nodeId);
+    if (!n) continue;
+    for (const zid of n.zone_path) {
+      const cur = zones.get(zid);
+      // primary outranks linked.
+      if (cur === "primary") continue;
+      zones.set(zid, hl === "primary" ? "primary" : "linked");
+    }
+  }
+  return zones;
+}
+
+/**
+ * computeCrossLink builds the highlight maps for BOTH lenses given the node
+ * selected in `selectedLens`.
+ *
+ *   - In the SELECTED lens: the selected node is "primary"; its edge-neighbors
+ *     are "linked"; everything else "none".
+ *   - In the OTHER lens: the same node id (if present — it almost always is,
+ *     since both lenses share the node set) is "primary"; its edge-neighbors
+ *     are "linked"; everything else "none". Zone ancestors of any highlighted
+ *     node are lit so the containing boxes read.
+ *
+ * Returns `{ infra, modules }`. When nothing is selected both are EMPTY.
+ */
+export function computeCrossLink(
+  selectedId: string | null,
+  infra: CompoundTopologyResponse | undefined,
+  modules: CompoundTopologyResponse | undefined,
+): { infra: CrossLinkHighlight; modules: CrossLinkHighlight } {
+  if (!selectedId) return { infra: EMPTY, modules: EMPTY };
+
+  const infraIds = indexNodeIds(infra);
+  const moduleIds = indexNodeIds(modules);
+  // The selected id must exist in at least one lens to be meaningful.
+  if (!infraIds.has(selectedId) && !moduleIds.has(selectedId)) {
+    return { infra: EMPTY, modules: EMPTY };
+  }
+
+  // Edge-neighbors are identical across lenses (edges don't change per lens),
+  // so compute once from whichever payload is present.
+  const edges = infra?.edges ?? modules?.edges ?? [];
+  const neighbors = neighborsOf(selectedId, edges);
+
+  function forLens(
+    data: CompoundTopologyResponse | undefined,
+    ids: Set<string>,
+  ): CrossLinkHighlight {
+    const nodes = new Map<string, CTHighlight>();
+    for (const id of ids) {
+      if (id === selectedId) nodes.set(id, "primary");
+      else if (neighbors.has(id)) nodes.set(id, "linked");
+      else nodes.set(id, "none");
+    }
+    const nodeIndex = new Map<string, CompoundNode>(
+      (data?.nodes ?? []).map((n) => [n.id, n] as const),
+    );
+    const zones = highlightZones(nodes, nodeIndex);
+    return { nodes, zones, active: true };
+  }
+
+  return {
+    infra: forLens(infra, infraIds),
+    modules: forLens(modules, moduleIds),
+  };
+}

--- a/webui-v2/src/components/compound-topology/index.ts
+++ b/webui-v2/src/components/compound-topology/index.ts
@@ -1,4 +1,8 @@
 export { CompoundTopology } from "./CompoundTopology";
+export { CompoundLens } from "./CompoundLens";
+export { CrossLinkedTopology } from "./CrossLinkedTopology";
+export { computeCrossLink } from "./crossLink";
+export type { CrossLinkHighlight } from "./crossLink";
 export {
   layoutCompoundTopology,
   TIER_ORDER,

--- a/webui-v2/src/components/compound-topology/layout.ts
+++ b/webui-v2/src/components/compound-topology/layout.ts
@@ -83,11 +83,25 @@ export const TIER_ORDER: CompoundTier[] = [
   "external",
 ];
 
+/**
+ * Cross-link highlight state for a node/zone (Model 2, #4810). When a node is
+ * selected in one lens, its counterpart(s) in the other lens are tinted:
+ *   - "primary" — the same entity (identity cross-link, the strongest link).
+ *   - "linked"  — an entity joined to the selection by a real typed edge.
+ *   - "none"    — not part of the current cross-link set (rendered dimmed when
+ *                 any selection is active).
+ */
+export type CTHighlight = "primary" | "linked" | "none";
+
 export interface CTNodeData {
   label: string;
   kind: string;
   tier: CompoundTier;
   repo: string;
+  /** Cross-link highlight state (Model 2). Undefined ⇒ no selection active. */
+  highlight?: CTHighlight;
+  /** True when a selection is active anywhere (drives dimming of "none"). */
+  dimmed?: boolean;
   [key: string]: unknown;
 }
 
@@ -106,6 +120,11 @@ export interface CTZoneData {
   depth: number;
   /** Toggles collapse for this zone id. */
   onToggle: (zoneId: string) => void;
+  /** Cross-link highlight state (Model 2) — set when this zone contains the
+   *  cross-linked counterpart of the node selected in the other lens. */
+  highlight?: CTHighlight;
+  /** True when a selection is active anywhere (drives dimming of "none"). */
+  dimmed?: boolean;
   [key: string]: unknown;
 }
 

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -22,6 +22,7 @@ import {
   LayoutList,
   ArrowUpRight,
   Network as NetworkIcon,
+  Link2 as Link2Icon,
 } from "lucide-react";
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -33,7 +34,7 @@ import type { InsightValue } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
-import { CompoundTopology } from "@/components/compound-topology";
+import { CompoundTopology, CrossLinkedTopology } from "@/components/compound-topology";
 import {
   useTopology,
   useTopologyDetail,
@@ -1731,7 +1732,7 @@ export default function TopologyScreen() {
     | "scheduled";
   const channelParam = searchParams.get("channel");
 
-  const [viewMode, setViewMode] = useState<"map" | "list" | "arch">("map");
+  const [viewMode, setViewMode] = useState<"map" | "list" | "arch" | "crosslink">("map");
   const [search, setSearch] = useState("");
   const [activeBrokers, setActiveBrokers] = useState<Set<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(channelParam);
@@ -2060,11 +2061,32 @@ export default function TopologyScreen() {
                 <NetworkIcon size={13} />
                 Architecture
               </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("crosslink")}
+                className={cn(
+                  "inline-flex items-center gap-1 px-2.5 h-7 text-xs border-l border-border transition-colors",
+                  viewMode === "crosslink"
+                    ? "bg-surface-2 text-text"
+                    : "text-text-3 hover:bg-surface",
+                )}
+                aria-pressed={viewMode === "crosslink"}
+                title="Cross-linked lenses — select a node to highlight its infra↔code counterpart (Model 2)"
+              >
+                <Link2Icon size={13} />
+                Cross-link
+              </button>
             </div>
           </div>
 
           {/* Workspace */}
-          {viewMode === "arch" ? (
+          {viewMode === "crosslink" ? (
+            /* Cross-linked lenses (Model 2, #4810) — Infra | Code side-by-side;
+               select a node to highlight its counterpart in the other lens. */
+            <div className="flex flex-1 min-h-0">
+              <CrossLinkedTopology groupId={groupId} className="flex-1 min-w-0" />
+            </div>
+          ) : viewMode === "arch" ? (
             /* Architecture diagram (Model 1, #4810/#4811) — compound zones +
                tier lanes + collapsible zones, independent of the broker
                channel filters above. Takes the full canvas. */


### PR DESCRIPTION
## Topology Model 2 — cross-linked lenses (#4810)

Model 1 (compound "Architecture" view) shipped; this adds **Model 2**: select a node in one lens, highlight its counterpart in the other.

### What backs the cross-links (real vs inferred)
**All links are REAL graph data — nothing is faked.** Two sources:
1. **Shared node identity (real).** `topology_compound.go` returns the *same* node set for every `group_by`; only `zone_path` changes per lens. So an entity that appears in both lenses is the same id → a true identity cross-link. The frontend fetches both the `infra` and `modules` payloads (shared/cached with each lens' own query — not a duplicate fetch) and maps the selected id across.
2. **Typed usage edges (real).** `reads/writes/invokes/consumes/routes/depends` edges (READS_FROM, WRITES_TO, ACCESSES_TABLE, FETCHES, CALLS, …) already join code entities to the IaC resources they use. Selecting a node also highlights its edge-neighbors.

A selected node's **zone ancestors** in the other lens are promoted too, so you can see WHERE the counterpart lives in that hierarchy.

### The two-lens + select-to-highlight interaction
- New **"Cross-link"** view-mode button on the Topology screen (alongside Map / List / Architecture).
- **Two canvases side-by-side**: LEFT = **Infra** (cloud→vpc/cluster→service), RIGHT = **Code/Modules** (repo→module). Both reuse Model 1's `group_by` payloads, ELK layout, #4866 zone styling, #4887 handles.
- **Shared selection**: click a node in either lens → it becomes `primary` (accent ring) in both, its edge-linked counterparts become `linked` (info ring), everything else dims; containing zones light up. Click pane / *clear* to reset. A banner shows the selection + edge-linked counterpart count + a legend stating links are real, none inferred.

### Backend data ticket filed
**#4983** — the graph has **no explicit infra↔code DEPLOYMENT edge** (no DEPLOYS/RUNS_ON/HOSTS; only CONTAINS + usage edges). So Model 2 covers code↔datastore *usage* and identity, but cannot yet cross-link *"this ECS service RUNS this code service"*. Ticket asks for derived RUNS/DEPLOYS/BACKED_BY edges (with an `inferred` flag) to enrich Models 2/3. **No fake deployment links were added.**

### Gates
- `npx tsc --noEmit` clean
- `npm run build` ✓
- `npx vitest run` — **172 unit tests pass** (incl. 7 new `crossLink.test.ts` covering identity link, edge-linked counterparts, zone-ancestor promotion, primary>linked precedence, and absent-id no-op). The ~12 e2e Playwright specs fail to collect under vitest as pre-existing.

Frontend-only, deploy-deferred. Part of #4810; **Model 3** (unified interleaved infra+code diagram) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)