### PR TITLE
fix(daemon): timeout canonicalizePath ReadDir so startup can't deadlock on a slow FS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **Daemon startup no longer deadlocks when `canonicalizePath`'s `os.ReadDir`
+  blocks on a slow filesystem (#5330):** at startup the daemon canonicalizes
+  each known repo path by walking its ancestors with a per-segment `os.ReadDir`,
+  previously with no timeout. If a single ancestor's FS call hung (a
+  `~/Documents` iCloud/Spotlight/TCC stall, a slow/unresponsive mount, or an
+  observed launchd-context permission stall) the entire startup blocked forever
+  and the daemon never began serving — the hang was only visible via a SIGQUIT
+  goroutine dump. Each `os.ReadDir` is now bounded by a timeout (default 3s,
+  overridable via `GRAFEL_CANONICALIZE_TIMEOUT_MS`); on timeout `canonicalizePath`
+  degrades to preserving the input casing for that and remaining segments — the
+  same fallback it already takes on a read error — and logs a WARN with the
+  offending path. A new `startup: state-migration begin` log is emitted before
+  the migration runs so a wedge here is diagnosable without a goroutine dump
+  ([#5330](https://github.com/cajasmota/grafel/issues/5330)).
+
 - **`grafel wizard` TUI renders correctly on legacy Windows CMD/conhost
   (#5340, #856):** the wizard's Bubble Tea TUI used Unicode glyphs (`›`, `✓`,
   `↑/↓`, `·`, `…`, `⚠`, `[✓]`, the braille spinner) with no console code-page

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -257,6 +257,13 @@ func Run(ctx context.Context, cfg Config) error {
 	// per-ref sub-directory layout introduced by PH1a (#2089). Called here
 	// (after EnsureLayout, before accepting RPCs) so every read path sees
 	// the new layout. Idempotent: already-migrated stores are skipped.
+	// #5330: log BEFORE the startup state migration. canonicalizePath (called
+	// transitively from MigrateToRefStore and the per-repo store-root mapping)
+	// does a per-segment os.ReadDir that, on a stuck FS, used to deadlock
+	// startup before ANY log line was emitted — the hang was only visible via a
+	// SIGQUIT goroutine dump. This line makes a wedge here diagnosable; a slow
+	// canonicalize now also logs a WARN with the offending path.
+	logger.Info("startup: state-migration begin")
 	if storeDir := StoreDir(); storeDir != "" {
 		if err := MigrateToRefStore(storeDir); err != nil {
 			// Non-fatal: log and continue; the daemon can still serve the
@@ -275,6 +282,7 @@ func Run(ctx context.Context, cfg Config) error {
 				"removed", removed, "freed_bytes", freed, "keep_n", keepN)
 		}
 	}
+	logger.Info("startup: state-migration done")
 
 	// #5264: unconditional INFO-level startup tracing between
 	// `MigrateToRefStore complete` and the dashboard goroutine launch. On the

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -48,11 +48,14 @@ package daemon
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 	"unicode/utf8"
 
 	"github.com/cajasmota/grafel/internal/gitmeta"
@@ -62,6 +65,62 @@ import (
 // every daemon startup pays the os.ReadDir cost at most once per unique
 // input path. Paths do not change casing during a daemon's lifetime.
 var canonicalCache sync.Map // map[string]string
+
+// readDirFunc is the directory-read primitive used by canonicalizePath.
+// It is a package var so tests can inject a slow/blocking implementation
+// to exercise the timeout guard without a real stuck filesystem.
+var readDirFunc = os.ReadDir
+
+// defaultCanonicalizeTimeout bounds the per-segment os.ReadDir call in
+// canonicalizePath. On case-insensitive filesystems this read is
+// effectively instant; the timeout only ever fires when an ancestor
+// directory's FS call hangs (an iCloud/Spotlight/TCC stall, a slow or
+// unresponsive mount, or a launchd-context permission stall). When it
+// fires we degrade to preserving the input casing rather than blocking
+// the daemon's startup forever (#5330).
+const defaultCanonicalizeTimeout = 3 * time.Second
+
+// canonicalizeTimeout returns the per-segment ReadDir timeout, honouring
+// the GRAFEL_CANONICALIZE_TIMEOUT_MS override. A zero, negative, or
+// unparseable value falls back to defaultCanonicalizeTimeout.
+func canonicalizeTimeout() time.Duration {
+	if v := os.Getenv("GRAFEL_CANONICALIZE_TIMEOUT_MS"); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return defaultCanonicalizeTimeout
+}
+
+// readDirBounded runs readDirFunc(dir) under a timeout. It returns the
+// entries (or read error) when the read completes in time, or a third
+// return of false when the read did not finish before the deadline.
+//
+// The read runs in its own goroutine writing to a 1-deep buffered
+// channel, so on a genuinely wedged filesystem that goroutine is simply
+// abandoned: it holds no lock, blocks nothing else, and its eventual
+// (or never) send cannot leak memory beyond the single buffered slot.
+// This is what lets daemon startup proceed instead of deadlocking on a
+// slow FS (#5330).
+func readDirBounded(dir string, timeout time.Duration) (entries []os.DirEntry, err error, ok bool) {
+	type result struct {
+		entries []os.DirEntry
+		err     error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		e, rdErr := readDirFunc(dir)
+		ch <- result{e, rdErr}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.entries, r.err, true
+	case <-timer.C:
+		return nil, nil, false
+	}
+}
 
 // canonicalizePath returns the path with the actual on-disk casing of
 // each component. On case-insensitive filesystems (APFS, NTFS) two
@@ -94,13 +153,25 @@ func canonicalizePath(absPath string) string {
 	rest = strings.TrimLeft(rest, string(filepath.Separator))
 	segments := strings.Split(rest, string(filepath.Separator))
 
+	timeout := canonicalizeTimeout()
 	canonical := vol + string(filepath.Separator)
 	for _, seg := range segments {
 		if seg == "" {
 			continue
 		}
-		// Try to find the real on-disk name for this segment.
-		entries, err := os.ReadDir(canonical)
+		// Try to find the real on-disk name for this segment, bounded by a
+		// timeout. A single ancestor whose os.ReadDir hangs (iCloud/Spotlight/
+		// TCC stall, slow mount, launchd-context permission stall) must never
+		// deadlock daemon startup (#5330) — on timeout we take the same
+		// degrade path as a read error below: preserve the input casing for
+		// this and all remaining segments.
+		entries, err, completed := readDirBounded(canonical, timeout)
+		if !completed {
+			slog.Warn("canonicalizePath: os.ReadDir timed out; preserving input casing",
+				"dir", canonical, "timeout", timeout, "path", absPath)
+			canonical = filepath.Join(canonical, seg)
+			continue
+		}
 		if err != nil {
 			// Directory doesn't exist or isn't readable; preserve input
 			// casing for this segment and all remaining segments.

--- a/internal/daemon/state_path_timeout_test.go
+++ b/internal/daemon/state_path_timeout_test.go
@@ -1,0 +1,154 @@
+package daemon
+
+// Tests for the canonicalizePath ReadDir timeout guard (#5330).
+//
+// Root cause: canonicalizePath walks each path ancestor and does a
+// blocking os.ReadDir on it with no timeout. If one ancestor's FS call
+// hangs (an iCloud/Spotlight/TCC stall, a slow/unresponsive mount, or a
+// launchd-context permission stall) the ENTIRE daemon startup deadlocks
+// forever. The fix bounds each ReadDir with a timeout and, on timeout,
+// degrades to preserving the input casing — the exact same fallback the
+// code already takes on a read error.
+//
+// These tests inject a slow/blocking readDirFunc so the timeout path is
+// exercised deterministically, with no real stuck filesystem required.
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// withReadDirFunc swaps readDirFunc for the duration of a test and
+// restores it afterwards.
+func withReadDirFunc(t *testing.T, f func(string) ([]os.DirEntry, error)) {
+	t.Helper()
+	prev := readDirFunc
+	readDirFunc = f
+	t.Cleanup(func() { readDirFunc = prev })
+}
+
+// TestCanonicalizePathTimesOutAndDegrades verifies that when os.ReadDir
+// blocks for far longer than the timeout, canonicalizePath returns
+// promptly (well under the block duration) with the casing-preserving
+// fallback rather than hanging.
+func TestCanonicalizePathTimesOutAndDegrades(t *testing.T) {
+	clearCanonicalCache()
+	// 20ms timeout; ReadDir blocks for 10s. If the guard works the call
+	// returns in ~20ms, not 10s.
+	t.Setenv("GRAFEL_CANONICALIZE_TIMEOUT_MS", "20")
+	blockStarted := make(chan struct{}, 1)
+	withReadDirFunc(t, func(string) ([]os.DirEntry, error) {
+		select {
+		case blockStarted <- struct{}{}:
+		default:
+		}
+		time.Sleep(10 * time.Second) // simulate a wedged FS
+		return nil, nil
+	})
+
+	const input = "/tmp/grafel-5330/SlowMount/Repo"
+	done := make(chan string, 1)
+	start := time.Now()
+	go func() { done <- canonicalizePath(input) }()
+
+	select {
+	case got := <-done:
+		elapsed := time.Since(start)
+		if elapsed > 2*time.Second {
+			t.Fatalf("canonicalizePath took %v; expected prompt return under the 10s block", elapsed)
+		}
+		// On timeout we preserve input casing → output equals the input.
+		if got != input {
+			t.Errorf("canonicalizePath(%q) = %q, want casing-preserving fallback %q", input, got, input)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("canonicalizePath did not return within 3s — it deadlocked on the slow ReadDir (#5330 regression)")
+	}
+	<-blockStarted // sanity: the blocking ReadDir actually ran
+}
+
+// TestCanonicalizePathFastReadDirCanonicalizes verifies the normal path:
+// a fast ReadDir that returns the real on-disk entry name canonicalizes
+// the segment's casing.
+func TestCanonicalizePathFastReadDirCanonicalizes(t *testing.T) {
+	clearCanonicalCache()
+	withReadDirFunc(t, func(dir string) ([]os.DirEntry, error) {
+		// Defer to the real ReadDir; this is fast and well under any timeout.
+		return os.ReadDir(dir)
+	})
+
+	dir := t.TempDir()
+	got := canonicalizePath(dir)
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("canonicalized path %q does not exist: %v", got, err)
+	}
+	wantInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("original path %q does not exist: %v", dir, err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Errorf("canonicalizePath(%q) = %q, not the same inode", dir, got)
+	}
+}
+
+// TestCanonicalizePathTimeoutResultIsCached verifies the cache still
+// works after a timeout: a second call returns the cached fallback
+// without invoking ReadDir again (so it can't block twice).
+func TestCanonicalizePathTimeoutResultIsCached(t *testing.T) {
+	clearCanonicalCache()
+	t.Setenv("GRAFEL_CANONICALIZE_TIMEOUT_MS", "20")
+
+	var calls int
+	gate := make(chan struct{})
+	withReadDirFunc(t, func(string) ([]os.DirEntry, error) {
+		calls++
+		<-gate // block forever (until test ends)
+		return nil, nil
+	})
+	t.Cleanup(func() { close(gate) })
+
+	const input = "/tmp/grafel-5330-cache/SlowMount/Repo"
+	first := canonicalizePath(input)
+	if _, ok := canonicalCache.Load(input); !ok {
+		t.Fatal("expected timeout result to be cached")
+	}
+	callsAfterFirst := calls
+	second := canonicalizePath(input)
+	if first != second {
+		t.Errorf("cached call returned different value: first=%q second=%q", first, second)
+	}
+	if calls != callsAfterFirst {
+		t.Errorf("second call invoked readDirFunc again (%d → %d); cache not used", callsAfterFirst, calls)
+	}
+}
+
+// TestCanonicalizeTimeoutEnvOverride verifies the env-override parsing
+// and that zero / negative / invalid values fall back to the default.
+func TestCanonicalizeTimeoutEnvOverride(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset", "", defaultCanonicalizeTimeout},
+		{"valid", "1500", 1500 * time.Millisecond},
+		{"zero", "0", defaultCanonicalizeTimeout},
+		{"negative", "-5", defaultCanonicalizeTimeout},
+		{"garbage", "abc", defaultCanonicalizeTimeout},
+		{"empty", "", defaultCanonicalizeTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env == "" {
+				os.Unsetenv("GRAFEL_CANONICALIZE_TIMEOUT_MS")
+			} else {
+				t.Setenv("GRAFEL_CANONICALIZE_TIMEOUT_MS", tc.env)
+			}
+			if got := canonicalizeTimeout(); got != tc.want {
+				t.Errorf("canonicalizeTimeout() with env %q = %v, want %v", tc.env, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #5330

## Root cause
At startup the daemon canonicalizes every known repo path via `canonicalizePath` (`internal/daemon/state_path.go`), called transitively from the state migration at `server.go`. It walks each path ancestor and does a blocking `os.ReadDir` on it with **no timeout**. If one ancestor's FS call hangs — a `~/Documents` iCloud/Spotlight/TCC stall, a slow/unresponsive mount, or (observed live) a launchd-context permission stall — the whole startup deadlocks forever: `goroutine 1 [syscall, N minutes]`, the daemon never logs `startup: pidfile-acquire done` and never serves. Confirmed live via a SIGQUIT goroutine dump. This has recurred several times.

## Fix
- **Bound each `os.ReadDir` with a timeout.** Default 3s, overridable via `GRAFEL_CANONICALIZE_TIMEOUT_MS` (zero/negative/garbage → default). On timeout `canonicalizePath` takes the *same* degrade path it already uses on a read error — preserve the input casing for this and all remaining segments and move on — so behaviour on a responsive FS is unchanged. The bounded read runs in a goroutine writing to a 1-deep buffered channel; on a genuinely wedged FS that goroutine is simply abandoned (holds no lock, blocks nothing, can't leak past the single buffered slot). The `canonicalCache` still pays each path at most once, so a timeout is never re-incurred.
- **Make a hang diagnosable.** Added `startup: state-migration begin` (+ matching `done`) before/after the migration — previously the daemon logged nothing until after this step, so the only way to see the hang was SIGQUIT. A canonicalize timeout also logs a `WARN` with the offending path.

## Tests (`internal/daemon/state_path_timeout_test.go`)
- Injected slow/blocking `readDirFunc` (refactored behind a package var): a `ReadDir` blocking 10s with a 20ms timeout → `canonicalizePath` returns in ~80ms with the casing-preserving fallback, does not hang.
- Fast `ReadDir` → normal canonicalization (same-inode assertion).
- Timeout result is cached: a second call returns the cached fallback without invoking `ReadDir` again.
- Env-override parsing: valid value applies; zero/negative/garbage/unset fall back to the 3s default.

## Validate
`go build ./...`, `go vet ./internal/daemon/...`, `gofmt -l` empty, full `go test ./internal/daemon/` green.