### PR TITLE
feat(cli): per-tool selection — install --tools flag + interactive wizard + 'grafel tools' command (#5256)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
 	golang.org/x/sys v0.44.0
+	golang.org/x/term v0.43.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.81.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -82,7 +83,6 @@ require (
 	golang.org/x/image v0.40.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/mode"
@@ -13,6 +15,8 @@ import (
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/skilllink"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
 )
 
 // registerMCPInClaudeConfigs registers the grafel MCP entry in all detected
@@ -84,6 +88,9 @@ func newInstallCmd() *cobra.Command {
 	var devMode bool
 	var force bool
 	var noHooks bool
+	var toolsCSV string
+	var noWizard bool
+	var assumeYes bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -118,6 +125,23 @@ Install also copies or symlinks the grafel skills into every detected
 Claude Code config directory's skills/ subdirectory.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
+
+			// ── per-tool selection (#5256) ─────────────────────────────────
+			// Resolve the desired tool set and persist it to every registered
+			// group's GroupConfig.Tools. Precedence:
+			//   1. --tools a,b,c   → explicit, validated, NON-interactive.
+			//   2. interactive wizard → only when stdin is a TTY AND neither
+			//      --tools nor --yes/--no-wizard was given.
+			//   3. otherwise (no flag, no TTY, or --yes/--no-wizard) → leave
+			//      the existing selection untouched, i.e. today's behaviour
+			//      (EnabledTools falls back to all tools). CI is never blocked.
+			if sel, ok, err := resolveToolSelection(cmd, out, toolsCSV, noWizard, assumeYes); err != nil {
+				return err
+			} else if ok {
+				if err := persistToolSelection(out, sel); err != nil {
+					return err
+				}
+			}
 
 			if foreground {
 				// --foreground: skip service registration, just run the daemon
@@ -252,7 +276,126 @@ Claude Code config directory's skills/ subdirectory.`,
 	// #2222: git hooks opt-out.
 	cmd.Flags().BoolVar(&noHooks, "no-hooks", false,
 		"skip automatic git hook installation (post-checkout, post-merge, post-rewrite, pre-push)")
+	// #5256: per-tool selection.
+	cmd.Flags().StringVar(&toolsCSV, "tools", "",
+		"comma-separated AI coding tools to target (e.g. claude,cursor,windsurf); when set, selection is non-interactive. Run 'grafel tools list' for valid IDs")
+	cmd.Flags().BoolVar(&noWizard, "no-wizard", false,
+		"skip the interactive tool-selection wizard even on a TTY (keep the current/default tool set)")
+	cmd.Flags().BoolVar(&assumeYes, "yes", false,
+		"assume defaults for all prompts (alias for --no-wizard for tool selection); never blocks automation")
 	return cmd
+}
+
+// resolveToolSelection decides the per-tool selection for `grafel install`.
+//
+// Returns (selection, applied, err):
+//   - (ids, true, nil)  → caller should persist ids to GroupConfig.Tools.
+//   - (nil, false, nil) → no change requested (no flag, no TTY, or --yes/
+//     --no-wizard): leave the existing selection alone so back-compat /
+//     automation behaviour is preserved.
+//
+// --tools wins and is non-interactive. Otherwise the wizard runs ONLY when
+// stdin is an interactive terminal and the user did not pass --yes/--no-wizard.
+func resolveToolSelection(cmd *cobra.Command, out io.Writer, toolsCSV string, noWizard, assumeYes bool) ([]string, bool, error) {
+	if toolsCSV != "" {
+		ids, err := tooladapter.ParseToolsFlag(toolsCSV)
+		if err != nil {
+			return nil, false, err
+		}
+		return ids, true, nil
+	}
+	if noWizard || assumeYes {
+		return nil, false, nil
+	}
+	if !stdinIsTTY() {
+		// Non-interactive / piped / CI: never prompt.
+		return nil, false, nil
+	}
+	ids, err := runToolWizard(out)
+	if err != nil {
+		return nil, false, err
+	}
+	return ids, true, nil
+}
+
+// stdinIsTTY reports whether standard input is an interactive terminal. It is
+// a var so tests can stub it.
+var stdinIsTTY = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// runToolWizard presents the interactive multi-select checkbox of all
+// adapters, pre-checked by DetectInstalled(), and returns the chosen IDs.
+// The selection→IDs mapping is delegated to tooladapter.NormalizeSelection so
+// the pure logic is testable without a TTY.
+func runToolWizard(out io.Writer) ([]string, error) {
+	choices := tooladapter.WizardChoices(nil)
+	opts := make([]huh.Option[string], 0, len(choices))
+	var preselected []string
+	for _, c := range choices {
+		label := c.DisplayName
+		if c.Detected {
+			label += " (detected)"
+		}
+		opts = append(opts, huh.NewOption(label, c.ID).Selected(c.PreChecked))
+		if c.PreChecked {
+			preselected = append(preselected, c.ID)
+		}
+	}
+	selected := append([]string{}, preselected...)
+	if err := huh.NewMultiSelect[string]().
+		Title("AI coding tools to target").
+		Description("Pre-checked tools were detected on this machine. Toggle with space, confirm with enter.").
+		Options(opts...).
+		Value(&selected).
+		Run(); err != nil {
+		return nil, err
+	}
+	ids := tooladapter.NormalizeSelection(selected)
+	if len(ids) == 0 {
+		fmt.Fprintln(out, "  no tools selected — keeping the default (all supported tools)")
+		// Persist an empty explicit set would disable everything; instead we
+		// treat "selected nothing" as "use the default" to avoid a footgun.
+		return tooladapter.AllIDs(), nil
+	}
+	return ids, nil
+}
+
+// persistToolSelection writes the resolved tool IDs into GroupConfig.Tools for
+// every registered group and re-applies the per-tool artifact delta in-process
+// (no subprocess, no daemon restart). With no groups registered it is a no-op
+// (the daemon-service install still proceeds).
+func persistToolSelection(out io.Writer, ids []string) error {
+	groups, err := registry.Groups()
+	if err != nil {
+		return fmt.Errorf("read registry: %w", err)
+	}
+	if len(groups) == 0 {
+		fmt.Fprintf(out, "  tools:   %v (saved on first group registration)\n", ids)
+		return nil
+	}
+	bin, _ := os.Executable()
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil || cfg == nil {
+			fmt.Fprintf(out, "  ⚠ tools: load %s: %v\n", g.Name, err)
+			continue
+		}
+		prev := tooladapter.EnabledTools(cfg)
+		cfg.Tools = ids
+		if err := registry.SaveGroupConfig(g.ConfigPath, cfg); err != nil {
+			fmt.Fprintf(out, "  ⚠ tools: save %s: %v\n", g.Name, err)
+			continue
+		}
+		res, err := install.ApplyToolDelta(cfg, g.Name, bin, prev, ids, nil)
+		if err != nil {
+			fmt.Fprintf(out, "  ⚠ tools: apply %s: %v\n", g.Name, err)
+			continue
+		}
+		fmt.Fprintf(out, "  tools:   %s → %v (enabled %v, disabled %v)\n",
+			g.Name, ids, res.Enabled, res.Disabled)
+	}
+	return nil
 }
 
 // runInstallDev runs the DEV-mode install transaction (issue #2212) and

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,7 @@ func newRoot() *cobra.Command {
 		newWizardCmd(),
 		newOnboardCmd(),
 		newInstallCmd(),
+		newToolsCmd(),
 		newUpdateCmd(),
 		newDoctorCmd(),
 		newStatusCmd(),

--- a/internal/cli/tools.go
+++ b/internal/cli/tools.go
@@ -1,0 +1,247 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// newToolsCmd returns the `grafel tools` command group (#5256): inspect and
+// change which AI coding tools grafel targets for a group, applying the
+// per-tool artifact delta IN-PROCESS (no `grafel install` subprocess, no
+// daemon restart).
+func newToolsCmd() *cobra.Command {
+	var group string
+
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "List or change the AI coding tools grafel targets",
+		Long: `tools inspects and changes which AI coding tools grafel installs
+into for a group (rules files, MCP entries, skills/hooks).
+
+  grafel tools                 list all tools with enabled/detected state
+  grafel tools list            (same as above)
+  grafel tools enable <id...>  enable tools and write their artifacts
+  grafel tools disable <id...> disable tools and remove their artifacts
+
+enable/disable update GroupConfig.Tools and re-apply only the changed tools'
+artifacts in-process — they never run 'grafel install' as a subprocess and
+never stop/start the daemon.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runToolsList(cmd.OutOrStdout(), group)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&group, "group", "", "group name (default: the only registered group)")
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all tools with enabled/detected state",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runToolsList(cmd.OutOrStdout(), group)
+		},
+	}
+
+	enableCmd := &cobra.Command{
+		Use:   "enable <id...>",
+		Short: "Enable tools and write their artifacts",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runToolsToggle(cmd.OutOrStdout(), group, args, true)
+		},
+	}
+
+	disableCmd := &cobra.Command{
+		Use:   "disable <id...>",
+		Short: "Disable tools and remove their artifacts",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runToolsToggle(cmd.OutOrStdout(), group, args, false)
+		},
+	}
+
+	cmd.AddCommand(listCmd, enableCmd, disableCmd)
+	return cmd
+}
+
+// runToolsList prints every registered adapter with its enabled state (for
+// the resolved group) and its DetectInstalled() signal.
+func runToolsList(out io.Writer, group string) error {
+	name, err := resolveGroup(group)
+	if err != nil {
+		return err
+	}
+	cfg, err := loadGroupConfigByName(name)
+	if err != nil {
+		return err
+	}
+	enabled := map[string]bool{}
+	for _, id := range tooladapter.EnabledTools(cfg) {
+		enabled[id] = true
+	}
+	explicit := len(cfg.Tools) > 0
+
+	fmt.Fprintf(out, "tools for group %q", name)
+	if !explicit {
+		fmt.Fprintf(out, " (no explicit selection — all tools enabled by default)")
+	}
+	fmt.Fprintln(out, ":")
+	for _, a := range tooladapter.All() {
+		state := "disabled"
+		if enabled[a.ID()] {
+			state = "enabled"
+		}
+		det := ""
+		if a.DetectInstalled() {
+			det = "  (detected)"
+		}
+		fmt.Fprintf(out, "  %-12s %-8s %s%s\n", a.ID(), state, a.DisplayName(), det)
+	}
+	return nil
+}
+
+// runToolsToggle enables or disables the given tool IDs for the resolved
+// group: it validates the IDs, updates GroupConfig.Tools, persists it, and
+// re-applies the artifact delta in-process via install.ApplyToolDelta.
+func runToolsToggle(out io.Writer, group string, ids []string, enable bool) error {
+	for _, id := range ids {
+		if _, ok := tooladapter.Lookup(strings.ToLower(strings.TrimSpace(id))); !ok {
+			return fmt.Errorf("unknown tool %q; valid tools: %s",
+				id, strings.Join(tooladapter.AllIDs(), ", "))
+		}
+	}
+	name, err := resolveGroup(group)
+	if err != nil {
+		return err
+	}
+	cfgPath, err := registeredConfigPath(name)
+	if err != nil {
+		return err
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil || cfg == nil {
+		return fmt.Errorf("load group %q config: %w", name, err)
+	}
+
+	prev := tooladapter.EnabledTools(cfg)
+	next := applyToggle(prev, ids, enable)
+
+	if equalIDSet(prev, next) {
+		fmt.Fprintf(out, "no change: tools already %v\n", tooladapter.SortedIDs(next))
+		return nil
+	}
+
+	cfg.Tools = next
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		return fmt.Errorf("save group config: %w", err)
+	}
+
+	bin, _ := os.Executable()
+	res, err := install.ApplyToolDelta(cfg, name, bin, prev, next, nil)
+	if err != nil {
+		return fmt.Errorf("apply tool delta: %w", err)
+	}
+
+	verb := "enabled"
+	if !enable {
+		verb = "disabled"
+	}
+	fmt.Fprintf(out, "%s %v for group %q\n", verb, ids, name)
+	fmt.Fprintf(out, "  tools now: %v\n", next)
+	if len(res.Enabled) > 0 {
+		fmt.Fprintf(out, "  wrote artifacts for: %v\n", res.Enabled)
+	}
+	if len(res.Disabled) > 0 {
+		fmt.Fprintf(out, "  removed artifacts for: %v\n", res.Disabled)
+	}
+	for repo, t := range res.RulesWritten {
+		fmt.Fprintf(out, "    %s: wrote %v\n", repo, t)
+	}
+	for repo, t := range res.RulesRemoved {
+		fmt.Fprintf(out, "    %s: removed %v\n", repo, t)
+	}
+	if len(res.MCPRegistered) > 0 {
+		fmt.Fprintf(out, "    MCP registered: %v\n", res.MCPRegistered)
+	}
+	if len(res.MCPUnregistered) > 0 {
+		fmt.Fprintf(out, "    MCP unregistered: %v\n", res.MCPUnregistered)
+	}
+	return nil
+}
+
+// applyToggle returns the new explicit tool-ID set after enabling (or
+// disabling) the given ids relative to prev. The result is normalized to
+// known IDs in registry order. Pure: testable without any FS.
+func applyToggle(prev, ids []string, enable bool) []string {
+	set := map[string]bool{}
+	for _, id := range prev {
+		set[id] = true
+	}
+	for _, id := range ids {
+		set[strings.ToLower(strings.TrimSpace(id))] = enable
+	}
+	var keep []string
+	for id, on := range set {
+		if on {
+			keep = append(keep, id)
+		}
+	}
+	return tooladapter.NormalizeSelection(keep)
+}
+
+// equalIDSet reports whether a and b contain the same IDs (order-insensitive).
+func equalIDSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := append([]string{}, a...)
+	bs := append([]string{}, b...)
+	sort.Strings(as)
+	sort.Strings(bs)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// registeredConfigPath returns the config path the registry recorded for the
+// named group (the source of truth), falling back to ConfigPathFor's computed
+// path only when the group is not yet registered.
+func registeredConfigPath(name string) (string, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return "", fmt.Errorf("read registry: %w", err)
+	}
+	for _, g := range groups {
+		if g.Name == name {
+			return g.ConfigPath, nil
+		}
+	}
+	return registry.ConfigPathFor(name)
+}
+
+// loadGroupConfigByName loads a group's GroupConfig by group name, returning a
+// non-nil (possibly empty) config so callers can resolve enablement.
+func loadGroupConfigByName(name string) (*registry.GroupConfig, error) {
+	cfgPath, err := registeredConfigPath(name)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("load group %q config: %w", name, err)
+	}
+	if cfg == nil {
+		cfg = &registry.GroupConfig{Name: name}
+	}
+	return cfg, nil
+}

--- a/internal/cli/tools_test.go
+++ b/internal/cli/tools_test.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestApplyToggle_Pure exercises the pure enable/disable set logic without any
+// filesystem — feeding simulated toggles and checking the resulting set.
+func TestApplyToggle_Pure(t *testing.T) {
+	cases := []struct {
+		name   string
+		prev   []string
+		ids    []string
+		enable bool
+		want   []string
+	}{
+		{"enable adds cursor", []string{"claude"}, []string{"cursor"}, true, []string{"claude", "cursor"}},
+		{"disable removes windsurf", []string{"claude", "windsurf"}, []string{"windsurf"}, false, []string{"claude"}},
+		{"enable is idempotent", []string{"claude"}, []string{"claude"}, true, []string{"claude"}},
+		{"disable unknown-in-prev no-op", []string{"claude"}, []string{"cursor"}, false, []string{"claude"}},
+		{"case-insensitive enable", []string{"claude"}, []string{"CURSOR"}, true, []string{"claude", "cursor"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyToggle(tc.prev, tc.ids, tc.enable)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("applyToggle = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveToolSelection_FlagWins(t *testing.T) {
+	cmd := newTestCmd(&bytes.Buffer{})
+	var out bytes.Buffer
+	ids, ok, err := resolveToolSelection(cmd, &out, "claude,cursor", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected applied=true when --tools given")
+	}
+	if !reflect.DeepEqual(ids, []string{"claude", "cursor"}) {
+		t.Fatalf("ids = %v", ids)
+	}
+}
+
+func TestResolveToolSelection_FlagUnknownErrors(t *testing.T) {
+	cmd := newTestCmd(&bytes.Buffer{})
+	var out bytes.Buffer
+	if _, _, err := resolveToolSelection(cmd, &out, "claude,nope", false, false); err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}
+
+// No flag + --yes (or no TTY) → no change, never blocks/promts.
+func TestResolveToolSelection_NoFlagYesIsNoOp(t *testing.T) {
+	cmd := newTestCmd(&bytes.Buffer{})
+	var out bytes.Buffer
+	ids, ok, err := resolveToolSelection(cmd, &out, "", false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || ids != nil {
+		t.Fatalf("expected no-op (--yes), got ok=%v ids=%v", ok, ids)
+	}
+}
+
+// No flag, non-TTY (stubbed) → no prompt, no change. Critical for CI.
+func TestResolveToolSelection_NoTTYNoPrompt(t *testing.T) {
+	orig := stdinIsTTY
+	stdinIsTTY = func() bool { return false }
+	defer func() { stdinIsTTY = orig }()
+
+	cmd := newTestCmd(&bytes.Buffer{})
+	var out bytes.Buffer
+	ids, ok, err := resolveToolSelection(cmd, &out, "", false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || ids != nil {
+		t.Fatalf("non-TTY must be a no-op, got ok=%v ids=%v", ok, ids)
+	}
+}
+
+// End-to-end through the registry: enable cursor on a group, assert the config
+// persisted the new Tools and the output reports the artifacts.
+func TestToolsToggle_EnablePersists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	makeTestRegistryGroup(t, home, "acme", "core")
+
+	// Seed an explicit selection so EnabledTools is literal (claude only).
+	seedTools(t, "acme", []string{"claude"})
+
+	var buf bytes.Buffer
+	if err := runToolsToggle(&buf, "acme", []string{"cursor"}, true); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+
+	cfg := loadCfg(t, "acme")
+	if !reflect.DeepEqual(cfg.Tools, []string{"claude", "cursor"}) {
+		t.Fatalf("persisted Tools = %v, want [claude cursor]", cfg.Tools)
+	}
+	if !strings.Contains(buf.String(), "enabled") {
+		t.Fatalf("output should report enable: %s", buf.String())
+	}
+}
+
+func TestToolsToggle_DisablePersists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	makeTestRegistryGroup(t, home, "acme", "core")
+	seedTools(t, "acme", []string{"claude", "windsurf"})
+
+	var buf bytes.Buffer
+	if err := runToolsToggle(&buf, "acme", []string{"windsurf"}, false); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	cfg := loadCfg(t, "acme")
+	if !reflect.DeepEqual(cfg.Tools, []string{"claude"}) {
+		t.Fatalf("persisted Tools = %v, want [claude]", cfg.Tools)
+	}
+}
+
+func TestToolsToggle_UnknownIDErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	makeTestRegistryGroup(t, home, "acme", "core")
+
+	var buf bytes.Buffer
+	if err := runToolsToggle(&buf, "acme", []string{"bogus"}, true); err == nil {
+		t.Fatal("expected error for unknown tool id")
+	}
+}
+
+func TestToolsList_RunsAndShowsState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	makeTestRegistryGroup(t, home, "acme", "core")
+	seedTools(t, "acme", []string{"claude"})
+
+	var buf bytes.Buffer
+	if err := runToolsList(&buf, "acme"); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	s := buf.String()
+	if !strings.Contains(s, "claude") || !strings.Contains(s, "enabled") {
+		t.Fatalf("list output missing expected rows: %s", s)
+	}
+	if !strings.Contains(s, "cursor") || !strings.Contains(s, "disabled") {
+		t.Fatalf("list should show cursor disabled: %s", s)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func seedTools(t *testing.T, group string, ids []string) {
+	t.Helper()
+	cfgPath, err := registeredConfigPath(group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Tools = ids
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func loadCfg(t *testing.T, group string) *registry.GroupConfig {
+	t.Helper()
+	cfgPath, err := registeredConfigPath(group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+// guard against accidental import drift.
+var _ = tooladapter.AllIDs

--- a/internal/install/tooladapter/selection.go
+++ b/internal/install/tooladapter/selection.go
@@ -1,0 +1,162 @@
+package tooladapter
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ParseToolsFlag parses the comma-separated value of `grafel install --tools`
+// (e.g. "claude,windsurf,cursor") into a validated, de-duplicated, order-
+// preserving slice of adapter IDs.
+//
+// Each token is trimmed and lower-cased before validation. Empty tokens
+// (e.g. trailing commas) are ignored. Every remaining token must match a
+// registered adapter ID — the first unknown token yields a clear error that
+// lists the valid IDs. An input that is empty/whitespace-only yields an
+// error too: a user who passed --tools meant to select something, so silently
+// falling back to "all tools" would be surprising. (The no-flag case never
+// reaches here.)
+func ParseToolsFlag(raw string) ([]string, error) {
+	seen := map[string]bool{}
+	var out []string
+	for _, tok := range strings.Split(raw, ",") {
+		id := strings.ToLower(strings.TrimSpace(tok))
+		if id == "" {
+			continue
+		}
+		if _, ok := Lookup(id); !ok {
+			return nil, fmt.Errorf("unknown tool %q; valid tools: %s",
+				id, strings.Join(AllIDs(), ", "))
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--tools requires at least one tool; valid tools: %s",
+			strings.Join(AllIDs(), ", "))
+	}
+	return out, nil
+}
+
+// DetectedIDs returns the set of adapter IDs whose DetectInstalled() reports
+// the tool is present on this machine, in registry order. Used by the CLI
+// wizard to pre-check likely tools.
+func DetectedIDs() []string {
+	var out []string
+	for _, a := range adapters() {
+		if a.DetectInstalled() {
+			out = append(out, a.ID())
+		}
+	}
+	return out
+}
+
+// WizardChoice is one row presented by the interactive `--tools` wizard: a
+// stable adapter ID, its human label, and whether DetectInstalled() flagged
+// it (so the UI can pre-check it and show a "(detected)" hint).
+type WizardChoice struct {
+	ID          string
+	DisplayName string
+	Detected    bool
+	// PreChecked is the initial checkbox state. It mirrors Detected today but
+	// is kept distinct so callers can seed from an existing config selection
+	// instead (e.g. re-running the wizard on an already-configured group).
+	PreChecked bool
+}
+
+// WizardChoices builds the ordered choice list for the interactive selector.
+// When preselected is non-nil it seeds PreChecked from that set (a previously
+// persisted GroupConfig.Tools); otherwise PreChecked mirrors DetectInstalled.
+// Detected is always the raw detection signal regardless of preselected, so
+// the UI can show "(detected)" independently of the initial check state.
+func WizardChoices(preselected []string) []WizardChoice {
+	var pre map[string]bool
+	if preselected != nil {
+		pre = map[string]bool{}
+		for _, id := range preselected {
+			pre[id] = true
+		}
+	}
+	var out []WizardChoice
+	for _, a := range adapters() {
+		det := a.DetectInstalled()
+		checked := det
+		if pre != nil {
+			checked = pre[a.ID()]
+		}
+		out = append(out, WizardChoice{
+			ID:          a.ID(),
+			DisplayName: a.DisplayName(),
+			Detected:    det,
+			PreChecked:  checked,
+		})
+	}
+	return out
+}
+
+// NormalizeSelection takes a raw selection (e.g. the IDs a user toggled on in
+// the wizard) and returns it filtered to known adapter IDs, de-duplicated,
+// and re-ordered to match the registry order. Unknown IDs are dropped. This
+// is the pure core of "what did the user pick" — fed simulated toggles it is
+// fully testable without a TTY.
+func NormalizeSelection(selected []string) []string {
+	want := map[string]bool{}
+	for _, id := range selected {
+		want[id] = true
+	}
+	var out []string
+	for _, a := range adapters() {
+		if want[a.ID()] {
+			out = append(out, a.ID())
+		}
+	}
+	return out
+}
+
+// ToolDelta is the difference between a previously-enabled tool set and a new
+// one: which adapter IDs are newly enabled (their artifacts must be written)
+// and which are newly disabled (their artifacts must be removed). Both lists
+// are in registry order. Unchanged tools appear in neither list.
+type ToolDelta struct {
+	Enabled  []string // present in next, absent from prev
+	Disabled []string // present in prev, absent from next
+}
+
+// ComputeDelta resolves prev and next through EnabledTools semantics is NOT
+// applied here — callers pass the already-resolved explicit ID sets so the
+// delta reflects the literal config change (an empty next means "disable
+// everything", distinct from the EnabledTools back-compat fallback). Both
+// inputs are normalized to known IDs in registry order before diffing.
+func ComputeDelta(prev, next []string) ToolDelta {
+	prevSet := map[string]bool{}
+	for _, id := range NormalizeSelection(prev) {
+		prevSet[id] = true
+	}
+	nextSet := map[string]bool{}
+	for _, id := range NormalizeSelection(next) {
+		nextSet[id] = true
+	}
+	var d ToolDelta
+	for _, a := range adapters() {
+		id := a.ID()
+		switch {
+		case nextSet[id] && !prevSet[id]:
+			d.Enabled = append(d.Enabled, id)
+		case prevSet[id] && !nextSet[id]:
+			d.Disabled = append(d.Disabled, id)
+		}
+	}
+	return d
+}
+
+// SortedIDs returns a lexicographically sorted copy of ids (handy for stable
+// test assertions and display).
+func SortedIDs(ids []string) []string {
+	out := append([]string{}, ids...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/install/tooladapter/selection_test.go
+++ b/internal/install/tooladapter/selection_test.go
@@ -1,0 +1,111 @@
+package tooladapter_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+)
+
+func TestParseToolsFlag_ValidDedupOrder(t *testing.T) {
+	got, err := tooladapter.ParseToolsFlag(" claude , windsurf,cursor ,claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"claude", "windsurf", "cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseToolsFlag_CaseInsensitive(t *testing.T) {
+	got, err := tooladapter.ParseToolsFlag("Claude,CURSOR")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"claude", "cursor"}) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestParseToolsFlag_Unknown(t *testing.T) {
+	_, err := tooladapter.ParseToolsFlag("claude,bogus")
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("error should name the unknown tool: %v", err)
+	}
+}
+
+func TestParseToolsFlag_Empty(t *testing.T) {
+	for _, in := range []string{"", "  ", ",", " , ,"} {
+		if _, err := tooladapter.ParseToolsFlag(in); err == nil {
+			t.Fatalf("expected error for empty input %q", in)
+		}
+	}
+}
+
+func TestNormalizeSelection_DropsUnknownReordersDedups(t *testing.T) {
+	// Feed out-of-order, with an unknown and a dup.
+	got := tooladapter.NormalizeSelection([]string{"cursor", "bogus", "claude", "cursor"})
+	// registry order is claude, codex, cursor, windsurf, ...
+	want := []string{"claude", "cursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestWizardChoices_PreCheckFromDetection(t *testing.T) {
+	choices := tooladapter.WizardChoices(nil)
+	if len(choices) != len(tooladapter.AllIDs()) {
+		t.Fatalf("expected %d choices, got %d", len(tooladapter.AllIDs()), len(choices))
+	}
+	for _, c := range choices {
+		if c.PreChecked != c.Detected {
+			t.Fatalf("nil preselected: PreChecked should mirror Detected for %s", c.ID)
+		}
+	}
+}
+
+func TestWizardChoices_PreCheckFromPreselected(t *testing.T) {
+	choices := tooladapter.WizardChoices([]string{"cursor"})
+	for _, c := range choices {
+		want := c.ID == "cursor"
+		if c.PreChecked != want {
+			t.Fatalf("PreChecked for %s = %v, want %v", c.ID, c.PreChecked, want)
+		}
+	}
+}
+
+func TestComputeDelta(t *testing.T) {
+	d := tooladapter.ComputeDelta(
+		[]string{"claude", "windsurf"},
+		[]string{"claude", "cursor"},
+	)
+	if !reflect.DeepEqual(d.Enabled, []string{"cursor"}) {
+		t.Fatalf("enabled = %v", d.Enabled)
+	}
+	if !reflect.DeepEqual(d.Disabled, []string{"windsurf"}) {
+		t.Fatalf("disabled = %v", d.Disabled)
+	}
+}
+
+func TestComputeDelta_EmptyNextDisablesAll(t *testing.T) {
+	d := tooladapter.ComputeDelta([]string{"claude", "cursor"}, nil)
+	if len(d.Enabled) != 0 {
+		t.Fatalf("enabled should be empty, got %v", d.Enabled)
+	}
+	// Disabled in registry order: claude before cursor.
+	if !reflect.DeepEqual(d.Disabled, []string{"claude", "cursor"}) {
+		t.Fatalf("disabled = %v", d.Disabled)
+	}
+}
+
+func TestComputeDelta_NoChange(t *testing.T) {
+	d := tooladapter.ComputeDelta([]string{"claude"}, []string{"claude"})
+	if len(d.Enabled) != 0 || len(d.Disabled) != 0 {
+		t.Fatalf("expected empty delta, got %+v", d)
+	}
+}

--- a/internal/install/tooldelta.go
+++ b/internal/install/tooldelta.go
@@ -1,0 +1,233 @@
+package install
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/rulesfiles"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// ToolDeltaOps abstracts the four filesystem primitives ApplyToolDelta needs
+// so tests can inject mocks and never touch the real (live) machine. The
+// production wiring (defaultToolDeltaOps) delegates to rulesfiles + mcpreg.
+type ToolDeltaOps struct {
+	// WriteRules writes the marker block into the given rules-file targets of
+	// a repo (newly-enabled tools). Mirrors Apply's rulesfiles.WriteTargets.
+	WriteRules func(repoRoot string, targets []string) error
+	// RemoveRules strips the marker block from the given rules-file targets of
+	// a repo (newly-disabled tools). Mirrors uninstall's RemoveTargets.
+	RemoveRules func(repoRoot string, targets []string) error
+	// RegisterMCP registers the grafel MCP entry for a tool (newly-enabled).
+	RegisterMCP func(tool mcpreg.Tool) error
+	// UnregisterMCP removes the grafel MCP entry for a tool (newly-disabled).
+	UnregisterMCP func(tool mcpreg.Tool) error
+}
+
+// defaultToolDeltaOps returns the production ToolDeltaOps wired to rulesfiles
+// + mcpreg, in-process (NO subprocess, NO daemon stop/start).
+func defaultToolDeltaOps(group, binPath string) ToolDeltaOps {
+	return ToolDeltaOps{
+		WriteRules: func(repoRoot string, targets []string) error {
+			_, err := rulesfiles.WriteTargets(repoRoot, rulesfiles.WriteOptions{GroupName: group}, targets)
+			return err
+		},
+		RemoveRules: func(repoRoot string, targets []string) error {
+			_, err := rulesfiles.RemoveTargets(repoRoot, targets)
+			return err
+		},
+		RegisterMCP: func(tool mcpreg.Tool) error {
+			_, err := mcpreg.Register(tool, binPath, "")
+			// Missing parent dir for an uninstalled tool is fine.
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		},
+		UnregisterMCP: func(tool mcpreg.Tool) error {
+			err := mcpreg.Unregister(tool)
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		},
+	}
+}
+
+// ToolDeltaResult reports, per affected tool, which artifacts ApplyToolDelta
+// touched, so the CLI can print a per-tool summary.
+type ToolDeltaResult struct {
+	// Enabled/Disabled echo the delta that was applied, in registry order.
+	Enabled  []string
+	Disabled []string
+	// RulesWritten/RulesRemoved map repo path → rules-file targets touched.
+	RulesWritten map[string][]string
+	RulesRemoved map[string][]string
+	// MCPRegistered/MCPUnregistered list the mcpreg tools touched.
+	MCPRegistered   []mcpreg.Tool
+	MCPUnregistered []mcpreg.Tool
+}
+
+// ApplyToolDelta applies a tool-selection delta IN-PROCESS: it writes the
+// newly-enabled tools' per-repo rules files + MCP entries and removes the
+// newly-disabled tools' artifacts, reusing the same rulesfiles + mcpreg
+// primitives that Apply / Uninstall use. It NEVER shells out to `grafel
+// install`, never restarts the daemon, and never touches OS services.
+//
+// Rules-file removal is computed against the SURVIVING tool set: a rules
+// file (e.g. AGENTS.md) shared by two tools is only stripped when the LAST
+// tool that reads it is disabled. MCP entries are likewise only unregistered
+// when no surviving tool still registers that mcpreg.Tool.
+//
+// prevTools/nextTools are the explicit (already-resolved) enabled ID sets;
+// the delta is literal (an empty nextTools disables everything). cfg supplies
+// the repos to operate on. ops is injectable for testing; pass the zero value
+// to use the production wiring.
+func ApplyToolDelta(cfg *registry.GroupConfig, group, binPath string, prevTools, nextTools []string, ops *ToolDeltaOps) (*ToolDeltaResult, error) {
+	if cfg == nil {
+		return nil, errors.New("config is required")
+	}
+	if group == "" {
+		return nil, errors.New("group is required")
+	}
+	var opv ToolDeltaOps
+	if ops != nil {
+		opv = *ops
+	} else {
+		opv = defaultToolDeltaOps(group, binPath)
+	}
+
+	delta := tooladapter.ComputeDelta(prevTools, nextTools)
+	res := &ToolDeltaResult{
+		Enabled:      delta.Enabled,
+		Disabled:     delta.Disabled,
+		RulesWritten: map[string][]string{},
+		RulesRemoved: map[string][]string{},
+	}
+
+	// Surviving rules-file targets / MCP tools = those still read/registered
+	// by a tool in nextTools. A shared artifact stays until its last owner is
+	// disabled.
+	survivingRules := targetsFor(nextTools)
+	survivingMCP := mcpToolsFor(nextTools)
+
+	// ── Rules files (per repo) ─────────────────────────────────────────────
+	enabledRules := subtractTargets(targetsFor(delta.Enabled), nil) // all newly-enabled targets are (re)written
+	// Disabled rules to remove = targets owned by disabled tools that NO
+	// surviving tool still reads.
+	removeRules := subtractTargets(targetsFor(delta.Disabled), survivingRules)
+
+	for _, r := range cfg.Repos {
+		repo := absRepo(r.Path)
+		if len(enabledRules) > 0 {
+			if err := opv.WriteRules(repo, enabledRules); err != nil {
+				return nil, fmt.Errorf("write rules for %s: %w", repo, err)
+			}
+			res.RulesWritten[repo] = append([]string{}, enabledRules...)
+		}
+		if len(removeRules) > 0 {
+			if err := opv.RemoveRules(repo, removeRules); err != nil {
+				return nil, fmt.Errorf("remove rules for %s: %w", repo, err)
+			}
+			res.RulesRemoved[repo] = append([]string{}, removeRules...)
+		}
+	}
+
+	// ── MCP entries (user-global, once each) ───────────────────────────────
+	for _, t := range mcpToolsFor(delta.Enabled) {
+		if err := opv.RegisterMCP(t); err != nil {
+			return nil, fmt.Errorf("register mcp %s: %w", t, err)
+		}
+		res.MCPRegistered = append(res.MCPRegistered, t)
+	}
+	survSet := map[mcpreg.Tool]bool{}
+	for _, t := range survivingMCP {
+		survSet[t] = true
+	}
+	for _, t := range mcpToolsFor(delta.Disabled) {
+		if survSet[t] {
+			continue // a surviving tool still registers this entry
+		}
+		if err := opv.UnregisterMCP(t); err != nil {
+			return nil, fmt.Errorf("unregister mcp %s: %w", t, err)
+		}
+		res.MCPUnregistered = append(res.MCPUnregistered, t)
+	}
+
+	return res, nil
+}
+
+// targetsFor returns the union of rules-file targets across the given tool
+// IDs, ordered by rulesfiles.Targets (matching Apply's ordering).
+func targetsFor(ids []string) []string {
+	want := map[string]bool{}
+	for _, id := range ids {
+		a, ok := tooladapter.Lookup(id)
+		if !ok {
+			continue
+		}
+		for _, t := range a.RulesFileTargets() {
+			want[t] = true
+		}
+	}
+	out := make([]string, 0, len(want))
+	for _, t := range rulesfiles.Targets {
+		if want[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// mcpToolsFor returns the distinct mcpreg.Tool entries registered by the
+// given tool IDs, in registry order.
+func mcpToolsFor(ids []string) []mcpreg.Tool {
+	idSet := map[string]bool{}
+	for _, id := range ids {
+		idSet[id] = true
+	}
+	seen := map[mcpreg.Tool]bool{}
+	var out []mcpreg.Tool
+	for _, a := range tooladapter.All() {
+		if !idSet[a.ID()] || !a.SupportsMCP() {
+			continue
+		}
+		t := a.MCPTool()
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}
+
+// subtractTargets returns targets in a that are NOT in b, preserving a's order.
+func subtractTargets(a, b []string) []string {
+	skip := map[string]bool{}
+	for _, t := range b {
+		skip[t] = true
+	}
+	var out []string
+	for _, t := range a {
+		if !skip[t] {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// absRepo resolves a (possibly relative) repo path to absolute, best-effort.
+func absRepo(p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
+}

--- a/internal/install/tooldelta_test.go
+++ b/internal/install/tooldelta_test.go
@@ -1,0 +1,137 @@
+package install
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// recordingOps captures every primitive call so tests can assert the delta
+// without touching the filesystem or the live machine.
+type recordingOps struct {
+	rulesWritten  map[string][]string // repo → targets
+	rulesRemoved  map[string][]string
+	mcpRegistered []mcpreg.Tool
+	mcpUnregister []mcpreg.Tool
+}
+
+func newRecordingOps() (*recordingOps, ToolDeltaOps) {
+	r := &recordingOps{
+		rulesWritten: map[string][]string{},
+		rulesRemoved: map[string][]string{},
+	}
+	ops := ToolDeltaOps{
+		WriteRules:    func(repo string, t []string) error { r.rulesWritten[repo] = t; return nil },
+		RemoveRules:   func(repo string, t []string) error { r.rulesRemoved[repo] = t; return nil },
+		RegisterMCP:   func(t mcpreg.Tool) error { r.mcpRegistered = append(r.mcpRegistered, t); return nil },
+		UnregisterMCP: func(t mcpreg.Tool) error { r.mcpUnregister = append(r.mcpUnregister, t); return nil },
+	}
+	return r, ops
+}
+
+func sortedTools(ts []mcpreg.Tool) []string {
+	out := make([]string, len(ts))
+	for i, t := range ts {
+		out[i] = string(t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cfgWithRepo() *registry.GroupConfig {
+	return &registry.GroupConfig{
+		Name:  "g",
+		Repos: []registry.Repo{{Path: "/tmp/repoX"}},
+	}
+}
+
+// Enabling cursor (was claude only) should write cursor's rules + register
+// cursor's MCP, and touch nothing for claude.
+func TestApplyToolDelta_EnableCursor(t *testing.T) {
+	rec, ops := newRecordingOps()
+	res, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel",
+		[]string{"claude"}, []string{"claude", "cursor"}, &ops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res.Enabled, []string{"cursor"}) {
+		t.Fatalf("enabled = %v", res.Enabled)
+	}
+	if len(res.Disabled) != 0 {
+		t.Fatalf("disabled = %v", res.Disabled)
+	}
+	if got := rec.rulesWritten["/tmp/repoX"]; !reflect.DeepEqual(got, []string{".cursorrules"}) {
+		t.Fatalf("rules written = %v", got)
+	}
+	if len(rec.rulesRemoved) != 0 {
+		t.Fatalf("nothing should be removed: %v", rec.rulesRemoved)
+	}
+	if got := sortedTools(rec.mcpRegistered); !reflect.DeepEqual(got, []string{string(mcpreg.Cursor)}) {
+		t.Fatalf("mcp registered = %v", got)
+	}
+}
+
+// Disabling windsurf (had claude+windsurf) removes windsurf's rules +
+// unregisters windsurf's MCP; claude untouched.
+func TestApplyToolDelta_DisableWindsurf(t *testing.T) {
+	rec, ops := newRecordingOps()
+	res, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel",
+		[]string{"claude", "windsurf"}, []string{"claude"}, &ops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res.Disabled, []string{"windsurf"}) {
+		t.Fatalf("disabled = %v", res.Disabled)
+	}
+	if got := rec.rulesRemoved["/tmp/repoX"]; !reflect.DeepEqual(got, []string{".windsurfrules"}) {
+		t.Fatalf("rules removed = %v", got)
+	}
+	if got := sortedTools(rec.mcpUnregister); !reflect.DeepEqual(got, []string{string(mcpreg.Windsurf)}) {
+		t.Fatalf("mcp unregistered = %v", got)
+	}
+}
+
+// Shared rules file: claude+codex both... actually claude→CLAUDE.md,
+// codex→AGENTS.md are distinct. Use a case where disabling does NOT strip a
+// file still owned by a surviving tool. claude (CLAUDE.md) + codex (AGENTS.md):
+// disabling codex strips AGENTS.md only, leaving CLAUDE.md.
+func TestApplyToolDelta_DisableCodexKeepsClaudeRules(t *testing.T) {
+	rec, ops := newRecordingOps()
+	_, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel",
+		[]string{"claude", "codex"}, []string{"claude"}, &ops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rec.rulesRemoved["/tmp/repoX"]; !reflect.DeepEqual(got, []string{"AGENTS.md"}) {
+		t.Fatalf("rules removed = %v (should strip only AGENTS.md)", got)
+	}
+	// codex registers an MCP entry → it should be unregistered.
+	if got := sortedTools(rec.mcpUnregister); !reflect.DeepEqual(got, []string{string(mcpreg.Codex)}) {
+		t.Fatalf("mcp unregistered = %v", got)
+	}
+}
+
+func TestApplyToolDelta_NoChangeNoOps(t *testing.T) {
+	rec, ops := newRecordingOps()
+	res, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel",
+		[]string{"claude"}, []string{"claude"}, &ops)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Enabled) != 0 || len(res.Disabled) != 0 {
+		t.Fatalf("expected empty delta: %+v", res)
+	}
+	if len(rec.rulesWritten) != 0 || len(rec.rulesRemoved) != 0 ||
+		len(rec.mcpRegistered) != 0 || len(rec.mcpUnregister) != 0 {
+		t.Fatalf("no primitive should have been called: %+v", rec)
+	}
+}
+
+func TestApplyToolDelta_NilConfigErrors(t *testing.T) {
+	if _, err := ApplyToolDelta(nil, "g", "", nil, nil, &ToolDeltaOps{}); err == nil {
+		t.Fatal("expected error for nil config")
+	}
+}


### PR DESCRIPTION
Part of EPIC #5252 — adds per-tool selection on top of the #5253 adapter foundation and the #5254/#5255 tool adapters.

## What

### `grafel install --tools claude,cursor,windsurf`
Comma-separated adapter IDs, validated against `tooladapter.AllIDs()` (unknown token → clear error listing valid IDs), de-duplicated + case-insensitive, persisted to every registered group's `GroupConfig.Tools`. When provided, selection is fully **non-interactive**.

### TTY-gated interactive wizard
A `charmbracelet/huh` multi-select (already a repo dep — no new heavy TUI dep) runs **only** when stdin is a terminal AND neither `--tools` nor `--yes`/`--no-wizard` was passed. Options are pre-checked by `DetectInstalled()` with a `(detected)` hint. **Back-compat**: non-interactive / no-TTY / `--yes` / `--no-wizard` = today's behaviour (`EnabledTools` falls back to all tools) — CI and scripted installs are never blocked or prompted. The selection→IDs mapping is the pure `tooladapter.NormalizeSelection`, unit-tested without a TTY.

### `grafel tools` command
```
grafel tools [list]          show every adapter with enabled/detected state
grafel tools enable <id...>  enable + write the newly-enabled artifacts
grafel tools disable <id...> disable + remove the newly-disabled artifacts
```
`enable`/`disable` update `GroupConfig.Tools` and **re-apply only the changed tools' artifacts** via the new in-process `install.ApplyToolDelta`, reusing the existing `rulesfiles` (`WriteTargets`/`RemoveTargets`) + `mcpreg` (`Register`/`Unregister`) primitives. Shared rules files / MCP entries are only stripped when their **last** owning tool is disabled. **No subprocess** `grafel install`/`uninstall` is run and the **daemon is never stopped/started**.

## Pure, testable core
Selection logic lives in pure helpers: `tooladapter.{ParseToolsFlag, WizardChoices, NormalizeSelection, ComputeDelta}` and `install.ApplyToolDelta` (with an injectable `ToolDeltaOps` so tests mock the FS — no touching the live machine).

## Validation
- `go build ./...` and `go vet ./internal/cli/... ./internal/install/...` clean.
- `go test ./internal/cli/... ./internal/install/...` green (new selection/delta/toggle/resolve tests + full suites).
- `grafel selftest` → all 6 layers PASS.
- Manual end-to-end: `tools list` shows state, `tools disable cursor` removes `.cursorrules` + unregisters the cursor MCP entry in-process.

Closes #5256
Refs #5252

🤖 Generated with [Claude Code](https://claude.com/claude-code)