### PR TITLE
fix(dashboard): wizard shows all repos of a multi-repo group (feed-terminal expected-count)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **Dashboard wizard showed only ONE repo of a multi-repo group** (Refs
+  [#5326](https://github.com/cajasmota/grafel/issues/5326)). The feed-terminal
+  fallback added for the freeze fix treated the per-repo SSE feed as terminal as
+  soon as *every row seen so far* was `done`/`error`, without knowing how many
+  repos to expect. Under the broker's drop policy the first repo could reach
+  `done` before the second repo emitted a single event, so the feed looked
+  terminal and the wizard tore the SSE subscription down — only one repo row
+  ever rendered (which one was a race, hence inconsistent backend-vs-frontend),
+  even though the backend correctly indexed all repos. The wizard now threads the
+  EXPECTED repo count (the same repo list it registers to start indexing) into
+  the feed: feed-terminal fires only once **all** expected repos have reported a
+  terminal phase, and the job poller remains the primary terminal signal. The
+  EventSource stays subscribed for the whole index, so every repo's rows render.
 - **Dashboard wizard indexing froze mid-extraction and never showed completion;
   rebuild appeared to idle-wait ~5 min** ([#5326](https://github.com/cajasmota/grafel/issues/5326)).
   Three independent defects on the rebuild/progress path:

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -113,8 +113,24 @@ export function ScanWizard(props: ScanWizardProps) {
   // #1527 — subscribe to the per-repo / per-MODULE progress stream once we're
   // on the Index step and have a group. For a monorepo this yields one row per
   // package; for a single repo, one row per repo.
+  //
+  // progressActive gates the subscription on the JOB being active (Index step +
+  // a group) — NOT on `terminal`/`feedTerminal` — so a premature feed-terminal
+  // can't tear the stream down before every repo reports (#5326).
   const progressActive = step === "index" && !!targetGroup;
-  const indexProgress = useIndexProgress(targetGroup, progressActive);
+  // How many repos THIS index registered — the same selection the wizard uses
+  // to start indexing (see runIndex): one per selected child git repo, else one
+  // per selected monorepo package, else 1 for a single repo. Threading this into
+  // the feed lets feed-terminal wait for ALL repos instead of firing after the
+  // first one finishes while the rest are still streaming (#5326).
+  const expectedRepos = scan?.valid
+    ? (scan.childGitRepos?.length ?? 0) > 0
+      ? selectedChildren.size
+      : (scan.packages?.length ?? 0) > 0
+        ? selectedPkgs.size
+        : 1
+    : undefined;
+  const indexProgress = useIndexProgress(targetGroup, progressActive, expectedRepos);
 
   // Reset everything when the dialog closes.
   function reset() {

--- a/webui-v2/src/hooks/use-index-progress.ts
+++ b/webui-v2/src/hooks/use-index-progress.ts
@@ -33,9 +33,11 @@ export interface UseIndexProgress {
   /** True once at least one progress event has arrived. */
   hasData: boolean;
   /**
-   * True once every repo row has reached a terminal (done/error) phase. Used by
-   * the wizard as a FALLBACK terminal signal so the button reaches "Done" even
-   * if the job poller is slow to flip (#5326 bug 1).
+   * True once ALL expected repo rows have reached a terminal (done/error)
+   * phase. Used by the wizard as a FALLBACK terminal signal so the button
+   * reaches "Done" even if the job poller is slow to flip (#5326 bug 1). Gated
+   * on the expected repo count so it can't fire after only the first of several
+   * repos finishes (#5326 multi-repo regression).
    */
   terminal: boolean;
 }
@@ -44,8 +46,19 @@ export interface UseIndexProgress {
  * Subscribe to the per-repo progress stream for `group`. Pass a falsy group or
  * `enabled === false` to stay disconnected (e.g. before the job has a group, or
  * after the wizard closes).
+ *
+ * `expectedRepos` is how many repos this index registered (selected child git
+ * repos, or selected monorepo packages, or 1). It gates the `terminal` flag so
+ * feed-terminal cannot fire after the FIRST repo finishes while later repos are
+ * still streaming (#5326). The EventSource stays subscribed the whole time
+ * `enabled` is true (the wizard gates that on the JOB being active, not on
+ * `terminal`), so every repo's events are received even if one finishes early.
  */
-export function useIndexProgress(group: string | undefined, enabled = true): UseIndexProgress {
+export function useIndexProgress(
+  group: string | undefined,
+  enabled = true,
+  expectedRepos?: number,
+): UseIndexProgress {
   const [rows, setRows] = useState<Map<string, ProgressRow>>(new Map());
   const [connected, setConnected] = useState(false);
 
@@ -89,6 +102,6 @@ export function useIndexProgress(group: string | undefined, enabled = true): Use
     rows: sorted,
     connected,
     hasData: rows.size > 0,
-    terminal: rowsTerminal(sorted),
+    terminal: rowsTerminal(sorted, expectedRepos),
   };
 }

--- a/webui-v2/src/lib/index-progress-fold.test.ts
+++ b/webui-v2/src/lib/index-progress-fold.test.ts
@@ -94,7 +94,7 @@ describe("rowsTerminal — wizard terminal fallback (#5326 bug 1)", () => {
       ev({ repo_slug: "backend", phase: "done", ts: 1 }),
       ev({ repo_slug: "frontend", phase: "running_algorithms", ts: 1 }),
     ]);
-    expect(rowsTerminal(rows)).toBe(false);
+    expect(rowsTerminal(rows, 2)).toBe(false);
   });
 
   it("is true once all repo rows reach done/error", () => {
@@ -102,10 +102,66 @@ describe("rowsTerminal — wizard terminal fallback (#5326 bug 1)", () => {
       ev({ repo_slug: "backend", phase: "done", ts: 1 }),
       ev({ repo_slug: "frontend", phase: "error", error: "boom", ts: 1 }),
     ]);
-    expect(rowsTerminal(rows)).toBe(true);
+    expect(rowsTerminal(rows, 2)).toBe(true);
   });
 
   it("is false for an empty feed (nothing to be terminal about)", () => {
-    expect(rowsTerminal([])).toBe(false);
+    expect(rowsTerminal([], 2)).toBe(false);
+  });
+});
+
+describe("rowsTerminal — expected-repo-count gate (#5326 multi-repo regression)", () => {
+  it("THE BUG: repo A done while repo B has not emitted yet → NOT terminal", () => {
+    // The exact race that broke multi-repo wizards: under the broker's drop
+    // policy the first repo finishes before the second emits a single event, so
+    // only one row exists. Without the expected count this looked terminal and
+    // the feed tore down before repo B ever appeared.
+    const rows = applyAll([
+      ev({ repo_slug: "backend", phase: "done", files_done: 173, files_total: 173, ts: 5 }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rowsTerminal(rows, 2)).toBe(false);
+  });
+
+  it("both expected repos done → terminal", () => {
+    const rows = applyAll([
+      ev({ repo_slug: "backend", phase: "done", ts: 5 }),
+      ev({ repo_slug: "frontend", phase: "done", ts: 5 }),
+    ]);
+    expect(rowsTerminal(rows, 2)).toBe(true);
+  });
+
+  it("all expected rows present but one still in-flight → not terminal", () => {
+    const rows = applyAll([
+      ev({ repo_slug: "backend", phase: "done", ts: 5 }),
+      ev({ repo_slug: "frontend", phase: "resolving_refs", ts: 5 }),
+    ]);
+    expect(rowsTerminal(rows, 2)).toBe(false);
+  });
+
+  it("unknown expectedRepos → never prematurely terminal on partial rows", () => {
+    const rows = applyAll([
+      ev({ repo_slug: "backend", phase: "done", ts: 5 }),
+    ]);
+    // Defer to the job poller rather than firing early.
+    expect(rowsTerminal(rows, undefined)).toBe(false);
+    expect(rowsTerminal(rows)).toBe(false);
+    expect(rowsTerminal(rows, 0)).toBe(false);
+  });
+
+  it("regression: single-repo group still reaches terminal (expectedRepos = 1)", () => {
+    const rows = applyAll([
+      ev({ repo_slug: "backend", phase: "done", files_done: 173, files_total: 173, ts: 5 }),
+    ]);
+    expect(rowsTerminal(rows, 1)).toBe(true);
+  });
+
+  it("more rows than expected (defensive) → still terminal when all done", () => {
+    const rows = applyAll([
+      ev({ repo_slug: "backend", phase: "done", ts: 5 }),
+      ev({ repo_slug: "frontend", phase: "done", ts: 5 }),
+      ev({ repo_slug: "shared", phase: "done", ts: 5 }),
+    ]);
+    expect(rowsTerminal(rows, 2)).toBe(true);
   });
 });

--- a/webui-v2/src/lib/index-progress-fold.ts
+++ b/webui-v2/src/lib/index-progress-fold.ts
@@ -83,9 +83,31 @@ export function fold(
   return next;
 }
 
-/** True once the per-repo feed shows every repo in a terminal (done/error) phase. */
-export function rowsTerminal(rows: ProgressRow[]): boolean {
-  return rows.length > 0 && rows.every((r) => r.phase === "done" || r.phase === "error");
+/**
+ * True once the per-repo feed shows EVERY expected repo in a terminal
+ * (done/error) phase.
+ *
+ * `expectedRepos` is the number of repos the wizard registered for this index
+ * (one per selected child git repo, or one per selected monorepo package, or 1
+ * for a single repo). It is REQUIRED to safely fire feed-terminal: under the
+ * SSE broker's drop policy the first repo can reach `done` before the second
+ * repo emits a single event, so `rows = [first:done]` would look terminal even
+ * though more repos are still coming. Gating on `rows.length >= expectedRepos`
+ * prevents that early fire (#5326) — only when all expected rows exist AND each
+ * is terminal do we report terminal.
+ *
+ * When `expectedRepos` is unknown (undefined / 0), we DELIBERATELY do not fire
+ * feed-terminal on partial rows: we return false and let the job poller be the
+ * terminal source of truth, so a premature "all rows so far are done" can never
+ * tear the feed down before later repos report.
+ */
+export function rowsTerminal(rows: ProgressRow[], expectedRepos?: number): boolean {
+  if (rows.length === 0) return false;
+  // Without a known expected count we can't tell "all repos done" from "the
+  // only repos seen SO FAR are done" — defer to the job poller (return false).
+  if (!expectedRepos || expectedRepos <= 0) return false;
+  if (rows.length < expectedRepos) return false;
+  return rows.every((r) => r.phase === "done" || r.phase === "error");
 }
 
 /** Stable sort for rendering: by repo, then module label. */


### PR DESCRIPTION
## Problem (Refs #5326)

The index wizard showed only **one** repo of a multi-repo group (inconsistently
backend OR frontend), even though the backend correctly indexed ALL repos.

## Root cause

The feed-terminal fallback (added with the #5326 freeze fix) treated the per-repo
SSE feed as terminal as soon as *every row seen so far* was `done`/`error` —
`rowsTerminal(rows)` had no idea how many repos to expect. The SSE events do carry
a distinct `repo_slug` per repo and the group genuinely indexes both
(`rebuild: done repos=2`), but under the broker's drop policy the **first** repo
can reach `done` before the **second** repo emits its first event. At that moment
`rows = [first:done]` → `rowsTerminal` true → the wizard flips `terminal` → the
SSE subscription tears down before the second repo reports → only one repo row
ever renders. Which repo "wins" is a race, hence the inconsistent backend-vs-frontend.

## Fix (frontend only)

Thread the **expected repo count** — the same repo list the wizard registers to
start indexing — into the feed so feed-terminal can't fire early:

- `index-progress-fold.ts`: `rowsTerminal(rows, expectedRepos?)` is true only when
  `expectedRepos` is known **AND** `rows.length >= expectedRepos` **AND** every row
  is `done`/`error`. With an unknown/0 count it returns `false` (defers to the job
  poller) rather than firing on partial rows. Pure function.
- `use-index-progress.ts`: hook accepts `expectedRepos` and forwards it; the
  EventSource stays subscribed for the whole index (gated on the job being active,
  not on `terminal`), so every repo's events arrive.
- `scan-wizard.tsx`: computes `expectedRepos` from the registered selection
  (selected child git repos → their count, else selected monorepo packages → their
  count, else 1) and passes it to `useIndexProgress`. `progressActive` keeps the
  feed enabled through completion.

The **job poller stays the primary terminal signal**; feed-terminal is now a
correct fallback, so the original #5326 freeze does not return. The one-row-per-repo
dedup and the modal size from #5329 are untouched.

## Tests (vitest, `src/lib/index-progress-fold.test.ts`)

- 2 expected repos, repo A `done` while repo B hasn't emitted → `rowsTerminal(rows, 2)` **false** (the exact bug).
- both repos `done` → terminal true.
- unknown `expectedRepos` (undefined/0) → not prematurely terminal on partial rows.
- regression: single-repo group (`expectedRepos = 1`) still reaches terminal.
- existing 2-repo terminal tests updated to pass the expected count.

## Validation

- `npm ci && npm run build` (tsc + vite) clean.
- `tsc --noEmit` / `npm run lint` clean.
- `npm test` green (16 files, 154 tests; the fold suite is 16 tests, all pass).
- Did NOT run `make dashboard-build` / touch `internal/dashboard/dist`.