### PR TITLE
fix(mcp): re-apply group-algo overlay on a cached group when it changes (#5403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Fixed
+- **Cached group re-applies the group-algo overlay when its file advances (#5403):** `State.Group()` now os.Stats the overlay on the serve path and re-stamps only when the mtime advances past the memoized value, so a recomputed overlay (scheduler or manual `group-algo --write`) takes effect without a daemon restart. Cheap (one stat/query), absence-tolerant. (Scheduler-trigger half for settled groups deferred for live validation.)
 - **Daemon no longer exits on transient `Accept()` errors (#5424):**
   `acceptLoop` previously returned the serve loop on **any** `Accept()` error
   other than `net.ErrClosed`, which made `Run` unlink the unix socket and drop

--- a/internal/mcp/group_algo_overlay_reapply_5403_test.go
+++ b/internal/mcp/group_algo_overlay_reapply_5403_test.go
@@ -1,0 +1,134 @@
+// group_algo_overlay_reapply_5403_test.go — #5403: a cached/already-loaded group
+// must re-apply the group-algo overlay when its <group>-algo.json file mtime
+// advances mid-session, WITHOUT a full reload.
+//
+// Root cause: applyGroupAlgoOverlay is called only at group LOAD (Reload). A
+// long-running daemon caches the group, so when the overlay file is recomputed
+// (scheduler after a reindex, or `grafel group-algo --write`) the cached group
+// keeps serving the last-applied state until a restart — the apply was never
+// re-called. The fix hooks the canonical group-serving entry path (State.Group,
+// used by clusters/inspect/orient/stats): it os.Stats the overlay and re-applies
+// only when the file mtime advanced past the memoized grp.algoMt.
+package mcp
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+)
+
+// TestGroupReapplyOverlayOnMtimeAdvance loads a group with overlay v1 applied,
+// then rewrites the overlay file with a NEWER mtime + a different community
+// assignment and issues a plain State.Group lookup. With the #5403 fix the
+// cached group reflects the NEW overlay without a Reload. It also asserts the
+// cheap path (unchanged mtime → no re-apply) and absence-tolerance.
+func TestGroupReapplyOverlayOnMtimeAdvance(t *testing.T) {
+	st, overlayPath, cur, beID, feID, mobID, _, _ := setupThreeRepoApplyGroup(t)
+
+	// --- v1 overlay: mobile → community 80.
+	ovV1 := &groupalgo.Overlay{
+		Group:        "upvate",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			beID:  {CommunityID: 39, PageRank: 0.0065, Centrality: 10415.99, IsGodNode: true},
+			feID:  {CommunityID: 203, PageRank: 0.004, Centrality: 16521.23, IsGodNode: true},
+			mobID: {CommunityID: 80, PageRank: 0.001, Centrality: 6706, IsArticulationPoint: true},
+		},
+		Communities: []graph.CommunityResult{
+			{ID: 39, Size: 2, AutoName: "serializer-serializers-core"},
+			{ID: 80, Size: 1, AutoName: "features-types-props"},
+		},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ovV1); err != nil {
+		t.Fatalf("write overlay v1: %v", err)
+	}
+	v1mt := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(overlayPath, v1mt, v1mt); err != nil {
+		t.Fatalf("set overlay v1 mtime: %v", err)
+	}
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload v1: %v", err)
+	}
+	if mob := entityByID(st.Group("upvate"), mobID); mob == nil || mob.CommunityID == nil || *mob.CommunityID != 80 {
+		t.Fatalf("v1: mobile not stamped to overlay community 80: %v", mob)
+	}
+
+	// --- Cheap path: a second Group() lookup with an UNCHANGED overlay file must
+	// NOT change anything (and, importantly, not re-read/re-stamp — verified by
+	// the value staying put with mtime unmoved).
+	grpBefore := st.Group("upvate")
+	algoMtBefore := grpBefore.algoMt
+	if mob := entityByID(st.Group("upvate"), mobID); mob == nil || *mob.CommunityID != 80 {
+		t.Fatalf("cheap path: mobile community changed unexpectedly: %v", mob)
+	}
+	if !grpBefore.algoMt.Equal(algoMtBefore) {
+		t.Fatalf("cheap path: algoMt advanced without a file change")
+	}
+
+	// --- v2 overlay: rewrite the SAME file in place with a NEWER mtime and move
+	// mobile to a DIFFERENT community (81). No Reload() is issued — this is the
+	// settled-daemon case (#5403): the scheduler/CLI rewrote the overlay on disk
+	// but never poked the cached group.
+	ovV2 := &groupalgo.Overlay{
+		Group:        "upvate",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			beID:  {CommunityID: 39, PageRank: 0.0065, Centrality: 10415.99, IsGodNode: true},
+			feID:  {CommunityID: 203, PageRank: 0.004, Centrality: 16521.23, IsGodNode: true},
+			mobID: {CommunityID: 81, PageRank: 0.009, Centrality: 9999, IsArticulationPoint: true},
+		},
+		Communities: []graph.CommunityResult{
+			{ID: 39, Size: 2, AutoName: "serializer-serializers-core"},
+			{ID: 81, Size: 1, AutoName: "features-types-props-v2"},
+		},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ovV2); err != nil {
+		t.Fatalf("write overlay v2: %v", err)
+	}
+	v2mt := time.Now() // strictly after v1mt (one hour ago)
+	if err := os.Chtimes(overlayPath, v2mt, v2mt); err != nil {
+		t.Fatalf("set overlay v2 mtime: %v", err)
+	}
+
+	// A plain serve lookup must now reflect the NEW overlay (community 81) WITHOUT
+	// any Reload().
+	grp := st.Group("upvate")
+	mob := entityByID(grp, mobID)
+	if mob == nil {
+		t.Fatalf("mobile entity missing after overlay v2")
+	}
+	if mob.CommunityID == nil || *mob.CommunityID != 81 {
+		t.Fatalf("#5403: cached group did not re-apply overlay v2; mobile community_id=%v want 81", mob.CommunityID)
+	}
+	if mob.PageRank == nil || *mob.PageRank != 0.009 {
+		t.Errorf("#5403: cached group did not re-apply overlay v2 pagerank; got %v want 0.009", mob.PageRank)
+	}
+	// grp.Communities reflects the v2 summary too (clusters path).
+	var seen81 bool
+	for _, c := range grp.Communities {
+		if c.ID == 81 {
+			seen81 = true
+		}
+	}
+	if !seen81 {
+		t.Errorf("#5403: grp.Communities did not refresh to the v2 overlay summary (community 81 missing)")
+	}
+
+	// --- Absence tolerance: remove the overlay file and confirm a lookup is a
+	// no-op (does not panic; entity keeps the last-applied v2 value — per-query we
+	// are non-destructive; a clear happens on the next Reload).
+	if err := os.Remove(overlayPath); err != nil {
+		t.Fatalf("remove overlay: %v", err)
+	}
+	grp2 := st.Group("upvate")
+	if grp2 == nil {
+		t.Fatalf("absent overlay: Group returned nil")
+	}
+	if mob := entityByID(grp2, mobID); mob == nil || mob.CommunityID == nil || *mob.CommunityID != 81 {
+		t.Fatalf("absent overlay: expected non-destructive no-op keeping v2 community 81, got %v", mob)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -854,10 +854,58 @@ func (s *State) reloadLocked() (int, bool, error) {
 }
 
 // Group returns a loaded group by name, or nil.
+//
+// Overlay-freshness check (#5403): the group-algo overlay is applied at group
+// LOAD (during Reload, via applyGroupAlgoOverlay). A long-running daemon caches
+// the group, so a settled group whose <group>-algo.json overlay is recomputed
+// mid-session (by the scheduler after a reindex, or a manual
+// `grafel group-algo --write`) keeps serving the LAST-APPLIED state until a
+// restart — the apply was never re-called on the cached group. Here, on the
+// canonical group-serving entry path (used by clusters/inspect/orient/stats),
+// we cheaply os.Stat the overlay file and, only when its mtime ADVANCES past the
+// memoized grp.algoMt, re-call applyGroupAlgoOverlay so the fresh overlay takes
+// effect without a reload. The stat is the only per-query cost; the overlay is
+// re-read/re-stamped solely when the file genuinely advanced (the #5402 per-repo
+// memo then re-stamps exactly the repos that need it). Absence-tolerant: a
+// missing overlay → no re-apply (today's behavior). Runs under s.mu, the same
+// lock applyGroupAlgoOverlay holds during Reload, so the shared apply/memo
+// fields are mutated race-free.
 func (s *State) Group(name string) *LoadedGroup {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.groups[name]
+	grp := s.groups[name]
+	if grp != nil {
+		s.refreshGroupAlgoOverlayLocked(grp)
+	}
+	return grp
+}
+
+// refreshGroupAlgoOverlayLocked re-applies the group-algo overlay to an
+// already-loaded group when its overlay file mtime has advanced past the
+// memoized grp.algoMt (#5403). Cheap by design: a single os.Stat; the overlay
+// is re-read and re-stamped only when the file advanced. Absence/stat-error →
+// no-op (the overlay may legitimately not exist yet). Caller must hold s.mu.
+func (s *State) refreshGroupAlgoOverlayLocked(grp *LoadedGroup) {
+	path := grp.algoFile
+	if path == "" {
+		var err error
+		if path, err = groupalgo.OverlayPath(grp.Name); err != nil || path == "" {
+			return
+		}
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		// Absent/unreadable overlay → no-op. If the group had previously applied
+		// an overlay that has since been removed, applyGroupAlgoOverlay (on the
+		// next Reload) handles the clear; per-query we stay non-destructive.
+		return
+	}
+	// Only re-apply when the file genuinely advanced. grp.algoApplied false with a
+	// present file (overlay appeared after a load that saw none) also re-applies.
+	if grp.algoApplied && !fi.ModTime().After(grp.algoMt) {
+		return
+	}
+	applyGroupAlgoOverlay(grp)
 }
 
 // SnapshotGroups returns a stable list of loaded group pointers.


### PR DESCRIPTION
Fixes the overlay-staleness observed during v0.1.3 validation: the group-algo overlay was applied only at group LOAD, so a long-running daemon kept serving a stale/unapplied overlay after a mid-session recompute until restart.

**Fix:** `State.Group()` (the canonical serve path for clusters/inspect/orient/stats) now cheaply os.Stats the overlay file and re-calls `applyGroupAlgoOverlay` only when the mtime advances past the memoized `grp.algoMt` (the #5402 per-repo memo then re-stamps exactly what changed). One stat/query; absence-tolerant; under `s.mu`.

**Deferred (needs live validation):** the scheduler-trigger half — A3 only recomputes the overlay on a link-pass after a reindex, so a *settled* group's overlay isn't proactively refreshed. Documented as a follow-up.

Test: `TestGroupReapplyOverlayOnMtimeAdvance` (rewrites the overlay with a newer mtime + different communities, asserts re-apply without reload; unchanged-mtime → no re-apply; absent → no-op). Build+vet+test green.