### PR TITLE
feat(wizard): choose which AI tools get the grafel MCP (smart default + remembered)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Added
+
+- **The wizard (CLI + web) now lets you choose which AI tools get the grafel
+  MCP server (#5344):** instead of auto-registering the grafel MCP entry in
+  every detected AI tool (Claude Code, Cursor, Windsurf, Codex, Kiro,
+  Antigravity), the setup wizard adds a "Configure MCP for which tools?" step
+  that lists the detected tools and lets you pick. The default is a smart
+  pre-selection — a tool is checked when its MCP config was modified recently
+  (within ~30 days) **or** already contains a grafel entry — and the wizard
+  **remembers your last choice** (persisted to `~/.grafel/mcp-tools.json`),
+  defaulting to it on subsequent runs. The step is skipped automatically when
+  ≤1 tool is detected. For scripting, `grafel wizard --mcp-tools=claude,cursor`
+  registers exactly those tools and `--no-mcp` registers none; without either
+  flag, non-interactive runs keep today's behavior (register every detected
+  tool) so existing scripts are unaffected
+  ([#5344](https://github.com/cajasmota/grafel/issues/5344)).
+
 ### Fixed
 
 - **`grafel wizard` TUI renders correctly on legacy Windows CMD/conhost

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/install/mcptools"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -31,6 +32,8 @@ func newWizardCmd() *cobra.Command {
 		agentHooks     bool
 		runInstall     bool
 		noIndex        bool
+		mcpToolsCSV    string
+		noMCP          bool
 	)
 	cmd := &cobra.Command{
 		Use:   "wizard",
@@ -52,6 +55,17 @@ func newWizardCmd() *cobra.Command {
 				NoIndex:        noIndex,
 				ErrOut:         cmd.ErrOrStderr(),
 			}
+			// Resolve the MCP-tools selection from flags (#5344). --no-mcp wins
+			// and registers none; --mcp-tools=a,b registers exactly those; with
+			// neither flag the selection stays nil (interactive prompt, or
+			// back-compat "all detected" in non-interactive mode).
+			if noMCP {
+				none := []string{}
+				opts.MCPTools = &none
+			} else if cmd.Flags().Changed("mcp-tools") {
+				ids := splitCSV(mcpToolsCSV)
+				opts.MCPTools = &ids
+			}
 			return runWizard(out, opts)
 		},
 	}
@@ -67,6 +81,8 @@ func newWizardCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&agentHooks, "agent-hooks", false, "opt-in: install the Claude Code PreToolUse grep-interceptor hook that nudges toward grafel on structural greps (advisory-only, never blocks; Claude Code only)")
 	cmd.Flags().BoolVar(&runInstall, "install", true, "run install at the end")
 	cmd.Flags().BoolVar(&noIndex, "no-index", false, "skip indexing the group at the end (default: index with live progress; requires a running daemon)")
+	cmd.Flags().StringVar(&mcpToolsCSV, "mcp-tools", "", "comma-separated AI tool IDs to register the grafel MCP server in (e.g. claude,cursor); skips the interactive picker. Without this flag (and without --no-mcp), interactive runs prompt and non-interactive runs register every detected tool")
+	cmd.Flags().BoolVar(&noMCP, "no-mcp", false, "do not register the grafel MCP server in any AI tool")
 	return cmd
 }
 
@@ -81,7 +97,12 @@ type wizardOptions struct {
 	AgentHooks          bool
 	RunInstall          bool
 	NoIndex             bool
-	ErrOut              io.Writer // stderr sink for warnings; nil → os.Stderr
+	// MCPTools, when non-nil, is the resolved selection of AI tool IDs to
+	// register the grafel MCP server in (#5344): nil = no explicit choice
+	// (prompt interactively, or all-detected non-interactively), empty = none,
+	// [ids] = exactly those. Set from --mcp-tools / --no-mcp.
+	MCPTools *[]string
+	ErrOut   io.Writer // stderr sink for warnings; nil → os.Stderr
 }
 
 // errWriter returns the configured stderr sink, defaulting to os.Stderr.
@@ -214,9 +235,20 @@ func finishWizard(out io.Writer, cfg *registry.GroupConfig, opts wizardOptions) 
 		cfg.GroupDocs = opts.GroupDocs
 	}
 
+	// Step 4b — choose which AI tools get the grafel MCP server (#5344). Only
+	// prompt interactively when no explicit selection was passed via flags. The
+	// non-interactive path leaves opts.MCPTools as-is (nil → all detected).
+	if opts.MCPTools == nil && !opts.NonInteractive {
+		sel, err := promptMCPTools()
+		if err != nil {
+			return err
+		}
+		opts.MCPTools = sel
+	}
+
 	// Steps 5-7 — persist + register + manifests + install. Shared with the
 	// non-interactive `group add` command via applyGroupConfig.
-	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall}); err != nil {
+	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: opts.MCPTools}); err != nil {
 		return err
 	}
 
@@ -233,6 +265,43 @@ func finishWizard(out io.Writer, cfg *registry.GroupConfig, opts wizardOptions) 
 		return nil
 	}
 	return maybeIndexGroup(out, opts.errWriter(), cfg.Name, opts.NoIndex)
+}
+
+// promptMCPTools runs the non-TTY (huh) MCP-tools picker (#5344). It returns a
+// non-nil selection of tool IDs to register the grafel MCP server in, defaulted
+// per the B+C heuristic (recently-used / previously-configured checked,
+// remembered last choice overriding). When ≤1 tool is detected the picker is
+// skipped and the detected set is auto-used (nil when none are detected, which
+// preserves the all-detected back-compat behaviour downstream).
+func promptMCPTools() (*[]string, error) {
+	tools := mcptools.Detect()
+	if len(tools) == 0 {
+		return nil, nil // nothing detected — keep back-compat (register all)
+	}
+	if len(tools) == 1 {
+		sel := []string{tools[0].ID}
+		return &sel, nil
+	}
+	opts := make([]huh.Option[string], 0, len(tools))
+	for _, t := range tools {
+		label := t.DisplayName
+		if t.HasGrafel {
+			label += " (configured)"
+		}
+		opts = append(opts, huh.NewOption(label, t.ID).Selected(t.DefaultSelected))
+	}
+	selected := mcptools.DefaultSelection(tools)
+	if err := huh.NewMultiSelect[string]().
+		Title("Configure MCP for which tools?").
+		Description("Your AI agents that can query this graph.\n" + navHintMulti).
+		Options(opts...).
+		Height(wizardListHeight(len(tools))).
+		Value(&selected).
+		WithTheme(wizardTheme()).
+		Run(); err != nil {
+		return nil, err
+	}
+	return &selected, nil
 }
 
 // maybeIndexGroup indexes group with live progress unless noIndex is set. A
@@ -262,6 +331,11 @@ type groupApplyOptions struct {
 	SkipWatchers bool
 	SkipMCP      bool
 	SkipRules    bool
+	// MCPTools, when non-nil, restricts MCP registration to the named tool
+	// adapter IDs — the wizard's "choose which AI tools get the grafel MCP"
+	// selection (#5344). nil preserves today's behaviour (all enabled tools);
+	// an empty slice registers none. Threaded straight into install.Options.
+	MCPTools *[]string
 }
 
 // applyGroupConfig persists the group config, registers it in the global
@@ -300,9 +374,18 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 		SkipWatchers:   ga.SkipWatchers,
 		SkipMCP:        ga.SkipMCP,
 		SkipRulesFiles: ga.SkipRules,
+		MCPTools:       ga.MCPTools,
 	})
 	if err != nil {
 		return nil, err
+	}
+	// Remember the chosen MCP tools so a later wizard run defaults to them (C,
+	// #5344). Only persist when a concrete selection was made (non-nil); a nil
+	// selection means "no explicit choice" and must not clobber a prior one.
+	if ga.MCPTools != nil {
+		if perr := mcptools.SaveLastChoice(*ga.MCPTools); perr != nil {
+			fmt.Fprintf(out, "warning: could not remember MCP tool choice: %v\n", perr)
+		}
 	}
 	fmt.Fprintf(out, "installed %d hooks, %d watchers, %d MCP entries\n",
 		len(res.HooksInstalled), len(res.WatcherUnits), len(res.MCPSettings))

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -28,9 +28,26 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/install/mcptools"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/registry"
 )
+
+// mcpToolOptions builds the wiztui MCP-tools picker options from the detector
+// (#5344), carrying the B+C computed default into the screen.
+func mcpToolOptions() []wiztui.MCPToolOption {
+	tools := mcptools.Detect()
+	out := make([]wiztui.MCPToolOption, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, wiztui.MCPToolOption{
+			ID:              t.ID,
+			DisplayName:     t.DisplayName,
+			HasGrafel:       t.HasGrafel,
+			DefaultSelected: t.DefaultSelected,
+		})
+	}
+	return out
+}
 
 // wizardUseTUI reports whether the full-screen Bubble Tea TUI should drive the
 // interactive wizard. It requires BOTH stdin and the wizard's stdout to be real
@@ -162,7 +179,15 @@ func runInteractiveTUI(out, errOut io.Writer, opts wizardOptions) (wiztui.Result
 	drv := wizardDriver{class: class}
 
 	idxFn := makeIndexFunc(out, errOut, class, opts)
-	m := wiztui.New(drv, idxFn, opts.Watchers, opts.GitHooks)
+	// Build the MCP-tools picker options (#5344) unless a flag already preset
+	// the selection (--mcp-tools / --no-mcp) — in which case the screen is
+	// skipped (empty options) and the flag selection is honoured by the
+	// IndexFunc.
+	var mcpOpts []wiztui.MCPToolOption
+	if opts.MCPTools == nil {
+		mcpOpts = mcpToolOptions()
+	}
+	m := wiztui.New(drv, idxFn, opts.Watchers, opts.GitHooks, mcpOpts)
 
 	// Switch the console to UTF-8 (Windows) before the alt-screen starts so the
 	// wizard's glyphs render instead of mojibake; restore on exit (#5340).
@@ -194,6 +219,14 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 
 			repos := reposForResult(class, r)
 
+			// Resolve the MCP-tools selection (#5344): the picker screen sets
+			// r.MCPTools; when a flag preset the choice the screen was skipped
+			// and r.MCPTools is nil, so fall back to opts.MCPTools.
+			mcpSel := r.MCPTools
+			if mcpSel == nil {
+				mcpSel = opts.MCPTools
+			}
+
 			// In the TUI, applyGroupConfig's stdout must NOT leak onto the
 			// alt-screen (fix C, #5340). Capture it into a sink buffer and feed
 			// the structured install.Result back into the Done screen instead.
@@ -201,7 +234,7 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 
 			// Add-to-existing-group path.
 			if r.Action == wiztui.ActionAddGroup && r.AddToGroup != "" {
-				if err := addReposToExistingGroupNoIndex(&sink, r.AddToGroup, repos, opts); err != nil {
+				if err := addReposToExistingGroupNoIndex(&sink, r.AddToGroup, repos, opts, mcpSel); err != nil {
 					outCh <- wiztui.IndexOutcome{Err: err}
 					return
 				}
@@ -216,7 +249,7 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 			cfg.Features.AgentHooks = opts.AgentHooks
 			cfg.GroupDocs = r.GroupDocs
 			cfg.Repos = repos
-			res, err := applyGroupConfig(&sink, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
+			res, err := applyGroupConfig(&sink, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: mcpSel})
 			if err != nil {
 				outCh <- wiztui.IndexOutcome{Err: err}
 				return
@@ -407,7 +440,7 @@ func toIndexOutcome(o rebuildOutcome, summary wiztui.InstallSummary) wiztui.Inde
 // addReposToExistingGroupNoIndex appends repos to an existing group and applies
 // the config WITHOUT triggering an index (the TUI streams the index itself via
 // streamIndex right after, so we don't want a double index here).
-func addReposToExistingGroupNoIndex(out io.Writer, group string, repos []registry.Repo, opts wizardOptions) error {
+func addReposToExistingGroupNoIndex(out io.Writer, group string, repos []registry.Repo, opts wizardOptions, mcpSel *[]string) error {
 	if len(repos) == 0 {
 		return errors.New("no repos selected to add")
 	}
@@ -436,7 +469,7 @@ func addReposToExistingGroupNoIndex(out io.Writer, group string, repos []registr
 	if added == 0 {
 		return errors.New("all selected repos are already in the group")
 	}
-	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall}); err != nil {
+	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: mcpSel}); err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "added %d repo(s) to group %q\n", added, group)

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -40,7 +40,12 @@ type Result struct {
 	GroupDocs  string
 	Watchers   bool
 	GitHooks   bool
-	Cancelled  bool // user pressed ctrl-c / esc out of the first screen
+	// MCPTools is the user's choice of which AI tools get the grafel MCP
+	// server (#5344). nil = no explicit choice (caller falls back to its
+	// default behaviour); non-nil (incl. empty) = register exactly these tool
+	// IDs. Set by the "Configure MCP for which tools?" screen.
+	MCPTools  *[]string
+	Cancelled bool // user pressed ctrl-c / esc out of the first screen
 
 	indexErr error // set if indexing failed (read via IndexErr)
 }
@@ -108,9 +113,20 @@ const (
 	scrGroupPick // add-to-group: pick target group
 	scrName
 	scrDocs
+	scrMCP // choose which AI tools get the grafel MCP server (#5344)
 	scrIndex
 	scrDone
 )
+
+// MCPToolOption is one selectable AI tool in the "Configure MCP for which
+// tools?" screen (#5344). The cli package builds these from the tool detector;
+// wiztui stays decoupled from the install package.
+type MCPToolOption struct {
+	ID              string // adapter ID persisted + passed to install
+	DisplayName     string // human-facing name
+	HasGrafel       bool   // already has a grafel entry (shown as "configured")
+	DefaultSelected bool   // B+C computed default checkbox state
+}
 
 // progressMsg / outcomeMsg are tea messages carrying indexing data.
 type progressMsg prog.Event
@@ -136,7 +152,12 @@ type Model struct {
 	groupPick  listModel
 	nameInput  inputModel
 	docsInput  inputModel
+	mcpList    multiListModel
 	idx        indexView
+
+	// mcpTools are the detected MCP-capable tools offered on the scrMCP
+	// screen, in display order. Empty (or len<=1) skips the screen (#5344).
+	mcpTools []MCPToolOption
 
 	// accumulated result
 	res Result
@@ -151,13 +172,16 @@ type Model struct {
 
 // New builds the wizard model. watchers/gitHooks seed the result defaults
 // (features are taken from flags, matching the current behavior — the TUI does
-// not re-prompt for them).
-func New(drv Driver, index IndexFunc, watchers, gitHooks bool) Model {
+// not re-prompt for them). mcpTools are the detected MCP-capable tools offered
+// on the "Configure MCP for which tools?" screen (#5344); pass nil/empty to
+// skip that screen entirely (e.g. a flag preset the selection, or ≤1 detected).
+func New(drv Driver, index IndexFunc, watchers, gitHooks bool, mcpTools []MCPToolOption) Model {
 	m := Model{
-		drv:   drv,
-		index: index,
-		scr:   scrAction,
-		step:  StepAction,
+		drv:      drv,
+		index:    index,
+		scr:      scrAction,
+		step:     StepAction,
+		mcpTools: mcpTools,
 	}
 	m.res.Watchers = watchers
 	m.res.GitHooks = gitHooks
@@ -252,6 +276,8 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updateName(msg)
 	case scrDocs:
 		return m.updateDocs(msg)
+	case scrMCP:
+		return m.updateMCP(msg)
 	case scrIndex:
 		// Index screen: only ctrl-c (handled globally) interrupts.
 		return m, nil
@@ -341,7 +367,7 @@ func (m Model) updateSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.res.Repos = repos
 		if m.res.Action == ActionAddGroup {
-			return m.startIndex()
+			return m.enterMCP()
 		}
 		return m.enterName()
 	}
@@ -428,6 +454,55 @@ func (m Model) updateDocs(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.docsInput, cmd = m.docsInput.Update(msg)
 	if m.docsInput.done {
 		m.res.GroupDocs = strings.TrimSpace(m.docsInput.value())
+		return m.enterMCP()
+	}
+	return m, cmd
+}
+
+// enterMCP transitions to the "Configure MCP for which tools?" screen (#5344).
+// When ≤1 tool is detected the screen is skipped and the detected set is
+// auto-used (no screen for a trivial choice).
+func (m Model) enterMCP() (tea.Model, tea.Cmd) {
+	if len(m.mcpTools) <= 1 {
+		// ≤1 detected: auto-use it (or leave nil when none) and index.
+		if len(m.mcpTools) == 1 {
+			sel := []string{m.mcpTools[0].ID}
+			m.res.MCPTools = &sel
+		}
+		return m.startIndex()
+	}
+	cands := make([]Candidate, 0, len(m.mcpTools))
+	for _, t := range m.mcpTools {
+		label := t.DisplayName
+		if t.HasGrafel {
+			label += " (configured)"
+		}
+		cands = append(cands, Candidate{Label: label, Value: t.ID, Selected: t.DefaultSelected})
+	}
+	m.mcpList = newMultiListModel("Configure MCP for which tools?", cands)
+	m.mcpList.context = "Your AI agents that can query this graph."
+	m.scr = scrMCP
+	m.step = StepName
+	return m, nil
+}
+
+func (m Model) updateMCP(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "esc" {
+		// Back to the docs screen.
+		m.docsInput = newInputModel("Path to shared group docs",
+			"A folder of shared markdown docs surfaced in the graph. Optional — press enter to skip.", m.res.GroupDocs, true)
+		m.scr = scrDocs
+		m.step = StepName
+		return m, m.docsInput.focusCmd()
+	}
+	var cmd tea.Cmd
+	m.mcpList, cmd = m.mcpList.Update(msg)
+	if m.mcpList.chosen {
+		sel := m.mcpList.values()
+		if sel == nil {
+			sel = []string{} // distinguish "chose none" from "no choice"
+		}
+		m.res.MCPTools = &sel
 		return m.startIndex()
 	}
 	return m, cmd
@@ -473,6 +548,9 @@ func (m Model) View() string {
 	case scrDocs:
 		body = m.docsInput.view()
 		hint = hintInputOpt()
+	case scrMCP:
+		body = m.mcpList.view(m.bodyHeight())
+		hint = hintMulti()
 	case scrIndex:
 		body = m.idx.view()
 		hint = hintIndex()

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -46,7 +46,14 @@ func send(m tea.Model, msg tea.Msg) tea.Model {
 }
 
 func newTestModel(d Driver, idx IndexFunc) Model {
-	m := New(d, idx, true, true)
+	m := New(d, idx, true, true, nil)
+	return m.update(tea.WindowSizeMsg{Width: 100, Height: 40})
+}
+
+// newTestModelMCP builds a model WITH detected MCP tools so the
+// "Configure MCP for which tools?" screen is exercised (#5344).
+func newTestModelMCP(d Driver, idx IndexFunc, mcp []MCPToolOption) Model {
+	m := New(d, idx, true, true, mcp)
 	return m.update(tea.WindowSizeMsg{Width: 100, Height: 40})
 }
 
@@ -203,6 +210,58 @@ func TestAddGroupFlow(t *testing.T) {
 	}
 	if m.res.AddToGroup != "existing" {
 		t.Errorf("AddToGroup = %q, want existing", m.res.AddToGroup)
+	}
+}
+
+// TestMCPScreenShownWhenMultipleTools: with >1 detected tool, the docs step
+// advances to the MCP picker (not straight to index), and confirming the
+// picker carries the selection into Result.MCPTools (#5344).
+func TestMCPScreenShownWhenMultipleTools(t *testing.T) {
+	d := fakeDriver{suggested: ActionSingle, cands: []Candidate{
+		{Label: "/repo", Value: "/repo", Selected: true},
+	}}
+	mcp := []MCPToolOption{
+		{ID: "claude", DisplayName: "Claude Code", DefaultSelected: true},
+		{ID: "cursor", DisplayName: "Cursor", DefaultSelected: false},
+	}
+	m := newTestModelMCP(d, nilIndex, mcp)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // name → docs
+	m = m.update(key("enter")) // docs → MCP (not index, because 2 tools)
+	if m.scr != scrMCP {
+		t.Fatalf("after docs enter, scr = %v, want scrMCP", m.scr)
+	}
+	// claude is default-checked; confirm as-is.
+	m = m.update(key("enter")) // confirm MCP → index
+	if m.scr != scrIndex {
+		t.Fatalf("after MCP enter, scr = %v, want scrIndex", m.scr)
+	}
+	if m.res.MCPTools == nil {
+		t.Fatal("MCPTools not set after the picker")
+	}
+	if got := *m.res.MCPTools; len(got) != 1 || got[0] != "claude" {
+		t.Errorf("MCPTools = %v, want [claude]", got)
+	}
+}
+
+// TestMCPScreenSkippedWhenSingleTool: with exactly 1 detected tool, the picker
+// is skipped and that tool is auto-selected (#5344).
+func TestMCPScreenSkippedWhenSingleTool(t *testing.T) {
+	d := fakeDriver{suggested: ActionSingle, cands: []Candidate{
+		{Label: "/repo", Value: "/repo", Selected: true},
+	}}
+	mcp := []MCPToolOption{{ID: "claude", DisplayName: "Claude Code", DefaultSelected: true}}
+	m := newTestModelMCP(d, nilIndex, mcp)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // name → docs
+	m = m.update(key("enter")) // docs → index (MCP skipped: only 1 tool)
+	if m.scr != scrIndex {
+		t.Fatalf("after docs enter, scr = %v, want scrIndex (single tool auto-used)", m.scr)
+	}
+	if m.res.MCPTools == nil || len(*m.res.MCPTools) != 1 || (*m.res.MCPTools)[0] != "claude" {
+		t.Errorf("MCPTools = %v, want [claude] auto-selected", m.res.MCPTools)
 	}
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -698,6 +698,7 @@ func (s *Server) routes() http.Handler {
 	// the same for an existing group. All index steps return a 202 JobAck the
 	// wizard streams via /api/v2/jobs/{id}/stream.
 	mux.HandleFunc("POST /api/v2/scan/inspect", s.handleV2ScanInspect)
+	mux.HandleFunc("GET /api/v2/mcp-tools/detect", s.handleV2DetectMCPTools)
 	mux.HandleFunc("POST /api/v2/groups/from-scan", s.handleV2CreateGroupFromScan)
 	mux.HandleFunc("POST /api/v2/groups/{group}/repos/scan", s.handleV2ScanRepos)
 	// fs/list powers the ScanWizard's server-side folder browser (#1529): the

--- a/internal/dashboard/v2_wizard.go
+++ b/internal/dashboard/v2_wizard.go
@@ -33,6 +33,7 @@ package dashboard
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -41,6 +42,9 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/mcptools"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -107,6 +111,25 @@ type v2WizardRepo struct {
 type v2FromScanReq struct {
 	Name  string         `json:"name"`
 	Repos []v2WizardRepo `json:"repos"`
+	// MCPTools, when non-nil, is the user's choice of which AI tools get the
+	// grafel MCP server (#5344). nil = back-compat (register every detected
+	// tool); empty = none; [ids] = exactly those. Mirrors the CLI wizard step.
+	MCPTools *[]string `json:"mcpTools,omitempty"`
+}
+
+// v2MCPToolStatus is one detected MCP-capable tool in the detect response,
+// mirroring the MCPToolStatus type in webui-v2/src/data/types.ts (#5344).
+type v2MCPToolStatus struct {
+	ID              string `json:"id"`
+	DisplayName     string `json:"displayName"`
+	HasGrafel       bool   `json:"hasGrafel"`
+	DefaultSelected bool   `json:"defaultSelected"`
+}
+
+// v2MCPToolsDetectReply is the GET /api/v2/mcp-tools/detect payload: the detected
+// MCP-capable tools with the B+C computed default selection.
+type v2MCPToolsDetectReply struct {
+	Tools []v2MCPToolStatus `json:"tools"`
 }
 
 // v2ScanReposReq is the body for POST /api/v2/groups/{group}/repos/scan.
@@ -213,6 +236,28 @@ func (s *Server) handleV2ScanInspect(w http.ResponseWriter, r *http.Request) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// GET /api/v2/mcp-tools/detect — detected MCP tools + B+C default selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2DetectMCPTools returns the detected MCP-capable AI tools and the
+// smart-default (B) / remembered-last-choice (C) selection so the web wizard's
+// "Configure MCP for which tools?" step can render its checkboxes (#5344). It
+// performs NO writes.
+func (s *Server) handleV2DetectMCPTools(w http.ResponseWriter, _ *http.Request) {
+	detected := mcptools.Detect()
+	tools := make([]v2MCPToolStatus, 0, len(detected))
+	for _, t := range detected {
+		tools = append(tools, v2MCPToolStatus{
+			ID:              t.ID,
+			DisplayName:     t.DisplayName,
+			HasGrafel:       t.HasGrafel,
+			DefaultSelected: t.DefaultSelected,
+		})
+	}
+	writeV2JSON(w, http.StatusOK, v2OK(v2MCPToolsDetectReply{Tools: tools}))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // POST /api/v2/groups/from-scan — create group + register repos + index
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -248,8 +293,58 @@ func (s *Server) handleV2CreateGroupFromScan(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// 2b. Register the grafel MCP server in the selected AI tools (#5344). A nil
+	// selection preserves back-compat (register every detected tool); an empty
+	// selection registers none. The chosen set is remembered (C) for next time.
+	registerWizardMCP(req.MCPTools)
+
 	// 3. Enqueue the async index job (reuses the #1512 actionJob infra).
 	s.enqueueWizardIndex(w, req.Name)
+}
+
+// registerWizardMCP registers the grafel MCP server in the tools the wizard
+// selected (#5344), mirroring install.Apply's MCP step but driven by the web
+// wizard's choice. sel semantics: nil = every detected MCP-capable tool
+// (back-compat); empty = none; [ids] = exactly those. The chosen set is
+// persisted via mcptools.SaveLastChoice so a later run defaults to it (C).
+// Per-tool failures are best-effort (an uninstalled tool is skipped); the group
+// is already created and will index regardless.
+func registerWizardMCP(sel *[]string) {
+	bin, _ := os.Executable()
+
+	// Resolve the target tool IDs. nil → all detected MCP-capable tools.
+	var ids []string
+	if sel == nil {
+		for _, t := range mcptools.Detect() {
+			ids = append(ids, t.ID)
+		}
+	} else {
+		ids = *sel
+	}
+
+	want := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		want[id] = true
+	}
+	for _, a := range tooladapter.All() {
+		if !a.SupportsMCP() || !want[a.ID()] {
+			continue
+		}
+		tool := a.MCPTool()
+		if tool == "" {
+			continue
+		}
+		if _, err := mcpreg.Register(tool, bin, ""); err != nil && !errors.Is(err, os.ErrNotExist) {
+			// Non-fatal: log via auditor-free best effort. The group still indexes.
+			continue
+		}
+	}
+
+	// Remember the explicit choice (C). nil means "no explicit choice" — don't
+	// clobber a prior remembered selection.
+	if sel != nil {
+		_ = mcptools.SaveLastChoice(*sel)
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/dashboard/v2_wizard_test.go
+++ b/internal/dashboard/v2_wizard_test.go
@@ -284,6 +284,53 @@ func TestV2CreateGroupFromScan_RequiresRepos(t *testing.T) {
 	}
 }
 
+// TestV2DetectMCPTools returns the detected MCP-capable tools with the smart
+// default (#5344). HOME is redirected to an isolated dir holding one Claude
+// config so the detector sees exactly one tool, default-checked (recent).
+func TestV2DetectMCPTools(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	// A fresh ~/.claude.json (recent mtime) → detected + default-checked.
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	resp, err := http.Get(ts.URL + "/api/v2/mcp-tools/detect")
+	if err != nil {
+		t.Fatalf("GET mcp-tools/detect: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+	var env struct {
+		OK   bool                  `json:"ok"`
+		Data v2MCPToolsDetectReply `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !env.OK {
+		t.Fatalf("not ok: %+v", env)
+	}
+	var claude *v2MCPToolStatus
+	for i := range env.Data.Tools {
+		if env.Data.Tools[i].ID == "claude" {
+			claude = &env.Data.Tools[i]
+		}
+	}
+	if claude == nil {
+		t.Fatalf("claude not detected; tools=%+v", env.Data.Tools)
+	}
+	if !claude.DefaultSelected {
+		t.Errorf("claude (recent config) should be default-selected: %+v", *claude)
+	}
+}
+
 // jsonQuote quotes a string for safe embedding in a JSON literal.
 func jsonQuote(s string) string {
 	b, _ := json.Marshal(s)

--- a/internal/install/enablement_test.go
+++ b/internal/install/enablement_test.go
@@ -41,6 +41,33 @@ func applyDryRun(t *testing.T, tools []string) *install.Result {
 	return res
 }
 
+// applyDryRunMCP is applyDryRun with an explicit MCP-tools selection (#5344):
+// all tools enabled in the group, but MCP registration filtered to mcpSel.
+func applyDryRunMCP(t *testing.T, mcpSel *[]string) *install.Result {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+
+	repo := t.TempDir()
+	cfg := &registry.GroupConfig{
+		Name:  "demo",
+		Repos: []registry.Repo{{Slug: "r", Path: repo}},
+	}
+	res, err := install.Apply(install.Options{
+		Group:    "demo",
+		Config:   cfg,
+		BinPath:  "/usr/local/bin/grafel",
+		DryRun:   true,
+		MCPTools: mcpSel,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	return res
+}
+
 // TestApply_DefaultEnablement_AllSixRulesFiles is the back-compat
 // regression guard at the Apply boundary: with no Tools the rules-file set
 // reported is exactly the historical six.
@@ -103,5 +130,54 @@ func TestApply_MCPSettings_CursorWindsurfCodex(t *testing.T) {
 	// copilot has no MCP host; nothing copilot-specific should appear.
 	if strings.Contains(joined, "copilot") {
 		t.Fatalf("copilot should not contribute an MCP path:\n%s", joined)
+	}
+}
+
+// TestApply_MCPTools_FiltersToSelection proves the wizard MCP-tools selection
+// (#5344) registers ONLY the named tools, even though every tool is enabled.
+func TestApply_MCPTools_FiltersToSelection(t *testing.T) {
+	sel := []string{"claude", "cursor"}
+	res := applyDryRunMCP(t, &sel)
+
+	joined := strings.Join(res.MCPSettings, "\n")
+	if !strings.Contains(joined, ".claude.json") {
+		t.Errorf("expected claude MCP path; got:\n%s", joined)
+	}
+	if !strings.Contains(joined, filepath.Join(".cursor", "mcp.json")) {
+		t.Errorf("expected cursor MCP path; got:\n%s", joined)
+	}
+	// windsurf is enabled but NOT selected — it must be absent.
+	if strings.Contains(joined, filepath.Join(".codeium", "windsurf")) {
+		t.Errorf("windsurf was not selected but appeared:\n%s", joined)
+	}
+	if strings.Contains(joined, filepath.Join(".codex", "config.toml")) {
+		t.Errorf("codex was not selected but appeared:\n%s", joined)
+	}
+}
+
+// TestApply_MCPTools_EmptyRegistersNone proves an empty (non-nil) selection
+// (the --no-mcp / "chose none" case) registers no MCP entries at all.
+func TestApply_MCPTools_EmptyRegistersNone(t *testing.T) {
+	empty := []string{}
+	res := applyDryRunMCP(t, &empty)
+	if len(res.MCPSettings) != 0 {
+		t.Errorf("empty MCP selection registered %d paths, want 0: %v", len(res.MCPSettings), res.MCPSettings)
+	}
+}
+
+// TestApply_MCPTools_NilIsBackCompat proves a nil selection preserves today's
+// behaviour: every enabled MCP-supporting tool is registered.
+func TestApply_MCPTools_NilIsBackCompat(t *testing.T) {
+	res := applyDryRunMCP(t, nil)
+	joined := strings.Join(res.MCPSettings, "\n")
+	for _, want := range []string{
+		".claude.json",
+		filepath.Join(".cursor", "mcp.json"),
+		filepath.Join(".codeium", "windsurf", "mcp_config.json"),
+		filepath.Join(".codex", "config.toml"),
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("nil selection (back-compat) missing %q:\n%s", want, joined)
+		}
 	}
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -43,6 +43,19 @@ type Options struct {
 	// either the explicit option OR the persisted feature flag enables it.
 	// CLAUDE CODE ONLY; advisory-only; never blocks.
 	InstallAgentHooks bool
+	// MCPTools, when non-nil, restricts MCP registration to the named tool
+	// adapter IDs (e.g. {"claude","cursor"}) — the wizard's "choose which AI
+	// tools get the grafel MCP server" selection (#5344). Semantics:
+	//
+	//   - nil   → back-compat: register every enabled MCP-supporting tool
+	//             (today's behaviour; existing non-interactive callers).
+	//   - []    → register NONE (the --no-mcp / "none selected" case).
+	//   - [ids] → register exactly the listed tools (filtered to the enabled
+	//             MCP-supporting set; unknown/non-MCP IDs are ignored).
+	//
+	// The filter is by adapter ID, applied on top of the enabled-tools set, so
+	// a tool the group config doesn't enable is never registered even if named.
+	MCPTools *[]string
 }
 
 // Result reports what an Apply call did so the CLI can print a summary.
@@ -225,7 +238,15 @@ func Apply(opts Options) (*Result, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, tool := range enabledMCPTools(adaptersForRepo) {
+		// The wizard MCP-tools selection (#5344) filters the enabled
+		// MCP-supporting adapters by ID before registration. A nil selection
+		// preserves today's behaviour (every enabled tool); a non-nil one —
+		// including an empty slice (register none) — is honoured exactly.
+		mcpAdapters := adaptersForRepo
+		if opts.MCPTools != nil {
+			mcpAdapters = filterAdaptersByID(adaptersForRepo, *opts.MCPTools)
+		}
+		for _, tool := range enabledMCPTools(mcpAdapters) {
 			if opts.DryRun {
 				p, _ := mcpreg.SettingsPath(tool)
 				res.MCPSettings = append(res.MCPSettings, p)
@@ -274,6 +295,24 @@ func enabledRulesTargets(adapters []tooladapter.Adapter) []string {
 				out = append(out, t)
 				delete(want, t)
 			}
+		}
+	}
+	return out
+}
+
+// filterAdaptersByID keeps only the adapters whose ID is in the selected set,
+// preserving registry order. Used by the wizard MCP-tools selection (#5344) so
+// MCP registration targets exactly the tools the user chose. An empty selection
+// yields no adapters (register none).
+func filterAdaptersByID(adapters []tooladapter.Adapter, selected []string) []tooladapter.Adapter {
+	want := make(map[string]bool, len(selected))
+	for _, id := range selected {
+		want[id] = true
+	}
+	var out []tooladapter.Adapter
+	for _, a := range adapters {
+		if want[a.ID()] {
+			out = append(out, a)
 		}
 	}
 	return out

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -584,3 +584,41 @@ func writeSettings(path string, doc map[string]any) error {
 	}
 	return os.Rename(tmp, path)
 }
+
+// HasGrafelEntry reports whether the config file at path already contains a
+// grafel MCP server entry. It is format-aware (JSON mcpServers.grafel for the
+// JSON hosts, the [mcp_servers.grafel] table for Codex TOML) and never errors:
+// a missing/unreadable/malformed file simply reports false. Used by the wizard
+// tool detector to pre-check tools that were previously configured (#5344).
+func HasGrafelEntry(path string) bool {
+	if isTOML(path) {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		_, present := stripGrafelBlock(string(raw))
+		return present
+	}
+	doc, err := readSettings(path)
+	if err != nil {
+		return false
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if servers == nil {
+		return false
+	}
+	_, ok := servers[ServerName]
+	return ok
+}
+
+// ConfigModTime returns the last-modified time of the tool's MCP config file,
+// and whether that file currently exists. A missing file yields (zero, false).
+// Used by the wizard tool detector to compute the "recently used" smart
+// default (#5344).
+func ConfigModTime(path string) (time.Time, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return info.ModTime(), true
+}

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -1,0 +1,236 @@
+// Package mcptools backs the wizard step that lets a user choose WHICH AI
+// tools get the grafel MCP server, instead of auto-registering every detected
+// tool (#5344).
+//
+// It builds on the existing tool registry (internal/install/tooladapter +
+// internal/install/mcpreg) rather than hard-coding a second list: the set of
+// selectable tools is exactly the MCP-supporting adapters. For each one it
+// reports whether the tool's config is present on this machine, the config
+// path + its last-modified time, and whether the config already contains a
+// grafel entry.
+//
+// The default selection is the decided B + C design:
+//
+//   - (B) smart default: a tool is checked when its config was modified
+//     recently (within RecentWindow) OR it already contains a grafel entry
+//     (previously configured). Clearly-stale tools are unchecked but stay
+//     visible so the user can re-check them.
+//   - (C) remember last choice: the user's selection is persisted to
+//     ~/.grafel/mcp-tools.json and, on subsequent runs, becomes the default
+//     (C overrides B once a choice has been made).
+package mcptools
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+)
+
+// RecentWindow is the "recently used" horizon for the smart (B) default: a
+// detected tool whose MCP config was modified within this window is checked by
+// default. ~30 days balances "I use this tool" against stale configs left over
+// from a tool the user abandoned.
+const RecentWindow = 30 * 24 * time.Hour
+
+// Tool describes one MCP-capable AI tool as surfaced to the wizard.
+type Tool struct {
+	// ID is the stable tooladapter ID (e.g. "claude", "cursor"). It is the
+	// value persisted in the last-choice file and passed to install via
+	// Options.MCPTools.
+	ID string `json:"id"`
+	// DisplayName is the human-facing name (e.g. "Claude Code").
+	DisplayName string `json:"displayName"`
+	// ConfigPath is the absolute path to the tool's MCP config file.
+	ConfigPath string `json:"configPath"`
+	// Detected reports whether the tool looks installed (its config file or
+	// parent dir exists).
+	Detected bool `json:"detected"`
+	// HasGrafel reports whether the config already contains a grafel entry.
+	HasGrafel bool `json:"hasGrafel"`
+	// LastModified is the config file's mtime (zero when the file is absent).
+	LastModified time.Time `json:"lastModified,omitempty"`
+	// DefaultSelected is the computed B+C default checkbox state.
+	DefaultSelected bool `json:"defaultSelected"`
+}
+
+// mcpAdapter pairs an adapter with its mcpreg tool. Only adapters that support
+// MCP are selectable.
+type mcpAdapter struct {
+	id          string
+	displayName string
+	tool        mcpreg.Tool
+}
+
+// mcpAdapters returns the MCP-supporting adapters in registry order, drawn from
+// the canonical tooladapter registry (no second hard-coded list).
+func mcpAdapters() []mcpAdapter {
+	var out []mcpAdapter
+	for _, a := range tooladapter.All() {
+		if !a.SupportsMCP() {
+			continue
+		}
+		t := a.MCPTool()
+		if t == "" {
+			continue
+		}
+		out = append(out, mcpAdapter{id: a.ID(), displayName: a.DisplayName(), tool: t})
+	}
+	return out
+}
+
+// nowFunc is overridable in tests so "recent" is deterministic.
+var nowFunc = time.Now
+
+// Detect inspects every MCP-capable tool and returns ONLY the detected ones
+// (config file or parent dir present), in registry order, with the B+C default
+// selection already computed. When a last-choice file exists its selection
+// overrides the smart (B) default for the tools it names (C); tools absent from
+// the saved choice fall back to B.
+//
+// Detect never errors on individual tools — an unreadable config simply yields
+// HasGrafel=false / a zero mtime.
+func Detect() []Tool {
+	last, _ := ReadLastChoice() // best-effort; nil when no prior choice
+	return detectWith(last)
+}
+
+// detectWith is the testable core of Detect: lastChoice (possibly nil) is the
+// remembered selection set.
+func detectWith(lastChoice map[string]bool) []Tool {
+	now := nowFunc()
+	var out []Tool
+	for _, a := range mcpAdapters() {
+		path, err := mcpreg.SettingsPath(a.tool)
+		if err != nil {
+			continue
+		}
+		mtime, fileExists := mcpreg.ConfigModTime(path)
+		detected := fileExists || parentDirExists(path)
+		if !detected {
+			continue
+		}
+		hasGrafel := mcpreg.HasGrafelEntry(path)
+		recent := fileExists && now.Sub(mtime) <= RecentWindow
+
+		// (B) smart default.
+		def := recent || hasGrafel
+		// (C) remembered choice overrides B for tools it names.
+		if lastChoice != nil {
+			if sel, ok := lastChoice[a.id]; ok {
+				def = sel
+			}
+		}
+
+		out = append(out, Tool{
+			ID:              a.id,
+			DisplayName:     a.displayName,
+			ConfigPath:      path,
+			Detected:        true,
+			HasGrafel:       hasGrafel,
+			LastModified:    mtime,
+			DefaultSelected: def,
+		})
+	}
+	return out
+}
+
+// parentDirExists reports whether the config file's parent directory exists —
+// the "tool installed but MCP not yet configured" signal mcpreg uses.
+func parentDirExists(path string) bool {
+	info, err := os.Stat(filepath.Dir(path))
+	return err == nil && info.IsDir()
+}
+
+// DefaultSelection returns the IDs of the tools whose DefaultSelected is true,
+// in the order Detect returned them. Convenience for callers that just want the
+// pre-checked set.
+func DefaultSelection(tools []Tool) []string {
+	var out []string
+	for _, t := range tools {
+		if t.DefaultSelected {
+			out = append(out, t.ID)
+		}
+	}
+	return out
+}
+
+// ── (C) last-choice persistence ──────────────────────────────────────────────
+
+// lastChoiceFile is the persisted last-selection document.
+type lastChoiceFile struct {
+	// Selected is the list of tool IDs the user last chose to register.
+	Selected []string `json:"selected"`
+	// SavedAt is an RFC3339 timestamp, informational only.
+	SavedAt string `json:"savedAt,omitempty"`
+}
+
+// LastChoicePath returns the path to ~/.grafel/mcp-tools.json. It honours HOME
+// so tests can redirect it.
+func LastChoicePath() (string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		home = h
+	}
+	return filepath.Join(home, ".grafel", "mcp-tools.json"), nil
+}
+
+// ReadLastChoice loads the remembered selection as a set of tool IDs. Returns
+// (nil, nil) when no choice has been saved yet (the common first-run case).
+func ReadLastChoice() (map[string]bool, error) {
+	path, err := LastChoicePath()
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var doc lastChoiceFile
+	if err := json.Unmarshal(b, &doc); err != nil {
+		// A corrupt file must not break the wizard — treat as "no choice".
+		return nil, nil
+	}
+	set := make(map[string]bool, len(doc.Selected))
+	for _, id := range doc.Selected {
+		set[id] = true
+	}
+	return set, nil
+}
+
+// SaveLastChoice persists the chosen tool IDs to ~/.grafel/mcp-tools.json so a
+// later wizard run defaults to them (C). The IDs are sorted for a stable file.
+// An empty slice is persisted faithfully (the user chose "none").
+func SaveLastChoice(ids []string) error {
+	path, err := LastChoicePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	sorted := append([]string(nil), ids...)
+	sort.Strings(sorted)
+	doc := lastChoiceFile{Selected: sorted, SavedAt: nowFunc().UTC().Format(time.RFC3339)}
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/install/mcptools/mcptools_test.go
+++ b/internal/install/mcptools/mcptools_test.go
@@ -1,0 +1,184 @@
+package mcptools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+)
+
+// setupHome points HOME at a temp dir so detection reads only files we create,
+// and stamps a fixed "now" so the recent-window default is deterministic.
+func setupHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return now }
+	t.Cleanup(func() { nowFunc = time.Now })
+	return home
+}
+
+// writeConfig writes a JSON MCP config for the given tool and sets its mtime.
+func writeConfig(t *testing.T, tool mcpreg.Tool, hasGrafel bool, mtime time.Time) string {
+	t.Helper()
+	path, err := mcpreg.SettingsPath(tool)
+	if err != nil {
+		t.Fatalf("SettingsPath(%s): %v", tool, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doc := map[string]any{}
+	if hasGrafel {
+		doc["mcpServers"] = map[string]any{
+			mcpreg.ServerName: map[string]any{"command": "grafel", "args": []string{"mcp-bridge"}},
+		}
+	} else {
+		doc["mcpServers"] = map[string]any{"other": map[string]any{"command": "x"}}
+	}
+	b, _ := json.MarshalIndent(doc, "", "  ")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// find returns the detected Tool with the given ID, or fails.
+func find(t *testing.T, tools []Tool, id string) Tool {
+	t.Helper()
+	for _, tl := range tools {
+		if tl.ID == id {
+			return tl
+		}
+	}
+	t.Fatalf("tool %q not in detected set %v", id, ids(tools))
+	return Tool{}
+}
+
+func ids(tools []Tool) []string {
+	out := make([]string, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, t.ID)
+	}
+	return out
+}
+
+// TestSmartDefault_B verifies the (B) default: recently-modified OR has-grafel →
+// checked; clearly-stale (no grafel, old mtime) → unchecked.
+func TestSmartDefault_B(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+
+	// claude: recent, no grafel → checked (recent).
+	writeConfig(t, mcpreg.ClaudeCode, false, now.Add(-2*24*time.Hour))
+	// cursor: stale, but HAS grafel → checked (previously configured).
+	writeConfig(t, mcpreg.Cursor, true, now.Add(-365*24*time.Hour))
+	// windsurf: stale, no grafel → unchecked.
+	writeConfig(t, mcpreg.Windsurf, false, now.Add(-90*24*time.Hour))
+
+	tools := detectWith(nil)
+
+	if c := find(t, tools, "claude"); !c.DefaultSelected {
+		t.Error("claude (recent) should be default-checked")
+	}
+	if c := find(t, tools, "cursor"); !c.DefaultSelected || !c.HasGrafel {
+		t.Errorf("cursor (has grafel) should be checked + HasGrafel; got %+v", c)
+	}
+	if c := find(t, tools, "windsurf"); c.DefaultSelected {
+		t.Error("windsurf (stale, no grafel) should be default-UNchecked")
+	}
+}
+
+// TestRememberedChoice_C verifies (C): a saved last-choice overrides the smart
+// (B) default for the tools it names.
+func TestRememberedChoice_C(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+
+	// claude: recent → B would check it. cursor: stale, no grafel → B unchecks.
+	writeConfig(t, mcpreg.ClaudeCode, false, now)
+	writeConfig(t, mcpreg.Cursor, false, now.Add(-365*24*time.Hour))
+
+	// Remembered choice: cursor IN, claude OUT — the inverse of B.
+	last := map[string]bool{"cursor": true, "claude": false}
+	tools := detectWith(last)
+
+	if c := find(t, tools, "claude"); c.DefaultSelected {
+		t.Error("claude should be UNchecked: remembered choice (C) overrides recent (B)")
+	}
+	if c := find(t, tools, "cursor"); !c.DefaultSelected {
+		t.Error("cursor should be checked: remembered choice (C) overrides stale (B)")
+	}
+}
+
+// TestDetect_OnlyDetectedTools verifies tools whose config + parent dir are
+// absent are excluded.
+func TestDetect_OnlyDetectedTools(t *testing.T) {
+	setupHome(t)
+	writeConfig(t, mcpreg.ClaudeCode, false, nowFunc())
+	// Nothing for cursor/windsurf/etc.
+
+	tools := detectWith(nil)
+	if got := ids(tools); len(got) != 1 || got[0] != "claude" {
+		t.Errorf("detected = %v, want only [claude]", got)
+	}
+}
+
+// TestLastChoice_RoundTrip verifies SaveLastChoice / ReadLastChoice persistence
+// (C) writes ~/.grafel/mcp-tools.json and reads it back as a set.
+func TestLastChoice_RoundTrip(t *testing.T) {
+	setupHome(t)
+
+	if got, err := ReadLastChoice(); err != nil || got != nil {
+		t.Fatalf("ReadLastChoice on fresh home = (%v, %v), want (nil, nil)", got, err)
+	}
+
+	if err := SaveLastChoice([]string{"cursor", "claude"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
+	}
+	path, _ := LastChoicePath()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+
+	set, err := ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice: %v", err)
+	}
+	if !set["claude"] || !set["cursor"] || set["windsurf"] {
+		t.Errorf("read set = %v, want {claude, cursor}", set)
+	}
+
+	// An empty selection ("chose none") must round-trip as a non-nil empty set.
+	if err := SaveLastChoice([]string{}); err != nil {
+		t.Fatalf("SaveLastChoice(empty): %v", err)
+	}
+	set, err = ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice after empty: %v", err)
+	}
+	if set == nil || len(set) != 0 {
+		t.Errorf("empty choice round-trip = %v, want non-nil empty set", set)
+	}
+}
+
+// TestDefaultSelection extracts the checked IDs in order.
+func TestDefaultSelection(t *testing.T) {
+	tools := []Tool{
+		{ID: "claude", DefaultSelected: true},
+		{ID: "cursor", DefaultSelected: false},
+		{ID: "windsurf", DefaultSelected: true},
+	}
+	got := DefaultSelection(tools)
+	if len(got) != 2 || got[0] != "claude" || got[1] != "windsurf" {
+		t.Errorf("DefaultSelection = %v, want [claude windsurf]", got)
+	}
+}

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -50,6 +50,7 @@ import {
   useScanReposIntoGroup,
   useWizardJob,
   useFsList,
+  useMCPToolsDetect,
 } from "@/hooks/use-wizard";
 import { useIndexProgress } from "@/hooks/use-index-progress";
 import { aggregateProgress, overallPhaseLabel } from "@/lib/index-progress-fold";
@@ -61,12 +62,19 @@ import {
   defaultActionFor,
   type WizardAction,
 } from "@/lib/wizard-action";
+import {
+  defaultSelectedIds,
+  shouldShowMCPStep,
+  autoMCPSelection,
+} from "@/lib/mcp-tools-default";
 import { cn } from "@/lib/utils";
 
 // Action-first flow (#5336): the wizard now opens on an action choice (single /
 // group / monorepo / add-to-group) — parity with the CLI wizard — before the
 // folder picker. The chosen action tunes the Detect step's labels and defaults.
-type WizardStep = "action" | "pick" | "detect" | "index";
+// "mcp" — choose which AI tools get the grafel MCP server (#5344). Create mode
+// only; skipped when ≤1 MCP-capable tool is detected.
+type WizardStep = "action" | "pick" | "detect" | "mcp" | "index";
 
 export interface ScanWizardProps {
   open: boolean;
@@ -107,6 +115,22 @@ export function ScanWizard(props: ScanWizardProps) {
   // repos, the user picks WHICH ones to index; each is registered as its own
   // repo (its absolute sub-path). Default: all children checked.
   const [selectedChildren, setSelectedChildren] = useState<Set<string>>(new Set());
+
+  // MCP-tools selection (#5344). Which AI tools get the grafel MCP server. Only
+  // relevant in create mode; defaulted from the detector's smart (B+C) defaults
+  // once the detect query resolves. `mcpInitialized` ensures we seed the default
+  // exactly once (so a user's unchecks aren't clobbered by a refetch).
+  const [selectedMCPTools, setSelectedMCPTools] = useState<Set<string>>(new Set());
+  const [mcpInitialized, setMcpInitialized] = useState(false);
+  const mcpDetect = useMCPToolsDetect(open && mode === "create");
+  const mcpTools = mcpDetect.data?.tools ?? [];
+
+  // Seed the default MCP selection from the detector's B+C defaults, once.
+  useEffect(() => {
+    if (mcpInitialized || !mcpDetect.data) return;
+    setSelectedMCPTools(new Set(defaultSelectedIds(mcpDetect.data.tools)));
+    setMcpInitialized(true);
+  }, [mcpDetect.data, mcpInitialized]);
 
   // Server-side folder browser (#1529). `browseDir` is the directory currently
   // being listed; null defaults to the daemon's home dir. `null` while the
@@ -154,6 +178,8 @@ export function ScanWizard(props: ScanWizardProps) {
     setJobId(null);
     setSelectedPkgs(new Set());
     setSelectedChildren(new Set());
+    setSelectedMCPTools(new Set());
+    setMcpInitialized(false);
     setBrowseDir(null);
     inspect.reset();
     createFromScan.reset();
@@ -215,8 +241,25 @@ export function ScanWizard(props: ScanWizardProps) {
     }
   }
 
+  // proceedFromDetect decides what comes after the Detect step (#5344). In
+  // create mode, when more than one MCP-capable tool is detected, show the MCP
+  // picker; otherwise (add-repo mode, or ≤1 tool) skip straight to indexing,
+  // auto-using the single detected tool's selection.
+  function proceedFromDetect() {
+    if (mode === "create" && shouldShowMCPStep(mcpTools)) {
+      setStep("mcp");
+      return;
+    }
+    // ≤1 tool (or add-repo mode): auto-use. In create mode a single tool is
+    // pre-checked; add-repo mode leaves the selection undefined (back-compat).
+    const sel = mode === "create" ? autoMCPSelection(mcpTools) : undefined;
+    void runIndex(sel);
+  }
+
   // --- Step 3: create/register + index ---
-  async function runIndex() {
+  // mcpToolsSel (#5344): the chosen MCP tool IDs to register (create mode);
+  // undefined preserves back-compat (register every detected tool / add-repo).
+  async function runIndex(mcpToolsSel?: string[]) {
     if (!scan?.valid) return;
     // Build the repo list based on what was detected:
     //   1. Child git repos (multi-repo-parent, #1531 follow-up): each selected
@@ -247,7 +290,7 @@ export function ScanWizard(props: ScanWizardProps) {
     try {
       if (mode === "create") {
         if (!nameSlug || nameDuplicate) return;
-        const ack = await createFromScan.mutateAsync({ name: nameSlug, repos });
+        const ack = await createFromScan.mutateAsync({ name: nameSlug, repos, mcpTools: mcpToolsSel });
         setJobId(ack.job_id);
       } else {
         const ack = await scanRepos.mutateAsync(repos);
@@ -326,6 +369,7 @@ export function ScanWizard(props: ScanWizardProps) {
           {step === "action" && "What do you want to index?"}
           {step === "pick" && "Point Grafel at a repository folder on this machine."}
           {step === "detect" && "Review what we detected, then start indexing."}
+          {step === "mcp" && "Choose which AI tools get the grafel MCP server."}
           {step === "index" && "Indexing in progress — you can leave this open."}
         </DialogDescription>
 
@@ -335,6 +379,8 @@ export function ScanWizard(props: ScanWizardProps) {
             ...(mode === "create" ? [{ id: "action" as WizardStep, label: "Action" }] : []),
             { id: "pick", label: "Pick" },
             { id: "detect", label: "Detect" },
+            // The MCP step only appears in create mode (#5344).
+            ...(mode === "create" ? [{ id: "mcp" as WizardStep, label: "MCP" }] : []),
             { id: "index", label: "Index" },
           ];
           return (
@@ -808,11 +854,90 @@ export function ScanWizard(props: ScanWizardProps) {
                   (scan.packages.length > 0 && selectedPkgs.size === 0) ||
                   (mode === "create" && (!nameSlug || nameDuplicate))
                 }
-                onClick={() => void runIndex()}
+                onClick={() => (mode === "create" ? proceedFromDetect() : void runIndex())}
                 data-testid="wizard-index"
               >
                 {indexing ? <Loader2 size={13} className="animate-spin" /> : null}
-                {mode === "create" ? "Create & index" : "Add & index"}
+                {/* In create mode the next step may be the MCP picker, so the
+                    label is action-neutral; add-repo goes straight to indexing. */}
+                {mode === "create"
+                  ? shouldShowMCPStep(mcpTools)
+                    ? "Next"
+                    : "Create & index"
+                  : "Add & index"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 2b — choose which AI tools get the grafel MCP server (#5344).
+            Create mode only; reached when >1 MCP-capable tool is detected. The
+            defaults are the detector's smart (recently-used / previously-
+            configured / remembered) selection. */}
+        {step === "mcp" && (
+          <div className="mt-4 space-y-4" data-testid="wizard-mcp">
+            <p className="text-sm text-text-3">Your AI agents that can query this graph.</p>
+            {mcpDetect.isLoading ? (
+              <div className="flex items-center gap-2 p-3 text-sm text-text-3">
+                <Loader2 size={14} className="animate-spin" /> Detecting tools…
+              </div>
+            ) : mcpTools.length === 0 ? (
+              <p className="text-sm text-text-4">No AI tools detected on this machine.</p>
+            ) : (
+              <ul className="max-h-64 overflow-y-auto rounded-lg border border-border bg-surface divide-y divide-border/60">
+                {mcpTools.map((t) => {
+                  const checked = selectedMCPTools.has(t.id);
+                  return (
+                    <li key={t.id}>
+                      <button
+                        type="button"
+                        role="checkbox"
+                        aria-checked={checked}
+                        className={cn(
+                          "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-2",
+                          checked ? "text-text-2" : "text-text-4",
+                        )}
+                        onClick={() =>
+                          setSelectedMCPTools((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(t.id)) next.delete(t.id);
+                            else next.add(t.id);
+                            return next;
+                          })
+                        }
+                        data-testid="wizard-mcp-tool"
+                        data-tool={t.id}
+                        data-checked={checked}
+                      >
+                        {checked ? (
+                          <CheckSquare size={15} className="shrink-0 text-accent-strong" />
+                        ) : (
+                          <Square size={15} className="shrink-0 text-text-4" />
+                        )}
+                        <span className="min-w-0 flex-1 truncate">{t.displayName}</span>
+                        {t.hasGrafel && (
+                          <Badge tone="neutral" className="shrink-0 text-[10px]">
+                            configured
+                          </Badge>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <div className="flex justify-between gap-2 pt-1">
+              <Button type="button" variant="ghost" onClick={() => setStep("detect")}>
+                Back
+              </Button>
+              <Button
+                type="button"
+                disabled={indexing}
+                onClick={() => void runIndex([...selectedMCPTools])}
+                data-testid="wizard-mcp-next"
+              >
+                {indexing ? <Loader2 size={13} className="animate-spin" /> : null}
+                Create &amp; index
               </Button>
             </div>
           </div>

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1416,6 +1416,24 @@ export interface WizardRepo {
   modules?: string[];
 }
 
+/**
+ * One detected MCP-capable AI tool offered in the wizard's "Configure MCP for
+ * which tools?" step (#5344). Mirrors v2MCPToolStatus in internal/dashboard.
+ */
+export interface MCPToolStatus {
+  id: string;
+  displayName: string;
+  /** The tool's config already contains a grafel entry (shown as "configured"). */
+  hasGrafel: boolean;
+  /** The smart (recently-used / previously-configured / remembered) default. */
+  defaultSelected: boolean;
+}
+
+/** Reply from GET /api/v2/mcp-tools/detect (#5344). */
+export interface MCPToolsDetectReply {
+  tools: MCPToolStatus[];
+}
+
 /* ------------------------------------------------------------------ *
  * Real-time per-repo / per-MODULE indexing progress (#1527). Streamed as
  * SSE `progress` events from GET /api/index-progress/:group. Mirrors the Go

--- a/webui-v2/src/hooks/use-wizard.ts
+++ b/webui-v2/src/hooks/use-wizard.ts
@@ -42,11 +42,32 @@ export function useScanInspect() {
   });
 }
 
+/**
+ * Detect the MCP-capable AI tools + the smart-default selection for the wizard's
+ * "Configure MCP for which tools?" step (#5344). Gated by `enabled` so the fetch
+ * only runs while the wizard is open in create mode.
+ */
+export function useMCPToolsDetect(enabled: boolean) {
+  return useQuery({
+    queryKey: ["mcp-tools-detect"],
+    queryFn: () => api.detectMCPTools(),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
 /** Create-group-from-scan: create + register + enqueue index job. Returns a JobAck. */
 export function useCreateGroupFromScan() {
   return useMutation({
-    mutationFn: ({ name, repos }: { name: string; repos: WizardRepo[] }) =>
-      api.createGroupFromScan(name, repos),
+    mutationFn: ({
+      name,
+      repos,
+      mcpTools,
+    }: {
+      name: string;
+      repos: WizardRepo[];
+      mcpTools?: string[];
+    }) => api.createGroupFromScan(name, repos, mcpTools),
   });
 }
 

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -56,6 +56,7 @@ import type {
   UpdateApplyReply,
   ScanInspectReply,
   WizardRepo,
+  MCPToolsDetectReply,
   FsListReply,
   ModuleAnalysisResponse,
   GroupRefsResponse,
@@ -193,13 +194,22 @@ export const api = {
     }),
 
   /**
+   * GET /api/v2/mcp-tools/detect — list the detected MCP-capable AI tools with
+   * the smart-default (recently-used / previously-configured) selection so the
+   * wizard's "Configure MCP for which tools?" step can render checkboxes (#5344).
+   */
+  detectMCPTools: () => requestV2<MCPToolsDetectReply>("/mcp-tools/detect"),
+
+  /**
    * POST /api/v2/groups/from-scan — create a group, register the scanned repos,
    * and enqueue an async index job. Returns a 202 JobAck the wizard streams.
+   * `mcpTools` (#5344): when provided, registers the grafel MCP server in exactly
+   * those tool IDs (empty = none); omit for back-compat (every detected tool).
    */
-  createGroupFromScan: (name: string, repos: WizardRepo[]) =>
+  createGroupFromScan: (name: string, repos: WizardRepo[], mcpTools?: string[]) =>
     requestV2<JobAck>("/groups/from-scan", {
       method: "POST",
-      body: JSON.stringify({ name, repos }),
+      body: JSON.stringify(mcpTools === undefined ? { name, repos } : { name, repos, mcpTools }),
     }),
 
   /**

--- a/webui-v2/src/lib/mcp-tools-default.test.ts
+++ b/webui-v2/src/lib/mcp-tools-default.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  defaultSelectedIds,
+  shouldShowMCPStep,
+  autoMCPSelection,
+} from "./mcp-tools-default";
+import type { MCPToolStatus } from "@/data/types";
+
+function tool(id: string, defaultSelected: boolean, hasGrafel = false): MCPToolStatus {
+  return { id, displayName: id, hasGrafel, defaultSelected };
+}
+
+describe("defaultSelectedIds", () => {
+  it("returns only the backend-default-selected tools, in order", () => {
+    const tools = [
+      tool("claude", true),
+      tool("cursor", false),
+      tool("windsurf", true),
+    ];
+    expect(defaultSelectedIds(tools)).toEqual(["claude", "windsurf"]);
+  });
+
+  it("returns [] when none are default-selected", () => {
+    expect(defaultSelectedIds([tool("a", false), tool("b", false)])).toEqual([]);
+  });
+});
+
+describe("shouldShowMCPStep", () => {
+  it("hides the step for 0 or 1 detected tool", () => {
+    expect(shouldShowMCPStep([])).toBe(false);
+    expect(shouldShowMCPStep([tool("claude", true)])).toBe(false);
+  });
+
+  it("shows the step when more than one tool is detected", () => {
+    expect(shouldShowMCPStep([tool("claude", true), tool("cursor", false)])).toBe(true);
+  });
+});
+
+describe("autoMCPSelection", () => {
+  it("auto-selects the single detected tool", () => {
+    expect(autoMCPSelection([tool("claude", false)])).toEqual(["claude"]);
+  });
+
+  it("returns undefined (back-compat) when no tools are detected", () => {
+    expect(autoMCPSelection([])).toBeUndefined();
+  });
+
+  it("returns undefined when >1 tool (caller shows the picker instead)", () => {
+    expect(autoMCPSelection([tool("a", true), tool("b", true)])).toBeUndefined();
+  });
+});

--- a/webui-v2/src/lib/mcp-tools-default.ts
+++ b/webui-v2/src/lib/mcp-tools-default.ts
@@ -1,0 +1,38 @@
+/* ============================================================
+   mcp-tools-default.ts — pure helpers for the wizard's "Configure MCP for
+   which tools?" step (#5344).
+
+   The smart (B) + remembered (C) default is computed on the BACKEND (see
+   internal/install/mcptools) and delivered as `defaultSelected` per tool.
+   The frontend's only job is to derive the initial checkbox set from that and
+   to decide whether the step is even worth showing.
+   ============================================================ */
+
+import type { MCPToolStatus } from "@/data/types";
+
+/**
+ * defaultSelectedIds returns the IDs of the tools the backend marked as
+ * default-selected — the initial checkbox state for the MCP step.
+ */
+export function defaultSelectedIds(tools: MCPToolStatus[]): string[] {
+  return tools.filter((t) => t.defaultSelected).map((t) => t.id);
+}
+
+/**
+ * shouldShowMCPStep reports whether the MCP picker should be shown. With ≤1
+ * detected tool there is no meaningful choice, so the step is skipped and the
+ * single tool (if any) is auto-used.
+ */
+export function shouldShowMCPStep(tools: MCPToolStatus[]): boolean {
+  return tools.length > 1;
+}
+
+/**
+ * autoMCPSelection returns the MCP selection to use when the picker is SKIPPED
+ * (≤1 tool): the single tool's id when exactly one is detected, else undefined
+ * (no detected tools → back-compat, register all downstream).
+ */
+export function autoMCPSelection(tools: MCPToolStatus[]): string[] | undefined {
+  if (tools.length === 1) return [tools[0].id];
+  return undefined;
+}


### PR DESCRIPTION
Fixes #5344

The setup wizard used to auto-register the grafel MCP server in **every** detected AI tool (Claude Code, Cursor, Windsurf, Codex, Kiro, Antigravity — easily 6). This PR adds a step that lets the user pick which tools get it, in both the CLI and web wizards.

## Detector (`internal/install/mcptools`)
A detector built on the **existing** tool registry (the MCP-supporting `tooladapter`s — no second hard-coded list). For each detected tool it reports: id, display name, config path, config mtime, and whether the config already contains a grafel entry. Backed by new `mcpreg.HasGrafelEntry` / `mcpreg.ConfigModTime` helpers (format-aware for JSON + Codex TOML, never-error).

## Default selection (B + C)
- **(B) smart default:** a tool is checked when its MCP config was modified **recently** (within ~30 days) **or** it already contains a grafel entry (previously configured). Clearly-stale tools are unchecked but stay visible to re-check.
- **(C) remember last choice:** the chosen tool IDs are persisted to **`~/.grafel/mcp-tools.json`** and become the default on subsequent runs (C overrides B once a choice exists).

## Install filtering
`install.Options` gains `MCPTools *[]string`: `nil` = today's behavior (all enabled tools), `[]` = none, `[ids]` = exactly those (filtered on top of the enabled-tools set). The MCP step filters adapters by ID before registration. The chosen set is persisted after a successful apply.

## CLI wizard step
A new wiztui screen **"Configure MCP for which tools?"** (multiselect, B+C default, "Your AI agents that can query this graph", `(configured)` hint) placed after group-docs, before indexing. **Skipped when ≤1 tool is detected.** A huh-based picker mirrors it in the non-TTY fallback.

## Web wizard step
`GET /api/v2/mcp-tools/detect` returns the detected tools + defaults; `POST /api/v2/groups/from-scan` accepts an optional `mcpTools` selection and registers the grafel MCP server in exactly those tools (remembering the choice). A new **MCP** checkbox step (create mode) sits between Detect and Index, seeded from the defaults, skipped when ≤1 tool.

## Flags (non-interactive)
- `--mcp-tools=claude,cursor` → register exactly those.
- `--no-mcp` → register none.
- Neither flag + non-interactive → current behavior (all detected), so scripts are unaffected.

## Tests
- Go: `go build ./...`, `go vet`, `gofmt -l` clean; `go test ./internal/install/... ./internal/cli/... ./internal/dashboard/...` green. New tests cover the B default, C persistence round-trip, install filtering (selection / empty=none / nil=back-compat), the ≤1-tool TUI skip, and the detect endpoint.
- Frontend: `npm ci`, `npm run build`, `tsc --noEmit`, `npm test` all clean; new vitest tests for the default/skip/auto-select helpers.

Not run (per scope): `make dashboard-build`, launchctl, live `~/.grafel`.