### PR TITLE
fix: flow-dag vertical edge handles not centered on node mid-sides (#4887 live bug)

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDag.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDag.tsx
@@ -35,6 +35,8 @@ import {
   Controls,
   MiniMap,
   ReactFlowProvider,
+  useReactFlow,
+  useNodesInitialized,
   type Node as RFNode,
   type NodeTypes,
   type EdgeTypes,
@@ -444,6 +446,18 @@ function FlowDagInner({
   const [elkLaid, setElkLaid] = useState<{ nodes: FlowDagRFNode[]; edges: FlowDagRFEdge[] }>(EMPTY);
   const [elkLaidOut, setElkLaidOut] = useState(false);
   const elkRunId = useRef(0);
+
+  // #4887: the FlowDag card has a fixed width but a content-driven HEIGHT (long
+  // names wrap, signature/doc/effect rows appear). ELK routes the centered
+  // top/bottom ports against the box height we hand it, so a first pass using the
+  // nominal NODE_H leaves vertical edges docking above the taller rendered card.
+  // After React Flow measures the painted cards we feed the REAL heights back and
+  // re-run ELK once, so the centered ports land on the card's true mid-sides in
+  // both orientations. `measuredHeights` is undefined on the first pass.
+  const [measuredHeights, setMeasuredHeights] = useState<Map<string, number> | undefined>(undefined);
+  const { getNodes } = useReactFlow();
+  const nodesInitialized = useNodesInitialized();
+
   useEffect(() => {
     if (engine !== "elk") return;
     if (!unfold) {
@@ -460,6 +474,8 @@ function FlowDagInner({
       expanded,
       onToggleExpand,
       unfold.hasOutEdge,
+      undefined,
+      measuredHeights,
     )
       .then((res) => {
         if (cancelled || myRun !== elkRunId.current) return;
@@ -477,7 +493,42 @@ function FlowDagInner({
     return () => {
       cancelled = true;
     };
-  }, [engine, unfold, direction, expanded, onToggleExpand, EMPTY]);
+  }, [engine, unfold, direction, expanded, onToggleExpand, measuredHeights, EMPTY]);
+
+  // The layout inputs (tree shape / direction / inline-expand) change the cards'
+  // measured heights, so drop the stale measurements when they do — the next ELK
+  // pass runs against NODE_H, then this effect re-measures and refines once.
+  useEffect(() => {
+    setMeasuredHeights(undefined);
+  }, [unfold, direction, expanded]);
+
+  // After ELK lays out and React Flow paints + measures the cards, read each
+  // card's real height and, if any differs from what the last ELK pass assumed,
+  // commit them so the layout effect re-runs once with true heights (#4887).
+  useEffect(() => {
+    if (engine !== "elk" || !elkLaidOut || !nodesInitialized || !unfold) return;
+    const next = new Map<string, number>();
+    for (const n of getNodes()) {
+      const m = n.measured?.height;
+      if (typeof m === "number" && Number.isFinite(m) && m > 0) next.set(n.id, m);
+    }
+    if (next.size === 0) return;
+    // Compare against the heights the current layout used (measuredHeights, or
+    // the nominal box when unmeasured). Re-commit only on a meaningful change so
+    // we converge in ONE refinement and never loop.
+    let changed = false;
+    for (const [id, h] of next) {
+      const prev = measuredHeights?.get(id);
+      if (prev == null || Math.abs(prev - h) > 0.5) {
+        changed = true;
+        break;
+      }
+    }
+    if (changed) setMeasuredHeights(next);
+    // getNodes is stable; measuredHeights intentionally read, not depended on, to
+    // avoid an extra pass — convergence is gated by the `changed` check.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [engine, elkLaidOut, nodesInitialized, unfold, getNodes]);
 
   const laidOut = engine === "dagre" ? tidyLaid : elkLaid;
   // True while ELK is still computing its first layout for the current inputs.

--- a/webui-v2/src/components/flow-dag/layout.test.ts
+++ b/webui-v2/src/components/flow-dag/layout.test.ts
@@ -462,6 +462,72 @@ describe("layoutTreeElk (#4827)", () => {
     expect(starts[1].x).toBeCloseTo(starts[0].x, 1);
     expect(starts[1].y).toBeCloseTo(starts[0].y, 1);
   });
+
+  // #4887 regression guard. The card has a FIXED width but a content-driven
+  // HEIGHT. Before this fix ELK always used the nominal NODE_H, so the centered
+  // bottom/top ports landed at y = box-bottom — ABOVE the taller rendered card —
+  // and vertical edges docked off the card's true mid-side. Passing the REAL
+  // measured heights back into layoutTreeElk must place the ports at each card's
+  // ACTUAL mid-side, in BOTH orientations. (Horizontal docks on the fixed-width
+  // X axis, so it was already centered, but we assert it stays centered too.)
+  const TALL = 150; // a card taller than NODE_H (long name + signature + effects)
+  const measured = (ids: string[]) => new Map(ids.map((id) => [id, TALL]));
+
+  it("docks edges on each card's MEASURED mid-side — TB (vertical, #4887)", async () => {
+    const { instances, hasOutEdge } = unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c")],
+      [e("a", "b"), e("a", "c")],
+    );
+    const heights = measured(instances.map((i) => i.id));
+    const { nodes: rf, edges } = await layoutTreeElk(
+      instances, "TB", new Set(), () => {}, hasOutEdge, undefined, heights,
+    );
+    const byId = new Map(rf.map((nd) => [nd.id, nd]));
+    // The laid-out node box height must equal the measured card height, so the
+    // visible card bottom/top coincide with the dock points.
+    for (const nd of rf) expect(nd.height).toBeCloseTo(TALL, 1);
+    for (const ed of edges) {
+      const pts = (ed.data as { elkPoints?: { x: number; y: number }[] }).elkPoints!;
+      const src = byId.get(ed.source)!;
+      const tgt = byId.get(ed.target)!;
+      const start = pts[0];
+      const end = pts[pts.length - 1];
+      // Source leaves the bottom-edge MID-point of its real (tall) box…
+      expect(start.x).toBeCloseTo(src.position.x + (src.width ?? 0) / 2, 1);
+      expect(start.y).toBeCloseTo(src.position.y + TALL, 1);
+      // …and enters the child's top-edge mid-point.
+      expect(end.x).toBeCloseTo(tgt.position.x + (tgt.width ?? 0) / 2, 1);
+      expect(end.y).toBeCloseTo(tgt.position.y, 1);
+    }
+  });
+
+  it("docks edges on each card's MEASURED mid-side — LR (horizontal, #4887)", async () => {
+    const { instances, hasOutEdge } = unfoldTree(
+      "a",
+      [n("a"), n("b"), n("c")],
+      [e("a", "b"), e("a", "c")],
+    );
+    const heights = measured(instances.map((i) => i.id));
+    const { nodes: rf, edges } = await layoutTreeElk(
+      instances, "LR", new Set(), () => {}, hasOutEdge, undefined, heights,
+    );
+    const byId = new Map(rf.map((nd) => [nd.id, nd]));
+    for (const nd of rf) expect(nd.height).toBeCloseTo(TALL, 1);
+    for (const ed of edges) {
+      const pts = (ed.data as { elkPoints?: { x: number; y: number }[] }).elkPoints!;
+      const src = byId.get(ed.source)!;
+      const tgt = byId.get(ed.target)!;
+      const start = pts[0];
+      const end = pts[pts.length - 1];
+      // Source leaves the right-edge mid-point of its real (tall) box…
+      expect(start.x).toBeCloseTo(src.position.x + (src.width ?? 0), 1);
+      expect(start.y).toBeCloseTo(src.position.y + TALL / 2, 1);
+      // …and enters the child's left-edge mid-point.
+      expect(end.x).toBeCloseTo(tgt.position.x, 1);
+      expect(end.y).toBeCloseTo(tgt.position.y + TALL / 2, 1);
+    }
+  });
 });
 
 describe("layoutTree leaf vs truncated (#4561)", () => {

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -559,6 +559,16 @@ function elkDirection(direction: FlowDagDirection): ElkDirection {
  * @param onToggle   inline-expand toggle handler (keyed by instance id)
  * @param hasOutEdge source ids with ≥1 out-edge (leaf-vs-truncated, #4561)
  * @param shape      optional node-shape/spacing overrides (flowchart-ready, #4819)
+ * @param measuredHeights #4887: real per-instance card heights (instanceId → px),
+ *   measured by React Flow after the first paint. The card has a FIXED width
+ *   (NODE_W) but its height grows with content (2-line names, signature, doc,
+ *   effect badges). ELK lays out and routes edges against the box height it is
+ *   given, so if that box is shorter than the rendered card, the centered ports
+ *   land ABOVE the card's true bottom — in VERTICAL (TB→DOWN) the edge then docks
+ *   off-center (the long-standing #4882/#4887 vertical bug). Feeding the measured
+ *   height back makes the ELK box equal the rendered card, so the bottom/top
+ *   centered ports sit exactly on the card's mid-sides. Absent on the first pass
+ *   (nothing measured yet) → falls back to NODE_H.
  */
 export async function layoutTreeElk(
   instances: TreeInstance[],
@@ -567,6 +577,7 @@ export async function layoutTreeElk(
   onToggle: (instanceId: string) => void,
   hasOutEdge?: Set<string>,
   shape?: FlowDagElkShape,
+  measuredHeights?: Map<string, number>,
 ): Promise<{ nodes: FlowDagNode[]; edges: FlowDagEdge[] }> {
   const renderedParents = new Set<string>();
   for (const inst of instances) {
@@ -600,11 +611,21 @@ export async function layoutTreeElk(
   const w = shape?.nodeWidth ?? NODE_W;
   const h = shape?.nodeHeight ?? NODE_H;
 
+  // #4887: per-instance box height — the REAL measured card height when we have
+  // it, else the nominal NODE_H. ELK's centered top/bottom ports are placed at
+  // y=0 and y=boxHeight, so the box must equal the rendered card for the
+  // vertical (TB) edge to dock on the true mid-side. (The card width is fixed,
+  // so horizontal docking was already correct.)
+  const heightFor = (id: string): number => {
+    const m = measuredHeights?.get(id);
+    return m && Number.isFinite(m) && m > 0 ? m : h;
+  };
+
   // Flat node list — the unfolded tree has no compound containment.
   const elkNodes: ElkLayoutNode[] = instances.map((inst) => ({
     id: inst.id,
     width: w,
-    height: h,
+    height: heightFor(inst.id),
     lane: depthById.get(inst.id) ?? 0,
   }));
   const elkEdges: ElkLayoutEdge[] = rfEdges.map((e) => ({
@@ -629,9 +650,14 @@ export async function layoutTreeElk(
   });
 
   // ELK positions are top-left already (flat graph → parent-relative == absolute).
+  // Stamp the laid-out height (the measured card height when known) so React
+  // Flow's node box matches the box ELK routed the centered ports against (#4887).
   for (const node of rfNodes) {
     const p = positions.get(node.id);
-    if (p) node.position = { x: p.x, y: p.y };
+    if (p) {
+      node.position = { x: p.x, y: p.y };
+      node.height = heightFor(node.id);
+    }
   }
 
   // Attach ELK's orthogonal route to each edge (#4843). The flat tree puts every


### PR DESCRIPTION
## MEASURED root cause

The Tree (downstream-flow) edge is drawn from ELK's routed `elkPoints`, not the React Flow handle — so the handle-id mismatch is NOT the bug. I ran `layoutWithElk` with `centeredPorts:true` for a parent→{2 children} tree and measured the routed endpoints vs node mid-sides:

```
DOWN:  edge START offset from parent bottom-center = (0.0, 0.0)
       edge END   offset from child  top-center    = (0.0, 0.0)
RIGHT: edge START offset from parent right-center  = (0.0, 0.0)
       edge END   offset from child  left-center   = (0.0, 0.0)
```

ELK's centered ports are **perfectly centered — against the box height it is given**. The real bug: the FlowDag card has a **fixed width (NODE_W=268)** but a **content-driven height** (long names wrap to 2 lines; signature / doc / file:line / effect-badge rows appear conditionally). `layoutTreeElk` always passed the nominal `NODE_H=92`. The rendered card is taller (~116–160px), so:

- **VERTICAL (TB→DOWN):** edges dock on the **Y** axis at `y = node.y + 92`, which lands **above** the taller card's true bottom → the edge meets the card off-center. ← the reported bug.
- **HORIZONTAL (LR→RIGHT):** edges dock on the **fixed-width X** axis → already centered. ← matches "only vertical is broken".

Every prior #4887/#4882/#4874 fix operated purely on ELK port geometry against the 92px box, so it kept "not landing".

## The fix

Feed the **real measured card heights** back into the layout. After ELK lays out and React Flow paints + measures the cards, `FlowDag` reads each node's `measured.height` and re-runs `layoutTreeElk` **once** with a `measuredHeights` map. The ELK box (and the stamped RF node height) then equals the rendered card, so the centered top/bottom (and left/right) ports sit on each card's **true mid-side in both orientations**.

- Converges in one refinement, gated by a `>0.5px` change check — no loop.
- Stale measurements are dropped + re-measured when tree shape / direction / inline-expand changes, so an **expanded (taller) card also docks correctly** (bonus).
- `layout.ts`: new optional `measuredHeights` param (defaulted → unchanged behavior for any other caller; there are none but FlowDag).

## Other diagrams verified

`iac-diagram`, `compound-topology`, and `flowchart` use **fixed-height cards** (`height:100%` filling the ELK box) so their box already equals the rendered node — not subject to this bug. `lib/elk-layout.ts` is **untouched**; the change is isolated to `flow-dag/`. **51 sibling ELK tests still pass.**

## Regression test (the guard the earlier fix lacked)

Added a vertical **and** horizontal assertion in `layout.test.ts`: with a card taller than NODE_H, every edge endpoint must land on the node's **MEASURED** mid-side (the earlier TB test only asserted against the nominal 92px box, which is why the live bug slipped through).

## Gates

- `tsc --noEmit` clean
- `vite build` clean (only the pre-existing chunk-size warning)
- `vitest` — `src/lib` (115) + `flow-dag` (41, incl. the 2 new) + sibling ELK diagrams (51) all pass

Frontend-only; deploy-deferred. Did NOT run `make dashboard-build`.

Refs #4887