### PR TITLE
feat(#5129): fsharp — Fable + Elmish/Feliz frontend extraction

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 249 records · **C/C++**: 20 · **clojure**: 4 · **crystal**: 1 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 1 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
+**Total**: 250 records · **C/C++**: 20 · **clojure**: 4 · **crystal**: 1 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -210,6 +210,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟢 24/24 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟢 24/24 | 🟢 8/8 | |
 | [dart](../by-language/dart.md) | [Flutter](../detail/lang.dart.framework.flutter.md) | 🟢 3/3 | 🟢 1/1 | 🟡 14/24 | 🟡 5/8 | |
+| [F#](../by-language/fsharp.md) | [Fable Elmish/Feliz (F# frontend)](../detail/lang.fsharp.framework.elmish.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/24 | 🟡 6/14 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |
 | [JS/TS](../by-language/jsts.md) | [Angular](../detail/lang.jsts.framework.angular.md) | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 17/17 | |

--- a/docs/coverage/by-language/fsharp.md
+++ b/docs/coverage/by-language/fsharp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # F#
 
-**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 2
+**Frameworks**: 2 · **Tools**: 1 · **ORMs**: 0 · **Other**: 2
 
 Back to [summary](../summary.md).
 
@@ -27,6 +27,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|---|---|---|
 | [Giraffe / Saturn (F# HTTP)](../detail/lang.fsharp.framework.giraffe.md) | 🟡 3/7 | 🔴 0/1 | 🟢 4/4 | ✅ 1/1 | 🔴 0/24 | 🟡 2/13 | |
+
+
+### UI Frontend
+
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Fable Elmish/Feliz (F# frontend)](../detail/lang.fsharp.framework.elmish.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/24 | 🟡 6/14 | |
 
 
 ## Tools

--- a/docs/coverage/detail/lang.fsharp.framework.elmish.md
+++ b/docs/coverage/detail/lang.fsharp.framework.elmish.md
@@ -1,0 +1,106 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.fsharp.framework.elmish` — Fable Elmish/Feliz (F# frontend)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [F#](../by-language/fsharp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** UI Frontend
+- **Capability cells:** 42
+
+## Capabilities
+
+
+### Structure
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Component extraction | ✅ `full` | `2026-06-13` | [link](https://github.com/cajasmota/archigraph/issues/5129) | `internal/extractors/fsharp/elmish_feliz.go`<br>`internal/extractors/fsharp/elmish_feliz_test.go`<br>`internal/extractors/fsharp/testdata/elmish_counter.fs` | Feliz/Fable.React component functions (let-bound bodies using the Html./prop./React. DSL or a ReactElement return) re-kinded SCOPE.UIComponent (feliz_component); nested component calls emit RENDERS edges. The MVU view is itself re-kinded. Import-gated on open Elmish/Feliz/Fable. |
+| Context extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Data fetching | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Prop extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| State management | ✅ `full` | `2026-06-13` | [link](https://github.com/cajasmota/archigraph/issues/5129) | `internal/extractors/fsharp/elmish_feliz.go`<br>`internal/extractors/fsharp/elmish_feliz_test.go`<br>`internal/extractors/fsharp/testdata/elmish_counter.fs` | Elmish MVU: the Model record re-kinded SCOPE.Model (elmish_model), the Msg DU re-kinded SCOPE.Event (elmish_msg) with its cases as messages, and init/update/view tagged Properties[elmish_role]. Program.mkProgram/mkSimple bootstrap flagged (elmish_program). Cmd dispatch (Cmd.ofMsg/OfAsync/OfPromise/batch/none) emits USES edges stamped Properties[dispatch]. |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Router pattern | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Framework-specific
+
+### Fable Elmish/Feliz
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Command dispatch extraction | ✅ `full` | `2026-06-14` | [link](https://github.com/cajasmota/archigraph/issues/5129) | `internal/extractors/fsharp/elmish_feliz.go`<br>`internal/extractors/fsharp/elmish_feliz_test.go`<br>`internal/extractors/fsharp/testdata/elmish_counter.fs` | Cmd.ofMsg / Cmd.OfAsync.* / Cmd.OfPromise.* / Cmd.OfFunc.* / Cmd.batch / Cmd.none / Cmd.map dispatch helpers inside update/init emit USES edges stamped Properties[dispatch]=<helper>, elmish_command=true. |
+| Elmish subscription extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/5129) | — | Elmish subscriptions (Program.withSubscription / Sub.batch) and message-source wiring are not yet modelled. |
+| Feliz component extraction | ✅ `full` | `2026-06-14` | [link](https://github.com/cajasmota/archigraph/issues/5129) | `internal/extractors/fsharp/elmish_feliz.go`<br>`internal/extractors/fsharp/elmish_feliz_test.go`<br>`internal/extractors/fsharp/testdata/elmish_counter.fs` | Feliz/Fable.React DSL bodies (Html./prop./React./ReactElement) re-kinded SCOPE.UIComponent (feliz_component) with RENDERS edges to nested child components, mirroring the React #610 composition convention. |
+| Feliz prop extraction | 🔴 `missing` | — | [link](https://github.com/cajasmota/archigraph/issues/5129) | — | Per-prop extraction of Feliz attribute lists (prop.text/prop.onClick/style props) into structured HAS_PROPS cells is deferred; only component-level recognition + RENDERS composition is implemented. |
+| Mvu triad extraction | ✅ `full` | `2026-06-14` | [link](https://github.com/cajasmota/archigraph/issues/5129) | `internal/extractors/fsharp/elmish_feliz.go`<br>`internal/extractors/fsharp/elmish_feliz_test.go`<br>`internal/extractors/fsharp/testdata/elmish_counter.fs` | init/update/view operations tagged Properties[elmish_role]=init|update|view (name-convention recognition incl. init*/update*/view*); Model record re-kinded SCOPE.Model and Msg DU re-kinded SCOPE.Event so the MVU data triad is queryable. |
+| Program bootstrap detection | ✅ `full` | `2026-06-14` | [link](https://github.com/cajasmota/archigraph/issues/5129) | `internal/extractors/fsharp/elmish_feliz.go`<br>`internal/extractors/fsharp/elmish_feliz_test.go`<br>`internal/extractors/fsharp/testdata/elmish_counter.fs` | Program.mkProgram / Program.mkSimple recognised; the host operation flagged Properties[elmish_program]=true. Program.withReactSynchronous/hydration wiring beyond the bootstrap flag is deferred. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.fsharp.framework.elmish ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 249 · **ORMs**: 172 · **Tools**: 124 · **Other**: 205
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 250 · **ORMs**: 172 · **Tools**: 124 · **Other**: 205
 
 ## Coverage by language
 
@@ -23,9 +23,9 @@
 | [clojure](by-language/clojure.md) | 4 | 4 | 5 | 1 |
 | [lua](by-language/lua.md) | 4 | 0 | 0 | 1 |
 | [dart](by-language/dart.md) | 3 | 1 | 0 | 1 |
+| [F#](by-language/fsharp.md) | 2 | 1 | 0 | 2 |
 | [crystal](by-language/crystal.md) | 1 | 0 | 1 | 1 |
 | [erlang](by-language/erlang.md) | 1 | 0 | 0 | 2 |
-| [F#](by-language/fsharp.md) | 1 | 1 | 0 | 2 |
 | [groovy](by-language/groovy.md) | 1 | 1 | 0 | 1 |
 | [nim](by-language/nim.md) | 1 | 0 | 4 | 1 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 5 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 249 frameworks · 124 tools · 172 ORMs · 205 other
+Total: 250 frameworks · 124 tools · 172 ORMs · 205 other

--- a/internal/extractors/fsharp/elmish_feliz.go
+++ b/internal/extractors/fsharp/elmish_feliz.go
@@ -1,0 +1,263 @@
+// Package fsharp: Fable + Elmish/Feliz frontend extraction (#5129, follow-up
+// #5049).
+//
+// Fable compiles F# to JavaScript; the dominant Fable UI stack is Elmish (an
+// Elm-style Model-View-Update architecture) rendered through Feliz (a typed
+// React DSL). Neither was modelled by the base extractor — an Elmish app's
+// `Model`/`Msg`/`update`/`view`/`init` all surfaced as undifferentiated
+// SCOPE.Component / SCOPE.Operation entities, and the Feliz component functions
+// looked like ordinary `let` bindings. This file recognises the framework and
+// decorates the already-extracted entities so the MVU triad, the Feliz
+// component tree, and command dispatch are queryable.
+//
+// Framework detection is import-gated (`open Elmish` / `open Feliz` /
+// `open Fable.*`) so a plain F# file is never mis-classified. When detection
+// fails the pass is a no-op — every base entity is returned unchanged.
+//
+// What it produces (all on top of the base extractor's entities):
+//   - the `Model` type            → re-kinded SCOPE.Model, subtype elmish_model
+//   - the `Msg` discriminated union → re-kinded SCOPE.Event, subtype elmish_msg
+//     (its DU-case sub-entities are the individual messages, already emitted by
+//      #4942; they inherit the Msg's role via Properties)
+//   - `init` / `update` / `view`   → Properties["elmish_role"] = init|update|view
+//   - the operation containing `Program.mkProgram` → Properties["elmish_program"]
+//   - Feliz component functions (body uses the `Html.`/`prop.`/`React.` DSL or
+//     returns a `ReactElement`) → re-kinded SCOPE.UIComponent, subtype
+//     feliz_component, with a RENDERS edge to each nested component it calls
+//   - command dispatch (`Cmd.ofMsg`/`Cmd.OfAsync`/`Cmd.batch`/`Cmd.none`) inside
+//     update/init → a USES edge stamped Properties["dispatch"] = the Cmd helper
+//
+// Honest scope: detection and decoration are structural (regex/heuristic) like
+// the rest of the F# extractor. Feliz attribute props, Elmish subscriptions, and
+// `Program.withReactSynchronous`/hydration wiring are recognised only insofar as
+// the program operation is flagged; per-prop extraction is deferred.
+package fsharp
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+var (
+	// Elmish/Feliz/Fable framework import markers. Any one of these `open`
+	// targets (prefix match) flips the file into frontend mode.
+	fableImportPrefixes = []string{
+		"Elmish",
+		"Feliz",
+		"Fable.Core",
+		"Fable.React",
+		"Fable.Import",
+		"Fable.Browser",
+	}
+
+	// Program.mkProgram / Program.mkSimple — the Elmish bootstrap that wires the
+	// init/update/view triad into a running program.
+	mkProgramRE = regexp.MustCompile(`\bProgram\.(?:mkProgram|mkSimple)\b`)
+
+	// Cmd dispatch helpers inside update/init bodies.
+	cmdDispatchRE = regexp.MustCompile(`\bCmd\.(ofMsg|OfAsync\.\w+|OfPromise\.\w+|OfFunc\.\w+|batch|none|map)\b`)
+
+	// Feliz/Fable.React DSL markers that identify a function as a view/component:
+	// `Html.div [...]`, `prop.children`, `React.functionComponent`, an explicit
+	// `ReactElement` return annotation, or a JSX-ish `Html.text`.
+	felizDSLRE = regexp.MustCompile(`\b(?:Html|Bulma|Daisy|Mui|Bind|Feliz)\.\w+|\bprop\.\w+|\bReact\.\w+|\bReactElement\b`)
+
+	// A call to another PascalCase component function inside a Feliz body, e.g.
+	// `Counter.view model dispatch` or `navbar props`. The head identifier is the
+	// rendered child component.
+	felizChildRE = regexp.MustCompile(`(?m)(?:^[ \t]*|[\[(]\s*|\|>\s*)([A-Za-z_][A-Za-z0-9_']*)[ \t]+(?:"|'|[0-9]|\(|\[|[a-z_])`)
+)
+
+// fileUsesFableFrontend reports whether any import marks the file as a Fable
+// Elmish/Feliz frontend module.
+func fileUsesFableFrontend(imports []string) bool {
+	for _, imp := range imports {
+		for _, p := range fableImportPrefixes {
+			if imp == p || strings.HasPrefix(imp, p+".") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// applyElmishFeliz decorates the base entities in place when the file is a Fable
+// Elmish/Feliz frontend module. It is a no-op for non-frontend files (wrong
+// language never reaches here; no-match files have no Fable imports).
+//
+// src is the raw F# source, filePath the repo-relative path, imports the
+// collected `open` targets, and entities the slice produced by extractFSharp.
+func applyElmishFeliz(src, filePath string, imports []string, entities []types.EntityRecord) {
+	if !fileUsesFableFrontend(imports) {
+		return
+	}
+
+	// Pass 1: re-kind the MVU data types (Model / Msg) and tag the triad
+	// operations. We index by name so the second component pass can skip them.
+	mvuOps := map[string]string{} // operation name → elmish role (init/update/view)
+	for i := range entities {
+		e := &entities[i]
+		switch {
+		case e.Kind == "SCOPE.Component" && e.Name == "Model" && e.Subtype == "record":
+			e.Kind = "SCOPE.Model"
+			e.Subtype = "elmish_model"
+			setProp(e, "elmish_role", "model")
+			setProp(e, "fable_frontend", "true")
+		case e.Kind == "SCOPE.Component" && e.Name == "Msg" && e.Subtype == "discriminated_union":
+			e.Kind = "SCOPE.Event"
+			e.Subtype = "elmish_msg"
+			setProp(e, "elmish_role", "msg")
+			setProp(e, "fable_frontend", "true")
+		case e.Kind == "SCOPE.Operation":
+			if role, ok := elmishTriadRole(e.Name); ok {
+				mvuOps[e.Name] = role
+				setProp(e, "elmish_role", role)
+				setProp(e, "fable_frontend", "true")
+			}
+		}
+	}
+
+	// Pass 2: flag the Elmish program bootstrap and wire Feliz components +
+	// command dispatch. Both need the per-operation body, which we re-derive
+	// from the entity's line span (the base extractor already computed it).
+	lines := strings.Split(src, "\n")
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != "SCOPE.Operation" && e.Kind != "SCOPE.UIComponent" {
+			continue
+		}
+		body := entityBody(lines, e)
+		if body == "" {
+			continue
+		}
+
+		// Program.mkProgram bootstrap → flag the host operation.
+		if mkProgramRE.MatchString(body) {
+			setProp(e, "elmish_program", "true")
+			setProp(e, "fable_frontend", "true")
+		}
+
+		// Command dispatch (init/update return `Model * Cmd<Msg>`).
+		for _, m := range cmdDispatchRE.FindAllStringSubmatch(body, -1) {
+			helper := "Cmd." + m[1]
+			addDispatchEdge(e, helper)
+		}
+
+		// Feliz/Fable.React component detection: a `let`-bound function whose body
+		// uses the Feliz DSL is a UI component. The MVU `view` is itself a Feliz
+		// component, so it is re-kinded too (its elmish_role=view survives).
+		if e.Subtype == "let" || mvuOps[e.Name] == "view" {
+			if felizDSLRE.MatchString(body) {
+				e.Kind = "SCOPE.UIComponent"
+				if e.Subtype == "let" {
+					e.Subtype = "feliz_component"
+				}
+				setProp(e, "fable_frontend", "true")
+				setProp(e, "ui_framework", "feliz")
+				// RENDERS edges to nested component functions.
+				addFelizRendersEdges(e, body, filePath)
+			}
+		}
+	}
+}
+
+// elmishTriadRole classifies an operation name as part of the Elmish MVU triad.
+// The Elmish convention names these `init`, `update`, and `view`; a trailing or
+// leading qualifier is tolerated (`initModel`, `updateState`, `viewMain`) so a
+// component module's locally-scoped triad is still recognised.
+func elmishTriadRole(name string) (string, bool) {
+	switch name {
+	case "init":
+		return "init", true
+	case "update":
+		return "update", true
+	case "view", "render":
+		return "view", true
+	}
+	switch {
+	case strings.HasPrefix(name, "init"):
+		return "init", true
+	case strings.HasPrefix(name, "update"):
+		return "update", true
+	case strings.HasPrefix(name, "view"):
+		return "view", true
+	}
+	return "", false
+}
+
+// addFelizRendersEdges scans a Feliz component body for calls to other
+// PascalCase / lower-case component functions and emits a RENDERS edge to each
+// unique child, mirroring the React component-composition convention (#610).
+func addFelizRendersEdges(e *types.EntityRecord, body, filePath string) {
+	seen := map[string]bool{}
+	scrubbed := scrubKeepingQuote(body)
+	for _, m := range felizChildRE.FindAllStringSubmatch(scrubbed, -1) {
+		child := m[1]
+		if child == "" || child == e.Name || seen[child] {
+			continue
+		}
+		if fsharpKeywords[child] || isFelizDSLHead(child) {
+			continue
+		}
+		// A child component name is a binding head; skip obvious non-components
+		// (single letters, the `prop`/`style`/`Html` DSL roots).
+		if len(child) < 2 {
+			continue
+		}
+		seen[child] = true
+		e.Relationships = append(e.Relationships, types.RelationshipRecord{
+			ToID: extractor.BuildOperationStructuralRef("fsharp", filePath, child),
+			Kind: "RENDERS",
+		})
+	}
+}
+
+// isFelizDSLHead reports whether tok is a Feliz/React DSL root that must not be
+// mistaken for a child component.
+func isFelizDSLHead(tok string) bool {
+	switch tok {
+	case "Html", "prop", "style", "React", "Feliz", "Bulma", "Daisy", "Mui",
+		"Bind", "color", "length", "text", "str", "ofInt", "ofFloat", "ofList":
+		return true
+	}
+	return false
+}
+
+// addDispatchEdge records a USES edge stamped with the Cmd helper that produced
+// it, de-duplicated per (helper) so a body that dispatches the same helper twice
+// emits one edge.
+func addDispatchEdge(e *types.EntityRecord, helper string) {
+	for _, r := range e.Relationships {
+		if r.Kind == "USES" && r.Properties["dispatch"] == helper {
+			return
+		}
+	}
+	e.Relationships = append(e.Relationships, types.RelationshipRecord{
+		ToID: "Cmd",
+		Kind: "USES",
+		Properties: map[string]string{
+			"dispatch":       helper,
+			"elmish_command": "true",
+		},
+	})
+}
+
+// entityBody re-derives the source body for an entity from its [StartLine,
+// EndLine] span (1-based, inclusive). Returns "" when the span is degenerate.
+func entityBody(lines []string, e *types.EntityRecord) string {
+	if e.StartLine <= 0 || e.EndLine < e.StartLine || e.EndLine > len(lines) {
+		return ""
+	}
+	return strings.Join(lines[e.StartLine-1:e.EndLine], "\n")
+}
+
+// setProp sets a Property on an entity, allocating the map on first use.
+func setProp(e *types.EntityRecord, key, val string) {
+	if e.Properties == nil {
+		e.Properties = map[string]string{}
+	}
+	e.Properties[key] = val
+}

--- a/internal/extractors/fsharp/elmish_feliz_test.go
+++ b/internal/extractors/fsharp/elmish_feliz_test.go
@@ -1,0 +1,194 @@
+package fsharp_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/fsharp"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// fsHasProp reports whether the named entity (matched by name) carries the
+// given Property value.
+func fsHasProp(ents []types.EntityRecord, name, key, val string) bool {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Properties[key] == val {
+			return true
+		}
+	}
+	return false
+}
+
+// fsByName returns the first entity with the given name, or nil.
+func fsByName(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// fsHasDispatch reports whether the named operation carries a Cmd-dispatch USES
+// edge for the given helper.
+func fsHasDispatch(ents []types.EntityRecord, name, helper string) bool {
+	for i := range ents {
+		if ents[i].Name != name {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "USES" && r.Properties["dispatch"] == helper {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestElmishFeliz_HappyPath runs the canonical MVU+Feliz fixture and asserts the
+// full set of #5129 decorations: re-kinded Model/Msg, tagged init/update/view,
+// the Feliz components, command dispatch, the program bootstrap, and the
+// view→child RENDERS edge.
+func TestElmishFeliz_HappyPath(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("testdata", "elmish_counter.fs"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	ents := runFSharp(t, string(src), "Counter.fs")
+
+	// Model → SCOPE.Model / elmish_model.
+	if m := fsFind(ents, "Model", "SCOPE.Model"); m == nil {
+		t.Error("Model not re-kinded to SCOPE.Model")
+	} else {
+		if m.Subtype != "elmish_model" {
+			t.Errorf("Model subtype = %q, want elmish_model", m.Subtype)
+		}
+		if m.Properties["elmish_role"] != "model" {
+			t.Errorf("Model elmish_role = %q, want model", m.Properties["elmish_role"])
+		}
+	}
+
+	// Msg → SCOPE.Event / elmish_msg.
+	if m := fsFind(ents, "Msg", "SCOPE.Event"); m == nil {
+		t.Error("Msg not re-kinded to SCOPE.Event")
+	} else if m.Subtype != "elmish_msg" {
+		t.Errorf("Msg subtype = %q, want elmish_msg", m.Subtype)
+	}
+
+	// init/update/view triad roles.
+	if !fsHasProp(ents, "init", "elmish_role", "init") {
+		t.Error("init not tagged elmish_role=init")
+	}
+	if !fsHasProp(ents, "update", "elmish_role", "update") {
+		t.Error("update not tagged elmish_role=update")
+	}
+	if !fsHasProp(ents, "view", "elmish_role", "view") {
+		t.Error("view not tagged elmish_role=view")
+	}
+
+	// view + counterButton are Feliz components.
+	if v := fsFind(ents, "view", "SCOPE.UIComponent"); v == nil {
+		t.Error("view not re-kinded to SCOPE.UIComponent")
+	} else if v.Properties["ui_framework"] != "feliz" {
+		t.Errorf("view ui_framework = %q, want feliz", v.Properties["ui_framework"])
+	}
+	if c := fsFind(ents, "counterButton", "SCOPE.UIComponent"); c == nil {
+		t.Error("counterButton not re-kinded to SCOPE.UIComponent")
+	} else if c.Subtype != "feliz_component" {
+		t.Errorf("counterButton subtype = %q, want feliz_component", c.Subtype)
+	}
+
+	// Command dispatch on init (Cmd.ofMsg) and update (Cmd.none / Cmd.OfAsync).
+	if !fsHasDispatch(ents, "init", "Cmd.ofMsg") {
+		t.Error("init missing Cmd.ofMsg dispatch edge")
+	}
+	if !fsHasDispatch(ents, "update", "Cmd.OfAsync.perform") {
+		t.Error("update missing Cmd.OfAsync.perform dispatch edge")
+	}
+
+	// Program bootstrap on main.
+	if !fsHasProp(ents, "main", "elmish_program", "true") {
+		t.Error("main not flagged elmish_program")
+	}
+
+	// view RENDERS counterButton (nested component composition).
+	if !fsHasRel(ents, "view", "SCOPE.UIComponent", "RENDERS",
+		extractor.BuildOperationStructuralRef("fsharp", "Counter.fs", "counterButton")) {
+		t.Error("view missing RENDERS edge to counterButton")
+	}
+}
+
+// TestElmishFeliz_NoMatchNoOp asserts that an ordinary F# file with no Fable
+// imports is left entirely undecorated — no re-kinding, no elmish props.
+func TestElmishFeliz_NoMatchNoOp(t *testing.T) {
+	src := `module Plain
+
+type Model =
+    { Count: int }
+
+type Msg =
+    | Increment
+
+let init () = { Count = 0 }
+
+let update msg model = model
+
+let view model dispatch = "no feliz here"
+`
+	ents := runFSharp(t, src, "Plain.fs")
+
+	// Model/Msg stay as plain SCOPE.Component — no frontend re-kinding.
+	if fsFind(ents, "Model", "SCOPE.Model") != nil {
+		t.Error("Model wrongly re-kinded in a non-Fable file")
+	}
+	if fsFind(ents, "Msg", "SCOPE.Event") != nil {
+		t.Error("Msg wrongly re-kinded in a non-Fable file")
+	}
+	if m := fsByName(ents, "Model"); m == nil || m.Kind != "SCOPE.Component" {
+		t.Error("Model should remain SCOPE.Component")
+	}
+	// No elmish_role anywhere.
+	for i := range ents {
+		if ents[i].Properties["elmish_role"] != "" || ents[i].Properties["fable_frontend"] != "" {
+			t.Errorf("entity %q carries elmish props in a non-Fable file", ents[i].Name)
+		}
+	}
+}
+
+// TestElmishFeliz_WrongLanguageNoOp asserts the decoration pass never fires for
+// a non-F# input: a C#-shaped source routed through the F# extractor must not
+// produce Elmish entities (and in practice another language's extractor owns
+// the file). We assert no frontend re-kinding occurs.
+func TestElmishFeliz_WrongLanguageNoOp(t *testing.T) {
+	// C# source — no F# `open Elmish`, no F# `type Model = { ... }`. Routed
+	// through the F# extractor it must not yield Elmish/Feliz decorations.
+	src := `using Elmish;
+
+public class Model {
+    public int Count { get; set; }
+}
+
+public enum Msg { Increment, Decrement }
+`
+	ext, ok := extractor.Get("fsharp")
+	if !ok {
+		t.Fatal("fsharp extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "Model.cs",
+		Content:  []byte(src),
+		Language: "csharp",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Model" || ents[i].Kind == "SCOPE.Event" ||
+			ents[i].Properties["fable_frontend"] == "true" {
+			t.Errorf("entity %q wrongly decorated as Fable frontend from C# input", ents[i].Name)
+		}
+	}
+}

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -409,6 +409,12 @@ func extractFSharp(src, filePath string) []types.EntityRecord {
 		entities = append(entities, memberEnts...)
 	}
 
+	// #5129: Fable + Elmish/Feliz frontend decoration. Import-gated — a no-op
+	// for any file that does not `open` Elmish/Feliz/Fable. Mutates the entities
+	// in place (re-kinds Model/Msg, tags the MVU triad, re-kinds Feliz components
+	// + emits RENDERS, stamps Cmd dispatch USES edges).
+	applyElmishFeliz(src, filePath, imports, entities)
+
 	return entities
 }
 

--- a/internal/extractors/fsharp/testdata/elmish_counter.fs
+++ b/internal/extractors/fsharp/testdata/elmish_counter.fs
@@ -1,0 +1,46 @@
+module Counter
+
+// Fable + Elmish/Feliz frontend fixture (#5129). A canonical MVU triad with a
+// Feliz view, command dispatch, and the Program bootstrap.
+
+open Elmish
+open Feliz
+
+type Model =
+    { Count: int
+      Loading: bool }
+
+type Msg =
+    | Increment
+    | Decrement
+    | Reset
+    | Loaded of int
+
+let init () : Model * Cmd<Msg> =
+    { Count = 0; Loading = false }, Cmd.ofMsg Reset
+
+let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
+    match msg with
+    | Increment -> { model with Count = model.Count + 1 }, Cmd.none
+    | Decrement -> { model with Count = model.Count - 1 }, Cmd.none
+    | Reset -> { model with Count = 0 }, Cmd.none
+    | Loaded n -> { model with Count = n; Loading = false }, Cmd.OfAsync.perform loadData () Loaded
+
+let counterButton (label: string) (onClick: unit -> unit) : ReactElement =
+    Html.button [
+        prop.text label
+        prop.onClick (fun _ -> onClick ())
+    ]
+
+let view (model: Model) (dispatch: Msg -> unit) : ReactElement =
+    Html.div [
+        prop.children [
+            Html.h1 [ prop.text (string model.Count) ]
+            counterButton "+" (fun () -> dispatch Increment)
+            counterButton "-" (fun () -> dispatch Decrement)
+        ]
+    ]
+
+let main () =
+    Program.mkProgram init update view
+    |> Program.run


### PR DESCRIPTION
## What this builds
Import-gated (\`open Elmish\` / \`Feliz\` / \`Fable.*\`) decoration pass over the existing F# extractor output (\`internal/extractors/fsharp/elmish_feliz.go\`, wired into \`extractFSharp\`). No-op for any file lacking Fable imports.

### Entities / edges / props
- **Elmish MVU triad**: \`Model\` record → re-kinded \`SCOPE.Model\` (subtype \`elmish_model\`); \`Msg\` DU → re-kinded \`SCOPE.Event\` (subtype \`elmish_msg\`, its DU-case sub-entities are the messages); \`init\`/\`update\`/\`view\` (incl. \`init*\`/\`update*\`/\`view*\` convention) tagged \`Properties[elmish_role]\`.
- **Program bootstrap**: \`Program.mkProgram\`/\`mkSimple\` → host operation flagged \`Properties[elmish_program]=true\`.
- **Feliz components**: \`let\`-bound functions whose body uses the \`Html.\`/\`prop.\`/\`React.\`/\`ReactElement\` DSL → re-kinded \`SCOPE.UIComponent\` (subtype \`feliz_component\`, \`ui_framework=feliz\`) with **RENDERS** edges to nested child components (mirrors React #610 composition).
- **Command dispatch**: \`Cmd.ofMsg\`/\`OfAsync.*\`/\`OfPromise.*\`/\`OfFunc.*\`/\`batch\`/\`none\`/\`map\` inside update/init → **USES** edges stamped \`Properties[dispatch]\`, \`elmish_command=true\`.

All entity kinds (SCOPE.Model/Event/UIComponent) are existing valid kinds; re-kinding is by field assignment, not new literals.

### Honestly deferred
- Per-prop Feliz attribute extraction (\`feliz_prop_extraction\` → missing).
- Elmish subscriptions / \`Program.withSubscription\` (\`elmish_subscription_extraction\` → missing).

### Registry cells / record
New \`lang.fsharp.framework.elmish\` record (category \`http_framework\`, subcategory \`ui_frontend\`, mirroring the React/Vue/Svelte frontend records). Lanes backfilled to taxonomy completeness; **full** flips proven by this PR's fixtures: \`Structure.component_extraction\`, \`Data Flow.state_management\`. \`framework_specific\` "Fable Elmish/Feliz" group: \`mvu_triad_extraction\`, \`program_bootstrap_detection\`, \`feliz_component_extraction\`, \`command_dispatch_extraction\` (full) + \`feliz_prop_extraction\`, \`elmish_subscription_extraction\` (missing). **Regenerated coverage docs included** (detail page + by-language/by-category/summary).

### Fixtures
- Happy path: \`internal/extractors/fsharp/testdata/elmish_counter.fs\` (full MVU+Feliz+Cmd+Program).
- No-match no-op (F# without Fable imports) and wrong-language no-op (C# routed through the F# extractor) — both assert zero frontend decoration.

### Gates
\`go build ./...\`, \`go vet ./internal/extractors/fsharp/...\`, fsharp + custom/fsharp + engine + types tests, \`coverage fmt --check\`, \`coverage validate\` **exit 0**, committed regenerated docs, **git status clean**. Run under sandbox HOME \`/tmp/agsbx-5129\`. Every cite points at a file committed in this PR.

Closes #5129