### PR TITLE
fix(wizard): TUI per-screen context + light-blue accent + captured Done summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Changed
 
+- **`grafel wizard` TUI polish — per-screen context, light-blue accent, and a
+  captured Done summary (#5340):** each step now carries a concise explanatory
+  subtitle so it's clear what's being configured (what indexing a single repo /
+  group / monorepo means; "Choose which repositories to include in this group";
+  the Name screen names the actual repos being grouped; the optional-docs screen
+  explains shared markdown docs). The accent (header badge, step-rail pills,
+  cursor `›`, selected/active highlights) moved from pink/magenta to a tasteful
+  **light blue** (adaptive 256-color `117`/`75`), keeping green for done/✓. And
+  the install/index output that previously scattered over the alt-screen on
+  completion ("saved …", "installed N hooks/watchers/MCP", watcher warnings) is
+  now **captured and rendered inside the Done screen** — a clean summary line
+  plus any watcher warning as a styled non-fatal note — so nothing prints
+  misaligned after the TUI tears down (the non-TTY/plain path still prints the
+  normal messages) ([#5340](https://github.com/cajasmota/grafel/issues/5340)).
 - **`grafel wizard` now uses a cohesive Bubble Tea TUI (#5340):** the
   interactive wizard is a single full-screen `tea.Model` state machine with
   consistent chrome on every step — a styled grafel header + a step rail

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -9,6 +9,7 @@ package cli
 // render a per-repo indexing view without owning any side effects.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -25,6 +26,7 @@ import (
 	"github.com/cajasmota/grafel/internal/cli/wiztui"
 	"github.com/cajasmota/grafel/internal/daemon/client"
 	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/registry"
@@ -187,13 +189,18 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 
 			repos := reposForResult(class, r)
 
+			// In the TUI, applyGroupConfig's stdout must NOT leak onto the
+			// alt-screen (fix C, #5340). Capture it into a sink buffer and feed
+			// the structured install.Result back into the Done screen instead.
+			var sink bytes.Buffer
+
 			// Add-to-existing-group path.
 			if r.Action == wiztui.ActionAddGroup && r.AddToGroup != "" {
-				if err := addReposToExistingGroupNoIndex(out, r.AddToGroup, repos, opts); err != nil {
+				if err := addReposToExistingGroupNoIndex(&sink, r.AddToGroup, repos, opts); err != nil {
 					outCh <- wiztui.IndexOutcome{Err: err}
 					return
 				}
-				streamIndex(evCh, outCh, r.AddToGroup, opts.NoIndex)
+				streamIndexWithSummary(evCh, outCh, r.AddToGroup, opts.NoIndex, wiztui.InstallSummary{})
 				return
 			}
 
@@ -204,33 +211,53 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 			cfg.Features.AgentHooks = opts.AgentHooks
 			cfg.GroupDocs = r.GroupDocs
 			cfg.Repos = repos
-			if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall}); err != nil {
+			res, err := applyGroupConfig(&sink, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
+			if err != nil {
 				outCh <- wiztui.IndexOutcome{Err: err}
 				return
 			}
-			streamIndex(evCh, outCh, cfg.Name, opts.NoIndex)
+			streamIndexWithSummary(evCh, outCh, cfg.Name, opts.NoIndex, installSummary(res))
 		}()
 
 		return evCh, outCh
 	}
 }
 
-// streamIndex triggers a daemon index of group and forwards broker progress
-// events onto evCh, then sends the terminal outcome on outCh. A down daemon or
-// --no-index is a soft completion (DaemonDown), not an error.
-func streamIndex(evCh chan<- progress.Event, outCh chan<- wiztui.IndexOutcome, group string, noIndex bool) {
+// installSummary maps an install.Result into the TUI's structured summary so the
+// Done screen can render "installed N hooks · N watchers · N MCP" plus any
+// watcher warnings, instead of those lines scattering over the alt-screen.
+func installSummary(res *install.Result) wiztui.InstallSummary {
+	if res == nil {
+		// RunInstall was false — nothing was installed.
+		return wiztui.InstallSummary{}
+	}
+	return wiztui.InstallSummary{
+		Applied:         true,
+		Hooks:           len(res.HooksInstalled),
+		Watchers:        len(res.WatcherUnits),
+		MCP:             len(res.MCPSettings),
+		WatcherWarnings: res.WatcherWarnings,
+		ConfigPath:      res.GroupConfigPath,
+	}
+}
+
+// streamIndexWithSummary triggers a daemon index of group and forwards broker
+// progress events onto evCh, then sends the terminal outcome on outCh — with the
+// captured install summary attached so the Done screen renders it. A down daemon
+// or --no-index is a soft completion (DaemonDown), not an error.
+func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.IndexOutcome, group string, noIndex bool, summary wiztui.InstallSummary) {
 	if noIndex {
-		outCh <- wiztui.IndexOutcome{DaemonDown: true}
+		outCh <- wiztui.IndexOutcome{DaemonDown: true, Install: summary}
 		return
 	}
 
 	c, err := client.Dial()
 	if err != nil {
 		if errors.Is(err, client.ErrDaemonNotRunning) {
-			outCh <- wiztui.IndexOutcome{DaemonDown: true}
+			outCh <- wiztui.IndexOutcome{DaemonDown: true, Install: summary}
 			return
 		}
-		outCh <- wiztui.IndexOutcome{Err: err}
+		outCh <- wiztui.IndexOutcome{Err: err, Install: summary}
 		return
 	}
 	defer c.Close()
@@ -261,14 +288,14 @@ func streamIndex(evCh chan<- progress.Event, outCh chan<- wiztui.IndexOutcome, g
 		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
 			o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
 			cancel()
-			outCh <- toIndexOutcome(o)
+			outCh <- toIndexOutcome(o, summary)
 			return
 		}
 	}
 
 	// No dashboard broker — just wait for the RPC outcome.
 	o := <-rpcCh
-	outCh <- toIndexOutcome(o)
+	outCh <- toIndexOutcome(o, summary)
 }
 
 // forwardBrokerToChannel reads broker SSE events and forwards parsed
@@ -340,10 +367,11 @@ func jsonUnmarshalEvent(data string, e *progress.Event) bool {
 	return json.Unmarshal([]byte(data), e) == nil
 }
 
-// toIndexOutcome maps a rebuildOutcome to the TUI's terminal IndexOutcome.
-func toIndexOutcome(o rebuildOutcome) wiztui.IndexOutcome {
+// toIndexOutcome maps a rebuildOutcome to the TUI's terminal IndexOutcome,
+// attaching the captured install summary so the Done screen renders it.
+func toIndexOutcome(o rebuildOutcome, summary wiztui.InstallSummary) wiztui.IndexOutcome {
 	if o.err != nil {
-		return wiztui.IndexOutcome{Err: o.err}
+		return wiztui.IndexOutcome{Err: o.err, Install: summary}
 	}
 	elapsed := ""
 	if o.elapsed > 0 {
@@ -353,6 +381,7 @@ func toIndexOutcome(o rebuildOutcome) wiztui.IndexOutcome {
 		Entities: o.entities,
 		Rels:     o.rels,
 		Elapsed:  elapsed,
+		Install:  summary,
 	}
 }
 

--- a/internal/cli/wiztui/chrome.go
+++ b/internal/cli/wiztui/chrome.go
@@ -28,10 +28,17 @@ var stepRail = []struct {
 	{StepIndex, "Index"},
 }
 
-// Palette — derived from the charm theme so the TUI feels of-a-piece with huh.
+// Palette — a tasteful light-blue accent (replacing the former pink/magenta) so
+// every accented element — the header badge, step-rail pills, the cursor ›, and
+// selected/active highlights — reads as one cohesive blue on dark terminals,
+// with a light-mode-friendly variant via AdaptiveColor. Green stays reserved for
+// done/✓ and the phase colors are unchanged.
 var (
-	colAccent  = lipgloss.Color("212") // pink/magenta accent
-	colAccent2 = lipgloss.Color("99")  // purple
+	// colAccent is the single source of truth for the wizard accent. 256-color
+	// 117 (#87d7ff-ish) is a clean light blue on dark terminals; the adaptive
+	// Light variant (75 / #5fafff) stays legible on light backgrounds.
+	colAccent  = lipgloss.AdaptiveColor{Light: "75", Dark: "117"}
+	colAccent2 = lipgloss.AdaptiveColor{Light: "33", Dark: "75"} // deeper blue
 	colMuted   = lipgloss.Color("241")
 	colFaint   = lipgloss.Color("238")
 	colText    = lipgloss.Color("252")
@@ -41,8 +48,9 @@ var (
 )
 
 var (
+	// On a light-blue badge, dark ink reads crisper than white.
 	titleStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("231")).
+			Foreground(lipgloss.Color("16")).
 			Background(colAccent).
 			Bold(true).
 			Padding(0, 1)

--- a/internal/cli/wiztui/chrome_test.go
+++ b/internal/cli/wiztui/chrome_test.go
@@ -1,0 +1,34 @@
+package wiztui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAccentIsLightBlue asserts the single-source-of-truth accent is the new
+// light blue (not the former pink/magenta 212), with a light-mode-friendly
+// adaptive variant (fix B, #5340).
+func TestAccentIsLightBlue(t *testing.T) {
+	ac := colAccent // declared as lipgloss.AdaptiveColor in the theme
+	if ac.Dark != "117" {
+		t.Errorf("accent Dark = %q, want 117 (light blue)", ac.Dark)
+	}
+	if ac.Light == "" {
+		t.Errorf("accent Light variant unset; want a light-mode-friendly blue")
+	}
+	// No lingering magenta anywhere in the accent colors.
+	for _, c := range []string{ac.Light, ac.Dark} {
+		if c == "212" || c == "211" || c == "213" {
+			t.Errorf("accent still uses pink/magenta color %q", c)
+		}
+	}
+}
+
+// TestHeaderUsesAccent asserts the rendered header references the accent badge
+// (smoke check that the theme wiring still produces styled output).
+func TestHeaderUsesAccent(t *testing.T) {
+	h := header(StepAction, 80)
+	if !strings.Contains(h, "grafel wizard") {
+		t.Errorf("header missing title:\n%s", h)
+	}
+}

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -29,6 +29,8 @@ type indexView struct {
 	summaryEntities int64
 	summaryRels     int64
 	elapsed         string
+	daemonDown      bool           // group registered but not indexed
+	install         InstallSummary // captured applyGroupConfig output (fix C)
 }
 
 func newIndexView(group string, expectedRepos int) indexView {
@@ -62,6 +64,7 @@ var (
 	rowDoneStyle    = lipgloss.NewStyle().Foreground(colGreen)
 	rowErrStyle     = lipgloss.NewStyle().Foreground(colRed)
 	rowCountStyle   = lipgloss.NewStyle().Foreground(colMuted)
+	rowWarnStyle    = lipgloss.NewStyle().Foreground(colYellow)
 	overallLblStyle = lipgloss.NewStyle().Foreground(colAccent2).Bold(true)
 )
 
@@ -136,7 +139,7 @@ func (v indexView) view() string {
 	b.WriteString(bar.ViewAs(pct))
 	b.WriteString(fmt.Sprintf("  %3d%%\n\n", int(pct*100)))
 
-	if len(rows) == 0 {
+	if len(rows) == 0 && !v.done() {
 		b.WriteString(rowCountStyle.Render("waiting for the indexer to report…"))
 		return b.String()
 	}
@@ -153,17 +156,48 @@ func (v indexView) view() string {
 		b.WriteString(rowErrStyle.Render("Index failed: " + v.errMsg))
 	} else if v.terminal {
 		b.WriteString("\n")
-		parts := []string{"Done"}
-		if v.summaryEntities > 0 {
-			parts = append(parts, fmt.Sprintf("%d entities", v.summaryEntities))
-		}
-		if v.summaryRels > 0 {
-			parts = append(parts, fmt.Sprintf("%d relationships", v.summaryRels))
-		}
-		if v.elapsed != "" {
-			parts = append(parts, v.elapsed)
-		}
-		b.WriteString(rowDoneStyle.Render(strings.Join(parts, "  ·  ")))
+		b.WriteString(v.doneSummary())
+	}
+
+	return b.String()
+}
+
+// doneSummary renders the clean Done block that replaces applyGroupConfig's raw
+// stdout (fix C, #5340): a one-line index result, the captured install counts,
+// and any watcher warnings as styled non-fatal notes.
+func (v indexView) doneSummary() string {
+	var b strings.Builder
+
+	// Index result line (entities / relationships / elapsed), or a soft note
+	// when the daemon was down and the group was only registered.
+	head := "Done"
+	if v.daemonDown {
+		head = "Registered (not indexed — daemon not running)"
+	}
+	parts := []string{head}
+	if v.summaryEntities > 0 {
+		parts = append(parts, fmt.Sprintf("%d entities", v.summaryEntities))
+	}
+	if v.summaryRels > 0 {
+		parts = append(parts, fmt.Sprintf("%d relationships", v.summaryRels))
+	}
+	if v.elapsed != "" {
+		parts = append(parts, v.elapsed)
+	}
+	b.WriteString(rowDoneStyle.Render(strings.Join(parts, "  ·  ")))
+
+	// Captured install summary (hooks · watchers · MCP).
+	if v.install.Applied {
+		b.WriteString("\n")
+		b.WriteString(rowCountStyle.Render(fmt.Sprintf(
+			"installed %d hooks · %d watchers · %d MCP",
+			v.install.Hooks, v.install.Watchers, v.install.MCP)))
+	}
+
+	// Watcher warnings as styled non-fatal notes.
+	for _, w := range v.install.WatcherWarnings {
+		b.WriteString("\n")
+		b.WriteString(rowWarnStyle.Render("⚠ " + w))
 	}
 
 	return b.String()

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -81,6 +81,22 @@ type IndexOutcome struct {
 	// DaemonDown indicates the group was registered but not indexed (daemon
 	// not running) — a soft, non-error completion.
 	DaemonDown bool
+	// Install summarizes what applyGroupConfig wrote (hooks/watchers/MCP) and
+	// any non-fatal watcher warnings, captured so the TUI can render them inside
+	// the Done screen instead of letting raw stdout scatter over the alt-screen.
+	Install InstallSummary
+}
+
+// InstallSummary is the captured, structured outcome of applyGroupConfig's
+// install transaction. The cli package fills it from install.Result so the TUI
+// owns all post-completion output (fix C, #5340).
+type InstallSummary struct {
+	Applied         bool     // an install transaction ran (RunInstall was true)
+	Hooks           int      // git hooks installed
+	Watchers        int      // watcher units written
+	MCP             int      // MCP settings entries touched
+	WatcherWarnings []string // non-fatal watcher-activation warnings
+	ConfigPath      string   // saved per-group config path (e.g. "saved …")
 }
 
 // screen identifies the active screen in the state machine.
@@ -152,8 +168,10 @@ func New(drv Driver, index IndexFunc, watchers, gitHooks bool) Model {
 		{Label: "Index a monorepo", Value: string(ActionMonorepo)},
 		{Label: "Add a repository to an existing group", Value: string(ActionAddGroup)},
 	})
-	// Pre-place cursor on the suggested action.
-	m.actionList.context = drv.ContextLine()
+	// Pre-place cursor on the suggested action, with a one-line explainer of
+	// what the four indexing modes mean under the detected-context line.
+	m.actionList.context = drv.ContextLine() + "\n" +
+		"A single repo, a group of related repos, a monorepo's packages, or add to an existing group."
 	m.actionList.setCursorByValue(string(drv.SuggestedAction()))
 	return m
 }
@@ -196,6 +214,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.idx.summaryEntities = o.Entities
 		m.idx.summaryRels = o.Rels
 		m.idx.elapsed = o.Elapsed
+		m.idx.daemonDown = o.DaemonDown
+		m.idx.install = o.Install
 		if o.Err != nil {
 			m.idx.failed = true
 			m.idx.errMsg = o.Err.Error()
@@ -281,6 +301,7 @@ func (m Model) enterSelect() (tea.Model, tea.Cmd) {
 	// Append the rescan entry.
 	cands = append(cands, Candidate{Label: "scan a different folder…", Value: RescanSentinel})
 	m.selectList = newMultiListModel(title, cands)
+	m.selectList.context = "Choose which repositories to include in this group."
 	m.scr = scrSelect
 	m.step = StepSelect
 	return m, nil
@@ -342,6 +363,7 @@ func (m Model) updateGroupPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		title, cands := m.drv.Candidates(ActionGroup)
 		cands = append(cands, Candidate{Label: "scan a different folder…", Value: RescanSentinel})
 		m.selectList = newMultiListModel(title, cands)
+		m.selectList.context = "Choose which repositories to add to “" + m.res.AddToGroup + "”."
 		m.scr = scrSelect
 		m.step = StepSelect
 		return m, nil
@@ -351,11 +373,29 @@ func (m Model) updateGroupPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) enterName() (tea.Model, tea.Cmd) {
 	def := m.drv.DefaultGroupName(m.res.Repos)
-	m.nameInput = newInputModel("Group name",
-		"Used as the registry key and the per-group config filename.", def, false)
+	desc := "The group's registry key and config filename. Repos in this group: " +
+		repoNames(m.res.Repos) + "."
+	m.nameInput = newInputModel("Group name", desc, def, false)
 	m.scr = scrName
 	m.step = StepName
 	return m, m.nameInput.focusCmd()
+}
+
+// repoNames renders a short, comma-joined list of repo basenames for the Name
+// screen's explainer (so the user sees exactly which repos they're grouping).
+func repoNames(repos []string) string {
+	if len(repos) == 0 {
+		return "(none)"
+	}
+	names := make([]string, 0, len(repos))
+	for _, p := range repos {
+		base := p
+		if i := strings.LastIndexAny(p, `/\`); i >= 0 && i < len(p)-1 {
+			base = p[i+1:]
+		}
+		names = append(names, base)
+	}
+	return strings.Join(names, ", ")
 }
 
 func (m Model) updateName(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -373,7 +413,7 @@ func (m Model) updateName(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.res.GroupName = v
 		m.docsInput = newInputModel("Path to shared group docs",
-			"optional · press enter to skip", "", true)
+			"A folder of shared markdown docs surfaced in the graph. Optional — press enter to skip.", "", true)
 		m.scr = scrDocs
 		return m, m.docsInput.focusCmd()
 	}

--- a/internal/cli/wiztui/view_test.go
+++ b/internal/cli/wiztui/view_test.go
@@ -54,3 +54,68 @@ func TestIndexView_RendersOneRowPerRepo(t *testing.T) {
 		t.Errorf("overall indexing label missing:\n%s", out)
 	}
 }
+
+// TestDoneScreen_RendersCapturedSummary drives the model to completion with an
+// outcome carrying a captured install summary + watcher warning and asserts the
+// Done screen renders all of it inline (fix C, #5340) rather than leaking it to
+// raw stdout.
+func TestDoneScreen_RendersCapturedSummary(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+	}}
+	m := newTestModel(d, nilIndex)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // name → docs
+	m = m.update(key("enter")) // docs → index (startIndex)
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex", m.scr)
+	}
+
+	// Land a terminal outcome with a captured install summary + warning.
+	m = m.update(outcomeMsg(IndexOutcome{
+		Entities: 1234,
+		Rels:     56,
+		Elapsed:  "2.1s",
+		Install: InstallSummary{
+			Applied:         true,
+			Hooks:           2,
+			Watchers:        1,
+			MCP:             3,
+			WatcherWarnings: []string{"watcher for X not activated (will retry); group is registered and indexed"},
+		},
+	}))
+	if m.scr != scrDone {
+		t.Fatalf("scr = %v, want scrDone", m.scr)
+	}
+
+	v := m.View()
+	for _, want := range []string{
+		"1234 entities",
+		"56 relationships",
+		"installed 2 hooks · 1 watchers · 3 MCP",
+		"⚠ watcher for X not activated",
+	} {
+		if !strings.Contains(v, want) {
+			t.Errorf("Done screen missing %q:\n%s", want, v)
+		}
+	}
+}
+
+// TestDoneScreen_DaemonDownNote: a daemon-down soft completion renders the
+// "registered (not indexed)" note while still showing the captured install
+// counts.
+func TestDoneScreen_DaemonDownNote(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	v.terminal = true
+	v.daemonDown = true
+	v.install = InstallSummary{Applied: true, Hooks: 1, Watchers: 0, MCP: 1}
+	out := v.view()
+	if !strings.Contains(out, "Registered (not indexed") {
+		t.Errorf("daemon-down note missing:\n%s", out)
+	}
+	if !strings.Contains(out, "installed 1 hooks · 0 watchers · 1 MCP") {
+		t.Errorf("install counts missing on daemon-down:\n%s", out)
+	}
+}

--- a/internal/cli/wiztui/widgets.go
+++ b/internal/cli/wiztui/widgets.go
@@ -146,6 +146,7 @@ func (m listModel) view(maxHeight int) string {
 
 type multiListModel struct {
 	title     string
+	context   string // optional context line(s) under the title
 	all       []Candidate
 	cursor    int
 	filter    string
@@ -258,6 +259,10 @@ func (m multiListModel) view(maxHeight int) string {
 	header := fmt.Sprintf("%s  (%d selected)", m.title, count)
 	b.WriteString(titleTxtStyle.Render(header))
 	b.WriteString("\n")
+	if m.context != "" {
+		b.WriteString(helpTextStyle.Render(m.context))
+		b.WriteString("\n")
+	}
 	if m.filtering || m.filter != "" {
 		b.WriteString(filterStyle.Render("filter: " + m.filter + "█"))
 		b.WriteString("\n")


### PR DESCRIPTION
Three polish items for the new Bubble Tea wizard TUI (`internal/cli/wiztui/`, merged via #5341). Refs #5340. Go-only.

### A. Per-screen explanatory context
Each screen now carries a concise (1-2 muted lines) subtitle so the user understands what they're configuring:
- **Action**: one line on what indexing a single repo / group / monorepo / add-to-group means.
- **Select**: "Choose which repositories to include in this group." (a new optional `context` line was added to the multi-select widget) — plus the existing detected context.
- **Name**: "The group's registry key and config filename. Repos in this group: <actual repo basenames>."
- **Docs (optional)**: "A folder of shared markdown docs surfaced in the graph. Optional — press enter to skip."

### B. Accent color: pink/magenta → light blue
The single source-of-truth accent (`colAccent` in `wiztui/chrome.go`) — header badge, step-rail pills, cursor `›`, selected/active highlights — moved from pink/magenta `212` to a tasteful **light blue** via `lipgloss.AdaptiveColor{Light: "75", Dark: "117"}`. Dark ink on the light-blue title badge reads crisper than white. Green stays reserved for done/✓; phase colors unchanged.

### C. Stop install/index output from breaking the layout
Previously `applyGroupConfig`'s raw stdout ("saved …", "installed N hooks/watchers/MCP", watcher warnings) printed straight to stdout while bubbletea's alt-screen owned the terminal, scattering misaligned text on completion. Now:
- `makeIndexFunc` runs `applyGroupConfig` against a captured `bytes.Buffer` sink instead of `os.Stdout`.
- The structured `install.Result` is mapped to a new `wiztui.InstallSummary` carried on `IndexOutcome` and surfaced INTO the model.
- The **Done** screen renders a clean summary: index result line (entities · relationships · elapsed, or a "Registered (not indexed — daemon not running)" soft note), "installed N hooks · N watchers · N MCP", and any **watcher warning** as a styled non-fatal note (`⚠ …`).
- The terminal summary now renders even with zero rows (`--no-index` / daemon-down).
- The **non-TTY/plain path is untouched** and still prints the normal messages — only the TUI path captures them.

### Tests
- `TestDoneScreen_RendersCapturedSummary` drives the model to completion with an outcome carrying a captured install summary + watcher warning and asserts the Done screen renders all of it inline.
- `TestDoneScreen_DaemonDownNote` asserts the daemon-down note + install counts render with no rows.
- `TestAccentIsLightBlue` asserts the theme accent is the new blue (`117`/`75`) with no lingering magenta.

`go build ./...`, `go vet ./internal/cli/...`, `gofmt -l` (empty), and `go test ./internal/cli/...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)