### PR TITLE
fix(#5230): DRF @action uses url_path verbatim (incl path params), hyphenated fallback

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -13,8 +13,13 @@
 // Plus, every `@action(detail=True|False, methods=[...], url_path="...")`
 // decorated method on the ViewSet class adds another endpoint:
 //
-//	detail=True:  /<prefix>/{pk}/<url_path or method_name>/
-//	detail=False: /<prefix>/<url_path or method_name>/
+//	detail=True:  /<prefix>/{pk}/<url_path or hyphenated-method-name>/
+//	detail=False: /<prefix>/<url_path or hyphenated-method-name>/
+//
+// When no `url_path=` is given DRF derives the segment from the method name
+// with `_`→`-` (`do_thing` → `do-thing`); an explicit `url_path` is used
+// verbatim including embedded `(?P<name>regex)` capture groups, which the
+// canonicaliser rewrites to `{name}` path params (#5230).
 //
 // The base `ApplyDjangoNestedURLConf` pass only emits ONE endpoint per
 // `router.register(...)` call (the list/create root). This pass is the
@@ -1332,9 +1337,16 @@ func emitActionRoutes(
 		} else {
 			actPosture = postureForAction(vc, act.methodName)
 		}
+		// #5230 — URL-segment derivation faithful to DRF semantics:
+		//   1. An explicit `url_path="<value>"` kwarg wins VERBATIM, including any
+		//      embedded `(?P<name>regex)` capture groups — canonicalDjango rewrites
+		//      those to `{name}` path params downstream (stripPythonNamedGroups).
+		//   2. With no url_path, DRF derives the segment from the Python method name
+		//      with underscores replaced by hyphens (`do_thing` → `do-thing`), NOT
+		//      the raw method name. Pre-#5230 the raw name leaked into the URL.
 		segment := act.urlPath
 		if segment == "" {
-			segment = act.methodName
+			segment = drfDefaultActionSegment(act.methodName)
 		}
 		methods := act.methods
 		if len(methods) == 0 {
@@ -1377,6 +1389,17 @@ func emitActionRoutes(
 			}
 		}
 	}
+}
+
+// drfDefaultActionSegment returns the URL segment DRF derives from an
+// @action-decorated method NAME when no `url_path=` kwarg is supplied (#5230).
+// DRF's router replaces underscores in the method name with hyphens to build
+// the default URL path: a method `do_thing` is routed at `.../do-thing/`, not
+// `.../do_thing/`. See rest_framework.routers — the default url_path is
+// `replace(method_name, '_', '-')`. A name with no underscore passes through
+// unchanged.
+func drfDefaultActionSegment(methodName string) string {
+	return strings.ReplaceAll(methodName, "_", "-")
 }
 
 // emitViewSetMethodEntities emits synthetic SCOPE.Operation entities for each

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -153,7 +153,7 @@ class ContractViewSet(ModelViewSet):
 
 // TestApplyDjangoDRFRoutes_CollectionActionDefaultGet verifies that
 // @action(detail=False) (no methods kwarg) defaults to GET and uses the
-// method name as the URL path.
+// HYPHENATED method name as the URL path (DRF replaces `_`→`-`). #5230.
 func TestApplyDjangoDRFRoutes_CollectionActionDefaultGet(t *testing.T) {
 	files := fileMap{
 		"urls.py": `
@@ -174,7 +174,10 @@ class ContractViewSet(ModelViewSet):
 `,
 	}
 	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
-	assertHasAllIDs(t, got, []string{"http:GET:/contracts/get_extras"})
+	// DRF default url_path for a method `get_extras` is `get-extras`, not the
+	// raw `get_extras` (#5230).
+	assertHasAllIDs(t, got, []string{"http:GET:/contracts/get-extras"})
+	assertHasNoneIDs(t, got, []string{"http:GET:/contracts/get_extras"})
 }
 
 // TestApplyDjangoDRFRoutes_ActionMultipleMethods verifies that an action
@@ -203,6 +206,168 @@ class ContractViewSet(ModelViewSet):
 		"http:GET:/contracts/{pk}/assigned_contacts",
 		"http:PUT:/contracts/{pk}/assigned_contacts",
 	})
+}
+
+// TestApplyDjangoDRFRoutes_ActionNestedURLPathParams verifies #5230: an
+// @action(url_path='contacts/(?P<contact_id>[^/.]+)/remove') emits the route at
+// the VERBATIM url_path value (not the method name), with the nested
+// `(?P<contact_id>…)` capture group surfaced as a `{contact_id}` path param.
+func TestApplyDjangoDRFRoutes_ActionNestedURLPathParams(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import BranchViewSet
+
+router = routers.DefaultRouter()
+router.register(r"branches", BranchViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class BranchViewSet(ModelViewSet):
+    @action(detail=True, methods=["delete"], url_path='contacts/(?P<contact_id>[^/.]+)/remove')
+    def remove_contact(self, request, pk=None, contact_id=None):
+        pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+	// url_path used verbatim; (?P<contact_id>…) becomes {contact_id}; the method
+	// name `remove_contact` must NOT leak into the URL.
+	assertHasAllIDs(t, got, []string{
+		"http:DELETE:/branches/{pk}/contacts/{contact_id}/remove",
+	})
+	assertHasNoneIDs(t, got, []string{
+		"http:DELETE:/branches/{pk}/remove_contact",
+		"http:DELETE:/branches/{pk}/remove-contact",
+	})
+	// contact_id surfaces as a canonical path param in the emitted path.
+	if !strings.Contains(idsFromString(got, "http:DELETE:/branches/{pk}/contacts/{contact_id}/remove"), "{contact_id}") {
+		t.Errorf("expected {contact_id} path param in the action route path")
+	}
+}
+
+// TestApplyDjangoDRFRoutes_ActionDefaultHyphenatedSegment verifies #5230: an
+// @action with no url_path and a method name `do_thing` is routed at the
+// HYPHENATED `do-thing`, mirroring DRF's `_`→`-` default-url_path derivation.
+func TestApplyDjangoDRFRoutes_ActionDefaultHyphenatedSegment(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import WidgetViewSet
+
+router = routers.DefaultRouter()
+router.register(r"widgets", WidgetViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class WidgetViewSet(ModelViewSet):
+    @action(detail=False)
+    def do_thing(self, request):
+        pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+	assertHasAllIDs(t, got, []string{"http:GET:/widgets/do-thing"})
+	assertHasNoneIDs(t, got, []string{"http:GET:/widgets/do_thing"})
+}
+
+// TestApplyDjangoDRFRoutes_NestedRouterActionParams verifies #5230 composes
+// correctly with a drf-nested-routers parent prefix: a nested router mounted at
+// `companies/(?P<company_pk>\d+)/branches` plus an @action with its own nested
+// url_path surfaces BOTH the parent `{company_pk}` and the action's
+// `{contact_id}` path params in the same route.
+func TestApplyDjangoDRFRoutes_NestedRouterActionParams(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from rest_framework_nested import routers as nested_routers
+from views import CompanyViewSet, BranchViewSet
+
+router = routers.DefaultRouter()
+router.register(r"companies", CompanyViewSet)
+
+companies_router = nested_routers.NestedSimpleRouter(router, r"companies", lookup="company")
+companies_router.register(r"branches", BranchViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class CompanyViewSet(ModelViewSet):
+    pass
+
+class BranchViewSet(ModelViewSet):
+    @action(detail=True, methods=["delete"], url_path='contacts/(?P<contact_id>[^/.]+)/remove')
+    def remove_contact(self, request, company_pk=None, pk=None, contact_id=None):
+        pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+	// The nested router lookup="company" contributes the parent `{company}`
+	// placeholder; the action's url_path contributes `{contact_id}`. Both
+	// nested-prefix and action capture params survive into the same route (#5230).
+	assertHasAllIDs(t, got, []string{
+		"http:DELETE:/companies/{company}/branches/{pk}/contacts/{contact_id}/remove",
+	})
+}
+
+// TestApplyDjangoDRFRoutes_BranchViewSetRegression5230 is the #5230 regression
+// fixture: a BranchViewSet with three actions (a nested-url_path detail action,
+// a hyphenated-default detail action, and a hyphenated-default collection
+// action) must produce the exact expected URL set.
+func TestApplyDjangoDRFRoutes_BranchViewSetRegression5230(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import BranchViewSet
+
+router = routers.DefaultRouter()
+router.register(r"branches", BranchViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class BranchViewSet(ModelViewSet):
+    @action(detail=True, methods=["delete"], url_path='contacts/(?P<contact_id>[^/.]+)/remove')
+    def remove_contact(self, request, pk=None, contact_id=None):
+        pass
+
+    @action(detail=True, methods=["post"])
+    def set_director(self, request, pk=None):
+        pass
+
+    @action(detail=True, methods=["post"])
+    def clear_director(self, request, pk=None):
+        pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+	assertHasAllIDs(t, got, []string{
+		"http:DELETE:/branches/{pk}/contacts/{contact_id}/remove",
+		"http:POST:/branches/{pk}/set-director",
+		"http:POST:/branches/{pk}/clear-director",
+	})
+	// Raw underscore method names must NOT appear in any action URL.
+	assertHasNoneIDs(t, got, []string{
+		"http:DELETE:/branches/{pk}/remove_contact",
+		"http:POST:/branches/{pk}/set_director",
+		"http:POST:/branches/{pk}/clear_director",
+	})
+}
+
+// idsFromString returns the id from records that equals want, or "" if absent.
+// Helper for path-param substring assertions.
+func idsFromString(records []types.EntityRecord, want string) string {
+	for _, e := range records {
+		if e.ID == want {
+			return e.ID
+		}
+	}
+	return ""
 }
 
 // TestApplyDjangoDRFRoutes_LookupFieldOverride verifies that a ViewSet


### PR DESCRIPTION
## Problem (#5230)

DRF `@action`-decorated viewset methods derived their endpoint URL segment from the **raw Python method name** when no `url_path=` kwarg was present, leaking underscores into the URL (`do_thing` → `/do_thing`). DRF's router replaces `_`→`-` for the default url_path, so the route is actually served at `/do-thing`.

The `url_path=` verbatim path (incl. nested `(?P<name>regex)` capture groups) was already handled — `canonicalDjango`/`stripPythonNamedGroups` rewrites `(?P<contact_id>[^/.]+)` to `{contact_id}`. The remaining defect was purely the underscore fallback.

## Fix

`internal/engine/django_drf_actions.go` — in `emitActionRoutes`, when `url_path` is absent, derive the segment via the new `drfDefaultActionSegment` (`strings.ReplaceAll(name, "_", "-")`). Explicit `url_path` is still used verbatim.

## Correct DRF semantics implemented
1. `url_path='<value>'` present → segment = `<value>` verbatim, incl. `(?P<name>...)` → `{name}` path params.
2. No `url_path` → method name with `_`→`-` (`do_thing` → `do-thing`).
3. Full path = router `register(prefix)` + `{lookup}` (detail) + action segment.

## Tests (`internal/engine/django_drf_actions_test.go`)
1. nested `url_path='contacts/(?P<contact_id>[^/.]+)/remove'` → `.../{pk}/contacts/{contact_id}/remove` + `{contact_id}` param.
2. no `url_path`, `do_thing` → `/do-thing` (hyphenated, not underscore).
3. nested-router parent `{company}` + action `{contact_id}` both present in one route.
4. `BranchViewSet` 3-action regression fixture (`remove_contact` / `set_director` / `clear_director`).
5. Updated the prior test that codified the bug (`get_extras` → `get-extras`).

## Generalization
the rewrite target / Express / Spring derive route paths from explicit decorator/annotation string args, not method names; ASP.NET Core's `[action]` token substitution is verbatim (no `_`→`-`). The method-name URL derivation is DRF-specific — no other framework shares this defect.

## Gates
`go build ./...` clean · `go vet ./internal/engine/` clean · `gofmt -l` empty on touched files · full `internal/engine` + `internal/links` suites pass.

Closes #5230

🤖 Generated with [Claude Code](https://claude.com/claude-code)