### PR TITLE
feat(#5030): nim — Allographer rdb() query attribution

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -109,7 +109,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [kotlin](../by-language/kotlin.md) | [Room (Android)](../detail/lang.kotlin.orm.room.md) | 🟡 7/10 | |
 | [kotlin](../by-language/kotlin.md) | [SQLDelight](../detail/lang.kotlin.orm.sqldelight.md) | 🟡 7/10 | |
 | [kotlin](../by-language/kotlin.md) | [Spring Data (Kotlin)](../detail/lang.kotlin.orm.spring-data.md) | 🟡 8/11 | |
-| [nim](../by-language/nim.md) | [Allographer (Nim query/schema builder)](../detail/lang.nim.orm.allographer.md) | 🟡 5/6 | |
+| [nim](../by-language/nim.md) | [Allographer (Nim query/schema builder)](../detail/lang.nim.orm.allographer.md) | 🟢 7/7 | |
 | [nim](../by-language/nim.md) | [Debby (Nim ORM)](../detail/lang.nim.orm.debby.md) | 🟡 5/9 | |
 | [nim](../by-language/nim.md) | [Norm (Nim ORM)](../detail/lang.nim.orm.norm.md) | 🟡 6/9 | |
 | [nim](../by-language/nim.md) | [ormin (Nim compile-time ORM)](../detail/lang.nim.orm.ormin.md) | 🟡 4/8 | |

--- a/docs/coverage/by-language/nim.md
+++ b/docs/coverage/by-language/nim.md
@@ -36,7 +36,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
-| [Allographer (Nim query/schema builder)](../detail/lang.nim.orm.allographer.md) | 🟡 5/6 | |
+| [Allographer (Nim query/schema builder)](../detail/lang.nim.orm.allographer.md) | 🟢 7/7 | |
 | [Debby (Nim ORM)](../detail/lang.nim.orm.debby.md) | 🟡 5/9 | |
 | [Norm (Nim ORM)](../detail/lang.nim.orm.norm.md) | 🟡 6/9 | |
 | [ormin (Nim compile-time ORM)](../detail/lang.nim.orm.ormin.md) | 🟡 4/8 | |

--- a/docs/coverage/detail/lang.nim.orm.allographer.md
+++ b/docs/coverage/detail/lang.nim.orm.allographer.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🔴 `missing` | — | 5030 | — | The Allographer rdb() query builder (`rdb().table("users").select(...).get()`) is not yet attributed to its table — query-builder attribution is deferred to follow-up #5030. This record covers the schema_builder surface only. |
+| Query attribution | ✅ `full` | `2026-06-13` | 5030 | `internal/custom/nim/allographer_query.go`<br>`internal/custom/nim/extractors_test.go` | The Allographer rdb() query builder (`rdb().table("t")...<op>()`) is attributed to its table by the query extractor (custom_nim_allographer_query, pre-filtered by nimAllographerHasQuery so schema-only files and arbitrary Nim are ignored). Each `rdb()` head bounds one query chain; the `.table("...")` anchor gives the table identity (the same key the schema-builder table uses, so query->table converges by name) and the terminal builder method classifies the op: `.get()/.first()/.find(/.pluck(/.count(/.max(/.min(/.avg(/.sum(` -> select; `.insert(/.insertId(/.insertID(` -> insert; `.update(` -> update; `.delete(` -> delete. One SCOPE.Schema/table per distinct table carries a QUERIES edge table->table (bare table name, resolved by the shared resolver) per distinct operation (operation + table props), reusing the SCOPE.Schema Kind + QUERIES edge the Norm/Debby query-attribution extractors use (no new kind). Proven by TestNimAllographerQuery_AttributesOps (users select+insert, posts update+delete asserted) + TestNimAllographerQuery_NonQueryNoop + TestNimAllographerQuery_WrongLanguageNoop. Honest remainder (follow-up #5116): join targets, raw SQL, and dynamic (non-literal) table names are not attributed. |
 
 ### Migrations
 
@@ -45,7 +45,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction function stamping | — `not_applicable` | — | — | — | Allographer transactions are run via the rdb() query-builder transaction API, not a syntactic block on the schema builder this record covers. There is no schema-builder-level transaction boundary to stamp; query-builder transaction stamping is out of scope here (see #5030). |
+| Transaction function stamping | 🟢 `partial` | — | 5030 | `internal/custom/nim/allographer_query.go`<br>`internal/custom/nim/extractors_test.go` | Allographer transactions are run via the rdb() query-builder transaction API (`rdb().transaction(proc() = ...)`). The query extractor bounds each `rdb().transaction(...)` block with a balanced-paren scan (txnBlockEnd) and stamps transaction=true on the QUERIES edge of every rdb() query whose chain head falls inside that block, so the transaction boundary is recorded on the queries it encloses. Proven by TestNimAllographerQuery_AttributesOps (accounts.update + ledger.insert inside an rdb().transaction(...) asserted transaction=true). Partial (honest): the boundary is stamped on the enclosed queries rather than synthesised as a standalone SCOPE.Operation transaction entity — that, plus nested/named transactions, is follow-up #5116. |
 
 ## Provenance
 

--- a/internal/custom/nim/allographer_query.go
+++ b/internal/custom/nim/allographer_query.go
@@ -1,0 +1,255 @@
+// allographer_query.go — Nim Allographer rdb() query-builder attribution
+// (#5030, follow-up to #4933).
+//
+// allographer_orm.go covers the CREATE-time schema (`schema().create(table(...))`)
+// and allographer_migrations.go (#5029) covers alter()/drop() evolution. The third
+// Allographer surface is the **rdb() query builder** — the runtime data-access API:
+//
+//	import allographer/query_builder
+//
+//	let users = rdb().table("users").select("id", "name").where("age", ">", 18).get()
+//	rdb().table("users").insert(%*{"name": "Ada"})
+//	rdb().table("users").where("id", "=", 1).update(%*{"name": "Grace"})
+//	rdb().table("posts").where("draft", "=", true).delete()
+//
+//	rdb().transaction(proc() {.async.} =
+//	  await rdb().table("accounts").where("id","=",1).update(%*{"bal": 0})
+//	  await rdb().table("ledger").insert(%*{"acct": 1})
+//	)
+//
+// Each `rdb().table("t")...<op>()` chain is a query against table `t`. The table
+// identity is the literal string passed to `.table("...")` (the same key the
+// schema-builder table uses, so query→table converges by name). The terminal
+// builder method classifies the operation:
+//
+//	.get() / .first() / .find( / .pluck( / .count( ...   -> select
+//	.insert( / .insertId( / .insertID(                   -> insert
+//	.update(                                              -> update
+//	.delete(                                              -> delete
+//
+// What this extractor emits (framework=allographer):
+//   - one SCOPE.Schema/table per distinct table referenced by an rdb() chain
+//     (identity = the .table("...") literal; converges with the schema-builder
+//     table of the same name), carrying a QUERIES edge table -> table (bare table
+//     name, resolved by the shared resolver) per distinct operation, with props:
+//     operation, table, and transaction=true when the chain is inside an
+//     rdb().transaction(...) block (query-builder transaction stamping).
+//
+// This reuses the SCOPE.Schema Kind + the QUERIES edge kind the Norm (#4904) and
+// Debby (#5028) query-attribution extractors already use — no new kind.
+//
+// Honest exclusions / follow-ups (#5112):
+//   - dynamic table names (a variable, not a string literal) are skipped — no
+//     fabricated query.
+//   - raw SQL via `rdb().raw("SELECT ...")` is not parsed for its target table
+//     (no table() anchor); only the fluent .table("...") form is attributed.
+//   - join targets (`.join("other", ...)`) inside a chain are not yet attributed
+//     as a second QUERIES edge — only the primary .table("...") is captured.
+//   - the transaction boundary is stamped on the queries inside it; a standalone
+//     SCOPE.Operation transaction entity is not synthesised.
+//
+// Registration key: "custom_nim_allographer_query".
+package nim
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_nim_allographer_query", &nimAllographerQueryExtractor{})
+}
+
+type nimAllographerQueryExtractor struct{}
+
+func (e *nimAllographerQueryExtractor) Language() string {
+	return "custom_nim_allographer_query"
+}
+
+var (
+	// nimAlloRdbTableRe anchors an rdb() query chain on its `.table("name")`. We
+	// require the `.table(` to be reachable from an `rdb()` head; the pre-filter
+	// guarantees both tokens are present, and we bound each chain from the rdb()
+	// head so a `.table("...")` that belongs to a schema().create block is not
+	// misattributed. Group 1 is the table name string literal.
+	nimAlloRdbHeadRe  = regexp.MustCompile(`\brdb\s*\(\s*\)`)
+	nimAlloRdbTableRe = regexp.MustCompile(`\.\s*table\s*\(\s*"([^"]+)"`)
+
+	// rdb().transaction( ... ) — the query-builder transaction boundary. Queries
+	// whose chain head falls inside this block are stamped transaction=true.
+	nimAlloRdbTxnHeadRe = regexp.MustCompile(`\brdb\s*\(\s*\)\s*\.\s*transaction\s*\(`)
+
+	// Operation classifiers, applied to a single rdb() chain body.
+	nimAlloOpSelectRe = regexp.MustCompile(`\.\s*(?:get|first|find|pluck|count|max|min|avg|sum)\s*\(`)
+	nimAlloOpInsertRe = regexp.MustCompile(`\.\s*(?:insert|insertId|insertID)\s*\(`)
+	nimAlloOpUpdateRe = regexp.MustCompile(`\.\s*update\s*\(`)
+	nimAlloOpDeleteRe = regexp.MustCompile(`\.\s*delete\s*\(`)
+)
+
+// nimAllographerHasQuery is a fast pre-filter: the file must use the rdb() query
+// builder against a table to be worth scanning.
+func nimAllographerHasQuery(content string) bool {
+	if !strings.Contains(content, "rdb(") {
+		return false
+	}
+	return strings.Contains(content, ".table(")
+}
+
+func (e *nimAllographerQueryExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "nim" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !nimAllographerHasQuery(src) {
+		return nil, nil
+	}
+
+	// Transaction byte ranges: each rdb().transaction(...) balanced body. A query
+	// chain head inside one of these ranges is stamped transaction=true.
+	var txnRanges [][2]int
+	for _, h := range nimAlloRdbTxnHeadRe.FindAllStringIndex(src, -1) {
+		openIdx := h[1] - 1 // the '(' that opens transaction(
+		if openIdx < 0 || openIdx >= len(src) || src[openIdx] != '(' {
+			continue
+		}
+		end := txnBlockEnd(src, openIdx)
+		txnRanges = append(txnRanges, [2]int{h[0], end})
+	}
+	inTxn := func(pos int) bool {
+		for _, r := range txnRanges {
+			if pos >= r[0] && pos < r[1] {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Each rdb() head begins a query chain bounded by the next rdb() head (or EOF).
+	heads := nimAlloRdbHeadRe.FindAllStringIndex(src, -1)
+	if len(heads) == 0 {
+		return nil, nil
+	}
+
+	// Aggregate ops per table: table -> set of (operation, transaction) keys, and
+	// keep the first source line per table for the entity position.
+	type opKey struct {
+		op  string
+		txn bool
+	}
+	tableOps := make(map[string]map[opKey]bool)
+	tableLine := make(map[string]int)
+	var tableOrder []string
+
+	for i, h := range heads {
+		start := h[0]
+		end := len(src)
+		if i+1 < len(heads) {
+			end = heads[i+1][0]
+		}
+		chain := src[start:end]
+
+		// The `.table("name")` anchoring this chain. Skip a transaction-only head
+		// (rdb().transaction(...)) — it has no .table of its own.
+		tm := nimAlloRdbTableRe.FindStringSubmatchIndex(chain)
+		if tm == nil {
+			continue
+		}
+		table := chain[tm[2]:tm[3]]
+		// The chain body that classifies the op runs from the table() anchor to the
+		// end of this rdb() chain.
+		body := chain[tm[1]:]
+
+		var op string
+		switch {
+		case nimAlloOpInsertRe.MatchString(body):
+			op = "insert"
+		case nimAlloOpUpdateRe.MatchString(body):
+			op = "update"
+		case nimAlloOpDeleteRe.MatchString(body):
+			op = "delete"
+		case nimAlloOpSelectRe.MatchString(body):
+			op = "select"
+		default:
+			// A `.table("t")` with no terminal op in this chain segment is a
+			// read builder whose terminal lands in the next segment; default to
+			// select so the table access is still attributed (the common case is
+			// `let x = rdb().table("t")...get()` on one logical chain).
+			op = "select"
+		}
+
+		txn := inTxn(start)
+		if tableOps[table] == nil {
+			tableOps[table] = make(map[opKey]bool)
+			tableLine[table] = nimLineOf(src, start)
+			tableOrder = append(tableOrder, table)
+		}
+		tableOps[table][opKey{op: op, txn: txn}] = true
+	}
+
+	if len(tableOrder) == 0 {
+		return nil, nil
+	}
+	sort.Strings(tableOrder)
+
+	var out []types.EntityRecord
+	for _, table := range tableOrder {
+		tbl := newAllographerSchema(table, "table", file.Path, tableLine[table],
+			"INFERRED_FROM_ALLOGRAPHER_QUERY")
+		// Deterministic op edge order.
+		keys := make([]opKey, 0, len(tableOps[table]))
+		for k := range tableOps[table] {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			if keys[i].op != keys[j].op {
+				return keys[i].op < keys[j].op
+			}
+			return !keys[i].txn && keys[j].txn
+		})
+		var rels []types.RelationshipRecord
+		for _, k := range keys {
+			props := map[string]string{
+				"operation": k.op,
+				"table":     table,
+			}
+			if k.txn {
+				props["transaction"] = "true"
+			}
+			rels = append(rels, types.RelationshipRecord{
+				ToID:       table,
+				Kind:       "QUERIES",
+				Properties: props,
+			})
+		}
+		tbl.Relationships = rels
+		tbl.ID = tbl.ComputeID()
+		out = append(out, tbl)
+	}
+	return out, nil
+}
+
+// txnBlockEnd returns the byte offset just past the balanced () pair starting at
+// the '(' at openIdx. If unbalanced, returns len(src).
+func txnBlockEnd(src string, openIdx int) int {
+	depth := 0
+	for i := openIdx; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return len(src)
+}

--- a/internal/custom/nim/extractors_test.go
+++ b/internal/custom/nim/extractors_test.go
@@ -867,3 +867,111 @@ func TestNimAllographerMigrations_WrongLanguageNoop(t *testing.T) {
 		t.Fatalf("expected no entities for non-nim language, got %d", len(ents))
 	}
 }
+
+// --- Allographer rdb() query-builder attribution (#5030) --------------------
+
+// TestNimAllographerQuery_AttributesOps proves rdb().table("t")...<op>() chains
+// synthesise a SCOPE.Schema/table (framework=allographer) carrying a QUERIES edge
+// table->table per distinct operation (select/insert/update/delete), and stamps
+// transaction=true on queries inside an rdb().transaction(...) block.
+func TestNimAllographerQuery_AttributesOps(t *testing.T) {
+	src := `
+import allographer/query_builder
+
+let users = rdb().table("users").select("id", "name").where("age", ">", 18).get()
+let first = rdb().table("users").where("id", "=", 1).first()
+discard rdb().table("users").insert(%*{"name": "Ada"})
+discard rdb().table("posts").where("id", "=", 1).update(%*{"title": "x"})
+discard rdb().table("posts").where("draft", "=", true).delete()
+
+rdb().transaction(proc() =
+  discard rdb().table("accounts").where("id", "=", 1).update(%*{"bal": 0})
+  discard rdb().table("ledger").insert(%*{"acct": 1})
+)
+`
+	e, ok := extreg.Get("custom_nim_allographer_query")
+	if !ok {
+		t.Fatal("custom_nim_allographer_query not registered")
+	}
+	ents, err := e.Extract(context.Background(), fi("src/repo.nim", "nim", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	views := viewsOf(ents)
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+		}
+		if en.Properties["framework"] != "allographer" {
+			t.Errorf("entity %q missing framework=allographer", en.Name)
+		}
+	}
+
+	// hasOp asserts a QUERIES edge table->table with operation op (and optional
+	// transaction stamp) exists on the table entity.
+	hasOp := func(table, op string, txn bool) bool {
+		v := pickView(views, table, "table")
+		if v == nil {
+			return false
+		}
+		for _, r := range v.rels {
+			if r.Kind != "QUERIES" || r.ToID != table {
+				continue
+			}
+			if r.Properties["operation"] != op || r.Properties["table"] != table {
+				continue
+			}
+			if txn != (r.Properties["transaction"] == "true") {
+				continue
+			}
+			return true
+		}
+		return false
+	}
+
+	if !hasOp("users", "select", false) {
+		t.Error("expected users QUERIES select")
+	}
+	if !hasOp("users", "insert", false) {
+		t.Error("expected users QUERIES insert")
+	}
+	if !hasOp("posts", "update", false) {
+		t.Error("expected posts QUERIES update")
+	}
+	if !hasOp("posts", "delete", false) {
+		t.Error("expected posts QUERIES delete")
+	}
+	// Transaction-stamped queries.
+	if !hasOp("accounts", "update", true) {
+		t.Error("expected accounts QUERIES update transaction=true")
+	}
+	if !hasOp("ledger", "insert", true) {
+		t.Error("expected ledger QUERIES insert transaction=true")
+	}
+}
+
+// TestNimAllographerQuery_NonQueryNoop proves a schema-only file (no rdb()) and
+// arbitrary Nim are ignored by the query extractor.
+func TestNimAllographerQuery_NonQueryNoop(t *testing.T) {
+	e, _ := extreg.Get("custom_nim_allographer_query")
+	schemaOnly := `
+import allographer/schema_builder
+schema().create(table("users", [Column().string("name")]))
+`
+	if ents, _ := e.Extract(context.Background(), fi("src/schema.nim", "nim", schemaOnly)); len(ents) != 0 {
+		t.Fatalf("expected no query entities for a schema-only file, got %d", len(ents))
+	}
+	arbitrary := `proc rdb() = discard` + "\n" + `echo "no table here"`
+	if ents, _ := e.Extract(context.Background(), fi("src/util.nim", "nim", arbitrary)); len(ents) != 0 {
+		t.Fatalf("expected no entities for arbitrary nim, got %d", len(ents))
+	}
+}
+
+// TestNimAllographerQuery_WrongLanguageNoop gates on language=="nim".
+func TestNimAllographerQuery_WrongLanguageNoop(t *testing.T) {
+	src := `discard rdb().table("users").get()`
+	e, _ := extreg.Get("custom_nim_allographer_query")
+	if ents, _ := e.Extract(context.Background(), fi("src/repo.nim", "go", src)); len(ents) != 0 {
+		t.Fatalf("expected no entities for non-nim language, got %d", len(ents))
+	}
+}


### PR DESCRIPTION
## Built (fixture-proven)
New extractor `custom_nim_allographer_query` (`internal/custom/nim/allographer_query.go`) — the third Allographer surface after schema (#4933) and migrations (#5029).

- **Query attribution**: each `rdb().table("t")...<op>()` chain -> one `SCOPE.Schema/table` (framework=allographer; identity = the `.table("...")` literal, converging by name with the schema-builder table) carrying a **QUERIES** edge `table -> table` (bare name, shared-resolver-resolved) per distinct operation.
  - Op classification by terminal builder method: `.get()/.first()/.find(/.pluck(/.count(/.max(/.min(/.avg(/.sum(` -> select; `.insert(/.insertId(/.insertID(` -> insert; `.update(` -> update; `.delete(` -> delete.
- **Transaction stamping**: `rdb().transaction(proc()=...)` body is bounded by a balanced-paren scan; every enclosed rdb() query's QUERIES edge is stamped `transaction=true`.
- Pre-filtered by `nimAllographerHasQuery` (`rdb(` + `.table(`) so schema-only files and arbitrary Nim are ignored.

### Edges / kinds
Reuses **SCOPE.Schema** Kind + **QUERIES** edge (the same the Norm/Debby query-attribution extractors emit). **No new Kind** — `go test ./internal/types/` green.

### Registry cells flipped (honest, fixture-backed)
- `lang.nim.orm.allographer` Queries.`query_attribution`: **missing -> full**
- `lang.nim.orm.allographer` Transactions.`transaction_function_stamping`: **not_applicable -> partial** (boundary stamped on enclosed queries; standalone txn entity deferred)

### Fixtures
- `TestNimAllographerQuery_AttributesOps` — users select+insert, posts update+delete, accounts.update + ledger.insert transaction=true asserted
- `TestNimAllographerQuery_NonQueryNoop`, `TestNimAllographerQuery_WrongLanguageNoop`

## Deferred -> follow-up #5116
Join targets, raw SQL (`rdb().raw(...)`), dynamic (non-literal) table names, and a standalone SCOPE.Operation transaction entity.

## Coverage docs
Regenerated `docs/coverage` (`coverage fmt` + `coverage gen`) committed; `coverage fmt --check` ok, `coverage validate` passes for these records (only 2 pre-existing rust/juniper cite errors remain on main, unrelated).

## Gates (sandbox HOME=/tmp/agsbx-5030)
`go build ./...` ok; `go vet ./internal/custom/nim/... ./internal/extractors/nim/...` clean; `go test ./internal/custom/nim/... ./internal/extractors/nim/... ./internal/types/` ok; `coverage fmt --check` ok.

Refs #5030