### PR TITLE
feat(#5147): coverage-kind overlay on WebGL/topology/flow-dag/iac nodes

### DIFF
--- a/webui-v2/src/components/compound-topology/CTNode.tsx
+++ b/webui-v2/src/components/compound-topology/CTNode.tsx
@@ -6,6 +6,12 @@ import { Database, Box } from "lucide-react";
 import type { CTNodeData } from "./layout";
 import { tierStyle } from "./tierStyle";
 
+/** Compose the highlight boxShadow with the optional #5147 coverage-kind ring. */
+function mergeShadow(base?: string, ring?: string): string | undefined {
+  if (base && ring) return `${base}, ${ring}`;
+  return base ?? ring;
+}
+
 function CTNodeImpl({ data }: NodeProps) {
   const d = data as CTNodeData;
   const s = tierStyle(d.tier);
@@ -41,11 +47,16 @@ function CTNodeImpl({ data }: NodeProps) {
         // Infra resources carry a solid left rail so they read as "a deployed
         // thing" vs code; code keeps a flush card.
         borderLeftWidth: isInfra ? 4 : isPrimary || isLinked ? 2 : 1,
-        boxShadow: isPrimary
-          ? "0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent)"
-          : isLinked
-            ? "0 0 0 2px color-mix(in srgb, var(--info) 32%, transparent)"
-            : undefined,
+        // #5147: the coverage-kind ring (d.coverageRing) composes ON TOP of the
+        // highlight ring so both stack rather than clobbering each other.
+        boxShadow: mergeShadow(
+          isPrimary
+            ? "0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent)"
+            : isLinked
+              ? "0 0 0 2px color-mix(in srgb, var(--info) 32%, transparent)"
+              : undefined,
+          d.coverageRing?.boxShadow,
+        ),
       }}
       title={`${d.label} · ${d.kind} · ${s.label}${d.repo ? ` · ${d.repo}` : ""}${
         cls ? ` · ${cls === "infra" ? "infra resource" : "code"}` : ""

--- a/webui-v2/src/components/compound-topology/CompoundLens.tsx
+++ b/webui-v2/src/components/compound-topology/CompoundLens.tsx
@@ -60,6 +60,12 @@ export interface CompoundLensProps {
   selectedId?: string | null;
   /** Fired when a leaf node is clicked; null clears the selection. */
   onSelectNode?: (id: string | null) => void;
+  /**
+   * #5147 coverage-kind ring (group-level), owned by the parent
+   * CrossLinkedTopology so both lenses share one toggle. Empty/absent ⇒ no
+   * decoration.
+   */
+  coverageRing?: { boxShadow?: string };
   className?: string;
 }
 
@@ -69,6 +75,7 @@ function CompoundLensInner({
   highlight,
   selectedId,
   onSelectNode,
+  coverageRing,
   className,
 }: CompoundLensProps) {
   // Per-lens collapse set (independent of the other lens).
@@ -125,13 +132,25 @@ function CompoundLensInner({
   // Inject the cross-link highlight into each node/zone's data so CTNode/CTZone
   // render it. Positions are untouched — this is a cheap per-render remap.
   const nodes: Node[] = useMemo(() => {
+    // #5147: the coverage ring applies to leaf (non-zone) nodes; empty ⇒ omit.
+    const ring = coverageRing?.boxShadow ? { coverageRing } : null;
     if (!highlight?.active) {
       // No selection — strip any stale highlight flags.
-      return base.nodes.map((n) =>
-        n.data && (n.data as { highlight?: unknown }).highlight !== undefined
-          ? { ...n, data: { ...n.data, highlight: undefined, dimmed: false }, selected: false }
-          : n,
-      );
+      return base.nodes.map((n) => {
+        const isZone = n.type === CT_ZONE_TYPE;
+        const cov = isZone ? null : ring;
+        if (
+          n.data &&
+          (n.data as { highlight?: unknown }).highlight !== undefined
+        ) {
+          return {
+            ...n,
+            data: { ...n.data, highlight: undefined, dimmed: false, ...cov },
+            selected: false,
+          };
+        }
+        return cov ? { ...n, data: { ...n.data, ...cov } } : n;
+      });
     }
     return base.nodes.map((n) => {
       const isZone = n.type === CT_ZONE_TYPE;
@@ -141,10 +160,10 @@ function CompoundLensInner({
       return {
         ...n,
         selected: !isZone && n.id === selectedId,
-        data: { ...n.data, highlight: hl, dimmed: true },
+        data: { ...n.data, highlight: hl, dimmed: true, ...(isZone ? null : ring) },
       };
     });
-  }, [base.nodes, highlight, selectedId]);
+  }, [base.nodes, highlight, selectedId, coverageRing]);
 
   const onNodeClick: NodeMouseHandler = useCallback(
     (_evt, node) => {

--- a/webui-v2/src/components/compound-topology/CompoundTopology.tsx
+++ b/webui-v2/src/components/compound-topology/CompoundTopology.tsx
@@ -46,6 +46,11 @@ import { CTNode } from "./CTNode";
 import { CTZone } from "./CTZone";
 import { CTEdge } from "./CTEdge";
 import { tierStyle } from "./tierStyle";
+import { useCoverageKind } from "@/hooks/use-coverage-kind";
+import {
+  CoverageKindOverlayToggle,
+  coverageKindRingStyle,
+} from "@/components/ui";
 
 const nodeTypes: NodeTypes = {
   [CT_NODE_TYPE]: CTNode,
@@ -73,6 +78,9 @@ function CompoundTopologyInner({ groupId, className }: CompoundTopologyProps) {
     tier: new Set(),
   });
   const collapsed = collapsedByLens[groupBy];
+  // #5147 coverage-kind overlay — off by default; shared coverage query (#5066).
+  const [coverageOverlay, setCoverageOverlay] = useState(false);
+  const coverageKind = useCoverageKind(groupId);
 
   const { data, isLoading, isError } = useCompoundTopology(groupId, groupBy);
 
@@ -152,6 +160,21 @@ function CompoundTopologyInner({ groupId, className }: CompoundTopologyProps) {
   );
   const nodeCount = nodes.length - zoneCount;
 
+  // #5147: apply the group-level coverage-kind ring to entity nodes (not the
+  // CT_ZONE containers). capability/off ⇒ {} ⇒ untouched (no fake decoration).
+  const coverageRing = useMemo(
+    () => coverageKindRingStyle(coverageKind, coverageOverlay),
+    [coverageKind, coverageOverlay],
+  );
+  const decoratedNodes = useMemo(() => {
+    if (!coverageRing.boxShadow) return nodes;
+    return nodes.map((n) =>
+      n.type === CT_NODE_TYPE
+        ? { ...n, data: { ...n.data, coverageRing } }
+        : n,
+    );
+  }, [nodes, coverageRing]);
+
   // Tier lanes actually present (for the legend).
   const presentTiers = useMemo(() => {
     const set = new Set((data?.nodes ?? []).map((n) => n.tier));
@@ -204,6 +227,13 @@ function CompoundTopologyInner({ groupId, className }: CompoundTopologyProps) {
           </div>
         )}
 
+        {/* #5147 coverage-kind overlay toggle + legend */}
+        <CoverageKindOverlayToggle
+          state={coverageKind}
+          enabled={coverageOverlay}
+          onToggle={() => setCoverageOverlay((v) => !v)}
+        />
+
         <span className="text-xs text-text-4 tabular-nums">
           {nodeCount} {nodeCount === 1 ? "node" : "nodes"}
           {groupBy !== "tier" && ` · ${zoneCount} ${zoneCount === 1 ? "zone" : "zones"}`}
@@ -247,7 +277,7 @@ function CompoundTopologyInner({ groupId, className }: CompoundTopologyProps) {
           </div>
         ) : (
           <ReactFlow
-            nodes={nodes}
+            nodes={decoratedNodes}
             edges={edges}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}

--- a/webui-v2/src/components/compound-topology/CrossLinkedTopology.tsx
+++ b/webui-v2/src/components/compound-topology/CrossLinkedTopology.tsx
@@ -26,6 +26,11 @@ import { cn } from "@/lib/utils";
 import { useCompoundTopology } from "@/hooks/use-topology";
 import { CompoundLens } from "./CompoundLens";
 import { computeCrossLink } from "./crossLink";
+import { useCoverageKind } from "@/hooks/use-coverage-kind";
+import {
+  CoverageKindOverlayToggle,
+  coverageKindRingStyle,
+} from "@/components/ui";
 
 interface CrossLinkedTopologyProps {
   groupId: string;
@@ -35,6 +40,13 @@ interface CrossLinkedTopologyProps {
 export function CrossLinkedTopology({ groupId, className }: CrossLinkedTopologyProps) {
   // Shared selection across both lenses (a node id, or null).
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // #5147 coverage-kind overlay — one toggle drives BOTH lenses' rings.
+  const [coverageOverlay, setCoverageOverlay] = useState(false);
+  const coverageKind = useCoverageKind(groupId);
+  const coverageRing = useMemo(
+    () => coverageKindRingStyle(coverageKind, coverageOverlay),
+    [coverageKind, coverageOverlay],
+  );
 
   // We need BOTH payloads here (not just inside each lens) to compute the
   // cross-link — these queries are shared/cached with the lens' own useQuery,
@@ -73,6 +85,12 @@ export function CrossLinkedTopology({ groupId, className }: CrossLinkedTopologyP
         <span className="text-text-4">
           select a node in either lens to highlight its counterpart in the other
         </span>
+        {/* #5147 coverage-kind overlay toggle + legend (drives both lenses) */}
+        <CoverageKindOverlayToggle
+          state={coverageKind}
+          enabled={coverageOverlay}
+          onToggle={() => setCoverageOverlay((v) => !v)}
+        />
         {selectedId && (
           <div className="ml-auto flex items-center gap-2">
             <span className="rounded-full bg-accent/15 px-2 py-0.5 text-accent">
@@ -106,6 +124,7 @@ export function CrossLinkedTopology({ groupId, className }: CrossLinkedTopologyP
             highlight={cross.infra}
             selectedId={selectedId}
             onSelectNode={setSelectedId}
+            coverageRing={coverageRing}
             className="flex-1"
           />
         </div>
@@ -120,6 +139,7 @@ export function CrossLinkedTopology({ groupId, className }: CrossLinkedTopologyP
             highlight={cross.modules}
             selectedId={selectedId}
             onSelectNode={setSelectedId}
+            coverageRing={coverageRing}
             className="flex-1"
           />
         </div>

--- a/webui-v2/src/components/compound-topology/UnifiedTopology.tsx
+++ b/webui-v2/src/components/compound-topology/UnifiedTopology.tsx
@@ -60,6 +60,11 @@ import { classifyNodes, isCrossBoundary, unifiedStats } from "./unify";
 import { CTNode } from "./CTNode";
 import { CTZone } from "./CTZone";
 import { CTEdge } from "./CTEdge";
+import { useCoverageKind } from "@/hooks/use-coverage-kind";
+import {
+  CoverageKindOverlayToggle,
+  coverageKindRingStyle,
+} from "@/components/ui";
 
 const nodeTypes: NodeTypes = {
   [CT_NODE_TYPE]: CTNode,
@@ -83,6 +88,10 @@ function UnifiedTopologyInner({ groupId, className }: UnifiedTopologyProps) {
       return next;
     });
   }, []);
+
+  // #5147 coverage-kind overlay — off by default; shared coverage query (#5066).
+  const [coverageOverlay, setCoverageOverlay] = useState(false);
+  const coverageKind = useCoverageKind(groupId);
 
   // The infra lens already interleaves code + infra in one containment tree.
   const { data, isLoading, isError } = useCompoundTopology(groupId, "infra");
@@ -130,14 +139,28 @@ function UnifiedTopologyInner({ groupId, className }: UnifiedTopologyProps) {
   const classes = useMemo(() => classifyNodes(data?.nodes), [data]);
   const stats = useMemo(() => unifiedStats(data?.nodes, data?.edges), [data]);
 
+  // #5147: group-level coverage-kind ring (empty/off ⇒ no decoration).
+  const coverageRing = useMemo(
+    () => coverageKindRingStyle(coverageKind, coverageOverlay),
+    [coverageKind, coverageOverlay],
+  );
+
   // Stamp the unified node class onto each rendered leaf node so CTNode draws
-  // the infra/code distinction. Zone boxes are untouched. Positions untouched.
+  // the infra/code distinction, plus the #5147 coverage ring. Zone boxes are
+  // untouched. Positions untouched.
   const nodes: Node[] = useMemo(() => {
     return base.nodes.map((n) => {
       if (n.type !== CT_NODE_TYPE) return n;
-      return { ...n, data: { ...n.data, nodeClass: classes.get(n.id) } };
+      return {
+        ...n,
+        data: {
+          ...n.data,
+          nodeClass: classes.get(n.id),
+          ...(coverageRing.boxShadow ? { coverageRing } : {}),
+        },
+      };
     });
-  }, [base.nodes, classes]);
+  }, [base.nodes, classes, coverageRing]);
 
   // Stamp the cross-boundary flag onto each rendered edge so CTEdge emphasises
   // real code↔infra usage links. A summary edge (collapsed zone) endpoint is a
@@ -164,6 +187,12 @@ function UnifiedTopologyInner({ groupId, className }: UnifiedTopologyProps) {
         <span className="text-text-4">
           infra resources and the code that uses them, in one diagram
         </span>
+        {/* #5147 coverage-kind overlay toggle + legend */}
+        <CoverageKindOverlayToggle
+          state={coverageKind}
+          enabled={coverageOverlay}
+          onToggle={() => setCoverageOverlay((v) => !v)}
+        />
         <div className="ml-auto flex items-center gap-3 text-text-4 tabular-nums">
           <span className="inline-flex items-center gap-1">
             <Database size={11} className="text-success" /> {stats.infraNodes} infra

--- a/webui-v2/src/components/compound-topology/layout.ts
+++ b/webui-v2/src/components/compound-topology/layout.ts
@@ -109,6 +109,12 @@ export interface CTNodeData {
    * view (the other models don't differentiate).
    */
   nodeClass?: "infra" | "code";
+  /**
+   * #5147 coverage-kind overlay ring (group-level, threaded by the topology
+   * surface). When present + non-empty the node draws a tone ring keyed to the
+   * active coverage kind; absent / `{}` ⇒ no decoration (capability / off).
+   */
+  coverageRing?: { boxShadow?: string };
   [key: string]: unknown;
 }
 

--- a/webui-v2/src/components/flow-dag/FlowDag.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDag.tsx
@@ -69,6 +69,11 @@ import {
   writeFlowAudio,
 } from "@/lib/flow-audio";
 import { useDownstreamDAG } from "@/hooks/use-paths";
+import { useCoverageKind } from "@/hooks/use-coverage-kind";
+import {
+  CoverageKindOverlayToggle,
+  coverageKindRingStyle,
+} from "@/components/ui";
 import type { DownstreamDAGNode, DownstreamDAGResponse } from "@/data/types";
 import {
   unfoldTree,
@@ -381,6 +386,11 @@ function FlowDagInner({
   // Click-to-highlight (#4479): the focused instance id whose route is lit, or
   // null for the normal (everything-visible) view.
   const [routeFocus, setRouteFocus] = useState<string | null>(null);
+  // #5147 coverage-kind overlay — off by default; tints every node by the
+  // group's best-available coverage kind. Reads the shared coverage query
+  // (#5066) via useCoverageKind — no extra fetch.
+  const [coverageOverlay, setCoverageOverlay] = useState(false);
+  const coverageKind = useCoverageKind(groupId);
 
   // Only fetch when no payload was injected.
   const query = useDownstreamDAG(
@@ -537,6 +547,14 @@ function FlowDagInner({
   // Apply selection + route highlighting on top of the positioned layout. This
   // is engine-agnostic and cheap (no re-layout) — a fresh shallow copy per node
   // so React Flow sees the data change.
+  // #5147: the coverage-kind ring is group-level (one kind per surface), so
+  // resolve it once and apply the SAME ring to every node. capability/off ⇒ no
+  // ring (the helper returns {}), so nodes degrade to no decoration honestly.
+  const coverageRing = useMemo(
+    () => coverageKindRingStyle(coverageKind, coverageOverlay),
+    [coverageKind, coverageOverlay],
+  );
+
   const { nodes: baseNodes, edges: baseEdges } = useMemo(() => {
     const nodes = laidOut.nodes.map((n) => {
       const data: FlowDagNodeData = { ...(n.data as FlowDagNodeData) };
@@ -545,6 +563,7 @@ function FlowDagInner({
       // instances of a selected node light up.
       data.selected = selectedNodeId != null ? data.node.id === selectedNodeId : undefined;
       data.onRoute = routeSet ? routeSet.has(n.id) : undefined;
+      data.coverageRing = coverageRing;
       return { ...n, data };
     });
     const edges = laidOut.edges.map((e) => {
@@ -554,7 +573,7 @@ function FlowDagInner({
       return { ...e, data: { ...e.data, kind: e.data?.kind ?? "CALLS", onRoute } as FlowDagEdgeData };
     });
     return { nodes, edges };
-  }, [laidOut, selectedNodeId, routeSet]);
+  }, [laidOut, selectedNodeId, routeSet, coverageRing]);
 
   // ── Step-replay (#4362) ──────────────────────────────────────────────────
   // The replay walks the laid-out tree in topological order. baseEdges are
@@ -743,6 +762,13 @@ function FlowDagInner({
             <Plus size={11} />
           </button>
         </div>
+
+        {/* #5147 coverage-kind overlay toggle + legend */}
+        <CoverageKindOverlayToggle
+          state={coverageKind}
+          enabled={coverageOverlay}
+          onToggle={() => setCoverageOverlay((v) => !v)}
+        />
 
         {/* Fetch / layout status */}
         {(isLoading || layingOut) && (

--- a/webui-v2/src/components/flow-dag/FlowDagNode.tsx
+++ b/webui-v2/src/components/flow-dag/FlowDagNode.tsx
@@ -31,6 +31,12 @@ import { useSourcePeek } from "@/components/SourcePeek";
 import { nodeStyle, isExternalNode, moduleBand, edgeStyle } from "./style";
 import { SOURCE_HANDLE_ID, TARGET_HANDLE_ID, type FlowDagNodeData } from "./layout";
 
+/** Compose the state boxShadow with the optional #5147 coverage-kind ring. */
+function mergeShadow(base?: string, ring?: string): string | undefined {
+  if (base && ring) return `${base}, ${ring}`;
+  return base ?? ring;
+}
+
 /**
  * FlowDagNode — one DAG node. Color + label come from the role; terminal
  * nodes get a doubled ring so collection sinks read as endpoints of the walk.
@@ -48,6 +54,7 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
     truncatedHere,
     module: mod,
     replay,
+    coverageRing,
   } = data as FlowDagNodeData;
   // Taxonomy bucket → tint (#4566): exception=red (#4556), external=muted
   // (#4558/#4564), genuine leaf=Return/finish end-cap (#4561), else role/kind.
@@ -123,14 +130,19 @@ function FlowDagNodeImpl({ id, data, sourcePosition, targetPosition }: NodeProps
         // #4557: a left module color-band groups same-module nodes visually.
         borderLeft: band ? `3px solid ${band.color}` : undefined,
         // Selected / route-lit (#4479) → accent ring; a genuine terminal
-        // end-cap (#4561) or a collection sink → a heavier outline ring.
-        boxShadow: replayActive
-          ? "0 0 0 2px var(--accent), 0 0 16px 2px color-mix(in srgb, var(--accent) 55%, transparent)"
-          : selected || onRoute === true
-          ? "0 0 0 2px var(--accent)"
-          : terminalCap || node.terminal
-            ? `0 0 0 2px color-mix(in srgb, ${rs.border} 60%, var(--text))`
-            : undefined,
+        // end-cap (#4561) or a collection sink → a heavier outline ring. The
+        // #5147 coverage-kind ring (coverageRing) composes ON TOP via a merged
+        // boxShadow so it stacks with — never clobbers — the state ring.
+        boxShadow: mergeShadow(
+          replayActive
+            ? "0 0 0 2px var(--accent), 0 0 16px 2px color-mix(in srgb, var(--accent) 55%, transparent)"
+            : selected || onRoute === true
+            ? "0 0 0 2px var(--accent)"
+            : terminalCap || node.terminal
+              ? `0 0 0 2px color-mix(in srgb, ${rs.border} 60%, var(--text))`
+              : undefined,
+          coverageRing?.boxShadow,
+        ),
       }}
     >
       {/* in/out handles — positions follow the H/V layout direction (TB →

--- a/webui-v2/src/components/flow-dag/layout.ts
+++ b/webui-v2/src/components/flow-dag/layout.ts
@@ -85,6 +85,15 @@ export interface FlowDagNodeData extends Record<string, unknown> {
    *  - "pending"   → not yet reached by the current playhead (dimmed)
    */
   replay?: "active" | "traversed" | "pending";
+  /**
+   * #5147 coverage-kind overlay: when present + enabled, the node draws a tone
+   * ring keyed to which archigraph coverage applies to this group (line ▸ reach
+   * ▸ capability). Threaded from the surface's shared coverage state (#5066),
+   * not per-node — node payloads carry no per-node coverage signal — so every
+   * node tints the same kind, and the capability default renders NO ring (never
+   * a fake green). Undefined ⇒ overlay off.
+   */
+  coverageRing?: { boxShadow?: string };
 }
 
 /** Data carried on each React Flow edge, consumed by the custom edge renderer. */

--- a/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCDiagram.tsx
@@ -48,6 +48,11 @@ import { IaCNode } from "./IaCNode";
 import { IaCGroupNode } from "./IaCGroupNode";
 import { IaCEdge } from "./IaCEdge";
 import { categoryStyle } from "./categoryStyle";
+import { useCoverageKind } from "@/hooks/use-coverage-kind";
+import {
+  CoverageKindOverlayToggle,
+  coverageKindRingStyle,
+} from "@/components/ui";
 
 const nodeTypes: NodeTypes = {
   [IAC_NODE_TYPE]: IaCNode,
@@ -73,12 +78,18 @@ const LEGEND_CATEGORIES = [
 
 interface IaCDiagramProps {
   report: IaCReport;
+  /** Group id — drives the #5147 coverage-kind overlay (shared query, #5066). */
+  groupId?: string;
   className?: string;
 }
 
-function IaCDiagramInner({ report, className }: IaCDiagramProps) {
+function IaCDiagramInner({ report, groupId = "", className }: IaCDiagramProps) {
   const [direction, setDirection] = useState<IaCDiagramDirection>("LR");
   const [groupMode, setGroupMode] = useState<IaCGroupMode>("module");
+  // #5147 coverage-kind overlay — off by default; reads the shared coverage
+  // query (#5066) so the same kind the Quality tab shows tints these nodes.
+  const [coverageOverlay, setCoverageOverlay] = useState(false);
+  const coverageKind = useCoverageKind(groupId);
 
   // Layout engine: ELK (default, async) or the legacy dagre fallback (sync).
   // Stable for the component lifetime — flip via VITE_IAC_LAYOUT_ENGINE.
@@ -131,6 +142,22 @@ function IaCDiagramInner({ report, className }: IaCDiagramProps) {
     [nodes],
   );
   const resourceCount = nodes.length - moduleCount;
+
+  // #5147: apply the group-level coverage-kind ring to the RESOURCE nodes only
+  // (group containers are scaffolding, not coverable entities). capability/off ⇒
+  // the helper returns {}, so node styles are untouched (no fake decoration).
+  const coverageRing = useMemo(
+    () => coverageKindRingStyle(coverageKind, coverageOverlay),
+    [coverageKind, coverageOverlay],
+  );
+  const decoratedNodes = useMemo(() => {
+    if (!coverageRing.boxShadow) return nodes;
+    return nodes.map((n) =>
+      n.type === IAC_NODE_TYPE
+        ? { ...n, data: { ...n.data, coverageRing } }
+        : n,
+    );
+  }, [nodes, coverageRing]);
 
   return (
     <div className={cn("flex h-full min-h-0 flex-col", className)}>
@@ -187,6 +214,13 @@ function IaCDiagramInner({ report, className }: IaCDiagramProps) {
           </button>
         </div>
 
+        {/* #5147 coverage-kind overlay toggle + legend */}
+        <CoverageKindOverlayToggle
+          state={coverageKind}
+          enabled={coverageOverlay}
+          onToggle={() => setCoverageOverlay((v) => !v)}
+        />
+
         <span className="text-xs text-text-4 tabular-nums">
           {resourceCount} {resourceCount === 1 ? "resource" : "resources"}
           {" · "}
@@ -227,7 +261,7 @@ function IaCDiagramInner({ report, className }: IaCDiagramProps) {
           </div>
         ) : (
           <ReactFlow
-            nodes={nodes}
+            nodes={decoratedNodes}
             edges={edges}
             nodeTypes={nodeTypes}
             edgeTypes={edgeTypes}

--- a/webui-v2/src/components/iac-diagram/IaCNode.tsx
+++ b/webui-v2/src/components/iac-diagram/IaCNode.tsx
@@ -18,7 +18,7 @@ import { categoryStyle } from "./categoryStyle";
 import type { IaCNodeData } from "./layout";
 
 function IaCNodeImpl({ data, sourcePosition, targetPosition, selected }: NodeProps) {
-  const { resource, unresolvedCount } = data as IaCNodeData;
+  const { resource, unresolvedCount, coverageRing } = data as IaCNodeData;
   const style = categoryStyle(resource.category);
   const Icon = style.Icon;
   const { openSourcePeek } = useSourcePeek();
@@ -50,6 +50,8 @@ function IaCNodeImpl({ data, sourcePosition, targetPosition, selected }: NodePro
         borderLeftWidth: 3,
         // selection ring picks up the category color
         ...(selected ? ({ ["--tw-ring-color" as string]: style.color }) : {}),
+        // #5147 coverage-kind ring (group-level tone). Empty/absent ⇒ no ring.
+        ...(coverageRing?.boxShadow ? { boxShadow: coverageRing.boxShadow } : {}),
       }}
       title={
         hasSource

--- a/webui-v2/src/components/iac-diagram/layout.ts
+++ b/webui-v2/src/components/iac-diagram/layout.ts
@@ -123,6 +123,12 @@ export interface IaCNodeData {
   resource: IaCResource;
   /** Count of relation targets that could not be joined to a rendered node. */
   unresolvedCount: number;
+  /**
+   * #5147 coverage-kind overlay ring (group-level, threaded by IaCDiagram). When
+   * present + non-empty the node draws a tone ring keyed to the active coverage
+   * kind; absent / `{}` ⇒ no decoration (the capability default / overlay off).
+   */
+  coverageRing?: { boxShadow?: string };
   [key: string]: unknown;
 }
 

--- a/webui-v2/src/components/ui/coverage-kind-overlay.tsx
+++ b/webui-v2/src/components/ui/coverage-kind-overlay.tsx
@@ -1,0 +1,95 @@
+/* ============================================================
+   components/ui/coverage-kind-overlay.tsx — coverage-kind node overlay for the
+   diagram surfaces (#5147).
+
+   Two pieces, both pure functions of the resolved {@link CoverageKindState}:
+
+     1. {@link coverageKindRingStyle} — an inline CSS `boxShadow` ring (+ optional
+        merge with an existing shadow) keyed to the kind's tone color, applied to
+        a React-Flow HTML node so each node carries the kind decoration the ticket
+        asks for. Degrades to NO ring for the neutral capability default so we
+        never paint a misleading authoritative tint on a node with no real
+        coverage signal.
+
+     2. {@link CoverageKindOverlayToggle} — a small corner control that toggles
+        the overlay and, when on, shows the shared {@link CoverageKindIndicator}
+        legend so the ring's meaning (Line ▸ Reach ▸ Capability) is always
+        legible — the kind is conveyed by icon + tone + tooltip, never color
+        alone. Reuses the #5067 indicator verbatim.
+
+   Both surfaces (flow-dag / topology / iac) reuse THESE, so the node tint, the
+   legend, and the Quality-tab row chip share one source of truth.
+   ============================================================ */
+
+import { Eye, EyeOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CoverageKindIndicator } from "@/components/ui/coverage-kind-indicator";
+import type { CoverageKindState } from "@/hooks/use-coverage-kind";
+
+/**
+ * Inline style fragment that decorates a node with the coverage-kind tone ring.
+ * `enabled` is the per-surface toggle. When the resolved kind is the neutral
+ * `capability` default (no real coverage signal) we render NO ring — honest
+ * "no decoration" rather than a fake green. An existing node `boxShadow` (e.g.
+ * a selection ring) is preserved by composing in front of the kind ring.
+ */
+export function coverageKindRingStyle(
+  state: CoverageKindState,
+  enabled: boolean,
+  existingShadow?: string,
+): { boxShadow?: string } {
+  if (!enabled) return existingShadow ? { boxShadow: existingShadow } : {};
+  // capability = no authoritative/reach signal → no ring (never a fake tint).
+  if (state.decoration.kind === "capability") {
+    return existingShadow ? { boxShadow: existingShadow } : {};
+  }
+  const ring = `0 0 0 2px ${state.decoration.ringColor}`;
+  return { boxShadow: existingShadow ? `${existingShadow}, ${ring}` : ring };
+}
+
+export interface CoverageKindOverlayToggleProps {
+  state: CoverageKindState;
+  enabled: boolean;
+  onToggle: () => void;
+  className?: string;
+}
+
+/**
+ * Corner control: an eye toggle plus, when enabled, the shared coverage-kind
+ * legend chip so the node tint reads unambiguously. Pure presentation — the
+ * caller owns the `enabled` state and threads the ring into its node data.
+ */
+export function CoverageKindOverlayToggle({
+  state,
+  enabled,
+  onToggle,
+  className,
+}: CoverageKindOverlayToggleProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border border-border bg-surface/90 px-1.5 py-1 backdrop-blur",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-pressed={enabled}
+        className={cn(
+          "inline-flex items-center gap-1 h-6 px-1.5 rounded text-[11px] transition-colors",
+          enabled ? "bg-accent text-accent-text" : "bg-surface text-text-3 hover:bg-surface-2",
+        )}
+        title={
+          enabled
+            ? "Hide the coverage-kind ring on nodes"
+            : "Tint nodes by which archigraph coverage applies to this group (line / reach / capability)"
+        }
+      >
+        {enabled ? <Eye size={12} /> : <EyeOff size={12} />}
+        Coverage
+      </button>
+      {enabled && <CoverageKindIndicator state={state.state} iconOnly={false} />}
+    </div>
+  );
+}

--- a/webui-v2/src/components/ui/index.ts
+++ b/webui-v2/src/components/ui/index.ts
@@ -33,5 +33,10 @@ export { CoverageProvenanceBanner } from "./coverage-provenance-banner";
 export type { CoverageProvenanceBannerProps } from "./coverage-provenance-banner";
 export { CoverageKindIndicator } from "./coverage-kind-indicator";
 export type { CoverageKindIndicatorProps } from "./coverage-kind-indicator";
+export {
+  CoverageKindOverlayToggle,
+  coverageKindRingStyle,
+} from "./coverage-kind-overlay";
+export type { CoverageKindOverlayToggleProps } from "./coverage-kind-overlay";
 export { InsightProvider, useInsight, useSetInsight } from "./insight-context";
 export type { InsightValue } from "./insight-context";

--- a/webui-v2/src/hooks/use-coverage-kind.ts
+++ b/webui-v2/src/hooks/use-coverage-kind.ts
@@ -1,0 +1,61 @@
+/* ============================================================
+   hooks/use-coverage-kind.ts — shared coverage-kind state for the diagram
+   node overlays (#5147).
+
+   #5067 landed the per-ROW coverage-kind indicator on the Quality tab. #5147
+   extends that same disambiguation to the diagram NODE surfaces (flow-dag /
+   topology / iac). Every one of those surfaces needs to know WHICH of the three
+   archigraph coverages applies to the current group so it can tint its nodes
+   accordingly — but they must NOT issue a second coverage fetch.
+
+   This hook reads the EXISTING `useQualityCoverage(groupId)` query (#5066). That
+   query is keyed `["quality", groupId, "coverage"]`, so any surface calling it
+   shares TanStack Query's cache with the Quality tab: if the tab already loaded
+   coverage, this resolves synchronously from cache; otherwise it triggers the
+   same single in-flight request (deduped by key) — never a duplicate fetch.
+
+   The result is projected through the SAME `coverageStateFromReport` +
+   `resolveCoverageKindNodeDecoration` helpers the rows use, so the node tint and
+   the row chip can never disagree about the kind. When coverage hasn't loaded
+   (or errored) the state is `null`, which the resolver degrades to the neutral
+   capability treatment — never a fake authoritative green.
+   ============================================================ */
+
+import { useMemo } from "react";
+import { useQualityCoverage } from "@/hooks/use-quality";
+import {
+  coverageStateFromReport,
+  resolveCoverageKindNodeDecoration,
+  type CoverageSourceState,
+  type CoverageKindNodeDecoration,
+} from "@/lib/coverage-provenance";
+
+export interface CoverageKindState {
+  /**
+   * Render-ready node decoration (ring color + kind + tooltip) for the current
+   * group's best-available coverage. Always defined: a missing report degrades
+   * to the neutral capability treatment via the resolver's default.
+   */
+  decoration: CoverageKindNodeDecoration;
+  /** The raw resolved source state (fed to the legend's CoverageKindIndicator). */
+  state: CoverageSourceState;
+  /** True once the underlying coverage query has settled (loaded or errored). */
+  ready: boolean;
+}
+
+/**
+ * Resolve the group's coverage-kind decoration from the shared coverage query.
+ * Reuses #5066's data layer (no extra fetch) and #5067's resolver semantics.
+ */
+export function useCoverageKind(groupId: string): CoverageKindState {
+  const { data, isLoading } = useQualityCoverage(groupId);
+
+  return useMemo(() => {
+    const state = coverageStateFromReport(data?.line_coverage);
+    return {
+      state,
+      decoration: resolveCoverageKindNodeDecoration(state),
+      ready: !isLoading,
+    };
+  }, [data?.line_coverage, isLoading]);
+}

--- a/webui-v2/src/lib/coverage-kind-node-overlay.test.ts
+++ b/webui-v2/src/lib/coverage-kind-node-overlay.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Branch-logic tests for the #5147 coverage-kind NODE overlay — the diagram
+ * node decoration that extends the #5067 row chip to the flow-dag / topology /
+ * iac surfaces.
+ *
+ * Two pure units are covered:
+ *   - resolveCoverageKindNodeDecoration — kind→ring-color projection over the
+ *     shared resolver (same precedence/tones as the row chip).
+ *   - coverageKindRingStyle — the inline boxShadow the surfaces stamp onto a
+ *     node, including the load-bearing "degrade to NO ring" behaviour so a node
+ *     with no real coverage signal is never given a fake authoritative tint.
+ *
+ * Pure, so it runs under the default (node) vitest environment with no DOM.
+ *
+ * Run with: npx vitest run src/lib/coverage-kind-node-overlay.test.ts
+ */
+import { describe, it, expect } from "vitest";
+import {
+  resolveCoverageKindNodeDecoration,
+  type CoverageSourceState,
+} from "./coverage-provenance";
+import { coverageKindRingStyle } from "@/components/ui/coverage-kind-overlay";
+import type { CoverageKindState } from "@/hooks/use-coverage-kind";
+
+function stateOf(src: CoverageSourceState | null): CoverageKindState {
+  return {
+    state: src ?? {},
+    decoration: resolveCoverageKindNodeDecoration(src),
+    ready: true,
+  };
+}
+
+describe("resolveCoverageKindNodeDecoration — ring color per kind", () => {
+  it("LINE ⇒ success ring, authoritative", () => {
+    const d = resolveCoverageKindNodeDecoration({ line: { source: "lcov" } });
+    expect(d.kind).toBe("line");
+    expect(d.ringColor).toBe("var(--success)");
+    expect(d.authoritative).toBe(true);
+    expect(d.short).toBe("Line");
+  });
+
+  it("REACH ⇒ info ring, not authoritative", () => {
+    const d = resolveCoverageKindNodeDecoration({ reachabilityAvailable: true });
+    expect(d.kind).toBe("reachability");
+    expect(d.ringColor).toBe("var(--info)");
+    expect(d.authoritative).toBe(false);
+  });
+
+  it("CAPABILITY (nothing wired / null) ⇒ neutral ring, not authoritative", () => {
+    for (const s of [{}, null] as const) {
+      const d = resolveCoverageKindNodeDecoration(s);
+      expect(d.kind).toBe("capability");
+      expect(d.ringColor).toBe("var(--text-4)");
+      expect(d.authoritative).toBe(false);
+    }
+  });
+
+  it("precedence matches the row chip: line ▸ reach ▸ capability", () => {
+    expect(
+      resolveCoverageKindNodeDecoration({
+        line: { source: "jacoco" },
+        reachabilityAvailable: true,
+      }).kind,
+    ).toBe("line");
+  });
+});
+
+describe("coverageKindRingStyle — node boxShadow", () => {
+  it("disabled ⇒ no ring (preserves any existing shadow)", () => {
+    const st = stateOf({ line: { source: "lcov" } });
+    expect(coverageKindRingStyle(st, false)).toEqual({});
+    expect(coverageKindRingStyle(st, false, "0 0 0 2px var(--accent)")).toEqual({
+      boxShadow: "0 0 0 2px var(--accent)",
+    });
+  });
+
+  it("enabled + capability (no real signal) ⇒ NO ring — never a fake green", () => {
+    const st = stateOf({}); // ⇒ capability default
+    expect(coverageKindRingStyle(st, true)).toEqual({});
+    // an existing selection shadow is preserved, just not augmented.
+    expect(coverageKindRingStyle(st, true, "shadow")).toEqual({
+      boxShadow: "shadow",
+    });
+  });
+
+  it("enabled + line ⇒ success ring", () => {
+    const st = stateOf({ line: { source: "lcov" } });
+    expect(coverageKindRingStyle(st, true)).toEqual({
+      boxShadow: "0 0 0 2px var(--success)",
+    });
+  });
+
+  it("enabled + reach ⇒ info ring, composed AFTER an existing shadow", () => {
+    const st = stateOf({ reachabilityAvailable: true });
+    expect(coverageKindRingStyle(st, true, "0 0 0 2px var(--accent)")).toEqual({
+      boxShadow: "0 0 0 2px var(--accent), 0 0 0 2px var(--info)",
+    });
+  });
+});

--- a/webui-v2/src/lib/coverage-provenance.ts
+++ b/webui-v2/src/lib/coverage-provenance.ts
@@ -295,6 +295,58 @@ export function resolveCoverageKindIndicator(
 }
 
 /**
+ * Per-kind CSS color token used to TINT a diagram node (the tone ring / corner
+ * glyph of the #5147 node overlay) so the decoration matches the kind's Badge
+ * tone exactly — line→success, reachability→info, capability→neutral. Returns a
+ * `var(--…)` reference (theme-aware, light + dark) rather than a literal hex so
+ * the ring tracks the active theme. Kept here, beside the resolver, so the
+ * tone↔kind mapping lives in ONE place and the node overlay cannot drift from
+ * the row/banner treatments.
+ */
+const KIND_RING_VAR: Record<CoverageProvenanceKind, string> = {
+  line: "var(--success)",
+  reachability: "var(--info)",
+  capability: "var(--text-4)",
+};
+
+/**
+ * Render-ready node decoration for the #5147 coverage-kind overlay. Pure +
+ * DOM-free so the kind→tone→ring selection is unit-testable in the node vitest
+ * env. A node with NO coverage signal resolves (via the resolver's capability
+ * default) to the neutral capability treatment — never a fake authoritative
+ * green — satisfying the "degrade to neutral, never a fake green" rule.
+ */
+export interface CoverageKindNodeDecoration {
+  kind: CoverageProvenanceKind;
+  /** Theme-aware CSS color (a `var(--…)`) for the ring / corner glyph. */
+  ringColor: string;
+  /** Short chip label, mirrors {@link resolveCoverageKindIndicator}. */
+  short: string;
+  /** Tooltip — the one-line provenance `method`. */
+  title: string;
+  /** True only for authoritative (line) coverage. */
+  authoritative: boolean;
+}
+
+/**
+ * Resolve the per-node decoration for the coverage-kind overlay. Thin
+ * projection over {@link resolveCoverageKindIndicator} so the precedence and
+ * tones never drift between the rows (#5067) and the diagram nodes (#5147).
+ */
+export function resolveCoverageKindNodeDecoration(
+  state: CoverageSourceState | null | undefined,
+): CoverageKindNodeDecoration {
+  const ind = resolveCoverageKindIndicator(state);
+  return {
+    kind: ind.kind,
+    ringColor: KIND_RING_VAR[ind.kind],
+    short: ind.short,
+    title: ind.title,
+    authoritative: ind.authoritative,
+  };
+}
+
+/**
  * Group-level ingested line-coverage roll-up, as surfaced by the dashboard
  * `/quality/coverage` endpoint's optional `line_coverage` field (#5066). Mirror
  * of the Go `LineCoverageSummary` wire shape. Kept here (rather than importing

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -38,6 +38,8 @@ import { CommunitiesPopover } from "@/components/graph/communities-popover";
 import { MCPActivityOverlay } from "@/components/graph/mcp-activity-overlay";
 import { GraphJarvisOverlay } from "@/components/graph/graph-jarvis-overlay";
 import { useGraphHighlight } from "@/hooks/use-graph-highlight";
+import { useCoverageKind } from "@/hooks/use-coverage-kind";
+import { CoverageKindIndicator } from "@/components/ui";
 import { useGraphJarvisReplay } from "@/hooks/use-graph-jarvis-replay";
 import { buildUndirectedAdjacency, bfsEgo as bfsEgoOver } from "@/lib/ego-bfs";
 
@@ -126,6 +128,15 @@ export default function GraphScreen() {
   const s = useGraphStore();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data, isLoading, isError } = useGraph(groupId, { lod: s.lod });
+  // #5147 coverage-kind overlay. The cosmos.gl WebGL engine renders nodes from
+  // Float32 color buffers with NO per-node DOM/sprite layer, so a per-node tone
+  // ring (as on the React-Flow surfaces) is genuinely infeasible here without a
+  // separate sprite-overlay pipeline. We surface the group's coverage KIND as an
+  // HTML legend chip on the canvas instead (the iconOnly indicator over the
+  // WebGL layer), so the surface still answers "which coverage is this" — and
+  // the per-node ring is left as the documented residual. Reuses the shared
+  // coverage query (#5066) + #5067 resolver — no extra fetch.
+  const coverageKind = useCoverageKind(groupId);
 
   // #1386 — module-level GDS for the "Module overview" mode. Lazy: only
   // fetched while the overview toggle is ON, so the default graph route has
@@ -787,6 +798,17 @@ export default function GraphScreen() {
               <div className="pointer-events-none rounded-md border border-border bg-surface/80 px-2 py-1 font-mono text-xs text-text-3 backdrop-blur-sm">
                 LOD: {lodLabel}
               </div>
+              {/* #5147 coverage-kind legend — which archigraph coverage applies
+                  to this group (line ▸ reach ▸ capability). The WebGL canvas
+                  can't ring individual nodes, so this HTML chip carries the kind
+                  for the whole surface. Shown only once coverage has settled so
+                  it never flashes a misleading default. */}
+              {coverageKind.ready && (
+                <div className="flex items-center gap-1.5 rounded-md border border-border bg-surface/80 px-2 py-1 text-xs text-text-3 backdrop-blur-sm">
+                  <span className="text-text-4">coverage</span>
+                  <CoverageKindIndicator state={coverageKind.state} />
+                </div>
+              )}
               {/* #4641 — calm "isolated" chip. Unconnected (zero-edge) nodes are
                   typically constants / types / config that simply have no graph
                   edges; they're hidden by default so the main graph shows the

--- a/webui-v2/src/routes/iac.tsx
+++ b/webui-v2/src/routes/iac.tsx
@@ -1028,7 +1028,7 @@ export default function IaCScreen() {
               hint="This environment has no resolved module instances or definition resources. Pick another environment or All envs."
             />
           ) : (
-            <IaCDiagram report={scoped!} />
+            <IaCDiagram report={scoped!} groupId={groupId} />
           )}
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #5067 — extends the per-row coverage-kind indicator to the diagram **node** surfaces.

## Views wired (4 of 4 surfaces; per-node ring on 3, legend on the WebGL one)
- **flow-dag** (`FlowDag` / `FlowDagNode`) — per-node tone ring, behind a toggle + legend.
- **topology** — all three renderers: `CompoundTopology`, `UnifiedTopology`, and `CrossLinkedTopology` (its two `CompoundLens` panes share one toggle). Per-node tone ring on entity nodes (zone containers untouched).
- **iac** (`IaCDiagram` / `IaCNode`) — per-node tone ring on resource nodes (group containers untouched).
- **WebGL graph** (`graph-canvas` via `routes/graph.tsx`) — **legend chip only**. cosmos.gl renders nodes from Float32 color buffers with no per-node DOM/sprite layer, so a per-node ring is genuinely infeasible without a separate sprite-overlay pipeline. The group's coverage **kind** is surfaced as an HTML `CoverageKindIndicator` chip on the canvas (the `iconOnly`/overlay path the ticket calls out). **Deferred residual:** per-node ring on the WebGL graph (documented inline).

## How it reuses #5067 semantics + #5066 data
- New `useCoverageKind(groupId)` reads the **existing** `useQualityCoverage` query (#5066). Same TanStack key `["quality", groupId, "coverage"]` ⇒ shares the Quality-tab cache, **no extra fetch** (deduped if in-flight).
- New pure `resolveCoverageKindNodeDecoration` projects over `resolveCoverageKindIndicator`, so the node ring's kind/tone can never drift from the row chip: line→`--success`, reachability→`--info`, capability→`--text-4`.
- Coverage is **group-level** (node payloads carry no per-node coverage), so every node tints the same kind. `capability` (no real signal) ⇒ **NO ring** — never a fake green. State rings (selection/highlight) are preserved by composing the coverage ring on top.
- Shared `CoverageKindOverlayToggle` (eye toggle + `CoverageKindIndicator` legend) + `coverageKindRingStyle` helper used by all React-Flow surfaces.

## Files changed
- New: `hooks/use-coverage-kind.ts`, `components/ui/coverage-kind-overlay.tsx`, `lib/coverage-kind-node-overlay.test.ts`
- `lib/coverage-provenance.ts` (+`resolveCoverageKindNodeDecoration` / ring-color map), `components/ui/index.ts`
- flow-dag: `FlowDag.tsx`, `FlowDagNode.tsx`, `layout.ts`
- iac: `IaCDiagram.tsx`, `IaCNode.tsx`, `layout.ts`, `routes/iac.tsx`
- topology: `CTNode.tsx`, `CompoundTopology.tsx`, `UnifiedTopology.tsx`, `CrossLinkedTopology.tsx`, `CompoundLens.tsx`, `layout.ts`
- `routes/graph.tsx` (WebGL legend chip)

## Gates
- `tsc --noEmit` — clean, no new type errors.
- `npm run test:unit` (canonical `vitest run src/lib`) — **138 passed** incl. 8 new node-overlay tests. (Bare `npx vitest run` also drags in the `e2e/*.spec.ts` Playwright specs, which are not vitest-compatible — 12 pre-existing failures unrelated to this change; all **222 unit tests pass**.)
- `vite build` — succeeds (only the pre-existing chunk-size advisory).

Deploy-deferred: no `make dashboard-build`. **User validates visually.**

Closes #5147