### PR TITLE
fix(daemon): watcher ignores build artifacts + gitignored paths; coalesce reindex (resilience)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,17 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **Daemon watcher re-index loop on build artifacts → memory thrash + MCP
+  socket loss (Refs #5392):** the file-watcher now ignores build/output
+  artifacts and gitignored paths and coalesces per-repo reindexes, so build
+  churn (e.g. an Android AAB/gradle build under a watched repo) no longer
+  triggers a continuous reindex loop / heap thrash. The static event-boundary
+  ignore set gained the mobile build dirs/outputs (`AAB/`, `.dart_tool/`,
+  `*.aab`/`*.apk`/`*.ipa`/`*.aar`) and generated-file globs
+  (`*.generated.*`, `*.g.dart`, `*.pb.go`, ...); the watcher now also honours
+  the repo's `.gitignore` at the event boundary (not just at directory
+  subscription time) so a write under any gitignored path is dropped before it
+  can arm a reindex, and exposes a `GRAFEL_WATCH_EXTRA_SKIP_DIRS` ops override.
 - **Windows installer latest-version auto-resolution produced garbage → 404
   (Refs #5318):** `install.bat` extracted the release tag from the
   `/releases/latest` redirect `location:` header with `%~nx`, which treats its

--- a/internal/daemon/watch/resilience_5392_test.go
+++ b/internal/daemon/watch/resilience_5392_test.go
@@ -1,0 +1,168 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSkipPath_BuildArtifacts5392 is the #5392 regression guard for the
+// static event-boundary filter: build/output artifact dirs and mobile
+// binary outputs must be dropped before they can arm a reindex, while
+// real source paths still pass through.
+func TestSkipPath_BuildArtifacts5392(t *testing.T) {
+	cases := map[string]bool{
+		// build/output dirs (the AAB/gradle churn that caused the incident)
+		"/repo/AAB/app-release.aab":              true,
+		"/repo/android/app/build/outputs/x.dex":  true,
+		"/repo/.gradle/8.0/fileHashes/hash.bin":  true,
+		"/repo/app/.dart_tool/package_config.js": true,
+		"/repo/dist/bundle.js":                   true,
+		"/repo/out/main.js":                      true,
+		"/repo/target/debug/app":                 true,
+		"/repo/node_modules/react/index.js":      true,
+		"/repo/.next/static/chunk.js":            true,
+		"/repo/bin/tool":                         true,
+		"/repo/obj/Debug/app.dll":                true,
+		"/repo/ios/Pods/Manifest.lock":           true,
+		// mobile binary outputs by extension
+		"/repo/build/app-release.aab": true,
+		"/repo/build/app-release.apk": true,
+		"/repo/build/MyApp.ipa":       true,
+		"/repo/build/lib.aar":         true,
+		// generated-file globs
+		"/repo/src/schema.generated.ts": true,
+		"/repo/lib/models.g.dart":       true,
+		"/repo/lib/user.freezed.dart":   true,
+		"/repo/api/service.pb.go":       true,
+		// real source — must NOT be skipped
+		"/repo/src/index.ts":      false,
+		"/repo/internal/cli/a.go": false,
+		"/repo/lib/main.dart":     false,
+		"/repo/app/src/User.kt":   false,
+	}
+	for p, wantSkip := range cases {
+		if got := ShouldSkipPath(p); got != wantSkip {
+			t.Errorf("ShouldSkipPath(%q) = %v, want %v", p, got, wantSkip)
+		}
+	}
+}
+
+// TestSkipPathForRepo_Gitignore5392 verifies that the repo-aware
+// event-boundary filter drops events under a gitignored path even when
+// the path is NOT a well-known static artifact name (the general case
+// that motivated honouring .gitignore at the event boundary).
+func TestSkipPathForRepo_Gitignore5392(t *testing.T) {
+	repo := t.TempDir()
+	// Gitignore an arbitrarily-named output dir + a bespoke artifact glob
+	// that the static lists do not know about.
+	gi := "secret-build/\n*.myartifact\n"
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte(gi), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evictRepoIgnoreState(repo)
+
+	mustSkip := []string{
+		filepath.Join(repo, "secret-build", "out.bin"),
+		filepath.Join(repo, "thing.myartifact"),
+	}
+	for _, p := range mustSkip {
+		if !ShouldSkipPathForRepo(repo, p) {
+			t.Errorf("ShouldSkipPathForRepo(%q) = false, want true (gitignored)", p)
+		}
+	}
+
+	mustPass := []string{
+		filepath.Join(repo, "src", "main.go"),
+		filepath.Join(repo, "README.md"),
+	}
+	for _, p := range mustPass {
+		if ShouldSkipPathForRepo(repo, p) {
+			t.Errorf("ShouldSkipPathForRepo(%q) = true, want false (real source)", p)
+		}
+	}
+
+	// Path outside the repo degrades to the static filter (no panic, no
+	// false skip for a real source path).
+	if ShouldSkipPathForRepo(repo, "/elsewhere/main.go") {
+		t.Errorf("expected out-of-repo source path not to be skipped")
+	}
+}
+
+// TestExtraSkipDirsEnv5392 verifies the GRAFEL_WATCH_EXTRA_SKIP_DIRS
+// ops escape hatch. Because the parse is sync.Once-guarded we set the
+// env before the first call in this binary; if another test already
+// triggered the parse this asserts the no-op default behaviour instead.
+func TestExtraSkipDirsEnv5392(t *testing.T) {
+	t.Setenv("GRAFEL_WATCH_EXTRA_SKIP_DIRS", "myoutdir, another ")
+	// Reset the once so this test deterministically observes the env
+	// regardless of whether another test already triggered the parse.
+	envExtraSkipOnce = sync.Once{}
+	got := extraSkipDirsFromEnv()
+	if _, ok := got["myoutdir"]; !ok {
+		t.Errorf("expected myoutdir in env extra-skip set, got %v", got)
+	}
+	if _, ok := got["another"]; !ok {
+		t.Errorf("expected 'another' (trimmed) in env extra-skip set, got %v", got)
+	}
+	if !ShouldSkipDir("myoutdir") {
+		t.Errorf("ShouldSkipDir(myoutdir) = false, want true via env")
+	}
+}
+
+// TestCoalesce_RapidWrites5392 is the per-repo coalesce guard: a burst of
+// N rapid writes to a single repo within the debounce window collapses to
+// at most ONE sink invocation (one reindex), not N.
+func TestCoalesce_RapidWrites5392(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	src := filepath.Join(repo, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	evictRepoIgnoreState(repo)
+
+	var calls atomic.Int32
+	w, err := newTestWatcher(200*time.Millisecond, func(string, bool) {
+		calls.Add(1)
+	})
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// 20 rapid writes well within the 200ms debounce window.
+	for i := 0; i < 20; i++ {
+		f := filepath.Join(src, "f"+itoa5392(i)+".go")
+		if err := os.WriteFile(f, []byte("package main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Wait past the debounce window for the coalesced sink to fire.
+	time.Sleep(500 * time.Millisecond)
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected exactly 1 coalesced sink call for 20 rapid writes, got %d", n)
+	}
+}
+
+func itoa5392(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/daemon/watch/skip.go
+++ b/internal/daemon/watch/skip.go
@@ -10,11 +10,34 @@
 package watch
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/cajasmota/grafel/internal/daemon/walk"
 )
+
+// envExtraSkipDirs holds additional directory basenames parsed once from
+// the GRAFEL_WATCH_EXTRA_SKIP_DIRS environment variable (comma-separated).
+// This is the global, ops-tunable escape hatch for sites whose build
+// tooling writes to a dir not covered by the built-in SkipDirs set (#5392).
+var (
+	envExtraSkipOnce sync.Once
+	envExtraSkipDirs map[string]struct{}
+)
+
+func extraSkipDirsFromEnv() map[string]struct{} {
+	envExtraSkipOnce.Do(func() {
+		envExtraSkipDirs = make(map[string]struct{})
+		for _, d := range strings.Split(os.Getenv("GRAFEL_WATCH_EXTRA_SKIP_DIRS"), ",") {
+			if d = strings.TrimSpace(d); d != "" {
+				envExtraSkipDirs[d] = struct{}{}
+			}
+		}
+	})
+	return envExtraSkipDirs
+}
 
 // SkipDirs is the static list of directory basenames the watcher never
 // recurses into. Source trees pin most of their churn behind these
@@ -70,11 +93,17 @@ var SkipDirs = map[string]struct{}{
 	// Android / Gradle
 	".gradle":  {},
 	"captures": {},
-	// Mobile build outputs
+	// Mobile build outputs (#5392: an Android AAB/gradle build under
+	// core-mobile churned these dirs and tripped a continuous reindex
+	// loop → 20GB heap thrash. AAB/ in particular is the project's
+	// Android App Bundle output dir).
 	"APK":      {},
+	"AAB":      {},
 	"IPA":      {},
 	"Builds":   {},
 	"Releases": {},
+	// Flutter / Dart
+	".dart_tool": {},
 	// Prior-tool outputs
 	"graphify-out": {},
 	"gfleet-out":   {},
@@ -109,6 +138,26 @@ var SkipExts = map[string]struct{}{
 	".dylib": {},
 	".dll":   {},
 	".exe":   {},
+	// Mobile build artifacts (#5392). These are large binary outputs of
+	// an app build; writing them must never trip a reindex.
+	".aab": {},
+	".apk": {},
+	".ipa": {},
+	".aar": {},
+}
+
+// SkipBaseGlobs is the list of basename glob patterns whose matches we
+// never re-index for. Unlike SkipExts (which keys on the final
+// extension only), these match anywhere in the basename so multi-dot
+// generated files like `schema.generated.ts` or `api.g.dart` are
+// dropped at the watcher event boundary (#5392).
+var SkipBaseGlobs = []string{
+	"*.generated.*", // foo.generated.ts, foo.generated.go, ...
+	"*.gen.*",       // foo.gen.go
+	"*.g.dart",      // Flutter codegen
+	"*.freezed.dart",
+	"*.pb.go",   // protobuf
+	"*.pb.dart", // protobuf
 }
 
 // ShouldSkipDir reports whether a directory basename is on the skip
@@ -116,6 +165,10 @@ var SkipExts = map[string]struct{}{
 // watcher and the indexer use the identical extended set (issue #805).
 func ShouldSkipDir(base string) bool {
 	if _, ok := SkipDirs[base]; ok {
+		return true
+	}
+	// Ops-tunable global escape hatch (#5392).
+	if _, ok := extraSkipDirsFromEnv()[base]; ok {
 		return true
 	}
 	// TCC guard (#5296): never recurse into macOS media-library bundles
@@ -144,8 +197,64 @@ func ShouldSkipPath(p string) bool {
 	if _, ok := SkipExts[ext]; ok {
 		return true
 	}
+	// Multi-dot generated-file globs (e.g. *.generated.*, *.g.dart).
+	base := filepath.Base(filepath.ToSlash(p))
+	for _, g := range SkipBaseGlobs {
+		if ok, _ := filepath.Match(g, base); ok {
+			return true
+		}
+	}
 	// Vim creates `4913` test files and `.foo.swp` style swap files;
 	// the latter is caught by .swp above, the former is rare enough to
 	// ignore (it lives at most for a few ms).
+	return false
+}
+
+// ShouldSkipPathForRepo is the repo-aware event-boundary filter. It is a
+// superset of ShouldSkipPath: in addition to the static SkipDirs /
+// SkipExts / SkipBaseGlobs rules it consults the repo's .gitignore (and
+// per-repo .grafel/watch.json) so that a file event under a gitignored
+// path NEVER triggers a reindex (#5392).
+//
+// This matters because the static lists can only cover *well-known*
+// artifact names. A repo may gitignore arbitrary build/output dirs
+// (e.g. AAB/, app/build/, *.aab) that the watcher's directory-level
+// subscription already declines to watch — but events can still surface
+// for them via a watched parent directory (e.g. a Create event for a new
+// gitignored subdir, or a file written at the repo root). Honouring
+// .gitignore at the event boundary drops that churn cheaply.
+//
+// repoPath must be the absolute repo root; p must be inside it. When
+// repoPath is empty or p is not under it, this degrades to ShouldSkipPath.
+func ShouldSkipPathForRepo(repoPath, p string) bool {
+	if ShouldSkipPath(p) {
+		return true
+	}
+	if repoPath == "" {
+		return false
+	}
+	rel, err := filepath.Rel(repoPath, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." || rel == "" {
+		return false
+	}
+	s := loadRepoIgnoreState(repoPath)
+	// Walk the path and each ancestor directory: a file is ignored if it
+	// OR any ancestor dir matches .gitignore (a `build/` rule ignores the
+	// dir, so everything beneath it is ignored too) or a per-repo
+	// exclude_dirs basename.
+	segs := strings.Split(rel, "/")
+	for i := 1; i <= len(segs); i++ {
+		sub := strings.Join(segs[:i], "/")
+		if _, ok := s.extraSkip[segs[i-1]]; ok {
+			return true
+		}
+		if skip, _ := s.gitignore.MatchDir(sub); skip {
+			return true
+		}
+	}
 	return false
 }

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -519,7 +519,27 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 	if ev.Op == fsnotify.Chmod {
 		return
 	}
+	// Cheap static filter first (no I/O, no repo lookup): SkipDirs /
+	// SkipExts / generated-file globs.
 	if ShouldSkipPath(ev.Name) {
+		atomic.AddUint64(&w.droppedSkips, 1)
+		return
+	}
+
+	// Determine the owning repo. We need it both for the gitignore-aware
+	// filter and to arm the debounce timer.
+	repo := w.repoFor(ev.Name)
+	if repo == "" {
+		return
+	}
+
+	// Repo-aware filter (#5392): drop events under a gitignored path or a
+	// per-repo excluded dir BEFORE arming a reindex. Build artifacts that
+	// the repo gitignores (e.g. AAB/, app/build/, *.aab) churn heavily
+	// during an Android/gradle build; honouring .gitignore here prevents
+	// the reindex loop + heap thrash even when the artifact dir doesn't
+	// match a well-known static name.
+	if ShouldSkipPathForRepo(repo, ev.Name) {
 		atomic.AddUint64(&w.droppedSkips, 1)
 		return
 	}
@@ -534,10 +554,6 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 		}
 	}
 
-	repo := w.repoFor(ev.Name)
-	if repo == "" {
-		return
-	}
 	w.recordAndArm(repo)
 }
 


### PR DESCRIPTION
Refs #5392.

## Incident
A daemon serving `the multi-repo group` + `the v3 group` + `the mobile repo` went unhealthy: `the mobile repo` was being **built** (Android AAB / gradle), the file-watcher reacted to the artifact/ignored-path writes (`build/`, `.gradle/`, `AAB/`, generated files) and re-indexed in a **tight loop** → `heap_mb` ~18–21 GB thrash → the **MCP socket (`~/.grafel/sockets/daemon.sock`) vanished**, blocking a a concurrent agent. Recovery was a `launchctl kickstart -k`.

Root cause: the watcher's **event-boundary** filter (`handleEvent` → `ShouldSkipPath`) only consulted static `SkipDirs`/`SkipExts` basenames. It did **not** honour the repo's `.gitignore` at the event boundary (only at directory *subscription* time), and was missing several mobile build-artifact names. So writes under a gitignored output dir, or to artifact files at a watched level, still armed a reindex.

## Fixes (event-boundary, where artifact churn is cheapest to drop)

**1. Ignore build/output artifacts + gitignored paths**
- Extended `SkipDirs`: `AAB/`, `.dart_tool/` (existing set already covers `build/`, `.gradle/`, `dist/`, `out/`, `target/`, `node_modules/`, `.next/`, `Pods/`, and `bin`/`obj` via `walk.IsHardcodedSkip`).
- Extended `SkipExts`: `.aab`, `.apk`, `.ipa`, `.aar`.
- New `SkipBaseGlobs`: `*.generated.*`, `*.gen.*`, `*.g.dart`, `*.freezed.dart`, `*.pb.go`, `*.pb.dart`.
- **New `ShouldSkipPathForRepo(repo, path)`** — repo-aware filter applied in `handleEvent` BEFORE arming a reindex. It is a superset of `ShouldSkipPath` and additionally consults the repo's **`.gitignore`** (walking the path + each ancestor dir so a `build/` rule ignores everything beneath it) and per-repo `watch.json:exclude_dirs`. A write under ANY gitignored path is now dropped even when the dir is not a well-known static name (e.g. a bespoke `AAB/` / `secret-build/` an individual repo gitignores).
- **`GRAFEL_WATCH_EXTRA_SKIP_DIRS`** env override (comma-separated) as a global ops escape hatch.

**2. Coalesce per-repo reindexes** — already present, now regression-tested:
- Watcher: per-repo 5s debounce timer (`recordAndArm`) collapses a burst into one sink call; bulk-detect short-circuits a checkout storm.
- Scheduler: at-most-one-reindex-per-repo via the `dirty` flag (#5138) — enqueues while a reindex is in-flight coalesce into a single follow-up.
- Added `TestCoalesce_RapidWrites5392`: 20 rapid writes → exactly 1 reindex.

## Tests
`internal/daemon/watch/resilience_5392_test.go`:
- `TestSkipPath_BuildArtifacts5392` — `AAB/`, `.gradle/`, `node_modules/`, `.dart_tool/`, `*.aab`, `*.generated.*`, `*.g.dart`, `*.pb.go` → **dropped**; real source (`.go/.ts/.dart/.kt`) → **enqueued**.
- `TestSkipPathForRepo_Gitignore5392` — a gitignored dir (`secret-build/`) and glob (`*.myartifact`) → **dropped**; real source → **enqueued**; out-of-repo path degrades safely.
- `TestExtraSkipDirsEnv5392` — env override honoured.
- `TestCoalesce_RapidWrites5392` — N writes → ≤1 reindex (injectable 200ms debounce).

Validation: `go build ./...`, `go vet ./internal/daemon/...`, `gofmt -l` clean, `go test -race ./internal/daemon/...` **all green** (no new failures).

## Socket-survival investigation (follow-up, not fixed here)
The incident's socket loss is a **separate** failure mode worth its own change. In `server.go`, `acceptLoop` returns on **any** non-`net.ErrClosed` error from `listener.Accept()` → `Run` returns `errors.New("listener closed")` → the daemon exits and the deferred cleanup `os.Remove`s the socket file. Under severe memory pressure `Accept()` can fail with **transient** errors (`EMFILE`/`ENOMEM` — "too many open files" / "cannot allocate memory"), which the loop currently treats as fatal and tears down the listener — matching "MCP socket vanished while dashboard HTTP stayed 200". 

Recommended follow-up: make `acceptLoop` resilient to transient `Accept()` errors (retry with backoff on `EMFILE`/`ENOMEM`/`net.Error.Temporary()` instead of exiting) and/or supervise + auto-recreate the unix listener independent of indexing load, so the RPC socket survives memory pressure. This PR's reindex-loop fix removes the *trigger*; the listener hardening removes the *blast radius*.