### PR TITLE
fix(install): robust latest-version resolution in install.bat (Windows 404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows installer latest-version auto-resolution produced garbage → 404
+  (Refs #5318):** `install.bat` extracted the release tag from the
+  `/releases/latest` redirect `location:` header with `%~nx`, which treats its
+  argument as a `\`-separated Windows path — but the header value is a
+  `/`-separated URL, so on some Windows builds it yielded garbage (e.g.
+  `LOC:=`) and built a 404 download URL. The tag is now sliced from the URL
+  with a delimiter-correct substring (`!LOC:*/tag/=!`, after the CR scrub),
+  with a GitHub releases-API fallback (`api.github.com/.../releases/latest`,
+  `tag_name`) when the redirect parse fails, and a sanity guard that rejects any
+  resolved version that does not look like a tag (must start with `v`, contain a
+  digit, and contain no `/`) before attempting a download — surfacing the
+  explicit `GRAFEL_VERSION` hint instead of a confusing 404. `install.ps1`
+  already used proper URI/regex parsing and is unaffected.
+
 ---
 
 ## [0.1.2] — 2026-06-23

--- a/install.bat
+++ b/install.bat
@@ -62,18 +62,63 @@ if defined GRAFEL_VERSION (
 if not defined VERSION (
     REM /releases/latest 302-redirects to /releases/tag/<version>. curl -sI
     REM prints the redirect target in the "location:" header; parse the tag.
-    for /f "tokens=2 delims= " %%H in ('curl -fsSLI "https://github.com/%REPO%/releases/latest" 2^>nul ^| findstr /I "^location:"') do (
-        set "LOC=%%H"
+    REM The header value is the FULL url, e.g.
+    REM   location: https://github.com/<repo>/releases/tag/vX.Y.Z<CR>
+    REM tokens=2 with a single space delim keeps the whole url (incl. its ':'
+    REM and '/') as one token. We must NOT use %%~nx here: that modifier treats
+    REM its arg as a '\'-separated Windows path, but the value is a '/'-separated
+    REM URL, so on some Windows builds it returns garbage (e.g. "LOC:=") and
+    REM yields a 404 download. Instead strip everything up to and including
+    REM "/tag/" with a delayed-expansion substring, leaving just the tag.
+    for /f "tokens=1,* delims= " %%H in ('curl -fsSLI "https://github.com/%REPO%/releases/latest" 2^>nul ^| findstr /I "^location:"') do (
+        set "LOC=%%I"
     )
     if defined LOC (
-        REM strip the trailing CR that HTTP headers carry, then take the last
-        REM path segment (the tag) via %%~nx.
+        REM scrub the trailing CR that HTTP headers carry FIRST, so the tag has
+        REM no stray CR, THEN slice off the URL prefix up to and incl. "/tag/".
         if defined CR set "LOC=!LOC:%CR%=!"
-        for %%T in ("!LOC!") do set "VERSION=%%~nxT"
+        REM only slice if the marker is actually present (substring replace is a
+        REM no-op when "/tag/" is absent, which would leave the full URL — we
+        REM guard against that below by validating the resulting VERSION).
+        set "VERSION=!LOC:*/tag/=!"
     )
 )
+
+REM --- fallback: GitHub releases API if the redirect parse failed or produced
+REM     something that still contains a URL separator (no real tag has '/'). ---
+set "BADVER="
+if defined VERSION if not "!VERSION:/=!"=="!VERSION!" set "BADVER=1"
+if not defined VERSION set "BADVER=1"
+if defined BADVER (
+    set "VERSION="
+    for /f "tokens=2 delims=:, " %%T in ('curl -fsSL "https://api.github.com/repos/%REPO%/releases/latest" 2^>nul ^| findstr /I /C:"tag_name"') do (
+        if not defined VERSION (
+            set "RAW=%%T"
+            REM strip surrounding double quotes from the JSON string value.
+            set "RAW=!RAW:"=!"
+            set "VERSION=!RAW!"
+        )
+    )
+)
+
 if not defined VERSION (
     echo error: failed to resolve latest release tag. Set GRAFEL_VERSION explicitly ^(e.g. v0.1.0^).
+    goto :fail
+)
+
+REM --- sanity-guard the resolved VERSION before building any download URL ---
+REM A valid tag looks like v<digits>... : it starts with 'v' and contains a
+REM digit, and must NOT contain a '/' (which would mean we kept part of a URL).
+REM Reject anything else with the explicit GRAFEL_VERSION hint instead of
+REM letting a garbage version produce a confusing 404.
+set "VERBAD="
+if not "!VERSION:~0,1!"=="v" set "VERBAD=1"
+if not "!VERSION:/=!"=="!VERSION!" set "VERBAD=1"
+set "HASDIGIT="
+for %%D in (0 1 2 3 4 5 6 7 8 9) do if not "!VERSION:%%D=!"=="!VERSION!" set "HASDIGIT=1"
+if not defined HASDIGIT set "VERBAD=1"
+if defined VERBAD (
+    echo error: resolved an invalid release tag ^("!VERSION!"^). Set GRAFEL_VERSION explicitly ^(e.g. v0.1.0^).
     goto :fail
 )
 

--- a/internal/install/installscript_version_test.go
+++ b/internal/install/installscript_version_test.go
@@ -1,0 +1,129 @@
+// installscript_version_test.go locks the tag-extraction *string operations*
+// performed by the Windows installer (install.bat) when it resolves the latest
+// release version. We cannot run cmd.exe in CI, so instead we model the exact
+// string transforms the batch script applies and assert they recover the tag
+// from the real GitHub "location:" redirect header — guarding against the
+// regression in #5318, where `%~nx` (a '\'-separated Windows PATH modifier) was
+// applied to a '/'-separated URL and produced garbage (e.g. "LOC:=") → a 404
+// download.
+//
+// install.bat resolves the tag with the equivalent of:
+//
+//	LOC     = <value of the "location:" header, CR stripped>
+//	VERSION = LOC with everything up to and including "/tag/" removed
+//	          ( batch: set "VERSION=!LOC:*/tag/=!" )
+//
+// followed by a sanity guard: VERSION must start with 'v', must NOT contain
+// '/', and must contain a digit.
+package install
+
+import (
+	"strings"
+	"testing"
+)
+
+// batExtractTagFromLocation mirrors `set "VERSION=!LOC:*/tag/=!"` after the CR
+// scrub: it strips everything up to and including the first "/tag/". When the
+// marker is absent the batch substring replace is a no-op, so we return the
+// input unchanged (which the sanity guard then rejects).
+func batExtractTagFromLocation(loc string) string {
+	loc = strings.TrimRight(loc, "\r")
+	const marker = "/tag/"
+	if i := strings.Index(loc, marker); i >= 0 {
+		return loc[i+len(marker):]
+	}
+	return loc
+}
+
+// batVersionLooksValid mirrors the install.bat sanity guard: starts with 'v',
+// contains no '/', and contains at least one digit.
+func batVersionLooksValid(v string) bool {
+	if !strings.HasPrefix(v, "v") {
+		return false
+	}
+	if strings.Contains(v, "/") {
+		return false
+	}
+	return strings.ContainsAny(v, "0123456789")
+}
+
+func TestBatExtractTagFromLocation(t *testing.T) {
+	cases := []struct {
+		name   string
+		loc    string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "real redirect header value",
+			loc:    "https://github.com/cajasmota/grafel/releases/tag/v0.1.2",
+			want:   "v0.1.2",
+			wantOK: true,
+		},
+		{
+			name:   "trailing CR is scrubbed before extraction",
+			loc:    "https://github.com/cajasmota/grafel/releases/tag/v0.1.2\r",
+			want:   "v0.1.2",
+			wantOK: true,
+		},
+		{
+			name:   "two-digit minor/patch",
+			loc:    "https://github.com/cajasmota/grafel/releases/tag/v10.20.30\r",
+			want:   "v10.20.30",
+			wantOK: true,
+		},
+		{
+			name:   "unexpected redirect without /tag/ is left intact and rejected",
+			loc:    "https://github.com/login\r",
+			want:   "https://github.com/login",
+			wantOK: false, // contains '/', sanity guard rejects → triggers fallback/error
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := batExtractTagFromLocation(tc.loc)
+			if got != tc.want {
+				t.Fatalf("batExtractTagFromLocation(%q) = %q, want %q", tc.loc, got, tc.want)
+			}
+			if ok := batVersionLooksValid(got); ok != tc.wantOK {
+				t.Fatalf("batVersionLooksValid(%q) = %v, want %v", got, ok, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestBatRejectsNxStyleGarbage documents the #5318 regression: the OLD logic
+// applied `%~nx` to the URL and yielded garbage. Whatever garbage slips through,
+// the sanity guard must reject it BEFORE building a (404) download URL.
+func TestBatRejectsNxStyleGarbage(t *testing.T) {
+	garbage := []string{
+		"LOC:=",  // the exact value the tester observed on Windows 11 26200
+		"",       // empty
+		"grafel", // no leading v, no digit
+		"https://github.com/cajasmota/grafel/releases/tag/v0.1.2", // full URL kept (no extraction)
+	}
+	for _, g := range garbage {
+		if batVersionLooksValid(g) {
+			t.Fatalf("sanity guard accepted garbage version %q; it must be rejected", g)
+		}
+	}
+}
+
+// batStripQuotes mirrors `set "RAW=!RAW:"=!"` in the API fallback: remove all
+// double quotes from the JSON string token.
+func batStripQuotes(s string) string { return strings.ReplaceAll(s, `"`, "") }
+
+// TestBatAPIFallbackTagExtraction models the API fallback's token handling:
+// `for /f "tokens=2 delims=:, "` over a `"tag_name": "vX.Y.Z",` line yields the
+// quoted version token, then the quotes are stripped.
+func TestBatAPIFallbackTagExtraction(t *testing.T) {
+	// token2 as cmd.exe would split `"tag_name": "v0.1.2",` on delims `:`,`,`,` `.
+	token2 := `"v0.1.2"`
+	got := batStripQuotes(token2)
+	if got != "v0.1.2" {
+		t.Fatalf("API fallback extraction = %q, want %q", got, "v0.1.2")
+	}
+	if !batVersionLooksValid(got) {
+		t.Fatalf("API fallback produced invalid version %q", got)
+	}
+}


### PR DESCRIPTION
Refs #5318. Confirmed by a real Windows tester (Windows 11, build 26200).

## Root cause — the `%~nx`-on-URL bug
`install.bat` resolved the latest release tag by HEAD-curling
`https://github.com/<repo>/releases/latest`, reading the `location:` redirect
header, scrubbing CR, then:

```bat
for %%T in ("!LOC!") do set "VERSION=%%~nxT"
```

`%~nx` is a **Windows-path** modifier: it splits on `\` (and treats `:` as a
drive separator). The header value is a `/`-separated **URL**
(`https://github.com/<repo>/releases/tag/vX.Y.Z`), which has no `\`, so `%~nx`
does not extract the last path segment. On the tester's machine it produced
`LOC:=`, which became `grafel_LOC:=_windows_x86_64.zip` → a **404** download →
install failed. (The `EnableDelayedExpansion` and CR capture were already
correct; the defect was purely the `~nx` path-extraction of a URL.)

## Fix
1. **No more `%~nx`.** Keep the full URL as one token
   (`tokens=1,* delims= `) and slice the tag with a delimiter-correct
   delayed substring, **after** the CR scrub:
   ```bat
   if defined CR set "LOC=!LOC:%CR%=!"
   set "VERSION=!LOC:*/tag/=!"   REM strips up to & incl. "/tag/"
   ```
2. **API fallback.** If the redirect parse yields nothing — or something that
   still contains a `/` (no real tag does) — query
   `https://api.github.com/repos/<repo>/releases/latest` and extract
   `"tag_name": "vX.Y.Z"` via `findstr` + `for /f`, stripping the JSON quotes.
3. **Sanity guard.** Before building any download URL, reject a VERSION that
   does not look like a tag (must start with `v`, contain a digit, and contain
   no `/`) and surface the explicit `GRAFEL_VERSION` hint — so no future
   garbage version can produce a confusing 404.
4. `GRAFEL_VERSION` override (the tester's current workaround) and the final
   clear error are preserved.
5. `install.ps1` already uses proper URI/regex parsing
   (`Resolve-Version`, `'/tag/([^/]+)/?$'`) — **unaffected, left as-is.**

## Hand-trace (real header value)
```
location: https://github.com/cajasmota/grafel/releases/tag/v0.1.2<CR>
 tokens=1,* delims=(space) -> %%I = https://.../tag/v0.1.2<CR>
 LOC := that ; scrub CR -> https://github.com/.../releases/tag/v0.1.2
 VERSION = !LOC:*/tag/=! -> "v0.1.2"            ✓
 BADVER? no '/' -> skip API ; VERBAD? v✓ digit✓ no-/✓ -> proceed
 => VERSION = v0.1.2
```
Failure modes also traced: curl-fail → API fallback → final error; redirect
without `/tag/` → substring no-op leaves URL → guard rejects '/' → fallback/
error (never a 404 attempt); old `LOC:=` garbage → rejected by the guard.

## Validation
cmd.exe can't run in CI, so the tag-extraction **string operations** are
locked by a Linux-runnable Go test
(`internal/install/installscript_version_test.go`): asserts
`.../releases/tag/v0.1.2` → `v0.1.2`, CR scrub, the no-`/tag/` reject, the
`LOC:=` garbage reject, and the API-fallback quote strip. `go test ./internal/install/` passes.
**Final validation is the Windows tester re-running the installer.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)