### PR TITLE
docs: coverage matrix in README, per-tool setup guide, refresh agent-hosts model IDs, drop ADR line

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ For per-agent setup instructions see [docs/agent-hosts.md](docs/agent-hosts.md).
 | [docs/mcp-tools.md](docs/mcp-tools.md) | MCP tool catalogue and pointer to full schema |
 | [docs/install.md](docs/install.md) | Full install matrix (script, binary, source, dev mode) |
 | [docs/tools.md](docs/tools.md) | Supported AI coding tools matrix + per-tool enable/disable (CLI + web) |
+| [docs/setup-per-tool.md](docs/setup-per-tool.md) | Step-by-step "set up grafel in my tool" guide (Claude Code, Codex, Cursor, Windsurf, Kiro, Antigravity, Codeium, Copilot) |
 | [docs/agent-hosts.md](docs/agent-hosts.md) | Per-agent setup (Claude Code, Cursor, Windsurf, Continue, Aider, Cline) |
 | [skills/README.md](skills/README.md) | Skill family — chains, dependencies, install |
 | [internal/mcp/SCHEMA.md](internal/mcp/SCHEMA.md) | Full MCP tool schema (canonical) |
-| [docs/adrs/](docs/adrs/) | Architectural decision records (ADR-0001 through ADR-0022) |
 | [CHANGELOG.md](CHANGELOG.md) | Version history and breaking changes |
 | [CLAUDE.md](CLAUDE.md) | When to use MCP vs grep (agent pairing guide) |
 
@@ -133,7 +133,26 @@ For per-agent setup instructions see [docs/agent-hosts.md](docs/agent-hosts.md).
 
 Core extractors for 50+ languages including Go, Python, TypeScript/JavaScript, Java, C#, C++, Rust, Ruby, PHP, Swift, Kotlin, Scala, Dart, Elixir, and more. Infrastructure: Terraform/HCL, Solidity, Verilog/SystemVerilog. Frontend: Vue SFC, Svelte, Astro. Cross-cutting: SQL, GraphQL, Protocol Buffers, Dockerfile.
 
-Each extractor emits language-specific edges (HTTP endpoints, ORM queries, dynamic dispatch, framework hooks). Full list in [AGENTS.md](AGENTS.md).
+Each extractor emits language-specific edges (HTTP endpoints, ORM queries, dynamic dispatch, framework hooks).
+
+### Coverage
+
+grafel tracks **39 languages (25 active), 255 frameworks, 176 ORMs, 129 tools, and 205 other** capabilities, plus cross-cutting infrastructure: databases, platform/k8s, message brokers, CI/CD, security, observability, protocols, and build systems.
+
+Top languages by framework support:
+
+| Language | Frameworks | ORMs | Tools |
+|----------|-----------:|-----:|------:|
+| JS/TS | 33 | 19 | 21 |
+| C/C++ | 25 | 10 | 16 |
+| python | 25 | 18 | 15 |
+| java | 23 | 15 | 10 |
+| go | 21 | 17 | 8 |
+| C# | 18 | 16 | 7 |
+| kotlin | 18 | 7 | 0 |
+| rust | 17 | 15 | 10 |
+
+See the [full coverage matrix](docs/coverage/summary.md) for every language and the complete cross-cutting infrastructure tables. Per-language detail lives in [docs/coverage/by-language/](docs/coverage/by-language/); per-category detail in [docs/coverage/by-category/](docs/coverage/by-category/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # grafel
 
-> A local code-knowledge-graph daemon that gives AI agents structural navigation — call graphs, cross-repo dependency traces, HTTP surface maps, and process flows — across one or many repositories, exposed via 65 MCP tools.
+> ## Map your codebase, navigate any part.
+>
+> *Where grep gets lost, the Grafel shows the way.*
+
+**No cloud indexing, no account, no data sent anywhere.** Everything runs locally — the daemon indexes on your machine and never phones home.
 
 [![Build](https://github.com/cajasmota/grafel/actions/workflows/test.yml/badge.svg)](https://github.com/cajasmota/grafel/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Status: Preview v0.x](https://img.shields.io/badge/status-preview_v0.x-orange.svg)](CHANGELOG.md)
+
+grafel is a local code-knowledge-graph daemon that gives AI agents structural navigation — call graphs, cross-repo dependency traces, HTTP surface maps, and process flows — across one or many repositories, exposed via 65 MCP tools.
+
+**A companion to `grep`, not a replacement.** `grep` finds text; grafel maps structure — use them together. The standout value is **navigation**: where is `X` defined, who calls `Y`, how a request flows end-to-end, the blast radius of a change. Those are the questions grep can't answer and the graph can. (Fewer file reads also means fewer tokens — a nice side effect, not the point.)
 
 ---
 
@@ -14,7 +22,7 @@ AI coding agents are good at reading files. They are not good at navigating rela
 
 grafel pre-builds the relationship map. It indexes your codebase into an in-memory graph (entities, call edges, import edges, HTTP routes, message-bus topics) and keeps it fresh via file watchers. When an agent asks a structural question, it gets a precise answer in one round-trip instead of twenty file reads.
 
-The graph lives entirely on your machine. No cloud indexing, no account, no data sent anywhere. One binary, one daemon process, one port.
+The graph lives entirely on your machine — local-first by design, as called out above. One binary, one daemon process, one port.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Reference documentation for grafel. The [README.md](../README.md) at the repo ro
 | [quickstart.md](quickstart.md) | Install, first index, first query — 5 commands |
 | [install.md](install.md) | Full install matrix: script, binary, source, dev mode, troubleshooting |
 | [tools.md](tools.md) | Supported AI coding tools matrix (MCP / rules / skills paths) + per-tool enable/disable via CLI and web |
+| [setup-per-tool.md](setup-per-tool.md) | Step-by-step setup per tool (what `grafel install` writes + how to verify) for Claude Code, Codex, Cursor, Windsurf, Kiro, Antigravity, Codeium, Copilot |
 | [agent-hosts.md](agent-hosts.md) | Per-agent MCP setup (Claude Code, Cursor, Windsurf, Continue, Aider, Cline) |
 
 ## Core concepts

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -3,8 +3,15 @@
 The graph-enrichment pass (`/grafel-graph-enrich`) runs hundreds to
 thousands of LLM calls in batches. Using the wrong model (Sonnet or Opus)
 inflates cost by 10–20× without meaningfully improving enrichment quality for
-most entities. This page shows how to set `claude-3-haiku-20240307` as the
+most entities. This page shows how to set `claude-haiku-4-5` as the
 active model in each supported agent host **before** starting enrichment.
+
+**Current tiers** (Anthropic list pricing, per million tokens):
+
+| Tier | Model ID | Input | Output |
+|------|----------|------:|-------:|
+| Cheap (Haiku) | `claude-haiku-4-5` | $1.00 | $5.00 |
+| Mid (Sonnet) | `claude-sonnet-4-6` | $3.00 | $15.00 |
 
 > **Model selection rule** (from [`skills/grafel-graph-enrich/SKILL.md`](../skills/grafel-graph-enrich/SKILL.md)):
 > Haiku for `high`, `medium`, and `low` criticality bands (the vast majority
@@ -24,6 +31,11 @@ active model in each supported agent host **before** starting enrichment.
 | [Continue](#continue) | Yes — `config.json` or inline picker | Yes (via MCP JSON config) | No | Set `defaultModel` to Haiku in config |
 | [Aider](#aider) | Yes — `--model` CLI flag or `.aider.conf.yml` | No (no MCP client) | No | Run enrichment outside Aider; use Claude Code instead |
 | [Cline](#cline) | Yes — model picker in VS Code sidebar | Yes (via MCP JSON config) | No — one model per task | Switch to Haiku before starting the task |
+| [Codex](#newer-hosts) | Session model (Codex settings / `~/.codex/config.toml`) | Yes (TOML config) | No | grafel enrichment runs whatever the session model is |
+| [Kiro](#newer-hosts) | Session model (Kiro settings) | Yes (`~/.kiro/settings/mcp.json`) | No | grafel enrichment runs whatever the session model is |
+| [Antigravity](#newer-hosts) | Session model (Antigravity settings) | Yes (`~/.gemini/antigravity/mcp_config.json`) | No | grafel enrichment runs whatever the session model is |
+| [Copilot](#newer-hosts) | Session model (Copilot model picker) | No (rules-only) | No | Rules-only; no `grafel_*` MCP tools — run enrichment in Claude Code |
+| [Codeium](#newer-hosts) | Session model (Codeium settings) | No (rules-only) | No | Rules-only; no `grafel_*` MCP tools — run enrichment in Claude Code |
 
 ---
 
@@ -37,7 +49,7 @@ Sonnet fallback.
 ### Set model at session start (recommended)
 
 ```sh
-claude --model claude-3-haiku-20240307
+claude --model claude-haiku-4-5
 ```
 
 Then invoke:
@@ -54,7 +66,7 @@ prompt you before switching to Sonnet for the critical tier.
 In the Claude Code chat:
 
 ```
-/model claude-3-haiku-20240307
+/model claude-haiku-4-5
 ```
 
 ### Per-project default
@@ -64,7 +76,7 @@ for a machine-wide default):
 
 ```json
 {
-  "model": "claude-3-haiku-20240307"
+  "model": "claude-haiku-4-5"
 }
 ```
 
@@ -79,25 +91,25 @@ command output. You can also check at any time:
 /model
 ```
 
-Expected output: `Current model: claude-3-haiku-20240307`
+Expected output: `Current model: claude-haiku-4-5`
 
 ### Recommended workflow for enrichment
 
-1. `claude --model claude-3-haiku-20240307` — start the session locked to Haiku.
+1. `claude --model claude-haiku-4-5` — start the session locked to Haiku.
 2. Run `grafel status` to confirm the daemon is up and MCP is connected.
 3. Invoke `/grafel-graph-enrich` — the skill fetches the pending enrichment
    queue, then prints a cost estimate and asks for confirmation before
    dispatching batches. The non-critical batches go to Haiku; the skill will ask
    you to confirm the model switch to Sonnet for the critical tier before sending
    those batches.
-4. After enrichment completes, run `/model claude-3-5-sonnet-20241022` (or whichever
+4. After enrichment completes, run `/model claude-sonnet-4-6` (or whichever
    model you prefer for interactive coding) to restore your normal session model.
 
 ### Troubleshooting
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Enrichment cost far higher than expected | Session model was Sonnet or Opus | Verify with `/model`; restart with `--model claude-3-haiku-20240307` and re-run |
+| Enrichment cost far higher than expected | Session model was Sonnet or Opus | Verify with `/model`; restart with `--model claude-haiku-4-5` and re-run |
 | `/model` command not found | Claude Code version too old | Upgrade: `npm i -g @anthropic-ai/claude-code@latest` |
 | Skill ignores `/model` change mid-run | Session model is advisory; the skill's per-batch override still applies | No action needed — the skill manages model selection per batch |
 | `settings.json` model ignored | Project file path wrong | Must be `.claude/settings.json` relative to the repo root you opened |
@@ -113,7 +125,7 @@ switching inside a single task.
 
 1. Open the AI panel: `Cmd+L` (macOS) / `Ctrl+L` (Linux/Windows).
 2. Click the **model selector** at the top of the panel.
-3. Choose **claude-3-haiku-20240307** (or the display name "Claude 3 Haiku").
+3. Choose **claude-haiku-4-5** (or the display name "Claude Haiku 4.5").
 
 ### Confirm the active model
 
@@ -136,7 +148,7 @@ Choose one of:
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "Claude 3 Haiku" not in model list | Anthropic API key not set in Cursor settings | Add key under **Cursor → Settings → Models → Anthropic** |
+| "Claude Haiku 4.5" not in model list | Anthropic API key not set in Cursor settings | Add key under **Cursor → Settings → Models → Anthropic** |
 | Model resets after closing the panel | Expected — Cursor does not persist per-chat model | Re-select before each enrichment run |
 
 ---
@@ -151,7 +163,7 @@ and does not persist across sessions.
 1. Open Cascade: `Cmd+L` (macOS) / `Ctrl+L` (Linux/Windows).
 2. Click the **model picker** (usually a small label near the top-right of
    the Cascade panel).
-3. Select **Claude 3 Haiku** (maps to `claude-3-haiku-20240307`).
+3. Select **Claude Haiku 4.5** (maps to `claude-haiku-4-5`).
 
 ### Confirm the active model
 
@@ -168,7 +180,7 @@ tier runs at Haiku quality.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| "Claude 3 Haiku" missing from picker | Codeium account plan does not include Haiku | Check your Codeium plan; Claude models require Codeium Pro or API key mode |
+| "Claude Haiku 4.5" missing from picker | Codeium account plan does not include Haiku | Check your Codeium plan; Claude models require Codeium Pro or API key mode |
 | Cascade panel not opening | Windsurf extension needs restart | `Cmd+Shift+P` → "Reload Window" |
 
 ---
@@ -186,13 +198,13 @@ Edit `~/.continue/config.json`:
 {
   "models": [
     {
-      "title": "Claude 3 Haiku",
+      "title": "Claude Haiku 4.5",
       "provider": "anthropic",
-      "model": "claude-3-haiku-20240307",
+      "model": "claude-haiku-4-5",
       "apiKey": "<your-anthropic-api-key>"
     }
   ],
-  "defaultModel": "Claude 3 Haiku"
+  "defaultModel": "Claude Haiku 4.5"
 }
 ```
 
@@ -201,7 +213,7 @@ Reload the Continue extension after saving (`Cmd+Shift+P` → "Continue: Reload"
 ### Switch model inline
 
 Click the model label at the bottom of the Continue chat panel and choose
-**Claude 3 Haiku** from the dropdown.
+**Claude Haiku 4.5** from the dropdown.
 
 ### Confirm the active model
 
@@ -235,13 +247,13 @@ the recommended workflow is:
 If you do use Aider for any Claude work:
 
 ```sh
-aider --model claude-3-haiku-20240307
+aider --model claude-haiku-4-5
 ```
 
 Or add to `.aider.conf.yml`:
 
 ```yaml
-model: claude-3-haiku-20240307
+model: claude-haiku-4-5
 ```
 
 ### Troubleshooting
@@ -262,17 +274,17 @@ per-task (set before starting the task).
 
 1. Open the Cline sidebar in VS Code.
 2. Click the **model selector** (gear icon or model name label near the top).
-3. Choose **claude-3-haiku-20240307**.
+3. Choose **claude-haiku-4-5**.
 
 ### Wire up MCP (required for `grafel_*` tools)
 
 Cline reads MCP server config from its VS Code extension settings.
-`grafel install` writes the server entry to `~/.claude/claude.json`,
+`grafel install` writes the server entry to `~/.claude.json`,
 but Cline uses its own config file. Copy the server entry:
 
 ```sh
 # After grafel install, inspect the generated entry:
-cat ~/.claude/claude.json | grep -A 10 '"grafel"'
+cat ~/.claude.json | grep -A 10 '"grafel"'
 ```
 
 Then add the equivalent entry to the Cline MCP config (VS Code settings →
@@ -308,6 +320,32 @@ tier-aware enrichment.
 
 ---
 
+## Newer hosts
+
+grafel also installs into Codex, Kiro, Antigravity, GitHub Copilot, and
+Codeium (see [tools.md](tools.md) for the exact config/rules paths each one
+gets). None of these expose grafel's per-batch model selection the way Claude
+Code does, so the guidance is short:
+
+- **Codex / Kiro / Antigravity** — MCP-capable, so the `grafel_*` tools are
+  available. There is no per-task model override for enrichment: select your
+  model in the host's own settings and grafel enrichment runs whatever the
+  current session model is. Choose the Haiku tier (`claude-haiku-4-5`) before
+  invoking `/grafel-graph-enrich` if the host lets you, then restore your
+  normal coding model afterward. Codex stores its MCP entry as TOML at
+  `~/.codex/config.toml`; Kiro at `~/.kiro/settings/mcp.json`; Antigravity at
+  `~/.gemini/antigravity/mcp_config.json`.
+- **GitHub Copilot / Codeium** — rules-only. grafel writes a guidance file
+  (`.github/copilot-instructions.md` for Copilot, `.codeium/instructions.md`
+  for Codeium) but registers **no** MCP server, so the `grafel_*` tools are not
+  callable from these hosts. Run enrichment in Claude Code instead.
+
+Don't try to force a specific model in a host that doesn't surface the choice —
+configure the model in the host's own settings and accept that enrichment runs
+at the session model's rate.
+
+---
+
 ## Recommended minimal setup
 
 If you are onboarding to grafel enrichment for the first time, this is
@@ -319,13 +357,13 @@ curl -fsSL https://raw.githubusercontent.com/cajasmota/grafel/main/install.sh | 
 
 # 2. Register your repos and start the daemon
 grafel wizard   # creates group config
-grafel install  # starts daemon, wires MCP, writes ~/.claude/claude.json
+grafel install  # starts daemon, wires MCP, writes ~/.claude.json
 
 # 3. Confirm MCP is connected
 grafel status   # should show "MCP: connected"
 
 # 4. Open Claude Code locked to Haiku
-claude --model claude-3-haiku-20240307
+claude --model claude-haiku-4-5
 
 # 5. Run the enrichment pass
 /grafel-graph-enrich

--- a/docs/install.md
+++ b/docs/install.md
@@ -117,7 +117,9 @@ The same selection is editable from the dashboard under **Settings → AI coding
 tools**.
 
 See [tools.md](tools.md) for the full supported-tools matrix (exact MCP config
-paths and rules-file paths per tool) and the complete enable/disable reference.
+paths and rules-file paths per tool) and the complete enable/disable reference,
+and [setup-per-tool.md](setup-per-tool.md) for step-by-step setup + verification
+in each tool.
 
 ---
 

--- a/docs/setup-per-tool.md
+++ b/docs/setup-per-tool.md
@@ -1,0 +1,234 @@
+# Setting up grafel in your AI coding tool
+
+This is the step-by-step "how do I get grafel working in *my* tool" guide. For
+the capability matrix (which artifact each tool gets) see [tools.md](tools.md);
+for the full install matrix (script, binary, source) see [install.md](install.md).
+
+The short version: **you almost never wire anything up by hand.** `grafel
+install` writes the MCP config, the rules file, and (for Claude Code) the
+skills and agent hook for every enabled tool, automatically. This page tells
+you what each tool gets, where it lands, and how to verify it.
+
+---
+
+## 1. Install grafel and let it wire your tools
+
+```sh
+# 1. Install the binary + daemon
+curl -fsSL https://raw.githubusercontent.com/cajasmota/grafel/main/install.sh | bash
+
+# 2. Register your repos (creates the group config)
+grafel wizard
+
+# 3. Wire MCP + rules + skills into your AI coding tools and start the daemon
+grafel install
+```
+
+`grafel install` does three things per enabled tool:
+
+- **Writes the MCP entry** — registers the grafel MCP server in the tool's
+  config so the agent can call the `grafel_*` tools (`grafel_find`,
+  `grafel_inspect`, `grafel_traces`, …). One global entry per tool; the single
+  daemon routes by the caller's working directory. The entry points at the
+  `grafel` binary with args `["mcp-bridge"]` (a local **stdio** server).
+- **Writes the rules file** — a marker-wrapped "prefer the grafel MCP over
+  grep" guidance block, written **per repo** into the tool's rules file.
+- **Writes skills + the agent hook** — the grafel skill family (slash commands)
+  and the opt-in `PreToolUse` grep-interceptor hook. **Claude Code only** today.
+
+A tool that lacks a capability is a no-op for that artifact — grafel only
+writes what the tool can actually consume.
+
+> **MCP tool names are `grafel_*`.** Once the MCP server is registered and the
+> tool is restarted, you'll see tools like `grafel_find`, `grafel_inspect`,
+> `grafel_expand`, and `grafel_traces` in the tool's MCP/tool list.
+
+---
+
+## 2. Choose which tools grafel targets
+
+By default grafel targets **every supported tool**. To pick a subset, use any of:
+
+```sh
+# Explicit allow-list (non-interactive)
+grafel install --tools claude,cursor,windsurf
+
+# Interactive multi-select wizard (on a TTY, with no --tools/--yes/--no-wizard)
+grafel install
+
+# Inspect / change the selection after install (in-process, no daemon restart)
+grafel tools list                 # show every tool with enabled/detected state
+grafel tools enable cursor kiro   # enable tools + write their artifacts
+grafel tools disable codeium      # disable tools + remove their artifacts
+```
+
+Valid tool IDs: `claude`, `codex`, `cursor`, `windsurf`, `codeium`,
+`copilot`, `kiro`, `antigravity`.
+
+You can also edit the selection from the dashboard under **Settings → AI coding
+tools** — a checklist with each tool's enabled and `(detected)` state. Saving
+applies the delta in-process; the daemon stays up (no `grafel install`, no
+restart).
+
+See [tools.md](tools.md) for the full selection semantics (precedence, defaults,
+web panel API).
+
+---
+
+## 3. Per-tool setup
+
+Each section lists: what `grafel install` writes, and how to verify it. After
+install, **restart the tool** so it re-reads its MCP config, then confirm the
+`grafel` MCP server appears (for MCP-capable tools) and/or the rules file
+exists.
+
+### Claude Code (`claude`)
+
+- **MCP**: `~/.claude.json` (global). Also registered into any
+  `~/.claude-*/` config dirs that contain a `.claude.json`.
+- **Rules**: `CLAUDE.md` (per repo).
+- **Skills**: the grafel skill family under `~/.claude/skills/`.
+- **Agent hook**: the opt-in `PreToolUse` grep-interceptor.
+
+**Verify**
+
+```sh
+grep -A 6 '"grafel"' ~/.claude.json     # MCP entry present
+ls CLAUDE.md                            # rules file in your repo
+ls ~/.claude/skills/ | grep grafel      # skills installed
+```
+
+Restart Claude Code, then run `/mcp` (or check the MCP panel) — the `grafel`
+server should be listed and its `grafel_*` tools available. The grafel slash
+commands (e.g. `/grafel-graph-enrich`) should also appear.
+
+### Codex (`codex`)
+
+- **MCP**: `~/.codex/config.toml` — **TOML**, table `[mcp_servers.grafel]`
+  (Codex uses TOML, not JSON; every other MCP tool uses JSON).
+- **Rules**: `AGENTS.md` (per repo).
+
+**Verify**
+
+```sh
+grep -A 4 '\[mcp_servers.grafel\]' ~/.codex/config.toml
+ls AGENTS.md
+```
+
+Restart Codex; confirm the `grafel` MCP server loads and the `grafel_*` tools
+are callable.
+
+### Cursor (`cursor`)
+
+- **MCP**: `~/.cursor/mcp.json` (JSON, `{ "mcpServers": { "grafel": … } }`).
+- **Rules**: `.cursorrules` (per repo).
+
+**Verify**
+
+```sh
+grep -A 6 '"grafel"' ~/.cursor/mcp.json
+ls .cursorrules
+```
+
+Restart Cursor; in **Settings → MCP** the `grafel` server should show as
+connected with its tools listed.
+
+### Windsurf (`windsurf`)
+
+- **MCP**: `~/.codeium/windsurf/mcp_config.json` (desktop app). The Windsurf
+  JetBrains plugin uses `~/.codeium/mcp_config.json`.
+- **Rules**: `.windsurfrules` (per repo).
+
+**Verify**
+
+```sh
+grep -A 6 '"grafel"' ~/.codeium/windsurf/mcp_config.json
+ls .windsurfrules
+```
+
+Restart Windsurf; the Cascade MCP panel should list the `grafel` server.
+
+### Kiro (`kiro`)
+
+- **MCP**: `~/.kiro/settings/mcp.json` (JSON, user-global). Kiro also supports a
+  workspace-level `<repo>/.kiro/settings/mcp.json`, but grafel writes the
+  user-global file.
+- **Rules**: `.kiro/steering/grafel.md` (per repo — Kiro reads steering markdown
+  from `<repo>/.kiro/steering/*.md`).
+
+**Verify**
+
+```sh
+grep -A 6 '"grafel"' ~/.kiro/settings/mcp.json
+ls .kiro/steering/grafel.md
+```
+
+Restart Kiro; confirm the `grafel` MCP server and its `grafel_*` tools.
+
+### Antigravity (`antigravity`)
+
+- **MCP**: `~/.gemini/antigravity/mcp_config.json` (JSON, same
+  `{ "mcpServers": { "grafel": … } }` stdio shape as Cursor/Kiro).
+- **Rules**: `.agent/rules/grafel.md` (per repo — Antigravity reads rules
+  markdown from `<repo>/.agent/rules/*.md`).
+
+**Verify**
+
+```sh
+grep -A 6 '"grafel"' ~/.gemini/antigravity/mcp_config.json
+ls .agent/rules/grafel.md
+```
+
+Restart Antigravity; confirm the `grafel` MCP server loads.
+
+### Codeium (`codeium`) — rules only
+
+- **MCP**: none. grafel does **not** register an MCP server for Codeium, so the
+  `grafel_*` tools are not callable here.
+- **Rules**: `.codeium/instructions.md` (per repo).
+
+**Verify**
+
+```sh
+ls .codeium/instructions.md
+```
+
+The rules file steers the agent toward grafel's conventions, but there is no
+MCP surface. For graph queries, use an MCP-capable host (Claude Code, Cursor,
+Windsurf, Kiro, Antigravity, Codex).
+
+### GitHub Copilot (`copilot`) — rules only
+
+- **MCP**: none.
+- **Rules**: `.github/copilot-instructions.md` (per repo).
+
+**Verify**
+
+```sh
+ls .github/copilot-instructions.md
+```
+
+Same as Codeium: rules-only, no `grafel_*` MCP tools. Use an MCP-capable host
+for graph queries.
+
+---
+
+## 4. Notes
+
+- **Rules files are per-repo**; MCP entries are written once to the
+  **user-global** path shown above. On Windows the same relative paths apply
+  under the user profile.
+- **Codex writes TOML** (`[mcp_servers.grafel]`); every other MCP-capable tool
+  writes JSON (`{ "mcpServers": { "grafel": { ... } } }`).
+- After enabling/disabling tools with `grafel tools enable|disable` or the web
+  panel, restart the affected tool so it re-reads its config.
+
+---
+
+## See also
+
+- [tools.md](tools.md) — supported-tools matrix + enable/disable reference.
+- [install.md](install.md) — full install matrix (script, binary, source).
+- [agent-hosts.md](agent-hosts.md) — per-agent model/session setup for the
+  enrichment skills.
+- [mcp-tools.md](mcp-tools.md) — the `grafel_*` MCP tool catalogue.


### PR DESCRIPTION
Pre-release documentation pass (docs/markdown only — no code changes).

## Changes

1. **README — drop the ADR line.** Removed the stale `docs/adrs/` (ADR-0001 through ADR-0022) row from the "What's inside" table.
2. **README — surface the real coverage matrix.** Replaced the wrong `AGENTS.md` link (that's the contributor process, not the data) with a new **Coverage** subsection: headline counts (39 languages / 25 active, 255 frameworks, 176 ORMs, 129 tools, 205 other), a compact top-8 languages table, and links to `docs/coverage/summary.md` (full matrix), `by-language/`, and `by-category/`. Numbers match `docs/coverage/summary.md` exactly.
3. **docs/agent-hosts.md — refresh stale model IDs + hosts.** `claude-3-haiku-20240307` → `claude-haiku-4-5` ($1/$5), `claude-3-5-sonnet-20241022` → `claude-sonnet-4-6` ($3/$15); added a tier/pricing table; added the newer hosts (Codex, Kiro, Antigravity, Copilot, Codeium) to the comparison table and a "Newer hosts" section. Fixed a stale `~/.claude/claude.json` → `~/.claude.json` path.
4. **docs/setup-per-tool.md (new) — per-tool install/setup guide.** Step-by-step "set up grafel in my tool" for all 8 supported tools, with exact MCP config + rules paths verified against `internal/install/mcpreg` and `internal/install/tooladapter`, how to choose tools, and how to verify each install. Linked from README, the docs index, and `install.md`.

Model IDs updated to **claude-haiku-4-5 / claude-sonnet-4-6** (current cheap/mid tiers).

## Validation
- `grep -rn "claude-3-..." docs/` → zero stale Anthropic IDs.
- ADR line and `Full list in AGENTS.md` removed from README.
- No `archigraph` mentions in README/docs.
- README coverage numbers match `docs/coverage/summary.md`.
- Every config path in the setup guide matches the install code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)