### PR TITLE
feat(wizard): cohesive Bubble Tea TUI (header, step rail, footer hints, per-repo indexing view)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Changed
 
+- **`grafel wizard` now uses a cohesive Bubble Tea TUI (#5340):** the
+  interactive wizard is a single full-screen `tea.Model` state machine with
+  consistent chrome on every step — a styled grafel header + a step rail
+  (`Action › Select › Name › Index`) highlighting the current stage, a spacious
+  body sized to the terminal (the four actions are always fully visible; long
+  repo lists scroll inside a tall viewport with a position indicator), and a
+  contextual footer key-hint bar on every screen (including the group-name and
+  optional-docs inputs → "optional · enter to skip"). The indexing step is now a
+  **per-repo view**: an overall progress bar plus **one row per repo** (name ·
+  phase label · files done/total · entities · spinner while active), folding the
+  broker SSE phase stream by `repo_slug` with a monotonic phase — which also
+  **fixes the dropped-repo display bug** where the old single-line
+  carriage-return renderer showed only one repo and dropped the rest. All
+  decision logic and side effects are preserved (`ClassifyPath`, group-name
+  default, `applyGroupConfig`, daemon auto-index); `ctrl-c`/`esc` cancel cleanly
+  with nothing registered. Non-interactive flags
+  (`--repos`/`--parent`/`--exclude`/`--no-index`) and non-TTY/CI/`$TERM=dumb`
+  contexts never launch the TUI and keep the line-based flow
+  ([#5340](https://github.com/cajasmota/grafel/issues/5340)).
 - **`grafel wizard` auto-indexes the new group with live progress (#5338):**
   after registering a group (or adding repos to an existing one), the wizard now
   triggers an index by default and renders live CLI phase progress — the same

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.26.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
+	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/huh v1.0.0
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/flatbuffers v25.12.19+incompatible
 	github.com/knights-analytics/hugot v0.7.3
@@ -31,10 +34,8 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
-	github.com/charmbracelet/bubbletea v1.3.6 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
+	github.com/charmbracelet/harmonica v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/charmbracelet/bubbletea v1.3.6 h1:VkHIxPJQeDt0aFJIsVxw8BQdh/F/L2KKZGs
 github.com/charmbracelet/bubbletea v1.3.6/go.mod h1:oQD9VCRQFF8KplacJLo28/jofOI2ToOfGYeFgBBxHOc=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/huh v1.0.0 h1:wOnedH8G4qzJbmhftTqrpppyqHakl/zbbNdXIWJyIxw=
 github.com/charmbracelet/huh v1.0.0/go.mod h1:5YVc+SlZ1IhQALxRPpkGwwEKftN/+OlJlnJYlDRFqN4=
 github.com/charmbracelet/lipgloss v1.1.0 h1:vYXsiLHVkK7fp74RkV7b2kq9+zDLoEU4MZoFqR/noCY=

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -124,6 +124,27 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 		return finishWizard(out, cfg, opts)
 	}
 
+	// INTERACTIVE path — when stdin/stdout are a real terminal, drive the
+	// cohesive Bubble Tea TUI (#5340): header + step rail, spacious body, footer
+	// key hints, and a per-repo indexing view. The TUI owns presentation only —
+	// it calls back into applyGroupConfig + the daemon index here, so all the
+	// decision/registration LOGIC is preserved. A cancel registers nothing.
+	if wizardUseTUI(out) {
+		res, err := runInteractiveTUI(out, opts.errWriter(), opts)
+		if err != nil {
+			return err
+		}
+		if res.Cancelled {
+			fmt.Fprintln(out, "cancelled — nothing was registered.")
+			return nil
+		}
+		// All side effects (register/install/index) ran inside the TUI loop.
+		return nil
+	}
+
+	// NON-TTY interactive fallback (pipes, CI, $TERM=dumb): keep the original
+	// huh/line-based flow so scripts and non-terminal environments never launch
+	// the full-screen TUI.
 	// INTERACTIVE path — action-first (#5336). Pick an action (single / group /
 	// monorepo / add-to-group) with a smart cwd default, then resolve candidates
 	// per action via the shared detect.ClassifyPath classifier.

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -1,0 +1,396 @@
+package cli
+
+// wizard_tui_run.go — wiring between the wizard's preserved decision logic and
+// the cohesive Bubble Tea TUI in internal/cli/wiztui (#5340).
+//
+// The TUI owns ONLY presentation + interaction. All classification, registry,
+// install, and indexing logic stays here and is reused verbatim. This file
+// implements wiztui.Driver and a channel-producing IndexFunc so the model can
+// render a per-repo indexing view without owning any side effects.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+
+	"github.com/cajasmota/grafel/internal/cli/wiztui"
+	"github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/progress"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// wizardUseTUI reports whether the full-screen Bubble Tea TUI should drive the
+// interactive wizard. It requires BOTH stdin and the wizard's stdout to be real
+// terminals, and a non-dumb $TERM, so pipes / CI / redirected output fall back
+// to the plain line-based huh flow (behavior preservation, #5340).
+func wizardUseTUI(out io.Writer) bool {
+	if t := os.Getenv("TERM"); t == "dumb" || t == "" {
+		return false
+	}
+	if os.Getenv("GRAFEL_NO_TUI") != "" {
+		return false
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return false
+	}
+	f, ok := out.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}
+
+// wizardDriver implements wiztui.Driver against the live classifier + registry.
+type wizardDriver struct {
+	class detect.Classification
+}
+
+func (d wizardDriver) ContextLine() string {
+	return "Detected: " + describeClassification(d.class)
+}
+
+func (d wizardDriver) SuggestedAction() wiztui.Action {
+	switch defaultAction(d.class) {
+	case actionGroup:
+		return wiztui.ActionGroup
+	case actionMonorepo:
+		return wiztui.ActionMonorepo
+	case actionAddGroup:
+		return wiztui.ActionAddGroup
+	default:
+		return wiztui.ActionSingle
+	}
+}
+
+// Candidates derives the selectable repos/packages for an action, reusing the
+// same precedence as the huh flow (groupCandidates / monorepo packages).
+func (d wizardDriver) Candidates(a wiztui.Action) (string, []wiztui.Candidate) {
+	switch a {
+	case wiztui.ActionSingle:
+		// Single: the cwd repo (or nothing — caller validates).
+		if d.class.IsGitRepo {
+			return "Repository to index", []wiztui.Candidate{
+				{Label: d.class.AbsPath, Value: d.class.AbsPath, Selected: true},
+			}
+		}
+		return "Repository to index", nil
+	case wiztui.ActionMonorepo:
+		if d.class.Monorepo == detect.KindNone || len(d.class.Packages) == 0 {
+			return "Packages", nil
+		}
+		cands := make([]wiztui.Candidate, 0, len(d.class.Packages))
+		for _, p := range d.class.Packages {
+			cands = append(cands, wiztui.Candidate{Label: p, Value: p, Selected: true})
+		}
+		return fmt.Sprintf("%d packages found", len(d.class.Packages)), cands
+	default: // group / add-group
+		paths := groupCandidates(d.class)
+		sort.Strings(paths)
+		cands := make([]wiztui.Candidate, 0, len(paths))
+		for _, p := range paths {
+			cands = append(cands, wiztui.Candidate{Label: p, Value: p, Selected: true})
+		}
+		return fmt.Sprintf("%d repos found", len(paths)), cands
+	}
+}
+
+func (d wizardDriver) Groups() []wiztui.Candidate {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	out := make([]wiztui.Candidate, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, wiztui.Candidate{Label: g.Name, Value: g.Name})
+	}
+	return out
+}
+
+func (d wizardDriver) DefaultGroupName(repos []string) string {
+	rs := make([]registry.Repo, 0, len(repos))
+	for _, p := range repos {
+		rs = append(rs, registry.Repo{Path: p})
+	}
+	return defaultGroupName(rs)
+}
+
+// reposForResult maps the TUI result's chosen paths to registry.Repo records,
+// matching the per-action mapping the huh flow uses (monorepo packages get a
+// module label and a composite slug).
+func reposForResult(class detect.Classification, r wiztui.Result) []registry.Repo {
+	if r.Action == wiztui.ActionMonorepo {
+		base := filepath.Base(class.AbsPath)
+		out := make([]registry.Repo, 0, len(r.Repos))
+		for _, pkg := range r.Repos {
+			abs := filepath.Join(class.AbsPath, filepath.FromSlash(pkg))
+			out = append(out, registry.Repo{
+				Slug:    base + "-" + filepath.Base(pkg),
+				Path:    abs,
+				Stack:   registry.StackList{detect.Stack(abs)},
+				Modules: []string{pkg},
+			})
+		}
+		return out
+	}
+	return reposFromPaths(r.Repos)
+}
+
+// runInteractiveTUI drives the full-screen Bubble Tea wizard. It returns the
+// model's Result. The caller (runWizard) applies all side effects based on it.
+// Indexing is performed INSIDE the model loop via the IndexFunc so the per-repo
+// view renders live, but the GROUP is only registered (applyGroupConfig) right
+// before indexing starts — never on a cancel.
+func runInteractiveTUI(out, errOut io.Writer, opts wizardOptions) (wiztui.Result, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return wiztui.Result{}, err
+	}
+	class, _ := detect.ClassifyPath(cwd)
+	drv := wizardDriver{class: class}
+
+	idxFn := makeIndexFunc(out, errOut, class, opts)
+	m := wiztui.New(drv, idxFn, opts.Watchers, opts.GitHooks)
+
+	prog := tea.NewProgram(m, tea.WithAltScreen(), tea.WithOutput(out))
+	final, err := prog.Run()
+	if err != nil {
+		return wiztui.Result{}, err
+	}
+	res := final.(wiztui.Model).Result()
+	return res, res.IndexErr()
+}
+
+// makeIndexFunc returns a wiztui.IndexFunc closure that, when the user confirms,
+// (1) assembles + applies the group config (register/install) and (2) starts the
+// daemon index, streaming broker progress.Events back to the model and the
+// terminal outcome. All registration happens HERE — only on confirm — so a
+// cancel registers nothing.
+func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wizardOptions) wiztui.IndexFunc {
+	return func(r wiztui.Result) (<-chan progress.Event, <-chan wiztui.IndexOutcome) {
+		evCh := make(chan progress.Event, 64)
+		outCh := make(chan wiztui.IndexOutcome, 1)
+
+		go func() {
+			defer close(evCh)
+			defer close(outCh)
+
+			repos := reposForResult(class, r)
+
+			// Add-to-existing-group path.
+			if r.Action == wiztui.ActionAddGroup && r.AddToGroup != "" {
+				if err := addReposToExistingGroupNoIndex(out, r.AddToGroup, repos, opts); err != nil {
+					outCh <- wiztui.IndexOutcome{Err: err}
+					return
+				}
+				streamIndex(evCh, outCh, r.AddToGroup, opts.NoIndex)
+				return
+			}
+
+			// New-group path: assemble config, apply (register + install).
+			cfg := &registry.GroupConfig{Name: r.GroupName}
+			cfg.Features.Watchers = r.Watchers
+			cfg.Features.GitHooks = r.GitHooks
+			cfg.Features.AgentHooks = opts.AgentHooks
+			cfg.GroupDocs = r.GroupDocs
+			cfg.Repos = repos
+			if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall}); err != nil {
+				outCh <- wiztui.IndexOutcome{Err: err}
+				return
+			}
+			streamIndex(evCh, outCh, cfg.Name, opts.NoIndex)
+		}()
+
+		return evCh, outCh
+	}
+}
+
+// streamIndex triggers a daemon index of group and forwards broker progress
+// events onto evCh, then sends the terminal outcome on outCh. A down daemon or
+// --no-index is a soft completion (DaemonDown), not an error.
+func streamIndex(evCh chan<- progress.Event, outCh chan<- wiztui.IndexOutcome, group string, noIndex bool) {
+	if noIndex {
+		outCh <- wiztui.IndexOutcome{DaemonDown: true}
+		return
+	}
+
+	c, err := client.Dial()
+	if err != nil {
+		if errors.Is(err, client.ErrDaemonNotRunning) {
+			outCh <- wiztui.IndexOutcome{DaemonDown: true}
+			return
+		}
+		outCh <- wiztui.IndexOutcome{Err: err}
+		return
+	}
+	defer c.Close()
+
+	dashPort := 0
+	if st, stErr := c.Status(); stErr == nil && st.DashboardPort > 0 {
+		dashPort = st.DashboardPort
+	}
+
+	rpcCh := make(chan rebuildOutcome, 1)
+	token := progressToken()
+	go func() {
+		reply, rpcErr := c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token})
+		rpcCh <- rebuildOutcome{
+			repos:    reply.Repos,
+			warning:  reply.Warning,
+			elapsed:  reply.ElapsedSec,
+			entities: reply.TotalEntities,
+			rels:     reply.TotalRels,
+			err:      rpcErr,
+		}
+	}()
+
+	// Stream broker SSE events to evCh while waiting for the RPC outcome.
+	if dashPort > 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+			o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
+			cancel()
+			outCh <- toIndexOutcome(o)
+			return
+		}
+	}
+
+	// No dashboard broker — just wait for the RPC outcome.
+	o := <-rpcCh
+	outCh <- toIndexOutcome(o)
+}
+
+// forwardBrokerToChannel reads broker SSE events and forwards parsed
+// progress.Events onto evCh until the RPC completes (rpcCh delivers) or the SSE
+// stream closes, then returns the RPC outcome.
+func forwardBrokerToChannel(
+	ctx context.Context,
+	sseCh <-chan sseEvent,
+	rpcCh <-chan rebuildOutcome,
+	evCh chan<- progress.Event,
+) rebuildOutcome {
+	for {
+		select {
+		case <-ctx.Done():
+			return <-rpcCh
+		case o := <-rpcCh:
+			// Drain a final batch of SSE events so the last "done" rows render.
+			drainBrokerToChannel(ctx, sseCh, evCh, 300)
+			return o
+		case ev, ok := <-sseCh:
+			if !ok {
+				// SSE closed before RPC — wait for the RPC outcome.
+				return <-rpcCh
+			}
+			if ev.name != "progress" || ev.data == "" {
+				continue
+			}
+			var e progress.Event
+			if jsonUnmarshalEvent(ev.data, &e) {
+				select {
+				case evCh <- e:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// drainBrokerToChannel reads from sseCh for up to maxWaitMS, forwarding final
+// progress events onto evCh (so the last "done" rows render before exit).
+func drainBrokerToChannel(ctx context.Context, sseCh <-chan sseEvent, evCh chan<- progress.Event, maxWaitMS int) {
+	deadline := time.After(time.Duration(maxWaitMS) * time.Millisecond)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline:
+			return
+		case ev, ok := <-sseCh:
+			if !ok {
+				return
+			}
+			if ev.name != "progress" || ev.data == "" {
+				continue
+			}
+			var e progress.Event
+			if jsonUnmarshalEvent(ev.data, &e) {
+				select {
+				case evCh <- e:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// jsonUnmarshalEvent parses an SSE data payload into a progress.Event.
+func jsonUnmarshalEvent(data string, e *progress.Event) bool {
+	return json.Unmarshal([]byte(data), e) == nil
+}
+
+// toIndexOutcome maps a rebuildOutcome to the TUI's terminal IndexOutcome.
+func toIndexOutcome(o rebuildOutcome) wiztui.IndexOutcome {
+	if o.err != nil {
+		return wiztui.IndexOutcome{Err: o.err}
+	}
+	elapsed := ""
+	if o.elapsed > 0 {
+		elapsed = fmtDuration(time.Duration(o.elapsed * float64(time.Second)))
+	}
+	return wiztui.IndexOutcome{
+		Entities: o.entities,
+		Rels:     o.rels,
+		Elapsed:  elapsed,
+	}
+}
+
+// addReposToExistingGroupNoIndex appends repos to an existing group and applies
+// the config WITHOUT triggering an index (the TUI streams the index itself via
+// streamIndex right after, so we don't want a double index here).
+func addReposToExistingGroupNoIndex(out io.Writer, group string, repos []registry.Repo, opts wizardOptions) error {
+	if len(repos) == 0 {
+		return errors.New("no repos selected to add")
+	}
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		return err
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		return fmt.Errorf("load group %q: %w", group, err)
+	}
+	existing := map[string]struct{}{}
+	for _, r := range cfg.Repos {
+		existing[r.Path] = struct{}{}
+	}
+	added := 0
+	for _, r := range repos {
+		if _, dup := existing[r.Path]; dup {
+			fmt.Fprintf(out, "skipping %s (already in group)\n", r.Path)
+			continue
+		}
+		cfg.Repos = append(cfg.Repos, r)
+		existing[r.Path] = struct{}{}
+		added++
+	}
+	if added == 0 {
+		return errors.New("all selected repos are already in the group")
+	}
+	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall}); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "added %d repo(s) to group %q\n", added, group)
+	return nil
+}

--- a/internal/cli/wizard_tui_run_test.go
+++ b/internal/cli/wizard_tui_run_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/cli/wiztui"
+)
+
+// TestWizardUseTUI_NonTTYFallsBack: a non-*os.File writer (e.g. a bytes.Buffer
+// used in tests / pipes) must NOT launch the full-screen TUI.
+func TestWizardUseTUI_NonTTYFallsBack(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	if wizardUseTUI(&bytes.Buffer{}) {
+		t.Error("wizardUseTUI(bytes.Buffer) = true; want false (not a terminal)")
+	}
+}
+
+// TestWizardUseTUI_DumbTermFallsBack: $TERM=dumb forces the line-based flow.
+func TestWizardUseTUI_DumbTermFallsBack(t *testing.T) {
+	t.Setenv("TERM", "dumb")
+	if wizardUseTUI(os.Stdout) {
+		t.Error("wizardUseTUI with TERM=dumb = true; want false")
+	}
+}
+
+// TestWizardUseTUI_EmptyTermFallsBack: an empty $TERM forces the line-based flow.
+func TestWizardUseTUI_EmptyTermFallsBack(t *testing.T) {
+	t.Setenv("TERM", "")
+	if wizardUseTUI(os.Stdout) {
+		t.Error("wizardUseTUI with empty TERM = true; want false")
+	}
+}
+
+// TestWizardUseTUI_OptOutEnv: GRAFEL_NO_TUI disables the TUI even on a TTY.
+func TestWizardUseTUI_OptOutEnv(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("GRAFEL_NO_TUI", "1")
+	if wizardUseTUI(os.Stdout) {
+		t.Error("GRAFEL_NO_TUI did not disable the TUI")
+	}
+}
+
+// TestReposForResult_Monorepo: monorepo packages map to composite slugs with a
+// recorded module, matching the huh flow.
+func TestReposForResult_Monorepo(t *testing.T) {
+	root := t.TempDir()
+	class := mustClassify(root)
+	// Force a monorepo-style result.
+	r := wiztui.Result{Action: wiztui.ActionMonorepo, Repos: []string{"services/auth", "packages/ui"}}
+	repos := reposForResult(class, r)
+	if len(repos) != 2 {
+		t.Fatalf("got %d repos, want 2", len(repos))
+	}
+	base := filepath.Base(class.AbsPath)
+	if repos[0].Slug != base+"-auth" {
+		t.Errorf("slug = %q, want %q", repos[0].Slug, base+"-auth")
+	}
+	if len(repos[0].Modules) != 1 || repos[0].Modules[0] != "services/auth" {
+		t.Errorf("modules = %v, want [services/auth]", repos[0].Modules)
+	}
+}

--- a/internal/cli/wiztui/chrome.go
+++ b/internal/cli/wiztui/chrome.go
@@ -1,0 +1,167 @@
+package wiztui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Step identifies a stage in the wizard flow, used to highlight the step rail.
+type Step int
+
+const (
+	StepAction Step = iota
+	StepSelect
+	StepName
+	StepIndex
+	StepDone
+)
+
+// stepRail is the ordered set of step labels shown in the header.
+var stepRail = []struct {
+	step  Step
+	label string
+}{
+	{StepAction, "Action"},
+	{StepSelect, "Select"},
+	{StepName, "Name"},
+	{StepIndex, "Index"},
+}
+
+// Palette — derived from the charm theme so the TUI feels of-a-piece with huh.
+var (
+	colAccent  = lipgloss.Color("212") // pink/magenta accent
+	colAccent2 = lipgloss.Color("99")  // purple
+	colMuted   = lipgloss.Color("241")
+	colFaint   = lipgloss.Color("238")
+	colText    = lipgloss.Color("252")
+	colGreen   = lipgloss.Color("42")
+	colYellow  = lipgloss.Color("214")
+	colRed     = lipgloss.Color("203")
+)
+
+var (
+	titleStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("231")).
+			Background(colAccent).
+			Bold(true).
+			Padding(0, 1)
+
+	railActiveStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("231")).
+			Background(colAccent2).
+			Bold(true).
+			Padding(0, 1)
+
+	railDoneStyle = lipgloss.NewStyle().
+			Foreground(colGreen).
+			Padding(0, 1)
+
+	railPendingStyle = lipgloss.NewStyle().
+				Foreground(colFaint).
+				Padding(0, 1)
+
+	railSepStyle = lipgloss.NewStyle().Foreground(colFaint)
+
+	footerStyle = lipgloss.NewStyle().
+			Foreground(colMuted).
+			BorderTop(true).
+			BorderStyle(lipgloss.NormalBorder()).
+			BorderForeground(colFaint)
+
+	bodyStyle = lipgloss.NewStyle().Padding(1, 1)
+
+	helpTextStyle = lipgloss.NewStyle().Foreground(colMuted)
+
+	contextStyle = lipgloss.NewStyle().Foreground(colAccent2).Italic(true)
+
+	errStyle = lipgloss.NewStyle().Foreground(colRed).Bold(true)
+)
+
+// header renders the grafel title plus the step rail with the current step
+// highlighted. width bounds the rendering.
+func header(current Step, width int) string {
+	title := titleStyle.Render("grafel wizard")
+
+	var rail []string
+	for i, s := range stepRail {
+		var seg string
+		switch {
+		case s.step == current:
+			seg = railActiveStyle.Render(s.label)
+		case s.step < current:
+			seg = railDoneStyle.Render("✓ " + s.label)
+		default:
+			seg = railPendingStyle.Render(s.label)
+		}
+		rail = append(rail, seg)
+		if i < len(stepRail)-1 {
+			rail = append(rail, railSepStyle.Render("›"))
+		}
+	}
+	railLine := lipgloss.JoinHorizontal(lipgloss.Center, rail...)
+
+	head := lipgloss.JoinHorizontal(lipgloss.Center, title, "  ", railLine)
+	if width > 0 {
+		head = lipgloss.NewStyle().Width(width).Render(head)
+	}
+	return head
+}
+
+// footer renders the contextual key-hint status bar. hint is the per-screen
+// key-hint string; width bounds it.
+func footer(hint string, width int) string {
+	s := footerStyle
+	if width > 0 {
+		s = s.Width(width)
+	}
+	return s.Render(helpTextStyle.Render(hint))
+}
+
+// frame assembles a full screen: header, body (given the remaining height), and
+// footer. body is the already-rendered active screen.
+func frame(current Step, body, hint string, width, height int) string {
+	head := header(current, width)
+	foot := footer(hint, width)
+
+	headH := lipgloss.Height(head)
+	footH := lipgloss.Height(foot)
+	bodyH := height - headH - footH - 1 // -1 spacer
+	if bodyH < 3 {
+		bodyH = 3
+	}
+
+	bs := bodyStyle
+	if width > 0 {
+		bs = bs.Width(width)
+	}
+	renderedBody := bs.Height(bodyH).Render(body)
+
+	return lipgloss.JoinVertical(lipgloss.Left, head, renderedBody, foot)
+}
+
+// Common footer hints per screen.
+const (
+	hintList     = "↑/↓ move · enter confirm · / filter · esc back · ctrl-c quit"
+	hintMulti    = "↑/↓ move · space select · a all · n none · enter confirm · / filter · esc back · ctrl-c quit"
+	hintInput    = "type to edit · enter confirm · esc back · ctrl-c quit"
+	hintInputOpt = "optional · enter to skip · esc back · ctrl-c quit"
+	hintIndex    = "indexing… · ctrl-c quit"
+	hintDone     = "enter / q to finish"
+)
+
+// truncate shortens s to max display columns, appending an ellipsis.
+func truncate(s string, max int) string {
+	if max <= 1 {
+		return ""
+	}
+	if lipgloss.Width(s) <= max {
+		return s
+	}
+	// Coarse rune-based truncation (paths/labels are ASCII-dominant here).
+	runes := []rune(s)
+	if len(runes) > max-1 {
+		runes = runes[:max-1]
+	}
+	return strings.TrimRight(string(runes), " ") + "…"
+}

--- a/internal/cli/wiztui/fold.go
+++ b/internal/cli/wiztui/fold.go
@@ -1,0 +1,269 @@
+// Package wiztui implements the cohesive Bubble Tea TUI for `grafel wizard`.
+//
+// fold.go is a Go port of the dashboard's per-repo progress folding
+// (webui-v2/src/lib/index-progress-fold.ts). It collapses the broker's
+// firehose of progress.Event records into exactly ONE row per repo, keyed by
+// repo_slug, with a monotonic phase so a stale lower phase never regresses a
+// more-advanced one. This is the model that fixes the dropped-repo display bug
+// in the CLI indexing view: instead of overwriting a single carriage-return
+// line (which dropped all-but-one repo), every repo renders as its own row.
+package wiztui
+
+import (
+	"sort"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// Phase labels, kept in lock-step with the dashboard PHASE_LABEL and the CLI
+// renderer so all three surfaces speak the same human phrase for the same
+// phase (#5334).
+var phaseLabel = map[string]string{
+	progress.PhaseScan:              "Scanning…",
+	progress.PhaseExtractAST:        "Extracting AST…",
+	progress.PhaseResolveRefs:       "Resolving references…",
+	progress.PhaseAlgorithms:        "Running algorithms…",
+	progress.PhaseMaterialize:       "Materializing graph…",
+	progress.PhaseBuildCommunities:  "Building communities…",
+	progress.PhaseComputeCentrality: "Computing centrality…",
+	progress.PhaseDetectLinks:       "Detecting cross-repo links…",
+	progress.PhaseComputeFlows:      "Computing flows…",
+	progress.PhaseWriteGraph:        "Writing graph…",
+	progress.PhaseDone:              "Done",
+	progress.PhaseError:             "Done",
+}
+
+// phaseOrder is the monotonic phase ranking, mirroring the backend's real
+// emission sequence so a later, finer phase never regresses to a coarse one.
+var phaseOrder = map[string]int{
+	progress.PhaseScan:              0,
+	progress.PhaseExtractAST:        1,
+	progress.PhaseResolveRefs:       2,
+	progress.PhaseMaterialize:       3,
+	progress.PhaseAlgorithms:        4,
+	progress.PhaseBuildCommunities:  5,
+	progress.PhaseComputeCentrality: 6,
+	progress.PhaseComputeFlows:      7,
+	progress.PhaseDetectLinks:       8,
+	progress.PhaseWriteGraph:        9,
+	progress.PhaseDone:              10,
+	progress.PhaseError:             10,
+}
+
+// phaseBands is the number of bands [0,100] is split into — one per
+// non-terminal phase index, matching PHASE_BANDS in the dashboard.
+const phaseBands = 10
+
+// PhaseLabel returns the human label for a phase, or the raw phase when unknown.
+func PhaseLabel(phase string) string {
+	if l, ok := phaseLabel[phase]; ok {
+		return l
+	}
+	return phase
+}
+
+// phaseRank returns the monotonic rank of a phase (unknown phases sort first).
+func phaseRank(phase string) int {
+	if r, ok := phaseOrder[phase]; ok {
+		return r
+	}
+	return -1
+}
+
+// Row is one per-repo progress row, the Go analogue of the dashboard ProgressRow.
+type Row struct {
+	Key           string
+	RepoSlug      string
+	Module        string
+	Phase         string
+	FilesDone     int
+	FilesTotal    int
+	EntitiesSoFar int
+	CurrentFile   string
+	Error         string
+	TS            int64
+}
+
+// Terminal reports whether the row has reached a terminal phase.
+func (r Row) Terminal() bool {
+	return r.Phase == progress.PhaseDone || r.Phase == progress.PhaseError
+}
+
+// Fold collapses progress events into one row per repo. It is a value-semantics
+// fold: callers hold a map[string]Row keyed by repo slug and call Fold per
+// event. Stale (older-ts) events and lower-ordered phases never regress an
+// existing row; terminal rows are never pulled back to an in-flight phase by a
+// late module-scoped event. A faithful port of fold() in index-progress-fold.ts.
+func Fold(rows map[string]Row, e progress.Event) map[string]Row {
+	if rows == nil {
+		rows = map[string]Row{}
+	}
+	key := e.RepoSlug
+	existing, had := rows[key]
+
+	// Ignore stale events that predate what we already have for this row.
+	if had && e.TS < existing.TS {
+		return rows
+	}
+
+	// Don't let a late, lower-ordered phase event overwrite a more-advanced
+	// phase already shown for this repo (the dropped/stale-row symptom #5326).
+	advance := !had || phaseRank(e.Phase) >= phaseRank(existing.Phase)
+	phase := e.Phase
+	if !advance {
+		phase = existing.Phase
+	}
+
+	next := Row{
+		Key:      key,
+		RepoSlug: e.RepoSlug,
+		Phase:    phase,
+		TS:       e.TS,
+	}
+
+	// Keep a module label only when it genuinely differs from the repo slug
+	// (true sub-module reporting) — never split a repo into a duplicate row.
+	if e.Module != "" && e.Module != e.RepoSlug {
+		next.Module = e.Module
+	} else if had {
+		next.Module = existing.Module
+	}
+
+	// Never regress files_done; carry forward the discovered total.
+	next.FilesDone = e.FilesDone
+	if had && existing.FilesDone > next.FilesDone {
+		next.FilesDone = existing.FilesDone
+	}
+	next.FilesTotal = e.FilesTotal
+	if next.FilesTotal == 0 && had {
+		next.FilesTotal = existing.FilesTotal
+	}
+	next.EntitiesSoFar = e.EntitiesSoFar
+	if had && existing.EntitiesSoFar > next.EntitiesSoFar {
+		next.EntitiesSoFar = existing.EntitiesSoFar
+	}
+	next.CurrentFile = e.CurrentFile
+	if next.CurrentFile == "" && had {
+		next.CurrentFile = existing.CurrentFile
+	}
+	next.Error = e.Error
+	if next.Error == "" && had {
+		next.Error = existing.Error
+	}
+
+	// Clone so callers can compare old vs new safely.
+	out := make(map[string]Row, len(rows)+1)
+	for k, v := range rows {
+		out[k] = v
+	}
+	out[key] = next
+	return out
+}
+
+// SortRows returns rows in a stable order (by repo slug, then module).
+func SortRows(rows map[string]Row) []Row {
+	out := make([]Row, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RepoSlug != out[j].RepoSlug {
+			return out[i].RepoSlug < out[j].RepoSlug
+		}
+		return out[i].Module < out[j].Module
+	})
+	return out
+}
+
+// rowFraction is the phase-weighted completion fraction (0..1) of one row.
+func rowFraction(r Row) float64 {
+	if r.Terminal() {
+		return 1
+	}
+	idx := phaseRank(r.Phase)
+	if idx < 0 {
+		return 0
+	}
+	base := float64(idx) / phaseBands
+	if r.Phase == progress.PhaseExtractAST && r.FilesTotal > 0 {
+		slice := float64(r.FilesDone) / float64(r.FilesTotal)
+		if slice < 0 {
+			slice = 0
+		}
+		if slice > 1 {
+			slice = 1
+		}
+		return base + slice/phaseBands
+	}
+	return base
+}
+
+// AggregateProgress is the [0,1] aggregate progress across all repos, averaged
+// over expectedRepos when known (so not-yet-reported repos count as 0 and the
+// bar doesn't jump when a late repo first appears).
+func AggregateProgress(rows map[string]Row, expectedRepos int) float64 {
+	denom := len(rows)
+	if expectedRepos > 0 && expectedRepos > denom {
+		denom = expectedRepos
+	}
+	if denom <= 0 {
+		return 0
+	}
+	var sum float64
+	for _, r := range rows {
+		sum += rowFraction(r)
+	}
+	pct := sum / float64(denom)
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 1 {
+		pct = 1
+	}
+	return pct
+}
+
+// OverallPhaseLabel returns the overall indexing label, derived from the
+// least-advanced active (non-terminal) repo — the phase the whole index is
+// gated on. When terminal or every row is terminal, the label is "Done".
+func OverallPhaseLabel(rows map[string]Row, terminal bool) string {
+	if terminal {
+		return "Done"
+	}
+	var least *Row
+	for _, r := range rows {
+		if r.Terminal() {
+			continue
+		}
+		rc := r
+		if least == nil || phaseRank(rc.Phase) < phaseRank(least.Phase) {
+			least = &rc
+		}
+	}
+	if least == nil {
+		return "Done"
+	}
+	return PhaseLabel(least.Phase)
+}
+
+// RowsTerminal reports whether every expected repo has reached a terminal
+// phase. Mirrors rowsTerminal(): without a known expected count it returns
+// false (defers to the RPC outcome), and it requires len(rows) >= expectedRepos
+// so an early "first repo done" never looks terminal before later repos report.
+func RowsTerminal(rows map[string]Row, expectedRepos int) bool {
+	if len(rows) == 0 {
+		return false
+	}
+	if expectedRepos <= 0 {
+		return false
+	}
+	if len(rows) < expectedRepos {
+		return false
+	}
+	for _, r := range rows {
+		if !r.Terminal() {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/wiztui/fold_test.go
+++ b/internal/cli/wiztui/fold_test.go
@@ -1,0 +1,135 @@
+package wiztui
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+func ev(slug, phase string, ts int64) progress.Event {
+	return progress.Event{RepoSlug: slug, Phase: phase, TS: ts}
+}
+
+// TestFold_MultipleReposManyRows is the dropped-repo regression: events for two
+// repos must yield two rows, not one. This is the core bug #5340 fixes.
+func TestFold_MultipleReposManyRows(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("backend", progress.PhaseScan, 1))
+	rows = Fold(rows, ev("frontend", progress.PhaseScan, 2))
+	rows = Fold(rows, ev("backend", progress.PhaseExtractAST, 3))
+	rows = Fold(rows, ev("frontend", progress.PhaseExtractAST, 4))
+
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (backend, frontend) — dropped-repo bug", len(rows))
+	}
+	if _, ok := rows["backend"]; !ok {
+		t.Error("backend row missing")
+	}
+	if _, ok := rows["frontend"]; !ok {
+		t.Error("frontend row missing")
+	}
+}
+
+// TestFold_MonotonicPhase: a late lower-ordered phase never regresses a row.
+func TestFold_MonotonicPhase(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("r", progress.PhaseWriteGraph, 5))
+	// A late scanning event (higher ts but lower phase) must not pull it back.
+	rows = Fold(rows, ev("r", progress.PhaseScan, 6))
+	if rows["r"].Phase != progress.PhaseWriteGraph {
+		t.Errorf("phase regressed to %q, want %q", rows["r"].Phase, progress.PhaseWriteGraph)
+	}
+}
+
+// TestFold_StaleTimestampIgnored: an event older than what we have is dropped.
+func TestFold_StaleTimestampIgnored(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("r", progress.PhaseExtractAST, 10))
+	before := rows["r"]
+	rows = Fold(rows, ev("r", progress.PhaseScan, 5)) // older ts
+	if rows["r"] != before {
+		t.Errorf("stale event mutated row: %+v -> %+v", before, rows["r"])
+	}
+}
+
+// TestFold_TerminalNotRegressed: a done row stays done even if a module-scoped
+// in-flight event arrives later.
+func TestFold_TerminalNotRegressed(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("r", progress.PhaseDone, 10))
+	rows = Fold(rows, ev("r", progress.PhaseExtractAST, 11))
+	if !rows["r"].Terminal() {
+		t.Errorf("terminal row regressed to %q", rows["r"].Phase)
+	}
+}
+
+// TestFold_FilesDoneNeverRegress: files_done only moves forward.
+func TestFold_FilesDoneNeverRegress(t *testing.T) {
+	rows := map[string]Row{}
+	e := ev("r", progress.PhaseExtractAST, 1)
+	e.FilesDone, e.FilesTotal = 50, 100
+	rows = Fold(rows, e)
+	e2 := ev("r", progress.PhaseExtractAST, 2)
+	e2.FilesDone, e2.FilesTotal = 30, 100 // out-of-order lower count
+	rows = Fold(rows, e2)
+	if rows["r"].FilesDone != 50 {
+		t.Errorf("files_done regressed to %d, want 50", rows["r"].FilesDone)
+	}
+}
+
+// TestAggregateProgress_ExpectedReposDenominator: a not-yet-reported repo counts
+// as 0 so the bar doesn't jump.
+func TestAggregateProgress_ExpectedReposDenominator(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("a", progress.PhaseDone, 1)) // 100%
+	// Only 1 of 2 expected repos reported → ~50%.
+	got := AggregateProgress(rows, 2)
+	if got < 0.45 || got > 0.55 {
+		t.Errorf("aggregate = %.2f, want ~0.50 (1 done of 2 expected)", got)
+	}
+	// Without expectedRepos, denominator is rows → 100%.
+	if g := AggregateProgress(rows, 0); g != 1 {
+		t.Errorf("aggregate w/o expected = %.2f, want 1.0", g)
+	}
+}
+
+// TestOverallPhaseLabel_LeastAdvanced: the gating label is the least-advanced
+// active repo.
+func TestOverallPhaseLabel_LeastAdvanced(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("a", progress.PhaseWriteGraph, 1))
+	rows = Fold(rows, ev("b", progress.PhaseScan, 2))
+	if l := OverallPhaseLabel(rows, false); l != "Scanning…" {
+		t.Errorf("label = %q, want Scanning… (least-advanced gates)", l)
+	}
+	if l := OverallPhaseLabel(rows, true); l != "Done" {
+		t.Errorf("terminal label = %q, want Done", l)
+	}
+}
+
+// TestRowsTerminal_GatesOnExpected: not terminal until all expected repos exist
+// and each is terminal.
+func TestRowsTerminal_GatesOnExpected(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("a", progress.PhaseDone, 1))
+	if RowsTerminal(rows, 2) {
+		t.Error("reported terminal with 1/2 repos — early-fire bug")
+	}
+	rows = Fold(rows, ev("b", progress.PhaseDone, 2))
+	if !RowsTerminal(rows, 2) {
+		t.Error("not terminal with 2/2 done repos")
+	}
+	if RowsTerminal(rows, 0) {
+		t.Error("terminal with unknown expected count — should defer")
+	}
+}
+
+func TestSortRows_StableBySlug(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("zeta", progress.PhaseScan, 1))
+	rows = Fold(rows, ev("alpha", progress.PhaseScan, 2))
+	got := SortRows(rows)
+	if got[0].RepoSlug != "alpha" || got[1].RepoSlug != "zeta" {
+		t.Errorf("sort order = %v, want [alpha zeta]", []string{got[0].RepoSlug, got[1].RepoSlug})
+	}
+}

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -1,0 +1,170 @@
+package wiztui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/progress"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
+
+	prog "github.com/cajasmota/grafel/internal/progress"
+)
+
+// indexView holds the state for the per-repo indexing screen. It folds broker
+// events into one Row per repo (fixing the dropped-repo bug) and renders an
+// overall progress bar plus one styled row per repo.
+type indexView struct {
+	group         string
+	expectedRepos int
+	rows          map[string]Row
+	bar           progress.Model
+	spin          spinner.Model
+	terminal      bool   // RPC reported done
+	failed        bool   // RPC reported an error
+	errMsg        string // terminal error text
+	width         int
+
+	// final summary, populated when the RPC outcome lands.
+	summaryEntities int64
+	summaryRels     int64
+	elapsed         string
+}
+
+func newIndexView(group string, expectedRepos int) indexView {
+	b := progress.New(
+		progress.WithDefaultGradient(),
+		progress.WithoutPercentage(),
+	)
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(colAccent)
+	return indexView{
+		group:         group,
+		expectedRepos: expectedRepos,
+		rows:          map[string]Row{},
+		bar:           b,
+		spin:          s,
+	}
+}
+
+// foldEvent folds a single broker event into the per-repo rows.
+func (v *indexView) foldEvent(e prog.Event) {
+	v.rows = Fold(v.rows, e)
+}
+
+// done reports whether the indexing screen has fully completed.
+func (v indexView) done() bool { return v.terminal || v.failed }
+
+var (
+	rowSlugStyle    = lipgloss.NewStyle().Foreground(colText).Bold(true)
+	rowPhaseStyle   = lipgloss.NewStyle().Foreground(colYellow)
+	rowDoneStyle    = lipgloss.NewStyle().Foreground(colGreen)
+	rowErrStyle     = lipgloss.NewStyle().Foreground(colRed)
+	rowCountStyle   = lipgloss.NewStyle().Foreground(colMuted)
+	overallLblStyle = lipgloss.NewStyle().Foreground(colAccent2).Bold(true)
+)
+
+// renderRow renders one repo row: name · phase · files done/total · entities ·
+// a spinner glyph while active.
+func (v indexView) renderRow(r Row, spinnerFrame string) string {
+	const slugW = 22
+
+	name := truncate(r.RepoSlug, slugW)
+	name = rowSlugStyle.Render(fmt.Sprintf("%-*s", slugW, name))
+
+	var glyph, phase string
+	switch {
+	case r.Phase == prog.PhaseError:
+		glyph = rowErrStyle.Render("✗")
+		msg := r.Error
+		if msg == "" {
+			msg = "error"
+		}
+		phase = rowErrStyle.Render(truncate(msg, 40))
+	case r.Phase == prog.PhaseDone:
+		glyph = rowDoneStyle.Render("✓")
+		phase = rowDoneStyle.Render("Done")
+	default:
+		glyph = spinnerFrame
+		phase = rowPhaseStyle.Render(PhaseLabel(r.Phase))
+	}
+
+	var extra []string
+	if r.FilesTotal > 0 && !r.Terminal() {
+		extra = append(extra, fmt.Sprintf("%d/%d files", r.FilesDone, r.FilesTotal))
+	}
+	if r.EntitiesSoFar > 0 {
+		extra = append(extra, fmt.Sprintf("%d entities", r.EntitiesSoFar))
+	}
+	tail := ""
+	if len(extra) > 0 {
+		tail = "  " + rowCountStyle.Render(strings.Join(extra, " · "))
+	}
+
+	return fmt.Sprintf("%s %s  %s%s", glyph, name, phase, tail)
+}
+
+// view renders the full indexing body (overall bar + per-repo rows + summary).
+func (v indexView) view() string {
+	var b strings.Builder
+
+	rows := SortRows(v.rows)
+
+	// Overall progress bar + label.
+	pct := AggregateProgress(v.rows, v.expectedRepos)
+	if v.terminal {
+		pct = 1
+	}
+	label := OverallPhaseLabel(v.rows, v.terminal)
+	if v.failed {
+		label = "Failed"
+	}
+
+	width := v.width - 4
+	if width < 20 {
+		width = 20
+	}
+	if width > 80 {
+		width = 80
+	}
+	bar := v.bar
+	bar.Width = width
+
+	b.WriteString(overallLblStyle.Render(fmt.Sprintf("Indexing %s — %s", v.group, label)))
+	b.WriteString("\n")
+	b.WriteString(bar.ViewAs(pct))
+	b.WriteString(fmt.Sprintf("  %3d%%\n\n", int(pct*100)))
+
+	if len(rows) == 0 {
+		b.WriteString(rowCountStyle.Render("waiting for the indexer to report…"))
+		return b.String()
+	}
+
+	spinnerFrame := v.spin.View()
+	for _, r := range rows {
+		b.WriteString(v.renderRow(r, spinnerFrame))
+		b.WriteString("\n")
+	}
+
+	// Done / error summary.
+	if v.failed {
+		b.WriteString("\n")
+		b.WriteString(rowErrStyle.Render("Index failed: " + v.errMsg))
+	} else if v.terminal {
+		b.WriteString("\n")
+		parts := []string{"Done"}
+		if v.summaryEntities > 0 {
+			parts = append(parts, fmt.Sprintf("%d entities", v.summaryEntities))
+		}
+		if v.summaryRels > 0 {
+			parts = append(parts, fmt.Sprintf("%d relationships", v.summaryRels))
+		}
+		if v.elapsed != "" {
+			parts = append(parts, v.elapsed)
+		}
+		b.WriteString(rowDoneStyle.Render(strings.Join(parts, "  ·  ")))
+	}
+
+	return b.String()
+}

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -1,0 +1,482 @@
+package wiztui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	prog "github.com/cajasmota/grafel/internal/progress"
+)
+
+// Action mirrors the four top-level wizard actions. The wiztui package keeps
+// its own enum so it has no dependency on the cli package (which imports it).
+type Action string
+
+const (
+	ActionSingle   Action = "single"
+	ActionGroup    Action = "group"
+	ActionMonorepo Action = "monorepo"
+	ActionAddGroup Action = "add-group"
+)
+
+// Candidate is one selectable repo/package/group option.
+type Candidate struct {
+	Label    string // shown to the user
+	Value    string // returned (abs path, package root, or group name)
+	Selected bool   // initial selection state (for multiselect)
+}
+
+// rescanSentinel is the special Candidate value for "scan a different folder…".
+const RescanSentinel = "\x00rescan"
+
+// Result is the outcome of the interactive selection portion of the wizard,
+// handed back to the cli package which owns all the side effects (classify,
+// applyGroupConfig, index). The TUI itself performs no registration.
+type Result struct {
+	Action     Action
+	Repos      []string // chosen absolute repo paths (or package roots)
+	AddToGroup string   // non-empty when Action == ActionAddGroup
+	GroupName  string
+	GroupDocs  string
+	Watchers   bool
+	GitHooks   bool
+	Cancelled  bool // user pressed ctrl-c / esc out of the first screen
+
+	indexErr error // set if indexing failed (read via IndexErr)
+}
+
+// IndexErr returns the indexing error, if any (nil on success / daemon-down).
+func (r Result) IndexErr() error { return r.indexErr }
+
+// Driver supplies the dynamic data the model needs at each step and is
+// implemented by the cli package. This keeps all classification / registry /
+// filesystem logic in cli (preserved verbatim) while the model owns only
+// presentation + interaction.
+type Driver interface {
+	// ContextLine is the "Detected: …" line for the action screen.
+	ContextLine() string
+	// SuggestedAction is the pre-placed cursor action on the action screen.
+	SuggestedAction() Action
+	// Candidates returns the selectable repos/packages for an action, plus a
+	// title. needsPath is true when no candidates could be derived and the
+	// caller should fall through to a path prompt (handled out-of-band).
+	Candidates(a Action) (title string, cands []Candidate)
+	// Groups returns the existing group names (for add-to-group).
+	Groups() []Candidate
+	// DefaultGroupName suggests a group name from chosen repo paths.
+	DefaultGroupName(repos []string) string
+}
+
+// IndexFunc starts the index for the assembled result and returns a channel of
+// progress events plus a channel that delivers the final outcome. It is invoked
+// by the model once the user confirms; the model only renders what flows back.
+type IndexFunc func(r Result) (<-chan prog.Event, <-chan IndexOutcome)
+
+// IndexOutcome is the terminal result of indexing.
+type IndexOutcome struct {
+	Entities int64
+	Rels     int64
+	Elapsed  string
+	Err      error
+	// DaemonDown indicates the group was registered but not indexed (daemon
+	// not running) — a soft, non-error completion.
+	DaemonDown bool
+}
+
+// screen identifies the active screen in the state machine.
+type screen int
+
+const (
+	scrAction screen = iota
+	scrSelect
+	scrGroupPick // add-to-group: pick target group
+	scrName
+	scrDocs
+	scrIndex
+	scrDone
+)
+
+// progressMsg / outcomeMsg are tea messages carrying indexing data.
+type progressMsg prog.Event
+type outcomeMsg IndexOutcome
+type indexStartedMsg struct {
+	events  <-chan prog.Event
+	outcome <-chan IndexOutcome
+}
+
+// Model is the full-screen Bubble Tea wizard model.
+type Model struct {
+	drv   Driver
+	index IndexFunc
+
+	width, height int
+
+	scr  screen
+	step Step
+
+	// screens
+	actionList listModel
+	selectList multiListModel
+	groupPick  listModel
+	nameInput  inputModel
+	docsInput  inputModel
+	idx        indexView
+
+	// accumulated result
+	res Result
+
+	// channels for live indexing
+	evCh  <-chan prog.Event
+	outCh <-chan IndexOutcome
+
+	err  string
+	quit bool
+}
+
+// New builds the wizard model. watchers/gitHooks seed the result defaults
+// (features are taken from flags, matching the current behavior — the TUI does
+// not re-prompt for them).
+func New(drv Driver, index IndexFunc, watchers, gitHooks bool) Model {
+	m := Model{
+		drv:   drv,
+		index: index,
+		scr:   scrAction,
+		step:  StepAction,
+	}
+	m.res.Watchers = watchers
+	m.res.GitHooks = gitHooks
+
+	m.actionList = newListModel("What do you want to index?", []Candidate{
+		{Label: "Index a single repository", Value: string(ActionSingle)},
+		{Label: "Index a group of related repositories", Value: string(ActionGroup)},
+		{Label: "Index a monorepo", Value: string(ActionMonorepo)},
+		{Label: "Add a repository to an existing group", Value: string(ActionAddGroup)},
+	})
+	// Pre-place cursor on the suggested action.
+	m.actionList.context = drv.ContextLine()
+	m.actionList.setCursorByValue(string(drv.SuggestedAction()))
+	return m
+}
+
+// Init implements tea.Model.
+func (m Model) Init() tea.Cmd { return nil }
+
+// Result returns the final accumulated result (read after the program exits).
+func (m Model) Result() Result { return m.res }
+
+// Update implements tea.Model.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.idx.width = msg.Width
+		return m, nil
+
+	case tea.KeyMsg:
+		// Global quit. ctrl-c always cancels cleanly (nothing registered).
+		if msg.Type == tea.KeyCtrlC {
+			m.res.Cancelled = true
+			m.quit = true
+			return m, tea.Quit
+		}
+		return m.updateKey(msg)
+
+	case indexStartedMsg:
+		m.evCh = msg.events
+		m.outCh = msg.outcome
+		return m, tea.Batch(m.idx.spin.Tick, waitEvent(m.evCh), waitOutcome(m.outCh))
+
+	case progressMsg:
+		m.idx.foldEvent(prog.Event(msg))
+		return m, waitEvent(m.evCh)
+
+	case outcomeMsg:
+		o := IndexOutcome(msg)
+		m.idx.summaryEntities = o.Entities
+		m.idx.summaryRels = o.Rels
+		m.idx.elapsed = o.Elapsed
+		if o.Err != nil {
+			m.idx.failed = true
+			m.idx.errMsg = o.Err.Error()
+			m.res.indexErr = o.Err
+		} else {
+			m.idx.terminal = true
+		}
+		m.scr = scrDone
+		m.step = StepDone
+		return m, nil
+
+	default:
+		// Spinner ticks while indexing.
+		if m.scr == scrIndex {
+			var cmd tea.Cmd
+			m.idx.spin, cmd = m.idx.spin.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+}
+
+// updateKey routes key events to the active screen.
+func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.err = ""
+	switch m.scr {
+	case scrAction:
+		return m.updateAction(msg)
+	case scrSelect:
+		return m.updateSelect(msg)
+	case scrGroupPick:
+		return m.updateGroupPick(msg)
+	case scrName:
+		return m.updateName(msg)
+	case scrDocs:
+		return m.updateDocs(msg)
+	case scrIndex:
+		// Index screen: only ctrl-c (handled globally) interrupts.
+		return m, nil
+	case scrDone:
+		switch msg.String() {
+		case "enter", "q", "esc":
+			m.quit = true
+			return m, tea.Quit
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) updateAction(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.actionList, cmd = m.actionList.Update(msg)
+	if msg.String() == "esc" {
+		m.res.Cancelled = true
+		m.quit = true
+		return m, tea.Quit
+	}
+	if m.actionList.chosen {
+		m.res.Action = Action(m.actionList.value())
+		return m.enterSelect()
+	}
+	return m, cmd
+}
+
+// enterSelect transitions to the Select screen, populating candidates.
+func (m Model) enterSelect() (tea.Model, tea.Cmd) {
+	if m.res.Action == ActionAddGroup {
+		groups := m.drv.Groups()
+		if len(groups) == 0 {
+			m.err = "no existing groups to add to"
+			// stay on action screen
+			m.actionList.chosen = false
+			return m, nil
+		}
+		m.groupPick = newListModel("Add to which group?", groups)
+		m.scr = scrGroupPick
+		m.step = StepSelect
+		return m, nil
+	}
+
+	title, cands := m.drv.Candidates(m.res.Action)
+	// Append the rescan entry.
+	cands = append(cands, Candidate{Label: "scan a different folder…", Value: RescanSentinel})
+	m.selectList = newMultiListModel(title, cands)
+	m.scr = scrSelect
+	m.step = StepSelect
+	return m, nil
+}
+
+func (m Model) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "esc" {
+		m.scr = scrAction
+		m.step = StepAction
+		m.actionList.chosen = false
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.selectList, cmd = m.selectList.Update(msg)
+	if m.selectList.chosen {
+		vals := m.selectList.values()
+		// Rescan path is handled by the caller (re-derive candidates) — here we
+		// just treat selecting rescan with nothing else as a no-op error.
+		var repos []string
+		rescan := false
+		for _, v := range vals {
+			if v == RescanSentinel {
+				rescan = true
+				continue
+			}
+			repos = append(repos, v)
+		}
+		if rescan && len(repos) == 0 {
+			m.err = "scan-a-different-folder isn't available in this view; pass a path via flags"
+			m.selectList.chosen = false
+			return m, nil
+		}
+		if len(repos) == 0 {
+			m.err = "select at least one repository (space to toggle)"
+			m.selectList.chosen = false
+			return m, nil
+		}
+		m.res.Repos = repos
+		if m.res.Action == ActionAddGroup {
+			return m.startIndex()
+		}
+		return m.enterName()
+	}
+	return m, cmd
+}
+
+func (m Model) updateGroupPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "esc" {
+		m.scr = scrAction
+		m.step = StepAction
+		m.actionList.chosen = false
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.groupPick, cmd = m.groupPick.Update(msg)
+	if m.groupPick.chosen {
+		m.res.AddToGroup = m.groupPick.value()
+		// Now pick repos to add.
+		title, cands := m.drv.Candidates(ActionGroup)
+		cands = append(cands, Candidate{Label: "scan a different folder…", Value: RescanSentinel})
+		m.selectList = newMultiListModel(title, cands)
+		m.scr = scrSelect
+		m.step = StepSelect
+		return m, nil
+	}
+	return m, cmd
+}
+
+func (m Model) enterName() (tea.Model, tea.Cmd) {
+	def := m.drv.DefaultGroupName(m.res.Repos)
+	m.nameInput = newInputModel("Group name",
+		"Used as the registry key and the per-group config filename.", def, false)
+	m.scr = scrName
+	m.step = StepName
+	return m, m.nameInput.focusCmd()
+}
+
+func (m Model) updateName(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "esc" {
+		return m.enterSelect()
+	}
+	var cmd tea.Cmd
+	m.nameInput, cmd = m.nameInput.Update(msg)
+	if m.nameInput.done {
+		v := strings.TrimSpace(m.nameInput.value())
+		if v == "" {
+			m.err = "group name is required"
+			m.nameInput.done = false
+			return m, nil
+		}
+		m.res.GroupName = v
+		m.docsInput = newInputModel("Path to shared group docs",
+			"optional · press enter to skip", "", true)
+		m.scr = scrDocs
+		return m, m.docsInput.focusCmd()
+	}
+	return m, cmd
+}
+
+func (m Model) updateDocs(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "esc" {
+		return m.enterName()
+	}
+	var cmd tea.Cmd
+	m.docsInput, cmd = m.docsInput.Update(msg)
+	if m.docsInput.done {
+		m.res.GroupDocs = strings.TrimSpace(m.docsInput.value())
+		return m.startIndex()
+	}
+	return m, cmd
+}
+
+// startIndex transitions to the indexing screen and kicks off the index.
+func (m Model) startIndex() (tea.Model, tea.Cmd) {
+	m.scr = scrIndex
+	m.step = StepIndex
+	name := m.res.GroupName
+	if m.res.AddToGroup != "" {
+		name = m.res.AddToGroup
+	}
+	m.idx = newIndexView(name, len(m.res.Repos))
+	m.idx.width = m.width
+	res := m.res
+	start := func() tea.Msg {
+		ev, out := m.index(res)
+		return indexStartedMsg{events: ev, outcome: out}
+	}
+	return m, start
+}
+
+// View implements tea.Model.
+func (m Model) View() string {
+	if m.quit {
+		return ""
+	}
+	var body, hint string
+	switch m.scr {
+	case scrAction:
+		body = m.actionList.view(m.bodyHeight())
+		hint = hintList
+	case scrSelect:
+		body = m.selectList.view(m.bodyHeight())
+		hint = hintMulti
+	case scrGroupPick:
+		body = m.groupPick.view(m.bodyHeight())
+		hint = hintList
+	case scrName:
+		body = m.nameInput.view()
+		hint = hintInput
+	case scrDocs:
+		body = m.docsInput.view()
+		hint = hintInputOpt
+	case scrIndex:
+		body = m.idx.view()
+		hint = hintIndex
+	case scrDone:
+		body = m.idx.view()
+		hint = hintDone
+	}
+	if m.err != "" {
+		body = errStyle.Render("⚠ "+m.err) + "\n\n" + body
+	}
+	return frame(m.step, body, hint, m.width, m.height)
+}
+
+func (m Model) bodyHeight() int {
+	h := m.height - 6 // header + footer + padding budget
+	if h < 6 {
+		h = 6
+	}
+	return h
+}
+
+// waitEvent / waitOutcome block on the index channels inside tea.Cmds.
+func waitEvent(ch <-chan prog.Event) tea.Cmd {
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		e, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return progressMsg(e)
+	}
+}
+
+func waitOutcome(ch <-chan IndexOutcome) tea.Cmd {
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		o, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return outcomeMsg(o)
+	}
+}

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -1,0 +1,215 @@
+package wiztui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// fakeDriver is a static Driver for headless model tests.
+type fakeDriver struct {
+	suggested Action
+	cands     []Candidate
+	groups    []Candidate
+}
+
+func (d fakeDriver) ContextLine() string              { return "Detected: test fixture" }
+func (d fakeDriver) SuggestedAction() Action          { return d.suggested }
+func (d fakeDriver) Groups() []Candidate              { return d.groups }
+func (d fakeDriver) DefaultGroupName([]string) string { return "mygroup" }
+func (d fakeDriver) Candidates(Action) (string, []Candidate) {
+	return "2 repos found", append([]Candidate(nil), d.cands...)
+}
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "space":
+		return tea.KeyMsg{Type: tea.KeySpace}
+	case "ctrl-c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func send(m tea.Model, msg tea.Msg) tea.Model {
+	nm, _ := m.Update(msg)
+	return nm
+}
+
+func newTestModel(d Driver, idx IndexFunc) Model {
+	m := New(d, idx, true, true)
+	return m.update(tea.WindowSizeMsg{Width: 100, Height: 40})
+}
+
+// update is a tiny test helper to apply a msg and return the concrete Model.
+func (m Model) update(msg tea.Msg) Model {
+	nm, _ := m.Update(msg)
+	return nm.(Model)
+}
+
+// TestCtrlCBeforeConfirmRegistersNothing: ctrl-c on the first screen cancels and
+// never invokes the IndexFunc (no registration).
+func TestCtrlCBeforeConfirmRegistersNothing(t *testing.T) {
+	indexed := false
+	idx := func(Result) (<-chan progress.Event, <-chan IndexOutcome) {
+		indexed = true
+		ev := make(chan progress.Event)
+		out := make(chan IndexOutcome)
+		close(ev)
+		close(out)
+		return ev, out
+	}
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+	}}
+	m := newTestModel(d, idx)
+	m = m.update(key("ctrl-c"))
+	if !m.Result().Cancelled {
+		t.Error("ctrl-c did not set Cancelled")
+	}
+	if indexed {
+		t.Error("IndexFunc was invoked despite cancel — registration leaked")
+	}
+}
+
+// TestEscOnActionCancels: esc on the action screen cancels cleanly.
+func TestEscOnActionCancels(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup}
+	m := newTestModel(d, nilIndex)
+	m = m.update(key("esc"))
+	if !m.Result().Cancelled {
+		t.Error("esc on action screen did not cancel")
+	}
+}
+
+// TestSingleFlowReachesIndex: action(single) → select(confirm) → index.
+func TestSingleFlowReachesIndex(t *testing.T) {
+	started := false
+	idx := func(r Result) (<-chan progress.Event, <-chan IndexOutcome) {
+		started = true
+		if r.Action != ActionSingle {
+			t.Errorf("action = %q, want single", r.Action)
+		}
+		ev := make(chan progress.Event)
+		out := make(chan IndexOutcome, 1)
+		close(ev)
+		out <- IndexOutcome{Entities: 5}
+		close(out)
+		return ev, out
+	}
+	d := fakeDriver{suggested: ActionSingle, cands: []Candidate{
+		{Label: "/repo", Value: "/repo", Selected: true},
+	}}
+	m := newTestModel(d, idx)
+	// Action screen: cursor pre-placed on single (suggested). Confirm.
+	m = m.update(key("enter")) // choose action → select screen
+	if m.scr != scrSelect {
+		t.Fatalf("after action enter, scr = %v, want scrSelect", m.scr)
+	}
+	// Single's one candidate is pre-selected; confirm → name screen (a single
+	// repo still becomes its own group, so a name is prompted).
+	m = m.update(key("enter"))
+	if m.scr != scrName {
+		t.Fatalf("after select enter, scr = %v, want scrName", m.scr)
+	}
+	m = m.update(key("enter")) // accept default group name → docs
+	if m.scr != scrDocs {
+		t.Fatalf("after name enter, scr = %v, want scrDocs", m.scr)
+	}
+	m = m.update(key("enter")) // skip docs → index
+	if m.scr != scrIndex {
+		t.Fatalf("after docs enter, scr = %v, want scrIndex", m.scr)
+	}
+	if m.index == nil {
+		t.Fatal("index func not wired")
+	}
+	// Simulate the indexStartedMsg → progress → outcome path.
+	evc, outc := m.index(m.res)
+	if !started {
+		t.Error("IndexFunc not started")
+	}
+	m = m.update(indexStartedMsg{events: evc, outcome: outc})
+	// Pump the outcome.
+	o := <-outc
+	m = m.update(outcomeMsg(o))
+	if m.scr != scrDone {
+		t.Errorf("after outcome, scr = %v, want scrDone", m.scr)
+	}
+}
+
+// TestGroupMultiSelectRequiresSelection: confirming with nothing selected errors
+// and stays on the select screen.
+func TestGroupMultiSelectRequiresSelection(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: false},
+		{Label: "/b", Value: "/b", Selected: false},
+	}}
+	m := newTestModel(d, nilIndex)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // confirm with none selected
+	if m.scr != scrSelect {
+		t.Errorf("advanced past select with 0 selected; scr=%v", m.scr)
+	}
+	if m.err == "" {
+		t.Error("expected an error message for empty selection")
+	}
+}
+
+// TestGroupFlowToName: selecting a repo advances to the name screen.
+func TestGroupFlowToName(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+		{Label: "/b", Value: "/b", Selected: true},
+	}}
+	m := newTestModel(d, nilIndex)
+	m = m.update(key("enter")) // action → select (both pre-selected)
+	m = m.update(key("enter")) // confirm selection → name
+	if m.scr != scrName {
+		t.Fatalf("scr = %v, want scrName", m.scr)
+	}
+	if m.nameInput.value() != "mygroup" {
+		t.Errorf("name prefilled %q, want mygroup", m.nameInput.value())
+	}
+}
+
+// TestAddGroupFlow: add-to-group picks a group then repos, then indexes.
+func TestAddGroupFlow(t *testing.T) {
+	d := fakeDriver{
+		suggested: ActionGroup,
+		cands:     []Candidate{{Label: "/x", Value: "/x", Selected: true}},
+		groups:    []Candidate{{Label: "existing", Value: "existing"}},
+	}
+	m := newTestModel(d, nilIndex)
+	// Move cursor to add-group (4th action) and confirm.
+	m = m.update(key("down"))
+	m = m.update(key("down"))
+	m = m.update(key("down"))
+	m = m.update(key("enter"))
+	if m.scr != scrGroupPick {
+		t.Fatalf("scr = %v, want scrGroupPick", m.scr)
+	}
+	m = m.update(key("enter")) // pick group
+	if m.scr != scrSelect {
+		t.Fatalf("scr = %v, want scrSelect after group pick", m.scr)
+	}
+	if m.res.AddToGroup != "existing" {
+		t.Errorf("AddToGroup = %q, want existing", m.res.AddToGroup)
+	}
+}
+
+func nilIndex(Result) (<-chan progress.Event, <-chan IndexOutcome) {
+	ev := make(chan progress.Event)
+	out := make(chan IndexOutcome)
+	close(ev)
+	close(out)
+	return ev, out
+}

--- a/internal/cli/wiztui/view_test.go
+++ b/internal/cli/wiztui/view_test.go
@@ -1,0 +1,56 @@
+package wiztui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// TestView_RendersAllScreensNoPanic walks the model through every screen and
+// asserts View() returns non-empty output with the chrome present.
+func TestView_RendersAllScreensNoPanic(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+		{Label: "/b", Value: "/b", Selected: true},
+	}}
+	m := newTestModel(d, nilIndex)
+
+	assertChrome := func(label string, mm Model) {
+		v := mm.View()
+		if !strings.Contains(v, "grafel wizard") {
+			t.Errorf("%s: header title missing", label)
+		}
+		if !strings.Contains(v, "ctrl-c") && mm.scr != scrDone {
+			t.Errorf("%s: footer hint missing", label)
+		}
+	}
+
+	assertChrome("action", m)
+	m = m.update(key("enter")) // → select
+	assertChrome("select", m)
+	m = m.update(key("enter")) // → name
+	assertChrome("name", m)
+	m = m.update(key("enter")) // → docs
+	assertChrome("docs", m)
+}
+
+// TestIndexView_RendersOneRowPerRepo asserts the indexing view renders a
+// distinct row for each repo (the dropped-repo fix, end-to-end through View).
+func TestIndexView_RendersOneRowPerRepo(t *testing.T) {
+	v := newIndexView("grp", 3)
+	v.width = 100
+	for _, slug := range []string{"backend", "frontend", "mobile"} {
+		v.foldEvent(progress.Event{RepoSlug: slug, Phase: progress.PhaseExtractAST, FilesDone: 10, FilesTotal: 100, TS: 1})
+	}
+	out := v.view()
+	for _, slug := range []string{"backend", "frontend", "mobile"} {
+		if !strings.Contains(out, slug) {
+			t.Errorf("indexing view dropped repo %q:\n%s", slug, out)
+		}
+	}
+	// Overall bar + label present.
+	if !strings.Contains(out, "Indexing grp") {
+		t.Errorf("overall indexing label missing:\n%s", out)
+	}
+}

--- a/internal/cli/wiztui/widgets.go
+++ b/internal/cli/wiztui/widgets.go
@@ -1,0 +1,368 @@
+package wiztui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ── listModel: a single-select list with type-to-filter ──────────────────────
+
+var (
+	cursorStyle   = lipgloss.NewStyle().Foreground(colAccent).Bold(true)
+	optStyle      = lipgloss.NewStyle().Foreground(colText)
+	optDimStyle   = lipgloss.NewStyle().Foreground(colMuted)
+	selOptStyle   = lipgloss.NewStyle().Foreground(colAccent).Bold(true)
+	titleTxtStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("231")).Bold(true)
+	filterStyle   = lipgloss.NewStyle().Foreground(colYellow)
+	posStyle      = lipgloss.NewStyle().Foreground(colMuted)
+)
+
+type listModel struct {
+	title     string
+	context   string // optional context line under the title
+	all       []Candidate
+	cursor    int
+	filter    string
+	filtering bool
+	chosen    bool
+}
+
+func newListModel(title string, opts []Candidate) listModel {
+	return listModel{title: title, all: opts}
+}
+
+func (m *listModel) setCursorByValue(v string) {
+	for i, c := range m.all {
+		if c.Value == v {
+			m.cursor = i
+			return
+		}
+	}
+}
+
+func (m listModel) visible() []Candidate {
+	if m.filter == "" {
+		return m.all
+	}
+	f := strings.ToLower(m.filter)
+	var out []Candidate
+	for _, c := range m.all {
+		if strings.Contains(strings.ToLower(c.Label), f) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func (m listModel) value() string {
+	vis := m.visible()
+	if m.cursor < 0 || m.cursor >= len(vis) {
+		return ""
+	}
+	return vis[m.cursor].Value
+}
+
+func (m listModel) Update(msg tea.KeyMsg) (listModel, tea.Cmd) {
+	vis := m.visible()
+	if m.filtering {
+		switch msg.Type {
+		case tea.KeyEnter:
+			m.filtering = false
+		case tea.KeyEsc:
+			m.filtering = false
+			m.filter = ""
+		case tea.KeyBackspace:
+			if len(m.filter) > 0 {
+				m.filter = m.filter[:len(m.filter)-1]
+			}
+		case tea.KeyRunes, tea.KeySpace:
+			m.filter += string(msg.Runes)
+		}
+		if m.cursor >= len(m.visible()) {
+			m.cursor = len(m.visible()) - 1
+		}
+		if m.cursor < 0 {
+			m.cursor = 0
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(vis)-1 {
+			m.cursor++
+		}
+	case "/":
+		m.filtering = true
+	case "enter":
+		if len(vis) > 0 {
+			m.chosen = true
+		}
+	}
+	return m, nil
+}
+
+func (m listModel) view(maxHeight int) string {
+	var b strings.Builder
+	b.WriteString(titleTxtStyle.Render(m.title))
+	b.WriteString("\n")
+	if m.context != "" {
+		b.WriteString(contextStyle.Render(m.context))
+		b.WriteString("\n")
+	}
+	if m.filtering || m.filter != "" {
+		b.WriteString(filterStyle.Render("filter: " + m.filter + "█"))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	vis := m.visible()
+	start, end, more := windowBounds(m.cursor, len(vis), maxHeight)
+	for i := start; i < end; i++ {
+		c := vis[i]
+		cursor := "  "
+		line := optStyle.Render(c.Label)
+		if i == m.cursor {
+			cursor = cursorStyle.Render("› ")
+			line = selOptStyle.Render(c.Label)
+		}
+		b.WriteString(cursor + line + "\n")
+	}
+	if more != "" {
+		b.WriteString(posStyle.Render(more))
+	}
+	return b.String()
+}
+
+// ── multiListModel: a multi-select list with [ ]/[✓] and type-to-filter ───────
+
+type multiListModel struct {
+	title     string
+	all       []Candidate
+	cursor    int
+	filter    string
+	filtering bool
+	chosen    bool
+}
+
+func newMultiListModel(title string, opts []Candidate) multiListModel {
+	return multiListModel{title: title, all: opts}
+}
+
+func (m multiListModel) visibleIdx() []int {
+	if m.filter == "" {
+		idx := make([]int, len(m.all))
+		for i := range m.all {
+			idx[i] = i
+		}
+		return idx
+	}
+	f := strings.ToLower(m.filter)
+	var out []int
+	for i, c := range m.all {
+		if strings.Contains(strings.ToLower(c.Label), f) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func (m multiListModel) values() []string {
+	var out []string
+	for _, c := range m.all {
+		if c.Selected {
+			out = append(out, c.Value)
+		}
+	}
+	return out
+}
+
+func (m multiListModel) selectedCount() int {
+	n := 0
+	for _, c := range m.all {
+		if c.Selected {
+			n++
+		}
+	}
+	return n
+}
+
+func (m multiListModel) Update(msg tea.KeyMsg) (multiListModel, tea.Cmd) {
+	vis := m.visibleIdx()
+	if m.filtering {
+		switch msg.Type {
+		case tea.KeyEnter:
+			m.filtering = false
+		case tea.KeyEsc:
+			m.filtering = false
+			m.filter = ""
+		case tea.KeyBackspace:
+			if len(m.filter) > 0 {
+				m.filter = m.filter[:len(m.filter)-1]
+			}
+		case tea.KeyRunes:
+			m.filter += string(msg.Runes)
+		}
+		if m.cursor >= len(m.visibleIdx()) {
+			m.cursor = len(m.visibleIdx()) - 1
+		}
+		if m.cursor < 0 {
+			m.cursor = 0
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+	case "down", "j":
+		if m.cursor < len(vis)-1 {
+			m.cursor++
+		}
+	case " ":
+		if m.cursor >= 0 && m.cursor < len(vis) {
+			realIdx := vis[m.cursor]
+			m.all[realIdx].Selected = !m.all[realIdx].Selected
+		}
+	case "a":
+		for _, i := range vis {
+			if m.all[i].Value != RescanSentinel {
+				m.all[i].Selected = true
+			}
+		}
+	case "n":
+		for _, i := range vis {
+			m.all[i].Selected = false
+		}
+	case "/":
+		m.filtering = true
+	case "enter":
+		m.chosen = true
+	}
+	return m, nil
+}
+
+func (m multiListModel) view(maxHeight int) string {
+	var b strings.Builder
+	count := m.selectedCount()
+	header := fmt.Sprintf("%s  (%d selected)", m.title, count)
+	b.WriteString(titleTxtStyle.Render(header))
+	b.WriteString("\n")
+	if m.filtering || m.filter != "" {
+		b.WriteString(filterStyle.Render("filter: " + m.filter + "█"))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	vis := m.visibleIdx()
+	start, end, more := windowBounds(m.cursor, len(vis), maxHeight)
+	for i := start; i < end; i++ {
+		realIdx := vis[i]
+		c := m.all[realIdx]
+		box := "[ ] "
+		lineStyle := optStyle
+		if c.Selected {
+			box = "[✓] "
+			lineStyle = selOptStyle
+		}
+		cursor := "  "
+		if i == m.cursor {
+			cursor = cursorStyle.Render("› ")
+			lineStyle = lineStyle.Bold(true)
+		}
+		label := c.Label
+		if c.Value == RescanSentinel {
+			label = optDimStyle.Render(c.Label)
+			box = "    "
+		} else {
+			label = lineStyle.Render(label)
+		}
+		b.WriteString(cursor + box + label + "\n")
+	}
+	if more != "" {
+		b.WriteString(posStyle.Render(more))
+	}
+	return b.String()
+}
+
+// ── inputModel: a single text input ──────────────────────────────────────────
+
+type inputModel struct {
+	title       string
+	description string
+	ti          textinput.Model
+	optional    bool
+	done        bool
+}
+
+func newInputModel(title, description, value string, optional bool) inputModel {
+	ti := textinput.New()
+	ti.SetValue(value)
+	ti.CursorEnd()
+	ti.Prompt = "› "
+	ti.PromptStyle = cursorStyle
+	ti.Width = 50
+	return inputModel{title: title, description: description, ti: ti, optional: optional}
+}
+
+func (m inputModel) focusCmd() tea.Cmd { return m.ti.Focus() }
+
+func (m inputModel) value() string { return m.ti.Value() }
+
+func (m inputModel) Update(msg tea.KeyMsg) (inputModel, tea.Cmd) {
+	if msg.Type == tea.KeyEnter {
+		m.done = true
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.ti, cmd = m.ti.Update(msg)
+	return m, cmd
+}
+
+func (m inputModel) view() string {
+	var b strings.Builder
+	b.WriteString(titleTxtStyle.Render(m.title))
+	b.WriteString("\n")
+	if m.description != "" {
+		b.WriteString(optDimStyle.Render(m.description))
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(m.ti.View())
+	return b.String()
+}
+
+// windowBounds returns the [start,end) slice of items to render given a cursor
+// position, total count, and a max number of visible rows, plus a position
+// indicator string when the list overflows (long lists scroll; short lists show
+// fully — the action screen's 4 items always fit).
+func windowBounds(cursor, total, maxRows int) (start, end int, indicator string) {
+	if maxRows < 3 {
+		maxRows = 3
+	}
+	if total <= maxRows {
+		return 0, total, ""
+	}
+	// Center the cursor in the window where possible.
+	start = cursor - maxRows/2
+	if start < 0 {
+		start = 0
+	}
+	end = start + maxRows
+	if end > total {
+		end = total
+		start = end - maxRows
+	}
+	indicator = fmt.Sprintf("  ── %d–%d of %d ──", start+1, end, total)
+	return start, end, indicator
+}


### PR DESCRIPTION
Fixes #5340

## What

`grafel wizard`'s interactive flow is now a cohesive **Bubble Tea TUI** —
a single full-screen `tea.Model` state machine — replacing the per-prompt
huh-form presentation. All decision LOGIC and the install/index CALLS are
preserved verbatim; only the presentation/interaction layer changed.

## Model design

- **`internal/cli/wiztui/`** — self-contained TUI package with no dependency on
  `cli` (cli imports it). The model talks to the app through two seams:
  - `Driver` (implemented by `cli.wizardDriver`): `ContextLine`,
    `SuggestedAction`, `Candidates`, `Groups`, `DefaultGroupName` — all backed
    by the existing `detect.ClassifyPath` / `registry` / `groupCandidates`.
  - `IndexFunc` (implemented by `cli.makeIndexFunc`): on final confirm it
    assembles the config, calls `applyGroupConfig` (register + install) and
    streams the daemon's broker SSE phase events back to the model as
    `tea.Msg`s. **Registration only happens on confirm — a cancel registers
    nothing.**
- State machine: `Action → Select → Name → Docs → Index → Done`
  (add-to-group inserts a group-pick screen; the indexing screen owns the live
  view).

## Chrome (consistent on every screen)

- **Header**: styled `grafel wizard` title + a step rail
  `Action › Select › Name › Index` with the current step highlighted and
  completed steps check-marked (lipgloss).
- **Body**: sized from `tea.WindowSizeMsg`. The 4 actions are always fully
  visible (no scroll); long repo lists scroll inside a tall window with a
  `── n–m of T ──` position indicator.
- **Footer**: contextual key-hints on every screen, e.g.
  `↑/↓ move · space select · a all · n none · enter confirm · / filter · esc back · ctrl-c quit`,
  and `optional · enter to skip` on the docs input.

## Screens

1. **Action** — 4-item list, cursor pre-placed on `ClassifyPath(cwd).Suggested`,
   with the "Detected: …" context line.
2. **Select** — multiselect `[ ]`/`[✓]` of candidates (per action: group repos /
   monorepo packages / single repo / add-to-group), type-to-filter, live count.
3. **Name** — text input prefilled with the container-folder default
   (`defaultGroupName`); then an optional, skippable docs path.
4. **Index** — overall progress bar + **one row per repo** (name · phase label ·
   files done/total · entities · spinner while active), then a Done summary.

## Indexing view — fixes the dropped-repo bug

The old `renderBrokerEvent` rendered single carriage-return lines keyed by slug,
so with multiple repos all-but-one were dropped. The new view ports the
dashboard's fold (`webui-v2/src/lib/index-progress-fold.ts`) to Go
(`internal/cli/wiztui/fold.go`): one `Row` per `repo_slug`, monotonic phase (a
late lower phase never regresses), aggregate progress + least-advanced overall
label. Every repo renders as its own row. Labels match the dashboard
(`Scanning / Extracting AST / Building communities / Computing centrality /
Detecting cross-repo links / Computing flows / Writing graph / Done`).

## Behavior preservation

- **Non-interactive** (`--repos/--parent/--exclude/--no-index`): unchanged,
  never launches the TUI (verified: registers group, no auto-index).
- **Non-TTY** (piped stdin/stdout, `$TERM=dumb`/empty, CI, or `GRAFEL_NO_TUI`):
  `wizardUseTUI` returns false → the original line-based huh flow runs, so
  scripts/pipes don't get alt-screen output.
- `applyGroupConfig`, `ClassifyPath`, the broker SSE index stream, watcher
  robustness, auto-index, and the group-name default are reused, not
  reimplemented. `ctrl-c`/`esc` cancel cleanly.

## Tests

- `internal/cli/wiztui`: fold (multi-repo → multi-row no-drop, monotonic phase,
  stale-ts ignore, terminal-not-regressed, files-done never regress, aggregate
  denominator, least-advanced label, terminal gating), state-machine transitions
  (single/group/add-group flows, empty-selection guard, **ctrl-c before confirm
  registers nothing**), and View()/indexing-view render smoke tests (one row per
  repo end-to-end).
- `internal/cli`: non-TTY fallback decision (buffer/dumb/empty-TERM/opt-out) and
  monorepo result mapping.
- `go build ./...`, `go vet ./internal/cli/...`, `gofmt -l` empty,
  `go test ./internal/cli/... ./internal/install/... ./cmd/grafel/...` all green.

## Dependencies

No new direct dependency was added to the module graph: `bubbletea`, `bubbles`,
and `lipgloss` were already present (transitively via `huh`) and are simply
promoted from `// indirect` to direct requires at their existing versions.
`harmonica` (used by `bubbles/progress`) is pulled in as a transitive indirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
