### PR TITLE
feat(#5022): rust — migration_schema_ops (SeaORM up()/down() ops + sqlx migrations/*.sql DDL)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -159,7 +159,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🟡 1/4 | |
 | [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 8/10 | |
 | [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/7 | |
-| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 9/11 | |
+| [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 10/11 | |
 | [rust](../by-language/rust.md) | [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/11 | |
 | [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟡 1/4 | |
 | [rust](../by-language/rust.md) | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/4 | |
@@ -170,7 +170,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [rust](../by-language/rust.md) | [redis-rs](../detail/lang.rust.driver.redis.md) | 🟡 1/4 | |
 | [rust](../by-language/rust.md) | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟡 2/4 | |
 | [rust](../by-language/rust.md) | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🟡 1/4 | |
-| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 5/7 | |
+| [rust](../by-language/rust.md) | [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 6/7 | |
 | [rust](../by-language/rust.md) | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🟡 1/4 | |
 | [scala](../by-language/scala.md) | [Anorm](../detail/lang.scala.orm.anorm.md) | 🟡 3/6 | |
 | [scala](../by-language/scala.md) | [Doobie](../detail/lang.scala.orm.doobie.md) | 🟡 3/6 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -69,7 +69,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|
 | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 8/10 | |
 | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/7 | |
-| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 9/11 | |
+| [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 10/11 | |
 | [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/11 | |
 | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟡 1/4 | |
 | [cdrs / scylla-rust-driver](../detail/lang.rust.driver.cassandra.md) | 🟡 1/4 | |
@@ -80,7 +80,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [redis-rs](../detail/lang.rust.driver.redis.md) | 🟡 1/4 | |
 | [rusqlite](../detail/lang.rust.orm.rusqlite.md) | 🟡 2/4 | |
 | [sqlite (Rust)](../detail/lang.rust.driver.sqlite.md) | 🟡 1/4 | |
-| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 5/7 | |
+| [sqlx (Rust)](../detail/lang.rust.orm.sqlx.md) | 🟡 6/7 | |
 | [tokio-postgres / postgres](../detail/lang.rust.driver.postgres.md) | 🟡 1/4 | |
 
 

--- a/docs/coverage/detail/lang.rust.orm.seaorm.md
+++ b/docs/coverage/detail/lang.rust.orm.seaorm.md
@@ -38,8 +38,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_migration.rs` | — |
-| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
+| Migration parsing | ✅ `full` | `2026-06-12` | 5022 | `internal/custom/rust/diesel_seaorm_test.go`<br>`internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_migration.rs` | #5022: impl MigrationTrait for M emits a migration component; the human migration id is resolved from the adjacent MigrationName::name impl (migration_id prop). Proven by TestSeaORM_Migration + TestSeaORM_MigrationSchemaOps_FromFixture. |
+| Migration schema ops | 🟢 `partial` | `2026-06-12` | 5022 | `internal/custom/rust/diesel_seaorm_test.go`<br>`internal/custom/rust/seaorm.go`<br>`internal/custom/rust/testdata/seaorm_migration.rs` | #5022: up()/down() schema-builder calls manager.{create,alter,drop,truncate,rename}_table and {create,drop}_index are parsed via balanced-paren spans into migration components carrying migration_op + the resolved .table(<Iden>::Table) target (or index .name); ColumnDef::new(<Iden>::<Col>) inside create/alter ops emits a schema_column per column with table_name+migration_op. Column SQL types (.integer()/.string() builder chain), default/not-null modifiers, and cross-file Iden->table-name resolution are deferred. Proven by TestSeaORM_MigrationSchemaOps_FromFixture/_AlterTable/_CreateIndex. |
 
 ### Transactions
 

--- a/docs/coverage/detail/lang.rust.orm.sqlx.md
+++ b/docs/coverage/detail/lang.rust.orm.sqlx.md
@@ -38,8 +38,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | sqlx::migrate! path + migration file refs detected; parsing the referenced migrations/*.sql DDL is out of scope (sqlx resolves them at compile time, not in the .rs source). |
-| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
+| Migration parsing | 🟢 `partial` | `2026-06-12` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | sqlx::migrate! path + migration file refs detected in .rs source; migrations/*.sql DDL files are now parsed directly for schema ops (see migration_schema_ops). |
+| Migration schema ops | 🟢 `partial` | `2026-06-12` | 5022 | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go`<br>`internal/custom/rust/testdata/sqlx_migration.sql` | #5022: a `.sql` file under a migrations/ directory is parsed for CREATE/ALTER/DROP TABLE -> migration components (migration_op + table_name) and REFERENCES -> foreign_key patterns. Column-level type parsing and migration ordering/up-down pairing are deferred. Proven by TestSqlx_MigrationSchemaOps (+ TestSqlx_NonMigrationSQLIgnored guard). |
 
 ### Transactions
 

--- a/internal/custom/rust/diesel_seaorm_test.go
+++ b/internal/custom/rust/diesel_seaorm_test.go
@@ -223,6 +223,108 @@ impl MigrationTrait for CreateUsersTable {
 }
 
 // ---------------------------------------------------------------------------
+// SeaORM — migration_schema_ops (#5022): up()/down() schema-builder ops
+// ---------------------------------------------------------------------------
+
+// The seaorm_migration.rs fixture creates a Users table in up() and drops it
+// in down(). We expect a migration component per op carrying migration_op +
+// the resolved table, plus a schema_column per ColumnDef::new(...).
+func TestSeaORM_MigrationSchemaOps_FromFixture(t *testing.T) {
+	src := readFixture(t, "testdata/seaorm_migration.rs")
+	ents := extract(t, "custom_rust_seaorm", fi("migration.rs", "rust", src))
+
+	create, ok := findEntity(ents, "SCOPE.Component", "seaorm:migration:create_table:Users")
+	if !ok {
+		t.Fatal("expected seaorm:migration:create_table:Users")
+	}
+	if create.Props["migration_op"] != "create_table" || create.Props["table_name"] != "Users" {
+		t.Errorf("create_table props = %v", create.Props)
+	}
+
+	if !containsEntity(ents, "SCOPE.Component", "seaorm:migration:drop_table:Users") {
+		t.Error("expected seaorm:migration:drop_table:Users from down()")
+	}
+
+	// Columns from ColumnDef::new(Users::Id) / ColumnDef::new(Users::Name).
+	idCol, ok := findEntity(ents, "SCOPE.Component", "seaorm:migration:column:Users.Id")
+	if !ok {
+		t.Fatal("expected schema_column seaorm:migration:column:Users.Id")
+	}
+	if idCol.Subtype != "schema_column" || idCol.Props["column_name"] != "Id" ||
+		idCol.Props["table_name"] != "Users" || idCol.Props["migration_op"] != "create_table" {
+		t.Errorf("Id column props = %v (subtype %q)", idCol.Props, idCol.Subtype)
+	}
+	if !containsEntity(ents, "SCOPE.Component", "seaorm:migration:column:Users.Name") {
+		t.Error("expected schema_column seaorm:migration:column:Users.Name")
+	}
+
+	// migration_parsing — migration id resolved from MigrationName::name impl.
+	mig, ok := findEntity(ents, "SCOPE.Component", "seaorm:migration:Migration")
+	if !ok {
+		t.Fatal("expected seaorm:migration:Migration component")
+	}
+	if mig.Props["migration_id"] != "m20220101_000001_create_users_table" {
+		t.Errorf("migration_id = %q", mig.Props["migration_id"])
+	}
+}
+
+// alter_table ops add columns to an existing table.
+func TestSeaORM_MigrationSchemaOps_AlterTable(t *testing.T) {
+	src := `
+use sea_orm_migration::prelude::*;
+
+impl MigrationTrait for AddEmail {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Users::Table)
+                    .add_column(ColumnDef::new(Users::Email).string().not_null())
+                    .to_owned(),
+            )
+            .await
+    }
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("alter.rs", "rust", src))
+
+	alter, ok := findEntity(ents, "SCOPE.Component", "seaorm:migration:alter_table:Users")
+	if !ok {
+		t.Fatal("expected seaorm:migration:alter_table:Users")
+	}
+	if alter.Props["migration_op"] != "alter_table" {
+		t.Errorf("alter props = %v", alter.Props)
+	}
+	if !containsEntity(ents, "SCOPE.Component", "seaorm:migration:column:Users.Email") {
+		t.Error("expected schema_column Users.Email from alter_table add_column")
+	}
+}
+
+// create_index resolves the index name and does NOT emit table columns.
+func TestSeaORM_MigrationSchemaOps_CreateIndex(t *testing.T) {
+	src := `
+impl MigrationTrait for AddIdx {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_index(
+                Index::create().name("idx_users_email").table(Users::Table).col(Users::Email).to_owned(),
+            )
+            .await
+    }
+}
+`
+	ents := extract(t, "custom_rust_seaorm", fi("idx.rs", "rust", src))
+	// Table is resolvable via .table(Users::Table), so the op is keyed on it.
+	idx, ok := findEntity(ents, "SCOPE.Component", "seaorm:migration:create_index:Users")
+	if !ok {
+		t.Fatal("expected seaorm:migration:create_index:Users")
+	}
+	if idx.Props["migration_op"] != "create_index" {
+		t.Errorf("index props = %v", idx.Props)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // SeaORM — non-rust file is ignored
 // ---------------------------------------------------------------------------
 

--- a/internal/custom/rust/seaorm.go
+++ b/internal/custom/rust/seaorm.go
@@ -79,6 +79,41 @@ var (
 		`\bimpl\s+MigrationTrait\s+for\s+(\w+)`,
 	)
 
+	// MigrationName::name impl returning the migration identifier string.
+	// fn name(&self) -> &str { "m20220101_000001_create_users_table" }
+	reSeaOrmMigrationName = regexp.MustCompile(
+		`fn\s+name\s*\(\s*&self\s*\)\s*->\s*&\s*str\s*\{\s*"([^"]+)"`,
+	)
+
+	// migration_schema_ops — schema-builder calls inside up()/down() bodies:
+	//   manager.create_table( Table::create().table(Users::Table) ... )
+	//   manager.alter_table(  Table::alter().table(Users::Table)  ... )
+	//   manager.drop_table(   Table::drop().table(Users::Table)   ... )
+	//   manager.create_index( Index::create().table(Users::Table) ... )
+	//   manager.drop_index(   Index::drop().name("idx_...")        ... )
+	// We anchor on the manager.<op>( call and then resolve the .table(<Iden>)
+	// or .name("<idx>") that names the affected object. The Iden enum's
+	// `::Table` variant maps the Rust enum name → logical table name.
+	reSeaOrmManagerOp = regexp.MustCompile(
+		`\bmanager\s*\.\s*(create_table|alter_table|drop_table|truncate_table|rename_table|create_index|drop_index)\s*\(`,
+	)
+
+	// .table(Users::Table) — names the target table via its Iden enum.
+	reSeaOrmTableIden = regexp.MustCompile(
+		`\.\s*table\s*\(\s*(\w+)\s*::\s*Table\s*\)`,
+	)
+
+	// .name("idx_users_name") — names an index target.
+	reSeaOrmIndexName = regexp.MustCompile(
+		`\.\s*name\s*\(\s*"([^"]+)"\s*\)`,
+	)
+
+	// ColumnDef::new(Users::Id) — a column definition inside a create/alter op.
+	// Captures the optional Iden enum and the column variant.
+	reSeaOrmColumnDef = regexp.MustCompile(
+		`ColumnDef::new\s*\(\s*(?:(\w+)\s*::\s*)?(\w+)\s*\)`,
+	)
+
 	// belongs_to with from/to column references → FK extraction
 	// #[sea_orm(belongs_to = "...", from = "Column::FieldId", to = "super::user::Column::Id")]
 	reSeaOrmBelongsToFK = regexp.MustCompile(
@@ -258,14 +293,100 @@ func (e *rustSeaORMExtractor) Extract(ctx context.Context, file extractor.FileIn
 	// 3. impl MigrationTrait for M → migration entity
 	for _, m := range reSeaOrmMigration.FindAllStringSubmatchIndex(src, -1) {
 		migName := src[m[2]:m[3]]
+		// migration_parsing — resolve the human migration id from the
+		// adjacent MigrationName::name impl when present.
+		migID := ""
+		if nm := reSeaOrmMigrationName.FindStringSubmatch(src); nm != nil {
+			migID = nm[1]
+		}
 		ent := makeEntity("seaorm:migration:"+migName, "SCOPE.Component", "migration",
 			file.Path, file.Language, lineOf(src, m[0]))
-		setProps(&ent,
+		props := []string{
 			"framework", "seaorm",
 			"migration_name", migName,
 			"provenance", "INFERRED_FROM_SEAORM_MIGRATION_TRAIT",
-		)
+		}
+		if migID != "" {
+			props = append(props, "migration_id", migID)
+		}
+		setProps(&ent, props...)
 		add(ent)
+	}
+
+	// 3b. migration_schema_ops — parse schema-builder calls in up()/down()
+	//     bodies. Each manager.<op>( ... ) call becomes a migration component
+	//     carrying migration_op + the resolved target table/index. For
+	//     create/alter ops we additionally emit a schema_column per
+	//     ColumnDef::new(...) found inside the call's balanced argument span.
+	for _, m := range reSeaOrmManagerOp.FindAllStringSubmatchIndex(src, -1) {
+		op := src[m[2]:m[3]]
+		// The opening paren of the manager.<op>( call is the last byte of the
+		// match. Find its balanced close to bound the call argument.
+		openParen := m[1] - 1
+		argSpan := src[m[1]:seaOrmBalancedClose(src, openParen)]
+
+		// Resolve the target object: a .table(<Iden>::Table) reference, or an
+		// index .name("...") for create_index/drop_index.
+		target := ""
+		targetKind := "table"
+		if tm := reSeaOrmTableIden.FindStringSubmatch(argSpan); tm != nil {
+			target = tm[1]
+		} else if strings.Contains(op, "index") {
+			if im := reSeaOrmIndexName.FindStringSubmatch(argSpan); im != nil {
+				target = im[1]
+				targetKind = "index"
+			}
+		}
+
+		name := "seaorm:migration:" + op
+		if target != "" {
+			name += ":" + target
+		}
+		opEnt := makeEntity(name, "SCOPE.Component", "migration",
+			file.Path, file.Language, lineOf(src, m[0]))
+		opProps := []string{
+			"framework", "seaorm",
+			"migration_op", op,
+			"provenance", "INFERRED_FROM_SEAORM_SCHEMA_MANAGER_OP",
+		}
+		if target != "" {
+			if targetKind == "index" {
+				opProps = append(opProps, "index_name", target)
+			} else {
+				opProps = append(opProps, "table_name", target)
+			}
+		}
+		setProps(&opEnt, opProps...)
+		add(opEnt)
+
+		// Columns are only meaningful for create/alter table ops.
+		if op == "create_table" || op == "alter_table" {
+			for _, cm := range reSeaOrmColumnDef.FindAllStringSubmatchIndex(argSpan, -1) {
+				colName := argSpan[cm[4]:cm[5]]
+				// Skip the table marker variant if it ever appears here.
+				if colName == "Table" {
+					continue
+				}
+				colKey := colName
+				if target != "" {
+					colKey = target + "." + colName
+				}
+				colEnt := makeEntity("seaorm:migration:column:"+colKey,
+					"SCOPE.Component", "schema_column",
+					file.Path, file.Language, lineOf(src, m[0]))
+				colProps := []string{
+					"framework", "seaorm",
+					"column_name", colName,
+					"migration_op", op,
+					"provenance", "INFERRED_FROM_SEAORM_COLUMN_DEF",
+				}
+				if target != "" {
+					colProps = append(colProps, "table_name", target)
+				}
+				setProps(&colEnt, colProps...)
+				add(colEnt)
+			}
+		}
 	}
 
 	// 4. foreign_key_extraction — belongs_to with explicit from/to column refs
@@ -331,4 +452,38 @@ func (e *rustSeaORMExtractor) Extract(ctx context.Context, file extractor.FileIn
 
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// seaOrmBalancedClose returns the index just past the byte at openIdx (which
+// must be an opening '(') up to and including its matching ')'. If the parens
+// are unbalanced (truncated source), it returns len(src). Parens inside string
+// literals are ignored. The returned index is suitable as an exclusive upper
+// bound: src[openIdx+1:seaOrmBalancedClose(src, openIdx)] is the call argument.
+func seaOrmBalancedClose(src string, openIdx int) int {
+	depth := 0
+	inStr := false
+	for i := openIdx; i < len(src); i++ {
+		c := src[i]
+		if inStr {
+			switch c {
+			case '\\':
+				i++ // skip escaped char
+			case '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return len(src)
 }

--- a/internal/custom/rust/sqlx_rbatis.go
+++ b/internal/custom/rust/sqlx_rbatis.go
@@ -111,7 +111,82 @@ var (
 
 	// struct Name (after FromRow derive)
 	reStructNameSqlx = regexp.MustCompile(`\bstruct\s+(\w+)`)
+
+	// migration_schema_ops — DDL in a sqlx `migrations/*.sql` file.
+	reSQLxCreateTable = regexp.MustCompile(
+		`(?is)CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["` + "`" + `]?(\w+)["` + "`" + `]?\s*\(`,
+	)
+	reSQLxAlterTable = regexp.MustCompile(
+		`(?is)ALTER\s+TABLE\s+["` + "`" + `]?(\w+)["` + "`" + `]?`,
+	)
+	reSQLxDropTable = regexp.MustCompile(
+		`(?is)DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?["` + "`" + `]?(\w+)["` + "`" + `]?`,
+	)
+	reSQLxReferences = regexp.MustCompile(
+		`(?i)\bREFERENCES\s+["` + "`" + `]?(\w+)["` + "`" + `]?\s*(?:\(\s*["` + "`" + `]?(\w+)["` + "`" + `]?\s*\))?`,
+	)
 )
+
+// isSqlxMigrationFile reports whether a `.sql` path looks like a sqlx
+// migration. sqlx places ordered DDL under a `migrations/` directory with a
+// numeric/timestamp prefix (migrations/0001_init.sql,
+// migrations/20230101_create_users.sql, and reversible *.up.sql/*.down.sql
+// variants). We accept any `.sql` under a `migrations/` segment. The diesel
+// extractor independently claims up.sql/down.sql; entity-name prefixes keep
+// the two framings disjoint.
+func isSqlxMigrationFile(path string) bool {
+	if !strings.HasSuffix(path, ".sql") {
+		return false
+	}
+	return strings.Contains(path, "migrations/") || strings.Contains(path, "migrations\\")
+}
+
+// extractSQLxMigration parses CREATE/ALTER/DROP TABLE (+ REFERENCES) DDL from a
+// sqlx migration .sql file, emitting one migration component per op carrying
+// migration_op + table_name, and a foreign_key pattern per REFERENCES clause.
+func (e *rustSqlxExtractor) extractSQLxMigration(src string, file extractor.FileInput, add func(types.EntityRecord)) {
+	emitOp := func(table, op, prov string, idx int) {
+		ent := makeEntity("sqlx:migration:"+op+":"+table,
+			"SCOPE.Component", "migration",
+			file.Path, "rust", lineOf(src, idx))
+		setProps(&ent,
+			"framework", "sqlx",
+			"table_name", table,
+			"migration_op", op,
+			"provenance", prov,
+		)
+		add(ent)
+	}
+	for _, m := range reSQLxCreateTable.FindAllStringSubmatchIndex(src, -1) {
+		emitOp(src[m[2]:m[3]], "create_table", "INFERRED_FROM_SQLX_SQL_CREATE_TABLE", m[0])
+	}
+	for _, m := range reSQLxAlterTable.FindAllStringSubmatchIndex(src, -1) {
+		emitOp(src[m[2]:m[3]], "alter_table", "INFERRED_FROM_SQLX_SQL_ALTER_TABLE", m[0])
+	}
+	for _, m := range reSQLxDropTable.FindAllStringSubmatchIndex(src, -1) {
+		emitOp(src[m[2]:m[3]], "drop_table", "INFERRED_FROM_SQLX_SQL_DROP_TABLE", m[0])
+	}
+	for _, m := range reSQLxReferences.FindAllStringSubmatchIndex(src, -1) {
+		refTable := src[m[2]:m[3]]
+		refCol := ""
+		if m[4] >= 0 {
+			refCol = src[m[4]:m[5]]
+		}
+		name := "sqlx:migration:fk:" + refTable
+		if refCol != "" {
+			name += "." + refCol
+		}
+		ent := makeEntity(name, "SCOPE.Pattern", "foreign_key",
+			file.Path, "rust", lineOf(src, m[0]))
+		setProps(&ent,
+			"framework", "sqlx",
+			"ref_table", refTable,
+			"ref_column", refCol,
+			"provenance", "INFERRED_FROM_SQLX_SQL_REFERENCES",
+		)
+		add(ent)
+	}
+}
 
 func (e *rustSqlxExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("archigraph/custom/rust")
@@ -138,6 +213,17 @@ func (e *rustSqlxExtractor) Extract(ctx context.Context, file extractor.FileInpu
 		}
 		seen[key] = true
 		entities = append(entities, ent)
+	}
+
+	// -----------------------------------------------------------------------
+	// 0. migration_schema_ops — sqlx `migrations/*.sql` DDL files.
+	//    These resolve at compile time from disk; parsing the DDL gives the
+	//    create/alter/drop table ops the .rs source can only reference.
+	// -----------------------------------------------------------------------
+	if isSqlxMigrationFile(file.Path) {
+		e.extractSQLxMigration(src, file, add)
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		return entities, nil
 	}
 
 	// -----------------------------------------------------------------------

--- a/internal/custom/rust/sqlx_rbatis_test.go
+++ b/internal/custom/rust/sqlx_rbatis_test.go
@@ -117,6 +117,40 @@ func TestSqlx_FixtureFile(t *testing.T) {
 	}
 }
 
+// migration_schema_ops (#5022): parse DDL from a sqlx migrations/*.sql file.
+func TestSqlx_MigrationSchemaOps(t *testing.T) {
+	src := readFixture(t, "testdata/sqlx_migration.sql")
+	ents := extract(t, "custom_rust_sqlx",
+		fi("migrations/20230101000000_create_users.sql", "rust", src))
+
+	create, ok := findEntity(ents, "SCOPE.Component", "sqlx:migration:create_table:users")
+	if !ok {
+		t.Fatal("expected sqlx:migration:create_table:users")
+	}
+	if create.Props["migration_op"] != "create_table" || create.Props["table_name"] != "users" {
+		t.Errorf("create_table props = %v", create.Props)
+	}
+	if !containsEntity(ents, "SCOPE.Component", "sqlx:migration:create_table:posts") {
+		t.Error("expected sqlx:migration:create_table:posts")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "sqlx:migration:alter_table:users") {
+		t.Error("expected sqlx:migration:alter_table:users")
+	}
+	// REFERENCES users(id) → foreign_key pattern.
+	if !containsEntity(ents, "SCOPE.Pattern", "sqlx:migration:fk:users.id") {
+		t.Error("expected sqlx:migration:fk:users.id from REFERENCES clause")
+	}
+}
+
+// A .sql file NOT under migrations/ is not treated as a sqlx migration.
+func TestSqlx_NonMigrationSQLIgnored(t *testing.T) {
+	src := `CREATE TABLE foo (id INT);`
+	ents := extract(t, "custom_rust_sqlx", fi("schema/foo.sql", "rust", src))
+	if containsEntitySubtype(ents, "SCOPE.Component", "migration") {
+		t.Error("non-migrations/ .sql must not yield sqlx migration ops")
+	}
+}
+
 func TestSqlx_NoMatch(t *testing.T) {
 	src := `
 fn main() {

--- a/internal/custom/rust/testdata/sqlx_migration.sql
+++ b/internal/custom/rust/testdata/sqlx_migration.sql
@@ -1,0 +1,13 @@
+-- sqlx migration: 20230101000000_create_users.sql
+CREATE TABLE IF NOT EXISTS users (
+    id    BIGSERIAL PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE posts (
+    id      BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    title   TEXT NOT NULL
+);
+
+ALTER TABLE users ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now();


### PR DESCRIPTION
## Built (fixture-proven)

**SeaORM** (`internal/custom/rust/seaorm.go`):
- `migration_schema_ops` (missing -> partial): parse `manager.{create,alter,drop,truncate,rename}_table` and `{create,drop}_index` calls in `MigrationTrait` `up()`/`down()` bodies via balanced-paren spans. Each becomes a `SCOPE.Component`/`migration` carrying `migration_op` + the resolved `.table(<Iden>::Table)` target (or index `.name`).
- Emit a `SCOPE.Component`/`schema_column` per `ColumnDef::new(<Iden>::<Col>)` inside create/alter ops (`table_name` + `migration_op` + `column_name`).
- `migration_parsing` (partial -> full): resolve the human migration id from the adjacent `MigrationName::name` impl (`migration_id` prop).

**sqlx** (`internal/custom/rust/sqlx_rbatis.go`):
- `migration_schema_ops` (missing -> partial): a `.sql` file under a `migrations/` directory is parsed for `CREATE`/`ALTER`/`DROP TABLE` -> migration components (`migration_op` + `table_name`) and `REFERENCES` -> `foreign_key` patterns. A `.sql` outside `migrations/` is not claimed (guard test).

## Edges / entities
Reuses existing Kinds only — `SCOPE.Component`/`migration`, `SCOPE.Component`/`schema_column`, `SCOPE.Pattern`/`foreign_key`. No new Kind, no new edge kind; all signal carried in Properties (`migration_op`, `table_name`, `column_name`, `migration_id`, `index_name`, `ref_table`/`ref_column`, `provenance`). `go test ./internal/types/` green.

## Registry cells flipped (honest)
- `lang.rust.orm.seaorm`: migration_parsing partial->full, migration_schema_ops missing->partial
- `lang.rust.orm.sqlx`: migration_schema_ops missing->partial (migration_parsing notes updated)

## Deferred (follow-ups)
- **rbatis** migration_schema_ops: https://github.com/cajasmota/archigraph/issues/5096 — rbatis uses `table_meta!`/`table_sync!`, a different shape; no fixture proof this PR so cell stays `missing`.
- SeaORM column SQL types (.integer()/.string() builder chain), not-null/default modifiers, and cross-file Iden->table-name resolution.
- sqlx column-level type parsing and up/down migration pairing/ordering.

## Fixtures
- `internal/custom/rust/testdata/seaorm_migration.rs` (existing): create_table+columns in up(), drop_table in down().
- `internal/custom/rust/testdata/sqlx_migration.sql` (new): CREATE/ALTER TABLE + REFERENCES.
- Tests: TestSeaORM_MigrationSchemaOps_FromFixture/_AlterTable/_CreateIndex; TestSqlx_MigrationSchemaOps; TestSqlx_NonMigrationSQLIgnored.

## Gates (sandbox HOME=/tmp/agsbx-5022)
go build ./..., go vet ./internal/..., go test ./internal/custom/rust/... ./internal/extractors/rust/... ./internal/types/ all green. `coverage fmt --check` ok (canonical), `coverage validate` ok. Regenerated docs/coverage committed (registry.json + by-category/orm.md + by-language/rust.md + detail/lang.rust.orm.{seaorm,sqlx}.md). Deploy-deferred.

Refs #5022