### PR TITLE
test: fix stale capability-dictionary subcategory order (resilience)

### DIFF
--- a/tools/coverage/capability_dictionary_test.go
+++ b/tools/coverage/capability_dictionary_test.go
@@ -50,7 +50,7 @@ func TestLoadCapabilityDictionaryFromDisk(t *testing.T) {
 	}
 	// Subcategory render order — http_framework subcategories must
 	// follow the explicit subcategory_order from the dictionary.
-	wantOrder := []string{"http_backend", "jvm_backend", "ui_frontend", "meta_framework", "mobile", "desktop", "rpc_framework", "static_site", "ai_integration", "task_queue"}
+	wantOrder := []string{"http_backend", "jvm_backend", "ui_frontend", "meta_framework", "mobile", "desktop", "rpc_framework", "static_site", "ai_integration", "task_queue", "resilience"}
 	if got := d.SubcategoriesByCategory("http_framework"); !reflect.DeepEqual(got, wantOrder) {
 		t.Errorf("SubcategoriesByCategory(http_framework) = %v, want %v", got, wantOrder)
 	}


### PR DESCRIPTION
`TestLoadCapabilityDictionaryFromDisk` is red on main: the `resilience` http_framework subcategory (added with csharp Polly/Coravel #5075) was never added to the test's hardcoded `wantOrder`. Append it. Test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)