### PR TITLE
fix(watchreg): Windows-safe concurrent register (in-process lock + retry) — last CI test

### DIFF
--- a/internal/daemon/watchreg/lock.go
+++ b/internal/daemon/watchreg/lock.go
@@ -2,6 +2,7 @@ package watchreg
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"time"
 )
@@ -30,6 +31,22 @@ func lockFile(path string) (func(), error) {
 			return func() { _ = os.Remove(path) }, nil
 		}
 		if !errors.Is(err, os.ErrExist) {
+			// On Windows the create can fail transiently even though the lock is not
+			// really held: when another holder has just called os.Remove(path), the
+			// file enters a "pending delete" state and any re-open of that exact name
+			// returns ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION (both surface as
+			// fs.ErrPermission), NOT ErrExist. Treat those the SAME as "lock held":
+			// back off and retry until the delete drains, mirroring the bounded-retry
+			// pattern used for the watchers.json rename. On Unix these errors never
+			// occur, so the loop is unaffected. Any other error (e.g. a bad/unwritable
+			// directory) is a real failure and is returned.
+			if errors.Is(err, fs.ErrPermission) {
+				if time.Now().After(deadline) {
+					return nil, err
+				}
+				time.Sleep(pollEvery)
+				continue
+			}
 			return nil, err
 		}
 		// Lock held — reclaim it if it is stale, else wait.

--- a/internal/daemon/watchreg/watchreg.go
+++ b/internal/daemon/watchreg/watchreg.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -55,9 +56,18 @@ type Entry struct {
 }
 
 // Registry is the on-disk watcher registry. It is safe for concurrent use
-// across processes via a sidecar lock file.
+// both WITHIN a process (an in-process mutex serializes the read-modify-write)
+// and ACROSS processes (a sidecar lock file).
 type Registry struct {
 	path string
+	// mu serializes the read-modify-write of watchers.json for goroutines in the
+	// SAME process. The sidecar lock file only coordinates SEPARATE processes; it
+	// is not re-entrant and, on Windows, a lock file pending deletion by one
+	// goroutine can race the O_CREATE|O_EXCL acquire of another (manifesting as
+	// "Access is denied"). Serializing in-process callers here makes concurrent
+	// Register/Deregister/Sweep deterministic and keeps each process to a single
+	// outstanding lock-file holder at a time.
+	mu sync.Mutex
 }
 
 // New returns a Registry backed by the watchers.json at path (typically
@@ -295,6 +305,15 @@ func renameReplace(src, dst string) error {
 // mutate runs fn under the registry lock against the current entries and writes
 // the result atomically. fn may reuse the input slice's backing array.
 func (r *Registry) mutate(fn func([]Entry) []Entry) error {
+	// Serialize same-process callers first: the cross-process lock file is not
+	// re-entrant and, on Windows, its acquire/release (O_CREATE|O_EXCL + Remove)
+	// races between goroutines. With this mutex held, exactly one goroutine per
+	// process contends for the lock file, eliminating the "Access is denied" race
+	// entirely for the in-process case and guaranteeing the read-modify-write is
+	// atomic w.r.t. other in-process mutators (no lost entries).
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	unlock, err := lockFile(r.path + ".lock")
 	if err != nil {
 		return err


### PR DESCRIPTION
Refs #5311

## Root cause
`TestConcurrentRegister` (20 goroutines registering concurrently) was the only red test left on Windows CI (macOS + ubuntu green). Each goroutine's `Register` failed with `open ...\watchers.json.lock: Access is denied.` and entries were lost (`got 6, want 20`).

The cross-process lock file is acquired via `os.OpenFile(O_CREATE|O_EXCL)` and released via `os.Remove`. On Windows, a file **pending deletion cannot be re-opened by the same name** — the create returns `ERROR_ACCESS_DENIED` (`fs.ErrPermission`), **not** `ErrExist`. `lockFile` only retried on `ErrExist` and returned every other error immediately, so a goroutine racing the release of a just-removed lock failed hard, aborting its read-modify-write and dropping its entry. The sibling `internal/registry` fix (#5312) was never applied here.

## Fix
1. **In-process serialization** — added a `sync.Mutex` to `Registry` so concurrent same-process goroutines serialize the read-modify-write of `watchers.json`. Makes the 20-goroutine test deterministic, keeps at most one in-process lock-file holder at a time (eliminating the self-inflicted Windows release/acquire race), and makes the RMW atomic w.r.t. other in-process mutators → no lost entries.
2. **Windows-safe lock acquire** — treat `fs.ErrPermission` (ERROR_ACCESS_DENIED / ERROR_SHARING_VIOLATION from a pending-delete lock file) the same as "lock held": bounded retry + backoff against the existing deadline instead of failing. Unix never hits this path, so behavior is unchanged.

`watchers.json` write already used the #5312 pattern (unique `CreateTemp` + bounded `renameReplace` retry); no change needed.

## Validation
- `go test ./internal/daemon/watchreg/ -run TestConcurrentRegister -race -count=3` → **PASS**, no race
- `go test ./internal/daemon/watchreg/...` green
- `gofmt -l` clean; `CGO_ENABLED=0 GOOS=windows go vet` + `go build` clean; `go build ./...` exit 0

Do not merge — coordinator merges + runs CI to confirm all-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)