### PR TITLE
feat(store): reap orphan top-level store roots + 'grafel store gc --prune' (#5263)

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -62,6 +62,7 @@ func newRoot() *cobra.Command {
 		newPatternsCmd(),
 		newMCPBridgeCmd(),
 		newCleanupCmd(),
+		newStoreCmd(),
 		newDocgenCmd(),
 		newRegisterCmd(),
 		newGroupCmd(),

--- a/internal/cli/store.go
+++ b/internal/cli/store.go
@@ -1,0 +1,245 @@
+// store.go — `grafel store` operator commands (issue #5263).
+//
+// `grafel store gc` attributes every top-level store root under the grafel
+// store and reaps the ORPHANs — roots whose source repo/worktree no longer
+// exists AND that map to no live registered group. It mirrors the daemon's
+// reaper safety model exactly (deadref.go / orphanroot.go):
+//
+//   - A root whose source path still exists is NEVER reaped.
+//   - A root mapping to a live registered group / primary is NEVER reaped.
+//   - A root within the grace window is NEVER reaped.
+//   - A root whose source path is UNDETERMINABLE (maps to no known repo or
+//     worktree) is KEPT — fail-closed. The store-root hash is one-way, so the
+//     only authoritative attribution is forward (known path → expected root).
+//
+// Default (and --dry-run) only PRINTS the attribution + would-reclaim bytes.
+// --prune actually removes the orphan roots. The command operates directly on
+// the store directory with the same liveness checks whether or not the daemon
+// is running; it never auto-runs prune.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+func newStoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "store",
+		Short: "Inspect and garbage-collect the grafel graph store",
+		Long: `Operator commands for the grafel graph store (~/.grafel/store).
+
+Subcommands:
+  gc   Attribute every top-level store root and (with --prune) reap orphans —
+       roots whose source repo/worktree is gone and that map to no live group.`,
+	}
+	cmd.AddCommand(newStoreGCCmd())
+	return cmd
+}
+
+func newStoreGCCmd() *cobra.Command {
+	var prune bool
+	var dryRun bool
+	cmd := &cobra.Command{
+		Use:   "gc [--prune]",
+		Short: "Reap orphan top-level store roots (default: dry-run)",
+		Long: `Enumerate every top-level store root and print its attribution:
+source path, whether that path still exists, whether it maps to a live
+registered group, ref count, on-disk size, age of newest graph artifact, and a
+verdict (KEEP / ORPHAN-would-prune).
+
+An ORPHAN is a root whose source path is GONE and which maps to no live
+group/primary and is outside the 24h grace window. The store-root hash is
+one-way, so a root that maps to NO known repo/worktree is reported
+UNDETERMINABLE and always KEPT (fail-closed).
+
+By default this is a DRY RUN — nothing is removed. Pass --prune to actually
+reap the ORPHAN roots and reclaim their bytes. Safe to run whether or not the
+daemon is running.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runStoreGC(cmd.OutOrStdout(), prune, cliKnownSourcePaths)
+		},
+	}
+	cmd.Flags().BoolVar(&prune, "prune", false,
+		"actually remove orphan roots (default: dry-run, nothing removed)")
+	// --dry-run is accepted for symmetry with `grafel cleanup`; it is the
+	// default and simply the negation of --prune. Explicit --dry-run wins.
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"list orphans without removing them (default behaviour)")
+	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
+		if dryRun {
+			prune = false
+		}
+		return nil
+	}
+	return cmd
+}
+
+func runStoreGC(w io.Writer, prune bool, knownPaths func() []string) error {
+	sweeper := daemon.NewOrphanRootSweeper(daemon.OrphanRootConfig{
+		KnownSourcePaths: knownPaths,
+	})
+
+	verdicts := sweeper.Attribute()
+	// Stable, browsable order: orphans first, then by size descending.
+	sort.SliceStable(verdicts, func(i, j int) bool {
+		if verdicts[i].IsOrphan() != verdicts[j].IsOrphan() {
+			return verdicts[i].IsOrphan()
+		}
+		return verdicts[i].SizeBytes > verdicts[j].SizeBytes
+	})
+
+	var totalBytes, orphanBytes int64
+	var orphanCount int
+	for _, v := range verdicts {
+		totalBytes += v.SizeBytes
+		if v.IsOrphan() {
+			orphanCount++
+			orphanBytes += v.SizeBytes
+		}
+		printVerdict(w, v)
+	}
+
+	fmt.Fprintf(w, "\n%d roots, %s total; %d orphan(s), %s would reclaim\n",
+		len(verdicts), hbytes(totalBytes), orphanCount, hbytes(orphanBytes))
+
+	if !prune {
+		if orphanCount > 0 {
+			fmt.Fprintln(w, "\n(dry-run) Run 'grafel store gc --prune' to reap the ORPHAN roots above.")
+		}
+		return nil
+	}
+
+	if orphanCount == 0 {
+		fmt.Fprintln(w, "\nNothing to prune.")
+		return nil
+	}
+
+	res := sweeper.Sweep()
+	fmt.Fprintf(w, "\n✓ Pruned %d orphan root(s), reclaimed %s.\n",
+		res.RootsReaped, hbytes(res.FreedBytes))
+	if res.RootsReaped < orphanCount {
+		fmt.Fprintf(w, "  (%d candidate(s) kept — removal failed or became live mid-sweep)\n",
+			orphanCount-res.RootsReaped)
+	}
+	return nil
+}
+
+func printVerdict(w io.Writer, v daemon.OrphanRootVerdict) {
+	mark := "KEEP  "
+	if v.IsOrphan() {
+		mark = "ORPHAN"
+	}
+	src := v.SourcePath
+	if src == "" {
+		src = "<undeterminable>"
+	}
+	exists := "gone"
+	if v.PathExists {
+		exists = "exists"
+	}
+	fmt.Fprintf(w, "%s  %s\n", mark, filepath.Base(v.Root))
+	fmt.Fprintf(w, "        src=%s (%s)  refs=%d  size=%s  age=%s\n",
+		src, exists, v.RefCount, hbytes(v.SizeBytes), humanAge(v.AgeOfNewest))
+	fmt.Fprintf(w, "        %s\n", v.Reason)
+}
+
+// cliKnownSourcePaths is the operator command's KnownSourcePaths provider. It
+// works WITHOUT a running daemon: it reads the registry directly for every
+// registered-group repo and enumerates each repo's git worktrees (so a root for
+// a still-checked-out worktree is correctly attributed to a live path). Paths
+// whose directory is gone are still included so their root can be attributed
+// and reaped; a root attributable to NO path here is left undeterminable
+// (fail-closed KEEP) by the sweeper.
+func cliKnownSourcePaths() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			abs = p
+		}
+		abs = filepath.Clean(abs)
+		if seen[abs] {
+			return
+		}
+		seen[abs] = true
+		out = append(out, abs)
+	}
+
+	groups, err := registry.Groups()
+	if err != nil {
+		return out
+	}
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			add(r.Path)
+			// Enumerate the repo's worktrees so worktree roots map to a live
+			// path. Best-effort: a non-git / gone repo simply yields nothing.
+			for _, wt := range gitWorktreePaths(r.Path) {
+				add(wt)
+			}
+		}
+	}
+	return out
+}
+
+// gitWorktreePaths returns the absolute paths of every worktree linked to
+// repoPath (including the main worktree) via `git worktree list --porcelain`.
+// Returns nil for a non-git / unreadable repo.
+func gitWorktreePaths(repoPath string) []string {
+	out := gitmeta.RunGit(repoPath, "worktree", "list", "--porcelain")
+	if out == "" {
+		return nil
+	}
+	var paths []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if p, ok := strings.CutPrefix(line, "worktree "); ok && p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// hbytes adapts the package humanBytes (uint64) to the int64 sizes the store
+// sweeper reports, clamping negatives to 0.
+func hbytes(b int64) string {
+	if b < 0 {
+		b = 0
+	}
+	return humanBytes(uint64(b))
+}
+
+// humanAge renders a duration as a compact age (e.g. "3d", "5h", "—" for zero).
+func humanAge(d time.Duration) string {
+	switch {
+	case d <= 0:
+		return "—"
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}

--- a/internal/cli/store_test.go
+++ b/internal/cli/store_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+// makeRoot creates a synthetic store root (with a graph.fb whose mtime is set
+// well outside the grace window) for sourcePath under the active
+// GRAFEL_DAEMON_ROOT and returns the root dir.
+func makeRoot(t *testing.T, sourcePath string) string {
+	t.Helper()
+	refDir := daemon.StateDirForRepoRef(sourcePath, "main")
+	if err := os.MkdirAll(refDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fb := filepath.Join(refDir, "graph.fb")
+	if err := os.WriteFile(fb, []byte("g"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	old := time.Now().Add(-72 * time.Hour)
+	if err := os.Chtimes(fb, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return daemon.RepoBaseDir(sourcePath)
+}
+
+// TestRunStoreGC_DryRunThenPrune drives the operator command's wrapper: a
+// dry-run must report the orphan + reclaim estimate WITHOUT touching disk, then
+// --prune must reap exactly the orphan.
+func TestRunStoreGC_DryRunThenPrune(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	liveDir := t.TempDir()
+	liveRoot := makeRoot(t, liveDir)
+
+	goneDir := filepath.Join(t.TempDir(), "gone")
+	orphanRoot := makeRoot(t, goneDir)
+	if err := os.RemoveAll(goneDir); err != nil {
+		t.Fatal(err)
+	}
+
+	known := func() []string { return []string{liveDir, goneDir} }
+
+	// --- dry-run -------------------------------------------------------------
+	var buf bytes.Buffer
+	if err := runStoreGC(&buf, false, known); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "ORPHAN") {
+		t.Errorf("dry-run output missing ORPHAN verdict:\n%s", out)
+	}
+	if !strings.Contains(out, "1 orphan(s)") {
+		t.Errorf("dry-run output missing orphan count:\n%s", out)
+	}
+	if !strings.Contains(out, "--prune") {
+		t.Errorf("dry-run output missing prune hint:\n%s", out)
+	}
+	// Disk untouched.
+	if !isDir(orphanRoot) || !isDir(liveRoot) {
+		t.Fatalf("dry-run removed a root (orphan=%v live=%v)", isDir(orphanRoot), isDir(liveRoot))
+	}
+
+	// --- prune ---------------------------------------------------------------
+	buf.Reset()
+	if err := runStoreGC(&buf, true, known); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	out = buf.String()
+	if !strings.Contains(out, "Pruned 1 orphan") {
+		t.Errorf("prune output missing reclamation summary:\n%s", out)
+	}
+	if isDir(orphanRoot) {
+		t.Errorf("prune did not remove orphan root %s", orphanRoot)
+	}
+	if !isDir(liveRoot) {
+		t.Errorf("prune wrongly removed live root %s", liveRoot)
+	}
+}
+
+func isDir(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}

--- a/internal/daemon/orphanroot.go
+++ b/internal/daemon/orphanroot.go
@@ -1,0 +1,383 @@
+// orphanroot.go — orphan top-level store-root GC (issue #5263, epic #5234).
+//
+// # Problem
+//
+// The vanished-repo Reaper (reaper.go, #3680) only GCs the stores of repos the
+// daemon is CURRENTLY TRACKING (registered repos + active worktree children)
+// whose directory has disappeared. The dead-ref sweeper (deadref.go, #5236)
+// only reclaims dead REFS *within* a still-present, still-tracked repo. Neither
+// reclaims a top-level store root that is tracked by NOTHING anymore: a
+// `<store>/<slug>-<hash>/` slot for a worktree/repo that was indexed once, then
+// removed from the registry (or whose worktree was deleted) so it never appears
+// in TrackedRepos again. On core-backend-v3 the live store grew to ~12GB across
+// 357 top-level roots, most of them such orphans.
+//
+// # The store-root ↔ source-path mapping (the key design decision)
+//
+// A root is `<store>/<slug>-<hash>` where hash = sha256(canonical(absPath))[:16]
+// (see state_path.go). The hash is ONE-WAY and roots do NOT self-record their
+// source path on disk (graph.json carries only a human label + is_worktree, not
+// the absolute path). So there is NO authoritative reverse mapping from a root
+// back to a filesystem path.
+//
+// Therefore attribution is done in the FORWARD direction: enumerate every KNOWN
+// source path (registered-group repos + their git worktrees — both still-present
+// AND already-vanished), compute RepoBaseDir(path) for each, and build a map
+// root → source path. An on-disk root is then attributed as:
+//
+//   - maps to a known path that STILL EXISTS  → KEEP (live).
+//   - maps to a known path that is GONE        → ORPHAN candidate (reapable).
+//   - maps to NO known path                    → source path UNDETERMINABLE →
+//                                                 KEEP (fail-closed).
+//
+// # Guards (mirror the ref-GC safety model exactly — do not over-delete)
+//
+//   - A root whose source path still exists is NEVER reaped.
+//   - A root mapping to a registered/live group repo (or its primary) is NEVER
+//     reaped — such a path is in the known set and (if present) exists.
+//   - Grace window: a root whose newest graph artifact mtime is within
+//     GraceWindow (default 24h) is kept, so an in-flight / just-finished index
+//     pass is never raced into deletion.
+//   - Fail-closed: if a root cannot be attributed to a known source path, or
+//     its liveness is otherwise undeterminable, it is KEPT and logged — never
+//     reaped. The store-root base being unreadable skips the whole sweep.
+//
+// This is intentionally conservative so it is safe to run continuously while
+// the daemon serves the rewrite agent. When in doubt, KEEP.
+package daemon
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// OrphanRootConfig wires the orphan top-level store-root sweep. All hooks are
+// optional except KnownSourcePaths; a nil hook is simply skipped.
+type OrphanRootConfig struct {
+	// KnownSourcePaths returns every source path the daemon has any knowledge
+	// of: registered-group repos and their git worktrees, INCLUDING ones whose
+	// directory has already vanished. The forward map RepoBaseDir(path) → path
+	// built from this set is the ONLY way a root is attributed to a path; a root
+	// not covered here is treated as undeterminable (fail-closed KEEP).
+	// Required; nil makes the sweep a no-op.
+	KnownSourcePaths func() []string
+
+	// StoreRootBase returns the directory that directly contains the top-level
+	// roots (its immediate sub-dirs are the per-repo slots). nil → the package
+	// StoreRootBase() (honours GRAFEL_DAEMON_ROOT).
+	StoreRootBase func() string
+
+	// RootForPath maps a source path to its top-level store root. nil →
+	// RepoBaseDir. Injected in tests to align with a fixture store layout.
+	RootForPath func(path string) string
+
+	// PathExists reports whether a source path still exists on disk as a
+	// directory. nil → repoExists (fail-SAFE: any stat error other than
+	// not-exist is treated as "exists" so a flaky FS never reaps a live root).
+	PathExists func(path string) bool
+
+	// Tier, when non-nil, has Forget(repoPath) called for every reaped orphan
+	// root so any lingering in-memory slots leave the tier accounting.
+	Tier TierForgetter
+
+	// DropReaderForRoot, when non-nil, releases any cached mmap readers tied to
+	// the reaped source path so resident graphs are released.
+	DropReaderForRoot func(repoPath string)
+
+	// GraceWindow protects a root whose newest graph artifact mtime is newer
+	// than now-grace from reaping. Default (zero): 24h. Negative disables the
+	// grace guard (tests).
+	GraceWindow time.Duration
+
+	// Now returns the current time; nil → time.Now. Injected in tests.
+	Now func() time.Time
+
+	// Logger for sweep diagnostics. nil → a default stderr logger.
+	Logger *slog.Logger
+}
+
+// OrphanRootVerdict is the per-root attribution emitted by the dry-run /
+// operator path. It is also the unit the prune path acts on.
+type OrphanRootVerdict struct {
+	// Root is the absolute top-level store-root directory.
+	Root string
+	// SourcePath is the attributed source path, or "" when undeterminable.
+	SourcePath string
+	// PathKnown is true when Root mapped to a known source path.
+	PathKnown bool
+	// PathExists is true when the attributed source path exists on disk.
+	PathExists bool
+	// RefCount is the number of stored refs under <root>/refs/.
+	RefCount int
+	// SizeBytes is the on-disk size of the root tree.
+	SizeBytes int64
+	// AgeOfNewest is how long ago the newest graph artifact under the root was
+	// written (0 when none found).
+	AgeOfNewest time.Duration
+	// WithinGrace is true when the newest artifact is inside the grace window.
+	WithinGrace bool
+	// Verdict is "KEEP" or "ORPHAN" (would-prune / pruned).
+	Verdict string
+	// Reason is a short human explanation of the verdict.
+	Reason string
+}
+
+// IsOrphan reports whether this root is a prune candidate under the full safety
+// predicate: attributed to a known source path, that path is GONE, and it is
+// outside the grace window. Anything undeterminable or live or recently-indexed
+// is NOT an orphan (fail-closed KEEP).
+func (v OrphanRootVerdict) IsOrphan() bool { return v.Verdict == "ORPHAN" }
+
+// OrphanRootResult summarises one prune sweep.
+type OrphanRootResult struct {
+	// RootsScanned is the number of on-disk top-level roots inspected.
+	RootsScanned int
+	// RootsReaped is the number of orphan roots removed.
+	RootsReaped int
+	// SlotsForgotten is the number of tier slots dropped.
+	SlotsForgotten int
+	// FreedBytes is the total bytes reclaimed from removed roots.
+	FreedBytes int64
+	// Kept is the number of roots kept (live, undeterminable, or in grace).
+	Kept int
+}
+
+// OrphanRootSweeper reaps top-level store roots that map to a vanished source
+// path and to no live group/primary, using the same conservative safety model
+// as the ref GC.
+type OrphanRootSweeper struct {
+	cfg    OrphanRootConfig
+	logger *slog.Logger
+}
+
+// NewOrphanRootSweeper constructs an OrphanRootSweeper. Call Sweep (prune) or
+// Attribute (dry-run) directly; the Reaper can drive Sweep on the shared cadence.
+func NewOrphanRootSweeper(cfg OrphanRootConfig) *OrphanRootSweeper {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "orphanroot")
+	}
+	if cfg.StoreRootBase == nil {
+		cfg.StoreRootBase = StoreRootBase
+	}
+	if cfg.RootForPath == nil {
+		cfg.RootForPath = RepoBaseDir
+	}
+	if cfg.PathExists == nil {
+		cfg.PathExists = repoExists
+	}
+	if cfg.GraceWindow == 0 {
+		cfg.GraceWindow = 24 * time.Hour
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &OrphanRootSweeper{cfg: cfg, logger: logger}
+}
+
+// rootToPath builds the forward attribution map root → source path from the
+// known source paths. When two paths hash to the same root (should not happen
+// in practice), an EXISTING path wins so a live root is never mis-attributed to
+// a vanished sibling.
+func (s *OrphanRootSweeper) rootToPath() map[string]string {
+	out := map[string]string{}
+	if s.cfg.KnownSourcePaths == nil {
+		return out
+	}
+	for _, p := range s.cfg.KnownSourcePaths() {
+		if p == "" {
+			continue
+		}
+		root := filepath.Clean(s.cfg.RootForPath(p))
+		if root == "" {
+			continue
+		}
+		if existing, ok := out[root]; ok {
+			// Prefer the path that still exists.
+			if s.cfg.PathExists(existing) {
+				continue
+			}
+		}
+		out[root] = p
+	}
+	return out
+}
+
+// Attribute enumerates every on-disk top-level store root and returns its
+// verdict WITHOUT removing anything (the dry-run / operator view). It applies
+// the exact safety predicate the prune path uses, so a root reported ORPHAN
+// here is precisely what --prune would remove.
+func (s *OrphanRootSweeper) Attribute() []OrphanRootVerdict {
+	base := s.cfg.StoreRootBase()
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		// Store base unreadable / missing — nothing to attribute. Fail-closed:
+		// we never guess at roots we cannot enumerate.
+		if !errors.Is(err, os.ErrNotExist) {
+			s.logger.Warn("orphanroot: store base unreadable — skipping sweep (fail-closed)", "base", base, "err", err)
+		}
+		return nil
+	}
+
+	r2p := s.rootToPath()
+	graceCutoff := s.cfg.Now().Add(-s.cfg.GraceWindow)
+
+	var out []OrphanRootVerdict
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		root := filepath.Join(base, e.Name())
+		v := OrphanRootVerdict{Root: root}
+
+		// Forward attribution: does this root map to a KNOWN source path?
+		src, known := r2p[filepath.Clean(root)]
+		v.SourcePath = src
+		v.PathKnown = known
+
+		// Cheap diagnostics for the operator view.
+		v.RefCount = countRefs(filepath.Join(root, "refs"))
+		if sz, serr := dirSizeHygiene(root); serr == nil {
+			v.SizeBytes = sz
+		}
+		newest, hasArtifact := newestArtifactMTime(root)
+		if hasArtifact {
+			v.AgeOfNewest = s.cfg.Now().Sub(newest)
+			// Grace guard uses the same cutoff semantics as deadref.
+			v.WithinGrace = s.cfg.GraceWindow >= 0 && !newest.Before(graceCutoff)
+		}
+
+		// Record liveness for the operator view (and reuse in the switch).
+		if known {
+			v.PathExists = s.cfg.PathExists(src)
+		}
+
+		switch {
+		case !known:
+			// Undeterminable source path → FAIL-CLOSED KEEP.
+			v.Verdict = "KEEP"
+			v.Reason = "source path undeterminable (no known repo/worktree maps to this root) — fail-closed"
+		case v.PathExists:
+			// Source path still exists (covers live group/primary repos) → KEEP.
+			v.Verdict = "KEEP"
+			v.Reason = "source path exists on disk"
+		case v.WithinGrace:
+			// Vanished but recently indexed → KEEP (race guard).
+			v.Verdict = "KEEP"
+			v.Reason = "source path gone but recently indexed (grace window)"
+		default:
+			// Vanished, not live, outside grace → ORPHAN.
+			v.Verdict = "ORPHAN"
+			v.Reason = "source path gone and maps to no live group/primary"
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// Sweep enumerates the store roots and PRUNES the orphans (path-gone, not-live,
+// outside grace). Roots that are live, undeterminable, or in grace are kept.
+// Returns what it reclaimed. Safe to call directly from tests or the reaper.
+func (s *OrphanRootSweeper) Sweep() OrphanRootResult {
+	var res OrphanRootResult
+	if s.cfg.KnownSourcePaths == nil {
+		return res
+	}
+	for _, v := range s.Attribute() {
+		res.RootsScanned++
+		if !v.IsOrphan() {
+			res.Kept++
+			continue
+		}
+		// Reap: remove the on-disk root tree + any in-mem slot.
+		sz, rmErr := removeRootTree(v.Root)
+		if rmErr != nil {
+			s.logger.Warn("orphanroot: root removal failed (non-fatal)", "root", v.Root, "src", v.SourcePath, "err", rmErr)
+			res.Kept++
+			continue
+		}
+		res.RootsReaped++
+		if sz > 0 {
+			res.FreedBytes += sz
+		}
+		s.logger.Info("orphanroot: reaped orphan store root",
+			"root", v.Root, "src", v.SourcePath, "freed_bytes", sz)
+
+		if s.cfg.DropReaderForRoot != nil && v.SourcePath != "" {
+			s.cfg.DropReaderForRoot(v.SourcePath)
+		}
+		if s.cfg.Tier != nil && v.SourcePath != "" {
+			res.SlotsForgotten += s.cfg.Tier.Forget(v.SourcePath)
+		}
+	}
+	if res.RootsReaped > 0 {
+		s.logger.Info("orphanroot: sweep complete",
+			"roots_scanned", res.RootsScanned,
+			"roots_reaped", res.RootsReaped,
+			"slots_forgotten", res.SlotsForgotten,
+			"freed_bytes", res.FreedBytes,
+			"kept", res.Kept)
+	}
+	return res
+}
+
+// countRefs returns the number of immediate sub-directories under refsDir (the
+// stored refs). A missing/unreadable dir returns 0.
+func countRefs(refsDir string) int {
+	entries, err := os.ReadDir(refsDir)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			n++
+		}
+	}
+	return n
+}
+
+// newestArtifactMTime walks root for the newest graph.fb / graph.json mtime
+// across all refs. Returns (zero, false) when no artifact is found.
+func newestArtifactMTime(root string) (time.Time, bool) {
+	var newest time.Time
+	found := false
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, e error) error {
+		if e != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if name != "graph.fb" && name != "graph.json" {
+			return nil
+		}
+		fi, ferr := d.Info()
+		if ferr != nil {
+			return nil
+		}
+		if mt := fi.ModTime(); mt.After(newest) {
+			newest = mt
+			found = true
+		}
+		return nil
+	})
+	return newest, found
+}
+
+// removeRootTree deletes root and returns the bytes it freed. A non-existent
+// dir is not an error (returns 0 freed). Mirrors removeRefStore.
+func removeRootTree(root string) (int64, error) {
+	sz, err := dirSizeHygiene(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		sz = 0
+	}
+	if rmErr := os.RemoveAll(root); rmErr != nil {
+		return 0, rmErr
+	}
+	return sz, nil
+}

--- a/internal/daemon/orphanroot_test.go
+++ b/internal/daemon/orphanroot_test.go
@@ -1,0 +1,223 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildRoot creates a synthetic store root for sourcePath under an isolated
+// GRAFEL_DAEMON_ROOT, with one ref dir holding a graph.fb of the given mtime.
+// Returns the root dir.
+func buildRoot(t *testing.T, sourcePath, ref string, mtime time.Time) string {
+	t.Helper()
+	refDir := StateDirForRepoRef(sourcePath, ref)
+	if err := os.MkdirAll(refDir, 0o755); err != nil {
+		t.Fatalf("mkdir refdir: %v", err)
+	}
+	fb := filepath.Join(refDir, "graph.fb")
+	if err := os.WriteFile(fb, []byte("synthetic-graph"), 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	if err := os.Chtimes(fb, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	return RepoBaseDir(sourcePath)
+}
+
+// orphanFixture wires an isolated daemon root + a frozen clock so grace-window
+// math is deterministic.
+type orphanFixture struct {
+	root string // GRAFEL_DAEMON_ROOT
+	now  time.Time
+}
+
+func newOrphanFixture(t *testing.T) *orphanFixture {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	return &orphanFixture{root: root, now: time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)}
+}
+
+func (f *orphanFixture) sweeper(known func() []string) *OrphanRootSweeper {
+	return NewOrphanRootSweeper(OrphanRootConfig{
+		KnownSourcePaths: known,
+		Now:              func() time.Time { return f.now },
+		// Default 24h grace.
+	})
+}
+
+func dirExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
+// TestOrphanRoot_AttributionAndPrune exercises every safety branch with one
+// synthetic store: (a) orphan → pruned, (b) live-path → kept, (c) live-group
+// primary → kept, (d) undeterminable → kept (fail-closed), (e) orphan within
+// grace → kept.
+func TestOrphanRoot_AttributionAndPrune(t *testing.T) {
+	f := newOrphanFixture(t)
+
+	old := f.now.Add(-72 * time.Hour) // outside grace
+	fresh := f.now.Add(-1 * time.Hour) // inside grace
+
+	// (b) live-path root: source dir exists on disk.
+	liveDir := t.TempDir()
+	liveRoot := buildRoot(t, liveDir, "main", old)
+
+	// (c) live-group/primary root: also a real, existing path (a registered
+	// group repo is, from the sweeper's POV, just a known path that exists).
+	primaryDir := t.TempDir()
+	primaryRoot := buildRoot(t, primaryDir, "main", old)
+
+	// (a) orphan root: known path, but its dir is GONE, old artifact.
+	goneDir := filepath.Join(t.TempDir(), "deleted-worktree")
+	orphanRoot := buildRoot(t, goneDir, "feature/x", old)
+	if err := os.RemoveAll(goneDir); err != nil {
+		t.Fatalf("rm goneDir: %v", err)
+	}
+
+	// (e) orphan within grace: known path gone but artifact is fresh.
+	graceDir := filepath.Join(t.TempDir(), "just-deleted")
+	graceRoot := buildRoot(t, graceDir, "main", fresh)
+	if err := os.RemoveAll(graceDir); err != nil {
+		t.Fatalf("rm graceDir: %v", err)
+	}
+
+	// (d) undeterminable root: build it for a path NOT in the known set, then
+	// delete the path. The sweeper cannot attribute it → fail-closed KEEP.
+	unknownDir := filepath.Join(t.TempDir(), "never-registered")
+	unknownRoot := buildRoot(t, unknownDir, "main", old)
+	if err := os.RemoveAll(unknownDir); err != nil {
+		t.Fatalf("rm unknownDir: %v", err)
+	}
+
+	known := func() []string {
+		// Note: unknownDir is intentionally OMITTED.
+		return []string{liveDir, primaryDir, goneDir, graceDir}
+	}
+
+	s := f.sweeper(known)
+
+	// --- dry-run attribution -------------------------------------------------
+	byRoot := map[string]OrphanRootVerdict{}
+	for _, v := range s.Attribute() {
+		byRoot[filepath.Clean(v.Root)] = v
+	}
+
+	check := func(name, root, wantVerdict string, wantOrphan bool) {
+		t.Helper()
+		v, ok := byRoot[filepath.Clean(root)]
+		if !ok {
+			t.Fatalf("%s: root %s not attributed", name, root)
+		}
+		if v.Verdict != wantVerdict {
+			t.Errorf("%s: verdict=%q want %q (reason=%q)", name, v.Verdict, wantVerdict, v.Reason)
+		}
+		if v.IsOrphan() != wantOrphan {
+			t.Errorf("%s: IsOrphan=%v want %v", name, v.IsOrphan(), wantOrphan)
+		}
+	}
+
+	check("(b) live-path", liveRoot, "KEEP", false)
+	check("(c) live-primary", primaryRoot, "KEEP", false)
+	check("(a) orphan", orphanRoot, "ORPHAN", true)
+	check("(e) grace", graceRoot, "KEEP", false)
+	check("(d) undeterminable", unknownRoot, "KEEP", false)
+
+	// The orphan verdict must carry size accounting > 0 (it has a graph.fb).
+	if byRoot[filepath.Clean(orphanRoot)].SizeBytes <= 0 {
+		t.Errorf("orphan SizeBytes should be > 0, got %d", byRoot[filepath.Clean(orphanRoot)].SizeBytes)
+	}
+	// Undeterminable must say so in the reason.
+	if got := byRoot[filepath.Clean(unknownRoot)].Reason; got == "" || !strings.Contains(got, "undeterminable") {
+		t.Errorf("undeterminable reason = %q, want mention of 'undeterminable'", got)
+	}
+
+	// Dry-run must NOT remove anything.
+	for _, root := range []string{liveRoot, primaryRoot, orphanRoot, graceRoot, unknownRoot} {
+		if !dirExists(root) {
+			t.Errorf("dry-run removed %s — must not touch disk", root)
+		}
+	}
+
+	// --- prune ---------------------------------------------------------------
+	wantFreed := dirSizeMust(t, orphanRoot)
+	res := s.Sweep()
+
+	if res.RootsReaped != 1 {
+		t.Fatalf("RootsReaped=%d want 1", res.RootsReaped)
+	}
+	if res.FreedBytes != wantFreed {
+		t.Errorf("FreedBytes=%d want %d", res.FreedBytes, wantFreed)
+	}
+	if res.Kept < 4 {
+		t.Errorf("Kept=%d want >=4 (live, primary, grace, undeterminable)", res.Kept)
+	}
+
+	// Only the orphan is gone; everything else survives.
+	if dirExists(orphanRoot) {
+		t.Errorf("orphan root NOT removed by prune: %s", orphanRoot)
+	}
+	for name, root := range map[string]string{
+		"live": liveRoot, "primary": primaryRoot, "grace": graceRoot, "undeterminable": unknownRoot,
+	} {
+		if !dirExists(root) {
+			t.Errorf("prune wrongly removed %s root %s", name, root)
+		}
+	}
+}
+
+// TestOrphanRoot_NoKnownPaths_KeepsEverything: with an empty known set every
+// root is undeterminable → nothing is reaped (fail-closed).
+func TestOrphanRoot_NoKnownPaths_KeepsEverything(t *testing.T) {
+	f := newOrphanFixture(t)
+	gone := filepath.Join(t.TempDir(), "x")
+	root := buildRoot(t, gone, "main", f.now.Add(-72*time.Hour))
+	_ = os.RemoveAll(gone)
+
+	s := f.sweeper(func() []string { return nil })
+	res := s.Sweep()
+	if res.RootsReaped != 0 {
+		t.Fatalf("RootsReaped=%d want 0 (fail-closed)", res.RootsReaped)
+	}
+	if !dirExists(root) {
+		t.Errorf("fail-closed sweep removed undeterminable root %s", root)
+	}
+}
+
+// TestOrphanRoot_GraceDisabledReapsFresh: a negative grace window disables the
+// grace guard, so even a freshly-indexed-but-gone root is reaped.
+func TestOrphanRoot_GraceDisabledReapsFresh(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	now := time.Now()
+	gone := filepath.Join(t.TempDir(), "fresh-gone")
+	storeRoot := buildRoot(t, gone, "main", now)
+	_ = os.RemoveAll(gone)
+
+	s := NewOrphanRootSweeper(OrphanRootConfig{
+		KnownSourcePaths: func() []string { return []string{gone} },
+		GraceWindow:      -1, // disable grace
+		Now:              func() time.Time { return now },
+	})
+	res := s.Sweep()
+	if res.RootsReaped != 1 {
+		t.Fatalf("RootsReaped=%d want 1 (grace disabled)", res.RootsReaped)
+	}
+	if dirExists(storeRoot) {
+		t.Errorf("root not reaped with grace disabled: %s", storeRoot)
+	}
+}
+
+func dirSizeMust(t *testing.T, dir string) int64 {
+	t.Helper()
+	sz, err := dirSizeHygiene(dir)
+	if err != nil {
+		t.Fatalf("dirSize %s: %v", dir, err)
+	}
+	return sz
+}

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -87,6 +87,15 @@ type ReaperConfig struct {
 	// the same cadence as the vanished-repo GC. nil disables it.
 	DeadRefs *DeadRefSweeper
 
+	// OrphanRoots, when non-nil, is the orphan top-level store-root sweep
+	// (#5263). It reaps whole `<store>/<slug>-<hash>/` roots that map to a
+	// vanished source path and to no live group/primary — the gap left by the
+	// vanished-repo GC (which only covers CURRENTLY-tracked repos) and the
+	// dead-ref GC (which only covers refs within still-tracked repos). Driven
+	// on the shared cadence. nil disables it. Conservative + fail-closed: an
+	// undeterminable root is always KEPT.
+	OrphanRoots *OrphanRootSweeper
+
 	// Interval between sweeps. Default (zero value): 5 minutes.
 	Interval time.Duration
 
@@ -109,6 +118,8 @@ type ReapResult struct {
 	WatchersReaped int
 	// DeadRefs summarises the dead-ref / dead-worktree sub-sweep (#5236).
 	DeadRefs DeadRefResult
+	// OrphanRoots summarises the orphan top-level store-root sub-sweep (#5263).
+	OrphanRoots OrphanRootResult
 }
 
 // Reaper periodically GCs stores for repos that no longer exist on disk.
@@ -166,6 +177,13 @@ func (r *Reaper) Sweep() ReapResult {
 	// graph are reclaimed without a separate scheduler.
 	if r.cfg.DeadRefs != nil {
 		res.DeadRefs = r.cfg.DeadRefs.Sweep()
+	}
+	// #5263: orphan top-level store-root sweep. Independent of the
+	// vanished-repo GC below; runs on the shared cadence so a root tracked by
+	// nothing (repo de-registered / worktree deleted) is reclaimed wholesale.
+	// Conservative + fail-closed: undeterminable roots are always kept.
+	if r.cfg.OrphanRoots != nil {
+		res.OrphanRoots = r.cfg.OrphanRoots.Sweep()
 	}
 	if r.cfg.TrackedRepos == nil {
 		return res

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -497,6 +497,23 @@ func Run(ctx context.Context, cfg Config) error {
 				Tier:           cfg.DeadRefTier,
 				Logger:         logger,
 			})
+			// #5263: orphan top-level store-root sweep. Reaps whole
+			// `<store>/<slug>-<hash>/` roots that map to a vanished source path
+			// and to no live group/primary — the gap between the vanished-repo
+			// GC (currently-tracked repos only) and the dead-ref GC (refs within
+			// still-tracked repos only). KnownSourcePaths includes EXPIRED
+			// worktrees so a now-gone path's root can still be attributed; roots
+			// attributable to no known path are kept (fail-closed).
+			orphanRootSweeper := NewOrphanRootSweeper(OrphanRootConfig{
+				KnownSourcePaths: makeKnownSourcePaths(cfg.ReposToWatch, wtStore),
+				// Tier / DropReaderForRoot are per-repo-path hooks; the daemon
+				// does not currently expose a whole-repo Forget here, and a
+				// reaped orphan root's source path is already GONE (no live
+				// slot to wake), so on-disk reclamation is the load-bearing
+				// effect. Any residual in-mem slot is dropped by the
+				// vanished-repo reaper / memory-pressure eviction.
+				Logger: logger,
+			})
 			reaper := NewReaper(ReaperConfig{
 				TrackedRepos:    trackedRepos,
 				StoreDirForRepo: repoBaseDir,
@@ -507,6 +524,7 @@ func Run(ctx context.Context, cfg Config) error {
 				// registered in the daemon-owned registry under the daemon root.
 				WatchRegistry: watchreg.New(watchreg.DefaultPath(cfg.Layout.Root)),
 				DeadRefs:      deadRefSweeper,
+				OrphanRoots:   orphanRootSweeper,
 				Logger:        logger,
 			})
 			reaperStop := make(chan struct{})

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -259,6 +259,36 @@ func repoBaseDir(absRepoPath string) string {
 	return filepath.Join(StoreDir(), repoSlug(absRepoPath))
 }
 
+// RepoBaseDir is the exported wrapper around repoBaseDir: it returns the
+// top-level store root directory for repoPath (the `<slug>-<hash>/` slot, or
+// `state/<hash>/` under GRAFEL_DAEMON_ROOT). The path is absolutised + cleaned
+// first so callers get the same root the writer used. This is the forward
+// (path → root) half of the store-root ↔ source-path mapping the orphan-root
+// GC relies on (#5263): the hash is one-way, so the ONLY authoritative way to
+// attribute a root to a path is to compute the expected root for every KNOWN
+// live source path and treat the rest as undeterminable.
+func RepoBaseDir(repoPath string) string {
+	if repoPath == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		abs = repoPath
+	}
+	return repoBaseDir(filepath.Clean(abs))
+}
+
+// StoreRootBase returns the directory that DIRECTLY contains the top-level
+// store roots — `<store>` normally, or `<GRAFEL_DAEMON_ROOT>/state` under an
+// isolated daemon root. Its immediate sub-directories are the per-repo roots
+// returned by RepoBaseDir. The orphan-root GC enumerates this directory.
+func StoreRootBase() string {
+	if root := os.Getenv(EnvRoot); root != "" {
+		return filepath.Join(root, "state")
+	}
+	return StoreDir()
+}
+
 // StateDirForRepoRef returns the per-ref state directory for repoPath
 // and a specific git ref:
 //

--- a/internal/daemon/worktree_gate.go
+++ b/internal/daemon/worktree_gate.go
@@ -67,3 +67,35 @@ func makeReaperTrackedRepos(reposToWatch func() []string, wtStore *worktree.Stor
 		return out
 	}
 }
+
+// makeKnownSourcePaths returns the orphan-root sweep's KnownSourcePaths
+// provider (#5263): the union of the registered repos (reposToWatch) and ALL
+// worktree children — active AND expired/vanished. Unlike makeReaperTrackedRepos
+// it deliberately includes vanished worktrees so their store roots can still be
+// ATTRIBUTED to a (now-gone) source path and reaped; a root attributable to no
+// known path is left undeterminable (fail-closed KEEP) by the sweeper. Either
+// input may be nil. Duplicate paths are de-duplicated.
+func makeKnownSourcePaths(reposToWatch func() []string, wtStore *worktree.Store) func() []string {
+	return func() []string {
+		seen := map[string]bool{}
+		var out []string
+		add := func(p string) {
+			if p == "" || seen[p] {
+				return
+			}
+			seen[p] = true
+			out = append(out, p)
+		}
+		if reposToWatch != nil {
+			for _, r := range reposToWatch() {
+				add(r)
+			}
+		}
+		if wtStore != nil {
+			for _, c := range wtStore.All() {
+				add(c.Path)
+			}
+		}
+		return out
+	}
+}


### PR DESCRIPTION
## Problem

The live store grew to ~12GB across **357 top-level roots**, dominated by orphan `<store>/<slug>-<hash>/` slots — repos/worktrees indexed once, then de-registered or deleted, so they never reappear in `TrackedRepos`.

## The GC gap

Two GCs existed but neither covered this case:
- **vanished-repo Reaper** (#3680) — only GCs repos the daemon is **currently tracking** whose dir disappeared.
- **dead-ref sweeper** (#5236) — only reclaims dead **refs** within a still-tracked repo.

A top-level root tracked by **nothing** was reclaimed by neither.

## Store-root ↔ source-path mapping (key design decision)

A root is `<store>/<slug>-<hash>`, hash = `sha256(canonical(absPath))[:16]` — **one-way**, and roots do not self-record their source path on disk (`graph.json` carries only a label + `is_worktree`). So attribution is done **forward**: compute `RepoBaseDir(path)` for every **known** source path (registered-group repos + their git worktrees, including vanished ones) and build `root → path`:

| root maps to | verdict |
|---|---|
| known path that **exists** | KEEP (live / live-group / primary) |
| known path that is **gone** | **ORPHAN** (reapable) |
| **no** known path | UNDETERMINABLE → KEEP (fail-closed) |

## Safety predicate (reused verbatim from the ref GC)

Never reap: a root whose source path exists; a root mapping to a live group/primary; anything within the **24h grace window** (newest `graph.fb` mtime); anything whose source path is **undeterminable** (fail-closed). Conservative by design — safe to run continuously while the daemon serves a concurrent agent.

## What landed

- `internal/daemon/orphanroot.go` — `OrphanRootSweeper` (`Attribute` = dry-run verdicts, `Sweep` = prune), wired into the Reaper on the shared 5-min cadence.
- exported `RepoBaseDir` / `StoreRootBase` (forward path→root mapping).
- `makeKnownSourcePaths` (registered repos + **all** worktree children incl. expired) so a now-gone path's root is still attributable.
- `grafel store` parent + `gc` subcommand. Default / `--dry-run` prints per-root attribution (src, exists?, refs, size, age, verdict) + would-reclaim total; `--prune` reaps orphans and reports reclaimed bytes. Works **with or without** the daemon running (reads the registry directly). Resolves the `store` unknown-command gap.

## Validation

- `go build ./...` ✅, `go vet ./internal/daemon ./cmd/grafel ./internal/cli` ✅
- new unit tests (temp fixture stores under `GRAFEL_DAEMON_ROOT`) cover all branches: (a) orphan → pruned, (b) live-path → kept, (c) live-group/primary → kept, (d) undeterminable → kept (fail-closed), (e) orphan within grace → kept; plus empty-known-set (fail-closed) and grace-disabled. `internal/daemon/...` and `internal/cli/` suites green.
- `cmd/grafel/` has one **pre-existing unrelated** failure on clean main (`TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions`).

**Prune was NOT run against any live store** — the coordinator runs it on a deploy window. All tests use temp fixtures.

Closes #5263

🤖 Generated with [Claude Code](https://claude.com/claude-code)