### PR TITLE
fix(daemon): cap group-algo to 2 cores + nice + 3-min debounce (CPU regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Fixed
+- **group-algo no longer pins the machine (CPU regression, v0.1.3):** the
+  background group-scope analytics pass (Louvain + PageRank + betweenness over
+  the whole group union) ran at the host's full GOMAXPROCS and re-fired on a
+  30s debounce, so on a 12-core machine it sat at **500–1000% CPU for hours** and
+  starved foreground work. It now runs **capped to 2 cores** (Go `GOMAXPROCS`,
+  env `GRAFEL_GROUP_ALGO_CPU` to override — set `=1` for a single core; was
+  effectively `NumCPU`), **niced (+10 OS priority demotion on Unix, no-op on
+  Windows)** so even those cores yield to a consumer's CI/dev harness, and with a
+  **3-minute debounce** (was 30s, env `GRAFEL_GROUP_ALGO_DEBOUNCE`) so a burst of
+  commits coalesces into one pass instead of re-triggering on nearly every push.
+  The `cap=` start-log now reports the real per-pass core cap, not the semaphore
+  concurrency. Betweenness already self-samples above 8k nodes (K=512 pivots), so
+  no change there; a follow-up may lower K further under the new cap.
 - **Cached group re-applies the group-algo overlay when its file advances (#5403):** `State.Group()` now os.Stats the overlay on the serve path and re-stamps only when the mtime advances past the memoized value, so a recomputed overlay (scheduler or manual `group-algo --write`) takes effect without a daemon restart. Cheap (one stat/query), absence-tolerant. (Scheduler-trigger half for settled groups deferred for live validation.)
 - **Daemon no longer exits on transient `Accept()` errors (#5424):**
   `acceptLoop` previously returned the serve loop on **any** `Accept()` error

--- a/cmd/grafel/group_algo.go
+++ b/cmd/grafel/group_algo.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 )
 
@@ -48,6 +49,14 @@ func runGroupAlgo(args []string) int {
 		return 2
 	}
 	group := positional[0]
+
+	// This subcommand is the heavy background analytics child (Louvain +
+	// PageRank + betweenness over the whole group union). Lower its OS
+	// scheduling priority so even its capped cores yield to foreground work —
+	// the v0.1.3 CPU regression starved a consumer's test harness. No-op on
+	// Windows. The GOMAXPROCS cap is applied by the parent (env, default 2);
+	// nice is best-effort self-renice so it holds however the child is spawned.
+	sched.NiceSelf()
 
 	// --diff (#5349 A4): run the differential validator (per-repo-old vs
 	// group-new) and emit a machine-readable JSON report on stdout. It writes

--- a/internal/daemon/sched/groupalgo_cpu_test.go
+++ b/internal/daemon/sched/groupalgo_cpu_test.go
@@ -1,0 +1,94 @@
+package sched
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestGroupAlgoGOMAXPROCSDefault asserts the background group-algo subprocess
+// CPU cap defaults to 2 cores ("the less the better"), independent of host
+// core count — the fix for the v0.1.3 CPU regression where the pass ran at the
+// host's full GOMAXPROCS.
+func TestGroupAlgoGOMAXPROCSDefault(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
+	if got := GroupAlgoGOMAXPROCS(); got != 2 {
+		t.Fatalf("default GroupAlgoGOMAXPROCS = %d, want 2", got)
+	}
+}
+
+// TestGroupAlgoGOMAXPROCSEnvOverride asserts GRAFEL_GROUP_ALGO_CPU overrides the
+// default, including the user's "throttle to a single core" case (=1).
+func TestGroupAlgoGOMAXPROCSEnvOverride(t *testing.T) {
+	cases := []struct {
+		env  string
+		want int
+	}{
+		{"1", 1}, // the user's explicit "one core" knob
+		{"3", 3},
+		{"  4  ", 4}, // whitespace-tolerant
+		{"0", 2},     // non-positive → default
+		{"-1", 2},    // non-positive → default
+		{"abc", 2},   // non-numeric → default
+		{"", 2},      // unset → default
+	}
+	for _, c := range cases {
+		t.Run(c.env, func(t *testing.T) {
+			t.Setenv("GRAFEL_GROUP_ALGO_CPU", c.env)
+			if got := GroupAlgoGOMAXPROCS(); got != c.want {
+				t.Fatalf("GroupAlgoGOMAXPROCS(%q) = %d, want %d", c.env, got, c.want)
+			}
+		})
+	}
+}
+
+// TestGroupAlgoDebounceDefault asserts the debounce default is 180s (3 min),
+// raised from 30s so a burst of commits coalesces into ONE group-algo pass.
+func TestGroupAlgoDebounceDefault(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_DEBOUNCE", "")
+	if got := groupAlgoDebounceFromEnv(); got != 180*time.Second {
+		t.Fatalf("default group-algo debounce = %s, want 180s", got)
+	}
+	if groupAlgoDebounceDefault != 180*time.Second {
+		t.Fatalf("groupAlgoDebounceDefault = %s, want 180s", groupAlgoDebounceDefault)
+	}
+}
+
+// TestGroupAlgoDebounceEnvOverride asserts GRAFEL_GROUP_ALGO_DEBOUNCE still
+// overrides the (now-longer) default, and that bad values fall back.
+func TestGroupAlgoDebounceEnvOverride(t *testing.T) {
+	cases := []struct {
+		env  string
+		want time.Duration
+	}{
+		{"45s", 45 * time.Second},
+		{"5m", 5 * time.Minute},
+		{"0s", 180 * time.Second},      // non-positive → default
+		{"garbage", 180 * time.Second}, // unparseable → default
+		{"", 180 * time.Second},        // unset → default
+	}
+	for _, c := range cases {
+		t.Run(c.env, func(t *testing.T) {
+			t.Setenv("GRAFEL_GROUP_ALGO_DEBOUNCE", c.env)
+			if got := groupAlgoDebounceFromEnv(); got != c.want {
+				t.Fatalf("debounce(%q) = %s, want %s", c.env, got, c.want)
+			}
+		})
+	}
+}
+
+// TestGroupAlgoNiceValue asserts the OS-priority demotion is a positive nice on
+// Unix and guarded off (0) on Windows. NiceSelf itself must never panic.
+func TestGroupAlgoNiceValue(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		if groupAlgoNice != 0 {
+			t.Fatalf("groupAlgoNice on windows = %d, want 0 (guarded off)", groupAlgoNice)
+		}
+	} else {
+		if groupAlgoNice <= 0 {
+			t.Fatalf("groupAlgoNice on %s = %d, want positive demotion", runtime.GOOS, groupAlgoNice)
+		}
+	}
+	// Best-effort, must not panic regardless of platform/permission.
+	NiceSelf()
+}

--- a/internal/daemon/sched/nice_unix.go
+++ b/internal/daemon/sched/nice_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package sched
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// groupAlgoNice is the positive nice increment applied to the group-algo
+// subprocess so it runs at a lower OS scheduling priority than foreground work.
+// +10 is a substantial-but-not-extreme demotion: the background analytics pass
+// yields the CPU to a consumer's CI / dev harness instead of starving it (the
+// v0.1.3 regression starved a user's Django test harness).
+const groupAlgoNice = 10
+
+// applyGroupAlgoNice arranges for the spawned child to start at a lower OS
+// priority. On Unix we put the child in its own process group and the runtime
+// applies the nice increment relative to the parent's priority via
+// SysProcAttr. The actual setpriority(2) call is issued by the child itself at
+// startup (see niceSelf), because Go's exec package does not expose a portable
+// "spawn at nice N" knob; here we only ensure the child is independently
+// schedulable. Kept as a hook so the spawn site stays platform-agnostic.
+func applyGroupAlgoNice(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// NiceSelf lowers the CURRENT process's OS scheduling priority by
+// groupAlgoNice. Called by the group-algo child at startup so it runs niced
+// regardless of how it was spawned. Best-effort: a failure (e.g. lacking
+// permission to renice) is silently ignored — the cap is the primary control.
+func NiceSelf() {
+	// PRIO_PROCESS=0, who=0 → the calling process. A positive value lowers
+	// priority. Errors are ignored: renicing DOWN never requires privilege, but
+	// guard anyway.
+	_ = syscall.Setpriority(syscall.PRIO_PROCESS, 0, groupAlgoNice)
+}

--- a/internal/daemon/sched/nice_windows.go
+++ b/internal/daemon/sched/nice_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package sched
+
+import "os/exec"
+
+// On Windows there is no setpriority(2)/nice. The CPU cap (GOMAXPROCS) is the
+// portable control; OS-priority demotion is a no-op here. (A BELOW_NORMAL
+// priority class could be set via CREATE_* flags, but the cap already bounds
+// the draw and we avoid platform-specific spawn surgery.)
+
+const groupAlgoNice = 0
+
+// applyGroupAlgoNice is a no-op on Windows.
+func applyGroupAlgoNice(cmd *exec.Cmd) {}
+
+// NiceSelf is a no-op on Windows.
+func NiceSelf() {}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -1074,10 +1074,16 @@ func (s *Scheduler) runLinks(ctx context.Context, group string) {
 }
 
 // groupAlgoDebounceDefault is the settling window between a successful link
-// pass and the group-scope algorithm pass it triggers. 30s mirrors the old
-// per-repo AlgoDebounce and is comfortably past the link-pass cadence so a
-// burst of repo reindexes lands a single coalesced group-algo pass.
-const groupAlgoDebounceDefault = 30 * time.Second
+// pass and the group-scope algorithm pass it triggers. The group-algo pass
+// (Louvain + PageRank + betweenness over the whole group union) is the
+// heaviest background job the daemon runs, so the debounce is deliberately
+// long: a burst of commits/reindexes within the window coalesces into ONE
+// pass instead of re-firing the analytics on nearly every push. Raised from
+// 30s to 180s after a CPU regression (v0.1.3) where back-to-back commits kept
+// re-triggering the pass and pinned a 12-core machine for hours. The window is
+// comfortably past the link-pass cadence. Override with
+// GRAFEL_GROUP_ALGO_DEBOUNCE.
+const groupAlgoDebounceDefault = 180 * time.Second
 
 // groupAlgoDebounceFromEnv resolves the group-algo debounce, honoring
 // GRAFEL_GROUP_ALGO_DEBOUNCE (a Go duration string, e.g. "45s"). An unset or
@@ -1144,7 +1150,12 @@ func (s *Scheduler) runGroupAlgo(ctx context.Context, group string) {
 	// from running concurrently with another capped pass (#2141 root-cause C).
 	// The acquire is interruptible via ctx so a cancellation (a new link pass
 	// completes, or daemon shutdown) doesn't block forever.
-	capN := cap(s.algoSem)
+	// The semaphore capacity (cap(s.algoSem)) only bounds how many algo passes
+	// may run CONCURRENTLY — it is NOT the CPU draw of a single pass. The actual
+	// core usage of the (subprocess) pass is its GOMAXPROCS. Log that real value
+	// so `cap=` reflects the cores the pass can consume, not the old, misleading
+	// NumCPU/2 concurrency number (the CPU-regression diagnosis confusion).
+	capN := GroupAlgoGOMAXPROCS()
 	s.logger.Info("group-algo: starting", "group", group, "cap", capN)
 	select {
 	case s.algoSem <- struct{}{}:

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -9,9 +9,34 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync/atomic"
 )
+
+// groupAlgoGOMAXPROCSDefault is the per-child CPU cap (Go GOMAXPROCS) for the
+// background group-algorithm subprocess. The pass (Louvain + PageRank +
+// betweenness over the whole group union) is the heaviest analytics job the
+// daemon runs. Without a cap the child inherits the daemon's GOMAXPROCS (= host
+// core count) and the Go runtime spins one worker thread per core — the v0.1.3
+// CPU regression where it pinned a 12-core machine at 500–1000% for hours.
+//
+// Default 2 mirrors GRAFEL_EXTRACT_GOMAXPROCS: "the less the better" for a
+// background job. The user can set GRAFEL_GROUP_ALGO_CPU=1 to throttle it to a
+// single core.
+const groupAlgoGOMAXPROCSDefault = 2
+
+// GroupAlgoGOMAXPROCS resolves the GOMAXPROCS cap applied to the group-algo
+// subprocess, honouring GRAFEL_GROUP_ALGO_CPU (a strictly-positive integer; 1
+// is valid). Unset, empty, non-numeric, or <= 0 → groupAlgoGOMAXPROCSDefault.
+func GroupAlgoGOMAXPROCS() int {
+	if raw := strings.TrimSpace(os.Getenv("GRAFEL_GROUP_ALGO_CPU")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+	}
+	return groupAlgoGOMAXPROCSDefault
+}
 
 // SubprocessIndexEnabled reports whether the daemon should run each
 // reindex job as a short-lived child process (S5 of issue #2155) instead
@@ -208,7 +233,18 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	}
 
 	cmd := exec.CommandContext(ctx, binary, "group-algo", group, "--write")
-	cmd.Env = os.Environ()
+	// Bound the child's Go runtime to GroupAlgoGOMAXPROCS() cores (default 2,
+	// env GRAFEL_GROUP_ALGO_CPU) so the background analytics pass cannot scale
+	// its worker pool to the full host core count — the v0.1.3 CPU regression.
+	// GOMAXPROCS is appended last so it wins over any inherited value. Mirrors
+	// the extract subprocess (GRAFEL_EXTRACT_GOMAXPROCS).
+	gomaxprocs := GroupAlgoGOMAXPROCS()
+	cmd.Env = append(os.Environ(), "GOMAXPROCS="+strconv.Itoa(gomaxprocs))
+	// Lower the child's OS scheduling priority (nice +10) so even its capped
+	// cores yield to foreground work (a consumer's CI / dev harness). No-op /
+	// guarded off on platforms without setpriority (e.g. Windows). See
+	// applyGroupAlgoNice (platform-split files).
+	applyGroupAlgoNice(cmd)
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {


### PR DESCRIPTION
## The regression (v0.1.3)

On a user's **12-core machine** the `grafel daemon` sat at **500–1000% CPU for hours**. The culprit is the group-algo feature (Louvain communities + PageRank + betweenness over the whole group union):

- It ran the subprocess at the **host's full `GOMAXPROCS`** (= core count) with no per-pass CPU bound — the same shape as the pre-v0.1.1 extract runaway.
- It **re-fired on a 30s debounce**, so back-to-back commits kept re-triggering the heaviest background job.
- The `group-algo: starting … cap=6` log was **misleading**: `cap` was `cap(algoSem)` (= `max(2, NumCPU/2)`), the *concurrency* of algo passes — **not** the cores a single pass draws. The real draw was the subprocess GOMAXPROCS.

Design intent (and the user's explicit instruction): this analytics pass must be **background, debounced, and CPU/memory-capped to 1–2 cores ("the less the better")**.

## Before → after

| | Before | After |
|---|---|---|
| Per-pass CPU | host GOMAXPROCS (~12 cores) | **2 cores** (`GRAFEL_GROUP_ALGO_CPU`, `=1` for one) |
| OS priority | normal (starved foreground) | **niced +10** (Unix; no-op/guarded Windows) |
| Debounce | 30s (re-fires per push) | **180s** (`GRAFEL_GROUP_ALGO_DEBOUNCE`) — coalesces a burst into one pass |
| `cap=` log | semaphore concurrency (misleading) | real per-pass core cap |

## What I changed

1. **CPU cap.** New `GroupAlgoGOMAXPROCS()` resolver (default **2**, env `GRAFEL_GROUP_ALGO_CPU`, mirrors `GRAFEL_EXTRACT_GOMAXPROCS`). Applied to the child env in `RunSubprocessGroupAlgo` (`internal/daemon/sched/subprocess_runner.go`), so the child's Go runtime can't scale its worker pool to the host.
2. **Nice.** `+10` OS-priority demotion so even the capped cores yield to a consumer's CI/dev harness. Implemented as a best-effort self-renice (`syscall.Setpriority(PRIO_PROCESS, 0, 10)`) at the child's `group-algo` startup, split into build-tagged `nice_unix.go` / `nice_windows.go` (Windows = no-op).
3. **Debounce.** `groupAlgoDebounceDefault` 30s → **180s** (env override kept).
4. **Honest log.** `cap=` now reports `GroupAlgoGOMAXPROCS()` (the real core cap), not the semaphore.

## Betweenness

Assessed, **not changed**. `ComputeCentrality` already switches to a deterministic sampled-pivot Brandes approximation above 8k nodes (K=512 pivots), so the dominant cost on a 37k-entity union is already near-linear — and with cores now capped+niced the foreground impact is fixed. Lowering K further would risk changing god-node/articulation semantics, so it's left as a documented follow-up rather than a blind change.

## Memory

No change — the subprocess already isolates the union heap (reclaimed on child exit) and targets ~300–600MB; no unbounded alloc observed.

## Tests

`internal/daemon/sched/groupalgo_cpu_test.go`: GOMAXPROCS resolver (default 2, env override incl. `=1`, bad-value fallback), debounce default 180s + env override, nice value (positive on Unix / 0-guarded on Windows). `go build ./...`, `go vet`, `gofmt` clean; new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)