### PR TITLE
feat(install): wire Antigravity MCP registration (~/.gemini/antigravity/mcp_config.json) (#5280)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -28,7 +28,7 @@ writes what the tool can actually consume.
 | **Codeium** (`codeium`) | ✗ | `.codeium/instructions.md` | ✗ | ✗ | ✗ (rules-only) |
 | **GitHub Copilot** (`copilot`) | ✗ | `.github/copilot-instructions.md` | ✗ | ✗ | ✗ (rules-only) |
 | **Kiro** (`kiro`) | ✓ `~/.kiro/settings/mcp.json` | `.kiro/steering/grafel.md` | ✗ | ✗ | ✓ (MCP config present) |
-| **Antigravity** (`antigravity`) | ✗ (rules-only today — see below) | `.agent/rules/grafel.md` | ✗ | ✗ | ✗ (rules-only) |
+| **Antigravity** (`antigravity`) | ✓ `~/.gemini/antigravity/mcp_config.json` | `.agent/rules/grafel.md` | ✗ | ✗ | ✓ (MCP config present) |
 
 Notes:
 
@@ -41,7 +41,7 @@ Notes:
   relative paths apply under the user profile.
 - **Detected?** is a best-effort signal that the tool is present on this
   machine: for MCP-capable tools it checks whether the tool's MCP config file
-  exists; the two rules-only tools (Codeium, Copilot, Antigravity) report "not
+  exists; the two rules-only tools (Codeium, Copilot) report "not
   detected" since there is no config file to probe. Detection is **advisory** —
   it only pre-checks tools in the wizard; install still honours your explicit
   selection regardless.
@@ -49,16 +49,14 @@ Notes:
   MCP-capable tool uses the JSON `{ "mcpServers": { "grafel": { ... } } }`
   shape.
 
-### Antigravity — rules-only today
+### Antigravity — MCP + rules
 
-Google Antigravity gets the rules file (`.agent/rules/grafel.md`) but **no MCP
-entry yet**. Antigravity's MCP config path is not confidently verifiable
-(public sources disagree on the location, and it uses a non-standard
-`serverUrl` JSON key), so grafel ships the rules adapter only rather than write
-a path it cannot justify. MCP support is tracked in
-[#5280](https://github.com/cajasmota/grafel/issues/5280); once the path and
-JSON shape are confirmed, Antigravity will register an MCP entry like the other
-tools.
+Google Antigravity gets both the rules file (`.agent/rules/grafel.md`) and an
+MCP entry at `~/.gemini/antigravity/mcp_config.json` (#5280). grafel is a local
+**stdio** server, so the entry uses the standard JSON
+`{ "mcpServers": { "grafel": { "command": ..., "args": ["mcp-bridge"] } } }`
+shape — identical to Cursor/Kiro. (The `serverUrl` key applies only to remote
+HTTP MCP servers and is not used here.)
 
 ---
 

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -81,6 +81,7 @@ const (
 	ContinueDev       Tool = "continue-dev"
 	Zed               Tool = "zed"
 	Kiro              Tool = "kiro"
+	Antigravity       Tool = "antigravity"
 )
 
 // ConfigShape describes the JSON layout of a host's config file for
@@ -202,6 +203,15 @@ func SettingsPath(tool Tool) (string, error) {
 		// user-global file — same convention as Cursor (~/.cursor/mcp.json).
 		// The JSON shape is identical to Cursor: { "mcpServers": { ... } }.
 		return filepath.Join(home, ".kiro", "settings", "mcp.json"), nil
+	case Antigravity:
+		// Google Antigravity (agentic IDE): user-global MCP config at
+		// ~/.gemini/antigravity/mcp_config.json (on Windows the same relative
+		// path under %USERPROFILE%). grafel is a local stdio server, so the
+		// entry is the standard JSON { "mcpServers": { "grafel": { command,
+		// args } } } shape — identical to Cursor/Kiro. The `serverUrl` key is
+		// only for remote HTTP MCP servers and does NOT apply here. Path source:
+		// the official github-mcp-server install-antigravity guide.
+		return filepath.Join(home, ".gemini", "antigravity", "mcp_config.json"), nil
 	}
 	return "", fmt.Errorf("unknown tool: %s", tool)
 }
@@ -264,6 +274,14 @@ func DetectContinueDevPaths() []HostTarget {
 // same shape as Cursor).
 func DetectKiroPaths() []HostTarget {
 	return DetectHostPaths([]string{".kiro", "settings"}, "mcp.json", ShapeFlat)
+}
+
+// DetectAntigravityPaths returns Antigravity config paths to register.
+// Uses ~/.gemini/antigravity/mcp_config.json — ShapeFlat (mcpServers key at
+// root, same JSON shape as Cursor/Kiro). grafel is a local stdio server, so
+// no remote `serverUrl` is involved.
+func DetectAntigravityPaths() []HostTarget {
+	return DetectHostPaths([]string{".gemini", "antigravity"}, "mcp_config.json", ShapeFlat)
 }
 
 // DetectZedPaths returns Zed config paths to register.

--- a/internal/install/mcpreg/mcpreg_test.go
+++ b/internal/install/mcpreg/mcpreg_test.go
@@ -596,6 +596,128 @@ func TestKiro_PreservesForeignServers_AndUnregisters(t *testing.T) {
 	}
 }
 
+// ── Antigravity tests ─────────────────────────────────────────────────────────
+
+// TestInstall_RegistersAntigravity: ~/.gemini/antigravity/ present →
+// DetectAntigravityPaths returns the mcp_config.json path and RegisterPath
+// writes a valid grafel entry with the Cursor-shaped { "mcpServers": { ... } }
+// layout (#5280).
+func TestInstall_RegistersAntigravity(t *testing.T) {
+	home := withHome(t)
+
+	agDir := filepath.Join(home, ".gemini", "antigravity")
+	if err := os.MkdirAll(agDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	targets := DetectAntigravityPaths()
+	wantPath := filepath.Join(agDir, "mcp_config.json")
+	if len(targets) != 1 || targets[0].Path != wantPath {
+		t.Fatalf("DetectAntigravityPaths: got %v, want [{%s ShapeFlat}]", targets, wantPath)
+	}
+	if targets[0].Shape != ShapeFlat {
+		t.Fatalf("Antigravity shape: got %v, want ShapeFlat", targets[0].Shape)
+	}
+
+	// SettingsPath(Antigravity) must resolve to the same user-global file.
+	sp, err := SettingsPath(Antigravity)
+	if err != nil {
+		t.Fatalf("SettingsPath(Antigravity): %v", err)
+	}
+	if sp != wantPath {
+		t.Fatalf("SettingsPath(Antigravity) = %q, want %q", sp, wantPath)
+	}
+
+	if _, err := RegisterPath(wantPath, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		McpServers map[string]Entry `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	got := doc.McpServers[ServerName]
+	if got.Command != "/usr/local/bin/grafel" {
+		t.Fatalf("antigravity: command = %q, want /usr/local/bin/grafel", got.Command)
+	}
+	if len(got.Args) != 1 || got.Args[0] != "mcp-bridge" {
+		t.Fatalf("antigravity: args = %v, want [mcp-bridge]", got.Args)
+	}
+	if got.Type != "stdio" {
+		t.Fatalf("antigravity: type = %q, want stdio", got.Type)
+	}
+}
+
+// TestInstall_SkipsAbsentAntigravity: no ~/.gemini/antigravity dir →
+// DetectAntigravityPaths is empty.
+func TestInstall_SkipsAbsentAntigravity(t *testing.T) {
+	withHome(t)
+	if targets := DetectAntigravityPaths(); len(targets) != 0 {
+		t.Fatalf("expected no Antigravity paths when dir absent, got %v", targets)
+	}
+}
+
+// TestAntigravity_PreservesForeignServers_AndUnregisters: registering grafel
+// into an Antigravity mcp_config.json that already has another server preserves
+// the foreign entry, and Unregister removes ONLY grafel's key (#5280 safety,
+// same as Cursor/Kiro).
+func TestAntigravity_PreservesForeignServers_AndUnregisters(t *testing.T) {
+	home := withHome(t)
+	agDir := filepath.Join(home, ".gemini", "antigravity")
+	if err := os.MkdirAll(agDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(agDir, "mcp_config.json")
+
+	seed := `{"mcpServers":{"other":{"command":"/bin/other","args":["x"]}},"someAGSetting":true}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	b, _ := os.ReadFile(path)
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["other"]; !ok {
+		t.Fatalf("foreign server 'other' was dropped: %v", servers)
+	}
+	if _, ok := servers[ServerName]; !ok {
+		t.Fatalf("grafel server not written: %v", servers)
+	}
+	if doc["someAGSetting"] != true {
+		t.Fatalf("unrelated key 'someAGSetting' not preserved: %v", doc["someAGSetting"])
+	}
+
+	if err := UnregisterPath(path); err != nil {
+		t.Fatal(err)
+	}
+	b, _ = os.ReadFile(path)
+	doc = nil
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	servers, _ = doc["mcpServers"].(map[string]any)
+	if _, ok := servers[ServerName]; ok {
+		t.Fatalf("grafel not removed on unregister: %v", servers)
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Fatalf("unregister dropped foreign server 'other': %v", servers)
+	}
+	if doc["someAGSetting"] != true {
+		t.Fatalf("unregister dropped unrelated key: %v", doc["someAGSetting"])
+	}
+}
+
 // ── Codex tests ───────────────────────────────────────────────────────────────
 
 // TestInstall_RegistersCodex: ~/.codex/ present → DetectCodexPaths returns
@@ -1006,6 +1128,7 @@ func TestInstall_SkipsAbsentHost(t *testing.T) {
 		{"ContinueDev", DetectContinueDevPaths},
 		{"Zed", DetectZedPaths},
 		{"Kiro", DetectKiroPaths},
+		{"Antigravity", DetectAntigravityPaths},
 	}
 	for _, h := range hosts {
 		t.Run(h.name, func(t *testing.T) {

--- a/internal/install/tooladapter/adapters.go
+++ b/internal/install/tooladapter/adapters.go
@@ -157,24 +157,21 @@ func (kiroAdapter) SupportsAgentHook() bool    { return false }
 // ── antigravity ──────────────────────────────────────────────────────
 //
 // Google Antigravity (agentic IDE) reads workspace rules as markdown from
-// <repo>/.agent/rules/*.md (we write .agent/rules/grafel.md).
+// <repo>/.agent/rules/*.md (we write .agent/rules/grafel.md) and registers an
+// MCP server in its user-global JSON config at
+// ~/.gemini/antigravity/mcp_config.json (mcpServers.grafel) — #5280.
 //
-// MCP: SupportsMCP()==false for now. Antigravity's MCP config path is not
-// confidently verifiable — public sources disagree on the location
-// (~/.gemini/antigravity/mcp_config.json vs ~/.gemini/config/mcp_config.json)
-// and Antigravity uses a non-standard `serverUrl` key (vs the usual `url`),
-// signalling its JSON shape is not a drop-in Cursor clone. Per #5255 we ship
-// the rules-file adapter only rather than invent a path we can't justify.
-// TODO(#5255 follow-up): confirm the Antigravity MCP config path + JSON
-// format against a pinned IDE version, then flip SupportsMCP()==true and add
-// the mcpreg.Tool entry (and a serverUrl-aware writer if needed).
+// grafel is a local stdio server (command=grafel binary, args=["mcp-bridge"]),
+// so the entry uses the standard JSON { "mcpServers": { ... } } shape —
+// identical to Cursor/Kiro and a drop-in for the existing JSON mcpreg writer.
+// The `serverUrl` key is only for remote HTTP MCP servers and does NOT apply.
 type antigravityAdapter struct{}
 
 func (antigravityAdapter) ID() string                 { return "antigravity" }
 func (antigravityAdapter) DisplayName() string        { return "Antigravity" }
-func (antigravityAdapter) DetectInstalled() bool      { return false }
+func (antigravityAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Antigravity) }
 func (antigravityAdapter) RulesFileTargets() []string { return []string{rulesAntigravity} }
-func (antigravityAdapter) SupportsMCP() bool          { return false }
-func (antigravityAdapter) MCPTool() mcpreg.Tool       { return "" }
+func (antigravityAdapter) SupportsMCP() bool          { return true }
+func (antigravityAdapter) MCPTool() mcpreg.Tool       { return mcpreg.Antigravity }
 func (antigravityAdapter) SupportsSkills() bool       { return false }
 func (antigravityAdapter) SupportsAgentHook() bool    { return false }

--- a/internal/install/tooladapter/tooladapter_test.go
+++ b/internal/install/tooladapter/tooladapter_test.go
@@ -30,7 +30,7 @@ func TestDefaultEnablement_ReproducesAllSixRulesFiles(t *testing.T) {
 // TestDefaultEnablement_MCPTools guards the set of MCP tools grafel
 // registers under the default (all-tools) enablement. Cursor and Codex were
 // added in #5254 alongside the pre-existing Claude + Windsurf; Kiro was added
-// in #5255 (Antigravity is rules-only, no MCP).
+// in #5255; Antigravity MCP was wired in #5280.
 func TestDefaultEnablement_MCPTools(t *testing.T) {
 	var mcp []mcpreg.Tool
 	for _, a := range tooladapter.EnabledAdapters(nil) {
@@ -39,7 +39,7 @@ func TestDefaultEnablement_MCPTools(t *testing.T) {
 		}
 	}
 	sort.Slice(mcp, func(i, j int) bool { return mcp[i] < mcp[j] })
-	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Codex, mcpreg.Cursor, mcpreg.Windsurf, mcpreg.Kiro}
+	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Codex, mcpreg.Cursor, mcpreg.Windsurf, mcpreg.Kiro, mcpreg.Antigravity}
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 	if !reflect.DeepEqual(mcp, want) {
 		t.Fatalf("default MCP tools = %v, want %v", mcp, want)
@@ -135,9 +135,9 @@ func TestKiroAdapter(t *testing.T) {
 	}
 }
 
-// TestAntigravityAdapter checks Antigravity is a rules-only adapter (#5255):
-// a workspace .agent/rules/grafel.md file and NO MCP entry (path not yet
-// confidently verifiable — see adapter doc TODO).
+// TestAntigravityAdapter checks Antigravity's targets: a workspace rules file
+// plus an MCP entry registered into the user-global
+// ~/.gemini/antigravity/mcp_config.json (#5280).
 func TestAntigravityAdapter(t *testing.T) {
 	cfg := &registry.GroupConfig{Tools: []string{"antigravity"}}
 	ad := tooladapter.EnabledAdapters(cfg)
@@ -148,8 +148,8 @@ func TestAntigravityAdapter(t *testing.T) {
 	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{".agent/rules/grafel.md"}) {
 		t.Fatalf("antigravity rules targets = %v, want [.agent/rules/grafel.md]", rt)
 	}
-	if a.SupportsMCP() || a.MCPTool() != "" {
-		t.Fatalf("antigravity must NOT register MCP (path unverified)")
+	if !a.SupportsMCP() || a.MCPTool() != mcpreg.Antigravity {
+		t.Fatalf("antigravity must register Antigravity MCP")
 	}
 	if a.SupportsAgentHook() || a.SupportsSkills() {
 		t.Fatalf("antigravity should not support hook/skills")


### PR DESCRIPTION
Wires MCP registration for the Antigravity tool adapter (EPIC #5252 follow-up).

## Resolved path & schema
- **Config path:** `~/.gemini/antigravity/mcp_config.json` (macOS/Linux; Windows: same relative path under `%USERPROFILE%`). Source: the official github-mcp-server install-antigravity guide.
- **Schema:** standard JSON `{ "mcpServers": { "grafel": { "command": ..., "args": ["mcp-bridge"], "type": "stdio" } } }` — identical to Cursor/Kiro.
- grafel is a local **stdio** server, so it's a drop-in for the existing JSON mcpreg writer. The `serverUrl` key is **remote-HTTP-only** and does NOT apply — no new format code added.

## Changes
- `mcpreg`: add `Antigravity` `Tool` const, `SettingsPath` case, `DetectAntigravityPaths` (ShapeFlat).
- `tooladapter`: `antigravityAdapter` now `SupportsMCP()=true`, `MCPTool()=Antigravity`, `DetectInstalled` via `hasMCPHost`; removed the #5255 rules-only `SupportsMCP=false` TODO.
- Reuses the existing JSON register/unregister/rollback + foreign-entry preservation verbatim.
- Tests mirror the Kiro MCP suite: register / skip-absent / foreign-entry-preservation+unregister; updated default-enablement + adapter tests + absent-host table.
- `docs/tools.md`: Antigravity MCP column ✗→✓ with the path; dropped the "rules-only today" note.

## Validation
- `go build ./...` PASS, `go vet ./internal/install/...` clean.
- `go test ./internal/install/...` all green (incl. new antigravity mcpreg tests + updated tooladapter default-enablement/adapter tests).
- `grafel selftest` → all 6 layers PASS.

Closes #5280
Refs #5252

🤖 Generated with [Claude Code](https://claude.com/claude-code)