### PR TITLE
feat(#4950): assembly — MASM/armasm structured directives (PROC/EXPORT/EXTERN/INCLUDE/AREA)

### DIFF
--- a/internal/extractors/assembly/extractor.go
+++ b/internal/extractors/assembly/extractor.go
@@ -116,13 +116,48 @@ var (
 	// includeRE matches gas `.include "file"` and NASM `%include "file"`.
 	includeRE = regexp.MustCompile(`(?m)^\s*(?:\.include|%include)\s+["']([^"']+)["']`)
 
+	// masmIncludeRE matches the MASM/armasm structured include spellings (no
+	// leading dot/percent, quotes optional): MASM `INCLUDE file` / `INCLUDELIB
+	// lib`, and armasm `GET file` / `INCLUDE file` (#4950). The path runs to
+	// end-of-line (comments are already scrubbed). INCLUDELIB names an import
+	// library; both are modelled as IMPORTS so the linkage surfaces.
+	masmIncludeRE = regexp.MustCompile(`(?mi)^\s*(?:include|includelib|get)\s+["']?([^"'\s][^"'\n]*?)["']?\s*$`)
+
 	// globlRE matches exported-symbol directives:
 	//   .globl name      .global name      .global name1, name2
 	globlRE = regexp.MustCompile(`(?m)^\s*\.glob[a]?l\s+(.+)$`)
 
+	// publicRE matches the MASM/armasm exported-symbol spellings (#4950):
+	//   PUBLIC name1, name2     (MASM)     EXPORT name     (armasm)
+	// Case-insensitive; a PUBLIC line may list several comma-separated names.
+	publicRE = regexp.MustCompile(`(?mi)^\s*(?:public|export|global)\s+(.+)$`)
+
 	// externRE matches external-symbol directives:
 	//   .extern name      extern name      (NASM)
 	externRE = regexp.MustCompile(`(?m)^\s*\.?extern\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// masmExternRE matches the MASM/armasm external-symbol spellings (#4950):
+	//   EXTERN name:type   EXTRN name:type   (MASM, optional :PROC/:DWORD type)
+	//   IMPORT name        (armasm)
+	// Case-insensitive; a list may be comma-separated. The optional `:type`
+	// suffix per name is stripped by splitMasmSymbolList.
+	masmExternRE = regexp.MustCompile(`(?mi)^\s*(?:extern|extrn|import)\s+(.+)$`)
+
+	// procStartRE matches the MASM/armasm structured-procedure opener (#4950):
+	//   name PROC            (MASM / armasm)
+	//   name FUNCTION        (armasm alias)
+	// The leading token is the procedure name (no trailing colon). PROC may be
+	// followed by attributes (NEAR/FAR/visibility) which we ignore.
+	procStartRE = regexp.MustCompile(`(?i)^\s*([A-Za-z_$][A-Za-z0-9_$]*)\s+(?:proc|function)\b`)
+
+	// procEndRE matches the MASM/armasm procedure terminator (#4950):
+	//   name ENDP   (MASM/armasm)    name ENDFUNC / ENDFUNC   (armasm)
+	procEndRE = regexp.MustCompile(`(?i)^\s*(?:([A-Za-z_$][A-Za-z0-9_$]*)\s+)?(?:endp|endfunc)\b`)
+
+	// areaRE matches the armasm section directive (#4950):
+	//   AREA <name>, CODE, READONLY      AREA |.text|, DATA
+	// The name may be bar-delimited (|.text|); group 1 is the raw name.
+	areaRE = regexp.MustCompile(`(?i)^\s*area\s+\|?([^,|\s]+)\|?`)
 
 	// equRE matches constant definitions across dialects:
 	//   .equ NAME, value     .set NAME, value
@@ -323,14 +358,43 @@ func collectExported(scrubbed string) map[string]bool {
 			out[name] = true
 		}
 	}
+	// MASM PUBLIC / armasm EXPORT (and the `GLOBAL name` spelling) — #4950.
+	for _, m := range publicRE.FindAllStringSubmatch(scrubbed, -1) {
+		for _, name := range splitMasmSymbolList(m[1]) {
+			out[name] = true
+		}
+	}
 	return out
 }
 
-// collectExternal returns the set of symbols declared .extern/extern.
+// collectExternal returns the set of symbols declared .extern/extern, plus the
+// MASM EXTERN/EXTRN and armasm IMPORT structured spellings (#4950).
 func collectExternal(scrubbed string) map[string]bool {
 	out := map[string]bool{}
 	for _, m := range externRE.FindAllStringSubmatch(scrubbed, -1) {
 		out[m[1]] = true
+	}
+	for _, m := range masmExternRE.FindAllStringSubmatch(scrubbed, -1) {
+		for _, name := range splitMasmSymbolList(m[1]) {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// splitMasmSymbolList parses a MASM/armasm symbol list, stripping the optional
+// per-name `:type` attribute (e.g. `EXTERN printf:PROC, exit:PROC` →
+// {printf, exit}) and trailing scrubbed-comment whitespace.
+func splitMasmSymbolList(s string) []string {
+	var out []string
+	for _, f := range splitSymbolList(s) {
+		if colon := strings.IndexByte(f, ':'); colon > 0 {
+			f = f[:colon]
+		}
+		f = strings.TrimSpace(f)
+		if f != "" && isLabelLike(f) {
+			out = append(out, f)
+		}
 	}
 	return out
 }
@@ -360,7 +424,12 @@ func splitSymbolList(s string) []string {
 func buildIncludeEntities(filePath, scrubbed, lang string) []types.EntityRecord {
 	seen := map[string]bool{}
 	var out []types.EntityRecord
-	for _, m := range includeRE.FindAllStringSubmatch(scrubbed, -1) {
+
+	// gas `.include` / NASM `%include`, then the MASM/armasm structured
+	// INCLUDE/INCLUDELIB/GET spellings (#4950). Both feed the same dedupe set.
+	matches := includeRE.FindAllStringSubmatch(scrubbed, -1)
+	matches = append(matches, masmIncludeRE.FindAllStringSubmatch(scrubbed, -1)...)
+	for _, m := range matches {
 		inc := strings.TrimSpace(m[1])
 		if inc == "" || seen[inc] {
 			continue
@@ -432,6 +501,10 @@ var sectionShorthands = map[string]string{
 func sectionName(line string) string {
 	t := strings.TrimSpace(line)
 	if m := sectionRE.FindStringSubmatch(line); m != nil {
+		return m[1]
+	}
+	// armasm `AREA <name>, CODE|DATA` section framing (#4950).
+	if m := areaRE.FindStringSubmatch(line); m != nil {
 		return m[1]
 	}
 	// Bare shorthand directives: ".text", ".data", possibly with trailing
@@ -531,6 +604,39 @@ func buildProcedureEntities(lines []string, filePath, lang, dialect string, expo
 
 	for i, raw := range lines {
 		line := raw
+
+		// MASM/armasm structured procedure framing (#4950): `name PROC` /
+		// `name FUNCTION` opens a procedure with no trailing colon, which
+		// labelRE would miss. `name ENDP` / `ENDFUNC` closes it (we record the
+		// EndLine and clear the current procedure so a following body line is
+		// not mis-attributed). These spellings coexist with colon-labels.
+		if m := procStartRE.FindStringSubmatch(line); m != nil {
+			name := m[1]
+			rec := types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "procedure",
+				SourceFile: filePath,
+				Language:   lang,
+				StartLine:  i + 1,
+				EndLine:    i + 1,
+				Signature:  strings.TrimSpace(line),
+				Properties: map[string]string{"dialect": dialect, "framing": "proc"},
+			}
+			if exported[name] {
+				rec.Properties["exported"] = "true"
+			}
+			curIdx = len(out)
+			out = append(out, rec)
+			continue
+		}
+		if procEndRE.MatchString(line) {
+			if curIdx >= 0 {
+				out[curIdx].EndLine = i + 1
+			}
+			curIdx = -1
+			continue
+		}
 
 		if name := labelName(line); name != "" {
 			// A global/exported label (or any top-level label) starts a new

--- a/internal/extractors/assembly/extractor_test.go
+++ b/internal/extractors/assembly/extractor_test.go
@@ -649,6 +649,113 @@ func TestResolverBindsBranchAndCrossFile(t *testing.T) {
 	}
 }
 
+// importedModules returns the set of source_module values across all IMPORTS
+// edges in the record set (#4950 INCLUDE/GET linkage assertions).
+func importedModules(recs []types.EntityRecord) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPORTS" {
+				out[rel.Properties["source_module"]] = true
+			}
+		}
+	}
+	return out
+}
+
+// MASM structured directives (#4950) --------------------------------------
+
+func TestExtractMASMStructured(t *testing.T) {
+	src := loadFixture(t, "x86_64.masm.fixture")
+	recs := extractAssembly(src, "win.asm", "assembly")
+
+	// name PROC / ENDP framing yields procedures even without a trailing colon.
+	for _, p := range []string{"main", "helper"} {
+		r := byName(recs, p)
+		if r == nil || r.Kind != "SCOPE.Operation" || r.Subtype != "procedure" {
+			t.Fatalf("PROC %q not a procedure: %v", p, r)
+		}
+		if r.Properties["framing"] != "proc" {
+			t.Errorf("PROC %q framing=%q want proc", p, r.Properties["framing"])
+		}
+	}
+	if m := byName(recs, "main"); m == nil || m.Properties["exported"] != "true" {
+		t.Errorf("main should be exported via PUBLIC: %v", m)
+	}
+
+	// PROC body is bounded by ENDP — helper's call to printf must attribute to
+	// helper-or-main, never leak to a stale procedure. Verify main's CALLS.
+	cc := callTargets(byName(recs, "main"))
+	if _, ok := cc["helper"]; !ok {
+		t.Errorf("main should CALL helper; got %v", cc)
+	}
+	// EXTERN printf:PROC → external locality on the printf call.
+	if e, ok := cc["printf"]; !ok {
+		t.Errorf("main should CALL printf; got %v", cc)
+	} else if e.Properties["locality"] != "external" {
+		t.Errorf("printf locality=%q want external (EXTERN)", e.Properties["locality"])
+	}
+	if e, ok := cc["ExitProcess"]; !ok {
+		t.Errorf("main should CALL ExitProcess; got %v", cc)
+	} else if e.Properties["locality"] != "external" {
+		t.Errorf("ExitProcess locality=%q want external (EXTERN)", e.Properties["locality"])
+	}
+
+	// INCLUDE / INCLUDELIB → IMPORTS edges.
+	imps := importedModules(recs)
+	for _, want := range []string{"windows.inc", "kernel32.lib"} {
+		if !imps[want] {
+			t.Errorf("missing IMPORTS for %q; got %v", want, imps)
+		}
+	}
+	// EQU constant still parses alongside the structured directives.
+	if c := byName(recs, "KMAX"); c == nil || c.Kind != "SCOPE.Constant" {
+		t.Errorf("KMAX EQU should be a constant; got %v", c)
+	}
+}
+
+// ARM armasm structured directives (#4950) --------------------------------
+
+func TestExtractARMArmasmStructured(t *testing.T) {
+	src := loadFixture(t, "arm.armasm.fixture")
+	recs := extractAssembly(src, "arm.s", "assembly")
+
+	// name PROC and name FUNCTION both open procedures.
+	for _, p := range []string{"main", "compute"} {
+		r := byName(recs, p)
+		if r == nil || r.Subtype != "procedure" {
+			t.Fatalf("armasm proc %q missing: %v", p, r)
+		}
+	}
+	if m := byName(recs, "main"); m == nil || m.Properties["exported"] != "true" {
+		t.Errorf("main should be exported via EXPORT: %v", m)
+	}
+
+	// AREA |.text|, CODE → section component.
+	if s := byName(recs, ".text"); s == nil || s.Subtype != "section" {
+		t.Errorf("AREA .text should be a section; got %v", s)
+	}
+
+	// IMPORT printf → external locality on the printf call.
+	cc := callTargets(byName(recs, "main"))
+	if e, ok := cc["printf"]; !ok {
+		t.Errorf("main should CALL printf; got %v", cc)
+	} else if e.Properties["locality"] != "external" {
+		t.Errorf("printf locality=%q want external (IMPORT)", e.Properties["locality"])
+	}
+	if _, ok := cc["compute"]; !ok {
+		t.Errorf("main should CALL compute; got %v", cc)
+	}
+
+	// GET / INCLUDE → IMPORTS edges.
+	imps := importedModules(recs)
+	for _, want := range []string{"macros.inc", "defs.inc"} {
+		if !imps[want] {
+			t.Errorf("missing IMPORTS for %q; got %v", want, imps)
+		}
+	}
+}
+
 // Full pipeline through Extract (language tagging) -------------------------
 
 func TestExtractTagsLanguage(t *testing.T) {

--- a/internal/extractors/assembly/testdata/arm.armasm.fixture
+++ b/internal/extractors/assembly/testdata/arm.armasm.fixture
@@ -1,0 +1,24 @@
+; ARM armasm (legacy) structured-directive fixture (#4950).
+; Exercises AREA section framing, name PROC/ENDP and FUNCTION/ENDFUNC
+; procedure framing, EXPORT/IMPORT linkage, and GET/INCLUDE includes.
+
+        GET     macros.inc
+        INCLUDE defs.inc
+
+        EXPORT  main
+        IMPORT  printf
+
+        AREA    .text, CODE, READONLY
+
+main    PROC
+        bl      compute
+        bl      printf
+        bx      lr
+        ENDP
+
+compute FUNCTION
+        add     r0, r0, #1
+        bx      lr
+        ENDFUNC
+
+        END

--- a/internal/extractors/assembly/testdata/x86_64.masm.fixture
+++ b/internal/extractors/assembly/testdata/x86_64.masm.fixture
@@ -1,0 +1,27 @@
+; MASM (Microsoft Macro Assembler) structured-directive fixture (#4950).
+; Exercises name PROC/ENDP framing, PUBLIC/EXTERN symbol directives, and
+; INCLUDE/INCLUDELIB linkage — none of which use the gas leading-dot spelling.
+
+INCLUDE windows.inc
+INCLUDELIB kernel32.lib
+
+PUBLIC main, helper
+EXTERN printf:PROC, ExitProcess:PROC
+
+KMAX EQU 100
+
+.code
+
+main PROC
+    call helper
+    call printf
+    call ExitProcess
+    ret
+main ENDP
+
+helper PROC
+    mov  eax, KMAX
+    ret
+helper ENDP
+
+END


### PR DESCRIPTION
Deepens the assembly line parser (split from #4909) so MASM and ARM armasm structured / non-gas directives are recognised. Reuses existing entity Kinds + edge kinds — **no new Kinds** (`go test ./internal/types/` green).

## Built (fixture-proven)
- **`name PROC`/`name ENDP`** and **`name FUNCTION`/`ENDFUNC`** procedure framing (no trailing colon) → `SCOPE.Operation(subtype=procedure, framing=proc)`; `ENDP`/`ENDFUNC` closes the span and clears the current procedure (`procStartRE`/`procEndRE` in `buildProcedureEntities`).
- **`PUBLIC`/`EXPORT`** → exported symbol (`publicRE` → `collectExported`); **`EXTERN`/`EXTRN`/`IMPORT`** → external symbol with CALLS `locality=external` (`masmExternRE` → `collectExternal`; optional `:PROC`/`:DWORD` type stripped by `splitMasmSymbolList`).
- **`INCLUDE file` / `INCLUDELIB lib` / `GET file`** → `IMPORTS` edge with source_module/imported_name/local_name (`masmIncludeRE` → `buildIncludeEntities`).
- **armasm `AREA <name>,CODE|DATA`** → `SCOPE.Component(subtype=section)` (`areaRE` in `sectionName`).

## Edges / Kinds
CALLS (locality=external), IMPORTS, SCOPE.Operation, SCOPE.Component — all pre-existing.

## Deferred (follow-ups filed)
- MASM `STRUCT`/`ENDS` record types and `SEGMENT`/`ENDS` segment directives (record/component entities).
- armasm column-1 data forms `LABEL EQU value` / `LABEL DCD ...`.
- Bar-delimited `|name|` AREA/label form (the `|` is scrubbed as an m68k line comment).

## Registry cells
- `lang.assembly.toolchain.masm` / `.armasm` **import_resolution_quality → full** (INCLUDE/GET imports + EXTERN/IMPORT/PUBLIC/EXPORT linkage).
- `.masm` / `.armasm` **core_extraction stays partial** (PROC framing + AREA done; STRUCT/SEGMENT/DCD deferred). Notes cite `#4950` + the code symbols.

## Fixtures
- `testdata/x86_64.masm.fixture` → `TestExtractMASMStructured`
- `testdata/arm.armasm.fixture` → `TestExtractARMArmasmStructured`

## Gates (sandbox HOME=/tmp/agsbx-4950)
`go build ./...` ✓ · `go vet ./internal/...` ✓ · `go test ./internal/extractors/assembly/... ./internal/types/...` ✓ · `coverage fmt --check` ✓ canonical · `coverage validate` exit 0 (no new assembly warnings). No `coverage gen` run (docs synced separately).

Closes #4950