### PR TITLE
fix: control-flow flowchart doesn't inline callee CFG (NestJS this.service.method delegators) — #4883 live bug

### DIFF
--- a/internal/dashboard/v2_paths_control_flow_inline.go
+++ b/internal/dashboard/v2_paths_control_flow_inline.go
@@ -222,7 +222,12 @@ func (in *cfgInliner) inline(ent *graph.Entity, g *substrate.ControlFlowGraph, l
 	canRecurse := depth+1 < in.maxDepth
 	if canRecurse && len(callees) > 0 {
 		for _, n := range g.Nodes {
-			if n.Shape != substrate.ShapeProcess || n.Label == "" {
+			// A call site can appear on a straight-line process node OR on a
+			// terminal `return <call>()` / `throw <call>()` node — the dominant
+			// NestJS thin-delegator pattern (`return this.service.create(body)`)
+			// is a RETURN node, not a process node, so we must consider those too
+			// or the handler's single delegating return never inlines (#4883).
+			if !cfgShapeSpliceable(n.Shape) || n.Label == "" {
 				continue
 			}
 			callee := in.matchCallee(n.Label, callees, visited)
@@ -385,6 +390,21 @@ func (in *cfgInliner) isExternalCall(label string, ent *graph.Entity) bool {
 		}
 	}
 	return false
+}
+
+// cfgShapeSpliceable reports whether a CFG node of this shape can host an inlined
+// callee call site. A call can appear on a straight-line statement (process) OR
+// on a `return <call>()` / `throw <call>()` terminal — the latter being the
+// dominant NestJS thin-delegator form (`return this.service.create(body)`) that
+// the original splice loop (process-only) silently skipped, leaving the handler's
+// single delegating return un-inlined at every depth (#4883).
+func cfgShapeSpliceable(shape substrate.CFGNodeShape) bool {
+	switch shape {
+	case substrate.ShapeProcess, substrate.ShapeReturn, substrate.ShapeThrow:
+		return true
+	default:
+		return false
+	}
 }
 
 // cfgShortCalleeName reduces a (possibly scoped) callee name to the bare method

--- a/internal/dashboard/v2_paths_control_flow_test.go
+++ b/internal/dashboard/v2_paths_control_flow_test.go
@@ -392,6 +392,144 @@ func TestControlFlow_DepthInlining(t *testing.T) {
 	}
 }
 
+// makeDelegatorCFGFixture mirrors the dominant NestJS thin-delegator shape that
+// the live #4883 bug hit: the handler's ENTIRE body is a single
+// `return this.service.create(body)` — a RETURN node, not a process node. The
+// callee has real branches so a working splice is observable.
+//
+//	POST /addresses
+//	  <--IMPLEMENTS-- AddressController.create (handler: `return this.service.create(body)`)
+//	         --CALLS--> AddressService.create  (callee: has an `if` + `throw` + `return`)
+func makeDelegatorCFGFixture(t *testing.T) *DashGroup {
+	t.Helper()
+	root := t.TempDir()
+
+	// Handler body is a SINGLE delegating return (lines 1..3).
+	handlerSrc := `create(body) {
+  return this.service.create(body);
+}
+`
+	// Callee `create` starts at line 5 (after the handler's 3 lines + 1 blank).
+	calleeSrc := `
+create(body) {
+  if (!body.street) {
+    throw new BadRequest("street required");
+  }
+  const saved = this.repo.save(body);
+  return saved;
+}
+`
+	full := handlerSrc + calleeSrc
+	file := "address.controller.ts"
+	if err := os.WriteFile(filepath.Join(root, file), []byte(full), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	ent := func(id, name, kind string, start, end int) graph.Entity {
+		return graph.Entity{ID: id, Name: name, Kind: kind, SourceFile: file, StartLine: start, EndLine: end}
+	}
+	epEnt := graph.Entity{
+		ID: "ep", Name: "POST /addresses", Kind: "http_endpoint_definition",
+		SourceFile: "routers.ts", StartLine: 1,
+		Properties: map[string]string{"verb": "POST", "path": "/addresses"},
+	}
+	handler := ent("handler", "AddressController.create", "Operation", 1, 3)
+	callee := ent("callee", "AddressService.create", "Operation", 5, 12)
+
+	doc := &graph.Document{
+		Repo:     "api",
+		Entities: []graph.Entity{epEnt, handler, callee},
+		Relationships: []graph.Relationship{
+			{FromID: "handler", ToID: "ep", Kind: "IMPLEMENTS"},
+			{FromID: "handler", ToID: "callee", Kind: "CALLS"},
+		},
+	}
+	return &DashGroup{
+		Name:  "testgrp",
+		Repos: map[string]*DashRepo{"api": {Slug: "api", Path: root, Doc: doc}},
+	}
+}
+
+// TestControlFlow_ReturnDelegatorInlining is the regression guard for the live
+// #4883 bug: a handler whose whole body is `return this.service.create(body)`
+// (a RETURN node) must still inline the callee CFG at depth>=2. Before the fix
+// the splice loop only considered process nodes, so this returned the 3-node
+// stub (entry / return / exit) at every depth.
+func TestControlFlow_ReturnDelegatorInlining(t *testing.T) {
+	ts := newPathsTestServer(t, makeDelegatorCFGFixture(t))
+	defer ts.Close()
+
+	fetch := func(query string) v2ControlFlowResponse {
+		t.Helper()
+		pathHash := hashStr("/addresses")
+		url := ts.URL + "/api/v2/groups/testgrp/paths/" + pathHash + "/control-flow?" + query
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatalf("GET control-flow: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("want 200, got %d", resp.StatusCode)
+		}
+		var body struct {
+			OK   bool                  `json:"ok"`
+			Data v2ControlFlowResponse `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return body.Data
+	}
+
+	// Depth 1 — the 3-node delegator stub (entry / return / exit), one frame, no
+	// callee body.
+	d1 := fetch("depth=1&detail=full")
+	if !d1.Supported {
+		t.Fatalf("depth1: want supported; note=%q", d1.Note)
+	}
+	if len(d1.Functions) != 1 {
+		t.Errorf("depth1: want one frame, got %d", len(d1.Functions))
+	}
+	if cfgAnyLabelContains(d1.Nodes, "BadRequest") {
+		t.Errorf("depth1: callee body must not be inlined")
+	}
+
+	// Depth 2 — the callee CFG must be spliced in place of the return-call node:
+	// its `if`/`throw` nodes appear and a second frame is reported.
+	d2 := fetch("depth=2&detail=full")
+	if !d2.Supported {
+		t.Fatalf("depth2: want supported; note=%q", d2.Note)
+	}
+	if len(d2.Functions) != 2 {
+		t.Fatalf("depth2: want two frames (handler+service), got %d: %+v", len(d2.Functions), d2.Functions)
+	}
+	var calleeFrame *v2CFGFunction
+	for i := range d2.Functions {
+		if d2.Functions[i].Name == "AddressService.create" {
+			calleeFrame = &d2.Functions[i]
+		}
+	}
+	if calleeFrame == nil {
+		t.Fatalf("depth2: no inlined frame for AddressService.create: %+v", d2.Functions)
+	}
+	var sawCalleeBody bool
+	for _, n := range d2.Nodes {
+		if n.Func == calleeFrame.Func && strings.Contains(n.Label, "BadRequest") {
+			sawCalleeBody = true
+		}
+	}
+	if !sawCalleeBody {
+		t.Errorf("depth2: service body (throw BadRequest) not inlined under frame %q; nodes=%+v", calleeFrame.Func, d2.Nodes)
+	}
+	// The whole point: more nodes inlined than the bare stub.
+	if len(d2.Nodes) <= len(d1.Nodes) {
+		t.Errorf("depth2: want more nodes than the depth1 stub (%d); got %d", len(d1.Nodes), len(d2.Nodes))
+	}
+	if d2.Cyclomatic <= d1.Cyclomatic {
+		t.Errorf("depth2: combined cyclomatic (%d) must exceed delegator stub (%d)", d2.Cyclomatic, d1.Cyclomatic)
+	}
+}
+
 func cfgAnyLabelContains(nodes []v2CFGNode, sub string) bool {
 	for _, n := range nodes {
 		if strings.Contains(n.Label, sub) {


### PR DESCRIPTION
## Root cause

The interprocedural CFG inliner (`internal/dashboard/v2_paths_control_flow_inline.go`, `cfgInliner.inline`) chooses which call sites to splice with:

```go
if n.Shape != substrate.ShapeProcess || n.Label == "" { continue }
```

i.e. it only considered **process** nodes as splice candidates. But the dominant NestJS thin-delegator handler is a single `return this.service.create(body)`, and the CFG builder (`internal/substrate/cfg.go` `cfgTerminalShape`) classifies any line matching `^\s*return\b` as a **`ShapeReturn`** terminal — never a `ShapeProcess`. So the one call node in a delegator handler was never a splice candidate, and the callee CFG was never inlined at any depth.

Result for the live repro (`POST /v1/alternate-addresses`, `AlternateAddressController.create` → `return this.service.create(body)`): the flowchart returned only **3 nodes** (`entry`, `return this.service.create(body)`, `exit`), one frame, at every depth — even though `downstream-dag` resolves the full controller → service → repo chain over the *same* CALLS edges. The CALLS resolution (`callsOut`) and the name match (`cfgLabelInvokes(label,"create")`) were both fine; the shape gate silently excluded the node.

The pre-existing depth test passed only because its fixture handler used a **process** form (`const rows = await this.service.fetch(...)`), never the `return <call>` delegator form.

## The fix

Splice on `ShapeReturn` and `ShapeThrow` in addition to `ShapeProcess`, via a new `cfgShapeSpliceable` helper. The exit wiring already works unchanged: a return node carries an `EdgeExit` to the end node, so `resolveFrom(returnID)` correctly yields the callee's exit ids and `resolveTo(end)` flows them to the parent's continuation. Generalised — applies to any handler→service→repo delegation in any supported language, not just alternate-addresses; unresolved leaves (e.g. TypeORM `save`) stay labelled stubs.

## Before / after (matches the live repro shape)

New fixture `makeDelegatorCFGFixture` mirrors the NestJS controller→service shape: handler body is exactly `return this.service.create(body)`; `AddressService.create` has a real `if` + `throw` + `return`.

- **depth=1:** 3-node delegator stub (entry / return / exit), 1 frame — unchanged.
- **depth>=2 (before fix):** still 1 frame, callee never inlined — `TestControlFlow_ReturnDelegatorInlining` FAILS (`want two frames, got 1`).
- **depth>=2 (after fix):** 2 frames (handler + `AddressService.create`), the service's `throw BadRequest` branch nodes appear inlined under the callee frame, node count and combined cyclomatic both rise.

Verified the new test fails on the old `ShapeProcess`-only gate and passes with the fix.

## Gates (sandbox HOME=/tmp/agsbx-cfgfix)

- `go build ./...` — pass
- `go vet ./internal/dashboard/ ./internal/substrate/ ./internal/types/` — pass
- `go test ./internal/dashboard/ ./internal/substrate/ ./internal/types/ -count=1` — pass

No coverage-capability change (bug fix), so no coverage-gen chore.

Refs #4883