### PR TITLE
fix(uninstall): Windows self-delete-safe --remove-binary (rename-aside + delete-on-reboot) (#5264)

### DIFF
--- a/internal/install/removebinary.go
+++ b/internal/install/removebinary.go
@@ -1,0 +1,91 @@
+// removebinary.go implements self-delete-safe removal of the installed CLI
+// binary for `grafel uninstall --remove-binary` (#5264).
+//
+// The tricky case is platform-specific: on Windows you cannot delete the file
+// backing a running executable, and the uninstall command IS that executable
+// deleting itself. removeBinary therefore dispatches to a build-tagged
+// implementation (removeBinaryPlatform):
+//
+//   - Unix/other (removebinary_other.go): a plain os.Remove. Unlinking a
+//     running binary is permitted on Unix, so nothing special is needed.
+//   - Windows (removebinary_windows.go): try os.Remove first; if it fails with
+//     a sharing/access error AND the target is the currently running exe,
+//     rename it aside within the same directory (allowed for a running exe)
+//     and schedule the orphan for deletion on reboot via MoveFileEx.
+//
+// The platform-neutral helpers (isRunningExecutable, sameFile,
+// renamedAsidePath) live here so they can be unit-tested on any OS.
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+// osRemove is os.Remove indirected so tests can simulate the Windows
+// "access denied while running" failure on a non-Windows host.
+var osRemove = os.Remove
+
+// removeBinary removes the installed CLI binary at binPath. It returns nil when
+// the binary is gone from its canonical install path afterwards — which, on
+// Windows, may mean it was renamed aside and scheduled for deletion on reboot
+// rather than deleted immediately (see removebinary_windows.go).
+func removeBinary(binPath string) error {
+	return removeBinaryPlatform(binPath)
+}
+
+// isRunningExecutable reports whether binPath refers to the same file as the
+// currently running executable. Both paths are canonicalised (symlinks
+// resolved, absolute) before comparison so that e.g. a relative invocation or a
+// symlinked install dir still matches. On any error resolving either side it
+// returns false (treat as "not the running exe" — the caller then just does a
+// plain remove).
+func isRunningExecutable(binPath string) bool {
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	return sameFile(binPath, self)
+}
+
+// sameFile reports whether two paths resolve to the same on-disk file. It first
+// tries os.SameFile (inode/volume identity, the most robust check) and falls
+// back to comparing canonicalised path strings when stat fails (e.g. the file
+// was already renamed). Path canonicalisation resolves symlinks and makes the
+// paths absolute; on Windows callers additionally normalise case.
+func sameFile(a, b string) bool {
+	ai, aerr := os.Stat(a)
+	bi, berr := os.Stat(b)
+	if aerr == nil && berr == nil {
+		if os.SameFile(ai, bi) {
+			return true
+		}
+	}
+	return canonicalPath(a) == canonicalPath(b)
+}
+
+// canonicalPath returns an absolute, symlink-resolved form of p for comparison.
+// It is best-effort: each step is skipped if it errors, so the function never
+// fails — at worst it returns p mostly unchanged. Windows case-folding is
+// applied by the windows build (see removebinary_windows.go's caseFold hook).
+func canonicalPath(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		p = resolved
+	}
+	return caseFold(filepath.Clean(p))
+}
+
+// renamedAsidePath derives a unique sibling path used to move a running exe out
+// of its canonical install location before scheduling it for delayed deletion.
+// It lives next to the original (same directory, so the rename is a cheap
+// directory-entry change that Windows permits even for a running exe) and
+// embeds the pid to avoid colliding with a concurrent uninstall.
+func renamedAsidePath(binPath string, pid int) string {
+	dir := filepath.Dir(binPath)
+	base := filepath.Base(binPath)
+	return filepath.Join(dir, "."+base+".delete-"+strconv.Itoa(pid)+".old")
+}

--- a/internal/install/removebinary_other.go
+++ b/internal/install/removebinary_other.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package install
+
+// removeBinaryPlatform removes the binary on Unix-like systems. Unlinking a
+// running executable is permitted there (the inode lives on until the last
+// open handle closes), so a plain os.Remove is all that's required.
+func removeBinaryPlatform(binPath string) error {
+	return osRemove(binPath)
+}
+
+// caseFold is the identity on case-sensitive filesystems. The windows build
+// overrides it with strings.ToLower so path comparison is case-insensitive.
+func caseFold(p string) string { return p }

--- a/internal/install/removebinary_test.go
+++ b/internal/install/removebinary_test.go
@@ -1,0 +1,111 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestRemoveBinary_RemovesNonRunningBinary verifies the entry function deletes a
+// plain (non-running) binary via the normal path on every OS.
+func TestRemoveBinary_RemovesNonRunningBinary(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "grafel-copy")
+	if err := os.WriteFile(bin, []byte("not the running process"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeBinary(bin); err != nil {
+		t.Fatalf("removeBinary: %v", err)
+	}
+	if _, err := os.Stat(bin); !os.IsNotExist(err) {
+		t.Fatalf("binary still present after removeBinary; stat err = %v", err)
+	}
+}
+
+// TestIsRunningExecutable verifies the running-exe detection: the test binary's
+// own os.Executable() matches, an arbitrary other file does not.
+func TestIsRunningExecutable(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	if !isRunningExecutable(self) {
+		t.Errorf("isRunningExecutable(self=%s) = false, want true", self)
+	}
+
+	other := filepath.Join(t.TempDir(), "other")
+	if err := os.WriteFile(other, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if isRunningExecutable(other) {
+		t.Errorf("isRunningExecutable(other=%s) = true, want false", other)
+	}
+}
+
+// TestSameFile checks identity detection across symlinks and distinct files.
+func TestSameFile(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	if err := os.WriteFile(a, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if sameFile(a, b) {
+		t.Errorf("sameFile(a,b) = true for distinct files")
+	}
+	if !sameFile(a, a) {
+		t.Errorf("sameFile(a,a) = false, want true")
+	}
+
+	// A symlink to a resolves to the same file.
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(a, link); err == nil {
+		if !sameFile(a, link) {
+			t.Errorf("sameFile(a, link->a) = false, want true")
+		}
+	}
+}
+
+// TestRenamedAsidePath checks the orphan path is a unique sibling in the same
+// directory and embeds the pid.
+func TestRenamedAsidePath(t *testing.T) {
+	bin := filepath.FromSlash("/opt/grafel/bin/grafel.exe")
+	pid := 4242
+	got := renamedAsidePath(bin, pid)
+
+	if filepath.Dir(got) != filepath.Dir(bin) {
+		t.Errorf("aside dir = %s, want same dir as bin %s", filepath.Dir(got), filepath.Dir(bin))
+	}
+	if got == bin {
+		t.Errorf("aside path equals original bin path")
+	}
+	if !strings.Contains(filepath.Base(got), strconv.Itoa(pid)) {
+		t.Errorf("aside base %q does not embed pid %d", filepath.Base(got), pid)
+	}
+	if !strings.HasSuffix(got, ".old") {
+		t.Errorf("aside path %q does not end in .old", got)
+	}
+	// Different pids yield different paths (no collision under concurrent uninstall).
+	if renamedAsidePath(bin, 1) == renamedAsidePath(bin, 2) {
+		t.Errorf("aside paths collide across pids")
+	}
+}
+
+// TestCanonicalPath checks absolute + clean normalisation is applied.
+func TestCanonicalPath(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "sub", "..", "file")
+	got := canonicalPath(p)
+	want := caseFold(filepath.Join(dir, "file"))
+	if got != want {
+		t.Errorf("canonicalPath(%q) = %q, want %q", p, got, want)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("canonicalPath result %q is not absolute", got)
+	}
+}

--- a/internal/install/removebinary_windows.go
+++ b/internal/install/removebinary_windows.go
@@ -1,0 +1,100 @@
+//go:build windows
+
+package install
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// removeBinaryPlatform removes the binary on Windows.
+//
+// Windows refuses to delete the file backing a running executable, and the
+// `grafel uninstall --remove-binary` command IS that executable trying to
+// delete itself, so a plain os.Remove returns ERROR_ACCESS_DENIED /
+// ERROR_SHARING_VIOLATION. We handle that case with the standard
+// rename-aside + delete-on-reboot dance:
+//
+//  1. Try os.Remove. If the binary is a *different* copy (not the running
+//     process) this succeeds and we're done.
+//  2. If it fails with a sharing/access error and binPath is the currently
+//     running exe, rename it to a unique sibling within the same directory.
+//     Renaming a running exe is allowed on Windows because it only mutates the
+//     directory entry, not the locked file body. This frees the canonical
+//     install path (<bin>\grafel.exe), which is what the uninstall guarantees.
+//  3. Schedule the renamed orphan for deletion on next reboot via
+//     MoveFileEx(.., NULL, MOVEFILE_DELAY_UNTIL_REBOOT), and best-effort try an
+//     immediate remove (usually still fails while running — harmless).
+//
+// Returning nil here means the binary is gone from its install path; the .old
+// orphan is reboot-cleaned.
+func removeBinaryPlatform(binPath string) error {
+	err := osRemove(binPath)
+	if err == nil {
+		return nil
+	}
+	if !isAccessOrSharingError(err) || !isRunningExecutable(binPath) {
+		return err
+	}
+
+	aside := renamedAsidePath(binPath, os.Getpid())
+	if rerr := os.Rename(binPath, aside); rerr != nil {
+		// Could not free the install path — surface the original error so the
+		// caller reports the genuine failure.
+		return fmt.Errorf("self-delete: rename %s aside: %w (original: %v)", binPath, rerr, err)
+	}
+
+	// The canonical install path is now clear. Schedule the orphan for deletion
+	// on reboot; this is best-effort and must not fail the uninstall.
+	if derr := scheduleDeleteOnReboot(aside); derr != nil {
+		fmt.Fprintf(os.Stderr,
+			"grafel uninstall: binary renamed to %s but could not schedule reboot deletion: %v\n",
+			aside, derr)
+	} else {
+		fmt.Fprintf(os.Stderr,
+			"grafel uninstall: removed binary from install path; running copy %s will be deleted on next reboot\n",
+			aside)
+	}
+	// Try an immediate removal too — succeeds if nothing holds the handle.
+	_ = os.Remove(aside)
+	return nil
+}
+
+// scheduleDeleteOnReboot asks Windows to delete path on the next reboot, after
+// any lock on it is released. Passing a NULL destination with
+// MOVEFILE_DELAY_UNTIL_REBOOT registers a pending delete in the registry.
+func scheduleDeleteOnReboot(path string) error {
+	from, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, nil, windows.MOVEFILE_DELAY_UNTIL_REBOOT)
+}
+
+// isAccessOrSharingError reports whether err is a Windows lock/permission
+// failure of the kind raised when deleting a file backing a running process.
+func isAccessOrSharingError(err error) bool {
+	if errors.Is(err, fs.ErrPermission) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case windows.ERROR_ACCESS_DENIED,
+			windows.ERROR_SHARING_VIOLATION,
+			windows.ERROR_LOCK_VIOLATION:
+			return true
+		}
+	}
+	return false
+}
+
+// caseFold lower-cases p so path comparison on Windows (a case-insensitive
+// filesystem) treats C:\Foo and c:\foo as equal.
+func caseFold(p string) string { return strings.ToLower(p) }

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -215,7 +215,11 @@ func RunUninstall(opts UninstallOptions) (*UninstallResult, error) {
 				fmt.Fprintf(os.Stderr, "grafel uninstall (dry-run): would remove binary %s\n", state.CLI.Path)
 				result.BinaryRemoved = true
 			} else if removeIt {
-				if err := os.Remove(state.CLI.Path); err != nil {
+				// removeBinary is self-delete-safe: on Windows it renames the
+				// running exe aside and schedules it for deletion on reboot when
+				// it cannot be unlinked directly (#5264). On Unix it is a plain
+				// os.Remove.
+				if err := removeBinary(state.CLI.Path); err != nil {
 					fmt.Fprintf(os.Stderr, "grafel uninstall: remove binary %s: %v\n", state.CLI.Path, err)
 				} else {
 					result.BinaryRemoved = true


### PR DESCRIPTION
## Problem

`grafel uninstall --remove-binary` fails on Windows with:

```
remove ...\.grafel\bin\grafel.exe: Access is denied
FAIL: binary still present after --remove-binary
```

This is the last remaining failure in the Windows acceptance selftest (#5264), but it is a **real product bug**: any Windows user who runs `grafel uninstall --remove-binary` hits it, not just CI.

## Root cause

Windows refuses to delete the file backing a **running** executable. The uninstall command IS that executable trying to delete its own file, so `os.Remove` returns `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION`. (On Unix this just works — unlinking a running binary is permitted, the inode survives until the last handle closes.)

## Fix — build-tagged self-delete-safe removal

- **`removebinary.go`** — shared entry point `removeBinary()` plus platform-neutral, unit-tested helpers: `isRunningExecutable` (compares `os.Executable()` to the target via `os.SameFile` + canonicalised paths), `sameFile`, `canonicalPath`, `renamedAsidePath`.
- **`removebinary_windows.go`** (`//go:build windows`):
  1. Try `os.Remove` first — if the binary is a *different* copy (not the running process) this succeeds and we're done.
  2. On a sharing/access error **and** when the target is the currently running exe: **rename it aside** to a unique sibling in the same directory. A same-directory rename of a running exe is permitted on Windows (directory-entry change only), which frees the canonical install path `<bin>\grafel.exe` — exactly what `--remove-binary` guarantees.
  3. **Schedule the orphan for deletion on next reboot** via `MoveFileEx(renamed, NULL, MOVEFILE_DELAY_UNTIL_REBOOT)` (`golang.org/x/sys/windows`, already a direct dep). Best-effort immediate `os.Remove` too. Treated as **success**.
- **`removebinary_other.go`** (`//go:build !windows`) — **Unix unchanged**: plain `os.Remove`.
- **`uninstall.go`** — calls `removeBinary()` instead of `os.Remove()` directly.

After this, `Test-Path <bin>\grafel.exe` is **FALSE** post-uninstall (the CI assertion passes) and the running copy is reboot-cleaned.

## Validation

- `go build ./...` PASS (macOS default).
- `go vet ./internal/install/...` PASS.
- Windows-specific `removebinary*.go` typecheck/compile cleanly for `GOOS=windows GOARCH=amd64` (verified in an isolated module to avoid the pre-existing CGO `go-tree-sitter` cross-compile blocker that affects the whole `./internal/install` tree regardless of this change).
- `go test ./internal/install/...` PASS, including new tests (remove-non-running-binary, running-exe detection, sameFile, rename-aside derivation, canonicalPath) and the existing `TestRunUninstall_RemoveBinaryFlag` through the new path.

Closes #5264
Refs #4457 #5223

🤖 Generated with [Claude Code](https://claude.com/claude-code)