### PR TITLE
feat(#4964): rust — juniper GraphQL endpoint/DTO/schema extraction

### DIFF
--- a/internal/custom/rust/juniper.go
+++ b/internal/custom/rust/juniper.go
@@ -1,0 +1,308 @@
+package rust
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// juniper is a code-first GraphQL server library for Rust (#4964). It is the
+// sibling of async-graphql but uses a different macro vocabulary:
+//
+//	#[derive(GraphQLObject)]
+//	struct User { id: i32, name: String }
+//
+//	#[derive(GraphQLInputObject)]
+//	struct NewUser { name: String }
+//
+//	#[derive(GraphQLEnum)]
+//	enum Episode { NewHope, Empire }
+//
+//	struct Query;
+//	#[graphql_object]
+//	impl Query {
+//	    fn user(&self, id: i32) -> User { ... }
+//	}
+//
+//	struct Mutation;
+//	#[graphql_object]
+//	impl Mutation {
+//	    fn create_user(&self, new: NewUser) -> User { ... }
+//	}
+//
+//	let schema = RootNode::new(Query, Mutation, Subscription);
+//	// or: Schema::new(Query, EmptyMutation::new(), EmptySubscription::new());
+//
+// Each resolver method on a Query/Mutation/Subscription root maps to a synthetic
+// GraphQL endpoint with verb GRAPHQL and path /graphql/<Root>/<field>, the EXACT
+// canonical shape async-graphql (Rust), gqlgen (Go), Strawberry (Python),
+// Apollo (JS), and Absinthe (Elixir) emit, so cross-repo client links join. Each
+// GraphQLObject/GraphQLInputObject struct becomes a SCOPE.Schema DTO; GraphQLEnum
+// becomes a DTO with role "enum". RootNode::new / Schema::new captures the schema
+// root and its operation-root type arguments as a SCOPE.Service.
+//
+// HONEST LIMIT: identical to the async-graphql extractor. When the resolver impl
+// block is not one of the three recognised roots (Query/Mutation/Subscription)
+// the operation root is inferred as "Object" and fields are still emitted but are
+// not addressable from a top-level GraphQL path (juniper field resolvers on a
+// `#[graphql_object] impl User`). Cross-file schema composition (root types
+// declared in another module than RootNode::new) is not chased. The
+// `#[graphql(name = "...")]` field-rename attribute is not yet honoured for the
+// GraphQL field name.
+
+func init() {
+	extractor.Register("custom_rust_juniper", &juniperExtractor{})
+}
+
+type juniperExtractor struct{}
+
+func (e *juniperExtractor) Language() string { return "custom_rust_juniper" }
+
+var (
+	// `#[graphql_object]` (optionally with arguments like
+	// `#[graphql_object(context = Ctx)]`) immediately preceding an `impl <Root>`
+	// block, possibly with intervening attributes. The `#[graphql_subscription]`
+	// variant is also accepted (subscription roots). Capture group 1 is the
+	// implemented type name, which is the GraphQL operation root.
+	reJuniperObjectImpl = regexp.MustCompile(
+		`#\[graphql_(?:object|subscription)[^\]]*\]\s*(?:#\[[^\]]*\]\s*)*impl\s+(?:<[^>]*>\s*)?([A-Za-z_]\w*)`,
+	)
+	// A resolver method inside a `#[graphql_object] impl` block. juniper resolvers
+	// are usually plain `fn`, but `async fn` is allowed on async runtimes. Capture
+	// group 1 (async) or group 2 (sync) is the field name.
+	reJuniperResolverFn = regexp.MustCompile(
+		`(?m)^\s*(?:pub\s+)?async\s+fn\s+([A-Za-z_]\w*)\s*\(|^\s*(?:pub\s+)?fn\s+([A-Za-z_]\w*)\s*\(`,
+	)
+	// `#[derive(... GraphQLObject ...)] struct Name` and the GraphQLInputObject
+	// variant. Capture group 1 is the derive list, group 2 is the type name.
+	reJuniperDeriveType = regexp.MustCompile(
+		`#\[derive\s*\(([^)]*\b(?:GraphQLObject|GraphQLInputObject)\b[^)]*)\)\]\s*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?struct\s+([A-Za-z_]\w*)`,
+	)
+	// `#[derive(... GraphQLEnum ...)] enum Name` — juniper GraphQL enum.
+	reJuniperDeriveEnum = regexp.MustCompile(
+		`#\[derive\s*\(([^)]*\bGraphQLEnum\b[^)]*)\)\]\s*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?enum\s+([A-Za-z_]\w*)`,
+	)
+	// `RootNode::new(` or `Schema::new(` — the call head. The argument list is
+	// read with a paren-balanced scan (juniperCallArgs) so nested constructor
+	// calls like `EmptyMutation::new()` do not truncate the root list.
+	reJuniperSchemaBuildHead = regexp.MustCompile(
+		`(?:RootNode|Schema)::new\s*\(`,
+	)
+)
+
+func (e *juniperExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.juniper_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "juniper"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+
+	// File-signal gate: require a juniper marker so this extractor is a no-op on
+	// plain Rust / async-graphql / axum files. The juniper-specific macros are
+	// unambiguous; we deliberately do NOT key on bare `RootNode`/`Schema` alone.
+	if !strings.Contains(src, "#[graphql_object") &&
+		!strings.Contains(src, "#[graphql_subscription") &&
+		!strings.Contains(src, "GraphQLObject") &&
+		!strings.Contains(src, "GraphQLInputObject") &&
+		!strings.Contains(src, "GraphQLEnum") {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. #[graphql_object] impl <Root> { fn field(...) } -> one GRAPHQL endpoint
+	//    per resolver method, path /graphql/<Root>/<field>.
+	for _, m := range reJuniperObjectImpl.FindAllStringSubmatchIndex(src, -1) {
+		root := src[m[2]:m[3]]
+		bodyStart, bodyEnd := agqlBlockBody(src, m[1])
+		if bodyStart < 0 {
+			continue
+		}
+		body := src[bodyStart:bodyEnd]
+
+		operation := agqlOperationForRoot(root)
+
+		for _, fm := range reJuniperResolverFn.FindAllStringSubmatchIndex(body, -1) {
+			var field string
+			if fm[2] >= 0 {
+				field = body[fm[2]:fm[3]]
+			} else if fm[4] >= 0 {
+				field = body[fm[4]:fm[5]]
+			}
+			if field == "" {
+				continue
+			}
+			// juniper convenience constructors are not resolver fields.
+			if field == "new" {
+				continue
+			}
+			fieldOff := bodyStart + fm[0]
+			path := rustNormalizePath("/graphql/" + root + "/" + field)
+			name := "GRAPHQL " + path
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, fieldOff))
+			setProps(&ent, "framework", "juniper",
+				"provenance", "INFERRED_FROM_JUNIPER_RESOLVER",
+				"http_method", "GRAPHQL", "verb", "GRAPHQL",
+				"route_path", path, "graphql_operation", operation,
+				"graphql_root", root, "graphql_field", field,
+				"handler_name", root+"."+field)
+			add(ent)
+		}
+	}
+
+	// 2. #[derive(GraphQLObject/GraphQLInputObject)] struct -> SCOPE.Schema DTO.
+	for _, m := range reJuniperDeriveType.FindAllStringSubmatchIndex(src, -1) {
+		derives := strings.TrimSpace(src[m[2]:m[3]])
+		typeName := src[m[4]:m[5]]
+		role := juniperDTORole(derives)
+		ent := makeEntity("graphql_dto:"+typeName, "SCOPE.Schema", "dto", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "juniper",
+			"provenance", "INFERRED_FROM_JUNIPER_DTO",
+			"dto_name", typeName, "graphql_dto_role", role, "derives", derives)
+		add(ent)
+	}
+
+	// 3. #[derive(GraphQLEnum)] enum -> SCOPE.Schema DTO (graphql enum).
+	for _, m := range reJuniperDeriveEnum.FindAllStringSubmatchIndex(src, -1) {
+		derives := strings.TrimSpace(src[m[2]:m[3]])
+		typeName := src[m[4]:m[5]]
+		ent := makeEntity("graphql_dto:"+typeName, "SCOPE.Schema", "dto", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "juniper",
+			"provenance", "INFERRED_FROM_JUNIPER_DTO",
+			"dto_name", typeName, "graphql_dto_role", "enum", "derives", derives)
+		add(ent)
+	}
+
+	// 4. RootNode::new(Query, Mutation, Subscription) -> SCOPE.Service schema root.
+	for _, m := range reJuniperSchemaBuildHead.FindAllStringIndex(src, -1) {
+		rawArgs, ok := juniperCallArgs(src, m[1]-1) // m[1]-1 points at the '('
+		if !ok {
+			continue
+		}
+		roots := juniperSplitRoots(rawArgs)
+		if len(roots) == 0 {
+			continue
+		}
+		ent := makeEntity("graphql_schema:"+strings.Join(roots, ","), "SCOPE.Service", "graphql_schema", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "juniper",
+			"provenance", "INFERRED_FROM_JUNIPER_SCHEMA",
+			"schema_roots", strings.Join(roots, ","))
+		if len(roots) >= 1 {
+			setProps(&ent, "query_root", roots[0])
+		}
+		if len(roots) >= 2 {
+			setProps(&ent, "mutation_root", roots[1])
+		}
+		if len(roots) >= 3 {
+			setProps(&ent, "subscription_root", roots[2])
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// juniperCallArgs returns the raw text inside the call parentheses whose opening
+// `(` is at index openParen, read with paren-balancing so nested constructor
+// calls (e.g. `EmptyMutation::new()`) are kept intact. Returns ("", false) when
+// the parentheses are unbalanced.
+func juniperCallArgs(src string, openParen int) (string, bool) {
+	if openParen < 0 || openParen >= len(src) || src[openParen] != '(' {
+		return "", false
+	}
+	depth := 0
+	for i := openParen; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[openParen+1 : i], true
+			}
+		}
+	}
+	return "", false
+}
+
+// juniperSplitRoots splits a RootNode::new / Schema::new argument list into the
+// individual root-type identifiers, splitting on TOP-LEVEL commas only (so a
+// nested `EmptyMutation::new()` argument is one root) and stripping the
+// constructor-call tail (`EmptyMutation::new()` -> `EmptyMutation`).
+func juniperSplitRoots(raw string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(raw); i++ {
+		switch raw[i] {
+		case '(', '<', '[':
+			depth++
+		case ')', '>', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, raw[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, raw[start:])
+
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// Drop any `::...`, `(...)`, or generic `<...>` tail; keep leading ident.
+		if i := strings.IndexAny(p, ":(<"); i >= 0 {
+			p = p[:i]
+		}
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// juniperDTORole classifies a DTO by its juniper derive list.
+func juniperDTORole(derives string) string {
+	switch {
+	case strings.Contains(derives, "GraphQLInputObject"):
+		return "input"
+	case strings.Contains(derives, "GraphQLObject"):
+		return "object"
+	default:
+		return "object"
+	}
+}

--- a/internal/custom/rust/juniper_test.go
+++ b/internal/custom/rust/juniper_test.go
@@ -1,0 +1,203 @@
+package rust_test
+
+import "testing"
+
+// juniper_test.go — value-asserting tests for the custom_rust_juniper extractor
+// (#4964). juniper is the GraphQL-server sibling of async-graphql with a distinct
+// macro vocabulary (#[graphql_object], #[derive(GraphQLObject/GraphQLInputObject/
+// GraphQLEnum)], RootNode::new). Asserts the EXACT canonical GRAPHQL endpoint
+// shape /graphql/<Root>/<field>, DTO roles, schema-root capture, the file-signal
+// gate (no-op on non-juniper Rust), and that juniper does not collide with the
+// async-graphql extractor.
+
+func TestJuniperResolverFields(t *testing.T) {
+	src := `
+struct Query;
+
+#[graphql_object]
+impl Query {
+    fn user(&self, id: i32) -> User {
+        User::default()
+    }
+    fn users(&self) -> Vec<User> {
+        vec![]
+    }
+}
+
+struct Mutation;
+
+#[graphql_object(context = Ctx)]
+impl Mutation {
+    fn create_user(&self, new: NewUser) -> User {
+        User::default()
+    }
+}
+
+struct Subscription;
+
+#[graphql_subscription]
+impl Subscription {
+    async fn user_added(&self) -> UserStream {
+        unimplemented!()
+    }
+}
+`
+	ents := extract(t, "custom_rust_juniper", fi("schema.rs", "rust", src))
+
+	for _, want := range []string{
+		"GRAPHQL /graphql/Query/user",
+		"GRAPHQL /graphql/Query/users",
+		"GRAPHQL /graphql/Mutation/create_user",
+		"GRAPHQL /graphql/Subscription/user_added",
+	} {
+		e := findEnt(ents, "SCOPE.Operation", want)
+		if e == nil {
+			t.Fatalf("expected juniper resolver endpoint %q", want)
+		}
+		if e.Props["verb"] != "GRAPHQL" {
+			t.Errorf("%s: verb = %q, want GRAPHQL", want, e.Props["verb"])
+		}
+		if e.Props["framework"] != "juniper" {
+			t.Errorf("%s: framework = %q, want juniper", want, e.Props["framework"])
+		}
+	}
+
+	// Operation kind derived from impl root.
+	if e := findEnt(ents, "SCOPE.Operation", "GRAPHQL /graphql/Query/user"); e != nil {
+		if e.Props["graphql_operation"] != "Query" {
+			t.Errorf("Query.user: graphql_operation = %q, want Query", e.Props["graphql_operation"])
+		}
+		if e.Props["handler_name"] != "Query.user" {
+			t.Errorf("Query.user: handler_name = %q, want Query.user", e.Props["handler_name"])
+		}
+	}
+	if e := findEnt(ents, "SCOPE.Operation", "GRAPHQL /graphql/Mutation/create_user"); e != nil {
+		if e.Props["graphql_operation"] != "Mutation" {
+			t.Errorf("create_user: graphql_operation = %q, want Mutation", e.Props["graphql_operation"])
+		}
+	}
+	if e := findEnt(ents, "SCOPE.Operation", "GRAPHQL /graphql/Subscription/user_added"); e != nil {
+		if e.Props["graphql_operation"] != "Subscription" {
+			t.Errorf("user_added: graphql_operation = %q, want Subscription", e.Props["graphql_operation"])
+		}
+	}
+}
+
+func TestJuniperDTOsAndEnum(t *testing.T) {
+	src := `
+#[derive(GraphQLObject)]
+struct User {
+    id: i32,
+    name: String,
+}
+
+#[derive(GraphQLInputObject)]
+struct NewUser {
+    name: String,
+}
+
+#[derive(GraphQLEnum)]
+enum Episode {
+    NewHope,
+    Empire,
+}
+`
+	ents := extract(t, "custom_rust_juniper", fi("types.rs", "rust", src))
+
+	cases := []struct {
+		name string
+		role string
+	}{
+		{"graphql_dto:User", "object"},
+		{"graphql_dto:NewUser", "input"},
+		{"graphql_dto:Episode", "enum"},
+	}
+	for _, c := range cases {
+		e := findEnt(ents, "SCOPE.Schema", c.name)
+		if e == nil {
+			t.Fatalf("expected DTO %q", c.name)
+		}
+		if e.Props["graphql_dto_role"] != c.role {
+			t.Errorf("%s: role = %q, want %q", c.name, e.Props["graphql_dto_role"], c.role)
+		}
+		if e.Props["framework"] != "juniper" {
+			t.Errorf("%s: framework = %q, want juniper", c.name, e.Props["framework"])
+		}
+	}
+}
+
+func TestJuniperSchemaRoot(t *testing.T) {
+	src := `
+#[derive(GraphQLObject)]
+struct User { id: i32 }
+
+fn make_schema() -> Schema {
+    RootNode::new(Query, Mutation, Subscription)
+}
+`
+	ents := extract(t, "custom_rust_juniper", fi("schema.rs", "rust", src))
+
+	e := findEnt(ents, "SCOPE.Service", "graphql_schema:Query,Mutation,Subscription")
+	if e == nil {
+		t.Fatalf("expected juniper schema-root SCOPE.Service")
+	}
+	if e.Props["query_root"] != "Query" || e.Props["mutation_root"] != "Mutation" || e.Props["subscription_root"] != "Subscription" {
+		t.Errorf("schema roots = %v", e.Props)
+	}
+}
+
+func TestJuniperSchemaRoot_EmptyConstructors(t *testing.T) {
+	src := `
+#[derive(GraphQLObject)]
+struct User { id: i32 }
+
+fn make_schema() -> Schema {
+    Schema::new(Query, EmptyMutation::new(), EmptySubscription::new())
+}
+`
+	ents := extract(t, "custom_rust_juniper", fi("schema.rs", "rust", src))
+
+	e := findEnt(ents, "SCOPE.Service", "graphql_schema:Query,EmptyMutation,EmptySubscription")
+	if e == nil {
+		t.Fatalf("expected juniper schema-root with stripped constructor tails")
+	}
+}
+
+// TestJuniperGate asserts the file-signal gate: a plain Rust file with no juniper
+// macro emits nothing, and an async-graphql file is NOT misattributed to juniper.
+func TestJuniperGate(t *testing.T) {
+	plain := `
+struct Query;
+impl Query {
+    fn user(&self) -> User { User::default() }
+}
+fn main() {}
+`
+	if ents := extract(t, "custom_rust_juniper", fi("plain.rs", "rust", plain)); len(ents) != 0 {
+		t.Fatalf("plain Rust should emit nothing, got %d", len(ents))
+	}
+
+	// async-graphql idiom (#[Object], SimpleObject) must not be picked up by the
+	// juniper extractor.
+	agql := `
+#[derive(SimpleObject)]
+struct User { id: ID }
+
+struct Query;
+#[Object]
+impl Query {
+    async fn user(&self) -> Result<User> { Ok(User::default()) }
+}
+`
+	if ents := extract(t, "custom_rust_juniper", fi("agql.rs", "rust", agql)); len(ents) != 0 {
+		t.Fatalf("async-graphql file should not be claimed by juniper, got %d", len(ents))
+	}
+}
+
+// TestJuniperNonRust asserts the language gate.
+func TestJuniperNonRust(t *testing.T) {
+	src := `#[graphql_object] impl Query { fn x() -> i32 { 1 } }`
+	if ents := extract(t, "custom_rust_juniper", fi("x.go", "go", src)); len(ents) != 0 {
+		t.Fatalf("non-rust language should emit nothing, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## What

Implements the **juniper GraphQL** slice of #4964 — juniper is the code-first GraphQL-server sibling of async-graphql (already covered) with a distinct macro vocabulary.

New `internal/custom/rust/juniper.go` (mirrors `async_graphql.go`):
- `#[graphql_object]` / `#[graphql_subscription]` impl blocks → one **GRAPHQL endpoint** per resolver method at the canonical `/graphql/<Root>/<field>` shape (same shape async-graphql/gqlgen/Strawberry/Apollo/Absinthe emit, so cross-repo client links join). Operation kind derived from impl root.
- `#[derive(GraphQLObject/GraphQLInputObject)]` structs + `#[derive(GraphQLEnum)]` enums → **SCOPE.Schema DTOs** with role (object/input/enum).
- `RootNode::new(...)` / `Schema::new(...)` → **SCOPE.Service** schema root. Uses a paren-balanced arg reader + top-level-comma splitter so `Schema::new(Query, EmptyMutation::new(), EmptySubscription::new())` keeps all three roots (an honesty improvement over the async-graphql `[^)]*` regex).
- File-signal gate keeps it a no-op on plain Rust / async-graphql files.

**Edges/Kinds:** reuses existing `SCOPE.Operation` (endpoint), `SCOPE.Schema` (dto), `SCOPE.Service` (graphql_schema) — **no new entity Kinds**, so no `internal/types` change needed.

## Built vs deferred

Built (fixture-proven, registry full): Routing endpoint_synthesis / handler_attribution / route_extraction; Validation dto_extraction; Type System enum/type_extraction (+ language-level interface/type_alias); Substrate error_flow (framework-agnostic pass).

Deferred (registry missing/#4964 + follow-ups filed):
- **#5007** — juniper code-first object-type→type GRAPH_RELATES graph (mirror `graphql_codefirst_typegraph.go`).
- **#5008** — remaining #4964 audit scope: connection pools (deadpool/bb8/r2d2/mobc), async-nats broker, ntex/Loco/Shuttle, test libs (mockito/wiremock/rstest/serial_test/insta).

## Registry

New `lang.rust.framework.juniper` record (cloned from async-graphql taxonomy, honest reset to missing/#4964, only fixture-proven cells flipped to full with cites `internal/custom/rust/juniper.go` + `juniper_test.go` + `#4964`). `coverage fmt --check` ✅ canonical, `coverage validate` ✅ ok 731 records.

## Fixtures

`internal/custom/rust/juniper_test.go`: TestJuniperResolverFields (Query/Mutation/Subscription endpoints + operation kind + handler), TestJuniperDTOsAndEnum (object/input/enum roles), TestJuniperSchemaRoot, TestJuniperSchemaRoot_EmptyConstructors (paren-balanced), TestJuniperGate (no-op on plain + async-graphql), TestJuniperNonRust (language gate).

## Gates (sandbox HOME=/tmp/agsbx-4964)

`go build ./...`, `go vet ./internal/custom/rust/...`, `go test ./internal/custom/rust/... ./internal/extractors/rust/... ./internal/types/` — all ✅. `coverage fmt --check` + `coverage validate` ✅.

Deploy-deferred. Closes #4964 (juniper slice; remaining scope in #5007/#5008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)