### PR TITLE
fix(selftest): make daemon-ready timeout configurable + bump default to 60s

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -376,6 +376,8 @@ jobs:
       - name: grafel selftest (acceptance ladder) (windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
+        env:
+          GRAFEL_SELFTEST_READY_TIMEOUT_SEC: 120
         run: |
           $ErrorActionPreference = 'Stop'
           # selftest is self-isolated (own temp GRAFEL_DAEMON_ROOT), but keep HOME

--- a/cmd/grafel/selftest.go
+++ b/cmd/grafel/selftest.go
@@ -123,7 +123,7 @@ func runSelftest(argv []string) int {
 
 	// ── Layer 1: daemon ready ─────────────────────────────────────────────────
 	r1 := timeLayer("daemon ready", func() (string, error) {
-		return selftestWaitReady(env, 30*time.Second)
+		return selftestWaitReady(env, selftestReadyTimeout())
 	})
 	add(r1)
 
@@ -155,7 +155,7 @@ func runSelftest(argv []string) int {
 			ctx, cancel = context.WithCancel(context.Background())
 			daemonDone = make(chan error, 1)
 			startDaemon()
-			if _, err := selftestWaitReady(env, 30*time.Second); err != nil {
+			if _, err := selftestWaitReady(env, selftestReadyTimeout()); err != nil {
 				return "", fmt.Errorf("daemon did not re-become ready: %w", err)
 			}
 			return selftestPersistence(env)
@@ -345,6 +345,18 @@ func selftestDaemonConfig(env *selftestEnv) daemon.Config {
 		DashboardPort:  env.dashPort,
 		DashboardBind:  "127.0.0.1",
 	}
+}
+
+// selftestReadyTimeout resolves the daemon-ready probe budget. Cold CGO
+// startup on Windows CI legitimately exceeds the old hard-coded 30s, so the
+// default is generous and overridable via GRAFEL_SELFTEST_READY_TIMEOUT_SEC.
+func selftestReadyTimeout() time.Duration {
+	if v := os.Getenv("GRAFEL_SELFTEST_READY_TIMEOUT_SEC"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return 60 * time.Second
 }
 
 // selftestWaitReady polls the daemon socket (RPC Ping) and the dashboard HTTP


### PR DESCRIPTION
## Root cause

On the Windows acceptance run, `grafel selftest` fails at Layer 1 "daemon ready" with `not ready within 30s (socket=true dashboard=false)`. The daemon socket/RPC comes up fine; the dashboard HTTP listener just doesn't bind within the hard-coded 30s probe on the cold CGO Windows CI runner.

The **install lifecycle itself PASSES on all three OSes** (macOS, Linux, Windows) — this is only the selftest readiness probe being too tight for cold Windows startup.

## Fix

- `cmd/grafel/selftest.go`: introduce `selftestReadyTimeout()` which reads `GRAFEL_SELFTEST_READY_TIMEOUT_SEC` (default **60s**, was 30s hard-coded) and apply it at both `selftestWaitReady` call sites (Layer 1 ready + persistence restart). Polling logic, the 1s httpClient timeout, and the `socket=%v dashboard=%v` diagnostic message are unchanged.
- `.github/workflows/acceptance.yml`: set `GRAFEL_SELFTEST_READY_TIMEOUT_SEC: 120` on the Windows selftest acceptance step so the cold runner has ample room. Unix step left on the 60s default.

## Validation

- `go build ./cmd/grafel` ✅, `go vet ./cmd/grafel` ✅
- Local isolated `grafel selftest` on macOS: **ALL LAYERS PASS**, daemon ready in ~137ms (well under the new 60s default).
- `acceptance.yml` parses as valid YAML.

Refs #4457 #5223 #5224

🤖 Generated with [Claude Code](https://claude.com/claude-code)