### PR TITLE
chore(coverage): resync docs stale from concurrent-gen merge

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -147,7 +147,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 10/24 | 🟡 6/13 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [rust](../by-language/rust.md) | [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [rust](../by-language/rust.md) | [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/13 | |
 | [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 9/24 | 🟡 4/12 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -38,7 +38,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
 | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 10/24 | 🟡 6/13 | |
 | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 22/24 | 🟡 7/12 | |
-| [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 1/24 | 🟡 1/13 | |
+| [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 1/24 | 🟡 2/13 | |
 | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 9/24 | 🟡 4/12 | |
 
 

--- a/docs/coverage/detail/lang.rust.framework.juniper.md
+++ b/docs/coverage/detail/lang.rust.framework.juniper.md
@@ -52,7 +52,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Type graph extraction | 🔴 `missing` | — | 4964 | — | #4964 deferred: the juniper code-first object-type->type GRAPH_RELATES graph (mirroring graphql_codefirst_typegraph.go for async-graphql) is not yet built; DTOs are catalogued but field->type edges are not emitted. Follow-up filed. |
+| Type graph extraction | ✅ `full` | `2026-06-13` | — | `internal/custom/rust/juniper.go`<br>`internal/custom/rust/juniper_typegraph.go`<br>`internal/custom/rust/juniper_typegraph_test.go` | #5007: new internal/custom/rust/juniper_typegraph.go mirrors the async-graphql code-first type-graph extractor (#3983) for juniper. Emits SCOPE.Schema/type nodes (BuildOperationStructuralRef("graphql",file,Type), shared identity with the SDL/async-graphql passes) + GRAPH_RELATES field->type edges off #[derive(GraphQLObject)] struct fields and #[graphql_object]/#[graphql_subscription] impl resolver return types, carrying the identical cardinality contract (field_name/list/nullable/item_nullable/cardinality/self_ref/framework=juniper). GraphQLInputObject/GraphQLEnum are edge targets but not field owners. Probe TestJunTG_ObjectStruct_FieldGraph asserts User.orders Vec<Order> to_many + Option<Account> nullable to_one + self_ref + input-object target + scalar fields no edge; TestJunTG_ResolverReturnType asserts Query.user FieldResult<User> unwrap to_one. Honest-partial: same-file resolution only; #[graphql(name=...)] field rename not yet honoured (follow-up). |
 
 ### Type System
 


### PR DESCRIPTION
Post-merge drift audit after #5108 found 3 `docs/coverage/*` files stale (concurrent per-PR gen merged a logically-stale shared index). Deterministic `coverage gen` resync on current main.

Refs #3628