### PR TITLE
fix(#5206): M5 resolve index — eliminate residual ambiguous-candidate divergence

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -16108,8 +16108,21 @@ func pythonDBAPIDriverPlaceholder(imports map[string]bool) string {
 	if len(imports) == 0 {
 		return generic
 	}
-	best := ""
+	// Determinism (#5206): iterate the import set in sorted order rather than
+	// in Go's randomised map-iteration order. A file that imports two concrete
+	// server engines (e.g. pymysql AND psycopg2) used to pick whichever
+	// placeholder happened to iterate FIRST, so the resolved ext:<driver>
+	// CALLS target flipped between runs (mysql ↔ psycopg2) — non-deterministic
+	// output that surfaced as a spurious flat-vs-M5 edge-set divergence (the
+	// indexes are identical; the instability is here, not in the resolver
+	// index). Sorting the imports makes the choice reproducible.
+	roots := make([]string, 0, len(imports))
 	for p := range imports {
+		roots = append(roots, p)
+	}
+	sort.Strings(roots)
+	best := ""
+	for _, p := range roots {
 		root := pythonImportRoot(p)
 		// django.db.* paths are DB-API-shaped but carry no engine signal
 		// (the engine lives in settings.DATABASES), so they leave `best`
@@ -16123,6 +16136,9 @@ func pythonDBAPIDriverPlaceholder(imports map[string]bool) string {
 			continue
 		}
 		// Prefer a concrete server engine over the sqlite3 stdlib fallback.
+		// Among multiple concrete engines the first in sorted-import order
+		// wins deterministically (the engine choice is heuristic anyway;
+		// stability across runs is what matters for parity).
 		if best == "sqlite3" && placeholder != "sqlite3" {
 			best = placeholder
 		}

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -5108,6 +5108,54 @@ func TestPythonDBAPIDriverPlaceholder_EngineMatrix(t *testing.T) {
 	}
 }
 
+// TestPythonDBAPIDriverPlaceholder_Deterministic is the #5206 regression guard.
+//
+// pythonDBAPIDriverPlaceholder used to iterate the file's import set in Go's
+// randomised map-iteration order and keep the FIRST concrete-engine placeholder
+// it saw. When a single file imports two concrete server engines (the
+// upvate_core core/views/sync_viewset.py case imports BOTH a MySQL driver and
+// psycopg2), the resolved ext:<driver> CALLS target flipped between mysql and
+// psycopg2 from one index run to the next — non-deterministic output that
+// surfaced as a spurious flat-vs-M5 resolver-index parity divergence (the two
+// resolver indexes are byte-identical; the instability lived here, not in the
+// index). The fix sorts the import set before iterating. This test asserts the
+// result is STABLE across many independently-constructed maps (Go randomises
+// per-map, so 200 fresh maps reliably exercises multiple iteration orders) and
+// that the multi-server-engine choice is the documented deterministic winner.
+func TestPythonDBAPIDriverPlaceholder_Deterministic(t *testing.T) {
+	cases := []struct {
+		name    string
+		imports []string
+		want    string // the single stable placeholder every run must return
+	}{
+		// The exact #5206 corpus shape: a file importing two concrete server
+		// engines. Sorted-import order makes mysql.connector precede psycopg2,
+		// so "mysql" is the deterministic winner.
+		{"mysql+psycopg2", []string{"mysql.connector", "psycopg2"}, "mysql"},
+		// Same set, declared in the opposite source order — must still be stable
+		// and identical (the map drops ordering anyway; the sort restores it).
+		{"psycopg2+mysql", []string{"psycopg2", "mysql.connector"}, "mysql"},
+		// Three concrete engines + the sqlite3 stdlib fallback: sqlite3 must
+		// never win, and the concrete winner must be stable.
+		{"mysql+psycopg2+oracle+sqlite", []string{"sqlite3", "psycopg2", "mysql.connector", "cx_Oracle"}, "cx_Oracle"},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			for i := 0; i < 200; i++ {
+				imports := map[string]bool{}
+				for _, imp := range c.imports {
+					imports[imp] = true
+				}
+				if got := pythonDBAPIDriverPlaceholder(imports); got != c.want {
+					t.Fatalf("iteration %d: pythonDBAPIDriverPlaceholder(%v) = %q; want stable %q "+
+						"(non-deterministic map iteration regressed — #5206)", i, c.imports, got, c.want)
+				}
+			}
+		})
+	}
+}
+
 // TestPythonPerImportGates_WithoutImport_KeepsSaferBiasMiss confirms
 // that on a python source file WITHOUT the gate's canonical import,
 // the generic verb is NOT classified — preserving #94's safer-bias


### PR DESCRIPTION
## Summary
Closes #5206.

The residual flat-vs-M5 resolve-index divergence reopened on #5206 was **not in the resolver index**. The flat `BuildIndex` and M5 `BuildIndexFromModulesOrdered` indexes are byte-identical — the #5207 global-position replay already guarantees that, and the full-table parity harness in `internal/resolve/symbol_index_parity_test.go` confirms it (still green).

The real cause was **non-deterministic Go map iteration** in `pythonDBAPIDriverPlaceholder` (`internal/external/synth.go`). It iterated the importing file's import *set* (`map[string]bool`) in Go's randomised order and kept the **first** concrete-engine placeholder it encountered. A file that imports two concrete server engines — e.g. `upvate_core`'s `core/views/sync_viewset.py` imports both a MySQL driver and `psycopg2` — therefore resolved its `ext:<driver>` CALLS targets to `ext:mysql` on one run and `ext:psycopg2` on the next.

Because the choice was random per process, the divergence showed up **even flat-vs-flat**, not just flat-vs-M5. The parity harness diffs two *separate* index runs, so this process-to-process noise masqueraded as an M5 regression.

## Reproduce (within-run edge-multiset diff, `upvate_core`)
Index a frozen copy twice flat and once with `ARCHIGRAPH_RESOLVE_MODULE_INDEX=1`, diff the sorted `(from_id,to_id,kind)` multiset.

| diff | before | after |
|---|---|---|
| flat-vs-flat (determinism) | 22 | **0** |
| flat-vs-M5 (parity) | 48 | **0** |

All 48 diverging edges before the fix were `ext:mysql` ⇄ `ext:psycopg2` swaps on the same `from_id`/edge-id — exactly the documented #5206 driver-swap family.

## Fix
Sort the import set before the winner loop in `pythonDBAPIDriverPlaceholder`. `flat` output is untouched in intent — this only removes randomness from a heuristic; it does **not** change `BuildIndex` / `refs.go` / the M5 index path.

## Test
`TestPythonDBAPIDriverPlaceholder_Deterministic` (internal/external/synth_test.go) asserts a stable placeholder across 200 freshly-constructed maps (Go randomises per map) for the two-server-engine #5206 shape and a 3-engine+sqlite shape.

## Gates (sandboxed isolated worktree)
- `go build ./...` clean
- `go test ./internal/resolve/... ./internal/types/... ./internal/external/...` green (incl. the M5 index-parity harness and the new determinism test)
- `gofmt -l internal/resolve/ internal/external/` empty

Note: the second corpus (`archigraph` self-index) could not be used as a parity datapoint — the full self-corpus copy OOMs the one-shot indexer in this sandbox (rc=137), identically before and after this change, so it is an unrelated infra limit. The `upvate_core` corpus exercises the exact #5206 ambiguity and proves 0/0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
