### PR TITLE
fix(windows): locale-invariant command checks + CI lint gate against OS-error-string matching

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -25,6 +25,10 @@ jobs:
           fi
       - name: go vet
         run: go vet ./...
+      # Guard against the locale-bug class (#5317): control flow that matches a
+      # localized OS command output / error string breaks on non-English locales.
+      - name: lint-localematch (locale-invariant command checks)
+        run: go run ./cmd/lint-localematch
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,14 @@ jobs:
 
       - run: go vet ./...
 
+      # Guard against the locale-bug class (#5317): control flow that matches a
+      # localized OS command output / error string (e.g.
+      # strings.Contains(out, "cannot find")) breaks on non-English locales.
+      # Run on Linux only — it is a static AST check, platform-independent.
+      - name: lint-localematch (locale-invariant command checks)
+        if: runner.os == 'Linux'
+        run: go run ./cmd/lint-localematch
+
       # gofmt check — only enforce on Linux to avoid CRLF noise from Windows
       # tooling. macOS and Linux share the same line endings in the repo so
       # running on ubuntu-latest is sufficient.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Changed
+
+- **Windows / locale resilience (#5317):** swept the codebase for control flow
+  that branched on a *localized* OS command output / error string — the bug
+  class behind the Spanish-Windows `schtasks` install failure — and migrated the
+  genuine occurrences to locale-invariant signals (process exit codes, on-disk
+  unit-file checks, and typed `syscall.Errno` values). Migrated: the watcher
+  `Unload()` for schtasks / systemctl / launchctl (`internal/install/watchers/`,
+  which had the same English-text match as the original bug), the daemon
+  launchd `Load()`/`Unload()` (`internal/daemon/service/launchd_darwin.go`), and
+  the selftest Windows "file in use" detector (`cmd/grafel/selftest.go`, now
+  errno-based). The daemon `schtasks` `Unload()` keeps its English match only as
+  a documented best-effort race fallback behind the exit-code `IsLoaded()` check
+  (Refs [#5317](https://github.com/cajasmota/grafel/issues/5317),
+  [#856](https://github.com/cajasmota/grafel/issues/856)).
+
+### Added
+
+- **CI lint gate `lint-localematch` (#5317):** a standard-library Go AST analyzer
+  (`cmd/lint-localematch`) that fails CI when new code matches command
+  output/error text for control flow — `strings.Contains/HasPrefix/HasSuffix/
+  Index/EqualFold` or `regexp.MatchString` whose subject is data-flow-derived
+  from an `exec.Command(...).Output()/CombinedOutput()/Run()` result or an
+  `err.Error()` in an exec-using file. Scoped to files that shell out (low false
+  positives); justified race fallbacks opt out with `// nolint:localematch`.
+  Wired into `make lint`, `pre-merge.yml`, and `test.yml`
+  (Refs [#5317](https://github.com/cajasmota/grafel/issues/5317)).
+
 ### Fixed
 
 - `grafel_find_callers` / `find_callees` / `neighbors` now resolve an entity by

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,16 @@ build-go-only:
 test:
 	$(GO) test -race -count=1 ./...
 
-lint:
-	@echo "lint: (no linter configured yet — run 'go vet ./...' for now)"
+lint: lint-localematch
+	$(GO) vet ./...
+
+# lint-localematch guards against the locale-bug class (#5317): branching on a
+# localized OS command output / error string (e.g. strings.Contains(out,
+# "cannot find")) breaks on non-English locales. Use exit codes / typed errors /
+# structured output instead. Justified race fallbacks use // nolint:localematch.
+.PHONY: lint-localematch
+lint-localematch:
+	$(GO) run ./cmd/lint-localematch
 
 fmt:
 	$(GO) fmt ./...

--- a/cmd/grafel/selftest.go
+++ b/cmd/grafel/selftest.go
@@ -657,9 +657,11 @@ func selftestTeardown(env *selftestEnv, cancel context.CancelFunc, done chan err
 
 // isWindowsFileInUse reports whether err is the Windows "the process cannot
 // access the file because it is being used by another process" failure (sharing
-// violation). It checks both the typed permission error and the OS-specific
-// message text so it matches whether the error arrives wrapped by os.RemoveAll
-// or as a raw *os.PathError. Only consulted on Windows by the teardown backstop.
+// violation) or an access-denied. It relies on locale-invariant signals only:
+// the typed fs.ErrPermission and the underlying numeric syscall.Errno
+// (ERROR_SHARING_VIOLATION=32, ERROR_ACCESS_DENIED=5, ERROR_LOCK_VIOLATION=33),
+// never on the localized OS error message text, which breaks on non-English
+// Windows. Only consulted on Windows by the teardown backstop.
 func isWindowsFileInUse(err error) bool {
 	if err == nil {
 		return false
@@ -667,10 +669,7 @@ func isWindowsFileInUse(err error) bool {
 	if errors.Is(err, fs.ErrPermission) {
 		return true
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "being used by another process") ||
-		strings.Contains(msg, "sharing violation") ||
-		strings.Contains(msg, "access is denied")
+	return isWindowsFileInUseErrno(err)
 }
 
 // removeAllWithRetry is os.RemoveAll with a short bounded backoff. On Windows a

--- a/cmd/grafel/selftest_errno_other.go
+++ b/cmd/grafel/selftest_errno_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+// isWindowsFileInUseErrno is a no-op on non-Windows platforms: the
+// sharing-violation errno semantics it checks are Windows-specific. On Unix an
+// open file can be unlinked, so this path is never the cause of a remove
+// failure.
+func isWindowsFileInUseErrno(err error) bool { return false }

--- a/cmd/grafel/selftest_errno_windows.go
+++ b/cmd/grafel/selftest_errno_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"syscall"
+)
+
+// Windows error numbers (winerror.h). These numeric codes are locale-invariant,
+// unlike the human-readable message strings.
+const (
+	errorAccessDenied     syscall.Errno = 5  // ERROR_ACCESS_DENIED
+	errorSharingViolation syscall.Errno = 32 // ERROR_SHARING_VIOLATION
+	errorLockViolation    syscall.Errno = 33 // ERROR_LOCK_VIOLATION
+)
+
+// isWindowsFileInUseErrno reports whether err unwraps to one of the Windows
+// "file is in use" / access-denied error numbers. It compares numeric
+// syscall.Errno values rather than localized message text.
+func isWindowsFileInUseErrno(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case errorAccessDenied, errorSharingViolation, errorLockViolation:
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/lint-localematch/main.go
+++ b/cmd/lint-localematch/main.go
@@ -1,0 +1,394 @@
+// Command lint-localematch is a low-false-positive guard against the
+// locale-bug CLASS that broke grafel on Spanish Windows (#5317, #856): code
+// that branches on a *localized, human-readable* OS error string — e.g.
+// `strings.Contains(out, "cannot find")` on the output/error of a shelled-out
+// command. Such matches silently stop matching when the OS speaks another
+// language, producing wrong control flow.
+//
+// The right signals are locale-invariant: process exit codes
+// (exec.ExitError.ExitCode()), typed/sentinel errors, structured output
+// (CSV/JSON), or native Go APIs. This linter flags string/regexp matches that
+// are data-flow-derived from command output or a command error, so a new
+// occurrence fails CI before it ships.
+//
+// Heuristic (accuracy over recall — it is a guard, not a prover):
+//
+//   - A file is "in scope" only if it calls exec.Command / exec.CommandContext.
+//     Pure source-parsing extractors that happen to use strings.Contains are
+//     never flagged.
+//   - Within such a file, a call to one of the matcher funcs
+//     (strings.Contains/HasPrefix/HasSuffix/Index/EqualFold,
+//     regexp.MatchString / (*Regexp).MatchString) is flagged when its *subject*
+//     argument is derived from command output. The subject is recognized as:
+//       * a variable whose name looks like captured output
+//         (out, output, stdout, stderr, combined, b, s, ...) AND that variable
+//         was assigned from a .Output()/.CombinedOutput()/.Run() call, OR
+//       * an `<x>.Error()` call (matching on an error message string), where the
+//         file is in scope (an exec error), OR
+//       * a `string(<outputVar>)` conversion of such a variable.
+//   - A `//nolint:localematch` comment on the same line (or the line above)
+//     suppresses the finding — reserved for justified best-effort *race
+//     fallbacks* whose PRIMARY decision is already exit-code/structured (the
+//     Unload() template).
+//
+// Usage:
+//
+//	go run ./cmd/lint-localematch [packages-root ...]   # default: internal cmd
+//
+// Exit status is non-zero when any un-suppressed violation is found.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// matcherFuncs are the text-comparison functions we treat as control-flow
+// matchers. Keyed by "pkg.Func"; (*regexp.Regexp).MatchString is handled by the
+// method-name set below.
+var matcherFuncs = map[string]bool{
+	"strings.Contains":   true,
+	"strings.HasPrefix":  true,
+	"strings.HasSuffix":  true,
+	"strings.Index":      true,
+	"strings.EqualFold":  true,
+	"regexp.MatchString": true,
+}
+
+// matcherMethods are method names (any receiver) we treat as matchers — covers
+// (*regexp.Regexp).MatchString / .Match. Method receivers are not resolved
+// without type info, so we additionally require an output-derived argument,
+// keeping false positives low.
+var matcherMethods = map[string]bool{
+	"MatchString": true,
+}
+
+// outputCaptureMethods mark a value as "captured command output" when a
+// variable is assigned from a call ending in one of these selector names.
+var outputCaptureMethods = map[string]bool{
+	"Output":         true,
+	"CombinedOutput": true,
+}
+
+// outputishNames are variable names that, combined with an in-scope (exec-using)
+// file, we treat as likely command output. Used as a fallback when we cannot
+// trace the assignment (e.g. `s := string(out)` chains across statements).
+var outputishNames = map[string]bool{
+	"out": true, "output": true, "stdout": true, "stderr": true,
+	"combined": true, "outBytes": true, "stdoutBytes": true,
+}
+
+type finding struct {
+	file string
+	line int
+	col  int
+	fn   string
+	arg  string
+}
+
+func main() {
+	roots := os.Args[1:]
+	if len(roots) == 0 {
+		roots = []string{"internal", "cmd"}
+	}
+
+	var files []string
+	for _, root := range roots {
+		_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				if d.Name() == "testdata" || d.Name() == "vendor" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+				files = append(files, path)
+			}
+			return nil
+		})
+	}
+	sort.Strings(files)
+
+	var findings []finding
+	for _, f := range files {
+		fs, err := analyzeFile(f)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "lint-localematch: parse %s: %v\n", f, err)
+			os.Exit(2)
+		}
+		findings = append(findings, fs...)
+	}
+
+	if len(findings) == 0 {
+		fmt.Println("lint-localematch: ok — no localized command-output matching found")
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "lint-localematch: localized command-output / error-string matching detected.")
+	fmt.Fprintln(os.Stderr, "Branch on locale-invariant signals instead: exit codes (exec.ExitError.ExitCode()),")
+	fmt.Fprintln(os.Stderr, "typed/sentinel errors, or structured output (CSV/JSON). See #5317.")
+	fmt.Fprintln(os.Stderr, "Justified best-effort race fallbacks may add a // nolint:localematch comment.")
+	fmt.Fprintln(os.Stderr, "")
+	for _, fnd := range findings {
+		fmt.Fprintf(os.Stderr, "  %s:%d:%d  %s(%s)\n", fnd.file, fnd.line, fnd.col, fnd.fn, fnd.arg)
+	}
+	os.Exit(1)
+}
+
+func analyzeFile(path string) ([]finding, error) {
+	fset := token.NewFileSet()
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	// Scope gate: only files that shell out are considered.
+	if !fileUsesExec(file) {
+		return nil, nil
+	}
+
+	// Build the set of variables known to hold captured command output, by
+	// scanning every assignment whose RHS is a *.Output()/*.CombinedOutput()
+	// call (the lhs name(s) before the err) or a string(<outputVar>) conversion.
+	outputVars := collectOutputVars(file)
+
+	// Collect //nolint:localematch suppression lines.
+	suppressed := collectSuppressions(fset, file)
+
+	var findings []finding
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		fnName, isMatcher := matcherName(call)
+		if !isMatcher {
+			return true
+		}
+		// The subject argument: arg 0 for strings.*; for regexp.MatchString the
+		// subject (the text being searched) is the 2nd arg; for (*Regexp).Match*
+		// the subject is the 1st arg. We check all string args to be safe.
+		subjectArgs := matcherSubjectArgs(call, fnName)
+		for _, arg := range subjectArgs {
+			if !argDerivesFromOutput(arg, outputVars) {
+				continue
+			}
+			pos := fset.Position(call.Pos())
+			if suppressed[pos.Line] {
+				continue
+			}
+			findings = append(findings, finding{
+				file: path, line: pos.Line, col: pos.Column,
+				fn: fnName, arg: exprString(arg),
+			})
+			break
+		}
+		return true
+	})
+	return findings, nil
+}
+
+func fileUsesExec(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == "exec" {
+			if sel.Sel.Name == "Command" || sel.Sel.Name == "CommandContext" {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// collectOutputVars returns the set of identifier names assigned from a command
+// output capture (.Output()/.CombinedOutput()) or a string()/[]byte conversion
+// chain of such a variable.
+func collectOutputVars(file *ast.File) map[string]bool {
+	vars := map[string]bool{}
+	// Iterate to a fixed point so `out := cmd.Output(); s := string(out)` both
+	// land in the set regardless of statement order within a func.
+	for changed := true; changed; {
+		changed = false
+		ast.Inspect(file, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for i, rhs := range assign.Rhs {
+				if !rhsIsOutput(rhs, vars) {
+					continue
+				}
+				// Map to the corresponding lhs name (1:1), or — for the common
+				// `out, err := cmd.Output()` — the first lhs.
+				lhsIdx := i
+				if len(assign.Lhs) == 1 {
+					lhsIdx = 0
+				}
+				if lhsIdx < len(assign.Lhs) {
+					if id, ok := assign.Lhs[lhsIdx].(*ast.Ident); ok && id.Name != "_" {
+						if !vars[id.Name] {
+							vars[id.Name] = true
+							changed = true
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+	return vars
+}
+
+// rhsIsOutput reports whether an RHS expression yields captured command output:
+// a call to *.Output()/*.CombinedOutput(), or string(<knownOutputVar>) /
+// strings.TrimSpace(<knownOutputVar>) and similar single-arg wrappers.
+func rhsIsOutput(rhs ast.Expr, known map[string]bool) bool {
+	call, ok := rhs.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	// *.Output() / *.CombinedOutput()
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+		if outputCaptureMethods[sel.Sel.Name] {
+			return true
+		}
+	}
+	// string(out) / []byte(out) / strings.TrimSpace(out) — propagate from a
+	// known output var passed as the sole interesting arg.
+	for _, a := range call.Args {
+		if id, ok := a.(*ast.Ident); ok && known[id.Name] {
+			return true
+		}
+	}
+	return false
+}
+
+// matcherName classifies a call expression as a known matcher. Returns the
+// canonical "pkg.Func" (or method name) and whether it matched.
+func matcherName(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	// Package-qualified: strings.Contains, regexp.MatchString.
+	if pkg, ok := sel.X.(*ast.Ident); ok {
+		full := pkg.Name + "." + sel.Sel.Name
+		if matcherFuncs[full] {
+			return full, true
+		}
+	}
+	// Method call: re.MatchString(...). Require it to be a recognized matcher
+	// method name; the output-derived-arg check downstream keeps this precise.
+	if matcherMethods[sel.Sel.Name] {
+		return sel.Sel.Name, true
+	}
+	return "", false
+}
+
+// matcherSubjectArgs returns the argument expressions of a matcher call that
+// represent the text being searched (the "haystack").
+func matcherSubjectArgs(call *ast.CallExpr, fnName string) []ast.Expr {
+	switch fnName {
+	case "regexp.MatchString":
+		// MatchString(pattern, s) — subject is arg 1.
+		if len(call.Args) >= 2 {
+			return call.Args[1:2]
+		}
+	case "MatchString":
+		// (*Regexp).MatchString(s) — subject is arg 0.
+		if len(call.Args) >= 1 {
+			return call.Args[0:1]
+		}
+	default:
+		// strings.Contains(s, substr) etc. — subject is arg 0.
+		if len(call.Args) >= 1 {
+			return call.Args[0:1]
+		}
+	}
+	return nil
+}
+
+// argDerivesFromOutput reports whether an argument expression is data-flow
+// derived from command output or a command error message.
+func argDerivesFromOutput(arg ast.Expr, outputVars map[string]bool) bool {
+	switch e := arg.(type) {
+	case *ast.Ident:
+		// `strings.Contains(s, ...)` where s := string(out) etc.
+		return outputVars[e.Name] || outputishNames[e.Name]
+	case *ast.CallExpr:
+		// string(out) inline, strings.ToLower(string(out)), err.Error().
+		if sel, ok := e.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Error" {
+			// <something>.Error() — matching on an error message string. Since
+			// the file is in scope (uses exec), this is an exec/OS error.
+			return true
+		}
+		for _, a := range e.Args {
+			if argDerivesFromOutput(a, outputVars) {
+				return true
+			}
+		}
+	case *ast.ParenExpr:
+		return argDerivesFromOutput(e.X, outputVars)
+	}
+	return false
+}
+
+// collectSuppressions returns the set of line numbers carrying a
+// //nolint:localematch (or //nolint:localematch,...) directive, on the matcher
+// line or the line immediately above.
+func collectSuppressions(fset *token.FileSet, file *ast.File) map[int]bool {
+	lines := map[int]bool{}
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			text := strings.TrimSpace(strings.TrimPrefix(c.Text, "//"))
+			if !strings.HasPrefix(text, "nolint") {
+				continue
+			}
+			if !strings.Contains(text, "localematch") {
+				continue
+			}
+			ln := fset.Position(c.Pos()).Line
+			lines[ln] = true   // same-line trailing comment
+			lines[ln+1] = true // comment on the line above the statement
+		}
+	}
+	return lines
+}
+
+func exprString(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.CallExpr:
+		if sel, ok := v.Fun.(*ast.SelectorExpr); ok {
+			return exprString(sel.X) + "." + sel.Sel.Name + "(…)"
+		}
+		return "…(…)"
+	case *ast.SelectorExpr:
+		return exprString(v.X) + "." + v.Sel.Name
+	case *ast.ParenExpr:
+		return "(" + exprString(v.X) + ")"
+	}
+	return "…"
+}

--- a/cmd/lint-localematch/main.go
+++ b/cmd/lint-localematch/main.go
@@ -20,12 +20,12 @@
 //     (strings.Contains/HasPrefix/HasSuffix/Index/EqualFold,
 //     regexp.MatchString / (*Regexp).MatchString) is flagged when its *subject*
 //     argument is derived from command output. The subject is recognized as:
-//       * a variable whose name looks like captured output
-//         (out, output, stdout, stderr, combined, b, s, ...) AND that variable
-//         was assigned from a .Output()/.CombinedOutput()/.Run() call, OR
-//       * an `<x>.Error()` call (matching on an error message string), where the
-//         file is in scope (an exec error), OR
-//       * a `string(<outputVar>)` conversion of such a variable.
+//   - a variable whose name looks like captured output
+//     (out, output, stdout, stderr, combined, b, s, ...) AND that variable
+//     was assigned from a .Output()/.CombinedOutput()/.Run() call, OR
+//   - an `<x>.Error()` call (matching on an error message string), where the
+//     file is in scope (an exec error), OR
+//   - a `string(<outputVar>)` conversion of such a variable.
 //   - A `//nolint:localematch` comment on the same line (or the line above)
 //     suppresses the finding — reserved for justified best-effort *race
 //     fallbacks* whose PRIMARY decision is already exit-code/structured (the

--- a/cmd/lint-localematch/main_test.go
+++ b/cmd/lint-localematch/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeGo writes src to a temp .go file and returns its path.
+func writeGo(t *testing.T, dir, name, src string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(src), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func TestAnalyzeFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name string
+		src  string
+		want int // expected findings
+	}{
+		{
+			name: "match_on_combinedoutput",
+			src: `package x
+import ("os/exec"; "strings")
+func f() bool {
+	out, _ := exec.Command("schtasks", "/delete").CombinedOutput()
+	return strings.Contains(string(out), "cannot find")
+}`,
+			want: 1,
+		},
+		{
+			name: "match_via_intermediate_var",
+			src: `package x
+import ("os/exec"; "strings")
+func f() bool {
+	out, _ := exec.Command("c").Output()
+	s := string(out)
+	return strings.Contains(s, "No such process")
+}`,
+			want: 1,
+		},
+		{
+			name: "match_on_error_string",
+			src: `package x
+import ("os/exec"; "strings")
+func f() bool {
+	err := exec.Command("c").Run()
+	return strings.Contains(err.Error(), "denied")
+}`,
+			want: 1,
+		},
+		{
+			name: "suppressed_by_nolint",
+			src: `package x
+import ("os/exec"; "strings")
+func f() bool {
+	out, _ := exec.Command("c").CombinedOutput()
+	return strings.Contains(string(out), "cannot find") // nolint:localematch
+}`,
+			want: 0,
+		},
+		{
+			name: "no_exec_in_file_is_ignored",
+			src: `package x
+import "strings"
+func f(s string) bool { return strings.Contains(s, "cannot find") }`,
+			want: 0,
+		},
+		{
+			name: "match_on_unrelated_literal_not_flagged",
+			src: `package x
+import ("os/exec"; "strings")
+func f(name string) bool {
+	_, _ = exec.Command("ps").Output()
+	return strings.Contains(name, "daemon") // name is not output-derived
+}`,
+			want: 0,
+		},
+		{
+			name: "exit_code_check_not_flagged",
+			src: `package x
+import "os/exec"
+func f() bool {
+	err := exec.Command("c").Run()
+	return err == nil
+}`,
+			want: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := writeGo(t, dir, tc.name+".go", tc.src)
+			got, err := analyzeFile(p)
+			if err != nil {
+				t.Fatalf("analyzeFile: %v", err)
+			}
+			if len(got) != tc.want {
+				t.Fatalf("got %d findings, want %d: %+v", len(got), tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -153,30 +153,27 @@ func (m *launchdManager) Unload() error {
 	// tears the service down.
 	stopRunningDaemon(m.opts.SocketPath)
 
-	// bootout unconditionally. launchctl returns err 3 ("No such process") when
-	// the service is not loaded — that is success-to-proceed, not a failure.
-	out, err := exec.Command("launchctl", "bootout", "gui/"+m.uid+"/"+launchLabel).CombinedOutput()
-	if err != nil {
-		s := string(out)
-		if strings.Contains(s, "No such process") || strings.Contains(s, "Boot-out failed: 3") ||
-			strings.Contains(s, "could not find") {
-			return nil // not loaded — desired state already reached
-		}
-		// Other bootout failures (e.g. transient I/O) are non-fatal: the
-		// subsequent Load + readiness poll is the real success signal.
-		return nil
-	}
+	// bootout unconditionally. launchctl exits non-zero when the service is not
+	// loaded (err 3 / "No such process") — that is success-to-proceed, not a
+	// failure. Every bootout outcome (not-loaded, transient I/O, success) is
+	// non-fatal here: the subsequent Load + readiness poll is the real success
+	// signal. So we ignore the result entirely rather than branching on the
+	// localized error text, which would break on non-English macOS.
+	_ = exec.Command("launchctl", "bootout", "gui/"+m.uid+"/"+launchLabel).Run()
 	return nil
 }
 
 func (m *launchdManager) Load() error {
 	out, err := exec.Command("launchctl", "bootstrap", "gui/"+m.uid, m.plistPath).CombinedOutput()
 	if err != nil {
-		s := string(out)
-		// "service already loaded" / err 5 means a previous bootout did not
-		// fully clear it. Converge: the service IS loaded, which is the goal.
-		if strings.Contains(s, "already loaded") || strings.Contains(s, "service already bootstrapped") {
-			return nil
+		// bootstrap exits non-zero (err 5 / "already bootstrapped") when a
+		// previous bootout did not fully clear the service. The goal is "loaded";
+		// confirm convergence via IsLoaded() (which uses the `launchctl list`
+		// exit code, locale-invariant) rather than matching the localized
+		// "already loaded" / "service already bootstrapped" text, which breaks
+		// on non-English macOS.
+		if loaded, _ := m.IsLoaded(); loaded {
+			return nil // already loaded — desired state reached
 		}
 		return fmt.Errorf("launchctl bootstrap: %w\n%s", err, out)
 	}

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -194,7 +194,11 @@ func (m *schtasksManager) Unload() error {
 	out, err := exec.Command("schtasks", "/delete", "/tn", taskName, "/f").CombinedOutput()
 	if err != nil {
 		s := string(out)
-		if strings.Contains(s, "cannot find") || strings.Contains(s, "does not exist") {
+		// best-effort race fallback only; the PRIMARY, locale-invariant decision
+		// is the IsLoaded() exit-code check above (schtasks /query). This English
+		// text-match merely tolerates the task disappearing between IsLoaded() and
+		// /delete and is never the sole signal. See #5317.
+		if strings.Contains(s, "cannot find") || strings.Contains(s, "does not exist") { // nolint:localematch
 			return nil
 		}
 		return fmt.Errorf("schtasks /delete: %w\n%s", err, out)

--- a/internal/install/watchers/loader_darwin.go
+++ b/internal/install/watchers/loader_darwin.go
@@ -40,15 +40,25 @@ func (darwinLoader) Load(u Unit) error {
 
 // Unload bootouts the LaunchAgent for the given unit. Errors are suppressed
 // when the unit was never loaded.
+//
+// "Already gone" is detected via the exit code of `launchctl list <label>`
+// (locale-invariant) rather than by matching the localized bootout error text
+// ("No such process" etc.), which breaks on non-English macOS. If the service
+// is not listed there is nothing to bootout — the desired absent state is
+// already reached, so we report success without shelling out to bootout.
 func (darwinLoader) Unload(u Unit) error {
 	uid := strconv.Itoa(os.Getuid())
-	out, err := exec.Command("launchctl", "bootout", "gui/"+uid+"/"+u.Label()).CombinedOutput()
-	if err != nil {
-		s := string(out)
-		if strings.Contains(s, "No such process") ||
-			strings.Contains(s, "Could not find specified service") ||
-			strings.Contains(s, "No domain") {
-			return nil // already gone
+	// launchctl list <label> exits non-zero when the label is not loaded; that
+	// is the locale-invariant signal that the desired absent state already holds.
+	if err := exec.Command("launchctl", "list", u.Label()).Run(); err != nil {
+		return nil // not loaded — already gone
+	}
+	if out, err := exec.Command("launchctl", "bootout", "gui/"+uid+"/"+u.Label()).CombinedOutput(); err != nil {
+		// Race: the service was listed above but disappeared before bootout.
+		// Re-check via the exit code of `launchctl list`; if it is now gone,
+		// the desired state is reached. Never match the localized error text.
+		if lerr := exec.Command("launchctl", "list", u.Label()).Run(); lerr != nil {
+			return nil // gone now — success-to-proceed
 		}
 		return fmt.Errorf("launchctl bootout %s: %w\n%s", u.Label(), err, out)
 	}

--- a/internal/install/watchers/loader_linux.go
+++ b/internal/install/watchers/loader_linux.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 )
 
 // linuxLoader implements Loader using systemctl --user for Linux systemd units.
@@ -42,17 +41,29 @@ func (linuxLoader) Load(u Unit) error {
 
 // Unload disables and stops the systemd user unit. Idempotent — if the unit
 // is already disabled/stopped the call succeeds.
+//
+// "Already gone" is detected by stat-ing the unit file on disk (locale- and
+// version-invariant) rather than by matching the localized `systemctl disable`
+// error text ("No such file" etc.), which breaks on non-English locales. If the
+// unit file is absent there is nothing to disable.
 func (linuxLoader) Unload(u Unit) error {
-	// --now stops the unit in addition to disabling it.
-	out, err := exec.Command("systemctl", "--user", "disable", "--now", u.Label()+".service").CombinedOutput()
+	path, err := UnitPath(u)
 	if err != nil {
-		s := string(out)
-		if strings.Contains(s, "No such file") ||
-			strings.Contains(s, "not found") ||
-			strings.Contains(s, "does not exist") {
-			return nil // already gone
+		return err
+	}
+	if _, serr := os.Stat(path); os.IsNotExist(serr) {
+		return nil // no unit file — already gone
+	}
+	// --now stops the unit in addition to disabling it.
+	out, derr := exec.Command("systemctl", "--user", "disable", "--now", u.Label()+".service").CombinedOutput()
+	if derr != nil {
+		// Race: the unit file vanished between the stat above and disable.
+		// Re-stat; if it is gone now, the desired absent state is reached.
+		// Never match the localized error text.
+		if _, serr := os.Stat(path); os.IsNotExist(serr) {
+			return nil // gone now — success-to-proceed
 		}
-		return fmt.Errorf("systemctl --user disable %s: %w\n%s", u.Label(), err, out)
+		return fmt.Errorf("systemctl --user disable %s: %w\n%s", u.Label(), derr, out)
 	}
 	return nil
 }

--- a/internal/install/watchers/loader_windows.go
+++ b/internal/install/watchers/loader_windows.go
@@ -71,15 +71,24 @@ func (e errNonFatal) IsNonFatal() bool { return true }
 func (windowsLoader) Unload(u Unit) error {
 	tn := u.Label()
 
+	// "Already gone" is detected via the exit code of `schtasks /query`
+	// (locale-invariant) rather than by matching the localized /delete error
+	// text ("cannot find" etc.), which breaks on non-English Windows. If the
+	// task is not registered there is nothing to delete.
+	if err := exec.Command("schtasks", "/query", "/tn", tn).Run(); err != nil {
+		return nil // task doesn't exist — already gone
+	}
+
 	// Stop any running instance — ignore errors (may not be running).
 	_ = exec.Command("schtasks", "/end", "/tn", tn).Run()
 
 	out, err := exec.Command("schtasks", "/delete", "/tn", tn, "/f").CombinedOutput()
 	if err != nil {
-		s := string(out)
-		if strings.Contains(s, "cannot find") ||
-			strings.Contains(s, "does not exist") {
-			return nil // already gone — treat as success
+		// Race: the task was registered above but disappeared before /delete.
+		// Re-check via the /query exit code; if it is gone now, the desired
+		// absent state is reached. Never match the localized error text.
+		if qerr := exec.Command("schtasks", "/query", "/tn", tn).Run(); qerr != nil {
+			return nil // gone now — success-to-proceed
 		}
 		return fmt.Errorf("schtasks /delete %s: %w\n%s", tn, err, out)
 	}


### PR DESCRIPTION
Fixes #5317 (Refs #856)

Makes the codebase immune to the **locale-bug class** that caused the Spanish-Windows `schtasks` install failure: control flow that branched on a *localized, human-readable* OS command output / error string (`strings.Contains(out, "cannot find")`) silently stops matching when the OS speaks another language. This (A) migrates existing occurrences to locale-invariant signals and (B) adds a CI lint gate against new ones.

## Part A — audit + migration

Swept all packages (priority: `internal/daemon/service/`, `internal/install/`, `internal/cli/`, `*_windows.go`, subprocess wrappers) for `strings.Contains/HasPrefix/Index/EqualFold` / `regexp` on the output or error of an `exec.Command`/`exec.CommandContext`.

| # | Location | Command | Finding | Action |
|---|----------|---------|---------|--------|
| 1 | `internal/install/watchers/loader_windows.go` Unload | `schtasks /delete` | matched `"cannot find"` / `"does not exist"` as **primary** control flow — the *exact same bug* as the original | **Migrated** → existence check via `schtasks /query` exit code first; text-match removed (race re-checks `/query` exit code) |
| 2 | `internal/install/watchers/loader_linux.go` Unload | `systemctl disable --now` | matched `"No such file"` / `"not found"` / `"does not exist"` | **Migrated** → stat the unit file on disk (locale/version-invariant); race re-stats |
| 3 | `internal/install/watchers/loader_darwin.go` Unload | `launchctl bootout` | matched `"No such process"` / `"Could not find specified service"` / `"No domain"` | **Migrated** → `launchctl list` exit code; race re-checks exit code |
| 4 | `internal/daemon/service/launchd_darwin.go` Unload | `launchctl bootout` | matched `"No such process"` / `"Boot-out failed: 3"` / `"could not find"` — but **both** error branches returned nil (dead control flow) | **Migrated** → drop the text match entirely; ignore the result (subsequent Load + readiness poll is the real signal) |
| 5 | `internal/daemon/service/launchd_darwin.go` Load | `launchctl bootstrap` | matched `"already loaded"` / `"service already bootstrapped"` for converge-to-loaded | **Migrated** → confirm via `IsLoaded()` (`launchctl list` exit code) |
| 6 | `cmd/grafel/selftest.go` `isWindowsFileInUse` | `os.RemoveAll` syscall error | matched `"being used by another process"` / `"sharing violation"` / `"access is denied"` (same class, syscall not exec) | **Migrated** → typed `fs.ErrPermission` (already) + numeric `syscall.Errno` (32/5/33) via new `selftest_errno_{windows,other}.go`; text match removed |
| 7 | `internal/daemon/service/schtasks_windows.go` Unload | `schtasks /delete` | matched `"cannot find"` / `"does not exist"` | **Left as documented best-effort race fallback** behind the **primary** exit-code `IsLoaded()` check (the already-merged template); annotated `// nolint:localematch` |

**False positives reviewed and left as-is** (not command-output control flow): `systemd_linux.go` (`is-enabled` machine-stable keywords `enabled`/`static`/`linked`, `ActiveState`/`MainPID` properties, `Environment=HOME=` parse of a file *we* generate); `worktree.go` / `commit_coupling_edges.go` / `scheduler.go` (git porcelain keywords `worktree `/`HEAD `/`branch `, locale-invariant by git contract); `process_darwin.go` (matches a user-supplied process-name needle against `ps`, not localized text); `dashboard/handlers_system.go` (colors grafel's own English log lines); `handlers_updates.go`/`watcher_ctl.go`/`selftest.go:628` (version strings / `\\.\pipe\` paths we construct); `doctor.go` (binary path match). The schtasks/watcher CSV `Status`/`PID`/`Running` parse is column-name-located (resilient to order) — column-name localization is a separate, harder concern left unchanged per the existing design comments.

## Part B — CI lint gate

`cmd/lint-localematch`: a **standard-library** Go AST analyzer (no new deps — `go/parser`+`go/ast`). It flags `strings.Contains/HasPrefix/HasSuffix/Index/EqualFold` and `regexp.MatchString` whose subject argument is data-flow-derived from `exec.Command(...).Output()/CombinedOutput()/Run()` or an `err.Error()` — **only in files that actually call `exec.Command`/`exec.CommandContext`** (scope gate → low false positives, accuracy over recall). Tracks output through `out, _ := cmd.Output()`, `s := string(out)` chains, and `string(out)`/`strings.ToLower(...)` wrappers. Justified race fallbacks opt out with `// nolint:localematch`.

**Why this approach:** `golang.org/x/tools/go/analysis` is not a current dependency; a stdlib AST pass keeps the gate dependency-free and fast, and the exec-scope gate plus output-derivation requirement gives high precision without full type-based data-flow. Unit-tested (`main_test.go`, 7 cases incl. suppression + the false-positive guards).

Wired into `make lint`, `.github/workflows/pre-merge.yml` (every-PR fast gate), and `.github/workflows/test.yml`.

## Lint proof

Clean on the migrated tree:
```
$ go run ./cmd/lint-localematch
lint-localematch: ok — no localized command-output matching found   (exit 0)
```
Catches a deliberately-added violation (`return strings.Contains(string(out), "could not be found")` in `loader_linux.go`):
```
lint-localematch: localized command-output / error-string matching detected.
  internal/install/watchers/loader_linux.go:95:9  strings.Contains(…(…))   (exit 1)
```
After removing the test violation → exit 0 again.

## Validation

`go build ./...` ✅ · `go vet` (darwin + `GOOS=windows`/`GOOS=linux` on touched pkgs) ✅ · `gofmt -l` empty ✅ · `go test ./internal/install/watchers/ ./internal/daemon/service/ ./cmd/lint-localematch/` ✅ green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
