### PR TITLE
fix(find): enforce min_score floor + bound expansion (no whole-repo dump on zero-selectivity) (#5289)

### DIFF
--- a/internal/mcp/find_zero_selectivity_5289_test.go
+++ b/internal/mcp/find_zero_selectivity_5289_test.go
@@ -1,0 +1,160 @@
+// find_zero_selectivity_5289_test.go — regression tests for #5289.
+//
+// Bug: grafel_find on a zero-selectivity query (terms that match NO entity
+// name) returned the WHOLE repo at score 0.00, then BFS-expanded (depth=3) over
+// a 6915-node densely-connected graph and built a 2.6M-edge summary → ~113s.
+//
+// Root cause: the min_score cull had a "preserve at least one hit" guard that
+// kept the ENTIRE sub-threshold candidate list when nothing cleared the 0.15
+// floor; those near-zero seeds then drove an UNBOUNDED BFS (bfs() passed
+// maxNodes=0) + an unbounded edge-summary.
+//
+// Fix: enforce the min_score floor honestly (drop every sub-floor hit, even if
+// that empties the list), return the single always-1 fallback with a
+// low-confidence hint WITHOUT expansion, and bound BFS/edge work defensively.
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildDenseRepo builds a single densely-connected repo of n entities whose
+// names share NO tokens with the zero-selectivity query below. Every node links
+// to the next ~k nodes so a depth-3 BFS from any seed (before the #5289 caps)
+// would reach essentially the whole graph and emit a huge edge summary.
+func buildDenseRepo(n, k int) *graph.Document {
+	doc := &graph.Document{Repo: "dense"}
+	for i := 0; i < n; i++ {
+		// Names use a private token namespace ("zqx…") so no query in these
+		// tests BM25-matches them by accident.
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         fmt.Sprintf("n%d", i),
+			Name:       fmt.Sprintf("zqxNode%d", i),
+			Kind:       "SCOPE.Function",
+			SourceFile: fmt.Sprintf("src/zqx/node%d.ts", i),
+			StartLine:  1,
+			PageRank:   pr(0.01),
+		})
+	}
+	for i := 0; i < n; i++ {
+		for j := 1; j <= k; j++ {
+			t := (i + j) % n
+			doc.Relationships = append(doc.Relationships, graph.Relationship{
+				ID:     fmt.Sprintf("e%d_%d", i, t),
+				FromID: fmt.Sprintf("n%d", i),
+				ToID:   fmt.Sprintf("n%d", t),
+				Kind:   "CALLS",
+			})
+		}
+	}
+	return doc
+}
+
+// TestFind_ZeroSelectivity_NoWholeRepoDump_5289 is the core regression: a query
+// whose terms match nothing must NOT return the whole repo, must be fast, and
+// must carry the low-confidence hint.
+func TestFind_ZeroSelectivity_NoWholeRepoDump_5289(t *testing.T) {
+	const n = 6000
+	doc := buildDenseRepo(n, 8) // 6000 nodes, ~48k edges, depth-3 reaches all
+	srv := newTestServer(t, doc)
+
+	start := time.Now()
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group": "test",
+		"query": "main features screens dashboard inspection building",
+	})
+	elapsed := time.Since(start)
+
+	if res == "" {
+		t.Fatal("expected a (low-confidence) result, got empty")
+	}
+
+	// 1) Must NOT dump the whole repo. The compact output names visible nodes;
+	//    a whole-repo dump would mention thousands of zqxNode names. Count them.
+	mentions := strings.Count(res, "zqxNode")
+	if mentions > findMaxVisibleNodes {
+		t.Fatalf("whole-repo dump: %d node mentions (cap %d). The min_score floor "+
+			"or expansion bound is not enforced.\n%.500s", mentions, findMaxVisibleNodes, res)
+	}
+	// For a true zero-selectivity query we expect just the single fallback node.
+	if mentions > 2 {
+		t.Errorf("expected ~1 fallback node for a zero-selectivity query, got %d node mentions", mentions)
+	}
+
+	// 2) Must carry the honest low-confidence hint (not a real subgraph).
+	if !strings.Contains(res, "no strong matches above min_score") {
+		t.Errorf("expected low-confidence hint; got:\n%s", res)
+	}
+
+	// 3) Must be fast — the unbounded path took ~113s live; bounded logic on a
+	//    6k-node fixture must be well under a second.
+	if elapsed > 2*time.Second {
+		t.Fatalf("zero-selectivity query too slow: %v (expected << 1s)", elapsed)
+	}
+	t.Logf("zero-selectivity query: %d node mentions, elapsed=%v", mentions, elapsed)
+}
+
+// TestFind_MinScoreFloorEnforced_5289 asserts the floor itself: with the default
+// min_score, sub-threshold hits are dropped (full=true exposes the raw match
+// list). A zero-selectivity query yields only the low-confidence fallback.
+func TestFind_MinScoreFloorEnforced_5289(t *testing.T) {
+	doc := buildDenseRepo(500, 4)
+	srv := newTestServer(t, doc)
+
+	out := callEndpointTool(t, srv.handleQueryGraph, map[string]any{
+		"group": "test",
+		"query": "main features screens dashboard inspection building",
+		"full":  true,
+	})
+
+	matches, _ := out["matches"].([]any)
+	if len(matches) > 1 {
+		t.Fatalf("min_score floor not enforced: expected <=1 (fallback only) match for a "+
+			"zero-selectivity query, got %d", len(matches))
+	}
+	if lc, _ := out["low_confidence"].(bool); !lc {
+		t.Errorf("expected low_confidence=true for zero-selectivity query; got %#v", out["low_confidence"])
+	}
+}
+
+// TestFind_SelectiveQuery_StillExpands_5289 guards against regression: a real
+// match above the floor must still be returned and BFS-expand its neighbours.
+func TestFind_SelectiveQuery_StillExpands_5289(t *testing.T) {
+	doc := &graph.Document{Repo: "app"}
+	// A clearly-named target plus a small neighbourhood reachable by CALLS.
+	doc.Entities = []graph.Entity{
+		{ID: "page", Name: "InspectionResultsPage", Kind: "SCOPE.Component",
+			SourceFile: "src/pages/InspectionResultsPage.tsx", StartLine: 1, PageRank: pr(0.2)},
+		{ID: "hook", Name: "useInspectionResults", Kind: "SCOPE.Function",
+			SourceFile: "src/hooks/useInspectionResults.ts", StartLine: 1, PageRank: pr(0.1)},
+		{ID: "api", Name: "fetchInspectionResults", Kind: "SCOPE.Function",
+			SourceFile: "src/api/inspection.ts", StartLine: 1, PageRank: pr(0.05)},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "r1", FromID: "page", ToID: "hook", Kind: "CALLS"},
+		{ID: "r2", FromID: "hook", ToID: "api", Kind: "CALLS"},
+	}
+	srv := newTestServer(t, doc)
+
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group": "test",
+		"query": "InspectionResultsPage",
+	})
+
+	if !strings.Contains(res, "InspectionResultsPage") {
+		t.Fatalf("selective query lost its primary match:\n%s", res)
+	}
+	// The neighbourhood must still expand (regression: don't over-prune).
+	if !strings.Contains(res, "useInspectionResults") {
+		t.Errorf("selective query did not BFS-expand neighbours:\n%s", res)
+	}
+	// And it must NOT carry the low-confidence hint.
+	if strings.Contains(res, "no strong matches above min_score") {
+		t.Errorf("selective query wrongly flagged low-confidence:\n%s", res)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -709,10 +709,20 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 		return all[i].hit.Score > all[j].hit.Score
 	})
 
-	// min_score cutoff (#1747): drop ranked hits below the threshold after
-	// re-ranking so the tail is clean. Only applied when minScore > 0 and there
-	// is at least one hit above the bar (avoids blanking on noisy corpora).
-	// The "always-1" fallback below still fires if the cull leaves the list empty.
+	// min_score cutoff (#1747 / #5289): drop ranked hits below the threshold
+	// after re-ranking so the tail is clean. Applied honestly: when minScore > 0,
+	// every hit below the bar is removed — even if that empties the list.
+	//
+	// #5289: the prior implementation kept the ENTIRE sub-threshold list when the
+	// cull would leave it empty ("preserve at least one hit"). For a
+	// zero-selectivity query (terms that BM25-match weakly or not at all), every
+	// candidate scored below 0.15, so the guard preserved up to `limit` near-zero
+	// (displayed score=0.00) hits per repo. Those leaked seeds then drove an
+	// unbounded depth-3 BFS that dumped the whole repo (6915 nodes / 2.6M-edge
+	// summary / ~113s) — see the bounded-expansion logic below. We now let the
+	// cull empty the list; the scoped "always-1" fallback (a SINGLE node) handles
+	// the empty case, and a zero-selectivity result is surfaced honestly rather
+	// than expanded.
 	if minScore > 0 && len(all) > 0 {
 		// Keep hits whose BM25/RRF score clears the bar. Since re-rank tier sorts
 		// noiseNone first, the best real hit is all[0]; only trim from the tail.
@@ -722,10 +732,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 				culled = append(culled, sc)
 			}
 		}
-		// Preserve at least one hit so the caller always gets a result.
-		if len(culled) > 0 {
-			all = culled
-		}
+		all = culled
 	}
 
 	// #2769 Phase 1C: drop hits whose entity confidence falls below the
@@ -755,7 +762,13 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 	//  2. Otherwise use the repo with the most raw BM25 candidate hits
 	//     (highest textual overlap with the query terms) — never cross-repo.
 	//  3. Fall back to the first repo if all hit counts are zero.
+	// lowConfidence is set when the only result is the always-1 fallback (no hit
+	// cleared min_score). In that case we return the single fallback node WITHOUT
+	// BFS expansion and with a hint, instead of expanding a non-match into the
+	// whole repo (#5289).
+	lowConfidence := false
 	if len(all) == 0 {
+		lowConfidence = true
 		scopedRepos := scopeFallbackRepos(repos, repoFilter, bm25HitsByRepo)
 		fallback := pickFallback(scopedRepos)
 		if fallback != nil {
@@ -782,6 +795,10 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 				"capped at max_results=%d; %d additional hits omitted (pass max_results up to 200 or tighten query)",
 				maxResults, preCapTotal-maxResults,
 			)
+		}
+		if lowConfidence {
+			out["low_confidence"] = true
+			out["hint"] = noStrongMatchHint
 		}
 		return jsonResult(out), nil
 	}
@@ -813,6 +830,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 	visibleNodes := []nodeWithRepo{}
 	visibleEdges := []renderEdge{}
 	seen := map[string]bool{} // prefixed id
+	expandTruncated := false
 
 	add := func(repo string, e *graph.Entity, score float64) {
 		pid := prefixedID(repo, e.ID)
@@ -825,13 +843,36 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 	for _, sc := range keep {
 		add(sc.repo.Repo, sc.hit.Entity, sc.hit.Score)
 	}
-	if mode != "none" {
+	// #5289: never BFS-expand a low-confidence fallback. The always-1 fallback
+	// node is a poor textual match injected only so the caller sees *something*;
+	// expanding it depth-3 over a densely-connected repo is exactly the
+	// pathological whole-repo dump (6915 nodes / 2.6M edges / ~113s) we are
+	// fixing. Return just the single fallback node with a hint instead.
+	if mode != "none" && !lowConfidence {
 		for _, sc := range keep {
+			// #5289: stop once the visible set reaches the node budget so a
+			// borderline-selective seed (a low-but-above-floor hit that fans out
+			// to a hub) can't expand into the whole repo. Both the BFS work and
+			// the O(visited * out-degree) edge-carry below are bounded by this.
+			if len(visibleNodes) >= findMaxVisibleNodes {
+				expandTruncated = true
+				break
+			}
 			adj := sc.repo.getAdjacency() // built lazily, cached until reload (#3367)
-			vis := bfs(adj, sc.hit.Entity.ID, depth, contextFilter)
+			// bfsBounded caps the per-seed visited set; combined with the
+			// visibleNodes ceiling this keeps a non-selective query well under a
+			// second instead of the ~113s unbounded case.
+			vis, vt := bfsBounded(adj, sc.hit.Entity.ID, depth, contextFilter, findMaxBFSNodesPerSeed)
+			if vt {
+				expandTruncated = true
+			}
 			for nid, d := range vis {
 				if nid == sc.hit.Entity.ID {
 					continue
+				}
+				if len(visibleNodes) >= findMaxVisibleNodes {
+					expandTruncated = true
+					break
 				}
 				if e, ok := sc.repo.LabelIndex.ByID[nid]; ok {
 					add(sc.repo.Repo, e, sc.hit.Score/float64(d+1))
@@ -841,8 +882,12 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 			// iterate out-edges from each visited node instead of scanning the
 			// full Doc.Relationships list. Every edge naturally appears exactly
 			// once (as an out-edge of its source) so direction semantics match
-			// the prior linear scan.
+			// the prior linear scan. Bounded by findMaxVisibleEdges (#5289).
 			for nid := range vis {
+				if len(visibleEdges) >= findMaxVisibleEdges {
+					expandTruncated = true
+					break
+				}
 				from := sc.repo.LabelIndex.ByID[nid]
 				if from == nil {
 					continue
@@ -851,6 +896,10 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 					continue
 				}
 				for _, e := range adj.Outgoing(nid) {
+					if len(visibleEdges) >= findMaxVisibleEdges {
+						expandTruncated = true
+						break
+					}
 					if !seen[prefixedID(sc.repo.Repo, e.target)] {
 						continue
 					}
@@ -870,6 +919,15 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 		Nodes:        visibleNodes,
 		Edges:        visibleEdges,
 		OneRepo:      oneRepo,
+	}
+	switch {
+	case lowConfidence:
+		rr.TruncatedNote = noStrongMatchHint
+	case expandTruncated:
+		rr.TruncatedNote = fmt.Sprintf(
+			"expansion capped (>%d nodes / %d edges) — broad query; tighten `query=` or use grafel_neighbors/grafel_topology for full structure",
+			findMaxVisibleNodes, findMaxVisibleEdges,
+		)
 	}
 	// Record the prefixed ids of every visible node so the MCP-activity glow
 	// highlights the compact result set (the rendered markdown has no ids).
@@ -975,6 +1033,30 @@ type scored struct {
 	repo *LoadedRepo
 	hit  Hit
 }
+
+// #5289 expansion bounds. A zero-/low-selectivity grafel_find query used to
+// leak sub-min_score seeds (displayed score=0.00) into an unbounded depth-3 BFS
+// that visited the whole repo (6915 nodes) and emitted a multi-million-edge
+// summary, taking ~113s. These caps keep the compact BFS expansion + edge-carry
+// bounded so even a borderline-selective query returns in well under a second.
+// Selective queries are unaffected: real matches above min_score rarely touch
+// these ceilings, and the small-subgraph common case never does.
+const (
+	// findMaxVisibleNodes caps the total node set rendered in the compact path
+	// (seeds + BFS-expanded neighbours across all seeds).
+	findMaxVisibleNodes = 400
+	// findMaxBFSNodesPerSeed caps the per-seed visited set inside bfsBounded so a
+	// single high-degree hub can't fan out to thousands of nodes.
+	findMaxBFSNodesPerSeed = 200
+	// findMaxVisibleEdges caps the edge-summary computation (O(visited*out-deg)).
+	findMaxVisibleEdges = 1500
+)
+
+// noStrongMatchHint is surfaced when no entity cleared the min_score floor and
+// the result is only the always-1 fallback (#5289). Returned instead of a
+// whole-repo dump so the caller knows to retry rather than treating a
+// non-selective result as a real subgraph.
+const noStrongMatchHint = "no strong matches above min_score — the query terms don't match any entity names; try different/more specific terms, or use grafel_orient / grafel_topology to explore the repo"
 
 // serializeHits is the structured (full=true) shape.
 //


### PR DESCRIPTION
## The bug (measured live, idle daemon)

`grafel_find` query=\"main features screens dashboard inspection building\" on the mobile repo (RN app) → **elapsed_ms=112948 (~113s)**, every node **score=0.00**, **6915 nodes** \"matched\", edges-summary **~2.6M**. The terms match no entity names, so BM25 scores ~0 for everything — but instead of honoring the documented `min_score>=0.15` floor and returning few/none, it returned the WHOLE repo at score 0, then BFS-expanded (depth=3) + built a multi-million-edge summary over it.

## Root cause (`internal/mcp/tools.go` `handleQueryGraph`)

1. **score-0 leak** — the min_score cull (#1747) had a *"preserve at least one hit"* guard: when culling would empty the list it kept the **entire** sub-threshold candidate set. For a zero-selectivity query every candidate scored below 0.15, so the guard preserved up to `limit` near-zero (displayed `0.00`) hits per repo.
2. **unbounded work** — the compact path then BFS-expanded each of the top 10 seeds via `bfs()`, which calls `bfsBounded` with `maxNodes=0` (**cap disabled**). On a densely-connected repo a depth-3 BFS reaches ~the whole graph, and the subsequent `O(visited * out-degree)` edge-carry built the 2.6M-edge summary. Both unbounded.

## The fix

- **Enforce the floor honestly**: drop every hit below `min_score`, even if that empties the list. The scoped always-1 fallback (a *single* PageRank node) handles the empty case; the result is flagged `low_confidence` and returned **without** BFS expansion, with a hint to retry / use `grafel_orient` / `grafel_topology`. No "nothing matched → return all" fallback.
- **Bound the work**: `bfsBounded` now runs with a per-seed node cap (`findMaxBFSNodesPerSeed=200`), the total visible-node set is capped (`findMaxVisibleNodes=400`), and the edge-summary is capped (`findMaxVisibleEdges=1500`), each emitting a truncation note.
- **Selective queries unaffected**: real matches above the floor still return and BFS-expand their neighbourhood; the common small-subgraph case never touches the caps.

## Before / after (fixture)

Regression test runs the live repro query over a 6000-node densely-connected graph (depth-3 BFS reaches the whole graph):

| | nodes returned | elapsed |
|---|---|---|
| unbounded (bug) | whole repo (thousands) | ~113s live |
| fixed | **1** (low-confidence fallback) | **~0.4s** |

## Tests (`internal/mcp/find_zero_selectivity_5289_test.go`)

- `TestFind_ZeroSelectivity_NoWholeRepoDump_5289` — zero-selectivity query → ~1 node, ~0.4s, carries the low-confidence hint (not a whole-repo dump).
- `TestFind_MinScoreFloorEnforced_5289` — default `min_score` leaves ≤1 match + `low_confidence=true`.
- `TestFind_SelectiveQuery_StillExpands_5289` — selective query still returns its primary hit and expands neighbours, not flagged low-confidence.

`go build ./...`, `go vet ./internal/mcp/...`, `go test ./internal/mcp/... ./internal/graph/...` all green; `grafel selftest` → all 6 layers PASS.

Closes #5289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>