### PR TITLE
fix(uninstall): --remove-binary removes the canonical bin path on Windows (acceptance regression)

### DIFF
--- a/internal/install/removebinary.go
+++ b/internal/install/removebinary.go
@@ -18,14 +18,82 @@
 package install
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 )
 
 // osRemove is os.Remove indirected so tests can simulate the Windows
 // "access denied while running" failure on a non-Windows host.
 var osRemove = os.Remove
+
+// osRename is os.Rename indirected so tests can simulate the Windows
+// "sharing violation while another process holds the exe" rename failure —
+// and its release on a later retry — on a non-Windows host.
+var osRename = os.Rename
+
+// removeBinaryRetries / removeBinaryRetryDelay bound the retry loop in
+// freeLockedBinaryPath that absorbs a *transient* lock on the install binary.
+// The acceptance regression (run 27847397341): `grafel install --copy` now
+// leaves a live daemon process running the installed exe (readiness gates on
+// the RPC socket — #5293 — so the daemon genuinely comes up on Windows CI).
+// `grafel uninstall` stops that daemon first, but Windows can hold the .exe
+// handle for a brief beat AFTER the daemon's socket disappears, so the
+// immediate os.Remove AND the rename-aside both fail with
+// ERROR_SHARING_VIOLATION and the binary survives. A short bounded retry rides
+// out that handle-release lag without weakening the guarantee: a permanent lock
+// still surfaces the genuine error. Variables (not consts) so tests can shrink
+// the delay.
+var (
+	removeBinaryRetries    = 20
+	removeBinaryRetryDelay = 150 * time.Millisecond
+)
+
+// freeLockedBinaryPath frees the canonical install path of a binary that is
+// currently locked, by renaming it aside (a directory-entry change Windows
+// permits even for a file backing a running/foreign-held process) within a
+// bounded retry loop. It is the platform-neutral core of the Windows
+// self-delete-safe removal, extracted here so it is unit-testable on any OS via
+// the injectable osRemove/osRename seams; isLock classifies the
+// platform-specific lock/sharing error.
+//
+// On each attempt it first re-tries a clean os.Remove (the lock may have
+// cleared — e.g. the daemon fully exited — letting us delete outright with no
+// orphan), then falls back to renaming the path aside. It returns:
+//   - asideUsed=true when the path was freed via rename (the caller schedules
+//     the orphan for delete-on-reboot);
+//   - asideUsed=false when a retried os.Remove (or the holder itself) cleared
+//     the path outright — nothing to schedule;
+//   - a non-nil error only when the lock never cleared within the budget.
+//
+// firstErr is the original os.Remove error, threaded through for context.
+func freeLockedBinaryPath(binPath, aside string, firstErr error, isLock func(error) bool) (asideUsed bool, err error) {
+	var rerr error
+	for attempt := 0; attempt < removeBinaryRetries; attempt++ {
+		if attempt > 0 {
+			if derr := osRemove(binPath); derr == nil {
+				return false, nil // lock cleared; deleted outright, no orphan.
+			} else if !isLock(derr) {
+				return false, derr
+			}
+		}
+		if rerr = osRename(binPath, aside); rerr == nil {
+			return true, nil // path freed via rename-aside.
+		}
+		if !isLock(rerr) {
+			break // a non-lock rename error won't clear by waiting.
+		}
+		time.Sleep(removeBinaryRetryDelay)
+	}
+	// If the file vanished while we retried (the holder deleted it, or an
+	// interleaved os.Remove won), the path is clear — success, nothing aside.
+	if _, serr := os.Stat(binPath); os.IsNotExist(serr) {
+		return false, nil
+	}
+	return false, fmt.Errorf("self-delete: rename %s aside: %w (original: %v)", binPath, rerr, firstErr)
+}
 
 // removeBinary removes the installed CLI binary at binPath. It returns nil when
 // the binary is gone from its canonical install path afterwards — which, on

--- a/internal/install/removebinary_lock_test.go
+++ b/internal/install/removebinary_lock_test.go
@@ -1,0 +1,169 @@
+package install
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// errLocked is a stand-in for the Windows ERROR_SHARING_VIOLATION /
+// ERROR_ACCESS_DENIED the OS raises while another process (or the running exe)
+// holds the install binary open. isTestLock classifies it.
+var errLocked = errors.New("the process cannot access the file because it is being used by another process")
+
+func isTestLock(err error) bool { return errors.Is(err, errLocked) }
+
+// withFastRetries shrinks the retry delay so the bounded loop runs instantly in
+// tests, restoring the originals afterwards. It also restores the osRemove /
+// osRename seams.
+func withFastRetries(t *testing.T) {
+	t.Helper()
+	origDelay, origRetries := removeBinaryRetryDelay, removeBinaryRetries
+	origRemove, origRename := osRemove, osRename
+	removeBinaryRetryDelay = time.Millisecond
+	removeBinaryRetries = 20
+	t.Cleanup(func() {
+		removeBinaryRetryDelay = origDelay
+		removeBinaryRetries = origRetries
+		osRemove = origRemove
+		osRename = origRename
+	})
+}
+
+// TestFreeLockedBinaryPath_TransientLockReleased reproduces the acceptance
+// regression (run 27847397341): the install binary is held by the just-stopped
+// daemon for a few beats (os.Remove AND os.Rename both fail with a sharing
+// violation), then the handle is released. freeLockedBinaryPath must ride out
+// the lag, rename the canonical path aside, and report success — so the
+// canonical <bin>\grafel.exe is genuinely gone.
+func TestFreeLockedBinaryPath_TransientLockReleased(t *testing.T) {
+	withFastRetries(t)
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "grafel.exe")
+	if err := os.WriteFile(bin, []byte("locked binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aside := renamedAsidePath(bin, 4242)
+
+	// Hold the lock for the first 3 attempts, then let the real rename through.
+	lockedAttempts := 3
+	calls := 0
+	osRemove = func(p string) error { return errLocked } // daemon still holds it
+	osRename = func(oldp, newp string) error {
+		calls++
+		if calls <= lockedAttempts {
+			return errLocked
+		}
+		return os.Rename(oldp, newp)
+	}
+
+	asideUsed, err := freeLockedBinaryPath(bin, aside, errLocked, isTestLock)
+	if err != nil {
+		t.Fatalf("freeLockedBinaryPath: unexpected error: %v", err)
+	}
+	if !asideUsed {
+		t.Fatalf("asideUsed = false, want true (path freed via rename-aside)")
+	}
+	// The canonical install path MUST be gone — the heart of the assertion.
+	if _, serr := os.Stat(bin); !os.IsNotExist(serr) {
+		t.Fatalf("canonical binary still present after free; stat err = %v", serr)
+	}
+	if _, serr := os.Stat(aside); serr != nil {
+		t.Fatalf("renamed-aside orphan missing: %v", serr)
+	}
+}
+
+// TestFreeLockedBinaryPath_LockClearsForRemove covers the path where the lock
+// clears enough for a retried os.Remove to delete the file outright (no orphan
+// left behind) — asideUsed must be false.
+func TestFreeLockedBinaryPath_LockClearsForRemove(t *testing.T) {
+	withFastRetries(t)
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "grafel.exe")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aside := renamedAsidePath(bin, 7)
+
+	removeCalls := 0
+	osRemove = func(p string) error {
+		removeCalls++
+		if removeCalls < 3 {
+			return errLocked
+		}
+		return os.Remove(p) // handle finally released
+	}
+	osRename = func(oldp, newp string) error { return errLocked } // rename never clears
+
+	asideUsed, err := freeLockedBinaryPath(bin, aside, errLocked, isTestLock)
+	if err != nil {
+		t.Fatalf("freeLockedBinaryPath: unexpected error: %v", err)
+	}
+	if asideUsed {
+		t.Fatalf("asideUsed = true, want false (cleared via os.Remove, no orphan)")
+	}
+	if _, serr := os.Stat(bin); !os.IsNotExist(serr) {
+		t.Fatalf("canonical binary still present; stat err = %v", serr)
+	}
+}
+
+// TestFreeLockedBinaryPath_PermanentLockSurfacesError ensures we do NOT weaken
+// the guarantee: when the lock never clears, freeLockedBinaryPath returns an
+// error so the uninstall reports the genuine failure (binary truly stuck).
+func TestFreeLockedBinaryPath_PermanentLockSurfacesError(t *testing.T) {
+	withFastRetries(t)
+	removeBinaryRetries = 4 // keep the test snappy
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "grafel.exe")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aside := renamedAsidePath(bin, 9)
+
+	osRemove = func(p string) error { return errLocked }
+	osRename = func(oldp, newp string) error { return errLocked }
+
+	asideUsed, err := freeLockedBinaryPath(bin, aside, errLocked, isTestLock)
+	if err == nil {
+		t.Fatalf("freeLockedBinaryPath: expected an error on a permanent lock, got nil (asideUsed=%v)", asideUsed)
+	}
+	// The binary genuinely remains — we must NOT have claimed success.
+	if _, serr := os.Stat(bin); serr != nil {
+		t.Fatalf("binary unexpectedly gone on permanent lock: %v", serr)
+	}
+}
+
+// TestFreeLockedBinaryPath_NonLockErrorNotRetried ensures a non-lock error from
+// os.Rename is surfaced immediately rather than retried for the full budget
+// (only sharing/lock errors are transient).
+func TestFreeLockedBinaryPath_NonLockErrorNotRetried(t *testing.T) {
+	withFastRetries(t)
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "grafel.exe")
+	if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	aside := renamedAsidePath(bin, 11)
+
+	osRemove = func(p string) error { return errLocked }
+	renameCalls := 0
+	bogus := errors.New("some non-lock rename failure")
+	osRename = func(oldp, newp string) error {
+		renameCalls++
+		return bogus
+	}
+
+	_, err := freeLockedBinaryPath(bin, aside, errLocked, isTestLock)
+	if err == nil {
+		t.Fatalf("expected error from non-lock rename failure")
+	}
+	if renameCalls != 1 {
+		t.Fatalf("rename retried %d times on a non-lock error; want 1 (no retry)", renameCalls)
+	}
+}

--- a/internal/install/removebinary_windows.go
+++ b/internal/install/removebinary_windows.go
@@ -39,15 +39,36 @@ func removeBinaryPlatform(binPath string) error {
 	if err == nil {
 		return nil
 	}
-	if !isAccessOrSharingError(err) || !isRunningExecutable(binPath) {
+	if !isAccessOrSharingError(err) {
 		return err
 	}
 
+	// The binary is locked. Two distinct causes converge here on Windows:
+	//
+	//   1. binPath IS the running uninstall exe — Windows refuses to unlink a
+	//      file backing a live process. The classic self-delete case.
+	//   2. binPath is held by ANOTHER process (e.g. the daemon `grafel install`
+	//      just started, which is still releasing its handle on the .exe a beat
+	//      after `grafel uninstall` stopped it — the #5293/acceptance regression).
+	//
+	// In BOTH cases the canonical install path is freed by renaming it aside
+	// (a directory-entry change Windows permits even for a running exe, and one
+	// that succeeds for a foreign-held exe as soon as the holder releases its
+	// handle). We therefore no longer gate the rename-aside on
+	// isRunningExecutable — renaming aside ANY locked target frees the canonical
+	// <bin>\grafel.exe the uninstall guarantees is gone. freeLockedBinaryPath
+	// rides out the brief handle-release lag from cause (2) with a bounded retry
+	// before giving up.
 	aside := renamedAsidePath(binPath, os.Getpid())
-	if rerr := os.Rename(binPath, aside); rerr != nil {
-		// Could not free the install path — surface the original error so the
-		// caller reports the genuine failure.
-		return fmt.Errorf("self-delete: rename %s aside: %w (original: %v)", binPath, rerr, err)
+	asideUsed, ferr := freeLockedBinaryPath(binPath, aside, err, isAccessOrSharingError)
+	if ferr != nil {
+		// Could not free the install path — surface the genuine failure.
+		return ferr
+	}
+	if !asideUsed {
+		// A retried remove (or the holder itself) cleared the path outright —
+		// no orphan to schedule.
+		return nil
 	}
 
 	// The canonical install path is now clear. Schedule the orphan for deletion


### PR DESCRIPTION
## Regression

The cross-OS acceptance gate failed on **windows-latest** at *Uninstall + assert clean*: `FAIL: binary still present after --remove-binary`. `grafel uninstall --yes --purge --remove-binary` left `<prefix>\bin\grafel.exe` on disk. It **passed** in the all-green run `27652683175` (commit `ffc38a5a3`, which already shipped the #5273 Windows rename-aside) and **regressed** after, in run `27847397341`.

## Root cause

Windows uninstall log (run 27847397341):

```
grafel uninstall: remove binary ...\bin\grafel.exe:
  self-delete: rename ...\bin\grafel.exe aside:
  The process cannot access the file because it is being used by another process.
  (original: remove ...: being used by another process.)
```

**#5293 (`a81fc665b`)** changed install readiness to gate on the **RPC socket** instead of the cold-index-bound `/healthz`. Side effect: `grafel install --copy` now genuinely leaves a **live daemon process** running `<prefix>\bin\grafel.exe` on Windows CI (previously the install's daemon-restart step timed out on `/healthz` and rolled back, so nothing held the exe). At uninstall the daemon is stopped first (`stopRunningDaemon` waits for the named pipe to vanish), but Windows holds the `.exe` handle for a brief beat **after** the socket closes — so both the immediate `os.Remove` **and** the rename-aside fail with `ERROR_SHARING_VIOLATION` and the binary survives.

Secondary latent gap: the prior rename-aside only fired when the target was the **running** exe (`isRunningExecutable`). A binary held by **another** process (the daemon) is exactly the failing case.

## Fix (Windows only; Unix unchanged)

- Extract the lock-handling core into a cross-platform, unit-testable `freeLockedBinaryPath()` that rides out a transient sharing/lock error with a **bounded retry** (20 × 150 ms ≈ 3 s, matching `stopRunningDaemon`'s socket wait) — re-trying a clean `os.Remove` first (deletes outright, no orphan, once the handle releases) and falling back to rename-aside.
- `removeBinaryPlatform` no longer gates rename-aside on `isRunningExecutable`: it frees the canonical `<bin>\grafel.exe` whether the holder is the running exe **or** a foreign process (the daemon). A **permanent** lock still surfaces the genuine error — the assertion's intent is not weakened.
- New `osRename` seam mirrors the existing `osRemove` seam so the regression is reproducible on any host.

## Tests

`removebinary_lock_test.go`: transient-lock-then-released (canonical path gone, orphan scheduled), lock-clears-for-remove (no orphan), permanent-lock (error surfaced, binary still present), non-lock-error-not-retried. Full `internal/install` suite green; `go build ./...` clean; `GOOS=windows` typecheck of the install pkg clean; `grafel selftest` 6/6.

The cross-OS acceptance uninstall step now genuinely removes the binary from `<prefix>/bin/grafel.exe`.

Refs #4457 #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)