### PR TITLE
fix(mcp): resolve find_callers/neighbors entities by name + qualified name (kill ~35% error rate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- `grafel_find_callers` / `find_callees` / `neighbors` now resolve an entity by
+  name or qualified name (not only the opaque entity_id), returning
+  disambiguation candidates when ambiguous instead of a hard `entity not found`
+  — fixes a ~35% error rate on name-based calls
+  ([#5314](https://github.com/cajasmota/grafel/issues/5314)).
+
+---
+
 ## [0.1.1] — 2026-06-20
 
 ### Fixed

--- a/internal/mcp/find_callers_name_resolution_test.go
+++ b/internal/mcp/find_callers_name_resolution_test.go
@@ -1,0 +1,167 @@
+package mcp
+
+// find_callers_name_resolution_test.go — #5314.
+//
+// grafel_find_callers / find_callees / neighbors used to accept ONLY the opaque
+// "<repo>::<hash>" entity_id and hard-errored ("entity not found") on the
+// name / qualified-name forms agents naturally pass — a ~35% error rate on
+// name-based calls even when the entity clearly exists. The shared
+// resolveEntityArg path now resolves by exact id → unique name/qualified_name →
+// disambiguation candidates when ambiguous, and only the genuine miss errors.
+//
+// These tests pin all five branches on a small fixture graph.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildNameResDoc builds: caller --CALLS--> target, plus two homonym entities
+// (DupName) so the ambiguity branch is exercisable.
+//
+//	core.svc.Caller         (Caller)   --CALLS--> core.svc.Target (Target)
+//	core.a.DupName / core.b.DupName    (two entities, same Name "DupName")
+func buildNameResDoc() *graph.Document {
+	return minDoc(
+		[]graph.Entity{
+			{ID: "ent-target", Name: "Target", QualifiedName: "core.svc.Target", Kind: "Function", SourceFile: "svc.py", StartLine: 10},
+			{ID: "ent-caller", Name: "Caller", QualifiedName: "core.svc.Caller", Kind: "Function", SourceFile: "svc.py", StartLine: 20},
+			{ID: "ent-dup-a", Name: "DupName", QualifiedName: "core.a.DupName", Kind: "Function", SourceFile: "a.py", StartLine: 1},
+			{ID: "ent-dup-b", Name: "DupName", QualifiedName: "core.b.DupName", Kind: "Function", SourceFile: "b.py", StartLine: 1},
+		},
+		[]graph.Relationship{
+			{FromID: "ent-caller", ToID: "ent-target", Kind: "CALLS"},
+		},
+	)
+}
+
+func callersOf(t *testing.T, out map[string]any) []any {
+	t.Helper()
+	c, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T (%+v)", out["callers"], out)
+	}
+	return c
+}
+
+// TestFindCallers_ByHexID is the regression guard: the exact local id behaves
+// exactly as today and is the reference result the name-based cases must match.
+func TestFindCallers_ByHexID(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "ent-target"})
+	if out["entity_name"] != "Target" {
+		t.Fatalf("entity_name = %v, want Target", out["entity_name"])
+	}
+	cs := callersOf(t, out)
+	if len(cs) != 1 {
+		t.Fatalf("want 1 caller, got %d: %+v", len(cs), cs)
+	}
+	if got := cs[0].(map[string]any)["name"]; got != "Caller" {
+		t.Fatalf("caller name = %v, want Caller", got)
+	}
+}
+
+// TestFindCallers_ByBareName: a bare Name that uniquely matches resolves and
+// returns the same result as the hex id — the core ~35%-error-rate fix.
+func TestFindCallers_ByBareName(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "Target"})
+	if out["entity_name"] != "Target" {
+		t.Fatalf("entity_name = %v, want Target", out["entity_name"])
+	}
+	cs := callersOf(t, out)
+	if len(cs) != 1 || cs[0].(map[string]any)["name"] != "Caller" {
+		t.Fatalf("bare-name result != hex-id result: %+v", cs)
+	}
+}
+
+// TestFindCallers_ByQualifiedName: a fully qualified name resolves too.
+func TestFindCallers_ByQualifiedName(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "core.svc.Target"})
+	if out["entity_name"] != "Target" {
+		t.Fatalf("entity_name = %v, want Target", out["entity_name"])
+	}
+	if len(callersOf(t, out)) != 1 {
+		t.Fatalf("qualified-name resolution lost the caller: %+v", out)
+	}
+}
+
+// TestFindCallers_AmbiguousName: a Name shared by 2 entities returns a
+// disambiguation envelope (candidates), NOT a bare error.
+func TestFindCallers_AmbiguousName(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "DupName"})
+	if out["ambiguous"] != true {
+		t.Fatalf("expected ambiguous=true, got %+v", out)
+	}
+	cands, ok := out["candidates"].([]any)
+	if !ok || len(cands) != 2 {
+		t.Fatalf("expected 2 candidates, got %T %+v", out["candidates"], out["candidates"])
+	}
+	// Candidates must carry precise entity_ids the agent can re-issue against.
+	ids := map[string]bool{}
+	for _, c := range cands {
+		ids[c.(map[string]any)["entity_id"].(string)] = true
+	}
+	if !ids["repo1::ent-dup-a"] || !ids["repo1::ent-dup-b"] {
+		t.Fatalf("candidate entity_ids missing precise ids: %+v", ids)
+	}
+}
+
+// TestFindCallers_NonexistentName: a genuine miss still errors verbatim.
+func TestFindCallers_NonexistentName(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"entity_id": "NoSuchEntity"}
+	res, err := srv.handleFindCallers(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected entity-not-found error result, got %+v", res)
+	}
+	if txt := extractResultText(t, res); !strings.Contains(txt, "entity not found") {
+		t.Fatalf("expected 'entity not found', got %q", txt)
+	}
+}
+
+// TestNeighbors_ByBareName: the shared resolver also lights up grafel_neighbors
+// (direction=in delegates to find_callers).
+func TestNeighbors_ByBareName(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	out := callFlowTool(t, srv.handleNeighbors, map[string]any{"entity_id": "Target", "direction": "in"})
+	if len(callersOf(t, out)) != 1 {
+		t.Fatalf("neighbors(in) by name lost the caller: %+v", out)
+	}
+}
+
+// TestNeighbors_Both_ByQualifiedName: direction=both merges callers + callees,
+// both resolved from the qualified name.
+func TestNeighbors_Both_ByQualifiedName(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	out := callFlowTool(t, srv.handleNeighbors, map[string]any{"entity_id": "core.svc.Caller", "direction": "both"})
+	// Caller CALLS Target → callees should include Target.
+	callees, ok := out["callees"].([]any)
+	if !ok || len(callees) != 1 {
+		t.Fatalf("neighbors(both) by qualified name lost callees: %+v", out)
+	}
+	if callees[0].(map[string]any)["name"] != "Target" {
+		t.Fatalf("callee name = %v, want Target", callees[0].(map[string]any)["name"])
+	}
+}
+
+// TestFindCallees_ByBareName: find_callees gains name resolution too.
+func TestFindCallees_ByBareName(t *testing.T) {
+	srv := newTestServer(t, buildNameResDoc())
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{"entity_id": "Caller"})
+	callees, ok := out["callees"].([]any)
+	if !ok || len(callees) != 1 || callees[0].(map[string]any)["name"] != "Target" {
+		t.Fatalf("find_callees by name failed: %+v", out)
+	}
+}

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -191,6 +191,24 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 		}
 	}
 
+	// #5314: shared name/qualified-name resolution. probe is the un-prefixed
+	// entity argument. resolveEntityArg first tries the exact hex id (happy
+	// path, unchanged), then falls back to a unique Name/QualifiedName match,
+	// and returns disambiguation candidates when the name is ambiguous. A
+	// genuine miss leaves (nil,"",nil) so the verbatim "entity not found" error
+	// below still fires. Restricting `repos`/`local` to the resolved entity
+	// keeps the downstream BFS and output shape byte-for-byte identical.
+	probe := local
+	if probe == "" {
+		probe = entityID
+	}
+	if rr, rl, disambig := resolveEntityArg(repos, entityID, probe); disambig != nil {
+		return nil, disambig
+	} else if rr != nil {
+		repos = []*LoadedRepo{rr}
+		local = rl
+	}
+
 	// Default shape: id, name, file, line, hop_count.
 	// Verbose shape: also includes kind, repo.
 	type caller struct {
@@ -537,6 +555,18 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
 			repos = []*LoadedRepo{r}
 		}
+	}
+
+	// #5314: shared name/qualified-name resolution (see findCallersStructured).
+	probe := local
+	if probe == "" {
+		probe = entityID
+	}
+	if rr, rl, disambig := resolveEntityArg(repos, entityID, probe); disambig != nil {
+		return nil, disambig
+	} else if rr != nil {
+		repos = []*LoadedRepo{rr}
+		local = rl
 	}
 
 	// Default shape: id, name, file, line, hop_count.
@@ -921,6 +951,48 @@ func resolveImpactTarget(repos []*LoadedRepo, target string) impactResolution {
 
 	// Pass 3: nothing matched.
 	return impactResolution{}
+}
+
+// resolveEntityArg is the SHARED entity_id resolution path for the neighbor
+// tools (grafel_find_callers / grafel_find_callees / grafel_neighbors). It
+// converts the dominant ~35% error class — agents passing a bare name or a
+// fully qualified name instead of the opaque "<repo>::<hash>" entity_id — into
+// a successful resolution (#5314).
+//
+// Behaviour, layered on top of resolveImpactTarget:
+//  1. Exact local-ID match in any in-scope repo → (repo, localID, nil). This is
+//     the historical happy path; semantics are unchanged so there is no
+//     regression for callers that already pass the hex id.
+//  2. Unique Name / QualifiedName match → (repo, localID, nil). The name-based
+//     call now resolves instead of erroring.
+//  3. Ambiguous (same name on >1 entity) → (nil, "", disambiguation result):
+//     a well-formed `ambiguous` envelope listing the candidate entity_ids so
+//     the agent can re-issue against a precise id, NOT a bare error.
+//  4. No match → (nil, "", nil): the caller emits its own verbatim
+//     `entity not found` error (the genuine not-found case).
+//
+// `probe` is the un-prefixed entity argument (local part of "<repo>::<id>" or
+// the raw entity_id). `repos` is the already repoHint-scoped candidate set, so
+// group/cwd/repo scoping and cross_repo semantics are honoured by construction.
+func resolveEntityArg(repos []*LoadedRepo, entityID, probe string) (*LoadedRepo, string, *mcpapi.CallToolResult) {
+	res := resolveImpactTarget(repos, probe)
+	if len(res.candidates) > 0 {
+		return nil, "", jsonResult(map[string]any{
+			"entity_id":  entityID,
+			"resolved":   false,
+			"ambiguous":  true,
+			"candidates": res.candidates,
+			"count":      0,
+			"reason": fmt.Sprintf("entity_id %q is ambiguous: %d entities share this name. "+
+				"Re-run with one of the precise entity_id values in `candidates`.",
+				entityID, len(res.candidates)),
+		})
+	}
+	if res.repo == nil {
+		// Genuine not-found — caller emits its own verbatim error.
+		return nil, "", nil
+	}
+	return res.repo, res.localID, nil
 }
 
 // handleImpactRadius returns all entities that would be affected if the given


### PR DESCRIPTION
Fixes #5314

## Root cause

`grafel_find_callers` / `find_callees` / the canonical `grafel_neighbors` only
accepted the opaque `"<repo>::<hash>"` entity_id. The per-repo resolution loop
did an exact `getByID()` lookup and, on miss, fell through to
`NewToolResultError("entity not found: "+entityID)`. So a **bare name** or a
**fully qualified name** that uniquely identifies an existing entity was
rejected with a hard error — the entire ~35% error rate on name-based calls.

Reproduced live: entity `AocHarvestViewSet.add_to_queue` (id
`the backend repo::d7b2f6caabf34b79`, qualified_name
`core.views.aoc_harvest_viewset.AocHarvestViewSet.add_to_queue`) resolved by
hex id but errored on both the bare name and the qualified name.

## Fix (shared resolver)

Added `resolveEntityArg`, layered on the **existing** `resolveImpactTarget`
matcher (already used by `grafel_impact_radius`) — no new ad-hoc matcher:

1. Exact local-ID match → unchanged happy path (no regression for hex-id callers).
2. Unique `Name` / `QualifiedName` match → resolves and proceeds.
3. Ambiguous (same name on >1 entity) → returns a well-formed `ambiguous`
   envelope listing candidate entity_ids (reuses the `impactCandidate` type),
   **not** a bare error.
4. Genuine miss → `(nil,"",nil)` so the verbatim `entity not found` error still
   fires.

Wired into both `findCallersStructured` and `findCalleesStructured`; since
`grafel_neighbors` delegates to both, all three tools gain name resolution.
`repos` is already repoHint/group/cwd-scoped at the call site, so cross-repo and
scoping semantics are honoured by construction. Output shape and token budgeting
are unchanged on the success path; the resolved entity simply restricts the
downstream BFS to the right repo + local id.

## Tests

New `internal/mcp/find_callers_name_resolution_test.go` (reuses `newTestServer`
/ `minDoc` / `callFlowTool` fixtures), all green:

- `TestFindCallers_ByHexID` — regression guard (reference result)
- `TestFindCallers_ByBareName` — bare name resolves, == hex-id result
- `TestFindCallers_ByQualifiedName` — qualified name resolves
- `TestFindCallers_AmbiguousName` — returns 2 disambiguation candidates, not an error
- `TestFindCallers_NonexistentName` — genuine miss still errors `entity not found`
- `TestNeighbors_ByBareName` / `TestNeighbors_Both_ByQualifiedName` — neighbors gains it
- `TestFindCallees_ByBareName` — callees gains it

`go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test ./internal/mcp/...`
green (incl. the 8 new tests).