### PR TITLE
fix(engine): green TestDRFGetPermissionsPageKey (DRF default action url_path is verbatim snake_case) (#5298)

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -13,13 +13,13 @@
 // Plus, every `@action(detail=True|False, methods=[...], url_path="...")`
 // decorated method on the ViewSet class adds another endpoint:
 //
-//	detail=True:  /<prefix>/{pk}/<url_path or hyphenated-method-name>/
-//	detail=False: /<prefix>/<url_path or hyphenated-method-name>/
+//	detail=True:  /<prefix>/{pk}/<url_path or verbatim-method-name>/
+//	detail=False: /<prefix>/<url_path or verbatim-method-name>/
 //
-// When no `url_path=` is given DRF derives the segment from the method name
-// with `_`→`-` (`do_thing` → `do-thing`); an explicit `url_path` is used
-// verbatim including embedded `(?P<name>regex)` capture groups, which the
-// canonicaliser rewrites to `{name}` path params (#5230).
+// When no `url_path=` is given DRF uses the method name VERBATIM as the segment
+// (underscores preserved: `do_thing` → `do_thing`); an explicit `url_path` is
+// used verbatim including embedded `(?P<name>regex)` capture groups, which the
+// canonicaliser rewrites to `{name}` path params (#5230 / #5298).
 //
 // The base `ApplyDjangoNestedURLConf` pass only emits ONE endpoint per
 // `router.register(...)` call (the list/create root). This pass is the
@@ -1337,13 +1337,16 @@ func emitActionRoutes(
 		} else {
 			actPosture = postureForAction(vc, act.methodName)
 		}
-		// #5230 — URL-segment derivation faithful to DRF semantics:
+		// #5230 / #5298 — URL-segment derivation faithful to DRF semantics:
 		//   1. An explicit `url_path="<value>"` kwarg wins VERBATIM, including any
 		//      embedded `(?P<name>regex)` capture groups — canonicalDjango rewrites
 		//      those to `{name}` path params downstream (stripPythonNamedGroups).
-		//   2. With no url_path, DRF derives the segment from the Python method name
-		//      with underscores replaced by hyphens (`do_thing` → `do-thing`), NOT
-		//      the raw method name. Pre-#5230 the raw name leaked into the URL.
+		//   2. With no url_path, DRF uses the Python method name VERBATIM as the URL
+		//      segment (underscores preserved). In rest_framework/decorators.py the
+		//      @action decorator sets `func.url_path = url_path if url_path else
+		//      func.__name__` — only `url_name` (the reverse() lookup name, not the
+		//      URL) gets the `_`→`-` replacement. So `do_thing` routes at
+		//      `.../do_thing/`, NOT `.../do-thing/`.
 		segment := act.urlPath
 		if segment == "" {
 			segment = drfDefaultActionSegment(act.methodName)
@@ -1392,14 +1395,16 @@ func emitActionRoutes(
 }
 
 // drfDefaultActionSegment returns the URL segment DRF derives from an
-// @action-decorated method NAME when no `url_path=` kwarg is supplied (#5230).
-// DRF's router replaces underscores in the method name with hyphens to build
-// the default URL path: a method `do_thing` is routed at `.../do-thing/`, not
-// `.../do_thing/`. See rest_framework.routers — the default url_path is
-// `replace(method_name, '_', '-')`. A name with no underscore passes through
-// unchanged.
+// @action-decorated method NAME when no `url_path=` kwarg is supplied
+// (#5230 / #5298). DRF uses the method name VERBATIM, with underscores
+// PRESERVED: `rest_framework/decorators.py` sets
+// `func.url_path = url_path if url_path else func.__name__`, so a method
+// `do_thing` is routed at `.../do_thing/`. (The `_`→`-` replacement applies
+// only to `url_name`, the reverse() lookup name — NOT the URL segment. The
+// earlier #5230 belief that the default url_path was hyphenated conflated the
+// two and broke snake_case action paths — #5298.)
 func drfDefaultActionSegment(methodName string) string {
-	return strings.ReplaceAll(methodName, "_", "-")
+	return methodName
 }
 
 // emitViewSetMethodEntities emits synthetic SCOPE.Operation entities for each

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -153,7 +153,7 @@ class ContractViewSet(ModelViewSet):
 
 // TestApplyDjangoDRFRoutes_CollectionActionDefaultGet verifies that
 // @action(detail=False) (no methods kwarg) defaults to GET and uses the
-// HYPHENATED method name as the URL path (DRF replaces `_`→`-`). #5230.
+// VERBATIM method name as the URL path (DRF keeps underscores). #5298.
 func TestApplyDjangoDRFRoutes_CollectionActionDefaultGet(t *testing.T) {
 	files := fileMap{
 		"urls.py": `
@@ -174,10 +174,10 @@ class ContractViewSet(ModelViewSet):
 `,
 	}
 	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
-	// DRF default url_path for a method `get_extras` is `get-extras`, not the
-	// raw `get_extras` (#5230).
-	assertHasAllIDs(t, got, []string{"http:GET:/contracts/get-extras"})
-	assertHasNoneIDs(t, got, []string{"http:GET:/contracts/get_extras"})
+	// DRF default url_path for a method `get_extras` is the verbatim
+	// `get_extras` (underscores preserved), not `get-extras` (#5298).
+	assertHasAllIDs(t, got, []string{"http:GET:/contracts/get_extras"})
+	assertHasNoneIDs(t, got, []string{"http:GET:/contracts/get-extras"})
 }
 
 // TestApplyDjangoDRFRoutes_ActionMultipleMethods verifies that an action
@@ -247,10 +247,12 @@ class BranchViewSet(ModelViewSet):
 	}
 }
 
-// TestApplyDjangoDRFRoutes_ActionDefaultHyphenatedSegment verifies #5230: an
-// @action with no url_path and a method name `do_thing` is routed at the
-// HYPHENATED `do-thing`, mirroring DRF's `_`→`-` default-url_path derivation.
-func TestApplyDjangoDRFRoutes_ActionDefaultHyphenatedSegment(t *testing.T) {
+// TestApplyDjangoDRFRoutes_ActionDefaultVerbatimSegment verifies #5298 (corrects
+// #5230): an @action with no url_path and a method name `do_thing` is routed at
+// the VERBATIM `do_thing` (underscores preserved). DRF's @action decorator sets
+// `func.url_path = url_path if url_path else func.__name__` — the `_`→`-`
+// replacement applies only to `url_name` (the reverse() lookup), NOT the URL.
+func TestApplyDjangoDRFRoutes_ActionDefaultVerbatimSegment(t *testing.T) {
 	files := fileMap{
 		"urls.py": `
 from rest_framework import routers
@@ -270,8 +272,8 @@ class WidgetViewSet(ModelViewSet):
 `,
 	}
 	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
-	assertHasAllIDs(t, got, []string{"http:GET:/widgets/do-thing"})
-	assertHasNoneIDs(t, got, []string{"http:GET:/widgets/do_thing"})
+	assertHasAllIDs(t, got, []string{"http:GET:/widgets/do_thing"})
+	assertHasNoneIDs(t, got, []string{"http:GET:/widgets/do-thing"})
 }
 
 // TestApplyDjangoDRFRoutes_NestedRouterActionParams verifies #5230 composes
@@ -314,10 +316,13 @@ class BranchViewSet(ModelViewSet):
 	})
 }
 
-// TestApplyDjangoDRFRoutes_BranchViewSetRegression5230 is the #5230 regression
-// fixture: a BranchViewSet with three actions (a nested-url_path detail action,
-// a hyphenated-default detail action, and a hyphenated-default collection
-// action) must produce the exact expected URL set.
+// TestApplyDjangoDRFRoutes_BranchViewSetRegression5230 is the #5230 / #5298
+// regression fixture: a BranchViewSet with actions (a nested-url_path detail
+// action plus two default-segment detail actions) must produce the exact
+// expected URL set. With no url_path the default segment is the method name
+// VERBATIM (underscores preserved) — `set_director`, not `set-director`
+// (#5298 corrects the earlier hyphenated belief; the explicit-url_path action
+// is still used verbatim with its capture group).
 func TestApplyDjangoDRFRoutes_BranchViewSetRegression5230(t *testing.T) {
 	files := fileMap{
 		"urls.py": `
@@ -348,14 +353,16 @@ class BranchViewSet(ModelViewSet):
 	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
 	assertHasAllIDs(t, got, []string{
 		"http:DELETE:/branches/{pk}/contacts/{contact_id}/remove",
-		"http:POST:/branches/{pk}/set-director",
-		"http:POST:/branches/{pk}/clear-director",
-	})
-	// Raw underscore method names must NOT appear in any action URL.
-	assertHasNoneIDs(t, got, []string{
-		"http:DELETE:/branches/{pk}/remove_contact",
 		"http:POST:/branches/{pk}/set_director",
 		"http:POST:/branches/{pk}/clear_director",
+	})
+	// The hyphenated forms must NOT appear — DRF's default url_path keeps
+	// underscores (only url_name is hyphenated). The remove_contact method's
+	// own name must not leak into the URL (its explicit url_path wins).
+	assertHasNoneIDs(t, got, []string{
+		"http:DELETE:/branches/{pk}/remove_contact",
+		"http:POST:/branches/{pk}/set-director",
+		"http:POST:/branches/{pk}/clear-director",
 	})
 }
 


### PR DESCRIPTION
## Root cause — the CODE was wrong, not the test

`drfDefaultActionSegment` (introduced by #5230) converted an `@action` method name's underscores to hyphens when no `url_path=` kwarg was supplied, claiming this mirrored DRF's default-`url_path` derivation. **That is factually wrong.**

In `rest_framework/decorators.py` the `@action` decorator sets:

```python
func.url_path = url_path if url_path else func.__name__
func.url_name = url_name if url_name else func.__name__.replace('_', '-')
```

The default **`url_path`** (the actual URL segment) is the method name **verbatim** — underscores preserved. Only **`url_name`** (the `reverse()` lookup name, *not* the URL) gets the `_`→`-` replacement. #5230 conflated the two, so every default-segment `@action` route was emitted hyphenated, breaking snake_case action paths.

### How it surfaced

`TestDRFGetPermissionsPageKey_PipelineStampsAuthPermissions` (cmd/grafel) failed on clean main: the fixture's `at_least_one_jurisdiction_has_maintenance_evaluation` action (no `url_path`) was routed at `/jurisdictions/at-least-one-jurisdiction-has-maintenance-evaluation` (hyphenated) while the test looked up the verbatim snake_case path. The test expectation is **correct**; the extraction was wrong.

```
missing GET /jurisdictions/at_least_one_jurisdiction_has_maintenance_evaluation
  got ... {path:/jurisdictions/at-least-one-jurisdiction-has-maintenance-evaluation verb:GET ...}
```

## Fix

- `drfDefaultActionSegment` now returns the method name **verbatim** (no `_`→`-`).
- Updated the three engine tests that codified the incorrect hyphenated behavior (`ActionDefault*`, `CollectionActionDefaultGet`, `BranchViewSetRegression5230`) to assert the verbatim snake_case segment. Explicit-`url_path` actions (incl. embedded `(?P<name>regex)` capture groups) are still used verbatim — unchanged.
- Corrected the file/func doc comments.

## Validation

- `go build ./...` PASS, `go vet` (engine + cmd/grafel) PASS
- `internal/engine` and `cmd/grafel` test packages green; `TestDRFGetPermissionsPageKey` PASS
- `grafel selftest` — all 6 layers PASS
- The only remaining repo-wide failures (`TestIncrementalConfig_..._NilConfig_EnvUnset`, `internal/install` + `mcpreg` sandbox-HOME guard) **pre-exist on clean main** and are unrelated to this change (verified via `git stash`).

Closes #5298

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)