### PR TITLE
fix(#5231): wire subprocess indexer + incremental default-on + status surfacing + clean hooks

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/process"
@@ -188,6 +190,12 @@ func runDoctor(w io.Writer) error {
 		fmt.Fprintf(w, "%s grafel binary: %s\n", statusOK, bin)
 	}
 
+	// Reindex-storm mitigations (#5231): surface whether the daemon's
+	// memory- and CPU-saving indexing paths are active so operators can
+	// confirm them at a glance. Both are read from the local process env,
+	// which a co-located daemon shares.
+	printIndexingModes(w)
+
 	regPath, _ := registry.RegistryPath()
 	groups, err := registry.Groups()
 	if err != nil {
@@ -347,6 +355,23 @@ func scanGrafelProcs(myPID int) ([]staleProcess, error) {
 		})
 	}
 	return result, nil
+}
+
+// printIndexingModes reports whether the two reindex-storm mitigations
+// (#5231) are active: incremental file-level reindex and subprocess
+// (out-of-daemon) indexing. Both are derived from the local process
+// environment, which a co-located daemon inherits at start.
+func printIndexingModes(w io.Writer) {
+	var cfg *extractor.ExtractorConfig // nil → IsIncrementalEnabled reads env
+	incremental := cfg.IsIncrementalEnabled()
+	subprocess := sched.SubprocessIndexEnabled()
+
+	// Incremental defaults ON (#5231); subprocess defaults OFF (memory
+	// isolation is opt-in until rollout completes).
+	fmt.Fprintf(w, "%s incremental reindex: %s (GRAFEL_INCREMENTAL_REINDEX; default on)\n",
+		statusOK, onOff(incremental))
+	fmt.Fprintf(w, "%s subprocess indexer: %s (GRAFEL_SUBPROCESS_INDEXER; default off)\n",
+		statusOK, onOff(subprocess))
 }
 
 func checkRepo(w io.Writer, r registry.Repo) {

--- a/internal/cli/indexing_modes_test.go
+++ b/internal/cli/indexing_modes_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestPrintIndexingModes verifies the #5231 surfacing in `grafel doctor`:
+// incremental defaults ON, subprocess defaults OFF, and the env override
+// flips incremental to off.
+func TestPrintIndexingModes(t *testing.T) {
+	t.Run("defaults: incremental on, subprocess off", func(t *testing.T) {
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "")
+		var buf bytes.Buffer
+		printIndexingModes(&buf)
+		out := buf.String()
+		if !strings.Contains(out, "incremental reindex: on") {
+			t.Fatalf("expected incremental ON by default, got:\n%s", out)
+		}
+		if !strings.Contains(out, "subprocess indexer: off") {
+			t.Fatalf("expected subprocess OFF by default, got:\n%s", out)
+		}
+	})
+
+	t.Run("incremental forced off via env", func(t *testing.T) {
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "0")
+		var buf bytes.Buffer
+		printIndexingModes(&buf)
+		if !strings.Contains(buf.String(), "incremental reindex: off") {
+			t.Fatalf("expected incremental OFF with =0, got:\n%s", buf.String())
+		}
+	})
+}
+
+// TestOnOff is a tiny guard for the shared on/off renderer used by both
+// status and doctor.
+func TestOnOff(t *testing.T) {
+	if onOff(true) != "on" || onOff(false) != "off" {
+		t.Fatalf("onOff: got %q/%q, want on/off", onOff(true), onOff(false))
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -12,7 +12,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
+	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -93,6 +95,13 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 				if st.DashboardPort > 0 {
 					fmt.Fprintf(w, "  dashboard: http://127.0.0.1:%d/\n", st.DashboardPort)
 				}
+				// Reindex-storm mitigations (#5231): incremental file-level
+				// reindex (default ON) and subprocess/out-of-daemon indexing
+				// (default OFF). Read from the local process env, which a
+				// co-located daemon shares.
+				var ecfg *extractor.ExtractorConfig // nil → reads env
+				fmt.Fprintf(w, "  indexing: incremental=%s subprocess=%s\n",
+					onOff(ecfg.IsIncrementalEnabled()), onOff(sched.SubprocessIndexEnabled()))
 			}
 			if st.WatcherRepos > 0 || st.WatcherEvents > 0 {
 				fmt.Fprintf(w, "  watcher: repos=%d dirs=%d events=%d dropped=%d",
@@ -279,6 +288,14 @@ func printWorktreeChildren(w io.Writer, groupName string) {
 			fmt.Fprintf(w, "  └─ worktree: %s @ %s\n", name, branch)
 		}
 	}
+}
+
+// onOff renders a bool as "on"/"off" for status/doctor indexing-mode lines.
+func onOff(b bool) string {
+	if b {
+		return "on"
+	}
+	return "off"
 }
 
 // humanBytes formats a byte count as a short human-readable string. We

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -35,8 +35,10 @@ import (
 // the Config-first / env-fallback logic in one place.
 type ExtractorConfig struct {
 	// Incremental reindex toggles (GRAFEL_INCREMENTAL_REINDEX,
-	// GRAFEL_INCREMENTAL_MAX_FILES). Non-pointer so the zero value
-	// is the documented default (disabled / auto-limit).
+	// GRAFEL_INCREMENTAL_MAX_FILES). The effective default when neither
+	// Config nor env sets a value is ON (#5231) — see IsIncrementalEnabled;
+	// the zero value here only means "not explicitly set via Config"
+	// (IncrementalReindexSet=false), which defers to that default.
 	IncrementalReindex  bool
 	IncrementalMaxFiles int // 0 means "auto" (gitmeta-based heuristic)
 
@@ -128,13 +130,22 @@ func (c *ExtractorConfig) EmitDestructureDetail() bool {
 }
 
 // IsIncrementalEnabled reports whether the incremental reindex path is active.
-// Config (when IncrementalReindexSet=true) wins; env var is the fallback;
-// default is false.
+// Config (when IncrementalReindexSet=true) wins; env var is the fallback.
+//
+// Default flipped to ON (#5231, the reindex-storm fix): the incremental
+// file-level patch is ~25× faster than a full reindex for single-file edits
+// and has a proven safe fall-through to the full IndexFn on any precondition
+// failure. Operators can still force the legacy full-reindex-every-time
+// behaviour with GRAFEL_INCREMENTAL_REINDEX=0 (or =false), which boolFromEnv
+// reports as an explicitly-set falsy value.
 func (c *ExtractorConfig) IsIncrementalEnabled() bool {
 	if c != nil && c.IncrementalReindexSet {
 		return c.IncrementalReindex
 	}
-	v, _ := boolFromEnv("GRAFEL_INCREMENTAL_REINDEX")
+	v, set := boolFromEnv("GRAFEL_INCREMENTAL_REINDEX")
+	if !set {
+		return true // default ON (#5231)
+	}
 	return v
 }
 

--- a/internal/extractor/incremental_default_test.go
+++ b/internal/extractor/incremental_default_test.go
@@ -1,0 +1,64 @@
+package extractor
+
+import "testing"
+
+// TestIsIncrementalEnabledDefaultOn pins the #5231 behaviour change: the
+// incremental file-level reindex path is ON by default (env unset) and can be
+// forced OFF with GRAFEL_INCREMENTAL_REINDEX=0/false, while an explicit Config
+// value always wins over the env.
+func TestIsIncrementalEnabledDefaultOn(t *testing.T) {
+	t.Run("env unset → default ON (#5231)", func(t *testing.T) {
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "")
+		var c *ExtractorConfig // nil receiver must also default ON
+		if !c.IsIncrementalEnabled() {
+			t.Fatal("nil-config IsIncrementalEnabled() = false; want true (default ON)")
+		}
+		cfg := ConfigFromEnv() // not explicitly set → defers to default
+		if !cfg.IsIncrementalEnabled() {
+			t.Fatal("ConfigFromEnv().IsIncrementalEnabled() = false; want true (default ON)")
+		}
+	})
+
+	t.Run("env =0 forces OFF", func(t *testing.T) {
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "0")
+		var c *ExtractorConfig
+		if c.IsIncrementalEnabled() {
+			t.Fatal("GRAFEL_INCREMENTAL_REINDEX=0 still enabled; want OFF")
+		}
+		cfg := ConfigFromEnv()
+		if cfg.IsIncrementalEnabled() {
+			t.Fatal("ConfigFromEnv with =0 still enabled; want OFF")
+		}
+	})
+
+	t.Run("env =false forces OFF", func(t *testing.T) {
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "false")
+		var c *ExtractorConfig
+		if c.IsIncrementalEnabled() {
+			t.Fatal("GRAFEL_INCREMENTAL_REINDEX=false still enabled; want OFF")
+		}
+	})
+
+	t.Run("env =1 ON", func(t *testing.T) {
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "1")
+		var c *ExtractorConfig
+		if !c.IsIncrementalEnabled() {
+			t.Fatal("GRAFEL_INCREMENTAL_REINDEX=1 not enabled; want ON")
+		}
+	})
+
+	t.Run("explicit Config wins over env", func(t *testing.T) {
+		// Env says OFF, Config explicitly says ON → Config wins.
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "0")
+		c := &ExtractorConfig{IncrementalReindex: true, IncrementalReindexSet: true}
+		if !c.IsIncrementalEnabled() {
+			t.Fatal("explicit Config ON overridden by env OFF; Config must win")
+		}
+		// Env unset (default ON), Config explicitly says OFF → Config wins.
+		t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "")
+		c = &ExtractorConfig{IncrementalReindex: false, IncrementalReindexSet: true}
+		if c.IsIncrementalEnabled() {
+			t.Fatal("explicit Config OFF overridden by default ON; Config must win")
+		}
+	})
+}


### PR DESCRIPTION
Code half of the reindex-storm fix (#5231). Investigation is in the issue comments.

## What changed
1. **Incremental reindex default → ON** (`extractor.IsIncrementalEnabled`). The file-level incremental patch is ~25× faster than a full reindex for single-file edits and has a proven safe fall-through to the full `IndexFn`. `GRAFEL_INCREMENTAL_REINDEX=0`/`false` still forces the legacy full reindex; an explicit `Config` value continues to win over the env. **Behavior change — called out explicitly.**
2. **Surface indexing modes** in `grafel doctor` and `grafel status`: both now report whether incremental + subprocess indexing are active (`IsIncrementalEnabled` / `sched.SubprocessIndexEnabled`). Shared `onOff()` renderer.

## Tasks that were already done on `main` (no change needed)
- **Wire subprocess indexer**: already wired. `daemonSchedulerIndex` (the full-reindex `IndexFn`) branches on `SubprocessIndexEnabled()` and calls `sched.RunSubprocessIndex`. The original "dead code" finding was an artifact of grepping only `internal/` — the call site is in `cmd/grafel/daemon.go`. Child output: `index-internal` writes `graph.fb` to the default daemon store layout (same path the in-process `Index` writes), and the daemon picks it up via `invalidateAfterIndex` dropping the cached mmap so the next MCP query reopens the fresh graph.
- **Strip `archigraph` hook lines**: already done by the rename PR. `internal/install/hooks_install.go` templates are grafel-only (`command -v grafel` / `grafel status`); zero `archigraph` references remain in non-test Go.

## Deferred
- `GRAFEL_SUBPROCESS_INDEXER` left **default OFF** (memory isolation stays opt-in pending live-deploy validation, per the existing rollout note). Surfaced as `off` in status/doctor.

## Tests
- `internal/extractor/incremental_default_test.go` — pins default-on, env-override OFF, and Config-wins.
- `internal/cli/indexing_modes_test.go` — doctor surfacing + `onOff`.
- `go build ./...`, `gofmt -l`, `go vet` clean on touched packages. Targeted suites pass: `./internal/extractor/... ./internal/daemon/sched/... ./internal/install/...`. (Pre-existing sandbox failures in `internal/cli` ref-flag/status tests reproduce on unmodified `origin/main` — daemon socket-path resolver hits `os.UserHomeDir()` under isolated-HOME; unrelated to this change.)

Refs #5231

🤖 Generated with [Claude Code](https://claude.com/claude-code)