### PR TITLE
perf(mem+disk): GC disappeared refs/worktrees — reclaim store + resident graph

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -570,6 +570,13 @@ func runDaemon(argv []string) error {
 				mcpSrv.Stop()
 			}
 		},
+
+		// #5236: dead-ref / dead-worktree GC hooks. When a branch is deleted or
+		// a worktree removed, the reaper-driven sweep reclaims its store dir;
+		// these hooks also drop the cached mmap reader and the tier slot so the
+		// resident graph leaves memory.
+		DeadRefTier:       deadRefTierForgetter{},
+		DeadRefDropReader: deadRefDropReader,
 	}
 
 	ctx := context.Background()

--- a/cmd/grafel/daemon_tier.go
+++ b/cmd/grafel/daemon_tier.go
@@ -271,6 +271,26 @@ func tierTouchRepoRef(repoPath, ref string) error {
 	return daemonTierMgr.Touch(tier.SlotKey{RepoPath: repoPath, Ref: ref})
 }
 
+// deadRefTierForgetter adapts daemonTierMgr.ForgetRef to the
+// daemon.RefForgetter interface used by the dead-ref sweeper (#5236). It is a
+// zero-value struct so it can be wired before daemonTierMgr is constructed;
+// the nil check happens at call time.
+type deadRefTierForgetter struct{}
+
+func (deadRefTierForgetter) ForgetRef(repoPath, ref string) bool {
+	if daemonTierMgr == nil {
+		return false
+	}
+	return daemonTierMgr.ForgetRef(repoPath, ref)
+}
+
+// deadRefDropReader releases the cached mmap'd fbreader for a reaped
+// (repoPath, ref) so its resident graph leaves memory (#5236). Wired as the
+// dead-ref sweeper's DropReader hook.
+func deadRefDropReader(repoPath, ref string) {
+	daemonMCPCache.InvalidateForRepoRef(repoPath, ref)
+}
+
 // tierEvictCallback releases the in-memory graph for a WARM→COLD transition.
 func tierEvictCallback(key tier.SlotKey) {
 	// Invalidate the mmap'd fbreader in the MCP graph cache.

--- a/internal/daemon/deadref.go
+++ b/internal/daemon/deadref.go
@@ -1,0 +1,369 @@
+// deadref.go — dead-ref / dead-worktree store GC (issue #5236, epic #5234).
+//
+// # Problem
+//
+// The vanished-repo Reaper (reaper.go, #3680) only GCs whole REPOS whose
+// directory disappears from disk. It does NOT reclaim dead REFS *within* a
+// still-present repo. Every branch the rewrite agent ever indexed leaves a
+// `~/.grafel/store/<slug-hash>/refs/<ref-safe>/graph.fb` behind, and the tier
+// Manager keeps the matching in-memory slot. When the agent runs
+// `git branch -d X` or removes a worktree, that ref's bytes + resident graph
+// should be reclaimed — but nothing does it. On core-backend-v3 this grew to
+// 252 stored refs / 13GB.
+//
+// # Fix
+//
+// DeadRefSweeper reconciles, per still-present tracked repo, the set of STORED
+// refs (sub-directories under <repoBaseDir>/refs/) against the set of LIVE
+// refs reported by git (branches + tags + worktree-checked-out refs, plus the
+// repo's primary/default branch). For any stored ref that git no longer knows
+// about it:
+//
+//  1. RemoveAll's the ref's store dir (refs/<ref-safe>/), reclaiming its bytes,
+//  2. drops the cached mmap reader (DropReader) so the resident graph for that
+//     ref is released,
+//  3. forgets the tier slot (ForgetRef) so it leaves the in-memory accounting.
+//
+// # Guards (do not over-delete)
+//
+//   - Primary/default ref (main/master/…) is NEVER reaped, even if git
+//     enumeration somehow omits it.
+//   - Grace window: a ref whose graph.fb was written within GraceWindow
+//     (default 24h) is kept, so an in-flight / just-finished index pass is
+//     never raced into deletion.
+//   - Fail-closed: if git ref enumeration fails for a repo, that repo is
+//     skipped entirely — nothing is reaped. A flaky/locked git can never cause
+//     a live ref's graph to be nuked.
+//   - The _unknown sentinel ref is never reaped (it is not a real branch).
+package daemon
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/gitmeta"
+)
+
+// RefForgetter is the narrow slice of tier.Manager the dead-ref sweeper needs:
+// drop the single slot for (repoPath, ref) from the in-memory accounting.
+// Implemented by *tier.Manager.ForgetRef.
+type RefForgetter interface {
+	ForgetRef(repoPath, ref string) bool
+}
+
+// DeadRefConfig wires the dead-ref / dead-worktree store sweep. All hooks are
+// optional except TrackedRepos and LiveRefs; a nil hook is simply skipped.
+type DeadRefConfig struct {
+	// TrackedRepos returns the absolute paths of repos the daemon tracks. Only
+	// still-present repos are swept (a vanished repo is handled wholesale by the
+	// Reaper). Required; nil makes the sweep a no-op.
+	TrackedRepos func() []string
+
+	// LiveRefs returns the set of refs git currently knows about for repoPath —
+	// branches, tags, and refs checked out in linked worktrees — together with
+	// the repo's primary/default branch. The bool is the FAIL-CLOSED signal:
+	// false means git enumeration failed and the repo MUST be skipped (no ref
+	// reaped). Required; nil makes the sweep a no-op.
+	LiveRefs func(repoPath string) (refs map[string]struct{}, ok bool)
+
+	// PrimaryRef returns the repo's primary/default ref (e.g. "main"). It is
+	// never reaped regardless of LiveRefs. nil → no extra primary guard beyond
+	// whatever LiveRefs already includes.
+	PrimaryRef func(repoPath string) string
+
+	// RefsDirForRepo returns <repoBaseDir>/refs for repoPath — the directory
+	// whose immediate sub-directories are the stored refs (ref-safe encoded).
+	// Required; nil makes the sweep a no-op.
+	RefsDirForRepo func(repoPath string) string
+
+	// DropReader, when non-nil, releases the cached mmap'd fbreader for a reaped
+	// (repoPath, ref) so the resident graph leaves memory. Wired to the MCP
+	// graph cache's per-ref invalidation in production.
+	DropReader func(repoPath, ref string)
+
+	// Tier, when non-nil, has ForgetRef(repoPath, ref) called for every reaped
+	// ref so its slot leaves the in-memory tier accounting.
+	Tier RefForgetter
+
+	// GraceWindow protects a ref whose graph.fb mtime is newer than now-grace
+	// from being reaped, avoiding races with in-flight indexing. Default (zero):
+	// 24h. A negative value disables the grace guard (tests).
+	GraceWindow time.Duration
+
+	// Now returns the current time; nil → time.Now. Injected in tests.
+	Now func() time.Time
+
+	// Logger for sweep diagnostics. nil → the sweeper inherits the reaper's.
+	Logger *slog.Logger
+}
+
+// DeadRefResult summarises one dead-ref sweep.
+type DeadRefResult struct {
+	// ReposScanned is the number of still-present tracked repos inspected.
+	ReposScanned int
+	// ReposSkipped is the number of repos skipped because git ref enumeration
+	// failed (fail-closed) or had no refs/ store dir.
+	ReposSkipped int
+	// RefsReaped is the number of stored refs whose dir was removed.
+	RefsReaped int
+	// SlotsForgotten is the number of tier slots dropped.
+	SlotsForgotten int
+	// FreedBytes is the total bytes reclaimed from deleted ref store dirs.
+	FreedBytes int64
+}
+
+// DeadRefSweeper reclaims store dirs + resident graphs for refs/worktrees that
+// git no longer knows about, within still-present repos.
+type DeadRefSweeper struct {
+	cfg    DeadRefConfig
+	logger *slog.Logger
+}
+
+// NewDeadRefSweeper constructs a DeadRefSweeper. Call Sweep directly (the
+// Reaper drives it on the shared cadence) or in tests.
+func NewDeadRefSweeper(cfg DeadRefConfig) *DeadRefSweeper {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "deadref")
+	}
+	if cfg.GraceWindow == 0 {
+		cfg.GraceWindow = 24 * time.Hour
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &DeadRefSweeper{cfg: cfg, logger: logger}
+}
+
+// Sweep runs one reconciliation pass synchronously and returns what it reaped.
+func (s *DeadRefSweeper) Sweep() DeadRefResult {
+	var res DeadRefResult
+	if s.cfg.TrackedRepos == nil || s.cfg.LiveRefs == nil || s.cfg.RefsDirForRepo == nil {
+		return res
+	}
+	for _, repo := range s.cfg.TrackedRepos() {
+		if repo == "" {
+			continue
+		}
+		// Only sweep repos still present on disk; vanished repos are GCed
+		// wholesale by the Reaper.
+		if !repoExists(repo) {
+			continue
+		}
+		s.sweepRepo(repo, &res)
+	}
+	if res.RefsReaped > 0 {
+		s.logger.Info("deadref: sweep complete",
+			"repos_scanned", res.ReposScanned,
+			"repos_skipped", res.ReposSkipped,
+			"refs_reaped", res.RefsReaped,
+			"slots_forgotten", res.SlotsForgotten,
+			"freed_bytes", res.FreedBytes)
+	}
+	return res
+}
+
+// sweepRepo reconciles one still-present repo's stored refs against git.
+func (s *DeadRefSweeper) sweepRepo(repo string, res *DeadRefResult) {
+	refsDir := s.cfg.RefsDirForRepo(repo)
+	if refsDir == "" {
+		res.ReposSkipped++
+		return
+	}
+	stored, err := os.ReadDir(refsDir)
+	if err != nil {
+		// No refs/ dir yet (repo not indexed) or unreadable — nothing to do.
+		res.ReposSkipped++
+		return
+	}
+
+	// FAIL-CLOSED: if git enumeration fails, skip the whole repo.
+	live, ok := s.cfg.LiveRefs(repo)
+	if !ok {
+		s.logger.Warn("deadref: git ref enumeration failed — skipping repo (fail-closed)", "repo", repo)
+		res.ReposSkipped++
+		return
+	}
+	res.ReposScanned++
+
+	// Primary/default ref is never reaped.
+	var primary string
+	if s.cfg.PrimaryRef != nil {
+		primary = s.cfg.PrimaryRef(repo)
+	}
+
+	graceCutoff := s.cfg.Now().Add(-s.cfg.GraceWindow)
+
+	for _, e := range stored {
+		if !e.IsDir() {
+			continue
+		}
+		refSafe := e.Name()
+		if refSafe == "_unknown" {
+			continue // sentinel — not a real branch.
+		}
+		ref := RefSafeDecode(refSafe)
+
+		// Guard: primary ref.
+		if ref != "" && ref == primary {
+			continue
+		}
+		// Guard: still a live ref/tag/worktree-checked-out ref.
+		if _, alive := live[ref]; alive {
+			continue
+		}
+		refDir := filepath.Join(refsDir, refSafe)
+		// Guard: grace window — keep recently-indexed refs.
+		if s.cfg.GraceWindow >= 0 && recentlyIndexed(refDir, graceCutoff) {
+			s.logger.Info("deadref: ref dead in git but recently indexed — keeping (grace window)", "repo", repo, "ref", ref)
+			continue
+		}
+
+		// Reap: remove store dir, drop reader, forget slot.
+		sz, rmErr := s.removeRefStore(refDir)
+		if rmErr != nil {
+			s.logger.Warn("deadref: ref store removal failed (non-fatal)", "repo", repo, "ref", ref, "dir", refDir, "err", rmErr)
+			continue
+		}
+		res.RefsReaped++
+		if sz > 0 {
+			res.FreedBytes += sz
+		}
+		s.logger.Info("deadref: reaped dead ref", "repo", repo, "ref", ref, "dir", refDir, "freed_bytes", sz)
+
+		if s.cfg.DropReader != nil {
+			s.cfg.DropReader(repo, ref)
+		}
+		if s.cfg.Tier != nil && s.cfg.Tier.ForgetRef(repo, ref) {
+			res.SlotsForgotten++
+		}
+	}
+}
+
+// recentlyIndexed reports whether the ref dir holds a graph.fb (or graph.json)
+// whose mtime is at/after cutoff — i.e. it was indexed inside the grace window.
+// A missing graph file is treated as NOT recent (eligible for reaping).
+func recentlyIndexed(refDir string, cutoff time.Time) bool {
+	for _, name := range []string{"graph.fb", "graph.json"} {
+		fi, err := os.Stat(filepath.Join(refDir, name))
+		if err != nil {
+			continue
+		}
+		if !fi.ModTime().Before(cutoff) {
+			return true
+		}
+	}
+	return false
+}
+
+// LiveGitRefs is the production LiveRefs enumerator (#5236). It returns the set
+// of refs git currently knows about for repoPath — local branches, tags, and
+// the branches checked out in any linked worktree — together with the repo's
+// primary/default branch.
+//
+// FAIL-CLOSED contract: the bool is false when git enumeration cannot be
+// trusted (repoPath is not a git repo, or `for-each-ref` produced no output and
+// the repo is unreadable). The caller MUST skip the repo on false so a flaky or
+// locked git can never strand a live ref into deletion. We treat a non-git path
+// and an empty top-level as failure; a real repo with zero non-primary refs
+// still returns true (with the primary branch present).
+func LiveGitRefs(repoPath string) (map[string]struct{}, bool) {
+	// Sanity: must be a git work tree.
+	top := gitmeta.RunGit(repoPath, "rev-parse", "--show-toplevel")
+	if top == "" {
+		return nil, false
+	}
+
+	refs := make(map[string]struct{})
+
+	// Local branches + tags. (Remote-tracking refs are intentionally excluded:
+	// they are never indexed as their own slot.)
+	out := gitmeta.RunGit(repoPath, "for-each-ref", "--format=%(refname:short)",
+		"refs/heads", "refs/tags")
+	for _, line := range strings.Split(out, "\n") {
+		if r := strings.TrimSpace(line); r != "" {
+			refs[r] = struct{}{}
+		}
+	}
+
+	// Branches checked out in linked worktrees. `worktree list --porcelain`
+	// emits a `branch refs/heads/<name>` line per worktree.
+	wtOut := gitmeta.RunGit(repoPath, "worktree", "list", "--porcelain")
+	for _, line := range strings.Split(wtOut, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "branch ") {
+			b := strings.TrimPrefix(line, "branch ")
+			b = strings.TrimPrefix(b, "refs/heads/")
+			if b != "" {
+				refs[b] = struct{}{}
+			}
+		}
+	}
+
+	// Always keep HEAD's current ref and the primary/default branch.
+	if cur := gitmeta.RunGit(repoPath, "symbolic-ref", "--short", "HEAD"); cur != "" {
+		refs[cur] = struct{}{}
+	}
+	if p := PrimaryGitRef(repoPath); p != "" {
+		refs[p] = struct{}{}
+	}
+
+	return refs, true
+}
+
+// PrimaryGitRef returns the repo's primary/default branch ("" if undetermined).
+// Prefers origin/HEAD; falls back to the conventional names.
+func PrimaryGitRef(repoPath string) string {
+	if originHead := gitmeta.RunGit(repoPath, "symbolic-ref", "refs/remotes/origin/HEAD", "--short"); originHead != "" {
+		if parts := strings.SplitN(originHead, "/", 2); len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	cur := gitmeta.RunGit(repoPath, "symbolic-ref", "--short", "HEAD")
+	switch cur {
+	case "main", "master", "trunk":
+		return cur
+	}
+	// Probe for a conventional default even when HEAD is on a feature branch.
+	for _, name := range []string{"main", "master", "trunk"} {
+		if gitmeta.RunGit(repoPath, "rev-parse", "--verify", "--quiet", "refs/heads/"+name) != "" {
+			return name
+		}
+	}
+	return cur
+}
+
+// RefsDirForRepo returns <repoBaseDir>/refs for repoPath — the directory whose
+// immediate sub-dirs are the ref-safe-encoded stored refs. This mirrors the
+// store layout used by StateDirForRepoRef.
+func RefsDirForRepo(repoPath string) string {
+	if repoPath == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		abs = repoPath
+	}
+	abs = filepath.Clean(abs)
+	return filepath.Join(repoBaseDir(abs), "refs")
+}
+
+// removeRefStore deletes refDir and returns the bytes it freed. A non-existent
+// dir is not an error (returns 0 freed).
+func (s *DeadRefSweeper) removeRefStore(refDir string) (int64, error) {
+	sz, err := dirSizeHygiene(refDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		sz = 0
+	}
+	if rmErr := os.RemoveAll(refDir); rmErr != nil {
+		return 0, rmErr
+	}
+	return sz, nil
+}

--- a/internal/daemon/deadref_test.go
+++ b/internal/daemon/deadref_test.go
@@ -1,0 +1,255 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeRefForgetter records ForgetRef calls and reports which (repo,ref) pairs
+// it "holds" as in-memory slots.
+type fakeRefForgetter struct {
+	held      map[[2]string]bool
+	forgotten [][2]string
+}
+
+func (f *fakeRefForgetter) ForgetRef(repoPath, ref string) bool {
+	key := [2]string{repoPath, ref}
+	f.forgotten = append(f.forgotten, key)
+	if f.held[key] {
+		delete(f.held, key)
+		return true
+	}
+	return false
+}
+
+// writeRefStore creates <root>/refs/<refSafe>/graph.fb with `bytes` of content
+// and the given mtime, returning the ref dir.
+func writeRefStore(t *testing.T, refsRoot, refSafe string, bytes int, mtime time.Time) string {
+	t.Helper()
+	dir := filepath.Join(refsRoot, refSafe)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fb := filepath.Join(dir, "graph.fb")
+	if err := os.WriteFile(fb, make([]byte, bytes), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(fb, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// newSweeperFixture builds a sweeper over a single still-present repo whose
+// refs/ store dir lives under a temp dir. liveRefs/ok drive the injected
+// enumerator; primary is the protected default ref.
+func newSweeperFixture(t *testing.T, repo, refsRoot string, live map[string]struct{}, ok bool, primary string, ff *fakeRefForgetter, dropped *[][2]string) *DeadRefSweeper {
+	t.Helper()
+	return NewDeadRefSweeper(DeadRefConfig{
+		TrackedRepos:   func() []string { return []string{repo} },
+		LiveRefs:       func(string) (map[string]struct{}, bool) { return live, ok },
+		PrimaryRef:     func(string) string { return primary },
+		RefsDirForRepo: func(string) string { return refsRoot },
+		Tier:           ff,
+		DropReader: func(rp, ref string) {
+			*dropped = append(*dropped, [2]string{rp, ref})
+		},
+		// Disable the grace window in tests that don't exercise it.
+		GraceWindow: -1,
+		Now:         func() time.Time { return time.Unix(1_700_000_000, 0) },
+	})
+}
+
+// repo must exist on disk for the sweeper to inspect it.
+func mkLiveRepo(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestDeadRef_reapsRefAbsentFromGit: a stored ref that git no longer lists is
+// reaped — its store dir removed, DropReader + ForgetRef called.
+func TestDeadRef_reapsRefAbsentFromGit(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	old := time.Unix(1_600_000_000, 0)
+
+	writeRefStore(t, refsRoot, "main", 1000, old)
+	deadDir := writeRefStore(t, refsRoot, "feature%2Fgone", 4096, old)
+
+	ff := &fakeRefForgetter{held: map[[2]string]bool{
+		{repo, "feature/gone"}: true,
+	}}
+	var dropped [][2]string
+	// git reports only main as live.
+	live := map[string]struct{}{"main": {}}
+	s := newSweeperFixture(t, repo, refsRoot, live, true, "main", ff, &dropped)
+
+	res := s.Sweep()
+
+	if res.RefsReaped != 1 {
+		t.Fatalf("RefsReaped=%d want 1", res.RefsReaped)
+	}
+	if res.FreedBytes != 4096 {
+		t.Errorf("FreedBytes=%d want 4096", res.FreedBytes)
+	}
+	if _, err := os.Stat(deadDir); !os.IsNotExist(err) {
+		t.Errorf("dead ref store dir still present: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(refsRoot, "main")); err != nil {
+		t.Errorf("live ref store dir was removed: %v", err)
+	}
+	if len(dropped) != 1 || dropped[0] != [2]string{repo, "feature/gone"} {
+		t.Errorf("DropReader calls=%v want [{%s feature/gone}]", dropped, repo)
+	}
+	if res.SlotsForgotten != 1 {
+		t.Errorf("SlotsForgotten=%d want 1", res.SlotsForgotten)
+	}
+}
+
+// TestDeadRef_keepsPrimaryAndRecentlyIndexed: the primary ref is never reaped
+// even if git omits it, and a recently-indexed ref (within grace) is kept.
+func TestDeadRef_keepsPrimaryAndRecentlyIndexed(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	now := time.Unix(1_700_000_000, 0)
+
+	// Primary ref dir, indexed long ago — must survive purely on the primary guard.
+	writeRefStore(t, refsRoot, "main", 1000, now.Add(-100*time.Hour))
+	// A dead-in-git ref whose graph.fb is fresh (within 24h grace) — kept.
+	recentDir := writeRefStore(t, refsRoot, "wip", 2000, now.Add(-1*time.Hour))
+
+	ff := &fakeRefForgetter{held: map[[2]string]bool{}}
+	var dropped [][2]string
+	// git lists NOTHING (both refs absent) to prove the guards stand alone.
+	live := map[string]struct{}{}
+	s := NewDeadRefSweeper(DeadRefConfig{
+		TrackedRepos:   func() []string { return []string{repo} },
+		LiveRefs:       func(string) (map[string]struct{}, bool) { return live, true },
+		PrimaryRef:     func(string) string { return "main" },
+		RefsDirForRepo: func(string) string { return refsRoot },
+		Tier:           ff,
+		DropReader:     func(rp, ref string) { dropped = append(dropped, [2]string{rp, ref}) },
+		GraceWindow:    24 * time.Hour,
+		Now:            func() time.Time { return now },
+	})
+
+	res := s.Sweep()
+
+	if res.RefsReaped != 0 {
+		t.Fatalf("RefsReaped=%d want 0 (primary + grace guards)", res.RefsReaped)
+	}
+	if _, err := os.Stat(filepath.Join(refsRoot, "main")); err != nil {
+		t.Errorf("primary ref dir was reaped: %v", err)
+	}
+	if _, err := os.Stat(recentDir); err != nil {
+		t.Errorf("recently-indexed ref dir was reaped: %v", err)
+	}
+	if len(dropped) != 0 {
+		t.Errorf("DropReader called unexpectedly: %v", dropped)
+	}
+}
+
+// TestDeadRef_failClosedOnGitError: when git enumeration fails (ok=false) the
+// repo is skipped entirely and nothing is reaped.
+func TestDeadRef_failClosedOnGitError(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	old := time.Unix(1_600_000_000, 0)
+	deadDir := writeRefStore(t, refsRoot, "anything", 4096, old)
+
+	ff := &fakeRefForgetter{held: map[[2]string]bool{{repo, "anything"}: true}}
+	var dropped [][2]string
+	// ok=false → fail-closed.
+	s := newSweeperFixture(t, repo, refsRoot, nil, false, "main", ff, &dropped)
+
+	res := s.Sweep()
+
+	if res.RefsReaped != 0 {
+		t.Fatalf("RefsReaped=%d want 0 (fail-closed)", res.RefsReaped)
+	}
+	if res.ReposSkipped != 1 {
+		t.Errorf("ReposSkipped=%d want 1", res.ReposSkipped)
+	}
+	if _, err := os.Stat(deadDir); err != nil {
+		t.Errorf("fail-closed but ref dir was removed: %v", err)
+	}
+	if len(ff.forgotten) != 0 {
+		t.Errorf("ForgetRef called under fail-closed: %v", ff.forgotten)
+	}
+}
+
+// TestDeadRef_reapsRemovedWorktreeRef: a worktree's checked-out ref that is no
+// longer in the live set (worktree removed) gets reaped.
+func TestDeadRef_reapsRemovedWorktreeRef(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	old := time.Unix(1_600_000_000, 0)
+
+	writeRefStore(t, refsRoot, "main", 1000, old)
+	wtDir := writeRefStore(t, refsRoot, "agent-branch", 8192, old)
+
+	ff := &fakeRefForgetter{held: map[[2]string]bool{{repo, "agent-branch"}: true}}
+	var dropped [][2]string
+	// Worktree removed → its branch no longer enumerated; only main remains.
+	live := map[string]struct{}{"main": {}}
+	s := newSweeperFixture(t, repo, refsRoot, live, true, "main", ff, &dropped)
+
+	res := s.Sweep()
+
+	if res.RefsReaped != 1 {
+		t.Fatalf("RefsReaped=%d want 1", res.RefsReaped)
+	}
+	if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+		t.Errorf("removed-worktree ref dir still present: %v", err)
+	}
+	if res.FreedBytes != 8192 {
+		t.Errorf("FreedBytes=%d want 8192", res.FreedBytes)
+	}
+}
+
+// TestDeadRef_skipsUnknownSentinel: the _unknown sentinel dir is never reaped.
+func TestDeadRef_skipsUnknownSentinel(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	old := time.Unix(1_600_000_000, 0)
+	unknownDir := writeRefStore(t, refsRoot, "_unknown", 512, old)
+
+	ff := &fakeRefForgetter{held: map[[2]string]bool{}}
+	var dropped [][2]string
+	s := newSweeperFixture(t, repo, refsRoot, map[string]struct{}{}, true, "main", ff, &dropped)
+
+	res := s.Sweep()
+	if res.RefsReaped != 0 {
+		t.Fatalf("RefsReaped=%d want 0 (sentinel skipped)", res.RefsReaped)
+	}
+	if _, err := os.Stat(unknownDir); err != nil {
+		t.Errorf("_unknown sentinel dir was reaped: %v", err)
+	}
+}
+
+// TestDeadRef_reaperDrivesSweep: the Reaper invokes the dead-ref sweep on its
+// Sweep() and surfaces the result.
+func TestDeadRef_reaperDrivesSweep(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	old := time.Unix(1_600_000_000, 0)
+	writeRefStore(t, refsRoot, "main", 1000, old)
+	writeRefStore(t, refsRoot, "dead", 2048, old)
+
+	ff := &fakeRefForgetter{held: map[[2]string]bool{{repo, "dead"}: true}}
+	var dropped [][2]string
+	sweeper := newSweeperFixture(t, repo, refsRoot, map[string]struct{}{"main": {}}, true, "main", ff, &dropped)
+
+	r := NewReaper(ReaperConfig{DeadRefs: sweeper})
+	res := r.Sweep()
+
+	if res.DeadRefs.RefsReaped != 1 {
+		t.Fatalf("reaper-driven DeadRefs.RefsReaped=%d want 1", res.DeadRefs.RefsReaped)
+	}
+}

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -81,6 +81,12 @@ type ReaperConfig struct {
 	// orphaned watchers. nil → os.Getpid (the running daemon owns the sweep).
 	LiveDaemonPID func() int
 
+	// DeadRefs, when non-nil, is the dead-ref / dead-worktree store sweep
+	// (#5236). It reclaims store dirs + resident graphs for refs that git no
+	// longer knows about, within still-present repos. The Reaper drives it on
+	// the same cadence as the vanished-repo GC. nil disables it.
+	DeadRefs *DeadRefSweeper
+
 	// Interval between sweeps. Default (zero value): 5 minutes.
 	Interval time.Duration
 
@@ -101,6 +107,8 @@ type ReapResult struct {
 	// WatchersReaped is the number of stale/orphaned `grafel watch` PID
 	// registry entries reaped this sweep (#5142).
 	WatchersReaped int
+	// DeadRefs summarises the dead-ref / dead-worktree sub-sweep (#5236).
+	DeadRefs DeadRefResult
 }
 
 // Reaper periodically GCs stores for repos that no longer exist on disk.
@@ -153,6 +161,12 @@ func (r *Reaper) Sweep() ReapResult {
 	// #5142: reap stale/orphaned `grafel watch` PIDs. Independent of the
 	// vanished-repo GC below, so it runs even in configs without TrackedRepos.
 	res.WatchersReaped = r.sweepWatchers()
+	// #5236: dead-ref / dead-worktree sweep. Independent of the vanished-repo
+	// GC below; runs on the same cadence so a deleted branch's store + resident
+	// graph are reclaimed without a separate scheduler.
+	if r.cfg.DeadRefs != nil {
+		res.DeadRefs = r.cfg.DeadRefs.Sweep()
+	}
 	if r.cfg.TrackedRepos == nil {
 		return res
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -181,6 +181,18 @@ type Config struct {
 	// are logged but do not block shutdown. Injected from cmd/grafel to call
 	// the MCP server's Stop method (issue #2530).
 	ShutdownCleanup func()
+
+	// DeadRefTier, when non-nil, is the tier Manager's per-ref forget hook
+	// (#5236). The dead-ref sweeper calls it to drop the in-memory slot for a
+	// reaped ref. Injected from cmd/grafel (which owns daemonTierMgr).
+	DeadRefTier RefForgetter
+
+	// DeadRefDropReader, when non-nil, releases the cached mmap'd fbreader for a
+	// reaped (repoPath, ref) so the resident graph leaves memory (#5236).
+	// Injected from cmd/grafel to call the MCP graph cache's per-ref
+	// invalidation. nil leaves the on-disk delete to run without an explicit
+	// reader drop (the cache ages out on its own).
+	DeadRefDropReader func(repoPath, ref string)
 }
 
 // Run starts the daemon. It blocks until either:
@@ -453,8 +465,21 @@ func Run(ctx context.Context, cfg Config) error {
 			// disk have their store dir deleted and their fsnotify
 			// subscription dropped, reclaiming the orphaned ~100MB worktree
 			// stores that accumulated under ~/.grafel/store/.
+			trackedRepos := makeReaperTrackedRepos(cfg.ReposToWatch, wtStore)
+			// #5236: dead-ref / dead-worktree sweep. Reclaims store dirs +
+			// resident graphs for refs git no longer knows about, within
+			// still-present repos. Driven by the reaper on the shared cadence.
+			deadRefSweeper := NewDeadRefSweeper(DeadRefConfig{
+				TrackedRepos:   trackedRepos,
+				LiveRefs:       LiveGitRefs,
+				PrimaryRef:     PrimaryGitRef,
+				RefsDirForRepo: RefsDirForRepo,
+				DropReader:     cfg.DeadRefDropReader,
+				Tier:           cfg.DeadRefTier,
+				Logger:         logger,
+			})
 			reaper := NewReaper(ReaperConfig{
-				TrackedRepos:    makeReaperTrackedRepos(cfg.ReposToWatch, wtStore),
+				TrackedRepos:    trackedRepos,
 				StoreDirForRepo: repoBaseDir,
 				Untrack: func(repoPath string) {
 					watcher.RemoveRepo(repoPath)
@@ -462,6 +487,7 @@ func Run(ctx context.Context, cfg Config) error {
 				// #5142: also reap stale/orphaned `grafel watch` PIDs that
 				// registered in the daemon-owned registry under the daemon root.
 				WatchRegistry: watchreg.New(watchreg.DefaultPath(cfg.Layout.Root)),
+				DeadRefs:      deadRefSweeper,
 				Logger:        logger,
 			})
 			reaperStop := make(chan struct{})

--- a/internal/daemon/tier/tier.go
+++ b/internal/daemon/tier/tier.go
@@ -492,6 +492,25 @@ func (m *Manager) Forget(repoPath string) int {
 	return n
 }
 
+// ForgetRef removes the single slot for (repoPath, ref) from the Manager,
+// dropping it from the in-memory accounting WITHOUT firing eviction/disk
+// callbacks. It is the tier-side half of the dead-ref reaper (issue #5236):
+// once a branch is deleted or a worktree is removed, its stored ref must be
+// untracked so the Manager stops counting it toward pressure and stops
+// attempting cold-wakes against a ref that is gone. The on-disk store dir and
+// the cached mmap reader are released separately by the dead-ref sweeper.
+// Returns true when a slot was actually present and removed.
+func (m *Manager) ForgetRef(repoPath, ref string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := SlotKey{RepoPath: repoPath, Ref: ref}
+	if _, ok := m.slots[key]; !ok {
+		return false
+	}
+	delete(m.slots, key)
+	return true
+}
+
 // Len returns the number of slots currently tracked. Used by the reaper's
 // memory-accounting assertions and diagnostics.
 func (m *Manager) Len() int {

--- a/internal/daemon/tier/tier_test.go
+++ b/internal/daemon/tier/tier_test.go
@@ -452,3 +452,34 @@ func TestManager_Forget(t *testing.T) {
 		t.Fatalf("second Forget returned %d, want 0", n)
 	}
 }
+
+func TestManager_ForgetRef(t *testing.T) {
+	clock, _ := makeClock()
+	m := tier.NewManagerForTest(tier.DefaultTTLConfig(), clock, noopEvict, noopReload)
+
+	repo := "/repos/app"
+	m.Register(tier.SlotKey{RepoPath: repo, Ref: "main"}, true, tier.SlotKindBranchMain)
+	m.Register(tier.SlotKey{RepoPath: repo, Ref: "feat/x"}, false, tier.SlotKindBranchFeature)
+
+	if got := m.Len(); got != 2 {
+		t.Fatalf("Len before = %d, want 2", got)
+	}
+
+	// Forget a single ref: only that slot is dropped.
+	if !m.ForgetRef(repo, "feat/x") {
+		t.Fatalf("ForgetRef(feat/x) = false, want true")
+	}
+	if got := m.Len(); got != 1 {
+		t.Fatalf("Len after = %d, want 1", got)
+	}
+	if m.Get(tier.SlotKey{RepoPath: repo, Ref: "main"}) != tier.TierHot {
+		t.Fatalf("main slot wrongly dropped by ForgetRef")
+	}
+	// Idempotent / unknown ref: returns false.
+	if m.ForgetRef(repo, "feat/x") {
+		t.Fatalf("second ForgetRef returned true, want false")
+	}
+	if m.ForgetRef(repo, "never-registered") {
+		t.Fatalf("ForgetRef of unknown ref returned true, want false")
+	}
+}


### PR DESCRIPTION
## Problem (#5236, epic #5234)

The #3680 reaper only GCs whole **vanished repos**. Dead **refs within a live repo** — a branch a concurrent agent deleted (`git branch -d X`) or a removed worktree — leaked forever: their `store/<repo-hash>/refs/<ref-safe>/graph.fb` dirs accumulated (**252 stored refs / 13GB** on the v3 backend repo) and their in-memory tier slots + mmap'd readers were never released.

## Fix

`DeadRefSweeper` (`internal/daemon/deadref.go`), driven by the existing reaper on the **same 5m cadence** (no separate scheduler). Per still-present tracked repo it reconciles:

- **STORED refs** — immediate sub-dirs of `<repoBaseDir>/refs/` (ref-safe encoded).
- **LIVE refs** — `git for-each-ref --format=%(refname:short) refs/heads refs/tags` + `git worktree list --porcelain` (`branch refs/heads/<x>` lines) + current `HEAD` + the primary/default branch.

Any stored ref git no longer knows about is reaped: `os.RemoveAll` its dir, drop the cached reader (`Cache.InvalidateForRepoRef`), and forget the tier slot (new `tier.Manager.ForgetRef`).

### Guards (don't over-delete)
- **Primary/default ref never reaped** — even if git enumeration omits it (`PrimaryGitRef` prefers `origin/HEAD`, falls back to main/master/trunk).
- **24h grace window** keyed off `graph.fb` mtime — a just-/in-flight-indexed ref is kept (configurable; negative disables).
- **Fail-closed** — if git ref enumeration fails, the whole repo is skipped and nothing is reaped.
- **`_unknown` sentinel** skipped (not a real branch).

## Tests (`deadref_test.go`, `tier_test.go`)
- ref absent from git → reaped (dir removed, DropReader + ForgetRef called, bytes freed)
- primary ref + recently-indexed ref → NOT reaped (guards stand alone even when git lists nothing)
- git enumeration error → nothing reaped, repo skipped (fail-closed)
- removed-worktree ref → reaped
- `_unknown` sentinel → skipped
- reaper drives the sweep and surfaces the result
- `tier.Manager.ForgetRef` drops one slot, idempotent, unknown-ref → false

## Gates (sandbox)
`go build ./...` clean · `go vet ./internal/daemon/...` clean · `gofmt -l` empty on touched · `go test ./internal/daemon/` + `./internal/daemon/tier/` pass. (Pre-existing `service` plist tests fail only because `GRAFEL_TEST_REQUIRE_ISOLATED_HOME` blanks `$HOME`; they pass with a real HOME and are unrelated.)

Closes #5236

🤖 Generated with [Claude Code](https://claude.com/claude-code)