### PR TITLE
fix(wizard): Windows console UTF-8 + ASCII glyph fallback for legacy CMD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **`grafel wizard` TUI renders correctly on legacy Windows CMD/conhost
+  (#5340, #856):** the wizard's Bubble Tea TUI used Unicode glyphs (`›`, `✓`,
+  `↑/↓`, `·`, `…`, `⚠`, `[✓]`, the braille spinner) with no console code-page
+  setup, so outside Windows Terminal it could render as mojibake. The TUI now
+  (1) switches the Windows console to the UTF-8 code page (65001) at startup and
+  restores the previous code page on exit, so a modern CMD/conhost with a
+  TrueType font shows the Unicode glyphs; and (2) falls back to an ASCII-safe
+  glyph set (`>`, `v`, `^/v`, `-`, `...`, `!`, `[x]`, `|/-\` spinner) on legacy
+  consoles. The glyph set is chosen by a single, unit-tested selector: ASCII on
+  Windows unless `WT_SESSION` (Windows Terminal) or `GRAFEL_TUI_UNICODE=1` is
+  set; `GRAFEL_ASCII=1` forces ASCII on any OS; non-Windows defaults to Unicode
+  ([#5340](https://github.com/cajasmota/grafel/issues/5340),
+  [#856](https://github.com/cajasmota/grafel/issues/856)).
 - **`grafel wizard` indexing view reliably shows one row per repo (#5340):** the
   TUI indexing screen could collapse to a single row labeled with the GROUP name
   (e.g. "ivivo") reaching Done instead of one row per repo (backend, frontend).

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -164,6 +164,11 @@ func runInteractiveTUI(out, errOut io.Writer, opts wizardOptions) (wiztui.Result
 	idxFn := makeIndexFunc(out, errOut, class, opts)
 	m := wiztui.New(drv, idxFn, opts.Watchers, opts.GitHooks)
 
+	// Switch the console to UTF-8 (Windows) before the alt-screen starts so the
+	// wizard's glyphs render instead of mojibake; restore on exit (#5340).
+	restoreConsole := wiztui.SetupConsole()
+	defer restoreConsole()
+
 	prog := tea.NewProgram(m, tea.WithAltScreen(), tea.WithOutput(out))
 	final, err := prog.Run()
 	if err != nil {

--- a/internal/cli/wiztui/chrome.go
+++ b/internal/cli/wiztui/chrome.go
@@ -98,13 +98,13 @@ func header(current Step, width int) string {
 		case s.step == current:
 			seg = railActiveStyle.Render(s.label)
 		case s.step < current:
-			seg = railDoneStyle.Render("✓ " + s.label)
+			seg = railDoneStyle.Render(g.Check + " " + s.label)
 		default:
 			seg = railPendingStyle.Render(s.label)
 		}
 		rail = append(rail, seg)
 		if i < len(stepRail)-1 {
-			rail = append(rail, railSepStyle.Render("›"))
+			rail = append(rail, railSepStyle.Render(g.RailSep))
 		}
 	}
 	railLine := lipgloss.JoinHorizontal(lipgloss.Center, rail...)
@@ -148,15 +148,30 @@ func frame(current Step, body, hint string, width, height int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, head, renderedBody, foot)
 }
 
-// Common footer hints per screen.
-const (
-	hintList     = "↑/↓ move · enter confirm · / filter · esc back · ctrl-c quit"
-	hintMulti    = "↑/↓ move · space select · a all · n none · enter confirm · / filter · esc back · ctrl-c quit"
-	hintInput    = "type to edit · enter confirm · esc back · ctrl-c quit"
-	hintInputOpt = "optional · enter to skip · esc back · ctrl-c quit"
-	hintIndex    = "indexing… · ctrl-c quit"
-	hintDone     = "enter / q to finish"
-)
+// Common footer hints per screen. These are functions (not consts) because they
+// interpolate the active glyph set (arrows, middot separators, ellipsis), which
+// is chosen at runtime for ASCII-vs-Unicode terminals (#5340).
+func hintList() string {
+	return g.ArrowUp + "/" + g.ArrowDown + " move " + g.MidDot + " enter confirm " + g.MidDot + " / filter " + g.MidDot + " esc back " + g.MidDot + " ctrl-c quit"
+}
+
+func hintMulti() string {
+	return g.ArrowUp + "/" + g.ArrowDown + " move " + g.MidDot + " space select " + g.MidDot + " a all " + g.MidDot + " n none " + g.MidDot + " enter confirm " + g.MidDot + " / filter " + g.MidDot + " esc back " + g.MidDot + " ctrl-c quit"
+}
+
+func hintInput() string {
+	return "type to edit " + g.MidDot + " enter confirm " + g.MidDot + " esc back " + g.MidDot + " ctrl-c quit"
+}
+
+func hintInputOpt() string {
+	return "optional " + g.MidDot + " enter to skip " + g.MidDot + " esc back " + g.MidDot + " ctrl-c quit"
+}
+
+func hintIndex() string {
+	return "indexing" + g.Ellipsis + " " + g.MidDot + " ctrl-c quit"
+}
+
+func hintDone() string { return "enter / q to finish" }
 
 // truncate shortens s to max display columns, appending an ellipsis.
 func truncate(s string, max int) string {
@@ -171,5 +186,5 @@ func truncate(s string, max int) string {
 	if len(runes) > max-1 {
 		runes = runes[:max-1]
 	}
-	return strings.TrimRight(string(runes), " ") + "…"
+	return strings.TrimRight(string(runes), " ") + g.Ellipsis
 }

--- a/internal/cli/wiztui/console_other.go
+++ b/internal/cli/wiztui/console_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package wiztui
+
+// enableUTF8Console is a no-op on non-Windows platforms, which are already
+// UTF-8 by default. It returns a no-op restore func so callers can defer it
+// unconditionally (#5340).
+func enableUTF8Console() func() { return func() {} }

--- a/internal/cli/wiztui/console_windows.go
+++ b/internal/cli/wiztui/console_windows.go
@@ -1,0 +1,43 @@
+//go:build windows
+
+package wiztui
+
+// console_windows.go switches the Windows console to the UTF-8 code page
+// (65001) for the duration of the TUI so that — on a modern CMD/conhost with a
+// TrueType font, or in Windows Terminal — the Unicode glyphs render instead of
+// showing as mojibake. The previous input/output code pages are restored when
+// the returned function runs (deferred by the caller), so we don't leave the
+// user's console in an unexpected state after the wizard exits (#5340).
+
+import "golang.org/x/sys/windows"
+
+// enableUTF8Console sets the console output AND input code pages to UTF-8 and
+// returns a restore func that puts the previous code pages back. Any failure is
+// non-fatal: we simply skip that half and the restore func becomes a no-op for
+// it (the ASCII glyph fallback still keeps legacy consoles readable).
+func enableUTF8Console() func() {
+	const cpUTF8 = 65001
+
+	prevOut, outErr := windows.GetConsoleOutputCP()
+	if outErr == nil {
+		if err := windows.SetConsoleOutputCP(cpUTF8); err != nil {
+			outErr = err
+		}
+	}
+
+	prevIn, inErr := windows.GetConsoleCP()
+	if inErr == nil {
+		if err := windows.SetConsoleCP(cpUTF8); err != nil {
+			inErr = err
+		}
+	}
+
+	return func() {
+		if outErr == nil {
+			_ = windows.SetConsoleOutputCP(prevOut)
+		}
+		if inErr == nil {
+			_ = windows.SetConsoleCP(prevIn)
+		}
+	}
+}

--- a/internal/cli/wiztui/glyphs.go
+++ b/internal/cli/wiztui/glyphs.go
@@ -1,0 +1,124 @@
+package wiztui
+
+// glyphs.go centralizes every non-ASCII display glyph the wizard TUI renders so
+// the whole package can switch between a Unicode set (rendered on capable
+// terminals) and an ASCII-safe fallback set (legacy Windows CMD / conhost,
+// which would otherwise show mojibake) from a single decision point (#5340).
+//
+// The active set is chosen ONCE at process start by pickGlyphs (see below) and
+// exposed as the package-level `g`. Tests override `g` directly.
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/charmbracelet/bubbles/spinner"
+)
+
+// glyphSet is the full set of display glyphs used across the wizard TUI. Every
+// renderer references this set instead of hardcoding a rune, so flipping
+// ascii-vs-unicode is a single swap.
+type glyphSet struct {
+	ascii bool // true for the ASCII fallback set
+
+	Cursor    string // selection cursor / input prompt ("› " vs "> ")
+	RailSep   string // step-rail separator ("›" vs ">")
+	Check     string // done/selected mark ("✓" vs "v")
+	Cross     string // error mark ("✗" vs "x")
+	ArrowUp   string // hint up arrow ("↑" vs "^")
+	ArrowDown string // hint down arrow ("↓" vs "v")
+	MidDot    string // separator between hint/summary segments ("·" vs "-")
+	Ellipsis  string // trailing ellipsis ("…" vs "...")
+	Warn      string // watcher-warning mark ("⚠" vs "!")
+	BoxOn     string // checked multiselect box ("[✓] " vs "[x] ")
+	BoxOff    string // unchecked multiselect box ("[ ] ")
+	Caret     string // text-input caret block ("█" vs "_")
+}
+
+// unicodeGlyphs is the rich set used on capable terminals.
+var unicodeGlyphs = glyphSet{
+	ascii:     false,
+	Cursor:    "› ",
+	RailSep:   "›",
+	Check:     "✓",
+	Cross:     "✗",
+	ArrowUp:   "↑",
+	ArrowDown: "↓",
+	MidDot:    "·",
+	Ellipsis:  "…",
+	Warn:      "⚠",
+	BoxOn:     "[✓] ",
+	BoxOff:    "[ ] ",
+	Caret:     "█",
+}
+
+// asciiGlyphs is the legacy-CMD-safe fallback. Every glyph is a plain ASCII
+// byte (or short ASCII run) that renders identically on conhost with any font.
+var asciiGlyphs = glyphSet{
+	ascii:     true,
+	Cursor:    "> ",
+	RailSep:   ">",
+	Check:     "v",
+	Cross:     "x",
+	ArrowUp:   "^",
+	ArrowDown: "v",
+	MidDot:    "-",
+	Ellipsis:  "...",
+	Warn:      "!",
+	BoxOn:     "[x] ",
+	BoxOff:    "[ ] ",
+	Caret:     "_",
+}
+
+// Spinner returns the bubbles spinner appropriate for the set: the ASCII
+// line spinner (|/-\) in fallback mode, else the braille Dot spinner.
+func (s glyphSet) Spinner() spinner.Spinner {
+	if s.ascii {
+		return spinner.Line
+	}
+	return spinner.Dot
+}
+
+// g is the active glyph set, selected once at package init from the environment
+// and OS. Tests may reassign it (restore with the value they captured).
+var g = pickGlyphs(runtime.GOOS, envLookup(os.LookupEnv))
+
+// envLookup adapts os.LookupEnv (or a test fake) into the predicate pickGlyphs
+// needs: whether a variable is set to a non-empty value.
+type envLookup func(string) (string, bool)
+
+func (e envLookup) has(key string) bool {
+	v, ok := e(key)
+	return ok && v != ""
+}
+
+// SetupConsole prepares the host console for the wizard TUI and returns a
+// restore func the caller must defer. On Windows it switches the console to the
+// UTF-8 code page (so Unicode glyphs render on a modern CMD/conhost) and
+// restores the previous code page on return; on every other OS it is a no-op.
+// It MUST be called before the alt-screen starts and its result deferred so the
+// console is restored on exit (#5340).
+func SetupConsole() func() { return enableUTF8Console() }
+
+// pickGlyphs is the single, unit-testable decision for ascii-vs-unicode glyphs:
+//
+//   - GRAFEL_ASCII=1 (or any non-empty value) forces ASCII on ANY OS.
+//   - GRAFEL_TUI_UNICODE forces Unicode (overriding the Windows-legacy default).
+//   - On Windows, default to ASCII UNLESS a known-Unicode terminal is present
+//     (WT_SESSION ⇒ Windows Terminal). Legacy CMD/conhost ⇒ ASCII.
+//   - On every other OS, default to Unicode.
+func pickGlyphs(goos string, env envLookup) glyphSet {
+	if env.has("GRAFEL_ASCII") {
+		return asciiGlyphs
+	}
+	if env.has("GRAFEL_TUI_UNICODE") {
+		return unicodeGlyphs
+	}
+	if goos == "windows" {
+		if env.has("WT_SESSION") {
+			return unicodeGlyphs
+		}
+		return asciiGlyphs
+	}
+	return unicodeGlyphs
+}

--- a/internal/cli/wiztui/glyphs_test.go
+++ b/internal/cli/wiztui/glyphs_test.go
@@ -1,0 +1,154 @@
+package wiztui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+)
+
+// fakeEnv builds an envLookup from a map for deterministic selector tests.
+func fakeEnv(m map[string]string) envLookup {
+	return func(k string) (string, bool) {
+		v, ok := m[k]
+		return v, ok
+	}
+}
+
+// TestPickGlyphs covers the ascii-vs-unicode decision matrix (#5340): legacy
+// Windows defaults to ASCII, Windows Terminal stays Unicode, GRAFEL_ASCII forces
+// ASCII anywhere, GRAFEL_TUI_UNICODE forces Unicode, non-Windows defaults Unicode.
+func TestPickGlyphs(t *testing.T) {
+	cases := []struct {
+		name      string
+		goos      string
+		env       map[string]string
+		wantASCII bool
+	}{
+		{"windows legacy CMD -> ASCII", "windows", nil, true},
+		{"windows terminal -> Unicode", "windows", map[string]string{"WT_SESSION": "abc"}, false},
+		{"windows + GRAFEL_TUI_UNICODE -> Unicode", "windows", map[string]string{"GRAFEL_TUI_UNICODE": "1"}, false},
+		{"windows + GRAFEL_ASCII -> ASCII", "windows", map[string]string{"GRAFEL_ASCII": "1", "WT_SESSION": "x"}, true},
+		{"linux default -> Unicode", "linux", nil, false},
+		{"darwin default -> Unicode", "darwin", nil, false},
+		{"linux + GRAFEL_ASCII -> ASCII", "linux", map[string]string{"GRAFEL_ASCII": "1"}, true},
+		{"empty WT_SESSION on windows -> ASCII", "windows", map[string]string{"WT_SESSION": ""}, true},
+		{"empty GRAFEL_ASCII ignored on linux -> Unicode", "linux", map[string]string{"GRAFEL_ASCII": ""}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pickGlyphs(tc.goos, fakeEnv(tc.env))
+			if got.ascii != tc.wantASCII {
+				t.Errorf("pickGlyphs(%s, %v).ascii = %v, want %v", tc.goos, tc.env, got.ascii, tc.wantASCII)
+			}
+		})
+	}
+}
+
+// TestGlyphSetsAreAllASCII asserts every glyph in the fallback set is pure ASCII
+// (so it can never mojibake on legacy conhost).
+func TestAsciiGlyphsArePureASCII(t *testing.T) {
+	vals := []string{
+		asciiGlyphs.Cursor, asciiGlyphs.RailSep, asciiGlyphs.Check, asciiGlyphs.Cross,
+		asciiGlyphs.ArrowUp, asciiGlyphs.ArrowDown, asciiGlyphs.MidDot, asciiGlyphs.Ellipsis,
+		asciiGlyphs.Warn, asciiGlyphs.BoxOn, asciiGlyphs.BoxOff, asciiGlyphs.Caret,
+	}
+	for _, v := range vals {
+		for _, r := range v {
+			if r > 127 {
+				t.Errorf("ascii glyph %q contains non-ASCII rune %q", v, r)
+			}
+		}
+	}
+}
+
+// TestSpinnerSelection asserts the ASCII set uses the Line spinner and the
+// Unicode set the braille Dot spinner.
+func TestSpinnerSelection(t *testing.T) {
+	if got := asciiGlyphs.Spinner(); got.Frames[0] != spinner.Line.Frames[0] {
+		t.Errorf("ascii spinner = %v, want Line", got.Frames)
+	}
+	if got := unicodeGlyphs.Spinner(); got.Frames[0] != spinner.Dot.Frames[0] {
+		t.Errorf("unicode spinner = %v, want Dot", got.Frames)
+	}
+}
+
+// withGlyphs runs fn with the active glyph set swapped to gs, restoring after.
+func withGlyphs(gs glyphSet, fn func()) {
+	prev := g
+	g = gs
+	defer func() { g = prev }()
+	fn()
+}
+
+// TestViewsRenderWithActiveSet asserts that when the ASCII set is active, the
+// rendered views contain NO raw Unicode glyphs (the mojibake risk) and DO
+// contain their ASCII equivalents (#5340).
+func TestViewsRenderWithActiveSet(t *testing.T) {
+	unicodeRunes := []string{"›", "✓", "✗", "↑", "↓", "·", "…", "⚠", "█"}
+
+	withGlyphs(asciiGlyphs, func() {
+		// Header step rail (rail separator + done check).
+		h := header(StepSelect, 80)
+		assertNoUnicode(t, "header", h, unicodeRunes)
+
+		// List view (cursor) + multiselect view (checkboxes + cursor).
+		lm := newListModel("pick", []Candidate{{Label: "a"}, {Label: "b"}})
+		assertNoUnicode(t, "listModel.view", lm.view(10), unicodeRunes)
+
+		mm := newMultiListModel("pick", []Candidate{{Label: "a", Selected: true}, {Label: "b"}})
+		mv := mm.view(10)
+		assertNoUnicode(t, "multiListModel.view", mv, unicodeRunes)
+		if !strings.Contains(mv, "[x] ") {
+			t.Errorf("ascii multiselect missing [x] checkbox:\n%s", mv)
+		}
+
+		// Hint strings.
+		for _, hint := range []string{hintList(), hintMulti(), hintInput(), hintInputOpt(), hintIndex(), hintDone()} {
+			assertNoUnicode(t, "hint", hint, unicodeRunes)
+		}
+
+		// Index view done summary (check + middot + warning).
+		iv := newIndexView("grp", 1)
+		iv.terminal = true
+		iv.summaryEntities = 5
+		iv.install = InstallSummary{Applied: true, Hooks: 1, WatcherWarnings: []string{"watcher not active"}}
+		// Exclude █: the bubbles/progress bar uses block chars by design (they
+		// render fine on Windows) and are intentionally left as-is (#5340).
+		assertNoUnicode(t, "indexView.view", iv.view(), unicodeRunesNoBlock(unicodeRunes))
+	})
+
+	// Unicode set must include the rich glyphs.
+	withGlyphs(unicodeGlyphs, func() {
+		h := header(StepSelect, 80)
+		if !strings.Contains(h, "✓") {
+			t.Errorf("unicode header missing ✓:\n%s", h)
+		}
+		lm := newListModel("pick", []Candidate{{Label: "a"}})
+		if !strings.Contains(lm.view(10), "›") {
+			t.Errorf("unicode list missing › cursor")
+		}
+	})
+}
+
+// unicodeRunesNoBlock returns the rune list without the █ block char (the
+// progress bar legitimately uses it).
+func unicodeRunesNoBlock(runes []string) []string {
+	out := make([]string, 0, len(runes))
+	for _, r := range runes {
+		if r == "█" {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func assertNoUnicode(t *testing.T, where, s string, runes []string) {
+	t.Helper()
+	for _, r := range runes {
+		if strings.Contains(s, r) {
+			t.Errorf("%s rendered raw Unicode glyph %q in ASCII mode:\n%s", where, r, s)
+		}
+	}
+}

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -46,7 +46,7 @@ func newIndexView(group string, expectedRepos int) indexView {
 		progress.WithoutPercentage(),
 	)
 	s := spinner.New()
-	s.Spinner = spinner.Dot
+	s.Spinner = g.Spinner()
 	s.Style = lipgloss.NewStyle().Foreground(colAccent)
 	return indexView{
 		group:         group,
@@ -139,14 +139,14 @@ func (v indexView) renderRow(r Row, spinnerFrame string) string {
 	var glyph, phase string
 	switch {
 	case r.Phase == prog.PhaseError:
-		glyph = rowErrStyle.Render("✗")
+		glyph = rowErrStyle.Render(g.Cross)
 		msg := r.Error
 		if msg == "" {
 			msg = "error"
 		}
 		phase = rowErrStyle.Render(truncate(msg, 40))
 	case r.Phase == prog.PhaseDone:
-		glyph = rowDoneStyle.Render("✓")
+		glyph = rowDoneStyle.Render(g.Check)
 		phase = rowDoneStyle.Render("Done")
 	default:
 		glyph = spinnerFrame
@@ -162,7 +162,7 @@ func (v indexView) renderRow(r Row, spinnerFrame string) string {
 	}
 	tail := ""
 	if len(extra) > 0 {
-		tail = "  " + rowCountStyle.Render(strings.Join(extra, " · "))
+		tail = "  " + rowCountStyle.Render(strings.Join(extra, " "+g.MidDot+" "))
 	}
 
 	return fmt.Sprintf("%s %s  %s%s", glyph, name, phase, tail)
@@ -200,7 +200,7 @@ func (v indexView) view() string {
 	b.WriteString(fmt.Sprintf("  %3d%%\n\n", int(pct*100)))
 
 	if len(rows) == 0 && !v.done() {
-		b.WriteString(rowCountStyle.Render("waiting for the indexer to report…"))
+		b.WriteString(rowCountStyle.Render("waiting for the indexer to report" + g.Ellipsis))
 		return b.String()
 	}
 
@@ -244,20 +244,20 @@ func (v indexView) doneSummary() string {
 	if v.elapsed != "" {
 		parts = append(parts, v.elapsed)
 	}
-	b.WriteString(rowDoneStyle.Render(strings.Join(parts, "  ·  ")))
+	b.WriteString(rowDoneStyle.Render(strings.Join(parts, "  "+g.MidDot+"  ")))
 
 	// Captured install summary (hooks · watchers · MCP).
 	if v.install.Applied {
 		b.WriteString("\n")
 		b.WriteString(rowCountStyle.Render(fmt.Sprintf(
-			"installed %d hooks · %d watchers · %d MCP",
+			"installed %d hooks "+g.MidDot+" %d watchers "+g.MidDot+" %d MCP",
 			v.install.Hooks, v.install.Watchers, v.install.MCP)))
 	}
 
 	// Watcher warnings as styled non-fatal notes.
 	for _, w := range v.install.WatcherWarnings {
 		b.WriteString("\n")
-		b.WriteString(rowWarnStyle.Render("⚠ " + w))
+		b.WriteString(rowWarnStyle.Render(g.Warn + " " + w))
 	}
 
 	return b.String()

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -299,7 +299,7 @@ func (m Model) enterSelect() (tea.Model, tea.Cmd) {
 
 	title, cands := m.drv.Candidates(m.res.Action)
 	// Append the rescan entry.
-	cands = append(cands, Candidate{Label: "scan a different folder…", Value: RescanSentinel})
+	cands = append(cands, Candidate{Label: "scan a different folder" + g.Ellipsis, Value: RescanSentinel})
 	m.selectList = newMultiListModel(title, cands)
 	m.selectList.context = "Choose which repositories to include in this group."
 	m.scr = scrSelect
@@ -361,7 +361,7 @@ func (m Model) updateGroupPick(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.res.AddToGroup = m.groupPick.value()
 		// Now pick repos to add.
 		title, cands := m.drv.Candidates(ActionGroup)
-		cands = append(cands, Candidate{Label: "scan a different folder…", Value: RescanSentinel})
+		cands = append(cands, Candidate{Label: "scan a different folder" + g.Ellipsis, Value: RescanSentinel})
 		m.selectList = newMultiListModel(title, cands)
 		m.selectList.context = "Choose which repositories to add to “" + m.res.AddToGroup + "”."
 		m.scr = scrSelect
@@ -460,28 +460,28 @@ func (m Model) View() string {
 	switch m.scr {
 	case scrAction:
 		body = m.actionList.view(m.bodyHeight())
-		hint = hintList
+		hint = hintList()
 	case scrSelect:
 		body = m.selectList.view(m.bodyHeight())
-		hint = hintMulti
+		hint = hintMulti()
 	case scrGroupPick:
 		body = m.groupPick.view(m.bodyHeight())
-		hint = hintList
+		hint = hintList()
 	case scrName:
 		body = m.nameInput.view()
-		hint = hintInput
+		hint = hintInput()
 	case scrDocs:
 		body = m.docsInput.view()
-		hint = hintInputOpt
+		hint = hintInputOpt()
 	case scrIndex:
 		body = m.idx.view()
-		hint = hintIndex
+		hint = hintIndex()
 	case scrDone:
 		body = m.idx.view()
-		hint = hintDone
+		hint = hintDone()
 	}
 	if m.err != "" {
-		body = errStyle.Render("⚠ "+m.err) + "\n\n" + body
+		body = errStyle.Render(g.Warn+" "+m.err) + "\n\n" + body
 	}
 	return frame(m.step, body, hint, m.width, m.height)
 }

--- a/internal/cli/wiztui/widgets.go
+++ b/internal/cli/wiztui/widgets.go
@@ -119,7 +119,7 @@ func (m listModel) view(maxHeight int) string {
 		b.WriteString("\n")
 	}
 	if m.filtering || m.filter != "" {
-		b.WriteString(filterStyle.Render("filter: " + m.filter + "█"))
+		b.WriteString(filterStyle.Render("filter: " + m.filter + g.Caret))
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
@@ -131,7 +131,7 @@ func (m listModel) view(maxHeight int) string {
 		cursor := "  "
 		line := optStyle.Render(c.Label)
 		if i == m.cursor {
-			cursor = cursorStyle.Render("› ")
+			cursor = cursorStyle.Render(g.Cursor)
 			line = selOptStyle.Render(c.Label)
 		}
 		b.WriteString(cursor + line + "\n")
@@ -264,7 +264,7 @@ func (m multiListModel) view(maxHeight int) string {
 		b.WriteString("\n")
 	}
 	if m.filtering || m.filter != "" {
-		b.WriteString(filterStyle.Render("filter: " + m.filter + "█"))
+		b.WriteString(filterStyle.Render("filter: " + m.filter + g.Caret))
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
@@ -274,15 +274,15 @@ func (m multiListModel) view(maxHeight int) string {
 	for i := start; i < end; i++ {
 		realIdx := vis[i]
 		c := m.all[realIdx]
-		box := "[ ] "
+		box := g.BoxOff
 		lineStyle := optStyle
 		if c.Selected {
-			box = "[✓] "
+			box = g.BoxOn
 			lineStyle = selOptStyle
 		}
 		cursor := "  "
 		if i == m.cursor {
-			cursor = cursorStyle.Render("› ")
+			cursor = cursorStyle.Render(g.Cursor)
 			lineStyle = lineStyle.Bold(true)
 		}
 		label := c.Label
@@ -314,7 +314,7 @@ func newInputModel(title, description, value string, optional bool) inputModel {
 	ti := textinput.New()
 	ti.SetValue(value)
 	ti.CursorEnd()
-	ti.Prompt = "› "
+	ti.Prompt = g.Cursor
 	ti.PromptStyle = cursorStyle
 	ti.Width = 50
 	return inputModel{title: title, description: description, ti: ti, optional: optional}


### PR DESCRIPTION
## Summary

The `grafel wizard` Bubble Tea TUI (`internal/cli/wiztui/`) rendered Unicode glyphs (`›`, `✓`, `↑/↓`, `·`, `…`, `⚠`, `[✓]`/`[ ]`, the braille spinner) with **no console code-page setup and no ASCII fallback**, so on legacy Windows **CMD/conhost** (i.e. anywhere that isn't Windows Terminal) it could render as mojibake. This fixes both halves. Refs #5340, #856.

## 1. Enable UTF-8 on the Windows console at startup

`internal/cli/wiztui/console_windows.go` (`//go:build windows`) calls `SetConsoleOutputCP(65001)` + `SetConsoleCP(65001)` via `golang.org/x/sys/windows`, capturing the previous code pages and restoring them on exit. `console_other.go` (`//go:build !windows`) is a no-op stub returning a no-op restore func. The exported `SetupConsole()` is called and deferred in `runInteractiveTUI` (`wizard_tui_run.go`) **before** the alt-screen program starts, so a modern CMD/conhost with a TrueType font renders the Unicode glyphs and the console is restored on exit.

## 2. ASCII-safe glyph fallback (centralized + gated)

`internal/cli/wiztui/glyphs.go` defines a single `glyphSet` with a **Unicode set** and an **ASCII set**, plus the active package-level `g`. Every hardcoded glyph across `chrome.go` / `widgets.go` / `indexview.go` / `model.go` now references `g` (step rail `›`/`✓`, list & input cursor, multiselect `[✓]`/`[ ]`, error/done/warn marks, hint arrows & middot separators, ellipses, filter caret). The braille `spinner.Dot` becomes `spinner.Line` (`|/-\`) in ASCII mode. The `bubbles/progress` bar's block chars are left as-is (they render fine on Windows).

### Gating (single, unit-tested decision — `pickGlyphs`)

| Condition | Glyph set |
|---|---|
| `GRAFEL_ASCII=1` (any OS) | **ASCII** (forced) |
| `GRAFEL_TUI_UNICODE=1` | **Unicode** (forced) |
| Windows + `WT_SESSION` (Windows Terminal) | Unicode |
| Windows, no WT (legacy CMD/conhost) | **ASCII** |
| Non-Windows (default) | Unicode |

## Dependency

No new dependency. `golang.org/x/sys` (which provides `golang.org/x/sys/windows`) is already a **direct** dependency in `go.mod`; `go.mod`/`go.sum` are unchanged.

## Tests + validation

- `go build ./...` ✅
- `CGO_ENABLED=0 GOOS=windows go build ./internal/cli/wiztui/` ✅ (the windows-tagged console file compiles). `./internal/cli/` fails cross-compile **only** on the pre-existing `smacker/go-tree-sitter` CGO transitive dep, which needs a native Windows C toolchain — unrelated to this change and built natively by the Windows CI.
- `go vet ./internal/cli/...` ✅, `gofmt -l` clean ✅, `go test ./internal/cli/...` green ✅
- New `glyphs_test.go` unit-tests the selector matrix (Windows+no-WT → ASCII; Windows+`WT_SESSION` → Unicode; `GRAFEL_ASCII` forces ASCII; non-Windows → Unicode), that the ASCII set is pure ASCII, spinner selection, and that all views render with **no raw Unicode glyphs** when ASCII is active.

⚠️ Real CMD/conhost rendering needs the **Windows reporter** to confirm visually — cross-compiled + reasoned here, not run on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)