### PR TITLE
feat(#5061): wire coverage ingestion + reachability into the indexer enrichment pass

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/algorithms"
 	"github.com/cajasmota/archigraph/internal/classifier"
+	"github.com/cajasmota/archigraph/internal/coverage"
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/extract"
 	"github.com/cajasmota/archigraph/internal/daemon/walk"
@@ -66,13 +67,14 @@ const (
 	PassLibBoundary   = "lib-boundary"   // Pass 8.9: first_party/third_party boundary on DEPENDS_ON edges (#3638)
 	PassMigrationSeq  = "migration-seq"  // Pass 8.10: DB-migration ordering metadata + Alembic PRECEDES (#3639)
 	PassMigrationOps  = "migration-ops"  // Pass 8.11: per-migration schema-op MODIFIES_TABLE edges (#3628 [schema])
+	PassCoverage      = "coverage"       // Pass 8.12: LCOV line-coverage + static test-reachability stamping (#5061 / #5036 / #5037)
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 	PassTestsWalkUp   = "tests-walkup"   // Pass 3.5: derive TESTS edges via helper walk-up
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassSharedDB, PassLibBoundary, PassMigrationSeq, PassMigrationOps, PassEmbed,
+	PassExtract, PassFramework, PassCrossLang, PassTestsWalkUp, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassEventFlow, PassModuleAgg, PassCommitCouple, PassCoupling, PassDepHygiene, PassSharedDB, PassLibBoundary, PassMigrationSeq, PassMigrationOps, PassCoverage, PassEmbed,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -199,6 +201,14 @@ type Indexer struct {
 	// graph treat the repo as a single unit (issue #1628). For TRUE monorepos
 	// it stays empty and module.Derive's per-package rollup applies.
 	singleModuleLabel string
+
+	// coverageCfg is the per-group coverage-ingestion config (#5061/#5036).
+	// Zero value means "discover the default report path" (coverage/lcov.info);
+	// a populated Config honors its explicit report_paths globs. The coverage
+	// enrichment pass (Pass 8.12) is a strict no-op when no LCOV report is
+	// found — only the static test-reachability sub-pass (#5037) then runs,
+	// since it needs no external report. Wired via WithCoverage.
+	coverageCfg coverage.Config
 }
 
 // IndexOption configures optional behaviour on the Indexer. Used as a
@@ -310,6 +320,17 @@ func WithIncremental(stateDir string) IndexOption {
 		i.incremental = true
 		i.incrementalStateDir = stateDir
 	}
+}
+
+// WithCoverage wires the per-group coverage-ingestion config (#5061) into the
+// coverage enrichment pass (Pass 8.12). cfg mirrors SonarQube's report-path
+// model: archigraph does NOT run tests, it ingests the LCOV report CI already
+// emits (see internal/coverage.Config). When cfg is the zero value the pass
+// discovers the conventional coverage/lcov.info under the repo root; when no
+// report is found the LCOV sub-pass no-ops and only static test-reachability
+// (#5037) runs. Pass --skip-pass=coverage to disable the whole pass.
+func WithCoverage(cfg coverage.Config) IndexOption {
+	return func(i *Indexer) { i.coverageCfg = cfg }
 }
 
 type indexerStats struct {
@@ -1792,6 +1813,32 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				"archigraph: migration-ops considered=%d tables=%d modifies_edges=%d access_converged=%d\n",
 				moStats.OpsConsidered, moStats.TablesConverged,
 				moStats.ModifiesEdges, moStats.AccessConvergedEdges)
+		}
+	}
+
+	// Pass 8.12 — coverage ingestion + static test-reachability (#5061, wiring
+	// the pure passes from #5036 + #5037). Runs AFTER all entity/relationship
+	// passes are finalised (so the TESTS+CALLS edges the reachability BFS reads,
+	// and the source spans the LCOV attribution overlays, reflect the final
+	// graph). Stamps coverage_pct/covered_lines/total_lines/coverage_source (from
+	// the configured LCOV report) and test_reachable/reaching_tests/reach_depth
+	// (from the in-graph call+test edges) onto entity Properties — no new Kinds,
+	// no fb-schema change (the Properties map round-trips via both serializers).
+	// OPT-IN + strict no-op when no LCOV report is configured/discovered; the
+	// reachability sub-pass still runs since it needs no external report.
+	// Skippable via --skip-pass=coverage.
+	if !i.skipPasses[PassCoverage] {
+		covStats := coverage.Enrich(doc, absRepo, i.coverageCfg)
+		if covStats.Skipped {
+			if verbose() {
+				fmt.Fprintf(os.Stderr, "archigraph: coverage skipped (%s)\n", covStats.SkipReason)
+			}
+		} else if verbose() || covStats.LCOVAttributed > 0 || covStats.ReachabilityReachable > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: coverage report=%q report_files=%d lcov_attributed=%d "+
+					"reachability_production=%d reachable=%d\n",
+				covStats.ReportPath, covStats.ReportFiles, covStats.LCOVAttributed,
+				covStats.ReachabilityProduction, covStats.ReachabilityReachable)
 		}
 	}
 

--- a/internal/coverage/enrich.go
+++ b/internal/coverage/enrich.go
@@ -1,0 +1,244 @@
+package coverage
+
+// enrich.go — the live indexer wiring (#5061) for the two pure coverage passes:
+//
+//   - LCOV line-coverage attribution (#5036): parse the configured report and
+//     stamp coverage_pct / covered_lines / total_lines / coverage_source onto
+//     entities by source-span overlap.
+//   - static test-reachability (#5037): BFS over TESTS+CALLS edges and stamp
+//     test_reachable / reaching_tests / reach_depth onto production entities.
+//
+// Both passes are deliberately pure (see attribute.go / reachability.go); this
+// file is the SEAM the indexer hooks: it adapts a graph.Document into the flat
+// []types.EntityRecord the pure passes consume, runs them behind the per-group
+// Config, and writes the resulting Properties back onto the Document's entities.
+//
+// Persistence: the stamped values land in EntityRecord/Entity.Properties (a
+// string map), which BOTH the graph.fb and graph.json serializers already
+// round-trip — no schema change to either serializer is required (the
+// prefer-Properties-over-Kinds / prefer-Properties-over-fb-field rule).
+//
+// It is OPT-IN and a strict no-op when no report is configured/discovered, so
+// groups without coverage are never affected.
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Stats summarizes one Enrich run for the indexer's verbose log line.
+type Stats struct {
+	// Skipped is true when the pass did no work (no report configured/found).
+	Skipped    bool
+	SkipReason string
+
+	// ReportPath is the report that was parsed ("" when none / reachability-only).
+	ReportPath string
+	// ReportFiles is the number of file blocks in the parsed LCOV report.
+	ReportFiles int
+	// LCOVAttributed is the number of entities stamped with line coverage.
+	LCOVAttributed int
+
+	// Reachability stats (always run when the pass is enabled).
+	ReachabilityProduction int // production entities considered
+	ReachabilityReachable  int // of which test-reachable
+}
+
+// DefaultReportPath is the discovery fallback when a group has not configured an
+// explicit report_paths glob: the conventional repo-root LCOV artifact.
+const DefaultReportPath = "coverage/lcov.info"
+
+// Enrich runs the coverage enrichment pass against an assembled graph.Document.
+//
+//   - repoRoot is the absolute path of the indexed repo (used to resolve the
+//     report glob and as the LCOV path root when cfg.RootPrefix is empty).
+//   - cfg is the per-group coverage config (see Config). When cfg is the zero
+//     value, Enrich falls back to discovering DefaultReportPath; if that file
+//     does not exist, the LCOV attribution sub-pass is a no-op (reachability
+//     still runs, since it needs no report).
+//
+// The Document's Entity.Properties are mutated in place with the coverage and
+// reachability keys. Returns Stats for logging. Never errors the index: a
+// malformed/absent report degrades to "reachability-only" rather than failing.
+func Enrich(doc *graph.Document, repoRoot string, cfg Config) Stats {
+	if doc == nil {
+		return Stats{Skipped: true, SkipReason: "nil document"}
+	}
+
+	var st Stats
+
+	// 1. Adapt the Document into the flat record view the pure passes consume.
+	//    The view carries each entity's ID, span, kind, subtype, tags,
+	//    properties, plus the TESTS/CALLS/HANDLES relationships attached to its
+	//    host (keyed by FromID) so the reachability BFS sees the edges.
+	records := documentRecords(doc)
+
+	// 2. Static test-reachability (#5037) — always runs when enabled; needs no
+	//    external report, only the in-graph TESTS+CALLS edges.
+	reach := ComputeReachability(records)
+	for _, r := range reach {
+		st.ReachabilityProduction++
+		if r.Reachable {
+			st.ReachabilityReachable++
+		}
+	}
+	reachByID := make(map[string]map[string]string, len(reach))
+	for _, r := range reach {
+		reachByID[r.EntityID] = r.Properties()
+	}
+
+	// 3. LCOV line-coverage attribution (#5036) — opt-in, resolved from cfg or
+	//    the default-discovery path. A missing report is a clean no-op.
+	attrByID := map[string]map[string]string{}
+	if reportPath, ok := resolveReport(repoRoot, cfg); ok {
+		st.ReportPath = reportPath
+		rootPrefix := cfg.RootPrefix
+		if rep, err := parseReportFile(reportPath); err == nil && rep != nil {
+			st.ReportFiles = len(rep.Files)
+			attrs := Attribute(records, rep, rootPrefix)
+			for _, a := range attrs {
+				attrByID[a.EntityID] = a.Properties("")
+			}
+			st.LCOVAttributed = len(attrs)
+		} else if err != nil {
+			st.SkipReason = "lcov parse failed: " + err.Error()
+		}
+	}
+
+	if len(reachByID) == 0 && len(attrByID) == 0 {
+		st.Skipped = true
+		if st.SkipReason == "" {
+			st.SkipReason = "no coverage signal (no report, no test edges)"
+		}
+		return st
+	}
+
+	// 4. Write the stamped properties back onto the Document's entities by ID.
+	for i := range doc.Entities {
+		id := doc.Entities[i].ID
+		props := mergedProps(reachByID[id], attrByID[id])
+		if len(props) == 0 {
+			continue
+		}
+		if doc.Entities[i].Properties == nil {
+			doc.Entities[i].Properties = map[string]string{}
+		}
+		for k, v := range props {
+			doc.Entities[i].Properties[k] = v
+		}
+	}
+
+	return st
+}
+
+// mergedProps unions the reachability and attribution property maps for one
+// entity. Either may be nil. Returns nil when both are empty.
+func mergedProps(reach, attr map[string]string) map[string]string {
+	if len(reach) == 0 && len(attr) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(reach)+len(attr))
+	for k, v := range reach {
+		out[k] = v
+	}
+	for k, v := range attr {
+		out[k] = v
+	}
+	return out
+}
+
+// documentRecords projects a graph.Document into the []types.EntityRecord view
+// the pure passes consume. Each entity carries the identity/span/kind fields the
+// passes read, plus the subset of relationships (host → target) needed for the
+// reachability BFS, attached to their host entity by FromID.
+func documentRecords(doc *graph.Document) []types.EntityRecord {
+	// Bucket relationships by their FromID so each becomes the host entity's
+	// embedded Relationships (the shape buildGraph expects).
+	relsByFrom := make(map[string][]types.RelationshipRecord)
+	for _, rel := range doc.Relationships {
+		relsByFrom[rel.FromID] = append(relsByFrom[rel.FromID], types.RelationshipRecord{
+			FromID: rel.FromID,
+			ToID:   rel.ToID,
+			Kind:   rel.Kind,
+		})
+	}
+
+	out := make([]types.EntityRecord, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		out[i] = types.EntityRecord{
+			ID:            e.ID,
+			Name:          e.Name,
+			QualifiedName: e.QualifiedName,
+			Kind:          e.Kind,
+			Subtype:       e.Subtype,
+			SourceFile:    e.SourceFile,
+			StartLine:     e.StartLine,
+			EndLine:       e.EndLine,
+			Language:      e.Language,
+			Tags:          e.Tags,
+			Relationships: relsByFrom[e.ID],
+		}
+	}
+	return out
+}
+
+// resolveReport resolves the LCOV report path to parse, returning (path, true)
+// when a readable report exists. Resolution order:
+//
+//  1. cfg.ReportPaths globs (when cfg.Enabled()), repo-relative, first match
+//     that exists on disk wins; globs are evaluated deterministically.
+//  2. DefaultReportPath under repoRoot when it exists (zero-config discovery).
+//
+// Returns ("", false) when nothing is found — the LCOV sub-pass then no-ops.
+func resolveReport(repoRoot string, cfg Config) (string, bool) {
+	if cfg.Enabled() {
+		var matches []string
+		for _, glob := range cfg.ReportPaths {
+			pat := glob
+			if !filepath.IsAbs(pat) {
+				pat = filepath.Join(repoRoot, glob)
+			}
+			m, err := filepath.Glob(pat)
+			if err != nil {
+				continue
+			}
+			matches = append(matches, m...)
+		}
+		sort.Strings(matches)
+		for _, m := range matches {
+			if fileExists(m) {
+				return m, true
+			}
+		}
+		// cfg enabled but nothing matched: do NOT fall through to default
+		// discovery — the group explicitly chose its paths.
+		return "", false
+	}
+
+	// Zero-config discovery.
+	def := filepath.Join(repoRoot, DefaultReportPath)
+	if fileExists(def) {
+		return def, true
+	}
+	return "", false
+}
+
+// parseReportFile opens and parses an LCOV report file.
+func parseReportFile(path string) (*Report, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ParseLCOV(f)
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}

--- a/internal/coverage/enrich_test.go
+++ b/internal/coverage/enrich_test.go
@@ -1,0 +1,185 @@
+package coverage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
+)
+
+// fixtureLCOV is a tiny LCOV report: src/svc.go has lines 10-13 instrumented,
+// 3 of 4 covered (line 12 unhit) → 75% line coverage for the spanned function.
+const fixtureLCOV = `SF:src/svc.go
+DA:10,5
+DA:11,2
+DA:12,0
+DA:13,4
+end_of_record
+`
+
+// TestEnrich_EndToEnd is the #5061 acceptance fixture: build a tiny Document +
+// a fixture lcov.info on disk, run the enrichment pass, persist the Document to
+// graph.fb, reload it, and assert the indexed entity carries coverage_pct (the
+// LCOV signal) AND test_reachable (the static-reachability signal) in its
+// round-tripped Properties. This proves the whole wiring: config/discovery →
+// parse → attribute + reachability → stamp → persist via the Properties map →
+// reload.
+func TestEnrich_EndToEnd(t *testing.T) {
+	repo := t.TempDir()
+
+	// Write the fixture LCOV at the default-discovery path.
+	covDir := filepath.Join(repo, "coverage")
+	if err := os.MkdirAll(covDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(covDir, "lcov.info"), []byte(fixtureLCOV), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A tiny graph: one production function (svc, spanning the instrumented
+	// lines) and one test that TESTS it — exercising BOTH sub-passes.
+	doc := &graph.Document{
+		Version: 1,
+		Entities: []graph.Entity{
+			{
+				ID:         "ent-svc",
+				Name:       "Handle",
+				Kind:       "SCOPE.Function",
+				SourceFile: "src/svc.go",
+				StartLine:  10,
+				EndLine:    13,
+				Language:   "go",
+			},
+			{
+				ID:         "ent-test",
+				Name:       "TestHandle",
+				Kind:       "SCOPE.Pattern",
+				Subtype:    "test_suite",
+				SourceFile: "src/svc_test.go",
+				StartLine:  1,
+				EndLine:    5,
+				Language:   "go",
+				Tags:       []string{"test"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "ent-test", ToID: "ent-svc", Kind: "TESTS"},
+		},
+	}
+
+	// Run the enrichment pass against the in-memory document.
+	st := Enrich(doc, repo, Config{}) // zero Config → default discovery
+	if st.Skipped {
+		t.Fatalf("enrich skipped unexpectedly: %s", st.SkipReason)
+	}
+	if st.LCOVAttributed == 0 {
+		t.Fatalf("expected at least one LCOV-attributed entity, got 0 (report=%q)", st.ReportPath)
+	}
+	if st.ReachabilityReachable == 0 {
+		t.Fatal("expected at least one test-reachable entity, got 0")
+	}
+
+	// Persist to graph.fb and reload — proving the stamped Properties survive
+	// the serializer round-trip (the persistence requirement of #5061).
+	fbPath := filepath.Join(repo, ".archigraph", "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write fb: %v", err)
+	}
+	reloaded, err := graph.LoadGraphFromDir(filepath.Join(repo, ".archigraph"))
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	var svc *graph.Entity
+	for i := range reloaded.Entities {
+		if reloaded.Entities[i].ID == "ent-svc" {
+			svc = &reloaded.Entities[i]
+			break
+		}
+	}
+	if svc == nil {
+		t.Fatal("svc entity missing after reload")
+	}
+
+	// LCOV signal: 3 of 4 instrumented lines covered → 75.0%.
+	if got := svc.Properties[PropCoveragePct]; got != "75.0" {
+		t.Errorf("%s = %q after reload, want %q", PropCoveragePct, got, "75.0")
+	}
+	if got := svc.Properties[PropCoverageSource]; got != SourceLCOV {
+		t.Errorf("%s = %q, want %q", PropCoverageSource, got, SourceLCOV)
+	}
+	if got := svc.Properties[PropCoveredLines]; got != "3" {
+		t.Errorf("%s = %q, want %q", PropCoveredLines, got, "3")
+	}
+	if got := svc.Properties[PropTotalLines]; got != "4" {
+		t.Errorf("%s = %q, want %q", PropTotalLines, got, "4")
+	}
+
+	// Reachability signal: the function is TESTS-reached at depth 1.
+	if got := svc.Properties[PropTestReachable]; got != "true" {
+		t.Errorf("%s = %q, want %q", PropTestReachable, got, "true")
+	}
+	if got := svc.Properties[PropReachDepth]; got != "1" {
+		t.Errorf("%s = %q, want %q", PropReachDepth, got, "1")
+	}
+}
+
+// TestEnrich_NoReport_NoOpLCOV proves the pass is opt-in for LCOV: with no
+// report on disk, no coverage_pct is stamped, but reachability still runs.
+func TestEnrich_NoReport_NoOpLCOV(t *testing.T) {
+	repo := t.TempDir() // empty: no coverage/lcov.info
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "ent-svc", Name: "Handle", Kind: "SCOPE.Function", SourceFile: "src/svc.go", StartLine: 10, EndLine: 13},
+			{ID: "ent-test", Name: "TestHandle", Kind: "SCOPE.Pattern", Subtype: "test_suite", SourceFile: "src/svc_test.go", Tags: []string{"test"}},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "ent-test", ToID: "ent-svc", Kind: "TESTS"},
+		},
+	}
+
+	st := Enrich(doc, repo, Config{})
+	if st.LCOVAttributed != 0 {
+		t.Errorf("expected no LCOV attribution without a report, got %d", st.LCOVAttributed)
+	}
+	if st.ReachabilityReachable == 0 {
+		t.Error("reachability should still run without a report")
+	}
+	svc := doc.Entities[0]
+	if _, ok := svc.Properties[PropCoveragePct]; ok {
+		t.Errorf("coverage_pct must not be stamped without a report; got %v", svc.Properties)
+	}
+	if got := svc.Properties[PropTestReachable]; got != "true" {
+		t.Errorf("%s = %q, want true", PropTestReachable, got)
+	}
+}
+
+// TestEnrich_ConfiguredGlob proves an explicit report_paths glob is honored
+// (and that a configured-but-unmatched glob does NOT fall back to discovery).
+func TestEnrich_ConfiguredGlob(t *testing.T) {
+	repo := t.TempDir()
+	nested := filepath.Join(repo, "packages", "web", "coverage")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "lcov.info"), []byte(fixtureLCOV), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "ent-svc", Name: "Handle", Kind: "SCOPE.Function", SourceFile: "src/svc.go", StartLine: 10, EndLine: 13},
+		},
+	}
+	cfg := Config{Format: FormatLCOV, ReportPaths: []string{"packages/*/coverage/lcov.info"}}
+	st := Enrich(doc, repo, cfg)
+	if st.LCOVAttributed == 0 {
+		t.Fatalf("configured glob did not resolve a report (report=%q)", st.ReportPath)
+	}
+	if got := doc.Entities[0].Properties[PropCoveragePct]; got != "75.0" {
+		t.Errorf("%s = %q, want 75.0", PropCoveragePct, got)
+	}
+}


### PR DESCRIPTION
## What this wires

The two coverage features shipped their logic as **pure passes** with a deliberate indexer SEAM:
- **#5036** LCOV line-coverage attribution (`Attribute` / `ApplyAttributions`)
- **#5037** static test-reachability (`ComputeReachability` / `ApplyReachability`)

Neither was wired into the live indexer, so coverage props never populated on real graphs. This PR is that wiring — **both passes, fully wired** (no deferral).

## Hook point

New **Pass 8.12** (`PassCoverage = "coverage"`) in `cmd/archigraph/index.go`, after the engine annotation passes (commit-couple … migration-ops) and before the Pass-6 enrichment-candidate emission. By then the graph is finalised, so the TESTS+CALLS edges the reachability BFS reads and the source spans the LCOV overlay needs all reflect the final topology. Skippable via `--skip-pass=coverage`.

## The driver: `internal/coverage/enrich.go`

`Enrich(doc *graph.Document, repoRoot string, cfg Config) Stats`:
1. Adapts the `graph.Document` into the flat `[]types.EntityRecord` view the pure passes consume (carrying ID/span/kind/subtype/tags + the per-host TESTS/CALLS relationships keyed by FromID).
2. Runs `ComputeReachability` → stamps `test_reachable` / `reach_depth` / `reaching_tests` / `reaching_test_count`.
3. If an LCOV report resolves, parses it and runs `Attribute` → stamps `coverage_pct` / `covered_lines` / `total_lines` / `coverage_source`.
4. Writes the merged props back onto `doc.Entities` by ID.

**Opt-in / no-op:** when no LCOV report is configured or discovered, the LCOV sub-pass is a strict no-op (reachability still runs — it needs no external report). Groups without coverage are never affected.

## Config

`WithCoverage(coverage.Config)` IndexOption + `coverageCfg` field. Report resolution:
- `cfg.ReportPaths` globs (repo-relative, mirrors `sonar.*.reportPaths`) when `cfg.Enabled()`; a configured-but-unmatched glob does **not** fall back to discovery (the group chose its paths).
- else zero-config discovery of `coverage/lcov.info` under the repo root.

## Persistence

Props land in the entity **Properties map**, which BOTH the `graph.fb` and `graph.json` serializers already round-trip — **no graph.fb schema change** (prefer-Properties-over-fb-field).

## End-to-end fixture

`internal/coverage/enrich_test.go` `TestEnrich_EndToEnd`: build a tiny `graph.Document` (one `SCOPE.Function` spanning the instrumented lines + one `SCOPE.Pattern` test that TESTS it) + a fixture `coverage/lcov.info`, run `Enrich`, persist to `graph.fb` via `fbwriter.WriteAtomic`, reload via `graph.LoadGraphFromDir`, and assert the reloaded entity carries `coverage_pct=75.0`, `coverage_source=lcov`, `covered_lines=3`, `total_lines=4`, `test_reachable=true`, `reach_depth=1`. Plus `TestEnrich_NoReport_NoOpLCOV` (LCOV no-op, reachability still runs) and `TestEnrich_ConfiguredGlob` (explicit glob honored).

## Gates (sandbox HOME=/tmp/agsbx-5061)

- `go build ./...` clean
- `go vet ./internal/...` clean
- `go test ./internal/coverage/... ./internal/graph/... ./internal/types/` all green

No coverage capability-registry cells changed (this is a pipeline wiring pass, not a language/framework capability), so no coverage-gen chore.

Closes #5061