### PR TITLE
ci(fix): acceptance.yml Windows ARCHIVE path (MSYS→Windows) so the install step resolves

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -152,7 +152,14 @@ jobs:
             echo "asset not ready yet (attempt $i); sleeping 20s"; sleep 20
           done
           test -f "artifact/$NAME" || { echo "FAIL: release asset $NAME not found"; exit 1; }
-          echo "ARCHIVE=$PWD/artifact/$NAME" >> "$GITHUB_ENV"
+          # Same MSYS→pwsh handoff as the dispatch build step: this bash step is
+          # MSYS on Windows so $PWD is /d/a/...; the pwsh "Install (windows)" step
+          # needs a native D:\a\... path. Convert on Windows, leave unix as-is.
+          ARCHIVE_PATH="$PWD/artifact/$NAME"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            ARCHIVE_PATH="$(cygpath -w "$ARCHIVE_PATH")"
+          fi
+          echo "ARCHIVE=${ARCHIVE_PATH}" >> "$GITHUB_ENV"
 
       # ── 1b. On manual dispatch (no release): build the binary locally ───────
       # Build the dashboard SPA first so the embed is the real UI (mirrors
@@ -231,7 +238,16 @@ jobs:
             NAME="grafel_dispatch_${{ steps.arch.outputs.os }}_${{ steps.arch.outputs.arch }}.tar.gz"
             (cd dist && tar czf "../artifact/${NAME}" grafel LICENSE README.md)
           fi
-          echo "ARCHIVE=$PWD/artifact/${NAME}" >> "$GITHUB_ENV"
+          # This bash step runs under MSYS on the Windows runner, so $PWD is a
+          # POSIX path (/d/a/grafel/grafel). The "Install (windows)" step that
+          # consumes ARCHIVE runs in pwsh, which cannot resolve a /d/a/... path
+          # (Expand-Archive fails). Convert to a native Windows path (D:\a\...)
+          # via cygpath on Windows; leave unix paths untouched.
+          ARCHIVE_PATH="$PWD/artifact/${NAME}"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            ARCHIVE_PATH="$(cygpath -w "$ARCHIVE_PATH")"
+          fi
+          echo "ARCHIVE=${ARCHIVE_PATH}" >> "$GITHUB_ENV"
 
       # ── 2. Install the artifact the way a user does (unix) ──────────────────
       # Extract into the real install prefix ($HOME/.grafel/bin) and add it to


### PR DESCRIPTION
## Problem

Dispatch run **27639824035** failed in the Windows `Install (windows)` step:

```
Expand-Archive -Path $env:ARCHIVE ...
The path '/d/a/grafel/grafel/artifact/grafel_dispatch_windows_x86_64.zip' does not exist or is not a valid file system path
```

The bash steps that export `ARCHIVE` to `$GITHUB_ENV` run under **MSYS** on the Windows runner, so `$PWD` is a POSIX path (`/d/a/grafel/grafel/...`). The consuming `Install (windows)` step runs in **pwsh**, which cannot resolve a `/d/a/...` path → exit 1. Linux + macOS jobs passed fully (this is Windows-only).

## Fix

Convert `ARCHIVE` to a native Windows path with `cygpath -w` in the `windows-latest` branch of **both** producer steps before writing `$GITHUB_ENV`:

- `Download released archive (release tags only)` — the `push`/tag path
- `Build grafel + package archive (local build)` — the `workflow_dispatch` path

Unix paths are left untouched, so Linux/macOS steps are unchanged.

## Full bash↔pwsh path audit (windows job)

`ARCHIVE` is the **only** filesystem path that crosses from a bash/MSYS step into a pwsh step. Verified the rest:

- `GRAFEL_PREFIX` is written *by pwsh* (`Join-Path $env:USERPROFILE`) → already native.
- All Integrity / Uninstall windows steps build paths purely in pwsh via `Join-Path` → no bash-produced paths consumed.
- `CGO_ENABLED` / `CC` are env values, not paths.

YAML validated: `ruby -ryaml` loads all workflows OK.

Refs #5226 #4457

🤖 Generated with [Claude Code](https://claude.com/claude-code)