### PR TITLE
feat(#5026): c-cpp — resolve variable-built SQL + multi-table sql_tables in nanodbc/SQLiteCpp/sqlite3 wrappers

### DIFF
--- a/docs/coverage/detail/lang.c-cpp.orm.nanodbc.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.nanodbc.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | — | 4978 | `internal/custom/cpp/orm_sql_wrappers.go`<br>`internal/engine/rules/cpp/orms/nanodbc.yaml` | Regex (custom_cpp_nanodbc): nanodbc::execute/prepare(conn, "SQL"), nanodbc::statement(conn, "SQL"), conn.execute("SQL") → query with classified sql_verb + sql_text + best-effort sql_table. String-literal SQL only; runtime-built/variable SQL is a cross-file dataflow gap (#4978). Detection still via nanodbc.yaml. |
+| Query attribution | 🟢 `partial` | — | 5026 | `internal/custom/cpp/orm_sql_wrappers.go`<br>`internal/engine/rules/cpp/orms/nanodbc.yaml` | Regex (custom_cpp_nanodbc): nanodbc::execute/prepare(conn, "SQL"), nanodbc::statement(conn, "SQL"), conn.execute("SQL") → query with classified sql_verb + sql_text + sql_table (first FROM/INTO/UPDATE/JOIN/TABLE) + sql_tables (ALL referenced tables for multi-table JOINs/CTEs/subqueries, #5026). #5026 also resolves intra-file variable-built SQL: std::string sql="..."; / auto/const char* decls, sql+=/<< concatenation, and the nanodbc prepared-then-bound two-step (statement stmt(conn); stmt.prepare(sql)) — bare identifiers are resolved against a file-local var→SQL map gated by a SQL-verb looksLikeSQL guard so non-SQL strings (log messages, paths) aren't attributed. partial: cross-FILE dataflow (SQL built in another translation unit) remains a gap. Detection still via nanodbc.yaml. |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.orm.sqlite-direct-c-api.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.sqlite-direct-c-api.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | — | 4978 | `internal/custom/cpp/orm_sql_wrappers.go`<br>`internal/engine/rules/cpp/orms/sqlite_direct_c_api.yaml` | Regex (custom_cpp_sqlite_capi): sqlite3_prepare_v2/v3/16(db, "SQL", …) and sqlite3_exec(db, "SQL", …) → query with classified sql_verb + sql_text + best-effort sql_table. String-literal SQL only; runtime-built/variable SQL is a cross-file dataflow gap (#4978). Detection still via sqlite_direct_c_api.yaml. |
+| Query attribution | 🟢 `partial` | — | 5026 | `internal/custom/cpp/orm_sql_wrappers.go`<br>`internal/engine/rules/cpp/orms/sqlite_direct_c_api.yaml` | Regex (custom_cpp_sqlite_capi): sqlite3_prepare_v2/v3/16(db, "SQL", …) and sqlite3_exec(db, "SQL", …) → query with classified sql_verb + sql_text + sql_table (first table) + sql_tables (ALL referenced tables for multi-table JOINs/CTEs/subqueries, #5026). #5026 also resolves intra-file variable-built SQL: std::string sql="..." decls, +=/<< concatenation, and the call-site .c_str()/.data() form (sqlite3_exec(db, sql.c_str(), …)) — bare identifiers resolved against a file-local var→SQL map gated by a SQL-verb guard. partial: cross-FILE dataflow remains a gap. Detection still via sqlite_direct_c_api.yaml. |
 
 ### Migrations
 

--- a/docs/coverage/detail/lang.c-cpp.orm.sqlitecpp.md
+++ b/docs/coverage/detail/lang.c-cpp.orm.sqlitecpp.md
@@ -32,7 +32,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Query attribution | 🟢 `partial` | — | 4978 | `internal/custom/cpp/orm_sql_wrappers.go`<br>`internal/engine/rules/cpp/orms/sqlitecpp.yaml` | Regex (custom_cpp_sqlitecpp): SQLite::Statement(db, "SQL") and db.exec("SQL") → query with classified sql_verb + sql_text + best-effort sql_table. Gated on SQLiteCpp/SQLite:: signal. String-literal SQL only; runtime-built/variable SQL is a cross-file dataflow gap (#4978). Detection still via sqlitecpp.yaml. |
+| Query attribution | 🟢 `partial` | — | 5026 | `internal/custom/cpp/orm_sql_wrappers.go`<br>`internal/engine/rules/cpp/orms/sqlitecpp.yaml` | Regex (custom_cpp_sqlitecpp): SQLite::Statement(db, "SQL") and db.exec("SQL") → query with classified sql_verb + sql_text + sql_table (first table) + sql_tables (ALL referenced tables for multi-table JOINs/CTEs/subqueries, #5026). Gated on SQLiteCpp/SQLite:: signal. #5026 also resolves intra-file variable-built SQL: std::string sql="..." decls, +=/<< concatenation, SQLite::Statement(db, sql) / db.exec(sql) — bare identifiers resolved against a file-local var→SQL map gated by a SQL-verb guard. partial: cross-FILE dataflow remains a gap. Detection still via sqlitecpp.yaml. |
 
 ### Migrations
 

--- a/internal/custom/cpp/orm_sql_wrappers.go
+++ b/internal/custom/cpp/orm_sql_wrappers.go
@@ -24,8 +24,18 @@ package cpp
 // layer), so they emit ONLY:
 //   SCOPE.Operation (subtype="query") with sql_verb + sql_text + sql_table.
 //
-// Status: partial (regex heuristic, no AST). String-literal SQL only; SQL built
-// at runtime / spread across variables is a known cross-file dataflow gap.
+// Status (#5026): regex heuristic, no AST. Both string-literal SQL *and*
+// intra-file variable-built SQL are attributed:
+//   - `std::string sql = "..."`, `auto sql = "..."`, `const char* sql = "..."`
+//   - `sql += "..."` concatenation and `sql << "..."` streamed builds
+// When a wrapper call passes a bare identifier (e.g. `stmt.prepare(sql)`,
+// `nanodbc::execute(conn, sql)`) instead of a string literal, the identifier is
+// resolved against the file-local var→SQL map. Cross-FILE dataflow (SQL built
+// in another translation unit) remains a gap.
+//
+// sql_table records the first referenced table (back-compat); sql_tables records
+// ALL tables referenced by FROM/INTO/UPDATE/JOIN/TABLE clauses (multi-table
+// JOINs / CTEs / subqueries), comma-joined and de-duplicated.
 
 import (
 	"context"
@@ -54,14 +64,16 @@ var sqlVerbKeywords = []string{
 	"CREATE", "DROP", "ALTER", "TRUNCATE", "PRAGMA", "WITH",
 }
 
-// reSQLTable extracts the primary table name from a SQL string for the common
-// FROM/INTO/UPDATE/JOIN/TABLE clauses. Best-effort: the first match wins.
+// reSQLTable extracts table names from a SQL string for the common
+// FROM/INTO/UPDATE/JOIN/TABLE clauses. All matches are collected (#5026) so
+// multi-table JOINs / subqueries / CTEs surface every referenced table.
 var reSQLTable = regexp.MustCompile(`(?is)\b(?:FROM|INTO|UPDATE|JOIN|TABLE)\s+` +
 	"[`\"\\[]?([A-Za-z_][A-Za-z0-9_.]*)[`\"\\]]?")
 
-// classifySQL returns the SQL verb (or "QUERY" when unknown) and the best-effort
-// primary table name ("" when none could be parsed) for a SQL string literal.
-func classifySQL(sqlText string) (verb, table string) {
+// classifySQL returns the SQL verb (or "QUERY" when unknown), the first-match
+// table name ("" when none), and ALL distinct referenced tables (in source
+// order) for a SQL string.
+func classifySQL(sqlText string) (verb, table string, tables []string) {
 	sqlUpper := strings.ToUpper(strings.TrimSpace(sqlText))
 	verb = "QUERY"
 	for _, kw := range sqlVerbKeywords {
@@ -70,15 +82,24 @@ func classifySQL(sqlText string) (verb, table string) {
 			break
 		}
 	}
-	if m := reSQLTable.FindStringSubmatch(sqlText); m != nil {
-		table = m[1]
+	seenTbl := map[string]bool{}
+	for _, m := range reSQLTable.FindAllStringSubmatch(sqlText, -1) {
+		t := m[1]
+		if seenTbl[t] {
+			continue
+		}
+		seenTbl[t] = true
+		tables = append(tables, t)
+		if table == "" {
+			table = t
+		}
 	}
-	return verb, table
+	return verb, table, tables
 }
 
-// emitSQLQuery builds a SCOPE.Operation(query) record for one SQL string literal.
+// emitSQLQuery builds a SCOPE.Operation(query) record for one SQL string.
 func emitSQLQuery(framework, provenance, sqlText, filePath string, lineNum int) types.EntityRecord {
-	verb, table := classifySQL(sqlText)
+	verb, table, tables := classifySQL(sqlText)
 	queryName := verb + "@L" + strconv.Itoa(lineNum)
 	ent := makeEntity(queryName, "SCOPE.Operation", "query", filePath, "cpp", lineNum)
 	props := []string{
@@ -90,8 +111,129 @@ func emitSQLQuery(framework, provenance, sqlText, filePath string, lineNum int) 
 	if table != "" {
 		props = append(props, "sql_table", table)
 	}
+	if len(tables) > 0 {
+		props = append(props, "sql_tables", strings.Join(tables, ","))
+	}
 	setProps(&ent, props...)
 	return ent
+}
+
+// ============================================================================
+// Intra-file variable-built SQL resolution (#5026)
+// ============================================================================
+
+var (
+	// std::string sql = "..."; / auto sql = "..."; / const char* sql = "...";
+	// std::string sql{"..."}; — declaration with a string-literal initializer.
+	// Capture: (1) var name, (2) SQL literal.
+	reSQLVarDecl = regexp.MustCompile(`(?s)\b(?:std\s*::\s*string|auto|const\s+char\s*\*|char\s*\*|string)\s+([A-Za-z_]\w*)\s*(?:=|\{)\s*"([^"]*)"`)
+
+	// sql = "..."; / sql += "..."; / sql << "..."; — assignment, concatenation,
+	// or stream-append onto an existing string variable.
+	// Capture: (1) var name, (2) operator-less, (3) SQL fragment.
+	reSQLVarAppend = regexp.MustCompile(`(?m)\b([A-Za-z_]\w*)\s*(?:\+?=|<<)\s*"([^"]*)"`)
+)
+
+// collectSQLVars builds a file-local map of identifier → assembled SQL text by
+// scanning declarations, `+=`/`=` assignments, and `<<` stream-appends. Multiple
+// fragments for the same variable are concatenated in source order so a
+// streamed/concatenated build (`sql = "SELECT ..."; sql += " WHERE ...";`)
+// resolves to the full statement. Best-effort, intra-file only.
+func collectSQLVars(src string) map[string]string {
+	if !strings.Contains(src, "\"") {
+		return nil
+	}
+	vars := map[string]string{}
+	// Declarations first (establish the variable + its leading fragment).
+	for _, m := range reSQLVarDecl.FindAllStringSubmatch(src, -1) {
+		name, frag := m[1], m[2]
+		if looksLikeSQL(frag) {
+			vars[name] = frag
+		}
+	}
+	// Then assignments / concatenations / stream-appends in source order.
+	for _, m := range reSQLVarAppend.FindAllStringSubmatch(src, -1) {
+		name, frag := m[1], m[2]
+		existing, known := vars[name]
+		if !known {
+			// A bare `sql = "SELECT ..."` first-assignment also seeds the map.
+			if looksLikeSQL(frag) {
+				vars[name] = frag
+			}
+			continue
+		}
+		vars[name] = joinSQLFragments(existing, frag)
+	}
+	return vars
+}
+
+// looksLikeSQL is a cheap guard so arbitrary string variables (paths, messages)
+// don't get mistaken for SQL: the fragment must start with a known SQL verb or
+// look like a clause continuation (whitespace/keyword) we can append.
+func looksLikeSQL(frag string) bool {
+	u := strings.ToUpper(strings.TrimSpace(frag))
+	for _, kw := range sqlVerbKeywords {
+		if strings.HasPrefix(u, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// joinSQLFragments concatenates two SQL fragments inserting a single space when
+// neither side already supplies separating whitespace.
+func joinSQLFragments(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if strings.HasSuffix(a, " ") || strings.HasPrefix(b, " ") {
+		return a + b
+	}
+	return a + " " + b
+}
+
+// sqlEmitter accumulates SCOPE.Operation(query) records, de-duplicating by line
+// so overlapping literal/variable regexes never double-emit for one call site.
+type sqlEmitter struct {
+	out  []types.EntityRecord
+	seen map[int]bool
+	src  string
+	path string
+	vars map[string]string
+}
+
+func newSQLEmitter(src, path string) *sqlEmitter {
+	return &sqlEmitter{seen: map[int]bool{}, src: src, path: path, vars: collectSQLVars(src)}
+}
+
+// addLiteral emits one query per string-literal capture (group 1 = SQL text).
+func (s *sqlEmitter) addLiteral(re *regexp.Regexp, framework, provenance string) {
+	for _, m := range re.FindAllStringSubmatchIndex(s.src, -1) {
+		lineNum := lineOf(s.src, m[0])
+		if s.seen[lineNum] {
+			continue
+		}
+		s.seen[lineNum] = true
+		s.out = append(s.out, emitSQLQuery(framework, provenance, s.src[m[2]:m[3]], s.path, lineNum))
+	}
+}
+
+// addVar emits one query per identifier capture (group 1 = var name) that
+// resolves to known SQL via the file-local var→SQL map.
+func (s *sqlEmitter) addVar(re *regexp.Regexp, framework, provenance string) {
+	for _, m := range re.FindAllStringSubmatchIndex(s.src, -1) {
+		lineNum := lineOf(s.src, m[0])
+		if s.seen[lineNum] {
+			continue
+		}
+		ident := s.src[m[2]:m[3]]
+		sqlText, ok := s.vars[ident]
+		if !ok {
+			continue
+		}
+		s.seen[lineNum] = true
+		s.out = append(s.out, emitSQLQuery(framework, provenance, sqlText, s.path, lineNum))
+	}
 }
 
 // ============================================================================
@@ -113,6 +255,15 @@ var (
 
 	// stmt.prepare("SQL") / conn.execute("SQL") — method form on a nanodbc handle.
 	reNanodbcMethod = regexp.MustCompile(`\.\s*(?:prepare|execute)\s*\(\s*"([^"]*)"`)
+
+	// Variable forms (#5026): SQL passed as a bare identifier rather than a
+	// string literal. Resolved against the file-local var→SQL map.
+	//   nanodbc::execute(conn, sql) / nanodbc::prepare(stmt, sql)
+	reNanodbcFreeFnVar = regexp.MustCompile(`\bnanodbc\s*::\s*(?:execute|prepare)\s*\([^,"]+,\s*([A-Za-z_]\w*)\s*[,)]`)
+	//   nanodbc::statement stmt(conn, sql)
+	reNanodbcStmtCtorVar = regexp.MustCompile(`\bnanodbc\s*::\s*statement\s+[A-Za-z_]\w*\s*\([^,"]+,\s*([A-Za-z_]\w*)\s*[,)]`)
+	//   stmt.prepare(sql) / conn.execute(sql) — prepared-then-bound two-step form.
+	reNanodbcMethodVar = regexp.MustCompile(`\.\s*(?:prepare|execute)\s*\(\s*([A-Za-z_]\w*)\s*[,)]`)
 )
 
 func (e *nanodbcExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -136,26 +287,18 @@ func (e *nanodbcExtractor) Extract(ctx context.Context, file extractor.FileInput
 		return nil, nil
 	}
 
-	var out []types.EntityRecord
-	seen := map[int]bool{} // dedup by line so overlapping regexes don't double-emit
+	em := newSQLEmitter(src, file.Path)
+	// Literal forms first so a literal call site isn't re-matched as a variable.
+	em.addLiteral(reNanodbcFreeFn, "nanodbc", "INFERRED_FROM_NANODBC_FREE_FN")
+	em.addLiteral(reNanodbcStmtCtor, "nanodbc", "INFERRED_FROM_NANODBC_STATEMENT")
+	em.addLiteral(reNanodbcMethod, "nanodbc", "INFERRED_FROM_NANODBC_METHOD")
+	// Variable forms (#5026): SQL passed as a bare identifier.
+	em.addVar(reNanodbcFreeFnVar, "nanodbc", "INFERRED_FROM_NANODBC_FREE_FN_VAR")
+	em.addVar(reNanodbcStmtCtorVar, "nanodbc", "INFERRED_FROM_NANODBC_STATEMENT_VAR")
+	em.addVar(reNanodbcMethodVar, "nanodbc", "INFERRED_FROM_NANODBC_METHOD_VAR")
 
-	add := func(re *regexp.Regexp, provenance string) {
-		for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
-			sqlText := src[m[2]:m[3]]
-			lineNum := lineOf(src, m[0])
-			if seen[lineNum] {
-				continue
-			}
-			seen[lineNum] = true
-			out = append(out, emitSQLQuery("nanodbc", provenance, sqlText, file.Path, lineNum))
-		}
-	}
-	add(reNanodbcFreeFn, "INFERRED_FROM_NANODBC_FREE_FN")
-	add(reNanodbcStmtCtor, "INFERRED_FROM_NANODBC_STATEMENT")
-	add(reNanodbcMethod, "INFERRED_FROM_NANODBC_METHOD")
-
-	span.SetAttributes(attribute.Int("entity_count", len(out)))
-	return out, nil
+	span.SetAttributes(attribute.Int("entity_count", len(em.out)))
+	return em.out, nil
 }
 
 // ============================================================================
@@ -174,6 +317,12 @@ var (
 	// db.exec("SQL") / database.exec("SQL") — direct exec on a SQLiteCpp Database.
 	// Capture: (1) SQL string literal.
 	reSQLiteCppExec = regexp.MustCompile(`\.\s*exec\s*\(\s*"([^"]*)"`)
+
+	// Variable forms (#5026): SQL passed as a bare identifier.
+	//   SQLite::Statement query(db, sql)
+	reSQLiteCppStmtVar = regexp.MustCompile(`\bSQLite\s*::\s*Statement\s+[A-Za-z_]\w*\s*\([^,"]+,\s*([A-Za-z_]\w*)\s*[,)]`)
+	//   db.exec(sql)
+	reSQLiteCppExecVar = regexp.MustCompile(`\.\s*exec\s*\(\s*([A-Za-z_]\w*)\s*[,)]`)
 )
 
 func (e *sqliteCppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -198,25 +347,14 @@ func (e *sqliteCppExtractor) Extract(ctx context.Context, file extractor.FileInp
 		return nil, nil
 	}
 
-	var out []types.EntityRecord
-	seen := map[int]bool{}
+	em := newSQLEmitter(src, file.Path)
+	em.addLiteral(reSQLiteCppStmt, "sqlitecpp", "INFERRED_FROM_SQLITECPP_STATEMENT")
+	em.addLiteral(reSQLiteCppExec, "sqlitecpp", "INFERRED_FROM_SQLITECPP_EXEC")
+	em.addVar(reSQLiteCppStmtVar, "sqlitecpp", "INFERRED_FROM_SQLITECPP_STATEMENT_VAR")
+	em.addVar(reSQLiteCppExecVar, "sqlitecpp", "INFERRED_FROM_SQLITECPP_EXEC_VAR")
 
-	add := func(re *regexp.Regexp, provenance string) {
-		for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
-			sqlText := src[m[2]:m[3]]
-			lineNum := lineOf(src, m[0])
-			if seen[lineNum] {
-				continue
-			}
-			seen[lineNum] = true
-			out = append(out, emitSQLQuery("sqlitecpp", provenance, sqlText, file.Path, lineNum))
-		}
-	}
-	add(reSQLiteCppStmt, "INFERRED_FROM_SQLITECPP_STATEMENT")
-	add(reSQLiteCppExec, "INFERRED_FROM_SQLITECPP_EXEC")
-
-	span.SetAttributes(attribute.Int("entity_count", len(out)))
-	return out, nil
+	span.SetAttributes(attribute.Int("entity_count", len(em.out)))
+	return em.out, nil
 }
 
 // ============================================================================
@@ -235,6 +373,13 @@ var (
 	// sqlite3_exec(db, "SQL", …)
 	// Capture: (1) SQL string literal (second argument).
 	reSQLiteCAPIExec = regexp.MustCompile(`(?s)\bsqlite3_exec\s*\([^,]+,\s*"([^"]*)"`)
+
+	// Variable forms (#5026): SQL passed as a bare identifier.
+	//   sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) — when sql is a variable,
+	//   it is often `sql.c_str()`; accept an optional `.c_str()`/`.data()` call.
+	reSQLiteCAPIPrepareVar = regexp.MustCompile(`\bsqlite3_prepare(?:_v2|_v3|16)?\s*\([^,"]+,\s*([A-Za-z_]\w*)\s*(?:\.\s*(?:c_str|data)\s*\(\s*\))?\s*,`)
+	//   sqlite3_exec(db, sql, …)
+	reSQLiteCAPIExecVar = regexp.MustCompile(`\bsqlite3_exec\s*\([^,"]+,\s*([A-Za-z_]\w*)\s*(?:\.\s*(?:c_str|data)\s*\(\s*\))?\s*,`)
 )
 
 func (e *sqliteCAPIExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
@@ -258,23 +403,12 @@ func (e *sqliteCAPIExtractor) Extract(ctx context.Context, file extractor.FileIn
 		return nil, nil
 	}
 
-	var out []types.EntityRecord
-	seen := map[int]bool{}
+	em := newSQLEmitter(src, file.Path)
+	em.addLiteral(reSQLiteCAPIPrepare, "sqlite_direct_c_api", "INFERRED_FROM_SQLITE3_PREPARE")
+	em.addLiteral(reSQLiteCAPIExec, "sqlite_direct_c_api", "INFERRED_FROM_SQLITE3_EXEC")
+	em.addVar(reSQLiteCAPIPrepareVar, "sqlite_direct_c_api", "INFERRED_FROM_SQLITE3_PREPARE_VAR")
+	em.addVar(reSQLiteCAPIExecVar, "sqlite_direct_c_api", "INFERRED_FROM_SQLITE3_EXEC_VAR")
 
-	add := func(re *regexp.Regexp, provenance string) {
-		for _, m := range re.FindAllStringSubmatchIndex(src, -1) {
-			sqlText := src[m[2]:m[3]]
-			lineNum := lineOf(src, m[0])
-			if seen[lineNum] {
-				continue
-			}
-			seen[lineNum] = true
-			out = append(out, emitSQLQuery("sqlite_direct_c_api", provenance, sqlText, file.Path, lineNum))
-		}
-	}
-	add(reSQLiteCAPIPrepare, "INFERRED_FROM_SQLITE3_PREPARE")
-	add(reSQLiteCAPIExec, "INFERRED_FROM_SQLITE3_EXEC")
-
-	span.SetAttributes(attribute.Int("entity_count", len(out)))
-	return out, nil
+	span.SetAttributes(attribute.Int("entity_count", len(em.out)))
+	return em.out, nil
 }

--- a/internal/custom/cpp/orm_sql_wrappers_test.go
+++ b/internal/custom/cpp/orm_sql_wrappers_test.go
@@ -162,3 +162,135 @@ func TestSQLiteCAPINoMatch(t *testing.T) {
 		t.Errorf("expected no entities for non-sqlite3 source, got %d", len(ents))
 	}
 }
+
+// ============================================================================
+// #5026 — variable-built SQL, prepared-then-bound, multi-table sql_tables
+// ============================================================================
+
+// nanodbc prepared-then-bound two-step form: SQL is a std::string variable,
+// then stmt.prepare(sql). Must resolve the variable to its SQL text.
+func TestNanodbcPreparedThenBoundVar(t *testing.T) {
+	src := `
+#include <nanodbc/nanodbc.h>
+void run(nanodbc::connection& conn) {
+	std::string sql = "SELECT id FROM orders WHERE status = ?";
+	nanodbc::statement stmt(conn);
+	stmt.prepare(sql);
+}
+`
+	ents := extract(t, "custom_cpp_nanodbc", fi("dao.cpp", "cpp", src))
+	q := queryByVerb(ents, "SELECT")
+	if q == nil {
+		t.Fatalf("expected SELECT from variable-built SQL, got %v", queryVerbs(ents))
+	}
+	if got := q.Props["sql_table"]; got != "orders" {
+		t.Errorf("sql_table = %q, want orders", got)
+	}
+	if got := q.Props["sql_text"]; got == "" {
+		t.Error("expected resolved sql_text from the variable")
+	}
+}
+
+// nanodbc free-function form with a variable arg, where the SQL is assembled
+// across multiple concatenation statements (sql = ...; sql += ...).
+func TestNanodbcConcatenatedVar(t *testing.T) {
+	src := `
+#include <nanodbc/nanodbc.h>
+void run(nanodbc::connection& conn) {
+	std::string sql = "INSERT INTO audit_log (msg)";
+	sql += " VALUES ('x')";
+	nanodbc::execute(conn, sql);
+}
+`
+	ents := extract(t, "custom_cpp_nanodbc", fi("dao.cpp", "cpp", src))
+	q := queryByVerb(ents, "INSERT")
+	if q == nil {
+		t.Fatalf("expected INSERT from concatenated SQL, got %v", queryVerbs(ents))
+	}
+	if got := q.Props["sql_table"]; got != "audit_log" {
+		t.Errorf("sql_table = %q, want audit_log", got)
+	}
+}
+
+// SQLiteCpp with a variable passed to db.exec(sql).
+func TestSQLiteCppVar(t *testing.T) {
+	src := `
+#include <SQLiteCpp/SQLiteCpp.h>
+void run(SQLite::Database& db) {
+	std::string sql = "DELETE FROM cache";
+	db.exec(sql);
+}
+`
+	ents := extract(t, "custom_cpp_sqlitecpp", fi("store.cpp", "cpp", src))
+	if q := queryByVerb(ents, "DELETE"); q == nil {
+		t.Fatalf("expected DELETE from variable SQL, got %v", queryVerbs(ents))
+	} else if got := q.Props["sql_table"]; got != "cache" {
+		t.Errorf("sql_table = %q, want cache", got)
+	}
+}
+
+// SQLite C API with a std::string variable + .c_str() at the call site.
+func TestSQLiteCAPIVarCStr(t *testing.T) {
+	src := `
+#include <sqlite3.h>
+void run(sqlite3* db) {
+	std::string sql = "UPDATE settings SET v = 1";
+	sqlite3_exec(db, sql.c_str(), NULL, NULL, NULL);
+}
+`
+	ents := extract(t, "custom_cpp_sqlite_capi", fi("db.c", "cpp", src))
+	if q := queryByVerb(ents, "UPDATE"); q == nil {
+		t.Fatalf("expected UPDATE from variable SQL, got %v", queryVerbs(ents))
+	} else if got := q.Props["sql_table"]; got != "settings" {
+		t.Errorf("sql_table = %q, want settings", got)
+	}
+}
+
+// Multi-table JOIN: sql_table keeps the first table (back-compat) while
+// sql_tables records ALL referenced tables.
+func TestSQLTablesMultiTable(t *testing.T) {
+	src := `
+#include <sqlite3.h>
+void run(sqlite3* db) {
+	sqlite3_stmt* st;
+	sqlite3_prepare_v2(db,
+		"SELECT u.id FROM users u JOIN orders o ON o.uid = u.id JOIN items i ON i.oid = o.id",
+		-1, &st, NULL);
+}
+`
+	ents := extract(t, "custom_cpp_sqlite_capi", fi("db.c", "cpp", src))
+	q := queryByVerb(ents, "SELECT")
+	if q == nil {
+		t.Fatalf("expected SELECT, got %v", queryVerbs(ents))
+	}
+	if got := q.Props["sql_table"]; got != "users" {
+		t.Errorf("sql_table = %q, want users (first match)", got)
+	}
+	if got := q.Props["sql_tables"]; got != "users,orders,items" {
+		t.Errorf("sql_tables = %q, want users,orders,items", got)
+	}
+}
+
+// Wrong-language no-op: a non-C/C++ language must not be processed even when the
+// content otherwise looks like a wrapper call.
+func TestSQLWrappersWrongLanguageNoOp(t *testing.T) {
+	src := `nanodbc::execute(conn, "SELECT 1 FROM t");`
+	if ents := extract(t, "custom_cpp_nanodbc", fi("dao.go", "go", src)); len(ents) != 0 {
+		t.Errorf("expected no entities for wrong language, got %d", len(ents))
+	}
+}
+
+// No-match no-op for the variable path: a string variable that isn't SQL (a log
+// message) must NOT be attributed even when passed to a wrapper call.
+func TestSQLWrappersNonSQLVarNoOp(t *testing.T) {
+	src := `
+#include <nanodbc/nanodbc.h>
+void run(nanodbc::connection& conn) {
+	std::string note = "just a log message, not sql";
+	conn.execute(note);
+}
+`
+	if ents := extract(t, "custom_cpp_nanodbc", fi("dao.cpp", "cpp", src)); len(ents) != 0 {
+		t.Errorf("expected no entities for non-SQL variable, got %d (%v)", len(ents), queryVerbs(ents))
+	}
+}


### PR DESCRIPTION
## What this builds (#5026, follow-up from #4978)

The three detection-only C/C++ SQL-wrapper extractors (`custom_cpp_{nanodbc,sqlitecpp,sqlite_capi}` in `internal/custom/cpp/orm_sql_wrappers.go`) previously attributed SQL only when passed as a **string literal** at the call site. This closes all three deferred items:

1. **Runtime-built / variable SQL** — intra-file dataflow. A new `collectSQLVars` builds a file-local `identifier → SQL` map from:
   - declarations: `std::string sql = "..."`, `auto sql = "..."`, `const char* sql = "..."`, `std::string sql{"..."}`
   - `sql = "..."` / `sql += "..."` concatenation and `sql << "..."` stream-appends (fragments joined in source order)
   When a wrapper call passes a bare identifier, it resolves against the map. Guarded by `looksLikeSQL` (must start with a SQL verb) so log messages / paths are **not** attributed.

2. **`sql_table` is first-match → emit all tables**. `classifySQL` now collects every `FROM/INTO/UPDATE/JOIN/TABLE` token (de-duped, source order). `sql_table` keeps the first match (back-compat); new **`sql_tables`** property records all referenced tables for multi-table JOINs / CTEs / subqueries.

3. **nanodbc prepared-then-bound** — `nanodbc::statement stmt(conn); stmt.prepare(sql);` two-step form where SQL is a variable is now resolved.

Schema/model attribution stays `not_applicable` (thin wrappers, no ORM model layer) — as the ticket specifies, not deferred.

### Entities / edges / props
- Reuses existing `SCOPE.Operation` (subtype `query`) — **no new Kinds** (`go test ./internal/types/` green).
- Properties only: existing `framework`/`provenance`/`sql_verb`/`sql_text`/`sql_table` + new `sql_tables`. New `*_VAR` provenance values distinguish variable-resolved sites.

### Registry cells
`lang.c-cpp.orm.{nanodbc,sqlitecpp,sqlite-direct-c-api}` → `Queries/query_attribution` notes updated (issue 4978→5026), documenting variable resolution + `sql_tables`. Status stays **partial** — honest: cross-FILE dataflow (SQL built in another translation unit) remains a gap (filed as the residual of this ticket; no new follow-up needed as it's the same SOCI-class dataflow gap tracked elsewhere). REGENERATED `docs/coverage/detail/*.md` included.

### Fixtures
Added: nanodbc prepared-then-bound var, nanodbc concatenated var, SQLiteCpp var exec, sqlite C API var `.c_str()`, multi-table `sql_tables` JOIN assertion, **wrong-language no-op** (`.go` file), **non-SQL-variable no-op** (log message passed to `execute`). All 14 wrapper tests pass.

### Gates (sandbox HOME=/tmp/agsbx-5026)
`go build ./...`, `go vet ./internal/...`, `internal/custom/cpp` + `internal/types` tests, `coverage fmt --check` (canonical), `coverage validate` (ok, pre-existing unrelated warnings only), committed regen'd docs/coverage.

Closes #5026