### PR TITLE
fix(transport): scope Windows named pipe by daemon root (#5264)

### DIFF
--- a/internal/daemon/paths_windows.go
+++ b/internal/daemon/paths_windows.go
@@ -22,11 +22,14 @@ func isWindowsPipePath(path string) bool {
 // because pipes are not filesystem objects.
 //
 // When GRAFEL_DAEMON_ROOT is set, that directory is used for all
-// filesystem paths (pid file, logs). The named-pipe path is always
-// user-scoped and does not change based on GRAFEL_DAEMON_ROOT.
+// filesystem paths (pid file, logs) AND the named-pipe path is scoped to
+// that root (via a hash of the root in the pipe name). This mirrors the
+// Unix transport, where the socket already lives under the root at
+// <root>/sockets/daemon.sock. Without root-scoping the pipe was a single
+// process-global object per user, so an isolated daemon (selftest, parallel
+// agent, or a second instance with a different root) collided on the shared
+// pipe and wedged at socket-listen (issue #5264).
 func DefaultLayout() (Layout, error) {
-	pipePath := transport.WindowsPipeName()
-
 	root := os.Getenv(EnvRoot)
 	if root == "" {
 		appData := os.Getenv("APPDATA")
@@ -39,6 +42,11 @@ func DefaultLayout() (Layout, error) {
 		}
 		root = filepath.Join(appData, "grafel")
 	}
+
+	// Derive the pipe name from the SAME root used for the filesystem paths
+	// so the listen side and the dial side (which both call DefaultLayout)
+	// agree on the pipe name.
+	pipePath := transport.WindowsPipeName(root)
 
 	logDir := filepath.Join(root, "logs")
 	// See no-rotation contract in layoutFromRoot (paths.go).

--- a/internal/daemon/service/service_windows.go
+++ b/internal/daemon/service/service_windows.go
@@ -14,10 +14,12 @@ import (
 // %APPDATA%\grafel as the base directory and a named-pipe path for
 // SocketPath.
 func resolvePlatformPaths(opts *Options) error {
-	if opts.SocketPath == "" {
-		opts.SocketPath = transport.WindowsPipeName()
-	}
-	if opts.LogDir == "" {
+	// Resolve the daemon root the same way daemon.DefaultLayout does so the
+	// installed service's named pipe is scoped to the same root the daemon
+	// and client derive (issue #5264). Honour GRAFEL_DAEMON_ROOT first, then
+	// fall back to %APPDATA%\grafel (or the home dir when APPDATA is unset).
+	root := os.Getenv("GRAFEL_DAEMON_ROOT")
+	if root == "" {
 		appData := os.Getenv("APPDATA")
 		if appData == "" {
 			home, err := os.UserHomeDir()
@@ -26,7 +28,14 @@ func resolvePlatformPaths(opts *Options) error {
 			}
 			appData = home
 		}
-		opts.LogDir = filepath.Join(appData, "grafel", "logs")
+		root = filepath.Join(appData, "grafel")
+	}
+
+	if opts.SocketPath == "" {
+		opts.SocketPath = transport.WindowsPipeName(root)
+	}
+	if opts.LogDir == "" {
+		opts.LogDir = filepath.Join(root, "logs")
 	}
 	return nil
 }

--- a/internal/daemon/transport/pipename.go
+++ b/internal/daemon/transport/pipename.go
@@ -1,0 +1,61 @@
+package transport
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+)
+
+// buildWindowsPipeName derives the root-scoped Windows named-pipe path from a
+// raw username and a daemon root directory. It is split out from
+// WindowsPipeName (which is //go:build windows because it calls
+// os/user.Current) so the name-derivation logic can be unit-tested on any
+// GOOS — the selftest wedge it fixes (#5264) is a Windows-only failure but the
+// derivation is pure string logic.
+//
+// Form: \\.\pipe\grafel-daemon-<username>-<rootHash>
+//
+// The username is lower-cased and stripped of any domain prefix so that
+// "DOMAIN\User" → "user". The root hash makes the pipe name unique per daemon
+// root, mirroring the Unix transport where the socket already lives under the
+// root at <root>/sockets/daemon.sock. An empty root degrades to the legacy
+// user-only name so a degenerate caller still produces a valid, stable path.
+func buildWindowsPipeName(username, root string) string {
+	if username == "" {
+		username = "daemon"
+	}
+	// Strip domain prefix (e.g. "DESKTOP-123\alice" → "alice").
+	if idx := strings.LastIndex(username, `\`); idx >= 0 {
+		username = username[idx+1:]
+	}
+	username = strings.ToLower(username)
+
+	name := `\\.\pipe\grafel-daemon-` + username
+	if h := rootHash(root); h != "" {
+		name += "-" + h
+	}
+	return name
+}
+
+// rootHash returns a short, deterministic, pipe-name-safe identifier for a
+// daemon root directory, or "" when root is empty.
+//
+// The path is lexically cleaned and lower-cased before hashing so that the
+// listen side and the dial side — which may pass casing-variant or
+// non-canonical spellings of the same root on case-insensitive NTFS — always
+// derive the same pipe name. (This mirrors the intent of the daemon package's
+// repoStateHash/canonicalizePath, kept self-contained here to avoid an import
+// cycle, since the daemon package imports transport.)
+//
+// 16 hex chars (64 bits) is collision-resistant for the handful of daemon
+// roots on any single host and keeps the full pipe name well under the
+// Windows ~256-char pipe-name limit.
+func rootHash(root string) string {
+	if root == "" {
+		return ""
+	}
+	canonical := strings.ToLower(filepath.Clean(root))
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:8]) // 16 hex chars
+}

--- a/internal/daemon/transport/pipename_test.go
+++ b/internal/daemon/transport/pipename_test.go
@@ -1,0 +1,83 @@
+package transport
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildWindowsPipeName_DistinctRootsDistinctPipes is the regression test
+// for issue #5264: the Windows named pipe must be scoped by daemon root so an
+// isolated daemon (selftest, parallel agent, second instance) does NOT collide
+// on a single process-global per-user pipe.
+func TestBuildWindowsPipeName_DistinctRootsDistinctPipes(t *testing.T) {
+	a := buildWindowsPipeName("alice", `C:\Users\alice\AppData\Roaming\grafel`)
+	b := buildWindowsPipeName("alice", `C:\tmp\agsbx-winpipe`)
+	if a == b {
+		t.Fatalf("distinct roots produced identical pipe names: %q", a)
+	}
+	for _, n := range []string{a, b} {
+		if !strings.HasPrefix(n, `\\.\pipe\grafel-daemon-`) {
+			t.Errorf("pipe name %q missing required prefix", n)
+		}
+		if len(n) > 256 {
+			t.Errorf("pipe name %q exceeds Windows length limit", n)
+		}
+	}
+}
+
+// TestBuildWindowsPipeName_StableForSameRoot verifies the derivation is
+// deterministic: the listen side and the dial side, given the same root, must
+// agree on the pipe name or they can never connect. Casing/lexical variants of
+// the same root must also agree (case-insensitive NTFS).
+func TestBuildWindowsPipeName_StableForSameRoot(t *testing.T) {
+	root := `C:\Users\alice\AppData\Roaming\grafel`
+	if got, want := buildWindowsPipeName("alice", root), buildWindowsPipeName("alice", root); got != want {
+		t.Fatalf("same root not stable: %q != %q", got, want)
+	}
+
+	// Casing variants must canonicalize to the same name (case-insensitive
+	// NTFS). This is the property the listen/dial sides rely on; we lower-case
+	// the root before hashing precisely so two case-spellings of the same
+	// directory derive one pipe. (Lexical normalization of trailing
+	// separators / "." segments is left to filepath.Clean, which is
+	// GOOS-specific for backslash paths and not exercised here off-Windows.)
+	want := buildWindowsPipeName("alice", root)
+	if got := buildWindowsPipeName("alice", `C:\Users\Alice\AppData\Roaming\Grafel`); got != want {
+		t.Errorf("casing variant derived %q; want %q", got, want)
+	}
+}
+
+// TestBuildWindowsPipeName_DomainStripAndLowercase checks the username
+// normalization (DOMAIN\User → user, lower-cased) is preserved.
+func TestBuildWindowsPipeName_DomainStripAndLowercase(t *testing.T) {
+	root := `C:\grafel`
+	if got, want := buildWindowsPipeName(`DESKTOP-123\Alice`, root), buildWindowsPipeName("alice", root); got != want {
+		t.Fatalf("domain/case not normalized: %q != %q", got, want)
+	}
+}
+
+// TestBuildWindowsPipeName_EmptyRootLegacyName confirms an empty root degrades
+// to the legacy user-only name (no trailing hash), so a degenerate caller
+// still gets a valid, stable pipe path.
+func TestBuildWindowsPipeName_EmptyRootLegacyName(t *testing.T) {
+	if got, want := buildWindowsPipeName("alice", ""), `\\.\pipe\grafel-daemon-alice`; got != want {
+		t.Fatalf("empty root: got %q want %q", got, want)
+	}
+}
+
+// TestRootHash_DistinctAndStable sanity-checks the hash helper directly.
+func TestRootHash_DistinctAndStable(t *testing.T) {
+	if rootHash("") != "" {
+		t.Errorf("empty root should hash to empty string")
+	}
+	h := rootHash(`C:\a`)
+	if len(h) != 16 {
+		t.Errorf("rootHash len = %d; want 16 hex chars", len(h))
+	}
+	if h == rootHash(`C:\b`) {
+		t.Errorf("distinct roots hashed identically")
+	}
+	if h != rootHash(`C:\a`) {
+		t.Errorf("rootHash not deterministic")
+	}
+}

--- a/internal/daemon/transport/transport_windows.go
+++ b/internal/daemon/transport/transport_windows.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"net"
 	"os/user"
-	"strings"
 	"time"
 
 	"github.com/Microsoft/go-winio"
@@ -25,22 +24,44 @@ import (
 // is down, matching the Unix ENOENT-fast-fail behaviour. See issue #4304.
 const maxDialTimeout = 2 * time.Second
 
-// WindowsPipeName returns the canonical named-pipe path for the current user.
-// Form: \\.\pipe\grafel-daemon-<username>
-// The username is lower-cased and stripped of any domain prefix so that
-// "DOMAIN\User" → "user".
-func WindowsPipeName() string {
+// WindowsPipeName returns the named-pipe path for the daemon rooted at
+// root.
+//
+// Form: \\.\pipe\grafel-daemon-<username>-<rootHash>
+//
+// The pipe is scoped by BOTH the current username AND a hash of the daemon
+// root directory. The username keeps two different users on the same box from
+// colliding (each user can only open their own pipe via the SDDL ACL anyway).
+// The root hash is the critical part: it makes the pipe name unique per daemon
+// root, exactly mirroring the Unix transport, where the RPC socket lives at
+// <root>/sockets/daemon.sock and is therefore already root-scoped.
+//
+// Without the root hash the Windows pipe was a single process-global object
+// per user (`grafel-daemon-<user>`). An isolated daemon — the selftest, a
+// parallel agent, or simply a second `grafel` instance with a different
+// GRAFEL_DAEMON_ROOT — would collide on that one shared pipe: the isolated
+// listener wedged at socket-listen while a DIFFERENT daemon answered probes,
+// cascading into "MCP: no groups registered" / "cold index: graph.fb not
+// found" / "persistence: daemon not running" (issue #5264). Scoping the pipe
+// by root makes distinct roots truly independent, which both fixes the
+// selftest wedge and lets two real daemons coexist on one Windows host.
+//
+// The same root MUST be passed on both the listen side (paths_windows.go's
+// DefaultLayout) and the dial side (client, which also reads
+// DefaultLayout().SocketPath), so the derived name is identical and the two
+// sides connect. Production passes its default root (%APPDATA%\grafel or
+// $GRAFEL_DAEMON_ROOT); its pipe name changes from the old global one, which
+// is fine — it is still deterministic per root.
+//
+// An empty root degrades to the legacy user-only name so a degenerate caller
+// still produces a valid, stable pipe path.
+func WindowsPipeName(root string) string {
 	u, err := user.Current()
 	username := "daemon"
 	if err == nil {
 		username = u.Username
-		// Strip domain prefix (e.g. "DESKTOP-123\alice" → "alice").
-		if idx := strings.LastIndex(username, "\\"); idx >= 0 {
-			username = username[idx+1:]
-		}
-		username = strings.ToLower(username)
 	}
-	return `\\.\pipe\grafel-daemon-` + username
+	return buildWindowsPipeName(username, root)
 }
 
 // listen creates a Windows named-pipe listener at addr.


### PR DESCRIPTION
## Root cause

The Windows acceptance startup trace **wedges at `socket-listen begin` with no matching `done`**, on pipe `\\.\pipe\grafel-daemon-runneradmin` — a **process-global, per-USERNAME** named pipe that is **not scoped to the daemon root**.

On Unix the RPC socket is already root-scoped (`<root>/sockets/daemon.sock`), so an isolated daemon (the selftest, a parallel agent, or any second instance with a different `GRAFEL_DAEMON_ROOT`) is truly isolated. On Windows the single global pipe meant the selftest's isolated daemon collided with a **different** daemon already owning the shared pipe: the isolated listener wedged at socket-listen while the other daemon answered the probe's `socket=true`, cascading into:

- `MCP: no groups registered`
- `cold index: graph.fb not found`
- `persistence: daemon not running`

This is also a real product bug — two grafel daemons on one Windows host collide.

## Fix

Scope the Windows named pipe by daemon root, mirroring the Unix root-scoped socket:

```
old: \\.\pipe\grafel-daemon-<username>
new: \\.\pipe\grafel-daemon-<username>-<sha256(lower(clean(root)))[:16]>
```

Both the daemon's **listen** side (`paths_windows.go` `DefaultLayout`) and the client's **dial** side (also via `DefaultLayout().SocketPath`) derive the name from the **same root**, so they still connect. The root is lower-cased before hashing so casing variants on case-insensitive NTFS map to one pipe. An empty root degrades to the legacy user-only name. Production's pipe name changes from the old global one — fine, still deterministic per root. The service-install path (`service_windows.go`) resolves the root the same way so the installed pipe matches.

Name-derivation logic is extracted into a build-tag-free helper (`buildWindowsPipeName` / `rootHash` in `pipename.go`) so it is unit-tested on any GOOS.

## Keep until data layers confirmed green

Per the coordinator plan, the Windows **dashboard decouple (#5266)** and the **startup trace logs** stay in place until the data layers (MCP / cold index / persistence) are confirmed green with this pipe fix. Re-tightening the dashboard check is a separate follow-up.

## Validation (macOS, isolated)

- `go build ./...` PASS
- `go vet ./internal/daemon/transport/... ./cmd/grafel` PASS
- Windows cross-build of `transport` + `service` packages PASS (`GOOS=windows`). Full `cmd/grafel` / `daemon` cross-build is blocked only by go-tree-sitter's CGO requirement — pre-existing, unrelated.
- New unit tests: distinct roots → distinct pipes; same root → stable; casing variant → same; domain/case normalization; empty-root legacy name. PASS.
- Isolated selftest **2x → ALL LAYERS PASS** (Unix socket path byte-for-byte unchanged).

Refs #5264 #4457 #5223

🤖 Generated with [Claude Code](https://claude.com/claude-code)