### PR TITLE
feat(#4939): fsharp — space-applied call capture + per-call line stamping

### DIFF
--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -7,7 +7,10 @@
 //   - type declarations (record, discriminated union, class, interface, struct, alias)
 //     → Kind="SCOPE.Component"
 //   - open statements → IMPORTS edges
-//   - function applications → CALLS edges
+//   - function applications → CALLS edges. Captured call forms: paren `name(`,
+//     pipe `|> name`, compose `>> name`, and space-applied `head arg`
+//     (F#'s dominant curried-application idiom). Each CALLS edge is stamped with
+//     a 1-based body-relative `line` Property (#4939).
 //   - Module CONTAINS members
 //
 // No tree-sitter grammar for F# is available in smacker/go-tree-sitter, so
@@ -21,6 +24,7 @@ package fsharp
 import (
 	"context"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
@@ -90,6 +94,29 @@ var (
 	// compose operator: >> Module.name
 	composeCallRE = regexp.MustCompile(
 		`>>\s*([A-Za-z_][A-Za-z0-9_.]*)`,
+	)
+
+	// space-application call: F#'s dominant call idiom is curried application
+	// written `head arg1 arg2` (e.g. `createUser "ada"`, `json user next ctx`).
+	// These produce no paren/pipe match, so the head symbol is captured here.
+	//
+	// To stay conservative (F# is whitespace-sensitive and a bare identifier
+	// followed by another identifier is ambiguous with type annotations,
+	// record fields, etc.) the head must sit at a *call position* — the start
+	// of a clause — and be followed by at least one whitespace-separated
+	// argument starter. Recognised clause starters:
+	//   - line start (after indentation)        ^[ \t]*
+	//   - `=` (binding / continuation)           `let x = head arg`
+	//   - `(` `[`                                grouping / list element
+	//   - `|>` `<|` `->` `;` `,`                 pipe / lambda body / sequencing
+	//   - `return` `return!` `yield` `yield!` `do` `do!` `then` `else`
+	// The argument starter is a string/char/number literal, an opening paren or
+	// bracket, or a lower-case identifier (an upper-case follower is more likely
+	// a type/DU-case, so it is excluded to avoid false positives).
+	spaceAppRE = regexp.MustCompile(
+		`(?m)(?:^[ \t]*|[=([;,]\s*|\|>\s*|<\|\s*|->\s*|\breturn!?\s+|\byield!?\s+|\bdo!?\s+|\bthen\s+|\belse\s+)` +
+			`([a-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)` +
+			`[ \t]+(?:"|'|@"|\$"|[0-9]|\(|\[|[a-z_])`,
 	)
 )
 
@@ -484,11 +511,13 @@ func collectCalls(body, callerName string) []types.RelationshipRecord {
 	seen := make(map[string]bool)
 	var out []types.RelationshipRecord
 
-	addCall := func(target string) {
+	// addCall records a CALLS edge to target, stamping the 1-based line (relative
+	// to the function body) at which the call site begins. Duplicate targets keep
+	// the FIRST line seen, matching the Nim/Erlang call_line convention (#4939).
+	addCall := func(target string, off int) {
 		if target == "" || callerName == target {
 			return
 		}
-		// Strip module qualifier if present (e.g. "List.map" → "List.map" kept as-is)
 		if fsharpKeywords[target] {
 			return
 		}
@@ -500,34 +529,73 @@ func collectCalls(body, callerName string) []types.RelationshipRecord {
 			return
 		}
 		seen[target] = true
+		line := 1 + strings.Count(scrubbed[:off], "\n")
 		out = append(out, types.RelationshipRecord{
 			ToID: target,
 			Kind: "CALLS",
+			Properties: map[string]string{
+				"line": strconv.Itoa(line),
+			},
 		})
 	}
 
-	// Regular function calls: name(
-	for _, m := range callRE.FindAllStringSubmatch(scrubbed, -1) {
-		if len(m) >= 2 {
-			addCall(m[1])
+	// Regular function calls: name( — the capture-group start is the call-site
+	// offset used for line stamping.
+	for _, m := range callRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) >= 4 && m[2] >= 0 {
+			addCall(scrubbed[m[2]:m[3]], m[2])
 		}
 	}
 
 	// Pipe operator: |> name or |> Module.name
-	for _, m := range pipeCallRE.FindAllStringSubmatch(scrubbed, -1) {
-		if len(m) >= 2 {
-			addCall(m[1])
+	for _, m := range pipeCallRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) >= 4 && m[2] >= 0 {
+			addCall(scrubbed[m[2]:m[3]], m[2])
 		}
 	}
 
 	// Compose operator: >> name
-	for _, m := range composeCallRE.FindAllStringSubmatch(scrubbed, -1) {
-		if len(m) >= 2 {
-			addCall(m[1])
+	for _, m := range composeCallRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) >= 4 && m[2] >= 0 {
+			addCall(scrubbed[m[2]:m[3]], m[2])
+		}
+	}
+
+	// Space-applied calls: head arg1 arg2 (F#'s dominant idiom). Gated to call
+	// positions so it does not fire on prose, type annotations, or record fields.
+	// Use a literal-preserving scrub: string/char literal bodies are blanked but
+	// the OPENING quote survives as a visible `"`, so a string argument
+	// (`createUser "ada"`) still presents an argument-starter to the scanner.
+	// Byte offsets are preserved, so head positions line up with `scrubbed`.
+	spaceScrubbed := scrubKeepingQuote(body)
+	for _, m := range spaceAppRE.FindAllStringSubmatchIndex(spaceScrubbed, -1) {
+		if len(m) >= 4 && m[2] >= 0 {
+			addCall(spaceScrubbed[m[2]:m[3]], m[2])
 		}
 	}
 
 	return out
+}
+
+// scrubKeepingQuote is like stripStringsAndComments but preserves the OPENING
+// quote of each string/char literal as a visible `"`. This lets the
+// space-application scanner recognise a string argument (`createUser "ada"`)
+// whose body would otherwise be blanked to whitespace. Byte offsets are
+// preserved exactly, so head-symbol offsets stay aligned with the standard scrub.
+func scrubKeepingQuote(src string) string {
+	scrubbed := []byte(stripStringsAndComments(src))
+	i := 0
+	for i < len(scrubbed) {
+		ch := src[i]
+		// A literal opens at a quote/char/verbatim/interpolated start where the
+		// standard scrub blanked it. Restore a single `"` marker, then let the
+		// inner bytes stay blank.
+		if (ch == '"' || ch == '\'') && scrubbed[i] == ' ' {
+			scrubbed[i] = '"'
+		}
+		i++
+	}
+	return string(scrubbed)
 }
 
 // stripStringsAndComments replaces string literals and //-line comments

--- a/internal/extractors/fsharp/fsharp_test.go
+++ b/internal/extractors/fsharp/fsharp_test.go
@@ -336,6 +336,111 @@ let process (n: Node) = n.Value
 	}
 }
 
+// fsRel returns the first relationship matching (name,kind,edgeKind,toID), or nil.
+func fsRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) *types.RelationshipRecord {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == edgeKind && r.ToID == toID {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// TestFSharp_SpaceApplicationCalls proves the space-applied application scanner
+// (#4939): F#'s dominant call idiom `head arg1 arg2` now emits CALLS edges that
+// the paren/pipe/compose scanners miss. This is the evidence behind flipping the
+// fsharp function-application coverage cell.
+func TestFSharp_SpaceApplicationCalls(t *testing.T) {
+	src := `module App
+
+let createUser name email = { Name = name; Email = email }
+let notify msg = printfn "%s" msg
+let render user = sprintf "%A" user
+
+let handler () =
+    let u = createUser "ada" "ada@example.com"
+    notify "created"
+    render u
+`
+	ents := runFSharp(t, src, "app.fs")
+
+	for _, target := range []string{"createUser", "notify", "render"} {
+		if !fsHasRel(ents, "handler", "SCOPE.Operation", "CALLS", target) {
+			t.Errorf("expected space-applied CALLS handler→%s", target)
+		}
+	}
+}
+
+// TestFSharp_SpaceApplicationGating proves the scanner stays conservative: it
+// does NOT fire on keywords, type-case heads, or non-call positions (#4939).
+func TestFSharp_SpaceApplicationGating(t *testing.T) {
+	src := `module App
+
+let helper x = x
+
+let caller flag =
+    if flag then helper 1
+    else helper 2
+`
+	ents := runFSharp(t, src, "g.fs")
+
+	// keyword heads (if/then/else) must never become CALLS
+	for _, kw := range []string{"if", "then", "else"} {
+		if fsHasRel(ents, "caller", "SCOPE.Operation", "CALLS", kw) {
+			t.Errorf("keyword %q must not produce a CALLS edge", kw)
+		}
+	}
+	// the real call (helper, applied after `then`/`else`) should be captured
+	if !fsHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("expected CALLS caller→helper from then/else clause")
+	}
+}
+
+// TestFSharp_CallLineStamping proves every CALLS edge carries a 1-based body
+// line Property (#4939), matching the Nim/Erlang call_line_precision convention.
+func TestFSharp_CallLineStamping(t *testing.T) {
+	src := `module App
+
+let helper x = x * 2
+let other y = y + 1
+
+let caller n =
+    let a = helper(n)
+    let b = other n
+    a + b
+`
+	ents := runFSharp(t, src, "lines.fs")
+
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "CALLS" {
+				continue
+			}
+			if r.Properties == nil || r.Properties["line"] == "" {
+				t.Errorf("CALLS %s→%s missing line Property (got %v)", e.Name, r.ToID, r.Properties)
+			}
+		}
+	}
+
+	// paren-call `helper(n)` is on body line 2, space-call `other n` on body line 3.
+	if r := fsRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper"); r == nil {
+		t.Error("expected CALLS caller→helper")
+	} else if r.Properties["line"] != "2" {
+		t.Errorf("helper call line = %q, want 2", r.Properties["line"])
+	}
+	if r := fsRel(ents, "caller", "SCOPE.Operation", "CALLS", "other"); r == nil {
+		t.Error("expected CALLS caller→other")
+	} else if r.Properties["line"] != "3" {
+		t.Errorf("other call line = %q, want 3", r.Properties["line"])
+	}
+}
+
 // TestFSharp_MemberFunctions — member definitions extracted as SCOPE.Operation.
 func TestFSharp_MemberFunctions(t *testing.T) {
 	src := `module App


### PR DESCRIPTION
## Built
Implements #4939 in the F# base extractor (`internal/extractors/fsharp/extractor.go` `collectCalls`):

- **Space-applied call capture** — F#'s dominant call idiom `head arg1 arg2` (e.g. `createUser "ada"`, `json user next ctx`) produced no CALLS edge before (only paren `name(`, pipe `|>`, compose `>>` were captured). New `spaceAppRE` head-symbol scanner captures it.
  - **Gated** to call positions: head must follow a clause-starter (line start / `=` / `(` / `[` / `|>` / `<|` / `->` / `;` / `,` / return / yield / do / then / else) and be followed by an argument-starter (string/char/number literal, `(`/`[`, or a lower-case identifier — upper-case excluded as likely DU-cases/types). Does not fire on prose, type annotations, or record fields.
  - `scrubKeepingQuote` — literal-preserving scrub that keeps each literal's opening quote visible (body blanked) so a string argument registers as an argument-starter without leaking string contents. Byte offsets preserved.
  - Existing keyword denylist, single-letter filter, self-recursion filter, per-body dedup all still apply.
- **Per-call line stamping** — every CALLS edge (paren/pipe/compose/space) now carries a 1-based body-relative `line` Property, matching the Nim/Erlang `call_line_precision` convention. Computed from the call-site capture-group offset via `FindAllStringSubmatchIndex`.

## Edges
`CALLS` (existing kind) — now from 4 call shapes instead of 3, each stamped with `Properties["line"]`. No new entity Kinds or edge kinds.

## Registry cells
- `lang.fsharp.core` / `call_line_precision`: **partial -> full** (issue 4906 -> 4939). Cites add `fsharp_test.go`. Notes rewritten to describe the 4 shapes, gating, scrubKeepingQuote, line stamping, and honest residuals.

## Fixtures
- `TestFSharp_SpaceApplicationCalls` — `createUser "ada"` / `notify "created"` / `render u` all emit CALLS.
- `TestFSharp_SpaceApplicationGating` — keyword heads (if/then/else) never become CALLS; real `helper` after then/else is captured.
- `TestFSharp_CallLineStamping` — every CALLS edge has a `line` Property; paren `helper(n)` = body line 2, space `other n` = body line 3.

## Deferred -> #5034
File-absolute line stamping (currently body-relative, matching Nim/Erlang); testmap `directCallRE` space-application resolver (cross-language-sensitive); partial-vs-full application distinction.

## Gates (sandbox HOME=/tmp/agsbx-4939)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/fsharp/... ./internal/custom/fsharp/... ./internal/types/` — all pass. `coverage fmt --check` + `coverage validate` pass; registry diff is 4 lines (surgical).

Closes #4939