### PR TITLE
feat(install): Antigravity + Kiro tool adapters (rules + MCP) (#5255)

### DIFF
--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -80,6 +80,7 @@ const (
 	Codex             Tool = "codex"
 	ContinueDev       Tool = "continue-dev"
 	Zed               Tool = "zed"
+	Kiro              Tool = "kiro"
 )
 
 // ConfigShape describes the JSON layout of a host's config file for
@@ -192,6 +193,15 @@ func SettingsPath(tool Tool) (string, error) {
 			return "", err
 		}
 		return filepath.Join(xdg, "zed", "settings.json"), nil
+	case Kiro:
+		// Kiro (AWS agentic IDE): user-global MCP config at
+		// ~/.kiro/settings/mcp.json. Kiro also supports a workspace-level
+		// config at <repo>/.kiro/settings/mcp.json, but to match grafel's
+		// ADR-0004 one-global-entry-per-tool model (the single daemon routes
+		// by caller-CWD, so a per-repo entry is unnecessary), we register the
+		// user-global file — same convention as Cursor (~/.cursor/mcp.json).
+		// The JSON shape is identical to Cursor: { "mcpServers": { ... } }.
+		return filepath.Join(home, ".kiro", "settings", "mcp.json"), nil
 	}
 	return "", fmt.Errorf("unknown tool: %s", tool)
 }
@@ -247,6 +257,13 @@ func DetectCodexPaths() []HostTarget {
 // other top-level keys such as "models"; all are preserved).
 func DetectContinueDevPaths() []HostTarget {
 	return DetectHostPaths([]string{".continue"}, "config.json", ShapeNested)
+}
+
+// DetectKiroPaths returns Kiro config paths to register.
+// Uses ~/.kiro/settings/mcp.json — ShapeFlat (mcpServers key at root,
+// same shape as Cursor).
+func DetectKiroPaths() []HostTarget {
+	return DetectHostPaths([]string{".kiro", "settings"}, "mcp.json", ShapeFlat)
 }
 
 // DetectZedPaths returns Zed config paths to register.

--- a/internal/install/mcpreg/mcpreg_test.go
+++ b/internal/install/mcpreg/mcpreg_test.go
@@ -477,6 +477,125 @@ func TestInstall_SkipsAbsentCursor(t *testing.T) {
 	}
 }
 
+// ── Kiro tests ──────────────────────────────────────────────────────────────
+
+// TestInstall_RegistersKiro: ~/.kiro/settings/ present → DetectKiroPaths
+// returns the mcp.json path and RegisterPath writes a valid grafel entry
+// with the Cursor-shaped { "mcpServers": { ... } } layout (#5255).
+func TestInstall_RegistersKiro(t *testing.T) {
+	home := withHome(t)
+
+	settingsDir := filepath.Join(home, ".kiro", "settings")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := DetectKiroPaths()
+	wantPath := filepath.Join(settingsDir, "mcp.json")
+	if len(targets) != 1 || targets[0].Path != wantPath {
+		t.Fatalf("DetectKiroPaths: got %v, want [{%s ShapeFlat}]", targets, wantPath)
+	}
+	if targets[0].Shape != ShapeFlat {
+		t.Fatalf("Kiro shape: got %v, want ShapeFlat", targets[0].Shape)
+	}
+
+	// SettingsPath(Kiro) must resolve to the same user-global file.
+	sp, err := SettingsPath(Kiro)
+	if err != nil {
+		t.Fatalf("SettingsPath(Kiro): %v", err)
+	}
+	if sp != wantPath {
+		t.Fatalf("SettingsPath(Kiro) = %q, want %q", sp, wantPath)
+	}
+
+	if _, err := RegisterPath(wantPath, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		McpServers map[string]Entry `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	got := doc.McpServers[ServerName]
+	if got.Command != "/usr/local/bin/grafel" {
+		t.Fatalf("kiro: command = %q, want /usr/local/bin/grafel", got.Command)
+	}
+	if len(got.Args) != 1 || got.Args[0] != "mcp-bridge" {
+		t.Fatalf("kiro: args = %v, want [mcp-bridge]", got.Args)
+	}
+	if got.Type != "stdio" {
+		t.Fatalf("kiro: type = %q, want stdio", got.Type)
+	}
+}
+
+// TestInstall_SkipsAbsentKiro: no ~/.kiro dir → DetectKiroPaths is empty.
+func TestInstall_SkipsAbsentKiro(t *testing.T) {
+	withHome(t)
+	if targets := DetectKiroPaths(); len(targets) != 0 {
+		t.Fatalf("expected no Kiro paths when .kiro absent, got %v", targets)
+	}
+}
+
+// TestKiro_PreservesForeignServers_AndUnregisters: registering grafel into a
+// Kiro mcp.json that already has another server preserves the foreign entry,
+// and Unregister removes ONLY grafel's key (#5255 safety, same as Cursor).
+func TestKiro_PreservesForeignServers_AndUnregisters(t *testing.T) {
+	home := withHome(t)
+	settingsDir := filepath.Join(home, ".kiro", "settings")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(settingsDir, "mcp.json")
+
+	seed := `{"mcpServers":{"other":{"command":"/bin/other","args":["x"]}},"someKiroSetting":true}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	b, _ := os.ReadFile(path)
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Fatalf("foreign server 'other' was dropped: %v", servers)
+	}
+	if _, ok := servers[ServerName]; !ok {
+		t.Fatalf("grafel server not written: %v", servers)
+	}
+	if doc["someKiroSetting"] != true {
+		t.Fatalf("unrelated key 'someKiroSetting' not preserved: %v", doc["someKiroSetting"])
+	}
+
+	if err := UnregisterPath(path); err != nil {
+		t.Fatal(err)
+	}
+	b, _ = os.ReadFile(path)
+	doc = nil
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	servers, _ = doc["mcpServers"].(map[string]any)
+	if _, ok := servers[ServerName]; ok {
+		t.Fatalf("grafel not removed on unregister: %v", servers)
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Fatalf("unregister dropped foreign server 'other': %v", servers)
+	}
+	if doc["someKiroSetting"] != true {
+		t.Fatalf("unregister dropped unrelated key: %v", doc["someKiroSetting"])
+	}
+}
+
 // ── Codex tests ───────────────────────────────────────────────────────────────
 
 // TestInstall_RegistersCodex: ~/.codex/ present → DetectCodexPaths returns
@@ -886,6 +1005,7 @@ func TestInstall_SkipsAbsentHost(t *testing.T) {
 		{"Codex", DetectCodexPaths},
 		{"ContinueDev", DetectContinueDevPaths},
 		{"Zed", DetectZedPaths},
+		{"Kiro", DetectKiroPaths},
 	}
 	for _, h := range hosts {
 		t.Run(h.name, func(t *testing.T) {

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -10,6 +10,8 @@
 //   - Cursor Composer  → .cursorrules
 //   - Codeium          → .codeium/instructions.md
 //   - GitHub Copilot   → .github/copilot-instructions.md
+//   - Kiro             → .kiro/steering/grafel.md
+//   - Antigravity      → .agent/rules/grafel.md
 //
 // `grafel install` historically only wrote the rules block into
 // AGENTS.md, which meant Cascade and Cursor sessions did not learn that
@@ -101,6 +103,8 @@ var Targets = []string{
 	".cursorrules",
 	".codeium/instructions.md",
 	".github/copilot-instructions.md",
+	".kiro/steering/grafel.md",
+	".agent/rules/grafel.md",
 }
 
 // Status is the per-file state reported by Scan / doctor.

--- a/internal/install/rulesfiles/rulesfiles_test.go
+++ b/internal/install/rulesfiles/rulesfiles_test.go
@@ -63,6 +63,57 @@ func TestWriteAll_FreshRepo(t *testing.T) {
 	}
 }
 
+// TestWriteTargets_KiroAndAntigravity verifies the #5255 nested-directory
+// targets (Kiro steering + Antigravity rules) round-trip: WriteTargets
+// creates the parent dirs and block, a second write is idempotent, and
+// RemoveTargets deletes the grafel-authored files.
+func TestWriteTargets_KiroAndAntigravity(t *testing.T) {
+	repo := t.TempDir()
+	targets := []string{".kiro/steering/grafel.md", ".agent/rules/grafel.md"}
+
+	res, err := WriteTargets(repo, WriteOptions{GroupName: "demo"}, targets)
+	if err != nil {
+		t.Fatalf("WriteTargets: %v", err)
+	}
+	if len(res.Written) != 2 {
+		t.Fatalf("expected 2 written, got %v", res.Written)
+	}
+	for _, target := range targets {
+		data, err := os.ReadFile(filepath.Join(repo, target))
+		if err != nil {
+			t.Fatalf("missing %s: %v", target, err)
+		}
+		if !bytes.Contains(data, []byte(StartMarker)) || !bytes.Contains(data, []byte("grafel MCP")) {
+			t.Errorf("%s: block not written", target)
+		}
+	}
+
+	// Idempotent: second write does not duplicate the block.
+	if _, err := WriteTargets(repo, WriteOptions{GroupName: "demo"}, targets); err != nil {
+		t.Fatalf("WriteTargets second: %v", err)
+	}
+	for _, target := range targets {
+		data, _ := os.ReadFile(filepath.Join(repo, target))
+		if n := bytes.Count(data, []byte(StartMarker)); n != 1 {
+			t.Errorf("%s: expected 1 block, got %d", target, n)
+		}
+	}
+
+	// Remove strips/deletes grafel-authored files.
+	rr, err := RemoveTargets(repo, targets)
+	if err != nil {
+		t.Fatalf("RemoveTargets: %v", err)
+	}
+	if len(rr.Deleted) != 2 {
+		t.Fatalf("expected 2 deleted (grafel sole author), got %v / stripped %v", rr.Deleted, rr.Stripped)
+	}
+	for _, target := range targets {
+		if _, err := os.Stat(filepath.Join(repo, target)); !os.IsNotExist(err) {
+			t.Errorf("%s: expected removed, stat err=%v", target, err)
+		}
+	}
+}
+
 // TestWriteAll_Idempotent verifies that a second run does not duplicate
 // the block.
 func TestWriteAll_Idempotent(t *testing.T) {

--- a/internal/install/tooladapter/adapters.go
+++ b/internal/install/tooladapter/adapters.go
@@ -17,6 +17,12 @@ const (
 	rulesCursor   = ".cursorrules"
 	rulesCodeium  = ".codeium/instructions.md"
 	rulesCopilot  = ".github/copilot-instructions.md"
+	// rulesKiro is Kiro's project-level steering file. Kiro reads markdown
+	// guidance from <repo>/.kiro/steering/*.md.
+	rulesKiro = ".kiro/steering/grafel.md"
+	// rulesAntigravity is Google Antigravity's workspace rules file. Rules
+	// live as markdown under <repo>/.agent/rules/*.md.
+	rulesAntigravity = ".agent/rules/grafel.md"
 )
 
 // hasMCPHost reports whether the given tool's MCP config file (or its
@@ -126,3 +132,49 @@ func (copilotAdapter) SupportsMCP() bool          { return false }
 func (copilotAdapter) MCPTool() mcpreg.Tool       { return "" }
 func (copilotAdapter) SupportsSkills() bool       { return false }
 func (copilotAdapter) SupportsAgentHook() bool    { return false }
+
+// ── kiro ─────────────────────────────────────────────────────────────
+//
+// Kiro (AWS agentic IDE) reads project-level steering files from
+// <repo>/.kiro/steering/*.md (we write .kiro/steering/grafel.md) and
+// connects to MCP servers via a JSON config with the same { "mcpServers":
+// { ... } } shape as Cursor. grafel registers in the user-global
+// ~/.kiro/settings/mcp.json (mcpreg.Kiro) to match ADR-0004's single
+// global-entry-per-tool model — the same choice made for Cursor. Kiro also
+// supports a workspace-level .kiro/settings/mcp.json, but a per-repo entry
+// is unnecessary since the daemon routes by caller-CWD. (#5255)
+type kiroAdapter struct{}
+
+func (kiroAdapter) ID() string                 { return "kiro" }
+func (kiroAdapter) DisplayName() string        { return "Kiro" }
+func (kiroAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Kiro) }
+func (kiroAdapter) RulesFileTargets() []string { return []string{rulesKiro} }
+func (kiroAdapter) SupportsMCP() bool          { return true }
+func (kiroAdapter) MCPTool() mcpreg.Tool       { return mcpreg.Kiro }
+func (kiroAdapter) SupportsSkills() bool       { return false }
+func (kiroAdapter) SupportsAgentHook() bool    { return false }
+
+// ── antigravity ──────────────────────────────────────────────────────
+//
+// Google Antigravity (agentic IDE) reads workspace rules as markdown from
+// <repo>/.agent/rules/*.md (we write .agent/rules/grafel.md).
+//
+// MCP: SupportsMCP()==false for now. Antigravity's MCP config path is not
+// confidently verifiable — public sources disagree on the location
+// (~/.gemini/antigravity/mcp_config.json vs ~/.gemini/config/mcp_config.json)
+// and Antigravity uses a non-standard `serverUrl` key (vs the usual `url`),
+// signalling its JSON shape is not a drop-in Cursor clone. Per #5255 we ship
+// the rules-file adapter only rather than invent a path we can't justify.
+// TODO(#5255 follow-up): confirm the Antigravity MCP config path + JSON
+// format against a pinned IDE version, then flip SupportsMCP()==true and add
+// the mcpreg.Tool entry (and a serverUrl-aware writer if needed).
+type antigravityAdapter struct{}
+
+func (antigravityAdapter) ID() string                 { return "antigravity" }
+func (antigravityAdapter) DisplayName() string        { return "Antigravity" }
+func (antigravityAdapter) DetectInstalled() bool      { return false }
+func (antigravityAdapter) RulesFileTargets() []string { return []string{rulesAntigravity} }
+func (antigravityAdapter) SupportsMCP() bool          { return false }
+func (antigravityAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (antigravityAdapter) SupportsSkills() bool       { return false }
+func (antigravityAdapter) SupportsAgentHook() bool    { return false }

--- a/internal/install/tooladapter/tooladapter.go
+++ b/internal/install/tooladapter/tooladapter.go
@@ -94,6 +94,8 @@ func adapters() []Adapter {
 		windsurfAdapter{},
 		codeiumAdapter{},
 		copilotAdapter{},
+		kiroAdapter{},
+		antigravityAdapter{},
 	}
 }
 

--- a/internal/install/tooladapter/tooladapter_test.go
+++ b/internal/install/tooladapter/tooladapter_test.go
@@ -29,7 +29,8 @@ func TestDefaultEnablement_ReproducesAllSixRulesFiles(t *testing.T) {
 
 // TestDefaultEnablement_MCPTools guards the set of MCP tools grafel
 // registers under the default (all-tools) enablement. Cursor and Codex were
-// added in #5254 alongside the pre-existing Claude + Windsurf.
+// added in #5254 alongside the pre-existing Claude + Windsurf; Kiro was added
+// in #5255 (Antigravity is rules-only, no MCP).
 func TestDefaultEnablement_MCPTools(t *testing.T) {
 	var mcp []mcpreg.Tool
 	for _, a := range tooladapter.EnabledAdapters(nil) {
@@ -38,7 +39,7 @@ func TestDefaultEnablement_MCPTools(t *testing.T) {
 		}
 	}
 	sort.Slice(mcp, func(i, j int) bool { return mcp[i] < mcp[j] })
-	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Codex, mcpreg.Cursor, mcpreg.Windsurf}
+	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Codex, mcpreg.Cursor, mcpreg.Windsurf, mcpreg.Kiro}
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 	if !reflect.DeepEqual(mcp, want) {
 		t.Fatalf("default MCP tools = %v, want %v", mcp, want)
@@ -108,9 +109,50 @@ func TestLookupAndAllIDs(t *testing.T) {
 	if _, ok := tooladapter.Lookup("does-not-exist"); ok {
 		t.Fatal("unknown id must not resolve")
 	}
-	want := []string{"claude", "codex", "cursor", "windsurf", "codeium", "copilot"}
+	want := []string{"claude", "codex", "cursor", "windsurf", "codeium", "copilot", "kiro", "antigravity"}
 	if got := tooladapter.AllIDs(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("AllIDs = %v, want %v", got, want)
+	}
+}
+
+// TestKiroAdapter checks Kiro's targets: a steering rules file plus an MCP
+// entry registered into the user-global ~/.kiro/settings/mcp.json (#5255).
+func TestKiroAdapter(t *testing.T) {
+	cfg := &registry.GroupConfig{Tools: []string{"kiro"}}
+	ad := tooladapter.EnabledAdapters(cfg)
+	if len(ad) != 1 || ad[0].ID() != "kiro" {
+		t.Fatalf("expected only kiro adapter, got %v", idsOf(ad))
+	}
+	a := ad[0]
+	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{".kiro/steering/grafel.md"}) {
+		t.Fatalf("kiro rules targets = %v, want [.kiro/steering/grafel.md]", rt)
+	}
+	if !a.SupportsMCP() || a.MCPTool() != mcpreg.Kiro {
+		t.Fatalf("kiro must register Kiro MCP")
+	}
+	if a.SupportsAgentHook() || a.SupportsSkills() {
+		t.Fatalf("kiro should not support hook/skills")
+	}
+}
+
+// TestAntigravityAdapter checks Antigravity is a rules-only adapter (#5255):
+// a workspace .agent/rules/grafel.md file and NO MCP entry (path not yet
+// confidently verifiable — see adapter doc TODO).
+func TestAntigravityAdapter(t *testing.T) {
+	cfg := &registry.GroupConfig{Tools: []string{"antigravity"}}
+	ad := tooladapter.EnabledAdapters(cfg)
+	if len(ad) != 1 || ad[0].ID() != "antigravity" {
+		t.Fatalf("expected only antigravity adapter, got %v", idsOf(ad))
+	}
+	a := ad[0]
+	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{".agent/rules/grafel.md"}) {
+		t.Fatalf("antigravity rules targets = %v, want [.agent/rules/grafel.md]", rt)
+	}
+	if a.SupportsMCP() || a.MCPTool() != "" {
+		t.Fatalf("antigravity must NOT register MCP (path unverified)")
+	}
+	if a.SupportsAgentHook() || a.SupportsSkills() {
+		t.Fatalf("antigravity should not support hook/skills")
 	}
 }
 


### PR DESCRIPTION
Adds two new ToolAdapters to the #5253 foundation, mirroring how Cursor/Codex were wired in #5276.

## Kiro (AWS agentic IDE) — rules + MCP
- **Steering file:** `<repo>/.kiro/steering/grafel.md` (Kiro reads project steering markdown from `.kiro/steering/*.md`). Written via the existing `rulesfiles` marker/upsert machinery, so uninstall strips it.
- **MCP:** user-global `~/.kiro/settings/mcp.json` (`mcpreg.Kiro`), JSON with the same `{ "mcpServers": { ... } }` shape as Cursor.
  - **Path choice / justification:** Kiro supports BOTH workspace-level (`<repo>/.kiro/settings/mcp.json`) and user-global (`~/.kiro/settings/mcp.json`). Per **ADR-0004** — exactly one grafel MCP entry per tool, a single global server that routes by caller-CWD; grafel never writes per-project MCP files — the user-global file is the natural fit. This matches the choice already made for Cursor (`~/.cursor/mcp.json`).
  - Reuses the JSON `mcpreg` dual-write / rollback / **foreign-entry + unrelated-key preservation**, and surgical unregister.

## Antigravity (Google agentic IDE) — rules only
- **Workspace rules:** `<repo>/.agent/rules/grafel.md` (Antigravity reads workspace rules as markdown from `.agent/rules/*.md` — verified against the official docs + community guides).
- **MCP: `SupportsMCP()==false` for now.** The MCP config path is **NOT confidently verifiable**:
  - Public sources disagree on the location (`~/.gemini/antigravity/mcp_config.json` vs `~/.gemini/config/mcp_config.json`).
  - Antigravity uses a non-standard `serverUrl` key (vs the usual `url`/Cursor `command`/`args`), so its JSON is not a drop-in Cursor clone.
  - Per the #5255 brief we ship the **rules-file adapter only** rather than invent a path we cannot justify, with an in-code `TODO` to flip `SupportsMCP` on once the path/format is pinned against a released IDE version.

## Enablement
Both adapters join the **DEFAULT (all-tools) set** — they are registered in the adapter registry, so `AllIDs()` / `EnabledTools()` include them, exactly as #5276 did for Cursor/Codex. A config with an explicit `tools` allow-list that omits them installs neither (opt-out via allow-list).

## Reused safety
- Rules files: same marker/remove machinery → uninstall strips their blocks; nested parent dirs (`.kiro/steering/`, `.agent/rules/`) auto-created by `atomicWrite`.
- Kiro MCP JSON: `mcpreg` backup/rollback + foreign-entry preservation + idempotent upsert + surgical unregister.
- No schema / entity-Kind changes — pure install wiring.

## Validation (NO live install/uninstall)
- `go build ./...` PASS; `go vet ./internal/install/...` clean.
- New unit tests (temp dirs only): kiro/antigravity rules write+remove idempotency; Kiro MCP entry (valid `mcpServers.grafel`, foreign-server + unrelated-key preservation, surgical unregister); `DetectKiroPaths` skip-when-absent; updated default-enablement + AllIDs guards.
- `go test ./internal/install/...` — **all green**.
- `grafel selftest` — **all 6 layers PASS**.

Closes #5255
Refs #5252

🤖 Generated with [Claude Code](https://claude.com/claude-code)