### PR TITLE
fix(groupalgo): overlay reports god-nodes' real PageRank (was 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Fixed
+- **group-algo overlay now reports god-nodes' real PageRank (was 0):** the
+  determinism rounding (`roundForDeterminism`) bucketed every score to a fixed
+  **1e-4 absolute** quantum. On large group unions (28k+ entities) PageRank mass
+  sums to 1 across all nodes, so even a top-5% **god-node**'s score is ~3–4e-5 —
+  below the bucket — and `math.Round(v*1e4)/1e4` collapsed it to **0**. The
+  overlay then showed a flagged god-node with `pagerank: 0`, a direct
+  contradiction (a god-node is by definition among the most central). Rounding is
+  now **hybrid**: scores ≥ 1e-3 keep the proven 1e-4 absolute bucket (issue #489
+  byte-determinism unchanged), while scores < 1e-3 round to **4 significant
+  figures** so small-but-meaningful values survive non-zero and stay ordered. The
+  `is_god` flag and `pagerank` value are now consistent.
 - **group-algo no longer pins the machine (CPU regression, v0.1.3):** the
   background group-scope analytics pass (Louvain + PageRank + betweenness over
   the whole group union) ran at the host's full GOMAXPROCS and re-fired on a

--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -708,7 +708,9 @@ func runtimeMSFor(start time.Time) int64 {
 	return time.Since(start).Milliseconds()
 }
 
-// roundForDeterminism rounds a gonum-derived score to 4 decimal digits.
+// roundForDeterminism rounds a gonum-derived score so the on-disk bytes stay
+// stable across runs of the same input, WITHOUT collapsing small scores to 0.
+//
 // Issue #481 — gonum's PageRank and Betweenness implementations iterate
 // over node maps internally, so tiny floating-point reorderings accumulate
 // to differences of ~1e-8 across runs of the same input. The PageRank
@@ -717,15 +719,40 @@ func runtimeMSFor(start time.Time) int64 {
 // Issue #489 — on larger graphs (gin ~6.4k entities, spdlog ~1.8k entities)
 // the accumulated float drift crosses the 1e-5 boundary occasionally,
 // causing 2/10 runs to produce different byte output even though the logical
-// PageRank ranking is identical. Widening the rounding bucket to 1e-4 (4
-// decimal places) absorbs all solver-tolerance noise while still retaining
-// actionable score differences — practical PageRank delta thresholds for
-// ranking are well above 1e-4.
+// PageRank ranking is identical. The original fix rounded to a fixed 1e-4
+// ABSOLUTE bucket (4 decimal places), whose ~1e-4 quantum sits far above the
+// ~1e-6 drift, so it is byte-stable.
+//
+// Flaw 4 — that absolute 1e-4 bucket is wrong for LARGE GROUP UNIONS (#5349,
+// 28k+ entities): PageRank mass sums to 1 across all nodes, so the average
+// score is ~1/28000 ≈ 3.6e-5 and even a top-5% god-node's score can be well
+// below 1e-4. math.Round(v*1e4)/1e4 then collapses those values to 0,
+// producing the contradiction "flagged god-node, pagerank 0".
+//
+// Fix — a HYBRID quantum:
+//   - |v| >= 1e-3: keep the proven 1e-4 ABSOLUTE bucket. These mid/large
+//     scores carry drift up to ~1e-6, and the 1e-4 quantum (100× the drift)
+//     keeps them byte-stable exactly as before (issue #489 determinism).
+//   - |v| < 1e-3: round to 4 SIGNIFICANT figures instead. The quantum then
+//     scales DOWN with the value, so a 4e-5 god-node pagerank keeps a ~1e-7
+//     quantum — non-zero and well-ordered — while still being far coarser than
+//     the proportionally-tiny drift on such small scores (so byte output stays
+//     deterministic). This is the only regime large unions exercise.
 func roundForDeterminism(v float64) float64 {
 	if v == 0 || math.IsNaN(v) || math.IsInf(v, 0) {
 		return v
 	}
-	const scale = 1e4
+	const absoluteFloor = 1e-3 // below this, switch to significant-figure rounding
+	if math.Abs(v) >= absoluteFloor {
+		const scale = 1e4 // 4 decimal places (the proven #489 determinism bucket)
+		return math.Round(v*scale) / scale
+	}
+	// Significant-figure rounding for small scores: scale so the most-significant
+	// digit sits just left of the decimal point, round to (sigFigs-1) fractional
+	// digits, then scale back. Relative precision => never zeroes a non-zero value.
+	const sigFigs = 4
+	exp := math.Floor(math.Log10(math.Abs(v)))
+	scale := math.Pow(10, float64(sigFigs-1)-exp)
 	return math.Round(v*scale) / scale
 }
 

--- a/internal/graph/algorithms_test.go
+++ b/internal/graph/algorithms_test.go
@@ -262,26 +262,39 @@ func TestDeterminism_PageRank(t *testing.T) {
 	}
 }
 
-// TestRoundForDeterminism_Precision — verify that roundForDeterminism buckets
-// values to 4 decimal places (1e-4 tolerance), which is the guarantee
-// established by issue #489 to absorb larger-graph float drift.
+// TestRoundForDeterminism_Precision — verify that roundForDeterminism rounds to
+// 6 SIGNIFICANT figures (relative precision), which absorbs the ~1e-6 solver
+// noise from issue #481/#489 on every graph size WITHOUT collapsing small
+// scores to 0 (flaw 4: large group unions have god-node pageranks < 1e-4 that
+// the old absolute-1e-4 rounding wrongly truncated to 0).
 func TestRoundForDeterminism_Precision(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		input float64
 		want  float64
 	}{
+		// |v| >= 1e-3: absolute 1e-4 bucket (the proven #489 determinism path).
 		{0.123456789, 0.1235},
-		{0.00001, 0.0},    // below 1e-4 threshold rounds to 0
-		{0.00005, 0.0001}, // rounds up to 1e-4
 		{0.12344, 0.1234},
 		{0.12345, 0.1235}, // rounds half-up
+		{0.0015, 0.0015},
 		{0.0, 0.0},
+		// |v| < 1e-3: 4 significant figures. Small scores typical of a 28k-node
+		// group union are PRESERVED (non-zero), not truncated to 0 like the old
+		// absolute-1e-4 rounding did.
+		{0.00003571, 0.00003571},    // god-node pagerank ~3.5e-5 survives
+		{0.000012345678, 1.235e-05}, // 4 sig figs, rounds half-up at the 5th
+		{0.0009994, 0.0009994},      // just below the 1e-3 cutoff: 4 sig figs
+		{1e-9, 1e-9},
 	}
 	for _, tc := range cases {
 		got := roundForDeterminism(tc.input)
 		if got != tc.want {
 			t.Errorf("roundForDeterminism(%v) = %v, want %v", tc.input, got, tc.want)
+		}
+		// Regression: a non-zero input must never round to exactly 0.
+		if tc.input != 0 && got == 0 {
+			t.Errorf("roundForDeterminism(%v) collapsed a non-zero score to 0", tc.input)
 		}
 	}
 }

--- a/internal/graph/groupalgo/overlay_godnode_pagerank_test.go
+++ b/internal/graph/groupalgo/overlay_godnode_pagerank_test.go
@@ -1,0 +1,134 @@
+package groupalgo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestBuildOverlay_GodNodesHaveNonZeroPageRank is the flaw-4 regression.
+//
+// On a large group union the PageRank mass (which sums to 1) is spread over
+// thousands of nodes, so every individual score — INCLUDING the top-5%
+// god-nodes — is small in absolute terms (often well below 1e-4). The old
+// roundForDeterminism rounded to a fixed 1e-4 ABSOLUTE bucket, which collapsed
+// those small-but-meaningful scores to 0. The overlay then reported a flagged
+// god-node with pagerank 0 — a direct contradiction (a god-node is by
+// definition among the MOST central entities, so its PageRank must be high,
+// never 0).
+//
+// The fix rounds to significant figures (relative precision) instead, so small
+// scores survive. This test builds a real overlay from a synthetic graph big
+// enough that god-node pageranks are below 1e-4, then asserts:
+//   - every is_god entity has a NON-ZERO pagerank (the regression),
+//   - that pagerank equals the value computed by the algorithm pass,
+//   - at least one god-node's pagerank is below 1e-4 (so the old absolute
+//     rounding WOULD have zeroed it) yet survives here.
+//
+// (A god-node can be flagged via top-5% betweenness rather than top-5%
+// pagerank, so it is NOT required to be among the very highest pageranks — only
+// that whatever its real pagerank is, the overlay reports it and it is not 0.)
+func TestBuildOverlay_GodNodesHaveNonZeroPageRank(t *testing.T) {
+	t.Parallel()
+
+	// Build a hub-and-spoke graph: a handful of hubs each receive edges from
+	// many distinct leaves. With several thousand nodes the PageRank mass is
+	// spread thin enough that god-node scores land below the old 1e-4
+	// absolute-rounding bucket — exactly the large-union regime of flaw 4.
+	const numHubs = 8
+	const leavesPerHub = 1600
+
+	var entities []graph.Entity
+	var rels []graph.Relationship
+	add := func(id string) {
+		entities = append(entities, graph.Entity{ID: id, Name: id, Kind: "function"})
+	}
+
+	hubs := make([]string, numHubs)
+	for h := 0; h < numHubs; h++ {
+		hub := fmt.Sprintf("hub-%d", h)
+		hubs[h] = hub
+		add(hub)
+	}
+	for h := 0; h < numHubs; h++ {
+		for l := 0; l < leavesPerHub; l++ {
+			leaf := fmt.Sprintf("leaf-%d-%d", h, l)
+			add(leaf)
+			// Leaf -> hub: pumps PageRank into the hub, making it central.
+			rels = append(rels, graph.Relationship{
+				ID:     fmt.Sprintf("e-%d-%d", h, l),
+				FromID: leaf,
+				ToID:   hubs[h],
+				Kind:   "CALLS",
+			})
+		}
+	}
+
+	res := graph.RunAlgorithms(entities, rels)
+	gar := &GroupAlgoResult{
+		Group:        "synthetic",
+		Results:      res,
+		EntityRepo:   map[string]string{},
+		SourceMtimes: map[string]int64{},
+		NumEntities:  len(entities),
+		NumRels:      len(rels),
+		NumRepos:     1,
+	}
+
+	ov := BuildOverlay(gar)
+	if ov == nil {
+		t.Fatal("expected non-nil overlay")
+	}
+
+	// Sanity: there should be god-nodes, and the synthetic graph is large enough
+	// that their pageranks land below the old 1e-4 absolute-rounding bucket
+	// (otherwise this test wouldn't exercise the regression).
+	godCount := 0
+	var maxPR float64
+	for _, eo := range ov.Results {
+		if eo.PageRank > maxPR {
+			maxPR = eo.PageRank
+		}
+	}
+	if maxPR == 0 {
+		t.Fatal("no entity has a non-zero pagerank — overlay/algorithm setup is wrong")
+	}
+
+	for id, eo := range ov.Results {
+		if !eo.IsGodNode {
+			continue
+		}
+		godCount++
+
+		// Regression: a flagged god-node must never report pagerank 0.
+		if eo.PageRank == 0 {
+			t.Errorf("god-node %q has pagerank 0 (flaw 4 regression): the is_god flag and pagerank are inconsistent", id)
+		}
+
+		// The overlay must carry the ACTUAL value the algorithm computed.
+		if got, want := eo.PageRank, res.PageRank[id]; got != want {
+			t.Errorf("god-node %q overlay pagerank=%v, want computed %v", id, got, want)
+		}
+	}
+
+	if godCount == 0 {
+		t.Fatal("expected at least one god-node in the overlay")
+	}
+
+	// Demonstrate the regression is real: at least one god-node pagerank is
+	// below 5e-5, which the OLD math.Round(v*1e4)/1e4 rounding would have
+	// truncated to exactly 0 (round(0.49)/1e4 == 0). Under the significant-figure
+	// fix it survives as a non-zero value (the no-zero invariant above proves it).
+	const oldRoundingZeroThreshold = 5e-5
+	zeroedByOld := 0
+	for _, eo := range ov.Results {
+		if eo.IsGodNode && eo.PageRank > 0 && eo.PageRank < oldRoundingZeroThreshold {
+			zeroedByOld++
+		}
+	}
+	if zeroedByOld == 0 {
+		t.Fatalf("test no longer exercises flaw 4: no god-node pagerank fell below %v (the old rounding's zero threshold) — make the graph larger", oldRoundingZeroThreshold)
+	}
+	t.Logf("flaw-4 coverage: %d/%d god-nodes have a pagerank the old 1e-4 rounding would have zeroed; all now carry their real value", zeroedByOld, godCount)
+}


### PR DESCRIPTION
## Root cause

The determinism rounding in `internal/graph/algorithms.go` collapsed god-nodes' PageRank to 0. The exact line:

```go
// internal/graph/algorithms.go — roundForDeterminism (old)
const scale = 1e4
return math.Round(v*scale) / scale   // 4-decimal ABSOLUTE bucket
```

`roundForDeterminism` rounded every gonum score to a fixed **1e-4 absolute** quantum (issue #489, to absorb ~1e-6 PageRank solver/iteration drift on mid-size graphs). That is fine when scores are O(0.01), but **wrong for large group unions** (#5349, 28k+ entities): PageRank mass sums to 1 across all nodes, so the average score is ~1/28000 ≈ 3.6e-5 and even a **top-5% god-node**'s score is typically ~3–4e-5 — *below* the bucket. `math.Round(3.6e-5 * 1e4)/1e4 = math.Round(0.36)/1e4 = 0`.

The overlay (`internal/graph/groupalgo/overlay.go` `BuildOverlay`) faithfully copies `r.PageRank[id]` into the per-entity record, so a flagged god-node ended up with `pagerank: 0` — the contradiction a user sees (flagged god-node, pagerank 0). The keying is correct; the value was zeroed upstream by the rounding.

## Fix

Make `roundForDeterminism` **hybrid** (scale-aware) so it stays byte-deterministic without zeroing small scores:

- `|v| >= 1e-3`: keep the proven **1e-4 absolute** bucket — issue #489 byte-determinism is unchanged (the 1e-4 quantum is ~100× the ~1e-6 drift).
- `|v| < 1e-3`: round to **4 significant figures** — the quantum scales down with the value, so a ~4e-5 god-node pagerank keeps a ~1e-7 quantum (non-zero, well-ordered) while still far coarser than the proportionally-tiny drift on such small scores.

This is the only god-node selection input touched; the god-node selection logic itself is unchanged. `is_god` and `pagerank` are now consistent.

## Tests

- `internal/graph/groupalgo/overlay_godnode_pagerank_test.go` (new): builds a real overlay from a ~12.8k-node synthetic hub-and-spoke graph via `graph.RunAlgorithms` → `BuildOverlay`, and asserts **every `is_god` entity has a non-zero pagerank equal to the computed value**. It also proves the regression is real: **632/640** god-nodes there have a pagerank the old 1e-4 rounding would have zeroed (`< 5e-5`), all now carrying their real value.
- `TestRoundForDeterminism_Precision` updated for the hybrid scheme (incl. a no-non-zero-rounds-to-0 assertion).
- `TestDeterminism_PageRank` (the #489 byte-determinism guard) still passes — the ≥1e-3 absolute path is unchanged.

`go build ./...`, `go vet ./internal/graph/...`, and `go test -count=1 ./internal/graph/ ./internal/graph/groupalgo/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)