### PR TITLE
fix(windows/ci): cross-platform process-liveness, RSS, and cross-batch ORM test failures

### DIFF
--- a/internal/cli/watcher_ctl.go
+++ b/internal/cli/watcher_ctl.go
@@ -9,13 +9,13 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/process"
 )
 
 // start/stop/restart now drive the per-machine daemon (ADR-0017). The
@@ -325,16 +325,11 @@ func isUnixSocketPath(path string) bool {
 
 // pidStillAlive reports whether the process with the given pid is still
 // running. Used by the start readiness loop to bail out early when the
-// spawned daemon dies instead of waiting out the whole budget.
+// spawned daemon dies instead of waiting out the whole budget. The
+// platform-specific liveness probe lives in internal/process (signal 0
+// on unix, OpenProcess + GetExitCodeProcess on windows).
 func pidStillAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return p.Signal(syscall.Signal(0)) == nil
+	return process.IsAlive(pid)
 }
 
 func runDaemonStop(out io.Writer) error {

--- a/internal/daemon/extract/coordinator_test.go
+++ b/internal/daemon/extract/coordinator_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/types"
@@ -251,16 +253,36 @@ def get_user_by_cognito(request, uid):
 		}
 	}
 
-	t.Logf("cross-batch ORM test: READS_FIELD=%d subprocesses=%d stderr=%s",
-		readsField, res.Subprocesses, stderrBuf.String())
+	// Cross-platform diagnostics (refs: ubuntu/windows divergence). The
+	// cross-batch ORM resolution is pure-Go regex over byte-identical
+	// content, so a READS_FIELD=0 result off-macOS points at one of a few
+	// upstream gaps. Surface them all so a failing CI run is diagnosable
+	// without re-running: whether both .py files were classified+processed
+	// into >=2 subprocesses, whether the User model + its field entity were
+	// extracted at all, and any non-fatal subprocess errors.
+	var userModel, cognitoField bool
+	for _, e := range res.Entities {
+		if strings.Contains(e.Name, "User") {
+			userModel = true
+		}
+		if strings.Contains(e.Name, "cognito_id") {
+			cognitoField = true
+		}
+	}
+	diag := fmt.Sprintf(
+		"subprocesses=%d processed=%d failed=%d entities=%d rels=%d "+
+			"userModelEntity=%v cognitoFieldEntity=%v byLang=%v nonFatalErrors=%v\nstderr:\n%s",
+		res.Subprocesses, res.Processed, res.Failed, len(res.Entities), len(res.Relationships),
+		userModel, cognitoField, res.ByLang, res.NonFatalErrors, stderrBuf.String())
+
+	t.Logf("cross-batch ORM test: READS_FIELD=%d %s", readsField, diag)
 
 	// With the fix: at least one READS_FIELD edge must exist for
 	// User.cognito_id resolved from views.py across the batch boundary.
 	if readsField == 0 {
 		t.Errorf("expected at least one READS_FIELD edge for cross-batch ORM reference "+
 			"(views.py → User.cognito_id defined in models.py); got 0\n"+
-			"subprocesses=%d — confirm BatchSize=1 forced cross-batch split\n"+
-			"stderr:\n%s", res.Subprocesses, stderrBuf.String())
+			"confirm BatchSize=1 forced cross-batch split.\n%s", diag)
 	}
 
 	// Confirm the coordinator actually spawned multiple subprocesses (one

--- a/internal/daemon/pidfile.go
+++ b/internal/daemon/pidfile.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 
 	"github.com/cajasmota/grafel/internal/process"
 )
@@ -96,18 +95,10 @@ func pidIsLiveDaemon(pid int) bool {
 	return isGrafel
 }
 
-// pidAlive returns true when a process with the given pid exists and
-// the current user can signal it. signal 0 is the POSIX existence
-// probe; on darwin and linux it does not deliver a signal but does
-// validate the pid.
+// pidAlive returns true when a process with the given pid exists. The
+// platform-specific liveness probe lives in internal/process: signal 0
+// on unix, OpenProcess + GetExitCodeProcess on windows (where the unix
+// probe always reports the wrong answer).
 func pidAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	err = p.Signal(syscall.Signal(0))
-	return err == nil
+	return process.IsAlive(pid)
 }

--- a/internal/process/isalive_unix.go
+++ b/internal/process/isalive_unix.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package process
+
+import (
+	"os"
+	"syscall"
+)
+
+// IsAlive reports whether a process with the given pid is currently
+// running. On unix (darwin/linux) it uses signal 0 — the POSIX existence
+// probe — which validates the pid without delivering a signal.
+//
+// A pid that exists but is owned by another user returns EPERM from the
+// probe; we treat that as alive because the process is demonstrably
+// present (the kernel had to look it up to deny us). Only ESRCH (no such
+// process) means dead.
+func IsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = p.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	// EPERM means the process exists but we may not signal it: still alive.
+	return err == syscall.EPERM
+}

--- a/internal/process/isalive_windows.go
+++ b/internal/process/isalive_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package process
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+// stillActive is the exit code reported by GetExitCodeProcess for a
+// process that has not yet terminated (Win32 STILL_ACTIVE == 259).
+const stillActive = 259
+
+// IsAlive reports whether a process with the given pid is currently
+// running on Windows.
+//
+// os.FindProcess always succeeds on Windows and Process.Signal is
+// unsupported there, so the unix signal-0 probe always reports the wrong
+// answer. Instead we OpenProcess with PROCESS_QUERY_LIMITED_INFORMATION
+// (the least-privileged handle that still answers liveness, available
+// even for processes in other sessions) and inspect the exit code:
+// STILL_ACTIVE (259) means running. A failed open with
+// ERROR_INVALID_PARAMETER means the pid does not map to any process —
+// dead.
+func IsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		// ERROR_INVALID_PARAMETER: no process with this pid -> dead.
+		// ERROR_ACCESS_DENIED: the process exists but we may not open
+		// it -> alive (the kernel resolved the pid to deny us).
+		if err == windows.ERROR_ACCESS_DENIED {
+			return true
+		}
+		return false
+	}
+	defer windows.CloseHandle(h)
+
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}

--- a/internal/process/process_other.go
+++ b/internal/process/process_other.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package process
 

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package process
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// FindByName is not implemented on Windows. Process enumeration here would
+// require WMI or Toolhelp32Snapshot; callers treat ErrUnsupported as
+// "cannot determine" and fall back to a coarser liveness check. Tracked as
+// a future improvement.
+func FindByName(_ string) ([]Info, error) {
+	return nil, ErrUnsupported
+}
+
+// Kill terminates the given PID. os.Process.Kill maps to TerminateProcess
+// on Windows; we open the process with PROCESS_TERMINATE and call it.
+func Kill(pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("process.Kill: invalid pid %d", pid)
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		return fmt.Errorf("OpenProcess(%d): %w", pid, err)
+	}
+	defer windows.CloseHandle(h)
+	if err := windows.TerminateProcess(h, 1); err != nil {
+		return fmt.Errorf("TerminateProcess(%d): %w", pid, err)
+	}
+	return nil
+}
+
+// CPUPercent is not implemented on Windows.
+func CPUPercent(_ int) (float64, error) {
+	return 0, fmt.Errorf("process.CPUPercent: unsupported platform windows")
+}
+
+// processMemoryCounters mirrors the Win32 PROCESS_MEMORY_COUNTERS struct
+// (psapi.h). WorkingSetSize is the resident set — the bytes the process
+// currently has in physical RAM — which is the honest Windows analogue of
+// unix RSS.
+type processMemoryCounters struct {
+	CB                         uint32
+	PageFaultCount             uint32
+	PeakWorkingSetSize         uintptr
+	WorkingSetSize             uintptr
+	QuotaPeakPagedPoolUsage    uintptr
+	QuotaPagedPoolUsage        uintptr
+	QuotaPeakNonPagedPoolUsage uintptr
+	QuotaNonPagedPoolUsage     uintptr
+	PagefileUsage              uintptr
+	PeakPagefileUsage          uintptr
+}
+
+var (
+	modpsapi                 = windows.NewLazySystemDLL("psapi.dll")
+	procGetProcessMemoryInfo = modpsapi.NewProc("GetProcessMemoryInfo")
+)
+
+// RSSBytes returns the resident set size (WorkingSetSize) of the process
+// with the given pid, via psapi!GetProcessMemoryInfo. This is the honest
+// physical-memory number used by FootprintBytes on Windows, distinct from
+// runtime.MemStats.Sys (reserved virtual address space).
+func RSSBytes(pid int) (uint64, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("process.RSSBytes: invalid pid %d", pid)
+	}
+	h, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false,
+		uint32(pid),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("OpenProcess(%d): %w", pid, err)
+	}
+	defer windows.CloseHandle(h)
+
+	var counters processMemoryCounters
+	counters.CB = uint32(unsafe.Sizeof(counters))
+	r1, _, callErr := procGetProcessMemoryInfo.Call(
+		uintptr(h),
+		uintptr(unsafe.Pointer(&counters)),
+		uintptr(counters.CB),
+	)
+	if r1 == 0 {
+		return 0, fmt.Errorf("GetProcessMemoryInfo(%d): %w", pid, callErr)
+	}
+	return uint64(counters.WorkingSetSize), nil
+}


### PR DESCRIPTION
Fixes platform-specific failures in the `test` CI that pass on macOS but fail on ubuntu/windows. Verified locally where possible (host build/vet, `GOOS=windows` build/vet of `internal/process`, full macOS test pass of the affected packages); CI is the real verifier for the windows-only paths.

## 1-4 · Windows process-liveness (TestPidStillAlive, TestPidAlive, TestWaitForExit_LiveProcessTimesOut, TestCleanStaleArtifacts_KeepsLivePidfile)
**Root cause:** both liveness probes (`pidStillAlive` in `internal/cli/watcher_ctl.go`, `pidAlive` in `internal/daemon/pidfile.go`) used `os.FindProcess` + `Process.Signal(syscall.Signal(0))`. That is Unix-only: on Windows `os.FindProcess` ALWAYS succeeds and `Process.Signal` is unsupported, so the probe returned the wrong answer for every pid — including the live current process. That cascaded: `waitForExit` never timed out for a live process, and `cleanStaleArtifacts` deleted a live-owner pidfile (treated as stale).
**Fix:** new build-tagged `process.IsAlive(pid)` — unix uses signal-0 (treating `EPERM` as alive); windows uses `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess == STILL_ACTIVE (259)` (treating `ERROR_ACCESS_DENIED` as alive, a failed open / `ERROR_INVALID_PARAMETER` as dead). Both callers delegate to it. The unix path preserves existing macOS/Linux behavior.
**Confidence: high.** Standard, well-understood Win32 liveness idiom; `x/sys/windows` already a dep.

## 5 · Windows RSS mislabel (TestStatusRSSReportsActualMemory)
**Root cause:** `process.RSSBytes` was unimplemented on Windows (the `!linux && !darwin` "other" file errored), so `FootprintBytes` fell back to `runtime.MemStats.Sys` (reserved virtual address space) → reported `RSSBytes == SysBytes`, the exact mislabel the test guards.
**Fix:** windows-tagged `RSSBytes` opens the process and calls `psapi!GetProcessMemoryInfo`, returning `WorkingSetSize` (resident set). Narrowed the "other" build tag to exclude windows; also added a real windows `Kill` (OpenProcess + TerminateProcess).
**Confidence: high** on `RSSBytes != SysBytes` (WorkingSetSize is true resident memory, structurally distinct from MemStats.Sys). The `processMemoryCounters` struct layout matches Win32 `PROCESS_MEMORY_COUNTERS`.

## 6 · Cross-batch ORM lookup (TestCoordinate_CrossBatchORMFieldLookup, ubuntu+windows)
**Investigation:** the full cross-batch resolution path (`writeORMFieldsFile` → `--orm-fields` → `readORMFieldsFile` → `BuildCrossFileFieldLookup` → `applyORMFieldEdges`) is pure-Go regex over byte-identical in-memory content, with absolute paths and CRLF-safe (`TrimSpace`) parsing. No `t.Parallel()` / shared-global race; the subprocess has its own fresh engine state. I found **no deterministic platform-specific defect** in the resolution code. The likely divergence is upstream of the resolution (file classification, the spawned `grafel` binary's environment, or subprocess build under `-race` on a loaded runner) and is not reproducible without the actual ubuntu/windows runner.
**Action:** rather than weaken the assertion or blanket-skip, I made the test **self-diagnosing** — the READS_FIELD==0 failure now dumps subprocess/processed/failed counts, whether the `User` model + `cognito_id` field entities were extracted at all, per-language bucket counts, and non-fatal subprocess errors. The next CI run will pinpoint where the closure breaks.
**Confidence: low** that this alone greens #6 (no code defect found to fix). It will surface the true cause for a targeted follow-up. Happy to iterate once CI shows the diagnostic output.

## Validation (local)
- `gofmt -l $(git ls-files '*.go')` — empty
- `go vet ./...` — clean
- `CGO_ENABLED=0 GOOS=windows go vet ./internal/process/` + `go build ./internal/process/` — clean (the daemon/cli `GOOS=windows` vet shows only pre-existing tree-sitter CGO-disabled exclusions; CI builds windows with CGO_ENABLED=1 + MinGW)
- `go build ./...` — clean
- macOS: `internal/process`, `internal/cli`, `internal/daemon`, and the ORM test all PASS

Do not merge until CI confirms — happy to iterate on any still-red leg (especially #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)