### PR TITLE
feat(#4969): csharp — Quartz.NET schedule-string + JobKey group parse

### DIFF
--- a/internal/custom/csharp/quartz_net.go
+++ b/internal/custom/csharp/quartz_net.go
@@ -3,6 +3,7 @@ package csharp
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -54,7 +55,60 @@ var (
 	qnJobIdentityRe = regexp.MustCompile(
 		`\.WithIdentity\s*\(\s*["']([^"']+)["']`,
 	)
+	// .WithIdentity("name", "group") — captures the optional JobKey/TriggerKey group (2nd arg)
+	qnIdentityGroupRe = regexp.MustCompile(
+		`\.WithIdentity\s*\(\s*["'][^"']+["']\s*,\s*["']([^"']+)["']`,
+	)
+	// .WithCronSchedule("0 0/5 * * * ?") — captures the cron expression string
+	qnCronScheduleRe = regexp.MustCompile(
+		`\.WithCronSchedule\s*\(\s*["']([^"']+)["']`,
+	)
+	// CronScheduleBuilder.CronSchedule("0 0/5 * * * ?")
+	qnCronBuilderRe = regexp.MustCompile(
+		`CronScheduleBuilder\.CronSchedule\s*\(\s*["']([^"']+)["']`,
+	)
+	// .WithSimpleSchedule(...) — marks a fixed-interval simple trigger
+	qnSimpleScheduleRe = regexp.MustCompile(
+		`\.WithSimpleSchedule\s*\(`,
+	)
+	// .WithIntervalInSeconds(40) / Minutes / Hours — captures interval magnitude + unit
+	qnIntervalRe = regexp.MustCompile(
+		`\.WithIntervalIn(Seconds|Minutes|Hours)\s*\(\s*(\d+)\s*\)`,
+	)
+	// .WithInterval(TimeSpan.FromSeconds(40)) — TimeSpan-based interval
+	qnTimeSpanIntervalRe = regexp.MustCompile(
+		`\.WithInterval\s*\(\s*TimeSpan\.From(Seconds|Minutes|Hours|Days)\s*\(\s*(\d+)`,
+	)
+	// .RepeatForever() — unbounded repeat marker on a simple schedule
+	qnRepeatForeverRe = regexp.MustCompile(
+		`\.RepeatForever\s*\(`,
+	)
 )
+
+// intervalToSeconds converts a (unit, magnitude) pair to a seconds count string.
+// Returns "" if the unit is unknown.
+func intervalToSeconds(unit, magnitude string) string {
+	n := 0
+	for _, c := range magnitude {
+		if c < '0' || c > '9' {
+			return ""
+		}
+		n = n*10 + int(c-'0')
+	}
+	switch unit {
+	case "Seconds":
+		// already seconds
+	case "Minutes":
+		n *= 60
+	case "Hours":
+		n *= 3600
+	case "Days":
+		n *= 86400
+	default:
+		return ""
+	}
+	return intStr(n)
+}
 
 func (e *quartzNetExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/csharp")
@@ -118,6 +172,15 @@ func (e *quartzNetExtractor) Extract(ctx context.Context, file extractor.FileInp
 		typeName := src[idx[2]:idx[3]]
 		line := lineOf(src, idx[0])
 		taskID := "task:quartz.net:" + typeName
+		// Scan the fluent job chain for the optional JobKey group: .WithIdentity("job1", "group1")
+		rest := src[idx[1]:]
+		if semi := strings.IndexByte(rest, ';'); semi >= 0 {
+			rest = rest[:semi]
+		}
+		jobGroup := ""
+		if gm := qnIdentityGroupRe.FindStringSubmatch(rest); gm != nil {
+			jobGroup = gm[1]
+		}
 		ent := makeEntity("JobBuilder.Create<"+typeName+">", "SCOPE.Operation", "job_builder", file.Path, file.Language, line)
 		setProps(&ent,
 			"framework", "quartz.net",
@@ -127,18 +190,55 @@ func (e *quartzNetExtractor) Extract(ctx context.Context, file extractor.FileInp
 			"edge_kind", "PRODUCES",
 			"provenance", "INFERRED_FROM_QUARTZ_NET_JOB_BUILDER",
 		)
+		if jobGroup != "" {
+			setProps(&ent, "job_group", jobGroup)
+		}
 		add(ent)
 	}
 
 	// 4. Producer: TriggerBuilder.Create()
 	for _, idx := range qnTriggerBuilderRe.FindAllStringIndex(src, -1) {
 		line := lineOf(src, idx[0])
-		// Try to extract trigger identity from .WithIdentity("name") after this position
+		// Scan the fluent trigger chain that follows, bounded to the next ';'
+		// so cron/interval/group from a later trigger don't bleed into this one.
 		rest := src[idx[1]:]
+		if semi := strings.IndexByte(rest, ';'); semi >= 0 {
+			rest = rest[:semi]
+		}
+
 		triggerName := ""
 		if im := qnJobIdentityRe.FindStringSubmatch(rest); im != nil {
 			triggerName = im[1]
 		}
+		triggerGroup := ""
+		if gm := qnIdentityGroupRe.FindStringSubmatch(rest); gm != nil {
+			triggerGroup = gm[1]
+		}
+
+		// Schedule string parse: cron expression or simple-interval.
+		cronExpr := ""
+		if cm := qnCronScheduleRe.FindStringSubmatch(rest); cm != nil {
+			cronExpr = cm[1]
+		} else if cm := qnCronBuilderRe.FindStringSubmatch(rest); cm != nil {
+			cronExpr = cm[1]
+		}
+		scheduleType := ""
+		intervalSeconds := ""
+		repeatForever := ""
+		if cronExpr != "" {
+			scheduleType = "cron"
+		} else if qnSimpleScheduleRe.MatchString(rest) {
+			scheduleType = "simple"
+			if iv := qnIntervalRe.FindStringSubmatch(rest); iv != nil {
+				intervalSeconds = intervalToSeconds(iv[1], iv[2])
+			} else if iv := qnTimeSpanIntervalRe.FindStringSubmatch(rest); iv != nil {
+				intervalSeconds = intervalToSeconds(iv[1], iv[2])
+			}
+			if qnRepeatForeverRe.MatchString(rest) {
+				repeatForever = "true"
+			}
+		}
+
 		name := "TriggerBuilder.Create"
 		if triggerName != "" {
 			name = "trigger:" + triggerName
@@ -151,6 +251,21 @@ func (e *quartzNetExtractor) Extract(ctx context.Context, file extractor.FileInp
 			"edge_kind", "PRODUCES",
 			"provenance", "INFERRED_FROM_QUARTZ_NET_TRIGGER_BUILDER",
 		)
+		if triggerGroup != "" {
+			setProps(&ent, "trigger_group", triggerGroup)
+		}
+		if scheduleType != "" {
+			setProps(&ent, "schedule_type", scheduleType)
+		}
+		if cronExpr != "" {
+			setProps(&ent, "cron_expression", cronExpr)
+		}
+		if intervalSeconds != "" {
+			setProps(&ent, "interval_seconds", intervalSeconds)
+		}
+		if repeatForever != "" {
+			setProps(&ent, "repeat_forever", repeatForever)
+		}
 		add(ent)
 	}
 

--- a/internal/custom/csharp/quartz_net_schedule_test.go
+++ b/internal/custom/csharp/quartz_net_schedule_test.go
@@ -1,0 +1,174 @@
+package csharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
+)
+
+// findTrigger returns the first trigger entity, or nil.
+func findTrigger(ents []types.EntityRecord) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == "trigger" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestQuartzNetCronScheduleParse(t *testing.T) {
+	src := `
+var trigger = TriggerBuilder.Create()
+    .WithIdentity("nightly", "reports")
+    .WithCronSchedule("0 0 2 * * ?")
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_quartz_net", fi("Sched.cs", "csharp", src))
+	tr := findTrigger(ents)
+	if tr == nil {
+		t.Fatal("expected a trigger entity")
+	}
+	if got := tr.Properties["cron_expression"]; got != "0 0 2 * * ?" {
+		t.Errorf("cron_expression = %q, want %q", got, "0 0 2 * * ?")
+	}
+	if got := tr.Properties["schedule_type"]; got != "cron" {
+		t.Errorf("schedule_type = %q, want cron", got)
+	}
+	if got := tr.Properties["trigger_group"]; got != "reports" {
+		t.Errorf("trigger_group = %q, want reports", got)
+	}
+	if got := tr.Properties["trigger_name"]; got != "nightly" {
+		t.Errorf("trigger_name = %q, want nightly", got)
+	}
+}
+
+func TestQuartzNetCronScheduleBuilder(t *testing.T) {
+	src := `
+var trigger = TriggerBuilder.Create()
+    .WithSchedule(CronScheduleBuilder.CronSchedule("0 0/15 * * * ?"))
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_quartz_net", fi("Sched.cs", "csharp", src))
+	tr := findTrigger(ents)
+	if tr == nil {
+		t.Fatal("expected a trigger entity")
+	}
+	if got := tr.Properties["cron_expression"]; got != "0 0/15 * * * ?" {
+		t.Errorf("cron_expression = %q, want %q", got, "0 0/15 * * * ?")
+	}
+	if got := tr.Properties["schedule_type"]; got != "cron" {
+		t.Errorf("schedule_type = %q, want cron", got)
+	}
+}
+
+func TestQuartzNetSimpleScheduleIntervalSeconds(t *testing.T) {
+	src := `
+var trigger = TriggerBuilder.Create()
+    .WithIdentity("poller")
+    .WithSimpleSchedule(x => x.WithIntervalInSeconds(40).RepeatForever())
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_quartz_net", fi("Sched.cs", "csharp", src))
+	tr := findTrigger(ents)
+	if tr == nil {
+		t.Fatal("expected a trigger entity")
+	}
+	if got := tr.Properties["schedule_type"]; got != "simple" {
+		t.Errorf("schedule_type = %q, want simple", got)
+	}
+	if got := tr.Properties["interval_seconds"]; got != "40" {
+		t.Errorf("interval_seconds = %q, want 40", got)
+	}
+	if got := tr.Properties["repeat_forever"]; got != "true" {
+		t.Errorf("repeat_forever = %q, want true", got)
+	}
+	// no cron on a simple schedule
+	if got := tr.Properties["cron_expression"]; got != "" {
+		t.Errorf("cron_expression = %q, want empty", got)
+	}
+}
+
+func TestQuartzNetSimpleScheduleIntervalMinutes(t *testing.T) {
+	src := `
+var trigger = TriggerBuilder.Create()
+    .WithSimpleSchedule(x => x.WithIntervalInMinutes(5))
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_quartz_net", fi("Sched.cs", "csharp", src))
+	tr := findTrigger(ents)
+	if tr == nil {
+		t.Fatal("expected a trigger entity")
+	}
+	if got := tr.Properties["interval_seconds"]; got != "300" {
+		t.Errorf("interval_seconds = %q, want 300 (5 min)", got)
+	}
+}
+
+func TestQuartzNetSimpleScheduleTimeSpanInterval(t *testing.T) {
+	src := `
+var trigger = TriggerBuilder.Create()
+    .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(2)))
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_quartz_net", fi("Sched.cs", "csharp", src))
+	tr := findTrigger(ents)
+	if tr == nil {
+		t.Fatal("expected a trigger entity")
+	}
+	if got := tr.Properties["interval_seconds"]; got != "7200" {
+		t.Errorf("interval_seconds = %q, want 7200 (2h)", got)
+	}
+}
+
+func TestQuartzNetJobKeyGroup(t *testing.T) {
+	src := `
+var job = JobBuilder.Create<SendEmailJob>()
+    .WithIdentity("emailJob", "notifications")
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_quartz_net", fi("Sched.cs", "csharp", src))
+	var jb *types.EntityRecord
+	for i := range ents {
+		if ents[i].Subtype == "job_builder" {
+			jb = &ents[i]
+		}
+	}
+	if jb == nil {
+		t.Fatal("expected a job_builder entity")
+	}
+	if got := jb.Properties["job_group"]; got != "notifications" {
+		t.Errorf("job_group = %q, want notifications", got)
+	}
+}
+
+// Two triggers in one file must not bleed schedule props into each other.
+func TestQuartzNetTriggerScheduleIsolation(t *testing.T) {
+	src := `
+var t1 = TriggerBuilder.Create().WithIdentity("a").WithCronSchedule("0 0 1 * * ?").Build();
+var t2 = TriggerBuilder.Create().WithIdentity("b").WithSimpleSchedule(x => x.WithIntervalInSeconds(10)).Build();
+`
+	ents := extractFull(t, "custom_csharp_quartz_net", fi("Sched.cs", "csharp", src))
+	var cron, simple *types.EntityRecord
+	for i := range ents {
+		if ents[i].Subtype != "trigger" {
+			continue
+		}
+		switch ents[i].Properties["schedule_type"] {
+		case "cron":
+			cron = &ents[i]
+		case "simple":
+			simple = &ents[i]
+		}
+	}
+	if cron == nil || simple == nil {
+		t.Fatalf("expected one cron and one simple trigger, got cron=%v simple=%v", cron, simple)
+	}
+	if cron.Properties["interval_seconds"] != "" {
+		t.Errorf("cron trigger leaked interval_seconds=%q", cron.Properties["interval_seconds"])
+	}
+	if simple.Properties["cron_expression"] != "" {
+		t.Errorf("simple trigger leaked cron_expression=%q", simple.Properties["cron_expression"])
+	}
+}


### PR DESCRIPTION
Spun out of #4922. Implements the highest-value piece of #4969: the **Quartz.NET schedule-string parse** (the #3628 schedule-string gap).

## Built (fixture-proven)
On `internal/custom/csharp/quartz_net.go`, the trigger and job fluent chains are now scanned (each bounded to the next `;` so co-located triggers/jobs don't bleed props into each other), and the schedule string + JobKey group are parsed onto the existing nodes:

**Trigger (SCOPE.Operation/trigger):**
- `.WithCronSchedule("...")` and `CronScheduleBuilder.CronSchedule("...")` -> `schedule_type=cron` + `cron_expression`
- `.WithSimpleSchedule(...)` -> `schedule_type=simple` with `interval_seconds` normalised from `WithIntervalIn{Seconds,Minutes,Hours}(n)` and `WithInterval(TimeSpan.From{Seconds,Minutes,Hours,Days}(n))`, plus `repeat_forever`
- `trigger_group` from `.WithIdentity("name", "group")`

**Job (SCOPE.Operation/job_builder):**
- `job_group` from `.WithIdentity("job", "group")`

No new entity Kinds / edge kinds — reuses the existing trigger/job_builder `SCOPE.Operation` records and PRODUCES edge; props-only enrichment.

## Edges / Kinds
None added. `go test ./internal/types/` passes.

## Registry cell
`msg.quartz-net / topic_attribution`: **partial -> full** (cites quartz_net.go + new quartz_net_schedule_test.go; closes the #3628 schedule-string gap for Quartz.NET). consumer_extraction and producer_extraction unchanged (already full).

## Fixtures
New `internal/custom/csharp/quartz_net_schedule_test.go` (7 prop-asserting tests): cron parse, CronScheduleBuilder, simple interval seconds/minutes, TimeSpan interval, JobKey group, and a co-located-trigger isolation test proving cron/simple props don't bleed.

## Deferred (follow-ups filed)
- #5015 — Hangfire dynamic enqueue args / non-literal lambdas (producer_extraction stays partial) + Hangfire Cron.* parse
- #5016 — Redis pub/sub message_broker view (med) + AutoMapper/Mapster + Polly/Coravel (low)

## Gates (sandbox HOME=/tmp/agsbx-4969)
`go build ./...` ✅, `go vet ./internal/...` ✅, `go test ./internal/custom/csharp/... ./internal/extractors/csharp/... ./internal/types/` ✅, `coverage fmt --check` ✅ canonical, `coverage validate` ✅ (731 records; pre-existing warnings only).

Deploy-deferred. Narrows #4969 (Quartz schedule piece done; Hangfire/Redis/AutoMapper/Polly tracked in #5015/#5016).