### PR TITLE
feat(#4968): csharp — WCF ServiceContract/OperationContract → RPC schema + transport

### DIFF
--- a/internal/custom/csharp/wcf.go
+++ b/internal/custom/csharp/wcf.go
@@ -1,0 +1,226 @@
+// Package csharp — WCF (Windows Communication Foundation) extractor for C#.
+//
+// Covers the service-contract surface for lang.csharp.framework.wcf (issue
+// #4968). WCF models RPC the way gRPC-net does: a [ServiceContract] interface
+// declares the service, each [OperationContract] method is an invokable
+// procedure, [DataContract]/[DataMember] types describe the payload schema, and
+// ServiceHost / AddServiceModelServices registrations bind the service to a
+// transport. We mirror the grpc_net.go shape so the two RPC frameworks read the
+// same in the graph.
+//
+//	Schema/procedure_extraction:
+//	  [OperationContract] methods inside a [ServiceContract] interface emitted
+//	  as SCOPE.Schema/procedure_extraction (one per operation). [ServiceContract]
+//	  interfaces/classes emitted as the owning service procedure surface.
+//
+//	Schema/schema_extraction:
+//	  [DataContract] C# classes and their [DataMember] properties emitted as
+//	  SCOPE.Schema/schema_extraction.
+//
+//	Transport/transport_binding:
+//	  new ServiceHost(typeof(X)) host registration and
+//	  builder.Services.AddServiceModelServices()/AddServiceModelWebServices()
+//	  (CoreWCF) emitted as SCOPE.Pattern/transport_binding.
+//
+// Registration key: "custom_csharp_wcf"
+// Issue #4968.
+package csharp
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_wcf", &wcfExtractor{})
+}
+
+type wcfExtractor struct{}
+
+func (e *wcfExtractor) Language() string { return "custom_csharp_wcf" }
+
+// ---------------------------------------------------------------------------
+// Regex catalog
+// ---------------------------------------------------------------------------
+
+var (
+	// [ServiceContract] on an interface or class — declares a WCF service.
+	// Captures the type name (the leading I on interfaces is part of the name).
+	reWCFServiceContract = regexp.MustCompile(
+		`\[ServiceContract\b[^\]]*\]\s*(?:public\s+|internal\s+)?(?:partial\s+)?(?:interface|class)\s+(\w+)`,
+	)
+
+	// [OperationContract] on a method — one invokable RPC operation. Captures
+	// the method name. The return type may be a generic (Task<T>) so we skip it.
+	reWCFOperationContract = regexp.MustCompile(
+		`\[OperationContract\b[^\]]*\]\s*(?:public\s+|internal\s+)?(?:async\s+)?[\w.<>\[\]]+(?:\s*<[^>]+>)?\s+(\w+)\s*\(`,
+	)
+
+	// [DataContract] C# class — WCF payload schema type.
+	reWCFDataContract = regexp.MustCompile(
+		`\[DataContract\b[^\]]*\]\s*(?:public\s+|internal\s+)?(?:partial\s+)?class\s+(\w+)`,
+	)
+
+	// [DataMember] property — a serialized member of a data contract.
+	reWCFDataMember = regexp.MustCompile(
+		`\[DataMember\b[^\]]*\]\s*(?:public\s+)?[\w.<>\[\]]+(?:\s*<[^>]+>)?\s+(\w+)\s*(?:\{|;|=)`,
+	)
+
+	// new ServiceHost(typeof(MyService)) — self-hosted WCF endpoint binding.
+	reWCFServiceHost = regexp.MustCompile(
+		`new\s+ServiceHost\s*\(\s*typeof\s*\(\s*(\w+)\s*\)`,
+	)
+
+	// CoreWCF registration: AddServiceModelServices / AddServiceModelWebServices.
+	reWCFAddServiceModel = regexp.MustCompile(
+		`\.AddServiceModel(?:Web)?Services\s*\(`,
+	)
+
+	// CoreWCF endpoint wiring: builder.AddServiceEndpoint<TService, TContract>()
+	// or serviceBuilder.AddServiceEndpoint(...). Captures the contract type when
+	// expressed generically.
+	reWCFAddServiceEndpoint = regexp.MustCompile(
+		`\.AddServiceEndpoint\s*<\s*(\w+)\s*,\s*(\w+)\s*>`,
+	)
+)
+
+// ---------------------------------------------------------------------------
+// Extract
+// ---------------------------------------------------------------------------
+
+func (e *wcfExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.wcf_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "wcf"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "csharp" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// Cheap gate: only WCF files carry these attributes / host types.
+	if !regexpAny(src, "[ServiceContract", "[OperationContract", "[DataContract",
+		"ServiceHost", "AddServiceModel") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// -------------------------------------------------------------------------
+	// Schema/procedure_extraction — the service + its operations
+	// -------------------------------------------------------------------------
+
+	// [ServiceContract] interfaces/classes
+	for _, m := range reWCFServiceContract.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity("service:"+name, "SCOPE.Schema", "procedure_extraction", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_SERVICE_CONTRACT",
+			"service_name", name)
+		add(ent)
+	}
+
+	// [OperationContract] methods
+	for _, m := range reWCFOperationContract.FindAllStringSubmatchIndex(src, -1) {
+		opName := src[m[2]:m[3]]
+		ent := makeEntity("operation:"+opName, "SCOPE.Schema", "procedure_extraction", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_OPERATION_CONTRACT",
+			"operation_name", opName)
+		add(ent)
+	}
+
+	// -------------------------------------------------------------------------
+	// Schema/schema_extraction — data contracts + members
+	// -------------------------------------------------------------------------
+
+	// [DataContract] classes
+	for _, m := range reWCFDataContract.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		ent := makeEntity("datacontract:"+name, "SCOPE.Schema", "schema_extraction", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_DATA_CONTRACT",
+			"class_name", name)
+		add(ent)
+	}
+
+	// [DataMember] properties
+	for _, m := range reWCFDataMember.FindAllStringSubmatchIndex(src, -1) {
+		field := src[m[2]:m[3]]
+		ent := makeEntity("datamember:"+field+":"+itoa(lineOf(src, m[0])),
+			"SCOPE.Schema", "schema_extraction", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_DATA_MEMBER",
+			"field_name", field)
+		add(ent)
+	}
+
+	// -------------------------------------------------------------------------
+	// Transport/transport_binding — host + CoreWCF registration
+	// -------------------------------------------------------------------------
+
+	// new ServiceHost(typeof(X)) — self-hosted endpoint
+	for _, m := range reWCFServiceHost.FindAllStringSubmatchIndex(src, -1) {
+		svc := src[m[2]:m[3]]
+		ent := makeEntity("service_host:"+svc, "SCOPE.Pattern", "transport_binding", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_SERVICE_HOST",
+			"service_type", svc)
+		add(ent)
+	}
+
+	// builder.AddServiceEndpoint<TService, TContract>() — CoreWCF endpoint
+	for _, m := range reWCFAddServiceEndpoint.FindAllStringSubmatchIndex(src, -1) {
+		svc := src[m[2]:m[3]]
+		contract := src[m[4]:m[5]]
+		ent := makeEntity("service_endpoint:"+svc+":"+contract, "SCOPE.Pattern", "transport_binding", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_ADD_SERVICE_ENDPOINT",
+			"service_type", svc, "contract_type", contract)
+		add(ent)
+	}
+
+	// .AddServiceModelServices() / .AddServiceModelWebServices() — CoreWCF wiring
+	for _, m := range reWCFAddServiceModel.FindAllStringIndex(src, -1) {
+		ent := makeEntity("add_service_model:"+file.Path+":"+itoa(lineOf(src, m[0])),
+			"SCOPE.Pattern", "transport_binding", file.Path, "csharp", lineOf(src, m[0]))
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_ADD_SERVICE_MODEL")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// regexpAny reports whether src contains any of the literal substrings. Used as
+// a cheap pre-filter before running the WCF regex catalog.
+func regexpAny(src string, subs ...string) bool {
+	for _, s := range subs {
+		if strings.Contains(src, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/custom/csharp/wcf_test.go
+++ b/internal/custom/csharp/wcf_test.go
@@ -1,0 +1,155 @@
+package csharp_test
+
+// ---------------------------------------------------------------------------
+// WCF — ServiceContract / OperationContract / DataContract / Transport (#4968)
+// ---------------------------------------------------------------------------
+
+import "testing"
+
+func TestWCFServiceContract(t *testing.T) {
+	src := `
+using System.ServiceModel;
+using System.Threading.Tasks;
+
+[ServiceContract]
+public interface IOrderService
+{
+    [OperationContract]
+    Order GetOrder(int id);
+
+    [OperationContract]
+    Task<bool> CreateOrder(Order order);
+}
+`
+	ents := extract(t, "custom_csharp_wcf", fi("IOrderService.cs", "csharp", src))
+
+	foundService := false
+	foundGet := false
+	foundCreate := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "procedure_extraction" {
+			switch e.Name {
+			case "service:IOrderService":
+				foundService = true
+			case "operation:GetOrder":
+				foundGet = true
+			case "operation:CreateOrder":
+				foundCreate = true
+			}
+		}
+	}
+	if !foundService {
+		t.Error("expected procedure_extraction service:IOrderService from [ServiceContract]")
+	}
+	if !foundGet {
+		t.Error("expected procedure_extraction operation:GetOrder from [OperationContract]")
+	}
+	if !foundCreate {
+		t.Error("expected procedure_extraction operation:CreateOrder from [OperationContract]")
+	}
+}
+
+func TestWCFDataContract(t *testing.T) {
+	src := `
+using System.Runtime.Serialization;
+
+[DataContract]
+public class Order
+{
+    [DataMember]
+    public int Id { get; set; }
+
+    [DataMember(Order = 2)]
+    public string Customer { get; set; }
+}
+`
+	ents := extractFull(t, "custom_csharp_wcf", fi("Order.cs", "csharp", src))
+
+	foundClass := false
+	memberCount := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "schema_extraction" {
+			if e.Name == "datacontract:Order" {
+				foundClass = true
+			}
+			if e.Properties["provenance"] == "INFERRED_FROM_DATA_MEMBER" {
+				memberCount++
+			}
+		}
+	}
+	if !foundClass {
+		t.Error("expected schema_extraction datacontract:Order from [DataContract]")
+	}
+	if memberCount != 2 {
+		t.Errorf("expected 2 [DataMember] schema entities, got %d", memberCount)
+	}
+}
+
+func TestWCFServiceHostBinding(t *testing.T) {
+	src := `
+using System.ServiceModel;
+
+class Program
+{
+    static void Main()
+    {
+        var host = new ServiceHost(typeof(OrderService));
+        host.Open();
+    }
+}
+`
+	ents := extract(t, "custom_csharp_wcf", fi("Program.cs", "csharp", src))
+
+	found := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Pattern" && e.Subtype == "transport_binding" &&
+			e.Name == "service_host:OrderService" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected transport_binding service_host:OrderService from new ServiceHost(typeof(...))")
+	}
+}
+
+func TestWCFCoreWCFRegistration(t *testing.T) {
+	src := `
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddServiceModelServices();
+var app = builder.Build();
+app.UseServiceModel(b =>
+{
+    b.AddService<OrderService>();
+    b.AddServiceEndpoint<OrderService, IOrderService>(new BasicHttpBinding(), "/order");
+});
+`
+	ents := extractFull(t, "custom_csharp_wcf", fi("Program.cs", "csharp", src))
+
+	foundAddModel := false
+	foundEndpoint := false
+	for _, e := range ents {
+		if e.Subtype == "transport_binding" {
+			if e.Properties["provenance"] == "INFERRED_FROM_ADD_SERVICE_MODEL" {
+				foundAddModel = true
+			}
+			if e.Name == "service_endpoint:OrderService:IOrderService" {
+				foundEndpoint = true
+			}
+		}
+	}
+	if !foundAddModel {
+		t.Error("expected transport_binding from AddServiceModelServices()")
+	}
+	if !foundEndpoint {
+		t.Error("expected transport_binding from AddServiceEndpoint<TService, TContract>()")
+	}
+}
+
+func TestWCFNoMatch(t *testing.T) {
+	src := `namespace MyApp { class Helper { public void Run() {} } }`
+	ents := extract(t, "custom_csharp_wcf", fi("Helper.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities on non-WCF source, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## What

Adds the WCF (Windows Communication Foundation) service-contract surface for C#, the highest-value untouched piece of #4968. WCF is modelled as RPC, mirroring the existing `grpc_net.go` shape so the two RPC frameworks read the same in the graph.

**New extractor** `internal/custom/csharp/wcf.go` (`custom_csharp_wcf`, prefix-dispatched, no list edit):
- `[ServiceContract]` interface/class -> `service:<Name>` — SCOPE.Schema/procedure_extraction
- `[OperationContract]` method -> `operation:<Name>` — SCOPE.Schema/procedure_extraction
- `[DataContract]` class -> `datacontract:<Name>`; `[DataMember]` prop -> datamember entity — SCOPE.Schema/schema_extraction
- `new ServiceHost(typeof(X))` self-host + CoreWCF `AddServiceModelServices()` / `AddServiceEndpoint<TSvc,TContract>()` -> SCOPE.Pattern/transport_binding
- Cheap literal pre-filter; no new entity Kinds (reuses SCOPE.Schema/SCOPE.Pattern).

## Edges / Kinds
No new Kinds — reuses existing SCOPE.Schema (procedure/schema_extraction) and SCOPE.Pattern (transport_binding), same as grpc-net. `go test ./internal/types/` green.

## Registry cells (lang.csharp.framework.wcf, NEW record)
Fixture-proven flipped to **partial**: `procedure_extraction`, `schema_extraction`, `transport_binding` (cite wcf.go + wcf_test.go).
Flipped **full** via framework-agnostic shared extractors: `type_extraction`, `interface_extraction`, `enum_extraction`, `tests_linkage`.
Marked **not_applicable** (HTTP/GraphQL-only, mirroring grpc-net): route_extraction, endpoint_synthesis, handler_attribution, endpoint_response_codes/pagination/deprecation, view_rendering, federation_extraction, type_graph_extraction, type_alias_extraction.
Remaining lanes seeded **missing** via `coverage backfill` (issue #4968). `coverage fmt --check` + `coverage validate` both pass (rc=0).

## Fixtures
`internal/custom/csharp/wcf_test.go` — 5 tests: ServiceContract+operations, DataContract+members(=2), ServiceHost binding, CoreWCF AddServiceModelServices+AddServiceEndpoint, no-match negative. All pass.

## Deferred (follow-ups filed)
- #5003 — SignalR: honor `[HubMethodName]` + dedicated realtime registry record (realtime synthesis already exists but undocumented + ignores the attr).
- #5004 — WCF client proxy (ChannelFactory/ClientBase), binding config addresses, [FaultContract], behaviors.
- #5005 — Test doubles (Moq/NSubstitute/Testcontainers/SpecFlow). Note: Refit/RestSharp/Flurl HTTP clients already covered by http_endpoint_csharp_client.go.

## Gates (sandbox HOME=/tmp/agsbx-4968)
`go build ./...` ✅, `go vet ./internal/...` ✅, `go test ./internal/custom/csharp/... ./internal/extractors/csharp/... ./internal/types/` ✅, `coverage fmt --check` ✅, `coverage validate` rc=0 ✅. No `coverage gen` per instructions. Deploy-deferred.

Narrows #4968 (WCF subset delivered; SignalR/test-doubles/clients tracked in #5003/#5004/#5005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)