### PR TITLE
fix(windows): end-to-end fixes — MCP named-pipe transport, schtasks locale/SID, watchreg dir, symlink fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   disambiguation candidates when ambiguous instead of a hard `entity not found`
   — fixes a ~35% error rate on name-based calls
   ([#5314](https://github.com/cajasmota/grafel/issues/5314)).
+- **Windows (end-to-end, from user feedback):** the MCP bridge now dials the
+  daemon via `transport.Dial`, selecting the named pipe on Windows (was a
+  hardcoded AF_UNIX `net.Dial("unix", ...)`), so `/mcp` can connect; the offline
+  stub also always carries a valid `inputSchema` so a connection failure surfaces
+  clearly instead of as a cryptic Zod rejection (Refs [#856](https://github.com/cajasmota/grafel/issues/856)).
+- **Windows (end-to-end, from user feedback):** `grafel install` no longer aborts
+  on a clean install — `schtasks` Unload now checks existence via the exit-code
+  based `IsLoaded()` instead of matching English-only error text (worked around a
+  localized "cannot find the file" on non-English Windows) (Refs [#856](https://github.com/cajasmota/grafel/issues/856)).
+- **Windows (end-to-end, from user feedback):** the task user SID is now resolved
+  via the native `os/user` API instead of shelling out to `whoami /user`, which a
+  PATH-shadowing MSYS/Git Bash `whoami` could break; an empty SID degrades to a
+  conditional (omitted) `<UserId>` instead of invalid task XML (Refs [#856](https://github.com/cajasmota/grafel/issues/856)).
+- **Windows (end-to-end, from user feedback):** the watcher PID registry now
+  creates its state directory before taking the lock, fixing a non-fatal
+  "system cannot find the path specified" on a fresh `%AppData%\grafel`
+  (Refs [#856](https://github.com/cajasmota/grafel/issues/856)).
+- **Windows (end-to-end, from user feedback):** cross-repo link passes now fall
+  back to copying `graph.json`/`graph.fb` into the staging dir when `os.Symlink`
+  fails for lack of `SeCreateSymbolicLinkPrivilege`, so cross-repo edges are no
+  longer silently 0 without Developer Mode/admin (Refs [#856](https://github.com/cajasmota/grafel/issues/856)).
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ Full install matrix for grafel. For the five-command path see [quickstart.md](qu
 | Requirement | Notes |
 |-------------|-------|
 | Go 1.26+ | CGO must be enabled (tree-sitter uses a C library) |
-| C compiler | macOS: `xcode-select --install` / Debian-Ubuntu: `apt install build-essential` / Windows: MinGW via MSYS2 |
+| C/C++ compiler | macOS: `xcode-select --install` / Debian-Ubuntu: `apt install build-essential` / Windows: MinGW-w64 (UCRT) via MSYS2 — set **both** `CC` (gcc) and `CXX` (g++): tree-sitter is C, its `yaml` grammar is C++. `CGO_ENABLED=0` → "build constraints exclude all Go files"; missing `CXX` → `exec: "g++": not found`. |
 | Node.js 20+ + npm | Dashboard build only — not needed at runtime after `make build` |
 | git | Required for indexing |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,6 +9,7 @@ This page gets you from zero to a running graph in five commands. For a full ins
 - **Go 1.26+** with CGO enabled. CGO is required because the tree-sitter extractor uses a C library.
   - macOS: `xcode-select --install` (Xcode Command Line Tools)
   - Debian/Ubuntu: `apt install build-essential`
+  - Windows: install [MinGW-w64](https://www.mingw-w64.org/) (UCRT) and set **both** `CC` and `CXX`. tree-sitter is C (needs `CC`/gcc) and its `yaml` grammar is C++ (needs `CXX`/g++). With `CGO_ENABLED=0` the build fails with "build constraints exclude all Go files"; with `CXX` unset it fails with `exec: "g++": not found` after the C step. For example, in PowerShell: `$env:CGO_ENABLED="1"; $env:CC="gcc"; $env:CXX="g++"`.
 - **Node.js 20+** and npm (used to build the embedded dashboard)
 - **git**
 

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -191,19 +192,48 @@ func stageGraphsDir(cfg *registry.GroupConfig) (string, func(), error) {
 			return "", func() {}, err
 		}
 		if hasJSON {
-			if err := os.Symlink(jsonSrc, filepath.Join(dstDir, "graph.json")); err != nil {
+			if err := linkOrCopyFile(jsonSrc, filepath.Join(dstDir, "graph.json")); err != nil {
 				cleanup()
 				return "", func() {}, err
 			}
 		}
 		if hasFB {
-			if err := os.Symlink(fbSrc, filepath.Join(dstDir, "graph.fb")); err != nil {
+			if err := linkOrCopyFile(fbSrc, filepath.Join(dstDir, "graph.fb")); err != nil {
 				cleanup()
 				return "", func() {}, err
 			}
 		}
 	}
 	return tmp, cleanup, nil
+}
+
+// linkOrCopyFile stages src at dst by symlink, falling back to a byte copy when
+// the symlink fails. On Windows, creating a symlink requires
+// SeCreateSymbolicLinkPrivilege (Developer Mode or admin); without it
+// os.Symlink fails with "A required privilege is not held by the client",
+// which previously aborted the cross-repo link passes and left cross-repo
+// edges at 0. The staging dir is a read-only temp that is deleted afterwards,
+// so a copy is an equivalent fallback. On Linux/mac the symlink never fails, so
+// the fallback is never taken and behavior is unchanged. Mirrors the
+// symlink→copy pattern used for skills in internal/install/dev.go.
+func linkOrCopyFile(src, dst string) error {
+	if err := os.Symlink(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 // runPhantomEdgePass is the P5 phantom-edge promotion pass (#769).

--- a/internal/cli/links_linkorcopy_test.go
+++ b/internal/cli/links_linkorcopy_test.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLinkOrCopyFile_Symlinks verifies the happy path: when os.Symlink
+// succeeds (Linux/mac, or Windows with the privilege), dst is a symlink to src
+// and no bytes are copied.
+func TestLinkOrCopyFile_Symlinks(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "graph.fb")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "staged", "graph.fb")
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := linkOrCopyFile(src, dst); err != nil {
+		t.Fatalf("linkOrCopyFile: %v", err)
+	}
+	// Where symlinks are permitted dst should be a symlink; the content must
+	// resolve to the source regardless.
+	if fi, err := os.Lstat(dst); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(dst)
+		if err != nil || target != src {
+			t.Errorf("symlink target = %q (err %v), want %q", target, err, src)
+		}
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "payload" {
+		t.Errorf("dst content = %q (err %v), want %q", got, err, "payload")
+	}
+}
+
+// TestLinkOrCopyFile_FallsBackToCopy simulates the Windows-without-privilege
+// case where os.Symlink fails: linkOrCopyFile must fall back to a byte copy so
+// the cross-repo staging still completes (bug 5). We force the symlink to fail
+// by pre-creating dst as a regular file (os.Symlink returns EEXIST); the
+// fallback then truncates and copies, leaving a real (non-symlink) file whose
+// bytes match src.
+func TestLinkOrCopyFile_FallsBackToCopy(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "graph.json")
+	if err := os.WriteFile(src, []byte("real-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "graph.json.dst")
+	// Pre-create dst so os.Symlink(src, dst) fails with EEXIST, exercising the
+	// copy fallback deterministically on every platform.
+	if err := os.WriteFile(dst, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := linkOrCopyFile(src, dst); err != nil {
+		t.Fatalf("linkOrCopyFile fallback: %v", err)
+	}
+
+	fi, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("expected a copied regular file, got a symlink")
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "real-bytes" {
+		t.Errorf("dst content = %q (err %v), want %q", got, err, "real-bytes")
+	}
+}

--- a/internal/cli/mcp_bridge.go
+++ b/internal/cli/mcp_bridge.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
@@ -17,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/transport"
 )
 
 // bridgeCWD returns the best available working-directory hint for the bridge
@@ -193,7 +193,11 @@ func (b *bridge) getRPCClient() (*rpc.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := net.Dial("unix", socketPath)
+	// transport.Dial selects the OS-appropriate transport: AF_UNIX on
+	// Linux/mac (identical to the previous net.Dial("unix", ...)) and a named
+	// pipe on Windows, matching transport.Listen on the daemon side. Hardcoding
+	// "unix" here meant the bridge could never reach the daemon on Windows.
+	conn, err := transport.Dial(socketPath)
 	if err != nil {
 		return nil, err
 	}
@@ -480,6 +484,12 @@ func (b *bridge) offlineToolList(id any) *rpc2Response {
 		{
 			Name:        "grafel_whoami",
 			Description: "Return grafel status. NOTE: daemon is currently offline — run 'grafel start'.",
+			// Always carry a valid JSON Schema, even in the degraded/offline
+			// path. Without this the field is omitted (omitempty) and Claude
+			// Code's Zod validation rejects the tool with a cryptic
+			// "expected object, received undefined" on inputSchema — masking
+			// the real cause (the daemon was unreachable).
+			InputSchema: json.RawMessage(`{"type":"object"}`),
 		},
 	}
 	result := map[string]any{"tools": stub}

--- a/internal/daemon/service/schtasks_userid_windows_test.go
+++ b/internal/daemon/service/schtasks_userid_windows_test.go
@@ -1,0 +1,70 @@
+//go:build windows
+
+package service
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// renderTaskXML renders the daemon task template with a caller-controlled SID so
+// the conditional <UserId> logic can be exercised deterministically (the
+// production GenerateTaskXML derives the SID from the live user). Internal test
+// (package service) so it can reach the unexported template + vars type.
+func renderTaskXML(t *testing.T, sid string) string {
+	t.Helper()
+	tmpl, err := template.New("task").Parse(daemonTaskXMLTemplate)
+	if err != nil {
+		t.Fatalf("parse template: %v", err)
+	}
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, daemonTaskVars{
+		TaskName: "com.grafel.daemon",
+		UserSID:  sid,
+		BinPath:  `C:\Program Files\grafel\grafel.exe`,
+	}); err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+	return buf.String()
+}
+
+// TestTaskXML_UserIDPresentWhenSIDKnown verifies a non-empty SID renders a
+// <UserId> element carrying that SID (bug 3).
+func TestTaskXML_UserIDPresentWhenSIDKnown(t *testing.T) {
+	const sid = "S-1-5-21-1111111111-2222222222-3333333333-1001"
+	out := renderTaskXML(t, sid)
+	want := "<UserId>" + sid + "</UserId>"
+	if !strings.Contains(out, want) {
+		t.Errorf("expected %q in rendered XML:\n%s", want, out)
+	}
+}
+
+// TestTaskXML_UserIDOmittedWhenSIDEmpty verifies an empty SID degrades to "no
+// <UserId>" (fire on any logon) instead of invalid <UserId></UserId>, which
+// Task Scheduler rejects (bug 3).
+func TestTaskXML_UserIDOmittedWhenSIDEmpty(t *testing.T) {
+	out := renderTaskXML(t, "")
+	if strings.Contains(out, "<UserId>") {
+		t.Errorf("expected no <UserId> element when SID is empty, got:\n%s", out)
+	}
+	if !strings.Contains(out, "<LogonTrigger>") {
+		t.Errorf("expected LogonTrigger even without a UserId:\n%s", out)
+	}
+}
+
+// TestCurrentUserSID_Shape verifies the native-API SID resolver returns either
+// an empty string or a trimmed Windows SID (starts with "S-"), never raw
+// whoami CSV output (bug 3 — no more shelling out to a PATH-shadowable whoami).
+func TestCurrentUserSID_Shape(t *testing.T) {
+	sid := currentUserSID()
+	if sid == "" {
+		return // acceptable: degrades to "any logon"
+	}
+	if sid != strings.TrimSpace(sid) {
+		t.Errorf("SID is not trimmed: %q", sid)
+	}
+	if !strings.HasPrefix(sid, "S-") {
+		t.Errorf("expected a Windows SID (S-...), got %q", sid)
+	}
+}

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -177,9 +177,19 @@ func (m *schtasksManager) IsLoaded() (bool, error) {
 
 func (m *schtasksManager) Unload() error {
 	stopRunningDaemon(m.opts.SocketPath)
+	// If the task isn't registered there is nothing to delete — and on a clean
+	// install schtasks /delete returns a localized "cannot find the file"
+	// error. IsLoaded() is exit-code based (schtasks /query), so it is
+	// locale-independent, unlike the English-only string match below. The
+	// contract of Unload() is that "not loaded" counts as success.
+	if loaded, _ := m.IsLoaded(); !loaded {
+		return nil
+	}
 	// /end stops a running instance; /delete removes the registration. Both are
 	// idempotent against a missing task: "cannot find" / "does not exist" are
-	// success-to-proceed (the desired absent state is reached).
+	// success-to-proceed (the desired absent state is reached). The English
+	// string match below remains as a best-effort fallback for races where the
+	// task disappears between IsLoaded() and /delete.
 	_ = exec.Command("schtasks", "/end", "/tn", taskName).Run()
 	out, err := exec.Command("schtasks", "/delete", "/tn", taskName, "/f").CombinedOutput()
 	if err != nil {

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -41,12 +42,12 @@ const daemonTaskXMLTemplate = `<?xml version="1.0" encoding="UTF-16"?>
   <Triggers>
     <LogonTrigger>
       <Enabled>true</Enabled>
-      <UserId>{{.UserSID}}</UserId>
+      {{if .UserSID}}<UserId>{{.UserSID}}</UserId>{{end}}
     </LogonTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">
-      <UserId>{{.UserSID}}</UserId>
+      {{if .UserSID}}<UserId>{{.UserSID}}</UserId>{{end}}
       <LogonType>InteractiveToken</LogonType>
       <RunLevel>LeastPrivilege</RunLevel>
     </Principal>
@@ -94,20 +95,19 @@ func taskXMLPath() (string, error) {
 }
 
 // currentUserSID returns the SID string for the running user.
-// On failure it returns an empty string — schtasks accepts an empty UserId
-// and defaults to the token user.
+// On failure it returns an empty string — the task template degrades a missing
+// UserId to "fire on any logon" rather than emitting invalid XML.
+//
+// We use the native os/user API rather than shelling out to `whoami /user`:
+// on a Windows dev shell whose PATH resolves `whoami` to the MSYS/Git Bash
+// binary (not System32), that Unix `whoami` does not understand `/user` and
+// fails, leaving the SID empty. On Windows, user.Current().Uid *is* the SID.
 func currentUserSID() string {
-	// whoami /user /fo csv /nh emits: "domain\user","S-1-5-..."
-	out, err := exec.Command("whoami", "/user", "/fo", "csv", "/nh").Output()
+	u, err := user.Current()
 	if err != nil {
 		return ""
 	}
-	r := csv.NewReader(strings.NewReader(strings.TrimSpace(string(out))))
-	records, err := r.Read()
-	if err != nil || len(records) < 2 {
-		return ""
-	}
-	return strings.TrimSpace(records[1])
+	return strings.TrimSpace(u.Uid)
 }
 
 // GenerateTaskXML renders the Task Scheduler XML for the given options.

--- a/internal/daemon/watchreg/watchreg.go
+++ b/internal/daemon/watchreg/watchreg.go
@@ -314,6 +314,15 @@ func (r *Registry) mutate(fn func([]Entry) []Entry) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Ensure the state directory exists before creating the .lock inside it.
+	// On a fresh install the state dir (e.g. %AppData%\grafel on Windows) may
+	// not exist yet, and opening the lock file inside a missing directory fails
+	// with "The system cannot find the path specified". Idempotent: a no-op
+	// when the directory already exists.
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
+		return err
+	}
+
 	unlock, err := lockFile(r.path + ".lock")
 	if err != nil {
 		return err

--- a/internal/daemon/watchreg/watchreg_test.go
+++ b/internal/daemon/watchreg/watchreg_test.go
@@ -1,6 +1,7 @@
 package watchreg
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -10,6 +11,34 @@ import (
 func newTestRegistry(t *testing.T) *Registry {
 	t.Helper()
 	return New(filepath.Join(t.TempDir(), FileName))
+}
+
+// TestMutate_CreatesParentDir verifies that mutating the registry on a fresh
+// install — where the state directory does not exist yet — creates the parent
+// directory instead of failing to open the .lock file. On a clean Windows
+// install %AppData%\grafel does not exist, and the lock open previously failed
+// with "The system cannot find the path specified" (bug 4).
+func TestMutate_CreatesParentDir(t *testing.T) {
+	// Path two levels below a fresh temp dir: neither nested dir exists yet.
+	missingDir := filepath.Join(t.TempDir(), "grafel", "state")
+	r := New(filepath.Join(missingDir, FileName))
+
+	if _, err := os.Stat(missingDir); !os.IsNotExist(err) {
+		t.Fatalf("precondition: dir should not exist yet, stat err = %v", err)
+	}
+	if err := r.Register(Entry{PID: 100, Repo: "/a", OwnerDaemonPID: 1}); err != nil {
+		t.Fatalf("Register on fresh path: %v", err)
+	}
+	if _, err := os.Stat(missingDir); err != nil {
+		t.Errorf("expected parent dir to be created, stat err = %v", err)
+	}
+	entries, err := r.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 || entries[0].PID != 100 {
+		t.Errorf("expected one entry PID 100, got %v", entries)
+	}
 }
 
 func pids(entries []Entry) []int {


### PR DESCRIPTION
Five well-diagnosed, Windows-only bugs that currently block running grafel end-to-end on Windows (MCP + daemon + cross-repo indexing), reported by a user who ran it end-to-end. All five pass macOS/Linux unchanged. `Refs #856` (Phase 2 — Windows: socket transport, path canonicalization, daemon registration).

## Fixes (one commit each)

1. **MCP bridge dials the wrong transport (CRITICAL — `/mcp` can't connect).** `getRPCClient()` hardcoded `net.Dial("unix", socketPath)`, but on Windows the daemon listens on a named pipe (`transport.Listen`). Bridge and daemon never connected, the bridge fell back to its offline stub, and that stub emitted a tool with no `inputSchema` — surfacing as a cryptic `expected object, received undefined` Zod rejection in Claude Code. Now dials via `transport.Dial` (AF_UNIX on Linux/mac, named pipe on Windows) and the offline stub always carries a valid `{"type":"object"}` schema.

2. **`schtasks /delete` is locale-dependent (install aborts).** On a clean install there is no task to delete; `schtasks` returns a localized "cannot find the file" error. The code only tolerated the English strings, so a Spanish Windows treated it as fatal. `Unload()` now checks existence via the exit-code-based `IsLoaded()` first; the English string match remains a best-effort race fallback.

3. **User SID comes back empty because `whoami` is PATH-shadowed (install aborts).** `currentUserSID()` shelled out to `whoami /user`; on a dev shell where PATH resolves `whoami` to the MSYS/Git Bash binary, that rejects `/user`, the SID is empty, and `<UserId></UserId>` is invalid task XML. Now uses the native `os/user` API (on Windows `user.Current().Uid` IS the SID), and `<UserId>` is conditional so an empty SID degrades to "any logon" rather than invalid XML.

4. **Watcher registry locks inside a non-existent dir (non-fatal, registry not written).** `mutate()` created `watchers.json.lock` without ensuring its parent exists; on a fresh `%AppData%\grafel` the lock open failed. Now `MkdirAll`s the parent before taking the lock (idempotent; no-op when it already exists).

5. **Link passes die on unprivileged symlink (cross-repo edges = 0).** Staging `graph.json`/`graph.fb` used `os.Symlink`, which on Windows needs `SeCreateSymbolicLinkPrivilege` (Developer Mode/admin). Without it the pass aborted and cross-repo edges stayed 0. New `linkOrCopyFile` helper tries symlink first and falls back to a byte copy (the staging dir is a read-only temp), mirroring the skills symlink→copy pattern in `internal/install/dev.go`.

Plus a **docs** commit: building from source on Windows needs CGO + a C compiler (tree-sitter is C) **and** `CXX`/g++ (tree-sitter's `yaml` grammar is C++) — install MinGW-w64 (UCRT) and set both `CC` and `CXX`. Documented in `docs/quickstart.md` and `docs/install.md`.

## macOS/Linux safety
- Fixes 2 & 3 live in `schtasks_windows.go` (`//go:build windows`) — not compiled off Windows (mac=launchd, Linux=systemd).
- Fix 1 (`transport.Dial`) resolves to AF_UNIX on Linux/mac — identical to the old `net.Dial("unix", ...)`.
- Fix 4 (`MkdirAll`) is idempotent — a no-op when the dir exists.
- Fix 5 (`linkOrCopyFile`) tries symlink first; the copy fallback only fires on symlink error, which does not happen on Linux/mac.

## Tests
- `schtasks_userid_windows_test.go` (`//go:build windows`): conditional `<UserId>` renders with a non-empty SID, is omitted (not empty) when blank; `currentUserSID` shape.
- watchreg `TestMutate_CreatesParentDir`: `Register` on a fresh path creates the parent dir.
- links `TestLinkOrCopyFile_FallsBackToCopy`: a forced symlink failure falls back to a real-file copy.

## Validation
- `go build ./...` ✅, `go vet ./...` ✅, `gofmt -l` empty ✅ (macOS).
- `CGO_ENABLED=0 GOOS=windows go build`/`go vet ./internal/daemon/service/ ./internal/daemon/watchreg/` ✅ — the `//go:build windows` schtasks file (and its windows-tagged test, via vet) compile under GOOS=windows.
- `go test ./internal/cli/ ./internal/daemon/... ./internal/mcp/...` ✅ green on macOS.
- Note: `CGO_ENABLED=0 GOOS=windows go build ./internal/cli/...` fails only inside the vendored `go-tree-sitter` dependency (it requires CGO) — this is **pre-existing on base `main`** and unrelated to these changes (it is exactly the CGO/CXX docs note). The real Windows build uses CGO + MinGW.

Credit to the user end-to-end Windows report for the precise root causes and diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
