### PR TITLE
feat(#5028): nim — ormin + Debby model->table mapping

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 168 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 1 · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **nim**: 2 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
+**Total**: 170 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 1 · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -110,7 +110,9 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 7/10 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 8/11 | |
 | [nim](../by-language/nim.md) | [Allographer (Nim query/schema builder)](../detail/lang.nim.orm.allographer.md) | 🟡 3/6 | |
+| [nim](../by-language/nim.md) | [Debby (Nim ORM)](../detail/lang.nim.orm.debby.md) | 🟡 5/9 | |
 | [nim](../by-language/nim.md) | [Norm (Nim ORM)](../detail/lang.nim.orm.norm.md) | 🟡 6/9 | |
+| [nim](../by-language/nim.md) | [ormin (Nim compile-time ORM)](../detail/lang.nim.orm.ormin.md) | 🟡 4/8 | |
 | [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/4 | |
 | [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/11 | |
 | [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/11 | |

--- a/docs/coverage/by-language/nim.md
+++ b/docs/coverage/by-language/nim.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # nim
 
-**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 2 · **Other**: 1
+**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 4 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -37,7 +37,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Allographer (Nim query/schema builder)](../detail/lang.nim.orm.allographer.md) | 🟡 3/6 | |
+| [Debby (Nim ORM)](../detail/lang.nim.orm.debby.md) | 🟡 5/9 | |
 | [Norm (Nim ORM)](../detail/lang.nim.orm.norm.md) | 🟡 6/9 | |
+| [ormin (Nim compile-time ORM)](../detail/lang.nim.orm.ormin.md) | 🟡 4/8 | |
 
 
 ## Other

--- a/docs/coverage/detail/lang.nim.orm.debby.md
+++ b/docs/coverage/detail/lang.nim.orm.debby.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.nim.orm.debby` — Debby (Nim ORM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [nim](../by-language/nim.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-06-12` | 5028 | `internal/custom/nim/debby_orm.go`<br>`internal/custom/nim/extractors_test.go` | Debby maps a PLAIN Nim `object` type (NOT `ref object of Model` like Norm) to a table whose name is the type name. An object type is treated as a persisted model only when the file imports Debby AND the type is named by a Debby db op (`db.createTable/dropTable/insert/get/update/delete/query(Type, ...)`) — the registration/usage is the signal, so arbitrary Nim records are not misfired. nimDebbyObjectRe + collectDebbyObjects + collectDebbyOps emit one SCOPE.Schema/model + one SCOPE.Schema/table (table identity = type name) per registered model, framework=debby + provenance. Pre-filtered by nimDebbyHasDebby. Proven by TestNimDebbyORM_ModelTableColumns + TestNimDebbyORM_UnregisteredObjectNoop + TestNimDebbyORM_NoDebbyNoop + TestNimDebbyORM_WrongLanguageNoop. |
+| Model lifecycle extraction | 🔴 `missing` | — | 5031 | — | — |
+| Schema extraction | ✅ `full` | `2026-06-12` | 5028 | `internal/custom/nim/debby_orm.go`<br>`internal/custom/nim/extractors_test.go` | Each public object field of a registered Debby model becomes a SCOPE.Schema/column carrying column_type (Option[T]/seq[T] wrappers unwrapped to the inner type, reusing normaliseNimFieldType) and the owning model name. collectDebbyFields. Proven by TestNimDebbyORM_ModelTableColumns (id/name/email/title/author/authorId columns asserted). Honest remainder: Debby column index pragmas beyond {.fk.} are not modelled (follow-up #5031). |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | — `not_applicable` | — | — | — | Debby models relations as plain typed object fields, not a declarative association DSL — there is no association macro to extract. |
+| Foreign key extraction | 🟢 `partial` | `2026-06-12` | 5028 | `internal/custom/nim/debby_orm.go`<br>`internal/custom/nim/extractors_test.go` | A field typed as another registered Debby model yields a REFERENCES edge model->referenced-model (fk_field + to_model props) and stamps foreign_key=true / fk_target on the column; an explicit `{.fk: Other.}` pragma on a scalar field yields a REFERENCES edge (fk_pragma=true) + foreign_key column even when the field type is not itself a model. nimDebbyFkPragmaRe. Proven by TestNimDebbyORM_ModelTableColumns (author typed FK + authorId pragma FK asserted). Partial (honest): cross-file FK targets emit a REFERENCES edge to the bare type name but are not resolved to the concrete entity here — cross-file resolution is follow-up #5031. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Debby loads related rows via explicit `db.get`/`db.query` calls, not a lazy-loading proxy layer — no lazy-load annotation to recognise. |
+| Relationship extraction | 🟢 `partial` | — | 5028 | `internal/custom/nim/debby_orm.go` | Field-typed-as-model + {.fk.} relationships surface as REFERENCES edges (see foreign_key_extraction). Debby has no separate declarative association DSL, so association_extraction/lazy_loading are not_applicable; full bidirectional relationship modelling is follow-up #5031. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🟢 `partial` | — | 5028 | `internal/custom/nim/debby_orm.go`<br>`internal/custom/nim/extractors_test.go` | A `db.insert/get/update/delete/query(Model, ...)` call site whose first argument names a recognised model TYPE emits a QUERIES edge from the model entity to its table (operation/table/model props), one edge per distinct operation; createTable/dropTable are treated as schema registration, not queries. collectDebbyOps. Proven by TestNimDebbyORM_ModelTableColumns (Post insert + User get asserted). Partial (honest): only the model-typed first-argument form is attributed; a query through a lowercase instance handle (`db.insert(post)`) and raw `db.query(sql(...))` string queries are not resolved file-locally — variable-handle + raw-SQL attribution is follow-up #5031. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | 5031 | — | — |
+| Migration schema ops | 🔴 `missing` | — | 5031 | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 5031 | — | Debby `db.withTransaction:` block boundaries are not yet stamped — transaction-boundary extraction (mirroring the Norm db.transaction: shape) is follow-up #5031. This record covers model->table/column mapping + FK + query attribution only. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.nim.orm.debby ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.nim.orm.ormin.md
+++ b/docs/coverage/detail/lang.nim.orm.ormin.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.nim.orm.ormin` — ormin (Nim compile-time ORM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [nim](../by-language/nim.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | 🟢 `partial` | `2026-06-12` | 5028 | `internal/custom/nim/extractors_test.go`<br>`internal/custom/nim/ormin_orm.go` | ormin is a COMPILE-TIME ORM: the schema is NOT Nim object types — a Nim model module binds an external SQL DSL file via `importModel(DbBackend.<be>, "model")`. The Nim-side binding is recorded as a SCOPE.Schema/model_import entity (framework=ormin) stamping backend + model_file (nimOrminImportRe). The model->table mapping itself is delivered by schema_extraction from the SQL DSL file. Proven by TestNimOrminORM_ImportModel. Partial (honest): there is no Nim `ref object` model layer to map (the SQL DSL IS the model), so model_import is the binding signal, not a per-type model entity — model entities are not_applicable on the Nim side. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | ormin generates typed query bindings at compile time; there is no per-instance active-record lifecycle (save/delete on a model object) to extract. |
+| Schema extraction | ✅ `full` | `2026-06-12` | 5028 | `internal/custom/nim/extractors_test.go`<br>`internal/custom/nim/ormin_orm.go` | The ormin model DSL is a `*.sql` file of `create table T(...)` DDL parsed at compile time. This extractor parses that DDL into one SCOPE.Schema/table per `create table T(` (orminCreateTableRe + paren-matched body) and one SCOPE.Schema/column per column definition (top-level-comma split, table-level constraint keywords filtered), framework=ormin, column_type = the SQL type, with primary_key=true / not_null=true stamped when present. Proven by TestNimOrminORM_SQLSchema (User/Post tables, name string not_null, id primary_key asserted) + TestNimOrminORM_NonSQLNoop. Honest remainder: the ormin query DSL (`query: select ... from ...`) attribution is follow-up #5031. |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | — `not_applicable` | — | — | — | ormin has no declarative association DSL — relations are expressed only as inline `references Other(col)` foreign-key column constraints in the SQL DSL (see foreign_key_extraction). |
+| Foreign key extraction | 🟢 `partial` | — | 5028 | `internal/custom/nim/extractors_test.go`<br>`internal/custom/nim/ormin_orm.go` | An inline column-level `<col> ... references Other(col)` foreign key in the SQL DSL yields a REFERENCES edge table->referenced-table (fk_field + to_table + references props) and stamps foreign_key=true / fk_target / fk_column on the column. orminRefRe. Proven by TestNimOrminORM_SQLSchema (Post.author -> User.id asserted). Partial (honest): table-level `foreign key (...) references ...(...)` constraint syntax and composite keys are follow-up #5031; cross-file targets resolve via the shared resolver. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | ormin loads related rows via explicit generated query bindings, not a lazy-loading proxy layer — no lazy-load annotation to recognise. |
+| Relationship extraction | 🟢 `partial` | — | 5028 | `internal/custom/nim/ormin_orm.go` | Foreign-key relationships surface as REFERENCES edges (see foreign_key_extraction). ormin has no separate declarative association DSL, so association_extraction/lazy_loading are not_applicable; bidirectional relationship modelling beyond the FK edge is follow-up #5031. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🔴 `missing` | — | 5031 | — | The ormin compile-time query DSL (`query: select id from User`) is not yet attributed to its table — query-DSL attribution is deferred to follow-up #5031. This record covers model->table/column mapping only. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | 5031 | — | — |
+| Migration schema ops | 🔴 `missing` | — | 5031 | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 5031 | — | ormin transaction blocks are not yet stamped — transaction-boundary extraction is follow-up #5031. This record covers model->table/column mapping only. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.nim.orm.ormin ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 168 · **Tools**: 120 · **Other**: 199
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 199
 
 ## Coverage by language
 
@@ -27,7 +27,7 @@
 | [erlang](by-language/erlang.md) | 1 | 0 | 0 | 2 |
 | [F#](by-language/fsharp.md) | 1 | 1 | 0 | 1 |
 | [groovy](by-language/groovy.md) | 1 | 1 | 0 | 1 |
-| [nim](by-language/nim.md) | 1 | 0 | 2 | 1 |
+| [nim](by-language/nim.md) | 1 | 0 | 4 | 1 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 5 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 5 |
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 246 frameworks · 120 tools · 168 ORMs · 199 other
+Total: 246 frameworks · 120 tools · 170 ORMs · 199 other

--- a/internal/custom/nim/debby_orm.go
+++ b/internal/custom/nim/debby_orm.go
@@ -1,0 +1,334 @@
+// debby_orm.go — Nim Debby ORM model → table/column schema synthesis (#5028).
+//
+// Debby (https://github.com/guzba/debby) is a Nim ORM in which a persisted model
+// is a PLAIN Nim `object` (NOT a `ref object of Model` like Norm — #4904). Debby
+// maps the object type to a table whose name is, by default, the type name; each
+// public object field becomes a column. The model is registered/created against a
+// Debby db handle (`db.createTable(User)` / `db.dropTable(User)`), and a field
+// typed as another Debby model (or carrying an `{.fk: Other.}` pragma) is a
+// foreign key to that model.
+//
+// Debby model shape:
+//
+//	import debby/sqlite
+//
+//	type
+//	  User = object
+//	    id: int
+//	    name: string
+//	    email: string
+//
+//	  Post = object
+//	    id: int
+//	    title: string
+//	    user: User            # FK → User (field typed as another model)
+//	    userId {.fk: User.}: int  # explicit FK pragma on a scalar field
+//
+//	db.createTable(User)
+//	db.createTable(Post)
+//
+// Because a plain `object` is too generic to scan blindly, this extractor only
+// treats an object type as a Debby model when the file imports Debby AND the type
+// is referenced by a Debby db operation (createTable/dropTable/insert/get/
+// update/delete/query) — the registration is the signal that the object is a
+// persisted model. This keeps us from misfiring on arbitrary Nim records.
+//
+// What this extractor emits (mirrors the Norm/Allographer SCOPE.Schema shape,
+// framework=debby):
+//   - one SCOPE.Schema/model per registered Debby `object` type
+//   - one SCOPE.Schema/table per model (table identity = the model type name)
+//   - one SCOPE.Schema/column per public object field, with column_type stamped
+//   - a REFERENCES edge model → referenced model for a field typed as another
+//     registered model, or an explicit `{.fk: Other.}` pragma
+//   - QUERIES edges model → its table for db.<op>(Model[, …]) call sites
+//     (insert/get/update/delete/query), one edge per attributed operation
+//
+// Honest exclusions / follow-ups (no fabricated schema; #5031):
+//   - cross-file FK targets carry the bare type name on the REFERENCES edge and
+//     resolve via the shared resolver.
+//   - Debby index pragmas, withTransaction transaction boundaries, and raw-SQL
+//     `db.query(sql(...))` attribution are follow-ups (#5031).
+//   - ormin (the other #5028 ORM) is covered by ormin_orm.go.
+//
+// Registration key: "custom_nim_debby_orm".
+package nim
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_nim_debby_orm", &nimDebbyORMExtractor{})
+}
+
+type nimDebbyORMExtractor struct{}
+
+func (e *nimDebbyORMExtractor) Language() string { return "custom_nim_debby_orm" }
+
+var (
+	// nimDebbyObjectRe matches a plain object type declaration:
+	// `User = object`, `Post* = object`. Capture group 1 is the type name
+	// (export marker stripped). Deliberately NOT `ref object of Model` — Debby
+	// uses plain objects, so this is the distinguishing shape from Norm.
+	nimDebbyObjectRe = regexp.MustCompile(
+		`(?m)^[ \t]*([A-Z][A-Za-z0-9_]*)\*?\s*=\s*object\b`)
+
+	// nimDebbyFieldRe matches an object field inside a model body, optionally
+	// carrying a field pragma block (`{.fk: User.}`). Group 1 is the field name,
+	// group 2 the optional pragma body, group 3 the field type.
+	nimDebbyFieldRe = regexp.MustCompile(
+		`(?m)^[ \t]+([a-z_][A-Za-z0-9_]*)\*?\s*(?:\{\.([^}]*?)\.?\})?\s*:\s*([A-Za-z_][A-Za-z0-9_\[\], ]*)`)
+
+	// nimDebbyFkPragmaRe extracts an explicit FK target from a field pragma
+	// (`fk: Other`).
+	nimDebbyFkPragmaRe = regexp.MustCompile(`\bfk\s*:\s*([A-Z][A-Za-z0-9_]*)`)
+
+	// nimDebbyRegisterRe matches a Debby db operation that names a model TYPE as
+	// its first argument — the registration/usage signal that the object is a
+	// persisted model. Group 1 is the operation, group 2 the model type name.
+	// Covers createTable/dropTable (registration) and insert/get/update/delete/
+	// query (usage), all of which take the model type or instance.
+	nimDebbyRegisterRe = regexp.MustCompile(
+		`(?m)\b[A-Za-z_][A-Za-z0-9_]*\s*\.\s*(createTable|dropTable|insert|get|update|delete|query)\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+)
+
+// nimDebbyHasDebby is a fast pre-filter: the file must import/reference Debby and
+// perform a Debby db operation, so we never misfire on arbitrary Nim objects.
+func nimDebbyHasDebby(content string) bool {
+	return strings.Contains(content, "debby") &&
+		nimDebbyRegisterRe.MatchString(content)
+}
+
+func (e *nimDebbyORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "nim" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !nimDebbyHasDebby(src) {
+		return nil, nil
+	}
+
+	// registered maps a type name → the set of operations attributed to it.
+	registered := collectDebbyOps(src)
+	if len(registered) == 0 {
+		return nil, nil
+	}
+
+	objects := collectDebbyObjects(src)
+	// Only objects that are registered/used as Debby models are persisted models.
+	var models []debbyModel
+	modelNames := make(map[string]bool)
+	for _, o := range objects {
+		if registered[o.name] != nil {
+			models = append(models, o)
+			modelNames[o.name] = true
+		}
+	}
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	for _, m := range models {
+		// 1. model entity
+		model := newDebbySchema(m.name, "model", file.Path, m.line,
+			"INFERRED_FROM_DEBBY_MODEL")
+		var rels []types.RelationshipRecord
+		// FK edges → referenced models.
+		for _, f := range m.fields {
+			target := ""
+			switch {
+			case f.fkTarget != "" && f.fkTarget != m.name:
+				target = f.fkTarget
+			case modelNames[f.typ] && f.typ != m.name:
+				target = f.typ
+			}
+			if target == "" {
+				continue
+			}
+			props := map[string]string{"fk_field": f.name, "to_model": target}
+			if f.fkTarget != "" {
+				props["fk_pragma"] = "true"
+			}
+			rels = append(rels, types.RelationshipRecord{
+				ToID: target, Kind: "REFERENCES", Properties: props,
+			})
+		}
+		// Query attribution: model → its table, one edge per attributed op.
+		for _, op := range debbyOpOrder(registered[m.name]) {
+			if op == "createTable" || op == "dropTable" {
+				continue // schema registration, not a query
+			}
+			rels = append(rels, types.RelationshipRecord{
+				ToID: m.name,
+				Kind: "QUERIES",
+				Properties: map[string]string{
+					"operation": op,
+					"table":     m.name,
+					"model":     m.name,
+				},
+			})
+		}
+		model.Relationships = rels
+		model.ID = model.ComputeID()
+		out = append(out, model)
+
+		// 2. table entity (identity = model type name).
+		table := newDebbySchema(m.name, "table", file.Path, m.line,
+			"INFERRED_FROM_DEBBY_TABLE")
+		table.Properties["model"] = m.name
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 3. column entities (one per public object field).
+		colSeen := make(map[string]bool)
+		for _, f := range m.fields {
+			if colSeen[f.name] {
+				continue
+			}
+			colSeen[f.name] = true
+			col := newDebbySchema(f.name, "column", file.Path, f.line,
+				"INFERRED_FROM_DEBBY_FIELD")
+			col.Properties["column_type"] = f.typ
+			col.Properties["model"] = m.name
+			fkTarget := f.fkTarget
+			if fkTarget == "" && modelNames[f.typ] && f.typ != m.name {
+				fkTarget = f.typ
+			}
+			if fkTarget != "" && fkTarget != m.name {
+				col.Properties["foreign_key"] = "true"
+				col.Properties["fk_target"] = fkTarget
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+	}
+	return out, nil
+}
+
+// collectDebbyOps scans db.<op>(Type, …) call sites and returns, per type name,
+// the set of operations attributed to it. Only first arguments that name a
+// recognised TYPE (capitalised identifier) are attributed — instance handles
+// (lowercase) are not, keeping attribution file-local + honest.
+func collectDebbyOps(src string) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, m := range nimDebbyRegisterRe.FindAllStringSubmatch(src, -1) {
+		op, arg := m[1], m[2]
+		if arg == "" || arg[0] < 'A' || arg[0] > 'Z' {
+			continue // not a type name
+		}
+		if out[arg] == nil {
+			out[arg] = map[string]bool{}
+		}
+		out[arg][op] = true
+	}
+	return out
+}
+
+// debbyOpOrder returns the operations in a stable order for deterministic edge
+// emission.
+func debbyOpOrder(ops map[string]bool) []string {
+	var out []string
+	for _, op := range []string{"createTable", "dropTable", "insert", "get", "update", "delete", "query"} {
+		if ops[op] {
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
+// debbyModel is a parsed Debby model with its fields.
+type debbyModel struct {
+	name   string
+	line   int
+	fields []debbyField
+}
+
+type debbyField struct {
+	name     string
+	typ      string
+	fkTarget string // {.fk: Other.}
+	line     int
+}
+
+// collectDebbyObjects finds every `T = object` declaration and the fields in its
+// indented body (reusing the shared leadingIndent/lineAt helpers from
+// norm_orm.go).
+func collectDebbyObjects(src string) []debbyModel {
+	idx := nimDebbyObjectRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	lines := strings.Split(src, "\n")
+	var models []debbyModel
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		objIndent := leadingIndent(lineAt(lines, startLine))
+		fields := collectDebbyFields(lines, startLine, objIndent)
+		models = append(models, debbyModel{name: name, line: startLine, fields: fields})
+	}
+	return models
+}
+
+// collectDebbyFields scans the indented body following an object header for
+// fields. A field line is more indented than the object header; the body ends at
+// the first non-blank line indented at or below the object header.
+func collectDebbyFields(lines []string, headerLine, objIndent int) []debbyField {
+	var fields []debbyField
+	seen := make(map[string]bool)
+	for ln := headerLine + 1; ln <= len(lines); ln++ {
+		raw := lineAt(lines, ln)
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		if leadingIndent(raw) <= objIndent {
+			break // dedent — object body ended
+		}
+		fm := nimDebbyFieldRe.FindStringSubmatch(raw)
+		if fm == nil {
+			continue
+		}
+		fname := fm[1]
+		pragma := fm[2]
+		ftyp := normaliseNimFieldType(fm[3])
+		if ftyp == "" || seen[fname] {
+			continue
+		}
+		seen[fname] = true
+		f := debbyField{name: fname, typ: ftyp, line: ln}
+		if pragma != "" {
+			if km := nimDebbyFkPragmaRe.FindStringSubmatch(pragma); km != nil {
+				f.fkTarget = km[1]
+			}
+		}
+		fields = append(fields, f)
+	}
+	return fields
+}
+
+// newDebbySchema builds a SCOPE.Schema entity with framework=debby and the given
+// provenance stamp.
+func newDebbySchema(name, subtype, path string, line int, provenance string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       name,
+		Kind:       "SCOPE.Schema",
+		Subtype:    subtype,
+		SourceFile: path,
+		Language:   "nim",
+		StartLine:  line,
+		EndLine:    line,
+		Properties: map[string]string{
+			"framework":  "debby",
+			"provenance": provenance,
+		},
+	}
+}

--- a/internal/custom/nim/extractors_test.go
+++ b/internal/custom/nim/extractors_test.go
@@ -454,6 +454,284 @@ type recView struct {
 	rels            []types.RelationshipRecord
 }
 
+func viewsOf(ents []types.EntityRecord) []recView {
+	views := make([]recView, len(ents))
+	for i, en := range ents {
+		views[i] = recView{en.Name, en.Subtype, en.Kind, en.Properties, en.Relationships}
+	}
+	return views
+}
+
+func pickView(views []recView, name, sub string) *recView {
+	for i := range views {
+		if views[i].name == name && views[i].sub == sub {
+			return &views[i]
+		}
+	}
+	return nil
+}
+
+// --- Debby ORM (#5028) ------------------------------------------------------
+
+// TestNimDebbyORM_ModelTableColumns proves a plain Debby `object` registered via
+// a Debby db op synthesises model + table + column SCOPE.Schema entities
+// (framework=debby), an FK edge for a field typed as another registered model and
+// for an explicit {.fk.} pragma, and QUERIES edges for insert/get usage.
+func TestNimDebbyORM_ModelTableColumns(t *testing.T) {
+	src := `
+import debby/sqlite
+
+type
+  User = object
+    id: int
+    name: string
+    email: string
+
+  Post = object
+    id: int
+    title: string
+    author: User
+    authorId {.fk: User.}: int
+
+db.createTable(User)
+db.createTable(Post)
+discard db.insert(Post)
+discard db.get(User, 1)
+`
+	e, ok := extreg.Get("custom_nim_debby_orm")
+	if !ok {
+		t.Fatal("custom_nim_debby_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("src/models.nim", "nim", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	views := viewsOf(ents)
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+		}
+		if en.Properties["framework"] != "debby" {
+			t.Errorf("entity %q missing framework=debby", en.Name)
+		}
+	}
+
+	for _, m := range []string{"User", "Post"} {
+		if pickView(views, m, "model") == nil {
+			t.Errorf("expected SCOPE.Schema/model %q", m)
+		}
+		if pickView(views, m, "table") == nil {
+			t.Errorf("expected SCOPE.Schema/table %q", m)
+		}
+	}
+	for _, c := range []string{"id", "name", "email", "title", "author", "authorId"} {
+		if pickView(views, c, "column") == nil {
+			t.Errorf("expected SCOPE.Schema/column %q", c)
+		}
+	}
+
+	// FK edge for the model-typed field author -> User.
+	post := pickView(views, "Post", "model")
+	if post == nil {
+		t.Fatal("missing Post model")
+	}
+	fkTyped, fkPragma, postInsert := false, false, false
+	for _, r := range post.rels {
+		if r.Kind == "REFERENCES" && r.ToID == "User" && r.Properties["fk_field"] == "author" {
+			fkTyped = true
+		}
+		if r.Kind == "REFERENCES" && r.ToID == "User" && r.Properties["fk_field"] == "authorId" && r.Properties["fk_pragma"] == "true" {
+			fkPragma = true
+		}
+		if r.Kind == "QUERIES" && r.Properties["operation"] == "insert" {
+			postInsert = true
+		}
+	}
+	if !fkTyped {
+		t.Error("expected REFERENCES Post->User (fk_field=author)")
+	}
+	if !fkPragma {
+		t.Error("expected REFERENCES Post->User (fk_field=authorId, fk_pragma=true)")
+	}
+	if !postInsert {
+		t.Error("expected Post QUERIES insert")
+	}
+
+	// author column stamped foreign_key.
+	if c := pickView(views, "author", "column"); c == nil || c.props["foreign_key"] != "true" || c.props["fk_target"] != "User" {
+		t.Error("expected author column foreign_key=true fk_target=User")
+	}
+
+	// User got a get query edge.
+	user := pickView(views, "User", "model")
+	userGet := false
+	if user != nil {
+		for _, r := range user.rels {
+			if r.Kind == "QUERIES" && r.Properties["operation"] == "get" {
+				userGet = true
+			}
+		}
+	}
+	if !userGet {
+		t.Error("expected User QUERIES get")
+	}
+}
+
+// TestNimDebbyORM_UnregisteredObjectNoop proves a plain object that is never
+// registered/used with a Debby db op is NOT treated as a model.
+func TestNimDebbyORM_UnregisteredObjectNoop(t *testing.T) {
+	src := `
+import debby/sqlite
+
+type
+  User = object
+    id: int
+    name: string
+
+  Config = object
+    host: string
+
+db.createTable(User)
+`
+	e, _ := extreg.Get("custom_nim_debby_orm")
+	ents, _ := e.Extract(context.Background(), fi("src/models.nim", "nim", src))
+	for _, en := range ents {
+		if en.Name == "Config" {
+			t.Error("expected unregistered Config object to be ignored")
+		}
+	}
+	if pickView(viewsOf(ents), "User", "model") == nil {
+		t.Error("expected registered User to be a model")
+	}
+}
+
+// TestNimDebbyORM_NoDebbyNoop proves a file without Debby is ignored.
+func TestNimDebbyORM_NoDebbyNoop(t *testing.T) {
+	src := `
+type User = object
+  id: int
+`
+	e, _ := extreg.Get("custom_nim_debby_orm")
+	ents, _ := e.Extract(context.Background(), fi("src/models.nim", "nim", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for a non-Debby file, got %d", len(ents))
+	}
+}
+
+// TestNimDebbyORM_WrongLanguageNoop gates on language=="nim".
+func TestNimDebbyORM_WrongLanguageNoop(t *testing.T) {
+	src := `import debby/sqlite
+type User = object
+  id: int
+db.createTable(User)`
+	e, _ := extreg.Get("custom_nim_debby_orm")
+	ents, _ := e.Extract(context.Background(), fi("src/models.nim", "go", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-nim language, got %d", len(ents))
+	}
+}
+
+// --- ormin ORM (#5028) ------------------------------------------------------
+
+// TestNimOrminORM_ImportModel proves a Nim `importModel(DbBackend.x, "file")`
+// call yields a SCOPE.Schema/model_import entity stamping backend + model_file.
+func TestNimOrminORM_ImportModel(t *testing.T) {
+	src := `
+import ormin
+
+importModel(DbBackend.postgre, "model")
+`
+	e, ok := extreg.Get("custom_nim_ormin_orm")
+	if !ok {
+		t.Fatal("custom_nim_ormin_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("src/db.nim", "nim", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	imp := pickView(viewsOf(ents), "model", "model_import")
+	if imp == nil {
+		t.Fatal("expected SCOPE.Schema/model_import keyed by model file")
+	}
+	if imp.props["framework"] != "ormin" || imp.props["backend"] != "postgre" || imp.props["model_file"] != "model" {
+		t.Errorf("expected model_import framework=ormin backend=postgre model_file=model, got %+v", imp.props)
+	}
+}
+
+// TestNimOrminORM_SQLSchema proves an ormin SQL DSL `create table` file
+// synthesises table + column entities (framework=ormin), stamps column_type,
+// primary_key / not_null, and yields a REFERENCES edge for an inline
+// `references Other(col)` foreign key.
+func TestNimOrminORM_SQLSchema(t *testing.T) {
+	src := `
+create table User(
+  id integer primary key,
+  name string not null,
+  email string not null
+);
+
+create table Post(
+  id integer primary key,
+  title string not null,
+  author integer references User(id)
+);
+`
+	e, _ := extreg.Get("custom_nim_ormin_orm")
+	ents, err := e.Extract(context.Background(), fi("model.sql", "sql", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	views := viewsOf(ents)
+	for _, en := range ents {
+		if en.Properties["framework"] != "ormin" {
+			t.Errorf("entity %q missing framework=ormin", en.Name)
+		}
+	}
+	for _, tbl := range []string{"User", "Post"} {
+		if pickView(views, tbl, "table") == nil {
+			t.Errorf("expected SCOPE.Schema/table %q", tbl)
+		}
+	}
+	if c := pickView(views, "name", "column"); c == nil || c.props["column_type"] != "string" || c.props["table"] != "User" || c.props["not_null"] != "true" {
+		t.Errorf("expected name column column_type=string not_null=true table=User, got %+v", c)
+	}
+	if c := pickView(views, "id", "column"); c == nil || c.props["primary_key"] != "true" {
+		t.Error("expected id column primary_key=true")
+	}
+	// FK column + edge.
+	fkCol := pickView(views, "author", "column")
+	if fkCol == nil || fkCol.props["foreign_key"] != "true" || fkCol.props["fk_target"] != "User" || fkCol.props["fk_column"] != "id" {
+		t.Errorf("expected author column foreign_key=true fk_target=User fk_column=id, got %+v", fkCol)
+	}
+	fkEdge := false
+	if pt := pickView(views, "Post", "table"); pt != nil {
+		for _, r := range pt.rels {
+			if r.Kind == "REFERENCES" && r.ToID == "User" && r.Properties["fk_field"] == "author" && r.Properties["references"] == "id" {
+				fkEdge = true
+			}
+		}
+	}
+	if !fkEdge {
+		t.Error("expected REFERENCES edge Post->User (fk_field=author, references=id)")
+	}
+}
+
+// TestNimOrminORM_NonSQLNoop proves a non-.sql file without importModel is
+// ignored, and a plain Nim file without ormin is ignored.
+func TestNimOrminORM_NonSQLNoop(t *testing.T) {
+	e, _ := extreg.Get("custom_nim_ormin_orm")
+	// A .sql file with no create table.
+	ents, _ := e.Extract(context.Background(), fi("data.sql", "sql", "select 1;"))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for a non-DDL sql file, got %d", len(ents))
+	}
+	// A Nim file with no ormin import.
+	ents2, _ := e.Extract(context.Background(), fi("src/x.nim", "nim", "echo \"hi\""))
+	if len(ents2) != 0 {
+		t.Fatalf("expected no entities for a non-ormin nim file, got %d", len(ents2))
+	}
+}
+
 // TestNimNormORM_OptionWrappedFK proves an Option[Model]/seq[Model] field is
 // unwrapped and recognised as a foreign key.
 func TestNimNormORM_OptionWrappedFK(t *testing.T) {

--- a/internal/custom/nim/ormin_orm.go
+++ b/internal/custom/nim/ormin_orm.go
@@ -1,0 +1,358 @@
+// ormin_orm.go — Nim ormin compile-time ORM model → table/column synthesis (#5028).
+//
+// ormin (https://github.com/Araq/ormin) is a COMPILE-TIME Nim ORM: the schema is
+// NOT declared as Nim object types. Instead a model module imports an external
+// SQL DSL file at compile time:
+//
+//	import ormin
+//	importModel(DbBackend.postgre, "model")   # loads model.sql at compile time
+//
+// and the schema itself lives in that SQL DSL file (`model.sql`), which is a set
+// of `create table` DDL statements ormin parses to generate typed query bindings:
+//
+//	create table User(
+//	  id integer primary key,
+//	  name string not null,
+//	  email string not null
+//	);
+//
+//	create table Post(
+//	  id integer primary key,
+//	  title string not null,
+//	  author integer references User(id)
+//	);
+//
+// So unlike Norm/Debby (Nim object scanning) and Allographer (a Nim schema
+// builder), ormin's model→table mapping requires SQL-DSL parsing. This extractor
+// covers the two surfaces ormin presents in a Nim project:
+//
+//  1. The Nim side: an `importModel(DbBackend.<be>, "model")` call is recorded as
+//     a SCOPE.Schema/model_import entity (framework=ormin) stamping the backend
+//     and the referenced model-file name — this is the binding signal that the
+//     repo uses ormin and which DSL file holds its schema.
+//  2. The SQL DSL side: a `*.sql` file is parsed for `create table T(...)`
+//     statements, each yielding a SCOPE.Schema/table + one SCOPE.Schema/column per
+//     column definition (column_type = the SQL type), with `<col> references
+//     Other(col)` foreign keys yielding a REFERENCES edge table → referenced table
+//     and stamping foreign_key on the column.
+//
+// What this extractor emits (framework=ormin, SCOPE.Schema shape):
+//   - one SCOPE.Schema/model_import per `importModel(DbBackend.<be>, "file")` (Nim)
+//   - one SCOPE.Schema/table per `create table T(...)` (SQL DSL)
+//   - one SCOPE.Schema/column per column definition, column_type = SQL type,
+//     primary_key=true / not_null=true stamped when present
+//   - a REFERENCES edge table → referenced table for a column
+//     `references Other(col)` foreign key
+//
+// Honest exclusions / follow-ups (no fabricated schema; #5031):
+//   - ormin query DSL attribution (`query: select id from User`) is a follow-up
+//     (#5031) — this record covers model→table/column mapping only.
+//   - table-level `foreign key (...) references ...(...)` constraint syntax and
+//     composite keys beyond the inline column-level `references` form are a
+//     follow-up (#5031).
+//   - Debby (the other #5028 ORM) is covered by debby_orm.go.
+//
+// Registration key: "custom_nim_ormin_orm".
+package nim
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_nim_ormin_orm", &nimOrminORMExtractor{})
+}
+
+type nimOrminORMExtractor struct{}
+
+func (e *nimOrminORMExtractor) Language() string { return "custom_nim_ormin_orm" }
+
+var (
+	// nimOrminImportRe matches the Nim-side `importModel(DbBackend.<be>, "file")`
+	// binding. Group 1 is the backend (sqlite/postgre/…), group 2 the referenced
+	// model-file base name (the `.sql` DSL file).
+	nimOrminImportRe = regexp.MustCompile(
+		`\bimportModel\s*\(\s*DbBackend\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*"([^"]+)"`)
+
+	// orminCreateTableRe matches a `create table T(` DDL header in the SQL DSL.
+	// Group 1 is the table name.
+	orminCreateTableRe = regexp.MustCompile(
+		`(?i)\bcreate\s+table\s+(?:if\s+not\s+exists\s+)?"?([A-Za-z_][A-Za-z0-9_]*)"?\s*\(`)
+)
+
+// nimOrminHasImport / orminSQLHasCreate are the per-surface pre-filters.
+func nimOrminHasImport(content string) bool {
+	return strings.Contains(content, "importModel") && strings.Contains(content, "DbBackend")
+}
+
+func orminSQLHasCreate(content string) bool {
+	lc := strings.ToLower(content)
+	return strings.Contains(lc, "create table")
+}
+
+func (e *nimOrminORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// Nim side: importModel(...) binding.
+	if file.Language == "nim" {
+		if !nimOrminHasImport(src) {
+			return nil, nil
+		}
+		return e.extractNimImport(src, file.Path), nil
+	}
+
+	// SQL DSL side: ormin model files are `.sql`. We parse create-table DDL only
+	// for files that look like an ormin model DSL (a `create table` is present).
+	// The indexer surfaces sql files with language "sql"; gate on the suffix too
+	// so we don't claim arbitrary SQL.
+	if strings.HasSuffix(strings.ToLower(file.Path), ".sql") && orminSQLHasCreate(src) {
+		return e.extractSQLSchema(src, file.Path), nil
+	}
+	return nil, nil
+}
+
+// extractNimImport emits a SCOPE.Schema/model_import per importModel(...) call.
+func (e *nimOrminORMExtractor) extractNimImport(src, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, m := range nimOrminImportRe.FindAllStringSubmatchIndex(src, -1) {
+		backend := src[m[2]:m[3]]
+		modelFile := src[m[4]:m[5]]
+		line := strings.Count(src[:m[0]], "\n") + 1
+		ent := newOrminSchema(modelFile, "model_import", path, line,
+			"INFERRED_FROM_ORMIN_IMPORT")
+		ent.Properties["backend"] = backend
+		ent.Properties["model_file"] = modelFile
+		ent.ID = ent.ComputeID()
+		out = append(out, ent)
+	}
+	return out
+}
+
+// extractSQLSchema parses `create table T(...)` DDL into table + column entities.
+func (e *nimOrminORMExtractor) extractSQLSchema(src, path string) []types.EntityRecord {
+	tables := collectOrminTables(src)
+	if len(tables) == 0 {
+		return nil
+	}
+	var out []types.EntityRecord
+	for _, t := range tables {
+		table := newOrminSchema(t.name, "table", path, t.line, "INFERRED_FROM_ORMIN_TABLE")
+		var rels []types.RelationshipRecord
+		for _, c := range t.columns {
+			if c.fkTable != "" && c.fkTable != t.name {
+				props := map[string]string{"fk_field": c.name, "to_table": c.fkTable}
+				if c.fkColumn != "" {
+					props["references"] = c.fkColumn
+				}
+				rels = append(rels, types.RelationshipRecord{
+					ToID: c.fkTable, Kind: "REFERENCES", Properties: props,
+				})
+			}
+		}
+		table.Relationships = rels
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		colSeen := make(map[string]bool)
+		for _, c := range t.columns {
+			if colSeen[c.name] {
+				continue
+			}
+			colSeen[c.name] = true
+			col := newOrminSchema(c.name, "column", path, c.line, "INFERRED_FROM_ORMIN_COLUMN")
+			col.Properties["column_type"] = c.typ
+			col.Properties["table"] = t.name
+			if c.primaryKey {
+				col.Properties["primary_key"] = "true"
+			}
+			if c.notNull {
+				col.Properties["not_null"] = "true"
+			}
+			if c.fkTable != "" && c.fkTable != t.name {
+				col.Properties["foreign_key"] = "true"
+				col.Properties["fk_target"] = c.fkTable
+				if c.fkColumn != "" {
+					col.Properties["fk_column"] = c.fkColumn
+				}
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+	}
+	return out
+}
+
+type orminTable struct {
+	name    string
+	line    int
+	columns []orminColumn
+}
+
+type orminColumn struct {
+	name       string
+	typ        string
+	primaryKey bool
+	notNull    bool
+	fkTable    string
+	fkColumn   string
+	line       int
+}
+
+var (
+	// orminColLineRe matches a single column definition line inside a create-table
+	// body: `name type ...`. Group 1 is the column name, group 2 the SQL type.
+	// Reserved table-level constraint keywords (primary/foreign/unique/constraint
+	// /check) are filtered out by the caller.
+	orminColLineRe = regexp.MustCompile(
+		`^\s*"?([A-Za-z_][A-Za-z0-9_]*)"?\s+([A-Za-z_][A-Za-z0-9_]*)`)
+
+	// orminRefRe extracts an inline column-level FK: `references Other(col)` /
+	// `references Other (col)` / `references Other`. Group 1 is the referenced
+	// table, group 2 the optional referenced column.
+	orminRefRe = regexp.MustCompile(
+		`(?i)\breferences\s+"?([A-Za-z_][A-Za-z0-9_]*)"?\s*(?:\(\s*"?([A-Za-z_][A-Za-z0-9_]*)"?\s*\))?`)
+)
+
+// orminReserved is the set of column-line leading tokens that are table-level
+// constraints, not real columns.
+var orminReserved = map[string]bool{
+	"primary": true, "foreign": true, "unique": true,
+	"constraint": true, "check": true, "index": true,
+}
+
+// collectOrminTables parses every `create table T( ... )` block by scanning from
+// the header `(` to the matching `)` at paren depth 0, then splitting the body on
+// top-level commas into column definitions.
+func collectOrminTables(src string) []orminTable {
+	idx := orminCreateTableRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	var tables []orminTable
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		headerLine := strings.Count(src[:m[0]], "\n") + 1
+		// Body begins right after the matched `(` (m[1] is end of full match).
+		bodyStart := m[1]
+		body, _ := orminParenBody(src[bodyStart-1:]) // include the `(`
+		cols := collectOrminColumns(body, headerLine)
+		tables = append(tables, orminTable{name: name, line: headerLine, columns: cols})
+	}
+	return tables
+}
+
+// orminParenBody returns the content between the first `(` and its matching `)`
+// (exclusive), and the number of bytes consumed including both parens.
+func orminParenBody(s string) (string, int) {
+	start := strings.IndexByte(s, '(')
+	if start < 0 {
+		return "", 0
+	}
+	depth := 0
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return s[start+1 : i], i + 1
+			}
+		}
+	}
+	return s[start+1:], len(s)
+}
+
+// collectOrminColumns splits a create-table body on top-level commas and parses
+// each segment as a column definition. lineBase is the table header line; the
+// segment's offset within the body gives its relative line.
+func collectOrminColumns(body string, lineBase int) []orminColumn {
+	var cols []orminColumn
+	segs := splitTopLevelCommas(body)
+	off := 0
+	for _, seg := range segs {
+		segOff := off
+		off += len(seg) + 1 // +1 for the comma
+		trimmed := strings.TrimSpace(seg)
+		if trimmed == "" {
+			continue
+		}
+		// Skip table-level constraints.
+		lead := strings.ToLower(strings.Fields(trimmed)[0])
+		if orminReserved[lead] {
+			continue
+		}
+		cm := orminColLineRe.FindStringSubmatch(trimmed)
+		if cm == nil {
+			continue
+		}
+		name, typ := cm[1], strings.ToLower(cm[2])
+		lc := strings.ToLower(seg)
+		// Line: count newlines from body start up to this segment's offset.
+		line := lineBase + strings.Count(body[:segOff], "\n")
+		c := orminColumn{name: name, typ: typ, line: line}
+		if strings.Contains(lc, "primary key") {
+			c.primaryKey = true
+		}
+		if strings.Contains(lc, "not null") {
+			c.notNull = true
+		}
+		if rm := orminRefRe.FindStringSubmatch(seg); rm != nil {
+			c.fkTable = rm[1]
+			c.fkColumn = rm[2]
+		}
+		cols = append(cols, c)
+	}
+	return cols
+}
+
+// splitTopLevelCommas splits s on commas that are not nested inside parentheses.
+func splitTopLevelCommas(s string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// newOrminSchema builds a SCOPE.Schema entity with framework=ormin and the given
+// provenance stamp.
+func newOrminSchema(name, subtype, path string, line int, provenance string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       name,
+		Kind:       "SCOPE.Schema",
+		Subtype:    subtype,
+		SourceFile: path,
+		Language:   "nim",
+		StartLine:  line,
+		EndLine:    line,
+		Properties: map[string]string{
+			"framework":  "ormin",
+			"provenance": provenance,
+		},
+	}
+}


### PR DESCRIPTION
## #5028 — nim ormin + Debby model->table mapping (deferred from #4933)

### Built (fixture-proven)
**Debby** (`internal/custom/nim/debby_orm.go`, framework=debby)
- Plain Nim `object` types (NOT `ref object of Model`) are treated as persisted models only when the file imports Debby AND the type is named by a Debby db op (`createTable/dropTable/insert/get/update/delete/query(Type, ...)`) — registration is the signal, so arbitrary records don't misfire.
- Emits SCOPE.Schema **model + table + column** per registered model. Table identity = type name; column_type stamped (Option/seq unwrapped).
- **REFERENCES** edges: field typed as another model, and explicit `{.fk: Other.}` pragma (fk_pragma=true) on a scalar field.
- **QUERIES** edges model->table per attributed op (insert/get/update/delete/query); createTable/dropTable excluded as schema registration.

**ormin** (`internal/custom/nim/ormin_orm.go`, framework=ormin) — compile-time ORM, two surfaces:
- Nim side: `importModel(DbBackend.<be>, "file")` -> SCOPE.Schema/**model_import** stamping backend + model_file (the binding signal; no Nim object model layer).
- SQL DSL side: the external `*.sql` `create table T(...)` DDL is parsed into SCOPE.Schema **table + column** entities, column_type = SQL type, **primary_key/not_null** stamped, inline `references Other(col)` -> **REFERENCES** edge + foreign_key column.

### Edges / kinds
Reuses existing kinds only — SCOPE.Schema (model/table/column/model_import subtypes), REFERENCES, QUERIES. No new entity Kinds (`go test ./internal/types/` green regardless).

### Registry cells
New records `lang.nim.orm.debby` + `lang.nim.orm.ormin`. Honestly flipped to **full** only what fixtures prove (Debby model/schema_extraction; ormin schema_extraction); FK/relationship/query marked **partial**; lifecycle/migrations/transactions/query-DSL marked **missing/not_applicable** with follow-up **#5031**. REGENERATED coverage docs included (`go run ./tools/coverage fmt && gen`); `fmt --check` + `validate` pass.

### Fixtures
`internal/custom/nim/extractors_test.go`: TestNimDebbyORM_ModelTableColumns / _UnregisteredObjectNoop / _NoDebbyNoop / _WrongLanguageNoop; TestNimOrminORM_ImportModel / _SQLSchema / _NonSQLNoop.

### Deferred -> follow-up #5031
Model lifecycle, migrations (parsing + schema ops), transaction boundaries (Debby withTransaction / ormin), ormin query-DSL + Debby variable-handle/raw-SQL query attribution, cross-file FK resolution, table-level FK-constraint syntax.

### Gates (all green, sandbox HOME=/tmp/agsbx-5028)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/custom/nim/... ./internal/types/`, `coverage fmt --check`, `coverage validate`, committed regenerated docs/coverage.

Deploy-deferred.

Refs #5028

🤖 Generated with [Claude Code](https://claude.com/claude-code)