### PR TITLE
feat(#5062): dashboard test-reachability surfacing — untested endpoints/functions

### DIFF
--- a/internal/dashboard/handlers_coverage.go
+++ b/internal/dashboard/handlers_coverage.go
@@ -72,6 +72,14 @@ type GroupCoverageReport struct {
 	// `coverage_source` prop — the common case until a report is ingested — so
 	// the provenance banner degrades cleanly to reachability/capability.
 	LineCoverage *LineCoverageSummary `json:"line_coverage,omitempty"`
+
+	// Reachability is the static test-reachability roll-up (#5037/#5062):
+	// endpoint-level tested/untested counts plus the orphan list (endpoints
+	// with no test path reaching their handler). Distinct from CoveragePct
+	// (reach %) and LineCoverage (executed %). Nil when no repo was scanned;
+	// Computed:false when scanned but the reachability pass never ran (pre-#5061
+	// index) so the UI shows "not computed — reindex".
+	Reachability *ReachabilitySummary `json:"reachability,omitempty"`
 }
 
 // LineCoverageSummary is the group-level roll-up of the per-entity ingested
@@ -252,6 +260,11 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 	// shape once all repos are scanned.
 	var lineCov lineCovAccumulator
 
+	// Static test-reachability roll-up (#5037/#5062). Folds the test_reachable
+	// props stamped onto endpoint entities (#5061) into an endpoint-level
+	// tested/untested summary + orphan list.
+	var reach reachAccumulator
+
 	// S8 (#2159): use the cached group to avoid per-request LoadGraphFromDir.
 	cachedGrpCov, _ := s.graphs.GetGroupCached(groupName)
 
@@ -320,12 +333,22 @@ func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
 
 		// Fold this repo's stamped ingested line-coverage props (#5066).
 		lineCov.accumulate(doc)
+
+		// Fold this repo's stamped endpoint reachability props (#5037/#5062).
+		reach.accumulate(doc, rp.Slug)
 	}
 
 	// Presence of any stamped entity ⇒ a report was ingested for this group, so
 	// we emit the authoritative line % (distinct from reach CoveragePct). When
 	// nothing was stamped, LineCoverage stays nil and the banner degrades.
 	result.LineCoverage = lineCov.summarize()
+
+	// Endpoint reachability summary (#5037/#5062). Only attach when at least one
+	// repo was scanned; the summary's Computed flag distinguishes
+	// "pass-never-ran" (degrade) from "ran, zero orphans".
+	if result.Repos > 0 {
+		result.Reachability = reach.summarize()
+	}
 
 	// ── compute group-level coverage % ───────────────────────────────────────
 	// CoveragePct stays pure reach-coverage; ContractCoveredPct is the union

--- a/internal/dashboard/handlers_coverage_reach.go
+++ b/internal/dashboard/handlers_coverage_reach.go
@@ -1,0 +1,165 @@
+package dashboard
+
+// handlers_coverage_reach.go — static test-reachability surfacing (#5062).
+//
+// #5037 computes, without executing anything, which production endpoints are
+// reachable from at least one test (the reachability pass in
+// internal/coverage/reachability.go stamps test_reachable / reaching_tests /
+// reach_depth onto entity Properties at index time, #5061).
+//
+// This file folds those stamped props into the GET /api/quality/coverage/{group}
+// payload as a ReachabilitySummary: an endpoint-level tested/untested roll-up
+// plus the high-value ORPHAN list — endpoints with NO test reaching their
+// handler. The dashboard CoverageTab renders the orphan surface so an agent
+// doing a parity rewrite can see exactly which architectural surfaces have zero
+// test exercising them.
+//
+// Degradation: if NO endpoint in the group carries a test_reachable prop, the
+// pass was not run (pre-#5061 index). In that case Computed is false and the UI
+// shows "reachability not computed — reindex" rather than implying every
+// endpoint is untested.
+
+import (
+	"sort"
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ReachabilitySummary is the wire shape for the static test-reachability signal
+// (#5037) surfaced on the coverage report. It is intentionally distinct from
+// LineCoverageSummary (executed line %) and from the reach CoveragePct band:
+// this is the endpoint-level "has any test path reaching it" signal.
+type ReachabilitySummary struct {
+	// Computed reports whether the reachability pass ran for this group. When
+	// false (no endpoint carried a test_reachable prop — a pre-#5061 index),
+	// the counts are meaningless and the UI must show "not computed — reindex"
+	// instead of implying everything is untested.
+	Computed bool `json:"computed"`
+
+	// TotalEndpoints / TestedEndpoints / OrphanEndpoints are the endpoint-level
+	// roll-up: how many HTTP endpoint surfaces have >=1 test reaching their
+	// handler vs none. Orphan = Total - Tested.
+	TotalEndpoints  int `json:"total_endpoints"`
+	TestedEndpoints int `json:"tested_endpoints"`
+	OrphanEndpoints int `json:"orphan_endpoints"`
+
+	// ReachablePct is 100*Tested/Total in [0,100]; 0 when Total is zero.
+	ReachablePct float64 `json:"reachable_pct"`
+
+	// Orphans is the capped, sorted list of endpoints with no test path
+	// reaching them — the actionable surface highlighted in the UI.
+	Orphans []ReachOrphanEndpoint `json:"orphans"`
+
+	// OrphansMore is the number of orphan endpoints elided beyond the cap.
+	OrphansMore int `json:"orphans_more,omitempty"`
+}
+
+// ReachOrphanEndpoint is one untested endpoint row.
+type ReachOrphanEndpoint struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourceFile string `json:"source_file,omitempty"`
+	StartLine  int    `json:"start_line,omitempty"`
+	Repo       string `json:"repo,omitempty"`
+}
+
+// reachOrphanCap bounds the orphan list returned on the wire so a group with a
+// large untested surface does not produce an unbounded payload. Matches the
+// spirit of PerFileUncoveredCap.
+const reachOrphanCap = 200
+
+// reachAccumulator folds endpoint-level reachability props across a group's
+// repo documents. Zero value is ready to use.
+type reachAccumulator struct {
+	computed bool
+	total    int
+	tested   int
+	orphans  []ReachOrphanEndpoint
+}
+
+// accumulate scans one repo document for HTTP endpoint entities carrying the
+// #5037 test_reachable prop, updating the roll-up and collecting orphans. repo
+// is the owning repo slug, attached to each orphan so the UI can resolve its
+// source through the correct repo root in a multi-repo group.
+func (a *reachAccumulator) accumulate(doc *graph.Document, repo string) {
+	if doc == nil {
+		return
+	}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Properties == nil || !isEndpointReachKind(e.Kind) {
+			continue
+		}
+		val, ok := e.Properties[coverage.PropTestReachable]
+		if !ok {
+			// Endpoint exists but was never visited by the reachability pass
+			// for this index — do not count it (avoids implying "untested").
+			continue
+		}
+		a.computed = true
+		a.total++
+		reachable, _ := strconv.ParseBool(val)
+		if reachable {
+			a.tested++
+			continue
+		}
+		a.orphans = append(a.orphans, ReachOrphanEndpoint{
+			ID:         e.ID,
+			Name:       e.Name,
+			Kind:       e.Kind,
+			SourceFile: e.SourceFile,
+			StartLine:  e.StartLine,
+			Repo:       repo,
+		})
+	}
+}
+
+// summarize turns the accumulated state into the wire shape, sorting and
+// capping the orphan list. Returns nil only when no document was ever scanned;
+// when scanned-but-not-stamped it returns a {Computed:false} summary so the UI
+// can distinguish "not computed" from "no orphans".
+func (a *reachAccumulator) summarize() *ReachabilitySummary {
+	s := &ReachabilitySummary{
+		Computed:        a.computed,
+		TotalEndpoints:  a.total,
+		TestedEndpoints: a.tested,
+		OrphanEndpoints: a.total - a.tested,
+	}
+	if a.total > 0 {
+		s.ReachablePct = 100.0 * float64(a.tested) / float64(a.total)
+	}
+
+	orphans := a.orphans
+	sort.SliceStable(orphans, func(i, j int) bool {
+		if orphans[i].SourceFile != orphans[j].SourceFile {
+			return orphans[i].SourceFile < orphans[j].SourceFile
+		}
+		if orphans[i].StartLine != orphans[j].StartLine {
+			return orphans[i].StartLine < orphans[j].StartLine
+		}
+		return orphans[i].Name < orphans[j].Name
+	})
+	if len(orphans) > reachOrphanCap {
+		s.OrphansMore = len(orphans) - reachOrphanCap
+		orphans = orphans[:reachOrphanCap]
+	}
+	s.Orphans = orphans
+	return s
+}
+
+// isEndpointReachKind reports whether a kind is an HTTP endpoint surface for
+// the reachability roll-up. Mirrors the MCP tool's isEndpointKind (#5060) so
+// the dashboard and MCP agree on what counts as an endpoint.
+func isEndpointReachKind(kind string) bool {
+	switch types.EntityKind(kind) {
+	case types.EntityKindEndpoint,
+		types.EntityKindRoute,
+		types.EntityKindHTTPEndpointDefinition:
+		return true
+	}
+	return false
+}

--- a/internal/dashboard/handlers_coverage_reach_test.go
+++ b/internal/dashboard/handlers_coverage_reach_test.go
@@ -1,0 +1,130 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func ep(id, name string, reachable string) graph.Entity {
+	props := map[string]string{}
+	if reachable != "" {
+		props[coverage.PropTestReachable] = reachable
+	}
+	return graph.Entity{ID: id, Name: name, Kind: "SCOPE.Endpoint", Properties: props}
+}
+
+func TestReachAccumulator_TestedUntestedRollup(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		ep("e1", "GET /a", "true"),
+		ep("e2", "POST /b", "false"),
+		ep("e3", "GET /c", "false"),
+		// A non-endpoint with the prop must be ignored.
+		{ID: "f1", Name: "helper", Kind: "SCOPE.Function",
+			Properties: map[string]string{coverage.PropTestReachable: "false"}},
+	}}
+
+	var a reachAccumulator
+	a.accumulate(doc, "repoA")
+	s := a.summarize()
+
+	if !s.Computed {
+		t.Fatal("expected Computed=true when endpoints carry the prop")
+	}
+	if s.TotalEndpoints != 3 || s.TestedEndpoints != 1 || s.OrphanEndpoints != 2 {
+		t.Fatalf("rollup mismatch: total=%d tested=%d orphan=%d",
+			s.TotalEndpoints, s.TestedEndpoints, s.OrphanEndpoints)
+	}
+	if len(s.Orphans) != 2 {
+		t.Fatalf("expected 2 orphans, got %d", len(s.Orphans))
+	}
+	for _, o := range s.Orphans {
+		if o.Repo != "repoA" {
+			t.Errorf("orphan %s missing repo slug, got %q", o.ID, o.Repo)
+		}
+	}
+	if got := s.ReachablePct; got < 33.0 || got > 34.0 {
+		t.Errorf("ReachablePct = %v, want ~33.3", got)
+	}
+}
+
+func TestReachAccumulator_NotComputedDegrades(t *testing.T) {
+	// Endpoints exist but none carry the reachability prop (pre-#5061 index).
+	doc := &graph.Document{Entities: []graph.Entity{
+		ep("e1", "GET /a", ""),
+		ep("e2", "POST /b", ""),
+	}}
+
+	var a reachAccumulator
+	a.accumulate(doc, "repoA")
+	s := a.summarize()
+
+	if s.Computed {
+		t.Fatal("expected Computed=false when no endpoint carries the prop")
+	}
+	if s.TotalEndpoints != 0 || s.OrphanEndpoints != 0 {
+		t.Fatalf("unstamped endpoints must not be counted: total=%d orphan=%d",
+			s.TotalEndpoints, s.OrphanEndpoints)
+	}
+	if len(s.Orphans) != 0 {
+		t.Fatalf("expected no orphans when not computed, got %d", len(s.Orphans))
+	}
+}
+
+func TestReachAccumulator_AllTestedNoOrphans(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		ep("e1", "GET /a", "true"),
+		ep("e2", "POST /b", "true"),
+	}}
+
+	var a reachAccumulator
+	a.accumulate(doc, "repoA")
+	s := a.summarize()
+
+	if !s.Computed {
+		t.Fatal("expected Computed=true")
+	}
+	if s.OrphanEndpoints != 0 || len(s.Orphans) != 0 {
+		t.Fatalf("expected zero orphans, got %d / %d", s.OrphanEndpoints, len(s.Orphans))
+	}
+	if s.ReachablePct != 100.0 {
+		t.Errorf("ReachablePct = %v, want 100", s.ReachablePct)
+	}
+}
+
+func TestReachAccumulator_OrphanCap(t *testing.T) {
+	ents := make([]graph.Entity, 0, reachOrphanCap+5)
+	for i := 0; i < reachOrphanCap+5; i++ {
+		ents = append(ents, ep("e"+string(rune('a'+i%26))+string(rune(i)), "GET /x", "false"))
+	}
+	doc := &graph.Document{Entities: ents}
+
+	var a reachAccumulator
+	a.accumulate(doc, "r")
+	s := a.summarize()
+
+	if len(s.Orphans) != reachOrphanCap {
+		t.Fatalf("orphan list not capped: got %d want %d", len(s.Orphans), reachOrphanCap)
+	}
+	if s.OrphansMore != 5 {
+		t.Errorf("OrphansMore = %d, want 5", s.OrphansMore)
+	}
+	if s.OrphanEndpoints != reachOrphanCap+5 {
+		t.Errorf("OrphanEndpoints count must reflect full total, got %d", s.OrphanEndpoints)
+	}
+}
+
+func TestReachAccumulator_MultiRepo(t *testing.T) {
+	var a reachAccumulator
+	a.accumulate(&graph.Document{Entities: []graph.Entity{ep("a1", "GET /a", "true")}}, "repoA")
+	a.accumulate(&graph.Document{Entities: []graph.Entity{ep("b1", "GET /b", "false")}}, "repoB")
+	s := a.summarize()
+
+	if s.TotalEndpoints != 2 || s.TestedEndpoints != 1 || s.OrphanEndpoints != 1 {
+		t.Fatalf("multi-repo rollup mismatch: %+v", s)
+	}
+	if len(s.Orphans) != 1 || s.Orphans[0].Repo != "repoB" {
+		t.Fatalf("orphan repo slug not propagated: %+v", s.Orphans)
+	}
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1953,6 +1953,48 @@ export interface GroupCoverageReport {
    * which is graph-derived reach coverage, not a measured line %.
    */
   line_coverage?: LineCoverageSummary;
+  /**
+   * Static test-reachability roll-up (#5037/#5062): which HTTP endpoints have
+   * at least one test path reaching their handler vs none (the "orphan"
+   * surface). Graph-derived, no execution — distinct from `coverage_pct` and
+   * `line_coverage`. Absent on older backends; when `computed` is false the
+   * reachability pass never ran for this group (pre-#5061 index) and the UI
+   * must show "not computed — reindex" rather than implying everything is
+   * untested.
+   */
+  reachability?: ReachabilitySummary;
+}
+
+/**
+ * Endpoint-level static test-reachability summary (#5037/#5062). Surfaces the
+ * orphan endpoints (no test path reaching their handler) as the actionable
+ * untested surface for a parity rewrite.
+ */
+export interface ReachabilitySummary {
+  /**
+   * Whether the reachability pass ran for this group. When false, the counts
+   * are meaningless (pre-#5061 index) and the UI shows a "not computed" notice.
+   */
+  computed: boolean;
+  total_endpoints: number;
+  tested_endpoints: number;
+  orphan_endpoints: number;
+  /** 100 * tested / total (0 when total === 0). */
+  reachable_pct: number;
+  /** Capped, sorted list of untested endpoints. */
+  orphans: ReachOrphanEndpoint[];
+  /** Count of orphan endpoints elided beyond the cap. */
+  orphans_more?: number;
+}
+
+/** One untested endpoint row (#5062). */
+export interface ReachOrphanEndpoint {
+  id: string;
+  name: string;
+  kind: string;
+  source_file?: string;
+  start_line?: number;
+  repo?: string;
 }
 
 /**

--- a/webui-v2/src/lib/reachability-summary.test.ts
+++ b/webui-v2/src/lib/reachability-summary.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReachabilitySummary } from "../data/types";
+import { resolveReachabilityView } from "./reachability-summary";
+
+function summary(over: Partial<ReachabilitySummary>): ReachabilitySummary {
+  return {
+    computed: true,
+    total_endpoints: 0,
+    tested_endpoints: 0,
+    orphan_endpoints: 0,
+    reachable_pct: 0,
+    orphans: [],
+    ...over,
+  };
+}
+
+describe("resolveReachabilityView", () => {
+  it("degrades to not-computed when the summary is absent (older backend)", () => {
+    const v = resolveReachabilityView(undefined);
+    expect(v.kind).toBe("not-computed");
+    expect(v.orphans).toBe(0);
+    expect(v.label).toMatch(/not computed/i);
+  });
+
+  it("degrades to not-computed when the pass never ran, NOT implying untested", () => {
+    const v = resolveReachabilityView(summary({ computed: false }));
+    expect(v.kind).toBe("not-computed");
+    // Must not report orphans/untested counts when nothing was computed.
+    expect(v.orphans).toBe(0);
+    expect(v.total).toBe(0);
+    expect(v.orphanRows).toHaveLength(0);
+  });
+
+  it("returns all-tested when there are zero orphans", () => {
+    const v = resolveReachabilityView(
+      summary({
+        total_endpoints: 4,
+        tested_endpoints: 4,
+        orphan_endpoints: 0,
+        reachable_pct: 100,
+      }),
+    );
+    expect(v.kind).toBe("all-tested");
+    expect(v.orphanRows).toHaveLength(0);
+    expect(v.reachablePct).toBe(100);
+    expect(v.label).toMatch(/all 4 endpoints/i);
+  });
+
+  it("returns has-orphans with the orphan rows when some endpoints are untested", () => {
+    const v = resolveReachabilityView(
+      summary({
+        total_endpoints: 5,
+        tested_endpoints: 3,
+        orphan_endpoints: 2,
+        reachable_pct: 60,
+        orphans: [
+          { id: "e1", name: "POST /inspections", kind: "SCOPE.Endpoint" },
+          { id: "e2", name: "GET /audit", kind: "SCOPE.Endpoint" },
+        ],
+        orphans_more: 0,
+      }),
+    );
+    expect(v.kind).toBe("has-orphans");
+    expect(v.orphans).toBe(2);
+    expect(v.orphanRows).toHaveLength(2);
+    expect(v.reachablePct).toBe(60);
+    expect(v.label).toMatch(/2 untested endpoints/i);
+  });
+
+  it("propagates the orphans_more cap overflow", () => {
+    const v = resolveReachabilityView(
+      summary({
+        total_endpoints: 250,
+        tested_endpoints: 0,
+        orphan_endpoints: 250,
+        orphans: [{ id: "e1", name: "GET /x", kind: "SCOPE.Endpoint" }],
+        orphans_more: 49,
+      }),
+    );
+    expect(v.kind).toBe("has-orphans");
+    expect(v.orphansMore).toBe(49);
+  });
+
+  it("handles a singular orphan label", () => {
+    const v = resolveReachabilityView(
+      summary({
+        total_endpoints: 1,
+        tested_endpoints: 0,
+        orphan_endpoints: 1,
+        orphans: [{ id: "e1", name: "GET /x", kind: "SCOPE.Endpoint" }],
+      }),
+    );
+    expect(v.label).toMatch(/1 untested endpoint\b/i);
+  });
+});

--- a/webui-v2/src/lib/reachability-summary.ts
+++ b/webui-v2/src/lib/reachability-summary.ts
@@ -1,0 +1,97 @@
+/**
+ * reachability-summary — pure branch logic for the dashboard's static
+ * test-reachability surface (#5037/#5062).
+ *
+ * #5037 computes, WITHOUT executing anything, which HTTP endpoints are
+ * reachable from at least one test (graph traversal over TESTS + CALLS edges).
+ * The pass stamps `test_reachable` onto endpoint entities at index time (#5061);
+ * the dashboard coverage endpoint rolls those into a `ReachabilitySummary`. The
+ * highest-value display is the ORPHAN surface — endpoints with NO test path
+ * reaching their handler.
+ *
+ * This module turns the raw summary into a single view-state descriptor with
+ * exactly three branches, so the renderer is a thin switch and the branch
+ * selection is unit-testable under the default (node) vitest environment — the
+ * same convention as {@link ./coverage-provenance}.
+ *
+ *   - "not-computed": the reachability pass never ran for this group (pre-#5061
+ *     index, or the summary is absent). We MUST NOT imply everything is
+ *     untested — show a "reindex to compute" notice instead.
+ *   - "all-tested": every endpoint has >=1 test reaching it (zero orphans).
+ *   - "has-orphans": one or more untested endpoints — highlight them.
+ */
+
+import type { ReachabilitySummary, ReachOrphanEndpoint } from "../data/types";
+
+/** Which branch the reachability surface should render. */
+export type ReachabilityViewKind = "not-computed" | "all-tested" | "has-orphans";
+
+/** Resolved, render-ready descriptor for the reachability surface. */
+export interface ReachabilityView {
+  kind: ReachabilityViewKind;
+  /** Endpoint-level roll-up counts (all 0 when not computed). */
+  total: number;
+  tested: number;
+  orphans: number;
+  /** 100 * tested / total, rounded for display; 0 when not computed. */
+  reachablePct: number;
+  /** Capped orphan rows to render (empty unless kind === "has-orphans"). */
+  orphanRows: ReachOrphanEndpoint[];
+  /** Orphan rows elided beyond the backend cap (0 when none). */
+  orphansMore: number;
+  /** One-line human summary suitable for a badge/heading. */
+  label: string;
+}
+
+/**
+ * resolveReachabilityView turns the (possibly absent / not-computed) summary
+ * into a single descriptor. Tolerant of an absent summary (older backend) — it
+ * collapses to the "not-computed" branch, never implying untested.
+ */
+export function resolveReachabilityView(
+  summary: ReachabilitySummary | undefined,
+): ReachabilityView {
+  // Absent, or the pass never ran for this group ⇒ degrade. Critically, we do
+  // NOT treat "no data" as "everything untested".
+  if (!summary || !summary.computed) {
+    return {
+      kind: "not-computed",
+      total: 0,
+      tested: 0,
+      orphans: 0,
+      reachablePct: 0,
+      orphanRows: [],
+      orphansMore: 0,
+      label: "Test-reachability not computed — reindex to compute",
+    };
+  }
+
+  const total = summary.total_endpoints;
+  const tested = summary.tested_endpoints;
+  const orphans = summary.orphan_endpoints;
+  const reachablePct = summary.reachable_pct;
+
+  if (orphans <= 0) {
+    return {
+      kind: "all-tested",
+      total,
+      tested,
+      orphans: 0,
+      reachablePct,
+      orphanRows: [],
+      orphansMore: 0,
+      label: `All ${total} endpoint${total === 1 ? "" : "s"} reachable from a test`,
+    };
+  }
+
+  return {
+    kind: "has-orphans",
+    total,
+    tested,
+    orphans,
+    reachablePct,
+    orphanRows: summary.orphans ?? [],
+    orphansMore: summary.orphans_more ?? 0,
+    label: `${orphans} untested endpoint${orphans === 1 ? "" : "s"} (no test reaches handler)`,
+  };
+}

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -70,6 +70,7 @@ import {
 import type { InsightValue } from "@/components/ui";
 import type { CoverageSourceState } from "@/lib/coverage-provenance";
 import { coverageStateFromReport } from "@/lib/coverage-provenance";
+import { resolveReachabilityView } from "@/lib/reachability-summary";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RefLine } from "@/components/RefLine";
 import { useSourcePeek } from "@/components/SourcePeek";
@@ -92,6 +93,8 @@ import type {
   NPlusOneFinding,
   GodNode,
   MetricTrend,
+  ReachabilitySummary,
+  ReachOrphanEndpoint,
 } from "@/data/types";
 
 // ---------------------------------------------------------------------------
@@ -789,6 +792,138 @@ function UncoveredRow({ u, repo }: { u: UncoveredEntity; repo: string }) {
   );
 }
 
+/**
+ * ReachabilitySurface — static test-reachability (#5037/#5062). The highest-
+ * value display is the ORPHAN list: endpoints with NO test path reaching their
+ * handler. All branch logic lives in resolveReachabilityView (pure, tested);
+ * this is a thin renderer over the descriptor.
+ *
+ *  - not-computed ⇒ a neutral "reindex to compute" notice (never implies
+ *    everything is untested).
+ *  - all-tested   ⇒ a success badge.
+ *  - has-orphans  ⇒ the highlighted untested-endpoint list.
+ */
+function ReachabilitySurface({
+  reachability,
+  groupId,
+  repo,
+}: {
+  reachability: ReachabilitySummary | undefined;
+  groupId: string;
+  repo: string;
+}) {
+  const view = resolveReachabilityView(reachability);
+
+  if (view.kind === "not-computed") {
+    return (
+      <div className="flex flex-wrap items-center gap-2 text-sm text-text-3">
+        <Info size={14} className="text-text-4 shrink-0" />
+        <span>
+          Static test-reachability not computed for this group — reindex to
+          mark tested vs untested endpoints.
+        </span>
+      </div>
+    );
+  }
+
+  if (view.kind === "all-tested") {
+    return (
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <Badge tone="success" className="inline-flex items-center gap-1">
+          <CheckCircle2 size={11} />
+          {view.label}
+        </Badge>
+        <span className="text-text-4 tabular-nums">
+          {view.reachablePct.toFixed(1)}% endpoints test-reachable
+        </span>
+      </div>
+    );
+  }
+
+  // has-orphans — the actionable untested surface.
+  return (
+    <Card>
+      <CardHeader className="flex flex-wrap items-center justify-between gap-2">
+        <CardTitle className="flex items-center gap-1.5">
+          <AlertTriangle size={14} className="text-warning shrink-0" />
+          Untested endpoints
+          <MetricInfo
+            hint={
+              <>
+                Endpoints with <strong>no test path reaching their handler</strong>,
+                computed statically (#5037) from TESTS + CALLS edges — no
+                execution. Distinct from line coverage: these architectural
+                surfaces have zero test exercising them, the most actionable
+                signal for a parity rewrite.
+              </>
+            }
+          />
+          <span className="ml-1 text-text-4 tabular-nums font-normal text-xs">
+            {view.orphans} of {view.total}
+          </span>
+        </CardTitle>
+        <span className="text-text-4 tabular-nums text-xs">
+          {view.reachablePct.toFixed(1)}% test-reachable
+        </span>
+      </CardHeader>
+      <CardBody className="space-y-2">
+        {view.orphanRows.map((o) => (
+          <ReachOrphanRow key={o.id} o={o} repo={repo} />
+        ))}
+        {view.orphansMore > 0 && (
+          <div className="text-xs text-text-4 px-1">
+            + {view.orphansMore} more untested endpoint
+            {view.orphansMore === 1 ? "" : "s"} not shown
+          </div>
+        )}
+      </CardBody>
+    </Card>
+  );
+  // `groupId` reserved for a future deep-link/filter (parity with siblings).
+  void groupId;
+}
+
+/** One untested-endpoint row, reusing RepoChip/RefLine like UncoveredRow. */
+function ReachOrphanRow({
+  o,
+  repo,
+}: {
+  o: ReachOrphanEndpoint;
+  repo: string;
+}) {
+  const entityRepo = o.repo || repo;
+  return (
+    <div className="flex flex-col gap-1.5 px-3 py-2.5 rounded-lg border border-warning/30 bg-warning/5 hover:bg-warning/10 transition-colors">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="font-mono text-sm text-text truncate" title={o.name}>
+          {o.name}
+        </span>
+        <div className="ml-auto flex items-center gap-1.5 shrink-0">
+          <Badge tone="warning" className="shrink-0 inline-flex items-center gap-0.5">
+            <AlertTriangle size={11} />
+            untested
+          </Badge>
+          <Badge tone="neutral" className="shrink-0">
+            {o.kind}
+          </Badge>
+        </div>
+      </div>
+      {o.source_file && (
+        <div className="flex items-center gap-2 min-w-0 -mx-1">
+          <RepoChip slug={entityRepo} className="text-[10px] shrink-0" />
+          <RefLine
+            repo={entityRepo}
+            file={o.source_file}
+            line={o.start_line ?? 0}
+            name=""
+            className="text-[11px] py-0.5 px-1 min-w-0"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
 function CoverageTab({ groupId }: { groupId: string }) {
   const { data, isLoading, isError } = useQualityCoverage(groupId);
   const [severity, setSeverity] = useState<"all" | "high" | "medium" | "low">("all");
@@ -877,6 +1012,17 @@ function CoverageTab({ groupId }: { groupId: string }) {
         totalTests={data.total_tests}
         contractOnly={data.contract_covered_only ?? 0}
         contractPct={data.contract_covered_pct ?? data.coverage_pct}
+      />
+
+      {/* Static test-reachability (#5037/#5062): tested vs untested endpoints,
+          highlighting the orphan surface (no test path reaching the handler).
+          Graph-derived, no execution — distinct from the reach gauge above and
+          the line-coverage badge. Degrades to a "not computed" notice on a
+          pre-#5061 index rather than implying everything is untested. */}
+      <ReachabilitySurface
+        reachability={data.reachability}
+        groupId={groupId}
+        repo={data.group}
       />
 
       {(data.by_directory?.length ?? 0) > 0 && (


### PR DESCRIPTION
## What this surfaces (v1)
Surfaces the **static test-reachability** signal (#5037 — computed without executing anything, stamped onto endpoint entities at index time by #5061, queryable via MCP #5060) in the dashboard **Quality → Coverage** tab. Pairs with the coverage provenance banner (#5038/#5066), reusing its data layer + lib-test conventions.

The highest-value display is the **orphan surface**: endpoints with **no test path reaching their handler** — the most actionable signal for a parity rewrite.

### API field exposed
`handlers_coverage.go` now folds the `test_reachable` props (alongside the existing #5066 `line_coverage` roll-up) into a new `reachability` field on `GET /api/quality/coverage/{group}`:
- `internal/dashboard/handlers_coverage_reach.go` — `ReachabilitySummary` (endpoint-level `total_endpoints`/`tested_endpoints`/`orphan_endpoints`/`reachable_pct`) + capped, repo-stamped `orphans[]` list. Endpoint kinds mirror the MCP tool's `isEndpointKind` (SCOPE.Endpoint / SCOPE.Route / http_endpoint_definition).

### Where surfaced in the UI
**Quality → Coverage tab** (`CoverageTab` in `src/routes/quality.tsx`), directly under the reach-coverage gauge — distinct from both the gauge (reach %) and the line-coverage badge (executed %):
- **has-orphans** ⇒ a highlighted "Untested endpoints" card listing each orphan (RepoChip + RefLine source link), with an `N of M` count + `X% test-reachable`.
- **all-tested** ⇒ a success badge.
- **not-computed** ⇒ see degradation.

### Degradation
`ReachabilitySummary.Computed` is false when **no** endpoint carried a `test_reachable` prop (pre-#5061 index). Unstamped endpoints are **not** counted, so the UI shows *"static test-reachability not computed — reindex"* rather than implying everything is untested. All branch selection lives in the pure `resolveReachabilityView()` (`src/lib/reachability-summary.ts`).

### Test
- `src/lib/reachability-summary.test.ts` — 6 vitest branch-logic tests (not-computed both ways, all-tested, has-orphans, cap overflow, singular label).
- `internal/dashboard/handlers_coverage_reach_test.go` — 5 Go tests (rollup, not-computed degrade, all-tested, orphan cap, multi-repo repo-slug propagation).

### Gates
- Go: `go build ./...` ✅, `go vet ./internal/dashboard/... ./internal/types/` ✅, `go test ./internal/dashboard/... ./internal/types/` ✅.
- Frontend: `npm run build` (tsc -b + vite) ✅, `npm run lint` (tsc --noEmit) ✅, `npm test -- --run` ✅ (124 lib tests incl. 6 new).
- Did NOT run `make dashboard-build`. Deploy-deferred.

### Deferred
- Per-**function** tested/untested column (v1 scopes the endpoint orphan surface, the highest-value signal). The `test_reachable` prop is stamped on functions too — a future column on the uncovered-entities rows can reuse the same plumbing.
- Cross with dynamic line coverage (reachable+0% lines = tautological test, #4893).

Refs #5062