### PR TITLE
feat(#4933): nim — Allographer schema-builder ORM coverage

### DIFF
--- a/internal/custom/nim/allographer_orm.go
+++ b/internal/custom/nim/allographer_orm.go
@@ -1,0 +1,284 @@
+// allographer_orm.go — Nim Allographer schema-builder table/column synthesis (#4933).
+//
+// Allographer (https://github.com/itsumura-h/nim-allographer) is a Nim query
+// builder + schema builder. Unlike Norm (#4904), an Allographer schema is NOT a
+// `ref object` type — it is declared imperatively against the schema builder:
+//
+//	import allographer/schema_builder
+//
+//	schema().create(
+//	  table("users", [
+//	    Column().increments("id"),
+//	    Column().string("name"),
+//	    Column().string("email").unique(),
+//	    Column().integer("age").nullable(),
+//	    Column().foreign("post_id").reference("id").on("posts").onDelete(SET_NULL),
+//	  ]),
+//	  table("posts", [
+//	    Column().increments("id"),
+//	    Column().string("title"),
+//	  ]),
+//	)
+//
+// The table identity is the literal string passed to `table("...")`. Each
+// `Column().<type>("name")` call inside that table block is a column whose
+// `column_type` is the builder method name (string/integer/increments/…). A
+// `Column().foreign("col").reference("refCol").on("refTable")` chain is a
+// foreign key: it yields a REFERENCES edge table → referenced table (keyed by
+// the `.on("...")` target) and stamps foreign_key on the column. `.unique()` and
+// `.nullable()` modifiers on a column chain are stamped on the column.
+//
+// What this extractor emits (mirrors the Norm + PHP/Eloquent SCOPE.Schema shape,
+// framework=allographer):
+//   - one SCOPE.Schema/table per `table("name", [...])` block
+//   - one SCOPE.Schema/column per `Column().<type>("col")` call, with column_type
+//     = the builder method, plus unique/nullable when modifiers are present
+//   - a REFERENCES edge table → referenced table for a `.foreign(...).on(...)`
+//     column chain (the FK signal), keyed by the `.on()` target table name
+//
+// Honest exclusions / follow-ups (no fabricated schema):
+//   - Allographer has no `ref object` model layer to map to the table — the
+//     schema builder IS the schema, so there is no separate model entity (model
+//     mapping is not_applicable for Allographer, unlike Norm).
+//   - alter()/drop() schema migrations are a follow-up (#5029); the rdb() query
+//     builder (rdb().table("x").select(...)) query attribution + rdb()
+//     transactions are a follow-up (#5030).
+//   - cross-file FK targets resolve via the shared resolver (REFERENCES carries
+//     the bare table name).
+//
+// Registration key: "custom_nim_allographer_orm".
+package nim
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_nim_allographer_orm", &nimAllographerORMExtractor{})
+}
+
+type nimAllographerORMExtractor struct{}
+
+func (e *nimAllographerORMExtractor) Language() string { return "custom_nim_allographer_orm" }
+
+var (
+	// nimAlloTableRe matches a `table("name"` schema-builder table declaration.
+	// Group 1 is the table name string literal.
+	nimAlloTableRe = regexp.MustCompile(`\btable\s*\(\s*"([^"]+)"`)
+
+	// nimAlloColumnRe matches a single `Column().<method>("col")` builder call.
+	// Group 1 is the builder method (the column type), group 2 the column name.
+	// `Column()` and `Column` (no parens) forms are both accepted.
+	nimAlloColumnRe = regexp.MustCompile(
+		`\bColumn\s*(?:\(\s*\))?\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(\s*"([^"]+)"`)
+
+	// nimAlloOnRe extracts the referenced table from a `.on("table")` chain link.
+	nimAlloOnRe = regexp.MustCompile(`\.\s*on\s*\(\s*"([^"]+)"`)
+	// nimAlloReferenceRe extracts the referenced column from `.reference("col")`.
+	nimAlloReferenceRe = regexp.MustCompile(`\.\s*reference\s*\(\s*"([^"]+)"`)
+	// nimAlloUniqueRe / nimAlloNullableRe are column-chain modifier markers.
+	nimAlloUniqueRe   = regexp.MustCompile(`\.\s*unique\s*\(`)
+	nimAlloNullableRe = regexp.MustCompile(`\.\s*nullable\s*\(`)
+)
+
+// nimAllographerHasSchema is a fast pre-filter: the file must reference the
+// Allographer schema builder (`table(` + `Column`) to be worth scanning, so we
+// never misfire on arbitrary Nim code.
+func nimAllographerHasSchema(content string) bool {
+	return strings.Contains(content, "Column") &&
+		strings.Contains(content, "table(") &&
+		(strings.Contains(content, "allographer") || strings.Contains(content, "schema"))
+}
+
+func (e *nimAllographerORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "nim" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !nimAllographerHasSchema(src) {
+		return nil, nil
+	}
+
+	tables := collectAllographerTables(src)
+	if len(tables) == 0 {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	for _, tbl := range tables {
+		// 1. table entity (identity = the table("...") string literal).
+		table := newAllographerSchema(tbl.name, "table", file.Path, tbl.line,
+			"INFERRED_FROM_ALLOGRAPHER_TABLE")
+		var rels []types.RelationshipRecord
+		for _, c := range tbl.columns {
+			if c.fkTable != "" && c.fkTable != tbl.name {
+				props := map[string]string{"fk_field": c.name, "to_table": c.fkTable}
+				if c.fkColumn != "" {
+					props["references"] = c.fkColumn
+				}
+				rels = append(rels, types.RelationshipRecord{
+					ToID: c.fkTable, Kind: "REFERENCES", Properties: props,
+				})
+			}
+		}
+		table.Relationships = rels
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 2. column entities (one per Column().<type>("col") call).
+		colSeen := make(map[string]bool)
+		for _, c := range tbl.columns {
+			if colSeen[c.name] {
+				continue
+			}
+			colSeen[c.name] = true
+			col := newAllographerSchema(c.name, "column", file.Path, c.line,
+				"INFERRED_FROM_ALLOGRAPHER_COLUMN")
+			col.Properties["column_type"] = c.typ
+			col.Properties["table"] = tbl.name
+			if c.unique {
+				col.Properties["unique"] = "true"
+			}
+			if c.nullable {
+				col.Properties["nullable"] = "true"
+			}
+			if c.fkTable != "" && c.fkTable != tbl.name {
+				col.Properties["foreign_key"] = "true"
+				col.Properties["fk_target"] = c.fkTable
+				if c.fkColumn != "" {
+					col.Properties["fk_column"] = c.fkColumn
+				}
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+	}
+	return out, nil
+}
+
+// allographerTable is a parsed Allographer schema-builder table block.
+type allographerTable struct {
+	name    string
+	line    int
+	columns []allographerColumn
+}
+
+type allographerColumn struct {
+	name     string
+	typ      string // builder method: string/integer/increments/…
+	unique   bool
+	nullable bool
+	fkTable  string // .on("table") target when this is a .foreign(...) chain
+	fkColumn string // .reference("col") target
+	line     int
+}
+
+// collectAllographerTables finds every `table("name", [...])` block and the
+// Column() builder calls in its body. The body of a table is bounded by the next
+// `table(` declaration (or EOF) — Allographer tables are sibling args to
+// schema().create(...), so a column belongs to the most recent table header
+// above it. Each physical line is scanned for a Column() call; a column chain may
+// span its own line (the common formatting), so we attribute per-line.
+func collectAllographerTables(src string) []allographerTable {
+	tblIdx := nimAlloTableRe.FindAllStringSubmatchIndex(src, -1)
+	if len(tblIdx) == 0 {
+		return nil
+	}
+	var tables []allographerTable
+	for i, m := range tblIdx {
+		name := src[m[2]:m[3]]
+		start := m[1] // end of the table("name" match → body begins here
+		end := len(src)
+		if i+1 < len(tblIdx) {
+			end = tblIdx[i+1][0] // next table( header bounds this body
+		}
+		line := strings.Count(src[:m[0]], "\n") + 1
+		body := src[start:end]
+		bodyLineBase := line
+		tables = append(tables, allographerTable{
+			name:    name,
+			line:    line,
+			columns: collectAllographerColumns(body, bodyLineBase),
+		})
+	}
+	return tables
+}
+
+// collectAllographerColumns scans a table body for Column().<type>("col") calls
+// (including Column().foreign("col"), whose type is "foreign"). Each Column()
+// call may carry trailing .unique()/.nullable() modifiers and, for a
+// .foreign("col").reference("c").on("table") chain, FK targets. The chain is read
+// from the Column() match position up to the next Column() boundary within the
+// body so modifiers attach to the right column.
+func collectAllographerColumns(body string, lineBase int) []allographerColumn {
+	colIdx := nimAlloColumnRe.FindAllStringSubmatchIndex(body, -1)
+	if len(colIdx) == 0 {
+		return nil
+	}
+
+	type chainStart struct {
+		pos  int
+		name string
+		typ  string // builder method: string/integer/increments/foreign/…
+	}
+	var starts []chainStart
+	for _, m := range colIdx {
+		starts = append(starts, chainStart{pos: m[0], name: body[m[4]:m[5]], typ: body[m[2]:m[3]]})
+	}
+	// Sort starts by position so each chain's body is [pos, nextPos).
+	sort.Slice(starts, func(i, j int) bool { return starts[i].pos < starts[j].pos })
+
+	var cols []allographerColumn
+	for i, s := range starts {
+		end := len(body)
+		if i+1 < len(starts) {
+			end = starts[i+1].pos
+		}
+		chain := body[s.pos:end]
+		line := lineBase + strings.Count(body[:s.pos], "\n")
+		c := allographerColumn{name: s.name, typ: s.typ, line: line}
+		if nimAlloUniqueRe.MatchString(chain) {
+			c.unique = true
+		}
+		if nimAlloNullableRe.MatchString(chain) {
+			c.nullable = true
+		}
+		// FK: a .on("table") within this chain (a .foreign chain, or an inline
+		// .reference().on() on a typed column) makes this a foreign key.
+		if om := nimAlloOnRe.FindStringSubmatch(chain); om != nil {
+			c.fkTable = om[1]
+		}
+		if rm := nimAlloReferenceRe.FindStringSubmatch(chain); rm != nil {
+			c.fkColumn = rm[1]
+		}
+		cols = append(cols, c)
+	}
+	return cols
+}
+
+// newAllographerSchema builds a SCOPE.Schema entity with framework=allographer
+// and the given provenance stamp.
+func newAllographerSchema(name, subtype, path string, line int, provenance string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       name,
+		Kind:       "SCOPE.Schema",
+		Subtype:    subtype,
+		SourceFile: path,
+		Language:   "nim",
+		StartLine:  line,
+		EndLine:    line,
+		Properties: map[string]string{
+			"framework":  "allographer",
+			"provenance": provenance,
+		},
+	}
+}

--- a/internal/custom/nim/extractors_test.go
+++ b/internal/custom/nim/extractors_test.go
@@ -331,6 +331,122 @@ proc store(db: DbConn, p: Post) =
 	}
 }
 
+// --- Allographer schema builder (#4933) -------------------------------------
+
+// TestNimAllographerORM_TablesColumnsFK proves an Allographer
+// schema().create(table("...", [Column()...])) declaration synthesises table +
+// column SCOPE.Schema entities (framework=allographer), stamps column_type from
+// the builder method, captures unique/nullable modifiers, and yields a
+// REFERENCES edge table->referenced-table for a .foreign().reference().on()
+// chain.
+func TestNimAllographerORM_TablesColumnsFK(t *testing.T) {
+	src := `
+import allographer/schema_builder
+
+schema().create(
+  table("users", [
+    Column().increments("id"),
+    Column().string("name"),
+    Column().string("email").unique(),
+    Column().integer("age").nullable(),
+  ]),
+  table("posts", [
+    Column().increments("id"),
+    Column().string("title"),
+    Column().foreign("user_id").reference("id").on("users").onDelete(SET_NULL),
+  ]),
+)
+`
+	e, ok := extreg.Get("custom_nim_allographer_orm")
+	if !ok {
+		t.Fatal("custom_nim_allographer_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("src/schema.nim", "nim", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	views := make([]recView, len(ents))
+	for i, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+		}
+		if en.Properties["framework"] != "allographer" {
+			t.Errorf("entity %q missing framework=allographer", en.Name)
+		}
+		views[i] = recView{en.Name, en.Subtype, en.Kind, en.Properties, en.Relationships}
+	}
+	pick := func(name, sub string) *recView {
+		for i := range views {
+			if views[i].name == name && views[i].sub == sub {
+				return &views[i]
+			}
+		}
+		return nil
+	}
+
+	// Tables.
+	for _, tbl := range []string{"users", "posts"} {
+		if pick(tbl, "table") == nil {
+			t.Errorf("expected SCOPE.Schema/table %q", tbl)
+		}
+	}
+	// Columns + column_type.
+	if c := pick("name", "column"); c == nil || c.props["column_type"] != "string" || c.props["table"] != "users" {
+		t.Error("expected users.name column column_type=string")
+	}
+	if c := pick("id", "column"); c == nil || c.props["column_type"] != "increments" {
+		t.Error("expected id column column_type=increments")
+	}
+	// Modifiers.
+	if c := pick("email", "column"); c == nil || c.props["unique"] != "true" {
+		t.Error("expected email column unique=true")
+	}
+	if c := pick("age", "column"); c == nil || c.props["nullable"] != "true" {
+		t.Error("expected age column nullable=true")
+	}
+	// FK column + edge.
+	fkCol := pick("user_id", "column")
+	if fkCol == nil || fkCol.props["foreign_key"] != "true" || fkCol.props["fk_target"] != "users" || fkCol.props["fk_column"] != "id" {
+		t.Errorf("expected user_id column foreign_key=true fk_target=users fk_column=id, got %+v", fkCol)
+	}
+	fkEdge := false
+	if pt := pick("posts", "table"); pt != nil {
+		for _, r := range pt.rels {
+			if r.Kind == "REFERENCES" && r.ToID == "users" && r.Properties["fk_field"] == "user_id" && r.Properties["references"] == "id" {
+				fkEdge = true
+			}
+		}
+	}
+	if !fkEdge {
+		t.Error("expected REFERENCES edge posts->users (fk_field=user_id, references=id)")
+	}
+}
+
+// TestNimAllographerORM_NonSchemaNoop proves an arbitrary Nim file with neither
+// a schema builder nor Column() calls is ignored.
+func TestNimAllographerORM_NonSchemaNoop(t *testing.T) {
+	src := `
+proc table(name: string) = discard
+echo "no columns here"
+`
+	e, _ := extreg.Get("custom_nim_allographer_orm")
+	ents, _ := e.Extract(context.Background(), fi("src/util.nim", "nim", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no schema entities for a non-Allographer file, got %d", len(ents))
+	}
+}
+
+// TestNimAllographerORM_WrongLanguageNoop gates on language=="nim".
+func TestNimAllographerORM_WrongLanguageNoop(t *testing.T) {
+	src := `schema().create(table("users", [Column().string("name")]))`
+	e, _ := extreg.Get("custom_nim_allographer_orm")
+	ents, _ := e.Extract(context.Background(), fi("src/schema.nim", "go", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-nim language, got %d", len(ents))
+	}
+}
+
 // recView is a flattened entity view for table-driven assertions.
 type recView struct {
 	name, sub, kind string

--- a/internal/custom/nim/norm_orm.go
+++ b/internal/custom/nim/norm_orm.go
@@ -56,7 +56,8 @@
 //     to the concrete entity here — the shared resolver handles binding.
 //   - Norm migrations (createTables/dropTables/migration procs) and column
 //     index pragmas beyond unique/dbType remain follow-ups (#4932 → see PR).
-//   - Allographer / ormin / Debby model→table mapping is deferred to #4933.
+//   - Allographer schema→table/column mapping is covered by allographer_orm.go
+//     (#4933); ormin / Debby model→table mapping remains follow-up (#5028).
 //
 // Registration key: "custom_nim_norm_orm".
 package nim


### PR DESCRIPTION
## Summary
Follow-up to #4904/#4932. Adds **Allographer** (Nim query/schema builder) model->table/column schema synthesis, the highest-value of the three ORMs named in #4933, fixture-proven and registry-documented. Mirrors `internal/custom/nim/norm_orm.go`.

## Built (this PR) — `lang.nim.orm.allographer`
New extractor `custom_nim_allographer_orm` (`internal/custom/nim/allographer_orm.go`) over `schema().create(table("name", [Column()...]))`:
- one **SCOPE.Schema/table** per `table("...")` block (identity = the string literal)
- one **SCOPE.Schema/column** per `Column().<method>("col")`; `column_type` = the builder method (string/integer/increments/foreign/…)
- `.unique()` -> `unique=true`, `.nullable()` -> `nullable=true` chain modifiers stamped on the column
- `Column().foreign("col").reference("refCol").on("refTable")` -> **REFERENCES** edge table->referenced-table (fk_field/to_table/references) + `foreign_key=true`/`fk_target`/`fk_column` on the column
- pre-filtered by `nimAllographerHasSchema`; gates on `language=="nim"`
- framework=allographer, provenance stamps; reuses existing Kinds (SCOPE.Schema) + edge kind (REFERENCES) — no new Kinds

**Honest registry cells:** schema_extraction=**full**, foreign_key_extraction=**full**, relationship_extraction=partial. model_extraction/model_lifecycle/association/lazy_loading=**not_applicable** (Allographer is a query/schema builder — the schema builder IS the schema, there is no `ref object` model layer, unlike Norm). Queries=missing (#5030), Migrations=missing (#5029), Transactions=not_applicable.

## Edges
- `REFERENCES` table -> referenced table (FK column chain)

## Fixtures
`internal/custom/nim/extractors_test.go`:
- `TestNimAllographerORM_TablesColumnsFK` — tables, column_type, unique/nullable, FK column + edge (posts.user_id -> users.id) all asserted
- `TestNimAllographerORM_NonSchemaNoop` — arbitrary Nim ignored
- `TestNimAllographerORM_WrongLanguageNoop` — language gate

## Deferred (follow-ups filed)
- **#5028** — ormin (compile-time SQL DSL) + Debby (plain-object model->table); both have a materially different shape from Norm/Allographer (ormin parses an external SQL file; Debby uses plain `object`)
- **#5029** — Allographer `alter()`/`drop()` schema migrations
- **#5030** — Allographer `rdb()` query-builder attribution + rdb() transactions

## Gates (sandbox HOME=/tmp/agsbx-4933)
- `go build ./...` ✅  `go vet ./internal/...` ✅
- `go test ./internal/custom/nim/... ./internal/extractors/nim/... ./internal/types/` ✅
- `coverage fmt --check` ✅  `coverage validate` ✅ (exit 0)

Deploy-deferred. Narrows #4933 (Allographer done; ormin/Debby tracked in #5028).

Refs #4933