### PR TITLE
docs(0.1.4): new-feature triage process + extractor recipe (#5415, #5416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **New-language-feature triage process (#5415, #5359 C1):**
+  `docs/new-language-feature-triage.md` — the decision procedure that turns a new
+  language version into scoped work. Each notable feature is classified
+  **(a) parse-only** / **(b) needs-new-extraction** / **(c) changes-existing-extraction**,
+  with explicit (a)-vs-(b) and (b)-vs-(c) tests and a "triage is spec-driven, not
+  grammar-driven" rule (don't block triage on the stale grammar). Ships a fillable
+  per-version **feature-impact-report template** (the A3 calendar cron, #5413,
+  points at it when version N lands) and a **worked example classifying 8 real
+  C# 13 features** (5×a · 1×b `field` keyword field-membership · 2×c `allows ref
+  struct` + partial properties), each carrying the grammar-bump prerequisite.
+  Wired into the cadence: A3 nudge → A2/A4 alarms fill the grammar-status row →
+  (b)/(c) action items feed the C2 recipe / C3 backfill.
+- **Extractor recipe for new constructs (#5416, #5359 C2):**
+  `docs/extractor-recipe.md` — the repeatable, grounded build path for each
+  (b)/(c) item from triage. Grounded in grafel's real architecture (pure manual
+  tree-sitter `node.Type()` traversal, no native queries) citing the C# extractor
+  (`internal/extractors/csharp/csharp.go`): locate the grammar node kind → add the
+  `case`/`build…` emit in the right extractor → register any new Kind in
+  `internal/types/kinds.go` + `All…Kinds()` and run the producer-kind guard
+  (`go test ./internal/types/`) → **update `registry.json` + coverage docs in the
+  SAME PR** (`go run ./tools/coverage update/gen/validate`, surgical 2-space edits)
+  → `coverage fmt --check` passes → add a value-asserting fixture test with
+  fixture-then-live validation. Includes a copy-into-PR pre-merge checklist.
 - **B2 assessment — migrate to the official tree-sitter binding + per-language
   modules (ADR-0023, #5418, #5359 B2):** a written go/no-go assessment of moving
   off the unmaintained single `smacker/go-tree-sitter` dependency to the live

--- a/docs/extractor-recipe.md
+++ b/docs/extractor-recipe.md
@@ -1,0 +1,206 @@
+# Extractor recipe — adding detection for a new construct (C2, epic #5359 — milestone 0.1.4)
+
+_Recipe maintained as of 2026-06-23. Companion to
+[`docs/new-language-feature-triage.md`](./new-language-feature-triage.md) (C1, the
+decision step that produces the work this recipe builds) and
+[`tools/coverage/AGENTS.md`](../tools/coverage/AGENTS.md)._
+
+This is the repeatable, end-to-end path to make grafel **model** a new language
+construct — once [C1 triage](./new-language-feature-triage.md) has classified it
+as **(b) needs-new-extraction** or **(c) changes-existing-extraction**. Follow it
+as a checklist. It is grounded in grafel's real extractor architecture, citing
+the C# extractor as the worked example.
+
+## grafel's extractor architecture (the 60-second model)
+
+grafel uses **pure manual tree-sitter Node traversal** — no native queries
+(`Query`/`QueryCursor` are used **zero** times; confirmed in the B2 assessment,
+ADR-0023 §1). Every per-language extractor:
+
+- Lives under `internal/extractors/<lang>/` and registers itself in an `init()`
+  via `extractor.Register("<lang>", &Extractor{})`
+  (e.g. `internal/extractors/csharp/csharp.go:50`).
+- Implements `extractor.Extractor`: `Language() string` and
+  `Extract(ctx, file) ([]types.EntityRecord, error)`
+  (`csharp.go:58`, `:61`).
+- Walks the CST **depth-first** with a `switch node.Type()` dispatch and emits
+  `types.EntityRecord` / `types.RelationshipRecord` values
+  (`csharp.go:108` `walk(...)`, the `switch node.Type()` at `:122`/`:136`).
+- Emits entities with a `Kind` string drawn from the validated set in
+  `internal/types/kinds.go` (e.g. `Kind: "SCOPE.Component"` at
+  `csharp.go:293`, `Kind: "CONTAINS"` at `:190`).
+
+So "adding extraction for a new construct" = **find its node kind in the CST →
+add a `case` to the right `switch node.Type()` that builds an
+`EntityRecord`/`RelationshipRecord` → register any new Kind → wire the coverage
+registry → fixture-test it.**
+
+## The recipe (checklist)
+
+### 1. Confirm the triage bucket and target
+
+From the C1 [feature-impact report](./new-language-feature-triage.md):
+
+- **(b)** → you'll add a new `case` (and likely a new `build…` helper).
+- **(c)** → you'll add/rename a node-type string in an existing `case`.
+
+Note the **grammar-bump prerequisite**: if the bundled grammar (smacker snapshot,
+2024-08-27 — see [`grammars.lock`](../grammars.lock)) can't yet produce the node
+kind, the [B1 catch-up bump](./grammar-freshness-audit.md) must land first or the
+`case` will never fire. Verify with a quick parse of a fixture (step 6) — an
+`ERROR` node where you expect your construct means the grammar is the blocker.
+
+### 2. Locate the node kind in the grammar
+
+Identify the exact tree-sitter **node type string** (and any **field names**) the
+construct produces. Two reliable ways:
+
+- Read the upstream grammar's `grammar.js` / `node-types.json` for
+  `tree-sitter/tree-sitter-<lang>` (the repo tracked in
+  [`grammars.lock`](../grammars.lock)).
+- Empirically: parse a minimal fixture and print node types. grafel reads
+  `node.Type()` everywhere (1628 call sites per ADR-0023); the same string is
+  what your `case` must match. For a quick dump, write a throwaway test under the
+  extractor package that walks the tree and logs `node.Type()` + `node.String()`.
+
+Record the node type (e.g. `record_declaration`) and any child fields you'll need
+via `node.ChildByFieldName("name")` (the pattern at `csharp.go:125`).
+
+### 3. Add the traversal + emit in the right extractor
+
+Edit `internal/extractors/<lang>/…`:
+
+- **(b):** add a `case "<node_kind>":` to the `switch node.Type()` (model:
+  `csharp.go:136`), and a `build…` helper that returns a
+  `types.EntityRecord` (model: `buildComponent` at `csharp.go:285`, which sets
+  `Kind`, `Subtype`, `Name`, position, and returns `(rec, ok)`). Append it to the
+  `out` slice. Emit any relationships as `types.RelationshipRecord{ToID:…,
+  Kind:"…"}` on the entity (model: the `CONTAINS` edges at `csharp.go:178`/`:190`).
+- **(c):** add the new/renamed node-type string to the existing `case`'s match
+  list and adapt the field lookups if a field was renamed (e.g. the
+  multi-string `case "class_declaration", "interface_declaration", …` at
+  `csharp.go:137`). Make the change **additive** — keep matching the old form so
+  you don't regress older code.
+- Keep the traversal honest: only emit for resolved/literal constructs; return
+  `(…, false)` and recurse into children when you can't build a clean record
+  (model: the `if !ok { … walk children … }` fallback at `csharp.go:148`).
+- Tag language on the way out if the extractor doesn't already
+  (`extractor.TagEntitiesLanguage` / `TagRelationshipsLanguage`,
+  `csharp.go:90`).
+
+### 4. Register any new entity/edge Kind
+
+If your construct needs a **Kind that doesn't already exist** in
+`internal/types/kinds.go`:
+
+1. Add the constant to the right block (`EntityKind…` near `kinds.go:13`, or
+   `RelationshipKind…` near `:471`).
+2. Add it to the enumerator so the validator accepts it — `AllEntityKinds()`
+   (`kinds.go:339`) / `AllRelationshipKinds()`, which back `IsValidEntityKind`
+   (`kinds.go:456`) and `IsValidRelationshipKind`.
+3. **Run the producer-kind guard** — this is the standing new-extractor check:
+
+   ```sh
+   go test ./internal/types/
+   ```
+
+   `internal/types/producer_kinds_test.go` scans the whole producer codebase for
+   hard-coded `Kind: "…"` literals on `Entity`/`Relationship`/`…Record`
+   composite literals and asserts every distinct value is covered by the
+   validator. A new Kind string that isn't registered **fails this test at
+   compile/test time** — it is the guardrail that catches typos and stale kinds.
+
+   Prefer reusing an existing Kind (e.g. `SCOPE.Component`, `SCOPE.Operation`,
+   `SCOPE.Schema`) over minting a new one unless the construct is genuinely a new
+   category — most new constructs map onto an existing Kind with a new `Subtype`.
+
+### 5. Update `registry.json` + coverage docs — in the SAME PR (the hard gate)
+
+**Standing rule (non-negotiable):** every new/changed capability updates
+`docs/coverage/registry.json` **and** the regenerated coverage docs **in the same
+PR**, guarded by `coverage fmt --check`. Splitting them across PRs breaks the CI
+gate (`.github/workflows/coverage-docs.yml`). See
+[`tools/coverage/AGENTS.md`](../tools/coverage/AGENTS.md).
+
+1. **Add/update the capability cell.** Prefer the tool over hand-editing JSON so
+   placement stays canonical:
+
+   ```sh
+   go run ./tools/coverage update <record-id> ...   # set status + cites + notes
+   ```
+
+   The cell's `cites` must point at the real files you touched
+   (`internal/extractors/<lang>/…`, the fixture/test, and `internal/types/kinds.go`
+   if you added a Kind). Set `status` honestly (`full` only when modeled +
+   tested + value-asserting; otherwise `partial`/`missing`).
+   - If you're adding a brand-new **capability key**, first add it to
+     `capability-dictionary.yaml` (the taxonomy is data-driven — don't hardcode
+     keys in Go), then `go run ./tools/coverage validate`.
+
+2. **Regenerate the markdown views** (deterministic; CI diffs them):
+
+   ```sh
+   go run ./tools/coverage gen
+   ```
+
+3. **Validate + assert canonical format.** `registry.json` must stay
+   **2-space-indented, sorted** canonical form — make **surgical** edits, never
+   re-serialize the whole file:
+
+   ```sh
+   go run ./tools/coverage validate
+   go run ./tools/coverage fmt --check   # exits non-zero if not canonical
+   ```
+
+   `coverage fmt --check` (`tools/coverage/fmt.go`) writes nothing and exits
+   non-zero when the on-disk file isn't the canonical 2-space sorted form it
+   would produce. Run `go run ./tools/coverage fmt` (no `--check`) to fix.
+
+4. **Commit the dictionary (if changed) + `registry.json` + the regenerated
+   `docs/coverage/**` together** with the extractor change.
+
+### 6. Add a fixture and a value-asserting test
+
+- Drop a minimal source file using the new construct under the extractor's
+  `testdata/` (model: `internal/extractors/csharp/testdata/`).
+- Add a test that runs `Extract` over it and **asserts the specific
+  entity/edge** is emitted with the right `Kind`/`Subtype`/`Name` and any edge
+  target (model: `internal/extractors/csharp/csharp_test.go` and the per-issue
+  tests like `issue4854_field_membership_test.go`). Assert *values*, not just
+  counts — a count test passes on the wrong node.
+
+  ```sh
+  go test ./internal/extractors/<lang>/...
+  ```
+
+- **Fixture-then-live validation:** a green fixture test is necessary but not
+  sufficient. The standing rule is to confirm the construct also surfaces on a
+  **real indexed project** (fixtures can pass while live extraction fails — a
+  recurring failure mode). Index a repo that uses the construct and verify the
+  entity/edge appears in the graph before calling the capability `full`.
+
+### 7. Close the loop
+
+- Tick the corresponding **(b)/(c) action item** in the C1 feature-impact report.
+- If the construct came from the catch-up window, note it against
+  [C3 backfill (#5417)](https://github.com/cajasmota/grafel/issues/5417).
+- Update [`grammars.lock`](../grammars.lock) `last_verified` for the language if
+  this confirmed it current for version N.
+
+## Pre-merge checklist (copy into the PR)
+
+- [ ] Node kind located in the grammar (and a fixture proves it parses, not
+      `ERROR` — grammar-bump prerequisite cleared).
+- [ ] `case` added/adapted in `internal/extractors/<lang>/…`; entity/edge emitted.
+- [ ] New Kind (if any) registered in `internal/types/kinds.go` +
+      `All…Kinds()`; **`go test ./internal/types/` green** (producer-kind guard).
+- [ ] `registry.json` cell added/updated via `go run ./tools/coverage update`
+      with real `cites`; `capability-dictionary.yaml` updated if a new key.
+- [ ] `go run ./tools/coverage gen` re-run; `docs/coverage/**` committed
+      **in this PR**.
+- [ ] `go run ./tools/coverage validate` clean; `go run ./tools/coverage fmt --check`
+      passes (2-space canonical, surgical edits only).
+- [ ] Value-asserting fixture test added; `go test ./internal/extractors/<lang>/...`
+      green.
+- [ ] Live validation: construct surfaces on a real indexed project (not just the
+      fixture).

--- a/docs/grammar-freshness-audit.md
+++ b/docs/grammar-freshness-audit.md
@@ -259,5 +259,9 @@ an alarm to catch up.
 1. **B3 (this audit + `grammars.lock`)** ✓ + **A1** Renovate ✓ + **A2** cron ✓.
 2. **B1** catch-up bump behind the fidelity/coverage benchmark.
 3. **A3** calendar ✓ + **A4** parse-error canary ✓.
-4. **C1/C2** process; **C3** backfill for the catch-up window.
-5. **B2** decoupling — assessment, may slip past 0.1.4.
+4. **C1** triage process ✓ (`docs/new-language-feature-triage.md`) + **C2**
+   extractor recipe ✓ (`docs/extractor-recipe.md`); **C3** backfill for the
+   catch-up window — **blocked on B1** (the grammar must parse the new syntax
+   before the (b)/(c) constructs can be modeled).
+5. **B2** decoupling — assessment ✓ (ADR-0023), phased migration may slip past
+   0.1.4.

--- a/docs/new-language-feature-triage.md
+++ b/docs/new-language-feature-triage.md
@@ -1,0 +1,141 @@
+# New-language-feature triage (C1, epic #5359 — milestone 0.1.4)
+
+_Process maintained as of 2026-06-23. Companion to
+[`docs/language-release-calendar.md`](./language-release-calendar.md) (A3),
+[`docs/grammar-freshness-audit.md`](./grammar-freshness-audit.md) (B3),
+[`grammars.lock`](../grammars.lock), and the
+[extractor recipe](./extractor-recipe.md) (C2)._
+
+## Why this exists
+
+A grammar bump makes new syntax **parse**; grafel must also **model** it. Those
+are two different kinds of work (epic #5359 Part C):
+
+1. **Syntax gap** — the bundled grammar doesn't recognise the new syntax. A
+   grammar bump fixes it (mechanical). tree-sitter is error-tolerant, so indexing
+   never *breaks* — it silently emits `ERROR` nodes instead.
+2. **Modeling gap** — even once the syntax parses, grafel's extractors don't put
+   the new construct in the graph. A new DI mechanism, routing syntax, async
+   idiom, or data construct needs **new detection logic + a coverage-registry
+   update**. This is the hard, per-feature work.
+
+C1 is the **decision procedure**: given a language version N's notable features,
+classify each one so the work is scoped before anyone opens an extractor PR. It
+turns "Java 25 shipped" into a concrete list of (b)/(c) action items that become
+[C2 recipe](./extractor-recipe.md) PRs (or [C3 backfill](https://github.com/cajasmota/grafel/issues/5417)).
+
+## The classification
+
+For each notable feature of version N, assign exactly one bucket:
+
+| Bucket | Meaning | grafel work | Routes to |
+|---|---|---|---|
+| **(a) parse-only** | The grammar's CST already represents it adequately and grafel's existing extractors either don't need to model it or already cover it. No new node kind to walk, no entity/edge to emit. | **None.** Note it and move on. | — |
+| **(b) needs-new-extraction** | A genuinely new construct grafel *should* model — a new node kind in the grammar that maps to an entity/edge grafel doesn't currently emit (a record type, a DI attribute, a routing form, an async/concurrency idiom, a new visibility/module mechanism). | **New extractor logic + new coverage cell.** | [C2 recipe](./extractor-recipe.md) → new PR |
+| **(c) changes-existing-extraction** | An existing construct grafel already extracts, but the new version **changed its syntax** (a new node-type name, a new field, an alternate declaration form). An existing extractor's `switch node.Type()` / `ChildByFieldName(...)` must adapt or it silently stops emitting. | **Patch the existing extractor + refresh its coverage cell.** | [C2 recipe](./extractor-recipe.md) → fix PR |
+
+### Deciding between the buckets
+
+- **(a) vs (b):** ask *"would grafel's graph be richer if it modeled this?"* If
+  the construct is a new kind of component/operation/endpoint/edge that a graph
+  consumer (MCP query, dashboard, impact radius) would want to see — it's (b). If
+  it's pure syntactic sugar that produces nodes grafel already walks (or that no
+  consumer cares about) — it's (a).
+- **(b) vs (c):** ask *"did grafel already emit something for the OLD form of
+  this?"* If yes and the syntax merely changed shape — it's (c) (an adaptation,
+  usually smaller). If the construct is new to the language — it's (b).
+- **Triage is spec-driven, not grammar-driven.** Because the bundled grammar is
+  ~22 months stale (see B3 audit §1), it may not even parse N yet. **Do not block
+  triage on the grammar bump.** Classify from the language *release notes* /
+  spec; record "grammar bump (B1) is a prerequisite" against any (b)/(c) item
+  whose node kind the bundled grammar can't yet produce. The grammar bump is the
+  prerequisite for *implementing* (b)/(c), not for *triaging* it.
+
+## The per-version impact-report template
+
+When version N lands (the A3 calendar cron, #5413, fires the reminder), copy the
+block below into `docs/feature-impact/<lang>-<version>.md` and fill it in. It is
+the standing artifact that turns a release into action items.
+
+```markdown
+# Feature-impact report — <Language> <Version>
+
+- **Released:** <YYYY-MM-DD>
+- **Triaged:** <YYYY-MM-DD> by <who>
+- **Grammar status:** <bundled snapshot parses N? — from A4 canary / A2 cron>
+  - A4 canary (`parse_error_canary` in `graph-stats.json`): <spike? per-lang rate>
+  - A2 cron tracking issue: <has upstream tree-sitter-<lang> shipped N support?>
+- **Grammar-bump prerequisite:** <yes/no — does any (b)/(c) item below need B1 first?>
+
+## Feature triage
+
+| # | Feature (from release notes) | Bucket | Rationale | Extractor / registry cell touched |
+|---|---|---|---|---|
+| 1 | <feature> | a / b / c | <why this bucket> | <internal/extractors/<lang>/… · registry id, or “none”> |
+| … | | | | |
+
+## Action items
+
+- [ ] (b) <feature> → C2 recipe PR: add <node_kind> extraction in
+      `internal/extractors/<lang>/…`, register Kind <…> if new, update
+      `registry.json` cell <id> + coverage docs (same PR), `coverage fmt --check`.
+- [ ] (c) <feature> → patch `internal/extractors/<lang>/…` `switch node.Type()`
+      for renamed/added node kind <…>; refresh registry cell <id>.
+- [ ] (a) items: no work — recorded above for the audit trail.
+- [ ] Update `grammars.lock` `last_verified` for <lang> once confirmed current.
+- [ ] Backfill candidates (released in the catch-up window) → C3 (#5417).
+```
+
+The report's deliverable is the **Action items** list: every (b) and (c) becomes
+a tracked follow-up built via the [C2 recipe](./extractor-recipe.md); (a) items
+are recorded for the audit trail and need no work.
+
+## Worked example — C# 13 (.NET 9, Nov 2024)
+
+Triaged spec-first from the C# 13 release notes. At triage time the bundled
+`tree-sitter-c-sharp` snapshot (2024-08-27) predates full C# 13 support, so
+several node kinds below **may emit `ERROR` nodes until the B1 catch-up bump** —
+that's flagged as the grammar-bump prerequisite, not a triage blocker. The
+relevant grafel extractor is `internal/extractors/csharp/` (entry
+`csharp.go`, the `walk()` `switch node.Type()` traversal).
+
+| # | C# 13 feature | Bucket | Rationale | Extractor / registry cell |
+|---|---|---|---|---|
+| 1 | **`params` collections** (`params ReadOnlySpan<T>`, any collection type) | **a** | Just a wider parameter modifier on `method_declaration`/`constructor_declaration`, which `csharp.go` already walks and emits as `SCOPE.Operation`. No new node kind, no new edge a consumer needs. | none |
+| 2 | **`ref struct` interface implementation / `allows ref struct`** anti-constraint | **c** | grafel already emits `struct_declaration → SCOPE.Component` and IMPLEMENTS edges. The new `allows ref struct` clause changes the `type_parameter_constraints` shape; the constraint-walking path may need to tolerate the new node so it doesn't drop the type. Adaptation of existing extraction. | `csharp.go` `buildComponent` / constraint walk; registry `csharp` type-system cell |
+| 3 | **`field` keyword (preview)** — semi-auto property backing field | **b** | A property accessor body referencing `field` is a new *member-level* construct. If grafel models property backing storage (field-membership, #4854 area), the `field` keyword introduces a new binding target the field-members pass should recognise. New modeling. | `internal/extractors/csharp/field_members.go`; registry `csharp` field-membership cell |
+| 4 | **New lock object** (`System.Threading.Lock`) | **a** | Purely a type swap at the call site (`lock` statement over a `Lock` instance). The `lock_statement` node is unchanged; grafel doesn't model lock objects as graph entities today and a consumer wouldn't query them. | none |
+| 5 | **Partial properties & indexers** | **c** | grafel walks `property_declaration` for field-membership; `partial` properties split a declaration across two `property_declaration` nodes with `partial` modifiers. The existing property/field path must de-duplicate / merge the split halves rather than emit two members. Adaptation. | `csharp.go` / `field_members.go`; registry `csharp` field-membership cell |
+| 6 | **Implicit index access in object initializers** (`^1` in initializers) | **a** | Sugar inside `initializer_expression`; produces expression nodes grafel doesn't model as entities. No graph-relevant construct. | none |
+| 7 | **Overload resolution priority** (`[OverloadResolutionPriority]` attribute) | **a** | A new attribute on `method_declaration`. grafel already emits the method as `SCOPE.Operation`; the attribute carries no graph edge a consumer queries (it's a compiler hint). Could become (b) later if attribute-driven analysis is added. | none |
+| 8 | **`Span<T>`/`ReadOnlySpan<T>` extension-method lookups** (collection-expr conversions) | **a** | Changes which extension methods bind, but the CALLS-edge target shape (`csharp.go` `extractCallRelationships`) is unchanged. Already-extracted call edges; no new node kind. | none |
+
+**Verdict for C# 13:** 5×(a) parse-only · 1×(b) `field` keyword field-membership
+modeling · 2×(c) `allows ref struct` constraint tolerance + partial-property
+merge. The two (c)s and the one (b) become C2-recipe follow-ups; all three carry
+the **grammar-bump prerequisite** (the bundled snapshot must parse C# 13 first —
+B1 catch-up bump, behind the fidelity/coverage benchmark gate). The five (a)s are
+recorded and need no work.
+
+## How this fits the cadence
+
+C1 is the **decision step** between the freshness alarms and the build work:
+
+| Signal | Mechanism | Feeds C1 by telling you… |
+|---|---|---|
+| **Proactive nudge** | [A3 calendar + cron](./language-release-calendar.md) (#5413) | a known release window is coming — *run the triage now*. The reminder issue links straight to this doc. |
+| **"Upstream moved"** | A2 `grammar-freshness.yml` cron (#5411) | the upstream `tree-sitter-<lang>` grammar shipped support for N — the bundled snapshot is the blocker (grammar-bump prerequisite for (b)/(c)). |
+| **"Parsing is actually failing"** | A4 parse-error canary (#5414) | the bundled grammar is emitting `ERROR` nodes on real indexed code — a hard syntax gap, version-agnostic. Fill the **Grammar status** row of the report from this. |
+
+The output of C1 — the per-version impact report's **Action items** — is the
+input to:
+
+- **[C2 — extractor recipe](./extractor-recipe.md) (#5416):** the repeatable build
+  path for each (b)/(c) item (locate node kind → add traversal/emit → register
+  Kind → update `registry.json` + coverage docs in the same PR →
+  `coverage fmt --check` → fixture/test).
+- **C3 — backfill (#5417):** the (b)/(c) features already released during the
+  ~22-month catch-up window, modeled (not just parsed) once B1 lands.
+
+All four reconcile against [`grammars.lock`](../grammars.lock), the source of
+truth for which grammar version each language rides.


### PR DESCRIPTION
Closes #5415, closes #5416. Part of epic #5359 (milestone 0.1.4, Part C).

Once a grammar bump makes new syntax **parse**, grafel must also **model** it. This docs PR stands up the two remaining process pieces of the freshness epic: how to decide what work a new language version needs, and how to actually add an extractor for a new construct.

## C1 — new-feature triage process (#5415)
`docs/new-language-feature-triage.md`:
- The classification each new feature gets: **(a) parse-only** (grammar handles it, no extractor change), **(b) needs-new-extraction** (a new construct grafel should model), **(c) changes-existing-extraction** (an existing extractor must adapt). With explicit (a)-vs-(b) and (b)-vs-(c) decision tests.
- "Triage is spec-driven, not grammar-driven" — because the bundled grammar is ~22 months stale it may not even parse N yet; classify from release notes and record the grammar-bump (B1) prerequisite against (b)/(c) items. Don't block triage on the bump.
- A fillable **per-version feature-impact-report template** the A3 calendar cron (#5413) points at when version N lands, producing a per-version Action-items list.
- A **worked example: C# 13** (.NET 9) classifying 8 real features — 5×(a) parse-only, 1×(b) `field` keyword field-membership modeling, 2×(c) `allows ref struct` constraint tolerance + partial-property merge — each carrying the grammar-bump prerequisite.
- Wired into the cadence: A3 nudge → A2/A4 alarms fill the grammar-status row → (b)/(c) action items feed the C2 recipe / C3 backfill.

## C2 — extractor recipe (#5416)
`docs/extractor-recipe.md` — a grounded, repeatable checklist:
- Grounded in grafel's real architecture (pure manual `node.Type()` traversal, no native queries — per ADR-0023) citing the C# extractor `internal/extractors/csharp/csharp.go` (the `init()` register, `walk()` `switch node.Type()`, `buildComponent` emit, `CONTAINS` edges) and `internal/types/kinds.go`.
- Steps: locate node kind in the grammar → add the `case`/`build…` emit in the right extractor → register any new entity/edge Kind (`internal/types/kinds.go` + `All…Kinds()`) and run the producer-kind guard `go test ./internal/types/` → **update `registry.json` + coverage docs in the SAME PR** (`go run ./tools/coverage update/gen/validate`, surgical 2-space-canonical edits) → `coverage fmt --check` passes → add a value-asserting fixture test + fixture-then-live validation.
- Bakes in the standing rules (new-extractor Kind check, registry-canonical 2-space format, same-PR coverage gate). Includes a copy-into-PR pre-merge checklist.

## Also
- CHANGELOG: two `### Added` bullets.
- `docs/grammar-freshness-audit.md` §5 sequencing: C1/C2 marked done, C3 backfill marked **blocked on B1**.

Docs/process only — no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)