### PR TITLE
feat: granular graph-assembly progress phases in CLI + wizard (communities, centrality, cross-repo links, flows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Changed
 
+- **Granular graph-assembly progress phases in the CLI and wizard (#5334):** the
+  graph-assembly tail used to collapse under one coarse "Materializing" /
+  "Running algorithms" label, so the long post-extraction passes looked stuck.
+  The real passes are now surfaced as live phases — **Building communities**
+  (Louvain), **Computing centrality** (PageRank/Betweenness), **Computing
+  flows** (process/event-flow walkers), **Writing graph**, and the group-level
+  **Detecting cross-repo links** — with identical human labels in BOTH the
+  `grafel index`/`rebuild`/`wizard` terminal output (live, TTY-aware) and the
+  dashboard scan wizard. The coarse phases are retained as fallbacks
+  ([#5334](https://github.com/cajasmota/grafel/issues/5334)).
 - **Index wizard main progress bar now reflects real progress (#5332):** the
   wizard's top progress bar was driven solely by the coarse job poller, which
   barely moves during indexing — so it looked frozen near 0% even while every

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1229,11 +1229,31 @@ func daemonRebuildFuncCore(
 		return rebuilt, "", fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
 
+	// #5334 — surface the GROUP-level cross-repo link pass as its own granular
+	// phase. This runs after every member repo is indexed (their per-repo rows
+	// are already terminal), so without a group-level event the wizard's overall
+	// label would sit at "Done" while the link pass is still churning. We emit a
+	// group-scoped event (RepoSlug == group) so both the wizard's aggregate
+	// label and the CLI's live line advance to "Detecting cross-repo links…".
+	// The phantom-edge pass re-runs process-flow inside linksFn, so the same
+	// phase also covers the group-level flow recompute.
+	linkTrk := progress.NewTracker(daemonProgressBroker, args.Group, args.Group)
+	linkTrk.Phase(progress.PhaseDetectLinks, "cross-repo links", 0)
+
 	// Cross-repo link passes run after every member is indexed.
 	warning := ""
 	if err := linksFn(args.Group); err != nil {
 		// Best-effort — surface as a warning, not a hard failure.
 		warning = fmt.Sprintf("link passes failed: %v", err)
+	}
+	// Terminalize the group-level link row so the wizard's feed-terminal gate
+	// (rowsTerminal) is not blocked by a perpetually non-terminal group row.
+	// expectedRepos counts member repos only, so the wizard tolerates this
+	// extra group row reaching done.
+	if warning != "" {
+		linkTrk.Fail(warning)
+	} else {
+		linkTrk.Done(0, 0)
 	}
 
 	// Explicitly invalidate the cache for each rebuilt repo (#2607).

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1650,6 +1650,15 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		i.runPass4AlgorithmsWithProgress(doc, trk)
 	}
 
+	// #5334 — surface the flow walkers (process-flow + event-flow) as a
+	// granular "Computing flows…" phase so the CLI/wizard tail no longer
+	// collapses under one "Materializing". One cheap event per the combined
+	// flow stage; the coarse PhaseMaterialize (emitted at buildDocument) is
+	// retained as the fallback band.
+	if !i.skipPasses[PassProcessFlow] || !i.skipPasses[PassEventFlow] {
+		trk.Phase(progress.PhaseComputeFlows, "process+event flows", doc.Stats.Entities)
+	}
+
 	// Pass 7 — process-flow BFS (#724). Runs AFTER all CALLS edges are
 	// finalised (resolver + external synthesis + Pass 4) so the trace
 	// algorithm sees the same graph as downstream consumers. Emits
@@ -1894,6 +1903,13 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// Properties BEFORE candidate emission, so previously agent-resolved
 	// values are preserved AND emitters skip already-described entities.
 	i.runPass6EmitEnrichmentCandidates(doc, absRepo)
+
+	// #5334 — surface the imminent graph write as a granular "Writing graph…"
+	// phase. The actual graph.fb / sidecar write happens in the Index() caller
+	// once Run returns (trk is out of scope there), so we emit the boundary here
+	// where the document is fully assembled and about to be persisted. Coarse
+	// PhaseMaterialize remains the fallback band.
+	trk.Phase(progress.PhaseWriteGraph, "graph.fb", doc.Stats.Entities)
 
 	// Emit the final done event before the summary log line.
 	trk.Done(len(files), doc.Stats.Entities)
@@ -2449,11 +2465,21 @@ func (i *Indexer) runPass4Algorithms(doc *graph.Document) {
 func (i *Indexer) runPass4AlgorithmsWithProgress(doc *graph.Document, trk *progress.Tracker) {
 	entityCount := doc.Stats.Entities
 
+	// #5334 — surface the two real algorithm passes as granular phases so the
+	// CLI and wizard show "Building communities…" then "Computing centrality…"
+	// instead of one coarse "Running algorithms". RunAlgorithms is a single
+	// combined call (we don't rewire the individual algorithms), so we emit the
+	// community-detection label at entry and the centrality label once the
+	// combined pass has produced its results. The coarse PhaseAlgorithms
+	// AlgorithmEvent is retained as a fallback for any consumer still keyed on
+	// it.
 	if trk != nil {
 		trk.AlgorithmEvent("Louvain+PageRank+Betweenness", entityCount)
+		trk.Phase(progress.PhaseBuildCommunities, "Louvain", entityCount)
 	}
 	res := graph.RunAlgorithms(doc.Entities, doc.Relationships)
 	if trk != nil {
+		trk.Phase(progress.PhaseComputeCentrality, "PageRank+Betweenness", entityCount)
 		trk.AlgorithmEvent("ArticulationPoints+SurpriseEdges", entityCount)
 	}
 

--- a/cmd/grafel/progress_instrumentation_test.go
+++ b/cmd/grafel/progress_instrumentation_test.go
@@ -169,6 +169,61 @@ func TestIndexerProgress_AlgorithmEvents(t *testing.T) {
 	}
 }
 
+// TestIndexerProgress_GranularAssemblyPhases verifies that the granular
+// graph-assembly phases (#5334) are emitted during a per-repo index and that
+// they appear in the expected relative order: community detection precedes
+// centrality, both precede the flow walkers, and writing the graph is the last
+// assembly phase before done.
+func TestIndexerProgress_GranularAssemblyPhases(t *testing.T) {
+	col := &progress.SliceCollector{}
+	idx := newTestIndexer(t, "crossfile_go", nil, "")
+	idx.publisher = col
+
+	if _, err := idx.Run(context.Background(), "testdata/crossfile_go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Record the index of the FIRST event for each granular phase.
+	firstIdx := map[string]int{}
+	for i, e := range col.Events {
+		if _, seen := firstIdx[e.Phase]; !seen {
+			firstIdx[e.Phase] = i
+		}
+	}
+
+	required := []string{
+		progress.PhaseBuildCommunities,
+		progress.PhaseComputeCentrality,
+		progress.PhaseComputeFlows,
+		progress.PhaseWriteGraph,
+	}
+	for _, p := range required {
+		if _, ok := firstIdx[p]; !ok {
+			t.Errorf("granular phase %q never emitted (seen: %v)", p, firstIdx)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+
+	// Ordering invariants (per-repo emission sequence).
+	assertBefore := func(a, b string) {
+		if firstIdx[a] >= firstIdx[b] {
+			t.Errorf("expected phase %q (idx %d) to emit before %q (idx %d)",
+				a, firstIdx[a], b, firstIdx[b])
+		}
+	}
+	assertBefore(progress.PhaseBuildCommunities, progress.PhaseComputeCentrality)
+	assertBefore(progress.PhaseComputeCentrality, progress.PhaseComputeFlows)
+	assertBefore(progress.PhaseComputeFlows, progress.PhaseWriteGraph)
+	assertBefore(progress.PhaseWriteGraph, progress.PhaseDone)
+
+	// The coarse PhaseAlgorithms is retained as a fallback and must still fire.
+	if _, ok := firstIdx[progress.PhaseAlgorithms]; !ok {
+		t.Error("coarse PhaseAlgorithms fallback no longer emitted")
+	}
+}
+
 // TestIndexerProgress_SkipAlgorithms verifies that algorithm events are NOT
 // emitted when PassGraphAlgo is skipped.
 func TestIndexerProgress_SkipAlgorithms(t *testing.T) {

--- a/internal/cli/repair_broker.go
+++ b/internal/cli/repair_broker.go
@@ -294,6 +294,24 @@ func renderBrokerEvent(
 			line = colorize(fmt.Sprintf("%s: running_algorithms…", slug), ansiYellow, tty, plain)
 		}
 
+	// #5334 — granular graph-assembly phases. Labels are kept in lock-step with
+	// the dashboard wizard (webui-v2 PHASE_LABEL) so CLI and web users see the
+	// same human phrase for the same phase.
+	case progress.PhaseBuildCommunities:
+		line = colorize(fmt.Sprintf("%s: Building communities…", slug), ansiYellow, tty, plain)
+
+	case progress.PhaseComputeCentrality:
+		line = colorize(fmt.Sprintf("%s: Computing centrality…", slug), ansiYellow, tty, plain)
+
+	case progress.PhaseDetectLinks:
+		line = colorize(fmt.Sprintf("%s: Detecting cross-repo links…", slug), ansiYellow, tty, plain)
+
+	case progress.PhaseComputeFlows:
+		line = colorize(fmt.Sprintf("%s: Computing flows…", slug), ansiYellow, tty, plain)
+
+	case progress.PhaseWriteGraph:
+		line = colorize(fmt.Sprintf("%s: Writing graph…", slug), ansiYellow, tty, plain)
+
 	case progress.PhaseMaterialize:
 		line = colorize(fmt.Sprintf("%s: materializing…", slug), ansiYellow, tty, plain)
 

--- a/internal/cli/repair_broker_test.go
+++ b/internal/cli/repair_broker_test.go
@@ -115,6 +115,43 @@ func TestRenderBrokerEvent_Algorithms_Named(t *testing.T) {
 	}
 }
 
+// TestRenderBrokerEvent_GranularPhases verifies the #5334 graph-assembly
+// phases render with their friendly labels in both plain (non-TTY) and TTY
+// (ANSI) modes. The label text must match the dashboard wizard's PHASE_LABEL.
+func TestRenderBrokerEvent_GranularPhases(t *testing.T) {
+	cases := []struct {
+		phase string
+		want  string
+	}{
+		{progress.PhaseBuildCommunities, "Building communities…"},
+		{progress.PhaseComputeCentrality, "Computing centrality…"},
+		{progress.PhaseDetectLinks, "Detecting cross-repo links…"},
+		{progress.PhaseComputeFlows, "Computing flows…"},
+		{progress.PhaseWriteGraph, "Writing graph…"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.phase, func(t *testing.T) {
+			e := progress.Event{RepoSlug: "svc", Phase: tc.phase}
+
+			// plain / non-TTY: friendly label, no ANSI escapes.
+			plain := renderBrokerEventPlain(e)
+			if !strings.Contains(plain, tc.want) {
+				t.Errorf("plain: missing label %q in %q", tc.want, plain)
+			}
+			if strings.Contains(plain, "\033[") {
+				t.Errorf("plain: unexpected ANSI escape in %q", plain)
+			}
+
+			// TTY: friendly label present (ANSI allowed).
+			var buf bytes.Buffer
+			renderBrokerEvent(&buf, e, map[string]int{}, true, false, false)
+			if !strings.Contains(buf.String(), tc.want) {
+				t.Errorf("tty: missing label %q in %q", tc.want, buf.String())
+			}
+		})
+	}
+}
+
 func TestRenderBrokerEvent_Materialize(t *testing.T) {
 	e := progress.Event{
 		RepoSlug: "svc",

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -35,12 +35,37 @@ const (
 
 	// PhaseAlgorithms is Pass 4 (PageRank, Louvain, betweenness,
 	// articulation points, surprise edges). One event per algorithm entry
-	// and exit.
+	// and exit. Retained as a coarse fallback; the granular pass boundaries
+	// below (#5334) split it into community detection and centrality.
 	PhaseAlgorithms = "running_algorithms"
 
+	// PhaseBuildCommunities is the community-detection slice of Pass 4
+	// (Louvain). Surfaced as "Building communities…" (#5334).
+	PhaseBuildCommunities = "building_communities"
+
+	// PhaseComputeCentrality is the centrality slice of Pass 4 (PageRank,
+	// betweenness, articulation points, surprise edges). Surfaced as
+	// "Computing centrality…" (#5334).
+	PhaseComputeCentrality = "computing_centrality"
+
 	// PhaseMaterialize covers buildDocument, graph.fb write, sidecar write,
-	// and enrichment-candidate emission.
+	// and enrichment-candidate emission. Retained as a coarse fallback; the
+	// granular boundaries below (#5334) split the group-assembly tail into
+	// cross-repo links, flows, and the graph write.
 	PhaseMaterialize = "materializing"
+
+	// PhaseDetectLinks is the cross-repo link-detection pass that runs at
+	// GROUP assembly after every member repo is indexed. Surfaced as
+	// "Detecting cross-repo links…" (#5334).
+	PhaseDetectLinks = "detecting_links"
+
+	// PhaseComputeFlows is the process-flow / event-flow walker pass.
+	// Surfaced as "Computing flows…" (#5334).
+	PhaseComputeFlows = "computing_flows"
+
+	// PhaseWriteGraph is the final graph.fb / sidecar write step. Surfaced
+	// as "Writing graph…" (#5334).
+	PhaseWriteGraph = "writing_graph"
 
 	// PhaseDone is emitted once with final totals.
 	PhaseDone = "done"
@@ -262,6 +287,28 @@ func (t *Tracker) Tick(phase string, filesDone int, bytesSeen int64, currentFile
 		BytesSeen:        bytesSeen,
 		CurrentFile:      currentFile,
 		Module:           t.module(currentFile),
+		PhaseStartedAtMS: t.phaseStartedAtMS,
+		TS:               nowMS(),
+	})
+}
+
+// Phase emits a single phase-boundary event for a granular pass (#5334),
+// carrying the current entity count and the named algorithm/pass when known.
+// Unlike PhaseStart it does not reset phaseStartedAtMS-derived file counters;
+// it is the cheap one-event-per-pass signal used to surface the graph-assembly
+// tail (communities, centrality, links, flows, write) in the CLI and wizard.
+// The pass runs after all files are processed, so FilesDone == FilesTotal.
+func (t *Tracker) Phase(phase, passName string, entitiesSoFar int) {
+	t.currentPhase = phase
+	t.phaseStartedAtMS = nowMS()
+	t.pub.Publish(Event{
+		GroupSlug:        t.groupSlug,
+		RepoSlug:         t.repoSlug,
+		Phase:            phase,
+		FilesTotal:       t.filesTotal,
+		FilesDone:        t.filesTotal,
+		EntitiesSoFar:    entitiesSoFar,
+		AlgorithmName:    passName,
 		PhaseStartedAtMS: t.phaseStartedAtMS,
 		TS:               nowMS(),
 	})

--- a/webui-v2/src/components/chrome/index-progress-feed.tsx
+++ b/webui-v2/src/components/chrome/index-progress-feed.tsx
@@ -22,6 +22,12 @@ const PHASE_LABEL: Record<ProgressPhase, string> = {
   resolving_refs: "Resolving refs",
   running_algorithms: "Running algorithms",
   materializing: "Materializing",
+  // #5334 — granular graph-assembly phases.
+  building_communities: "Building communities",
+  computing_centrality: "Computing centrality",
+  detecting_links: "Detecting cross-repo links",
+  computing_flows: "Computing flows",
+  writing_graph: "Writing graph",
   done: "Indexed",
   error: "Failed",
 };

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1416,6 +1416,14 @@ export type ProgressPhase =
   | "resolving_refs"
   | "running_algorithms"
   | "materializing"
+  // #5334 — granular graph-assembly phases (split from the coarse
+  // running_algorithms / materializing). The coarse two are retained above as
+  // fallbacks for older events.
+  | "building_communities"
+  | "computing_centrality"
+  | "detecting_links"
+  | "computing_flows"
+  | "writing_graph"
   | "done"
   | "error";
 

--- a/webui-v2/src/lib/index-progress-fold.test.ts
+++ b/webui-v2/src/lib/index-progress-fold.test.ts
@@ -199,21 +199,52 @@ describe("rowFraction — phase-weighted per-repo completion (#5332)", () => {
   });
 
   it("extracting_ast adds the files slice within its band", () => {
-    // base = 1/5 = 0.2; +50% of the 0.2 band = 0.3
-    expect(rowFraction(row({ phase: "extracting_ast", filesDone: 50, filesTotal: 100 }))).toBeCloseTo(0.3);
+    // base = 1/10 = 0.1; +50% of the 0.1 band = 0.15 (#5334: 10 bands)
+    expect(rowFraction(row({ phase: "extracting_ast", filesDone: 50, filesTotal: 100 }))).toBeCloseTo(0.15);
   });
 
   it("sub-progress-less phases advance only via their band", () => {
-    expect(rowFraction(row({ phase: "resolving_refs" }))).toBeCloseTo(0.4);
-    expect(rowFraction(row({ phase: "running_algorithms" }))).toBeCloseTo(0.6);
-    expect(rowFraction(row({ phase: "materializing" }))).toBeCloseTo(0.8);
+    // #5334 — 10 bands, emission-order indices.
+    expect(rowFraction(row({ phase: "resolving_refs" }))).toBeCloseTo(0.2);
+    expect(rowFraction(row({ phase: "materializing" }))).toBeCloseTo(0.3);
+    expect(rowFraction(row({ phase: "running_algorithms" }))).toBeCloseTo(0.4);
+  });
+
+  it("granular graph-assembly phases each occupy a higher band (#5334)", () => {
+    expect(rowFraction(row({ phase: "building_communities" }))).toBeCloseTo(0.5);
+    expect(rowFraction(row({ phase: "computing_centrality" }))).toBeCloseTo(0.6);
+    expect(rowFraction(row({ phase: "computing_flows" }))).toBeCloseTo(0.7);
+    expect(rowFraction(row({ phase: "detecting_links" }))).toBeCloseTo(0.8);
+    expect(rowFraction(row({ phase: "writing_graph" }))).toBeCloseTo(0.9);
+  });
+
+  it("rowFraction is strictly increasing across the assembly sequence (#5334)", () => {
+    const seq: ProgressRow["phase"][] = [
+      "scanning",
+      "extracting_ast",
+      "resolving_refs",
+      "materializing",
+      "running_algorithms",
+      "building_communities",
+      "computing_centrality",
+      "computing_flows",
+      "detecting_links",
+      "writing_graph",
+      "done",
+    ];
+    let last = -1;
+    for (const phase of seq) {
+      const f = rowFraction(row({ phase }));
+      expect(f).toBeGreaterThan(last);
+      last = f;
+    }
   });
 });
 
 describe("aggregateProgress (#5332)", () => {
   it("single repo extracting at 50% files → sensible mid value", () => {
     const p = aggregateProgress([row({ phase: "extracting_ast", filesDone: 50, filesTotal: 100 })]);
-    expect(p).toBe(30); // 0.3 * 100
+    expect(p).toBe(15); // 0.15 * 100 (#5334: 10 bands)
   });
 
   it("one repo done + one extracting → between the two", () => {
@@ -221,8 +252,8 @@ describe("aggregateProgress (#5332)", () => {
       row({ repoSlug: "a", phase: "done" }),
       row({ repoSlug: "b", phase: "extracting_ast", filesDone: 0, filesTotal: 100 }),
     ]);
-    // (1 + 0.2) / 2 = 0.6
-    expect(p).toBe(60);
+    // (1 + 0.1) / 2 = 0.55 (#5334: 10 bands)
+    expect(p).toBe(55);
     expect(p).toBeGreaterThan(0);
     expect(p).toBeLessThan(100);
   });
@@ -237,7 +268,7 @@ describe("aggregateProgress (#5332)", () => {
 
   it("unknown expectedRepos → averages over present rows", () => {
     const p = aggregateProgress([row({ phase: "materializing" })], undefined);
-    expect(p).toBe(80);
+    expect(p).toBe(30); // 0.3 * 100 (#5334: 10 bands)
   });
 
   it("expectedRepos counts not-yet-reporting repos as 0 (bar doesn't jump)", () => {
@@ -261,8 +292,13 @@ describe("aggregateProgress (#5332)", () => {
       "scanning",
       "extracting_ast",
       "resolving_refs",
-      "running_algorithms",
       "materializing",
+      "running_algorithms",
+      "building_communities",
+      "computing_centrality",
+      "computing_flows",
+      "detecting_links",
+      "writing_graph",
       "done",
     ];
     let last = -1;
@@ -281,6 +317,14 @@ describe("overallPhaseLabel (#5332)", () => {
     expect(overallPhaseLabel([row({ phase: "resolving_refs" })])).toBe("Resolving references…");
     expect(overallPhaseLabel([row({ phase: "running_algorithms" })])).toBe("Running algorithms…");
     expect(overallPhaseLabel([row({ phase: "materializing" })])).toBe("Materializing graph…");
+  });
+
+  it("maps the granular graph-assembly phases to friendly labels (#5334)", () => {
+    expect(overallPhaseLabel([row({ phase: "building_communities" })])).toBe("Building communities…");
+    expect(overallPhaseLabel([row({ phase: "computing_centrality" })])).toBe("Computing centrality…");
+    expect(overallPhaseLabel([row({ phase: "detecting_links" })])).toBe("Detecting cross-repo links…");
+    expect(overallPhaseLabel([row({ phase: "computing_flows" })])).toBe("Computing flows…");
+    expect(overallPhaseLabel([row({ phase: "writing_graph" })])).toBe("Writing graph…");
   });
 
   it("reflects the LEAST-advanced active repo", () => {

--- a/webui-v2/src/lib/index-progress-fold.ts
+++ b/webui-v2/src/lib/index-progress-fold.ts
@@ -28,15 +28,34 @@ export function rowKey(e: Pick<ProgressEvent, "repo_slug">): string {
   return e.repo_slug;
 }
 
-/** Monotonic phase order so a stale lower phase never overwrites a higher one. */
+/**
+ * Monotonic phase order so a stale lower phase never overwrites a higher one.
+ *
+ * #5334 — the graph-assembly tail is split into granular passes. The order
+ * mirrors the backend's real emission sequence so a later, finer phase never
+ * regresses to a coarse one:
+ *   buildDocument → materializing(coarse) → running_algorithms(coarse) →
+ *   building_communities → computing_centrality → computing_flows →
+ *   writing_graph → done.
+ * detecting_links is a GROUP-level pass that runs on its own row (keyed by the
+ * group slug) after every member repo is done; it only needs to precede that
+ * row's terminal `done`, so it slots just below writing_graph.
+ * The coarse phases (running_algorithms, materializing) are retained as
+ * fallback bands for any older event still keyed on them.
+ */
 const PHASE_ORDER: Record<ProgressRow["phase"], number> = {
   scanning: 0,
   extracting_ast: 1,
   resolving_refs: 2,
-  running_algorithms: 3,
-  materializing: 4,
-  done: 5,
-  error: 5,
+  materializing: 3,
+  running_algorithms: 4,
+  building_communities: 5,
+  computing_centrality: 6,
+  computing_flows: 7,
+  detecting_links: 8,
+  writing_graph: 9,
+  done: 10,
+  error: 10,
 };
 
 /**
@@ -122,25 +141,31 @@ export function rowsTerminal(rows: ProgressRow[], expectedRepos?: number): boole
    long, sub-progress-less "Materializing" phase.
    ------------------------------------------------------------------ */
 
-/** Number of bands the [0,100] bar is split into — one per non-terminal phase. */
-const PHASE_BANDS = 5;
+/**
+ * Number of bands the [0,100] bar is split into — one per non-terminal phase
+ * index (0..9), so each granular assembly pass advances the bar by ~10% as the
+ * repo crosses into it. Must equal the `done` PHASE_ORDER value so a repo at
+ * the last non-terminal phase reads <100% and only `done` pegs to 100% (#5334).
+ */
+const PHASE_BANDS = 10;
 
 /**
  * Phase-weighted completion fraction (0..1) for a single repo row.
  *
- *   base   = phaseIndex / 5     (each phase is a 20% band)
+ *   base   = phaseIndex / PHASE_BANDS   (each phase is one band)
  *   within `extracting_ast` we have real file granularity, so add the
  *          filesDone/filesTotal slice of that one band.
  *   done   = 1 (100%)
  *   error  = counts as 100% so a failed repo doesn't peg the average low.
  *
- * The other sub-progress-less phases (resolving_refs / running_algorithms /
- * materializing) still advance the bar via their phase band as the repo
- * crosses into them — that's what keeps "Materializing" from looking stuck.
+ * The sub-progress-less assembly phases (resolving_refs, running_algorithms,
+ * building_communities, computing_centrality, computing_flows, writing_graph)
+ * still advance the bar via their phase band as the repo crosses into them —
+ * that's what keeps the assembly tail from looking stuck (#5334).
  */
 export function rowFraction(row: Pick<ProgressRow, "phase" | "filesDone" | "filesTotal">): number {
   if (row.phase === "done" || row.phase === "error") return 1;
-  const idx = PHASE_ORDER[row.phase]; // 0..4 for non-terminal phases
+  const idx = PHASE_ORDER[row.phase]; // 0..9 for non-terminal phases
   const base = idx / PHASE_BANDS;
   if (row.phase === "extracting_ast" && row.filesTotal > 0) {
     const slice = Math.min(1, Math.max(0, row.filesDone / row.filesTotal));
@@ -181,6 +206,14 @@ const PHASE_LABEL: Record<ProgressRow["phase"], string> = {
   resolving_refs: "Resolving references…",
   running_algorithms: "Running algorithms…",
   materializing: "Materializing graph…",
+  // #5334 — granular graph-assembly labels, kept in lock-step with the CLI
+  // renderer (internal/cli/repair_broker.go) so both surfaces speak the same
+  // human phrase for the same phase.
+  building_communities: "Building communities…",
+  computing_centrality: "Computing centrality…",
+  detecting_links: "Detecting cross-repo links…",
+  computing_flows: "Computing flows…",
+  writing_graph: "Writing graph…",
   done: "Done",
   error: "Done",
 };


### PR DESCRIPTION
Fixes #5334

The graph-assembly tail used to collapse under one coarse "Materializing" /
"Running algorithms" label, so the long post-extraction passes looked stuck in
both the CLI and the dashboard wizard. This surfaces the real passes as live,
consistently-labelled phases across BOTH surfaces.

## Passes wired

**Per-repo** (`cmd/grafel/index.go`, threaded on the existing `Tracker`):
- `building_communities` (Louvain) + `computing_centrality` (PageRank/Betweenness)
  — emitted around the single combined `graph.RunAlgorithms` call (we do not
  rewire the individual algorithms), splitting the coarse `running_algorithms`.
- `computing_flows` — around the process-flow + event-flow walkers.
- `writing_graph` — at the point the document is fully assembled and the
  `graph.fb`/sidecar write is imminent (the write itself happens in the `Index()`
  caller once `Run()` returns).

**Group** (`cmd/grafel/daemon.go`, `daemonRebuildFuncCore`):
- `detecting_links` — emitted as a group-scoped event (`RepoSlug == group`)
  around the cross-repo link pass, which runs after every member repo is indexed
  (their per-repo rows are already terminal) and also re-runs process-flow for
  phantom cross-repo chains. The group row is terminalized (`Done`/`Fail`) after
  the pass so the wizard's `rowsTerminal` feed gate isn't blocked.

The coarse `running_algorithms` / `materializing` phases are retained as
fallbacks; standalone CLI indexing is unaffected.

## CLI rendering

The `grafel index`/`rebuild`/`wizard` progress feed already consumes the same
`progress.Event` SSE stream via `renderBrokerEvent` (`internal/cli/repair_broker.go`).
New phases are mapped to friendly labels there — "Building communities…",
"Computing centrality…", "Detecting cross-repo links…", "Computing flows…",
"Writing graph…" — TTY-aware (ANSI overwrite on a terminal; plain one-line-per-
transition under `--plain`/non-TTY). Labels are kept in lock-step with the
dashboard wizard's `PHASE_LABEL`.

## Dashboard

`webui-v2/src/lib/index-progress-fold.ts`: `PHASE_ORDER` extended monotonically
(mirroring the backend's real emission order), `PHASE_BANDS` 5→10 so each pass
occupies its own band between extraction and done (aggregate bar never regresses),
and `PHASE_LABEL`/`overallPhaseLabel` get the friendly labels. `ProgressPhase`
union + the per-row badge map updated. #5329/#5331/#5333 (dedup, terminal +
expected-count, aggregate bar + pulse) are preserved.

## Tests

- Backend: `building_communities → computing_centrality → computing_flows →
  writing_graph` emit in order during a per-repo index; coarse fallback still fires.
- CLI: TTY + non-TTY label rendering per new phase.
- Frontend: `rowFraction` strictly increasing across the full assembly sequence,
  `PHASE_ORDER` monotonic, `overallPhaseLabel` mapping for new phases; existing
  band-math assertions updated for the 10-band model.

## Validation

- `go build ./...`, `go vet`, `gofmt -l` empty,
  `go test ./internal/progress/... ./internal/cli/... ./cmd/grafel/...` green.
- `cd webui-v2 && npm ci && npm run build` clean; `tsc --noEmit`/`npm run lint`
  clean; `npm test` green (174 tests, incl. new fold tests). `internal/dashboard/dist`
  untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)