### PR TITLE
feat(graph): group-algo overlay storage + atomic swap + apply at group load (#5354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Added
+
+- **Group-algo overlay storage + atomic swap, applied at MCP group load
+  (Refs #5354, #5349):** the group-scope algorithm pass (A1) now persists its
+  result as a single `~/.grafel/groups/<group>-algo.json` overlay
+  (`entity_id → {community_id, pagerank, centrality, is_god_node,
+  is_articulation_point}` + a community summary, stats, and per-repo
+  `source_mtimes`). The overlay is written via an atomic temp-file + rename, so
+  a reader observes either the whole previous overlay or the whole new one —
+  never a torn read across files. At MCP group load the overlay, when present
+  and not stale (every recorded repo's current `graph.fb` mtime still matches),
+  is stamped onto the in-memory entities by ID and surfaced as
+  `LoadedGroup.Communities`; it is memoized by mtime so a mid-session swap
+  reloads only the overlay. **Absence-tolerant:** a missing or stale overlay is
+  a no-op — entities keep whatever `graph.fb` carried (today's per-repo values)
+  — so there is **no behavior change until an overlay file exists** (only A3's
+  scheduler will produce one). The hidden `grafel group-algo` command gains a
+  `--write` flag to persist the overlay; the default stays dry.
+
 ### Fixed
 
 - **Windows installer latest-version auto-resolution produced garbage → 404

--- a/cmd/grafel/group_algo.go
+++ b/cmd/grafel/group_algo.go
@@ -1,18 +1,21 @@
 package main
 
-// group_algo.go — hidden `grafel group-algo <group> --dry-run` subcommand
-// (#5349 A1, epic #5350).
+// group_algo.go — hidden `grafel group-algo <group> [--dry-run|--write]`
+// subcommand (#5349 A1/A2, epic #5350).
 //
 // Assembles the union of a group's per-repo graphs and runs the graph
 // algorithm pass (Louvain communities + PageRank/Betweenness centrality) ONCE
-// at group scope, then prints stats. With --dry-run (the only mode in A1) it
-// writes NO files and mutates no state — it is a pure read + compute + report.
+// at group scope, then prints stats. With --dry-run (the A1 default) it writes
+// NO files and mutates no state — a pure read + compute + report. With --write
+// (A2) it additionally persists the result as the <group>-algo.json overlay via
+// an atomic temp+rename swap (groupalgo.WriteOverlayFromResult); A3's scheduler
+// will be the real trigger for this path.
 //
 // Not part of the public command surface; intercepted before cobra dispatch in
 // main.go (mirrors the xrepo-verify / index-internal hidden harnesses). The
-// scheduling (A3) and overlay persistence (A2) land in follow-up PRs.
+// scheduling (A3) lands in a follow-up PR.
 //
-//	grafel group-algo <group> --dry-run
+//	grafel group-algo <group> [--dry-run|--write]
 
 import (
 	"fmt"
@@ -24,18 +27,29 @@ import (
 
 func runGroupAlgo(args []string) int {
 	dryRun := false
+	write := false
 	var positional []string
 	for _, a := range args {
 		switch a {
 		case "--dry-run":
 			dryRun = true
+		case "--write":
+			write = true
 		default:
 			positional = append(positional, a)
 		}
 	}
 	if len(positional) != 1 {
-		fmt.Fprintln(os.Stderr, "usage: grafel group-algo <group> --dry-run")
+		fmt.Fprintln(os.Stderr, "usage: grafel group-algo <group> [--dry-run|--write]")
 		return 2
+	}
+	if write && dryRun {
+		fmt.Fprintln(os.Stderr, "grafel group-algo: --write and --dry-run are mutually exclusive")
+		return 2
+	}
+	// Default (no flag) stays dry — A1 behavior is preserved.
+	if !write {
+		dryRun = true
 	}
 	group := positional[0]
 
@@ -43,6 +57,13 @@ func runGroupAlgo(args []string) int {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "grafel group-algo: %v\n", err)
 		return 1
+	}
+
+	if write {
+		if werr := groupalgo.WriteOverlayFromResult(res); werr != nil {
+			fmt.Fprintf(os.Stderr, "grafel group-algo: write overlay: %v\n", werr)
+			return 1
+		}
 	}
 
 	printGroupAlgoStats(os.Stdout, res, dryRun)
@@ -58,6 +79,8 @@ func printGroupAlgoStats(w *os.File, res *groupalgo.GroupAlgoResult, dryRun bool
 	fmt.Fprintf(w, "group-algo: %s", res.Group)
 	if dryRun {
 		fmt.Fprint(w, " (dry-run — no files written)")
+	} else {
+		fmt.Fprint(w, " (overlay written)")
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintf(w, "  repos:          %d\n", res.NumRepos)

--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -1,0 +1,237 @@
+package groupalgo
+
+// overlay.go — group-algo OVERLAY storage + atomic swap (#5349 A2, epic #5350).
+//
+// The group-scope algorithm pass (A1) produces per-entity community-ids,
+// PageRank, betweenness centrality, god-node / articulation-point flags, plus a
+// community summary and corpus stats. A2 persists that result as a SINGLE
+// overlay file:
+//
+//	$GRAFEL_HOME (or ~/.grafel)/groups/<group>-algo.json
+//
+// living alongside the existing <group>-links*.json sidecars. A single file is
+// the key design decision (plan §2.3 option C): one os.Rename = one atomic swap
+// point, so a reader either sees the entire previous overlay or the entire new
+// one — never a torn read across N files. The write uses the temp-file +
+// rename pattern from internal/daemon/algo/cache.go:writeToDisk.
+//
+// Staleness: the overlay records each source repo's graph.fb mtime
+// (source_mtimes[slug] → unix nanos) at compute time. It is stale when ANY
+// repo's current graph.fb mtime differs from the stored value — a general/N
+// version of cache.go:readFromDisk's single-mtime check. A stale (or absent)
+// overlay is NOT applied: consumers fall back to whatever the per-repo graph.fb
+// carried (today's per-repo algo values, or the -2/0 sentinels). This makes the
+// apply path absence-tolerant — there is NO behavior change until an overlay
+// file actually exists (which only A3's scheduler produces in the live daemon).
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// EntityOverlay is the per-entity slice of the group-algo result. Fields mirror
+// the graph.Entity algo attributes (graph.go:84-89) so the MCP apply step can
+// copy them straight onto the in-memory entities by ID.
+type EntityOverlay struct {
+	CommunityID         int     `json:"community_id"`
+	PageRank            float64 `json:"pagerank"`
+	Centrality          float64 `json:"centrality"`
+	IsGodNode           bool    `json:"is_god_node,omitempty"`
+	IsArticulationPoint bool    `json:"is_articulation_point,omitempty"`
+}
+
+// Overlay is the on-disk <group>-algo.json document.
+type Overlay struct {
+	// Group is the group name (informational; the filename is authoritative).
+	Group string `json:"group"`
+	// ComputedAt is when the group-algo pass that produced this overlay ran.
+	ComputedAt time.Time `json:"computed_at"`
+	// SourceMtimes records each repo's graph.fb mtime (unix nanos) at compute
+	// time. Used for N-way staleness invalidation.
+	SourceMtimes map[string]int64 `json:"source_mtimes"`
+	// Results maps entity id → its group-scope algo values.
+	Results map[string]EntityOverlay `json:"results"`
+	// Communities is the group community summary (for grafel_clusters /
+	// handleListCommunities).
+	Communities []graph.CommunityResult `json:"communities,omitempty"`
+	// Stats is the corpus-level group-algo stats.
+	Stats graph.AlgorithmStats `json:"stats"`
+}
+
+// OverlayPath returns the canonical <group>-algo.json path under the grafel
+// home, honoring $GRAFEL_HOME. It mirrors the convention used by
+// defaultLinksFile (state.go) so the overlay lives next to the -links sidecars.
+func OverlayPath(group string) (string, error) {
+	h, err := registry.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(h, "groups", group+"-algo.json"), nil
+}
+
+// BuildOverlay projects a GroupAlgoResult into the on-disk Overlay shape.
+// Returns nil for a nil/empty result so callers can skip writing.
+func BuildOverlay(res *GroupAlgoResult) *Overlay {
+	if res == nil || res.Results == nil {
+		return nil
+	}
+	r := res.Results
+	ov := &Overlay{
+		Group:        res.Group,
+		ComputedAt:   time.Now().UTC(),
+		SourceMtimes: map[string]int64{},
+		Results:      make(map[string]EntityOverlay, len(r.CommunityID)),
+		Communities:  r.Communities,
+		Stats:        r.Stats,
+	}
+	for slug, mt := range res.SourceMtimes {
+		ov.SourceMtimes[slug] = mt
+	}
+	// Build the per-entity map. CommunityID is the spine: every entity that
+	// participated in the pass has a community id (even -1 ungrouped). PageRank
+	// and Centrality default to 0 when absent.
+	for id, cid := range r.CommunityID {
+		ov.Results[id] = EntityOverlay{
+			CommunityID:         cid,
+			PageRank:            r.PageRank[id],
+			Centrality:          r.Centrality[id],
+			IsGodNode:           r.GodNodes[id],
+			IsArticulationPoint: r.ArticulationPoints[id],
+		}
+	}
+	// Some entities may have a PageRank/Centrality but no community entry in
+	// degenerate cases; fold them in so the overlay is a superset.
+	for id := range r.PageRank {
+		if _, ok := ov.Results[id]; !ok {
+			ov.Results[id] = EntityOverlay{
+				CommunityID:         -2, // sentinel: not assigned a community
+				PageRank:            r.PageRank[id],
+				Centrality:          r.Centrality[id],
+				IsGodNode:           r.GodNodes[id],
+				IsArticulationPoint: r.ArticulationPoints[id],
+			}
+		}
+	}
+	return ov
+}
+
+// WriteOverlay atomically writes the overlay to <group>-algo.json via a
+// temp-file + rename (single-syscall swap; never a torn read). A nil overlay is
+// a no-op (nothing to persist — e.g. an empty group).
+func WriteOverlay(group string, ov *Overlay) error {
+	if ov == nil {
+		return nil
+	}
+	path, err := OverlayPath(group)
+	if err != nil {
+		return err
+	}
+	return WriteOverlayTo(path, ov)
+}
+
+// WriteOverlayTo is WriteOverlay with an explicit destination path (used by
+// tests and by callers that already resolved the path).
+func WriteOverlayTo(path string, ov *Overlay) error {
+	if ov == nil {
+		return nil
+	}
+	data, err := json.Marshal(ov)
+	if err != nil {
+		return fmt.Errorf("marshal overlay: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdirall: %w", err)
+	}
+	// Temp file in the SAME directory as the target so os.Rename is an atomic
+	// intra-filesystem swap. A unique suffix (pid) avoids two concurrent writers
+	// clobbering each other's temp file mid-write.
+	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// WriteOverlayFromResult is the convenience A1→A2 bridge: build + write in one
+// call. A nil/empty result writes nothing (no-op).
+func WriteOverlayFromResult(res *GroupAlgoResult) error {
+	if res == nil {
+		return nil
+	}
+	return WriteOverlay(res.Group, BuildOverlay(res))
+}
+
+// ReadOverlay loads and validates the overlay for a group. It returns
+// (overlay, true) only on a present, well-formed, NON-stale overlay; otherwise
+// (nil, false) — absent, corrupt, or stale all collapse to a no-op miss so the
+// apply path is absence-tolerant.
+//
+// currentMtimes maps each repo slug → its current graph.fb mtime (unix nanos).
+// The overlay is stale if any slug recorded in source_mtimes has a different
+// current mtime (or is missing from currentMtimes — a repo whose graph.fb
+// vanished). Repos present in currentMtimes but absent from the overlay's
+// source_mtimes do NOT mark it stale on their own (a freshly-added repo simply
+// is not yet covered); but the OVERLAY's own recorded sources must all match.
+func ReadOverlay(path string, currentMtimes map[string]int64) (*Overlay, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false // absent or unreadable
+	}
+	var ov Overlay
+	if err := json.Unmarshal(data, &ov); err != nil {
+		return nil, false // corrupt (e.g. a partial write that — impossibly — leaked)
+	}
+	if IsOverlayStale(&ov, currentMtimes) {
+		return nil, false
+	}
+	return &ov, true
+}
+
+// CurrentSourceMtimes returns each repo's current graph.fb mtime (unix nanos)
+// keyed by the group-config slug — the SAME keying the overlay's source_mtimes
+// uses. Consumers (the MCP apply path) compare this against the overlay to
+// detect staleness without re-deriving slugs themselves. A repo with no
+// graph.fb yet is simply absent from the map. An unknown group is an error.
+func CurrentSourceMtimes(group string) (map[string]int64, error) {
+	cfg, err := resolveGroup(group)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]int64{}
+	for _, r := range cfg.Repos {
+		stateDir := daemon.StateDirForRepo(r.Path)
+		fbPath := filepath.Join(stateDir, "graph.fb")
+		if fi, statErr := os.Stat(fbPath); statErr == nil {
+			out[r.Slug] = fi.ModTime().UnixNano()
+		}
+	}
+	return out, nil
+}
+
+// IsOverlayStale reports whether the overlay no longer matches the current
+// on-disk graph.fb mtimes. Generalizes cache.go:readFromDisk's single-mtime
+// check to N repos: stale if ANY recorded source repo's current mtime differs
+// from the stored value (or the repo is missing from currentMtimes).
+func IsOverlayStale(ov *Overlay, currentMtimes map[string]int64) bool {
+	if ov == nil {
+		return true
+	}
+	for slug, stored := range ov.SourceMtimes {
+		cur, ok := currentMtimes[slug]
+		if !ok || cur != stored {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/graph/groupalgo/overlay_test.go
+++ b/internal/graph/groupalgo/overlay_test.go
@@ -1,0 +1,260 @@
+package groupalgo
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// sampleResult builds a small GroupAlgoResult for overlay round-trip tests.
+func sampleResult() *GroupAlgoResult {
+	return &GroupAlgoResult{
+		Group: "acme",
+		Results: &graph.AlgorithmResults{
+			CommunityID: map[string]int{"svc:Service": 7, "web:b1": 7, "svc:a1": 3},
+			PageRank:    map[string]float64{"svc:Service": 0.42, "web:b1": 0.01, "svc:a1": 0.05},
+			Centrality:  map[string]float64{"svc:Service": 0.9},
+			GodNodes:    map[string]bool{"svc:Service": true},
+			ArticulationPoints: map[string]bool{
+				"svc:Service": true,
+			},
+			Communities: []graph.CommunityResult{{ID: 7, Size: 2, AutoName: "service-core"}},
+			Stats:       graph.AlgorithmStats{NumCommunities: 2, LouvainModularity: 0.31, NumGodNodes: 1},
+		},
+		EntityRepo:   map[string]string{"svc:Service": "svc", "web:b1": "web", "svc:a1": "svc"},
+		SourceMtimes: map[string]int64{"svc": 111, "web": 222},
+		NumEntities:  3,
+		NumRels:      2,
+		NumRepos:     2,
+	}
+}
+
+// TestBuildOverlay_RoundTrip checks BuildOverlay projects every entity and that
+// the per-entity values match the source result.
+func TestBuildOverlay_RoundTrip(t *testing.T) {
+	ov := BuildOverlay(sampleResult())
+	if ov == nil {
+		t.Fatal("expected non-nil overlay")
+	}
+	if len(ov.Results) != 3 {
+		t.Fatalf("expected 3 entity overlays, got %d", len(ov.Results))
+	}
+	svc := ov.Results["svc:Service"]
+	if svc.CommunityID != 7 || svc.PageRank != 0.42 || svc.Centrality != 0.9 || !svc.IsGodNode || !svc.IsArticulationPoint {
+		t.Errorf("svc:Service overlay wrong: %+v", svc)
+	}
+	if ov.SourceMtimes["svc"] != 111 || ov.SourceMtimes["web"] != 222 {
+		t.Errorf("source mtimes not copied: %v", ov.SourceMtimes)
+	}
+	if len(ov.Communities) != 1 || ov.Communities[0].AutoName != "service-core" {
+		t.Errorf("communities summary not carried: %v", ov.Communities)
+	}
+	if ov.Stats.NumCommunities != 2 {
+		t.Errorf("stats not carried: %+v", ov.Stats)
+	}
+}
+
+func TestBuildOverlay_NilResult(t *testing.T) {
+	if BuildOverlay(nil) != nil {
+		t.Error("nil result should yield nil overlay")
+	}
+	if BuildOverlay(&GroupAlgoResult{Group: "x"}) != nil {
+		t.Error("result with nil Results should yield nil overlay")
+	}
+}
+
+// TestWriteReadOverlay covers a full write→read with matching mtimes (fresh).
+func TestWriteReadOverlay(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acme-algo.json")
+	ov := BuildOverlay(sampleResult())
+	if err := WriteOverlayTo(path, ov); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Fresh: current mtimes equal the stored ones.
+	got, ok := ReadOverlay(path, map[string]int64{"svc": 111, "web": 222})
+	if !ok {
+		t.Fatal("expected fresh overlay to read back")
+	}
+	if got.Results["svc:Service"].PageRank != 0.42 {
+		t.Errorf("round-trip pagerank wrong: %v", got.Results["svc:Service"])
+	}
+}
+
+// TestReadOverlay_Stale: bumping one repo's current mtime marks it stale.
+func TestReadOverlay_Stale(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acme-algo.json")
+	if err := WriteOverlayTo(path, BuildOverlay(sampleResult())); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// web's graph.fb mtime moved → stale.
+	if _, ok := ReadOverlay(path, map[string]int64{"svc": 111, "web": 999}); ok {
+		t.Error("expected stale overlay (web mtime changed) to be rejected")
+	}
+	// A recorded repo missing from current mtimes → also stale.
+	if _, ok := ReadOverlay(path, map[string]int64{"svc": 111}); ok {
+		t.Error("expected stale overlay (web graph.fb vanished) to be rejected")
+	}
+}
+
+func TestReadOverlay_Absent(t *testing.T) {
+	if _, ok := ReadOverlay(filepath.Join(t.TempDir(), "nope-algo.json"), nil); ok {
+		t.Error("absent overlay must read as (nil,false)")
+	}
+}
+
+func TestReadOverlay_Corrupt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x-algo.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadOverlay(path, nil); ok {
+		t.Error("corrupt overlay must read as (nil,false)")
+	}
+}
+
+func TestIsOverlayStale(t *testing.T) {
+	ov := &Overlay{SourceMtimes: map[string]int64{"a": 1, "b": 2}}
+	if IsOverlayStale(ov, map[string]int64{"a": 1, "b": 2}) {
+		t.Error("matching mtimes must not be stale")
+	}
+	if IsOverlayStale(ov, map[string]int64{"a": 1, "b": 3}) == false {
+		t.Error("changed mtime must be stale")
+	}
+	if IsOverlayStale(nil, nil) == false {
+		t.Error("nil overlay is stale")
+	}
+	// Extra repo in current (not in overlay) does not by itself make it stale.
+	if IsOverlayStale(ov, map[string]int64{"a": 1, "b": 2, "c": 9}) {
+		t.Error("extra current repo must not mark overlay stale")
+	}
+}
+
+// TestOverlay_NoTornRead is the A2 atomic-swap acceptance: a reader loop reading
+// the overlay while a writer rewrites it via temp+rename must NEVER observe a
+// partial / invalid JSON document. Because each write is a single os.Rename, the
+// reader sees either the old file or the new one in full.
+func TestOverlay_NoTornRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "race-algo.json")
+
+	// Seed an initial overlay so the first reads succeed.
+	base := sampleResult()
+	if err := WriteOverlayTo(path, BuildOverlay(base)); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	var stop atomic.Bool
+	var wg sync.WaitGroup
+	var torn atomic.Int64
+	var reads atomic.Int64
+
+	// Writer: rewrite the overlay rapidly with varying contents.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000 && !stop.Load(); i++ {
+			r := sampleResult()
+			// vary a value so each write is distinct/larger sometimes.
+			r.Results.PageRank["svc:Service"] = float64(i)
+			for k := 0; k < i%50; k++ {
+				r.Results.CommunityID[string(rune('A'+k%26))+string(rune('0'+k%10))] = k
+			}
+			if err := WriteOverlayTo(path, BuildOverlay(r)); err != nil {
+				t.Errorf("writer: %v", err)
+				return
+			}
+		}
+		stop.Store(true)
+	}()
+
+	// Readers: read + json.Unmarshal in a tight loop; any unmarshal error is a
+	// torn read (must be zero).
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					// ENOENT is impossible with rename-in-place, but tolerate any
+					// transient and keep going; it is not a torn read.
+					continue
+				}
+				reads.Add(1)
+				var ov Overlay
+				if err := json.Unmarshal(data, &ov); err != nil {
+					torn.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Bound the test by time as a backstop.
+	go func() {
+		time.Sleep(2 * time.Second)
+		stop.Store(true)
+	}()
+	wg.Wait()
+
+	if reads.Load() == 0 {
+		t.Fatal("reader observed zero reads — test did not exercise the race")
+	}
+	if torn.Load() != 0 {
+		t.Fatalf("observed %d torn reads over %d reads (atomic swap broken)", torn.Load(), reads.Load())
+	}
+	t.Logf("no torn reads over %d reads", reads.Load())
+}
+
+// TestCurrentSourceMtimes_OnDisk verifies the slug→mtime helper reads real
+// graph.fb mtimes for a registered group (and skips never-indexed repos).
+func TestCurrentSourceMtimes_OnDisk(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoA, repoB, _ := fixtureGraphs()
+	pathA := filepath.Join(root, "repoA")
+	pathB := filepath.Join(root, "repoB")
+	rA := writeFixtureRepo(t, "svc", pathA, repoA)
+	rB := writeFixtureRepo(t, "web", pathB, repoB)
+
+	cfgPath, err := registry.ConfigPathFor("acme")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "acme", Repos: []registry.Repo{rA, rB}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("acme", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	cur, err := CurrentSourceMtimes("acme")
+	if err != nil {
+		t.Fatalf("CurrentSourceMtimes: %v", err)
+	}
+	if _, ok := cur["svc"]; !ok {
+		t.Error("missing svc mtime")
+	}
+	if _, ok := cur["web"]; !ok {
+		t.Error("missing web mtime")
+	}
+}
+
+// TestWriteOverlayFromResult_NilNoop confirms nil/empty results write nothing.
+func TestWriteOverlayFromResult_NilNoop(t *testing.T) {
+	if err := WriteOverlayFromResult(nil); err != nil {
+		t.Errorf("nil result write must be a no-op, got %v", err)
+	}
+}

--- a/internal/mcp/group_algo_overlay_apply_5354_test.go
+++ b/internal/mcp/group_algo_overlay_apply_5354_test.go
@@ -1,0 +1,271 @@
+// group_algo_overlay_apply_5354_test.go — A2 (#5354): MCP applies the
+// <group>-algo.json overlay onto in-memory entities at group load, and is
+// absence/staleness tolerant.
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// applyFixtureDoc builds a tiny per-repo graph with slug-qualified IDs and NO
+// algo fields set (so any group values that show up came from the overlay).
+func applyFixtureDoc(slug string, names ...string) *graph.Document {
+	doc := &graph.Document{Version: 1, Repo: slug}
+	for _, n := range names {
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         slug + ":" + n,
+			Name:       n,
+			Kind:       "function",
+			SourceFile: slug + "/" + n + ".go",
+			Language:   "go",
+		})
+	}
+	return doc
+}
+
+// setupApplyGroup writes two on-disk graph.fb repos, registers the group config
+// (so CurrentSourceMtimes resolves), and returns a *State pointing at them plus
+// the resolved overlay path and current source mtimes.
+func setupApplyGroup(t *testing.T) (st *State, overlayPath string, curMtimes map[string]int64, serviceID, leafID string) {
+	t.Helper()
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	pathA := filepath.Join(root, "svc")
+	pathB := filepath.Join(root, "web")
+
+	docA := applyFixtureDoc("svc", "Service", "a1")
+	docB := applyFixtureDoc("web", "b1")
+
+	for _, rp := range []struct {
+		path string
+		doc  *graph.Document
+	}{{pathA, docA}, {pathB, docB}} {
+		stateDir := daemon.StateDirForRepo(rp.path)
+		fbPath := filepath.Join(stateDir, "graph.fb")
+		if err := fbwriter.WriteAtomic(fbPath, rp.doc); err != nil {
+			t.Fatalf("write graph.fb: %v", err)
+		}
+	}
+
+	// Register the group config so groupalgo.CurrentSourceMtimes can resolve it.
+	cfgPath, err := registry.ConfigPathFor("acme")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "acme", Repos: []registry.Repo{
+		{Slug: "svc", Path: pathA},
+		{Slug: "web", Path: pathB},
+	}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("acme", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	// Build the in-memory mcp Registry pointing at the two repo paths. Repo
+	// names match the group-config slugs.
+	regPath := filepath.Join(home, "registry.json")
+	inMem := &Registry{
+		Path: regPath,
+		Groups: map[string]RegistryGroup{
+			"acme": {Repos: map[string]RegistryRepo{
+				"svc": {Path: pathA},
+				"web": {Path: pathB},
+			}},
+		},
+	}
+	st = NewState(inMem)
+
+	overlayPath, err = groupalgo.OverlayPath("acme")
+	if err != nil {
+		t.Fatalf("overlay path: %v", err)
+	}
+	curMtimes, err = groupalgo.CurrentSourceMtimes("acme")
+	if err != nil {
+		t.Fatalf("current mtimes: %v", err)
+	}
+	return st, overlayPath, curMtimes, "svc:Service", "web:b1"
+}
+
+func entityByID(grp *LoadedGroup, id string) *graph.Entity {
+	for _, lr := range grp.Repos {
+		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		for i := range lr.Doc.Entities {
+			if lr.Doc.Entities[i].ID == id {
+				return &lr.Doc.Entities[i]
+			}
+		}
+	}
+	return nil
+}
+
+// TestApplyOverlay_GroupValuesAppliedAtLoad: with a fresh overlay present, a
+// cross-repo entity reads the GROUP community_id + pagerank after Reload.
+func TestApplyOverlay_GroupValuesAppliedAtLoad(t *testing.T) {
+	st, overlayPath, cur, serviceID, leafID := setupApplyGroup(t)
+
+	ov := &groupalgo.Overlay{
+		Group:        "acme",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			serviceID: {CommunityID: 42, PageRank: 0.77, Centrality: 0.5, IsGodNode: true},
+			leafID:    {CommunityID: 42, PageRank: 0.02},
+		},
+		Communities: []graph.CommunityResult{{ID: 42, Size: 2, AutoName: "cross-repo-core"}},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	grp := st.Group("acme")
+	if grp == nil {
+		t.Fatal("group not loaded")
+	}
+
+	svc := entityByID(grp, serviceID)
+	if svc == nil {
+		t.Fatalf("%s not found", serviceID)
+	}
+	if svc.CommunityID == nil || *svc.CommunityID != 42 {
+		t.Errorf("Service community_id = %v; want 42 (group overlay not applied)", svc.CommunityID)
+	}
+	if svc.PageRank == nil || *svc.PageRank != 0.77 {
+		t.Errorf("Service pagerank = %v; want 0.77", svc.PageRank)
+	}
+	if !svc.IsGodNode {
+		t.Error("Service IsGodNode not applied from overlay")
+	}
+	// Cross-repo leaf in the SAME group community.
+	leaf := entityByID(grp, leafID)
+	if leaf == nil || leaf.CommunityID == nil || *leaf.CommunityID != 42 {
+		t.Errorf("cross-repo leaf community_id = %v; want 42", leaf)
+	}
+	// Group community summary surfaced for grafel_clusters.
+	if len(grp.Communities) != 1 || grp.Communities[0].AutoName != "cross-repo-core" {
+		t.Errorf("group Communities summary not applied: %v", grp.Communities)
+	}
+}
+
+// TestApplyOverlay_AbsentIsNoop: with no overlay, entities keep their graph.fb
+// values (here: nil/unset). No panic, no group values.
+func TestApplyOverlay_AbsentIsNoop(t *testing.T) {
+	st, overlayPath, _, serviceID, _ := setupApplyGroup(t)
+	// Ensure no overlay exists.
+	_ = os.Remove(overlayPath)
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	grp := st.Group("acme")
+	if grp == nil {
+		t.Fatal("group not loaded")
+	}
+	svc := entityByID(grp, serviceID)
+	if svc == nil {
+		t.Fatalf("%s not found", serviceID)
+	}
+	if svc.CommunityID != nil {
+		t.Errorf("absent overlay leaked a community_id: %v (must stay graph.fb value nil)", *svc.CommunityID)
+	}
+	if svc.PageRank != nil {
+		t.Errorf("absent overlay leaked a pagerank: %v", *svc.PageRank)
+	}
+	if grp.Communities != nil {
+		t.Errorf("absent overlay leaked a community summary: %v", grp.Communities)
+	}
+}
+
+// TestApplyOverlay_StaleNotApplied: an overlay whose recorded source mtime no
+// longer matches the current graph.fb mtime is treated as stale → not applied.
+func TestApplyOverlay_StaleNotApplied(t *testing.T) {
+	st, overlayPath, cur, serviceID, _ := setupApplyGroup(t)
+
+	// Record DELIBERATELY-WRONG source mtimes so the overlay is stale vs the
+	// real on-disk graph.fb mtimes.
+	stale := map[string]int64{}
+	for slug, mt := range cur {
+		stale[slug] = mt + 1 // off by one nano → mismatch
+	}
+	ov := &groupalgo.Overlay{
+		Group:        "acme",
+		SourceMtimes: stale,
+		Results: map[string]groupalgo.EntityOverlay{
+			serviceID: {CommunityID: 99, PageRank: 0.9},
+		},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	grp := st.Group("acme")
+	svc := entityByID(grp, serviceID)
+	if svc == nil {
+		t.Fatalf("%s not found", serviceID)
+	}
+	if svc.CommunityID != nil {
+		t.Errorf("stale overlay was applied (community_id=%v); must fall back to graph.fb", *svc.CommunityID)
+	}
+}
+
+// TestApplyOverlay_MidSessionSwap: after applying overlay v1, swapping in a new
+// overlay (different values, fresh mtimes) and reloading picks up v2 without a
+// graph.fb change.
+func TestApplyOverlay_MidSessionSwap(t *testing.T) {
+	st, overlayPath, cur, serviceID, _ := setupApplyGroup(t)
+
+	write := func(pr float64) {
+		ov := &groupalgo.Overlay{
+			Group:        "acme",
+			SourceMtimes: cur,
+			Results:      map[string]groupalgo.EntityOverlay{serviceID: {CommunityID: 1, PageRank: pr}},
+		}
+		if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+			t.Fatalf("write overlay: %v", err)
+		}
+	}
+
+	write(0.10)
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload v1: %v", err)
+	}
+	if svc := entityByID(st.Group("acme"), serviceID); svc == nil || svc.PageRank == nil || *svc.PageRank != 0.10 {
+		t.Fatalf("v1 not applied: %v", svc)
+	}
+
+	// Ensure the overlay mtime advances (filesystem granularity safety).
+	time.Sleep(10 * time.Millisecond)
+	future := time.Now().Add(time.Second)
+	_ = os.Chtimes(overlayPath, future, future)
+	write(0.20)
+	// Bump again to guarantee a later mtime than v1.
+	future2 := time.Now().Add(2 * time.Second)
+	_ = os.Chtimes(overlayPath, future2, future2)
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload v2: %v", err)
+	}
+	if svc := entityByID(st.Group("acme"), serviceID); svc == nil || svc.PageRank == nil || *svc.PageRank != 0.20 {
+		t.Fatalf("v2 swap not applied: %v", svc)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cajasmota/grafel/internal/embed"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 )
 
 // Registry is the on-disk registry.json describing groups and their repos.
@@ -463,6 +464,19 @@ type LoadedGroup struct {
 	LinksFile string
 	linksMt   time.Time
 	MemoryDir string
+
+	// Communities is the GROUP-scope community summary applied from the
+	// <group>-algo.json overlay (A2, #5354). nil when no overlay is present —
+	// consumers then fall back to per-repo community data carried in graph.fb.
+	Communities []graph.CommunityResult
+	// algoFile / algoMt memoize the overlay by mtime (mirrors LinksFile/linksMt)
+	// so a mid-session swap of <group>-algo.json reloads only the overlay, not
+	// the graphs. algoApplied records whether the last-loaded overlay's values
+	// are currently stamped onto the in-memory entities, so a stale/absent
+	// overlay after a previous apply does not leave group values lingering.
+	algoFile    string
+	algoMt      time.Time
+	algoApplied bool
 }
 
 // WorktreeLookup is the narrow interface ResolveCWD uses to query the PH3
@@ -808,6 +822,13 @@ func (s *State) reloadLocked() (int, bool, error) {
 		} else if os.IsNotExist(err) {
 			grp.Links = nil
 		}
+
+		// Apply the group-algo overlay (A2, #5354). Absence-tolerant: when the
+		// <group>-algo.json overlay is missing or stale the entities keep
+		// whatever graph.fb carried (today's per-repo algo values / sentinels) —
+		// NO behavior change until an overlay exists. Memoized by mtime so a
+		// mid-session atomic swap reloads only the overlay, not the graphs.
+		applyGroupAlgoOverlay(grp)
 	}
 	// Recompute the tool-surface signature. If it differs from the previous
 	// value the caller will emit notifications/tools/list_changed (#1772).
@@ -1004,6 +1025,89 @@ func filterLinksBySource(links []CrossRepoLink, repo string) []CrossRepoLink {
 		}
 	}
 	return out
+}
+
+// applyGroupAlgoOverlay loads the <group>-algo.json overlay (A2, #5354) and, if
+// present and NOT stale, stamps the group-scope algo values
+// (CommunityID/Centrality/PageRank/IsGodNode/IsArticulationPt) onto the
+// in-memory entities by ID, and sets grp.Communities from the overlay summary.
+//
+// Absence-tolerant: a missing or stale overlay is a no-op — entities keep
+// whatever graph.fb carried (per-repo values or sentinels). There is NO
+// behavior change until an overlay file exists (which only A3's scheduler
+// produces). The overlay is memoized by mtime (mirrors LinksFile/linksMt) so a
+// mid-session atomic swap reloads only the overlay.
+//
+// Re-stamping is idempotent: the values overwrite the same pointer fields each
+// reload. A reparse (graph.fb mtime change) resets the entity to its graph.fb
+// value first, then this re-applies the (matching) overlay — so a stale overlay
+// (which always coincides with a graph.fb mtime change) cleanly falls back.
+func applyGroupAlgoOverlay(grp *LoadedGroup) {
+	path, err := groupalgo.OverlayPath(grp.Name)
+	if err != nil || path == "" {
+		return
+	}
+	grp.algoFile = path
+
+	fi, statErr := os.Stat(path)
+	if statErr != nil {
+		// Absent overlay → no-op. Clear any memoized mtime so a later-created
+		// overlay is picked up; leave entity fields as graph.fb carried them.
+		grp.algoMt = time.Time{}
+		grp.algoApplied = false
+		return
+	}
+
+	cur, mtErr := groupalgo.CurrentSourceMtimes(grp.Name)
+	if mtErr != nil {
+		return
+	}
+	ov, ok := groupalgo.ReadOverlay(path, cur)
+	if !ok {
+		// Stale or corrupt → no-op (fall back to graph.fb values). A stale
+		// overlay coincides with a repo reparse, which already reset the fields.
+		grp.algoMt = time.Time{}
+		grp.algoApplied = false
+		return
+	}
+
+	// Memoize: skip re-stamping when neither the overlay nor the graphs changed.
+	// We re-apply whenever the overlay mtime advanced OR a repo was reparsed
+	// this reload (which would have reset entity fields to graph.fb values).
+	if grp.algoApplied && fi.ModTime().Equal(grp.algoMt) {
+		// Still set the summary (cheap; keeps grp.Communities authoritative).
+		grp.Communities = ov.Communities
+		return
+	}
+
+	for _, lr := range grp.Repos {
+		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		ents := lr.Doc.Entities
+		for i := range ents {
+			eo, has := ov.Results[ents[i].ID]
+			if !has {
+				continue
+			}
+			cid := eo.CommunityID
+			pr := eo.PageRank
+			cen := eo.Centrality
+			ents[i].CommunityID = &cid
+			ents[i].PageRank = &pr
+			ents[i].Centrality = &cen
+			ents[i].IsGodNode = eo.IsGodNode
+			ents[i].IsArticulationPt = eo.IsArticulationPoint
+		}
+		// Re-arm lazy derived indexes (TopKPageRank etc.) so they rebuild
+		// against the freshly-stamped group values rather than stale per-repo
+		// ones (mirrors the resetIndexes() call after a reparse).
+		lr.resetIndexes()
+	}
+
+	grp.Communities = ov.Communities
+	grp.algoMt = fi.ModTime()
+	grp.algoApplied = true
 }
 
 // defaultLinksFile is the conventional path for cross-repo links.


### PR DESCRIPTION
Refs #5354, #5349

Part **A2** of the group-level graph-algorithms foundation (epic #5350), building on A1 (#5357). Go-only.

## What this adds

The group-scope algorithm result (A1's `RunGroupAlgorithms`) is now persisted as a single overlay file and applied at MCP group load.

### Overlay format — `~/.grafel/groups/<group>-algo.json`
```
{
  group, computed_at,
  source_mtimes: { slug -> graph.fb mtime (unix nanos) },
  results: { entity_id -> { community_id, pagerank, centrality, is_god_node, is_articulation_point } },
  communities: [ ...summary... ],
  stats: { ... }
}
```
Lives alongside the existing `<group>-links*.json` sidecars.

### Atomic-swap mechanism
The overlay is written with the temp-file + `os.Rename` pattern from `internal/daemon/algo/cache.go:writeToDisk`. A single rename is one syscall, so a reader sees **either** the entire previous overlay **or** the entire new one — never a torn read. The A2 acceptance test runs 4 reader goroutines `json.Unmarshal`-ing the file in a tight loop while a writer rewrites it ~thousands of times; zero torn reads (also `-race` clean).

### Staleness — generalized N-mtime check
`cache.go`'s single graph.fb mtime check is generalized to N repos: the overlay is **stale if any** recorded source repo's current `graph.fb` mtime differs from the stored `source_mtimes[slug]` (or the repo vanished). Stale → not applied.

### Apply at MCP group load
In `internal/mcp/state.go`, after a group's repos + links load, `applyGroupAlgoOverlay` reads the overlay and — only when present and not stale — stamps `e.CommunityID/Centrality/PageRank/IsGodNode/IsArticulationPt` onto the in-memory entities by ID and sets `LoadedGroup.Communities`. The overlay is memoized by mtime (mirrors `LinksFile`/`linksMt`) so a mid-session atomic swap reloads only the overlay, not the graphs.

## Absence-tolerance guarantee

This is the critical property for the live daemon (another agent is using the live MCP, and only A3 will ever produce an overlay):

- **No overlay file present → no-op.** Entities keep whatever `graph.fb` carried (today's per-repo algo values / sentinels). `LoadedGroup.Communities` stays nil.
- **Stale overlay → no-op** (same fallback). A stale overlay always coincides with a `graph.fb` mtime change, which reparses that repo's entities back to graph.fb values first.
- **Corrupt overlay → no-op.**

So there is **no behavior change until an overlay file exists** — which nothing in this PR writes during normal daemon operation. The hidden `grafel group-algo <group>` command gains an opt-in `--write` flag (A3's scheduler will be the real trigger); the default stays dry.

## Scope notes

- Per-repo Pass 4 and the scheduler wiring are untouched (A3's job).
- `ensureAlgoResults` (`algo_demand.go`) left in place as a follow-up; not deleted here.

## Tests
- `internal/graph/groupalgo/overlay_test.go`: build/round-trip, write→read, staleness (mtime bump + vanished repo), absent, corrupt, **no-torn-read race**, `CurrentSourceMtimes` on-disk, nil no-op.
- `internal/mcp/group_algo_overlay_apply_5354_test.go`: group values applied at load (cross-repo entity reads GROUP community_id/pagerank + community summary), absent = no-op, stale = not applied, mid-session swap reloads.

## Validate (local)
`go build ./...`, `go vet ./internal/graph/... ./internal/mcp/...`, `gofmt -l` empty, `go test ./internal/graph/... ./internal/mcp/...` green (incl. `-race` on the new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)