### PR TITLE
feat(#5007): rust juniper — code-first object-type GRAPH_RELATES graph

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -148,7 +148,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [rust](../by-language/rust.md) | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 6/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 11/24 | 🟡 6/13 | |
 | [rust](../by-language/rust.md) | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 5/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
-| [rust](../by-language/rust.md) | [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/13 | |
+| [rust](../by-language/rust.md) | [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 2/13 | |
 | [rust](../by-language/rust.md) | [ntex](../detail/lang.rust.framework.ntex.md) | 🟡 5/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [rust](../by-language/rust.md) | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 10/24 | 🟡 4/12 | |
 | [swift](../by-language/swift.md) | [Vapor](../detail/lang.swift.framework.vapor.md) | 🟡 3/7 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 21/25 | 🟡 6/12 | |

--- a/docs/coverage/by-language/rust.md
+++ b/docs/coverage/by-language/rust.md
@@ -39,7 +39,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [Warp](../detail/lang.rust.framework.warp.md) | 🟡 6/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [async-graphql](../detail/lang.rust.framework.async-graphql.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 11/24 | 🟡 6/13 | |
 | [hyper](../detail/lang.rust.framework.hyper.md) | 🟡 5/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
-| [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 1/13 | |
+| [juniper](../detail/lang.rust.framework.juniper.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 3/24 | 🟡 2/13 | |
 | [ntex](../detail/lang.rust.framework.ntex.md) | 🟡 5/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 7/12 | |
 | [utoipa](../detail/lang.rust.framework.utoipa.md) | 🟡 3/6 | 🔴 0/1 | ✅ 4/4 | 🔴 0/1 | 🟡 10/24 | 🟡 4/12 | |
 

--- a/docs/coverage/detail/lang.rust.framework.juniper.md
+++ b/docs/coverage/detail/lang.rust.framework.juniper.md
@@ -53,7 +53,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Type graph extraction | 🔴 `missing` | — | 5007 | — | — |
+| Type graph extraction | ✅ `full` | `2026-06-14` | — | `internal/custom/rust/juniper.go`<br>`internal/custom/rust/juniper_typegraph.go`<br>`internal/custom/rust/juniper_typegraph_test.go` | #5007: new internal/custom/rust/juniper_typegraph.go mirrors the async-graphql code-first type-graph extractor (#3983) for juniper. Emits SCOPE.Schema/type nodes (BuildOperationStructuralRef("graphql",file,Type), shared identity with the SDL/async-graphql/py/jsts passes) + GRAPH_RELATES field->type edges off #[derive(GraphQLObject)] struct fields and #[graphql_object]/#[graphql_subscription] impl resolver return types, carrying the SDL cardinality contract (field_name/list/nullable/item_nullable/cardinality/self_ref, framework=juniper). Probe TestJunTG_GraphQLObject_FieldGraph asserts User.orders Vec<Order> to_many + Option<Account> nullable to_one + manager Option<User> self_ref + scalar/GraphQLInputObject fields no edge; TestJunTG_ResolverReturnType asserts Query.user FieldResult<User> to_one unwrap + Vec<Order> to_many; wrong-language + plain-struct no-op probes. Honest-partial: same-file resolution only; GraphQLInputObject/GraphQLEnum stay DTO-catalog (#4964). |
 
 ### Type System
 

--- a/internal/custom/rust/juniper_typegraph.go
+++ b/internal/custom/rust/juniper_typegraph.go
@@ -1,0 +1,243 @@
+package rust
+
+// juniper_typegraph.go — code-first GraphQL schema type→type graph for juniper
+// (#5007, follow-up from #4964). The juniper sibling of
+// internal/custom/rust/graphql_codefirst_typegraph.go (async-graphql, #3983) and
+// internal/custom/{python,javascript}/graphql_codefirst_typegraph.go.
+//
+// internal/custom/rust/juniper.go already emits the flat DTO catalog (a
+// SCOPE.Schema/dto per #[derive(GraphQLObject/GraphQLInputObject/GraphQLEnum)]
+// type) and the synthetic GRAPHQL endpoint per #[graphql_object] resolver
+// method. What it does NOT emit is the typed field→type relationship graph (the
+// #3804 lane): which object type references which other object type, with what
+// cardinality. juniper's Schema.type_graph_extraction was HONESTLY missing.
+//
+// This extractor closes that gap for juniper:
+//
+//	#[derive(GraphQLObject)]
+//	struct User {
+//	    id: i32,                  // scalar -> no edge
+//	    name: String,             // scalar -> no edge
+//	    orders: Vec<Order>,       // GRAPH_RELATES User->Order  to_many
+//	    account: Option<Account>, // GRAPH_RELATES User->Account nullable to_one
+//	    manager: Option<User>,    // self_ref
+//	}
+//
+//	struct Query;
+//	#[graphql_object]
+//	impl Query {
+//	    // resolver return type -> GRAPH_RELATES Query->User
+//	    fn user(&self, id: i32) -> FieldResult<User> { ... }
+//	    fn orders(&self) -> Vec<Order> { ... }
+//	}
+//
+// Each object type (a #[derive(GraphQLObject)] struct, the resolver root of a
+// #[graphql_object] / #[graphql_subscription] impl) becomes a SCOPE.Schema/type
+// node addressed with the SAME canonical structural ref the SDL pass and the
+// async-graphql / py / jsts code-first passes use
+// (BuildOperationStructuralRef("graphql", file, TypeName)), so identities
+// converge on one node per type across passes/repos. Each object-typed struct
+// field and each resolver return type becomes a GRAPH_RELATES edge carrying the
+// identical cardinality property contract as the SDL / async-graphql / py / jsts
+// emitters:
+//
+//	{field_name, list, nullable, item_nullable, cardinality:to_one|to_many,
+//	 self_ref, graphql_field, framework:juniper}
+//
+// HONEST LIMITS (identical to the async-graphql extractor):
+//   - Field-type resolution is heuristic and same-file: a field whose innermost
+//     type identifier is a scalar (i32/String/...) or is not an object type
+//     declared in the SAME file produces NO edge. Cross-module references and
+//     custom scalars are not chased.
+//   - GraphQLInputObject and GraphQLEnum types are intentionally NOT owners —
+//     inputs/enums are the flat DTO catalog (already credited in #4964) and carry
+//     no object→object data relations in the output type graph.
+//   - A plain `struct` with no juniper derive emits no type node and no edge; a
+//     non-GraphQL `impl` (no #[graphql_object]/#[graphql_subscription]) emits no
+//     resolver edge. The #[graphql(name = "...")] field-rename attribute is not
+//     yet honoured for the GraphQL field name (matches juniper.go).
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_rust_juniper_typegraph", &rustJuniperTypeGraphExtractor{})
+}
+
+// rustJuniperTypeGraphExtractor builds the object-type→type relationship graph
+// for juniper code-first schemas.
+type rustJuniperTypeGraphExtractor struct{}
+
+func (e *rustJuniperTypeGraphExtractor) Language() string {
+	return "custom_rust_juniper_typegraph"
+}
+
+var (
+	// #[derive(... GraphQLObject ...)] struct Name { ... } — juniper output
+	// object types. These are the owners of the field graph and edge targets.
+	// Negative lookahead is not available in RE2; GraphQLInputObject is filtered
+	// out below by requiring the derive token NOT to be the input/enum form.
+	reJunTGObjectStruct = regexp.MustCompile(
+		`#\[derive\s*\(([^)]*\bGraphQLObject\b[^)]*)\)\]\s*(?:#\[[^\]]*\]\s*)*(?:pub\s+)?struct\s+([A-Za-z_]\w*)`,
+	)
+	// #[graphql_object ...] / #[graphql_subscription ...] (resolver impl)
+	// immediately preceding `impl <Root>`. Group 1 = the resolver root type name.
+	reJunTGObjectImpl = regexp.MustCompile(
+		`#\[graphql_(?:object|subscription)[^\]]*\]\s*(?:#\[[^\]]*\]\s*)*impl\s+(?:<[^>]*>\s*)?([A-Za-z_]\w*)`,
+	)
+)
+
+func (e *rustJuniperTypeGraphExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.rust_juniper_typegraph")
+	_, span := tracer.Start(ctx, "custom.rust_juniper_typegraph")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 || file.Language != "rust" {
+		return nil, nil
+	}
+	src := string(file.Content)
+
+	// File-signal gate: require a juniper marker (mirrors juniper.go).
+	if !strings.Contains(src, "#[graphql_object") &&
+		!strings.Contains(src, "#[graphql_subscription") &&
+		!strings.Contains(src, "GraphQLObject") {
+		return nil, nil
+	}
+
+	type ownerBlock struct {
+		name string
+		kind string // "struct" | "resolver"
+		line int
+		body string
+	}
+	var owners []ownerBlock
+	known := map[string]bool{}
+
+	// #[derive(GraphQLObject)] structs are both owners and edge targets.
+	// GraphQLInputObject also matches the substring GraphQLObject, so require the
+	// derive group to NOT contain the input/enum forms.
+	for _, m := range reJunTGObjectStruct.FindAllStringSubmatchIndex(src, -1) {
+		derives := src[m[2]:m[3]]
+		if strings.Contains(derives, "GraphQLInputObject") {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		bodyStart, bodyEnd := agqlBlockBody(src, m[5])
+		body := ""
+		if bodyStart >= 0 {
+			body = src[bodyStart:bodyEnd]
+		}
+		owners = append(owners, ownerBlock{name: name, kind: "struct", line: lineOf(src, m[0]), body: body})
+		known[name] = true
+	}
+	// #[graphql_object]/#[graphql_subscription] impl <Root> resolver blocks are
+	// owners; their return types are edge targets.
+	for _, m := range reJunTGObjectImpl.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		bodyStart, bodyEnd := agqlBlockBody(src, m[1])
+		body := ""
+		if bodyStart >= 0 {
+			body = src[bodyStart:bodyEnd]
+		}
+		owners = append(owners, ownerBlock{name: name, kind: "resolver", line: lineOf(src, m[0]), body: body})
+	}
+
+	if len(owners) == 0 {
+		return nil, nil
+	}
+
+	nodes := map[string]int{}
+	var out []types.EntityRecord
+	nodeFor := func(name string, line int) {
+		if _, ok := nodes[name]; ok {
+			return
+		}
+		ent := makeEntity(name, "SCOPE.Schema", "type", file.Path, file.Language, line)
+		setProps(&ent,
+			"graphql_type", name,
+			"framework", "juniper",
+			"code_first", "true",
+			"structural_ref", extractor.BuildOperationStructuralRef("graphql", file.Path, name),
+			"provenance", "INFERRED_FROM_CODEFIRST_GRAPHQL_OBJECTTYPE",
+		)
+		out = append(out, ent)
+		nodes[name] = len(out) - 1
+	}
+
+	seen := map[string]bool{}
+	emit := func(owner, fieldName, target string, tc rustGqlCard) {
+		if !known[target] || rustGqlScalars[target] {
+			return
+		}
+		key := owner + "|" + fieldName + "|" + target
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		ownerRef := extractor.BuildOperationStructuralRef("graphql", file.Path, owner)
+		targetRef := extractor.BuildOperationStructuralRef("graphql", file.Path, target)
+		props := map[string]string{
+			"field_name":    fieldName,
+			"list":          rustGqlBool(tc.list),
+			"nullable":      rustGqlBool(tc.nullable),
+			"cardinality":   rustGqlCardLabel(tc),
+			"self_ref":      rustGqlBool(target == owner),
+			"graphql_field": owner + "." + fieldName,
+			"framework":     "juniper",
+			"provenance":    "INFERRED_FROM_CODEFIRST_GRAPHQL_FIELD",
+		}
+		if tc.list {
+			props["item_nullable"] = rustGqlBool(tc.itemNullable)
+		}
+		idx := nodes[owner]
+		out[idx].Relationships = append(out[idx].Relationships,
+			types.RelationshipRecord{
+				FromID:     ownerRef,
+				ToID:       targetRef,
+				Kind:       string(types.RelationshipKindGraphRelates),
+				Properties: props,
+			})
+	}
+
+	for _, ow := range owners {
+		nodeFor(ow.name, ow.line)
+		switch ow.kind {
+		case "struct":
+			for _, fm := range reGqlTGStructField.FindAllStringSubmatch(ow.body, -1) {
+				fieldName := fm[1]
+				typeExpr := strings.TrimSpace(fm[2])
+				base, tc := rustParseTypeExpr(typeExpr)
+				if base == "" {
+					continue
+				}
+				emit(ow.name, fieldName, base, tc)
+			}
+		case "resolver":
+			for _, fm := range reGqlTGResolverFn.FindAllStringSubmatchIndex(ow.body, -1) {
+				fieldName := ow.body[fm[2]:fm[3]]
+				ret := rustResolverReturnType(ow.body, fm[0])
+				if ret == "" {
+					continue
+				}
+				base, tc := rustParseTypeExpr(ret)
+				if base == "" {
+					continue
+				}
+				emit(ow.name, fieldName, base, tc)
+			}
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/rust/juniper_typegraph_test.go
+++ b/internal/custom/rust/juniper_typegraph_test.go
@@ -1,0 +1,306 @@
+package rust_test
+
+// juniper_typegraph_test.go — value-asserting tests for the
+// custom_rust_juniper_typegraph extractor (#5007, follow-up from #4964).
+//
+// Asserts the GRAPH_RELATES object-type→type edges for juniper carry the exact
+// FromID/ToID structural refs + cardinality the SDL / async-graphql / py / jsts
+// passes emit, that the owning type node is reused (no duplicate), that resolver
+// return types produce root→type edges, and that scalar / unresolved /
+// non-GraphQL / wrong-language inputs make NO edge.
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/rust"
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func runJunTG(t *testing.T, path, lang, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get("custom_rust_juniper_typegraph")
+	if !ok {
+		t.Fatal("custom_rust_juniper_typegraph not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extractor.FileInput{Path: path, Language: lang, Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}
+
+func junTGRef(path, name string) string {
+	return "scope:operation:method:graphql:" + path + ":" + name
+}
+
+func findJunTG(ents []types.EntityRecord, fromID, toID, field string) *types.RelationshipRecord {
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			r := &ents[i].Relationships[j]
+			if r.Kind == string(types.RelationshipKindGraphRelates) &&
+				r.FromID == fromID && r.ToID == toID && r.Properties["field_name"] == field {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func countJunTGNodes(ents []types.EntityRecord, name string) int {
+	n := 0
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "type" && e.Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+func countJunTGEdges(ents []types.EntityRecord) int {
+	n := 0
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == string(types.RelationshipKindGraphRelates) {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestJunTG_GraphQLObject_FieldGraph (happy path) asserts the GraphQLObject
+// struct field graph: scalar fields make no edge, Vec<Order> is a to_many edge,
+// Option<Account> is a nullable to_one edge, and a self-reference is flagged.
+func TestJunTG_GraphQLObject_FieldGraph(t *testing.T) {
+	path := "schema.rs"
+	src := `
+use juniper::*;
+
+#[derive(GraphQLObject)]
+struct User {
+    id: i32,
+    name: String,
+    orders: Vec<Order>,
+    account: Option<Account>,
+    manager: Option<User>,
+}
+
+#[derive(GraphQLObject)]
+struct Order { id: i32 }
+
+#[derive(GraphQLObject)]
+struct Account { id: i32 }
+
+#[derive(GraphQLInputObject)]
+struct NewUser { name: String, account: Option<Account> }
+`
+	ents := runJunTG(t, path, "rust", src)
+
+	// User node exists exactly once.
+	if n := countJunTGNodes(ents, "User"); n != 1 {
+		t.Fatalf("expected exactly 1 User type node, got %d", n)
+	}
+	// GraphQLInputObject NewUser is NOT an owner / type node.
+	if n := countJunTGNodes(ents, "NewUser"); n != 0 {
+		t.Errorf("GraphQLInputObject NewUser must not be a type node, got %d", n)
+	}
+
+	userRef := junTGRef(path, "User")
+
+	// orders: Vec<Order> -> to_many edge, framework=juniper.
+	o := findJunTG(ents, userRef, junTGRef(path, "Order"), "orders")
+	if o == nil {
+		t.Fatal("missing User.orders -> Order GRAPH_RELATES edge")
+	}
+	if o.Properties["cardinality"] != "to_many" || o.Properties["list"] != "true" {
+		t.Errorf("User.orders want list=true/to_many, got list=%q card=%q",
+			o.Properties["list"], o.Properties["cardinality"])
+	}
+	if o.Properties["nullable"] != "false" {
+		t.Errorf("User.orders want nullable=false, got %q", o.Properties["nullable"])
+	}
+	if o.Properties["framework"] != "juniper" {
+		t.Errorf("want framework=juniper, got %q", o.Properties["framework"])
+	}
+	if o.Properties["graphql_field"] != "User.orders" {
+		t.Errorf("want graphql_field=User.orders, got %q", o.Properties["graphql_field"])
+	}
+
+	// account: Option<Account> -> nullable to_one edge.
+	a := findJunTG(ents, userRef, junTGRef(path, "Account"), "account")
+	if a == nil {
+		t.Fatal("missing User.account -> Account GRAPH_RELATES edge")
+	}
+	if a.Properties["cardinality"] != "to_one" || a.Properties["list"] != "false" {
+		t.Errorf("User.account want to_one/list=false, got card=%q list=%q",
+			a.Properties["cardinality"], a.Properties["list"])
+	}
+	if a.Properties["nullable"] != "true" {
+		t.Errorf("User.account want nullable=true, got %q", a.Properties["nullable"])
+	}
+
+	// manager: Option<User> -> self_ref.
+	m := findJunTG(ents, userRef, userRef, "manager")
+	if m == nil {
+		t.Fatal("missing User.manager -> User self-reference edge")
+	}
+	if m.Properties["self_ref"] != "true" {
+		t.Errorf("User.manager want self_ref=true, got %q", m.Properties["self_ref"])
+	}
+
+	// Scalar fields id/name make NO edge. NewUser input fields make NO edge.
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			switch r.Properties["field_name"] {
+			case "id", "name":
+				t.Errorf("scalar field %q must not produce an edge", r.Properties["field_name"])
+			}
+			if r.Properties["graphql_field"] == "NewUser.account" {
+				t.Error("GraphQLInputObject field must not produce an edge")
+			}
+		}
+	}
+}
+
+// TestJunTG_ResolverReturnType asserts a #[graphql_object] impl Query resolver's
+// return type produces a Query->Type edge with the right cardinality, including
+// FieldResult<T> / Vec<T> unwrapping; scalar returns make no edge.
+func TestJunTG_ResolverReturnType(t *testing.T) {
+	path := "query.rs"
+	src := `
+use juniper::*;
+
+#[derive(GraphQLObject)]
+struct User { id: i32 }
+
+#[derive(GraphQLObject)]
+struct Order { id: i32 }
+
+struct Query;
+
+#[graphql_object]
+impl Query {
+    fn user(&self, id: i32) -> FieldResult<User> {
+        todo!()
+    }
+    fn orders(&self) -> Vec<Order> {
+        todo!()
+    }
+    fn count(&self) -> i32 {
+        0
+    }
+}
+`
+	ents := runJunTG(t, path, "rust", src)
+	queryRef := junTGRef(path, "Query")
+
+	// user(...) -> FieldResult<User> unwrapped to a to_one User edge.
+	u := findJunTG(ents, queryRef, junTGRef(path, "User"), "user")
+	if u == nil {
+		t.Fatal("missing Query.user -> User resolver edge (FieldResult<T> unwrap)")
+	}
+	if u.Properties["cardinality"] != "to_one" {
+		t.Errorf("Query.user want to_one, got %q", u.Properties["cardinality"])
+	}
+
+	// orders(...) -> Vec<Order> to_many edge.
+	o := findJunTG(ents, queryRef, junTGRef(path, "Order"), "orders")
+	if o == nil {
+		t.Fatal("missing Query.orders -> Order resolver edge")
+	}
+	if o.Properties["cardinality"] != "to_many" {
+		t.Errorf("Query.orders want to_many, got %q", o.Properties["cardinality"])
+	}
+
+	// count(...) -> i32 scalar return makes NO edge.
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Properties["field_name"] == "count" {
+				t.Error("scalar resolver return i32 must not produce an edge")
+			}
+		}
+	}
+}
+
+// TestJunTG_WrongLanguageNoOp (wrong-language no-op) asserts a non-rust file with
+// juniper-looking content emits nothing.
+func TestJunTG_WrongLanguageNoOp(t *testing.T) {
+	path := "schema.go"
+	src := `
+#[derive(GraphQLObject)]
+struct User { orders: Vec<Order> }
+#[derive(GraphQLObject)]
+struct Order { id: i32 }
+`
+	ents := runJunTG(t, path, "go", src)
+	if len(ents) != 0 {
+		t.Fatalf("non-rust language must emit nothing, got %d entities", len(ents))
+	}
+}
+
+// TestJunTG_NoMatchPlainStruct (no-match no-op) asserts a plain Rust struct with
+// no juniper derive (and no other juniper signal) produces NO node and NO edge.
+func TestJunTG_NoMatchPlainStruct(t *testing.T) {
+	path := "plain.rs"
+	src := `
+struct User {
+    id: u64,
+    orders: Vec<Order>,
+}
+struct Order { id: u64 }
+`
+	ents := runJunTG(t, path, "rust", src)
+	if len(ents) != 0 {
+		t.Fatalf("plain struct (no juniper signal) must emit nothing, got %d entities", len(ents))
+	}
+}
+
+// TestJunTG_NegativeNonGraphQLImpl asserts a plain `impl` block (no
+// #[graphql_object]) within an otherwise-juniper file produces NO resolver edge
+// and the impl root is not a type node.
+func TestJunTG_NegativeNonGraphQLImpl(t *testing.T) {
+	path := "mixed.rs"
+	src := `
+use juniper::*;
+
+#[derive(GraphQLObject)]
+struct User { id: i32 }
+
+struct Helper;
+impl Helper {
+    fn user(&self) -> User { todo!() }
+}
+`
+	ents := runJunTG(t, path, "rust", src)
+	if countJunTGNodes(ents, "Helper") != 0 {
+		t.Error("non-#[graphql_object] impl Helper must not become a GraphQL type node")
+	}
+	if countJunTGEdges(ents) != 0 {
+		t.Errorf("plain impl (no #[graphql_object]) must produce no resolver edge, got %d edges", countJunTGEdges(ents))
+	}
+}
+
+// TestJunTG_UnresolvedFieldNoEdge asserts a field referencing a type not declared
+// in the same file makes NO edge (honest same-file limit).
+func TestJunTG_UnresolvedFieldNoEdge(t *testing.T) {
+	path := "partial.rs"
+	src := `
+use juniper::*;
+
+#[derive(GraphQLObject)]
+struct User {
+    id: i32,
+    external: Vec<RemoteThing>,
+}
+`
+	ents := runJunTG(t, path, "rust", src)
+	if countJunTGEdges(ents) != 0 {
+		t.Errorf("unresolved cross-file type must produce no edge, got %d", countJunTGEdges(ents))
+	}
+	if countJunTGNodes(ents, "User") != 1 {
+		t.Errorf("User node should still be emitted, got %d", countJunTGNodes(ents, "User"))
+	}
+}


### PR DESCRIPTION
## What this builds

New extractor `internal/custom/rust/juniper_typegraph.go` (`custom_rust_juniper_typegraph`) — the juniper sibling of the async-graphql code-first type-graph extractor (#3983, `graphql_codefirst_typegraph.go`). Closes the deferred #4964 lane: juniper DTOs were catalogued but no field→type edges were emitted (Schema/type_graph_extraction was `missing/#5007`).

### Entities / edges / props
- **SCOPE.Schema/type** node per `#[derive(GraphQLObject)]` struct and per `#[graphql_object]`/`#[graphql_subscription]` impl resolver root. Addressed with the shared canonical `BuildOperationStructuralRef("graphql", file, Type)` — identity converges with the SDL / async-graphql / py / jsts passes (one node per type, no duplicates). Props: `graphql_type, framework=juniper, code_first=true, structural_ref, provenance`.
- **GRAPH_RELATES** field→type edge (reuses existing `types.RelationshipKindGraphRelates` — no new Kind) off object-typed struct fields and resolver return types, carrying the identical SDL cardinality contract: `field_name, list, nullable, item_nullable, cardinality(to_one|to_many), self_ref, graphql_field, framework=juniper, provenance`. Reuses the shared `rustParseTypeExpr`/`rustResolverReturnType`/`agqlBlockBody`/`rustGqlScalars` helpers (FieldResult/Result/Vec/Option unwrapping).

### Honest scope (only cells fixtures prove)
- Owners are output object types only. `#[derive(GraphQLInputObject)]`/`GraphQLEnum` stay in the flat DTO catalog (#4964) — NOT owners, no input→input edges.
- Same-file resolution only: a field whose innermost type is a scalar or an undeclared (cross-file) type produces NO edge.
- Non-`#[graphql_object]` plain `impl` → no resolver edge; plain struct (no juniper derive) → no node/edge.

### Fixtures (inline, mirroring async-graphql test style)
- Happy path: `TestJunTG_GraphQLObject_FieldGraph` (Vec<Order> to_many, Option<Account> nullable to_one, Option<User> self_ref, scalar + GraphQLInputObject fields no edge) + `TestJunTG_ResolverReturnType` (Query.user FieldResult<User> to_one unwrap, Vec<Order> to_many, i32 no edge).
- Wrong-language no-op: `TestJunTG_WrongLanguageNoOp` (lang=go → nothing).
- No-match no-op: `TestJunTG_NoMatchPlainStruct` (plain struct → nothing).
- Plus `TestJunTG_NegativeNonGraphQLImpl`, `TestJunTG_UnresolvedFieldNoEdge`.

### Registry / coverage docs (REGENERATED, included)
Surgical edit: `lang.rust.framework.juniper` → `Schema.type_graph_extraction` flipped `missing/#5007` → `full`, cites the 3 files below, notes describe probes + honest-partial. Ran `coverage fmt` + `coverage gen` (re-run after final edit). Regenerated `docs/coverage/by-category/http_framework.md`, `docs/coverage/by-language/rust.md`, `docs/coverage/detail/lang.rust.framework.juniper.md` are committed.

### Gates (all green on the FINAL committed tree, sandbox HOME=/tmp/agsbx-5007)
- `go build ./...` OK, `go vet ./internal/...` OK
- `go test ./internal/custom/rust/... ./internal/engine/... ./internal/types/` OK
- `coverage fmt --check` exit 0, `coverage validate` **exit 0**
- `git status --porcelain` EMPTY

### Cite-existence proof (the #5108→#5120 revert guard)
Every cited path is git-ls-files-tracked on the committed tree:
- `internal/custom/rust/juniper.go` → TRACKED
- `internal/custom/rust/juniper_typegraph.go` → TRACKED
- `internal/custom/rust/juniper_typegraph_test.go` → TRACKED

Closes #5007