### PR TITLE
feat(#5036): coverage ingestion — add cobertura + jacoco parsers

### DIFF
--- a/internal/coverage/attribute.go
+++ b/internal/coverage/attribute.go
@@ -18,8 +18,12 @@ const (
 	PropCoverageMeasAt = "coverage_measured_at"
 )
 
-// SourceLCOV is the coverage_source value stamped by the LCOV ingestor.
-const SourceLCOV = "lcov"
+// coverage_source values stamped onto attributed entities, one per parser.
+const (
+	SourceLCOV      = "lcov"
+	SourceCobertura = "cobertura"
+	SourceJaCoCo    = "jacoco"
+)
 
 // Attribution is the computed coverage for one graph entity.
 type Attribution struct {
@@ -94,6 +98,13 @@ func Attribute(entities []types.EntityRecord, rep *Report, rootPrefix string) []
 		normed[i] = nf{norm: Normalize(rep.Files[i].Path, rootPrefix), fc: &rep.Files[i]}
 	}
 
+	// The coverage_source stamped on every attribution follows the report's
+	// originating parser; default to LCOV for reports built without a Source.
+	source := rep.Source
+	if source == "" {
+		source = SourceLCOV
+	}
+
 	out := make([]Attribution, 0, len(entities))
 	for _, e := range entities {
 		esrc := Normalize(e.SourceFile, "")
@@ -129,7 +140,7 @@ func Attribute(entities []types.EntityRecord, rep *Report, rootPrefix string) []
 			CoveragePct:  pct,
 			CoveredLines: covered,
 			TotalLines:   total,
-			Source:       SourceLCOV,
+			Source:       source,
 		})
 	}
 	return out

--- a/internal/coverage/cobertura.go
+++ b/internal/coverage/cobertura.go
@@ -1,0 +1,108 @@
+package coverage
+
+import (
+	"encoding/xml"
+	"io"
+	"sort"
+)
+
+// Cobertura XML (coverage.py, generic) document model. Only the line-coverage
+// fields archigraph attributes from are mapped; everything else (rates,
+// conditions, methods, branch data) is parsed-tolerant and ignored.
+//
+// Shape:
+//
+//	<coverage>
+//	  <packages>
+//	    <package>
+//	      <classes>
+//	        <class filename="src/calc.py">
+//	          <lines>
+//	            <line number="1" hits="5"/>
+//	          </lines>
+//	        </class>
+type coberturaDoc struct {
+	XMLName  xml.Name           `xml:"coverage"`
+	Packages []coberturaPackage `xml:"packages>package"`
+}
+
+type coberturaPackage struct {
+	Classes []coberturaClass `xml:"classes>class"`
+}
+
+type coberturaClass struct {
+	Filename string          `xml:"filename,attr"`
+	Lines    []coberturaLine `xml:"lines>line"`
+}
+
+type coberturaLine struct {
+	Number int `xml:"number,attr"`
+	Hits   int `xml:"hits,attr"`
+}
+
+// ParseCobertura parses a Cobertura XML coverage report into the same per-file
+// line-coverage Report that ParseLCOV produces.
+//
+// A <line number= hits=> contributes one instrumented line: it counts toward
+// TotalLines, and toward CoveredLines when hits > 0. Multiple <class> blocks for
+// the same filename (Cobertura emits one class per top-level type, so a file
+// with several classes appears repeatedly) are merged into a single
+// FileCoverage; duplicate line numbers keep the maximum hit count, matching the
+// LCOV duplicate-DA rule.
+//
+// Unknown elements/attributes are ignored so the parser tolerates the many
+// Cobertura dialects (coverage.py, gocover-cobertura, generic). The returned
+// Report carries Source = SourceCobertura so attribution stamps coverage_source
+// correctly.
+func ParseCobertura(r io.Reader) (*Report, error) {
+	var doc coberturaDoc
+	dec := xml.NewDecoder(r)
+	if err := dec.Decode(&doc); err != nil {
+		return nil, err
+	}
+
+	// Merge classes by filename. Cobertura emits one <class> per top-level
+	// type, so a source file with several classes appears as several blocks
+	// that must roll up into a single FileCoverage.
+	byPath := map[string]*FileCoverage{}
+
+	merge := func(c *coberturaClass) {
+		if c.Filename == "" {
+			return
+		}
+		fc := byPath[c.Filename]
+		if fc == nil {
+			fc = &FileCoverage{Path: c.Filename, LineHits: map[int]int{}}
+			byPath[c.Filename] = fc
+		}
+		for _, ln := range c.Lines {
+			if ln.Number <= 0 {
+				continue
+			}
+			if prev, ok := fc.LineHits[ln.Number]; !ok || ln.Hits > prev {
+				fc.LineHits[ln.Number] = ln.Hits
+			}
+		}
+	}
+
+	for pi := range doc.Packages {
+		for ci := range doc.Packages[pi].Classes {
+			merge(&doc.Packages[pi].Classes[ci])
+		}
+	}
+
+	rep := &Report{Source: SourceCobertura}
+	for _, fc := range byPath {
+		fc.TotalLines = len(fc.LineHits)
+		covered := 0
+		for _, h := range fc.LineHits {
+			if h > 0 {
+				covered++
+			}
+		}
+		fc.CoveredLines = covered
+		rep.Files = append(rep.Files, *fc)
+	}
+	sort.Slice(rep.Files, func(i, j int) bool { return rep.Files[i].Path < rep.Files[j].Path })
+	return rep, nil
+}

--- a/internal/coverage/cobertura_test.go
+++ b/internal/coverage/cobertura_test.go
@@ -1,0 +1,68 @@
+package coverage
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func loadCobertura(t *testing.T) *Report {
+	t.Helper()
+	f, err := os.Open("testdata/sample.cobertura.xml")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer f.Close()
+	rep, err := ParseCobertura(f)
+	if err != nil {
+		t.Fatalf("ParseCobertura: %v", err)
+	}
+	return rep
+}
+
+func TestParseCobertura_FileSummaries(t *testing.T) {
+	rep := loadCobertura(t)
+	if rep.Source != SourceCobertura {
+		t.Errorf("source: want %q, got %q", SourceCobertura, rep.Source)
+	}
+	if len(rep.Files) != 2 {
+		t.Fatalf("want 2 files, got %d", len(rep.Files))
+	}
+
+	calc := rep.ByPath("src/calc.py")
+	if calc == nil {
+		t.Fatal("calc.py not parsed")
+	}
+	// Two <class> blocks for src/calc.py merge: lines 1-5,10,11,14 covered (8),
+	// 7-9 uncovered → 11 total, 8 covered.
+	if calc.TotalLines != 11 || calc.CoveredLines != 8 {
+		t.Errorf("calc totals: want 8/11, got %d/%d", calc.CoveredLines, calc.TotalLines)
+	}
+	if calc.LineHits[1] != 5 || calc.LineHits[7] != 0 || calc.LineHits[14] != 2 {
+		t.Errorf("line hits wrong: l1=%d l7=%d l14=%d", calc.LineHits[1], calc.LineHits[7], calc.LineHits[14])
+	}
+
+	util := rep.ByPath("src/util.py")
+	if util == nil || util.TotalLines != 2 || util.CoveredLines != 2 {
+		t.Errorf("util totals: want 2/2, got %+v", util)
+	}
+}
+
+func TestParseCobertura_Malformed(t *testing.T) {
+	// Not XML at all → decode error.
+	if _, err := ParseCobertura(strings.NewReader("not xml at all")); err == nil {
+		t.Error("want error on non-XML input, got nil")
+	}
+}
+
+func TestParseCobertura_NoMatchNoOp(t *testing.T) {
+	// Well-formed but with no <packages>/<class> → empty report, no error.
+	in := strings.NewReader(`<?xml version="1.0"?><coverage></coverage>`)
+	rep, err := ParseCobertura(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rep.Files) != 0 {
+		t.Errorf("want 0 files for empty coverage, got %d", len(rep.Files))
+	}
+}

--- a/internal/coverage/config.go
+++ b/internal/coverage/config.go
@@ -26,8 +26,13 @@ type Config struct {
 	RootPrefix string `json:"root_prefix,omitempty" yaml:"root_prefix,omitempty"`
 }
 
-// FormatLCOV is the only Config.Format value honored in v1.
-const FormatLCOV = "lcov"
+// Config.Format values selecting a parser. When empty, the format is detected
+// from the report file (extension + root element) — see DetectFormat.
+const (
+	FormatLCOV      = "lcov"
+	FormatCobertura = "cobertura"
+	FormatJaCoCo    = "jacoco"
+)
 
 // Enabled reports whether the group has opted into coverage ingestion.
 func (c Config) Enabled() bool {

--- a/internal/coverage/enrich.go
+++ b/internal/coverage/enrich.go
@@ -38,9 +38,11 @@ type Stats struct {
 
 	// ReportPath is the report that was parsed ("" when none / reachability-only).
 	ReportPath string
-	// ReportFiles is the number of file blocks in the parsed LCOV report.
+	// ReportFiles is the number of file blocks in the parsed coverage report
+	// (LCOV/Cobertura/JaCoCo).
 	ReportFiles int
-	// LCOVAttributed is the number of entities stamped with line coverage.
+	// LCOVAttributed is the number of entities stamped with line coverage from
+	// the parsed report (the field name is historical; it covers any format).
 	LCOVAttributed int
 
 	// Reachability stats (always run when the pass is enabled).
@@ -97,7 +99,7 @@ func Enrich(doc *graph.Document, repoRoot string, cfg Config) Stats {
 	if reportPath, ok := resolveReport(repoRoot, cfg); ok {
 		st.ReportPath = reportPath
 		rootPrefix := cfg.RootPrefix
-		if rep, err := parseReportFile(reportPath); err == nil && rep != nil {
+		if rep, err := parseReportFile(reportPath, cfg.Format); err == nil && rep != nil {
 			st.ReportFiles = len(rep.Files)
 			attrs := Attribute(records, rep, rootPrefix)
 			for _, a := range attrs {
@@ -228,14 +230,16 @@ func resolveReport(repoRoot string, cfg Config) (string, bool) {
 	return "", false
 }
 
-// parseReportFile opens and parses an LCOV report file.
-func parseReportFile(path string) (*Report, error) {
+// parseReportFile opens and parses a coverage report file. format is the
+// pinned Config.Format ("" auto-detects from content); it dispatches through
+// ParseReport so LCOV/Cobertura/JaCoCo all share one ingestion path.
+func parseReportFile(path, format string) (*Report, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
-	return ParseLCOV(f)
+	return ParseReport(format, f)
 }
 
 func fileExists(p string) bool {

--- a/internal/coverage/jacoco.go
+++ b/internal/coverage/jacoco.go
@@ -1,0 +1,120 @@
+package coverage
+
+import (
+	"encoding/xml"
+	"io"
+	"path"
+	"sort"
+)
+
+// JaCoCo XML (JVM) document model. JaCoCo reports per-line *instruction*
+// coverage as ci (covered instructions) / mi (missed instructions) counts on
+// each <line>; a line is "covered" when ci > 0. Branch counts (cb/mb) are
+// parsed-tolerant and ignored.
+//
+// Shape:
+//
+//	<report>
+//	  <package name="com/example">
+//	    <sourcefile name="Calc.java">
+//	      <line nr="1" mi="0" ci="3"/>
+//	    </sourcefile>
+//
+// The graph stores source paths as repo-relative file paths, so the package
+// name (a slash-separated directory) is joined with the sourcefile name to form
+// the report path (e.g. "com/example/Calc.java"). Path normalization/matching
+// against entity SourceFile happens downstream in Attribute via samePath, which
+// already compares on basename suffixes.
+type jacocoReport struct {
+	XMLName  xml.Name        `xml:"report"`
+	Packages []jacocoPackage `xml:"package"`
+}
+
+type jacocoPackage struct {
+	Name        string             `xml:"name,attr"`
+	SourceFiles []jacocoSourceFile `xml:"sourcefile"`
+}
+
+type jacocoSourceFile struct {
+	Name  string       `xml:"name,attr"`
+	Lines []jacocoLine `xml:"line"`
+}
+
+type jacocoLine struct {
+	Nr int `xml:"nr,attr"`
+	// Ci is covered instructions, Mi missed instructions. A line is covered
+	// when Ci > 0.
+	Ci int `xml:"ci,attr"`
+	Mi int `xml:"mi,attr"`
+}
+
+// ParseJaCoCo parses a JaCoCo XML coverage report into the same per-file
+// line-coverage Report that ParseLCOV produces.
+//
+// Each <line nr= ci= mi=> is one instrumented line: it counts toward TotalLines
+// and, when ci > 0, toward CoveredLines. The report path is "<package
+// name>/<sourcefile name>" so it carries enough directory context to match the
+// graph's repo-relative SourceFile. Duplicate line numbers within a sourcefile
+// keep the maximum covered-instruction count, mirroring the LCOV duplicate-DA
+// rule.
+//
+// The DOCTYPE-declared external DTD JaCoCo emits is not fetched: the decoder is
+// configured to leave entity resolution off (the default Strict decoder does
+// not perform network access). Unknown elements/attributes are ignored. The
+// returned Report carries Source = SourceJaCoCo.
+func ParseJaCoCo(r io.Reader) (*Report, error) {
+	var doc jacocoReport
+	dec := xml.NewDecoder(r)
+	// JaCoCo reports begin with a DOCTYPE referencing an external DTD. Make the
+	// decoder tolerant of that without attempting any network fetch by leaving
+	// Entity nil (default) — encoding/xml never resolves external DTDs.
+	if err := dec.Decode(&doc); err != nil {
+		return nil, err
+	}
+
+	byPath := map[string]*FileCoverage{}
+	for pi := range doc.Packages {
+		pkg := &doc.Packages[pi]
+		for si := range pkg.SourceFiles {
+			sf := &pkg.SourceFiles[si]
+			if sf.Name == "" {
+				continue
+			}
+			p := sf.Name
+			if pkg.Name != "" {
+				p = path.Join(pkg.Name, sf.Name)
+			}
+			fc := byPath[p]
+			if fc == nil {
+				fc = &FileCoverage{Path: p, LineHits: map[int]int{}}
+				byPath[p] = fc
+			}
+			for _, ln := range sf.Lines {
+				if ln.Nr <= 0 {
+					continue
+				}
+				// Represent JaCoCo's instruction coverage as a hit count: ci
+				// (covered instructions) so any value > 0 reads as "covered",
+				// consistent with how LineHits is consumed (hits > 0 == covered).
+				if prev, ok := fc.LineHits[ln.Nr]; !ok || ln.Ci > prev {
+					fc.LineHits[ln.Nr] = ln.Ci
+				}
+			}
+		}
+	}
+
+	rep := &Report{Source: SourceJaCoCo}
+	for _, fc := range byPath {
+		fc.TotalLines = len(fc.LineHits)
+		covered := 0
+		for _, h := range fc.LineHits {
+			if h > 0 {
+				covered++
+			}
+		}
+		fc.CoveredLines = covered
+		rep.Files = append(rep.Files, *fc)
+	}
+	sort.Slice(rep.Files, func(i, j int) bool { return rep.Files[i].Path < rep.Files[j].Path })
+	return rep, nil
+}

--- a/internal/coverage/jacoco_test.go
+++ b/internal/coverage/jacoco_test.go
@@ -1,0 +1,66 @@
+package coverage
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func loadJaCoCo(t *testing.T) *Report {
+	t.Helper()
+	f, err := os.Open("testdata/sample.jacoco.xml")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer f.Close()
+	rep, err := ParseJaCoCo(f)
+	if err != nil {
+		t.Fatalf("ParseJaCoCo: %v", err)
+	}
+	return rep
+}
+
+func TestParseJaCoCo_FileSummaries(t *testing.T) {
+	rep := loadJaCoCo(t)
+	if rep.Source != SourceJaCoCo {
+		t.Errorf("source: want %q, got %q", SourceJaCoCo, rep.Source)
+	}
+	if len(rep.Files) != 2 {
+		t.Fatalf("want 2 files, got %d", len(rep.Files))
+	}
+
+	// package name is joined with the sourcefile name.
+	calc := rep.ByPath("com/example/Calc.java")
+	if calc == nil {
+		t.Fatal("Calc.java not parsed")
+	}
+	// ci>0 covered: lines 1-5,10,11 covered (7); 7-9 missed → 10 total, 7 covered.
+	if calc.TotalLines != 10 || calc.CoveredLines != 7 {
+		t.Errorf("calc totals: want 7/10, got %d/%d", calc.CoveredLines, calc.TotalLines)
+	}
+	if calc.LineHits[1] != 3 || calc.LineHits[7] != 0 {
+		t.Errorf("line hits wrong: l1=%d l7=%d", calc.LineHits[1], calc.LineHits[7])
+	}
+
+	util := rep.ByPath("com/example/Util.java")
+	if util == nil || util.TotalLines != 2 || util.CoveredLines != 2 {
+		t.Errorf("util totals: want 2/2, got %+v", util)
+	}
+}
+
+func TestParseJaCoCo_Malformed(t *testing.T) {
+	if _, err := ParseJaCoCo(strings.NewReader("not xml at all")); err == nil {
+		t.Error("want error on non-XML input, got nil")
+	}
+}
+
+func TestParseJaCoCo_NoMatchNoOp(t *testing.T) {
+	in := strings.NewReader(`<?xml version="1.0"?><report name="empty"></report>`)
+	rep, err := ParseJaCoCo(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rep.Files) != 0 {
+		t.Errorf("want 0 files for empty report, got %d", len(rep.Files))
+	}
+}

--- a/internal/coverage/lcov.go
+++ b/internal/coverage/lcov.go
@@ -2,9 +2,10 @@
 // NOT execute tests — it parses the report CI already emits) and attaches real
 // line-coverage to structural graph entities by source-span overlap.
 //
-// v1 (#5036) ships the LCOV parser + entity attribution as a pure, table-tested
-// transformation. Cobertura/JaCoCo parsers, dashboard overlay, and the
-// archigraph_coverage MCP query are deferred to follow-ups.
+// #5036 ships the LCOV, Cobertura and JaCoCo parsers + entity attribution as
+// pure, table-tested transformations behind a shared ingestion entry point
+// (ParseReport, parse.go). The dashboard overlay and the archigraph_coverage
+// MCP query are deferred to follow-ups.
 package coverage
 
 import (
@@ -51,9 +52,14 @@ func (f FileCoverage) Pct() float64 {
 	return 100.0 * float64(f.CoveredLines) / float64(f.TotalLines)
 }
 
-// Report is a parsed LCOV report: a set of per-file coverage blocks.
+// Report is a parsed coverage report: a set of per-file coverage blocks.
+//
+// Source records which parser produced the report (SourceLCOV / SourceCobertura
+// / SourceJaCoCo) so attribution stamps the correct coverage_source on entities.
+// ParseLCOV sets it to SourceLCOV; the XML parsers set their own.
 type Report struct {
-	Files []FileCoverage
+	Files  []FileCoverage
+	Source string
 }
 
 // ByPath returns the FileCoverage for the (raw, un-normalized) path, or nil.
@@ -83,7 +89,7 @@ func (r *Report) ByPath(path string) *FileCoverage {
 // are absent the totals are derived from the DA lines so a minimal report still
 // yields correct percentages.
 func ParseLCOV(r io.Reader) (*Report, error) {
-	rep := &Report{}
+	rep := &Report{Source: SourceLCOV}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 

--- a/internal/coverage/parse.go
+++ b/internal/coverage/parse.go
@@ -1,0 +1,86 @@
+package coverage
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ParseReport is the single ingestion entry point shared by every coverage
+// format. It dispatches to the LCOV / Cobertura / JaCoCo parser by `format`
+// (one of the Format* constants); when `format` is empty it auto-detects from
+// the report content (see detectFormat). The chosen parser sets Report.Source.
+//
+// This is the seam the indexer enrichment pass (enrich.go) drives so that adding
+// a format never duplicates the attribution/enrich path — every parser produces
+// the same per-file *Report.
+func ParseReport(format string, r io.Reader) (*Report, error) {
+	// Buffer the input so detection can sniff the head and the chosen parser can
+	// still read the whole stream. Coverage reports are modest in size.
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	f := strings.ToLower(strings.TrimSpace(format))
+	if f == "" {
+		f = detectFormat(data)
+	}
+
+	switch f {
+	case FormatLCOV:
+		return ParseLCOV(bytes.NewReader(data))
+	case FormatCobertura:
+		return ParseCobertura(bytes.NewReader(data))
+	case FormatJaCoCo:
+		return ParseJaCoCo(bytes.NewReader(data))
+	default:
+		return nil, fmt.Errorf("coverage: unrecognized report format %q", format)
+	}
+}
+
+// detectFormat sniffs the report bytes to pick a parser when the group has not
+// pinned Config.Format:
+//
+//   - XML reports are disambiguated by their root element: <coverage> →
+//     Cobertura, <report> → JaCoCo (the JaCoCo root element).
+//   - everything else falls back to LCOV, whose line-oriented "SF:/DA:" syntax
+//     is not XML and is the historical default.
+//
+// Returns "" when nothing matches (ParseReport then errors).
+func detectFormat(data []byte) string {
+	head := bytes.TrimSpace(data)
+	if len(head) == 0 {
+		return ""
+	}
+	if head[0] == '<' {
+		switch xmlRootElement(data) {
+		case "coverage":
+			return FormatCobertura
+		case "report":
+			return FormatJaCoCo
+		default:
+			return ""
+		}
+	}
+	// Non-XML: LCOV is the only line-oriented format.
+	return FormatLCOV
+}
+
+// xmlRootElement returns the local name of the first XML start element (the
+// document root), skipping the prolog, comments, DOCTYPE and processing
+// instructions. Returns "" if the stream has no start element.
+func xmlRootElement(data []byte) string {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		if se, ok := tok.(xml.StartElement); ok {
+			return se.Name.Local
+		}
+	}
+}

--- a/internal/coverage/parse_test.go
+++ b/internal/coverage/parse_test.go
@@ -1,0 +1,78 @@
+package coverage
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseReport_Dispatch(t *testing.T) {
+	cases := []struct {
+		name       string
+		format     string // "" → auto-detect
+		fixture    string
+		wantSource string
+		wantFiles  int
+	}{
+		{"explicit-lcov", FormatLCOV, "testdata/sample.info", SourceLCOV, 2},
+		{"explicit-cobertura", FormatCobertura, "testdata/sample.cobertura.xml", SourceCobertura, 2},
+		{"explicit-jacoco", FormatJaCoCo, "testdata/sample.jacoco.xml", SourceJaCoCo, 2},
+		{"detect-lcov", "", "testdata/sample.info", SourceLCOV, 2},
+		{"detect-cobertura", "", "testdata/sample.cobertura.xml", SourceCobertura, 2},
+		{"detect-jacoco", "", "testdata/sample.jacoco.xml", SourceJaCoCo, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := os.Open(tc.fixture)
+			if err != nil {
+				t.Fatalf("open: %v", err)
+			}
+			defer f.Close()
+			rep, err := ParseReport(tc.format, f)
+			if err != nil {
+				t.Fatalf("ParseReport: %v", err)
+			}
+			if rep.Source != tc.wantSource {
+				t.Errorf("source: want %q, got %q", tc.wantSource, rep.Source)
+			}
+			if len(rep.Files) != tc.wantFiles {
+				t.Errorf("files: want %d, got %d", tc.wantFiles, len(rep.Files))
+			}
+		})
+	}
+}
+
+func TestParseReport_UnknownFormat(t *testing.T) {
+	if _, err := ParseReport("bogus", strings.NewReader("anything")); err == nil {
+		t.Error("want error for unknown format, got nil")
+	}
+}
+
+func TestParseReport_DetectUnknownXMLNoOp(t *testing.T) {
+	// XML root that is neither <coverage> nor <report> → unrecognized.
+	if _, err := ParseReport("", strings.NewReader(`<?xml version="1.0"?><other/>`)); err == nil {
+		t.Error("want error for unrecognized XML root, got nil")
+	}
+}
+
+func TestDetectFormat(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lcov", "SF:a.go\nDA:1,1\nend_of_record\n", FormatLCOV},
+		{"cobertura", `<?xml version="1.0"?><coverage></coverage>`, FormatCobertura},
+		{"jacoco", `<?xml version="1.0"?><report></report>`, FormatJaCoCo},
+		{"jacoco-with-doctype", `<?xml version="1.0"?><!DOCTYPE report SYSTEM "report.dtd"><report></report>`, FormatJaCoCo},
+		{"empty", "", ""},
+		{"unknown-xml", `<other/>`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectFormat([]byte(tc.in)); got != tc.want {
+				t.Errorf("detectFormat: want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/coverage/testdata/sample.cobertura.xml
+++ b/internal/coverage/testdata/sample.cobertura.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage line-rate="0.8" branch-rate="0.5" version="1.9" timestamp="1700000000">
+  <packages>
+    <package name="src" line-rate="0.8" branch-rate="0.5">
+      <classes>
+        <class name="calc" filename="src/calc.py" line-rate="0.8">
+          <lines>
+            <line number="1" hits="5"/>
+            <line number="2" hits="5"/>
+            <line number="3" hits="5"/>
+            <line number="4" hits="5"/>
+            <line number="5" hits="5"/>
+            <line number="7" hits="0"/>
+            <line number="8" hits="0"/>
+            <line number="9" hits="0"/>
+            <line number="10" hits="5"/>
+            <line number="11" hits="5"/>
+          </lines>
+        </class>
+        <!-- Second class in the SAME file: must merge into one FileCoverage. -->
+        <class name="calc.Helper" filename="src/calc.py" line-rate="1.0">
+          <lines>
+            <line number="14" hits="2"/>
+          </lines>
+        </class>
+        <class name="util" filename="src/util.py" line-rate="1.0">
+          <lines>
+            <line number="1" hits="3"/>
+            <line number="2" hits="3"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>

--- a/internal/coverage/testdata/sample.jacoco.xml
+++ b/internal/coverage/testdata/sample.jacoco.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.1//EN" "report.dtd">
+<report name="sample">
+  <package name="com/example">
+    <sourcefile name="Calc.java">
+      <line nr="1" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="2" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="3" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="4" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="5" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="7" mi="2" ci="0" mb="0" cb="0"/>
+      <line nr="8" mi="2" ci="0" mb="0" cb="0"/>
+      <line nr="9" mi="2" ci="0" mb="0" cb="0"/>
+      <line nr="10" mi="0" ci="3" mb="0" cb="0"/>
+      <line nr="11" mi="0" ci="3" mb="0" cb="0"/>
+    </sourcefile>
+    <sourcefile name="Util.java">
+      <line nr="1" mi="0" ci="2"/>
+      <line nr="2" mi="0" ci="2"/>
+    </sourcefile>
+  </package>
+</report>


### PR DESCRIPTION
## What this builds

Completes #5036's parser scope: adds **Cobertura (XML)** and **JaCoCo (XML)** coverage ingestion alongside the existing **LCOV** parser, wired into the *same* attribution/enrich path — no duplication.

### New parsers
- `internal/coverage/cobertura.go` — `ParseCobertura`: `<coverage><packages><package><classes><class filename=><lines><line number= hits=>`. Multiple `<class>` blocks for one file merge into a single `FileCoverage` (duplicate line keeps max hits, mirroring LCOV's duplicate-DA rule); a line counts covered when `hits>0`. Sets `Report.Source = cobertura`.
- `internal/coverage/jacoco.go` — `ParseJaCoCo`: `<report><package name=><sourcefile name=><line nr= ci= mi=>`. Covered when `ci>0`; report path is `package/sourcefile` so it carries enough directory context for the existing `samePath` suffix matcher. Sets `Report.Source = jacoco`. External DTD in the DOCTYPE is never fetched (Go's encoding/xml does not resolve external DTDs).

### Dispatch wiring (mirrors lcov)
- `internal/coverage/parse.go` — `ParseReport(format, r)`: one ingestion entry point that dispatches by pinned `Config.Format` or, when empty, auto-detects from content (XML root `<coverage>`→cobertura, `<report>`→jacoco, otherwise lcov).
- `Report` gains a `Source` field; `Attribute` now stamps `coverage_source` from `rep.Source` (lcov/cobertura/jacoco) instead of hardcoding lcov — so the **identical downstream attribution/enrich path** serves all three formats.
- `enrich.go` `parseReportFile` routes through `ParseReport` with `cfg.Format`. `config.go` adds `FormatCobertura`/`FormatJaCoCo` constants.

Every format produces the same per-file `*Report` → `Attribute` → `ApplyAttributions`/`Enrich` path. No change to attribution, span overlap, normalization, or the indexer seam.

### Fixtures + tests (mirror `lcov_test.go`)
- `testdata/sample.cobertura.xml`, `testdata/sample.jacoco.xml`.
- `cobertura_test.go`, `jacoco_test.go`, `parse_test.go`: per-format happy path (file summaries, line hits, source tag, multi-class merge), malformed-input error, and well-formed-but-no-match no-op; plus a dispatch/detection table test across all three formats (explicit + auto-detect).

### Deferred (out of scope, per ticket non-goals / follow-ups)
Dashboard coverage overlay and the `archigraph_coverage` MCP query remain follow-ups (unchanged from the LCOV v1 deferral). No instrumentation/execution.

### Gates (sandbox HOME=/tmp/agsbx-5036)
- `go build ./...` — OK
- `go vet ./internal/...` — OK
- `go test ./internal/coverage/... ./internal/links/... ./internal/types/` — all ok
- `go run ./tools/coverage validate` — exit 0 (pre-existing warnings only; no registry/coverage-doc change in this PR)
- `git status --porcelain` — clean

Closes #5036