### PR TITLE
feat(#5135): env-driven CPU/concurrency tuning — split rebuild vs churn cap + daemon knob + docs

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -145,6 +146,51 @@ func resolveEnvRebuildConcurrency() int {
 	return defaultRebuildConcurrency()
 }
 
+// resolveDaemonGOMAXPROCS returns the GOMAXPROCS the daemon process should run
+// at, given the host core count and the ARCHIGRAPH_DAEMON_GOMAXPROCS env var
+// (#5135). It returns 0 when no cap should be applied (env unset/invalid or the
+// requested value is >= the host core count, in which case the Go default is
+// already correct and we leave it untouched).
+//
+// This is the NATIVE in-process knob: it bounds the daemon's own Go runtime
+// parallelism (in-process extraction/reindex, GC, algorithm passes) WITHOUT
+// requiring the generic GOMAXPROCS env var (which is fine, but undocumented and
+// easy to confuse with the per-subprocess ARCHIGRAPH_EXTRACT_GOMAXPROCS cap).
+//
+// Tradeoff (documented in docs/settings.md): because query handling shares the
+// same process, lowering this also lowers the ceiling on concurrent query
+// throughput. It is the right knob when the daemon's OWN in-process indexing
+// (ARCHIGRAPH_SUBPROC_EXTRACT unset/0) is the CPU source; when the subprocess
+// extractor is enabled, prefer ARCHIGRAPH_EXTRACT_GOMAXPROCS / _CONCURRENCY,
+// which throttle the children without touching query latency.
+func resolveDaemonGOMAXPROCS(hostCPU int) int {
+	n := envPositiveInt2("ARCHIGRAPH_DAEMON_GOMAXPROCS")
+	if n <= 0 {
+		return 0
+	}
+	if hostCPU > 0 && n >= hostCPU {
+		// Already at/above the Go default — nothing to cap.
+		return 0
+	}
+	return n
+}
+
+// envPositiveInt2 reads a strictly-positive integer from the named env var,
+// returning 0 when unset, empty, non-numeric, or <= 0. (Mirrors the helper in
+// internal/daemon/extract; duplicated here to avoid an import cycle / exporting
+// an internal helper for one call site.)
+func envPositiveInt2(name string) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
 // runDaemon is the long-running mode of the archigraph binary. It is
 // wired into the CLI as a hidden `archigraph daemon` subcommand —
 // users normally reach it via `archigraph start`, which forks this
@@ -165,6 +211,17 @@ func runDaemon(argv []string) error {
 	// Always log so future heap regressions are diagnosable.
 	gcLog := log.New(os.Stderr, "archigraph-daemon: ", log.LstdFlags|log.Lmicroseconds)
 	gcLog.Printf("gc-tune: GOGC=50 (override=%v)", gcOverride)
+
+	// #5135: native in-process GOMAXPROCS cap. ARCHIGRAPH_DAEMON_GOMAXPROCS
+	// bounds the daemon's own Go-runtime parallelism (in-process extraction,
+	// reindex, GC, algorithm passes) without needing the generic GOMAXPROCS
+	// env var. Only applied when set, valid, and below the host core count;
+	// otherwise the Go default (= host cores) is left untouched. See
+	// docs/settings.md for the query-latency tradeoff.
+	if gmp := resolveDaemonGOMAXPROCS(runtime.NumCPU()); gmp > 0 {
+		prev := runtime.GOMAXPROCS(gmp)
+		gcLog.Printf("cpu-tune: ARCHIGRAPH_DAEMON_GOMAXPROCS=%d applied (was %d, host=%d)", gmp, prev, runtime.NumCPU())
+	}
 
 	// Parse daemon-only flags. The root cobra command has flag parsing
 	// disabled for "daemon" so we own the argv. Unknown flags exit
@@ -641,6 +698,9 @@ func daemonIndexFunc(args proto.IndexArgs) (string, string, error) {
 		WithPrintSkipped(args.PrintSkipped),
 		WithAdditionalSkipDirs(args.AdditionalSkipDirs),
 		WithExportJSON(args.ExportJSON),
+		// #5135: an `archigraph index` RPC is an explicit user-triggered
+		// foreground index — run it at the higher rebuild CPU cap.
+		WithInteractive(true),
 	}
 	// Capture stats into a local buffer when the caller asked for them.
 	// setCapturedStats is a tiny package-level swap (Phase A serializes
@@ -680,6 +740,11 @@ func daemonIndexFunc(args proto.IndexArgs) (string, string, error) {
 // per-repo indexes complete.
 func makeDaemonRebuildFunc(concurrency int) daemon.RebuildFunc {
 	indexFn := func(repoPath, outPath, repoTag string, skipPasses []string, pretty, jsonStats bool, opts ...IndexOption) error {
+		// #5135: a rebuild RPC is an explicit, user-triggered foreground
+		// rebuild — run it at the higher ARCHIGRAPH_REBUILD_GOMAXPROCS cap
+		// instead of the throttled background extract cap. WithInteractive is
+		// prepended so an explicit opts override (if any) still wins.
+		opts = append([]IndexOption{WithInteractive(true)}, opts...)
 		return Index(repoPath, outPath, repoTag, skipPasses, pretty, jsonStats, opts...)
 	}
 	linksFn := func(group string) error {

--- a/cmd/archigraph/daemon_gomaxprocs_test.go
+++ b/cmd/archigraph/daemon_gomaxprocs_test.go
@@ -1,0 +1,67 @@
+package main
+
+import "testing"
+
+// TestResolveDaemonGOMAXPROCS verifies the #5135 native in-process daemon CPU
+// knob: ARCHIGRAPH_DAEMON_GOMAXPROCS caps the daemon's own Go-runtime
+// parallelism, returning 0 ("leave the Go default untouched") when unset/empty,
+// invalid, or already >= the host core count. envPositiveInt2 treats an empty
+// or whitespace-only value as unset, so the empty-string cases exercise the
+// unset branch deterministically without an os.Unsetenv dance.
+func TestResolveDaemonGOMAXPROCS(t *testing.T) {
+	const host = 12
+
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"empty", "", 0},
+		{"blank", "   ", 0},
+		{"valid-below-host", "3", 3},
+		{"one", "1", 1},
+		{"equal-host-noop", "12", 0},
+		{"above-host-noop", "20", 0},
+		{"zero-ignored", "0", 0},
+		{"negative-ignored", "-4", 0},
+		{"garbage-ignored", "abc", 0},
+		{"float-ignored", "2.5", 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ARCHIGRAPH_DAEMON_GOMAXPROCS", tc.env)
+			if got := resolveDaemonGOMAXPROCS(host); got != tc.want {
+				t.Fatalf("resolveDaemonGOMAXPROCS(env=%q, host=%d) = %d, want %d", tc.env, host, got, tc.want)
+			}
+		})
+	}
+
+	// host=0 (unknown core count) must not panic and should still return the
+	// requested cap (no host ceiling to compare against).
+	t.Setenv("ARCHIGRAPH_DAEMON_GOMAXPROCS", "4")
+	if got := resolveDaemonGOMAXPROCS(0); got != 4 {
+		t.Fatalf("resolveDaemonGOMAXPROCS(host=0) = %d, want 4", got)
+	}
+}
+
+// TestEnvPositiveInt2 covers the local env helper used by the daemon CPU knob.
+func TestEnvPositiveInt2(t *testing.T) {
+	cases := map[string]int{
+		"":        0,
+		"   ":     0,
+		"5":       5,
+		" 7 ":     7,
+		"0":       0,
+		"-3":      0,
+		"abc":     0,
+		"3.5":     0,
+		"1000000": 1000000,
+	}
+	for raw, want := range cases {
+		t.Setenv("AG_TEST_ENV_POSINT2", raw)
+		if got := envPositiveInt2("AG_TEST_ENV_POSINT2"); got != want {
+			t.Errorf("envPositiveInt2(%q) = %d, want %d", raw, got, want)
+		}
+	}
+}

--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -202,6 +202,15 @@ type Indexer struct {
 	// it stays empty and module.Derive's per-package rollup applies.
 	singleModuleLabel string
 
+	// interactive marks this index run as an explicit, user-triggered
+	// foreground rebuild (`archigraph rebuild` / `archigraph index`) rather
+	// than a background watch/churn-triggered reindex (#5135). It is forwarded
+	// to the subprocess extract coordinator (when ARCHIGRAPH_SUBPROC_EXTRACT=1)
+	// so the foreground rebuild runs at the higher ARCHIGRAPH_REBUILD_GOMAXPROCS
+	// cap (default = host cores) instead of the throttled background
+	// ARCHIGRAPH_EXTRACT_GOMAXPROCS cap (default 2). Wired via WithInteractive.
+	interactive bool
+
 	// coverageCfg is the per-group coverage-ingestion config (#5061/#5036).
 	// Zero value means "discover the default report path" (coverage/lcov.info);
 	// a populated Config honors its explicit report_paths globs. The coverage
@@ -331,6 +340,17 @@ func WithIncremental(stateDir string) IndexOption {
 // (#5037) runs. Pass --skip-pass=coverage to disable the whole pass.
 func WithCoverage(cfg coverage.Config) IndexOption {
 	return func(i *Indexer) { i.coverageCfg = cfg }
+}
+
+// WithInteractive marks an index run as an explicit, user-triggered foreground
+// rebuild rather than a background watch/churn-triggered reindex (#5135). When
+// true (and ARCHIGRAPH_SUBPROC_EXTRACT=1), the subprocess extract coordinator
+// runs at the higher ARCHIGRAPH_REBUILD_GOMAXPROCS cap (default = host cores)
+// and wider fan-out, instead of the throttled background extract cap (default
+// ARCHIGRAPH_EXTRACT_GOMAXPROCS=2). Set by the daemon's rebuild RPC path and by
+// the `archigraph index` CLI; left false on the scheduler's reactive reindex.
+func WithInteractive(enabled bool) IndexOption {
+	return func(i *Indexer) { i.interactive = enabled }
 }
 
 type indexerStats struct {
@@ -921,6 +941,9 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			BatchSize:   subprocBatchSize(),
 			SkipPasses:  skipPassNames(i.skipPasses),
 			Stderr:      os.Stderr,
+			// #5135: foreground rebuilds run at the higher rebuild cap;
+			// background scheduler reindexes stay throttled.
+			Interactive: i.interactive,
 		})
 		if cerr != nil {
 			trk.Fail(cerr.Error())

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -37,6 +37,42 @@ fall back to the defaults below.
 | `indexer_parallelism` | int | `4` | 1–32 | Number of parallel goroutines used during indexing. **Requires daemon restart.** |
 | `log_level` | string | `"info"` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | Daemon log verbosity |
 
+## CPU / concurrency / reindex environment variables
+
+These knobs are read from the daemon's environment (not `settings.json`) and
+let you dial CPU usage without recompiling. They take effect on the next daemon
+start — set them in whatever launches `archigraph start` (your shell profile,
+a launchd/systemd unit, etc.). Issues [#5134](https://github.com/cajasmota/archigraph/issues/5134)
+and [#5135](https://github.com/cajasmota/archigraph/issues/5135).
+
+archigraph distinguishes two reindex paths and caps them independently:
+
+- **Background reindex** — the watcher/scheduler re-indexing a repo after a
+  file save, merge, or branch switch. On a high-churn repo this can fire
+  continuously, so it is throttled by default.
+- **Explicit rebuild** — a user-triggered `archigraph rebuild` / `archigraph index`
+  (or a dashboard rebuild). You are waiting on it, so it runs at host speed.
+
+The CPU caps below only bite when the **subprocess extractor** is enabled
+(`ARCHIGRAPH_SUBPROC_EXTRACT=1`), which forks one `archigraph extract` child
+per file batch. When it is off (the default), the daemon extracts in-process and
+`ARCHIGRAPH_DAEMON_GOMAXPROCS` / the generic `GOMAXPROCS` are the relevant knobs.
+
+| Env var | Default | Path | Effect / when to change |
+|---------|---------|------|--------------------------|
+| `ARCHIGRAPH_EXTRACT_GOMAXPROCS` | `2` | background | `GOMAXPROCS` set on each **background** extract subprocess. Total extract draw ≈ `concurrency × this`. Lower to `1` to throttle a daemon that's burning CPU on a high-churn repo; raise if background reindexes feel slow and the host is idle. |
+| `ARCHIGRAPH_REBUILD_GOMAXPROCS` | host cores (`NumCPU`) | explicit | `GOMAXPROCS` set on each **explicit-rebuild** extract subprocess. Defaults to the full host so a user-triggered rebuild runs fast (it is no longer throttled by the background cap — [#5135](https://github.com/cajasmota/archigraph/issues/5135)). Lower it if explicit rebuilds on a shared host need to leave headroom for CI. |
+| `ARCHIGRAPH_EXTRACT_CONCURRENCY` | auto (`NumCPU/2`, capped at 4 background; `NumCPU` explicit) | both | Hard ceiling on the number of concurrent extract subprocesses, honored on **both** paths. Set to `1` as an emergency throttle on a contended machine — it caps explicit rebuilds too. |
+| `ARCHIGRAPH_DAEMON_GOMAXPROCS` | unset (Go default = host cores) | in-process | Caps the **daemon's own** Go-runtime parallelism (in-process extraction, reindex, GC, algorithm passes) without the generic `GOMAXPROCS`. Use this when in-process indexing (subprocess extractor off) is the CPU source. **Tradeoff:** query handling shares the same process, so lowering this also lowers the ceiling on concurrent query throughput. Ignored when ≥ host cores. |
+| `GOMAXPROCS` | host cores | in-process | Standard Go knob. Caps the entire daemon process (queries **and** in-process indexing). Prefer `ARCHIGRAPH_DAEMON_GOMAXPROCS` (same effect, archigraph-scoped name) or the per-subprocess caps above, which don't touch query latency. |
+| `ARCHIGRAPH_INCREMENTAL_REINDEX` | `0` (off) | background | `1` switches single-file edits to a diff-aware incremental reindex (only changed files are re-extracted) instead of a full repo reindex on every settle. Recommended on high-churn repos to cut continuous reindex thrash. |
+| `ARCHIGRAPH_REBUILD_CONCURRENCY` | auto (memory-tuned, floor 2, cap 16) | explicit | Number of **repos** indexed in parallel during a group rebuild (distinct from subprocess fan-out *within* a repo). Auto-tuned from system RAM; override to bound memory on constrained hosts. (Legacy alias: `ARCHIGRAPH_MAX_CONCURRENT_GROUPS`.) |
+
+All of the above are **read at daemon start** and require a restart to apply —
+they cannot yet be changed live. Runtime-without-restart reload is tracked
+separately; until then, restart the daemon (`archigraph restart`) after changing
+any value.
+
 ## API endpoints
 
 | Method | Path | Description |

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -55,6 +55,20 @@ type CoordinatorConfig struct {
 	// Stderr receives subprocess stderr (logs, progress). When nil the
 	// coordinator discards it.
 	Stderr io.Writer
+
+	// Interactive marks this extraction as an explicit, user-triggered
+	// foreground rebuild (e.g. `archigraph rebuild` / `archigraph index`)
+	// rather than a background watch/churn-triggered reindex (#5135).
+	//
+	// The #5134 CPU cap (a low per-subprocess GOMAXPROCS, default 2) exists
+	// to stop continuous background reindexes from saturating a shared host.
+	// But applying that same low cap to an EXPLICIT rebuild makes the thing
+	// the user is actively waiting on needlessly slow. When Interactive is
+	// true the coordinator uses the higher ARCHIGRAPH_REBUILD_GOMAXPROCS cap
+	// (default = host core count) and the rebuild fan-out concurrency, so the
+	// foreground rebuild runs fast; only the throttled background path keeps
+	// the conservative ARCHIGRAPH_EXTRACT_GOMAXPROCS=2 default.
+	Interactive bool
 }
 
 func (c CoordinatorConfig) concurrency() int {
@@ -65,8 +79,19 @@ func (c CoordinatorConfig) concurrency() int {
 	// ARCHIGRAPH_EXTRACT_CONCURRENCY caps the number of concurrent extract
 	// subprocesses. Used to throttle the daemon on shared/contended machines
 	// where a high-churn repo (merge-every-few-minutes) would otherwise drive
-	// continuous full-reindex fan-out (#3648).
+	// continuous full-reindex fan-out (#3648). It applies to BOTH paths — an
+	// operator-set ceiling on contended hosts is honored even for explicit
+	// rebuilds.
 	if n := envPositiveInt("ARCHIGRAPH_EXTRACT_CONCURRENCY"); n > 0 {
+		return n
+	}
+	// #5135: explicit foreground rebuilds fan out wider (the user is waiting
+	// on them); background churn reindexes stay at the conservative cap.
+	if c.Interactive {
+		n := runtime.NumCPU()
+		if n < 1 {
+			n = 1
+		}
 		return n
 	}
 	n := runtime.NumCPU() / 2
@@ -92,11 +117,43 @@ func (c CoordinatorConfig) concurrency() int {
 //	ARCHIGRAPH_EXTRACT_GOMAXPROCS overrides the per-child value.
 //	Default: 2 (so 4 children × 2 = ~8 worker threads worst-case, vs the
 //	         previous unbounded 4 × hostCores).
+//
+// #5135: this is the BACKGROUND (watch/churn-triggered) cap. Explicit
+// foreground rebuilds use childGOMAXPROCS() with Interactive=true, which
+// resolves the higher ARCHIGRAPH_REBUILD_GOMAXPROCS instead.
 func extractGOMAXPROCS() int {
 	if n := envPositiveInt("ARCHIGRAPH_EXTRACT_GOMAXPROCS"); n > 0 {
 		return n
 	}
 	return 2
+}
+
+// rebuildGOMAXPROCS returns the per-subprocess GOMAXPROCS cap for an EXPLICIT,
+// user-triggered foreground rebuild (#5135). The user is actively waiting on
+// these, so they should run at host speed — only background churn reindexes
+// are throttled by the conservative extractGOMAXPROCS() default.
+//
+//	ARCHIGRAPH_REBUILD_GOMAXPROCS overrides the per-child value.
+//	Default: host core count (runtime.NumCPU()), i.e. effectively uncapped.
+func rebuildGOMAXPROCS() int {
+	if n := envPositiveInt("ARCHIGRAPH_REBUILD_GOMAXPROCS"); n > 0 {
+		return n
+	}
+	n := runtime.NumCPU()
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// childGOMAXPROCS resolves the per-subprocess GOMAXPROCS cap for THIS
+// extraction, dispatching on whether it is an interactive foreground rebuild
+// or a throttled background reindex (#5135).
+func (c CoordinatorConfig) childGOMAXPROCS() int {
+	if c.Interactive {
+		return rebuildGOMAXPROCS()
+	}
+	return extractGOMAXPROCS()
 }
 
 // envPositiveInt reads a strictly-positive integer from the named env var.
@@ -250,7 +307,7 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 	// Per-subprocess GOMAXPROCS cap (#3648). Computed once; applied to every
 	// child's environment so the Go runtime in each extract subprocess does not
 	// scale its thread pool to the full host core count.
-	childGOMAXPROCS := strconv.Itoa(extractGOMAXPROCS())
+	childGOMAXPROCS := strconv.Itoa(cfg.childGOMAXPROCS())
 	childEnv := append(os.Environ(), "GOMAXPROCS="+childGOMAXPROCS)
 	var wg sync.WaitGroup
 	var firstErr error

--- a/internal/daemon/extract/cpu_cap_test.go
+++ b/internal/daemon/extract/cpu_cap_test.go
@@ -81,3 +81,86 @@ func TestEnvPositiveInt(t *testing.T) {
 		t.Errorf("unset var: envPositiveInt() = %d, want 0", got)
 	}
 }
+
+// TestRebuildGOMAXPROCS verifies the #5135 explicit-rebuild cap and its
+// override. Foreground rebuilds run at host speed by default (= NumCPU), and
+// ARCHIGRAPH_REBUILD_GOMAXPROCS overrides the per-child value.
+func TestRebuildGOMAXPROCS(t *testing.T) {
+	wantDefault := runtime.NumCPU()
+	if wantDefault < 1 {
+		wantDefault = 1
+	}
+	if got := rebuildGOMAXPROCS(); got != wantDefault {
+		t.Fatalf("default rebuildGOMAXPROCS() = %d, want host cores %d", got, wantDefault)
+	}
+
+	t.Setenv("ARCHIGRAPH_REBUILD_GOMAXPROCS", "6")
+	if got := rebuildGOMAXPROCS(); got != 6 {
+		t.Fatalf("override rebuildGOMAXPROCS() = %d, want 6", got)
+	}
+
+	// Non-positive / garbage → host-cores default.
+	t.Setenv("ARCHIGRAPH_REBUILD_GOMAXPROCS", "0")
+	if got := rebuildGOMAXPROCS(); got != wantDefault {
+		t.Fatalf("zero override ignored: rebuildGOMAXPROCS() = %d, want %d", got, wantDefault)
+	}
+	t.Setenv("ARCHIGRAPH_REBUILD_GOMAXPROCS", "garbage")
+	if got := rebuildGOMAXPROCS(); got != wantDefault {
+		t.Fatalf("garbage override ignored: rebuildGOMAXPROCS() = %d, want %d", got, wantDefault)
+	}
+}
+
+// TestChildGOMAXPROCSSplit is the core #5135 proof: the SAME env settings yield
+// the LOW background cap for a watch/churn reindex and the HIGH rebuild cap for
+// an explicit foreground rebuild, dispatched purely on CoordinatorConfig.Interactive.
+func TestChildGOMAXPROCSSplit(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_EXTRACT_GOMAXPROCS", "2")
+	t.Setenv("ARCHIGRAPH_REBUILD_GOMAXPROCS", "9")
+
+	bg := CoordinatorConfig{Interactive: false}.childGOMAXPROCS()
+	if bg != 2 {
+		t.Fatalf("background childGOMAXPROCS() = %d, want 2 (extract cap)", bg)
+	}
+
+	fg := CoordinatorConfig{Interactive: true}.childGOMAXPROCS()
+	if fg != 9 {
+		t.Fatalf("interactive childGOMAXPROCS() = %d, want 9 (rebuild cap)", fg)
+	}
+
+	if bg >= fg {
+		t.Fatalf("expected background cap (%d) < interactive cap (%d)", bg, fg)
+	}
+}
+
+// TestInteractiveConcurrency verifies the #5135 fan-out split: an explicit
+// rebuild fans out to NumCPU subprocesses while a background reindex stays at
+// the conservative NumCPU/2-capped-at-4 default — unless an explicit
+// CoordinatorConfig.Concurrency or ARCHIGRAPH_EXTRACT_CONCURRENCY ceiling is set.
+func TestInteractiveConcurrency(t *testing.T) {
+	// No env override: interactive fans wider than background.
+	bg := CoordinatorConfig{Interactive: false}.concurrency()
+	fg := CoordinatorConfig{Interactive: true}.concurrency()
+
+	wantFG := runtime.NumCPU()
+	if wantFG < 1 {
+		wantFG = 1
+	}
+	if fg != wantFG {
+		t.Fatalf("interactive concurrency() = %d, want host cores %d", fg, wantFG)
+	}
+	if runtime.NumCPU() > 8 && !(fg > bg) {
+		t.Fatalf("expected interactive concurrency (%d) > background (%d) on a >8-core host", fg, bg)
+	}
+
+	// An operator-set ceiling (ARCHIGRAPH_EXTRACT_CONCURRENCY) is honored on
+	// BOTH paths — even interactive rebuilds respect a contended-host cap.
+	t.Setenv("ARCHIGRAPH_EXTRACT_CONCURRENCY", "1")
+	if got := (CoordinatorConfig{Interactive: true}).concurrency(); got != 1 {
+		t.Fatalf("interactive should honor ARCHIGRAPH_EXTRACT_CONCURRENCY ceiling: got %d, want 1", got)
+	}
+
+	// An explicit config field still wins over everything.
+	if got := (CoordinatorConfig{Interactive: true, Concurrency: 3}).concurrency(); got != 3 {
+		t.Fatalf("explicit Concurrency should win: got %d, want 3", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #5134. Makes the daemon's CPU/concurrency/reindex tuning fully env-driven, documented, and splits the throttle so it no longer slows explicit user-triggered rebuilds.

## Env knobs (defaults)
| Env var | Default | Path | Effect |
|---|---|---|---|
| `ARCHIGRAPH_EXTRACT_GOMAXPROCS` | `2` | background | per-subprocess GOMAXPROCS for **background** (watch/churn) reindex (#5134, unchanged) |
| `ARCHIGRAPH_REBUILD_GOMAXPROCS` | host cores | explicit | **NEW** — per-subprocess GOMAXPROCS for **explicit** `archigraph rebuild`/`index`; defaults to full host so foreground rebuilds run fast |
| `ARCHIGRAPH_EXTRACT_CONCURRENCY` | auto | both | subprocess fan-out ceiling, honored on both paths (emergency throttle) |
| `ARCHIGRAPH_DAEMON_GOMAXPROCS` | unset | in-process | **NEW** — caps the daemon's own in-process Go parallelism without the generic `GOMAXPROCS` |
| `GOMAXPROCS` | host cores | in-process | standard Go knob (documented for contrast) |
| `ARCHIGRAPH_INCREMENTAL_REINDEX` | `0` | background | diff-aware incremental reindex (documented) |
| `ARCHIGRAPH_REBUILD_CONCURRENCY` | auto | explicit | parallel **repos** per group rebuild (documented) |

## Rebuild-vs-churn split — LANDED
`CoordinatorConfig.Interactive` dispatches the per-subprocess cap and fan-out:
- Background scheduler reindex (`daemonSchedulerIndex` → `Index`) stays throttled (`ARCHIGRAPH_EXTRACT_GOMAXPROCS=2`, `NumCPU/2` capped at 4).
- Explicit rebuild RPC (`makeDaemonRebuildFunc`) and `archigraph index` RPC (`daemonIndexFunc`) set `WithInteractive(true)` → `ARCHIGRAPH_REBUILD_GOMAXPROCS` (host cores) + `NumCPU` fan-out.
- An operator-set `ARCHIGRAPH_EXTRACT_CONCURRENCY` ceiling and explicit `CoordinatorConfig.Concurrency` still win on both paths.

(The cap only bites when `ARCHIGRAPH_SUBPROC_EXTRACT=1`, the subprocess extractor; in-process is covered by `ARCHIGRAPH_DAEMON_GOMAXPROCS`.)

## Native daemon knob — LANDED
`ARCHIGRAPH_DAEMON_GOMAXPROCS` applied at daemon startup via `runtime.GOMAXPROCS` (`resolveDaemonGOMAXPROCS`), ignored when ≥ host cores. Query-latency tradeoff documented.

## Docs
New "CPU / concurrency / reindex environment variables" section in `docs/settings.md` — every knob with default + path + effect + when-to-change. No file moves, inbound links intact, no coverage-gen chore needed.

## Runtime-reload (no restart) — DEFERRED
Reading caps from a config file on each reindex touches the scheduler hot path; deferred to a follow-up (filed) to keep this PR low-risk. All knobs are read at daemon start.

## Tests
- `internal/daemon/extract/cpu_cap_test.go`: `TestRebuildGOMAXPROCS`, `TestChildGOMAXPROCSSplit` (same env → low background cap vs high rebuild cap), `TestInteractiveConcurrency`.
- `cmd/archigraph/daemon_gomaxprocs_test.go`: `TestResolveDaemonGOMAXPROCS` (table: below/equal/above host, garbage, host=0), `TestEnvPositiveInt2`.

## Gates (sandbox HOME=/tmp/agsbx-5135)
`go build ./...` ok · `go vet ./internal/...` ok · `go test ./internal/daemon/... ./internal/types/` ok · `go test ./cmd/archigraph/ -run GOMAXPROCS...` ok

Deploy-deferred (binary change → daemon rebuild + restart). Live daemon untouched.

Refs #5135