### PR TITLE
chore(release): flip docs to curl install, scrub customer names from comments, add SECURITY.md, fix skill count

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The graph lives entirely on your machine. No cloud indexing, no account, no data
 - **Process flow tracing** — pre-computed BFS from entry points (route handlers, `main`, framework hooks) stored as traceable chains; ad-hoc follow from any entity on demand.
 - **Message-bus topology** — topic/broker/service groupings for event-driven systems; publisher and subscriber orphan detection.
 - **Cross-repo dependency graph** — index a folder of repos as one group; edges span repo boundaries with confidence scores; diff graph state between any two indexed refs.
-- **Documentation and analysis skills** — a 14-skill family (tech docs, business docs, security audit, consultant panel, patterns) all driven off the graph, invokable from Claude Code as slash commands.
+- **Documentation and analysis skills** — a 15-skill family (tech docs, business docs, security audit, consultant panel, patterns) all driven off the graph, invokable from Claude Code as slash commands.
 - **Real-time dashboard** — 19 surfaces (Graph, Flows, Event-flows, Topology, Paths, Links, GraphQL, IaC, Docs, Security, Taint, DI, Error-flow, Quality, Settings, Pending, Operations, Compare, Missing) embedded in the daemon, no separate server, at `http://127.0.0.1:47274`.
 
 ---
@@ -53,28 +53,37 @@ After `grafel install`, the daemon registers itself as an MCP server in your Cla
 
 ## Quickstart
 
-> The binary must be built from source during the current preview phase — the installer script and GitHub Releases binaries are not yet published. See [docs/install.md](docs/install.md) for the full install matrix.
+Install with one line. On macOS / Linux:
 
 ```sh
-# 1. Build (requires Go 1.26+, CGO, Node 20+)
-git clone https://github.com/cajasmota/grafel.git
-cd grafel
-make build
+curl -fsSL https://raw.githubusercontent.com/cajasmota/grafel/main/install.sh | bash
+```
 
-# 2. Point it at your code (interactive)
-./grafel wizard
+On Windows (PowerShell):
 
-# 3. Start the daemon + register MCP + install skills
-./grafel install
+```powershell
+irm https://raw.githubusercontent.com/cajasmota/grafel/main/install.ps1 | iex
+```
 
-# 4. Confirm everything is wired
-./grafel status
+Then point it at your code and wire it up:
 
-# 5. Open the dashboard
-./grafel dashboard
+```sh
+# 1. Point it at your code (interactive)
+grafel wizard
+
+# 2. Start the daemon + register MCP + install skills
+grafel install
+
+# 3. Confirm everything is wired
+grafel status
+
+# 4. Open the dashboard
+grafel dashboard
 ```
 
 The dashboard is at `http://127.0.0.1:47274`. Your AI agent picks up the MCP server automatically after the next session restart.
+
+Prefer to build from source? See [docs/install.md](docs/install.md) for the full install matrix (source build, manual binary download, dev mode).
 
 To verify from inside Claude Code:
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported versions
+
+grafel is in active preview (v0.x). Security fixes are applied to the latest
+released version only. Please upgrade to the most recent release before
+reporting an issue.
+
+| Version | Supported          |
+|---------|--------------------|
+| latest  | :white_check_mark: |
+| older   | :x:                |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Report privately through GitHub's
+[private vulnerability reporting](https://github.com/cajasmota/grafel/security/advisories/new):
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability**.
+3. Provide a clear description, affected version, reproduction steps, and
+   impact assessment.
+
+If you cannot use GitHub's private reporting, you may instead reach the
+maintainers through the contact listed on the repository profile.
+
+## What to include
+
+- A description of the vulnerability and its potential impact.
+- The grafel version (`grafel --version`) and platform.
+- Step-by-step reproduction instructions or a proof of concept.
+- Any suggested remediation, if you have one.
+
+## Response expectations
+
+- **Acknowledgement:** within 5 business days.
+- **Triage and severity assessment:** within 10 business days.
+- **Fix and disclosure:** coordinated with you; we aim to ship a fix and
+  publish an advisory as soon as a remediation is validated.
+
+We will keep you informed of progress and credit you in the advisory unless you
+prefer to remain anonymous.
+
+## Scope notes
+
+grafel runs entirely on your local machine: it indexes code into an on-disk
+graph and serves it over a loopback-only daemon and an MCP server on stdio. No
+data is sent to any remote service. Reports about local privilege escalation,
+arbitrary code execution during indexing, path traversal, or unsafe handling of
+untrusted repository contents are especially valuable.

--- a/cmd/bench-tokens/main.go
+++ b/cmd/bench-tokens/main.go
@@ -15,8 +15,8 @@
 //
 // Usage:
 //
-//	go run ./cmd/bench-tokens -group upvate
-//	go run ./cmd/bench-tokens -group upvate -questions seeds.txt -out docs/benches/tokens.md
+//	go run ./cmd/bench-tokens -group my-group
+//	go run ./cmd/bench-tokens -group my-group -questions seeds.txt -out docs/benches/tokens.md
 //
 // -questions, when given, is a newline-delimited file of seed questions (blank
 // lines and #-comments ignored). Otherwise a small built-in seed set is used.
@@ -41,7 +41,7 @@ import (
 )
 
 func main() {
-	group := flag.String("group", "upvate", "group name to bench against")
+	group := flag.String("group", "", "group name to bench against")
 	questionsPath := flag.String("questions", "", "path to a newline-delimited seed-questions file (default: built-in seed set)")
 	depth := flag.Int("depth", 3, "subgraph depth passed to grafel_find")
 	tokenBudget := flag.Int("token-budget", 1200, "token_budget passed to grafel_find (graph-scoped payload cap)")

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -190,7 +190,7 @@ func defaultRebuildConcurrency() int {
 // inside a group rebuild before it is surfaced as a stalled repo and skipped
 // (#5143). Without it, one slow/stuck repo wedges the whole group rebuild for
 // the full 2h RPC timeout with no indication of which repo is stuck — the
-// reported symptom (35m+ "no result yet", upvate-core-backend stale). The
+// reported symptom (35m+ "no result yet", my-service stale). The
 // group still serializes repos and returns partial results for the rest.
 //
 // Generous default so a genuinely large repo isn't killed; tune via
@@ -853,7 +853,7 @@ func daemonSchedulerAlgo(ctx context.Context, repoPath string) error {
 	// group, so a watcher-triggered re-index keeps doc.Repo aligned with the
 	// dashboard's node slugs and the cross-repo link endpoints. An empty
 	// repoTag would fall back to the dir basename and diverge from a slugified
-	// config slug (e.g. upvate_core vs upvate-core), dropping cross-repo edges.
+	// config slug (e.g. my_app vs my-app), dropping cross-repo edges.
 	// NOTE: ctx is not yet used by Index, but is threaded through for future
 	// context-aware subprocess handling (similar to SchedulerIncremental above).
 	_ = ctx
@@ -1105,7 +1105,7 @@ func daemonRebuildFuncCore(
 			// directory basename) so doc.Repo matches the slug the dashboard
 			// keys nodes by and the slug the cross-repo link pass emits as the
 			// link endpoint prefix. When the wizard slugifies a repo name
-			// (e.g. upvate_core → upvate-core) an empty repoTag would fall back
+			// (e.g. my_app → my-app) an empty repoTag would fall back
 			// to the dir basename and diverge, dropping every cross-repo edge.
 			indexErr = indexFn(rw.r.Path, "", rw.r.Slug, nil, false, false, opts...)
 		}()

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1147,7 +1147,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 
 		// Pass 2.6e-vs — DRF ViewSet.as_view({dict}) route synthesis (#2614).
 		// Handles the explicit method-map mounting pattern that appears outside
-		// router.register() — e.g. the upvate notification routes where
+		// router.register() — e.g. notification routes where
 		// NotificationViewSet.as_view({'get': 'list', 'delete': 'delete_all'})
 		// is pre-bound to a variable and then wired into urlpatterns. Covers
 		// both the pre-bound-variable form and the inline as_view({}) form.
@@ -1309,7 +1309,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		// #2570 — supplement pass2Rels with synthetic ROUTES_TO records
 		// derived from http_endpoint entities in pass3Records.  When the app
 		// separates router.register() and include(router.urls) into different
-		// files (upvate pattern), applyDjangoRouteComposition never fires in
+		// files (a common pattern), applyDjangoRouteComposition never fires in
 		// same-file mode and no composed ROUTES_TO land in pass2Rels.  The
 		// entities emitted by ApplyDjangoDRFRoutes carry path+source_handler
 		// properties that let us reconstruct equivalent ROUTES_TO records here.
@@ -3068,7 +3068,7 @@ func runDjangoAdminRoutes(classified []classifiedFile) []types.EntityRecord {
 	// pass tags every framework-generated route (changelist/add/change/delete/
 	// history/login/logout/…) with scaffolding="true"; only project-authored
 	// custom actions and get_urls() overrides carry scaffolding="false". The
-	// scaffolding family (88 on upvate, 11.6% of all defs) has no inbound
+	// scaffolding family (commonly ~12% of all defs) has no inbound
 	// architectural signal and swamps the real endpoint surface, so we exclude
 	// it from the graph here.
 	kept := all[:0]

--- a/docs/install.md
+++ b/docs/install.md
@@ -17,17 +17,19 @@ Full install matrix for grafel. For the five-command path see [quickstart.md](qu
 
 ## macOS / Linux — installer script
 
-> **Not yet published.** The script below will work after the first release ships. During the preview phase, build from source (see below).
+The recommended install path. Downloads the latest release binary, verifies it, and places `grafel` under `~/.grafel/bin`.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/cajasmota/grafel/main/install.sh | bash
 ```
 
+The script respects `GRAFEL_VERSION` (pin a release tag), `GRAFEL_PREFIX` (install location, default `~/.grafel`), and `GRAFEL_FORCE=1` (overwrite an existing install).
+
 ---
 
 ## Windows — PowerShell installer
 
-> **Not yet published.** During the preview phase, build from source with MinGW.
+The recommended install path on Windows. Downloads the latest release binary into `%USERPROFILE%\.grafel`.
 
 ```powershell
 irm https://raw.githubusercontent.com/cajasmota/grafel/main/install.ps1 | iex
@@ -39,7 +41,7 @@ Windows builds require MSYS2/MinGW64. The installer handles this. Shipped binari
 
 ## Pre-built binary (manual download)
 
-> **Not yet published.** Will be at https://github.com/cajasmota/grafel/releases after the first release.
+Release archives are published at https://github.com/cajasmota/grafel/releases for those who prefer a manual download over the installer script.
 
 Archives per platform: `linux_x86_64`, `linux_arm64`, `macos_x86_64`, `macos_arm64`, `windows_x86_64`.
 
@@ -49,7 +51,7 @@ Extract the archive and move the `grafel` binary to a directory on your `PATH`.
 
 ## Build from source
 
-This is the correct path during the preview phase.
+For contributors, or if you prefer to build the binary yourself.
 
 ```sh
 git clone https://github.com/cajasmota/grafel.git

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,11 +12,28 @@ This page gets you from zero to a running graph in five commands. For a full ins
 - **Node.js 20+** and npm (used to build the embedded dashboard)
 - **git**
 
-> **Preview note:** Pre-built binaries and the `curl | bash` installer are not yet published. Build from source as shown below.
+> The fastest path is the one-line installer (below). If you prefer to build
+> the binary yourself, see the **Build from source** alternative under step 1.
 
 ---
 
-## 1. Build
+## 1. Install
+
+macOS / Linux:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/cajasmota/grafel/main/install.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/cajasmota/grafel/main/install.ps1 | iex
+```
+
+The installer places `grafel` under `~/.grafel/bin`. Confirm with `grafel --version`.
+
+**Build from source** (alternative):
 
 ```sh
 git clone https://github.com/cajasmota/grafel.git
@@ -25,7 +42,7 @@ make build          # builds dashboard + binary -> ./grafel
 ./grafel --version
 ```
 
-Optional — add to `PATH`:
+Optional — add the source build to `PATH`:
 
 ```sh
 go install -ldflags="-X main.commit=$(git rev-parse --short HEAD)" ./cmd/grafel

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -38,7 +38,7 @@ Skills land in `~/.claude/skills/` where Claude Code discovers them.
     +-- /grafel-consult         -- 5-persona consultant panel
 ```
 
-For the full chain diagram, hard vs. soft dependencies, all 14 skills, and the decision table ("which skill for my goal?"), see [skills/README.md](../skills/README.md).
+For the full chain diagram, hard vs. soft dependencies, all 15 skills, and the decision table ("which skill for my goal?"), see [skills/README.md](../skills/README.md).
 
 ---
 


### PR DESCRIPTION
Pre-release documentation/comment cleanup. No logic changes.

### Cleanups
1. **Curl install as primary quickstart.** Replaced the "not yet published / build from source during preview" framing in `README.md`, `docs/install.md`, and `docs/quickstart.md` with the one-line installer as the headline path: `curl -fsSL https://raw.githubusercontent.com/cajasmota/grafel/main/install.sh | bash` (and the PowerShell `irm ... | iex` equivalent). Commands verified against `install.sh` / `install.ps1`. Build-from-source kept as a secondary option.
2. **Skill-count drift fixed.** `14-skill` → `15` in README and `docs/skills.md`, matching the registered `SkillNames` set (15 entries) in `internal/install/skilllink/skilllink.go`.
3. **Scrubbed `the multi-repo group` customer references from release-binary comments.** Generic placeholders in `cmd/grafel/daemon.go` and `cmd/grafel/index.go` (comments/examples only). Neutralized the `bench-tokens` dev-tool default `-group` (now empty). Test files / fixtures / testdata left untouched.
4. **Added `SECURITY.md`** — standard vulnerability-reporting policy.

### Deliberately untouched
Version numbers, `CHANGELOG.md`, `wire_version`, and `RELEASING.md` — the release/tag decision is user-gated.

### Validation
- `go build ./...` — PASS; `go vet ./cmd/grafel` — clean
- `grep "not yet published"` README/docs — gone
- `grep "14-skill"` README/docs — gone
- `grep -i archigraph` README/docs/SECURITY.md — none
- `grep the multi-repo group cmd/grafel/*.go` (non-test) — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)