### PR TITLE
fix(install): recognize legacy archigraph rules block + skills reconcile + uninstall rules-block removal (#5274)

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -42,7 +42,7 @@ func registerMCPInClaudeConfigs(out io.Writer, binPath string, claudeConfigDirs 
 	return registered
 }
 
-// installSkillsInClaudeConfigs symlinks the 6 grafel skills into every
+// installSkillsInClaudeConfigs symlinks the 15 grafel skills into every
 // detected Claude Code config directory. It's extracted into a separate
 // function so it can be tested independently of service.Install.
 //

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -325,6 +325,13 @@ func Uninstall(group string, purge bool) error {
 		for _, r := range cfg.Repos {
 			_ = hooks.Uninstall(r.Path)
 			_ = agenthooks.Uninstall(r.Path)
+			// Strip the grafel rules block from this repo's rules files,
+			// mirroring the WriteTargets step in Apply. Only the
+			// marker-wrapped region is removed; surrounding user content is
+			// preserved, and a file is deleted only if grafel was its sole
+			// author (#5274). Best-effort: I/O errors are ignored so a
+			// single unwritable file never blocks the rest of uninstall.
+			_, _ = rulesfiles.RemoveAll(r.Path)
 			u := watchers.Unit{Group: group, Repo: r.Path, BinPath: bin}
 			// Deregister from the OS scheduler before removing the unit file so
 			// that the OS does not attempt to launch a missing binary.

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -58,17 +58,25 @@ var (
 	EndMarker   = "<!-- grafel:mcp-usage:end -->"
 )
 
-// startMarkerAnyVersion matches an existing grafel block regardless
-// of its embedded version number, so we can replace older blocks in
-// place. The end marker is unversioned and a literal string.
-var startMarkerAnyVersion = regexp.MustCompile(`<!-- grafel:mcp-usage:start v=\d+ -->`)
+// startMarkerAnyVersion matches an existing managed block regardless of
+// its embedded version number, so we can replace older blocks in place.
+// It matches BOTH the current `grafel:mcp-usage` marker and the legacy
+// `archigraph:mcp-usage` marker written by pre-rename binaries, so an
+// existing archigraph block is recognised and replaced in place instead
+// of having a second grafel block appended next to it (#5274). The end
+// marker may be versioned (current) or unversioned; both forms appear in
+// historical files.
+var startMarkerAnyVersion = regexp.MustCompile(`<!-- (?:grafel|archigraph):mcp-usage:start v=\d+ -->`)
 
 // blockRegexAnyVersion captures the entire marker-wrapped region (start
 // + content + end), with DOTALL so newlines inside the block are
-// consumed.
+// consumed. Like startMarkerAnyVersion it matches both the current
+// `grafel:mcp-usage` markers and the legacy `archigraph:mcp-usage`
+// markers, so a legacy block is replaced/removed cleanly rather than
+// duplicated (#5274).
 var blockRegexAnyVersion = regexp.MustCompile(
-	`(?s)<!-- grafel:mcp-usage:start v=\d+ -->.*?` +
-		regexp.QuoteMeta(EndMarker))
+	`(?s)<!-- (?:grafel|archigraph):mcp-usage:start v=\d+ -->.*?` +
+		`<!-- (?:grafel|archigraph):mcp-usage:end -->`)
 
 // PredecessorTokens are the names of older tools whose guidance, if
 // found in a rules file, indicates a stale file that probably misleads
@@ -77,6 +85,7 @@ var blockRegexAnyVersion = regexp.MustCompile(
 // adding generic words here risks false positives.
 var PredecessorTokens = []string{
 	"graphify",
+	"archigraph",
 }
 
 // Targets is the canonical list of per-repo rules-file paths the
@@ -194,6 +203,83 @@ func WriteTargets(repoRoot string, opts WriteOptions, targets []string) (*WriteR
 		}
 	}
 	return res, nil
+}
+
+// RemoveResult is the outcome of stripping the grafel block from a
+// repo's rules files on uninstall.
+type RemoveResult struct {
+	// Stripped lists files whose grafel block was removed while leaving
+	// surrounding user content intact.
+	Stripped []string
+	// Deleted lists files that were removed entirely because, after
+	// stripping the block, nothing but whitespace remained.
+	Deleted []string
+}
+
+// RemoveAll strips the grafel-managed block from every Target under
+// repoRoot. It is the symmetric inverse of WriteAll for uninstall: only
+// the marker-wrapped region is touched, all surrounding user content is
+// preserved byte-for-byte, and a file is deleted only when removing the
+// block leaves it empty (i.e. grafel was the sole author of that file).
+//
+// It is idempotent and best-effort: files that don't exist or don't
+// contain a grafel block are silently skipped. Errors are returned only
+// for genuine I/O problems.
+func RemoveAll(repoRoot string) (*RemoveResult, error) {
+	return RemoveTargets(repoRoot, Targets)
+}
+
+// RemoveTargets is RemoveAll restricted to an explicit subset of targets,
+// mirroring WriteTargets so the uninstall path can strip exactly the
+// files the install wrote.
+func RemoveTargets(repoRoot string, targets []string) (*RemoveResult, error) {
+	res := &RemoveResult{}
+	for _, target := range targets {
+		abs := filepath.Join(repoRoot, target)
+		existing, err := os.ReadFile(abs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return res, fmt.Errorf("rulesfiles: read %s: %w", target, err)
+		}
+		if !blockRegexAnyVersion.Match(existing) {
+			// No grafel block — leave the file completely untouched.
+			continue
+		}
+		out := blockRegexAnyVersion.ReplaceAll(existing, nil)
+		// If only whitespace remains, grafel was the sole author of this
+		// file — delete it. Otherwise rewrite with the block removed,
+		// trimming any leftover blank-line gap at the seam.
+		if len(strings.TrimSpace(string(out))) == 0 {
+			if err := os.Remove(abs); err != nil && !os.IsNotExist(err) {
+				return res, fmt.Errorf("rulesfiles: remove %s: %w", target, err)
+			}
+			res.Deleted = append(res.Deleted, target)
+			continue
+		}
+		cleaned := tidySeam(out)
+		if err := atomicWrite(abs, cleaned); err != nil {
+			return res, fmt.Errorf("rulesfiles: rewrite %s: %w", target, err)
+		}
+		res.Stripped = append(res.Stripped, target)
+	}
+	return res, nil
+}
+
+// tidySeam collapses the run of blank lines left where the block used to
+// sit (install appends the block after a blank-line separator) into a
+// single trailing newline, so removing the block doesn't leave a growing
+// gap. User content above/below is otherwise preserved.
+func tidySeam(b []byte) []byte {
+	s := string(b)
+	// Collapse 3+ consecutive newlines (created by removing a block that
+	// was separated from prose by a blank line) into two.
+	for strings.Contains(s, "\n\n\n") {
+		s = strings.ReplaceAll(s, "\n\n\n", "\n\n")
+	}
+	s = strings.TrimRight(s, " \t\n") + "\n"
+	return []byte(s)
 }
 
 // Scan returns the FileStatus for every Target under repoRoot without

--- a/internal/install/rulesfiles/rulesfiles_test.go
+++ b/internal/install/rulesfiles/rulesfiles_test.go
@@ -267,3 +267,158 @@ func TestIsPureStaleFile(t *testing.T) {
 		})
 	}
 }
+
+// TestWriteAll_ReplacesLegacyArchigraphBlock covers #5274: a file holding
+// a legacy `archigraph:mcp-usage` block must be recognised and replaced
+// in place by the current grafel block — no duplicate block, no leftover
+// archigraph marker.
+func TestWriteAll_ReplacesLegacyArchigraphBlock(t *testing.T) {
+	repo := t.TempDir()
+	legacy := "# Notes\n\n<!-- archigraph:mcp-usage:start v=1 -->\n## archigraph MCP\nold guidance pointing at archigraph\n<!-- archigraph:mcp-usage:end -->\n"
+	path := filepath.Join(repo, "CLAUDE.md")
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	s := string(data)
+	// Legacy markers must be gone entirely.
+	if strings.Contains(s, "archigraph:mcp-usage") {
+		t.Errorf("legacy archigraph marker still present:\n%s", s)
+	}
+	// Exactly one current grafel block (no duplicate appended).
+	if n := strings.Count(s, "grafel:mcp-usage:start"); n != 1 {
+		t.Errorf("expected exactly 1 grafel start marker, got %d:\n%s", n, s)
+	}
+	if !strings.Contains(s, StartMarker) {
+		t.Errorf("current grafel block missing:\n%s", s)
+	}
+	// Surrounding user content preserved.
+	if !strings.Contains(s, "# Notes") {
+		t.Errorf("surrounding user content lost:\n%s", s)
+	}
+}
+
+// TestWriteAll_LegacyArchigraphOnlyFile verifies a file that is ONLY a
+// legacy archigraph block is cleanly replaced (still one block, no dup).
+func TestWriteAll_LegacyArchigraphOnlyFile(t *testing.T) {
+	repo := t.TempDir()
+	legacy := "<!-- archigraph:mcp-usage:start v=2 -->\nguidance\n<!-- archigraph:mcp-usage:end -->\n"
+	path := filepath.Join(repo, ".cursorrules")
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	s, _ := os.ReadFile(path)
+	if strings.Contains(string(s), "archigraph:mcp-usage") {
+		t.Errorf("legacy marker still present:\n%s", s)
+	}
+	if n := strings.Count(string(s), "grafel:mcp-usage:start"); n != 1 {
+		t.Errorf("expected 1 grafel block, got %d:\n%s", n, s)
+	}
+}
+
+// TestWriteAll_GraphifyStillHandled is a regression guard that the older
+// graphify pure-stale heuristic still works after the archigraph changes.
+func TestWriteAll_GraphifyStillHandled(t *testing.T) {
+	repo := t.TempDir()
+	stale := "# Graphify\n\n- Run `graphify update`\n"
+	path := filepath.Join(repo, ".windsurfrules")
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res, err := WriteAll(repo, WriteOptions{GroupName: "demo"})
+	if err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	if len(res.ReplacedStale) == 0 {
+		t.Fatalf("graphify pure-stale not replaced: %+v", res)
+	}
+	s, _ := os.ReadFile(path)
+	if strings.Contains(string(s), "graphify") {
+		t.Errorf("graphify content not removed:\n%s", s)
+	}
+}
+
+// TestRemoveAll_StripsBlockPreservesProse covers the uninstall side of
+// #5274: stripping the grafel block must leave surrounding user prose
+// intact, while a file that is ONLY the grafel block is deleted.
+func TestRemoveAll_StripsBlockPreservesProse(t *testing.T) {
+	repo := t.TempDir()
+
+	// File with prose + grafel block → block stripped, prose kept.
+	mixedPath := filepath.Join(repo, "CLAUDE.md")
+	prose := "# My Project\n\nImportant local instructions.\n"
+	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
+		t.Fatalf("WriteAll: %v", err)
+	}
+	// Overwrite CLAUDE.md with prose + block so we control the prose.
+	mixed := prose + "\n" + RenderBlock("demo") + "\n"
+	if err := os.WriteFile(mixedPath, []byte(mixed), 0o644); err != nil {
+		t.Fatalf("seed mixed: %v", err)
+	}
+
+	res, err := RemoveAll(repo)
+	if err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	// CLAUDE.md keeps prose, loses the block.
+	data, rerr := os.ReadFile(mixedPath)
+	if rerr != nil {
+		t.Fatalf("CLAUDE.md should still exist: %v", rerr)
+	}
+	if strings.Contains(string(data), "grafel:mcp-usage") {
+		t.Errorf("grafel block not stripped from mixed file:\n%s", data)
+	}
+	if !strings.Contains(string(data), "Important local instructions.") {
+		t.Errorf("user prose lost:\n%s", data)
+	}
+	if !contains(res.Stripped, "CLAUDE.md") {
+		t.Errorf("CLAUDE.md not reported stripped: %+v", res)
+	}
+
+	// Files that were ONLY the grafel block (every other Target, since
+	// WriteAll wrote a block-only file there) are deleted.
+	if _, err := os.Stat(filepath.Join(repo, ".windsurfrules")); !os.IsNotExist(err) {
+		t.Errorf(".windsurfrules (block-only) should have been deleted, err=%v", err)
+	}
+	if !contains(res.Deleted, ".windsurfrules") {
+		t.Errorf(".windsurfrules not reported deleted: %+v", res)
+	}
+}
+
+// TestRemoveAll_LeavesNonGrafelFilesUntouched ensures removal never
+// touches a file that has no grafel block.
+func TestRemoveAll_LeavesNonGrafelFilesUntouched(t *testing.T) {
+	repo := t.TempDir()
+	path := filepath.Join(repo, "CLAUDE.md")
+	original := "# Just my notes\n\nNo grafel here.\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	res, err := RemoveAll(repo)
+	if err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != original {
+		t.Errorf("non-grafel file modified:\nwant %q\ngot  %q", original, data)
+	}
+	if len(res.Stripped) != 0 || len(res.Deleted) != 0 {
+		t.Errorf("expected no-op, got %+v", res)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/install/skilllink/skilllink.go
+++ b/internal/install/skilllink/skilllink.go
@@ -18,11 +18,23 @@ import (
 	"strings"
 )
 
-// SkillNames lists the 8 grafel skills in canonical order.
+// SkillNames lists the 15 user-invocable grafel skills in canonical order.
+//
+// Deliberately EXCLUDED from this list (#5274): `grafel-graph-read` and
+// `grafel-graph-write`. Those two are not standalone Claude skills — their
+// SKILL.md frontmatter describes them as "Shared grafel read/persistence
+// protocol — Compose into any persona", and they carry no `when-to-use`
+// (so Claude Code would never auto-trigger them). They are shared protocol
+// fragments composed into the consult/docs personas, not user-facing
+// commands, so symlinking them would surface two un-triggerable skills in
+// the user's skills directory. `grafel-feedback`, by contrast, IS a
+// directly user-invocable skill (it has a full `when-to-use` and a
+// /grafel-feedback entry point) and is included.
 var SkillNames = []string{
 	"grafel-aware-review",
 	"grafel-business-docs",
 	"grafel-consult",
+	"grafel-feedback",
 	"grafel-graph-enrich",
 	"grafel-graph-quality",
 	"grafel-help",

--- a/internal/install/skilllink/skilllink_test.go
+++ b/internal/install/skilllink/skilllink_test.go
@@ -651,3 +651,38 @@ func TestValidateSkillSymlinks(t *testing.T) {
 func stringContains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }
+
+// TestSkillNames_Reconciled guards the #5274 skills reconcile: the set is
+// the expected count, includes the user-facing grafel-feedback skill, and
+// deliberately EXCLUDES the persona-only shared protocols grafel-graph-read
+// and grafel-graph-write.
+func TestSkillNames_Reconciled(t *testing.T) {
+	const want = 15
+	if len(SkillNames) != want {
+		t.Errorf("SkillNames count = %d, want %d: %v", len(SkillNames), want, SkillNames)
+	}
+	has := func(name string) bool {
+		for _, s := range SkillNames {
+			if s == name {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("grafel-feedback") {
+		t.Errorf("grafel-feedback (user-invocable) must be in SkillNames")
+	}
+	for _, excluded := range []string{"grafel-graph-read", "grafel-graph-write"} {
+		if has(excluded) {
+			t.Errorf("%s is a persona-only shared protocol and must NOT be in SkillNames", excluded)
+		}
+	}
+	// No duplicates.
+	seen := map[string]bool{}
+	for _, s := range SkillNames {
+		if seen[s] {
+			t.Errorf("duplicate skill: %s", s)
+		}
+		seen[s] = true
+	}
+}


### PR DESCRIPTION
Install/uninstall audit follow-ups for #5274 (install-code portion).

## P0 — duplicate stale block on archigraph→grafel upgrade
An existing user with a legacy `<!-- archigraph:mcp-usage:start --> … :end -->` block was neither recognized for in-place replacement nor flagged stale, so `grafel install` **APPENDED a second grafel block**, leaving a duplicate stale archigraph block. Fix: extend `startMarkerAnyVersion` / `blockRegexAnyVersion` to match BOTH `grafel:mcp-usage` and the legacy `archigraph:mcp-usage` markers, so a legacy block is **replaced in place** (one current `grafel:mcp-usage:start v=2` block, no leftover archigraph marker). Also added `"archigraph"` to `PredecessorTokens`.

## P1 — skills reconcile
`skills/` has 17 dirs; `SkillNames` listed 14.
- **Added `grafel-feedback`** — it is a directly user-invocable skill (full `when-to-use`, `/grafel-feedback` entry point).
- **Left OUT `grafel-graph-read` / `grafel-graph-write`** — their SKILL.md frontmatter says "Shared grafel read/persistence protocol — Compose into any persona" and they carry **no `when-to-use`**, i.e. persona-composed shared protocol fragments, not standalone Claude skills. Symlinking them would surface two un-triggerable skills. Documented the deliberate exclusion in a code comment.
- Fixed stale count comments (`skilllink.go`, `cli/install.go` → 15).

## P1 — uninstall removes rules blocks (symmetry)
Uninstall previously left the grafel block in every rules file. Added `rulesfiles.RemoveAll` / `RemoveTargets`: strips only the marker-wrapped block (reusing `blockRegexAnyVersion`), preserves surrounding user prose byte-for-byte, collapses the leftover blank-line seam, and deletes a file only when grafel was its sole author. Wired into `install.Uninstall`, which iterates the group's repos exactly like `Apply` (the path that writes the rules files via `WriteTargets`).

## Validation
- `go build ./...` PASS, `go vet ./internal/install/... ./internal/cli/...` clean.
- `go test ./internal/install/... ./internal/cli/...` green incl. new tests (legacy-archigraph in-place replace — mixed + block-only; graphify regression guard; uninstall strip-preserves-prose + delete-block-only + leave-non-grafel-untouched; skills count/feedback-in/graph-read+write-out).
- `grafel selftest` — all 6 layers PASS.

Refs #5274

🤖 Generated with [Claude Code](https://claude.com/claude-code)