### PR TITLE
feat(#5074): csharp — AutoMapper/Mapster mapping-profile extraction

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 170 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 1 · **C#**: 14 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
+**Total**: 172 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 1 · **C#**: 16 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -28,11 +28,13 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [clojure](../by-language/clojure.md) | [next.jdbc](../detail/lang.clojure.driver.next-jdbc.md) | 🔴 0/11 | |
 | [crystal](../by-language/crystal.md) | [Granite (Crystal ORM)](../detail/lang.crystal.orm.granite.md) | 🟡 7/10 | |
 | [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 2/5 | |
+| [C#](../by-language/csharp.md) | [AutoMapper (.NET object-object mapper)](../detail/lang.csharp.mapper.automapper.md) | ✅ 1/1 | |
 | [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 2/5 | |
 | [C#](../by-language/csharp.md) | [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 3/6 | |
 | [C#](../by-language/csharp.md) | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 8/11 | |
 | [C#](../by-language/csharp.md) | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 7/10 | |
 | [C#](../by-language/csharp.md) | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🟡 6/9 | |
+| [C#](../by-language/csharp.md) | [Mapster (.NET object-object mapper)](../detail/lang.csharp.mapper.mapster.md) | ✅ 1/1 | |
 | [C#](../by-language/csharp.md) | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🔴 0/4 | |
 | [C#](../by-language/csharp.md) | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | 🟡 3/6 | |
 | [C#](../by-language/csharp.md) | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | 🔴 0/4 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # C#
 
-**Frameworks**: 17 · **Tools**: 7 · **ORMs**: 14 · **Other**: 8
+**Frameworks**: 17 · **Tools**: 7 · **ORMs**: 16 · **Other**: 8
 
 Back to [summary](../summary.md).
 
@@ -89,11 +89,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 2/5 | |
+| [AutoMapper (.NET object-object mapper)](../detail/lang.csharp.mapper.automapper.md) | ✅ 1/1 | |
 | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 2/5 | |
 | [Dapper](../detail/lang.csharp.orm.dapper.md) | 🟡 3/6 | |
 | [Entity Framework Core](../detail/lang.csharp.orm.efcore.md) | 🟡 8/11 | |
 | [LINQ to SQL](../detail/lang.csharp.orm.linq-to-sql.md) | 🟡 7/10 | |
 | [LinqToDB](../detail/lang.csharp.orm.linqtodb.md) | 🟡 6/9 | |
+| [Mapster (.NET object-object mapper)](../detail/lang.csharp.mapper.mapster.md) | ✅ 1/1 | |
 | [Microsoft.Data.Sqlite](../detail/lang.csharp.driver.sqlite.md) | 🔴 0/4 | |
 | [MongoDB.Driver (C#)](../detail/lang.csharp.driver.mongodb.md) | 🟡 3/6 | |
 | [MySQL.Data / MySqlConnector](../detail/lang.csharp.driver.mysql.md) | 🔴 0/4 | |

--- a/docs/coverage/detail/lang.csharp.mapper.automapper.md
+++ b/docs/coverage/detail/lang.csharp.mapper.automapper.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.mapper.automapper` — AutoMapper (.NET object-object mapper)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Schema extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Foreign key extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Relationship extraction | ✅ `full` | `2026-06-13` | — | `internal/custom/csharp/object_mapping.go`<br>`internal/custom/csharp/object_mapping_test.go` | #5074: AutoMapper Profile subclass (class X : Profile) -> SCOPE.Pattern(mapping_profile); CreateMap<TSrc,TDest>() (+chained .ForMember member maps, .ReverseMap) -> SCOPE.Pattern(object_mapping) carrying a MAPS_TO edge Class:<TSrc> -> Class:<TDest> (resolvable to the real DTO/entity classes via the byName Class: fallback), with member_map_count and a reverse MAPS_TO for .ReverseMap(). Proven by TestObjectMappingAutoMapperMapster. Honest-partial: open generics / runtime-typed sources carry no fabricated edge. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Migration schema ops | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.mapper.automapper ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.csharp.mapper.mapster.md
+++ b/docs/coverage/detail/lang.csharp.mapper.mapster.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.mapper.mapster` — Mapster (.NET object-object mapper)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Schema extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Foreign key extraction | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Relationship extraction | ✅ `full` | `2026-06-13` | — | `internal/custom/csharp/object_mapping.go`<br>`internal/custom/csharp/object_mapping_test.go` | #5074: Mapster TypeAdapterConfig<TSrc,TDest> and config.NewConfig<TSrc,TDest>() registrations -> SCOPE.Pattern(object_mapping) carrying a MAPS_TO edge Class:<TSrc> -> Class:<TDest> (resolvable via byName Class: fallback); inline expr.Adapt<TDest>() projection -> SCOPE.Pattern(object_mapping) destination-only (dynamic_source, no fabricated source edge). Proven by TestObjectMappingAutoMapperMapster. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+| Migration schema ops | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | — `not_applicable` | — | — | — | object-object mapper config (AutoMapper Profile / Mapster) — not a DB ORM: no models/queries/migrations/transactions of its own; the mapping is the source->dest relationship surfaced via relationship_extraction. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.mapper.mapster ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 170 · **Tools**: 120 · **Other**: 203
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 172 · **Tools**: 120 · **Other**: 203
 
 ## Coverage by language
 
@@ -13,7 +13,7 @@
 | [go](by-language/go.md) | 21 | 8 | 17 | 5 |
 | [C/C++](by-language/c-cpp.md) | 20 | 16 | 10 | 4 |
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
-| [C#](by-language/csharp.md) | 17 | 7 | 14 | 8 |
+| [C#](by-language/csharp.md) | 17 | 7 | 16 | 8 |
 | [php](by-language/php.md) | 16 | 6 | 14 | 1 |
 | [rust](by-language/rust.md) | 15 | 6 | 15 | 4 |
 | [elixir](by-language/elixir.md) | 14 | 9 | 10 | 5 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 246 frameworks · 120 tools · 170 ORMs · 203 other
+Total: 246 frameworks · 120 tools · 172 ORMs · 203 other

--- a/internal/custom/csharp/object_mapping.go
+++ b/internal/custom/csharp/object_mapping.go
@@ -1,0 +1,294 @@
+package csharp
+
+// object_mapping.go — AutoMapper / Mapster object-mapping topology extractor
+// (#5074, spun out of #5016/#4969). Surfaces DTO↔entity mapping topology so a
+// configured object-mapping is a traversable subgraph rather than being buried
+// inside a mapper-configuration class.
+//
+// AutoMapper — mapping is declared inside a `Profile` subclass via
+// `CreateMap<TSource, TDest>()`, optionally refined by chained `.ForMember(...)`
+// member maps:
+//
+//	public class UserProfile : Profile {
+//	    public UserProfile() {
+//	        CreateMap<User, UserDto>()
+//	            .ForMember(d => d.FullName, o => o.MapFrom(s => s.Name));
+//	        CreateMap<Order, OrderDto>().ReverseMap();
+//	    }
+//	}
+//
+// Mapster — global/typed configuration registrations and inline projections:
+//
+//	TypeAdapterConfig<User, UserDto>.NewConfig();
+//	config.NewConfig<Order, OrderDto>();
+//	var dto = user.Adapt<UserDto>();          // inline projection (dest only)
+//
+// Emission model (reuses existing entity Kinds — no new Kind):
+//   - one SCOPE.Pattern subtype="mapping_profile" per AutoMapper Profile class
+//     (the owning configuration unit).
+//   - one SCOPE.Pattern subtype="object_mapping" per CreateMap / NewConfig pair,
+//     carrying a MAPS_TO relationship from the source type (`Class:<TSrc>`) to
+//     the destination type (`Class:<TDest>`) so source→dest is resolvable to the
+//     real DTO/entity class entities by the linker's byName fallback.
+//   - one SCOPE.Pattern subtype="object_mapping" per `.Adapt<TDest>()` inline
+//     projection (destination-only — the source is a runtime expression, so we
+//     emit honest-partial: no fabricated source edge).
+//
+// MAPS_TO edge properties: framework, source_type, dest_type, member_map_count
+// (AutoMapper .ForMember count), reverse ("true" when .ReverseMap() present),
+// owning profile (AutoMapper), provenance.
+//
+// Honest-partial: open generics, runtime-typed sources (`.Adapt<T>()`) and
+// fully-dynamic registrations carry no fabricated MAPS_TO source.
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_object_mapping", &objectMappingExtractor{})
+}
+
+type objectMappingExtractor struct{}
+
+func (e *objectMappingExtractor) Language() string { return "custom_csharp_object_mapping" }
+
+var (
+	// AutoMapper Profile subclass: `class X : Profile` (also `: Profile,` / `: Profile {`).
+	csProfileRe = regexp.MustCompile(`\bclass\s+(\w+)\s*:\s*[^\{]*\bProfile\b`)
+
+	// AutoMapper CreateMap<TSource, TDest>() — two explicit type args.
+	csCreateMapRe = regexp.MustCompile(`\bCreateMap\s*<\s*([\w.]+)\s*,\s*([\w.]+)\s*>\s*\(`)
+
+	// Mapster TypeAdapterConfig<TSource, TDest>.NewConfig() and
+	// `someConfig.NewConfig<TSource, TDest>()` — both supply explicit src,dest.
+	csTypeAdapterCfgRe = regexp.MustCompile(`\bTypeAdapterConfig\s*<\s*([\w.]+)\s*,\s*([\w.]+)\s*>`)
+	csNewConfigRe      = regexp.MustCompile(`\.NewConfig\s*<\s*([\w.]+)\s*,\s*([\w.]+)\s*>\s*\(`)
+
+	// Mapster inline projection `expr.Adapt<TDest>()` — destination only.
+	csAdaptRe = regexp.MustCompile(`\.Adapt\s*<\s*([\w.]+)\s*>\s*\(`)
+)
+
+// csChainWindow returns the source slice of the fluent call chain starting at
+// `start`, terminated by the first top-level `;` (depth-aware over parens so a
+// `MapFrom(s => s.X)` lambda's own `;`-free body is included). The fluent
+// chain may span multiple lines, so only a depth-0 `;` terminates it.
+func csChainWindow(src string, start int) string {
+	depth := 0
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ';':
+			if depth == 0 {
+				return src[start:i]
+			}
+		}
+	}
+	return src[start:]
+}
+
+// csShortType returns the trailing identifier of a possibly-dotted type name
+// (`App.Models.User` -> `User`) for the byName-resolvable `Class:<T>` ref.
+func csShortType(t string) string {
+	if i := strings.LastIndexByte(t, '.'); i >= 0 {
+		return t[i+1:]
+	}
+	return t
+}
+
+func csMapsToEdge(srcType, destType, framework, profile string, memberMaps int, reverse bool) types.RelationshipRecord {
+	props := map[string]string{
+		"framework":   framework,
+		"language":    "csharp",
+		"source_type": srcType,
+		"dest_type":   destType,
+		"provenance":  "INFERRED_FROM_OBJECT_MAPPING",
+	}
+	if memberMaps > 0 {
+		props["member_map_count"] = fmt.Sprintf("%d", memberMaps)
+	}
+	if reverse {
+		props["reverse"] = "true"
+	}
+	if profile != "" {
+		props["profile"] = profile
+	}
+	return types.RelationshipRecord{
+		FromID:     "Class:" + csShortType(srcType),
+		ToID:       "Class:" + csShortType(destType),
+		Kind:       string(types.RelationshipKindMapsTo),
+		Properties: props,
+	}
+}
+
+func (e *objectMappingExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.csharp_object_mapping")
+	_, span := tracer.Start(ctx, "custom.csharp_object_mapping")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Cheap pre-filter: only run on files that mention a mapping API.
+	if !strings.Contains(src, "CreateMap") && !strings.Contains(src, "TypeAdapterConfig") &&
+		!strings.Contains(src, "NewConfig") && !strings.Contains(src, ".Adapt<") &&
+		!strings.Contains(src, ".Adapt <") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// --- AutoMapper Profile classes (the owning configuration unit) ---
+	// Record (name, byte-offset) so each CreateMap can be attributed to its
+	// enclosing profile by the nearest preceding profile declaration.
+	type profileDecl struct {
+		name string
+		off  int
+	}
+	var profiles []profileDecl
+	for _, m := range csProfileRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		profiles = append(profiles, profileDecl{name: name, off: m[0]})
+		ent := makeEntity(name, "SCOPE.Pattern", "mapping_profile", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "automapper",
+			"pattern_type", "mapping_profile",
+			"profile", name,
+			"provenance", "INFERRED_FROM_AUTOMAPPER_PROFILE")
+		add(ent)
+	}
+	profileAt := func(off int) string {
+		best := ""
+		bestOff := -1
+		for _, p := range profiles {
+			if p.off < off && p.off > bestOff {
+				bestOff = p.off
+				best = p.name
+			}
+		}
+		return best
+	}
+
+	// --- AutoMapper CreateMap<TSrc, TDest>() (+ chained .ForMember / .ReverseMap) ---
+	for _, m := range csCreateMapRe.FindAllStringSubmatchIndex(src, -1) {
+		srcType := src[m[2]:m[3]]
+		destType := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		window := csChainWindow(src, m[0])
+		memberMaps := strings.Count(window, ".ForMember")
+		reverse := strings.Contains(window, ".ReverseMap")
+		profile := profileAt(m[0])
+
+		name := srcType + " -> " + destType
+		ent := makeEntity(name, "SCOPE.Pattern", "object_mapping", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "automapper",
+			"pattern_type", "object_mapping",
+			"source_type", srcType,
+			"dest_type", destType,
+			"member_map_count", fmt.Sprintf("%d", memberMaps),
+			"provenance", "INFERRED_FROM_AUTOMAPPER_CREATEMAP")
+		if reverse {
+			setProps(&ent, "reverse", "true")
+		}
+		if profile != "" {
+			setProps(&ent, "profile", profile)
+		}
+		ent.Relationships = append(ent.Relationships,
+			csMapsToEdge(srcType, destType, "automapper", profile, memberMaps, reverse))
+		add(ent)
+
+		// .ReverseMap() declares the inverse mapping too — emit its MAPS_TO so
+		// the dest→source direction is also traversable (no separate entity to
+		// avoid a duplicate Pattern node; the reverse edge hangs off the same).
+		if reverse {
+			ent2 := &out[len(out)-1]
+			ent2.Relationships = append(ent2.Relationships,
+				csMapsToEdge(destType, srcType, "automapper", profile, 0, false))
+		}
+	}
+
+	// --- Mapster TypeAdapterConfig<TSrc, TDest>... ---
+	for _, m := range csTypeAdapterCfgRe.FindAllStringSubmatchIndex(src, -1) {
+		srcType := src[m[2]:m[3]]
+		destType := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		name := srcType + " -> " + destType
+		ent := makeEntity(name, "SCOPE.Pattern", "object_mapping", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mapster",
+			"pattern_type", "object_mapping",
+			"source_type", srcType,
+			"dest_type", destType,
+			"registration", "type_adapter_config",
+			"provenance", "INFERRED_FROM_MAPSTER_TYPEADAPTERCONFIG")
+		ent.Relationships = append(ent.Relationships,
+			csMapsToEdge(srcType, destType, "mapster", "", 0, false))
+		add(ent)
+	}
+
+	// --- Mapster config.NewConfig<TSrc, TDest>() ---
+	for _, m := range csNewConfigRe.FindAllStringSubmatchIndex(src, -1) {
+		srcType := src[m[2]:m[3]]
+		destType := src[m[4]:m[5]]
+		line := lineOf(src, m[0])
+		name := srcType + " -> " + destType
+		ent := makeEntity(name, "SCOPE.Pattern", "object_mapping", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mapster",
+			"pattern_type", "object_mapping",
+			"source_type", srcType,
+			"dest_type", destType,
+			"registration", "new_config",
+			"provenance", "INFERRED_FROM_MAPSTER_NEWCONFIG")
+		ent.Relationships = append(ent.Relationships,
+			csMapsToEdge(srcType, destType, "mapster", "", 0, false))
+		add(ent)
+	}
+
+	// --- Mapster inline projection `expr.Adapt<TDest>()` (destination-only) ---
+	// Honest-partial: the source is a runtime expression, so we record the
+	// destination projection but emit no fabricated MAPS_TO source.
+	for _, m := range csAdaptRe.FindAllStringSubmatchIndex(src, -1) {
+		destType := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		name := "Adapt -> " + destType
+		ent := makeEntity(name, "SCOPE.Pattern", "object_mapping", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "mapster",
+			"pattern_type", "object_mapping",
+			"dest_type", destType,
+			"registration", "adapt_projection",
+			"dynamic_source", "true",
+			"provenance", "INFERRED_FROM_MAPSTER_ADAPT")
+		add(ent)
+	}
+
+	return out, nil
+}

--- a/internal/custom/csharp/object_mapping_test.go
+++ b/internal/custom/csharp/object_mapping_test.go
@@ -1,0 +1,149 @@
+package csharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// AutoMapper / Mapster object-mapping topology coverage (#5074). Value-
+// asserting: source→dest MAPS_TO edges must be recovered (resolvable to the
+// real DTO/entity classes via Class:<T>), member-map counts captured, and the
+// Mapster registrations + honest-partial inline projection surfaced.
+
+const objectMappingSrc = `
+using AutoMapper;
+using Mapster;
+
+public class UserProfile : Profile
+{
+    public UserProfile()
+    {
+        CreateMap<User, UserDto>()
+            .ForMember(d => d.FullName, o => o.MapFrom(s => s.Name))
+            .ForMember(d => d.Email, o => o.MapFrom(s => s.EmailAddress));
+        CreateMap<Order, OrderDto>().ReverseMap();
+    }
+}
+
+public class MapsterConfig
+{
+    public static void Register(TypeAdapterConfig config)
+    {
+        TypeAdapterConfig<Product, ProductDto>.NewConfig();
+        config.NewConfig<Category, CategoryDto>();
+    }
+
+    public CustomerDto Map(Customer c) => c.Adapt<CustomerDto>();
+}
+`
+
+func mapEdgeOf(ent *types.EntityRecord, kind, fromID, toID string) *types.RelationshipRecord {
+	for i := range ent.Relationships {
+		r := &ent.Relationships[i]
+		if r.Kind == kind && r.FromID == fromID && r.ToID == toID {
+			return r
+		}
+	}
+	return nil
+}
+
+func TestObjectMappingAutoMapperMapster(t *testing.T) {
+	ents := extractFull(t, "custom_csharp_object_mapping",
+		fi("Mapping.cs", "csharp", objectMappingSrc))
+
+	// --- AutoMapper Profile recovered ---
+	prof := findBy(ents, "mapping_profile", "UserProfile")
+	if prof == nil {
+		t.Fatal("expected mapping_profile 'UserProfile'")
+	}
+	if prof.Properties["framework"] != "automapper" {
+		t.Errorf("profile framework = %q, want automapper", prof.Properties["framework"])
+	}
+
+	// --- CreateMap<User, UserDto> with two .ForMember member maps ---
+	um := findBy(ents, "object_mapping", "User -> UserDto")
+	if um == nil {
+		t.Fatal("expected object_mapping 'User -> UserDto'")
+	}
+	if um.Properties["member_map_count"] != "2" {
+		t.Errorf("User->UserDto member_map_count = %q, want 2", um.Properties["member_map_count"])
+	}
+	if um.Properties["profile"] != "UserProfile" {
+		t.Errorf("User->UserDto profile = %q, want UserProfile", um.Properties["profile"])
+	}
+	if r := mapEdgeOf(um, "MAPS_TO", "Class:User", "Class:UserDto"); r == nil {
+		t.Error("expected MAPS_TO Class:User -> Class:UserDto")
+	} else if r.Properties["framework"] != "automapper" {
+		t.Errorf("MAPS_TO framework = %q, want automapper", r.Properties["framework"])
+	}
+
+	// --- CreateMap<Order, OrderDto>().ReverseMap() — both directions ---
+	om := findBy(ents, "object_mapping", "Order -> OrderDto")
+	if om == nil {
+		t.Fatal("expected object_mapping 'Order -> OrderDto'")
+	}
+	if om.Properties["reverse"] != "true" {
+		t.Errorf("Order->OrderDto reverse = %q, want true", om.Properties["reverse"])
+	}
+	if mapEdgeOf(om, "MAPS_TO", "Class:Order", "Class:OrderDto") == nil {
+		t.Error("expected forward MAPS_TO Class:Order -> Class:OrderDto")
+	}
+	if mapEdgeOf(om, "MAPS_TO", "Class:OrderDto", "Class:Order") == nil {
+		t.Error("expected reverse MAPS_TO Class:OrderDto -> Class:Order (.ReverseMap)")
+	}
+
+	// --- Mapster TypeAdapterConfig<Product, ProductDto> ---
+	pm := findBy(ents, "object_mapping", "Product -> ProductDto")
+	if pm == nil {
+		t.Fatal("expected object_mapping 'Product -> ProductDto'")
+	}
+	if pm.Properties["framework"] != "mapster" {
+		t.Errorf("Product->ProductDto framework = %q, want mapster", pm.Properties["framework"])
+	}
+	if pm.Properties["registration"] != "type_adapter_config" {
+		t.Errorf("Product->ProductDto registration = %q, want type_adapter_config", pm.Properties["registration"])
+	}
+	if mapEdgeOf(pm, "MAPS_TO", "Class:Product", "Class:ProductDto") == nil {
+		t.Error("expected MAPS_TO Class:Product -> Class:ProductDto")
+	}
+
+	// --- Mapster config.NewConfig<Category, CategoryDto>() ---
+	cm := findBy(ents, "object_mapping", "Category -> CategoryDto")
+	if cm == nil {
+		t.Fatal("expected object_mapping 'Category -> CategoryDto'")
+	}
+	if cm.Properties["registration"] != "new_config" {
+		t.Errorf("Category->CategoryDto registration = %q, want new_config", cm.Properties["registration"])
+	}
+	if mapEdgeOf(cm, "MAPS_TO", "Class:Category", "Class:CategoryDto") == nil {
+		t.Error("expected MAPS_TO Class:Category -> Class:CategoryDto")
+	}
+
+	// --- Mapster inline `.Adapt<CustomerDto>()` projection (honest-partial) ---
+	am := findBy(ents, "object_mapping", "Adapt -> CustomerDto")
+	if am == nil {
+		t.Fatal("expected object_mapping 'Adapt -> CustomerDto'")
+	}
+	if am.Properties["dynamic_source"] != "true" {
+		t.Errorf("Adapt projection dynamic_source = %q, want true", am.Properties["dynamic_source"])
+	}
+	// honest-partial: no fabricated source edge
+	if len(am.Relationships) != 0 {
+		t.Errorf("Adapt projection should carry no MAPS_TO edge, got %d", len(am.Relationships))
+	}
+}
+
+// Non-mapping C# must produce nothing (pre-filter guard).
+func TestObjectMappingIgnoresUnrelated(t *testing.T) {
+	src := `
+public class PlainService
+{
+    public int Add(int a, int b) => a + b;
+}
+`
+	ents := extractFull(t, "custom_csharp_object_mapping", fi("Plain.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities from non-mapping source, got %d", len(ents))
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -1296,6 +1296,15 @@ const (
 	// supervision hierarchy a traversable subgraph rather than being buried
 	// inside the supervisor's init body.
 	RelationshipKindSupervises RelationshipKind = "SUPERVISES"
+
+	// #5074 object-mapping topology: a configured object-mapping
+	// (AutoMapper Profile.CreateMap<TSrc,TDest> / Mapster NewConfig /
+	// .Adapt<T>()) from a source DTO/entity type to a destination type.
+	//   MAPS_TO : source type (SCOPE.Schema/class) → destination type
+	// Carries the mapping framework, the optional member-mapping count and
+	// the owning profile on edge properties so DTO↔entity mapping topology is
+	// traversable rather than buried in a mapper configuration class.
+	RelationshipKindMapsTo RelationshipKind = "MAPS_TO"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -1458,6 +1467,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindRationaleFor,
 		// #4929 Erlang/OTP supervision-tree child_spec edge:
 		RelationshipKindSupervises,
+		// #5074 object-mapping topology (AutoMapper/Mapster source→dest):
+		RelationshipKindMapsTo,
 	}
 }
 


### PR DESCRIPTION
## What

Surface C# object-mapping topology (#5074, spun out of #5016/#4969) so a configured DTO↔entity mapping is a traversable subgraph rather than buried inside a mapper-configuration class. New extractor `internal/custom/csharp/object_mapping.go`.

### AutoMapper
- `class X : Profile` → `SCOPE.Pattern(mapping_profile)` (the owning config unit)
- `CreateMap<TSrc,TDest>()` (+ chained `.ForMember` member maps, `.ReverseMap`) → `SCOPE.Pattern(object_mapping)` carrying a **MAPS_TO** edge `Class:<TSrc>` → `Class:<TDest>`, with `member_map_count` + owning `profile`. `.ReverseMap()` emits the inverse MAPS_TO too. Fluent chain is depth-aware (terminated by a top-level `;`) so multi-line `.ForMember` chains are counted.

### Mapster
- `TypeAdapterConfig<TSrc,TDest>` and `config.NewConfig<TSrc,TDest>()` registrations → `object_mapping` + MAPS_TO
- inline `expr.Adapt<TDest>()` → destination-only `object_mapping` (honest-partial: runtime source, `dynamic_source=true`, **no fabricated** MAPS_TO source edge)

## Edges
New `RelationshipKind` **MAPS_TO** (`internal/types/kinds.go`): registered in `AllRelationshipKinds`, validated by `TestProducerKindLiterals_AreValid`. `FromID`/`ToID` use the `Class:<short-type>` byName ref so source/dest resolve to the real DTO/entity class entities. Reuses existing entity Kind `SCOPE.Pattern` (no new entity Kind).

## Registry cells (REGENERATED coverage docs included)
Two new cells under `orm`/`orm_mapper` (the C# data-mapper bucket where StackExchange.Redis already lives):
- `lang.csharp.mapper.automapper` — `relationship_extraction=full` (cited + proven); DB-ORM capabilities `not_applicable` (object-object mapper, no models/queries/migrations/transactions of its own)
- `lang.csharp.mapper.mapster` — same

Regenerated `docs/coverage/{summary.md,by-category/orm.md,by-language/csharp.md,detail/lang.csharp.mapper.*.md}` committed.

## Fixtures / tests
- `TestObjectMappingAutoMapperMapster` — asserts profile recovery, CreateMap member-map count, profile attribution, forward + reverse MAPS_TO, both Mapster registration forms, and honest-partial `.Adapt<T>()` (no edge)
- `TestObjectMappingIgnoresUnrelated` — pre-filter negative

## Gates (sandbox HOME=/tmp/agsbx-5074)
`go build ./...` ✅ · `go vet ./internal/...` ✅ · `go test ./internal/custom/csharp/... ./internal/extractors/csharp/... ./internal/types/` ✅ · `coverage fmt --check` ✅ (canonical) · `coverage validate` ✅ (0 errors) · regenerated docs/coverage committed.

Deploy-deferred. Sandbox HOME=/tmp/agsbx-5074.

Closes #5074