### PR TITLE
feat(#5016): csharp — Redis pub/sub message_broker view (StackExchange.Redis ISubscriber)

### DIFF
--- a/docs/coverage/detail/msg.broker.redis.md
+++ b/docs/coverage/detail/msg.broker.redis.md
@@ -12,9 +12,9 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Consumer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/redis_pubsub_edges.go` | — |
-| Producer extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/redis_pubsub_edges.go` | — |
-| Topic attribution | ✅ `full` | `2026-05-28` | — | `internal/engine/redis_pubsub_edges.go` | — |
+| Consumer extraction | ✅ `full` | `2026-06-12` | 5016 | `internal/engine/redis_pubsub_edges.go`<br>`internal/engine/redis_pubsub_edges_test.go` | #5016: C# (StackExchange.Redis ISubscriber) added via synthesizeCSharpRedisPubSub — .Subscribe/.SubscribeAsync("chan" | RedisChannel.Literal/Pattern(...)) -> SUBSCRIBES_TO the canonical channel:redis-pubsub:<name> SCOPE.Queue, so a C# subscriber pairs cross-repo with publishers in any covered language. Wildcard (RedisChannel.Pattern / `*`) flagged is_pattern. Languages: python, js/ts, go, ruby, java/kotlin (Spring), elixir (Redix), csharp. |
+| Producer extraction | ✅ `full` | `2026-06-12` | 5016 | `internal/engine/redis_pubsub_edges.go`<br>`internal/engine/redis_pubsub_edges_test.go` | #5016: C# (StackExchange.Redis ISubscriber) added via synthesizeCSharpRedisPubSub — .Publish/.PublishAsync("chan" | RedisChannel.Literal(...)) -> PUBLISHES_TO the canonical channel:redis-pubsub:<name> SCOPE.Queue from the enclosing class/method. Honest-partial: dynamic/interpolated channels honest-skipped. Languages: python, js/ts, go, ruby, java/kotlin, elixir, csharp. |
+| Topic attribution | ✅ `full` | `2026-06-12` | 5016 | `internal/engine/redis_pubsub_edges.go`<br>`internal/engine/redis_pubsub_edges_test.go` | #5016: C# pub/sub channels mint the SAME channel:redis-pubsub:<name> SCOPE.Queue node as every other language, so topic_pass.go joins C# producers/consumers to cross-language counterparts (broker=redis). |
 
 ## Provenance
 

--- a/internal/engine/redis_pubsub_edges.go
+++ b/internal/engine/redis_pubsub_edges.go
@@ -82,7 +82,7 @@ const redisPubSubChannelEntityKind = "SCOPE.Queue"
 // can emit synthetics for `lang`.
 func redisPubSubSynthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "python", "javascript", "typescript", "go", "ruby", "java", "kotlin", "elixir":
+	case "python", "javascript", "typescript", "go", "ruby", "java", "kotlin", "elixir", "csharp":
 		return true
 	default:
 		return false
@@ -213,6 +213,8 @@ func applyRedisPubSubEdges(args DetectorPassArgs) DetectorPassResult {
 		synthesizeSpringRedisPubSub(src, emitChannel, emitEdge)
 	case "elixir":
 		synthesizeElixirRedisPubSub(src, emitChannel, emitEdge)
+	case "csharp":
+		synthesizeCSharpRedisPubSub(src, emitChannel, emitEdge)
 	}
 
 	return DetectorPassResult{Entities: entities, Relationships: relationships}
@@ -959,5 +961,100 @@ func synthesizeElixirRedisPubSub(
 			"messaging_layer": "redix",
 			"channel_type":    "pubsub",
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C# — StackExchange.Redis ISubscriber (#5016)
+// ---------------------------------------------------------------------------
+//
+// StackExchange.Redis exposes pub/sub through the multiplexer's ISubscriber.
+// Before #5016 the C# Redis extractor (internal/custom/csharp/redis.go)
+// recorded Publish/Subscribe only as a per-file ORM keyspace access
+// (SCOPE.Datastore + PUBLISHES_TO/SUBSCRIBES_TO to a Datastore node) — useful
+// for data-access topology but invisible to the cross-repo message_broker
+// view. This synthesizer adds the broker view: it emits the SAME canonical
+// `channel:redis-pubsub:<name>` SCOPE.Queue entity the other languages use, so
+// a C# publisher and a (e.g. Node/Python/Kotlin) subscriber on the same
+// channel pair up cross-repo via the import-channel linker (P7) — no new
+// matching code.
+//
+// Producer:  sub.Publish("events", payload)
+//            sub.PublishAsync("events", payload)
+//            sub.Publish(RedisChannel.Literal("events"), payload)
+//            sub.Publish(new RedisChannel("events", RedisChannel.PatternMode.Literal), p)
+// Consumer:  sub.Subscribe("events", handler)
+//            sub.SubscribeAsync("events", handler)
+//            sub.Subscribe(RedisChannel.Pattern("orders.*"), handler)  // wildcard
+//
+// The first argument is the RedisChannel. We capture the first string literal
+// after the verb (covering both a bare "events" and the literal nested inside
+// RedisChannel.Literal(...) / RedisChannel.Pattern(...) / new RedisChannel(...)).
+// Pattern subscriptions are flagged via a trailing/embedded `*` wildcard or an
+// explicit RedisChannel.Pattern(...) / PatternMode.Pattern marker.
+
+// csRedisPubSubRe captures the StackExchange.Redis ISubscriber verb plus the
+// first string literal argument. Group 1 = verb (Publish/PublishAsync/
+// Subscribe/SubscribeAsync), group 2 = the channel literal. The optional
+// `RedisChannel.Literal(` / `RedisChannel.Pattern(` / `new RedisChannel(`
+// wrapper before the literal is matched non-capturing so both bare and
+// wrapped channel forms resolve to the same name.
+var csRedisPubSubRe = regexp.MustCompile(
+	`\.(Publish|PublishAsync|Subscribe|SubscribeAsync)\s*\(\s*(?:(?:new\s+)?RedisChannel\s*(?:\.\s*(?:Literal|Pattern))?\s*\(\s*)?"([^"\n\r]+)"`,
+)
+
+func synthesizeCSharpRedisPubSub(
+	src string,
+	emitChannel func(channelID, channelName, channelType string, isWildcard bool, props map[string]string),
+	emitEdge func(callerKind, callerName, channelID, edgeKind string, props map[string]string),
+) {
+	// Guard: must reference StackExchange.Redis ISubscriber pub/sub tokens.
+	if !strings.Contains(src, ".Publish") && !strings.Contains(src, ".Subscribe") {
+		return
+	}
+
+	// Enclosing class name for a stable per-file caller entity.
+	className := ""
+	if m := classNameRe.FindStringSubmatch(src); len(m) >= 2 {
+		className = m[1]
+	}
+
+	for _, m := range csRedisPubSubRe.FindAllStringSubmatchIndex(src, -1) {
+		verb := src[m[2]:m[3]]
+		ch := src[m[4]:m[5]]
+		if !looksLikeRedisChannel(ch) {
+			continue
+		}
+		isPublish := strings.HasPrefix(verb, "Publish")
+		// A wildcard `*` makes this a pattern subscription (psubscribe-style).
+		// RedisChannel.Pattern(...) also implies a pattern; both surface as a
+		// `*`-bearing literal in practice, so the glob check covers it.
+		isWildcard := strings.Contains(ch, "*")
+
+		caller := className
+		if caller == "" {
+			caller = findFollowingMethod(src, m[0])
+		}
+		if caller == "" {
+			continue
+		}
+
+		id := redisPubSubChannelID(ch)
+		emitChannel(id, ch, "pubsub", isWildcard, map[string]string{
+			"messaging_layer": "stackexchange-redis",
+		})
+
+		edge := subscribesToEdgeKind
+		if isPublish {
+			edge = publishesToEdgeKind
+		}
+		props := map[string]string{
+			"messaging_layer": "stackexchange-redis",
+			"channel_type":    "pubsub",
+		}
+		if isWildcard {
+			props["is_pattern"] = "true"
+		}
+		emitEdge("Service", caller, id, edge, props)
 	}
 }

--- a/internal/engine/redis_pubsub_edges_test.go
+++ b/internal/engine/redis_pubsub_edges_test.go
@@ -870,3 +870,163 @@ end
 		t.Fatalf("expected literal-channel SCOPE.Queue, ents=%v", ents)
 	}
 }
+
+// ============================================================================
+// C# — StackExchange.Redis ISubscriber (#5016)
+// ============================================================================
+
+func TestRedisPubSub_CSharp_Publish(t *testing.T) {
+	src := `using StackExchange.Redis;
+
+public class NotificationPublisher
+{
+    private readonly ISubscriber _sub;
+    public NotificationPublisher(IConnectionMultiplexer mux) => _sub = mux.GetSubscriber();
+
+    public void SendPush(string payload)
+    {
+        _sub.Publish("notifications.push", payload);
+    }
+}
+`
+	ents, rels := runRedisPubSub(t, "csharp", src)
+
+	wantID := "channel:redis-pubsub:notifications.push"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected entity %q; got %v", wantID, ents)
+	}
+	wantRel := "PUBLISHES_TO|Service:NotificationPublisher|SCOPE.Queue:channel:redis-pubsub:notifications.push"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+func TestRedisPubSub_CSharp_PublishAsync(t *testing.T) {
+	src := `using StackExchange.Redis;
+
+public class EventBus
+{
+    private readonly ISubscriber _sub;
+    public async Task Emit(string payload)
+    {
+        await _sub.PublishAsync("orders.created", payload);
+    }
+}
+`
+	ents, rels := runRedisPubSub(t, "csharp", src)
+	wantID := "channel:redis-pubsub:orders.created"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected entity %q; got %v", wantID, ents)
+	}
+	wantRel := "PUBLISHES_TO|Service:EventBus|SCOPE.Queue:channel:redis-pubsub:orders.created"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+func TestRedisPubSub_CSharp_Subscribe(t *testing.T) {
+	src := `using StackExchange.Redis;
+
+public class NotificationListener
+{
+    private readonly ISubscriber _sub;
+    public void Start()
+    {
+        _sub.Subscribe("notifications.push", (channel, message) => Handle(message));
+    }
+    private void Handle(RedisValue m) { }
+}
+`
+	ents, rels := runRedisPubSub(t, "csharp", src)
+	wantID := "channel:redis-pubsub:notifications.push"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected entity %q; got %v", wantID, ents)
+	}
+	wantRel := "SUBSCRIBES_TO|Service:NotificationListener|SCOPE.Queue:channel:redis-pubsub:notifications.push"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+func TestRedisPubSub_CSharp_RedisChannelLiteralWrapper(t *testing.T) {
+	src := `using StackExchange.Redis;
+
+public class TelemetrySink
+{
+    private readonly ISubscriber _sub;
+    public void Push(string p) =>
+        _sub.Publish(RedisChannel.Literal("telemetry.events"), p);
+}
+`
+	ents, rels := runRedisPubSub(t, "csharp", src)
+	wantID := "channel:redis-pubsub:telemetry.events"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected entity %q; got %v", wantID, ents)
+	}
+	wantRel := "PUBLISHES_TO|Service:TelemetrySink|SCOPE.Queue:channel:redis-pubsub:telemetry.events"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+func TestRedisPubSub_CSharp_PatternSubscribeWildcard(t *testing.T) {
+	src := `using StackExchange.Redis;
+
+public class OrderWatcher
+{
+    private readonly ISubscriber _sub;
+    public void Watch() =>
+        _sub.Subscribe(RedisChannel.Pattern("orders.*"), (c, m) => {});
+}
+`
+	ents, rels := runRedisPubSub(t, "csharp", src)
+	wantID := "channel:redis-pubsub:orders.*"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected wildcard entity %q; got %v", wantID, ents)
+	}
+	wantRel := "SUBSCRIBES_TO|Service:OrderWatcher|SCOPE.Queue:channel:redis-pubsub:orders.*"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+// Cross-repo: a C# publisher and a Node subscriber on the same channel must
+// resolve to the SAME canonical SCOPE.Queue ID so P7 pairs them.
+func TestRedisPubSub_CSharp_CrossRepoTopicLink(t *testing.T) {
+	csSrc := `using StackExchange.Redis;
+public class Pub {
+    private readonly ISubscriber _sub;
+    public void Go(string p) => _sub.Publish("user.events", p);
+}`
+	nodeSrc := `const redis = require("ioredis");
+const sub = new redis();
+sub.subscribe("user.events", (msg) => {});`
+
+	csEnts, csRels := runRedisPubSub(t, "csharp", csSrc)
+	nodeEnts, nodeRels := runRedisPubSub(t, "javascript", nodeSrc)
+
+	wantID := "channel:redis-pubsub:user.events"
+	if !hasEntity(csEnts, wantID) || !hasEntity(nodeEnts, wantID) {
+		t.Fatalf("expected shared entity %q on both sides; cs=%v node=%v", wantID, csEnts, nodeEnts)
+	}
+	if !hasRel(csRels, "PUBLISHES_TO|Service:Pub|SCOPE.Queue:"+wantID) {
+		t.Errorf("missing C# publisher edge; got %v", csRels)
+	}
+	if len(nodeRels) == 0 {
+		t.Errorf("expected node subscriber edge; got none")
+	}
+}
+
+// Cache-only StackExchange.Redis file must NOT fire the pub/sub synthesis.
+func TestRedisPubSub_CSharp_NoCacheOps(t *testing.T) {
+	src := `using StackExchange.Redis;
+public class Cache {
+    private readonly IDatabase _db;
+    public string Get(string k) => _db.StringGet(k);
+    public void Set(string k, string v) => _db.StringSet(k, v);
+}`
+	ents, rels := runRedisPubSub(t, "csharp", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Errorf("cache-only file should yield no pub/sub synthetics; got ents=%v rels=%v", ents, rels)
+	}
+}


### PR DESCRIPTION
## What

Adds the **C# (StackExchange.Redis) message_broker view** for Redis pub/sub — the top-value item from #5016. Before this, C# `Publish`/`Subscribe` were recorded only as per-file ORM keyspace access (`SCOPE.Datastore`, via `internal/custom/csharp/redis.go`), invisible to the cross-repo broker topology. C# was the **only major language missing** from the `redis_pubsub_edges` engine pass.

`synthesizeCSharpRedisPubSub` (new, in `internal/engine/redis_pubsub_edges.go`) emits the SAME canonical `channel:redis-pubsub:<name>` `SCOPE.Queue` entity every other language uses, so a C# publisher pairs cross-repo with a Node/Python/Kotlin/etc. subscriber via the existing `topic_pass.go` import-channel linker — no new matching code.

### Edges / entities
- `.Publish` / `.PublishAsync(...)` -> `PUBLISHES_TO` `SCOPE.Queue:channel:redis-pubsub:<name>`
- `.Subscribe` / `.SubscribeAsync(...)` -> `SUBSCRIBES_TO` same node
- Caller = enclosing `class` (via shared `classNameRe`), fallback to following method
- Channel forms: bare `"chan"`, `RedisChannel.Literal("chan")`, `RedisChannel.Pattern("chan*")`, `new RedisChannel("chan", ...)`
- Wildcard (`*` / `RedisChannel.Pattern`) flagged `is_pattern` / `is_wildcard`
- `messaging_layer=stackexchange-redis`, `broker=redis`, `channel_type=pubsub`
- Honest-partial: dynamic/interpolated channels (no static literal) are skipped, not fabricated

### Built vs deferred
- **Built:** Redis pub/sub broker view for C# (the med/top-value item), fixture-proven.
- **Deferred (follow-ups to file under #5016):** AutoMapper/Mapster mapping-profile extraction (low); Polly/Coravel resilience-policy extraction (low). These are independent low-priority extractors, not part of the broker view.

## Registry cells
`msg.broker.redis` (multi) — `consumer_extraction`, `producer_extraction`, `topic_attribution` notes updated to honestly record csharp coverage + cite the new test; `issue: 5016`, `verified_at: 2026-06-12`. Status stays `full` (now honestly so for C#). **Regenerated `docs/coverage` committed** (`msg.broker.redis.md`) — keeps `verify` CI green.

## Fixtures (7, all pass)
`TestRedisPubSub_CSharp_{Publish, PublishAsync, Subscribe, RedisChannelLiteralWrapper, PatternSubscribeWildcard, CrossRepoTopicLink, NoCacheOps}` — incl. a C#-publisher↔Node-subscriber cross-repo same-ID join and a cache-only negative test.

## Gates (sandbox HOME=/tmp/agsbx-5016)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/custom/csharp/... ./internal/engine/... ./internal/extractors/csharp/... ./internal/types/` all green; `coverage fmt --check` canonical; `coverage validate` ok (pre-existing unrelated warnings only); regenerated `docs/coverage` committed.

Deploy-deferred.

Refs #5016