### PR TITLE
fix(mcp): un-deprecate expand/find_callers/find_callees (metrics show active use)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Changed
 
+- **Un-deprecated `grafel_expand` / `grafel_find_callers` / `grafel_find_callees`
+  — they are first-class tools again (Refs #5386):** live MCP usage metrics show
+  these are actively used (`find_callers` 16 calls) and agents reach for the
+  explicit names over `grafel_neighbors(direction=…)` (2 calls). The
+  "Deprecated…" framing is removed from their tool descriptions and the
+  handshake instructions; all tools (including `grafel_neighbors`) are kept and
+  fully functional. The `node`→`entity_id` param alias on `grafel_expand`
+  (#1916) is unaffected.
+
 - **Graph algorithms now run once per GROUP via a debounced/capped/background
   scheduler; the per-repo algorithm pass is removed (Refs #5355, #5349):**
   communities, PageRank, betweenness, god-nodes and articulation points are now

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -70,7 +70,7 @@ const mcpInstructions = `grafel: a code knowledge-graph over your indexed repos 
 CONVENTIONS
 - entity_id/source/target accept an id, qualified_name, OR a bare label.
 - Output is token-budgeted; pass verbose / token_budget / max_results for more.
-- Defaults to cwd repo at HEAD; widen with cross_repo=true or group/ref. Each tool's inputSchema documents its params. Deprecated: expand, find_callers, find_callees - use neighbors.
+- Defaults to cwd repo at HEAD; widen with cross_repo=true or group/ref. Each tool's inputSchema documents its params.
 
 PICK A TOOL BY INTENT
 - Find code: find (semantic "where is X?"); search_entities (substring); get_source (by id|qname|label); inspect (entity + calls/called_by).
@@ -529,7 +529,7 @@ func (s *Server) registerTools() {
 	), s.wrap("grafel_inspect", s.handleGetNode))
 
 	s.addTool(mcpapi.NewTool("grafel_expand",
-		mcpapi.WithDescription("Deprecated alias of grafel_neighbors. Returns neighbors of entity_id."),
+		mcpapi.WithDescription("Neighbors of an entity (both directions). Alias of grafel_neighbors."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		// 'node' kept as a deprecated alias for one release cycle (#1916).
 		mcpapi.WithString("node"),
@@ -1038,9 +1038,8 @@ func (s *Server) registerTools() {
 	), s.wrap("grafel_neighbors", s.handleNeighbors))
 
 	// verbose=true (default false) read from request map to stay under token ceiling.
-	// Deprecated alias for grafel_neighbors(direction=in) (#1753).
 	s.addTool(mcpapi.NewTool("grafel_find_callers",
-		mcpapi.WithDescription("Deprecated: use grafel_neighbors(direction=in). Inbound callers."),
+		mcpapi.WithDescription("Inbound callers of an entity (who calls it). grafel_neighbors(direction=in)."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),
@@ -1050,9 +1049,8 @@ func (s *Server) registerTools() {
 		// #2769 Phase 1C: min_confidence accepted via #1639 token-ceiling pattern.
 	), s.wrap("grafel_find_callers", s.handleFindCallers))
 
-	// Deprecated alias for grafel_neighbors(direction=out) (#1753).
 	s.addTool(mcpapi.NewTool("grafel_find_callees",
-		mcpapi.WithDescription("Deprecated: use grafel_neighbors(direction=out). Outbound callees."),
+		mcpapi.WithDescription("Outbound callees of an entity (what it calls). grafel_neighbors(direction=out)."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3440,8 +3440,8 @@ func TestMCPInstructionsOrientationMap(t *testing.T) {
 	}
 
 	// (2) cross-cutting conventions: the id|qualified_name|label form and the
-	// deprecated-tool steer toward neighbors.
-	for _, want := range []string{"qualified_name", "bare label", "Deprecated", "neighbors"} {
+	// neighbors navigation tool.
+	for _, want := range []string{"qualified_name", "bare label", "neighbors"} {
 		if !strings.Contains(mcpInstructions, want) {
 			t.Errorf("instructions missing convention marker %q", want)
 		}


### PR DESCRIPTION
## Summary

Un-deprecate three traversal MCP tools that **live usage metrics show are actively used**, while keeping ALL tools fully functional.

- `grafel_find_callers` — **16 calls** live
- `grafel_find_callees`
- `grafel_expand`

vs `grafel_neighbors(direction=…)` — **2 calls**. Agents prefer the explicit, intent-named tools over the parameterized `neighbors` form, so demoting them to "deprecated" was steering against actual usage.

## What changed (Go-only, `internal/mcp/server.go`)

- Replaced the three `"Deprecated…"` tool descriptions with concise first-class ones (all under the mcp-audit 80-char per-tool budget):
  - `grafel_find_callers` → `Inbound callers of an entity (who calls it). grafel_neighbors(direction=in).`
  - `grafel_find_callees` → `Outbound callees of an entity (what it calls). grafel_neighbors(direction=out).`
  - `grafel_expand` → `Neighbors of an entity (both directions). Alias of grafel_neighbors.`
- Removed the `// Deprecated alias …` code comments.
- Removed the `Deprecated: expand, find_callers, find_callees - use neighbors.` steer from the handshake instructions string.
- `grafel_neighbors` is unchanged; no tool removed; no handler/param changed. The `node`→`entity_id` param alias on `grafel_expand` (#1916) still works (param accepted, per-call deprecation log retained).

## Tests
- Updated `TestMCPInstructionsOrientationMap` (server_test.go) to drop the now-removed `"Deprecated"` instruction marker.
- `param_rename_test.go` / `token_sprint_test.go` assert param-alias behavior + registration only — unaffected and green.

## Validation (local)
- `go build ./...` ✓
- `go vet ./internal/mcp/...` ✓
- `gofmt -l` empty ✓
- `go test ./internal/mcp/...` green ✓
- `go run ./cmd/mcp-audit` PASS — handshake **6119 tokens** (unchanged), all descriptions valid.

Refs #5386

🤖 Generated with [Claude Code](https://claude.com/claude-code)