### PR TITLE
feat(#5068): MCP coverage freshness — measured_at + stale-vs-index signal

### DIFF
--- a/docs/mcp-tools/audit.md
+++ b/docs/mcp-tools/audit.md
@@ -42,7 +42,9 @@ Production entities with no TESTS edge, ranked by severity.
 
 Key parameters: `entity_id` (optional — scoped query), `repo_filter[]`, `severity`, `limit` (default 100), `top_directories` (bool).
 
-Output: production entities lacking TESTS edges, ranked by severity.
+Output: production entities lacking TESTS edges, ranked by severity, followed by a **coverage-freshness** block (#5068).
+
+**Coverage freshness (#5068).** Both this tool and `archigraph_test_reachability` append a freshness section that tells an agent whether any *ingested* line-coverage report (LCOV/Cobertura/JaCoCo, #5036) is **stale relative to the latest index**. The verdict mirrors the dashboard provenance banner (#5038): a measurement is **STALE** when its `coverage_measured_at` predates the latest index `generated_at` (the report annotates a graph that has since been re-indexed, so "% covered" may no longer reflect current code) and **FRESH** when at/after it; the delta between the two is surfaced. It degrades honestly: *no* entity carrying `coverage_source` ⇒ "no coverage report ingested" (the counts above are static reach-coverage, not a measured line %); a report with no `coverage_measured_at` stamp, or no index timestamp to compare against ⇒ **UNKNOWN** rather than a fabricated verdict. STALE output tells the agent to re-run tests + reingest the report, then re-index.
 
 ---
 
@@ -56,7 +58,7 @@ The signal is computed by the indexer (#5037 / #5061) and **stamped onto entity 
 
 Key parameters: `entity_id` (optional — focus a single entity), `repo_filter[]`, `untested_only` (bool — list only orphans), `endpoints_only` (bool — HTTP endpoints/routes only), `limit` (default 100).
 
-Output: group and per-module reachability roll-ups (% reachable), an endpoint roll-up, and a row listing sorted **orphans-first** (endpoints before plain functions). Each reachable row shows `depth` and reaching-test count; a `[reachable-but-0%-lines]` tag flags entities statically reached by a test yet with 0% measured LCOV line coverage (the candidate-ineffective-test signal, crossing #5036). The canonical orphan query is `untested_only=true` (optionally with `endpoints_only=true`): "which endpoints/handlers have NO test reaching them".
+Output: group and per-module reachability roll-ups (% reachable), an endpoint roll-up, and a row listing sorted **orphans-first** (endpoints before plain functions). Each reachable row shows `depth` and reaching-test count; a `[reachable-but-0%-lines]` tag flags entities statically reached by a test yet with 0% measured LCOV line coverage (the candidate-ineffective-test signal, crossing #5036). The canonical orphan query is `untested_only=true` (optionally with `endpoints_only=true`): "which endpoints/handlers have NO test reaching them". The output ends with the same **coverage-freshness** block described under [`archigraph_test_coverage`](#archigraph_test_coverage) (#5068) — relevant here because the `[reachable-but-0%-lines]` cross-signal is only meaningful against a *current* coverage report.
 
 ---
 

--- a/internal/mcp/coverage_freshness.go
+++ b/internal/mcp/coverage_freshness.go
@@ -1,0 +1,179 @@
+// coverage_freshness.go — shared coverage-freshness signal for the coverage MCP
+// tools (#5068).
+//
+// archigraph can ingest a real line-coverage report (LCOV / Cobertura / JaCoCo,
+// #5036) and stamp `coverage_source` / `coverage_measured_at` onto entities at
+// index time (#5061). That ingested measurement can go STALE: if the source is
+// re-indexed after the coverage report was produced, the report predates the
+// graph it is annotating and "% covered" may no longer reflect current code.
+//
+// The dashboard provenance banner (#5038) computes this staleness verdict
+// client-side (webui-v2/src/lib/coverage-provenance.ts): stale when
+// measured_at < latest index time. This file mirrors that exact rule so an
+// AGENT querying via the coverage MCP tools gets the same freshness/stale
+// verdict directly, without re-deriving it from raw props.
+//
+// The signal degrades honestly:
+//   - no entity carries coverage_source         → "no coverage report ingested"
+//   - report ingested but no measured_at stamp  → freshness unknown (no verdict)
+//   - measured_at present, no index timestamp   → echo measured_at, no verdict
+//   - both present                              → FRESH or STALE + the delta
+package mcp
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+)
+
+// coverageFreshness is the freshness verdict for a group's ingested
+// line-coverage measurement, mirroring the dashboard provenance banner (#5038).
+type coverageFreshness struct {
+	// ingested is true when ANY entity in the group carried a coverage_source
+	// prop (a report was actually ingested). When false, all other fields are
+	// zero and the only honest statement is "no coverage report ingested".
+	ingested bool
+	// source is the first non-empty coverage_source seen (e.g. "lcov").
+	source string
+	// entities counts how many entities carried coverage_source — distinguishes
+	// a real (if sparse) ingestion from none at all.
+	entities int
+	// measuredAt is the latest coverage_measured_at seen (RFC3339). Empty when
+	// the ingestor stamped no timestamp.
+	measuredAt string
+	// indexedAt is the latest index time across the group's repos (the document
+	// GeneratedAt). Zero when no repo carried a timestamp.
+	indexedAt time.Time
+	// haveVerdict is true only when both measuredAt parsed and indexedAt is set,
+	// so a stale/fresh judgement could actually be made.
+	haveVerdict bool
+	// stale is the verdict (only meaningful when haveVerdict): the coverage
+	// measurement predates the latest index → may no longer reflect the code.
+	stale bool
+	// delta is indexedAt - measuredAt (only meaningful when haveVerdict). When
+	// stale it is the positive amount the index is newer than the measurement.
+	delta time.Duration
+}
+
+// computeCoverageFreshness folds the loaded group's documents into a single
+// freshness verdict. Pure over the loaded graph (no IO): scans entity props for
+// coverage_source / coverage_measured_at and the per-repo document GeneratedAt.
+//
+// Repos are visited in sorted order so the "first source seen" is deterministic.
+func computeCoverageFreshness(lg *LoadedGroup) coverageFreshness {
+	var f coverageFreshness
+	if lg == nil {
+		return f
+	}
+
+	repoNames := make([]string, 0, len(lg.Repos))
+	for name := range lg.Repos {
+		repoNames = append(repoNames, name)
+	}
+	sort.Strings(repoNames)
+
+	for _, name := range repoNames {
+		lr := lg.Repos[name]
+		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		// Latest index time across repos drives the staleness comparison.
+		if g := lr.Doc.GeneratedAt; g.After(f.indexedAt) {
+			f.indexedAt = g
+		}
+		for i := range lr.Doc.Entities {
+			e := &lr.Doc.Entities[i]
+			if len(e.Properties) == 0 {
+				continue
+			}
+			src := e.Properties[coverage.PropCoverageSource]
+			if src == "" {
+				continue
+			}
+			f.ingested = true
+			f.entities++
+			if f.source == "" {
+				f.source = src
+			}
+			// RFC3339 timestamps sort lexicographically, so a string compare
+			// picks the most recent measurement without parsing.
+			if at := e.Properties[coverage.PropCoverageMeasAt]; at > f.measuredAt {
+				f.measuredAt = at
+			}
+		}
+	}
+
+	// Verdict only when both sides of the comparison exist.
+	if f.measuredAt != "" && !f.indexedAt.IsZero() {
+		if mt, err := time.Parse(time.RFC3339, f.measuredAt); err == nil {
+			f.haveVerdict = true
+			f.stale = mt.Before(f.indexedAt)
+			f.delta = f.indexedAt.Sub(mt)
+		}
+	}
+	return f
+}
+
+// renderCoverageFreshness renders the freshness block as a markdown section for
+// the coverage MCP tools. Always returns a non-empty, honest section: it states
+// "no report ingested" when nothing is stamped, and degrades when timestamps
+// are missing rather than asserting a verdict it cannot support.
+func renderCoverageFreshness(f coverageFreshness) string {
+	out := "\n### Coverage freshness\n\n"
+
+	if !f.ingested {
+		out += "_No coverage report ingested for this group_ — the counts above are " +
+			"static reach-coverage (graph-derived TESTS edges), not a measured line %. " +
+			"To ingest real line coverage, point archigraph at your lcov/cobertura/jacoco " +
+			"report (coverage.report_paths) and re-index.\n"
+		return out
+	}
+
+	out += fmt.Sprintf("coverage_source   : %s (%d entities stamped)\n", f.source, f.entities)
+	if f.measuredAt != "" {
+		out += fmt.Sprintf("measured_at       : %s\n", f.measuredAt)
+	} else {
+		out += "measured_at       : (not stamped by ingestor)\n"
+	}
+	if !f.indexedAt.IsZero() {
+		out += fmt.Sprintf("indexed_at        : %s\n", f.indexedAt.UTC().Format(time.RFC3339))
+	}
+
+	switch {
+	case f.haveVerdict && f.stale:
+		out += fmt.Sprintf(
+			"verdict           : STALE — the coverage report predates the latest index by %s.\n"+
+				"                    Coverage may be stale; re-run tests + reingest the report, then re-index.\n",
+			humanizeDelta(f.delta),
+		)
+	case f.haveVerdict && !f.stale:
+		out += fmt.Sprintf(
+			"verdict           : FRESH — the coverage report is at or newer than the latest index (by %s).\n",
+			humanizeDelta(f.delta.Abs()),
+		)
+	case f.measuredAt == "":
+		out += "verdict           : UNKNOWN — ingestor stamped no measured_at, so staleness can't be judged.\n"
+	default:
+		out += "verdict           : UNKNOWN — no index timestamp available to compare against.\n"
+	}
+	return out
+}
+
+// humanizeDelta renders a duration compactly for the freshness line.
+func humanizeDelta(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%.1fh", d.Hours())
+	default:
+		return fmt.Sprintf("%.1fd", d.Hours()/24)
+	}
+}

--- a/internal/mcp/coverage_freshness_test.go
+++ b/internal/mcp/coverage_freshness_test.go
@@ -1,0 +1,109 @@
+// coverage_freshness_test.go — fixtures for the coverage-freshness signal
+// (#5068): stale when the ingested coverage measurement predates the latest
+// index; fresh when at/after; graceful when timestamps are absent.
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/coverage"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// fixtureGroup builds a one-repo LoadedGroup whose document was indexed at
+// indexedAt and (optionally) carries a coverage_source/measured_at stamp.
+func fixtureGroup(indexedAt time.Time, source, measuredAt string) *LoadedGroup {
+	ent := graph.Entity{ID: "e1", Name: "Svc"}
+	if source != "" {
+		ent.Properties = map[string]string{coverage.PropCoverageSource: source}
+		if measuredAt != "" {
+			ent.Properties[coverage.PropCoverageMeasAt] = measuredAt
+		}
+	}
+	return &LoadedGroup{
+		Name: "g",
+		Repos: map[string]*LoadedRepo{
+			"r": {
+				Repo: "r",
+				Doc: &graph.Document{
+					GeneratedAt: indexedAt,
+					Entities:    []graph.Entity{ent},
+				},
+			},
+		},
+	}
+}
+
+func TestCoverageFreshness_Stale(t *testing.T) {
+	idx := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	measured := "2026-06-10T00:00:00Z" // older than index → STALE
+	f := computeCoverageFreshness(fixtureGroup(idx, coverage.SourceLCOV, measured))
+	if !f.ingested {
+		t.Fatal("expected ingested=true")
+	}
+	if !f.haveVerdict || !f.stale {
+		t.Fatalf("expected STALE verdict, got %+v", f)
+	}
+	out := renderCoverageFreshness(f)
+	if !strings.Contains(out, "STALE") || !strings.Contains(out, "reingest") {
+		t.Fatalf("render missing stale guidance:\n%s", out)
+	}
+}
+
+func TestCoverageFreshness_Fresh(t *testing.T) {
+	idx := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	measured := "2026-06-13T12:00:00Z" // newer than index → FRESH
+	f := computeCoverageFreshness(fixtureGroup(idx, coverage.SourceLCOV, measured))
+	if !f.haveVerdict || f.stale {
+		t.Fatalf("expected FRESH verdict, got %+v", f)
+	}
+	if out := renderCoverageFreshness(f); !strings.Contains(out, "FRESH") {
+		t.Fatalf("render missing FRESH:\n%s", out)
+	}
+}
+
+func TestCoverageFreshness_NoIngestion(t *testing.T) {
+	idx := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	f := computeCoverageFreshness(fixtureGroup(idx, "", ""))
+	if f.ingested {
+		t.Fatalf("expected ingested=false, got %+v", f)
+	}
+	out := renderCoverageFreshness(f)
+	if !strings.Contains(out, "No coverage report ingested") {
+		t.Fatalf("render should state no ingestion:\n%s", out)
+	}
+}
+
+func TestCoverageFreshness_IngestedNoMeasuredAt(t *testing.T) {
+	idx := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	f := computeCoverageFreshness(fixtureGroup(idx, coverage.SourceLCOV, ""))
+	if !f.ingested || f.haveVerdict {
+		t.Fatalf("expected ingested w/o verdict, got %+v", f)
+	}
+	if out := renderCoverageFreshness(f); !strings.Contains(out, "UNKNOWN") {
+		t.Fatalf("render should be UNKNOWN when no measured_at:\n%s", out)
+	}
+}
+
+func TestCoverageFreshness_NoIndexTimestamp(t *testing.T) {
+	// Zero GeneratedAt → no index time to compare against.
+	f := computeCoverageFreshness(fixtureGroup(time.Time{}, coverage.SourceLCOV, "2026-06-10T00:00:00Z"))
+	if f.haveVerdict {
+		t.Fatalf("expected no verdict without index time, got %+v", f)
+	}
+	if out := renderCoverageFreshness(f); !strings.Contains(out, "UNKNOWN") {
+		t.Fatalf("render should be UNKNOWN without index time:\n%s", out)
+	}
+}
+
+func TestCoverageFreshness_NilGroup(t *testing.T) {
+	f := computeCoverageFreshness(nil)
+	if f.ingested {
+		t.Fatal("nil group must be non-ingested")
+	}
+	if out := renderCoverageFreshness(f); !strings.Contains(out, "No coverage report ingested") {
+		t.Fatalf("nil group should degrade gracefully:\n%s", out)
+	}
+}

--- a/internal/mcp/coverage_tools.go
+++ b/internal/mcp/coverage_tools.go
@@ -184,6 +184,10 @@ func (s *Server) handleTestCoverage(ctx context.Context, req mcpapi.CallToolRequ
 		}
 	}
 
+	// Freshness signal (#5068): is any ingested line-coverage measurement stale
+	// relative to the latest index? Degrades honestly when nothing is ingested.
+	out += renderCoverageFreshness(computeCoverageFreshness(lg))
+
 	return mcpapi.NewToolResultText(out), nil
 }
 

--- a/internal/mcp/reachability_tools.go
+++ b/internal/mcp/reachability_tools.go
@@ -241,6 +241,11 @@ func (s *Server) handleTestReachability(ctx context.Context, req mcpapi.CallTool
 		}
 	}
 
+	// Freshness signal (#5068): any reachable-but-0%-lines cross-signal above is
+	// only meaningful against a CURRENT coverage report — surface whether the
+	// ingested measurement is stale relative to the latest index.
+	out += renderCoverageFreshness(computeCoverageFreshness(lg))
+
 	return mcpapi.NewToolResultText(out), nil
 }
 


### PR DESCRIPTION
## What

Surfaces a **coverage-freshness** signal through the coverage MCP tools so an agent can reason directly about whether ingested line coverage is current — the same verdict the dashboard provenance banner (#5038) computes client-side from `coverage_measured_at` vs the latest index.

### Tools updated
- **`archigraph_test_coverage`** — appends a freshness block to the group dump.
- **`archigraph_test_reachability`** — appends the same block (relevant because its `[reachable-but-0%-lines]` cross-signal is only meaningful against a *current* coverage report).

No new tool, no catalogue count change.

### Stale computation
Shared pure helper `computeCoverageFreshness(*LoadedGroup)` (new `internal/mcp/coverage_freshness.go`) folds the loaded graph:
- scans entity props for `coverage_source` + `coverage_measured_at` (latest, RFC3339 lexicographic),
- takes the latest `Document.GeneratedAt` across repos as the index time,
- **STALE when `measured_at` < index `generated_at`** (mirrors `coverage-provenance.ts`: `measuredT < indexT`), FRESH at/after, and surfaces the delta.

### Degradation (honest)
- No entity carries `coverage_source` ⇒ "no coverage report ingested" (counts are static reach-coverage, not a measured line %).
- Report ingested but no `measured_at` stamp ⇒ **UNKNOWN**.
- No index timestamp to compare against ⇒ **UNKNOWN**.
- Nil group ⇒ graceful no-ingestion message.

### Docs
`docs/mcp-tools/audit.md` — freshness section documented under both tools.

### Fixture
`internal/mcp/coverage_freshness_test.go`: stale (measured < index), fresh (measured ≥ index), no-ingestion, ingested-without-measured_at, no-index-timestamp, nil-group.

### Gates (sandbox HOME=/tmp/agsbx-5068)
`go build ./...`, `go vet ./internal/...`, `go test ./internal/mcp/... ./internal/coverage/... ./internal/types/` — all green.

Closes #5068