### PR TITLE
fix(daemon): close mcp-activity handle on shutdown + robust Windows teardown; re-require dashboard (#5264)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -54,6 +54,36 @@ import (
 // created once in runDaemon before the RPC + dashboard servers start.
 var daemonProgressBroker = progress.NewBroker()
 
+// daemonActivityBroker is the process-wide MCP activity broker, captured at
+// dashboard wiring time so the graceful-stop path (ShutdownCleanup) can flush
+// and close its disk log handle (~/.grafel/mcp-activity.jsonl) before anything
+// removes the home dir. On Windows an open handle blocks unlink, which is what
+// made the isolated selftest teardown fail (#5264). Guarded by
+// daemonActivityBrokerMu.
+var (
+	daemonActivityBroker   *mcp.MCPActivityBroker
+	daemonActivityBrokerMu sync.Mutex
+)
+
+// setDaemonActivityBroker records the process-wide activity broker so the
+// shutdown path can close its disk log.
+func setDaemonActivityBroker(b *mcp.MCPActivityBroker) {
+	daemonActivityBrokerMu.Lock()
+	daemonActivityBroker = b
+	daemonActivityBrokerMu.Unlock()
+}
+
+// closeDaemonActivityLog flushes and closes the MCP activity disk log handle.
+// Idempotent and nil-safe; called from ShutdownCleanup on graceful stop.
+func closeDaemonActivityLog() {
+	daemonActivityBrokerMu.Lock()
+	b := daemonActivityBroker
+	daemonActivityBrokerMu.Unlock()
+	if b != nil {
+		b.CloseLog()
+	}
+}
+
 // defaultDashboardPort is the default TCP port for the embedded dashboard.
 const defaultDashboardPort = 47274
 
@@ -603,6 +633,10 @@ func runDaemon(argv []string) error {
 			if mcpSrv, err := mcpServerInstance(); err == nil {
 				mcpSrv.Stop()
 			}
+			// #5264: flush + close the MCP activity disk log so its file handle
+			// is released. On Windows an open handle blocks unlink, which made
+			// the isolated selftest teardown (os.RemoveAll of ~/.grafel) fail.
+			closeDaemonActivityLog()
 		},
 
 		// #5236: dead-ref / dead-worktree GC hooks. When a branch is deleted or
@@ -1423,6 +1457,9 @@ func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Contex
 			srv.SetMCPActivityLog(logPath)
 		}
 		srv.SetMCPActivityBroker(activityBroker)
+		// Record the broker process-wide so the graceful-stop path can flush +
+		// close its disk log handle before ~/.grafel is removed (#5264).
+		setDaemonActivityBroker(activityBroker)
 		// Wire the broker into the shared MCP server (lazily initialised).
 		// We call mcpServerInstance here to ensure it exists; on failure we
 		// proceed without activity emission rather than crashing the daemon.

--- a/cmd/grafel/selftest.go
+++ b/cmd/grafel/selftest.go
@@ -423,23 +423,10 @@ func selftestWaitReady(env *selftestEnv, timeout time.Duration) (string, error) 
 		if socketReady && dashReady {
 			return fmt.Sprintf("socket=%s dashboard=%s", env.layout.SocketPath, dashURL), nil
 		}
-		// INTERIM (#5264): On Windows CI the ISOLATED in-proc selftest daemon
-		// hangs somewhere after `MigrateToRefStore complete` so the dashboard
-		// goroutine never binds (socket=true, dashboard=false forever). The
-		// PRODUCTION daemon serves /healthz=200 on Windows, so this is a
-		// selftest-path-only defect we cannot yet reproduce locally. To unblock
-		// the gate, treat dashboard-readiness as BEST-EFFORT on Windows: once the
-		// RPC socket answers Ping, Layer-1 passes and we move on (later layers —
-		// MCP, cold-index — still run and the Part-B startup tracing will reveal
-		// the wedged step on the next Windows CI run). Non-Windows is unchanged.
-		if runtimeIsWindows() && socketReady && !dashReady {
-			fmt.Fprintf(os.Stderr, "selftest: WARNING dashboard-readiness skipped on Windows (socket up, dashboard not yet bound) pending #5264 — passing Layer-1 on RPC socket alone\n")
-			detail := fmt.Sprintf("socket=%s dashboard=skipped-on-windows(#5264)", env.layout.SocketPath)
-			if ep := env.dashErr.Load(); ep != nil && *ep != nil {
-				detail = fmt.Sprintf("%s dashErr=%v", detail, *ep)
-			}
-			return detail, nil
-		}
+		// (#5264) The Windows-only dashboard-readiness skip is removed: the
+		// Windows acceptance run confirmed the isolated selftest daemon now
+		// binds the dashboard (`daemon ready ... dashboard=http://127.0.0.1:…/`),
+		// so Layer-1 requires a real dashboard URL on every OS — no skip branch.
 		time.Sleep(100 * time.Millisecond)
 	}
 	// Surface the dashboard goroutine's real bind/serve error (if any) so a
@@ -635,11 +622,35 @@ func selftestTeardown(env *selftestEnv, cancel context.CancelFunc, done chan err
 		}
 	}
 	if !keepRoot {
-		if err := os.RemoveAll(env.root); err != nil {
+		if err := removeAllWithRetry(env.root); err != nil {
 			return "", fmt.Errorf("remove isolated root: %w", err)
 		}
 	}
 	return "clean shutdown; isolated root removed; no leftover socket", nil
+}
+
+// removeAllWithRetry is os.RemoveAll with a short bounded backoff. On Windows a
+// file cannot be unlinked while any process holds an open handle, and handles
+// are released slightly asynchronously after the owning goroutine exits — so a
+// single RemoveAll can race a not-quite-closed handle (e.g. the MCP activity
+// log; see #5264) and fail with "being used by another process". Retrying for a
+// short window tolerates that brief lag. On Unix the first attempt almost always
+// succeeds (open files can be unlinked), so the retry loop costs nothing.
+func removeAllWithRetry(path string) error {
+	const attempts = 10
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = os.RemoveAll(path); err == nil {
+			return nil
+		}
+		// Confirm it's really gone (RemoveAll can report an error yet still have
+		// removed the tree on some platforms); bail out cleanly if so.
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return err
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -169,6 +169,20 @@ func (b *MCPActivityBroker) SetLog(l *ActivityLog) {
 	b.mu.Unlock()
 }
 
+// CloseLog flushes and closes the attached disk log (if any) and detaches it
+// from the broker. Idempotent and safe to call on daemon shutdown; after it
+// returns the underlying file handle is released, which is required before the
+// isolated test root (~/.grafel) can be removed on Windows.
+func (b *MCPActivityBroker) CloseLog() {
+	b.mu.Lock()
+	l := b.log
+	b.log = nil
+	b.mu.Unlock()
+	if l != nil {
+		l.Close()
+	}
+}
+
 // Publish fans e out to every subscriber and (optionally) appends it to the
 // disk log. Non-blocking: slow subscribers are silently dropped.
 func (b *MCPActivityBroker) Publish(e MCPActivityEvent) {

--- a/internal/mcp/activity_log.go
+++ b/internal/mcp/activity_log.go
@@ -34,6 +34,15 @@ type ActivityLog struct {
 	queue chan MCPActivityEvent
 	once  sync.Once
 	done  chan struct{}
+
+	// started records whether the background worker has been launched. Close
+	// must not block on the worker's done channel if Append was never called
+	// (the worker — and therefore the open file handle — never came into
+	// existence). Guarded by startMu.
+	startMu   sync.Mutex
+	started   bool
+	closed    bool
+	closeOnce sync.Once
 }
 
 // NewActivityLog constructs an ActivityLog that writes to path. The
@@ -65,8 +74,21 @@ func DefaultActivityLogPath() string {
 
 // Append enqueues e for disk write. Returns immediately; never blocks.
 // The background goroutine (started on first call) performs the actual I/O.
+// Safe to call after Close: the event is silently dropped (sending on the
+// closed queue would otherwise panic, which select+default does NOT prevent).
 func (l *ActivityLog) Append(e MCPActivityEvent) {
+	l.startMu.Lock()
+	closed := l.closed
+	l.startMu.Unlock()
+	if closed {
+		return
+	}
 	l.once.Do(l.startWorker)
+	defer func() {
+		// Tolerate a Close that raced between the closed-check above and the
+		// send below: sending on a closed channel panics; recover and drop.
+		_ = recover()
+	}()
 	select {
 	case l.queue <- e:
 	default:
@@ -74,16 +96,49 @@ func (l *ActivityLog) Append(e MCPActivityEvent) {
 	}
 }
 
-// Close flushes the remaining queue and stops the background goroutine.
-// After Close returns, further Append calls are silently dropped.
+// Close flushes the remaining queue, stops the background goroutine and waits
+// for it to release the open file handle. It is idempotent and nil-safe, and
+// it does not block when the worker was never started (no Append ever ran), so
+// it is always safe to call on daemon shutdown.
+//
+// Closing the file handle here is what makes the isolated-root teardown work on
+// Windows: Windows refuses to unlink a file while a handle is open, whereas
+// Unix tolerates it. The daemon's graceful-stop path must call Close before any
+// caller removes ~/.grafel.
 func (l *ActivityLog) Close() {
-	close(l.queue)
-	<-l.done
+	if l == nil {
+		return
+	}
+	l.closeOnce.Do(func() {
+		l.startMu.Lock()
+		started := l.started
+		// Mark as closed so any concurrent startWorker becomes a no-op and the
+		// worker goroutine is never launched after Close, and so Append drops
+		// events instead of sending on the closed queue.
+		l.started = true
+		l.closed = true
+		l.startMu.Unlock()
+
+		close(l.queue)
+		if started {
+			// Worker is running (or about to drain the now-closed queue); wait
+			// for it to flush and Close the file handle.
+			<-l.done
+		}
+	})
 }
 
 // startWorker launches the background I/O goroutine. Called once via
-// sync.Once on the first Append.
+// sync.Once on the first Append. If Close has already run, it is a no-op so no
+// new file handle is opened after shutdown.
 func (l *ActivityLog) startWorker() {
+	l.startMu.Lock()
+	if l.started {
+		l.startMu.Unlock()
+		return
+	}
+	l.started = true
+	l.startMu.Unlock()
 	go l.worker()
 }
 

--- a/internal/mcp/activity_log_test.go
+++ b/internal/mcp/activity_log_test.go
@@ -1,0 +1,86 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestActivityLogCloseWithoutAppend ensures Close does not deadlock when the
+// background worker was never started (no Append ever called). Before #5264 the
+// fix, Close blocked forever on <-l.done because the worker — which closes the
+// done channel — only starts on the first Append.
+func TestActivityLogCloseWithoutAppend(t *testing.T) {
+	l := NewActivityLog(filepath.Join(t.TempDir(), ".grafel", activityLogFile))
+	done := make(chan struct{})
+	go func() {
+		l.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() blocked when worker was never started")
+	}
+}
+
+// TestActivityLogCloseIdempotent ensures Close can be called multiple times
+// (and is nil-safe) without panicking on the already-closed queue channel.
+func TestActivityLogCloseIdempotent(t *testing.T) {
+	var nilLog *ActivityLog
+	nilLog.Close() // must not panic
+
+	l := NewActivityLog(filepath.Join(t.TempDir(), ".grafel", activityLogFile))
+	l.Append(MCPActivityEvent{ToolName: "test"})
+	l.Close()
+	l.Close() // second call must be a no-op, not a double-close panic
+}
+
+// TestActivityLogCloseReleasesHandle is the #5264 regression: after Close the
+// log file must be removable (on Windows an open handle blocks unlink; this
+// verifies the worker has released its handle by the time Close returns).
+func TestActivityLogCloseReleasesHandle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".grafel", activityLogFile)
+	l := NewActivityLog(path)
+	l.Append(MCPActivityEvent{ToolName: "test"})
+	l.Close()
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected log file to exist after Close: %v", err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("could not remove dir after Close (handle still open?): %v", err)
+	}
+}
+
+// TestActivityLogAppendAfterClose ensures Append after Close does not panic by
+// sending on the closed queue (it must be silently dropped).
+func TestActivityLogAppendAfterClose(t *testing.T) {
+	l := NewActivityLog(filepath.Join(t.TempDir(), ".grafel", activityLogFile))
+	l.Append(MCPActivityEvent{ToolName: "first"})
+	l.Close()
+	// Append after Close: startWorker is a no-op (started==true) and the
+	// select default path drops the event rather than sending on the closed
+	// queue. Must not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Append after Close panicked: %v", r)
+		}
+	}()
+	l.Append(MCPActivityEvent{ToolName: "after-close"})
+}
+
+// TestBrokerCloseLogIdempotent ensures the broker's CloseLog is safe with and
+// without an attached log, and is idempotent.
+func TestBrokerCloseLogIdempotent(t *testing.T) {
+	b := NewMCPActivityBroker()
+	b.CloseLog() // no log attached — must be a no-op
+
+	l := NewActivityLog(filepath.Join(t.TempDir(), ".grafel", activityLogFile))
+	b.SetLog(l)
+	b.Publish(MCPActivityEvent{ToolName: "test"})
+	b.CloseLog()
+	b.CloseLog() // detached + already closed — must not panic
+}


### PR DESCRIPTION
## Problem

The final Windows selftest acceptance layer (**teardown**) failed:

```
remove isolated root: unlinkat ...\.grafel\mcp-activity.jsonl:
The process cannot access the file because it is being used by another process.
```

Classic Windows: a file handle is still open when the isolated root is removed. Unix allows unlinking files with open handles; Windows does not. The MCP activity log's writer goroutine held `~/.grafel/mcp-activity.jsonl` open and was never closed before the selftest's `os.RemoveAll` ran.

## Root fix — close the handle on graceful stop

- `ActivityLog.Close` is now **idempotent, nil-safe**, and no longer **deadlocks** when the background worker was never started (the old `Close` blocked on `<-l.done` forever if `Append` was never called — the worker, which closes `done`, only starts on the first `Append`). `startWorker` is a no-op after `Close`, and `Append`-after-`Close` drops the event instead of panicking on a send to the closed queue.
- New `MCPActivityBroker.CloseLog` flushes + closes + detaches the disk log.
- The daemon captures the broker process-wide (`setDaemonActivityBroker`) and the graceful-stop `ShutdownCleanup` hook calls `closeDaemonActivityLog()` → `CloseLog`, releasing the handle **before** anything removes `~/.grafel`.

## Belt-and-suspenders — robust teardown

`selftestTeardown` now uses `removeAllWithRetry`: `os.RemoveAll` with a short bounded backoff (~2s, 10×200ms) to tolerate Windows releasing handles slightly asynchronously, plus any other transiently-open file. On Unix the first attempt succeeds, so the retry costs nothing.

## Re-tighten the dashboard check

The latest Windows run proved the isolated selftest daemon now binds the dashboard (`daemon ready ... dashboard=http://127.0.0.1:51290/`), so the Windows-only dashboard-readiness skip in `selftestWaitReady` (#5266) is **removed**. Layer-1 now REQUIRES a real dashboard URL on every OS. Startup trace logs are kept.

## Validation (macOS, isolated)

- `go build ./...` PASS; `go vet ./cmd/grafel ./internal/daemon ./internal/mcp` clean; `gofmt` clean.
- New `internal/mcp/activity_log_test.go` (race-clean): close-without-append (no deadlock), idempotent/nil-safe close, **handle release** (file removable after `Close` — the #5264 regression), append-after-close, broker `CloseLog`.
- Isolated `grafel selftest` 2× → **ALL 6 layers PASS incl. teardown**, with a real dashboard URL in Layer-1 and **no skip warning**.
- Pre-existing unrelated `TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions` failure confirmed present on base; not touched.

Closes #5264
Refs #4457 #5223

🤖 Generated with [Claude Code](https://claude.com/claude-code)