### PR TITLE
feat(#4967): csharp MassTransit message-bus extraction (+ NServiceBus/Rebus) — producer/consumer converge

### DIFF
--- a/internal/custom/csharp/handle_messages.go
+++ b/internal/custom/csharp/handle_messages.go
@@ -1,0 +1,159 @@
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_nservicebus", &handleMessagesExtractor{})
+}
+
+// handleMessagesExtractor covers the IHandleMessages<T> handler convention shared
+// by NServiceBus and Rebus — the two long-standing .NET service buses that route
+// by the message type a handler declares. Builds on MassTransit (#4967) /
+// MediatR (#4922); these buses use a single shared interface for both products.
+//
+// Consumers (the handle side):
+//   - class XHandler : IHandleMessages<OrderPlaced>   → message handler
+//   - class XHandler : IAmInitiatedBy<OrderPlaced>    → saga initiator (NServiceBus)
+//
+// Producers (the dispatch side):
+//   - bus.Send(new ProcessOrder())    / context.Send(...)   → point-to-point command
+//   - bus.Publish(new OrderPlaced())  / context.Publish(..) → fan-out event
+//
+// The Publish/Send producer verbs collide with MediatR + MassTransit, so this
+// extractor is gated on an IHandleMessages signal (the unambiguous marker for the
+// NServiceBus/Rebus family). Each message type is normalised to a task_id
+// (msgbus:message:<T>) so the dispatch site and the handler converge by contract.
+type handleMessagesExtractor struct{}
+
+func (e *handleMessagesExtractor) Language() string { return "custom_csharp_nservicebus" }
+
+var (
+	// class XHandler : IHandleMessages<OrderPlaced>
+	hmHandlerRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bIHandleMessages\s*<\s*(\w+)`,
+	)
+	// class XSaga : IAmInitiatedBy<OrderPlaced>  (NServiceBus saga initiation)
+	hmInitiatedByRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bIAmInitiatedBy\s*<\s*(\w+)`,
+	)
+	// bus.Publish(new OrderPlaced()) / context.Publish(new T())
+	hmPublishRe = regexp.MustCompile(
+		`(?m)\b\w+\.Publish\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// bus.Send(new ProcessOrder()) / context.Send(new T())
+	hmSendRe = regexp.MustCompile(
+		`(?m)\b\w+\.Send\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// Signal gate: the IHandleMessages family marker.
+	hmSignalRe = regexp.MustCompile(`(?m)\b(?:using\s+NServiceBus|using\s+Rebus|IHandleMessages\s*<|IAmInitiatedBy\s*<)`)
+)
+
+func (e *handleMessagesExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.nservicebus_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "nservicebus"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !hmSignalRe.MatchString(src) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name + ":" + ent.Subtype
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// 1. Consumer: class XHandler : IHandleMessages<T>
+	for _, idx := range hmHandlerRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		msgType := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity(className, "SCOPE.Service", "message_handler", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "nservicebus",
+			"pattern_type", "message_handler",
+			"message_type", msgType,
+			"task_id", "msgbus:message:"+msgType,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_HANDLE_MESSAGES",
+		)
+		add(ent)
+	}
+
+	// 2. Consumer: class XSaga : IAmInitiatedBy<T>
+	for _, idx := range hmInitiatedByRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		msgType := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity(className, "SCOPE.Service", "saga_initiator", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "nservicebus",
+			"pattern_type", "saga_initiator",
+			"message_type", msgType,
+			"task_id", "msgbus:message:"+msgType,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_AM_INITIATED_BY",
+		)
+		add(ent)
+	}
+
+	// 3. Producer: bus.Publish(new T())
+	for _, idx := range hmPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity("Publish "+msgType, "SCOPE.Operation", "publish", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "nservicebus",
+			"pattern_type", "publish",
+			"message_type", msgType,
+			"task_id", "msgbus:message:"+msgType,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_NSERVICEBUS_PUBLISH",
+		)
+		add(ent)
+	}
+
+	// 4. Producer: bus.Send(new T())
+	for _, idx := range hmSendRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity("Send "+msgType, "SCOPE.Operation", "send", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "nservicebus",
+			"pattern_type", "send",
+			"message_type", msgType,
+			"task_id", "msgbus:message:"+msgType,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_NSERVICEBUS_SEND",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/csharp/handle_messages_test.go
+++ b/internal/custom/csharp/handle_messages_test.go
@@ -1,0 +1,93 @@
+package csharp_test
+
+import (
+	"testing"
+)
+
+// NServiceBus / Rebus IHandleMessages<T> handler-convention coverage (#4967).
+// Value-asserting: Publish/Send (PRODUCES) and IHandleMessages<T> (CONSUMES)
+// converge by task_id, so dispatch and handler link by message contract.
+
+const nServiceBusSrc = `
+using NServiceBus;
+
+public class OrderPlaced { public int Id { get; set; } }
+public class ProcessOrder { public int Id { get; set; } }
+
+public class OrderPlacedHandler : IHandleMessages<OrderPlaced>
+{
+    public Task Handle(OrderPlaced message, IMessageHandlerContext context) => Task.CompletedTask;
+}
+
+public class OrderSaga : IAmInitiatedBy<OrderPlaced>
+{
+    public Task Handle(OrderPlaced message, IMessageHandlerContext context) => Task.CompletedTask;
+}
+
+public class OrderEndpoint
+{
+    private readonly IMessageSession _bus;
+
+    public async Task Run()
+    {
+        await _bus.Publish(new OrderPlaced { Id = 1 });
+        await _bus.Send(new ProcessOrder { Id = 1 });
+    }
+}
+`
+
+func TestHandleMessagesConverge(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_nservicebus", fi("Orders.cs", "csharp", nServiceBusSrc))
+
+	pub := findBySub(ents, "publish", "Publish OrderPlaced")
+	if pub == nil {
+		t.Fatal("expected publish 'Publish OrderPlaced'")
+	}
+	if pub.Properties["edge_kind"] != "PRODUCES" {
+		t.Errorf("publish edge_kind = %q, want PRODUCES", pub.Properties["edge_kind"])
+	}
+
+	h := findBySub(ents, "message_handler", "OrderPlacedHandler")
+	if h == nil {
+		t.Fatal("expected message_handler 'OrderPlacedHandler'")
+	}
+	if h.Properties["edge_kind"] != "CONSUMES" {
+		t.Errorf("handler edge_kind = %q, want CONSUMES", h.Properties["edge_kind"])
+	}
+	if h.Properties["task_id"] != pub.Properties["task_id"] {
+		t.Errorf("handler task_id %q != publish task_id %q",
+			h.Properties["task_id"], pub.Properties["task_id"])
+	}
+	if h.Properties["message_type"] != "OrderPlaced" {
+		t.Errorf("handler message_type = %q, want OrderPlaced", h.Properties["message_type"])
+	}
+
+	if findBySub(ents, "send", "Send ProcessOrder") == nil {
+		t.Error("expected send 'Send ProcessOrder'")
+	}
+
+	saga := findBySub(ents, "saga_initiator", "OrderSaga")
+	if saga == nil {
+		t.Fatal("expected saga_initiator 'OrderSaga'")
+	}
+	if saga.Properties["message_type"] != "OrderPlaced" {
+		t.Errorf("saga_initiator message_type = %q, want OrderPlaced", saga.Properties["message_type"])
+	}
+}
+
+// No IHandleMessages signal -> nothing (shared Publish/Send not mis-claimed).
+func TestHandleMessagesSignalGate(t *testing.T) {
+	const noSignal = `
+public class Foo
+{
+    public void Bar()
+    {
+        _mediator.Publish(new SomethingHappened());
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_nservicebus", fi("Foo.cs", "csharp", noSignal))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without IHandleMessages signal, got %d", len(ents))
+	}
+}

--- a/internal/custom/csharp/masstransit.go
+++ b/internal/custom/csharp/masstransit.go
@@ -1,0 +1,192 @@
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_masstransit", &massTransitExtractor{})
+}
+
+// massTransitExtractor detects MassTransit cross-process message-bus usage —
+// the dominant .NET service bus (RabbitMQ / Azure Service Bus / Amazon SQS
+// transports). Builds on the MediatR (#4922) in-process pattern; these are the
+// cross-process publish/send + consume sites that converge by message type.
+//
+// Producers (the dispatch side):
+//   - _publishEndpoint.Publish(new OrderSubmitted{ ... })  → fan-out event
+//   - _sendEndpoint.Send(new ProcessOrder{ ... })          → point-to-point command
+//   - bus.Publish(new OrderSubmitted())                    → fan-out event
+//   - context.Publish(new OrderSubmitted())                → from inside a consumer
+//   - context.Send(new ProcessOrder())                     → from inside a consumer
+//
+// Consumers (the consume side):
+//   - class XConsumer : IConsumer<OrderSubmitted>          → message consumer
+//
+// Sagas / state machines (orchestration):
+//   - class XSaga : ISaga, InitiatedBy<T> / Orchestrates<T> / Observes<T>
+//   - class XStateMachine : MassTransitStateMachine<TState>
+//
+// Each message type is normalised to a task_id (masstransit:message:<T>) so the
+// publish/send (PRODUCES) site and the consumer (CONSUMES) site converge by
+// message contract, exactly as the MediatR extractor converges by task_id.
+type massTransitExtractor struct{}
+
+func (e *massTransitExtractor) Language() string { return "custom_csharp_masstransit" }
+
+var (
+	// _x.Publish(new OrderSubmitted{...}) / bus.Publish(new T()) / context.Publish(new T())
+	mxPublishRe = regexp.MustCompile(
+		`(?m)\b\w+\.Publish\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// _x.Send(new ProcessOrder{...}) / context.Send(new T())
+	mxSendRe = regexp.MustCompile(
+		`(?m)\b\w+\.Send\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// class XConsumer : IConsumer<OrderSubmitted>
+	mxConsumerRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bIConsumer\s*<\s*(\w+)`,
+	)
+	// class OrderSaga : ISaga ...  (saga persistence + lifecycle correlation)
+	mxSagaRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bISaga\b`,
+	)
+	// class OrderStateMachine : MassTransitStateMachine<OrderState>
+	mxStateMachineRe = regexp.MustCompile(
+		`(?m)(?:class|record|struct)\s+(\w+)\s*(?:<[^>]*>)?\s*:\s*[^{};]*\bMassTransitStateMachine\s*<\s*(\w+)`,
+	)
+)
+
+func (e *massTransitExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.masstransit_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "masstransit"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	// Cheap signal gate: only pay the regex cost on files that actually touch
+	// MassTransit, so unrelated C# (incl. MediatR Send/Publish) is not scanned.
+	if !mxHasSignal(src) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name + ":" + ent.Subtype
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// 1. Producer: Publish(new T{...}) — fan-out event
+	for _, idx := range mxPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity("Publish "+msgType, "SCOPE.Operation", "publish", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "masstransit",
+			"pattern_type", "publish",
+			"message_type", msgType,
+			"task_id", "masstransit:message:"+msgType,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_MASSTRANSIT_PUBLISH",
+		)
+		add(ent)
+	}
+
+	// 2. Producer: Send(new T{...}) — point-to-point command
+	for _, idx := range mxSendRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity("Send "+msgType, "SCOPE.Operation", "send", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "masstransit",
+			"pattern_type", "send",
+			"message_type", msgType,
+			"task_id", "masstransit:message:"+msgType,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_MASSTRANSIT_SEND",
+		)
+		add(ent)
+	}
+
+	// 3. Consumer: class XConsumer : IConsumer<T>
+	for _, idx := range mxConsumerRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		msgType := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity(className, "SCOPE.Service", "consumer", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "masstransit",
+			"pattern_type", "consumer",
+			"message_type", msgType,
+			"task_id", "masstransit:message:"+msgType,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_MASSTRANSIT_CONSUMER",
+		)
+		add(ent)
+	}
+
+	// 4. Saga: class XSaga : ISaga (orchestration / correlated lifecycle)
+	for _, idx := range mxSagaRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity(className, "SCOPE.Service", "saga", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "masstransit",
+			"pattern_type", "saga",
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_MASSTRANSIT_SAGA",
+		)
+		add(ent)
+	}
+
+	// 5. State machine: class X : MassTransitStateMachine<TState>
+	for _, idx := range mxStateMachineRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		stateType := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity(className, "SCOPE.Service", "state_machine", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "masstransit",
+			"pattern_type", "state_machine",
+			"message_type", stateType,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_MASSTRANSIT_STATE_MACHINE",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// mxSignalRe gates the file: a MassTransit using-directive, an IConsumer<>/ISaga/
+// MassTransitStateMachine declaration, or an endpoint type. This keeps the shared
+// Publish/Send verbs (also used by MediatR) from being mis-attributed to
+// MassTransit on files that never reference it.
+var mxSignalRe = regexp.MustCompile(
+	`(?m)\b(?:using\s+MassTransit|IConsumer\s*<|ISaga\b|MassTransitStateMachine\s*<|IPublishEndpoint|ISendEndpoint|ConsumeContext\s*<)`,
+)
+
+func mxHasSignal(src string) bool { return mxSignalRe.MatchString(src) }

--- a/internal/custom/csharp/masstransit_test.go
+++ b/internal/custom/csharp/masstransit_test.go
@@ -1,0 +1,140 @@
+package csharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// MassTransit cross-process message-bus coverage (#4967). Value-asserting:
+// Publish/Send (PRODUCES) and IConsumer<T> (CONSUMES) must converge by task_id,
+// so the bus producer and its consumer link by message contract.
+
+const massTransitSrc = `
+using MassTransit;
+
+public record OrderSubmitted(int Id);
+public record ProcessOrder(int Id);
+
+public class OrderSubmittedConsumer : IConsumer<OrderSubmitted>
+{
+    public Task Consume(ConsumeContext<OrderSubmitted> context) => Task.CompletedTask;
+}
+
+public class OrderSaga : ISaga
+{
+    public Guid CorrelationId { get; set; }
+}
+
+public class OrderStateMachine : MassTransitStateMachine<OrderState>
+{
+}
+
+public class OrderService
+{
+    private readonly IPublishEndpoint _publishEndpoint;
+    private readonly ISendEndpoint _sendEndpoint;
+
+    public async Task Submit(int id)
+    {
+        await _publishEndpoint.Publish(new OrderSubmitted(id));
+        await _sendEndpoint.Send(new ProcessOrder { Id = id });
+    }
+}
+`
+
+func findBySub(ents []types.EntityRecord, subtype, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == subtype && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestMassTransitPublishConsumerConverge(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_masstransit", fi("Orders.cs", "csharp", massTransitSrc))
+
+	pub := findBySub(ents, "publish", "Publish OrderSubmitted")
+	if pub == nil {
+		t.Fatal("expected publish 'Publish OrderSubmitted'")
+	}
+	if pub.Properties["edge_kind"] != "PRODUCES" {
+		t.Errorf("publish edge_kind = %q, want PRODUCES", pub.Properties["edge_kind"])
+	}
+	if pub.Properties["task_id"] != "masstransit:message:OrderSubmitted" {
+		t.Errorf("publish task_id = %q", pub.Properties["task_id"])
+	}
+
+	cons := findBySub(ents, "consumer", "OrderSubmittedConsumer")
+	if cons == nil {
+		t.Fatal("expected consumer 'OrderSubmittedConsumer'")
+	}
+	if cons.Kind != "SCOPE.Service" {
+		t.Errorf("consumer kind = %q, want SCOPE.Service", cons.Kind)
+	}
+	if cons.Properties["edge_kind"] != "CONSUMES" {
+		t.Errorf("consumer edge_kind = %q, want CONSUMES", cons.Properties["edge_kind"])
+	}
+	if cons.Properties["task_id"] != pub.Properties["task_id"] {
+		t.Errorf("consumer task_id %q != publish task_id %q",
+			cons.Properties["task_id"], pub.Properties["task_id"])
+	}
+	if cons.Properties["message_type"] != "OrderSubmitted" {
+		t.Errorf("consumer message_type = %q, want OrderSubmitted", cons.Properties["message_type"])
+	}
+}
+
+func TestMassTransitSend(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_masstransit", fi("Orders.cs", "csharp", massTransitSrc))
+
+	send := findBySub(ents, "send", "Send ProcessOrder")
+	if send == nil {
+		t.Fatal("expected send 'Send ProcessOrder'")
+	}
+	if send.Properties["edge_kind"] != "PRODUCES" {
+		t.Errorf("send edge_kind = %q, want PRODUCES", send.Properties["edge_kind"])
+	}
+	if send.Properties["task_id"] != "masstransit:message:ProcessOrder" {
+		t.Errorf("send task_id = %q", send.Properties["task_id"])
+	}
+}
+
+func TestMassTransitSagaAndStateMachine(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_masstransit", fi("Orders.cs", "csharp", massTransitSrc))
+
+	saga := findBySub(ents, "saga", "OrderSaga")
+	if saga == nil {
+		t.Fatal("expected saga 'OrderSaga'")
+	}
+	if saga.Properties["edge_kind"] != "CONSUMES" {
+		t.Errorf("saga edge_kind = %q, want CONSUMES", saga.Properties["edge_kind"])
+	}
+
+	sm := findBySub(ents, "state_machine", "OrderStateMachine")
+	if sm == nil {
+		t.Fatal("expected state_machine 'OrderStateMachine'")
+	}
+	if sm.Properties["message_type"] != "OrderState" {
+		t.Errorf("state_machine message_type = %q, want OrderState", sm.Properties["message_type"])
+	}
+}
+
+// A plain C# file with no MassTransit signal must produce nothing — the shared
+// Publish/Send verbs must not be attributed to MassTransit (MediatR guard).
+func TestMassTransitSignalGate(t *testing.T) {
+	const noSignal = `
+public class Foo
+{
+    public void Bar()
+    {
+        _mediator.Publish(new SomethingHappened());
+        _x.Send(new DoThing());
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_masstransit", fi("Foo.cs", "csharp", noSignal))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without MassTransit signal, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## What

Cross-process .NET message-bus extraction, building on the MediatR in-process work (#4922). Producer and consumer sites converge by message contract via a shared `task_id`, mirroring MediatR.

### Buses DONE (fixture-proven)
- **MassTransit** (dominant .NET service bus) — `internal/custom/csharp/masstransit.go`
  - Consumer: `class X : IConsumer<T>` -> SCOPE.Service(consumer) CONSUMES
  - Saga: `class X : ISaga` -> SCOPE.Service(saga); `MassTransitStateMachine<TState>` -> state_machine
  - Producer: `_publishEndpoint.Publish(new T{...})` / `bus.Publish` / `context.Publish` -> publish; `_sendEndpoint.Send` / `context.Send` -> send (PRODUCES)
  - Converge by `masstransit:message:<T>`
- **NServiceBus / Rebus** (shared `IHandleMessages<T>` convention) — `internal/custom/csharp/handle_messages.go`
  - Consumer: `IHandleMessages<T>` -> message_handler; `IAmInitiatedBy<T>` -> saga_initiator (CONSUMES)
  - Producer: `bus.Publish/Send(new T())` (PRODUCES)
  - Converge by `msgbus:message:<T>`

Both extractors are **signal-gated** (using-directive / marker interface) so the shared `Publish`/`Send` verbs are not mis-attributed across buses or onto MediatR-only files — proven by negative tests.

### Converge approach
Same as MediatR: no AST receiver-type resolution; producer (`new T` literal) and consumer (marker interface) are stamped with the same `task_id` keyed on the message type, so the graph links them by contract. Honest-partial where dispatch isn't a `new` literal.

### Deferred (follow-ups filed)
- **#4995** — Wolverine (method-convention `Handle(T)`, no marker interface; needs a convention resolver)
- **#4996** — native broker clients: RabbitMQ.Client (BasicPublish/BasicConsume), Confluent.Kafka (IProducer/IConsumer + topic), Azure.Messaging.ServiceBus + EventHubs

### Registry
`msg.masstransit` + `msg.nservicebus` — consumer_extraction & producer_extraction **full**, topic_attribution **partial** (MassTransit/NServiceBus messages are plain POCOs with no marker interface, so the contract isn't separately emitted as SCOPE.Schema, and transport endpoint/queue config isn't yet recovered — noted in record + tracked).

### Fixtures
`masstransit_test.go` (converge, send, saga/state-machine, signal-gate), `handle_messages_test.go` (converge, signal-gate).

### Gates (sandbox HOME=/tmp/agsbx-4967)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/custom/csharp/... ./internal/extractors/csharp/... ./internal/types/` all pass. `coverage fmt --check` canonical + `coverage validate` ok (729 records). No `coverage gen` markdown.

Deploy-deferred.

Narrows #4967 (MassTransit + NServiceBus/Rebus done; Wolverine -> #4995, native clients -> #4996).

🤖 Generated with [Claude Code](https://claude.com/claude-code)