### PR TITLE
feat(#5063): coverage effectiveness cross-product — reachability × line-coverage (ineffective-test detection)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -112,6 +112,7 @@ Security, secrets, licenses, test coverage, dead code, and cross-group parity.
 | [`archigraph_license_audit`](mcp-tools/audit.md#archigraph_license_audit) | Audit dependency licenses; flag GPL/AGPL conflicts. |
 | [`archigraph_test_coverage`](mcp-tools/audit.md#archigraph_test_coverage) | Production entities with no TESTS edge, ranked by severity. |
 | [`archigraph_test_reachability`](mcp-tools/audit.md#archigraph_test_reachability) | Static test-reachability (TESTS+CALLS): orphan fns/endpoints with no test path. |
+| [`archigraph_coverage_effectiveness`](mcp-tools/audit.md#archigraph_coverage_effectiveness) | Reachability × line-coverage cross-product: reachable-but-0%-lines (ineffective tests) + quadrants. |
 | [`archigraph_dead_code`](mcp-tools/audit.md#archigraph_dead_code) | Reachability dead-code: entities unreached by entry-points. |
 | [`archigraph_find_dead_code`](mcp-tools/audit.md#archigraph_find_dead_code) | Dead/unwired code: isolated, marked-unused, or test-only symbols. |
 | [`archigraph_security_findings`](mcp-tools/audit.md#archigraph_security_findings) | Taint-flow findings: source → sink paths ranked by confidence. |

--- a/docs/mcp-tools/audit.md
+++ b/docs/mcp-tools/audit.md
@@ -60,6 +60,26 @@ Output: group and per-module reachability roll-ups (% reachable), an endpoint ro
 
 ---
 
+## `archigraph_coverage_effectiveness`
+
+The reachability × line-coverage **cross-product** report (#5063): it crosses the static test-reachability signal (#5037) with the ingested LCOV line coverage (#5036) — both **stamped onto entity properties at index time** by #5061 — and classifies every production function/endpoint into a small set of meaningful quadrants:
+
+- **reachable + 0% lines** → candidate **ineffective / tautological test** (the headline signal): a static test path reaches the entity, yet not one of its production lines actually ran. Cross-check with [`archigraph_contract_test_effectiveness`](#archigraph_contract_test_effectiveness) (#4893).
+- **reachable + low coverage** (< 50%) → weak coverage.
+- **reachable + covered** (≥ 50%) → healthy: tested and run.
+- **reachable + no line-coverage measurement** → reachable, but the entity is absent from the LCOV report, so the line-coverage cross is unavailable for it.
+- **unreachable** → untested surface (the #5037 orphans).
+
+It reports per-module and group quadrant roll-ups and the headline **ineffective-test list**. Like the sibling reachability tool, it **reads the stamped properties off the loaded graph — it does not recompute** (it runs the pure `coverage.ComputeEffectivenessReport` over them).
+
+**Honest degradation:** when a group/module carries reachability but **no ingested line coverage** (`coverage_pct` absent on every entity), the tool reports the reachability quadrants and states that the line-coverage cross — and therefore the reachable-but-0%-lines signal — is unavailable, rather than fabricating a verdict. When nothing is stamped at all, it says *"reachability not computed — reindex"*.
+
+Key parameters: `repo_filter[]`, `ineffective_only` (bool — show only the reachable-but-0%-lines list + roll-ups), `limit` (default 100).
+
+Output: group + per-module quadrant roll-ups (worst-first by ineffective+untested ratio), the ineffective-test list, and a quadrant-sorted entity listing. Dashboard surfacing of this report is owned by #5062 / #5067.
+
+---
+
 ## `archigraph_dead_code`
 
 Reachability dead-code: entities unreached by entry-points.

--- a/internal/coverage/crossproduct.go
+++ b/internal/coverage/crossproduct.go
@@ -1,0 +1,244 @@
+// crossproduct.go — first-class reachability × line-coverage cross-product
+// report (#5063).
+//
+// This promotes the pure CrossSignal verdict (reachable && line_pct == 0 =>
+// candidate ineffective/tautological test) from a single-entity helper into a
+// first-class, group-wide REPORT: it classifies every production fn/endpoint
+// into a small set of meaningful quadrants combining
+//
+//   - #5037 static test-reachability (PropTestReachable / PropReachingTests…),
+//     stamped at index time by #5061; and
+//   - #5036 dynamic LCOV line coverage (PropCoveragePct / PropCoveredLines…),
+//     stamped at index time by #5061,
+//
+// and rolls the quadrants up per module/group with counts. The headline signal
+// is the EffReachableNoLines quadrant: an entity that has a static test path
+// reaching it (reachable) yet 0% measured line coverage — a candidate
+// ineffective / tautological test (ties into the #4893 tautology detector).
+//
+// Pure: this is a read-only transformation over already-stamped entity
+// Properties. It does not run the LCOV or reachability passes, does not mutate
+// inputs, does not touch Kinds, and does not call the indexer/daemon. The MCP
+// surfacing (archigraph_coverage_effectiveness) and dashboard surfacing
+// (#5062 / #5067) consume this report.
+//
+// HONEST degradation: an entity that is reachability-stamped but has NO line
+// coverage signal cannot be crossed — it lands in EffReachableNoCoverage (NOT
+// EffReachableNoLines, which requires a measured 0%). The roll-up tracks how
+// many entities have line coverage at all (CoverageMeasured) so a caller can
+// honestly say "line-coverage cross unavailable for this group" rather than
+// fabricating a verdict.
+package coverage
+
+import (
+	"sort"
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// EffectivenessVerdict is the quadrant an entity falls into when static
+// reachability is crossed with line coverage. It is a refinement of
+// CrossSignalVerdict that splits the "reachable" side by coverage band so the
+// report can separate weak coverage from healthy coverage, and separates
+// "reachable but no measured line coverage at all" (honest degradation) from
+// "reachable but measured 0%" (the ineffective-test signal).
+type EffectivenessVerdict string
+
+const (
+	// EffReachableNoLines: reachable from a test AND measured line_pct == 0 —
+	// the HEADLINE signal. A static test path reaches the entity, yet not one
+	// production line executed: a candidate ineffective / tautological test
+	// (#4893). Distinct from EffReachableNoCoverage, which has no measurement.
+	EffReachableNoLines EffectivenessVerdict = "reachable_no_lines"
+	// EffReachableLowCoverage: reachable AND 0 < line_pct < LowCoverageThreshold
+	// — weak coverage, the test path barely exercises the entity.
+	EffReachableLowCoverage EffectivenessVerdict = "reachable_low_coverage"
+	// EffReachableCovered: reachable AND line_pct >= LowCoverageThreshold —
+	// healthy: tested and actually run.
+	EffReachableCovered EffectivenessVerdict = "reachable_covered"
+	// EffReachableNoCoverage: reachable but NO line-coverage measurement exists
+	// for the entity (absent from the LCOV report, or the group has no ingested
+	// coverage at all). HONEST degradation: we cannot cross, so we do not claim
+	// the test is ineffective.
+	EffReachableNoCoverage EffectivenessVerdict = "reachable_no_coverage"
+	// EffUntested: not reachable from any test — untested surface (#5037
+	// orphans). Line coverage, if any, is incidental and not crossed here.
+	EffUntested EffectivenessVerdict = "untested"
+	// EffNotMeasured: the entity carries no reachability signal at all (e.g.
+	// indexed before #5061, or not a reachability-considered production kind).
+	// Cannot classify.
+	EffNotMeasured EffectivenessVerdict = "not_measured"
+)
+
+// LowCoverageThreshold is the line-coverage percentage (exclusive lower bound
+// is 0) below which a reachable entity is classed EffReachableLowCoverage
+// rather than EffReachableCovered. Chosen as a conservative "barely exercised"
+// cutoff; callers wanting a different band can re-derive from the raw pct.
+const LowCoverageThreshold = 50.0
+
+// ClassifyEffectiveness reads the reachability + LCOV properties already
+// stamped on an entity and returns its cross-product quadrant. Pure over the
+// property map; mirrors CrossSignal but with the richer coverage-band split and
+// the honest no-measurement quadrant.
+//
+// It deliberately does NOT depend on entity Kind — callers feed it only
+// production-entity properties (the report layer applies the production filter).
+func ClassifyEffectiveness(props map[string]string) EffectivenessVerdict {
+	reachStr, hasReach := props[PropTestReachable]
+	if !hasReach {
+		return EffNotMeasured
+	}
+	reachable, _ := strconv.ParseBool(reachStr)
+	if !reachable {
+		return EffUntested
+	}
+	pctStr, hasPct := props[PropCoveragePct]
+	if !hasPct {
+		return EffReachableNoCoverage
+	}
+	pct, err := strconv.ParseFloat(pctStr, 64)
+	if err != nil {
+		return EffReachableNoCoverage
+	}
+	switch {
+	case pct <= 0:
+		return EffReachableNoLines
+	case pct < LowCoverageThreshold:
+		return EffReachableLowCoverage
+	default:
+		return EffReachableCovered
+	}
+}
+
+// EffectivenessRow is one production entity's cross-product classification,
+// projected from its stamped properties. The raw signals are retained so a
+// caller (MCP tool / dashboard) can render detail without re-reading props.
+type EffectivenessRow struct {
+	EntityID    string
+	Verdict     EffectivenessVerdict
+	Reachable   bool
+	ReachDepth  int
+	ReachCount  int     // distinct reaching tests (uncapped)
+	HasCoverage bool    // a line-coverage measurement exists for this entity
+	CoveragePct float64 // measured line coverage; valid only when HasCoverage
+}
+
+// classifyRow builds an EffectivenessRow from an entity's stamped properties.
+func classifyRow(id string, props map[string]string) EffectivenessRow {
+	row := EffectivenessRow{EntityID: id, Verdict: ClassifyEffectiveness(props)}
+	if v, ok := props[PropTestReachable]; ok {
+		row.Reachable, _ = strconv.ParseBool(v)
+	}
+	if row.Reachable {
+		row.ReachDepth, _ = strconv.Atoi(props[PropReachDepth])
+		row.ReachCount, _ = strconv.Atoi(props[PropReachingTestCount])
+	}
+	if v, ok := props[PropCoveragePct]; ok {
+		if pct, err := strconv.ParseFloat(v, 64); err == nil {
+			row.HasCoverage = true
+			row.CoveragePct = pct
+		}
+	}
+	return row
+}
+
+// EffectivenessCounts is the per-quadrant count breakdown for a set of
+// production entities, plus the derived totals a roll-up needs.
+type EffectivenessCounts struct {
+	Total                int // production entities considered (reachability-stamped)
+	ReachableNoLines     int // the ineffective-test signal
+	ReachableLowCoverage int
+	ReachableCovered     int
+	ReachableNoCoverage  int
+	Untested             int
+	// CoverageMeasured is the number of entities with ANY line-coverage signal
+	// (the cross-product denominator). When 0, the line-coverage cross is
+	// unavailable for this bucket — report reachability quadrants only.
+	CoverageMeasured int
+}
+
+// add folds one row into the counts.
+func (c *EffectivenessCounts) add(r EffectivenessRow) {
+	c.Total++
+	if r.HasCoverage {
+		c.CoverageMeasured++
+	}
+	switch r.Verdict {
+	case EffReachableNoLines:
+		c.ReachableNoLines++
+	case EffReachableLowCoverage:
+		c.ReachableLowCoverage++
+	case EffReachableCovered:
+		c.ReachableCovered++
+	case EffReachableNoCoverage:
+		c.ReachableNoCoverage++
+	case EffUntested:
+		c.Untested++
+	}
+}
+
+// LineCrossAvailable reports whether at least one entity in the bucket has a
+// line-coverage measurement to cross with reachability. When false, the caller
+// MUST degrade honestly (reachability quadrants only).
+func (c EffectivenessCounts) LineCrossAvailable() bool { return c.CoverageMeasured > 0 }
+
+// EffectivenessReport is the first-class cross-product report: per-entity
+// classification, the headline ineffective-test list (reachable-but-0%-lines),
+// and per-module + group roll-ups.
+type EffectivenessReport struct {
+	// Rows is the per-entity classification for every reachability-stamped
+	// production entity, in input order.
+	Rows []EffectivenessRow
+	// Ineffective is the subset of Rows in the EffReachableNoLines quadrant —
+	// the headline candidate ineffective/tautological tests — sorted by entity
+	// ID for determinism.
+	Ineffective []EffectivenessRow
+	// Group is the group-wide quadrant breakdown.
+	Group EffectivenessCounts
+	// Modules is the per-module breakdown, keyed by module bucket (Properties
+	// "module" when present, else source-file directory).
+	Modules map[string]EffectivenessCounts
+}
+
+// ComputeEffectivenessReport is the first-class cross-product report builder.
+// It crosses #5037 reachability with #5036 line coverage over the already-
+// stamped Properties of the entity batch, classifies each production entity
+// into a quadrant, collects the ineffective-test list, and rolls up per module
+// and group. Pure: inputs are not mutated.
+//
+// Only reachability-stamped production entities are considered (those carry the
+// PropTestReachable property the #5061 pass stamps); other entities — schemas,
+// configs, tests, or anything indexed before #5061 — are skipped, so an
+// unstamped group yields an empty report (Group.Total == 0), which the caller
+// surfaces as "reachability not computed — reindex".
+func ComputeEffectivenessReport(entities []types.EntityRecord) EffectivenessReport {
+	rep := EffectivenessReport{Modules: map[string]EffectivenessCounts{}}
+	for _, e := range entities {
+		if e.Properties == nil {
+			continue
+		}
+		if _, ok := e.Properties[PropTestReachable]; !ok {
+			continue // not a reachability-considered production entity
+		}
+		row := classifyRow(entityID(e), e.Properties)
+		rep.Rows = append(rep.Rows, row)
+		rep.Group.add(row)
+
+		mod := moduleKey(e.SourceFile)
+		if m := e.Properties["module"]; m != "" {
+			mod = m
+		}
+		mc := rep.Modules[mod]
+		mc.add(row)
+		rep.Modules[mod] = mc
+
+		if row.Verdict == EffReachableNoLines {
+			rep.Ineffective = append(rep.Ineffective, row)
+		}
+	}
+	sort.Slice(rep.Ineffective, func(i, j int) bool {
+		return rep.Ineffective[i].EntityID < rep.Ineffective[j].EntityID
+	})
+	return rep
+}

--- a/internal/coverage/crossproduct_test.go
+++ b/internal/coverage/crossproduct_test.go
@@ -1,0 +1,182 @@
+package coverage
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// effFixture is a set of production entities already stamped with #5037
+// reachability + #5036 line-coverage properties (as the #5061 enrichment pass
+// would), exercising every cross-product quadrant:
+//
+//	reachNoLines  : reachable, coverage_pct=0   -> EffReachableNoLines (headline)
+//	reachLow      : reachable, coverage_pct=20  -> EffReachableLowCoverage
+//	reachCovered  : reachable, coverage_pct=90  -> EffReachableCovered
+//	reachNoCov    : reachable, NO coverage prop -> EffReachableNoCoverage (degrade)
+//	orphan        : reachable=false             -> EffUntested
+//	unstamped     : no reachability prop        -> skipped entirely
+//
+// reachNoLines + reachLow live in module "api"; the rest in "svc"/"core".
+func effFixture() []types.EntityRecord {
+	mk := func(id, mod string, props map[string]string) types.EntityRecord {
+		p := map[string]string{}
+		for k, v := range props {
+			p[k] = v
+		}
+		if mod != "" {
+			p["module"] = mod
+		}
+		return types.EntityRecord{
+			ID: id, Kind: string(types.EntityKindFunction), Name: id,
+			SourceFile: "src/" + id + ".go", Properties: p,
+		}
+	}
+	return []types.EntityRecord{
+		mk("reachNoLines", "api", map[string]string{
+			PropTestReachable: "true", PropReachDepth: "1", PropReachingTestCount: "2",
+			PropCoveragePct: "0.0", PropCoveredLines: "0", PropTotalLines: "12",
+		}),
+		mk("reachLow", "api", map[string]string{
+			PropTestReachable: "true", PropReachDepth: "2", PropReachingTestCount: "1",
+			PropCoveragePct: "20.0", PropCoveredLines: "2", PropTotalLines: "10",
+		}),
+		mk("reachCovered", "svc", map[string]string{
+			PropTestReachable: "true", PropReachDepth: "1", PropReachingTestCount: "3",
+			PropCoveragePct: "90.0", PropCoveredLines: "9", PropTotalLines: "10",
+		}),
+		mk("reachNoCov", "svc", map[string]string{
+			PropTestReachable: "true", PropReachDepth: "1", PropReachingTestCount: "1",
+		}),
+		mk("orphan", "core", map[string]string{
+			PropTestReachable: "false",
+		}),
+		// Unstamped: no reachability prop -> skipped (e.g. indexed pre-#5061).
+		{ID: "unstamped", Kind: string(types.EntityKindFunction), Name: "unstamped",
+			SourceFile: "src/unstamped.go", Properties: map[string]string{"module": "core"}},
+	}
+}
+
+func TestClassifyEffectiveness_Quadrants(t *testing.T) {
+	cases := []struct {
+		name  string
+		props map[string]string
+		want  EffectivenessVerdict
+	}{
+		{"reachable 0% -> no lines", map[string]string{PropTestReachable: "true", PropCoveragePct: "0.0"}, EffReachableNoLines},
+		{"reachable just below threshold -> low", map[string]string{PropTestReachable: "true", PropCoveragePct: "49.9"}, EffReachableLowCoverage},
+		{"reachable at threshold -> covered", map[string]string{PropTestReachable: "true", PropCoveragePct: "50.0"}, EffReachableCovered},
+		{"reachable high -> covered", map[string]string{PropTestReachable: "true", PropCoveragePct: "95.0"}, EffReachableCovered},
+		{"reachable no coverage prop -> degrade", map[string]string{PropTestReachable: "true"}, EffReachableNoCoverage},
+		{"reachable bad coverage prop -> degrade", map[string]string{PropTestReachable: "true", PropCoveragePct: "n/a"}, EffReachableNoCoverage},
+		{"unreachable -> untested", map[string]string{PropTestReachable: "false"}, EffUntested},
+		{"no reachability prop -> not measured", map[string]string{PropCoveragePct: "80.0"}, EffNotMeasured},
+	}
+	for _, c := range cases {
+		if got := ClassifyEffectiveness(c.props); got != c.want {
+			t.Errorf("%s: ClassifyEffectiveness = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestComputeEffectivenessReport_QuadrantCountsAndIneffectiveList(t *testing.T) {
+	rep := ComputeEffectivenessReport(effFixture())
+
+	// Group quadrant counts. The unstamped entity must be skipped entirely.
+	g := rep.Group
+	if g.Total != 5 {
+		t.Fatalf("Group.Total = %d, want 5 (unstamped entity must be skipped)", g.Total)
+	}
+	if g.ReachableNoLines != 1 {
+		t.Errorf("ReachableNoLines = %d, want 1", g.ReachableNoLines)
+	}
+	if g.ReachableLowCoverage != 1 {
+		t.Errorf("ReachableLowCoverage = %d, want 1", g.ReachableLowCoverage)
+	}
+	if g.ReachableCovered != 1 {
+		t.Errorf("ReachableCovered = %d, want 1", g.ReachableCovered)
+	}
+	if g.ReachableNoCoverage != 1 {
+		t.Errorf("ReachableNoCoverage = %d, want 1", g.ReachableNoCoverage)
+	}
+	if g.Untested != 1 {
+		t.Errorf("Untested = %d, want 1", g.Untested)
+	}
+	if g.CoverageMeasured != 3 {
+		t.Errorf("CoverageMeasured = %d, want 3 (reachNoLines+reachLow+reachCovered)", g.CoverageMeasured)
+	}
+	if !g.LineCrossAvailable() {
+		t.Error("LineCrossAvailable = false, want true (3 measured entities)")
+	}
+
+	// Headline ineffective-test list: exactly reachNoLines.
+	if len(rep.Ineffective) != 1 {
+		t.Fatalf("len(Ineffective) = %d, want 1", len(rep.Ineffective))
+	}
+	in := rep.Ineffective[0]
+	if in.EntityID != "reachNoLines" {
+		t.Errorf("Ineffective[0].EntityID = %q, want reachNoLines", in.EntityID)
+	}
+	if in.Verdict != EffReachableNoLines {
+		t.Errorf("Ineffective[0].Verdict = %q, want %q", in.Verdict, EffReachableNoLines)
+	}
+	if !in.Reachable || in.ReachCount != 2 || !in.HasCoverage || in.CoveragePct != 0 {
+		t.Errorf("Ineffective[0] raw signals wrong: %+v", in)
+	}
+
+	// Per-module roll-up: "api" has the two reachable-with-coverage, "svc" has
+	// covered+nocov, "core" has the single orphan.
+	api := rep.Modules["api"]
+	if api.Total != 2 || api.ReachableNoLines != 1 || api.ReachableLowCoverage != 1 {
+		t.Errorf("api module roll-up wrong: %+v", api)
+	}
+	svc := rep.Modules["svc"]
+	if svc.Total != 2 || svc.ReachableCovered != 1 || svc.ReachableNoCoverage != 1 {
+		t.Errorf("svc module roll-up wrong: %+v", svc)
+	}
+	if svc.CoverageMeasured != 1 {
+		t.Errorf("svc CoverageMeasured = %d, want 1", svc.CoverageMeasured)
+	}
+	core := rep.Modules["core"]
+	if core.Total != 1 || core.Untested != 1 {
+		t.Errorf("core module roll-up wrong: %+v", core)
+	}
+}
+
+// TestComputeEffectivenessReport_HonestDegradation: a group with reachability
+// but NO ingested line coverage reports reachability quadrants and signals that
+// the line-coverage cross is unavailable — it does NOT fabricate ineffective
+// tests.
+func TestComputeEffectivenessReport_HonestDegradation(t *testing.T) {
+	ents := []types.EntityRecord{
+		{ID: "a", Kind: string(types.EntityKindFunction), Name: "a", SourceFile: "src/a.go",
+			Properties: map[string]string{PropTestReachable: "true", PropReachDepth: "1", PropReachingTestCount: "1"}},
+		{ID: "b", Kind: string(types.EntityKindFunction), Name: "b", SourceFile: "src/b.go",
+			Properties: map[string]string{PropTestReachable: "false"}},
+	}
+	rep := ComputeEffectivenessReport(ents)
+	if rep.Group.CoverageMeasured != 0 {
+		t.Fatalf("CoverageMeasured = %d, want 0", rep.Group.CoverageMeasured)
+	}
+	if rep.Group.LineCrossAvailable() {
+		t.Error("LineCrossAvailable = true, want false (no ingested line coverage)")
+	}
+	if len(rep.Ineffective) != 0 {
+		t.Errorf("Ineffective = %v, want empty (must not fabricate without coverage)", rep.Ineffective)
+	}
+	if rep.Group.ReachableNoCoverage != 1 || rep.Group.Untested != 1 {
+		t.Errorf("degraded quadrants wrong: %+v", rep.Group)
+	}
+}
+
+// TestComputeEffectivenessReport_Unstamped: an entirely unstamped batch yields
+// an empty report so the caller can say "reachability not computed — reindex".
+func TestComputeEffectivenessReport_Unstamped(t *testing.T) {
+	ents := []types.EntityRecord{
+		{ID: "x", Kind: string(types.EntityKindFunction), Name: "x", SourceFile: "src/x.go"},
+	}
+	rep := ComputeEffectivenessReport(ents)
+	if rep.Group.Total != 0 || len(rep.Rows) != 0 {
+		t.Errorf("unstamped batch: want empty report, got Total=%d rows=%d", rep.Group.Total, len(rep.Rows))
+	}
+}

--- a/internal/mcp/coverage_effectiveness_tool.go
+++ b/internal/mcp/coverage_effectiveness_tool.go
@@ -1,0 +1,275 @@
+// coverage_effectiveness_tool.go — MCP tool for the reachability × line-coverage
+// cross-product report (#5063).
+//
+// Tool: archigraph_coverage_effectiveness
+//
+//	Crosses #5037 static test-reachability with #5036 ingested LCOV line
+//	coverage — both stamped on entity Properties at index time by #5061 — and
+//	classifies every production fn/endpoint into the meaningful quadrants:
+//
+//	  reachable + 0% lines  -> ineffective/tautological test  (HEADLINE, #4893)
+//	  reachable + low%      -> weak coverage
+//	  reachable + good%     -> covered
+//	  reachable + no cov    -> measured-reachable, coverage cross unavailable
+//	  unreachable           -> untested surface (#5037 orphans)
+//
+//	with per-module + group roll-ups, and surfaces the headline ineffective-test
+//	list (a static test path reaches the entity yet not one production line
+//	executed). This is the cheap, high-value surfacing path requested by #5063;
+//	the dashboard surfacing is owned by #5062 / #5067.
+//
+// This tool does NOT recompute anything — it reads the stamped Properties off
+// the loaded graph (the same way archigraph_test_reachability does) and runs
+// the pure coverage.ComputeEffectivenessReport over them. HONEST degradation:
+// when a group/module has reachability but NO ingested line coverage, it says
+// the line-coverage cross is unavailable rather than fabricating verdicts; when
+// nothing is stamped at all, it tells the agent to reindex.
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/types"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// effEntity carries a stamped production entity plus its projected
+// classification row, so the renderer can show name/location alongside the
+// verdict without re-reading properties.
+type effEntity struct {
+	id         string
+	name       string
+	sourceFile string
+	startLine  int
+	isEndpoint bool
+	row        coverage.EffectivenessRow
+}
+
+// handleCoverageEffectiveness implements archigraph_coverage_effectiveness.
+func (s *Server) handleCoverageEffectiveness(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, toolErr := s.resolveAndGroup(req)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+
+	repoFilter := argStringSlice(req, "repo_filter")
+	ineffectiveOnly := argBool(req, "ineffective_only", false)
+	limit := argInt(req, "limit", 100)
+
+	repoNames := make([]string, 0, len(lg.Repos))
+	for name := range lg.Repos {
+		repoNames = append(repoNames, name)
+	}
+	sort.Strings(repoNames)
+
+	// Collect the stamped production entities across the (filtered) repos,
+	// preserving the meta we need to render, and feed them to the pure report.
+	var ents []types.EntityRecord
+	meta := map[string]effEntity{}
+	stampedSeen := false
+	for _, name := range repoNames {
+		lr := lg.Repos[name]
+		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		if len(repoFilter) > 0 && !repoMatchesSlice(lr.Repo, repoFilter) {
+			continue
+		}
+		for i := range lr.Doc.Entities {
+			e := &lr.Doc.Entities[i]
+			if e.Properties == nil {
+				continue
+			}
+			if _, ok := e.Properties[coverage.PropTestReachable]; !ok {
+				continue
+			}
+			stampedSeen = true
+			// The pure report reads only ID, SourceFile and Properties; build a
+			// minimal record rather than depending on a full graph→record copy.
+			ents = append(ents, types.EntityRecord{
+				ID:         e.ID,
+				Kind:       e.Kind,
+				SourceFile: e.SourceFile,
+				Properties: e.Properties,
+			})
+			meta[e.ID] = effEntity{
+				id: e.ID, name: e.Name, sourceFile: e.SourceFile,
+				startLine: e.StartLine, isEndpoint: isEndpointKind(e.Kind),
+			}
+		}
+	}
+
+	if !stampedSeen {
+		return mcpapi.NewToolResultText(fmt.Sprintf(
+			"## Coverage effectiveness — group %q\n\n"+
+				"_Reachability not computed for this group._ No entity carries the "+
+				"`%s` property, so the group was indexed before the #5061 enrichment "+
+				"pass (or has no test/call edges).\n\n"+
+				"**Reindex the group** to populate the static test-reachability signal "+
+				"(and ingest LCOV for the line-coverage cross), then re-run this tool.\n",
+			lg.Name, coverage.PropTestReachable,
+		)), nil
+	}
+
+	rep := coverage.ComputeEffectivenessReport(ents)
+
+	// Attach meta to rows for rendering.
+	for i := range rep.Rows {
+		if m, ok := meta[rep.Rows[i].EntityID]; ok {
+			m.row = rep.Rows[i]
+			meta[rep.Rows[i].EntityID] = m
+		}
+	}
+
+	out := renderEffectiveness(lg.Name, rep, meta, ineffectiveOnly, limit)
+	return mcpapi.NewToolResultText(out), nil
+}
+
+// renderEffectiveness builds the markdown report body.
+func renderEffectiveness(group string, rep coverage.EffectivenessReport, meta map[string]effEntity, ineffectiveOnly bool, limit int) string {
+	g := rep.Group
+	out := fmt.Sprintf("## Coverage effectiveness — group %q\n\n", group)
+	out += fmt.Sprintf(
+		"Production entities (reachability-stamped) : %d\n"+
+			"  reachable + 0%% lines (ineffective?)      : %d\n"+
+			"  reachable + low coverage (<%.0f%%)         : %d\n"+
+			"  reachable + covered                       : %d\n"+
+			"  reachable + no line-coverage measurement  : %d\n"+
+			"  unreachable (untested surface)            : %d\n",
+		g.Total, g.ReachableNoLines, coverage.LowCoverageThreshold,
+		g.ReachableLowCoverage, g.ReachableCovered, g.ReachableNoCoverage, g.Untested,
+	)
+
+	// Honest degradation note for the line-coverage cross.
+	if !g.LineCrossAvailable() {
+		out += "\n> **Line-coverage cross unavailable for this group** — no entity " +
+			"carries an ingested LCOV measurement (`" + coverage.PropCoveragePct + "`). " +
+			"Reporting reachability quadrants only; the ineffective-test (reachable-but-0%-lines) " +
+			"signal cannot be computed without line coverage. Ingest LCOV (#5036) and reindex.\n"
+	} else {
+		out += fmt.Sprintf("\nLine coverage measured on %d of %d reachability-stamped entities.\n",
+			g.CoverageMeasured, g.Total)
+	}
+
+	// Per-module breakdown — worst first (most ineffective+untested per total).
+	if len(rep.Modules) > 0 {
+		type mr struct {
+			mod string
+			c   coverage.EffectivenessCounts
+		}
+		mods := make([]mr, 0, len(rep.Modules))
+		for m, c := range rep.Modules {
+			mods = append(mods, mr{m, c})
+		}
+		sort.Slice(mods, func(i, j int) bool {
+			ri := effBadRatio(mods[i].c)
+			rj := effBadRatio(mods[j].c)
+			if ri != rj {
+				return ri > rj // worst (most ineffective/untested) first
+			}
+			return mods[i].mod < mods[j].mod
+		})
+		if len(mods) > 20 {
+			mods = mods[:20]
+		}
+		out += "\n### Modules by ineffective+untested ratio (worst first)\n\n"
+		out += fmt.Sprintf("%-6s %-6s %-6s %-6s  %s\n", "Inef", "Untst", "Cov", "Total", "Module")
+		for _, m := range mods {
+			out += fmt.Sprintf("%-6d %-6d %-6d %-6d  %s\n",
+				m.c.ReachableNoLines, m.c.Untested, m.c.ReachableCovered, m.c.Total, m.mod)
+		}
+	}
+
+	// Headline: the ineffective-test list (reachable-but-0%-lines).
+	out += fmt.Sprintf("\n### Ineffective tests — reachable but 0%% lines (%d)\n\n", len(rep.Ineffective))
+	if len(rep.Ineffective) == 0 {
+		if g.LineCrossAvailable() {
+			out += "_None — every reachable, line-measured entity executed at least one line._\n"
+		} else {
+			out += "_Not computable without ingested line coverage (see note above)._\n"
+		}
+	} else {
+		out += "> A static test path reaches each of these, yet 0% of its lines ran — " +
+			"likely an ineffective / tautological test. Cross-check with " +
+			"`archigraph_contract_test_effectiveness` (#4893).\n\n"
+		shown := rep.Ineffective
+		if len(shown) > limit {
+			shown = shown[:limit]
+		}
+		for _, r := range shown {
+			m := meta[r.EntityID]
+			out += fmt.Sprintf("- %s  %s:%d  (reaching_tests=%d, depth=%d, lines=0%%)\n",
+				m.name, m.sourceFile, m.startLine, r.ReachCount, r.ReachDepth)
+		}
+		if len(rep.Ineffective) > len(shown) {
+			out += fmt.Sprintf("  …and %d more.\n", len(rep.Ineffective)-len(shown))
+		}
+	}
+
+	if ineffectiveOnly {
+		return out
+	}
+
+	// Full quadrant listing — worst quadrant first, capped at limit.
+	rows := make([]coverage.EffectivenessRow, len(rep.Rows))
+	copy(rows, rep.Rows)
+	sort.SliceStable(rows, func(i, j int) bool {
+		oi, oj := verdictOrder(rows[i].Verdict), verdictOrder(rows[j].Verdict)
+		if oi != oj {
+			return oi < oj
+		}
+		return meta[rows[i].EntityID].sourceFile < meta[rows[j].EntityID].sourceFile
+	})
+	shown := rows
+	if len(shown) > limit {
+		shown = shown[:limit]
+	}
+	out += fmt.Sprintf("\n### Entities by quadrant (%d shown of %d)\n\n", len(shown), len(rows))
+	for _, r := range shown {
+		m := meta[r.EntityID]
+		detail := ""
+		if r.HasCoverage {
+			detail = fmt.Sprintf("  lines=%.1f%%", r.CoveragePct)
+		}
+		if r.Reachable {
+			detail += fmt.Sprintf("  depth=%d tests=%d", r.ReachDepth, r.ReachCount)
+		}
+		tag := ""
+		if m.isEndpoint {
+			tag = "endpoint "
+		}
+		out += fmt.Sprintf("- [%s] %s%s  %s:%d%s\n",
+			r.Verdict, tag, m.name, m.sourceFile, m.startLine, detail)
+	}
+	return out
+}
+
+// effBadRatio is the fraction of a bucket that is ineffective-or-untested — the
+// sort key for "worst module first".
+func effBadRatio(c coverage.EffectivenessCounts) float64 {
+	if c.Total == 0 {
+		return 0
+	}
+	return float64(c.ReachableNoLines+c.Untested) / float64(c.Total)
+}
+
+// verdictOrder ranks quadrants worst→best for the row listing.
+func verdictOrder(v coverage.EffectivenessVerdict) int {
+	switch v {
+	case coverage.EffReachableNoLines:
+		return 0
+	case coverage.EffUntested:
+		return 1
+	case coverage.EffReachableLowCoverage:
+		return 2
+	case coverage.EffReachableNoCoverage:
+		return 3
+	case coverage.EffReachableCovered:
+		return 4
+	default:
+		return 5
+	}
+}

--- a/internal/mcp/coverage_effectiveness_tool_test.go
+++ b/internal/mcp/coverage_effectiveness_tool_test.go
@@ -1,0 +1,190 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildEffectivenessDoc builds entities stamped with both #5037 reachability
+// and #5036 LCOV line coverage (as #5061's enrichment pass would), exercising
+// every cross-product quadrant the archigraph_coverage_effectiveness tool
+// classifies. The tool reads these directly — it never recomputes.
+//
+//	fn_ineffective  reachable=true  coverage_pct=0   → reachable_no_lines (headline)
+//	fn_weak         reachable=true  coverage_pct=20  → reachable_low_coverage
+//	fn_covered      reachable=true  coverage_pct=92  → reachable_covered
+//	fn_no_cov       reachable=true  (no coverage prop) → reachable_no_coverage
+//	ep_orphan       reachable=false                   → untested
+//	schema_x        (no reachability prop)            → ignored
+func buildEffectivenessDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID: "fn_ineffective", Name: "ValidateTax", Kind: "SCOPE.Function",
+				SourceFile: "tax/validate.go", StartLine: 8,
+				Properties: map[string]string{
+					coverage.PropTestReachable:     "true",
+					coverage.PropReachDepth:        "1",
+					coverage.PropReachingTestCount: "2",
+					coverage.PropReachingTests:     "test_tax,test_tax2",
+					coverage.PropCoveragePct:       "0.0",
+					coverage.PropCoveredLines:      "0",
+					coverage.PropTotalLines:        "14",
+				},
+			},
+			{
+				ID: "fn_weak", Name: "ApplyDiscount", Kind: "SCOPE.Function",
+				SourceFile: "pricing/discount.go", StartLine: 20,
+				Properties: map[string]string{
+					coverage.PropTestReachable:     "true",
+					coverage.PropReachDepth:        "2",
+					coverage.PropReachingTestCount: "1",
+					coverage.PropCoveragePct:       "20.0",
+				},
+			},
+			{
+				ID: "fn_covered", Name: "ProcessOrder", Kind: "SCOPE.Function",
+				SourceFile: "orders/process.go", StartLine: 10,
+				Properties: map[string]string{
+					coverage.PropTestReachable:     "true",
+					coverage.PropReachDepth:        "1",
+					coverage.PropReachingTestCount: "3",
+					coverage.PropCoveragePct:       "92.0",
+				},
+			},
+			{
+				ID: "fn_no_cov", Name: "ReconcileLedger", Kind: "SCOPE.Function",
+				SourceFile: "ledger/reconcile.go", StartLine: 40,
+				Properties: map[string]string{
+					coverage.PropTestReachable:     "true",
+					coverage.PropReachDepth:        "1",
+					coverage.PropReachingTestCount: "1",
+				},
+			},
+			{
+				ID: "ep_orphan", Name: "POST /inspections", Kind: "SCOPE.Endpoint",
+				SourceFile: "inspections/routes.go", StartLine: 12,
+				Properties: map[string]string{
+					coverage.PropTestReachable: "false",
+				},
+			},
+			{
+				ID: "schema_x", Name: "Order", Kind: "SCOPE.Schema",
+				SourceFile: "orders/model.go", StartLine: 1,
+				// No reachability prop — must be ignored.
+			},
+		},
+	}
+}
+
+func callEffectiveness(t *testing.T, srv *Server, args map[string]any) string {
+	t.Helper()
+	args["group"] = "test"
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleCoverageEffectiveness(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	return resultText(res)
+}
+
+func TestCoverageEffectiveness_Quadrants(t *testing.T) {
+	srv := newTestServer(t, buildEffectivenessDoc())
+	out := callEffectiveness(t, srv, map[string]any{})
+
+	// Group quadrant counts (5 stamped production entities; schema_x ignored).
+	for _, want := range []string{
+		"Production entities (reachability-stamped) : 5",
+		"reachable + 0% lines (ineffective?)      : 1",
+		"reachable + low coverage",
+		"reachable + covered                       : 1",
+		"reachable + no line-coverage measurement  : 1",
+		"unreachable (untested surface)            : 1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+
+	// The headline ineffective-test must be surfaced by name.
+	if !strings.Contains(out, "Ineffective tests — reachable but 0% lines (1)") {
+		t.Errorf("missing ineffective header:\n%s", out)
+	}
+	if !strings.Contains(out, "ValidateTax") {
+		t.Errorf("ineffective test ValidateTax not surfaced:\n%s", out)
+	}
+	// Healthy/covered entities must NOT be in the ineffective list.
+	idxIneff := strings.Index(out, "Ineffective tests")
+	idxQuad := strings.Index(out, "Entities by quadrant")
+	ineffSection := out[idxIneff:idxQuad]
+	if strings.Contains(ineffSection, "ProcessOrder") {
+		t.Errorf("covered fn leaked into ineffective list:\n%s", ineffSection)
+	}
+
+	// schema_x must never appear.
+	if strings.Contains(out, "schema_x") || strings.Contains(out, "model.go") {
+		t.Errorf("non-production entity leaked:\n%s", out)
+	}
+}
+
+func TestCoverageEffectiveness_IneffectiveOnly(t *testing.T) {
+	srv := newTestServer(t, buildEffectivenessDoc())
+	out := callEffectiveness(t, srv, map[string]any{"ineffective_only": true})
+
+	if !strings.Contains(out, "ValidateTax") {
+		t.Errorf("expected ineffective test listed:\n%s", out)
+	}
+	// The full quadrant listing must be suppressed.
+	if strings.Contains(out, "Entities by quadrant") {
+		t.Errorf("ineffective_only should suppress full listing:\n%s", out)
+	}
+}
+
+// TestCoverageEffectiveness_HonestDegradation: a group with reachability but no
+// ingested line coverage reports reachability quadrants and explicitly says the
+// line-coverage cross is unavailable — it does NOT fabricate ineffective tests.
+func TestCoverageEffectiveness_HonestDegradation(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{ID: "fn_a", Name: "Alpha", Kind: "SCOPE.Function", SourceFile: "a.go", StartLine: 1,
+				Properties: map[string]string{coverage.PropTestReachable: "true", coverage.PropReachDepth: "1", coverage.PropReachingTestCount: "1"}},
+			{ID: "fn_b", Name: "Beta", Kind: "SCOPE.Function", SourceFile: "b.go", StartLine: 1,
+				Properties: map[string]string{coverage.PropTestReachable: "false"}},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callEffectiveness(t, srv, map[string]any{})
+
+	if !strings.Contains(out, "Line-coverage cross unavailable for this group") {
+		t.Errorf("expected degradation note, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Ineffective tests — reachable but 0% lines (0)") {
+		t.Errorf("must not fabricate ineffective tests:\n%s", out)
+	}
+}
+
+// TestCoverageEffectiveness_Unstamped: no reachability props → reindex hint.
+func TestCoverageEffectiveness_Unstamped(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{ID: "fn_a", Name: "Alpha", Kind: "SCOPE.Function", SourceFile: "a.go", StartLine: 1},
+		},
+	}
+	srv := newTestServer(t, doc)
+	out := callEffectiveness(t, srv, map[string]any{})
+	if !strings.Contains(out, "Reindex the group") {
+		t.Errorf("expected reindex hint for unstamped group:\n%s", out)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1121,6 +1121,20 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("ref"), // PH1c: optional git ref
 	), s.wrap("archigraph_test_reachability", s.handleTestReachability))
 
+	// #5063: coverage effectiveness — crosses #5037 reachability with #5036
+	// LCOV line coverage (both stamped by #5061) into quadrants; headline is
+	// reachable-but-0%-lines (candidate ineffective/tautological tests, #4893).
+	// Reads stamped props; does not recompute. Dashboard surfacing = #5062/#5067.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_coverage_effectiveness",
+		mcpapi.WithDescription("Reachability x line-coverage: reachable-but-0%-lines (ineffective tests)."),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithBoolean("ineffective_only", mcpapi.DefaultBool(false)),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+		mcpapi.WithAny("ref"),
+	), s.wrap("archigraph_coverage_effectiveness", s.handleCoverageEffectiveness))
+
 	// archigraph_module_analysis — module-level GDS (#1384, epic #1380).
 	// action=cycles|centrality|all over the aggregated module graph: SCCs,
 	// PageRank, betweenness. Bird's-eye view alongside entity-level tools.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -578,6 +578,7 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_secrets", "archigraph_quality_cycles",
 		"archigraph_test_coverage", "archigraph_license_audit",
 		"archigraph_test_reachability",
+		"archigraph_coverage_effectiveness",
 		"archigraph_module_analysis", "archigraph_diff_refs",
 		// #1742 subgraph retained (despite deprecation)
 		"archigraph_subgraph",
@@ -719,8 +720,9 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 archigraph_apply_doc_semantics (#4309 doc ingestion L2 apply step).
 	// +1 archigraph_control_flow (#4822 on-demand per-function CFG, control-flow epic #4820 part (b)).
 	// +1 archigraph_contract_test_effectiveness (#4893 tautological/oracle-blind spec detector).
-	if got := len(allRegisteredTools); got != 67 {
-		t.Errorf("expected 67 registered tools, got %d — update this count if tools are added/removed (added archigraph_test_reachability #5060)", got)
+	// +1 archigraph_coverage_effectiveness (#5063 reachability x line-coverage cross-product).
+	if got := len(allRegisteredTools); got != 68 {
+		t.Errorf("expected 68 registered tools, got %d — update this count if tools are added/removed (added archigraph_coverage_effectiveness #5063)", got)
 	}
 }
 
@@ -3165,41 +3167,42 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	// Go-level error. The wrap middleware injects elapsed_ms on both success
 	// and IsError=true results, so this test validates both paths.
 	minimalArgs := map[string]map[string]any{
-		"archigraph_whoami":               {"group": "g"},
-		"archigraph_get_source":           {"group": "g", "entity_id": "DashboardScreen"},
-		"archigraph_find":                 {"group": "g", "query": "DashboardScreen"},
-		"archigraph_inspect":              {"group": "g", "label_or_id": "DashboardScreen"},
-		"archigraph_expand":               {"group": "g", "node": "DashboardScreen"},
-		"archigraph_trace":                {"group": "g", "source": "r1::a1", "target": "r1::a4"},
-		"archigraph_traces":               {"group": "g", "action": "list"},
-		"archigraph_clusters":             {"group": "g"},
-		"archigraph_orient":               {"group": "g"}, // #4290 orientation analysis
-		"archigraph_stats":                {"group": "g"},
-		"archigraph_enrichments":          {"group": "g", "action": "list"},
-		"archigraph_repairs":              {"group": "g", "action": "list"},
-		"archigraph_apply_docgen_repairs": {"group": "g"},
-		"archigraph_apply_doc_semantics":  {"group": "g"},
-		"archigraph_patterns":             {"group": "g", "action": "query", "text": "test"},
-		"archigraph_topology":             {"group": "g", "action": "orphan_publishers"},
-		"archigraph_flows":                {"group": "g", "action": "dead_ends"},
-		"archigraph_graph_patterns":       {"group": "g", "action": "list"},
-		"archigraph_search_entities":      {"group": "g", "query": "Dashboard"},
-		"archigraph_subgraph":             {"group": "g", "entity_id": "r1::a1"},
-		"archigraph_find_paths":           {"group": "g", "from": "r1::a1", "to": "r1::a4"},
-		"archigraph_endpoints":            {"group": "g", "action": "definitions"},
-		"archigraph_effective_contract":   {"group": "g", "entity_id": "r1::a2"},
-		"archigraph_find_callers":         {"group": "g", "entity_id": "r1::a2"},
-		"archigraph_find_callees":         {"group": "g", "entity_id": "r1::a2"},
-		"archigraph_impact_radius":        {"group": "g", "entity_id": "r1::a2"},
-		"archigraph_find_dead_code":       {"group": "g"},
-		"archigraph_quality_cycles":       {"group": "g"},
-		"archigraph_auth_coverage":        {"group": "g"},
-		"archigraph_test_coverage":        {"group": "g"},
-		"archigraph_test_reachability":    {"group": "g"},
-		"archigraph_module_analysis":      {"group": "g"},
-		"archigraph_secrets":              {"group": "g"},
-		"archigraph_neighbors":            {"group": "g", "entity_id": "r1::a2", "direction": "both"},
-		"archigraph_status":               {"group": "g"},
+		"archigraph_whoami":                 {"group": "g"},
+		"archigraph_get_source":             {"group": "g", "entity_id": "DashboardScreen"},
+		"archigraph_find":                   {"group": "g", "query": "DashboardScreen"},
+		"archigraph_inspect":                {"group": "g", "label_or_id": "DashboardScreen"},
+		"archigraph_expand":                 {"group": "g", "node": "DashboardScreen"},
+		"archigraph_trace":                  {"group": "g", "source": "r1::a1", "target": "r1::a4"},
+		"archigraph_traces":                 {"group": "g", "action": "list"},
+		"archigraph_clusters":               {"group": "g"},
+		"archigraph_orient":                 {"group": "g"}, // #4290 orientation analysis
+		"archigraph_stats":                  {"group": "g"},
+		"archigraph_enrichments":            {"group": "g", "action": "list"},
+		"archigraph_repairs":                {"group": "g", "action": "list"},
+		"archigraph_apply_docgen_repairs":   {"group": "g"},
+		"archigraph_apply_doc_semantics":    {"group": "g"},
+		"archigraph_patterns":               {"group": "g", "action": "query", "text": "test"},
+		"archigraph_topology":               {"group": "g", "action": "orphan_publishers"},
+		"archigraph_flows":                  {"group": "g", "action": "dead_ends"},
+		"archigraph_graph_patterns":         {"group": "g", "action": "list"},
+		"archigraph_search_entities":        {"group": "g", "query": "Dashboard"},
+		"archigraph_subgraph":               {"group": "g", "entity_id": "r1::a1"},
+		"archigraph_find_paths":             {"group": "g", "from": "r1::a1", "to": "r1::a4"},
+		"archigraph_endpoints":              {"group": "g", "action": "definitions"},
+		"archigraph_effective_contract":     {"group": "g", "entity_id": "r1::a2"},
+		"archigraph_find_callers":           {"group": "g", "entity_id": "r1::a2"},
+		"archigraph_find_callees":           {"group": "g", "entity_id": "r1::a2"},
+		"archigraph_impact_radius":          {"group": "g", "entity_id": "r1::a2"},
+		"archigraph_find_dead_code":         {"group": "g"},
+		"archigraph_quality_cycles":         {"group": "g"},
+		"archigraph_auth_coverage":          {"group": "g"},
+		"archigraph_test_coverage":          {"group": "g"},
+		"archigraph_test_reachability":      {"group": "g"},
+		"archigraph_coverage_effectiveness": {"group": "g"},
+		"archigraph_module_analysis":        {"group": "g"},
+		"archigraph_secrets":                {"group": "g"},
+		"archigraph_neighbors":              {"group": "g", "entity_id": "r1::a2", "direction": "both"},
+		"archigraph_status":                 {"group": "g"},
 		// PH5 (#2093): diff tool — repo/ref_a/ref_b all required.
 		"archigraph_diff_refs": {"group": "g", "repo": "r1", "ref_a": "main", "ref_b": "feat/x"},
 		// #4292: PR-impact tool. Single mode args; repo lookup fails gracefully
@@ -3304,8 +3307,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 67 {
-		t.Errorf("expected 67 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_test_reachability #5060)", len(tools))
+	if len(tools) != 68 {
+		t.Errorf("expected 68 registered tools, got %d — update minimalArgs if tools are added/removed (added archigraph_coverage_effectiveness #5063)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
Promotes the pure `CrossSignal` verdict (reachable && line_pct==0 => candidate ineffective/tautological test) from a single-entity helper into a **first-class reachability × line-coverage cross-product report**, surfaced via a new MCP tool.

## Quadrant model (`internal/coverage/crossproduct.go`)
`ComputeEffectivenessReport` is a pure function over the already-stamped entity Properties (#5037 reachability + #5036 LCOV line coverage, both stamped at index time by #5061). It classifies every reachability-stamped **production** fn/endpoint into:

- **`reachable_no_lines`** — reachable from a test AND measured `coverage_pct == 0` → candidate **ineffective / tautological test** (the headline signal; cross-refs #4893).
- **`reachable_low_coverage`** — reachable AND `0 < pct < 50%` → weak coverage.
- **`reachable_covered`** — reachable AND `pct >= 50%` → healthy.
- **`reachable_no_coverage`** — reachable but no line-coverage measurement exists → honest degradation, cannot cross.
- **`untested`** — not reachable from any test → #5037 orphan surface.

Plus per-module and group quadrant roll-ups (`EffectivenessCounts`, with `CoverageMeasured`/`LineCrossAvailable`) and the headline `Ineffective` list. `ClassifyEffectiveness` refines `CrossSignal` with the coverage-band split + the honest no-measurement quadrant.

## Where surfaced (MCP)
New tool **`archigraph_coverage_effectiveness`** (`internal/mcp/coverage_effectiveness_tool.go`): reads the stamped props off the loaded graph, runs the pure report, renders group/per-module quadrant roll-ups (worst-first), the **ineffective-test list** (reachable-but-0%-lines, with reaching-test count + depth), and a quadrant-sorted entity listing. Params: `repo_filter[]`, `ineffective_only`, `limit`. It does **not** recompute. **Tool count 67 → 68.** Dashboard surfacing is left to #5062/#5067 (referenced, not duplicated).

## Ineffective-test signal
The `reachable_no_lines` quadrant is the headline: a static TESTS+CALLS path reaches the entity, yet 0% of its production lines ran — a likely tautological/ineffective test. The tool points the agent at `archigraph_contract_test_effectiveness` (#4893) for confirmation.

## Honest degradation
When a group/module carries reachability but **no ingested line coverage** (`coverage_pct` absent everywhere), the report sets `CoverageMeasured=0` / `LineCrossAvailable()=false`; the tool prints "Line-coverage cross unavailable for this group" and an empty ineffective list rather than fabricating verdicts. An entirely unstamped group yields a "reindex" hint.

## Fixtures
- `internal/coverage/crossproduct_test.go`: quadrant classification, per-module + group counts, the reachable-but-0% ineffective list, honest degradation (no fabrication), unstamped → empty report.
- `internal/mcp/coverage_effectiveness_tool_test.go`: the same via the MCP handler (quadrant render, ineffective list, `ineffective_only` suppression, degradation note, reindex hint).

## Docs
`docs/mcp-tools.md` catalogue row + full `docs/mcp-tools/audit.md` section added (no coverage-registry cell change → no coverage-gen chore).

## Gates (sandbox HOME=/tmp/agsbx-5063)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/coverage/... ./internal/mcp/... ./internal/types/` all green (incl. the 68-tool handshake-budget + ≤80-char description gates). Deploy-deferred.

Refs #5063