### PR TITLE
fix(test): stabilize flaky daemon/dashboard timing tests (deterministic await)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,18 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **Stabilized flaky daemon timing tests (`TestIndexProgress_LivePolling` +
+  SSE/poller siblings):** replaced fixed `time.Sleep` waits + tight deadlines
+  with deterministic bounded-await on the actual condition, so the pre-milestone
+  full 3-OS CI is reliable. `TestIndexProgress_LivePolling` now awaits the
+  rebuild session becoming visible mid-flight (instead of a 20ms sleep + a 200ms
+  rebuild window that scheduler jitter on a loaded `-race` runner could overrun);
+  `TestSSE_MultipleSubscribers` awaits both subscribers attaching via
+  `broker.Stats()` (instead of a 50ms sleep before publishing, which could race
+  ahead of a not-yet-registered subscriber); and `TestSSE_DisconnectRemovesSubscriber`
+  awaits the broker deregistering the subscriber (instead of asserting once after
+  a fixed 200ms). Test-only changes; no production behavior change.
+
 - **Daemon watcher re-index loop on build artifacts → memory thrash + MCP
   socket loss (Refs #5392):** the file-watcher now ignores build/output
   artifacts and gitignored paths and coalesces per-repo reindexes, so build

--- a/internal/daemon/progress_test.go
+++ b/internal/daemon/progress_test.go
@@ -61,8 +61,13 @@ func TestIndexProgress_EmptyToken(t *testing.T) {
 // can be polled mid-flight and returns Done=true after the rebuild completes.
 func TestIndexProgress_LivePolling(t *testing.T) {
 	repos := []string{"/repo/alpha", "/repo/beta"}
-	// 200ms delay gives the test enough time to poll once mid-flight.
-	layout := runDaemonForTest(t, nil, slowRebuildFunc(repos, 200*time.Millisecond))
+	// 2s delay keeps the rebuild "in flight" for long enough that the mid-flight
+	// poll below — which bounded-awaits the session becoming visible rather than
+	// sleeping a fixed amount — always lands while the rebuild is still sleeping,
+	// even on a heavily loaded / -race CI runner. The previous 200ms window was
+	// tight enough that scheduler jitter could let the rebuild finish before the
+	// mid-flight assertion ran (timing flake).
+	layout := runDaemonForTest(t, nil, slowRebuildFunc(repos, 2*time.Second))
 
 	// Primary connection: fires off the blocking Rebuild.
 	primary, err := client.DialPath(layout.SocketPath)
@@ -94,21 +99,32 @@ func TestIndexProgress_LivePolling(t *testing.T) {
 		resultCh <- rebuildResult{reply, err}
 	}()
 
-	// Allow the rebuild goroutine to start and register the session.
-	time.Sleep(20 * time.Millisecond)
-
-	// Poll for progress — at this point the rebuild is sleeping.
-	prog, err := poll.IndexProgress(token)
-	if err != nil {
-		t.Fatalf("IndexProgress mid-flight: %v", err)
-	}
-	// The session is registered and active — Done must be false.
-	if prog.Done {
-		t.Error("expected Done=false mid-flight, got true")
-	}
-	// We should have at least one repo state visible (the started stub).
-	if len(prog.Repos) == 0 {
-		t.Error("expected at least one repo state mid-flight")
+	// Bounded-await the mid-flight progress snapshot rather than sleeping a fixed
+	// 20ms and hoping the background Rebuild goroutine has already issued its RPC
+	// and registered the session. On a loaded/-race CI runner the goroutine can
+	// take well over 20ms to send the RPC over the socket, so a single fixed-sleep
+	// snapshot was racy: it could observe the not-yet-registered token (Done=true,
+	// zero repos) and fail. We retry until the session is visible and active —
+	// Done=false with at least one repo state — which is the actual condition
+	// under test. The rebuild sleeps 2s, so this deadline comfortably resolves
+	// while it is still in flight.
+	var prog proto.IndexProgressReply
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for {
+		prog, err = poll.IndexProgress(token)
+		if err != nil {
+			t.Fatalf("IndexProgress mid-flight: %v", err)
+		}
+		// Session registered and active with at least one repo state visible
+		// (the started stub) — this is the mid-flight condition we assert.
+		if !prog.Done && len(prog.Repos) > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("rebuild session never became visible mid-flight: Done=%v repos=%d",
+				prog.Done, len(prog.Repos))
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	// Wait for rebuild to complete.

--- a/internal/dashboard/handlers_progress_test.go
+++ b/internal/dashboard/handlers_progress_test.go
@@ -229,8 +229,19 @@ func TestSSE_MultipleSubscribers(t *testing.T) {
 	readSSELines(t, r1, 1, 2*time.Second)
 	readSSELines(t, r2, 1, 2*time.Second)
 
-	// Give the broker a moment to register both subscribers.
-	time.Sleep(50 * time.Millisecond)
+	// Bounded-await both subscribers being registered with the broker rather than
+	// sleeping a fixed 50ms and hoping both SSE handler goroutines have called
+	// Subscribe by then. On a loaded/-race CI runner handler registration can lag
+	// past 50ms, so the subsequent Publish would race ahead of a not-yet-attached
+	// subscriber and that subscriber would miss the event (timing flake). We poll
+	// Stats() until both are attached, which is the actual precondition.
+	subDeadline := time.Now().Add(5 * time.Second)
+	for broker.Stats()["shared-group"] < 2 {
+		if time.Now().After(subDeadline) {
+			t.Fatalf("both subscribers never registered: stats=%v", broker.Stats())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	broker.Publish(progress.Event{
 		GroupSlug: "shared-group",
@@ -273,12 +284,21 @@ func TestSSE_DisconnectRemovesSubscriber(t *testing.T) {
 	// Cancel the client context to simulate disconnect.
 	cancel()
 
-	// Allow the server goroutine to detect the disconnect and call cancel().
-	time.Sleep(200 * time.Millisecond)
-
-	stats := broker.Stats()
-	if n := stats["temp-group"]; n != 0 {
-		t.Errorf("broker still has %d subscriber(s) for temp-group after disconnect", n)
+	// Bounded-await the server goroutine detecting the disconnect and
+	// deregistering the subscriber, rather than sleeping a fixed 200ms and
+	// asserting once. Under load the detect-and-unsubscribe path can take longer
+	// than 200ms, which made the single-shot assertion flaky.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if n := broker.Stats()["temp-group"]; n == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Errorf("broker still has %d subscriber(s) for temp-group after disconnect",
+				broker.Stats()["temp-group"])
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Stabilizes `TestIndexProgress_LivePolling` + SSE/poller heartbeat timing tests (bounded polling vs fixed sleeps). Test-only. Validated by CI (NOT run locally with -count loops — those re-run the cpu_cap tests that froze the dev machine). Recovered from the interrupted flaky-test agent.