### PR TITLE
fix(wizard): finalize all per-repo rows to Done on index completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **Wizard indexing view now marks all per-repo rows Done on successful
+  completion (#5340):** previously a repo could freeze on its last intermediate
+  phase (e.g. "Building communities…") if its final SSE events (centrality →
+  writing → done) arrived after the Rebuild RPC returned done and the forwarder
+  stopped. The overall bar reached "Done · 100%" but the stuck row disagreed. On
+  a successful `IndexOutcome` the view now finalizes every non-terminal row to
+  Done (preserving its files/entities counts); failures leave rows as-is.
 - **Daemon startup no longer deadlocks when `canonicalizePath`'s `os.ReadDir`
   blocks on a slow filesystem (#5330):** at startup the daemon canonicalizes
   each known repo path by walking its ancestors with a per-segment `os.ReadDir`,

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -75,6 +75,24 @@ func (v *indexView) foldEvent(e prog.Event) {
 // done reports whether the indexing screen has fully completed.
 func (v indexView) done() bool { return v.terminal || v.failed }
 
+// finalizeRows marks every per-repo row terminal (Done) on a successful index
+// completion. Because the index as a whole succeeded, every repo is done — but a
+// repo's final SSE events (centrality → writing → done) can arrive after the
+// Rebuild RPC returns done and the forwarder stops, leaving that row frozen on
+// its last intermediate phase (e.g. "Building communities…"). Rather than depend
+// on capturing that final SSE batch, advance any non-terminal row to PhaseDone,
+// preserving its files/entities counts. Rows already done/error are left as-is.
+// Only call this on SUCCESS; on failure rows keep their existing state (#5340).
+func (v *indexView) finalizeRows() {
+	for k, r := range v.rows {
+		if r.Terminal() {
+			continue
+		}
+		r.Phase = prog.PhaseDone
+		v.rows[k] = r
+	}
+}
+
 // overallLabel derives the header phase for the whole index. While per-repo
 // rows are still in flight it reflects the least-advanced repo. Once every repo
 // is terminal but the group-scoped pass (cross-repo links / flows) is still

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -246,6 +246,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.res.indexErr = o.Err
 		} else {
 			m.idx.terminal = true
+			// The whole index succeeded, so every repo is done. Force any row
+			// still on an intermediate phase to Done — its final SSE events may
+			// have arrived after the RPC returned and been dropped (#5340).
+			m.idx.finalizeRows()
 		}
 		m.scr = scrDone
 		m.step = StepDone

--- a/internal/cli/wiztui/view_test.go
+++ b/internal/cli/wiztui/view_test.go
@@ -190,6 +190,116 @@ func TestDoneScreen_RendersCapturedSummary(t *testing.T) {
 	}
 }
 
+// TestModel_SuccessFinalizesStuckRows is the #5340 regression: one repo's last
+// SSE event is an intermediate phase (building_communities) because its final
+// events (centrality → writing → done) arrived after the Rebuild RPC returned
+// and the forwarder stopped. When the success IndexOutcome lands, BOTH rows must
+// render Done — the stuck one is force-finalized — with counts preserved and no
+// spinner glyph on it.
+func TestModel_SuccessFinalizesStuckRows(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+	}}
+	m := newTestModel(d, nilIndex)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // name → docs
+	m = m.update(key("enter")) // docs → index
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex", m.scr)
+	}
+
+	// frontend reaches done; backend freezes mid-flight on building_communities
+	// with real counts attached.
+	m = m.update(progressMsg(progress.Event{RepoSlug: "frontend", Phase: progress.PhaseDone, TS: 1}))
+	m = m.update(progressMsg(progress.Event{
+		RepoSlug: "backend", Phase: progress.PhaseBuildCommunities,
+		FilesDone: 80, FilesTotal: 80, EntitiesSoFar: 421, TS: 2,
+	}))
+
+	// Sanity: backend is NOT yet terminal before the outcome lands.
+	if r := m.idx.rows["backend"]; r.Terminal() {
+		t.Fatalf("backend terminal too early: %q", r.Phase)
+	}
+
+	// Success outcome lands.
+	m = m.update(outcomeMsg(IndexOutcome{Entities: 999, Rels: 10, Elapsed: "1.0s"}))
+	if m.scr != scrDone {
+		t.Fatalf("scr = %v, want scrDone", m.scr)
+	}
+
+	// Both rows must now be terminal Done.
+	for _, slug := range []string{"frontend", "backend"} {
+		r, ok := m.idx.rows[slug]
+		if !ok {
+			t.Fatalf("row %q missing", slug)
+		}
+		if r.Phase != progress.PhaseDone {
+			t.Errorf("row %q phase = %q, want %q", slug, r.Phase, progress.PhaseDone)
+		}
+	}
+	// Counts on the previously-stuck row are preserved.
+	if r := m.idx.rows["backend"]; r.EntitiesSoFar != 421 || r.FilesDone != 80 {
+		t.Errorf("backend counts not preserved: files=%d entities=%d", r.FilesDone, r.EntitiesSoFar)
+	}
+
+	// View renders both as Done with no spinner glyph.
+	out := m.View()
+	if n := strings.Count(out, rowDoneStyle.Render("Done")); n < 2 {
+		t.Errorf("expected >=2 Done rows, got %d:\n%s", n, out)
+	}
+	if strings.Contains(out, m.idx.spin.View()) && m.idx.spin.View() != "" {
+		t.Errorf("spinner still present on finalized rows:\n%s", out)
+	}
+}
+
+// TestModel_FailureDoesNotForceDone asserts a FAILURE outcome leaves an
+// in-flight row on its phase — only success force-finalizes rows.
+func TestModel_FailureDoesNotForceDone(t *testing.T) {
+	v := newIndexView("grp", 2)
+	v.width = 100
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseBuildCommunities, TS: 1})
+
+	// Simulate the failure branch of the outcome handler: no finalizeRows call.
+	v.failed = true
+	v.errMsg = "boom"
+
+	if r := v.rows["backend"]; r.Phase != progress.PhaseBuildCommunities {
+		t.Errorf("backend phase = %q, want %q (failure must not force Done)",
+			r.Phase, progress.PhaseBuildCommunities)
+	}
+
+	// And finalizeRows itself, if not called, leaves rows untouched — guard the
+	// contract by asserting an explicit non-call keeps the row in-flight.
+	if v.rows["backend"].Terminal() {
+		t.Error("row should remain in-flight on failure")
+	}
+}
+
+// TestFinalizeRows_PreservesTerminalAndCounts unit-tests finalizeRows directly:
+// done/error rows are untouched, in-flight rows advance to Done with counts kept.
+func TestFinalizeRows_PreservesTerminalAndCounts(t *testing.T) {
+	v := newIndexView("grp", 3)
+	v.foldEvent(progress.Event{RepoSlug: "a", Phase: progress.PhaseDone, EntitiesSoFar: 5, TS: 1})
+	v.foldEvent(progress.Event{RepoSlug: "b", Phase: progress.PhaseError, TS: 1})
+	v.foldEvent(progress.Event{RepoSlug: "c", Phase: progress.PhaseBuildCommunities, EntitiesSoFar: 7, FilesDone: 3, TS: 1})
+
+	v.finalizeRows()
+
+	if v.rows["a"].Phase != progress.PhaseDone || v.rows["a"].EntitiesSoFar != 5 {
+		t.Errorf("done row a mutated: %+v", v.rows["a"])
+	}
+	if v.rows["b"].Phase != progress.PhaseError {
+		t.Errorf("error row b regressed to %q", v.rows["b"].Phase)
+	}
+	if v.rows["c"].Phase != progress.PhaseDone {
+		t.Errorf("in-flight row c not finalized: %q", v.rows["c"].Phase)
+	}
+	if v.rows["c"].EntitiesSoFar != 7 || v.rows["c"].FilesDone != 3 {
+		t.Errorf("row c counts not preserved: %+v", v.rows["c"])
+	}
+}
+
 // TestDoneScreen_DaemonDownNote: a daemon-down soft completion renders the
 // "registered (not indexed)" note while still showing the captured install
 // counts.


### PR DESCRIPTION
Refs #5340

## Problem
At the end of indexing the wizard TUI shows the overall as "Done · 100%", but a per-repo row can be stuck on its last intermediate phase (e.g. `backend` shows "Building communities…" instead of "Done").

## Root cause
`indexview.go` folds broker SSE events into per-repo rows. `wizard_tui_run.go`'s `forwardBrokerToChannel` forwards events until the Rebuild RPC outcome arrives, then drains a final batch (#5343). But a repo can have several phases left (centrality → writing → done) when the RPC returns done, so its later events are missed and its row freezes on the last-seen phase. The overall reaches terminal from the `IndexOutcome`, but the rows don't.

## Fix (completion-driven, robust)
When the index completes **successfully** (the `IndexOutcome` with done/success reaches the model), the indexing view now marks every per-repo row terminal via a new `finalizeRows()` method: each row whose phase is not already `done`/`error` is advanced to `done`, preserving its files/entities counts and clearing the spinner. The whole index succeeded, so every repo is done — no dependency on capturing the final SSE batch. On **failure** rows are left as-is. This only changes the terminal frame; live per-repo rows during indexing (#5343) and the captured Done summary (#5342) are untouched.

## Tests
- `TestModel_SuccessFinalizesStuckRows`: one repo's last event is `building_communities` with real counts, the other is `done`; after the success `IndexOutcome` both rows render Done, counts preserved, no spinner.
- `TestModel_FailureDoesNotForceDone`: a failure outcome leaves the in-flight row on its phase.
- `TestFinalizeRows_PreservesTerminalAndCounts`: done/error rows untouched, in-flight rows advance to Done with counts kept.

Validated: `go build ./...`, `go vet ./internal/cli/...`, `gofmt -l` empty, `go test ./internal/cli/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)