### PR TITLE
perf(mem): tighter GOMEMLIMIT default (cap fraction-of-RAM) + surface active limit

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -372,6 +372,17 @@ func printIndexingModes(w io.Writer) {
 		statusOK, onOff(incremental))
 	fmt.Fprintf(w, "%s subprocess indexer: %s (GRAFEL_SUBPROCESS_INDEXER; default off)\n",
 		statusOK, onOff(subprocess))
+
+	// Go soft memory limit (#5237). Report the resolved limit + where it
+	// came from so operators can see whether GOMEMLIMIT / the env override /
+	// the fraction-of-RAM default is in effect.
+	if mb, src := daemon.MemLimitSummary(); mb > 0 {
+		fmt.Fprintf(w, "%s go soft mem limit: %dMB (%s; GRAFEL_DAEMON_MEMLIMIT_MB)\n",
+			statusOK, mb, src)
+	} else {
+		fmt.Fprintf(w, "%s go soft mem limit: unbounded (%s; GRAFEL_DAEMON_MEMLIMIT_MB)\n",
+			statusOK, src)
+	}
 }
 
 func checkRepo(w io.Writer, r registry.Repo) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/client"
 	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
@@ -102,6 +103,13 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 				var ecfg *extractor.ExtractorConfig // nil → reads env
 				fmt.Fprintf(w, "  indexing: incremental=%s subprocess=%s\n",
 					onOff(ecfg.IsIncrementalEnabled()), onOff(sched.SubprocessIndexEnabled()))
+				// Go soft memory limit (#5237): show the resolved limit +
+				// source so operators can see what's bounding daemon RSS.
+				if mb, src := daemon.MemLimitSummary(); mb > 0 {
+					fmt.Fprintf(w, "  mem_limit: %dMB (%s)\n", mb, src)
+				} else {
+					fmt.Fprintf(w, "  mem_limit: unbounded (%s)\n", src)
+				}
 			}
 			if st.WatcherRepos > 0 || st.WatcherEvents > 0 {
 				fmt.Fprintf(w, "  watcher: repos=%d dirs=%d events=%d dropped=%d",

--- a/internal/daemon/memlimit.go
+++ b/internal/daemon/memlimit.go
@@ -17,35 +17,53 @@ import (
 const memLimitEnv = "GRAFEL_DAEMON_MEMLIMIT_MB"
 
 // memLimitFraction is the fraction of total system RAM used as the default
-// soft limit when the operator has not pinned a value via memLimitEnv. 0.75
-// leaves a quarter of RAM for the page cache, other processes, and the
-// kernel — conservative enough that on a 16GB host the daemon GCs hard
-// before it can balloon to the observed 10.2GB peak, but loose enough that a
-// single legitimate large reindex (peak heap ~1-1.5GB per job) is nowhere
-// near the limit and does not trigger GC thrash.
-const memLimitFraction = 0.75
+// soft limit when the operator has not pinned a value via memLimitEnv. 0.40
+// is deliberately conservative: the daemon is a background developer tool
+// that should leave the bulk of RAM for the editor, language servers,
+// browser, and the page cache. On an 8GB laptop this resolves to ~3.2GB
+// (then capped, see memLimitCeilingMB). The previous 0.75 fraction is what
+// let the runtime hoard a multi-GB reclaimable arena on big-RAM hosts —
+// measured live on a 64GB box, the old 12GB limit left ~1.5GB of
+// heap_released sitting idle. The cap (not the fraction) is what bites on
+// any reasonably large host; the fraction only governs small hosts, where
+// it backs off proportionally rather than pinning a large absolute value.
+const memLimitFraction = 0.40
+
+// memLimitCeilingMB caps the fraction-of-RAM result so a big-RAM host can
+// never hand the daemon a lax limit it will hoard against. Measured live:
+// pinning the limit at 1536MB dropped idle phys_footprint 2.6GB → 1.75GB
+// (heap_released 1571MB → 370MB), and a legitimate large reindex peaks at
+// ~1-1.5GB heap per job. 2560MB (2.5GB) sits comfortably above that working
+// set — and because the limit is SOFT, a job that briefly exceeds it just
+// makes Go GC harder rather than OOM-kill the indexer — while being tight
+// enough that the runtime promptly returns idle arena to the OS instead of
+// retaining it. This ceiling is the constraint that actually fires on any
+// host with more than ~6.25GB RAM (0.40 * 6.25GB ≈ 2.5GB).
+const memLimitCeilingMB int64 = 2560
 
 // memLimitFloorMB is the smallest soft limit we will ever apply. On a tiny
 // host (or when TotalMemoryMB returns 0) we must not set a limit so low that
 // a normal index would constantly hit it and thrash; 2GB is comfortably
-// above the per-job peak heap.
+// above the per-job peak heap. Note floor (2048) < ceiling (2560), so on
+// hosts between ~5GB and ~6.25GB RAM the resolved limit lands in that band
+// untouched by either clamp.
 const memLimitFloorMB int64 = 2048
 
 // applyMemoryLimit sets a conservative Go soft memory limit (GOMEMLIMIT) so
 // the runtime collects more aggressively as it nears the cap, bounding the
-// daemon's peak footprint (#3648).
+// daemon's peak footprint (#3648, tightened in #5237).
 //
 // Precedence:
 //  1. If the standard GOMEMLIMIT env var is already set, the Go runtime has
 //     already honored it — we do nothing and log that we deferred to it.
 //  2. GRAFEL_DAEMON_MEMLIMIT_MB (MB; "off"/"0"/negative disables).
-//  3. Default: memLimitFraction of total system RAM, floored at
-//     memLimitFloorMB. If total RAM is unknown (0), we fall back to the
-//     floor.
+//  3. Default: memLimitFraction of total system RAM, clamped to
+//     [memLimitFloorMB, memLimitCeilingMB]. If total RAM is unknown (0), we
+//     fall back to the floor.
 //
 // This is intentionally a soft limit: Go will exceed it transiently rather
 // than OOM-killing the indexer, it just GCs harder — so a legitimate heavy
-// reindex still completes, it simply doesn't get to retain a 10GB arena.
+// reindex still completes, it simply doesn't get to retain a multi-GB arena.
 func applyMemoryLimit(logger *slog.Logger) {
 	if logger == nil {
 		logger = slog.Default()
@@ -92,8 +110,40 @@ func resolveMemLimitMB() (int64, string) {
 		return memLimitFloorMB, "floor (system RAM unknown)"
 	}
 	limit := int64(float64(totalMB) * memLimitFraction)
+	// Cap first so a big-RAM host can't grant a lax limit, then floor so a
+	// tiny host isn't starved. Ceiling > floor, so the order is stable.
+	if limit > memLimitCeilingMB {
+		return memLimitCeilingMB, "fraction-of-RAM (capped)"
+	}
 	if limit < memLimitFloorMB {
-		limit = memLimitFloorMB
+		return memLimitFloorMB, "fraction-of-RAM (floored)"
 	}
 	return limit, "fraction-of-RAM"
+}
+
+// ResolveMemLimitMB exposes the resolved Go soft memory limit (in MB) and a
+// short source tag for operator-facing surfaces (grafel status / doctor).
+// A non-positive limit means the daemon-applied limit is disabled. This does
+// NOT account for an explicit GOMEMLIMIT env var, which takes precedence at
+// daemon startup; callers that want full fidelity should check GOMEMLIMIT
+// themselves (see MemLimitSummary).
+func ResolveMemLimitMB() (int64, string) {
+	return resolveMemLimitMB()
+}
+
+// MemLimitSummary returns the effective Go soft memory limit the daemon
+// would apply, honoring the same precedence as applyMemoryLimit:
+//
+//	explicit GOMEMLIMIT > GRAFEL_DAEMON_MEMLIMIT_MB > fraction-of-RAM default.
+//
+// It returns the limit in MB (<=0 means disabled / unbounded) and a short
+// source tag. When an explicit GOMEMLIMIT is set, mb is reported as 0 with
+// source "GOMEMLIMIT (runtime env)" because the raw value may carry a unit
+// suffix (e.g. "4GiB") that we do not parse here — the tag tells the operator
+// to read GOMEMLIMIT directly.
+func MemLimitSummary() (mb int64, source string) {
+	if v := os.Getenv("GOMEMLIMIT"); v != "" && v != "off" {
+		return 0, "GOMEMLIMIT=" + v + " (runtime env)"
+	}
+	return resolveMemLimitMB()
 }

--- a/internal/daemon/memlimit_test.go
+++ b/internal/daemon/memlimit_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"runtime/debug"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/process"
@@ -30,25 +31,90 @@ func TestResolveMemLimitMB_Disabled(t *testing.T) {
 	}
 }
 
-// TestResolveMemLimitMB_DefaultFractionOrFloor asserts the default is a
-// fraction of system RAM, never below the floor.
-func TestResolveMemLimitMB_DefaultFractionOrFloor(t *testing.T) {
+// TestResolveMemLimitMB_DefaultClamped asserts the default is a fraction of
+// system RAM, clamped into [floor, ceiling]. The ceiling is what bounds
+// big-RAM hosts (#5237); the floor protects tiny hosts.
+func TestResolveMemLimitMB_DefaultClamped(t *testing.T) {
 	t.Setenv(memLimitEnv, "") // ensure no override
 	mb, src := resolveMemLimitMB()
 	if mb < memLimitFloorMB {
 		t.Errorf("default limit %d below floor %d (src=%s)", mb, memLimitFloorMB, src)
 	}
-	// If the host reports total RAM, the default must be ~fraction of it
-	// (and at least the floor).
+	if mb > memLimitCeilingMB {
+		t.Errorf("default limit %d above ceiling %d (src=%s)", mb, memLimitCeilingMB, src)
+	}
+	// The default must equal the fraction-of-RAM value clamped into the band.
 	if total := process.TotalMemoryMB(); total > 0 {
 		want := int64(float64(total) * memLimitFraction)
+		if want > memLimitCeilingMB {
+			want = memLimitCeilingMB
+		}
 		if want < memLimitFloorMB {
 			want = memLimitFloorMB
 		}
 		if mb != want {
-			t.Errorf("default limit: want %d (%.0f%% of %dMB, floored) got %d",
-				want, memLimitFraction*100, total, mb)
+			t.Errorf("default limit: want %d (%.0f%% of %dMB, clamped to [%d,%d]) got %d",
+				want, memLimitFraction*100, total, memLimitFloorMB, memLimitCeilingMB, mb)
 		}
+	}
+}
+
+// TestMemLimitClampBoundaries verifies the cap + floor formula directly for
+// representative host sizes (8GB, 64GB, and a tiny host) independent of the
+// machine the test runs on. Mirrors resolveMemLimitMB's clamp logic.
+func TestMemLimitClampBoundaries(t *testing.T) {
+	clamp := func(totalMB int64) int64 {
+		limit := int64(float64(totalMB) * memLimitFraction)
+		if limit > memLimitCeilingMB {
+			return memLimitCeilingMB
+		}
+		if limit < memLimitFloorMB {
+			return memLimitFloorMB
+		}
+		return limit
+	}
+	cases := []struct {
+		name    string
+		totalMB int64
+		want    int64
+	}{
+		// 0.40*8192 = 3276 → capped to ceiling 2560.
+		{"8GB host capped", 8192, memLimitCeilingMB},
+		// 0.40*65536 = 26214 → capped to ceiling 2560.
+		{"64GB host capped", 65536, memLimitCeilingMB},
+		// 0.40*4096 = 1638 → below floor → floor 2048.
+		{"4GB host floored", 4096, memLimitFloorMB},
+		// 0.40*6144 = 2457 → inside [2048,2560] band, untouched.
+		{"6GB host in band", 6144, 2457},
+	}
+	for _, tc := range cases {
+		if got := clamp(tc.totalMB); got != tc.want {
+			t.Errorf("%s: clamp(%dMB)=%d want %d", tc.name, tc.totalMB, got, tc.want)
+		}
+	}
+}
+
+// TestMemLimitSummary_GoMemLimitWins asserts an explicit GOMEMLIMIT is
+// reported with the runtime-env source and takes precedence over the default.
+func TestMemLimitSummary_GoMemLimitWins(t *testing.T) {
+	t.Setenv(memLimitEnv, "")
+	t.Setenv("GOMEMLIMIT", "4GiB")
+	mb, src := MemLimitSummary()
+	if mb != 0 {
+		t.Errorf("GOMEMLIMIT set: want mb=0 (unparsed) got %d", mb)
+	}
+	if !strings.Contains(src, "GOMEMLIMIT") || !strings.Contains(src, "4GiB") {
+		t.Errorf("source %q should mention GOMEMLIMIT=4GiB", src)
+	}
+}
+
+// TestMemLimitSummary_EnvOverrideThenDefault asserts the override and default
+// flow through MemLimitSummary when no GOMEMLIMIT is set.
+func TestMemLimitSummary_EnvOverrideThenDefault(t *testing.T) {
+	t.Setenv("GOMEMLIMIT", "")
+	t.Setenv(memLimitEnv, "1536")
+	if mb, src := MemLimitSummary(); mb != 1536 || src != memLimitEnv {
+		t.Errorf("override via summary: got mb=%d src=%q want 1536 / %q", mb, src, memLimitEnv)
 	}
 }
 


### PR DESCRIPTION
## Problem
The daemon's Go soft memory limit defaulted to `0.75 * system RAM` with no absolute cap. On a 64GB dev box that resolved to **~12GB** — so lax the Go runtime hoarded ~1.5GB of reclaimable arena at idle (measured `heap_released` ~1571MB). Live test: pinning `GRAFEL_DAEMON_MEMLIMIT_MB=1536` dropped idle `phys_footprint` **2.6GB → 1.75GB** (`heap_released` 1571 → 370MB).

## Fix (#5237)
- **Lower `memLimitFraction` 0.75 → 0.40** — a background dev tool should leave the bulk of RAM for the editor/LSP/browser/page-cache.
- **Add `memLimitCeilingMB` = 2560 (2.5GB)** so a big-RAM host can never grant a lax limit. This cap is the clamp that fires on any host with >~6.25GB RAM. The limit is **soft**, so a heavy reindex (peak heap ~1–1.5GB/job) that briefly exceeds it just GCs harder — no OOM.
- Keep `memLimitFloorMB` = 2048 for tiny hosts; resolved limit is clamped into `[floor, ceiling]`.
- **Override precedence preserved:** explicit `GOMEMLIMIT` > `GRAFEL_DAEMON_MEMLIMIT_MB` > fraction-of-RAM default.

### What hosts resolve to now
| Host RAM | old (0.75, uncapped) | new (0.40, cap 2560) |
|---|---|---|
| 8GB  | 6144MB | **2560MB** (capped) |
| 64GB | 49152MB | **2560MB** (capped) |
| 4GB  | 3072MB | **2048MB** (floored) |
| 6GB  | 4608MB | 2457MB (in band) |

## Surfacing
New exported `daemon.MemLimitSummary()` / `daemon.ResolveMemLimitMB()`. Extended (not duplicated) the existing #5231 indexing-modes render:
- `grafel status` → `mem_limit: 2560MB (fraction-of-RAM (capped))`
- `grafel doctor` → `go soft mem limit: 2560MB (...; GRAFEL_DAEMON_MEMLIMIT_MB)`

`MemLimitSummary` reports an explicit `GOMEMLIMIT` with a `GOMEMLIMIT=… (runtime env)` tag.

## Tests
Updated `resolveMemLimitMB` default test for the clamp band; added boundary cases for 8/64/4/6GB hosts and `MemLimitSummary` GOMEMLIMIT/override precedence.

## Gates (sandbox)
`go build ./...` clean · `go vet ./internal/daemon/... ./internal/cli/...` clean · `gofmt -l` empty · `go test ./internal/daemon/` + cli status/doctor tests pass.

Closes #5237

🤖 Generated with [Claude Code](https://claude.com/claude-code)