### PR TITLE
docs+release: fix stale <group> arg, Go 1.26 prereq, windows/arm64 release leg (#5274)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ your repos
 
 When an agent calls `grafel_find(query="payment processing")`, the daemon runs BM25 against entity labels and qualified names, then expands outward via BFS — returning a ranked, token-budgeted subgraph in one call. No files are read at query time.
 
-After `grafel install <group>`, the daemon registers itself as an MCP server in your Claude Code config automatically. No manual JSON editing.
+After `grafel install`, the daemon registers itself as an MCP server in your Claude Code config automatically. No manual JSON editing.
 
 ---
 
@@ -56,7 +56,7 @@ After `grafel install <group>`, the daemon registers itself as an MCP server in 
 > The binary must be built from source during the current preview phase — the installer script and GitHub Releases binaries are not yet published. See [docs/install.md](docs/install.md) for the full install matrix.
 
 ```sh
-# 1. Build (requires Go 1.25.5+, CGO, Node 20+)
+# 1. Build (requires Go 1.26+, CGO, Node 20+)
 git clone https://github.com/cajasmota/grafel.git
 cd grafel
 make build
@@ -65,10 +65,10 @@ make build
 ./grafel wizard
 
 # 3. Start the daemon + register MCP + install skills
-./grafel install <group>
+./grafel install
 
 # 4. Confirm everything is wired
-./grafel status <group>
+./grafel status
 
 # 5. Open the dashboard
 ./grafel dashboard

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -84,7 +84,7 @@ Expected output: `Current model: claude-3-haiku-20240307`
 ### Recommended workflow for enrichment
 
 1. `claude --model claude-3-haiku-20240307` — start the session locked to Haiku.
-2. Run `grafel status <group>` to confirm the daemon is up and MCP is connected.
+2. Run `grafel status` to confirm the daemon is up and MCP is connected.
 3. Invoke `/grafel-graph-enrich` — the skill fetches the pending enrichment
    queue, then prints a cost estimate and asks for confirmation before
    dispatching batches. The non-critical batches go to Haiku; the skill will ask
@@ -267,7 +267,7 @@ per-task (set before starting the task).
 ### Wire up MCP (required for `grafel_*` tools)
 
 Cline reads MCP server config from its VS Code extension settings.
-`grafel install <group>` writes the server entry to `~/.claude/claude.json`,
+`grafel install` writes the server entry to `~/.claude/claude.json`,
 but Cline uses its own config file. Copy the server entry:
 
 ```sh
@@ -318,11 +318,11 @@ the fastest path to a working, cost-safe enrichment environment:
 curl -fsSL https://raw.githubusercontent.com/cajasmota/grafel/main/install.sh | bash
 
 # 2. Register your repos and start the daemon
-grafel wizard          # creates group config
-grafel install <group> # starts daemon, wires MCP, writes ~/.claude/claude.json
+grafel wizard   # creates group config
+grafel install  # starts daemon, wires MCP, writes ~/.claude/claude.json
 
 # 3. Confirm MCP is connected
-grafel status <group>  # should show "MCP: connected"
+grafel status   # should show "MCP: connected"
 
 # 4. Open Claude Code locked to Haiku
 claude --model claude-3-haiku-20240307

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ Full install matrix for grafel. For the five-command path see [quickstart.md](qu
 
 | Requirement | Notes |
 |-------------|-------|
-| Go 1.25.5+ | CGO must be enabled (tree-sitter uses a C library) |
+| Go 1.26+ | CGO must be enabled (tree-sitter uses a C library) |
 | C compiler | macOS: `xcode-select --install` / Debian-Ubuntu: `apt install build-essential` / Windows: MinGW via MSYS2 |
 | Node.js 20+ + npm | Dashboard build only — not needed at runtime after `make build` |
 | git | Required for indexing |
@@ -90,8 +90,8 @@ This creates symlinks in `~/.claude/skills/` pointing back to `skills/` in the s
 ```sh
 grafel doctor               # smoke-check install + tools
 grafel wizard               # create a group (interactive)
-grafel install <group>      # start daemon, register MCP, install skills
-grafel status <group>       # confirm MCP: connected
+grafel install              # start daemon, register MCP, install skills
+grafel status               # confirm MCP: connected
 ```
 
 ---

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -12,12 +12,12 @@ This page is the orientation-level **index**: one row per tool grouped by catego
 
 ## Setup
 
-After `grafel install <group>`, the MCP server is registered automatically in your agent's config. The daemon registers one server per machine; multiple groups can be active simultaneously. The server uses stdio transport.
+After `grafel install`, the MCP server is registered automatically in your agent's config. The daemon registers one server per machine; multiple groups can be active simultaneously. The server uses stdio transport.
 
 To verify the wiring:
 
 ```sh
-grafel status <group>    # shows MCP: connected / disconnected
+grafel status    # shows MCP: connected / disconnected
 ```
 
 For per-agent config details see [agent-hosts.md](agent-hosts.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ This page gets you from zero to a running graph in five commands. For a full ins
 
 ## Prerequisites
 
-- **Go 1.25.5+** with CGO enabled. CGO is required because the tree-sitter extractor uses a C library.
+- **Go 1.26+** with CGO enabled. CGO is required because the tree-sitter extractor uses a C library.
   - macOS: `xcode-select --install` (Xcode Command Line Tools)
   - Debian/Ubuntu: `apt install build-essential`
 - **Node.js 20+** and npm (used to build the embedded dashboard)
@@ -52,7 +52,7 @@ You can also use the **Add group** button in the dashboard after step 3.
 ## 3. Start the daemon + register MCP
 
 ```sh
-./grafel install <group>
+./grafel install
 ```
 
 This starts the daemon as a background service, registers the MCP server in your AI agent's config (Claude Code's `~/.claude/claude.json`, or equivalent for other clients), and installs the skill family to `~/.claude/skills/`.
@@ -60,7 +60,7 @@ This starts the daemon as a background service, registers the MCP server in your
 To verify:
 
 ```sh
-./grafel status <group>
+./grafel status
 ```
 
 Output shows `MCP: connected` when the wiring is complete.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,8 +29,8 @@ The dashboard is embedded in the binary. If it shows a blank page:
 ### Agent shows "grafel MCP not found" or no `grafel_*` tools
 
 1. Confirm the daemon is running: `grafel status`
-2. Confirm the MCP entry exists: `grafel status <group>` should show `MCP: connected`
-3. If not connected, re-run: `grafel install <group>`
+2. Confirm the MCP entry exists: `grafel status` should show `MCP: connected`
+3. If not connected, re-run: `grafel install`
 4. Restart your agent session — MCP servers are loaded at session start
 
 ### Agent is in the wrong group or returns `source: "none"` from `grafel_whoami`

--- a/install.ps1
+++ b/install.ps1
@@ -26,7 +26,15 @@ function Get-Arch {
     if ($env:PROCESSOR_ARCHITEW6432) { $procArch = $env:PROCESSOR_ARCHITEW6432 }
     switch ($procArch) {
         'AMD64' { return 'x86_64' }
-        'ARM64' { return 'arm64' }
+        'ARM64' {
+            # No native windows/arm64 release artifact is published: the release
+            # build uses CGO (tree-sitter) and GitHub's x64 Windows runners have
+            # no windows-arm64 C cross-toolchain, so an arm64 leg is not buildable
+            # in CI. Windows on ARM64 runs x64 binaries transparently via
+            # emulation, so install the x86_64 archive instead (#5274).
+            Write-Info "  note: no native windows/arm64 build is published; installing the x86_64 build (runs under Windows ARM64 x64 emulation)."
+            return 'x86_64'
+        }
         'x86'   {
             if ([Environment]::Is64BitOperatingSystem) { return 'x86_64' }
             Fail "unsupported architecture: x86 (32-bit)"


### PR DESCRIPTION
Install/uninstall audit follow-ups (#5274). Docs / scripts / release only — does **not** touch \`internal/install/*.go\` and changes no install behavior.

## Fixes

**1. Stale \`<group>\` arg (finding 6c)** — the \`install\` positional was removed in ADR-0017 Phase C and is now silently ignored. Verified against latest main: \`internal/cli/install.go\` declares \`Use: "install"\` (no positional); \`status [group]\` is an optional registry *filter*, not the daemon-status check the docs describe. Removed the \`<group>\` arg from \`grafel install\` / \`grafel status\` examples in README.md, docs/install.md, docs/quickstart.md, docs/troubleshooting.md, docs/mcp-tools.md, docs/agent-hosts.md (more occurrences than the original finding listed — all swept).

**2. Go prerequisite (finding 6d)** — docs said "Go 1.25.5+"; \`go.mod\` requires \`go 1.26.0\` and release.yml builds with setup-go 1.26. Bumped to **Go 1.26+** in docs/install.md and docs/quickstart.md (and the README build note).

**3. Windows arm64 (finding 5g)** — \`install.ps1\` requested \`grafel_<v>_windows_arm64.zip\` with no matching release artifact → Win-ARM64 users 404.
**Decision: install.ps1 x86_64 fallback (NOT a new release-matrix leg).** Rationale: the release Windows build is CGO (tree-sitter) using MSYS2 **MINGW64** (\`x86_64-w64-mingw32-gcc\`) and GitHub's x64 Windows runners have **no windows-arm64 C cross-toolchain**, so a windows/arm64 CGO leg is not buildable in CI. Windows on ARM64 runs x64 binaries transparently via emulation, so \`Get-Arch\` now returns \`x86_64\` for \`ARM64\` with an informational note. This removes the 404 with zero CI risk.

**4. install.sh post-place (finding 5f)** — **no change.** It correctly runs \`grafel doctor\` and prints a \`grafel wizard\` hint; there is no misleading comment/echo claiming it runs \`grafel install\`.

## Validation
- \`release.yml\` parses (YAML) — unchanged, included only as the build-source-of-truth for the arm64 decision.
- Grep confirms **no remaining** \`grafel install <group>\` / \`grafel status <group>\` / \`Go 1.25\` references in README, docs, or install scripts.
- shellcheck on install.sh: only pre-existing intentional SC2016 infos (literal \`\$PATH\` in rc-file lines); none introduced.

Refs #5274

🤖 Generated with [Claude Code](https://claude.com/claude-code)