### PR TITLE
refactor(extractors): migrate python+java to ts.Node abstraction (B2 Phase 1 #5418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,18 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   the A4 canary. Feeds the 0.1.4 freshness infrastructure (A2 cron) and the B2
   decoupling assessment.
 
+### Changed
+- **Migrated the `python` and `java` extractors onto the `ts.Node` abstraction
+  (smacker-backed, no behavior change)** — B2 Phase 1 plumbing toward the
+  one-runtime cutover (#5418, ADR 0023). Both extractors now traverse the
+  binding-agnostic `internal/treesitter/ts` façade (`ts.Node`/`ts.Tree`) instead
+  of the concrete `smacker/go-tree-sitter` `*sitter.Node`, and read the shared
+  `FileInput.TSTree` (falling back to an inline smacker parse via the grammar
+  adapter when no tree is supplied, as the Go extractor does). Default builds stay
+  100% smacker-backed and link-safe; this is mechanical, behavior-preserving
+  plumbing — the full python+java extractor suites pass unchanged (zero fidelity
+  delta). Mirrors the Phase-0 Go-extractor migration.
+
 ## [0.1.3] — 2026-06-23
 
 ### Fixed

--- a/internal/extractors/java/call_line_property_test.go
+++ b/internal/extractors/java/call_line_property_test.go
@@ -25,7 +25,7 @@ func extractJavaForLine(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/java/config_consumer.go
+++ b/internal/extractors/java/config_consumer.go
@@ -26,7 +26,7 @@ import (
 	"regexp"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -45,15 +45,15 @@ var (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitConfigConsumerEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
 
 	var reads []extractor.ConfigRead
 
-	var walk func(n *sitter.Node, enclosingClass, enclosingMethod string)
-	walk = func(n *sitter.Node, enclosingClass, enclosingMethod string) {
+	var walk func(n ts.Node, enclosingClass, enclosingMethod string)
+	walk = func(n ts.Node, enclosingClass, enclosingMethod string) {
 		if n == nil {
 			return
 		}
@@ -103,7 +103,7 @@ func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entiti
 
 // walkMethodBody scans a method body for env.getProperty("key") calls and
 // appends the resolved reads to *reads under the method's Name.
-func walkMethodBody(n *sitter.Node, src []byte, method string, reads *[]extractor.ConfigRead) {
+func walkMethodBody(n ts.Node, src []byte, method string, reads *[]extractor.ConfigRead) {
 	if n == nil {
 		return
 	}
@@ -120,7 +120,7 @@ func walkMethodBody(n *sitter.Node, src []byte, method string, reads *[]extracto
 // valueAndConfigPropertyKeys returns every config key declared by @Value or
 // @ConfigProperty annotations attached anywhere under node (a field or method
 // declaration). We scan the node's modifier text for annotations.
-func valueAndConfigPropertyKeys(node *sitter.Node, src []byte) []string {
+func valueAndConfigPropertyKeys(node ts.Node, src []byte) []string {
 	var keys []string
 	for _, ann := range findAnnotations(node, src) {
 		name, argText := ann.name, ann.args
@@ -140,7 +140,7 @@ func valueAndConfigPropertyKeys(node *sitter.Node, src []byte) []string {
 
 // configurationPropertiesKeys returns the prefix declared by a class-level
 // @ConfigurationProperties(prefix="app") / @ConfigurationProperties("app").
-func configurationPropertiesKeys(classNode *sitter.Node, src []byte) []string {
+func configurationPropertiesKeys(classNode ts.Node, src []byte) []string {
 	var keys []string
 	for _, ann := range findAnnotations(classNode, src) {
 		if ann.name != "ConfigurationProperties" {
@@ -166,7 +166,7 @@ type javaAnnotation struct {
 // findAnnotations walks the modifiers of node (only the immediate modifiers
 // child, not nested declarations) and returns each annotation's simple name
 // plus its raw argument text.
-func findAnnotations(node *sitter.Node, src []byte) []javaAnnotation {
+func findAnnotations(node ts.Node, src []byte) []javaAnnotation {
 	var out []javaAnnotation
 	for i := 0; i < int(node.ChildCount()); i++ {
 		child := node.Child(i)
@@ -205,7 +205,7 @@ func lastIdent(s string) string {
 
 // getPropertyKey returns the literal key of an environment.getProperty("key")
 // call, or "" when the call doesn't match or the key is non-literal.
-func getPropertyKey(call *sitter.Node, src []byte) string {
+func getPropertyKey(call ts.Node, src []byte) string {
 	nameNode := call.ChildByFieldName("name")
 	objNode := call.ChildByFieldName("object")
 	argsNode := call.ChildByFieldName("arguments")

--- a/internal/extractors/java/config_consumer_test.go
+++ b/internal/extractors/java/config_consumer_test.go
@@ -22,7 +22,7 @@ func extractJavaRaw(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Cfg.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/java/const_collection.go
+++ b/internal/extractors/java/const_collection.go
@@ -29,7 +29,7 @@ package java
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -45,7 +45,7 @@ import (
 // typeName is the enclosing class/interface/enum simple name (already package-
 // unqualified, matching buildField's parentType). bodyNode is the
 // class_body / interface_body / enum_body node.
-func buildJavaConstCollections(typeName string, bodyNode *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func buildJavaConstCollections(typeName string, bodyNode ts.Node, file extractor.FileInput) []types.EntityRecord {
 	if bodyNode == nil || typeName == "" {
 		return nil
 	}
@@ -132,7 +132,7 @@ func buildJavaConstCollections(typeName string, bodyNode *sitter.Node, file extr
 
 // javaFieldIsStaticFinal reports whether a field_declaration carries BOTH the
 // `static` and `final` modifiers (the Java constant idiom).
-func javaFieldIsStaticFinal(field *sitter.Node) bool {
+func javaFieldIsStaticFinal(field ts.Node) bool {
 	mods := firstChildOfType(field, "modifiers")
 	if mods == nil {
 		return false
@@ -152,7 +152,7 @@ func javaFieldIsStaticFinal(field *sitter.Node) bool {
 // javaFieldDeclaratorInit returns the variable_declarator and its initializer
 // (the named node after `=`) for a field_declaration / constant_declaration.
 // Returns nil,nil when there is no single-variable initializer.
-func javaFieldDeclaratorInit(field *sitter.Node) (decl *sitter.Node, init *sitter.Node) {
+func javaFieldDeclaratorInit(field ts.Node) (decl ts.Node, init ts.Node) {
 	decl = firstChildOfType(field, "variable_declarator")
 	if decl == nil {
 		return nil, nil
@@ -184,7 +184,7 @@ func javaFieldDeclaratorInit(field *sitter.Node) (decl *sitter.Node, init *sitte
 //   - array_initializer { lit, lit, ... }                    → java_const_array
 //
 // ok=false for any other initializer shape.
-func javaCollectionMembers(init *sitter.Node, src []byte) ([]extractor.EnumMember, string, bool) {
+func javaCollectionMembers(init ts.Node, src []byte) ([]extractor.EnumMember, string, bool) {
 	switch init.Type() {
 	case "array_initializer":
 		members := javaArrayMembers(init, src)
@@ -204,7 +204,7 @@ func javaCollectionMembers(init *sitter.Node, src []byte) ([]extractor.EnumMembe
 // array_initializer as a self-keyed member (Name==Value==literal), so a
 // constant string array is enumerable as a value-set. The 0-based element
 // index seeds nothing; the literal text is the identity.
-func javaArrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
+func javaArrayMembers(arr ts.Node, src []byte) []extractor.EnumMember {
 	var out []extractor.EnumMember
 	for i := 0; i < int(arr.NamedChildCount()); i++ {
 		el := arr.NamedChild(i)
@@ -230,7 +230,7 @@ func javaArrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
 // javaMapInvocationMembers handles the three map-factory shapes by inspecting
 // the receiver/leaf of a method_invocation chain. Returns the {key,value}
 // members and ok=true only when at least one key was resolved.
-func javaMapInvocationMembers(call *sitter.Node, src []byte) ([]extractor.EnumMember, bool) {
+func javaMapInvocationMembers(call ts.Node, src []byte) ([]extractor.EnumMember, bool) {
 	leaf := javaInvocationLeaf(call, src)
 	switch leaf {
 	case "of":
@@ -271,8 +271,8 @@ func javaMapInvocationMembers(call *sitter.Node, src []byte) ([]extractor.EnumMe
 
 // javaFlatPairMembers reads an argument_list of alternating key,value literals
 // and returns one member per pair. A trailing odd argument is ignored.
-func javaFlatPairMembers(args *sitter.Node, src []byte) []extractor.EnumMember {
-	var lits []*sitter.Node
+func javaFlatPairMembers(args ts.Node, src []byte) []extractor.EnumMember {
+	var lits []ts.Node
 	for i := 0; i < int(args.NamedChildCount()); i++ {
 		a := args.NamedChild(i)
 		if a == nil {
@@ -304,7 +304,7 @@ func javaFlatPairMembers(args *sitter.Node, src []byte) []extractor.EnumMember {
 // chain bottom-up, collecting each `.put(key, value)` pair. The chain is a
 // left-nested method_invocation; we descend the receiver (object) field until
 // we exhaust the chain.
-func javaBuilderPutMembers(buildCall *sitter.Node, src []byte) []extractor.EnumMember {
+func javaBuilderPutMembers(buildCall ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	// Start from the receiver of `.build()` and walk down `.put(...)` links.
 	cur := buildCall.ChildByFieldName("object")
@@ -325,7 +325,7 @@ func javaBuilderPutMembers(buildCall *sitter.Node, src []byte) []extractor.EnumM
 
 // javaInvocationLeaf returns the method name (the `name` field) of a
 // method_invocation, e.g. "of" for `Map.of(...)`, "build" for `...build()`.
-func javaInvocationLeaf(call *sitter.Node, src []byte) string {
+func javaInvocationLeaf(call ts.Node, src []byte) string {
 	if call == nil || call.Type() != "method_invocation" {
 		return ""
 	}
@@ -338,13 +338,13 @@ func javaInvocationLeaf(call *sitter.Node, src []byte) string {
 // javaScalarLiteral returns the literal value of a scalar constant initializer
 // (string/number/bool/char), or ok=false when the initializer is not a single
 // literal. Used to collect constant-group members.
-func javaScalarLiteral(init *sitter.Node, src []byte) (string, bool) {
+func javaScalarLiteral(init ts.Node, src []byte) (string, bool) {
 	return javaLiteralText(init, src)
 }
 
 // javaLiteralText returns the normalised literal text of a literal node
 // (quotes stripped for strings), and ok=true only for recognised literal kinds.
-func javaLiteralText(node *sitter.Node, src []byte) (string, bool) {
+func javaLiteralText(node ts.Node, src []byte) (string, bool) {
 	if node == nil {
 		return "", false
 	}

--- a/internal/extractors/java/enum_valueset.go
+++ b/internal/extractors/java/enum_valueset.go
@@ -15,14 +15,14 @@ package java
 // recorded value-less — the member name is kept, no fabricated value.
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
 // buildJavaEnumValueSet builds the SCOPE.Enum node for a Java `enum_declaration`.
-func buildJavaEnumValueSet(node *sitter.Node, file extractor.FileInput) (recOut types.EntityRecord, ok bool) {
+func buildJavaEnumValueSet(node ts.Node, file extractor.FileInput) (recOut types.EntityRecord, ok bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -59,7 +59,7 @@ func buildJavaEnumValueSet(node *sitter.Node, file extractor.FileInput) (recOut 
 // javaEnumConstantValue returns the statically-known literal value of an
 // enum_constant's first constructor argument, or "" when the constant has no
 // argument list or the first argument is not a literal.
-func javaEnumConstantValue(constNode *sitter.Node, src []byte) string {
+func javaEnumConstantValue(constNode ts.Node, src []byte) string {
 	args := childByType(constNode, "argument_list")
 	if args == nil {
 		return ""
@@ -83,7 +83,7 @@ func javaEnumConstantValue(constNode *sitter.Node, src []byte) string {
 }
 
 // firstChildOfType returns the first direct child of n with the given type.
-func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func firstChildOfType(n ts.Node, typ string) ts.Node {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		if ch != nil && ch.Type() == typ {
@@ -95,6 +95,6 @@ func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
 
 // childByType is an alias kept local to this file to avoid coupling to other
 // helpers' naming; identical semantics to firstChildOfType.
-func childByType(n *sitter.Node, typ string) *sitter.Node {
+func childByType(n ts.Node, typ string) ts.Node {
 	return firstChildOfType(n, typ)
 }

--- a/internal/extractors/java/enum_valueset_test.go
+++ b/internal/extractors/java/enum_valueset_test.go
@@ -19,7 +19,7 @@ func extractJavaForEnum(t *testing.T, path, src string) []types.EntityRecord {
 		t.Fatal("java extractor not registered")
 	}
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: path, Content: []byte(src), Language: "java", Tree: tree,
+		Path: path, Content: []byte(src), Language: "java", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/java/exception_flow.go
+++ b/internal/extractors/java/exception_flow.go
@@ -22,7 +22,7 @@ package java
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -33,7 +33,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -41,8 +41,8 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 
 	var edges []extractor.ExceptionEdge
 
-	var walk func(n *sitter.Node, enclosingClass, enclosingMethod string)
-	walk = func(n *sitter.Node, enclosingClass, enclosingMethod string) {
+	var walk func(n ts.Node, enclosingClass, enclosingMethod string)
+	walk = func(n ts.Node, enclosingClass, enclosingMethod string) {
 		if n == nil {
 			return
 		}
@@ -100,8 +100,8 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 // javaThrowType returns the constructed exception class for `throw new X(...)`
 // (including `throw new pkg.X(...)` → bare X), or "" for a re-throw of a
 // variable / computed expression (`throw e;`) which carries no NEW type.
-func javaThrowType(throwNode *sitter.Node, src []byte) string {
-	var expr *sitter.Node
+func javaThrowType(throwNode ts.Node, src []byte) string {
+	var expr ts.Node
 	for i := 0; i < int(throwNode.NamedChildCount()); i++ {
 		c := throwNode.NamedChild(i)
 		if c != nil {
@@ -122,8 +122,8 @@ func javaThrowType(throwNode *sitter.Node, src []byte) string {
 // javaThrowsClauseTypes returns each type named in a method/constructor
 // `throws A, B, C` clause. The grammar exposes this as a `throws` child node
 // whose named children are the thrown types.
-func javaThrowsClauseTypes(declNode *sitter.Node, src []byte) []string {
-	var throwsNode *sitter.Node
+func javaThrowsClauseTypes(declNode ts.Node, src []byte) []string {
+	var throwsNode ts.Node
 	for i := 0; i < int(declNode.ChildCount()); i++ {
 		c := declNode.Child(i)
 		if c != nil && c.Type() == "throws" {
@@ -150,7 +150,7 @@ func javaThrowsClauseTypes(declNode *sitter.Node, src []byte) []string {
 // javaCatchTypes returns each caught type from a catch clause, expanding a
 // multi-catch `catch (A | B e)` into {A, B}. The grammar nests a
 // catch_formal_parameter → catch_type whose named children are the union types.
-func javaCatchTypes(catchNode *sitter.Node, src []byte) []string {
+func javaCatchTypes(catchNode ts.Node, src []byte) []string {
 	param := findFirstChildOfType(catchNode, "catch_formal_parameter")
 	if param == nil {
 		return nil
@@ -178,7 +178,7 @@ func javaCatchTypes(catchNode *sitter.Node, src []byte) []string {
 // findFirstChildOfType returns the first (depth-first) descendant of n whose
 // node type equals typ, or nil. Used to reach catch_formal_parameter /
 // catch_type without hard-coding child indices across grammar versions.
-func findFirstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func findFirstChildOfType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}

--- a/internal/extractors/java/field_validations.go
+++ b/internal/extractors/java/field_validations.go
@@ -56,7 +56,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -111,7 +111,7 @@ var javaBeanValidationScalar = map[string]string{
 func emitJavaFieldValidations(
 	parentType string,
 	before, after int,
-	fieldNodes map[string]*sitter.Node,
+	fieldNodes map[string]ts.Node,
 	src []byte,
 	out *[]types.EntityRecord,
 ) {
@@ -151,7 +151,7 @@ func emitJavaFieldValidations(
 // field_declaration, a formal_parameter (record component) or any node whose
 // direct/`modifiers` children include annotation nodes — the helper finds the
 // annotation nodes either way.
-func javaFieldValidationChips(node *sitter.Node, src []byte) []string {
+func javaFieldValidationChips(node ts.Node, src []byte) []string {
 	if node == nil {
 		return nil
 	}
@@ -191,9 +191,9 @@ func javaFieldValidationChips(node *sitter.Node, src []byte) []string {
 // to a declaration. For a field_declaration / formal_parameter the annotations
 // live under a `modifiers` child; for nodes that themselves are `modifiers`
 // they are direct children. Both shapes are handled.
-func javaAnnotationNodes(node *sitter.Node) []*sitter.Node {
-	var out []*sitter.Node
-	collect := func(parent *sitter.Node) {
+func javaAnnotationNodes(node ts.Node) []ts.Node {
+	var out []ts.Node
+	collect := func(parent ts.Node) {
 		for i := 0; i < int(parent.NamedChildCount()); i++ {
 			ch := parent.NamedChild(i)
 			if ch == nil {
@@ -236,7 +236,7 @@ func simpleAnnotationName(name string) string {
 // javaSizeChip folds a @Size annotation into a chip. With both bounds it yields
 // `Size:0..120`; with only max it yields `MaxLength:120`; with only min it
 // yields `MinLength:1`. Returns "" when neither bound is a scalar.
-func javaSizeChip(ann *sitter.Node, src []byte) string {
+func javaSizeChip(ann ts.Node, src []byte) string {
 	pairs := javaAnnotationArgPairs(ann, src)
 	minV, hasMin := pairs["min"]
 	maxV, hasMax := pairs["max"]
@@ -255,7 +255,7 @@ func javaSizeChip(ann *sitter.Node, src []byte) string {
 // like @Min(0) / @Max(120) / @DecimalMin("0.0"). It accepts both the implicit
 // `value` form (`@Min(0)`) and the named form (`@Min(value = 0)`). String
 // literals (DecimalMin/DecimalMax) are unquoted. Returns "" for non-scalar args.
-func javaAnnotationScalarArg(ann *sitter.Node, src []byte) string {
+func javaAnnotationScalarArg(ann ts.Node, src []byte) string {
 	args := ann.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
@@ -283,7 +283,7 @@ func javaAnnotationScalarArg(ann *sitter.Node, src []byte) string {
 // javaAnnotationArgPairs returns the named element_value_pair arguments of an
 // annotation as a key→scalar map (`@Size(min = 1, max = 120)` →
 // {"min":"1","max":"120"}). Non-scalar values are dropped.
-func javaAnnotationArgPairs(ann *sitter.Node, src []byte) map[string]string {
+func javaAnnotationArgPairs(ann ts.Node, src []byte) map[string]string {
 	args := ann.ChildByFieldName("arguments")
 	if args == nil {
 		return nil
@@ -316,7 +316,7 @@ func javaAnnotationArgPairs(ann *sitter.Node, src []byte) map[string]string {
 // comma-joined property). String literals are kept only when numeric
 // (@DecimalMin("0.0")). Compound expressions yield "". Reuses javaLiteralText
 // for the literal kinds it recognises.
-func javaValidationScalar(n *sitter.Node, src []byte) string {
+func javaValidationScalar(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/java/imports_test.go
+++ b/internal/extractors/java/imports_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsjava "github.com/smacker/go-tree-sitter/java"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -20,9 +20,12 @@ import (
 // bubble up via t.Fatal so callers can assume non-nil non-empty output.
 func runJavaExtract(t *testing.T, src string) []types.EntityRecord {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsjava.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsjava.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -31,7 +34,7 @@ func runJavaExtract(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Demo.java",
 		Language: "java",
 		Content:  []byte(src),
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/java/issue1994_endline_test.go
+++ b/internal/extractors/java/issue1994_endline_test.go
@@ -54,7 +54,7 @@ public class AuthController {
 		Path:     "client_fixture_x/api/AuthController.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)
@@ -125,7 +125,7 @@ public class Order {
 		Path:     "client_fixture_x/model/Order.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)

--- a/internal/extractors/java/issue1996_1997_manifest_inject_test.go
+++ b/internal/extractors/java/issue1996_1997_manifest_inject_test.go
@@ -48,7 +48,7 @@ public class TransfersController extends BaseController implements ApiService, A
 		Path:     "client_fixture_x/api/TransfersController.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract returned error: %v", err)

--- a/internal/extractors/java/issue2023_inject_consistency_test.go
+++ b/internal/extractors/java/issue2023_inject_consistency_test.go
@@ -244,7 +244,7 @@ public class ManyController {
 				Path:     "client_fixture_x/api/" + tc.name + ".java",
 				Content:  []byte(tc.src),
 				Language: "java",
-				Tree:     parseForTest(t, tc.src),
+				TSTree:   parseForTest(t, tc.src),
 			})
 			if err != nil {
 				t.Fatalf("Extract: %v", err)
@@ -313,7 +313,7 @@ public class TransfersController {
 		Path:     "client_fixture_x/api/TransfersController.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/java/issue2062_lombok_dto_calls_test.go
+++ b/internal/extractors/java/issue2062_lombok_dto_calls_test.go
@@ -47,7 +47,7 @@ class Caller {
 		Path:     "com/example/dto/ProductDTO.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -136,7 +136,7 @@ public class ProductController {
 		Path:     "com/example/dto/ProductDTO.java",
 		Content:  []byte(dtoSrc),
 		Language: "java",
-		Tree:     parseForTest(t, dtoSrc),
+		TSTree:   parseForTest(t, dtoSrc),
 	})
 	if err != nil {
 		t.Fatalf("Extract(dto): %v", err)
@@ -145,7 +145,7 @@ public class ProductController {
 		Path:     "com/example/api/ProductController.java",
 		Content:  []byte(controllerSrc),
 		Language: "java",
-		Tree:     parseForTest(t, controllerSrc),
+		TSTree:   parseForTest(t, controllerSrc),
 	})
 	if err != nil {
 		t.Fatalf("Extract(controller): %v", err)

--- a/internal/extractors/java/issue2111_jaxrs_calls_test.go
+++ b/internal/extractors/java/issue2111_jaxrs_calls_test.go
@@ -63,7 +63,7 @@ public class UsersController {
 		Path:     "client_fixture_x/api/UsersController.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract error: %v", err)
@@ -123,7 +123,7 @@ public class OrdersController {
 		Path:     "client_fixture_x/api/OrdersController.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract error: %v", err)
@@ -178,7 +178,7 @@ public class Helper {
 		Path:     "client_fixture_x/api/Helper.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract error: %v", err)
@@ -237,7 +237,7 @@ public class OrdersController {
 		Path:     "client_fixture_x/api/OrdersController.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     parseForTest(t, src),
+		TSTree:   parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract error: %v", err)

--- a/internal/extractors/java/issue4682_localvar_receiver_test.go
+++ b/internal/extractors/java/issue4682_localvar_receiver_test.go
@@ -41,7 +41,7 @@ func jcovExtract(t *testing.T, path, src string) []types.EntityRecord {
 	}
 	out, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path: path, Content: []byte(src), Language: "java",
-		Tree: parseForTest(t, src),
+		TSTree: parseForTest(t, src),
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -35,11 +35,11 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/txscope"
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -54,7 +54,7 @@ func init() {
 // method body — avoids false positives from an @Transactional token appearing
 // inside a string literal or comment in the body. Returns a zero stamp when no
 // @Transactional annotation is present.
-func javaMethodTxStamp(methodNode *sitter.Node, src []byte) txscope.Stamp {
+func javaMethodTxStamp(methodNode ts.Node, src []byte) txscope.Stamp {
 	mods := methodModifiersText(methodNode, src)
 	if mods == "" {
 		return txscope.Stamp{}
@@ -64,7 +64,7 @@ func javaMethodTxStamp(methodNode *sitter.Node, src []byte) txscope.Stamp {
 
 // methodModifiersText returns the source text of a declaration's `modifiers`
 // child (annotations + visibility keywords), or "" when absent.
-func methodModifiersText(node *sitter.Node, src []byte) string {
+func methodModifiersText(node ts.Node, src []byte) string {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch != nil && ch.Type() == "modifiers" {
@@ -80,14 +80,14 @@ func methodModifiersText(node *sitter.Node, src []byte) string {
 // stamp. This realises Spring's class-level @Transactional → all-methods
 // semantics. A method with its own @Transactional (already stamped during the
 // primary walk) keeps its own — more specific — propagation/isolation.
-func stampClassLevelTransactional(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func stampClassLevelTransactional(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil {
 		return
 	}
 	walkClassTx(root, "", file, entities)
 }
 
-func walkClassTx(n *sitter.Node, pkgQualifier string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func walkClassTx(n ts.Node, pkgQualifier string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if n == nil {
 		return
 	}
@@ -150,7 +150,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	defer span.End()
 	span.SetAttributes(attribute.String("file", file.Path))
 
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		span.SetAttributes(
 			attribute.Int("entity_count", 0),
 			attribute.Int("error_pattern_count", 0),
@@ -164,7 +164,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	imports := collectImportNames(root, file.Content)
 	// Issue #1917 — extract the file's package declaration so QualifiedName
 	// can be set to "<package>.<ClassName>" and "<package>.<Class>.<method>".
@@ -309,7 +309,7 @@ type classCtx struct {
 }
 
 func walk(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	parentType string,
 	cc *classCtx,
@@ -408,7 +408,7 @@ func walk(
 		// Bean Validation pass can stamp Properties["validations"] without
 		// re-traversing the tree.
 		recBefore := len(*out)
-		fieldNodes := map[string]*sitter.Node{}
+		fieldNodes := map[string]ts.Node{}
 		if node.Type() == "record_declaration" {
 			if params := node.ChildByFieldName("parameters"); params != nil {
 				for i := range params.ChildCount() {
@@ -783,7 +783,7 @@ func walk(
 // ID at emit time. Self-recursion is skipped (compared against the
 // caller's bare name regardless of the callee's dotted form).
 func extractCallRelationships(
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	callerName string,
 	cc *classCtx,
@@ -861,7 +861,7 @@ func extractCallRelationships(
 // shape. Falls back to the bare leaf name when no receiver type is
 // known.
 func javaCallTarget(
-	call *sitter.Node,
+	call ts.Node,
 	src []byte,
 	cc *classCtx,
 	paramTypes map[string]string,
@@ -970,7 +970,7 @@ var panacheQueryDSLChainMethods = map[string]bool{
 //  6. Anything else — return "" so the caller falls back to the bare
 //     method name.
 func receiverTypeName(
-	obj *sitter.Node,
+	obj ts.Node,
 	src []byte,
 	cc *classCtx,
 	paramTypes map[string]string,
@@ -1065,7 +1065,7 @@ func isPascalCase(s string) bool {
 //
 // Multi-declarator fields (`int x, y, z;`) bind every variable to the
 // same declared type. Fields without a parseable type are dropped.
-func collectFieldTypes(body *sitter.Node, src []byte) map[string]string {
+func collectFieldTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -1103,7 +1103,7 @@ func collectFieldTypes(body *sitter.Node, src []byte) map[string]string {
 // every formal_parameter on a method_declaration / constructor_
 // declaration node. Variadic parameters ("Type... args") strip the
 // "..." and bind args to the leaf type.
-func collectParamTypes(node *sitter.Node, src []byte) map[string]string {
+func collectParamTypes(node ts.Node, src []byte) map[string]string {
 	if node == nil {
 		return nil
 	}
@@ -1159,7 +1159,7 @@ func collectParamTypes(node *sitter.Node, src []byte) map[string]string {
 // are loop-local rebinds in different sibling blocks — both bind to
 // the same type in idiomatic code, and the conservative pick still
 // matches.
-func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
+func collectLocalVarTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -1223,7 +1223,7 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 // receiver never types to a non-constructed class. The rightmost
 // type_identifier is taken (so `new com.x.XController(...)` → "XController",
 // matching javaCallTarget's object-creation handling).
-func newExprClassName(value *sitter.Node, src []byte) string {
+func newExprClassName(value ts.Node, src []byte) string {
 	if value == nil || value.Type() != "object_creation_expression" {
 		return ""
 	}
@@ -1243,7 +1243,7 @@ func newExprClassName(value *sitter.Node, src []byte) string {
 // yields "List"; `Map<String, Owner>` yields "Map"; `Owner[]` yields
 // "Owner"; `int` yields "int". Returns "" for type nodes the function
 // can't characterise.
-func leafTypeName(typ *sitter.Node, src []byte) string {
+func leafTypeName(typ ts.Node, src []byte) string {
 	if typ == nil {
 		return ""
 	}
@@ -1282,7 +1282,7 @@ func leafTypeName(typ *sitter.Node, src []byte) string {
 // fields/methods are not included; the receiver-binder uses this set
 // only to confirm a PascalCase identifier was imported (a future
 // tightening — for now the case heuristic alone gates emission).
-func collectImportNames(root *sitter.Node, src []byte) map[string]bool {
+func collectImportNames(root ts.Node, src []byte) map[string]bool {
 	if root == nil {
 		return nil
 	}
@@ -1318,7 +1318,7 @@ func collectImportNames(root *sitter.Node, src []byte) map[string]bool {
 // declaration is present (default package).
 //
 // Example: `package com.example.users.controllers;` → "com.example.users.controllers"
-func collectPackageName(root *sitter.Node, src []byte) string {
+func collectPackageName(root ts.Node, src []byte) string {
 	if root == nil {
 		return ""
 	}
@@ -1344,7 +1344,7 @@ func collectPackageName(root *sitter.Node, src []byte) string {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -1352,8 +1352,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -1371,7 +1371,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 //
 // Issue #1917 — QualifiedName is set to "<package>.<ClassName>" when pkgName
 // is non-empty, giving inspect consumers a fully-qualified type reference.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype, pkgName string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype, pkgName string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -1406,7 +1406,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype, pkgNam
 //
 // Issue #1917 — QualifiedName is set to "<package>.<emittedName>" when pkgName
 // is non-empty, giving inspect consumers a fully-qualified method reference.
-func buildOperation(node *sitter.Node, file extractor.FileInput, subtype, parentType, pkgName string) (types.EntityRecord, bool) {
+func buildOperation(node ts.Node, file extractor.FileInput, subtype, parentType, pkgName string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -1442,7 +1442,7 @@ func buildOperation(node *sitter.Node, file extractor.FileInput, subtype, parent
 // when non-empty, matching the pattern used for methods (issue #65) so
 // the resolver's byLocation index can bind CONTAINS stubs to field entities
 // the same way it binds class→method CONTAINS edges.
-func buildField(node *sitter.Node, file extractor.FileInput, parentType string) (types.EntityRecord, bool) {
+func buildField(node ts.Node, file extractor.FileInput, parentType string) (types.EntityRecord, bool) {
 	// Field declarations have a "declarator" child containing the variable name.
 	name := ""
 	for i := range node.ChildCount() {
@@ -1477,7 +1477,7 @@ func buildField(node *sitter.Node, file extractor.FileInput, parentType string) 
 }
 
 // buildFieldSignature produces "Type name" for a Java field, stripping visibility.
-func buildFieldSignature(node *sitter.Node, src []byte, name string) string {
+func buildFieldSignature(node ts.Node, src []byte, name string) string {
 	raw := strings.TrimSpace(string(src[node.StartByte():node.EndByte()]))
 	// Remove everything after '=' (initializer).
 	if idx := strings.Index(raw, "="); idx >= 0 {
@@ -1494,7 +1494,7 @@ func buildFieldSignature(node *sitter.Node, src []byte, name string) string {
 }
 
 // nodeText returns the source text covered by node.
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -1502,7 +1502,7 @@ func nodeText(node *sitter.Node, src []byte) string {
 }
 
 // childFieldText extracts the text of a named child field (e.g. "name").
-func childFieldText(node *sitter.Node, field string, src []byte) string {
+func childFieldText(node ts.Node, field string, src []byte) string {
 	child := node.ChildByFieldName(field)
 	if child == nil {
 		return ""
@@ -1514,7 +1514,7 @@ func childFieldText(node *sitter.Node, field string, src []byte) string {
 // Captures annotations + return type + name + parameters, collapsing
 // multi-line declarations into a single line (up to the opening brace).
 // Strips visibility modifiers and annotation arguments.
-func buildMethodSignature(node *sitter.Node, src []byte) string {
+func buildMethodSignature(node ts.Node, src []byte) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	// Strip annotation arguments FIRST to remove braces inside annotation args
 	// like @DeleteMapping("/{id}") → @DeleteMapping, so the body-brace search
@@ -1535,7 +1535,7 @@ func buildMethodSignature(node *sitter.Node, src []byte) string {
 
 // buildClassSignature constructs a readable signature up to the opening brace.
 // Strips visibility modifiers and annotation arguments to match Python convention.
-func buildClassSignature(node *sitter.Node, src []byte, name string) string {
+func buildClassSignature(node ts.Node, src []byte, name string) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "{"); idx >= 0 {
 		raw = raw[:idx]
@@ -1557,7 +1557,7 @@ func buildClassSignature(node *sitter.Node, src []byte, name string) string {
 // stripped — `extends List<Owner>` yields "List".
 //
 // Issue #1996 — required input for the docgen ClassManifest `bases` field.
-func javaSuperclassNames(node *sitter.Node, src []byte) []string {
+func javaSuperclassNames(node ts.Node, src []byte) []string {
 	if node == nil {
 		return nil
 	}
@@ -1587,7 +1587,7 @@ func javaSuperclassNames(node *sitter.Node, src []byte) []string {
 //
 // Issue #1996 — required input for the docgen ClassManifest `interfaces`
 // field.
-func javaSuperInterfaceNames(node *sitter.Node, src []byte) []string {
+func javaSuperInterfaceNames(node ts.Node, src []byte) []string {
 	if node == nil {
 		return nil
 	}
@@ -1608,7 +1608,7 @@ func javaSuperInterfaceNames(node *sitter.Node, src []byte) []string {
 	}
 	var out []string
 	// si may directly be a type_list, or wrap one.
-	var list *sitter.Node
+	var list ts.Node
 	if si.Type() == "type_list" {
 		list = si
 	} else {
@@ -1648,7 +1648,7 @@ func javaSuperInterfaceNames(node *sitter.Node, src []byte) []string {
 // The Schema/CONTAINS edge for the field itself is still emitted by the
 // regular field_declaration case in walk(); this function does not
 // suppress it.
-func javaInjectFieldTypes(body *sitter.Node, src []byte) []string {
+func javaInjectFieldTypes(body ts.Node, src []byte) []string {
 	if body == nil {
 		return nil
 	}
@@ -1674,7 +1674,7 @@ func javaInjectFieldTypes(body *sitter.Node, src []byte) []string {
 
 // javaFieldHasInjectAnnotation reports whether a field_declaration node
 // carries an @Inject or @Autowired annotation in its `modifiers` child.
-func javaFieldHasInjectAnnotation(field *sitter.Node, src []byte) bool {
+func javaFieldHasInjectAnnotation(field ts.Node, src []byte) bool {
 	if field == nil {
 		return false
 	}

--- a/internal/extractors/java/java_test.go
+++ b/internal/extractors/java/java_test.go
@@ -6,20 +6,27 @@ import (
 	"path/filepath"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsjava "github.com/smacker/go-tree-sitter/java"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/java"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
-// parseForTest parses Java source using the real grammar.
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+// parseForTest parses Java source into a ts.Tree via the smacker adapter. Tests
+// stamp the result on FileInput.TSTree (which the migrated Java extractor
+// consumes); the smacker adapter keeps these tests linkable in the default build
+// while exercising the ts façade (B2 #5418).
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsjava.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsjava.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -62,7 +69,7 @@ public class UserService implements UserRepository {
 		Path:     "UserService.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -109,7 +116,7 @@ public class Foo {
 		Path:     "Foo.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -148,7 +155,7 @@ public interface IRepository {
 		Path:     "repo.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -178,7 +185,7 @@ public class Svc {
 		Path:     "svc.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -208,7 +215,7 @@ public class Bar {
 		Path:     "bar.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -240,7 +247,7 @@ public class Foo {}
 		Path:     "imports.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -275,7 +282,7 @@ func TestJavaExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.java",
 		Content:  []byte(""),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -292,7 +299,7 @@ func TestJavaExtractor_NilTree(t *testing.T) {
 		Path:     "nil.java",
 		Content:  []byte("public class Foo {}"),
 		Language: "java",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -318,7 +325,7 @@ public class BadClass {
 		Path:     "malformed.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	// Must not panic; may return partial results.
 	if err != nil {
@@ -356,7 +363,7 @@ func TestJavaExtractor_LineNumbers(t *testing.T) {
 		Path:     "lines.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -390,7 +397,7 @@ public class Outer {
 		Path:     "nested.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -440,7 +447,7 @@ public class OrderSerializer {
 		Path:     "Serializers.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -521,7 +528,7 @@ func TestJavaExtractor_DuplicateMethodsFromFixture(t *testing.T) {
 		Path:     path,
 		Content:  src,
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -625,7 +632,7 @@ public class OrderController {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "src/controllers/OrderController.java",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)
@@ -678,7 +685,7 @@ public class ListRequest {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "src/main/java/com/example/dto/ListRequest.java",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)
@@ -730,7 +737,7 @@ func TestJavaExtractor_QualifiedName_NoPackage(t *testing.T) {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "Foo.java",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/java/nosql_model.go
+++ b/internal/extractors/java/nosql_model.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // nosql_model.go — Spring Data NoSQL schema/model extraction (#4283, follow-up
@@ -144,7 +144,7 @@ func annotationName(args string, namedKeys ...string) string {
 // emitted children (operations + SCOPE.Schema/field entities); only the
 // SCOPE.Schema/field entries whose Name is "<Class>.<field>" are wired.
 func emitNoSQLModel(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	className, classDeclSrc, classBodySrc, pkgName string,
 	fieldStart, fieldEnd int,

--- a/internal/extractors/java/observability.go
+++ b/internal/extractors/java/observability.go
@@ -52,7 +52,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -99,7 +99,7 @@ var javaMetricAnnotations = map[string]bool{
 // instrumentation sites (Micrometer/Dropwizard metrics, Brave/Sleuth spans,
 // SLF4J structured logs) and returns the corresponding INSTRUMENTS edges.
 // methodName keys dynamic-name stubs.
-func javaObsEdges(methodNode *sitter.Node, methodName string, src []byte) []types.RelationshipRecord {
+func javaObsEdges(methodNode ts.Node, methodName string, src []byte) []types.RelationshipRecord {
 	if methodNode == nil {
 		return nil
 	}
@@ -165,7 +165,7 @@ func javaObsEdges(methodNode *sitter.Node, methodName string, src []byte) []type
 // the method. The metric name is the annotation's first string-literal value
 // when present; a bare @Timed (no name) is emitted dynamic (Micrometer derives
 // the name from the method/registry config — not statically resolvable here).
-func javaMetricAnnotationHits(methodNode *sitter.Node, src []byte) []javaObsHit {
+func javaMetricAnnotationHits(methodNode ts.Node, src []byte) []javaObsHit {
 	var hits []javaObsHit
 	for i := 0; i < int(methodNode.ChildCount()); i++ {
 		child := methodNode.Child(i)
@@ -205,7 +205,7 @@ func javaMetricAnnotationHits(methodNode *sitter.Node, src []byte) []javaObsHit 
 // javaBodyObsHits scans a method body for call-form instrumentation: Micrometer
 // / Dropwizard registry metric calls, Micrometer Counter.builder("name"),
 // Brave/Sleuth tracer.nextSpan().name("op"), and SLF4J fluent keyed logging.
-func javaBodyObsHits(body *sitter.Node, src []byte) []javaObsHit {
+func javaBodyObsHits(body ts.Node, src []byte) []javaObsHit {
 	if body == nil {
 		return nil
 	}
@@ -236,7 +236,7 @@ func javaBodyObsHits(body *sitter.Node, src []byte) []javaObsHit {
 // Registry-method calls are gated on a receiver that looks like a meter/metric
 // registry so unrelated `.counter(...)` calls don't match. Returns false when
 // the call is not a metric-creation call.
-func javaMetricCallHit(call *sitter.Node, src []byte) (javaObsHit, bool) {
+func javaMetricCallHit(call ts.Node, src []byte) (javaObsHit, bool) {
 	name := javaInvocationName(call, src)
 	args := call.ChildByFieldName("arguments")
 	obj := call.ChildByFieldName("object")
@@ -291,7 +291,7 @@ func javaMetricCallHit(call *sitter.Node, src []byte) (javaObsHit, bool) {
 // identifier containing "registry" or being a conventional short name, so
 // arbitrary `x.counter(...)` calls on unrelated objects are not misread as
 // metric instrumentation.
-func javaMetricReceiverName(obj *sitter.Node, src []byte) string {
+func javaMetricReceiverName(obj ts.Node, src []byte) string {
 	if obj == nil || obj.Type() != "identifier" {
 		return ""
 	}
@@ -306,7 +306,7 @@ func javaMetricReceiverName(obj *sitter.Node, src []byte) string {
 // javaBraveSpanHit matches the Spring Sleuth / Brave fluent span form
 // `tracer.nextSpan().name("op")` — anchored on the `.name("op")` call whose
 // receiver chain includes a `nextSpan()` call. Returns false otherwise.
-func javaBraveSpanHit(call *sitter.Node, src []byte) (javaObsHit, bool) {
+func javaBraveSpanHit(call ts.Node, src []byte) (javaObsHit, bool) {
 	if javaInvocationName(call, src) != "name" {
 		return javaObsHit{}, false
 	}
@@ -325,7 +325,7 @@ func javaBraveSpanHit(call *sitter.Node, src []byte) (javaObsHit, bool) {
 
 // javaChainHasInvocation reports whether the receiver (`object`) chain rooted at
 // n contains a method_invocation named want.
-func javaChainHasInvocation(n *sitter.Node, want string, src []byte) bool {
+func javaChainHasInvocation(n ts.Node, want string, src []byte) bool {
 	for n != nil && n.Type() == "method_invocation" {
 		if javaInvocationName(n, src) == want {
 			return true
@@ -343,7 +343,7 @@ func javaChainHasInvocation(n *sitter.Node, want string, src []byte) bool {
 // non-literal but the call is a recognised structured-logging chain, the hit is
 // emitted dynamic (keyed event with an unresolved message). Plain free-text
 // `logger.info("text")` is intentionally NOT matched (no structured key).
-func javaSlf4jLogHit(call *sitter.Node, src []byte) (javaObsHit, bool) {
+func javaSlf4jLogHit(call ts.Node, src []byte) (javaObsHit, bool) {
 	if javaInvocationName(call, src) != "log" {
 		return javaObsHit{}, false
 	}
@@ -379,7 +379,7 @@ var javaSlf4jFluentLevels = map[string]bool{
 
 // javaChainHasFluentLevel reports whether the receiver chain contains an SLF4J
 // fluent level entry (atInfo()/atError()/...).
-func javaChainHasFluentLevel(n *sitter.Node, src []byte) bool {
+func javaChainHasFluentLevel(n ts.Node, src []byte) bool {
 	for n != nil && n.Type() == "method_invocation" {
 		if javaSlf4jFluentLevels[javaInvocationName(n, src)] {
 			return true
@@ -391,7 +391,7 @@ func javaChainHasFluentLevel(n *sitter.Node, src []byte) bool {
 
 // javaChainHasAnyInvocation reports whether the receiver chain contains a
 // method_invocation whose name is one of wants.
-func javaChainHasAnyInvocation(n *sitter.Node, src []byte, wants ...string) bool {
+func javaChainHasAnyInvocation(n ts.Node, src []byte, wants ...string) bool {
 	want := make(map[string]bool, len(wants))
 	for _, w := range wants {
 		want[w] = true

--- a/internal/extractors/java/prune_import_placeholders.go
+++ b/internal/extractors/java/prune_import_placeholders.go
@@ -51,7 +51,7 @@ package java
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -65,7 +65,7 @@ import (
 // fileEntity must be non-nil. On return, fileEntity.Relationships will
 // contain one IMPORTS record per import_declaration node found in root.
 // Malformed import nodes (empty text after stripping) are silently dropped.
-func attachImportRelationships(root *sitter.Node, file extractor.FileInput, fileEntity *types.EntityRecord) {
+func attachImportRelationships(root ts.Node, file extractor.FileInput, fileEntity *types.EntityRecord) {
 	if root == nil || fileEntity == nil {
 		return
 	}
@@ -91,7 +91,7 @@ func attachImportRelationships(root *sitter.Node, file extractor.FileInput, file
 // absent) and wildcard="1" is set, matching the Python extractor contract.
 //
 // Returns (zero, false) for empty or unparseable import text.
-func buildImportRel(node *sitter.Node, file extractor.FileInput) (types.RelationshipRecord, bool) {
+func buildImportRel(node ts.Node, file extractor.FileInput) (types.RelationshipRecord, bool) {
 	raw := strings.TrimSpace(string(file.Content[node.StartByte():node.EndByte()]))
 	raw = strings.TrimPrefix(raw, "import ")
 	_ = strings.HasPrefix(raw, "static ") // isStatic recorded below via leaf

--- a/internal/extractors/java/prune_import_placeholders_test.go
+++ b/internal/extractors/java/prune_import_placeholders_test.go
@@ -47,7 +47,7 @@ func extractJavaForTest(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.java",
 		Language: "java",
 		Content:  []byte(src),
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/java/references.go
+++ b/internal/extractors/java/references.go
@@ -65,7 +65,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -119,7 +119,7 @@ type javaFrame struct {
 // enclosing operation entity.
 //
 // Mutates entities in place. Safe to call with an empty slice — no-op.
-func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitReferences(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -282,8 +282,8 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 			})
 	}
 
-	var walk func(n *sitter.Node, parentClass string, fstack []javaFrame)
-	walk = func(n *sitter.Node, parentClass string, fstack []javaFrame) {
+	var walk func(n ts.Node, parentClass string, fstack []javaFrame)
+	walk = func(n ts.Node, parentClass string, fstack []javaFrame) {
 		if n == nil {
 			return
 		}
@@ -384,7 +384,7 @@ func findEntityIndex(entities []types.EntityRecord, emittedName, filePath string
 //   - skip self-name (an identifier matching the enclosing operation's leaf)
 //   - otherwise look up in bareSymbols and emit
 func handleIdentifier(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	fstack []javaFrame,
 	bareSymbols map[string]javaSymbol,
@@ -424,7 +424,7 @@ func handleIdentifier(
 // declaration (`Foo x = ...`), or return-type position. These are
 // strictly REFERENCES, never CALLS.
 func handleTypeIdentifier(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	fstack []javaFrame,
 	bareSymbols map[string]javaSymbol,
@@ -464,7 +464,7 @@ func handleTypeIdentifier(
 //   - otherwise leave the receiver to the generic identifier walk
 //     (recursion handles it).
 func handleFieldAccess(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	fstack []javaFrame,
 	bareSymbols map[string]javaSymbol,
@@ -560,7 +560,7 @@ func handleFieldAccess(
 //	parent is `catch_formal_parameter`
 //	parent is `import_declaration` / `package_declaration`
 //	parent is `inferred_parameters` (lambda parameter list)
-func isJavaDeclarationPosition(n *sitter.Node) bool {
+func isJavaDeclarationPosition(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false
@@ -584,7 +584,7 @@ func isJavaDeclarationPosition(n *sitter.Node) bool {
 // child of a `method_invocation` node, or the type child of an
 // `object_creation_expression`. CALLS owns those edges — REFERENCES
 // would double-count.
-func isJavaCallCallee(n *sitter.Node) bool {
+func isJavaCallCallee(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false
@@ -600,7 +600,7 @@ func isJavaCallCallee(n *sitter.Node) bool {
 // `field` child of a `field_access` node. The field_access handler
 // owns the binding decision; the bare identifier walk should skip it
 // to avoid double-emission.
-func isJavaFieldAccessField(n *sitter.Node) bool {
+func isJavaFieldAccessField(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false

--- a/internal/extractors/java/relationships_test.go
+++ b/internal/extractors/java/relationships_test.go
@@ -17,7 +17,7 @@ func runJava(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.java",
 		Content:  []byte(src),
 		Language: "java",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/java/template_render.go
+++ b/internal/extractors/java/template_render.go
@@ -29,7 +29,7 @@ package java
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -51,7 +51,7 @@ var springMappingAnnotations = map[string]bool{
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitTemplateRenderEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -59,8 +59,8 @@ func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entiti
 
 	var edges []extractor.TemplateEdge
 
-	var walk func(n *sitter.Node, enclosingClass string)
-	walk = func(n *sitter.Node, enclosingClass string) {
+	var walk func(n ts.Node, enclosingClass string)
+	walk = func(n ts.Node, enclosingClass string) {
 		if n == nil {
 			return
 		}
@@ -110,7 +110,7 @@ func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entiti
 //   - the method MUST NOT carry @ResponseBody (else String is a REST body)
 //   - the returned value MUST be a String literal, or `new ModelAndView("...")`
 //     with a literal first argument; anything else (variable, computed) → drop.
-func javaSpringViewName(method *sitter.Node, enclosingClass string, src []byte) (string, string) {
+func javaSpringViewName(method ts.Node, enclosingClass string, src []byte) (string, string) {
 	anns := annotationNames(method, src)
 	if anns["ResponseBody"] {
 		return "", "" // REST response body, not a view name
@@ -132,8 +132,8 @@ func javaSpringViewName(method *sitter.Node, enclosingClass string, src []byte) 
 	}
 	// Find a `return <expr>;` whose expr is a String literal or ModelAndView(...).
 	var found, pat string
-	var scan func(n *sitter.Node)
-	scan = func(n *sitter.Node) {
+	var scan func(n ts.Node)
+	scan = func(n ts.Node) {
 		if n == nil || found != "" {
 			return
 		}
@@ -167,8 +167,8 @@ func javaSpringViewName(method *sitter.Node, enclosingClass string, src []byte) 
 //
 // Returns "", "" for a non-literal return (variable / concatenation / computed),
 // so dynamic view names never fabricate a node.
-func javaReturnViewName(ret *sitter.Node, src []byte) (string, string) {
-	var expr *sitter.Node
+func javaReturnViewName(ret ts.Node, src []byte) (string, string) {
+	var expr ts.Node
 	for i := 0; i < int(ret.NamedChildCount()); i++ {
 		c := ret.NamedChild(i)
 		if c != nil {
@@ -207,7 +207,7 @@ func javaReturnViewName(ret *sitter.Node, src []byte) (string, string) {
 
 // annotationNames returns the set of simple annotation names on a declaration's
 // immediate modifiers (e.g. {"Controller": true, "GetMapping": true}).
-func annotationNames(decl *sitter.Node, src []byte) map[string]bool {
+func annotationNames(decl ts.Node, src []byte) map[string]bool {
 	out := map[string]bool{}
 	for _, a := range findAnnotations(decl, src) {
 		if a.name != "" {

--- a/internal/extractors/java/tracing.go
+++ b/internal/extractors/java/tracing.go
@@ -34,7 +34,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -52,7 +52,7 @@ type javaSpanHit struct {
 // `spanBuilder(...).startSpan()` calls in its body — and returns the
 // corresponding INSTRUMENTS edges. methodName is the bare method name used as
 // the @WithSpan default span name and to key dynamic-name stubs.
-func javaTracingSpanEdges(methodNode *sitter.Node, methodName string, src []byte) []types.RelationshipRecord {
+func javaTracingSpanEdges(methodNode ts.Node, methodName string, src []byte) []types.RelationshipRecord {
 	if methodNode == nil {
 		return nil
 	}
@@ -101,7 +101,7 @@ func javaTracingSpanEdges(methodNode *sitter.Node, methodName string, src []byte
 // javaWithSpanHits returns a single hit when the method carries a @WithSpan
 // annotation. The span name is the annotation's first string-literal argument
 // when present, otherwise the bare method name.
-func javaWithSpanHits(methodNode *sitter.Node, methodName string, src []byte) []javaSpanHit {
+func javaWithSpanHits(methodNode ts.Node, methodName string, src []byte) []javaSpanHit {
 	var hits []javaSpanHit
 	// The modifiers child carries the annotations preceding the method.
 	for i := 0; i < int(methodNode.ChildCount()); i++ {
@@ -139,7 +139,7 @@ func javaWithSpanHits(methodNode *sitter.Node, methodName string, src []byte) []
 // javaAnnotationStringValue returns the first string-literal value found in an
 // annotation_argument_list — handling both @X("v") and @X(value="v") — or ""
 // when none is present.
-func javaAnnotationStringValue(args *sitter.Node, src []byte) string {
+func javaAnnotationStringValue(args ts.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
@@ -158,7 +158,7 @@ func javaAnnotationStringValue(args *sitter.Node, src []byte) string {
 // receiver chain to find the `spanBuilder(...)` call that carries the span name.
 // Anchoring on startSpan (the OTel call that actually creates the span) avoids
 // matching a bare `spanBuilder(...)` whose span is never started.
-func javaSpanBuilderHits(body *sitter.Node, src []byte) []javaSpanHit {
+func javaSpanBuilderHits(body ts.Node, src []byte) []javaSpanHit {
 	if body == nil {
 		return nil
 	}
@@ -185,7 +185,7 @@ func javaSpanBuilderHits(body *sitter.Node, src []byte) []javaSpanHit {
 // javaFindSpanBuilderInChain walks the receiver (`object`) chain of a startSpan
 // invocation looking for the `spanBuilder(...)` call. Returns the spanBuilder
 // method_invocation node, or nil when the chain does not contain one.
-func javaFindSpanBuilderInChain(startSpanCall *sitter.Node, src []byte) *sitter.Node {
+func javaFindSpanBuilderInChain(startSpanCall ts.Node, src []byte) ts.Node {
 	obj := startSpanCall.ChildByFieldName("object")
 	for obj != nil && obj.Type() == "method_invocation" {
 		if javaInvocationName(obj, src) == "spanBuilder" {
@@ -198,7 +198,7 @@ func javaFindSpanBuilderInChain(startSpanCall *sitter.Node, src []byte) *sitter.
 
 // javaFirstStringArg returns the first string-literal argument value in an
 // argument_list, or "" when the first argument is non-literal / absent.
-func javaFirstStringArg(args *sitter.Node, src []byte) string {
+func javaFirstStringArg(args ts.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
@@ -217,7 +217,7 @@ func javaFirstStringArg(args *sitter.Node, src []byte) string {
 }
 
 // javaInvocationName returns the bare name of a method_invocation node.
-func javaInvocationName(call *sitter.Node, src []byte) string {
+func javaInvocationName(call ts.Node, src []byte) string {
 	name := call.ChildByFieldName("name")
 	if name == nil {
 		return ""

--- a/internal/extractors/java/transaction_boundary_test.go
+++ b/internal/extractors/java/transaction_boundary_test.go
@@ -18,7 +18,7 @@ func extractJavaTx(t *testing.T, src string) []types.EntityRecord {
 		t.Fatal("java extractor not registered")
 	}
 	recs, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "Service.java", Content: []byte(src), Language: "java", Tree: tree,
+		Path: "Service.java", Content: []byte(src), Language: "java", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/python/async_semantics.go
+++ b/internal/extractors/python/async_semantics.go
@@ -36,7 +36,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -78,7 +78,7 @@ var channelLayerCallRe = regexp.MustCompile(
 //   - Appends CALLS edges from each enclosing function to a synthetic
 //     `ext:channel_layer:<method>` stub for each channel-layer dispatch
 //     call site found in the file.
-func applyAsyncSemantics(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func applyAsyncSemantics(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}

--- a/internal/extractors/python/bundle_c_test.go
+++ b/internal/extractors/python/bundle_c_test.go
@@ -36,7 +36,7 @@ func extractBundleC(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	ents, err := ext.Extract(context.Background(), file)
 	if err != nil {

--- a/internal/extractors/python/cbv_inherited_methods.go
+++ b/internal/extractors/python/cbv_inherited_methods.go
@@ -28,7 +28,7 @@ import (
 	"sort"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/frameworks/baseknowledge"
@@ -67,7 +67,7 @@ func cbvInheritedMembers(baseLeaf string) (methods []string, known bool) {
 // `django.views.generic.View` — extractBaseClasses normalises the leaf.
 //
 // Mutates *entities in place. Safe with nil/empty inputs.
-func emitCBVInheritedMethodAnnotations(_ *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitCBVInheritedMethodAnnotations(_ ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if entities == nil || len(*entities) == 0 {
 		return
 	}

--- a/internal/extractors/python/config_consumer.go
+++ b/internal/extractors/python/config_consumer.go
@@ -51,7 +51,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -61,7 +61,7 @@ import (
 // patterns and appends DEPENDS_ON_CONFIG edges to the enclosing entity.
 //
 // Mutates *entities in place. Safe to call with nil or empty input.
-func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitConfigConsumerEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -160,8 +160,8 @@ func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entiti
 		return stack[len(stack)-1]
 	}
 
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -342,7 +342,7 @@ func buildConfigTargetID(configName string) string {
 //	os.getenv("X" [, default])
 //	environ.get("X" [, default])          (when `environ` was imported from os)
 //	getenv("X" [, default])               (when `getenv` was imported from os)
-func envKeyFromCall(fn, args *sitter.Node, src []byte, osImported bool, environLocal, getenvLocal string) string {
+func envKeyFromCall(fn, args ts.Node, src []byte, osImported bool, environLocal, getenvLocal string) string {
 	calleeText := strings.TrimSpace(nodeText(fn, src))
 	matched := false
 	switch {

--- a/internal/extractors/python/config_module.go
+++ b/internal/extractors/python/config_module.go
@@ -47,7 +47,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -89,7 +89,7 @@ const configAssignmentRatio = 0.80
 //
 // Returns true when a config_module entity was appended, false otherwise.
 // Callers may use the boolean to increment an OTel attribute counter.
-func emitConfigModuleEntity(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) bool {
+func emitConfigModuleEntity(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) bool {
 	base := filepath.Base(filepath.FromSlash(file.Path))
 
 	// --- criterion 1: filename match ---
@@ -191,7 +191,7 @@ func emitConfigModuleEntity(root *sitter.Node, file extractor.FileInput, out *[]
 // Only the direct children of the module root are examined (file-level
 // scope). Nested statements inside functions, classes, or if-blocks are
 // intentionally NOT counted — we want the file-level heuristic only.
-func countTopLevelStatements(root *sitter.Node, src []byte) (assignCount, totalCount int) {
+func countTopLevelStatements(root ts.Node, src []byte) (assignCount, totalCount int) {
 	if root == nil {
 		return 0, 0
 	}
@@ -226,7 +226,7 @@ func countTopLevelStatements(root *sitter.Node, src []byte) (assignCount, totalC
 // of every simple module-level assignment (identifier = expr). At most 50
 // names are returned to keep the Property value bounded. Dunder names are
 // excluded.
-func collectTopLevelAssignmentNames(root *sitter.Node, src []byte) []string {
+func collectTopLevelAssignmentNames(root ts.Node, src []byte) []string {
 	if root == nil {
 		return nil
 	}
@@ -246,7 +246,7 @@ func collectTopLevelAssignmentNames(root *sitter.Node, src []byte) []string {
 			if expr == nil {
 				continue
 			}
-			var lhs *sitter.Node
+			var lhs ts.Node
 			switch expr.Type() {
 			case "assignment":
 				lhs = expr.ChildByFieldName("left")
@@ -292,7 +292,7 @@ func collectTopLevelAssignmentNames(root *sitter.Node, src []byte) []string {
 // or bare identifiers (IsAuthenticated); both are reduced to their leaf class
 // name (IsAuthenticated). Only the top-level REST_FRAMEWORK assignment is
 // examined.
-func extractDRFDefaultPermissionClasses(root *sitter.Node, src []byte) ([]string, bool) {
+func extractDRFDefaultPermissionClasses(root ts.Node, src []byte) ([]string, bool) {
 	if root == nil {
 		return nil, false
 	}
@@ -323,7 +323,7 @@ func extractDRFDefaultPermissionClasses(root *sitter.Node, src []byte) ([]string
 // dictDefaultPermissionClasses reads a `dictionary` node and, if it has a
 // "DEFAULT_PERMISSION_CLASSES" key, returns the leaf names of its value list
 // plus present=true.
-func dictDefaultPermissionClasses(dict *sitter.Node, src []byte) ([]string, bool) {
+func dictDefaultPermissionClasses(dict ts.Node, src []byte) ([]string, bool) {
 	for i := 0; i < int(dict.NamedChildCount()); i++ {
 		pair := dict.NamedChild(i)
 		if pair == nil || pair.Type() != "pair" {
@@ -352,7 +352,7 @@ func dictDefaultPermissionClasses(dict *sitter.Node, src []byte) ([]string, bool
 // parseListLiteralStringsOrIdents reads a list/tuple/set literal and returns
 // the raw source text of each element (string literal or identifier/attribute),
 // tolerating the mixed string-or-symbol forms common in DRF settings.
-func parseListLiteralStringsOrIdents(n *sitter.Node, src []byte) []string {
+func parseListLiteralStringsOrIdents(n ts.Node, src []byte) []string {
 	if n == nil {
 		return nil
 	}

--- a/internal/extractors/python/config_module_test.go
+++ b/internal/extractors/python/config_module_test.go
@@ -71,7 +71,7 @@ func TestConfigModule_SettingsPy(t *testing.T) {
 		Path:     "upvate_core/settings.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {
@@ -170,7 +170,7 @@ func TestConfigModule_ManageWithMain(t *testing.T) {
 		Path:     "manage.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {
@@ -231,7 +231,7 @@ func TestConfigModule_UtilsNormal(t *testing.T) {
 		Path:     "app/utils/utils.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {

--- a/internal/extractors/python/crossfile.go
+++ b/internal/extractors/python/crossfile.go
@@ -36,7 +36,7 @@ import (
 	"strings"
 	"sync"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -168,7 +168,7 @@ func resolveBaseFile(baseName, consumerFile string) string {
 //
 // Returns nil when the class has no base-class list or the list is empty.
 func extractBaseClasses(
-	classNode *sitter.Node,
+	classNode ts.Node,
 	filePath string,
 	className string,
 	src []byte,
@@ -249,7 +249,7 @@ func extractBaseClasses(
 //	attribute            → "module.Foo"  (e.g. models.Model)
 //	subscript            → "List[str]" → "List"  (generic base, return inner name)
 //	keyword_argument     → skip (e.g. metaclass=ABCMeta)
-func extractBaseNameFromNode(n *sitter.Node, src []byte) string {
+func extractBaseNameFromNode(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/python/crossfile_test.go
+++ b/internal/extractors/python/crossfile_test.go
@@ -449,7 +449,7 @@ func cfExtract(t *testing.T, filePath, src string) []types.EntityRecord {
 		Path:     filePath,
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/python/crossmodule_calls.go
+++ b/internal/extractors/python/crossmodule_calls.go
@@ -62,7 +62,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 )
@@ -96,7 +96,7 @@ type pythonImportMap map[string]pythonImportBinding
 //
 // The map is intentionally small and per-file — it is rebuilt for every
 // extracted file and never escapes the Extract call frame.
-func buildPythonImportMap(root *sitter.Node, file extractor.FileInput) pythonImportMap {
+func buildPythonImportMap(root ts.Node, file extractor.FileInput) pythonImportMap {
 	if root == nil {
 		return nil
 	}
@@ -180,7 +180,7 @@ func buildPythonImportMap(root *sitter.Node, file extractor.FileInput) pythonImp
 // or when the relative climb would escape the file's package (more dots
 // than parent segments) — in which case the caller leaves the binding
 // out of the map rather than emit a malformed key.
-func resolvePythonImportModule(modNode *sitter.Node, file extractor.FileInput) string {
+func resolvePythonImportModule(modNode ts.Node, file extractor.FileInput) string {
 	if modNode == nil {
 		return ""
 	}
@@ -274,7 +274,7 @@ func resolvePythonImportModule(modNode *sitter.Node, file extractor.FileInput) s
 // or a deeper attribute chain; emitting a guess risks binding edges to the
 // wrong entity).
 func extractCallTargetImportAlias(
-	call *sitter.Node,
+	call ts.Node,
 	src []byte,
 	imports pythonImportMap,
 ) (alias, leaf string) {

--- a/internal/extractors/python/data_dispatch.go
+++ b/internal/extractors/python/data_dispatch.go
@@ -85,7 +85,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -115,7 +115,7 @@ type moduleConstRegistry map[string][]moduleConstEntry
 //
 // Mutation guard: names that appear as an assignment LHS ANYWHERE in the
 // file body other than their own definition are excluded from the registry.
-func scanModuleConstCallables(root *sitter.Node, src []byte, imports pythonImportMap) moduleConstRegistry {
+func scanModuleConstCallables(root ts.Node, src []byte, imports pythonImportMap) moduleConstRegistry {
 	if root == nil {
 		return nil
 	}
@@ -200,7 +200,7 @@ func scanModuleConstCallables(root *sitter.Node, src []byte, imports pythonImpor
 // that is (or contains at position 0) an attribute-shaped callable reference
 // whose receiver is a known import alias or PascalCase class name.
 func extractCallableEntriesFromLiteral(
-	node *sitter.Node,
+	node ts.Node,
 	src []byte,
 	imports pythonImportMap,
 ) []moduleConstEntry {
@@ -230,7 +230,7 @@ func extractCallableEntriesFromLiteral(
 //
 // Returns (entry, true) when a valid callable reference is found.
 func extractCallableFromElem(
-	elem *sitter.Node,
+	elem ts.Node,
 	src []byte,
 	imports pythonImportMap,
 ) (moduleConstEntry, bool) {
@@ -262,7 +262,7 @@ func extractCallableFromElem(
 //
 // The attribute (right side) is the leaf function name.
 func attrNodeToEntry(
-	attr *sitter.Node,
+	attr ts.Node,
 	src []byte,
 	imports pythonImportMap,
 ) (moduleConstEntry, bool) {
@@ -300,11 +300,11 @@ func attrNodeToEntry(
 // assignment or augmented_assignment. Only names already present in the map
 // are counted. The count for the single defining top-level assignment is 1;
 // any additional assignment raises it to >1, triggering the mutation guard.
-func collectAssignmentLHSNames(root *sitter.Node, src []byte, counts map[string]int) {
+func collectAssignmentLHSNames(root ts.Node, src []byte, counts map[string]int) {
 	if root == nil || len(counts) == 0 {
 		return
 	}
-	stack := []*sitter.Node{root}
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -345,7 +345,7 @@ func collectAssignmentLHSNames(root *sitter.Node, src []byte, counts map[string]
 // shape as the direct cross-module alias path (#1706). De-duplication against
 // the already-emitted `seen` map is done by the caller.
 func extractDataDispatchCalls(
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	reg moduleConstRegistry,
 	callerName string,
@@ -377,7 +377,7 @@ type seenKeyDD struct{ target, alias string }
 //	for f in STEPS:           — single identifier
 //	for f, _ in STEPS:        — pattern_list / tuple_pattern, first element taken
 func inspectForStmt(
-	forStmt *sitter.Node,
+	forStmt ts.Node,
 	src []byte,
 	reg moduleConstRegistry,
 	seen map[seenKeyDD]bool,
@@ -449,7 +449,7 @@ func inspectForStmt(
 //	for (f, _) in ...:        → "f"   (parenthesised pattern)
 //
 // Returns "" for any unrecognised or non-identifier shape.
-func extractForLoopVar(forStmt *sitter.Node, src []byte) string {
+func extractForLoopVar(forStmt ts.Node, src []byte) string {
 	target := forStmt.ChildByFieldName("left")
 	if target == nil {
 		return ""
@@ -475,7 +475,7 @@ func extractForLoopVar(forStmt *sitter.Node, src []byte) string {
 // node where the `function` child is an `identifier` node whose text equals
 // loopVar. Only direct calls `loopVar(...)` qualify; chained calls like
 // `loopVar.method(...)` or `loopVar[0](...)` do not.
-func bodyCallsLoopVar(body *sitter.Node, src []byte, loopVar string) bool {
+func bodyCallsLoopVar(body ts.Node, src []byte, loopVar string) bool {
 	calls := findAll(body, "call")
 	for _, call := range calls {
 		fn := call.ChildByFieldName("function")
@@ -494,11 +494,11 @@ func bodyCallsLoopVar(body *sitter.Node, src []byte, loopVar string) bool {
 
 // bodyReassigns reports whether body contains an assignment or
 // augmented_assignment whose LHS is the bare identifier `name`.
-func bodyReassigns(body *sitter.Node, src []byte, name string) bool {
+func bodyReassigns(body ts.Node, src []byte, name string) bool {
 	if body == nil || name == "" {
 		return false
 	}
-	stack := []*sitter.Node{body}
+	stack := []ts.Node{body}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -547,7 +547,7 @@ func isUpperCaseConst(name string) bool {
 //
 // This is a lightweight wrapper used by the scanner to pre-filter candidates
 // before the full mutation-guard pass.
-func resolveModuleConstName(lhs *sitter.Node, src []byte) string {
+func resolveModuleConstName(lhs ts.Node, src []byte) string {
 	if lhs == nil || lhs.Type() != "identifier" {
 		return ""
 	}
@@ -578,7 +578,7 @@ func isKnownImportReceiver(receiver string, imports pythonImportMap) bool {
 // least one valid callable reference (attribute node or nested tuple/list
 // with an attribute as first element). Used as a fast pre-filter to avoid
 // full entry extraction on non-callable lists.
-func hasSingleCallableRef(node *sitter.Node, src []byte, imports pythonImportMap) bool {
+func hasSingleCallableRef(node ts.Node, src []byte, imports pythonImportMap) bool {
 	if node == nil {
 		return false
 	}
@@ -587,7 +587,7 @@ func hasSingleCallableRef(node *sitter.Node, src []byte, imports pythonImportMap
 		if elem == nil {
 			continue
 		}
-		var attr *sitter.Node
+		var attr ts.Node
 		switch elem.Type() {
 		case "attribute":
 			attr = elem
@@ -617,14 +617,14 @@ func hasSingleCallableRef(node *sitter.Node, src []byte, imports pythonImportMap
 // scanModuleConstCallables and is threaded through from Extract. It is a
 // thin alias kept separate so the scanning logic can be unit-tested in
 // isolation without going through the full Extract pipeline.
-func buildModuleConstRegistry(root *sitter.Node, src []byte, imports pythonImportMap) moduleConstRegistry {
+func buildModuleConstRegistry(root ts.Node, src []byte, imports pythonImportMap) moduleConstRegistry {
 	return scanModuleConstCallables(root, src, imports)
 }
 
 // suffixStrings extracts the string values of all string literal children
 // inside an element node. Used for debug/tracing only (not called in the
 // hot path). Kept for completeness / future enrichment.
-func suffixStrings(node *sitter.Node, src []byte) []string {
+func suffixStrings(node ts.Node, src []byte) []string {
 	if node == nil {
 		return nil
 	}

--- a/internal/extractors/python/data_dispatch_test.go
+++ b/internal/extractors/python/data_dispatch_test.go
@@ -26,7 +26,7 @@ func ddExtract(t *testing.T, filePath, src string) []ddRel {
 		Path:     filePath,
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -346,7 +346,7 @@ def run(ctx):
 		Path:     "sagas/dispatch_source.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -621,7 +621,7 @@ def run_beta(ctx):
 		Path:     "wf/sources.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/python/decorators_generic.go
+++ b/internal/extractors/python/decorators_generic.go
@@ -36,7 +36,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -47,14 +47,14 @@ import (
 // `decorator_<name>` properties on it for each decorator on the definition.
 //
 // Mutates *entities in place. Safe to call with nil/empty input.
-func emitGenericDecoratorProperties(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitGenericDecoratorProperties(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
 	walkDecoratedDefs(root, "", file, entities)
 }
 
-func walkDecoratedDefs(n *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func walkDecoratedDefs(n ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if n == nil {
 		return
 	}
@@ -95,7 +95,7 @@ func walkDecoratedDefs(n *sitter.Node, parentClass string, file extractor.FileIn
 // stampDecoratorsOnOperation scans every decorator child of decoratedNode and
 // stamps a `decorator_<leaf>` property on the matching SCOPE.Operation entity
 // found by SourceFile + qualified Name.
-func stampDecoratorsOnOperation(decoratedNode, fnNode *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func stampDecoratorsOnOperation(decoratedNode, fnNode ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	methodNameNode := fnNode.ChildByFieldName("name")
 	if methodNameNode == nil {
 		return

--- a/internal/extractors/python/discriminator.go
+++ b/internal/extractors/python/discriminator.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -43,7 +43,7 @@ type pyDiscriminatorHit struct {
 // extractPythonDiscriminators walks the body node (a function/method body block)
 // and returns a comma-separated "var=value" string for every discriminator
 // comparison found. Returns "" when no discriminators are found or body is nil.
-func extractPythonDiscriminators(body *sitter.Node, src []byte) string {
+func extractPythonDiscriminators(body ts.Node, src []byte) string {
 	hits := extractPythonDiscriminatorHits(body, src)
 	if len(hits) == 0 {
 		return ""
@@ -59,7 +59,7 @@ func extractPythonDiscriminators(body *sitter.Node, src []byte) string {
 // pyDiscriminatorHit per unique (var, literal) pair found. Used by
 // stampPythonDiscriminators (#2666) to emit DISCRIMINATES_ON edges with
 // line + literal properties.
-func extractPythonDiscriminatorHits(body *sitter.Node, src []byte) []pyDiscriminatorHit {
+func extractPythonDiscriminatorHits(body ts.Node, src []byte) []pyDiscriminatorHit {
 	if body == nil {
 		return nil
 	}
@@ -97,7 +97,7 @@ func extractPythonDiscriminatorHits(body *sitter.Node, src []byte) []pyDiscrimin
 //	(child[3] = another operator, child[4] = another operand for chained comparisons)
 //
 // We only inspect the first comparison pair (child[0..2]).
-func discriminatorFromPythonComparison(n *sitter.Node, src []byte) (varName, litVal string, ok bool) {
+func discriminatorFromPythonComparison(n ts.Node, src []byte) (varName, litVal string, ok bool) {
 	if n == nil || n.Type() != "comparison_operator" {
 		return "", "", false
 	}
@@ -149,7 +149,7 @@ func discriminatorFromPythonComparison(n *sitter.Node, src []byte) (varName, lit
 //   - "true"      — Python True keyword
 //   - "false"     — Python False keyword
 //   - "none"      — Python None keyword
-func isPythonDiscriminatorLiteral(n *sitter.Node) bool {
+func isPythonDiscriminatorLiteral(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -166,7 +166,7 @@ func isPythonDiscriminatorLiteral(n *sitter.Node) bool {
 // pythonLiteralValue extracts the display value from a Python literal node.
 // String literals have their surrounding quotes stripped. Other literals
 // return their raw text.
-func pythonLiteralValue(n *sitter.Node, src []byte) string {
+func pythonLiteralValue(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -207,7 +207,7 @@ func pythonLiteralValue(n *sitter.Node, src []byte) string {
 // stampPythonDiscriminators stamps Properties["discriminators"] on the entity
 // at index idx in the out slice when discriminators are found in body.
 // Called immediately after appending a function/method entity.
-func stampPythonDiscriminators(body *sitter.Node, src []byte, out *[]types.EntityRecord, idx int) {
+func stampPythonDiscriminators(body ts.Node, src []byte, out *[]types.EntityRecord, idx int) {
 	if body == nil || out == nil || idx < 0 || idx >= len(*out) {
 		return
 	}

--- a/internal/extractors/python/django_admin.go
+++ b/internal/extractors/python/django_admin.go
@@ -34,7 +34,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -59,7 +59,7 @@ var adminModelAdminProps = []string{
 
 // emitDjangoAdminEdges is the entry point invoked from Extract. No-op for
 // non-admin files.
-func emitDjangoAdminEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitDjangoAdminEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -123,10 +123,10 @@ type adminSiteRegisterPair struct {
 // Both positional and dotted-identifier args survive intact. The first arg
 // may itself be a list `[M1, M2]` (Django supports registering multiple
 // models in one call); we expand into one pair per model.
-func collectAdminSiteRegisterCalls(root *sitter.Node, src []byte) []adminSiteRegisterPair {
+func collectAdminSiteRegisterCalls(root ts.Node, src []byte) []adminSiteRegisterPair {
 	var out []adminSiteRegisterPair
-	var walk func(n *sitter.Node)
-	walk = func(n *sitter.Node) {
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -183,10 +183,10 @@ type adminDecoratorRegister struct {
 // collectAdminDecoratorRegisterCalls scans the module for class definitions
 // whose decorator list includes `@admin.register(M [, M2, …])` and returns
 // the captured model list + admin class name.
-func collectAdminDecoratorRegisterCalls(root *sitter.Node, src []byte) []adminDecoratorRegister {
+func collectAdminDecoratorRegisterCalls(root ts.Node, src []byte) []adminDecoratorRegister {
 	var out []adminDecoratorRegister
-	var walk func(n *sitter.Node)
-	walk = func(n *sitter.Node) {
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -249,9 +249,9 @@ func collectAdminDecoratorRegisterCalls(root *sitter.Node, src []byte) []adminDe
 // that extends ModelAdmin / admin.ModelAdmin / TabularInline / StackedInline,
 // captures the canonical ModelAdmin attribute keys (list_display, etc.) as
 // flat properties on the class entity. Also tags @admin.action methods.
-func captureModelAdminProperties(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+func captureModelAdminProperties(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -312,7 +312,7 @@ func captureModelAdminProperties(root *sitter.Node, file extractor.FileInput, en
 }
 
 // handleAdminClass captures ModelAdmin properties on the matching class entity.
-func handleAdminClass(cd *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func handleAdminClass(cd ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	nameNode := cd.ChildByFieldName("name")
 	if nameNode == nil {
 		return
@@ -353,7 +353,7 @@ func handleAdminClass(cd *sitter.Node, parentClass string, file extractor.FileIn
 // classExtendsAdmin reports whether the class extends one of the Django
 // admin base classes: ModelAdmin, admin.ModelAdmin, TabularInline,
 // StackedInline, admin.TabularInline, admin.StackedInline.
-func classExtendsAdmin(cd *sitter.Node, src []byte) bool {
+func classExtendsAdmin(cd ts.Node, src []byte) bool {
 	supers := cd.ChildByFieldName("superclasses")
 	if supers == nil {
 		return false
@@ -375,7 +375,7 @@ func classExtendsAdmin(cd *sitter.Node, src []byte) bool {
 // method and, when found, stamps Properties["admin_action"]="true" plus the
 // captured description / permissions kwargs on the matching Operation
 // entity.
-func stampAdminActionOnMethod(decorated, inner *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func stampAdminActionOnMethod(decorated, inner ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	methodNameNode := inner.ChildByFieldName("name")
 	if methodNameNode == nil {
 		return

--- a/internal/extractors/python/django_drf_actions.go
+++ b/internal/extractors/python/django_drf_actions.go
@@ -46,7 +46,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -58,7 +58,7 @@ import (
 // matching Operation entity by Name ("<Class>.<method>").
 //
 // Mutates *entities in place. Safe to call with nil/empty input.
-func emitDRFActionProperties(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitDRFActionProperties(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -68,7 +68,7 @@ func emitDRFActionProperties(root *sitter.Node, file extractor.FileInput, entiti
 	walkDRFAction(root, "", file, entities)
 }
 
-func walkDRFAction(n *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func walkDRFAction(n ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if n == nil {
 		return
 	}
@@ -108,7 +108,7 @@ func walkDRFAction(n *sitter.Node, parentClass string, file extractor.FileInput,
 // decorated_definition wrapping a function_definition, scans the decorator
 // list for an `@action(...)` call. When found, the kwargs are parsed and
 // stamped on the matching SCOPE.Operation entity.
-func scanClassBodyForActions(body *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func scanClassBodyForActions(body ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	for i := 0; i < int(body.ChildCount()); i++ {
 		ch := body.Child(i)
 		if ch == nil || ch.Type() != "decorated_definition" {
@@ -178,7 +178,7 @@ func scanClassBodyForActions(body *sitter.Node, parentClass string, file extract
 // `@rest_framework.decorators.action(...)`, `@decorators.action(...)`).
 // Returns nil when no action decorator is present or the decorator is bare
 // (`@action` without parens).
-func findActionDecoratorCall(decoratedNode *sitter.Node, src []byte) *sitter.Node {
+func findActionDecoratorCall(decoratedNode ts.Node, src []byte) ts.Node {
 	for i := 0; i < int(decoratedNode.ChildCount()); i++ {
 		ch := decoratedNode.Child(i)
 		if ch == nil || ch.Type() != "decorator" {
@@ -210,7 +210,7 @@ func findActionDecoratorCall(decoratedNode *sitter.Node, src []byte) *sitter.Nod
 //	identifier            → "action"
 //	attribute (a.b.c)     → "c"
 //	dotted_name (a.b.c)   → "c"
-func decoratorLeaf(n *sitter.Node, src []byte) string {
+func decoratorLeaf(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -231,7 +231,7 @@ func decoratorLeaf(n *sitter.Node, src []byte) string {
 
 // parseActionKwargs reads the keyword arguments of an `@action(...)` call
 // node and returns the canonical property map.
-func parseActionKwargs(call *sitter.Node, src []byte) map[string]string {
+func parseActionKwargs(call ts.Node, src []byte) map[string]string {
 	out := map[string]string{}
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
@@ -294,7 +294,7 @@ func parseActionKwargs(call *sitter.Node, src []byte) map[string]string {
 // parseListLiteralStrings reads a Python `[ "a", "b" ]` or `( "a", "b" )`
 // node and returns the unquoted string literals it contains. Non-string
 // elements are skipped silently.
-func parseListLiteralStrings(n *sitter.Node, src []byte) []string {
+func parseListLiteralStrings(n ts.Node, src []byte) []string {
 	if n == nil {
 		return nil
 	}
@@ -325,7 +325,7 @@ func parseListLiteralStrings(n *sitter.Node, src []byte) []string {
 // parseListLiteralIdentifiers reads a Python `[ A, B.C ]` node and returns
 // the identifier-shaped elements as their full source text (so a dotted
 // attribute like `permissions.IsAdmin` survives intact).
-func parseListLiteralIdentifiers(n *sitter.Node, src []byte) []string {
+func parseListLiteralIdentifiers(n ts.Node, src []byte) []string {
 	if n == nil {
 		return nil
 	}

--- a/internal/extractors/python/django_drf_permissions.go
+++ b/internal/extractors/python/django_drf_permissions.go
@@ -45,7 +45,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -56,7 +56,7 @@ import (
 //
 // Safe to call on any class body — non-DRF classes simply have neither shape
 // and the function is a no-op.
-func applyDRFPermissionProperties(parent *types.EntityRecord, classBody *sitter.Node, src []byte) {
+func applyDRFPermissionProperties(parent *types.EntityRecord, classBody ts.Node, src []byte) {
 	if parent == nil || classBody == nil {
 		return
 	}
@@ -164,7 +164,7 @@ func stampDRFActionAuth(props map[string]string) {
 }
 
 // isGetPermissionsDef reports whether fnDef is `def get_permissions(self):`.
-func isGetPermissionsDef(fnDef *sitter.Node, src []byte) bool {
+func isGetPermissionsDef(fnDef ts.Node, src []byte) bool {
 	if fnDef == nil {
 		return false
 	}
@@ -180,7 +180,7 @@ func isGetPermissionsDef(fnDef *sitter.Node, src []byte) bool {
 // The result is a best-effort, deduplicated list of the bare identifier names
 // (e.g. "IsAuthenticated", "AllowAny", "CustomActionPermissionCheck"). The
 // auth_coverage detector decides which of those constitute real protection.
-func getPermissionsReferencedClasses(fnDef *sitter.Node, src []byte) []string {
+func getPermissionsReferencedClasses(fnDef ts.Node, src []byte) []string {
 	body := fnDef.ChildByFieldName("body")
 	if body == nil {
 		return nil
@@ -203,7 +203,7 @@ func getPermissionsReferencedClasses(fnDef *sitter.Node, src []byte) []string {
 // every `permission_classes = [...]` assignment (regardless of nesting depth —
 // these typically live inside if/elif branches), feeds the list-literal
 // identifiers to add. Falls through to `return [...]` expressions too.
-func collectPermissionAssignments(n *sitter.Node, src []byte, add func(string)) {
+func collectPermissionAssignments(n ts.Node, src []byte, add func(string)) {
 	if n == nil {
 		return
 	}

--- a/internal/extractors/python/django_relational.go
+++ b/internal/extractors/python/django_relational.go
@@ -58,7 +58,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -148,7 +148,7 @@ var djangoRelationalFieldTypes = map[string]struct{}{
 //	after        — len(*out) immediately before this function is invoked
 //	out          — entity slice pointer (in/out)
 func enrichDjangoModelFieldsAndManagers(
-	body *sitter.Node,
+	body ts.Node,
 	file extractor.FileInput,
 	parentClass string,
 	classIdx int,
@@ -319,7 +319,7 @@ func enrichDjangoModelFieldsAndManagers(
 func stampDjangoFieldProperties(
 	field *types.EntityRecord,
 	fieldType string,
-	callNode *sitter.Node,
+	callNode ts.Node,
 	src []byte,
 ) {
 	if field == nil || callNode == nil {
@@ -387,7 +387,7 @@ func stampDjangoFieldProperties(
 // class so `expand(<Model>)` lists itself as a neighbour where appropriate.
 //
 // Returns ("", "", false) when no resolvable positional/keyword target is found.
-func extractRelationalTargetName(callNode *sitter.Node, src []byte, parentClass string) (className, rawString string, isSelf bool) {
+func extractRelationalTargetName(callNode ts.Node, src []byte, parentClass string) (className, rawString string, isSelf bool) {
 	argsNode := callNode.ChildByFieldName("arguments")
 	if argsNode == nil {
 		return "", "", false
@@ -440,7 +440,7 @@ func extractRelationalTargetName(callNode *sitter.Node, src []byte, parentClass 
 // Returns ("", "", false) for shapes we don't recognise (callables,
 // conditional expressions, etc.) rather than emitting a malformed REFERENCES
 // edge.
-func parseTargetExpr(node *sitter.Node, src []byte, parentClass string) (className, rawString string, isSelf bool) {
+func parseTargetExpr(node ts.Node, src []byte, parentClass string) (className, rawString string, isSelf bool) {
 	if node == nil {
 		return "", "", false
 	}

--- a/internal/extractors/python/django_relational_test.go
+++ b/internal/extractors/python/django_relational_test.go
@@ -68,7 +68,7 @@ func extractDjango(t *testing.T, src string) []types.EntityRecord {
 		Path:     "client_fixture_a/models.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {

--- a/internal/extractors/python/drf_serializer_fields.go
+++ b/internal/extractors/python/drf_serializer_fields.go
@@ -55,7 +55,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -119,7 +119,7 @@ var drfScalarSerializerFieldTypes = map[string]struct{}{
 //	before/after — entity-slice window emitted by the body walk
 //	out          — entity slice pointer (in/out)
 func emitDRFSerializerFieldRefs(
-	body *sitter.Node,
+	body ts.Node,
 	file extractor.FileInput,
 	parentClass string,
 	classIdx int,
@@ -366,7 +366,7 @@ func metaModelLeaf(cls *types.EntityRecord) string {
 //	PrimaryKeyRelatedField(queryset=models.Foo.objects)    → "Foo"
 //	SlugRelatedField(queryset=Foo.objects.all(), slug_field="…") → "Foo"
 //	HyperlinkedRelatedField(queryset=Foo.objects.all(), view_name="…") → "Foo"
-func extractRelatedFieldTarget(callNode *sitter.Node, src []byte) string {
+func extractRelatedFieldTarget(callNode ts.Node, src []byte) string {
 	argsNode := callNode.ChildByFieldName("arguments")
 	if argsNode == nil {
 		return ""
@@ -397,7 +397,7 @@ func extractRelatedFieldTarget(callNode *sitter.Node, src []byte) string {
 // call chain (e.g. `Foo.objects.all()` → "Foo"; `models.Foo.objects` → "Foo"
 // — the latter takes the bare-model leaf when the leftmost is a module-style
 // lowercase identifier).
-func leftmostIdentifier(node *sitter.Node, src []byte) string {
+func leftmostIdentifier(node ts.Node, src []byte) string {
 	for node != nil {
 		switch node.Type() {
 		case "identifier":
@@ -439,7 +439,7 @@ func leftmostIdentifier(node *sitter.Node, src []byte) string {
 
 // lookupStringKwarg returns the unquoted value of a string-literal kwarg on
 // the given call, or "" when the kwarg is absent or not a string literal.
-func lookupStringKwarg(callNode *sitter.Node, src []byte, name string) string {
+func lookupStringKwarg(callNode ts.Node, src []byte, name string) string {
 	argsNode := callNode.ChildByFieldName("arguments")
 	if argsNode == nil {
 		return ""

--- a/internal/extractors/python/exception_flow.go
+++ b/internal/extractors/python/exception_flow.go
@@ -28,7 +28,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -39,7 +39,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input. raise/except at module scope attach to the file entity.
-func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -55,8 +55,8 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 		return stack[len(stack)-1]
 	}
 
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -142,10 +142,10 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 // bare-identifier raise to start with an uppercase letter before treating it
 // as a type. A call (`raise Foo()`) or qualified attribute (`raise mod.Foo`)
 // is an explicit construction/reference, so no case guard is applied there.
-func pyRaiseType(raiseNode *sitter.Node, src []byte) string {
+func pyRaiseType(raiseNode ts.Node, src []byte) string {
 	// The exception expression is the first named child; subsequent named
 	// children (e.g. the `from <cause>`) are ignored.
-	var expr *sitter.Node
+	var expr ts.Node
 	for i := 0; i < int(raiseNode.NamedChildCount()); i++ {
 		c := raiseNode.NamedChild(i)
 		if c == nil {
@@ -188,11 +188,11 @@ func startsUpper(s string) bool {
 // `except:` (bare) yields none; `except E:` yields {E}; `except (A, B):` yields
 // {A, B}. Each token is the bare class name (last dotted segment); dynamic
 // entries are dropped by NormalizeExceptionType downstream.
-func pyExceptTypes(exceptNode *sitter.Node, src []byte) []string {
+func pyExceptTypes(exceptNode ts.Node, src []byte) []string {
 	// The type expression is the first named child of the except_clause that
 	// is NOT the `as <name>` binding and NOT the body block. In the tree-sitter
 	// Python grammar the clause children are: [type_expr] [as identifier] block.
-	var typeExpr *sitter.Node
+	var typeExpr ts.Node
 	for i := 0; i < int(exceptNode.NamedChildCount()); i++ {
 		c := exceptNode.NamedChild(i)
 		if c == nil {
@@ -236,7 +236,7 @@ func pyExceptTypes(exceptNode *sitter.Node, src []byte) []string {
 // other shape (so dynamic raises drop). The bare name is returned verbatim;
 // NormalizeExceptionType (called inside EmitExceptionEdges) strips qualification
 // and rejects non-identifier tokens.
-func pyTypeFromExpr(n *sitter.Node, src []byte) string {
+func pyTypeFromExpr(n ts.Node, src []byte) string {
 	switch n.Type() {
 	case "identifier":
 		return strings.TrimSpace(nodeText(n, src))

--- a/internal/extractors/python/external_service.go
+++ b/internal/extractors/python/external_service.go
@@ -31,7 +31,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -43,7 +43,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input. SDK calls at module scope attach to the file entity.
-func emitServiceDependencyEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitServiceDependencyEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -63,8 +63,8 @@ func emitServiceDependencyEdges(root *sitter.Node, file extractor.FileInput, ent
 		return stack[len(stack)-1]
 	}
 
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -139,7 +139,7 @@ func emitServiceDependencyEdges(root *sitter.Node, file extractor.FileInput, ent
 //
 // Returns ok=false when no recognised SDK root is found (so non-SDK
 // `.create()` / `.send()` calls never fabricate an edge).
-func pyServiceCall(call *sitter.Node, src []byte, imports pythonImportMap, from string) (extractor.ServiceCall, bool) {
+func pyServiceCall(call ts.Node, src []byte, imports pythonImportMap, from string) (extractor.ServiceCall, bool) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return extractor.ServiceCall{}, false
@@ -194,7 +194,7 @@ func pyServiceCall(call *sitter.Node, src []byte, imports pythonImportMap, from 
 // ("stripe", "Charge.create"); for `boto3.client` it returns ("boto3",
 // "client"). Returns ("", "") when the chain does not root at a plain
 // identifier (e.g. a subscript or call in the middle).
-func pyAttributeRootAndTail(attr *sitter.Node, src []byte) (string, string) {
+func pyAttributeRootAndTail(attr ts.Node, src []byte) (string, string) {
 	var parts []string
 	node := attr
 	for node != nil && node.Type() == "attribute" {
@@ -216,7 +216,7 @@ func pyAttributeRootAndTail(attr *sitter.Node, src []byte) (string, string) {
 // boto3.resource(...) call: the first positional argument, when a string
 // literal, is mapped via AWSServiceFromArg. A non-literal (dynamic variable)
 // argument yields aws-generic; an unrecognised literal yields "" (drop).
-func pyAWSServiceFromCall(call *sitter.Node, src []byte) string {
+func pyAWSServiceFromCall(call ts.Node, src []byte) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return extractor.ServiceAWSGeneric

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -30,12 +30,11 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tspython "github.com/smacker/go-tree-sitter/python"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -102,16 +101,24 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		return nil, nil
 	}
 
-	// Parse with a fresh parser when tree is nil (e.g. in tests or malformed input).
-	tree := file.Tree
+	// If a pre-parsed tree was supplied by the pipeline, reuse it. Otherwise
+	// parse inline via the language's grammar adapter — this path is for direct
+	// test callers that hand the extractor raw content with no tree (B2 #5418).
+	tree := file.TSTree
 	if tree == nil {
-		parser := sitter.NewParser()
-		parser.SetLanguage(tspython.GetLanguage())
-		var parseErr error
-		tree, parseErr = parser.ParseCtx(ctx, nil, file.Content)
+		parser, parseErr := pythonAdapter.NewParser(pythonGrammar())
+		if parseErr != nil {
+			return nil, fmt.Errorf("python extractor: parser init failed: %w", parseErr)
+		}
+		defer parser.Close()
+		tree, parseErr = parser.Parse(file.Content)
 		if parseErr != nil {
 			return nil, fmt.Errorf("python extractor: parse failed: %w", parseErr)
 		}
+		if tree == nil {
+			return nil, fmt.Errorf("python extractor: parse produced nil tree")
+		}
+		defer tree.Close()
 	}
 
 	root := tree.RootNode()
@@ -600,7 +607,7 @@ func isDjangoMigrationFile(path string) bool {
 // Issue #68 — multi-level nesting is preserved by appending each enclosing
 // class name with a "." separator as the walker descends.
 func walkNode(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	parentClass string,
 	out *[]types.EntityRecord,
@@ -930,7 +937,7 @@ func walkNode(
 // When a human-friendly label is available from the filename stem and differs
 // from the AST name, it is stored in Properties["display_name"] so MCP
 // consumers can surface both, but the Name field is never overwritten.
-func buildClass(node *sitter.Node, file extractor.FileInput) types.EntityRecord {
+func buildClass(node ts.Node, file extractor.FileInput) types.EntityRecord {
 	nameNode := node.ChildByFieldName("name")
 	if nameNode == nil {
 		return types.EntityRecord{}
@@ -1017,7 +1024,7 @@ func toPascalCase(s string) string {
 // form is the same encoding used by Format B structural references and is
 // indexed natively by resolve.Index.byMember, which splits Name on the LAST
 // '.' to preserve multi-level scopes.
-func buildFunction(node *sitter.Node, file extractor.FileInput, parentClass string) types.EntityRecord {
+func buildFunction(node ts.Node, file extractor.FileInput, parentClass string) types.EntityRecord {
 	nameNode := node.ChildByFieldName("name")
 	if nameNode == nil {
 		return types.EntityRecord{}
@@ -1092,7 +1099,7 @@ func buildFunction(node *sitter.Node, file extractor.FileInput, parentClass stri
 // module-level functions). It is used to qualify `self.X` calls and to
 // detect when an inferred class-qualified target is in fact self-recursion.
 func extractCallRelationships(
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	callerName, parentClass string,
 	imports pythonImportMap,
@@ -1284,7 +1291,7 @@ var osExecLeaves = map[string]struct{}{
 //
 // Bare `system(...)` / `run(...)` without a module receiver are NOT matched —
 // those could be user functions and the normal resolver should handle them.
-func isSubprocessExecCall(call *sitter.Node, src []byte, imports pythonImportMap) bool {
+func isSubprocessExecCall(call ts.Node, src []byte, imports pythonImportMap) bool {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "attribute" {
 		return false
@@ -1341,7 +1348,7 @@ func isSubprocessExecCall(call *sitter.Node, src []byte, imports pythonImportMap
 //
 // `os.spawn*` takes a mode argument first; we scan for the first string/list
 // literal among the positional arguments rather than assuming arg index 0.
-func subprocessBinaryName(call *sitter.Node, src []byte) string {
+func subprocessBinaryName(call ts.Node, src []byte) string {
 	argsNode := call.ChildByFieldName("arguments")
 	if argsNode == nil {
 		return ""
@@ -1410,7 +1417,7 @@ func binaryFromProgramPath(p string) string {
 // `string` node with its surrounding quotes (and any prefix like r/f/b)
 // stripped. f-strings with interpolations are returned with the raw body so
 // callers can decide whether the result is statically usable.
-func pyStringLiteralValue(n *sitter.Node, src []byte) string {
+func pyStringLiteralValue(n ts.Node, src []byte) string {
 	// Prefer the string_content child when present (grammar ≥ 0.20 splits the
 	// literal into string_start / string_content / string_end).
 	for i := 0; i < int(n.NamedChildCount()); i++ {
@@ -1479,7 +1486,7 @@ func pyStringLiteralValue(n *sitter.Node, src []byte) string {
 // different type), and a non-PascalCase RHS constructor (factory function,
 // lowercased helper) yields no entry. Returns nil for bodies with no
 // qualifying binding so the hot path allocates nothing.
-func localReceiverTypes(body *sitter.Node, src []byte) map[string]string {
+func localReceiverTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -1522,7 +1529,7 @@ func localReceiverTypes(body *sitter.Node, src []byte) map[string]string {
 	return locals
 }
 
-func callTarget(call *sitter.Node, src []byte, parentClass string, localRecv map[string]string) (string, bool) {
+func callTarget(call ts.Node, src []byte, parentClass string, localRecv map[string]string) (string, bool) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return "", false
@@ -1579,7 +1586,7 @@ func callTarget(call *sitter.Node, src []byte, parentClass string, localRecv map
 // deliberately left unresolved here: making a guess would risk binding edges
 // to the wrong class. The resolver's name-collision logic is a safer place
 // to disambiguate those cases.
-func receiverClass(recv *sitter.Node, src []byte, parentClass string, localRecv map[string]string) string {
+func receiverClass(recv ts.Node, src []byte, parentClass string, localRecv map[string]string) string {
 	if recv == nil {
 		return ""
 	}
@@ -1687,7 +1694,7 @@ func isPascalCaseClassName(name string) bool {
 //	                              inside the source module. Equal to
 //	                              local_name when no alias is present.
 //	Properties["wildcard"]      — "1" when the import is `from x import *`.
-func extractImports(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractImports(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	if root == nil {
 		return nil
 	}
@@ -1774,7 +1781,7 @@ func extractImports(root *sitter.Node, file extractor.FileInput) []types.EntityR
 // path is the dotted import path stripped of any "as <alias>" suffix; alias
 // is the binding identifier introduced by `as` (or "" when not present).
 // Wildcards return ("*", ""). Unrecognised shapes return ("", "").
-func dottedNameAndAlias(node *sitter.Node, src []byte) (string, string) {
+func dottedNameAndAlias(node ts.Node, src []byte) (string, string) {
 	if node == nil {
 		return "", ""
 	}
@@ -1797,7 +1804,7 @@ func dottedNameAndAlias(node *sitter.Node, src []byte) (string, string) {
 // dottedNamePath flattens a dotted_name / identifier / aliased_import node into
 // its source-text path. Aliases are stripped (only the underlying name is used).
 // Returns "" for unrecognised node shapes.
-func dottedNamePath(node *sitter.Node, src []byte) string {
+func dottedNamePath(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -1891,7 +1898,7 @@ func pyFieldSignature(name, typeAnn string) string {
 }
 
 func extractClassFields(
-	body *sitter.Node,
+	body ts.Node,
 	file extractor.FileInput,
 	parentClass string,
 	out *[]types.EntityRecord,
@@ -1914,7 +1921,7 @@ func extractClassFields(
 			if expr == nil {
 				continue
 			}
-			var lhs *sitter.Node
+			var lhs ts.Node
 			var typeAnn string
 			switch expr.Type() {
 			case "assignment":
@@ -1987,7 +1994,7 @@ func extractClassFields(
 //	self.x         → []                             (attribute LHS — not a
 //	                                                 class attribute)
 //	x[0]           → []                             (subscript LHS)
-func classAttrLHSNames(lhs *sitter.Node, src []byte) []string {
+func classAttrLHSNames(lhs ts.Node, src []byte) []string {
 	if lhs == nil {
 		return nil
 	}
@@ -2054,7 +2061,7 @@ func skipClassAttrName(name string) bool {
 func applyFrameworkInnerClassProperties(
 	parent *types.EntityRecord,
 	innerClass *types.EntityRecord,
-	classBody *sitter.Node,
+	classBody ts.Node,
 	src []byte,
 	childParent string,
 ) {
@@ -2076,7 +2083,7 @@ func applyFrameworkInnerClassProperties(
 
 	// Find the class_definition node inside classBody that matches innerClass
 	// by start line so we can walk its body for key-value assignments.
-	var innerBody *sitter.Node
+	var innerBody ts.Node
 	for i := range int(classBody.ChildCount()) {
 		ch := classBody.Child(i)
 		if ch == nil {
@@ -2085,7 +2092,7 @@ func applyFrameworkInnerClassProperties(
 		// The inner class may be a bare class_definition or wrapped in a
 		// decorated_definition. In practice Meta/Config are never decorated,
 		// but handle both for robustness.
-		var candidate *sitter.Node
+		var candidate ts.Node
 		switch ch.Type() {
 		case "class_definition":
 			candidate = ch
@@ -2170,7 +2177,7 @@ func applyFrameworkInnerClassProperties(
 // map[identifier]rawValue for every simple `identifier = expr` assignment. The
 // value is the raw source text of the right-hand side, trimmed of whitespace.
 // Only the top-level body scope is examined; nested blocks are skipped.
-func parseSimpleAssignments(body *sitter.Node, src []byte) map[string]string {
+func parseSimpleAssignments(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -2220,12 +2227,12 @@ func stripQuotes(v string) string {
 
 // findAll returns every descendant of root whose Type() matches kind.
 // Recursion is iterative to stay safe on deeply-nested trees.
-func findAll(root *sitter.Node, kind string) []*sitter.Node {
+func findAll(root ts.Node, kind string) []ts.Node {
 	if root == nil {
 		return nil
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -2267,7 +2274,7 @@ func findAll(root *sitter.Node, kind string) []*sitter.Node {
 // The function is a no-op when innerClassName does not end in ".Meta" or when
 // no `constraints = [...]` assignment is present in the Meta body.
 func extractMetaConstraintEntities(
-	metaClassBody *sitter.Node,
+	metaClassBody ts.Node,
 	file extractor.FileInput,
 	innerClassName string,
 	parentClass string,
@@ -2285,13 +2292,13 @@ func extractMetaConstraintEntities(
 
 	// Locate the Meta class_definition node inside metaClassBody so we can
 	// walk its body for the `constraints = [...]` assignment.
-	var metaBody *sitter.Node
+	var metaBody ts.Node
 	for i := range int(metaClassBody.ChildCount()) {
 		ch := metaClassBody.Child(i)
 		if ch == nil {
 			continue
 		}
-		var candidate *sitter.Node
+		var candidate ts.Node
 		switch ch.Type() {
 		case "class_definition":
 			candidate = ch
@@ -2427,6 +2434,6 @@ func extractMetaConstraintEntities(
 }
 
 // nodeText returns the raw source bytes for a tree-sitter node as a string.
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	return string(src[node.StartByte():node.EndByte()])
 }

--- a/internal/extractors/python/extractor_test.go
+++ b/internal/extractors/python/extractor_test.go
@@ -8,21 +8,28 @@ import (
 	"testing"
 	"time"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tspython "github.com/smacker/go-tree-sitter/python"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 	// Blank import to trigger init() registration.
 	_ "github.com/cajasmota/grafel/internal/extractors/python"
 )
 
-// parse is a test helper that parses Python source with tree-sitter.
-func parse(t *testing.T, src []byte) *sitter.Tree {
+// parse parses Python source into a binding-agnostic ts.Tree via the smacker
+// adapter. Tests stamp the result on FileInput.TSTree (which the migrated Python
+// extractor consumes). Using the smacker adapter keeps these tests linkable in
+// the default build while exercising the ts façade (B2 #5418).
+func parse(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tspython.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tspython.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -41,7 +48,7 @@ func extractPy(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -50,12 +57,12 @@ func extractPy(t *testing.T, src, path string) []types.EntityRecord {
 }
 
 // makeFile builds a FileInput for tests.
-func makeFile(src string, tree *sitter.Tree) extractor.FileInput {
+func makeFile(src string, tree ts.Tree) extractor.FileInput {
 	return extractor.FileInput{
 		Path:     "test.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 }
 
@@ -152,7 +159,7 @@ class Bar:
 		Path:     "app/orders/handlers.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {
@@ -321,7 +328,7 @@ func TestExtract_EmptyFile(t *testing.T) {
 		Path:     "empty.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     nil, // nil tree: extractor must handle gracefully
+		TSTree:   nil, // nil tree: extractor must handle gracefully
 	})
 	if err != nil {
 		t.Fatalf("Extract on empty file: unexpected error: %v", err)
@@ -378,7 +385,7 @@ func TestExtract_NilTree(t *testing.T) {
 		Path:     "standalone.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     nil, // extractor must parse internally
+		TSTree:   nil, // extractor must parse internally
 	})
 	if err != nil {
 		t.Fatalf("Extract with nil tree: %v", err)
@@ -548,7 +555,7 @@ func TestExtract_BinaryContent(t *testing.T) {
 			Path:     "binary.py",
 			Content:  binary,
 			Language: "python",
-			Tree:     nil,
+			TSTree:   nil,
 		})
 		if err != nil {
 			t.Logf("binary input returned error (acceptable): %v", err)
@@ -673,7 +680,7 @@ func TestExtract_DuplicateMethodsFromFixture(t *testing.T) {
 		Path:     path,
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -730,7 +737,7 @@ func TestExtract_ControlFlowMethodsInheritClassQualifier(t *testing.T) {
 		Path:     path,
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -817,7 +824,7 @@ func TestExtract_ClassSubtypeLabels(t *testing.T) {
 		Path:     path,
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -888,7 +895,7 @@ func TestExtract_NestedClassesFromFixture(t *testing.T) {
 		Path:     path,
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -1797,7 +1804,7 @@ class Migration(migrations.Migration):
 	tree := parse(t, []byte(src))
 	migEnts, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path: "core/migrations/0042_device_serial.py", Content: []byte(src),
-		Language: "python", Tree: tree,
+		Language: "python", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("extract migration: %v", err)
@@ -1827,7 +1834,7 @@ class Migration(migrations.Migration):
 	tree2 := parse(t, []byte(src))
 	normEnts, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path: "core/models/device.py", Content: []byte(src),
-		Language: "python", Tree: tree2,
+		Language: "python", TSTree: tree2,
 	})
 	if err != nil {
 		t.Fatalf("extract normal: %v", err)
@@ -1864,7 +1871,7 @@ func TestExtract_DjangoMigrationFixtures(t *testing.T) {
 		Path:     "core/migrations/0042_device_serial_number.py",
 		Content:  migSrc,
 		Language: "python",
-		Tree:     parse(t, migSrc),
+		TSTree:   parse(t, migSrc),
 	})
 	if err != nil {
 		t.Fatalf("extract django_migration fixture: %v", err)
@@ -1911,7 +1918,7 @@ func TestExtract_DjangoMigrationFixtures(t *testing.T) {
 		Path:     "core/models.py",
 		Content:  modSrc,
 		Language: "python",
-		Tree:     parse(t, modSrc),
+		TSTree:   parse(t, modSrc),
 	})
 	if err != nil {
 		t.Fatalf("extract django_models fixture: %v", err)
@@ -1997,7 +2004,7 @@ class Migration(migrations.Migration):
 	path := "accounts/migrations/0044_user_cognito_id.py"
 	tree := parse(t, []byte(src))
 	ents, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: path, Content: []byte(src), Language: "python", Tree: tree,
+		Path: path, Content: []byte(src), Language: "python", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -2097,7 +2104,7 @@ class b:
 		Path:     filePath,
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/python/field_type_4868_test.go
+++ b/internal/extractors/python/field_type_4868_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tspython "github.com/smacker/go-tree-sitter/python"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/python"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
 func TestExtract_AnnotatedFieldSignature_4868(t *testing.T) {
@@ -23,9 +23,12 @@ class CreateAddressBody:
     building: int
     group: int | None
 `)
-	p := sitter.NewParser()
-	p.SetLanguage(tspython.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	p, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tspython.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer p.Close()
+	tree, err := p.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -33,7 +36,7 @@ class CreateAddressBody:
 		Path:     "core/dto/address.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	ext, _ := extractor.Get("python")
 	ents, err := ext.Extract(context.Background(), fi)

--- a/internal/extractors/python/field_validations.go
+++ b/internal/extractors/python/field_validations.go
@@ -47,7 +47,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -121,7 +121,7 @@ var pydanticConstrainedTypes = map[string]struct{}{
 // Parameters mirror emitDRFSerializerFieldRefs: the [before, after) window
 // bounds the slice region holding this class's field entities.
 func emitPythonFieldValidations(
-	body *sitter.Node,
+	body ts.Node,
 	file extractor.FileInput,
 	parentClass string,
 	classIdx int,
@@ -220,8 +220,8 @@ func emitPythonFieldValidations(
 // single field declaration: the RHS value when it is a recognised constraint
 // call, plus any Field()/constrained-type call embedded in the annotation
 // (Annotated[T, Field(...)] or a bare conint(...)/constr(...) annotation).
-func constraintCalls(annot, rhs *sitter.Node, src []byte) []*sitter.Node {
-	var calls []*sitter.Node
+func constraintCalls(annot, rhs ts.Node, src []byte) []ts.Node {
+	var calls []ts.Node
 	if rhs != nil && rhs.Type() == "call" {
 		calls = append(calls, rhs)
 	}
@@ -241,7 +241,7 @@ func constraintCalls(annot, rhs *sitter.Node, src []byte) []*sitter.Node {
 // that look like Field(...) or a Pydantic constrained-type constructor. It
 // recurses through generic_type / type_parameter so Annotated[str, Field(...)]
 // and Optional[conint(gt=0)] are reached.
-func collectAnnotationCalls(n *sitter.Node, src []byte, out *[]*sitter.Node) {
+func collectAnnotationCalls(n ts.Node, src []byte, out *[]ts.Node) {
 	if n == nil {
 		return
 	}
@@ -258,7 +258,7 @@ func collectAnnotationCalls(n *sitter.Node, src []byte, out *[]*sitter.Node) {
 
 // isConstraintCall reports whether a call node is a Pydantic Field(...) or a
 // recognised constrained-type constructor.
-func isConstraintCall(call *sitter.Node, src []byte) bool {
+func isConstraintCall(call ts.Node, src []byte) bool {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return false
@@ -273,7 +273,7 @@ func isConstraintCall(call *sitter.Node, src []byte) bool {
 
 // callConstraintChips derives the constraint chips for a single recognised
 // constraint call (Pydantic Field()/con*() or a DRF serializers.X()).
-func callConstraintChips(call *sitter.Node, src []byte) []string {
+func callConstraintChips(call ts.Node, src []byte) []string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return nil
@@ -340,7 +340,7 @@ func callConstraintChips(call *sitter.Node, src []byte) []string {
 }
 
 // drfBoolChip2chip maps a DRF boolean kwarg's value to its chip (or "").
-func drfBoolChip2chip(bc drfBoolChip, val *sitter.Node, src []byte) string {
+func drfBoolChip2chip(bc drfBoolChip, val ts.Node, src []byte) string {
 	if val == nil {
 		return ""
 	}
@@ -355,7 +355,7 @@ func drfBoolChip2chip(bc drfBoolChip, val *sitter.Node, src []byte) string {
 
 // callHasEllipsisArg reports whether the call has a leading `...` positional
 // argument (Pydantic Field(..., …) → required).
-func callHasEllipsisArg(call *sitter.Node) bool {
+func callHasEllipsisArg(call ts.Node) bool {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return false
@@ -380,7 +380,7 @@ func callHasEllipsisArg(call *sitter.Node) bool {
 
 // callLeafName returns the trailing identifier of a call's function node
 // (`serializers.CharField` → "CharField", `Field` → "Field").
-func callLeafName(fn *sitter.Node, src []byte) string {
+func callLeafName(fn ts.Node, src []byte) string {
 	if fn == nil {
 		return ""
 	}
@@ -398,7 +398,7 @@ func callLeafName(fn *sitter.Node, src []byte) string {
 // annotationIsOptional reports whether an annotation expression denotes an
 // Optional value: `Optional[...]`, `Optional`, or a `X | None` / `None | X`
 // union.
-func annotationIsOptional(annot *sitter.Node, src []byte) bool {
+func annotationIsOptional(annot ts.Node, src []byte) bool {
 	text := nodeText(annot, src)
 	if strings.Contains(text, "Optional[") || text == "Optional" {
 		return true
@@ -415,7 +415,7 @@ func annotationIsOptional(annot *sitter.Node, src []byte) bool {
 // name as string positional arguments. `@field_validator("name", "email")` →
 // {"name","email"}. `@validator("*")` is ignored (too broad for a per-field
 // marker).
-func collectValidatorFieldTargets(body *sitter.Node, src []byte) map[string]bool {
+func collectValidatorFieldTargets(body ts.Node, src []byte) map[string]bool {
 	out := map[string]bool{}
 	for i := 0; i < int(body.ChildCount()); i++ {
 		stmt := body.Child(i)
@@ -460,7 +460,7 @@ func collectValidatorFieldTargets(body *sitter.Node, src []byte) map[string]bool
 }
 
 // firstNamedChild returns the first named child of a node, or nil.
-func firstNamedChild(n *sitter.Node) *sitter.Node {
+func firstNamedChild(n ts.Node) ts.Node {
 	if n == nil || n.NamedChildCount() == 0 {
 		return nil
 	}
@@ -469,7 +469,7 @@ func firstNamedChild(n *sitter.Node) *sitter.Node {
 
 // leafIdentText returns the trailing identifier of an identifier/attribute
 // node (`pydantic.field_validator` → "field_validator").
-func leafIdentText(n *sitter.Node, src []byte) string {
+func leafIdentText(n ts.Node, src []byte) string {
 	t := nodeText(n, src)
 	if dot := strings.LastIndexByte(t, '.'); dot >= 0 {
 		return t[dot+1:]
@@ -482,7 +482,7 @@ func leafIdentText(n *sitter.Node, src []byte) string {
 // (strings with commas, regexes, expressions) yield "" so the caller folds a
 // bare marker instead. Strings are dropped (they may contain commas which
 // would corrupt the comma-joined property).
-func scalarText(val *sitter.Node, src []byte) string {
+func scalarText(val ts.Node, src []byte) string {
 	if val == nil {
 		return ""
 	}

--- a/internal/extractors/python/getattr_dispatch.go
+++ b/internal/extractors/python/getattr_dispatch.go
@@ -36,7 +36,7 @@ package python
 import (
 	"strconv"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -49,7 +49,7 @@ import (
 // (target,alias) dedup set bridged from the primary call pass so we never
 // double-emit an edge the direct path already produced.
 func extractGetattrDispatchCalls(
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	parentClass, callerName string,
 	seen map[seenKeyDD]bool,
@@ -66,8 +66,8 @@ func extractGetattrDispatchCalls(
 	binder := extractor.NewLiteralBindingResolver(nil)
 	var rels []types.RelationshipRecord
 
-	var walk func(n *sitter.Node)
-	walk = func(n *sitter.Node) {
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -114,7 +114,7 @@ func extractGetattrDispatchCalls(
 // binder: a bare string-literal RHS Binds; any other RHS Taints. Multi-target /
 // augmented / annotated assignments and non-identifier targets are ignored
 // (they neither establish nor reliably clear a simple-name binding).
-func recordPyAssignment(n *sitter.Node, src []byte, binder *extractor.LiteralBindingResolver) {
+func recordPyAssignment(n ts.Node, src []byte, binder *extractor.LiteralBindingResolver) {
 	// assignment children: identifier, "=", <rhs>  (simple form).
 	if n.ChildCount() < 3 {
 		return
@@ -144,7 +144,7 @@ func recordPyAssignment(n *sitter.Node, src []byte, binder *extractor.LiteralBin
 // string literal, returns (method, dynVar, true). dynVar is the source variable
 // name for the binder-resolved form, or "" for the inline-string form. Returns
 // ("","",false) for any other call.
-func getattrDispatchTarget(outer *sitter.Node, src []byte, binder *extractor.LiteralBindingResolver) (string, string, bool) {
+func getattrDispatchTarget(outer ts.Node, src []byte, binder *extractor.LiteralBindingResolver) (string, string, bool) {
 	// Outer call's function child must itself be the `getattr(self, X)` call.
 	fn := outer.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "call" {
@@ -159,7 +159,7 @@ func getattrDispatchTarget(outer *sitter.Node, src []byte, binder *extractor.Lit
 		return "", "", false
 	}
 	// Collect the two positional argument nodes (named children, comma-separated).
-	var pos []*sitter.Node
+	var pos []ts.Node
 	for i := 0; i < int(args.NamedChildCount()); i++ {
 		ch := args.NamedChild(i)
 		if ch != nil {

--- a/internal/extractors/python/grammar.go
+++ b/internal/extractors/python/grammar.go
@@ -1,0 +1,25 @@
+package python
+
+import (
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
+	tspython "github.com/smacker/go-tree-sitter/python"
+)
+
+// Python grammar provider for the extractor's inline-parse fallback (B2 Phase 1,
+// #5418, ADR 0023). The extractor traverses the binding-agnostic ts façade; this
+// is the single place that names a concrete binding.
+//
+// Python is smacker-backed in BOTH build configurations for now: unlike Go (B2
+// Phase 0), it has no official-binding grammar module yet, so there is no
+// ts_official variant to tag-split against. When Python is promoted to the
+// official runtime (a later B2 phase), this file becomes a build-tagged pair
+// (language_smacker.go / language_official.go) exactly like the Go extractor.
+//
+// Keeping it untagged means `go build` and `go build -tags ts_official` both
+// compile the Python extractor unchanged — the official tag only affects which
+// grammars are routed off smacker (currently just Go), not Python.
+
+func pythonGrammar() ts.Language { return tssmacker.WrapLanguage(tspython.GetLanguage()) }
+
+var pythonAdapter = tssmacker.New()

--- a/internal/extractors/python/migration_gate_test.go
+++ b/internal/extractors/python/migration_gate_test.go
@@ -14,18 +14,21 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 	tspython "github.com/smacker/go-tree-sitter/python"
 )
 
-// parsePython parses Python source using tree-sitter and returns the parse tree.
-func parsePython(t *testing.T, src []byte) *sitter.Tree {
+// parsePython parses Python source into a ts.Tree via the smacker adapter (B2 #5418).
+func parsePython(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tspython.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
 	defer parser.Close()
-	parser.SetLanguage(tspython.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, src)
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse error: %v", err)
 	}
@@ -36,14 +39,14 @@ func parsePython(t *testing.T, src []byte) *sitter.Tree {
 }
 
 // extractPythonWithPath extracts entities from Python source with the given file path.
-func extractPythonWithPath(t *testing.T, src []byte, path string, tree *sitter.Tree) []types.EntityRecord {
+func extractPythonWithPath(t *testing.T, src []byte, path string, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	ext := &Extractor{}
 	file := extractor.FileInput{
 		Path:     path,
 		Language: "python",
 		Content:  src,
-		Tree:     tree,
+		TSTree:   tree,
 		RepoRoot: "/test",
 	}
 	entities, err := ext.Extract(context.Background(), file)

--- a/internal/extractors/python/nested_ctor_refs.go
+++ b/internal/extractors/python/nested_ctor_refs.go
@@ -58,7 +58,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -86,7 +86,7 @@ type nestedEdgeKey struct{ from, to string }
 // call-callee + attribute-receiver shapes that REFERENCES skipped).
 //
 // Safe to call with nil/empty inputs.
-func emitNestedConstructorRefs(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitNestedConstructorRefs(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -198,8 +198,8 @@ func emitNestedConstructorRefs(root *sitter.Node, file extractor.FileInput, enti
 	//      body); the enclosing entity is the method.
 	//
 	// Nested classes recurse with the dotted parent name.
-	var walkClass func(classNode *sitter.Node, parentClass string)
-	walkClass = func(classNode *sitter.Node, parentClass string) {
+	var walkClass func(classNode ts.Node, parentClass string)
+	walkClass = func(classNode ts.Node, parentClass string) {
 		if classNode == nil {
 			return
 		}
@@ -265,8 +265,8 @@ func emitNestedConstructorRefs(root *sitter.Node, file extractor.FileInput, enti
 
 	// Top-level walk: find every class_definition (including those
 	// wrapped in a decorated_definition) and process it.
-	var walkTop func(n *sitter.Node)
-	walkTop = func(n *sitter.Node) {
+	var walkTop func(n ts.Node)
+	walkTop = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -294,7 +294,7 @@ func emitNestedConstructorRefs(root *sitter.Node, file extractor.FileInput, enti
 // inside method bodies). The enclosing entity is the method itself,
 // looked up by emitted Name "<parentClass>.<methodLeaf>".
 func scanMethodForClassRefs(
-	fnNode *sitter.Node,
+	fnNode ts.Node,
 	file extractor.FileInput,
 	parentClass string,
 	classTargets map[string]classRefTarget,
@@ -347,7 +347,7 @@ func scanMethodForClassRefs(
 // lower-case-callable case (function calls) that the CALLS pass owns
 // and avoids spurious REFERENCES to local variables.
 func scanNodeForClassRefs(
-	node *sitter.Node,
+	node ts.Node,
 	src []byte,
 	classTargets map[string]classRefTarget,
 	onMatch func(leaf string, t classRefTarget),
@@ -377,7 +377,7 @@ func scanNodeForClassRefs(
 // or an `attribute` node whose final leaf is the class name. Anything
 // else (subscripts, lambdas, conditional_expression, etc.) is ignored.
 func tryEmitClassRef(
-	fnOrObj *sitter.Node,
+	fnOrObj ts.Node,
 	src []byte,
 	classTargets map[string]classRefTarget,
 	onMatch func(leaf string, t classRefTarget),

--- a/internal/extractors/python/observability.go
+++ b/internal/extractors/python/observability.go
@@ -48,7 +48,7 @@ package python
 import (
 	"strconv"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -101,7 +101,7 @@ var pyPrometheusInstrumentMethods = map[string]bool{
 // assignments are considered; the registry is used to resolve `@METRIC.time()`
 // decorators and `METRIC.inc()` body calls to a metric name. Returns nil when no
 // metric is declared (zero cost for files that don't use Prometheus).
-func buildPyMetricRegistry(root *sitter.Node, src []byte) pyMetricRegistry {
+func buildPyMetricRegistry(root ts.Node, src []byte) pyMetricRegistry {
 	if root == nil {
 		return nil
 	}
@@ -152,7 +152,7 @@ func buildPyMetricRegistry(root *sitter.Node, src []byte) pyMetricRegistry {
 // pyCallFunctionName returns the bare callee name of a `call` node, handling both
 // a plain identifier callee (`Summary(...)`) and an attribute callee
 // (`prom.Summary(...)` → "Summary"). Returns "" when the callee is neither.
-func pyCallFunctionName(call *sitter.Node, src []byte) string {
+func pyCallFunctionName(call ts.Node, src []byte) string {
 	if call == nil || call.Type() != "call" {
 		return ""
 	}
@@ -174,7 +174,7 @@ func pyCallFunctionName(call *sitter.Node, src []byte) string {
 // extractPyInstrHits collects every non-OTel instrumentation site for a function
 // from its decorators (decoratorParent, when non-nil) and its body. metricReg
 // resolves Prometheus metric variables to metric names.
-func extractPyInstrHits(funcNode, decoratorParent *sitter.Node, enclosingName string, metricReg pyMetricRegistry, src []byte) []pyInstrHit {
+func extractPyInstrHits(funcNode, decoratorParent ts.Node, enclosingName string, metricReg pyMetricRegistry, src []byte) []pyInstrHit {
 	if funcNode == nil {
 		return nil
 	}
@@ -208,12 +208,12 @@ func extractPyInstrHits(funcNode, decoratorParent *sitter.Node, enclosingName st
 // (@... attached to a function). Handles ddtrace `@tracer.wrap`, Sentry
 // `@sentry_sdk.trace`, New Relic `@function_trace`/`@background_task`/
 // `@newrelic.agent.function_trace`, and Prometheus `@METRIC.time()`.
-func pyDecoratorInstrHits(dec *sitter.Node, enclosingName string, metricReg pyMetricRegistry, src []byte) []pyInstrHit {
+func pyDecoratorInstrHits(dec ts.Node, enclosingName string, metricReg pyMetricRegistry, src []byte) []pyInstrHit {
 	// A decorator child is either an `attribute`/`identifier` (bare @x.y / @x)
 	// or a `call` (@x(...)). Resolve the dotted path of the decorator callee and
 	// its argument list (when present).
-	var calleeNode *sitter.Node // identifier/attribute being applied
-	var argsNode *sitter.Node   // argument_list when the decorator is a call
+	var calleeNode ts.Node // identifier/attribute being applied
+	var argsNode ts.Node   // argument_list when the decorator is a call
 
 	for i := 0; i < int(dec.ChildCount()); i++ {
 		ch := dec.Child(i)
@@ -292,7 +292,7 @@ func pyDecoratorInstrHits(dec *sitter.Node, enclosingName string, metricReg pyMe
 // (ddtrace `tracer.trace(...)`, Sentry `start_transaction`/`start_span`) or a
 // Prometheus metric mutation (`METRIC.inc()` / `.observe()` / `.set()` on a known
 // metric var). Returns false when the call is not an instrumentation call.
-func pyBodyInstrHit(call *sitter.Node, metricReg pyMetricRegistry, src []byte) (pyInstrHit, bool) {
+func pyBodyInstrHit(call ts.Node, metricReg pyMetricRegistry, src []byte) (pyInstrHit, bool) {
 	if call == nil || call.Type() != "call" {
 		return pyInstrHit{}, false
 	}
@@ -360,7 +360,7 @@ func pyBodyInstrHit(call *sitter.Node, metricReg pyMetricRegistry, src []byte) (
 // pyAttrLeaf returns the last dotted segment of an identifier/attribute node:
 // `tracer.wrap` → "wrap", `newrelic.agent.function_trace` → "function_trace",
 // a bare `foo` → "foo".
-func pyAttrLeaf(n *sitter.Node, src []byte) string {
+func pyAttrLeaf(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -378,7 +378,7 @@ func pyAttrLeaf(n *sitter.Node, src []byte) string {
 // pyAttrReceiverName returns the identifier name of the immediate receiver of an
 // attribute node: `REQUEST_TIME.time` → "REQUEST_TIME". Returns "" when the
 // receiver is not a bare identifier (e.g. a nested attribute or a call).
-func pyAttrReceiverName(n *sitter.Node, src []byte) string {
+func pyAttrReceiverName(n ts.Node, src []byte) string {
 	if n == nil || n.Type() != "attribute" {
 		return ""
 	}
@@ -392,7 +392,7 @@ func pyAttrReceiverName(n *sitter.Node, src []byte) string {
 // pyDottedPath renders the full dotted path of an identifier/attribute node:
 // `sentry_sdk.trace` → "sentry_sdk.trace". Non-identifier receivers terminate
 // the path. Returns the leaf alone when the path cannot be fully rendered.
-func pyDottedPath(n *sitter.Node, src []byte) string {
+func pyDottedPath(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -416,7 +416,7 @@ func pyDottedPath(n *sitter.Node, src []byte) string {
 
 // pyFirstPositionalString returns the value of the first positional argument when
 // it is a string literal, else "".
-func pyFirstPositionalString(args *sitter.Node, src []byte) string {
+func pyFirstPositionalString(args ts.Node, src []byte) string {
 	nameNode := firstPositionalArg(args)
 	if nameNode != nil && nameNode.Type() == "string" {
 		return pythonLiteralValue(nameNode, src)
@@ -427,7 +427,7 @@ func pyFirstPositionalString(args *sitter.Node, src []byte) string {
 // pyKeywordStringArg returns the string-literal value of the keyword argument
 // named key in args (`name="checkout"` → "checkout"), or "" when absent / not a
 // string literal.
-func pyKeywordStringArg(args *sitter.Node, key string, src []byte) string {
+func pyKeywordStringArg(args ts.Node, key string, src []byte) string {
 	if args == nil {
 		return ""
 	}
@@ -457,7 +457,7 @@ func pyKeywordStringArg(args *sitter.Node, key string, src []byte) string {
 // found in funcNode's decorators and body. metricReg resolves Prometheus metric
 // variables to metric names. enclosingName keys dynamic stubs and supplies the
 // default span name for name-defaulting decorators (ddtrace/New Relic/Sentry).
-func stampPythonObservability(funcNode, decoratorParent *sitter.Node, enclosingName string, metricReg pyMetricRegistry, src []byte, out *[]types.EntityRecord, idx int) {
+func stampPythonObservability(funcNode, decoratorParent ts.Node, enclosingName string, metricReg pyMetricRegistry, src []byte, out *[]types.EntityRecord, idx int) {
 	if funcNode == nil || out == nil || idx < 0 || idx >= len(*out) {
 		return
 	}

--- a/internal/extractors/python/package_module_test.go
+++ b/internal/extractors/python/package_module_test.go
@@ -75,7 +75,7 @@ func TestPackageModule_InitPyWithClassAndFunction(t *testing.T) {
 		Path:     "core/__init__.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {
@@ -136,7 +136,7 @@ func TestPackageModule_SubPackageInitPy(t *testing.T) {
 		Path:     "core/views/__init__.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {
@@ -177,7 +177,7 @@ func TestPackageModule_PlainPyFile(t *testing.T) {
 		Path:     "core/tasks.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {
@@ -216,7 +216,7 @@ func TestPackageModule_EmptyInitPy(t *testing.T) {
 		Path:     "mypkg/__init__.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {

--- a/internal/extractors/python/python_relational_bundle_test.go
+++ b/internal/extractors/python/python_relational_bundle_test.go
@@ -30,7 +30,7 @@ func runPy(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	entities, err := ext.Extract(context.Background(), fi)
 	if err != nil {

--- a/internal/extractors/python/qualified_name_field_1725_test.go
+++ b/internal/extractors/python/qualified_name_field_1725_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tspython "github.com/smacker/go-tree-sitter/python"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/python"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -22,9 +22,12 @@ class DeficiencyCreateSerializer:
     fields = ['title', 'body']
     permission_classes = [IsAuthenticated]
 `)
-	p := sitter.NewParser()
-	p.SetLanguage(tspython.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	p, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tspython.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer p.Close()
+	tree, err := p.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -33,7 +36,7 @@ class DeficiencyCreateSerializer:
 		Path:     "core/serializers/deficiency_serializer.py",
 		Content:  src,
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	}
 	ext, ok := extractor.Get("python")
 	if !ok {

--- a/internal/extractors/python/references.go
+++ b/internal/extractors/python/references.go
@@ -60,7 +60,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -133,7 +133,7 @@ type pySymbol struct {
 // edges to the enclosing function entity.
 //
 // Mutates entities in place. Safe to call with an empty slice — no-op.
-func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitReferences(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -257,8 +257,8 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 	// Walk recursively. parentClass propagates down class_definition
 	// bodies; the function frame stack grows on function_definition /
 	// lambda nodes.
-	var walk func(n *sitter.Node, parentClass string, fstack []frame)
-	walk = func(n *sitter.Node, parentClass string, fstack []frame) {
+	var walk func(n ts.Node, parentClass string, fstack []frame)
+	walk = func(n ts.Node, parentClass string, fstack []frame) {
 		if n == nil {
 			return
 		}
@@ -369,7 +369,7 @@ func findEntityIndex(entities []types.EntityRecord, emittedName, filePath string
 //   - skip self-name (an identifier matching the enclosing function's leaf)
 //   - otherwise look up in bareSymbols and emit
 func handleIdentifier(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	parentClass string,
 	fstack []frame,
@@ -412,7 +412,7 @@ func handleIdentifier(
 //   - if obj is `cls`, same (class-method receiver).
 //   - otherwise leave the receiver to the generic identifier walk.
 func handleAttribute(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	fstack []frame,
 	dottedSymbols map[string]pySymbol,
@@ -482,7 +482,7 @@ type frame struct {
 //	parent is `global_statement` / `nonlocal_statement`
 //	parent is `assignment` and this is the `left` field
 //	parent is `for_in_clause` / `for_statement` and this is the `left` field
-func isPyDeclarationPosition(n *sitter.Node) bool {
+func isPyDeclarationPosition(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false
@@ -520,7 +520,7 @@ func isPyDeclarationPosition(n *sitter.Node) bool {
 // isPyCallCallee reports whether the identifier node is the `function`
 // child of a `call` node. CALLS owns that edge — REFERENCES would
 // double-count.
-func isPyCallCallee(n *sitter.Node) bool {
+func isPyCallCallee(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false

--- a/internal/extractors/python/router_register.go
+++ b/internal/extractors/python/router_register.go
@@ -42,7 +42,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -52,7 +52,7 @@ import (
 // ...)` call sites and appends REFERENCES edges from the file entity to
 // each ViewSet's structural-ref. Safe with nil/empty inputs and non-urls
 // files (no-op).
-func emitRouterRegisterEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitRouterRegisterEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -79,8 +79,8 @@ func emitRouterRegisterEdges(root *sitter.Node, file extractor.FileInput, entiti
 	// property captures the first prefix seen.
 	emitted := make(map[string]bool)
 
-	var walk func(n *sitter.Node)
-	walk = func(n *sitter.Node) {
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -124,7 +124,7 @@ func isRouterRegisterCandidateFile(path string) bool {
 // edge from the file entity to a structural-ref of the second argument
 // (treated as the ViewSet class). Non-matching calls return silently.
 func tryEmitRegisterEdge(
-	callNode *sitter.Node,
+	callNode ts.Node,
 	file extractor.FileInput,
 	fileIdx int,
 	entities *[]types.EntityRecord,
@@ -150,7 +150,7 @@ func tryEmitRegisterEdge(
 
 	// Collect positional args (skipping punctuation) and capture the
 	// `basename=` kwarg when present.
-	var positional []*sitter.Node
+	var positional []ts.Node
 	basename := ""
 	for i := 0; i < int(argsNode.ChildCount()); i++ {
 		arg := argsNode.Child(i)

--- a/internal/extractors/python/serializer_method_field.go
+++ b/internal/extractors/python/serializer_method_field.go
@@ -38,7 +38,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -51,12 +51,12 @@ import (
 // matching method's structural-ref.
 //
 // Mutates *entities in place; safe with nil/empty inputs.
-func emitSerializerMethodFieldLinks(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitSerializerMethodFieldLinks(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -98,7 +98,7 @@ func emitSerializerMethodFieldLinks(root *sitter.Node, file extractor.FileInput,
 // name (`method_name=` kwarg or default `get_<field>`), confirms the
 // sibling method exists as a SCOPE.Operation entity, and stamps the
 // RESOLVED_BY edge.
-func scanSerializerBody(body *sitter.Node, file extractor.FileInput, parentClass string, entities *[]types.EntityRecord) {
+func scanSerializerBody(body ts.Node, file extractor.FileInput, parentClass string, entities *[]types.EntityRecord) {
 	if body == nil || parentClass == "" {
 		return
 	}
@@ -212,7 +212,7 @@ func scanSerializerBody(body *sitter.Node, file extractor.FileInput, parentClass
 // kwarg of a SerializerMethodField call, with surrounding quotes
 // stripped. Returns "" when the kwarg is absent or its value isn't a
 // string literal.
-func lookupSerializerMethodName(callNode *sitter.Node, src []byte) string {
+func lookupSerializerMethodName(callNode ts.Node, src []byte) string {
 	argsNode := callNode.ChildByFieldName("arguments")
 	if argsNode == nil {
 		return ""

--- a/internal/extractors/python/tag_entities_language_integration_test.go
+++ b/internal/extractors/python/tag_entities_language_integration_test.go
@@ -58,7 +58,7 @@ class Article(models.Model):
 		Path:     "blog/models.py",
 		Content:  []byte(src),
 		Language: "python",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/python/template_render.go
+++ b/internal/extractors/python/template_render.go
@@ -35,7 +35,7 @@
 package python
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -48,7 +48,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input. Renders at module scope attach to the file entity.
-func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitTemplateRenderEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -64,8 +64,8 @@ func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entiti
 		return stack[len(stack)-1]
 	}
 
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -145,7 +145,7 @@ func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entiti
 // argument is a plain string literal, returns the (raw) template name and the
 // detector pattern label. Returns "", "" otherwise (including dynamic names —
 // a non-string template argument yields nothing, so EmitTemplateEdges drops it).
-func pyRenderCallTemplate(call *sitter.Node, src []byte) (string, string) {
+func pyRenderCallTemplate(call ts.Node, src []byte) (string, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return "", ""
@@ -186,7 +186,7 @@ func pyRenderCallTemplate(call *sitter.Node, src []byte) (string, string) {
 // pyFirstStringArg returns the unquoted value of the first positional string
 // literal argument in an argument_list, or "" if the first positional argument
 // is not a plain string literal (dynamic name → drop).
-func pyFirstStringArg(args *sitter.Node, src []byte) string {
+func pyFirstStringArg(args ts.Node, src []byte) string {
 	return pyNthStringArg(args, src, 0)
 }
 
@@ -194,7 +194,7 @@ func pyFirstStringArg(args *sitter.Node, src []byte) string {
 // it is a plain string literal; "" otherwise. Keyword arguments are skipped
 // when counting positionals. A non-string positional at index n yields "" so
 // dynamic template names never fabricate an edge.
-func pyNthStringArg(args *sitter.Node, src []byte, n int) string {
+func pyNthStringArg(args ts.Node, src []byte, n int) string {
 	pos := -1
 	for i := 0; i < int(args.NamedChildCount()); i++ {
 		c := args.NamedChild(i)
@@ -219,14 +219,14 @@ func pyNthStringArg(args *sitter.Node, src []byte, n int) string {
 // pyTemplateNameAttr scans a class body for a `template_name = '...'`
 // assignment (Django class-based views) and returns the unquoted literal, or ""
 // if absent / dynamic.
-func pyTemplateNameAttr(body *sitter.Node, src []byte) string {
+func pyTemplateNameAttr(body ts.Node, src []byte) string {
 	for i := 0; i < int(body.NamedChildCount()); i++ {
 		stmt := body.NamedChild(i)
 		if stmt == nil {
 			continue
 		}
 		// expression_statement → assignment
-		var assign *sitter.Node
+		var assign ts.Node
 		if stmt.Type() == "expression_statement" && stmt.NamedChildCount() > 0 {
 			assign = stmt.NamedChild(0)
 		} else if stmt.Type() == "assignment" {
@@ -272,7 +272,7 @@ var drfHTMLRenderers = map[string]bool{
 //     `renderers.BrowsableAPIRenderer`) whose TRAILING name is a known DRF HTML
 //     renderer count. JSON / data-only renderers and unknown names are skipped,
 //     so a JSON-only view emits no HTML render path.
-func pyDRFHTMLRenderers(body *sitter.Node, src []byte) []string {
+func pyDRFHTMLRenderers(body ts.Node, src []byte) []string {
 	var out []string
 	seen := map[string]bool{}
 	for i := 0; i < int(body.NamedChildCount()); i++ {
@@ -280,7 +280,7 @@ func pyDRFHTMLRenderers(body *sitter.Node, src []byte) []string {
 		if stmt == nil {
 			continue
 		}
-		var assign *sitter.Node
+		var assign ts.Node
 		if stmt.Type() == "expression_statement" && stmt.NamedChildCount() > 0 {
 			assign = stmt.NamedChild(0)
 		} else if stmt.Type() == "assignment" {

--- a/internal/extractors/python/tracing.go
+++ b/internal/extractors/python/tracing.go
@@ -32,7 +32,7 @@ package python
 import (
 	"strconv"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -59,7 +59,7 @@ var pyTracingSpanMethods = map[string]bool{
 // per OpenTelemetry span-creation site found in its body OR in its decorators.
 // The decoratorParent node, when non-nil, is the decorated_definition wrapping
 // funcNode; its decorator children are scanned for the decorator form.
-func extractPythonSpanHits(funcNode, decoratorParent *sitter.Node, src []byte) []pySpanHit {
+func extractPythonSpanHits(funcNode, decoratorParent ts.Node, src []byte) []pySpanHit {
 	if funcNode == nil {
 		return nil
 	}
@@ -121,7 +121,7 @@ func extractPythonSpanHits(funcNode, decoratorParent *sitter.Node, src []byte) [
 // pySpanFromCall inspects a `call` node and returns a pySpanHit when it is an
 // OpenTelemetry span-creation call (`<recv>.start_as_current_span(...)` or
 // `<recv>.start_span(...)`).
-func pySpanFromCall(call *sitter.Node, src []byte) (pySpanHit, bool) {
+func pySpanFromCall(call ts.Node, src []byte) (pySpanHit, bool) {
 	if call == nil || call.Type() != "call" {
 		return pySpanHit{}, false
 	}
@@ -160,7 +160,7 @@ func pySpanFromCall(call *sitter.Node, src []byte) (pySpanHit, bool) {
 // firstPositionalArg returns the first positional argument node inside an
 // argument_list, skipping the structural "(" "," ")" tokens and keyword
 // arguments. Returns nil when there is no positional argument.
-func firstPositionalArg(args *sitter.Node) *sitter.Node {
+func firstPositionalArg(args ts.Node) ts.Node {
 	if args == nil {
 		return nil
 	}
@@ -186,7 +186,7 @@ func firstPositionalArg(args *sitter.Node) *sitter.Node {
 
 // findFirstChildOfType returns the first descendant of root whose Type() equals
 // kind (depth-first), or nil. Used to locate the `call` inside a `decorator`.
-func findFirstChildOfType(root *sitter.Node, kind string) *sitter.Node {
+func findFirstChildOfType(root ts.Node, kind string) ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -203,7 +203,7 @@ func findFirstChildOfType(root *sitter.Node, kind string) *sitter.Node {
 //
 // enclosingName is the bare function/method name, used to key the synthetic
 // stub for dynamic span names ("span:<fn>").
-func stampPythonTracingSpans(funcNode, decoratorParent *sitter.Node, enclosingName string, src []byte, out *[]types.EntityRecord, idx int) {
+func stampPythonTracingSpans(funcNode, decoratorParent ts.Node, enclosingName string, src []byte, out *[]types.EntityRecord, idx int) {
 	if funcNode == nil || out == nil || idx < 0 || idx >= len(*out) {
 		return
 	}

--- a/internal/extractors/python/transaction_boundary.go
+++ b/internal/extractors/python/transaction_boundary.go
@@ -22,7 +22,7 @@
 package python
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/txscope"
@@ -32,14 +32,14 @@ import (
 // emitTransactionBoundaryProperties walks every function/method definition and
 // stamps transaction properties on the matching SCOPE.Operation entity.
 // Mutates *entities in place. Safe to call with nil/empty input.
-func emitTransactionBoundaryProperties(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitTransactionBoundaryProperties(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
 	walkTxDefs(root, "", file, entities)
 }
 
-func walkTxDefs(n *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func walkTxDefs(n ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if n == nil {
 		return
 	}
@@ -88,7 +88,7 @@ func walkTxDefs(n *sitter.Node, parentClass string, file extractor.FileInput, en
 // stampTxOnOperation runs the txscope detector over spanNode's source (which
 // may be the decorator-inclusive decorated_definition) and stamps the matching
 // operation entity when a transaction boundary is found.
-func stampTxOnOperation(spanNode, fnNode *sitter.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
+func stampTxOnOperation(spanNode, fnNode ts.Node, parentClass string, file extractor.FileInput, entities *[]types.EntityRecord) {
 	nameNode := fnNode.ChildByFieldName("name")
 	if nameNode == nil {
 		return

--- a/internal/extractors/python/translation_key.go
+++ b/internal/extractors/python/translation_key.go
@@ -31,7 +31,7 @@ package python
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -62,7 +62,7 @@ func isI18nPythonSource(module string) bool {
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input. Keys at module scope attach to the file entity.
-func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitTranslationKeyEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -105,8 +105,8 @@ func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entiti
 		return stack[len(stack)-1]
 	}
 
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -173,7 +173,7 @@ func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entiti
 //     and the tail is a gettext-family function.
 //
 // Returns ok=false for an unrecognised callee or a dynamic first argument.
-func pyTranslationCall(call *sitter.Node, src []byte, i18nLocal, gettextModuleAliases map[string]bool) (string, bool) {
+func pyTranslationCall(call ts.Node, src []byte, i18nLocal, gettextModuleAliases map[string]bool) (string, bool) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return "", false
@@ -199,7 +199,7 @@ func pyTranslationCall(call *sitter.Node, src []byte, i18nLocal, gettextModuleAl
 // is a static string literal. Returns ok=false for a dynamic first argument
 // (variable, f-string, concatenation) — the honest-partial boundary. Uses
 // pyStringLiteralValue so an f-string with an interpolation yields "" (drop).
-func pyTransFirstStringArg(call *sitter.Node, src []byte) (string, bool) {
+func pyTransFirstStringArg(call ts.Node, src []byte) (string, bool) {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return "", false

--- a/internal/extractors/python/types.go
+++ b/internal/extractors/python/types.go
@@ -33,7 +33,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -68,7 +68,7 @@ var dataclassDecoratorNames = map[string]struct{}{
 //
 // Runs after the primary walk so the class entities it annotates already
 // exist in *out. Append-only for type aliases; in-place stamp for classes.
-func applyTypeSystemAnnotations(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func applyTypeSystemAnnotations(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if root == nil {
 		return
 	}
@@ -109,7 +109,7 @@ func applyTypeSystemAnnotations(root *sitter.Node, file extractor.FileInput, out
 // partial: the dict form requires an UPPER_SNAKE / PascalCase name AND at least
 // one statically-literal value; a dict whose values are all non-literal
 // expressions (callables, calls) yields no node.
-func buildConstantSetFromAssignment(asn *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildConstantSetFromAssignment(asn ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	left := asn.ChildByFieldName("left")
 	if left == nil || left.Type() != "identifier" {
 		return types.EntityRecord{}, false
@@ -151,7 +151,7 @@ func buildConstantSetFromAssignment(asn *sitter.Node, file extractor.FileInput) 
 // statically-known literal (number/string/bool/None) or "" for non-literal
 // value expressions (recorded so the key is still enumerable). Each member
 // carries the pair's source line.
-func pythonDictMembers(dict *sitter.Node, src []byte) []extractor.EnumMember {
+func pythonDictMembers(dict ts.Node, src []byte) []extractor.EnumMember {
 	var out []extractor.EnumMember
 	for i := 0; i < int(dict.NamedChildCount()); i++ {
 		pair := dict.NamedChild(i)
@@ -184,13 +184,13 @@ func pythonDictMembers(dict *sitter.Node, src []byte) []extractor.EnumMember {
 // pythonLiteralAliasMembers returns the literal arms of a `Literal[...]`
 // subscript as value-set members (each arm name==value), or ok=false when the
 // subscripted head is not `Literal` or any arm is non-literal.
-func pythonLiteralAliasMembers(sub *sitter.Node, src []byte) ([]extractor.EnumMember, bool) {
+func pythonLiteralAliasMembers(sub ts.Node, src []byte) ([]extractor.EnumMember, bool) {
 	v := sub.ChildByFieldName("value")
 	if v == nil || baseLeafName(v, src) != "Literal" {
 		return nil, false
 	}
 	sl := sub.ChildByFieldName("subscript")
-	var args []*sitter.Node
+	var args []ts.Node
 	if sl != nil {
 		args = append(args, sl)
 	} else {
@@ -218,7 +218,7 @@ func pythonLiteralAliasMembers(sub *sitter.Node, src []byte) ([]extractor.EnumMe
 // collectLiteralArms appends one value-set member per string/number literal arm
 // found under n. Any non-literal arm makes the whole alias not a closed value-
 // set, so it is skipped (the caller drops it if nothing literal remains).
-func collectLiteralArms(n *sitter.Node, src []byte, line int, out *[]extractor.EnumMember) {
+func collectLiteralArms(n ts.Node, src []byte, line int, out *[]extractor.EnumMember) {
 	if n == nil {
 		return
 	}
@@ -249,7 +249,7 @@ func hasLiteralValue(members []extractor.EnumMember) bool {
 // annotateTypeClass inspects one class_definition node, classifies it against
 // the Type System taxonomy from its base list (+ decorators), and stamps the
 // matching SCOPE.Component/class entity in *out. No-op for ordinary classes.
-func annotateTypeClass(cls *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func annotateTypeClass(cls ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	nameNode := cls.ChildByFieldName("name")
 	if nameNode == nil {
 		return
@@ -359,7 +359,7 @@ func stampClassTypeProps(out *[]types.EntityRecord, filePath, bareName string, p
 // `typing.Protocol` → "Protocol", `TypedDict` → "TypedDict". Keyword arguments
 // (metaclass=, total=) are skipped. Generic subscripts (`Protocol[T]`) reduce
 // to the leaf of the value being subscripted.
-func classBaseLeafNames(cls *sitter.Node, src []byte) []string {
+func classBaseLeafNames(cls ts.Node, src []byte) []string {
 	args := cls.ChildByFieldName("superclasses")
 	if args == nil {
 		// Grammar exposes the base list as an unnamed argument_list child.
@@ -388,7 +388,7 @@ func classBaseLeafNames(cls *sitter.Node, src []byte) []string {
 
 // baseLeafName reduces a single base-class expression node to its leaf
 // identifier. Returns "" for keyword arguments (metaclass=, total=).
-func baseLeafName(arg *sitter.Node, src []byte) string {
+func baseLeafName(arg ts.Node, src []byte) string {
 	switch arg.Type() {
 	case "identifier":
 		return nodeText(arg, src)
@@ -410,7 +410,7 @@ func baseLeafName(arg *sitter.Node, src []byte) string {
 // classHasDataclassDecorator reports whether the class_definition is wrapped in
 // a decorated_definition whose decorator list includes @dataclass (bare or
 // `@dataclasses.dataclass`, with or without a call: `@dataclass(frozen=True)`).
-func classHasDataclassDecorator(cls *sitter.Node, src []byte) bool {
+func classHasDataclassDecorator(cls ts.Node, src []byte) bool {
 	parent := cls.Parent()
 	if parent == nil || parent.Type() != "decorated_definition" {
 		return false
@@ -431,7 +431,7 @@ func classHasDataclassDecorator(cls *sitter.Node, src []byte) bool {
 
 // decoratorLeafName extracts the leaf identifier of a decorator node, handling
 // `@name`, `@mod.name`, and the call forms `@name(...)` / `@mod.name(...)`.
-func decoratorLeafName(dec *sitter.Node, src []byte) string {
+func decoratorLeafName(dec ts.Node, src []byte) string {
 	// A decorator's named child is the expression after '@'.
 	for i := 0; i < int(dec.NamedChildCount()); i++ {
 		expr := dec.NamedChild(i)
@@ -456,7 +456,7 @@ func decoratorLeafName(dec *sitter.Node, src []byte) string {
 
 // decoratorLeafFromExpr reduces a decorator-call function expression to its
 // leaf identifier (`dataclass` from `dataclasses.dataclass(...)`).
-func decoratorLeafFromExpr(fn *sitter.Node, src []byte) string {
+func decoratorLeafFromExpr(fn ts.Node, src []byte) string {
 	switch fn.Type() {
 	case "identifier":
 		return nodeText(fn, src)
@@ -470,7 +470,7 @@ func decoratorLeafFromExpr(fn *sitter.Node, src []byte) string {
 
 // classMethodNames returns the names of methods (function_definition nodes)
 // declared directly in the class body — used for protocol_methods.
-func classMethodNames(cls *sitter.Node, src []byte) []string {
+func classMethodNames(cls ts.Node, src []byte) []string {
 	body := cls.ChildByFieldName("body")
 	if body == nil {
 		return nil
@@ -501,7 +501,7 @@ func classMethodNames(cls *sitter.Node, src []byte) []string {
 // number, string, or `True/False/None`; computed RHS (call, attribute,
 // arithmetic) yields a value-less member so the name is recorded honestly
 // without fabricating a value.
-func classEnumMembers(cls *sitter.Node, src []byte) []extractor.EnumMember {
+func classEnumMembers(cls ts.Node, src []byte) []extractor.EnumMember {
 	body := cls.ChildByFieldName("body")
 	if body == nil {
 		return nil
@@ -540,7 +540,7 @@ func classEnumMembers(cls *sitter.Node, src []byte) []extractor.EnumMember {
 // attribute access) so the member is recorded without a fabricated value.
 // Django TextChoices/IntegerChoices `("db", "Label")` tuples resolve to the
 // first element (the stored DB value), which is the parity-relevant literal.
-func pythonEnumLiteralValue(rhs *sitter.Node, src []byte) string {
+func pythonEnumLiteralValue(rhs ts.Node, src []byte) string {
 	if rhs == nil {
 		return ""
 	}
@@ -566,7 +566,7 @@ func pythonEnumLiteralValue(rhs *sitter.Node, src []byte) string {
 // (`x: int`, `name: str = ""`) used for TypedDict / NamedTuple / dataclass
 // shapes. Only annotated assignments count — a bare `x = 1` is not a field of
 // a TypedDict and is skipped.
-func classAnnotatedFields(cls *sitter.Node, src []byte) []string {
+func classAnnotatedFields(cls ts.Node, src []byte) []string {
 	body := cls.ChildByFieldName("body")
 	if body == nil {
 		return nil
@@ -603,8 +603,8 @@ func classAnnotatedFields(cls *sitter.Node, src []byte) []string {
 // moduleLevelAssignments returns the assignment nodes that live directly at
 // module scope (children of the root module's top-level expression_statements),
 // excluding any assignment nested inside a class or function body.
-func moduleLevelAssignments(root *sitter.Node) []*sitter.Node {
-	var out []*sitter.Node
+func moduleLevelAssignments(root ts.Node) []ts.Node {
+	var out []ts.Node
 	for i := 0; i < int(root.NamedChildCount()); i++ {
 		stmt := root.NamedChild(i)
 		if stmt == nil || stmt.Type() != "expression_statement" {
@@ -627,7 +627,7 @@ func moduleLevelAssignments(root *sitter.Node) []*sitter.Node {
 //	X = A | B                   — PEP 604 union of bare type names (PascalCase)
 //
 // A plain `X = SomeValue()` or `X = 3` is NOT a type alias and returns false.
-func buildAssignmentTypeAlias(asn *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildAssignmentTypeAlias(asn ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	left := asn.ChildByFieldName("left")
 	if left == nil || left.Type() != "identifier" {
 		return types.EntityRecord{}, false
@@ -658,7 +658,7 @@ func buildAssignmentTypeAlias(asn *sitter.Node, file extractor.FileInput) (types
 
 // typeAnnotationLeaf reduces an annotation node (the `type` field of an
 // annotated assignment) to its leaf identifier.
-func typeAnnotationLeaf(ann *sitter.Node, src []byte) string {
+func typeAnnotationLeaf(ann ts.Node, src []byte) string {
 	target := ann
 	if ann.Type() == "type" && ann.NamedChildCount() > 0 {
 		target = ann.NamedChild(0)
@@ -689,7 +689,7 @@ var typingAliasHeads = map[string]struct{}{
 // by design: only the typing-module subscript heads and PEP 604 unions of
 // PascalCase type names qualify, so runtime-value assignments are never
 // misclassified.
-func rhsLooksLikeTypeExpression(rhs *sitter.Node, src []byte) bool {
+func rhsLooksLikeTypeExpression(rhs ts.Node, src []byte) bool {
 	switch rhs.Type() {
 	case "subscript":
 		// Union[...], Dict[str, int], etc. — match the subscripted head leaf.
@@ -714,7 +714,7 @@ func rhsLooksLikeTypeExpression(rhs *sitter.Node, src []byte) bool {
 // isTypeOperand reports whether a PEP 604 union operand is a type reference:
 // a PascalCase identifier, a None literal, a dotted attribute whose leaf is
 // PascalCase, or a subscript over one of those.
-func isTypeOperand(n *sitter.Node, src []byte) bool {
+func isTypeOperand(n ts.Node, src []byte) bool {
 	if n == nil {
 		return false
 	}
@@ -752,7 +752,7 @@ func isPascalCase(s string) bool {
 // buildPEP695TypeAlias builds a SCOPE.Schema/type_alias entity for a PEP 695
 // `type X = ...` statement (Python 3.12+). These are unambiguous type aliases
 // by grammar, so no RHS heuristic is needed.
-func buildPEP695TypeAlias(ts *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildPEP695TypeAlias(ts ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	// type_alias_statement children: type (lhs name) '=' type (rhs).
 	left := ts.ChildByFieldName("left")
 	right := ts.ChildByFieldName("right")
@@ -776,7 +776,7 @@ func buildPEP695TypeAlias(ts *sitter.Node, file extractor.FileInput) (types.Enti
 // by the PEP 695 and assignment code paths. rhs may be nil (then no type_body
 // property is set). The pep613 flag records whether the alias was explicitly
 // annotated / PEP 695 (vs inferred from a typing subscript heuristic).
-func newTypeAliasEntity(name string, rhs, span *sitter.Node, file extractor.FileInput, explicit bool) types.EntityRecord {
+func newTypeAliasEntity(name string, rhs, span ts.Node, file extractor.FileInput, explicit bool) types.EntityRecord {
 	mod := filePathToModule(file.Path)
 	qn := name
 	if mod != "" {


### PR DESCRIPTION
## What

B2 **Phase 1, Batch 1** of the tree-sitter binding migration (#5418, ADR 0023): migrate the **python** and **java** extractors off the concrete `smacker/go-tree-sitter` `*sitter.Node` onto the binding-agnostic `internal/treesitter/ts` façade (`ts.Node` / `ts.Tree`). Still **smacker-backed** in the default build (link-safe, no co-link blocker) — this is the mechanical, behavior-preserving plumbing that makes the eventual one-runtime cutover possible. Mirrors the Phase-0 Go-extractor migration end-to-end.

## How

- **Non-test files** (39 of them): pure swap — `*sitter.Node → ts.Node`, drop the `sitter "github.com/smacker/go-tree-sitter"` root import, add the `ts` import. `Type()`/`Child`/`ChildByFieldName`/`StartByte`/`StartPoint`/etc. all exist on `ts.Node` and are used as-is; the nil contract (`if n == nil`) and `uint32` widths are preserved by the façade.
- **python `extractor.go`**: reads the shared `file.TSTree`; when nil (direct test callers with raw content) it parses inline via the grammar adapter — exactly as the Go extractor does. The grammar provider lives in a new **`grammar.go`** (`pythonGrammar()` / `pythonAdapter`, smacker-backed).
- **java `java.go`**: reads `file.TSTree` (java has no inline-parse fallback — it requires a supplied tree, same as before). No grammar provider needed in non-test code.
- **Test tree-helpers** updated to build a `ts.Tree` via the smacker adapter (`tssmacker.New().NewParser(tssmacker.WrapLanguage(...))`) and stamp `FileInput.TSTree` (`Tree:` → `TSTree:`). No test **assertion** was changed — only the tree-plumbing, so this exercises the façade path rather than the old inline fallback.

## Note on the `grammar.go` build tag

Unlike Go (Phase 0, which has both `language_smacker.go` and `language_official.go`), python has **no official-binding grammar module yet** — so its provider is intentionally **untagged**: the python extractor compiles & links under both `go build` and `go build -tags ts_official`. When python is promoted to the official runtime (a later B2 phase) this file becomes the tag-split pair. (Java needs no provider at all in non-test code.)

## Zero-delta confirmation

Default build:
- `go build ./...` ✅ (exit 0) · `go vet ./internal/extractors/python ./internal/extractors/java` ✅ · `gofmt -l` clean ✅
- `go test -count=1 ./internal/extractors/python/ ./internal/extractors/java/` ✅ **PASS unchanged** — the abstraction over smacker is behavior-preserving, so any test delta would be a mapping bug; there is none.
- `go build -tags ts_official ./internal/extractors/python ./internal/extractors/java` ✅ compiles (the `./...` tag build still hits the pre-existing co-link blocker §1, unchanged by this PR).
- No `*sitter.Node` and no smacker-root import remain in either package (residual `smacker` refs are only the grammar subpkg + adapter feeding the façade, mirroring the Go extractor's accepted end-state).

Machine-safe: targeted package builds/tests only; no daemon, no full-suite, no cpu_cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)