### PR TITLE
feat(install): per-enabled-tool doctor checks + uninstall sweeps all tools' MCP entries (#5258)

### DIFF
--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -106,6 +106,15 @@ type DoctorOptions struct {
 	// SkillsDir is the primary Claude skills directory.
 	// When empty it is derived from ClaudeConfigDirs or auto-detected from HOME.
 	SkillsDir string
+
+	// groupsFn / loadGroupFn resolve the registered groups and their configs
+	// for the per-enabled-tool checks (#5258). When nil they default to
+	// registry.Groups / registry.LoadGroupConfig. Injectable so tests can
+	// drive the enabled-tool set without a real registry on disk.
+	groupsFn     func() ([]registry.GroupRef, error)
+	loadGroupFn  func(path string) (*registry.GroupConfig, error)
+	mcpEntryFn   func(cfgPath string) (missing bool, drift string)
+	mcpPathForFn func(tool mcpreg.Tool) (string, error)
 }
 
 func (o *DoctorOptions) applyDefaults() error {
@@ -203,7 +212,18 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 		report.Checks = append(report.Checks, c)
 	}
 
-	// ── Check 7: Stale staging dirs ─────────────────────────────────────────
+	// ── Check 7: Per-enabled-tool wiring (issue #5258) ──────────────────────
+	// For every tool ENABLED in any group's config, verify its own artifacts:
+	// the MCP entry in that tool's config file (where SupportsMCP), and its
+	// rules file(s) across the group's repos. Skills are Claude-only and are
+	// already covered by Check 3, so they are not re-reported here. These rows
+	// are Warning severity (a per-tool gap doesn't break the install) — Claude's
+	// critical MCP/skills checks above keep their existing severity.
+	for _, c := range checkEnabledTools(opts) {
+		report.Checks = append(report.Checks, c)
+	}
+
+	// ── Check 8: Stale staging dirs ─────────────────────────────────────────
 	if staleCheck := checkStaleStagingDirs(opts.StatePath); staleCheck != nil {
 		report.Checks = append(report.Checks, *staleCheck)
 	}
@@ -644,6 +664,88 @@ func scanRulesFilesForRepo(group, repoPath string) CheckResult {
 		}
 	}
 	return cr
+}
+
+// checkEnabledTools emits one CheckResult per (group, enabled-tool) pair,
+// validating that tool's own wiring (issue #5258):
+//
+//   - MCP: when the adapter SupportsMCP, the grafel entry must be present in
+//     that tool's config file (mcpreg.SettingsPath — .claude.json, Cursor's
+//     ~/.cursor/mcp.json, Windsurf's mcp_config.json, Codex's config.toml,
+//     Kiro's mcp.json). A missing config file is reported as "mcp not wired"
+//     rather than an error — the tool may simply not be installed.
+//   - rules: each of the adapter's rules-file targets must contain the current
+//     grafel block in every repo of the group.
+//
+// Severity is Warning: a per-tool gap means that tool's agent won't reach for
+// the grafel MCP first, but it does not break the install. Claude's critical
+// MCP/skills checks (Checks 3 & 4) are unchanged. When no groups are
+// registered the slice is empty (a fresh machine isn't "broken").
+func checkEnabledTools(opts DoctorOptions) []CheckResult {
+	bindings := resolveEnabledToolBindings(opts.groupsFn, opts.loadGroupFn)
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	mcpEntry := opts.mcpEntryFn
+	if mcpEntry == nil {
+		mcpEntry = mcpEntryDrift
+	}
+	mcpPathFor := opts.mcpPathForFn
+	if mcpPathFor == nil {
+		mcpPathFor = mcpreg.SettingsPath
+	}
+
+	var results []CheckResult
+	for _, b := range bindings {
+		a := b.adapter
+		cr := CheckResult{
+			Surface:  fmt.Sprintf("tool/%s/%s", b.group, a.ID()),
+			OK:       true,
+			Severity: SeverityWarning,
+		}
+
+		// ── MCP entry in the tool's own config file ───────────────────────
+		if a.SupportsMCP() {
+			tool := a.MCPTool()
+			cfgPath, err := mcpPathFor(tool)
+			if err != nil {
+				cr.OK = false
+				cr.Drift = append(cr.Drift, fmt.Sprintf("mcp: cannot resolve config path: %v", err))
+			} else if _, statErr := os.Stat(cfgPath); statErr != nil {
+				// Tool's config file absent — tool likely not installed.
+				cr.OK = false
+				cr.Drift = append(cr.Drift, fmt.Sprintf("mcp not wired (%s absent — tool installed?)", cfgPath))
+			} else if missing, drift := mcpEntry(cfgPath); missing {
+				cr.OK = false
+				cr.Drift = append(cr.Drift, fmt.Sprintf("mcp entry absent from %s", cfgPath))
+			} else if drift != "" {
+				cr.OK = false
+				cr.Drift = append(cr.Drift, fmt.Sprintf("mcp: %s", drift))
+			}
+		}
+
+		// ── rules file(s) across the group's repos ────────────────────────
+		want := map[string]bool{}
+		for _, t := range a.RulesFileTargets() {
+			want[t] = true
+		}
+		if len(want) > 0 {
+			for _, repo := range b.repos {
+				for _, st := range rulesfiles.Scan(repo) {
+					if !want[st.Target] || st.Status == rulesfiles.StatusOK {
+						continue
+					}
+					cr.OK = false
+					label := strings.ToUpper(string(st.Status))
+					cr.Drift = append(cr.Drift, fmt.Sprintf("rules %s [%s] (%s)", st.Target, label, filepath.Base(repo)))
+				}
+			}
+		}
+
+		results = append(results, cr)
+	}
+	return results
 }
 
 // checkStaleStagingDirs looks for .grafel/staging/<run_id>/ directories

--- a/internal/install/pertool.go
+++ b/internal/install/pertool.go
@@ -1,0 +1,94 @@
+// pertool.go — per-enabled-tool awareness shared by doctor and uninstall (#5258).
+//
+// install.json records the Claude .claude.json paths (MCP.RegisteredPaths) and
+// the owned skills, but NOT the enabled-tool set: that lives in each group's
+// config (registry.GroupConfig.Tools, resolved through
+// tooladapter.EnabledTools). To make `grafel doctor` report — and `grafel
+// uninstall` sweep — EVERY enabled tool (Cursor/Windsurf/Codex/Kiro/…), both
+// commands resolve the enabled adapters from the registry here.
+//
+// The resolution is best-effort and never fatal: a machine with no groups
+// registered yields an empty set, and an unreadable group config is skipped
+// (doctor surfaces it via its own rules-file scan, which shares this path's
+// registry read).
+package install
+
+import (
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// enabledToolBinding pairs a resolved adapter with the group it was enabled in.
+// One adapter may appear once per group (the same tool can be enabled across
+// multiple groups); callers that operate on user-global artifacts (MCP configs)
+// de-duplicate by mcpreg.Tool, while per-repo artifacts (rules files) are
+// scoped per group's repos.
+type enabledToolBinding struct {
+	group   string
+	repos   []string
+	adapter tooladapter.Adapter
+}
+
+// resolveEnabledToolBindings walks every registered grafel group and returns
+// one binding per (group, enabled-adapter) pair, in a deterministic order
+// (group order from the registry × registry adapter order). It never errors:
+// registry/config read failures collapse to a shorter list. groupsFn and
+// loadFn are injectable so doctor/uninstall tests can drive the set without a
+// real registry on disk.
+func resolveEnabledToolBindings(
+	groupsFn func() ([]registry.GroupRef, error),
+	loadFn func(path string) (*registry.GroupConfig, error),
+) []enabledToolBinding {
+	if groupsFn == nil {
+		groupsFn = registry.Groups
+	}
+	if loadFn == nil {
+		loadFn = registry.LoadGroupConfig
+	}
+	groups, err := groupsFn()
+	if err != nil {
+		return nil
+	}
+	var out []enabledToolBinding
+	for _, g := range groups {
+		cfg, lerr := loadFn(g.ConfigPath)
+		if lerr != nil || cfg == nil {
+			continue
+		}
+		repos := make([]string, 0, len(cfg.Repos))
+		for _, r := range cfg.Repos {
+			repos = append(repos, r.Path)
+		}
+		for _, a := range tooladapter.EnabledAdapters(cfg) {
+			out = append(out, enabledToolBinding{
+				group:   g.Name,
+				repos:   repos,
+				adapter: a,
+			})
+		}
+	}
+	return out
+}
+
+// mcpToolsFromBindings returns the distinct mcpreg.Tool entries registered by
+// every enabled tool across all groups, in first-seen order. This is the set
+// `uninstall` must deregister from (each tool's own config file/format) so the
+// sweep covers Cursor/Windsurf/Codex/Kiro and not just Claude's
+// .claude.json paths.
+func mcpToolsFromBindings(bindings []enabledToolBinding) []mcpreg.Tool {
+	seen := map[mcpreg.Tool]bool{}
+	var out []mcpreg.Tool
+	for _, b := range bindings {
+		if !b.adapter.SupportsMCP() {
+			continue
+		}
+		t := b.adapter.MCPTool()
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out
+}

--- a/internal/install/pertool_test.go
+++ b/internal/install/pertool_test.go
@@ -1,0 +1,294 @@
+package install
+
+// pertool_test.go — per-enabled-tool doctor checks + multi-tool uninstall MCP
+// sweep (#5258). These tests drive the injectable hooks on DoctorOptions /
+// UninstallOptions so they never read a real registry or touch live config
+// files; every path is under a t.TempDir HOME.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/rulesfiles"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// fakeGroups returns a groupsFn/loadGroupFn pair backed by an in-memory config.
+func fakeGroups(cfg *registry.GroupConfig) (
+	func() ([]registry.GroupRef, error),
+	func(string) (*registry.GroupConfig, error),
+) {
+	groupsFn := func() ([]registry.GroupRef, error) {
+		return []registry.GroupRef{{Name: cfg.Name, ConfigPath: "/fake/" + cfg.Name + ".json"}}, nil
+	}
+	loadFn := func(string) (*registry.GroupConfig, error) { return cfg, nil }
+	return groupsFn, loadFn
+}
+
+func findCheck(checks []CheckResult, surface string) (CheckResult, bool) {
+	for _, c := range checks {
+		if c.Surface == surface {
+			return c, true
+		}
+	}
+	return CheckResult{}, false
+}
+
+// writeJSONMCP writes a config file with grafel plus a foreign server entry.
+func writeJSONMCP(t *testing.T, path string, withGrafel bool) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	servers := map[string]any{
+		"other": map[string]any{"command": "/bin/other", "args": []string{"x"}},
+	}
+	if withGrafel {
+		servers[mcpreg.ServerName] = map[string]any{"command": "/bin/grafel", "args": []string{"mcp-bridge"}}
+	}
+	doc := map[string]any{"mcpServers": servers}
+	b, _ := json.MarshalIndent(doc, "", "  ")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCheckEnabledTools_PerToolStatus verifies doctor emits one row per
+// (group, enabled-tool) and reports OK when a tool's MCP entry + rules file are
+// present, missing when the MCP entry is absent, and "not wired" when the
+// tool's config file does not exist.
+func TestCheckEnabledTools_PerToolStatus(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	repo := filepath.Join(home, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write the rules block to all targets so rules checks pass for every tool.
+	if _, err := rulesfiles.WriteAll(repo, rulesfiles.WriteOptions{GroupName: "g1"}); err != nil {
+		t.Fatalf("WriteAll rules: %v", err)
+	}
+
+	// claude: MCP entry present in ~/.claude.json (OK).
+	claudePath, _ := mcpreg.SettingsPath(mcpreg.ClaudeCode)
+	writeJSONMCP(t, claudePath, true)
+	// cursor: config file present but NO grafel entry → "mcp entry absent".
+	cursorPath, _ := mcpreg.SettingsPath(mcpreg.Cursor)
+	writeJSONMCP(t, cursorPath, false)
+	// codex: config file ABSENT entirely → "mcp not wired".
+
+	cfg := &registry.GroupConfig{
+		Name:  "g1",
+		Repos: []registry.Repo{{Path: repo}},
+		Tools: []string{"claude", "cursor", "codex"},
+	}
+	groupsFn, loadFn := fakeGroups(cfg)
+
+	checks := checkEnabledTools(DoctorOptions{groupsFn: groupsFn, loadGroupFn: loadFn})
+
+	claudeRow, ok := findCheck(checks, "tool/g1/claude")
+	if !ok {
+		t.Fatalf("missing claude row; got %d checks", len(checks))
+	}
+	if !claudeRow.OK {
+		t.Errorf("claude row should be OK, drift=%v", claudeRow.Drift)
+	}
+
+	cursorRow, ok := findCheck(checks, "tool/g1/cursor")
+	if !ok {
+		t.Fatal("missing cursor row")
+	}
+	if cursorRow.OK || cursorRow.Severity != SeverityWarning {
+		t.Errorf("cursor row should be Warning+not-OK, got OK=%v sev=%v", cursorRow.OK, cursorRow.Severity)
+	}
+	if !strings.Contains(strings.Join(cursorRow.Drift, " "), "mcp entry absent") {
+		t.Errorf("cursor drift should mention 'mcp entry absent', got %v", cursorRow.Drift)
+	}
+
+	codexRow, ok := findCheck(checks, "tool/g1/codex")
+	if !ok {
+		t.Fatal("missing codex row")
+	}
+	if codexRow.OK {
+		t.Error("codex row should be not-OK (config absent)")
+	}
+	if !strings.Contains(strings.Join(codexRow.Drift, " "), "not wired") {
+		t.Errorf("codex drift should mention 'not wired', got %v", codexRow.Drift)
+	}
+}
+
+// TestCheckEnabledTools_RulesDrift verifies a missing rules file for an enabled
+// tool is reported on that tool's row.
+func TestCheckEnabledTools_RulesDrift(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repo := filepath.Join(home, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Do NOT write any rules files → cursor's .cursorrules will be MISSING.
+	cursorPath, _ := mcpreg.SettingsPath(mcpreg.Cursor)
+	writeJSONMCP(t, cursorPath, true) // MCP fine; only rules should drift.
+
+	cfg := &registry.GroupConfig{
+		Name:  "g1",
+		Repos: []registry.Repo{{Path: repo}},
+		Tools: []string{"cursor"},
+	}
+	groupsFn, loadFn := fakeGroups(cfg)
+	checks := checkEnabledTools(DoctorOptions{groupsFn: groupsFn, loadGroupFn: loadFn})
+
+	row, ok := findCheck(checks, "tool/g1/cursor")
+	if !ok {
+		t.Fatal("missing cursor row")
+	}
+	if row.OK {
+		t.Error("cursor row should report rules drift")
+	}
+	if !strings.Contains(strings.Join(row.Drift, " "), ".cursorrules") {
+		t.Errorf("expected .cursorrules drift, got %v", row.Drift)
+	}
+}
+
+// TestCheckEnabledTools_NoGroups verifies an empty registry yields no rows.
+func TestCheckEnabledTools_NoGroups(t *testing.T) {
+	groupsFn := func() ([]registry.GroupRef, error) { return nil, nil }
+	loadFn := func(string) (*registry.GroupConfig, error) { return nil, nil }
+	if got := checkEnabledTools(DoctorOptions{groupsFn: groupsFn, loadGroupFn: loadFn}); got != nil {
+		t.Errorf("expected nil checks for no groups, got %v", got)
+	}
+}
+
+// TestUninstall_SweepsAllEnabledToolsMCP verifies uninstall removes grafel's
+// MCP entry from EVERY enabled tool's own config (JSON: cursor/windsurf/kiro;
+// TOML: codex) while preserving each foreign entry, and leaves no grafel entry.
+func TestUninstall_SweepsAllEnabledToolsMCP(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	binPath := filepath.Join(home, "grafel")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Register grafel into each tool's real config file (JSON + Codex TOML),
+	// alongside a pre-existing foreign entry, via the real mcpreg writers.
+	jsonTools := []mcpreg.Tool{mcpreg.Cursor, mcpreg.Windsurf, mcpreg.Kiro}
+	for _, tool := range jsonTools {
+		p, _ := mcpreg.SettingsPath(tool)
+		writeJSONMCP(t, p, false) // seed a foreign "other" entry only
+		if _, err := mcpreg.Register(tool, binPath, ""); err != nil {
+			t.Fatalf("Register %s: %v", tool, err)
+		}
+	}
+	// Codex TOML with a foreign table + grafel.
+	codexPath, _ := mcpreg.SettingsPath(mcpreg.Codex)
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(codexPath, []byte("[mcp_servers.other]\ncommand = \"/bin/other\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mcpreg.Register(mcpreg.Codex, binPath, ""); err != nil {
+		t.Fatalf("Register codex: %v", err)
+	}
+
+	// Minimal install.json so RunUninstall proceeds past the state read.
+	statePath := filepath.Join(home, ".grafel", "install.json")
+	st := NewState(ModeCopy)
+	st.CLI = CLIRecord{Path: binPath}
+	if err := WriteState(statePath, st); err != nil {
+		t.Fatalf("WriteState: %v", err)
+	}
+
+	cfg := &registry.GroupConfig{
+		Name:  "g1",
+		Tools: []string{"cursor", "windsurf", "kiro", "codex"},
+	}
+	groupsFn, loadFn := fakeGroups(cfg)
+
+	res, err := RunUninstall(UninstallOptions{
+		StatePath:      statePath,
+		SkipDaemonStop: true,
+		Yes:            true,
+		groupsFn:       groupsFn,
+		loadGroupFn:    loadFn,
+	})
+	if err != nil {
+		t.Fatalf("RunUninstall: %v", err)
+	}
+
+	// All four tools should be in the sweep result.
+	if len(res.MCPToolsDeregistered) != 4 {
+		t.Errorf("expected 4 tools deregistered, got %v", res.MCPToolsDeregistered)
+	}
+
+	// JSON tools: grafel gone, foreign "other" preserved.
+	for _, tool := range jsonTools {
+		p, _ := mcpreg.SettingsPath(tool)
+		data, rerr := os.ReadFile(p)
+		if rerr != nil {
+			t.Fatalf("read %s: %v", tool, rerr)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(data, &doc); err != nil {
+			t.Fatalf("parse %s: %v", tool, err)
+		}
+		servers, _ := doc["mcpServers"].(map[string]any)
+		if servers == nil {
+			t.Fatalf("%s: mcpServers vanished (foreign entry lost)", tool)
+		}
+		if _, ok := servers[mcpreg.ServerName]; ok {
+			t.Errorf("%s: grafel entry still present after uninstall", tool)
+		}
+		if _, ok := servers["other"]; !ok {
+			t.Errorf("%s: foreign 'other' entry was removed (should be preserved)", tool)
+		}
+	}
+
+	// Codex TOML: grafel table gone, foreign table preserved.
+	tomlData, rerr := os.ReadFile(codexPath)
+	if rerr != nil {
+		t.Fatalf("read codex toml: %v", rerr)
+	}
+	tomlStr := string(tomlData)
+	if strings.Contains(tomlStr, "[mcp_servers.grafel]") {
+		t.Errorf("codex: grafel table still present:\n%s", tomlStr)
+	}
+	if !strings.Contains(tomlStr, "[mcp_servers.other]") {
+		t.Errorf("codex: foreign table removed (should be preserved):\n%s", tomlStr)
+	}
+}
+
+// TestUninstall_NoEnabledMCPTools verifies the sweep is a no-op (and does not
+// error) when no enabled tool supports MCP.
+func TestUninstall_NoEnabledMCPTools(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	statePath := filepath.Join(home, ".grafel", "install.json")
+	if err := WriteState(statePath, NewState(ModeCopy)); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &registry.GroupConfig{Name: "g1", Tools: []string{"copilot"}} // rules-only
+	groupsFn, loadFn := fakeGroups(cfg)
+
+	res, err := RunUninstall(UninstallOptions{
+		StatePath:      statePath,
+		SkipDaemonStop: true,
+		Yes:            true,
+		groupsFn:       groupsFn,
+		loadGroupFn:    loadFn,
+	})
+	if err != nil {
+		t.Fatalf("RunUninstall: %v", err)
+	}
+	if len(res.MCPToolsDeregistered) != 0 {
+		t.Errorf("expected no tools deregistered, got %v", res.MCPToolsDeregistered)
+	}
+}

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/service"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/skilllink"
+	"github.com/cajasmota/grafel/internal/registry"
 )
 
 // UninstallOptions controls RunUninstall behaviour.
@@ -86,6 +87,20 @@ type UninstallOptions struct {
 	// warnFn receives WARN lines (e.g. when the daemon stop is skipped for
 	// isolation safety). When nil it writes to os.Stderr.
 	warnFn func(string)
+
+	// groupsFn / loadGroupFn resolve registered groups + their configs so the
+	// MCP deregistration sweep covers EVERY enabled tool's own config file
+	// (Cursor/Windsurf/Codex/Kiro), not just the recorded .claude.json paths
+	// (#5258). When nil they default to registry.Groups /
+	// registry.LoadGroupConfig. Injectable for tests.
+	groupsFn    func() ([]registry.GroupRef, error)
+	loadGroupFn func(path string) (*registry.GroupConfig, error)
+
+	// unregisterToolFn removes grafel's MCP entry from a tool's own config
+	// file (per-format: JSON or Codex TOML), preserving foreign entries. When
+	// nil it defaults to mcpreg.Unregister. Injectable so tests assert the
+	// multi-tool sweep without touching live config files.
+	unregisterToolFn func(tool mcpreg.Tool) error
 }
 
 // UninstallResult reports what RunUninstall accomplished.
@@ -95,6 +110,11 @@ type UninstallResult struct {
 
 	// MCPPaths lists the .claude.json files updated.
 	MCPPaths []string
+
+	// MCPToolsDeregistered lists the per-tool MCP configs (Cursor/Windsurf/
+	// Codex/Kiro/…) grafel's entry was removed from beyond the recorded
+	// .claude.json paths (#5258).
+	MCPToolsDeregistered []mcpreg.Tool
 
 	// DaemonStopped is true when the daemon was stopped.
 	DaemonStopped bool
@@ -149,6 +169,9 @@ func (o *UninstallOptions) applyDefaults() error {
 		o.warnFn = func(msg string) {
 			fmt.Fprintf(os.Stderr, "grafel uninstall: WARN: %s\n", msg)
 		}
+	}
+	if o.unregisterToolFn == nil {
+		o.unregisterToolFn = mcpreg.Unregister
 	}
 	return nil
 }
@@ -223,6 +246,29 @@ func RunUninstall(opts UninstallOptions) (*UninstallResult, error) {
 			fmt.Fprintf(os.Stderr, "grafel uninstall: deregister MCP %s: %v\n", cfgPath, err)
 		} else {
 			result.MCPPaths = append(result.MCPPaths, cfgPath)
+		}
+	}
+
+	// ── Step 2b: Sweep every enabled tool's own MCP config (#5258) ────────────
+	// Step 2 only removed grafel from the recorded .claude.json paths. The
+	// enabled-tool set lives in each group's config, so resolve it here and
+	// deregister grafel's entry from EVERY enabled tool's own config file —
+	// Cursor (~/.cursor/mcp.json), Windsurf (~/.codeium/windsurf/mcp_config.json),
+	// Codex (~/.codex/config.toml, TOML), Kiro (~/.kiro/settings/mcp.json).
+	// mcpreg.Unregister dispatches per-format (JSON vs TOML) and removes ONLY
+	// grafel's key/table, preserving every foreign server. Idempotent: a
+	// missing file or absent entry is a no-op.
+	bindings := resolveEnabledToolBindings(opts.groupsFn, opts.loadGroupFn)
+	for _, tool := range mcpToolsFromBindings(bindings) {
+		if opts.DryRun {
+			fmt.Fprintf(os.Stderr, "grafel uninstall (dry-run): would deregister MCP for tool %s\n", tool)
+			result.MCPToolsDeregistered = append(result.MCPToolsDeregistered, tool)
+			continue
+		}
+		if err := opts.unregisterToolFn(tool); err != nil {
+			fmt.Fprintf(os.Stderr, "grafel uninstall: deregister MCP for tool %s: %v\n", tool, err)
+		} else {
+			result.MCPToolsDeregistered = append(result.MCPToolsDeregistered, tool)
 		}
 	}
 


### PR DESCRIPTION
Part of EPIC #5252. Makes `grafel doctor` and `grafel uninstall` aware of EVERY enabled tool, not just Claude. The enabled-tool set lives in each group's config (`registry.GroupConfig.Tools` → `tooladapter.EnabledTools`), so both commands resolve the enabled adapters via a shared helper (`internal/install/pertool.go`, `resolveEnabledToolBindings`).

## doctor — per enabled tool
Adds one **Warning-severity** row per `(group, enabled-tool)`: `tool/<group>/<id>`. For each enabled adapter:
- **MCP**: entry present in that tool's own config file (`mcpreg.SettingsPath`: `.claude.json`, `~/.cursor/mcp.json`, `~/.codeium/windsurf/mcp_config.json`, `~/.codex/config.toml`, `~/.kiro/settings/mcp.json`) where `SupportsMCP`. Reports `mcp entry absent` vs `mcp not wired (<path> absent — tool installed?)`.
- **rules**: the adapter's `RulesFileTargets` contain the current grafel block across the group's repos (e.g. `rules .cursorrules [MISSING] (repo)`).
- **skills**: Claude-only, already covered by the existing skills check — not re-reported.

Existing Claude/critical CLI/daemon/MCP/skills checks keep their severity. A per-tool gap is Warning (exit-zero) and never hard-fails doctor.

Output shape:
```
[ ok ] tool/g1/claude
[warn] tool/g1/cursor
       mcp entry absent from /home/u/.cursor/mcp.json
[warn] tool/g1/codex
       mcp not wired (/home/u/.codex/config.toml absent — tool installed?)
```

## uninstall — sweep ALL enabled tools' MCP entries
Step 2 only deregistered grafel from the recorded `.claude.json` paths. New **Step 2b** resolves the enabled-tool set and removes grafel's entry from EVERY enabled tool's own config (Cursor/Windsurf/Kiro JSON + Codex TOML) via `mcpreg.Unregister`, which dispatches per-format and removes **only** grafel's key/table — **foreign servers preserved**. Idempotent (missing file or absent entry is a no-op). Reuses the same `mcpreg` unregister primitives as #5256 `ApplyToolDelta`; #5274 already handles rules-block removal across tools. Skills (Claude) removal unchanged. New `UninstallResult.MCPToolsDeregistered` records the swept tools.

## Validation (no live uninstall/launchctl)
- `go build ./...` PASS; `go vet ./internal/install/...` clean.
- `go test ./internal/install/...` green.
- `grafel selftest` → all 6 layers PASS.
- New in-package tests (temp HOMEs, injectable hooks — never the live registry/configs):
  - doctor reports per-tool OK (claude wired) vs missing (cursor: entry absent) vs not-wired (codex: config absent), plus a rules-drift row;
  - uninstall removes grafel from cursor/windsurf/kiro (JSON) + codex (TOML) while **preserving a foreign entry** in each, and is a no-op when no enabled tool supports MCP.

Closes #5258
Refs #5252

🤖 Generated with [Claude Code](https://claude.com/claude-code)