### PR TITLE
feat(#4979): c-cpp — GUI/CV/game framework detection records

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 250 records · **C/C++**: 20 · **clojure**: 4 · **crystal**: 1 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
+**Total**: 255 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 1 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -262,8 +262,13 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 | Language | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|---|
+| [C/C++](../by-language/c-cpp.md) | [Cocos2d-x](../detail/lang.c-cpp.framework.cocos2d-x.md) | 🟡 11/13 | 🔴 0/2 | |
+| [C/C++](../by-language/c-cpp.md) | [Dear ImGui](../detail/lang.c-cpp.framework.dear-imgui.md) | 🟡 11/13 | 🔴 0/1 | |
+| [C/C++](../by-language/c-cpp.md) | [JUCE](../detail/lang.c-cpp.framework.juce.md) | 🟡 11/13 | 🔴 0/2 | |
+| [C/C++](../by-language/c-cpp.md) | [OpenCV](../detail/lang.c-cpp.framework.opencv.md) | 🟡 11/13 | 🔴 0/1 | |
 | [C/C++](../by-language/c-cpp.md) | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | 🟡 11/13 | 🟢 2/2 | |
 | [C/C++](../by-language/c-cpp.md) | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | 🟡 11/13 | 🟢 2/2 | |
+| [C/C++](../by-language/c-cpp.md) | [wxWidgets](../detail/lang.c-cpp.framework.wxwidgets.md) | 🟡 11/13 | 🔴 0/2 | |
 | [C#](../by-language/csharp.md) | [Uno Platform](../detail/lang.csharp.framework.uno.md) | 🟢 13/13 | 🟢 3/3 | |
 | [C#](../by-language/csharp.md) | [WPF](../detail/lang.csharp.framework.wpf.md) | 🟢 13/13 | 🟢 3/3 | |
 | [C#](../by-language/csharp.md) | [Windows Forms](../detail/lang.csharp.framework.winforms.md) | 🟢 13/13 | 🟢 3/3 | |

--- a/docs/coverage/by-language/c-cpp.md
+++ b/docs/coverage/by-language/c-cpp.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # C/C++
 
-**Frameworks**: 20 · **Tools**: 16 · **ORMs**: 10 · **Other**: 4
+**Frameworks**: 25 · **Tools**: 16 · **ORMs**: 10 · **Other**: 4
 
 Back to [summary](../summary.md).
 
@@ -54,8 +54,13 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 | Name | Substrate | Other capabilities | Notes |
 |---|---|---|---|
+| [Cocos2d-x](../detail/lang.c-cpp.framework.cocos2d-x.md) | 🟡 11/13 | 🔴 0/2 | |
+| [Dear ImGui](../detail/lang.c-cpp.framework.dear-imgui.md) | 🟡 11/13 | 🔴 0/1 | |
+| [JUCE](../detail/lang.c-cpp.framework.juce.md) | 🟡 11/13 | 🔴 0/2 | |
+| [OpenCV](../detail/lang.c-cpp.framework.opencv.md) | 🟡 11/13 | 🔴 0/1 | |
 | [ROS (Robot Operating System)](../detail/lang.c-cpp.framework.ros.md) | 🟡 11/13 | 🟢 2/2 | |
 | [Unreal Engine](../detail/lang.c-cpp.framework.unreal-engine.md) | 🟡 11/13 | 🟢 2/2 | |
+| [wxWidgets](../detail/lang.c-cpp.framework.wxwidgets.md) | 🟡 11/13 | 🔴 0/2 | |
 
 
 ### RPC Framework

--- a/docs/coverage/detail/lang.c-cpp.framework.cocos2d-x.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.cocos2d-x.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.cocos2d-x` — Cocos2d-x
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Desktop
+- **Capability cells:** 16
+
+## Capabilities
+
+
+### Process
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| IPC extraction | 🔴 `missing` | — | 4979 | — | Detection-only (#4979 follow-up from #4926). rules/cpp/frameworks/cocos2d_x.yaml carries the detection signature (cocos2d.h include, CREATE_FUNC()/USING_NS_CC macros, cocos2d:: namespace, CCScene/CCLayer/CCSprite/CCDirector markers); no Go extractor emits scene/node-graph or game-loop IPC for the 2D game engine yet. |
+| Main renderer split | — `not_applicable` | — | — | — | 2D game engine; the game-loop/render distinction is not a main-process/renderer-process split (e.g. Electron). NA for this architectural concept. |
+
+### Native
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Native module imports | 🔴 `missing` | — | 4979 | — | Detection-only (#4979). Engine bundled in-repo (cocos2d/ subdir) or via add_subdirectory(cocos2d); no native-module-import extraction for the engine. |
+
+### Updates
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | ✅ `full` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| Config consumption | 🔴 `missing` | — | 3641 | — | — |
+| Constant propagation | ✅ `full` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go` | — |
+| DB effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Dead code detection | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| Env fallback recognition | ✅ `full` | — | — | `internal/substrate/c_cpp.go` | — |
+| Error flow | ✅ `full` | — | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | — |
+| Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
+| Fs effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| HTTP effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Import resolution quality | 🟢 `partial` | — | — | `internal/engine/cpp_gui_cv_game_detection_test.go`<br>`internal/engine/rules/cpp/frameworks/cocos2d_x.yaml`<br>`internal/substrate/c_cpp.go` | Detection signature for the framework lives in cocos2d_x.yaml (include/namespace/macro markers); generic c-cpp include resolution applies. Fixtures: TestCppGuiCvGameDetection (happy/wrong-language/no-match) in cpp_gui_cv_game_detection_test.go. |
+| Mutation effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Reachability analysis | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.cocos2d-x ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.c-cpp.framework.dear-imgui.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.dear-imgui.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.dear-imgui` — Dear ImGui
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Desktop
+- **Capability cells:** 16
+
+## Capabilities
+
+
+### Process
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| IPC extraction | — `not_applicable` | — | — | — | Immediate-mode GUI library (single-process, per-frame draw calls); no IPC/message-bus surface to extract. |
+| Main renderer split | — `not_applicable` | — | — | — | Immediate-mode GUI; imgui_impl_* backends are render integrations, not a main-process/renderer-process split. NA. |
+
+### Native
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Native module imports | 🔴 `missing` | — | 4979 | — | Detection-only (#4979). Often vendored as source (imgui/ subdir); no native-module-import extraction. |
+
+### Updates
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | ✅ `full` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| Config consumption | 🔴 `missing` | — | 3641 | — | — |
+| Constant propagation | ✅ `full` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go` | — |
+| DB effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Dead code detection | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| Env fallback recognition | ✅ `full` | — | — | `internal/substrate/c_cpp.go` | — |
+| Error flow | ✅ `full` | — | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | — |
+| Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
+| Fs effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| HTTP effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Import resolution quality | 🟢 `partial` | — | — | `internal/engine/cpp_gui_cv_game_detection_test.go`<br>`internal/engine/rules/cpp/frameworks/dear_imgui.yaml`<br>`internal/substrate/c_cpp.go` | Detection signature for the framework lives in dear_imgui.yaml (imgui.h include, ImGui::Begin/End/Button markers, imgui_impl_* backends); generic c-cpp include resolution applies. Fixtures: TestCppGuiCvGameDetection (happy/wrong-language/no-match). |
+| Mutation effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Reachability analysis | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.dear-imgui ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.c-cpp.framework.juce.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.juce.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.juce` — JUCE
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Desktop
+- **Capability cells:** 16
+
+## Capabilities
+
+
+### Process
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| IPC extraction | 🔴 `missing` | — | 4979 | — | Detection-only (#4979). Audio app/plugin framework; no extractor for JUCE InterprocessConnection / plugin-host messaging yet. |
+| Main renderer split | — `not_applicable` | — | — | — | Audio/GUI framework; audio thread vs message thread is not a main-process/renderer-process split. NA. |
+
+### Native
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Native module imports | 🔴 `missing` | — | 4979 | — | Detection-only (#4979). juce_add_plugin()/juce_add_gui_app() + juce_* modules are CMake markers; no native-module-import extraction. |
+
+### Updates
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | ✅ `full` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| Config consumption | 🔴 `missing` | — | 3641 | — | — |
+| Constant propagation | ✅ `full` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go` | — |
+| DB effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Dead code detection | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| Env fallback recognition | ✅ `full` | — | — | `internal/substrate/c_cpp.go` | — |
+| Error flow | ✅ `full` | — | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | — |
+| Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
+| Fs effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| HTTP effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Import resolution quality | 🟢 `partial` | — | — | `internal/engine/cpp_gui_cv_game_detection_test.go`<br>`internal/engine/rules/cpp/frameworks/juce.yaml`<br>`internal/substrate/c_cpp.go` | Detection signature for the framework lives in juce.yaml (JuceHeader.h include, AudioProcessor/JUCEApplication markers, juce_add_plugin() CMake DSL); generic c-cpp include resolution applies. Fixtures: TestCppGuiCvGameDetection (happy/wrong-language/no-match). |
+| Mutation effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Reachability analysis | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.juce ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.c-cpp.framework.opencv.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.opencv.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.opencv` — OpenCV
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Desktop
+- **Capability cells:** 16
+
+## Capabilities
+
+
+### Process
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| IPC extraction | — `not_applicable` | — | — | — | Computer-vision / ML library (in-process algorithms); no IPC/messaging surface to extract. |
+| Main renderer split | — `not_applicable` | — | — | — | CV library, not a multi-process desktop app; no main/renderer split. NA. |
+
+### Native
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Native module imports | 🔴 `missing` | — | 4979 | — | Detection-only (#4979). find_package(OpenCV) + opencv_* link targets are CMake markers; no native-module-import extraction. |
+
+### Updates
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | ✅ `full` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| Config consumption | 🔴 `missing` | — | 3641 | — | — |
+| Constant propagation | ✅ `full` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go` | — |
+| DB effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Dead code detection | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| Env fallback recognition | ✅ `full` | — | — | `internal/substrate/c_cpp.go` | — |
+| Error flow | ✅ `full` | — | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | — |
+| Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
+| Fs effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| HTTP effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Import resolution quality | 🟢 `partial` | — | — | `internal/engine/cpp_gui_cv_game_detection_test.go`<br>`internal/engine/rules/cpp/frameworks/opencv.yaml`<br>`internal/substrate/c_cpp.go` | Detection signature for the framework lives in opencv.yaml (opencv2/ includes, cv:: namespace markers, find_package(OpenCV) CMake); generic c-cpp include resolution applies. Fixtures: TestCppGuiCvGameDetection (happy/wrong-language/no-match). |
+| Mutation effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Reachability analysis | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.opencv ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.c-cpp.framework.wxwidgets.md
+++ b/docs/coverage/detail/lang.c-cpp.framework.wxwidgets.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.c-cpp.framework.wxwidgets` — wxWidgets
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [C/C++](../by-language/c-cpp.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Desktop
+- **Capability cells:** 16
+
+## Capabilities
+
+
+### Process
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| IPC extraction | 🔴 `missing` | — | 4979 | — | Detection-only (#4979). Native GUI toolkit; no extractor for wxWidgets event tables / IPC classes yet. |
+| Main renderer split | — `not_applicable` | — | — | — | Single-process native GUI toolkit; no main/renderer process split. NA. |
+
+### Native
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Native module imports | 🔴 `missing` | — | 4979 | — | Detection-only (#4979). find_package(wxWidgets) + wx::core/base link targets are CMake markers; no native-module-import extraction. |
+
+### Updates
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | ✅ `full` | — | — | `internal/graph/graph.go`<br>`internal/mcp/tools.go`<br>`internal/types/confidence.go` | — |
+| Config consumption | 🔴 `missing` | — | 3641 | — | — |
+| Constant propagation | ✅ `full` | — | — | `internal/links/constant_propagation.go`<br>`internal/substrate/c_cpp.go` | — |
+| DB effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Dead code detection | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/mcp/dead_code.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+| Env fallback recognition | ✅ `full` | — | — | `internal/substrate/c_cpp.go` | — |
+| Error flow | ✅ `full` | — | — | `internal/extractor/exception_flow.go`<br>`internal/extractors/cpp/exception_flow.go`<br>`internal/extractors/cpp/exception_flow_test.go` | — |
+| Feature flag gating | 🔴 `missing` | — | feature_flag_gating:#3706-not-yet-extracted | — | — |
+| Fs effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| HTTP effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Import resolution quality | 🟢 `partial` | — | — | `internal/engine/cpp_gui_cv_game_detection_test.go`<br>`internal/engine/rules/cpp/frameworks/wxwidgets.yaml`<br>`internal/substrate/c_cpp.go` | Detection signature for the framework lives in wxwidgets.yaml (wx/ includes, wxApp/wxFrame markers, IMPLEMENT_APP()/wxBEGIN_EVENT_TABLE macros); generic c-cpp include resolution applies. Fixtures: TestCppGuiCvGameDetection (happy/wrong-language/no-match). |
+| Mutation effect | 🟢 `partial` | — | — | `internal/links/effect_propagation.go`<br>`internal/substrate/effect_sinks_c_cpp.go` | — |
+| Reachability analysis | 🟢 `partial` | — | — | `internal/links/reachability.go`<br>`internal/substrate/entry_points.go`<br>`internal/substrate/entry_points_c_cpp.go` | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.c-cpp.framework.wxwidgets ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,17 +1,17 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # archigraph capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 250 · **ORMs**: 176 · **Tools**: 129 · **Other**: 205
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 255 · **ORMs**: 176 · **Tools**: 129 · **Other**: 205
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
 | [JS/TS](by-language/jsts.md) | 33 | 21 | 19 | 8 |
+| [C/C++](by-language/c-cpp.md) | 25 | 16 | 10 | 4 |
 | [python](by-language/python.md) | 25 | 15 | 18 | 10 |
 | [java](by-language/java.md) | 23 | 10 | 15 | 4 |
 | [go](by-language/go.md) | 21 | 8 | 17 | 5 |
-| [C/C++](by-language/c-cpp.md) | 20 | 16 | 10 | 4 |
 | [C#](by-language/csharp.md) | 18 | 7 | 16 | 9 |
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
 | [rust](by-language/rust.md) | 17 | 10 | 15 | 5 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 250 frameworks · 129 tools · 176 ORMs · 205 other
+Total: 255 frameworks · 129 tools · 176 ORMs · 205 other

--- a/internal/engine/cpp_gui_cv_game_detection_test.go
+++ b/internal/engine/cpp_gui_cv_game_detection_test.go
@@ -1,0 +1,232 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This file is the coverage fixture for #4979 — detection-only registry records
+// for the five C/C++ GUI / computer-vision / game frameworks whose detection
+// signatures live in rules/cpp/frameworks/*.yaml (added by #4926, recorded by
+// #4979). These frameworks are DETECTION-ONLY: the engine carries no deep
+// component/state extractor for them, so the coverage cells they back are
+// framework-specific = missing/not_applicable with the generic c-cpp substrate
+// inherited. Each cite in the registry points at the YAML these tests load.
+//
+// Each framework family is proven by three cases, mirroring the
+// happy-path / wrong-language-no-op / no-match-no-op fixture contract used by
+// the rest of the c/c++ coverage work:
+//
+//   - happy path:           a representative C++ source string contains the
+//                           framework's structural markers / include patterns
+//                           declared in its detection YAML.
+//   - wrong-language no-op:  the same detection signatures do NOT fire on a
+//                           source from an unrelated language (Python here),
+//                           guarding against cross-language misattribution.
+//   - no-match no-op:        a plain C++ source that uses none of the framework
+//                           matches none of the framework's markers.
+
+// cppDetectionBlock is the minimal shape of a rules/cpp/frameworks/*.yaml file
+// needed to read its detection signatures. Only the fields these fixtures
+// assert on are decoded.
+type cppDetectionBlock struct {
+	Frameworks struct {
+		Name      string `yaml:"name"`
+		Category  string `yaml:"category"`
+		Detection struct {
+			IncludePatterns   []string `yaml:"include_patterns"`
+			StructuralMarkers []string `yaml:"structural_markers"`
+		} `yaml:"detection"`
+	} `yaml:"frameworks"`
+}
+
+func loadCppFrameworkDetection(t *testing.T, file string) cppDetectionBlock {
+	t.Helper()
+	data, err := rulesFS.ReadFile("rules/cpp/frameworks/" + file)
+	if err != nil {
+		t.Fatalf("embedded detection YAML %q not found: %v", file, err)
+	}
+	var blk cppDetectionBlock
+	if err := yaml.Unmarshal(data, &blk); err != nil {
+		t.Fatalf("parsing %q: %v", file, err)
+	}
+	return blk
+}
+
+// anyMarkerMatches reports whether src contains any of the framework's
+// structural markers or include patterns.
+func anyMarkerMatches(blk cppDetectionBlock, src string) (string, bool) {
+	sigs := append([]string{}, blk.Frameworks.Detection.StructuralMarkers...)
+	sigs = append(sigs, blk.Frameworks.Detection.IncludePatterns...)
+	for _, s := range sigs {
+		if s == "" {
+			continue
+		}
+		if strings.Contains(src, s) {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+func TestCppGuiCvGameDetection(t *testing.T) {
+	cases := []struct {
+		file         string
+		wantName     string
+		wantCategory string
+		// happy is a representative C++ source that uses the framework.
+		happy string
+		// wrongLang is a same-purpose source in an unrelated language; the
+		// C/C++ structural markers must NOT appear in it.
+		wrongLang string
+		// noMatch is a plain C++ source that uses none of the framework.
+		noMatch string
+	}{
+		{
+			file:         "opencv.yaml",
+			wantName:     "OpenCV",
+			wantCategory: "computer_vision",
+			happy: `#include <opencv2/opencv.hpp>
+int main() {
+    cv::Mat img = cv::imread("in.png");
+    cv::imshow("w", img);
+    cv::waitKey(0);
+}`,
+			// Python OpenCV bindings: cv2 module, no cv:: namespace / opencv2 includes.
+			wrongLang: `import cv2
+img = cv2.imread("in.png")
+cv2.imshow("w", img)
+cv2.waitKey(0)`,
+			noMatch: `#include <vector>
+int add(int a, int b) { return a + b; }`,
+		},
+		{
+			file:         "dear_imgui.yaml",
+			wantName:     "Dear ImGui",
+			wantCategory: "immediate_mode_gui",
+			happy: `#include "imgui.h"
+void draw() {
+    ImGui::Begin("hello");
+    ImGui::Button("ok");
+    ImGui::End();
+}`,
+			// pyimgui: imgui module, snake_case API, no ImGui:: C++ namespace.
+			wrongLang: `import imgui
+imgui.begin("hello")
+imgui.button("ok")
+imgui.end()`,
+			noMatch: `#include <string>
+std::string greet() { return "hi"; }`,
+		},
+		{
+			file:         "cocos2d_x.yaml",
+			wantName:     "Cocos2d-x",
+			wantCategory: "game_engine_2d",
+			happy: `#include "cocos2d.h"
+USING_NS_CC;
+class GameScene : public cocos2d::Layer {
+    CREATE_FUNC(GameScene);
+    CCSprite* hero;
+};`,
+			// Cocos Creator (TypeScript) component, not cocos2d-x C++.
+			wrongLang: `import { _decorator, Component } from 'cc';
+const { ccclass } = _decorator;
+@ccclass('GameScene')
+export class GameScene extends Component {}`,
+			noMatch: `#include <cstdio>
+void log() { printf("tick\n"); }`,
+		},
+		{
+			file:         "juce.yaml",
+			wantName:     "JUCE",
+			wantCategory: "audio_gui_framework",
+			happy: `#include <JuceHeader.h>
+class Plugin : public AudioProcessor {
+    void prepareToPlay(double, int) override {}
+};`,
+			// Web Audio API (JS) — different audio stack, no JUCE markers.
+			wrongLang: `const ctx = new AudioContext();
+const node = ctx.createGain();
+node.connect(ctx.destination);`,
+			noMatch: `#include <cmath>
+double square(double x) { return x * x; }`,
+		},
+		{
+			file:         "wxwidgets.yaml",
+			wantName:     "wxWidgets",
+			wantCategory: "gui_application",
+			happy: `#include <wx/wx.h>
+class MyApp : public wxApp {
+public:
+    bool OnInit() override { auto* f = new wxFrame(nullptr, wxID_ANY, "t"); f->Show(); return true; }
+};
+IMPLEMENT_APP(MyApp);`,
+			// wxPython — Python bindings, no <wx/...> C++ includes / macros.
+			wrongLang: `import wx
+app = wx.App()
+frame = wx.Frame(None, title="t")
+frame.Show()
+app.MainLoop()`,
+			noMatch: `#include <iostream>
+int main() { std::cout << "hi"; }`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.wantName, func(t *testing.T) {
+			blk := loadCppFrameworkDetection(t, tc.file)
+
+			// Sanity: the YAML declares the expected framework + category.
+			if blk.Frameworks.Name != tc.wantName {
+				t.Errorf("%s: name = %q, want %q", tc.file, blk.Frameworks.Name, tc.wantName)
+			}
+			if blk.Frameworks.Category != tc.wantCategory {
+				t.Errorf("%s: category = %q, want %q", tc.file, blk.Frameworks.Category, tc.wantCategory)
+			}
+			if len(blk.Frameworks.Detection.StructuralMarkers) == 0 {
+				t.Fatalf("%s: no structural_markers declared", tc.file)
+			}
+
+			// Happy path: a representative C++ source matches the framework.
+			if marker, ok := anyMarkerMatches(blk, tc.happy); !ok {
+				t.Errorf("%s: happy-path source matched no detection signature", tc.file)
+			} else {
+				t.Logf("%s: happy match on %q", tc.file, marker)
+			}
+
+			// Wrong-language no-op: the C/C++ signatures must not fire on a
+			// same-purpose source written in an unrelated language.
+			if marker, ok := anyMarkerMatches(blk, tc.wrongLang); ok {
+				t.Errorf("%s: detection signature %q misfired on wrong-language source", tc.file, marker)
+			}
+
+			// No-match no-op: a plain C++ source using none of the framework
+			// matches nothing.
+			if marker, ok := anyMarkerMatches(blk, tc.noMatch); ok {
+				t.Errorf("%s: detection signature %q misfired on no-match source", tc.file, marker)
+			}
+		})
+	}
+}
+
+// TestCppGuiCvGameDetection_ScopedToCpp guards the wrong-language contract at
+// the corpus level: each of the five frameworks' detection YAMLs is embedded
+// only under rules/cpp/frameworks/ and not duplicated under another language
+// bucket, so its C/C++ structural markers cannot be loaded as another
+// language's rules.
+func TestCppGuiCvGameDetection_ScopedToCpp(t *testing.T) {
+	files := []string{"opencv.yaml", "dear_imgui.yaml", "cocos2d_x.yaml", "juce.yaml", "wxwidgets.yaml"}
+	otherLangs := []string{"c", "go", "python", "rust", "java", "javascript_typescript", "csharp"}
+	for _, f := range files {
+		if _, err := rulesFS.ReadFile("rules/cpp/frameworks/" + f); err != nil {
+			t.Errorf("%s: not embedded under rules/cpp/frameworks/: %v", f, err)
+		}
+		for _, lang := range otherLangs {
+			if _, err := rulesFS.ReadFile("rules/" + lang + "/frameworks/" + f); err == nil {
+				t.Errorf("%s: unexpectedly embedded under rules/%s/frameworks/ — should be cpp-only", f, lang)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Follow-up from #4926. Records the five C/C++ GUI/CV/game framework detection signatures (`rules/cpp/frameworks/*.yaml`, added by #4926) that had no registry record.

## Taxonomy decision
The registry `language` category has a FIXED subcategory set with no `computer_vision` or `game_engine` key, and immediate-mode/audio/CV stacks map poorly to `ui_frontend`. Following the existing **unreal-engine** precedent (a game engine recorded as `http_framework`/`desktop`), all five are recorded as `http_framework`/`desktop` **detection-only** records — no disallowed keys invented.

## Per-framework (all detection-only, http_framework/desktop)
- **opencv** (`opencv.yaml`) — computer-vision/ML; `opencv2/` includes, `cv::` namespace, `find_package(OpenCV)`.
- **dear-imgui** (`dear_imgui.yaml`) — immediate-mode GUI; `imgui.h`, `ImGui::Begin/End/Button`, `imgui_impl_*` backends.
- **cocos2d-x** (`cocos2d_x.yaml`) — 2D game engine; `cocos2d.h`, `CREATE_FUNC()`/`USING_NS_CC`, `CCScene/CCLayer/CCSprite`.
- **juce** (`juce.yaml`) — audio app/plugin/GUI; `JuceHeader.h`, `AudioProcessor`, `juce_add_plugin()`.
- **wxwidgets** (`wxwidgets.yaml`) — native GUI toolkit; `wx/` includes, `wxApp/wxFrame`, `IMPLEMENT_APP()`/`wxBEGIN_EVENT_TABLE`.

Each record: framework-specific cells (`ipc_extraction`/`main_renderer_split`/`native_module_imports`) = `missing`(#4979)/`not_applicable`; the detection signature is cited on `import_resolution_quality` (YAML + fixtures); generic c-cpp Substrate cells inherited from the existing language-level substrate cites.

## Registry cells / docs
+5 records (760→765). REGENERATED `docs/coverage` committed: `summary.md`, `by-category/http_framework.md`, `by-language/c-cpp.md`, and 5 new `detail/lang.c-cpp.framework.*.md` pages.

## Fixtures
`internal/engine/cpp_gui_cv_game_detection_test.go`:
- `TestCppGuiCvGameDetection` — per framework: happy-path (C++ source matches the YAML detection markers), wrong-language no-op (Python/TS/JS equivalent does NOT fire the C/C++ markers), no-match no-op (plain C++ matches nothing).
- `TestCppGuiCvGameDetection_ScopedToCpp` — corpus-level guard that each YAML is embedded only under `rules/cpp/frameworks/` (not another language bucket).

Every `cite` points at a file committed in this PR or already in-tree (the YAMLs + substrate Go). CITE-EXISTENCE verified.

## Gates (all pass, sandbox HOME=/tmp/agsbx-4979)
`go build ./...`, `go vet ./internal/...`, c/cpp + extractors/cpp + engine + types + tools/coverage tests, `coverage fmt --check` (canonical), `coverage validate` (exit 0), `git status` clean.

Closes #4979