### PR TITLE
feat(#4929): erlang OTP — supervision-tree child_spec edges + gen_server message-tag dispatch

### DIFF
--- a/internal/extractors/erlang/extractor.go
+++ b/internal/extractors/erlang/extractor.go
@@ -5,6 +5,7 @@
 //   - OTP modules (-behaviour(gen_server).)        → Subtype refined to gen_server_module / supervisor_module / application_module / otp_module; Properties["otp_behaviour"], Tags ["otp", "otp:gen_server", ...]
 //   - function clauses (name(Args) -> body.)       → Kind="SCOPE.Operation", Subtype="function" / "exported_function"
 //   - OTP callbacks (handle_call/3, init/1, ...)   → Subtype="otp_callback", Properties["otp_callback_of"]
+//   - gen_server dispatch callbacks                → Properties["otp_dispatch_tags"] + Tags ["otp_msg:<tag>", ...] (the recovered per-clause message tags)
 //   - record attributes (-record(Foo, {...}).)     → Kind="SCOPE.Component", Subtype="record"
 //   - include attributes (-include("foo.hrl").)   → IMPORTS relationships
 //
@@ -12,6 +13,7 @@
 //   - IMPORTS — every -include/-include_lib attribute
 //   - CALLS   — Module:Function and bare Function invocations inside function bodies
 //   - CONTAINS — module entity links to each exported function
+//   - SUPERVISES — supervisor module → each child module named in its init/1 child spec list
 //
 // No tree-sitter grammar for Erlang is available in smacker/go-tree-sitter.
 // This extractor uses line-oriented regex parsing, matching the Nim extractor
@@ -102,6 +104,27 @@ var (
 	behaviourRE = regexp.MustCompile(
 		`(?m)^-behaviou?r\s*\(\s*([a-z][a-zA-Z0-9_@]*)\s*\)\s*\.`,
 	)
+
+	// childSpecMapStartRE matches the `start => {Mod, Fun, Args}` MFA inside a
+	// modern map-form child spec (#{id => ..., start => {Mod, fn, []}}).
+	// Group 1: the child module atom (the M of the start MFA).
+	childSpecMapStartRE = regexp.MustCompile(
+		`start\s*=>\s*\{\s*([a-z][a-zA-Z0-9_@]*)\s*,`,
+	)
+
+	// childSpecMapIDRE captures the `id => atom` key of a map-form child spec
+	// so the SUPERVISES edge can carry the child id. Group 1: the id atom.
+	childSpecMapIDRE = regexp.MustCompile(
+		`id\s*=>\s*([a-z][a-zA-Z0-9_@]*)`,
+	)
+
+	// childSpecTupleRE matches a legacy tuple child spec head:
+	//   {Id, {M, F, A}, Restart, Shutdown, Type, Modules}
+	// Group 1: the child id atom; Group 2: the child module atom (M of the MFA).
+	// The id may be an atom; the inner {M, F, A} carries the module.
+	childSpecTupleRE = regexp.MustCompile(
+		`\{\s*([a-z][a-zA-Z0-9_@]*)\s*,\s*\{\s*([a-z][a-zA-Z0-9_@]*)\s*,`,
+	)
 )
 
 // otpCallbacks maps each OTP behaviour to the canonical callback function
@@ -180,11 +203,13 @@ type funcInfo struct {
 	startLine int
 	endLine   int
 	calls     []string // raw call targets extracted from all clauses
+	argHeads  []string // per-clause argument text (the "(...)" of each clause head)
 }
 
 // clauseMatch holds the parsed data for a single function clause head match.
 type clauseMatch struct {
 	name      string
+	args      string // the parenthesised argument text of the clause head, e.g. "({get, Key}, _From, State)"
 	line      int
 	matchEnd  int // byte offset after the '->'
 	matchByte int // byte offset of the match start
@@ -332,6 +357,7 @@ func extractErlang(src, filePath string) []types.EntityRecord {
 		line := strings.Count(src[:m[0]], "\n") + 1
 		clauses = append(clauses, clauseMatch{
 			name:      name,
+			args:      src[m[4]:m[5]], // group 2: the "(...)" arg text
 			line:      line,
 			matchEnd:  m[1],
 			matchByte: m[0],
@@ -373,6 +399,24 @@ func extractErlang(src, filePath string) []types.EntityRecord {
 			}
 			rec.Properties["otp_callback_of"] = strings.Join(bs, ",")
 			rec.Tags = append(rec.Tags, "otp_callback")
+
+			// ── message-tag dispatch ─────────────────────────────────────
+			// For the request-dispatching callbacks (handle_call/cast/info),
+			// recover the message TAG of each clause — the first pattern
+			// element of the first argument, e.g. `{get, Key}` → "get",
+			// bare `flush` → "flush". This makes per-message-tag handling
+			// distinguishable on the callback entity (and lets a caller's
+			// gen_server:call(?SERVER, {get, _}) be associated with the
+			// clause that handles tag `get`).
+			if isDispatchCallback(fi.name) {
+				tags := dispatchTags(fi.argHeads)
+				if len(tags) > 0 {
+					rec.Properties["otp_dispatch_tags"] = strings.Join(tags, ",")
+					for _, tg := range tags {
+						rec.Tags = append(rec.Tags, "otp_msg:"+tg)
+					}
+				}
+			}
 		}
 		opIdx := len(entities)
 		entities = append(entities, rec)
@@ -389,7 +433,222 @@ func extractErlang(src, filePath string) []types.EntityRecord {
 		_ = opIdx
 	}
 
+	// ── 7. Supervision-tree child_spec edges ───────────────────────────────
+	// When this module is a `supervisor`, its `init/1` returns the child spec
+	// list. Parse each child spec (modern map or legacy tuple form) and emit a
+	// SUPERVISES edge from the supervisor module entity → each child module so
+	// the supervision hierarchy is a traversable subgraph.
+	if moduleIdx >= 0 && behaviourSet["supervisor"] {
+		var initBody string
+		for _, fi := range funcs {
+			if fi.name == "init" {
+				initBody = strings.Join(fi.calls, "\n")
+				break
+			}
+		}
+		if initBody != "" {
+			for _, c := range parseChildSpecs(initBody) {
+				rel := types.RelationshipRecord{
+					ToID: c.module,
+					Kind: "SUPERVISES",
+					Properties: map[string]string{
+						"provenance": "otp_child_spec",
+					},
+				}
+				if c.id != "" {
+					rel.Properties["child_id"] = c.id
+				}
+				entities[moduleIdx].Relationships = append(
+					entities[moduleIdx].Relationships, rel)
+			}
+		}
+	}
+
 	return entities
+}
+
+// childSpec is a single supervised child recovered from a supervisor's
+// init/1 child-spec list.
+type childSpec struct {
+	id     string // the spec's id atom (empty if not recoverable)
+	module string // the child module (the M of the start MFA)
+}
+
+// isDispatchCallback reports whether a callback name is one of the gen_server /
+// gen_event request-dispatching callbacks whose first argument carries a
+// message tag worth recovering.
+func isDispatchCallback(name string) bool {
+	switch name {
+	case "handle_call", "handle_cast", "handle_info", "handle_event",
+		"handle_sync_event":
+		return true
+	}
+	return false
+}
+
+// dispatchTags recovers, in clause order and de-duplicated, the message tag of
+// each dispatch-callback clause. The tag is the first pattern element of the
+// first argument: `{get, Key}` → "get", a bare atom `flush` → "flush". Wildcard
+// catch-all clauses (`_Request`, `_Msg`, `_`) and variable first args (which
+// start uppercase or `_`) are skipped — they carry no concrete tag.
+func dispatchTags(argHeads []string) []string {
+	var tags []string
+	seen := make(map[string]bool)
+	for _, ah := range argHeads {
+		tag := firstArgTag(ah)
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		tags = append(tags, tag)
+	}
+	return tags
+}
+
+// firstArgTag extracts the message tag from a clause's parenthesised argument
+// text `(...)`. It isolates the first top-level argument, then:
+//   - `{tag, ...}` tuple  → "tag" (first element, must be a lowercase atom)
+//   - bare lowercase atom → the atom itself
+//   - variable / wildcard → "" (no concrete tag)
+func firstArgTag(argText string) string {
+	inner := strings.TrimSpace(argText)
+	inner = strings.TrimPrefix(inner, "(")
+	inner = strings.TrimSuffix(inner, ")")
+	first := splitTopLevelFirst(inner)
+	first = strings.TrimSpace(first)
+	if first == "" {
+		return ""
+	}
+	if strings.HasPrefix(first, "{") {
+		// Tuple pattern: take the first element.
+		body := strings.TrimPrefix(first, "{")
+		elem := splitTopLevelFirst(body)
+		elem = strings.TrimSpace(elem)
+		if isAtom(elem) {
+			return elem
+		}
+		return ""
+	}
+	if isAtom(first) {
+		return first
+	}
+	return ""
+}
+
+// splitTopLevelFirst returns the substring up to the first top-level comma,
+// respecting nesting of (), {}, [], <<>>. The remainder (other arguments /
+// tuple elements) is discarded.
+func splitTopLevelFirst(s string) string {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '{', '[':
+			depth++
+		case ')', '}', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				return s[:i]
+			}
+		}
+	}
+	return s
+}
+
+// isAtom reports whether s is a bare unquoted Erlang atom (lowercase start,
+// alnum/_/@ tail) and not a known keyword.
+func isAtom(s string) bool {
+	if s == "" {
+		return false
+	}
+	c := s[0]
+	if c < 'a' || c > 'z' {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		ch := s[i]
+		if !(ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' ||
+			ch >= '0' && ch <= '9' || ch == '_' || ch == '@') {
+			return false
+		}
+	}
+	return !erlangKeywords[s]
+}
+
+// parseChildSpecs scans a supervisor init/1 body for child specs and returns
+// the recovered children, de-duplicated by module (keeping the first id seen).
+// Both the modern map form (#{id => ..., start => {Mod, F, A}}) and the legacy
+// tuple form ({Id, {M, F, A}, ...}) are recognised. Comments and string/atom
+// literals are scrubbed first so MFAs inside them are not matched.
+func parseChildSpecs(body string) []childSpec {
+	scrubbed := stripCommentsAndStrings(body)
+	var out []childSpec
+	seen := make(map[string]bool)
+
+	add := func(module, id string) {
+		if module == "" || erlangKeywords[module] || seen[module] {
+			return
+		}
+		seen[module] = true
+		out = append(out, childSpec{id: id, module: module})
+	}
+
+	// Modern map form: a `#{... start => {Mod, ...}}` map. We pair each map's
+	// `start => {Mod,` with the nearest preceding `id => Atom` (if any) within
+	// the same map by scanning map starts.
+	for _, seg := range mapSegments(scrubbed) {
+		sm := childSpecMapStartRE.FindStringSubmatch(seg)
+		if sm == nil {
+			continue
+		}
+		id := ""
+		if im := childSpecMapIDRE.FindStringSubmatch(seg); im != nil {
+			id = im[1]
+		}
+		add(sm[1], id)
+	}
+
+	// Legacy tuple form: {Id, {M, F, A}, ...}.
+	for _, tm := range childSpecTupleRE.FindAllStringSubmatch(scrubbed, -1) {
+		add(tm[2], tm[1])
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].module < out[j].module })
+	return out
+}
+
+// mapSegments splits a body into the text of each `#{ ... }` map literal,
+// respecting nested braces, so each child-spec map is matched in isolation
+// (a `start =>` is paired with the `id =>` of the same map, not a sibling).
+func mapSegments(s string) []string {
+	var segs []string
+	for i := 0; i < len(s); i++ {
+		if s[i] == '#' && i+1 < len(s) && s[i+1] == '{' {
+			depth := 0
+			j := i + 1
+			for ; j < len(s); j++ {
+				switch s[j] {
+				case '{':
+					depth++
+				case '}':
+					depth--
+					if depth == 0 {
+						break
+					}
+				}
+				if depth == 0 {
+					break
+				}
+			}
+			if j < len(s) {
+				segs = append(segs, s[i:j+1])
+				i = j
+			}
+		}
+	}
+	return segs
 }
 
 // ---------------------------------------------------------------------------
@@ -455,6 +714,7 @@ func groupClauses(src string, clauses []clauseMatch) []funcInfo {
 		if acc, exists := accMap[c.name]; exists {
 			acc.fi.endLine = endLine
 			acc.fi.calls = append(acc.fi.calls, body)
+			acc.fi.argHeads = append(acc.fi.argHeads, c.args)
 		} else {
 			accMap[c.name] = &accumulator{
 				fi: funcInfo{
@@ -462,6 +722,7 @@ func groupClauses(src string, clauses []clauseMatch) []funcInfo {
 					startLine: c.line,
 					endLine:   endLine,
 					calls:     []string{body},
+					argHeads:  []string{c.args},
 				},
 				firstIdx: i,
 			}

--- a/internal/extractors/erlang/extractor_test.go
+++ b/internal/extractors/erlang/extractor_test.go
@@ -3,6 +3,7 @@ package erlang_test
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
@@ -605,6 +606,132 @@ init([]) ->
 			t.Errorf("init should be a supervisor callback, got %q", rec.Properties["otp_callback_of"])
 		}
 	}
+}
+
+// supTreeFixture is a supervisor whose init/1 returns a child spec list using
+// both the modern map form and the legacy tuple form, so the SUPERVISES edge
+// extraction is exercised against both shapes.
+const supTreeFixture = `-module(top_sup).
+-behaviour(supervisor).
+-export([start_link/0, init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{strategy => one_for_one, intensity => 5, period => 10},
+    Worker = #{id => cache_server,
+               start => {cache_server, start_link, []},
+               restart => permanent,
+               type => worker},
+    Logger = #{id => logger_srv,
+               start => {logger_srv, start_link, []}},
+    Legacy = {db_pool, {db_pool, start_link, []}, permanent, 5000, worker, [db_pool]},
+    {ok, {SupFlags, [Worker, Logger, Legacy]}}.
+`
+
+// TestErlangExtractor_SupervisionTreeEdges verifies SUPERVISES edges are
+// emitted from the supervisor module to every child module declared in its
+// init/1 child spec list, across both map and tuple spec forms.
+func TestErlangExtractor_SupervisionTreeEdges(t *testing.T) {
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "top_sup.erl",
+		Content:  []byte(supTreeFixture),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var sup bool
+	supervised := map[string]string{} // module -> child_id
+	for _, rec := range got {
+		if rec.Name == "top_sup" && rec.Kind == "SCOPE.Component" {
+			sup = true
+			for _, rel := range rec.Relationships {
+				if rel.Kind == "SUPERVISES" {
+					supervised[rel.ToID] = rel.Properties["child_id"]
+					if rel.Properties["provenance"] != "otp_child_spec" {
+						t.Errorf("SUPERVISES %s: expected provenance otp_child_spec, got %q",
+							rel.ToID, rel.Properties["provenance"])
+					}
+				}
+			}
+		}
+	}
+	if !sup {
+		t.Fatal("supervisor module top_sup not found")
+	}
+	want := map[string]string{
+		"cache_server": "cache_server",
+		"logger_srv":   "logger_srv",
+		"db_pool":      "db_pool",
+	}
+	for mod, id := range want {
+		gotID, ok := supervised[mod]
+		if !ok {
+			t.Errorf("expected SUPERVISES edge to child module %q, missing", mod)
+			continue
+		}
+		if gotID != id {
+			t.Errorf("child %q: expected child_id %q, got %q", mod, id, gotID)
+		}
+	}
+	if len(supervised) != len(want) {
+		t.Errorf("expected exactly %d SUPERVISES edges, got %d: %v",
+			len(want), len(supervised), supervised)
+	}
+}
+
+// TestErlangExtractor_MessageTagDispatch verifies per-message-tag dispatch is
+// recovered on the gen_server handle_call/handle_cast callbacks.
+func TestErlangExtractor_MessageTagDispatch(t *testing.T) {
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "cache_server.erl",
+		Content:  []byte(genServerFixture),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantTags := map[string]string{
+		"handle_call": "get",            // {get, Key} → get; catch-all skipped
+		"handle_cast": "put,delete,flush", // {put,..},{delete,..},flush in clause order
+	}
+	seen := map[string]bool{}
+	for _, rec := range got {
+		if rec.Kind != "SCOPE.Operation" {
+			continue
+		}
+		want, ok := wantTags[rec.Name]
+		if !ok {
+			continue
+		}
+		seen[rec.Name] = true
+		if rec.Properties["otp_dispatch_tags"] != want {
+			t.Errorf("%s: expected otp_dispatch_tags=%q, got %q",
+				rec.Name, want, rec.Properties["otp_dispatch_tags"])
+		}
+		// Each tag should also surface as an otp_msg:<tag> tag.
+		for _, tg := range splitComma(want) {
+			if !hasTag(rec.Tags, "otp_msg:"+tg) {
+				t.Errorf("%s: expected tag otp_msg:%s, got %v", rec.Name, tg, rec.Tags)
+			}
+		}
+	}
+	for cb := range wantTags {
+		if !seen[cb] {
+			t.Errorf("dispatch callback %q not found", cb)
+		}
+	}
+}
+
+func splitComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
 }
 
 func hasTag(tags []string, want string) bool {

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -1285,6 +1285,17 @@ const (
 	//                   call. The DesignDecision→Section anchoring uses the
 	//                   existing CONTAINS edge; no new hierarchy kind. OPT-IN.
 	RelationshipKindRationaleFor RelationshipKind = "RATIONALE_FOR"
+
+	// #4929 (follow-up #4903): Erlang/OTP supervision-tree edge. Emitted from a
+	// supervisor module entity → each child module named in its `init/1` child
+	// spec list. The child spec may be a modern map
+	// (`#{id => ..., start => {Mod, Fun, Args}}`) or the legacy tuple
+	// (`{Id, {M, F, A}, Restart, Shutdown, Type, Modules}`); in both forms the
+	// child module is the `M` of the `start` MFA. Properties on the edge:
+	// child_id (the spec's id), provenance ("otp_child_spec"). Makes the OTP
+	// supervision hierarchy a traversable subgraph rather than being buried
+	// inside the supervisor's init body.
+	RelationshipKindSupervises RelationshipKind = "SUPERVISES"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1445,6 +1456,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindInstantiates,
 		// #4308/#4309 agent-driven semantic doc ingestion (opt-in, emit/apply):
 		RelationshipKindRationaleFor,
+		// #4929 Erlang/OTP supervision-tree child_spec edge:
+		RelationshipKindSupervises,
 	}
 }
 


### PR DESCRIPTION
Deepening follow-up to #4903 (OTP behaviour/callback detection). Builds the next two semantic layers on top of it.

## Supervision-tree child_spec edges
- New edge Kind **`SUPERVISES`** (`RelationshipKindSupervises` in `internal/types/kinds.go`, added to `AllRelationshipKinds`; the producer-kinds guardrail in `internal/types` scans the new `Kind: "SUPERVISES"` literal and passes).
- When a module is a `supervisor` (`behaviourSet["supervisor"]`), its `init/1` body is parsed for the child spec list and a SUPERVISES edge is emitted from the supervisor module entity → each child module.
- `parseChildSpecs` handles **both** spec shapes after comment/string scrubbing:
  - modern map form `#{id => ..., start => {Mod, Fun, Args}}` (`childSpecMapStartRE` for the start-MFA module, `childSpecMapIDRE` for the id; map literals isolated by `mapSegments` so each `start` is paired with its own `id`),
  - legacy tuple form `{Id, {M, F, A}, Restart, Shutdown, Type, Modules}` (`childSpecTupleRE`).
- Children de-duplicated by module; edge Properties: `child_id`, `provenance="otp_child_spec"`.

## gen_server message-tag dispatch
- For the request-dispatching callbacks (`handle_call`/`handle_cast`/`handle_info`/`handle_event`/`handle_sync_event`; `isDispatchCallback`) the message **tag** of each clause is recovered — the first pattern element of the first argument (`{get, Key}` → `get`; bare atom `flush` → `flush`).
- Recovered from per-clause argument heads (`funcInfo.argHeads`, `clauseMatch.args` = `funcHeadRE` group 2) via `firstArgTag` + `splitTopLevelFirst` (nesting-aware top-level comma split over `(){}[]`) + `isAtom`. Variable/wildcard catch-all clauses (`_Request`, `_Msg`, `_`) carry no concrete tag and are skipped.
- Tags emitted in clause order, de-duplicated, onto the callback entity: `Properties["otp_dispatch_tags"]` (comma-list) + Tags `["otp_msg:<tag>", ...]`.

## New edge Kind
`SUPERVISES` (`RelationshipKindSupervises`) — supervisor module → child module. Registered + `go test ./internal/types/` passes (new-Kind rule).

## Fixtures
- `TestErlangExtractor_SupervisionTreeEdges` — supervisor with three children (`cache_server` + `logger_srv` maps + `db_pool` legacy tuple), asserts the three SUPERVISES edges + `child_id`/`provenance` props.
- `TestErlangExtractor_MessageTagDispatch` — `handle_call` → `get`; `handle_cast` → `put,delete,flush`; asserts `otp_dispatch_tags` + `otp_msg:*` tags.

## Registry
`docs/coverage/registry.json` `lang.erlang.runtime.otp/core_extraction` flipped **partial → full** (issue 4929), cites add `internal/types/kinds.go`, note documents both new layers with the proving tests. The `language` category has a fixed capability key set, so both capabilities are documented honestly within the existing `core_extraction` cell rather than inventing new keys. `coverage fmt --check` (canonical) + `coverage validate` (exit 0, 0 errors) pass.

## Gates (sandbox HOME=/tmp/agsbx-4929)
- `go build ./...` ✅
- `go vet ./internal/extractors/erlang/... ./internal/types/` ✅
- `go test ./internal/extractors/erlang/... ./internal/types/` ✅
- `coverage fmt --check` ✅ · `coverage validate` ✅

Deploy-deferred. Closes #4929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)