### PR TITLE
feat(store): record source path + opt-in recoverable reap of undeterminable roots (#5267, #5268)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -556,6 +556,16 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 			fmt.Fprintf(os.Stderr, "grafel: wrote %s\n", fbPath)
 		}
 
+		// #5267: record the canonical absolute source path in the top-level
+		// `<root>/root.json` manifest so the orphan-root GC can attribute this
+		// root WITHOUT the one-way forward hash map (a removed-from-registry /
+		// deleted source path is then still reapable). Best-effort: a failure
+		// here never fails the index pass — attribution falls back to the
+		// forward map for this root.
+		if err := daemon.WriteRootManifest(absRepo); err != nil {
+			fmt.Fprintf(os.Stderr, "grafel: root manifest write failed (non-fatal): %v\n", err)
+		}
+
 		if idx.exportJSON {
 			if err := graph.WriteAtomic(outPath, doc, pretty); err != nil {
 				return err

--- a/internal/cli/store.go
+++ b/internal/cli/store.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,6 +51,9 @@ Subcommands:
 func newStoreGCCmd() *cobra.Command {
 	var prune bool
 	var dryRun bool
+	var includeUndeterminable bool
+	var olderThan string
+	var yes bool
 	cmd := &cobra.Command{
 		Use:   "gc [--prune]",
 		Short: "Reap orphan top-level store roots (default: dry-run)",
@@ -59,15 +63,51 @@ registered group, ref count, on-disk size, age of newest graph artifact, and a
 verdict (KEEP / ORPHAN-would-prune).
 
 An ORPHAN is a root whose source path is GONE and which maps to no live
-group/primary and is outside the 24h grace window. The store-root hash is
-one-way, so a root that maps to NO known repo/worktree is reported
-UNDETERMINABLE and always KEPT (fail-closed).
+group/primary and is outside the 24h grace window. A root now records its
+canonical source path in a root.json manifest (#5267), so even a root whose
+repo was removed from the registry / deleted from disk is attributable and
+reapable. A LEGACY root with no manifest that maps to NO known repo/worktree is
+reported UNDETERMINABLE and KEPT (fail-closed).
 
 By default this is a DRY RUN — nothing is removed. Pass --prune to actually
-reap the ORPHAN roots and reclaim their bytes. Safe to run whether or not the
-daemon is running.`,
+reap the ORPHAN roots and reclaim their bytes.
+
+Operator opt-in (#5268), for legacy stores with undeterminable roots:
+  --include-undeterminable  also consider undeterminable (legacy / unmapped)
+                            roots. REQUIRES --older-than. Reaping a root is
+                            recoverable — it re-indexes automatically if needed.
+  --older-than <dur>        only reap an undeterminable root whose newest graph
+                            artifact is older than this (e.g. 168h, 7d, 30d).
+  --yes                     REQUIRED to actually prune in --include-undeterminable
+                            mode; without it the run stays a dry-run even with
+                            --prune (guard against accidental aggressive reap).
+
+The periodic in-daemon reaper NEVER uses the opt-in path — it stays fail-closed.
+Safe to run whether or not the daemon is running.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runStoreGC(cmd.OutOrStdout(), prune, cliKnownSourcePaths)
+			var reapOlderThan time.Duration
+			if olderThan != "" {
+				d, perr := parseDurationWithDays(olderThan)
+				if perr != nil {
+					return fmt.Errorf("invalid --older-than %q: %w", olderThan, perr)
+				}
+				reapOlderThan = d
+			}
+			if includeUndeterminable && reapOlderThan <= 0 {
+				return fmt.Errorf("--include-undeterminable requires --older-than <dur> (e.g. --older-than 7d) so undeterminable roots are reaped only beyond an explicit age bound")
+			}
+			// --yes is the prune authorisation for opt-in mode. Without it the
+			// run is forced to dry-run even if --prune was passed.
+			effectivePrune := prune
+			if includeUndeterminable && !yes {
+				effectivePrune = false
+			}
+			return runStoreGC(cmd.OutOrStdout(), storeGCOpts{
+				prune:                 effectivePrune,
+				includeUndeterminable: includeUndeterminable,
+				reapOlderThan:         reapOlderThan,
+				yesWithheld:           includeUndeterminable && !yes && prune,
+			}, cliKnownSourcePaths)
 		},
 	}
 	cmd.Flags().BoolVar(&prune, "prune", false,
@@ -76,6 +116,12 @@ daemon is running.`,
 	// default and simply the negation of --prune. Explicit --dry-run wins.
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"list orphans without removing them (default behaviour)")
+	cmd.Flags().BoolVar(&includeUndeterminable, "include-undeterminable", false,
+		"also consider undeterminable (legacy/unmapped) roots; requires --older-than and --yes to prune")
+	cmd.Flags().StringVar(&olderThan, "older-than", "",
+		"in --include-undeterminable mode, only reap roots untouched longer than this (e.g. 168h, 7d, 30d)")
+	cmd.Flags().BoolVar(&yes, "yes", false,
+		"confirm the aggressive opt-in reap; REQUIRED to prune when --include-undeterminable is set")
 	cmd.PreRunE = func(cmd *cobra.Command, _ []string) error {
 		if dryRun {
 			prune = false
@@ -85,10 +131,44 @@ daemon is running.`,
 	return cmd
 }
 
-func runStoreGC(w io.Writer, prune bool, knownPaths func() []string) error {
+// parseDurationWithDays parses a Go duration, additionally accepting a trailing
+// "d" day suffix (e.g. "7d" → 168h, "30d" → 720h) which time.ParseDuration does
+// not support. A bare "d" value is multiplied into hours before delegating.
+func parseDurationWithDays(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if rest, ok := strings.CutSuffix(s, "d"); ok {
+		// Guard against "d" colliding with a valid unit-less suffix: only treat
+		// it as days when the remainder is a plain number.
+		if n, err := strconv.ParseFloat(strings.TrimSpace(rest), 64); err == nil {
+			return time.Duration(n * float64(24*time.Hour)), nil
+		}
+	}
+	return time.ParseDuration(s)
+}
+
+// storeGCOpts bundles the resolved `store gc` flags for runStoreGC.
+type storeGCOpts struct {
+	// prune is the EFFECTIVE prune decision (already gated by --yes in opt-in
+	// mode): true → actually remove orphans.
+	prune bool
+	// includeUndeterminable enables the operator opt-in reap of undeterminable
+	// (legacy/unmapped) roots, bounded by reapOlderThan.
+	includeUndeterminable bool
+	// reapOlderThan is the explicit age bound for the opt-in reap (>0 required
+	// when includeUndeterminable is set).
+	reapOlderThan time.Duration
+	// yesWithheld is true when --prune --include-undeterminable was requested
+	// WITHOUT --yes, so we forced dry-run and want to tell the operator why.
+	yesWithheld bool
+}
+
+func runStoreGC(w io.Writer, opts storeGCOpts, knownPaths func() []string) error {
 	sweeper := daemon.NewOrphanRootSweeper(daemon.OrphanRootConfig{
-		KnownSourcePaths: knownPaths,
+		KnownSourcePaths:        knownPaths,
+		AllowUndeterminableReap: opts.includeUndeterminable,
+		ReapOlderThan:           opts.reapOlderThan,
 	})
+	prune := opts.prune
 
 	verdicts := sweeper.Attribute()
 	// Stable, browsable order: orphans first, then by size descending.
@@ -113,9 +193,20 @@ func runStoreGC(w io.Writer, prune bool, knownPaths func() []string) error {
 	fmt.Fprintf(w, "\n%d roots, %s total; %d orphan(s), %s would reclaim\n",
 		len(verdicts), hbytes(totalBytes), orphanCount, hbytes(orphanBytes))
 
+	if opts.includeUndeterminable {
+		fmt.Fprintf(w, "(opt-in: undeterminable roots untouched > %s are reapable; reaped roots re-index automatically if needed later.)\n",
+			humanAge(opts.reapOlderThan))
+	}
+
 	if !prune {
 		if orphanCount > 0 {
-			fmt.Fprintln(w, "\n(dry-run) Run 'grafel store gc --prune' to reap the ORPHAN roots above.")
+			if opts.yesWithheld {
+				fmt.Fprintln(w, "\n(dry-run) --include-undeterminable requires --yes to prune; re-run with --prune --yes to reap the ORPHAN roots above.")
+			} else if opts.includeUndeterminable {
+				fmt.Fprintln(w, "\n(dry-run) Run 'grafel store gc --include-undeterminable --older-than <dur> --prune --yes' to reap the ORPHAN roots above.")
+			} else {
+				fmt.Fprintln(w, "\n(dry-run) Run 'grafel store gc --prune' to reap the ORPHAN roots above.")
+			}
 		}
 		return nil
 	}
@@ -131,6 +222,9 @@ func runStoreGC(w io.Writer, prune bool, knownPaths func() []string) error {
 	if res.RootsReaped < orphanCount {
 		fmt.Fprintf(w, "  (%d candidate(s) kept — removal failed or became live mid-sweep)\n",
 			orphanCount-res.RootsReaped)
+	}
+	if opts.includeUndeterminable {
+		fmt.Fprintln(w, "  Reaped roots re-index automatically the next time their source path is registered/indexed.")
 	}
 	return nil
 }

--- a/internal/cli/store_test.go
+++ b/internal/cli/store_test.go
@@ -50,7 +50,7 @@ func TestRunStoreGC_DryRunThenPrune(t *testing.T) {
 
 	// --- dry-run -------------------------------------------------------------
 	var buf bytes.Buffer
-	if err := runStoreGC(&buf, false, known); err != nil {
+	if err := runStoreGC(&buf, storeGCOpts{prune: false}, known); err != nil {
 		t.Fatalf("dry-run: %v", err)
 	}
 	out := buf.String()
@@ -70,7 +70,7 @@ func TestRunStoreGC_DryRunThenPrune(t *testing.T) {
 
 	// --- prune ---------------------------------------------------------------
 	buf.Reset()
-	if err := runStoreGC(&buf, true, known); err != nil {
+	if err := runStoreGC(&buf, storeGCOpts{prune: true}, known); err != nil {
 		t.Fatalf("prune: %v", err)
 	}
 	out = buf.String()
@@ -88,4 +88,99 @@ func TestRunStoreGC_DryRunThenPrune(t *testing.T) {
 func isDir(p string) bool {
 	fi, err := os.Stat(p)
 	return err == nil && fi.IsDir()
+}
+
+// TestRunStoreGC_5268_OptInYesGating drives the operator command's opt-in reap:
+// an undeterminable-gone OLD root is reaped only with --include-undeterminable
+// + --older-than + --yes; without --yes it stays dry-run; a newer root and a
+// live-path root are always kept; default mode (no flag) keeps undeterminable.
+func TestRunStoreGC_5268_OptInYesGating(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	// Old undeterminable-gone root (no manifest, not in known set). Age its
+	// graph.fb to 30d so it is older than the 7d bound below.
+	oldDir := filepath.Join(t.TempDir(), "old-gone")
+	oldRoot := makeRoot(t, oldDir)
+	thirtyDaysAgo := time.Now().Add(-30 * 24 * time.Hour)
+	for _, ref := range []string{"main"} {
+		fb := filepath.Join(daemon.StateDirForRepoRef(oldDir, ref), "graph.fb")
+		if err := os.Chtimes(fb, thirtyDaysAgo, thirtyDaysAgo); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.RemoveAll(oldDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Live-path root (exists).
+	liveDir := t.TempDir()
+	liveRoot := makeRoot(t, liveDir)
+
+	// Forward map knows ONLY the live path → oldRoot is undeterminable.
+	known := func() []string { return []string{liveDir} }
+	sevenDays := 7 * 24 * time.Hour
+
+	// (1) default mode (no opt-in): undeterminable old root KEPT.
+	var buf bytes.Buffer
+	if err := runStoreGC(&buf, storeGCOpts{prune: true}, known); err != nil {
+		t.Fatalf("default prune: %v", err)
+	}
+	if !isDir(oldRoot) {
+		t.Errorf("default mode reaped an undeterminable root — fail-closed broken")
+	}
+
+	// (2) opt-in but WITHOUT --yes (yesWithheld): stays dry-run, nothing reaped.
+	buf.Reset()
+	err := runStoreGC(&buf, storeGCOpts{
+		prune: false, includeUndeterminable: true, reapOlderThan: sevenDays, yesWithheld: true,
+	}, known)
+	if err != nil {
+		t.Fatalf("opt-in no-yes: %v", err)
+	}
+	if !isDir(oldRoot) {
+		t.Errorf("opt-in without --yes reaped a root — must stay dry-run")
+	}
+	if !strings.Contains(buf.String(), "--yes") {
+		t.Errorf("opt-in no-yes output missing --yes hint:\n%s", buf.String())
+	}
+
+	// (3) opt-in WITH --yes (prune true): old root reaped, live kept.
+	buf.Reset()
+	if err := runStoreGC(&buf, storeGCOpts{
+		prune: true, includeUndeterminable: true, reapOlderThan: sevenDays,
+	}, known); err != nil {
+		t.Fatalf("opt-in prune: %v", err)
+	}
+	if isDir(oldRoot) {
+		t.Errorf("opt-in --yes did not reap old undeterminable root %s", oldRoot)
+	}
+	if !isDir(liveRoot) {
+		t.Errorf("opt-in --yes wrongly reaped live-path root %s", liveRoot)
+	}
+	if !strings.Contains(buf.String(), "re-index") {
+		t.Errorf("opt-in prune output missing re-index note:\n%s", buf.String())
+	}
+}
+
+// TestParseDurationWithDays verifies the day-suffix duration parsing.
+func TestParseDurationWithDays(t *testing.T) {
+	cases := map[string]time.Duration{
+		"7d":   7 * 24 * time.Hour,
+		"30d":  30 * 24 * time.Hour,
+		"168h": 168 * time.Hour,
+		"90m":  90 * time.Minute,
+	}
+	for in, want := range cases {
+		got, err := parseDurationWithDays(in)
+		if err != nil {
+			t.Errorf("parseDurationWithDays(%q): %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseDurationWithDays(%q) = %v, want %v", in, got, want)
+		}
+	}
+	if _, err := parseDurationWithDays("notaduration"); err == nil {
+		t.Errorf("parseDurationWithDays(garbage): want error, got nil")
+	}
 }

--- a/internal/daemon/orphanroot.go
+++ b/internal/daemon/orphanroot.go
@@ -79,6 +79,27 @@ type OrphanRootConfig struct {
 	// not-exist is treated as "exists" so a flaky FS never reaps a live root).
 	PathExists func(path string) bool
 
+	// ReadRootManifest reads a root's recorded source-path manifest (#5267).
+	// Returns (manifest, present, err); present=false for a legacy root with no
+	// manifest. nil → ReadRootManifest. When a manifest IS present, its recorded
+	// source_path is preferred over the forward map, so a root whose source path
+	// was removed from the registry (and thus no longer hashes forward) is still
+	// attributable. Injected in tests.
+	ReadRootManifest func(rootDir string) (RootManifest, bool, error)
+
+	// AllowUndeterminableReap, when true, lets the OPERATOR opt-in reap path
+	// (#5268) consider roots whose source path is undeterminable (legacy +
+	// path-gone + not in the forward map), bounded by ReapOlderThan. The
+	// PERIODIC reaper NEVER sets this — it stays fail-closed. Default false.
+	AllowUndeterminableReap bool
+
+	// ReapOlderThan bounds the opt-in undeterminable reap: only an
+	// undeterminable root whose newest graph artifact mtime is older than this
+	// is eligible. Ignored unless AllowUndeterminableReap is true. A zero/negative
+	// value with AllowUndeterminableReap set reaps NOTHING (an explicit age
+	// bound is required to reap undeterminable roots).
+	ReapOlderThan time.Duration
+
 	// Tier, when non-nil, has Forget(repoPath) called for every reaped orphan
 	// root so any lingering in-memory slots leave the tier accounting.
 	Tier TierForgetter
@@ -106,8 +127,16 @@ type OrphanRootVerdict struct {
 	Root string
 	// SourcePath is the attributed source path, or "" when undeterminable.
 	SourcePath string
-	// PathKnown is true when Root mapped to a known source path.
+	// PathKnown is true when Root mapped to a known source path (via the
+	// recorded manifest source_path OR the forward map).
 	PathKnown bool
+	// FromManifest is true when SourcePath came from the root's recorded
+	// `root.json` manifest (#5267) rather than the forward hash map.
+	FromManifest bool
+	// Undeterminable is true when the source path could not be determined at all
+	// (no manifest AND not in the forward map). Such a root is KEPT by default
+	// and only reaped under the operator opt-in (#5268).
+	Undeterminable bool
 	// PathExists is true when the attributed source path exists on disk.
 	PathExists bool
 	// RefCount is the number of stored refs under <root>/refs/.
@@ -168,6 +197,9 @@ func NewOrphanRootSweeper(cfg OrphanRootConfig) *OrphanRootSweeper {
 	}
 	if cfg.PathExists == nil {
 		cfg.PathExists = repoExists
+	}
+	if cfg.ReadRootManifest == nil {
+		cfg.ReadRootManifest = ReadRootManifest
 	}
 	if cfg.GraceWindow == 0 {
 		cfg.GraceWindow = 24 * time.Hour
@@ -233,10 +265,23 @@ func (s *OrphanRootSweeper) Attribute() []OrphanRootVerdict {
 		root := filepath.Join(base, e.Name())
 		v := OrphanRootVerdict{Root: root}
 
-		// Forward attribution: does this root map to a KNOWN source path?
-		src, known := r2p[filepath.Clean(root)]
+		// Attribution priority (#5267): prefer the root's RECORDED source path
+		// (root.json manifest) over the one-way forward map. A recorded path is
+		// authoritative even when the path was removed from the registry / git
+		// worktree set and so no longer hashes forward to this root.
+		var src string
+		var known bool
+		if mfst, present, mErr := s.cfg.ReadRootManifest(root); mErr == nil && present && mfst.SourcePath != "" {
+			src = mfst.SourcePath
+			known = true
+			v.FromManifest = true
+		} else {
+			// Legacy root (no manifest) → fall back to the forward map.
+			src, known = r2p[filepath.Clean(root)]
+		}
 		v.SourcePath = src
 		v.PathKnown = known
+		v.Undeterminable = !known
 
 		// Cheap diagnostics for the operator view.
 		v.RefCount = countRefs(filepath.Join(root, "refs"))
@@ -256,26 +301,63 @@ func (s *OrphanRootSweeper) Attribute() []OrphanRootVerdict {
 		}
 
 		switch {
-		case !known:
-			// Undeterminable source path → FAIL-CLOSED KEEP.
-			v.Verdict = "KEEP"
-			v.Reason = "source path undeterminable (no known repo/worktree maps to this root) — fail-closed"
-		case v.PathExists:
-			// Source path still exists (covers live group/primary repos) → KEEP.
+		case known && v.PathExists:
+			// Source path exists (covers live group/primary repos) → KEEP. This
+			// guard precedes the undeterminable branch so a root with a recorded
+			// manifest whose path STILL EXISTS is never reaped, even in opt-in mode.
 			v.Verdict = "KEEP"
 			v.Reason = "source path exists on disk"
-		case v.WithinGrace:
-			// Vanished but recently indexed → KEEP (race guard).
+		case known && v.WithinGrace:
+			// Known-but-gone yet recently indexed → KEEP (race guard).
 			v.Verdict = "KEEP"
 			v.Reason = "source path gone but recently indexed (grace window)"
-		default:
-			// Vanished, not live, outside grace → ORPHAN.
+		case known:
+			// Known, vanished, not live, outside grace → ORPHAN. With a recorded
+			// manifest this is now attributable WITHOUT the forward map.
 			v.Verdict = "ORPHAN"
-			v.Reason = "source path gone and maps to no live group/primary"
+			if v.FromManifest {
+				v.Reason = "recorded source path gone and maps to no live group/primary"
+			} else {
+				v.Reason = "source path gone and maps to no live group/primary"
+			}
+		case s.cfg.AllowUndeterminableReap && s.reapableUndeterminable(v):
+			// Operator opt-in (#5268): undeterminable + gone + older than the
+			// explicit age bound → ORPHAN. Recoverable (re-indexes if needed).
+			v.Verdict = "ORPHAN"
+			v.Reason = "source path undeterminable and untouched beyond --older-than — operator opt-in reap (re-indexes if needed)"
+		case v.WithinGrace:
+			// Undeterminable but recently indexed → KEEP even in opt-in mode.
+			v.Verdict = "KEEP"
+			v.Reason = "source path undeterminable; recently indexed (grace window)"
+		default:
+			// Undeterminable source path → FAIL-CLOSED KEEP (default + periodic).
+			v.Verdict = "KEEP"
+			v.Reason = "source path undeterminable (no manifest; no known repo/worktree maps to this root) — fail-closed"
 		}
 		out = append(out, v)
 	}
 	return out
+}
+
+// reapableUndeterminable reports whether an UNDETERMINABLE root is eligible for
+// the operator opt-in reap (#5268). It is the only path that can reap a root
+// whose source path is undeterminable, and it requires an EXPLICIT positive age
+// bound: a root is reapable only when its newest graph artifact is OLDER than
+// ReapOlderThan. With a zero/negative bound nothing is reaped (an explicit
+// --older-than is mandatory). A root with no artifact at all has unknown age and
+// is conservatively NOT reaped.
+func (s *OrphanRootSweeper) reapableUndeterminable(v OrphanRootVerdict) bool {
+	if !s.cfg.AllowUndeterminableReap {
+		return false
+	}
+	if s.cfg.ReapOlderThan <= 0 {
+		return false
+	}
+	if v.AgeOfNewest <= 0 {
+		// No datable artifact → unknown age → keep (conservative).
+		return false
+	}
+	return v.AgeOfNewest > s.cfg.ReapOlderThan
 }
 
 // Sweep enumerates the store roots and PRUNES the orphans (path-gone, not-live,

--- a/internal/daemon/orphanroot_test.go
+++ b/internal/daemon/orphanroot_test.go
@@ -221,3 +221,176 @@ func dirSizeMust(t *testing.T, dir string) int64 {
 	}
 	return sz
 }
+
+// writeManifest writes a root.json manifest recording sourcePath into the given
+// store-root dir (#5267).
+func writeManifest(t *testing.T, sourcePath string) {
+	t.Helper()
+	if err := WriteRootManifest(sourcePath); err != nil {
+		t.Fatalf("WriteRootManifest(%s): %v", sourcePath, err)
+	}
+}
+
+// TestOrphanRoot_5267_ManifestAttributesWithoutForwardMap: a root WITH a
+// recorded source_path that is GONE + old is attributed ORPHAN even when the
+// forward map (KnownSourcePaths) knows NOTHING — the recorded path makes it
+// self-attributing. The same recorded path STILL EXISTING → KEEP. A legacy root
+// with NO manifest and not in the forward map → KEEP (fail-closed fallback).
+func TestOrphanRoot_5267_ManifestAttributesWithoutForwardMap(t *testing.T) {
+	f := newOrphanFixture(t)
+	old := f.now.Add(-72 * time.Hour)
+
+	// (1) manifest + gone path → ORPHAN without any forward map.
+	goneDir := filepath.Join(t.TempDir(), "removed-from-registry")
+	goneRoot := buildRoot(t, goneDir, "main", old)
+	writeManifest(t, goneDir)
+	if err := os.RemoveAll(goneDir); err != nil {
+		t.Fatalf("rm goneDir: %v", err)
+	}
+
+	// (2) manifest + existing path → KEEP.
+	liveDir := t.TempDir()
+	liveRoot := buildRoot(t, liveDir, "main", old)
+	writeManifest(t, liveDir)
+
+	// (3) legacy root: no manifest, not in forward map → KEEP (fail-closed).
+	legacyDir := filepath.Join(t.TempDir(), "legacy-gone")
+	legacyRoot := buildRoot(t, legacyDir, "main", old)
+	if err := os.RemoveAll(legacyDir); err != nil {
+		t.Fatalf("rm legacyDir: %v", err)
+	}
+
+	// Forward map is EMPTY — attribution must come entirely from manifests.
+	s := f.sweeper(func() []string { return nil })
+	got := map[string]OrphanRootVerdict{}
+	for _, v := range s.Attribute() {
+		got[v.Root] = v
+	}
+
+	if v := got[goneRoot]; !v.IsOrphan() || !v.FromManifest {
+		t.Errorf("gone+manifest root: want ORPHAN+FromManifest, got verdict=%s fromManifest=%v reason=%q",
+			v.Verdict, v.FromManifest, v.Reason)
+	}
+	if v := got[liveRoot]; v.IsOrphan() {
+		t.Errorf("live+manifest root: want KEEP, got ORPHAN (%q)", v.Reason)
+	}
+	if v := got[legacyRoot]; v.IsOrphan() || !v.Undeterminable {
+		t.Errorf("legacy no-manifest root: want KEEP+Undeterminable, got verdict=%s undeterminable=%v",
+			v.Verdict, v.Undeterminable)
+	}
+
+	// Periodic Sweep (no opt-in) must reap ONLY the manifest-attributed orphan,
+	// never the undeterminable legacy root.
+	res := s.Sweep()
+	if res.RootsReaped != 1 {
+		t.Fatalf("Sweep reaped %d roots, want 1 (manifest orphan only)", res.RootsReaped)
+	}
+	if dirExists(goneRoot) {
+		t.Errorf("manifest orphan root not reaped: %s", goneRoot)
+	}
+	if !dirExists(legacyRoot) {
+		t.Errorf("undeterminable legacy root wrongly reaped: %s", legacyRoot)
+	}
+}
+
+// TestOrphanRoot_5268_OptInUndeterminableReap exercises the operator opt-in
+// reap of undeterminable-gone roots, bounded by ReapOlderThan, and the safety
+// guards around it.
+func TestOrphanRoot_5268_OptInUndeterminableReap(t *testing.T) {
+	f := newOrphanFixture(t)
+	old := f.now.Add(-30 * 24 * time.Hour) // 30d old
+	recent := f.now.Add(-2 * time.Hour)    // newer than a 7d bound
+
+	// Undeterminable + gone + OLD (30d) → eligible.
+	oldDir := filepath.Join(t.TempDir(), "old-undeterminable")
+	oldRoot := buildRoot(t, oldDir, "main", old)
+	if err := os.RemoveAll(oldDir); err != nil {
+		t.Fatalf("rm oldDir: %v", err)
+	}
+
+	// Undeterminable + gone + NEWER than 7d → KEPT.
+	newDir := filepath.Join(t.TempDir(), "new-undeterminable")
+	newRoot := buildRoot(t, newDir, "main", recent)
+	if err := os.RemoveAll(newDir); err != nil {
+		t.Fatalf("rm newDir: %v", err)
+	}
+
+	// Live-path root (exists, and in the known forward map like a registered
+	// group repo) → KEPT even with the opt-in flag.
+	liveDir := t.TempDir()
+	liveRoot := buildRoot(t, liveDir, "main", old)
+
+	sevenDays := 7 * 24 * time.Hour
+	known := func() []string { return []string{liveDir} }
+
+	// --- opt-in attribution with a 7d bound -----------------------------------
+	optIn := NewOrphanRootSweeper(OrphanRootConfig{
+		KnownSourcePaths:        known,
+		Now:                     func() time.Time { return f.now },
+		AllowUndeterminableReap: true,
+		ReapOlderThan:           sevenDays,
+	})
+	got := map[string]OrphanRootVerdict{}
+	for _, v := range optIn.Attribute() {
+		got[v.Root] = v
+	}
+	if v := got[oldRoot]; !v.IsOrphan() {
+		t.Errorf("old undeterminable root: want ORPHAN under opt-in, got %s (%q)", v.Verdict, v.Reason)
+	}
+	if v := got[newRoot]; v.IsOrphan() {
+		t.Errorf("new undeterminable root: want KEEP (newer than --older-than), got ORPHAN")
+	}
+	if v := got[liveRoot]; v.IsOrphan() {
+		t.Errorf("live-path root: want KEEP even with opt-in, got ORPHAN")
+	}
+
+	// --- default sweeper (no opt-in) keeps ALL undeterminable roots -----------
+	plain := f.sweeper(func() []string { return nil })
+	for _, v := range plain.Attribute() {
+		if v.Root == oldRoot && v.IsOrphan() {
+			t.Errorf("default sweeper reaped undeterminable old root — fail-closed broken")
+		}
+	}
+
+	// --- prune in opt-in mode reaps ONLY the old one --------------------------
+	res := optIn.Sweep()
+	if res.RootsReaped != 1 {
+		t.Fatalf("opt-in Sweep reaped %d, want 1", res.RootsReaped)
+	}
+	if dirExists(oldRoot) {
+		t.Errorf("old undeterminable root not reaped under opt-in: %s", oldRoot)
+	}
+	if !dirExists(newRoot) || !dirExists(liveRoot) {
+		t.Errorf("opt-in sweep wrongly reaped a protected root (new=%v live=%v)",
+			dirExists(newRoot), dirExists(liveRoot))
+	}
+}
+
+// TestOrphanRoot_5268_RequiresAgeBound: opt-in mode with NO age bound (zero
+// ReapOlderThan) reaps NOTHING — an explicit bound is mandatory.
+func TestOrphanRoot_5268_RequiresAgeBound(t *testing.T) {
+	f := newOrphanFixture(t)
+	old := f.now.Add(-365 * 24 * time.Hour)
+
+	goneDir := filepath.Join(t.TempDir(), "ancient-undeterminable")
+	goneRoot := buildRoot(t, goneDir, "main", old)
+	if err := os.RemoveAll(goneDir); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+
+	s := NewOrphanRootSweeper(OrphanRootConfig{
+		KnownSourcePaths:        func() []string { return nil },
+		Now:                     func() time.Time { return f.now },
+		AllowUndeterminableReap: true,
+		ReapOlderThan:           0, // no bound → reap nothing
+	})
+	for _, v := range s.Attribute() {
+		if v.Root == goneRoot && v.IsOrphan() {
+			t.Errorf("opt-in with no age bound reaped a root — explicit --older-than must be required")
+		}
+	}
+	if res := s.Sweep(); res.RootsReaped != 0 {
+		t.Errorf("opt-in with no age bound reaped %d roots, want 0", res.RootsReaped)
+	}
+	_ = goneRoot
+}

--- a/internal/daemon/root_manifest.go
+++ b/internal/daemon/root_manifest.go
@@ -1,0 +1,129 @@
+// root_manifest.go — per-root source-path manifest (issue #5267, epic #5234).
+//
+// # Why this exists
+//
+// The store-root ↔ source-path mapping is ONE-WAY: a root is
+// `<store>/<slug>-<hash>` where hash = sha256(canonical(absPath))[:16] (see
+// state_path.go), and roots historically did NOT self-record their source path
+// on disk — graph.json carries only a human label + is_worktree, not the
+// absolute path. So the orphan-root GC (#5263) could only attribute a root in
+// the FORWARD direction (enumerate every KNOWN live source path, hash it, match
+// the root) and KEPT everything else fail-closed.
+//
+// On the live 12.1GB / 355-root store that meant `store gc --dry-run` reclaimed
+// 0 bytes: 307 roots were `<undeterminable> (gone) → fail-closed KEEP` because
+// no currently-known repo/worktree hashed to them — their source paths had been
+// removed from the registry / deleted from disk and there was nothing left to
+// hash forward.
+//
+// # What this adds
+//
+// At every index write we now persist a tiny `<root>/root.json` manifest that
+// records the CANONICAL ABSOLUTE source path (the exact string fed to the hash).
+// orphanroot.Attribute() prefers this recorded path when present: read it →
+// stat it → if gone + not-live + outside grace → ORPHAN, attributable WITHOUT
+// the forward map. When the field is absent (legacy roots written before this
+// change) the sweeper falls back to the existing forward-map + fail-closed
+// behaviour, so legacy roots are never broken.
+//
+// The manifest is intentionally minimal and written best-effort (a failure to
+// write it never fails an index pass — attribution simply falls back to the
+// forward map for that root).
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// RootManifestName is the basename of the per-root source-path manifest written
+// at the TOP LEVEL of a store root (a sibling of refs/), so the orphan-root GC
+// can read it with a single stat+read while enumerating StoreRootBase.
+const RootManifestName = "root.json"
+
+// RootManifest is the on-disk `<root>/root.json` payload. It is deliberately
+// tiny — its sole job is to make a root self-attributing so the GC need not
+// hash a still-known source path forward to identify it.
+type RootManifest struct {
+	// Version is the manifest schema version (currently 1). Reserved for
+	// forward-compatible field additions.
+	Version int `json:"version"`
+	// SourcePath is the CANONICAL ABSOLUTE source path of the repo/worktree
+	// this root was created for — the exact string fed to repoStateHash (i.e.
+	// canonicalizePath(filepath.Clean(filepath.Abs(repoPath)))). The GC stats
+	// this directly: if it is gone (and not otherwise live / within grace) the
+	// root is reapable without any forward map.
+	SourcePath string `json:"source_path"`
+}
+
+// canonicalSourcePath returns the canonical absolute form of repoPath — the
+// SAME transformation repoStateHash applies before hashing. Recording this
+// exact string in the manifest guarantees a later stat of it round-trips to the
+// path whose hash named the root.
+func canonicalSourcePath(repoPath string) string {
+	if repoPath == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		abs = repoPath
+	}
+	return canonicalizePath(filepath.Clean(abs))
+}
+
+// WriteRootManifest writes (or refreshes) `<root>/root.json` for repoPath,
+// recording its canonical absolute source path so the orphan-root GC can
+// attribute the root WITHOUT the forward map (#5267). It is best-effort: the
+// returned error is for logging only — callers MUST NOT fail an index pass on
+// it, since attribution degrades gracefully to the forward-map fallback.
+//
+// The write is atomic (tmp file + rename) so a concurrent reader never observes
+// a torn manifest.
+func WriteRootManifest(repoPath string) error {
+	if repoPath == "" {
+		return nil
+	}
+	root := RepoBaseDir(repoPath)
+	if root == "" {
+		return nil
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return err
+	}
+	m := RootManifest{Version: 1, SourcePath: canonicalSourcePath(repoPath)}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	dst := filepath.Join(root, RootManifestName)
+	tmp := dst + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// ReadRootManifest reads `<root>/root.json` for the given top-level store-root
+// directory. It returns (manifest, true, nil) when the manifest exists and
+// parses; (zero, false, nil) when the manifest is simply absent (a legacy root);
+// and (zero, false, err) on a read/parse error other than not-exist (so the
+// caller can fall back conservatively).
+func ReadRootManifest(rootDir string) (RootManifest, bool, error) {
+	var m RootManifest
+	data, err := os.ReadFile(filepath.Join(rootDir, RootManifestName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return m, false, nil
+		}
+		return m, false, err
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return m, false, err
+	}
+	return m, true, nil
+}


### PR DESCRIPTION
## The 0-reclaim finding

`grafel store gc --dry-run` on the real **12.1GB / 355-root** store reclaims **0 bytes**: 307 roots are `<undeterminable> (gone) → fail-closed KEEP`. The root→path map is one-way `hash(canonical(absPath))` and roots never recorded their source path, so a repo removed from the registry / deleted from disk no longer hashes forward to its root and can't be attributed.

## Recoverability reframe

Reaping a root is **recoverable** — worst case is a re-index. So an operator opt-in to reap old undeterminable-gone roots is low-risk. This PR adds (1) forward source-path recording and (2) the opt-in reap.

## #5267 — record source path in root manifest

- Index now writes a tiny `<root>/root.json` (`RootManifestName`) recording the **canonical absolute source path** (the exact string fed to the hash), via `daemon.WriteRootManifest`. Best-effort; never fails an index pass.
- `orphanroot.Attribute()` prefers the recorded `source_path` when present: read → stat → gone + not-live + outside grace → **ORPHAN**, attributable **without** the forward map. Absent field (legacy roots) → forward-map + fail-closed fallback. Legacy roots are never broken.

## #5268 — opt-in recoverable reap (operator-only)

`grafel store gc` flags:
- `--include-undeterminable` — also consider undeterminable (legacy/unmapped) roots; **requires** `--older-than`.
- `--older-than <dur>` — Go duration, also accepts `7d`/`30d` day-suffix; only reap roots whose newest `graph.fb` mtime is older.
- `--yes` — **required** to actually prune in opt-in mode; without it the run stays dry-run even with `--prune`.

Output prints per-root reason + reclaimed bytes and notes that reaped roots re-index automatically if needed later.

## Safety

The **periodic in-daemon reaper NEVER uses the opt-in path** — `AllowUndeterminableReap` defaults false, so it stays fail-closed. Even in opt-in mode a root whose source path **exists**, maps to a **live group/primary**, or is **within `--older-than`** is never reaped.

## Tests

New unit tests (temp fixture stores via `GRAFEL_DAEMON_ROOT`):
- #5267: manifest+gone+old → ORPHAN without forward map; manifest+existing → KEEP; legacy no-manifest → fail-closed KEEP.
- #5268: opt-in old undeterminable → reaped; newer-than-bound → KEPT; live-path → KEPT; no `--yes` → dry-run; default mode → unchanged; no age bound → reaps nothing; day-suffix duration parsing.

`go build ./...` ✅ · `go vet` clean · `internal/daemon/...` + `internal/cli/...` green · `cmd/grafel` green except the pre-existing unrelated `TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions`.

Closes #5267
Closes #5268

🤖 Generated with [Claude Code](https://claude.com/claude-code)