### PR TITLE
docs: 0.1.3 milestone pass (cross-repo group algorithms + MCP changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,20 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   fully functional. The `node`→`entity_id` param alias on `grafel_expand`
   (#1916) is unaffected.
 
+- **MCP `tools/list` token trim — per-connect handshake ~7592 → ~6113 tokens
+  (−1479, −19.5%) (Refs #5387):** strip the blanket annotation-hint block
+  (`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`) that
+  mcp-go's `NewTool` stamps on every tool by default. The four hints were
+  identical across all 68 registered tools and inaccurate (read-only query
+  tools like `grafel_find` were advertised as destructive), so they were pure
+  duplicated boilerplate. A centralized `addTool` helper resets the annotation
+  to empty when it still carries exactly the `NewTool` default, so it serializes
+  as `{}` instead of the ~89-char hint block; all 68 registrations route
+  through it. No change to the tool surface (names, params, types, enums,
+  required-sets, handlers) or behavior — measured by `cmd/mcp-audit`. (The live
+  daemon bridge `MCPToolInfo` never emitted annotations, so this is zero-change
+  there and a win for the stock mcp-go stdio path / the audited budget.)
+
 - **Graph algorithms now run once per GROUP via a debounced/capped/background
   scheduler; the per-repo algorithm pass is removed (Refs #5355, #5349):**
   communities, PageRank, betweenness, god-nodes and articulation points are now
@@ -668,19 +682,6 @@ and graph schema may change between minor versions.
 ---
 
 ## [Unreleased] — v1.0-rc (2026-05-21, overnight session)
-
-### Changed
-
-- **MCP `tools/list` token trim** — strip the blanket annotation-hint block
-  (`readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`) that
-  mcp-go's `NewTool` stamps on every tool by default. The hints were identical
-  across all 68 tools and inaccurate (read-only query tools were advertised as
-  destructive), so they were pure duplicated boilerplate. Cuts the per-connect
-  handshake from ~7592 → ~6113 tokens (−1479, −19.5%) as measured by
-  `cmd/mcp-audit`, with no change to the tool surface (names, params, types,
-  enums, required-sets, handlers) or behavior. Note: the live daemon bridge
-  (`MCPToolInfo`) never emitted annotations, so this is zero-change there and a
-  win for the stock mcp-go stdio path / the audited budget. (Refs #5386)
 
 ### Dashboard — new surfaces and nav
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The graph lives entirely on your machine — local-first by design, as called ou
 - **Process flow tracing** — pre-computed BFS from entry points (route handlers, `main`, framework hooks) stored as traceable chains; ad-hoc follow from any entity on demand.
 - **Message-bus topology** — topic/broker/service groupings for event-driven systems; publisher and subscriber orphan detection.
 - **Cross-repo dependency graph** — index a folder of repos as one group; edges span repo boundaries with confidence scores; diff graph state between any two indexed refs.
+- **Cross-repo group-level intelligence** — communities and importance (PageRank/centrality) are computed once over the assembled group graph, not per repo, so they reflect cross-repo structure: a community can span repos when cross-repo links connect them, and a backend entity called from the frontend or mobile gets the importance that wiring earns. Surfaced in `grafel_clusters` (with `repos[]`/`cross_repo`), `grafel_inspect`, `grafel_orient`, and `grafel_stats`.
 - **Documentation and analysis skills** — a 15-skill family (tech docs, business docs, security audit, consultant panel, patterns) all driven off the graph, invokable from Claude Code as slash commands.
 - **Real-time dashboard** — 19 surfaces (Graph, Flows, Event-flows, Topology, Paths, Links, GraphQL, IaC, Docs, Security, Taint, DI, Error-flow, Quality, Settings, Pending, Operations, Compare, Missing) embedded in the daemon, no separate server, at `http://127.0.0.1:47274`.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -58,9 +58,9 @@ Walk edges, find paths, and follow flows between entities.
 | Tool | One-line purpose |
 |------|-----------------|
 | [`grafel_neighbors`](mcp-tools/graph-traversal.md#grafel_neighbors) | Graph neighbors of an entity. `direction=in\|out\|both` (default `both`). |
-| [`grafel_expand`](mcp-tools/graph-traversal.md#grafel_expand) | *Deprecated alias* of `grafel_neighbors`. |
-| [`grafel_find_callers`](mcp-tools/graph-traversal.md#grafel_find_callers) | *Deprecated alias* of `grafel_neighbors(direction=in)`. Ranked by call frequency. |
-| [`grafel_find_callees`](mcp-tools/graph-traversal.md#grafel_find_callees) | *Deprecated alias* of `grafel_neighbors(direction=out)`. |
+| [`grafel_expand`](mcp-tools/graph-traversal.md#grafel_expand) | Neighbors of an entity out to a given depth (equivalent to `grafel_neighbors`). |
+| [`grafel_find_callers`](mcp-tools/graph-traversal.md#grafel_find_callers) | Inbound callers (equivalent to `grafel_neighbors(direction=in)`). Ranked by call frequency. |
+| [`grafel_find_callees`](mcp-tools/graph-traversal.md#grafel_find_callees) | Outbound callees (equivalent to `grafel_neighbors(direction=out)`). |
 | [`grafel_find_paths`](mcp-tools/graph-traversal.md#grafel_find_paths) | Shortest path between two entities with confidence score. |
 | [`grafel_trace`](mcp-tools/graph-traversal.md#grafel_trace) | Confidence-weighted shortest path (Dijkstra) between two nodes. |
 | [`grafel_traces`](mcp-tools/graph-traversal.md#grafel_traces) | Pre-computed process-flow traces. `action=list\|get\|follow`. |
@@ -72,7 +72,7 @@ Modules, communities, HTTP surface, topology, flows, and impact.
 
 | Tool | One-line purpose |
 |------|-----------------|
-| [`grafel_clusters`](mcp-tools/cross-cutting-analysis.md#grafel_clusters) | Louvain communities with top-ranked entities. Fast module map. |
+| [`grafel_clusters`](mcp-tools/cross-cutting-analysis.md#grafel_clusters) | Louvain communities with top-ranked entities. Group-scoped (can span repos) when the group-algo overlay is applied. Fast module map. |
 | [`grafel_module_analysis`](mcp-tools/cross-cutting-analysis.md#grafel_module_analysis) | Module-level SCC + PageRank + betweenness. `action=cycles\|centrality\|all`. |
 | [`grafel_import_cycles`](mcp-tools/cross-cutting-analysis.md#grafel_import_cycles) | IMPORTS cycle clusters per repo (Tarjan SCC). |
 | [`grafel_quality_cycles`](mcp-tools/cross-cutting-analysis.md#grafel_quality_cycles) | Detect import cycles via Tarjan SCC; weakest edge + fix hint. |

--- a/docs/mcp-tools/cross-cutting-analysis.md
+++ b/docs/mcp-tools/cross-cutting-analysis.md
@@ -8,11 +8,11 @@ Modules, communities, HTTP surface, message topology, flows, and change impact.
 
 ## `grafel_clusters`
 
-Louvain communities across loaded graphs — a fast module map.
+Louvain communities — a fast module map. When the group-algo overlay is applied, communities are computed over the assembled group graph (union of all repos + cross-repo links), so a community can span repos; otherwise it falls back to the per-repo communities baked into each `graph.fb`.
 
 Key parameters: `repo_filter[]`, `top_entities_limit` (default 3), `min_size` (default 20).
 
-Output: list of community clusters with representative entities.
+Output: list of community clusters with representative entities. Group-scoped rows carry `repos[]` and a `cross_repo` flag; per-repo fallback rows carry a single `repo`.
 
 ---
 

--- a/docs/mcp-tools/graph-traversal.md
+++ b/docs/mcp-tools/graph-traversal.md
@@ -2,7 +2,7 @@
 
 [← Back to the MCP tools index](../mcp-tools.md)
 
-Walk edges, find paths, and follow flows between entities. For new code prefer `grafel_neighbors` over the deprecated `expand` / `find_callers` / `find_callees` aliases.
+Walk edges, find paths, and follow flows between entities. `grafel_neighbors` and the explicit `grafel_expand` / `grafel_find_callers` / `grafel_find_callees` are all first-class — reach for whichever reads clearest (`find_callers` for inbound callers, `find_callees` for outbound callees).
 
 ---
 
@@ -12,23 +12,21 @@ Graph neighbors of an entity.
 
 Key parameters: `entity_id` (required), `direction` (`in`/`out`/`both`, default `both`), `depth` (default 1), `token_budget` (default 800), `fields[]`.
 
-Output: list of neighboring entities with edge kind + direction. Supersedes `find_callers`/`find_callees`.
+Output: list of neighboring entities with edge kind + direction. The directional `find_callers`/`find_callees` are first-class equivalents for when the explicit name reads clearer.
 
 ---
 
 ## `grafel_expand`
 
-*Deprecated alias* of `grafel_neighbors`. Returns neighbors of `entity_id`.
+Return the neighbors of `entity_id` out to a given depth. Equivalent to `grafel_neighbors`; first-class, kept for the explicit name.
 
 Key parameters: `entity_id` (or deprecated `node`), `depth` (default 1), `token_budget` (default 800), `repo_filter[]`, `fields[]`.
-
-> **Deprecation**: prefer `grafel_neighbors` for new code.
 
 ---
 
 ## `grafel_find_callers`
 
-*Deprecated alias* of `grafel_neighbors(direction=in)` — inbound callers.
+Inbound callers of `entity_id` (equivalent to `grafel_neighbors(direction=in)`); first-class.
 
 Results are **ranked by call frequency** (descending) within each hop level, then alphabetically. Frequency is summed from `Properties["count"]` on CALLS edges (or 1.0 per raw edge when count is absent).
 
@@ -36,17 +34,13 @@ Key parameters: `entity_id` (required), `depth` (default 1), `token_budget` (def
 
 **Route-literal resolution.** If `entity_id` starts with `/` AND does not match any entity by ID or name, the handler treats it as an in-app route literal: it searches NAVIGATES_TO edges whose `ToID == "route:<literal>"` (or whose `Properties["route"]` equals the literal) and returns the push-site callers directly. Each caller carries `file`, `line`, `route`, and `params_keys`. Response includes `resolved_as: "navigation_route"`.
 
-> **Deprecation**: prefer `grafel_neighbors(direction=in)` for new code.
-
 ---
 
 ## `grafel_find_callees`
 
-*Deprecated alias* of `grafel_neighbors(direction=out)` — outbound callees.
+Outbound callees of `entity_id` (equivalent to `grafel_neighbors(direction=out)`); first-class.
 
 Key parameters: `entity_id` (required), `depth` (default 1), `token_budget` (default 800).
-
-> **Deprecation**: prefer `grafel_neighbors(direction=out)` for new code.
 
 ---
 

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -111,7 +111,7 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`grafel_expand`](#grafel_expand) | Return neighbors of a node out to a given depth. |
 | [`grafel_trace`](#grafel_trace) | Confidence-weighted shortest path between two nodes. |
 | [`grafel_traces`](#grafel_traces) | Process-flow traces (action: list\|get\|follow). |
-| [`grafel_clusters`](#grafel_clusters) | List Louvain communities across the loaded graphs. |
+| [`grafel_clusters`](#grafel_clusters) | List Louvain communities; group-scoped (can span repos via `repos[]`/`cross_repo`) when the group-algo overlay is applied. |
 | [`grafel_stats`](#grafel_stats) | Corpus-level metrics for the resolved group. |
 | [`grafel_enrichments`](#grafel_enrichments) | Manage enrichment candidates (action: list\|submit\|reject). |
 | [`grafel_cross_links`](#grafel_cross_links) | Manage cross-repo link candidates (action: list\|accept\|reject). |
@@ -135,9 +135,9 @@ Agents using these names will receive a "tool not found" error — update to the
 | `grafel_endpoint_posture` | Per-endpoint/function posture: error_flow (throws/catches → ExceptionType), rate_limit, deprecation/version, feature_gates (GATED_BY → FeatureFlag), and HTTP/gRPC/tRPC auth. `entity_id` for one entity; omit for a repo-wide scan (facet/path_contains/method filters). |
 | `grafel_control_flow` | On-demand (not persisted) per-function control-flow graph for the flowchart view (#4819): nodes (start/decision/loop/process/return/throw/end) + edges (seq/branch_true/branch_false/loop_back/exit), with predicate text on decision/loop nodes and effect annotations on process nodes, plus cyclomatic complexity. `entity_id` required; `detail`=outline\|decisions\|data\|full for token control. Languages: python + jsts validated. |
 | [`grafel_effective_contract`](#grafel_effective_contract) | Per-verb effective contract of a ViewSet/controller (kind, status, error_statuses, serializer, pagination, permissions). |
-| `grafel_neighbors` | Graph neighbors of `entity_id` (`direction=in\|out\|both`, default `both`). **Unifies `find_callers` + `find_callees` (#1753).** |
-| [`grafel_find_callers`](#grafel_find_callers) | **Deprecated alias** of `grafel_neighbors(direction=in)`. Removed next release. |
-| [`grafel_find_callees`](#grafel_find_callees) | **Deprecated alias** of `grafel_neighbors(direction=out)`. Removed next release. |
+| `grafel_neighbors` | Graph neighbors of `entity_id` (`direction=in\|out\|both`, default `both`). Generalizes `find_callers` + `find_callees` (#1753). |
+| [`grafel_find_callers`](#grafel_find_callers) | Inbound callers (equivalent to `grafel_neighbors(direction=in)`). First-class. |
+| [`grafel_find_callees`](#grafel_find_callees) | Outbound callees (equivalent to `grafel_neighbors(direction=out)`). First-class. |
 | [`grafel_impact_radius`](#grafel_impact_radius) | Blast-radius analysis with per-entity risk score. |
 | [`grafel_find_dead_code`](#grafel_find_dead_code) | Entities with 0 inbound/outbound project edges. |
 | [`grafel_auth_coverage`](#grafel_auth_coverage) | Security audit: flag HTTP endpoints missing auth decorators/middleware. |
@@ -321,6 +321,7 @@ Previously named `grafel_describe` (renamed in #668).
 |------|------|----------|---------|-------------|
 | `label_or_id` | string | yes | — | Entity ID, `<repo>::<localId>`, qualified name (case-insensitive), or label (case-insensitive). |
 | `verbose` | boolean | no | `false` | Restore `end_line`, `language`, `repo`, `pagerank`, `community_id`, `properties` (#1739). |
+| `include` | string[] | no | `[]` | Opt-in projections. `community`/`pagerank`/`centrality` surface the group-algo overlay values (#5396) on the narrow (non-verbose) payload — `centrality` is surfaced here for the first time, and god-node / articulation-point flags ride along. `call_contexts` adds control-flow attribution on outbound CALLS edges (#4832). |
 | `repo_filter` | string[] | no | `[]` | Common arg. |
 | `group`, `cwd` | string | no | — | Common args. |
 
@@ -380,7 +381,10 @@ were in the graph but invisible to read tools — only CALLS + the DI subset wer
 projected.
 
 With `verbose=true`, the response also includes `end_line`, `language`, `repo`,
-`pagerank`, `community_id`, and `properties`.
+`pagerank`, `community_id`, and `properties`. The `pagerank`/`community_id`
+(and, via `include`, `centrality`) values come from the group-algo overlay when
+one is applied — so they reflect the cross-repo union, not a per-repo pass — and
+are simply omitted when no overlay is present (absence-tolerant).
 
 If the call resolves to a single repo, `id` is local; otherwise it is prefixed.
 Returns a tool error when no entity matches.
@@ -556,8 +560,15 @@ Three sub-actions selected via the required `action` argument:
 
 ### `grafel_clusters`
 
-List Louvain communities pre-baked into each repo's `graph.json` (see
-ADR-0005).
+List Louvain communities. When a group-algo overlay
+(`~/.grafel/groups/<group>-algo.json`) is present, communities are computed once
+over the **assembled group graph** (the union of every repo plus the cross-repo
+links), so a single community can span more than one repo (#5396, #5349). Each
+row then reports the `repos` its members occupy and a `cross_repo` flag; a
+`repo_filter` naming only one repo of a cross-repo community still surfaces that
+community. With no overlay present (absence-tolerant), behavior falls back to the
+per-repo Louvain communities baked into each repo's `graph.fb` (see ADR-0005),
+and each row is tagged to a single `repo`.
 
 Previously named `grafel_list_clusters` (renamed in #668).
 
@@ -570,19 +581,24 @@ Previously named `grafel_list_clusters` (renamed in #668).
 | `min_size` | number | no | `20` | Minimum community size to include. Pass `0` to return all communities regardless of size. Added in #2289 (PR #2310); declared in schema by #2318. |
 | `group`, `cwd` | string | no | — | Common args. |
 
-**Output** — JSON array:
+**Output** — JSON array. With the group-algo overlay applied, each community row
+carries the `repos` its members span and a `cross_repo` flag (`true` when
+`len(repos) > 1`):
 
 ```json
 [
   {
-    "repo": "mobile-app",
-    "id": 3,
+    "id": 80,
     "size": 47,
     "modularity": 0.412,
-    "top_entities": ["OrderViewSet", "OrderSerializer", "OrderModel"]
+    "top_entities": ["OrderViewSet", "OrderSerializer", "OrderModel"],
+    "repos": ["api-backend", "core-mobile"],
+    "cross_repo": true
   }
 ]
 ```
+
+Without the overlay, the per-repo fallback rows carry a single `repo` instead.
 
 ---
 

--- a/internal/mcp/TOOL_NAMING_AUDIT.md
+++ b/internal/mcp/TOOL_NAMING_AUDIT.md
@@ -22,9 +22,9 @@ description-shrink #1742 Phase-C lands.
 | 5 | `grafel_inspect`               | RENAME                 | `grafel_get_entity`    | Generic name → `get_<object>` per #1765. |
 | 6 | `grafel_get_source`            | KEEP                   | `grafel_get_source`    | Already conforms to `get_<object>`. |
 | 7 | `grafel_neighbors` *(new)*     | KEEP                   | `grafel_neighbors`     | Folds find_callers + find_callees (#1753). |
-| 8 | `grafel_find_callers`          | DROP (next release)    | (use neighbors)            | Deprecated alias; kept this release for compat. |
-| 9 | `grafel_find_callees`          | DROP (next release)    | (use neighbors)            | Deprecated alias; kept this release for compat. |
-|10 | `grafel_expand`                | DROP (next release)    | `grafel_neighbors`     | Functionality folds into neighbors (direction=both). Stays this release; description points to neighbors. |
+| 8 | `grafel_find_callers`          | KEEP                   | `grafel_find_callers`  | Un-deprecated (#5386/#5393): metrics show active use; first-class directional alias of `neighbors(direction=in)`. |
+| 9 | `grafel_find_callees`          | KEEP                   | `grafel_find_callees`  | Un-deprecated (#5386/#5393): first-class directional alias of `neighbors(direction=out)`. |
+|10 | `grafel_expand`                | KEEP                   | `grafel_expand`        | Un-deprecated (#5386/#5393): first-class equivalent of `neighbors(direction=both)`; agents reach for the explicit name. |
 |11 | `grafel_trace`                 | KEEP                   | `grafel_shortest_path` | Verb-only name; rename next release. |
 |12 | `grafel_traces`                | KEEP                   | `grafel_flows`         | Noun-only name; conflict with existing `grafel_flows` (process-flow). Fold both under one process-flow surface next release. |
 |13 | `grafel_find_paths`            | KEEP                   | `grafel_find_paths`    | Verb_object — conforms. |
@@ -75,7 +75,7 @@ This PR ships:
 - `max_results` ceiling + `min_score` floor on find (#1807, #1921)
 - `notifications/tools/list_changed` emission when registry mutates (#1772)
 - `query` confirmed as canonical search arg (#1770) — already landed via #2003
-- Deprecation-aliased `find_callers` / `find_callees` continue to work
+- `find_callers` / `find_callees` un-deprecated and first-class again (#5386/#5393)
 - Audit doc + rename map (this file) (#1765)
 - Handshake budget bumped 3,200 → 3,500 to seat the additions
 


### PR DESCRIPTION
Docs-only milestone pass for 0.1.3. No code, tests, build, or daemon changes.

## What shipped in 0.1.3 (documented here)
- **Cross-repo group-level intelligence (headline):** communities (Louvain) + importance (PageRank/centrality) now compute over the assembled group graph (union of all repos + cross-repo links), so they reflect cross-repo structure — communities can span repos, and a backend entity called from the frontend/mobile earns cross-repo importance. Surfaced in `grafel_clusters` (now `repos[]`/`cross_repo`), `grafel_inspect`, `grafel_orient`, `grafel_stats`. (Epics #5350/#5349.)
- **MCP overhead:** per-connect handshake trimmed ~19.5% (7592→6113); `grafel_expand`/`find_callers`/`find_callees` un-deprecated (first-class again — metrics showed active use).
- **Daemon resilience:** watcher ignores build artifacts + gitignored paths.

## What this PR updates
- **README.md** — new "Cross-repo group-level intelligence" bullet in *What you get* (tight, doesn't over-claim — communities span repos only when cross-repo links exist).
- **CHANGELOG.md** — `[Unreleased]` already captured the group-algo work (A1–A4 + read-side fixes), un-deprecate, watcher resilience, and flaky-test stabilization. Added the missing **MCP `tools/list` token-trim** entry (#5387) under `### Changed`, and removed a stray duplicate of it that had been appended to the historical v1.0-rc block. `[Unreleased]` intentionally **not** renamed to `[0.1.3]` (coordinator does that at tag time).
- **internal/mcp/SCHEMA.md** — `grafel_clusters` now documents the group-scope overlay (cross-repo communities, `repos[]`/`cross_repo` output, per-repo fallback); `grafel_inspect` documents `include=community,pagerank,centrality` (centrality surfaced for the first time) and that verbose algo values come from the group overlay; index rows for `find_callers`/`find_callees` un-deprecated.
- **docs/mcp-tools.md, docs/mcp-tools/graph-traversal.md, docs/mcp-tools/cross-cutting-analysis.md** — un-deprecate `expand`/`find_callers`/`find_callees` (first-class equivalents); note group-scoped clusters.
- **internal/mcp/TOOL_NAMING_AUDIT.md** — flip `find_callers`/`find_callees`/`expand` from `DROP (next release)` to `KEEP`.

## Coverage matrix — unaffected (no capability change)
0.1.3 is group-algorithm + MCP work, **not** extractor/language work. No language or framework capability changed, so `docs/coverage/` is intentionally untouched. (Coverage tooling not run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)