### PR TITLE
feat: daemon runtime-reload CPU caps (#5137) + reap stale watch PIDs (#5142)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -12,16 +12,20 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/agents"
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/caps"
+	"github.com/cajasmota/archigraph/internal/daemon/extract"
 	"github.com/cajasmota/archigraph/internal/daemon/mode"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
@@ -191,7 +195,21 @@ func resolveEnvRebuildConcurrency() int {
 // extractor is enabled, prefer ARCHIGRAPH_EXTRACT_GOMAXPROCS / _CONCURRENCY,
 // which throttle the children without touching query latency.
 func resolveDaemonGOMAXPROCS(hostCPU int) int {
+	return resolveDaemonGOMAXPROCSWith(hostCPU, 0)
+}
+
+// resolveDaemonGOMAXPROCSWith is the #5137 runtime-reloadable form of
+// resolveDaemonGOMAXPROCS. fileVal is the cpu.json override (0 = unset). The
+// precedence is env (ARCHIGRAPH_DAEMON_GOMAXPROCS) > cpu.json > "no cap": env is
+// captured at process start and never changes in a running daemon, so the
+// config file is the live-mutable surface the SIGHUP handler reads. As with the
+// env-only form, a requested value at/above the host core count returns 0 ("the
+// Go default is already correct, leave it untouched").
+func resolveDaemonGOMAXPROCSWith(hostCPU, fileVal int) int {
 	n := envPositiveInt2("ARCHIGRAPH_DAEMON_GOMAXPROCS")
+	if n <= 0 && fileVal > 0 {
+		n = fileVal
+	}
 	if n <= 0 {
 		return 0
 	}
@@ -200,6 +218,61 @@ func resolveDaemonGOMAXPROCS(hostCPU int) int {
 		return 0
 	}
 	return n
+}
+
+// applyDaemonGOMAXPROCSFromCaps re-resolves the daemon's in-process GOMAXPROCS
+// from (env + cpu.json) and live-applies it via runtime.GOMAXPROCS when it
+// differs from the current setting. Returns (newValue, previousValue, changed).
+// runtime.GOMAXPROCS(n) is documented as safe to call from a running program,
+// so this is the #5137 no-restart live re-apply. A resolved value of 0 means
+// "no cap" — we restore the Go default (host core count) so lowering then
+// clearing the cap in cpu.json restores full parallelism without a restart.
+func applyDaemonGOMAXPROCSFromCaps(store *caps.Store, hostCPU int) (int, int, bool) {
+	fileVal := 0
+	if store != nil {
+		if cfg, err := store.Load(); err == nil {
+			fileVal = cfg.DaemonGOMAXPROCSValue()
+		}
+	}
+	target := resolveDaemonGOMAXPROCSWith(hostCPU, fileVal)
+	if target <= 0 {
+		// No cap requested — ensure we are at the Go default (host cores).
+		target = hostCPU
+	}
+	if target < 1 {
+		target = 1
+	}
+	cur := runtime.GOMAXPROCS(0) // query without changing
+	if cur == target {
+		return target, cur, false
+	}
+	prev := runtime.GOMAXPROCS(target)
+	return target, prev, true
+}
+
+// installCapReloadHandler registers a SIGHUP handler that re-reads cpu.json and
+// live-applies the daemon's in-process GOMAXPROCS (#5137). The per-subprocess
+// extract caps need no signal — the coordinator re-reads cpu.json on each
+// reindex via the installed extract caps Store — but the daemon's OWN GOMAXPROCS
+// is applied once at process start, so a signal (or restart) is required to
+// change it live. SIGHUP is the conventional "reload config" signal.
+//
+// The handler runs for the life of the process; the registered channel is never
+// closed (daemon teardown is process exit), matching the daemon's other
+// long-lived goroutines.
+func installCapReloadHandler(store *caps.Store, logf interface{ Printf(string, ...any) }) {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGHUP)
+	go func() {
+		for range ch {
+			n, prev, changed := applyDaemonGOMAXPROCSFromCaps(store, runtime.NumCPU())
+			if changed {
+				logf.Printf("cpu-tune: SIGHUP reload — daemon GOMAXPROCS=%d applied (was %d, host=%d)", n, prev, runtime.NumCPU())
+			} else {
+				logf.Printf("cpu-tune: SIGHUP reload — daemon GOMAXPROCS unchanged (=%d, host=%d)", n, runtime.NumCPU())
+			}
+		}
+	}()
 }
 
 // envPositiveInt2 reads a strictly-positive integer from the named env var,
@@ -314,6 +387,17 @@ func runDaemon(argv []string) error {
 	if err := daemon.EnsureLayout(layout); err != nil {
 		return fmt.Errorf("ensure layout: %w", err)
 	}
+
+	// #5137: install the runtime-reloadable CPU/concurrency cap store and a
+	// SIGHUP handler. cpu.json under the daemon root is re-read cheaply (mtime
+	// cached) on the reindex hot path by the extract coordinator (so editing it
+	// changes the per-subprocess extract caps on the NEXT reindex with no
+	// restart), and SIGHUP triggers a LIVE re-apply of the daemon's own
+	// in-process GOMAXPROCS via runtime.GOMAXPROCS — which is safe to call at
+	// runtime. Precedence (per knob): env var > cpu.json > built-in default.
+	capStore := caps.NewStore(caps.DefaultPath(layout.Root))
+	extract.SetRuntimeCaps(capStore)
+	installCapReloadHandler(capStore, gcLog)
 
 	// #1626: one-time sweep to relocate any pre-existing in-repo
 	// `.archigraph/` graph artifacts into the external store, so groups

--- a/cmd/archigraph/daemon_caps_reload_test.go
+++ b/cmd/archigraph/daemon_caps_reload_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon/caps"
+)
+
+// TestResolveDaemonGOMAXPROCSWith covers the #5137 env>file>none precedence for
+// the daemon's own in-process GOMAXPROCS, including the host-ceiling no-op.
+func TestResolveDaemonGOMAXPROCSWith(t *testing.T) {
+	const host = 12
+	cases := []struct {
+		name    string
+		env     string
+		fileVal int
+		want    int
+	}{
+		{"none", "", 0, 0},
+		{"file-only", "", 3, 3},
+		{"env-only", "5", 0, 5},
+		{"env-beats-file", "5", 9, 5},
+		{"file-at-host-noop", "", 12, 0},
+		{"file-above-host-noop", "", 20, 0},
+		{"env-at-host-noop-ignores-file", "12", 3, 0},
+		{"file-nonpositive-treated-unset", "", 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ARCHIGRAPH_DAEMON_GOMAXPROCS", tc.env)
+			if got := resolveDaemonGOMAXPROCSWith(host, tc.fileVal); got != tc.want {
+				t.Fatalf("resolveDaemonGOMAXPROCSWith(host=%d, env=%q, file=%d) = %d, want %d",
+					host, tc.env, tc.fileVal, got, tc.want)
+			}
+		})
+	}
+}
+
+// writeCPUJSON writes cpu.json into dir and bumps its mtime forward so the
+// caps.Store's (mtime,size) cache key changes deterministically.
+func writeCPUJSON(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, caps.FileName)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write cpu.json: %v", err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	_ = os.Chtimes(path, future, future)
+	return path
+}
+
+// TestApplyDaemonGOMAXPROCSFromCaps is the #5137 live re-apply proof: editing
+// cpu.json and re-invoking the apply function (what the SIGHUP handler does)
+// changes runtime.GOMAXPROCS with no restart, and clearing the cap restores the
+// host default. The test restores the original GOMAXPROCS on exit so it does not
+// leak global state into other tests.
+func TestApplyDaemonGOMAXPROCSFromCaps(t *testing.T) {
+	orig := runtime.GOMAXPROCS(0)
+	t.Cleanup(func() { runtime.GOMAXPROCS(orig) })
+
+	// Use a fixed synthetic host count well above any cap we set so the
+	// host-ceiling no-op never interferes.
+	const host = 64
+	t.Setenv("ARCHIGRAPH_DAEMON_GOMAXPROCS", "") // env unset → file drives it
+
+	dir := t.TempDir()
+	store := caps.NewStore(caps.DefaultPath(dir))
+
+	// 1. cpu.json caps the daemon to 2 → applied live.
+	writeCPUJSON(t, dir, `{"daemon_gomaxprocs": 2}`)
+	n, _, changed := applyDaemonGOMAXPROCSFromCaps(store, host)
+	if n != 2 || !changed {
+		t.Fatalf("first apply: got (n=%d, changed=%v), want (2, true)", n, changed)
+	}
+	if got := runtime.GOMAXPROCS(0); got != 2 {
+		t.Fatalf("runtime.GOMAXPROCS not applied: got %d, want 2", got)
+	}
+
+	// 2. Re-apply with no change → no-op.
+	if _, _, changed := applyDaemonGOMAXPROCSFromCaps(store, host); changed {
+		t.Fatalf("re-apply with unchanged file should report changed=false")
+	}
+
+	// 3. Raise the cap to 5 → applied live without restart.
+	writeCPUJSON(t, dir, `{"daemon_gomaxprocs": 5}`)
+	n, prev, changed := applyDaemonGOMAXPROCSFromCaps(store, host)
+	if n != 5 || prev != 2 || !changed {
+		t.Fatalf("raise: got (n=%d, prev=%d, changed=%v), want (5, 2, true)", n, prev, changed)
+	}
+	if got := runtime.GOMAXPROCS(0); got != 5 {
+		t.Fatalf("raise not applied: got %d, want 5", got)
+	}
+
+	// 4. Clear the cap → restore the host default (no restart).
+	writeCPUJSON(t, dir, `{}`)
+	n, _, changed = applyDaemonGOMAXPROCSFromCaps(store, host)
+	if n != host || !changed {
+		t.Fatalf("clear: got (n=%d, changed=%v), want (host=%d, true)", n, changed, host)
+	}
+	if got := runtime.GOMAXPROCS(0); got != host {
+		t.Fatalf("clear not applied: got %d, want host %d", got, host)
+	}
+}
+
+// TestApplyDaemonGOMAXPROCSFromCaps_NilStore: a nil store with no env cap leaves
+// GOMAXPROCS at the host default (no-op when already there).
+func TestApplyDaemonGOMAXPROCSFromCaps_NilStore(t *testing.T) {
+	orig := runtime.GOMAXPROCS(0)
+	t.Cleanup(func() { runtime.GOMAXPROCS(orig) })
+	t.Setenv("ARCHIGRAPH_DAEMON_GOMAXPROCS", "")
+
+	host := runtime.NumCPU()
+	runtime.GOMAXPROCS(host) // ensure we start at host default
+	n, _, changed := applyDaemonGOMAXPROCSFromCaps(nil, host)
+	if n != host {
+		t.Fatalf("nil store: n=%d, want host %d", n, host)
+	}
+	if changed {
+		t.Fatalf("nil store at host default should be a no-op (changed=false)")
+	}
+}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -68,10 +68,39 @@ per file batch. When it is off (the default), the daemon extracts in-process and
 | `ARCHIGRAPH_INCREMENTAL_REINDEX` | `0` (off) | background | `1` switches single-file edits to a diff-aware incremental reindex (only changed files are re-extracted) instead of a full repo reindex on every settle. Recommended on high-churn repos to cut continuous reindex thrash. |
 | `ARCHIGRAPH_REBUILD_CONCURRENCY` | auto (memory-tuned, floor 2, cap 16) | explicit | Number of **repos** indexed in parallel during a group rebuild (distinct from subprocess fan-out *within* a repo). Auto-tuned from system RAM; override to bound memory on constrained hosts. (Legacy alias: `ARCHIGRAPH_MAX_CONCURRENT_GROUPS`.) |
 
-All of the above are **read at daemon start** and require a restart to apply —
-they cannot yet be changed live. Runtime-without-restart reload is tracked
-separately; until then, restart the daemon (`archigraph restart`) after changing
-any value.
+### Runtime reload without restart (#5137)
+
+The four CPU/concurrency caps —
+`ARCHIGRAPH_EXTRACT_GOMAXPROCS`, `ARCHIGRAPH_REBUILD_GOMAXPROCS`,
+`ARCHIGRAPH_EXTRACT_CONCURRENCY`, and `ARCHIGRAPH_DAEMON_GOMAXPROCS` — can be
+changed **without restarting the daemon** via a JSON config file at
+`~/.archigraph/cpu.json` (under `$ARCHIGRAPH_DAEMON_ROOT` when set):
+
+```json
+{
+  "extract_gomaxprocs": 1,
+  "rebuild_gomaxprocs": 8,
+  "extract_concurrency": 2,
+  "daemon_gomaxprocs": 4
+}
+```
+
+Precedence per knob is **env var > `cpu.json` > built-in default** (an explicit
+`--flag`/config field still wins over all three). The env vars themselves are
+still read once at process start and cannot change in a running daemon —
+`cpu.json` is the live-mutable surface.
+
+- The three **per-subprocess** caps (`extract_gomaxprocs`,
+  `rebuild_gomaxprocs`, `extract_concurrency`) are re-read cheaply (mtime-cached)
+  at the start of **every reindex**: edit `cpu.json` and the new value applies on
+  the next reindex, no restart.
+- The **in-process** `daemon_gomaxprocs` is applied live on `SIGHUP`
+  (`kill -HUP <daemon-pid>`): the daemon re-reads `cpu.json` and calls
+  `runtime.GOMAXPROCS` immediately. Clearing the cap restores the host default.
+
+The remaining knobs in this doc (`daemon_rss_budget_mb`, `indexer_parallelism`,
+`ARCHIGRAPH_REBUILD_CONCURRENCY`, the `ARCHIGRAPH_MAX_*` budgets) are still
+**read at daemon start** and require `archigraph restart` to apply.
 
 ## API endpoints
 

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/client"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/daemon/watchreg"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
@@ -127,6 +128,25 @@ func runWatch(repo, group string, interval time.Duration) error {
 	defer tick.Stop()
 	fmt.Fprintf(os.Stderr, "archigraph watch: %s (every %s)\n", repo, interval)
 
+	// #5142: register this standalone watcher in the daemon-owned PID registry
+	// so the daemon can reap us if we are ever orphaned (our owning daemon dies
+	// or restarts onto a new PID). The OwnerDaemonPID stamp lets the daemon's
+	// sweep distinguish a watcher it still owns from a leftover from a previous
+	// daemon generation. Best-effort: a registry write failure must never stop
+	// the watcher from doing its job, and the #5141 self-reap is the fallback.
+	if reg := watcherRegistry(); reg != nil {
+		entry := watchreg.Entry{
+			PID:            os.Getpid(),
+			Repo:           absRepoForWatch(repo),
+			OwnerDaemonPID: liveDaemonPID(),
+		}
+		if err := reg.Register(entry); err != nil {
+			fmt.Fprintf(os.Stderr, "archigraph watch: pid registry register failed (non-fatal): %v\n", err)
+		} else {
+			defer func() { _ = reg.Deregister(entry.PID) }()
+		}
+	}
+
 	// graphMtimes tracks the last-seen mtime of every registered repo's
 	// graph.json across the groups we care about. When any value
 	// changes between ticks, we re-run the link passes for the affected
@@ -191,6 +211,37 @@ func runWatch(repo, group string, interval time.Duration) error {
 			}
 		}
 	}
+}
+
+// watcherRegistry returns the daemon-owned watcher PID registry (#5142), or nil
+// when the daemon layout cannot be resolved (in which case the watcher simply
+// does not register — the #5141 self-reap remains the fallback).
+func watcherRegistry() *watchreg.Registry {
+	layout, err := daemon.DefaultLayout()
+	if err != nil || layout.Root == "" {
+		return nil
+	}
+	return watchreg.New(watchreg.DefaultPath(layout.Root))
+}
+
+// absRepoForWatch resolves repo to an absolute path for the registry entry,
+// falling back to the raw value on error (diagnostic field only).
+func absRepoForWatch(repo string) string {
+	if abs, err := filepath.Abs(repo); err == nil {
+		return abs
+	}
+	return repo
+}
+
+// liveDaemonPID returns the PID recorded in the daemon pidfile, or 0 when it is
+// missing/unreadable. Stamped into the watcher's registry entry as its owner so
+// the daemon sweep can detect orphans from a previous daemon generation.
+func liveDaemonPID() int {
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return 0
+	}
+	return daemon.ReadPIDFile(layout.PIDPath)
 }
 
 // groupsForRepo returns the names of the groups whose config lists

--- a/internal/daemon/caps/caps.go
+++ b/internal/daemon/caps/caps.go
@@ -1,0 +1,178 @@
+// Package caps provides runtime-reloadable CPU / concurrency caps for the
+// daemon (issue #5137, follow-up to #5135).
+//
+// # Problem
+//
+// #5135 (PR #5136) made the CPU/concurrency knobs env-driven, but env vars are
+// captured at process start and cannot be changed in a running daemon — every
+// tweak required `archigraph restart`. The original #5135 ask was to let the
+// operator change the caps "at any time".
+//
+// # Design
+//
+// caps adds a small JSON config file, `~/.archigraph/cpu.json`, that the daemon
+// re-reads cheaply on demand. The precedence the daemon resolves each cap by is:
+//
+//	explicit flag/field  >  env var  >  config file  >  built-in default
+//
+// The config file is the only RUNTIME-mutable surface: editing it and either
+// SIGHUP'ing the daemon (for the in-process daemon GOMAXPROCS) or simply
+// triggering the next reindex (for the per-subprocess extract caps) applies the
+// new value with no restart.
+//
+// # Cheap re-read
+//
+// The config file sits on the reindex hot path, so the Store caches the parsed
+// file keyed on its (mtime, size) and only re-parses when the file actually
+// changes. A missing file is a valid state (all caps fall through to env →
+// default) and is cached as such so a steady "no cpu.json" daemon does not
+// stat-and-fail on every reindex beyond the first.
+//
+// The Store is safe for concurrent use: Load() may be called from the scheduler
+// worker pool and the SIGHUP handler simultaneously.
+package caps
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// FileName is the basename of the runtime cap config under the daemon root.
+const FileName = "cpu.json"
+
+// Config is the JSON schema of cpu.json. Every field is a pointer so the
+// daemon can distinguish "unset" (fall through to env/default) from an explicit
+// zero. A non-positive value is treated as unset by the resolvers.
+type Config struct {
+	// ExtractGOMAXPROCS overrides ARCHIGRAPH_EXTRACT_GOMAXPROCS — the
+	// per-subprocess GOMAXPROCS cap for BACKGROUND (watch/churn) reindexes.
+	ExtractGOMAXPROCS *int `json:"extract_gomaxprocs,omitempty"`
+	// RebuildGOMAXPROCS overrides ARCHIGRAPH_REBUILD_GOMAXPROCS — the
+	// per-subprocess cap for EXPLICIT foreground rebuilds.
+	RebuildGOMAXPROCS *int `json:"rebuild_gomaxprocs,omitempty"`
+	// ExtractConcurrency overrides ARCHIGRAPH_EXTRACT_CONCURRENCY — the number
+	// of concurrent extract subprocesses.
+	ExtractConcurrency *int `json:"extract_concurrency,omitempty"`
+	// DaemonGOMAXPROCS overrides ARCHIGRAPH_DAEMON_GOMAXPROCS — the daemon's
+	// own in-process Go-runtime parallelism. Applied live via runtime.GOMAXPROCS
+	// on SIGHUP.
+	DaemonGOMAXPROCS *int `json:"daemon_gomaxprocs,omitempty"`
+}
+
+// fileKey identifies a file version cheaply (mtime + size). A zero key means
+// "no file present" (or never loaded).
+type fileKey struct {
+	modUnixNano int64
+	size        int64
+}
+
+// Store caches the parsed cpu.json keyed on its (mtime,size) so the daemon can
+// re-read it on the reindex hot path without re-parsing JSON on every call.
+type Store struct {
+	path string
+
+	mu     sync.Mutex
+	key    fileKey
+	cfg    Config
+	loaded bool
+}
+
+// NewStore returns a Store backed by the cpu.json at path. path is typically
+// filepath.Join(layout.Root, FileName). A Store with an empty path is valid and
+// always resolves to the empty Config (every cap falls through to env/default).
+func NewStore(path string) *Store {
+	return &Store{path: path}
+}
+
+// DefaultPath returns the conventional cpu.json path under daemonRoot.
+func DefaultPath(daemonRoot string) string {
+	if daemonRoot == "" {
+		return ""
+	}
+	return filepath.Join(daemonRoot, FileName)
+}
+
+// Load returns the current Config, re-parsing cpu.json only when the file's
+// (mtime,size) has changed since the last Load. A missing/empty/unreadable file
+// yields the zero Config and a nil error — absence is a valid state. A present
+// but malformed file returns the last good Config (or zero) plus the parse
+// error so the caller can log it; the daemon never wedges on bad JSON.
+func (s *Store) Load() (Config, error) {
+	if s == nil || s.path == "" {
+		return Config{}, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fi, statErr := os.Stat(s.path)
+	if statErr != nil {
+		// Missing file is the steady-state "no overrides" case. Cache the
+		// empty config under the zero key so we don't re-stat-and-fail-parse
+		// pointlessly, and report no error.
+		if os.IsNotExist(statErr) {
+			s.key = fileKey{}
+			s.cfg = Config{}
+			s.loaded = true
+			return Config{}, nil
+		}
+		// Other stat errors (permissions, IO): return last good config, surface
+		// the error so the caller can log once.
+		if s.loaded {
+			return s.cfg, statErr
+		}
+		return Config{}, statErr
+	}
+
+	cur := fileKey{modUnixNano: fi.ModTime().UnixNano(), size: fi.Size()}
+	if s.loaded && cur == s.key {
+		return s.cfg, nil // unchanged — serve cached parse.
+	}
+
+	raw, readErr := os.ReadFile(s.path)
+	if readErr != nil {
+		if s.loaded {
+			return s.cfg, readErr
+		}
+		return Config{}, readErr
+	}
+	var parsed Config
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		// Keep last good config; do NOT advance the key, so a corrected file is
+		// re-read on the next Load.
+		if s.loaded {
+			return s.cfg, err
+		}
+		return Config{}, err
+	}
+	s.key = cur
+	s.cfg = parsed
+	s.loaded = true
+	return parsed, nil
+}
+
+// posval dereferences a *int override, returning it only when strictly
+// positive. nil or non-positive yields 0 ("unset").
+func posval(p *int) int {
+	if p == nil || *p <= 0 {
+		return 0
+	}
+	return *p
+}
+
+// ExtractGOMAXPROCS returns the config-file override for the background extract
+// cap, or 0 when unset.
+func (c Config) ExtractGOMAXPROCSValue() int { return posval(c.ExtractGOMAXPROCS) }
+
+// RebuildGOMAXPROCSValue returns the config-file override for the foreground
+// rebuild cap, or 0 when unset.
+func (c Config) RebuildGOMAXPROCSValue() int { return posval(c.RebuildGOMAXPROCS) }
+
+// ExtractConcurrencyValue returns the config-file override for the subprocess
+// fan-out, or 0 when unset.
+func (c Config) ExtractConcurrencyValue() int { return posval(c.ExtractConcurrency) }
+
+// DaemonGOMAXPROCSValue returns the config-file override for the daemon's own
+// GOMAXPROCS, or 0 when unset.
+func (c Config) DaemonGOMAXPROCSValue() int { return posval(c.DaemonGOMAXPROCS) }

--- a/internal/daemon/caps/caps_test.go
+++ b/internal/daemon/caps/caps_test.go
@@ -1,0 +1,176 @@
+package caps
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func intp(n int) *int { return &n }
+
+// TestLoad_MissingFile is a valid "no overrides" state: zero Config, no error.
+func TestLoad_MissingFile(t *testing.T) {
+	s := NewStore(filepath.Join(t.TempDir(), "cpu.json"))
+	cfg, err := s.Load()
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if cfg != (Config{}) {
+		t.Fatalf("missing file should yield zero Config, got %+v", cfg)
+	}
+}
+
+// TestLoad_NilStoreAndEmptyPath both resolve to the zero Config.
+func TestLoad_NilStoreAndEmptyPath(t *testing.T) {
+	var nilStore *Store
+	if cfg, err := nilStore.Load(); err != nil || cfg != (Config{}) {
+		t.Fatalf("nil store: got (%+v, %v), want (zero, nil)", cfg, err)
+	}
+	if cfg, err := NewStore("").Load(); err != nil || cfg != (Config{}) {
+		t.Fatalf("empty path: got (%+v, %v), want (zero, nil)", cfg, err)
+	}
+}
+
+// TestLoad_ParsesOverrides confirms the JSON schema and the *Value() accessors.
+func TestLoad_ParsesOverrides(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cpu.json")
+	writeFile(t, path, `{
+		"extract_gomaxprocs": 3,
+		"rebuild_gomaxprocs": 7,
+		"extract_concurrency": 2,
+		"daemon_gomaxprocs": 4
+	}`)
+	cfg, err := NewStore(path).Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := cfg.ExtractGOMAXPROCSValue(); got != 3 {
+		t.Errorf("extract gomaxprocs = %d, want 3", got)
+	}
+	if got := cfg.RebuildGOMAXPROCSValue(); got != 7 {
+		t.Errorf("rebuild gomaxprocs = %d, want 7", got)
+	}
+	if got := cfg.ExtractConcurrencyValue(); got != 2 {
+		t.Errorf("extract concurrency = %d, want 2", got)
+	}
+	if got := cfg.DaemonGOMAXPROCSValue(); got != 4 {
+		t.Errorf("daemon gomaxprocs = %d, want 4", got)
+	}
+}
+
+// TestValue_UnsetAndNonPositive: nil pointer or non-positive value reads as 0.
+func TestValue_UnsetAndNonPositive(t *testing.T) {
+	if got := (Config{}).ExtractGOMAXPROCSValue(); got != 0 {
+		t.Errorf("nil pointer should read 0, got %d", got)
+	}
+	if got := (Config{ExtractGOMAXPROCS: intp(0)}).ExtractGOMAXPROCSValue(); got != 0 {
+		t.Errorf("zero should read 0, got %d", got)
+	}
+	if got := (Config{DaemonGOMAXPROCS: intp(-2)}).DaemonGOMAXPROCSValue(); got != 0 {
+		t.Errorf("negative should read 0, got %d", got)
+	}
+}
+
+// TestLoad_ReReadOnChange is the core #5137 live-reload proof: editing the file
+// changes the resolved value on the NEXT Load with no restart, and an unchanged
+// file is served from cache (no re-parse needed for correctness, but the value
+// must stay stable).
+func TestLoad_ReReadOnChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cpu.json")
+	writeFile(t, path, `{"extract_gomaxprocs": 2}`)
+	s := NewStore(path)
+
+	cfg, err := s.Load()
+	if err != nil || cfg.ExtractGOMAXPROCSValue() != 2 {
+		t.Fatalf("first load: got (%d, %v), want (2, nil)", cfg.ExtractGOMAXPROCSValue(), err)
+	}
+
+	// Unchanged file → same value (cache hit).
+	cfg, _ = s.Load()
+	if cfg.ExtractGOMAXPROCSValue() != 2 {
+		t.Fatalf("cached load changed value: %d", cfg.ExtractGOMAXPROCSValue())
+	}
+
+	// Edit the file. Bump mtime forward so the (mtime,size) key changes even on
+	// coarse-resolution filesystems where two writes in the same second would
+	// otherwise collide.
+	writeFile(t, path, `{"extract_gomaxprocs": 5}`)
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(path, future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	cfg, err = s.Load()
+	if err != nil || cfg.ExtractGOMAXPROCSValue() != 5 {
+		t.Fatalf("after edit: got (%d, %v), want (5, nil) — file edit must take effect without restart",
+			cfg.ExtractGOMAXPROCSValue(), err)
+	}
+}
+
+// TestLoad_MalformedKeepsLastGood: a bad file surfaces the parse error but does
+// NOT change the effective value from the last good parse — the daemon never
+// wedges on corrupt JSON.
+func TestLoad_MalformedKeepsLastGood(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cpu.json")
+	writeFile(t, path, `{"daemon_gomaxprocs": 4}`)
+	s := NewStore(path)
+	if cfg, err := s.Load(); err != nil || cfg.DaemonGOMAXPROCSValue() != 4 {
+		t.Fatalf("good load: got (%d, %v)", cfg.DaemonGOMAXPROCSValue(), err)
+	}
+
+	writeFile(t, path, `{ this is not json `)
+	future := time.Now().Add(2 * time.Second)
+	_ = os.Chtimes(path, future, future)
+
+	cfg, err := s.Load()
+	if err == nil {
+		t.Fatalf("malformed file should surface a parse error")
+	}
+	if cfg.DaemonGOMAXPROCSValue() != 4 {
+		t.Fatalf("malformed file must keep last good value 4, got %d", cfg.DaemonGOMAXPROCSValue())
+	}
+}
+
+// TestLoad_Concurrent exercises the mutex: the SIGHUP handler and the scheduler
+// worker pool may Load concurrently.
+func TestLoad_Concurrent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cpu.json")
+	writeFile(t, path, `{"extract_concurrency": 3}`)
+	s := NewStore(path)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if cfg, _ := s.Load(); cfg.ExtractConcurrencyValue() != 3 {
+				t.Errorf("concurrent load got %d, want 3", cfg.ExtractConcurrencyValue())
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestDefaultPath joins the root with the canonical filename and treats an empty
+// root as "no config".
+func TestDefaultPath(t *testing.T) {
+	if got := DefaultPath("/x/y"); got != filepath.Join("/x/y", FileName) {
+		t.Errorf("DefaultPath = %q", got)
+	}
+	if got := DefaultPath(""); got != "" {
+		t.Errorf("empty root should give empty path, got %q", got)
+	}
+}

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/cajasmota/archigraph/internal/classifier"
+	"github.com/cajasmota/archigraph/internal/daemon/caps"
 	"github.com/cajasmota/archigraph/internal/engine"
 	bazelextract "github.com/cajasmota/archigraph/internal/extractors/bazel"
 	configextract "github.com/cajasmota/archigraph/internal/extractors/config"
@@ -71,6 +72,41 @@ type CoordinatorConfig struct {
 	Interactive bool
 }
 
+// runtimeCaps is the process-wide runtime-reloadable cap store (#5137). The
+// daemon installs a real *caps.Store at startup (NewStore(layout.Root/cpu.json));
+// when nil — non-daemon callers, plain `archigraph index` subprocesses, tests —
+// the config-file tier is simply skipped and resolution falls through to
+// env → default exactly as before #5137. Guarded by runtimeCapsMu so the
+// SIGHUP handler and the scheduler worker pool can touch it concurrently.
+var (
+	runtimeCapsMu sync.RWMutex
+	runtimeCaps   *caps.Store
+)
+
+// SetRuntimeCaps installs (or clears, with nil) the runtime cap store. Called
+// once by the daemon at startup. Safe for concurrent use.
+func SetRuntimeCaps(s *caps.Store) {
+	runtimeCapsMu.Lock()
+	runtimeCaps = s
+	runtimeCapsMu.Unlock()
+}
+
+// loadRuntimeCaps does a cheap (mtime-cached) re-read of cpu.json. Returns the
+// zero Config when no store is installed or the file is absent/unreadable, so a
+// missing file is indistinguishable from "no overrides". Parse errors are
+// swallowed here (the daemon's SIGHUP handler logs them); a bad file must never
+// change the effective cap from its env/default value.
+func loadRuntimeCaps() caps.Config {
+	runtimeCapsMu.RLock()
+	s := runtimeCaps
+	runtimeCapsMu.RUnlock()
+	if s == nil {
+		return caps.Config{}
+	}
+	cfg, _ := s.Load()
+	return cfg
+}
+
 func (c CoordinatorConfig) concurrency() int {
 	if c.Concurrency > 0 {
 		return c.Concurrency
@@ -82,7 +118,14 @@ func (c CoordinatorConfig) concurrency() int {
 	// continuous full-reindex fan-out (#3648). It applies to BOTH paths — an
 	// operator-set ceiling on contended hosts is honored even for explicit
 	// rebuilds.
+	//
+	// #5137: env wins over the runtime-reloadable cpu.json, which wins over the
+	// auto-tuned default. Editing cpu.json takes effect on the NEXT reindex with
+	// no daemon restart.
 	if n := envPositiveInt("ARCHIGRAPH_EXTRACT_CONCURRENCY"); n > 0 {
+		return n
+	}
+	if n := loadRuntimeCaps().ExtractConcurrencyValue(); n > 0 {
 		return n
 	}
 	// #5135: explicit foreground rebuilds fan out wider (the user is waiting
@@ -125,6 +168,10 @@ func extractGOMAXPROCS() int {
 	if n := envPositiveInt("ARCHIGRAPH_EXTRACT_GOMAXPROCS"); n > 0 {
 		return n
 	}
+	// #5137: runtime-reloadable cpu.json override (env > file > default).
+	if n := loadRuntimeCaps().ExtractGOMAXPROCSValue(); n > 0 {
+		return n
+	}
 	return 2
 }
 
@@ -137,6 +184,10 @@ func extractGOMAXPROCS() int {
 //	Default: host core count (runtime.NumCPU()), i.e. effectively uncapped.
 func rebuildGOMAXPROCS() int {
 	if n := envPositiveInt("ARCHIGRAPH_REBUILD_GOMAXPROCS"); n > 0 {
+		return n
+	}
+	// #5137: runtime-reloadable cpu.json override (env > file > default).
+	if n := loadRuntimeCaps().RebuildGOMAXPROCSValue(); n > 0 {
 		return n
 	}
 	n := runtime.NumCPU()

--- a/internal/daemon/extract/runtime_caps_test.go
+++ b/internal/daemon/extract/runtime_caps_test.go
@@ -1,0 +1,86 @@
+package extract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/caps"
+)
+
+// installCapsFile writes a cpu.json into a temp dir, installs a Store pointing at
+// it as the process-wide runtime caps, and registers cleanup that clears it.
+func installCapsFile(t *testing.T, json string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, caps.FileName)
+	if err := os.WriteFile(path, []byte(json), 0o600); err != nil {
+		t.Fatalf("write cpu.json: %v", err)
+	}
+	SetRuntimeCaps(caps.NewStore(path))
+	t.Cleanup(func() { SetRuntimeCaps(nil) })
+}
+
+// TestRuntimeCaps_ExtractGOMAXPROCS_FileOverridesDefault: with no env set, the
+// cpu.json value takes effect (the #5137 no-restart path).
+func TestRuntimeCaps_ExtractGOMAXPROCS_FileOverridesDefault(t *testing.T) {
+	installCapsFile(t, `{"extract_gomaxprocs": 5}`)
+	if got := extractGOMAXPROCS(); got != 5 {
+		t.Fatalf("extractGOMAXPROCS() = %d, want 5 (from cpu.json)", got)
+	}
+}
+
+// TestRuntimeCaps_EnvBeatsFile: env var wins over cpu.json, which wins over the
+// built-in default. This is the documented precedence.
+func TestRuntimeCaps_EnvBeatsFile(t *testing.T) {
+	installCapsFile(t, `{"extract_gomaxprocs": 5, "rebuild_gomaxprocs": 5, "extract_concurrency": 5}`)
+
+	t.Setenv("ARCHIGRAPH_EXTRACT_GOMAXPROCS", "9")
+	if got := extractGOMAXPROCS(); got != 9 {
+		t.Fatalf("env should beat file: extractGOMAXPROCS() = %d, want 9", got)
+	}
+
+	t.Setenv("ARCHIGRAPH_REBUILD_GOMAXPROCS", "11")
+	if got := rebuildGOMAXPROCS(); got != 11 {
+		t.Fatalf("env should beat file: rebuildGOMAXPROCS() = %d, want 11", got)
+	}
+
+	t.Setenv("ARCHIGRAPH_EXTRACT_CONCURRENCY", "7")
+	if got := (CoordinatorConfig{}).concurrency(); got != 7 {
+		t.Fatalf("env should beat file: concurrency() = %d, want 7", got)
+	}
+}
+
+// TestRuntimeCaps_FileConcurrency: cpu.json drives the subprocess fan-out when
+// neither an explicit field nor the env var is set.
+func TestRuntimeCaps_FileConcurrency(t *testing.T) {
+	installCapsFile(t, `{"extract_concurrency": 3}`)
+	if got := (CoordinatorConfig{}).concurrency(); got != 3 {
+		t.Fatalf("concurrency() = %d, want 3 (from cpu.json)", got)
+	}
+	// Explicit field still wins over the file.
+	if got := (CoordinatorConfig{Concurrency: 6}).concurrency(); got != 6 {
+		t.Fatalf("explicit field should win over file: concurrency() = %d, want 6", got)
+	}
+}
+
+// TestRuntimeCaps_RebuildFileOverride: cpu.json rebuild cap applies on the
+// interactive path.
+func TestRuntimeCaps_RebuildFileOverride(t *testing.T) {
+	installCapsFile(t, `{"rebuild_gomaxprocs": 8}`)
+	if got := rebuildGOMAXPROCS(); got != 8 {
+		t.Fatalf("rebuildGOMAXPROCS() = %d, want 8 (from cpu.json)", got)
+	}
+	if got := (CoordinatorConfig{Interactive: true}).childGOMAXPROCS(); got != 8 {
+		t.Fatalf("interactive childGOMAXPROCS() = %d, want 8 (from cpu.json)", got)
+	}
+}
+
+// TestRuntimeCaps_NoStore_FallsThrough: with no store installed, resolution is
+// exactly the pre-#5137 env→default behavior.
+func TestRuntimeCaps_NoStore_FallsThrough(t *testing.T) {
+	SetRuntimeCaps(nil)
+	if got := extractGOMAXPROCS(); got != 2 {
+		t.Fatalf("no store: extractGOMAXPROCS() = %d, want default 2", got)
+	}
+}

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -32,7 +32,11 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"syscall"
 	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon/watchreg"
+	"github.com/cajasmota/archigraph/internal/process"
 )
 
 // TierForgetter is the narrow slice of tier.Manager the reaper needs: drop all
@@ -66,6 +70,17 @@ type ReaperConfig struct {
 	// poller, fsnotify subscription). Invoked after the store is removed.
 	Untrack func(repoPath string)
 
+	// WatchRegistry, when non-nil, is the daemon-owned `archigraph watch` PID
+	// registry (#5142). On every sweep the reaper reconciles it: entries whose
+	// process is dead are dropped, and live-but-orphaned watchers (owned by a
+	// previous daemon generation) are SIGTERM'd and dropped. nil disables
+	// watcher reaping (e.g. modes without standalone watchers).
+	WatchRegistry *watchreg.Registry
+
+	// LiveDaemonPID returns the PID of the currently-live daemon, used to detect
+	// orphaned watchers. nil → os.Getpid (the running daemon owns the sweep).
+	LiveDaemonPID func() int
+
 	// Interval between sweeps. Default (zero value): 5 minutes.
 	Interval time.Duration
 
@@ -83,6 +98,9 @@ type ReapResult struct {
 	SlotsForgotten int
 	// FreedBytes is the total bytes reclaimed from deleted store dirs.
 	FreedBytes int64
+	// WatchersReaped is the number of stale/orphaned `archigraph watch` PID
+	// registry entries reaped this sweep (#5142).
+	WatchersReaped int
 }
 
 // Reaper periodically GCs stores for repos that no longer exist on disk.
@@ -132,6 +150,9 @@ func (r *Reaper) Start(stopCh <-chan struct{}) {
 // Safe to call directly from tests.
 func (r *Reaper) Sweep() ReapResult {
 	var res ReapResult
+	// #5142: reap stale/orphaned `archigraph watch` PIDs. Independent of the
+	// vanished-repo GC below, so it runs even in configs without TrackedRepos.
+	res.WatchersReaped = r.sweepWatchers()
 	if r.cfg.TrackedRepos == nil {
 		return res
 	}
@@ -177,6 +198,56 @@ func (r *Reaper) Sweep() ReapResult {
 			"freed_bytes", res.FreedBytes)
 	}
 	return res
+}
+
+// sweepWatchers reconciles the daemon-owned `archigraph watch` PID registry
+// (#5142): it drops entries whose process is dead and SIGTERMs + drops
+// live-but-orphaned watchers (owned by a previous daemon generation). Returns
+// the number of entries reaped. A nil WatchRegistry disables the sweep.
+//
+// Liveness uses the same signal-0 probe as the daemon pidfile; the kill is a
+// SIGTERM (graceful — the watcher's signal handler exits cleanly). Both are
+// injected as functions only in tests; production uses the real syscalls.
+func (r *Reaper) sweepWatchers() int {
+	if r.cfg.WatchRegistry == nil {
+		return 0
+	}
+	liveDaemonPID := r.cfg.LiveDaemonPID
+	if liveDaemonPID == nil {
+		liveDaemonPID = os.Getpid
+	}
+	res, err := r.cfg.WatchRegistry.Sweep(watchreg.SweepDeps{
+		Alive:         pidAliveProbe,
+		Kill:          sigtermPID,
+		LiveDaemonPID: liveDaemonPID,
+	})
+	if err != nil {
+		r.logger.Warn("reaper: watcher PID registry sweep failed (non-fatal)", "err", err)
+		return 0
+	}
+	if res.Reaped() > 0 {
+		r.logger.Info("reaper: reaped stale archigraph-watch PIDs",
+			"dead", res.Dead, "orphaned", res.Orphaned, "kill_errors", len(res.KillErrors))
+	}
+	return res.Reaped()
+}
+
+// pidAliveProbe reports whether pid names a live process (signal-0 existence
+// probe; portable on darwin/linux).
+func pidAliveProbe(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}
+
+// sigtermPID sends SIGTERM to pid via the process package's portable Kill.
+func sigtermPID(pid int) error {
+	return process.Kill(pid)
 }
 
 // removeStore deletes storeDir and returns the bytes it freed. A non-existent

--- a/internal/daemon/reaper_watch_test.go
+++ b/internal/daemon/reaper_watch_test.go
@@ -1,0 +1,47 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/watchreg"
+)
+
+// TestReaper_sweepsWatchRegistry verifies the #5142 wiring: Reaper.Sweep drops
+// dead watcher PIDs and reaps orphaned ones via the injected WatchRegistry,
+// independent of the vanished-repo GC. It uses the registry's real on-disk
+// store but relies on the package-level liveness probe — so we register only
+// PIDs that are genuinely dead (a never-allocated high PID and the reaper's own
+// orphan logic) to keep the assertion deterministic without spawning processes.
+func TestReaper_sweepsWatchRegistry(t *testing.T) {
+	reg := watchreg.New(filepath.Join(t.TempDir(), watchreg.FileName))
+
+	// A PID that is certainly dead (process enumeration treats it as gone).
+	deadPID := 999_999_999
+	if err := reg.Register(watchreg.Entry{PID: deadPID, Repo: "/gone", OwnerDaemonPID: 4242}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	r := NewReaper(ReaperConfig{
+		WatchRegistry: reg,
+		// No TrackedRepos → vanished-repo GC is a no-op; only watcher sweep runs.
+	})
+	res := r.Sweep()
+	if res.WatchersReaped != 1 {
+		t.Fatalf("WatchersReaped = %d, want 1 (dead PID reaped)", res.WatchersReaped)
+	}
+	got, _ := reg.List()
+	if len(got) != 0 {
+		t.Fatalf("dead watcher entry should be gone, registry has %d entries", len(got))
+	}
+}
+
+// TestReaper_watchSweepDisabledWhenNil: with no WatchRegistry, the watcher
+// sweep is a no-op and the zero-tracker result stays empty (matches the
+// existing TestReaper_noOpWhenNoTracker contract).
+func TestReaper_watchSweepDisabledWhenNil(t *testing.T) {
+	r := NewReaper(ReaperConfig{})
+	if res := r.Sweep(); res != (ReapResult{}) {
+		t.Fatalf("nil WatchRegistry + nil TrackedRepos should yield zero result, got %+v", res)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
 	"github.com/cajasmota/archigraph/internal/daemon/transport"
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
+	"github.com/cajasmota/archigraph/internal/daemon/watchreg"
 	"github.com/cajasmota/archigraph/internal/daemon/worktree"
 	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/gitmeta"
@@ -458,7 +459,10 @@ func Run(ctx context.Context, cfg Config) error {
 				Untrack: func(repoPath string) {
 					watcher.RemoveRepo(repoPath)
 				},
-				Logger: logger,
+				// #5142: also reap stale/orphaned `archigraph watch` PIDs that
+				// registered in the daemon-owned registry under the daemon root.
+				WatchRegistry: watchreg.New(watchreg.DefaultPath(cfg.Layout.Root)),
+				Logger:        logger,
 			})
 			reaperStop := make(chan struct{})
 			reaper.Start(reaperStop)

--- a/internal/daemon/watchreg/lock.go
+++ b/internal/daemon/watchreg/lock.go
@@ -1,0 +1,49 @@
+package watchreg
+
+import (
+	"errors"
+	"os"
+	"time"
+)
+
+// lockFile acquires an advisory lock on path via an atomic O_CREATE|O_EXCL
+// create, returning an unlock closure that removes the lock file. This is the
+// portable (no cgo, no x/sys) cross-process mutex used to serialize the
+// registry read-modify-write between the standalone watchers and the daemon
+// sweep.
+//
+// A stale lock (older than staleLockAge — left by a process that crashed
+// mid-mutation) is forcibly reclaimed so the registry can never wedge
+// permanently. The mutation it guards is sub-millisecond, so the timeout is
+// generous relative to the work.
+func lockFile(path string) (func(), error) {
+	const (
+		staleLockAge = 30 * time.Second
+		maxWait      = 5 * time.Second
+		pollEvery    = 5 * time.Millisecond
+	)
+	deadline := time.Now().Add(maxWait)
+	for {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err == nil {
+			_ = f.Close()
+			return func() { _ = os.Remove(path) }, nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return nil, err
+		}
+		// Lock held — reclaim it if it is stale, else wait.
+		if fi, statErr := os.Stat(path); statErr == nil {
+			if time.Since(fi.ModTime()) > staleLockAge {
+				_ = os.Remove(path) // best-effort steal; loop retries the create.
+				continue
+			}
+		}
+		if time.Now().After(deadline) {
+			// Last-resort steal so a hung holder cannot block the daemon forever.
+			_ = os.Remove(path)
+			continue
+		}
+		time.Sleep(pollEvery)
+	}
+}

--- a/internal/daemon/watchreg/watchreg.go
+++ b/internal/daemon/watchreg/watchreg.go
@@ -1,0 +1,265 @@
+// Package watchreg is the daemon-owned registry of standalone `archigraph watch`
+// child processes (issue #5142, follow-up to #5140/#5141).
+//
+// # Problem
+//
+// Pre-Phase-B, `archigraph watch <repo>` runs as a standalone launchd/systemd
+// process. If its owning daemon dies/restarts, the watcher is orphaned. #5141
+// gave the watcher a self-reap (exit after N consecutive daemon-unreachable
+// failures), but that is best-effort and slow: a watcher that is wedged, paused,
+// or whose daemon comes back on a different socket can linger. #5142 asks the
+// daemon to OWN the lifecycle — track watcher PIDs and reap dead/orphaned ones.
+//
+// # Design
+//
+// Each standalone watcher writes a tiny JSON entry into a shared registry file
+// under the daemon root (`~/.archigraph/watchers.json`) at startup and removes
+// its own entry on clean exit. The daemon's reaper periodically:
+//
+//  1. drops entries whose PID is no longer alive (signal-0 probe), and
+//  2. SIGTERMs + drops entries that are alive but ORPHANED — their recorded
+//     owner daemon PID is no longer the live daemon (the daemon that restarted
+//     adopts the file by stamping its own PID; any watcher still claiming the
+//     old owner is a leftover from a previous daemon generation).
+//
+// The registry is a single JSON file guarded by an OS file lock for the
+// read-modify-write, so concurrent watcher registrations and the daemon sweep
+// never corrupt it. All process-touching operations (liveness, kill) are
+// injectable so the staleness/reaping logic is unit-testable with fake PIDs.
+package watchreg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// FileName is the basename of the watcher registry under the daemon root.
+const FileName = "watchers.json"
+
+// Entry records one standalone `archigraph watch` process.
+type Entry struct {
+	// PID is the watcher process id.
+	PID int `json:"pid"`
+	// Repo is the absolute repo path the watcher polls (diagnostic).
+	Repo string `json:"repo"`
+	// OwnerDaemonPID is the PID of the daemon that was live when the watcher
+	// registered. When the live daemon's PID differs, the watcher is an orphan
+	// from a previous daemon generation and is reaped. Zero means "unknown
+	// owner" — never treated as orphaned on that basis alone.
+	OwnerDaemonPID int `json:"owner_daemon_pid,omitempty"`
+	// StartedUnix is the watcher's registration time (diagnostic).
+	StartedUnix int64 `json:"started_unix,omitempty"`
+}
+
+// Registry is the on-disk watcher registry. It is safe for concurrent use
+// across processes via a sidecar lock file.
+type Registry struct {
+	path string
+}
+
+// New returns a Registry backed by the watchers.json at path (typically
+// filepath.Join(layout.Root, FileName)).
+func New(path string) *Registry { return &Registry{path: path} }
+
+// DefaultPath returns the conventional watchers.json path under daemonRoot.
+func DefaultPath(daemonRoot string) string {
+	if daemonRoot == "" {
+		return ""
+	}
+	return filepath.Join(daemonRoot, FileName)
+}
+
+// Register adds (or refreshes) the entry for e.PID, stamping StartedUnix when
+// unset. An existing entry with the same PID is replaced. The read-modify-write
+// is serialized by an OS file lock.
+func (r *Registry) Register(e Entry) error {
+	if e.StartedUnix == 0 {
+		e.StartedUnix = time.Now().Unix()
+	}
+	return r.mutate(func(entries []Entry) []Entry {
+		out := entries[:0]
+		for _, x := range entries {
+			if x.PID != e.PID {
+				out = append(out, x)
+			}
+		}
+		return append(out, e)
+	})
+}
+
+// Deregister removes the entry for pid (clean watcher exit). Missing pid is a
+// no-op.
+func (r *Registry) Deregister(pid int) error {
+	return r.mutate(func(entries []Entry) []Entry {
+		out := entries[:0]
+		for _, x := range entries {
+			if x.PID != pid {
+				out = append(out, x)
+			}
+		}
+		return out
+	})
+}
+
+// List returns the current entries (sorted by PID for determinism).
+func (r *Registry) List() ([]Entry, error) {
+	entries, err := r.read()
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].PID < entries[j].PID })
+	return entries, nil
+}
+
+// SweepDeps are the injectable process primitives the reaper uses, so the
+// staleness/reaping logic can be unit-tested with fake PIDs.
+type SweepDeps struct {
+	// Alive reports whether the process with pid exists (signal-0 probe in
+	// production).
+	Alive func(pid int) bool
+	// Kill sends SIGTERM to pid. Errors are recorded but do not abort the sweep.
+	Kill func(pid int) error
+	// LiveDaemonPID returns the PID of the currently-live daemon (os.Getpid in
+	// production). An entry whose OwnerDaemonPID is non-zero and != this value is
+	// an orphan from a previous daemon generation.
+	LiveDaemonPID func() int
+}
+
+// SweepResult summarises one reaping pass.
+type SweepResult struct {
+	// Dead are PIDs dropped because the process no longer exists.
+	Dead []int
+	// Orphaned are live PIDs that were SIGTERM'd + dropped because their owner
+	// daemon is no longer the live daemon.
+	Orphaned []int
+	// KillErrors maps PID → error for orphans whose SIGTERM failed (they are
+	// still dropped from the registry — a kill failure usually means the process
+	// raced to exit).
+	KillErrors map[int]error
+}
+
+// Reaped reports the total number of entries removed by the sweep.
+func (s SweepResult) Reaped() int { return len(s.Dead) + len(s.Orphaned) }
+
+// Sweep reconciles the registry against process liveness and ownership. Dead
+// entries are dropped; live-but-orphaned entries are SIGTERM'd and dropped.
+// Live entries owned by the current daemon are kept. The whole pass is one
+// locked read-modify-write so it never races a concurrent Register/Deregister.
+func (r *Registry) Sweep(deps SweepDeps) (SweepResult, error) {
+	res := SweepResult{KillErrors: map[int]error{}}
+	if deps.Alive == nil {
+		deps.Alive = func(int) bool { return true }
+	}
+	live := 0
+	if deps.LiveDaemonPID != nil {
+		live = deps.LiveDaemonPID()
+	}
+	err := r.mutate(func(entries []Entry) []Entry {
+		kept := entries[:0]
+		for _, e := range entries {
+			if e.PID <= 0 {
+				continue // malformed — drop.
+			}
+			if !deps.Alive(e.PID) {
+				res.Dead = append(res.Dead, e.PID)
+				continue
+			}
+			// Alive but orphaned: owner recorded, and it isn't the live daemon.
+			if e.OwnerDaemonPID > 0 && live > 0 && e.OwnerDaemonPID != live {
+				res.Orphaned = append(res.Orphaned, e.PID)
+				if deps.Kill != nil {
+					if kerr := deps.Kill(e.PID); kerr != nil {
+						res.KillErrors[e.PID] = kerr
+					}
+				}
+				continue
+			}
+			kept = append(kept, e)
+		}
+		return kept
+	})
+	sort.Ints(res.Dead)
+	sort.Ints(res.Orphaned)
+	return res, err
+}
+
+// AdoptOwner rewrites every entry's OwnerDaemonPID to newOwner. Called once by a
+// freshly-started daemon so watchers spawned under it (and any pre-existing
+// watcher this daemon chooses to adopt) are owned by the live daemon; any
+// watcher still claiming a DIFFERENT owner after this is a true orphan that the
+// next Sweep reaps. Returns the number of entries whose owner changed.
+//
+// NOTE: AdoptOwner is intentionally NOT called blindly at daemon start — doing
+// so would adopt genuine orphans and hide them from the sweep. The daemon calls
+// Sweep FIRST (reaping orphans from the dead previous daemon) and only then, if
+// it spawns watchers itself, stamps them with its own PID via Register.
+func (r *Registry) AdoptOwner(newOwner int) (int, error) {
+	changed := 0
+	err := r.mutate(func(entries []Entry) []Entry {
+		for i := range entries {
+			if entries[i].OwnerDaemonPID != newOwner {
+				entries[i].OwnerDaemonPID = newOwner
+				changed++
+			}
+		}
+		return entries
+	})
+	return changed, err
+}
+
+// --- internal read/write with file locking ---
+
+func (r *Registry) read() ([]Entry, error) {
+	b, err := os.ReadFile(r.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // empty registry is valid.
+		}
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var entries []Entry
+	if err := json.Unmarshal(b, &entries); err != nil {
+		// A corrupt registry must not wedge the daemon: treat as empty. The next
+		// write overwrites it cleanly.
+		return nil, nil
+	}
+	return entries, nil
+}
+
+func (r *Registry) write(entries []Entry) error {
+	if entries == nil {
+		entries = []Entry{}
+	}
+	b, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	tmp := r.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, r.path)
+}
+
+// mutate runs fn under the registry lock against the current entries and writes
+// the result atomically. fn may reuse the input slice's backing array.
+func (r *Registry) mutate(fn func([]Entry) []Entry) error {
+	unlock, err := lockFile(r.path + ".lock")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	entries, err := r.read()
+	if err != nil {
+		return err
+	}
+	return r.write(fn(entries))
+}

--- a/internal/daemon/watchreg/watchreg_test.go
+++ b/internal/daemon/watchreg/watchreg_test.go
@@ -1,0 +1,241 @@
+package watchreg
+
+import (
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func newTestRegistry(t *testing.T) *Registry {
+	t.Helper()
+	return New(filepath.Join(t.TempDir(), FileName))
+}
+
+func pids(entries []Entry) []int {
+	out := make([]int, len(entries))
+	for i, e := range entries {
+		out[i] = e.PID
+	}
+	return out
+}
+
+// TestRegisterListDeregister covers the basic lifecycle.
+func TestRegisterListDeregister(t *testing.T) {
+	r := newTestRegistry(t)
+
+	if got, err := r.List(); err != nil || len(got) != 0 {
+		t.Fatalf("empty registry: got (%v, %v)", got, err)
+	}
+
+	if err := r.Register(Entry{PID: 100, Repo: "/a", OwnerDaemonPID: 1}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if err := r.Register(Entry{PID: 200, Repo: "/b", OwnerDaemonPID: 1}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	got, _ := r.List()
+	if !reflect.DeepEqual(pids(got), []int{100, 200}) {
+		t.Fatalf("after register: pids = %v, want [100 200]", pids(got))
+	}
+	if got[0].StartedUnix == 0 {
+		t.Fatalf("StartedUnix should be stamped on register")
+	}
+
+	// Re-register same PID replaces (no dup).
+	if err := r.Register(Entry{PID: 100, Repo: "/a2", OwnerDaemonPID: 2}); err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	got, _ = r.List()
+	if !reflect.DeepEqual(pids(got), []int{100, 200}) {
+		t.Fatalf("re-register should not dup: pids = %v", pids(got))
+	}
+	if got[0].Repo != "/a2" || got[0].OwnerDaemonPID != 2 {
+		t.Fatalf("re-register should replace fields: %+v", got[0])
+	}
+
+	if err := r.Deregister(100); err != nil {
+		t.Fatalf("deregister: %v", err)
+	}
+	got, _ = r.List()
+	if !reflect.DeepEqual(pids(got), []int{200}) {
+		t.Fatalf("after deregister: pids = %v, want [200]", pids(got))
+	}
+
+	// Deregister missing PID is a no-op.
+	if err := r.Deregister(999); err != nil {
+		t.Fatalf("deregister missing: %v", err)
+	}
+}
+
+// TestSweep_DropsDeadPIDs: an entry whose process is gone is dropped (no kill).
+func TestSweep_DropsDeadPIDs(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{PID: 100, OwnerDaemonPID: 7})
+	_ = r.Register(Entry{PID: 200, OwnerDaemonPID: 7})
+
+	var killed []int
+	res, err := r.Sweep(SweepDeps{
+		Alive:         func(pid int) bool { return pid == 200 }, // 100 is dead
+		Kill:          func(pid int) error { killed = append(killed, pid); return nil },
+		LiveDaemonPID: func() int { return 7 }, // owner matches → 200 is healthy
+	})
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if !reflect.DeepEqual(res.Dead, []int{100}) {
+		t.Fatalf("Dead = %v, want [100]", res.Dead)
+	}
+	if len(res.Orphaned) != 0 {
+		t.Fatalf("Orphaned = %v, want none", res.Orphaned)
+	}
+	if len(killed) != 0 {
+		t.Fatalf("dead PIDs must NOT be killed, killed=%v", killed)
+	}
+	got, _ := r.List()
+	if !reflect.DeepEqual(pids(got), []int{200}) {
+		t.Fatalf("after sweep: pids = %v, want [200]", pids(got))
+	}
+}
+
+// TestSweep_ReapsOrphans: a live watcher whose owner daemon is no longer the
+// live daemon is SIGTERM'd and dropped.
+func TestSweep_ReapsOrphans(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{PID: 100, OwnerDaemonPID: 7}) // owned by old daemon 7
+	_ = r.Register(Entry{PID: 200, OwnerDaemonPID: 9}) // owned by live daemon 9
+
+	var killed []int
+	res, err := r.Sweep(SweepDeps{
+		Alive:         func(int) bool { return true }, // both alive
+		Kill:          func(pid int) error { killed = append(killed, pid); return nil },
+		LiveDaemonPID: func() int { return 9 },
+	})
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if !reflect.DeepEqual(res.Orphaned, []int{100}) {
+		t.Fatalf("Orphaned = %v, want [100]", res.Orphaned)
+	}
+	if !reflect.DeepEqual(killed, []int{100}) {
+		t.Fatalf("orphan must be SIGTERM'd, killed=%v want [100]", killed)
+	}
+	got, _ := r.List()
+	if !reflect.DeepEqual(pids(got), []int{200}) {
+		t.Fatalf("after sweep: pids = %v, want [200] (live owned watcher kept)", pids(got))
+	}
+	if res.Reaped() != 1 {
+		t.Fatalf("Reaped() = %d, want 1", res.Reaped())
+	}
+}
+
+// TestSweep_UnknownOwnerNeverOrphaned: an entry with OwnerDaemonPID==0 is never
+// reaped on the orphan basis — we only kill watchers we can prove belong to a
+// dead daemon generation.
+func TestSweep_UnknownOwnerNeverOrphaned(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{PID: 100, OwnerDaemonPID: 0})
+
+	var killed []int
+	res, _ := r.Sweep(SweepDeps{
+		Alive:         func(int) bool { return true },
+		Kill:          func(pid int) error { killed = append(killed, pid); return nil },
+		LiveDaemonPID: func() int { return 9 },
+	})
+	if res.Reaped() != 0 {
+		t.Fatalf("unknown-owner live watcher must not be reaped: %+v", res)
+	}
+	if len(killed) != 0 {
+		t.Fatalf("unknown-owner watcher must not be killed, killed=%v", killed)
+	}
+}
+
+// TestSweep_KillErrorStillDrops: a SIGTERM failure (process raced to exit) is
+// recorded but the orphan is still removed from the registry.
+func TestSweep_KillErrorStillDrops(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{PID: 100, OwnerDaemonPID: 7})
+
+	res, _ := r.Sweep(SweepDeps{
+		Alive:         func(int) bool { return true },
+		Kill:          func(int) error { return errKill },
+		LiveDaemonPID: func() int { return 9 },
+	})
+	if len(res.KillErrors) != 1 || res.KillErrors[100] == nil {
+		t.Fatalf("KillErrors should record pid 100: %+v", res.KillErrors)
+	}
+	got, _ := r.List()
+	if len(got) != 0 {
+		t.Fatalf("orphan must be dropped even when kill fails: %v", pids(got))
+	}
+}
+
+// TestSweep_DropsMalformed: a non-positive PID entry is dropped as malformed.
+func TestSweep_DropsMalformed(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{PID: 0})
+	_ = r.Register(Entry{PID: 50, OwnerDaemonPID: 9})
+	r.Sweep(SweepDeps{Alive: func(int) bool { return true }, LiveDaemonPID: func() int { return 9 }})
+	got, _ := r.List()
+	if !reflect.DeepEqual(pids(got), []int{50}) {
+		t.Fatalf("malformed PID 0 should be dropped: pids = %v", pids(got))
+	}
+}
+
+// TestAdoptOwner rewrites every entry's owner and reports the change count.
+func TestAdoptOwner(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{PID: 100, OwnerDaemonPID: 7})
+	_ = r.Register(Entry{PID: 200, OwnerDaemonPID: 9})
+
+	changed, err := r.AdoptOwner(9)
+	if err != nil {
+		t.Fatalf("adopt: %v", err)
+	}
+	if changed != 1 { // only PID 100 changed (200 was already 9)
+		t.Fatalf("AdoptOwner changed = %d, want 1", changed)
+	}
+	got, _ := r.List()
+	for _, e := range got {
+		if e.OwnerDaemonPID != 9 {
+			t.Fatalf("entry %d owner = %d, want 9", e.PID, e.OwnerDaemonPID)
+		}
+	}
+}
+
+// TestConcurrentRegister exercises the cross-process lock under contention.
+func TestConcurrentRegister(t *testing.T) {
+	r := newTestRegistry(t)
+	var wg sync.WaitGroup
+	for i := 1; i <= 20; i++ {
+		wg.Add(1)
+		go func(pid int) {
+			defer wg.Done()
+			if err := r.Register(Entry{PID: pid, OwnerDaemonPID: 1}); err != nil {
+				t.Errorf("register %d: %v", pid, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	got, _ := r.List()
+	if len(got) != 20 {
+		t.Fatalf("concurrent register lost entries: got %d, want 20", len(got))
+	}
+}
+
+// TestSweep_NilAliveDefaultsAlive: with no Alive func, entries are treated as
+// alive (only orphan reaping applies).
+func TestSweep_NilAliveDefaultsAlive(t *testing.T) {
+	r := newTestRegistry(t)
+	_ = r.Register(Entry{PID: 100, OwnerDaemonPID: 9})
+	res, _ := r.Sweep(SweepDeps{LiveDaemonPID: func() int { return 9 }})
+	if res.Reaped() != 0 {
+		t.Fatalf("nil Alive should default to alive, healthy entry kept: %+v", res)
+	}
+}
+
+var errKill = errTest("kill failed")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }


### PR DESCRIPTION
Two daemon follow-ups in one PR. Deploy-deferred: code is built + unit-tested in an isolated sandbox; the live daemon must be restarted by the maintainer to validate the signal/process-touching paths (see live-validation steps below).

## #5137 — runtime-reload CPU/concurrency caps (follow-up to #5135)

**What built.** New `internal/daemon/caps` package: a JSON config file at `~/.archigraph/cpu.json` (under `$ARCHIGRAPH_DAEMON_ROOT` when set) holding the four caps (`extract_gomaxprocs`, `rebuild_gomaxprocs`, `extract_concurrency`, `daemon_gomaxprocs`). The store re-parses only when the file's `(mtime,size)` changes, so it is safe on the reindex hot path. Resolution precedence per knob is **explicit field/flag > env var > cpu.json > built-in default** (env is still captured once at process start; cpu.json is the live-mutable surface).

- The three **per-subprocess** caps are re-read on the start of **every reindex** via a process-wide store installed into the extract coordinator (`extract.SetRuntimeCaps`) — editing `cpu.json` takes effect on the next reindex, no restart.
- The **in-process** `daemon_gomaxprocs` is applied **live on SIGHUP** (`installCapReloadHandler` → `runtime.GOMAXPROCS`, which is documented-safe at runtime). Clearing the cap restores the host default.
- `docs/settings.md` updated: the require-restart caveat is dropped for these four knobs and the cpu.json reload contract is documented.

**Unit-tested** (no live daemon needed):
- `internal/daemon/caps`: missing-file = valid empty config, parse, mtime-cached re-read picks up an edit, malformed file keeps last-good + surfaces the error, concurrent Load, precedence accessors.
- `internal/daemon/extract` (`runtime_caps_test.go`): file-overrides-default, env-beats-file, file-driven concurrency, explicit-field-wins, no-store fall-through.
- `cmd/archigraph` (`daemon_caps_reload_test.go`): `resolveDaemonGOMAXPROCSWith` precedence + host-ceiling no-op; `applyDaemonGOMAXPROCSFromCaps` proves edit→live `runtime.GOMAXPROCS` change→raise→clear-restores-host, with GOMAXPROCS restored on exit.

**Needs live validation after restart:** that an actual `kill -HUP <daemon-pid>` triggers the reload log line and changes the live daemon's GOMAXPROCS; and that editing cpu.json changes the per-subprocess caps on a real subsequent reindex (the SIGHUP wiring + the coordinator hot-path read are exercised only end-to-end in a running daemon).

## #5142 — daemon-owned reaping of stale `archigraph watch` PIDs (follow-up to #5140/#5141)

**What built.** New `internal/daemon/watchreg` package: a daemon-owned PID registry file at `~/.archigraph/watchers.json`. Each standalone `archigraph watch` registers `{pid, repo, owner_daemon_pid}` at startup (stamping the live daemon's pidfile PID as owner) and deregisters on clean exit (`internal/cli/watch.go`). The read-modify-write is serialized by a portable O_CREATE|O_EXCL lock (with stale-lock reclaim) so concurrent watcher registrations and the daemon sweep never corrupt it. The existing `internal/daemon/reaper.go` now also sweeps the registry every cycle (reconciled per #5140's ask): entries whose PID is dead (signal-0 probe) are dropped; live-but-**orphaned** watchers (owner PID != the live daemon PID, i.e. a leftover from a previous daemon generation) are **SIGTERM'd and dropped**. Unknown-owner (PID 0) entries are never reaped on the orphan basis. Wired in `internal/daemon/server.go`.

How this satisfies the remaining #5142 work: when a daemon dies/restarts, the new daemon has a different PID, so every watcher still claiming the old owner is detected as orphaned and reaped on the next sweep — covering both "reap stale watch PIDs on start/restart" and "kill orphaned watchers" without a fragile cmdline scan. The #5141 self-reap remains the belt-and-suspenders fallback.

**Unit-tested** (fake PIDs, no spawned processes):
- `internal/daemon/watchreg`: register/list/dedup/deregister, drop-dead-PIDs (no kill), reap-orphans (SIGTERM + drop), unknown-owner-never-orphaned, kill-error-still-drops, malformed-PID drop, AdoptOwner, concurrent register under the lock, nil-Alive defaults-alive.
- `internal/daemon` (`reaper_watch_test.go`): `Reaper.Sweep` reaps a genuinely-dead PID through the injected registry, and the sweep is a no-op (zero `ReapResult`) when `WatchRegistry` is nil.

**Needs live validation after restart:** that a real orphaned `archigraph watch` process (owner daemon killed, new daemon started) is actually SIGTERM'd by the running daemon's reaper sweep, and that a real watcher registers/deregisters its pidfile entry across start/clean-exit.

## Status
- **#5137: fully delivered** (config-file + env + default resolution, per-subprocess hot-path re-read, SIGHUP live re-apply of daemon GOMAXPROCS, docs). Live-validation of the signal path is the only thing the maintainer must confirm post-restart.
- **#5142: fully delivered** (registry write from the watcher, daemon-side dead+orphan sweep reconciled into reaper.go). Live-validation of real-process SIGTERM is the only post-restart confirmation needed.

## Gates (isolated sandbox HOME=/tmp/agsbx-daemon)
- `go build ./...` — clean
- `go vet ./internal/... ./cmd/archigraph/...` — clean
- `go test ./internal/daemon/... ./internal/cli/... ./cmd/archigraph/... ./internal/daemon/caps/... ./internal/daemon/watchreg/...` — all pass
- `gofmt -l` — clean
- `git status --porcelain` — clean (committed)
- No registry.json / coverage docs touched (code + one docs/settings.md edit only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5137
Closes #5142