### PR TITLE
feat(#4996): csharp — native broker clients (Kafka/RabbitMQ/Azure.Messaging)

### DIFF
--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 58 records · **C/C++**: 3 · **C#**: 6 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
+**Total**: 60 records · **C/C++**: 3 · **C#**: 8 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -39,9 +39,11 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [C/C++](../by-language/c-cpp.md) | [MQTT (Paho C/C++ / Mosquitto)](../detail/lang.c-cpp.framework.mqtt.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [C/C++](../by-language/c-cpp.md) | [ZeroMQ (libzmq/cppzmq)](../detail/lang.c-cpp.framework.zeromq.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [C/C++](../by-language/c-cpp.md) | [librdkafka (C/C++ Kafka client)](../detail/lang.c-cpp.framework.librdkafka.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [Kafka — C# (Confluent.Kafka)](../detail/msg.broker.kafka-dotnet.md) | 🟢 | 🟢 | ✅ | 🟢 | |
 | [C#](../by-language/csharp.md) | [MassTransit (.NET cross-process service bus)](../detail/msg.masstransit.md) | ✅ | ✅ | 🟢 | 🟢 | |
 | [C#](../by-language/csharp.md) | [MediatR (.NET in-process CQRS / mediator)](../detail/msg.mediatr.md) | ✅ | ✅ | ✅ | ✅ | |
 | [C#](../by-language/csharp.md) | [NServiceBus / Rebus (IHandleMessages<T> convention)](../detail/msg.nservicebus.md) | ✅ | ✅ | 🟢 | 🟢 | |
+| [C#](../by-language/csharp.md) | [RabbitMQ — C# (RabbitMQ.Client)](../detail/msg.broker.rabbitmq-dotnet.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [C#](../by-language/csharp.md) | [Wolverine (.NET convention-based message bus)](../detail/msg.wolverine.md) | ✅ | ✅ | 🟢 | 🟢 | |
 | [elixir](../by-language/elixir.md) | [Broadway (Elixir data pipelines)](../detail/lang.elixir.framework.broadway.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [go](../by-language/go.md) | [Kafka — Go (Sarama / segmentio/kafka-go)](../detail/msg.broker.kafka-go.md) | 🟢 | ✅ | 🟢 | 🟢 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # C#
 
-**Frameworks**: 17 · **Tools**: 7 · **ORMs**: 14 · **Other**: 6
+**Frameworks**: 17 · **Tools**: 7 · **ORMs**: 14 · **Other**: 8
 
 Back to [summary](../summary.md).
 
@@ -119,7 +119,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
 |---|---|---|---|---|
+| [Kafka — C# (Confluent.Kafka)](../detail/msg.broker.kafka-dotnet.md) | 🟢 | 🟢 | ✅ | |
 | [MassTransit (.NET cross-process service bus)](../detail/msg.masstransit.md) | ✅ | ✅ | 🟢 | |
 | [MediatR (.NET in-process CQRS / mediator)](../detail/msg.mediatr.md) | ✅ | ✅ | ✅ | |
 | [NServiceBus / Rebus (IHandleMessages<T> convention)](../detail/msg.nservicebus.md) | ✅ | ✅ | 🟢 | |
+| [RabbitMQ — C# (RabbitMQ.Client)](../detail/msg.broker.rabbitmq-dotnet.md) | 🟢 | 🟢 | 🟢 | |
 | [Wolverine (.NET convention-based message bus)](../detail/msg.wolverine.md) | ✅ | ✅ | 🟢 | |

--- a/docs/coverage/detail/msg.broker.kafka-dotnet.md
+++ b/docs/coverage/detail/msg.broker.kafka-dotnet.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.broker.kafka-dotnet` — Kafka — C# (Confluent.Kafka)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | 🟢 `partial` | `2026-06-13` | 4996 | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_edges_test.go` | #4996: synthesizeCSharpKafka (kafka_edges.go, case "csharp") resolves Confluent.Kafka consumer.Subscribe("topic") and the array form consumer.Subscribe(new[] { "a", "b" }) / new List<string>{...}, emitting SUBSCRIBES_TO from the enclosing method to topic:kafka:<name> (messaging_layer=confluent-kafka-dotnet). Honest-partial: only string-literal topics; dynamic/computed topic names and per-partition Assign are not modelled. |
+| Producer extraction | 🟢 `partial` | `2026-06-13` | 4996 | `internal/engine/kafka_edges.go`<br>`internal/engine/kafka_edges_test.go` | #4996: synthesizeCSharpKafka handles Confluent.Kafka IProducer.Produce("topic", ...) and ProduceAsync("topic", ...) producer sites, emitting PUBLISHES_TO from the enclosing method to topic:kafka:<name> (messaging_layer=confluent-kafka-dotnet). Honest-partial: literal topic first-arg only. |
+| Topic attribution | ✅ `full` | `2026-06-13` | 4996 | `internal/engine/kafka_edges.go`<br>`internal/links/topic_pass.go` | #4996: topic is the explicit string-literal first argument (Produce/ProduceAsync/Subscribe), so attribution is FULL for literals — topic:kafka:<name> SCOPE.MessageTopic nodes join a C# producer to a consumer (any language) cross-repo via topic_pass.go (channel=kafka). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.broker.kafka-dotnet ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.broker.rabbitmq-dotnet.md
+++ b/docs/coverage/detail/msg.broker.rabbitmq-dotnet.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.broker.rabbitmq-dotnet` — RabbitMQ — C# (RabbitMQ.Client)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Brokers
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | 🟢 `partial` | `2026-06-13` | 4996 | `internal/engine/rabbitmq_edges.go`<br>`internal/engine/rabbitmq_edges_test.go` | #4996: synthesizeCSharpRabbitMQ (rabbitmq_edges.go, case "csharp") resolves RabbitMQ.Client channel.BasicConsume(queue: "q" | positional) consumer sites -> SUBSCRIBES_TO rabbitmq:<name> (messaging_layer=rabbitmq-dotnet), and records channel.QueueDeclare(...) queue nodes. Honest-partial: literal queue names only; EventingBasicConsumer.Received handler attribution not modelled. |
+| Producer extraction | 🟢 `partial` | `2026-06-13` | 4996 | `internal/engine/rabbitmq_edges.go`<br>`internal/engine/rabbitmq_edges_test.go` | #4996: synthesizeCSharpRabbitMQ resolves channel.BasicPublish(exchange:, routingKey:, ...) (named, either order) and the positional BasicPublish("ex", "rk", ...) producer sites -> PUBLISHES_TO from the enclosing method, keyed by the routing-key literal (rabbitmq:<name>), with the exchange recorded as an edge property. Honest-partial: literal routing-key only; fanout (empty routing key) and dynamic keys not attributed. |
+| Topic attribution | 🟢 `partial` | `2026-06-13` | 4996 | `internal/engine/rabbitmq_edges.go`<br>`internal/links/topic_pass.go` | #4996: routing-key/queue literals become rabbitmq:<name> SCOPE.Queue nodes joined producer->consumer cross-repo via topic_pass.go (channel=rabbitmq); exchange recorded as edge prop. Honest-partial: literal keys only; exchange-binding topology not decomposed. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.broker.rabbitmq-dotnet ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 200
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 202
 
 ## Coverage by language
 
@@ -13,7 +13,7 @@
 | [go](by-language/go.md) | 21 | 8 | 17 | 5 |
 | [C/C++](by-language/c-cpp.md) | 20 | 16 | 10 | 4 |
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
-| [C#](by-language/csharp.md) | 17 | 7 | 14 | 6 |
+| [C#](by-language/csharp.md) | 17 | 7 | 14 | 8 |
 | [php](by-language/php.md) | 16 | 6 | 14 | 1 |
 | [rust](by-language/rust.md) | 15 | 6 | 15 | 4 |
 | [elixir](by-language/elixir.md) | 14 | 9 | 10 | 5 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 246 frameworks · 120 tools · 170 ORMs · 200 other
+Total: 246 frameworks · 120 tools · 170 ORMs · 202 other

--- a/internal/engine/kafka_edges.go
+++ b/internal/engine/kafka_edges.go
@@ -58,7 +58,7 @@ const transformsEdgeKind = "TRANSFORMS"
 // and Go — the languages with non-trivial Kafka adoption in the corpora.
 func kafkaSynthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "java", "kotlin", "javascript", "typescript", "python", "go", "php", "rust", "cpp", "c":
+	case "java", "kotlin", "javascript", "typescript", "python", "go", "php", "rust", "cpp", "c", "csharp":
 		return true
 	default:
 		return false
@@ -184,6 +184,8 @@ func applyKafkaEdges(args DetectorPassArgs) DetectorPassResult {
 		synthesizeRustRdKafka(src, emitTopic, emitEdge)
 	case "cpp", "c":
 		synthesizeCppRdKafka(src, emitTopic, emitEdge)
+	case "csharp":
+		synthesizeCSharpKafka(src, emitTopic, emitEdge)
 	}
 
 	return DetectorPassResult{Entities: entities, Relationships: relationships}
@@ -1377,6 +1379,96 @@ func synthesizeCppRdKafka(
 				emitConsumer(unq, "rdkafkacpp", m[0])
 			}
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C# — Confluent.Kafka (IProducer<K,V> / IConsumer<K,V>)
+// ---------------------------------------------------------------------------
+//
+// Producer (the dispatch side):
+//
+//	producer.Produce("orders", new Message<...> { ... });
+//	await producer.ProduceAsync("orders", new Message<...> { ... });
+//
+// Consumer (the consume side):
+//
+//	consumer.Subscribe("orders");
+//	consumer.Subscribe(new[] { "orders", "payments" });
+//	consumer.Subscribe(new List<string> { "orders", "payments" });
+//
+// The topic string is the explicit first argument, so attribution is FULL for
+// string literals. Dynamic / non-literal topic names are skipped — we never
+// fabricate a topic entity for a name we cannot read statically.
+
+// csKafkaProduceRe captures `producer.Produce("topic", ...)` and
+// `producer.ProduceAsync("topic", ...)`. Group 1 = topic literal.
+var csKafkaProduceRe = regexp.MustCompile(`\.Produce(?:Async)?\s*\(\s*"([^"\n\r]+)"`)
+
+// csKafkaSubscribeSingleRe captures `consumer.Subscribe("topic")` — a single
+// string-literal argument (not an array/list). Group 1 = topic literal.
+var csKafkaSubscribeSingleRe = regexp.MustCompile(`\.Subscribe\s*\(\s*"([^"\n\r]+)"\s*\)`)
+
+// csKafkaSubscribeListRe captures the array / collection form
+// `consumer.Subscribe(new[] { "a", "b" })` / `new List<string> { "a", "b" }`.
+// Group 1 = the brace body holding the comma-separated string literals.
+var csKafkaSubscribeListRe = regexp.MustCompile(`\.Subscribe\s*\(\s*new\s*[^{(]*?\{([^}]*)\}`)
+
+func synthesizeCSharpKafka(
+	src string,
+	emitTopic func(topicID, topicName, broker string, dynamic bool, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	// Fast pre-filter: only process files that reference Confluent.Kafka.
+	if !strings.Contains(src, "Kafka") && !strings.Contains(src, "Produce") &&
+		!strings.Contains(src, "Subscribe") {
+		return
+	}
+
+	enclosing := func(offset int) string { return findEnclosingCSharpMethod(src, offset) }
+
+	emitProducer := func(topic string, offset int) {
+		if !looksLikeKafkaTopic(topic) {
+			return
+		}
+		id := kafkaTopicID(topic)
+		emitTopic(id, topic, "kafka", false, map[string]string{"messaging_layer": "confluent-kafka-dotnet"})
+		emitEdge("SCOPE.Operation", enclosing(offset), id, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "confluent-kafka-dotnet",
+		})
+	}
+	emitConsumer := func(topic string, offset int) {
+		if !looksLikeKafkaTopic(topic) {
+			return
+		}
+		id := kafkaTopicID(topic)
+		emitTopic(id, topic, "kafka", false, map[string]string{"messaging_layer": "confluent-kafka-dotnet"})
+		emitEdge("SCOPE.Operation", enclosing(offset), id, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "confluent-kafka-dotnet",
+		})
+	}
+
+	// Producer: Produce("topic", ...) / ProduceAsync("topic", ...)
+	for _, m := range csKafkaProduceRe.FindAllStringSubmatchIndex(src, -1) {
+		emitProducer(src[m[2]:m[3]], m[0])
+	}
+	// Consumer: Subscribe(new[] { "a", "b" }) — the array/list form first so we
+	// can offset the single-literal form against it.
+	listOffsets := map[int]bool{}
+	for _, m := range csKafkaSubscribeListRe.FindAllStringSubmatchIndex(src, -1) {
+		listOffsets[m[0]] = true
+		for _, tok := range strings.Split(src[m[2]:m[3]], ",") {
+			if unq, ok := unquote(tok); ok {
+				emitConsumer(unq, m[0])
+			}
+		}
+	}
+	// Consumer: Subscribe("topic") — single string literal.
+	for _, m := range csKafkaSubscribeSingleRe.FindAllStringSubmatchIndex(src, -1) {
+		if listOffsets[m[0]] {
+			continue
+		}
+		emitConsumer(src[m[2]:m[3]], m[0])
 	}
 }
 

--- a/internal/engine/kafka_edges_test.go
+++ b/internal/engine/kafka_edges_test.go
@@ -893,3 +893,100 @@ void Worker::run(RdKafka::KafkaConsumer *consumer) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// C# / Confluent.Kafka (#4996)
+// ---------------------------------------------------------------------------
+
+// TestKafka_CSharp_ProduceProducer covers Confluent.Kafka Produce/ProduceAsync
+// with a literal topic. Producer-side: PUBLISHES_TO.
+func TestKafka_CSharp_ProduceProducer(t *testing.T) {
+	src := `using Confluent.Kafka;
+
+public class OrderPublisher
+{
+    private readonly IProducer<Null, string> _producer;
+
+    public async Task Emit(string body)
+    {
+        await _producer.ProduceAsync("orders.created", new Message<Null, string> { Value = body });
+        _producer.Produce("orders.shipped", new Message<Null, string> { Value = body });
+    }
+}
+`
+	ents, rels := runKafkaDetect(t, "csharp", "src/OrderPublisher.cs", src)
+	if topicByName(ents, "orders.created") == nil {
+		t.Fatalf("expected MessageTopic for orders.created, got %v", ents)
+	}
+	if topicByName(ents, "orders.shipped") == nil {
+		t.Fatalf("expected MessageTopic for orders.shipped, got %v", ents)
+	}
+	pub := edgesOfKind(rels, publishesToEdgeKind)
+	if len(pub) < 2 {
+		t.Fatalf("expected >=2 PUBLISHES_TO edges, got %d", len(pub))
+	}
+	foundTopic, foundCaller := false, false
+	for _, p := range pub {
+		if strings.Contains(p.ToID, "kafka:orders.created") {
+			foundTopic = true
+		}
+		if strings.Contains(p.FromID, "Emit") {
+			foundCaller = true
+		}
+		if p.Properties["messaging_layer"] != "confluent-kafka-dotnet" {
+			t.Errorf("messaging_layer = %q, want confluent-kafka-dotnet", p.Properties["messaging_layer"])
+		}
+	}
+	if !foundTopic {
+		t.Fatalf("expected PUBLISHES_TO -> kafka:orders.created, pubs=%v", pub)
+	}
+	if !foundCaller {
+		t.Fatalf("expected PUBLISHES_TO from enclosing method Emit, pubs=%v", pub)
+	}
+}
+
+// TestKafka_CSharp_SubscribeConsumer covers consumer.Subscribe single-literal
+// and array forms. Consumer-side: SUBSCRIBES_TO.
+func TestKafka_CSharp_SubscribeConsumer(t *testing.T) {
+	src := `using Confluent.Kafka;
+
+public class OrderConsumer
+{
+    private readonly IConsumer<Null, string> _consumer;
+
+    public void Start()
+    {
+        _consumer.Subscribe("orders.created");
+        _consumer.Subscribe(new[] { "payments.settled", "orders.shipped" });
+    }
+}
+`
+	ents, rels := runKafkaDetect(t, "csharp", "src/OrderConsumer.cs", src)
+	for _, want := range []string{"orders.created", "payments.settled", "orders.shipped"} {
+		if topicByName(ents, want) == nil {
+			t.Fatalf("expected MessageTopic for %q, got %v", want, ents)
+		}
+	}
+	sub := edgesOfKind(rels, subscribesToEdgeKind)
+	if len(sub) < 3 {
+		t.Fatalf("expected >=3 SUBSCRIBES_TO edges, got %d (%v)", len(sub), sub)
+	}
+	found := false
+	for _, s := range sub {
+		if strings.Contains(s.ToID, "kafka:payments.settled") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected SUBSCRIBES_TO -> kafka:payments.settled, subs=%v", sub)
+	}
+}
+
+// TestKafka_CSharp_NoSignal asserts a non-Kafka C# file emits nothing.
+func TestKafka_CSharp_NoSignal(t *testing.T) {
+	src := `public class Plain { public void Run() { var x = 1; } }`
+	ents, rels := runKafkaDetect(t, "csharp", "src/Plain.cs", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("expected no entities/edges for non-Kafka file, got ents=%d rels=%d", len(ents), len(rels))
+	}
+}

--- a/internal/engine/rabbitmq_edges.go
+++ b/internal/engine/rabbitmq_edges.go
@@ -43,7 +43,7 @@ const queueEntityKind = "SCOPE.Queue"
 // can emit synthetics for `lang`.
 func rabbitmqSynthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "java", "kotlin", "javascript", "typescript", "python", "go", "rust":
+	case "java", "kotlin", "javascript", "typescript", "python", "go", "rust", "csharp":
 		return true
 	default:
 		return false
@@ -146,6 +146,8 @@ func applyRabbitMQEdges(args DetectorPassArgs) DetectorPassResult {
 		synthesizeGoRabbitMQ(src, emitQueue, emitEdge)
 	case "rust":
 		synthesizeRustLapin(src, emitQueue, emitEdge)
+	case "csharp":
+		synthesizeCSharpRabbitMQ(src, emitQueue, emitEdge)
 	}
 
 	return DetectorPassResult{Entities: entities, Relationships: relationships}
@@ -943,5 +945,161 @@ func synthesizeRustLapin(
 		}
 		qID := rabbitmqQueueID(queueName)
 		emitQueue(qID, queueName, "", "", map[string]string{"declared": "true"})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// C# — RabbitMQ.Client (IModel / IChannel BasicPublish / BasicConsume)
+// ---------------------------------------------------------------------------
+//
+// Producer (the dispatch side):
+//
+//	channel.BasicPublish(exchange: "ex", routingKey: "orders", body: body);
+//	channel.BasicPublish("ex", "orders", null, body);            // positional
+//	await channel.BasicPublishAsync(exchange: "ex", routingKey: "orders", ...);
+//
+// Consumer (the consume side):
+//
+//	channel.BasicConsume(queue: "orders", autoAck: true, consumer: c);
+//	channel.BasicConsume("orders", true, consumer);              // positional
+//
+// Declaration (the topology side):
+//
+//	channel.QueueDeclare(queue: "orders", durable: true, ...);
+//	channel.QueueDeclare("orders", true, false, false, null);   // positional
+//
+// The routing-key / queue literal is the cross-repo identity (rabbitmq:<name>),
+// mirroring the lapin (Rust) and pika (Python) models. The exchange is recorded
+// as an edge property. Honest-partial: only string-literal args are resolved;
+// named-argument order independence is handled for the publish form, but
+// dynamic / expression args and fanout (empty routing key) publishes are not
+// attributed to a queue.
+
+// csRabbitPublishNamedRe captures the named-argument BasicPublish form
+// `BasicPublish(exchange: "ex", routingKey: "rk", ...)` in either argument
+// order. Group 1/2 = exchange (either order), group 3/4 = routing key.
+var csRabbitPublishNamedRe = regexp.MustCompile(
+	`\.BasicPublish(?:Async)?\s*\(\s*(?:exchange\s*:\s*"([^"\n\r]*)"\s*,\s*routingKey\s*:\s*"([^"\n\r]+)"|routingKey\s*:\s*"([^"\n\r]+)"\s*,\s*exchange\s*:\s*"([^"\n\r]*)")`,
+)
+
+// csRabbitPublishPosRe captures the positional BasicPublish form
+// `BasicPublish("ex", "rk", ...)`. Group 1 = exchange, group 2 = routing key.
+var csRabbitPublishPosRe = regexp.MustCompile(
+	`\.BasicPublish(?:Async)?\s*\(\s*"([^"\n\r]*)"\s*,\s*"([^"\n\r]+)"`,
+)
+
+// csRabbitConsumeNamedRe captures `BasicConsume(queue: "orders", ...)`.
+var csRabbitConsumeNamedRe = regexp.MustCompile(
+	`\.BasicConsume(?:Async)?\s*\([^)]*?queue\s*:\s*"([^"\n\r]+)"`,
+)
+
+// csRabbitConsumePosRe captures positional `BasicConsume("orders", ...)`.
+var csRabbitConsumePosRe = regexp.MustCompile(
+	`\.BasicConsume(?:Async)?\s*\(\s*"([^"\n\r]+)"`,
+)
+
+// csRabbitQueueDeclareNamedRe captures `QueueDeclare(queue: "orders", ...)`.
+var csRabbitQueueDeclareNamedRe = regexp.MustCompile(
+	`\.QueueDeclare(?:Async|Passive)?\s*\([^)]*?queue\s*:\s*"([^"\n\r]+)"`,
+)
+
+// csRabbitQueueDeclarePosRe captures positional `QueueDeclare("orders", ...)`.
+var csRabbitQueueDeclarePosRe = regexp.MustCompile(
+	`\.QueueDeclare(?:Async|Passive)?\s*\(\s*"([^"\n\r]+)"`,
+)
+
+func synthesizeCSharpRabbitMQ(
+	src string,
+	emitQueue func(queueID, queueName, exchange, routingKey string, props map[string]string),
+	emitEdge func(callerKind, callerName, queueID, edgeKind string, props map[string]string),
+) {
+	// Fast pre-filter: only process files that reference RabbitMQ.Client.
+	if !strings.Contains(src, "RabbitMQ") && !strings.Contains(src, "BasicPublish") &&
+		!strings.Contains(src, "BasicConsume") && !strings.Contains(src, "QueueDeclare") {
+		return
+	}
+
+	enclosing := func(offset int) string { return findEnclosingCSharpMethod(src, offset) }
+
+	emitPublish := func(exchange, routingKey string, offset int) {
+		if !looksLikeQueueName(routingKey) {
+			return
+		}
+		qID := rabbitmqQueueID(routingKey)
+		emitQueue(qID, routingKey, exchange, routingKey, map[string]string{
+			"messaging_layer": "rabbitmq-dotnet",
+		})
+		emitEdge("SCOPE.Operation", enclosing(offset), qID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "rabbitmq-dotnet",
+			"exchange":        exchange,
+			"routing_key":     routingKey,
+		})
+	}
+	emitConsume := func(queueName string, offset int) {
+		if !looksLikeQueueName(queueName) {
+			return
+		}
+		qID := rabbitmqQueueID(queueName)
+		emitQueue(qID, queueName, "", "", map[string]string{"messaging_layer": "rabbitmq-dotnet"})
+		emitEdge("SCOPE.Operation", enclosing(offset), qID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "rabbitmq-dotnet",
+		})
+	}
+
+	// Producer: BasicPublish named form (either arg order).
+	pubOffsets := map[int]bool{}
+	for _, m := range csRabbitPublishNamedRe.FindAllStringSubmatchIndex(src, -1) {
+		pubOffsets[m[0]] = true
+		var exchange, routingKey string
+		if m[2] != -1 { // exchange, routingKey order
+			exchange, routingKey = src[m[2]:m[3]], src[m[4]:m[5]]
+		} else { // routingKey, exchange order
+			routingKey, exchange = src[m[6]:m[7]], src[m[8]:m[9]]
+		}
+		emitPublish(exchange, routingKey, m[0])
+	}
+	// Producer: BasicPublish positional form.
+	for _, m := range csRabbitPublishPosRe.FindAllStringSubmatchIndex(src, -1) {
+		if pubOffsets[m[0]] {
+			continue
+		}
+		emitPublish(src[m[2]:m[3]], src[m[4]:m[5]], m[0])
+	}
+
+	// Consumer: BasicConsume named form.
+	consOffsets := map[int]bool{}
+	for _, m := range csRabbitConsumeNamedRe.FindAllStringSubmatchIndex(src, -1) {
+		consOffsets[m[0]] = true
+		emitConsume(src[m[2]:m[3]], m[0])
+	}
+	// Consumer: BasicConsume positional form.
+	for _, m := range csRabbitConsumePosRe.FindAllStringSubmatchIndex(src, -1) {
+		if consOffsets[m[0]] {
+			continue
+		}
+		emitConsume(src[m[2]:m[3]], m[0])
+	}
+
+	// Declaration: QueueDeclare — record the node even with no pub/sub site.
+	declOffsets := map[int]bool{}
+	for _, m := range csRabbitQueueDeclareNamedRe.FindAllStringSubmatchIndex(src, -1) {
+		declOffsets[m[0]] = true
+		name := src[m[2]:m[3]]
+		if looksLikeQueueName(name) {
+			emitQueue(rabbitmqQueueID(name), name, "", "", map[string]string{
+				"messaging_layer": "rabbitmq-dotnet", "declared": "true",
+			})
+		}
+	}
+	for _, m := range csRabbitQueueDeclarePosRe.FindAllStringSubmatchIndex(src, -1) {
+		if declOffsets[m[0]] {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if looksLikeQueueName(name) {
+			emitQueue(rabbitmqQueueID(name), name, "", "", map[string]string{
+				"messaging_layer": "rabbitmq-dotnet", "declared": "true",
+			})
+		}
 	}
 }

--- a/internal/engine/rabbitmq_edges_test.go
+++ b/internal/engine/rabbitmq_edges_test.go
@@ -493,3 +493,140 @@ async fn setup(channel: &Channel) {
 		t.Errorf("expected declared=true, got %q", q.props["declared"])
 	}
 }
+
+// ---------------------------------------------------------------------------
+// C# — RabbitMQ.Client (#4996)
+// ---------------------------------------------------------------------------
+
+// TestRabbitMQ_CSharp_BasicPublishNamed covers the named-argument
+// channel.BasicPublish(exchange:, routingKey:, body:) producer form.
+func TestRabbitMQ_CSharp_BasicPublishNamed(t *testing.T) {
+	src := `using RabbitMQ.Client;
+
+public class OrderPublisher
+{
+    public void Send(IModel channel, byte[] body)
+    {
+        channel.BasicPublish(exchange: "orders-exchange", routingKey: "orders.created", body: body);
+    }
+}
+`
+	ents, rels := runRabbitMQDetect(t, "csharp", "src/OrderPublisher.cs", src)
+	qID := rabbitmqQueueID("orders.created")
+	q := queueByName(ents, qID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue %q, ents=%v", qID, ents)
+	}
+	if q.props["broker"] != "rabbitmq" {
+		t.Errorf("queue broker = %q, want rabbitmq", q.props["broker"])
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	found := false
+	for _, p := range pubs {
+		if strings.Contains(p.to, qID) {
+			found = true
+			if p.props["exchange"] != "orders-exchange" {
+				t.Errorf("exchange prop = %q, want orders-exchange", p.props["exchange"])
+			}
+			if p.props["messaging_layer"] != "rabbitmq-dotnet" {
+				t.Errorf("messaging_layer = %q, want rabbitmq-dotnet", p.props["messaging_layer"])
+			}
+			if !strings.Contains(p.from, "Send") {
+				t.Errorf("PUBLISHES_TO from = %q, want enclosing method Send", p.from)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected PUBLISHES_TO -> %q, pubs=%v", qID, pubs)
+	}
+}
+
+// TestRabbitMQ_CSharp_BasicPublishPositional covers the positional
+// channel.BasicPublish("ex", "rk", ...) form.
+func TestRabbitMQ_CSharp_BasicPublishPositional(t *testing.T) {
+	src := `using RabbitMQ.Client;
+
+public class Worker
+{
+    public void Emit(IModel channel, byte[] body)
+    {
+        channel.BasicPublish("ex", "tasks.queued", null, body);
+    }
+}
+`
+	ents, rels := runRabbitMQDetect(t, "csharp", "src/Worker.cs", src)
+	qID := rabbitmqQueueID("tasks.queued")
+	if queueByName(ents, qID) == nil {
+		t.Fatalf("expected SCOPE.Queue %q, ents=%v", qID, ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 || !strings.Contains(pubs[0].to, qID) {
+		t.Fatalf("expected PUBLISHES_TO -> %q, pubs=%v", qID, pubs)
+	}
+}
+
+// TestRabbitMQ_CSharp_BasicConsume covers named + positional consumer forms.
+func TestRabbitMQ_CSharp_BasicConsume(t *testing.T) {
+	src := `using RabbitMQ.Client;
+
+public class OrderConsumer
+{
+    public void Start(IModel channel, IBasicConsumer c)
+    {
+        channel.BasicConsume(queue: "orders.created", autoAck: true, consumer: c);
+        channel.BasicConsume("payments.settled", true, c);
+    }
+}
+`
+	ents, rels := runRabbitMQDetect(t, "csharp", "src/OrderConsumer.cs", src)
+	for _, name := range []string{"orders.created", "payments.settled"} {
+		if queueByName(ents, rabbitmqQueueID(name)) == nil {
+			t.Fatalf("expected SCOPE.Queue for %q, ents=%v", name, ents)
+		}
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) < 2 {
+		t.Fatalf("expected >=2 SUBSCRIBES_TO edges, got %d (%v)", len(subs), subs)
+	}
+	found := false
+	for _, s := range subs {
+		if strings.Contains(s.to, rabbitmqQueueID("payments.settled")) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected SUBSCRIBES_TO -> rabbitmq:payments.settled, subs=%v", subs)
+	}
+}
+
+// TestRabbitMQ_CSharp_QueueDeclare asserts a QueueDeclare emits a queue node
+// even with no pub/sub call site.
+func TestRabbitMQ_CSharp_QueueDeclare(t *testing.T) {
+	src := `using RabbitMQ.Client;
+
+public class Topology
+{
+    public void Setup(IModel channel)
+    {
+        channel.QueueDeclare(queue: "audit.events", durable: true, exclusive: false, autoDelete: false, arguments: null);
+    }
+}
+`
+	ents, _ := runRabbitMQDetect(t, "csharp", "src/Topology.cs", src)
+	q := queueByName(ents, rabbitmqQueueID("audit.events"))
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for audit.events, ents=%v", ents)
+	}
+	if q.props["declared"] != "true" {
+		t.Errorf("declared prop = %q, want true", q.props["declared"])
+	}
+}
+
+// TestRabbitMQ_CSharp_NoSignal asserts a non-RabbitMQ C# file emits nothing.
+func TestRabbitMQ_CSharp_NoSignal(t *testing.T) {
+	src := `public class Plain { public void Run() { var x = 1; } }`
+	ents, rels := runRabbitMQDetect(t, "csharp", "src/Plain.cs", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("expected nothing for non-RabbitMQ file, got ents=%d rels=%d", len(ents), len(rels))
+	}
+}


### PR DESCRIPTION
## Built vs deferred

C# native low-level broker clients (spun out of #4967, where the bus abstractions landed).

**Built (fixture-proven):**
- **Confluent.Kafka** — `synthesizeCSharpKafka` (kafka_edges.go, case "csharp"):
  - Producer: `Produce("topic", ...)` / `ProduceAsync("topic", ...)` → `PUBLISHES_TO topic:kafka:<name>`
  - Consumer: `Subscribe("topic")` and array form `Subscribe(new[] { "a", "b" })` / `new List<string>{...}` → `SUBSCRIBES_TO`
  - **topic_attribution = FULL** (topic is the explicit string-literal first argument)
- **RabbitMQ.Client** — `synthesizeCSharpRabbitMQ` (rabbitmq_edges.go, case "csharp"):
  - Producer: `BasicPublish(exchange:, routingKey:, ...)` (named, either order) + positional `BasicPublish("ex", "rk", ...)` → `PUBLISHES_TO rabbitmq:<name>`, exchange recorded as edge prop
  - Consumer: `BasicConsume(queue: "q")` (named/positional) → `SUBSCRIBES_TO`
  - `QueueDeclare(...)` → queue node (declared=true)
- **Azure.Messaging (ServiceBus + EventHubs)** — *already implemented* in `azure_messaging_edges.go` (`synthesizeCSharpAzureMessaging`, case "csharp"). No change needed; this PR completes the remaining native-client gap.

**Deferred (follow-ups to file):**
- RabbitMQ `EventingBasicConsumer.Received` / `AsyncEventingBasicConsumer` handler-method attribution (only the BasicConsume call site is modelled).
- Kafka per-partition `Assign(new TopicPartition(...))` consumer form.
- RabbitMQ fanout (empty routing key) and exchange-binding topology decomposition.
- Dynamic/computed (non-literal) topic/queue/routing-key names (intentionally skipped — never fabricate).

## Edges & model
Reuses the established cross-repo synthesis model: `SCOPE.MessageTopic` (`kafka:<name>`) / `SCOPE.Queue` (`rabbitmq:<name>`) nodes + `PUBLISHES_TO`/`SUBSCRIBES_TO` edges from the enclosing C# method, joined producer↔consumer cross-repo by `internal/links/topic_pass.go` with no new linker code. No new entity/edge Kinds.

## Registry cells
New per-language records mirroring `msg.broker.kafka-go`/`rabbitmq-go`:
- `msg.broker.kafka-dotnet`: producer partial, consumer partial, **topic_attribution full**
- `msg.broker.rabbitmq-dotnet`: producer/consumer/topic_attribution partial

Regenerated `docs/coverage` included (detail/msg.broker.kafka-dotnet.md, detail/msg.broker.rabbitmq-dotnet.md, by-language/csharp.md, by-category/message_broker.md, summary.md). `coverage fmt --check` + `coverage validate` pass.

## Fixtures
- kafka_edges_test.go: `TestKafka_CSharp_ProduceProducer`, `TestKafka_CSharp_SubscribeConsumer` (single + array), `TestKafka_CSharp_NoSignal`
- rabbitmq_edges_test.go: `TestRabbitMQ_CSharp_BasicPublishNamed`, `...Positional`, `...BasicConsume`, `...QueueDeclare`, `...NoSignal`

All value-asserting (exact `kafka:<name>`/`rabbitmq:<name>` ID + directional edge + enclosing-method caller).

## Gates (sandbox HOME=/tmp/agsbx-4996)
`go build ./...` ✅, `go vet ./internal/...` ✅, `go test ./internal/custom/csharp/... ./internal/engine/... ./internal/extractors/csharp/... ./internal/types/` ✅, `coverage fmt --check` ✅, `coverage validate` ✅ (new records carry issue refs; only pre-existing capability-map warnings remain, same shape as kafka-go/rabbitmq-go).

Deploy-deferred.

Refs #4996