### PR TITLE
fix(ci): tolerate grafel doctor non-zero exit on Windows acceptance

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -284,7 +284,8 @@ jobs:
           $ErrorActionPreference = 'Stop'
           (Get-Command grafel).Source
           grafel --version
-          try { grafel doctor } catch { Write-Host "doctor non-zero (no service in headless CI) — tolerated" }
+          grafel doctor
+          if ($LASTEXITCODE -ne 0) { Write-Host "doctor non-zero (not yet installed / no service in headless CI) — tolerated"; $global:LASTEXITCODE = 0 }
 
       # MCP config + install.json via the real `grafel install --copy` path.
       # Service registration (launchd/systemd) is expected to warn in headless


### PR DESCRIPTION
## Root cause

In `.github/workflows/acceptance.yml`, the **"Integrity — binary on PATH + version (windows)"** step (pwsh) wrapped `grafel doctor` in a PowerShell `try/catch`. But `try/catch` does **not** catch a native binary's non-zero exit code — it only catches PowerShell terminating errors. So when `grafel doctor` legitimately exits `1` (expected: `install.json` does not exist yet — the real `grafel install --copy` runs in a *later* step), the non-zero `$LASTEXITCODE` propagated and failed the whole step.

The Unix sibling step already tolerates this correctly with `grafel doctor || echo "...tolerated"`.

## Fix

Mirror the Unix intent: run `grafel doctor` directly, then check `$LASTEXITCODE` and reset it to 0 when non-zero (tolerated). `$ErrorActionPreference = 'Stop'` is left as-is — doctor is a native command and its exit code is now handled explicitly.

```diff
-          try { grafel doctor } catch { Write-Host "doctor non-zero (no service in headless CI) — tolerated" }
+          grafel doctor
+          if ($LASTEXITCODE -ne 0) { Write-Host "doctor non-zero (not yet installed / no service in headless CI) — tolerated"; $global:LASTEXITCODE = 0 }
```

Scope: windows step only. The Unix step is unchanged. The windows MCP/install.json and uninstall steps use try/catch around `grafel install`/`uninstall` (whose post-conditions are asserted separately via `Test-Path`/`throw`), not `doctor`, so they are intentionally untouched — those are real assertions, not doctor tolerance.

Linux/macOS acceptance already passes; this is the 4th Windows-CI-harness layer (a CI-harness shell-semantics fix, **not** a product bug).

Refs #4457 #5223