### PR TITLE
feat(#5067): coverage overlay on dashboard rows — line vs reachability vs capability

### DIFF
--- a/webui-v2/src/components/ui/coverage-kind-indicator.tsx
+++ b/webui-v2/src/components/ui/coverage-kind-indicator.tsx
@@ -1,0 +1,71 @@
+import { GaugeCircle, Layers, ClipboardList } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import {
+  resolveCoverageKindIndicator,
+  type CoverageSourceState,
+  type CoverageProvenanceKind,
+} from "@/lib/coverage-provenance";
+
+/**
+ * CoverageKindIndicator (#5067) — a compact inline chip that sits next to an
+ * individual coverage "%" on a diagram surface (file-tree / module / endpoint
+ * row, and where cheap a topology node) so the user can always tell WHICH of
+ * the three archigraph coverages that specific number is.
+ *
+ * The full {@link CoverageProvenanceBanner} (#5038) disambiguates a whole
+ * surface; this disambiguates one row. Both share {@link
+ * resolveCoverageProvenance} so the precedence (line ▸ reachability ▸
+ * capability) and tones never drift apart.
+ *
+ * THREE distinct visual treatments — the whole point per #5038/#5067 — so the
+ * kind is legible at a glance and not by color alone:
+ *
+ *   - line        → success tone + gauge icon  ("Line")        authoritative %
+ *   - reachability→ info tone + layers icon    ("Reach")       NOT a measured %
+ *   - capability  → neutral tone + clipboard   ("Capability")  NOT test coverage
+ *
+ * Degradation: when `state` is absent/empty the underlying resolver returns the
+ * capability default, so we render the neutral "Capability" chip — never a
+ * misleading authoritative treatment.
+ */
+
+const KIND_ICON: Record<CoverageProvenanceKind, typeof GaugeCircle> = {
+  line: GaugeCircle,
+  reachability: Layers,
+  capability: ClipboardList,
+};
+
+export interface CoverageKindIndicatorProps {
+  /** Raw availability state for this row/node; absent ⇒ capability default. */
+  state?: CoverageSourceState | null;
+  /**
+   * Render only the icon (+ tooltip), dropping the text label. For dense rows /
+   * diagram nodes where horizontal space is scarce. The kind is still conveyed
+   * by icon + tone + tooltip, never color alone (the tooltip names the kind).
+   */
+  iconOnly?: boolean;
+  className?: string;
+}
+
+export function CoverageKindIndicator({
+  state,
+  iconOnly = false,
+  className,
+}: CoverageKindIndicatorProps) {
+  const ind = resolveCoverageKindIndicator(state);
+  const Icon = KIND_ICON[ind.kind];
+
+  return (
+    <Badge
+      tone={ind.tone}
+      title={ind.title}
+      aria-label={`${ind.label} — ${ind.title}`}
+      data-coverage-kind={ind.kind}
+      className={cn("gap-1 px-1.5", className)}
+    >
+      <Icon size={11} aria-hidden className="shrink-0" />
+      {iconOnly ? null : <span className="leading-none">{ind.short}</span>}
+    </Badge>
+  );
+}

--- a/webui-v2/src/components/ui/index.ts
+++ b/webui-v2/src/components/ui/index.ts
@@ -31,5 +31,7 @@ export { InsightBanner } from "./insight-banner";
 export type { InsightBannerProps, InsightBannerAgent } from "./insight-banner";
 export { CoverageProvenanceBanner } from "./coverage-provenance-banner";
 export type { CoverageProvenanceBannerProps } from "./coverage-provenance-banner";
+export { CoverageKindIndicator } from "./coverage-kind-indicator";
+export type { CoverageKindIndicatorProps } from "./coverage-kind-indicator";
 export { InsightProvider, useInsight, useSetInsight } from "./insight-context";
 export type { InsightValue } from "./insight-context";

--- a/webui-v2/src/lib/coverage-kind-indicator.test.ts
+++ b/webui-v2/src/lib/coverage-kind-indicator.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Branch-logic tests for resolveCoverageKindIndicator (#5067) — the compact
+ * per-row / per-node coverage-kind chip.
+ *
+ * Verifies it is a faithful projection of resolveCoverageProvenance: the SAME
+ * precedence (line ▸ reachability ▸ capability), the SAME tones, the correct
+ * short label per kind, and — load-bearing for honest degradation — that ONLY
+ * ingested line coverage is marked `authoritative`. Pure, so it runs under the
+ * default (node) vitest environment with no DOM.
+ *
+ * Run with: npx vitest run src/lib/coverage-kind-indicator.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import {
+  resolveCoverageKindIndicator,
+  type CoverageSourceState,
+} from "./coverage-provenance";
+
+describe("resolveCoverageKindIndicator — which treatment per state", () => {
+  it("LINE: ingested line coverage ⇒ success tone, 'Line', authoritative", () => {
+    const state: CoverageSourceState = {
+      line: { source: "lcov", measuredAt: "2026-06-12T10:00:00Z", pct: 73.4 },
+      reachabilityAvailable: true, // line still wins
+      reportIngestionConfigured: true,
+    };
+    const ind = resolveCoverageKindIndicator(state);
+    expect(ind.kind).toBe("line");
+    expect(ind.tone).toBe("success");
+    expect(ind.short).toBe("Line");
+    expect(ind.label).toBe("Line coverage");
+    expect(ind.authoritative).toBe(true);
+    expect(ind.title).toContain("LCOV");
+  });
+
+  it("REACH: reachability-only ⇒ info tone, 'Reach', NOT authoritative", () => {
+    const state: CoverageSourceState = { reachabilityAvailable: true };
+    const ind = resolveCoverageKindIndicator(state);
+    expect(ind.kind).toBe("reachability");
+    expect(ind.tone).toBe("info");
+    expect(ind.short).toBe("Reach");
+    expect(ind.label).toBe("Static test-reachability");
+    expect(ind.authoritative).toBe(false);
+    expect(ind.title.toLowerCase()).toContain("reachability");
+  });
+
+  it("CAPABILITY: nothing wired ⇒ neutral tone, 'Capability', NOT authoritative", () => {
+    const ind = resolveCoverageKindIndicator({});
+    expect(ind.kind).toBe("capability");
+    expect(ind.tone).toBe("neutral");
+    expect(ind.short).toBe("Capability");
+    expect(ind.authoritative).toBe(false);
+  });
+
+  it("degrades to capability on null/undefined ⇒ never a misleading authoritative chip", () => {
+    for (const s of [null, undefined] as const) {
+      const ind = resolveCoverageKindIndicator(s);
+      expect(ind.kind).toBe("capability");
+      expect(ind.tone).toBe("neutral");
+      expect(ind.authoritative).toBe(false);
+    }
+  });
+
+  it("precedence: line beats reachability beats capability", () => {
+    const line = resolveCoverageKindIndicator({
+      line: { source: "jacoco" },
+      reachabilityAvailable: true,
+    });
+    expect(line.kind).toBe("line");
+
+    const reach = resolveCoverageKindIndicator({ reachabilityAvailable: true });
+    expect(reach.kind).toBe("reachability");
+
+    const cap = resolveCoverageKindIndicator({ reachabilityAvailable: false });
+    expect(cap.kind).toBe("capability");
+  });
+
+  it("exactly one kind is ever authoritative (only line)", () => {
+    expect(
+      resolveCoverageKindIndicator({ line: { source: "lcov" } }).authoritative,
+    ).toBe(true);
+    expect(
+      resolveCoverageKindIndicator({ reachabilityAvailable: true }).authoritative,
+    ).toBe(false);
+    expect(resolveCoverageKindIndicator({}).authoritative).toBe(false);
+  });
+});

--- a/webui-v2/src/lib/coverage-provenance.ts
+++ b/webui-v2/src/lib/coverage-provenance.ts
@@ -239,6 +239,62 @@ export function resolveCoverageProvenance(
 }
 
 /**
+ * Compact, render-ready descriptor for the per-row / per-node coverage-kind
+ * INDICATOR (#5067). Where the full {@link CoverageProvenanceBanner} explains a
+ * whole surface, this drives a small inline chip that sits next to an
+ * individual coverage number (a file-tree row, a module row, an endpoint row,
+ * and — where cheap — a diagram node) so the user can always tell WHICH of the
+ * three coverages that specific "%" is. It is a strict projection of
+ * {@link resolveCoverageProvenance}: same precedence, same tones, just trimmed
+ * to what fits in a chip. Pure + DOM-free so the branch selection is unit
+ * testable under the default (node) vitest environment.
+ */
+export interface CoverageKindIndicator {
+  kind: CoverageProvenanceKind;
+  /** Visual tone (shared with the banner / Badge tones). */
+  tone: "success" | "info" | "neutral";
+  /** Ultra-short chip label, e.g. "Line" / "Reach" / "Capability". */
+  short: string;
+  /** Slightly longer label for wider chips / aria, e.g. "Line coverage". */
+  label: string;
+  /**
+   * Whether this chip represents a real, measured/authoritative line "%". Only
+   * `kind === "line"` is authoritative; reachability and capability are NOT and
+   * the caller should render their "%" (if any) as non-authoritative. Lets a
+   * row avoid painting a misleading green "80%" for a non-line source.
+   */
+  authoritative: boolean;
+  /** Tooltip — the one-line `method` from the full provenance descriptor. */
+  title: string;
+}
+
+const KIND_SHORT: Record<CoverageProvenanceKind, string> = {
+  line: "Line",
+  reachability: "Reach",
+  capability: "Capability",
+};
+
+/**
+ * Resolve the per-row/per-node coverage-kind indicator. Thin projection over
+ * {@link resolveCoverageProvenance} so the precedence (line ▸ reachability ▸
+ * capability) and tones stay in ONE place and cannot drift between the banner
+ * and the inline chips.
+ */
+export function resolveCoverageKindIndicator(
+  state: CoverageSourceState | null | undefined,
+): CoverageKindIndicator {
+  const p = resolveCoverageProvenance(state);
+  return {
+    kind: p.kind,
+    tone: p.tone,
+    short: KIND_SHORT[p.kind],
+    label: p.label,
+    authoritative: p.kind === "line",
+    title: p.method,
+  };
+}
+
+/**
  * Group-level ingested line-coverage roll-up, as surfaced by the dashboard
  * `/quality/coverage` endpoint's optional `line_coverage` field (#5066). Mirror
  * of the Go `LineCoverageSummary` wire shape. Kept here (rather than importing

--- a/webui-v2/src/routes/quality.tsx
+++ b/webui-v2/src/routes/quality.tsx
@@ -65,6 +65,7 @@ import {
   TabCount,
   DefTerm,
   CoverageProvenanceBanner,
+  CoverageKindIndicator,
   useSetInsight,
 } from "@/components/ui";
 import type { InsightValue } from "@/components/ui";
@@ -829,6 +830,7 @@ function ReachabilitySurface({
   if (view.kind === "all-tested") {
     return (
       <div className="flex flex-wrap items-center gap-2 text-sm">
+        <CoverageKindIndicator state={{ reachabilityAvailable: true }} />
         <Badge tone="success" className="inline-flex items-center gap-1">
           <CheckCircle2 size={11} />
           {view.label}
@@ -861,6 +863,10 @@ function ReachabilitySurface({
           <span className="ml-1 text-text-4 tabular-nums font-normal text-xs">
             {view.orphans} of {view.total}
           </span>
+          <CoverageKindIndicator
+            state={{ reachabilityAvailable: true }}
+            className="ml-1 font-normal"
+          />
         </CardTitle>
         <span className="text-text-4 tabular-nums text-xs">
           {view.reachablePct.toFixed(1)}% test-reachable
@@ -995,6 +1001,9 @@ function CoverageTab({ groupId }: { groupId: string }) {
         // line %, shown distinctly from the reach-coverage gauge below so the
         // two numbers are never conflated.
         <div className="flex flex-wrap items-center gap-2 text-sm">
+          {/* Coverage-kind indicator (#5067) — the authoritative LINE
+              treatment, distinct from the Reach chip on the tree below. */}
+          <CoverageKindIndicator state={coverageProvenance} />
           <Badge tone="success">
             Line coverage {lineCov.coverage_pct.toFixed(1)}%
           </Badge>
@@ -1047,6 +1056,14 @@ function CoverageTab({ groupId }: { groupId: string }) {
                   {treeUncoveredCount} uncovered
                 </span>
               )}
+              {/* Per-surface coverage-kind indicator (#5067). This tree is
+                  ALWAYS graph-derived reach coverage (`coverage_pct`), even
+                  when an ingested line % exists above — force the "Reach" chip
+                  so the tree's numbers are never mistaken for the line %. */}
+              <CoverageKindIndicator
+                state={{ reachabilityAvailable: true }}
+                className="ml-1 font-normal"
+              />
             </CardTitle>
             {treeCarriesUncovered ? (
               severityFilter


### PR DESCRIPTION
## What

A reusable **`CoverageKindIndicator`** chip that sits next to a coverage "%" on the dashboard's Quality surfaces so the user can always tell WHICH of archigraph's three coverages that number is — the core disambiguation #5038 asks for, now extended past the banner to per-surface indicators (#5067).

It is driven by a new pure helper `resolveCoverageKindIndicator` in `coverage-provenance.ts`, a strict projection of the existing `resolveCoverageProvenance` — so the precedence (**line ▸ reachability ▸ capability**) and tones can never drift apart from the #5038 banner.

## Where the overlay landed (Quality tab)
- **Ingested line-coverage badge** → Line treatment (`coverageStateFromReport(line_coverage)`), the only authoritative %.
- **"By directory" coverage-tree header** → forced **Reach** treatment, because that tree is always graph-derived `coverage_pct` (reach coverage) even when an ingested line % exists above — so the tree's numbers are never mistaken for the line %.
- **Static test-reachability surfaces** (all-tested badge + untested-endpoints header) → Reach treatment.

## The 3 visual treatments + how provenance picks
| Kind | Tone | Icon | Label | Authoritative |
|---|---|---|---|---|
| line | success | gauge | "Line" | yes (measured %) |
| reachability | info | layers | "Reach" | no |
| capability | neutral | clipboard | "Capability" | no |

The kind is selected by `resolveCoverageProvenance`'s precedence: ingested line coverage wins; else static reachability; else capability. Each chip carries the one-line `method` as its tooltip + an `aria-label`, so the kind is conveyed by icon + tone + text, never color alone.

## Degradation
Absent/empty/null state → resolver returns the **capability** default → neutral "Capability" chip. Only `kind === "line"` is marked `authoritative`, so a non-line source is never painted as a measured green %. No fake 0% / fake green.

## Test
`src/lib/coverage-kind-indicator.test.ts` (6 cases) — asserts the treatment per state, the line ▸ reach ▸ capability precedence, that exactly one kind (line) is authoritative, and the null/undefined → capability degrade. Lives in `src/lib` so the default `npm test` glob picks it up.

## Deferred
WebGL/cytoscape graph nodes, flow-dag, topology, and iac diagram nodes — those are canvas/WebGL, not DOM rows, so a per-node chip needs node-decoration plumbing. Filed as **#5147** (an `iconOnly` chip variant is already in place for a future HTML-overlay path).

## Gates
- `npm run build` clean
- `npx tsc --noEmit` clean
- `npm test -- --run` → 14 files / 130 tests pass (+6 new)

Closes #5067
Refs #5038 #5147

🤖 Generated with [Claude Code](https://claude.com/claude-code)