### PR TITLE
feat(#4946): cobol — PERFORM THRU/GO TO control flow + expanded mutation effects

### DIFF
--- a/internal/extractors/cobol/extractor.go
+++ b/internal/extractors/cobol/extractor.go
@@ -84,6 +84,20 @@ var (
 	// Group 1: target paragraph/section name.
 	performRe = regexp.MustCompile(`(?i)\bPERFORM\s+([A-Za-z0-9][A-Za-z0-9-]*)`)
 
+	// performThruRe matches `PERFORM <a> THRU <b>` / `PERFORM <a> THROUGH <b>`
+	// out-of-line range execution (#4946). Group 1: range-start paragraph;
+	// group 2: range-end paragraph. The range end is an additional control
+	// target — the PERFORM transfers through every paragraph from <a> to <b>,
+	// so we model both endpoints as CALLS edges (start via=PERFORM by the
+	// general performRe above, end via=PERFORM-THRU here).
+	performThruRe = regexp.MustCompile(`(?i)\bPERFORM\s+([A-Za-z0-9][A-Za-z0-9-]*)\s+(?:THRU|THROUGH)\s+([A-Za-z0-9][A-Za-z0-9-]*)`)
+
+	// goToTargetsRe captures the whole target list of a GO TO statement up to
+	// the terminating period / DEPENDING clause, so `GO TO A B C DEPENDING ON X`
+	// yields each of A, B, C as a branch target.
+	goToTargetsRe   = regexp.MustCompile(`(?i)\bGO\s*TO\s+([A-Za-z][A-Za-z0-9- ]*?)(?:\s+DEPENDING\b|\.|$)`)
+	cobolIdentRe    = regexp.MustCompile(`[A-Za-z][A-Za-z0-9-]*`)
+
 	// callRe matches `CALL '<program>'` / `CALL "<program>"` dynamic calls.
 	// Group 1: literal program name (without quotes).
 	callLiteralRe = regexp.MustCompile(`(?i)\bCALL\s+['"]([A-Za-z0-9$#@][A-Za-z0-9$#@_-]*)['"]`)
@@ -635,6 +649,48 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 					},
 				}
 				attachCall(entities, currentParagraphIdx, programIdx, rel)
+			}
+
+			// PERFORM <a> THRU <b> → CALLS to the range-end paragraph (#4946).
+			// The start paragraph is already emitted by performRe above; the
+			// THRU/THROUGH end is the additional control target the PERFORM
+			// reaches by falling through the paragraph range.
+			for _, tm := range performThruRe.FindAllStringSubmatch(ln.code, -1) {
+				rangeEnd := tm[2]
+				if performInlineKeywords[strings.ToUpper(rangeEnd)] {
+					continue
+				}
+				rel := types.RelationshipRecord{
+					ToID: rangeEnd,
+					Kind: "CALLS",
+					Properties: map[string]string{
+						"line":        strconv.Itoa(ln.num),
+						"via":         "PERFORM-THRU",
+						"range_start": tm[1],
+					},
+				}
+				attachCall(entities, currentParagraphIdx, programIdx, rel)
+			}
+
+			// GO TO <para> [<para>...] [DEPENDING ON x] → CALLS (intra-program
+			// unconditional / conditional branch, #4946). Each target paragraph
+			// in the list becomes a control-flow edge tagged via=GO-TO.
+			for _, gm := range goToTargetsRe.FindAllStringSubmatch(ln.code, -1) {
+				for _, target := range cobolIdentRe.FindAllString(gm[1], -1) {
+					up := strings.ToUpper(target)
+					if cobolReservedHeads[up] || performInlineKeywords[up] {
+						continue
+					}
+					rel := types.RelationshipRecord{
+						ToID: target,
+						Kind: "CALLS",
+						Properties: map[string]string{
+							"line": strconv.Itoa(ln.num),
+							"via":  "GO-TO",
+						},
+					}
+					attachCall(entities, currentParagraphIdx, programIdx, rel)
+				}
 			}
 
 			// CALL '<program>' → CALLS (external, inter-program).

--- a/internal/extractors/cobol/extractor_test.go
+++ b/internal/extractors/cobol/extractor_test.go
@@ -166,6 +166,91 @@ func TestExtractor_PerformIsIntraCall(t *testing.T) {
 	}
 }
 
+// relByViaTo returns the first CALLS edge to target whose via property equals
+// via, or false.
+func relByViaTo(recs []types.EntityRecord, target, via string) (types.RelationshipRecord, bool) {
+	for _, rel := range relationsByKind(recs, "CALLS") {
+		if rel.ToID == target && rel.Properties["via"] == via {
+			return rel, true
+		}
+	}
+	return types.RelationshipRecord{}, false
+}
+
+// TestExtractor_PerformThruRange proves PERFORM <a> THRU <b> emits CALLS edges
+// to both range endpoints (#4946): the start via=PERFORM and the end
+// via=PERFORM-THRU carrying range_start.
+func TestExtractor_PerformThruRange(t *testing.T) {
+	src := "" +
+		"       IDENTIFICATION DIVISION.\n" +
+		"       PROGRAM-ID. RANGER.\n" +
+		"       PROCEDURE DIVISION.\n" +
+		"       MAIN-PARA.\n" +
+		"           PERFORM STEP-A THRU STEP-C.\n" +
+		"           PERFORM STEP-D THROUGH STEP-E.\n" +
+		"           GOBACK.\n" +
+		"       STEP-A.\n" +
+		"           CONTINUE.\n" +
+		"       STEP-C.\n" +
+		"           CONTINUE.\n" +
+		"       STEP-D.\n" +
+		"           CONTINUE.\n" +
+		"       STEP-E.\n" +
+		"           CONTINUE.\n"
+	recs := run(t, "ranger.cbl", src)
+
+	// Start endpoints emitted via=PERFORM.
+	if _, ok := relByViaTo(recs, "STEP-A", "PERFORM"); !ok {
+		t.Error("expected PERFORM edge to range-start STEP-A")
+	}
+	// THRU end emitted via=PERFORM-THRU with range_start.
+	end, ok := relByViaTo(recs, "STEP-C", "PERFORM-THRU")
+	if !ok {
+		t.Fatal("expected PERFORM-THRU edge to range-end STEP-C")
+	}
+	if end.Properties["range_start"] != "STEP-A" {
+		t.Errorf("PERFORM-THRU edge to STEP-C missing range_start=STEP-A: %v", end.Properties)
+	}
+	// THROUGH spelling also works.
+	if _, ok := relByViaTo(recs, "STEP-E", "PERFORM-THRU"); !ok {
+		t.Error("expected PERFORM-THRU edge for THROUGH spelling to STEP-E")
+	}
+}
+
+// TestExtractor_GoToControlFlow proves GO TO emits intra-program CALLS edges
+// tagged via=GO-TO, including the DEPENDING ON multi-target form (#4946).
+func TestExtractor_GoToControlFlow(t *testing.T) {
+	src := "" +
+		"       IDENTIFICATION DIVISION.\n" +
+		"       PROGRAM-ID. BRANCHER.\n" +
+		"       PROCEDURE DIVISION.\n" +
+		"       MAIN-PARA.\n" +
+		"           GO TO EXIT-PARA.\n" +
+		"       DISPATCH-PARA.\n" +
+		"           GO TO OPT-ONE OPT-TWO OPT-THREE DEPENDING ON WS-IDX.\n" +
+		"       EXIT-PARA.\n" +
+		"           GOBACK.\n" +
+		"       OPT-ONE.\n" +
+		"           CONTINUE.\n" +
+		"       OPT-TWO.\n" +
+		"           CONTINUE.\n" +
+		"       OPT-THREE.\n" +
+		"           CONTINUE.\n"
+	recs := run(t, "brancher.cbl", src)
+
+	for _, target := range []string{"EXIT-PARA", "OPT-ONE", "OPT-TWO", "OPT-THREE"} {
+		if _, ok := relByViaTo(recs, target, "GO-TO"); !ok {
+			t.Errorf("expected GO-TO CALLS edge to %q", target)
+		}
+	}
+	// DEPENDING / ON must not become spurious targets.
+	for _, notTarget := range []string{"DEPENDING", "ON", "WS-IDX"} {
+		if _, ok := relByViaTo(recs, notTarget, "GO-TO"); ok {
+			t.Errorf("GO TO produced a spurious GO-TO edge to %q", notTarget)
+		}
+	}
+}
+
 func TestExtractor_CallIsExternal(t *testing.T) {
 	src := loadFixture(t, "payroll.cbl")
 	recs := run(t, "payroll.cbl", src)

--- a/internal/substrate/effect_sinks_cobol.go
+++ b/internal/substrate/effect_sinks_cobol.go
@@ -13,9 +13,12 @@
 //     / service calls treated as the COBOL analog of an outbound
 //     request (the closest effect in the lattice for CICS
 //     inter-program / service control transfers)
-//   - mutation : MOVE ... TO <ident> / SET <ident> / COMPUTE <ident> — an
-//     observable working-storage state write (low confidence; the
-//     most common COBOL statement so it is intentionally weak)
+//   - mutation : MOVE ... TO <ident> / SET <ident> / COMPUTE <ident> /
+//     ADD|SUBTRACT|MULTIPLY|DIVIDE ... GIVING <ident> /
+//     STRING|UNSTRING ... INTO <ident> / INITIALIZE <ident> /
+//     INSPECT ... REPLACING (#4946) — an observable working-storage
+//     state write (low confidence; the most common COBOL statement
+//     so it is intentionally weak)
 //
 // Function attribution binds each sink to the nearest preceding PARAGRAPH
 // header (a lone identifier + period in Area A inside PROCEDURE DIVISION).
@@ -88,11 +91,25 @@ var cobolCICSFSWriteRe = regexp.MustCompile(
 	`(?is)EXEC\s+CICS\b[^.]*?\b(?:WRITEQ|WRITE|REWRITE|DELETEQ|DELETE)\b`,
 )
 
-// cobolMutationRe matches working-storage state writes.
+// cobolMutationRe matches working-storage state writes. Beyond the core
+// MOVE/SET/COMPUTE writes (#2743), it covers the arithmetic GIVING forms and
+// the string / table mutation verbs (#4946):
+//
+//   - ADD/SUBTRACT/MULTIPLY/DIVIDE ... GIVING <ident> — the GIVING target is
+//     the written receiving field (the non-GIVING form mutates the trailing
+//     operand and is covered by the leading-verb alternatives).
+//   - STRING ... INTO <ident> / UNSTRING ... INTO <ident> — concatenation /
+//     split write into a receiving data item.
+//   - INITIALIZE <ident> — resets one or more data items to their default.
+//   - INSPECT <ident> ... REPLACING — in-place character substitution write.
 var cobolMutationRe = regexp.MustCompile(
 	`(?im)\bMOVE\b[^.]*?\bTO\s+[A-Za-z]` +
 		`|\bSET\s+[A-Za-z][A-Za-z0-9-]*\s+TO\b` +
-		`|\bCOMPUTE\s+[A-Za-z]`,
+		`|\bCOMPUTE\s+[A-Za-z]` +
+		`|\b(?:ADD|SUBTRACT|MULTIPLY|DIVIDE)\b[^.]*?\bGIVING\s+[A-Za-z]` +
+		`|\b(?:STRING|UNSTRING)\b[^.]*?\bINTO\s+[A-Za-z]` +
+		`|\bINITIALIZE\s+[A-Za-z]` +
+		`|\bINSPECT\b[^.]*?\bREPLACING\b`,
 )
 
 func sniffEffectsCobol(content string) []EffectMatch {
@@ -108,7 +125,7 @@ func sniffEffectsCobol(content string) []EffectMatch {
 	out = appendCobolMatches(out, content, headers, cobolCICSRe, EffectHTTPOut, "EXEC-CICS.LINK/XCTL/WEB", 0.85)
 	out = appendCobolMatches(out, content, headers, cobolCICSFSReadRe, EffectFSRead, "EXEC-CICS.READ/READQ", 0.9)
 	out = appendCobolMatches(out, content, headers, cobolCICSFSWriteRe, EffectFSWrite, "EXEC-CICS.WRITE/WRITEQ/REWRITE", 0.9)
-	out = appendCobolMatches(out, content, headers, cobolMutationRe, EffectMutation, "MOVE...TO/SET/COMPUTE", 0.6)
+	out = appendCobolMatches(out, content, headers, cobolMutationRe, EffectMutation, "MOVE/SET/COMPUTE/ARITH-GIVING/STRING/INITIALIZE/INSPECT", 0.6)
 	return out
 }
 

--- a/internal/substrate/effect_sinks_cobol_test.go
+++ b/internal/substrate/effect_sinks_cobol_test.go
@@ -74,6 +74,52 @@ func TestSniffEffectsCobol_Mutation(t *testing.T) {
 	}
 }
 
+// TestSniffEffectsCobol_MutationExpanded proves the expanded mutation verb set
+// (#4946): arithmetic GIVING, STRING/UNSTRING INTO, INITIALIZE, and INSPECT
+// REPLACING each register a mutation effect on their paragraph.
+func TestSniffEffectsCobol_MutationExpanded(t *testing.T) {
+	cases := map[string]string{
+		"ADD-GIVING": `       PROCEDURE DIVISION.
+       ADD-GIVING.
+           ADD WS-A TO WS-B GIVING WS-TOTAL.
+`,
+		"SUB-GIVING": `       PROCEDURE DIVISION.
+       SUB-GIVING.
+           SUBTRACT WS-A FROM WS-B GIVING WS-NET.
+`,
+		"MUL-GIVING": `       PROCEDURE DIVISION.
+       MUL-GIVING.
+           MULTIPLY WS-A BY WS-B GIVING WS-PROD.
+`,
+		"DIV-GIVING": `       PROCEDURE DIVISION.
+       DIV-GIVING.
+           DIVIDE WS-A INTO WS-B GIVING WS-Q.
+`,
+		"STRING-INTO": `       PROCEDURE DIVISION.
+       STRING-INTO.
+           STRING WS-A WS-B DELIMITED BY SIZE INTO WS-OUT.
+`,
+		"UNSTRING-INTO": `       PROCEDURE DIVISION.
+       UNSTRING-INTO.
+           UNSTRING WS-IN DELIMITED BY ',' INTO WS-A WS-B.
+`,
+		"INIT": `       PROCEDURE DIVISION.
+       INIT.
+           INITIALIZE WS-RECORD.
+`,
+		"INSPECT-REPL": `       PROCEDURE DIVISION.
+       INSPECT-REPL.
+           INSPECT WS-TEXT REPLACING ALL ' ' BY '-'.
+`,
+	}
+	for fn, src := range cases {
+		got := cobolEffectsByFn(src)
+		if !got[fn][EffectMutation] {
+			t.Errorf("%s expected mutation effect, got %v", fn, got[fn])
+		}
+	}
+}
+
 // TestSniffEffectsCobol_CICSFileIO proves EXEC CICS file/queue I/O
 // (READ/READQ → fs_read, WRITE/WRITEQ/REWRITE → fs_write) is surfaced as
 // filesystem effects, deepening CICS beyond the http_out flag (#2838).


### PR DESCRIPTION
## Built (fixture-proven)

**Control flow edges (extractor.go):**
- `PERFORM <a> THRU/THROUGH <b>` → CALLS to the range-end paragraph, `via=PERFORM-THRU range_start=<a>` (the start endpoint keeps its existing `via=PERFORM` edge).
- `GO TO <para>` and the multi-target `GO TO a b c DEPENDING ON x` form → one intra-program CALLS per target, `via=GO-TO`. Reserved words / `DEPENDING`/`ON`/the index variable are filtered out.

**Expanded mutation effect (effect_sinks_cobol.go):**
- Mutation sniffer broadened beyond MOVE/SET/COMPUTE to: `ADD|SUBTRACT|MULTIPLY|DIVIDE ... GIVING <ident>`, `STRING|UNSTRING ... INTO <ident>`, `INITIALIZE <ident>`, `INSPECT ... REPLACING`.

**Reused kinds:** existing `CALLS` edge kind + `EffectMutation` — no new entity Kinds or edge kinds (no `internal/types` change needed; `go test ./internal/types/` still green).

## Edges
- `CALLS` (via=PERFORM-THRU, via=GO-TO) — intra-program control flow.
- `EffectMutation` — expanded verb set.

## Registry cells (surgical edit, canonical)
`lang.cobol.core`:
- `call_line_precision` notes — document PERFORM-THRU + GO-TO edges, cite new tests, point residual dynamic-CALL weakness at #5040.
- `core_extraction` notes — record control-flow + expanded mutation as built (was the #4946 WEAK note).

## Fixtures
- `TestExtractor_PerformThruRange` — THRU + THROUGH, range_start prop.
- `TestExtractor_GoToControlFlow` — GO TO + DEPENDING ON multi-target, negative cases.
- `TestSniffEffectsCobol_MutationExpanded` — all 8 new mutation verbs.

## Deferred (follow-up filed)
- **#5040** — dynamic `CALL <data-item>` MOVE-literal data-flow target resolution (still emits bare-variable ToID, `dynamic_ref=true`). Out of scope here as it needs intra-paragraph data-flow tracing.

## Gates (sandbox HOME=/tmp/agsbx-4946)
- `go build ./...` ✓
- `go vet ./internal/extractors/cobol/... ./internal/substrate/...` ✓
- `go test` cobol + substrate + internal/types + tools/coverage ✓
- `coverage fmt --check` ✓ (canonical) · `coverage validate` exit 0 ✓

Deploy-deferred.

Closes #4946