### PR TITLE
fix(windows): install.json location so acceptance integrity + uninstall agree on the prefix

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -272,7 +272,14 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $Prefix = Join-Path $env:USERPROFILE '.grafel'
+          # grafel resolves its home as $HOME (if set) else %USERPROFILE% — see
+          # internal/install/state.go userHomeDir(). GitHub's Windows runner
+          # exports HOME, which can differ from USERPROFILE, so mirror the exact
+          # binary precedence here (and in the integrity/uninstall steps) instead
+          # of hard-coding USERPROFILE — otherwise the install writes install.json
+          # under $HOME\.grafel while the check looks under %USERPROFILE%\.grafel.
+          $GrafelHome = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
+          $Prefix = Join-Path $GrafelHome '.grafel'
           $BinDir = Join-Path $Prefix 'bin'
           $Extract = Join-Path $Prefix 'extract'
           New-Item -ItemType Directory -Force -Path $BinDir, $Extract | Out-Null
@@ -326,6 +333,9 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          # Mirror grafel's home precedence ($HOME else %USERPROFILE%) — see the
+          # Install (windows) step for why hard-coding USERPROFILE is wrong in CI.
+          $GrafelHome = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
           $claudeDir = Join-Path $env:USERPROFILE '.claude'
           New-Item -ItemType Directory -Force -Path $claudeDir | Out-Null
           $claudeCfg = Join-Path $claudeDir '.claude.json'
@@ -333,7 +343,7 @@ jobs:
           try {
             grafel install --copy --skills-source-dir ./skills --claude-config-dirs $claudeCfg --force
           } catch { Write-Host "install: service step warned (no service manager in CI) — tolerated" }
-          $prefix = Join-Path $env:USERPROFILE '.grafel'
+          $prefix = Join-Path $GrafelHome '.grafel'
           if (-not (Test-Path (Join-Path $prefix 'install.json'))) { throw "install.json not written" }
           if (-not (Test-Path $prefix)) { throw "~/.grafel not created" }
           if (-not (Select-String -Path $claudeCfg -Pattern 'grafel' -Quiet)) { throw "MCP not registered in .claude.json" }
@@ -366,8 +376,11 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Continue'
+          # Mirror grafel's home precedence ($HOME else %USERPROFILE%) so the
+          # teardown asserts against the same prefix the install actually used.
+          $GrafelHome = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
           $claudeCfg = Join-Path (Join-Path $env:USERPROFILE '.claude') '.claude.json'
-          $prefix = Join-Path $env:USERPROFILE '.grafel'
+          $prefix = Join-Path $GrafelHome '.grafel'
           try {
             grafel uninstall --yes --purge --remove-binary --claude-config-dirs $claudeCfg
           } catch { Write-Host "uninstall: service step warned — tolerated" }

--- a/docs/runbooks/release-signoff.md
+++ b/docs/runbooks/release-signoff.md
@@ -120,6 +120,11 @@ Run in PowerShell as the **current user**:
       schtasks /query /tn com.grafel.daemon    # ERROR: cannot find the file specified
       Test-Path "$env:USERPROFILE\.grafel"     # False
       ```
+      > grafel resolves its home as `$HOME` if that variable is set, otherwise
+      > `%USERPROFILE%` (see `internal/install/state.go`). On a normal user
+      > session `$HOME` is unset so `%USERPROFILE%\.grafel` is correct. If you
+      > have exported `HOME` (some shells/CI do, and it can differ from
+      > `%USERPROFILE%`), check `"$env:HOME\.grafel"` instead.
       Confirm the MCP entry is gone from each AI-tool config (e.g.
       `%USERPROFILE%\.claude\.claude.json`).
 


### PR DESCRIPTION
## Problem

The release acceptance gate (run 27640467634) FAILS on Windows: after `grafel install --copy`, the integrity step reports `install.json not found at C:\Users\runneradmin\.grafel\install.json — grafel has not been installed`. Linux + macOS PASS.

## Root cause (where grafel writes install.json per-OS)

`internal/install/state.go` `DefaultStatePath()` → `userHomeDir()`:

```go
func userHomeDir() (string, error) {
    if h := os.Getenv("HOME"); h != "" { return h, nil }  // HOME first
    return os.UserHomeDir()                                // %USERPROFILE% on Windows
}
```

- **Unix:** `$HOME/.grafel/install.json`.
- **Windows, real user session:** `$HOME` unset → `os.UserHomeDir()` → `%USERPROFILE%\.grafel\install.json`. Runbook is correct.
- **Windows GitHub runner:** the runner **exports `$HOME`**, which can differ from `%USERPROFILE%`. The binary trusted `$HOME`; the acceptance steps hard-coded `%USERPROFILE%`. They only agreed by luck.

This HOME-first precedence is **intentional and consistent** across the codebase (`mcpreg`, `mcp/docstate`, `embed/config`) — it exists so `t.Setenv("HOME", ...)` test isolation works on Windows, where `os.UserHomeDir()` ignores HOME. So the Go path is NOT a bug; changing it would break Windows test isolation. The brittle side was the **acceptance assertions**.

Why MCP passed but install.json failed: the MCP `.claude.json` path is pinned by the explicit `--claude-config-dirs` flag, so it never relied on the home resolver. Only `install.json` (derived from `userHomeDir()`) drifted.

## Fix

The three Windows acceptance steps (Install / Integrity / Uninstall) now derive the `.grafel` prefix exactly the way the binary does:

```pwsh
$GrafelHome = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
$Prefix = Join-Path $GrafelHome '.grafel'
```

so install, integrity check, and teardown all target the same dir. The `.claude` config stays `%USERPROFILE%`-based (install is told explicitly via `--claude-config-dirs`). Runbook updated with the `$HOME`-vs-`%USERPROFILE%` note. **No Go behavior changed.**

## Gates

- `go build ./...` clean; `go vet ./internal/install/...` clean
- `internal/install/...` tests PASS
- `gofmt -l` clean on touched files (no Go files changed)
- acceptance.yml parses (ruby -ryaml)
- Windows cross-compile of the install package OK (the only failures are the local CGO tree-sitter toolchain, unrelated to this change; real CI uses the proper Windows toolchain)

Refs #4457 #5226