### PR TITLE
test(graph): group-algo differential validator + sampled betweenness perf guard (#5356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,24 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Added
 
+- **Group-algo differential validator + sampled-pivot betweenness perf guard
+  (Refs #5356, #5349):** a `grafel group-algo <group> --diff` mode runs BOTH the
+  OLD per-repo pass (re-derived locally — the production per-repo pass was removed
+  in A3) and the NEW group pass over the union, then emits a machine-readable
+  JSON report (`DiffReport`): # entities whose `community_id` changed, the top-N
+  PageRank **rank churn**, the modularity delta, and a **cross-repo-rank
+  non-decreasing assertion** — no entity that receives a cross-repo phantom CALLS
+  edge may LOSE PageRank rank group-vs-repo (the core thesis; the process exits
+  non-zero and lists the regressions if it ever does), so CI / the upvate
+  baseline re-run can gate on it. Separately, `ComputeCentrality` gains a
+  **sampled-pivot betweenness approximation** (deterministic seed, K random Brandes
+  pivots scaled by V/K) gated by node count — exact below the threshold, sampled
+  above (default 8000, env `GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD`); PageRank and
+  community detection stay exact every pass. This bounds the ~O(V·E) exact
+  betweenness on 28k+-entity group unions: a 28k-node synthetic pass completes in
+  seconds under budget, and full-vs-sampled top-50 betweenness overlap is ≥0.9
+  (the god-node tier is preserved). **No behavior change until deployed.**
+
 - **Group-algo overlay storage + atomic swap, applied at MCP group load
   (Refs #5354, #5349):** the group-scope algorithm pass (A1) now persists its
   result as a single `~/.grafel/groups/<group>-algo.json` overlay

--- a/cmd/grafel/group_algo.go
+++ b/cmd/grafel/group_algo.go
@@ -18,6 +18,7 @@ package main
 //	grafel group-algo <group> [--dry-run|--write]
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -28,6 +29,7 @@ import (
 func runGroupAlgo(args []string) int {
 	dryRun := false
 	write := false
+	diff := false
 	var positional []string
 	for _, a := range args {
 		switch a {
@@ -35,14 +37,46 @@ func runGroupAlgo(args []string) int {
 			dryRun = true
 		case "--write":
 			write = true
+		case "--diff":
+			diff = true
 		default:
 			positional = append(positional, a)
 		}
 	}
 	if len(positional) != 1 {
-		fmt.Fprintln(os.Stderr, "usage: grafel group-algo <group> [--dry-run|--write]")
+		fmt.Fprintln(os.Stderr, "usage: grafel group-algo <group> [--dry-run|--write|--diff]")
 		return 2
 	}
+	group := positional[0]
+
+	// --diff (#5349 A4): run the differential validator (per-repo-old vs
+	// group-new) and emit a machine-readable JSON report on stdout. It writes
+	// no overlay; CI / the upvate baseline re-run consume the JSON. The process
+	// exits non-zero if the core thesis assertion fails (a cross-repo entity
+	// LOST PageRank rank at group scope).
+	if diff {
+		if write || dryRun {
+			fmt.Fprintln(os.Stderr, "grafel group-algo: --diff cannot be combined with --write/--dry-run")
+			return 2
+		}
+		rep, derr := groupalgo.DiffGroup(group, 0)
+		if derr != nil {
+			fmt.Fprintf(os.Stderr, "grafel group-algo --diff: %v\n", derr)
+			return 1
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if eerr := enc.Encode(rep); eerr != nil {
+			fmt.Fprintf(os.Stderr, "grafel group-algo --diff: encode report: %v\n", eerr)
+			return 1
+		}
+		if !rep.CrossRepoRankNonDecreasing {
+			fmt.Fprintf(os.Stderr, "grafel group-algo --diff: FAIL — %d cross-repo entit(ies) lost PageRank rank at group scope\n", len(rep.CrossRepoRankRegressions))
+			return 1
+		}
+		return 0
+	}
+
 	if write && dryRun {
 		fmt.Fprintln(os.Stderr, "grafel group-algo: --write and --dry-run are mutually exclusive")
 		return 2
@@ -51,7 +85,6 @@ func runGroupAlgo(args []string) int {
 	if !write {
 		dryRun = true
 	}
-	group := positional[0]
 
 	res, err := groupalgo.RunGroupAlgorithms(group)
 	if err != nil {

--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -36,6 +36,7 @@ import (
 	"sort"
 	"time"
 
+	gonumgraph "gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/community"
 	"gonum.org/v1/gonum/graph/network"
 	"gonum.org/v1/gonum/graph/path"
@@ -505,6 +506,47 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 // unweighted Brandes implementation (much cheaper) and document the trade-off.
 const betweennessExactCutoff = 3000
 
+// betweennessSampleThreshold is the node count above which betweenness switches
+// from exact (full Brandes, O(V·E)) to a sampled-pivot approximation
+// (O(K·E), K = betweennessSampleSize). On 28k+-entity group unions (#5349 A4,
+// plan §4 risk 1) exact betweenness is minutes-scary; sampling preserves the
+// important nodes (god-node tier) at a fraction of the cost. PageRank and
+// community detection stay EXACT every pass (decision Q1); only betweenness
+// samples above this threshold.
+//
+// Override at runtime with GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD (a positive
+// integer). A value of 0 or a parse failure falls back to the default.
+const betweennessSampleThreshold = 8000
+
+// betweennessSampleSize is the number of random pivot sources K used by the
+// sampled Brandes approximation. The estimator sums single-source dependencies
+// from K pivots and scales by V/K (standard Brandes-sampling, Bader et al.).
+// 512 pivots gives a tight top-K ranking estimate on sparse code graphs.
+const betweennessSampleSize = 512
+
+// betweennessSampleSeed is the fixed PCG seed for pivot selection so the
+// sampled approximation is byte-reproducible across runs of the same graph
+// (mirrors the fixed-seed determinism elsewhere in this file).
+const betweennessSampleSeed = 0x5349
+
+// betweennessSampleThresholdValue returns the node-count threshold above which
+// betweenness is sampled, honouring the GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD
+// override. Factored out so tests can assert the gate and the env override.
+func betweennessSampleThresholdValue() int {
+	if v := os.Getenv("GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD"); v != "" {
+		if n := atoiSafe(v); n > 0 {
+			return n
+		}
+	}
+	return betweennessSampleThreshold
+}
+
+// BetweennessSampleThreshold exports the effective betweenness-sampling node
+// threshold (honouring GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD) so out-of-package
+// consumers (e.g. the group-algo differential validator) can report whether a
+// group was large enough to trigger the sampled approximation.
+func BetweennessSampleThreshold() int { return betweennessSampleThresholdValue() }
+
 func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[string]float64, map[string]float64) {
 	betw := make(map[string]float64, idx.next)
 	pr := make(map[string]float64, idx.next)
@@ -516,9 +558,14 @@ func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[str
 		pr[idx.fromInt[id]] = 0
 	}
 
-	// Betweenness — choose exact-weighted vs unweighted based on graph size.
+	// Betweenness — choose exact-weighted vs unweighted vs sampled by size.
 	var raw map[int64]float64
-	if int(idx.next) <= betwennessNodeCount(idx) {
+	switch {
+	case int(idx.next) > betweennessSampleThresholdValue():
+		// Large group union (#5349 A4): exact Brandes is O(V·E) and scary on
+		// 28k+ nodes. Use the deterministic sampled-pivot approximation.
+		raw = sampledBetweenness(g, betweennessSampleSize, betweennessSampleSeed)
+	case int(idx.next) <= betwennessNodeCount(idx):
 		// FloydWarshall is O(V^3) and precomputes all shortest paths; on
 		// graphs <= cutoff this is the most accurate option.
 		shortest, ok := path.FloydWarshall(g)
@@ -549,6 +596,106 @@ func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[str
 		pr[idx.fromInt[nid]] = roundForDeterminism(sanitizeFloat(v))
 	}
 	return betw, pr
+}
+
+// sampledBetweenness approximates betweenness centrality on a directed graph
+// using K random pivot sources (Brandes-sampling, Bader/Brandes-Pich). For each
+// pivot s it runs a single-source unweighted BFS, builds the shortest-path DAG
+// (sigma counts + predecessor lists in non-decreasing distance order), then
+// back-accumulates dependencies delta exactly as in Brandes' algorithm. The sum
+// of single-source dependencies over K pivots is an unbiased estimator of the
+// full betweenness scaled by K/V; we rescale by V/K so the magnitudes match the
+// exact directed Brandes output and the god-node tier (top-K ranking) is
+// preserved (acceptance: top-50 overlap >= 0.9 vs exact on mid-size graphs).
+//
+// Pivot selection uses a fixed PCG seed so the approximation is byte-stable
+// across runs of the same graph (the on-disk determinism contract, #481).
+// Unweighted shortest paths are used (matching network.Betweenness, the exact
+// fallback above the FloydWarshall cutoff) so the comparison is apples-to-apples.
+func sampledBetweenness(g *simple.WeightedDirectedGraph, k int, seed uint64) map[int64]float64 {
+	nodes := gonumgraph.NodesOf(g.Nodes())
+	v := len(nodes)
+	cb := make(map[int64]float64, v)
+	if v == 0 {
+		return cb
+	}
+	ids := make([]int64, v)
+	for i, n := range nodes {
+		ids[i] = n.ID()
+	}
+	// Deterministic order so the seeded pivot draw is reproducible regardless
+	// of gonum's internal node-map iteration order.
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	if k > v {
+		k = v
+	}
+	// Deterministic pivot sample without replacement via a seeded Fisher-Yates
+	// partial shuffle over a copy of the sorted ids.
+	rng := rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15)) //nolint:gosec // reproducibility, not security
+	perm := make([]int64, v)
+	copy(perm, ids)
+	for i := 0; i < k; i++ {
+		j := i + int(rng.Uint64N(uint64(v-i)))
+		perm[i], perm[j] = perm[j], perm[i]
+	}
+	pivots := perm[:k]
+
+	// Pre-extract successor adjacency once (avoids repeated gonum map lookups).
+	succ := make(map[int64][]int64, v)
+	for _, id := range ids {
+		var out []int64
+		it := g.From(id)
+		for it.Next() {
+			out = append(out, it.Node().ID())
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] }) // determinism
+		succ[id] = out
+	}
+
+	for _, s := range pivots {
+		// Single-source Brandes (unweighted BFS).
+		stack := make([]int64, 0, v)
+		pred := make(map[int64][]int64, v)
+		sigma := make(map[int64]float64, v)
+		dist := make(map[int64]int, v)
+		sigma[s] = 1
+		dist[s] = 0
+		queue := []int64{s}
+		for len(queue) > 0 {
+			cur := queue[0]
+			queue = queue[1:]
+			stack = append(stack, cur)
+			for _, w := range succ[cur] {
+				if _, seen := dist[w]; !seen {
+					dist[w] = dist[cur] + 1
+					queue = append(queue, w)
+				}
+				if dist[w] == dist[cur]+1 {
+					sigma[w] += sigma[cur]
+					pred[w] = append(pred[w], cur)
+				}
+			}
+		}
+		// Back-accumulation.
+		delta := make(map[int64]float64, len(stack))
+		for i := len(stack) - 1; i >= 0; i-- {
+			w := stack[i]
+			for _, p := range pred[w] {
+				delta[p] += (sigma[p] / sigma[w]) * (1 + delta[w])
+			}
+			if w != s {
+				cb[w] += delta[w]
+			}
+		}
+	}
+
+	// Rescale so sampled magnitudes match full Brandes (V/K estimator scale).
+	scale := float64(v) / float64(k)
+	for id := range cb {
+		cb[id] *= scale
+	}
+	return cb
 }
 
 // runtimeMSFor returns wall-clock milliseconds elapsed since start, or 0

--- a/internal/graph/algorithms_sampled_test.go
+++ b/internal/graph/algorithms_sampled_test.go
@@ -1,0 +1,227 @@
+package graph
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"testing"
+	"time"
+
+	"gonum.org/v1/gonum/graph/network"
+)
+
+// buildSyntheticGraph generates a deterministic synthetic graph with n entities
+// and roughly avgDeg outbound edges per node, using a fixed seed so tests are
+// reproducible. A handful of "hub" nodes receive a disproportionate share of
+// inbound edges so betweenness/PageRank have a clear top tier to preserve.
+func buildSyntheticGraph(n, avgDeg int, seed uint64) ([]Entity, []Relationship) {
+	rng := rand.New(rand.NewPCG(seed, seed^0xabcdef))
+	ents := make([]Entity, n)
+	for i := 0; i < n; i++ {
+		ents[i] = Entity{
+			ID:         fmt.Sprintf("e%07d", i),
+			Name:       fmt.Sprintf("E%d", i),
+			Kind:       "function",
+			SourceFile: fmt.Sprintf("pkg%d/file%d.go", i%50, i),
+			Language:   "go",
+		}
+	}
+	// Designate ~0.5% of nodes as hubs.
+	numHubs := n / 200
+	if numHubs < 5 {
+		numHubs = 5
+	}
+	hubs := make([]int, numHubs)
+	for i := range hubs {
+		hubs[i] = int(rng.Uint64N(uint64(n)))
+	}
+
+	var rels []Relationship
+	for i := 0; i < n; i++ {
+		deg := avgDeg
+		for d := 0; d < deg; d++ {
+			var to int
+			// 40% of edges point at a hub (creates the importance tier).
+			if rng.Uint64N(100) < 40 {
+				to = hubs[int(rng.Uint64N(uint64(numHubs)))]
+			} else {
+				to = int(rng.Uint64N(uint64(n)))
+			}
+			if to == i {
+				continue
+			}
+			rels = append(rels, Relationship{
+				ID:     fmt.Sprintf("e%07d->e%07d-%d", i, to, d),
+				FromID: ents[i].ID,
+				ToID:   ents[to].ID,
+				Kind:   "CALLS",
+			})
+		}
+	}
+	return ents, rels
+}
+
+// topKByValue returns the IDs of the top-k entries by value, ties broken by id
+// (matches the determinism contract used elsewhere).
+func topKByValue(m map[string]float64, k int) []string {
+	type row struct {
+		id string
+		v  float64
+	}
+	rows := make([]row, 0, len(m))
+	for id, v := range m {
+		rows = append(rows, row{id, v})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].v != rows[j].v {
+			return rows[i].v > rows[j].v
+		}
+		return rows[i].id < rows[j].id
+	})
+	if k > len(rows) {
+		k = len(rows)
+	}
+	out := make([]string, k)
+	for i := 0; i < k; i++ {
+		out[i] = rows[i].id
+	}
+	return out
+}
+
+// TestBetweennessSampleThresholdGate verifies the node-count gate: below the
+// threshold the exact path runs, above it the sampled approximation runs. We
+// drive it through the env override so the test stays fast.
+func TestBetweennessSampleThresholdGate(t *testing.T) {
+	// Force a tiny threshold so a small graph trips the sampled path.
+	t.Setenv("GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD", "10")
+	if got := betweennessSampleThresholdValue(); got != 10 {
+		t.Fatalf("threshold override not honoured: got %d want 10", got)
+	}
+
+	ents, rels := buildSyntheticGraph(200, 4, 1)
+	g, idx := BuildGraph(ents, rels)
+	// 200 nodes > threshold(10) -> sampled path must be taken. We can't observe
+	// the branch directly, but we CAN assert the result is non-empty and that
+	// the same call is deterministic (seeded), which only the sampled path
+	// guarantees at this size (exact Betweenness is also deterministic, so we
+	// additionally verify the dedicated sampled function matches the gated call).
+	betw, _ := ComputeCentrality(g, idx)
+	direct := sampledBetweenness(g, betweennessSampleSize, betweennessSampleSeed)
+	// The gated ComputeCentrality rounds for determinism; compare top-tier.
+	gatedTop := topKByValue(betw, 10)
+	directScaled := map[string]float64{}
+	for nid, v := range direct {
+		directScaled[idx.fromInt[nid]] = v
+	}
+	directTop := topKByValue(directScaled, 10)
+	overlap := overlapFraction(gatedTop, directTop)
+	if overlap < 0.9 {
+		t.Errorf("gated sampled path diverges from direct sampledBetweenness: overlap=%.2f", overlap)
+	}
+
+	// Below threshold: exact path. Make the threshold huge so a small graph
+	// stays exact, and a separate run must still produce sensible scores.
+	t.Setenv("GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD", "100000")
+	if got := betweennessSampleThresholdValue(); got != 100000 {
+		t.Fatalf("threshold override not honoured: got %d want 100000", got)
+	}
+	betwExact, _ := ComputeCentrality(g, idx)
+	if len(betwExact) != len(ents) {
+		t.Errorf("exact path: betw map has %d keys, want %d", len(betwExact), len(ents))
+	}
+}
+
+// TestBetweennessSampledDeterministic confirms the sampled approximation is
+// byte-reproducible (fixed seed) across repeated calls on the same graph.
+func TestBetweennessSampledDeterministic(t *testing.T) {
+	ents, rels := buildSyntheticGraph(1000, 4, 7)
+	g, _ := BuildGraph(ents, rels)
+	a := sampledBetweenness(g, 256, betweennessSampleSeed)
+	b := sampledBetweenness(g, 256, betweennessSampleSeed)
+	if len(a) != len(b) {
+		t.Fatalf("non-deterministic key count: %d vs %d", len(a), len(b))
+	}
+	for k, va := range a {
+		if vb := b[k]; va != vb {
+			t.Fatalf("non-deterministic value for %d: %v vs %v", k, va, vb)
+		}
+	}
+}
+
+// TestBetweennessSampledTop50Overlap is the quality acceptance test: on a
+// mid-size synthetic graph, the sampled betweenness must agree with EXACT
+// betweenness on the top-50 nodes by >= 0.9 overlap (the important nodes — the
+// god-node tier — are preserved by the approximation).
+func TestBetweennessSampledTop50Overlap(t *testing.T) {
+	ents, rels := buildSyntheticGraph(2500, 5, 42)
+	g, idx := BuildGraph(ents, rels)
+
+	// EXACT unweighted Brandes (network.Betweenness) as ground truth.
+	exactRaw := network.Betweenness(g)
+	exact := map[string]float64{}
+	for nid, v := range exactRaw {
+		exact[idx.fromInt[nid]] = v
+	}
+
+	// Sampled with the production K.
+	sampRaw := sampledBetweenness(g, betweennessSampleSize, betweennessSampleSeed)
+	samp := map[string]float64{}
+	for nid, v := range sampRaw {
+		samp[idx.fromInt[nid]] = v
+	}
+
+	exactTop := topKByValue(exact, 50)
+	sampTop := topKByValue(samp, 50)
+	overlap := overlapFraction(exactTop, sampTop)
+	t.Logf("full-vs-sampled top-50 betweenness overlap = %.3f (K=%d, V=%d)", overlap, betweennessSampleSize, len(ents))
+	if overlap < 0.9 {
+		t.Errorf("top-50 overlap %.3f < 0.9 — sampled approximation lost too many important nodes", overlap)
+	}
+}
+
+// TestBetweennessPerfBudget_28k is the perf guard: on a >=28k-entity synthetic
+// group the centrality pass (with sampling enabled by the node-count gate)
+// completes under a budget. Gated behind testing.Short() so the default suite
+// stays fast.
+func TestBetweennessPerfBudget_28k(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping 28k-synthetic perf test in -short mode")
+	}
+	const n = 28000
+	const budget = 60 * time.Second
+
+	ents, rels := buildSyntheticGraph(n, 5, 99)
+	g, idx := BuildGraph(ents, rels)
+	if int(idx.next) <= betweennessSampleThresholdValue() {
+		t.Fatalf("28k graph (%d nodes) did not exceed sampling threshold %d", idx.next, betweennessSampleThresholdValue())
+	}
+
+	start := time.Now()
+	betw, pr := ComputeCentrality(g, idx)
+	elapsed := time.Since(start)
+	t.Logf("28k-node centrality (sampled betweenness) completed in %s (budget %s)", elapsed, budget)
+	if elapsed > budget {
+		t.Errorf("centrality pass took %s, over budget %s", elapsed, budget)
+	}
+	if len(betw) != n || len(pr) != n {
+		t.Errorf("expected %d betw/%d pr keys, got %d/%d", n, n, len(betw), len(pr))
+	}
+}
+
+// overlapFraction returns |A ∩ B| / |A| for two ID slices.
+func overlapFraction(a, b []string) float64 {
+	if len(a) == 0 {
+		return 1
+	}
+	set := make(map[string]struct{}, len(b))
+	for _, id := range b {
+		set[id] = struct{}{}
+	}
+	hit := 0
+	for _, id := range a {
+		if _, ok := set[id]; ok {
+			hit++
+		}
+	}
+	return float64(hit) / float64(len(a))
+}

--- a/internal/graph/groupalgo/diff.go
+++ b/internal/graph/groupalgo/diff.go
@@ -1,0 +1,352 @@
+// diff.go — differential validator (#5349 A4, epic #5350).
+//
+// The trust gate for Part A's per-repo->group migration. It runs BOTH passes
+// over a group's assembled union and reports how the group-scope result differs
+// from the OLD per-repo result:
+//
+//   - OLD: graph.RunAlgorithms run on EACH repo's graph independently (the
+//     production per-repo Pass-4 was removed in A3, so the harness re-derives it
+//     locally for comparison — it does NOT depend on any per-repo pass still
+//     running).
+//   - NEW: groupalgo.RunGroupAlgorithms over the union (the A1 deliverable).
+//
+// Reported deltas:
+//   - CommunityChanged: # entities whose community_id changed (per-repo->group).
+//   - PageRankRankChurn: how the top-N PageRank importance ordering shifts.
+//   - ModularityDelta:  group modularity - mean per-repo modularity.
+//   - CrossRepoRankRegressions: the CORE THESIS sanity assertion. Every entity
+//     that is called cross-repo (receives a phantom CALLS edge from another
+//     repo) must rank >= its per-repo PageRank rank at group scope — cross-repo
+//     hubs should gain importance, never lose it. Any regression is a failure
+//     and is listed here.
+//
+// The whole report marshals to JSON (DiffReport) so CI / the upvate baseline
+// re-run can consume it.
+package groupalgo
+
+import (
+	"sort"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// RankChurnRow records, for one entity in the group top-N by PageRank, where it
+// ranked per-repo vs group (1-based; 0 = "outside the compared top-N / absent").
+type RankChurnRow struct {
+	EntityID    string `json:"entity_id"`
+	Repo        string `json:"repo"`
+	GroupRank   int    `json:"group_rank"`
+	PerRepoRank int    `json:"per_repo_rank"`
+	// RankDelta = PerRepoRank - GroupRank. Positive = the entity rose (better
+	// rank number) at group scope; negative = it fell.
+	RankDelta float64 `json:"rank_delta"`
+}
+
+// RankRegression is a cross-repo-called entity whose PageRank RANK got worse
+// (numerically larger) at group scope — a violation of the core thesis.
+type RankRegression struct {
+	EntityID    string `json:"entity_id"`
+	Repo        string `json:"repo"`
+	PerRepoRank int    `json:"per_repo_rank"`
+	GroupRank   int    `json:"group_rank"`
+}
+
+// DiffReport is the machine-readable output of the differential validator.
+type DiffReport struct {
+	Group              string `json:"group"`
+	NumRepos           int    `json:"num_repos"`
+	NumEntities        int    `json:"num_entities"`
+	NumRels            int    `json:"num_relationships"`
+	TopN               int    `json:"top_n"`
+	BetweennessSampled bool   `json:"betweenness_sampled"`
+
+	// Community churn.
+	CommunityChanged int `json:"community_changed"`
+
+	// Modularity.
+	GroupModularity       float64 `json:"group_modularity"`
+	MeanPerRepoModularity float64 `json:"mean_per_repo_modularity"`
+	ModularityDelta       float64 `json:"modularity_delta"`
+
+	// PageRank rank churn over the group top-N.
+	TopRankChurn []RankChurnRow `json:"top_rank_churn"`
+
+	// The core thesis assertion. CrossRepoEntities is the count of entities
+	// that receive a cross-repo phantom CALLS edge. CrossRepoRankRegressions
+	// lists any that LOST PageRank rank at group scope (must be empty).
+	CrossRepoEntities        int              `json:"cross_repo_entities"`
+	CrossRepoRankRegressions []RankRegression `json:"cross_repo_rank_regressions"`
+	// CrossRepoRankNonDecreasing is the pass/fail of the assertion: true iff
+	// CrossRepoRankRegressions is empty.
+	CrossRepoRankNonDecreasing bool `json:"cross_repo_rank_non_decreasing"`
+}
+
+// rankMap turns a PageRank score map into 1-based ranks (rank 1 = highest
+// score). Ties break by entity ID for determinism. Entities absent from the
+// score map are not in the result.
+func rankMap(pr map[string]float64) map[string]int {
+	type row struct {
+		id string
+		pr float64
+	}
+	rows := make([]row, 0, len(pr))
+	for id, v := range pr {
+		rows = append(rows, row{id, v})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].pr != rows[j].pr {
+			return rows[i].pr > rows[j].pr
+		}
+		return rows[i].id < rows[j].id
+	})
+	out := make(map[string]int, len(rows))
+	for i, r := range rows {
+		out[r.id] = i + 1
+	}
+	return out
+}
+
+// crossRepoCalledEntities returns the set of entity IDs that receive a CALLS
+// edge whose source is in a DIFFERENT repo (the phantom cross-repo edges). This
+// is the population the core thesis is about: their inbound cross-repo edges are
+// only visible at group scope, so their rank must not regress.
+func crossRepoCalledEntities(rels []graph.Relationship, entityRepo map[string]string) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range rels {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		fromRepo, okF := entityRepo[r.FromID]
+		toRepo, okT := entityRepo[r.ToID]
+		if !okF || !okT {
+			continue
+		}
+		if fromRepo != toRepo {
+			out[r.ToID] = true
+		}
+	}
+	return out
+}
+
+// DiffGroup runs the differential validator for a group: it assembles the union
+// once, runs the OLD per-repo pass on each repo independently, runs the NEW
+// group pass over the union, and returns a DiffReport. topN bounds the PageRank
+// rank-churn table (<=0 defaults to 25).
+func DiffGroup(group string, topN int) (*DiffReport, error) {
+	if topN <= 0 {
+		topN = 25
+	}
+
+	// NEW group pass (also gives us the union + per-repo attribution).
+	groupRes, err := RunGroupAlgorithms(group)
+	if err != nil {
+		return nil, err
+	}
+	ents, rels, entityRepo, _, err := AssembleGroupGraph(group)
+	if err != nil {
+		return nil, err
+	}
+
+	// OLD per-repo pass: partition the union back into per-repo slices and run
+	// graph.RunAlgorithms on each independently (re-derives the pre-A3 pass).
+	repoEnts := map[string][]graph.Entity{}
+	for _, e := range ents {
+		slug := entityRepo[e.ID]
+		repoEnts[slug] = append(repoEnts[slug], e)
+	}
+	repoRels := map[string][]graph.Relationship{}
+	for _, r := range rels {
+		fromRepo := entityRepo[r.FromID]
+		toRepo := entityRepo[r.ToID]
+		// A relationship belongs to the per-repo pass only when BOTH endpoints
+		// are in the same repo (cross-repo phantom edges did not exist in the
+		// old per-repo world).
+		if fromRepo != "" && fromRepo == toRepo {
+			repoRels[fromRepo] = append(repoRels[fromRepo], r)
+		}
+	}
+
+	perRepoPR := map[string]float64{} // entity id -> per-repo pagerank
+	perRepoComm := map[string]int{}   // entity id -> per-repo community id
+	var modularities []float64
+	commBaseNext := 0
+	// Stable repo order for deterministic community-id namespacing.
+	repoSlugs := make([]string, 0, len(repoEnts))
+	for slug := range repoEnts {
+		repoSlugs = append(repoSlugs, slug)
+	}
+	sort.Strings(repoSlugs)
+	for _, slug := range repoSlugs {
+		res := graph.RunAlgorithms(repoEnts[slug], repoRels[slug])
+		if res == nil {
+			continue
+		}
+		modularities = append(modularities, res.Stats.LouvainModularity)
+		base := commBaseNext
+		maxCid := -1
+		for id, pr := range res.PageRank {
+			perRepoPR[id] = pr
+		}
+		for id, cid := range res.CommunityID {
+			if cid < 0 {
+				perRepoComm[id] = cid // keep sentinel as-is
+				continue
+			}
+			perRepoComm[id] = base + cid
+			if cid > maxCid {
+				maxCid = cid
+			}
+		}
+		commBaseNext = base + maxCid + 1
+	}
+
+	groupPR := groupRes.Results.PageRank
+	groupComm := groupRes.Results.CommunityID
+
+	// Community churn: count entities whose community id changed. Because the
+	// numeric ids are not comparable across the two passes, we compare via a
+	// canonical signature: two entities are "co-clustered the same" iff their
+	// (this-entity, partner) co-membership is preserved. A cheaper, well-defined
+	// proxy used here: an entity "changed" if the SET of repos in its community
+	// differs — at group scope cross-repo entities join a multi-repo community
+	// they could never be in per-repo. We compute the simplest robust signal:
+	// an entity changed iff its group community spans repos its per-repo
+	// community did not (i.e. it gained cross-repo co-members).
+	communityChanged := communityChurn(groupComm, perRepoComm, entityRepo)
+
+	// PageRank rank maps.
+	groupRanks := rankMap(groupPR)
+	perRepoRanks := rankMap(perRepoPR)
+
+	// Top-N group entities -> churn rows.
+	type prRow struct {
+		id string
+		pr float64
+	}
+	grows := make([]prRow, 0, len(groupPR))
+	for id, v := range groupPR {
+		grows = append(grows, prRow{id, v})
+	}
+	sort.Slice(grows, func(i, j int) bool {
+		if grows[i].pr != grows[j].pr {
+			return grows[i].pr > grows[j].pr
+		}
+		return grows[i].id < grows[j].id
+	})
+	n := topN
+	if len(grows) < n {
+		n = len(grows)
+	}
+	churn := make([]RankChurnRow, 0, n)
+	for i := 0; i < n; i++ {
+		id := grows[i].id
+		gr := groupRanks[id]
+		pr := perRepoRanks[id]
+		churn = append(churn, RankChurnRow{
+			EntityID:    id,
+			Repo:        entityRepo[id],
+			GroupRank:   gr,
+			PerRepoRank: pr,
+			RankDelta:   float64(pr - gr),
+		})
+	}
+
+	// Core thesis assertion: cross-repo-called entities must not lose rank.
+	xrepo := crossRepoCalledEntities(rels, entityRepo)
+	var regressions []RankRegression
+	for id := range xrepo {
+		gr, okG := groupRanks[id]
+		pr, okR := perRepoRanks[id]
+		if !okG || !okR {
+			continue // not ranked in one pass — skip (can't compare)
+		}
+		// A larger rank number = worse importance. Regression iff group rank is
+		// strictly worse than per-repo rank.
+		if gr > pr {
+			regressions = append(regressions, RankRegression{
+				EntityID:    id,
+				Repo:        entityRepo[id],
+				PerRepoRank: pr,
+				GroupRank:   gr,
+			})
+		}
+	}
+	sort.Slice(regressions, func(i, j int) bool {
+		return regressions[i].EntityID < regressions[j].EntityID
+	})
+
+	meanMod := 0.0
+	if len(modularities) > 0 {
+		sum := 0.0
+		for _, m := range modularities {
+			sum += m
+		}
+		meanMod = sum / float64(len(modularities))
+	}
+	groupMod := groupRes.Results.Stats.LouvainModularity
+
+	return &DiffReport{
+		Group:                      group,
+		NumRepos:                   groupRes.NumRepos,
+		NumEntities:                groupRes.NumEntities,
+		NumRels:                    groupRes.NumRels,
+		TopN:                       n,
+		BetweennessSampled:         groupRes.NumEntities > betweennessSampleThresholdValueExported(),
+		CommunityChanged:           communityChanged,
+		GroupModularity:            groupMod,
+		MeanPerRepoModularity:      meanMod,
+		ModularityDelta:            groupMod - meanMod,
+		TopRankChurn:               churn,
+		CrossRepoEntities:          len(xrepo),
+		CrossRepoRankRegressions:   regressions,
+		CrossRepoRankNonDecreasing: len(regressions) == 0,
+	}, nil
+}
+
+// communityChurn counts entities whose community co-membership gained cross-repo
+// members at group scope (i.e. their group community spans more repos than they
+// could ever be co-clustered with per-repo). This is a stable, id-namespacing-
+// independent measure of "the community assignment changed because of the union".
+func communityChurn(groupComm map[string]int, perRepoComm map[string]int, entityRepo map[string]string) int {
+	// repos present in each GROUP community.
+	groupCommRepos := map[int]map[string]struct{}{}
+	for id, cid := range groupComm {
+		if cid < 0 {
+			continue
+		}
+		if groupCommRepos[cid] == nil {
+			groupCommRepos[cid] = map[string]struct{}{}
+		}
+		if repo := entityRepo[id]; repo != "" {
+			groupCommRepos[cid][repo] = struct{}{}
+		}
+	}
+	changed := 0
+	for id, gcid := range groupComm {
+		if gcid < 0 {
+			continue
+		}
+		// Per-repo, an entity's community is by construction single-repo. If its
+		// GROUP community spans >1 repo, its assignment materially changed.
+		if len(groupCommRepos[gcid]) > 1 {
+			changed++
+			continue
+		}
+		// Single-repo group community: it changed iff the entity was ungrouped
+		// per-repo but grouped now (or vice-versa).
+		pr, ok := perRepoComm[id]
+		if !ok || pr < 0 {
+			changed++
+		}
+	}
+	return changed
+}
+
+// betweennessSampleThresholdValueExported bridges to the package-private
+// threshold in the graph package via a small indirection (the diff report only
+// needs to know whether the group was large enough to sample). It mirrors
+// graph.betweennessSampleThresholdValue() — kept here so groupalgo does not have
+// to export internals from the graph package. Default matches graph's default.
+func betweennessSampleThresholdValueExported() int {
+	return graph.BetweennessSampleThreshold()
+}

--- a/internal/graph/groupalgo/diff_test.go
+++ b/internal/graph/groupalgo/diff_test.go
@@ -1,0 +1,139 @@
+package groupalgo
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestDiffGroup_CrossRepoRankNonDecreasing is the A4 acceptance test: on the
+// 2-repo fixture with a cross-repo CALLS edge into repo-A's Service, the diff
+// report is produced and the cross-repo hub's PageRank RANK is non-decreasing
+// group-vs-repo (the core thesis — cross-repo inbound edges lift a hub's rank,
+// never lower it). The report must also marshal cleanly to JSON for CI.
+func TestDiffGroup_CrossRepoRankNonDecreasing(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoA, repoB, serviceID := fixtureGraphs()
+	pathA := filepath.Join(root, "repoA")
+	pathB := filepath.Join(root, "repoB")
+	rA := writeFixtureRepo(t, "svc", pathA, repoA)
+	rB := writeFixtureRepo(t, "web", pathB, repoB)
+
+	cfgPath, err := registry.ConfigPathFor("acme")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "acme", Repos: []registry.Repo{rA, rB}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("acme", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	rep, err := DiffGroup("acme", 10)
+	if err != nil {
+		t.Fatalf("DiffGroup: %v", err)
+	}
+
+	// Report is well-formed.
+	if rep.Group != "acme" {
+		t.Errorf("report group=%q want acme", rep.Group)
+	}
+	if rep.NumRepos != 2 {
+		t.Errorf("NumRepos=%d want 2", rep.NumRepos)
+	}
+	if rep.NumEntities != len(repoA.Entities)+len(repoB.Entities) {
+		t.Errorf("NumEntities=%d want %d", rep.NumEntities, len(repoA.Entities)+len(repoB.Entities))
+	}
+	if len(rep.TopRankChurn) == 0 {
+		t.Errorf("expected a non-empty top rank churn table")
+	}
+
+	// The six cross-repo CALLS edges into Service make it a cross-repo entity.
+	if rep.CrossRepoEntities == 0 {
+		t.Fatalf("expected at least one cross-repo-called entity (Service)")
+	}
+
+	// CORE THESIS: no cross-repo entity lost rank.
+	if !rep.CrossRepoRankNonDecreasing {
+		t.Fatalf("cross-repo rank assertion FAILED: regressions=%+v", rep.CrossRepoRankRegressions)
+	}
+
+	// Service specifically must be ranked, and not regressed.
+	for _, r := range rep.CrossRepoRankRegressions {
+		if r.EntityID == serviceID {
+			t.Fatalf("Service regressed: per-repo rank=%d group rank=%d", r.PerRepoRank, r.GroupRank)
+		}
+	}
+
+	// Service's group rank must be <= its per-repo rank (rose or held).
+	var svcRow *RankChurnRow
+	for i := range rep.TopRankChurn {
+		if rep.TopRankChurn[i].EntityID == serviceID {
+			svcRow = &rep.TopRankChurn[i]
+			break
+		}
+	}
+	if svcRow == nil {
+		t.Fatalf("Service not in top rank churn table; cannot verify rank movement")
+	}
+	if svcRow.PerRepoRank > 0 && svcRow.GroupRank > svcRow.PerRepoRank {
+		t.Errorf("Service rank regressed: per-repo=%d group=%d", svcRow.PerRepoRank, svcRow.GroupRank)
+	}
+	t.Logf("Service rank: per-repo=%d group=%d (delta=%.0f), cross-repo entities=%d, community changed=%d, modularity delta=%.4f",
+		svcRow.PerRepoRank, svcRow.GroupRank, svcRow.RankDelta, rep.CrossRepoEntities, rep.CommunityChanged, rep.ModularityDelta)
+
+	// JSON round-trips (CI consumability).
+	b, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	var back DiffReport
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if back.CrossRepoRankNonDecreasing != rep.CrossRepoRankNonDecreasing {
+		t.Errorf("JSON round-trip changed assertion result")
+	}
+}
+
+// TestDiffGroup_Empty confirms an empty group produces a clean report (assertion
+// trivially holds, no panic).
+func TestDiffGroup_Empty(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoPath := filepath.Join(root, "ghost")
+	cfgPath, err := registry.ConfigPathFor("empty")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "empty", Repos: []registry.Repo{{Slug: "ghost", Path: repoPath}}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("empty", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	rep, err := DiffGroup("empty", 0)
+	if err != nil {
+		t.Fatalf("DiffGroup(empty): %v", err)
+	}
+	if rep.NumEntities != 0 {
+		t.Errorf("NumEntities=%d want 0", rep.NumEntities)
+	}
+	if !rep.CrossRepoRankNonDecreasing {
+		t.Errorf("empty group should trivially satisfy the rank assertion")
+	}
+	if len(rep.CrossRepoRankRegressions) != 0 {
+		t.Errorf("empty group should have no regressions")
+	}
+}


### PR DESCRIPTION
Refs #5356, #5349

Part A4 — the validation/trust gate for the per-repo→group algorithm migration (epic #5350). Builds on A1/A2/A3 (merged). Go-only.

## 1. Differential validator — `grafel group-algo <group> --diff`
Runs BOTH passes over a group and emits a machine-readable JSON `DiffReport`:
- OLD: `graph.RunAlgorithms` on each repo independently (the production per-repo pass was removed in A3, so the harness re-derives it locally for comparison).
- NEW: `groupalgo.RunGroupAlgorithms` over the union.

Report shape:
```json
{
  "group": "acme",
  "num_repos": 2, "num_entities": 13, "num_relationships": 21,
  "top_n": 10, "betweenness_sampled": false,
  "community_changed": 8,
  "group_modularity": ..., "mean_per_repo_modularity": ..., "modularity_delta": 0.0341,
  "top_rank_churn": [ { "entity_id": "...", "repo": "...", "group_rank": 1, "per_repo_rank": 1, "rank_delta": 0 }, ... ],
  "cross_repo_entities": 1,
  "cross_repo_rank_regressions": [],
  "cross_repo_rank_non_decreasing": true
}
```
**Core thesis assertion:** no entity that receives a cross-repo phantom CALLS edge may LOSE PageRank rank group-vs-repo. The `--diff` process exits non-zero and lists the regressions if it ever does — consumable as a CI / the multi-repo group-baseline gate.

**Fixture diff result:** on the 2-repo fixture (repo-B's 6 modules each CALL repo-A's `Service` cross-repo), `Service` holds **PageRank rank 1 in both** per-repo and group passes → `cross_repo_rank_non_decreasing: true`, zero regressions. The cross-repo hub keeps (and is positioned to gain) rank; it never loses it.

## 2. Sampled-pivot betweenness perf guard
`ComputeCentrality` gains a deterministic sampled-Brandes approximation (K random pivot sources, single-source dependency accumulation, scaled by V/K), gated by node count:
- exact below the threshold, **sampled above** (default **8000**, env `GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD`).
- PageRank + community detection stay **exact every pass** (decision Q1); only betweenness samples above the threshold.
- fixed PCG seed → byte-reproducible.

This bounds the ~O(V·E) exact betweenness on 28k+-entity group unions (plan §4 risk 1).

- **28k synthetic perf:** centrality pass (sampling on) completes in **~8s** (budget 60s); test gated behind `testing.Short()`.
- **Quality:** full-vs-sampled betweenness **top-50 overlap = 0.96** (≥ 0.9) on a 2.5k synthetic graph — the god-node tier is preserved.

## Tests
- `internal/graph/groupalgo/diff_test.go`: 2-repo cross-repo fixture diff (Service rank non-decreasing, JSON round-trips) + empty-group.
- `internal/graph/algorithms_sampled_test.go`: threshold gate (exact below / sampled above, env override), 28k perf budget (`-short`-skippable), top-50 overlap ≥0.9, sampled determinism.

## Validate (local, no CI)
`go build ./...`, `go vet ./internal/graph/... ./cmd/grafel/...`, `gofmt -l` empty, `go test ./internal/graph/...` green.

Do NOT merge — coordinator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
