### PR TITLE
feat(#4972): kotlin nested @Valid VALIDATES edge (parity Java #3605)

### DIFF
--- a/internal/custom/kotlin/validation.go
+++ b/internal/custom/kotlin/validation.go
@@ -99,6 +99,15 @@ var (
 		`\b(?:validate|Validator)\s*(?:<\s*([A-Z][A-Za-z0-9_]*)\s*>)?\s*\(`,
 	)
 
+	// @Valid (any Kotlin use-site target) on a property — the cascade marker
+	// that drives nested-model recursion. Matches @Valid, @field:Valid,
+	// @get:Valid, @property:Valid, @param:Valid.
+	reFieldValid = regexp.MustCompile(`@(?:field:|get:|param:|property:|set:)?Valid\b`)
+
+	// Element-position @Valid inside a generic, e.g. List<@Valid AddressDto> or
+	// Map<String, @Valid AddressDto>. Submatch 1 = the annotated element type.
+	reElementValid = regexp.MustCompile(`@Valid\s+([A-Z][A-Za-z0-9_.]*)`)
+
 	// konform: Validation<Foo> { ... } — submatch 1 = validated type.
 	reKonformHead = regexp.MustCompile(`\bValidation\s*<\s*([A-Z][A-Za-z0-9_]*)\s*>\s*\{`)
 	// konform property block:  Foo::bar { ... }  — submatch 1 = receiver type,
@@ -379,6 +388,7 @@ func emitDataClasses(add func(types.EntityRecord), src string, heads []classHead
 		setProps(&dtoEnt, "provenance", "INFERRED_FROM_DATA_CLASS")
 
 		var propList []string
+		var validatesEdges []types.RelationshipRecord
 		for _, pm := range reDataProperty.FindAllStringSubmatchIndex(body, -1) {
 			annoBlock := body[pm[2]:pm[3]]
 			pname := body[pm[6]:pm[7]]
@@ -396,6 +406,24 @@ func emitDataClasses(add func(types.EntityRecord), src string, heads []classHead
 				wire = w[1]
 			}
 
+			// ── Nested @Valid recursion → VALIDATES edge (#4972, parity Java #3605).
+			// When a property carries @Valid (any use-site target) — or the
+			// generic element form List<@Valid X> — emit a class→class VALIDATES
+			// edge from the owning DTO to the nested DTO type. For a collection
+			// property the validation target is the element type, not the wrapper.
+			if nested := nestedValidTarget(annoBlock, ptype); nested != "" && !kotlinPrimitives[nested] {
+				validatesEdges = append(validatesEdges, types.RelationshipRecord{
+					ToID: nested,
+					Kind: "VALIDATES",
+					Properties: map[string]string{
+						"field":     pname,
+						"via":       "valid_annotation",
+						"framework": "BeanValidation",
+						"owner_dto": h.name,
+					},
+				})
+			}
+
 			// Per-property keys (value-asserted by tests).
 			setProps(&dtoEnt,
 				"prop."+pname+".type", ptype,
@@ -411,8 +439,54 @@ func emitDataClasses(add func(types.EntityRecord), src string, heads []classHead
 			setProps(&dtoEnt, "properties", strings.Join(propList, ","))
 			setProps(&dtoEnt, "property_count", strconv.Itoa(len(propList)))
 		}
+		if len(validatesEdges) > 0 {
+			dtoEnt.Relationships = append(dtoEnt.Relationships, validatesEdges...)
+		}
 		add(dtoEnt)
 	}
+}
+
+// nestedValidTarget resolves the nested DTO type a @Valid cascade annotation
+// targets on a data-class property, or "" when the property is not @Valid.
+// It handles both the property-level annotation form (@field:Valid val nested:
+// AddressDto) and the generic-element form (val items: List<@Valid AddressDto>),
+// unwrapping a single level of collection / generic wrapper to the element type.
+func nestedValidTarget(annoBlock, ptype string) string {
+	// Generic-element form: List<@Valid AddressDto> / Map<String, @Valid X>.
+	if m := reElementValid.FindStringSubmatch(ptype); m != nil {
+		return strings.TrimSuffix(m[1], "?")
+	}
+	// Property-level @Valid (any use-site target) on the leading annotation block.
+	if !reFieldValid.MatchString(annoBlock) {
+		return ""
+	}
+	return validationElementType(ptype)
+}
+
+// validationElementType strips nullability and unwraps one level of a generic
+// collection wrapper (List<T>, Set<T>, Collection<T>, Iterable<T>, Array<T>) to
+// the element type T, so the VALIDATES edge points at the validated DTO rather
+// than the collection. For Map<K,V> the value type V is taken.
+func validationElementType(ptype string) string {
+	t := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(ptype), "?"))
+	open := strings.IndexByte(t, '<')
+	if open < 0 {
+		return t
+	}
+	wrapper := strings.TrimSpace(t[:open])
+	inner := strings.TrimSpace(strings.TrimSuffix(t[open+1:], ">"))
+	switch wrapper {
+	case "List", "Set", "Collection", "Iterable", "Sequence", "Array", "MutableList", "MutableSet":
+		return strings.TrimSuffix(strings.TrimSpace(inner), "?")
+	case "Map", "MutableMap":
+		// Map<K, V> → value type V.
+		if c := strings.LastIndexByte(inner, ','); c >= 0 {
+			return strings.TrimSuffix(strings.TrimSpace(inner[c+1:]), "?")
+		}
+		return ""
+	}
+	// Unknown generic — treat the raw wrapper as the validated type.
+	return wrapper
 }
 
 // emitKonform parses konform Validation<T> { T::field { constraint(bound) } }

--- a/internal/custom/kotlin/validation_test.go
+++ b/internal/custom/kotlin/validation_test.go
@@ -6,6 +6,8 @@ package kotlin_test
 
 import (
 	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 func TestValidationAtValid(t *testing.T) {
@@ -316,4 +318,93 @@ data class LoginRequest(
 	if findEntity(ents, "SCOPE.Pattern", "validation:rule:LoginRequest.username:NotNull") == nil {
 		t.Error("expected username -> NotNull rule")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Nested @Valid → VALIDATES edge (#4972, parity with Java #3605).
+// A @Valid-annotated DTO field cascades validation into the nested DTO type;
+// the owning DTO must carry a VALIDATES edge to that nested type.
+// ---------------------------------------------------------------------------
+
+func TestValidationNestedValidVALIDATESEdge(t *testing.T) {
+	src := `
+data class OrderRequest(
+    @field:NotNull val id: String,
+    @field:Valid val shippingAddress: AddressDto,
+    @get:Valid val billingAddress: AddressDto?,
+    @field:Valid val items: List<LineItemDto>,
+    val notes: String?
+)
+
+data class AddressDto(
+    @field:NotBlank val street: String
+)
+
+data class LineItemDto(
+    @field:Min(1) val quantity: Int
+)
+`
+	ents := extractRels(t, "custom_kotlin_validation", fi("OrderRequest.kt", "kotlin", src))
+
+	// Owner DTO → nested DTO via @field:Valid.
+	if !hasEdge(ents, "OrderRequest", "VALIDATES", "AddressDto") {
+		t.Errorf("expected OrderRequest VALIDATES AddressDto; edges=%v", dumpValidatesEdges(ents))
+	}
+	// Collection element form: List<LineItemDto> unwraps to LineItemDto.
+	if !hasEdge(ents, "OrderRequest", "VALIDATES", "LineItemDto") {
+		t.Errorf("expected OrderRequest VALIDATES LineItemDto (List element); edges=%v", dumpValidatesEdges(ents))
+	}
+	// Edge carries the field + via metadata.
+	for _, e := range ents {
+		if e.Name != "OrderRequest" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "VALIDATES" && r.ToID == "AddressDto" {
+				if r.Properties["via"] != "valid_annotation" {
+					t.Errorf("expected via=valid_annotation, got %q", r.Properties["via"])
+				}
+				if r.Properties["field"] == "" {
+					t.Error("expected non-empty field on VALIDATES edge")
+				}
+			}
+		}
+	}
+	// A non-@Valid field must NOT produce a VALIDATES edge.
+	if hasEdge(ents, "OrderRequest", "VALIDATES", "String") {
+		t.Error("plain (non-@Valid) field should not emit a VALIDATES edge")
+	}
+}
+
+// Generic-element annotation form: List<@Valid AddressDto> — the @Valid sits on
+// the element type inside the generic, not on the property annotation block.
+func TestValidationNestedValidElementForm(t *testing.T) {
+	src := `
+data class BatchRequest(
+    val addresses: List<@Valid AddressDto>
+)
+
+data class AddressDto(
+    @field:NotBlank val street: String
+)
+`
+	ents := extractRels(t, "custom_kotlin_validation", fi("BatchRequest.kt", "kotlin", src))
+	if !hasEdge(ents, "BatchRequest", "VALIDATES", "AddressDto") {
+		t.Errorf("expected BatchRequest VALIDATES AddressDto (List<@Valid X>); edges=%v", dumpValidatesEdges(ents))
+	}
+}
+
+func dumpValidatesEdges(ents []types.EntityRecord) string {
+	out := ""
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "VALIDATES" {
+				out += "\n  " + e.Name + " -VALIDATES-> " + r.ToID
+			}
+		}
+	}
+	if out == "" {
+		return "(none)"
+	}
+	return out
 }


### PR DESCRIPTION
## What
Materialize the nested `@Valid` **owner→nested VALIDATES edge** for Kotlin DTOs, achieving parity with the Java #3605 carrier-synthesis path. Split from #4924.

## How
- `emitDataClasses` (`internal/custom/kotlin/validation.go`) now inspects each data-class property for a cascade `@Valid` annotation via the new `nestedValidTarget` helper and, when present, attaches a class→class `VALIDATES` `RelationshipRecord` to the owning DTO `SCOPE.Schema(dto)` entity. `ToID` is the bare nested DTO type name, resolved by name at edge-assembly time (same embedded-relationship model as the Compose `NAVIGATES_TO`/`USES` edges).
- Handles every Kotlin use-site target: `@Valid`, `@field:Valid`, `@get:Valid`, `@property:Valid`, `@param:Valid`.
- `@field:Valid` collection unwrap (`validationElementType`): `List`/`Set`/`Collection`/`Iterable`/`Sequence`/`Array`/`Mutable*` → element type; `Map<K,V>` → value type. So `List<LineItemDto>` validates `LineItemDto`.
- Generic-element form `List<@Valid AddressDto>` (annotation on the element inside the generic) handled via `reElementValid`.
- Reuses the existing `VALIDATES` RelationshipKind (already used by Java) — no new edge Kind.

## Fixtures (honest, fixture-proven)
- `TestValidationNestedValidVALIDATESEdge` — `OrderRequest` → `AddressDto` (`@field:Valid`) and → `LineItemDto` (`@field:Valid List<LineItemDto>`); asserts `via=valid_annotation` + non-empty `field`; asserts a plain (non-`@Valid`) field emits no VALIDATES edge.
- `TestValidationNestedValidElementForm` — `BatchRequest` → `AddressDto` via `List<@Valid AddressDto>`.

## Registry
`lang.kotlin.validation.bean-validation` → `nested_model_extraction`: **partial → full** (cite + fixture names). Surgical edit preserving canonical 2-space JSON encoding.

## Gates (sandbox isolated HOME=/tmp/agsbx-4972)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/custom/kotlin/... ./internal/extractors/kotlin/... ./internal/types/ ./tools/coverage/...` all pass; `coverage fmt --check` ok (canonical), `coverage validate` exit 0.

Generalize-extraction note: konform/Valiktor nested-block recursion remains out of scope for this edge (those DSLs don't use `@Valid` cascade markers); follow-up worthwhile if a konform `validate(Foo::nested)` nesting pattern emerges.

Deploy-deferred. Closes #4972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)