### PR TITLE
feat(dashboard): wizard main progress reflects real per-repo/phase progress + phase label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Changed
 
+- **Index wizard main progress bar now reflects real progress (#5332):** the
+  wizard's top progress bar was driven solely by the coarse job poller, which
+  barely moves during indexing — so it looked frozen near 0% even while every
+  repo was at "Materializing"/"Indexed". It now derives a real aggregate from
+  the per-repo feed (each repo contributes a phase-weighted fraction that
+  advances as it crosses phase boundaries, including through the long
+  sub-progress-less "Materializing" phase), and the header shows the current
+  overall phase ("Scanning…", "Extracting AST…", …, "Materializing graph…",
+  "Done") instead of a static "Indexing…". The active bar also gets a tasteful
+  shimmer (respecting `prefers-reduced-motion`) so it never reads as stuck
+  ([#5332](https://github.com/cajasmota/grafel/issues/5332)).
 - **Windows / locale resilience (#5317):** swept the codebase for control flow
   that branched on a *localized* OS command output / error string — the bug
   class behind the Spanish-Windows `schtasks` install failure — and migrated the

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -52,6 +52,7 @@ import {
   useFsList,
 } from "@/hooks/use-wizard";
 import { useIndexProgress } from "@/hooks/use-index-progress";
+import { aggregateProgress, overallPhaseLabel } from "@/lib/index-progress-fold";
 import { IndexProgressFeed } from "@/components/chrome/index-progress-feed";
 import { ApiError } from "@/lib/api";
 import type { ScanInspectReply, WizardRepo } from "@/data/types";
@@ -263,6 +264,26 @@ export function ScanWizard(props: ScanWizardProps) {
         ? "failed"
         : "done"
       : jobStatus;
+
+  // Main progress bar (#5332). The job-poller value (jobProgress) barely moves
+  // during indexing, so the bar looked frozen near 0% even when repos were at
+  // "Materializing"/"Indexed". Derive a real aggregate from the per-repo feed:
+  // each repo contributes a phase-weighted fraction (advancing as it crosses
+  // phase boundaries, even through sub-progress-less phases like Materializing).
+  // Use the feed value when it has data; otherwise fall back to jobProgress.
+  // Once terminal, pin to 100%.
+  const aggregate = aggregateProgress(indexProgress.rows, expectedRepos);
+  const barProgress = terminal
+    ? 100
+    : indexProgress.hasData
+      ? aggregate
+      : jobProgress;
+  // Overall phase label from the least-advanced active repo, so the header
+  // reflects what the index is actually doing instead of a static string.
+  const phaseLabel = overallPhaseLabel(indexProgress.rows, terminal);
+  // Subtle "alive" pulse while non-terminal — especially during the
+  // sub-progress-less phases that would otherwise look frozen.
+  const barActive = !terminal;
 
   return (
     <Dialog
@@ -722,7 +743,11 @@ export function ScanWizard(props: ScanWizardProps) {
               )}
               <span className="text-sm text-text-2" data-testid="wizard-status">
                 {effectiveStatus === "queued" && "Queued…"}
-                {effectiveStatus === "running" && (job.data?.message || "Indexing…")}
+                {/* While running, surface the current overall phase (derived from
+                    the least-advanced active repo) instead of a static string,
+                    so "Materializing graph…" no longer reads as stuck (#5332). */}
+                {effectiveStatus === "running" &&
+                  (indexProgress.hasData ? phaseLabel : job.data?.message || "Indexing…")}
                 {effectiveStatus === "done" && (job.data?.message || "Indexing complete.")}
                 {effectiveStatus === "failed" && (job.data?.error || "Indexing failed.")}
                 {!effectiveStatus && "Starting…"}
@@ -738,8 +763,15 @@ export function ScanWizard(props: ScanWizardProps) {
                     : effectiveStatus === "done"
                       ? "bg-success"
                       : "bg-accent",
+                  // A tasteful shimmer keeps the bar visibly alive during the
+                  // sub-progress-less phases (resolving/algorithms/materializing)
+                  // that advance only at phase boundaries (#5332). Respects
+                  // prefers-reduced-motion via the keyframe utility.
+                  barActive && "wizard-bar-pulse",
                 )}
-                style={{ width: `${effectiveStatus === "done" ? 100 : jobProgress}%` }}
+                style={{ width: `${barProgress}%` }}
+                data-testid="wizard-progress-bar"
+                data-progress={barProgress}
               />
             </div>
 

--- a/webui-v2/src/lib/index-progress-fold.test.ts
+++ b/webui-v2/src/lib/index-progress-fold.test.ts
@@ -1,7 +1,29 @@
 import { describe, it, expect } from "vitest";
 
-import { fold, rowKey, rowsTerminal, sortRows } from "./index-progress-fold";
+import {
+  aggregateProgress,
+  fold,
+  overallPhaseLabel,
+  rowFraction,
+  rowKey,
+  rowsTerminal,
+  sortRows,
+} from "./index-progress-fold";
 import type { ProgressEvent, ProgressRow } from "@/data/types";
+
+/** Minimal ProgressRow builder for the aggregate/label tests. */
+function row(p: Partial<ProgressRow>): ProgressRow {
+  return {
+    key: p.repoSlug ?? "backend",
+    repoSlug: "backend",
+    phase: "extracting_ast",
+    filesDone: 0,
+    filesTotal: 0,
+    entitiesSoFar: 0,
+    ts: 1,
+    ...p,
+  };
+}
 
 function ev(p: Partial<ProgressEvent>): ProgressEvent {
   return {
@@ -163,5 +185,126 @@ describe("rowsTerminal — expected-repo-count gate (#5326 multi-repo regression
       ev({ repo_slug: "shared", phase: "done", ts: 5 }),
     ]);
     expect(rowsTerminal(rows, 2)).toBe(true);
+  });
+});
+
+describe("rowFraction — phase-weighted per-repo completion (#5332)", () => {
+  it("done / error count as 100%", () => {
+    expect(rowFraction(row({ phase: "done" }))).toBe(1);
+    expect(rowFraction(row({ phase: "error" }))).toBe(1);
+  });
+
+  it("scanning is the bottom band (0%)", () => {
+    expect(rowFraction(row({ phase: "scanning" }))).toBe(0);
+  });
+
+  it("extracting_ast adds the files slice within its band", () => {
+    // base = 1/5 = 0.2; +50% of the 0.2 band = 0.3
+    expect(rowFraction(row({ phase: "extracting_ast", filesDone: 50, filesTotal: 100 }))).toBeCloseTo(0.3);
+  });
+
+  it("sub-progress-less phases advance only via their band", () => {
+    expect(rowFraction(row({ phase: "resolving_refs" }))).toBeCloseTo(0.4);
+    expect(rowFraction(row({ phase: "running_algorithms" }))).toBeCloseTo(0.6);
+    expect(rowFraction(row({ phase: "materializing" }))).toBeCloseTo(0.8);
+  });
+});
+
+describe("aggregateProgress (#5332)", () => {
+  it("single repo extracting at 50% files → sensible mid value", () => {
+    const p = aggregateProgress([row({ phase: "extracting_ast", filesDone: 50, filesTotal: 100 })]);
+    expect(p).toBe(30); // 0.3 * 100
+  });
+
+  it("one repo done + one extracting → between the two", () => {
+    const p = aggregateProgress([
+      row({ repoSlug: "a", phase: "done" }),
+      row({ repoSlug: "b", phase: "extracting_ast", filesDone: 0, filesTotal: 100 }),
+    ]);
+    // (1 + 0.2) / 2 = 0.6
+    expect(p).toBe(60);
+    expect(p).toBeGreaterThan(0);
+    expect(p).toBeLessThan(100);
+  });
+
+  it("all done → 100", () => {
+    const p = aggregateProgress([
+      row({ repoSlug: "a", phase: "done" }),
+      row({ repoSlug: "b", phase: "done" }),
+    ]);
+    expect(p).toBe(100);
+  });
+
+  it("unknown expectedRepos → averages over present rows", () => {
+    const p = aggregateProgress([row({ phase: "materializing" })], undefined);
+    expect(p).toBe(80);
+  });
+
+  it("expectedRepos counts not-yet-reporting repos as 0 (bar doesn't jump)", () => {
+    // 1 of 4 expected repos reporting, that one done → 1/4 = 25%
+    const p = aggregateProgress([row({ phase: "done" })], 4);
+    expect(p).toBe(25);
+  });
+
+  it("empty / zero denominator → 0", () => {
+    expect(aggregateProgress([])).toBe(0);
+    expect(aggregateProgress([], 0)).toBe(0);
+  });
+
+  it("is clamped to [0,100]", () => {
+    const p = aggregateProgress([row({ phase: "done" })], 1);
+    expect(p).toBe(100);
+  });
+
+  it("does not go backwards across a normal phase sequence (monotonic-ish)", () => {
+    const seq: ProgressRow["phase"][] = [
+      "scanning",
+      "extracting_ast",
+      "resolving_refs",
+      "running_algorithms",
+      "materializing",
+      "done",
+    ];
+    let last = -1;
+    for (const phase of seq) {
+      const p = aggregateProgress([row({ phase, filesDone: 100, filesTotal: 100 })], 1);
+      expect(p).toBeGreaterThanOrEqual(last);
+      last = p;
+    }
+  });
+});
+
+describe("overallPhaseLabel (#5332)", () => {
+  it("maps each phase to its human label", () => {
+    expect(overallPhaseLabel([row({ phase: "scanning" })])).toBe("Scanning…");
+    expect(overallPhaseLabel([row({ phase: "extracting_ast" })])).toBe("Extracting AST…");
+    expect(overallPhaseLabel([row({ phase: "resolving_refs" })])).toBe("Resolving references…");
+    expect(overallPhaseLabel([row({ phase: "running_algorithms" })])).toBe("Running algorithms…");
+    expect(overallPhaseLabel([row({ phase: "materializing" })])).toBe("Materializing graph…");
+  });
+
+  it("reflects the LEAST-advanced active repo", () => {
+    const label = overallPhaseLabel([
+      row({ repoSlug: "a", phase: "materializing" }),
+      row({ repoSlug: "b", phase: "extracting_ast" }),
+    ]);
+    expect(label).toBe("Extracting AST…");
+  });
+
+  it("ignores terminal rows when picking the least-advanced active phase", () => {
+    const label = overallPhaseLabel([
+      row({ repoSlug: "a", phase: "done" }),
+      row({ repoSlug: "b", phase: "materializing" }),
+    ]);
+    expect(label).toBe("Materializing graph…");
+  });
+
+  it("terminal flag → Done", () => {
+    expect(overallPhaseLabel([row({ phase: "extracting_ast" })], true)).toBe("Done");
+  });
+
+  it("all rows terminal → Done", () => {
+    expect(overallPhaseLabel([row({ phase: "done" })])).toBe("Done");
+    expect(overallPhaseLabel([])).toBe("Done");
   });
 });

--- a/webui-v2/src/lib/index-progress-fold.ts
+++ b/webui-v2/src/lib/index-progress-fold.ts
@@ -110,6 +110,98 @@ export function rowsTerminal(rows: ProgressRow[], expectedRepos?: number): boole
   return rows.every((r) => r.phase === "done" || r.phase === "error");
 }
 
+/* ------------------------------------------------------------------
+   Aggregate progress + phase label (#5332).
+
+   The wizard's MAIN progress bar used to be driven solely by the coarse
+   job-poller value, which barely moves during indexing (it stayed near 0%
+   even while every repo was at "Materializing"/"Indexed"), so the bar looked
+   frozen. These pure helpers derive a real aggregate percentage and a
+   human-readable overall-phase label straight from the per-repo feed rows,
+   so the bar advances as repos cross phase boundaries — including through the
+   long, sub-progress-less "Materializing" phase.
+   ------------------------------------------------------------------ */
+
+/** Number of bands the [0,100] bar is split into — one per non-terminal phase. */
+const PHASE_BANDS = 5;
+
+/**
+ * Phase-weighted completion fraction (0..1) for a single repo row.
+ *
+ *   base   = phaseIndex / 5     (each phase is a 20% band)
+ *   within `extracting_ast` we have real file granularity, so add the
+ *          filesDone/filesTotal slice of that one band.
+ *   done   = 1 (100%)
+ *   error  = counts as 100% so a failed repo doesn't peg the average low.
+ *
+ * The other sub-progress-less phases (resolving_refs / running_algorithms /
+ * materializing) still advance the bar via their phase band as the repo
+ * crosses into them — that's what keeps "Materializing" from looking stuck.
+ */
+export function rowFraction(row: Pick<ProgressRow, "phase" | "filesDone" | "filesTotal">): number {
+  if (row.phase === "done" || row.phase === "error") return 1;
+  const idx = PHASE_ORDER[row.phase]; // 0..4 for non-terminal phases
+  const base = idx / PHASE_BANDS;
+  if (row.phase === "extracting_ast" && row.filesTotal > 0) {
+    const slice = Math.min(1, Math.max(0, row.filesDone / row.filesTotal));
+    return base + slice / PHASE_BANDS;
+  }
+  return base;
+}
+
+/**
+ * Aggregate progress (0..100) across all repos, for the wizard's main bar.
+ *
+ * Each repo contributes its phase-weighted `rowFraction`; we average across
+ * `expectedRepos` when known (so repos that have not reported yet count as 0
+ * and the bar doesn't jump when a late repo first appears), otherwise across
+ * the rows we actually have. Returns 0 when there's nothing to show.
+ *
+ * Callers should still display 100 once the wizard is terminal — this helper
+ * only reflects the rows it's given (a repo can be at "done" while another is
+ * mid-extraction).
+ */
+export function aggregateProgress(
+  rows: Pick<ProgressRow, "phase" | "filesDone" | "filesTotal">[],
+  expectedRepos?: number,
+): number {
+  const denom =
+    expectedRepos && expectedRepos > 0 ? Math.max(expectedRepos, rows.length) : rows.length;
+  if (denom <= 0) return 0;
+  const sum = rows.reduce((acc, r) => acc + rowFraction(r), 0);
+  const pct = (sum / denom) * 100;
+  // Clamp into [0,100]; the wizard owns the final "100% once terminal" jump.
+  return Math.min(100, Math.max(0, Math.round(pct)));
+}
+
+/** Human label for an overall indexing phase, shown in the wizard header. */
+const PHASE_LABEL: Record<ProgressRow["phase"], string> = {
+  scanning: "Scanning…",
+  extracting_ast: "Extracting AST…",
+  resolving_refs: "Resolving references…",
+  running_algorithms: "Running algorithms…",
+  materializing: "Materializing graph…",
+  done: "Done",
+  error: "Done",
+};
+
+/**
+ * Overall-phase label for the wizard header, derived from the LEAST-advanced
+ * active (non-terminal) repo — that's the phase the whole index is gated on.
+ * When `terminal` (or every row is terminal / there are no active rows), the
+ * label is "Done".
+ */
+export function overallPhaseLabel(rows: ProgressRow[], terminal?: boolean): string {
+  if (terminal) return "Done";
+  const active = rows.filter((r) => r.phase !== "done" && r.phase !== "error");
+  if (active.length === 0) return "Done";
+  // Least-advanced active phase gates overall progress.
+  const least = active.reduce((min, r) =>
+    PHASE_ORDER[r.phase] < PHASE_ORDER[min.phase] ? r : min,
+  );
+  return PHASE_LABEL[least.phase];
+}
+
 /** Stable sort for rendering: by repo, then module label. */
 export function sortRows(rows: Iterable<ProgressRow>): ProgressRow[] {
   return [...rows].sort((a, b) => {

--- a/webui-v2/src/styles/app.css
+++ b/webui-v2/src/styles/app.css
@@ -162,6 +162,31 @@
   animation: flow-replay-bounce 180ms ease-out;
 }
 
+/* ── Wizard progress bar pulse (#5332) ───────────────────────────────────────
+   The index wizard's main bar advances via phase-weighted aggregate progress,
+   but the sub-progress-less phases (resolving refs / running algorithms /
+   materializing) only move it at phase boundaries — so a subtle traveling
+   shimmer keeps the active (non-terminal) bar visibly alive between jumps and
+   reassures the user it isn't frozen. Tasteful, low-contrast; the global
+   prefers-reduced-motion rule below collapses it to a no-op. */
+@keyframes wizard-bar-pulse {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+.wizard-bar-pulse {
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0)    0%,
+    rgba(255, 255, 255, 0)    35%,
+    rgba(255, 255, 255, 0.35) 50%,
+    rgba(255, 255, 255, 0)    65%,
+    rgba(255, 255, 255, 0)    100%
+  );
+  background-size: 200% auto;
+  background-repeat: no-repeat;
+  animation: wizard-bar-pulse 1.6s ease-in-out infinite;
+}
+
 /* Honor reduced-motion globally (per handoff motion rules). */
 @media (prefers-reduced-motion: reduce) {
   *,


### PR DESCRIPTION
Fixes #5332

## Problem
The index wizard's top progress bar was driven solely by the coarse job poller (`jobProgress`), which barely moves during indexing. It looked frozen near 0% even when every repo was already at "Materializing"/"Indexed", and the long sub-progress-less "Materializing" graph-assembly phase had no sub-progress — so users thought indexing was stuck. The header status was a static "Indexing…".

## Approach (frontend-only)
**`webui-v2/src/lib/index-progress-fold.ts`** — three new pure, unit-tested helpers:
- `rowFraction(row)` → phase-weighted completion (0..1) for one repo: `phaseIndex/5` band, plus the `filesDone/filesTotal` slice within `extracting_ast`; `done`/`error` = 100%.
- `aggregateProgress(rows, expectedRepos?)` → 0..100 averaged over `expectedRepos` when known (so not-yet-reporting repos count as 0 and the bar doesn't jump), else over present rows; clamped.
- `overallPhaseLabel(rows, terminal?)` → human label from the **least-advanced active** (non-terminal) repo ("Scanning…", "Extracting AST…", "Resolving references…", "Running algorithms…", "Materializing graph…"), "Done" when terminal.

**`scan-wizard.tsx`** — main bar now uses the feed aggregate when `hasData` (falls back to `jobProgress` otherwise, pins 100% once `terminal`); header shows the current phase instead of the static string; active (non-terminal) bar gets a subtle shimmer.

**`styles/app.css`** — `.wizard-bar-pulse` shimmer keyframe; the existing global `prefers-reduced-motion` rule collapses it to a no-op.

Preserves: one-row-per-repo dedup (#5329), terminal + expected-repo-count logic (#5331), modal sizing, single-repo groups, per-repo phase labels.

## Tests
Added to `index-progress-fold.test.ts`: `rowFraction` bands; `aggregateProgress` (single repo extracting 50% → mid, done+extracting → between, all done → 100, unknown/known `expectedRepos`, empty → 0, clamp, monotonic-ish across a normal phase sequence); `overallPhaseLabel` (each phase → label, least-advanced active, ignores terminal rows, terminal → "Done").

## Validation
- `npm ci && npm run build` (tsc + vite): clean
- `tsc --noEmit` / `npm run lint`: clean
- `npm test`: 16 files / 171 tests green (incl. new tests)
- Did NOT run `make dashboard-build` or touch `internal/dashboard/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)