### PR TITLE
chore: resync coverage docs after #5022

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -162,7 +162,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [ruby](../by-language/ruby.md) | [redis-rb](../detail/lang.ruby.driver.redis.md) | 🟡 1/4 | |
 | [ruby](../by-language/ruby.md) | [sqlite3 (Ruby driver)](../detail/lang.ruby.driver.sqlite.md) | 🟡 1/4 | |
 | [rust](../by-language/rust.md) | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 8/10 | |
-| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/7 | |
+| [rust](../by-language/rust.md) | [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 5/7 | |
 | [rust](../by-language/rust.md) | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 10/11 | |
 | [rust](../by-language/rust.md) | [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/11 | |
 | [rust](../by-language/rust.md) | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟡 1/4 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -74,7 +74,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Other capabilities | Notes |
 |---|---|---|
 | [Diesel](../detail/lang.rust.orm.diesel.md) | 🟡 8/10 | |
-| [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 4/7 | |
+| [Rbatis](../detail/lang.rust.orm.rbatis.md) | 🟡 5/7 | |
 | [SeaORM](../detail/lang.rust.orm.seaorm.md) | 🟡 10/11 | |
 | [SeaQuery](../detail/lang.rust.framework.sea-query.md) | 🟡 3/11 | |
 | [aws-sdk-dynamodb (Rust)](../detail/lang.rust.driver.dynamodb.md) | 🟡 1/4 | |

--- a/docs/coverage/detail/lang.rust.orm.rbatis.md
+++ b/docs/coverage/detail/lang.rust.orm.rbatis.md
@@ -38,8 +38,8 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go` | Detects table_meta! and rbatis::table_sync! migration macros |
-| Migration schema ops | 🔴 `missing` | — | 3628 | — | — |
+| Migration parsing | 🟢 `partial` | `2026-05-30` | — | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go`<br>`internal/custom/rust/testdata/rbatis_migration.rs` | Detects table_meta! and rbatis::table_sync! migration macros |
+| Migration schema ops | 🟢 `partial` | `2026-06-14` | 5096 | `internal/custom/rust/sqlx_rbatis.go`<br>`internal/custom/rust/sqlx_rbatis_test.go`<br>`internal/custom/rust/testdata/rbatis_migration.rs` | #5096: rbatis migrations are driven by rbatis::table_sync!(pool, Struct::default()) and table_meta!(Struct) rather than a SeaORM-style up()/down() builder or standalone migrations/*.sql files. Each macro is resolved to a create_table migration component carrying migration_op + table_name (from the model struct’s #[crud_table(table_name=...)], else the struct name), plus a schema_column per struct field. Column SQL types/modifiers and MODIFIES_TABLE edge-wiring are deferred. Proven by TestRbatis_MigrationSchemaOps(+_TableMetaFallback/_Fixture/_WrongLanguageNoOp/_NoMatchNoOp). |
 
 ### Transactions
 


### PR DESCRIPTION
#5167 committed the rbatis `migration_schema_ops` registry edit (missing→partial) but a stale doc regen — `coverage gen` drift of 3 files. Docs-only resync; `coverage fmt --check` + `validate` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)