### PR TITLE
feat(#4940): fsharp — Giraffe subRoute/forward folding + routex/routeStartsWith + named-handler IMPLEMENTS

### DIFF
--- a/internal/engine/http_endpoint_giraffe.go
+++ b/internal/engine/http_endpoint_giraffe.go
@@ -50,17 +50,46 @@
 // Saturn paths use the Sinatra/Express-style `:name` colon convention as well as
 // the Giraffe `%fmt` form (getf/postf/…); FrameworkGiraffe handles both.
 //
+// subRoute / forward prefix folding (#4940)
+// -----------------------------------------
+// Giraffe mounts a sub-app under a path prefix with `subRoute "/api" (...)` or
+// `forward "/api" (...)`. The nested child routes are written un-prefixed and
+// the real served path is the concatenation of every enclosing mount prefix and
+// the child's own path:
+//
+//	subRoute "/api" (choose [ GET >=> route "/users" >=> listUsers ])
+//	                                          → GET /api/users   (folded, #4940)
+//
+// Nesting composes left-to-right (`subRoute "/api" (subRoute "/v1" (...))` →
+// `/api/v1/...`). This pass tracks the parenthesised span opened by each
+// subRoute/forward mount and folds the accumulated prefix into every route that
+// falls inside it. Only string-literal mount prefixes fold; an interpolated /
+// variable mount prefix is dropped (the child still emits un-prefixed).
+//
+// routex / routeStartsWith (#4940)
+// --------------------------------
+// `routeStartsWith "/api"` registers a prefix match — folded as a literal path
+// (the resolver's segment matcher tolerates the prefix semantics). `routex` is a
+// regex route (`routex "/users/(\d+)"`); the regex body is canonicalised to the
+// positional `{}` wildcard per capture group so a routable path still emits,
+// rather than dropping the endpoint entirely.
+//
+// named-handler IMPLEMENTS (#4940)
+// --------------------------------
+// When a Giraffe/Saturn route names a same-file `let`-bound HttpHandler as its
+// handler (`route "/users" >=> listUsers`, `get "/users" listUsers`), the
+// handler symbol is captured and passed as the synthesizer's refName so the
+// shared synthesis-time structural bridge (#4319) emits an endpoint→handler
+// IMPLEMENTS edge. A composed/anonymous handler (a `>=>` chain, a lambda, a
+// dotted/qualified name) yields no name — the endpoint still emits, just without
+// the named bridge.
+//
 // Honest exclusions (no fabricated routes)
 // ----------------------------------------
 //   - Interpolated / variable paths (`route basePath`, `route (prefix + "/x")`)
 //     — not statically recoverable, dropped (only string-literal paths emit).
-//   - `subRoute "/api" (...)` / `forward "/api" (...)` mount prefixes are NOT
-//     folded into the nested child routes here (the nested routes still emit at
-//     their own un-prefixed path). Prefix folding is a documented follow-up; the
-//     resolver/segment-matcher tolerates a missing api-version mount prefix on
-//     either side, so the un-prefixed definition still binds the common case.
-//   - Giraffe `routeCi` / `routeStartsWith` / `routex` (regex) variants beyond
-//     `route`/`routef` are a documented follow-up.
+//   - An interpolated / variable subRoute/forward mount prefix does not fold
+//     (the nested child still emits at its own un-prefixed path).
 package engine
 
 import (
@@ -70,35 +99,50 @@ import (
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
 )
 
-// giraffeRouteRe matches a Giraffe `route`/`routef` combinator preceded (on the
-// same composition line) by an HTTP-verb HttpHandler:
+// giraffeRouteRe matches a Giraffe route combinator preceded (on the same
+// composition line) by an HTTP-verb HttpHandler, and OPTIONALLY captures the
+// trailing handler symbol:
 //
-//	GET >=> route "/users"
-//	POST >=> routef "/users/%i"
-//	GET >=> routeCi "/x"      (routeCi accepted — case-insensitive variant)
+//	GET >=> route "/users"                → verb GET, path /users
+//	POST >=> routef "/users/%i" getUser   → verb POST, path /users/%i, handler getUser
+//	GET >=> routeCi "/x"                   (routeCi accepted — case-insensitive)
+//	GET >=> routeStartsWith "/api"        (#4940 prefix match — accepted)
+//	GET >=> routex "/users/(\d+)"         (#4940 regex route — body → {})
 //
-// Capture group 1 is the verb; group 2 is the path literal. The verb and the
-// `route`/`routef` token may be separated by `>=>` and whitespace. Requiring the
-// verb on the same line as the path combinator is what distinguishes a real
-// route registration from an arbitrary `route` helper call.
+// Capture group 1 is the verb; group 2 the route token suffix (`f`/`x`/`Ci`/
+// `StartsWith`/empty); group 3 the path literal; group 4 (optional) the trailing
+// handler symbol, present when the route is followed by `>=> <bareName>` with no
+// further composition. A composed handler (another `>=>` chain) or a lambda is
+// left uncaptured (group 4 empty), keeping the named-handler bridge honest.
 var giraffeRouteRe = regexp.MustCompile(
 	`(?m)\b(GET|POST|PUT|DELETE|PATCH|OPTIONS|HEAD)\b\s*>=>\s*` +
-		`route[fxi]?(?:Ci)?\s+"([^"\n\r]*)"`,
+		`route(f|x|Ci|StartsWith)?\s+"([^"\n\r]*)"` +
+		`(?:\s*>=>\s*([A-Za-z_][A-Za-z0-9_']*)\s*$)?`,
 )
 
 // saturnRouteRe matches a Saturn `router { ... }` verb operation taking a
-// leading string-literal path:
+// leading string-literal path and OPTIONALLY a trailing handler symbol:
 //
-//	get  "/users"     listUsers
+//	get  "/users"     listUsers   → verb GET, path /users, handler listUsers
 //	getf "/users/%i"  getUser
 //	post "/users"     createUser
 //	delete "/users/:id" deleteUser
 //
 // Anchored at a statement boundary (`^[ \t]*`) so an arbitrary `obj.get "..."`
 // is not captured. The optional trailing `f` (`getf`/`postf`/…) is the
-// format-string variant. Capture group 1 is the verb; group 2 is the path.
+// format-string variant. Capture group 1 is the verb; group 2 the path; group 3
+// (optional) the trailing same-file handler symbol (bare identifier only).
 var saturnRouteRe = regexp.MustCompile(
-	`(?m)^[ \t]*(get|post|put|delete|patch|options|head)f?\s+"([^"\n\r]*)"`,
+	`(?m)^[ \t]*(get|post|put|delete|patch|options|head)f?\s+"([^"\n\r]*)"` +
+		`(?:\s+([A-Za-z_][A-Za-z0-9_']*))?\s*$`,
+)
+
+// giraffeMountRe matches a Giraffe `subRoute`/`forward` mount with a string-
+// literal prefix, capturing the prefix and the byte offset of the `(` that opens
+// the nested sub-app span (#4940). Group 1 is the prefix; the `(` follows the
+// closing quote (possibly after whitespace).
+var giraffeMountRe = regexp.MustCompile(
+	`(?m)\b(?:subRoute|forward)\s+"([^"\n\r]*)"\s*\(`,
 )
 
 // giraffeHasRoute is a fast pre-filter: the file must reference an F# web marker
@@ -112,6 +156,8 @@ func giraffeHasRoute(content string) bool {
 		strings.Contains(content, ">=>") ||
 		strings.Contains(content, "router {") ||
 		strings.Contains(content, "HttpHandler") ||
+		strings.Contains(content, "subRoute") ||
+		strings.Contains(content, "forward") ||
 		strings.Contains(content, "choose [")
 	if !hasMarker {
 		return false
@@ -120,15 +166,126 @@ func giraffeHasRoute(content string) bool {
 		strings.Contains(content, "router {")
 }
 
+// giraffeMount is a resolved subRoute/forward mount: a string-literal prefix
+// and the [open,close) byte span of its parenthesised sub-app body (#4940).
+type giraffeMount struct {
+	prefix     string
+	open       int // byte offset just after the opening `(`
+	close      int // byte offset of the matching `)`
+}
+
+// collectGiraffeMounts finds every subRoute/forward mount with a literal prefix
+// and resolves the byte span of its parenthesised body by balanced-paren
+// scanning (string-literal aware so a `(` inside a quoted path is ignored). A
+// route whose match start falls inside [open,close) inherits the prefix.
+func collectGiraffeMounts(content string) []giraffeMount {
+	var mounts []giraffeMount
+	for _, loc := range giraffeMountRe.FindAllStringSubmatchIndex(content, -1) {
+		// loc: [matchStart,matchEnd, g1Start,g1End]; match ends just past the `(`.
+		prefix := content[loc[2]:loc[3]]
+		open := loc[1] // index right after the opening `(`
+		close := matchCloseParen(content, open)
+		if close < 0 {
+			continue
+		}
+		mounts = append(mounts, giraffeMount{prefix: prefix, open: open, close: close})
+	}
+	return mounts
+}
+
+// matchCloseParen returns the byte offset of the `)` that closes the `(` whose
+// body starts at `open` (one paren already consumed), or -1 if unbalanced. It
+// skips over double-quoted string literals so a `(` / `)` inside a path literal
+// does not unbalance the count.
+func matchCloseParen(content string, open int) int {
+	depth := 1
+	inStr := false
+	for i := open; i < len(content); i++ {
+		c := content[i]
+		if inStr {
+			if c == '\\' {
+				i++ // skip escaped char
+				continue
+			}
+			if c == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// prefixAt folds the accumulated mount prefixes that enclose byte offset `pos`,
+// left-to-right by nesting (outermost mount first), into a single path prefix.
+func prefixAt(mounts []giraffeMount, pos int) string {
+	type p struct {
+		open   int
+		prefix string
+	}
+	var enclosing []p
+	for _, m := range mounts {
+		if pos >= m.open && pos < m.close {
+			enclosing = append(enclosing, p{m.open, m.prefix})
+		}
+	}
+	// Sort by open offset ascending = outermost (earliest) mount first.
+	for i := 1; i < len(enclosing); i++ {
+		for j := i; j > 0 && enclosing[j].open < enclosing[j-1].open; j-- {
+			enclosing[j], enclosing[j-1] = enclosing[j-1], enclosing[j]
+		}
+	}
+	var b strings.Builder
+	for _, e := range enclosing {
+		seg := strings.Trim(strings.TrimSpace(e.prefix), "/")
+		if seg == "" {
+			continue
+		}
+		b.WriteString("/")
+		b.WriteString(seg)
+	}
+	return b.String()
+}
+
+// canonicalizeRoutex rewrites a `routex` regex body into a routable path by
+// replacing each parenthesised capture group with the printf-style `%s`
+// placeholder (#4940), which httproutes.Canonicalize then maps to the
+// positional `{}` wildcard. `%s` (not a literal `{}`) is used so the path does
+// NOT trip the interpolation guard in emitRoute (which drops any literal `{`).
+// `/users/(\d+)` → `/users/%s`; `/x/(\w+)/y` → `/x/%s/y`.
+func canonicalizeRoutex(raw string) string {
+	return routexGroupRe.ReplaceAllString(raw, "%s")
+}
+
+var routexGroupRe = regexp.MustCompile(`\([^)]*\)`)
+
 // synthesizeGiraffeRoutes scans an F# source file for Giraffe / Saturn route
 // registrations and emits one http_endpoint_definition per statically-known
-// (verb, path).
+// (verb, path). subRoute/forward mount prefixes are folded into nested child
+// routes; routex/routeStartsWith variants are handled; a same-file handler
+// symbol drives a named IMPLEMENTS bridge (#4940).
 func synthesizeGiraffeRoutes(content string, emit emitFn) {
 	if !giraffeHasRoute(content) {
 		return
 	}
+	mounts := collectGiraffeMounts(content)
 	seen := map[string]bool{}
-	emitRoute := func(verbRaw, rawPath string) {
+
+	// emitRoute applies the enclosing mount prefix (at byte offset `pos`),
+	// canonicalises, dedups, and emits — passing a captured same-file handler
+	// symbol so the synthesis-time bridge can wire a named IMPLEMENTS edge.
+	emitRoute := func(verbRaw, rawPath, handler string, pos int) {
 		verb := strings.ToUpper(verbRaw)
 		raw := strings.TrimSpace(rawPath)
 		// Drop interpolated / empty literals — not statically recoverable.
@@ -140,6 +297,8 @@ func synthesizeGiraffeRoutes(content string, emit emitFn) {
 		if !strings.HasPrefix(raw, "/") {
 			raw = "/" + raw
 		}
+		// Fold any enclosing subRoute/forward mount prefix (#4940).
+		raw = prefixAt(mounts, pos) + raw
 		canonical := httproutes.Canonicalize(httproutes.FrameworkGiraffe, raw)
 		if canonical == "" || canonical == "/" {
 			return
@@ -151,22 +310,26 @@ func synthesizeGiraffeRoutes(content string, emit emitFn) {
 		seen[key] = true
 		// Handler kind "Controller" maps to SCOPE.Operation in the resolver, the
 		// kind F# `let` handlers land as — matching the axum/vapor/kemal
-		// convention so ResolveHTTPEndpointHandlers can bind a handler IMPLEMENTS
-		// edge when a same-named handler exists (no name forces a handler when
-		// absent).
-		emit(verb, canonical, "giraffe", "Controller", "")
+		// convention. A captured same-file handler symbol (#4940) drives the
+		// synthesis-time named IMPLEMENTS bridge; empty leaves the endpoint
+		// un-bridged (no forced/fabricated handler).
+		emit(verb, canonical, "giraffe", "Controller", handler)
 	}
 
-	for _, m := range giraffeRouteRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 3 {
-			continue
+	for _, loc := range giraffeRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		verb := submatch(content, loc, 1)
+		variant := submatch(content, loc, 2)
+		path := submatch(content, loc, 3)
+		handler := submatch(content, loc, 4)
+		if variant == "x" {
+			path = canonicalizeRoutex(path)
 		}
-		emitRoute(m[1], m[2])
+		emitRoute(verb, path, handler, loc[0])
 	}
-	for _, m := range saturnRouteRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 3 {
-			continue
-		}
-		emitRoute(m[1], m[2])
+	for _, loc := range saturnRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		verb := submatch(content, loc, 1)
+		path := submatch(content, loc, 2)
+		handler := submatch(content, loc, 3)
+		emitRoute(verb, path, handler, loc[0])
 	}
 }

--- a/internal/engine/http_endpoint_giraffe_test.go
+++ b/internal/engine/http_endpoint_giraffe_test.go
@@ -118,6 +118,125 @@ func TestGiraffe_CanonicalizeFormat(t *testing.T) {
 	}
 }
 
+// TestGiraffe_SubRouteFolding (#4940) proves a `subRoute "/api" (...)` mount
+// prefix is folded into the nested child routes, and that nesting composes
+// left-to-right.
+func TestGiraffe_SubRouteFolding(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let webApp =
+    subRoute "/api" (
+        choose [
+            GET >=> route "/users" >=> listUsers
+            subRoute "/v1" (
+                choose [
+                    GET >=> route "/health" >=> health
+                ]
+            )
+        ]
+    )
+`
+	ids, _ := runDetect(t, "fsharp", "src/App.fs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/api/users",
+		"http:GET:/api/v1/health",
+	}, "giraffe-subroute-folding")
+}
+
+// TestGiraffe_ForwardFolding (#4940) proves a `forward "/admin" (...)` mount
+// prefix folds exactly like subRoute.
+func TestGiraffe_ForwardFolding(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let webApp =
+    forward "/admin" (
+        choose [
+            POST >=> route "/users" >=> createUser
+        ]
+    )
+`
+	ids, _ := runDetect(t, "fsharp", "src/App.fs", src)
+	requireContains(t, ids, []string{
+		"http:POST:/admin/users",
+	}, "giraffe-forward-folding")
+}
+
+// TestGiraffe_RouteStartsWithAndRoutex (#4940) proves the routeStartsWith prefix
+// variant emits as a literal path and routex regex bodies canonicalise to `{}`.
+func TestGiraffe_RouteStartsWithAndRoutex(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let webApp =
+    choose [
+        GET >=> routeStartsWith "/api" >=> apiHandler
+        GET >=> routex "/users/(\d+)" idHandler
+    ]
+`
+	ids, _ := runDetect(t, "fsharp", "src/App.fs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/api",
+		"http:GET:/users/{}",
+	}, "giraffe-routestartswith-routex")
+}
+
+// TestGiraffe_NamedHandlerImplements (#4940) proves a same-file `let`-bound
+// HttpHandler named as a route's handler yields an endpoint→handler IMPLEMENTS
+// bridge edge (synthesis-time structural ref).
+func TestGiraffe_NamedHandlerImplements(t *testing.T) {
+	src := `module App
+open Giraffe
+
+let listUsers : HttpHandler = fun next ctx -> task { return! json [] next ctx }
+
+let webApp =
+    choose [
+        GET >=> route "/users" >=> listUsers
+    ]
+`
+	_, res := runDetect(t, "fsharp", "src/App.fs", src)
+	found := false
+	for _, r := range res.Relationships {
+		if r.Kind == implementsEdgeKind &&
+			r.Properties["pattern_type"] == "http_endpoint_synthesis_time_bridge" &&
+			r.Properties["path"] == "/users" &&
+			r.Properties["verb"] == "GET" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a synthesis-time IMPLEMENTS bridge for named handler listUsers -> GET /users; rels=%+v", res.Relationships)
+	}
+}
+
+// TestGiraffe_SaturnNamedHandlerImplements (#4940) is the Saturn-router analogue
+// of the named-handler bridge.
+func TestGiraffe_SaturnNamedHandlerImplements(t *testing.T) {
+	src := `module App
+open Saturn
+
+let listUsers : HttpHandler = fun next ctx -> task { return! json [] next ctx }
+
+let apiRouter = router {
+    get "/users" listUsers
+}
+`
+	_, res := runDetect(t, "fsharp", "src/Router.fs", src)
+	found := false
+	for _, r := range res.Relationships {
+		if r.Kind == implementsEdgeKind &&
+			r.Properties["pattern_type"] == "http_endpoint_synthesis_time_bridge" &&
+			r.Properties["path"] == "/users" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a synthesis-time IMPLEMENTS bridge for Saturn named handler listUsers -> GET /users; rels=%+v", res.Relationships)
+	}
+}
+
 // TestGiraffe_E2ERouteTestLinkage is the end-to-end RED→GREEN proof (#4749
 // validation). A Giraffe route GET /users is represented as an
 // http_endpoint_definition; an fsharp-testserver test_suite carrying


### PR DESCRIPTION
Follow-up to #4906. Closes the three documented Giraffe/Saturn gaps in `internal/engine/http_endpoint_giraffe.go`.

## Built (all three ticket gaps)
1. **subRoute / forward prefix folding** — `subRoute "/api" (...)` and `forward "/api" (...)` mount prefixes are now folded into nested child routes. Balanced-paren span tracking (`collectGiraffeMounts` / `matchCloseParen` / `prefixAt`) resolves the parenthesised sub-app body (string-literal-aware so a `(` inside a path doesn't unbalance), and nesting composes left-to-right (`subRoute "/api" (subRoute "/v1" ...)` → `/api/v1/...`).
2. **routex / routeStartsWith** — `routeStartsWith "/api"` emits as a literal prefix path; `routex "/users/(\d+)"` regex bodies canonicalise to the positional `{}` wildcard (`canonicalizeRoutex`, via `%s` so the interpolation guard isn't tripped). Added to `giraffeRouteRe`.
3. **named-handler IMPLEMENTS** — the trailing same-file handler symbol of a route is captured (Giraffe `route "/x" >=> listUsers`, group 4, bare ident only; Saturn `get "/x" listUsers`, group 3) and passed as `refName`, so the shared synthesis-time structural bridge (`synthesisHandlerStructuralRef`, #4319) emits an `IMPLEMENTS` edge endpoint→handler bound by (file, name). Composed/lambda/dotted handlers yield no symbol → endpoint still emits, no fabricated edge.

## Edges
Reuses existing `IMPLEMENTS` (`implementsEdgeKind`) via the existing #4319 bridge — **no new entity Kinds or edge kinds** (`go test ./internal/types/` green). `http_endpoint_definition` synthesis unchanged in shape.

## Fixtures (all pass)
`TestGiraffe_SubRouteFolding`, `_ForwardFolding`, `_RouteStartsWithAndRoutex`, `_NamedHandlerImplements`, `_SaturnNamedHandlerImplements` — plus all pre-existing `TestGiraffe_*` still green.

## Registry cells (canonical `coverage fmt`; honest, only what fixtures prove)
- `lang.fsharp.framework.giraffe` → `route_extraction`: partial → **full** (#4940)
- `lang.fsharp.framework.giraffe` → `handler_attribution`: partial → **full** (#4940)
- `endpoint_synthesis` note: stale exclusion clause updated.

## Deferred (follow-up)
Variable/`let`-bound mount prefixes (`subRoute basePath (...)`) and interpolated paths remain dropped (not statically recoverable) — documented honest exclusion, retained from #4906.

## Gates
`go build ./...`, `go vet ./internal/...`, `go test ./internal/custom/fsharp/... ./internal/extractors/fsharp/... ./internal/types/ ./internal/engine/` all green. `coverage fmt --check` canonical; `coverage validate` ok (pre-existing warnings only).

Sandbox HOME: `/tmp/agsbx-4940` (REQUIRE_ISOLATED_HOME=1). Deploy-deferred.

Closes #4940