### PR TITLE
fix(test/graph): windows-safe overlay atomic-rename + mmap unmap before cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ### Fixed
 
+- **Windows CI green for the group-algo overlay (no production behavior change on
+  Unix):** the overlay's atomic temp+rename now **retries on the transient
+  Windows sharing/access violation** (`ERROR_SHARING_VIOLATION` /
+  `ERROR_ACCESS_DENIED` / `ERROR_LOCK_VIOLATION`) raised when `os.Rename`
+  replaces a destination a concurrent reader still has open — a bounded backoff
+  (~10 tries) that rides out the microsecond window the MCP reader holds the file
+  (`TestOverlay_NoTornRead` is the stress case). On Unix it is a single
+  `os.Rename` (open files are inode-referenced, so rename-over-open always
+  succeeds) — unchanged. Separately, the `ApplyOverlay` MCP tests now
+  `State.Close()` (unmap each repo's `graph.fb` mmap) before `t.TempDir`'s
+  cleanup, because Windows cannot delete a memory-mapped file while the view is
+  open — `t.Cleanup` is LIFO so registering the unmap after `t.TempDir` runs it
+  first.
 - **Group-algo overlay now keeps surfacing on `inspect`/`orient`/`stats`/`clusters`
   after a repo is reparsed — incl. `core-mobile` (Fixes #5400, #5401, #5397):**
   `applyGroupAlgoOverlay` memoized the per-entity stamp at the **group** level by

--- a/internal/graph/groupalgo/atomicrename_other.go
+++ b/internal/graph/groupalgo/atomicrename_other.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package groupalgo
+
+import "os"
+
+// atomicRename performs the temp→dest swap that finalizes an overlay write.
+//
+// On Unix, os.Rename over an existing destination is a single atomic syscall
+// even while concurrent readers hold the destination open (open files are
+// referenced by inode, not by directory entry), so a single attempt is correct
+// and there is NO behavior change versus a bare os.Rename. The retrying
+// variant lives in atomicrename_windows.go, where renaming over a file a
+// reader still has open can transiently fail with a sharing violation.
+func atomicRename(tmp, dst string) error {
+	return os.Rename(tmp, dst)
+}

--- a/internal/graph/groupalgo/atomicrename_windows.go
+++ b/internal/graph/groupalgo/atomicrename_windows.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package groupalgo
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// atomicRenameRetries / atomicRenameRetryDelay bound the Windows rename-over
+// retry loop. Unlike Unix, Windows rename-over-existing fails with
+// ERROR_SHARING_VIOLATION / ERROR_ACCESS_DENIED while ANY process still holds
+// the destination open — including a concurrent reader mid os.ReadFile. The
+// overlay's real reader (the MCP apply path) opens, reads, and closes the
+// file in a single brief operation, so the destination is held only for a few
+// microseconds at a time; a short bounded backoff rides out that window and
+// lets the swap land. ~10 tries × a few ms ≈ tens of ms worst case, which is
+// imperceptible for the overlay write yet survives the no-torn-read stress
+// test's four tight reader loops. Variables (not consts) so a future test can
+// shrink the delay.
+var (
+	atomicRenameRetries    = 10
+	atomicRenameRetryDelay = 3 * time.Millisecond
+)
+
+// atomicRename performs the temp→dest swap that finalizes an overlay write,
+// retrying on the transient Windows sharing/access violation raised when a
+// concurrent reader still has the destination open. A persistent lock still
+// surfaces the genuine error after the bounded loop exhausts.
+func atomicRename(tmp, dst string) error {
+	var err error
+	for i := 0; i < atomicRenameRetries; i++ {
+		err = os.Rename(tmp, dst)
+		if err == nil {
+			return nil
+		}
+		if !isSharingOrAccessError(err) {
+			return err
+		}
+		time.Sleep(atomicRenameRetryDelay)
+	}
+	return err
+}
+
+// isSharingOrAccessError reports whether err is the transient Windows lock
+// raised when renaming over a destination another handle still has open.
+// Mirrors install.isAccessOrSharingError (kept local to avoid an import cycle
+// across the graph/install boundary).
+func isSharingOrAccessError(err error) bool {
+	if errors.Is(err, fs.ErrPermission) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case windows.ERROR_ACCESS_DENIED,
+			windows.ERROR_SHARING_VIOLATION,
+			windows.ERROR_LOCK_VIOLATION:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -156,7 +156,11 @@ func WriteOverlayTo(path string, ov *Overlay) error {
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return fmt.Errorf("write tmp: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	// atomicRename is a single os.Rename on Unix, and a bounded sharing-violation
+	// retry on Windows (atomicrename_windows.go) where renaming over a file a
+	// concurrent reader still has open transiently fails with ACCESS_DENIED /
+	// ERROR_SHARING_VIOLATION.
+	if err := atomicRename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("rename: %w", err)
 	}

--- a/internal/mcp/group_algo_overlay_apply_5354_test.go
+++ b/internal/mcp/group_algo_overlay_apply_5354_test.go
@@ -88,6 +88,13 @@ func setupApplyGroup(t *testing.T) (st *State, overlayPath string, curMtimes map
 		},
 	}
 	st = NewState(inMem)
+	// Release the per-repo graph.fb mmap handles BEFORE t.TempDir's cleanup
+	// deletes the directory. On Windows a memory-mapped file cannot be deleted
+	// while the mapping/view is open, so t.TempDir's RemoveAll fails with
+	// "Access is denied" on graph.fb unless State.Close() unmaps first. Because
+	// t.Cleanup runs LIFO and t.TempDir registered its cleanup first (above),
+	// registering Close here guarantees the unmap happens before the delete.
+	t.Cleanup(st.Close)
 
 	overlayPath, err = groupalgo.OverlayPath("acme")
 	if err != nil {

--- a/internal/mcp/group_algo_overlay_restamp_5400_test.go
+++ b/internal/mcp/group_algo_overlay_restamp_5400_test.go
@@ -91,6 +91,13 @@ func setupThreeRepoApplyGroup(t *testing.T) (st *State, overlayPath string, cur 
 		},
 	}
 	st = NewState(inMem)
+	// Release the per-repo graph.fb mmap handles BEFORE t.TempDir's cleanup
+	// deletes the directory. On Windows a memory-mapped file cannot be deleted
+	// while the mapping/view is open, so t.TempDir's RemoveAll fails with
+	// "Access is denied" on graph.fb unless State.Close() unmaps first. Because
+	// t.Cleanup runs LIFO and t.TempDir registered its cleanup first (above),
+	// registering Close here guarantees the unmap happens before the delete.
+	t.Cleanup(st.Close)
 
 	overlayPath, err = groupalgo.OverlayPath("upvate")
 	if err != nil {


### PR DESCRIPTION
## Why

Two **Windows-only** CI failures are blocking the v0.1.3 tag (ubuntu + macos pass). Both are in the group-algo overlay path. Go-only; reasoned about Windows file semantics — CI re-validates.

## Failure 1 — `TestOverlay_NoTornRead` (`internal/graph/groupalgo/overlay_test.go`)

```
writer: rename: rename <tmp>.tmp.NNNN <…>race-algo.json: Access is denied
```

**Root cause:** the no-torn-read stress test runs 4 concurrent reader goroutines doing `os.ReadFile` in a tight loop while the writer does temp-file + `os.Rename`. On Windows, `os.Rename` over a destination that another handle still has open fails with `ERROR_SHARING_VIOLATION` / `ERROR_ACCESS_DENIED`. (On Unix this never happens — open files are referenced by inode, not directory entry, so rename-over-open is a single atomic syscall.)

**Fix (production code, robust):** new build-tagged `atomicRename(tmp, dst)`:
- `atomicrename_other.go` (`!windows`): a single `os.Rename` — **no behavior change** on Unix.
- `atomicrename_windows.go` (`windows`): a bounded backoff (~10 tries × 3ms) that retries only on the transient sharing/access/lock violation, mirroring the existing `install.isAccessOrSharingError` classifier. A persistent lock still surfaces the genuine error.

`WriteOverlayTo` now calls `atomicRename` instead of a bare `os.Rename`. The overlay's real reader (the MCP apply path) opens→reads→closes in microseconds, so the retry lands almost immediately; this just makes the swap robust against a concurrent reader on Windows. The reader uses `os.Open`/`os.ReadFile`, which open with share-delete by default — no stricter open to change.

## Failure 2 — `TestApplyOverlay_GroupValuesAppliedAtLoad` + `TestApplyOverlay_ReStampsReparsedMobileRepo` (`internal/mcp/*overlay*_test.go`)

```
TempDir RemoveAll cleanup: …graph.fb: Access is denied
```

**Root cause:** the tests load a group via `State`, which mmaps each repo's `graph.fb` (`fbreader.Reader`). On Windows a memory-mapped file cannot be deleted while the view/mapping is open, so `t.TempDir()`'s `RemoveAll` cleanup fails on `graph.fb`.

**Fix (test only):** register `t.Cleanup(st.Close)` in each setup helper (`setupApplyGroup`, `setupThreeRepoApplyGroup`) **after** `t.TempDir()`. `State.Close()` already unmaps every `lr.Reader` (→ `fbreader` `UnmapViewOfFile` + `CloseHandle` on Windows). Because `t.Cleanup` is LIFO and `t.TempDir` registered its delete first, the unmap runs **before** the directory delete. This covers all tests using those helpers (apply, absent, stale, mid-session-swap, restamp).

## Validation (light, Windows-reasoned)

- `go build ./...` ✅
- `go vet ./internal/graph/groupalgo/ ./internal/mcp/` ✅
- `gofmt -l` empty ✅
- `go test -count=1 -run 'TestOverlay_NoTornRead|TestApplyOverlay' ./internal/graph/groupalgo/ ./internal/mcp/` ✅ (macOS — confirms no regression on the Unix single-rename path)
- `golang.org/x/sys/windows` `ERROR_ACCESS_DENIED`/`ERROR_SHARING_VIOLATION`/`ERROR_LOCK_VIOLATION` confirmed present (v0.44.0); the windows file uses the exact imports/constants as the already-compiling `removebinary_windows.go`. (Local `GOOS=windows` vet is blocked only by `go-tree-sitter` needing CGO — unrelated to these changes; real Windows CI builds with CGO.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)