### PR TITLE
fix(flows): persist recomputed process/event flows to canonical graph.fb (not just graph.json)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   `graph.fb` + `graph.json` is now covered by a regression test
   (`internal/cli/links_processflow_fb_test.go`) that loads the resulting
   `graph.fb` (not `graph.json`) and asserts `SCOPE.Process` flow entities
-  are present, so the fix can't silently regress (Refs #1893, #1702).
+  are present, so the fix can't silently regress (#5306; Refs #1893, #1702).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
+## [0.1.1] — 2026-06-20
+
+### Fixed
+
+- **Process/event flows persist to the canonical `graph.fb` the daemon
+  serves.** The phantom-edge pass (`runPhantomEdgePass`) re-runs
+  `RunProcessFlowWithCompanions` + `RunEventFlow` after promoting cross-repo
+  CALLS edges; post ADR-0016 (flip-day) the daemon loads `graph.fb`, so a
+  `graph.json`-only writeback left recomputed flows invisible to the daemon
+  and dashboard (live proof: `graph.json` held 30+32 `SCOPE.Process`
+  entities while `grafel status` reported `0 flows`). The dual-write of
+  `graph.fb` + `graph.json` is now covered by a regression test
+  (`internal/cli/links_processflow_fb_test.go`) that loads the resulting
+  `graph.fb` (not `graph.json`) and asserts `SCOPE.Process` flow entities
+  are present, so the fix can't silently regress (Refs #1893, #1702).
+
+---
+
 ## [0.1.0] — 2026-05-23 (Preview Release)
 
 grafel's first pre-release. Active development; APIs, MCP tool names,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,6 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
-## [0.1.1] — 2026-06-20
-
-### Fixed
-
-- **Process/event flows persist to the canonical `graph.fb` the daemon
-  serves.** The phantom-edge pass (`runPhantomEdgePass`) re-runs
-  `RunProcessFlowWithCompanions` + `RunEventFlow` after promoting cross-repo
-  CALLS edges; post ADR-0016 (flip-day) the daemon loads `graph.fb`, so a
-  `graph.json`-only writeback left recomputed flows invisible to the daemon
-  and dashboard (live proof: `graph.json` held 30+32 `SCOPE.Process`
-  entities while `grafel status` reported `0 flows`). The dual-write of
-  `graph.fb` + `graph.json` is now covered by a regression test
-  (`internal/cli/links_processflow_fb_test.go`) that loads the resulting
-  `graph.fb` (not `graph.json`) and asserts `SCOPE.Process` flow entities
-  are present, so the fix can't silently regress (#5306; Refs #1893, #1702).
-
----
-
 ## [0.1.0] — 2026-05-23 (Preview Release)
 
 grafel's first pre-release. Active development; APIs, MCP tool names,

--- a/internal/cli/links_processflow_fb_test.go
+++ b/internal/cli/links_processflow_fb_test.go
@@ -1,0 +1,181 @@
+// links_processflow_fb_test.go — regression lock for the flow-invisibility
+// bug (Refs #1893, #1702).
+//
+// THE BUG (pre-fix): runPhantomEdgePass re-runs RunProcessFlowWithCompanions
+// + RunEventFlow after promoting cross-repo phantom CALLS edges, but post
+// ADR-0016 (flip-day #808) the daemon serves the canonical graph.fb while
+// the pass historically wrote only graph.json. So recomputed Process/Event
+// flow entities never reached the daemon or dashboard — live proof was
+// graph.json holding 30+32 SCOPE.Process entities while `grafel status`
+// reported "0 flows".
+//
+// THE LOCK: build a two-repo fixture group with a cross-repo HTTP call
+// (client repo "fe" → server route in "be"), write each repo's fixture as
+// graph.fb, run the phantom-edge pass, then DELETE the affected repo's
+// graph.json and load graph.fb (LoadGraphFromDir can now only read fb).
+// Assert SCOPE.Process flow entities are present (count > 0). If the write
+// path ever regresses to graph.json-only, the fb load returns zero Process
+// entities and this test fails.
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/links"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// writeFixtureFB writes doc as graph.fb (and graph.json) into the state dir
+// the phantom-edge pass and daemon resolve for repoPath. Mirrors how
+// `grafel index` seeds per-repo state.
+func writeFixtureFB(t *testing.T, repoPath string, doc *graph.Document) {
+	t.Helper()
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir %s: %v", stateDir, err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write fixture graph.fb: %v", err)
+	}
+	// Also seed graph.json so the pass's load path + dual-write behave like
+	// production; the assertion below deletes it before loading to force a
+	// pure-fb read.
+	if err := graph.WriteAtomic(filepath.Join(stateDir, "graph.json"), doc, false); err != nil {
+		t.Fatalf("write fixture graph.json: %v", err)
+	}
+}
+
+// countProcessEntities returns how many SCOPE.Process flow entities a doc holds.
+func countProcessEntities(doc *graph.Document) int {
+	n := 0
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == engine.EntityKindProcess {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPhantomEdgePass_WritesFlowsToFB locks the fb-write of recomputed
+// cross-repo process flows (the primary fix). It exercises the real
+// runPhantomEdgePass write path and asserts the flows land in graph.fb,
+// not just graph.json.
+func TestPhantomEdgePass_WritesFlowsToFB(t *testing.T) {
+	// Isolate all daemon/state paths into a tempdir.
+	daemonRoot := t.TempDir()
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	// Two fixture repo working trees (non-git is fine; gitmeta.Capture falls
+	// back to a default ref and StateDirForRepo resolves consistently).
+	fePath := filepath.Join(t.TempDir(), "fe")
+	bePath := filepath.Join(t.TempDir(), "be")
+	for _, p := range []string{fePath, bePath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir repo %s: %v", p, err)
+		}
+	}
+
+	// Frontend doc: a multi-hop chain whose tail makes a cross-repo HTTP
+	// call. The phantom CALLS edge is injected by the pass (from links.json),
+	// NOT pre-seeded here — so this fixture has no Process flow yet.
+	fe := &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "fe_entry", Name: "loadDashboard", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+			{ID: "fe_loadData", Name: "fetchSummary", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "fe_r1", FromID: "fe_entry", ToID: "fe_loadData", Kind: "CALLS"},
+		},
+	}
+	// Backend doc: a handler with its own downstream CALLS chain.
+	be := &graph.Document{
+		Repo: "be",
+		Entities: []graph.Entity{
+			{ID: "be_handler", Name: "OrdersController.getSummary", Kind: "SCOPE.Operation", Language: "java", SourceFile: "OrdersController.java"},
+			{ID: "be_service", Name: "OrderService.summarize", Kind: "SCOPE.Operation", Language: "java", SourceFile: "OrderService.java"},
+			{ID: "be_repo", Name: "OrderRepository.fetchAll", Kind: "SCOPE.Operation", Language: "java", SourceFile: "OrderRepository.java"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "be_r1", FromID: "be_handler", ToID: "be_service", Kind: "CALLS"},
+			{ID: "be_r2", FromID: "be_service", ToID: "be_repo", Kind: "CALLS"},
+		},
+	}
+	writeFixtureFB(t, fePath, fe)
+	writeFixtureFB(t, bePath, be)
+
+	// Group config keyed by slug (docs map + link Source/Target use slugs).
+	cfg := &registry.GroupConfig{
+		Name: "fixtgrp",
+		Repos: []registry.Repo{
+			{Slug: "fe", Path: fePath},
+			{Slug: "be", Path: bePath},
+		},
+	}
+
+	// Links file: one cross-repo HTTP CALLS link fe_loadData → be_handler.
+	// method=http makes it a phantom-edge candidate; only "fe" is an
+	// affectedRepo (source of the cross-repo CALLS), so only fe gets its
+	// flow recomputed + written.
+	linksDoc := links.Document{
+		Version: 1,
+		Links: []links.Link{
+			{
+				ID:       "lnk1",
+				Source:   "fe::fe_loadData",
+				Target:   "be::be_handler",
+				Relation: links.RelationCalls,
+				Method:   links.MethodHTTP,
+			},
+		},
+	}
+	linksPath := filepath.Join(t.TempDir(), "fixtgrp-links.json")
+	b, err := json.Marshal(linksDoc)
+	if err != nil {
+		t.Fatalf("marshal links: %v", err)
+	}
+	if err := os.WriteFile(linksPath, b, 0o644); err != nil {
+		t.Fatalf("write links file: %v", err)
+	}
+
+	// Run the production phantom-edge pass.
+	added, err := runPhantomEdgePass("fixtgrp", cfg, linksPath)
+	if err != nil {
+		t.Fatalf("runPhantomEdgePass: %v", err)
+	}
+	if added == 0 {
+		t.Fatalf("expected ≥1 phantom edge promoted, got 0")
+	}
+
+	// PRIMARY ASSERTION: the recomputed process flows must be in graph.fb.
+	// Force a pure-fb read by deleting graph.json for the affected repo, then
+	// load via LoadGraphFromDir (which now can only read graph.fb).
+	feState := daemon.StateDirForRepo(fePath)
+	fbPath := filepath.Join(feState, "graph.fb")
+	jsonPath := filepath.Join(feState, "graph.json")
+	if _, statErr := os.Stat(fbPath); statErr != nil {
+		t.Fatalf("graph.fb missing for fe after pass: %v", statErr)
+	}
+	if err := os.Remove(jsonPath); err != nil {
+		t.Fatalf("remove graph.json to force fb read: %v", err)
+	}
+
+	loaded, err := graph.LoadGraphFromDir(feState)
+	if err != nil {
+		t.Fatalf("load graph.fb after pass: %v", err)
+	}
+	got := countProcessEntities(loaded)
+	if got == 0 {
+		t.Fatalf("REGRESSION: graph.fb has 0 SCOPE.Process flow entities after phantom-edge pass — "+
+			"flows were written to graph.json only and never reach the daemon (ADR-0016). "+
+			"entities=%d relationships=%d", len(loaded.Entities), len(loaded.Relationships))
+	}
+	t.Logf("graph.fb has %d SCOPE.Process flow entities after phantom-edge pass (added=%d)", got, added)
+}


### PR DESCRIPTION
## Root cause

`runPhantomEdgePass` (P5, `internal/cli/links.go`) strips stale `SCOPE.Process` entities and re-runs `engine.RunProcessFlowWithCompanions` + `engine.RunEventFlow` after promoting cross-repo phantom CALLS edges. Post **ADR-0016 (flip-day #808)** the daemon loads the canonical `graph.fb`, but the writeback historically persisted **only `graph.json`** — so the recomputed Process/Event flow entities never reached the daemon or dashboard.

**Live proof (before fix):** `graph.json` for the affected repos held **30 + 32 `SCOPE.Process`** entities, while `grafel status` reported **`0 flows`** even after a daemon restart. The daemon never calls `RunProcessFlow` itself (confirmed: only `links.go` does), so a json-only writeback meant the flows were computed and immediately lost.

## Primary fix (verified in place + locked)

The dual-write of `graph.fb` + `graph.json` in `runPhantomEdgePass` is present — it writes `graph.fb` at `daemon.StateDirForRepo(r.Path)/graph.fb` via `fbwriter.WriteAtomic` (the same FlatBuffers writer the index pipeline uses), atomically (temp + rename), and stamps an identical mtime on both encodings. This shipped in **#1702** (`fix: dual-write graph.fb+graph.json in phantom-edge and enrichment writeback paths`).

This PR **locks** that behavior with a regression test so it can't silently return:

`internal/cli/links_processflow_fb_test.go` — builds a 2-repo fixture group with a cross-repo HTTP call (client repo `fe` → server route in `be`), runs the real `runPhantomEdgePass`, **deletes the affected repo's `graph.json` to force a pure-fb read**, loads `graph.fb` via `graph.LoadGraphFromDir`, and asserts `SCOPE.Process` flow entities are present (count > 0).

Verified the test **FAILS** when the fb write is removed (graph.fb keeps only the 2 stale fixture entities, 0 flows) and **PASSES** with it in place.

## Secondary fix (single-repo / no-cross-repo) — investigated, deferred (premise does not hold)

The brief's premise ("single-repo / no-cross-repo groups never get process flows AT ALL") is **not true on current main**:

- `grafel index` runs `PassProcessFlow` (Pass 7, `engine.RunProcessFlow`) for **every** repo by default (not in any default skip set) and writes the result to canonical `graph.fb`. So single-repo and no-outbound-cross-repo repos already get their **intra-repo** flows computed and persisted.
- The phantom-edge pass only re-runs (strip + recompute-with-companions) for cross-repo-affected repos, to *extend* flows across phantom edges. Non-affected repos keep their correct index-time fb flows untouched.

Making the pass re-run for all repos would be redundant recomputation, not a fix — so no code change here.

## Validation

- `go build ./...` exit 0; `go vet ./internal/cli/ ./internal/engine/` clean.
- New regression test PASSES.
- `go test ./internal/cli/... ./internal/engine/... ./internal/links/...` all green.
- `grafel selftest` 6/6 PASS.

Refs #1893, #1702