### PR TITLE
feat(wizard): action-first flow + smart cwd detection + CLI↔dashboard parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Changed
 
+- **Index wizard is now action-first with smart cwd detection (#5336):** both the
+  CLI (`grafel wizard`) and the dashboard scan wizard now open on an explicit
+  action choice — **Index a single repository**, **Index a group of related
+  repositories**, **Index a monorepo**, **Add a repository to an existing
+  group** — with the cursor pre-placed on a smart default derived from the
+  current directory. This fixes container folders: a parent directory holding
+  multiple repos (e.g. `ivivo/` with `backend/` + `frontend/`) now resolves to
+  exactly those child repos instead of scanning the cwd's PARENT for unrelated
+  siblings. CLI and dashboard share a single source of truth — the new
+  `detect.ClassifyPath` classifier — so they agree on what a folder is (its own
+  git status, immediate child git repos, monorepo packages, sibling repos) and
+  which action to suggest. The non-interactive `--repos`/`--parent`/`--exclude`
+  flags are unchanged for scripting
+  ([#5336](https://github.com/cajasmota/grafel/issues/5336)).
 - **Granular graph-assembly progress phases in the CLI and wizard (#5334):** the
   graph-assembly tail used to collapse under one coarse "Materializing" /
   "Running algorithms" label, so the long post-extraction passes looked stuck.

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -85,8 +85,52 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 	cfg.Features.AgentHooks = opts.AgentHooks
 	cfg.GroupDocs = opts.GroupDocs
 
-	// Step 1 — group name.
-	if opts.GroupName == "" && !opts.NonInteractive {
+	// NON-INTERACTIVE path (--repos/--parent/--exclude): unchanged flag-driven
+	// discovery, for scripting. Requires --group up front.
+	if opts.NonInteractive {
+		if opts.GroupName == "" {
+			return errors.New("group name required")
+		}
+		cfg.Name = opts.GroupName
+		candidates, err := discoverCandidates(out, opts)
+		if err != nil {
+			return err
+		}
+		if len(candidates) == 0 {
+			return errors.New("no repos selected")
+		}
+		for _, p := range candidates {
+			abs, _ := filepath.Abs(p)
+			cfg.Repos = append(cfg.Repos, registry.Repo{
+				Slug:  filepath.Base(abs),
+				Path:  abs,
+				Stack: registry.StackList{detect.Stack(abs)},
+			})
+		}
+		return finishWizard(out, cfg, opts)
+	}
+
+	// INTERACTIVE path — action-first (#5336). Pick an action (single / group /
+	// monorepo / add-to-group) with a smart cwd default, then resolve candidates
+	// per action via the shared detect.ClassifyPath classifier.
+	repos, addTo, err := runInteractiveRepoSelect(out)
+	if err != nil {
+		return err
+	}
+	// "Add to existing group" short-circuits: append the chosen repos to the
+	// target group's config and apply, rather than creating a new group.
+	if addTo != "" {
+		return addReposToExistingGroup(out, addTo, repos, opts)
+	}
+	if len(repos) == 0 {
+		return errors.New("no repos selected")
+	}
+	cfg.Repos = append(cfg.Repos, repos...)
+
+	// Group name — prompted AFTER the action so "add to existing group" can skip
+	// it. Pre-fill a suggestion from the first repo's basename.
+	if opts.GroupName == "" {
+		opts.GroupName = filepath.Base(repos[0].Path)
 		if err := huh.NewInput().
 			Title("Group name").
 			Description("Used as the registry key and the per-group config filename.").
@@ -100,39 +144,13 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 		return errors.New("group name required")
 	}
 	cfg.Name = opts.GroupName
+	return finishWizard(out, cfg, opts)
+}
 
-	// Step 2 — repo discovery.
-	candidates, err := discoverCandidates(out, opts)
-	if err != nil {
-		return err
-	}
-	var chosen []string
-	if opts.NonInteractive || len(candidates) == 0 {
-		chosen = candidates
-	} else {
-		opts2 := make([]huh.Option[string], 0, len(candidates))
-		for _, c := range candidates {
-			opts2 = append(opts2, huh.NewOption(c, c).Selected(true))
-		}
-		if err := huh.NewMultiSelect[string]().
-			Title("Repos to include").
-			Options(opts2...).
-			Value(&chosen).
-			Run(); err != nil {
-			return err
-		}
-	}
-	if len(chosen) == 0 {
-		return errors.New("no repos selected")
-	}
-	for _, p := range chosen {
-		abs, _ := filepath.Abs(p)
-		cfg.Repos = append(cfg.Repos, registry.Repo{
-			Slug:  filepath.Base(abs),
-			Path:  abs,
-			Stack: registry.StackList{detect.Stack(abs)},
-		})
-	}
+// finishWizard runs the remaining interactive prompts (features, group docs) and
+// then persists + installs the assembled group config. Shared by both the
+// non-interactive and interactive paths.
+func finishWizard(out io.Writer, cfg *registry.GroupConfig, opts wizardOptions) error {
 
 	// Step 3 — features (skip prompt; defaults from flags).
 	if !opts.NonInteractive {
@@ -160,7 +178,7 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 
 	// Steps 5-7 — persist + register + manifests + install. Shared with the
 	// non-interactive `group add` command via applyGroupConfig.
-	_, err = applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
+	_, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
 	return err
 }
 
@@ -218,6 +236,424 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 	fmt.Fprintf(out, "installed %d hooks, %d watchers, %d MCP entries\n",
 		len(res.HooksInstalled), len(res.WatcherUnits), len(res.MCPSettings))
 	return res, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Action-first interactive flow (#5336)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// wizardAction is one of the four top-level index actions.
+type wizardAction string
+
+const (
+	actionSingle   wizardAction = "single"
+	actionGroup    wizardAction = "group"
+	actionMonorepo wizardAction = "monorepo"
+	actionAddGroup wizardAction = "add-group"
+)
+
+// repoFromPath builds a registry.Repo for an absolute path, detecting its stack.
+func repoFromPath(abs string) registry.Repo {
+	return registry.Repo{
+		Slug:  filepath.Base(abs),
+		Path:  abs,
+		Stack: registry.StackList{detect.Stack(abs)},
+	}
+}
+
+// runInteractiveRepoSelect drives the action-first interactive flow. It returns
+// the chosen repos and, when the user picked "add to existing group", the name
+// of that group (in which case the repos are appended there by the caller rather
+// than forming a new group). Replaces the old filepath.Dir(cwd) sibling scan.
+func runInteractiveRepoSelect(out io.Writer) (repos []registry.Repo, addToGroup string, err error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, "", err
+	}
+	class, _ := detect.ClassifyPath(cwd)
+
+	// Step 1 — action select. ALWAYS show all four; pre-place the cursor on the
+	// smart default derived from ClassifyPath(cwd).
+	action := defaultAction(class)
+	if err := huh.NewSelect[wizardAction]().
+		Title("What do you want to index?").
+		Description(fmt.Sprintf("Detected: %s", describeClassification(class))).
+		Options(
+			huh.NewOption("Index a single repository", actionSingle),
+			huh.NewOption("Index a group of related repositories", actionGroup),
+			huh.NewOption("Index a monorepo", actionMonorepo),
+			huh.NewOption("Add a repository to an existing group", actionAddGroup),
+		).
+		Value(&action).
+		Run(); err != nil {
+		return nil, "", err
+	}
+
+	switch action {
+	case actionSingle:
+		repos, err = resolveSingleAction(class)
+		return repos, "", err
+	case actionGroup:
+		repos, err = resolveGroupAction(out, class)
+		return repos, "", err
+	case actionMonorepo:
+		repos, err = resolveMonorepoAction(out, class)
+		return repos, "", err
+	case actionAddGroup:
+		return resolveAddToGroupAction(out)
+	default:
+		return nil, "", errors.New("no action selected")
+	}
+}
+
+// defaultAction maps a classification's suggested action to a wizardAction.
+func defaultAction(c detect.Classification) wizardAction {
+	switch c.Suggested {
+	case detect.ActionGroup:
+		return actionGroup
+	case detect.ActionMonorepo:
+		return actionMonorepo
+	case detect.ActionSingle:
+		return actionSingle
+	default:
+		return actionSingle
+	}
+}
+
+// describeClassification renders a short human label of what cwd looks like.
+func describeClassification(c detect.Classification) string {
+	switch {
+	case len(c.ChildGitRepos) > 0:
+		return fmt.Sprintf("%s holds %d git repos (%s)", filepath.Base(c.AbsPath),
+			len(c.ChildGitRepos), strings.Join(c.ChildGitRepos, ", "))
+	case c.Monorepo != detect.KindNone && len(c.Packages) > 0:
+		return fmt.Sprintf("%s monorepo, %d packages", c.Monorepo, len(c.Packages))
+	case c.IsGitRepo && len(c.SiblingGitRepos) > 0:
+		return fmt.Sprintf("git repo with %d sibling repos", len(c.SiblingGitRepos))
+	case c.IsGitRepo:
+		return "single git repo"
+	default:
+		return "no git repo at " + filepath.Base(c.AbsPath)
+	}
+}
+
+// resolveSingle confirms cwd when it is a git repo, else prompts for a path. No
+// scan is performed.
+func resolveSingleAction(class detect.Classification) ([]registry.Repo, error) {
+	if class.IsGitRepo {
+		confirm := true
+		if err := huh.NewConfirm().
+			Title(fmt.Sprintf("Index %s?", class.AbsPath)).
+			Value(&confirm).Run(); err != nil {
+			return nil, err
+		}
+		if confirm {
+			return []registry.Repo{repoFromPath(class.AbsPath)}, nil
+		}
+	}
+	abs, err := promptGitRepoPath("Path to the repository")
+	if err != nil {
+		return nil, err
+	}
+	return []registry.Repo{repoFromPath(abs)}, nil
+}
+
+// resolveGroup resolves the candidate source AUTOMATICALLY (option 1a — no
+// "siblings vs parent" prompt): child git repos if present (ivivo→backend+
+// frontend), elif cwd is a git repo → cwd + its siblings, else prompt for a
+// folder. The candidates are shown as a filtered, scrollable [ ]/[✓] multiselect
+// with a count in the title, plus an explicit "scan a different folder…" entry.
+func resolveGroupAction(out io.Writer, class detect.Classification) ([]registry.Repo, error) {
+	candidates := groupCandidates(class)
+	for {
+		if len(candidates) == 0 {
+			abs, err := promptDir("Folder to scan for git repos")
+			if err != nil {
+				return nil, err
+			}
+			candidates = groupCandidates(mustClassify(abs))
+			if len(candidates) == 0 {
+				fmt.Fprintf(out, "no git repos found under %s\n", abs)
+			}
+			continue
+		}
+		chosen, rescan, err := multiSelectRepos(candidates)
+		if err != nil {
+			return nil, err
+		}
+		if rescan {
+			abs, err := promptDir("Folder to scan for git repos")
+			if err != nil {
+				return nil, err
+			}
+			candidates = groupCandidates(mustClassify(abs))
+			continue
+		}
+		return reposFromPaths(chosen), nil
+	}
+}
+
+// groupCandidates derives the absolute candidate repo paths for the group action
+// from a classification (option 1a precedence).
+func groupCandidates(class detect.Classification) []string {
+	if len(class.ChildGitRepos) > 0 {
+		out := make([]string, 0, len(class.ChildGitRepos))
+		for _, name := range class.ChildGitRepos {
+			out = append(out, filepath.Join(class.AbsPath, name))
+		}
+		return out
+	}
+	if class.IsGitRepo {
+		out := append([]string{class.AbsPath}, class.SiblingGitRepos...)
+		sort.Strings(out)
+		return out
+	}
+	return nil
+}
+
+// resolveMonorepo detects packages via the shared classifier and presents a
+// [ ]/[✓] multiselect of package roots. Each selected package is registered as
+// its own repo (its absolute sub-path) with the module recorded.
+func resolveMonorepoAction(out io.Writer, class detect.Classification) ([]registry.Repo, error) {
+	if class.Monorepo == detect.KindNone || len(class.Packages) == 0 {
+		// cwd isn't a monorepo — let the user point at one.
+		abs, err := promptDir("Path to the monorepo")
+		if err != nil {
+			return nil, err
+		}
+		class = mustClassify(abs)
+		if class.Monorepo == detect.KindNone || len(class.Packages) == 0 {
+			return nil, fmt.Errorf("%s is not a monorepo (no packages detected)", abs)
+		}
+	}
+	opts := make([]huh.Option[string], 0, len(class.Packages))
+	for _, p := range class.Packages {
+		opts = append(opts, huh.NewOption(p, p).Selected(true))
+	}
+	var chosen []string
+	if err := huh.NewMultiSelect[string]().
+		Title(fmt.Sprintf("%d packages found", len(class.Packages))).
+		Options(opts...).
+		Filterable(true).
+		Height(min(len(class.Packages)+4, 18)).
+		Value(&chosen).
+		Run(); err != nil {
+		return nil, err
+	}
+	if len(chosen) == 0 {
+		return nil, errors.New("no packages selected")
+	}
+	base := filepath.Base(class.AbsPath)
+	repos := make([]registry.Repo, 0, len(chosen))
+	for _, pkg := range chosen {
+		abs := filepath.Join(class.AbsPath, filepath.FromSlash(pkg))
+		repos = append(repos, registry.Repo{
+			Slug:    base + "-" + filepath.Base(pkg),
+			Path:    abs,
+			Stack:   registry.StackList{detect.Stack(abs)},
+			Modules: []string{pkg},
+		})
+	}
+	return repos, nil
+}
+
+// resolveAddToGroup lists existing groups, lets the user pick one, then multi-add
+// newly-discovered candidate repos and/or a typed path. Returns the repos and the
+// target group name (non-empty signals the add-to-group path to the caller).
+func resolveAddToGroupAction(out io.Writer) ([]registry.Repo, string, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil, "", err
+	}
+	if len(groups) == 0 {
+		return nil, "", errors.New("no existing groups to add to")
+	}
+	gopts := make([]huh.Option[string], 0, len(groups))
+	for _, g := range groups {
+		gopts = append(gopts, huh.NewOption(g.Name, g.Name))
+	}
+	var target string
+	if err := huh.NewSelect[string]().
+		Title("Add to which group?").
+		Options(gopts...).
+		Value(&target).
+		Run(); err != nil {
+		return nil, "", err
+	}
+
+	// Discover candidates from cwd; let the user also scan a different folder.
+	cwd, _ := os.Getwd()
+	candidates := groupCandidates(mustClassify(cwd))
+	var chosen []string
+	if len(candidates) > 0 {
+		picked, rescan, err := multiSelectRepos(candidates)
+		if err != nil {
+			return nil, "", err
+		}
+		if rescan {
+			abs, err := promptDir("Folder to scan for git repos")
+			if err != nil {
+				return nil, "", err
+			}
+			picked, _, err = multiSelectRepos(groupCandidates(mustClassify(abs)))
+			if err != nil {
+				return nil, "", err
+			}
+		}
+		chosen = picked
+	} else {
+		abs, err := promptGitRepoPath("Path to the repository to add")
+		if err != nil {
+			return nil, "", err
+		}
+		chosen = []string{abs}
+	}
+	if len(chosen) == 0 {
+		return nil, "", errors.New("no repos selected to add")
+	}
+	return reposFromPaths(chosen), target, nil
+}
+
+// addReposToExistingGroup loads the target group's config, appends the new repos
+// (skipping ones already present by absolute path), and re-applies it.
+func addReposToExistingGroup(out io.Writer, group string, repos []registry.Repo, opts wizardOptions) error {
+	if len(repos) == 0 {
+		return errors.New("no repos selected to add")
+	}
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		return err
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		return fmt.Errorf("load group %q: %w", group, err)
+	}
+	existing := map[string]struct{}{}
+	for _, r := range cfg.Repos {
+		existing[r.Path] = struct{}{}
+	}
+	added := 0
+	for _, r := range repos {
+		if _, dup := existing[r.Path]; dup {
+			fmt.Fprintf(out, "skipping %s (already in group)\n", r.Path)
+			continue
+		}
+		cfg.Repos = append(cfg.Repos, r)
+		existing[r.Path] = struct{}{}
+		added++
+	}
+	if added == 0 {
+		return errors.New("all selected repos are already in the group")
+	}
+	_, err = applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
+	if err == nil {
+		fmt.Fprintf(out, "added %d repo(s) to group %q\n", added, group)
+	}
+	return err
+}
+
+// multiSelectRepos renders a scrollable, type-to-filter [ ]/[✓] multiselect of
+// absolute repo paths (default all selected) plus an explicit "scan a different
+// folder…" entry. Returns the chosen absolute paths, or rescan=true when the
+// user picked the rescan entry.
+func multiSelectRepos(candidates []string) (chosen []string, rescan bool, err error) {
+	const rescanSentinel = "\x00rescan"
+	opts := make([]huh.Option[string], 0, len(candidates)+1)
+	for _, c := range candidates {
+		opts = append(opts, huh.NewOption(c, c).Selected(true))
+	}
+	opts = append(opts, huh.NewOption("scan a different folder…", rescanSentinel))
+	var selected []string
+	if err := huh.NewMultiSelect[string]().
+		Title(fmt.Sprintf("%d repos found", len(candidates))).
+		Options(opts...).
+		Filterable(true).
+		Height(min(len(candidates)+5, 18)).
+		Value(&selected).
+		Run(); err != nil {
+		return nil, false, err
+	}
+	for _, s := range selected {
+		if s == rescanSentinel {
+			return nil, true, nil
+		}
+	}
+	return selected, false, nil
+}
+
+// reposFromPaths maps absolute paths to registry.Repo records.
+func reposFromPaths(paths []string) []registry.Repo {
+	out := make([]registry.Repo, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, repoFromPath(p))
+	}
+	return out
+}
+
+// mustClassify classifies a path, swallowing the error (returns a zero-value
+// Classification with AbsPath set on failure).
+func mustClassify(path string) detect.Classification {
+	c, err := detect.ClassifyPath(path)
+	if err != nil {
+		abs, _ := filepath.Abs(path)
+		return detect.Classification{AbsPath: abs}
+	}
+	return c
+}
+
+// promptDir prompts for a directory path, expanding ~ and validating existence.
+func promptDir(title string) (string, error) {
+	var p string
+	if err := huh.NewInput().
+		Title(title).
+		Validate(func(s string) error {
+			abs, err := expandUser(s)
+			if err != nil {
+				return err
+			}
+			info, err := os.Stat(abs)
+			if err != nil || !info.IsDir() {
+				return errors.New("not a directory")
+			}
+			return nil
+		}).
+		Value(&p).Run(); err != nil {
+		return "", err
+	}
+	return expandUser(p)
+}
+
+// promptGitRepoPath prompts for a path that must be a git repo.
+func promptGitRepoPath(title string) (string, error) {
+	var p string
+	if err := huh.NewInput().
+		Title(title).
+		Validate(func(s string) error {
+			abs, err := expandUser(s)
+			if err != nil {
+				return err
+			}
+			if !isGitRepo(abs) {
+				return errors.New("not a git repository")
+			}
+			return nil
+		}).
+		Value(&p).Run(); err != nil {
+		return "", err
+	}
+	return expandUser(p)
+}
+
+// expandUser resolves ~ and returns an absolute path.
+func expandUser(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	if strings.HasPrefix(p, "~") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			p = filepath.Join(home, strings.TrimPrefix(p, "~"))
+		}
+	}
+	return filepath.Abs(p)
 }
 
 // discoverCandidates returns absolute paths to repos selected for this

--- a/internal/cli/wizard_actions_test.go
+++ b/internal/cli/wizard_actions_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/detect"
+)
+
+func mkGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git", "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGroupCandidates_Container is the ivivo case: classifying the container
+// folder yields its child git repos as the group candidates — NOT the parent's
+// siblings.
+func TestGroupCandidates_Container(t *testing.T) {
+	root := t.TempDir()
+	ivivo := filepath.Join(root, "ivivo")
+	mkGitRepo(t, filepath.Join(ivivo, "backend"))
+	mkGitRepo(t, filepath.Join(ivivo, "frontend"))
+	mkGitRepo(t, filepath.Join(root, "unrelated"))
+
+	class, err := detect.ClassifyPath(ivivo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := groupCandidates(class)
+	if len(got) != 2 {
+		t.Fatalf("groupCandidates = %v, want 2 (backend, frontend)", got)
+	}
+	if filepath.Base(got[0]) != "backend" || filepath.Base(got[1]) != "frontend" {
+		t.Errorf("got %v, want [backend frontend]", got)
+	}
+	for _, c := range got {
+		if filepath.Base(c) == "unrelated" {
+			t.Errorf("unrelated sibling leaked into candidates: %v", got)
+		}
+	}
+	if defaultAction(class) != actionGroup {
+		t.Errorf("defaultAction = %q, want group", defaultAction(class))
+	}
+}
+
+// TestGroupCandidates_RepoWithSiblings: classifying a git repo that has siblings
+// yields the repo itself plus its siblings.
+func TestGroupCandidates_RepoWithSiblings(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "service-a")
+	b := filepath.Join(root, "service-b")
+	mkGitRepo(t, a)
+	mkGitRepo(t, b)
+
+	class, err := detect.ClassifyPath(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := groupCandidates(class)
+	if len(got) != 2 {
+		t.Fatalf("groupCandidates = %v, want 2 (self + sibling)", got)
+	}
+	if defaultAction(class) != actionGroup {
+		t.Errorf("defaultAction = %q, want group", defaultAction(class))
+	}
+}
+
+func TestDefaultAction(t *testing.T) {
+	cases := []struct {
+		sug  detect.SuggestedAction
+		want wizardAction
+	}{
+		{detect.ActionSingle, actionSingle},
+		{detect.ActionGroup, actionGroup},
+		{detect.ActionMonorepo, actionMonorepo},
+		{detect.ActionNone, actionSingle}, // falls back to single
+	}
+	for _, c := range cases {
+		got := defaultAction(detect.Classification{Suggested: c.sug})
+		if got != c.want {
+			t.Errorf("defaultAction(%q) = %q, want %q", c.sug, got, c.want)
+		}
+	}
+}

--- a/internal/dashboard/v2_wizard.go
+++ b/internal/dashboard/v2_wizard.go
@@ -78,6 +78,16 @@ type v2ScanInspectReply struct {
 	// when Packages is non-empty, "" when neither. The frontend uses this to
 	// label the checkbox list appropriately.
 	ChildrenKind string `json:"childrenKind"`
+	// SiblingGitRepos are the ABSOLUTE paths of the OTHER git repos alongside
+	// AbsPath in its parent (populated only when AbsPath is itself a git repo).
+	// Used by the action-first "group" flow to offer "this repo + siblings".
+	SiblingGitRepos []string `json:"siblingGitRepos"`
+	// IsGitRepo reports whether AbsPath itself is a git repo.
+	IsGitRepo bool `json:"isGitRepo"`
+	// SuggestedAction is the recommended wizard action ("single","group",
+	// "monorepo","") derived from the shared detect.ClassifyPath classifier so
+	// the dashboard's action-first step matches the CLI (#5336).
+	SuggestedAction string `json:"suggestedAction"`
 	// HasAgentsMD is true when AGENTS.md / CLAUDE.md / GEMINI.md exists at the root.
 	HasAgentsMD bool `json:"hasAgentsMd"`
 	// AlreadyRegistered is the existing group name if .grafel/group.json exists.
@@ -107,28 +117,6 @@ type v2ScanReposReq struct {
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/v2/scan/inspect — resolve + detect (no writes)
 // ─────────────────────────────────────────────────────────────────────────────
-
-// detectChildGitRepos returns the names of immediate subdirectories of dir
-// that contain a .git entry (file or directory), sorted alphabetically. It
-// does NOT recurse; only depth-1 children are checked. Returns nil (not an
-// empty slice) when no such children exist so callers can test with len().
-func detectChildGitRepos(dir string) []string {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var children []string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		candidate := filepath.Join(dir, e.Name(), ".git")
-		if _, err := os.Stat(candidate); err == nil {
-			children = append(children, e.Name())
-		}
-	}
-	return children
-}
 
 // handleV2ScanInspect resolves a server-side path and returns a stack +
 // monorepo detection preview. It performs NO registry writes; it is the
@@ -169,45 +157,54 @@ func (s *Server) handleV2ScanInspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	base := filepath.Base(abs)
-	mono, _ := detect.DetectMonorepo(abs)
-	pkgs := mono.Packages
-	if pkgs == nil {
-		pkgs = []string{}
-	}
 
-	// Detect child git repos (the multi-repo-parent pattern). A parent directory
-	// containing N sub-repos is NOT itself a monorepo (no workspace manifest), so
-	// DetectMonorepo returns KindNone. We detect it by checking which immediate
-	// subdirs contain a .git entry. If child git repos are found we prefer them
-	// over monorepo packages (a plain parent dir can't meaningfully be both).
-	childGitRepos := detectChildGitRepos(abs)
-	if childGitRepos == nil {
-		childGitRepos = []string{}
-	}
+	// Classify the path with the SHARED detect.ClassifyPath classifier — the
+	// SAME single source of truth the CLI wizard uses (#5336). This yields the
+	// child git repos (the ivivo/backend+frontend case), monorepo packages,
+	// sibling git repos, and a suggested action, so the dashboard's action-first
+	// step matches the CLI exactly.
+	class, _ := detect.ClassifyPath(abs)
 
-	// Determine childrenKind and resolve precedence: child git repos win over
-	// monorepo packages when both would be present (shouldn't happen in practice
-	// but be explicit and safe).
+	pkgs := class.Packages
+	childGitRepos := class.ChildGitRepos
+	siblings := class.SiblingGitRepos
+
+	// Resolve precedence for the checkbox list: child git repos win over monorepo
+	// packages when both would be present (a container of repos isn't a monorepo).
 	var childrenKind string
 	if len(childGitRepos) > 0 {
-		// Child git repos detected — clear packages to avoid confusion.
-		pkgs = []string{}
+		pkgs = nil // clear packages to avoid confusion in the UI
 		childrenKind = "git-repos"
 	} else if len(pkgs) > 0 {
 		childrenKind = "packages"
 	}
 
+	// Normalize nil slices to [] so the JSON carries empty arrays (the frontend
+	// expects arrays, not null).
+	if pkgs == nil {
+		pkgs = []string{}
+	}
+	if childGitRepos == nil {
+		childGitRepos = []string{}
+	}
+	if siblings == nil {
+		siblings = []string{}
+	}
+
 	reply := v2ScanInspectReply{
-		Valid:          true,
-		AbsPath:        abs,
-		SuggestedGroup: slugify(base),
-		SuggestedSlug:  slugify(base),
-		Stack:          detect.Stack(abs),
-		Monorepo:       string(mono.Kind),
-		Packages:       pkgs,
-		ChildGitRepos:  childGitRepos,
-		ChildrenKind:   childrenKind,
-		HasAgentsMD:    fileExists(abs, "AGENTS.md") || fileExists(abs, "CLAUDE.md") || fileExists(abs, "GEMINI.md"),
+		Valid:           true,
+		AbsPath:         abs,
+		SuggestedGroup:  slugify(base),
+		SuggestedSlug:   slugify(base),
+		Stack:           detect.Stack(abs),
+		Monorepo:        string(class.Monorepo),
+		Packages:        pkgs,
+		ChildGitRepos:   childGitRepos,
+		ChildrenKind:    childrenKind,
+		SiblingGitRepos: siblings,
+		IsGitRepo:       class.IsGitRepo,
+		SuggestedAction: string(class.Suggested),
+		HasAgentsMD:     fileExists(abs, "AGENTS.md") || fileExists(abs, "CLAUDE.md") || fileExists(abs, "GEMINI.md"),
 	}
 	if fileExists(abs, ".grafel/group.json") {
 		reply.AlreadyRegistered = readManifestGroup(filepath.Join(abs, ".grafel", "group.json"))

--- a/internal/install/detect/classify.go
+++ b/internal/install/detect/classify.go
@@ -1,0 +1,196 @@
+// classify.go — shared path classification for the index wizard (#5336).
+//
+// ClassifyPath is the SINGLE SOURCE OF TRUTH used by both the CLI wizard
+// (internal/cli/wizard.go) and the dashboard scan/inspect handler
+// (internal/dashboard/v2_wizard.go) so the two surfaces agree on what a folder
+// IS and what action makes sense for it.
+//
+// The motivating bug: the old CLI wizard always scanned filepath.Dir(cwd) — the
+// PARENT of the cwd — for sibling git repos. For a "container" folder like
+//
+//	ivivo/
+//	  backend/   (.git)
+//	  frontend/  (.git)
+//
+// running the wizard from inside `ivivo` listed ivivo's UNRELATED siblings and
+// missed backend+frontend entirely. ClassifyPath instead understands the folder
+// you point it at: it reports whether the folder itself is a git repo, its
+// immediate CHILD git repos (the ivivo case), its monorepo packages, and — when
+// the folder is itself a repo — its SIBLING git repos. A suggested action is
+// derived from that so the wizard can pre-place its cursor sensibly.
+
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// SuggestedAction is the wizard action ClassifyPath recommends for a path.
+type SuggestedAction string
+
+const (
+	// ActionSingle — the path is a single git repo with no child repos and is
+	// not a monorepo. Index it as one unit.
+	ActionSingle SuggestedAction = "single"
+	// ActionGroup — the path is a container of multiple git repos (the ivivo
+	// case: child git repos), OR a git repo that has sibling git repos. Index a
+	// group of related repos.
+	ActionGroup SuggestedAction = "group"
+	// ActionMonorepo — the path is a monorepo (workspace manifest or container
+	// layout) with multiple package roots. Index selected packages.
+	ActionMonorepo SuggestedAction = "monorepo"
+	// ActionNone — the path is empty / not a repo / nothing indexable found.
+	ActionNone SuggestedAction = ""
+)
+
+// Classification is the result of ClassifyPath. All repo/package lists are
+// names/paths RELATIVE to the appropriate anchor, documented per field, so both
+// the CLI and the dashboard can render and resolve them consistently.
+type Classification struct {
+	// AbsPath is the resolved absolute path that was classified.
+	AbsPath string
+
+	// IsGitRepo reports whether AbsPath itself contains a .git entry.
+	IsGitRepo bool
+
+	// ChildGitRepos are the names of AbsPath's immediate child directories that
+	// are themselves git repos (relative to AbsPath). This is the ivivo case:
+	// classifying ivivo/ yields ["backend","frontend"]. Sorted, nil when none.
+	ChildGitRepos []string
+
+	// SiblingGitRepos are the ABSOLUTE paths of the OTHER git repos that live
+	// alongside AbsPath in its parent directory (excluding AbsPath itself).
+	// Populated only when AbsPath is itself a git repo — it answers "this repo
+	// plus its siblings" for the group action. Sorted, nil when none.
+	SiblingGitRepos []string
+
+	// Monorepo is the detected monorepo layout (KindNone when not a monorepo).
+	Monorepo MonorepoKind
+
+	// Packages are the repo-relative package roots when AbsPath is a monorepo.
+	// Sorted, nil when not a monorepo.
+	Packages []string
+
+	// Stack is the dominant detected stack of AbsPath ("go","node",…).
+	Stack string
+
+	// Suggested is the recommended wizard action derived from the above.
+	Suggested SuggestedAction
+}
+
+// ClassifyPath inspects absPath (which need not be absolute; it is resolved)
+// and returns a Classification describing how it should be indexed. It performs
+// NO writes. The precedence for the suggested action is:
+//
+//  1. Container of child git repos (ivivo: backend+frontend) → group.
+//  2. Monorepo (workspace manifest or services/apps/… layout) → monorepo.
+//  3. Git repo WITH siblings → group; a lone git repo → single.
+//  4. Nothing indexable → none.
+//
+// Note that ChildGitRepos and Packages are mutually exclusive in the suggested
+// action: a folder full of independent git repos is treated as a group, not a
+// monorepo, even if a child happens to carry a workspace manifest. Both lists
+// are still populated for callers that want to present alternatives.
+func ClassifyPath(path string) (Classification, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return Classification{}, err
+	}
+	c := Classification{AbsPath: abs}
+
+	c.IsGitRepo = dirHasGit(abs)
+	c.ChildGitRepos = childGitRepoNames(abs)
+
+	mono, err := DetectMonorepo(abs)
+	if err == nil {
+		c.Monorepo = mono.Kind
+		c.Packages = mono.Packages
+	}
+
+	if c.IsGitRepo {
+		c.SiblingGitRepos = siblingGitRepos(abs)
+		c.Stack = Stack(abs)
+	}
+
+	c.Suggested = suggestAction(c)
+	return c, nil
+}
+
+// suggestAction derives the recommended action from an otherwise-populated
+// Classification (see ClassifyPath's precedence doc).
+func suggestAction(c Classification) SuggestedAction {
+	switch {
+	case len(c.ChildGitRepos) > 0:
+		return ActionGroup
+	case c.IsGitRepo:
+		// A repo that is also a monorepo: prefer the monorepo action so the user
+		// gets per-package selection (the more specific intent).
+		if c.Monorepo != KindNone && len(c.Packages) > 0 {
+			return ActionMonorepo
+		}
+		if len(c.SiblingGitRepos) > 0 {
+			return ActionGroup
+		}
+		return ActionSingle
+	case c.Monorepo != KindNone && len(c.Packages) > 0:
+		return ActionMonorepo
+	default:
+		return ActionNone
+	}
+}
+
+// dirHasGit reports whether dir exists, is a directory, and contains a .git
+// entry (file or dir — covering worktrees and submodules).
+func dirHasGit(dir string) bool {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+// childGitRepoNames returns the names of dir's immediate child directories that
+// are git repos, sorted. Returns nil when none (so callers can test with len).
+func childGitRepoNames(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if dirHasGit(filepath.Join(dir, e.Name())) {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// siblingGitRepos returns the absolute paths of the OTHER git repos in repo's
+// parent directory (excluding repo itself), sorted. Returns nil when none.
+func siblingGitRepos(repo string) []string {
+	parent := filepath.Dir(repo)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return nil
+	}
+	self := filepath.Base(repo)
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() || e.Name() == self {
+			continue
+		}
+		full := filepath.Join(parent, e.Name())
+		if dirHasGit(full) {
+			out = append(out, full)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/install/detect/classify_test.go
+++ b/internal/install/detect/classify_test.go
@@ -1,0 +1,151 @@
+package detect
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// mkGitRepo creates dir/.git so dirHasGit reports true, plus an optional
+// manifest file to give it a stack.
+func mkGitRepo(t *testing.T, dir, manifest, body string) {
+	t.Helper()
+	write(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\n")
+	if manifest != "" {
+		write(t, filepath.Join(dir, manifest), body)
+	}
+}
+
+// TestClassifyPath_Container is the ivivo case: a plain folder holding two child
+// git repos. It must report ChildGitRepos=[backend,frontend] and suggest group,
+// NOT scan the parent for siblings.
+func TestClassifyPath_Container(t *testing.T) {
+	root := t.TempDir()
+	ivivo := filepath.Join(root, "ivivo")
+	mkGitRepo(t, filepath.Join(ivivo, "backend"), "go.mod", "module backend\n")
+	mkGitRepo(t, filepath.Join(ivivo, "frontend"), "package.json", `{"name":"frontend"}`)
+	// An unrelated sibling of ivivo that must NOT leak in.
+	mkGitRepo(t, filepath.Join(root, "unrelated"), "go.mod", "module unrelated\n")
+
+	c, err := ClassifyPath(ivivo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.IsGitRepo {
+		t.Errorf("ivivo should not itself be a git repo")
+	}
+	if got := c.ChildGitRepos; len(got) != 2 || got[0] != "backend" || got[1] != "frontend" {
+		t.Errorf("ChildGitRepos = %v, want [backend frontend]", got)
+	}
+	if c.Suggested != ActionGroup {
+		t.Errorf("Suggested = %q, want group", c.Suggested)
+	}
+	if len(c.SiblingGitRepos) != 0 {
+		t.Errorf("SiblingGitRepos should be empty for a non-repo container, got %v", c.SiblingGitRepos)
+	}
+}
+
+// TestClassifyPath_SingleWithSiblings: a lone git repo that has a sibling git
+// repo → single is NOT right; we want group (this repo + sibling). With no
+// siblings → single.
+func TestClassifyPath_SingleWithSiblings(t *testing.T) {
+	root := t.TempDir()
+	repoA := filepath.Join(root, "service-a")
+	repoB := filepath.Join(root, "service-b")
+	mkGitRepo(t, repoA, "go.mod", "module a\n")
+	mkGitRepo(t, repoB, "go.mod", "module b\n")
+
+	c, err := ClassifyPath(repoA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.IsGitRepo {
+		t.Fatalf("service-a should be a git repo")
+	}
+	if c.Stack != "go" {
+		t.Errorf("Stack = %q, want go", c.Stack)
+	}
+	if len(c.SiblingGitRepos) != 1 || filepath.Base(c.SiblingGitRepos[0]) != "service-b" {
+		t.Errorf("SiblingGitRepos = %v, want [service-b]", c.SiblingGitRepos)
+	}
+	if c.Suggested != ActionGroup {
+		t.Errorf("Suggested = %q, want group (repo with siblings)", c.Suggested)
+	}
+}
+
+func TestClassifyPath_LoneSingle(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "lonely")
+	mkGitRepo(t, repo, "go.mod", "module lonely\n")
+
+	c, err := ClassifyPath(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.SiblingGitRepos) != 0 {
+		t.Errorf("SiblingGitRepos = %v, want empty", c.SiblingGitRepos)
+	}
+	if c.Suggested != ActionSingle {
+		t.Errorf("Suggested = %q, want single", c.Suggested)
+	}
+}
+
+// TestClassifyPath_Monorepo: a pnpm workspace → packages + monorepo action.
+func TestClassifyPath_Monorepo(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "mono")
+	mkGitRepo(t, repo, "pnpm-workspace.yaml", "packages:\n  - packages/*\n")
+	write(t, filepath.Join(repo, "packages", "web", "package.json"), `{"name":"web"}`)
+	write(t, filepath.Join(repo, "packages", "api", "package.json"), `{"name":"api"}`)
+
+	c, err := ClassifyPath(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Monorepo == KindNone {
+		t.Fatalf("expected a monorepo kind, got none")
+	}
+	if len(c.Packages) != 2 {
+		t.Errorf("Packages = %v, want 2 entries", c.Packages)
+	}
+	if c.Suggested != ActionMonorepo {
+		t.Errorf("Suggested = %q, want monorepo", c.Suggested)
+	}
+}
+
+// TestClassifyPath_Empty: an empty dir → no children, no packages, none.
+func TestClassifyPath_Empty(t *testing.T) {
+	root := t.TempDir()
+	empty := filepath.Join(root, "empty")
+	write(t, filepath.Join(empty, ".keep"), "")
+
+	c, err := ClassifyPath(empty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.IsGitRepo || len(c.ChildGitRepos) != 0 || len(c.Packages) != 0 {
+		t.Errorf("empty dir misclassified: %+v", c)
+	}
+	if c.Suggested != ActionNone {
+		t.Errorf("Suggested = %q, want none", c.Suggested)
+	}
+}
+
+// TestClassifyPath_ContainerWinsOverMonorepo: child git repos take precedence
+// even if a child carries a workspace manifest at the container level.
+func TestClassifyPath_ContainerWinsOverMonorepo(t *testing.T) {
+	root := t.TempDir()
+	container := filepath.Join(root, "platform")
+	mkGitRepo(t, filepath.Join(container, "api"), "go.mod", "module api\n")
+	mkGitRepo(t, filepath.Join(container, "web"), "package.json", `{"name":"web"}`)
+
+	c, err := ClassifyPath(container)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Suggested != ActionGroup {
+		t.Errorf("Suggested = %q, want group", c.Suggested)
+	}
+	if len(c.ChildGitRepos) != 2 {
+		t.Errorf("ChildGitRepos = %v, want 2", c.ChildGitRepos)
+	}
+}

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -56,9 +56,17 @@ import { aggregateProgress, overallPhaseLabel } from "@/lib/index-progress-fold"
 import { IndexProgressFeed } from "@/components/chrome/index-progress-feed";
 import { ApiError } from "@/lib/api";
 import type { ScanInspectReply, WizardRepo } from "@/data/types";
+import {
+  WIZARD_ACTIONS,
+  defaultActionFor,
+  type WizardAction,
+} from "@/lib/wizard-action";
 import { cn } from "@/lib/utils";
 
-type WizardStep = "pick" | "detect" | "index";
+// Action-first flow (#5336): the wizard now opens on an action choice (single /
+// group / monorepo / add-to-group) — parity with the CLI wizard — before the
+// folder picker. The chosen action tunes the Detect step's labels and defaults.
+type WizardStep = "action" | "pick" | "detect" | "index";
 
 export interface ScanWizardProps {
   open: boolean;
@@ -82,7 +90,10 @@ function slugify(s: string): string {
 export function ScanWizard(props: ScanWizardProps) {
   const { open, onOpenChange, mode, groupId, groupName, takenNames = [], existingPaths = [], onIndexed } = props;
 
-  const [step, setStep] = useState<WizardStep>("pick");
+  // In "create" mode the wizard opens on the action choice; in "add-repo" mode
+  // the action is implicitly "add-group" so we skip straight to the picker.
+  const [step, setStep] = useState<WizardStep>(mode === "create" ? "action" : "pick");
+  const [action, setAction] = useState<WizardAction>(mode === "add-repo" ? "add-group" : "single");
   const [path, setPath] = useState("");
   const [scan, setScan] = useState<ScanInspectReply | null>(null);
   const [name, setName] = useState("");
@@ -135,7 +146,8 @@ export function ScanWizard(props: ScanWizardProps) {
 
   // Reset everything when the dialog closes.
   function reset() {
-    setStep("pick");
+    setStep(mode === "create" ? "action" : "pick");
+    setAction(mode === "add-repo" ? "add-group" : "single");
     setPath("");
     setScan(null);
     setName("");
@@ -180,6 +192,14 @@ export function ScanWizard(props: ScanWizardProps) {
       const result = await inspect.mutateAsync(p);
       setScan(result);
       if (result.valid) {
+        // Reconcile the chosen action with what the shared classifier detected
+        // (#5336). In add-repo mode the action is pinned to "add-group". In
+        // create mode, if the detected smart default disagrees with the picked
+        // action, prefer the detection so the Detect step shows the right
+        // selection list (e.g. a container folder → group/child repos).
+        if (mode === "create") {
+          setAction(defaultActionFor(result));
+        }
         setName((prev) => prev || result.suggestedGroup);
         // Default to ALL detected packages checked (#1531). Empty for a single
         // repo — then runIndex registers the whole folder as one repo.
@@ -303,32 +323,93 @@ export function ScanWizard(props: ScanWizardProps) {
           {mode === "create" ? "Index a new group" : <>Add a repo to <span className="font-mono">{groupName}</span></>}
         </DialogTitle>
         <DialogDescription>
+          {step === "action" && "What do you want to index?"}
           {step === "pick" && "Point Grafel at a repository folder on this machine."}
           {step === "detect" && "Review what we detected, then start indexing."}
           {step === "index" && "Indexing in progress — you can leave this open."}
         </DialogDescription>
 
-        {/* Stepper */}
-        <ol className="mt-3 flex items-center gap-2 text-xs text-text-3" data-testid="wizard-stepper">
-          {(["pick", "detect", "index"] as WizardStep[]).map((s, i) => (
-            <li key={s} className="flex items-center gap-2">
-              <span
-                className={cn(
-                  "inline-flex size-5 items-center justify-center rounded-full border font-mono",
-                  step === s
-                    ? "border-accent bg-accent-soft text-accent-strong"
-                    : "border-border text-text-4",
-                )}
-              >
-                {i + 1}
-              </span>
-              <span className={cn(step === s ? "text-text-2" : "text-text-4")}>
-                {s === "pick" ? "Pick" : s === "detect" ? "Detect" : "Index"}
-              </span>
-              {i < 2 && <span className="text-border">/</span>}
-            </li>
-          ))}
-        </ol>
+        {/* Stepper — the "action" step is only present in create mode. */}
+        {(() => {
+          const steps: { id: WizardStep; label: string }[] = [
+            ...(mode === "create" ? [{ id: "action" as WizardStep, label: "Action" }] : []),
+            { id: "pick", label: "Pick" },
+            { id: "detect", label: "Detect" },
+            { id: "index", label: "Index" },
+          ];
+          return (
+            <ol className="mt-3 flex items-center gap-2 text-xs text-text-3" data-testid="wizard-stepper">
+              {steps.map((s, i) => (
+                <li key={s.id} className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      "inline-flex size-5 items-center justify-center rounded-full border font-mono",
+                      step === s.id
+                        ? "border-accent bg-accent-soft text-accent-strong"
+                        : "border-border text-text-4",
+                    )}
+                  >
+                    {i + 1}
+                  </span>
+                  <span className={cn(step === s.id ? "text-text-2" : "text-text-4")}>{s.label}</span>
+                  {i < steps.length - 1 && <span className="text-border">/</span>}
+                </li>
+              ))}
+            </ol>
+          );
+        })()}
+
+        {/* Step 0 — action select (create mode only): the four-action first step,
+            parity with the CLI wizard (#5336). The picked action tunes the
+            Detect step; the smart default is reconciled against detection once a
+            folder is scanned. */}
+        {step === "action" && (
+          <div className="mt-4 space-y-2" data-testid="wizard-action">
+            <ul className="space-y-2">
+              {WIZARD_ACTIONS.map((a) => {
+                const selected = action === a.value;
+                return (
+                  <li key={a.value}>
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left text-sm",
+                        selected
+                          ? "border-accent bg-accent-soft text-text-1"
+                          : "border-border bg-surface text-text-2 hover:bg-surface-2",
+                      )}
+                      onClick={() => setAction(a.value)}
+                      data-testid="wizard-action-option"
+                      data-action={a.value}
+                      data-selected={selected}
+                    >
+                      <span
+                        className={cn(
+                          "inline-flex size-4 shrink-0 items-center justify-center rounded-full border",
+                          selected ? "border-accent-strong" : "border-text-4",
+                        )}
+                      >
+                        {selected && <span className="size-2 rounded-full bg-accent-strong" />}
+                      </span>
+                      <span className="min-w-0 flex-1">{a.label}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="flex justify-between gap-2 pt-2">
+              <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={() => setStep("pick")} data-testid="wizard-action-next">
+                Next
+                <ArrowRight size={13} />
+              </Button>
+            </div>
+          </div>
+        )}
 
         {/* Step 1 — pick directory: a server-side folder browser (#1529). The
             daemon lists ITS OWN filesystem so navigating to a folder and
@@ -476,7 +557,14 @@ export function ScanWizard(props: ScanWizardProps) {
               </label>
             </form>
 
-            <div className="flex justify-end pt-1">
+            <div className="flex justify-between pt-1">
+              {mode === "create" ? (
+                <Button type="button" variant="ghost" onClick={() => setStep("action")}>
+                  Back
+                </Button>
+              ) : (
+                <span />
+              )}
               <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
                 Cancel
               </Button>

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1356,6 +1356,20 @@ export interface ScanInspectReply {
    * non-empty, "" otherwise. The UI uses this to label the checkbox list.
    */
   childrenKind: "git-repos" | "packages" | "";
+  /**
+   * Absolute paths of the OTHER git repos alongside absPath in its parent —
+   * populated only when absPath is itself a git repo. Used by the action-first
+   * "group" flow to offer "this repo + its siblings" (#5336).
+   */
+  siblingGitRepos: string[];
+  /** Whether absPath itself is a git repo. */
+  isGitRepo: boolean;
+  /**
+   * Recommended wizard action derived from the shared detect.ClassifyPath
+   * classifier ("single" | "group" | "monorepo" | ""), so the dashboard's
+   * action-first step matches the CLI wizard (#5336).
+   */
+  suggestedAction: "single" | "group" | "monorepo" | "";
   hasAgentsMd: boolean;
   alreadyRegistered?: string;
   error?: string;

--- a/webui-v2/src/lib/wizard-action.test.ts
+++ b/webui-v2/src/lib/wizard-action.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+
+import { defaultActionFor, groupCandidatesFor } from "./wizard-action";
+import type { ScanInspectReply } from "@/data/types";
+
+function reply(partial: Partial<ScanInspectReply>): ScanInspectReply {
+  return {
+    valid: true,
+    absPath: "/code/x",
+    suggestedGroup: "x",
+    suggestedSlug: "x",
+    stack: "go",
+    monorepo: "",
+    packages: [],
+    childGitRepos: [],
+    childrenKind: "",
+    siblingGitRepos: [],
+    isGitRepo: false,
+    suggestedAction: "",
+    hasAgentsMd: false,
+    ...partial,
+  };
+}
+
+describe("defaultActionFor", () => {
+  it("maps suggestedAction through", () => {
+    expect(defaultActionFor(reply({ suggestedAction: "group" }))).toBe("group");
+    expect(defaultActionFor(reply({ suggestedAction: "monorepo" }))).toBe("monorepo");
+    expect(defaultActionFor(reply({ suggestedAction: "single" }))).toBe("single");
+  });
+  it("falls back to single for empty/null", () => {
+    expect(defaultActionFor(reply({ suggestedAction: "" }))).toBe("single");
+    expect(defaultActionFor(null)).toBe("single");
+  });
+});
+
+describe("groupCandidatesFor", () => {
+  it("returns child git repos (the ivivo case)", () => {
+    const scan = reply({
+      absPath: "/code/ivivo",
+      isGitRepo: false,
+      childGitRepos: ["frontend", "backend"],
+      childrenKind: "git-repos",
+      suggestedAction: "group",
+    });
+    expect(groupCandidatesFor(scan)).toEqual(["backend", "frontend"]);
+  });
+
+  it("returns self + sibling basenames when the path is a repo with siblings", () => {
+    const scan = reply({
+      absPath: "/code/service-a",
+      isGitRepo: true,
+      siblingGitRepos: ["/code/service-b", "/code/service-c"],
+      suggestedAction: "group",
+    });
+    expect(groupCandidatesFor(scan)).toEqual(["service-a", "service-b", "service-c"]);
+  });
+
+  it("returns empty for an invalid or non-repo folder", () => {
+    expect(groupCandidatesFor(reply({ valid: false }))).toEqual([]);
+    expect(groupCandidatesFor(reply({ isGitRepo: false, childGitRepos: [] }))).toEqual([]);
+    expect(groupCandidatesFor(null)).toEqual([]);
+  });
+});

--- a/webui-v2/src/lib/wizard-action.ts
+++ b/webui-v2/src/lib/wizard-action.ts
@@ -1,0 +1,72 @@
+/* wizard-action.ts — action-first wizard logic (#5336), shared with the CLI.
+ *
+ * The dashboard scan wizard mirrors the CLI's four-action first step:
+ *   single   — index one repository
+ *   group    — index a group of related repositories
+ *   monorepo — index a monorepo's packages
+ *   add-group — add a repository to an existing group
+ *
+ * The "detect" reply from POST /api/v2/scan/inspect carries a `suggestedAction`
+ * computed by the SAME Go classifier (detect.ClassifyPath) the CLI uses, plus
+ * the child git repos / sibling git repos / packages it found. These pure
+ * helpers turn that reply into UI defaults so the two surfaces agree. They are
+ * dependency-free and unit-tested (the component itself isn't covered by the
+ * src/lib vitest scope). */
+
+import type { ScanInspectReply } from "@/data/types";
+
+export type WizardAction = "single" | "group" | "monorepo" | "add-group";
+
+/** The four actions, in display order, with their labels (parity with the CLI). */
+export const WIZARD_ACTIONS: { value: WizardAction; label: string }[] = [
+  { value: "single", label: "Index a single repository" },
+  { value: "group", label: "Index a group of related repositories" },
+  { value: "monorepo", label: "Index a monorepo" },
+  { value: "add-group", label: "Add a repository to an existing group" },
+];
+
+/**
+ * defaultActionFor maps a scan reply's `suggestedAction` to the wizard's default
+ * action. Falls back to "single" when unknown/empty — matching the CLI's
+ * defaultAction(). "add-group" is never auto-suggested (it depends on existing
+ * groups, a user intent rather than a folder property).
+ */
+export function defaultActionFor(scan: ScanInspectReply | null): WizardAction {
+  switch (scan?.suggestedAction) {
+    case "group":
+      return "group";
+    case "monorepo":
+      return "monorepo";
+    case "single":
+      return "single";
+    default:
+      return "single";
+  }
+}
+
+/**
+ * groupCandidatesFor derives the candidate group member repos from a scan reply,
+ * as RELATIVE names (matching how the checkbox list renders childGitRepos):
+ *   - child git repos when present (the ivivo case: backend + frontend), else
+ *   - the repo itself ("." ) plus its sibling basenames when absPath is a repo,
+ *   - otherwise empty.
+ *
+ * This is the data the "group" action presents as a multiselect — the same
+ * precedence (option 1a) the CLI's groupCandidates() uses.
+ */
+export function groupCandidatesFor(scan: ScanInspectReply | null): string[] {
+  if (!scan?.valid) return [];
+  if ((scan.childGitRepos?.length ?? 0) > 0) {
+    return [...scan.childGitRepos].sort();
+  }
+  if (scan.isGitRepo) {
+    const siblings = (scan.siblingGitRepos ?? []).map(basename);
+    return [basename(scan.absPath), ...siblings].sort();
+  }
+  return [];
+}
+
+function basename(p: string): string {
+  const parts = p.replace(/\/+$/, "").split("/");
+  return parts[parts.length - 1] || p;
+}


### PR DESCRIPTION
Fixes #5336

The index wizard scanned the **parent** of cwd for sibling git repos, which misfired for container folders: running it inside `another group/` (holding `backend/` + `frontend/`, each with `.git`) listed another group's unrelated siblings and missed the real repos. This reworks both the CLI and dashboard wizards to an **action-first flow** with smart cwd detection, sharing a single classifier so the two surfaces agree.

## A. Shared classifier — `detect.ClassifyPath(absPath)`
New `internal/install/detect/classify.go`. Returns a `Classification`:
- `IsGitRepo` — is the path itself a git repo
- `ChildGitRepos` — immediate child git repos (the another group case → `[backend, frontend]`)
- `SiblingGitRepos` — absolute paths of the OTHER repos in the parent (only when the path is itself a repo)
- `Monorepo` + `Packages` — reuses existing `DetectMonorepo`
- `Stack`, and a `Suggested` action (`single` / `group` / `monorepo` / none)

Precedence: container of child repos → group; monorepo → monorepo; repo with siblings → group; lone repo → single. Unit-tested (container, single+siblings, lone, monorepo, empty, container-wins-over-monorepo).

## B. CLI wizard — action-first (the core fix)
Interactive `grafel wizard` now:
1. **Action select** (always all 4: single / group / monorepo / add-to-group), cursor pre-placed on `ClassifyPath(cwd).Suggested`.
2. Per action:
   - **Single** — confirm cwd if it's a repo, else prompt a path. No scan.
   - **Group** — auto-resolve candidates (option 1a, no siblings-vs-parent prompt): child git repos if present (another group → backend+frontend), elif cwd-is-repo → cwd + siblings, else prompt a folder. Shown as a `[ ]`/`[✓]` multiselect, filterable + scrollable, count in the title, plus a "scan a different folder…" entry.
   - **Monorepo** — shared-classifier packages → `[ ]`/`[✓]` multiselect, each package registered as its own repo with `Modules`.
   - **Add to existing group** — pick a registry group → multi-add discovered/typed repos appended to it.

The old `filepath.Dir(cwd)` default scan is gone. Non-interactive `--repos`/`--parent`/`--exclude` are unchanged for scripting.

## C. Dashboard wizard — parity
`POST /api/v2/scan/inspect` now classifies via the SAME `ClassifyPath` and returns `suggestedAction`, `isGitRepo`, `siblingGitRepos` (alongside the existing `childGitRepos`/`packages`). `scan-wizard.tsx` gains the same four-action first step (create mode), with the smart default reconciled against detection once a folder is scanned. Action-logic extracted to a unit-tested `lib/wizard-action.ts`. The #5326/#5329/#5331/#5333/#5334 progress fixes are intact.

## How another group resolves now (both surfaces)
`ClassifyPath(another group)` → `IsGitRepo=false`, `ChildGitRepos=[backend, frontend]`, `Suggested=group`. CLI group action presents `another group/backend` + `another group/frontend` as the multiselect; the dashboard's group action shows the same two child repos. Unrelated siblings of `another group` never enter the candidate set.

## Validation
- Go: `go build ./...`, `go vet`, `gofmt -l` empty, `go test ./internal/install/... ./internal/cli/... ./internal/dashboard/ ./cmd/grafel/...` green.
- Frontend: `npm ci && npm run build` clean, `tsc --noEmit` clean, `npm test` green (179 tests incl. new `wizard-action.test.ts`).
- `internal/dashboard/dist` untouched; `make dashboard-build` not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
