### PR TITLE
feat(#5066): wire ingested coverage into dashboard data layer + provenance banner

### DIFF
--- a/internal/dashboard/handlers_coverage.go
+++ b/internal/dashboard/handlers_coverage.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/coverage"
 	"github.com/cajasmota/archigraph/internal/graph"
 )
 
@@ -62,6 +63,123 @@ type GroupCoverageReport struct {
 	// coverage tree: directory → file → entity. Severity sorted (high first)
 	// and capped per file (PerFileUncoveredCap) with a per-file overflow count.
 	ByFileUncovered map[string]FileUncovered `json:"by_file_uncovered,omitempty"`
+
+	// LineCoverage (#5066) surfaces the REAL ingested line coverage (#5036)
+	// when a coverage report (LCOV/Cobertura/JaCoCo) was ingested and stamped
+	// onto entities at index time (#5061). It is distinct from CoveragePct,
+	// which is graph-derived reach coverage (static test-reachability), not a
+	// measured line %. Nil when no entity in the group carries the stamped
+	// `coverage_source` prop — the common case until a report is ingested — so
+	// the provenance banner degrades cleanly to reachability/capability.
+	LineCoverage *LineCoverageSummary `json:"line_coverage,omitempty"`
+}
+
+// LineCoverageSummary is the group-level roll-up of the per-entity ingested
+// line-coverage props (#5036) stamped at index time (#5061). It is the
+// authoritative, executed line % — never conflated with reach coverage.
+//
+// Presence of this object is itself the "report ingestion ran for this group"
+// signal the provenance banner (#5038) keys off: an entity only carries
+// `coverage_source` if a report was actually ingested.
+type LineCoverageSummary struct {
+	// Source is the coverage_source prop, e.g. "lcov" (the first non-empty
+	// source seen; v1 honors a single ingestor per group).
+	Source string `json:"source"`
+	// CoveredLines / TotalLines are the group-wide sums over file-scope
+	// entities (whole-file roll-ups), so the percentage is a true line ratio
+	// and not double-counted across nested span-bearing entities.
+	CoveredLines int `json:"covered_lines"`
+	TotalLines   int `json:"total_lines"`
+	// CoveragePct is 100*CoveredLines/TotalLines, or 0 when TotalLines==0.
+	CoveragePct float64 `json:"coverage_pct"`
+	// MeasuredAt is the coverage_measured_at prop (RFC3339), the latest seen
+	// across entities. Empty when the ingestor did not stamp a timestamp.
+	MeasuredAt string `json:"measured_at,omitempty"`
+	// Entities is how many entities carried a stamped coverage_source prop —
+	// distinguishes a real (if zero-line) ingestion from no ingestion at all.
+	Entities int `json:"entities"`
+}
+
+// lineCovAccumulator folds stamped ingested line-coverage props (#5036/#5061)
+// from one or more documents into a group-level roll-up. It is keyed by the
+// forward-slash source path so the line ratio is a true per-file roll-up and
+// not double-counted across the nested span-bearing entities that share a file:
+// for each file it keeps the widest (whole-file-scope) total_lines stamp seen.
+//
+// Kept as a small pure helper (no Server/IO) so the aggregation policy is
+// directly unit-testable (#5066).
+type lineCovAccumulator struct {
+	byFile     map[string]lineCovFile // source path → widest file stamp
+	source     string                 // first non-empty coverage_source seen
+	measuredAt string                 // latest coverage_measured_at seen
+	entities   int                    // count of entities carrying coverage_source
+}
+
+type lineCovFile struct{ covered, total int }
+
+// accumulate folds every entity in doc that carries a coverage_source prop.
+func (a *lineCovAccumulator) accumulate(doc *graph.Document) {
+	if doc == nil {
+		return
+	}
+	for ei := range doc.Entities {
+		ent := &doc.Entities[ei]
+		if len(ent.Properties) == 0 {
+			continue
+		}
+		src := ent.Properties[coverage.PropCoverageSource]
+		if src == "" {
+			continue
+		}
+		a.entities++
+		if a.source == "" {
+			a.source = src
+		}
+		// RFC3339 timestamps sort lexicographically, so a string compare picks
+		// the most recent measurement without parsing.
+		if at := ent.Properties[coverage.PropCoverageMeasAt]; at > a.measuredAt {
+			a.measuredAt = at
+		}
+		covered, cErr := strconv.Atoi(ent.Properties[coverage.PropCoveredLines])
+		total, tErr := strconv.Atoi(ent.Properties[coverage.PropTotalLines])
+		if cErr != nil || tErr != nil || total <= 0 {
+			continue
+		}
+		key := filepath.ToSlash(ent.SourceFile)
+		if key == "" {
+			key = ent.ID
+		}
+		if a.byFile == nil {
+			a.byFile = make(map[string]lineCovFile)
+		}
+		// A file-scope entity reports the full file's total_lines; a span
+		// entity a subset. Keeping the max total (with its covered) avoids both
+		// double-counting and undercounting.
+		if cur, ok := a.byFile[key]; !ok || total > cur.total {
+			a.byFile[key] = lineCovFile{covered: covered, total: total}
+		}
+	}
+}
+
+// summarize renders the wire shape, or nil when no report was ingested (no
+// entity carried coverage_source) so the provenance banner degrades cleanly.
+func (a *lineCovAccumulator) summarize() *LineCoverageSummary {
+	if a.entities == 0 {
+		return nil
+	}
+	s := &LineCoverageSummary{
+		Source:     a.source,
+		MeasuredAt: a.measuredAt,
+		Entities:   a.entities,
+	}
+	for _, f := range a.byFile {
+		s.CoveredLines += f.covered
+		s.TotalLines += f.total
+	}
+	if s.TotalLines > 0 {
+		s.CoveragePct = 100.0 * float64(s.CoveredLines) / float64(s.TotalLines)
+	}
+	return s
 }
 
 // PerFileUncoveredCap bounds how many uncovered-entity leaves a single file
@@ -128,6 +246,12 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 	modAcc := make(map[string]*modAccum)
 	fileAcc := make(map[string]*fileAccum)
 
+	// Ingested line-coverage roll-up (#5066). The #5036 props are stamped onto
+	// entities at index time (#5061); accumulateLineCoverage folds each doc's
+	// stamped entities into lineCov, which summarize() turns into the wire
+	// shape once all repos are scanned.
+	var lineCov lineCovAccumulator
+
 	// S8 (#2159): use the cached group to avoid per-request LoadGraphFromDir.
 	cachedGrpCov, _ := s.graphs.GetGroupCached(groupName)
 
@@ -193,7 +317,15 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 			modAcc[m.Module].total += m.Total
 			modAcc[m.Module].covered += m.Covered
 		}
+
+		// Fold this repo's stamped ingested line-coverage props (#5066).
+		lineCov.accumulate(doc)
 	}
+
+	// Presence of any stamped entity ⇒ a report was ingested for this group, so
+	// we emit the authoritative line % (distinct from reach CoveragePct). When
+	// nothing was stamped, LineCoverage stays nil and the banner degrades.
+	result.LineCoverage = lineCov.summarize()
 
 	// ── compute group-level coverage % ───────────────────────────────────────
 	// CoveragePct stays pure reach-coverage; ContractCoveredPct is the union

--- a/internal/dashboard/handlers_coverage_lineagg_test.go
+++ b/internal/dashboard/handlers_coverage_lineagg_test.go
@@ -1,0 +1,131 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ent builds a graph.Entity carrying the stamped ingested-line-coverage props
+// (#5036) for the accumulator tests.
+func ent(id, file, source, covered, total, measuredAt string) graph.Entity {
+	props := map[string]string{}
+	if source != "" {
+		props[coverage.PropCoverageSource] = source
+	}
+	if covered != "" {
+		props[coverage.PropCoveredLines] = covered
+	}
+	if total != "" {
+		props[coverage.PropTotalLines] = total
+	}
+	if measuredAt != "" {
+		props[coverage.PropCoverageMeasAt] = measuredAt
+	}
+	return graph.Entity{ID: id, SourceFile: file, Properties: props}
+}
+
+func TestLineCovAccumulator_NoStampReturnsNil(t *testing.T) {
+	var a lineCovAccumulator
+	a.accumulate(&graph.Document{Entities: []graph.Entity{
+		{ID: "e1", SourceFile: "a.ts"}, // no coverage props
+		{ID: "e2", SourceFile: "b.ts", Properties: map[string]string{"other": "x"}},
+	}})
+	if got := a.summarize(); got != nil {
+		t.Fatalf("expected nil summary when nothing stamped, got %+v", got)
+	}
+}
+
+func TestLineCovAccumulator_NilDocSafe(t *testing.T) {
+	var a lineCovAccumulator
+	a.accumulate(nil)
+	if got := a.summarize(); got != nil {
+		t.Fatalf("expected nil summary for nil doc, got %+v", got)
+	}
+}
+
+func TestLineCovAccumulator_RollUpAndSourceAndMeasuredAt(t *testing.T) {
+	var a lineCovAccumulator
+	a.accumulate(&graph.Document{Entities: []graph.Entity{
+		ent("a-file", "a.ts", "lcov", "8", "10", "2026-06-10T00:00:00Z"),
+		ent("b-file", "b.ts", "lcov", "5", "20", "2026-06-12T00:00:00Z"),
+	}})
+	s := a.summarize()
+	if s == nil {
+		t.Fatal("expected a summary")
+	}
+	if s.Source != "lcov" {
+		t.Errorf("source = %q, want lcov", s.Source)
+	}
+	if s.CoveredLines != 13 || s.TotalLines != 30 {
+		t.Errorf("covered/total = %d/%d, want 13/30", s.CoveredLines, s.TotalLines)
+	}
+	wantPct := 100.0 * 13.0 / 30.0
+	if s.CoveragePct != wantPct {
+		t.Errorf("pct = %v, want %v", s.CoveragePct, wantPct)
+	}
+	if s.MeasuredAt != "2026-06-12T00:00:00Z" {
+		t.Errorf("measuredAt = %q, want latest 2026-06-12...", s.MeasuredAt)
+	}
+	if s.Entities != 2 {
+		t.Errorf("entities = %d, want 2", s.Entities)
+	}
+}
+
+// Nested span entities in the same file must not inflate the line totals: the
+// widest (whole-file) stamp wins per file.
+func TestLineCovAccumulator_NoDoubleCountWithinFile(t *testing.T) {
+	var a lineCovAccumulator
+	a.accumulate(&graph.Document{Entities: []graph.Entity{
+		// whole-file stamp
+		ent("file-scope", "a.ts", "lcov", "40", "50", ""),
+		// nested function span in the same file — narrower total
+		ent("fn1", "a.ts", "lcov", "8", "10", ""),
+		ent("fn2", "a.ts", "lcov", "5", "12", ""),
+	}})
+	s := a.summarize()
+	if s == nil {
+		t.Fatal("expected a summary")
+	}
+	if s.TotalLines != 50 || s.CoveredLines != 40 {
+		t.Errorf("covered/total = %d/%d, want 40/50 (widest stamp wins)", s.CoveredLines, s.TotalLines)
+	}
+	if s.Entities != 3 {
+		t.Errorf("entities = %d, want 3 (all stamped count)", s.Entities)
+	}
+}
+
+// A real (if zero-line) ingestion still surfaces — entities>0 with no valid
+// line numbers yields a non-nil summary at 0%.
+func TestLineCovAccumulator_StampedButNoValidLines(t *testing.T) {
+	var a lineCovAccumulator
+	a.accumulate(&graph.Document{Entities: []graph.Entity{
+		ent("e1", "a.ts", "lcov", "", "", "2026-06-12T00:00:00Z"),
+	}})
+	s := a.summarize()
+	if s == nil {
+		t.Fatal("expected non-nil summary for stamped-but-no-lines ingestion")
+	}
+	if s.TotalLines != 0 || s.CoveragePct != 0 {
+		t.Errorf("want 0 total / 0 pct, got %d / %v", s.TotalLines, s.CoveragePct)
+	}
+}
+
+// Accumulating across multiple repos (docs) merges into one roll-up.
+func TestLineCovAccumulator_MultiDoc(t *testing.T) {
+	var a lineCovAccumulator
+	a.accumulate(&graph.Document{Entities: []graph.Entity{
+		ent("r1", "x.ts", "lcov", "10", "10", "2026-06-09T00:00:00Z"),
+	}})
+	a.accumulate(&graph.Document{Entities: []graph.Entity{
+		ent("r2", "y.ts", "lcov", "0", "10", "2026-06-11T00:00:00Z"),
+	}})
+	s := a.summarize()
+	if s.CoveredLines != 10 || s.TotalLines != 20 {
+		t.Errorf("covered/total = %d/%d, want 10/20", s.CoveredLines, s.TotalLines)
+	}
+	if s.MeasuredAt != "2026-06-11T00:00:00Z" {
+		t.Errorf("measuredAt = %q, want latest across docs", s.MeasuredAt)
+	}
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1943,6 +1943,33 @@ export interface GroupCoverageReport {
    * backends — the UI falls back to the flat `uncovered_entities` list.
    */
   by_file_uncovered?: Record<string, FileUncovered>;
+  /**
+   * Real ingested LINE coverage (#5036), rolled up across the group from the
+   * entity props stamped at index time (#5061). Present ONLY when a coverage
+   * report (LCOV/Cobertura/JaCoCo) was actually ingested — its presence is the
+   * authoritative "report ingestion ran" signal the provenance banner keys
+   * off. Absent (the common case) ⇒ no report ingested; the banner degrades to
+   * static reachability / capability coverage. Distinct from `coverage_pct`,
+   * which is graph-derived reach coverage, not a measured line %.
+   */
+  line_coverage?: LineCoverageSummary;
+}
+
+/**
+ * Group-level roll-up of ingested line coverage (#5066). The authoritative,
+ * executed line % — never the same as `coverage_pct` (reach coverage).
+ */
+export interface LineCoverageSummary {
+  /** `coverage_source` prop, e.g. "lcov". */
+  source: string;
+  covered_lines: number;
+  total_lines: number;
+  /** 100 * covered_lines / total_lines (0 when total_lines === 0). */
+  coverage_pct: number;
+  /** `coverage_measured_at` (RFC3339), latest across entities. May be absent. */
+  measured_at?: string;
+  /** How many entities carried a stamped `coverage_source` prop. */
+  entities: number;
 }
 
 /** One declared / used / unused / phantom external dependency. */

--- a/webui-v2/src/lib/coverage-provenance.test.ts
+++ b/webui-v2/src/lib/coverage-provenance.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from "vitest";
 import {
   resolveCoverageProvenance,
+  coverageStateFromReport,
   COVERAGE_DEFINITIONS,
   COVERAGE_MCP_TOOL,
   type CoverageSourceState,
@@ -130,5 +131,60 @@ describe("self-documenting definitions", () => {
       expect(d.title.length).toBeGreaterThan(0);
       expect(d.body.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("coverageStateFromReport — #5066 endpoint wiring", () => {
+  it("renders the INGESTED LINE COVERAGE state when the API reports line_coverage", () => {
+    // What the /quality/coverage endpoint now returns once a report is ingested.
+    const apiLineCoverage = {
+      source: "lcov",
+      covered_lines: 734,
+      total_lines: 1000,
+      coverage_pct: 73.4,
+      measured_at: "2026-06-12T10:00:00Z",
+      entities: 42,
+    };
+    const state = coverageStateFromReport(apiLineCoverage);
+    // The banner upgrades automatically off this state.
+    const p = resolveCoverageProvenance(state);
+    expect(p.kind).toBe("line");
+    expect(p.label).toBe("Line coverage");
+    expect(p.method).toContain("ingested from LCOV");
+    expect(p.method).toContain("measured 2026-06-12T10:00:00Z");
+    expect(p.freshness?.measuredAt).toBe("2026-06-12T10:00:00Z");
+    // Ingestion is active ⇒ no "how to enable" nag.
+    expect(p.howToEnable).toBeNull();
+    // And we carry the real line numbers through for the % display.
+    expect(state.line?.pct).toBe(73.4);
+    expect(state.line?.coveredLines).toBe(734);
+    expect(state.reportIngestionConfigured).toBe(true);
+  });
+
+  it("flags the line measurement STALE when it predates the latest index", () => {
+    const state = coverageStateFromReport(
+      {
+        source: "lcov",
+        covered_lines: 1,
+        total_lines: 2,
+        coverage_pct: 50,
+        measured_at: "2026-06-10T00:00:00Z",
+        entities: 1,
+      },
+      "2026-06-12T00:00:00Z", // index newer than measurement
+    );
+    const p = resolveCoverageProvenance(state);
+    expect(p.kind).toBe("line");
+    expect(p.freshness?.stale).toBe(true);
+  });
+
+  it("DEGRADES to reachability when no line_coverage is present", () => {
+    const state = coverageStateFromReport(undefined);
+    expect(state.line).toBeUndefined();
+    expect(state.reachabilityAvailable).toBe(true);
+    const p = resolveCoverageProvenance(state);
+    expect(p.kind).toBe("reachability");
+    // Not yet configured ⇒ surfaces the how-to-enable affordance.
+    expect(p.howToEnable).not.toBeNull();
   });
 });

--- a/webui-v2/src/lib/coverage-provenance.ts
+++ b/webui-v2/src/lib/coverage-provenance.ts
@@ -237,3 +237,51 @@ export function resolveCoverageProvenance(
     freshness: null,
   };
 }
+
+/**
+ * Group-level ingested line-coverage roll-up, as surfaced by the dashboard
+ * `/quality/coverage` endpoint's optional `line_coverage` field (#5066). Mirror
+ * of the Go `LineCoverageSummary` wire shape. Kept here (rather than importing
+ * from data/types) so this module stays dependency-free and node-testable.
+ */
+export interface LineCoverageReport {
+  source: string;
+  covered_lines: number;
+  total_lines: number;
+  coverage_pct: number;
+  measured_at?: string;
+  entities: number;
+}
+
+/**
+ * Build the banner's {@link CoverageSourceState} from what the coverage
+ * endpoint returns (#5066 wiring). When `line_coverage` is present a report was
+ * ingested, so we populate the authoritative `line` state and mark ingestion
+ * configured; otherwise we degrade to static reachability and the banner shows
+ * the "how to enable" affordance. Pure so the wiring is unit-testable without a
+ * DOM (the CoverageTab call site is a thin pass-through over this).
+ *
+ * @param lineCoverage  the endpoint's `line_coverage` field (or undefined)
+ * @param latestIndexAt optional ISO index time for the staleness check
+ */
+export function coverageStateFromReport(
+  lineCoverage: LineCoverageReport | null | undefined,
+  latestIndexAt?: string,
+): CoverageSourceState {
+  if (lineCoverage && lineCoverage.source) {
+    return {
+      line: {
+        source: lineCoverage.source,
+        measuredAt: lineCoverage.measured_at,
+        pct: lineCoverage.coverage_pct,
+        coveredLines: lineCoverage.covered_lines,
+        totalLines: lineCoverage.total_lines,
+      },
+      // line_coverage only exists because a report was ingested.
+      reportIngestionConfigured: true,
+      reachabilityAvailable: true,
+      latestIndexAt,
+    };
+  }
+  return { reachabilityAvailable: true };
+}

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -69,6 +69,7 @@ import {
 } from "@/components/ui";
 import type { InsightValue } from "@/components/ui";
 import type { CoverageSourceState } from "@/lib/coverage-provenance";
+import { coverageStateFromReport } from "@/lib/coverage-provenance";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { useSourcePeek } from "@/components/SourcePeek";
@@ -839,20 +840,36 @@ function CoverageTab({ groupId }: { groupId: string }) {
     </div>
   );
 
-  // Coverage provenance (#5038). The dashboard's headline `coverage_pct` is
-  // graph-derived REACH coverage (static test-reachability), not a measured
-  // line %. Ingested line coverage (#5036) and ingestion-config state are not
-  // yet wired into this endpoint, so we report reachability and let the banner
-  // surface the "how to enable" affordance. When the data layer later exposes
-  // stamped line-coverage props + ingestion config, populate `line` /
-  // `reportIngestionConfigured` here and the banner upgrades automatically.
-  const coverageProvenance: CoverageSourceState = {
-    reachabilityAvailable: true,
-  };
+  // Coverage provenance (#5066, wires #5038). The dashboard's headline
+  // `coverage_pct` is graph-derived REACH coverage (static test-reachability),
+  // not a measured line %. When a coverage report was ingested (#5036) the
+  // endpoint now carries `line_coverage` — its presence is the authoritative
+  // "report ingestion ran" signal, so we populate `line` (authoritative % +
+  // measured-at) and mark ingestion configured, and the banner upgrades to the
+  // line-coverage state automatically. Otherwise we report reachability and the
+  // banner surfaces the "how to enable" affordance.
+  const lineCov = data.line_coverage;
+  const coverageProvenance: CoverageSourceState =
+    coverageStateFromReport(lineCov);
 
   return (
     <div className="space-y-4">
       <CoverageProvenanceBanner state={coverageProvenance} />
+      {lineCov && (
+        // Real ingested line coverage (#5066) — the authoritative executed
+        // line %, shown distinctly from the reach-coverage gauge below so the
+        // two numbers are never conflated.
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Badge tone="success">
+            Line coverage {lineCov.coverage_pct.toFixed(1)}%
+          </Badge>
+          <span className="text-text-4 tabular-nums">
+            {lineCov.covered_lines.toLocaleString()} /{" "}
+            {lineCov.total_lines.toLocaleString()} lines (
+            {lineCov.source.toUpperCase()})
+          </span>
+        </div>
+      )}
       <CoverageGauge
         covered={data.covered_production}
         total={data.total_production}


### PR DESCRIPTION
## What this builds
Surfaces the #5036-stamped per-entity line-coverage props (stamped at index time by #5061) through the dashboard data layer and wires the CoverageProvenanceBanner (#5038) to consume the REAL state, replacing the hardcoded `reachabilityAvailable: true` placeholder PR #5065 left.

### API fields exposed (handlers_coverage.go)
- New `GroupCoverageReport.line_coverage` (`omitempty`) of shape `LineCoverageSummary`: `source`, `covered_lines`, `total_lines`, `coverage_pct`, `measured_at`, `entities`.
- `lineCovAccumulator` folds the stamped entity props (`coverage_source` / `covered_lines` / `total_lines` / `coverage_measured_at`) **per source file** — the widest (whole-file) stamp wins per file, so nested span-bearing entities can't inflate the group line ratio. It rolls up the group source, summed covered/total lines, pct, and the latest `measured_at`.
- **Presence of `line_coverage` is itself the authoritative "report ingestion ran for this group" signal** (an entity only carries `coverage_source` if a report was actually ingested). Nil when nothing was stamped — the common case — so the banner degrades.
- `line_coverage` stays **distinct from `coverage_pct`**, which remains pure graph-derived reach coverage.

### How the banner now reads real state (frontend)
- `coverage-provenance.ts`: new pure `coverageStateFromReport(line_coverage, latestIndexAt?)` maps the endpoint field to the banner's `CoverageSourceState` — populates `line` + `reportIngestionConfigured: true` when ingested, else returns `{ reachabilityAvailable: true }`.
- `quality.tsx` `CoverageTab` now calls that helper instead of the hardcoded placeholder; the existing banner logic upgrades to the **line** kind automatically, showing "Line coverage — ingested from LCOV …, measured \<date\>", a real stale check, and no "how to enable" nag.
- `data/types.ts`: `LineCoverageSummary` type + `GroupCoverageReport.line_coverage`.

### % display
A compact, clearly-labeled strip on the Coverage tab when ingested coverage exists — `Line coverage NN.N%` badge + `covered / total lines (SOURCE)` — rendered **distinctly from** the reach-coverage gauge so the two numbers are never conflated. Absent gracefully when no report.

### Degradation
Groups without ingested coverage keep `line_coverage` nil; `coverageStateFromReport(undefined)` returns reachability state and the banner stays on reachability/capability with the how-to-enable affordance.

### Tests
- Go: 6 unit tests on the pure `lineCovAccumulator` (no-stamp→nil, nil-doc, roll-up + source + latest measured_at, no-double-count-within-file, stamped-but-no-valid-lines, multi-doc).
- Frontend: 3 new tests in `coverage-provenance.test.ts` — **ingested line-coverage state renders when the API reports `line_coverage`**, stale-flag when measurement predates index, and degrade-to-reachability when absent.

### Gates (sandbox HOME=/tmp/agsbx-5066)
- `go build ./...` ✅, `go vet ./internal/dashboard/... ./internal/coverage/...` ✅, `go test ./internal/dashboard/... ./internal/types/` ✅.
- `npm run build` ✅ (pre-existing chunk-size warning only; tsc typecheck clean), `npm test` ✅ (118 lib tests, 16 in coverage-provenance incl. the 3 new).
- Did NOT run `make dashboard-build` / the embed (deploy-window only).

### Deferred follow-ups
- Per-file/per-module ingested line % on the coverage tree rows (needs the props rolled up per file/module in the payload, not just group-level) and the diagram coverage overlay — **#5067 owns the overlay**.
- MCP-surfaced freshness.

Refs #5066