### PR TITLE
fix(#5140): exclude <repo>/.archigraph from watcher + backoff-die orphan watch (reindex loop root cause)

### DIFF
--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -17,6 +17,60 @@ import (
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
+// watchBackoffConfig tunes the standalone watcher's failure handling
+// (issue #5140). When the daemon is unreachable the watcher must NOT
+// tight-loop and spam its err log forever (that, together with a stale
+// orphan process, was a primary driver of the observed CPU runaway).
+// Instead it backs off exponentially and exits after maxConsecutive
+// consecutive failures so a watcher whose daemon was restarted dies
+// rather than busy-looping.
+type watchBackoffConfig struct {
+	// base is the first backoff sleep after a failure.
+	base time.Duration
+	// max caps the per-failure backoff sleep.
+	max time.Duration
+	// maxConsecutive is the number of back-to-back failures after which
+	// the watcher gives up and exits. Zero means "never die" (only used
+	// by tests that want to exercise the sleep schedule in isolation).
+	maxConsecutive int
+}
+
+func defaultWatchBackoff() watchBackoffConfig {
+	return watchBackoffConfig{
+		base:           2 * time.Second,
+		max:            60 * time.Second,
+		maxConsecutive: 10,
+	}
+}
+
+// activeWatchBackoff is the backoff policy runWatch uses. It is a var
+// (not a constant call) so tests can substitute a fast schedule without
+// waiting out the production exponential delays.
+var activeWatchBackoff = defaultWatchBackoff
+
+// backoffSleep returns the sleep duration for the Nth (1-based)
+// consecutive failure: base * 2^(failures-1), capped at max. A
+// failures count <= 1 yields the base delay.
+func (c watchBackoffConfig) backoffSleep(failures int) time.Duration {
+	d := c.base
+	for i := 1; i < failures; i++ {
+		d *= 2
+		if d >= c.max {
+			return c.max
+		}
+	}
+	if d > c.max {
+		return c.max
+	}
+	return d
+}
+
+// shouldDie reports whether the watcher has hit its consecutive-failure
+// ceiling and must exit. maxConsecutive == 0 disables the ceiling.
+func (c watchBackoffConfig) shouldDie(failures int) bool {
+	return c.maxConsecutive > 0 && failures >= c.maxConsecutive
+}
+
 // indexViaDaemon calls the daemon's Index RPC for one repo. Returns
 // the canonical "daemon not running" error so the watcher loop's log
 // line is identical to what `archigraph index` would print.
@@ -77,7 +131,20 @@ func runWatch(repo, group string, interval time.Duration) error {
 	// graph.json across the groups we care about. When any value
 	// changes between ticks, we re-run the link passes for the affected
 	// group(s).
+	//
+	// NOTE (issue #5140): this is a *staleness/cross-repo-link* signal
+	// only. The watcher deliberately does NOT treat a graph.json mtime
+	// bump as a source change that re-triggers a repo reindex — the
+	// daemon writes <repo>/.archigraph/graph.json as the OUTPUT of every
+	// index, and reading that write back as an input would form a
+	// self-reinforcing reindex loop. The repo reindex below is driven
+	// purely by the poll tick (and, in Phase B, by the daemon's own
+	// fsnotify watcher, which already excludes <repo>/.archigraph/ via
+	// watch.ShouldSkipPath).
 	graphMtimes := snapshotGraphMtimes(repo, group)
+
+	backoff := activeWatchBackoff()
+	consecutiveFailures := 0
 
 	for {
 		select {
@@ -89,10 +156,30 @@ func runWatch(repo, group string, interval time.Duration) error {
 			// RPC client. Phase B will retire this subcommand entirely
 			// once the daemon's fsnotify loop is wired in.
 			if err := indexViaDaemon(repo); err != nil {
-				fmt.Fprintf(os.Stderr, "archigraph watch: index failed: %v\n", err)
+				consecutiveFailures++
+				fmt.Fprintf(os.Stderr, "archigraph watch: index failed (%d/%d): %v\n",
+					consecutiveFailures, backoff.maxConsecutive, err)
+				// Backoff + die (issue #5140): a watcher whose daemon was
+				// restarted (or is permanently gone) must not tight-loop
+				// and spam its err log forever. Exit after N consecutive
+				// failures so an orphaned watcher reaps itself.
+				if backoff.shouldDie(consecutiveFailures) {
+					return fmt.Errorf("archigraph watch: giving up after %d consecutive index failures (last: %w)",
+						consecutiveFailures, err)
+				}
+				sleep := backoff.backoffSleep(consecutiveFailures)
+				select {
+				case <-stop:
+					return nil
+				case <-time.After(sleep):
+				}
+				continue
 			}
+			consecutiveFailures = 0
 			// 2. Detect any cross-repo graph.json mtime changes and
-			// re-run link passes for the affected groups.
+			// re-run link passes for the affected groups. (Staleness
+			// signal only — see the note above; this does not re-trigger
+			// a reindex of `repo` itself.)
 			changed := detectGraphChanges(repo, group, graphMtimes)
 			for _, g := range changed {
 				if activeHooks.RunLinks == nil {

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -143,3 +143,87 @@ func TestRunWatch_TriggersLinksHookOnGraphChange(t *testing.T) {
 		t.Fatalf("expected RunLinks hook to fire once for group 'g', got %v", called)
 	}
 }
+
+// TestWatchBackoff_SleepSchedule verifies the standalone watcher's
+// exponential backoff schedule (issue #5140): the Nth consecutive
+// failure sleeps base*2^(N-1), capped at max.
+func TestWatchBackoff_SleepSchedule(t *testing.T) {
+	c := watchBackoffConfig{base: 1 * time.Second, max: 8 * time.Second, maxConsecutive: 10}
+	cases := []struct {
+		failures int
+		want     time.Duration
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+		{5, 8 * time.Second},  // capped
+		{99, 8 * time.Second}, // still capped, no overflow
+	}
+	for _, tc := range cases {
+		if got := c.backoffSleep(tc.failures); got != tc.want {
+			t.Errorf("backoffSleep(%d) = %s, want %s", tc.failures, got, tc.want)
+		}
+	}
+}
+
+// TestWatchBackoff_ShouldDie verifies the consecutive-failure ceiling:
+// the watcher exits (rather than tight-looping) once it has hit
+// maxConsecutive back-to-back daemon-unreachable failures (issue #5140).
+func TestWatchBackoff_ShouldDie(t *testing.T) {
+	c := watchBackoffConfig{base: time.Second, max: time.Minute, maxConsecutive: 3}
+	for _, tc := range []struct {
+		failures int
+		want     bool
+	}{
+		{0, false},
+		{1, false},
+		{2, false},
+		{3, true},
+		{4, true},
+	} {
+		if got := c.shouldDie(tc.failures); got != tc.want {
+			t.Errorf("shouldDie(%d) = %v, want %v", tc.failures, got, tc.want)
+		}
+	}
+
+	// maxConsecutive == 0 disables the ceiling entirely.
+	never := watchBackoffConfig{base: time.Second, max: time.Minute, maxConsecutive: 0}
+	if never.shouldDie(1000) {
+		t.Fatal("maxConsecutive==0 must never trigger shouldDie")
+	}
+}
+
+// TestRunWatch_BacksOffAndDiesWhenDaemonUnreachable is an end-to-end
+// check that runWatch returns (exits) after the consecutive-failure
+// ceiling instead of looping forever when the daemon is not running
+// (issue #5140). No live daemon is started; Dial fails fast.
+func TestRunWatch_BacksOffAndDiesWhenDaemonUnreachable(t *testing.T) {
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "solo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Substitute a fast backoff so the test finishes in well under a
+	// second while still exercising the real backoff+die loop.
+	prev := activeWatchBackoff
+	activeWatchBackoff = func() watchBackoffConfig {
+		return watchBackoffConfig{base: time.Millisecond, max: 5 * time.Millisecond, maxConsecutive: 3}
+	}
+	t.Cleanup(func() { activeWatchBackoff = prev })
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runWatch(repo, "", 5*time.Millisecond)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected runWatch to return a give-up error, got nil")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runWatch did not exit after repeated daemon-unreachable failures (issue #5140 regression)")
+	}
+}

--- a/internal/daemon/watch/s4_test.go
+++ b/internal/daemon/watch/s4_test.go
@@ -110,6 +110,33 @@ func TestSkipDirsExtended(t *testing.T) {
 	}
 }
 
+// TestShouldSkipPath_ArchigraphSelfWrites is the #5140 regression guard:
+// the daemon writes its own outputs (graph.json, graph.fb, logs/*) under
+// <repo>/.archigraph/. A watch event on any of those MUST be dropped by
+// ShouldSkipPath so writing the index output never reads back as a repo
+// source change and re-triggers a reindex (the self-reinforcing loop).
+// A real source file under the repo MUST still pass through.
+func TestShouldSkipPath_ArchigraphSelfWrites(t *testing.T) {
+	cases := map[string]bool{
+		// daemon self-writes — must be skipped
+		"/repo/.archigraph/graph.json":           true,
+		"/repo/.archigraph/graph.fb":             true,
+		"/repo/.archigraph/logs/watcher.err.log": true,
+		"/repo/.archigraph/logs/index.log":       true,
+		".archigraph/graph.json":                 true,
+		"nested/pkg/.archigraph/graph.json":      true,
+		// real source — must NOT be skipped
+		"/repo/src/x.ts":          false,
+		"/repo/internal/cli/a.go": false,
+		"/repo/pkg/main.py":       false,
+	}
+	for p, wantSkip := range cases {
+		if got := ShouldSkipPath(p); got != wantSkip {
+			t.Errorf("ShouldSkipPath(%q) = %v, want %v", p, got, wantSkip)
+		}
+	}
+}
+
 // TestGitignoreRespected verifies that ShouldSkipDirGitignore respects
 // a root .gitignore file.
 func TestGitignoreRespected(t *testing.T) {


### PR DESCRIPTION
## Root cause (live-diagnosed)
A standalone `archigraph watch <repo>` process (separate from the daemon) for core-mobile survived daemon restarts as an orphan (pid 3533). Its loop in `internal/cli/watch.go`:
1. Reindexed via daemon RPC on every poll tick.
2. On `daemon not running` / `unexpected EOF` it **tight-looped forever**, spamming `<repo>/.archigraph/logs/watcher.err.log`.
3. When the daemon was up, each reindex **WROTE `<repo>/.archigraph/graph.json`** — and the watcher's graph.json mtime poll read that write back as a change → **self-reinforcing reindex loop** (~7 cores, 164× reindex in 1h23m).

## What was already correct
The daemon's in-process fsnotify watcher (`internal/daemon/watch/watcher.go` → `ShouldSkipPath`), the candidate-file discovery walk (`internal/daemon/walk/walker.go` → `hardcodedSkipDirs`), and markdown ingest (`internal/ingest/discover.go`) **already exclude `<repo>/.archigraph/`** (since #805). So a self-write under `.archigraph/` already never counts as a source change for the daemon's own watcher/walk. Verified, not changed.

## The fix
The remaining gap was the **standalone watcher**: no skip logic, no backoff, no death on a dead daemon.
- **`internal/cli/watch.go`** — add exponential backoff (base 2s, cap 60s) and **exit after 10 consecutive daemon-unreachable failures** (`backoffSleep` / `shouldDie`), so an orphaned watcher whose daemon was restarted reaps itself instead of busy-looping and spamming logs. Backoff policy is an overridable package var (`activeWatchBackoff`) for fast tests.
- Documented in-code that the `graph.json` mtime poll is a **staleness / cross-repo-link signal only** and must never re-trigger a reindex of `repo` itself (the self-write loop). The repo reindex stays poll/fsnotify-driven; the daemon's fsnotify path already filters `.archigraph`.

## Tests
- `internal/cli`: `TestWatchBackoff_SleepSchedule` (2s→4s→…→cap, no overflow), `TestWatchBackoff_ShouldDie` (ceiling + disabled), `TestRunWatch_BacksOffAndDiesWhenDaemonUnreachable` (e2e: `runWatch` **returns** instead of looping when no daemon).
- `internal/daemon/watch`: `TestShouldSkipPath_ArchigraphSelfWrites` — #5140 regression guard: `.archigraph/graph.json`, `graph.fb`, `logs/*` are skipped; `src/x.ts`, `*.go`, `*.py` still pass.

## Gates (sandbox HOME=/tmp/agsbx-5140)
`go build ./...` ✅ · `go vet ./internal/cli/... ./internal/daemon/watch/...` ✅ · `go test ./internal/cli/ ./internal/daemon/watch/ ./internal/types/` ✅ · `-race` on new tests ✅ · gofmt clean.

## Deploy
Needs a **daemon rebuild + restart** to take effect (changes the `archigraph` binary's `watch` subcommand). Deploy-deferred.

## Follow-up
Full **daemon-owned reaping of stale `archigraph watch` PIDs** (fix #1 in the issue — daemon tracks/kills watcher children on shutdown/restart) is larger; this PR lands the high-value backoff-die. A follow-up should add PID ownership to the daemon reaper.

Closes #5140