### PR TITLE
feat(install): MCP registration for Cursor, Windsurf, Codex (#5254)

### DIFF
--- a/internal/install/enablement_test.go
+++ b/internal/install/enablement_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/install"
@@ -77,5 +78,30 @@ func TestApply_RestrictedEnablement_OnlySubset(t *testing.T) {
 	sort.Strings(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("restricted rules files = %v, want %v", got, want)
+	}
+}
+
+// TestApply_MCPSettings_CursorWindsurfCodex proves that enabling the three
+// #5254 MCP tools records their per-tool config paths (in the right format)
+// in Result.MCPSettings, and that a tool without MCP (copilot) records none.
+func TestApply_MCPSettings_CursorWindsurfCodex(t *testing.T) {
+	res := applyDryRun(t, []string{"cursor", "windsurf", "codex", "copilot"})
+
+	joined := strings.Join(res.MCPSettings, "\n")
+	for _, want := range []string{
+		filepath.Join(".cursor", "mcp.json"),
+		filepath.Join(".codeium", "windsurf", "mcp_config.json"),
+		filepath.Join(".codex", "config.toml"),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("MCPSettings missing %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, filepath.Join(".codex", "config.json")) {
+		t.Fatalf("Codex MCP must be config.toml, not config.json:\n%s", joined)
+	}
+	// copilot has no MCP host; nothing copilot-specific should appear.
+	if strings.Contains(joined, "copilot") {
+		t.Fatalf("copilot should not contribute an MCP path:\n%s", joined)
 	}
 }

--- a/internal/install/mcpreg/json_hosts_test.go
+++ b/internal/install/mcpreg/json_hosts_test.go
@@ -1,0 +1,93 @@
+package mcpreg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// jsonHostCases covers the JSON-shaped MCP hosts whose grafel entries are
+// added in #5254 (Cursor) plus the pre-existing Windsurf. Codex is TOML and
+// covered separately in toml_test.go.
+var jsonHostCases = []Tool{Cursor, Windsurf}
+
+func TestJSONHosts_RegisterPreservesForeignEntry(t *testing.T) {
+	for _, tool := range jsonHostCases {
+		t.Run(string(tool), func(t *testing.T) {
+			withHome(t)
+			path, err := SettingsPath(tool)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.HasSuffix(path, ".toml") {
+				t.Fatalf("%s should be JSON, got %q", tool, path)
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			pre := `{"someSetting":true,"mcpServers":{"other":{"command":"/x","args":["serve"]}}}`
+			if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Register(tool, "/bin/grafel", "/r.json"); err != nil {
+				t.Fatal(err)
+			}
+			var doc map[string]any
+			b, _ := os.ReadFile(path)
+			if err := json.Unmarshal(b, &doc); err != nil {
+				t.Fatalf("invalid JSON after register: %v\n%s", err, b)
+			}
+			if doc["someSetting"] != true {
+				t.Fatalf("lost top-level key: %s", b)
+			}
+			servers, _ := doc["mcpServers"].(map[string]any)
+			if _, ok := servers["other"]; !ok {
+				t.Fatalf("lost foreign server: %s", b)
+			}
+			g, ok := servers[ServerName].(map[string]any)
+			if !ok {
+				t.Fatalf("grafel entry missing: %s", b)
+			}
+			if g["command"] != "/bin/grafel" {
+				t.Fatalf("grafel command wrong: %s", b)
+			}
+		})
+	}
+}
+
+func TestJSONHosts_UnregisterRemovesOnlyGrafel(t *testing.T) {
+	for _, tool := range jsonHostCases {
+		t.Run(string(tool), func(t *testing.T) {
+			withHome(t)
+			path, _ := SettingsPath(tool)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			pre := `{"someSetting":true,"mcpServers":{"other":{"command":"/x"}}}`
+			if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Register(tool, "/bin/grafel", "/r.json"); err != nil {
+				t.Fatal(err)
+			}
+			if err := Unregister(tool); err != nil {
+				t.Fatal(err)
+			}
+			var doc map[string]any
+			b, _ := os.ReadFile(path)
+			_ = json.Unmarshal(b, &doc)
+			if doc["someSetting"] != true {
+				t.Fatalf("lost top-level key after unregister: %s", b)
+			}
+			servers, _ := doc["mcpServers"].(map[string]any)
+			if _, ok := servers["other"]; !ok {
+				t.Fatalf("lost foreign server after unregister: %s", b)
+			}
+			if _, ok := servers[ServerName]; ok {
+				t.Fatalf("grafel entry not removed: %s", b)
+			}
+		})
+	}
+}

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -178,8 +178,10 @@ func SettingsPath(tool Tool) (string, error) {
 		// Cursor: ~/.cursor/mcp.json
 		return filepath.Join(home, ".cursor", "mcp.json"), nil
 	case Codex:
-		// Codex CLI: ~/.codex/config.json
-		return filepath.Join(home, ".codex", "config.json"), nil
+		// Codex CLI: ~/.codex/config.toml. Codex uses TOML (not JSON) and
+		// expects the table [mcp_servers.<name>] (underscore, not the
+		// JSON-world "mcpServers"). See registerTOML/unregisterTOML.
+		return filepath.Join(home, ".codex", "config.toml"), nil
 	case ContinueDev:
 		// Continue.dev: ~/.continue/config.json
 		return filepath.Join(home, ".continue", "config.json"), nil
@@ -404,6 +406,12 @@ func RegisterPath(path, binPath string) (string, error) {
 	if err := backupOnce(path); err != nil {
 		return "", fmt.Errorf("backup %s: %w", filepath.Base(path), err)
 	}
+	if isTOML(path) {
+		// Codex-style TOML host. The same backup/sidecar machinery above
+		// already snapshotted the original, so rollback (RestorePath) is
+		// format-agnostic — it restores or deletes the raw bytes.
+		return path, registerTOML(path, binPath)
+	}
 	doc, err := readSettings(path)
 	if err != nil {
 		return "", err
@@ -438,6 +446,9 @@ func Unregister(tool Tool) error {
 // `{"mcpServers":{}}`. Returns nil if the file or entry doesn't exist
 // (idempotent). It NEVER overwrites foreign servers or resets the file to `{}`.
 func UnregisterPath(path string) error {
+	if isTOML(path) {
+		return unregisterTOML(path)
+	}
 	doc, err := readSettings(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/install/mcpreg/toml.go
+++ b/internal/install/mcpreg/toml.go
@@ -1,0 +1,159 @@
+package mcpreg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Codex (the OpenAI CLI) configures MCP servers in ~/.codex/config.toml, NOT
+// JSON, and under the table name `mcp_servers` (underscore) rather than the
+// JSON-world `mcpServers`. grafel has no TOML dependency in go.mod, so rather
+// than pull one in we treat the file line-by-line as a sequence of
+// table-delimited blocks and surgically add/remove only the
+// [mcp_servers.grafel] block. Every other table — including foreign MCP
+// servers such as [mcp_servers.other] and unrelated top-level keys — is
+// preserved byte-for-byte. The same backup/sidecar machinery used for the
+// JSON hosts snapshots the original first, so rollback (RestorePath) is
+// format-agnostic.
+
+// codexServerTable is the TOML table header grafel owns in Codex config.
+// Codex requires the underscore form `mcp_servers`; the hyphen/camelCase
+// variants are silently ignored by Codex.
+const codexServerTable = "mcp_servers." + ServerName
+
+// isTOML reports whether a config path should be edited as TOML rather than
+// JSON. Dispatch is purely on file extension so format-agnostic callers
+// (e.g. the uninstall loop, which only has a recorded path) route correctly.
+func isTOML(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".toml")
+}
+
+// tomlHeader returns the table name from a line like `[a.b.c]` (trimmed),
+// or "" if the line is not a (standard, non-array) table header. Array-of-
+// tables headers (`[[x]]`) are intentionally not matched: we never write one
+// and must leave any foreign ones untouched as ordinary content.
+func tomlHeader(line string) string {
+	t := strings.TrimSpace(line)
+	if len(t) < 2 || t[0] != '[' || t[len(t)-1] != ']' {
+		return ""
+	}
+	if strings.HasPrefix(t, "[[") {
+		return ""
+	}
+	return strings.TrimSpace(t[1 : len(t)-1])
+}
+
+// stripGrafelBlock returns the file content with the [mcp_servers.grafel]
+// table (its header line plus all following lines up to the next table
+// header or EOF) removed, and reports whether such a block was present.
+// Leading blank lines that immediately preceded the removed block are also
+// trimmed so we don't accumulate blank lines across re-registrations.
+func stripGrafelBlock(content string) (string, bool) {
+	lines := strings.Split(content, "\n")
+	var out []string
+	removed := false
+	skipping := false
+	for _, line := range lines {
+		hdr := tomlHeader(line)
+		if hdr != "" {
+			if hdr == codexServerTable {
+				skipping = true
+				removed = true
+				// Drop trailing blank lines we already emitted that were
+				// acting as the separator before this block.
+				for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+					out = out[:len(out)-1]
+				}
+				continue
+			}
+			skipping = false
+		}
+		if skipping {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n"), removed
+}
+
+// grafelTOMLBlock renders the canonical grafel server table. Mirrors the JSON
+// Entry: command + args ["mcp-bridge"]. (Codex derives stdio transport from
+// the presence of command/args, so no explicit type key is emitted.)
+func grafelTOMLBlock(binPath string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s]\n", codexServerTable)
+	fmt.Fprintf(&b, "command = %s\n", tomlQuote(binPath))
+	b.WriteString("args = [" + tomlQuote("mcp-bridge") + "]\n")
+	return b.String()
+}
+
+// tomlQuote renders a Go string as a TOML basic string literal.
+func tomlQuote(s string) string {
+	// strconv.Quote produces a valid TOML basic string for our inputs
+	// (escapes backslashes, quotes and control chars the same way).
+	return strconv.Quote(s)
+}
+
+// registerTOML adds or replaces the [mcp_servers.grafel] table in a Codex
+// config.toml, preserving every other table and top-level key. Idempotent.
+func registerTOML(path, binPath string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	stripped, _ := stripGrafelBlock(string(raw))
+	// Normalise: trim a trailing run of blank lines, then re-append exactly
+	// one separating blank line before our block when there is prior content.
+	stripped = strings.TrimRight(stripped, "\n")
+	var out strings.Builder
+	if strings.TrimSpace(stripped) != "" {
+		out.WriteString(stripped)
+		out.WriteString("\n\n")
+	}
+	out.WriteString(grafelTOMLBlock(binPath))
+	return writeRaw(path, out.String())
+}
+
+// unregisterTOML removes ONLY the [mcp_servers.grafel] table from a Codex
+// config.toml, leaving every foreign table intact. Idempotent: a missing
+// file or missing block is a no-op. If removing grafel leaves the file empty
+// (or whitespace-only) the now-pointless file is deleted rather than left as
+// an empty husk.
+func unregisterTOML(path string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	stripped, removed := stripGrafelBlock(string(raw))
+	if !removed {
+		return nil
+	}
+	if strings.TrimSpace(stripped) == "" {
+		// We were the only content; don't leave an empty file behind.
+		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+			return rmErr
+		}
+		return nil
+	}
+	return writeRaw(path, strings.TrimRight(stripped, "\n")+"\n")
+}
+
+// writeRaw writes content atomically (temp file + rename), matching the JSON
+// writer's durability behaviour.
+func writeRaw(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/install/mcpreg/toml_test.go
+++ b/internal/install/mcpreg/toml_test.go
@@ -1,0 +1,232 @@
+package mcpreg
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// codexConfig returns the Codex config.toml path under the isolated HOME.
+func codexConfig(t *testing.T) string {
+	t.Helper()
+	p, err := SettingsPath(Codex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(p, ".toml") {
+		t.Fatalf("Codex SettingsPath should be a .toml file, got %q", p)
+	}
+	return p
+}
+
+func TestTOML_RegisterCreatesTable(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "[mcp_servers.grafel]") {
+		t.Fatalf("missing grafel table:\n%s", got)
+	}
+	if !strings.Contains(got, `command = "/bin/grafel"`) {
+		t.Fatalf("missing/incorrect command:\n%s", got)
+	}
+	if !strings.Contains(got, `args = ["mcp-bridge"]`) {
+		t.Fatalf("missing/incorrect args:\n%s", got)
+	}
+}
+
+func TestTOML_PreservesForeignTablesAndTopLevel(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pre := `model = "o4-mini"
+approval_policy = "on-request"
+
+[mcp_servers.other]
+command = "/usr/bin/other"
+args = ["serve"]
+
+[history]
+persistence = "save-all"
+`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path)
+	s := string(got)
+	for _, want := range []string{
+		`model = "o4-mini"`,
+		`approval_policy = "on-request"`,
+		"[mcp_servers.other]",
+		`command = "/usr/bin/other"`,
+		"[history]",
+		`persistence = "save-all"`,
+		"[mcp_servers.grafel]",
+		`command = "/bin/grafel"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("expected %q preserved/present, got:\n%s", want, s)
+		}
+	}
+}
+
+func TestTOML_Idempotent(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := os.ReadFile(path)
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(path)
+	if string(first) != string(second) {
+		t.Fatalf("re-register changed file:\nFIRST:\n%s\nSECOND:\n%s", first, second)
+	}
+	// Exactly one grafel table.
+	if n := strings.Count(string(second), "[mcp_servers.grafel]"); n != 1 {
+		t.Fatalf("expected exactly 1 grafel table, got %d:\n%s", n, second)
+	}
+}
+
+func TestTOML_UpdatesCommandOnReRegister(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	if _, err := Register(Codex, "/old/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Register(Codex, "/new/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := os.ReadFile(path)
+	if strings.Contains(string(s), "/old/grafel") {
+		t.Fatalf("stale command not replaced:\n%s", s)
+	}
+	if !strings.Contains(string(s), `command = "/new/grafel"`) {
+		t.Fatalf("new command missing:\n%s", s)
+	}
+	if n := strings.Count(string(s), "[mcp_servers.grafel]"); n != 1 {
+		t.Fatalf("expected exactly 1 grafel table, got %d:\n%s", n, s)
+	}
+}
+
+func TestTOML_UnregisterRemovesOnlyGrafel(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pre := `model = "o4-mini"
+
+[mcp_servers.other]
+command = "/usr/bin/other"
+`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Unregister(Codex); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := os.ReadFile(path)
+	str := string(s)
+	if strings.Contains(str, "[mcp_servers.grafel]") {
+		t.Fatalf("grafel table not removed:\n%s", str)
+	}
+	if !strings.Contains(str, "[mcp_servers.other]") || !strings.Contains(str, `model = "o4-mini"`) {
+		t.Fatalf("foreign content lost on unregister:\n%s", str)
+	}
+}
+
+func TestTOML_UnregisterIdempotentAndMissingFile(t *testing.T) {
+	withHome(t)
+	// No file at all: no-op.
+	if err := Unregister(Codex); err != nil {
+		t.Fatalf("unregister with no file should be nil, got %v", err)
+	}
+	// File with only foreign content, no grafel: no-op, unchanged.
+	path := codexConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pre := "model = \"x\"\n\n[mcp_servers.other]\ncommand = \"/o\"\n"
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Unregister(Codex); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := os.ReadFile(path)
+	if string(s) != pre {
+		t.Fatalf("file changed despite no grafel block:\n%s", s)
+	}
+}
+
+func TestTOML_UnregisterDeletesSoleGrafelFile(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	// grafel-created file (no prior content).
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Unregister(Codex); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		b, _ := os.ReadFile(path)
+		t.Fatalf("expected sole-grafel file to be deleted, still present:\n%s", b)
+	}
+}
+
+func TestTOML_RestoreRollsBackToOriginal(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orig := "model = \"o4-mini\"\n\n[mcp_servers.other]\ncommand = \"/o\"\n"
+	if err := os.WriteFile(path, []byte(orig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	// Rollback restores the byte-exact original (backup is format-agnostic).
+	if err := RestorePath(path); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := os.ReadFile(path)
+	if string(s) != orig {
+		t.Fatalf("restore did not reproduce original:\nGOT:\n%s\nWANT:\n%s", s, orig)
+	}
+}
+
+func TestTOML_RestoreDeletesCreatedFile(t *testing.T) {
+	withHome(t)
+	path := codexConfig(t)
+	// grafel created the file (no original) → restore deletes it.
+	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RestorePath(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("restore should have deleted grafel-created file %s", path)
+	}
+}

--- a/internal/install/tooladapter/adapters.go
+++ b/internal/install/tooladapter/adapters.go
@@ -53,31 +53,31 @@ func (claudeAdapter) SupportsAgentHook() bool    { return true }
 
 // ── codex ────────────────────────────────────────────────────────────
 //
-// Codex / OpenAI reads AGENTS.md. No MCP entry is registered by grafel
-// today (Codex MCP is a follow-up, #5254/#5255).
+// Codex / OpenAI reads AGENTS.md and registers an MCP server in its TOML
+// config (~/.codex/config.toml, table [mcp_servers.grafel]) — #5254.
 type codexAdapter struct{}
 
 func (codexAdapter) ID() string                 { return "codex" }
 func (codexAdapter) DisplayName() string        { return "Codex" }
 func (codexAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Codex) }
 func (codexAdapter) RulesFileTargets() []string { return []string{rulesAGENTS} }
-func (codexAdapter) SupportsMCP() bool          { return false }
-func (codexAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (codexAdapter) SupportsMCP() bool          { return true }
+func (codexAdapter) MCPTool() mcpreg.Tool       { return mcpreg.Codex }
 func (codexAdapter) SupportsSkills() bool       { return false }
 func (codexAdapter) SupportsAgentHook() bool    { return false }
 
 // ── cursor ───────────────────────────────────────────────────────────
 //
-// Cursor Composer reads .cursorrules. grafel does not register Cursor MCP
-// today (#5254/#5255).
+// Cursor Composer reads .cursorrules and registers an MCP server in its
+// user-global JSON config (~/.cursor/mcp.json, mcpServers.grafel) — #5254.
 type cursorAdapter struct{}
 
 func (cursorAdapter) ID() string                 { return "cursor" }
 func (cursorAdapter) DisplayName() string        { return "Cursor" }
 func (cursorAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Cursor) }
 func (cursorAdapter) RulesFileTargets() []string { return []string{rulesCursor} }
-func (cursorAdapter) SupportsMCP() bool          { return false }
-func (cursorAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (cursorAdapter) SupportsMCP() bool          { return true }
+func (cursorAdapter) MCPTool() mcpreg.Tool       { return mcpreg.Cursor }
 func (cursorAdapter) SupportsSkills() bool       { return false }
 func (cursorAdapter) SupportsAgentHook() bool    { return false }
 

--- a/internal/install/tooladapter/tooladapter.go
+++ b/internal/install/tooladapter/tooladapter.go
@@ -42,8 +42,8 @@ import (
 //   - RulesFileTargets() returns nil/empty when the tool has no per-repo
 //     rules file convention.
 //   - SupportsMCP()/MCPTool() report whether grafel registers an MCP entry
-//     for this tool TODAY (only Claude + Windsurf return true here; other
-//     tools' MCP is a follow-up ticket).
+//     for this tool (Claude, Windsurf, Cursor and Codex return true; Codex
+//     is written as TOML, the rest as JSON — see mcpreg).
 //   - SupportsSkills()/SupportsAgentHook() are Claude-only today.
 type Adapter interface {
 	// ID is the stable, lowercase identifier persisted in

--- a/internal/install/tooladapter/tooladapter_test.go
+++ b/internal/install/tooladapter/tooladapter_test.go
@@ -27,9 +27,10 @@ func TestDefaultEnablement_ReproducesAllSixRulesFiles(t *testing.T) {
 	}
 }
 
-// TestDefaultEnablement_ClaudeAndWindsurfMCP guards that the default set
-// registers exactly the two MCP tools grafel writes today.
-func TestDefaultEnablement_ClaudeAndWindsurfMCP(t *testing.T) {
+// TestDefaultEnablement_MCPTools guards the set of MCP tools grafel
+// registers under the default (all-tools) enablement. Cursor and Codex were
+// added in #5254 alongside the pre-existing Claude + Windsurf.
+func TestDefaultEnablement_MCPTools(t *testing.T) {
 	var mcp []mcpreg.Tool
 	for _, a := range tooladapter.EnabledAdapters(nil) {
 		if a.SupportsMCP() {
@@ -37,7 +38,7 @@ func TestDefaultEnablement_ClaudeAndWindsurfMCP(t *testing.T) {
 		}
 	}
 	sort.Slice(mcp, func(i, j int) bool { return mcp[i] < mcp[j] })
-	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Windsurf}
+	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Codex, mcpreg.Cursor, mcpreg.Windsurf}
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 	if !reflect.DeepEqual(mcp, want) {
 		t.Fatalf("default MCP tools = %v, want %v", mcp, want)
@@ -55,9 +56,12 @@ func TestRestrictedEnablement_OnlySubset(t *testing.T) {
 	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{".cursorrules"}) {
 		t.Fatalf("cursor rules targets = %v, want [.cursorrules]", rt)
 	}
-	// Cursor has no MCP today and no agent hook.
-	if ad[0].SupportsMCP() || ad[0].SupportsAgentHook() || ad[0].SupportsSkills() {
-		t.Fatalf("cursor should not support MCP/hook/skills")
+	// Cursor registers MCP (#5254) but has no agent hook or skills.
+	if !ad[0].SupportsMCP() || ad[0].MCPTool() != mcpreg.Cursor {
+		t.Fatalf("cursor must register Cursor MCP")
+	}
+	if ad[0].SupportsAgentHook() || ad[0].SupportsSkills() {
+		t.Fatalf("cursor should not support hook/skills")
 	}
 }
 


### PR DESCRIPTION
Extends grafel's MCP registration beyond Claude to **Cursor**, **Windsurf** and **Codex**, each wired behind its `tooladapter` so the entry is written only when that tool is in the enabled set (#5253 enablement model). Part of EPIC #5252; builds on the ToolAdapter foundation (#5253).

## The three adapters / paths / formats
| Tool | Config path | Format | Key |
|------|-------------|--------|-----|
| Cursor | `~/.cursor/mcp.json` | JSON | `mcpServers.grafel` |
| Windsurf | `~/.codeium/windsurf/mcp_config.json` | JSON | `mcpServers.grafel` (pre-existing — verified/completed) |
| Codex | `~/.codex/config.toml` | **TOML** | `[mcp_servers.grafel]` |

- **Cursor** uses the **user-global** `mcp.json` (documented choice — matches grafel's ADR-0004 "one global server, route by caller-CWD"; grafel never writes per-project `.mcp.json`).
- **Codex** previously had `SettingsPath` pointing at `config.json`; corrected to the real Codex CLI path/format: `config.toml`, table name `mcp_servers` **with an underscore** (the hyphen/camelCase variants are silently ignored by Codex).

## Reused safety (Claude path, verbatim for JSON hosts)
- Idempotent surgical upsert of `mcpServers.grafel`.
- **Foreign `mcpServers` entries + all top-level keys preserved** — never clobbered.
- **Rollback** via the existing backup/sidecar machinery (`RestorePath`): grafel-created files are deleted, real originals restored byte-for-byte.
- Uninstall/deregister (`UnregisterPath`) removes **only** the `grafel` key and drops an emptied `mcpServers`.

## TOML handling for Codex
`go.mod` has no TOML dependency, so Codex gets a minimal **block-based TOML editor** (`internal/install/mcpreg/toml.go`) that splits the file on table headers and adds/removes **only** the `[mcp_servers.grafel]` table — every foreign table (incl. `[mcp_servers.other]`) and top-level key is kept byte-for-byte. `Register`/`Unregister`/`RestorePath` dispatch on the `.toml` extension, so the format-agnostic uninstall loop routes correctly and Codex inherits the same backup/rollback semantics as the JSON hosts.

## Enablement / back-compat
Default enablement still registers every tool — Windsurf was already written unconditionally for default installs; Cursor and Codex now join it under the same model. Restricting `tools` to a subset writes only that subset's MCP entries.

## Tests (isolated temp HOME, never real HOME)
- TOML: create table, **preserve foreign tables + top-level keys**, idempotent re-register, command-update, unregister-removes-only-grafel, sole-file deletion, **restore rollback** to byte-exact original.
- JSON hosts (Cursor + Windsurf): foreign-entry preservation + grafel-only unregister.
- `Apply` (dry-run) records the right per-tool paths/formats and copilot (no MCP host) contributes none.
- `go build ./...`, `go vet ./internal/install/...`, `go test ./internal/install/...` all green. The pre-existing unrelated `TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions` (cmd/grafel, the backend framework DRF) is the only failure and is untouched by this change.

Closes #5254
Refs #5252

🤖 Generated with [Claude Code](https://claude.com/claude-code)