### PR TITLE
fix(selftest): bind dashboard to :0 + report resolved port (kills Windows rebind race) (#5224)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1362,17 +1362,30 @@ func daemonPatternGroupDirs() map[string]string {
 //
 // This function lives in cmd/grafel (not internal/daemon) to avoid the
 // import cycle: internal/dashboard already imports internal/daemon.
-func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Context, bind string, port int, logger *slog.Logger) error {
-	return func(ctx context.Context, bind string, port int, logger *slog.Logger) error {
+func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Context, bind string, port int, logger *slog.Logger, onListen func(addr string)) error {
+	return func(ctx context.Context, bind string, port int, logger *slog.Logger, onListen func(addr string)) error {
 		addr := net.JoinHostPort(bind, strconv.Itoa(port))
 		l, err := net.Listen("tcp", addr)
 		if err != nil {
 			return fmt.Errorf("dashboard listen %s: %w", addr, err)
 		}
 
+		// Resolve the ACTUAL bound address. When port==0 the OS assigned a
+		// free port at bind time (#5224); read it back so the dashboard
+		// config and any onListen observer see the real port — no
+		// pick-then-close-then-rebind race.
+		resolvedPort := port
+		if tcpAddr, ok := l.Addr().(*net.TCPAddr); ok {
+			resolvedPort = tcpAddr.Port
+		}
+		addr = net.JoinHostPort(bind, strconv.Itoa(resolvedPort))
+		if onListen != nil {
+			onListen(l.Addr().String())
+		}
+
 		// Build dashboard config: fixed port (the daemon already owns the listener).
 		cfg := dashboard.Config{
-			PortRange: dashboard.PortRange{Min: port, Max: port},
+			PortRange: dashboard.PortRange{Min: resolvedPort, Max: resolvedPort},
 			Bind:      bind,
 		}
 		srv, err := dashboard.NewServer(cfg, dashboard.NewLiveStore())

--- a/cmd/grafel/selftest.go
+++ b/cmd/grafel/selftest.go
@@ -12,7 +12,9 @@ package main
 //   - A fresh temp dir becomes BOTH the daemon root (GRAFEL_DAEMON_ROOT) and the
 //     registry/store home (GRAFEL_HOME), so the registry, the graph store, the
 //     socket, the pid file and the logs all live under it.
-//   - The dashboard binds a dynamic free port (GRAFEL_DASHBOARD_PORT).
+//   - The dashboard binds 127.0.0.1:0 (OS-assigned free port at bind time);
+//     the resolved port is learned via the daemon's OnDashboardListen hook
+//     (#5224 — avoids a pick-then-rebind race that flaked on Windows CI).
 //   - The Layer-1 self-defense conflict check is disabled for the run
 //     (GRAFEL_DISABLE_SELFDEFENSE) so the isolated daemon boots even when a
 //     canonical user daemon is already running.
@@ -48,6 +50,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
@@ -81,10 +84,19 @@ type layerResult struct {
 
 // selftestEnv holds the resolved isolation knobs + paths for one run.
 type selftestEnv struct {
-	root     string // temp daemon root == GRAFEL_HOME == GRAFEL_DAEMON_ROOT
-	repoDir  string // materialised fixture working tree (a git repo)
-	dashPort int
-	layout   daemon.Layout
+	root    string // temp daemon root == GRAFEL_HOME == GRAFEL_DAEMON_ROOT
+	repoDir string // materialised fixture working tree (a git repo)
+	layout  daemon.Layout
+
+	// dashPort is the dashboard port. We bind 127.0.0.1:0 and let the OS
+	// pick a free port AT BIND TIME, then learn the resolved port via the
+	// daemon's OnDashboardListen hook (stored atomically below). This kills
+	// the pick-then-close-then-rebind race that flaked on Windows CI (#5224).
+	dashPort atomic.Int64
+	// dashErr captures the dashboard goroutine's bind/serve error (if any) so
+	// a readiness timeout can report the REAL reason instead of an opaque
+	// dashboard=false (#5224, Part B).
+	dashErr atomic.Pointer[error]
 }
 
 // runSelftest is the `grafel selftest` entrypoint. It returns a process exit
@@ -151,7 +163,12 @@ func runSelftest(argv []string) int {
 			if err := selftestStopDaemon(env, cancel, daemonDone); err != nil {
 				return "", fmt.Errorf("stop daemon: %w", err)
 			}
-			// Restart a fresh daemon against the SAME isolated root.
+			// Restart a fresh daemon against the SAME isolated root. Reset the
+			// resolved-dashboard-port latch so selftestWaitReady waits for the
+			// NEW daemon's OnDashboardListen rather than probing the stale port
+			// from the first boot (#5224).
+			env.dashPort.Store(0)
+			env.dashErr.Store(nil)
 			ctx, cancel = context.WithCancel(context.Background())
 			daemonDone = make(chan error, 1)
 			startDaemon()
@@ -233,14 +250,13 @@ func setupSelftestEnv() (*selftestEnv, error) {
 		return nil, fmt.Errorf("register group: %w", err)
 	}
 
-	// Pick a free dashboard port and pin it via env so the daemon binds it.
-	port, err := freeTCPPort()
-	if err != nil {
-		return nil, fmt.Errorf("pick dashboard port: %w", err)
-	}
-	if err := mustSetenv("GRAFEL_DASHBOARD_PORT", strconv.Itoa(port)); err != nil {
-		return nil, err
-	}
+	// NOTE: the dashboard port is NOT pre-picked here. The old approach bound
+	// 127.0.0.1:0, read the port, CLOSED the socket, then handed the number to
+	// the daemon to RE-BIND — which races on Windows (TIME_WAIT / ephemeral
+	// exclusion) and made the daemon's net.Listen fail silently, so the
+	// readiness probe saw dashboard=false forever. Instead we pass
+	// DashboardPort=0 to the daemon (it binds 127.0.0.1:0 ONCE, at the moment
+	// it serves) and learn the resolved port via OnDashboardListen (#5224).
 
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
@@ -250,7 +266,7 @@ func setupSelftestEnv() (*selftestEnv, error) {
 		return nil, fmt.Errorf("ensure layout: %w", err)
 	}
 
-	return &selftestEnv{root: root, repoDir: repoDir, dashPort: port, layout: layout}, nil
+	return &selftestEnv{root: root, repoDir: repoDir, layout: layout}, nil
 }
 
 // materializeFixture writes every embedded fixture file into destDir.
@@ -342,8 +358,23 @@ func selftestDaemonConfig(env *selftestEnv) daemon.Config {
 		MCPListTools:   daemonMCPListTools,
 		MCPCallTool:    daemonMCPCallTool,
 		DashboardServe: makeDaemonDashboardServe(time.Now()),
-		DashboardPort:  env.dashPort,
-		DashboardBind:  "127.0.0.1",
+		// 0 = let the OS pick a free port AT BIND TIME (no pick-then-rebind
+		// race). The resolved port arrives via OnDashboardListen (#5224).
+		DashboardPort: 0,
+		DashboardBind: "127.0.0.1",
+		OnDashboardListen: func(addr string) {
+			// addr is "127.0.0.1:<port>"; extract and store the port.
+			if _, portStr, err := net.SplitHostPort(addr); err == nil {
+				if p, perr := strconv.Atoi(portStr); perr == nil {
+					env.dashPort.Store(int64(p))
+				}
+			}
+		},
+		OnDashboardError: func(err error) {
+			if err != nil {
+				env.dashErr.Store(&err)
+			}
+		},
 	}
 }
 
@@ -365,7 +396,7 @@ func selftestWaitReady(env *selftestEnv, timeout time.Duration) (string, error) 
 	deadline := time.Now().Add(timeout)
 	socketReady := false
 	dashReady := false
-	dashURL := fmt.Sprintf("http://127.0.0.1:%d/", env.dashPort)
+	dashURL := ""
 	httpClient := &http.Client{Timeout: 1 * time.Second}
 
 	for time.Now().Before(deadline) {
@@ -378,15 +409,29 @@ func selftestWaitReady(env *selftestEnv, timeout time.Duration) (string, error) 
 			}
 		}
 		if !dashReady {
-			if resp, err := httpClient.Get(dashURL); err == nil {
-				_ = resp.Body.Close()
-				dashReady = true
+			// The dashboard port is OS-assigned at bind time and reported via
+			// OnDashboardListen (#5224). Until that fires, port is 0 and we
+			// can't probe yet — just keep polling.
+			if p := env.dashPort.Load(); p > 0 {
+				dashURL = fmt.Sprintf("http://127.0.0.1:%d/", p)
+				if resp, err := httpClient.Get(dashURL); err == nil {
+					_ = resp.Body.Close()
+					dashReady = true
+				}
 			}
 		}
 		if socketReady && dashReady {
 			return fmt.Sprintf("socket=%s dashboard=%s", env.layout.SocketPath, dashURL), nil
 		}
 		time.Sleep(100 * time.Millisecond)
+	}
+	// Surface the dashboard goroutine's real bind/serve error (if any) so a
+	// future failure (e.g. on Windows CI) shows the reason, not just
+	// dashboard=false (#5224, Part B).
+	if !dashReady {
+		if ep := env.dashErr.Load(); ep != nil && *ep != nil {
+			return "", fmt.Errorf("not ready within %s (socket=%v dashboard=%v: %v)", timeout, socketReady, dashReady, *ep)
+		}
 	}
 	return "", fmt.Errorf("not ready within %s (socket=%v dashboard=%v)", timeout, socketReady, dashReady)
 }
@@ -746,16 +791,6 @@ func selftestStatsEntitiesWithRetry(env *selftestEnv, timeout time.Duration) str
 		time.Sleep(250 * time.Millisecond)
 	}
 	return last
-}
-
-// freeTCPPort asks the OS for an ephemeral free port and returns it.
-func freeTCPPort() (int, error) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
 }
 
 // timeLayer runs fn, records wall time, and builds a layerResult.

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -114,12 +114,19 @@ type Config struct {
 	// function value avoids the import cycle that would arise if
 	// internal/daemon imported internal/dashboard directly.
 	//
-	// The hook receives the bind address and port to listen on, and the
-	// daemon logger. It should block until ctx is done.
-	DashboardServe func(ctx context.Context, bind string, port int, logger *slog.Logger) error
+	// The hook receives the bind address and port to listen on, the daemon
+	// logger, and an onListen callback. It should call onListen exactly once
+	// with the listener's RESOLVED address (e.g. "127.0.0.1:54231") as soon
+	// as net.Listen succeeds — this matters when port==0 (OS-assigned), so a
+	// caller can learn the actual port without a pick-then-rebind race
+	// (#5224). It should block until ctx is done.
+	DashboardServe func(ctx context.Context, bind string, port int, logger *slog.Logger, onListen func(addr string)) error
 
 	// DashboardPort is the TCP port for the embedded dashboard HTTP server
-	// (#929/#931). When 0 the dashboard is disabled. Default production
+	// (#929/#931). When negative the dashboard is disabled. 0 means "let the
+	// OS pick a free port at bind time" (used by `grafel selftest` to avoid a
+	// pick-then-close-then-rebind race that flakes on Windows — #5224); the
+	// resolved port is reported via OnDashboardListen. Default production
 	// value is 47274. Configurable via GRAFEL_DASHBOARD_PORT env or
 	// ~/.config/grafel/daemon.toml.
 	DashboardPort int
@@ -127,6 +134,18 @@ type Config struct {
 	// DashboardBind is the bind address for the dashboard TCP listener.
 	// Defaults to "127.0.0.1" (loopback-only).
 	DashboardBind string
+
+	// OnDashboardListen, when non-nil, is called with the dashboard
+	// listener's RESOLVED address (host:port) once it binds. This lets a
+	// caller that passed DashboardPort==0 learn the OS-assigned port without
+	// pre-binding+closing+rebinding (#5224).
+	OnDashboardListen func(addr string)
+
+	// OnDashboardError, when non-nil, is called with any error returned by
+	// the DashboardServe hook (e.g. a bind failure). The dashboard goroutine
+	// is non-fatal by design, so this hook lets a caller surface the real
+	// reason a readiness probe never sees the dashboard come up (#5224).
+	OnDashboardError func(err error)
 
 	// WatcherConfig tunes the file watcher. Zero value uses built-in
 	// defaults (5 s debounce, 50-event bulk threshold, 30 s heartbeat).
@@ -532,7 +551,9 @@ func Run(ctx context.Context, cfg Config) error {
 	// block the RPC socket. Shuts down when the daemon context is done.
 	// The DashboardServe hook is injected from cmd/grafel to avoid
 	// the import cycle that would arise from importing internal/dashboard here.
-	if cfg.DashboardServe != nil && cfg.DashboardPort > 0 {
+	// DashboardPort==0 means "OS-pick a free port at bind time" (#5224);
+	// only a NEGATIVE port disables the dashboard.
+	if cfg.DashboardServe != nil && cfg.DashboardPort >= 0 {
 		bind := cfg.DashboardBind
 		if bind == "" {
 			bind = "127.0.0.1"
@@ -540,11 +561,18 @@ func Run(ctx context.Context, cfg Config) error {
 		dashCtx, dashCancel := context.WithCancel(ctx)
 		defer dashCancel()
 		go func() {
-			if err := cfg.DashboardServe(dashCtx, bind, cfg.DashboardPort, logger); err != nil {
+			if err := cfg.DashboardServe(dashCtx, bind, cfg.DashboardPort, logger, cfg.OnDashboardListen); err != nil {
 				logger.Error("dashboard", "err", err)
+				if cfg.OnDashboardError != nil {
+					cfg.OnDashboardError(err)
+				}
 			}
 		}()
-		logger.Info("dashboard listening", "url", "http://"+bind+":"+fmt.Sprintf("%d", cfg.DashboardPort)+"/")
+		if cfg.DashboardPort > 0 {
+			logger.Info("dashboard listening", "url", "http://"+bind+":"+fmt.Sprintf("%d", cfg.DashboardPort)+"/")
+		} else {
+			logger.Info("dashboard listening", "bind", bind, "port", "os-assigned")
+		}
 	}
 
 	server := rpc.NewServer()


### PR DESCRIPTION
## The bug
`grafel selftest` Layer-1 "daemon ready" failed **only on the Windows CI runner**: `not ready within 2m (socket=true dashboard=false)`. The dashboard HTTP listener itself works on Windows in production — proven by `windows-cgo-experiment.yml`'s `/healthz` check on the fixed port 47274 — so **this is a probe fix, not a product fix**.

## Root cause — pick-then-rebind race
`setupSelftestEnv` bound `127.0.0.1:0`, read the OS-assigned port, **closed** the socket, then handed that number to the daemon to **re-bind**. On Windows the close-then-rebind races (TIME_WAIT / ephemeral-port exclusion), so the daemon's `net.Listen` failed. That error is **logged-only** (the dashboard goroutine is non-fatal by design), so the readiness probe saw `dashboard=false` forever and timed out.

## The fix

**Part A — eliminate the race.** The selftest now passes `DashboardPort=0` and lets the OS pick a free port **at bind time, exactly once**, inside the dashboard serve path. The daemon reports the resolved port back via a new `daemon.Config.OnDashboardListen(addr)` hook; the `DashboardServe` hook signature gains an `onListen` callback it invokes with `l.Addr()` right after `net.Listen` succeeds, and uses the resolved port for the dashboard's own config. `selftestWaitReady` waits for the reported port (held in an `atomic`) before probing, and **resets it across the persistence-layer restart** so it probes the new daemon's port, not the stale one. `server.go`'s gate changes from `DashboardPort>0` to `>=0` (0 = OS-pick; only a *negative* port disables the dashboard — production always passes a positive port, so its behavior is unchanged). `freeTCPPort` is removed (its only caller is gone).

**Part B — diagnosability.** A new `OnDashboardError(err)` hook captures the dashboard goroutine's bind/serve error so a future readiness timeout reports the **real reason**: `... (socket=true dashboard=false: <err>)` instead of an opaque `dashboard=false`. Best-effort; never blocks.

## Mechanism chosen to report the resolved port
A callback on `daemon.Config` — `OnDashboardListen func(addr string)` — set by the selftest. It matches how the daemon already injects dashboard wiring via function values to avoid the `internal/daemon` ↔ `internal/dashboard` import cycle. The selftest stores the port in an `atomic.Int64`; the bind error is stored in an `atomic.Pointer[error]`.

## Validation (macOS, isolated)
- `go build ./...` ✓, `go vet ./cmd/grafel ./internal/daemon` ✓, `gofmt` clean ✓
- `go test ./internal/daemon/` → `ok`
- 3 consecutive isolated `grafel selftest` runs → **ALL LAYERS PASS**, daemon-ready in ~130-160ms on distinct OS-assigned ports (50469 / 50609 / 50916), persistence restart re-binds a fresh port each time.
- (The unrelated `TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions` failure in `cmd/grafel` **pre-exists on main** and is untouched by this change.)

Refs #4457 #5223 #5224

🤖 Generated with [Claude Code](https://claude.com/claude-code)