### PR TITLE
feat(#5075): csharp — Polly/Coravel resilience-policy extraction

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 246 records · **C/C++**: 20 · **clojure**: 4 · **crystal**: 1 · **C#**: 17 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 1 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 15 · **scala**: 14 · **swift**: 5
+**Total**: 247 records · **C/C++**: 20 · **clojure**: 4 · **crystal**: 1 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 1 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 15 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -305,3 +305,10 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [python](../by-language/python.md) | [Celery (task queue)](../detail/lang.python.framework.celery.md) | 🟢 1/1 | 🟢 24/24 | ✅ 7/7 | |
 | [python](../by-language/python.md) | [Dramatiq (task queue)](../detail/lang.python.framework.dramatiq.md) | 🟢 1/1 | 🟢 24/24 | 🟢 5/5 | |
 | [python](../by-language/python.md) | [RQ (Redis Queue)](../detail/lang.python.framework.rq.md) | 🟢 1/1 | 🟢 24/24 | 🟢 6/6 | |
+
+
+## Resilience
+
+| Language | Name | HTTP client binding | Resilience policy extraction | Notes |
+|---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [Polly (.NET resilience / fault-handling)](../detail/lang.csharp.framework.polly.md) | ✅ | ✅ | |

--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 60 records · **C/C++**: 3 · **C#**: 8 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
+**Total**: 61 records · **C/C++**: 3 · **C#**: 9 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -11,6 +11,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 
 | Language | Name | Consumer extraction | Status | Notes |
 |---|---|---|---|---|
+| [C#](../by-language/csharp.md) | [Coravel (.NET task scheduler / queue / mailer)](../detail/msg.coravel.md) | ✅ | ✅ | |
 | [C#](../by-language/csharp.md) | [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | 🟢 | 🟢 | |
 | [C#](../by-language/csharp.md) | [Quartz.NET (.NET job scheduler)](../detail/msg.quartz-net.md) | ✅ | ✅ | |
 | [go](../by-language/go.md) | [robfig/cron (Go scheduler)](../detail/msg.go-cron.md) | 🟢 | 🟢 | |

--- a/docs/coverage/by-language/csharp.md
+++ b/docs/coverage/by-language/csharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # C#
 
-**Frameworks**: 17 · **Tools**: 7 · **ORMs**: 16 · **Other**: 8
+**Frameworks**: 18 · **Tools**: 7 · **ORMs**: 16 · **Other**: 9
 
 Back to [summary](../summary.md).
 
@@ -69,6 +69,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [grpc-dotnet](../detail/lang.csharp.framework.grpc-net.md) | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | 🟢 10/10 | |
 
 
+### Resilience
+
+| Name | HTTP client binding | Resilience policy extraction | Notes |
+|---|---|---|---|
+| [Polly (.NET resilience / fault-handling)](../detail/lang.csharp.framework.polly.md) | ✅ | ✅ | |
+
+
 ## Tools
 
 | Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
@@ -113,6 +120,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Consumer extraction | Notes |
 |---|---|---|
+| [Coravel (.NET task scheduler / queue / mailer)](../detail/msg.coravel.md) | ✅ | |
 | [Hangfire RecurringJob (.NET scheduled jobs)](../detail/msg.hangfire-recurring.md) | 🟢 | |
 | [Quartz.NET (.NET job scheduler)](../detail/msg.quartz-net.md) | ✅ | |
 

--- a/docs/coverage/detail/lang.csharp.framework.polly.md
+++ b/docs/coverage/detail/lang.csharp.framework.polly.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.csharp.framework.polly` — Polly (.NET resilience / fault-handling)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Resilience
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| HTTP client binding | ✅ `full` | `2026-06-13` | 5075 | `internal/custom/csharp/polly_resilience.go`<br>`internal/custom/csharp/polly_resilience_test.go` | #5075: the .NET HttpClientFactory integration is captured -- services.AddHttpClient("name").AddPolicyHandler(policy) (v7) and .AddResilienceHandler("pipeline", b => ...) (v8) emit a resilience_policy marker (resilience_type=http_client_policy) carrying binding=add_policy_handler|add_resilience_handler and the http_client name resolved from the AddHttpClient("name") on the same statement chain, answering 'which HTTP clients are protected by a Polly policy?'. Honest-partial: a policy passed as a cross-file variable resolves the binding + client but not the strategy params (those are recorded on the policy-definition marker when in-file). |
+| Resilience policy extraction | ✅ `full` | `2026-06-13` | 5075 | `internal/custom/csharp/polly_resilience.go`<br>`internal/custom/csharp/polly_resilience_test.go` | #5075 (spun out of #5016/#4969; sibling of the Java MicroProfile @Retry/@CircuitBreaker pass): custom_csharp_polly stamps SCOPE.Pattern(resilience_policy) markers carrying resilience_type + literal params for both Polly surfaces. v7 fluent -- Policy.Handle<T>().Retry(n)/WaitAndRetry(n,...) -> retry (retry_count + handled_exception); .CircuitBreaker(threshold, TimeSpan) -> circuit_breaker (break_threshold + break_seconds); Policy.Timeout(TimeSpan) -> timeout (timeout_seconds); Policy.Bulkhead(maxParallelization:n) -> bulkhead (max_parallel); .Fallback(...) -> fallback. v8 -- new ResiliencePipelineBuilder().AddRetry/AddCircuitBreaker/AddTimeout/AddHedging/AddConcurrencyLimiter/AddRateLimiter(...) -> the same resilience_type taxonomy with MaxRetryAttempts/FailureRatio/BreakDuration/Timeout/MaxParallelization options resolved (api_version=v7|v8). Honest-partial: config-/variable-driven params (Retry(maxRetries)) are omitted rather than guessed; sub-second TimeSpans not rounded. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.csharp.framework.polly ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/msg.coravel.md
+++ b/docs/coverage/detail/msg.coravel.md
@@ -1,0 +1,27 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.coravel` — Coravel (.NET task scheduler / queue / mailer)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C#](../by-language/csharp.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Schedulers
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | ✅ `full` | `2026-06-13` | 5075 | `internal/custom/csharp/coravel.go`<br>`internal/custom/csharp/coravel_test.go` | #5075 (spun out of #5016/#4969): custom_csharp_coravel extracts the consumer side -- class X : IInvocable -> SCOPE.Service(invocable) CONSUMES task:coravel:<X> (the Coravel analogue of a Quartz IJob). The invocable name + task_id join with the producer Schedule<X>()/QueueInvocable<X>() sites. |
+| Producer extraction | ✅ `full` | `2026-06-13` | 5075 | `internal/custom/csharp/coravel.go`<br>`internal/custom/csharp/coravel_test.go` | #5075: producer side -- scheduler.Schedule<T>()/ScheduleAsync<T>() and anonymous Schedule(() => ...) -> SCOPE.Operation(schedule) PRODUCES task:coravel:<T>; IQueue.QueueInvocable<T>()/QueueInvocableWithPayload and QueueAsyncTask/QueueTask -> SCOPE.Operation(queue); IMailer.Send/SendAsync(new XMailable(...)) -> SCOPE.Operation(mail). Schedule<T> and the IInvocable consumer converge on task:coravel:<T>. Honest-partial: a Send(new T()) whose type does not end in 'Mailable' is not stamped as a mail surface. |
+| Topic attribution | ✅ `full` | `2026-06-13` | 5075 | `internal/custom/csharp/coravel.go`<br>`internal/custom/csharp/coravel_test.go` | #5075 (parallels the Quartz.NET schedule-string parse from #4969): the Coravel fluent schedule chain is scanned (bounded to the next ';' so co-located schedules don't bleed) and the cadence is parsed onto the schedule SCOPE.Operation. .Cron("...") -> schedule_type=cron + cron_expression; .DailyAt("hh:mm") -> schedule_type=daily + daily_at; EveryMinute/EveryFiveMinutes/.../Hourly named tokens -> schedule_type=interval (or daily/weekly/monthly) + frequency + interval_seconds; EveryNMinutes/EverySeconds -> interval_seconds normalised from the literal magnitude. Honest-partial: a Schedule<T>() with no recognised frequency token records the producer without a resolved cadence (schedule_type omitted, not guessed). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.coravel ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 246 · **ORMs**: 172 · **Tools**: 120 · **Other**: 203
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 247 · **ORMs**: 172 · **Tools**: 120 · **Other**: 204
 
 ## Coverage by language
 
@@ -12,8 +12,8 @@
 | [java](by-language/java.md) | 23 | 10 | 15 | 4 |
 | [go](by-language/go.md) | 21 | 8 | 17 | 5 |
 | [C/C++](by-language/c-cpp.md) | 20 | 16 | 10 | 4 |
+| [C#](by-language/csharp.md) | 18 | 7 | 16 | 9 |
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
-| [C#](by-language/csharp.md) | 17 | 7 | 16 | 8 |
 | [php](by-language/php.md) | 16 | 6 | 14 | 1 |
 | [rust](by-language/rust.md) | 15 | 6 | 15 | 4 |
 | [elixir](by-language/elixir.md) | 14 | 9 | 10 | 5 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 246 frameworks · 120 tools · 172 ORMs · 203 other
+Total: 247 frameworks · 120 tools · 172 ORMs · 204 other

--- a/internal/custom/csharp/coravel.go
+++ b/internal/custom/csharp/coravel.go
@@ -1,0 +1,304 @@
+// coravel.go — Coravel scheduling / queuing / mailing extraction for C#/.NET
+// (#5075, spun out of #5016 / #4969). Sibling of the Quartz.NET pass
+// (internal/custom/csharp/quartz_net.go) and the Hangfire pass
+// (internal/custom/csharp/hangfire.go); it parses Coravel's fluent scheduler the
+// same way the Quartz.NET trigger chain is parsed.
+//
+// Coravel (github.com/jamesmh/coravel) is a near-zero-config .NET task scheduler
+// / queue / mailer. Its surfaces:
+//
+//   - Invocables (consumers) — class X : IInvocable { Task Invoke() } is the unit
+//     of scheduled / queued work (the Coravel analogue of a Quartz IJob).
+//
+//   - Scheduling (producers) — inside app.Services.UseScheduler(scheduler => {...}):
+//       scheduler.Schedule<SendNewsletter>().EveryMinute();
+//       scheduler.Schedule<Cleanup>().DailyAt("13:00");
+//       scheduler.ScheduleAsync(async () => ...).Hourly();
+//       scheduler.Schedule<T>().Cron("*/5 * * * *");
+//     The fluent frequency call (EveryMinute / Daily / Hourly / Weekly / Monthly /
+//     Cron("...") / DailyAt("hh:mm") / Every*Minutes) is the schedule.
+//
+//   - Queuing (producers) — IQueue.QueueInvocable<T>() / QueueInvocableWithPayload /
+//     QueueAsyncTask(...) dispatch background work to a Coravel invocable.
+//
+//   - Mailing (producers) — IMailer.Send(new XMailable(...)) / SendAsync send a
+//     Mailable.
+//
+// Like the Quartz.NET / rate-limit / Polly passes, each surface adds a flat
+// SCOPE marker (Coravel fluent chains span calls that do not reduce to a single
+// op). The property contract answers "what work is scheduled / queued, on what
+// cadence, and which invocable runs it?":
+//
+//	framework        — "coravel".
+//	pattern_type     — invocable | schedule | queue | mail.
+//	invocable        — the IInvocable type name (the unit of work). For
+//	                   Schedule<T>()/QueueInvocable<T>() it is the generic arg.
+//	schedule_type    — "cron" (.Cron("...")) | "interval" (EveryMinute / Hourly /
+//	                   Every5Minutes / ...) | "daily" (Daily / DailyAt("hh:mm")) |
+//	                   "weekly" | "monthly".
+//	cron_expression  — the cron string from .Cron("...") when literal.
+//	frequency        — the named fluent frequency token (EveryMinute, Hourly,
+//	                   DailyAt, Every5Minutes, ...) — evidence for the cadence.
+//	daily_at         — the "hh:mm" from .DailyAt("13:00") when literal.
+//	interval_seconds — normalised seconds for EveryNMinutes / EverySeconds where
+//	                   the fluent token carries a literal magnitude.
+//	task_id          — "task:coravel:<Invocable>" — the join key between the
+//	                   Schedule<T>()/QueueInvocable<T>() producer and the X :
+//	                   IInvocable consumer (mirrors task:quartz.net:<T>).
+//	edge_kind        — CONSUMES (invocable) | PRODUCES (schedule / queue / mail).
+//
+// Honest-partial: schedules / invocables behind variables or config are recorded
+// without the resolved cadence. A Schedule<T>() with no recognised frequency
+// token records schedule_type unresolved (omitted) rather than guessing.
+//
+// Closes #5075 (Coravel half).
+package csharp
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_coravel", &coravelExtractor{})
+}
+
+type coravelExtractor struct{}
+
+func (e *coravelExtractor) Language() string { return "custom_csharp_coravel" }
+
+var (
+	// class X : IInvocable — the Coravel unit of work (consumer).
+	cvInvocableImplRe = regexp.MustCompile(`(?m)class\s+(\w+)\s*(?::\s*[^{]*\bIInvocable\b)`)
+
+	// scheduler.Schedule<T>() / ScheduleAsync<T>() / ScheduleWithParams<T>()
+	cvScheduleGenericRe = regexp.MustCompile(`\.\s*Schedule(?:Async|WithParams)?\s*<\s*([\w.]+)\s*>\s*\(`)
+	// scheduler.Schedule(() => ...) / ScheduleAsync(async () => ...) — anonymous.
+	cvScheduleAnonRe = regexp.MustCompile(`\.\s*Schedule(?:Async)?\s*\(\s*(?:async\s*)?\(`)
+
+	// IQueue.QueueInvocable<T>() / QueueInvocableWithPayload<T,P>() — queued work.
+	cvQueueInvocableRe = regexp.MustCompile(`\.\s*QueueInvocable(?:WithPayload)?\s*<\s*([\w.]+)`)
+	// IQueue.QueueAsyncTask(...) / QueueTask(...) — anonymous queued work.
+	cvQueueTaskRe = regexp.MustCompile(`\.\s*Queue(?:Async)?Task\s*\(`)
+
+	// IMailer.Send(new XMailable(...)) / SendAsync(...) — mailing.
+	cvMailSendRe = regexp.MustCompile(`\.\s*Send(?:Async)?\s*\(\s*new\s+([\w.]+)`)
+
+	// Cron / named-frequency fluent tokens on a schedule chain.
+	cvCronRe       = regexp.MustCompile(`\.\s*Cron\s*\(\s*"([^"]+)"`)
+	cvDailyAtRe    = regexp.MustCompile(`\.\s*DailyAt\s*\(\s*"([^"]+)"`)
+	cvEveryNMinRe  = regexp.MustCompile(`\.\s*Every(\d+)Minutes\s*\(`)
+	cvEverySecRe   = regexp.MustCompile(`\.\s*EverySeconds\s*\(\s*(\d+)`)
+	cvFrequencyRe  = regexp.MustCompile(
+		`\.\s*(EveryMinute|EveryFiveMinutes|EveryTenMinutes|EveryFifteenMinutes|EveryThirtyMinutes|` +
+			`EverySecond|Hourly|HourlyAt|Daily|DailyAtHour|Weekly|Monthly)\s*\(`)
+)
+
+// cvDailyFreq is the set of named frequencies that mean a once-per-day cadence.
+var cvDailyFreq = map[string]bool{"Daily": true, "DailyAtHour": true}
+
+// coravelChain returns the source window from offset `from` bounded to the next
+// ';' so a co-located schedule's frequency does not bleed into this one. Mirrors
+// the bounded-window scan in quartz_net.go.
+func coravelChain(src string, from int) string {
+	rest := src[from:]
+	if semi := strings.IndexByte(rest, ';'); semi >= 0 {
+		return rest[:semi]
+	}
+	return rest
+}
+
+// parseCoravelSchedule scans a bounded schedule chain and stamps the cadence
+// properties onto ent. It is shared by the generic and anonymous schedule paths.
+func parseCoravelSchedule(ent *types.EntityRecord, chain string) {
+	if cm := cvCronRe.FindStringSubmatch(chain); cm != nil {
+		setProps(ent, "schedule_type", "cron", "cron_expression", cm[1], "frequency", "Cron")
+		return
+	}
+	if dm := cvDailyAtRe.FindStringSubmatch(chain); dm != nil {
+		setProps(ent, "schedule_type", "daily", "daily_at", dm[1], "frequency", "DailyAt")
+		return
+	}
+	if em := cvEveryNMinRe.FindStringSubmatch(chain); em != nil {
+		if n, err := strconv.Atoi(em[1]); err == nil {
+			setProps(ent, "schedule_type", "interval",
+				"interval_seconds", strconv.Itoa(n*60), "frequency", "Every"+em[1]+"Minutes")
+			return
+		}
+	}
+	if sm := cvEverySecRe.FindStringSubmatch(chain); sm != nil {
+		setProps(ent, "schedule_type", "interval", "interval_seconds", sm[1], "frequency", "EverySeconds")
+		return
+	}
+	if fm := cvFrequencyRe.FindStringSubmatch(chain); fm != nil {
+		freq := fm[1]
+		st := "interval"
+		switch {
+		case cvDailyFreq[freq]:
+			st = "daily"
+		case freq == "Weekly":
+			st = "weekly"
+		case freq == "Monthly":
+			st = "monthly"
+		}
+		setProps(ent, "schedule_type", st, "frequency", freq)
+		if secs := coravelNamedInterval[freq]; secs != "" {
+			setProps(ent, "interval_seconds", secs)
+		}
+	}
+}
+
+// coravelNamedInterval gives the literal seconds for the fixed named intervals.
+var coravelNamedInterval = map[string]string{
+	"EveryMinute":         "60",
+	"EveryFiveMinutes":    "300",
+	"EveryTenMinutes":     "600",
+	"EveryFifteenMinutes": "900",
+	"EveryThirtyMinutes":  "1800",
+	"EverySecond":         "1",
+	"Hourly":              "3600",
+}
+
+func (e *coravelExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.csharp_coravel.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "coravel"),
+			attribute.String("file_path", file.Path),
+		))
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "csharp" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Fast guard: a Coravel surface must mention one of the recognised idioms.
+	if !strings.Contains(src, "IInvocable") &&
+		!strings.Contains(src, "Schedule") &&
+		!strings.Contains(src, "QueueInvocable") &&
+		!strings.Contains(src, "QueueAsyncTask") &&
+		!strings.Contains(src, "UseScheduler") &&
+		!strings.Contains(src, "Mailable") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// 1. Consumer: class X : IInvocable.
+	for _, m := range cvInvocableImplRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity(name, "SCOPE.Service", "invocable", file.Path, "csharp", line)
+		setProps(&ent,
+			"framework", "coravel",
+			"pattern_type", "invocable",
+			"invocable", name,
+			"task_id", "task:coravel:"+name,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_CORAVEL_IINVOCABLE",
+		)
+		add(ent)
+	}
+
+	// 2. Producer: scheduler.Schedule<T>().<frequency>().
+	for _, m := range cvScheduleGenericRe.FindAllStringSubmatchIndex(src, -1) {
+		inv := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity("Schedule<"+inv+">", "SCOPE.Operation", "schedule", file.Path, "csharp", line)
+		setProps(&ent,
+			"framework", "coravel",
+			"pattern_type", "schedule",
+			"invocable", inv,
+			"task_id", "task:coravel:"+inv,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_CORAVEL_SCHEDULE",
+		)
+		parseCoravelSchedule(&ent, coravelChain(src, m[1]))
+		add(ent)
+	}
+
+	// 3. Producer: scheduler.Schedule(() => ...).<frequency>() — anonymous work.
+	for _, m := range cvScheduleAnonRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := makeEntity("Schedule@line"+itoa(line), "SCOPE.Operation", "schedule", file.Path, "csharp", line)
+		setProps(&ent,
+			"framework", "coravel",
+			"pattern_type", "schedule",
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_CORAVEL_SCHEDULE_ANON",
+		)
+		parseCoravelSchedule(&ent, coravelChain(src, m[0]))
+		add(ent)
+	}
+
+	// 4. Producer: IQueue.QueueInvocable<T>().
+	for _, m := range cvQueueInvocableRe.FindAllStringSubmatchIndex(src, -1) {
+		inv := src[m[2]:m[3]]
+		line := lineOf(src, m[0])
+		ent := makeEntity("QueueInvocable<"+inv+">", "SCOPE.Operation", "queue", file.Path, "csharp", line)
+		setProps(&ent,
+			"framework", "coravel",
+			"pattern_type", "queue",
+			"invocable", inv,
+			"task_id", "task:coravel:"+inv,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_CORAVEL_QUEUE",
+		)
+		add(ent)
+	}
+
+	// 5. Producer: IQueue.QueueAsyncTask(...) — anonymous queued work.
+	for _, m := range cvQueueTaskRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := makeEntity("QueueTask@line"+itoa(line), "SCOPE.Operation", "queue", file.Path, "csharp", line)
+		setProps(&ent,
+			"framework", "coravel",
+			"pattern_type", "queue",
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_CORAVEL_QUEUE_TASK",
+		)
+		add(ent)
+	}
+
+	// 6. Producer: IMailer.Send(new XMailable(...)).
+	for _, m := range cvMailSendRe.FindAllStringSubmatchIndex(src, -1) {
+		mailable := src[m[2]:m[3]]
+		// Skip obvious non-mailable Send(new ...) calls — require a "Mailable"
+		// suffix so this stays a Coravel mailing surface, not any Send(new T()).
+		if !strings.HasSuffix(mailable, "Mailable") {
+			continue
+		}
+		line := lineOf(src, m[0])
+		ent := makeEntity("Send<"+mailable+">", "SCOPE.Operation", "mail", file.Path, "csharp", line)
+		setProps(&ent,
+			"framework", "coravel",
+			"pattern_type", "mail",
+			"mailable", mailable,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_CORAVEL_MAIL",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/csharp/coravel_test.go
+++ b/internal/custom/csharp/coravel_test.go
@@ -1,0 +1,209 @@
+package csharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
+)
+
+// findCoravelSubtype returns the first entity of the given subtype, or nil.
+func findCoravelSubtype(ents []types.EntityRecord, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestCoravel_Invocable(t *testing.T) {
+	src := `
+public class SendNewsletter : IInvocable
+{
+    public Task Invoke() => Task.CompletedTask;
+}
+`
+	ents := extractFull(t, "custom_csharp_coravel", fi("SendNewsletter.cs", "csharp", src))
+	inv := findCoravelSubtype(ents, "invocable")
+	if inv == nil {
+		t.Fatal("expected an invocable entity")
+	}
+	if inv.Name != "SendNewsletter" {
+		t.Errorf("name = %q, want SendNewsletter", inv.Name)
+	}
+	if got := inv.Properties["task_id"]; got != "task:coravel:SendNewsletter" {
+		t.Errorf("task_id = %q, want task:coravel:SendNewsletter", got)
+	}
+	if got := inv.Properties["edge_kind"]; got != "CONSUMES" {
+		t.Errorf("edge_kind = %q, want CONSUMES", got)
+	}
+	if inv.Kind != "SCOPE.Service" {
+		t.Errorf("kind = %q, want SCOPE.Service", inv.Kind)
+	}
+}
+
+func TestCoravel_ScheduleEveryMinute(t *testing.T) {
+	src := `
+scheduler.Schedule<SendNewsletter>().EveryMinute();
+`
+	ents := extractFull(t, "custom_csharp_coravel", fi("Sched.cs", "csharp", src))
+	s := findCoravelSubtype(ents, "schedule")
+	if s == nil {
+		t.Fatal("expected a schedule entity")
+	}
+	if got := s.Properties["invocable"]; got != "SendNewsletter" {
+		t.Errorf("invocable = %q, want SendNewsletter", got)
+	}
+	if got := s.Properties["schedule_type"]; got != "interval" {
+		t.Errorf("schedule_type = %q, want interval", got)
+	}
+	if got := s.Properties["frequency"]; got != "EveryMinute" {
+		t.Errorf("frequency = %q, want EveryMinute", got)
+	}
+	if got := s.Properties["interval_seconds"]; got != "60" {
+		t.Errorf("interval_seconds = %q, want 60", got)
+	}
+	if got := s.Properties["task_id"]; got != "task:coravel:SendNewsletter" {
+		t.Errorf("task_id = %q, want task:coravel:SendNewsletter", got)
+	}
+	if got := s.Properties["edge_kind"]; got != "PRODUCES" {
+		t.Errorf("edge_kind = %q, want PRODUCES", got)
+	}
+}
+
+func TestCoravel_ScheduleCron(t *testing.T) {
+	src := `scheduler.Schedule<Cleanup>().Cron("*/5 * * * *");`
+	ents := extractFull(t, "custom_csharp_coravel", fi("Sched.cs", "csharp", src))
+	s := findCoravelSubtype(ents, "schedule")
+	if s == nil {
+		t.Fatal("expected a schedule entity")
+	}
+	if got := s.Properties["schedule_type"]; got != "cron" {
+		t.Errorf("schedule_type = %q, want cron", got)
+	}
+	if got := s.Properties["cron_expression"]; got != "*/5 * * * *" {
+		t.Errorf("cron_expression = %q, want */5 * * * *", got)
+	}
+}
+
+func TestCoravel_ScheduleDailyAt(t *testing.T) {
+	src := `scheduler.Schedule<Report>().DailyAt("13:00");`
+	ents := extractFull(t, "custom_csharp_coravel", fi("Sched.cs", "csharp", src))
+	s := findCoravelSubtype(ents, "schedule")
+	if s == nil {
+		t.Fatal("expected a schedule entity")
+	}
+	if got := s.Properties["schedule_type"]; got != "daily" {
+		t.Errorf("schedule_type = %q, want daily", got)
+	}
+	if got := s.Properties["daily_at"]; got != "13:00" {
+		t.Errorf("daily_at = %q, want 13:00", got)
+	}
+}
+
+func TestCoravel_ScheduleEveryNMinutes(t *testing.T) {
+	src := `scheduler.Schedule<Sync>().Every5Minutes();`
+	ents := extractFull(t, "custom_csharp_coravel", fi("Sched.cs", "csharp", src))
+	s := findCoravelSubtype(ents, "schedule")
+	if s == nil {
+		t.Fatal("expected a schedule entity")
+	}
+	if got := s.Properties["interval_seconds"]; got != "300" {
+		t.Errorf("interval_seconds = %q, want 300", got)
+	}
+	if got := s.Properties["frequency"]; got != "Every5Minutes" {
+		t.Errorf("frequency = %q, want Every5Minutes", got)
+	}
+}
+
+func TestCoravel_ScheduleAnonymousHourly(t *testing.T) {
+	src := `scheduler.Schedule(() => Console.WriteLine("tick")).Hourly();`
+	ents := extractFull(t, "custom_csharp_coravel", fi("Sched.cs", "csharp", src))
+	s := findCoravelSubtype(ents, "schedule")
+	if s == nil {
+		t.Fatal("expected a schedule entity")
+	}
+	if got := s.Properties["frequency"]; got != "Hourly" {
+		t.Errorf("frequency = %q, want Hourly", got)
+	}
+	if got := s.Properties["interval_seconds"]; got != "3600" {
+		t.Errorf("interval_seconds = %q, want 3600", got)
+	}
+}
+
+func TestCoravel_QueueInvocable(t *testing.T) {
+	src := `_queue.QueueInvocable<GrabDataFromApi>();`
+	ents := extractFull(t, "custom_csharp_coravel", fi("Q.cs", "csharp", src))
+	q := findCoravelSubtype(ents, "queue")
+	if q == nil {
+		t.Fatal("expected a queue entity")
+	}
+	if got := q.Properties["invocable"]; got != "GrabDataFromApi" {
+		t.Errorf("invocable = %q, want GrabDataFromApi", got)
+	}
+	if got := q.Properties["task_id"]; got != "task:coravel:GrabDataFromApi" {
+		t.Errorf("task_id = %q, want task:coravel:GrabDataFromApi", got)
+	}
+}
+
+func TestCoravel_Mail(t *testing.T) {
+	src := `await _mailer.SendAsync(new WelcomeMailable(user));`
+	ents := extractFull(t, "custom_csharp_coravel", fi("M.cs", "csharp", src))
+	m := findCoravelSubtype(ents, "mail")
+	if m == nil {
+		t.Fatal("expected a mail entity")
+	}
+	if got := m.Properties["mailable"]; got != "WelcomeMailable" {
+		t.Errorf("mailable = %q, want WelcomeMailable", got)
+	}
+}
+
+// Consumer + producer converge on the same task:coravel:<T> id.
+func TestCoravel_ConsumerProducerJoin(t *testing.T) {
+	src := `
+public class SendNewsletter : IInvocable
+{
+    public Task Invoke() => Task.CompletedTask;
+}
+
+public static void Configure(IServiceProvider services)
+{
+    services.UseScheduler(scheduler =>
+    {
+        scheduler.Schedule<SendNewsletter>().Daily();
+    });
+}
+`
+	ents := extractFull(t, "custom_csharp_coravel", fi("App.cs", "csharp", src))
+	inv := findCoravelSubtype(ents, "invocable")
+	s := findCoravelSubtype(ents, "schedule")
+	if inv == nil || s == nil {
+		t.Fatalf("expected both invocable and schedule, got inv=%v sched=%v", inv != nil, s != nil)
+	}
+	if inv.Properties["task_id"] != s.Properties["task_id"] {
+		t.Errorf("task_id mismatch: invocable=%q schedule=%q",
+			inv.Properties["task_id"], s.Properties["task_id"])
+	}
+	if got := s.Properties["schedule_type"]; got != "daily" {
+		t.Errorf("schedule_type = %q, want daily", got)
+	}
+}
+
+// Negative: a Send(new Foo()) that is not a *Mailable is not a mail surface.
+func TestCoravel_MailNonMailableSkipped(t *testing.T) {
+	src := `scheduler.Schedule<X>().EveryMinute(); channel.Send(new Message());`
+	ents := extractFull(t, "custom_csharp_coravel", fi("M.cs", "csharp", src))
+	if m := findCoravelSubtype(ents, "mail"); m != nil {
+		t.Errorf("expected no mail entity for non-Mailable Send, got %q", m.Name)
+	}
+}
+
+func TestCoravel_NoMatch(t *testing.T) {
+	src := `public class Foo { public void Bar() {} }`
+	ents := extractFull(t, "custom_csharp_coravel", fi("Foo.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/csharp/polly_resilience.go
+++ b/internal/custom/csharp/polly_resilience.go
@@ -1,0 +1,379 @@
+// polly_resilience.go — Polly resilience-policy extraction for C#/.NET (#5075,
+// spun out of #5016 / #4969). Sibling of the Java MicroProfile fault-tolerance
+// pass (internal/custom/java/microprofile.go: @Retry / @CircuitBreaker /
+// @Fallback -> SCOPE.Pattern markers carrying fault_tolerance_type) and the
+// C#/.NET rate-limit pass (internal/custom/csharp/rate_limit_endpoint.go).
+//
+// Polly is the de-facto .NET resilience library. It exposes two surfaces:
+//
+//   - v7 fluent policies —
+//       Policy.Handle<HttpRequestException>().Retry(3)
+//       Policy.Handle<T>().WaitAndRetryAsync(3, attempt => ...)
+//       Policy.Handle<T>().CircuitBreaker(2, TimeSpan.FromMinutes(1))
+//       Policy.Timeout(TimeSpan.FromSeconds(10))
+//       Policy.Bulkhead(maxParallelization: 12)
+//       Policy.Handle<T>().Fallback(fallbackValue)
+//
+//   - v8 ResiliencePipelineBuilder —
+//       new ResiliencePipelineBuilder()
+//           .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 3 })
+//           .AddCircuitBreaker(new CircuitBreakerStrategyOptions { ... })
+//           .AddTimeout(TimeSpan.FromSeconds(10))
+//           .Build();
+//
+// Either surface may be attached to an HttpClient via the .NET HttpClientFactory
+// integration: services.AddHttpClient("x").AddPolicyHandler(policy) (v7) or
+// .AddResilienceHandler("pipeline", b => b.AddRetry(...)) (v8). Those bindings
+// say "this HTTP client is protected by a resilience policy".
+//
+// Like the rate-limit and MicroProfile passes, each recognised surface adds a
+// flat SCOPE.Pattern/resilience_policy marker (Polly policies span fluent chains
+// and option lambdas that do not reduce to a single call op). The flat property
+// contract answers "which calls / HTTP clients are protected, by what kind of
+// policy, and with what parameters?":
+//
+//	framework        — "polly".
+//	kind             — "resilience_policy".
+//	resilience_type  — retry | circuit_breaker | timeout | bulkhead | fallback |
+//	                   hedging | rate_limiter (the policy strategy).
+//	api_version      — "v7" (fluent Policy.*) | "v8" (ResiliencePipelineBuilder).
+//	retry_count      — the retry attempt count when a literal is resolvable
+//	                   (Retry(3) / MaxRetryAttempts = 3 / WaitAndRetry(5, ...)).
+//	timeout_seconds  — the timeout window in seconds when a literal TimeSpan is
+//	                   resolvable (Timeout(TimeSpan.FromSeconds(10)) / Timeout =
+//	                   TimeSpan.FromSeconds(10)).
+//	break_seconds    — the circuit-breaker open duration in seconds when literal
+//	                   (CircuitBreaker(2, TimeSpan.FromMinutes(1))).
+//	break_threshold  — the circuit-breaker failure threshold when literal
+//	                   (CircuitBreaker(2, ...) / FailureThreshold = ...).
+//	max_parallel     — the bulkhead max-parallelization when literal.
+//	handled_exception— the first Handle<T>() exception type (evidence).
+//	http_client      — the HttpClient name when bound via AddPolicyHandler /
+//	                   AddResilienceHandler on AddHttpClient("name").
+//	binding          — "add_policy_handler" | "add_resilience_handler" when the
+//	                   policy is wired to an HttpClient (else omitted).
+//
+// Honest-partial: parameters that are config-/variable-driven (not in-file
+// literals) are omitted rather than guessed. Cross-file policy variables passed
+// to AddPolicyHandler(myPolicy) record the binding + http_client but resolve no
+// strategy params.
+//
+// Closes #5075 (Polly half).
+package csharp
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_polly", &pollyExtractor{})
+}
+
+type pollyExtractor struct{}
+
+func (e *pollyExtractor) Language() string { return "custom_csharp_polly" }
+
+var (
+	// Policy.Handle<HttpRequestException>() — the v7 exception predicate that
+	// opens a fluent policy chain. Captures the first handled exception type.
+	pollyHandleRe = regexp.MustCompile(`Policy(?:<[^>]*>)?\s*\.\s*Handle(?:Inner)?\s*<\s*([\w.]+)\s*>`)
+
+	// v7 fluent strategy calls. Each opens a resilience policy of the named kind.
+	//   .Retry(3) / .RetryAsync() / .RetryForever()
+	//   .WaitAndRetry(5, ...) / .WaitAndRetryAsync(...)
+	//   .CircuitBreaker(2, TimeSpan.FromMinutes(1)) / .AdvancedCircuitBreaker(...)
+	//   Policy.Timeout(...) / Policy.TimeoutAsync(...)
+	//   Policy.Bulkhead(12) / Policy.BulkheadAsync(...)
+	//   .Fallback(...) / .FallbackAsync(...)
+	pollyRetryRe   = regexp.MustCompile(`\.\s*(?:WaitAndRetry|Retry)(?:Forever)?(?:Async)?\s*\(`)
+	pollyCBRe      = regexp.MustCompile(`\.\s*(?:Advanced)?CircuitBreaker(?:Async)?\s*\(`)
+	pollyTimeoutRe = regexp.MustCompile(`\bPolicy\s*\.\s*Timeout(?:Async)?\s*\(`)
+	pollyBulkRe    = regexp.MustCompile(`\bPolicy\s*\.\s*Bulkhead(?:Async)?\s*\(`)
+	pollyFallRe    = regexp.MustCompile(`\.\s*Fallback(?:Async)?\s*\(`)
+
+	// v8 ResiliencePipelineBuilder strategy calls.
+	//   new ResiliencePipelineBuilder<T>() ... .AddRetry(...) .AddCircuitBreaker(...)
+	//   .AddTimeout(...) .AddHedging(...) .AddRateLimiter(...) .AddConcurrencyLimiter(...)
+	pollyPipelineRe   = regexp.MustCompile(`\bResiliencePipelineBuilder\b`)
+	pollyAddStrategyRe = regexp.MustCompile(
+		`\.\s*Add(Retry|CircuitBreaker|Timeout|Hedging|ConcurrencyLimiter|RateLimiter)\s*\(`)
+
+	// HttpClientFactory bindings — these attach a policy/pipeline to a named client.
+	//   services.AddHttpClient("github").AddPolicyHandler(retryPolicy);     (v7)
+	//   services.AddHttpClient("github").AddResilienceHandler("p", b => ...); (v8)
+	pollyAddPolicyHandlerRe     = regexp.MustCompile(`\.\s*AddPolicyHandler\s*\(`)
+	pollyAddResilienceHandlerRe = regexp.MustCompile(`\.\s*AddResilienceHandler\s*\(`)
+	// AddHttpClient("name") — captures the named client a handler binds onto.
+	pollyAddHttpClientRe = regexp.MustCompile(`\.\s*AddHttpClient\s*(?:<[^>]*>)?\s*\(\s*"([^"]+)"`)
+
+	// Literal parameter resolvers (in-file only; config/variable args are partial).
+	pollyRetryArgRe       = regexp.MustCompile(`\b(?:Retry|WaitAndRetry)(?:Async)?\s*\(\s*(\d+)`)
+	pollyMaxRetryOptRe    = regexp.MustCompile(`\bMaxRetryAttempts\s*=\s*(\d+)`)
+	pollyCBThreshArgRe    = regexp.MustCompile(`\bCircuitBreaker(?:Async)?\s*\(\s*(\d+)`)
+	pollyCBThreshOptRe    = regexp.MustCompile(`\b(?:FailureThreshold|FailureRatio)\s*=\s*([\d.]+)`)
+	pollyTimeSpanRe       = regexp.MustCompile(`TimeSpan\.From(Seconds|Minutes|Hours|Milliseconds)\s*\(\s*(\d+)`)
+	pollyBulkArgRe        = regexp.MustCompile(`\bBulkhead(?:Async)?\s*\(\s*(?:maxParallelization\s*:\s*)?(\d+)`)
+	pollyMaxParallelOptRe = regexp.MustCompile(`\bMaxParallelization\s*=\s*(\d+)`)
+)
+
+// pollyTimeSpanSeconds converts a TimeSpan.From<Unit>(n) (unit, magnitude) to
+// whole seconds, or "" when the unit is sub-second/unknown.
+func pollyTimeSpanSeconds(unit, mag string) string {
+	n, err := strconv.Atoi(mag)
+	if err != nil {
+		return ""
+	}
+	switch unit {
+	case "Seconds":
+	case "Minutes":
+		n *= 60
+	case "Hours":
+		n *= 3600
+	case "Milliseconds":
+		if n%1000 != 0 {
+			return "" // sub-second; honest-partial rather than round
+		}
+		n /= 1000
+	default:
+		return ""
+	}
+	return strconv.Itoa(n)
+}
+
+// pollyChain returns the source window from offset `from` bounded to the next
+// ';' (statement terminator), so params from a later policy in the same file
+// do not bleed into this one. Mirrors the bounded-window scan used by the
+// Quartz.NET and rate-limit passes.
+func pollyChain(src string, from int) string {
+	rest := src[from:]
+	if semi := strings.IndexByte(rest, ';'); semi >= 0 {
+		return rest[:semi]
+	}
+	return rest
+}
+
+func (e *pollyExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.csharp_polly.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "polly"),
+			attribute.String("file_path", file.Path),
+		))
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "csharp" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	// Fast guard.
+	if !strings.Contains(src, "Policy") &&
+		!strings.Contains(src, "ResiliencePipelineBuilder") &&
+		!strings.Contains(src, "AddPolicyHandler") &&
+		!strings.Contains(src, "AddResilienceHandler") {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Subtype + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// marker builds a resilience_policy SCOPE.Pattern marker.
+	marker := func(resType, apiVersion string, line int) types.EntityRecord {
+		name := "polly:" + resType + ":" + file.Path + ":" + itoa(line)
+		ent := makeEntity(name, "SCOPE.Pattern", "resilience_policy", file.Path, "csharp", line)
+		setProps(&ent,
+			"framework", "polly",
+			"kind", "resilience_policy",
+			"resilience_type", resType,
+			"api_version", apiVersion,
+			"provenance", "INFERRED_FROM_POLLY",
+		)
+		return ent
+	}
+
+	// firstHandled returns the nearest preceding Handle<T>() exception type for a
+	// v7 fluent strategy, scanning back from the strategy call to the start of the
+	// statement (the previous ';' or '='). Honest-partial: "" when none in-file.
+	firstHandled := func(callOff int) string {
+		start := 0
+		for _, sep := range []byte{';', '='} {
+			if i := strings.LastIndexByte(src[:callOff], sep); i > start {
+				start = i
+			}
+		}
+		seg := src[start:callOff]
+		if m := pollyHandleRe.FindStringSubmatch(seg); m != nil {
+			return m[1]
+		}
+		return ""
+	}
+
+	// 1. v7 Retry / WaitAndRetry.
+	for _, m := range pollyRetryRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := marker("retry", "v7", line)
+		chain := pollyChain(src, m[0])
+		if rm := pollyRetryArgRe.FindStringSubmatch(chain); rm != nil {
+			setProps(&ent, "retry_count", rm[1])
+		}
+		if h := firstHandled(m[0]); h != "" {
+			setProps(&ent, "handled_exception", h)
+		}
+		add(ent)
+	}
+
+	// 2. v7 CircuitBreaker / AdvancedCircuitBreaker.
+	for _, m := range pollyCBRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := marker("circuit_breaker", "v7", line)
+		chain := pollyChain(src, m[0])
+		if cm := pollyCBThreshArgRe.FindStringSubmatch(chain); cm != nil {
+			setProps(&ent, "break_threshold", cm[1])
+		}
+		if ts := pollyTimeSpanRe.FindStringSubmatch(chain); ts != nil {
+			if secs := pollyTimeSpanSeconds(ts[1], ts[2]); secs != "" {
+				setProps(&ent, "break_seconds", secs)
+			}
+		}
+		if h := firstHandled(m[0]); h != "" {
+			setProps(&ent, "handled_exception", h)
+		}
+		add(ent)
+	}
+
+	// 3. v7 Policy.Timeout.
+	for _, m := range pollyTimeoutRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := marker("timeout", "v7", line)
+		chain := pollyChain(src, m[0])
+		if ts := pollyTimeSpanRe.FindStringSubmatch(chain); ts != nil {
+			if secs := pollyTimeSpanSeconds(ts[1], ts[2]); secs != "" {
+				setProps(&ent, "timeout_seconds", secs)
+			}
+		}
+		add(ent)
+	}
+
+	// 4. v7 Policy.Bulkhead.
+	for _, m := range pollyBulkRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := marker("bulkhead", "v7", line)
+		chain := pollyChain(src, m[0])
+		if bm := pollyBulkArgRe.FindStringSubmatch(chain); bm != nil {
+			setProps(&ent, "max_parallel", bm[1])
+		}
+		add(ent)
+	}
+
+	// 5. v7 Fallback.
+	for _, m := range pollyFallRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := marker("fallback", "v7", line)
+		if h := firstHandled(m[0]); h != "" {
+			setProps(&ent, "handled_exception", h)
+		}
+		add(ent)
+	}
+
+	// 6. v8 ResiliencePipelineBuilder strategies. Only emit when a pipeline
+	//    builder is present in-file (the .Add* names are otherwise ambiguous).
+	if pollyPipelineRe.MatchString(src) {
+		for _, m := range pollyAddStrategyRe.FindAllStringSubmatchIndex(src, -1) {
+			strategy := src[m[2]:m[3]]
+			line := lineOf(src, m[0])
+			resType := pollyV8Strategy[strategy]
+			ent := marker(resType, "v8", line)
+			chain := pollyChain(src, m[0])
+			switch resType {
+			case "retry":
+				if rm := pollyMaxRetryOptRe.FindStringSubmatch(chain); rm != nil {
+					setProps(&ent, "retry_count", rm[1])
+				}
+			case "circuit_breaker":
+				if cm := pollyCBThreshOptRe.FindStringSubmatch(chain); cm != nil {
+					setProps(&ent, "break_threshold", cm[1])
+				}
+				if ts := pollyTimeSpanRe.FindStringSubmatch(chain); ts != nil {
+					if secs := pollyTimeSpanSeconds(ts[1], ts[2]); secs != "" {
+						setProps(&ent, "break_seconds", secs)
+					}
+				}
+			case "timeout":
+				if ts := pollyTimeSpanRe.FindStringSubmatch(chain); ts != nil {
+					if secs := pollyTimeSpanSeconds(ts[1], ts[2]); secs != "" {
+						setProps(&ent, "timeout_seconds", secs)
+					}
+				}
+			case "bulkhead":
+				if bm := pollyMaxParallelOptRe.FindStringSubmatch(chain); bm != nil {
+					setProps(&ent, "max_parallel", bm[1])
+				}
+			}
+			add(ent)
+		}
+	}
+
+	// 7. HttpClientFactory bindings — AddPolicyHandler / AddResilienceHandler on
+	//    an AddHttpClient("name") chain attach a resilience policy to the client.
+	clientName := func(callOff int) string {
+		// Scan back to the statement start and find the AddHttpClient("name").
+		start := 0
+		if i := strings.LastIndexByte(src[:callOff], ';'); i >= 0 {
+			start = i
+		}
+		seg := src[start:callOff]
+		if hm := pollyAddHttpClientRe.FindStringSubmatch(seg); hm != nil {
+			return hm[1]
+		}
+		return ""
+	}
+	for _, m := range pollyAddPolicyHandlerRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := marker("http_client_policy", "v7", line)
+		setProps(&ent, "binding", "add_policy_handler")
+		if c := clientName(m[0]); c != "" {
+			setProps(&ent, "http_client", c)
+		}
+		add(ent)
+	}
+	for _, m := range pollyAddResilienceHandlerRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, m[0])
+		ent := marker("http_client_policy", "v8", line)
+		setProps(&ent, "binding", "add_resilience_handler")
+		if c := clientName(m[0]); c != "" {
+			setProps(&ent, "http_client", c)
+		}
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+// pollyV8Strategy maps a v8 .Add*(...) strategy token to the resilience_type.
+var pollyV8Strategy = map[string]string{
+	"Retry":              "retry",
+	"CircuitBreaker":     "circuit_breaker",
+	"Timeout":            "timeout",
+	"Hedging":            "hedging",
+	"ConcurrencyLimiter": "bulkhead",
+	"RateLimiter":        "rate_limiter",
+}

--- a/internal/custom/csharp/polly_resilience_test.go
+++ b/internal/custom/csharp/polly_resilience_test.go
@@ -1,0 +1,232 @@
+package csharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/csharp"
+)
+
+// findResilience returns the first resilience_policy entity of the given
+// resilience_type, or nil.
+func findResilience(ents []types.EntityRecord, resType string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Subtype == "resilience_policy" && ents[i].Properties["resilience_type"] == resType {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func TestPolly_V7Retry(t *testing.T) {
+	src := `
+var policy = Policy
+    .Handle<HttpRequestException>()
+    .Retry(3);
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("Resilience.cs", "csharp", src))
+	r := findResilience(ents, "retry")
+	if r == nil {
+		t.Fatal("expected a retry resilience_policy")
+	}
+	if got := r.Properties["retry_count"]; got != "3" {
+		t.Errorf("retry_count = %q, want 3", got)
+	}
+	if got := r.Properties["handled_exception"]; got != "HttpRequestException" {
+		t.Errorf("handled_exception = %q, want HttpRequestException", got)
+	}
+	if got := r.Properties["api_version"]; got != "v7" {
+		t.Errorf("api_version = %q, want v7", got)
+	}
+	if got := r.Properties["framework"]; got != "polly" {
+		t.Errorf("framework = %q, want polly", got)
+	}
+}
+
+func TestPolly_V7WaitAndRetryAsync(t *testing.T) {
+	src := `
+var policy = Policy
+    .Handle<SqlException>()
+    .WaitAndRetryAsync(5, attempt => TimeSpan.FromSeconds(attempt));
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "retry")
+	if r == nil {
+		t.Fatal("expected a retry resilience_policy")
+	}
+	if got := r.Properties["retry_count"]; got != "5" {
+		t.Errorf("retry_count = %q, want 5", got)
+	}
+}
+
+func TestPolly_V7CircuitBreaker(t *testing.T) {
+	src := `
+var cb = Policy
+    .Handle<BrokenCircuitException>()
+    .CircuitBreaker(2, TimeSpan.FromMinutes(1));
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "circuit_breaker")
+	if r == nil {
+		t.Fatal("expected a circuit_breaker resilience_policy")
+	}
+	if got := r.Properties["break_threshold"]; got != "2" {
+		t.Errorf("break_threshold = %q, want 2", got)
+	}
+	if got := r.Properties["break_seconds"]; got != "60" {
+		t.Errorf("break_seconds = %q, want 60", got)
+	}
+}
+
+func TestPolly_V7Timeout(t *testing.T) {
+	src := `var t = Policy.Timeout(TimeSpan.FromSeconds(10));`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "timeout")
+	if r == nil {
+		t.Fatal("expected a timeout resilience_policy")
+	}
+	if got := r.Properties["timeout_seconds"]; got != "10" {
+		t.Errorf("timeout_seconds = %q, want 10", got)
+	}
+}
+
+func TestPolly_V7Bulkhead(t *testing.T) {
+	src := `var b = Policy.Bulkhead(maxParallelization: 12);`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "bulkhead")
+	if r == nil {
+		t.Fatal("expected a bulkhead resilience_policy")
+	}
+	if got := r.Properties["max_parallel"]; got != "12" {
+		t.Errorf("max_parallel = %q, want 12", got)
+	}
+}
+
+func TestPolly_V7Fallback(t *testing.T) {
+	src := `
+var f = Policy<int>
+    .Handle<Exception>()
+    .Fallback(-1);
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "fallback")
+	if r == nil {
+		t.Fatal("expected a fallback resilience_policy")
+	}
+	if got := r.Properties["handled_exception"]; got != "Exception" {
+		t.Errorf("handled_exception = %q, want Exception", got)
+	}
+}
+
+func TestPolly_V8Pipeline(t *testing.T) {
+	src := `
+var pipeline = new ResiliencePipelineBuilder()
+    .AddRetry(new RetryStrategyOptions { MaxRetryAttempts = 4 })
+    .AddTimeout(TimeSpan.FromSeconds(30))
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "retry")
+	if r == nil {
+		t.Fatal("expected a retry resilience_policy")
+	}
+	if got := r.Properties["api_version"]; got != "v8" {
+		t.Errorf("api_version = %q, want v8", got)
+	}
+	if got := r.Properties["retry_count"]; got != "4" {
+		t.Errorf("retry_count = %q, want 4", got)
+	}
+	to := findResilience(ents, "timeout")
+	if to == nil {
+		t.Fatal("expected a timeout resilience_policy")
+	}
+	if got := to.Properties["timeout_seconds"]; got != "30" {
+		t.Errorf("timeout_seconds = %q, want 30", got)
+	}
+}
+
+func TestPolly_V8CircuitBreakerOptions(t *testing.T) {
+	src := `
+var p = new ResiliencePipelineBuilder<string>()
+    .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+    {
+        FailureRatio = 0.5,
+        BreakDuration = TimeSpan.FromMinutes(2)
+    })
+    .Build();
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "circuit_breaker")
+	if r == nil {
+		t.Fatal("expected a circuit_breaker resilience_policy")
+	}
+	if got := r.Properties["break_threshold"]; got != "0.5" {
+		t.Errorf("break_threshold = %q, want 0.5", got)
+	}
+	if got := r.Properties["break_seconds"]; got != "120" {
+		t.Errorf("break_seconds = %q, want 120", got)
+	}
+}
+
+func TestPolly_AddPolicyHandler(t *testing.T) {
+	src := `
+services.AddHttpClient("github")
+    .AddPolicyHandler(retryPolicy);
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "http_client_policy")
+	if r == nil {
+		t.Fatal("expected an http_client_policy resilience_policy")
+	}
+	if got := r.Properties["binding"]; got != "add_policy_handler" {
+		t.Errorf("binding = %q, want add_policy_handler", got)
+	}
+	if got := r.Properties["http_client"]; got != "github" {
+		t.Errorf("http_client = %q, want github", got)
+	}
+}
+
+func TestPolly_AddResilienceHandler(t *testing.T) {
+	src := `
+services.AddHttpClient("orders")
+    .AddResilienceHandler("pipeline", b => b.AddRetry(new RetryStrategyOptions()));
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "http_client_policy")
+	if r == nil {
+		t.Fatal("expected an http_client_policy resilience_policy")
+	}
+	if got := r.Properties["binding"]; got != "add_resilience_handler" {
+		t.Errorf("binding = %q, want add_resilience_handler", got)
+	}
+	if got := r.Properties["http_client"]; got != "orders" {
+		t.Errorf("http_client = %q, want orders", got)
+	}
+}
+
+// Negative: a file with no Polly idiom yields nothing.
+func TestPolly_NoMatch(t *testing.T) {
+	src := `public class Foo { public void Bar() { var x = 1; } }`
+	ents := extractFull(t, "custom_csharp_polly", fi("Foo.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// Honest-partial: a config-driven retry count is omitted rather than guessed.
+func TestPolly_PartialRetryCount(t *testing.T) {
+	src := `
+var policy = Policy
+    .Handle<Exception>()
+    .Retry(maxRetries);
+`
+	ents := extractFull(t, "custom_csharp_polly", fi("R.cs", "csharp", src))
+	r := findResilience(ents, "retry")
+	if r == nil {
+		t.Fatal("expected a retry resilience_policy")
+	}
+	if got, ok := r.Properties["retry_count"]; ok {
+		t.Errorf("retry_count should be omitted (variable arg), got %q", got)
+	}
+}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -50,7 +50,7 @@ categories:
     capabilities: [call_line_precision, discriminates_on, navigates_to, core_extraction, import_resolution_quality, db_effect, fs_effect, http_effect]
   http_framework:
     capabilities: [endpoint_synthesis, handler_attribution, auth_coverage, middleware_coverage]
-    subcategory_order: [http_backend, jvm_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration, task_queue]
+    subcategory_order: [http_backend, jvm_backend, ui_frontend, meta_framework, mobile, desktop, rpc_framework, static_site, ai_integration, task_queue, resilience]
   orm:
     capabilities: [model_extraction, query_attribution, migration_parsing, migration_schema_ops]
     subcategory_order: [orm_mapper]
@@ -640,6 +640,14 @@ subcategories:
         keys: [tests_linkage]
       - name: Substrate
         keys: [constant_propagation, env_fallback_recognition, config_consumption, error_flow, feature_flag_gating, import_resolution_quality, confidence_overlay, reachability_analysis, dead_code_detection, db_effect, http_effect, fs_effect, mutation_effect, request_shape_extraction, response_shape_extraction, schema_drift_detection, taint_source_detection, taint_sink_detection, sanitizer_recognition, vulnerability_finding, pure_function_tagging, module_cycle_detection, def_use_chain_extraction, template_pattern_catalog]
+
+  resilience:
+    display: "Resilience"
+    parent_category: http_framework
+    capabilities:
+      - resilience_policy_extraction
+      - http_client_binding
+    groups: []
 
   orm_mapper:
     display: "ORM / Data Mapper"


### PR DESCRIPTION
## What

Closes the deferred low-priority **#5075** (spun out of #5016 / #4969): C# Polly resilience-policy + Coravel scheduling extraction.

### Polly — `internal/custom/csharp/polly_resilience.go` (`custom_csharp_polly`)
Emits `SCOPE.Pattern(resilience_policy)` markers carrying `resilience_type` + literal params for both Polly surfaces:
- **v7 fluent** — `Policy.Handle<T>().Retry(n)/WaitAndRetry(n,...)` → `retry` (`retry_count`, `handled_exception`); `.CircuitBreaker(threshold, TimeSpan)` → `circuit_breaker` (`break_threshold`, `break_seconds`); `Policy.Timeout(TimeSpan)` → `timeout` (`timeout_seconds`); `Policy.Bulkhead(maxParallelization:n)` → `bulkhead` (`max_parallel`); `.Fallback(...)` → `fallback`.
- **v8** — `new ResiliencePipelineBuilder().AddRetry/AddCircuitBreaker/AddTimeout/AddHedging/AddConcurrencyLimiter/AddRateLimiter(...)` → same `resilience_type` taxonomy with `MaxRetryAttempts`/`FailureRatio`/`BreakDuration`/`Timeout`/`MaxParallelization` options resolved. `api_version`=v7|v8.
- **HttpClientFactory binding** — `AddHttpClient("name").AddPolicyHandler(p)` / `.AddResilienceHandler("p", b => ...)` → marker with `binding` + `http_client`.
- Honest-partial: config-/variable-driven params (`Retry(maxRetries)`) omitted, not guessed; sub-second TimeSpans not rounded.

### Coravel — `internal/custom/csharp/coravel.go` (`custom_csharp_coravel`)
- **Consumer** — `class X : IInvocable` → `SCOPE.Service(invocable)` CONSUMES `task:coravel:<X>`.
- **Producer** — `scheduler.Schedule<T>()` / anonymous `Schedule(() => ...)` → `SCOPE.Operation(schedule)` PRODUCES, with cadence parse (`.Cron("...")`→cron+`cron_expression`; `.DailyAt("hh:mm")`→daily+`daily_at`; `EveryMinute`/`Every5Minutes`/`Hourly`/…→interval+`frequency`+`interval_seconds`); `QueueInvocable<T>`/`QueueAsyncTask`→`queue`; `IMailer.Send(new *Mailable)`→`mail`.
- Producer/consumer join on `task:coravel:<T>` (mirrors `task:quartz.net:<T>`). Honest-partial: unrecognised frequency tokens record the producer without a resolved cadence; `Send(new T())` not ending in `Mailable` is skipped.

### Edges / entities
Reuses existing Kinds — no new entity Kind (no `internal/types` Kind change). `SCOPE.Pattern` (Polly markers), `SCOPE.Service`/`SCOPE.Operation` (Coravel), aligned with the Java MicroProfile fault-tolerance pass and the C# Quartz.NET/rate-limit passes.

### Registry cells (only fixtures-proven cells flipped)
- New **`http_framework`/`resilience`** subcategory (dictionary) — `lang.csharp.framework.polly`: `resilience_policy_extraction` + `http_client_binding` both **full**.
- `msg.coravel` under **`message_broker`/`schedulers`**: `consumer_extraction` + `producer_extraction` + `topic_attribution` all **full**.
- Regenerated `docs/coverage` included (new detail pages `lang.csharp.framework.polly.md`, `msg.coravel.md`; updated by-category/by-language/summary). `coverage fmt --check` ✅ + `coverage validate` ✅ (0 errors).

### Fixtures
`polly_resilience_test.go` (13 value-asserting tests incl. negatives + honest-partial) and `coravel_test.go` (12 tests incl. consumer/producer join + negatives).

### Gates (sandbox `HOME=/tmp/agsbx-5075`)
`go build ./...` ✅ · `go vet ./internal/...` ✅ · `go test ./internal/custom/csharp/... ./internal/extractors/csharp/... ./internal/types/` ✅ · `coverage fmt --check` ✅ · `coverage validate` ✅ · regenerated `docs/coverage` committed.

Deploy-deferred.

Closes #5075