### PR TITLE
feat(#4978): c-cpp — query_attribution for nanodbc/SQLiteCpp/sqlite3 C API

### DIFF
--- a/internal/custom/cpp/orm_sql_wrappers.go
+++ b/internal/custom/cpp/orm_sql_wrappers.go
@@ -1,0 +1,280 @@
+package cpp
+
+// orm_sql_wrappers.go — query attribution for three detection-only C/C++
+// datastore wrappers (#4978, follow-up from #4926):
+//
+//  1. custom_cpp_nanodbc  — nanodbc thin ODBC wrapper
+//     Detects:
+//     - nanodbc::execute(conn, "SQL")            → query_attribution
+//     - nanodbc::prepare(stmt, "SQL")            → query_attribution
+//     - nanodbc::statement stmt(conn, "SQL")     → query_attribution
+//     - stmt.prepare("SQL") / conn.execute("SQL")→ query_attribution
+//
+//  2. custom_cpp_sqlitecpp — SQLiteCpp RAII SQLite wrapper
+//     Detects:
+//     - SQLite::Statement query(db, "SQL")       → query_attribution
+//     - db.exec("SQL")                           → query_attribution
+//
+//  3. custom_cpp_sqlite_capi — direct SQLite3 C API
+//     Detects:
+//     - sqlite3_prepare_v2(db, "SQL", …)         → query_attribution
+//     - sqlite3_exec(db, "SQL", …)               → query_attribution
+//
+// All three are thin SQL execution wrappers (no ORM model/relationship/lazy
+// layer), so they emit ONLY:
+//   SCOPE.Operation (subtype="query") with sql_verb + sql_text + sql_table.
+//
+// Status: partial (regex heuristic, no AST). String-literal SQL only; SQL built
+// at runtime / spread across variables is a known cross-file dataflow gap.
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_cpp_nanodbc", &nanodbcExtractor{})
+	extractor.Register("custom_cpp_sqlitecpp", &sqliteCppExtractor{})
+	extractor.Register("custom_cpp_sqlite_capi", &sqliteCAPIExtractor{})
+}
+
+// sqlVerbKeywords is the verb-classification set shared by the SQL-wrapper
+// extractors, ordered so multi-word prefixes never shadow a shorter sibling.
+var sqlVerbKeywords = []string{
+	"SELECT", "INSERT", "UPDATE", "DELETE", "REPLACE",
+	"CREATE", "DROP", "ALTER", "TRUNCATE", "PRAGMA", "WITH",
+}
+
+// reSQLTable extracts the primary table name from a SQL string for the common
+// FROM/INTO/UPDATE/JOIN/TABLE clauses. Best-effort: the first match wins.
+var reSQLTable = regexp.MustCompile(`(?is)\b(?:FROM|INTO|UPDATE|JOIN|TABLE)\s+` +
+	"[`\"\\[]?([A-Za-z_][A-Za-z0-9_.]*)[`\"\\]]?")
+
+// classifySQL returns the SQL verb (or "QUERY" when unknown) and the best-effort
+// primary table name ("" when none could be parsed) for a SQL string literal.
+func classifySQL(sqlText string) (verb, table string) {
+	sqlUpper := strings.ToUpper(strings.TrimSpace(sqlText))
+	verb = "QUERY"
+	for _, kw := range sqlVerbKeywords {
+		if strings.HasPrefix(sqlUpper, kw) {
+			verb = kw
+			break
+		}
+	}
+	if m := reSQLTable.FindStringSubmatch(sqlText); m != nil {
+		table = m[1]
+	}
+	return verb, table
+}
+
+// emitSQLQuery builds a SCOPE.Operation(query) record for one SQL string literal.
+func emitSQLQuery(framework, provenance, sqlText, filePath string, lineNum int) types.EntityRecord {
+	verb, table := classifySQL(sqlText)
+	queryName := verb + "@L" + strconv.Itoa(lineNum)
+	ent := makeEntity(queryName, "SCOPE.Operation", "query", filePath, "cpp", lineNum)
+	props := []string{
+		"framework", framework,
+		"provenance", provenance,
+		"sql_verb", verb,
+		"sql_text", truncate(sqlText, 120),
+	}
+	if table != "" {
+		props = append(props, "sql_table", table)
+	}
+	setProps(&ent, props...)
+	return ent
+}
+
+// ============================================================================
+// nanodbc — thin ODBC wrapper
+// ============================================================================
+
+type nanodbcExtractor struct{}
+
+func (e *nanodbcExtractor) Language() string { return "custom_cpp_nanodbc" }
+
+var (
+	// nanodbc::execute(conn, "SQL") / nanodbc::prepare(stmt, "SQL")
+	// Capture: (1) SQL string literal (second argument).
+	reNanodbcFreeFn = regexp.MustCompile(`(?s)\bnanodbc\s*::\s*(?:execute|prepare)\s*\([^,]+,\s*"([^"]*)"`)
+
+	// nanodbc::statement stmt(conn, "SQL")
+	// Capture: (1) SQL string literal (second ctor argument).
+	reNanodbcStmtCtor = regexp.MustCompile(`(?s)\bnanodbc\s*::\s*statement\s+[A-Za-z_]\w*\s*\([^,]+,\s*"([^"]*)"`)
+
+	// stmt.prepare("SQL") / conn.execute("SQL") — method form on a nanodbc handle.
+	reNanodbcMethod = regexp.MustCompile(`\.\s*(?:prepare|execute)\s*\(\s*"([^"]*)"`)
+)
+
+func (e *nanodbcExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.nanodbc_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("file_path", file.Path),
+			attribute.String("framework", "nanodbc"),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" && file.Language != "c" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "nanodbc") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := map[int]bool{} // dedup by line so overlapping regexes don't double-emit
+
+	add := func(re *regexp.Regexp, provenance string) {
+		for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+			sqlText := src[m[2]:m[3]]
+			lineNum := lineOf(src, m[0])
+			if seen[lineNum] {
+				continue
+			}
+			seen[lineNum] = true
+			out = append(out, emitSQLQuery("nanodbc", provenance, sqlText, file.Path, lineNum))
+		}
+	}
+	add(reNanodbcFreeFn, "INFERRED_FROM_NANODBC_FREE_FN")
+	add(reNanodbcStmtCtor, "INFERRED_FROM_NANODBC_STATEMENT")
+	add(reNanodbcMethod, "INFERRED_FROM_NANODBC_METHOD")
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// SQLiteCpp — RAII SQLite wrapper
+// ============================================================================
+
+type sqliteCppExtractor struct{}
+
+func (e *sqliteCppExtractor) Language() string { return "custom_cpp_sqlitecpp" }
+
+var (
+	// SQLite::Statement query(db, "SQL")
+	// Capture: (1) SQL string literal (second ctor argument).
+	reSQLiteCppStmt = regexp.MustCompile(`(?s)\bSQLite\s*::\s*Statement\s+[A-Za-z_]\w*\s*\([^,]+,\s*"([^"]*)"`)
+
+	// db.exec("SQL") / database.exec("SQL") — direct exec on a SQLiteCpp Database.
+	// Capture: (1) SQL string literal.
+	reSQLiteCppExec = regexp.MustCompile(`\.\s*exec\s*\(\s*"([^"]*)"`)
+)
+
+func (e *sqliteCppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.sqlitecpp_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("file_path", file.Path),
+			attribute.String("framework", "sqlitecpp"),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" && file.Language != "c" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Gate on the SQLiteCpp namespace/include — `.exec(` alone is too generic.
+	if !strings.Contains(src, "SQLiteCpp") && !strings.Contains(src, "SQLite::") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := map[int]bool{}
+
+	add := func(re *regexp.Regexp, provenance string) {
+		for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+			sqlText := src[m[2]:m[3]]
+			lineNum := lineOf(src, m[0])
+			if seen[lineNum] {
+				continue
+			}
+			seen[lineNum] = true
+			out = append(out, emitSQLQuery("sqlitecpp", provenance, sqlText, file.Path, lineNum))
+		}
+	}
+	add(reSQLiteCppStmt, "INFERRED_FROM_SQLITECPP_STATEMENT")
+	add(reSQLiteCppExec, "INFERRED_FROM_SQLITECPP_EXEC")
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// ============================================================================
+// SQLite direct C API
+// ============================================================================
+
+type sqliteCAPIExtractor struct{}
+
+func (e *sqliteCAPIExtractor) Language() string { return "custom_cpp_sqlite_capi" }
+
+var (
+	// sqlite3_prepare_v2(db, "SQL", …) / sqlite3_prepare(db, "SQL", …)
+	// Capture: (1) SQL string literal (second argument).
+	reSQLiteCAPIPrepare = regexp.MustCompile(`(?s)\bsqlite3_prepare(?:_v2|_v3|16)?\s*\([^,]+,\s*"([^"]*)"`)
+
+	// sqlite3_exec(db, "SQL", …)
+	// Capture: (1) SQL string literal (second argument).
+	reSQLiteCAPIExec = regexp.MustCompile(`(?s)\bsqlite3_exec\s*\([^,]+,\s*"([^"]*)"`)
+)
+
+func (e *sqliteCAPIExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/cpp")
+	_, span := tracer.Start(ctx, "indexer.sqlite_capi_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("file_path", file.Path),
+			attribute.String("framework", "sqlite_direct_c_api"),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	if file.Language != "cpp" && file.Language != "c" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !strings.Contains(src, "sqlite3_") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := map[int]bool{}
+
+	add := func(re *regexp.Regexp, provenance string) {
+		for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
+			sqlText := src[m[2]:m[3]]
+			lineNum := lineOf(src, m[0])
+			if seen[lineNum] {
+				continue
+			}
+			seen[lineNum] = true
+			out = append(out, emitSQLQuery("sqlite_direct_c_api", provenance, sqlText, file.Path, lineNum))
+		}
+	}
+	add(reSQLiteCAPIPrepare, "INFERRED_FROM_SQLITE3_PREPARE")
+	add(reSQLiteCAPIExec, "INFERRED_FROM_SQLITE3_EXEC")
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/cpp/orm_sql_wrappers_test.go
+++ b/internal/custom/cpp/orm_sql_wrappers_test.go
@@ -1,0 +1,164 @@
+package cpp_test
+
+// orm_sql_wrappers_test.go — tests for the #4978 query-attribution extractors
+// of the three detection-only C/C++ SQL wrappers: nanodbc, SQLiteCpp, and the
+// direct SQLite3 C API.
+
+import (
+	"testing"
+)
+
+// queryVerbs collects (sql_verb) from every SCOPE.Operation/query entity.
+func queryVerbs(ents []entitySummary) []string {
+	var verbs []string
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "query" {
+			verbs = append(verbs, e.Props["sql_verb"])
+		}
+	}
+	return verbs
+}
+
+// queryByVerb returns the first query entity whose sql_verb matches, or nil.
+func queryByVerb(ents []entitySummary, verb string) *entitySummary {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Operation" && ents[i].Subtype == "query" &&
+			ents[i].Props["sql_verb"] == verb {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// ============================================================================
+// nanodbc
+// ============================================================================
+
+func TestNanodbcQueryExtraction(t *testing.T) {
+	src := `
+#include <nanodbc/nanodbc.h>
+void run(nanodbc::connection& conn) {
+	nanodbc::execute(conn, "SELECT id, name FROM users WHERE id = 1");
+	nanodbc::statement stmt(conn, "INSERT INTO logs (msg) VALUES ('x')");
+	nanodbc::result r = nanodbc::execute(conn, "DELETE FROM sessions");
+}
+`
+	ents := extract(t, "custom_cpp_nanodbc", fi("dao.cpp", "cpp", src))
+	verbs := queryVerbs(ents)
+	for _, want := range []string{"SELECT", "INSERT", "DELETE"} {
+		if !containsStr(verbs, want) {
+			t.Errorf("expected %s verb, got %v", want, verbs)
+		}
+	}
+	// Value assertion: table is resolved from the SQL, not just the verb.
+	if q := queryByVerb(ents, "SELECT"); q == nil {
+		t.Fatal("no SELECT query")
+	} else {
+		if got := q.Props["sql_table"]; got != "users" {
+			t.Errorf("SELECT sql_table = %q, want users", got)
+		}
+		if got := q.Props["framework"]; got != "nanodbc" {
+			t.Errorf("framework = %q, want nanodbc", got)
+		}
+	}
+}
+
+func TestNanodbcMethodForm(t *testing.T) {
+	src := `
+#include <nanodbc/nanodbc.h>
+void run(nanodbc::connection& conn) {
+	conn.execute("UPDATE accounts SET balance = 0");
+}
+`
+	ents := extract(t, "custom_cpp_nanodbc", fi("dao.cpp", "cpp", src))
+	if q := queryByVerb(ents, "UPDATE"); q == nil {
+		t.Fatalf("expected UPDATE query, got %v", queryVerbs(ents))
+	} else if got := q.Props["sql_table"]; got != "accounts" {
+		t.Errorf("UPDATE sql_table = %q, want accounts", got)
+	}
+}
+
+func TestNanodbcNoMatch(t *testing.T) {
+	src := `int main() { return 0; }`
+	if ents := extract(t, "custom_cpp_nanodbc", fi("main.cpp", "cpp", src)); len(ents) != 0 {
+		t.Errorf("expected no entities for non-nanodbc source, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// SQLiteCpp
+// ============================================================================
+
+func TestSQLiteCppQueryExtraction(t *testing.T) {
+	src := `
+#include <SQLiteCpp/SQLiteCpp.h>
+void run(SQLite::Database& db) {
+	SQLite::Statement query(db, "SELECT * FROM products WHERE price > 10");
+	db.exec("CREATE TABLE widgets (id INTEGER PRIMARY KEY)");
+}
+`
+	ents := extract(t, "custom_cpp_sqlitecpp", fi("store.cpp", "cpp", src))
+	verbs := queryVerbs(ents)
+	for _, want := range []string{"SELECT", "CREATE"} {
+		if !containsStr(verbs, want) {
+			t.Errorf("expected %s verb, got %v", want, verbs)
+		}
+	}
+	if q := queryByVerb(ents, "SELECT"); q == nil {
+		t.Fatal("no SELECT query")
+	} else {
+		if got := q.Props["sql_table"]; got != "products" {
+			t.Errorf("SELECT sql_table = %q, want products", got)
+		}
+		if got := q.Props["framework"]; got != "sqlitecpp" {
+			t.Errorf("framework = %q, want sqlitecpp", got)
+		}
+	}
+}
+
+func TestSQLiteCppNoMatch(t *testing.T) {
+	// `.exec(` is generic; without the SQLiteCpp signal we must NOT match.
+	src := `void f() { thread.exec("not sql"); }`
+	if ents := extract(t, "custom_cpp_sqlitecpp", fi("x.cpp", "cpp", src)); len(ents) != 0 {
+		t.Errorf("expected no entities without SQLiteCpp signal, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// SQLite direct C API
+// ============================================================================
+
+func TestSQLiteCAPIQueryExtraction(t *testing.T) {
+	src := `
+#include <sqlite3.h>
+void run(sqlite3* db) {
+	sqlite3_stmt* stmt;
+	sqlite3_prepare_v2(db, "SELECT name FROM customers", -1, &stmt, NULL);
+	sqlite3_exec(db, "DELETE FROM cache", NULL, NULL, NULL);
+}
+`
+	ents := extract(t, "custom_cpp_sqlite_capi", fi("db.c", "cpp", src))
+	verbs := queryVerbs(ents)
+	for _, want := range []string{"SELECT", "DELETE"} {
+		if !containsStr(verbs, want) {
+			t.Errorf("expected %s verb, got %v", want, verbs)
+		}
+	}
+	if q := queryByVerb(ents, "SELECT"); q == nil {
+		t.Fatal("no SELECT query")
+	} else {
+		if got := q.Props["sql_table"]; got != "customers" {
+			t.Errorf("SELECT sql_table = %q, want customers", got)
+		}
+		if got := q.Props["framework"]; got != "sqlite_direct_c_api" {
+			t.Errorf("framework = %q, want sqlite_direct_c_api", got)
+		}
+	}
+}
+
+func TestSQLiteCAPINoMatch(t *testing.T) {
+	src := `int main() { return 0; }`
+	if ents := extract(t, "custom_cpp_sqlite_capi", fi("main.cpp", "cpp", src)); len(ents) != 0 {
+		t.Errorf("expected no entities for non-sqlite3 source, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## What
Adds query_attribution to the three detection-only C/C++ SQL wrappers from #4978 (follow-up of #4926). New file `internal/custom/cpp/orm_sql_wrappers.go` registers three extractors that emit `SCOPE.Operation(subtype=query)` with **sql_verb + sql_text + best-effort sql_table**:

| Extractor | Detects |
|---|---|
| `custom_cpp_nanodbc` | `nanodbc::execute/prepare(conn, "SQL")`, `nanodbc::statement s(conn, "SQL")`, `conn.execute("SQL")` |
| `custom_cpp_sqlitecpp` | `SQLite::Statement q(db, "SQL")`, `db.exec("SQL")` (gated on SQLiteCpp/`SQLite::` signal) |
| `custom_cpp_sqlite_capi` | `sqlite3_prepare_v2/v3/16(db, "SQL", …)`, `sqlite3_exec(db, "SQL", …)` |

Shared `classifySQL` helper classifies the verb (SELECT/INSERT/UPDATE/DELETE/REPLACE/CREATE/DROP/ALTER/TRUNCATE/PRAGMA/WITH) and parses the primary table. All three reuse the existing `SCOPE.Operation`/`query` Kind+subtype (no new Kinds; `internal/types` test passes). Auto-dispatched via the `custom_cpp_` prefix in custom_dispatch.go.

## Built vs deferred
- **Built (fixture-proven):** query_attribution for all three wrappers (string-literal SQL), verb classification, table extraction, signal-gated no-op.
- **Deferred → #5026:** runtime/variable-built SQL (dataflow gap), multi-table sql_table, nanodbc two-step prepare-then-bind. Schema/model/relationship/migration stay **not_applicable** (thin wrappers, no ORM layer) — unchanged.

## Registry cells
`docs/coverage/registry.json` — `query_attribution` flipped **missing → partial** for `lang.c-cpp.orm.{nanodbc,sqlite-direct-c-api,sqlitecpp}`, cites added (`orm_sql_wrappers.go` + the existing engine YAML), `#4978` retained. Only these 3 cells changed. Detection YAMLs untouched.

## Fixtures
`internal/custom/cpp/orm_sql_wrappers_test.go` — 7 tests: verb+table value assertions per wrapper, nanodbc method-form, SQLiteCpp generic-`.exec`-must-not-match guard, no-match guards.

## Gates (sandbox HOME=/tmp/agsbx-4978)
- `go build ./...` ✅
- `go vet ./internal/...` ✅
- `go test ./internal/custom/cpp/... ./internal/types/ ./internal/extractors/...` ✅
- `coverage fmt --check` ✅ canonical · `coverage validate` ✅ (731 records; warnings pre-existing/unrelated)

Deploy-deferred. Narrows #4978 (query_attribution done; deferred scope tracked in #5026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)