### PR TITLE
fix(test): green the cross-platform test CI tail (Windows path/pid/tool-config + ORM)

### DIFF
--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -274,6 +274,25 @@ type Result struct {
 // Memory contract: the coordinator's RSS is bounded by the final record
 // set (entities + relationships) plus a small per-subprocess buffer for
 // JSON decoding. It never holds AST trees or per-file source bytes.
+
+// syncWriter serializes concurrent Writes to an underlying writer. The
+// coordinator fans out N subprocesses, each with its own os/exec stderr-copier
+// goroutine, all targeting one shared writer; without this guard those writes
+// race (data race under -race) and can interleave bytes. The mutex makes each
+// Write atomic w.r.t. the others while preserving the caller's writer.
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func newSyncWriter(w io.Writer) *syncWriter { return &syncWriter{w: w} }
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}
+
 func Coordinate(ctx context.Context, repoRoot string, files []string, cfg CoordinatorConfig) (*Result, error) {
 	if repoRoot == "" {
 		return nil, errors.New("coordinator: repoRoot is required")
@@ -347,6 +366,13 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 	if stderr == nil {
 		stderr = io.Discard
 	}
+	// Every subprocess's os/exec copier goroutine writes the child's stderr
+	// into this single shared writer concurrently. A plain writer (e.g. the
+	// caller's *bytes.Buffer) is not safe for concurrent Write, which is a real
+	// data race (caught by -race on CI) AND can interleave/corrupt log bytes in
+	// production. Serialize all subprocess writes through a mutex-guarded
+	// wrapper so the fan-out is safe regardless of the writer the caller passes.
+	stderr = newSyncWriter(stderr)
 
 	res := &Result{
 		ByLang:     map[string]int{},

--- a/internal/daemon/watchreg/watchreg.go
+++ b/internal/daemon/watchreg/watchreg.go
@@ -241,11 +241,55 @@ func (r *Registry) write(entries []Entry) error {
 		return err
 	}
 	b = append(b, '\n')
-	tmp := r.path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+
+	// Write to a UNIQUE temp file in the same directory (os.CreateTemp picks a
+	// collision-free name), then atomically rename it over r.path. A fixed
+	// "<path>.tmp" name is unsafe on Windows: if two writers in different
+	// processes ever overlap (or a previous crash left the temp open), the
+	// reused name collides and the rename can fail. CreateTemp sidesteps that.
+	dir := filepath.Dir(r.path)
+	f, err := os.CreateTemp(dir, "."+FileName+".tmp-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, r.path)
+	tmp := f.Name()
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := renameReplace(tmp, r.path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// renameReplace atomically replaces dst with src. On Unix os.Rename already
+// replaces an existing target in a single try. On Windows MoveFileEx (which
+// os.Rename uses with MOVEFILE_REPLACE_EXISTING) can still fail transiently
+// with a sharing violation / access-denied when dst is momentarily open — by
+// a concurrent reader, an indexer, or antivirus. The mutation this guards is
+// already serialized by the registry lock, so the only failures left are these
+// transient Windows sharing windows; a short bounded retry clears them. Unix
+// succeeds on the first iteration and never sleeps.
+func renameReplace(src, dst string) error {
+	const (
+		attempts  = 20
+		pollEvery = 5 * time.Millisecond
+	)
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = os.Rename(src, dst); err == nil {
+			return nil
+		}
+		time.Sleep(pollEvery)
+	}
+	return err
 }
 
 // mutate runs fn under the registry lock against the current entries and writes

--- a/internal/dashboard/v2_source.go
+++ b/internal/dashboard/v2_source.go
@@ -29,6 +29,7 @@ import (
 	"bufio"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -187,7 +188,13 @@ func resolveSourcePath(grp *DashGroup, rawFile, wantRepo string) (abs, slug, rel
 	// Normalise the requested path: strip any leading separators and clean it.
 	// An absolute incoming path is treated as repo-relative by taking its
 	// cleaned form (we never read outside a repo root).
-	clean := filepath.Clean("/" + filepath.ToSlash(rawFile))
+	//
+	// Use path.Clean (always '/'), NOT filepath.Clean: on Windows the latter
+	// rewrites separators to '\\', which (a) breaks the leading-'/' trim below
+	// and (b) yields a backslash repo-relative path that no longer matches the
+	// slash-form paths the rest of the dashboard speaks. The OS-disk boundary is
+	// crossed exactly once, via filepath.FromSlash in tryRepo.
+	clean := path.Clean("/" + filepath.ToSlash(rawFile))
 	clean = strings.TrimPrefix(clean, "/")
 
 	tryRepo := func(repo *DashRepo) (string, string, bool) {

--- a/internal/extractors/golang/issue4332_crosspkg_test.go
+++ b/internal/extractors/golang/issue4332_crosspkg_test.go
@@ -17,6 +17,7 @@ package golang
 import (
 	"context"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -90,7 +91,7 @@ func TestIssue4332_ImportersConnectAcrossPackages(t *testing.T) {
 	for k := range merged {
 		e := merged[k]
 		if e.Kind == "SCOPE.Component" && e.Subtype == "file" &&
-			filepath.Dir(e.SourceFile) == "internal/resolve" {
+			path.Dir(e.SourceFile) == "internal/resolve" {
 			resolveFileIDs[e.ID] = true
 		}
 	}

--- a/internal/extractors/golang/issue4705_replace_test.go
+++ b/internal/extractors/golang/issue4705_replace_test.go
@@ -7,6 +7,7 @@ package golang
 import (
 	"context"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -77,7 +78,7 @@ func TestIssue4705_ReplaceImportResolvesInternal(t *testing.T) {
 	for k := range merged {
 		e := merged[k]
 		if e.Kind == "SCOPE.Component" && e.Subtype == "file" &&
-			filepath.Dir(e.SourceFile) == "internal/x" {
+			path.Dir(e.SourceFile) == "internal/x" {
 			xFileIDs[e.ID] = true
 		}
 	}

--- a/internal/install/tooldelta_test.go
+++ b/internal/install/tooldelta_test.go
@@ -1,6 +1,8 @@
 package install
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -41,10 +43,18 @@ func sortedTools(ts []mcpreg.Tool) []string {
 	return out
 }
 
+// repoPath is a platform-appropriate ABSOLUTE repo path. ApplyToolDelta keys
+// its result maps by absRepo(r.Path) — on Windows a Unix-style "/tmp/repoX" is
+// NOT absolute, so filepath.Abs would rewrite it to e.g. C:\tmp\repoX and the
+// map key would no longer match the literal. Using an already-absolute path
+// (filepath.Join of a volume-rooted temp base) makes the key stable on every
+// OS while keeping the assertions exact.
+var repoPath = filepath.Join(os.TempDir(), "repoX")
+
 func cfgWithRepo() *registry.GroupConfig {
 	return &registry.GroupConfig{
 		Name:  "g",
-		Repos: []registry.Repo{{Path: "/tmp/repoX"}},
+		Repos: []registry.Repo{{Path: repoPath}},
 	}
 }
 
@@ -63,7 +73,7 @@ func TestApplyToolDelta_EnableCursor(t *testing.T) {
 	if len(res.Disabled) != 0 {
 		t.Fatalf("disabled = %v", res.Disabled)
 	}
-	if got := rec.rulesWritten["/tmp/repoX"]; !reflect.DeepEqual(got, []string{".cursorrules"}) {
+	if got := rec.rulesWritten[repoPath]; !reflect.DeepEqual(got, []string{".cursorrules"}) {
 		t.Fatalf("rules written = %v", got)
 	}
 	if len(rec.rulesRemoved) != 0 {
@@ -86,7 +96,7 @@ func TestApplyToolDelta_DisableWindsurf(t *testing.T) {
 	if !reflect.DeepEqual(res.Disabled, []string{"windsurf"}) {
 		t.Fatalf("disabled = %v", res.Disabled)
 	}
-	if got := rec.rulesRemoved["/tmp/repoX"]; !reflect.DeepEqual(got, []string{".windsurfrules"}) {
+	if got := rec.rulesRemoved[repoPath]; !reflect.DeepEqual(got, []string{".windsurfrules"}) {
 		t.Fatalf("rules removed = %v", got)
 	}
 	if got := sortedTools(rec.mcpUnregister); !reflect.DeepEqual(got, []string{string(mcpreg.Windsurf)}) {
@@ -105,7 +115,7 @@ func TestApplyToolDelta_DisableCodexKeepsClaudeRules(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := rec.rulesRemoved["/tmp/repoX"]; !reflect.DeepEqual(got, []string{"AGENTS.md"}) {
+	if got := rec.rulesRemoved[repoPath]; !reflect.DeepEqual(got, []string{"AGENTS.md"}) {
 		t.Fatalf("rules removed = %v (should strip only AGENTS.md)", got)
 	}
 	// codex registers an MCP entry → it should be unregistered.

--- a/internal/process/pid_exe_other.go
+++ b/internal/process/pid_exe_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package process
+
+// pidExeBaseName returns the basename of the executable backing pid and true
+// when the platform can answer it via a cheap, pid-targeted primitive.
+//
+// On non-Windows platforms PidIsGrafel already resolves the process via
+// FindByName (ps/proc), so there is no separate single-pid primitive worth
+// wiring here: returning (_, false) tells PidIsGrafel to use its FindByName
+// path unchanged. The Windows build provides the real implementation, where
+// per-pid OpenProcess + QueryFullProcessImageName is available even though
+// full process enumeration is not.
+func pidExeBaseName(_ int) (string, bool) {
+	return "", false
+}

--- a/internal/process/pid_is_grafel_test.go
+++ b/internal/process/pid_is_grafel_test.go
@@ -20,17 +20,20 @@ func TestPidIsGrafel_NonPositive(t *testing.T) {
 	}
 }
 
-// On unsupported platforms PidIsGrafel reports ErrUnsupported so callers
-// know to fall back. On supported platforms (darwin/linux) it must succeed and
-// report false for a process that is not grafel.
+// PidIsGrafel must classify a LIVE non-grafel process (the test binary) as
+// not-grafel on every platform that can resolve a live pid's identity:
+//   - darwin/linux via the FindByName ps/proc scan,
+//   - windows via the pid-targeted QueryFullProcessImageName primitive.
+//
+// Only platforms with NO introspection path at all report ErrUnsupported.
 func TestPidIsGrafel_SelfIsNotGrafel(t *testing.T) {
 	ok, err := PidIsGrafel(os.Getpid())
 	switch runtime.GOOS {
-	case "darwin", "linux":
+	case "darwin", "linux", "windows":
 		if err != nil {
 			t.Fatalf("unexpected error on %s: %v", runtime.GOOS, err)
 		}
-		// The test binary is "process.test", not "grafel".
+		// The test binary is "process.test(.exe)", not "grafel".
 		if ok {
 			t.Fatal("test binary must not be classified as an grafel process")
 		}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -20,6 +20,7 @@ package process
 import (
 	"os"
 	"runtime"
+	"strings"
 )
 
 // Footprint is an honest physical-memory reading for the current process.
@@ -111,6 +112,16 @@ func PidIsGrafel(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}
+	// Fast, PID-targeted path: some platforms (Windows) cannot enumerate
+	// every process cheaply but CAN open a single pid and read its image
+	// path. When the primitive is available we compare the executable
+	// basename directly — this is more precise than a name scan and avoids
+	// the ErrUnsupported fallback that would otherwise honor a recycled
+	// foreign pid as "the daemon".
+	if base, ok := pidExeBaseName(pid); ok {
+		return exeBaseNameIsGrafel(base), nil
+	}
+
 	procs, err := FindByName("grafel")
 	if err != nil {
 		// Distinguish "platform can't enumerate" from a transient scan error.
@@ -127,4 +138,13 @@ func PidIsGrafel(pid int) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// exeBaseNameIsGrafel reports whether an executable basename names the grafel
+// binary. It mirrors FindByName's case-insensitive substring match, and strips
+// a trailing platform extension (".exe" on Windows) so "grafel.exe" matches.
+func exeBaseNameIsGrafel(base string) bool {
+	b := strings.ToLower(base)
+	b = strings.TrimSuffix(b, ".exe")
+	return strings.Contains(b, "grafel")
 }

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -4,6 +4,7 @@ package process
 
 import (
 	"fmt"
+	"path/filepath"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -15,6 +16,45 @@ import (
 // a future improvement.
 func FindByName(_ string) ([]Info, error) {
 	return nil, ErrUnsupported
+}
+
+// pidExeBaseName returns the basename of the executable backing pid via a
+// single, pid-targeted OpenProcess + QueryFullProcessImageName. This is the
+// Windows substitute for FindByName-based PidIsGrafel: full process
+// enumeration is unavailable here, but a single pid's image path is cheaply
+// queryable with PROCESS_QUERY_LIMITED_INFORMATION (the same low-privilege
+// handle IsAlive already uses, openable across sessions).
+//
+// The second result is true when the basename was resolved. A false result
+// (process gone, or open/query failed) tells PidIsGrafel it could not verify
+// ownership for this pid — but because we DID try directly here, a live
+// non-grafel pid resolves to a non-matching basename → (false, true), which
+// PidIsGrafel turns into a definitive "not grafel". Only when the image path
+// is genuinely unreadable do we return false, leaving the decision to the
+// caller's liveness probe.
+func pidExeBaseName(pid int) (string, bool) {
+	if pid <= 0 {
+		return "", false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		// Process is gone (ERROR_INVALID_PARAMETER) or otherwise unopenable.
+		// We cannot read the image path; report "unknown" so the caller falls
+		// back to its liveness probe rather than mislabeling the pid.
+		return "", false
+	}
+	defer windows.CloseHandle(h)
+
+	buf := make([]uint16, windows.MAX_PATH)
+	size := uint32(len(buf))
+	if err := windows.QueryFullProcessImageName(h, 0, &buf[0], &size); err != nil {
+		return "", false
+	}
+	full := windows.UTF16ToString(buf[:size])
+	if full == "" {
+		return "", false
+	}
+	return filepath.Base(full), true
 }
 
 // Kill terminates the given PID. os.Process.Kill maps to TerminateProcess


### PR DESCRIPTION
Greens the 11 cross-platform-only failures in `test.yml` (all pass on macOS; fail on ubuntu/windows). Each fix targets a ROOT CAUSE — no weakened assertions, no blanket skips. macOS stays green.

Refs #5311

## Cluster A — Windows path resolution (`\` vs `/`)
`TestResolveSourcePath_FindsFileAcrossRepos`, `TestResolveSourcePath_StaleRepoHintFallsBackToGroupScan`, `TestIssue4332_ImportersConnectAcrossPackages`, `TestIssue4705_ReplaceImportResolvesInternal`

- **Production bug** (`internal/dashboard/v2_source.go`): `resolveSourcePath` used `filepath.Clean` on a slash-domain path. On Windows that rewrites `/`→`\`, breaking the leading-`/` trim and returning a backslash repo-relative path that no longer matches the slash-form paths the dashboard speaks. Switched to `path.Clean` (always `/`); the lone OS-disk boundary stays `filepath.FromSlash` in `tryRepo`. Traversal guard unchanged.
- **Test bug** (`issue4332`/`issue4705`): compared `filepath.Dir(SourceFile)` (OS-separated → `internal\resolve` on Windows) against a `/` literal. `SourceFile` is slash-form, so switched to `path.Dir`.

**Confidence: high.**

## Cluster B — Windows tool-config paths
`TestApplyToolDelta_EnableCursor`, `TestApplyToolDelta_DisableWindsurf`, `TestApplyToolDelta_DisableCodexKeepsClaudeRules`

`ApplyToolDelta` keys result maps by `absRepo(r.Path)`. The tests used `/tmp/repoX`, which is NOT absolute on Windows → `filepath.Abs` rewrites it to `C:\tmp\repoX` → literal-key lookups miss. Test now uses `filepath.Join(os.TempDir(), "repoX")` so `absRepo` returns it unchanged on every OS. **Confidence: high.**

## Cluster C — pid ownership (#5308 follow-up)
`TestAcquirePIDFile_LiveNonGrafelPID_TreatedStale`, `TestPidIsLiveDaemon`

After #5308 gave Windows a real liveness probe, the ownership check still relied on `FindByName` (ErrUnsupported on Windows) → `pidIsLiveDaemon` fell back to "alive ⇒ honor it", so a live NON-grafel pid was wrongly treated as the daemon. Added pid-targeted `pidExeBaseName(pid)`: Windows opens the single pid (`PROCESS_QUERY_LIMITED_INFORMATION`) and reads its image path via `QueryFullProcessImageName`, comparing the exe basename (`.exe`-stripped, case-insensitive contains `grafel`). `PidIsGrafel` consults this first, falling back to `FindByName` only when unavailable. Non-Windows returns `(_, false)` → ps/proc path unchanged. **Confidence: high** (logic + cross-build/vet verified; native-Windows syscall behavior is CI-verified).

## Cluster D — concurrency
`TestConcurrentRegister`

Registry write used a fixed `<path>.tmp` + `os.Rename`. On Windows `MoveFileEx` can fail transiently (sharing violation / access-denied) when the target is momentarily open, and a reused fixed temp name is collision-prone. Now writes a UNIQUE `os.CreateTemp` file and replaces via a short bounded rename retry (`renameReplace`). Mutation is already lock-serialized, so the retry only absorbs the Windows sharing transient; Unix succeeds first try, never sleeps. Verified `go test -race` x3. **Confidence: high.**

## Cluster E — env-specific ORM (ubuntu + windows)
`TestCoordinate_CrossBatchORMFieldLookup`

**ORM diagnostics pulled (ubuntu job of run 27876829146):**
```
READS_FIELD=1 subprocesses=2 processed=2 failed=0 entities=16 rels=5
userModelEntity=true cognitoFieldEntity=true byLang=map[python:16] nonFatalErrors=[]
```
The ORM assertions PASS — the failure was a **data race** (`-race`): two `os/exec` stderr-copier goroutines (one per subprocess) doing `io.Copy` into the SAME `bytes.Buffer` concurrently (`coordinator.go:415/460`). Root cause: `Coordinate` assigns the single shared `cfg.Stderr` to every subprocess `cmd.Stderr`; `os/exec` runs a copier goroutine per command → concurrent unsynchronized writes (a real race that also interleaves stderr in production). Fix: wrap the shared writer in a mutex-guarded `syncWriter`. The race exists on macOS too (timing-hidden); `-race` caught it off-mac. Verified clean under `go test -race`. **Confidence: high.**

## Validation (host = macOS)
- `gofmt -l` on the diff: empty.
- `go vet ./...`: clean. `CGO_ENABLED=0 GOOS=windows go vet/build ./internal/process/`: clean (the only package with new Windows syscall code).
- `go test` (process, daemon, watchreg, install, tooladapter, dashboard, extractors/golang, resolve): all green. ORM + watchreg verified under `-race`.

Note: `install`/`watchreg`/`dashboard`/`extractors/golang`/`extract` transitively pull CGO tree-sitter, so they can't be cross-vetted from macOS (`go-tree-sitter` needs CGO) — CI vets/builds these natively on Windows (with CGO enabled), where the windows `go vet ./...` step already passes.

CI is the real verifier for Windows/Linux — please run and iterate on any still-red test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)