### PR TITLE
fix(wizard): reliable per-repo rows in TUI indexing view (subscribe before rebuild; group phase in overall)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **`grafel wizard` indexing view reliably shows one row per repo (#5340):** the
+  TUI indexing screen could collapse to a single row labeled with the GROUP name
+  (e.g. "ivivo") reaching Done instead of one row per repo (backend, frontend).
+  Two causes are fixed: (1) the wizard now establishes the broker SSE
+  subscription **before** triggering the Rebuild RPC, so the early per-repo
+  extraction events aren't missed when the index runs fast (previously the
+  rebuild fired first and the per-repo events had already replayed by the time we
+  subscribed); and (2) the group-scoped event (the cross-repo links/flows pass,
+  whose `repo_slug` equals the group) is no longer folded into a spurious
+  per-repo row — its phase surfaces in the overall "Indexing &lt;group&gt; — …"
+  label instead ([#5340](https://github.com/cajasmota/grafel/issues/5340)).
 - **Watcher install is robust to the flaky launchctl err-5 and never aborts the
   wizard (#5338):** `launchctl bootstrap` intermittently fails the first
   bootstrap of a freshly written plist with exit code 5 ("Bootstrap failed: 5:

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -267,8 +267,37 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 		dashPort = st.DashboardPort
 	}
 
-	rpcCh := make(chan rebuildOutcome, 1)
 	token := progressToken()
+
+	// Establish the broker SSE subscription BEFORE triggering the Rebuild so no
+	// early per-repo extraction events are lost when the index runs fast (#5340).
+	// subscribeSSE connects synchronously (it returns only once the HTTP stream
+	// is open), so by the time we fire the Rebuild RPC the broker is listening
+	// and per-repo events (backend/frontend) are guaranteed to be delivered.
+	if dashPort > 0 {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+			rpcCh := triggerRebuild(c, group, token)
+			o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
+			cancel()
+			outCh <- toIndexOutcome(o, summary)
+			return
+		}
+	}
+
+	// No dashboard broker — just trigger the rebuild and wait for the outcome.
+	rpcCh := triggerRebuild(c, group, token)
+	o := <-rpcCh
+	outCh <- toIndexOutcome(o, summary)
+}
+
+// triggerRebuild fires the daemon Rebuild RPC for group on a goroutine and
+// returns a buffered channel that delivers the single rebuild outcome. It is
+// invoked AFTER the broker SSE subscription is established so the per-repo
+// extraction events that race the RPC are not dropped (#5340).
+func triggerRebuild(c *client.Client, group string, token string) <-chan rebuildOutcome {
+	rpcCh := make(chan rebuildOutcome, 1)
 	go func() {
 		reply, rpcErr := c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token})
 		rpcCh <- rebuildOutcome{
@@ -280,22 +309,7 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 			err:      rpcErr,
 		}
 	}()
-
-	// Stream broker SSE events to evCh while waiting for the RPC outcome.
-	if dashPort > 0 {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
-			o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
-			cancel()
-			outCh <- toIndexOutcome(o, summary)
-			return
-		}
-	}
-
-	// No dashboard broker — just wait for the RPC outcome.
-	o := <-rpcCh
-	outCh <- toIndexOutcome(o, summary)
+	return rpcCh
 }
 
 // forwardBrokerToChannel reads broker SSE events and forwards parsed

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -40,7 +40,9 @@ type indexView struct {
 
 func newIndexView(group string, expectedRepos int) indexView {
 	b := progress.New(
-		progress.WithDefaultGradient(),
+		// Blue → teal/green gradient (matches the light-blue accent), replacing
+		// the charm default pink→purple.
+		progress.WithScaledGradient("#5FB0FF", "#2FD6A6"),
 		progress.WithoutPercentage(),
 	)
 	s := spinner.New()

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -18,12 +18,17 @@ type indexView struct {
 	group         string
 	expectedRepos int
 	rows          map[string]Row
-	bar           progress.Model
-	spin          spinner.Model
-	terminal      bool   // RPC reported done
-	failed        bool   // RPC reported an error
-	errMsg        string // terminal error text
-	width         int
+	// groupPhase holds the phase of the group-scoped event (RepoSlug == group),
+	// e.g. the cross-repo links / flows pass added by the granular-phases work.
+	// It is NOT a repo and must never render as a per-repo row (#5340); it only
+	// surfaces in the overall label/bar.
+	groupPhase string
+	bar        progress.Model
+	spin       spinner.Model
+	terminal   bool   // RPC reported done
+	failed     bool   // RPC reported an error
+	errMsg     string // terminal error text
+	width      int
 
 	// final summary, populated when the RPC outcome lands.
 	summaryEntities int64
@@ -50,13 +55,66 @@ func newIndexView(group string, expectedRepos int) indexView {
 	}
 }
 
-// foldEvent folds a single broker event into the per-repo rows.
+// foldEvent folds a single broker event into the per-repo rows. A group-scoped
+// event (RepoSlug == group, the cross-repo links/flows pass) is NOT a repo: it
+// updates the overall group phase instead of spawning a spurious group row
+// (#5340). Per-repo events (backend, frontend, …) always fold into rows.
 func (v *indexView) foldEvent(e prog.Event) {
+	if v.group != "" && e.RepoSlug == v.group {
+		// Monotonic: never regress the group phase to a coarser one.
+		if phaseRank(e.Phase) >= phaseRank(v.groupPhase) {
+			v.groupPhase = e.Phase
+		}
+		return
+	}
 	v.rows = Fold(v.rows, e)
 }
 
 // done reports whether the indexing screen has fully completed.
 func (v indexView) done() bool { return v.terminal || v.failed }
+
+// overallLabel derives the header phase for the whole index. While per-repo
+// rows are still in flight it reflects the least-advanced repo. Once every repo
+// is terminal but the group-scoped pass (cross-repo links / flows) is still
+// running, it surfaces THAT group phase instead — so the group-level work shows
+// in the overall label rather than as a spurious per-repo row (#5340).
+func (v indexView) overallLabel() string {
+	if v.terminal {
+		return "Done"
+	}
+	repoLabel := OverallPhaseLabel(v.rows, false)
+	// If the group-scoped phase is in flight and more advanced than (or follows)
+	// the per-repo work, prefer it. "Done" from OverallPhaseLabel means all rows
+	// are terminal, so any non-terminal group phase takes over the label.
+	if v.groupPhase != "" {
+		gp := v.groupPhase
+		if gp != prog.PhaseDone && gp != prog.PhaseError {
+			if repoLabel == "Done" || phaseRank(gp) >= phaseRank(leastActivePhase(v.rows)) {
+				return PhaseLabel(gp)
+			}
+		}
+	}
+	return repoLabel
+}
+
+// leastActivePhase returns the phase of the least-advanced non-terminal repo,
+// or PhaseDone when every repo is terminal (used to decide whether the
+// group-scoped phase should take over the overall label).
+func leastActivePhase(rows map[string]Row) string {
+	least := ""
+	for _, r := range rows {
+		if r.Terminal() {
+			continue
+		}
+		if least == "" || phaseRank(r.Phase) < phaseRank(least) {
+			least = r.Phase
+		}
+	}
+	if least == "" {
+		return prog.PhaseDone
+	}
+	return least
+}
 
 var (
 	rowSlugStyle    = lipgloss.NewStyle().Foreground(colText).Bold(true)
@@ -119,7 +177,7 @@ func (v indexView) view() string {
 	if v.terminal {
 		pct = 1
 	}
-	label := OverallPhaseLabel(v.rows, v.terminal)
+	label := v.overallLabel()
 	if v.failed {
 		label = "Failed"
 	}

--- a/internal/cli/wiztui/view_test.go
+++ b/internal/cli/wiztui/view_test.go
@@ -55,6 +55,94 @@ func TestIndexView_RendersOneRowPerRepo(t *testing.T) {
 	}
 }
 
+// TestIndexView_GroupScopedEventNotARow is the core #5340 regression: the
+// cross-repo pass emits an event with RepoSlug == group ("ivivo"). That event
+// must NOT become a per-repo row; it only updates the overall group phase. The
+// per-repo rows (backend, frontend) must always render, and the group must NOT.
+func TestIndexView_GroupScopedEventNotARow(t *testing.T) {
+	v := newIndexView("ivivo", 2)
+	v.width = 100
+	// Realistic order: per-repo extraction, per-repo done, then the group-scoped
+	// cross-repo links pass, then the group terminal.
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseExtractAST, TS: 1})
+	v.foldEvent(progress.Event{RepoSlug: "frontend", Phase: progress.PhaseExtractAST, TS: 2})
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseDone, TS: 3})
+	v.foldEvent(progress.Event{RepoSlug: "frontend", Phase: progress.PhaseDone, TS: 4})
+	v.foldEvent(progress.Event{RepoSlug: "ivivo", Phase: progress.PhaseDetectLinks, TS: 5})
+
+	if len(v.rows) != 2 {
+		t.Fatalf("got %d rows, want exactly 2 (backend, frontend) — group row leaked: %v",
+			len(v.rows), keysOf(v.rows))
+	}
+	if _, ok := v.rows["ivivo"]; ok {
+		t.Error("group-scoped event 'ivivo' rendered as a per-repo row (the #5340 bug)")
+	}
+	for _, slug := range []string{"backend", "frontend"} {
+		r, ok := v.rows[slug]
+		if !ok {
+			t.Errorf("per-repo row %q missing", slug)
+			continue
+		}
+		if !r.Terminal() {
+			t.Errorf("repo %q should be terminal, got %q", slug, r.Phase)
+		}
+	}
+	// The overall label surfaces the group-scoped phase, not a spurious row.
+	if v.groupPhase != progress.PhaseDetectLinks {
+		t.Errorf("groupPhase = %q, want %q", v.groupPhase, progress.PhaseDetectLinks)
+	}
+	if got := v.overallLabel(); got != PhaseLabel(progress.PhaseDetectLinks) {
+		t.Errorf("overall label = %q, want %q (group phase surfaces in label)",
+			got, PhaseLabel(progress.PhaseDetectLinks))
+	}
+	out := v.view()
+	if !strings.Contains(out, "backend") || !strings.Contains(out, "frontend") {
+		t.Errorf("per-repo rows missing from view:\n%s", out)
+	}
+	if !strings.Contains(out, PhaseLabel(progress.PhaseDetectLinks)) {
+		t.Errorf("group phase missing from overall label:\n%s", out)
+	}
+}
+
+// TestIndexView_GroupEventFoldedRegardlessOfOrder asserts the group-scoped event
+// is excluded from rows no matter when it arrives — interleaved with per-repo
+// events or first.
+func TestIndexView_GroupEventFoldedRegardlessOfOrder(t *testing.T) {
+	orders := [][]progress.Event{
+		{ // group event arrives first
+			{RepoSlug: "ivivo", Phase: progress.PhaseScan, TS: 1},
+			{RepoSlug: "backend", Phase: progress.PhaseExtractAST, TS: 2},
+			{RepoSlug: "frontend", Phase: progress.PhaseExtractAST, TS: 3},
+			{RepoSlug: "ivivo", Phase: progress.PhaseDetectLinks, TS: 4},
+		},
+		{ // group event interleaved between per-repo events
+			{RepoSlug: "backend", Phase: progress.PhaseScan, TS: 1},
+			{RepoSlug: "ivivo", Phase: progress.PhaseDetectLinks, TS: 2},
+			{RepoSlug: "frontend", Phase: progress.PhaseScan, TS: 3},
+		},
+	}
+	for i, evs := range orders {
+		v := newIndexView("ivivo", 2)
+		for _, e := range evs {
+			v.foldEvent(e)
+		}
+		if _, ok := v.rows["ivivo"]; ok {
+			t.Errorf("order %d: group 'ivivo' leaked into rows", i)
+		}
+		if len(v.rows) != 2 {
+			t.Errorf("order %d: got %d rows, want 2: %v", i, len(v.rows), keysOf(v.rows))
+		}
+	}
+}
+
+func keysOf(rows map[string]Row) []string {
+	out := make([]string, 0, len(rows))
+	for k := range rows {
+		out = append(out, k)
+	}
+	return out
+}
+
 // TestDoneScreen_RendersCapturedSummary drives the model to completion with an
 // outcome carrying a captured install summary + watcher warning and asserts the
 // Done screen renders all of it inline (fix C, #5340) rather than leaking it to


### PR DESCRIPTION
Refs #5340.

## Symptom
The wizard indexing view (TUI) showed a SINGLE row labeled with the GROUP name (e.g. "another group") reaching "Done", instead of one row per repo (backend + frontend).

## Root cause
The daemon emits broker `progress.Event`s per-repo (`RepoSlug=backend`/`frontend`) during extraction/algorithms, PLUS a GROUP-scoped event (`RepoSlug == group`) for the cross-repo links/flows pass (granular-phases work). Two problems:

1. `streamIndexWithSummary` triggered the **Rebuild RPC first**, then subscribed to the broker SSE. When the index ran fast, the per-repo extraction events had already fired/replayed and the late subscription only carried the terminal/group event → the CLI missed backend/frontend and showed only the group row. (It "worked" before only by timing luck.)
2. The CLI fold keys rows by `e.RepoSlug`, so the group-scoped event became its own "another group" row.

## Fixes
1. **Subscribe before rebuild.** `streamIndexWithSummary` now calls `subscribeSSE` (which connects synchronously) FIRST, and only then fires the Rebuild RPC — extracted into a `triggerRebuild` helper. No early per-repo events are dropped. The RPC-outcome / drain-final-events logic and the InstallSummary threading from #5342 are intact.
2. **Group-scoped event is not a repo row.** `indexView.foldEvent` routes an event whose `RepoSlug == group` to a new `groupPhase` field (monotonic) and excludes it from `rows`. `overallLabel()` surfaces that phase in the "Indexing &lt;group&gt; — Detecting cross-repo links…" header; per-repo rows (backend, frontend) always render.

After the fix a 2-repo group shows exactly 2 rows, each progressing to Done, with the overall bar/label reflecting aggregate + the current group-level phase.

## Tests
- `TestIndexView_GroupScopedEventNotARow`: realistic stream {backend/frontend extracting → done, group detect_links} → exactly backend+frontend rows, no group row, both terminal, overall label = group phase.
- `TestIndexView_GroupEventFoldedRegardlessOfOrder`: group event arriving first / interleaved is always excluded from rows.

## Validation
`go build ./...`, `go vet ./internal/cli/...`, `gofmt -l` clean, `go test ./internal/cli/...` green. Row behavior is tested via injected events (no live daemon in sandbox); coordinator to live-validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)