### PR TITLE
fix: NestJS DTO bare-declaration field types empty in live shape (root cause of #4881)

### DIFF
--- a/cmd/archigraph/dto_field_signature_fb_4881_test.go
+++ b/cmd/archigraph/dto_field_signature_fb_4881_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestDTOFieldSignatureSurvivesFBRoundTrip is the end-to-end regression test
+// for #4881: a NestJS DTO with bare class-field declarations
+// (`id: number;`, `type: string | null;`) must round-trip its field-type
+// SIGNATURE all the way through the binary graph.fb persistence path the
+// daemon MCP + dashboard read. Before the fix the FlatBuffers Entity table had
+// no `signature` slot, so every entity (field, function, class, …) came back
+// from graph.fb with Signature="" — which made the dashboard shape API render
+// every DTO field with an empty type. This test fails on the unpatched
+// writer/schema and passes once the signature slot is persisted + restored.
+func TestDTOFieldSignatureSurvivesFBRoundTrip(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", t.TempDir())
+	repo := t.TempDir()
+	srcDir := filepath.Join(repo, "src", "modules", "equipment-types", "dto", "response")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dto := `import { EquipmentType } from '../../models/equipment-type.entity';
+import { EquipmentCategory } from '../../models/equipment-category.enum';
+
+export class EquipmentTypeResponse {
+  id: number;
+  category: EquipmentCategory;
+  type: string | null;
+  alias: string | null;
+
+  constructor(id: number, category: EquipmentCategory, type: string | null, alias: string | null) {
+    this.id = id;
+    this.category = category;
+    this.type = type;
+    this.alias = alias;
+  }
+
+  static from(entity: EquipmentType): EquipmentTypeResponse {
+    return new EquipmentTypeResponse(entity.id, entity.category, entity.type, entity.alias);
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(srcDir, "equipment-type.response.dto.ts"), []byte(dto), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitInitCommit(t, repo)
+
+	out := filepath.Join(repo, ".ag", "graph.json")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := Index(repo, out, "dto-test", nil, true, false); err != nil {
+		t.Fatalf("index: %v", err)
+	}
+
+	// LoadGraphFromDir reads graph.fb first (the binary fast-path the daemon
+	// MCP + dashboard use) — exactly the path that dropped the signature.
+	doc, err := graph.LoadGraphFromDir(filepath.Dir(out))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	want := map[string]string{
+		"EquipmentTypeResponse.id":       "id: number",
+		"EquipmentTypeResponse.category": "category: EquipmentCategory",
+		"EquipmentTypeResponse.type":     "type: string | null",
+		"EquipmentTypeResponse.alias":    "alias: string | null",
+	}
+	got := map[string]string{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" && strings.HasPrefix(e.Name, "EquipmentTypeResponse.") {
+			got[e.Name] = e.Signature
+		}
+	}
+	for name, wantSig := range want {
+		if got[name] != wantSig {
+			t.Errorf("field %s: signature=%q after graph.fb round-trip, want %q (the field TYPE was dropped by the binary persistence path)", name, got[name], wantSig)
+		}
+	}
+}

--- a/internal/graph/fbgraph/Entity.go
+++ b/internal/graph/fbgraph/Entity.go
@@ -262,8 +262,16 @@ func (rcv *Entity) Language() []byte {
 	return nil
 }
 
+func (rcv *Entity) Signature() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(40))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
 func EntityStart(builder *flatbuffers.Builder) {
-	builder.StartObject(18)
+	builder.StartObject(19)
 }
 func EntityAddId(builder *flatbuffers.Builder, id flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(id), 0)
@@ -321,6 +329,9 @@ func EntityAddEmbeddingRef(builder *flatbuffers.Builder, embeddingRef flatbuffer
 }
 func EntityAddLanguage(builder *flatbuffers.Builder, language flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(17, flatbuffers.UOffsetT(language), 0)
+}
+func EntityAddSignature(builder *flatbuffers.Builder, signature flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(18, flatbuffers.UOffsetT(signature), 0)
 }
 func EntityEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/internal/graph/fbversion/version.go
+++ b/internal/graph/fbversion/version.go
@@ -11,4 +11,9 @@ package fbversion
 // load expects. Bump together with any schema change in graph.fbs that
 // breaks readers. Both internal/graph and internal/graph/fbwriter
 // import this package — drift is now compile-time impossible.
-const Version = 3
+// Version 4 (#4881) — added the `signature` slot to the Entity table so the
+// binary graph.fb path persists entity signatures (it never did before, which
+// dropped SCOPE.Schema field TYPES from the dashboard shape API). A v3 graph.fb
+// has no signatures, so the min-version gate rejects it and forces a clean
+// reindex that repopulates signatures.
+const Version = 4

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -106,6 +106,16 @@ func buildEntity(b *flatbuffers.Builder, e *graph.Entity) flatbuffers.UOffsetT {
 		embRefOff = b.CreateString(e.EmbeddingRef)
 	}
 
+	// Issue #4881 — persist the entity signature through the binary graph.fb
+	// path. Created up-front (before EntityStart) per FlatBuffers child-offset
+	// ordering. Only emitted when non-empty so signature-less entities stay
+	// byte-identical to the pre-#4881 shape (modulo the FormatVersion bump).
+	var sigOff flatbuffers.UOffsetT
+	hasSig := e.Signature != ""
+	if hasSig {
+		sigOff = b.CreateString(e.Signature)
+	}
+
 	fb.EntityStart(b)
 	fb.EntityAddId(b, idOff)
 	fb.EntityAddQualifiedName(b, qnOff)
@@ -149,6 +159,11 @@ func buildEntity(b *flatbuffers.Builder, e *graph.Entity) flatbuffers.UOffsetT {
 	// stay byte-identical to the pre-#2370 shape (modulo FormatVersion bump).
 	if hasLang {
 		fb.EntityAddLanguage(b, langOff)
+	}
+	// Issue #4881 — emit signature only when present so empty-signature
+	// entities stay byte-identical to the pre-#4881 shape.
+	if hasSig {
+		fb.EntityAddSignature(b, sigOff)
 	}
 	return fb.EntityEnd(b)
 }

--- a/internal/graph/fbwriter/writer_test.go
+++ b/internal/graph/fbwriter/writer_test.go
@@ -1,6 +1,7 @@
 package fbwriter_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/graph"
 	fb "github.com/cajasmota/archigraph/internal/graph/fbgraph"
 	"github.com/cajasmota/archigraph/internal/graph/fbreader"
+	"github.com/cajasmota/archigraph/internal/graph/fbversion"
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 )
 
@@ -472,12 +474,54 @@ func TestLoaderRejectsOldFormatVersion(t *testing.T) {
 	// Spot-check the operative phrases — verbatim error string is part of the
 	// loader contract and must point the user at `archigraph index`.
 	for _, want := range []string{
-		"graph.fb format version 2 is older than required version 3",
+		fmt.Sprintf("graph.fb format version 2 is older than required version %d", fbversion.Version),
 		"please reindex",
 		"archigraph index <repo>",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error message missing %q\nfull message: %s", want, msg)
 		}
+	}
+}
+
+// TestRoundtripSignature guards #4881: the Entity `signature` slot must
+// round-trip through the binary graph.fb path. Before the fix the FB Entity
+// table had no signature field, so every entity's Signature was silently
+// dropped on write — which emptied SCOPE.Schema field TYPES in the dashboard.
+// Entities with an empty signature must read back empty (no spurious value).
+func TestRoundtripSignature(t *testing.T) {
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC),
+		Repo:        "fixture-sig",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "Dto.id", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: "a.ts", StartLine: 1, Signature: "id: number"},
+			{ID: "ent0000000000000b", Name: "Dto.type", Kind: "SCOPE.Schema", Subtype: "field", SourceFile: "a.ts", StartLine: 2, Signature: "type: string | null"},
+			// No signature — must read back empty.
+			{ID: "ent0000000000000c", Name: "bare", Kind: "function", SourceFile: "b.ts", StartLine: 3},
+		},
+	}
+	doc.Stats.Entities = len(doc.Entities)
+
+	out := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(out, doc); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := graph.LoadGraphFromDir(filepath.Dir(out))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	sigByID := map[string]string{}
+	for i := range got.Entities {
+		sigByID[got.Entities[i].ID] = got.Entities[i].Signature
+	}
+	if sigByID["ent0000000000000a"] != "id: number" {
+		t.Errorf("field signature lost: got %q want %q", sigByID["ent0000000000000a"], "id: number")
+	}
+	if sigByID["ent0000000000000b"] != "type: string | null" {
+		t.Errorf("nullable field signature lost: got %q want %q", sigByID["ent0000000000000b"], "type: string | null")
+	}
+	if sigByID["ent0000000000000c"] != "" {
+		t.Errorf("empty signature should stay empty: got %q", sigByID["ent0000000000000c"])
 	}
 }

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -231,6 +231,14 @@ func fbEntityToGraphEntity(e *fb.Entity) Entity {
 	if lang := string(e.Language()); lang != "" {
 		ent.Language = lang
 	}
+	// Issue #4881 — restore the entity Signature from its dedicated FB slot.
+	// Previously absent from the schema, so every entity loaded from graph.fb
+	// had Signature="" — which made SCOPE.Schema field entities (whose
+	// signature carries the field TYPE, e.g. "id: number") render with an
+	// empty type in the dashboard shape API.
+	if sig := string(e.Signature()); sig != "" {
+		ent.Signature = sig
+	}
 	// Restore Pass 4 (graph-algorithm) attributes (#1620). community_id uses
 	// a sentinel of -2 to mean "not computed"; only materialise the pointer
 	// when the algo pass actually ran so an Entity loaded from a

--- a/internal/graph/schema/graph.fbs
+++ b/internal/graph/schema/graph.fbs
@@ -61,6 +61,20 @@ table Entity {
   // FormatVersion is bumped to force a clean reindex (archigraph is
   // pre-1.0; no backward-compat path).
   language: string;
+
+  // Issue #4881 — dedicated slot for the entity signature. The binary
+  // graph.fb path (the one the daemon MCP + dashboard actually read) had
+  // NO signature field, so every entity round-tripped through graph.fb
+  // with Signature="" even though graph.json preserved it. For SCOPE.Schema
+  // field entities the signature is the canonical carrier of the field
+  // TYPE + nullability ("id: number", "type: string | null"), so the
+  // dashboard shape API rendered every DTO field with an empty type. This
+  // bug was general — graph.fb dropped the signature for functions, classes,
+  // methods and every other kind too; field types are just where it was most
+  // visible. Appended after `language` so existing field IDs are unchanged
+  // and old graph.fb files read back with an empty signature (prior
+  // behavior). FormatVersion is bumped to force a clean reindex.
+  signature: string;
 }
 
 // Community is one Louvain modularity community summarised for the


### PR DESCRIPTION
## Root cause (the real one)

The live repro was **not** in the JS/TS extractor — the deployed #4881/#4868 extractor fix is correct. Verified by running the actual extractor on the exact `EquipmentTypeResponse` source: it emits the field entities with the **right** signatures:

```
EquipmentTypeResponse.id        SIG="id: number"
EquipmentTypeResponse.category  SIG="category: EquipmentCategory"
EquipmentTypeResponse.type      SIG="type: string | null"
EquipmentTypeResponse.alias     SIG="alias: string | null"
```

Tracing the **full pipeline** end-to-end (instrumented `buildDocument`), the signature was correct at every stage — pass1, post-merge/dedup, buildDocument return, and right up to `graph.WriteAtomic`. Yet `graph.LoadGraphFromDir` read it back as `""`.

**The break is in serialization.** The binary `graph.fb` FlatBuffers `Entity` table **had no `signature` field at all**. `fbwriter.buildEntity` encoded id/kind/subtype/name/source/properties/language/etc. but never `e.Signature`. So every entity round-tripping through `graph.fb` lost its signature.

The daemon MCP and the dashboard read **graph.fb** (the binary fast-path), not graph.json (which preserves Signature via JSON tags). That's the exact split: graph.json had the type, the live dashboard shape API didn't → `type:""` on every DTO field.

This was **general** — graph.fb dropped the signature for functions, classes, methods, and every other kind too. Field TYPES are just where it was most user-visible (the shape API derives the type from the field signature).

## The fix

- `internal/graph/schema/graph.fbs` — add `signature: string` to the `Entity` table (appended after `language`, so old field IDs are unchanged).
- `internal/graph/fbgraph/Entity.go` — regenerated with `flatc --go` (adds `Signature()` accessor at slot 18 / offset 40 + `EntityAddSignature`, StartObject 18→19). Only Entity.go changed; other generated files are byte-identical.
- `internal/graph/fbwriter/writer.go` — encode the signature in `buildEntity`, only when non-empty (preserves byte-identity for signature-less entities).
- `internal/graph/load.go` — restore `ent.Signature` from the FB slot in the decode path.
- `internal/graph/fbversion/version.go` — bump FormatVersion 3→4. A v3 graph.fb has no signatures, so the min-version gate rejects it and forces a clean reindex that repopulates them (same pattern as #2370).

## Tests

- `internal/graph/fbwriter/writer_test.go::TestRoundtripSignature` — focused FB write→read round-trip asserting field signatures (incl. nullable union) survive and empty signatures stay empty.
- `cmd/archigraph/dto_field_signature_fb_4881_test.go::TestDTOFieldSignatureSurvivesFBRoundTrip` — full-pipeline e2e: indexes the real `EquipmentTypeResponse` DTO, loads via `LoadGraphFromDir` (graph.fb path), asserts `id: number` / `category: EquipmentCategory` / `type: string | null` / `alias: string | null`. Fails on the unpatched writer, passes with the fix.
- Updated `TestLoaderRejectsOldFormatVersion` for the version bump (now references `fbversion.Version` instead of a hardcoded 3).

## Gates (sandbox HOME=/tmp/agsbx-dtofix)

- `go build ./...` ✅
- `go vet ./internal/...` ✅
- `go test ./internal/graph/... ./internal/extractors/javascript/... ./internal/dashboard/... ./internal/types/ ./cmd/archigraph/` ✅

Pure serialization bug fix — no coverage-capability change.

Refs #4881