### PR TITLE
feat(install): ToolAdapter abstraction + per-tool enablement model (#5253)

### DIFF
--- a/internal/install/enablement_test.go
+++ b/internal/install/enablement_test.go
@@ -1,0 +1,81 @@
+package install_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/rulesfiles"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// applyDryRun runs install.Apply in DryRun mode under an isolated HOME and
+// returns the Result. DryRun writes nothing but populates Result the same
+// way as a real install, so it is a faithful probe of the per-tool
+// enablement wiring.
+func applyDryRun(t *testing.T, tools []string) *install.Result {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+
+	repo := t.TempDir()
+	cfg := &registry.GroupConfig{
+		Name:  "demo",
+		Repos: []registry.Repo{{Slug: "r", Path: repo}},
+		Tools: tools,
+	}
+	res, err := install.Apply(install.Options{
+		Group:   "demo",
+		Config:  cfg,
+		BinPath: "/usr/local/bin/grafel",
+		DryRun:  true,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	return res
+}
+
+// TestApply_DefaultEnablement_AllSixRulesFiles is the back-compat
+// regression guard at the Apply boundary: with no Tools the rules-file set
+// reported is exactly the historical six.
+func TestApply_DefaultEnablement_AllSixRulesFiles(t *testing.T) {
+	res := applyDryRun(t, nil)
+
+	var repoPath string
+	for p := range res.RulesFiles {
+		repoPath = p
+	}
+	if repoPath == "" {
+		t.Fatal("no repo recorded in RulesFiles")
+	}
+	got := append([]string{}, res.RulesFiles[repoPath]...)
+	want := append([]string{}, rulesfiles.Targets...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("default rules files = %v, want %v", got, want)
+	}
+}
+
+// TestApply_RestrictedEnablement_OnlySubset proves a restricted Tools list
+// writes only that subset's rules files.
+func TestApply_RestrictedEnablement_OnlySubset(t *testing.T) {
+	res := applyDryRun(t, []string{"cursor", "copilot"})
+
+	var repoPath string
+	for p := range res.RulesFiles {
+		repoPath = p
+	}
+	got := append([]string{}, res.RulesFiles[repoPath]...)
+	want := []string{".cursorrules", ".github/copilot-instructions.md"}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("restricted rules files = %v, want %v", got, want)
+	}
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cajasmota/grafel/internal/install/hooks"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/rulesfiles"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
 )
@@ -86,6 +87,13 @@ func Apply(opts Options) (*Result, error) {
 
 	res := &Result{}
 
+	// Resolve the enabled tool adapters for this group. Back-compat: an
+	// absent/empty Config.Tools yields every supported tool, reproducing
+	// the historical hard-coded sequence (all six rules files + Claude
+	// skills/hooks + Claude/Windsurf MCP). The same set drives the
+	// per-repo rules/hook steps and the MCP step below.
+	adaptersForRepo := tooladapter.EnabledAdapters(opts.Config)
+
 	cfgPath, err := registry.ConfigPathFor(opts.Group)
 	if err != nil {
 		return nil, err
@@ -126,39 +134,48 @@ func Apply(opts Options) (*Result, error) {
 			res.HooksInstalled = append(res.HooksInstalled, repo)
 		}
 		if !opts.SkipRulesFiles {
-			if !opts.DryRun {
-				wr, werr := rulesfiles.WriteAll(repo, rulesfiles.WriteOptions{
-					GroupName: opts.Group,
-				})
-				if werr != nil {
-					return nil, fmt.Errorf("rules files for %s: %w", repo, werr)
-				}
-				if wr != nil {
+			// Collect the union of rules-file targets across the enabled
+			// tools, ordered by rulesfiles.Targets so Result reporting is
+			// identical to the historical single-WriteAll behaviour.
+			targets := enabledRulesTargets(adaptersForRepo)
+			if len(targets) > 0 {
+				if !opts.DryRun {
+					wr, werr := rulesfiles.WriteTargets(repo, rulesfiles.WriteOptions{
+						GroupName: opts.Group,
+					}, targets)
+					if werr != nil {
+						return nil, fmt.Errorf("rules files for %s: %w", repo, werr)
+					}
+					if wr != nil {
+						if res.RulesFiles == nil {
+							res.RulesFiles = map[string][]string{}
+						}
+						res.RulesFiles[repo] = wr.Written
+						if len(wr.SkippedMixedStale) > 0 {
+							if res.RulesFilesStaleSkipped == nil {
+								res.RulesFilesStaleSkipped = map[string][]string{}
+							}
+							res.RulesFilesStaleSkipped[repo] = wr.SkippedMixedStale
+						}
+						if len(wr.ReplacedStale) > 0 {
+							if res.RulesFilesStaleReplaced == nil {
+								res.RulesFilesStaleReplaced = map[string][]string{}
+							}
+							res.RulesFilesStaleReplaced[repo] = wr.ReplacedStale
+						}
+					}
+				} else {
 					if res.RulesFiles == nil {
 						res.RulesFiles = map[string][]string{}
 					}
-					res.RulesFiles[repo] = wr.Written
-					if len(wr.SkippedMixedStale) > 0 {
-						if res.RulesFilesStaleSkipped == nil {
-							res.RulesFilesStaleSkipped = map[string][]string{}
-						}
-						res.RulesFilesStaleSkipped[repo] = wr.SkippedMixedStale
-					}
-					if len(wr.ReplacedStale) > 0 {
-						if res.RulesFilesStaleReplaced == nil {
-							res.RulesFilesStaleReplaced = map[string][]string{}
-						}
-						res.RulesFilesStaleReplaced[repo] = wr.ReplacedStale
-					}
+					res.RulesFiles[repo] = append([]string{}, targets...)
 				}
-			} else {
-				if res.RulesFiles == nil {
-					res.RulesFiles = map[string][]string{}
-				}
-				res.RulesFiles[repo] = append([]string{}, rulesfiles.Targets...)
 			}
 		}
-		if opts.InstallAgentHooks || opts.Config.Features.AgentHooks {
+		// The opt-in PreToolUse agent hook is Claude-only. Install it only
+		// when (a) an adapter that supports it is enabled, AND (b) the
+		// option/feature flag requests it.
+		if (opts.InstallAgentHooks || opts.Config.Features.AgentHooks) && anyAdapterSupportsAgentHook(adaptersForRepo) {
 			if !opts.DryRun {
 				if _, err := agenthooks.Install(repo); err != nil {
 					return nil, fmt.Errorf("agent hooks for %s: %w", repo, err)
@@ -197,7 +214,7 @@ func Apply(opts Options) (*Result, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, tool := range []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Windsurf} {
+		for _, tool := range enabledMCPTools(adaptersForRepo) {
 			if opts.DryRun {
 				p, _ := mcpreg.SettingsPath(tool)
 				res.MCPSettings = append(res.MCPSettings, p)
@@ -217,6 +234,68 @@ func Apply(opts Options) (*Result, error) {
 	}
 
 	return res, nil
+}
+
+// enabledRulesTargets returns the union of rules-file targets across the
+// given adapters, ordered to match rulesfiles.Targets so the resulting
+// Result.RulesFiles slice is identical to the historical single-WriteAll
+// ordering. Duplicate targets (multiple tools reading the same file) are
+// de-duplicated.
+func enabledRulesTargets(adapters []tooladapter.Adapter) []string {
+	want := map[string]bool{}
+	for _, a := range adapters {
+		for _, t := range a.RulesFileTargets() {
+			want[t] = true
+		}
+	}
+	out := make([]string, 0, len(want))
+	for _, t := range rulesfiles.Targets {
+		if want[t] {
+			out = append(out, t)
+			delete(want, t)
+		}
+	}
+	// Any target not present in rulesfiles.Targets (shouldn't happen for
+	// the built-in adapters) is appended in adapter order for safety.
+	for _, a := range adapters {
+		for _, t := range a.RulesFileTargets() {
+			if want[t] {
+				out = append(out, t)
+				delete(want, t)
+			}
+		}
+	}
+	return out
+}
+
+// enabledMCPTools returns the mcpreg.Tool entries to register, in adapter
+// order, for the adapters that support MCP today. De-duplicated.
+func enabledMCPTools(adapters []tooladapter.Adapter) []mcpreg.Tool {
+	seen := map[mcpreg.Tool]bool{}
+	var out []mcpreg.Tool
+	for _, a := range adapters {
+		if !a.SupportsMCP() {
+			continue
+		}
+		t := a.MCPTool()
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+// anyAdapterSupportsAgentHook reports whether any enabled adapter exposes
+// the opt-in PreToolUse agent hook (Claude-only today).
+func anyAdapterSupportsAgentHook(adapters []tooladapter.Adapter) bool {
+	for _, a := range adapters {
+		if a.SupportsAgentHook() {
+			return true
+		}
+	}
+	return false
 }
 
 // Uninstall reverses Apply for a single group: removes hooks/watchers

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -154,13 +154,26 @@ type WriteResult struct {
 // disk full); per-file decisions (skip-mixed-stale, replace-stale) are
 // reported via the returned WriteResult.
 func WriteAll(repoRoot string, opts WriteOptions) (*WriteResult, error) {
+	return WriteTargets(repoRoot, opts, Targets)
+}
+
+// WriteTargets is WriteAll restricted to an explicit subset of rules-file
+// targets. It is used by the per-tool ToolAdapter model so that a given
+// tool only writes the rules file(s) it actually reads, instead of the
+// full canonical set. The block content and per-file decision tree are
+// identical to WriteAll — only the set of paths differs.
+//
+// Passing rulesfiles.Targets reproduces WriteAll exactly. Unknown paths
+// are written verbatim under repoRoot (callers pass values from this
+// package's Targets list).
+func WriteTargets(repoRoot string, opts WriteOptions, targets []string) (*WriteResult, error) {
 	if opts.Logger == nil {
 		opts.Logger = os.Stderr
 	}
 	block := RenderBlock(opts.GroupName)
 
 	res := &WriteResult{}
-	for _, target := range Targets {
+	for _, target := range targets {
 		abs := filepath.Join(repoRoot, target)
 		action, err := upsert(abs, block)
 		if err != nil {

--- a/internal/install/tooladapter/adapters.go
+++ b/internal/install/tooladapter/adapters.go
@@ -1,0 +1,128 @@
+package tooladapter
+
+import (
+	"os"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+)
+
+// Rules-file target constants mirror entries in rulesfiles.Targets. They
+// are duplicated here as string literals (rather than indexing the slice)
+// so that each adapter's target is self-documenting and stable even if the
+// order of rulesfiles.Targets changes.
+const (
+	rulesAGENTS   = "AGENTS.md"
+	rulesCLAUDE   = "CLAUDE.md"
+	rulesWindsurf = ".windsurfrules"
+	rulesCursor   = ".cursorrules"
+	rulesCodeium  = ".codeium/instructions.md"
+	rulesCopilot  = ".github/copilot-instructions.md"
+)
+
+// hasMCPHost reports whether the given tool's MCP config file (or its
+// parent dir) exists — a best-effort "is this tool installed" signal.
+func hasMCPHost(tool mcpreg.Tool) bool {
+	p, err := mcpreg.SettingsPath(tool)
+	if err != nil {
+		return false
+	}
+	if _, err := os.Stat(p); err == nil {
+		return true
+	}
+	return false
+}
+
+// ── claude ───────────────────────────────────────────────────────────
+//
+// The flagship: MCP (.claude.json) + skills (~/.claude/skills/) + rules
+// (CLAUDE.md) + the opt-in PreToolUse agent hook. Skills and the agent
+// hook stay Claude-only. CLAUDE.md is written here; AGENTS.md is owned by
+// the codex adapter (Claude Code also reads AGENTS.md, but to avoid two
+// adapters writing the same file the canonical owner is codex — see
+// rulesfiles package doc).
+type claudeAdapter struct{}
+
+func (claudeAdapter) ID() string                 { return "claude" }
+func (claudeAdapter) DisplayName() string        { return "Claude Code" }
+func (claudeAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.ClaudeCode) }
+func (claudeAdapter) RulesFileTargets() []string { return []string{rulesCLAUDE} }
+func (claudeAdapter) SupportsMCP() bool          { return true }
+func (claudeAdapter) MCPTool() mcpreg.Tool       { return mcpreg.ClaudeCode }
+func (claudeAdapter) SupportsSkills() bool       { return true }
+func (claudeAdapter) SupportsAgentHook() bool    { return true }
+
+// ── codex ────────────────────────────────────────────────────────────
+//
+// Codex / OpenAI reads AGENTS.md. No MCP entry is registered by grafel
+// today (Codex MCP is a follow-up, #5254/#5255).
+type codexAdapter struct{}
+
+func (codexAdapter) ID() string                 { return "codex" }
+func (codexAdapter) DisplayName() string        { return "Codex" }
+func (codexAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Codex) }
+func (codexAdapter) RulesFileTargets() []string { return []string{rulesAGENTS} }
+func (codexAdapter) SupportsMCP() bool          { return false }
+func (codexAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (codexAdapter) SupportsSkills() bool       { return false }
+func (codexAdapter) SupportsAgentHook() bool    { return false }
+
+// ── cursor ───────────────────────────────────────────────────────────
+//
+// Cursor Composer reads .cursorrules. grafel does not register Cursor MCP
+// today (#5254/#5255).
+type cursorAdapter struct{}
+
+func (cursorAdapter) ID() string                 { return "cursor" }
+func (cursorAdapter) DisplayName() string        { return "Cursor" }
+func (cursorAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Cursor) }
+func (cursorAdapter) RulesFileTargets() []string { return []string{rulesCursor} }
+func (cursorAdapter) SupportsMCP() bool          { return false }
+func (cursorAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (cursorAdapter) SupportsSkills() bool       { return false }
+func (cursorAdapter) SupportsAgentHook() bool    { return false }
+
+// ── windsurf ─────────────────────────────────────────────────────────
+//
+// Windsurf Cascade reads .windsurfrules. NOTE: grafel DOES register a
+// Windsurf MCP entry today (mcpreg.Windsurf), so unlike the other
+// rules-only tools this adapter reports SupportsMCP()==true to preserve
+// current behaviour.
+type windsurfAdapter struct{}
+
+func (windsurfAdapter) ID() string                 { return "windsurf" }
+func (windsurfAdapter) DisplayName() string        { return "Windsurf" }
+func (windsurfAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Windsurf) }
+func (windsurfAdapter) RulesFileTargets() []string { return []string{rulesWindsurf} }
+func (windsurfAdapter) SupportsMCP() bool          { return true }
+func (windsurfAdapter) MCPTool() mcpreg.Tool       { return mcpreg.Windsurf }
+func (windsurfAdapter) SupportsSkills() bool       { return false }
+func (windsurfAdapter) SupportsAgentHook() bool    { return false }
+
+// ── codeium ──────────────────────────────────────────────────────────
+//
+// Codeium reads .codeium/instructions.md. No grafel MCP entry today.
+type codeiumAdapter struct{}
+
+func (codeiumAdapter) ID() string                 { return "codeium" }
+func (codeiumAdapter) DisplayName() string        { return "Codeium" }
+func (codeiumAdapter) DetectInstalled() bool      { return false }
+func (codeiumAdapter) RulesFileTargets() []string { return []string{rulesCodeium} }
+func (codeiumAdapter) SupportsMCP() bool          { return false }
+func (codeiumAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (codeiumAdapter) SupportsSkills() bool       { return false }
+func (codeiumAdapter) SupportsAgentHook() bool    { return false }
+
+// ── copilot ──────────────────────────────────────────────────────────
+//
+// GitHub Copilot reads .github/copilot-instructions.md. No grafel MCP
+// entry today.
+type copilotAdapter struct{}
+
+func (copilotAdapter) ID() string                 { return "copilot" }
+func (copilotAdapter) DisplayName() string        { return "GitHub Copilot" }
+func (copilotAdapter) DetectInstalled() bool      { return false }
+func (copilotAdapter) RulesFileTargets() []string { return []string{rulesCopilot} }
+func (copilotAdapter) SupportsMCP() bool          { return false }
+func (copilotAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (copilotAdapter) SupportsSkills() bool       { return false }
+func (copilotAdapter) SupportsAgentHook() bool    { return false }

--- a/internal/install/tooladapter/tooladapter.go
+++ b/internal/install/tooladapter/tooladapter.go
@@ -1,0 +1,175 @@
+// Package tooladapter defines the ToolAdapter abstraction: a uniform
+// interface over the AI coding tools that `grafel install` targets, plus
+// a registry of the tools grafel supports today.
+//
+// Motivation (#5253, EPIC #5252). Historically install.Apply hard-coded
+// the sequence of artifacts it wrote: the six rules-file conventions, the
+// Claude + Windsurf MCP entries, the Claude skills copy, and the opt-in
+// Claude agent hook. Adding a new tool meant editing Apply in several
+// places. This package inverts that: each tool is an Adapter that declares
+// which of the three artifact kinds it supports —
+//
+//   - rules file(s)  — the marker-wrapped "use the grafel MCP" block,
+//   - MCP registration — the per-tool mcpServers entry, and
+//   - skills/commands — Claude-only skill copy,
+//
+// plus the opt-in agent hook (Claude-only). A tool that lacks a capability
+// reports it as a no-op (empty target list / Supports* == false), so
+// Apply can iterate adapters uniformly and a new tool is added by
+// implementing Adapter and registering it — WITHOUT editing Apply.
+//
+// SCOPE: this package is the abstraction + the faithful re-expression of
+// TODAY's behaviour. It deliberately does NOT add MCP writers for tools
+// that grafel does not register today (Cursor/Windsurf-rules/Codex/etc.
+// MCP is #5254/#5255), nor the CLI wizard (#5256) or web UI (#5257). The
+// adapters DELEGATE to the existing writers (rulesfiles, mcpreg,
+// agenthooks) so the file-format logic is unchanged.
+package tooladapter
+
+import (
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// Adapter is the uniform interface over a single AI coding tool grafel can
+// install into. Implementations are value types registered in registry()
+// below; a new tool is added by implementing this interface and appending
+// it there — Apply never needs to change.
+//
+// The three capability groups are expressed so that a tool lacking a
+// capability is a pure no-op:
+//
+//   - RulesFileTargets() returns nil/empty when the tool has no per-repo
+//     rules file convention.
+//   - SupportsMCP()/MCPTool() report whether grafel registers an MCP entry
+//     for this tool TODAY (only Claude + Windsurf return true here; other
+//     tools' MCP is a follow-up ticket).
+//   - SupportsSkills()/SupportsAgentHook() are Claude-only today.
+type Adapter interface {
+	// ID is the stable, lowercase identifier persisted in
+	// GroupConfig.Tools (e.g. "claude", "cursor"). Never change an
+	// existing ID — it is a config key.
+	ID() string
+
+	// DisplayName is the human-facing tool name (e.g. "Claude Code").
+	DisplayName() string
+
+	// DetectInstalled reports a best-effort guess that the tool is present
+	// on this machine. It is advisory only — Apply still honours the
+	// enabled-tools set regardless — and is intended for the future CLI
+	// wizard (#5256) to pre-select likely tools.
+	DetectInstalled() bool
+
+	// RulesFileTargets returns the per-repo rules-file paths (relative,
+	// forward-slash, drawn from rulesfiles.Targets) this tool reads. Empty
+	// when the tool has no rules-file convention.
+	RulesFileTargets() []string
+
+	// SupportsMCP reports whether grafel registers an MCP entry for this
+	// tool today. MCPTool returns the mcpreg.Tool to register when true.
+	SupportsMCP() bool
+	MCPTool() mcpreg.Tool
+
+	// SupportsSkills reports whether this tool consumes the grafel skills
+	// bundle (Claude-only today). The actual skills copy lives in the
+	// global install transaction (copy.go); this flag lets future per-tool
+	// gating of that step key off the adapter set.
+	SupportsSkills() bool
+
+	// SupportsAgentHook reports whether this tool exposes the opt-in
+	// PreToolUse grep-interceptor agent hook (Claude-only today).
+	SupportsAgentHook() bool
+}
+
+// registry is the ordered list of adapters for the tools grafel supports
+// today. Order is the order Apply iterates, which determines the order of
+// rules-file writes and Result reporting; keep it stable.
+//
+// To add a tool: implement Adapter and append it here.
+func adapters() []Adapter {
+	return []Adapter{
+		claudeAdapter{},
+		codexAdapter{},
+		cursorAdapter{},
+		windsurfAdapter{},
+		codeiumAdapter{},
+		copilotAdapter{},
+	}
+}
+
+// All returns every registered adapter in deterministic order.
+func All() []Adapter {
+	return adapters()
+}
+
+// Lookup returns the adapter with the given ID, or (nil, false) if no such
+// tool is registered.
+func Lookup(id string) (Adapter, bool) {
+	for _, a := range adapters() {
+		if a.ID() == id {
+			return a, true
+		}
+	}
+	return nil, false
+}
+
+// AllIDs returns the IDs of every registered adapter, in registry order.
+// This is the historical default enablement set (every supported tool).
+func AllIDs() []string {
+	all := adapters()
+	out := make([]string, 0, len(all))
+	for _, a := range all {
+		out = append(out, a.ID())
+	}
+	return out
+}
+
+// EnabledTools resolves the effective enabled-tool set for a group config.
+//
+// Back-compat contract (#5253): when cfg is nil, or cfg.Tools is absent or
+// empty, the effective set is the historical default — every supported
+// tool (AllIDs) — so existing configs and new installs that don't specify
+// `tools` behave exactly as before (Claude full + all six rules files +
+// Claude/Windsurf MCP). When cfg.Tools is non-empty it is honoured as the
+// explicit allow-list, filtered to known adapter IDs (unknown IDs are
+// dropped) and de-duplicated, preserving the caller's order.
+func EnabledTools(cfg *registry.GroupConfig) []string {
+	if cfg == nil || len(cfg.Tools) == 0 {
+		return AllIDs()
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(cfg.Tools))
+	for _, id := range cfg.Tools {
+		if seen[id] {
+			continue
+		}
+		if _, ok := Lookup(id); !ok {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		// Config named only unknown tools — fall back to default rather
+		// than installing nothing.
+		return AllIDs()
+	}
+	return out
+}
+
+// EnabledAdapters resolves EnabledTools and returns the matching Adapter
+// values in registry order (not config order), so iteration over them is
+// deterministic regardless of how the user ordered `tools`.
+func EnabledAdapters(cfg *registry.GroupConfig) []Adapter {
+	enabled := map[string]bool{}
+	for _, id := range EnabledTools(cfg) {
+		enabled[id] = true
+	}
+	var out []Adapter
+	for _, a := range adapters() {
+		if enabled[a.ID()] {
+			out = append(out, a)
+		}
+	}
+	return out
+}

--- a/internal/install/tooladapter/tooladapter_test.go
+++ b/internal/install/tooladapter/tooladapter_test.go
@@ -1,0 +1,133 @@
+package tooladapter_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/rulesfiles"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestDefaultEnablement_ReproducesAllSixRulesFiles is the core back-compat
+// guard: with no explicit Tools the union of rules-file targets across the
+// enabled adapters must equal exactly rulesfiles.Targets (the historical
+// all-six set).
+func TestDefaultEnablement_ReproducesAllSixRulesFiles(t *testing.T) {
+	for _, cfg := range []*registry.GroupConfig{nil, {}, {Tools: nil}, {Tools: []string{}}} {
+		got := unionRulesTargets(tooladapter.EnabledAdapters(cfg))
+		want := append([]string{}, rulesfiles.Targets...)
+		sort.Strings(got)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("default enablement rules targets = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestDefaultEnablement_ClaudeAndWindsurfMCP guards that the default set
+// registers exactly the two MCP tools grafel writes today.
+func TestDefaultEnablement_ClaudeAndWindsurfMCP(t *testing.T) {
+	var mcp []mcpreg.Tool
+	for _, a := range tooladapter.EnabledAdapters(nil) {
+		if a.SupportsMCP() {
+			mcp = append(mcp, a.MCPTool())
+		}
+	}
+	sort.Slice(mcp, func(i, j int) bool { return mcp[i] < mcp[j] })
+	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Windsurf}
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+	if !reflect.DeepEqual(mcp, want) {
+		t.Fatalf("default MCP tools = %v, want %v", mcp, want)
+	}
+}
+
+// TestRestrictedEnablement_OnlySubset proves a restricted Tools list yields
+// only that subset's artifacts.
+func TestRestrictedEnablement_OnlySubset(t *testing.T) {
+	cfg := &registry.GroupConfig{Tools: []string{"cursor"}}
+	ad := tooladapter.EnabledAdapters(cfg)
+	if len(ad) != 1 || ad[0].ID() != "cursor" {
+		t.Fatalf("expected only cursor adapter, got %v", idsOf(ad))
+	}
+	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{".cursorrules"}) {
+		t.Fatalf("cursor rules targets = %v, want [.cursorrules]", rt)
+	}
+	// Cursor has no MCP today and no agent hook.
+	if ad[0].SupportsMCP() || ad[0].SupportsAgentHook() || ad[0].SupportsSkills() {
+		t.Fatalf("cursor should not support MCP/hook/skills")
+	}
+}
+
+// TestRestrictedEnablement_ClaudeOnly proves Claude-only keeps MCP + skills
+// + hook + CLAUDE.md and drops the other five rules files.
+func TestRestrictedEnablement_ClaudeOnly(t *testing.T) {
+	cfg := &registry.GroupConfig{Tools: []string{"claude"}}
+	ad := tooladapter.EnabledAdapters(cfg)
+	if len(ad) != 1 || ad[0].ID() != "claude" {
+		t.Fatalf("expected only claude adapter, got %v", idsOf(ad))
+	}
+	a := ad[0]
+	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{"CLAUDE.md"}) {
+		t.Fatalf("claude rules targets = %v, want [CLAUDE.md]", rt)
+	}
+	if !a.SupportsMCP() || a.MCPTool() != mcpreg.ClaudeCode {
+		t.Fatalf("claude must register ClaudeCode MCP")
+	}
+	if !a.SupportsSkills() || !a.SupportsAgentHook() {
+		t.Fatalf("claude must support skills + agent hook")
+	}
+}
+
+// TestEnabledTools_UnknownIDsDropped_FallbackToDefault verifies unknown IDs
+// are filtered, and an all-unknown list falls back to the full default
+// rather than installing nothing.
+func TestEnabledTools_UnknownIDsDropped_FallbackToDefault(t *testing.T) {
+	cfg := &registry.GroupConfig{Tools: []string{"cursor", "nope", "cursor"}}
+	got := tooladapter.EnabledTools(cfg)
+	if !reflect.DeepEqual(got, []string{"cursor"}) {
+		t.Fatalf("EnabledTools dedup/filter = %v, want [cursor]", got)
+	}
+
+	allUnknown := &registry.GroupConfig{Tools: []string{"nope", "ghost"}}
+	if got := tooladapter.EnabledTools(allUnknown); !reflect.DeepEqual(got, tooladapter.AllIDs()) {
+		t.Fatalf("all-unknown fallback = %v, want default %v", got, tooladapter.AllIDs())
+	}
+}
+
+func TestLookupAndAllIDs(t *testing.T) {
+	if _, ok := tooladapter.Lookup("claude"); !ok {
+		t.Fatal("claude must be registered")
+	}
+	if _, ok := tooladapter.Lookup("does-not-exist"); ok {
+		t.Fatal("unknown id must not resolve")
+	}
+	want := []string{"claude", "codex", "cursor", "windsurf", "codeium", "copilot"}
+	if got := tooladapter.AllIDs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("AllIDs = %v, want %v", got, want)
+	}
+}
+
+func unionRulesTargets(ad []tooladapter.Adapter) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, a := range ad {
+		for _, t := range a.RulesFileTargets() {
+			if !seen[t] {
+				seen[t] = true
+				out = append(out, t)
+			}
+		}
+	}
+	return out
+}
+
+func idsOf(ad []tooladapter.Adapter) []string {
+	out := make([]string, 0, len(ad))
+	for _, a := range ad {
+		out = append(out, a.ID())
+	}
+	return out
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -150,6 +150,20 @@ type GroupConfig struct {
 		// nagging users who don't want it (#4273).
 		AgentHooks bool `json:"agent_hooks,omitempty"`
 	} `json:"features"`
+	// Tools is the set of AI coding tools this group's install targets,
+	// identified by ToolAdapter ID (e.g. "claude", "cursor", "copilot").
+	// It gates which per-tool artifacts (rules files, MCP entries, skills)
+	// `grafel install` writes.
+	//
+	// Back-compat: when absent or empty the effective set is the historical
+	// default — every supported tool, i.e. Claude (full: MCP + skills +
+	// rules + opt-in hooks) plus all rules-file conventions. Resolve the
+	// effective set with DefaultEnabledTools / EnabledTools rather than
+	// reading this field directly.
+	//
+	// Example fleet JSON:
+	//   "tools": ["claude", "cursor"]
+	Tools []string `json:"tools,omitempty"`
 	// ExtraStdlibFilter is a user-extensible map from language tag to a list
 	// of bare-name symbols that should be suppressed as if they were stdlib
 	// builtins — i.e. no placeholder External entity is emitted for them.


### PR DESCRIPTION
Part of EPIC #5252.

## What
Introduces `internal/install/tooladapter` — a uniform `Adapter` interface over the AI coding tools `grafel install` targets — and a per-tool **enablement model** persisted on `GroupConfig.Tools`. Refactors `install.Apply()` to iterate the enabled adapters for the rules-file, agent-hook, and MCP steps instead of a hard-coded sequence.

## Adapter interface
```go
type Adapter interface {
    ID() string                  // stable config key: "claude", "cursor", ...
    DisplayName() string
    DetectInstalled() bool       // best-effort, advisory only (for #5256 wizard)
    RulesFileTargets() []string  // rulesfiles.Targets subset; empty == no-op
    SupportsMCP() bool
    MCPTool() mcpreg.Tool
    SupportsSkills() bool        // Claude-only today
    SupportsAgentHook() bool     // Claude-only today
}
```
Adapters registered today: `claude` (MCP + skills + CLAUDE.md + opt-in hook), `codex` (AGENTS.md), `cursor` (.cursorrules), `windsurf` (.windsurfrules + MCP), `codeium` (.codeium/instructions.md), `copilot` (.github/copilot-instructions.md). A new tool is added by implementing `Adapter` and appending it to the registry — **no `Apply()` edit required**.

Adapters **delegate** to the existing writers (`rulesfiles`, `mcpreg`, `agenthooks`); no file-format logic was rewritten. New `rulesfiles.WriteTargets` writes an explicit subset; `WriteAll` now delegates to it (byte-identical behaviour).

## Enablement + back-compat
`GroupConfig.Tools []string` (JSON `tools`, `omitempty`) is the enabled-tool allow-list. **When absent/empty the effective set = every supported tool**, reproducing today's behaviour exactly: all six rules files + Claude skills/opt-in hook + Claude & Windsurf MCP. Resolved via `tooladapter.EnabledTools` / `EnabledAdapters`. Unknown IDs are dropped; an all-unknown list falls back to the default rather than installing nothing.

`SkipRulesFiles` / `SkipMCP` / `InstallAgentHooks` / `DryRun` semantics preserved and now gate across adapters. `Result` reports the same fields with identical ordering (rules files ordered by `rulesfiles.Targets`).

## Scope / non-goals
This PR is the abstraction + enablement + faithful refactor only. `doctor.go` and the uninstall path are untouched and keep compiling/behaving as before. Follow-ups under EPIC #5252: new-tool MCP writers (#5254/#5255), CLI `--tools` wizard (#5256), web UI (#5257), per-tool doctor/uninstall (#5258).

## Tests
- `tooladapter` unit tests: default enablement == all six rules files + Claude/Windsurf MCP; restricted/Claude-only sets yield only their subset; unknown-ID drop + fallback.
- Apply-level DryRun test guards default-six vs restricted-subset at the `Apply()` boundary.
- `go build ./...` PASS · `go test ./internal/install/...` PASS · `go vet` clean.

Closes #5253

🤖 Generated with [Claude Code](https://claude.com/claude-code)