### PR TITLE
feat(#5049): fsharp — validation (DataAnnotations field chips)

### DIFF
--- a/docs/coverage/by-category/validation.md
+++ b/docs/coverage/by-category/validation.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # validation
 
-**Total**: 11 records · **C/C++**: 1 · **java**: 1 · **JS/TS**: 4 · **kotlin**: 1 · **python**: 3 · **rust**: 1
+**Total**: 12 records · **C/C++**: 1 · **F#**: 1 · **java**: 1 · **JS/TS**: 4 · **kotlin**: 1 · **python**: 3 · **rust**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -12,6 +12,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | Language | Name | Testing | Other capabilities | Status | Notes |
 |---|---|---|---|---|---|
 | [C/C++](../by-language/c-cpp.md) | [nlohmann/json (C++)](../detail/lang.c-cpp.framework.nlohmann-json.md) | ✅ 1/1 | 🟡 3/5 | 🔴 | |
+| [F#](../by-language/fsharp.md) | [DataAnnotations (F# records)](../detail/lang.fsharp.validation.dataannotations.md) | 🔴 0/1 | 🟡 2/4 | 🔴 | |
 | [java](../by-language/java.md) | [Bean Validation (Jakarta/javax)](../detail/lang.java.validation.bean-validation.md) | 🔴 0/1 | ✅ 4/4 | 🔴 | |
 | [JS/TS](../by-language/jsts.md) | [Joi (@hapi/joi)](../detail/lang.jsts.validation.joi.md) | 🟢 1/1 | 🟡 2/5 | 🔴 | |
 | [JS/TS](../by-language/jsts.md) | [Yup](../detail/lang.jsts.validation.yup.md) | 🟢 1/1 | 🟡 2/5 | 🔴 | |

--- a/docs/coverage/by-language/fsharp.md
+++ b/docs/coverage/by-language/fsharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # F#
 
-**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 1
+**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 2
 
 Back to [summary](../summary.md).
 
@@ -40,3 +40,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Category | Status | Notes |
 |---|---|---|---|
 | [F#](../detail/lang.fsharp.core.md) | [language](../by-category/language.md) | 🟢 | |
+
+### Validation
+
+| Name | Testing | Other capabilities | Notes |
+|---|---|---|---|
+| [DataAnnotations (F# records)](../detail/lang.fsharp.validation.dataannotations.md) | 🔴 0/1 | 🟡 2/4 | |

--- a/docs/coverage/detail/lang.fsharp.validation.dataannotations.md
+++ b/docs/coverage/detail/lang.fsharp.validation.dataannotations.md
@@ -1,0 +1,48 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.fsharp.validation.dataannotations` — DataAnnotations (F# records)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [F#](../by-language/fsharp.md)
+- **Category:** [validation](../by-category/validation.md)
+- **Subcategory:** Validation
+- **Capability cells:** 6
+
+## Capabilities
+
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Nested model extraction | 🔴 `missing` | — | 5049 | — | Nested record references are captured as field types but not expanded into a structured nested-schema tree, and no owner->nested VALIDATES edge is materialised yet. Honest-partial deferred to a follow-up. |
+| Schema extraction | ✅ `full` | `2026-06-13` | 5049 | `internal/extractors/fsharp/du_record_members.go`<br>`internal/extractors/fsharp/fsharp_test.go` | #4942: F# record types emit each field as a SCOPE.Schema/field sub-entity (extractTypeMembers/parseRecordFields), with a type->field CONTAINS edge. Proven by TestFSharp_RecordFields. |
+
+### Constraints
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Constraint extraction | ✅ `full` | `2026-06-13` | 5049 | `internal/extractors/fsharp/du_record_members.go`<br>`internal/extractors/fsharp/field_validations.go`<br>`internal/extractors/fsharp/fsharp_test.go` | #5049: System.ComponentModel.DataAnnotations attributes on record fields ([<Required>]/[<EmailAddress>]/[<StringLength(n)>]/[<MinLength(n)>]/[<MaxLength(n)>]/[<Range(lo,hi)>]/[<RegularExpression(..)>] and markers Phone/Url/CreditCard/Compare/...) are parsed off the preceding (and inline) [<...>] attribute lines and folded into terse comma-free chips on Properties["validations"] (Required, Email, MaxLength:120, Range:1..5, Pattern), which the dashboard ShapeTree renders. Mirrors the Java #4872 / TS #4858 / Python #4871 field-validation chips. Non-validation attributes ([<CLIMutable>]) are ignored. Proven by TestFSharp_DataAnnotationsValidations, TestFSharp_InlineValidationAttribute, TestFSharp_NonValidationAttributesIgnored. |
+| Custom validator extraction | 🔴 `missing` | — | 5049 | — | [<CustomValidation(typeof<...>, "Method")>] and IValidatableObject.Validate custom validators are not yet linked. Deferred follow-up (Validus / FsToolkit.ErrorHandling Result/Validation pipelines also deferred). |
+
+### Coercion
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type coercion recognition | — `not_applicable` | `2026-06-13` | — | — | DataAnnotations validate, they do not coerce types; model binding/coercion is the HTTP framework's responsibility. |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 5049 | — | No validation-specific test-linkage fixtures yet; general F# test-linkage substrate provides TESTS edges. Deferred follow-up. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.fsharp.validation.dataannotations ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 202
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 203
 
 ## Coverage by language
 
@@ -25,7 +25,7 @@
 | [dart](by-language/dart.md) | 3 | 1 | 0 | 1 |
 | [crystal](by-language/crystal.md) | 1 | 0 | 1 | 1 |
 | [erlang](by-language/erlang.md) | 1 | 0 | 0 | 2 |
-| [F#](by-language/fsharp.md) | 1 | 1 | 0 | 1 |
+| [F#](by-language/fsharp.md) | 1 | 1 | 0 | 2 |
 | [groovy](by-language/groovy.md) | 1 | 1 | 0 | 1 |
 | [nim](by-language/nim.md) | 1 | 0 | 4 | 1 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 5 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 246 frameworks · 120 tools · 170 ORMs · 202 other
+Total: 246 frameworks · 120 tools · 170 ORMs · 203 other

--- a/internal/extractors/fsharp/du_record_members.go
+++ b/internal/extractors/fsharp/du_record_members.go
@@ -62,6 +62,16 @@ func extractTypeMembers(
 		if mi.typ != "" {
 			sig = mi.name + ": " + mi.typ
 		}
+		props := map[string]string{
+			"member_name":  mi.name,
+			"member_type":  mi.typ,
+			"parent_class": owner,
+		}
+		// #5049: stamp DataAnnotations validation chips so the dashboard
+		// ShapeTree renders them (Properties["validations"], comma-joined).
+		if len(mi.validations) > 0 {
+			props["validations"] = strings.Join(mi.validations, ",")
+		}
 		ents = append(ents, types.EntityRecord{
 			Name:       dotted,
 			Kind:       "SCOPE.Schema",
@@ -71,11 +81,7 @@ func extractTypeMembers(
 			StartLine:  line,
 			EndLine:    line,
 			Signature:  sig,
-			Properties: map[string]string{
-				"member_name":  mi.name,
-				"member_type":  mi.typ,
-				"parent_class": owner,
-			},
+			Properties: props,
 		})
 		rels = append(rels, types.RelationshipRecord{
 			ToID: extractor.BuildSchemaFieldStructuralRef("fsharp", filePath, dotted),
@@ -87,9 +93,10 @@ func extractTypeMembers(
 
 // memberInfo holds a parsed DU case / record field.
 type memberInfo struct {
-	name       string
-	typ        string // payload type (DU `of T`) or field type annotation
-	lineOffset int    // line offset relative to the type declaration start
+	name        string
+	typ         string   // payload type (DU `of T`) or field type annotation
+	lineOffset  int      // line offset relative to the type declaration start
+	validations []string // #5049: DataAnnotations chips from preceding [<...>] attributes
 }
 
 // parseRecordFields parses the body of an F# record type, returning one entry
@@ -98,12 +105,26 @@ type memberInfo struct {
 // tolerated.
 func parseRecordFields(body string) []memberInfo {
 	var out []memberInfo
+	// #5049: DataAnnotations attributes (`[<Required>]`) precede the field they
+	// decorate, often on their own line(s). Accumulate the raw attribute lines
+	// seen since the last field and attach them to the next field parsed.
+	var pendingAttrs []string
 	for lineNo, raw := range strings.Split(body, "\n") {
 		line := raw
 		// Strip the enclosing braces so a single-line `{ X: int; Y: int }`
 		// degrades to a `;`-separated field list.
 		line = strings.ReplaceAll(line, "{", "")
 		line = strings.ReplaceAll(line, "}", "")
+		// A line that carries an attribute group but no field declaration is a
+		// standalone attribute line — remember it for the next field. A line
+		// that carries both (`[<Required>] Email: string`) is handled inline:
+		// fsValidationChips reads the `[<...>]` prefix off the same raw line.
+		hasAttr := strings.Contains(line, "[<")
+		hasField := strings.ContainsRune(line, ':')
+		if hasAttr && !hasField {
+			pendingAttrs = append(pendingAttrs, line)
+			continue
+		}
 		for _, seg := range strings.Split(line, ";") {
 			seg = strings.TrimSpace(seg)
 			if seg == "" {
@@ -116,10 +137,29 @@ func parseRecordFields(body string) []memberInfo {
 			}
 			name := strings.TrimSpace(seg[:colon])
 			typ := strings.TrimSpace(seg[colon+1:])
+			// An inline attribute prefix (`[<Required>] Email`) leaks into the
+			// name; collect its chips, then strip it off the field name.
+			var inlineAttrs []string
+			if strings.Contains(name, "[<") {
+				inlineAttrs = []string{name}
+				if gt := strings.LastIndex(name, ">]"); gt >= 0 {
+					name = strings.TrimSpace(name[gt+2:])
+				}
+			}
 			if !isFieldName(name) {
 				continue
 			}
-			out = append(out, memberInfo{name: name, typ: typ, lineOffset: lineNo})
+			mi := memberInfo{name: name, typ: typ, lineOffset: lineNo}
+			if attrs := append(append([]string{}, pendingAttrs...), inlineAttrs...); len(attrs) > 0 {
+				mi.validations = fsValidationChips(attrs)
+			}
+			out = append(out, mi)
+			pendingAttrs = nil
+		}
+		// A non-attribute, non-field line (blank / comment) clears any dangling
+		// attributes so they don't bind to a far-away field.
+		if !hasAttr && !hasField {
+			pendingAttrs = nil
 		}
 	}
 	return out

--- a/internal/extractors/fsharp/field_validations.go
+++ b/internal/extractors/fsharp/field_validations.go
@@ -1,0 +1,192 @@
+// field_validations.go — #5049 (follow-up #4942). Per-field validation
+// constraints for F# record fields, stamped onto the SCOPE.Schema/field entity
+// under Properties["validations"] (comma-joined) so the dashboard ShapeTree
+// surfaces them as small constraint chips — mirroring the Java Bean-Validation
+// support (#4872, internal/extractors/java/field_validations.go), the TS
+// class-validator support (#4858) and the Python field-validation support
+// (#4871).
+//
+// The dashboard side already exists: internal/dashboard/shape_tree.go reads
+// Properties["validations"] (comma-split) into v2ShapeRow.Validations, and
+// webui-v2/src/components/ShapeTree.tsx renders the chips. This pass only has
+// to populate that property on the F# record-field entities.
+//
+// F# DataAnnotations attributes are written in the `[<Attribute>]` syntax and
+// sit on the line(s) preceding the record field they decorate, e.g.
+//
+//	type CreateUserDto = {
+//	    [<Required>]
+//	    [<EmailAddress>]
+//	    Email: string
+//
+//	    [<StringLength(120)>]
+//	    [<MinLength(2)>]
+//	    Name: string
+//	}
+//
+// Several attributes may also share a single bracket as a `;`-separated list
+// (`[<Required; EmailAddress>]`). The chip text is kept terse and comma-free
+// (Properties is comma-joined and the dashboard splits on ","): scalar bounds
+// fold their value (`MaxLength:120`, `Range:1..5`), the rest render as a bare
+// marker (`Required`, `Email`). Only stamped when at least one constraint is
+// found; existing Properties are preserved.
+package fsharp
+
+import (
+	"strings"
+)
+
+// fsValidationMarkers maps a DataAnnotations attribute simple name (without the
+// `Attribute` suffix) to the bare marker chip it produces. These carry no
+// scalar bound worth folding, so only the attribute identity is recorded.
+//
+// [<Required>] renders as `Required` to match the Java/TS/Python required
+// marker.
+var fsValidationMarkers = map[string]string{
+	"Required":         "Required",
+	"EmailAddress":     "Email",
+	"Phone":            "Phone",
+	"Url":              "Url",
+	"CreditCard":       "CreditCard",
+	"Compare":          "Compare",
+	"DataType":         "DataType",
+	"EnumDataType":     "EnumDataType",
+	"FileExtensions":   "FileExtensions",
+	"Base64String":     "Base64String",
+	"AllowedValues":    "AllowedValues",
+	"DeniedValues":     "DeniedValues",
+	"Timestamp":        "Timestamp",
+	"ConcurrencyCheck": "ConcurrencyCheck",
+}
+
+// fsValidationScalar maps a DataAnnotations attribute whose single argument is a
+// scalar bound to the chip prefix it folds into (`[<MaxLength(120)>]` →
+// "MaxLength:120").
+var fsValidationScalar = map[string]string{
+	"MaxLength": "MaxLength",
+	"MinLength": "MinLength",
+	"StringLength": "MaxLength", // StringLength(max) → MaxLength:max
+}
+
+// fsValidationChips parses the attribute lines preceding an F# record field and
+// returns the terse, comma-free validation chips. `attrLines` are the raw
+// source lines that appeared above the field, each potentially carrying one or
+// more `[<...>]` attribute groups. Unrecognised attributes are ignored so the
+// chip list stays validation-only (a `[<JsonProperty>]` or `[<CLIMutable>]`
+// attribute never leaks in).
+func fsValidationChips(attrLines []string) []string {
+	var chips []string
+	seen := make(map[string]bool)
+	add := func(c string) {
+		if c == "" || seen[c] {
+			return
+		}
+		seen[c] = true
+		chips = append(chips, c)
+	}
+	for _, line := range attrLines {
+		for _, attr := range fsParseAttrGroup(line) {
+			name, arg := fsSplitAttr(attr)
+			name = strings.TrimSuffix(name, "Attribute")
+			switch {
+			case name == "Range":
+				// [<Range(1, 5)>] → Range:1..5
+				lo, hi, ok := fsRangeBounds(arg)
+				if ok {
+					add("Range:" + lo + ".." + hi)
+				} else {
+					add("Range")
+				}
+			case name == "RegularExpression":
+				// Pattern body is a regex full of commas/brackets — record only
+				// the marker so it can't corrupt the comma-joined property.
+				add("Pattern")
+			case fsValidationScalar[name] != "":
+				v := fsFirstArg(arg)
+				if v != "" {
+					add(fsValidationScalar[name] + ":" + v)
+				} else {
+					add(fsValidationScalar[name])
+				}
+			case fsValidationMarkers[name] != "":
+				add(fsValidationMarkers[name])
+			}
+		}
+	}
+	return chips
+}
+
+// fsParseAttrGroup extracts the individual attribute bodies from a source line,
+// splitting `[<A>] [<B>]` into ["A","B"] and `[<A; B(1)>]` into ["A","B(1)"].
+// Only the text between `[<` and `>]` is considered.
+func fsParseAttrGroup(line string) []string {
+	var out []string
+	for {
+		open := strings.Index(line, "[<")
+		if open < 0 {
+			break
+		}
+		close := strings.Index(line[open:], ">]")
+		if close < 0 {
+			break
+		}
+		inner := line[open+2 : open+close]
+		for _, seg := range strings.Split(inner, ";") {
+			seg = strings.TrimSpace(seg)
+			if seg != "" {
+				out = append(out, seg)
+			}
+		}
+		line = line[open+close+2:]
+	}
+	return out
+}
+
+// fsSplitAttr splits an attribute body `StringLength(120)` into its name
+// (`StringLength`) and raw argument text (`120`). A bare attribute (`Required`)
+// returns an empty argument.
+func fsSplitAttr(attr string) (name, arg string) {
+	attr = strings.TrimSpace(attr)
+	if p := strings.IndexByte(attr, '('); p >= 0 {
+		name = strings.TrimSpace(attr[:p])
+		arg = attr[p+1:]
+		if c := strings.LastIndexByte(arg, ')'); c >= 0 {
+			arg = arg[:c]
+		}
+		return name, strings.TrimSpace(arg)
+	}
+	return attr, ""
+}
+
+// fsFirstArg returns the first comma-separated argument of an attribute's raw
+// argument text, dropping any named-argument noise (`ErrorMessage = "..."`).
+func fsFirstArg(arg string) string {
+	if arg == "" {
+		return ""
+	}
+	first := strings.SplitN(arg, ",", 2)[0]
+	first = strings.TrimSpace(first)
+	// A named argument (e.g. ErrorMessage="x") is not a scalar bound.
+	if strings.ContainsRune(first, '=') || strings.ContainsRune(first, '"') {
+		return ""
+	}
+	return first
+}
+
+// fsRangeBounds parses a `[<Range(lo, hi)>]` argument list into its low/high
+// scalar bounds, ignoring any trailing named arguments.
+func fsRangeBounds(arg string) (lo, hi string, ok bool) {
+	parts := strings.Split(arg, ",")
+	if len(parts) < 2 {
+		return "", "", false
+	}
+	lo = strings.TrimSpace(parts[0])
+	hi = strings.TrimSpace(parts[1])
+	if lo == "" || hi == "" {
+		return "", "", false
+	}
+	if strings.ContainsAny(lo, "=\"") || strings.ContainsAny(hi, "=\"") {
+		return "", "", false
+	}
+	return lo, hi, true
+}

--- a/internal/extractors/fsharp/fsharp_test.go
+++ b/internal/extractors/fsharp/fsharp_test.go
@@ -692,6 +692,102 @@ type Person = {
 	}
 }
 
+// TestFSharp_DataAnnotationsValidations — #5049: DataAnnotations attributes
+// preceding a record field are collected into Properties["validations"]
+// (comma-joined chips) so the dashboard ShapeTree renders constraint chips —
+// mirroring the Java/TS/Python field-validation support.
+func TestFSharp_DataAnnotationsValidations(t *testing.T) {
+	src := `module Dto
+
+type CreateUserDto = {
+    [<Required>]
+    [<EmailAddress>]
+    Email: string
+
+    [<StringLength(120)>]
+    [<MinLength(2)>]
+    Name: string
+
+    [<Required; Range(1, 5)>]
+    Rating: int
+
+    [<RegularExpression("^[0-9]+$")>]
+    Code: string
+
+    Note: string
+}
+`
+	ents := runFSharp(t, src, "dto.fs")
+
+	cases := []struct {
+		name, want string
+	}{
+		{"CreateUserDto.Email", "Required,Email"},
+		{"CreateUserDto.Name", "MaxLength:120,MinLength:2"},
+		{"CreateUserDto.Rating", "Required,Range:1..5"},
+		{"CreateUserDto.Code", "Pattern"},
+	}
+	for _, c := range cases {
+		fe := fsFind(ents, c.name, "SCOPE.Schema")
+		if fe == nil {
+			t.Fatalf("expected field %q", c.name)
+		}
+		if got := fe.Properties["validations"]; got != c.want {
+			t.Errorf("field %q validations=%q, want %q", c.name, got, c.want)
+		}
+	}
+
+	// A field with no attributes must NOT carry a validations property.
+	if fe := fsFind(ents, "CreateUserDto.Note", "SCOPE.Schema"); fe == nil {
+		t.Fatal("expected field CreateUserDto.Note")
+	} else if _, ok := fe.Properties["validations"]; ok {
+		t.Errorf("Note should have no validations, got %q", fe.Properties["validations"])
+	}
+}
+
+// TestFSharp_InlineValidationAttribute — #5049: an attribute on the SAME line as
+// the field (`[<Required>] Email: string`) is still collected, and the leading
+// attribute is stripped off the field name.
+func TestFSharp_InlineValidationAttribute(t *testing.T) {
+	src := `module Dto
+
+type LoginDto = {
+    [<Required>] Username: string
+}
+`
+	ents := runFSharp(t, src, "login.fs")
+	fe := fsFind(ents, "LoginDto.Username", "SCOPE.Schema")
+	if fe == nil {
+		t.Fatalf("expected field LoginDto.Username (attr should be stripped off name)")
+	}
+	if got := fe.Properties["validations"]; got != "Required" {
+		t.Errorf("Username validations=%q, want Required", got)
+	}
+	if mt := fe.Properties["member_type"]; mt != "string" {
+		t.Errorf("Username member_type=%q, want string", mt)
+	}
+}
+
+// TestFSharp_NonValidationAttributesIgnored — #5049: non-validation attributes
+// (`[<CLIMutable>]`, `[<JsonProperty>]`) never leak into the validations chips.
+func TestFSharp_NonValidationAttributesIgnored(t *testing.T) {
+	src := `module Dto
+
+type Config = {
+    [<CLIMutable>]
+    Host: string
+}
+`
+	ents := runFSharp(t, src, "config.fs")
+	fe := fsFind(ents, "Config.Host", "SCOPE.Schema")
+	if fe == nil {
+		t.Fatalf("expected field Config.Host")
+	}
+	if v, ok := fe.Properties["validations"]; ok {
+		t.Errorf("Host should have no validation chips, got %q", v)
+	}
+}
+
 // TestFSharp_DUCases — #4942: DU CASES are emitted as individual
 // SCOPE.Schema/du_case sub-entities, with payload types captured from `of T`.
 func TestFSharp_DUCases(t *testing.T) {


### PR DESCRIPTION
## Built (fixture-proven)
**validation** — the highest-value theme of #5049. F# record fields decorated with `System.ComponentModel.DataAnnotations` attributes now surface as constraint chips on the dashboard ShapeTree, mirroring the Java (#4872), TS class-validator (#4858) and Python (#4871) field-validation support.

- New `internal/extractors/fsharp/field_validations.go`: parses `[<...>]` attribute groups off the lines preceding (and inline with) each record field and folds them into terse, comma-free chips stamped on `Properties["validations"]` (the property `internal/dashboard/shape_tree.go` + `ShapeTree.tsx` already render).
  - Markers: `Required`, `Email` (EmailAddress), `Phone`, `Url`, `CreditCard`, `Compare`, `DataType`, `Base64String`, `AllowedValues`/`DeniedValues`, `ConcurrencyCheck`, …
  - Scalar-folding: `StringLength(120)`/`MaxLength(n)` → `MaxLength:120`, `MinLength:2`.
  - Range: `[<Range(1, 5)>]` → `Range:1..5`.
  - `[<RegularExpression("…")>]` → bare `Pattern` marker (regex body kept out of the comma-joined property).
  - Multi-attr brackets (`[<Required; Range(1,5)>]`) and inline-on-field (`[<Required>] Email: string`) both handled; non-validation attributes (`[<CLIMutable>]`) are ignored.
- `du_record_members.go`: `parseRecordFields` accumulates preceding attribute lines and `extractTypeMembers` stamps the chips onto the existing `SCOPE.Schema/field` entities (no new Kind/edge — reuses the established Properties chip model).

### Edges / Kinds
No new entity Kind or edge kind. Reuses `SCOPE.Schema/field` + the existing type→field `CONTAINS` edge and the `Properties["validations"]` chip convention.

### Registry cells
New record `lang.fsharp.validation.dataannotations` (category=validation, subcategory=validation_lib):
- `Schema.schema_extraction` = **full** (record fields already emitted, #4942).
- `Constraints.constraint_extraction` = **full** (this PR, fixture-proven).
- `Schema.nested_model_extraction`, `Constraints.custom_validator_extraction`, `Testing.tests_linkage` = **missing** (honest, deferred).
- `Coercion.type_coercion_recognition` = not_applicable.

REGENERATED coverage docs included: `coverage fmt` + `coverage gen` committed (`docs/coverage/registry.json`, `by-category/validation.md`, `by-language/fsharp.md`, `summary.md`, new `detail/lang.fsharp.validation.dataannotations.md`). `coverage fmt --check` + `coverage validate` pass.

### Fixtures
`TestFSharp_DataAnnotationsValidations`, `TestFSharp_InlineValidationAttribute`, `TestFSharp_NonValidationAttributesIgnored` (in `fsharp_test.go`).

## Deferred (follow-ups to file under #5049)
- **Logging**: Serilog / Microsoft.Extensions.Logging / printfn-eprintfn log-call extraction.
- **Fable/Elmish/Feliz frontend**: framework detection + MVU init/update/view + Feliz component DSL.
- **Validation tail**: Validus / FsToolkit.ErrorHandling Result/Validation pipelines, `[<CustomValidation>]`/IValidatableObject, nested-record VALIDATES edge.

## Gates (sandbox HOME=/tmp/agsbx-5049)
`go build ./...` ✅, `go vet ./internal/...` ✅, `go test ./internal/custom/fsharp/... ./internal/extractors/fsharp/... ./internal/types/` ✅, `coverage fmt --check` ✅, `coverage validate` ✅. Deploy-deferred.

Refs #5049