### PR TITLE
feat(#4936): crystal — Jennifer/Clear/Avram/Crecto ORM extraction

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 172 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 1 · **C#**: 16 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
+**Total**: 176 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -26,7 +26,11 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [clojure](../by-language/clojure.md) | [HoneySQL](../detail/lang.clojure.driver.honeysql.md) | 🔴 0/11 | |
 | [clojure](../by-language/clojure.md) | [clojure.java.jdbc (legacy)](../detail/lang.clojure.driver.clojure-java-jdbc.md) | 🔴 0/11 | |
 | [clojure](../by-language/clojure.md) | [next.jdbc](../detail/lang.clojure.driver.next-jdbc.md) | 🔴 0/11 | |
+| [crystal](../by-language/crystal.md) | [Avram (Lucky Crystal ORM)](../detail/lang.crystal.orm.avram.md) | 🟡 5/9 | |
+| [crystal](../by-language/crystal.md) | [Clear (Crystal ORM)](../detail/lang.crystal.orm.clear.md) | 🟡 5/9 | |
+| [crystal](../by-language/crystal.md) | [Crecto (Crystal ORM)](../detail/lang.crystal.orm.crecto.md) | 🟡 5/9 | |
 | [crystal](../by-language/crystal.md) | [Granite (Crystal ORM)](../detail/lang.crystal.orm.granite.md) | ✅ 10/10 | |
+| [crystal](../by-language/crystal.md) | [Jennifer (Crystal ORM)](../detail/lang.crystal.orm.jennifer.md) | 🟡 5/9 | |
 | [C#](../by-language/csharp.md) | [AWSSDK.DynamoDBv2](../detail/lang.csharp.driver.dynamodb.md) | 🟡 2/5 | |
 | [C#](../by-language/csharp.md) | [AutoMapper (.NET object-object mapper)](../detail/lang.csharp.mapper.automapper.md) | ✅ 1/1 | |
 | [C#](../by-language/csharp.md) | [CassandraCSharpDriver](../detail/lang.csharp.driver.cassandra.md) | 🟡 2/5 | |

--- a/docs/coverage/by-language/crystal.md
+++ b/docs/coverage/by-language/crystal.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # crystal
 
-**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 1 · **Other**: 1
+**Frameworks**: 1 · **Tools**: 0 · **ORMs**: 5 · **Other**: 1
 
 Back to [summary](../summary.md).
 
@@ -36,7 +36,11 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Other capabilities | Notes |
 |---|---|---|
+| [Avram (Lucky Crystal ORM)](../detail/lang.crystal.orm.avram.md) | 🟡 5/9 | |
+| [Clear (Crystal ORM)](../detail/lang.crystal.orm.clear.md) | 🟡 5/9 | |
+| [Crecto (Crystal ORM)](../detail/lang.crystal.orm.crecto.md) | 🟡 5/9 | |
 | [Granite (Crystal ORM)](../detail/lang.crystal.orm.granite.md) | ✅ 10/10 | |
+| [Jennifer (Crystal ORM)](../detail/lang.crystal.orm.jennifer.md) | 🟡 5/9 | |
 
 
 ## Other

--- a/docs/coverage/detail/lang.crystal.orm.avram.md
+++ b/docs/coverage/detail/lang.crystal.orm.avram.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.crystal.orm.avram` — Avram (Lucky Crystal ORM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [crystal](../by-language/crystal.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/avram_orm.go`<br>`internal/custom/crystal/avram_orm_test.go` | Avram (luckyframework/avram) is the ORM that ships with the Lucky web framework. A persisted model is a `class T < BaseModel` (avramModelRe), file-level pre-filtered by avramHasModel on the Avram::Model marker so an arbitrary BaseModel subclass never misfires. Each model emits one SCOPE.Schema/model + one SCOPE.Schema/table; the table identity is the explicit `table :<name> do` / `table "<name>" do` block argument (avramTableRe) when present, otherwise the model class name (anonymous `table do`). Carries framework=avram + provenance. Proven by TestCrystalAvramORM_ModelTableColumns (explicit table :accounts + anonymous table do → User) + TestCrystalAvramORM_NonModelNoop + TestCrystalAvramORM_WrongLanguageNoop. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | Avram lifecycle hooks (SaveOperation callbacks) are deferred — only model/table/column/association extraction is implemented in this PR (#4936). No lifecycle hook recognition is claimed. |
+| Schema extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/avram_orm.go`<br>`internal/custom/crystal/avram_orm_test.go` | Inside the `table do … end` block, each `column <name> : <Type>` (avramColumnRe) and each `primary_key <name> : <Type>` (avramPrimaryKeyRe, stamped primary_key=true) becomes a SCOPE.Schema/column carrying column_type (nilable `?` marker trimmed) + the owning model. The `timestamps` macro (avramTimestampsRe) synthesises created_at/updated_at Time columns stamped auto_timestamp=true. Proven by TestCrystalAvramORM_ModelTableColumns (primary_key id, email `String?` trimmed, timestamps columns). |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/avram_orm.go`<br>`internal/custom/crystal/avram_orm_test.go` | belongs_to/has_many/has_one macros in Avram's typed form `belongs_to <name> : <Class>` (avramAssocRe) each emit a SCOPE.Schema/association entity stamping assoc_kind, the owning model, and the resolved target (has_many singularised; explicit `: <Class>` target honoured by avramAssocTarget). Proven by TestCrystalAvramORM_ModelTableColumns (has_many posts : Post, belongs_to account : Account). |
+| Foreign key extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/avram_orm.go`<br>`internal/custom/crystal/avram_orm_test.go` | A `belongs_to account : Account` association yields a REFERENCES edge model → target (fk_field + to_model props), the typed `: <Class>` target winning over the CamelCased name. Cross-file target resolution is delegated to the shared resolver. Proven by TestCrystalAvramORM_ModelTableColumns (REFERENCES User→Account, fk_field=account). |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Avram associations are loaded via explicit query preloads, not a static lazy-loading proxy declaration — no lazy-load annotation to recognise. |
+| Relationship extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/avram_orm.go`<br>`internal/custom/crystal/avram_orm_test.go` | belongs_to/has_many/has_one association macros are extracted as association entities (assoc_kind + target) and belongs_to additionally yields a REFERENCES FK edge — see association_extraction/foreign_key_extraction. Proven by TestCrystalAvramORM_ModelTableColumns. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🔴 `missing` | — | 4936 | — | Avram query DSL attribution (Model.query chains binding to a table) is deferred — this PR (#4936) implements model/table/column/association extraction only. Granite (lang.crystal.orm.granite) carries query_attribution; Avram's is a follow-up. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | 4936 | — | Avram migration parsing is deferred — this PR implements model/table/column/association extraction only. Granite carries migrations; Avram's is a follow-up. |
+| Migration schema ops | 🔴 `missing` | — | 4936 | — | Avram migration schema-op normalisation is deferred — see migration_parsing. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 4936 | — | Avram transaction-boundary stamping is deferred — this PR implements model/table/column/association extraction only. Granite carries transactions; Avram's is a follow-up. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.crystal.orm.avram ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.crystal.orm.clear.md
+++ b/docs/coverage/detail/lang.crystal.orm.clear.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.crystal.orm.clear` — Clear (Crystal ORM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [crystal](../by-language/crystal.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/clear_orm.go`<br>`internal/custom/crystal/clear_orm_test.go` | Clear (anykeyh/clear) is a Crystal ORM + query builder for PostgreSQL. A persisted model is a class that mixes in `Clear::Model` — clearClassRe finds the class and clearIncludeRe gates on the `include Clear::Model` marker within the class body (so a class that does not include it is skipped, honest), pre-filtered by clearHasModel. Each model emits one SCOPE.Schema/model + one SCOPE.Schema/table; the table identity is the explicit `self.table = "<name>"` assignment (clearTableRe) when present, otherwise the model class name. Carries framework=clear + provenance. Proven by TestCrystalClearORM_ModelTableColumns (self.table users/accounts) + TestCrystalClearORM_NonModelNoop (Config without include skipped) + TestCrystalClearORM_WrongLanguageNoop. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | Clear lifecycle hooks are deferred — only model/table/column/association extraction is implemented in this PR (#4936). No lifecycle hook recognition is claimed. |
+| Schema extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/clear_orm.go`<br>`internal/custom/crystal/clear_orm_test.go` | Each `column <name> : <Type>[, primary: true]` macro (clearColumnRe) becomes a SCOPE.Schema/column carrying column_type (nilable `?` marker trimmed) + the owning model, with primary_key=true stamped on the primary column. The `timestamps` macro (clearTimestampsRe) synthesises created_at/updated_at Time columns stamped auto_timestamp=true. Proven by TestCrystalClearORM_ModelTableColumns (id primary, email `String?` trimmed, timestamps columns). |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/clear_orm.go`<br>`internal/custom/crystal/clear_orm_test.go` | belongs_to/has_many/has_one macros in Clear's typed form `belongs_to <name> : <Class>` (clearAssocRe) each emit a SCOPE.Schema/association entity stamping assoc_kind, the owning model, and the resolved target (has_many singularised; explicit `: <Class>` target honoured by clearAssocTarget). Proven by TestCrystalClearORM_ModelTableColumns (has_many posts : Post, belongs_to account : Account). |
+| Foreign key extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/clear_orm.go`<br>`internal/custom/crystal/clear_orm_test.go` | A `belongs_to account : Account` association yields a REFERENCES edge model → target (fk_field + to_model props), the typed `: <Class>` target winning over the CamelCased name. Cross-file target resolution is delegated to the shared resolver. Proven by TestCrystalClearORM_ModelTableColumns (REFERENCES User→Account, fk_field=account). |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Clear associations are loaded via explicit query/accessor calls, not a static lazy-loading proxy declaration — no lazy-load annotation to recognise. |
+| Relationship extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/clear_orm.go`<br>`internal/custom/crystal/clear_orm_test.go` | belongs_to/has_many/has_one association macros are extracted as association entities (assoc_kind + target) and belongs_to additionally yields a REFERENCES FK edge — see association_extraction/foreign_key_extraction. Proven by TestCrystalClearORM_ModelTableColumns. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🔴 `missing` | — | 4936 | — | Clear query-builder attribution is deferred — this PR (#4936) implements model/table/column/association extraction only. Granite (lang.crystal.orm.granite) carries query_attribution; Clear's is a follow-up. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | 4936 | — | Clear migration parsing is deferred — this PR implements model/table/column/association extraction only. Granite carries migrations; Clear's is a follow-up. |
+| Migration schema ops | 🔴 `missing` | — | 4936 | — | Clear migration schema-op normalisation is deferred — see migration_parsing. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 4936 | — | Clear transaction-boundary stamping is deferred — this PR implements model/table/column/association extraction only. Granite carries transactions; Clear's is a follow-up. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.crystal.orm.clear ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.crystal.orm.crecto.md
+++ b/docs/coverage/detail/lang.crystal.orm.crecto.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.crystal.orm.crecto` — Crecto (Crystal ORM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [crystal](../by-language/crystal.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/crecto_orm.go`<br>`internal/custom/crystal/crecto_orm_test.go` | Crecto (Crecto/crecto) is a Crystal ORM modelled on Elixir's Ecto. A persisted model is a class carrying a `schema "<table>" do … end` block — crectoClassRe finds the class and crectoSchemaRe gates on the schema block (a class with no schema block is skipped, honest), file-level pre-filtered by crectoHasModel on the Crecto::Schema marker. Each model emits one SCOPE.Schema/model + one SCOPE.Schema/table keyed by the `schema "<name>"` argument. Carries framework=crecto + provenance. Proven by TestCrystalCrectoORM_ModelTableColumns (schema "users") + TestCrystalCrectoORM_NonModelNoop (Config without schema block skipped) + TestCrystalCrectoORM_WrongLanguageNoop. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | Crecto lifecycle hooks are deferred — only model/table/column/association extraction is implemented in this PR (#4936). No lifecycle hook recognition is claimed. |
+| Schema extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/crecto_orm.go`<br>`internal/custom/crystal/crecto_orm_test.go` | Each `field :<name>, <Type>` macro (crectoFieldRe) becomes a SCOPE.Schema/column carrying column_type + the owning model. Crecto injects an implicit `id` primary key by default; this is synthesised (column_type=PkeyValue, primary_key=true, provenance INFERRED_FROM_CRECTO_IMPLICIT_PK) unless the model declares an explicit `primary_key`/`set_primary_key` override (crectoPrimaryKeyOptRe). Proven by TestCrystalCrectoORM_ModelTableColumns (field :name/:email/:age with age Int32, synthesised id primary key). |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/crecto_orm.go`<br>`internal/custom/crystal/crecto_orm_test.go` | belongs_to/has_many/has_one macros (crectoAssocRe) each emit a SCOPE.Schema/association entity stamping assoc_kind, the owning model, and the resolved target (has_many singularised; explicit `, <Class>` target honoured by crectoAssocTarget). Proven by TestCrystalCrectoORM_ModelTableColumns (has_many :posts, Post; belongs_to :account, Account). |
+| Foreign key extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/crecto_orm.go`<br>`internal/custom/crystal/crecto_orm_test.go` | A `belongs_to :account, Account` association yields a REFERENCES edge model → target (fk_field + to_model props), the explicit `, <Class>` target winning over the CamelCased name. Cross-file target resolution is delegated to the shared resolver. Proven by TestCrystalCrectoORM_ModelTableColumns (REFERENCES User→Account, fk_field=account). |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Crecto associations are loaded via explicit Repo preloads, not a static lazy-loading proxy declaration — no lazy-load annotation to recognise. |
+| Relationship extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/crecto_orm.go`<br>`internal/custom/crystal/crecto_orm_test.go` | belongs_to/has_many/has_one association macros are extracted as association entities (assoc_kind + target) and belongs_to additionally yields a REFERENCES FK edge — see association_extraction/foreign_key_extraction. Proven by TestCrystalCrectoORM_ModelTableColumns. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🔴 `missing` | — | 4936 | — | Crecto Repo/query DSL attribution is deferred — this PR (#4936) implements model/table/column/association extraction only. Granite (lang.crystal.orm.granite) carries query_attribution; Crecto's is a follow-up. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | 4936 | — | Crecto migration parsing is deferred — this PR implements model/table/column/association extraction only. Granite carries migrations; Crecto's is a follow-up. |
+| Migration schema ops | 🔴 `missing` | — | 4936 | — | Crecto migration schema-op normalisation is deferred — see migration_parsing. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 4936 | — | Crecto transaction-boundary stamping is deferred — this PR implements model/table/column/association extraction only. Granite carries transactions; Crecto's is a follow-up. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.crystal.orm.crecto ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.crystal.orm.jennifer.md
+++ b/docs/coverage/detail/lang.crystal.orm.jennifer.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.crystal.orm.jennifer` — Jennifer (Crystal ORM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [crystal](../by-language/crystal.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/jennifer_orm.go`<br>`internal/custom/crystal/jennifer_orm_test.go` | Jennifer (imdrasil/jennifer.cr) is a Crystal ORM + query DSL. A persisted model is a `class T < Jennifer::Model::Base` (jenniferModelRe, pre-filtered by jenniferHasModel on the Jennifer::Model::Base marker). Each such class emits one SCOPE.Schema/model + one SCOPE.Schema/table; the table identity is the explicit `table_name "<name>"` macro (jenniferTableNameRe) when present, otherwise the model class name. Carries framework=jennifer + provenance. Proven by TestCrystalJenniferORM_ModelTableColumns (table_name users/accounts) + TestCrystalJenniferORM_NonModelNoop + TestCrystalJenniferORM_WrongLanguageNoop. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | Jennifer lifecycle callbacks are deferred — only model/table/column/association extraction is implemented in this PR (#4936). No lifecycle callback recognition is claimed. |
+| Schema extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/jennifer_orm.go`<br>`internal/custom/crystal/jennifer_orm_test.go` | Each `<name>: <Type>` entry inside the `mapping(…)` macro (jenniferMappingRe + jenniferMappingFieldRe) becomes a SCOPE.Schema/column carrying column_type (nilable `?` marker trimmed) + the owning model. A `Primary32`/`Primary64` type alias or an explicit `primary: true` option marks the column primary_key=true (jenniferFieldIsPrimary), and Primary32/Primary64 are normalised to Int32/Int64 (jenniferNormaliseType). The `with_timestamps` macro (jenniferWithTimestampsRe) synthesises the conventional created_at/updated_at Time columns stamped auto_timestamp=true. Proven by TestCrystalJenniferORM_ModelTableColumns (id Primary32→Int32 primary, email `String?` trimmed, with_timestamps columns). |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/jennifer_orm.go`<br>`internal/custom/crystal/jennifer_orm_test.go` | belongs_to/has_many/has_one/has_and_belongs_to_many macros (jenniferAssocRe) each emit a SCOPE.Schema/association entity stamping assoc_kind, the owning model, and the resolved target model name (has_many/habtm singularised; explicit `, <Class>` target argument honoured by jenniferAssocTarget). Proven by TestCrystalJenniferORM_ModelTableColumns (has_many :posts, Post → target Post; belongs_to :account, Account). |
+| Foreign key extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/jennifer_orm.go`<br>`internal/custom/crystal/jennifer_orm_test.go` | A `belongs_to :account, Account` association yields a REFERENCES edge model → target (fk_field + to_model props), the explicit `, <Class>` target winning over the CamelCased name. Cross-file target resolution is delegated to the shared resolver via the bare target name. Proven by TestCrystalJenniferORM_ModelTableColumns (REFERENCES User→Account, fk_field=account). |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Jennifer associations are loaded via explicit query/accessor calls, not a static lazy-loading proxy declaration — no lazy-load annotation to recognise. |
+| Relationship extraction | ✅ `full` | `2026-06-14` | 4936 | `internal/custom/crystal/jennifer_orm.go`<br>`internal/custom/crystal/jennifer_orm_test.go` | belongs_to/has_many/has_one/has_and_belongs_to_many association macros are extracted as association entities (assoc_kind + target) and belongs_to additionally yields a REFERENCES FK edge — see association_extraction/foreign_key_extraction. Proven by TestCrystalJenniferORM_ModelTableColumns. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🔴 `missing` | — | 4936 | — | Jennifer query DSL attribution is deferred — this PR (#4936) implements model/table/column/association extraction only. Granite (lang.crystal.orm.granite) carries query_attribution; Jennifer's is a follow-up. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | 4936 | — | Jennifer migration parsing is deferred — this PR implements model/table/column/association extraction only. Granite carries migrations; Jennifer's is a follow-up. |
+| Migration schema ops | 🔴 `missing` | — | 4936 | — | Jennifer migration schema-op normalisation is deferred — see migration_parsing. |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 4936 | — | Jennifer transaction-boundary stamping is deferred — this PR implements model/table/column/association extraction only. Granite carries transactions; Jennifer's is a follow-up. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.crystal.orm.jennifer ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 250 · **ORMs**: 172 · **Tools**: 129 · **Other**: 205
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 250 · **ORMs**: 176 · **Tools**: 129 · **Other**: 205
 
 ## Coverage by language
 
@@ -24,7 +24,7 @@
 | [lua](by-language/lua.md) | 4 | 0 | 0 | 1 |
 | [dart](by-language/dart.md) | 3 | 1 | 0 | 1 |
 | [F#](by-language/fsharp.md) | 2 | 1 | 0 | 2 |
-| [crystal](by-language/crystal.md) | 1 | 0 | 1 | 1 |
+| [crystal](by-language/crystal.md) | 1 | 0 | 5 | 1 |
 | [erlang](by-language/erlang.md) | 1 | 5 | 0 | 2 |
 | [groovy](by-language/groovy.md) | 1 | 1 | 0 | 1 |
 | [nim](by-language/nim.md) | 1 | 0 | 4 | 1 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 250 frameworks · 129 tools · 172 ORMs · 205 other
+Total: 250 frameworks · 129 tools · 176 ORMs · 205 other

--- a/internal/custom/crystal/avram_orm.go
+++ b/internal/custom/crystal/avram_orm.go
@@ -1,0 +1,285 @@
+// avram_orm.go — Crystal Avram (Lucky framework) ORM model → table/column/
+// association schema synthesis (#4936, follow-up to #4905/#3871).
+//
+// Avram (https://github.com/luckyframework/avram) is the ORM that ships with the
+// Lucky web framework. A persisted model is a class that inherits from a
+// `BaseModel` (itself `< Avram::Model`) and declares its schema inside a
+// `table do … end` block:
+//
+//	class User < BaseModel
+//	  table do
+//	    primary_key id : Int64
+//	    column name : String
+//	    column email : String?
+//	    has_many posts : Post
+//	    belongs_to account : Account
+//	    timestamps
+//	  end
+//	end
+//
+// The `table do … end` block may carry an explicit name —
+// `table :custom_users do` / `table "custom_users" do`.
+//
+// What this extractor emits (mirrors the Granite ORM shape — SCOPE.Schema
+// entities carrying framework=avram + provenance props):
+//   - one SCOPE.Schema/model per `class T < BaseModel` (the file must reference
+//     Avram::Model so we never misfire on an arbitrary BaseModel).
+//   - one SCOPE.Schema/table per model. The table identity is the explicit
+//     `table :<name> do` / `table "<name>" do` argument when present, otherwise
+//     the model class name.
+//   - one SCOPE.Schema/column per `column <name> : <Type>` and per
+//     `primary_key <name> : <Type>` (the latter stamped primary_key=true).
+//   - a REFERENCES edge model → referenced model for each `belongs_to`.
+//   - an association SCOPE.Schema/association entity per belongs_to/has_many/
+//     has_one carrying assoc_kind + target.
+//   - the `timestamps` macro synthesises created_at/updated_at Time columns.
+//
+// Honest exclusions / follow-ups (no fabricated schema):
+//   - Avram query DSL attribution, operations/SaveOperations, migrations, and
+//     transactions are deferred.
+//
+// Registration key: "custom_crystal_avram_orm".
+package crystal
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_crystal_avram_orm", &avramORMExtractor{})
+}
+
+type avramORMExtractor struct{}
+
+func (e *avramORMExtractor) Language() string { return "custom_crystal_avram_orm" }
+
+var (
+	// avramModelRe matches `class T < BaseModel`. Group 1 is the model class
+	// name. The file-level Avram::Model pre-filter gates this against arbitrary
+	// BaseModel subclasses.
+	avramModelRe = regexp.MustCompile(
+		`(?m)^[ \t]*(?:abstract\s+)?class\s+([A-Z]\w*)\s*<\s*BaseModel\b`)
+
+	// avramTableRe matches the `table [:name | "name"] do` block opener. Group 1
+	// is the optional explicit table name.
+	avramTableRe = regexp.MustCompile(
+		`(?m)^[ \t]*table\s+(?::?["']?([A-Za-z_]\w*)["']?\s+)?do\b`)
+
+	// avramColumnRe matches a `column <name> : <Type>[, opts…]` declaration.
+	avramColumnRe = regexp.MustCompile(
+		`(?m)^[ \t]*column\s+([a-z_]\w*)\s*:\s*([A-Za-z_][\w:]*\??)\s*(,.*)?$`)
+
+	// avramPrimaryKeyRe matches a `primary_key <name> : <Type>` declaration.
+	avramPrimaryKeyRe = regexp.MustCompile(
+		`(?m)^[ \t]*primary_key\s+([a-z_]\w*)\s*:\s*([A-Za-z_][\w:]*\??)`)
+
+	// avramTimestampsRe matches the `timestamps` macro.
+	avramTimestampsRe = regexp.MustCompile(`(?m)^[ \t]*timestamps\b`)
+
+	// avramAssocRe matches a belongs_to / has_many / has_one association in
+	// Avram's typed form `belongs_to <name> : <Class>`. Group 1 = kind; group 2 =
+	// name; group 3 = the optional explicit `: <Class>` target.
+	avramAssocRe = regexp.MustCompile(
+		`(?m)^[ \t]*(belongs_to|has_many|has_one)\s+:?["']?([a-z_]\w*)["']?(?:\s*:\s*([A-Z][\w:]*))?`)
+)
+
+// avramHasModel is a fast pre-filter: the file must reference Avram::Model.
+func avramHasModel(content string) bool {
+	return strings.Contains(content, "Avram::Model")
+}
+
+func (e *avramORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "crystal" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !avramHasModel(src) {
+		return nil, nil
+	}
+
+	models := collectAvramModels(src)
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	for _, m := range models {
+		tableName := m.table
+		if tableName == "" {
+			tableName = m.name
+		}
+
+		// 1. model entity + belongs_to REFERENCES edges.
+		model := newCrystalSchema(m.name, "model", "avram", file.Path, m.line,
+			"INFERRED_FROM_AVRAM_MODEL")
+		var rels []types.RelationshipRecord
+		for _, a := range m.assocs {
+			if a.kind != "belongs_to" {
+				continue
+			}
+			target := avramAssocTarget(a)
+			rels = append(rels, types.RelationshipRecord{
+				ToID: target,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"fk_field": a.name,
+					"to_model": target,
+				},
+			})
+		}
+		model.Relationships = rels
+		model.ID = model.ComputeID()
+		out = append(out, model)
+
+		// 2. table entity.
+		table := newCrystalSchema(tableName, "table", "avram", file.Path, m.line,
+			"INFERRED_FROM_AVRAM_TABLE")
+		table.Properties["model"] = m.name
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 3. column entities.
+		colSeen := make(map[string]bool)
+		for _, c := range m.columns {
+			if colSeen[c.name] {
+				continue
+			}
+			colSeen[c.name] = true
+			provenance := "INFERRED_FROM_AVRAM_COLUMN"
+			if c.auto {
+				provenance = "INFERRED_FROM_AVRAM_TIMESTAMPS"
+			}
+			col := newCrystalSchema(c.name, "column", "avram", file.Path, c.line,
+				provenance)
+			col.Properties["column_type"] = c.typ
+			col.Properties["model"] = m.name
+			if c.primary {
+				col.Properties["primary_key"] = "true"
+			}
+			if c.auto {
+				col.Properties["auto_timestamp"] = "true"
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+
+		// 4. association entities.
+		assocSeen := make(map[string]bool)
+		for _, a := range m.assocs {
+			key := a.kind + ":" + a.name
+			if assocSeen[key] {
+				continue
+			}
+			assocSeen[key] = true
+			assoc := newCrystalSchema(a.name, "association", "avram", file.Path, a.line,
+				"INFERRED_FROM_AVRAM_ASSOCIATION")
+			assoc.Properties["assoc_kind"] = a.kind
+			assoc.Properties["model"] = m.name
+			assoc.Properties["target"] = avramAssocTarget(a)
+			assoc.ID = assoc.ComputeID()
+			out = append(out, assoc)
+		}
+	}
+	return out, nil
+}
+
+// avramAssocTarget resolves the association target model: an explicit typed
+// `: <Class>` target wins, otherwise the CamelCased (singularised for plural
+// has_many) name.
+func avramAssocTarget(a avramAssoc) string {
+	if a.target != "" {
+		return a.target
+	}
+	name := a.name
+	if a.kind == "has_many" {
+		name = graniteSingular(name)
+	}
+	return camelize(name)
+}
+
+type avramModel struct {
+	name    string
+	table   string
+	line    int
+	columns []graniteColumn
+	assocs  []avramAssoc
+}
+
+type avramAssoc struct {
+	kind   string
+	name   string
+	target string
+	line   int
+}
+
+// collectAvramModels finds every `class T < BaseModel` and the table do … end
+// block's column/primary_key/association macros in its body.
+func collectAvramModels(src string) []avramModel {
+	idx := avramModelRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	var models []avramModel
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		bodyEnd := graniteClassEnd(src, m[1])
+		body := src[m[1]:bodyEnd]
+
+		am := avramModel{name: name, line: startLine}
+
+		if tm := avramTableRe.FindStringSubmatch(body); tm != nil {
+			am.table = tm[1] // may be empty (anonymous `table do`)
+		}
+
+		// primary_key declarations (stamped primary).
+		for _, pk := range avramPrimaryKeyRe.FindAllStringSubmatchIndex(body, -1) {
+			am.columns = append(am.columns, graniteColumn{
+				name:    body[pk[2]:pk[3]],
+				typ:     strings.TrimSuffix(body[pk[4]:pk[5]], "?"),
+				primary: true,
+				line:    startLine + strings.Count(body[:pk[0]], "\n"),
+			})
+		}
+
+		// column declarations.
+		for _, col := range avramColumnRe.FindAllStringSubmatchIndex(body, -1) {
+			am.columns = append(am.columns, graniteColumn{
+				name: body[col[2]:col[3]],
+				typ:  strings.TrimSuffix(body[col[4]:col[5]], "?"),
+				line: startLine + strings.Count(body[:col[0]], "\n"),
+			})
+		}
+
+		if tsLoc := avramTimestampsRe.FindStringIndex(body); tsLoc != nil {
+			tsLine := startLine + strings.Count(body[:tsLoc[0]], "\n")
+			for _, n := range []string{"created_at", "updated_at"} {
+				am.columns = append(am.columns, graniteColumn{
+					name: n, typ: "Time", auto: true, line: tsLine,
+				})
+			}
+		}
+
+		for _, as := range avramAssocRe.FindAllStringSubmatchIndex(body, -1) {
+			a := avramAssoc{
+				kind: body[as[2]:as[3]],
+				name: body[as[4]:as[5]],
+				line: startLine + strings.Count(body[:as[0]], "\n"),
+			}
+			if as[6] >= 0 {
+				a.target = body[as[6]:as[7]]
+			}
+			am.assocs = append(am.assocs, a)
+		}
+		models = append(models, am)
+	}
+	return models
+}

--- a/internal/custom/crystal/avram_orm_test.go
+++ b/internal/custom/crystal/avram_orm_test.go
@@ -1,0 +1,164 @@
+package crystal_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
+)
+
+// afi builds an Avram-test FileInput.
+func afi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestCrystalAvramORM_ModelTableColumns proves a `class T < BaseModel` (in a
+// file referencing Avram::Model) synthesises model + table + column +
+// association SCOPE.Schema entities from the `table do … end` block, stamps the
+// primary_key column, trims the nilable marker, synthesises timestamps columns,
+// honours an explicit table name, and emits a belongs_to FK edge.
+func TestCrystalAvramORM_ModelTableColumns(t *testing.T) {
+	src := `
+require "avram"
+abstract class BaseModel < Avram::Model
+end
+
+class Account < BaseModel
+  table :accounts do
+    primary_key id : Int64
+    column name : String
+  end
+end
+
+class User < BaseModel
+  table do
+    primary_key id : Int64
+    column name : String
+    column email : String?
+    timestamps
+    has_many posts : Post
+    belongs_to account : Account
+  end
+end
+`
+	e, ok := extreg.Get("custom_crystal_avram_orm")
+	if !ok {
+		t.Fatal("custom_crystal_avram_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), afi("src/models.cr", "crystal", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	type key struct{ name, sub string }
+	got := map[key]bool{}
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+			continue
+		}
+		if en.Properties["framework"] != "avram" {
+			t.Errorf("entity %q missing framework=avram", en.Name)
+		}
+		got[key{en.Name, en.Subtype}] = true
+	}
+
+	for _, m := range []string{"User", "Account"} {
+		if !got[key{m, "model"}] {
+			t.Errorf("expected SCOPE.Schema/model %q", m)
+		}
+	}
+	// Account has an explicit `table :accounts do`; User uses anonymous `table do`
+	// so the table is keyed by the class name.
+	if !got[key{"accounts", "table"}] {
+		t.Error("expected SCOPE.Schema/table accounts (explicit table name)")
+	}
+	if !got[key{"User", "table"}] {
+		t.Error("expected SCOPE.Schema/table User (anonymous table do → class name)")
+	}
+	for _, c := range []string{"id", "name", "email", "created_at", "updated_at"} {
+		if !got[key{c, "column"}] {
+			t.Errorf("expected SCOPE.Schema/column %q", c)
+		}
+	}
+	if !got[key{"posts", "association"}] {
+		t.Error("expected SCOPE.Schema/association posts (has_many)")
+	}
+	if !got[key{"account", "association"}] {
+		t.Error("expected SCOPE.Schema/association account (belongs_to)")
+	}
+
+	primaryStamped := false
+	emailTrimmed := false
+	tsAuto := false
+	fkFound := false
+	for _, en := range ents {
+		if en.Name == "id" && en.Subtype == "column" && en.Properties["primary_key"] == "true" {
+			primaryStamped = true
+		}
+		if en.Name == "email" && en.Subtype == "column" && en.Properties["column_type"] == "String" {
+			emailTrimmed = true
+		}
+		if en.Name == "created_at" && en.Subtype == "column" && en.Properties["auto_timestamp"] == "true" {
+			tsAuto = true
+		}
+		if en.Name == "User" && en.Subtype == "model" {
+			for _, r := range en.Relationships {
+				if r.Kind == "REFERENCES" && r.ToID == "Account" && r.Properties["fk_field"] == "account" {
+					fkFound = true
+				}
+			}
+		}
+	}
+	if !primaryStamped {
+		t.Error("expected id column primary_key=true from primary_key declaration")
+	}
+	if !emailTrimmed {
+		t.Error("expected email column column_type=String (nilable `?` trimmed)")
+	}
+	if !tsAuto {
+		t.Error("expected created_at column auto_timestamp=true from timestamps")
+	}
+	if !fkFound {
+		t.Error("expected REFERENCES edge User→Account (fk_field=account) from belongs_to account : Account")
+	}
+}
+
+// TestCrystalAvramORM_NonModelNoop proves a plain class (no BaseModel parent) is
+// ignored even when Avram::Model appears in the file.
+func TestCrystalAvramORM_NonModelNoop(t *testing.T) {
+	src := `
+require "avram"
+abstract class BaseModel < Avram::Model
+end
+
+class Config
+  def initialize(@host : String)
+  end
+end
+`
+	e, _ := extreg.Get("custom_crystal_avram_orm")
+	ents, _ := e.Extract(context.Background(), afi("src/config.cr", "crystal", src))
+	for _, en := range ents {
+		if en.Name == "Config" {
+			t.Errorf("Config (not a BaseModel subclass) must not be extracted: got %q/%s", en.Name, en.Subtype)
+		}
+	}
+}
+
+// TestCrystalAvramORM_WrongLanguageNoop gates on language=="crystal".
+func TestCrystalAvramORM_WrongLanguageNoop(t *testing.T) {
+	src := `class User < BaseModel
+  table do
+    primary_key id : Int64
+  end
+end
+# Avram::Model`
+	e, _ := extreg.Get("custom_crystal_avram_orm")
+	ents, _ := e.Extract(context.Background(), afi("src/models.cr", "ruby", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-crystal language, got %d", len(ents))
+	}
+}

--- a/internal/custom/crystal/clear_orm.go
+++ b/internal/custom/crystal/clear_orm.go
@@ -1,0 +1,283 @@
+// clear_orm.go — Crystal Clear ORM model → table/column/association schema
+// synthesis (#4936, follow-up to #4905/#3871).
+//
+// Clear (https://github.com/anykeyh/clear) is a Crystal ORM + query builder for
+// PostgreSQL. A persisted model is a class that mixes in `Clear::Model` and
+// declares its columns with the `column` macro:
+//
+//	class User
+//	  include Clear::Model
+//	  self.table = "users"
+//
+//	  column id : Int64, primary: true
+//	  column name : String
+//	  column email : String?
+//
+//	  has_many posts : Post
+//	  belongs_to account : Account
+//	end
+//
+// What this extractor emits (mirrors the Granite ORM shape — SCOPE.Schema
+// entities carrying framework=clear + provenance props):
+//   - one SCOPE.Schema/model per class that `include Clear::Model`.
+//   - one SCOPE.Schema/table per model. The table identity is the explicit
+//     `self.table = "<name>"` assignment when present, otherwise the model class
+//     name.
+//   - one SCOPE.Schema/column per `column <name> : <Type>[, primary: true]`
+//     macro, stamping column_type (nilable `?` trimmed) + the owning model, with
+//     primary_key=true on the primary column.
+//   - a REFERENCES edge model → referenced model for each `belongs_to` (the FK
+//     signal). Clear's `belongs_to <name> : <Class>` typed form names the target
+//     explicitly; otherwise the CamelCased name is used.
+//   - an association SCOPE.Schema/association entity per belongs_to/has_many/
+//     has_one carrying assoc_kind + target.
+//   - the `timestamps` macro synthesises created_at/updated_at Time columns.
+//
+// Honest exclusions / follow-ups (no fabricated schema):
+//   - Clear query DSL attribution, migrations, and transactions are deferred.
+//
+// Registration key: "custom_crystal_clear_orm".
+package crystal
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_crystal_clear_orm", &clearORMExtractor{})
+}
+
+type clearORMExtractor struct{}
+
+func (e *clearORMExtractor) Language() string { return "custom_crystal_clear_orm" }
+
+var (
+	// clearModelRe matches a class that mixes in Clear::Model. Group 1 is the
+	// model class name. Clear uses `class T` + `include Clear::Model`, so the
+	// include is the model marker (matched separately within the class body).
+	clearClassRe = regexp.MustCompile(
+		`(?m)^[ \t]*(?:abstract\s+)?class\s+([A-Z]\w*)\b`)
+
+	// clearIncludeRe matches `include Clear::Model` inside a class body.
+	clearIncludeRe = regexp.MustCompile(`(?m)^[ \t]*include\s+Clear::Model\b`)
+
+	// clearTableRe matches `self.table = "<name>"`. Group 1 is the table name.
+	clearTableRe = regexp.MustCompile(
+		`(?m)^[ \t]*self\.table\s*=\s*["']([A-Za-z_]\w*)["']`)
+
+	// clearColumnRe matches `column <name> : <Type>[, opts…]`. Group 1 = name;
+	// group 2 = type; group 3 = the option tail (scanned for primary).
+	clearColumnRe = regexp.MustCompile(
+		`(?m)^[ \t]*column\s+([a-z_]\w*)\s*:\s*([A-Za-z_][\w:]*\??)\s*(,.*)?$`)
+
+	// clearTimestampsRe matches the `timestamps` macro.
+	clearTimestampsRe = regexp.MustCompile(`(?m)^[ \t]*timestamps\b`)
+
+	// clearAssocRe matches a belongs_to / has_many / has_one association in
+	// Clear's typed form `belongs_to <name> : <Class>`. Group 1 = kind; group 2 =
+	// name; group 3 = the optional explicit `: <Class>` target.
+	clearAssocRe = regexp.MustCompile(
+		`(?m)^[ \t]*(belongs_to|has_many|has_one)\s+:?["']?([a-z_]\w*)["']?(?:\s*:\s*([A-Z][\w:]*))?`)
+)
+
+// clearHasModel is a fast pre-filter: the file must reference Clear::Model.
+func clearHasModel(content string) bool {
+	return strings.Contains(content, "Clear::Model")
+}
+
+func (e *clearORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "crystal" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !clearHasModel(src) {
+		return nil, nil
+	}
+
+	models := collectClearModels(src)
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	for _, m := range models {
+		tableName := m.table
+		if tableName == "" {
+			tableName = m.name
+		}
+
+		// 1. model entity + belongs_to REFERENCES edges.
+		model := newCrystalSchema(m.name, "model", "clear", file.Path, m.line,
+			"INFERRED_FROM_CLEAR_MODEL")
+		var rels []types.RelationshipRecord
+		for _, a := range m.assocs {
+			if a.kind != "belongs_to" {
+				continue
+			}
+			target := clearAssocTarget(a)
+			rels = append(rels, types.RelationshipRecord{
+				ToID: target,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"fk_field": a.name,
+					"to_model": target,
+				},
+			})
+		}
+		model.Relationships = rels
+		model.ID = model.ComputeID()
+		out = append(out, model)
+
+		// 2. table entity.
+		table := newCrystalSchema(tableName, "table", "clear", file.Path, m.line,
+			"INFERRED_FROM_CLEAR_TABLE")
+		table.Properties["model"] = m.name
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 3. column entities.
+		colSeen := make(map[string]bool)
+		for _, c := range m.columns {
+			if colSeen[c.name] {
+				continue
+			}
+			colSeen[c.name] = true
+			provenance := "INFERRED_FROM_CLEAR_COLUMN"
+			if c.auto {
+				provenance = "INFERRED_FROM_CLEAR_TIMESTAMPS"
+			}
+			col := newCrystalSchema(c.name, "column", "clear", file.Path, c.line,
+				provenance)
+			col.Properties["column_type"] = c.typ
+			col.Properties["model"] = m.name
+			if c.primary {
+				col.Properties["primary_key"] = "true"
+			}
+			if c.auto {
+				col.Properties["auto_timestamp"] = "true"
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+
+		// 4. association entities.
+		assocSeen := make(map[string]bool)
+		for _, a := range m.assocs {
+			key := a.kind + ":" + a.name
+			if assocSeen[key] {
+				continue
+			}
+			assocSeen[key] = true
+			assoc := newCrystalSchema(a.name, "association", "clear", file.Path, a.line,
+				"INFERRED_FROM_CLEAR_ASSOCIATION")
+			assoc.Properties["assoc_kind"] = a.kind
+			assoc.Properties["model"] = m.name
+			assoc.Properties["target"] = clearAssocTarget(a)
+			assoc.ID = assoc.ComputeID()
+			out = append(out, assoc)
+		}
+	}
+	return out, nil
+}
+
+// clearAssocTarget resolves the association target model: an explicit typed
+// `: <Class>` target wins, otherwise the CamelCased (singularised for plural
+// has_many) name.
+func clearAssocTarget(a clearAssoc) string {
+	if a.target != "" {
+		return a.target
+	}
+	name := a.name
+	if a.kind == "has_many" {
+		name = graniteSingular(name)
+	}
+	return camelize(name)
+}
+
+type clearModel struct {
+	name    string
+	table   string
+	line    int
+	columns []graniteColumn
+	assocs  []clearAssoc
+}
+
+type clearAssoc struct {
+	kind   string
+	name   string
+	target string
+	line   int
+}
+
+// collectClearModels finds every class that `include Clear::Model` and the
+// self.table/column/association macros in its `end`-terminated body.
+func collectClearModels(src string) []clearModel {
+	idx := clearClassRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	var models []clearModel
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		bodyEnd := graniteClassEnd(src, m[1])
+		body := src[m[1]:bodyEnd]
+
+		// Only a class that mixes in Clear::Model is a model.
+		if !clearIncludeRe.MatchString(body) {
+			continue
+		}
+
+		cm := clearModel{name: name, line: startLine}
+
+		if tm := clearTableRe.FindStringSubmatch(body); tm != nil {
+			cm.table = tm[1]
+		}
+
+		for _, col := range clearColumnRe.FindAllStringSubmatchIndex(body, -1) {
+			cname := body[col[2]:col[3]]
+			ctyp := strings.TrimSuffix(body[col[4]:col[5]], "?")
+			opts := ""
+			if col[6] >= 0 {
+				opts = body[col[6]:col[7]]
+			}
+			cm.columns = append(cm.columns, graniteColumn{
+				name:    cname,
+				typ:     ctyp,
+				primary: strings.Contains(opts, "primary"),
+				line:    startLine + strings.Count(body[:col[0]], "\n"),
+			})
+		}
+
+		if tsLoc := clearTimestampsRe.FindStringIndex(body); tsLoc != nil {
+			tsLine := startLine + strings.Count(body[:tsLoc[0]], "\n")
+			for _, n := range []string{"created_at", "updated_at"} {
+				cm.columns = append(cm.columns, graniteColumn{
+					name: n, typ: "Time", auto: true, line: tsLine,
+				})
+			}
+		}
+
+		for _, am := range clearAssocRe.FindAllStringSubmatchIndex(body, -1) {
+			a := clearAssoc{
+				kind: body[am[2]:am[3]],
+				name: body[am[4]:am[5]],
+				line: startLine + strings.Count(body[:am[0]], "\n"),
+			}
+			if am[6] >= 0 {
+				a.target = body[am[6]:am[7]]
+			}
+			cm.assocs = append(cm.assocs, a)
+		}
+		models = append(models, cm)
+	}
+	return models
+}

--- a/internal/custom/crystal/clear_orm_test.go
+++ b/internal/custom/crystal/clear_orm_test.go
@@ -1,0 +1,169 @@
+package crystal_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
+)
+
+// cfi builds a Clear-test FileInput.
+func cfi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestCrystalClearORM_ModelTableColumns proves a class that `include
+// Clear::Model` synthesises model + table + column + association SCOPE.Schema
+// entities, honours `self.table`, stamps the primary column, trims the nilable
+// marker, synthesises timestamps columns, and emits a belongs_to FK edge.
+func TestCrystalClearORM_ModelTableColumns(t *testing.T) {
+	src := `
+require "clear"
+
+class Account
+  include Clear::Model
+  self.table = "accounts"
+
+  column id : Int64, primary: true
+  column name : String
+end
+
+class User
+  include Clear::Model
+  self.table = "users"
+
+  column id : Int64, primary: true
+  column name : String
+  column email : String?
+
+  timestamps
+
+  has_many posts : Post
+  belongs_to account : Account
+end
+`
+	e, ok := extreg.Get("custom_crystal_clear_orm")
+	if !ok {
+		t.Fatal("custom_crystal_clear_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), cfi("src/models.cr", "crystal", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	type key struct{ name, sub string }
+	got := map[key]bool{}
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+			continue
+		}
+		if en.Properties["framework"] != "clear" {
+			t.Errorf("entity %q missing framework=clear", en.Name)
+		}
+		got[key{en.Name, en.Subtype}] = true
+	}
+
+	for _, m := range []string{"User", "Account"} {
+		if !got[key{m, "model"}] {
+			t.Errorf("expected SCOPE.Schema/model %q", m)
+		}
+	}
+	for _, tbl := range []string{"users", "accounts"} {
+		if !got[key{tbl, "table"}] {
+			t.Errorf("expected SCOPE.Schema/table %q", tbl)
+		}
+	}
+	for _, c := range []string{"id", "name", "email", "created_at", "updated_at"} {
+		if !got[key{c, "column"}] {
+			t.Errorf("expected SCOPE.Schema/column %q", c)
+		}
+	}
+	if !got[key{"posts", "association"}] {
+		t.Error("expected SCOPE.Schema/association posts (has_many)")
+	}
+	if !got[key{"account", "association"}] {
+		t.Error("expected SCOPE.Schema/association account (belongs_to)")
+	}
+
+	primaryStamped := false
+	emailTrimmed := false
+	tsAuto := false
+	fkFound := false
+	accTarget := ""
+	for _, en := range ents {
+		if en.Name == "id" && en.Subtype == "column" && en.Properties["primary_key"] == "true" {
+			primaryStamped = true
+		}
+		if en.Name == "email" && en.Subtype == "column" && en.Properties["column_type"] == "String" {
+			emailTrimmed = true
+		}
+		if en.Name == "updated_at" && en.Subtype == "column" && en.Properties["auto_timestamp"] == "true" {
+			tsAuto = true
+		}
+		if en.Name == "User" && en.Subtype == "model" {
+			for _, r := range en.Relationships {
+				if r.Kind == "REFERENCES" && r.ToID == "Account" && r.Properties["fk_field"] == "account" {
+					fkFound = true
+				}
+			}
+		}
+		if en.Name == "account" && en.Subtype == "association" {
+			accTarget = en.Properties["target"]
+		}
+	}
+	if !primaryStamped {
+		t.Error("expected id column primary_key=true")
+	}
+	if !emailTrimmed {
+		t.Error("expected email column column_type=String (nilable `?` trimmed)")
+	}
+	if !tsAuto {
+		t.Error("expected updated_at column auto_timestamp=true from timestamps")
+	}
+	if !fkFound {
+		t.Error("expected REFERENCES edge User→Account (fk_field=account) from belongs_to account : Account")
+	}
+	if accTarget != "Account" {
+		t.Errorf("expected belongs_to account : Account target=Account, got %q", accTarget)
+	}
+}
+
+// TestCrystalClearORM_NonModelNoop proves a plain class WITHOUT include
+// Clear::Model is ignored even when Clear::Model appears elsewhere in the file.
+func TestCrystalClearORM_NonModelNoop(t *testing.T) {
+	src := `
+require "clear"
+# Clear::Model referenced in a comment, but no class includes it.
+class Config
+  def initialize(@host : String)
+  end
+end
+
+class Helper
+  include Clear::Model
+end
+`
+	e, _ := extreg.Get("custom_crystal_clear_orm")
+	ents, _ := e.Extract(context.Background(), cfi("src/config.cr", "crystal", src))
+	for _, en := range ents {
+		if en.Properties["model"] == "Config" || en.Name == "Config" {
+			t.Errorf("Config (no include Clear::Model) must not be extracted: got %q/%s", en.Name, en.Subtype)
+		}
+	}
+}
+
+// TestCrystalClearORM_WrongLanguageNoop gates on language=="crystal".
+func TestCrystalClearORM_WrongLanguageNoop(t *testing.T) {
+	src := `class User
+  include Clear::Model
+  column id : Int64, primary: true
+end`
+	e, _ := extreg.Get("custom_crystal_clear_orm")
+	ents, _ := e.Extract(context.Background(), cfi("src/models.cr", "ruby", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-crystal language, got %d", len(ents))
+	}
+}

--- a/internal/custom/crystal/crecto_orm.go
+++ b/internal/custom/crystal/crecto_orm.go
@@ -1,0 +1,265 @@
+// crecto_orm.go — Crystal Crecto ORM model → table/column/association schema
+// synthesis (#4936, follow-up to #4905/#3871).
+//
+// Crecto (https://github.com/Crecto/crecto) is a Crystal ORM modelled on
+// Elixir's Ecto. A persisted model is a class that mixes in `Crecto::Model` and
+// declares its schema with a `schema "<table>" do … end` block of `field`
+// macros:
+//
+//	class User
+//	  include Crecto::Schema
+//
+//	  schema "users" do
+//	    field :name, String
+//	    field :email, String
+//	    field :age, Int32
+//	    has_many :posts, Post
+//	    belongs_to :account, Account
+//	  end
+//	end
+//
+// Crecto injects an implicit `id` primary key by default (the `primary_key`
+// option overrides it); the `schema` block name is the table.
+//
+// What this extractor emits (mirrors the Granite ORM shape — SCOPE.Schema
+// entities carrying framework=crecto + provenance props):
+//   - one SCOPE.Schema/model per class carrying a `schema "<table>" do` block
+//     (the file must reference Crecto::Schema so we never misfire).
+//   - one SCOPE.Schema/table per model, keyed by the `schema "<name>"` argument.
+//   - one SCOPE.Schema/column per `field :<name>, <Type>` macro, stamping
+//     column_type + the owning model. The implicit `id` primary key is
+//     synthesised (primary_key=true) unless the model opts out.
+//   - a REFERENCES edge model → referenced model for each `belongs_to`.
+//   - an association SCOPE.Schema/association entity per belongs_to/has_many/
+//     has_one carrying assoc_kind + target.
+//
+// Honest exclusions / follow-ups (no fabricated schema):
+//   - Crecto query/repo DSL attribution, migrations, and transactions are
+//     deferred.
+//
+// Registration key: "custom_crystal_crecto_orm".
+package crystal
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_crystal_crecto_orm", &crectoORMExtractor{})
+}
+
+type crectoORMExtractor struct{}
+
+func (e *crectoORMExtractor) Language() string { return "custom_crystal_crecto_orm" }
+
+var (
+	// crectoClassRe matches a class declaration. Group 1 is the model class name.
+	// The model marker (`include Crecto::Schema` + a `schema "…" do` block) is
+	// checked within the body.
+	crectoClassRe = regexp.MustCompile(
+		`(?m)^[ \t]*(?:abstract\s+)?class\s+([A-Z]\w*)\b`)
+
+	// crectoSchemaRe matches the `schema "<table>" do` block opener. Group 1 is
+	// the table name.
+	crectoSchemaRe = regexp.MustCompile(
+		`(?m)^[ \t]*schema\s+["']([A-Za-z_]\w*)["']\s+do\b`)
+
+	// crectoFieldRe matches a `field :<name>, <Type>[, opts…]` macro. Group 1 =
+	// field name; group 2 = type token.
+	crectoFieldRe = regexp.MustCompile(
+		`(?m)^[ \t]*field\s+:?["']?([a-z_]\w*)["']?\s*,\s*([A-Za-z_][\w:]*)`)
+
+	// crectoAssocRe matches a belongs_to / has_many / has_one association.
+	// Group 1 = kind; group 2 = name; group 3 = the optional explicit
+	// `, <Class>` target argument.
+	crectoAssocRe = regexp.MustCompile(
+		`(?m)^[ \t]*(belongs_to|has_many|has_one)\s+:?["']?([a-z_]\w*)["']?(?:\s*,\s*([A-Z][\w:]*))?`)
+
+	// crectoPrimaryKeyOptRe matches an explicit `set_primary_key` / `primary_key`
+	// override declaration (opts out of the implicit id synthesis).
+	crectoPrimaryKeyOptRe = regexp.MustCompile(`(?m)^[ \t]*(?:set_primary_key|primary_key)\b`)
+)
+
+// crectoHasModel is a fast pre-filter: the file must reference Crecto::Schema.
+func crectoHasModel(content string) bool {
+	return strings.Contains(content, "Crecto::Schema")
+}
+
+func (e *crectoORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "crystal" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !crectoHasModel(src) {
+		return nil, nil
+	}
+
+	models := collectCrectoModels(src)
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	for _, m := range models {
+		// 1. model entity + belongs_to REFERENCES edges.
+		model := newCrystalSchema(m.name, "model", "crecto", file.Path, m.line,
+			"INFERRED_FROM_CRECTO_MODEL")
+		var rels []types.RelationshipRecord
+		for _, a := range m.assocs {
+			if a.kind != "belongs_to" {
+				continue
+			}
+			target := crectoAssocTarget(a)
+			rels = append(rels, types.RelationshipRecord{
+				ToID: target,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"fk_field": a.name,
+					"to_model": target,
+				},
+			})
+		}
+		model.Relationships = rels
+		model.ID = model.ComputeID()
+		out = append(out, model)
+
+		// 2. table entity (the schema "<name>" argument).
+		table := newCrystalSchema(m.table, "table", "crecto", file.Path, m.line,
+			"INFERRED_FROM_CRECTO_TABLE")
+		table.Properties["model"] = m.name
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 3. column entities, with the implicit id primary key synthesised
+		//    unless the model declares an explicit primary-key override.
+		colSeen := make(map[string]bool)
+		if !m.explicitPK {
+			col := newCrystalSchema("id", "column", "crecto", file.Path, m.line,
+				"INFERRED_FROM_CRECTO_IMPLICIT_PK")
+			col.Properties["column_type"] = "PkeyValue"
+			col.Properties["model"] = m.name
+			col.Properties["primary_key"] = "true"
+			col.ID = col.ComputeID()
+			out = append(out, col)
+			colSeen["id"] = true
+		}
+		for _, c := range m.columns {
+			if colSeen[c.name] {
+				continue
+			}
+			colSeen[c.name] = true
+			col := newCrystalSchema(c.name, "column", "crecto", file.Path, c.line,
+				"INFERRED_FROM_CRECTO_FIELD")
+			col.Properties["column_type"] = c.typ
+			col.Properties["model"] = m.name
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+
+		// 4. association entities.
+		assocSeen := make(map[string]bool)
+		for _, a := range m.assocs {
+			key := a.kind + ":" + a.name
+			if assocSeen[key] {
+				continue
+			}
+			assocSeen[key] = true
+			assoc := newCrystalSchema(a.name, "association", "crecto", file.Path, a.line,
+				"INFERRED_FROM_CRECTO_ASSOCIATION")
+			assoc.Properties["assoc_kind"] = a.kind
+			assoc.Properties["model"] = m.name
+			assoc.Properties["target"] = crectoAssocTarget(a)
+			assoc.ID = assoc.ComputeID()
+			out = append(out, assoc)
+		}
+	}
+	return out, nil
+}
+
+// crectoAssocTarget resolves the association target model: an explicit
+// `, <Class>` argument wins, otherwise the CamelCased (singularised for plural
+// has_many) name.
+func crectoAssocTarget(a crectoAssoc) string {
+	if a.target != "" {
+		return a.target
+	}
+	name := a.name
+	if a.kind == "has_many" {
+		name = graniteSingular(name)
+	}
+	return camelize(name)
+}
+
+type crectoModel struct {
+	name       string
+	table      string
+	line       int
+	explicitPK bool
+	columns    []graniteColumn
+	assocs     []crectoAssoc
+}
+
+type crectoAssoc struct {
+	kind   string
+	name   string
+	target string
+	line   int
+}
+
+// collectCrectoModels finds every class carrying a `schema "<table>" do` block
+// and the field/association macros in its body.
+func collectCrectoModels(src string) []crectoModel {
+	idx := crectoClassRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	var models []crectoModel
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		bodyEnd := graniteClassEnd(src, m[1])
+		body := src[m[1]:bodyEnd]
+
+		sm := crectoSchemaRe.FindStringSubmatch(body)
+		if sm == nil {
+			continue // not a Crecto schema-bearing class
+		}
+
+		cm := crectoModel{
+			name:       name,
+			table:      sm[1],
+			line:       startLine,
+			explicitPK: crectoPrimaryKeyOptRe.MatchString(body),
+		}
+
+		for _, fm := range crectoFieldRe.FindAllStringSubmatchIndex(body, -1) {
+			cm.columns = append(cm.columns, graniteColumn{
+				name: body[fm[2]:fm[3]],
+				typ:  body[fm[4]:fm[5]],
+				line: startLine + strings.Count(body[:fm[0]], "\n"),
+			})
+		}
+
+		for _, as := range crectoAssocRe.FindAllStringSubmatchIndex(body, -1) {
+			a := crectoAssoc{
+				kind: body[as[2]:as[3]],
+				name: body[as[4]:as[5]],
+				line: startLine + strings.Count(body[:as[0]], "\n"),
+			}
+			if as[6] >= 0 {
+				a.target = body[as[6]:as[7]]
+			}
+			cm.assocs = append(cm.assocs, a)
+		}
+		models = append(models, cm)
+	}
+	return models
+}

--- a/internal/custom/crystal/crecto_orm_test.go
+++ b/internal/custom/crystal/crecto_orm_test.go
@@ -1,0 +1,137 @@
+package crystal_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
+)
+
+// rfi builds a Crecto-test FileInput.
+func rfi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestCrystalCrectoORM_ModelTableColumns proves a class with a `schema "<table>"
+// do … field … end` block synthesises model + table + column + association
+// SCOPE.Schema entities, synthesises the implicit id primary key, and emits a
+// belongs_to FK edge.
+func TestCrystalCrectoORM_ModelTableColumns(t *testing.T) {
+	src := `
+require "crecto"
+
+class User
+  include Crecto::Schema
+
+  schema "users" do
+    field :name, String
+    field :email, String
+    field :age, Int32
+    has_many :posts, Post
+    belongs_to :account, Account
+  end
+end
+`
+	e, ok := extreg.Get("custom_crystal_crecto_orm")
+	if !ok {
+		t.Fatal("custom_crystal_crecto_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), rfi("src/user.cr", "crystal", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	type key struct{ name, sub string }
+	got := map[key]bool{}
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+			continue
+		}
+		if en.Properties["framework"] != "crecto" {
+			t.Errorf("entity %q missing framework=crecto", en.Name)
+		}
+		got[key{en.Name, en.Subtype}] = true
+	}
+
+	if !got[key{"User", "model"}] {
+		t.Error("expected SCOPE.Schema/model User")
+	}
+	if !got[key{"users", "table"}] {
+		t.Error("expected SCOPE.Schema/table users (schema name)")
+	}
+	for _, c := range []string{"id", "name", "email", "age"} {
+		if !got[key{c, "column"}] {
+			t.Errorf("expected SCOPE.Schema/column %q", c)
+		}
+	}
+	if !got[key{"posts", "association"}] {
+		t.Error("expected SCOPE.Schema/association posts (has_many)")
+	}
+	if !got[key{"account", "association"}] {
+		t.Error("expected SCOPE.Schema/association account (belongs_to)")
+	}
+
+	implicitPK := false
+	ageType := ""
+	fkFound := false
+	for _, en := range ents {
+		if en.Name == "id" && en.Subtype == "column" && en.Properties["primary_key"] == "true" {
+			implicitPK = true
+		}
+		if en.Name == "age" && en.Subtype == "column" {
+			ageType = en.Properties["column_type"]
+		}
+		if en.Name == "User" && en.Subtype == "model" {
+			for _, r := range en.Relationships {
+				if r.Kind == "REFERENCES" && r.ToID == "Account" && r.Properties["fk_field"] == "account" {
+					fkFound = true
+				}
+			}
+		}
+	}
+	if !implicitPK {
+		t.Error("expected synthesised implicit id primary-key column (primary_key=true)")
+	}
+	if ageType != "Int32" {
+		t.Errorf("expected age column column_type=Int32, got %q", ageType)
+	}
+	if !fkFound {
+		t.Error("expected REFERENCES edge User→Account (fk_field=account) from belongs_to :account")
+	}
+}
+
+// TestCrystalCrectoORM_NonModelNoop proves a class with no `schema "…" do`
+// block is ignored even when Crecto::Schema is referenced in the file.
+func TestCrystalCrectoORM_NonModelNoop(t *testing.T) {
+	src := `
+require "crecto"
+# Crecto::Schema referenced, but Config declares no schema block.
+class Config
+  def initialize(@host : String)
+  end
+end
+`
+	e, _ := extreg.Get("custom_crystal_crecto_orm")
+	ents, _ := e.Extract(context.Background(), rfi("src/config.cr", "crystal", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for a class with no schema block, got %d", len(ents))
+	}
+}
+
+// TestCrystalCrectoORM_WrongLanguageNoop gates on language=="crystal".
+func TestCrystalCrectoORM_WrongLanguageNoop(t *testing.T) {
+	src := `class User
+  include Crecto::Schema
+  schema "users" do
+    field :name, String
+  end
+end`
+	e, _ := extreg.Get("custom_crystal_crecto_orm")
+	ents, _ := e.Extract(context.Background(), rfi("src/user.cr", "ruby", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-crystal language, got %d", len(ents))
+	}
+}

--- a/internal/custom/crystal/jennifer_orm.go
+++ b/internal/custom/crystal/jennifer_orm.go
@@ -1,0 +1,313 @@
+// jennifer_orm.go — Crystal Jennifer ORM model → table/column/association
+// schema synthesis (#4936, follow-up to #4905/#3871).
+//
+// Jennifer (https://github.com/imdrasil/jennifer.cr) is a Crystal ORM + query
+// DSL. A persisted model is a class that inherits from `Jennifer::Model::Base`
+// and declares its columns inside a `mapping(...)` macro:
+//
+//	class User < Jennifer::Model::Base
+//	  table_name "users"
+//
+//	  mapping(
+//	    id: Primary32,
+//	    name: String?,
+//	    email: String,
+//	  )
+//
+//	  with_timestamps
+//
+//	  has_many :posts, Post
+//	  belongs_to :account, Account
+//	end
+//
+// What this extractor emits (mirrors the Granite ORM shape — SCOPE.Schema
+// entities carrying framework=jennifer + provenance props):
+//   - one SCOPE.Schema/model per `class T < Jennifer::Model::Base`.
+//   - one SCOPE.Schema/table per model. The table identity is the explicit
+//     `table_name "<name>"` macro argument when present, otherwise the model
+//     class name (Jennifer's runtime default is the snake_case pluralisation;
+//     we record the declared name so the explicit-override case is exact).
+//   - one SCOPE.Schema/column per `<name>: <Type>` entry inside the `mapping(…)`
+//     macro, stamping column_type (nilable `?` marker trimmed) and the owning
+//     model. A `Primary32`/`Primary64`/`primary: true` mapping marks the column
+//     primary_key=true.
+//   - a REFERENCES edge model → referenced model for each `belongs_to :other`
+//     association (the FK signal), keyed by the association name (the explicit
+//     `, <Class>` target argument wins over the CamelCased name).
+//   - an association SCOPE.Schema/association entity per belongs_to/has_many/
+//     has_one/has_and_belongs_to_many carrying assoc_kind + target.
+//   - the `with_timestamps` macro synthesises the conventional created_at/
+//     updated_at Time audit columns (auto_timestamp=true).
+//
+// Honest exclusions / follow-ups (no fabricated schema):
+//   - Jennifer query DSL attribution, migrations, and transactions are deferred
+//     (Granite has them; Jennifer's are a separate follow-up).
+//
+// Registration key: "custom_crystal_jennifer_orm".
+package crystal
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_crystal_jennifer_orm", &jenniferORMExtractor{})
+}
+
+type jenniferORMExtractor struct{}
+
+func (e *jenniferORMExtractor) Language() string { return "custom_crystal_jennifer_orm" }
+
+var (
+	// jenniferModelRe matches `class T < Jennifer::Model::Base`. Group 1 is the
+	// model class name.
+	jenniferModelRe = regexp.MustCompile(
+		`(?m)^[ \t]*(?:abstract\s+)?class\s+([A-Z]\w*)\s*<\s*Jennifer::Model::Base\b`)
+
+	// jenniferTableNameRe matches the `table_name "<name>"` / `table_name :name`
+	// macro. Group 1 is the table name.
+	jenniferTableNameRe = regexp.MustCompile(
+		`(?m)^[ \t]*table_name\s+:?["']?([A-Za-z_]\w*)["']?`)
+
+	// jenniferMappingRe matches the whole `mapping( … )` macro body (group 1).
+	jenniferMappingRe = regexp.MustCompile(`(?s)\bmapping\s*\(\s*(.*?)\)`)
+
+	// jenniferMappingFieldRe matches one `<name>: <Type>[, opts…]` entry inside a
+	// mapping body. Group 1 = field name; group 2 = type token.
+	jenniferMappingFieldRe = regexp.MustCompile(
+		`(?m)^[ \t]*([a-z_]\w*)\s*:\s*([A-Za-z_][\w:]*\??)(.*)$`)
+
+	// jenniferWithTimestampsRe matches the `with_timestamps` macro.
+	jenniferWithTimestampsRe = regexp.MustCompile(`(?m)^[ \t]*with_timestamps\b`)
+
+	// jenniferAssocRe matches a belongs_to / has_many / has_one /
+	// has_and_belongs_to_many association. Group 1 = kind; group 2 = name;
+	// group 3 = the optional explicit `, <Class>` target argument.
+	jenniferAssocRe = regexp.MustCompile(
+		`(?m)^[ \t]*(belongs_to|has_many|has_one|has_and_belongs_to_many)\s+:?["']?([a-z_]\w*)["']?(?:\s*,\s*([A-Z][\w:]*))?`)
+)
+
+// jenniferHasModel is a fast pre-filter: the file must reference Jennifer's base
+// type to be worth scanning.
+func jenniferHasModel(content string) bool {
+	return strings.Contains(content, "Jennifer::Model::Base")
+}
+
+func (e *jenniferORMExtractor) Extract(
+	ctx context.Context,
+	file extractor.FileInput,
+) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 || file.Language != "crystal" {
+		return nil, nil
+	}
+	src := string(file.Content)
+	if !jenniferHasModel(src) {
+		return nil, nil
+	}
+
+	models := collectJenniferModels(src)
+	if len(models) == 0 {
+		return nil, nil
+	}
+
+	var out []types.EntityRecord
+	for _, m := range models {
+		tableName := m.table
+		if tableName == "" {
+			tableName = m.name
+		}
+
+		// 1. model entity + belongs_to REFERENCES edges.
+		model := newCrystalSchema(m.name, "model", "jennifer", file.Path, m.line,
+			"INFERRED_FROM_JENNIFER_MODEL")
+		var rels []types.RelationshipRecord
+		for _, a := range m.assocs {
+			if a.kind != "belongs_to" {
+				continue
+			}
+			target := jenniferAssocTarget(a)
+			rels = append(rels, types.RelationshipRecord{
+				ToID: target,
+				Kind: "REFERENCES",
+				Properties: map[string]string{
+					"fk_field": a.name,
+					"to_model": target,
+				},
+			})
+		}
+		model.Relationships = rels
+		model.ID = model.ComputeID()
+		out = append(out, model)
+
+		// 2. table entity.
+		table := newCrystalSchema(tableName, "table", "jennifer", file.Path, m.line,
+			"INFERRED_FROM_JENNIFER_TABLE")
+		table.Properties["model"] = m.name
+		table.ID = table.ComputeID()
+		out = append(out, table)
+
+		// 3. column entities.
+		colSeen := make(map[string]bool)
+		for _, c := range m.columns {
+			if colSeen[c.name] {
+				continue
+			}
+			colSeen[c.name] = true
+			provenance := "INFERRED_FROM_JENNIFER_COLUMN"
+			if c.auto {
+				provenance = "INFERRED_FROM_JENNIFER_TIMESTAMPS"
+			}
+			col := newCrystalSchema(c.name, "column", "jennifer", file.Path, c.line,
+				provenance)
+			col.Properties["column_type"] = c.typ
+			col.Properties["model"] = m.name
+			if c.primary {
+				col.Properties["primary_key"] = "true"
+			}
+			if c.auto {
+				col.Properties["auto_timestamp"] = "true"
+			}
+			col.ID = col.ComputeID()
+			out = append(out, col)
+		}
+
+		// 4. association entities.
+		assocSeen := make(map[string]bool)
+		for _, a := range m.assocs {
+			key := a.kind + ":" + a.name
+			if assocSeen[key] {
+				continue
+			}
+			assocSeen[key] = true
+			assoc := newCrystalSchema(a.name, "association", "jennifer", file.Path, a.line,
+				"INFERRED_FROM_JENNIFER_ASSOCIATION")
+			assoc.Properties["assoc_kind"] = a.kind
+			assoc.Properties["model"] = m.name
+			assoc.Properties["target"] = jenniferAssocTarget(a)
+			assoc.ID = assoc.ComputeID()
+			out = append(out, assoc)
+		}
+	}
+	return out, nil
+}
+
+// jenniferAssocTarget resolves the target model: an explicit `, <Class>` argument
+// wins, otherwise the CamelCased (singularised for plural has_many/habtm) name.
+func jenniferAssocTarget(a jenniferAssoc) string {
+	if a.target != "" {
+		return a.target
+	}
+	name := a.name
+	if a.kind == "has_many" || a.kind == "has_and_belongs_to_many" {
+		name = graniteSingular(name)
+	}
+	return camelize(name)
+}
+
+type jenniferModel struct {
+	name    string
+	table   string
+	line    int
+	columns []graniteColumn
+	assocs  []jenniferAssoc
+}
+
+type jenniferAssoc struct {
+	kind   string
+	name   string
+	target string
+	line   int
+}
+
+// collectJenniferModels finds every `class T < Jennifer::Model::Base` and the
+// table_name/mapping/association macros in its `end`-terminated body.
+func collectJenniferModels(src string) []jenniferModel {
+	idx := jenniferModelRe.FindAllStringSubmatchIndex(src, -1)
+	if len(idx) == 0 {
+		return nil
+	}
+	var models []jenniferModel
+	for _, m := range idx {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		bodyEnd := graniteClassEnd(src, m[1])
+		body := src[m[1]:bodyEnd]
+
+		jm := jenniferModel{name: name, line: startLine}
+
+		if tm := jenniferTableNameRe.FindStringSubmatch(body); tm != nil {
+			jm.table = tm[1]
+		}
+
+		// mapping(…) fields.
+		if mm := jenniferMappingRe.FindStringSubmatchIndex(body); mm != nil {
+			mapBody := body[mm[2]:mm[3]]
+			mapBodyStartLine := startLine + strings.Count(body[:mm[2]], "\n")
+			for _, fm := range jenniferMappingFieldRe.FindAllStringSubmatchIndex(mapBody, -1) {
+				fname := mapBody[fm[2]:fm[3]]
+				ftyp := mapBody[fm[4]:fm[5]]
+				rest := ""
+				if fm[6] >= 0 {
+					rest = mapBody[fm[6]:fm[7]]
+				}
+				primary := jenniferFieldIsPrimary(ftyp, rest)
+				ftyp = jenniferNormaliseType(strings.TrimSuffix(ftyp, "?"))
+				jm.columns = append(jm.columns, graniteColumn{
+					name:    fname,
+					typ:     ftyp,
+					primary: primary,
+					line:    mapBodyStartLine + strings.Count(mapBody[:fm[0]], "\n"),
+				})
+			}
+		}
+
+		// with_timestamps → created_at/updated_at Time columns.
+		if tsLoc := jenniferWithTimestampsRe.FindStringIndex(body); tsLoc != nil {
+			tsLine := startLine + strings.Count(body[:tsLoc[0]], "\n")
+			for _, n := range []string{"created_at", "updated_at"} {
+				jm.columns = append(jm.columns, graniteColumn{
+					name: n, typ: "Time", auto: true, line: tsLine,
+				})
+			}
+		}
+
+		for _, am := range jenniferAssocRe.FindAllStringSubmatchIndex(body, -1) {
+			a := jenniferAssoc{
+				kind: body[am[2]:am[3]],
+				name: body[am[4]:am[5]],
+				line: startLine + strings.Count(body[:am[0]], "\n"),
+			}
+			if am[6] >= 0 {
+				a.target = body[am[6]:am[7]]
+			}
+			jm.assocs = append(jm.assocs, a)
+		}
+		models = append(models, jm)
+	}
+	return models
+}
+
+// jenniferFieldIsPrimary reports whether a mapping field is the primary key: a
+// `Primary32`/`Primary64` type alias, or an explicit `primary: true` option.
+func jenniferFieldIsPrimary(typ, rest string) bool {
+	return strings.HasPrefix(typ, "Primary") || strings.Contains(rest, "primary: true") ||
+		strings.Contains(rest, "primary:true")
+}
+
+// jenniferNormaliseType maps Jennifer's Primary32/Primary64 mapping aliases to
+// their concrete integer types (the runtime mapping); other types pass through.
+func jenniferNormaliseType(typ string) string {
+	switch typ {
+	case "Primary32":
+		return "Int32"
+	case "Primary64":
+		return "Int64"
+	default:
+		return typ
+	}
+}

--- a/internal/custom/crystal/jennifer_orm_test.go
+++ b/internal/custom/crystal/jennifer_orm_test.go
@@ -1,0 +1,165 @@
+package crystal_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/crystal"
+)
+
+// jfi builds a Jennifer-test FileInput.
+func jfi(path, lang, src string) extreg.FileInput {
+	return extreg.FileInput{Path: path, Language: lang, Content: []byte(src)}
+}
+
+// TestCrystalJenniferORM_ModelTableColumns proves a `class T <
+// Jennifer::Model::Base` model synthesises model + table + column + association
+// SCOPE.Schema entities, honours `table_name`, maps Primary32 to a primary
+// column, trims the nilable marker, synthesises with_timestamps columns, and
+// emits a belongs_to FK edge.
+func TestCrystalJenniferORM_ModelTableColumns(t *testing.T) {
+	src := `
+require "jennifer"
+
+class Account < Jennifer::Model::Base
+  table_name "accounts"
+
+  mapping(
+    id: Primary32,
+    name: String,
+  )
+end
+
+class User < Jennifer::Model::Base
+  table_name "users"
+
+  mapping(
+    id: Primary32,
+    name: String,
+    email: String?,
+  )
+
+  with_timestamps
+
+  has_many :posts, Post
+  belongs_to :account, Account
+end
+`
+	e, ok := extreg.Get("custom_crystal_jennifer_orm")
+	if !ok {
+		t.Fatal("custom_crystal_jennifer_orm not registered")
+	}
+	ents, err := e.Extract(context.Background(), jfi("src/models.cr", "crystal", src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	type key struct{ name, sub string }
+	got := map[key]bool{}
+	for _, en := range ents {
+		if en.Kind != "SCOPE.Schema" {
+			t.Errorf("unexpected kind %q for %q", en.Kind, en.Name)
+			continue
+		}
+		if en.Properties["framework"] != "jennifer" {
+			t.Errorf("entity %q missing framework=jennifer", en.Name)
+		}
+		got[key{en.Name, en.Subtype}] = true
+	}
+
+	for _, m := range []string{"User", "Account"} {
+		if !got[key{m, "model"}] {
+			t.Errorf("expected SCOPE.Schema/model %q", m)
+		}
+	}
+	for _, tbl := range []string{"users", "accounts"} {
+		if !got[key{tbl, "table"}] {
+			t.Errorf("expected SCOPE.Schema/table %q", tbl)
+		}
+	}
+	for _, c := range []string{"id", "name", "email", "created_at", "updated_at"} {
+		if !got[key{c, "column"}] {
+			t.Errorf("expected SCOPE.Schema/column %q", c)
+		}
+	}
+	if !got[key{"posts", "association"}] {
+		t.Error("expected SCOPE.Schema/association posts (has_many)")
+	}
+	if !got[key{"account", "association"}] {
+		t.Error("expected SCOPE.Schema/association account (belongs_to)")
+	}
+
+	primaryStamped := false
+	emailTrimmed := false
+	tsAuto := false
+	fkFound := false
+	postsTarget := ""
+	for _, en := range ents {
+		if en.Name == "id" && en.Subtype == "column" && en.Properties["primary_key"] == "true" {
+			if en.Properties["column_type"] == "Int32" {
+				primaryStamped = true
+			}
+		}
+		if en.Name == "email" && en.Subtype == "column" && en.Properties["column_type"] == "String" {
+			emailTrimmed = true
+		}
+		if en.Name == "created_at" && en.Subtype == "column" && en.Properties["auto_timestamp"] == "true" {
+			tsAuto = true
+		}
+		if en.Name == "User" && en.Subtype == "model" {
+			for _, r := range en.Relationships {
+				if r.Kind == "REFERENCES" && r.ToID == "Account" && r.Properties["fk_field"] == "account" {
+					fkFound = true
+				}
+			}
+		}
+		if en.Name == "posts" && en.Subtype == "association" {
+			postsTarget = en.Properties["target"]
+		}
+	}
+	if !primaryStamped {
+		t.Error("expected id column primary_key=true + column_type=Int32 from Primary32")
+	}
+	if !emailTrimmed {
+		t.Error("expected email column column_type=String (nilable `?` trimmed)")
+	}
+	if !tsAuto {
+		t.Error("expected created_at column auto_timestamp=true from with_timestamps")
+	}
+	if !fkFound {
+		t.Error("expected REFERENCES edge User→Account (fk_field=account) from belongs_to :account")
+	}
+	if postsTarget != "Post" {
+		t.Errorf("expected has_many :posts, Post target=Post, got %q", postsTarget)
+	}
+}
+
+// TestCrystalJenniferORM_NonModelNoop proves a plain (non-Jennifer) class is
+// ignored.
+func TestCrystalJenniferORM_NonModelNoop(t *testing.T) {
+	src := `
+class Config
+  def initialize(@host : String)
+  end
+end
+`
+	e, _ := extreg.Get("custom_crystal_jennifer_orm")
+	ents, _ := e.Extract(context.Background(), jfi("src/config.cr", "crystal", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for a non-Jennifer class, got %d", len(ents))
+	}
+}
+
+// TestCrystalJenniferORM_WrongLanguageNoop gates on language=="crystal".
+func TestCrystalJenniferORM_WrongLanguageNoop(t *testing.T) {
+	src := `class User < Jennifer::Model::Base
+  mapping(id: Primary32)
+end`
+	e, _ := extreg.Get("custom_crystal_jennifer_orm")
+	ents, _ := e.Extract(context.Background(), jfi("src/models.cr", "ruby", src))
+	if len(ents) != 0 {
+		t.Fatalf("expected no entities for non-crystal language, got %d", len(ents))
+	}
+}

--- a/internal/custom/crystal/orm_shared.go
+++ b/internal/custom/crystal/orm_shared.go
@@ -1,0 +1,27 @@
+// orm_shared.go — shared helper for the Crystal ORM extractors (#4936).
+//
+// newCrystalSchema builds a SCOPE.Schema entity stamped with the given Crystal
+// ORM framework + provenance, mirroring newGraniteSchema's shape so the four
+// additional ORMs (Jennifer/Clear/Avram/Crecto) emit a uniform model/table/
+// column/association entity shape.
+package crystal
+
+import "github.com/cajasmota/archigraph/internal/types"
+
+// newCrystalSchema builds a SCOPE.Schema entity with the given framework +
+// provenance stamp. The grain (subtype) is model/table/column/association.
+func newCrystalSchema(name, subtype, framework, path string, line int, provenance string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       name,
+		Kind:       "SCOPE.Schema",
+		Subtype:    subtype,
+		SourceFile: path,
+		Language:   "crystal",
+		StartLine:  line,
+		EndLine:    line,
+		Properties: map[string]string{
+			"framework":  framework,
+			"provenance": provenance,
+		},
+	}
+}


### PR DESCRIPTION
Follow-up to #4905 / epic #3871. Adds model→table/column/association extraction for the four additional major Crystal ORMs, mirroring the existing Granite extractor shape (SCOPE.Schema model/table/column/association entities + REFERENCES FK edges, framework + provenance props). New shared helper `newCrystalSchema`; all four register under the `custom_crystal_` dispatch prefix (no engine wiring needed — same as Granite).

## Per-ORM

**Jennifer** (`internal/custom/crystal/jennifer_orm.go`) — `class T < Jennifer::Model::Base`. model+table (`table_name` or class name); columns from the `mapping(…)` macro with `Primary32`/`Primary64`→primary (normalised to Int32/Int64) and nilable `?` trim; `with_timestamps`→created_at/updated_at; belongs_to/has_many/has_one/has_and_belongs_to_many associations + belongs_to REFERENCES edge (explicit `, <Class>` target honoured). Registry: `lang.crystal.orm.jennifer`.

**Clear** (`clear_orm.go`) — class + `include Clear::Model` (gated within the class body, so a non-including class is honestly skipped). model+table (`self.table = "…"` or class name); `column x : T [, primary:]` columns + nilable trim; `timestamps`; typed `belongs_to/has_many/has_one x : Class` associations + FK edge. Registry: `lang.crystal.orm.clear`.

**Avram (Lucky)** (`avram_orm.go`) — `class T < BaseModel` (file-level `Avram::Model` pre-filter so arbitrary BaseModel subclasses never misfire). model+table (`table :name do` / `table "name" do` / anonymous `table do`→class name); `primary_key x : T` (primary) + `column x : T` columns; `timestamps`; typed associations + FK edge. Registry: `lang.crystal.orm.avram`.

**Crecto** (`crecto_orm.go`) — class with a `schema "table" do … end` block (gated, so a non-schema class is skipped). model+table (schema name); `field :x, T` columns; implicit `id` primary key synthesised unless an explicit `primary_key`/`set_primary_key` override; belongs_to/has_many/has_one + FK edge. Registry: `lang.crystal.orm.crecto`.

## Entities / edges / props
SCOPE.Schema {model, table, column, association} carrying `framework` (jennifer/clear/avram/crecto) + `provenance` + `model`/`column_type`/`primary_key`/`auto_timestamp`/`assoc_kind`/`target`; REFERENCES edge model→target with `fk_field`+`to_model`. Mirrors Granite exactly.

## Registry / coverage docs
4 new `orm_mapper` records (Models: model_extraction+schema_extraction full, model_lifecycle_extraction n/a; Relationships: association/foreign_key/relationship_extraction full, lazy_loading_recognition n/a; Queries/Migrations/Transactions `missing` with tracking issue #4936 — honestly deferred, Granite carries them). Regenerated `docs/coverage` (detail pages for all 4, by-category/orm, by-language/crystal, summary) committed. `coverage fmt --check` + `coverage validate` exit 0.

## Fixtures (per ORM)
Happy path (model/table/column/primary/nilable-trim/timestamps/association/FK-edge) + non-model no-op + wrong-language no-op.

## Gates
`go build ./...`, `go vet ./internal/...`, `go test ./internal/custom/crystal/... ./internal/engine/... ./internal/types/ ./tools/coverage/...`, `coverage fmt --check`, `coverage validate` (exit 0) all pass. git status clean. Sandbox HOME=/tmp/agsbx-4936 (live MCP/daemon untouched).

## Deferred (honest, not claimed)
Per-ORM query DSL attribution, migrations, transactions, lifecycle callbacks — Granite has them; these are follow-ups (recorded `missing` in the registry).

Closes #4936