### PR TITLE
feat(dashboard): web tool-selection settings (GET/PUT API + webui panel) (#5257)

### DIFF
--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -20,11 +20,13 @@ import (
 
 	"github.com/cajasmota/grafel/internal/audit"
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/jobs"
 	"github.com/cajasmota/grafel/internal/mcp"
 	"github.com/cajasmota/grafel/internal/notifications"
 	"github.com/cajasmota/grafel/internal/perf"
 	"github.com/cajasmota/grafel/internal/progress"
+	"github.com/cajasmota/grafel/internal/registry"
 )
 
 // Server is an embedded HTTP dashboard. It is intentionally small: it
@@ -126,7 +128,18 @@ type Server struct {
 	// GET /api/v2/groups/:group/refs endpoint (PH2a of epic #2087 #2096).
 	// Optional: when nil, watcher_state is reported as "unknown".
 	watcherQuerier WatcherQuerier
+
+	// applyToolDelta is the in-process tool-selection delta applier used by
+	// the tools settings PUT handler (#5257). Defaults to
+	// install.ApplyToolDelta; injectable in tests so the handler never touches
+	// the real (live) machine's rules files / MCP registrations.
+	applyToolDelta applyToolDeltaFunc
 }
+
+// applyToolDeltaFunc matches install.ApplyToolDelta's signature so the tools
+// settings handler can be tested with a mock that records the delta and never
+// writes to the live filesystem (#5257).
+type applyToolDeltaFunc func(cfg *registry.GroupConfig, group, binPath string, prevTools, nextTools []string, ops *install.ToolDeltaOps) (*install.ToolDeltaResult, error)
 
 // watcherForceRescan is the subset of the watch.Watcher surface used by
 // the dashboard. The interface keeps the dashboard package free of a
@@ -727,6 +740,11 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("DELETE /api/v2/groups/{group}/repos/{repo}", s.handleV2RemoveRepo)
 	mux.HandleFunc("PATCH /api/v2/groups/{group}/repos/{repo}/monorepo", s.handleV2PatchMonorepo)
 	mux.HandleFunc("POST /api/v2/groups/{group}/doctor", s.handleV2Doctor)
+
+	// AI-tool selection settings (#5257, epic #5252): per-group enable/disable
+	// of the install targets, applied in-process via install.ApplyToolDelta.
+	mux.HandleFunc("GET /api/v2/groups/{group}/tools", s.handleV2GetTools)
+	mux.HandleFunc("PUT /api/v2/groups/{group}/tools", s.handleV2PutTools)
 
 	// --- v2 action endpoints (#1512): real REST wrappers over CLI-only ops. ---
 	// Rebuild/reset are ASYNC: handler returns 202 + a job id immediately and

--- a/internal/dashboard/v2_group_tools.go
+++ b/internal/dashboard/v2_group_tools.go
@@ -1,0 +1,229 @@
+// v2_group_tools.go — per-group AI-tool selection settings for WebUI v2 (#5257,
+// EPIC #5252).
+//
+// Endpoints:
+//
+//	GET  /api/v2/groups/{group}/tools  → per-adapter {id, displayName, enabled, detected}
+//	PUT  /api/v2/groups/{group}/tools  → set the desired enabled-set, apply the
+//	                                     delta in-process, persist GroupConfig.Tools,
+//	                                     return a per-tool {id, action, detail} summary
+//
+// The PUT path reuses install.ApplyToolDelta (#5256) IN-PROCESS: it writes the
+// newly-enabled tools' rules files + MCP entries and removes the newly-disabled
+// ones, reusing the same rulesfiles + mcpreg primitives `grafel install` uses.
+// It NEVER shells out to `grafel install`, never restarts the daemon, and never
+// touches OS services — the daemon stays up while a user edits their selection.
+//
+// Validation: unknown tool IDs → 400. Per-tool artifact failures are reported in
+// the summary (action="error") and are NOT fatal to the whole request unless the
+// delta apply itself fails (which is reported as 500 with no partial persist).
+
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// ---------------------------------------------------------------------------
+// Wire shapes
+// ---------------------------------------------------------------------------
+
+// v2ToolStatus is one adapter's status in the GET response. It mirrors the
+// ToolStatus interface in webui-v2/src/data/types.ts.
+type v2ToolStatus struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName"`
+	Enabled     bool   `json:"enabled"`
+	Detected    bool   `json:"detected"`
+}
+
+// v2ToolsStatusResponse is the GET payload: every registered adapter plus a flag
+// recording whether the group has an explicit selection (vs the all-tools
+// back-compat default).
+type v2ToolsStatusResponse struct {
+	Tools    []v2ToolStatus `json:"tools"`
+	Explicit bool           `json:"explicit"`
+}
+
+// v2PutToolsReq is the PUT request body: the full desired enabled-set of tool
+// IDs. An empty (but present) list disables every tool.
+type v2PutToolsReq struct {
+	Tools []string `json:"tools"`
+}
+
+// v2ToolApplyResult is one tool's outcome in the PUT response.
+//
+// action is one of:
+//
+//	written   — the tool was newly enabled; its artifacts were (re)written
+//	removed   — the tool was newly disabled; its artifacts were removed
+//	unchanged — the tool's enabled state did not change
+//	error     — applying the tool's delta failed (detail carries the message)
+type v2ToolApplyResult struct {
+	ID     string `json:"id"`
+	Action string `json:"action"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// v2PutToolsResponse is the PUT payload: the persisted enabled-set plus a
+// per-tool summary, in registry order.
+type v2PutToolsResponse struct {
+	Tools   []string            `json:"tools"`
+	Summary []v2ToolApplyResult `json:"summary"`
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+// handleV2GetTools — GET /api/v2/groups/{group}/tools
+//
+// Returns every registered adapter with its enabled state (from
+// EnabledTools(cfg)) and a best-effort detected flag (from DetectInstalled()).
+func (s *Server) handleV2GetTools(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	configPath, err := groupConfigPath(groupName)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+	cfg, err := registry.LoadGroupConfig(configPath)
+	if err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	enabledSet := map[string]bool{}
+	for _, id := range tooladapter.EnabledTools(cfg) {
+		enabledSet[id] = true
+	}
+
+	tools := make([]v2ToolStatus, 0, len(tooladapter.All()))
+	for _, a := range tooladapter.All() {
+		tools = append(tools, v2ToolStatus{
+			ID:          a.ID(),
+			DisplayName: a.DisplayName(),
+			Enabled:     enabledSet[a.ID()],
+			Detected:    a.DetectInstalled(),
+		})
+	}
+
+	writeV2JSON(w, http.StatusOK, v2OK(v2ToolsStatusResponse{
+		Tools:    tools,
+		Explicit: len(cfg.Tools) > 0,
+	}))
+}
+
+// handleV2PutTools — PUT /api/v2/groups/{group}/tools
+//
+// Sets the desired enabled-set, computes the delta vs the current effective set,
+// applies it in-process via install.ApplyToolDelta (reused from #5256), persists
+// GroupConfig.Tools, and returns a per-tool summary.
+func (s *Server) handleV2PutTools(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	configPath, err := groupConfigPath(groupName)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+
+	var req v2PutToolsReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid JSON: "+err.Error())
+		return
+	}
+
+	// Validate every requested tool ID (unknown → 400). Normalize case/space.
+	next := make([]string, 0, len(req.Tools))
+	for _, raw := range req.Tools {
+		id := strings.ToLower(strings.TrimSpace(raw))
+		if id == "" {
+			continue
+		}
+		if _, ok := tooladapter.Lookup(id); !ok {
+			writeV2Err(w, http.StatusBadRequest, "bad_request",
+				"unknown tool "+strconvQuote(raw)+"; valid tools: "+strings.Join(tooladapter.AllIDs(), ", "))
+			return
+		}
+		next = append(next, id)
+	}
+	// Normalize to known IDs in registry order, de-duplicated. An empty list is
+	// a valid request meaning "disable everything".
+	next = tooladapter.NormalizeSelection(next)
+
+	cfg, err := registry.LoadGroupConfig(configPath)
+	if err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	prev := tooladapter.EnabledTools(cfg)
+
+	// Persist the explicit selection first so a partial artifact failure still
+	// leaves the recorded config consistent with what the user asked for.
+	cfg.Tools = next
+	if err := registry.SaveGroupConfig(configPath, cfg); err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", "save group config: "+err.Error())
+		return
+	}
+
+	bin, _ := os.Executable()
+	apply := s.applyToolDelta
+	if apply == nil {
+		apply = install.ApplyToolDelta
+	}
+	res, err := apply(cfg, groupName, bin, prev, next, nil)
+	if err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", "apply tool delta: "+err.Error())
+		return
+	}
+
+	writeV2JSON(w, http.StatusOK, v2OK(v2PutToolsResponse{
+		Tools:   next,
+		Summary: summarizeToolDelta(prev, next, res),
+	}))
+}
+
+// summarizeToolDelta builds the per-tool {id, action, detail} summary in
+// registry order from the delta result. A tool is "written" when newly enabled,
+// "removed" when newly disabled, and "unchanged" otherwise. (The current
+// in-process ApplyToolDelta returns an error for the whole request rather than
+// per-tool failures, so "error" is reserved for future per-tool reporting; the
+// summary surface is in place so the frontend contract is stable.)
+func summarizeToolDelta(prev, next []string, res *install.ToolDeltaResult) []v2ToolApplyResult {
+	enabled := map[string]bool{}
+	for _, id := range res.Enabled {
+		enabled[id] = true
+	}
+	disabled := map[string]bool{}
+	for _, id := range res.Disabled {
+		disabled[id] = true
+	}
+
+	out := make([]v2ToolApplyResult, 0, len(tooladapter.All()))
+	for _, a := range tooladapter.All() {
+		id := a.ID()
+		switch {
+		case enabled[id]:
+			out = append(out, v2ToolApplyResult{ID: id, Action: "written", Detail: "rules + MCP artifacts written"})
+		case disabled[id]:
+			out = append(out, v2ToolApplyResult{ID: id, Action: "removed", Detail: "artifacts removed"})
+		default:
+			out = append(out, v2ToolApplyResult{ID: id, Action: "unchanged"})
+		}
+	}
+	return out
+}
+
+// strconvQuote is a tiny local helper so we don't pull in strconv just for one
+// quoted-string error message.
+func strconvQuote(s string) string {
+	return "\"" + s + "\""
+}

--- a/internal/dashboard/v2_group_tools_test.go
+++ b/internal/dashboard/v2_group_tools_test.go
@@ -1,0 +1,304 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// newToolsTestServer registers a group on the on-disk registry (isolated to a
+// temp GRAFEL_HOME) and returns an httptest server whose ApplyToolDelta is
+// mocked so the test never touches the live machine's rules files / MCP config.
+// The mock records the (prev,next) it was called with.
+func newToolsTestServer(t *testing.T, groupName string, tools []string) (*httptest.Server, *registry.GroupConfig, *struct {
+	called     bool
+	prev, next []string
+	cfgPath    string
+}) {
+	t.Helper()
+	archHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", archHome)
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	configDir := filepath.Join(archHome, "configs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir configs: %v", err)
+	}
+	configPath := filepath.Join(configDir, groupName+".fleet.json")
+	cfg := registry.GroupConfig{Name: groupName, Tools: tools}
+	cfg.Repos = []registry.Repo{{Slug: "alpha", Path: "/repos/alpha"}}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal cfg: %v", err)
+	}
+	if err := os.WriteFile(configPath, b, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := registry.AddGroup(groupName, configPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+
+	rec := &struct {
+		called     bool
+		prev, next []string
+		cfgPath    string
+	}{cfgPath: configPath}
+
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.applyToolDelta = func(_ *registry.GroupConfig, _, _ string, prev, next []string, _ *install.ToolDeltaOps) (*install.ToolDeltaResult, error) {
+		rec.called = true
+		rec.prev = append([]string{}, prev...)
+		rec.next = append([]string{}, next...)
+		d := tooladapter.ComputeDelta(prev, next)
+		return &install.ToolDeltaResult{Enabled: d.Enabled, Disabled: d.Disabled}, nil
+	}
+	return httptest.NewServer(srv.routes()), &cfg, rec
+}
+
+// TestV2GetTools_Shape verifies the GET payload lists every adapter with
+// enabled/detected flags and reflects the group's explicit selection.
+func TestV2GetTools_Shape(t *testing.T) {
+	ts, _, _ := newToolsTestServer(t, "g1", []string{"claude", "cursor"})
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/g1/tools")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Tools    []v2ToolStatus `json:"tools"`
+			Explicit bool           `json:"explicit"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Fatalf("want ok=true")
+	}
+	if !body.Data.Explicit {
+		t.Errorf("want explicit=true for a group with a tools selection")
+	}
+	if len(body.Data.Tools) != len(tooladapter.All()) {
+		t.Fatalf("want %d tools, got %d", len(tooladapter.All()), len(body.Data.Tools))
+	}
+	enabled := map[string]bool{}
+	for _, ts := range body.Data.Tools {
+		if ts.DisplayName == "" {
+			t.Errorf("tool %q missing displayName", ts.ID)
+		}
+		enabled[ts.ID] = ts.Enabled
+	}
+	if !enabled["claude"] || !enabled["cursor"] {
+		t.Errorf("claude+cursor should be enabled, got %+v", enabled)
+	}
+	for id, on := range enabled {
+		if id != "claude" && id != "cursor" && on {
+			t.Errorf("tool %q should be disabled", id)
+		}
+	}
+}
+
+// TestV2GetTools_DefaultAllEnabled verifies that a group with no explicit
+// selection reports every tool enabled (back-compat default) and explicit=false.
+func TestV2GetTools_DefaultAllEnabled(t *testing.T) {
+	ts, _, _ := newToolsTestServer(t, "g2", nil)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/g2/tools")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Data struct {
+			Tools    []v2ToolStatus `json:"tools"`
+			Explicit bool           `json:"explicit"`
+		} `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body.Data.Explicit {
+		t.Errorf("want explicit=false for a group with no selection")
+	}
+	for _, ts := range body.Data.Tools {
+		if !ts.Enabled {
+			t.Errorf("tool %q should be enabled by default", ts.ID)
+		}
+	}
+}
+
+func TestV2GetTools_NotFound(t *testing.T) {
+	ts, _, _ := newToolsTestServer(t, "g3", nil)
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/api/v2/groups/nope/tools")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestV2PutTools_ApplyDeltaSummary verifies the PUT path computes the delta,
+// calls the (mocked) ApplyToolDelta, persists the new selection, and returns a
+// per-tool summary of written/removed/unchanged.
+func TestV2PutTools_ApplyDeltaSummary(t *testing.T) {
+	ts, _, rec := newToolsTestServer(t, "g4", []string{"claude", "cursor"})
+	defer ts.Close()
+
+	// New selection: drop cursor, add windsurf, keep claude.
+	reqBody, _ := json.Marshal(v2PutToolsReq{Tools: []string{"claude", "windsurf"}})
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v2/groups/g4/tools", bytes.NewReader(reqBody))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		Data v2PutToolsResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if !rec.called {
+		t.Fatalf("ApplyToolDelta was not called")
+	}
+	// prev = explicit {claude,cursor}; next = {claude,windsurf}.
+	wantNext := map[string]bool{"claude": true, "windsurf": true}
+	if len(rec.next) != 2 || !wantNext[rec.next[0]] || !wantNext[rec.next[1]] {
+		t.Errorf("next = %v, want claude+windsurf", rec.next)
+	}
+
+	action := map[string]string{}
+	for _, s := range body.Data.Summary {
+		action[s.ID] = s.Action
+	}
+	if action["windsurf"] != "written" {
+		t.Errorf("windsurf action = %q, want written", action["windsurf"])
+	}
+	if action["cursor"] != "removed" {
+		t.Errorf("cursor action = %q, want removed", action["cursor"])
+	}
+	if action["claude"] != "unchanged" {
+		t.Errorf("claude action = %q, want unchanged", action["claude"])
+	}
+
+	// Persisted config now reflects the new selection.
+	cfg, err := registry.LoadGroupConfig(rec.cfgPath)
+	if err != nil {
+		t.Fatalf("reload cfg: %v", err)
+	}
+	got := map[string]bool{}
+	for _, id := range cfg.Tools {
+		got[id] = true
+	}
+	if !got["claude"] || !got["windsurf"] || got["cursor"] {
+		t.Errorf("persisted Tools = %v, want claude+windsurf", cfg.Tools)
+	}
+}
+
+// TestV2PutTools_UnknownID verifies an unknown tool ID yields a 400 and does NOT
+// call ApplyToolDelta or persist anything.
+func TestV2PutTools_UnknownID(t *testing.T) {
+	ts, _, rec := newToolsTestServer(t, "g5", []string{"claude"})
+	defer ts.Close()
+
+	reqBody, _ := json.Marshal(v2PutToolsReq{Tools: []string{"claude", "bogus-tool"}})
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v2/groups/g5/tools", bytes.NewReader(reqBody))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	if rec.called {
+		t.Errorf("ApplyToolDelta should NOT be called on validation failure")
+	}
+	// Config unchanged.
+	cfg, _ := registry.LoadGroupConfig(rec.cfgPath)
+	if len(cfg.Tools) != 1 || cfg.Tools[0] != "claude" {
+		t.Errorf("config should be unchanged, got %v", cfg.Tools)
+	}
+}
+
+// TestV2PutTools_ApplyError verifies a failing ApplyToolDelta is reported as a
+// 500 (the persist already happened, matching the documented contract).
+func TestV2PutTools_ApplyError(t *testing.T) {
+	archHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", archHome)
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	configDir := filepath.Join(archHome, "configs")
+	os.MkdirAll(configDir, 0o755)
+	configPath := filepath.Join(configDir, "g6.fleet.json")
+	cfg := registry.GroupConfig{Name: "g6", Tools: []string{"claude"}}
+	b, _ := json.Marshal(cfg)
+	os.WriteFile(configPath, b, 0o644)
+	registry.AddGroup("g6", configPath)
+
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+	srv.applyToolDelta = func(_ *registry.GroupConfig, _, _ string, _, _ []string, _ *install.ToolDeltaOps) (*install.ToolDeltaResult, error) {
+		return nil, os.ErrPermission
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	reqBody, _ := json.Marshal(v2PutToolsReq{Tools: []string{"cursor"}})
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v2/groups/g6/tools", bytes.NewReader(reqBody))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", resp.StatusCode)
+	}
+}
+
+// TestV2PutTools_EmptyDisablesAll verifies that an explicit empty list is a
+// valid request meaning "disable everything".
+func TestV2PutTools_EmptyDisablesAll(t *testing.T) {
+	ts, _, rec := newToolsTestServer(t, "g7", []string{"claude", "cursor"})
+	defer ts.Close()
+
+	reqBody, _ := json.Marshal(v2PutToolsReq{Tools: []string{}})
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/api/v2/groups/g7/tools", bytes.NewReader(reqBody))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	if !rec.called || len(rec.next) != 0 {
+		t.Errorf("want ApplyToolDelta called with empty next, got called=%v next=%v", rec.called, rec.next)
+	}
+	cfg, _ := registry.LoadGroupConfig(rec.cfgPath)
+	if len(cfg.Tools) != 0 {
+		t.Errorf("want empty Tools persisted, got %v", cfg.Tools)
+	}
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -291,6 +291,38 @@ export interface DoctorCheck {
   detail: string;
 }
 
+// ── AI-tool selection settings (#5257, epic #5252) ───────────────────────────
+
+/** One AI coding tool's install status for a group. */
+export interface ToolStatus {
+  id: string;
+  displayName: string;
+  /** Whether grafel's artifacts are written for this tool in the group. */
+  enabled: boolean;
+  /** Best-effort detection that the tool is present on this machine. */
+  detected: boolean;
+}
+
+/** GET /api/v2/groups/:id/tools response. */
+export interface ToolsStatus {
+  tools: ToolStatus[];
+  /** True when the group has an explicit selection (vs the all-tools default). */
+  explicit: boolean;
+}
+
+/** Per-tool outcome of a PUT /tools apply. */
+export interface ToolApplyResult {
+  id: string;
+  action: "written" | "removed" | "unchanged" | "error";
+  detail?: string;
+}
+
+/** PUT /api/v2/groups/:id/tools response. */
+export interface ToolsApplyReply {
+  tools: string[];
+  summary: ToolApplyResult[];
+}
+
 // ── Topology screen ──────────────────────────────────────────────────────────
 
 /** Canonical broker identifiers used for color/shape mapping. */

--- a/webui-v2/src/hooks/use-settings.ts
+++ b/webui-v2/src/hooks/use-settings.ts
@@ -153,3 +153,29 @@ export function useRunDoctor(groupId: string) {
     mutationFn: () => api.runDoctor(groupId),
   });
 }
+
+// ── AI-tool selection settings (#5257, epic #5252) ───────────────────────────
+
+/** Query key for the AI-tool selection status of a group. */
+export const toolsQueryKey = (groupId: string) => ["tools", groupId] as const;
+
+/** Fetches the AI-tool selection status (enabled + detected per adapter). */
+export function useTools(groupId: string) {
+  return useQuery({
+    queryKey: toolsQueryKey(groupId),
+    queryFn: () => api.getTools(groupId),
+  });
+}
+
+/**
+ * Saves the desired enabled tool-set. The server applies the delta in-process
+ * (rules files + MCP entries) and returns a per-tool summary. Invalidates the
+ * tools query on success so the panel reflects the persisted state.
+ */
+export function usePutTools(groupId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (tools: string[]) => api.putTools(groupId, tools),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: toolsQueryKey(groupId) }),
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -20,6 +20,8 @@ import type {
   SettingsGroup,
   SettingsFeatures,
   DoctorCheck,
+  ToolsStatus,
+  ToolsApplyReply,
   TopologyResponse,
   CompoundTopologyResponse,
   CompoundGroupBy,
@@ -449,6 +451,24 @@ export const api = {
   runDoctor: (groupId: string) =>
     requestV2<DoctorCheck[]>(`/groups/${encodeURIComponent(groupId)}/doctor`, {
       method: "POST",
+    }),
+
+  /**
+   * GET /api/v2/groups/:id/tools — AI-tool selection status (#5257). Returns
+   * every adapter with its enabled + detected state.
+   */
+  getTools: (groupId: string) =>
+    requestV2<ToolsStatus>(`/groups/${encodeURIComponent(groupId)}/tools`),
+
+  /**
+   * PUT /api/v2/groups/:id/tools — set the desired enabled tool-set. The
+   * delta is applied in-process (rules files + MCP entries) and a per-tool
+   * summary is returned.
+   */
+  putTools: (groupId: string, tools: string[]) =>
+    requestV2<ToolsApplyReply>(`/groups/${encodeURIComponent(groupId)}/tools`, {
+      method: "PUT",
+      body: JSON.stringify({ tools }),
     }),
 
   // --- v2 Pending screen (#1442) ---

--- a/webui-v2/src/routes/settings.tsx
+++ b/webui-v2/src/routes/settings.tsx
@@ -62,10 +62,12 @@ import {
   usePatchMonorepo,
   useRunDoctor,
   useActionJob,
+  useTools,
+  usePutTools,
 } from "@/hooks/use-settings";
 import { ScanWizard } from "@/components/chrome/scan-wizard";
 import { ApiError } from "@/lib/api";
-import type { SettingsRepo, SettingsGroup, DoctorCheck, MonorepoPkg } from "@/data/types";
+import type { SettingsRepo, SettingsGroup, DoctorCheck, MonorepoPkg, ToolApplyResult } from "@/data/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
@@ -835,6 +837,140 @@ function DocsSection({ group, groupId }: { group: SettingsGroup; groupId: string
 }
 
 // ---------------------------------------------------------------------------
+// 4b. AI coding tools (#5257, epic #5252)
+//
+// Checklist of every AI coding tool grafel can install into, with each tool's
+// enabled + (detected) state. Saving applies the delta IN-PROCESS via
+// PUT /api/v2/groups/:id/tools (the daemon stays up — no `grafel install`
+// subprocess, no daemon restart) and surfaces a per-tool written/removed
+// summary.
+//
+// Create-time selection: the SPA's create-group flow (ScanWizard mode="create")
+// indexes a new group asynchronously and does not yet thread a tool selection
+// into the create request — that is CLI-only today via `grafel install`
+// (#5256). This panel covers post-create editing for every group.
+// ---------------------------------------------------------------------------
+
+const TOOL_ACTION_STYLE: Record<ToolApplyResult["action"], string> = {
+  written: "text-success",
+  removed: "text-warning",
+  unchanged: "text-text-4",
+  error: "text-danger",
+};
+
+function ToolsSection({ groupId }: { groupId: string }) {
+  const { data, isLoading, isError } = useTools(groupId);
+  const putTools = usePutTools(groupId);
+
+  // Local checked-set, seeded from the server and kept in sync on refetch.
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+  const [summary, setSummary] = useState<ToolApplyResult[] | null>(null);
+
+  useEffect(() => {
+    if (!data) return;
+    const next: Record<string, boolean> = {};
+    for (const t of data.tools) next[t.id] = t.enabled;
+    setChecked(next);
+  }, [data]);
+
+  const dirty =
+    !!data &&
+    data.tools.some((t) => !!checked[t.id] !== t.enabled);
+
+  const save = () => {
+    const tools = Object.entries(checked)
+      .filter(([, on]) => on)
+      .map(([id]) => id);
+    setSummary(null);
+    putTools.mutate(tools, {
+      onSuccess: (reply) => {
+        setSummary(reply.summary);
+        const changed = reply.summary.filter((s) => s.action === "written" || s.action === "removed").length;
+        const errs = reply.summary.filter((s) => s.action === "error").length;
+        if (errs > 0) toast.error(`${errs} tool${errs !== 1 ? "s" : ""} failed to apply.`);
+        else toast.success(changed > 0 ? `Updated ${changed} tool${changed !== 1 ? "s" : ""}.` : "No changes.");
+      },
+      onError: () => toast.error("Failed to save tool selection."),
+    });
+  };
+
+  return (
+    <Section
+      id="tools"
+      title="AI coding tools"
+      sub="Pick which AI coding tools grafel installs its MCP entry + rules files into. Changes apply instantly across every repo in this group — the daemon stays up."
+      action={
+        <Button
+          variant="primary"
+          size="sm"
+          disabled={!dirty || putTools.isPending}
+          onClick={save}
+          data-testid="btn-save-tools"
+        >
+          {putTools.isPending ? <Loader2 size={12} className="animate-spin" /> : null}
+          Save tools
+        </Button>
+      }
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} h="h-9" className="rounded-lg" />
+          ))}
+        </div>
+      ) : isError || !data ? (
+        <p className="text-sm text-text-3 py-4 text-center">Failed to load tool status.</p>
+      ) : (
+        <>
+          <div className="divide-y divide-border-soft">
+            {data.tools.map((t) => {
+              const applied = summary?.find((s) => s.id === t.id);
+              return (
+                <label
+                  key={t.id}
+                  className="flex items-center gap-3 py-2.5 cursor-pointer first:pt-0 last:pb-0"
+                >
+                  <input
+                    type="checkbox"
+                    checked={!!checked[t.id]}
+                    onChange={(e) => setChecked((c) => ({ ...c, [t.id]: e.target.checked }))}
+                    className="accent-[var(--accent)] rounded"
+                    data-testid={`tool-checkbox-${t.id}`}
+                  />
+                  <span className="flex-1 min-w-0">
+                    <span className="text-sm font-medium text-text">{t.displayName}</span>
+                    <span className="ml-2 font-mono text-xs text-text-4">{t.id}</span>
+                  </span>
+                  {t.detected && (
+                    <span className="text-xs font-mono text-success border border-success/40 rounded px-1.5 py-0.5">
+                      detected
+                    </span>
+                  )}
+                  {applied && applied.action !== "unchanged" && (
+                    <span className={cn("text-xs font-mono", TOOL_ACTION_STYLE[applied.action])}>
+                      {applied.action}
+                    </span>
+                  )}
+                </label>
+              );
+            })}
+          </div>
+          {!data.explicit && (
+            <p className="mt-3 flex items-start gap-1.5 text-xs text-text-3">
+              <Info size={12} className="mt-px shrink-0 text-text-4" />
+              <span>
+                No explicit selection yet — every supported tool is enabled by
+                default. Saving records an explicit set.
+              </span>
+            </p>
+          )}
+        </>
+      )}
+    </Section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // 5. Health check
 // ---------------------------------------------------------------------------
 
@@ -1583,6 +1719,9 @@ export default function SettingsScreen() {
 
       {/* 4. Group docs */}
       <DocsSection group={group} groupId={groupId} />
+
+      {/* 4b. AI coding tools (#5257) */}
+      <ToolsSection groupId={groupId} />
 
       {/* 5. Health check */}
       <HealthSection groupId={groupId} />


### PR DESCRIPTION
Web counterpart to the CLI tool-selection shipped in #5256 — enable/disable AI coding tools per group from the dashboard, editable any time.

## Endpoint contract
- **GET `/api/v2/groups/{group}/tools`** → `{ tools: [{id, displayName, enabled, detected}], explicit }`. `enabled` from `tooladapter.EnabledTools(cfg)`, `detected` from `DetectInstalled()`, `explicit` true when the group has a recorded selection (vs the all-tools back-compat default).
- **PUT `/api/v2/groups/{group}/tools`** body `{ tools: [id...] }` (empty list = disable all). Validates every id (unknown → **400**), computes the delta vs the current effective set, persists `GroupConfig.Tools`, applies the delta, returns `{ tools, summary: [{id, action: written|removed|unchanged|error, detail}] }`.

## In-process ApplyToolDelta reuse (#5256)
The PUT path calls `install.ApplyToolDelta` **in-process** — it writes newly-enabled tools' rules files + MCP entries and removes newly-disabled ones via the same `rulesfiles`/`mcpreg` primitives `grafel install` uses. **No `grafel install` subprocess, no daemon stop/restart, no OS-service calls** — the daemon stays up while the user edits. `ApplyToolDelta` is wired through an injectable `Server.applyToolDelta` field so handler tests run the full delta/persist/summary path with a mock and never touch the live machine.

## Frontend panel (webui-v2)
- **"AI coding tools" settings panel** in the Settings screen: checklist of every adapter with enabled + `(detected)` badges, a Save action that PUTs the selection and surfaces the per-tool written/removed summary, reflecting current state on load. Follows existing `Section`/`Switch`/api-client/TanStack-Query conventions (`api.getTools`/`putTools`, `useTools`/`usePutTools`).
- **Create-flow checklist — noted CLI-only**: the SPA create-group flow (`ScanWizard` mode="create") indexes asynchronously and does not thread a tool selection into the create request; create-time selection is CLI-only today via `grafel install` (#5256). The panel covers post-create editing for every group — noted in-code and in the panel copy rather than inventing a create-time backend contract.

## Validation
- `go build ./...` PASS; `go vet ./internal/dashboard/...` clean.
- `go test ./internal/dashboard/... ./internal/install/...` green, incl. new handler tests: GET status shape + default-all-enabled, PUT delta-apply summary, unknown-id 400 (no persist/apply), apply-error 500, empty-disables-all.
- webui-v2: `npm ci` + `tsc --noEmit` clean; vitest **138 passed**; `npm run build` (`tsc -b && vite build`) succeeds.
- `grafel selftest`: **all 6 layers PASS**.
- `internal/dashboard/dist` left as the committed PLACEHOLDER (the real bundle is produced at release time by `make dashboard-build`); the SPA build was verified to compile.

Closes #5257
Refs #5252

🤖 Generated with [Claude Code](https://claude.com/claude-code)