### PR TITLE
feat(#5004): csharp — WCF client proxy (ChannelFactory/ClientBase) client_codegen

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -277,7 +277,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 |---|---|---|---|---|---|---|---|---|
 | [C/C++](../by-language/c-cpp.md) | [Protocol Buffers (C++)](../detail/lang.c-cpp.framework.protobuf.md) | 🔴 0/6 | 🔴 0/1 | ✅ 3/3 | 🔴 0/1 | 🟡 8/25 | 🟡 3/15 | |
 | [C/C++](../by-language/c-cpp.md) | [gRPC C++ (grpc++)](../detail/lang.c-cpp.framework.grpc.md) | — | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 8/24 | 🟡 7/10 | |
-| [C#](../by-language/csharp.md) | [WCF](../detail/lang.csharp.framework.wcf.md) | — | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🔴 0/25 | 🟡 3/14 | |
+| [C#](../by-language/csharp.md) | [WCF](../detail/lang.csharp.framework.wcf.md) | — | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🔴 0/25 | 🟡 4/14 | |
 | [C#](../by-language/csharp.md) | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | — | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | 🟢 10/10 | |
 | [elixir](../by-language/elixir.md) | [elixir-grpc](../detail/lang.elixir.framework.grpc.md) | — | 🟢 1/1 | 🟢 4/4 | ✅ 1/1 | 🟡 13/24 | 🟡 6/10 | |
 | [go](../by-language/go.md) | [gRPC-Go (google.golang.org/grpc)](../detail/lang.go.framework.grpc.md) | — | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/25 | 🟡 3/10 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -65,7 +65,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|
-| [WCF](../detail/lang.csharp.framework.wcf.md) | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🔴 0/25 | 🟡 3/14 | |
+| [WCF](../detail/lang.csharp.framework.wcf.md) | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🔴 0/25 | 🟡 4/14 | |
 | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | 🟢 10/10 | |
 
 

--- a/docs/coverage/detail/lang.csharp.framework.wcf.md
+++ b/docs/coverage/detail/lang.csharp.framework.wcf.md
@@ -24,7 +24,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Client codegen | 🔴 `missing` | — | 4968 | — | — |
+| Client codegen | 🟢 `partial` | — | 5004 | `internal/custom/csharp/wcf.go`<br>`internal/custom/csharp/wcf_test.go` | WCF client proxies -> SCOPE.Component/client_codegen (mirrors grpc_net.go): new ChannelFactory<IContract>(...) -> channel_factory:<Contract> with a USES edge -> contract:<Contract>; class XxxClient : ClientBase<IContract> -> client_base:<Name> + USES -> contract:<Contract>; new XxxClient(...) -> client:<Name> (common non-proxy *Client types like HttpClient excluded). Honest-partial: App.config/code binding address+mode props, channelFactory.CreateChannel() call-site attribution, and [FaultContract] error_flow deferred (#5004). |
 
 ### Transport
 

--- a/internal/custom/csharp/wcf.go
+++ b/internal/custom/csharp/wcf.go
@@ -22,8 +22,18 @@
 //	  builder.Services.AddServiceModelServices()/AddServiceModelWebServices()
 //	  (CoreWCF) emitted as SCOPE.Pattern/transport_binding.
 //
+//	Codegen/client_codegen (#5004):
+//	  WCF client proxies emitted as SCOPE.Component/client_codegen, mirroring the
+//	  grpc_net.go client surface. Three idioms are recognised:
+//	    - new ChannelFactory<IContract>(...) — the factory carries a USES edge to
+//	      the consumed service contract (contract:<IContract>).
+//	    - class XxxClient : ClientBase<IContract> — a generated proxy class, with
+//	      a USES edge to its contract type argument.
+//	    - new XxxClient(...) — instantiation of a generated ClientBase proxy.
+//	  These are the WCF analogue of an outbound RPC call into a [ServiceContract].
+//
 // Registration key: "custom_csharp_wcf"
-// Issue #4968.
+// Issues #4968, #5004.
 package csharp
 
 import (
@@ -90,6 +100,26 @@ var (
 	reWCFAddServiceEndpoint = regexp.MustCompile(
 		`\.AddServiceEndpoint\s*<\s*(\w+)\s*,\s*(\w+)\s*>`,
 	)
+
+	// new ChannelFactory<IContract>(...) — the canonical WCF client proxy
+	// factory. Captures the consumed service-contract type argument. The leaf
+	// type is taken so qualified names (Foo.IBar) normalise to IBar.
+	reWCFChannelFactory = regexp.MustCompile(
+		`new\s+ChannelFactory\s*<\s*([\w.]+)\s*>`,
+	)
+
+	// class XxxClient : ClientBase<IContract> — a generated WCF client proxy
+	// class (svcutil/Add Service Reference output). Captures the proxy class name
+	// and its contract type argument.
+	reWCFClientBase = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s*:\s*ClientBase\s*<\s*([\w.]+)\s*>`,
+	)
+
+	// new XxxClient(...) — instantiation of a generated proxy whose name ends in
+	// Client. Cheap heuristic mirroring grpc_net.go's reGRPCClientCtor.
+	reWCFClientCtor = regexp.MustCompile(
+		`new\s+([\w.]*Client)\s*\(`,
+	)
 )
 
 // ---------------------------------------------------------------------------
@@ -116,9 +146,10 @@ func (e *wcfExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 
 	src := string(file.Content)
 
-	// Cheap gate: only WCF files carry these attributes / host types.
+	// Cheap gate: only WCF files carry these attributes / host types / client
+	// proxy idioms.
 	if !regexpAny(src, "[ServiceContract", "[OperationContract", "[DataContract",
-		"ServiceHost", "AddServiceModel") {
+		"ServiceHost", "AddServiceModel", "ChannelFactory", "ClientBase") {
 		return nil, nil
 	}
 
@@ -210,8 +241,93 @@ func (e *wcfExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		add(ent)
 	}
 
+	// -------------------------------------------------------------------------
+	// Codegen/client_codegen — outbound WCF client proxies (#5004)
+	// -------------------------------------------------------------------------
+
+	// new ChannelFactory<IContract>(...) — channel-factory proxy. USES the
+	// consumed service contract, the WCF analogue of an outbound RPC call.
+	for _, m := range reWCFChannelFactory.FindAllStringSubmatchIndex(src, -1) {
+		contract := leafType(src[m[2]:m[3]])
+		if contract == "" {
+			continue
+		}
+		line := lineOf(src, m[0])
+		ent := makeEntity("channel_factory:"+contract, "SCOPE.Component", "client_codegen", file.Path, "csharp", line)
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_CHANNEL_FACTORY",
+			"contract_type", contract, "proxy_kind", "channel_factory")
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID: "contract:" + contract,
+			Kind: string(types.RelationshipKindUses),
+			Properties: map[string]string{
+				"contract_type": contract,
+				"framework":     "wcf",
+				"proxy_kind":    "channel_factory",
+				"line":          itoa(line),
+			},
+		})
+		add(ent)
+	}
+
+	// class XxxClient : ClientBase<IContract> — generated proxy class. USES the
+	// contract type argument it proxies.
+	for _, m := range reWCFClientBase.FindAllStringSubmatchIndex(src, -1) {
+		clientName := src[m[2]:m[3]]
+		contract := leafType(src[m[4]:m[5]])
+		line := lineOf(src, m[0])
+		ent := makeEntity("client_base:"+clientName, "SCOPE.Component", "client_codegen", file.Path, "csharp", line)
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_CLIENT_BASE",
+			"client_class", clientName, "contract_type", contract, "proxy_kind", "client_base")
+		if contract != "" {
+			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+				ToID: "contract:" + contract,
+				Kind: string(types.RelationshipKindUses),
+				Properties: map[string]string{
+					"client_class":  clientName,
+					"contract_type": contract,
+					"framework":     "wcf",
+					"proxy_kind":    "client_base",
+					"line":          itoa(line),
+				},
+			})
+		}
+		add(ent)
+	}
+
+	// new XxxClient(...) — instantiation of a generated proxy. Skip the
+	// ChannelFactory ctor (handled above) which also ends in "...Factory", not
+	// "...Client", so no overlap there.
+	for _, m := range reWCFClientCtor.FindAllStringSubmatchIndex(src, -1) {
+		clientName := leafType(src[m[2]:m[3]])
+		if clientName == "" || wcfNonProxyClients[clientName] {
+			continue
+		}
+		line := lineOf(src, m[0])
+		ent := makeEntity("client:"+clientName, "SCOPE.Component", "client_codegen", file.Path, "csharp", line)
+		setProps(&ent, "framework", "wcf", "provenance", "INFERRED_FROM_CLIENT_CTOR",
+			"client_class", clientName, "proxy_kind", "client_ctor")
+		add(ent)
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// wcfNonProxyClients are common .NET client types that end in "Client" but are
+// not WCF generated proxies — excluded from the new XxxClient(...) heuristic so
+// the client_codegen surface stays WCF-specific.
+var wcfNonProxyClients = map[string]bool{
+	"HttpClient":        true,
+	"WebClient":         true,
+	"TcpClient":         true,
+	"UdpClient":         true,
+	"SmtpClient":        true,
+	"GrpcClient":        true,
+	"HttpMessageClient": true,
+	"RestClient":        true,
+	"BlobClient":        true,
+	"QueueClient":       true,
+	"ServiceBusClient":  true,
 }
 
 // regexpAny reports whether src contains any of the literal substrings. Used as

--- a/internal/custom/csharp/wcf_test.go
+++ b/internal/custom/csharp/wcf_test.go
@@ -146,6 +146,105 @@ app.UseServiceModel(b =>
 	}
 }
 
+// ---------------------------------------------------------------------------
+// WCF — client proxy / client_codegen (#5004)
+// ---------------------------------------------------------------------------
+
+func TestWCFChannelFactoryClientProxy(t *testing.T) {
+	src := `
+using System.ServiceModel;
+
+class OrderClient
+{
+    public void Run()
+    {
+        var factory = new ChannelFactory<IOrderService>(new BasicHttpBinding(), "http://host/order");
+        var channel = factory.CreateChannel();
+        channel.GetOrder(1);
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_wcf", fi("OrderClient.cs", "csharp", src))
+
+	proxy := findEntity(ents, "channel_factory:IOrderService")
+	if proxy == nil {
+		t.Fatal("expected client_codegen channel_factory:IOrderService from new ChannelFactory<IOrderService>()")
+	}
+	if proxy.Kind != "SCOPE.Component" || proxy.Subtype != "client_codegen" {
+		t.Errorf("expected SCOPE.Component/client_codegen, got %s/%s", proxy.Kind, proxy.Subtype)
+	}
+	if proxy.Properties["contract_type"] != "IOrderService" {
+		t.Errorf("expected contract_type=IOrderService, got %q", proxy.Properties["contract_type"])
+	}
+	foundUses := false
+	for _, r := range proxy.Relationships {
+		if r.Kind == "USES" && r.ToID == "contract:IOrderService" {
+			foundUses = true
+		}
+	}
+	if !foundUses {
+		t.Error("expected USES edge -> contract:IOrderService from ChannelFactory proxy")
+	}
+}
+
+func TestWCFClientBaseProxy(t *testing.T) {
+	src := `
+using System.ServiceModel;
+
+public partial class OrderServiceClient : ClientBase<IOrderService>, IOrderService
+{
+    public Order GetOrder(int id) => Channel.GetOrder(id);
+}
+`
+	ents := extractFull(t, "custom_csharp_wcf", fi("OrderServiceClient.cs", "csharp", src))
+
+	proxy := findEntity(ents, "client_base:OrderServiceClient")
+	if proxy == nil {
+		t.Fatal("expected client_codegen client_base:OrderServiceClient from class : ClientBase<IOrderService>")
+	}
+	if proxy.Kind != "SCOPE.Component" || proxy.Subtype != "client_codegen" {
+		t.Errorf("expected SCOPE.Component/client_codegen, got %s/%s", proxy.Kind, proxy.Subtype)
+	}
+	if proxy.Properties["contract_type"] != "IOrderService" {
+		t.Errorf("expected contract_type=IOrderService, got %q", proxy.Properties["contract_type"])
+	}
+	foundUses := false
+	for _, r := range proxy.Relationships {
+		if r.Kind == "USES" && r.ToID == "contract:IOrderService" {
+			foundUses = true
+		}
+	}
+	if !foundUses {
+		t.Error("expected USES edge -> contract:IOrderService from ClientBase proxy class")
+	}
+}
+
+func TestWCFClientCtorAndExclusions(t *testing.T) {
+	src := `
+using System.ServiceModel;
+using System.Net.Http;
+
+public partial class OrderServiceClient : ClientBase<IOrderService> {}
+
+class Caller
+{
+    void Run()
+    {
+        var proxy = new OrderServiceClient();
+        var http = new HttpClient();
+    }
+}
+`
+	ents := extractFull(t, "custom_csharp_wcf", fi("Caller.cs", "csharp", src))
+
+	if findEntity(ents, "client:OrderServiceClient") == nil {
+		t.Error("expected client:OrderServiceClient from new OrderServiceClient()")
+	}
+	if findEntity(ents, "client:HttpClient") != nil {
+		t.Error("HttpClient must be excluded from WCF client_codegen proxies")
+	}
+}
+
 func TestWCFNoMatch(t *testing.T) {
 	src := `namespace MyApp { class Helper { public void Run() {} } }`
 	ents := extract(t, "custom_csharp_wcf", fi("Helper.cs", "csharp", src))


### PR DESCRIPTION
## What

Adds the **WCF client-proxy surface** to `internal/custom/csharp/wcf.go`, the highest-value piece deferred from #4968. Mirrors the `grpc_net.go` `client_codegen` shape so the two RPC frameworks read the same in the graph.

## Built

Three outbound client idioms -> `SCOPE.Component/client_codegen`:
- `new ChannelFactory<IContract>(...)` -> `channel_factory:<Contract>` with a **USES** edge -> `contract:<Contract>` (the WCF analogue of an outbound RPC call into a [ServiceContract]).
- `class XxxClient : ClientBase<IContract>` -> `client_base:<Name>` + **USES** edge -> `contract:<Contract>`.
- `new XxxClient(...)` -> `client:<Name>` (common non-proxy `*Client` types — HttpClient/WebClient/TcpClient/ServiceBusClient/etc — excluded so the surface stays WCF-specific).

Reuses existing entity Kind (`SCOPE.Component`) + edge kind (`USES`) — **no new Kind**, so no `internal/types` schema change.

## Edges
- `USES` : client proxy -> `contract:<IContract>`

## Registry cells
- `lang.csharp.framework.wcf` **Codegen/client_codegen**: `missing` -> `partial` (cites wcf.go + wcf_test.go, issue 5004).
- Regenerated coverage docs **included**: `docs/coverage/registry.json`, `by-category/http_framework.md`, `by-language/csharp.md`, `detail/lang.csharp.framework.wcf.md`.

## Fixtures (wcf_test.go)
- `TestWCFChannelFactoryClientProxy` — ChannelFactory proxy + USES->contract edge.
- `TestWCFClientBaseProxy` — ClientBase<T> proxy class + USES->contract edge.
- `TestWCFClientCtorAndExclusions` — `new XxxClient()` fires; `new HttpClient()` excluded.

## Deferred (honest-partial, follow-ups under #5004)
- App.config `<system.serviceModel>` / code binding address+security-mode props (richer `transport_binding`).
- `channelFactory.CreateChannel()` call-site attribution to the proxy.
- `[FaultContract]` -> error_flow (note: framework-agnostic exception_flow already covers throw/catch, so this is incremental).
- `[ServiceBehavior]`/`[OperationBehavior]` instancing/concurrency metadata; `[PrincipalPermission]`/message-security auth.

## Gates (all green, sandbox isolated HOME=/tmp/agsbx-5004)
- `go build ./...` ✅
- `go vet ./internal/...` ✅
- `go test ./internal/custom/csharp/... ./internal/types/` ✅
- `coverage fmt --check` ✅ (canonical)
- `coverage validate` ✅
- regenerated `docs/coverage` committed.

Refs #5004