### PR TITLE
fix(#5138): coalesce reindex per repo — one in-flight + single pending follow-up (thrash root cause)

### DIFF
--- a/internal/daemon/sched/coalesce_test.go
+++ b/internal/daemon/sched/coalesce_test.go
@@ -1,0 +1,215 @@
+package sched
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCoalesce_OneInFlightPlusSingleFollowUp proves the #5138 invariant:
+// N concurrent reindex requests for ONE repo while a reindex is in-flight
+// collapse into exactly ONE in-flight run plus AT MOST ONE coalesced
+// follow-up — never N stacked jobs.
+//
+// Deterministic synchronisation (no sleeps): the fake Index func signals
+// when it has entered the in-flight run (so the duplicate enqueues are
+// guaranteed to arrive while inflight[repo] is set), then blocks on a gate
+// the test releases. We assert the Index func is invoked at most twice.
+func TestCoalesce_OneInFlightPlusSingleFollowUp(t *testing.T) {
+	var calls atomic.Int32
+	entered := make(chan struct{}, 1) // signalled each time Index enters
+	release := make(chan struct{})    // test releases the in-flight run(s)
+
+	s := New(Config{
+		Workers: 4, // plenty of workers — coalescing must NOT rely on a 1-worker pool
+		Index: func(_ context.Context, _ string, _ string) error {
+			calls.Add(1)
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	const repo = "/repo-a"
+
+	// Kick off the first reindex and wait until it is provably in-flight.
+	s.Enqueue(repo)
+	<-entered
+
+	// Fire 10 more reindex requests for the SAME repo while the first is
+	// held in-flight. These must all coalesce into a single dirty marker.
+	for i := 0; i < 10; i++ {
+		s.Enqueue(repo)
+	}
+
+	// Wait until the scheduler has observed at least one of those enqueues
+	// as a dirty mark (deterministic: poll the guarded map, not a sleep).
+	waitFor(t, time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.dirty[repo]
+	})
+
+	// Release all runs. The in-flight run completes and, because the repo
+	// is dirty, schedules exactly ONE follow-up. The follow-up also reads
+	// from the (now-closed) release channel, so it proceeds immediately.
+	close(release)
+
+	// The follow-up run must enter exactly once.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a single coalesced follow-up run, none occurred")
+	}
+
+	// Deterministically settle: wait until the scheduler has no in-flight,
+	// no pending, and no dirty work for this repo — i.e. everything drained.
+	waitFor(t, 2*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		_, running := s.inflight[repo]
+		return !running && !s.dirty[repo] && !s.pendingIndex[repo]
+	})
+
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("coalescing failed: Index invoked %d times, want exactly 2 "+
+			"(1 in-flight + 1 coalesced follow-up)", got)
+	}
+}
+
+// TestCoalesce_NoLostUpdate proves requirement #3: a change that lands
+// DURING an in-flight reindex must still be captured by the single
+// follow-up — the marker is set after the run snapshots its input. We model
+// "the later change" by having the test enqueue strictly after the run has
+// entered (so the run's snapshot predates it) and asserting a follow-up runs.
+func TestCoalesce_NoLostUpdate(t *testing.T) {
+	var runs atomic.Int32
+	entered := make(chan struct{}, 8)
+	gate1 := make(chan struct{})
+
+	var mu sync.Mutex
+	var gate2 chan struct{}
+
+	s := New(Config{
+		Workers: 2,
+		Index: func(_ context.Context, _ string, _ string) error {
+			n := runs.Add(1)
+			entered <- struct{}{}
+			if n == 1 {
+				<-gate1 // hold the first run open
+			} else {
+				mu.Lock()
+				g := gate2
+				mu.Unlock()
+				if g != nil {
+					<-g
+				}
+			}
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	const repo = "/repo-b"
+	mu.Lock()
+	gate2 = make(chan struct{})
+	mu.Unlock()
+
+	// Run 1 starts and is held open (snapshot taken).
+	s.Enqueue(repo)
+	<-entered
+
+	// The "later change" lands while run 1 is still in-flight.
+	s.Enqueue(repo)
+	waitFor(t, time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.dirty[repo]
+	})
+
+	// Complete run 1 — the follow-up MUST run because dirty was set after
+	// the snapshot. If the marker were lost, no second run would ever start.
+	close(gate1)
+
+	select {
+	case <-entered:
+		// follow-up run started — no lost update. Good.
+	case <-time.After(2 * time.Second):
+		t.Fatal("no-lost-update violated: change during in-flight run did not trigger a follow-up")
+	}
+
+	mu.Lock()
+	close(gate2)
+	mu.Unlock()
+
+	waitFor(t, time.Second, func() bool { return runs.Load() == 2 })
+	if got := runs.Load(); got != 2 {
+		t.Fatalf("expected exactly 2 runs (in-flight + single follow-up), got %d", got)
+	}
+}
+
+// TestCoalesce_PerRepoNotGlobal proves requirement #4: coalescing is
+// per-repo. Two DIFFERENT repos enqueued concurrently must BOTH reindex at
+// the same time — the in-flight guard for repo A must not block repo B.
+func TestCoalesce_PerRepoNotGlobal(t *testing.T) {
+	bothIn := make(chan string, 2)
+	release := make(chan struct{})
+
+	s := New(Config{
+		Workers: 2,
+		Index: func(_ context.Context, repoPath string, _ string) error {
+			bothIn <- repoPath
+			<-release
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/repo-x")
+	s.Enqueue("/repo-y")
+
+	// Both must be in-flight concurrently. Collect two DISTINCT repos before
+	// releasing either — if coalescing were global this would deadlock and
+	// the test times out.
+	seen := map[string]bool{}
+	timeout := time.After(2 * time.Second)
+	for len(seen) < 2 {
+		select {
+		case r := <-bothIn:
+			seen[r] = true
+		case <-timeout:
+			t.Fatalf("per-repo concurrency violated: only %d/2 repos ran concurrently (seen=%v)", len(seen), seen)
+		}
+	}
+	close(release)
+
+	if !seen["/repo-x"] || !seen["/repo-y"] {
+		t.Fatalf("expected both /repo-x and /repo-y to run concurrently, saw %v", seen)
+	}
+}
+
+// waitFor polls cond until true or the deadline elapses (deterministic
+// convergence on a guarded predicate — not a fixed sleep). It fails the
+// test on timeout.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !cond() {
+		t.Fatalf("waitFor: condition not met within %s", d)
+	}
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -274,6 +274,16 @@ type Scheduler struct {
 	mu           sync.Mutex
 	inflight     map[string]int64  // repo → predicted MB charged against the ledger
 	pendingIndex map[string]bool   // repos already enqueued but not yet running
+	// dirty marks repos that received an enqueue WHILE a reindex for that
+	// same repo was already in-flight (#5138). Per-repo reindex coalescing:
+	// at most one reindex per repo runs at a time; any number of enqueues
+	// arriving mid-run collapse into this single boolean. When the in-flight
+	// run finishes, runIndex consumes the marker and schedules EXACTLY ONE
+	// follow-up reindex — capturing all intervening changes in one pass with
+	// no lost update (the marker is set AFTER the run snapshots its input, so
+	// a change landing mid-run still triggers the follow-up). N events during
+	// a reindex → 1 follow-up, not N. Guarded by mu.
+	dirty        map[string]bool
 	pendingRefs  map[string]string // repo → ref captured at last Enqueue (overwritten on re-enqueue)
 	pendingQ     []string          // ordered admission queue
 	queueLen     int               // pending + admitted-but-not-yet-running
@@ -382,6 +392,7 @@ func New(cfg Config) *Scheduler {
 		algoSem:        make(chan struct{}, algoCap),
 		inflight:       map[string]int64{},
 		pendingIndex:   map[string]bool{},
+		dirty:          map[string]bool{},
 		pendingRefs:    map[string]string{},
 		linkTimers:     map[string]*time.Timer{},
 		linkPending:    map[string]bool{},
@@ -493,8 +504,14 @@ func (s *Scheduler) dedupLoop() {
 			s.mu.Lock()
 			s.cancelAlgoLocked(p)
 			if _, running := s.inflight[p]; running {
-				// Already running: update the stored ref so if it re-queues
-				// after completion it uses the latest ref.
+				// Already running for this repo (#5138): do NOT start a
+				// second concurrent reindex. Mark the repo dirty so that
+				// when the in-flight run completes, runIndex schedules
+				// EXACTLY ONE follow-up that picks up this (and any other
+				// mid-run) change. N enqueues during the run collapse into
+				// this single boolean → 1 follow-up, not N. Also update the
+				// stored ref so the follow-up uses the latest observed ref.
+				s.dirty[p] = true
 				if req.ref != "" {
 					s.pendingRefs[p] = req.ref
 				}
@@ -825,6 +842,15 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	s.mu.Lock()
 	s.pendingIndex[repoPath] = false
 	s.queueLen--
+	// #5138 no-lost-update: clear the dirty marker BEFORE the index runs so
+	// that this run is treated as covering the repo state as of now. The
+	// actual extraction (below) snapshots the working tree shortly after.
+	// Any enqueue arriving AFTER this point re-sets dirty[repoPath] (via
+	// dedupLoop, since inflight[repoPath] is still set), guaranteeing the
+	// post-run check sees it and schedules exactly one follow-up. Clearing
+	// it AFTER the run instead would race: a change landing between the
+	// snapshot and the clear would be silently dropped.
+	delete(s.dirty, repoPath)
 	s.mu.Unlock()
 
 	t0 := time.Now()
@@ -916,7 +942,32 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	if s.usedMB < 0 {
 		s.usedMB = 0
 	}
+	// #5138: consume the dirty marker while still holding the lock and
+	// inflight[repoPath] is already cleared. If any enqueue arrived during
+	// this run it set dirty[repoPath]=true; schedule EXACTLY ONE follow-up
+	// reindex to capture all those coalesced changes in a single pass.
+	// Reading-and-clearing under the lock makes this atomic w.r.t. dedupLoop:
+	// either an enqueue landed before this point (caught here → one
+	// follow-up) or it lands after (sees inflight cleared → enqueues a fresh
+	// job normally). No double-run, no lost update.
+	followUp := s.dirty[repoPath]
+	if followUp {
+		delete(s.dirty, repoPath)
+	}
+	// Prefer the latest observed ref recorded while dirty; fall back to the
+	// ref this run used. dedupLoop overwrites pendingRefs[repoPath] on every
+	// mid-run enqueue, so it holds the most recent branch for the follow-up.
+	followUpRef := tok.ref
+	if r, ok := s.pendingRefs[repoPath]; ok && r != "" {
+		followUpRef = r
+	}
 	s.mu.Unlock()
+
+	if followUp {
+		s.logEvent("reindex_coalesced_followup", repoPath,
+			"changes landed during in-flight reindex — scheduling single follow-up (#5138)")
+		s.EnqueueRef(repoPath, followUpRef)
+	}
 
 	// History persistence happens outside the lock (its own mutex +
 	// file IO). Only record when the job succeeded; failed runs may
@@ -1103,6 +1154,12 @@ type Snapshot struct {
 	BudgetMB    int64
 	UsedMB      int64
 	BlockedJobs []string
+
+	// CoalescedDirty lists repos that have an in-flight reindex AND received
+	// further enqueues during it (#5138). Each will get exactly one follow-up
+	// when its in-flight run completes — these are the requests that, before
+	// coalescing, would have stacked into concurrent same-repo reindex jobs.
+	CoalescedDirty []string
 }
 
 // InFlightJob is one currently-running index, with its reserved MB.
@@ -1151,6 +1208,12 @@ func (s *Scheduler) Snapshot() Snapshot {
 	}
 	sort.Strings(out.PendingLinks)
 	out.BlockedJobs = append(out.BlockedJobs, s.pendingQ...)
+	for p, d := range s.dirty {
+		if d {
+			out.CoalescedDirty = append(out.CoalescedDirty, p)
+		}
+	}
+	sort.Strings(out.CoalescedDirty)
 	for p, st := range s.indexedRepos {
 		out.IndexedRepos = append(out.IndexedRepos, RepoSnapshot{
 			Path: p, LastIndex: st.LastIndex, LastAlgo: st.LastAlgo,


### PR DESCRIPTION
## Root cause (where two same-repo jobs could run)

The reindex scheduler (`internal/daemon/sched/scheduler.go`) already deduped at enqueue time, but its `dedupLoop` handling of the **in-flight** case was lossy:

```
if _, running := s.inflight[p]; running {
    // only updated the ref, then `continue` — DROPPED the request
}
```

An enqueue arriving while a repo's reindex was in-flight just updated the stored ref and returned **without recording that more work was pending**. Two consequences:

1. **Lost update**: a file change landing mid-reindex (after the extractor snapshotted the tree) was silently dropped until the *next* unrelated FS event re-triggered the repo.
2. **No follow-up coalescing primitive**: there was no per-repo "dirty" marker, so the only way intervening changes got picked up was a *fresh* enqueue — and combined with the watch/poller/rebuild paths each independently enqueuing, `in_flight` for one repo oscillated **1↔2** and, under merge-storm churn (~20 worktrees, merge-every-few-min), multiplied into the observed thrash (164× re-discovery of one repo in 1h23m). #5134 capped CPU *per job* and #5135 split the caps, but neither stopped the job **count** from multiplying — that is this PR.

## Coalescing design (in-flight set + dirty marker)

Per-repo, mutex-guarded, in the scheduler:

- **`dirty map[string]bool`** added alongside the existing `inflight` / `pendingIndex` maps.
- `dedupLoop`: an enqueue for a repo with `inflight[p]` set now does `s.dirty[p] = true` (and updates the ref) instead of silently dropping. **N enqueues during a run collapse into one boolean → one follow-up, not N.**
- `runIndex`: `delete(s.dirty, repoPath)` is done **before** the extraction snapshots the working tree; the post-run consume reads-and-clears `dirty` **under the lock, after `delete(s.inflight, …)`**, and if set schedules **exactly one** follow-up via `EnqueueRef` (latest observed ref).

At most **one in-flight reindex per repo** (the pre-existing `inflight` guard) **plus at most one coalesced follow-up**.

## No-lost-update guarantee

The marker is cleared **before** the run's snapshot and consumed **after** completion under the same mutex that `dedupLoop` holds. So an enqueue is either:
- caught by the post-run consume (it set `dirty` before `inflight` was cleared) → triggers the single follow-up, **or**
- it lands after `inflight` is cleared → `dedupLoop` sees no in-flight and enqueues a fresh job normally.

Either way the later change is reindexed exactly once — no double-run, no lost update.

## Per-repo, not global

The guard/marker are keyed by repo path. Two different repos still reindex concurrently; only same-repo requests coalesce. Composes with the existing debounce (#5134): debounce coalesces rapid events *pre-enqueue*; this coalesces at the *in-flight/scheduler* layer. Explicit `archigraph rebuild` still forces a fresh index (async path routes through this same scheduler guard; the synchronous Rebuild RPC remains serialized per-group by `groupRebuildMu`).

Also added `Snapshot.CoalescedDirty` so `/status` surfaces repos with a pending follow-up (the symptom that was previously an invisible 1↔2 oscillation).

## Tests (deterministic; pass under `-race`)

`internal/daemon/sched/coalesce_test.go` — channels/guarded predicates, no sleeps:
- **OneInFlightPlusSingleFollowUp**: 10 concurrent same-repo requests (4-worker pool, so coalescing can't rely on a 1-worker pool) → fake Index invoked **exactly 2×**.
- **NoLostUpdate**: a change landing during the in-flight run → exactly one follow-up that observes it (the follow-up provably runs).
- **PerRepoNotGlobal**: two different repos enqueued concurrently → both run at the same time (would deadlock/timeout if coalescing were global).

`-race -count=10` clean.

## Gates (sandbox HOME)

- `go build ./...` ✅
- `go vet ./internal/...` ✅
- `go test ./internal/daemon/... ./internal/types/` ✅ (full daemon suite, sandboxed HOME)
- `go test ./internal/daemon/sched/ -run Coalesce -race -count=10` ✅

## Deploy

Requires a daemon **rebuild + restart** to take effect (binary/scheduler change). Deploy-deferred.

Closes #5138
Refs #5134 #3648