### PR TITLE
feat(graph): assemble group graph + run algorithms once at group scope (#5353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Added
 
+- **Group-level graph algorithms — foundation (Refs #5353, #5349):** a hidden
+  `grafel group-algo <group> --dry-run` command assembles the union of a
+  group's per-repo graphs (entities + relationships, including the cross-repo
+  phantom CALLS edges already written into each `graph.fb` by the link pass)
+  and runs the Louvain communities + PageRank/Betweenness centrality pass
+  **once** at group scope, printing stats (union counts, communities and how
+  many span >1 repo, modularity, top-10 PageRank with source repo). This is the
+  foundation for group-level communities/centrality so cross-repo hubs rank by
+  their true cross-repo importance. No behavior change to the default path yet —
+  overlay storage (A2) and the debounced/capped/background scheduler (A3) land
+  in follow-ups. New package `internal/graph/groupalgo`.
 - **The wizard (CLI + web) now lets you choose which AI tools get the grafel
   MCP server (#5344):** instead of auto-registering the grafel MCP entry in
   every detected AI tool (Claude Code, Cursor, Windsurf, Codex, Kiro,

--- a/cmd/grafel/group_algo.go
+++ b/cmd/grafel/group_algo.go
@@ -1,0 +1,126 @@
+package main
+
+// group_algo.go — hidden `grafel group-algo <group> --dry-run` subcommand
+// (#5349 A1, epic #5350).
+//
+// Assembles the union of a group's per-repo graphs and runs the graph
+// algorithm pass (Louvain communities + PageRank/Betweenness centrality) ONCE
+// at group scope, then prints stats. With --dry-run (the only mode in A1) it
+// writes NO files and mutates no state — it is a pure read + compute + report.
+//
+// Not part of the public command surface; intercepted before cobra dispatch in
+// main.go (mirrors the xrepo-verify / index-internal hidden harnesses). The
+// scheduling (A3) and overlay persistence (A2) land in follow-up PRs.
+//
+//	grafel group-algo <group> --dry-run
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+)
+
+func runGroupAlgo(args []string) int {
+	dryRun := false
+	var positional []string
+	for _, a := range args {
+		switch a {
+		case "--dry-run":
+			dryRun = true
+		default:
+			positional = append(positional, a)
+		}
+	}
+	if len(positional) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: grafel group-algo <group> --dry-run")
+		return 2
+	}
+	group := positional[0]
+
+	res, err := groupalgo.RunGroupAlgorithms(group)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grafel group-algo: %v\n", err)
+		return 1
+	}
+
+	printGroupAlgoStats(os.Stdout, res, dryRun)
+	return 0
+}
+
+// printGroupAlgoStats reports the union size, community spread (how many
+// communities span more than one repo — the whole point of group scope),
+// modularity, and the top-10 PageRank entities with their source repo.
+func printGroupAlgoStats(w *os.File, res *groupalgo.GroupAlgoResult, dryRun bool) {
+	r := res.Results
+
+	fmt.Fprintf(w, "group-algo: %s", res.Group)
+	if dryRun {
+		fmt.Fprint(w, " (dry-run — no files written)")
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  repos:          %d\n", res.NumRepos)
+	fmt.Fprintf(w, "  union entities: %d\n", res.NumEntities)
+	fmt.Fprintf(w, "  union rels:     %d\n", res.NumRels)
+
+	if r == nil || len(r.CommunityID) == 0 {
+		fmt.Fprintln(w, "  (empty group — no algorithm output)")
+		return
+	}
+
+	// Count communities and how many SPAN more than one repo.
+	reposPerCommunity := map[int]map[string]struct{}{}
+	for entityID, cid := range r.CommunityID {
+		if cid < 0 {
+			continue // -1 ungrouped / -2 not-computed sentinels
+		}
+		repo := res.EntityRepo[entityID]
+		if reposPerCommunity[cid] == nil {
+			reposPerCommunity[cid] = map[string]struct{}{}
+		}
+		if repo != "" {
+			reposPerCommunity[cid][repo] = struct{}{}
+		}
+	}
+	spanning := 0
+	for _, repos := range reposPerCommunity {
+		if len(repos) > 1 {
+			spanning++
+		}
+	}
+
+	fmt.Fprintf(w, "  communities:    %d (%d span >1 repo)\n", r.Stats.NumCommunities, spanning)
+	fmt.Fprintf(w, "  modularity:     %.4f\n", r.Stats.LouvainModularity)
+	fmt.Fprintf(w, "  god nodes:      %d\n", r.Stats.NumGodNodes)
+	fmt.Fprintf(w, "  articulation:   %d\n", r.Stats.NumArticulationPts)
+
+	// Top-10 PageRank entities with their repo.
+	type prRow struct {
+		id   string
+		pr   float64
+		repo string
+	}
+	rows := make([]prRow, 0, len(r.PageRank))
+	for id, pr := range r.PageRank {
+		rows = append(rows, prRow{id: id, pr: pr, repo: res.EntityRepo[id]})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].pr != rows[j].pr {
+			return rows[i].pr > rows[j].pr
+		}
+		return rows[i].id < rows[j].id
+	})
+	n := 10
+	if len(rows) < n {
+		n = len(rows)
+	}
+	fmt.Fprintln(w, "  top-10 pagerank:")
+	for i := 0; i < n; i++ {
+		repo := rows[i].repo
+		if repo == "" {
+			repo = "?"
+		}
+		fmt.Fprintf(w, "    %2d. %-10s  pr=%.6f  %s\n", i+1, repo, rows[i].pr, rows[i].id)
+	}
+}

--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -27,6 +27,13 @@ func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "index-internal" {
 		os.Exit(runIndexInternal(os.Args[2:]))
 	}
+	// Hidden group-level algorithm harness (#5349 A1 / epic #5350). Assembles
+	// the union of a group's per-repo graphs and runs the algorithm pass ONCE
+	// at group scope, printing stats. --dry-run writes no files. Not part of the
+	// public command surface; intercepted before cobra dispatch.
+	if len(os.Args) >= 2 && os.Args[1] == "group-algo" {
+		os.Exit(runGroupAlgo(os.Args[2:]))
+	}
 	// Release acceptance ladder (#5224). Intercepted before cobra dispatch
 	// because it owns its own argv, lifecycle, and exit code (it boots an
 	// isolated in-process daemon and asserts each layer). Lives in cmd/grafel

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -1,0 +1,170 @@
+// Package groupalgo assembles the union of a group's per-repo graphs and runs
+// the graph algorithm pass (Louvain communities + PageRank/Betweenness
+// centrality) ONCE at group scope, rather than per-repo.
+//
+// Motivation (#5349, epic #5350): grafel computes communities + centrality
+// per-repo today (cmd/grafel/index.go Pass 4). For a multi-repo group that is
+// the wrong scope — the algorithms never see cross-repo edges, so the stored
+// community-ids and centrality scores are per-repo fragments. A backend
+// AuthService called by 40 frontend modules has huge *cross-repo* PageRank,
+// but per-repo computation never sees those inbound edges and under-ranks it.
+//
+// This package (Part A1) is the FOUNDATION: pure assembly + a single algorithm
+// pass over the union. It does NOT schedule, persist, or swap an overlay (A2
+// adds storage; A3 adds the debounced/capped/background scheduler).
+//
+// Cross-repo phantom CALLS edges are ALREADY written into each repo's graph.fb
+// by the P5 link pass (internal/cli/links.go runPhantomEdgePass). Entity IDs
+// are group-unique (slug-qualified — that is how phantom edges resolve across
+// repos). So the union is plain concatenation of each repo's entities +
+// relationships; no link re-derivation is needed (decision Q4 in the plan).
+package groupalgo
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// GroupAlgoResult wraps the single group-scope algorithm pass.
+//
+// Results holds the per-entity + corpus-level outputs (community_id, pagerank,
+// betweenness centrality, god-nodes, articulation points, the community
+// summary, and stats). It is nil for an empty group.
+//
+// EntityRepo maps each entity ID to the slug of the repo it came from, so
+// consumers (and the dry-run printer) can attribute a centrality hub or a
+// community to its source repo, and detect communities that SPAN multiple
+// repos. SourceMtimes records each repo's graph.fb mtime (unix nanoseconds) at
+// assembly time — A2 uses this for overlay staleness; A1 just records it.
+type GroupAlgoResult struct {
+	Group        string
+	Results      *graph.AlgorithmResults
+	EntityRepo   map[string]string // entity id -> repo slug
+	SourceMtimes map[string]int64  // repo slug -> graph.fb mtime (unix nanos)
+	NumEntities  int
+	NumRels      int
+	NumRepos     int
+}
+
+// resolveGroup looks up a group by name and loads its config.
+func resolveGroup(group string) (*registry.GroupConfig, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil, err
+	}
+	var ref *registry.GroupRef
+	for i := range groups {
+		if groups[i].Name == group {
+			ref = &groups[i]
+			break
+		}
+	}
+	if ref == nil {
+		return nil, fmt.Errorf("unknown group: %s", group)
+	}
+	cfg, err := registry.LoadGroupConfig(ref.ConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+// AssembleGroupGraph loads every repo's graph.fb and concatenates entities +
+// relationships into a single in-memory group graph. The cross-repo phantom
+// CALLS edges are already present in each repo's graph.fb (post-P5), so the
+// union is a plain concatenation — no link re-derivation.
+//
+// Returns:
+//   - entities: union of every repo's doc.Entities (IDs are group-unique).
+//   - rels:     union of every repo's doc.Relationships (includes the phantom
+//     cross-repo CALLS edges injected by the link pass).
+//   - entityRepo: entity id -> repo slug (for attribution).
+//   - srcMtimes: repo slug -> graph.fb mtime in unix nanoseconds.
+//
+// A repo whose graph.fb is missing (never indexed) is skipped, not an error —
+// the union of the remaining repos is still valid. An unknown group is an
+// error. An empty group yields empty (non-nil) slices and maps.
+func AssembleGroupGraph(group string) (entities []graph.Entity, rels []graph.Relationship, entityRepo map[string]string, srcMtimes map[string]int64, err error) {
+	cfg, err := resolveGroup(group)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	entities = []graph.Entity{}
+	rels = []graph.Relationship{}
+	entityRepo = map[string]string{}
+	srcMtimes = map[string]int64{}
+
+	for _, r := range cfg.Repos {
+		stateDir := daemon.StateDirForRepo(r.Path)
+
+		// Record the graph.fb mtime when present. A repo that was never indexed
+		// has neither graph.fb nor graph.json — skip it (not an error): the
+		// union of the remaining repos is still valid.
+		fbPath := filepath.Join(stateDir, "graph.fb")
+		jsonPath := filepath.Join(stateDir, "graph.json")
+		fbExists := false
+		if fi, statErr := os.Stat(fbPath); statErr == nil {
+			srcMtimes[r.Slug] = fi.ModTime().UnixNano()
+			fbExists = true
+		}
+		if !fbExists {
+			if _, statErr := os.Stat(jsonPath); statErr != nil {
+				// Neither artifact present — repo not yet indexed; skip.
+				continue
+			}
+		}
+
+		doc, lerr := graph.LoadGraphFromDir(stateDir)
+		if lerr != nil {
+			return nil, nil, nil, nil, fmt.Errorf("load graph for repo %q (%s): %w", r.Slug, r.Path, lerr)
+		}
+		if doc == nil {
+			continue
+		}
+		for i := range doc.Entities {
+			entities = append(entities, doc.Entities[i])
+			entityRepo[doc.Entities[i].ID] = r.Slug
+		}
+		rels = append(rels, doc.Relationships...)
+	}
+
+	return entities, rels, entityRepo, srcMtimes, nil
+}
+
+// RunGroupAlgorithms assembles the group union and runs graph.RunAlgorithms
+// ONCE over it. This is the A1 deliverable: a single algorithm pass at group
+// scope so cross-repo edges are finally seen by communities + centrality.
+//
+// An empty group (no entities across any repo) returns a non-nil result whose
+// Results is an empty AlgorithmResults (graph.RunAlgorithms guards len==0), so
+// callers get a safe no-op rather than a panic.
+func RunGroupAlgorithms(group string) (*GroupAlgoResult, error) {
+	entities, rels, entityRepo, srcMtimes, err := AssembleGroupGraph(group)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, _ := resolveGroup(group) // already validated above; ignore re-lookup error
+	numRepos := 0
+	if cfg != nil {
+		numRepos = len(cfg.Repos)
+	}
+
+	res := graph.RunAlgorithms(entities, rels)
+
+	return &GroupAlgoResult{
+		Group:        group,
+		Results:      res,
+		EntityRepo:   entityRepo,
+		SourceMtimes: srcMtimes,
+		NumEntities:  len(entities),
+		NumRels:      len(rels),
+		NumRepos:     numRepos,
+	}, nil
+}

--- a/internal/graph/groupalgo/groupalgo_test.go
+++ b/internal/graph/groupalgo/groupalgo_test.go
@@ -1,0 +1,316 @@
+package groupalgo
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// fixtureGraphs builds two per-repo graphs that, when unioned, form ONE
+// cross-repo subsystem: repo-A defines Service plus a cluster of internal
+// callers; repo-B is a cluster of modules, each of which CALLS Service in
+// repo-A (the cross-repo phantom CALLS edges that the link pass would have
+// written into repo-B's graph.fb).
+//
+// IDs are slug-qualified so they are group-unique, exactly as the real
+// extractor produces them (which is what lets phantom edges resolve across
+// repos — decision Q4).
+func fixtureGraphs() (repoA, repoB *graph.Document, serviceID string) {
+	const aSlug = "svc"
+	const bSlug = "web"
+
+	mkEnt := func(slug, name string) graph.Entity {
+		return graph.Entity{
+			ID:         slug + ":" + name,
+			Name:       name,
+			Kind:       "function",
+			SourceFile: slug + "/" + name + ".go",
+			Language:   "go",
+		}
+	}
+	mkRel := func(from, to string) graph.Relationship {
+		return graph.Relationship{
+			ID:     from + "->" + to,
+			FromID: from,
+			ToID:   to,
+			Kind:   "CALLS",
+		}
+	}
+
+	serviceID = aSlug + ":Service"
+
+	// repo-A: Service + an internal callers cluster (a1..a6 all call Service,
+	// and chain a bit among themselves so Louvain sees a community).
+	repoA = &graph.Document{Version: 1, Repo: aSlug}
+	repoA.Entities = append(repoA.Entities, mkEnt(aSlug, "Service"))
+	for _, n := range []string{"a1", "a2", "a3", "a4", "a5", "a6"} {
+		repoA.Entities = append(repoA.Entities, mkEnt(aSlug, n))
+		repoA.Relationships = append(repoA.Relationships, mkRel(aSlug+":"+n, serviceID))
+	}
+	// internal chaining within A
+	repoA.Relationships = append(repoA.Relationships,
+		mkRel(aSlug+":a1", aSlug+":a2"),
+		mkRel(aSlug+":a2", aSlug+":a3"),
+		mkRel(aSlug+":a3", aSlug+":a4"),
+	)
+
+	// repo-B: a module cluster (b1..b6) chained among themselves, each calling
+	// into repo-A's Service via a cross-repo phantom CALLS edge.
+	repoB = &graph.Document{Version: 1, Repo: bSlug}
+	for _, n := range []string{"b1", "b2", "b3", "b4", "b5", "b6"} {
+		repoB.Entities = append(repoB.Entities, mkEnt(bSlug, n))
+		// CROSS-REPO edge: repo-B's bN -> repo-A's Service.
+		repoB.Relationships = append(repoB.Relationships, mkRel(bSlug+":"+n, serviceID))
+	}
+	repoB.Relationships = append(repoB.Relationships,
+		mkRel(bSlug+":b1", bSlug+":b2"),
+		mkRel(bSlug+":b2", bSlug+":b3"),
+		mkRel(bSlug+":b3", bSlug+":b4"),
+		mkRel(bSlug+":b4", bSlug+":b5"),
+	)
+
+	return repoA, repoB, serviceID
+}
+
+// TestUnion_CrossRepoCommunityAndPageRank is the A1 acceptance thesis, exercised
+// in-memory: running RunAlgorithms over the UNION must (a) place entities from
+// both repos in a single community, and (b) give Service a strictly higher
+// PageRank than it gets from repo-A alone (proving the cross-repo inbound edges
+// from repo-B are now seen).
+func TestUnion_CrossRepoCommunityAndPageRank(t *testing.T) {
+	repoA, repoB, serviceID := fixtureGraphs()
+
+	// Per-repo (repo-A only) PageRank — the OLD per-repo scope. Compare Service
+	// against a repo-A leaf peer (a1) that has the same kind of internal edges.
+	// PageRank is L1-normalised (the whole vector sums to ~1), so the absolute
+	// score of a node MECHANICALLY shrinks as the union grows — the meaningful,
+	// scale-invariant signal is Service's IMPORTANCE relative to its peers. The
+	// thesis of #5349 is precisely that cross-repo inbound edges raise Service's
+	// relative importance; we measure it as the Service/peer PageRank ratio.
+	perRepo := graph.RunAlgorithms(repoA.Entities, repoA.Relationships)
+	perRepoRatio := perRepo.PageRank[serviceID] / perRepo.PageRank["svc:a1"]
+
+	// Group union.
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, repoA.Entities...)
+	ents = append(ents, repoB.Entities...)
+	rels = append(rels, repoA.Relationships...)
+	rels = append(rels, repoB.Relationships...)
+
+	entityRepo := map[string]string{}
+	for _, e := range repoA.Entities {
+		entityRepo[e.ID] = "svc"
+	}
+	for _, e := range repoB.Entities {
+		entityRepo[e.ID] = "web"
+	}
+
+	group := graph.RunAlgorithms(ents, rels)
+	groupRatio := group.PageRank[serviceID] / group.PageRank["svc:a1"]
+
+	// (b) Service's relative PageRank RISES at group scope: the six extra
+	// cross-repo inbound CALLS from repo-B make Service a bigger hub relative to
+	// a repo-A leaf than per-repo computation could ever see.
+	if !(groupRatio > perRepoRatio) {
+		t.Errorf("expected group Service/peer PageRank ratio > per-repo: group=%.4f per-repo=%.4f", groupRatio, perRepoRatio)
+	}
+	t.Logf("Service/peer PageRank ratio: per-repo=%.4f group=%.4f (rise=%.4f)", perRepoRatio, groupRatio, groupRatio-perRepoRatio)
+
+	// (b') And in the group, Service must out-rank a repo-B module that has NO
+	// cross-repo inbound (b1 only receives one internal edge), confirming the
+	// cross-repo inbound edges are what lift it.
+	if !(group.PageRank[serviceID] > group.PageRank["web:b1"]) {
+		t.Errorf("expected group PageRank(Service) > PageRank(web:b1): %.6f vs %.6f", group.PageRank[serviceID], group.PageRank["web:b1"])
+	}
+
+	// (a) A single community spans BOTH repos. Find the community Service is in,
+	// confirm it contains at least one entity from each repo.
+	svcComm, ok := group.CommunityID[serviceID]
+	if !ok {
+		t.Fatalf("Service has no community id in group result")
+	}
+	sawSvcRepo, sawWebRepo := false, false
+	for id, cid := range group.CommunityID {
+		if cid != svcComm {
+			continue
+		}
+		switch entityRepo[id] {
+		case "svc":
+			sawSvcRepo = true
+		case "web":
+			sawWebRepo = true
+		}
+	}
+	if !(sawSvcRepo && sawWebRepo) {
+		// Report community spread for debugging.
+		spread := map[int]map[string]int{}
+		for id, cid := range group.CommunityID {
+			if spread[cid] == nil {
+				spread[cid] = map[string]int{}
+			}
+			spread[cid][entityRepo[id]]++
+		}
+		t.Fatalf("Service's community %d does not span both repos (svc=%v web=%v). spread=%v",
+			svcComm, sawSvcRepo, sawWebRepo, spread)
+	}
+	t.Logf("Service community %d spans both repos (cross-repo subsystem formed)", svcComm)
+}
+
+// TestRunAlgorithms_EmptyGroup_NoPanic confirms the zero-entity guard.
+func TestRunAlgorithms_EmptyGroup_NoPanic(t *testing.T) {
+	res := graph.RunAlgorithms(nil, nil)
+	if res == nil {
+		t.Fatal("expected non-nil empty result")
+	}
+	if len(res.CommunityID) != 0 || len(res.PageRank) != 0 {
+		t.Errorf("expected empty maps, got community=%d pagerank=%d", len(res.CommunityID), len(res.PageRank))
+	}
+}
+
+// writeFixtureRepo writes a tiny graph.fb into the daemon state dir for repoPath
+// and returns a registry.Repo entry pointing at it.
+func writeFixtureRepo(t *testing.T, slug, repoPath string, doc *graph.Document) registry.Repo {
+	t.Helper()
+	stateDir := daemon.StateDirForRepo(repoPath)
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write fixture graph.fb for %s: %v", slug, err)
+	}
+	return registry.Repo{Slug: slug, Path: repoPath}
+}
+
+// TestAssembleGroupGraph_OnDisk is the integration test: register a real
+// 2-repo group with on-disk graph.fb files and assert AssembleGroupGraph +
+// RunGroupAlgorithms concatenate them and form a cross-repo community.
+func TestAssembleGroupGraph_OnDisk(t *testing.T) {
+	// Isolate all grafel state into the test tempdir.
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoA, repoB, serviceID := fixtureGraphs()
+	// Use non-git working-tree dirs; StateDirForRepo tolerates non-git (default ref).
+	pathA := filepath.Join(root, "repoA")
+	pathB := filepath.Join(root, "repoB")
+	rA := writeFixtureRepo(t, "svc", pathA, repoA)
+	rB := writeFixtureRepo(t, "web", pathB, repoB)
+
+	// Register the group config + registry entry.
+	cfgPath, err := registry.ConfigPathFor("acme")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "acme", Repos: []registry.Repo{rA, rB}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("acme", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	// Assemble.
+	ents, rels, entityRepo, srcMtimes, err := AssembleGroupGraph("acme")
+	if err != nil {
+		t.Fatalf("AssembleGroupGraph: %v", err)
+	}
+	wantEnts := len(repoA.Entities) + len(repoB.Entities)
+	wantRels := len(repoA.Relationships) + len(repoB.Relationships)
+	if len(ents) != wantEnts {
+		t.Errorf("union entities=%d want=%d", len(ents), wantEnts)
+	}
+	if len(rels) != wantRels {
+		t.Errorf("union rels=%d want=%d", len(rels), wantRels)
+	}
+	if entityRepo[serviceID] != "svc" {
+		t.Errorf("Service attributed to repo %q want svc", entityRepo[serviceID])
+	}
+	if entityRepo["web:b1"] != "web" {
+		t.Errorf("web:b1 attributed to repo %q want web", entityRepo["web:b1"])
+	}
+	if _, ok := srcMtimes["svc"]; !ok {
+		t.Errorf("srcMtimes missing svc graph.fb mtime")
+	}
+	if _, ok := srcMtimes["web"]; !ok {
+		t.Errorf("srcMtimes missing web graph.fb mtime")
+	}
+
+	// RunGroupAlgorithms end-to-end.
+	res, err := RunGroupAlgorithms("acme")
+	if err != nil {
+		t.Fatalf("RunGroupAlgorithms: %v", err)
+	}
+	if res.NumRepos != 2 {
+		t.Errorf("NumRepos=%d want 2", res.NumRepos)
+	}
+	if res.Results == nil || len(res.Results.CommunityID) == 0 {
+		t.Fatalf("expected non-empty algorithm results")
+	}
+	// Cross-repo community formed.
+	svcComm := res.Results.CommunityID[serviceID]
+	sawSvc, sawWeb := false, false
+	for id, cid := range res.Results.CommunityID {
+		if cid != svcComm {
+			continue
+		}
+		switch res.EntityRepo[id] {
+		case "svc":
+			sawSvc = true
+		case "web":
+			sawWeb = true
+		}
+	}
+	if !(sawSvc && sawWeb) {
+		t.Errorf("on-disk: Service community %d does not span both repos (svc=%v web=%v)", svcComm, sawSvc, sawWeb)
+	}
+}
+
+// TestRunGroupAlgorithms_EmptyGroup confirms a registered group with no indexed
+// repos yields an empty (non-nil) result and does not panic.
+func TestRunGroupAlgorithms_EmptyGroup(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	// A repo path that was never indexed (no graph.fb) — skipped during assembly.
+	repoPath := filepath.Join(root, "ghost")
+	cfgPath, err := registry.ConfigPathFor("empty")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "empty", Repos: []registry.Repo{{Slug: "ghost", Path: repoPath}}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("empty", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	res, err := RunGroupAlgorithms("empty")
+	if err != nil {
+		t.Fatalf("RunGroupAlgorithms (empty): %v", err)
+	}
+	if res.NumEntities != 0 {
+		t.Errorf("NumEntities=%d want 0", res.NumEntities)
+	}
+	if res.Results == nil {
+		t.Fatal("expected non-nil Results even for empty group")
+	}
+	if len(res.Results.CommunityID) != 0 {
+		t.Errorf("expected empty CommunityID, got %d", len(res.Results.CommunityID))
+	}
+}
+
+// TestUnknownGroup confirms an unregistered group name is an error, not a panic.
+func TestUnknownGroup(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+	if _, err := RunGroupAlgorithms("does-not-exist"); err == nil {
+		t.Fatal("expected error for unknown group")
+	}
+}


### PR DESCRIPTION
Refs #5353, #5349

## What this builds (A1 — foundation only)

Part A1 of the group-level graph-algorithms epic (#5350): run Louvain
communities + PageRank/Betweenness centrality **once over the assembled group
graph** instead of per-repo, so cross-repo edges are finally seen.

- **`internal/graph/groupalgo`** (new package):
  - `AssembleGroupGraph(group)` — enumerates the group's repos via the
    registry, loads each repo's `graph.fb` with `graph.LoadGraphFromDir` (same
    load pattern as `algo_demand.go:41`), and concatenates entities +
    relationships. The cross-repo phantom CALLS edges are already present in each
    `graph.fb` post-P5, and entity IDs are group-unique, so the union is a plain
    concatenation — **no link re-derivation**. Returns `(entities, rels,
    entityRepo, srcMtimes)`; records each repo's `graph.fb` mtime; skips
    never-indexed repos.
  - `RunGroupAlgorithms(group)` — calls `graph.RunAlgorithms` **once** on the
    union and wraps `*graph.AlgorithmResults` with per-entity repo attribution +
    source mtimes. Empty group → empty (non-nil) result, no panic; unknown group
    → error.
- **Hidden `grafel group-algo <group> --dry-run`** (`cmd/grafel`, intercepted
  before cobra dispatch like `xrepo-verify`/`index-internal`) — prints union
  entity/rel counts, # communities and how many span >1 repo, modularity,
  god/articulation counts, and the top-10 PageRank entities with their source
  repo. Writes no files.
- Per-repo Pass 4 (`cmd/grafel/index.go`) left untouched (A3 removes it). No
  scheduling or overlay storage yet (A2/A3).

## Acceptance test outcome — validates #5350's premise ✅

Fixture: repo-A defines `Service` + an internal caller cluster; repo-B is a
module cluster where every module has a cross-repo CALLS edge into repo-A's
`Service`.

- **A single cross-repo community forms.** `Service`'s community contains
  entities from BOTH repos (asserted in-memory and via an on-disk 2-repo
  registered-group fixture). Per-repo computation can never produce this.
- **`Service`'s relative PageRank rises at group scope.** PageRank is
  L1-normalised, so a node's *absolute* score mechanically shrinks as the union
  grows; the scale-invariant signal is importance relative to peers. The
  `Service`/peer (repo-A leaf) PageRank ratio rises **5.84 → 10.59** at group
  scope, and in the group `Service` out-ranks a repo-B module with no cross-repo
  inbound — proving the cross-repo inbound edges are now seen. (Note: I assert
  the *relative* ratio rather than the raw absolute value the issue text
  literally lists, because normalization makes the raw-absolute claim false on a
  larger union; the relative metric is the faithful, robust expression of the
  same thesis.)
- **Zero-entity group → empty result, no panic**; unknown group → error.

Tests: `internal/graph/groupalgo/groupalgo_test.go` (in-memory thesis test +
on-disk integration test with a real registered group under isolated
`GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT` + empty/unknown-group guards).

## Q4 — phantom cross-repo edge IDs are group-unique ✅

Confirmed by reading `internal/links/phantom_edges.go` + `internal/cli/links.go`:
- The **only** cross-repo edges written back into `graph.fb` are the P5 phantom
  **CALLS** edges (`PromoteToPhantomEdges`, `links.go:369`/`:373`). `MethodHTTP`,
  `kafka_topic`, `ws_channel` are *methods* of CALLS-relation links and all
  promote to `Kind="CALLS"` phantom edges. Dataflow / sameas / import /
  shared_label links stay sidecar-only and are **not** in `graph.fb` — so they
  do not affect the A1 union.
- A phantom edge's `ToID = c.targetID` is the **real** target entity's ID inside
  the target repo. Entity IDs are produced by `graph.EntityID` (`graph.go:111`),
  which salts the hash with a per-repo tag → globally unique across the group.
  So in the concatenated union the phantom edge's endpoints resolve to the
  actual cross-repo entities. **Group-uniqueness verified for the CALLS family;
  no other edge kind reaches the union.**

## Validation

`go build ./...` ✅ · `go vet ./internal/graph/... ./cmd/grafel/...` ✅ ·
`gofmt -l` empty ✅ · `go test ./internal/graph/... ./internal/cli/...` green ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)