### PR TITLE
fix: daemon CPU runaway — bound extract subprocess CPU + exclude .claude worktrees from watch (#3648)

### DIFF
--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -60,12 +61,54 @@ func (c CoordinatorConfig) concurrency() int {
 	if c.Concurrency > 0 {
 		return c.Concurrency
 	}
+	// Emergency runtime override (no redeploy needed once this build ships):
+	// ARCHIGRAPH_EXTRACT_CONCURRENCY caps the number of concurrent extract
+	// subprocesses. Used to throttle the daemon on shared/contended machines
+	// where a high-churn repo (merge-every-few-minutes) would otherwise drive
+	// continuous full-reindex fan-out (#3648).
+	if n := envPositiveInt("ARCHIGRAPH_EXTRACT_CONCURRENCY"); n > 0 {
+		return n
+	}
 	n := runtime.NumCPU() / 2
 	if n < 1 {
 		n = 1
 	}
 	if n > 4 {
 		n = 4
+	}
+	return n
+}
+
+// extractGOMAXPROCS returns the per-subprocess GOMAXPROCS cap. Each extract
+// subprocess is a full archigraph process; without this it inherits the
+// daemon's GOMAXPROCS (= host core count) and the Go runtime spins one OS
+// thread per core. With concurrency() subprocesses running in parallel the
+// effective CPU draw becomes concurrency × hostCores, which is the observed
+// runaway (#3648: ~7 of 12 cores during back-to-back reindexes).
+//
+// Bounding each child to a small GOMAXPROCS keeps total extract CPU at roughly
+// concurrency × cap cores, leaving headroom for the consuming repo's CI.
+//
+//	ARCHIGRAPH_EXTRACT_GOMAXPROCS overrides the per-child value.
+//	Default: 2 (so 4 children × 2 = ~8 worker threads worst-case, vs the
+//	         previous unbounded 4 × hostCores).
+func extractGOMAXPROCS() int {
+	if n := envPositiveInt("ARCHIGRAPH_EXTRACT_GOMAXPROCS"); n > 0 {
+		return n
+	}
+	return 2
+}
+
+// envPositiveInt reads a strictly-positive integer from the named env var.
+// Returns 0 when unset, empty, non-numeric, or <= 0.
+func envPositiveInt(name string) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n <= 0 {
+		return 0
 	}
 	return n
 }
@@ -204,6 +247,11 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 	var mu sync.Mutex
 
 	sem := make(chan struct{}, cfg.concurrency())
+	// Per-subprocess GOMAXPROCS cap (#3648). Computed once; applied to every
+	// child's environment so the Go runtime in each extract subprocess does not
+	// scale its thread pool to the full host core count.
+	childGOMAXPROCS := strconv.Itoa(extractGOMAXPROCS())
+	childEnv := append(os.Environ(), "GOMAXPROCS="+childGOMAXPROCS)
 	var wg sync.WaitGroup
 	var firstErr error
 	var firstErrOnce sync.Once
@@ -245,6 +293,11 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 			}
 
 			cmd := exec.CommandContext(ctx, bin, args...)
+			// Bound the child's Go runtime to extractGOMAXPROCS() cores so
+			// concurrent extract subprocesses can't collectively saturate the
+			// host (#3648). GOMAXPROCS is appended last so it wins over any
+			// inherited value.
+			cmd.Env = childEnv
 			cmd.Stderr = stderr
 			stdout, perr := cmd.StdoutPipe()
 			if perr != nil {

--- a/internal/daemon/extract/cpu_cap_test.go
+++ b/internal/daemon/extract/cpu_cap_test.go
@@ -1,0 +1,83 @@
+package extract
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestConcurrencyEnvOverride verifies the #3648 emergency throttle:
+// ARCHIGRAPH_EXTRACT_CONCURRENCY overrides the auto-tuned subprocess fan-out,
+// while an explicit CoordinatorConfig.Concurrency still wins over the env var.
+func TestConcurrencyEnvOverride(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EXTRACT_CONCURRENCY", "1")
+	if got := (CoordinatorConfig{}).concurrency(); got != 1 {
+		t.Fatalf("env override: concurrency() = %d, want 1", got)
+	}
+
+	// Explicit config field takes precedence over the env var.
+	if got := (CoordinatorConfig{Concurrency: 3}).concurrency(); got != 3 {
+		t.Fatalf("explicit config: concurrency() = %d, want 3", got)
+	}
+
+	// Garbage / non-positive values are ignored → fall back to auto-tune.
+	t.Setenv("ARCHIGRAPH_EXTRACT_CONCURRENCY", "not-a-number")
+	auto := (CoordinatorConfig{}).concurrency()
+	want := runtime.NumCPU() / 2
+	if want < 1 {
+		want = 1
+	}
+	if want > 4 {
+		want = 4
+	}
+	if auto != want {
+		t.Fatalf("invalid env ignored: concurrency() = %d, want auto %d", auto, want)
+	}
+}
+
+// TestExtractGOMAXPROCS verifies the per-subprocess GOMAXPROCS cap and its
+// override. Each extract subprocess inherits this value so concurrent children
+// cannot collectively saturate the host (#3648 runaway).
+func TestExtractGOMAXPROCS(t *testing.T) {
+	if got := extractGOMAXPROCS(); got != 2 {
+		t.Fatalf("default extractGOMAXPROCS() = %d, want 2", got)
+	}
+
+	t.Setenv("ARCHIGRAPH_EXTRACT_GOMAXPROCS", "1")
+	if got := extractGOMAXPROCS(); got != 1 {
+		t.Fatalf("override extractGOMAXPROCS() = %d, want 1", got)
+	}
+
+	// Non-positive / garbage → default.
+	t.Setenv("ARCHIGRAPH_EXTRACT_GOMAXPROCS", "0")
+	if got := extractGOMAXPROCS(); got != 2 {
+		t.Fatalf("zero override ignored: extractGOMAXPROCS() = %d, want 2", got)
+	}
+	t.Setenv("ARCHIGRAPH_EXTRACT_GOMAXPROCS", "-4")
+	if got := extractGOMAXPROCS(); got != 2 {
+		t.Fatalf("negative override ignored: extractGOMAXPROCS() = %d, want 2", got)
+	}
+}
+
+func TestEnvPositiveInt(t *testing.T) {
+	cases := map[string]int{
+		"":          0,
+		"   ":       0,
+		"5":         5,
+		" 7 ":       7,
+		"0":         0,
+		"-3":        0,
+		"abc":       0,
+		"3.5":       0,
+		"1000000":   1000000,
+	}
+	for raw, want := range cases {
+		t.Setenv("AG_TEST_ENV_POSINT", raw)
+		if got := envPositiveInt("AG_TEST_ENV_POSINT"); got != want {
+			t.Errorf("envPositiveInt(%q) = %d, want %d", raw, got, want)
+		}
+	}
+	// Unset var → 0.
+	if got := envPositiveInt("AG_TEST_DEFINITELY_UNSET_VAR_3648"); got != 0 {
+		t.Errorf("unset var: envPositiveInt() = %d, want 0", got)
+	}
+}

--- a/internal/daemon/watch/skip.go
+++ b/internal/daemon/watch/skip.go
@@ -30,6 +30,15 @@ var SkipDirs = map[string]struct{}{
 	".git":        {},
 	".hg":         {},
 	".svn":        {},
+	// Agent scratch / linked git worktrees (#3648). Tools like Claude Code
+	// keep ephemeral checkouts under .claude/worktrees/, each a full repo
+	// tree with its own ~500MB node_modules. These are high-churn (a fresh
+	// branch every few minutes) and must never be walked or watched — doing
+	// so multiplies the watch set and feeds continuous reindex thrash on the
+	// parent repo. node_modules below is already skipped by basename, but
+	// skipping .claude outright also drops the worktrees' source trees, which
+	// otherwise rely solely on the consuming repo gitignoring .claude/worktrees.
+	".claude": {},
 	// JS / TS
 	"node_modules":  {},
 	".next":         {},

--- a/internal/daemon/watch/watcher_test.go
+++ b/internal/daemon/watch/watcher_test.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,7 @@ func TestShouldSkipDir(t *testing.T) {
 		"internal":     false,
 		".archigraph":  true,
 		"dist":         true,
+		".claude":      true, // #3648: agent scratch / linked worktrees
 	}
 	for in, want := range cases {
 		if got := ShouldSkipDir(in); got != want {
@@ -36,6 +38,10 @@ func TestShouldSkipPath(t *testing.T) {
 		"/repo/a.log":                      true,
 		"/repo/a.swp":                      true,
 		"/repo/cmd/foo/main_test.go":       false,
+		// #3648: agent worktrees under .claude/ must be dropped at any depth,
+		// including the high-churn node_modules nested inside each worktree.
+		"/repo/.claude/worktrees/agent-x/src/main.ts":               true,
+		"/repo/.claude/worktrees/agent-x/node_modules/foo/index.js": true,
 	}
 	for in, want := range cases {
 		if got := ShouldSkipPath(in); got != want {
@@ -196,6 +202,82 @@ func TestSkipDirRespected(t *testing.T) {
 	if got := calls.Load(); got != 1 {
 		t.Errorf("expected 1 sink call for src write, got %d", got)
 	}
+}
+
+// TestClaudeWorktreeNotWatched is the #3648 regression guard: edits inside a
+// .claude/worktrees/<agent> checkout (the scratch worktrees Claude Code creates,
+// each a full repo tree with its own node_modules) must NEVER reach the sink.
+// Before .claude was added to SkipDirs, the worktrees' source trees were walked
+// and watched, so every agent merge fed a full-reindex of the parent repo.
+func TestClaudeWorktreeNotWatched(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	// A worktree source tree AND its nested node_modules, mirroring the live layout.
+	wtSrc := filepath.Join(repo, ".claude", "worktrees", "agent-x", "src")
+	wtNM := filepath.Join(repo, ".claude", "worktrees", "agent-x", "node_modules", "pkg")
+	if err := os.MkdirAll(wtSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(wtNM, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(repo, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w, err := newTestWatcher(100*time.Millisecond, func(string, bool) {
+		calls.Add(1)
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// The worktree directory must not have been subscribed at all.
+	for _, d := range w.Repos() {
+		_ = d
+	}
+	w.mu.Lock()
+	for dir := range w.dirToRepo {
+		if filepathHasClaude(dir) {
+			w.mu.Unlock()
+			t.Fatalf("watcher subscribed a .claude path it should have skipped: %s", dir)
+		}
+	}
+	w.mu.Unlock()
+
+	// Writes inside the worktree (source AND node_modules) must be ignored.
+	if err := os.WriteFile(filepath.Join(wtSrc, "feature.ts"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtNM, "index.js"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Errorf("expected 0 sink calls for .claude/worktrees writes, got %d", got)
+	}
+
+	// Sanity: a real source write still triggers exactly one reindex.
+	if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 sink call for src write, got %d", got)
+	}
+}
+
+func filepathHasClaude(p string) bool {
+	return strings.Contains(filepath.ToSlash(p), "/.claude/") ||
+		strings.HasSuffix(filepath.ToSlash(p), "/.claude")
 }
 
 // TestBulkDetection verifies that a burst exceeding BulkThreshold in one


### PR DESCRIPTION
## Root cause (hot path)

The live daemon (pid 43782) bursts to ~693–786% CPU (~7 of 12 cores) while watching/indexing a high-churn NestJS repo (`core-backend-v3`, group `upvate-v3`) that lands a merge every few minutes.

Diagnosis (read-only `sample`/`lsof`/code):

1. **Watch scope is fine.** `.claude/worktrees/`, nested `node_modules`, `dist`, `coverage`, `.git` are correctly excluded (basename `SkipDirs` + the consuming repo's `.gitignore` for `.claude/worktrees`). `lsof` on the live daemon showed **no** worktree / nested-node_modules dirs open. So the burn is in re-indexing, not the watcher walk.

2. **Incremental reindex is OFF by default** (`ARCHIGRAPH_INCREMENTAL_REINDEX`, `ExtractorConfig.IsIncrementalEnabled()` → false). Every debounced settle, and every `bulk=true` (a merge fires 50+ events → forced full reindex), triggers a **full repo reindex**. Merge-every-few-minutes × full-reindex = continuous thrash.

3. **The actual hot path — unbounded per-subprocess CPU.** `internal/daemon/extract/coordinator.go` forks up to `NumCPU/2` capped at 4 extract **subprocesses**. Each child is a full `archigraph` process that **inherits the daemon's GOMAXPROCS = host core count (12)**, so the Go runtime in each child spins one OS thread per core. Effective draw = `concurrency × hostCores` = up to `4 × 12`. The "capped at 4" bounds process *count*, not cores. This matches the measured ~7-core burn exactly (a few children warming/winding down at any instant + GC).

No regressing commit in the watcher/walk/indexer in the last 7 days — the running binary is at HEAD. The regression surfaced because the *consuming repo's churn profile* changed (≈20 agent worktrees + merge-every-few-minutes), which turned the pre-existing unbounded-child-CPU behavior into a runaway. The fix bounds it structurally.

## The fix

- **Cap each extract subprocess's CPU**: set `GOMAXPROCS=2` on every child's env (override `ARCHIGRAPH_EXTRACT_GOMAXPROCS`). Total extract draw is now ~`concurrency × 2` cores instead of `concurrency × hostCores`.
- **Emergency throttle**: `ARCHIGRAPH_EXTRACT_CONCURRENCY` env override for subprocess fan-out (tune without a code change once this build ships).
- **Defense-in-depth exclude**: add `.claude` to the watcher `SkipDirs`. Agent worktrees under `.claude/worktrees/` are full repo trees with ~500MB `node_modules` each and a fresh branch every few minutes; previously they were dropped only via the consuming repo's `.gitignore`. Skipping `.claude` by basename also drops the worktrees' source trees, independent of repo gitignore.

## Tests

- `internal/daemon/extract/cpu_cap_test.go` — per-subprocess GOMAXPROCS default+override, concurrency env override (explicit config still wins, garbage ignored), `envPositiveInt` edge cases.
- `internal/daemon/watch/watcher_test.go` — `.claude` in `ShouldSkipDir`; `.claude/worktrees/**` (src + nested node_modules) dropped by `ShouldSkipPath`; new `TestClaudeWorktreeNotWatched` regression guard proving worktree writes never reach the reindex sink while a real `src/` write still triggers exactly one reindex (`dirs=2` subscribed).

## Gates (sandbox HOME)

`go build ./...` ✅ · `go vet ./internal/...` ✅ · `go test ./internal/daemon/extract/ ./internal/daemon/watch/ ./internal/types/` ✅

## Deploy

Requires a daemon **rebuild + restart** to take effect (binary change). Immediate mitigation without a deploy: drop `.archigraph/watch.json` in the repo is not enough for CPU — instead restart the daemon with `ARCHIGRAPH_INCREMENTAL_REINDEX=1` (switches single-file edits to incremental) and/or `ARCHIGRAPH_EXTRACT_CONCURRENCY=1`. Those env knobs exist on the current binary too (incremental) — but `ARCHIGRAPH_EXTRACT_CONCURRENCY`/`ARCHIGRAPH_EXTRACT_GOMAXPROCS` ship with this PR.

Refs #3648