### PR TITLE
feat(windows): CMD install.bat + non-admin/manual install docs (3 methods)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   fails for lack of `SeCreateSymbolicLinkPrivilege`, so cross-repo edges are no
   longer silently 0 without Developer Mode/admin (Refs [#856](https://github.com/cajasmota/grafel/issues/856)).
 
+### Added
+
+- **Windows CMD installer + manual install path.** A new `install.bat` provides
+  a non-PowerShell, non-admin one-line install for `cmd.exe`
+  (`curl -fL …/install.bat -o "%TEMP%\grafel-install.bat" && "%TEMP%\grafel-install.bat"`);
+  it mirrors `install.ps1` exactly (same `%USERPROFILE%\.grafel\bin` prefix,
+  release asset names, `checksums.txt` SHA256 verification, and user-PATH append)
+  using only Windows 10 1803+ built-ins. New `docs/install-windows-manual.md`
+  documents a step-by-step locked-down/air-gapped install, and the install docs
+  (README, `docs/install.md`, `docs/quickstart.md`) now present all three Windows
+  methods — PowerShell, CMD, and manual
+  (Fixes [#5319](https://github.com/cajasmota/grafel/issues/5319), Refs
+  [#5318](https://github.com/cajasmota/grafel/issues/5318),
+  [#856](https://github.com/cajasmota/grafel/issues/856)).
+
 ---
 
 ## [0.1.1] — 2026-06-20

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ On Windows (PowerShell):
 irm https://raw.githubusercontent.com/cajasmota/grafel/main/install.ps1 | iex
 ```
 
+On Windows without PowerShell (CMD):
+
+```bat
+curl -fL https://raw.githubusercontent.com/cajasmota/grafel/main/install.bat -o "%TEMP%\grafel-install.bat" && "%TEMP%\grafel-install.bat"
+```
+
+All Windows paths are non-admin. For a locked-down/manual install see [docs/install-windows-manual.md](docs/install-windows-manual.md).
+
 Then point it at your code and wire it up:
 
 ```sh

--- a/docs/install-windows-manual.md
+++ b/docs/install-windows-manual.md
@@ -1,0 +1,164 @@
+# Manual Windows install
+
+For locked-down, air-gapped, policy-restricted, or CMD-only machines where the
+[PowerShell](install.md#windows--three-ways-to-install) or
+[CMD](install.md#windows--three-ways-to-install) one-liners are not an option.
+Every step below uses only Windows 10 1803+ built-ins and **requires no
+administrator rights** — grafel installs entirely under your user profile.
+
+> **TL;DR for the impatient:** download `grafel_<version>_windows_x86_64.zip`,
+> extract it to `%USERPROFILE%\.grafel\bin`, add that folder to your user PATH,
+> then run `grafel install`.
+
+---
+
+## 1. Pick the right release asset
+
+Open the releases page and grab the **Windows x86_64** archive from the latest
+release:
+
+- https://github.com/cajasmota/grafel/releases/latest
+
+Download the asset named:
+
+```
+grafel_<version>_windows_x86_64.zip
+```
+
+(for example `grafel_0.1.1_windows_x86_64.zip`), along with `checksums.txt` from
+the same release if you want to verify the download (recommended).
+
+> **ARM64 note:** there is no native `windows_arm64` build — the release links a
+> C library (tree-sitter) and GitHub's runners have no Windows-ARM64
+> cross-toolchain. Windows on ARM runs x64 binaries transparently via emulation,
+> so use the `windows_x86_64` archive there too.
+
+Save both files somewhere convenient, e.g. your `Downloads` folder. The commands
+below assume:
+
+```bat
+cd %USERPROFILE%\Downloads
+```
+
+---
+
+## 2. (Optional) Verify the checksum
+
+In **CMD**, compute the SHA256 of the archive and compare it against the line for
+your asset in `checksums.txt`:
+
+```bat
+certutil -hashfile grafel_0.1.1_windows_x86_64.zip SHA256
+```
+
+Then open `checksums.txt` and confirm the hash on the line ending in
+`grafel_0.1.1_windows_x86_64.zip` matches (case-insensitive). If they differ, do
+**not** proceed — re-download the asset.
+
+---
+
+## 3. Extract to the install folder
+
+grafel lives under `%USERPROFILE%\.grafel\bin` (the same location the
+PowerShell and CMD installers use). Create it and extract `grafel.exe` into it:
+
+```bat
+mkdir "%USERPROFILE%\.grafel\bin"
+tar -xf grafel_0.1.1_windows_x86_64.zip -C "%USERPROFILE%\.grafel\bin"
+```
+
+`tar` is built into Windows 10 1803 and later. If you prefer, you can instead
+right-click the `.zip` in File Explorer → **Extract All…**, then move the
+extracted `grafel.exe` into `%USERPROFILE%\.grafel\bin`.
+
+Confirm the binary is in place:
+
+```bat
+"%USERPROFILE%\.grafel\bin\grafel.exe" --version
+```
+
+---
+
+## 4. Add the folder to your PATH
+
+`grafel install` registers the MCP server, git hooks, and watchers — it does
+**not** modify your OS `PATH`. So add the bin folder yourself. Pick either
+method; both affect only your **user** PATH and need no admin rights.
+
+### Option A — CMD (`setx`)
+
+```bat
+setx Path "%PATH%;%USERPROFILE%\.grafel\bin"
+```
+
+> `setx` writes the persisted user PATH but does **not** update the current
+> window. Open a **new** terminal afterwards (or run
+> `set "PATH=%PATH%;%USERPROFILE%\.grafel\bin"` to patch just this session).
+>
+> If your existing user PATH is very long (near the legacy 1024-char limit),
+> prefer Option B so you don't risk truncation.
+
+### Option B — System Properties UI
+
+1. Press <kbd>Win</kbd> and type **"Edit environment variables for your
+   account"**, open it.
+2. Under **User variables for &lt;you&gt;**, select **Path** → **Edit…**.
+3. Click **New** and paste the full path, e.g.
+   `C:\Users\<you>\.grafel\bin`.
+4. **OK** out of every dialog.
+5. Open a **new** terminal so the change takes effect.
+
+---
+
+## 5. Register grafel and verify
+
+In a **new** terminal (so PATH is picked up):
+
+```bat
+grafel install
+```
+
+This registers the MCP entry, installs git hooks and watchers, writes the IDE
+rules files, and (for Claude Code) installs skills. It does not need admin
+rights — the merged symlink fix lets a standard user install everything under
+the user profile.
+
+Then smoke-test:
+
+```bat
+grafel --version
+grafel doctor
+```
+
+`grafel doctor` checks the install and detected AI coding tools. When it's
+green, point grafel at your code:
+
+```bat
+grafel wizard
+```
+
+---
+
+## Upgrading manually
+
+Repeat steps 1–3 with the new release archive (overwrite `grafel.exe` in
+`%USERPROFILE%\.grafel\bin`), then run `grafel install` again. PATH is already
+set, so steps 4 is a one-time thing. Alternatively, once grafel is on PATH,
+`grafel update` handles upgrades for you.
+
+---
+
+## Uninstalling
+
+```bat
+grafel uninstall
+```
+
+removes skills, MCP entries, and stops the daemon (graphs are preserved; add
+`--purge` to remove them too). To finish, delete `%USERPROFILE%\.grafel` and
+remove the bin folder from your user PATH (reverse of step 4).
+
+---
+
+See [install.md](install.md) for the full install matrix and
+[troubleshooting.md](troubleshooting.md) if something doesn't line up.

--- a/docs/install.md
+++ b/docs/install.md
@@ -27,15 +27,31 @@ The script respects `GRAFEL_VERSION` (pin a release tag), `GRAFEL_PREFIX` (insta
 
 ---
 
-## Windows — PowerShell installer
+## Windows — three ways to install
 
-The recommended install path on Windows. Downloads the latest release binary into `%USERPROFILE%\.grafel`.
+All three paths install the same release binary into `%USERPROFILE%\.grafel\bin`, add that folder to your **user** PATH, and run `grafel install`. **None require administrator rights** — everything lives under your user profile. There is no native `windows_arm64` build; on Windows on ARM the x86_64 binary runs under x64 emulation, and the installers select it automatically.
+
+### PowerShell (recommended)
 
 ```powershell
 irm https://raw.githubusercontent.com/cajasmota/grafel/main/install.ps1 | iex
 ```
 
-Windows builds require MSYS2/MinGW64. The installer handles this. Shipped binaries link statically against MinGW — users do not need MinGW installed at runtime.
+### CMD (no PowerShell)
+
+`cmd.exe` can't pipe-execute a remote script the way PowerShell's `iex` can, so download the `.bat` first, then run it:
+
+```bat
+curl -fL https://raw.githubusercontent.com/cajasmota/grafel/main/install.bat -o "%TEMP%\grafel-install.bat" && "%TEMP%\grafel-install.bat"
+```
+
+The `.bat` mirrors the PowerShell installer exactly (same prefix, asset names, SHA256 verification, user-PATH append) using only Windows 10 1803+ built-ins (`curl`, `certutil`, `tar`, `setx`).
+
+### Manual (locked-down / air-gapped)
+
+Download the `windows_x86_64` archive from the [releases page](https://github.com/cajasmota/grafel/releases/latest), extract it, add the folder to PATH, and run `grafel install`. Full step-by-step with copy-pasteable commands: **[install-windows-manual.md](install-windows-manual.md)**.
+
+Both the PowerShell and CMD installers, as well as `GRAFEL_VERSION` / `GRAFEL_PREFIX`, are documented inline at the top of each script. Windows release binaries link statically against MinGW — users do not need MinGW installed at runtime.
 
 ---
 
@@ -45,7 +61,7 @@ Release archives are published at https://github.com/cajasmota/grafel/releases f
 
 Archives per platform: `linux_x86_64`, `linux_arm64`, `macos_x86_64`, `macos_arm64`, `windows_x86_64`.
 
-Extract the archive and move the `grafel` binary to a directory on your `PATH`.
+Extract the archive and move the `grafel` binary to a directory on your `PATH`. On Windows, see [install-windows-manual.md](install-windows-manual.md) for the exact extract + PATH + `grafel install` steps.
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -32,7 +32,13 @@ Windows (PowerShell):
 irm https://raw.githubusercontent.com/cajasmota/grafel/main/install.ps1 | iex
 ```
 
-The installer places `grafel` under `~/.grafel/bin`. Confirm with `grafel --version`.
+Windows without PowerShell (CMD):
+
+```bat
+curl -fL https://raw.githubusercontent.com/cajasmota/grafel/main/install.bat -o "%TEMP%\grafel-install.bat" && "%TEMP%\grafel-install.bat"
+```
+
+The installer places `grafel` under `~/.grafel/bin`. Confirm with `grafel --version`. All Windows paths are non-admin; for a manual/air-gapped install see [install-windows-manual.md](install-windows-manual.md).
 
 **Build from source** (alternative):
 

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,241 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+REM grafel one-line installer for Windows (CMD / no PowerShell, non-admin).
+REM
+REM Usage:
+REM   curl -fL https://raw.githubusercontent.com/cajasmota/grafel/main/install.bat -o "%TEMP%\grafel-install.bat" ^&^& "%TEMP%\grafel-install.bat"
+REM
+REM Environment variables:
+REM   GRAFEL_VERSION   Release tag to install (default: latest, e.g. v0.1.0)
+REM   GRAFEL_PREFIX    Install prefix (default: %USERPROFILE%\.grafel)
+REM
+REM This mirrors install.ps1: same prefix (%USERPROFILE%\.grafel\bin), same
+REM release asset names, same checksums.txt verification, and the same
+REM USER-PATH append. It needs only Windows 10 1803+ built-ins (curl, certutil,
+REM tar, reg, setx) and never requires administrator rights.
+
+set "REPO=cajasmota/grafel"
+
+if defined GRAFEL_PREFIX (
+    set "PREFIX=%GRAFEL_PREFIX%"
+) else (
+    set "PREFIX=%USERPROFILE%\.grafel"
+)
+set "BINDIR=%PREFIX%\bin"
+
+REM Carriage-return literal, used to scrub the trailing CR off curl's HTTP
+REM response headers when resolving the latest version.
+for /f %%R in ('copy /Z "%~f0" nul') do set "CR=%%R"
+set "TMPZIP=%TEMP%\grafel-%RANDOM%%RANDOM%.zip"
+set "TMPSUMS=%TEMP%\grafel-%RANDOM%%RANDOM%-checksums.txt"
+set "TMPEXTRACT=%TEMP%\grafel-extract-%RANDOM%%RANDOM%"
+
+REM --- architecture detection (mirror install.ps1 Get-Arch) ---
+set "PROC=%PROCESSOR_ARCHITECTURE%"
+if defined PROCESSOR_ARCHITEW6432 set "PROC=%PROCESSOR_ARCHITEW6432%"
+
+if /I "%PROC%"=="AMD64" (
+    set "ARCH=x86_64"
+) else if /I "%PROC%"=="ARM64" (
+    REM No native windows/arm64 release artifact is published: the release build
+    REM uses CGO (tree-sitter) and GitHub's Windows runners have no
+    REM windows-arm64 C cross-toolchain. Windows on ARM64 runs x64 binaries
+    REM transparently via emulation, so install the x86_64 archive (#5274).
+    echo   note: no native windows/arm64 build is published; installing the x86_64 build ^(runs under Windows ARM64 x64 emulation^).
+    set "ARCH=x86_64"
+) else if /I "%PROC%"=="x86" (
+    REM 32-bit cmd on 64-bit Windows is handled by PROCESSOR_ARCHITEW6432 above;
+    REM a genuine 32-bit OS is unsupported.
+    echo error: unsupported architecture: x86 ^(32-bit^). grafel ships 64-bit only.
+    goto :fail
+) else (
+    echo error: unsupported architecture: %PROC%
+    goto :fail
+)
+
+REM --- resolve version (mirror install.ps1 Resolve-Version) ---
+if defined GRAFEL_VERSION (
+    if /I not "%GRAFEL_VERSION%"=="latest" (
+        set "VERSION=%GRAFEL_VERSION%"
+    )
+)
+if not defined VERSION (
+    REM /releases/latest 302-redirects to /releases/tag/<version>. curl -sI
+    REM prints the redirect target in the "location:" header; parse the tag.
+    for /f "tokens=2 delims= " %%H in ('curl -fsSLI "https://github.com/%REPO%/releases/latest" 2^>nul ^| findstr /I "^location:"') do (
+        set "LOC=%%H"
+    )
+    if defined LOC (
+        REM strip the trailing CR that HTTP headers carry, then take the last
+        REM path segment (the tag) via %%~nx.
+        if defined CR set "LOC=!LOC:%CR%=!"
+        for %%T in ("!LOC!") do set "VERSION=%%~nxT"
+    )
+)
+if not defined VERSION (
+    echo error: failed to resolve latest release tag. Set GRAFEL_VERSION explicitly ^(e.g. v0.1.0^).
+    goto :fail
+)
+
+REM strip a leading "v" for the asset filename (grafel_<ver>_windows_<arch>.zip)
+set "VERNOV=%VERSION%"
+if "%VERNOV:~0,1%"=="v" set "VERNOV=%VERNOV:~1%"
+
+set "ARCHIVE=grafel_%VERNOV%_windows_%ARCH%.zip"
+set "ARCHIVE_URL=https://github.com/%REPO%/releases/download/%VERSION%/%ARCHIVE%"
+set "CHECKSUMS_URL=https://github.com/%REPO%/releases/download/%VERSION%/checksums.txt"
+
+echo grafel installer
+echo   version: %VERSION%
+echo   target:  windows/%ARCH%
+echo   prefix:  %PREFIX%
+
+if exist "%BINDIR%\grafel.exe" echo   upgrading existing install at %BINDIR%
+
+if not exist "%BINDIR%" mkdir "%BINDIR%"
+
+REM --- download archive (curl, 3 retries) ---
+echo downloading %ARCHIVE_URL%
+curl -fL --retry 3 -o "%TMPZIP%" "%ARCHIVE_URL%"
+if errorlevel 1 (
+    echo error: failed to download %ARCHIVE_URL%
+    goto :fail
+)
+
+echo downloading checksums.txt
+curl -fL --retry 3 -o "%TMPSUMS%" "%CHECKSUMS_URL%"
+if errorlevel 1 (
+    echo error: failed to download %CHECKSUMS_URL%
+    goto :fail
+)
+
+REM --- verify SHA256 against checksums.txt ---
+echo verifying SHA256
+set "EXPECTED="
+for /f "usebackq tokens=1,2" %%A in ("%TMPSUMS%") do (
+    if /I "%%B"=="%ARCHIVE%" set "EXPECTED=%%A"
+)
+if not defined EXPECTED (
+    echo error: checksum for %ARCHIVE% not found in checksums.txt
+    goto :fail
+)
+
+set "ACTUAL="
+REM certutil prints the hash on the line AFTER the "SHA256 hash of file" banner.
+for /f "skip=1 tokens=* delims=" %%H in ('certutil -hashfile "%TMPZIP%" SHA256') do (
+    if not defined ACTUAL (
+        set "LINE=%%H"
+        REM the hash line has no spaces; the "CertUtil:" trailer line does.
+        if not "!LINE:CertUtil=!"=="!LINE!" (
+            rem skip the trailer
+        ) else (
+            set "ACTUAL=!LINE: =!"
+        )
+    )
+)
+if not defined ACTUAL (
+    echo error: failed to compute SHA256 of %TMPZIP%
+    goto :fail
+)
+
+REM normalize case for comparison (certutil is lower-case; checksums.txt too).
+if /I not "%EXPECTED%"=="%ACTUAL%" (
+    echo error: checksum mismatch for %ARCHIVE%
+    echo   expected: %EXPECTED%
+    echo   actual:   %ACTUAL%
+    goto :fail
+)
+
+REM --- extract (tar ships with Windows 10 1803+) ---
+echo extracting
+if not exist "%TMPEXTRACT%" mkdir "%TMPEXTRACT%"
+tar -xf "%TMPZIP%" -C "%TMPEXTRACT%"
+if errorlevel 1 (
+    echo error: failed to extract %TMPZIP%
+    goto :fail
+)
+
+REM locate grafel.exe in the extracted tree (top-level per release.yml).
+set "BINSRC="
+if exist "%TMPEXTRACT%\grafel.exe" set "BINSRC=%TMPEXTRACT%\grafel.exe"
+if not defined BINSRC (
+    for /f "delims=" %%F in ('dir /b /s "%TMPEXTRACT%\grafel.exe" 2^>nul') do (
+        if not defined BINSRC set "BINSRC=%%F"
+    )
+)
+if not defined BINSRC (
+    echo error: archive did not contain grafel.exe
+    goto :fail
+)
+
+copy /Y "%BINSRC%" "%BINDIR%\grafel.exe" >nul
+if errorlevel 1 (
+    echo error: failed to copy grafel.exe into %BINDIR%
+    goto :fail
+)
+
+REM --- add %BINDIR% to the USER PATH (non-admin, never touches system PATH) ---
+REM `grafel install` registers MCP/hooks/watchers but does NOT manage the OS
+REM PATH, so the installer owns it here, exactly like install.ps1's
+REM Add-ToUserPath.
+set "USERPATH="
+for /f "usebackq tokens=2,*" %%A in (`reg query HKCU\Environment /v Path 2^>nul ^| findstr /I "Path"`) do set "USERPATH=%%B"
+
+set "ALREADY="
+if defined USERPATH (
+    REM case-insensitive substring check, padded with ; so we match whole entries.
+    set "PADDED=;!USERPATH!;"
+    set "NEEDLE=;%BINDIR%;"
+    if /I not "!PADDED:%NEEDLE%=!"=="!PADDED!" set "ALREADY=1"
+)
+
+if defined ALREADY (
+    echo   PATH already contains %BINDIR%
+) else (
+    if defined USERPATH (
+        REM trim a single trailing ; then append.
+        if "!USERPATH:~-1!"==";" set "USERPATH=!USERPATH:~0,-1!"
+        setx Path "!USERPATH!;%BINDIR%" >nul
+    ) else (
+        setx Path "%BINDIR%" >nul
+    )
+    if errorlevel 1 (
+        echo   warning: could not update USER PATH automatically.
+        echo   add this folder to PATH manually: %BINDIR%
+    ) else (
+        echo   added %BINDIR% to your USER PATH
+    )
+)
+REM make grafel.exe resolvable in THIS session for the install step below.
+set "PATH=%PATH%;%BINDIR%"
+
+echo.
+REM --- register MCP / hooks / watchers (does NOT touch PATH) ---
+"%BINDIR%\grafel.exe" install
+REM `grafel install` may exit non-zero before any group exists; don't abort the
+REM whole installer on that — the binary is on disk and on PATH.
+
+echo.
+"%BINDIR%\grafel.exe" --version 2>nul
+
+echo.
+echo Done. grafel is installed at %BINDIR%\grafel.exe
+echo Restart your shell ^(or open a new terminal^) so PATH picks up %BINDIR%, then run:
+echo   grafel --version
+echo   grafel wizard
+call :cleanup
+endlocal
+exit /b 0
+
+:fail
+call :cleanup
+echo.
+echo install failed.
+endlocal
+exit /b 1
+
+:cleanup
+if exist "%TMPZIP%" del /f /q "%TMPZIP%" >nul 2>&1
+if exist "%TMPSUMS%" del /f /q "%TMPSUMS%" >nul 2>&1
+if exist "%TMPEXTRACT%" rmdir /s /q "%TMPEXTRACT%" >nul 2>&1
+goto :eof


### PR DESCRIPTION
Fixes #5319

Delivers a non-PowerShell, non-admin Windows install path plus full docs for all three Windows install methods. Mostly script + docs. Refs #5318, #856.

## What `grafel install` does re: PATH (finding)

`grafel install` (`internal/install/`) registers the MCP entry, git hooks, watcher units, IDE rules files, and (Claude Code) skills — all under the user profile. It does **not** touch the OS `PATH` (no `setx` / `HKCU\Environment` / `registerPath` anywhere in `internal/install/` or `cmd/grafel`). PATH ownership lives in the shell installers: `install.ps1`'s `Add-ToUserPath` appends `%USERPROFILE%\.grafel\bin` to the **user** PATH. So `install.bat` mirrors that and owns PATH itself (user PATH only, never system, never admin), then delegates MCP/hooks/watchers to `grafel install`.

## `install.bat` behavior (mirrors install.ps1 exactly)

- Arch via `%PROCESSOR_ARCHITECTURE%` / `%PROCESSOR_ARCHITEW6432%`; AMD64 → `x86_64`; ARM64 prints the "no native windows/arm64, runs under x64 emulation" note and uses `x86_64` (matches install.ps1 + release.yml, which builds windows/amd64 only); genuine 32-bit OS rejected.
- Version: honors `GRAFEL_VERSION`, else resolves `latest` by parsing the `location:` header of the `/releases/latest` 302 (CR-scrubbed) — same approach as install.ps1/install.sh.
- Asset: `grafel_<ver>_windows_x86_64.zip` + `checksums.txt` from GitHub releases — exact names from `.github/workflows/release.yml`.
- Download with `curl -fL --retry 3`; SHA256 via `certutil -hashfile … SHA256` matched against `checksums.txt`, failing loudly on mismatch.
- Extract with `tar -xf` into `%USERPROFILE%\.grafel\bin` (same prefix as install.ps1; honors `GRAFEL_PREFIX`).
- User-PATH append via `reg query HKCU\Environment /v Path` + `setx` (idempotent; never clobbers system PATH; non-admin).
- Runs `grafel.exe install`, prints `--version`, cleans up the temp zip. Every `%VAR%` quoted; `ERRORLEVEL` checked after curl/certutil/tar/copy. Windows 10 1803+ built-ins only.
- `.gitattributes` already enforces `*.bat eol=crlf`, so the file ships with correct CRLF endings.

## Docs added / updated

- **New** `docs/install-windows-manual.md` — step-by-step locked-down/air-gapped manual install (pick asset → optional certutil verify → tar/Explorer extract → setx or System Properties PATH → `grafel install` + `doctor`), copy-pasteable.
- `docs/install.md` — new "Windows — three ways to install" section (PowerShell / CMD / Manual), non-admin framing.
- `README.md` + `docs/quickstart.md` — CMD one-liner + manual-install link alongside the PowerShell one-liner.
- `CHANGELOG.md` — `### Added` bullet under `[Unreleased]`.

## Validation

- `go build ./...` clean (no Go touched; only a pre-existing tree-sitter C warning).
- Self-reviewed the `.bat` for quoting, ERRORLEVEL checks, asset names (match release.yml), and URLs (match install.ps1). **Real end-to-end verification requires a Windows box** — like the rest of the Windows work, the reporter will test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)