### PR TITLE
feat(#5008): rust — conn pools + async-nats + ntex/Loco/Shuttle + test libs

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 100 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **java**: 8 · **JS/TS**: 20 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 5 · **scala**: 2
+**Total**: 104 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **java**: 8 · **JS/TS**: 20 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -104,7 +104,11 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [rust](../by-language/rust.md) | [Cargo (Cargo.toml)](../detail/build.cargo.md) | ✅ | ✅ | |
 | [rust](../by-language/rust.md) | [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | ✅ | |
 | [rust](../by-language/rust.md) | [criterion (benchmark)](../detail/test.criterion.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [insta](../detail/test.insta.md) | ✅ | ✅ | |
 | [rust](../by-language/rust.md) | [mockall](../detail/test.mockall.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [mockito (Rust)](../detail/test.mockito-rs.md) | ✅ | ✅ | |
 | [rust](../by-language/rust.md) | [proptest](../detail/test.proptest.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [serial_test](../detail/test.serial-test.md) | ✅ | ✅ | |
+| [rust](../by-language/rust.md) | [wiremock](../detail/test.wiremock.md) | ✅ | ✅ | |
 | [scala](../by-language/scala.md) | [Mill](../detail/build.mill.md) | 🔴 | 🔴 | |
 | [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | ✅ | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 247 records · **C/C++**: 20 · **clojure**: 4 · **crystal**: 1 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 1 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 15 · **scala**: 14 · **swift**: 5
+**Total**: 249 records · **C/C++**: 20 · **clojure**: 4 · **crystal**: 1 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 1 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -138,6 +138,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 11/12 | |
 | [rust](../by-language/rust.md) | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 11/12 | |
 | [rust](../by-language/rust.md) | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
+| [rust](../by-language/rust.md) | [Loco.rs](../detail/lang.rust.framework.loco.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
@@ -148,6 +149,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 11/24 | 🟡 6/13 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/13 | |
+| [rust](../by-language/rust.md) | [ntex](../detail/lang.rust.framework.ntex.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 10/24 | 🟡 4/12 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |
 

--- a/docs/coverage/by-category/platform.md
+++ b/docs/coverage/by-category/platform.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # platform
 
-**Total**: 45 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 39 · **python**: 1 · **ruby**: 1
+**Total**: 46 records · **java**: 2 · **javascript**: 1 · **JS/TS**: 1 · **multi**: 39 · **python**: 1 · **ruby**: 1 · **rust**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -19,6 +19,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [multi](../by-language/multi.md) | [Pulumi](../detail/infra.iac.pulumi.md) | 🟢 | 🟢 | — | — | — | — | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [multi](../by-language/multi.md) | [Serverless Framework](../detail/infra.iac.serverless-framework.md) | ✅ | — | ✅ | ✅ | — | — | 🟢 | — | ✅ | 🟢 | |
 | [multi](../by-language/multi.md) | [Terraform (HCL)](../detail/infra.iac.terraform.md) | ✅ | ✅ | — | — | — | ✅ | 🟢 | ✅ | ✅ | 🟢 | |
+| [rust](../by-language/rust.md) | [Shuttle (deploy runtime)](../detail/platform.rust.shuttle.md) | — | — | — | — | — | — | 🟢 | — | 🟢 | 🟢 | |
 
 ## Containers & Orchestration
 

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # rust
 
-**Frameworks**: 15 · **Tools**: 6 · **ORMs**: 15 · **Other**: 4
+**Frameworks**: 17 · **Tools**: 10 · **ORMs**: 15 · **Other**: 5
 
 Back to [summary](../summary.md).
 
@@ -29,6 +29,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Actix Web](../detail/lang.rust.framework.actix.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 11/12 | |
 | [Axum](../detail/lang.rust.framework.axum.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 11/12 | |
 | [Gotham](../detail/lang.rust.framework.gotham.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
+| [Loco.rs](../detail/lang.rust.framework.loco.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [Poem](../detail/lang.rust.framework.poem.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [Rocket](../detail/lang.rust.framework.rocket.md) | ✅ 6/6 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [Salvo](../detail/lang.rust.framework.salvo.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
@@ -39,6 +40,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 11/24 | 🟡 6/13 | |
 | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/13 | |
+| [ntex](../detail/lang.rust.framework.ntex.md) | 🟡 5/6 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 10/24 | 🟡 4/12 | |
 
 
@@ -57,8 +59,12 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Cargo.toml](../detail/pkg.cargo.md) | — | — | 🔴 | ✅ | — | |
 | [cargo test (stdlib)](../detail/test.cargo-test.md) | ✅ | — | — | — | ✅ | |
 | [criterion (benchmark)](../detail/test.criterion.md) | ✅ | — | — | — | ✅ | |
+| [insta](../detail/test.insta.md) | ✅ | — | — | — | ✅ | |
 | [mockall](../detail/test.mockall.md) | ✅ | — | — | — | ✅ | |
+| [mockito (Rust)](../detail/test.mockito-rs.md) | ✅ | — | — | — | ✅ | |
 | [proptest](../detail/test.proptest.md) | ✅ | — | — | — | ✅ | |
+| [serial_test](../detail/test.serial-test.md) | ✅ | — | — | — | ✅ | |
+| [wiremock](../detail/test.wiremock.md) | ✅ | — | — | — | ✅ | |
 
 ## ORMs
 
@@ -94,6 +100,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [async-nats (NATS)](../detail/lang.rust.framework.async-nats.md) | 🟢 | 🟢 | 🟢 | |
 | [lapin (AMQP/RabbitMQ)](../detail/lang.rust.framework.lapin.md) | 🟢 | 🟢 | 🟢 | |
 | [rdkafka (Kafka)](../detail/lang.rust.framework.rdkafka.md) | 🟢 | 🟢 | 🟢 | |
+
+
+### IaC / Provisioning
+
+| Name | Dependency attribution | Iac cross stack reference | Iac environment region account | Iac event source wiring | Iac iam grant attribution | Iac output export extraction | Iac resource property extraction | Iac stack app topology | Resource extraction | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [Shuttle (deploy runtime)](../detail/platform.rust.shuttle.md) | — | — | — | — | — | — | 🟢 | — | 🟢 | |
 
 
 ### Validation

--- a/docs/coverage/detail/lang.rust.framework.loco.md
+++ b/docs/coverage/detail/lang.rust.framework.loco.md
@@ -1,0 +1,131 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.loco` — Loco.rs
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 49
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3628 | — | — |
+| Endpoint pagination posture | ✅ `full` | `2026-06-13` | 5019 | `internal/custom/rust/endpoint_pagination.go`<br>`internal/custom/rust/endpoint_pagination_test.go` | #5019 (child of #3628) Rust port: paginated/pagination_style/pagination_params/pagination_source stamped at the SOURCE by re-emitting the SCOPE.Operation/endpoint op so it merges onto the producer route op by Name (same approach as endpoint_response_codes.go; the engine applyEndpointPagination pass is gated on http_endpoint_definition and cannot reach Rust SCOPE.Operation custom entities). tide: `app.at("/p").get(handler)` names a handler; literal `req.query(...).get("limit")`-style query reads in the body name the params (plus typed `Query<Struct>` fields). Value-asserted TestRustPagination_TideLiteralReads (cursor->cursor). HONEST-PARTIAL (shared classifier): a lone limit-like param or a lone `.limit()` with no offset companion is ambiguous and NOT stamped (TestRustPagination_LoneLimitNotStamped, _LimitOnlyOrmNotStamped); a handler with no pagination shape is not re-emitted (TestRustPagination_NoPaginationNotStamped). Styles: limit+offset->offset, page->page, cursor/after/before/page_token->cursor. hyper (raw match-arm dispatch) and tower (no HTTP routes) remain missing (no named handler) — deferred follow-up. |
+| Endpoint response codes | ✅ `full` | `2026-06-12` | 5018 | `internal/custom/rust/endpoint_response_codes.go`<br>`internal/custom/rust/endpoint_response_codes_test.go` | #5018 (child of #3628, follow-up to #4965) Rust port: response_codes/success_code/response_codes_source stamped at the SOURCE by re-emitting the SCOPE.Operation/endpoint op so it merges onto the producer route op by Name (same handler-name correlation as axum; the engine applyEndpointResponseCodes pass is gated on http_endpoint_definition and cannot reach Rust SCOPE.Operation custom entities). extractHandlerNamed builds a handler->verdict map from every fn body once, then re-runs each framework's PRODUCER route regexes (minor_fw_routing.go) and stamps the verdict onto routes naming a resolving handler. poem: .at("/p", post(h)) + Response::builder().status(StatusCode::X)/bare StatusCode::X. warp: filter chain .and_then(h)/.map(h) + warp::reply::with_status(reply, StatusCode::X). tide: .at("/p").post(h) + Response::builder(NNN)/.set_status(NNN) positional status. gotham: route.verb("/p").to(h)/.associate + (StatusCode::X, body) create_response. salvo: Router::with_path("p").verb(h) + res.status_code(StatusCode::X). Shared StatusCode/Status name table + numeric constructors. Honest-partial: a route whose handler resolves no literal status is left to the producer (no fabricated 200). Value-asserted: TestRustRespCodes_PoemHandlerStatus, _WarpWithStatus, _TideBuilderStatus, _GothamRouteStatus, _SalvoStatusCode (+ _MinorFwNoStatusNotStamped negative). hyper (raw match-arm, no named handler) and tower (no HTTP routes) DEFERRED to a follow-up. |
+| Endpoint synthesis | ✅ `full` | `2026-06-14` | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: Loco.rs controller route producer — Routes::new().add("/p", get(h).post(h2)) axum-style method routers (one endpoint per verb) composed with .prefix("/api"); gated on a `loco_rs` token. Path params normalised to {id}; .prefix -> SCOPE.Component. Value-asserted: TestLocoRouteChain (+ wrong-language + no-match no-ops). Non-Routing cells inherited from the shared rust passes. |
+| Handler attribution | ✅ `full` | `2026-06-14` | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: handler_name captured per verb in a Loco method router; asserted by TestLocoRouteChain. |
+| Route extraction | ✅ `full` | `2026-06-14` | 5008 | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: Loco .prefix("/api") composition + {id} normalisation. |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for tide |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🟢 `partial` | `2026-06-12` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/extractors/rust/issue4854_field_membership_test.go`<br>`internal/extractors/rust/struct_fields.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. #4854: the serde/utoipa/ORM-gated custom emitters only emitted field members for bound DTOs; the GENERAL primary-pass now emits a SCOPE.Schema/field entity + struct->field CONTAINS for EVERY named struct field (serde rename wire name honoured, serde skip excluded, Name '<Struct>.<wire>' dedups by Name in MergeWithCustom) and for named fields of struct-style enum variants ('<Enum>.<Variant>.<field>'), so any Rust data struct projects field rows in the dashboard shape tree — closing the same gap #4845/#4851 fixed for JS/TS and #4850/#4855 for Go. Rust has no inheritance so there is no EXTENDS. emitRustStructFields/emitRustEnumVariantFields in rust/struct_fields.go; value-asserted by TestRustStructFieldsAreContained/TestRustEnumVariantFieldsAreContained. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but tide layer chains are not ordered/enumerated like tower |
+| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
+| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/cross/testmap/frameworks.go` | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🟢 `partial` | `2026-06-11` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_cross_orm_read_4692_test.go`<br>`internal/substrate/effect_sinks_rust.go` | #4737 (Rust slice of the #4692 cross-ORM receiver-typed read-reach audit): the ambiguous Diesel/sea-orm read terminals (.first/.find/.filter/.select/.all/.one + .order/.limit/.offset/.join) that collide with Rust Iterator combinators are now credited db_read ONLY on a query/table/Entity-typed receiver (Diesel schema::table root, .into_boxed()/QueryDsl chain, sea-orm Entity::find()) -- propagated across let q2 = q.filter(...) chains to a fixpoint and matched inline off a query root (users::table.filter(...).first(conn)). The distinctive terminals (sqlx::query!, .fetch_*, diesel::select/sql_query, .load/.get_result(s), .find_by_id/.stream/.paginate) stay bare on any receiver. vec.iter().filter(...).find(...) / slice.first() stay PURE (over-credit guard). Value-asserted in TestRustDieselSeaOrmTypedRead_4737 / TestRustIteratorNoFalsePositive_4737 / TestRustRepoReadChainSink_4737. |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| Config consumption | 🟢 `partial` | `2026-06-12` | config_consumption:#5079-keyless-envy-figment-extract-deferred | `internal/extractor/config_key.go`<br>`internal/extractors/rust/config_consumer.go`<br>`internal/extractors/rust/config_consumer_test.go`<br>`internal/extractors/rust/rust.go` | #5020+#5079: literal env/config-crate key reads emit the config-consumption topology — env::var(K)/std::env::var/env::var_os, dotenvy::var(K), figment Env::prefixed(P), and (#5079) the config crate typed getters cfg.get_string/get_int/get_bool/get_float(K) + turbofish cfg.get::<T>(K) — each becomes a shared SCOPE.Config/config_key node + a DEPENDS_ON_CONFIG edge (pattern=config_crate) from the reading function (receiver-qualified Foo.method), via emitConfigConsumerEdges -> extractor.EmitConfigReads. Honest-partial: only LITERAL string keys recorded — dynamic env::var(name) and bare HashMap .get(k) yield nothing; the truly KEYLESS crate APIs envy::from_env::<T>() and Figment::new().merge(...).extract::<T>() (whole-struct deserialise, no single literal key) remain deferred (#5079 follow-up). Value-asserted: TestRustConfig_EnvVar/Dotenvy/FigmentPrefix/MethodHostName/ConfigCrateGetters/ConfigCrateTurbofish/BareGetNotConfig/DynamicKeySkipped. |
+| Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
+| Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
+| Feature flag gating | 🟢 `partial` | `2026-06-12` | feature_flag_gating:#5079-cfg-combinator-keys-and-attribute-attribution-deferred | `internal/engine/feature_flag_edges.go`<br>`internal/engine/feature_flag_edges_test.go` | #5079: Rust conditional-compilation feature gating — cfg!(feature=x) macro + #[cfg(feature=x)] / #[cfg_attr(feature=x,...)] attributes — emits a SCOPE.FeatureFlag entity (feature:<key>, subtype rust-cfg) + a GATED_BY edge from the enclosing function, via a lang-gated matcher in applyFeatureFlagEdges (distinct from the runtime flag-SDK model). Honest-partial: a cfg! macro in a function body attributes to that function; a #[cfg(...)] attribute precedes its item and attributes to prior-function/file scope (same caveat as .NET [FeatureGate]); a multi-feature combinator all(...)/any(...) captures only the FIRST feature key. Value-asserted: TestFeatureFlag_Rust_cfg_macro/cfg_attribute/cfg_combinator_firstKey/cfg_langGated_noFabrication. |
+| Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | — |
+| Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | — |
+| Reachability analysis | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| Request shape extraction | 🟢 `partial` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
+| Response shape extraction | 🟢 `partial` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| Sanitizer recognition | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+| Schema drift detection | 🟢 `partial` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+| Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_rust.go` | — |
+| Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.loco ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.rust.framework.ntex.md
+++ b/docs/coverage/detail/lang.rust.framework.ntex.md
@@ -1,0 +1,131 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.rust.framework.ntex` — ntex
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 49
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | 3628 | — | — |
+| Endpoint pagination posture | ✅ `full` | `2026-06-13` | 5019 | `internal/custom/rust/endpoint_pagination.go`<br>`internal/custom/rust/endpoint_pagination_test.go` | #5019 (child of #3628) Rust port: paginated/pagination_style/pagination_params/pagination_source stamped at the SOURCE by re-emitting the SCOPE.Operation/endpoint op so it merges onto the producer route op by Name (same approach as endpoint_response_codes.go; the engine applyEndpointPagination pass is gated on http_endpoint_definition and cannot reach Rust SCOPE.Operation custom entities). tide: `app.at("/p").get(handler)` names a handler; literal `req.query(...).get("limit")`-style query reads in the body name the params (plus typed `Query<Struct>` fields). Value-asserted TestRustPagination_TideLiteralReads (cursor->cursor). HONEST-PARTIAL (shared classifier): a lone limit-like param or a lone `.limit()` with no offset companion is ambiguous and NOT stamped (TestRustPagination_LoneLimitNotStamped, _LimitOnlyOrmNotStamped); a handler with no pagination shape is not re-emitted (TestRustPagination_NoPaginationNotStamped). Styles: limit+offset->offset, page->page, cursor/after/before/page_token->cursor. hyper (raw match-arm dispatch) and tower (no HTTP routes) remain missing (no named handler) — deferred follow-up. |
+| Endpoint response codes | ✅ `full` | `2026-06-12` | 5018 | `internal/custom/rust/endpoint_response_codes.go`<br>`internal/custom/rust/endpoint_response_codes_test.go` | #5018 (child of #3628, follow-up to #4965) Rust port: response_codes/success_code/response_codes_source stamped at the SOURCE by re-emitting the SCOPE.Operation/endpoint op so it merges onto the producer route op by Name (same handler-name correlation as axum; the engine applyEndpointResponseCodes pass is gated on http_endpoint_definition and cannot reach Rust SCOPE.Operation custom entities). extractHandlerNamed builds a handler->verdict map from every fn body once, then re-runs each framework's PRODUCER route regexes (minor_fw_routing.go) and stamps the verdict onto routes naming a resolving handler. poem: .at("/p", post(h)) + Response::builder().status(StatusCode::X)/bare StatusCode::X. warp: filter chain .and_then(h)/.map(h) + warp::reply::with_status(reply, StatusCode::X). tide: .at("/p").post(h) + Response::builder(NNN)/.set_status(NNN) positional status. gotham: route.verb("/p").to(h)/.associate + (StatusCode::X, body) create_response. salvo: Router::with_path("p").verb(h) + res.status_code(StatusCode::X). Shared StatusCode/Status name table + numeric constructors. Honest-partial: a route whose handler resolves no literal status is left to the producer (no fabricated 200). Value-asserted: TestRustRespCodes_PoemHandlerStatus, _WarpWithStatus, _TideBuilderStatus, _GothamRouteStatus, _SalvoStatusCode (+ _MinorFwNoStatusNotStamped negative). hyper (raw match-arm, no named handler) and tower (no HTTP routes) DEFERRED to a follow-up. |
+| Endpoint synthesis | ✅ `full` | `2026-06-14` | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: ntex (actix-derived) route producer mirrors actix_web.go — attribute macros #[get("/p")]/#[web::get("/p")] + manual .route("/p", web::get().to(h)) + web::resource("/p").route(web::get().to(h)), scope-aware via web::scope("/prefix"). Gated on a `ntex` token so it cannot fire on real actix files. Path params normalised to {id}. HttpServer::new()/web::server() -> SCOPE.Service, .wrap(MW) -> SCOPE.Pattern. Value-asserted: TestNtexMacroRoute/TestNtexResourceScopeComposed/TestNtexServerAndMiddleware (+ wrong-language + no-match no-ops). Non-Routing cells inherited from the shared rust passes (identical to the other minor-framework records). |
+| Handler attribution | ✅ `full` | `2026-06-14` | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: handler_name captured for every ntex route; asserted by TestNtexResourceScopeComposed. |
+| Route extraction | ✅ `full` | `2026-06-14` | 5008 | `internal/custom/rust/helpers.go`<br>`internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: ntex scope+resource path composition with {id} param normalisation (helpers.rustNormalizePath/rustJoinPaths). |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | view_rendering:#3628-not-yet-extracted | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | heuristic auth-signal detection (jwt/bearer/apikey/session keywords + middleware-name classification); no framework-specific guard-to-validator binding modelled for tide |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🟢 `partial` | `2026-06-12` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go`<br>`internal/extractors/rust/issue4854_field_membership_test.go`<br>`internal/extractors/rust/struct_fields.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. #4854: the serde/utoipa/ORM-gated custom emitters only emitted field members for bound DTOs; the GENERAL primary-pass now emits a SCOPE.Schema/field entity + struct->field CONTAINS for EVERY named struct field (serde rename wire name honoured, serde skip excluded, Name '<Struct>.<wire>' dedups by Name in MergeWithCustom) and for named fields of struct-style enum variants ('<Enum>.<Variant>.<field>'), so any Rust data struct projects field rows in the dashboard shape tree — closing the same gap #4845/#4851 fixed for JS/TS and #4850/#4855 for Go. Rust has no inheritance so there is no EXTENDS. emitRustStructFields/emitRustEnumVariantFields in rust/struct_fields.go; value-asserted by TestRustStructFieldsAreContained/TestRustEnumVariantFieldsAreContained. |
+| Request validation | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/fw_validation.go` | serde/validator DTO field+constraint decomposition (field name, type, #[serde] rename_all/rename/default/skip/flatten, #[validate(length/range/email/regex/custom/nested)] with specific bounds) is implemented in fw_validation.go and proven by value-asserting tests. Flipped full only for flagship axum/actix/rocket where DTOs are typed extractor payloads (Json/Form). This framework's body-deser path is value-untyped at the extraction site (serde_json::from_slice / body_json), so DTO-to-extractor binding is not statically proven here — honest-partial pending cross-file type-flow. |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/auth.go`<br>`internal/custom/rust/auth_policy.go` | framework middleware registration surface detected (with/middleware/attach/filter/add_middleware) but tide layer chains are not ordered/enumerated like tower |
+| Rate limit stamping | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/3778) | — | endpoint rate-limit / throttle stamping not yet implemented for this framework; the #3628 child shipped express-rate-limit (JS/TS) + slowapi/django-ratelimit/flask-limiter/DRF (Python). express-slow-down-compatible / framework-native limiters for this framework are future work. |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | — `not_applicable` | — | — | — | GraphQL schema type→type graph (object-typed field -> referenced object type with list/nullable cardinality) is a GraphQL-only concept; this framework is not a GraphQL server, so it has no GraphQL object-type relationship graph. |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Interface extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type alias extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+| Type extraction | ✅ `full` | `2026-05-30` | — | `internal/extractors/rust/rust.go` | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | 3628 | — | — |
+| DI injection point | 🔴 `missing` | — | 3628 | — | — |
+| DI scope resolution | 🔴 `missing` | — | 3628 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/extractors/cross/testmap/frameworks.go` | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🟢 `partial` | `2026-05-30` | backfill:dictionary-completeness | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing info!/warn!/error!/debug!/trace! (qualified + bare), log::*, event!(Level,..), slog::*, #[instrument]; level+library captured, static message head captured when leading string literal. Stays PARTIAL: messages are often format strings with interpolated/structured fields, and logger->subscriber/appender binding is cross-file (same limitation as PHP/Java/Ruby per-framework log cells) |
+| Metric extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | metrics crate counter!/gauge!/histogram!("name"), prometheus register_*!/IntCounter::new/Opts::new("name"), opentelemetry meter.u64_counter("name"); metric NAME captured as observability_name + observability_kind/library props; value-asserting tests TestRustObs_MetricsMacro_CapturesName_Issue3416 + TestRustObs_PrometheusName_Issue3416 + TestRustObs_OtelMeter_Issue3416. Per-call-site literal name needs no cross-file resolution; binding meter->exporter stays out of scope |
+| Trace extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/rust/observability.go`<br>`internal/custom/rust/observability_auth_test.go` | tracing span!(Level,"name")/info_span!("name"), opentelemetry global::tracer("svc")/tracer.start("name")/span_builder("name"); span NAME captured as observability_name; value-asserting tests TestRustObs_SpanName_Issue3416 + TestRustObs_OtelSpanName_Issue3416. Literal span name needs no cross-file resolution; #[instrument]-derived names and tracer->exporter binding stay out of scope |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🟢 `partial` | `2026-06-11` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_cross_orm_read_4692_test.go`<br>`internal/substrate/effect_sinks_rust.go` | #4737 (Rust slice of the #4692 cross-ORM receiver-typed read-reach audit): the ambiguous Diesel/sea-orm read terminals (.first/.find/.filter/.select/.all/.one + .order/.limit/.offset/.join) that collide with Rust Iterator combinators are now credited db_read ONLY on a query/table/Entity-typed receiver (Diesel schema::table root, .into_boxed()/QueryDsl chain, sea-orm Entity::find()) -- propagated across let q2 = q.filter(...) chains to a fixpoint and matched inline off a query root (users::table.filter(...).first(conn)). The distinctive terminals (sqlx::query!, .fetch_*, diesel::select/sql_query, .load/.get_result(s), .find_by_id/.stream/.paginate) stay bare on any receiver. vec.iter().filter(...).find(...) / slice.first() stay PURE (over-credit guard). Value-asserted in TestRustDieselSeaOrmTypedRead_4737 / TestRustIteratorNoFalsePositive_4737 / TestRustRepoReadChainSink_4737. |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | ✅ `full` | `2026-05-28` | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| Config consumption | 🟢 `partial` | `2026-06-12` | config_consumption:#5079-keyless-envy-figment-extract-deferred | `internal/extractor/config_key.go`<br>`internal/extractors/rust/config_consumer.go`<br>`internal/extractors/rust/config_consumer_test.go`<br>`internal/extractors/rust/rust.go` | #5020+#5079: literal env/config-crate key reads emit the config-consumption topology — env::var(K)/std::env::var/env::var_os, dotenvy::var(K), figment Env::prefixed(P), and (#5079) the config crate typed getters cfg.get_string/get_int/get_bool/get_float(K) + turbofish cfg.get::<T>(K) — each becomes a shared SCOPE.Config/config_key node + a DEPENDS_ON_CONFIG edge (pattern=config_crate) from the reading function (receiver-qualified Foo.method), via emitConfigConsumerEdges -> extractor.EmitConfigReads. Honest-partial: only LITERAL string keys recorded — dynamic env::var(name) and bare HashMap .get(k) yield nothing; the truly KEYLESS crate APIs envy::from_env::<T>() and Figment::new().merge(...).extract::<T>() (whole-struct deserialise, no single literal key) remain deferred (#5079 follow-up). Value-asserted: TestRustConfig_EnvVar/Dotenvy/FigmentPrefix/MethodHostName/ConfigCrateGetters/ConfigCrateTurbofish/BareGetNotConfig/DynamicKeySkipped. |
+| Constant propagation | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| Dead code detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| Def use chain extraction | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/def_use_pass.go`<br>`internal/substrate/def_use_rust.go` | — |
+| Env fallback recognition | ✅ `full` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| Error flow | ✅ `full` | `2026-06-03` | 3628 | `internal/extractor/exception_flow.go`<br>`internal/extractors/rust/exception_flow.go`<br>`internal/extractors/rust/exception_flow_test.go` | Err(Type::ctor())/Err(Type::Variant)/Err(Type(..)) + bail!/ensure!(Type::X) + .ok_or(Type::X)/.ok_or_else(||Type::X) -> THROWS (enum variant normalized to leading-segment ENUM type); match Err(Type)/if let Err(Type)/.map_err(|e: Type|) -> CATCHES; bare ? propagation, Box<dyn Error>, string panic!, Err(var)/Err(make()) re-raise dropped (honest-partial, #3628) |
+| Feature flag gating | 🟢 `partial` | `2026-06-12` | feature_flag_gating:#5079-cfg-combinator-keys-and-attribute-attribution-deferred | `internal/engine/feature_flag_edges.go`<br>`internal/engine/feature_flag_edges_test.go` | #5079: Rust conditional-compilation feature gating — cfg!(feature=x) macro + #[cfg(feature=x)] / #[cfg_attr(feature=x,...)] attributes — emits a SCOPE.FeatureFlag entity (feature:<key>, subtype rust-cfg) + a GATED_BY edge from the enclosing function, via a lang-gated matcher in applyFeatureFlagEdges (distinct from the runtime flag-SDK model). Honest-partial: a cfg! macro in a function body attributes to that function; a #[cfg(...)] attribute precedes its item and attributes to prior-function/file scope (same caveat as .NET [FeatureGate]); a multi-feature combinator all(...)/any(...) captures only the FIRST feature key. Value-asserted: TestFeatureFlag_Rust_cfg_macro/cfg_attribute/cfg_combinator_firstKey/cfg_langGated_noFabrication. |
+| Fs effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| HTTP effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| Import resolution quality | 🟢 `partial` | `2026-05-27` | — | `internal/links/constant_propagation.go`<br>`internal/substrate/rust.go`<br>`internal/substrate/substrate.go` | — |
+| Module cycle detection | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/module_cycle_pass.go` | — |
+| Mutation effect | 🟢 `partial` | `2026-05-28` | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_rust.go` | — |
+| Pure function tagging | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/pure_function_pass.go` | — |
+| Reachability analysis | 🟢 `partial` | `2026-05-28` | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_rust.go` | — |
+| Request shape extraction | 🟢 `partial` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| Request sink dataflow | 🔴 `missing` | — | 3740 | — | — |
+| Response shape extraction | 🟢 `partial` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| Sanitizer recognition | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+| Schema drift detection | 🟢 `partial` | `2026-05-28` | [link](https://github.com/cajasmota/archigraph/issues/2771) | `internal/links/payload_drift.go`<br>`internal/mcp/payload_drift_tool.go`<br>`internal/substrate/payload_shapes.go`<br>`internal/substrate/payload_shapes_rust.go` | — |
+| Taint sink detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+| Taint source detection | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+| Template pattern catalog | 🟢 `partial` | — | backfill:dictionary-completeness | `internal/links/template_pattern_pass.go`<br>`internal/substrate/template_pattern_rust.go` | — |
+| Vulnerability finding | 🟢 `partial` | `2026-05-28` | — | `internal/links/taint_flow.go`<br>`internal/substrate/taint_sites_rust.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.rust.framework.ntex ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/platform.rust.shuttle.md
+++ b/docs/coverage/detail/platform.rust.shuttle.md
@@ -1,0 +1,33 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `platform.rust.shuttle` — Shuttle (deploy runtime)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [platform](../by-category/platform.md)
+- **Subcategory:** IaC / Provisioning
+- **Capability cells:** 9
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency attribution | — `not_applicable` | — | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: not applicable to Shuttle's attribute-macro runtime-provisioning model (no IaC stack graph / cross-stack refs / IAM grants); only entrypoint + managed-resource declarations are surfaced (resource_extraction). |
+| Iac cross stack reference | — `not_applicable` | — | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: not applicable to Shuttle's attribute-macro runtime-provisioning model (no IaC stack graph / cross-stack refs / IAM grants); only entrypoint + managed-resource declarations are surfaced (resource_extraction). |
+| Iac environment region account | — `not_applicable` | — | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: not applicable to Shuttle's attribute-macro runtime-provisioning model (no IaC stack graph / cross-stack refs / IAM grants); only entrypoint + managed-resource declarations are surfaced (resource_extraction). |
+| Iac event source wiring | — `not_applicable` | — | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: not applicable to Shuttle's attribute-macro runtime-provisioning model (no IaC stack graph / cross-stack refs / IAM grants); only entrypoint + managed-resource declarations are surfaced (resource_extraction). |
+| Iac iam grant attribution | — `not_applicable` | — | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: not applicable to Shuttle's attribute-macro runtime-provisioning model (no IaC stack graph / cross-stack refs / IAM grants); only entrypoint + managed-resource declarations are surfaced (resource_extraction). |
+| Iac output export extraction | — `not_applicable` | — | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: not applicable to Shuttle's attribute-macro runtime-provisioning model (no IaC stack graph / cross-stack refs / IAM grants); only entrypoint + managed-resource declarations are surfaced (resource_extraction). |
+| Iac resource property extraction | 🟢 `partial` | `2026-06-14` | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: resource_provider/resource_type props stamped on each Shuttle managed-resource component; deeper per-resource config (db size/region) not modelled. |
+| Iac stack app topology | — `not_applicable` | — | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: not applicable to Shuttle's attribute-macro runtime-provisioning model (no IaC stack graph / cross-stack refs / IAM grants); only entrypoint + managed-resource declarations are surfaced (resource_extraction). |
+| Resource extraction | 🟢 `partial` | `2026-06-14` | 5008 | `internal/custom/rust/ntex_loco_shuttle.go`<br>`internal/custom/rust/ntex_loco_shuttle_test.go` | #5008: Shuttle managed-resource extraction — #[shuttle_runtime::main] entrypoint -> SCOPE.Service (deploy_runtime=shuttle, entrypoint=fn) and each #[shuttle_*::Resource] annotation (shuttle_shared_db::Postgres, shuttle_secrets::Secrets, shuttle_aws_rds::*, shuttle_persist::*, …) -> SCOPE.Component (resource_provider/resource_type). Gated on a `shuttle_` token; the runtime::main macro is excluded from the resource set. Value-asserted: TestShuttleRuntimeAndResources (+ wrong-language + no-match no-ops). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update platform.rust.shuttle ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.insta.md
+++ b/docs/coverage/detail/test.insta.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.insta` — insta
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/tests_edges.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | #5008: insta snapshot testing (assert_snapshot!/assert_debug_snapshot!/assert_json_snapshot! + snapshots/ *.snap structural markers) detection added to rust/test_patterns.yaml; dev-dependency manifest parsing, same model as test.mockall. |
+| Target extraction | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/rules/rust/test_patterns.yaml`<br>`internal/extractors/cross/testmap/frameworks.go` | #5008: insta snapshot testing (assert_snapshot!/assert_debug_snapshot!/assert_json_snapshot! + snapshots/ *.snap structural markers) detection added to rust/test_patterns.yaml; dev-dependency manifest parsing, same model as test.mockall. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.insta ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.mockito-rs.md
+++ b/docs/coverage/detail/test.mockito-rs.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.mockito-rs` — mockito (Rust)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/tests_edges.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | #5008: mockito (Rust) in-process HTTP mock server (mockito::Server::new + .mock(method,path).with_status().create()) detection added to rust/test_patterns.yaml; dev-dependency manifest parsing via the cross testmap/build path, same model as test.mockall. Distinct from the JVM Mockito (test.mockito). |
+| Target extraction | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/rules/rust/test_patterns.yaml`<br>`internal/extractors/cross/testmap/frameworks.go` | #5008: mockito (Rust) in-process HTTP mock server (mockito::Server::new + .mock(method,path).with_status().create()) detection added to rust/test_patterns.yaml; dev-dependency manifest parsing via the cross testmap/build path, same model as test.mockall. Distinct from the JVM Mockito (test.mockito). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.mockito-rs ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.serial-test.md
+++ b/docs/coverage/detail/test.serial-test.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.serial-test` — serial_test
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/tests_edges.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | #5008: serial_test (#[serial]/#[parallel]/#[file_serial]) detection added to rust/test_patterns.yaml; the underlying #[test]/#[tokio::test] fn is already linked to its subject by the shared rustTestRE in frameworks.go (extra-attribute lines tolerated), so a #[serial]-decorated test is attributed without a serial-specific code path. |
+| Target extraction | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/rules/rust/test_patterns.yaml`<br>`internal/extractors/cross/testmap/frameworks.go` | #5008: serial_test (#[serial]/#[parallel]/#[file_serial]) detection added to rust/test_patterns.yaml; the underlying #[test]/#[tokio::test] fn is already linked to its subject by the shared rustTestRE in frameworks.go (extra-attribute lines tolerated), so a #[serial]-decorated test is attributed without a serial-specific code path. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.serial-test ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.wiremock.md
+++ b/docs/coverage/detail/test.wiremock.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.wiremock` — wiremock
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [rust](../by-language/rust.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/tests_edges.go`<br>`internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/resolver.go` | #5008: wiremock async HTTP mock server (MockServer::start + Mock::given(matcher).respond_with(ResponseTemplate::new).mount) detection added to rust/test_patterns.yaml; dev-dependency manifest parsing, same model as test.mockall. |
+| Target extraction | ✅ `full` | `2026-06-14` | 5008 | `internal/engine/rules/rust/test_patterns.yaml`<br>`internal/extractors/cross/testmap/frameworks.go` | #5008: wiremock async HTTP mock server (MockServer::start + Mock::given(matcher).respond_with(ResponseTemplate::new).mount) detection added to rust/test_patterns.yaml; dev-dependency manifest parsing, same model as test.mockall. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.wiremock ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 247 · **ORMs**: 172 · **Tools**: 120 · **Other**: 204
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 249 · **ORMs**: 172 · **Tools**: 124 · **Other**: 205
 
 ## Coverage by language
 
@@ -14,8 +14,8 @@
 | [C/C++](by-language/c-cpp.md) | 20 | 16 | 10 | 4 |
 | [C#](by-language/csharp.md) | 18 | 7 | 16 | 9 |
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
+| [rust](by-language/rust.md) | 17 | 10 | 15 | 5 |
 | [php](by-language/php.md) | 16 | 6 | 14 | 1 |
-| [rust](by-language/rust.md) | 15 | 6 | 15 | 4 |
 | [elixir](by-language/elixir.md) | 14 | 9 | 10 | 5 |
 | [scala](by-language/scala.md) | 14 | 3 | 7 | 1 |
 | [ruby](by-language/ruby.md) | 9 | 6 | 14 | 8 |
@@ -53,7 +53,7 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 
 | Lane | Records | Tools |
 |---|---:|---|
-| [IaC / Provisioning](by-category/platform.md#iac--provisioning) | 8 | AWS CDK, AWS CloudFormation, Ansible, Azure Bicep, … |
+| [IaC / Provisioning](by-category/platform.md#iac--provisioning) | 9 | AWS CDK, AWS CloudFormation, Ansible, Azure Bicep, … |
 | [Containers & Orchestration](by-category/platform.md#containers--orchestration) | 5 | Dockerfile, Helm charts, Kubernetes manifests, Kustomize, … |
 | [Config Files](by-category/platform.md#config-files) | 7 | .env, .ini, .properties, .toml, … |
 | [Workflow / DAG & State Machines](by-category/platform.md#workflow--dag--state-machines) | 8 | Apache Airflow, Argo Workflows, Celery canvas, Python transitions, … |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 247 frameworks · 120 tools · 172 ORMs · 204 other
+Total: 249 frameworks · 124 tools · 172 ORMs · 205 other

--- a/internal/custom/rust/ntex_loco_shuttle.go
+++ b/internal/custom/rust/ntex_loco_shuttle.go
@@ -1,0 +1,415 @@
+package rust
+
+// ntex_loco_shuttle.go — route / deploy-substrate extractors for three more
+// Rust frameworks deferred from the #4964 audit (follow-up #5008):
+//
+//   - ntex      : actix-derived async HTTP framework. Same #[get("/p")] route
+//                 macros + manual web::resource("/p").route(web::get().to(h))
+//                 + web::scope("/prefix") + ntex::web::HttpServer builder as
+//                 actix, so this mirrors actix_web.go's producer surface.
+//   - Loco.rs   : batteries-included MVC framework. Routes are declared with
+//                 Routes::new().add("/path", get(handler)) (axum-style method
+//                 routers under the hood) and prefixed via .prefix("/api").
+//   - Shuttle   : a deploy / runtime substrate, NOT an HTTP router. The
+//                 #[shuttle_runtime::main] entrypoint + #[shuttle_*::*]
+//                 resource annotations (shuttle_shared_db::Postgres, etc.)
+//                 declare the managed runtime + provisioned resources. We
+//                 emit a SCOPE.Service for the runtime entrypoint and a
+//                 SCOPE.Component per declared managed resource so the deploy
+//                 substrate is visible in the graph.
+//
+// All patterns are regex-based, conservative, and fixture-proven. Each
+// extractor returns nil for non-rust files (wrong-language no-op) and for
+// files with no matching signal (no-match no-op).
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_ntex", &ntexExtractor{})
+	extractor.Register("custom_rust_loco", &locoExtractor{})
+	extractor.Register("custom_rust_shuttle", &shuttleExtractor{})
+}
+
+// ---------------------------------------------------------------------------
+// ntex (actix-derived)
+// ---------------------------------------------------------------------------
+
+type ntexExtractor struct{}
+
+func (e *ntexExtractor) Language() string { return "custom_rust_ntex" }
+
+var (
+	// ntex signal — require an ntex import / path so the actix-shaped route
+	// regexes below cannot mis-fire on a real actix file (which has its own
+	// extractor). ntex code references `ntex::web` / `ntex::` or `use ntex`.
+	reNtexSignal = regexp.MustCompile(`\bntex\b`)
+
+	// #[get("/path")] / #[web::get("/path")] async fn handler(...) — attribute
+	// route macros (ntex exposes both the bare and web::-qualified forms).
+	reNtexRouteMacro = regexp.MustCompile(
+		`#\[(?:web::)?(get|post|put|delete|patch|head|options)\s*\(\s*"([^"]+)"\s*\)\][\s\S]*?(?:async\s+)?fn\s+(\w+)\s*\(`,
+	)
+	// web::scope("/prefix")
+	reNtexScope = regexp.MustCompile(
+		`web::scope\s*\(\s*"([^"]+)"\s*\)`,
+	)
+	// Manual route registration. ntex exposes BOTH the actix-style
+	//   .route("/p", web::get().to(h))
+	// and the resource-builder style
+	//   web::resource("/p").route(web::get().to(h))
+	// We capture the chained-on-resource verb+handler with the path on the
+	// resource() call.
+	reNtexRouteManual = regexp.MustCompile(
+		`\.route\s*\(\s*"([^"]+)"\s*,\s*web::(get|post|put|delete|patch|head|options)\s*\(\s*\)\.to\s*\(\s*(\w+)\s*\)`,
+	)
+	reNtexResource = regexp.MustCompile(
+		`web::resource\s*\(\s*"([^"]+)"\s*\)\s*\.route\s*\(\s*web::(get|post|put|delete|patch|head|options)\s*\(\s*\)\.to\s*\(\s*(\w+)\s*\)`,
+	)
+	// .wrap(Middleware)
+	reNtexWrap = regexp.MustCompile(
+		`\.wrap\s*\(\s*([A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)`,
+	)
+	// HttpServer::new( — ntex::web::HttpServer / web::server builder.
+	reNtexServer = regexp.MustCompile(
+		`(?:HttpServer\s*::\s*new|web::server)\s*\(`,
+	)
+)
+
+// ntexScopePrefix returns the nearest preceding web::scope("/prefix") on the
+// same chain (no `;` separator) as the route at routeOff. Mirrors
+// actixScopePrefix.
+func ntexScopePrefix(src string, routeOff int) string {
+	locs := reNtexScope.FindAllStringSubmatchIndex(src, -1)
+	best := -1
+	var prefix string
+	for _, sm := range locs {
+		if sm[0] > routeOff {
+			break
+		}
+		if strings.ContainsAny(src[sm[1]:routeOff], ";") {
+			continue
+		}
+		best = sm[0]
+		prefix = rustNormalizePath(src[sm[2]:sm[3]])
+	}
+	if best < 0 {
+		return ""
+	}
+	return prefix
+}
+
+func (e *ntexExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.ntex_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "ntex"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !reNtexSignal.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Attribute route macros -> SCOPE.Operation/endpoint.
+	for _, m := range reNtexRouteMacro.FindAllStringSubmatchIndex(src, -1) {
+		method := strings.ToUpper(src[m[2]:m[3]])
+		path := rustNormalizePath(src[m[4]:m[5]])
+		handler := src[m[6]:m[7]]
+		name := method + " " + path
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ntex", "provenance", "INFERRED_FROM_NTEX_ROUTE",
+			"http_method", method, "route_pattern", path, "handler_name", handler)
+		add(ent)
+	}
+
+	// 2. web::resource("/p").route(web::get().to(h)) -> endpoint (scope-aware).
+	for _, m := range reNtexResource.FindAllStringSubmatchIndex(src, -1) {
+		path := rustNormalizePath(src[m[2]:m[3]])
+		method := strings.ToUpper(src[m[4]:m[5]])
+		handler := src[m[6]:m[7]]
+		prefix := ntexScopePrefix(src, m[0])
+		fullPath := rustJoinPaths(prefix, path)
+		name := method + " " + fullPath
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ntex", "provenance", "INFERRED_FROM_NTEX_RESOURCE",
+			"http_method", method, "route_pattern", fullPath, "handler_name", handler)
+		if prefix != "" {
+			setProps(&ent, "scope_prefix", prefix)
+		}
+		add(ent)
+	}
+
+	// 3. Manual .route("/p", web::get().to(h)) -> endpoint (scope-aware).
+	for _, m := range reNtexRouteManual.FindAllStringSubmatchIndex(src, -1) {
+		path := rustNormalizePath(src[m[2]:m[3]])
+		method := strings.ToUpper(src[m[4]:m[5]])
+		handler := src[m[6]:m[7]]
+		prefix := ntexScopePrefix(src, m[0])
+		fullPath := rustJoinPaths(prefix, path)
+		name := method + " " + fullPath
+		ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ntex", "provenance", "INFERRED_FROM_NTEX_ROUTE",
+			"http_method", method, "route_pattern", fullPath, "handler_name", handler)
+		if prefix != "" {
+			setProps(&ent, "scope_prefix", prefix)
+		}
+		add(ent)
+	}
+
+	// 4. web::scope("/prefix") -> SCOPE.Component.
+	for _, m := range reNtexScope.FindAllStringSubmatchIndex(src, -1) {
+		prefix := src[m[2]:m[3]]
+		ent := makeEntity(prefix, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ntex", "provenance", "INFERRED_FROM_NTEX_SCOPE",
+			"scope_prefix", prefix)
+		add(ent)
+	}
+
+	// 5. .wrap(Middleware) -> SCOPE.Pattern.
+	for _, m := range reNtexWrap.FindAllStringSubmatchIndex(src, -1) {
+		mwType := src[m[2]:m[3]]
+		ent := makeEntity("middleware:"+mwType, "SCOPE.Pattern", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ntex", "provenance", "INFERRED_FROM_NTEX_MIDDLEWARE",
+			"middleware_type", mwType)
+		add(ent)
+	}
+
+	// 6. HttpServer::new()/web::server() -> SCOPE.Service.
+	for _, m := range reNtexServer.FindAllStringIndex(src, -1) {
+		ent := makeEntity("ntex::HttpServer", "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "ntex", "provenance", "INFERRED_FROM_NTEX_SERVER")
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Loco.rs
+// ---------------------------------------------------------------------------
+
+type locoExtractor struct{}
+
+func (e *locoExtractor) Language() string { return "custom_rust_loco" }
+
+var (
+	// Loco signal — `loco_rs::` import path or `use loco_rs`.
+	reLocoSignal = regexp.MustCompile(`\bloco_rs\b`)
+
+	// Routes::new().add("/path", get(handler).post(other)) — a Loco controller
+	// route. The verb argument is an axum-style method router (one or more
+	// verb(handler) chained). We capture the path + the whole method-router
+	// argument and re-scan with reLocoVerb. The method-router body excludes
+	// parens/semicolons so the match cannot run past the .add(...) call.
+	reLocoAdd = regexp.MustCompile(
+		`\.add\s*\(\s*"([^"]+)"\s*,\s*((?:get|post|put|delete|patch|head|options)\s*\(\s*\w+\s*\)(?:\s*\.\s*(?:get|post|put|delete|patch|head|options)\s*\(\s*\w+\s*\))*)`,
+	)
+	// Individual verb(handler) calls inside a Loco method-router argument.
+	reLocoVerb = regexp.MustCompile(
+		`(get|post|put|delete|patch|head|options)\s*\(\s*(\w+)\s*\)`,
+	)
+	// Routes::new().prefix("/api") — controller mount prefix.
+	reLocoPrefix = regexp.MustCompile(
+		`\.prefix\s*\(\s*"([^"]+)"\s*\)`,
+	)
+)
+
+// locoPrefix returns the nearest preceding .prefix("/p") on the same Routes
+// chain (no `;` between it and the route at routeOff).
+func locoPrefix(src string, routeOff int) string {
+	locs := reLocoPrefix.FindAllStringSubmatchIndex(src, -1)
+	best := -1
+	var prefix string
+	for _, sm := range locs {
+		if sm[0] > routeOff {
+			break
+		}
+		if strings.ContainsAny(src[sm[1]:routeOff], ";") {
+			continue
+		}
+		best = sm[0]
+		prefix = rustNormalizePath(src[sm[2]:sm[3]])
+	}
+	if best < 0 {
+		return ""
+	}
+	return prefix
+}
+
+func (e *locoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.loco_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "loco"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !reLocoSignal.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. Routes::new().add("/p", get(h).post(h2)) -> one endpoint per verb.
+	for _, m := range reLocoAdd.FindAllStringSubmatchIndex(src, -1) {
+		path := rustNormalizePath(src[m[2]:m[3]])
+		methodRouter := src[m[4]:m[5]]
+		prefix := locoPrefix(src, m[0])
+		fullPath := rustJoinPaths(prefix, path)
+		for _, vm := range reLocoVerb.FindAllStringSubmatch(methodRouter, -1) {
+			method := strings.ToUpper(vm[1])
+			handler := vm[2]
+			name := method + " " + fullPath
+			ent := makeEntity(name, "SCOPE.Operation", "endpoint", file.Path, file.Language, lineOf(src, m[0]))
+			setProps(&ent, "framework", "loco", "provenance", "INFERRED_FROM_LOCO_ROUTE",
+				"http_method", method, "route_pattern", fullPath, "handler_name", handler)
+			if prefix != "" {
+				setProps(&ent, "scope_prefix", prefix)
+			}
+			add(ent)
+		}
+	}
+
+	// 2. .prefix("/api") -> SCOPE.Component (controller mount).
+	for _, m := range reLocoPrefix.FindAllStringSubmatchIndex(src, -1) {
+		prefix := rustNormalizePath(src[m[2]:m[3]])
+		ent := makeEntity("loco-prefix:"+prefix, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "loco", "provenance", "INFERRED_FROM_LOCO_PREFIX",
+			"scope_prefix", prefix)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// ---------------------------------------------------------------------------
+// Shuttle (deploy / runtime substrate)
+// ---------------------------------------------------------------------------
+
+type shuttleExtractor struct{}
+
+func (e *shuttleExtractor) Language() string { return "custom_rust_shuttle" }
+
+var (
+	// Shuttle signal — any `shuttle_` crate reference.
+	reShuttleSignal = regexp.MustCompile(`\bshuttle_\w+\b`)
+
+	// #[shuttle_runtime::main] — the managed-runtime entrypoint. The annotated
+	// async fn is the deploy entrypoint.
+	reShuttleMain = regexp.MustCompile(
+		`#\[shuttle_runtime::main\][\s\S]*?(?:async\s+)?fn\s+(\w+)\s*\(`,
+	)
+	// #[shuttle_shared_db::Postgres] / #[shuttle_secrets::Secrets] /
+	// #[shuttle_aws_rds::Postgres] / #[shuttle_persist::Persist] — a managed
+	// resource provisioned by the platform and injected into main(). Captures
+	// the provider crate (group 1) + the resource type (group 2).
+	reShuttleResource = regexp.MustCompile(
+		`#\[(shuttle_\w+)::(\w+)\b`,
+	)
+)
+
+func (e *shuttleExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/rust")
+	_, span := tracer.Start(ctx, "indexer.shuttle_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "shuttle"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !reShuttleSignal.MatchString(src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// 1. #[shuttle_runtime::main] entrypoint -> SCOPE.Service (deploy substrate).
+	for _, m := range reShuttleMain.FindAllStringSubmatchIndex(src, -1) {
+		fn := src[m[2]:m[3]]
+		ent := makeEntity("shuttle::"+fn, "SCOPE.Service", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "shuttle", "provenance", "INFERRED_FROM_SHUTTLE_MAIN",
+			"deploy_runtime", "shuttle", "entrypoint", fn)
+		add(ent)
+	}
+
+	// 2. #[shuttle_*::Resource] managed resources -> SCOPE.Component (one per
+	//    provider::resource declaration). The #[shuttle_runtime::main] macro is
+	//    the entrypoint, not a provisioned resource, so it is excluded here.
+	for _, m := range reShuttleResource.FindAllStringSubmatchIndex(src, -1) {
+		provider := src[m[2]:m[3]]
+		resource := src[m[4]:m[5]]
+		if provider == "shuttle_runtime" && resource == "main" {
+			continue
+		}
+		name := provider + "::" + resource
+		ent := makeEntity("shuttle-resource:"+name, "SCOPE.Component", "", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "shuttle", "provenance", "INFERRED_FROM_SHUTTLE_RESOURCE",
+			"deploy_runtime", "shuttle", "resource_provider", provider, "resource_type", resource)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/rust/ntex_loco_shuttle_test.go
+++ b/internal/custom/rust/ntex_loco_shuttle_test.go
@@ -1,0 +1,187 @@
+package rust_test
+
+// Tests for the ntex / Loco.rs / Shuttle extractors (#5008).
+// Each framework gets: happy-path endpoint/substrate assertions, a
+// wrong-language no-op (file.Language != "rust"), and a no-match no-op
+// (rust file without the framework signal).
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// ntex
+// ---------------------------------------------------------------------------
+
+func TestNtexMacroRoute(t *testing.T) {
+	src := `
+use ntex::web;
+
+#[web::get("/users")]
+async fn list_users() -> impl web::Responder { web::HttpResponse::Ok() }
+
+#[web::post("/users/{id}")]
+async fn update_user() -> impl web::Responder { web::HttpResponse::Ok() }
+`
+	ents := extract(t, "custom_rust_ntex", fi("handlers.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /users") {
+		t.Error("expected GET /users")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "POST /users/{id}") {
+		t.Error("expected POST /users/{id}")
+	}
+}
+
+func TestNtexResourceScopeComposed(t *testing.T) {
+	src := `
+use ntex::web;
+let app = web::scope("/api")
+    .service(web::resource("/users/{id}").route(web::get().to(get_user)));
+`
+	ents := extract(t, "custom_rust_ntex", fi("app.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Operation", "GET /api/users/{id}") {
+		t.Error("expected scope-composed GET /api/users/{id}")
+	}
+	if p, _ := entityProp(ents, "SCOPE.Operation", "GET /api/users/{id}", "handler_name"); p != "get_user" {
+		t.Errorf("handler_name = %q, want get_user", p)
+	}
+	if !containsEntity(ents, "SCOPE.Component", "/api") {
+		t.Error("expected /api scope component")
+	}
+}
+
+func TestNtexServerAndMiddleware(t *testing.T) {
+	src := `
+use ntex::web;
+let server = web::HttpServer::new(|| {
+    web::App::new().wrap(Logger::default())
+}).bind("127.0.0.1:8080")?.run();
+`
+	ents := extract(t, "custom_rust_ntex", fi("main.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Service", "ntex::HttpServer") {
+		t.Error("expected ntex::HttpServer service")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "middleware:Logger::default") {
+		t.Error("expected middleware:Logger::default pattern")
+	}
+}
+
+// Wrong-language no-op: an ntex-looking source tagged as a non-rust file.
+func TestNtexWrongLanguageNoOp(t *testing.T) {
+	src := `use ntex::web; #[web::get("/users")] async fn h() {}`
+	ents := extract(t, "custom_rust_ntex", fi("handlers.go", "go", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-rust file, got %d", len(ents))
+	}
+}
+
+// No-match no-op: a rust file with no ntex signal yields nothing (and must not
+// false-fire on a real actix file — which has no `ntex` token).
+func TestNtexNoMatchNoOp(t *testing.T) {
+	src := `
+use actix_web::web;
+#[get("/users")]
+async fn list_users() -> impl Responder { HttpResponse::Ok() }
+`
+	ents := extract(t, "custom_rust_ntex", fi("handlers.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities (no ntex signal), got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Loco.rs
+// ---------------------------------------------------------------------------
+
+func TestLocoRouteChain(t *testing.T) {
+	src := `
+use loco_rs::prelude::*;
+
+pub fn routes() -> Routes {
+    Routes::new()
+        .prefix("/api")
+        .add("/users", get(list).post(create))
+        .add("/users/:id", delete(remove));
+}
+`
+	ents := extract(t, "custom_rust_loco", fi("controller.rs", "rust", src))
+	for _, want := range []string{
+		"GET /api/users", "POST /api/users", "DELETE /api/users/{id}",
+	} {
+		if !containsEntity(ents, "SCOPE.Operation", want) {
+			t.Errorf("expected %q", want)
+		}
+	}
+	if p, _ := entityProp(ents, "SCOPE.Operation", "POST /api/users", "handler_name"); p != "create" {
+		t.Errorf("handler_name = %q, want create", p)
+	}
+	if !containsEntity(ents, "SCOPE.Component", "loco-prefix:/api") {
+		t.Error("expected loco-prefix:/api component")
+	}
+}
+
+func TestLocoWrongLanguageNoOp(t *testing.T) {
+	src := `use loco_rs::prelude::*; Routes::new().add("/u", get(h));`
+	ents := extract(t, "custom_rust_loco", fi("c.py", "python", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-rust file, got %d", len(ents))
+	}
+}
+
+func TestLocoNoMatchNoOp(t *testing.T) {
+	// axum-style Routes::new().add but no loco_rs signal -> no-op.
+	src := `let r = Routes::new().add("/users", get(list));`
+	ents := extract(t, "custom_rust_loco", fi("r.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities (no loco_rs signal), got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Shuttle (deploy substrate)
+// ---------------------------------------------------------------------------
+
+func TestShuttleRuntimeAndResources(t *testing.T) {
+	src := `
+use shuttle_axum::ShuttleAxum;
+
+#[shuttle_runtime::main]
+async fn main(
+    #[shuttle_shared_db::Postgres] pool: PgPool,
+    #[shuttle_secrets::Secrets] secrets: SecretStore,
+) -> ShuttleAxum {
+    Ok(router.into())
+}
+`
+	ents := extract(t, "custom_rust_shuttle", fi("main.rs", "rust", src))
+	if !containsEntity(ents, "SCOPE.Service", "shuttle::main") {
+		t.Error("expected shuttle::main deploy entrypoint service")
+	}
+	if dr, _ := entityProp(ents, "SCOPE.Service", "shuttle::main", "deploy_runtime"); dr != "shuttle" {
+		t.Errorf("deploy_runtime = %q, want shuttle", dr)
+	}
+	if !containsEntity(ents, "SCOPE.Component", "shuttle-resource:shuttle_shared_db::Postgres") {
+		t.Error("expected shuttle_shared_db::Postgres managed resource")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "shuttle-resource:shuttle_secrets::Secrets") {
+		t.Error("expected shuttle_secrets::Secrets managed resource")
+	}
+	// The runtime entrypoint macro must NOT also be emitted as a resource.
+	if containsEntity(ents, "SCOPE.Component", "shuttle-resource:shuttle_runtime::main") {
+		t.Error("shuttle_runtime::main must not be a managed-resource component")
+	}
+}
+
+func TestShuttleWrongLanguageNoOp(t *testing.T) {
+	src := `#[shuttle_runtime::main] async fn main() {}`
+	ents := extract(t, "custom_rust_shuttle", fi("main.ts", "typescript", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-rust file, got %d", len(ents))
+	}
+}
+
+func TestShuttleNoMatchNoOp(t *testing.T) {
+	src := `#[tokio::main] async fn main() { run().await; }`
+	ents := extract(t, "custom_rust_shuttle", fi("main.rs", "rust", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities (no shuttle_ signal), got %d", len(ents))
+	}
+}

--- a/internal/engine/rules/rust/test_patterns.yaml
+++ b/internal/engine/rules/rust/test_patterns.yaml
@@ -136,6 +136,102 @@ testing:
     a separate test crate beyond tokio itself.
 
     '
+- name: serial_test
+  crate: serial_test
+  category: test_isolation
+  crates_io_version_2025: 3.x
+  detection:
+    cargo_toml_deps:
+    - serial_test
+    dev_dependency: true
+    import_markers:
+    - 'use serial_test::'
+    code_patterns:
+    - '#[serial]'
+    - '#[serial('
+    - '#[parallel]'
+    - '#[file_serial]'
+  notes: 'Forces annotated tests to run serially rather than in parallel. #[serial]
+    attribute (optionally with a named lock group) is the detection signal. Combined
+    with #[test]/#[tokio::test]; rustTestRE already links the underlying test fn.
+
+    '
+- name: mockito
+  crate: mockito
+  category: http_mocking
+  crates_io_version_2025: 1.x
+  detection:
+    cargo_toml_deps:
+    - mockito
+    dev_dependency: true
+    import_markers:
+    - 'use mockito::'
+    code_patterns:
+    - mockito::Server::new
+    - mockito::server_url
+    - .mock(
+    - .with_status(
+    - .with_body(
+    - .create()
+    - Matcher::
+  notes: 'In-process HTTP mock server for testing HTTP clients. mockito::Server::new()
+    and the .mock(method, path) builder are the detection signals. Used inside
+    test functions to stub outbound HTTP. Should be a [dev-dependency].
+
+    '
+- name: wiremock
+  crate: wiremock
+  category: http_mocking
+  crates_io_version_2025: 0.6.x
+  detection:
+    cargo_toml_deps:
+    - wiremock
+    dev_dependency: true
+    import_markers:
+    - 'use wiremock::'
+    - 'use wiremock::matchers::'
+    code_patterns:
+    - MockServer::start
+    - Mock::given(
+    - .respond_with(
+    - ResponseTemplate::new(
+    - .mount(
+    - matchers::method(
+    - matchers::path(
+  notes: 'Async HTTP mock server (tokio-native). MockServer::start() + the
+    Mock::given(matcher).respond_with(...).mount(&server) builder are the detection
+    signals. The async counterpart to mockito. Should be a [dev-dependency].
+
+    '
+- name: insta
+  crate: insta
+  category: snapshot
+  crates_io_version_2025: 1.x
+  detection:
+    cargo_toml_deps:
+    - insta
+    dev_dependency: true
+    import_markers:
+    - 'use insta::'
+    structural_markers:
+    - snapshots/
+    - '*.snap'
+    config_markers:
+    - .insta.yaml
+    code_patterns:
+    - assert_snapshot!(
+    - assert_debug_snapshot!(
+    - assert_json_snapshot!(
+    - assert_yaml_snapshot!(
+    - assert_ron_snapshot!(
+    - insta::with_settings!
+    - glob!(
+  notes: 'Snapshot testing library. assert_snapshot!/assert_debug_snapshot!/
+    assert_json_snapshot! macros write reference snapshots under snapshots/ (*.snap).
+    The snapshots/ directory and .snap files are structural signals. Used inside
+    test functions; should be a [dev-dependency] (cargo-insta is the companion CLI).
+
+    '
 test_conventions:
   inline_unit_tests:
     pattern: '#[cfg(test)] mod tests { ... }'

--- a/internal/substrate/effect_sinks_rust.go
+++ b/internal/substrate/effect_sinks_rust.go
@@ -157,6 +157,33 @@ var rustMutationRe = regexp.MustCompile(
 	`\bself\s*\.\s*[A-Za-z_][\w]*\s*=(?:[^=])`,
 )
 
+// rustPoolSignalRe gates the connection-pool acquisition credit. A file must
+// reference one of the Rust connection-pool crates (deadpool / bb8 / r2d2 /
+// mobc) before a bare `.get()`/`.acquire()` is interpreted as a pooled DB
+// connection checkout — without the gate those method names collide with
+// Option::get / HashMap::get / Mutex::acquire and would false-positive.
+var rustPoolSignalRe = regexp.MustCompile(`\b(?:deadpool|bb8|r2d2|mobc)\b`)
+
+// rustPoolAcquireRe matches a pooled-connection checkout on a `pool`-named
+// receiver across the four crates:
+//
+//	deadpool : pool.get().await?                 (Pool::get)
+//	bb8      : pool.get().await?                 (Pool::get)
+//	mobc     : pool.get().await?                 (Pool::get)
+//	r2d2     : pool.get()? / pool.get_conn()     (sync, no .await)
+//	sqlx     : pool.acquire().await?             (sqlx::Pool::acquire)
+//
+// The receiver is anchored to a name CONTAINING `pool` (case-insensitive) so a
+// generic `cache.get(k)` in a pool-importing file is not mis-credited. The
+// checkout itself is a DB-substrate touch (it reaches the database to lease a
+// live connection), so we credit db_read — this restores attribution to a
+// function that only leases the connection and passes it down, the exact
+// weak-attribution gap called out in #5008. Honest-partial: only a
+// pool-named receiver is credited; an aliased connection handle is not traced.
+var rustPoolAcquireRe = regexp.MustCompile(
+	`\b[A-Za-z_]*[Pp]ool\w*\s*\.\s*(?:get|get_conn|acquire)\s*\(\s*\)`,
+)
+
 func sniffEffectsRust(content string) []EffectMatch {
 	if content == "" {
 		return nil
@@ -173,6 +200,30 @@ func sniffEffectsRust(content string) []EffectMatch {
 	out = appendRustMatches(out, content, headers, rustFSWriteRe, EffectFSWrite, "std::fs::write/File::create", 1.0)
 	out = appendRustMatches(out, content, headers, rustProcessRe, EffectFSWrite, "process::Command", 0.9)
 	out = appendRustMatches(out, content, headers, rustMutationRe, EffectMutation, "self.field=", 0.7)
+	out = append(out, rustPoolAcquireMatches(content, headers)...)
+	return out
+}
+
+// rustPoolAcquireMatches credits db_read for a connection-pool checkout
+// (deadpool / bb8 / r2d2 / mobc / sqlx::Pool) so a function that leases a
+// pooled connection — even when the subsequent query runs on the leased handle
+// in a callee — is attributed to the database substrate. Gated on a pool-crate
+// signal in the file to avoid colliding with Option::get / Mutex::acquire.
+func rustPoolAcquireMatches(content string, headers []funcHeader) []EffectMatch {
+	if !rustPoolSignalRe.MatchString(content) {
+		return nil
+	}
+	var out []EffectMatch
+	for _, m := range rustPoolAcquireRe.FindAllStringIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     EffectDBRead,
+			Sink:       "conn-pool.acquire(deadpool/bb8/r2d2/mobc)",
+			Confidence: 0.8,
+		})
+	}
 	return out
 }
 

--- a/internal/substrate/effect_sinks_rust_pool_5008_test.go
+++ b/internal/substrate/effect_sinks_rust_pool_5008_test.go
@@ -1,0 +1,79 @@
+package substrate
+
+// Connection-pool db_effect attribution (#5008).
+//
+// A pooled-connection checkout (deadpool / bb8 / r2d2 / mobc / sqlx::Pool)
+// reaches the database to lease a live connection, so the leasing function is
+// credited db_read even when the subsequent query runs on the leased handle in
+// a callee. Gated on a pool-crate signal so the bare .get()/.acquire() method
+// names cannot collide with Option::get / HashMap::get / Mutex::acquire.
+
+import "testing"
+
+// A (happy path): each crate's pool checkout earns db_read on the enclosing fn.
+func TestRustConnPoolAcquire_5008(t *testing.T) {
+	src := `
+use deadpool_postgres::Pool;
+use bb8::Pool as Bb8Pool;
+
+impl Db {
+    pub async fn deadpool_handler(&self, pool: &Pool) -> Result<(), Error> {
+        let client = pool.get().await?;
+        client.query("anything", &[]).await?;
+        Ok(())
+    }
+    pub async fn bb8_handler(&self, pool: &Bb8Pool) -> Result<(), Error> {
+        let conn = pool.get().await?;
+        Ok(())
+    }
+    pub fn r2d2_handler(&self, db_pool: &r2d2::Pool<C>) -> Result<(), Error> {
+        let conn = db_pool.get()?;
+        Ok(())
+    }
+    pub async fn mobc_handler(&self, conn_pool: &mobc::Pool<C>) -> Result<(), Error> {
+        let conn = conn_pool.get().await?;
+        Ok(())
+    }
+}
+`
+	by := groupByEffect(sniffEffectsRust(src))
+	mustHave(t, by, EffectDBRead, "deadpool_handler")
+	mustHave(t, by, EffectDBRead, "bb8_handler")
+	mustHave(t, by, EffectDBRead, "r2d2_handler")
+	mustHave(t, by, EffectDBRead, "mobc_handler")
+}
+
+// B (negative — no pool crate signal): a bare `cache.get()` / `lock.acquire()`
+// in a file WITHOUT any pool crate earns no db_read (false-positive guard).
+func TestRustConnPoolNoSignalNoCredit_5008(t *testing.T) {
+	src := `
+use std::collections::HashMap;
+
+impl Cache {
+    pub fn lookup(&self, key: &str) -> Option<&str> {
+        let pool = self.map.get(key);
+        pool.copied()
+    }
+}
+`
+	by := groupByEffect(sniffEffectsRust(src))
+	mustNotHave(t, by, EffectDBRead, "lookup")
+}
+
+// C (negative — pool crate present but the .get() is on a non-pool receiver):
+// a HashMap .get() in a pool-importing file is NOT mis-credited because the
+// receiver name does not contain `pool`.
+func TestRustConnPoolNonPoolReceiverNoCredit_5008(t *testing.T) {
+	src := `
+use deadpool_redis::Pool;
+
+impl Svc {
+    pub fn read_cfg(&self, settings: &HashMap<String, String>) -> Option<String> {
+        let v = settings.get("key");
+        v.cloned()
+    }
+}
+`
+	by := groupByEffect(sniffEffectsRust(src))
+	mustNotHave(t, by, EffectDBRead, "read_cfg")
+}


### PR DESCRIPTION
Follow-up from the #4964 deferred audit (#5008).

## What was built

**New custom extractors** (`internal/custom/rust/ntex_loco_shuttle.go`):
- **ntex** (actix-derived HTTP framework): attribute macros `#[get(...)]`/`#[web::get(...)]`, manual `.route("/p", web::get().to(h))`, `web::resource("/p").route(web::get().to(h))` — scope-aware via `web::scope("/prefix")`; `HttpServer::new()`/`web::server()` -> `SCOPE.Service`, `.wrap(MW)` -> `SCOPE.Pattern`. Gated on a `ntex` token so it never mis-fires on real actix files (which have their own extractor). Mirrors `actix_web.go`.
- **Loco.rs**: `Routes::new().add("/p", get(h).post(h2))` axum-style method routers (one endpoint per verb) composed with `.prefix("/api")`. Gated on `loco_rs`.
- **Shuttle** (deploy/runtime substrate): `#[shuttle_runtime::main]` -> `SCOPE.Service` (`deploy_runtime`/`entrypoint`) + each `#[shuttle_*::Resource]` managed-resource annotation -> `SCOPE.Component` (`resource_provider`/`resource_type`). Gated on `shuttle_`; the runtime macro is excluded from the resource set.

**Connection-pool db_effect attribution** (`internal/substrate/effect_sinks_rust.go`):
- A pooled checkout `pool.get()`/`get_conn()`/`acquire()` (deadpool/bb8/r2d2/mobc/sqlx::Pool) is credited `db_read` on the leasing fn — restoring attribution the pool indirection weakened (#5008). Gated on a pool-crate signal (`deadpool|bb8|r2d2|mobc`) + a `*pool*`-named receiver so `.get()`/`.acquire()` don't collide with `Option::get`/`HashMap::get`/`Mutex::acquire`.

**Test libs** (`internal/engine/rules/rust/test_patterns.yaml`):
- `serial_test` (`#[serial]`), `mockito`, `wiremock`, `insta` detection added. The underlying `#[test]`/`#[tokio::test]`/`#[rstest]` fn is already linked by the shared `rustTestRE` (which tolerates extra attribute lines), so no new code path is needed.

**async-nats**: already implemented (`internal/engine/nats_edges.go` + registry `lang.rust.framework.async-nats`) — verified, no change required.

## Edges / props
- `SCOPE.Operation`/endpoint (`http_method`, `route_pattern`, `handler_name`, `scope_prefix`, `framework`, `provenance`), `SCOPE.Component`, `SCOPE.Service`, `SCOPE.Pattern` for ntex/Loco/Shuttle (reuses existing Kinds — no new Kind, `go test ./internal/types/` green).
- `EffectDBRead` matches for pool checkouts feed the existing db_effect propagation.

## Registry cells (docs/coverage/registry.json) + REGENERATED docs/coverage
- `lang.rust.framework.ntex` / `.loco` (http_framework/http_backend, Routing endpoint_synthesis+handler_attribution+route_extraction = full, fixture-cited; non-Routing lanes inherited from the shared rust passes)
- `platform.rust.shuttle` (platform/iac_provisioning, resource_extraction + iac_resource_property_extraction = partial, rest not_applicable to the macro-provisioning model)
- `test.serial-test` / `test.mockito-rs` / `test.wiremock` / `test.insta` (build_system, dependency_graph + target_extraction = full, mirroring `test.mockall`)
- Regenerated `docs/coverage/{detail,by-category,by-language,summary}` committed.

## Fixtures
Happy path + wrong-language no-op + no-match no-op for each: `TestNtex*`, `TestLoco*`, `TestShuttle*` (`ntex_loco_shuttle_test.go`), `TestRustConnPool*_5008` (`effect_sinks_rust_pool_5008_test.go`).

## Gates (sandbox HOME=/tmp/agsbx-5008)
`go build ./...`, `go vet ./internal/...`, rust + substrate + types + testmap tests, `coverage fmt --check` (canonical), `coverage validate` (0 errors), regenerated docs/coverage all green. Every cite points at a committed file. **Deploy-deferred.**

Closes #5008

🤖 Generated with [Claude Code](https://claude.com/claude-code)