### PR TITLE
feat(#4947): cobol — CICS TS/TD queue datastores + BMS/MFS screen maps

### DIFF
--- a/internal/extractors/cobol/depth.go
+++ b/internal/extractors/cobol/depth.go
@@ -427,6 +427,174 @@ func extractCICSTransfers(body string) []cicsCmd {
 }
 
 // ---------------------------------------------------------------------------
+// EXEC CICS TS/TD queue + BMS/MFS screen-map depth — #4947
+//
+// READQ/WRITEQ/DELETEQ TS|TD carry an fs_effect but, until now, no resolvable
+// queue entity — so cross-program coupling through a shared temporary-storage
+// (TS) or transient-data (TD) queue was invisible (unlike native VSAM SELECT,
+// #4908). We emit one SCOPE.Datastore/queue entity per queue name and wire a
+// READS_FROM (READQ) / WRITES_TO (WRITEQ, DELETEQ) edge from the enclosing
+// paragraph, mirroring the file-I/O data-flow model. The queue NAME may be a
+// literal ('ORDERQ') or a data-item holding the queue name at run time — the
+// latter is flagged dynamic_ref so the by-name resolver does not over-bind.
+//
+// SEND/RECEIVE MAP surface the BMS (CICS) / MFS (IMS) screen map as a
+// SCOPE.View/screen entity. SEND MAP renders output to the terminal (a RENDERS
+// edge, paragraph → screen); RECEIVE MAP reads operator input back (a
+// REFERENCES edge). This makes the online-transaction presentation layer — the
+// 3270/terminal screens a CICS/IMS program drives — a first-class node.
+// ---------------------------------------------------------------------------
+
+var (
+	// cicsQueueRe matches a TS/TD queue verb and captures its QUEUE / QNAME
+	// operand. The operand may be a literal ('NAME') or a data-item reference.
+	// Group 1: verb (READQ|WRITEQ|DELETEQ); group 2: TS|TD; group 3: operand.
+	cicsQueueRe = regexp.MustCompile(
+		`(?is)\b(READQ|WRITEQ|DELETEQ)\s+(TS|TD)\b[^.]*?\b(?:QUEUE|QNAME)\s*\(\s*('?[A-Za-z0-9$#@][A-Za-z0-9$#@_.-]*'?)\s*\)`,
+	)
+
+	// cicsMapRe matches SEND/RECEIVE MAP('NAME') and optionally MAPSET('SET').
+	// Group 1: verb (SEND|RECEIVE); group 2: map name (literal or data-item).
+	cicsMapRe = regexp.MustCompile(
+		`(?is)\b(SEND|RECEIVE)\b[^.]*?\bMAP\s*\(\s*('?[A-Za-z0-9$#@][A-Za-z0-9$#@_.-]*'?)\s*\)`,
+	)
+
+	// cicsMapsetRe captures the MAPSET operand on the same command (the BMS map
+	// physically lives in a load-module mapset; recorded for resolution).
+	cicsMapsetRe = regexp.MustCompile(
+		`(?is)\bMAPSET\s*\(\s*('?[A-Za-z0-9$#@][A-Za-z0-9$#@_.-]*'?)\s*\)`,
+	)
+)
+
+// cicsQueueOp is a detected TS/TD queue access.
+type cicsQueueOp struct {
+	verb    string // READQ | WRITEQ | DELETEQ
+	qtype   string // TS | TD
+	name    string // queue name (literal text, quotes stripped) or data-item
+	dynamic bool   // true when the operand is a data-item, not a literal
+}
+
+// cicsMapOp is a detected BMS/MFS screen-map access.
+type cicsMapOp struct {
+	verb    string // SEND | RECEIVE
+	name    string // map name (literal text, quotes stripped) or data-item
+	mapset  string // MAPSET name when present
+	dynamic bool   // true when the map operand is a data-item, not a literal
+}
+
+// unquoteOperand strips matching single quotes from a CICS operand and reports
+// whether the operand was a quoted literal (vs a data-item reference).
+func unquoteOperand(s string) (val string, literal bool) {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && strings.HasPrefix(s, "'") && strings.HasSuffix(s, "'") {
+		return s[1 : len(s)-1], true
+	}
+	return s, false
+}
+
+// extractCICSQueues scans a CICS block body for TS/TD queue verbs.
+func extractCICSQueues(body string) []cicsQueueOp {
+	var out []cicsQueueOp
+	for _, m := range cicsQueueRe.FindAllStringSubmatch(body, -1) {
+		name, literal := unquoteOperand(m[3])
+		out = append(out, cicsQueueOp{
+			verb:    strings.ToUpper(m[1]),
+			qtype:   strings.ToUpper(m[2]),
+			name:    name,
+			dynamic: !literal,
+		})
+	}
+	return out
+}
+
+// extractCICSMaps scans a CICS block body for SEND/RECEIVE MAP commands.
+func extractCICSMaps(body string) []cicsMapOp {
+	var out []cicsMapOp
+	mapset := ""
+	if sm := cicsMapsetRe.FindStringSubmatch(body); sm != nil {
+		if v, _ := unquoteOperand(sm[1]); v != "" {
+			mapset = v
+		}
+	}
+	for _, m := range cicsMapRe.FindAllStringSubmatch(body, -1) {
+		name, literal := unquoteOperand(m[2])
+		out = append(out, cicsMapOp{
+			verb:    strings.ToUpper(m[1]),
+			name:    name,
+			mapset:  mapset,
+			dynamic: !literal,
+		})
+	}
+	return out
+}
+
+// cicsQueueRefName is the canonical name used for a TS/TD queue datastore. A
+// dynamic (data-item) operand keeps the data-item name so the same variable
+// across programs still couples; a literal keeps the literal queue name.
+func cicsQueueRef(filePath, qtype, name string) string {
+	return "scope:datastore:cobol:" + filepath.ToSlash(filePath) + "#queue:" + qtype + ":" + strings.ToUpper(name)
+}
+
+// cicsMapRef is the canonical identity for a BMS/MFS screen-map View entity.
+func cicsMapRef(filePath, name string) string {
+	return "scope:view:cobol:" + filepath.ToSlash(filePath) + "#map:" + strings.ToUpper(name)
+}
+
+// buildCICSQueueEntity emits the SCOPE.Datastore/queue entity for a TS/TD queue.
+func buildCICSQueueEntity(filePath string, q cicsQueueOp, line int) types.EntityRecord {
+	props := map[string]string{
+		"queue":      q.name,
+		"queue_type": q.qtype, // TS (temporary storage) or TD (transient data)
+		"storage":    "cics-" + strings.ToLower(q.qtype) + "-queue",
+		"provenance": "INFERRED_FROM_EXEC_CICS",
+	}
+	if q.dynamic {
+		props["dynamic_ref"] = "true"
+	}
+	return types.EntityRecord{
+		Name:          q.name,
+		Kind:          "SCOPE.Datastore",
+		Subtype:       "queue",
+		QualifiedName: cicsQueueRef(filePath, q.qtype, q.name),
+		SourceFile:    filePath,
+		Language:      "cobol",
+		StartLine:     line,
+		EndLine:       line,
+		Signature:     "EXEC CICS " + q.verb + " " + q.qtype + " QUEUE(" + q.name + ")",
+		Properties:    props,
+		QualityScore:  0.75,
+	}
+}
+
+// buildCICSMapEntity emits the SCOPE.View/screen entity for a BMS/MFS map.
+func buildCICSMapEntity(filePath string, mp cicsMapOp, line int) types.EntityRecord {
+	props := map[string]string{
+		"map":        mp.name,
+		"ui":         "bms", // BMS (CICS 3270) / MFS (IMS) screen map
+		"provenance": "INFERRED_FROM_EXEC_CICS",
+	}
+	if mp.mapset != "" {
+		props["mapset"] = mp.mapset
+	}
+	if mp.dynamic {
+		props["dynamic_ref"] = "true"
+	}
+	return types.EntityRecord{
+		Name:          mp.name,
+		Kind:          "SCOPE.View",
+		Subtype:       "screen",
+		QualifiedName: cicsMapRef(filePath, mp.name),
+		SourceFile:    filePath,
+		Language:      "cobol",
+		StartLine:     line,
+		EndLine:       line,
+		Signature:     "EXEC CICS " + mp.verb + " MAP(" + mp.name + ")",
+		Properties:    props,
+		QualityScore:  0.75,
+	}
+}
+
+// ---------------------------------------------------------------------------
 // FILE-CONTROL / VSAM file-control extraction — #4908
 //
 // ENVIRONMENT DIVISION ▸ INPUT-OUTPUT SECTION ▸ FILE-CONTROL declares the

--- a/internal/extractors/cobol/extractor.go
+++ b/internal/extractors/cobol/extractor.go
@@ -95,8 +95,8 @@ var (
 	// goToTargetsRe captures the whole target list of a GO TO statement up to
 	// the terminating period / DEPENDING clause, so `GO TO A B C DEPENDING ON X`
 	// yields each of A, B, C as a branch target.
-	goToTargetsRe   = regexp.MustCompile(`(?i)\bGO\s*TO\s+([A-Za-z][A-Za-z0-9- ]*?)(?:\s+DEPENDING\b|\.|$)`)
-	cobolIdentRe    = regexp.MustCompile(`[A-Za-z][A-Za-z0-9-]*`)
+	goToTargetsRe = regexp.MustCompile(`(?i)\bGO\s*TO\s+([A-Za-z][A-Za-z0-9- ]*?)(?:\s+DEPENDING\b|\.|$)`)
+	cobolIdentRe  = regexp.MustCompile(`[A-Za-z][A-Za-z0-9-]*`)
 
 	// callRe matches `CALL '<program>'` / `CALL "<program>"` dynamic calls.
 	// Group 1: literal program name (without quotes).
@@ -275,6 +275,12 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 	// span many lines; we buffer its body until END-EXEC, then extract.
 	var execBuf *execBlock
 
+	// CICS TS/TD queue + BMS/MFS screen-map entity dedup (#4947). A queue or
+	// map referenced by several commands yields a single datastore/view entity
+	// but one data-flow / render edge per access.
+	cicsQueueIdx := map[string]int{}
+	cicsMapIdx := map[string]int{}
+
 	// FILE-CONTROL / SELECT tracking (#4908). When inside FILE-CONTROL we
 	// buffer each SELECT statement to its terminating period (the VSAM
 	// ORGANIZATION / ACCESS / RECORD KEY clauses usually trail on continuation
@@ -354,6 +360,74 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 		case "CICS":
 			for _, c := range extractCICSTransfers(blk.text) {
 				attachCall(entities, currentParagraphIdx, programIdx, cicsCallEdge(c, blk.startLine))
+			}
+			// CICS TS/TD queue I/O (#4947): emit a resolvable queue datastore +
+			// READS_FROM (READQ) / WRITES_TO (WRITEQ, DELETEQ) data-flow edge
+			// from the enclosing paragraph (else the program).
+			fromRef := sqlFunctionRef(filePath, fnRefName())
+			ioIdx := currentParagraphIdx
+			if ioIdx < 0 {
+				ioIdx = programIdx
+			}
+			for _, q := range extractCICSQueues(blk.text) {
+				key := q.qtype + ":" + strings.ToUpper(q.name)
+				if _, ok := cicsQueueIdx[key]; !ok {
+					cicsQueueIdx[key] = len(entities)
+					entities = append(entities, buildCICSQueueEntity(filePath, q, blk.startLine))
+				}
+				qEnt := entities[cicsQueueIdx[key]]
+				kind := "READS_FROM"
+				if q.verb == "WRITEQ" || q.verb == "DELETEQ" {
+					kind = "WRITES_TO"
+				}
+				if ioIdx >= 0 {
+					props := map[string]string{
+						"line":  strconv.Itoa(blk.startLine),
+						"queue": q.name,
+						"via":   "EXEC-CICS-" + q.verb,
+					}
+					if q.dynamic {
+						props["dynamic_ref"] = "true"
+					}
+					entities[ioIdx].Relationships = append(entities[ioIdx].Relationships,
+						types.RelationshipRecord{
+							FromID:     fromRef,
+							ToID:       qEnt.QualifiedName,
+							Kind:       kind,
+							Properties: props,
+						})
+				}
+			}
+			// CICS BMS/MFS screen maps (#4947): SEND MAP → RENDERS, RECEIVE MAP
+			// → REFERENCES, both binding the paragraph to a SCOPE.View/screen.
+			for _, mp := range extractCICSMaps(blk.text) {
+				key := strings.ToUpper(mp.name)
+				if _, ok := cicsMapIdx[key]; !ok {
+					cicsMapIdx[key] = len(entities)
+					entities = append(entities, buildCICSMapEntity(filePath, mp, blk.startLine))
+				}
+				mEnt := entities[cicsMapIdx[key]]
+				kind := "RENDERS"
+				if mp.verb == "RECEIVE" {
+					kind = "REFERENCES"
+				}
+				if ioIdx >= 0 {
+					props := map[string]string{
+						"line": strconv.Itoa(blk.startLine),
+						"map":  mp.name,
+						"via":  "EXEC-CICS-" + mp.verb,
+					}
+					if mp.dynamic {
+						props["dynamic_ref"] = "true"
+					}
+					entities[ioIdx].Relationships = append(entities[ioIdx].Relationships,
+						types.RelationshipRecord{
+							FromID:     fromRef,
+							ToID:       mEnt.QualifiedName,
+							Kind:       kind,
+							Properties: props,
+						})
+				}
 			}
 		}
 	}

--- a/internal/extractors/cobol/extractor_test.go
+++ b/internal/extractors/cobol/extractor_test.go
@@ -540,6 +540,159 @@ func TestExtractor_CICSProgramTransfer(t *testing.T) {
 	}
 }
 
+// TestExtractor_CICSQueues proves EXEC CICS READQ/WRITEQ TS surface a
+// resolvable SCOPE.Datastore/queue and wire READS_FROM / WRITES_TO data-flow
+// edges (cross-program queue coupling, #4947).
+func TestExtractor_CICSQueues(t *testing.T) {
+	src := loadFixture(t, "orderui.cbl")
+	recs := run(t, "orderui.cbl", src)
+
+	queues := findByKind(recs, "SCOPE.Datastore", "queue")
+	if len(queues) != 1 {
+		t.Fatalf("expected 1 queue datastore, got %d", len(queues))
+	}
+	q := queues[0]
+	// The QUEUE operand is a data-item (WS-MSG-QUEUE), so dynamic_ref is set.
+	if q.Properties["queue_type"] != "TS" {
+		t.Errorf("queue_type = %q, want TS", q.Properties["queue_type"])
+	}
+	if q.Properties["storage"] != "cics-ts-queue" {
+		t.Errorf("storage = %q, want cics-ts-queue", q.Properties["storage"])
+	}
+	if q.Properties["dynamic_ref"] != "true" {
+		t.Errorf("expected dynamic_ref=true for data-item queue operand")
+	}
+
+	// READQ TS → READS_FROM; WRITEQ TS → WRITES_TO, both binding the queue.
+	var readOK, writeOK bool
+	for _, rel := range relationsByKind(recs, "READS_FROM") {
+		if rel.ToID == q.QualifiedName && rel.Properties["via"] == "EXEC-CICS-READQ" {
+			readOK = true
+		}
+	}
+	for _, rel := range relationsByKind(recs, "WRITES_TO") {
+		if rel.ToID == q.QualifiedName && rel.Properties["via"] == "EXEC-CICS-WRITEQ" {
+			writeOK = true
+		}
+	}
+	if !readOK {
+		t.Error("expected READS_FROM edge for READQ TS queue")
+	}
+	if !writeOK {
+		t.Error("expected WRITES_TO edge for WRITEQ TS queue")
+	}
+}
+
+// TestExtractor_CICSScreenMaps proves EXEC CICS SEND/RECEIVE MAP surface a
+// SCOPE.View/screen entity with RENDERS (SEND) / REFERENCES (RECEIVE) edges
+// (BMS/MFS presentation layer, #4947).
+func TestExtractor_CICSScreenMaps(t *testing.T) {
+	src := loadFixture(t, "orderui.cbl")
+	recs := run(t, "orderui.cbl", src)
+
+	maps := findByKind(recs, "SCOPE.View", "screen")
+	if len(maps) != 1 {
+		t.Fatalf("expected 1 screen map view, got %d", len(maps))
+	}
+	m := maps[0]
+	if m.Name != "ORDMAP" {
+		t.Errorf("map name = %q, want ORDMAP", m.Name)
+	}
+	if m.Properties["ui"] != "bms" {
+		t.Errorf("ui = %q, want bms", m.Properties["ui"])
+	}
+	// RECEIVE MAP('ORDMAP') → REFERENCES (operator input read back).
+	var refOK bool
+	for _, rel := range relationsByKind(recs, "REFERENCES") {
+		if rel.ToID == m.QualifiedName && rel.Properties["via"] == "EXEC-CICS-RECEIVE" {
+			refOK = true
+		}
+	}
+	if !refOK {
+		t.Error("expected REFERENCES edge for RECEIVE MAP ORDMAP")
+	}
+}
+
+// TestExtractor_CICSScreenMapSend proves SEND MAP emits a RENDERS edge.
+func TestExtractor_CICSScreenMapSend(t *testing.T) {
+	src := "       IDENTIFICATION DIVISION.\n" +
+		"       PROGRAM-ID. SCRNTEST.\n" +
+		"       PROCEDURE DIVISION.\n" +
+		"       SHOW-SCREEN.\n" +
+		"           EXEC CICS SEND MAP('MENUMAP') MAPSET('MENUSET')\n" +
+		"               FROM(WS-MENU-AREA)\n" +
+		"           END-EXEC.\n"
+	recs := run(t, "scrn.cbl", src)
+
+	maps := findByKind(recs, "SCOPE.View", "screen")
+	if len(maps) != 1 {
+		t.Fatalf("expected 1 screen map view, got %d", len(maps))
+	}
+	m := maps[0]
+	if m.Name != "MENUMAP" {
+		t.Errorf("map name = %q, want MENUMAP", m.Name)
+	}
+	if m.Properties["mapset"] != "MENUSET" {
+		t.Errorf("mapset = %q, want MENUSET", m.Properties["mapset"])
+	}
+	if m.Properties["dynamic_ref"] == "true" {
+		t.Error("literal map operand must not be flagged dynamic_ref")
+	}
+	var renderOK bool
+	for _, rel := range relationsByKind(recs, "RENDERS") {
+		if rel.ToID == m.QualifiedName && rel.Properties["via"] == "EXEC-CICS-SEND" {
+			renderOK = true
+		}
+	}
+	if !renderOK {
+		t.Error("expected RENDERS edge for SEND MAP MENUMAP")
+	}
+}
+
+// TestExtractor_CICSQueueLiteralAndTD proves a literal TS/TD queue operand
+// yields a non-dynamic queue and DELETEQ is a write-class mutation.
+func TestExtractor_CICSQueueLiteralAndTD(t *testing.T) {
+	src := "       IDENTIFICATION DIVISION.\n" +
+		"       PROGRAM-ID. QTEST.\n" +
+		"       PROCEDURE DIVISION.\n" +
+		"       PROC-Q.\n" +
+		"           EXEC CICS WRITEQ TD QUEUE('LOGQ')\n" +
+		"               FROM(WS-REC)\n" +
+		"           END-EXEC\n" +
+		"           EXEC CICS DELETEQ TS QUEUE('TMPQ')\n" +
+		"           END-EXEC.\n"
+	recs := run(t, "qtest.cbl", src)
+
+	byName := map[string]types.EntityRecord{}
+	for _, q := range findByKind(recs, "SCOPE.Datastore", "queue") {
+		byName[q.Name] = q
+	}
+	logq, ok := byName["LOGQ"]
+	if !ok {
+		t.Fatal("expected LOGQ TD queue")
+	}
+	if logq.Properties["queue_type"] != "TD" {
+		t.Errorf("LOGQ queue_type = %q, want TD", logq.Properties["queue_type"])
+	}
+	if logq.Properties["dynamic_ref"] == "true" {
+		t.Error("literal LOGQ operand must not be dynamic_ref")
+	}
+	// DELETEQ TS → WRITES_TO (a mutation of the queue).
+	tmpq, ok := byName["TMPQ"]
+	if !ok {
+		t.Fatal("expected TMPQ TS queue")
+	}
+	var delOK bool
+	for _, rel := range relationsByKind(recs, "WRITES_TO") {
+		if rel.ToID == tmpq.QualifiedName && rel.Properties["via"] == "EXEC-CICS-DELETEQ" {
+			delOK = true
+		}
+	}
+	if !delOK {
+		t.Error("expected WRITES_TO edge for DELETEQ TS TMPQ")
+	}
+}
+
 // TestExtractor_DataHierarchy proves 01/05 nesting binds child fields to their
 // parent group (parent property + CONTAINS edge) and captures REDEFINES/OCCURS.
 func TestExtractor_DataHierarchy(t *testing.T) {


### PR DESCRIPTION
## Built (fixture-proven)
- **CICS TS/TD queues** → resolvable `SCOPE.Datastore/queue` entities. `extractCICSQueues` parses `READQ/WRITEQ/DELETEQ TS|TD QUEUE('NAME'|data-item)` from the buffered EXEC CICS block; `buildCICSQueueEntity` emits one deduped queue per (qtype, name) with props `queue_type`=TS|TD, `storage`=cics-<ts|td>-queue, `dynamic_ref` when the operand is a data-item. Data-flow edges from the enclosing paragraph: **READS_FROM** (READQ), **WRITES_TO** (WRITEQ, DELETEQ), tagged `via=EXEC-CICS-<VERB>`. Cross-program queue coupling is now explicit (mirrors native VSAM SELECT, #4908).
- **BMS/MFS screen maps** → `SCOPE.View/screen` entities. `extractCICSMaps` parses `SEND/RECEIVE MAP('NAME')` (+ optional `MAPSET`); `buildCICSMapEntity` emits one deduped view per map name (props `ui`=bms, `mapset`, `dynamic_ref`). Edges: **RENDERS** (SEND, terminal output), **REFERENCES** (RECEIVE, operator input).

No new entity Kinds or edge kinds — reuses `SCOPE.Datastore`, `SCOPE.View`, `READS_FROM`, `WRITES_TO`, `RENDERS`, `REFERENCES` (`go test ./internal/types/` green).

## Edges
- queue: `paragraph --READS_FROM--> queue` (READQ), `paragraph --WRITES_TO--> queue` (WRITEQ/DELETEQ)
- map: `paragraph --RENDERS--> screen` (SEND), `paragraph --REFERENCES--> screen` (RECEIVE)

## Registry cells (lang.cobol.embedded.cics)
Honest upgrade of the two existing cells whose WEAK markers cited #4947:
- `fs_effect` — queue target now resolvable (queue datastore + data-flow edge); WEAK marker removed. Cites + orderui.cbl + extractor.go/extractor_test.go.
- `call_line_precision` — extended beyond program transfer to BMS/MFS SEND/RECEIVE MAP view entities; WEAK marker removed. Cites updated.
(The `language` category capability allow-list does not include message_broker/view_rendering keys, so the modeling is documented on the existing queue/view-bearing cells rather than as new keys.)

## Fixtures / tests
- `testdata/orderui.cbl` (pre-existing) now drives `TestExtractor_CICSQueues` (READQ/WRITEQ TS, dynamic_ref) + `TestExtractor_CICSScreenMaps` (RECEIVE MAP → REFERENCES).
- New inline-source tests: `TestExtractor_CICSScreenMapSend` (SEND MAP + MAPSET → RENDERS, literal not dynamic), `TestExtractor_CICSQueueLiteralAndTD` (literal TD queue, DELETEQ → WRITES_TO).

## Deferred → #5046
Micro Focus / ACUCOBOL non-CICS screen I/O variants; TD-queue `DESTID` operand; remote-queue `SYSID` routing.

## Gates (sandbox HOME=/tmp/agsbx-4947)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/extractors/cobol/... ./internal/types/... ./tools/coverage/...` all green. `coverage fmt --check` canonical, `coverage validate` ok (732 records; only pre-existing unrelated warnings).

Closes #4947