### PR TITLE
feat(#5008): rust — connection pools + async-nats message_broker

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 56 records · **C/C++**: 3 · **C#**: 5 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 2
+**Total**: 57 records · **C/C++**: 3 · **C#**: 5 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -67,6 +67,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [python](../by-language/python.md) | [Django signals (intra-repo pub/sub)](../detail/msg.django-signals.md) | ✅ | ✅ | ✅ | ✅ | |
 | [python](../by-language/python.md) | [ORM model lifecycle-hook → handler TRIGGERS (Django signals, SQLAlchemy events)](../detail/msg.orm-lifecycle-hooks-py.md) | ✅ | ✅ | ✅ | ✅ | |
 | [ruby](../by-language/ruby.md) | [ORM model lifecycle-hook → handler TRIGGERS (ActiveRecord callbacks)](../detail/msg.orm-lifecycle-hooks-ruby.md) | ✅ | ✅ | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [async-nats (NATS)](../detail/lang.rust.framework.async-nats.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [rust](../by-language/rust.md) | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [rust](../by-language/rust.md) | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # rust
 
-**Frameworks**: 15 · **Tools**: 6 · **ORMs**: 15 · **Other**: 3
+**Frameworks**: 15 · **Tools**: 6 · **ORMs**: 15 · **Other**: 4
 
 Back to [summary](../summary.md).
 
@@ -91,6 +91,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
 |---|---|---|---|---|
+| [async-nats (NATS)](../detail/lang.rust.framework.async-nats.md) | 🟢 | 🟢 | 🟢 | |
 | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | 🟢 | |
 | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | 🟢 | |
 

--- a/docs/coverage/detail/lang.rust.framework.async-nats.md
+++ b/docs/coverage/detail/lang.rust.framework.async-nats.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.async-nats` — async-nats (NATS)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | 🟢 `partial` | `2026-06-12` | 5008 | `internal/engine/nats_edges.go`<br>`internal/engine/nats_edges_test.go` | async-nats client.subscribe("subject").await and client.queue_subscribe("subject","queue").await -> SUBSCRIBES_TO (queue group recorded as edge/entity prop); jetstream subscribes flagged jetstream=true. SCOPE.Queue keyed nats:<subject> joins cross-repo, attributed to the enclosing fn. Partial: literal string subjects only; caller attribution is same-file nearest-fn. |
+| Producer extraction | 🟢 `partial` | `2026-06-12` | 5008 | `internal/engine/nats_edges.go`<br>`internal/engine/nats_edges_test.go` | async-nats client.publish("subject",payload).await and client.request("subject",...).await (request_reply) -> PUBLISHES_TO; jetstream.publish("subject",...) flagged jetstream=true. SCOPE.Queue keyed nats:<subject> joins cross-repo via the import-channel linker, attributed to the enclosing fn. Partial: only literal string subjects are resolved (impl ToSubject variables / format!() are skipped); caller attribution is same-file nearest-fn. |
+| Topic attribution | 🟢 `partial` | `2026-06-12` | 5008 | `internal/engine/nats_edges.go`<br>`internal/engine/nats_edges_test.go` | Subjects keyed nats:<subject> as SCOPE.Queue entities matched across producer/consumer and across repos by shared synthetic ID. Wildcard subjects (orders.*, inventory.>) preserved as-is. Partial: only literal subjects are attributed; dynamic subjects are skipped. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.async-nats ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 168 · **Tools**: 120 · **Other**: 198
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 168 · **Tools**: 120 · **Other**: 199
 
 ## Coverage by language
 
@@ -15,7 +15,7 @@
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
 | [C#](by-language/csharp.md) | 17 | 7 | 14 | 5 |
 | [php](by-language/php.md) | 16 | 6 | 14 | 1 |
-| [rust](by-language/rust.md) | 15 | 6 | 15 | 3 |
+| [rust](by-language/rust.md) | 15 | 6 | 15 | 4 |
 | [elixir](by-language/elixir.md) | 14 | 9 | 10 | 5 |
 | [scala](by-language/scala.md) | 14 | 3 | 7 | 1 |
 | [ruby](by-language/ruby.md) | 9 | 6 | 14 | 8 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 246 frameworks · 120 tools · 168 ORMs · 198 other
+Total: 246 frameworks · 120 tools · 168 ORMs · 199 other

--- a/internal/engine/nats_edges.go
+++ b/internal/engine/nats_edges.go
@@ -18,6 +18,11 @@
 //   - Java: connection.publish(subject, data),
 //     subscription = connection.subscribe(subject),
 //     dispatcher.subscribe(subject, handler)
+//   - Rust async-nats: client.publish("subject", payload).await,
+//     client.subscribe("subject").await,
+//     client.queue_subscribe("subject", "queue").await,
+//     client.request("subject", payload).await,
+//     jetstream.publish("subject", payload).await
 //   - NATS JetStream: js.publish(subject, ...), js.subscribe(subject, ...)
 //     — emits jetstream=true property
 //   - NATS Streaming (STAN, deprecated): stan.Publish / stan.QueueSubscribe
@@ -46,7 +51,7 @@ import (
 // synthetics for `lang`.
 func natsSynthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "java", "kotlin", "javascript", "typescript", "python", "go":
+	case "java", "kotlin", "javascript", "typescript", "python", "go", "rust":
 		return true
 	default:
 		return false
@@ -139,6 +144,8 @@ func applyNATSEdges(args DetectorPassArgs) DetectorPassResult {
 		synthesizeJavaNATS(src, emitSubject, emitEdge)
 	case "go":
 		synthesizeGoNATS(src, emitSubject, emitEdge)
+	case "rust":
+		synthesizeRustNATS(src, emitSubject, emitEdge)
 	}
 
 	return DetectorPassResult{Entities: entities, Relationships: relationships}
@@ -774,5 +781,162 @@ func synthesizeJavaNATS(
 			"messaging_layer": "nats-jetstream-java",
 			"jetstream":       "true",
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rust — async-nats
+// ---------------------------------------------------------------------------
+//
+// async-nats core API (the `client` may be any variable name, so we anchor on
+// the method name rather than the receiver):
+//   - client.publish("subject", payload).await
+//   - client.subscribe("subject").await
+//   - client.queue_subscribe("subject", "queue").await
+//   - client.request("subject", payload).await       (request/reply)
+//   - jetstream.publish("subject", payload).await     (JetStream context)
+//
+// HONEST PARTIAL: only literal string subjects are resolved. async-nats
+// accepts `impl ToSubject` (String, &str, Subject), so non-literal subjects
+// (variables, format!()) are skipped — same literal-only stance as the
+// rdkafka/lapin Rust passes. Caller attribution is same-file nearest-fn via
+// findEnclosingRustFnName.
+
+// rustNATSPublishRe captures `.publish("subject", ...)`.
+// Group 1 = subject.
+var rustNATSPublishRe = regexp.MustCompile(`\.publish\s*\(\s*"([^"\n\r]+)"`)
+
+// rustNATSSubscribeRe captures `.subscribe("subject")`.
+// Group 1 = subject.
+var rustNATSSubscribeRe = regexp.MustCompile(`\.subscribe\s*\(\s*"([^"\n\r]+)"`)
+
+// rustNATSQueueSubscribeRe captures `.queue_subscribe("subject", "queue")`.
+// Groups: 1=subject, 2=queue-group.
+var rustNATSQueueSubscribeRe = regexp.MustCompile(`\.queue_subscribe\s*\(\s*"([^"\n\r]+)"\s*,\s*"([^"\n\r]+)"`)
+
+// rustNATSRequestRe captures `.request("subject", ...)` — request/reply.
+// Group 1 = subject.
+var rustNATSRequestRe = regexp.MustCompile(`\.request\s*\(\s*"([^"\n\r]+)"`)
+
+// rustNATSJetStreamRe detects whether a JetStream context is in play in this
+// file, so we can flag publishes/subscribes accordingly.
+var rustNATSJetStreamRe = regexp.MustCompile(`jetstream`)
+
+func synthesizeRustNATS(
+	src string,
+	emitSubject func(subjectID, subject string, props map[string]string),
+	emitEdge func(callerKind, callerName, subjectID, edgeKind string, props map[string]string),
+) {
+	// Require an async-nats signal to avoid colliding with other libraries
+	// that expose .publish/.subscribe (e.g. redis pubsub). async-nats is
+	// imported as `async_nats` / `async-nats` (crate) and types live under it.
+	hasNATS := strings.Contains(src, "async_nats") || strings.Contains(src, "async-nats") ||
+		strings.Contains(src, "nats::") || strings.Contains(src, "Subject")
+	if !hasNATS {
+		return
+	}
+
+	jetstream := rustNATSJetStreamRe.MatchString(src)
+
+	enclosing := func(offset int) string {
+		return findEnclosingRustFnName(src, offset)
+	}
+
+	layer := "async-nats"
+	if jetstream {
+		layer = "nats-jetstream-rust"
+	}
+
+	// queue_subscribe must run before the generic subscribe pass so its
+	// offset can be skipped (queue_subscribe also matches .subscribe(...)
+	// loosely? No — distinct method name, but the trailing `subscribe`
+	// substring of `queue_subscribe` is NOT matched by rustNATSSubscribeRe
+	// because that regex anchors on `.subscribe(` with a leading dot, and
+	// `.queue_subscribe(` has no `.subscribe(` boundary. Still, run it first
+	// for clarity and to emit the queue_group property).
+	for _, m := range rustNATSQueueSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		queueGroup := src[m[4]:m[5]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		props := map[string]string{"queue_group": queueGroup}
+		if jetstream {
+			props["jetstream"] = "true"
+		}
+		emitSubject(subID, subject, props)
+		caller := enclosing(m[0])
+		edgeProps := map[string]string{
+			"messaging_layer": layer,
+			"queue_group":     queueGroup,
+		}
+		if jetstream {
+			edgeProps["jetstream"] = "true"
+		}
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, edgeProps)
+	}
+
+	// .publish("subject", ...)
+	for _, m := range rustNATSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		props := map[string]string{}
+		if jetstream {
+			props["jetstream"] = "true"
+		}
+		emitSubject(subID, subject, props)
+		caller := enclosing(m[0])
+		edgeProps := map[string]string{"messaging_layer": layer}
+		if jetstream {
+			edgeProps["jetstream"] = "true"
+		}
+		emitEdge("Function", caller, subID, publishesToEdgeKind, edgeProps)
+	}
+
+	// .subscribe("subject")
+	for _, m := range rustNATSSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		props := map[string]string{}
+		if jetstream {
+			props["jetstream"] = "true"
+		}
+		emitSubject(subID, subject, props)
+		caller := enclosing(m[0])
+		edgeProps := map[string]string{"messaging_layer": layer}
+		if jetstream {
+			edgeProps["jetstream"] = "true"
+		}
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, edgeProps)
+	}
+
+	// .request("subject", ...) — request/reply
+	for _, m := range rustNATSRequestRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		props := map[string]string{"pattern": "request_reply"}
+		if jetstream {
+			props["jetstream"] = "true"
+		}
+		emitSubject(subID, subject, props)
+		caller := enclosing(m[0])
+		edgeProps := map[string]string{
+			"messaging_layer": layer,
+			"pattern":         "request_reply",
+		}
+		if jetstream {
+			edgeProps["jetstream"] = "true"
+		}
+		emitEdge("Function", caller, subID, publishesToEdgeKind, edgeProps)
 	}
 }

--- a/internal/engine/nats_edges_test.go
+++ b/internal/engine/nats_edges_test.go
@@ -561,3 +561,157 @@ func main() {
 		t.Fatalf("no nats signal: expected empty, got ents=%v rels=%v", ents, rels)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Rust — async-nats
+// ---------------------------------------------------------------------------
+
+// TestNATS_Rust_Publish covers async-nats client.publish("subject", payload).await.
+func TestNATS_Rust_Publish(t *testing.T) {
+	src := `use async_nats;
+
+async fn publish_order(client: &async_nats::Client, data: Vec<u8>) -> Result<(), async_nats::Error> {
+    client.publish("orders.created", data.into()).await?;
+    Ok(())
+}
+`
+	ents, rels := runNATSDetect(t, "rust", "orders.rs", src)
+	subID := natsSubjectID("orders.created")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.created, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	if !strings.Contains(pubs[0].to, subID) {
+		t.Fatalf("PUBLISHES_TO ToID = %q, want to contain %q", pubs[0].to, subID)
+	}
+	if pubs[0].props["broker"] != "nats" {
+		t.Fatalf("broker = %q, want nats", pubs[0].props["broker"])
+	}
+	if pubs[0].props["messaging_layer"] != "async-nats" {
+		t.Fatalf("messaging_layer = %q, want async-nats", pubs[0].props["messaging_layer"])
+	}
+	if !strings.Contains(pubs[0].from, "publish_order") {
+		t.Fatalf("caller = %q, want to contain publish_order", pubs[0].from)
+	}
+}
+
+// TestNATS_Rust_Subscribe covers async-nats client.subscribe("subject").await.
+func TestNATS_Rust_Subscribe(t *testing.T) {
+	src := `use async_nats;
+
+async fn start_consumer(client: &async_nats::Client) -> Result<(), async_nats::Error> {
+    let mut subscriber = client.subscribe("orders.created").await?;
+    while let Some(message) = subscriber.next().await {
+        handle(message);
+    }
+    Ok(())
+}
+`
+	ents, rels := runNATSDetect(t, "rust", "consumer.rs", src)
+	subID := natsSubjectID("orders.created")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.created, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+	if subs[0].props["messaging_layer"] != "async-nats" {
+		t.Fatalf("messaging_layer = %q, want async-nats", subs[0].props["messaging_layer"])
+	}
+}
+
+// TestNATS_Rust_QueueSubscribe covers client.queue_subscribe("subject", "queue").await.
+func TestNATS_Rust_QueueSubscribe(t *testing.T) {
+	src := `use async_nats;
+
+async fn start_worker(client: &async_nats::Client) -> Result<(), async_nats::Error> {
+    let mut sub = client.queue_subscribe("jobs.process", "worker-pool").await?;
+    while let Some(msg) = sub.next().await {
+        handle_job(msg);
+    }
+    Ok(())
+}
+`
+	ents, rels := runNATSDetect(t, "rust", "worker.rs", src)
+	subID := natsSubjectID("jobs.process")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for jobs.process, ents=%v", ents)
+	}
+	if q.props["queue_group"] != "worker-pool" {
+		t.Fatalf("queue_group = %q, want worker-pool", q.props["queue_group"])
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+	if subs[0].props["queue_group"] != "worker-pool" {
+		t.Fatalf("edge queue_group = %q, want worker-pool", subs[0].props["queue_group"])
+	}
+}
+
+// TestNATS_Rust_Request covers client.request("subject", payload).await (request/reply).
+func TestNATS_Rust_Request(t *testing.T) {
+	src := `use async_nats;
+
+async fn ask(client: &async_nats::Client) -> Result<(), async_nats::Error> {
+    let response = client.request("rpc.echo", "ping".into()).await?;
+    Ok(())
+}
+`
+	_, rels := runNATSDetect(t, "rust", "rpc.rs", src)
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge for request, rels=%v", rels)
+	}
+	if pubs[0].props["pattern"] != "request_reply" {
+		t.Fatalf("pattern = %q, want request_reply", pubs[0].props["pattern"])
+	}
+}
+
+// TestNATS_Rust_JetStream covers a JetStream context flagging jetstream=true.
+func TestNATS_Rust_JetStream(t *testing.T) {
+	src := `use async_nats::jetstream;
+
+async fn publish_event(jetstream: jetstream::Context, data: Vec<u8>) -> Result<(), async_nats::Error> {
+    jetstream.publish("events.stream", data.into()).await?;
+    Ok(())
+}
+`
+	ents, rels := runNATSDetect(t, "rust", "stream.rs", src)
+	subID := natsSubjectID("events.stream")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for events.stream, ents=%v", ents)
+	}
+	if q.props["jetstream"] != "true" {
+		t.Fatalf("jetstream prop = %q, want true", q.props["jetstream"])
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	if pubs[0].props["jetstream"] != "true" {
+		t.Fatalf("edge jetstream = %q, want true", pubs[0].props["jetstream"])
+	}
+	if pubs[0].props["messaging_layer"] != "nats-jetstream-rust" {
+		t.Fatalf("messaging_layer = %q, want nats-jetstream-rust", pubs[0].props["messaging_layer"])
+	}
+}
+
+// TestNATS_Rust_NoSignal verifies a Rust file without async-nats markers is ignored.
+func TestNATS_Rust_NoSignal(t *testing.T) {
+	src := `fn main() {
+    let client = redis::Client::open("redis://localhost").unwrap();
+    client.publish("some.channel", "hi");
+}
+`
+	ents, rels := runNATSDetect(t, "rust", "noise.rs", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("no async-nats signal: expected empty, got ents=%v rels=%v", ents, rels)
+	}
+}


### PR DESCRIPTION
## Built (fixture-proven)
**async-nats** Rust message_broker support, extending the existing cross-repo NATS pass (`internal/engine/nats_edges.go`) — Rust is now the 7th language on that pass (alongside Go/Node/TS/Python/Java/Kotlin).

| Call | Edge | Notes |
|---|---|---|
| `client.publish("subj", payload).await` | `PUBLISHES_TO` | messaging_layer=async-nats |
| `client.subscribe("subj").await` | `SUBSCRIBES_TO` | |
| `client.queue_subscribe("subj","q").await` | `SUBSCRIBES_TO` | queue_group prop |
| `client.request("subj", ...).await` | `PUBLISHES_TO` | pattern=request_reply |
| `jetstream.publish(...)` (jetstream context) | `PUBLISHES_TO` | jetstream=true, messaging_layer=nats-jetstream-rust |

- Reuses `SCOPE.Queue` (`queueEntityKind`) keyed `nats:<subject>` — producer/consumer join cross-repo via the existing import-channel linker. **No new entity Kind / edge kind** (no `internal/types` change needed).
- Caller attribution via existing `findEnclosingRustFnName` (same-file nearest-fn).
- Guarded on an async-nats signal (`async_nats` / `nats::` / `Subject`) so it does not collide with redis-pubsub `.publish`/`.subscribe`.
- **Honest partial**: only literal string subjects resolved (`impl ToSubject` variables / `format!()` skipped) — same literal-only stance as the rdkafka/lapin Rust passes.

### Registry / coverage docs (regenerated, committed)
- Added `lang.rust.framework.async-nats` (producer/consumer/topic_attribution = `partial`, cites nats_edges.go).
- Ran `coverage fmt` + `coverage gen`; committed regenerated `docs/coverage/registry.json`, `summary.md`, `by-language/rust.md`, `by-category/message_broker.md`, and new `detail/lang.rust.framework.async-nats.md`.

### Fixtures
6 new tests in `nats_edges_test.go`: publish, subscribe, queue_subscribe (queue group), request (request_reply), jetstream (jetstream=true + nats-jetstream-rust layer), no-signal guard. All pass.

## Deferred (filed as remaining #5008 scope — split further on pickup)
- **Connection pools** (deadpool/bb8/r2d2/mobc) — db_effect pool→underlying-DB attribution. Substrate/effect work, separate pass.
- **ntex** routing extractor (mirror actix_web.go).
- **Loco.rs** + **Shuttle** framework records.
- Rust test libs: mockito / wiremock / rstest / serial_test / insta.

These remain tracked under #5008 / its parent #4964.

## Gates (all green, sandbox HOME=/tmp/agsbx-5008)
- `go build ./...` ✅
- `go vet ./internal/engine/` ✅
- `go test ./internal/engine/` (full suite) ✅
- `go test ./internal/custom/rust/... ./internal/extractors/rust/... ./internal/types/` ✅
- `coverage fmt --check` ✅ canonical
- `coverage validate` ✅ exit 0 (pre-existing unrelated warnings only)

Deploy-deferred.

Refs #5008