### PR TITLE
feat(#4948): cobol — IMS DB/DC (DL/I) segment I/O extraction

### DIFF
--- a/internal/extractors/cobol/depth.go
+++ b/internal/extractors/cobol/depth.go
@@ -181,13 +181,13 @@ func trimPseudo(s string) string {
 
 // execBlock is one EXEC SQL / EXEC CICS block accumulated across lines.
 type execBlock struct {
-	kind      string // "SQL" or "CICS"
+	kind      string // "SQL", "CICS" or "DLI"
 	startLine int
 	text      string // joined block body (between EXEC <kind> and END-EXEC)
 }
 
 var (
-	execStartRe = regexp.MustCompile(`(?i)\bEXEC\s+(SQL|CICS)\b`)
+	execStartRe = regexp.MustCompile(`(?i)\bEXEC\s+(SQL|CICS|DLI)\b`)
 	execEndRe   = regexp.MustCompile(`(?i)\bEND-EXEC\b`)
 
 	// SQL DML / cursor patterns. Table names follow FROM / INTO / UPDATE /
@@ -726,6 +726,194 @@ func buildFileResourceEntity(filePath string, fs fileSelect) types.EntityRecord 
 		Signature:     "SELECT " + fs.logical + " ASSIGN TO " + fs.assignTo,
 		Properties:    props,
 	}
+}
+
+// ---------------------------------------------------------------------------
+// IMS DB/DC (DL/I) segment I/O — #4948
+//
+// IMS DL/I is the 2nd most common mainframe data layer after DB2. A program
+// reaches it two ways, both of which were previously invisible (execStartRe
+// matched only SQL|CICS):
+//
+//	EXEC DLI GU|GN|GHU|GNP|GHN|ISRT|REPL|DLET SEGMENT(<seg>) ... END-EXEC
+//	CALL 'CBLTDLI' USING <func> <pcb> <io-area> <ssa>      (or 'AIBTDLI')
+//
+// An IMS *segment* is the hierarchical-database analog of a relational table,
+// so we model each accessed segment as a SCOPE.DataAccess entity (orm=ims-dli)
+// carrying an ACCESSES_TABLE edge FromID=enclosing paragraph — exactly the
+// shape extractSQLEntities uses for DB2 tables, so segment access resolves
+// through the same pipeline. The DL/I function code maps to a DML operation:
+// GU/GN/GHU/GNP/GHN (get) → SELECT; ISRT → INSERT; REPL → UPDATE; DLET →
+// DELETE. The EXEC DLI form names the segment directly (SEGMENT(<seg>)); the
+// CALL CBLTDLI form passes the segment inside the SSA argument, which is
+// typically a working-storage data item, so a segment is only resolvable from
+// the CALL form when an inline SSA literal `'SEGNAME(...'` is present.
+// ---------------------------------------------------------------------------
+
+const ormIMSDLI = "ims-dli"
+
+var (
+	// dliFuncRe captures the DL/I function code in an EXEC DLI block
+	// (EXEC DLI GU SEGMENT(...)). The function keyword leads the command.
+	dliFuncRe = regexp.MustCompile(`(?i)\bEXEC\s+DLI\s+([A-Z]+)\b`)
+	// dliSegmentRe captures one or more SEGMENT(<name>) operands in an
+	// EXEC DLI block (a path call may reference several segments).
+	dliSegmentRe = regexp.MustCompile(`(?i)\bSEGMENT\s*\(\s*([A-Za-z][A-Za-z0-9#@$-]*)\s*\)`)
+
+	// dliCallModuleRe matches a CALL to a DL/I interface module — CBLTDLI
+	// (COBOL/TDLI), AIBTDLI (AIB interface), or the assembler-style ASMTDLI /
+	// PLITDLI variants — capturing the module name.
+	dliCallModuleRe = regexp.MustCompile(`(?i)\bCALL\s+['"]((?:CBL|AIB|ASM|PLI)TDLI)['"]`)
+	// dliFuncLiteralRe captures an inline DL/I function-code literal in a
+	// CBLTDLI USING list (CALL 'CBLTDLI' USING 'GU' ...). The 4-char form
+	// (e.g. 'GHU ', 'ISRT') and the data-name form are both common; only the
+	// literal form is classified here (the data-name form stays generic).
+	dliFuncLiteralRe = regexp.MustCompile(`(?i)\bUSING\b[^.]*?['"]\s*(GU|GN|GHU|GNP|GHN|GHNP|ISRT|REPL|DLET)\s*['"]`)
+	// dliSSASegRe captures a segment name from an inline SSA literal in the
+	// USING list. A qualified SSA names the segment then a key in parens
+	// (USING ... 'PARTROOT(PARTKEY  ='); an unqualified SSA is just the bare
+	// 8-char segment name (USING ... 'PARTDETL'). The leading 1-8 char token
+	// of the quoted literal is the segment; function-code literals (GU/ISRT…)
+	// are excluded by dliFuncCodeReserved. Trailing key/blanks are tolerated.
+	dliSSASegRe = regexp.MustCompile(`(?i)['"]\s*([A-Za-z][A-Za-z0-9#@$-]{0,7})\s*(?:\(|['"]|\s)`)
+)
+
+// dliOpFor maps a DL/I function code to the primary DML operation, mirroring
+// sqlOpFor so IMS segment access classifies on the same SELECT/INSERT/UPDATE/
+// DELETE lattice as embedded SQL.
+func dliOpFor(fn string) string {
+	switch strings.ToUpper(fn) {
+	case "ISRT":
+		return "INSERT"
+	case "REPL":
+		return "UPDATE"
+	case "DLET":
+		return "DELETE"
+	case "GU", "GN", "GHU", "GNP", "GHN", "GHNP", "GNHP":
+		return "SELECT"
+	default:
+		return "EXEC"
+	}
+}
+
+// dliSegmentRef builds a stable identity for an IMS segment SCOPE.DataAccess
+// entity, matching dataAccessRef so the resolver binds ACCESSES_TABLE to it.
+func dliSegmentRef(filePath, op, segment string) string {
+	return "scope:dataaccess:" + filepath.ToSlash(filePath) + "#" + ormIMSDLI + ":" + op + ":" + segment
+}
+
+// buildDLISegmentEntity emits one SCOPE.DataAccess entity per accessed IMS
+// segment, with an ACCESSES_TABLE edge FromID=enclosing paragraph (fnRef).
+func buildDLISegmentEntity(filePath, fnQName, fnRef, op, segment string, line int, via string) types.EntityRecord {
+	ref := dliSegmentRef(filePath, op, segment)
+	rec := types.EntityRecord{
+		Name:          op + " " + segment,
+		Kind:          kindDataAccess,
+		QualifiedName: ref,
+		SourceFile:    filePath,
+		Language:      "cobol",
+		Subtype:       ormIMSDLI,
+		StartLine:     line,
+		EndLine:       line,
+		Properties: map[string]string{
+			"segment":      segment,
+			"operation":    op,
+			"orm":          ormIMSDLI,
+			"ref":          ref,
+			"function_ref": fnQName,
+			"via":          via,
+			"provenance":   "INFERRED_FROM_IMS_DLI",
+		},
+		QualityScore: 0.8,
+	}
+	rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+		FromID: fnRef,
+		ToID:   ref,
+		Kind:   relAccessesTab,
+		Properties: map[string]string{
+			"function_qname": fnQName,
+			"orm":            ormIMSDLI,
+			"operation":      op,
+			"segment":        segment,
+			"via":            via,
+			"line":           strconv.Itoa(line),
+		},
+	})
+	return rec
+}
+
+// extractDLIEntities turns one EXEC DLI block into SCOPE.DataAccess segment
+// entities — one per referenced SEGMENT(<name>) — mirroring extractSQLEntities
+// for DB2 tables. The DL/I function code classifies the operation.
+func extractDLIEntities(filePath, fnQName string, blk execBlock) []types.EntityRecord {
+	fn := ""
+	if m := dliFuncRe.FindStringSubmatch(blk.text); m != nil {
+		fn = m[1]
+	}
+	op := dliOpFor(fn)
+	fnRef := sqlFunctionRef(filePath, fnQName)
+
+	segments := map[string]bool{}
+	for _, m := range dliSegmentRe.FindAllStringSubmatch(blk.text, -1) {
+		seg := strings.ToUpper(m[1])
+		if seg != "" {
+			segments[seg] = true
+		}
+	}
+
+	var out []types.EntityRecord
+	for seg := range segments {
+		out = append(out, buildDLISegmentEntity(filePath, fnQName, fnRef, op, seg, blk.startLine, "EXEC-DLI-"+strings.ToUpper(fn)))
+	}
+	return out
+}
+
+// dliFuncCodeReserved are USING-list tokens that follow CBLTDLI but are not
+// SSA segment literals.
+var dliFuncCodeReserved = map[string]bool{
+	"GU": true, "GN": true, "GHU": true, "GNP": true, "GHN": true,
+	"GHNP": true, "ISRT": true, "REPL": true, "DLET": true,
+}
+
+// extractDLICall classifies a `CALL 'CBLTDLI'/'AIBTDLI' USING ...` statement.
+// The function code (when an inline literal) maps to a DML operation; the
+// segment is recovered only from an inline SSA literal (the data-name SSA form
+// is not statically resolvable here). Returns nil when no segment is
+// recoverable — the abstract db_effect (effect_sinks_cobol.go) still records
+// the read/write, so the call is never wholly invisible. `line` is the source
+// line; `module` is the matched DL/I interface module.
+func extractDLICall(filePath, fnQName, code, module string, line int) []types.EntityRecord {
+	op := "EXEC"
+	if m := dliFuncLiteralRe.FindStringSubmatch(code); m != nil {
+		op = dliOpFor(m[1])
+	}
+	fnRef := sqlFunctionRef(filePath, fnQName)
+
+	// Scan only the USING argument list for SSA literals — strip the leading
+	// `CALL '<module>'` so the interface-module name is never mistaken for a
+	// segment.
+	args := code
+	if loc := dliCallModuleRe.FindStringIndex(args); loc != nil {
+		args = args[loc[1]:]
+	}
+
+	// Recover a segment name from an inline SSA literal: the leading token of
+	// a quoted `'SEG(...'` (qualified) or `'SEG'` (unqualified) operand in the
+	// USING list. Skip function-code literals (e.g. 'GHU ').
+	segments := map[string]bool{}
+	for _, m := range dliSSASegRe.FindAllStringSubmatch(args, -1) {
+		seg := strings.ToUpper(strings.TrimSpace(m[1]))
+		if seg == "" || dliFuncCodeReserved[seg] {
+			continue
+		}
+		segments[seg] = true
+	}
+
+	var out []types.EntityRecord
+	for seg := range segments {
+		out = append(out, buildDLISegmentEntity(filePath, fnQName, fnRef, op, seg, line, "CALL-"+strings.ToUpper(module)))
+	}
+	return out
 }
 
 // cicsCallEdge builds the CALLS relationship for a CICS program/transaction

--- a/internal/extractors/cobol/extractor.go
+++ b/internal/extractors/cobol/extractor.go
@@ -357,6 +357,11 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 		switch blk.kind {
 		case "SQL":
 			entities = append(entities, extractSQLEntities(filePath, fnRefName(), blk)...)
+		case "DLI":
+			// IMS DB/DC (DL/I) segment I/O (#4948): EXEC DLI GU|GN|GHU|ISRT|REPL|
+			// DLET SEGMENT(<seg>) → SCOPE.DataAccess segment entity + ACCESSES_TABLE
+			// edge from the enclosing paragraph (segment = the IMS table analog).
+			entities = append(entities, extractDLIEntities(filePath, fnRefName(), blk)...)
 		case "CICS":
 			for _, c := range extractCICSTransfers(blk.text) {
 				attachCall(entities, currentParagraphIdx, programIdx, cicsCallEdge(c, blk.startLine))
@@ -782,6 +787,16 @@ func extractCOBOL(src, filePath, repoRoot string) []types.EntityRecord {
 				}
 				attachCall(entities, currentParagraphIdx, programIdx, rel)
 			}
+			// CALL 'CBLTDLI'/'AIBTDLI' USING <func> <pcb> <io> <ssa> → IMS DL/I
+			// segment I/O (#4948). The CALLS edge to the interface module is
+			// already emitted above; here we additionally surface the accessed
+			// IMS segment as a SCOPE.DataAccess entity (when statically
+			// recoverable from an inline SSA literal) with an ACCESSES_TABLE edge.
+			if dm := dliCallModuleRe.FindStringSubmatch(ln.code); dm != nil {
+				entities = append(entities,
+					extractDLICall(filePath, fnRefName(), ln.code, dm[1], ln.num)...)
+			}
+
 			// CALL <data-item> (dynamic call via a variable). Only when no
 			// literal CALL matched on the line (avoids double-counting).
 			if !matchedLiteral {

--- a/internal/extractors/cobol/extractor_test.go
+++ b/internal/extractors/cobol/extractor_test.go
@@ -504,6 +504,96 @@ func TestExtractor_EmbeddedSQLCursor(t *testing.T) {
 	}
 }
 
+// dliSegmentFor reports whether an IMS DL/I segment SCOPE.DataAccess entity
+// (orm=ims-dli) exists for the given operation + segment.
+func dliSegmentFor(recs []types.EntityRecord, op, segment string) bool {
+	for _, r := range findDataAccess(recs, "ims-dli") {
+		if r.Properties["operation"] == op && r.Properties["segment"] == segment {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExtractor_IMSDLISegments proves EXEC DLI GU|GN|ISRT|REPL|DLET
+// SEGMENT(<seg>) yields SCOPE.DataAccess segment entities (orm=ims-dli) with
+// ACCESSES_TABLE edges from the enclosing paragraph — the IMS DB/DC data layer
+// (#4948), the hierarchical analog of the DB2 table pipeline.
+func TestExtractor_IMSDLISegments(t *testing.T) {
+	src := loadFixture(t, "imsparts.cbl")
+	recs := run(t, "imsparts.cbl", src)
+
+	want := []struct{ op, segment string }{
+		{"SELECT", "PARTROOT"}, // EXEC DLI GU SEGMENT(PARTROOT)
+		{"SELECT", "PARTDETL"}, // EXEC DLI GN SEGMENT(PARTDETL)
+		{"INSERT", "PARTDETL"}, // EXEC DLI ISRT SEGMENT(PARTDETL)
+		{"UPDATE", "PARTROOT"}, // EXEC DLI REPL SEGMENT(PARTROOT)
+		{"DELETE", "PARTDETL"}, // EXEC DLI DLET SEGMENT(PARTDETL)
+	}
+	for _, w := range want {
+		if !dliSegmentFor(recs, w.op, w.segment) {
+			t.Errorf("expected IMS DL/I SCOPE.DataAccess %s %s", w.op, w.segment)
+		}
+	}
+
+	// Each segment access carries an orm=ims-dli ACCESSES_TABLE edge.
+	var imsEdges int
+	for _, rel := range relationsByKind(recs, "ACCESSES_TABLE") {
+		if rel.Properties["orm"] == "ims-dli" {
+			imsEdges++
+		}
+	}
+	if imsEdges == 0 {
+		t.Error("expected orm=ims-dli ACCESSES_TABLE edges for EXEC DLI")
+	}
+	// The via tag identifies the DL/I function command.
+	var taggedGU bool
+	for _, r := range findDataAccess(recs, "ims-dli") {
+		if r.Properties["segment"] == "PARTROOT" && r.Properties["operation"] == "SELECT" &&
+			r.Properties["via"] == "EXEC-DLI-GU" {
+			taggedGU = true
+		}
+	}
+	if !taggedGU {
+		t.Error("expected EXEC-DLI-GU via tag on PARTROOT SELECT segment access")
+	}
+}
+
+// TestExtractor_IMSDLICall proves CALL 'CBLTDLI'/'AIBTDLI' USING <func> ...
+// surfaces the IMS segment from an inline SSA literal (when statically
+// recoverable) as a SCOPE.DataAccess entity with the correct operation, while
+// the CALLS edge to the interface module is preserved (#4948).
+func TestExtractor_IMSDLICall(t *testing.T) {
+	src := loadFixture(t, "imsparts.cbl")
+	recs := run(t, "imsparts.cbl", src)
+
+	// CALL 'CBLTDLI' USING 'GU  ' ... 'PARTROOT(PARTKEY = ...' → SELECT PARTROOT.
+	if !dliSegmentFor(recs, "SELECT", "PARTROOT") {
+		t.Error("expected CBLTDLI GU to surface SELECT PARTROOT from SSA literal")
+	}
+	// CALL 'AIBTDLI' USING 'ISRT' ... 'PARTDETL' → INSERT PARTDETL.
+	if !dliSegmentFor(recs, "INSERT", "PARTDETL") {
+		t.Error("expected AIBTDLI ISRT to surface INSERT PARTDETL from SSA literal")
+	}
+	// The CALLS edge to the DL/I interface module is still emitted.
+	for _, mod := range []string{"CBLTDLI", "AIBTDLI"} {
+		if !hasCallTo(recs, mod) {
+			t.Errorf("expected CALLS edge to DL/I interface module %q", mod)
+		}
+	}
+	// A CALL-sourced segment access carries the CALL-<MODULE> via tag.
+	var taggedCall bool
+	for _, r := range findDataAccess(recs, "ims-dli") {
+		if r.Properties["segment"] == "PARTDETL" && r.Properties["operation"] == "INSERT" &&
+			r.Properties["via"] == "CALL-AIBTDLI" {
+			taggedCall = true
+		}
+	}
+	if !taggedCall {
+		t.Error("expected CALL-AIBTDLI via tag on PARTDETL INSERT segment access")
+	}
+}
+
 // TestExtractor_CICSProgramTransfer proves EXEC CICS LINK/XCTL/START become
 // external CALLS edges (CICS transaction-graph depth).
 func TestExtractor_CICSProgramTransfer(t *testing.T) {

--- a/internal/extractors/cobol/testdata/imsparts.cbl
+++ b/internal/extractors/cobol/testdata/imsparts.cbl
@@ -1,0 +1,54 @@
+      ******************************************************************
+      * IMSPARTS.CBL — IMS DB/DC (DL/I) segment I/O fixture (#4948).     *
+      * Proves: EXEC DLI GU|GN|ISRT|REPL|DLET SEGMENT(<seg>) and         *
+      * CALL 'CBLTDLI'/'AIBTDLI' USING <func> <pcb> <io> <ssa> emit      *
+      * SCOPE.DataAccess segment entities (orm=ims-dli) with             *
+      * ACCESSES_TABLE edges from the enclosing paragraph, plus db_read / *
+      * db_write effects. A segment is the IMS analog of a DB2 table.     *
+      ******************************************************************
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. IMSPARTS.
+
+       ENVIRONMENT DIVISION.
+
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01  WS-FUNC               PIC X(04).
+       01  PART-IO-AREA          PIC X(80).
+
+       LINKAGE SECTION.
+       01  IO-PCB.
+           05  IO-PCB-LTERM      PIC X(08).
+       01  DB-PCB.
+           05  DB-PCB-DBD        PIC X(08).
+
+       PROCEDURE DIVISION.
+       GET-ROOT.
+           EXEC DLI GU SEGMENT(PARTROOT)
+               WHERE (PARTKEY = WS-PARTKEY)
+           END-EXEC.
+
+       GET-NEXT-DETAIL.
+           EXEC DLI GN SEGMENT(PARTDETL)
+           END-EXEC.
+
+       ADD-DETAIL.
+           EXEC DLI ISRT SEGMENT(PARTDETL)
+           END-EXEC.
+
+       UPDATE-ROOT.
+           EXEC DLI REPL SEGMENT(PARTROOT)
+           END-EXEC.
+
+       PURGE-DETAIL.
+           EXEC DLI DLET SEGMENT(PARTDETL)
+           END-EXEC.
+
+       CALL-GET-UNIQUE.
+           CALL 'CBLTDLI' USING 'GU  ' DB-PCB IO 'PARTROOT(KEY ='.
+
+       CALL-INSERT.
+           CALL 'AIBTDLI' USING 'ISRT' DB-PCB IO 'PARTDETL'.
+
+       MSG-IN.
+           CALL 'CBLTDLI' USING 'GU  ' IO-PCB PART-IO-AREA.

--- a/internal/substrate/effect_sinks_cobol.go
+++ b/internal/substrate/effect_sinks_cobol.go
@@ -7,8 +7,12 @@
 //     (sequential / indexed / relative file I/O on an FD record)
 //   - fs_write : WRITE <rec> / REWRITE <rec> / DELETE <file> / OPEN OUTPUT /
 //     OPEN EXTEND / RELEASE
-//   - db_read  : EXEC SQL SELECT / OPEN <cursor> / FETCH (embedded DB2)
-//   - db_write : EXEC SQL INSERT|UPDATE|DELETE|MERGE (embedded DB2)
+//   - db_read  : EXEC SQL SELECT / OPEN <cursor> / FETCH (embedded DB2);
+//     EXEC DLI GU|GN|GHU|GNP|GHN / CALL 'CBLTDLI'/'AIBTDLI' get-function
+//     (IMS DB/DC segment retrieval, #4948)
+//   - db_write : EXEC SQL INSERT|UPDATE|DELETE|MERGE (embedded DB2);
+//     EXEC DLI ISRT|REPL|DLET / CALL CBLTDLI/AIBTDLI mutate-function
+//     (IMS DB/DC segment insert/replace/delete, #4948)
 //   - http_out : EXEC CICS LINK / XCTL / WEB / INVOKE — outbound transaction
 //     / service calls treated as the COBOL analog of an outbound
 //     request (the closest effect in the lattice for CICS
@@ -69,6 +73,22 @@ var cobolDBWriteRe = regexp.MustCompile(
 	`(?is)EXEC\s+SQL\b[^.]*?\b(?:INSERT|UPDATE|DELETE|MERGE|CREATE|DROP|ALTER)\b`,
 )
 
+// cobolDLIReadRe matches IMS DB/DC (DL/I) segment retrieval — the 2nd most
+// common mainframe data layer (#4948). Both call shapes are covered: the
+// command-level EXEC DLI GU|GN|GHU|GNP|GHN form, and the call-level
+// CALL 'CBLTDLI'/'AIBTDLI' ... with a get function-code literal.
+var cobolDLIReadRe = regexp.MustCompile(
+	`(?is)\bEXEC\s+DLI\s+(?:GU|GN|GHU|GNP|GHN|GHNP)\b` +
+		`|(?is)\bCALL\s+['"](?:CBL|AIB|ASM|PLI)TDLI['"][^.]*?['"]\s*(?:GU|GN|GHU|GNP|GHN|GHNP)\s*['"]`,
+)
+
+// cobolDLIWriteRe matches IMS DL/I segment mutation: ISRT (insert), REPL
+// (replace/update), DLET (delete) — via EXEC DLI or the CBLTDLI/AIBTDLI call.
+var cobolDLIWriteRe = regexp.MustCompile(
+	`(?is)\bEXEC\s+DLI\s+(?:ISRT|REPL|DLET)\b` +
+		`|(?is)\bCALL\s+['"](?:CBL|AIB|ASM|PLI)TDLI['"][^.]*?['"]\s*(?:ISRT|REPL|DLET)\s*['"]`,
+)
+
 // cobolCICSRe matches EXEC CICS outbound transaction / service primitives:
 // program transfer (LINK/XCTL), transaction scheduling (START), and terminal
 // / web service traffic (SEND/RECEIVE/WEB/INVOKE) — all modelled as the COBOL
@@ -122,6 +142,8 @@ func sniffEffectsCobol(content string) []EffectMatch {
 	out = appendCobolMatches(out, content, headers, cobolFSWriteRe, EffectFSWrite, "WRITE/REWRITE/DELETE", 1.0)
 	out = appendCobolMatches(out, content, headers, cobolDBReadRe, EffectDBRead, "EXEC-SQL.SELECT/FETCH", 1.0)
 	out = appendCobolMatches(out, content, headers, cobolDBWriteRe, EffectDBWrite, "EXEC-SQL.INSERT/UPDATE/DELETE", 1.0)
+	out = appendCobolMatches(out, content, headers, cobolDLIReadRe, EffectDBRead, "IMS-DLI.GU/GN/GHU", 1.0)
+	out = appendCobolMatches(out, content, headers, cobolDLIWriteRe, EffectDBWrite, "IMS-DLI.ISRT/REPL/DLET", 1.0)
 	out = appendCobolMatches(out, content, headers, cobolCICSRe, EffectHTTPOut, "EXEC-CICS.LINK/XCTL/WEB", 0.85)
 	out = appendCobolMatches(out, content, headers, cobolCICSFSReadRe, EffectFSRead, "EXEC-CICS.READ/READQ", 0.9)
 	out = appendCobolMatches(out, content, headers, cobolCICSFSWriteRe, EffectFSWrite, "EXEC-CICS.WRITE/WRITEQ/REWRITE", 0.9)


### PR DESCRIPTION
## Built
Recognises **IMS DB/DC (DL/I)** — the 2nd most common mainframe data layer — which was previously invisible (`execStartRe` matched only SQL|CICS). Modelled on the embedded-SQL pipeline: an IMS *segment* is the hierarchical analog of a relational table.

- **EXEC DLI** `GU|GN|GHU|GNP|GHN|ISRT|REPL|DLET SEGMENT(<seg>)` → `SCOPE.DataAccess` segment entity (`orm=ims-dli`) + **ACCESSES_TABLE** edge FromID=enclosing paragraph. Function code → DML op (GU/GN…→SELECT, ISRT→INSERT, REPL→UPDATE, DLET→DELETE), `via=EXEC-DLI-<func>`, `provenance=INFERRED_FROM_IMS_DLI`. (`extractDLIEntities`, depth.go; `execStartRe` now matches DLI.)
- **CALL 'CBLTDLI'/'AIBTDLI'** `USING <func> <pcb> <io> <ssa>` → `extractDLICall`: function-code literal classifies the operation; segment recovered from an inline SSA literal (`'SEG(KEY='` qualified or bare `'SEG'`); the `CALLS` edge to the interface module is preserved.
- **db_read / db_write** effect sniffing for both forms (`effect_sinks_cobol.go`: `cobolDLIReadRe` / `cobolDLIWriteRe`).

## Edges / entities
Reuses existing `SCOPE.DataAccess` Kind + `ACCESSES_TABLE` / `CALLS` edge kinds — **no new Kinds** (`go test ./internal/types/` green).

## Registry cells
`lang.cobol.runtime.ibm-enterprise` → `db_effect` note rewritten from the WEAK #4948 placeholder to the implemented IMS DL/I description; added `testdata/imsparts.cbl` cite. Only this cell touched; surgical + canonical (`coverage fmt`).

## Fixtures
`internal/extractors/cobol/testdata/imsparts.cbl` — proven by `TestExtractor_IMSDLISegments` and `TestExtractor_IMSDLICall`.

## Deferred (follow-ups to file)
- IO-PCB message-queue GU/ISRT segment binding (no segment name without SSA parse).
- data-name SSA / data-name function-code resolution via working-storage VALUE tracing.
- DBD/PSB (DBDGEN/PSBGEN) hierarchy extraction.

## Gates (sandbox HOME=/tmp/agsbx-4948)
`go build ./...` ✅, `go vet ./internal/...` ✅, `go test` on cobol + substrate + types ✅, `coverage fmt --check` ✅, `coverage validate` ✅ (732 records; pre-existing warnings only).

Deploy-deferred.

Closes #4948