### PR TITLE
feat(#5060): archigraph_test_reachability MCP tool — untested fns/endpoints

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP tools
 
-archigraph exposes **65 MCP tools** (plus one cwd-gate sentinel, `archigraph_status`), all prefixed `archigraph_`. The canonical source of truth for inputs, outputs, and response shapes is:
+archigraph exposes **66 MCP tools** (plus one cwd-gate sentinel, `archigraph_status`), all prefixed `archigraph_`. The canonical source of truth for inputs, outputs, and response shapes is:
 
 **[`internal/mcp/SCHEMA.md`](../internal/mcp/SCHEMA.md)**
 
@@ -111,6 +111,7 @@ Security, secrets, licenses, test coverage, dead code, and cross-group parity.
 | [`archigraph_secrets`](mcp-tools/audit.md#archigraph_secrets) | Scan for hardcoded secrets; masked findings by severity. |
 | [`archigraph_license_audit`](mcp-tools/audit.md#archigraph_license_audit) | Audit dependency licenses; flag GPL/AGPL conflicts. |
 | [`archigraph_test_coverage`](mcp-tools/audit.md#archigraph_test_coverage) | Production entities with no TESTS edge, ranked by severity. |
+| [`archigraph_test_reachability`](mcp-tools/audit.md#archigraph_test_reachability) | Static test-reachability (TESTS+CALLS): orphan fns/endpoints with no test path. |
 | [`archigraph_dead_code`](mcp-tools/audit.md#archigraph_dead_code) | Reachability dead-code: entities unreached by entry-points. |
 | [`archigraph_find_dead_code`](mcp-tools/audit.md#archigraph_find_dead_code) | Dead/unwired code: isolated, marked-unused, or test-only symbols. |
 | [`archigraph_security_findings`](mcp-tools/audit.md#archigraph_security_findings) | Taint-flow findings: source → sink paths ranked by confidence. |

--- a/docs/mcp-tools/audit.md
+++ b/docs/mcp-tools/audit.md
@@ -46,6 +46,20 @@ Output: production entities lacking TESTS edges, ranked by severity.
 
 ---
 
+## `archigraph_test_reachability`
+
+Static test-reachability over the **TESTS + CALLS** call graph: which functions and endpoints are reached by *any* test path, and — the key signal — which are **orphans** with no test path at all.
+
+Unlike `archigraph_test_coverage` (which only checks for a *direct* inbound `TESTS` edge), this tool reflects *transitive* reachability: a function is reachable if a test reaches it through one or more `CALLS` hops. It surfaces the reaching tests and the minimum hop depth per entity.
+
+The signal is computed by the indexer (#5037 / #5061) and **stamped onto entity properties** (`test_reachable`, `reaching_tests`, `reaching_test_count`, `reach_depth`). This tool **reads those properties off the loaded graph — it does not recompute**. If a group was indexed before the reachability pass landed (no entity carries `test_reachable`), the tool says *"reachability not computed — reindex"* rather than returning a misleading empty/all-zero result.
+
+Key parameters: `entity_id` (optional — focus a single entity), `repo_filter[]`, `untested_only` (bool — list only orphans), `endpoints_only` (bool — HTTP endpoints/routes only), `limit` (default 100).
+
+Output: group and per-module reachability roll-ups (% reachable), an endpoint roll-up, and a row listing sorted **orphans-first** (endpoints before plain functions). Each reachable row shows `depth` and reaching-test count; a `[reachable-but-0%-lines]` tag flags entities statically reached by a test yet with 0% measured LCOV line coverage (the candidate-ineffective-test signal, crossing #5036). The canonical orphan query is `untested_only=true` (optionally with `endpoints_only=true`): "which endpoints/handlers have NO test reaching them".
+
+---
+
 ## `archigraph_dead_code`
 
 Reachability dead-code: entities unreached by entry-points.

--- a/internal/mcp/reachability_tools.go
+++ b/internal/mcp/reachability_tools.go
@@ -1,0 +1,344 @@
+// reachability_tools.go — MCP tool for static test-reachability (#5060).
+//
+// Tool: archigraph_test_reachability
+//
+//	Surfaces the static test-reachability signal computed by #5037 and stamped
+//	onto production entities at index time by the #5061 enrichment pass. Unlike
+//	archigraph_test_coverage (which only checks for a *direct* inbound TESTS
+//	edge), this tool reflects transitive reachability over TESTS+CALLS edges:
+//	"is there ANY test path that reaches this function/endpoint?" — with the
+//	reaching tests and minimum hop depth.
+//
+// The KEY use case is orphan discovery: which endpoints / handlers / functions
+// have NO test path reaching them at all (the parity-rewrite risk surface).
+//
+// This tool does NOT recompute anything. It reads the properties the indexer
+// already stamped (coverage.PropTestReachable / PropReachingTests /
+// PropReachingTestCount / PropReachDepth) directly off the loaded graph, the
+// same way the other read-only MCP tools read entities. When those properties
+// are absent for a group (indexed before #5061, or with no test edges), it says
+// so explicitly rather than returning a misleading all-zero result.
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// reachRow is one production entity's reachability verdict, projected from its
+// stamped properties.
+type reachRow struct {
+	id          string
+	name        string
+	kind        string
+	sourceFile  string
+	startLine   int
+	isEndpoint  bool
+	reachable   bool
+	depth       int
+	reachCount  int    // distinct reaching tests (uncapped)
+	reaching    string // comma-joined capped list, as stamped
+	crossSignal coverage.CrossSignalVerdict
+}
+
+// handleTestReachability implements archigraph_test_reachability.
+func (s *Server) handleTestReachability(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, toolErr := s.resolveAndGroup(req)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+
+	entityID := argString(req, "entity_id", "")
+	repoFilter := argStringSlice(req, "repo_filter")
+	untestedOnly := argBool(req, "untested_only", false)
+	endpointsOnly := argBool(req, "endpoints_only", false)
+	limit := argInt(req, "limit", 100)
+
+	// ── collect projected rows across the (filtered) repos ────────────────────
+	repoNames := make([]string, 0, len(lg.Repos))
+	for name := range lg.Repos {
+		repoNames = append(repoNames, name)
+	}
+	sort.Strings(repoNames)
+
+	var rows []reachRow
+	stampedSeen := false // did ANY entity carry the reachability prop?
+	modAcc := map[string]*coverage.RollUp{}
+
+	for _, name := range repoNames {
+		lr := lg.Repos[name]
+		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		if len(repoFilter) > 0 && !repoMatchesSlice(lr.Repo, repoFilter) {
+			continue
+		}
+		for i := range lr.Doc.Entities {
+			e := &lr.Doc.Entities[i]
+			if e.Properties == nil {
+				continue
+			}
+			val, ok := e.Properties[coverage.PropTestReachable]
+			if !ok {
+				continue // not a reachability-considered production entity
+			}
+			stampedSeen = true
+
+			row := projectReachRow(e, val)
+
+			// module roll-up (over all stamped production entities, pre-filter).
+			mod := moduleOf(e)
+			acc := modAcc[mod]
+			if acc == nil {
+				acc = &coverage.RollUp{}
+				modAcc[mod] = acc
+			}
+			acc.Total++
+			if row.reachable {
+				acc.Reachable++
+			}
+
+			// row-level filters.
+			if entityID != "" && row.id != entityID {
+				continue
+			}
+			if endpointsOnly && !row.isEndpoint {
+				continue
+			}
+			if untestedOnly && row.reachable {
+				continue
+			}
+			rows = append(rows, row)
+		}
+	}
+
+	// ── honesty gate: nothing stamped → tell the agent to reindex ─────────────
+	if !stampedSeen {
+		return mcpapi.NewToolResultText(fmt.Sprintf(
+			"## Test reachability — group %q\n\n"+
+				"_Reachability not computed for this group._ No entity carries the "+
+				"`%s` property, which means the group was indexed before the #5061 "+
+				"reachability enrichment pass (or has no test/call edges to traverse).\n\n"+
+				"**Reindex the group** to populate the static test-reachability signal, "+
+				"then re-run this tool.\n",
+			lg.Name, coverage.PropTestReachable,
+		)), nil
+	}
+
+	// ── group + endpoint roll-ups ─────────────────────────────────────────────
+	var grpTotal, grpReach, epTotal, epReach int
+	for _, a := range modAcc {
+		grpTotal += a.Total
+		grpReach += a.Reachable
+	}
+	// Endpoint roll-up is derived from rows we projected as endpoints; but
+	// because row-level filters may have excluded some, recompute from the docs
+	// is overkill — instead count endpoints across the *unfiltered* stamped set.
+	epTotal, epReach = endpointRollup(lg, repoFilter)
+
+	// ── sort rows: orphans first, then most-reaching, then location ───────────
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].reachable != rows[j].reachable {
+			return !rows[i].reachable // unreachable (orphans) first
+		}
+		if rows[i].isEndpoint != rows[j].isEndpoint {
+			return rows[i].isEndpoint // endpoints before plain functions
+		}
+		if rows[i].sourceFile != rows[j].sourceFile {
+			return rows[i].sourceFile < rows[j].sourceFile
+		}
+		return rows[i].startLine < rows[j].startLine
+	})
+	shown := rows
+	if len(shown) > limit {
+		shown = shown[:limit]
+	}
+
+	// ── render ────────────────────────────────────────────────────────────────
+	out := fmt.Sprintf("## Test reachability — group %q\n\n", lg.Name)
+	out += fmt.Sprintf(
+		"Production entities : %d\n"+
+			"Test-reachable      : %d (%s)\n"+
+			"Orphans (untested)  : %d\n",
+		grpTotal, grpReach, pct(grpReach, grpTotal),
+		grpTotal-grpReach,
+	)
+	if epTotal > 0 {
+		out += fmt.Sprintf(
+			"Endpoints           : %d\n"+
+				"Endpoints reachable : %d (%s)\n"+
+				"Endpoint orphans    : %d\n",
+			epTotal, epReach, pct(epReach, epTotal), epTotal-epReach,
+		)
+	}
+
+	// per-module breakdown, least-reachable first.
+	if len(modAcc) > 0 {
+		type mr struct {
+			mod   string
+			total int
+			reach int
+		}
+		mods := make([]mr, 0, len(modAcc))
+		for m, a := range modAcc {
+			mods = append(mods, mr{m, a.Total, a.Reachable})
+		}
+		sort.Slice(mods, func(i, j int) bool {
+			pi := ratio(mods[i].reach, mods[i].total)
+			pj := ratio(mods[j].reach, mods[j].total)
+			if pi != pj {
+				return pi < pj
+			}
+			return mods[i].mod < mods[j].mod
+		})
+		if len(mods) > 20 {
+			mods = mods[:20]
+		}
+		out += "\n### Modules by reachability (lowest first)\n\n"
+		out += fmt.Sprintf("%-9s %-6s %-6s  %s\n", "Reach%", "Rch", "Total", "Module")
+		for _, m := range mods {
+			out += fmt.Sprintf("%-9s %-6d %-6d  %s\n", pct(m.reach, m.total), m.reach, m.total, m.mod)
+		}
+	}
+
+	// the row listing — defaults to orphans-first so "what has no test path" is
+	// answered at the top.
+	heading := "Entities"
+	if untestedOnly {
+		heading = "Orphans (no test path)"
+	} else if endpointsOnly {
+		heading = "Endpoints"
+	}
+	out += fmt.Sprintf("\n### %s (%d shown of %d)\n\n", heading, len(shown), len(rows))
+	if len(shown) == 0 {
+		out += "_No matching entities._\n"
+	}
+	for _, r := range shown {
+		marker := "ORPHAN"
+		detail := ""
+		if r.reachable {
+			marker = "reachable"
+			detail = fmt.Sprintf("  depth=%d tests=%d", r.depth, r.reachCount)
+			if r.crossSignal == coverage.CrossSignalReachableNoLines {
+				detail += "  [reachable-but-0%-lines]"
+			}
+		}
+		tag := ""
+		if r.isEndpoint {
+			tag = "endpoint "
+		}
+		out += fmt.Sprintf("- [%s] %s%s  %s:%d%s\n",
+			marker, tag, r.name, r.sourceFile, r.startLine, detail)
+		if r.reachable && r.reaching != "" && (entityID != "" || len(shown) <= 25) {
+			out += "    reaching_tests: " + r.reaching + "\n"
+		}
+	}
+
+	return mcpapi.NewToolResultText(out), nil
+}
+
+// projectReachRow reads the stamped reachability properties off a loaded entity
+// into a reachRow. reachableStr is the already-fetched PropTestReachable value.
+func projectReachRow(e *graph.Entity, reachableStr string) reachRow {
+	reachable, _ := strconv.ParseBool(reachableStr)
+	row := reachRow{
+		id:          e.ID,
+		name:        e.Name,
+		kind:        e.Kind,
+		sourceFile:  e.SourceFile,
+		startLine:   e.StartLine,
+		isEndpoint:  isEndpointKind(e.Kind),
+		reachable:   reachable,
+		crossSignal: coverage.CrossSignal(e.Properties),
+	}
+	if reachable {
+		row.depth, _ = strconv.Atoi(e.Properties[coverage.PropReachDepth])
+		row.reachCount, _ = strconv.Atoi(e.Properties[coverage.PropReachingTestCount])
+		row.reaching = e.Properties[coverage.PropReachingTests]
+	}
+	return row
+}
+
+// endpointRollup counts stamped endpoint entities and how many are reachable,
+// across the (filtered) repos. Separate from the row projection so the endpoint
+// summary is independent of row-level filters.
+func endpointRollup(lg *LoadedGroup, repoFilter []string) (total, reachable int) {
+	for _, lr := range lg.Repos {
+		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		if len(repoFilter) > 0 && !repoMatchesSlice(lr.Repo, repoFilter) {
+			continue
+		}
+		for i := range lr.Doc.Entities {
+			e := &lr.Doc.Entities[i]
+			if e.Properties == nil || !isEndpointKind(e.Kind) {
+				continue
+			}
+			val, ok := e.Properties[coverage.PropTestReachable]
+			if !ok {
+				continue
+			}
+			total++
+			if r, _ := strconv.ParseBool(val); r {
+				reachable++
+			}
+		}
+	}
+	return total, reachable
+}
+
+// isEndpointKind reports whether a kind is an HTTP endpoint surface (both the
+// SCOPE.Endpoint scope kind and the http_endpoint_definition cross-link kind).
+func isEndpointKind(kind string) bool {
+	switch types.EntityKind(kind) {
+	case types.EntityKindEndpoint,
+		types.EntityKindRoute,
+		types.EntityKindHTTPEndpointDefinition:
+		return true
+	}
+	return false
+}
+
+// moduleOf returns an entity's module bucket: the stamped Properties["module"]
+// when present, else the containing directory of its source file.
+func moduleOf(e *graph.Entity) string {
+	if e.Properties != nil {
+		if m := e.Properties["module"]; m != "" {
+			return m
+		}
+	}
+	src := e.SourceFile
+	if src == "" {
+		return "."
+	}
+	for i := len(src) - 1; i >= 0; i-- {
+		if src[i] == '/' || src[i] == '\\' {
+			return src[:i]
+		}
+	}
+	return "."
+}
+
+// pct formats reach/total as a percentage string; "n/a" when total is zero.
+func pct(reach, total int) string {
+	if total == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", 100.0*float64(reach)/float64(total))
+}
+
+// ratio returns reach/total in [0,1]; 0 when total is zero (sort helper).
+func ratio(reach, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	return float64(reach) / float64(total)
+}

--- a/internal/mcp/reachability_tools_5060_test.go
+++ b/internal/mcp/reachability_tools_5060_test.go
@@ -1,0 +1,205 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildReachabilityDoc builds a Document whose entities carry the static
+// test-reachability properties that #5061's enrichment pass stamps. The tool
+// reads these directly — it never recomputes.
+//
+//	fn_reached   Function  test_reachable=true  depth=2  tests=test_a,test_b
+//	ep_reached   Endpoint  test_reachable=true  (via handler) depth=1
+//	ep_orphan    Endpoint  test_reachable=false  ← the orphan we want surfaced
+//	fn_orphan    Function  test_reachable=false  reachable-but-0%-lines? no
+//	fn_no_lines  Function  test_reachable=true   line_pct=0 → reachable_no_lines
+//	schema_x     Schema    (no reachability prop — not a production entity)
+func buildReachabilityDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID: "fn_reached", Name: "ProcessOrder", Kind: "SCOPE.Function",
+				SourceFile: "orders/process.go", StartLine: 10,
+				Properties: map[string]string{
+					coverage.PropTestReachable:     "true",
+					coverage.PropReachDepth:        "2",
+					coverage.PropReachingTestCount: "2",
+					coverage.PropReachingTests:     "test_a,test_b",
+				},
+			},
+			{
+				ID: "ep_reached", Name: "GET /orders", Kind: "SCOPE.Endpoint",
+				SourceFile: "orders/routes.go", StartLine: 5,
+				Properties: map[string]string{
+					coverage.PropTestReachable:     "true",
+					coverage.PropReachDepth:        "1",
+					coverage.PropReachingTestCount: "1",
+					coverage.PropReachingTests:     "test_e2e",
+				},
+			},
+			{
+				ID: "ep_orphan", Name: "POST /inspections", Kind: "SCOPE.Endpoint",
+				SourceFile: "inspections/routes.go", StartLine: 12,
+				Properties: map[string]string{
+					coverage.PropTestReachable: "false",
+				},
+			},
+			{
+				ID: "fn_orphan", Name: "ReconcileLedger", Kind: "SCOPE.Function",
+				SourceFile: "ledger/reconcile.go", StartLine: 40,
+				Properties: map[string]string{
+					coverage.PropTestReachable: "false",
+				},
+			},
+			{
+				ID: "fn_no_lines", Name: "ValidateTax", Kind: "SCOPE.Function",
+				SourceFile: "tax/validate.go", StartLine: 8,
+				Properties: map[string]string{
+					coverage.PropTestReachable:     "true",
+					coverage.PropReachDepth:        "1",
+					coverage.PropReachingTestCount: "1",
+					coverage.PropReachingTests:     "test_tax",
+					coverage.PropCoveragePct:       "0",
+				},
+			},
+			{
+				ID: "schema_x", Name: "Order", Kind: "SCOPE.Schema",
+				SourceFile: "orders/model.go", StartLine: 1,
+				// No reachability prop — not a production entity; must be ignored.
+			},
+		},
+	}
+}
+
+func callReach(t *testing.T, srv *Server, args map[string]any) string {
+	t.Helper()
+	args["group"] = "test"
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleTestReachability(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	return resultText(res)
+}
+
+func TestTestReachability_DefaultListing(t *testing.T) {
+	srv := newTestServer(t, buildReachabilityDoc())
+	out := callReach(t, srv, map[string]any{})
+
+	// Roll-ups: 5 production entities (4 reachable: fn_reached, ep_reached,
+	// fn_no_lines; ep_orphan + fn_orphan are not). schema_x excluded.
+	if !strings.Contains(out, "Production entities : 5") {
+		t.Errorf("expected 5 production entities, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Test-reachable      : 3") {
+		t.Errorf("expected 3 reachable, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Orphans (untested)  : 2") {
+		t.Errorf("expected 2 orphans, got:\n%s", out)
+	}
+	// Endpoint roll-up: 2 endpoints, 1 reachable.
+	if !strings.Contains(out, "Endpoints           : 2") {
+		t.Errorf("expected 2 endpoints, got:\n%s", out)
+	}
+	// Orphans should sort to the top (endpoint orphan first).
+	if !strings.Contains(out, "[ORPHAN]") {
+		t.Errorf("expected ORPHAN marker, got:\n%s", out)
+	}
+	idxOrphan := strings.Index(out, "POST /inspections")
+	idxReachable := strings.Index(out, "ProcessOrder")
+	if idxOrphan == -1 || idxReachable == -1 || idxOrphan > idxReachable {
+		t.Errorf("orphan endpoint should sort before reachable fn:\n%s", out)
+	}
+	// schema_x (a non-production Schema, with no reachability prop) must never
+	// appear — neither by id nor by name.
+	if strings.Contains(out, "schema_x") || strings.Contains(out, "model.go") {
+		t.Errorf("non-production entity leaked into output:\n%s", out)
+	}
+}
+
+func TestTestReachability_UntestedOnly(t *testing.T) {
+	srv := newTestServer(t, buildReachabilityDoc())
+	out := callReach(t, srv, map[string]any{"untested_only": true})
+
+	if !strings.Contains(out, "POST /inspections") || !strings.Contains(out, "ReconcileLedger") {
+		t.Errorf("expected both orphans listed, got:\n%s", out)
+	}
+	// Reachable entities must be filtered out of the listing.
+	if strings.Contains(out, "[reachable]") {
+		t.Errorf("untested_only should not list reachable rows:\n%s", out)
+	}
+}
+
+func TestTestReachability_EndpointsOnly(t *testing.T) {
+	srv := newTestServer(t, buildReachabilityDoc())
+	out := callReach(t, srv, map[string]any{"endpoints_only": true})
+
+	if !strings.Contains(out, "POST /inspections") || !strings.Contains(out, "GET /orders") {
+		t.Errorf("expected both endpoints, got:\n%s", out)
+	}
+	// Plain functions must not appear in endpoints_only listing.
+	if strings.Contains(out, "ProcessOrder") || strings.Contains(out, "ReconcileLedger") {
+		t.Errorf("endpoints_only leaked a function:\n%s", out)
+	}
+}
+
+func TestTestReachability_EntityFocus(t *testing.T) {
+	srv := newTestServer(t, buildReachabilityDoc())
+	out := callReach(t, srv, map[string]any{"entity_id": "fn_reached"})
+
+	if !strings.Contains(out, "ProcessOrder") {
+		t.Errorf("expected focused entity, got:\n%s", out)
+	}
+	if !strings.Contains(out, "depth=2") || !strings.Contains(out, "tests=2") {
+		t.Errorf("expected depth/test count detail, got:\n%s", out)
+	}
+	if !strings.Contains(out, "reaching_tests: test_a,test_b") {
+		t.Errorf("expected reaching tests for focused entity, got:\n%s", out)
+	}
+	// Other entities should be filtered out.
+	if strings.Contains(out, "ReconcileLedger") {
+		t.Errorf("entity_id focus leaked other rows:\n%s", out)
+	}
+}
+
+func TestTestReachability_CrossSignal(t *testing.T) {
+	srv := newTestServer(t, buildReachabilityDoc())
+	out := callReach(t, srv, map[string]any{})
+	// fn_no_lines is reachable but has line_pct=0 → reachable-but-0%-lines tag.
+	if !strings.Contains(out, "ValidateTax") {
+		t.Fatalf("expected ValidateTax row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "reachable-but-0%-lines") {
+		t.Errorf("expected cross-signal tag for reachable_no_lines entity:\n%s", out)
+	}
+}
+
+func TestTestReachability_NotComputed(t *testing.T) {
+	// A doc with NO reachability props at all → honesty path.
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{ID: "f1", Name: "Foo", Kind: "SCOPE.Function", SourceFile: "a.go", StartLine: 1},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callReach(t, srv, map[string]any{})
+
+	if !strings.Contains(out, "Reachability not computed") {
+		t.Errorf("expected not-computed honesty message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Reindex") {
+		t.Errorf("expected reindex guidance, got:\n%s", out)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1105,6 +1105,22 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("ref"), // PH1c: optional git ref
 	), s.wrap("archigraph_test_coverage", s.handleTestCoverage))
 
+	// #5060: static test-reachability — transitive TESTS+CALLS reach (#5037),
+	// stamped at index time by #5061. Surfaces orphan endpoints/functions with
+	// NO test path, the reaching tests, and min hop depth. Reads stamped props;
+	// does not recompute.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_test_reachability",
+		mcpapi.WithDescription("Static test-reachability: fns/endpoints with NO test path (orphans), depth."),
+		mcpapi.WithString("entity_id"),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithBoolean("untested_only", mcpapi.DefaultBool(false)),
+		mcpapi.WithBoolean("endpoints_only", mcpapi.DefaultBool(false)),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+		mcpapi.WithAny("ref"), // PH1c: optional git ref
+	), s.wrap("archigraph_test_reachability", s.handleTestReachability))
+
 	// archigraph_module_analysis — module-level GDS (#1384, epic #1380).
 	// action=cycles|centrality|all over the aggregated module graph: SCCs,
 	// PageRank, betweenness. Bird's-eye view alongside entity-level tools.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -577,6 +577,7 @@ func TestToolNameSurface(t *testing.T) {
 		// Additional audit/analysis tools
 		"archigraph_secrets", "archigraph_quality_cycles",
 		"archigraph_test_coverage", "archigraph_license_audit",
+		"archigraph_test_reachability",
 		"archigraph_module_analysis", "archigraph_diff_refs",
 		// #1742 subgraph retained (despite deprecation)
 		"archigraph_subgraph",
@@ -718,8 +719,8 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_apply_doc_semantics (#4309 doc ingestion L2 apply step).
 	// +1 archigraph_control_flow (#4822 on-demand per-function CFG, control-flow epic #4820 part (b)).
 	// +1 archigraph_contract_test_effectiveness (#4893 tautological/oracle-blind spec detector).
-	if got := len(allRegisteredTools); got != 66 {
-		t.Errorf("expected 66 registered tools, got %d — update this count if tools are added/removed (added archigraph_contract_test_effectiveness #4893)", got)
+	if got := len(allRegisteredTools); got != 67 {
+		t.Errorf("expected 67 registered tools, got %d — update this count if tools are added/removed (added archigraph_test_reachability #5060)", got)
 	}
 }
 
@@ -3194,6 +3195,7 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_quality_cycles":       {"group": "g"},
 		"archigraph_auth_coverage":        {"group": "g"},
 		"archigraph_test_coverage":        {"group": "g"},
+		"archigraph_test_reachability":    {"group": "g"},
 		"archigraph_module_analysis":      {"group": "g"},
 		"archigraph_secrets":              {"group": "g"},
 		"archigraph_neighbors":            {"group": "g", "entity_id": "r1::a2", "direction": "both"},
@@ -3302,8 +3304,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 66 {
-		t.Errorf("expected 66 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_contract_test_effectiveness #4893)", len(tools))
+	if len(tools) != 67 {
+		t.Errorf("expected 67 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_test_reachability #5060)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
## What

New read-only MCP tool **`archigraph_test_reachability`** that exposes the static test-reachability signal — computed by #5037 and stamped onto entity Properties at index time by #5061 — to agents.

Unlike `archigraph_test_coverage` (direct inbound `TESTS` edge only), this reflects **transitive** reachability over `TESTS + CALLS`: a function/endpoint is reachable if *any* test reaches it through ≥0 call hops.

## What it returns

- Group + per-module reachability roll-ups (`% reachable`, least-reachable module first).
- Endpoint roll-up (endpoints reachable vs orphan).
- Row listing sorted **orphans-first** (endpoints before plain functions). Reachable rows show min `depth` and reaching-test count; a `[reachable-but-0%-lines]` tag crosses #5036 LCOV line-coverage to flag candidate-ineffective tests.

### The orphan query (key use case)
`untested_only=true` (optionally `+ endpoints_only=true`) → "which endpoints/handlers have **NO** test path reaching them". Also `entity_id` to focus one entity, `repo_filter[]`, `limit`.

## Where it reads the props

`internal/mcp/reachability_tools.go` reads `coverage.PropTestReachable` / `PropReachingTests` / `PropReachingTestCount` / `PropReachDepth` directly off the loaded `graph.Entity.Properties` — the same seam #5061's `coverage.Enrich` stamps. **It does not recompute.** Presence of `test_reachable` on any entity = the group was reachability-enriched (the pass emits an explicit `true`/`false` on every production entity).

## Honesty

If **no** entity carries `test_reachable` (group indexed before #5061, or no test/call edges), the tool returns a clear *"Reachability not computed for this group — reindex"* message rather than an empty/all-zero (misleading) result.

## Docs

- `docs/mcp-tools/audit.md` — full detail section (sits next to `archigraph_test_coverage`).
- `docs/mcp-tools.md` — Audit index-table row added; catalogue count **65 → 66**.

## Fixture / test

`internal/mcp/reachability_tools_5060_test.go` exercises the handler against a fixture graph carrying stamped reachability props: default listing + roll-ups, `untested_only`, `endpoints_only`, `entity_id` focus, the reachable-but-0%-lines cross-signal, and the not-computed honesty path. Non-production (Schema) entities are confirmed excluded.

## Gates (sandbox HOME=/tmp/agsbx-5060)

`go build ./...`, `go vet ./internal/...`, `go test ./internal/mcp/... ./internal/coverage/... ./internal/types/` — all pass. Tool-surface count assertions bumped 66→67 (registered tools incl. sentinel) in `server_test.go` (`TestToolNameSurface` + `minimalArgs` map + `wantPresent`); description kept ≤80 chars for the handshake budget gate.

Deploy-deferred.

Refs #5060