### PR TITLE
feat(#4942): fsharp — DU cases + record fields as sub-entities, alias subtype

### DIFF
--- a/internal/extractors/fsharp/du_record_members.go
+++ b/internal/extractors/fsharp/du_record_members.go
@@ -1,0 +1,244 @@
+// Package fsharp: discriminated-union case + record-field sub-entity emission.
+//
+// #4942 (follow-up #4906): classifyTypeSubtype already distinguishes
+// record / discriminated_union / interface / class / struct, but the
+// individual DU CASES (`Circle | Rectangle`) and record FIELDS were not
+// emitted as their own entities — they were invisible in the graph. This file
+// parses a type body and emits each case / field as a SCOPE.Schema/field
+// sub-entity (dotted Name "<Type>.<member>"), mirroring the Rust
+// struct-field / enum-variant precedent (internal/extractors/rust/struct_fields.go),
+// and attaches a type→member CONTAINS edge via BuildSchemaFieldStructuralRef
+// so the sub-entities are never orphans.
+//
+// It also recognises a pure type ALIAS (`type Foo = Bar`) so classifyTypeSubtype
+// can return "alias" instead of the catch-all "type".
+package fsharp
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractTypeMembers parses the body of a type declaration and returns the
+// DU-case / record-field sub-entities plus the type→member CONTAINS edges to
+// attach to the owner Component. `subtype` is the classifyTypeSubtype result so
+// only record/discriminated_union bodies are scanned (class/interface/struct
+// members already flow through the member CONTAINS path).
+func extractTypeMembers(
+	owner, subtype, body, filePath string,
+	startLine int,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	var names []memberInfo
+	switch subtype {
+	case "record":
+		names = parseRecordFields(body)
+	case "discriminated_union":
+		names = parseDUCases(body)
+	default:
+		return nil, nil
+	}
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	memberSubtype := "field"
+	if subtype == "discriminated_union" {
+		memberSubtype = "du_case"
+	}
+
+	seen := make(map[string]bool, len(names))
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	for _, mi := range names {
+		if mi.name == "" || seen[mi.name] {
+			continue
+		}
+		seen[mi.name] = true
+		dotted := owner + "." + mi.name
+		line := startLine + mi.lineOffset
+		sig := mi.name
+		if mi.typ != "" {
+			sig = mi.name + ": " + mi.typ
+		}
+		ents = append(ents, types.EntityRecord{
+			Name:       dotted,
+			Kind:       "SCOPE.Schema",
+			Subtype:    memberSubtype,
+			SourceFile: filePath,
+			Language:   "fsharp",
+			StartLine:  line,
+			EndLine:    line,
+			Signature:  sig,
+			Properties: map[string]string{
+				"member_name":  mi.name,
+				"member_type":  mi.typ,
+				"parent_class": owner,
+			},
+		})
+		rels = append(rels, types.RelationshipRecord{
+			ToID: extractor.BuildSchemaFieldStructuralRef("fsharp", filePath, dotted),
+			Kind: "CONTAINS",
+		})
+	}
+	return ents, rels
+}
+
+// memberInfo holds a parsed DU case / record field.
+type memberInfo struct {
+	name       string
+	typ        string // payload type (DU `of T`) or field type annotation
+	lineOffset int    // line offset relative to the type declaration start
+}
+
+// parseRecordFields parses the body of an F# record type, returning one entry
+// per `Name: Type` field. Handles both multi-line and single-line
+// (`{ X: int; Y: int }`) record bodies. `mutable` field qualifiers are
+// tolerated.
+func parseRecordFields(body string) []memberInfo {
+	var out []memberInfo
+	for lineNo, raw := range strings.Split(body, "\n") {
+		line := raw
+		// Strip the enclosing braces so a single-line `{ X: int; Y: int }`
+		// degrades to a `;`-separated field list.
+		line = strings.ReplaceAll(line, "{", "")
+		line = strings.ReplaceAll(line, "}", "")
+		for _, seg := range strings.Split(line, ";") {
+			seg = strings.TrimSpace(seg)
+			if seg == "" {
+				continue
+			}
+			seg = strings.TrimPrefix(seg, "mutable ")
+			colon := strings.IndexByte(seg, ':')
+			if colon < 0 {
+				continue
+			}
+			name := strings.TrimSpace(seg[:colon])
+			typ := strings.TrimSpace(seg[colon+1:])
+			if !isFieldName(name) {
+				continue
+			}
+			out = append(out, memberInfo{name: name, typ: typ, lineOffset: lineNo})
+		}
+	}
+	return out
+}
+
+// parseDUCases parses the body of an F# discriminated union, returning one
+// entry per `| Case [of Payload]` case. The leading bar of the first case may
+// be omitted in F# (`type T = A | B`), so a bar-less first case on the type
+// line is also captured.
+func parseDUCases(body string) []memberInfo {
+	var out []memberInfo
+	for lineNo, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		// Each physical line may carry several `|`-separated cases.
+		for _, seg := range strings.Split(line, "|") {
+			seg = strings.TrimSpace(seg)
+			if seg == "" {
+				continue
+			}
+			name, typ := splitDUCase(seg)
+			if !isDUCaseName(name) {
+				continue
+			}
+			out = append(out, memberInfo{name: name, typ: typ, lineOffset: lineNo})
+		}
+	}
+	return out
+}
+
+// splitDUCase splits a single DU case segment `Circle of float` into its
+// case name and (optional) payload type.
+func splitDUCase(seg string) (name, typ string) {
+	// Trim any trailing member-attribute / `with` augmentation noise.
+	if idx := strings.Index(seg, " with"); idx >= 0 {
+		seg = seg[:idx]
+	}
+	fields := strings.Fields(seg)
+	if len(fields) == 0 {
+		return "", ""
+	}
+	name = fields[0]
+	if i := strings.Index(seg, " of "); i >= 0 {
+		typ = strings.TrimSpace(seg[i+len(" of "):])
+	}
+	return name, typ
+}
+
+// isFieldName reports whether tok is a plausible F# record-field identifier
+// (must start with a letter or underscore; F# fields are PascalCase by
+// convention but lower-case is legal).
+func isFieldName(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	for i, r := range tok {
+		if i == 0 {
+			if !(r == '_' || isLetter(r)) {
+				return false
+			}
+			continue
+		}
+		if !(r == '_' || r == '\'' || isLetter(r) || (r >= '0' && r <= '9')) {
+			return false
+		}
+	}
+	return true
+}
+
+// isDUCaseName reports whether tok is a plausible DU case name. DU cases are
+// upper-case by F# rule, which also lets us reject stray lowercase tokens that
+// leak from multi-line case payloads.
+func isDUCaseName(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	r := rune(tok[0])
+	if !(r >= 'A' && r <= 'Z') {
+		return false
+	}
+	return isFieldName(tok)
+}
+
+func isLetter(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// isAliasBody reports whether a type body is a pure alias target
+// (`type Foo = Bar` / `type Id = int` / `type Pair = int * string`) rather than
+// a record / DU / class / interface / struct. Used by classifyTypeSubtype to
+// distinguish the "alias" subtype from the catch-all "type".
+func isAliasBody(body string) bool {
+	b := strings.TrimSpace(body)
+	if b == "" {
+		return false
+	}
+	// Anything that opens a structured type is not an alias.
+	if strings.HasPrefix(b, "{") || strings.HasPrefix(b, "|") {
+		return false
+	}
+	first := strings.Fields(b)
+	if len(first) == 0 {
+		return false
+	}
+	switch first[0] {
+	case "interface", "class", "struct", "abstract", "inherit", "member", "delegate":
+		return false
+	}
+	// A pure alias body is a single logical type expression — it has no `=`
+	// continuation and no newline-separated member block. If subsequent
+	// non-blank lines exist, it is a structured body, not an alias.
+	lines := strings.Split(b, "\n")
+	nonBlank := 0
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) != "" {
+			nonBlank++
+		}
+	}
+	return nonBlank == 1
+}

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -335,6 +335,11 @@ func extractFSharp(src, filePath string) []types.EntityRecord {
 			})
 		}
 
+		// #4942: emit DU cases / record fields as SCOPE.Schema sub-entities,
+		// with a type→member CONTAINS edge each.
+		memberEnts, memberRels := extractTypeMembers(name, subtype, body, filePath, startLine)
+		rels = append(rels, memberRels...)
+
 		entities = append(entities, types.EntityRecord{
 			Name:       name,
 			Kind:       "SCOPE.Component",
@@ -349,6 +354,7 @@ func extractFSharp(src, filePath string) []types.EntityRecord {
 			},
 			Relationships: rels,
 		})
+		entities = append(entities, memberEnts...)
 	}
 
 	return entities
@@ -377,6 +383,11 @@ func classifyTypeSubtype(decl, body string) string {
 	}
 	if strings.Contains(decl, "struct") {
 		return "struct"
+	}
+	// #4942: a pure alias (`type Foo = Bar`, `type Id = int`) is a distinct
+	// subtype, not the catch-all "type".
+	if isAliasBody(body) {
+		return "alias"
 	}
 	return "type"
 }

--- a/internal/extractors/fsharp/fsharp_test.go
+++ b/internal/extractors/fsharp/fsharp_test.go
@@ -645,3 +645,124 @@ let processAsync () =
 		}
 	}
 }
+
+// fsSchemaRef builds the canonical Format A schema-field structural ref the
+// extractor emits for a type→member CONTAINS edge (#4942).
+func fsSchemaRef(filePath, dotted string) string {
+	return extractor.BuildSchemaFieldStructuralRef("fsharp", filePath, dotted)
+}
+
+// TestFSharp_RecordFields — #4942: record FIELDS are emitted as individual
+// SCOPE.Schema/field sub-entities (dotted "<Type>.<field>") with the parent
+// record CONTAINING each one.
+func TestFSharp_RecordFields(t *testing.T) {
+	src := `module Domain
+
+type Person = {
+    Name: string
+    Age: int
+    mutable Score: float
+}
+`
+	ents := runFSharp(t, src, "person.fs")
+
+	for _, f := range []struct{ name, typ string }{
+		{"Person.Name", "string"},
+		{"Person.Age", "int"},
+		{"Person.Score", "float"},
+	} {
+		fe := fsFind(ents, f.name, "SCOPE.Schema")
+		if fe == nil {
+			t.Fatalf("expected record field %q as SCOPE.Schema", f.name)
+		}
+		if fe.Subtype != "field" {
+			t.Errorf("field %q subtype=%q, want field", f.name, fe.Subtype)
+		}
+		if fe.Properties["member_type"] != f.typ {
+			t.Errorf("field %q member_type=%q, want %q", f.name, fe.Properties["member_type"], f.typ)
+		}
+		if fe.Properties["parent_class"] != "Person" {
+			t.Errorf("field %q parent_class=%q, want Person", f.name, fe.Properties["parent_class"])
+		}
+		// CONTAINS edge from the owner type to the field.
+		if !fsHasRel(ents, "Person", "SCOPE.Component", "CONTAINS", fsSchemaRef("person.fs", f.name)) {
+			t.Errorf("expected Person CONTAINS %q", f.name)
+		}
+	}
+}
+
+// TestFSharp_DUCases — #4942: DU CASES are emitted as individual
+// SCOPE.Schema/du_case sub-entities, with payload types captured from `of T`.
+func TestFSharp_DUCases(t *testing.T) {
+	src := `module Shapes
+
+type Shape =
+    | Circle of float
+    | Rectangle of float * float
+    | Point
+`
+	ents := runFSharp(t, src, "shapes.fs")
+
+	for _, c := range []struct{ name, typ string }{
+		{"Shape.Circle", "float"},
+		{"Shape.Rectangle", "float * float"},
+		{"Shape.Point", ""},
+	} {
+		ce := fsFind(ents, c.name, "SCOPE.Schema")
+		if ce == nil {
+			t.Fatalf("expected DU case %q as SCOPE.Schema", c.name)
+		}
+		if ce.Subtype != "du_case" {
+			t.Errorf("case %q subtype=%q, want du_case", c.name, ce.Subtype)
+		}
+		if ce.Properties["member_type"] != c.typ {
+			t.Errorf("case %q member_type=%q, want %q", c.name, ce.Properties["member_type"], c.typ)
+		}
+		if !fsHasRel(ents, "Shape", "SCOPE.Component", "CONTAINS", fsSchemaRef("shapes.fs", c.name)) {
+			t.Errorf("expected Shape CONTAINS %q", c.name)
+		}
+	}
+}
+
+// TestFSharp_SingleLineRecord — #4942: a single-line record body
+// `{ X: int; Y: int }` still yields one field entity per `;`-separated field.
+func TestFSharp_SingleLineRecord(t *testing.T) {
+	src := `module Geo
+
+type Point = { X: int; Y: int }
+`
+	ents := runFSharp(t, src, "geo.fs")
+	for _, name := range []string{"Point.X", "Point.Y"} {
+		if fsFind(ents, name, "SCOPE.Schema") == nil {
+			t.Errorf("expected single-line record field %q", name)
+		}
+	}
+}
+
+// TestFSharp_TypeAlias — #4942: a pure type alias `type Foo = Bar` classifies
+// as the "alias" subtype, distinct from the catch-all "type", and emits no
+// spurious field/case sub-entities.
+func TestFSharp_TypeAlias(t *testing.T) {
+	src := `module Aliases
+
+type UserId = int
+type Name = string
+type Pair = int * string
+`
+	ents := runFSharp(t, src, "aliases.fs")
+	for _, name := range []string{"UserId", "Name", "Pair"} {
+		te := fsFind(ents, name, "SCOPE.Component")
+		if te == nil {
+			t.Fatalf("expected alias type %q", name)
+		}
+		if te.Subtype != "alias" {
+			t.Errorf("alias %q subtype=%q, want alias", name, te.Subtype)
+		}
+	}
+	// No sub-entities for aliases.
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" {
+			t.Errorf("alias produced unexpected schema sub-entity %q", e.Name)
+		}
+	}
+}


### PR DESCRIPTION
## Built (fixture-proven)
- **DU CASES + record FIELDS as sub-entities** (`internal/extractors/fsharp/du_record_members.go`): `extractTypeMembers` parses a record/DU type body and emits one `SCOPE.Schema` entity per member — dotted Name `<Type>.<member>`, Subtype `field` (records) / `du_case` (DUs), with `member_name`/`member_type`/`parent_class` Properties. `parseRecordFields` handles multi-line and single-line `{ X:int; Y:int }` bodies (`mutable` tolerated); `parseDUCases` handles `| Case [of Payload]` (leading-bar-optional first case, `of`-payload type captured, `with`-augmentation trimmed). Each member gets a type→member **CONTAINS** edge via `BuildSchemaFieldStructuralRef` (Rust struct-field/enum-variant precedent) so sub-entities are never orphans.
- **`alias` subtype**: `classifyTypeSubtype` now returns `alias` for a pure single-line `type Foo = Bar` / `type Id = int` body (via `isAliasBody`) instead of the catch-all `type`.

### Edges / Kinds reused (no new Kinds)
- Entity Kind `SCOPE.Schema` + Subtypes `field`/`du_case`; edge kind `CONTAINS`; structural ref `BuildSchemaFieldStructuralRef`. `go test ./internal/types/` passes (no new Kinds registered).

### Registry cells
- `lang.fsharp.core` / `core_extraction` (stays `full`): notes extended for #4942 (DU cases, fields, alias subtype); added cite `du_record_members.go`; issue → 4942; verified_at 2026-06-12. **Only this cell touched** — honest, fixtures prove it.

### Fixtures
- `TestFSharp_RecordFields`, `TestFSharp_DUCases`, `TestFSharp_SingleLineRecord`, `TestFSharp_TypeAlias` (+ existing `TestFSharp_TypeSubtypes` still green).

### Deferred (follow-ups filed)
- **#5048**: computation-expression (`async{}`/`task{}`/custom builders) + active-pattern modelling.
- **#5049**: Fable+Elmish/Feliz frontend, Serilog/MEL/printfn log_extraction, Validus/FsToolkit/DataAnnotations validation.

### Gates (sandbox HOME=/tmp/agsbx-4942)
`go build ./...` OK · `go vet ./internal/...` OK · `go test` fsharp + custom/fsharp + types OK · `coverage fmt --check` canonical · `coverage validate` exit 0.

Closes #4942