### PR TITLE
fix(wizard): auto-index on create + container-folder name + TUI hints/space + watcher install robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Watcher install is robust to the flaky launchctl err-5 and never aborts the
+  wizard (#5338):** `launchctl bootstrap` intermittently fails the first
+  bootstrap of a freshly written plist with exit code 5 ("Bootstrap failed: 5:
+  Input/output error"). The macOS watcher loader now retries the
+  bootout→bootstrap pair (bounded, with a small backoff) **specifically on err
+  5**, which clears the transient failure. And a watcher that still fails to
+  activate is now a **non-fatal warning** instead of an abort: the group config
+  is already persisted, so the wizard completes and the group indexes
+  ("warning: watcher for X not activated: …; the group is still registered and
+  will index") ([#5338](https://github.com/cajasmota/grafel/issues/5338)).
+- **Deleting a group now cleans up its watcher launchd/systemd/schtasks units
+  (#5338):** group delete (CLI `grafel delete`, dashboard `DELETE
+  /api/v2/groups/{group}`) previously left `com.grafel.watcher.<group>.*` jobs
+  loaded and plists on disk, so recreating the group fought stale state. Delete
+  now Unloads (bootout) and removes the watcher unit + plist for every repo in
+  the group — idempotent, tolerating "not loaded"
+  ([#5338](https://github.com/cajasmota/grafel/issues/5338)).
+
+### Changed
+
+- **`grafel wizard` auto-indexes the new group with live progress (#5338):**
+  after registering a group (or adding repos to an existing one), the wizard now
+  triggers an index by default and renders live CLI phase progress — the same
+  broker event stream the dashboard shows — so it ends register → "Indexing…" →
+  "Done". A `--no-index` flag skips it for scripting, and a down daemon is a
+  warning (the group is registered and indexes later), not a failure
+  ([#5338](https://github.com/cajasmota/grafel/issues/5338)).
+- **Wizard group-name default is the container folder, not a child repo
+  (#5338):** from `ivivo/` holding `backend/` + `frontend/`, the suggested group
+  name is now `ivivo` (the common-parent container folder) instead of an
+  arbitrary selected child repo's slug. A single selected repo still defaults to
+  its own basename ([#5338](https://github.com/cajasmota/grafel/issues/5338)).
+- **Wizard TUI gains navigation hints, more height, and `[ ]`/`[✓]` checkboxes
+  (#5338):** each interactive step now shows a footer hint ("↑/↓ move · space
+  select · enter confirm · / filter · esc back") so users discover that **space**
+  toggles a multiselect item; the select/multiselect lists use more terminal
+  height (and scroll when long) instead of a few cramped rows; and multiselect
+  options now render explicit `[ ]`/`[✓]` brackets (the stock huh `ThemeCharm`
+  glyphs `•`/`✓` were ambiguous — the fix sets the correct
+  `SelectedPrefix`/`UnselectedPrefix` theme fields)
+  ([#5338](https://github.com/cajasmota/grafel/issues/5338)).
+
 ### Changed
 
 - **Index wizard is now action-first with smart cwd detection (#5336):** both the

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -422,6 +422,88 @@ func finishRebuild(
 	return nil
 }
 
+// indexGroupWithProgress triggers a full index of a group via the daemon and
+// renders live phase progress to w (the same broker SSE / poll-fallback flow as
+// `grafel rebuild`), then prints a summary. It is the shared entry point used by
+// the wizard and `group add` so a freshly-registered group ends with the same
+// "Indexing… → Done" experience as the dashboard (#5338).
+//
+// It returns errDaemonNotRunning when the daemon is down so callers can degrade
+// gracefully (the group is still registered; the user can index later).
+func indexGroupWithProgress(w, errW io.Writer, group string) error {
+	c, err := client.Dial()
+	if err != nil {
+		if errors.Is(err, client.ErrDaemonNotRunning) {
+			return errDaemonNotRunning
+		}
+		return err
+	}
+	defer c.Close()
+
+	dashPort := 0
+	if st, stErr := c.Status(); stErr == nil && st.DashboardPort > 0 {
+		dashPort = st.DashboardPort
+	}
+
+	outcomeCh := make(chan rebuildOutcome, 1)
+	token := progressToken()
+	go func() {
+		reply, rpcErr := c.Rebuild(proto.RebuildArgs{
+			Group:         group,
+			ProgressToken: token,
+		})
+		outcomeCh <- rebuildOutcome{
+			repos:    reply.Repos,
+			warning:  reply.Warning,
+			elapsed:  reply.ElapsedSec,
+			entities: reply.TotalEntities,
+			rels:     reply.TotalRels,
+			err:      rpcErr,
+		}
+	}()
+
+	fmt.Fprintf(w, "Indexing group '%s'...\n", group)
+
+	// Path 1: live broker progress via SSE (matches the dashboard exactly).
+	if dashPort > 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+			outcome := runBrokerProgress(ctx, w, group, sseCh, outcomeCh, false, false)
+			cancel()
+			if outcome.err != nil {
+				return outcome.err
+			}
+			return finishIndexSummary(w, errW, group, token, outcome)
+		}
+	}
+
+	// Path 2: no dashboard broker — wait for the RPC and print the summary.
+	outcome := <-outcomeCh
+	if outcome.err != nil {
+		return outcome.err
+	}
+	return finishIndexSummary(w, errW, group, token, outcome)
+}
+
+// finishIndexSummary renders the post-index summary for indexGroupWithProgress.
+// It mirrors finishRebuild's non-JSON branch but is writer-based (no cobra).
+func finishIndexSummary(w, errW io.Writer, group, token string, o rebuildOutcome) error {
+	elapsed := time.Duration(o.elapsed * float64(time.Second))
+	if len(o.repos) > 0 {
+		sum := ComputeRebuildSummary(group, o.repos, elapsed)
+		PrintRebuildSummary(w, sum)
+		recordHealthHistory(group, sum)
+	} else {
+		fmt.Fprintf(w, "Group '%s' indexed\n", group)
+	}
+	if o.warning != "" {
+		fmt.Fprintf(errW, "warning: %s\n", o.warning)
+	}
+	_ = token
+	return nil
+}
+
 // printProgressLine emits one human-readable progress line for a repo.
 //
 // Format follows the spec from issue #989:

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -30,6 +30,7 @@ func newWizardCmd() *cobra.Command {
 		gitHooks       bool
 		agentHooks     bool
 		runInstall     bool
+		noIndex        bool
 	)
 	cmd := &cobra.Command{
 		Use:   "wizard",
@@ -48,6 +49,8 @@ func newWizardCmd() *cobra.Command {
 				GitHooks:       gitHooks,
 				AgentHooks:     agentHooks,
 				RunInstall:     runInstall,
+				NoIndex:        noIndex,
+				ErrOut:         cmd.ErrOrStderr(),
 			}
 			return runWizard(out, opts)
 		},
@@ -63,6 +66,7 @@ func newWizardCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&gitHooks, "git-hooks", true, "enable git hooks")
 	cmd.Flags().BoolVar(&agentHooks, "agent-hooks", false, "opt-in: install the Claude Code PreToolUse grep-interceptor hook that nudges toward grafel on structural greps (advisory-only, never blocks; Claude Code only)")
 	cmd.Flags().BoolVar(&runInstall, "install", true, "run install at the end")
+	cmd.Flags().BoolVar(&noIndex, "no-index", false, "skip indexing the group at the end (default: index with live progress; requires a running daemon)")
 	return cmd
 }
 
@@ -76,6 +80,16 @@ type wizardOptions struct {
 	Watchers, GitHooks  bool
 	AgentHooks          bool
 	RunInstall          bool
+	NoIndex             bool
+	ErrOut              io.Writer // stderr sink for warnings; nil → os.Stderr
+}
+
+// errWriter returns the configured stderr sink, defaulting to os.Stderr.
+func (o wizardOptions) errWriter() io.Writer {
+	if o.ErrOut != nil {
+		return o.ErrOut
+	}
+	return os.Stderr
 }
 
 func runWizard(out io.Writer, opts wizardOptions) error {
@@ -128,9 +142,12 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 	cfg.Repos = append(cfg.Repos, repos...)
 
 	// Group name — prompted AFTER the action so "add to existing group" can skip
-	// it. Pre-fill a suggestion from the first repo's basename.
+	// it. Pre-fill a suggestion from the CONTAINER folder (the common parent of
+	// the selected repos), not a child repo's slug: from ivivo/ holding
+	// backend+frontend the default is "ivivo", not "backend" (#5338). For a
+	// single repo the repo's own basename is the sensible default.
 	if opts.GroupName == "" {
-		opts.GroupName = filepath.Base(repos[0].Path)
+		opts.GroupName = defaultGroupName(repos)
 		if err := huh.NewInput().
 			Title("Group name").
 			Description("Used as the registry key and the per-group config filename.").
@@ -178,8 +195,41 @@ func finishWizard(out io.Writer, cfg *registry.GroupConfig, opts wizardOptions) 
 
 	// Steps 5-7 — persist + register + manifests + install. Shared with the
 	// non-interactive `group add` command via applyGroupConfig.
-	_, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
-	return err
+	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall}); err != nil {
+		return err
+	}
+
+	// Step 8 — index the freshly-registered group with live phase progress so
+	// the wizard ends register → "Indexing…" → "Done", matching the dashboard
+	// (#5338). Opt out with --no-index. A down daemon is a warning, not a
+	// failure: the group is registered and will index later.
+	//
+	// The non-interactive (scripting/CI) path does NOT auto-index — it is
+	// flag-driven and callers there opt in explicitly (e.g. `group add
+	// --index`), so a missing daemon never breaks an automated `wizard
+	// --non-interactive` run.
+	if opts.NonInteractive {
+		return nil
+	}
+	return maybeIndexGroup(out, opts.errWriter(), cfg.Name, opts.NoIndex)
+}
+
+// maybeIndexGroup indexes group with live progress unless noIndex is set. A
+// daemon-not-running condition is downgraded to a warning so the wizard still
+// completes successfully (the group is already registered).
+func maybeIndexGroup(out, errOut io.Writer, group string, noIndex bool) error {
+	if noIndex {
+		fmt.Fprintf(out, "skipping index (--no-index); run `grafel rebuild %s` when ready\n", group)
+		return nil
+	}
+	if err := indexGroupWithProgress(out, errOut, group); err != nil {
+		if errors.Is(err, errDaemonNotRunning) {
+			fmt.Fprintf(out, "daemon not running — group registered but not indexed; run `grafel rebuild %s` once the daemon is up\n", group)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // groupApplyOptions controls the side-effecting half of group registration
@@ -235,6 +285,9 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 	}
 	fmt.Fprintf(out, "installed %d hooks, %d watchers, %d MCP entries\n",
 		len(res.HooksInstalled), len(res.WatcherUnits), len(res.MCPSettings))
+	for _, warn := range res.WatcherWarnings {
+		fmt.Fprintf(out, "warning: %s\n", warn)
+	}
 	return res, nil
 }
 
@@ -251,6 +304,33 @@ const (
 	actionMonorepo wizardAction = "monorepo"
 	actionAddGroup wizardAction = "add-group"
 )
+
+// defaultGroupName suggests a group name for the selected repos. For a single
+// repo it is that repo's basename. For multiple repos it is the basename of
+// their common parent directory — the CONTAINER folder (e.g. ivivo/ for
+// ivivo/backend + ivivo/frontend) — so the default is the umbrella name rather
+// than an arbitrary child repo's slug (#5338). Falls back to the first repo's
+// basename when no common parent can be derived.
+func defaultGroupName(repos []registry.Repo) string {
+	if len(repos) == 0 {
+		return ""
+	}
+	if len(repos) == 1 {
+		return filepath.Base(repos[0].Path)
+	}
+	parent := filepath.Dir(repos[0].Path)
+	for _, r := range repos[1:] {
+		if filepath.Dir(r.Path) != parent {
+			// Repos don't share a single parent — fall back to the first
+			// repo's container folder rather than an unrelated ancestor.
+			return filepath.Base(filepath.Dir(repos[0].Path))
+		}
+	}
+	if base := filepath.Base(parent); base != "" && base != "." && base != string(filepath.Separator) {
+		return base
+	}
+	return filepath.Base(repos[0].Path)
+}
 
 // repoFromPath builds a registry.Repo for an absolute path, detecting its stack.
 func repoFromPath(abs string) registry.Repo {
@@ -277,14 +357,16 @@ func runInteractiveRepoSelect(out io.Writer) (repos []registry.Repo, addToGroup 
 	action := defaultAction(class)
 	if err := huh.NewSelect[wizardAction]().
 		Title("What do you want to index?").
-		Description(fmt.Sprintf("Detected: %s", describeClassification(class))).
+		Description(fmt.Sprintf("Detected: %s\n%s", describeClassification(class), navHintSelect)).
 		Options(
 			huh.NewOption("Index a single repository", actionSingle),
 			huh.NewOption("Index a group of related repositories", actionGroup),
 			huh.NewOption("Index a monorepo", actionMonorepo),
 			huh.NewOption("Add a repository to an existing group", actionAddGroup),
 		).
+		Height(wizardListHeight(4)).
 		Value(&action).
+		WithTheme(wizardTheme()).
 		Run(); err != nil {
 		return nil, "", err
 	}
@@ -433,10 +515,12 @@ func resolveMonorepoAction(out io.Writer, class detect.Classification) ([]regist
 	var chosen []string
 	if err := huh.NewMultiSelect[string]().
 		Title(fmt.Sprintf("%d packages found", len(class.Packages))).
+		Description(navHintMulti).
 		Options(opts...).
 		Filterable(true).
-		Height(min(len(class.Packages)+4, 18)).
+		Height(wizardListHeight(len(class.Packages))).
 		Value(&chosen).
+		WithTheme(wizardTheme()).
 		Run(); err != nil {
 		return nil, err
 	}
@@ -475,8 +559,11 @@ func resolveAddToGroupAction(out io.Writer) ([]registry.Repo, string, error) {
 	var target string
 	if err := huh.NewSelect[string]().
 		Title("Add to which group?").
+		Description(navHintSelect).
 		Options(gopts...).
+		Height(wizardListHeight(len(gopts))).
 		Value(&target).
+		WithTheme(wizardTheme()).
 		Run(); err != nil {
 		return nil, "", err
 	}
@@ -546,10 +633,12 @@ func addReposToExistingGroup(out io.Writer, group string, repos []registry.Repo,
 		return errors.New("all selected repos are already in the group")
 	}
 	_, err = applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
-	if err == nil {
-		fmt.Fprintf(out, "added %d repo(s) to group %q\n", added, group)
+	if err != nil {
+		return err
 	}
-	return err
+	fmt.Fprintf(out, "added %d repo(s) to group %q\n", added, group)
+	// Re-index so the newly-added repos are queryable immediately (#5338).
+	return maybeIndexGroup(out, opts.errWriter(), group, opts.NoIndex)
 }
 
 // multiSelectRepos renders a scrollable, type-to-filter [ ]/[✓] multiselect of
@@ -566,10 +655,12 @@ func multiSelectRepos(candidates []string) (chosen []string, rescan bool, err er
 	var selected []string
 	if err := huh.NewMultiSelect[string]().
 		Title(fmt.Sprintf("%d repos found", len(candidates))).
+		Description(navHintMulti).
 		Options(opts...).
 		Filterable(true).
-		Height(min(len(candidates)+5, 18)).
+		Height(wizardListHeight(len(candidates) + 1)).
 		Value(&selected).
+		WithTheme(wizardTheme()).
 		Run(); err != nil {
 		return nil, false, err
 	}

--- a/internal/cli/wizard_groupname_test.go
+++ b/internal/cli/wizard_groupname_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestDefaultGroupName_ContainerFolderForGroup verifies the #5338 fix: a group
+// of sibling repos under a container folder (ivivo/backend, ivivo/frontend)
+// defaults the group name to the CONTAINER folder ("ivivo"), not a child repo.
+func TestDefaultGroupName_ContainerFolderForGroup(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "home", "me", "ivivo")
+	repos := []registry.Repo{
+		{Path: filepath.Join(root, "backend")},
+		{Path: filepath.Join(root, "frontend")},
+	}
+	if got := defaultGroupName(repos); got != "ivivo" {
+		t.Fatalf("want container folder %q, got %q", "ivivo", got)
+	}
+}
+
+// TestDefaultGroupName_SingleRepoUsesRepoName verifies a single selected repo
+// still defaults to the repo's own basename.
+func TestDefaultGroupName_SingleRepoUsesRepoName(t *testing.T) {
+	repos := []registry.Repo{
+		{Path: filepath.Join(string(filepath.Separator), "home", "me", "ivivo", "backend")},
+	}
+	if got := defaultGroupName(repos); got != "backend" {
+		t.Fatalf("want repo basename %q, got %q", "backend", got)
+	}
+}
+
+// TestDefaultGroupName_MonorepoPackagesUseRoot verifies monorepo package paths
+// (all under one root) default to the monorepo root's basename.
+func TestDefaultGroupName_MonorepoPackagesUseRoot(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "src", "myapp")
+	repos := []registry.Repo{
+		{Path: filepath.Join(root, "api")},
+		{Path: filepath.Join(root, "web")},
+		{Path: filepath.Join(root, "shared")},
+	}
+	if got := defaultGroupName(repos); got != "myapp" {
+		t.Fatalf("want monorepo root %q, got %q", "myapp", got)
+	}
+}
+
+// TestDefaultGroupName_DisjointParentsFallBack verifies that repos without a
+// single shared parent fall back to the first repo's container folder rather
+// than picking an unrelated ancestor.
+func TestDefaultGroupName_DisjointParentsFallBack(t *testing.T) {
+	repos := []registry.Repo{
+		{Path: filepath.Join(string(filepath.Separator), "a", "alpha", "svc1")},
+		{Path: filepath.Join(string(filepath.Separator), "b", "beta", "svc2")},
+	}
+	if got := defaultGroupName(repos); got != "alpha" {
+		t.Fatalf("want first repo's container %q, got %q", "alpha", got)
+	}
+}

--- a/internal/cli/wizard_tui.go
+++ b/internal/cli/wizard_tui.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// wizardNavHint is the per-step footer shown under interactive wizard fields so
+// users discover the keys — most importantly that SPACE toggles a multiselect
+// item (#5338). Rendered via each field's Description.
+const (
+	// navHintMulti documents multiselect navigation (space toggles).
+	navHintMulti = "↑/↓ move · space select · enter confirm · / filter · esc back"
+	// navHintSelect documents single-select navigation (enter confirms).
+	navHintSelect = "↑/↓ move · enter confirm · / filter · esc back"
+)
+
+// wizardListHeight returns a roomy height for a list of n options, clamped so a
+// short list isn't cramped and a long list scrolls instead of flooding the
+// terminal. Floor of 10 gives a comfortable window; ceiling of 20 keeps it from
+// dwarfing small terminals (#5338).
+func wizardListHeight(n int) int {
+	h := n + 4 // options + title/description/help chrome
+	if h < 10 {
+		h = 10
+	}
+	if h > 20 {
+		h = 20
+	}
+	return h
+}
+
+// wizardTheme returns the huh theme used by the interactive wizard. It is based
+// on ThemeCharm but overrides the multiselect prefixes so selected/unselected
+// options render as [✓]/[ ] brackets. The stock ThemeCharm uses "✓ "/"• ",
+// which reads ambiguously as a bullet list rather than checkboxes — the #5337
+// attempt to get brackets set the wrong field; the correct fields are
+// Focused/Blurred.SelectedPrefix and UnselectedPrefix (#5338).
+func wizardTheme() *huh.Theme {
+	t := huh.ThemeCharm()
+
+	// Preserve ThemeCharm's colors but swap the glyphs for explicit brackets.
+	selFG := t.Focused.SelectedPrefix.GetForeground()
+	unselFG := t.Focused.UnselectedPrefix.GetForeground()
+	t.Focused.SelectedPrefix = lipgloss.NewStyle().Foreground(selFG).SetString("[✓] ")
+	t.Focused.UnselectedPrefix = lipgloss.NewStyle().Foreground(unselFG).SetString("[ ] ")
+
+	blurSelFG := t.Blurred.SelectedPrefix.GetForeground()
+	blurUnselFG := t.Blurred.UnselectedPrefix.GetForeground()
+	t.Blurred.SelectedPrefix = lipgloss.NewStyle().Foreground(blurSelFG).SetString("[✓] ")
+	t.Blurred.UnselectedPrefix = lipgloss.NewStyle().Foreground(blurUnselFG).SetString("[ ] ")
+
+	return t
+}

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/daemon/watch"
 	"github.com/cajasmota/grafel/internal/install/hooks"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/perf"
 	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/registry"
@@ -756,6 +757,10 @@ func (s *Service) RemoveRepo(args *proto.RemoveRepoArgs, reply *proto.RemoveRepo
 		s.watcher.RemoveRepo(repoPath)
 	}
 
+	// Tear down the OS-level watcher launchd/systemd/schtasks unit + plist so a
+	// later recreate does not fight stale state (#5338). Idempotent.
+	watchers.Cleanup(args.Group, repoPath, "")
+
 	// Remove git hooks.
 	if cfg.Features.GitHooks {
 		_ = hooks.Uninstall(repoPath)
@@ -822,6 +827,9 @@ func (s *Service) DeleteGroup(args *proto.DeleteGroupArgs, reply *proto.DeleteGr
 			if s.watcher != nil {
 				s.watcher.RemoveRepo(r.Path)
 			}
+			// Tear down the OS-level watcher unit + plist so a later recreate
+			// of this group does not fight stale launchd state (#5338).
+			watchers.Cleanup(args.Group, r.Path, "")
 			// Remove git hooks.
 			if cfg.Features.GitHooks {
 				_ = hooks.Uninstall(r.Path)

--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -385,6 +386,9 @@ func (s *Server) handleV2DeleteGroup(w http.ResponseWriter, r *http.Request) {
 			stateDir := daemon.StateDirForRepo(rep.Path)
 			// Best-effort: non-fatal per repo — do NOT touch source code.
 			_ = os.RemoveAll(stateDir)
+			// Tear down the OS-level watcher unit + plist so a later recreate
+			// of this group does not fight stale launchd state (#5338).
+			watchers.Cleanup(groupName, rep.Path, "")
 		}
 	}
 

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -66,6 +66,12 @@ type Result struct {
 	// PreToolUse grep-interceptor hook (#4273). Empty unless agent hooks
 	// were enabled.
 	AgentHooksInstalled []string
+	// WatcherWarnings collects non-fatal watcher-activation failures. The
+	// group config is fully saved before watchers are activated, so a watcher
+	// that fails to load (e.g. a flaky launchctl error that survives the
+	// bounded retry) must NOT abort the install — the group is still
+	// registered and will index. Callers surface these as warnings.
+	WatcherWarnings []string
 }
 
 // Apply registers the group, writes its config, then installs hooks +
@@ -194,9 +200,14 @@ func Apply(opts Options) (*Result, error) {
 
 				// Activate the watcher unit through the OS-native loader
 				// (launchctl on macOS, systemctl on Linux, schtasks on Windows).
+				// A watcher that fails to activate is a NON-FATAL warning: the
+				// group config is already persisted (above), so the group is
+				// registered and will index regardless. Aborting here used to
+				// fail the whole wizard on a flaky launchctl error (#5338).
 				loader := watchers.NewLoader()
 				if lerr := loader.Load(u); lerr != nil && !watchers.IsNonFatal(lerr) {
-					return nil, fmt.Errorf("activate watcher for %s: %w", repo, lerr)
+					res.WatcherWarnings = append(res.WatcherWarnings,
+						fmt.Sprintf("watcher for %s not activated: %v; the group is still registered and will index", repo, lerr))
 				}
 				// Report activation state regardless of non-fatal /run failures.
 				if st, serr := loader.Status(u); serr == nil {

--- a/internal/install/watcher_nonfatal_darwin_test.go
+++ b/internal/install/watcher_nonfatal_darwin_test.go
@@ -1,0 +1,58 @@
+//go:build darwin
+
+package install_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestApply_WatcherActivationFailureIsNonFatal verifies the #5338 fix: when the
+// OS watcher loader fails to activate a unit (here a forced launchctl failure),
+// install.Apply does NOT abort — it records a WatcherWarning and returns nil so
+// the wizard completes and the (already-saved) group still indexes.
+func TestApply_WatcherActivationFailureIsNonFatal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+
+	// Force every launchctl invocation to fail with a non-err-5 (real) error so
+	// the loader gives up immediately and returns a fatal-looking error that
+	// Apply must downgrade to a warning.
+	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
+		return []byte("boom"), exec.Command("sh", "-c", "exit 1").Run()
+	})
+	defer restore()
+
+	repo := t.TempDir()
+	cfg := &registry.GroupConfig{
+		Name:  "demo",
+		Repos: []registry.Repo{{Slug: "r", Path: repo}},
+	}
+	cfg.Features.Watchers = true
+
+	res, err := install.Apply(install.Options{
+		Group:          "demo",
+		Config:         cfg,
+		BinPath:        "/usr/local/bin/grafel",
+		SkipHooks:      true,
+		SkipRulesFiles: true,
+		SkipMCP:        true,
+	})
+	if err != nil {
+		t.Fatalf("Apply should be non-fatal on watcher activation failure, got: %v", err)
+	}
+	if len(res.WatcherWarnings) == 0 {
+		t.Fatal("expected a WatcherWarning to be recorded")
+	}
+	if !strings.Contains(res.WatcherWarnings[0], "still registered and will index") {
+		t.Fatalf("warning should reassure the group is registered, got: %q", res.WatcherWarnings[0])
+	}
+}

--- a/internal/install/watchers/cleanup_test.go
+++ b/internal/install/watchers/cleanup_test.go
@@ -1,0 +1,45 @@
+package watchers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCleanup_RemovesUnitFile verifies the #5338 group-delete fix: Cleanup
+// removes the on-disk watcher unit/plist for a repo so a later recreate does
+// not fight stale state.
+func TestCleanup_RemovesUnitFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), ".config"))
+
+	u := Unit{Group: "demo", Repo: filepath.Join(t.TempDir(), "core"), BinPath: "/bin/grafel"}
+	path, err := Write(u)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("unit file should exist after Write: %v", err)
+	}
+
+	// Cleanup must remove the unit file. (The OS Unload step is best-effort and
+	// idempotent; on a clean test box the unit was never loaded, which Unload
+	// treats as success.)
+	Cleanup(u.Group, u.Repo, u.BinPath)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("unit file should be removed after Cleanup, stat err=%v", err)
+	}
+}
+
+// TestCleanup_Idempotent verifies Cleanup tolerates a never-installed unit
+// (no file on disk, not loaded) without panicking or erroring.
+func TestCleanup_Idempotent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), ".config"))
+
+	u := Unit{Group: "demo", Repo: filepath.Join(t.TempDir(), "never"), BinPath: "/bin/grafel"}
+	// No Write — nothing exists. Cleanup must be a no-op.
+	Cleanup(u.Group, u.Repo, u.BinPath)
+	Cleanup(u.Group, u.Repo, u.BinPath) // twice, still fine
+}

--- a/internal/install/watchers/loader_darwin.go
+++ b/internal/install/watchers/loader_darwin.go
@@ -3,11 +3,13 @@
 package watchers
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // darwinLoader implements Loader using launchctl for macOS LaunchAgents.
@@ -16,8 +18,51 @@ type darwinLoader struct{}
 // NewLoader returns the macOS launchctl-based Loader.
 func NewLoader() Loader { return darwinLoader{} }
 
+// launchctlRunner runs `launchctl <args...>` and returns its combined output
+// and error. It is a package var so tests can inject a fake launchctl (e.g. to
+// simulate the flaky err-5 bootstrap) without shelling out.
+var launchctlRunner = func(args ...string) ([]byte, error) {
+	return exec.Command("launchctl", args...).CombinedOutput()
+}
+
+// SetLaunchctlRunnerForTest swaps the launchctl command runner and returns a
+// restore func. It exists so cross-package tests (e.g. install.Apply's
+// watcher-activation path) can simulate launchctl failures without shelling
+// out. Test-only; do not use in production code.
+func SetLaunchctlRunnerForTest(fn func(args ...string) ([]byte, error)) (restore func()) {
+	orig := launchctlRunner
+	launchctlRunner = fn
+	return func() { launchctlRunner = orig }
+}
+
+// bootstrapRetries is the number of bootout→bootstrap attempts made when
+// launchctl bootstrap returns the flaky err 5 (EIO / "Input/output error").
+// launchd intermittently fails the very first bootstrap of a freshly written
+// plist with exit 5; a bounded retry (with a small backoff) clears it.
+const bootstrapRetries = 3
+
+// bootstrapBackoff is the pause between err-5 bootstrap retries.
+var bootstrapBackoff = 200 * time.Millisecond
+
+// isLaunchctlErr5 reports whether err is a launchctl exit-code-5 failure.
+// launchctl returns exit 5 for the transient "Bootstrap failed: 5:
+// Input/output error" condition; it is locale-invariant (exit code, not text).
+func isLaunchctlErr5(err error) bool {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode() == 5
+	}
+	return false
+}
+
 // Load writes the plist (via Write) and bootstraps it into the current user's
 // launchd domain. If the unit is already running it is a no-op.
+//
+// launchd intermittently fails the first bootstrap of a freshly written plist
+// with the flaky exit code 5 ("Bootstrap failed: 5: Input/output error"). This
+// is not a real configuration error — a bootout→bootstrap retry clears it. We
+// therefore retry the bootout+bootstrap pair a bounded number of times,
+// specifically on err 5, with a small backoff between attempts.
 func (darwinLoader) Load(u Unit) error {
 	path, err := UnitPath(u)
 	if err != nil {
@@ -28,14 +73,29 @@ func (darwinLoader) Load(u Unit) error {
 	}
 
 	uid := strconv.Itoa(os.Getuid())
-	// Bootout any stale entry so bootstrap succeeds cleanly.
-	_ = exec.Command("launchctl", "bootout", "gui/"+uid+"/"+u.Label()).Run()
+	label := u.Label()
 
-	out, err := exec.Command("launchctl", "bootstrap", "gui/"+uid, path).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("launchctl bootstrap %s: %w\n%s", u.Label(), err, out)
+	var lastOut []byte
+	var lastErr error
+	for attempt := 1; attempt <= bootstrapRetries; attempt++ {
+		// Bootout any stale entry so bootstrap succeeds cleanly.
+		_, _ = launchctlRunner("bootout", "gui/"+uid+"/"+label)
+
+		out, berr := launchctlRunner("bootstrap", "gui/"+uid, path)
+		if berr == nil {
+			return nil
+		}
+		lastOut, lastErr = out, berr
+
+		// Only the flaky err-5 is worth retrying; any other failure is real.
+		if !isLaunchctlErr5(berr) {
+			break
+		}
+		if attempt < bootstrapRetries {
+			time.Sleep(bootstrapBackoff)
+		}
 	}
-	return nil
+	return fmt.Errorf("launchctl bootstrap %s: %w\n%s", label, lastErr, lastOut)
 }
 
 // Unload bootouts the LaunchAgent for the given unit. Errors are suppressed

--- a/internal/install/watchers/loader_darwin_test.go
+++ b/internal/install/watchers/loader_darwin_test.go
@@ -1,0 +1,130 @@
+//go:build darwin
+
+package watchers
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// err5 returns an *exec.ExitError-like error whose ExitCode() is 5, matching
+// the flaky launchctl "Bootstrap failed: 5: Input/output error" condition.
+// We obtain a real ExitError by running a process that exits 5.
+func err5(t *testing.T) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit 5").Run()
+	if err == nil {
+		t.Fatal("expected non-nil error from `exit 5`")
+	}
+	if !isLaunchctlErr5(err) {
+		t.Fatalf("test scaffold produced wrong exit code: %v", err)
+	}
+	return err
+}
+
+// withFakeLaunchctl swaps launchctlRunner for the duration of the test.
+func withFakeLaunchctl(t *testing.T, fn func(args ...string) ([]byte, error)) {
+	t.Helper()
+	orig := launchctlRunner
+	origBackoff := bootstrapBackoff
+	launchctlRunner = fn
+	bootstrapBackoff = time.Millisecond // keep tests fast
+	t.Cleanup(func() {
+		launchctlRunner = orig
+		bootstrapBackoff = origBackoff
+	})
+}
+
+// writePlist writes a dummy plist for a unit into a temp HOME so Load's
+// os.Stat(path) precondition passes.
+func writePlist(t *testing.T, u Unit) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	path, err := UnitPath(u)
+	if err != nil {
+		t.Fatalf("UnitPath: %v", err)
+	}
+	if _, err := Write(u); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !strings.HasSuffix(path, ".plist") {
+		t.Fatalf("expected .plist path, got %s", path)
+	}
+}
+
+// TestLoad_RetriesOnErr5 verifies that a bootstrap that fails with err 5 once
+// (or twice) and then succeeds results in Load returning nil — i.e. the
+// bootout→bootstrap pair is retried specifically on the flaky err 5.
+func TestLoad_RetriesOnErr5(t *testing.T) {
+	u := Unit{Group: "demo", Repo: filepath.Join(t.TempDir(), "core"), BinPath: "/bin/grafel"}
+	writePlist(t, u)
+
+	bootstraps := 0
+	withFakeLaunchctl(t, func(args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "bootstrap" {
+			bootstraps++
+			if bootstraps < 2 {
+				return []byte("Bootstrap failed: 5: Input/output error"), err5(t)
+			}
+			return nil, nil // succeed on the 2nd attempt
+		}
+		return nil, nil // bootout always "succeeds"
+	})
+
+	if err := (darwinLoader{}).Load(u); err != nil {
+		t.Fatalf("Load should succeed after err-5 retry, got: %v", err)
+	}
+	if bootstraps != 2 {
+		t.Fatalf("expected 2 bootstrap attempts, got %d", bootstraps)
+	}
+}
+
+// TestLoad_GivesUpAfterRetriesOnErr5 verifies that a persistent err 5 is
+// retried up to bootstrapRetries times and then surfaced as an error.
+func TestLoad_GivesUpAfterRetriesOnErr5(t *testing.T) {
+	u := Unit{Group: "demo", Repo: filepath.Join(t.TempDir(), "core"), BinPath: "/bin/grafel"}
+	writePlist(t, u)
+
+	bootstraps := 0
+	withFakeLaunchctl(t, func(args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "bootstrap" {
+			bootstraps++
+			return []byte("Bootstrap failed: 5: Input/output error"), err5(t)
+		}
+		return nil, nil
+	})
+
+	if err := (darwinLoader{}).Load(u); err == nil {
+		t.Fatal("Load should fail when err 5 never clears")
+	}
+	if bootstraps != bootstrapRetries {
+		t.Fatalf("expected %d bootstrap attempts, got %d", bootstrapRetries, bootstraps)
+	}
+}
+
+// TestLoad_DoesNotRetryNonErr5 verifies that a non-err-5 bootstrap failure is
+// NOT retried — it is a real error surfaced immediately.
+func TestLoad_DoesNotRetryNonErr5(t *testing.T) {
+	u := Unit{Group: "demo", Repo: filepath.Join(t.TempDir(), "core"), BinPath: "/bin/grafel"}
+	writePlist(t, u)
+
+	bootstraps := 0
+	withFakeLaunchctl(t, func(args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "bootstrap" {
+			bootstraps++
+			// exit 1, not 5 — a real error.
+			return []byte("some other failure"), exec.Command("sh", "-c", "exit 1").Run()
+		}
+		return nil, nil
+	})
+
+	if err := (darwinLoader{}).Load(u); err == nil {
+		t.Fatal("Load should fail on a non-err-5 failure")
+	}
+	if bootstraps != 1 {
+		t.Fatalf("expected exactly 1 bootstrap attempt for non-err-5, got %d", bootstraps)
+	}
+}

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -201,6 +201,23 @@ func Write(u Unit) (string, error) {
 	return path, nil
 }
 
+// Cleanup fully deactivates and removes the watcher unit for a single repo:
+// it Unloads the unit from the OS scheduler (launchctl bootout / systemctl
+// disable / schtasks delete) and then removes the on-disk unit file. Both
+// steps are idempotent — a not-loaded unit and a missing file are treated as
+// success — so Cleanup is safe to call when deleting a group whether or not a
+// watcher was ever activated. This prevents stale com.grafel.watcher.<group>.*
+// launchd jobs / plists from lingering and fighting a later recreate (#5338).
+func Cleanup(group, repoPath, binPath string) {
+	u := Unit{Group: group, Repo: repoPath, BinPath: binPath}
+	loader := NewLoader()
+	// Deregister from the OS scheduler before deleting the file so the OS does
+	// not try to relaunch a missing binary. Errors are tolerated: "not loaded"
+	// already satisfies the desired absent state.
+	_ = loader.Unload(u)
+	_ = Remove(u)
+}
+
 // Remove deletes the unit file if it exists.
 func Remove(u Unit) error {
 	path, err := UnitPath(u)


### PR DESCRIPTION
Fixes #5338 — polishes the index-wizard COMPLETION flow (follow-up to action-first wizard #5337). Six live-testing issues, all in Go (CLI + install + daemon + a dashboard handler).

## 1. Watcher install robustness (the live blocker)
- **err-5 retry:** `launchctl bootstrap` intermittently fails the first bootstrap of a freshly written plist with exit 5 (EIO / "Bootstrap failed: 5: Input/output error"). The darwin loader (`internal/install/watchers/loader_darwin.go`) now retries the **bootout→bootstrap** pair up to 3 times **specifically on err 5** (detected by exit code, locale-invariant), with a 200ms backoff. Non-err-5 failures are surfaced immediately (not retried). A swappable `launchctlRunner` package var makes it unit-testable.
- **Non-fatal activation:** a watcher that still fails to activate is now a **warning, not an abort**. `install.Apply` collects `Result.WatcherWarnings` ("watcher for X not activated: …; the group is still registered and will index") instead of returning the error, so the wizard completes. The CLI prints the warnings.
- _Tests:_ `loader_darwin_test.go` (retry-then-succeed, give-up-after-N, no-retry-on-non-err5), `watcher_nonfatal_darwin_test.go` (Apply stays non-fatal + records the warning).

## 2. Delete cleans up watcher launchd units
New idempotent `watchers.Cleanup(group, repo, bin)` = Unload (bootout, tolerating "not loaded") + Remove (plist). Wired into the daemon `DeleteGroup` **and** `RemoveRepo` RPCs (`internal/daemon/service.go`) and the dashboard `DELETE /api/v2/groups/{group}` handler (`internal/dashboard/v2_group_settings.go`). Stops stale `com.grafel.watcher.<group>.*` jobs from fighting a recreate. _Tests:_ `cleanup_test.go` (removes unit file; idempotent on never-installed).

## 3. Auto-index on group create / add
New `indexGroupWithProgress` (`internal/cli/repair.go`) dials the daemon, triggers a group Rebuild, and renders the **same live broker SSE phase progress as the dashboard** (poll/wait fallback when no broker). The wizard now ends register → "Indexing…" → "Done" by default. `--no-index` skips it (scripting). A down daemon → warning, not failure. The non-interactive path stays flag-driven (no auto-index).

## 4. Group-name default = container folder
`defaultGroupName` defaults to the basename of the repos' **common-parent** container folder (`another group`), not an arbitrary selected child repo (`backend`). Single repo still uses its own basename. _Tests:_ `wizard_groupname_test.go` (group/monorepo/single/disjoint).

## 5. TUI navigation hints
Per-step footers via field `.Description()`: `↑/↓ move · space select · enter confirm · / filter · esc back` — so users discover that **space** toggles multiselect items.

## 6. Bigger TUI + `[ ]`/`[✓]` glyphs
- `wizardListHeight` gives roomy, scrolling lists (floor 10, ceil 20) instead of cramped rows.
- The #5337 bracket attempt failed because stock huh `ThemeCharm` overrides the prefixes to `✓ `/`• `. The fix (`wizard_tui.go` `wizardTheme()`) sets the **correct** fields — `Focused/Blurred.SelectedPrefix`/`UnselectedPrefix` → `[✓] `/`[ ] ` — verified against the vendored huh v1.0.0 `theme.go`.

## Tests / validate
`go build ./...`, `go vet`, `gofmt -l` clean. `go test` green for `internal/install/...`, `internal/cli/...`, `internal/daemon/...`, `internal/dashboard/`, `cmd/grafel/...`. No frontend change (delete cleanup is server-side), so no webui build. Did not run `make dashboard-build`, launchctl, or touch the live `~/.grafel`/LaunchAgents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)