### PR TITLE
fix(mcp): surface group overlay on inspect + the mobile repo (orient/stats) (#5400,#5401,#5397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **Group-algo overlay now keeps surfacing on `inspect`/`orient`/`stats`/`clusters`
+  after a repo is reparsed — incl. `core-mobile` (Fixes #5400, #5401, #5397):**
+  `applyGroupAlgoOverlay` memoized the per-entity stamp at the **group** level by
+  the overlay FILE's mtime. But a repo's `graph.fb` can be rewritten (a reparse →
+  fresh `doc.Entities` carrying the per-repo sentinel `community_id:-1`) AFTER the
+  overlay was first applied. With the file-level memo, that reparsed repo was
+  never re-stamped and silently reverted to `community_id:-1` — exactly the
+  `core-mobile` symptom (#5401): `grafel_orient` showed `community_id:-1` for its
+  entities, `grafel_inspect` surfaced no algo fields at all (#5400), and
+  `grafel_stats` + `grafel_clusters repo_filter=core-mobile` reported 0
+  communities (#5397) — even though the overlay placed core-mobile in community
+  80. The stamp memo is now **per repo**: a repo is re-stamped whenever its
+  `graph.fb` was reparsed since the last stamp (or the overlay file advanced), so
+  the overlay community/pagerank/centrality survive a mid-session reparse of any
+  one repo. `grafel_stats` now also derives each repo's community count from the
+  overlay-stamped per-entity `community_id` (matching `grafel_clusters`) instead
+  of the now-empty per-repo `Doc.Communities`. Fully absence-tolerant.
+
 - **MCP read-side now serves the group-algo overlay instead of per-repo Louvain
   (Fixes #5396, #5397):** the group-level overlay (`~/.grafel/groups/<group>-algo.json`)
   was computed correctly and stamped onto entities by `applyGroupAlgoOverlay`,

--- a/internal/mcp/group_algo_overlay_restamp_5400_test.go
+++ b/internal/mcp/group_algo_overlay_restamp_5400_test.go
@@ -1,0 +1,326 @@
+// group_algo_overlay_restamp_5400_test.go — #5400/#5401/#5397: the group-algo
+// overlay must keep surfacing on inspect / orient / stats / clusters for a repo
+// whose graph.fb is reparsed AFTER the overlay was first applied.
+//
+// Root cause fixed here: applyGroupAlgoOverlay memoized the stamp at the GROUP
+// level by the overlay FILE's mtime. A repo's graph.fb can be rewritten (a
+// reparse → fresh doc.Entities carrying the per-repo sentinel community id, e.g.
+// -1) after the overlay was first applied. With the file-level memo the apply
+// early-returned and that reparsed repo's entities silently reverted to
+// community_id:-1 (core-mobile, #5401) — so grafel_inspect surfaced nothing
+// (#5400) and grafel_stats / clusters repo_filter reported 0 communities (#5397)
+// for it. The fix re-stamps a repo whenever ITS graph.fb was reparsed since the
+// last stamp, independent of the overlay file mtime.
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/registry"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// setupThreeRepoApplyGroup writes three on-disk graph.fb repos (a backend, a
+// frontend, and a mobile-like repo whose per-repo Louvain never persisted, so
+// its on-disk entities carry the sentinel community id -1), registers the group,
+// and returns the State plus the mobile repo's state dir + doc so the test can
+// rewrite (reparse) the mobile graph.fb mid-session.
+func setupThreeRepoApplyGroup(t *testing.T) (st *State, overlayPath string, cur map[string]int64,
+	beID, feID, mobID, mobileStateDir string, mobileDoc *graph.Document) {
+	t.Helper()
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	pathBE := filepath.Join(root, "backend")
+	pathFE := filepath.Join(root, "frontend")
+	pathMob := filepath.Join(root, "mobile")
+
+	docBE := applyFixtureDoc("backend", "DeviceViewSet")
+	docFE := applyFixtureDoc("frontend", "callApi")
+	// The mobile doc carries the per-repo SENTINEL community id (-1): its per-repo
+	// Louvain never persisted (the real core-mobile situation, #5397). The overlay
+	// will reassign it to a real cross-repo community.
+	docMob := applyFixtureDoc("mobile", "coreMobileModule")
+	docMob.Entities[0].CommunityID = ip(-1)
+
+	for _, rp := range []struct {
+		path string
+		doc  *graph.Document
+	}{{pathBE, docBE}, {pathFE, docFE}, {pathMob, docMob}} {
+		stateDir := daemon.StateDirForRepo(rp.path)
+		if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), rp.doc); err != nil {
+			t.Fatalf("write graph.fb: %v", err)
+		}
+	}
+
+	cfgPath, err := registry.ConfigPathFor("upvate")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "upvate", Repos: []registry.Repo{
+		{Slug: "backend", Path: pathBE},
+		{Slug: "frontend", Path: pathFE},
+		{Slug: "mobile", Path: pathMob},
+	}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("upvate", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	inMem := &Registry{
+		Path: filepath.Join(home, "registry.json"),
+		Groups: map[string]RegistryGroup{
+			"upvate": {Repos: map[string]RegistryRepo{
+				"backend":  {Path: pathBE},
+				"frontend": {Path: pathFE},
+				"mobile":   {Path: pathMob},
+			}},
+		},
+	}
+	st = NewState(inMem)
+
+	overlayPath, err = groupalgo.OverlayPath("upvate")
+	if err != nil {
+		t.Fatalf("overlay path: %v", err)
+	}
+	cur, err = groupalgo.CurrentSourceMtimes("upvate")
+	if err != nil {
+		t.Fatalf("current mtimes: %v", err)
+	}
+	return st, overlayPath, cur, "backend:DeviceViewSet", "frontend:callApi",
+		"mobile:coreMobileModule", daemon.StateDirForRepo(pathMob), docMob
+}
+
+// TestApplyOverlay_ReStampsReparsedMobileRepo reproduces #5400/#5401/#5397: after
+// the overlay is applied, the mobile repo's graph.fb is rewritten (reparse).
+// Without the per-repo re-stamp fix, the mobile entity reverts to community_id:-1
+// and inspect/stats/clusters drop it. With the fix it keeps overlay community 80.
+func TestApplyOverlay_ReStampsReparsedMobileRepo(t *testing.T) {
+	st, overlayPath, cur, beID, feID, mobID, mobStateDir, mobDoc := setupThreeRepoApplyGroup(t)
+
+	// Overlay assigns the mobile module to a real cross-repo community (80),
+	// the backend god-node to 39, the frontend to 203 — mirroring the live upvate
+	// overlay shape from the validation report.
+	ov := &groupalgo.Overlay{
+		Group:        "upvate",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			beID:  {CommunityID: 39, PageRank: 0.0065, Centrality: 10415.99, IsGodNode: true},
+			feID:  {CommunityID: 203, PageRank: 0.004, Centrality: 16521.23, IsGodNode: true},
+			mobID: {CommunityID: 80, PageRank: 0.001, Centrality: 6706, IsArticulationPoint: true},
+		},
+		Communities: []graph.CommunityResult{
+			{ID: 39, Size: 2, AutoName: "serializer-serializers-core"},
+			{ID: 203, Size: 1, AutoName: "use-hooks-actions"},
+			{ID: 80, Size: 1, AutoName: "features-types-props"},
+		},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	// Pin the overlay file mtime so that after we rewrite it below it keeps the
+	// SAME mtime — this is what makes the (buggy) group-level memo skip the
+	// re-stamp. The real daemon rewrites the overlay in place on its schedule;
+	// what must NOT gate the per-repo re-stamp is the overlay FILE mtime.
+	pinned := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(overlayPath, pinned, pinned); err != nil {
+		t.Fatalf("pin overlay mtime: %v", err)
+	}
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload v1: %v", err)
+	}
+	// Sanity: mobile stamped to 80 on the first apply.
+	if mob := entityByID(st.Group("upvate"), mobID); mob == nil || mob.CommunityID == nil || *mob.CommunityID != 80 {
+		t.Fatalf("v1: mobile not stamped to overlay community 80: %v", mob)
+	}
+
+	// --- Now reparse ONLY the mobile repo: rewrite its graph.fb with a later
+	// mtime, keeping the SENTINEL community id -1 (a fresh per-repo parse). The
+	// overlay file is UNCHANGED. This is exactly the live core-mobile race.
+	time.Sleep(10 * time.Millisecond)
+	mobDoc.Entities[0].CommunityID = ip(-1) // back to the per-repo sentinel
+	// Change the BYTES (add a new entity) so the #3377 content-hash skip does not
+	// short-circuit the reparse — we need a genuine fresh parse that rebuilds
+	// doc.Entities (and the LabelIndex) carrying the sentinel community ids.
+	mobDoc.Entities = append(mobDoc.Entities, graph.Entity{
+		ID: "mobile:useMemo", Name: "useMemo", Kind: "function",
+		SourceFile: "mobile/hooks.tsx", Language: "ts", CommunityID: ip(-1),
+	})
+	if err := fbwriter.WriteAtomic(filepath.Join(mobStateDir, "graph.fb"), mobDoc); err != nil {
+		t.Fatalf("rewrite mobile graph.fb: %v", err)
+	}
+	future := time.Now().Add(time.Second)
+	_ = os.Chtimes(filepath.Join(mobStateDir, "graph.fb"), future, future)
+
+	// Recompute current mtimes and REWRITE the overlay's recorded source_mtimes so
+	// it is not considered stale (the daemon's scheduler keeps the overlay fresh;
+	// the bug is the apply MEMO skipping the re-stamp, not staleness). Keep the
+	// overlay FILE mtime unchanged-ish so the group-level memo would have skipped.
+	cur2, err := groupalgo.CurrentSourceMtimes("upvate")
+	if err != nil {
+		t.Fatalf("current mtimes v2: %v", err)
+	}
+	ov.SourceMtimes = cur2
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("rewrite overlay: %v", err)
+	}
+	// Restore the SAME (pinned) overlay file mtime so the group-level memo would
+	// treat the overlay as unchanged — isolating the per-repo re-stamp behavior.
+	if err := os.Chtimes(overlayPath, pinned, pinned); err != nil {
+		t.Fatalf("re-pin overlay mtime: %v", err)
+	}
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload v2: %v", err)
+	}
+	grp := st.Group("upvate")
+
+	// (#5401) mobile must STILL carry overlay community 80, not the sentinel -1.
+	mob := entityByID(grp, mobID)
+	if mob == nil {
+		t.Fatalf("mobile entity missing after reparse")
+	}
+	if mob.CommunityID == nil || *mob.CommunityID != 80 {
+		t.Fatalf("#5401: reparsed mobile reverted to community_id=%v; want overlay 80 (re-stamp missed)", mob.CommunityID)
+	}
+	if !mob.IsArticulationPt {
+		t.Errorf("#5401: reparsed mobile lost overlay is_articulation_point flag")
+	}
+
+	// (#5400) inspect surfaces the mobile entity's overlay community/pagerank.
+	inspectOut := inspectAlgo(t, st, "mobile::"+mobID)
+	if cid, ok := inspectOut["community_id"].(float64); !ok || int(cid) != 80 {
+		t.Errorf("#5400: inspect did not surface mobile overlay community_id=80, got %v", inspectOut["community_id"])
+	}
+	if pr, ok := inspectOut["pagerank"].(float64); !ok || pr == 0 {
+		t.Errorf("#5400: inspect did not surface mobile overlay pagerank, got %v", inspectOut["pagerank"])
+	}
+
+	// backend still surfaces its overlay community via inspect too.
+	beOut := inspectAlgo(t, st, "backend::"+beID)
+	if cid, ok := beOut["community_id"].(float64); !ok || int(cid) != 39 {
+		t.Errorf("#5400: inspect did not surface backend overlay community_id=39, got %v", beOut["community_id"])
+	}
+
+	// (#5397) grafel_stats reports a non-zero community count for the mobile repo
+	// (recovered from the overlay-stamped per-entity CommunityID, not the empty
+	// per-repo Doc.Communities).
+	mobileComm := statsCommunitiesForRepo(t, st, "mobile")
+	if mobileComm < 1 {
+		t.Errorf("#5397: grafel_stats reports %d communities for mobile; want >=1 (overlay community 80)", mobileComm)
+	}
+
+	// (#5397) clusters repo_filter=mobile surfaces community 80.
+	if !clustersHasCommunityForRepoFilter(t, st, "mobile", 80) {
+		t.Errorf("#5397: clusters repo_filter=mobile dropped overlay community 80")
+	}
+}
+
+// --- small helpers (local to this test file) ---
+
+// inspectAlgo runs grafel_inspect with include=community,pagerank,centrality and
+// returns the decoded JSON object.
+func inspectAlgo(t *testing.T, st *State, prefixedID string) map[string]any {
+	t.Helper()
+	srv := &Server{State: st}
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"group":     "upvate",
+		"entity_id": prefixedID,
+		"include":   "community,pagerank,centrality",
+	}
+	res, err := srv.handleGetNode(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGetNode error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("inspect tool error: %v", res)
+	}
+	return extractResultJSON(t, res)
+}
+
+// statsCommunitiesForRepo runs grafel_stats and returns the community count
+// reported for the named repo.
+func statsCommunitiesForRepo(t *testing.T, st *State, repo string) int {
+	t.Helper()
+	srv := &Server{State: st}
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "upvate"}
+	res, err := srv.handleGraphStats(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleGraphStats error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("stats tool error: %v", res)
+	}
+	out := extractResultJSON(t, res)
+	repos, _ := out["repos"].([]any)
+	for _, ri := range repos {
+		m, _ := ri.(map[string]any)
+		if m == nil {
+			continue
+		}
+		if m["repo"] == repo {
+			if c, ok := m["communities"].(float64); ok {
+				return int(c)
+			}
+		}
+	}
+	return -1
+}
+
+// clustersHasCommunityForRepoFilter runs grafel_clusters repo_filter=[repo] and
+// reports whether community id is present.
+func clustersHasCommunityForRepoFilter(t *testing.T, st *State, repo string, id int) bool {
+	t.Helper()
+	srv := &Server{State: st}
+	items := clustersResult2(t, srv, map[string]any{"min_size": 1, "repo_filter": []any{repo}})
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		if m == nil {
+			continue
+		}
+		if cidF, ok := m["id"].(float64); ok && int(cidF) == id {
+			return true
+		}
+	}
+	return false
+}
+
+// clustersResult2 mirrors clustersResult but targets the "upvate" test group.
+func clustersResult2(t *testing.T, srv *Server, args map[string]any) []any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	if args == nil {
+		args = map[string]any{}
+	}
+	args["group"] = "upvate"
+	req.Params.Arguments = args
+	res, err := srv.handleListCommunities(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleListCommunities error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("clusters tool error: %v", res)
+	}
+	var arr []any
+	if err := json.Unmarshal([]byte(extractResultText(t, res)), &arr); err != nil {
+		t.Fatalf("clusters: unmarshal array failed: %v", err)
+	}
+	return arr
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -317,6 +317,20 @@ type LoadedRepo struct {
 	// first successful load.
 	contentHash uint64
 	loadErr     string // populated when last reload failed; doc may be stale
+
+	// algoStampedMt is the lr.mtime value at which applyGroupAlgoOverlay last
+	// stamped the group overlay (CommunityID/PageRank/Centrality/god/articulation)
+	// onto this repo's in-memory entities (#5400/#5401). The overlay apply is
+	// memoized at the GROUP level by the overlay file's own mtime, but a repo's
+	// graph.fb can be rewritten (reparse → fresh doc.Entities with the per-repo
+	// sentinel community ids, e.g. -1) AFTER the overlay was first applied. When
+	// that happens the overlay file mtime is unchanged, so the group-level memo
+	// would skip re-stamping and the reparsed repo's entities silently revert to
+	// community_id:-1 (the core-mobile symptom in #5401). Tracking the stamped
+	// mtime per repo lets the apply re-stamp exactly the repos that were reparsed
+	// since the last stamp, regardless of the overlay-file memo. The zero value
+	// means "never stamped", so a freshly-loaded repo is always (re-)stamped.
+	algoStampedMt time.Time
 }
 
 // resetIndexes re-arms every lazy-index sync.Once and clears the cached
@@ -1071,17 +1085,33 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 		return
 	}
 
-	// Memoize: skip re-stamping when neither the overlay nor the graphs changed.
-	// We re-apply whenever the overlay mtime advanced OR a repo was reparsed
-	// this reload (which would have reset entity fields to graph.fb values).
-	if grp.algoApplied && fi.ModTime().Equal(grp.algoMt) {
-		// Still set the summary (cheap; keeps grp.Communities authoritative).
-		grp.Communities = ov.Communities
-		return
-	}
+	// The community summary is always cheap to refresh and keeps grp.Communities
+	// authoritative for the clusters path even when no per-entity re-stamp is
+	// needed this reload.
+	grp.Communities = ov.Communities
+
+	// Memoization is now PER REPO, not group-wide (#5400/#5401). The previous
+	// group-level memo skipped ALL re-stamping whenever the overlay file mtime
+	// was unchanged — but a repo's graph.fb can be rewritten AFTER the overlay
+	// was first applied (a reparse produces fresh doc.Entities carrying the
+	// per-repo sentinel community ids, e.g. -1). With the group memo, that
+	// reparsed repo never got re-stamped and silently reverted to
+	// community_id:-1 (the core-mobile symptom in #5401; the same staleness
+	// also left grafel_inspect surfacing nothing in #5400). We re-stamp a repo
+	// whenever EITHER the overlay file advanced (overlayChanged) OR that repo's
+	// graph.fb was reparsed since we last stamped it (lr.mtime moved). This
+	// re-stamps exactly the repos that need it and is a no-op for the steady
+	// state where neither the overlay nor any graph changed.
+	overlayChanged := !grp.algoApplied || !fi.ModTime().Equal(grp.algoMt)
 
 	for _, lr := range grp.Repos {
 		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		// Skip a repo only when the overlay is unchanged AND this repo was not
+		// reparsed since we last stamped it. The zero algoStampedMt (never
+		// stamped) always falls through to (re-)stamp.
+		if !overlayChanged && lr.mtime.Equal(lr.algoStampedMt) {
 			continue
 		}
 		ents := lr.Doc.Entities
@@ -1103,9 +1133,9 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 		// against the freshly-stamped group values rather than stale per-repo
 		// ones (mirrors the resetIndexes() call after a reparse).
 		lr.resetIndexes()
+		lr.algoStampedMt = lr.mtime
 	}
 
-	grp.Communities = ov.Communities
 	grp.algoMt = fi.ModTime()
 	grp.algoApplied = true
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2889,6 +2889,29 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 	}
 	sort.Strings(names)
 	totalImport, totalBug := 0, 0
+	// #5397/#5401: when the group-algo overlay is applied (lg.Communities set),
+	// the per-repo Louvain summary (r.Doc.Communities) is empty — the per-repo
+	// pass was removed in A3 — so reporting len(r.Doc.Communities) understates
+	// (core-mobile showed 0). Recover each repo's community count from the
+	// overlay-stamped per-entity CommunityID instead, matching what
+	// grafel_clusters surfaces. -1/-2 sentinels (ungrouped) are not counted.
+	overlayCommByRepo := map[string]int{}
+	if len(lg.Communities) > 0 {
+		for n, r := range lg.Repos {
+			if r == nil || r.Doc == nil {
+				continue
+			}
+			seen := map[int]struct{}{}
+			for i := range r.Doc.Entities {
+				cid := r.Doc.Entities[i].CommunityID
+				if cid == nil || *cid < 0 {
+					continue
+				}
+				seen[*cid] = struct{}{}
+			}
+			overlayCommByRepo[n] = len(seen)
+		}
+	}
 	// Collect the loaded repos so we can pass them to computeUnresolvedBreakdown
 	// without a second pass over the names slice.
 	var loadedRepos []*LoadedRepo
@@ -2906,11 +2929,15 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 		rImport, rBug := countEdgesForFidelity(r)
 		totalImport += rImport
 		totalBug += rBug
+		commCount := len(r.Doc.Communities)
+		if len(lg.Communities) > 0 {
+			commCount = overlayCommByRepo[name]
+		}
 		repoStats = append(repoStats, map[string]any{
 			"repo":          name,
 			"entities":      len(r.Doc.Entities),
 			"relationships": len(r.Doc.Relationships),
-			"communities":   len(r.Doc.Communities),
+			"communities":   commCount,
 		})
 		loadedRepos = append(loadedRepos, r)
 	}


### PR DESCRIPTION
## Summary
Closes the two read-side gaps left after #5399's group-algo overlay serving:
**(b)** `grafel_inspect` surfaced no algo fields (#5400), and **(c)**
`grafel_orient`/`stats`/`clusters repo_filter` left **the mobile repo** at
`community_id:-1` (#5401/#5397) despite the overlay placing it in community 80.

## Root cause (why the mobile repo was -1)
`applyGroupAlgoOverlay` stamps each entity's `CommunityID`/`PageRank`/`Centrality`/
god/articulation from `~/.grafel/groups/<group>-algo.json`, but it **memoized the
stamp at the GROUP level by the overlay FILE's mtime**:

```go
if grp.algoApplied && fi.ModTime().Equal(grp.algoMt) { ...; return } // skips re-stamp
```

A repo's `graph.fb` is rewritten on every reparse, producing **fresh
`doc.Entities` + a fresh `LabelIndex`** carrying the *per-repo* sentinel
`community_id` (e.g. `-1`). When a repo is reparsed **after** the overlay was
first applied, the overlay file mtime is unchanged, so the group-level memo
early-returns and that repo's freshly-parsed entities are **never re-stamped** —
they revert to `community_id:-1`.

the mobile repo hit this deterministically: its `develop` `graph.fb` was rewritten
*after* the overlay (the validation report even notes the 08:04 vs 07:56 race),
and its per-repo Louvain never persisted, so its on-disk sentinel is `-1`.
Because `inspect`, `orient`, `stats`, and `clusters` all read the **same**
per-entity `CommunityID`, they dropped the mobile repo together. (inspect's #5399
wiring was correct — it just read a reverted `e.CommunityID`.)

## Fix
- **Per-repo stamp memo** (`LoadedRepo.algoStampedMt`): re-stamp a repo whenever
  the overlay file advanced **OR** that repo's `graph.fb` was reparsed since the
  last stamp (`lr.mtime` moved). Re-stamps exactly the repos that need it; no-op
  in the steady state. The group community summary is refreshed every apply.
- **`grafel_stats`** now derives each repo's community count from the
  overlay-stamped per-entity `community_id` (matching `grafel_clusters`) when the
  overlay is applied, instead of the now-empty per-repo `Doc.Communities`
  (which was 0 for the mobile repo after the per-repo pass was removed in A3).

Fully absence-tolerant: with no overlay, every tool keeps prior per-repo behavior.

## Tests
`internal/mcp/group_algo_overlay_restamp_5400_test.go`: a 3-repo (backend /
frontend / mobile) group writes a real on-disk overlay, applies it, then
**reparses the mobile repo's `graph.fb` mid-session** (sentinel `-1`, overlay
file mtime pinned). Asserts the mobile entity keeps overlay community **80**,
`grafel_inspect` surfaces its `community_id`/`pagerank`, `grafel_stats` reports
>=1 community for mobile, and `clusters repo_filter=mobile` keeps community 80.
The test **FAILS without the per-repo memo** (mobile reverts to -1) and **PASSES
with it**. `go build ./...`, `go vet ./internal/mcp/`, `gofmt -l` all clean.

Fixes #5400, #5401, #5397. Refs #5349 #5399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)