### PR TITLE
feat(#5038): coverage-provenance banner v1 — disambiguate line vs reachability vs capability coverage

### DIFF
--- a/webui-v2/src/components/ui/coverage-provenance-banner.tsx
+++ b/webui-v2/src/components/ui/coverage-provenance-banner.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import {
+  ChevronDown,
+  ClipboardList,
+  GaugeCircle,
+  Layers,
+  AlertTriangle,
+  Bot,
+  Plug,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  resolveCoverageProvenance,
+  COVERAGE_DEFINITIONS,
+  type CoverageSourceState,
+  type CoverageProvenanceKind,
+} from "@/lib/coverage-provenance";
+
+export interface CoverageProvenanceBannerProps {
+  /**
+   * Raw availability state for the current view. When omitted (or empty) the
+   * banner degrades to the capability-coverage explanation — never a
+   * misleading authoritative "%". This is the expected v1 state until ingested
+   * line coverage (#5036) is wired into the dashboard data layer.
+   */
+  state?: CoverageSourceState | null;
+  className?: string;
+}
+
+const KIND_ICON: Record<CoverageProvenanceKind, typeof GaugeCircle> = {
+  line: GaugeCircle,
+  reachability: Layers,
+  capability: ClipboardList,
+};
+
+const TONE_CLASSES: Record<
+  "success" | "info" | "neutral",
+  { border: string; bg: string; icon: string }
+> = {
+  success: { border: "border-l-success", bg: "bg-success/5", icon: "text-success" },
+  info: { border: "border-l-info", bg: "bg-info/5", icon: "text-info" },
+  neutral: { border: "border-l-border", bg: "bg-surface-2/40", icon: "text-text-4" },
+};
+
+/**
+ * CoverageProvenanceBanner (#5038) — whenever the dashboard shows a coverage
+ * number, this banner states HOW it was measured (line ▸ reachability ▸
+ * capability), whether report ingestion is available, what it means for
+ * agents/MCP, and (for ingested line coverage) when it was measured + whether
+ * it is stale. All branch selection lives in {@link resolveCoverageProvenance}
+ * — this component is a pure renderer over that descriptor, and degrades
+ * gracefully to the capability explanation when nothing is wired.
+ */
+export function CoverageProvenanceBanner({ state, className }: CoverageProvenanceBannerProps) {
+  const [open, setOpen] = useState(false);
+  const p = resolveCoverageProvenance(state);
+  const Icon = KIND_ICON[p.kind];
+  const tone = TONE_CLASSES[p.tone];
+
+  return (
+    <div
+      className={cn(
+        "w-full overflow-hidden rounded-lg border border-border border-l-4 bg-surface",
+        tone.border,
+        tone.bg,
+        className,
+      )}
+    >
+      <div className="px-4 py-3">
+        <div className="flex items-start gap-2.5">
+          <Icon size={16} className={cn("mt-0.5 shrink-0", tone.icon)} aria-hidden />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-text-2">
+                {p.label}
+              </span>
+              {p.freshness?.stale && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-full border border-warning/40 bg-warning/10 px-1.5 py-px text-[10px] font-medium text-warning"
+                  title="Coverage was measured before the most recent index — it may be stale."
+                >
+                  <AlertTriangle size={10} aria-hidden />
+                  may be stale
+                </span>
+              )}
+            </div>
+
+            <p className="text-sm leading-relaxed text-text-3">{p.method}</p>
+
+            {p.freshness?.measuredAt && !p.freshness.stale && (
+              <p className="text-xs text-text-4">Measured {p.freshness.measuredAt}.</p>
+            )}
+
+            {/* Agents / MCP meaning */}
+            <p className="flex items-start gap-1.5 text-xs leading-relaxed text-text-4">
+              <Bot size={12} className="mt-0.5 shrink-0" aria-hidden />
+              <span>{p.agentMeaning}</span>
+            </p>
+
+            {/* Availability — how to turn on real line coverage */}
+            {p.howToEnable && (
+              <p className="flex items-start gap-1.5 text-xs leading-relaxed text-text-4">
+                <Plug size={12} className="mt-0.5 shrink-0" aria-hidden />
+                <span>{p.howToEnable}</span>
+              </p>
+            )}
+
+            {/* Self-documenting expandable: defines all three coverage types. */}
+            <button
+              type="button"
+              onClick={() => setOpen((v) => !v)}
+              aria-expanded={open}
+              className="inline-flex items-center gap-1 text-xs text-text-3 transition-colors hover:text-text-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] rounded"
+            >
+              <ChevronDown
+                size={13}
+                className={cn("transition-transform", open && "rotate-180")}
+                aria-hidden
+              />
+              {open ? "Hide" : "What are the coverage types?"}
+            </button>
+
+            {open && (
+              <dl className="mt-1 space-y-2 border-t border-border pt-2">
+                {COVERAGE_DEFINITIONS.map((d) => (
+                  <div key={d.kind}>
+                    <dt
+                      className={cn(
+                        "text-xs font-semibold",
+                        d.kind === p.kind ? tone.icon : "text-text-2",
+                      )}
+                    >
+                      {d.title}
+                      {d.kind === p.kind && (
+                        <span className="ml-1.5 font-normal text-text-4">
+                          (what you're seeing)
+                        </span>
+                      )}
+                    </dt>
+                    <dd className="text-xs leading-relaxed text-text-4">{d.body}</dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui-v2/src/components/ui/index.ts
+++ b/webui-v2/src/components/ui/index.ts
@@ -29,5 +29,7 @@ export { DefTerm } from "./screen-description";
 export type { ScreenDescriptionTerm } from "./screen-description";
 export { InsightBanner } from "./insight-banner";
 export type { InsightBannerProps, InsightBannerAgent } from "./insight-banner";
+export { CoverageProvenanceBanner } from "./coverage-provenance-banner";
+export type { CoverageProvenanceBannerProps } from "./coverage-provenance-banner";
 export { InsightProvider, useInsight, useSetInsight } from "./insight-context";
 export type { InsightValue } from "./insight-context";

--- a/webui-v2/src/lib/coverage-provenance.test.ts
+++ b/webui-v2/src/lib/coverage-provenance.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Branch-logic tests for resolveCoverageProvenance (#5038).
+ *
+ * Verifies the degradation precedence (line ▸ reachability ▸ capability), the
+ * "how to enable" affordance gating, the freshness/stale verdict, and that we
+ * never claim an authoritative line "%" when a report wasn't ingested.
+ *
+ * Run with: npx vitest run src/lib/coverage-provenance.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import {
+  resolveCoverageProvenance,
+  COVERAGE_DEFINITIONS,
+  COVERAGE_MCP_TOOL,
+  type CoverageSourceState,
+} from "./coverage-provenance";
+
+describe("resolveCoverageProvenance — source precedence", () => {
+  it("picks ingested LINE coverage when present (authoritative %)", () => {
+    const state: CoverageSourceState = {
+      line: { source: "lcov", measuredAt: "2026-06-12T10:00:00Z", pct: 73.4 },
+      reachabilityAvailable: true, // line still wins over reachability
+      reportIngestionConfigured: true,
+    };
+    const p = resolveCoverageProvenance(state);
+    expect(p.kind).toBe("line");
+    expect(p.tone).toBe("success");
+    expect(p.method).toContain("LCOV");
+    expect(p.method).toContain("coverage_source: lcov");
+    expect(p.method).toContain("measured 2026-06-12T10:00:00Z");
+    // Ingestion is active ⇒ no "how to enable" nag.
+    expect(p.howToEnable).toBeNull();
+    expect(p.agentMeaning).toContain(COVERAGE_MCP_TOOL);
+  });
+
+  it("falls back to static REACHABILITY when no line report but reachability exists", () => {
+    const state: CoverageSourceState = { reachabilityAvailable: true };
+    const p = resolveCoverageProvenance(state);
+    expect(p.kind).toBe("reachability");
+    expect(p.tone).toBe("info");
+    expect(p.method).toContain("static");
+    // Must NOT imply a measured line %.
+    expect(p.method.toLowerCase()).toContain("not a measured line");
+    expect(p.freshness).toBeNull();
+  });
+
+  it("defaults to CAPABILITY coverage when nothing is wired", () => {
+    const p = resolveCoverageProvenance({});
+    expect(p.kind).toBe("capability");
+    expect(p.tone).toBe("neutral");
+    expect(p.method).toContain("NOT test execution");
+  });
+
+  it("treats null/undefined state as the capability default", () => {
+    expect(resolveCoverageProvenance(null).kind).toBe("capability");
+    expect(resolveCoverageProvenance(undefined).kind).toBe("capability");
+  });
+
+  it("ignores a line block with no source string", () => {
+    // A malformed/empty line block must not be treated as authoritative.
+    const state = { line: { source: "" }, reachabilityAvailable: true } as CoverageSourceState;
+    const p = resolveCoverageProvenance(state);
+    expect(p.kind).toBe("reachability");
+  });
+});
+
+describe("resolveCoverageProvenance — how-to-enable affordance", () => {
+  it("shows how-to-enable when reachability is shown and ingestion is NOT configured", () => {
+    const p = resolveCoverageProvenance({
+      reachabilityAvailable: true,
+      reportIngestionConfigured: false,
+    });
+    expect(p.howToEnable).not.toBeNull();
+    expect(p.howToEnable).toContain("lcov/cobertura/jacoco");
+  });
+
+  it("hides how-to-enable when ingestion IS configured (just no report yet)", () => {
+    const p = resolveCoverageProvenance({
+      reachabilityAvailable: true,
+      reportIngestionConfigured: true,
+    });
+    expect(p.howToEnable).toBeNull();
+  });
+
+  it("shows how-to-enable on the capability default when ingestion not configured", () => {
+    const p = resolveCoverageProvenance({});
+    expect(p.howToEnable).not.toBeNull();
+  });
+});
+
+describe("resolveCoverageProvenance — freshness / staleness", () => {
+  it("flags stale when measurement predates latest index", () => {
+    const p = resolveCoverageProvenance({
+      line: { source: "lcov", measuredAt: "2026-06-01T00:00:00Z" },
+      latestIndexAt: "2026-06-12T00:00:00Z",
+    });
+    expect(p.freshness?.stale).toBe(true);
+    expect(p.freshness?.measuredAt).toBe("2026-06-01T00:00:00Z");
+  });
+
+  it("is fresh when measurement is at/after latest index", () => {
+    const p = resolveCoverageProvenance({
+      line: { source: "lcov", measuredAt: "2026-06-12T00:00:00Z" },
+      latestIndexAt: "2026-06-01T00:00:00Z",
+    });
+    expect(p.freshness?.stale).toBe(false);
+  });
+
+  it("does not judge staleness without a latest-index timestamp", () => {
+    const p = resolveCoverageProvenance({
+      line: { source: "lcov", measuredAt: "2026-06-12T00:00:00Z" },
+    });
+    expect(p.freshness?.stale).toBe(false);
+  });
+
+  it("does not judge staleness on malformed timestamps", () => {
+    const p = resolveCoverageProvenance({
+      line: { source: "lcov", measuredAt: "not-a-date" },
+      latestIndexAt: "also-not-a-date",
+    });
+    expect(p.freshness?.stale).toBe(false);
+  });
+});
+
+describe("self-documenting definitions", () => {
+  it("defines all three coverage concepts", () => {
+    const kinds = COVERAGE_DEFINITIONS.map((d) => d.kind);
+    expect(kinds).toEqual(["line", "reachability", "capability"]);
+    for (const d of COVERAGE_DEFINITIONS) {
+      expect(d.title.length).toBeGreaterThan(0);
+      expect(d.body.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/webui-v2/src/lib/coverage-provenance.ts
+++ b/webui-v2/src/lib/coverage-provenance.ts
@@ -1,0 +1,239 @@
+/**
+ * coverage-provenance — pure provenance/branch logic for the dashboard
+ * coverage-provenance banner (#5038).
+ *
+ * archigraph surfaces THREE distinct things all colloquially called
+ * "coverage", and a bare "%" reads as authoritative when it may be any of
+ * them, stale, or absent. This module turns the raw availability state for a
+ * given view into a single, unambiguous provenance descriptor that the
+ * {@link CoverageProvenanceBanner} renders. It is intentionally DOM-free and
+ * side-effect-free so the branch selection is unit-testable under the default
+ * (node) vitest environment — the component is a thin renderer over the
+ * descriptor this returns.
+ *
+ * The three concepts (kept verbatim in {@link COVERAGE_DEFINITIONS} for the
+ * self-documenting tooltip):
+ *
+ *   1. CAPABILITY coverage (registry.json) — what archigraph's EXTRACTOR
+ *      supports per language/framework. NOT test execution.
+ *   2. LINE coverage (dynamic, #5036) — real %, present ONLY if an
+ *      LCOV/Cobertura/JaCoCo report was ingested. Stamps entity props
+ *      `coverage_pct` / `covered_lines` / `total_lines` / `coverage_source` /
+ *      `coverage_measured_at`.
+ *   3. REACHABILITY (static, #5037) — graph-derived `test_reachable` /
+ *      reaching tests, no execution.
+ *
+ * Degradation rule (v1): live wiring of ingested line-coverage into the
+ * dashboard data layer is still pending (#5036 landed the parser/attribution,
+ * not the dashboard hook), so most callers will only have reachability or
+ * nothing. We pick the BEST available source and NEVER present a misleading
+ * authoritative "%". When nothing is wired, we fall back to the
+ * capability-coverage explanation as the safe default.
+ */
+
+/** Which of the three coverage concepts a rendered number actually is. */
+export type CoverageProvenanceKind = "line" | "reachability" | "capability";
+
+/** Coverage-report format archigraph can ingest (mirrors sonar.*.reportPaths). */
+export type CoverageReportFormat = "lcov" | "cobertura" | "jacoco";
+
+/**
+ * Raw availability state for the CURRENT view, assembled by the caller from
+ * whatever the data layer exposes. Every field is optional precisely because
+ * v1 lives in a half-wired world — the logic below copes with any subset.
+ */
+export interface CoverageSourceState {
+  /**
+   * Line coverage ingested from a report for this group/view (#5036). Present
+   * only when the dashboard data layer actually carries the stamped
+   * `coverage_source` props. Absent (the common v1 case) ⇒ no report ingested.
+   */
+  line?: {
+    /** `coverage_source` prop, e.g. "lcov". */
+    source: string;
+    /** `coverage_measured_at` — ISO-8601 string, if the backend stamped it. */
+    measuredAt?: string;
+    /** Optional already-computed percentage for display context. */
+    pct?: number;
+    coveredLines?: number;
+    totalLines?: number;
+  };
+  /**
+   * Static test-reachability is available for this view (#5037) — graph-derived
+   * tested/untested with no execution. This is what `coverage_pct` on the
+   * existing /quality/coverage endpoint actually is today.
+   */
+  reachabilityAvailable?: boolean;
+  /**
+   * Whether report ingestion is CONFIGURED/available for this group (a
+   * coverage `format` + `report_paths` is set). Drives the "how to enable"
+   * affordance: if ingestion is not configured we tell the user how to turn
+   * it on.
+   */
+  reportIngestionConfigured?: boolean;
+  /**
+   * Latest index timestamp (ISO-8601) for the group, used only to flag a line
+   * coverage measurement as STALE when it predates the most recent index.
+   * Omitted ⇒ no staleness judgement is made (rendered without a stale badge).
+   */
+  latestIndexAt?: string;
+}
+
+/** The freshness verdict for an ingested line-coverage measurement. */
+export interface CoverageFreshness {
+  /** ISO-8601 measurement time, echoed for display. */
+  measuredAt?: string;
+  /** True when the measurement predates the latest index (so it may be stale). */
+  stale: boolean;
+}
+
+/**
+ * Fully-resolved, render-ready provenance descriptor. The banner component is
+ * a pure function of this — no further branching lives in the component.
+ */
+export interface CoverageProvenance {
+  kind: CoverageProvenanceKind;
+  /** Visual tone the banner should use (maps to existing Badge tones). */
+  tone: "success" | "info" | "neutral";
+  /** Short headline, e.g. "Line coverage" / "Static test-reachability". */
+  label: string;
+  /** One-line statement of source + method. The load-bearing message. */
+  method: string;
+  /**
+   * "How to enable" line — present ONLY when ingestion is not configured and
+   * could meaningfully upgrade what's shown (i.e. we're degraded below line
+   * coverage). Null when ingestion is already configured/active.
+   */
+  howToEnable: string | null;
+  /** What this number means for AI agents querying via MCP. */
+  agentMeaning: string;
+  /** Freshness verdict — present only for ingested line coverage. */
+  freshness: CoverageFreshness | null;
+}
+
+/** The MCP tool agents use to query coverage provenance. */
+export const COVERAGE_MCP_TOOL = "archigraph_coverage";
+
+/**
+ * Self-documenting definitions of all three coverage concepts — rendered
+ * verbatim in the banner's expandable/tooltip so the surface explains itself.
+ */
+export const COVERAGE_DEFINITIONS: ReadonlyArray<{
+  kind: CoverageProvenanceKind;
+  title: string;
+  body: string;
+}> = [
+  {
+    kind: "line",
+    title: "Line coverage (dynamic)",
+    body:
+      "A real, executed percentage — % of source lines a test suite actually ran. " +
+      "Present only when a coverage report (LCOV / Cobertura / JaCoCo) was ingested. " +
+      "archigraph reads the report (SonarQube model); it never runs your tests.",
+  },
+  {
+    kind: "reachability",
+    title: "Static test-reachability",
+    body:
+      "Graph-derived: % of production entities a test can structurally reach " +
+      "(a test CALLS the handler), with no execution. Available without any " +
+      "coverage report. Tells you what is wired to a test, not what a test ran.",
+  },
+  {
+    kind: "capability",
+    title: "Capability coverage",
+    body:
+      "What archigraph's EXTRACTOR supports for a language/framework " +
+      "(from registry.json). This is NOT test coverage and NOT test execution — " +
+      "it describes how completely archigraph can model your code.",
+  },
+];
+
+const AGENT_MEANING: Record<CoverageProvenanceKind, string> = {
+  line:
+    `Agents query this via ${COVERAGE_MCP_TOOL}; entities carry ingested ` +
+    "covered_lines/total_lines, so an agent can target the least-covered code first.",
+  reachability:
+    `Agents query this via ${COVERAGE_MCP_TOOL}; uncovered endpoints (no TESTS edge) ` +
+    "are flagged in parity checks so an agent knows what to test next.",
+  capability:
+    `Agents read this from the capability registry, not ${COVERAGE_MCP_TOOL}; it tells ` +
+    "them how much of the code archigraph can model, not what tests cover.",
+};
+
+const HOW_TO_ENABLE =
+  "Enable real line coverage: point archigraph at your lcov/cobertura/jacoco " +
+  "report path (coverage.report_paths, mirroring sonar.*.reportPaths), then re-index.";
+
+/** Format the measured-at line, defensively (the input may be malformed). */
+function parseTime(iso: string | undefined): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Resolve the raw availability state into the single provenance descriptor the
+ * banner renders. Pure; the whole degradation policy lives here.
+ *
+ * Precedence (best available wins, never a misleading authoritative %):
+ *   1. Ingested LINE coverage if present (real, dynamic).
+ *   2. Else static REACHABILITY if available (graph-derived).
+ *   3. Else CAPABILITY coverage (the safe default when nothing is wired).
+ */
+export function resolveCoverageProvenance(
+  state: CoverageSourceState | null | undefined,
+): CoverageProvenance {
+  const s = state ?? {};
+
+  // 1. Real ingested line coverage — the only authoritative "%".
+  if (s.line && s.line.source) {
+    const measuredAt = s.line.measuredAt;
+    const measuredT = parseTime(measuredAt);
+    const indexT = parseTime(s.latestIndexAt);
+    const stale = measuredT != null && indexT != null ? measuredT < indexT : false;
+
+    const sourceUpper = s.line.source.toUpperCase();
+    const measuredSuffix = measuredAt ? `, measured ${measuredAt}` : "";
+    return {
+      kind: "line",
+      tone: "success",
+      label: "Line coverage",
+      method: `Line coverage — ingested from ${sourceUpper} (coverage_source: ${s.line.source})${measuredSuffix}.`,
+      // Ingestion is clearly active here, so no "how to enable".
+      howToEnable: null,
+      agentMeaning: AGENT_MEANING.line,
+      freshness: { measuredAt, stale },
+    };
+  }
+
+  // 2. Static reachability fallback — graph-derived, no execution.
+  if (s.reachabilityAvailable) {
+    return {
+      kind: "reachability",
+      tone: "info",
+      label: "Static test-reachability",
+      method:
+        "No coverage report ingested for this group — showing static " +
+        "test-reachability (graph-derived: a test structurally reaches the code, " +
+        "not a measured line %).",
+      // Only offer "how to enable" when ingestion isn't already configured.
+      howToEnable: s.reportIngestionConfigured ? null : HOW_TO_ENABLE,
+      agentMeaning: AGENT_MEANING.reachability,
+      freshness: null,
+    };
+  }
+
+  // 3. Safe default — capability coverage. Nothing test-related is wired.
+  return {
+    kind: "capability",
+    tone: "neutral",
+    label: "Capability coverage",
+    method:
+      "Capability coverage — what archigraph's extractor supports for this " +
+      "language/framework. NOT test execution and NOT test reachability.",
+    howToEnable: s.reportIngestionConfigured ? null : HOW_TO_ENABLE,
+    agentMeaning: AGENT_MEANING.capability,
+    freshness: null,
+  };
+}

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -64,9 +64,11 @@ import {
   TooltipContent,
   TabCount,
   DefTerm,
+  CoverageProvenanceBanner,
   useSetInsight,
 } from "@/components/ui";
 import type { InsightValue } from "@/components/ui";
+import type { CoverageSourceState } from "@/lib/coverage-provenance";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { useSourcePeek } from "@/components/SourcePeek";
@@ -837,8 +839,20 @@ function CoverageTab({ groupId }: { groupId: string }) {
     </div>
   );
 
+  // Coverage provenance (#5038). The dashboard's headline `coverage_pct` is
+  // graph-derived REACH coverage (static test-reachability), not a measured
+  // line %. Ingested line coverage (#5036) and ingestion-config state are not
+  // yet wired into this endpoint, so we report reachability and let the banner
+  // surface the "how to enable" affordance. When the data layer later exposes
+  // stamped line-coverage props + ingestion config, populate `line` /
+  // `reportIngestionConfigured` here and the banner upgrades automatically.
+  const coverageProvenance: CoverageSourceState = {
+    reachabilityAvailable: true,
+  };
+
   return (
     <div className="space-y-4">
+      <CoverageProvenanceBanner state={coverageProvenance} />
       <CoverageGauge
         covered={data.covered_production}
         total={data.total_production}


### PR DESCRIPTION
## What this builds (v1)
A reusable **CoverageProvenanceBanner** so that whenever the dashboard shows a coverage number, a banner states HOW it was measured, whether report ingestion is available, and what it means for agents/MCP. Disambiguates the three concepts users conflate:

1. **Capability coverage** (registry.json) — what the extractor supports. NOT test execution.
2. **Line coverage** (dynamic, #5036) — real %, only if an LCOV/Cobertura/JaCoCo report was ingested (`coverage_source`/`covered_lines`/`total_lines`/`coverage_measured_at`).
3. **Static test-reachability** (#5037) — graph-derived, no execution.

### Pieces
- `webui-v2/src/lib/coverage-provenance.ts` — pure, DOM-free `resolveCoverageProvenance()`: all branch selection + degradation policy lives here (so it's unit-testable under the default node vitest env, matching the `src/lib` test convention).
- `webui-v2/src/components/ui/coverage-provenance-banner.tsx` — thin renderer: source+method line, agent/MCP meaning (`archigraph_coverage`), "how to enable" affordance, stale badge, measured-at, and a self-documenting expandable defining all three coverage types. Exported from the `ui` barrel.
- `webui-v2/src/lib/coverage-provenance.test.ts` — 13 vitest branch-logic tests.

### Where it's placed
**Quality → Coverage tab**, above the coverage gauge (`CoverageTab` in `src/routes/quality.tsx`). That tab's headline `coverage_pct` is graph-derived **reach** coverage.

### Degradation logic
Precedence **line ▸ reachability ▸ capability**, picking the best available source and **never** rendering a misleading authoritative `%`:
- Ingested line coverage present ⇒ authoritative `%`, measured-at, stale check, no nag.
- Else reachability available ⇒ "no report ingested — showing static test-reachability" + how-to-enable (unless ingestion already configured).
- Else (nothing wired) ⇒ **capability-coverage** explanation (the safe default).

Since #5036's stamped line-coverage props and ingestion-config state are not yet exposed on the `/quality/coverage` endpoint, the wired CoverageTab state is `reachabilityAvailable: true` — the banner degrades cleanly and shows the how-to-enable line. When the data layer later exposes those props, populate `line`/`reportIngestionConfigured` at the call site and the banner upgrades automatically.

### Tests / gates
- `npm ci` ✅, `npm run build` ✅ (pre-existing chunk-size warning only), `npm run lint` (tsc --noEmit) ✅, `npm test` ✅ (115 lib tests incl. the 13 new).

### Deferred (follow-ups to file)
- Wiring real ingested line coverage into the dashboard data layer (depends on the #5036 live indexer hook).
- Coverage overlay/column on diagrams.
- MCP-surfaced freshness.

Did NOT run the embed / `make dashboard-build` (deploy-window only).

Refs #5038