### PR TITLE
fix(#4882): flow-dag TB-layout edges anchor to top/bottom mid-handles

### DIFF
--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -29,7 +29,7 @@ import { RepoChip } from "@/lib/repo-color";
 import { effectBadge } from "@/lib/effect-badge";
 import { useSourcePeek } from "@/components/SourcePeek";
 import { nodeStyle, isExternalNode, moduleBand, edgeStyle } from "./style";
-import type { FlowDagNodeData } from "./layout";
+import { SOURCE_HANDLE_ID, TARGET_HANDLE_ID, type FlowDagNodeData } from "./layout";
 
 /**
  * FlowDagNode — one DAG node. Color + label come from the role; terminal
@@ -133,9 +133,25 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
             : undefined,
       }}
     >
-      {/* in/out handles — positions follow the H/V layout direction. */}
-      <Handle type="target" position={targetPosition ?? Position.Left} className="!bg-text-4" />
-      <Handle type="source" position={sourcePosition ?? Position.Right} className="!bg-text-4" />
+      {/* in/out handles — positions follow the H/V layout direction (TB →
+          top/bottom, LR → left/right). Stable ids ({@link TARGET_HANDLE_ID} /
+          {@link SOURCE_HANDLE_ID}) so the edge binds to THIS centered handle
+          deterministically: with multiple handles per type, React Flow's
+          fallback "pick any handle of this type" is unspecified, which is how a
+          TB edge could resolve against a stale Left/Right anchor and dock on the
+          side (#4882). The edges set sourceHandle/targetHandle to match. */}
+      <Handle
+        id={TARGET_HANDLE_ID}
+        type="target"
+        position={targetPosition ?? Position.Left}
+        className="!bg-text-4"
+      />
+      <Handle
+        id={SOURCE_HANDLE_ID}
+        type="source"
+        position={sourcePosition ?? Position.Right}
+        className="!bg-text-4"
+      />
 
       <div className="px-2.5 py-2">
         {/* Header — two tidy rows (#4816). Cramming kind + role + terminal +

--- a/webui-v2/src/components/flow-dag/Flowchart.tsx
+++ b/webui-v2/src/components/flow-dag/Flowchart.tsx
@@ -58,7 +58,12 @@ import type {
   ControlFlowResponse,
 } from "@/data/types";
 import type { FlowDagDirection } from "./layout";
-import { FlowchartNode, type FlowchartNodeData } from "./FlowchartNode";
+import {
+  FlowchartNode,
+  type FlowchartNodeData,
+  FLOWCHART_SOURCE_HANDLE_ID,
+  FLOWCHART_TARGET_HANDLE_ID,
+} from "./FlowchartNode";
 import { FlowchartEdge, type FlowchartEdgeData } from "./FlowchartEdge";
 import { boxFor, defaultCaption } from "./flowchart-shapes";
 
@@ -176,6 +181,11 @@ function FlowchartInner({
       id: `cfe_${i}_${e.from}_${e.to}_${e.kind}`,
       source: e.from,
       target: e.to,
+      // Bind to the node's single centered handles so endpoints resolve to the
+      // direction-aware mid-side (TB → bottom→top, LR → right→left), not an
+      // arbitrary same-type handle — the #4882 vertical side-anchor fix.
+      sourceHandle: FLOWCHART_SOURCE_HANDLE_ID,
+      targetHandle: FLOWCHART_TARGET_HANDLE_ID,
       type: FLOWCHART_EDGE_TYPE,
       markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14 },
       data: { kind: e.kind },

--- a/webui-v2/src/components/flow-dag/FlowchartNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowchartNode.tsx
@@ -20,6 +20,16 @@ import { Database, Globe, FileCog, Mail, HardDrive } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ControlFlowShape, ControlFlowEffect } from "@/data/types";
 
+/**
+ * Stable handle ids for the flowchart node's single centered source/target
+ * handle. The position is direction-aware (TB → bottom/top, LR → right/left);
+ * the id is constant so each edge binds to the exact centered handle rather than
+ * an arbitrary same-type one (the #4882 vertical side-anchor class of bug). The
+ * Flowchart wires sourceHandle/targetHandle to these.
+ */
+export const FLOWCHART_SOURCE_HANDLE_ID = "flowchart-out";
+export const FLOWCHART_TARGET_HANDLE_ID = "flowchart-in";
+
 export interface FlowchartNodeData extends Record<string, unknown> {
   shape: ControlFlowShape;
   /** Short caption (label at full detail, else a shape-derived default). */
@@ -144,6 +154,7 @@ function FlowchartNodeImpl({ data }: NodeProps) {
         </span>
       )}
       <Handle
+        id={FLOWCHART_TARGET_HANDLE_ID}
         type="target"
         position={d.targetPos}
         className="!w-1.5 !h-1.5 !border-0 !bg-[var(--border)]"
@@ -219,6 +230,7 @@ function FlowchartNodeImpl({ data }: NodeProps) {
       ) : null}
 
       <Handle
+        id={FLOWCHART_SOURCE_HANDLE_ID}
         type="source"
         position={d.sourcePos}
         className="!w-1.5 !h-1.5 !border-0 !bg-[var(--border)]"

--- a/webui-v2/src/components/flow-dag/layout.test.ts
+++ b/webui-v2/src/components/flow-dag/layout.test.ts
@@ -4,7 +4,14 @@
  * Run with: npx vitest run src/components/flow-dag/layout.test.ts
  */
 import { describe, it, expect } from "vitest";
-import { unfoldTree, layoutTree, layoutTreeElk } from "./layout";
+import { Position } from "@xyflow/react";
+import {
+  unfoldTree,
+  layoutTree,
+  layoutTreeElk,
+  SOURCE_HANDLE_ID,
+  TARGET_HANDLE_ID,
+} from "./layout";
 import { routeInstanceIds } from "./route";
 import {
   nodeBucket,
@@ -528,6 +535,39 @@ describe("layoutTreeElk (#4827)", () => {
       expect(end.y).toBeCloseTo(tgt.position.y + TALL / 2, 1);
     }
   });
+
+  // #4882 regression guard. The centered handle is direction-aware (TB →
+  // bottom/top, LR → left/right) but its id is constant, and every edge must
+  // bind to it explicitly so React Flow resolves the endpoint at the centered
+  // handle — not an arbitrary same-type handle, which is how a TB edge could
+  // dock on the node side. This holds in BOTH orientations and is independent of
+  // ELK's orthogonal route (it governs the smoothstep fallback too).
+  for (const dir of ["TB", "LR"] as const) {
+    it(`binds every edge to the centered source/target handle ids — ${dir} (#4882)`, async () => {
+      const { instances, hasOutEdge } = unfoldTree(
+        "a",
+        [n("a"), n("b"), n("c")],
+        [e("a", "b"), e("a", "c")],
+      );
+      const { nodes: rf, edges } = await layoutTreeElk(
+        instances, dir, new Set(), () => {}, hasOutEdge,
+      );
+      // The node's handle faces follow the direction…
+      const expectSource = dir === "LR" ? Position.Right : Position.Bottom;
+      const expectTarget = dir === "LR" ? Position.Left : Position.Top;
+      for (const nd of rf) {
+        expect(nd.sourcePosition).toBe(expectSource);
+        expect(nd.targetPosition).toBe(expectTarget);
+      }
+      // …and every edge binds to the single centered handle by id, so the
+      // endpoint resolves to that face's mid-point in either orientation.
+      expect(edges.length).toBeGreaterThan(0);
+      for (const ed of edges) {
+        expect(ed.sourceHandle).toBe(SOURCE_HANDLE_ID);
+        expect(ed.targetHandle).toBe(TARGET_HANDLE_ID);
+      }
+    });
+  }
 });
 
 describe("layoutTree leaf vs truncated (#4561)", () => {

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -160,6 +160,22 @@ const NODE_TYPE = "flowDag";
 const EDGE_TYPE = "flowDag";
 
 /**
+ * Stable handle ids for the single centered source/target handle each node
+ * renders. The handle POSITION is direction-aware (TB → Bottom/Top, LR →
+ * Right/Left), but the id is constant so every edge can bind to the exact
+ * centered handle. Without an explicit id, React Flow resolves an edge endpoint
+ * against *some* handle of the matching type, which is unspecified when a node
+ * exposes more than one — the latent cause of #4882's vertical (TB) edges
+ * docking on the node side instead of the bottom/top mid-point. Edges set
+ * sourceHandle/targetHandle to these so the binding is deterministic in every
+ * direction and on the smoothstep fallback (when ELK's orthogonal route is
+ * absent). Exported so FlowDagNode (handle render) and buildFlowDagEdges (edge
+ * binding) share one source of truth.
+ */
+export const SOURCE_HANDLE_ID = "flowdag-out";
+export const TARGET_HANDLE_ID = "flowdag-in";
+
+/**
  * Hard ceiling on unfolded instances. A pure-tree unfold of a diamond-heavy DAG
  * can blow up combinatorially; this caps the rendered tree so the browser never
  * hangs. The depth control is the primary lever; this is the safety net.
@@ -427,6 +443,11 @@ function buildFlowDagEdges(instances: TreeInstance[]): FlowDagEdge[] {
       id: `e__${inst.id}`,
       source: inst.parentId!,
       target: inst.id,
+      // Bind to the node's single centered handles so the endpoint resolves to
+      // the direction-aware mid-side (TB → bottom→top, LR → right→left) instead
+      // of an arbitrary same-type handle — the #4882 vertical side-anchor fix.
+      sourceHandle: SOURCE_HANDLE_ID,
+      targetHandle: TARGET_HANDLE_ID,
       type: EDGE_TYPE,
       data: { kind: inst.edgeKind ?? "CALLS" },
     }));


### PR DESCRIPTION
## Root cause

The #4874/#4887 centered-handle work made the *port geometry* direction-aware (TB: source=bottom-center/SOUTH, target=top-center/NORTH) and #4887's measured-height feedback lands those ELK ports on the real (content-tall) card bottom. That math is correct and tested. **But** each React Flow node renders **two handles per type with no `id`**, and edges carried no `sourceHandle`/`targetHandle`. React Flow then resolves an edge endpoint against *some* same-type handle, which is unspecified when a node exposes more than one — so a vertical (TB) out-edge could bind to a stale Left/Right side anchor and dock on the node **side** instead of the bottom mid-point. That is exactly the `only vertical` symptom in the live UAT.

Horizontal (LR) was unaffected because the card has a **fixed width** (NODE_W=268), so its left/right faces are always centered regardless of which handle resolves.

## The fix — direction-aware AND deterministically-bound handles

Give each node a **single, stable, direction-aware centered source/target handle id** and **bind every edge to it** via `sourceHandle`/`targetHandle`, in both surfaces:

- `flow-dag/layout.ts` — export `SOURCE_HANDLE_ID`/`TARGET_HANDLE_ID`; `buildFlowDagEdges` sets them on every tree edge.
- `flow-dag/FlowDagNode.tsx` — stamp those ids on the two `<Handle>`s (positions stay direction-aware: TB → Bottom/Top, LR → Right/Left).
- `flow-dag/FlowchartNode.tsx` — export + stamp `FLOWCHART_{SOURCE,TARGET}_HANDLE_ID` on the flowchart handles.
- `flow-dag/Flowchart.tsx` — bind flowchart edges to those handle ids.

The handle **position** remains direction-aware; the **id is constant** so the endpoint always resolves to that centered face — for ELK's orthogonal route **and** the smoothstep fallback (when no ELK route is present yet).

## Files changed
- `webui-v2/src/components/flow-dag/layout.ts`
- `webui-v2/src/components/flow-dag/FlowDagNode.tsx`
- `webui-v2/src/components/flow-dag/FlowchartNode.tsx`
- `webui-v2/src/components/flow-dag/Flowchart.tsx`
- `webui-v2/src/components/flow-dag/layout.test.ts` (TB+LR regression)

## How horizontal behavior is preserved
LR keeps `source=Position.Right` / `target=Position.Left` (asserted in the new test) and the same centered ELK ports; only the previously-ambiguous handle binding is now explicit. No LR geometry changed — the existing LR measured-mid-side test (#4887) still passes unchanged.

## Verification
- `npx vitest run src/components/flow-dag` → **43 passed** (incl. 2 new `binds every edge to the centered source/target handle ids — TB/LR (#4882)` cases).
- `npx vite build` → **success**.
- `tsc --noEmit` (npm run lint) → **clean**, no new type errors.

## Deploy-deferred
Implemented + built here; **the user validates visually after deploy** — in vertical Tree AND Flowchart every node's outgoing edges should leave a single bottom-center point and enter children at top-center, matching the horizontal behavior.

Closes #4882