### PR TITLE
feat(#4995): csharp — Wolverine message-bus (Handle + IMessageBus producers)

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 57 records · **C/C++**: 3 · **C#**: 5 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
+**Total**: 58 records · **C/C++**: 3 · **C#**: 6 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -42,6 +42,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [C#](../by-language/csharp.md) | [MassTransit (.NET cross-process service bus)](../detail/msg.masstransit.md) | ✅ | ✅ | 🟢 | 🟢 | |
 | [C#](../by-language/csharp.md) | [MediatR (.NET in-process CQRS / mediator)](../detail/msg.mediatr.md) | ✅ | ✅ | ✅ | ✅ | |
 | [C#](../by-language/csharp.md) | [NServiceBus / Rebus (IHandleMessages<T> convention)](../detail/msg.nservicebus.md) | ✅ | ✅ | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [Wolverine (.NET convention-based message bus)](../detail/msg.wolverine.md) | ✅ | ✅ | 🟢 | 🟢 | |
 | [elixir](../by-language/elixir.md) | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [go](../by-language/go.md) | [Kafka — Go (Sarama / segmentio/kafka-go)](../detail/msg.broker.kafka-go.md) | 🟢 | ✅ | 🟢 | 🟢 | |
 | [go](../by-language/go.md) | [NATS — Go (nats.go / JetStream)](../detail/msg.broker.nats-go.md) | ✅ | ✅ | ✅ | ✅ | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # C#
 
-**Frameworks**: 17 · **Tools**: 7 · **ORMs**: 14 · **Other**: 5
+**Frameworks**: 17 · **Tools**: 7 · **ORMs**: 14 · **Other**: 6
 
 Back to [summary](../summary.md).
 
@@ -122,3 +122,4 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [MassTransit (.NET cross-process service bus)](../detail/msg.masstransit.md) | ✅ | ✅ | 🟢 | |
 | [MediatR (.NET in-process CQRS / mediator)](../detail/msg.mediatr.md) | ✅ | ✅ | ✅ | |
 | [NServiceBus / Rebus (IHandleMessages<T> convention)](../detail/msg.nservicebus.md) | ✅ | ✅ | 🟢 | |
+| [Wolverine (.NET convention-based message bus)](../detail/msg.wolverine.md) | ✅ | ✅ | 🟢 | |

--- a/docs/coverage/detail/msg.wolverine.md
+++ b/docs/coverage/detail/msg.wolverine.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.wolverine` — Wolverine (.NET convention-based message bus)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | ✅ `full` | `2026-06-13` | — | `internal/custom/csharp/wolverine.go`<br>`internal/custom/csharp/wolverine_test.go` | #4995 (spun out of #4967): Wolverine has no marker interface — it routes by method convention, so the handler is any class with a Handle/Handles/Consume/Consumes method whose first parameter is the message type. The enclosing class -> SCOPE.Service(handler) CONSUMES with task_id wolverine:message:<T> so it converges with its PublishAsync/SendAsync/InvokeAsync producer by message contract. Proven by TestWolverinePublishHandlerConverge (asserts task_id convergence + edge_kind=CONSUMES) and TestWolverineConsumeConventionHandler. Honest-partial: the convention method is attributed to the nearest preceding class declaration (regex enclosing-scope, not AST), so deeply nested types are not disambiguated, and Handle methods with no explicit-typed first parameter are not parsed. |
+| Producer extraction | ✅ `full` | `2026-06-13` | — | `internal/custom/csharp/wolverine.go`<br>`internal/custom/csharp/wolverine_test.go` | #4995: IMessageBus dispatch — bus.PublishAsync(new T{...}) -> SCOPE.Operation(publish), bus.SendAsync(new T{...}) -> SCOPE.Operation(send), bus.InvokeAsync<TResp>(new T{...}) -> SCOPE.Operation(invoke), each PRODUCES carrying message_type + task_id wolverine:message:<T>. A Wolverine signal gate (using Wolverine / IMessageBus / .PublishAsync / .InvokeAsync / .SendAsync) keeps the shared convention Handle/Consume verbs from being mis-attributed on non-Wolverine files (proven by TestWolverineSignalGate). Honest-partial: only 'new' literal dispatch is parsed; inline-var / generic PublishAsync<T>() with no literal, and AST receiver-type resolution, are not. |
+| Topic attribution | 🟢 `partial` | — | 4995 | `internal/custom/csharp/wolverine.go`<br>`internal/custom/csharp/wolverine_test.go` | #4995: the message type is the topic — producer (publish/send/invoke) and convention handler all share task_id wolverine:message:<T> so they converge by contract (proven by TestWolverineAllEntitiesConverge). Honest-partial: the message contract class itself is not separately emitted as a SCOPE.Schema (Wolverine messages are plain POCOs, no marker interface), and transport/queue routing from endpoint config (PublishMessage<T>().ToRabbitExchange(...) etc.) is not yet recovered — tracked as a follow-up. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.wolverine ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 199
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 200
 
 ## Coverage by language
 
@@ -13,7 +13,7 @@
 | [go](by-language/go.md) | 21 | 8 | 17 | 5 |
 | [C/C++](by-language/c-cpp.md) | 20 | 16 | 10 | 4 |
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
-| [C#](by-language/csharp.md) | 17 | 7 | 14 | 5 |
+| [C#](by-language/csharp.md) | 17 | 7 | 14 | 6 |
 | [php](by-language/php.md) | 16 | 6 | 14 | 1 |
 | [rust](by-language/rust.md) | 15 | 6 | 15 | 4 |
 | [elixir](by-language/elixir.md) | 14 | 9 | 10 | 5 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 246 frameworks · 120 tools · 170 ORMs · 199 other
+Total: 246 frameworks · 120 tools · 170 ORMs · 200 other

--- a/internal/custom/csharp/wolverine.go
+++ b/internal/custom/csharp/wolverine.go
@@ -1,0 +1,207 @@
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_wolverine", &wolverineExtractor{})
+}
+
+// wolverineExtractor detects Wolverine cross-process message-bus usage. Unlike
+// MassTransit (#4967, IConsumer<T> marker interface) and NServiceBus/Rebus
+// (#4967, IHandleMessages<T> marker interface), Wolverine routes by *method
+// convention*: a handler is any class with a Handle/Handles/Consume/Consumes
+// method whose first parameter is the message type — there is no marker
+// interface to anchor on. The producer side dispatches through IMessageBus
+// (PublishAsync / InvokeAsync / SendAsync).
+//
+// Producers (the dispatch side):
+//   - bus.PublishAsync(new OrderPlaced())   → fan-out event (PRODUCES)
+//   - bus.SendAsync(new ProcessOrder())     → point-to-point command (PRODUCES)
+//   - bus.InvokeAsync<TResp>(new Query())   → request/response (PRODUCES)
+//
+// Consumers (the consume side, convention-based):
+//   - class XHandler { public void Handle(OrderPlaced msg) {} }
+//   - public Task Handle(OrderPlaced msg) / static Task Handle(...)
+//   - public void Consume(OrderPlaced msg)
+//
+// Each message type is normalised to task_id wolverine:message:<T> so the
+// dispatch (PRODUCES) site and the convention handler (CONSUMES) site converge
+// by message contract, exactly as the MassTransit / NServiceBus extractors do.
+type wolverineExtractor struct{}
+
+func (e *wolverineExtractor) Language() string { return "custom_csharp_wolverine" }
+
+var (
+	// bus.PublishAsync(new OrderPlaced{...}) / messageBus.PublishAsync(new T())
+	wolPublishRe = regexp.MustCompile(
+		`(?m)\b\w+\.PublishAsync\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// bus.SendAsync(new ProcessOrder{...})
+	wolSendRe = regexp.MustCompile(
+		`(?m)\b\w+\.SendAsync\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// bus.InvokeAsync<TResp>(new Query{...}) / bus.InvokeAsync(new Command())
+	wolInvokeRe = regexp.MustCompile(
+		`(?m)\b\w+\.InvokeAsync\s*(?:<[^>]*>)?\s*\(\s*new\s+(\w+)\s*[\(\{]`,
+	)
+	// Convention handler method: public Task Handle(OrderPlaced msg) { ... }
+	// Matches Handle / Handles / Consume / Consumes with an explicit-typed first
+	// parameter. Allows optional static / async / public / private modifiers and
+	// any return type (void / Task / Task<T> / ValueTask). The first parameter's
+	// declared type is the message contract.
+	wolHandleMethodRe = regexp.MustCompile(
+		`(?m)\b(?:public|internal|private|protected|static|async|\s)+\s*(?:void|Task|ValueTask)(?:\s*<[^>]*>)?\s+(Handle|Handles|Consume|Consumes)\s*\(\s*(?:\[[^\]]*\]\s*)*(\w+)\s+\w+`,
+	)
+	// Class/record declaration so a convention handler method can be attributed
+	// to its enclosing handler type.
+	wolClassDeclRe = regexp.MustCompile(
+		`(?m)(?:public\s+|internal\s+|static\s+|sealed\s+|partial\s+)*(?:class|record|struct)\s+(\w+)`,
+	)
+)
+
+func (e *wolverineExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.wolverine_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "wolverine"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	// Cheap signal gate: only pay the regex cost on files that actually touch
+	// Wolverine, so unrelated C# (incl. MediatR / MassTransit Handle/Consume
+	// look-alikes) is not mis-attributed.
+	if !wolHasSignal(src) {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name + ":" + ent.Subtype
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// 1. Producer: PublishAsync(new T{...}) — fan-out event
+	for _, idx := range wolPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity("PublishAsync "+msgType, "SCOPE.Operation", "publish", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "wolverine",
+			"pattern_type", "publish",
+			"message_type", msgType,
+			"task_id", "wolverine:message:"+msgType,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_WOLVERINE_PUBLISH",
+		)
+		add(ent)
+	}
+
+	// 2. Producer: SendAsync(new T{...}) — point-to-point command
+	for _, idx := range wolSendRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity("SendAsync "+msgType, "SCOPE.Operation", "send", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "wolverine",
+			"pattern_type", "send",
+			"message_type", msgType,
+			"task_id", "wolverine:message:"+msgType,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_WOLVERINE_SEND",
+		)
+		add(ent)
+	}
+
+	// 3. Producer: InvokeAsync<TResp>(new T{...}) — request/response command
+	for _, idx := range wolInvokeRe.FindAllStringSubmatchIndex(src, -1) {
+		msgType := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity("InvokeAsync "+msgType, "SCOPE.Operation", "invoke", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "wolverine",
+			"pattern_type", "invoke",
+			"message_type", msgType,
+			"task_id", "wolverine:message:"+msgType,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_WOLVERINE_INVOKE",
+		)
+		add(ent)
+	}
+
+	// 4. Consumer: convention Handle/Consume(T msg) method, attributed to its
+	// enclosing handler class. Wolverine has no marker interface, so the unit of
+	// extraction is the handler type, keyed by the message type of the handler
+	// method's first parameter — the same task_id the producer carries.
+	classStarts := wolClassDeclRe.FindAllStringSubmatchIndex(src, -1)
+	for _, idx := range wolHandleMethodRe.FindAllStringSubmatchIndex(src, -1) {
+		methodOff := idx[0]
+		msgType := src[idx[4]:idx[5]]
+		className := enclosingClassName(classStarts, src, methodOff)
+		if className == "" {
+			continue
+		}
+		line := lineOf(src, methodOff)
+		ent := makeEntity(className, "SCOPE.Service", "handler", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "wolverine",
+			"pattern_type", "handler",
+			"message_type", msgType,
+			"task_id", "wolverine:message:"+msgType,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_WOLVERINE_HANDLER",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// enclosingClassName returns the name of the nearest class/record/struct
+// declaration that starts before methodOff. classStarts is the ordered match
+// set from wolClassDeclRe (FindAllStringSubmatchIndex), so the last declaration
+// whose start offset precedes the method is the enclosing type. Returns "" when
+// no class precedes the method (e.g. a top-level / file-scoped Handle).
+func enclosingClassName(classStarts [][]int, src string, methodOff int) string {
+	name := ""
+	for _, c := range classStarts {
+		if c[0] >= methodOff {
+			break
+		}
+		name = src[c[2]:c[3]]
+	}
+	return name
+}
+
+// wolSignalRe gates the file: a Wolverine using-directive or an IMessageBus
+// reference. This keeps the convention-based Handle/Consume verbs (also used by
+// MassTransit ConsumeContext and ad-hoc code) from being mis-attributed to
+// Wolverine on files that never reference it.
+var wolSignalRe = regexp.MustCompile(
+	`(?m)\b(?:using\s+Wolverine|IMessageBus\b|\.PublishAsync\b|\.InvokeAsync\b|\.SendAsync\b)`,
+)
+
+func wolHasSignal(src string) bool { return wolSignalRe.MatchString(src) }

--- a/internal/custom/csharp/wolverine_test.go
+++ b/internal/custom/csharp/wolverine_test.go
@@ -1,0 +1,155 @@
+package csharp_test
+
+import (
+	"testing"
+)
+
+// Wolverine cross-process message-bus coverage (#4995). Unlike MassTransit /
+// NServiceBus (marker interfaces), Wolverine routes by method convention:
+// a Handle(T)/Consume(T) method makes the enclosing class a handler. Producers
+// dispatch via IMessageBus PublishAsync/SendAsync/InvokeAsync. Value-asserting:
+// the convention handler (CONSUMES) and the dispatch site (PRODUCES) must
+// converge by task_id wolverine:message:<T>.
+
+const wolverineSrc = `
+using Wolverine;
+
+public record OrderPlaced(int Id);
+public record ProcessOrder(int Id);
+public record GetTotal(int Id);
+
+public class OrderPlacedHandler
+{
+    public Task Handle(OrderPlaced msg) => Task.CompletedTask;
+}
+
+public class ProcessOrderHandler
+{
+    public void Consume(ProcessOrder msg) { }
+}
+
+public class OrderService
+{
+    private readonly IMessageBus _bus;
+
+    public async Task Run(int id)
+    {
+        await _bus.PublishAsync(new OrderPlaced(id));
+        await _bus.SendAsync(new ProcessOrder { Id = id });
+        var total = await _bus.InvokeAsync<int>(new GetTotal(id));
+    }
+}
+`
+
+func TestWolverinePublishHandlerConverge(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_wolverine", fi("Orders.cs", "csharp", wolverineSrc))
+
+	pub := findBySub(ents, "publish", "PublishAsync OrderPlaced")
+	if pub == nil {
+		t.Fatal("expected publish 'PublishAsync OrderPlaced'")
+	}
+	if pub.Properties["edge_kind"] != "PRODUCES" {
+		t.Errorf("publish edge_kind = %q, want PRODUCES", pub.Properties["edge_kind"])
+	}
+	if pub.Properties["task_id"] != "wolverine:message:OrderPlaced" {
+		t.Errorf("publish task_id = %q", pub.Properties["task_id"])
+	}
+
+	h := findBySub(ents, "handler", "OrderPlacedHandler")
+	if h == nil {
+		t.Fatal("expected handler 'OrderPlacedHandler'")
+	}
+	if h.Kind != "SCOPE.Service" {
+		t.Errorf("handler kind = %q, want SCOPE.Service", h.Kind)
+	}
+	if h.Properties["edge_kind"] != "CONSUMES" {
+		t.Errorf("handler edge_kind = %q, want CONSUMES", h.Properties["edge_kind"])
+	}
+	if h.Properties["message_type"] != "OrderPlaced" {
+		t.Errorf("handler message_type = %q, want OrderPlaced", h.Properties["message_type"])
+	}
+	if h.Properties["task_id"] != pub.Properties["task_id"] {
+		t.Errorf("handler task_id %q != publish task_id %q",
+			h.Properties["task_id"], pub.Properties["task_id"])
+	}
+}
+
+func TestWolverineConsumeConventionHandler(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_wolverine", fi("Orders.cs", "csharp", wolverineSrc))
+
+	// A Consume(T) method also marks a convention handler.
+	h := findBySub(ents, "handler", "ProcessOrderHandler")
+	if h == nil {
+		t.Fatal("expected handler 'ProcessOrderHandler' from Consume(T)")
+	}
+	if h.Properties["task_id"] != "wolverine:message:ProcessOrder" {
+		t.Errorf("handler task_id = %q, want wolverine:message:ProcessOrder", h.Properties["task_id"])
+	}
+
+	send := findBySub(ents, "send", "SendAsync ProcessOrder")
+	if send == nil {
+		t.Fatal("expected send 'SendAsync ProcessOrder'")
+	}
+	if send.Properties["edge_kind"] != "PRODUCES" {
+		t.Errorf("send edge_kind = %q, want PRODUCES", send.Properties["edge_kind"])
+	}
+	if send.Properties["task_id"] != h.Properties["task_id"] {
+		t.Errorf("send task_id %q != handler task_id %q",
+			send.Properties["task_id"], h.Properties["task_id"])
+	}
+}
+
+func TestWolverineInvokeRequestResponse(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_wolverine", fi("Orders.cs", "csharp", wolverineSrc))
+
+	inv := findBySub(ents, "invoke", "InvokeAsync GetTotal")
+	if inv == nil {
+		t.Fatal("expected invoke 'InvokeAsync GetTotal'")
+	}
+	if inv.Properties["edge_kind"] != "PRODUCES" {
+		t.Errorf("invoke edge_kind = %q, want PRODUCES", inv.Properties["edge_kind"])
+	}
+	if inv.Properties["task_id"] != "wolverine:message:GetTotal" {
+		t.Errorf("invoke task_id = %q, want wolverine:message:GetTotal", inv.Properties["task_id"])
+	}
+	if inv.Kind != "SCOPE.Operation" {
+		t.Errorf("invoke kind = %q, want SCOPE.Operation", inv.Kind)
+	}
+}
+
+// The signal gate must keep a convention Handle(T) on a non-Wolverine file from
+// being mis-attributed. A plain class with a Handle method but no Wolverine /
+// IMessageBus / *Async dispatch signal yields nothing.
+func TestWolverineSignalGate(t *testing.T) {
+	const noSignal = `
+public class SomeButton
+{
+    public void Handle(ClickEvent e) { }
+}
+`
+	ents := extractFull(t, "custom_csharp_wolverine", fi("Button.cs", "csharp", noSignal))
+	for _, e := range ents {
+		if e.Properties["framework"] == "wolverine" {
+			t.Errorf("signal gate leaked a wolverine entity: %s %s", e.Subtype, e.Name)
+		}
+	}
+}
+
+// Convergence sanity: every emitted entity carries a wolverine:message:<T>
+// task_id and a PRODUCES/CONSUMES edge_kind, so the graph can link them.
+func TestWolverineAllEntitiesConverge(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_wolverine", fi("Orders.cs", "csharp", wolverineSrc))
+	if len(ents) == 0 {
+		t.Fatal("expected wolverine entities")
+	}
+	for _, e := range ents {
+		tid := e.Properties["task_id"]
+		if tid == "" || tid[:len("wolverine:message:")] != "wolverine:message:" {
+			t.Errorf("entity %s %s has bad task_id %q", e.Subtype, e.Name, tid)
+		}
+		ek := e.Properties["edge_kind"]
+		if ek != "PRODUCES" && ek != "CONSUMES" {
+			t.Errorf("entity %s %s has bad edge_kind %q", e.Subtype, e.Name, ek)
+		}
+	}
+}


### PR DESCRIPTION
## Wolverine message-bus extraction (csharp)

Spun out of #4967. Unlike MassTransit (IConsumer<T>) and NServiceBus/Rebus (IHandleMessages<T>), Wolverine has **no marker interface** — it routes by **method convention**. This adds a convention resolver + IMessageBus producer detection. New self-registering extractor `custom_csharp_wolverine`.

### Built (fixture-proven)
- **Consumers (convention-based, CONSUMES)**: any class with a `Handle`/`Handles`/`Consume`/`Consumes(T msg)` method → enclosing class `SCOPE.Service(handler)`, message type = first param. Enclosing class resolved by nearest-preceding `class/record/struct` declaration.
- **Producers (PRODUCES)** via IMessageBus:
  - `bus.PublishAsync(new T{...})` → `SCOPE.Operation(publish)`
  - `bus.SendAsync(new T{...})` → `SCOPE.Operation(send)`
  - `bus.InvokeAsync<TResp>(new T{...})` → `SCOPE.Operation(invoke)`
- **Convergence**: producer + handler share `task_id wolverine:message:<T>` so they link by message contract (same model as MassTransit/NServiceBus).
- **Signal gate** (`using Wolverine` / `IMessageBus` / `.PublishAsync` / `.InvokeAsync` / `.SendAsync`) keeps the shared convention verbs from being mis-attributed on non-Wolverine files.

### Edges / Kinds
- Reuses existing entity Kinds (`SCOPE.Operation`, `SCOPE.Service`) and edge kinds **PRODUCES / CONSUMES** carried in Properties (`edge_kind`, `task_id`, `message_type`). **No new Kinds** — `go test ./internal/types/` green, no registration needed.

### Registry cells (msg.wolverine, csharp, brokers)
- `consumer_extraction: full`, `producer_extraction: full`, `topic_attribution: partial` — only cells the fixtures prove.

### Regenerated coverage docs (included)
`coverage fmt` + `coverage gen` run; committed: `registry.json`, `detail/msg.wolverine.md`, `by-category/message_broker.md`, `by-language/csharp.md`, `summary.md`. `coverage fmt --check` = canonical; `coverage validate` = ok (736 records; wolverine warnings are the same capability-map mapping class as merged msg.masstransit/msg.mediatr — separate symbol-map concern, not a validation failure).

### Deferred (follow-ups to file under #4995)
- Non-`new`-literal dispatch (inline var / generic `PublishAsync<T>()` with no literal); no AST receiver-type resolution.
- `Handle` methods with no explicit-typed first parameter.
- Deeply-nested handler types (regex enclosing-scope, not AST).
- Message contract POCO not emitted as `SCOPE.Schema`.
- Transport/queue routing recovery (`PublishMessage<T>().ToRabbitExchange(...)` etc.).

### Fixtures (5 tests, all pass)
`TestWolverinePublishHandlerConverge`, `TestWolverineConsumeConventionHandler`, `TestWolverineInvokeRequestResponse`, `TestWolverineSignalGate`, `TestWolverineAllEntitiesConverge`.

### Gates (sandbox HOME=/tmp/agsbx-4995)
- `go build ./...` ✅
- `go vet ./internal/custom/csharp/...` ✅
- `go test ./internal/custom/csharp/... ./internal/engine/... ./internal/extractors/csharp/... ./internal/types/` ✅
- `coverage fmt --check` ✅ · `coverage validate` ✅

Deploy-deferred.

Refs #4995