### PR TITLE
docs(#5084): fix stale tool names/counts/paths + enhance undocumented surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Pair them: MCP narrows the search space; grep verifies edge-property questions M
 ## Three concrete examples
 
 **MCP-good — structural navigation:**
-"Which services call `OrderService.CreateOrder`?" → `archigraph_find` + `archigraph_callers` gives you
+"Which services call `OrderService.CreateOrder`?" → `archigraph_find` + `archigraph_find_callers` gives you
 the precise call graph with repo context, in one round-trip. grep would require you to know every
 caller file location across every repo in the group.
 
@@ -19,7 +19,7 @@ the source files is faster and more complete for this class of pattern.
 
 **Paired — search space reduction then raw verify:**
 "Does any service leak the internal `User.PasswordHash` field in an HTTP response?" →
-1. MCP: `archigraph_find entity_type=http_endpoint_definition` + `archigraph_paths` to identify
+1. MCP: `archigraph_find entity_type=http_endpoint_definition` + `archigraph_find_paths` to identify
    every endpoint that touches `User`. Narrows a 500-file repo to 8 handlers.
 2. grep: search only those 8 handler files for `PasswordHash` to confirm whether it appears in any
    serialisation path.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # archigraph
 
-> A local code-knowledge-graph daemon that gives AI agents structural navigation — call graphs, cross-repo dependency traces, HTTP surface maps, and process flows — across one or many repositories, exposed via 29 MCP tools.
+> A local code-knowledge-graph daemon that gives AI agents structural navigation — call graphs, cross-repo dependency traces, HTTP surface maps, and process flows — across one or many repositories, exposed via 65 MCP tools.
 
 [![Build](https://github.com/cajasmota/archigraph/actions/workflows/test.yml/badge.svg)](https://github.com/cajasmota/archigraph/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -26,7 +26,7 @@ The graph lives entirely on your machine. No cloud indexing, no account, no data
 - **Message-bus topology** — topic/broker/service groupings for event-driven systems; publisher and subscriber orphan detection.
 - **Cross-repo dependency graph** — index a folder of repos as one group; edges span repo boundaries with confidence scores; diff graph state between any two indexed refs.
 - **Documentation and analysis skills** — a 14-skill family (tech docs, business docs, security audit, consultant panel, patterns) all driven off the graph, invokable from Claude Code as slash commands.
-- **Real-time dashboard** — 12 surfaces (Graph, Flows, Topology, Paths, Docs, Quality, Patterns, ...) embedded in the daemon, no separate server, at `http://127.0.0.1:47274`.
+- **Real-time dashboard** — 19 surfaces (Graph, Flows, Event-flows, Topology, Paths, Links, GraphQL, IaC, Docs, Security, Taint, DI, Error-flow, Quality, Settings, Pending, Operations, Compare, Missing) embedded in the daemon, no separate server, at `http://127.0.0.1:47274`.
 
 ---
 
@@ -113,7 +113,7 @@ For per-agent setup instructions see [docs/agent-hosts.md](docs/agent-hosts.md).
 | [docs/agent-hosts.md](docs/agent-hosts.md) | Per-agent setup (Claude Code, Cursor, Windsurf, Continue, Aider, Cline) |
 | [skills/README.md](skills/README.md) | Skill family — chains, dependencies, install |
 | [internal/mcp/SCHEMA.md](internal/mcp/SCHEMA.md) | Full MCP tool schema (canonical) |
-| [docs/adrs/](docs/adrs/) | Architectural decision records (ADR-0001 through ADR-0020) |
+| [docs/adrs/](docs/adrs/) | Architectural decision records (ADR-0001 through ADR-0022) |
 | [CHANGELOG.md](CHANGELOG.md) | Version history and breaking changes |
 | [CLAUDE.md](CLAUDE.md) | When to use MCP vs grep (agent pairing guide) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Reference documentation for archigraph. The [README.md](../README.md) at the rep
 | Doc | Contents |
 |-----|----------|
 | [concepts.md](concepts.md) | Knowledge graph model, entity kinds, edge kinds, residual edges, repair |
-| [modes.md](modes.md) | Single-repo vs multi-repo groups, monorepo splitting, group lifecycle |
+| [modes.md](modes.md) | Daemon operational modes (background, workstation, readonly) — memory, background activity, feature activation |
 | [graph-format.md](graph-format.md) | On-disk graph format (`.archigraph/graph.fb`), binary schema, JSON export |
 | [embedding.md](embedding.md) | Semantic search embedding strategy (BM25 + optional MiniLM / BYO endpoint) |
 
@@ -45,5 +45,5 @@ Reference documentation for archigraph. The [README.md](../README.md) at the rep
 | Doc | Contents |
 |-----|----------|
 | [../internal/mcp/SCHEMA.md](../internal/mcp/SCHEMA.md) | Full MCP tool schema — canonical source of truth for inputs/outputs |
-| [adrs/README.md](adrs/README.md) | Architectural decision records index (ADR-0001 through ADR-0020) |
+| [adrs/README.md](adrs/README.md) | Architectural decision records index (ADR-0001 through ADR-0022) |
 | [RELEASING.md](RELEASING.md) | Release process (maintainer reference) |

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -1,12 +1,12 @@
-# Agent host configuration — Haiku for Pass 13 enrichment
+# Agent host configuration — Haiku for graph enrichment
 
-Pass 13 (LLM enrichment) runs hundreds to thousands of LLM calls in batches.
-Using the wrong model (Sonnet or Opus) inflates cost by 10–20× without
-meaningfully improving enrichment quality for most entities.
-This page shows how to set `claude-3-haiku-20240307` as the active model in
-each supported agent host **before** starting Pass 13.
+The graph-enrichment pass (`/archigraph-graph-enrich`) runs hundreds to
+thousands of LLM calls in batches. Using the wrong model (Sonnet or Opus)
+inflates cost by 10–20× without meaningfully improving enrichment quality for
+most entities. This page shows how to set `claude-3-haiku-20240307` as the
+active model in each supported agent host **before** starting enrichment.
 
-> **Model selection rule** (from [`skills/generate-docs/SKILL.md`](../skills/generate-docs/SKILL.md)):
+> **Model selection rule** (from [`skills/archigraph-graph-enrich/SKILL.md`](../skills/archigraph-graph-enrich/SKILL.md)):
 > Haiku for `high`, `medium`, and `low` criticality bands (the vast majority
 > of a corpus). Sonnet only for the small `critical` tier (score ≥ 80).
 > The skill enforces this automatically — but only when the host allows
@@ -19,17 +19,17 @@ each supported agent host **before** starting Pass 13.
 | Host | Can set model? | Supports MCP? | Per-call override? | Notes |
 |------|---------------|--------------|-------------------|-------|
 | [Claude Code](#claude-code) | Yes — CLI flag, slash command, or `settings.json` | Yes (native) | Yes — skill drives model selection per batch | Full support; recommended |
-| [Cursor](#cursor) | Yes — model picker per session | Yes (via MCP JSON config) | No — one model for the whole session | Switch to Haiku before invoking `/generate-docs` |
-| [Windsurf](#windsurf-codeium) | Yes — Cascade model picker | Yes (via MCP JSON config) | No — one model for the whole session | Switch to Haiku before invoking `/generate-docs` |
+| [Cursor](#cursor) | Yes — model picker per session | Yes (via MCP JSON config) | No — one model for the whole session | Switch to Haiku before invoking `/archigraph-graph-enrich` |
+| [Windsurf](#windsurf-codeium) | Yes — Cascade model picker | Yes (via MCP JSON config) | No — one model for the whole session | Switch to Haiku before invoking `/archigraph-graph-enrich` |
 | [Continue](#continue) | Yes — `config.json` or inline picker | Yes (via MCP JSON config) | No | Set `defaultModel` to Haiku in config |
-| [Aider](#aider) | Yes — `--model` CLI flag or `.aider.conf.yml` | No (no MCP client) | No | Run Pass 13 outside Aider; use Claude Code instead |
+| [Aider](#aider) | Yes — `--model` CLI flag or `.aider.conf.yml` | No (no MCP client) | No | Run enrichment outside Aider; use Claude Code instead |
 | [Cline](#cline) | Yes — model picker in VS Code sidebar | Yes (via MCP JSON config) | No — one model per task | Switch to Haiku before starting the task |
 
 ---
 
 ## Claude Code
 
-Pass 13 runs inside Claude Code and the `/generate-docs` skill drives model
+Enrichment runs inside Claude Code and the `/archigraph-graph-enrich` skill drives model
 selection automatically (Haiku for non-critical batches, Sonnet for the
 critical tier). You can still lock the session to Haiku to prevent accidental
 Sonnet fallback.
@@ -43,10 +43,10 @@ claude --model claude-3-haiku-20240307
 Then invoke:
 
 ```
-/generate-docs
+/archigraph-graph-enrich
 ```
 
-The skill's Pass 13 will use Haiku for all non-critical batches and will
+The skill's enrichment will use Haiku for all non-critical batches and will
 prompt you before switching to Sonnet for the critical tier.
 
 ### Switch model mid-session
@@ -81,24 +81,23 @@ command output. You can also check at any time:
 
 Expected output: `Current model: claude-3-haiku-20240307`
 
-### Recommended workflow for Pass 13
+### Recommended workflow for enrichment
 
 1. `claude --model claude-3-haiku-20240307` — start the session locked to Haiku.
 2. Run `archigraph status <group>` to confirm the daemon is up and MCP is connected.
-3. Invoke `/generate-docs` — the skill runs Passes 0–12 at whatever model is set,
-   then reaches Pass 13.
-4. At Pass 13, the skill prints a cost estimate and asks for confirmation before
+3. Invoke `/archigraph-graph-enrich` — the skill fetches the pending enrichment
+   queue, then prints a cost estimate and asks for confirmation before
    dispatching batches. The non-critical batches go to Haiku; the skill will ask
    you to confirm the model switch to Sonnet for the critical tier before sending
    those batches.
-5. After Pass 13 completes, run `/model claude-3-5-sonnet-20241022` (or whichever
+4. After enrichment completes, run `/model claude-3-5-sonnet-20241022` (or whichever
    model you prefer for interactive coding) to restore your normal session model.
 
 ### Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Pass 13 cost far higher than expected | Session model was Sonnet or Opus | Verify with `/model`; restart with `--model claude-3-haiku-20240307` and re-run |
+| Enrichment cost far higher than expected | Session model was Sonnet or Opus | Verify with `/model`; restart with `--model claude-3-haiku-20240307` and re-run |
 | `/model` command not found | Claude Code version too old | Upgrade: `npm i -g @anthropic-ai/claude-code@latest` |
 | Skill ignores `/model` change mid-run | Session model is advisory; the skill's per-batch override still applies | No action needed — the skill manages model selection per batch |
 | `settings.json` model ignored | Project file path wrong | Must be `.claude/settings.json` relative to the repo root you opened |
@@ -110,7 +109,7 @@ Expected output: `Current model: claude-3-haiku-20240307`
 Cursor selects the model per chat session. It does not support mid-run model
 switching inside a single task.
 
-### Set model before starting Pass 13
+### Set model before starting enrichment
 
 1. Open the AI panel: `Cmd+L` (macOS) / `Ctrl+L` (Linux/Windows).
 2. Click the **model selector** at the top of the panel.
@@ -121,13 +120,13 @@ switching inside a single task.
 The model name is shown in the panel header while a request is in flight.
 There is no CLI command to query it.
 
-### Recommended workflow for Pass 13
+### Recommended workflow for enrichment
 
 Because Cursor does not allow mid-run model switching, all batches — including
-the critical tier — will use the model active when you invoke `/generate-docs`.
+the critical tier — will use the model active when you invoke `/archigraph-graph-enrich`.
 Choose one of:
 
-- **Option A (preferred):** use Claude Code for Pass 13 (supports per-batch
+- **Option A (preferred):** use Claude Code for enrichment (supports per-batch
   model selection).
 - **Option B:** set Haiku in Cursor, accept that the critical tier also runs
   Haiku, and re-run critical-tier entities in a Claude Code session afterward
@@ -138,7 +137,7 @@ Choose one of:
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | "Claude 3 Haiku" not in model list | Anthropic API key not set in Cursor settings | Add key under **Cursor → Settings → Models → Anthropic** |
-| Model resets after closing the panel | Expected — Cursor does not persist per-chat model | Re-select before each Pass 13 run |
+| Model resets after closing the panel | Expected — Cursor does not persist per-chat model | Re-select before each enrichment run |
 
 ---
 
@@ -147,7 +146,7 @@ Choose one of:
 Windsurf uses Cascade for AI interactions. Model selection is per-session
 and does not persist across sessions.
 
-### Set model before starting Pass 13
+### Set model before starting enrichment
 
 1. Open Cascade: `Cmd+L` (macOS) / `Ctrl+L` (Linux/Windows).
 2. Click the **model picker** (usually a small label near the top-right of
@@ -158,10 +157,10 @@ and does not persist across sessions.
 
 The model name is shown in the Cascade panel header.
 
-### Recommended workflow for Pass 13
+### Recommended workflow for enrichment
 
 Same constraint as Cursor — no per-batch model switching. Prefer Claude Code
-for Pass 13 if your corpus has a significant critical tier. If you must use
+for enrichment if your corpus has a significant critical tier. If you must use
 Windsurf, set Haiku before invoking the skill and accept that the critical
 tier runs at Haiku quality.
 
@@ -220,15 +219,15 @@ The current model is shown in the Continue chat panel footer.
 ## Aider
 
 Aider is a terminal-based AI coding tool. It does not have an MCP client, so
-it cannot call `archigraph_*` MCP tools directly. **Pass 13 cannot run inside
-Aider.** Use Claude Code for Pass 13.
+it cannot call `archigraph_*` MCP tools directly. **enrichment cannot run inside
+Aider.** Use Claude Code for enrichment.
 
 If you use Aider for your normal coding sessions but want to run enrichment,
 the recommended workflow is:
 
 1. Finish your Aider session and commit your work.
 2. Open Claude Code in the same directory.
-3. Run Pass 13 inside Claude Code as described in the [Claude Code](#claude-code) section.
+3. Run enrichment inside Claude Code as described in the [Claude Code](#claude-code) section.
 4. Return to Aider after enrichment is complete.
 
 ### Setting the model in Aider (for reference)
@@ -249,7 +248,7 @@ model: claude-3-haiku-20240307
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `archigraph_*` tools not found in Aider | Aider has no MCP client | Use Claude Code for Pass 13 |
+| `archigraph_*` tools not found in Aider | Aider has no MCP client | Use Claude Code for enrichment |
 | Aider rejects the model name | Aider version too old | `pip install --upgrade aider-chat` |
 
 ---
@@ -259,7 +258,7 @@ model: claude-3-haiku-20240307
 Cline is a VS Code extension with MCP client support. Model selection is
 per-task (set before starting the task).
 
-### Set model before starting Pass 13
+### Set model before starting enrichment
 
 1. Open the Cline sidebar in VS Code.
 2. Click the **model selector** (gear icon or model name label near the top).
@@ -293,7 +292,7 @@ Then add the equivalent entry to the Cline MCP config (VS Code settings →
 
 The model is shown in the Cline task panel header before each task run.
 
-### Recommended workflow for Pass 13
+### Recommended workflow for enrichment
 
 Set Haiku before clicking "Start Task". The same no-per-batch-switching
 constraint applies as for Cursor and Windsurf — prefer Claude Code for full
@@ -312,7 +311,7 @@ tier-aware enrichment.
 ## Recommended minimal setup
 
 If you are onboarding to archigraph enrichment for the first time, this is
-the fastest path to a working, cost-safe Pass 13 environment:
+the fastest path to a working, cost-safe enrichment environment:
 
 ```sh
 # 1. Install archigraph
@@ -328,17 +327,17 @@ archigraph status <group>  # should show "MCP: connected"
 # 4. Open Claude Code locked to Haiku
 claude --model claude-3-haiku-20240307
 
-# 5. Run the full doc + enrichment pipeline
-/generate-docs
+# 5. Run the enrichment pass
+/archigraph-graph-enrich
 ```
 
-Total setup time: ~5 minutes. Pass 13 will then run at Haiku rates for most
+Total setup time: ~5 minutes. Enrichment will then run at Haiku rates for most
 entities, with a cost-estimate confirmation gate before any Sonnet batches.
 
 ---
 
 ## Related
 
-- [`skills/generate-docs/SKILL.md`](../skills/generate-docs/SKILL.md) — full Pass 13 procedure, model selection table, batching rules, and resume semantics.
+- [`skills/archigraph-graph-enrich/SKILL.md`](../skills/archigraph-graph-enrich/SKILL.md) — full enrichment procedure, model selection table, batching rules, and resume semantics.
 - [`docs/settings.md`](settings.md) — archigraph daemon settings reference.
 - [MCP Activity surface (`/mcp-activity`)](http://127.0.0.1:47274/mcp-activity) — live view of MCP tool calls; useful to confirm the daemon is receiving archigraph calls from your agent host.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -68,7 +68,7 @@ Beyond residual edges, the enrichment queue holds three types of candidates:
 - **Cross-repo link candidates** — edges where the target might be in a sibling repo (`archigraph_cross_links`)
 - **Enrichment candidates** — `http_endpoint`, `process_flow`, and `message_topic` entities that the indexer flagged for LLM annotation (`archigraph_enrichments`)
 
-The dashboard **Pending** surface (`/pending`) shows the full queue tiered by priority (Critical / High / Medium / Low).
+The dashboard **Pending** surface (`/g/:groupId/pending`) shows the full queue tiered by priority (Critical / High / Medium / Low).
 
 The `/archigraph-graph-enrich` skill emits YAML frontmatter for HTTP endpoints, flows, and topics — this makes the **Paths**, **Flows**, and **Topology** dashboard panels display data.
 
@@ -98,3 +98,37 @@ See [user-guide/multi-branch.md](user-guide/multi-branch.md) for the full guide.
 As agents work with the graph, they can save findings via `archigraph_save_finding`. Over time, recurring structural patterns are extracted and stored as first-class entities. These are visible in the **Patterns** dashboard surface and manageable via the `/archigraph-patterns-discover` and `/archigraph-patterns-sync` skills.
 
 See [ADR-0018](adrs/0018-agent-learned-patterns.md) for the full design.
+
+---
+
+## Dashboard surfaces
+
+The dashboard is embedded in the daemon at `http://127.0.0.1:47274`. After
+selecting a group, every surface is nested under `/g/:groupId/` — so the
+Pending view, for example, is `/g/:groupId/pending`, not a bare `/pending`.
+The available surfaces (routes defined in `webui-v2/src/routes/router.tsx`):
+
+| Surface | Path | Shows |
+|---------|------|-------|
+| Graph | `/g/:groupId/graph` | Entity/edge graph explorer |
+| Flows | `/g/:groupId/flows` | Pre-computed process flows |
+| Event-flows | `/g/:groupId/event-flows` | Message-bus / event-driven flows |
+| Topology | `/g/:groupId/topology` | Topic/broker/service topology |
+| Paths | `/g/:groupId/paths` | HTTP endpoint surface and pairings |
+| Links | `/g/:groupId/links` | Cross-repo link candidates |
+| GraphQL | `/g/:groupId/graphql` | GraphQL schema surface |
+| IaC | `/g/:groupId/iac` | Infrastructure-as-code resources |
+| Docs | `/g/:groupId/docs` | Generated documentation viewer |
+| Security | `/g/:groupId/security` | Security findings |
+| Taint | `/g/:groupId/taint` | Taint / data-flow reachability |
+| DI | `/g/:groupId/di` | Dependency-injection wiring |
+| Error-flow | `/g/:groupId/errorflow` | Error / exception propagation |
+| Quality | `/g/:groupId/quality` | Extraction-quality metrics |
+| Settings | `/g/:groupId/settings` | Per-group daemon settings |
+| Pending | `/g/:groupId/pending` | Residual / repair / enrichment queue |
+| Operations | `/g/:groupId/operations` | Index/rebuild operation log |
+| Compare | `/g/:groupId/compare` | Structural ref-to-ref diff |
+| Missing | `/g/:groupId/missing` | Unresolved / missing targets |
+
+Most surfaces light up only after the graph is indexed and (for Paths, Flows,
+and Topology) enriched via `/archigraph-graph-enrich`.

--- a/docs/docgen-llm-mode.md
+++ b/docs/docgen-llm-mode.md
@@ -65,8 +65,9 @@ It turns the deterministic stubs into LLM-filled prose via a three-step loop:
 ```
  daemon side                 orchestrator side (Claude Code)      daemon side
 ┌─────────────┐             ┌──────────────────────────────┐    ┌─────────────┐
-│  --llm-mode │             │  /generate-docs Pass 20       │    │  --llm-mode │
-│    =emit    │ ──bundle──► │  (skills/generate-docs)       │ ──►│    =apply   │
+│  --llm-mode │             │  Pass 20 orchestrate          │    │  --llm-mode │
+│    =emit    │ ──bundle──► │  (skills/archigraph-tech-docs │ ──►│    =apply   │
+│             │             │   or /archigraph-test-page)   │    │             │
 └─────────────┘             └──────────────────────────────┘    └─────────────┘
    Tier 0 or 1                  reads bundle, fills each           re-runs Tier
    writes bundle.json           section with LLM prose,            contracts,
@@ -87,7 +88,7 @@ sequenceDiagram
     Daemon->>Daemon: build LLMPromptBundle<br/>(entity context, 1-hop neighbours,<br/>guidance, max_words, max_mermaid)
     Daemon-->>Dev: writes <pageID>-page-bundle.json
 
-    Dev->>Skill: invoke /generate-docs (Pass 20)
+    Dev->>Skill: invoke /archigraph-tech-docs (or /archigraph-test-page) — Pass 20
     Skill->>Skill: locate *-bundle.json files
     loop for each section in bundle
         Skill->>Cache: check section cache (prompt_hash)
@@ -114,7 +115,7 @@ sequenceDiagram
    budgets, and a `prompt_hash` (SHA-256 over version + section names + entity
    ID + graph node hash + guidance text). Source: `internal/docgen/llm_bundle.go`.
 
-2. **Orchestrate** — Pass 20 of the `generate-docs` skill reads every bundle
+2. **Orchestrate** — Pass 20 of the `archigraph-tech-docs` skill reads every bundle
    file, calls the LLM once per section, assembles an `LLMRunResult` JSON, and
    writes it next to the bundle. The pass is idempotent: it skips any bundle
    whose result file already exists with a matching `prompt_hash`.
@@ -128,8 +129,8 @@ sequenceDiagram
 
 ## 3. Claude Code Skill Integration (Pass 20 / #1822)
 
-Pass 20 lives at `skills/generate-docs/prompts/20-llm-orchestrate.md`.
-It is part of the `generate-docs` skill (`skills/generate-docs/SKILL.md`).
+Pass 20 lives at `skills/archigraph-tech-docs/prompts/20-llm-orchestrate.md`.
+It is part of the `archigraph-tech-docs` skill (`skills/archigraph-tech-docs/SKILL.md`).
 
 **Trigger phrases** that invoke Pass 20:
 
@@ -205,7 +206,7 @@ archigraph docgen \
 # Output: ~/.archigraph/docs/<group>/.tier0-<ts>/<entity-id>-capabilities-bundle.json
 
 # Step 2: run Pass 20 in Claude Code.
-# In Claude Code:  /generate-docs
+# In Claude Code:  /archigraph-test-page   (single-entity emit→fill→apply loop)
 # (Pass 20 auto-detects the bundle and fills the section.)
 
 # Step 3: apply.
@@ -232,7 +233,7 @@ archigraph docgen \
   --llm-mode=emit
 
 # Step 2: fill via Pass 20 in Claude Code.
-# /generate-docs  →  Pass 20 runs automatically.
+# /archigraph-test-page  →  Pass 20 runs automatically.
 
 # Step 3: apply and verify contracts.
 archigraph docgen \
@@ -342,8 +343,8 @@ reference-scripts, reference-misc, module-readme, glossary, how-to-local-dev
 
 ## See Also
 
-- `skills/generate-docs/SKILL.md` — full pass pipeline (Passes 0–20)
-- `skills/generate-docs/prompts/20-llm-orchestrate.md` — Pass 20 full procedure
+- `skills/archigraph-tech-docs/SKILL.md` — full pass pipeline (Passes 0–20)
+- `skills/archigraph-tech-docs/prompts/20-llm-orchestrate.md` — Pass 20 full procedure
 - `internal/docgen/llm_bundle.go` — schema source of truth
 - `internal/docgen/llm_apply.go` — apply-time contract enforcement
 - `docs/adrs/0015-residual-repair-agent-enrichment.md` — residual repair (ADR-0015)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,7 @@ archigraph start             # start the daemon
 archigraph doctor            # check for port conflicts, permission errors
 ```
 
-The daemon listens on `http://127.0.0.1:47274`. If that port is occupied by another process, change it in `~/.archigraph/settings.json` (`daemon_port`) and restart.
+The daemon listens on `http://127.0.0.1:47274`. If that port is occupied by another process, override it with the `ARCHIGRAPH_DASHBOARD_PORT` environment variable before starting the daemon (e.g. `ARCHIGRAPH_DASHBOARD_PORT=48000 archigraph start`), then restart. For a standalone dev server you can also pass `archigraph dashboard serve --port N`. There is no `daemon_port` field in `settings.json`.
 
 ### Dashboard shows a blank page or fails to load
 

--- a/docs/user-guide/multi-branch.md
+++ b/docs/user-guide/multi-branch.md
@@ -176,7 +176,7 @@ An agent can ask for the structural diff between two refs in a single call:
 
 ```json
 {
-  "tool": "archigraph_diff",
+  "tool": "archigraph_diff_refs",
   "arguments": {
     "repo": "my-repo",
     "ref_a": "main",


### PR DESCRIPTION
Applies the verified STALE-FIX + cheap ENHANCE items from the pre-release docs audit in #5084. Markdown-only. Every new value was verified against source first; #5076/#5081 fixes were re-read and not re-touched.

## STALE-FIX (old → new + source citation)

**docs/agent-hosts.md** (major)
- Dead skill path `../skills/generate-docs/SKILL.md` → `../skills/archigraph-graph-enrich/SKILL.md`. The enrichment pass now lives in the split-out `archigraph-graph-enrich` skill (`skills/README.md`, `skills/archigraph-graph-enrich/SKILL.md`).
- `/generate-docs` invocations → `/archigraph-graph-enrich`; "Pass 13" terminology generalized to "enrichment" (the skill's enrichment phase = `prompts/13-enrichment.md`).
- Model IDs `claude-3-haiku-20240307` / `claude-3-5-sonnet-20241022` were **kept**: source proves they are still current — they are the live model-selection table in `skills/archigraph-graph-enrich/SKILL.md` (lines 41-44). The audit's "obsolete model IDs" claim could not be confirmed against source, so they were left unchanged.

**docs/docgen-llm-mode.md** (major)
- All `skills/generate-docs/...` paths → `skills/archigraph-tech-docs/...`. Pass 20 (`prompts/20-llm-orchestrate.md`) and the docgen LLM-mode loop now live in `archigraph-tech-docs` (confirmed: `skills/archigraph-tech-docs/prompts/20-llm-orchestrate.md` exists; `skills/archigraph-tech-docs/SKILL.md` line 11 "extraction of the technical tier (Passes 0–12 + Pass 20)").
- `/generate-docs` single-entity Recipe invocations → `/archigraph-test-page` (`skills/archigraph-test-page/SKILL.md`: "drives the complete docgen LLM-mode loop — emit, fill, apply — on a single entity", uses `--seed-entity`/`--llm-mode`). "Pass 20" name kept (still the real prompt name).

**README.md**
- "29 MCP tools" → "65 MCP tools" (`internal/mcp/server.go`: 65 distinct `archigraph_*` `AddTool` registrations + 1 sentinel `archigraph_status`; matches the #5076-corrected `docs/mcp-tools.md` "65 MCP tools").
- "12 surfaces" → "19 surfaces", enumerated from `webui-v2/src/routes/router.tsx` child routes under `/g/:groupId`.
- ADR range "0001 through 0020" → "0001 through 0022" (`docs/adrs/` contains `0022-http-mcp-transport.md`).
- `docs/mcp-tools.md` link left as-is: it still exists (now an index page) post-#5076, so not dead.

**docs/README.md**
- `modes.md` mislabel "Single-repo vs multi-repo groups, monorepo splitting" → "Daemon operational modes (background, workstation, readonly)…" (`docs/modes.md` H1 "Daemon Operational Modes"; modes background/workstation/readonly).
- ADR range "0001 through 0020" → "0001 through 0022".

**docs/troubleshooting.md**
- Wrong `~/.archigraph/settings.json (daemon_port)` instruction → real mechanism: `ARCHIGRAPH_DASHBOARD_PORT` env var or `archigraph dashboard serve --port N`. No `daemon_port` field exists in `AppSettings` (`internal/dashboard/handlers_settings.go`); port resolution is in `cmd/archigraph/dashboard.go` (`os.Getenv("ARCHIGRAPH_DASHBOARD_PORT")`, default 47274).

**CLAUDE.md** (repo root)
- `archigraph_callers` → `archigraph_find_callers`; `archigraph_paths` → `archigraph_find_paths` (both verified in `internal/mcp/server.go` `AddTool` list).

**docs/user-guide/multi-branch.md**
- `archigraph_diff` → `archigraph_diff_refs` (verified in `internal/mcp/server.go`).

## ENHANCE
- **docs/concepts.md** — added a "Dashboard surfaces" table enumerating all 19 surfaces with their correct nested `/g/:groupId/...` paths (from `webui-v2/src/routes/router.tsx`), and fixed the bare `/pending` inline path to `/g/:groupId/pending`.
- The audit's other ENHANCE targets (parity/diff family `archigraph_payload_drift`/`_auth_posture_diff`/`_literal_parity`/`_response_shape_diff`/`_stub_detector`, plus `archigraph_control_flow`/`_topology`/`_data_flows`/`_effects`) were found **already documented** in the new `docs/mcp-tools/` category pages + index created by #5076 (audit was against the older HEAD `0d56a1e84`). No redundant stubs added.

## Could-not-verify / skipped
- "Obsolete model IDs" in agent-hosts.md — refuted by source (IDs are current in the live enrichment skill); left unchanged.
- `docs/settings.md` (`webhooks`/`perf_budgets`/`quality_budgets`) and `docs/architecture/personas.md` numbering fixes — listed as ENHANCE but outside the requested STALE-FIX scope; not done here.

## Link check
All relative markdown links in every touched file resolve. No links to deleted `docs/migration/` remain. No fabricated tool names — every tool name written is present in `internal/mcp/server.go`.

## REMOVE candidates — left for human sign-off
The 4 REMOVE candidates (`docs/agent-instructions-draft.md`, `docs/specs/milestone-2-dashboard-plan.md`, `docs/quality/xrepo-http-coverage-1409.md`, `docs/quality/baseline.md`) were **not** touched — they await separate human sign-off.

Refs #5084