### PR TITLE
test: green the unit suite for v0.1.0 (fix stale/real failures)

### DIFF
--- a/internal/extractors/incremental_test.go
+++ b/internal/extractors/incremental_test.go
@@ -149,10 +149,21 @@ func loadGraphRelKinds(t *testing.T, stateDir string) []string {
 // Test: incremental opt-in flag
 // ─────────────────────────────────────────────────────────────────────────────
 
-func TestIncrementalEnabled_DefaultOff(t *testing.T) {
+// TestIncrementalEnabled_DefaultOn pins the #5231 behaviour change: with the
+// env var unset (and no Config), incremental reindex is ON by default.
+func TestIncrementalEnabled_DefaultOn(t *testing.T) {
 	t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "")
+	if !extractors.IncrementalEnabled() {
+		t.Error("IncrementalEnabled() should be true (default ON, #5231) when env var is unset")
+	}
+}
+
+// TestIncrementalEnabled_ForcedOff verifies the legacy full-reindex behaviour is
+// still reachable via GRAFEL_INCREMENTAL_REINDEX=0.
+func TestIncrementalEnabled_ForcedOff(t *testing.T) {
+	t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "0")
 	if extractors.IncrementalEnabled() {
-		t.Error("IncrementalEnabled() should be false when env var is unset")
+		t.Error("IncrementalEnabled() should be false when GRAFEL_INCREMENTAL_REINDEX=0")
 	}
 }
 
@@ -1120,7 +1131,8 @@ func TestIncrementalConfig_IsIncrementalEnabled_ConfigOnly_On(t *testing.T) {
 }
 
 // TestIncrementalConfig_IsIncrementalEnabled_ConfigOnly_Off verifies that
-// Config=false overrides the default-off env (i.e., returns false deterministically).
+// Config=false overrides the default (now ON, #5231) — i.e., returns false
+// deterministically when Config explicitly disables incremental.
 func TestIncrementalConfig_IsIncrementalEnabled_ConfigOnly_Off(t *testing.T) {
 	t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "")
 	cfg := extractor.ExtractorConfig{
@@ -1156,12 +1168,12 @@ func TestIncrementalConfig_IsIncrementalEnabled_ConfigWins(t *testing.T) {
 }
 
 // TestIncrementalConfig_IsIncrementalEnabled_NilConfig_EnvUnset checks the
-// documented default: nil Config + unset env → false (disabled).
+// documented default after #5231: nil Config + unset env → true (enabled).
 func TestIncrementalConfig_IsIncrementalEnabled_NilConfig_EnvUnset(t *testing.T) {
 	t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "")
 	var cfg *extractor.ExtractorConfig
-	if cfg.IsIncrementalEnabled() {
-		t.Error("nil Config + unset env: default should be off (false)")
+	if !cfg.IsIncrementalEnabled() {
+		t.Error("nil Config + unset env: default should be on (true) after #5231")
 	}
 }
 


### PR DESCRIPTION
Greens the unit suite for the v0.1.0 release.

## REAL failures found + fixed (internal/extractors)

Both are stale test expectations from the incremental-reindex default flip ON (#5231/#5232). The production code (`ExtractorConfig.IsIncrementalEnabled`) is correct — env unset + nil Config returns `true`. The **tests** asserted the old default-OFF and were the wrong side, so the tests were updated (no production behavior changed).

1. `TestIncrementalEnabled_DefaultOff` → renamed `TestIncrementalEnabled_DefaultOn`; now asserts default ON when `GRAFEL_INCREMENTAL_REINDEX` is unset. Added `TestIncrementalEnabled_ForcedOff` to retain coverage of the legacy `=0` opt-out path.
2. `TestIncrementalConfig_IsIncrementalEnabled_NilConfig_EnvUnset`: flipped assertion to expect `true`, matching the canonical pin `TestIsIncrementalEnabledDefaultOn` in `internal/extractor/incremental_default_test.go`.
3. Refreshed a stale "default-off env" comment on the `ConfigOnly_Off` case.

## Isolation artifact (NOT a real failure, NOT changed)

`internal/daemon/TestSelfDefenseCheck_RunRefusesWhenCalledFromTmpBinary` only fails in the sandbox because (a) `GRAFEL_DISABLE_SELFDEFENSE=1` was exported (so the /tmp binary correctly does **not** self-refuse) and (b) a sibling test's transient daemon was misdetected as the canonical daemon. Under a fresh `mktemp` HOME with `GRAFEL_DISABLE_SELFDEFENSE` unset and the package run alone it **PASSES** (`--- PASS`, 15.01s) — the CI clean-runner case. No change needed.

## Validation (clean isolation: fresh mktemp HOME, GRAFEL_DAEMON_ROOT set, no GRAFEL_DISABLE_SELFDEFENSE)

- `go build ./...` PASS
- `go test ./...` → **302 ok / 0 FAIL**
- `go vet ./internal/extractors/` PASS
- `grafel selftest` → all 6 layers PASS

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>