### PR TITLE
feat(#4810): Topology Model 3 — unified infra+code architecture diagram

### DIFF
--- a/webui-v2/src/components/compound-topology/CTEdge.tsx
+++ b/webui-v2/src/components/compound-topology/CTEdge.tsx
@@ -42,6 +42,10 @@ function CTEdgeImpl({
     });
   }
   const stroke = edgeStroke(d.type);
+  // Unified diagram (Model 3, #4810): a real code↔infra usage edge (e.g. a
+  // service that WRITES a queue) is drawn thicker/fully-opaque so the
+  // code-to-infra wiring stands out from intra-layer edges.
+  const cross = d.crossBoundary === true;
 
   return (
     <>
@@ -51,8 +55,9 @@ function CTEdgeImpl({
         markerEnd={markerEnd}
         style={{
           stroke,
-          strokeWidth: d.summary ? 2 : 1.25,
+          strokeWidth: cross ? 2.25 : d.summary ? 2 : 1.25,
           strokeDasharray: d.summary ? "6 3" : undefined,
+          opacity: cross ? 1 : 0.9,
         }}
       />
       <EdgeLabelRenderer>

--- a/webui-v2/src/components/compound-topology/CTNode.tsx
+++ b/webui-v2/src/components/compound-topology/CTNode.tsx
@@ -2,6 +2,7 @@
 
 import { memo } from "react";
 import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Database, Box } from "lucide-react";
 import type { CTNodeData } from "./layout";
 import { tierStyle } from "./tierStyle";
 
@@ -18,14 +19,28 @@ function CTNodeImpl({ data }: NodeProps) {
   const dim = d.dimmed && hl === "none";
   const borderColor = isPrimary ? "var(--accent)" : isLinked ? "var(--info)" : s.color;
 
+  // Unified diagram (Model 3, #4810): infra resources read differently from
+  // code entities so the single interleaved canvas stays legible. Infra nodes
+  // get a heavier left rail + a datastore glyph and a slightly more "panel"
+  // shape; code nodes keep the rounded card. Undefined outside the unified view
+  // (no visual change there).
+  const cls = d.nodeClass;
+  const isInfra = cls === "infra";
+  const isCode = cls === "code";
+  const ClassIcon = isInfra ? Database : isCode ? Box : null;
+  const shapeClass = isInfra ? "rounded-sm" : "rounded-md";
+
   return (
     <div
-      className="flex h-full w-full flex-col justify-center rounded-md border px-2.5 py-1 transition-opacity"
+      className={`flex h-full w-full flex-col justify-center border px-2.5 py-1 transition-opacity ${shapeClass}`}
       style={{
         borderColor,
         borderWidth: isPrimary || isLinked ? 2 : 1,
         background: s.tint,
         opacity: dim ? 0.28 : 1,
+        // Infra resources carry a solid left rail so they read as "a deployed
+        // thing" vs code; code keeps a flush card.
+        borderLeftWidth: isInfra ? 4 : isPrimary || isLinked ? 2 : 1,
         boxShadow: isPrimary
           ? "0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent)"
           : isLinked
@@ -33,14 +48,17 @@ function CTNodeImpl({ data }: NodeProps) {
             : undefined,
       }}
       title={`${d.label} · ${d.kind} · ${s.label}${d.repo ? ` · ${d.repo}` : ""}${
-        isPrimary ? " · cross-linked (same entity)" : isLinked ? " · linked by edge" : ""
-      }`}
+        cls ? ` · ${cls === "infra" ? "infra resource" : "code"}` : ""
+      }${isPrimary ? " · cross-linked (same entity)" : isLinked ? " · linked by edge" : ""}`}
     >
       <Handle type="target" position={Position.Left} className="!h-1.5 !w-1.5 !border-0 !bg-text-4" />
-      <span className="truncate text-[11px] font-medium text-text" style={{ color: s.color }}>
-        {d.label || d.kind}
+      <span className="flex items-center gap-1 truncate text-[11px] font-medium" style={{ color: s.color }}>
+        {ClassIcon && <ClassIcon size={10} className="shrink-0" />}
+        <span className="truncate">{d.label || d.kind}</span>
       </span>
-      <span className="truncate text-[9px] uppercase tracking-wide text-text-4">{d.kind}</span>
+      <span className="truncate text-[9px] uppercase tracking-wide text-text-4">
+        {isInfra ? "infra · " : isCode ? "code · " : ""}{d.kind}
+      </span>
       <Handle type="source" position={Position.Right} className="!h-1.5 !w-1.5 !border-0 !bg-text-4" />
     </div>
   );

--- a/webui-v2/src/components/compound-topology/UnifiedTopology.tsx
+++ b/webui-v2/src/components/compound-topology/UnifiedTopology.tsx
@@ -1,0 +1,251 @@
+/* ============================================================
+   components/compound-topology/UnifiedTopology.tsx
+
+   Model 3 of the compound-topology epic (#4810) — the "unified infra+code
+   architecture diagram". A SINGLE compound canvas that interleaves infra
+   resources AND code modules/services together (vs Model 2's two side-by-side
+   lenses).
+
+   How the unification is real (no synthesised links):
+
+     - We render the INFRA lens payload (group_by=infra). That payload already
+       places EVERY entity — IaC resources and the code that uses them — inside
+       ONE infra containment hierarchy (cloud → network → service, with code
+       nested where it belongs). So the interleaving is already in the graph; we
+       draw it as a single picture instead of two.
+
+     - Each leaf node is classified infra vs code (unify.ts, derived from
+       kind→tier) and rendered with a distinct glyph/shape so the two layers are
+       legible — the TEAM-reference architecture-diagram style.
+
+     - The typed usage edges that CROSS the code↔infra boundary (service →
+       writes → queue, module → reads → table) are the REAL cross-links Model 2
+       surfaced. Here they're drawn with emphasis so you SEE the wiring.
+
+   Reuses the Model-1/2 foundation untouched: the ELK compound layout, #4866
+   zone styling, #4887 centered handles, and the CTNode/CTZone/CTEdge renderers.
+
+   Limitation (honest): backend DEPLOYS/RUNS_ON deployment edges are missing
+   (#4983), so the only cross-layer links shown are the real usage edges
+   (reads/writes/invokes/consumes/routes/depends). We never fabricate deployment
+   placement — when there are no cross-boundary edges the legend says so.
+   ============================================================ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge,
+  type NodeTypes,
+  type EdgeTypes,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { Boxes, Database, Box, Link2, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useCompoundTopology } from "@/hooks/use-topology";
+import {
+  layoutCompoundTopology,
+  layoutCompoundTopologyElk,
+  defaultLayoutEngine,
+  CT_NODE_TYPE,
+  CT_ZONE_TYPE,
+  CT_EDGE_TYPE,
+  type CTLayoutResult,
+} from "./layout";
+import { classifyNodes, isCrossBoundary, unifiedStats } from "./unify";
+import { CTNode } from "./CTNode";
+import { CTZone } from "./CTZone";
+import { CTEdge } from "./CTEdge";
+
+const nodeTypes: NodeTypes = {
+  [CT_NODE_TYPE]: CTNode,
+  [CT_ZONE_TYPE]: CTZone,
+};
+const edgeTypes: EdgeTypes = { [CT_EDGE_TYPE]: CTEdge };
+
+interface UnifiedTopologyProps {
+  groupId: string;
+  className?: string;
+}
+
+function UnifiedTopologyInner({ groupId, className }: UnifiedTopologyProps) {
+  // Per-zone collapse set.
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const onToggle = useCallback((zoneId: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(zoneId)) next.delete(zoneId);
+      else next.add(zoneId);
+      return next;
+    });
+  }, []);
+
+  // The infra lens already interleaves code + infra in one containment tree.
+  const { data, isLoading, isError } = useCompoundTopology(groupId, "infra");
+
+  const engine = useMemo(() => defaultLayoutEngine(), []);
+  const EMPTY: CTLayoutResult = useMemo(
+    () => ({ nodes: [], edges: [], capped: false, summaryEdgeCount: 0 }),
+    [],
+  );
+
+  const dagreResult = useMemo(
+    () => (engine === "dagre" ? layoutCompoundTopology(data, collapsed, onToggle) : EMPTY),
+    [engine, data, collapsed, onToggle, EMPTY],
+  );
+
+  const [elkResult, setElkResult] = useState<CTLayoutResult>(EMPTY);
+  const [elkLaidOut, setElkLaidOut] = useState(false);
+  const elkRunId = useRef(0);
+  useEffect(() => {
+    if (engine !== "elk") return;
+    const myRun = ++elkRunId.current;
+    let cancelled = false;
+    setElkLaidOut(false);
+    layoutCompoundTopologyElk(data, collapsed, onToggle)
+      .then((res) => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        setElkResult(res);
+        setElkLaidOut(true);
+      })
+      .catch(() => {
+        if (cancelled || myRun !== elkRunId.current) return;
+        setElkResult(layoutCompoundTopology(data, collapsed, onToggle));
+        setElkLaidOut(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [engine, data, collapsed, onToggle]);
+
+  const base = engine === "dagre" ? dagreResult : elkResult;
+  const layingOut = engine === "elk" && !elkLaidOut;
+
+  // Classify the WHOLE node set (independent of collapse) so stats + edge
+  // boundary detection are stable.
+  const classes = useMemo(() => classifyNodes(data?.nodes), [data]);
+  const stats = useMemo(() => unifiedStats(data?.nodes, data?.edges), [data]);
+
+  // Stamp the unified node class onto each rendered leaf node so CTNode draws
+  // the infra/code distinction. Zone boxes are untouched. Positions untouched.
+  const nodes: Node[] = useMemo(() => {
+    return base.nodes.map((n) => {
+      if (n.type !== CT_NODE_TYPE) return n;
+      return { ...n, data: { ...n.data, nodeClass: classes.get(n.id) } };
+    });
+  }, [base.nodes, classes]);
+
+  // Stamp the cross-boundary flag onto each rendered edge so CTEdge emphasises
+  // real code↔infra usage links. A summary edge (collapsed zone) endpoint is a
+  // zone id, not a node id — those won't be in `classes`, so they read as
+  // intra-layer, which is correct (we can't assert a boundary we can't see).
+  const edges: Edge[] = useMemo(() => {
+    return base.edges.map((e) => {
+      const cross = isCrossBoundary(
+        { source: e.source, target: e.target },
+        classes,
+      );
+      return { ...e, data: { ...e.data, crossBoundary: cross } };
+    });
+  }, [base.edges, classes]);
+
+  const noCrossLinks = !layingOut && nodes.length > 0 && stats.crossEdges === 0;
+
+  return (
+    <div className={cn("flex h-full min-h-0 flex-col", className)}>
+      {/* Header / banner */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface px-3 py-2 text-xs">
+        <Boxes size={13} className="text-accent" />
+        <span className="font-medium text-text-2">Unified architecture</span>
+        <span className="text-text-4">
+          infra resources and the code that uses them, in one diagram
+        </span>
+        <div className="ml-auto flex items-center gap-3 text-text-4 tabular-nums">
+          <span className="inline-flex items-center gap-1">
+            <Database size={11} className="text-success" /> {stats.infraNodes} infra
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Box size={11} className="text-accent" /> {stats.codeNodes} code
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Link2 size={11} className="text-info" /> {stats.crossEdges} code↔infra link
+            {stats.crossEdges === 1 ? "" : "s"}
+          </span>
+        </div>
+      </div>
+
+      {/* Canvas */}
+      <div className="relative min-h-0 flex-1">
+        {isLoading || layingOut ? (
+          <div className="flex h-full items-center justify-center text-sm text-text-4">
+            {isLoading ? "Loading…" : "Laying out…"}
+          </div>
+        ) : isError ? (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+            <p className="text-md font-semibold text-text">Couldn&apos;t load topology</p>
+            <p className="text-sm text-text-3">Make sure the daemon is running.</p>
+          </div>
+        ) : nodes.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-text-4">
+            No architecturally-significant nodes.
+          </div>
+        ) : (
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
+            fitView
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable
+            proOptions={{ hideAttribution: true }}
+            minZoom={0.08}
+            fitViewOptions={{ padding: 0.16 }}
+          >
+            <Background gap={18} size={1} color="var(--border)" />
+            <Controls showInteractive={false} />
+            <MiniMap pannable zoomable className="!border !border-border !bg-surface" />
+          </ReactFlow>
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="flex flex-wrap items-center gap-3 border-t border-border bg-surface px-3 py-1.5 text-[10px] text-text-4">
+        <span className="inline-flex items-center gap-1">
+          <Database size={11} className="text-success" /> infra resource (datastore · queue · function · network…)
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <Box size={11} className="text-accent" /> code (module · service · endpoint…)
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <span className="inline-block h-0.5 w-4" style={{ background: "var(--info)" }} />
+          code↔infra usage edge (reads/writes/invokes…) — real graph data, none inferred
+        </span>
+        {noCrossLinks ? (
+          <span className="inline-flex items-center gap-1 text-warning">
+            <AlertTriangle size={11} />
+            no code↔infra usage edges in this graph; deployment links (DEPLOYS/RUNS_ON) are not yet extracted (#4983)
+          </span>
+        ) : (
+          <span className="text-text-4">
+            deployment links (DEPLOYS/RUNS_ON) not yet extracted (#4983) — only real usage edges are drawn
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Model-3 unified infra+code architecture diagram, wrapped in a provider. */
+export function UnifiedTopology(props: UnifiedTopologyProps) {
+  return (
+    <ReactFlowProvider>
+      <UnifiedTopologyInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/webui-v2/src/components/compound-topology/index.ts
+++ b/webui-v2/src/components/compound-topology/index.ts
@@ -1,8 +1,11 @@
 export { CompoundTopology } from "./CompoundTopology";
 export { CompoundLens } from "./CompoundLens";
 export { CrossLinkedTopology } from "./CrossLinkedTopology";
+export { UnifiedTopology } from "./UnifiedTopology";
 export { computeCrossLink } from "./crossLink";
 export type { CrossLinkHighlight } from "./crossLink";
+export { classifyNode, classifyNodes, isCrossBoundary, unifiedStats } from "./unify";
+export type { NodeClass, UnifiedStats } from "./unify";
 export {
   layoutCompoundTopology,
   TIER_ORDER,

--- a/webui-v2/src/components/compound-topology/layout.ts
+++ b/webui-v2/src/components/compound-topology/layout.ts
@@ -102,6 +102,13 @@ export interface CTNodeData {
   highlight?: CTHighlight;
   /** True when a selection is active anywhere (drives dimming of "none"). */
   dimmed?: boolean;
+  /**
+   * Unified-diagram node class (Model 3, #4810): "infra" = an IaC/deployed
+   * resource, "code" = a code entity. Drives the icon/shape that visually
+   * distinguishes the two interleaved layers. Undefined outside the unified
+   * view (the other models don't differentiate).
+   */
+  nodeClass?: "infra" | "code";
   [key: string]: unknown;
 }
 
@@ -141,6 +148,13 @@ export interface CTEdgeData {
    * under the dagre fallback.
    */
   elkPoints?: ElkPoint2D[];
+  /**
+   * Unified-diagram flag (Model 3, #4810): true when this edge crosses the
+   * code↔infra boundary (e.g. a service that WRITES a queue). Drawn with
+   * emphasis so the real code-to-infra wiring stands out. Undefined outside the
+   * unified view.
+   */
+  crossBoundary?: boolean;
   [key: string]: unknown;
 }
 

--- a/webui-v2/src/components/compound-topology/unify.test.ts
+++ b/webui-v2/src/components/compound-topology/unify.test.ts
@@ -1,0 +1,116 @@
+/* unify.test.ts — Model 3 (#4810) unified infra+code classification + the real
+   code↔infra cross-boundary edge detection that powers the single interleaved
+   architecture diagram. Pure data, no React. */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyNode,
+  classifyNodes,
+  isCrossBoundary,
+  unifiedStats,
+} from "./unify";
+import type { CompoundNode, CompoundEdge } from "@/data/types";
+
+const node = (
+  id: string,
+  kind: string,
+  tier: CompoundNode["tier"],
+): CompoundNode => ({ id, label: id, kind, tier, repo: "api", zone_path: [] });
+
+describe("classifyNode", () => {
+  it("classifies IaC resource kinds as infra (provider-agnostic, substring)", () => {
+    expect(classifyNode({ kind: "Datastore", tier: "data" })).toBe("infra");
+    expect(classifyNode({ kind: "dynamodb_table", tier: "data" })).toBe("infra");
+    expect(classifyNode({ kind: "sqs_queue", tier: "messaging" })).toBe("infra");
+    expect(classifyNode({ kind: "s3_bucket", tier: "compute" })).toBe("infra");
+    expect(classifyNode({ kind: "LambdaFunction", tier: "compute" })).toBe("infra");
+    expect(classifyNode({ kind: "VPC", tier: "edge" })).toBe("infra");
+  });
+
+  it("classifies code entity kinds as code", () => {
+    expect(classifyNode({ kind: "Service", tier: "compute" })).toBe("code");
+    expect(classifyNode({ kind: "HTTPEndpoint", tier: "edge" })).toBe("code");
+    expect(classifyNode({ kind: "Module", tier: "compute" })).toBe("code");
+    expect(classifyNode({ kind: "Controller", tier: "edge" })).toBe("code");
+  });
+
+  it("falls back to tier when the kind is unrecognised", () => {
+    // data / messaging lanes are infra by tier even with a generic kind.
+    expect(classifyNode({ kind: "Thing", tier: "data" })).toBe("infra");
+    expect(classifyNode({ kind: "Thing", tier: "messaging" })).toBe("infra");
+    // everything else defaults to code.
+    expect(classifyNode({ kind: "Thing", tier: "compute" })).toBe("code");
+    expect(classifyNode({ kind: "", tier: "client" })).toBe("code");
+  });
+});
+
+describe("classifyNodes", () => {
+  it("maps every node id to its class", () => {
+    const m = classifyNodes([
+      node("db", "Datastore", "data"),
+      node("svc", "Service", "compute"),
+    ]);
+    expect(m.get("db")).toBe("infra");
+    expect(m.get("svc")).toBe("code");
+    expect(m.size).toBe(2);
+  });
+
+  it("tolerates undefined", () => {
+    expect(classifyNodes(undefined).size).toBe(0);
+  });
+});
+
+describe("isCrossBoundary", () => {
+  const classes = classifyNodes([
+    node("db", "Datastore", "data"),
+    node("q", "Queue", "messaging"),
+    node("svc", "Service", "compute"),
+  ]);
+
+  it("is true for a code→infra edge (real usage link)", () => {
+    expect(isCrossBoundary({ source: "svc", target: "db" }, classes)).toBe(true);
+    expect(isCrossBoundary({ source: "q", target: "svc" }, classes)).toBe(true);
+  });
+
+  it("is false for an intra-layer edge", () => {
+    expect(isCrossBoundary({ source: "db", target: "q" }, classes)).toBe(false);
+  });
+
+  it("is false when an endpoint is not on the canvas (e.g. a collapsed-zone id)", () => {
+    expect(isCrossBoundary({ source: "svc", target: "zone:x" }, classes)).toBe(false);
+  });
+});
+
+describe("unifiedStats", () => {
+  const nodes = [
+    node("db", "Datastore", "data"),
+    node("q", "Queue", "messaging"),
+    node("svc", "Service", "compute"),
+    node("ep", "HTTPEndpoint", "edge"),
+  ];
+  const edge = (s: string, t: string): CompoundEdge => ({
+    source: s,
+    target: t,
+    type: "reads",
+    label: "reads",
+    agg_key: `reads ${s} ${t}`,
+  });
+
+  it("counts infra/code nodes and real cross-boundary edges", () => {
+    const stats = unifiedStats(nodes, [
+      edge("svc", "db"), // cross
+      edge("svc", "q"), // cross
+      edge("ep", "svc"), // intra (code→code)
+      edge("db", "q"), // intra (infra→infra)
+    ]);
+    expect(stats.infraNodes).toBe(2);
+    expect(stats.codeNodes).toBe(2);
+    expect(stats.crossEdges).toBe(2);
+    expect(stats.totalEdges).toBe(4);
+  });
+
+  it("reports zero cross edges when the graph has no code↔infra usage links (#4983)", () => {
+    const stats = unifiedStats(nodes, [edge("ep", "svc")]);
+    expect(stats.crossEdges).toBe(0);
+  });
+});

--- a/webui-v2/src/components/compound-topology/unify.ts
+++ b/webui-v2/src/components/compound-topology/unify.ts
@@ -1,0 +1,171 @@
+/* ============================================================
+   components/compound-topology/unify.ts
+
+   Model 3 of the compound-topology epic (#4810) — the "unified infra+code
+   architecture diagram". ONE compound canvas that interleaves infra resources
+   AND code modules/services together (vs Model 2's two side-by-side lenses).
+
+   The unification is REAL, not synthesised:
+
+     - The infra lens payload (group_by=infra) already places EVERY entity —
+       both IaC resources and the code that uses them — inside ONE infra
+       containment hierarchy (cloud → network → service, with code nested where
+       it belongs). So the interleaving already exists in the graph; we render
+       it as a single canvas.
+
+     - On top of that we classify each node as `infra` (an IaC resource:
+       datastore/queue/function/network/compute…) vs `code` (a module, service,
+       endpoint, handler…). The class is derived from the node's kind first,
+       then its tier as a fallback. This is what lets us VISUALLY distinguish
+       the two layers (icon/colour/shape) so the single picture stays legible —
+       the TEAM-reference architecture-diagram style.
+
+     - We then mark the typed usage edges that CROSS the code↔infra boundary
+       (e.g. "service X writes to queue Y", "module A reads table B"). These are
+       the real cross-links — the same shared-identity + typed-usage edges
+       Model 2 surfaced — and in the unified diagram we draw them with emphasis
+       so you SEE the code-to-infra wiring at a glance.
+
+   This module is pure (no React / DOM) so the classification + edge-marking is
+   unit-testable.
+   ============================================================ */
+
+import type {
+  CompoundNode,
+  CompoundEdge,
+  CompoundTier,
+} from "@/data/types";
+
+/**
+ * A node in the unified diagram is one of two classes. `infra` = an IaC /
+ * deployed resource; `code` = a code entity (module/service/endpoint). The
+ * distinction drives the icon/colour/shape so the single canvas reads as two
+ * interleaved layers rather than an undifferentiated hairball.
+ */
+export type NodeClass = "infra" | "code";
+
+/**
+ * Kinds that are unambiguously infra resources. Provider-agnostic (matches the
+ * generic names the compound backend emits): datastore/queue/topic/function/
+ * bucket/network/cluster/cloud/gateway/load-balancer/cache/secret/… plus the
+ * IaC umbrella kinds. Matched case-insensitively as a substring so e.g.
+ * "datastore", "dynamodb_table", "sqs_queue", "s3_bucket" all classify.
+ */
+const INFRA_KIND_HINTS = [
+  "datastore",
+  "database",
+  "table",
+  "queue",
+  "topic",
+  "subject",
+  "stream",
+  "bucket",
+  "storage",
+  "cache",
+  "function",
+  "lambda",
+  "network",
+  "vpc",
+  "subnet",
+  "cluster",
+  "cloud",
+  "gateway",
+  "balancer",
+  "loadbalancer",
+  "cdn",
+  "dns",
+  "secret",
+  "resource",
+  "infra",
+  "container",
+  "pod",
+  "node_group",
+  "instance",
+  "broker",
+  "registry",
+];
+
+/**
+ * Tiers that, absent a clearer kind signal, indicate an infra resource. `data`
+ * and `messaging` lanes are datastores / queues; `edge` is gateways/CDNs.
+ * `client`/`auth`/`compute`/`external` lean code (a service, handler, SDK call).
+ */
+const INFRA_TIERS: ReadonlySet<CompoundTier> = new Set<CompoundTier>([
+  "data",
+  "messaging",
+]);
+
+/**
+ * classifyNode decides whether a node is an infra resource or a code entity.
+ * Kind wins (it is the most specific signal); tier is the fallback. Defaults to
+ * "code" so an unknown entity reads as application code rather than infra.
+ */
+export function classifyNode(node: {
+  kind: string;
+  tier: CompoundTier;
+}): NodeClass {
+  const kind = (node.kind || "").toLowerCase();
+  for (const hint of INFRA_KIND_HINTS) {
+    if (kind.includes(hint)) return "infra";
+  }
+  if (INFRA_TIERS.has(node.tier)) return "infra";
+  return "code";
+}
+
+/** A map from node id → its unified class, for the whole node set. */
+export function classifyNodes(
+  nodes: CompoundNode[] | undefined,
+): Map<string, NodeClass> {
+  const out = new Map<string, NodeClass>();
+  for (const n of nodes ?? []) out.set(n.id, classifyNode(n));
+  return out;
+}
+
+/**
+ * isCrossBoundary returns true when an edge joins a code node to an infra node
+ * (in either direction) — the real code↔infra usage links we want to emphasise
+ * in the unified diagram. Edges where the class of an endpoint is unknown
+ * (endpoint not on the canvas) are NOT cross-boundary.
+ */
+export function isCrossBoundary(
+  edge: { source: string; target: string },
+  classes: Map<string, NodeClass>,
+): boolean {
+  const s = classes.get(edge.source);
+  const t = classes.get(edge.target);
+  if (!s || !t) return false;
+  return s !== t;
+}
+
+/** Per-class counts + the number of real cross-boundary (code↔infra) edges. */
+export interface UnifiedStats {
+  infraNodes: number;
+  codeNodes: number;
+  crossEdges: number;
+  totalEdges: number;
+}
+
+/**
+ * unifiedStats summarises the interleaved diagram: how many infra vs code nodes
+ * are present and how many real cross-boundary usage edges wire them together.
+ * Drives the legend / empty-state copy. When there are zero cross-boundary
+ * edges the caller surfaces the #4983 limitation (deployment links missing).
+ */
+export function unifiedStats(
+  nodes: CompoundNode[] | undefined,
+  edges: CompoundEdge[] | undefined,
+): UnifiedStats {
+  const classes = classifyNodes(nodes);
+  let infraNodes = 0;
+  let codeNodes = 0;
+  for (const c of classes.values()) {
+    if (c === "infra") infraNodes++;
+    else codeNodes++;
+  }
+  let crossEdges = 0;
+  const all = edges ?? [];
+  for (const e of all) {
+    if (isCrossBoundary(e, classes)) crossEdges++;
+  }
+  return { infraNodes, codeNodes, crossEdges, totalEdges: all.length };
+}

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -23,6 +23,7 @@ import {
   ArrowUpRight,
   Network as NetworkIcon,
   Link2 as Link2Icon,
+  Layers as LayersIcon,
 } from "lucide-react";
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -34,7 +35,7 @@ import type { InsightValue } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import { RefLine } from "@/components/RefLine";
 import { RepoChip } from "@/lib/repo-color";
-import { CompoundTopology, CrossLinkedTopology } from "@/components/compound-topology";
+import { CompoundTopology, CrossLinkedTopology, UnifiedTopology } from "@/components/compound-topology";
 import {
   useTopology,
   useTopologyDetail,
@@ -1732,7 +1733,9 @@ export default function TopologyScreen() {
     | "scheduled";
   const channelParam = searchParams.get("channel");
 
-  const [viewMode, setViewMode] = useState<"map" | "list" | "arch" | "crosslink">("map");
+  const [viewMode, setViewMode] = useState<
+    "map" | "list" | "arch" | "crosslink" | "unified"
+  >("map");
   const [search, setSearch] = useState("");
   const [activeBrokers, setActiveBrokers] = useState<Set<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(channelParam);
@@ -2076,11 +2079,33 @@ export default function TopologyScreen() {
                 <Link2Icon size={13} />
                 Cross-link
               </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("unified")}
+                className={cn(
+                  "inline-flex items-center gap-1 px-2.5 h-7 text-xs border-l border-border transition-colors",
+                  viewMode === "unified"
+                    ? "bg-surface-2 text-text"
+                    : "text-text-3 hover:bg-surface",
+                )}
+                aria-pressed={viewMode === "unified"}
+                title="Unified diagram — infra resources and the code that uses them in one architecture picture (Model 3)"
+              >
+                <LayersIcon size={13} />
+                Unified
+              </button>
             </div>
           </div>
 
           {/* Workspace */}
-          {viewMode === "crosslink" ? (
+          {viewMode === "unified" ? (
+            /* Unified infra+code architecture diagram (Model 3, #4810) — ONE
+               compound canvas interleaving IaC resources and the code that uses
+               them, with the real code↔infra usage edges drawn. */
+            <div className="flex flex-1 min-h-0">
+              <UnifiedTopology groupId={groupId} className="flex-1 min-w-0" />
+            </div>
+          ) : viewMode === "crosslink" ? (
             /* Cross-linked lenses (Model 2, #4810) — Infra | Code side-by-side;
                select a node to highlight its counterpart in the other lens. */
             <div className="flex flex-1 min-h-0">


### PR DESCRIPTION
Model 3 of the compound-topology epic (#4810) — the **unified infra+code architecture diagram**. ONE compound canvas that interleaves infra resources AND code modules/services together (vs Model 2's two side-by-side lenses). **Completes #4810 (Models 1-3).**

## Unification approach (no fabricated links)
- Renders the **infra-lens** compound payload, which already places *every* entity — IaC resources and the code that uses them — inside one infra containment hierarchy (cloud → network → service, code nested where it belongs). The interleaving already exists in the graph; Model 3 draws it as a single picture.
- New pure, unit-tested `unify.ts` **classifies each node infra-vs-code** (kind hints first, tier fallback) so the two layers are visually distinct: infra resources get a datastore glyph + heavier left rail + panel shape; code keeps the rounded box card. Provider-agnostic (datastore/queue/function/network/… substring match).
- **Marks the typed usage edges that cross the code↔infra boundary** (a service that *writes* a queue, a module that *reads* a table) and draws them with emphasis — so you SEE the code-to-infra wiring.

## What edges are drawn
Only **real** edges: the same shared-identity + typed-usage edges (reads/writes/invokes/consumes/routes/depends) Model 2 surfaced. Cross-boundary (code↔infra) ones are emphasised; intra-layer ones are drawn normally.

## New view-mode
Adds a **"Unified"** button beside Map / List / Architecture / Cross-link. Header shows live infra/code/cross-link counts.

## Honest limitation (#4983)
Backend **DEPLOYS/RUNS_ON** deployment edges are not yet extracted, so the only cross-layer links shown are real *usage* edges — **no deployment placement is fabricated**. The legend notes this, and an empty-state warning surfaces when a graph has zero code↔infra usage edges.

## Reuses Model-1/2 foundation
ELK compound layout, #4866 zone styling, #4887 centered handles, and the `CTNode`/`CTZone`/`CTEdge` renderers — untouched except for two optional, backward-compatible data fields (`nodeClass`, `crossBoundary`).

## Gates
`npx tsc --noEmit` clean · `npm run build` passes · `npx vitest run` → **182 unit tests pass** (+10 new `unify.test.ts`); the ~12 e2e Playwright specs fail to collect under vitest, pre-existing. Frontend-only, deploy-deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)