### PR TITLE
feat(#4976): jsts zod/joi/yup chain constraints → per-field validation chips

### DIFF
--- a/internal/custom/javascript/issue4976_chain_constraints_test.go
+++ b/internal/custom/javascript/issue4976_chain_constraints_test.go
@@ -1,0 +1,142 @@
+package javascript_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/javascript"
+)
+
+// Issue #4976 — fold zod/joi/yup chain constraints into the per-field
+// `validations` chip list so the ShapeTree renders schema constraints
+// (`MaxLength:120`, `Email`, `Min:0`, `Required`, …) with the same chip format
+// as class-validator (#4858). Builds on #4925 (zod/joi/yup schema + field
+// members).
+
+// fieldChips returns the comma-split Properties["validations"] chips for the
+// SCOPE.Schema/field sub-entity named "<Schema>.<field>".
+func fieldChips(ents []types.EntityRecord, qualified string) []string {
+	e := fieldChild(ents, qualified)
+	if e == nil || e.Properties == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(e.Properties["validations"])
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(raw, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func hasChip(chips []string, want string) bool {
+	for _, c := range chips {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func wantChips(t *testing.T, ents []types.EntityRecord, field string, want ...string) {
+	t.Helper()
+	chips := fieldChips(ents, field)
+	for _, w := range want {
+		if !hasChip(chips, w) {
+			t.Errorf("field %q: missing chip %q (got %v)", field, w, chips)
+		}
+	}
+}
+
+func TestZodChainConstraints_StampedAsChips(t *testing.T) {
+	src := `import { z } from 'zod';
+const CreateUser = z.object({
+  name: z.string().min(2).max(120),
+  email: z.string().email(),
+  age: z.number().int().min(0).max(150),
+  bio: z.string().max(500).optional(),
+  website: z.string().url(),
+});`
+	ents := extractFull(t, "custom_js_validation_schema", fi("users.ts", "typescript", src))
+
+	// string min/max → MinLength/MaxLength with the scalar bound folded in.
+	wantChips(t, ents, "CreateUser.name", "MinLength:2", "MaxLength:120")
+	// .email() → flag chip.
+	wantChips(t, ents, "CreateUser.email", "Email")
+	// numeric min/max stay Min/Max; .int() → Int.
+	wantChips(t, ents, "CreateUser.age", "Int", "Min:0", "Max:150")
+	// string .max() on an optional field still folds the bound.
+	wantChips(t, ents, "CreateUser.bio", "MaxLength:500")
+	wantChips(t, ents, "CreateUser.website", "Url")
+
+	// .optional() marks the field optional.
+	bio := fieldChild(ents, "CreateUser.bio")
+	if bio == nil || bio.Properties["optional"] != "true" {
+		t.Errorf("CreateUser.bio expected optional=true (props=%v)", bio.Properties)
+	}
+}
+
+func TestJoiChainConstraints_StampedAsChips(t *testing.T) {
+	src := `const CreateUser = Joi.object({
+  name: Joi.string().min(2).max(120).required(),
+  email: Joi.string().email().required(),
+  age: Joi.number().integer().min(0).max(10),
+  nickname: Joi.string().pattern(/^[a-z]+$/),
+});`
+	ents := extractFull(t, "custom_js_validation_schema", fi("users.ts", "typescript", src))
+
+	wantChips(t, ents, "CreateUser.name", "MinLength:2", "MaxLength:120", "Required")
+	wantChips(t, ents, "CreateUser.email", "Email", "Required")
+	wantChips(t, ents, "CreateUser.age", "Int", "Min:0", "Max:10")
+	// regex literal arg is compound → bare Pattern chip (no folded arg).
+	wantChips(t, ents, "CreateUser.nickname", "Pattern")
+
+	// joi defaults to optional unless .required() is present.
+	nick := fieldChild(ents, "CreateUser.nickname")
+	if nick == nil || nick.Properties["optional"] != "true" {
+		t.Errorf("CreateUser.nickname expected optional=true (props=%v)", nick.Properties)
+	}
+	name := fieldChild(ents, "CreateUser.name")
+	if name != nil && name.Properties["optional"] == "true" {
+		t.Errorf("CreateUser.name has .required() → expected not optional (props=%v)", name.Properties)
+	}
+}
+
+func TestYupChainConstraints_StampedAsChips(t *testing.T) {
+	src := `const CreateUser = yup.object().shape({
+  name: yup.string().required().min(2).max(120),
+  email: yup.string().email(),
+  age: yup.number().integer().min(0).max(150),
+  handle: yup.string().matches(/^@\w+$/),
+});`
+	ents := extractFull(t, "custom_js_validation_schema", fi("users.ts", "typescript", src))
+
+	wantChips(t, ents, "CreateUser.name", "Required", "MinLength:2", "MaxLength:120")
+	wantChips(t, ents, "CreateUser.email", "Email")
+	wantChips(t, ents, "CreateUser.age", "Int", "Min:0", "Max:150")
+	wantChips(t, ents, "CreateUser.handle", "Pattern")
+}
+
+// A schema field with no recognised chain constraints must carry no
+// `validations` property (honest — no empty chip bag).
+func TestSchemaField_NoChainConstraints_NoValidationsProp(t *testing.T) {
+	src := `import { z } from 'zod';
+const Plain = z.object({ id: z.string(), flag: z.boolean() });`
+	ents := extractFull(t, "custom_js_validation_schema", fi("plain.ts", "typescript", src))
+
+	for _, f := range []string{"Plain.id", "Plain.flag"} {
+		e := fieldChild(ents, f)
+		if e == nil {
+			t.Fatalf("expected field member %q", f)
+		}
+		if _, ok := e.Properties["validations"]; ok {
+			t.Errorf("field %q should carry no validations prop (got %q)", f, e.Properties["validations"])
+		}
+	}
+}

--- a/internal/custom/javascript/validation_schema.go
+++ b/internal/custom/javascript/validation_schema.go
@@ -137,7 +137,7 @@ func (e *validationSchemaExtractor) Extract(ctx context.Context, file extreg.Fil
 			name := src[m[2]:m[3]]
 			openParen := m[1] - 1 // header ends at the `(` of `.object(`
 			body := balancedObjectBody(src, openParen)
-			fields := extractSchemaFields(sd.field, body)
+			fields := extractSchemaFields(sd.field, body, sd.lib)
 			if len(fields) == 0 {
 				// A schema with no statically-detectable scalar fields (dynamic /
 				// computed). Still emit the schema entity, but it carries no
@@ -349,23 +349,230 @@ type schemaField struct {
 	name       string
 	typ        string
 	validators []string
-	optional   bool
+	// validations carries the terse chain-constraint chips for zod/joi/yup
+	// schema fields (`MaxLength:120`, `Email`, `Min:0`, `Required`, …), folded
+	// from the field's method chain by parseChainConstraints (#4976) and stamped
+	// onto the field member's Properties["validations"] for the ShapeTree.
+	validations []string
+	optional    bool
 }
 
 // extractSchemaFields pulls `name: lib.<kind>()` field declarations out of a
-// schema object body, normalizing the kind to a scalar type.
-func extractSchemaFields(re *regexp.Regexp, body string) []schemaField {
+// schema object body, normalizing the kind to a scalar type. For each field it
+// also captures the method chain that follows the factory (e.g.
+// `z.string().max(120).email()`) and folds the recognised chain constraints
+// into terse validation chips (`MaxLength:120`, `Email`, …) consistent with the
+// class-validator chip format (#4858 / #4976) so the ShapeTree renders them
+// identically for schema-based validators.
+func extractSchemaFields(re *regexp.Regexp, body string, lib string) []schemaField {
 	var fields []schemaField
 	seen := make(map[string]bool)
-	for _, m := range re.FindAllStringSubmatch(body, -1) {
-		name := m[1]
+	for _, m := range re.FindAllStringSubmatchIndex(body, -1) {
+		name := body[m[2]:m[3]]
 		if seen[name] {
 			continue
 		}
 		seen[name] = true
-		fields = append(fields, schemaField{name: name, typ: normalizeScalar(m[2])})
+		kind := body[m[4]:m[5]]
+		// The chain begins at the factory call's opening `(` (one char before the
+		// match end) and runs to the end of this field's value (the next
+		// top-level comma in the object body, or EOF).
+		chain := fieldChain(body, m[1]-1)
+		chips := parseChainConstraints(lib, kind, chain)
+		optional := chainIsOptional(lib, kind, chips, chain)
+		fields = append(fields, schemaField{
+			name: name, typ: normalizeScalar(kind), validations: chips, optional: optional,
+		})
 	}
 	return fields
+}
+
+// fieldChain returns the schema-field value text starting at the factory call's
+// opening `(` (openParenIdx) and ending at the next comma that sits at the same
+// brace/paren/bracket depth as the field declaration (i.e. the separator
+// between this field and the next), or end of body. This isolates a single
+// field's full method chain — `z.string().min(2).max(120)` — from its
+// siblings so the chain parser only sees this field's constraints.
+func fieldChain(body string, openParenIdx int) string {
+	if openParenIdx < 0 || openParenIdx >= len(body) {
+		return ""
+	}
+	depth := 0
+	for i := openParenIdx; i < len(body); i++ {
+		switch body[i] {
+		case '(', '{', '[':
+			depth++
+		case ')', '}', ']':
+			depth--
+		case ',':
+			if depth <= 0 {
+				return body[openParenIdx:i]
+			}
+		}
+	}
+	return body[openParenIdx:]
+}
+
+// chainMethodRe matches a `.method(args)` or `.method` link in a schema method
+// chain. Group 1 = method name, group 2 = the raw argument list (may be empty
+// or absent for property-style links like zod `.optional` is always a call, but
+// kept permissive).
+var chainMethodRe = regexp.MustCompile(`\.\s*([A-Za-z_]\w*)\s*(?:\(([^()]*)\))?`)
+
+// zodChainChips maps a zod chain method to a terse constraint chip. A "" target
+// means the method carries a single scalar arg folded as `Chip:<arg>`; methods
+// not present here are ignored (kept terse).
+var zodChainChips = map[string]string{
+	"email": "Email", "uuid": "UUID", "url": "Url", "regex": "Pattern",
+	"int": "Int", "positive": "Positive", "negative": "Negative",
+	"nonempty": "NotEmpty", "cuid": "Cuid", "datetime": "DateTime", "ip": "IP",
+}
+
+// zodScalarArgChips: zod chain methods whose first scalar arg is folded into
+// the chip text — `.max(120)` → `MaxLength:120` (for string/array) but the
+// label is normalized below.
+var zodScalarArgChips = map[string]string{
+	"max": "Max", "min": "Min", "length": "Length", "gt": "GreaterThan",
+	"gte": "Min", "lt": "LessThan", "lte": "Max", "multipleof": "MultipleOf",
+}
+
+// joiChainChips: joi chain methods that carry no scalar bound (flag-style).
+var joiChainChips = map[string]string{
+	"required": "Required", "email": "Email", "uuid": "UUID", "guid": "UUID",
+	"uri": "Url", "pattern": "Pattern", "regex": "Pattern", "integer": "Int",
+	"positive": "Positive", "negative": "Negative",
+}
+
+// joiScalarArgChips: joi chain methods whose first scalar arg is folded.
+var joiScalarArgChips = map[string]string{
+	"max": "Max", "min": "Min", "length": "Length", "greater": "GreaterThan",
+	"less": "LessThan",
+}
+
+// yupChainChips: yup chain methods that carry no scalar bound.
+var yupChainChips = map[string]string{
+	"required": "Required", "email": "Email", "uuid": "UUID", "url": "Url",
+	"matches": "Pattern", "positive": "Positive", "negative": "Negative",
+	"integer": "Int",
+}
+
+// yupScalarArgChips: yup chain methods whose first scalar arg is folded.
+var yupScalarArgChips = map[string]string{
+	"max": "Max", "min": "Min", "length": "Length",
+}
+
+// parseChainConstraints walks a schema field's method chain and returns the
+// recognised constraints as terse chips in source order (e.g.
+// `["MaxLength:120","Email"]`). The label set is normalized across zod/joi/yup
+// so the ShapeTree renders schema constraints with the same chip vocabulary as
+// class-validator: `Min`/`Max`/`Length`/`Email`/`Pattern`/`Required`/… For
+// `min`/`max`/`length` the chip is `MinLength`/`MaxLength` when the field is a
+// string or array (length bound) and `Min`/`Max` for numeric kinds — matching
+// the class-validator `@MinLength`/`@Min` split.
+func parseChainConstraints(lib, kind, chain string) []string {
+	var flags map[string]string
+	var args map[string]string
+	switch lib {
+	case "zod":
+		flags, args = zodChainChips, zodScalarArgChips
+	case "joi":
+		flags, args = joiChainChips, joiScalarArgChips
+	case "yup":
+		flags, args = yupChainChips, yupScalarArgChips
+	default:
+		return nil
+	}
+	lengthKind := isLengthKind(normalizeScalar(kind))
+	var out []string
+	seen := make(map[string]bool)
+	for _, m := range chainMethodRe.FindAllStringSubmatch(chain, -1) {
+		method := strings.ToLower(m[1])
+		arg := strings.TrimSpace(m[2])
+		if label, ok := args[method]; ok {
+			// Split Min/Max into MinLength/MaxLength for string/array bounds so the
+			// chip matches the class-validator vocabulary.
+			if lengthKind {
+				switch label {
+				case "Min":
+					label = "MinLength"
+				case "Max":
+					label = "MaxLength"
+				case "Length":
+					label = "Length"
+				}
+			}
+			chip := label
+			if v := firstChainScalar(arg); v != "" {
+				chip = label + ":" + v
+			}
+			if !seen[chip] {
+				seen[chip] = true
+				out = append(out, chip)
+			}
+			continue
+		}
+		if label, ok := flags[method]; ok {
+			if !seen[label] {
+				seen[label] = true
+				out = append(out, label)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// isLengthKind reports whether a normalized scalar kind measures a length bound
+// (string / array) rather than a numeric magnitude, so `min`/`max` map to
+// `MinLength`/`MaxLength` vs `Min`/`Max`.
+func isLengthKind(kind string) bool {
+	return kind == "string" || kind == "array"
+}
+
+// firstChainScalar returns a single numeric/string scalar from a chain method's
+// raw argument list, or "" for empty / compound args (objects, regex literals,
+// multiple args) so those chips stay bare.
+func firstChainScalar(arg string) string {
+	if arg == "" {
+		return ""
+	}
+	if strings.ContainsAny(arg, ",{}[]") {
+		return ""
+	}
+	arg = strings.TrimSpace(arg)
+	// Numeric literal.
+	if numericLiteralRe.MatchString(arg) {
+		return arg
+	}
+	// Simple quoted string → drop quotes.
+	if len(arg) >= 2 && (arg[0] == '\'' || arg[0] == '"' || arg[0] == '`') {
+		return strings.Trim(arg, "'\"`")
+	}
+	return ""
+}
+
+var numericLiteralRe = regexp.MustCompile(`^-?\d+(?:\.\d+)?$`)
+
+// chainIsOptional reports whether a schema field is declared optional via its
+// chain — zod `.optional()`/`.nullish()`, joi without `.required()`, yup
+// without `.required()`. Joi/yup default to optional unless `.required()` is
+// present; zod defaults to required unless `.optional()`/`.nullish()` present.
+func chainIsOptional(lib, kind string, chips []string, chain string) bool {
+	hasRequired := false
+	for _, c := range chips {
+		if c == "Required" {
+			hasRequired = true
+		}
+	}
+	switch lib {
+	case "zod":
+		return strings.Contains(chain, ".optional(") || strings.Contains(chain, ".nullish(")
+	case "joi", "yup":
+		return !hasRequired
+	}
+	return false
 }
 
 // cvFieldDecoratorsRe captures the full run of decorators preceding a property
@@ -575,6 +782,15 @@ func emitSchemaFieldMembers(owner *types.EntityRecord, fields []schemaField, lib
 		}
 		if len(annots) > 0 {
 			setProps(&child, "validators", strings.Join(annots, " "))
+		}
+		// Issue #4976: fold zod/joi/yup chain constraints into the per-field
+		// `validations` chip list (comma-joined) so the ShapeTree renders schema
+		// constraints (`MaxLength:120`, `Email`, `Min:0`, `Required`, …) with the
+		// same chip format as class-validator (#4858). class-validator DTO fields
+		// get their `validations` chips from the tree-sitter pass
+		// (class_validator_fields.go); the schema-chain libraries get them here.
+		if len(f.validations) > 0 {
+			setProps(&child, "validations", strings.Join(f.validations, ","))
 		}
 		owner.Relationships = append(owner.Relationships,
 			containsFieldEdge(owner.Name, child.ID, f.name, library))


### PR DESCRIPTION
Builds on #4858 (class-validator chips) + #4925 (zod/joi/yup schema records). Deploy-deferred.

## What
Folds zod/joi/yup field method-chain constraints into the per-field `Properties["validations"]` chip list, using the **same chip format as class-validator (#4858)** so the dashboard ShapeTree renders schema-based validators identically to class-validator / pydantic DTOs.

`parseChainConstraints` (internal/custom/javascript/validation_schema.go) walks each schema field's method chain and emits terse, source-ordered chips per validator:

- **zod**: `.min/.max` → `MinLength`/`MaxLength` (string/array) or `Min`/`Max` (numeric) with the scalar bound; `.int/.email/.uuid/.url/.regex/.positive/.negative` → `Int`/`Email`/`UUID`/`Url`/`Pattern`/…; `.optional()`/`.nullish()` set the field optional.
- **joi**: `.min/.max` length/numeric split; `.required/.email/.uuid/.uri/.pattern/.integer` → `Required`/`Email`/`UUID`/`Url`/`Pattern`/`Int`; fields default optional unless `.required()`.
- **yup**: `.min/.max` split; `.required/.email/.uuid/.url/.matches/.integer` → `Required`/`Email`/`UUID`/`Url`/`Pattern`/`Int`.

`fieldChain` isolates a single field's chain via brace/paren/bracket depth tracking; `firstChainScalar` folds simple numeric/string args into the chip (`MaxLength:120`), while compound args (regex literals, option objects) stay bare (`Pattern`). Chips stamped on the `SCOPE.Schema/field` member entity in `emitSchemaFieldMembers`. Honest: no `validations` prop when a field has no recognised constraints.

## Covered vs deferred
- **Covered (this PR):** `constraint_extraction` for zod + joi + yup (the chain-chip folding) — registry cells flipped `missing` → `full`, fixture-proven.
- **Deferred (left `missing`, honest):** `custom_validator_extraction` (`.refine/.superRefine`, `Joi.custom`, `yup.test`) and `type_coercion_recognition` (`z.coerce.*`, joi `convert:true`, yup `.cast()`) — larger modeling follow-ups, not part of chain-chip folding.

## Tests / gates (sandbox HOME)
- `TestZodChainConstraints_StampedAsChips`, `TestJoiChainConstraints_StampedAsChips`, `TestYupChainConstraints_StampedAsChips`, `TestSchemaField_NoChainConstraints_NoValidationsProp` (internal/custom/javascript/issue4976_chain_constraints_test.go).
- `go build ./...`, `go vet ./internal/...` clean.
- `go test ./internal/extractors/javascript/... ./internal/custom/... ./internal/dashboard/... ./internal/types/` pass.
- `coverage fmt --check` ✅ canonical, `coverage validate` ✅ (warnings only, exit 0).
- Sandbox HOME=/tmp/agsbx-4976 (isolated-home gate enforced).

Closes #4976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)