### PR TITLE
perf(mem): zero-copy mmap in fbreader — eliminate the ~560MB graph heap copy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
+	golang.org/x/sys v0.44.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.81.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -81,7 +82,6 @@ require (
 	golang.org/x/image v0.40.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect

--- a/internal/graph/fbreader/mmap_unix.go
+++ b/internal/graph/fbreader/mmap_unix.go
@@ -1,0 +1,65 @@
+//go:build darwin || linux
+
+package fbreader
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// mmapRegion is a read-only memory mapping of a file. The data slice is a
+// page-cache-backed view: reading from it faults pages in lazily and costs
+// no heap. The mapping stays valid until unmap is called; FlatBuffer
+// accessors read lazily against data, so it must outlive every read.
+type mmapRegion struct {
+	data []byte
+}
+
+// mmapOpen memory-maps path read-only and returns a contiguous []byte view
+// of the whole file. No bytes are copied to the heap — the returned slice
+// aliases the page cache directly.
+func mmapOpen(path string) (*mmapRegion, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	// We can close the fd immediately: on Unix the mapping keeps its own
+	// reference to the underlying file, so the region stays valid after the
+	// descriptor is gone.
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := fi.Size()
+	if size == 0 {
+		return nil, fmt.Errorf("fbreader: %s is empty", path)
+	}
+	if int64(int(size)) != size {
+		return nil, fmt.Errorf("fbreader: %s too large to mmap on this platform (%d bytes)", path, size)
+	}
+
+	data, err := unix.Mmap(int(f.Fd()), 0, int(size), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("fbreader: mmap %s: %w", path, err)
+	}
+	return &mmapRegion{data: data}, nil
+}
+
+// bytes returns the contiguous file view. The slice is valid only until
+// unmap is called.
+func (m *mmapRegion) bytes() []byte { return m.data }
+
+// unmap releases the mapping. After it returns, the slice from bytes() must
+// not be touched.
+func (m *mmapRegion) unmap() error {
+	if m == nil || m.data == nil {
+		return nil
+	}
+	err := unix.Munmap(m.data)
+	m.data = nil
+	return err
+}

--- a/internal/graph/fbreader/mmap_windows.go
+++ b/internal/graph/fbreader/mmap_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package fbreader
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// mmapRegion is a read-only memory mapping of a file. The data slice is a
+// page-cache-backed view: reading from it faults pages in lazily and costs
+// no heap. The mapping stays valid until unmap is called; FlatBuffer
+// accessors read lazily against data, so it must outlive every read.
+type mmapRegion struct {
+	data    []byte
+	mapping windows.Handle
+	addr    uintptr
+}
+
+// mmapOpen memory-maps path read-only and returns a contiguous []byte view
+// of the whole file. No bytes are copied to the heap — the returned slice
+// aliases the mapped view directly.
+func mmapOpen(path string) (*mmapRegion, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	size := fi.Size()
+	if size == 0 {
+		return nil, fmt.Errorf("fbreader: %s is empty", path)
+	}
+	if int64(int(size)) != size {
+		return nil, fmt.Errorf("fbreader: %s too large to mmap on this platform (%d bytes)", path, size)
+	}
+
+	// CreateFileMapping with maxsize 0 sizes the mapping to the whole file.
+	mapping, err := windows.CreateFileMapping(
+		windows.Handle(f.Fd()),
+		nil,
+		windows.PAGE_READONLY,
+		0, 0,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fbreader: CreateFileMapping %s: %w", path, err)
+	}
+
+	addr, err := windows.MapViewOfFile(
+		mapping,
+		windows.FILE_MAP_READ,
+		0, 0,
+		uintptr(size),
+	)
+	if err != nil {
+		windows.CloseHandle(mapping)
+		return nil, fmt.Errorf("fbreader: MapViewOfFile %s: %w", path, err)
+	}
+
+	data := unsafe.Slice((*byte)(unsafe.Pointer(addr)), int(size))
+	return &mmapRegion{data: data, mapping: mapping, addr: addr}, nil
+}
+
+// bytes returns the contiguous file view. The slice is valid only until
+// unmap is called.
+func (m *mmapRegion) bytes() []byte { return m.data }
+
+// unmap releases the mapped view and closes the mapping handle. After it
+// returns, the slice from bytes() must not be touched.
+func (m *mmapRegion) unmap() error {
+	if m == nil || m.data == nil {
+		return nil
+	}
+	var firstErr error
+	if err := windows.UnmapViewOfFile(m.addr); err != nil {
+		firstErr = err
+	}
+	if err := windows.CloseHandle(m.mapping); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	m.data = nil
+	m.addr = 0
+	m.mapping = 0
+	return firstErr
+}

--- a/internal/graph/fbreader/reader.go
+++ b/internal/graph/fbreader/reader.go
@@ -12,45 +12,46 @@ package fbreader
 import (
 	"fmt"
 
-	"golang.org/x/exp/mmap"
-
 	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
 )
 
 // Reader holds an mmap'd graph.fb plus a parsed root view. The zero
 // value is not usable; call Open.
+//
+// The FlatBuffer root and every accessor obtained from it read lazily
+// against the mmap region's bytes. That region — and therefore any
+// []byte/string view a caller pulls out of an Entity/Relationship — is
+// only valid until Close is called. Callers must not retain such views
+// past Close (the daemon caches the Reader and drops it on
+// invalidateAfterIndex, which is the correct lifetime boundary).
 type Reader struct {
-	ra    *mmap.ReaderAt
-	buf   []byte
-	root  *fb.Graph
-	nEnts int
-	nRels int
+	region *mmapRegion
+	root   *fb.Graph
+	nEnts  int
+	nRels  int
 }
 
 // Open memory-maps graphFB and returns a Reader. Close releases the
 // mapping; the caller is responsible for invoking it.
+//
+// The file is mapped as a contiguous, read-only, page-cache-backed view
+// (no heap copy of the graph bytes). The FlatBuffer root is parsed
+// directly against that view, so individual fields are decoded on demand
+// without ever materialising the full file on the heap.
 func Open(path string) (*Reader, error) {
-	ra, err := mmap.Open(path)
+	region, err := mmapOpen(path)
 	if err != nil {
-		return nil, fmt.Errorf("fbreader: mmap %s: %w", path, err)
+		return nil, err
 	}
+	buf := region.bytes()
 	// Guard against truncated or malformed files: a valid FlatBuffer needs
 	// at least a 4-byte root-table offset followed by a 4-byte vtable offset.
 	// Without this check, GetRootAsGraph panics on short buffers and the
 	// mmap is leaked — on Windows this prevents the test's t.TempDir cleanup
 	// from removing the file (issue surfaced by TestStatusGraphFileDetection).
-	if ra.Len() < 8 {
-		ra.Close()
-		return nil, fmt.Errorf("fbreader: %s too short to be a flatbuffer (%d bytes)", path, ra.Len())
-	}
-	// FlatBuffers needs a contiguous []byte. mmap.ReaderAt does not expose
-	// the slice directly, so we read into a single allocation. This is
-	// O(N) but a single bulk memcpy from the page cache; the win comes
-	// from skipping JSON parse, not from skipping the read itself.
-	buf := make([]byte, ra.Len())
-	if _, err := ra.ReadAt(buf, 0); err != nil {
-		ra.Close()
-		return nil, fmt.Errorf("fbreader: read mmap: %w", err)
+	if len(buf) < 8 {
+		_ = region.unmap()
+		return nil, fmt.Errorf("fbreader: %s too short to be a flatbuffer (%d bytes)", path, len(buf))
 	}
 	// Belt-and-suspenders: catch any residual panic from FlatBuffer parsing
 	// of a malformed but length-passing buffer, and free the mmap before
@@ -60,26 +61,29 @@ func Open(path string) (*Reader, error) {
 	// be invalid).
 	defer func() {
 		if r := recover(); r != nil {
-			ra.Close()
+			_ = region.unmap()
 			panic(r)
 		}
 	}()
 	root := fb.GetRootAsGraph(buf, 0)
 	return &Reader{
-		ra:    ra,
-		buf:   buf,
-		root:  root,
-		nEnts: root.EntitiesLength(),
-		nRels: root.RelationshipsLength(),
+		region: region,
+		root:   root,
+		nEnts:  root.EntitiesLength(),
+		nRels:  root.RelationshipsLength(),
 	}, nil
 }
 
-// Close releases the underlying mmap.
+// Close releases the underlying mmap. After Close returns, no field or
+// string previously read from this Reader (or from any Entity/Relationship
+// it produced) may be accessed — the backing memory is unmapped.
 func (r *Reader) Close() error {
-	if r == nil || r.ra == nil {
+	if r == nil || r.region == nil {
 		return nil
 	}
-	return r.ra.Close()
+	err := r.region.unmap()
+	r.region = nil
+	return err
 }
 
 // Version returns the on-disk schema version (Graph.version).


### PR DESCRIPTION
## What

`fbreader.Open` mmap'd `graph.fb` via `golang.org/x/exp/mmap`, but because FlatBuffers needs a contiguous `[]byte` and `mmap.ReaderAt` does not expose its slice, it allocated a heap buffer the size of the **entire file** and `ReadAt`-copied every byte into it:

```go
buf := make([]byte, ra.Len())   // heap alloc of the FULL file
ra.ReadAt(buf, 0)               // page cache → heap copy
root := fb.GetRootAsGraph(buf, 0)
```

For the v3 backend repo (333MB) + archigraph (230MB) that is **~560MB of resident heap that is just graph bytes** — the mmap saved nothing.

## Fix

Replace the copy with a real read-only memory map that returns a contiguous, **page-cache-backed `[]byte` view** of the file, handed directly to `fb.GetRootAsGraph`. FlatBuffer accessors read lazily against the view; no graph bytes ever land on the heap.

- **Cross-platform**, build-tagged helpers (`mmap_unix.go` / `mmap_windows.go`):
  - darwin/linux: `unix.Mmap(PROT_READ, MAP_SHARED)` / `unix.Munmap`
  - windows: `CreateFileMapping(PAGE_READONLY)` + `MapViewOfFile` / `UnmapViewOfFile` + `CloseHandle`
- **Lifetime**: the `Reader` owns the mapping; `Close()` unmaps it. The view (and any `[]byte`/string a caller pulls from an `Entity`/`Relationship`) is valid only until `Close` — now documented on `Reader`/`Open`/`Close`. The daemon caches the Reader and drops it on `invalidateAfterIndex`, the correct boundary.
- Preserved the **`<8`-byte length guard** and the **panic-recovery defer** that unmaps before re-panicking on a malformed-but-length-passing buffer.
- Promoted `golang.org/x/sys` to a direct dependency (already vendored; `go.sum` untouched).

## Benchmark

`BenchmarkFBOpen`, 45MB synthetic fixture, darwin:

| | B/op | allocs/op | ns/op |
|---|---|---|---|
| before (heap copy) | 45,605,320 | 8 | ~5.7ms |
| after (zero-copy)  | 416 | 7 | ~0.11ms |

The full per-file heap copy is gone (B/op drops from filesize to near-zero) and `Open` is ~50x faster. At production scale this removes the ~560MB graph heap copy across the two cached readers.

## Gates

- `go build ./...` clean (darwin)
- `go vet ./internal/graph/...` clean
- `gofmt -l` empty on touched files
- `go test ./internal/graph/...` passes
- cross-compiles: `GOOS=linux go build ./internal/graph/fbreader/` and `GOOS=windows go build ./internal/graph/fbreader/`

Closes #5235

🤖 Generated with [Claude Code](https://claude.com/claude-code)