### PR TITLE
fix(uninstall): --purge also clears backups/ + empty .grafel root (preserve foreign content) (#5274)

### DIFF
--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -85,7 +85,9 @@ rebuilding it. Use --remove-binary to also delete the binary (with
 confirmation unless --yes).
 
 Default: leaves ~/.grafel/store/ (your graphs) intact.
-Use --purge to also remove store/ and docs/.
+Use --purge to also remove every grafel-created dir under ~/.grafel
+(store/, docs/, backups/, logs/, sockets/) and the ~/.grafel root
+itself when it is left empty (foreign content is preserved).
 
 Idempotent: if grafel is not installed the command exits 0.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -122,11 +124,11 @@ Idempotent: if grafel is not installed the command exits 0.`,
 				if result.StateRemoved {
 					fmt.Fprintln(out, "  install.json removed")
 				}
-				if result.StoreRemoved {
-					fmt.Fprintln(out, "  store/ removed")
+				for _, d := range result.PurgedDirs {
+					fmt.Fprintf(out, "  %s/ removed\n", d)
 				}
-				if result.DocsRemoved {
-					fmt.Fprintln(out, "  docs/ removed")
+				if result.RootRemoved {
+					fmt.Fprintln(out, "  ~/.grafel removed (empty)")
 				}
 				fmt.Fprintln(out, "✓ grafel uninstalled")
 				return nil
@@ -154,7 +156,7 @@ Idempotent: if grafel is not installed the command exits 0.`,
 	cmd.Flags().BoolVar(&skipSkillUnlink, "skip-skill-unlink", false,
 		"skip removing skills from Claude Code's skills/ directories")
 	cmd.Flags().BoolVar(&purge, "purge", false,
-		"also remove ~/.grafel/store/ and ~/.grafel/docs/ (user graphs and docs)")
+		"also remove all grafel dirs under ~/.grafel (store/, docs/, backups/, logs/, sockets/) + the empty root")
 	cmd.Flags().BoolVar(&removeBinary, "remove-binary", false,
 		"also delete the installed CLI binary (default: keep it so a reinstall/start needs no re-download)")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false,

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -12,7 +12,9 @@
 //     unless --yes).
 //  6. Remove ~/.grafel/install.json.
 //  7. Default: leave ~/.grafel/store/ intact.
-//     --purge: also remove ~/.grafel/store/ and ~/.grafel/docs/.
+//     --purge: also remove every grafel-created scratch dir under the prefix
+//     (store/, docs/, backups/, logs/, sockets/) and, if the ~/.grafel root is
+//     then empty, the root itself — foreign (non-grafel) content is preserved.
 //
 // All steps are idempotent: missing files are silently skipped.
 // If no install.json is found the command exits 0 (nothing to do).
@@ -37,8 +39,10 @@ type UninstallOptions struct {
 	// Defaults to DefaultStatePath().
 	StatePath string
 
-	// Purge, when true, also removes ~/.grafel/store/ and
-	// ~/.grafel/docs/ in addition to the install artifacts.
+	// Purge, when true, also removes every grafel-created scratch dir under
+	// the prefix (store/, docs/, backups/, logs/, sockets/) in addition to the
+	// install artifacts, and removes the ~/.grafel root itself when it is left
+	// empty (foreign content is preserved).
 	Purge bool
 
 	// RemoveBinary, when true, removes the installed CLI binary as part of
@@ -130,7 +134,24 @@ type UninstallResult struct {
 
 	// DocsRemoved is true when ~/.grafel/docs/ was removed (--purge only).
 	DocsRemoved bool
+
+	// PurgedDirs lists the grafel-created scratch subdirectories removed under
+	// the prefix during --purge (store/, docs/, backups/, logs/, sockets/).
+	PurgedDirs []string
+
+	// RootRemoved is true when the ~/.grafel root directory itself was removed
+	// after purge because it was left empty (no foreign content). It stays
+	// false when the root still held foreign (non-grafel) content, which is
+	// preserved (--purge only).
+	RootRemoved bool
 }
+
+// grafelScratchDirs are the subdirectories grafel creates under the install
+// prefix (~/.grafel). --purge removes all of these. Keep in sync with the
+// daemon/install paths: store/ + docs/ (graph + generated docs), backups/
+// (incl. backups/mcpreg/ config snapshots), logs/ (daemon logs), sockets/
+// (unix socket dir).
+var grafelScratchDirs = []string{"store", "docs", "backups", "logs", "sockets"}
 
 func (o *UninstallOptions) applyDefaults() error {
 	if o.StatePath == "" {
@@ -340,32 +361,56 @@ func RunUninstall(opts UninstallOptions) (*UninstallResult, error) {
 		}
 	}
 
-	// ── Step 6 (--purge): Remove store/ and docs/ ─────────────────────────────
+	// ── Step 6 (--purge): Remove grafel scratch dirs + empty root ─────────────
+	// --purge removes EVERY grafel-created subdirectory under the prefix —
+	// store/, docs/, backups/ (incl. the mcpreg config snapshots), logs/, and
+	// sockets/ — not just store/+docs/ (the leftover gap from #5274). It then
+	// attempts to remove the ~/.grafel root itself, but ONLY when it is empty:
+	// os.Remove (non-recursive) succeeds on an empty dir and fails on a
+	// non-empty one, so any FOREIGN content a user placed under the prefix is
+	// preserved. install.json/store/docs/backups/logs/sockets were each removed
+	// individually above, so an empty root means "grafel artifacts only".
 	if opts.Purge {
 		grafelDir := filepath.Dir(opts.StatePath)
 
-		storePath := filepath.Join(grafelDir, "store")
-		if opts.DryRun {
-			fmt.Fprintf(os.Stderr, "grafel uninstall --purge (dry-run): would remove %s\n", storePath)
-			result.StoreRemoved = true
-		} else {
-			if err := os.RemoveAll(storePath); err != nil {
-				fmt.Fprintf(os.Stderr, "grafel uninstall --purge: remove store: %v\n", err)
+		for _, name := range grafelScratchDirs {
+			p := filepath.Join(grafelDir, name)
+			if opts.DryRun {
+				fmt.Fprintf(os.Stderr, "grafel uninstall --purge (dry-run): would remove %s\n", p)
+				result.PurgedDirs = append(result.PurgedDirs, name)
+				continue
+			}
+			if err := os.RemoveAll(p); err != nil {
+				fmt.Fprintf(os.Stderr, "grafel uninstall --purge: remove %s: %v\n", p, err)
 			} else {
-				result.StoreRemoved = true
+				result.PurgedDirs = append(result.PurgedDirs, name)
 			}
 		}
 
-		docsPath := filepath.Join(grafelDir, "docs")
-		if opts.DryRun {
-			fmt.Fprintf(os.Stderr, "grafel uninstall --purge (dry-run): would remove %s\n", docsPath)
-			result.DocsRemoved = true
-		} else {
-			if err := os.RemoveAll(docsPath); err != nil {
-				fmt.Fprintf(os.Stderr, "grafel uninstall --purge: remove docs: %v\n", err)
-			} else {
+		// Back-compat: keep the existing StoreRemoved/DocsRemoved flags.
+		for _, name := range result.PurgedDirs {
+			switch name {
+			case "store":
+				result.StoreRemoved = true
+			case "docs":
 				result.DocsRemoved = true
 			}
+		}
+
+		// Attempt to remove the now-(hopefully-)empty root. Non-recursive
+		// os.Remove only succeeds when the directory is empty — foreign content
+		// keeps the root in place and is left untouched.
+		if opts.DryRun {
+			fmt.Fprintf(os.Stderr, "grafel uninstall --purge (dry-run): would remove %s if empty\n", grafelDir)
+			result.RootRemoved = true
+		} else if err := os.Remove(grafelDir); err != nil {
+			if !os.IsNotExist(err) {
+				// ENOTEMPTY (foreign content) or other error: keep the root.
+				opts.warnFn(fmt.Sprintf(
+					"--purge: kept %s (not empty — preserving non-grafel content)", grafelDir))
+			}
+		} else {
+			result.RootRemoved = true
 		}
 	}
 

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -136,18 +136,28 @@ func TestRunUninstall_Purge(t *testing.T) {
 		t.Fatalf("RunCopy: %v", err)
 	}
 
-	// Create fake store/ and docs/ directories.
+	// Create every grafel-created scratch dir under the prefix, each with a
+	// sentinel file so we can confirm full recursive removal.
 	grafelDir := filepath.Dir(env.statePath)
-	storePath := filepath.Join(grafelDir, "store")
-	docsPath := filepath.Join(grafelDir, "docs")
-	for _, p := range []string{storePath, docsPath} {
+	scratch := []string{"store", "docs", "backups", "logs", "sockets"}
+	paths := map[string]string{}
+	for _, name := range scratch {
+		p := filepath.Join(grafelDir, name)
+		paths[name] = p
 		if err := os.MkdirAll(p, 0o755); err != nil {
 			t.Fatalf("create %s: %v", p, err)
 		}
-		// Put a sentinel file inside to confirm removal.
 		if err := os.WriteFile(filepath.Join(p, "sentinel"), []byte("data"), 0o644); err != nil {
 			t.Fatalf("write sentinel in %s: %v", p, err)
 		}
+	}
+	// backups/mcpreg/*.json snapshot, the specific leftover from #5274.
+	mcpregDir := filepath.Join(paths["backups"], "mcpreg")
+	if err := os.MkdirAll(mcpregDir, 0o755); err != nil {
+		t.Fatalf("create mcpreg dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mcpregDir, "snap.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write mcpreg snapshot: %v", err)
 	}
 
 	result, err := install.RunUninstall(install.UninstallOptions{
@@ -166,11 +176,74 @@ func TestRunUninstall_Purge(t *testing.T) {
 	if !result.DocsRemoved {
 		t.Error("DocsRemoved should be true with --purge")
 	}
+	for _, name := range scratch {
+		if _, err := os.Stat(paths[name]); err == nil {
+			t.Errorf("%s/ still exists after --purge", name)
+		}
+	}
+	if len(result.PurgedDirs) != len(scratch) {
+		t.Errorf("PurgedDirs = %v, want all of %v", result.PurgedDirs, scratch)
+	}
+	// The root contained only grafel artifacts → it must be removed.
+	if !result.RootRemoved {
+		t.Error("RootRemoved should be true when .grafel root is left empty")
+	}
+	if _, err := os.Stat(grafelDir); err == nil {
+		t.Error(".grafel root still exists after --purge of an empty root")
+	}
+}
+
+// TestRunUninstall_PurgePreservesForeignRoot verifies that --purge removes the
+// grafel scratch dirs but preserves the ~/.grafel root (and the foreign file)
+// when a non-grafel file is present in the prefix (#5274 safety).
+func TestRunUninstall_PurgePreservesForeignRoot(t *testing.T) {
+	env := newTestEnv(t)
+
+	if _, err := install.RunCopy(install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	}); err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+
+	grafelDir := filepath.Dir(env.statePath)
+	storePath := filepath.Join(grafelDir, "store")
+	if err := os.MkdirAll(storePath, 0o755); err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	// A foreign file the user dropped into ~/.grafel — must be preserved.
+	foreign := filepath.Join(grafelDir, "user-notes.txt")
+	if err := os.WriteFile(foreign, []byte("mine"), 0o644); err != nil {
+		t.Fatalf("write foreign file: %v", err)
+	}
+
+	result, err := install.RunUninstall(install.UninstallOptions{
+		StatePath:      env.statePath,
+		Purge:          true,
+		Yes:            true,
+		SkipDaemonStop: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUninstall --purge: %v", err)
+	}
+
+	// Grafel scratch dir gone …
 	if _, err := os.Stat(storePath); err == nil {
 		t.Error("store/ still exists after --purge")
 	}
-	if _, err := os.Stat(docsPath); err == nil {
-		t.Error("docs/ still exists after --purge")
+	// … but the root and the foreign file are preserved.
+	if result.RootRemoved {
+		t.Error("RootRemoved should be false when foreign content is present")
+	}
+	if _, err := os.Stat(grafelDir); err != nil {
+		t.Errorf(".grafel root should be preserved with foreign content: %v", err)
+	}
+	if data, err := os.ReadFile(foreign); err != nil || string(data) != "mine" {
+		t.Errorf("foreign file should be preserved intact: data=%q err=%v", data, err)
 	}
 }
 


### PR DESCRIPTION
## The gap (audit finding 4b)

After `grafel uninstall --yes --purge --remove-binary`, leftovers remained under `~/.grafel/`:
- `backups/` (incl. the mcpreg `*.json` config snapshots)
- empty `logs/` (and `backups/`)
- the `.grafel` root dir itself

`--purge` previously only removed `store/` + `docs/`.

## Fix

`--purge` now removes **every** grafel-created scratch dir under the prefix: `store/`, `docs/`, `backups/` (incl. `backups/mcpreg/`), `logs/`, and `sockets/`.

It then attempts to remove the `~/.grafel` root **only via a non-recursive `os.Remove`** — which succeeds on an empty dir and fails (ENOTEMPTY) on a non-empty one. So:
- empty root (grafel artifacts only) → root removed
- FOREIGN (non-grafel) content present → root **kept**, foreign content preserved, warning logged

There is never an unconditional `os.RemoveAll` of the whole prefix. `--purge` stays opt-in (no behavior change without the flag) and idempotent.

`UninstallResult` gains `PurgedDirs` + `RootRemoved`; CLI help text and the uninstall summary are updated.

## Validation
- `go build ./...`, `go vet ./internal/install/... ./internal/cli/...` — pass
- `go test ./internal/install/...` — green (incl. new `TestRunUninstall_Purge` full-clear + empty-root-removed, and `TestRunUninstall_PurgePreservesForeignRoot` foreign-file-kept safety)
- `grafel selftest` — all 6 layers PASS (teardown removes the isolated root, no leftover socket)

Closes #5274

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>