### PR TITLE
fix(mcp): serve group-algo overlay on the read-side (clusters/inspect/impact) (#5396, #5397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP read-side now serves the group-algo overlay instead of per-repo Louvain
+  (Fixes #5396, #5397):** the group-level overlay (`~/.grafel/groups/<group>-algo.json`)
+  was computed correctly and stamped onto entities by `applyGroupAlgoOverlay`,
+  but the query tools never read it. `grafel_clusters`/`handleListCommunities`
+  now serves the **group** communities when the overlay is applied — so a
+  community can surface members spanning >1 repo (reported via a `repos` list and
+  a `cross_repo` flag instead of being force-tagged to a single repo), and
+  `core-mobile` entities (community 80) appear instead of a whole repo silently
+  showing 0 communities (#5397). A `repo_filter` naming only one repo of a
+  cross-repo community still surfaces that community. `grafel_inspect` now
+  surfaces the overlay `community_id`/`pagerank`/`centrality` (and god-node /
+  articulation-point flags) when requested via
+  `include=community,pagerank,centrality`, not only under `verbose` — and
+  `centrality` is surfaced at all for the first time. `grafel_orient` already
+  reads the overlay-stamped per-entity values. Fully absence-tolerant: with no
+  overlay present, every tool keeps its prior per-repo behavior unchanged.
+
 ### Changed
 
 - **Un-deprecated `grafel_expand` / `grafel_find_callers` / `grafel_find_callees`

--- a/internal/mcp/groupalgo_readside_5396_test.go
+++ b/internal/mcp/groupalgo_readside_5396_test.go
@@ -1,0 +1,183 @@
+package mcp
+
+// groupalgo_readside_5396_test.go — read-side serving of the group-algo overlay
+// (#5396, #5397).
+//
+// The group-algo overlay (~/.grafel/groups/<group>-algo.json) is computed by a
+// single Louvain pass across ALL repos in the group, then applied to the live
+// graph by applyGroupAlgoOverlay (#5354): it stamps each entity's CommunityID /
+// PageRank / Centrality and populates LoadedGroup.Communities with the group
+// community summary.
+//
+// Before #5396 the read-side consumers ignored that overlay:
+//   - handleListCommunities looped repos and read per-repo r.Doc.Communities, so
+//     a cross-repo community was never visible and a repo whose per-repo Louvain
+//     never persisted (core-mobile, #5397) silently produced zero communities.
+//   - grafel_inspect only surfaced pagerank/community_id under verbose and never
+//     centrality, and ignored include=community,pagerank,centrality.
+//
+// These tests build a synthetic 2-repo group with an overlay placing a
+// cross-repo entity in a shared community and assert the read-side now serves
+// the group view.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// twoRepoOverlayServer builds a "test" group with two repos whose entities are
+// already overlay-stamped into a single shared group community (id 42) plus one
+// backend-only community (id 7), and sets lg.Communities to the group summary —
+// exactly the post-applyGroupAlgoOverlay state the read-side must serve.
+func twoRepoOverlayServer(t *testing.T) *Server {
+	t.Helper()
+	backend := &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "be_shared", Name: "User", Kind: "SCOPE.Class", SourceFile: "user.py", StartLine: 1,
+				CommunityID: ip(42), PageRank: f64p(0.0065), Centrality: f64p(10415.99), IsGodNode: true},
+			{ID: "be_only", Name: "Migration", Kind: "SCOPE.Class", SourceFile: "m.py", StartLine: 1,
+				CommunityID: ip(7), PageRank: f64p(0.001), Centrality: f64p(3.0)},
+		},
+	}
+	mobile := &graph.Document{
+		Repo: "core-mobile",
+		Entities: []graph.Entity{
+			{ID: "mob_shared", Name: "ResponsiveView", Kind: "SCOPE.Component", SourceFile: "v.tsx", StartLine: 1,
+				CommunityID: ip(42), PageRank: f64p(0.004), Centrality: f64p(120.5)},
+		},
+	}
+	srv := newTestServer(t, backend, mobile)
+
+	// Mirror what applyGroupAlgoOverlay would have set: the group community
+	// summary. core-mobile (#5397) carries members of community 42 even though
+	// it has no per-repo Doc.Communities of its own.
+	srv.State.mu.Lock()
+	lg := srv.State.groups["test"]
+	lg.Communities = []graph.CommunityResult{
+		{ID: 42, Size: 2, Modularity: 0.7319, TopEntities: []string{"be_shared", "mob_shared"}, AutoName: "user-domain"},
+		{ID: 7, Size: 1, Modularity: 0.5, TopEntities: []string{"be_only"}, AutoName: "migrations"},
+	}
+	srv.State.mu.Unlock()
+	return srv
+}
+
+func clustersResult(t *testing.T, srv *Server, args map[string]any) []any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	if args == nil {
+		args = map[string]any{}
+	}
+	args["group"] = "test"
+	req.Params.Arguments = args
+	res, err := srv.handleListCommunities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleListCommunities error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("clusters tool error: %v", res)
+	}
+	// handleListCommunities returns a top-level JSON array.
+	var arr []any
+	if err := json.Unmarshal([]byte(extractResultText(t, res)), &arr); err != nil {
+		t.Fatalf("clusters: unmarshal array failed: %v\nraw: %s", err, extractResultText(t, res))
+	}
+	return arr
+}
+
+// TestClusters_ServesGroupOverlay_CrossRepoCommunity asserts handleListCommunities
+// returns a community whose members span both repos (#5396) and is NOT
+// force-tagged to a single repo — including core-mobile (#5397).
+func TestClusters_ServesGroupOverlay_CrossRepoCommunity(t *testing.T) {
+	srv := twoRepoOverlayServer(t)
+	items := clustersResult(t, srv, map[string]any{"min_size": 1})
+
+	var crossRepo map[string]any
+	for _, it := range items {
+		m := it.(map[string]any)
+		if int(m["id"].(float64)) == 42 {
+			crossRepo = m
+		}
+		// No group community may be force-tagged to a single repo via "repo".
+		if _, hasSingleRepo := m["repo"]; hasSingleRepo {
+			t.Errorf("group community %v force-tagged to single repo (per-repo path leaked): %v", m["id"], m)
+		}
+	}
+	if crossRepo == nil {
+		t.Fatalf("community 42 (cross-repo) not returned; got %v", items)
+	}
+	if cr, _ := crossRepo["cross_repo"].(bool); !cr {
+		t.Errorf("community 42 not flagged cross_repo: %v", crossRepo)
+	}
+	reposAny, ok := crossRepo["repos"].([]any)
+	if !ok || len(reposAny) != 2 {
+		t.Fatalf("community 42 must span 2 repos, got repos=%v", crossRepo["repos"])
+	}
+	seen := map[string]bool{}
+	for _, r := range reposAny {
+		seen[r.(string)] = true
+	}
+	if !seen["backend"] || !seen["core-mobile"] {
+		t.Errorf("community 42 members must span backend AND core-mobile (#5397), got %v", reposAny)
+	}
+}
+
+// TestClusters_RepoFilter_KeepsCrossRepoCommunity asserts a repo_filter naming
+// only one of a cross-repo community's repos still surfaces that community.
+func TestClusters_RepoFilter_KeepsCrossRepoCommunity(t *testing.T) {
+	srv := twoRepoOverlayServer(t)
+	items := clustersResult(t, srv, map[string]any{"min_size": 1, "repo_filter": []any{"core-mobile"}})
+
+	found42, found7 := false, false
+	for _, it := range items {
+		m := it.(map[string]any)
+		switch int(m["id"].(float64)) {
+		case 42:
+			found42 = true
+		case 7:
+			found7 = true
+		}
+	}
+	if !found42 {
+		t.Errorf("repo_filter=core-mobile dropped cross-repo community 42 (#5397)")
+	}
+	if found7 {
+		t.Errorf("repo_filter=core-mobile should NOT surface backend-only community 7")
+	}
+}
+
+// TestInspect_SurfacesOverlayAlgoFields asserts grafel_inspect surfaces the
+// overlay community_id/pagerank/centrality when requested via
+// include=community,pagerank,centrality (validation flaw 3 / #5396).
+func TestInspect_SurfacesOverlayAlgoFields(t *testing.T) {
+	srv := twoRepoOverlayServer(t)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"group":     "test",
+		"entity_id": "backend::be_shared",
+		"include":   "community,pagerank,centrality",
+	}
+	res, err := srv.handleGetNode(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetNode error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("inspect tool error: %v", res)
+	}
+	out := extractResultJSON(t, res)
+
+	cid, ok := out["community_id"].(float64)
+	if !ok || int(cid) != 42 {
+		t.Errorf("inspect did not surface overlay community_id=42, got %v", out["community_id"])
+	}
+	if pr, ok := out["pagerank"].(float64); !ok || pr == 0 {
+		t.Errorf("inspect did not surface overlay pagerank, got %v", out["pagerank"])
+	}
+	if cen, ok := out["centrality"].(float64); !ok || cen == 0 {
+		t.Errorf("inspect did not surface overlay centrality, got %v", out["centrality"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1175,6 +1175,13 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	// (conditional/condition/in_loop). Off by default so the inspect payload is
 	// byte-identical (#2828 token-reduction respected).
 	includeCallContexts := includeWants(req, "call_contexts")
+	// #5396 (validation flaw 3): surface the group-algo overlay values
+	// (community_id/pagerank/centrality) when explicitly requested via
+	// include=community,pagerank,centrality — previously inspect only emitted
+	// pagerank/community_id under verbose, and never centrality. Verbose already
+	// projects these (a superset), so only the non-verbose include path needs it.
+	includeAlgo := !verbose && (includeWants(req, "community") ||
+		includeWants(req, "pagerank") || includeWants(req, "centrality"))
 	allFindings := loadFindings(findingsMemDir(g, lg))
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
@@ -1182,6 +1189,9 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 			if e, ok := r.LabelIndex.ByID[local]; ok {
 				scopeIsOne := len(repos) == 1
 				out := serializeEntity(r.Repo, e, scopeIsOne, verbose)
+				if includeAlgo {
+					addAlgoFields(out, e)
+				}
 				// #2290: omit findings key entirely when no findings exist.
 				if fs := findingsForEntity(allFindings, e.ID, prefixedID(r.Repo, e.ID)); len(fs) > 0 {
 					out["findings"] = findingsToJSON(fs, 0)
@@ -1259,6 +1269,9 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	m := matches[0]
 	scopeIsOne := len(repos) == 1
 	out := serializeEntity(m.repo.Repo, m.ent, scopeIsOne, verbose)
+	if includeAlgo {
+		addAlgoFields(out, m.ent)
+	}
 	// #2290: omit findings key entirely when no findings exist.
 	if fs := findingsForEntity(allFindings, m.ent.ID, prefixedID(m.repo.Repo, m.ent.ID)); len(fs) > 0 {
 		out["findings"] = findingsToJSON(fs, 0)
@@ -1896,17 +1909,39 @@ func serializeEntity(repo string, e *graph.Entity, scopeIsOne bool, verbose ...b
 		out["end_line"] = e.EndLine
 		out["language"] = e.Language
 		out["repo"] = repo
-		if e.PageRank != nil {
-			out["pagerank"] = *e.PageRank
-		}
-		if e.CommunityID != nil {
-			out["community_id"] = *e.CommunityID
-		}
+		// Verbose has always surfaced pagerank/community_id; centrality and the
+		// god-node/articulation flags are added here so a verbose inspect is a
+		// superset of include= (#5396).
+		addAlgoFields(out, e)
 		if len(e.Properties) > 0 {
 			out["properties"] = e.Properties
 		}
 	}
 	return out
+}
+
+// addAlgoFields projects the group-algo overlay values (stamped onto every
+// entity by applyGroupAlgoOverlay, #5354) onto an inspect payload. Pointers are
+// absence-tolerant: with no overlay (and no per-repo algo pass) the fields are
+// simply omitted. Called for verbose inspects and for
+// include=community,pagerank,centrality requests (#5396, validation flaw 3 —
+// inspect previously gated these on verbose only and never surfaced centrality).
+func addAlgoFields(out map[string]any, e *graph.Entity) {
+	if e.PageRank != nil {
+		out["pagerank"] = *e.PageRank
+	}
+	if e.CommunityID != nil {
+		out["community_id"] = *e.CommunityID
+	}
+	if e.Centrality != nil {
+		out["centrality"] = *e.Centrality
+	}
+	if e.IsGodNode {
+		out["is_god_node"] = true
+	}
+	if e.IsArticulationPt {
+		out["is_articulation_point"] = true
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -2211,12 +2246,26 @@ func (s *Server) handleListCommunities(ctx context.Context, req mcpapi.CallToolR
 	if errRes != nil {
 		return errRes, nil
 	}
-	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	repoFilter := argStringSlice(req, "repo_filter")
+	repos := reposToConsider(lg, repoFilter)
 	// Defaults sized to keep an overview response cheap; both are overridable
 	// via the same arg map the rest of the tool surface uses (issue #2289).
 	// Pass top_entities_limit=-1 / min_size=0 to disable either cap.
 	topLimit := argInt(req, "top_entities_limit", 3)
 	minSize := argInt(req, "min_size", 20)
+
+	// #5396: when the group-algo overlay is applied (lg.Communities populated),
+	// serve the GROUP communities — these were computed by a single Louvain run
+	// across all repos in the group, so a community can span >1 repo. The
+	// per-entity CommunityID was already stamped onto every entity by
+	// applyGroupAlgoOverlay (#5354), so we recover each community's membership
+	// (and its repo span, #5397 — incl. core-mobile) by scanning the loaded
+	// entities. Absence-tolerant: an empty overlay falls back to the per-repo
+	// path below unchanged.
+	if len(lg.Communities) > 0 {
+		return jsonResult(groupCommunities(lg, repoFilter, minSize, topLimit)), nil
+	}
+
 	out := []map[string]any{}
 	for _, r := range repos {
 		if r.Doc == nil {
@@ -2245,6 +2294,99 @@ func (s *Server) handleListCommunities(ctx context.Context, req mcpapi.CallToolR
 		}
 	}
 	return jsonResult(out), nil
+}
+
+// groupCommunities renders the group-algo overlay communities (#5396). Each
+// overlay community was computed across the whole group, so its members can
+// live in more than one repo. Membership and repo span are reconstructed from
+// the overlay-stamped per-entity CommunityID (set by applyGroupAlgoOverlay).
+//
+// A community is NOT force-tagged to a single repo: it reports the full set of
+// repos its members occupy via the "repos" field, plus a cross-repo flag. When
+// repo_filter is set, a community surfaces if ANY of its members is in a
+// filtered repo (so a cross-repo community is not dropped just because the
+// filter names only one of its repos).
+func groupCommunities(lg *LoadedGroup, repoFilter []string, minSize, topLimit int) []map[string]any {
+	// repos a member of community id occupies (deduped, sorted on emit).
+	reposByCommunity := map[int]map[string]struct{}{}
+	for _, r := range lg.Repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			cid := r.Doc.Entities[i].CommunityID
+			if cid == nil {
+				continue
+			}
+			m := reposByCommunity[*cid]
+			if m == nil {
+				m = map[string]struct{}{}
+				reposByCommunity[*cid] = m
+			}
+			m[r.Repo] = struct{}{}
+		}
+	}
+
+	// repo_filter membership: a community surfaces if any of its repos is named.
+	wantRepo := map[string]struct{}{}
+	allRepos := len(repoFilter) == 0 || (len(repoFilter) == 1 && repoFilter[0] == "*")
+	if !allRepos {
+		for _, n := range repoFilter {
+			wantRepo[n] = struct{}{}
+		}
+	}
+
+	comms := make([]graph.CommunityResult, len(lg.Communities))
+	copy(comms, lg.Communities)
+	sort.SliceStable(comms, func(i, j int) bool { return comms[i].Size > comms[j].Size })
+
+	out := []map[string]any{}
+	for _, c := range comms {
+		if c.Size < minSize {
+			continue
+		}
+		repoSet := reposByCommunity[c.ID]
+		repoList := make([]string, 0, len(repoSet))
+		for rn := range repoSet {
+			repoList = append(repoList, rn)
+		}
+		sort.Strings(repoList)
+
+		if !allRepos {
+			match := false
+			for _, rn := range repoList {
+				if _, ok := wantRepo[rn]; ok {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+
+		top := c.TopEntities
+		if topLimit >= 0 && len(top) > topLimit {
+			top = top[:topLimit]
+		}
+		name := c.AgentName
+		if name == "" {
+			name = c.AutoName
+		}
+		row := map[string]any{
+			"id":           c.ID,
+			"size":         c.Size,
+			"modularity":   c.Modularity,
+			"top_entities": top,
+			"repos":        repoList,
+			"cross_repo":   len(repoList) > 1,
+		}
+		if name != "" {
+			row["name"] = name
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

The group-algo overlay (`~/.grafel/groups/<group>-algo.json`, #5349/#5354) is computed across the whole group and **already applied** to the in-memory graph by `applyGroupAlgoOverlay` (`internal/mcp/state.go`): it stamps each entity's `CommunityID`/`PageRank`/`Centrality`/god-node/articulation flags and populates `LoadedGroup.Communities` with the group community summary. That apply runs correctly at group load.

The gap was entirely **read-side**: the consumer tools never used the overlay.

- `handleListCommunities` (`grafel_clusters`) looped repos and read **per-repo** `r.Doc.Communities`, stamping a single `repo` per community → cross-repo communities never surfaced; `the mobile repo`, whose per-repo Louvain was never persisted, silently showed **0 communities** (#5397).
- `grafel_inspect` (`handleGetNode`/`serializeEntity`) surfaced `pagerank`/`community_id` **only under `verbose`**, never `centrality`, and ignored `include=community,pagerank,centrality` (validation flaw 3).
- `grafel_impact_radius` is purely degree-based (reads no community/centrality fields) and `grafel_orient` already reads the overlay-stamped per-entity values — so they needed no change beyond the apply that already runs.

## Fix (absence-tolerant)

- **`grafel_clusters` / `handleListCommunities`:** when `LoadedGroup.Communities` is populated (overlay applied), serve the **group** communities. Each community's repo span is reconstructed from the overlay-stamped per-entity `CommunityID`, reported as a `repos[]` list plus a `cross_repo` flag — **never force-tagged to a single repo**. `the mobile repo` members surface (#5397). A `repo_filter` naming only one repo of a cross-repo community still surfaces that community.
- **`grafel_inspect`:** new `addAlgoFields` helper surfaces `community_id`/`pagerank`/`centrality` (+ god-node / articulation flags) when requested via `include=community,pagerank,centrality`, as well as under `verbose`. `centrality` is surfaced for the first time.
- **No overlay present → every tool keeps its prior per-repo behavior unchanged.**

## Tests

`internal/mcp/groupalgo_readside_5396_test.go` (light, package-local):
- 2-repo synthetic group with an overlay placing a cross-repo entity in a shared community (id 42) → `handleListCommunities` returns community 42 with members spanning **both** repos (backend + the mobile repo), `cross_repo:true`, no forced single `repo`.
- `repo_filter=["the mobile repo"]` still surfaces the cross-repo community 42 and excludes the backend-only community 7.
- `grafel_inspect ... include=community,pagerank,centrality` surfaces the overlay `community_id=42`, `pagerank`, and `centrality`.

`go build ./...`, `go vet ./internal/mcp/...`, `gofmt -l` clean; existing inspect field-elision tests pass unchanged.

Fixes #5396, #5397.