### PR TITLE
fix(install): gate install readiness on RPC socket, not full-index /healthz (#5293)

### DIFF
--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -10,7 +10,7 @@
 //  1. CLI binary identification (SHA-256 of the running binary).
 //  2. Skills copy: copy skills/<name>/ → ~/.claude/skills/<name>/ (no symlinks).
 //  3. MCP registration: write grafel entry into all detected .claude.json files.
-//  4. Daemon restart: graceful stop + start, wait for /healthz.
+//  4. Daemon restart: graceful stop + start, wait for the RPC socket (#5293).
 //  5. .gitignore integration: append /.grafel/ if inside a git repo.
 //  6. Persist ~/.grafel/install.json.
 //
@@ -26,17 +26,87 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	dclient "github.com/cajasmota/grafel/internal/daemon/client"
 	"github.com/cajasmota/grafel/internal/daemon/service"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/skilllink"
 )
 
+// defaultInstallHealthTimeout is the wait budget for step-4 daemon readiness.
+// A fresh daemon cold-indexes registered groups before its dashboard /healthz
+// endpoint returns 200; on a real codebase that can take well over the old
+// hard-coded 10s. We therefore gate step-4 success on the RPC SOCKET coming up
+// (the daemon accepts connections as soon as it serves, independent of the
+// cold index) and use a generous, overridable budget for the socket to appear.
+// Mirrors the selftest readiness fix (#5264) and the #5293 install repro.
+const defaultInstallHealthTimeout = 60 * time.Second
+
+// installHealthTimeout resolves the step-4 readiness budget. Overridable via
+// GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC so operators can extend it on very large
+// repos. The caller passes the configured timeout in; a zero/negative value
+// falls back to the default.
+func installHealthTimeout(configured time.Duration) time.Duration {
+	if v := os.Getenv("GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	if configured > 0 {
+		return configured
+	}
+	return defaultInstallHealthTimeout
+}
+
+// socketPingFunc probes the daemon's RPC socket and returns the reported
+// version. It succeeds as soon as the daemon accepts connections — BEFORE the
+// initial cold index completes. Injectable so tests need no real daemon.
+type socketPingFunc func(socketPath string) (version string, err error)
+
+// healthzGetFunc fetches the dashboard /healthz body. It is best-effort only —
+// readiness is gated on the socket, not on /healthz — so its failure (e.g.
+// because the dashboard is still cold-indexing) does NOT fail the install.
+type healthzGetFunc func(port int) (body string, err error)
+
+// defaultSocketPing is the production RPC-socket probe: Dial + Ping, the exact
+// liveness probe `grafel status` and selftest use.
+func defaultSocketPing(socketPath string) (string, error) {
+	c, err := dclient.DialPath(socketPath)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = c.Close() }()
+	reply, err := c.Ping()
+	if err != nil {
+		return "", err
+	}
+	return reply.Version, nil
+}
+
+// defaultHealthzGet is the production best-effort dashboard /healthz fetch.
+func defaultHealthzGet(port int) (string, error) {
+	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", port)
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("/healthz returned HTTP %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return string(body), nil
+}
+
 // defaultDaemonRestart is the production daemon restart implementation.
-// It calls service.Install (registers/starts the OS service) and then
-// polls /healthz to confirm the daemon is up.
+// It calls service.Install (registers/starts the OS service) and then waits
+// for the daemon to be genuinely up — gating on the RPC SOCKET (Ping), not the
+// dashboard /healthz (which lags behind the initial cold index, the #5293 bug).
 func defaultDaemonRestart(binPath string, port int, timeout time.Duration) (string, error) {
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
@@ -52,7 +122,7 @@ func defaultDaemonRestart(binPath string, port int, timeout time.Duration) (stri
 	if _, err := service.Install(svcOpts); err != nil {
 		return "", fmt.Errorf("service install: %w", err)
 	}
-	return waitForHealthz(port, timeout)
+	return waitForDaemonReady(layout.SocketPath, port, installHealthTimeout(timeout), defaultSocketPing, defaultHealthzGet)
 }
 
 // DaemonRestartFunc is the injectable function for step 4 (daemon restart).
@@ -88,8 +158,11 @@ type CopyOptions struct {
 	// DryRun logs every action without writing anything.
 	DryRun bool
 
-	// HealthzTimeout is the maximum wait time for the daemon to become healthy
-	// after restart.  Defaults to 10 seconds.
+	// HealthzTimeout is the maximum wait time for the daemon to become ready
+	// (its RPC socket answering Ping) after restart. Defaults to
+	// defaultInstallHealthTimeout (60s); GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC
+	// overrides it. Readiness is gated on the socket, NOT on the dashboard
+	// /healthz, which lags behind the initial cold index (#5293).
 	HealthzTimeout time.Duration
 
 	// DaemonPort is the HTTP port where the daemon's /healthz endpoint lives.
@@ -417,7 +490,11 @@ func (o *CopyOptions) applyDefaults() error {
 		o.WorkingDir = cwd
 	}
 	if o.HealthzTimeout == 0 {
-		o.HealthzTimeout = 10 * time.Second
+		// Generous default: step-4 readiness gates on the RPC socket (not the
+		// cold-index-bound /healthz), but the socket itself can take a while to
+		// appear on a slow cold start. Overridable via
+		// GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC (see installHealthTimeout). (#5293)
+		o.HealthzTimeout = defaultInstallHealthTimeout
 	}
 	if o.DaemonPort == 0 {
 		o.DaemonPort = 47274
@@ -631,29 +708,42 @@ func copyFile(src, dst string) error {
 	return err
 }
 
-// waitForHealthz polls http://127.0.0.1:<port>/healthz until it returns a
-// 200 or the timeout elapses. Returns the response body (daemon version string)
-// on success.
-func waitForHealthz(port int, timeout time.Duration) (string, error) {
-	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", port)
+// waitForDaemonReady waits until the daemon is genuinely up. Readiness is
+// gated on the RPC SOCKET (Ping) — which the daemon serves as soon as it
+// accepts connections, BEFORE the initial cold index finishes — rather than on
+// the dashboard /healthz, which is gated on that cold index and can take far
+// longer than 10s on a real codebase (the #5293 bug: install reported failure
+// even though the daemon was up and indexing fine).
+//
+// Once the socket answers, install SUCCEEDS. Initial indexing continues async;
+// we print a note to that effect. The /healthz body is fetched best-effort
+// purely to enrich the recorded version string — its failure never fails the
+// install.
+//
+// If the socket never answers within the timeout, the daemon genuinely did not
+// start and we return the helpful error (so install still fails honestly when
+// the daemon is actually down).
+func waitForDaemonReady(socketPath string, port int, timeout time.Duration, ping socketPingFunc, healthz healthzGetFunc) (string, error) {
 	deadline := time.Now().Add(timeout)
 	const pollInterval = 300 * time.Millisecond
 
-	client := &http.Client{Timeout: 2 * time.Second}
-
 	for time.Now().Before(deadline) {
-		resp, err := client.Get(url)
-		if err == nil && resp.StatusCode == http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
-			return string(body), nil
-		}
-		if resp != nil {
-			_ = resp.Body.Close()
+		version, err := ping(socketPath)
+		if err == nil {
+			// Socket is up — the daemon is serving. Try /healthz best-effort to
+			// enrich the version string, but do NOT block on it (it lags behind
+			// the cold index).
+			if healthz != nil {
+				if body, herr := healthz(port); herr == nil && strings.TrimSpace(body) != "" {
+					version = strings.TrimSpace(body)
+				}
+			}
+			fmt.Fprintln(os.Stderr, "grafel install: daemon started; initial indexing in progress (continues in the background)")
+			return version, nil
 		}
 		time.Sleep(pollInterval)
 	}
-	return "", fmt.Errorf("daemon did not respond on %s within %s; run 'grafel start' and retry", url, timeout)
+	return "", fmt.Errorf("daemon did not respond on its socket %s within %s; run 'grafel start' and retry", socketPath, timeout)
 }
 
 // ── rollback helpers ──────────────────────────────────────────────────────────

--- a/internal/install/readiness_test.go
+++ b/internal/install/readiness_test.go
@@ -1,0 +1,109 @@
+package install
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestWaitForDaemonReady_SocketUpHealthzSlow simulates the #5293 repro: the
+// daemon's RPC socket comes up quickly but its dashboard /healthz (gated on the
+// initial cold index) is still slow / failing. Readiness must SUCCEED on the
+// socket within budget — not falsely fail like the old /healthz-gated wait.
+func TestWaitForDaemonReady_SocketUpHealthzSlow(t *testing.T) {
+	var pings int32
+	ping := func(socketPath string) (string, error) {
+		// Socket answers immediately (daemon is serving) and reports a version,
+		// even though it is still cold-indexing.
+		atomic.AddInt32(&pings, 1)
+		return "1.2.3-socket", nil
+	}
+	// /healthz never returns 200 (still cold-indexing) — must NOT fail install.
+	healthz := func(port int) (string, error) {
+		return "", fmt.Errorf("dashboard still cold-indexing (HTTP 503)")
+	}
+
+	version, err := waitForDaemonReady("/tmp/fake.sock", 47274, 2*time.Second, ping, healthz)
+	if err != nil {
+		t.Fatalf("expected readiness to succeed on the socket, got error: %v", err)
+	}
+	if version != "1.2.3-socket" {
+		t.Errorf("expected version from socket Ping, got %q", version)
+	}
+	if atomic.LoadInt32(&pings) == 0 {
+		t.Error("expected the socket Ping probe to be used")
+	}
+}
+
+// TestWaitForDaemonReady_HealthzEnrichesVersion verifies that when /healthz IS
+// available it enriches the version string, but readiness is still primarily
+// gated on the socket.
+func TestWaitForDaemonReady_HealthzEnrichesVersion(t *testing.T) {
+	ping := func(socketPath string) (string, error) { return "socket-ver", nil }
+	healthz := func(port int) (string, error) { return "  healthz-ver  ", nil }
+
+	version, err := waitForDaemonReady("/tmp/fake.sock", 47274, 2*time.Second, ping, healthz)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "healthz-ver" {
+		t.Errorf("expected /healthz body to enrich version, got %q", version)
+	}
+}
+
+// TestWaitForDaemonReady_SocketEventuallyUp verifies the probe keeps polling
+// until the socket comes up (slow cold start) and then succeeds.
+func TestWaitForDaemonReady_SocketEventuallyUp(t *testing.T) {
+	var calls int32
+	ping := func(socketPath string) (string, error) {
+		if atomic.AddInt32(&calls, 1) < 3 {
+			return "", fmt.Errorf("daemon not running yet")
+		}
+		return "late-ver", nil
+	}
+
+	version, err := waitForDaemonReady("/tmp/fake.sock", 47274, 5*time.Second, ping, nil)
+	if err != nil {
+		t.Fatalf("expected eventual success, got: %v", err)
+	}
+	if version != "late-ver" {
+		t.Errorf("expected late-ver, got %q", version)
+	}
+}
+
+// TestWaitForDaemonReady_DaemonNeverStarts verifies the check still FAILS
+// honestly (with the helpful message) when the socket never answers — install
+// must not be weakened into a no-op.
+func TestWaitForDaemonReady_DaemonNeverStarts(t *testing.T) {
+	ping := func(socketPath string) (string, error) {
+		return "", fmt.Errorf("connection refused")
+	}
+
+	_, err := waitForDaemonReady("/tmp/never.sock", 47274, 500*time.Millisecond, ping, nil)
+	if err == nil {
+		t.Fatal("expected readiness to FAIL when the daemon never starts, but it succeeded")
+	}
+	if !contains(err.Error(), "did not respond on its socket") {
+		t.Errorf("expected helpful socket error, got: %v", err)
+	}
+	if !contains(err.Error(), "grafel start") {
+		t.Errorf("expected retry hint in error, got: %v", err)
+	}
+}
+
+// TestInstallHealthTimeout_EnvOverride verifies the configurable budget.
+func TestInstallHealthTimeout_EnvOverride(t *testing.T) {
+	t.Setenv("GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC", "120")
+	if got := installHealthTimeout(10 * time.Second); got != 120*time.Second {
+		t.Errorf("env override: want 120s, got %s", got)
+	}
+
+	t.Setenv("GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC", "")
+	if got := installHealthTimeout(0); got != defaultInstallHealthTimeout {
+		t.Errorf("zero configured: want default %s, got %s", defaultInstallHealthTimeout, got)
+	}
+	if got := installHealthTimeout(15 * time.Second); got != 15*time.Second {
+		t.Errorf("configured passthrough: want 15s, got %s", got)
+	}
+}


### PR DESCRIPTION
## The live step-4 repro

`grafel install --copy` fails at:

```
✗ install (copy mode) failed: step 4 – daemon restart:
  daemon did not respond on http://127.0.0.1:47274/healthz within 10s
```

…even though the daemon **is** up and finishes indexing fine. Install then reports failure and rolls back / leaves MCP unregistered.

## Root cause

Step 4 polled the dashboard `/healthz` endpoint, which only returns 200 **after** the freshly-started daemon finishes its initial **cold index** of the registered groups. On a real codebase that cold index exceeds the hard-coded **10s** step-4 wait, so install times out and reports failure — a false negative. CI's fixture is tiny so it never triggers.

## The fix (mirrors selftest #5264)

Gate step-4 success on the daemon's **RPC socket** (Dial + Ping) — the exact liveness probe `grafel status` and selftest use. The socket is served as soon as the daemon accepts connections, **independent of cold-index completion**.

- Dashboard `/healthz` is now fetched **best-effort only**, purely to enrich the recorded version string; its failure never fails the install.
- Initial indexing continues async; we print `daemon started; initial indexing in progress`.
- Budget is generous (**60s** default) and overridable via `GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC`.

The check is **not** weakened to a no-op: install still requires the daemon to answer Ping on its socket, and still **fails** with the helpful `did not respond on its socket ... run 'grafel start' and retry` message when the daemon genuinely never starts.

## Tests

`internal/install/readiness_test.go` (injectable probes — no real daemon/launchctl spawned):
- socket-up-but-`/healthz`-slow → readiness **succeeds** within budget (the bug)
- `/healthz` enriches the version when present
- slow-cold-start socket eventually succeeds
- daemon-never-starts → still **fails** with the helpful message
- `GRAFEL_INSTALL_HEALTH_TIMEOUT_SEC` override

`go build ./...`, `go vet ./internal/install/...`, `go test ./internal/install/...` green; `grafel selftest` all 6 layers PASS.

Closes #5293

🤖 Generated with [Claude Code](https://claude.com/claude-code)