### PR TITLE
feat(#4941): fsharp db_effect — EF Core/Dapper.FSharp/Npgsql.FSharp

### DIFF
--- a/internal/substrate/effect_sinks_fsharp.go
+++ b/internal/substrate/effect_sinks_fsharp.go
@@ -1,0 +1,172 @@
+// F# effect-sink sniffer (#4941 — db_effect for the F# data stack).
+//
+// Builds on the F# coverage from #4906 (base extractor + Giraffe/Saturn
+// routing + testmap). #4906 shipped NO db_effect coverage; this sniffer
+// adds data-access classification for the high-value F# data drivers.
+//
+// Recognises F# data-access sink primitives:
+//
+//   - db_read   :
+//       * EF Core (F#): DbSet LINQ reads — ctx.Users.Find/Where/Single/
+//         First/FirstOrDefault/Any/Count/ToList/ToListAsync/AsNoTracking
+//         (...Async variants), and the F# `query { for x in ctx.T ... }`
+//         computation expression (fsharpEFQueryCERe).
+//       * Dapper / Dapper.FSharp: conn.Query/QueryAsync/QueryFirst*/
+//         QuerySingle*/QueryMultiple* and Dapper.FSharp `select { ... }`
+//         CE + conn.SelectAsync<T>.
+//       * Npgsql.FSharp: a `Sql.query "SELECT ..."` literal (classified by
+//         the leading SQL verb — fsharpNpgsqlReadRe).
+//   - db_write  :
+//       * EF Core (F#): ctx.SaveChanges()/SaveChangesAsync(),
+//         ctx.Users.Add/AddAsync/AddRange/Update/UpdateRange/Remove/
+//         RemoveRange/ExecuteUpdate/ExecuteDelete.
+//       * Dapper / Dapper.FSharp: conn.Execute/ExecuteAsync/ExecuteScalar*
+//         and Dapper.FSharp `insert`/`update`/`delete` CEs +
+//         conn.InsertAsync/UpdateAsync/DeleteAsync.
+//       * Npgsql.FSharp: `Sql.query "INSERT|UPDATE|DELETE|..."` literal
+//         (write SQL verb — fsharpNpgsqlWriteRe).
+//   - http_out  : System.Net.Http HttpClient.GetAsync/PostAsync/PutAsync/
+//     PatchAsync/DeleteAsync/SendAsync/GetStringAsync/GetByteArrayAsync,
+//     and FsHttp `http { GET ... }` / Http.get|post helpers.
+//
+// Function attribution uses F# `let [rec] name` / `member [this|_|x].Name`
+// declaration headers (the same shapes the #4906 base extractor names as
+// SCOPE.Operation). F# is off-side-rule; nearestHeader binds each sink to
+// its nearest preceding declaration by line, matching the Crystal/Dart
+// precedent. Table attribution (ACCESSES_TABLE) is out of scope for the
+// sink sniffer — it emits the standard db_read/db_write/http_out effects,
+// consumed downstream by internal/links/effect_propagation.go (mirrors
+// every other language's effect sink).
+package substrate
+
+import "regexp"
+
+func init() { RegisterEffectSniffer("fsharp", sniffEffectsFSharp) }
+
+// fsharpFuncHeaderRe matches F# `let`/`member` declaration headers.
+// Capture group 1 is the binding/member name. Covers:
+//
+//	let name ...        / let rec name ...   / let inline name ...
+//	let private name    / let mutable name
+//	member this.Name    / member _.Name      / member x.Name
+//	member val Name     / override this.Name / abstract member Name
+var fsharpFuncHeaderRe = regexp.MustCompile(
+	`(?m)^\s*(?:(?:override|abstract|default|static|private|internal|public)\s+)*` +
+		`(?:let(?:\s+(?:rec|inline|mutable|private))*\s+([A-Za-z_][\w']*)` +
+		`|member(?:\s+val)?\s+(?:[A-Za-z_][\w']*\s*\.\s*)?([A-Za-z_][\w']*))`,
+)
+
+// fsharpHTTPRe matches outbound HTTP primitives (System.Net.Http + FsHttp).
+var fsharpHTTPRe = regexp.MustCompile(
+	`\b(?:client|_client|httpClient|http)\s*\.\s*` +
+		`(?:GetAsync|PostAsync|PutAsync|PatchAsync|DeleteAsync|SendAsync|` +
+		`GetStringAsync|GetByteArrayAsync|GetStreamAsync)\s*\(` +
+		`|\bHttp\s*\.\s*(?:get|post|put|patch|delete|request)\b` +
+		`|\bhttp\s*\{\s*(?:GET|POST|PUT|PATCH|DELETE)\b`,
+)
+
+// fsharpEFReadRe matches EF Core (F#) DbSet LINQ read primitives.
+// dbSet is the DbSet member access `ctx.Users.` / `db.Orders.` etc.
+var fsharpEFReadRe = regexp.MustCompile(
+	`\b[A-Za-z_][\w']*\s*\.\s*[A-Z][\w']*\s*\.\s*` +
+		`(?:Find|FindAsync|Where|Single|SingleAsync|SingleOrDefault|SingleOrDefaultAsync|` +
+		`First|FirstAsync|FirstOrDefault|FirstOrDefaultAsync|Any|AnyAsync|All|` +
+		`Count|CountAsync|LongCount|ToList|ToListAsync|ToArray|ToArrayAsync|` +
+		`AsNoTracking|Include|Select|OrderBy|FromSqlRaw|FromSqlInterpolated)\s*\(`,
+)
+
+// fsharpEFQueryCERe matches the F# `query { for x in ctx.Table ... }` CE.
+var fsharpEFQueryCERe = regexp.MustCompile(
+	`\bquery\s*\{\s*for\b`,
+)
+
+// fsharpEFWriteRe matches EF Core (F#) write primitives.
+var fsharpEFWriteRe = regexp.MustCompile(
+	`\b[A-Za-z_][\w']*\s*\.\s*(?:SaveChanges|SaveChangesAsync)\s*\(` +
+		`|\b[A-Za-z_][\w']*\s*\.\s*[A-Z][\w']*\s*\.\s*` +
+		`(?:Add|AddAsync|AddRange|AddRangeAsync|Update|UpdateRange|` +
+		`Remove|RemoveRange|ExecuteUpdate|ExecuteUpdateAsync|` +
+		`ExecuteDelete|ExecuteDeleteAsync)\s*\(`,
+)
+
+// fsharpDapperReadRe matches Dapper / Dapper.FSharp read primitives.
+var fsharpDapperReadRe = regexp.MustCompile(
+	`\b(?:conn|connection|db|_conn|_db|cnn)\s*\.\s*` +
+		`(?:Query|QueryAsync|QueryFirst|QueryFirstAsync|QueryFirstOrDefault|` +
+		`QueryFirstOrDefaultAsync|QuerySingle|QuerySingleAsync|` +
+		`QuerySingleOrDefault|QuerySingleOrDefaultAsync|QueryMultiple|` +
+		`QueryMultipleAsync|SelectAsync|GetAsync|GetListAsync)\b` +
+		`|\bselect\s*\{\s*(?:for\b|table\b)`,
+)
+
+// fsharpDapperWriteRe matches Dapper / Dapper.FSharp write primitives.
+var fsharpDapperWriteRe = regexp.MustCompile(
+	`\b(?:conn|connection|db|_conn|_db|cnn)\s*\.\s*` +
+		`(?:Execute|ExecuteAsync|ExecuteScalar|ExecuteScalarAsync|` +
+		`ExecuteReader|ExecuteReaderAsync|InsertAsync|UpdateAsync|` +
+		`DeleteAsync)\b` +
+		`|\b(?:insert|update|delete)\s*\{\s*(?:for\b|into\b|table\b)`,
+)
+
+// fsharpNpgsqlReadRe matches Npgsql.FSharp `Sql.query "SELECT|WITH ..."`.
+var fsharpNpgsqlReadRe = regexp.MustCompile(
+	`\bSql\s*\.\s*query\s+(?:@?"""|@?")\s*(?i:SELECT|WITH)\b`,
+)
+
+// fsharpNpgsqlWriteRe matches Npgsql.FSharp `Sql.query "INSERT|UPDATE|..."`.
+var fsharpNpgsqlWriteRe = regexp.MustCompile(
+	`\bSql\s*\.\s*query\s+(?:@?"""|@?")\s*(?i:INSERT|UPDATE|DELETE|CREATE|DROP|ALTER|TRUNCATE|MERGE|UPSERT)\b`,
+)
+
+func sniffEffectsFSharp(content string) []EffectMatch {
+	if content == "" {
+		return nil
+	}
+	headers := scanFSharpEffectHeaders(content)
+	var out []EffectMatch
+	out = appendFSharpMatches(out, content, headers, fsharpHTTPRe, EffectHTTPOut, "HttpClient/FsHttp", 0.95)
+	out = appendFSharpMatches(out, content, headers, fsharpEFReadRe, EffectDBRead, "efcore.dbset.read", 0.85)
+	out = appendFSharpMatches(out, content, headers, fsharpEFQueryCERe, EffectDBRead, "efcore.query-ce", 0.8)
+	out = appendFSharpMatches(out, content, headers, fsharpEFWriteRe, EffectDBWrite, "efcore.write", 0.85)
+	out = appendFSharpMatches(out, content, headers, fsharpDapperReadRe, EffectDBRead, "dapper.read", 0.85)
+	out = appendFSharpMatches(out, content, headers, fsharpDapperWriteRe, EffectDBWrite, "dapper.write", 0.85)
+	out = appendFSharpMatches(out, content, headers, fsharpNpgsqlReadRe, EffectDBRead, "npgsql.fsharp.read", 0.9)
+	out = appendFSharpMatches(out, content, headers, fsharpNpgsqlWriteRe, EffectDBWrite, "npgsql.fsharp.write", 0.9)
+	return out
+}
+
+func scanFSharpEffectHeaders(content string) []funcHeader {
+	var hs []funcHeader
+	for _, m := range fsharpFuncHeaderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		// Group 1 = let-binding name, group 2 = member name; exactly one fires.
+		name := ""
+		if m[2] >= 0 {
+			name = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			name = content[m[4]:m[5]]
+		}
+		if name == "" {
+			continue
+		}
+		hs = append(hs, funcHeader{Line: lineOfOffset(content, m[0]), Name: name})
+	}
+	return hs
+}
+
+func appendFSharpMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect, sink string, conf float64) []EffectMatch {
+	for _, m := range re.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		fn := nearestHeader(headers, line)
+		out = append(out, EffectMatch{
+			Function:   fn,
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: conf,
+		})
+	}
+	return out
+}

--- a/internal/substrate/effect_sinks_fsharp_test.go
+++ b/internal/substrate/effect_sinks_fsharp_test.go
@@ -1,0 +1,175 @@
+package substrate
+
+import "testing"
+
+// fsharpEffectsByFn collapses sniffer output into fn -> set-of-effects.
+func fsharpEffectsByFn(content string) map[string]map[Effect]bool {
+	out := map[string]map[Effect]bool{}
+	for _, m := range sniffEffectsFSharp(content) {
+		if out[m.Function] == nil {
+			out[m.Function] = map[Effect]bool{}
+		}
+		out[m.Function][m.Effect] = true
+	}
+	return out
+}
+
+// TestSniffEffectsFSharp_EFCore proves EF Core (F#) DbSet LINQ reads and
+// SaveChanges/Add writes are classified and attributed to the enclosing
+// let-binding.
+func TestSniffEffectsFSharp_EFCore(t *testing.T) {
+	src := `module UserRepo
+
+let getUser (ctx: AppDbContext) id =
+    ctx.Users.FirstOrDefaultAsync(fun u -> u.Id = id)
+
+let listUsers (ctx: AppDbContext) =
+    ctx.Users.AsNoTracking().ToListAsync()
+
+let createUser (ctx: AppDbContext) user =
+    ctx.Users.Add(user) |> ignore
+    ctx.SaveChangesAsync()
+`
+	got := fsharpEffectsByFn(src)
+	if !got["getUser"][EffectDBRead] {
+		t.Errorf("getUser expected db_read, got %v", got["getUser"])
+	}
+	if !got["listUsers"][EffectDBRead] {
+		t.Errorf("listUsers expected db_read, got %v", got["listUsers"])
+	}
+	if !got["createUser"][EffectDBWrite] {
+		t.Errorf("createUser expected db_write, got %v", got["createUser"])
+	}
+}
+
+// TestSniffEffectsFSharp_EFQueryCE proves the F# `query { for x in ... }`
+// computation expression registers as db_read.
+func TestSniffEffectsFSharp_EFQueryCE(t *testing.T) {
+	src := `module Reports
+
+let activeOrders (ctx: AppDbContext) =
+    query {
+        for o in ctx.Orders do
+        where (o.Status = "active")
+        select o
+    }
+`
+	got := fsharpEffectsByFn(src)
+	if !got["activeOrders"][EffectDBRead] {
+		t.Errorf("activeOrders expected db_read (query CE), got %v", got["activeOrders"])
+	}
+}
+
+// TestSniffEffectsFSharp_Dapper proves Dapper / Dapper.FSharp reads/writes
+// (method calls + computation-expression CEs) are classified.
+func TestSniffEffectsFSharp_Dapper(t *testing.T) {
+	src := `module Data
+
+let findOrders (conn: IDbConnection) =
+    conn.QueryAsync<Order>("select * from orders")
+
+let dapperSelect (conn: IDbConnection) =
+    select {
+        for o in orderTable
+        where (o.id = 1)
+    } |> conn.SelectAsync<Order>
+
+let saveOrder (conn: IDbConnection) o =
+    conn.ExecuteAsync("insert into orders values (@Id)", o)
+
+let dapperInsert (conn: IDbConnection) o =
+    insert {
+        into orderTable
+        value o
+    } |> conn.InsertAsync
+`
+	got := fsharpEffectsByFn(src)
+	if !got["findOrders"][EffectDBRead] {
+		t.Errorf("findOrders expected db_read, got %v", got["findOrders"])
+	}
+	if !got["dapperSelect"][EffectDBRead] {
+		t.Errorf("dapperSelect expected db_read, got %v", got["dapperSelect"])
+	}
+	if !got["saveOrder"][EffectDBWrite] {
+		t.Errorf("saveOrder expected db_write, got %v", got["saveOrder"])
+	}
+	if !got["dapperInsert"][EffectDBWrite] {
+		t.Errorf("dapperInsert expected db_write, got %v", got["dapperInsert"])
+	}
+}
+
+// TestSniffEffectsFSharp_NpgsqlFSharp proves Npgsql.FSharp `Sql.query`
+// literals are classified by their leading SQL verb.
+func TestSniffEffectsFSharp_NpgsqlFSharp(t *testing.T) {
+	src := `module Pg
+
+let loadUsers conn =
+    conn
+    |> Sql.query "SELECT id, name FROM users"
+    |> Sql.executeAsync (fun read -> read.int "id")
+
+let insertUser conn name =
+    conn
+    |> Sql.query "INSERT INTO users (name) VALUES (@name)"
+    |> Sql.parameters [ "@name", Sql.text name ]
+    |> Sql.executeNonQueryAsync
+`
+	got := fsharpEffectsByFn(src)
+	if !got["loadUsers"][EffectDBRead] {
+		t.Errorf("loadUsers expected db_read, got %v", got["loadUsers"])
+	}
+	if !got["insertUser"][EffectDBWrite] {
+		t.Errorf("insertUser expected db_write, got %v", got["insertUser"])
+	}
+	// A SELECT must not be misclassified as a write.
+	if got["loadUsers"][EffectDBWrite] {
+		t.Errorf("loadUsers must not be db_write, got %v", got["loadUsers"])
+	}
+}
+
+// TestSniffEffectsFSharp_HTTP proves HttpClient / FsHttp outbound calls are
+// classified as http_out and attributed to member bindings.
+func TestSniffEffectsFSharp_HTTP(t *testing.T) {
+	src := `type ApiClient(client: HttpClient) =
+    member this.FetchUser id =
+        client.GetStringAsync(sprintf "https://api/users/%d" id)
+    member _.PushEvent payload =
+        client.PostAsync("https://api/events", payload)
+`
+	got := fsharpEffectsByFn(src)
+	if !got["FetchUser"][EffectHTTPOut] {
+		t.Errorf("FetchUser expected http_out, got %v", got["FetchUser"])
+	}
+	if !got["PushEvent"][EffectHTTPOut] {
+		t.Errorf("PushEvent expected http_out, got %v", got["PushEvent"])
+	}
+}
+
+func TestSniffEffectsFSharp_Registered(t *testing.T) {
+	if EffectSnifferFor("fsharp") == nil {
+		t.Fatal("fsharp effect sniffer not registered")
+	}
+}
+
+func TestSniffEffectsFSharp_Empty(t *testing.T) {
+	if got := sniffEffectsFSharp(""); got != nil {
+		t.Errorf("empty content must yield nil, got %v", got)
+	}
+}
+
+// TestSniffEffectsFSharp_NonDataNoop proves a pure F# file with no
+// data-access primitives yields no db effects (no false positives).
+func TestSniffEffectsFSharp_NonDataNoop(t *testing.T) {
+	src := `module Math
+
+let add a b = a + b
+
+let rec fib n =
+    if n < 2 then n else fib (n - 1) + fib (n - 2)
+`
+	for _, m := range sniffEffectsFSharp(src) {
+		if m.Effect == EffectDBRead || m.Effect == EffectDBWrite {
+			t.Errorf("pure module must yield no db effect, got %v at %s", m.Effect, m.Function)
+		}
+	}
+}


### PR DESCRIPTION
## #4941 — fsharp db_effect (follow-up #4906)

F# had **no** db_effect coverage after #4906. This adds the first, via a per-language effect sniffer (`internal/substrate/effect_sinks_fsharp.go`) registered as `RegisterEffectSniffer("fsharp", ...)`, mirroring the Crystal/Dart precedent. Emits standard `db_read`/`db_write`/`http_out` `EffectMatch` records consumed by `internal/links/effect_propagation.go` like every other language.

### Drivers DONE (fixture-proven)
- **EF Core (F#)** — DbSet LINQ reads (`ctx.T.Find/Where/Single/First/FirstOrDefault/Any/Count/ToList(Async)/AsNoTracking/Include/FromSqlRaw`) + the F# `query { for x in ctx.T ... }` computation expression → `db_read`; `ctx.SaveChanges(Async)`, `ctx.T.Add(Async)/AddRange/Update/Remove/ExecuteUpdate/ExecuteDelete` → `db_write`.
- **Dapper / Dapper.FSharp** — `conn.Query*/QueryFirst*/QuerySingle*/QueryMultiple*/SelectAsync` + `select { for ... }` CE → `db_read`; `conn.Execute*/ExecuteScalar*/InsertAsync/UpdateAsync/DeleteAsync` + `insert`/`update`/`delete` CEs → `db_write`.
- **Npgsql.FSharp** — `Sql.query "<sql>"` literal **classified by leading SQL verb** (SELECT/WITH → read; INSERT/UPDATE/DELETE/CREATE/DROP/ALTER/TRUNCATE/MERGE → write); a SELECT is never misclassified as a write (asserted).
- **http_out** — System.Net.Http `HttpClient.*Async` + FsHttp `http { GET ... }` / `Http.get`.

Function attribution via `scanFSharpEffectHeaders` (richer than the existing payload-shapes let-only scan — covers `let [rec/inline]` **and** `member this/_/x.Name`, so member-bound repositories attribute correctly).

### Deferred → follow-ups
- **#4999** SQLProvider type-provider write paths + table attribution (generic `query{}` SELECTs already caught).
- **#5000** raw-SQL table attribution / ACCESSES_TABLE for Npgsql.FSharp + Dapper literals + EF DbSet.
- **#5001** Dapper ambiguous `Execute` literal-verb refinement + receiver-type resolution; plus the non-db tail of #4941 (FsCheck/Hedgehog/Unquote/FsUnit test records, Falco/Suave/Oxpecker/ASP.NET-minimal-F# web frameworks).

### Registry
`lang.fsharp.framework.giraffe` → `Data.db_effect` flipped `missing` → **partial** with cites + honest notes. `coverage fmt --check` ✅ canonical, `coverage validate` ✅ (pre-existing warnings only).

### Gates (sandbox HOME=/tmp/agsbx-4941)
`go build ./...` ✅ · `go vet ./internal/...` ✅ · `go test ./internal/substrate/... ./internal/engine/... ./internal/types/ ./internal/custom/fsharp/...` ✅ · `coverage fmt --check` ✅ · `coverage validate` ✅. 8 new value-asserting tests in `effect_sinks_fsharp_test.go`.

Narrows #4941 (db_effect done; SQLProvider + table-attr + non-db tail tracked in #4999/#5000/#5001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)