### PR TITLE
refactor(extractors): migrate javascript+typescript to ts.Node (B2 Phase 1 #5418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,17 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   100% smacker-backed and link-safe; this is mechanical, behavior-preserving
   plumbing — the full python+java extractor suites pass unchanged (zero fidelity
   delta). Mirrors the Phase-0 Go-extractor migration.
+- **Migrated the `javascript`+`typescript` extractors to the `ts.Node`
+  abstraction (smacker-backed, no behavior change)** — B2 Phase 1 (#5418). The
+  JS/TS extractor (which handles both `javascript` and `typescript`) now
+  traverses the binding-agnostic `internal/treesitter/ts` façade
+  (`ts.Node`/`ts.Tree`) and reads the shared `FileInput.TSTree` instead of the
+  concrete `smacker/go-tree-sitter` `*sitter.Node`/`*sitter.Tree`. No inline
+  parse fallback exists (the extractor early-returns when no tree is supplied),
+  so no grammar provider was added; test tree-helpers build `ts.Tree` via the
+  smacker adapter and stamp `TSTree`. Default builds stay 100% smacker-backed and
+  link-safe; mechanical and behavior-preserving — the javascript+typescript
+  extractor suite passes unchanged (zero fidelity delta).
 
 ## [0.1.3] — 2026-06-23
 

--- a/internal/extractors/javascript/angular.go
+++ b/internal/extractors/javascript/angular.go
@@ -35,7 +35,7 @@ import (
 	"regexp"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -205,7 +205,7 @@ var reAngularPascalTag = regexp.MustCompile(`<([a-z][a-z0-9]*-[a-z0-9-]*|[A-Z][A
 // (and, when the class is inside an export_statement, the export_statement's
 // previous siblings are folded in because the decorator is a child of the
 // export_statement in that grammar shape).
-func (x *extractor) angularDecoratorFor(class *sitter.Node) (string, *sitter.Node) {
+func (x *extractor) angularDecoratorFor(class ts.Node) (string, ts.Node) {
 	if class == nil {
 		return "", nil
 	}
@@ -231,7 +231,7 @@ func (x *extractor) angularDecoratorFor(class *sitter.Node) (string, *sitter.Nod
 
 // decoratorIdent returns the decorator's identifier name and its underlying
 // call_expression (when the decorator is a call like `@Component({...})`).
-func (x *extractor) decoratorIdent(dec *sitter.Node) (string, *sitter.Node) {
+func (x *extractor) decoratorIdent(dec ts.Node) (string, ts.Node) {
 	for i := 0; i < int(dec.ChildCount()); i++ {
 		c := dec.Child(i)
 		switch c.Type() {
@@ -251,7 +251,7 @@ func (x *extractor) decoratorIdent(dec *sitter.Node) (string, *sitter.Node) {
 // service/pipe/module) for a decorated class. It returns true when the class
 // was Angular-decorated and fully handled (the generic class path should be
 // skipped). The decorator name + call node come from angularDecoratorFor.
-func (x *extractor) handleAngularClass(n *sitter.Node, decorator string, call *sitter.Node) bool {
+func (x *extractor) handleAngularClass(n ts.Node, decorator string, call ts.Node) bool {
 	subtype, ok := angularClassDecorators[decorator]
 	if !ok {
 		return false
@@ -436,13 +436,13 @@ func (x *extractor) handleAngularClass(n *sitter.Node, decorator string, call *s
 // (selector, template) from a decorator call's first object-literal argument.
 // templateUrl is recorded under "template_url" but does not yield RENDERS edges
 // (the markup lives in a separate file the extractor does not parse here).
-func (x *extractor) angularDecoratorMeta(call *sitter.Node) map[string]string {
+func (x *extractor) angularDecoratorMeta(call ts.Node) map[string]string {
 	out := map[string]string{}
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return out
 	}
-	var obj *sitter.Node
+	var obj ts.Node
 	for i := 0; i < int(args.ChildCount()); i++ {
 		if args.Child(i).Type() == "object" {
 			obj = args.Child(i)
@@ -481,7 +481,7 @@ func (x *extractor) angularDecoratorMeta(call *sitter.Node) map[string]string {
 // the class constructor's parameter list, e.g. `constructor(private http:
 // HttpClient, store: Store)` → ["HttpClient", "Store"]. These are Angular's DI
 // "context" dependencies (context_extraction capability).
-func (x *extractor) angularConstructorInjections(body *sitter.Node) []string {
+func (x *extractor) angularConstructorInjections(body ts.Node) []string {
 	var out []string
 	seen := map[string]bool{}
 	for i := 0; i < int(body.ChildCount()); i++ {
@@ -574,7 +574,7 @@ var angularInputOutputDecorators = map[string]string{
 // fields and returns one SCOPE.Operation subtype="component_prop" per field.
 // The Angular grammar shape is a `public_field_definition` whose first child is
 // a `decorator` (see the AST dump in this package's tests).
-func (x *extractor) angularInputOutputProps(body *sitter.Node, className string) []types.EntityRecord {
+func (x *extractor) angularInputOutputProps(body ts.Node, className string) []types.EntityRecord {
 	var out []types.EntityRecord
 	seen := map[string]bool{}
 	for i := 0; i < int(body.ChildCount()); i++ {
@@ -651,7 +651,7 @@ var angularHTTPMethods = map[string]bool{
 // fixed to "http" — any member_expression `this.X.<verb>(...)` where <verb> is
 // an HttpClient method is treated as a fetch site (the field's declared type is
 // HttpClient by Angular convention).
-func (x *extractor) angularDataFetching(body *sitter.Node, className string) ([]types.EntityRecord, []types.RelationshipRecord) {
+func (x *extractor) angularDataFetching(body ts.Node, className string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	var ents []types.EntityRecord
 	var rels []types.RelationshipRecord
 	seen := map[string]bool{}
@@ -725,7 +725,7 @@ func (x *extractor) angularDataFetching(body *sitter.Node, className string) ([]
 // angularFirstStringArg returns the first string-literal argument of a call
 // expression, stripped of quotes, or "" when the first argument is not a
 // string literal.
-func angularFirstStringArg(x *extractor, call *sitter.Node) string {
+func angularFirstStringArg(x *extractor, call ts.Node) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
@@ -773,7 +773,7 @@ var angularStateContainerFactories = map[string]string{
 //	ngrx    : this.store.select(...) / this.store.dispatch(...)
 //	          → CALLS edge to the Store method (unchanged; kept so the Redux
 //	            store path does not regress)
-func (x *extractor) angularStateManagement(body *sitter.Node, className string) ([]types.EntityRecord, []types.RelationshipRecord) {
+func (x *extractor) angularStateManagement(body ts.Node, className string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	if body == nil {
 		return nil, nil
 	}
@@ -782,7 +782,7 @@ func (x *extractor) angularStateManagement(body *sitter.Node, className string) 
 	seenStore := map[string]bool{}
 	seenState := map[string]bool{}
 
-	emitContainer := func(name, lib, primitive, sig string, node *sitter.Node) {
+	emitContainer := func(name, lib, primitive, sig string, node ts.Node) {
 		if name == "" || seenState[name] {
 			return
 		}
@@ -900,7 +900,7 @@ var reAngularBranch = regexp.MustCompile(`(\*ngIf|\*ngFor|\*ngSwitchCase|\*ngSwi
 // distinct directive kind (Data Flow / branch_conditions). The component's
 // source node provides the location anchor (inline templates do not carry
 // independent line numbers in this extractor).
-func (x *extractor) angularBranchConditions(template, className string, anchor *sitter.Node) []types.EntityRecord {
+func (x *extractor) angularBranchConditions(template, className string, anchor ts.Node) []types.EntityRecord {
 	var out []types.EntityRecord
 	seen := map[string]bool{}
 	start, end := lines(anchor)

--- a/internal/extractors/javascript/angular_global_di.go
+++ b/internal/extractors/javascript/angular_global_di.go
@@ -42,7 +42,7 @@ import (
 	"regexp"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -93,7 +93,7 @@ var reAngularIdent = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*)\b`)
 // x.entities: it appends global USES edges onto the declaring @NgModule entity
 // (already emitted by handleAngularClass) and, when a standalone bootstrap is
 // present, emits a synthetic `app` entity owning the bootstrap USES edges.
-func (x *extractor) angularGlobalProviders(root *sitter.Node) {
+func (x *extractor) angularGlobalProviders(root ts.Node) {
 	if root == nil {
 		return
 	}
@@ -224,7 +224,7 @@ func angularProviderObjectSpans(body string) [][2]int {
 // angularModuleProviders scans every @NgModule-decorated class for its
 // providers array and appends a module → bound-class USES edge (global=true)
 // per provider onto the already-emitted module entity.
-func (x *extractor) angularModuleProviders(root *sitter.Node) {
+func (x *extractor) angularModuleProviders(root ts.Node) {
 	for _, dec := range findAllNodes(root, "decorator") {
 		name, call := x.decoratorIdent(dec)
 		if name != "NgModule" || call == nil {
@@ -254,7 +254,7 @@ func (x *extractor) angularModuleProviders(root *sitter.Node) {
 // hangs the app → target USES edges (global=true) off it, mirroring the NestJS
 // bootstrap `app` owner (#4329). Functional interceptors registered via
 // `provideHttpClient(withInterceptors([fn]))` also become app → fn edges.
-func (x *extractor) angularBootstrapProviders(root *sitter.Node) {
+func (x *extractor) angularBootstrapProviders(root ts.Node) {
 	for _, call := range findAllNodes(root, "call_expression") {
 		fn := call.ChildByFieldName("function")
 		if fn == nil || x.nodeText(fn) != "bootstrapApplication" {
@@ -337,7 +337,7 @@ func angularGlobalUsesEdge(owner string, e angularProviderEdge, framework, via s
 
 // decoratedClassName returns the name of the class a decorator node decorates,
 // by scanning the decorator's parent for the sibling class_declaration.
-func (x *extractor) decoratedClassName(dec *sitter.Node) string {
+func (x *extractor) decoratedClassName(dec ts.Node) string {
 	parent := dec.Parent()
 	if parent == nil {
 		return ""
@@ -355,12 +355,12 @@ func (x *extractor) decoratedClassName(dec *sitter.Node) string {
 // array of a decorator call's first object-literal argument (e.g. the
 // `providers` array of @NgModule), or "" when absent. Raw text is used so the
 // uniform provider-object / bare-class parsing (shared with NestJS) applies.
-func (x *extractor) angularDecoratorArrayRaw(call *sitter.Node, key string) string {
+func (x *extractor) angularDecoratorArrayRaw(call ts.Node, key string) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
 	}
-	var obj *sitter.Node
+	var obj ts.Node
 	for i := 0; i < int(args.ChildCount()); i++ {
 		if args.Child(i).Type() == "object" {
 			obj = args.Child(i)
@@ -375,7 +375,7 @@ func (x *extractor) angularDecoratorArrayRaw(call *sitter.Node, key string) stri
 
 // angularOptionsProvidersRaw returns the raw `providers: [...]` array body from
 // the second (options) argument of a bootstrapApplication(App, {providers}) call.
-func (x *extractor) angularOptionsProvidersRaw(args *sitter.Node) string {
+func (x *extractor) angularOptionsProvidersRaw(args ts.Node) string {
 	// Find object-literal arguments (skip the leading component identifier).
 	for i := 0; i < int(args.ChildCount()); i++ {
 		c := args.Child(i)
@@ -391,7 +391,7 @@ func (x *extractor) angularOptionsProvidersRaw(args *sitter.Node) string {
 
 // angularObjectArrayRaw returns the raw text inside the `key: [...]` array value
 // of an object-literal node, or "" when the key is absent / not an array.
-func (x *extractor) angularObjectArrayRaw(obj *sitter.Node, key string) string {
+func (x *extractor) angularObjectArrayRaw(obj ts.Node, key string) string {
 	for i := 0; i < int(obj.ChildCount()); i++ {
 		pair := obj.Child(i)
 		if pair.Type() != "pair" {
@@ -430,7 +430,7 @@ func (x *extractor) entityIndexByName(name string) int {
 // ensureAngularAppEntity returns the index of the synthetic `app` entity,
 // emitting it (once) when absent. The entity owns the bootstrap global USES
 // edges so the bound classes are retained and resolve through the symbol table.
-func (x *extractor) ensureAngularAppEntity(anchor *sitter.Node) int {
+func (x *extractor) ensureAngularAppEntity(anchor ts.Node) int {
 	if idx := x.entityIndexByName(angularAppEntityName); idx >= 0 {
 		return idx
 	}

--- a/internal/extractors/javascript/angular_global_di_test.go
+++ b/internal/extractors/javascript/angular_global_di_test.go
@@ -39,7 +39,7 @@ func extractTS4378(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Language: "typescript",
 		Content:  []byte(src),
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract %s: %v", path, err)

--- a/internal/extractors/javascript/angular_nav_lifecycle.go
+++ b/internal/extractors/javascript/angular_nav_lifecycle.go
@@ -35,7 +35,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -67,7 +67,7 @@ var reAngularRoutePath = regexp.MustCompile(`\bpath\s*:\s*['"]([^'"]*)['"]`)
 // returns one NAVIGATES_TO edge per distinct route. The receiver must look like
 // a Router (a `router`-suffixed identifier or `.router` member access) so plain
 // array .navigate-like calls are not misread.
-func (x *extractor) angularNavigationRels(body *sitter.Node, className string) []types.RelationshipRecord {
+func (x *extractor) angularNavigationRels(body ts.Node, className string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
@@ -127,7 +127,7 @@ func angularLooksLikeRouter(recvText string) bool {
 // (`['/users', id]`); navigateByUrl() takes a string. Array commands are joined
 // with '/' and dynamic (non-literal) segments are normalised to the {*}
 // sentinel so the route matches server-side definitions.
-func angularNavRouteArg(x *extractor, call *sitter.Node, method string) string {
+func angularNavRouteArg(x *extractor, call ts.Node, method string) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
@@ -150,7 +150,7 @@ func angularNavRouteArg(x *extractor, call *sitter.Node, method string) string {
 // angularURLCommandsToRoute joins an Angular URL-command array (`['/users', id,
 // 'edit']`) into a single route string. String-literal segments are kept;
 // dynamic segments (identifiers, member expressions) become the {*} sentinel.
-func angularURLCommandsToRoute(x *extractor, arr *sitter.Node) string {
+func angularURLCommandsToRoute(x *extractor, arr ts.Node) string {
 	var segs []string
 	for i := 0; i < int(arr.ChildCount()); i++ {
 		c := arr.Child(i)
@@ -181,7 +181,7 @@ func angularURLCommandsToRoute(x *extractor, arr *sitter.Node) string {
 // directives and returns one NAVIGATES_TO edge per distinct destination. Both
 // the string form (routerLink="/x") and binding form ([routerLink]="['/x']")
 // are recognised. The component's source node anchors the line number.
-func (x *extractor) angularRouterLinkRels(template, className string, anchor *sitter.Node) []types.RelationshipRecord {
+func (x *extractor) angularRouterLinkRels(template, className string, anchor ts.Node) []types.RelationshipRecord {
 	if template == "" {
 		return nil
 	}
@@ -248,7 +248,7 @@ func angularRouterLinkValue(raw string) string {
 // forChild route-table declarations and returns one NAVIGATES_TO edge per
 // declared `path:` segment. This captures the route *definitions* (the
 // declarative half of router_pattern) distinct from imperative navigation.
-func (x *extractor) angularRouteTableRels(body *sitter.Node, className string) []types.RelationshipRecord {
+func (x *extractor) angularRouteTableRels(body ts.Node, className string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
@@ -296,7 +296,7 @@ func (x *extractor) angularRouteTableRels(body *sitter.Node, className string) [
 // The signal bindings declared in the body are collected first so a `.set`/
 // `.update` call is only treated as a state setter when its receiver is a known
 // signal (avoiding false positives on Set.add-style methods).
-func (x *extractor) angularStateSetterEmission(body *sitter.Node, className string) []types.EntityRecord {
+func (x *extractor) angularStateSetterEmission(body ts.Node, className string) []types.EntityRecord {
 	if body == nil {
 		return nil
 	}
@@ -305,7 +305,7 @@ func (x *extractor) angularStateSetterEmission(body *sitter.Node, className stri
 	var ents []types.EntityRecord
 	seen := map[string]bool{}
 
-	emit := func(name, stateName, sig string, props map[string]string, node *sitter.Node) {
+	emit := func(name, stateName, sig string, props map[string]string, node ts.Node) {
 		if name == "" || seen[name] {
 			return
 		}
@@ -408,7 +408,7 @@ func (x *extractor) angularStateSetterEmission(body *sitter.Node, className stri
 // Subject ctors). The two name sets gate `.set`/`.update`/`.mutate` (signals)
 // and `.next` (subjects) setter detection so those methods are only treated as
 // state mutations when their receiver is a known reactive container.
-func (x *extractor) angularSignalBindings(body *sitter.Node) (signals, subjects map[string]bool) {
+func (x *extractor) angularSignalBindings(body ts.Node) (signals, subjects map[string]bool) {
 	signals = map[string]bool{}
 	subjects = map[string]bool{}
 	for _, decl := range findAllNodes(body, "variable_declarator", "public_field_definition", "field_definition") {
@@ -483,7 +483,7 @@ func angularSignalLeafName(recvText string) string {
 // store.dispatch(...). For `dispatch(loadUser())` → "loadUser"; for
 // `dispatch({ type: '[User] Load' })` → the type string. Returns "" when the
 // shape is unrecognised.
-func angularDispatchActionName(x *extractor, call *sitter.Node) string {
+func angularDispatchActionName(x *extractor, call ts.Node) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""

--- a/internal/extractors/javascript/angular_route_guards.go
+++ b/internal/extractors/javascript/angular_route_guards.go
@@ -44,7 +44,7 @@ package javascript
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -64,7 +64,7 @@ var angularGuardArrayKeys = map[string]bool{
 // walk) that scans every route-config object literal for guard/resolver bindings
 // and emits route → guard/resolver CLASS USES edges. It is a no-op on files with
 // no Angular route config.
-func (x *extractor) angularRouteGuards(root *sitter.Node) {
+func (x *extractor) angularRouteGuards(root ts.Node) {
 	if root == nil {
 		return
 	}
@@ -85,7 +85,7 @@ func (x *extractor) angularRouteGuards(root *sitter.Node) {
 // …). Requiring a guard key — not merely `path` — keeps the pass tightly scoped
 // to routes that actually bind a guard, so a plain `{ path, component }` route
 // emits no spurious USES edge (the regression invariant).
-func (x *extractor) angularLooksLikeRoute(obj *sitter.Node) bool {
+func (x *extractor) angularLooksLikeRoute(obj ts.Node) bool {
 	for _, key := range x.angularObjectKeys(obj) {
 		if angularGuardArrayKeys[key] || key == "resolve" {
 			return true
@@ -96,7 +96,7 @@ func (x *extractor) angularLooksLikeRoute(obj *sitter.Node) bool {
 
 // angularObjectKeys returns the property-key names of an object literal's direct
 // `pair` children (shorthand/spread entries are skipped).
-func (x *extractor) angularObjectKeys(obj *sitter.Node) []string {
+func (x *extractor) angularObjectKeys(obj ts.Node) []string {
 	var keys []string
 	for i := 0; i < int(obj.ChildCount()); i++ {
 		pair := obj.Child(i)
@@ -115,7 +115,7 @@ func (x *extractor) angularObjectKeys(obj *sitter.Node) []string {
 // segment, normalised so an empty default path renders as "<index>". When the
 // route object has no `path` (a pathless layout route) it falls back to
 // "<route>" so the edge still carries an anchor.
-func (x *extractor) angularRoutePathLabel(obj *sitter.Node) string {
+func (x *extractor) angularRoutePathLabel(obj ts.Node) string {
 	for i := 0; i < int(obj.ChildCount()); i++ {
 		pair := obj.Child(i)
 		if pair == nil || pair.Type() != "pair" {
@@ -137,7 +137,7 @@ func (x *extractor) angularRoutePathLabel(obj *sitter.Node) string {
 // own the route's guard USES edges: the nearest enclosing class entity when the
 // route array sits in a class body, otherwise the file entity (index 0). The
 // index is guaranteed valid (the file entity always exists).
-func (x *extractor) angularRouteOwner(obj *sitter.Node) (string, int) {
+func (x *extractor) angularRouteOwner(obj ts.Node) (string, int) {
 	for n := obj.Parent(); n != nil; n = n.Parent() {
 		if n.Type() != "class_declaration" {
 			continue
@@ -159,7 +159,7 @@ func (x *extractor) angularRouteOwner(obj *sitter.Node) (string, int) {
 // object-map (di_role=resolver) and best-effort functional guards (the
 // inject(Service) target). Duplicate (target, role) pairs within a route are
 // de-duplicated.
-func (x *extractor) angularRouteGuardEdges(obj *sitter.Node, route, owner string) []types.RelationshipRecord {
+func (x *extractor) angularRouteGuardEdges(obj ts.Node, route, owner string) []types.RelationshipRecord {
 	var edges []types.RelationshipRecord
 	seen := map[string]bool{}
 
@@ -233,7 +233,7 @@ type angularGuardTarget struct {
 // identifier element is a class guard. An arrow-function element is a functional
 // guard — best-effort resolved to the first `inject(Service)` class referenced
 // in its body; if none is statically recoverable the element is dropped.
-func (x *extractor) angularGuardArrayTargets(arr *sitter.Node) []angularGuardTarget {
+func (x *extractor) angularGuardArrayTargets(arr ts.Node) []angularGuardTarget {
 	if arr == nil || arr.Type() != "array" {
 		return nil
 	}
@@ -262,7 +262,7 @@ func (x *extractor) angularGuardArrayTargets(arr *sitter.Node) []angularGuardTar
 // of an inline functional guard: the first-argument identifier of an
 // `inject(ServiceClass)` call inside the arrow body. Returns "" when no static
 // inject(...) target is present (the honest-skip path).
-func (x *extractor) angularFunctionalGuardService(fn *sitter.Node) string {
+func (x *extractor) angularFunctionalGuardService(fn ts.Node) string {
 	for _, call := range findAllNodes(fn, "call_expression") {
 		callee := call.ChildByFieldName("function")
 		if callee == nil || x.nodeText(callee) != "inject" {

--- a/internal/extractors/javascript/angular_rxjs_guards.go
+++ b/internal/extractors/javascript/angular_rxjs_guards.go
@@ -42,7 +42,7 @@ import (
 	"regexp"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -84,7 +84,7 @@ var angularRxjsSubjects = map[string]bool{
 // and subjects (issue #2874 — rxjs_pattern_detection). Each entity carries the
 // component name + framework so it is attributable to the class via the
 // CONTAINS edges handleAngularClass appends.
-func (x *extractor) angularRxjsPatterns(body *sitter.Node, className string) []types.EntityRecord {
+func (x *extractor) angularRxjsPatterns(body ts.Node, className string) []types.EntityRecord {
 	if body == nil {
 		return nil
 	}
@@ -211,7 +211,7 @@ func (x *extractor) angularRxjsPatterns(body *sitter.Node, className string) []t
 // call's argument list. Every call_expression argument is treated as an
 // operator stage; its callee leaf name is the operator. Bare identifiers (a
 // pre-built operator reference passed without a call) are also captured.
-func (x *extractor) angularPipeOperators(call *sitter.Node) []string {
+func (x *extractor) angularPipeOperators(call ts.Node) []string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return nil
@@ -330,7 +330,7 @@ var angularGuardFnTypes = map[string]string{
 // angularClassGuardSubtype inspects a class_declaration's heritage clause and
 // returns ("angular_guard"|"angular_interceptor", interfaceName) when the class
 // implements an Angular guard or HttpInterceptor interface, else ("", "").
-func (x *extractor) angularClassGuardSubtype(class *sitter.Node) (string, string) {
+func (x *extractor) angularClassGuardSubtype(class ts.Node) (string, string) {
 	if class == nil {
 		return "", ""
 	}
@@ -376,7 +376,7 @@ func (x *extractor) angularClassGuardSubtype(class *sitter.Node) (string, string
 // IMPLEMENTS edge to the guard interface). The role vocabulary matches the
 // functional form (angularFunctionalGuards) so guard/interceptor queries are
 // uniform across class and functional shapes.
-func (x *extractor) angularGuardClassRels(class *sitter.Node, className string) (role, iface string, rels []types.RelationshipRecord) {
+func (x *extractor) angularGuardClassRels(class ts.Node, className string) (role, iface string, rels []types.RelationshipRecord) {
 	subtype, iface := x.angularClassGuardSubtype(class)
 	if subtype == "" {
 		return "", "", nil
@@ -403,7 +403,7 @@ func (x *extractor) angularGuardClassRels(class *sitter.Node, className string) 
 // siblings). It emits one SCOPE.Component entity per match (subtype
 // angular_guard / angular_interceptor) so functional guards are first-class
 // alongside the class form. Called as a program-level pass from Extract.
-func (x *extractor) angularFunctionalGuards(root *sitter.Node) {
+func (x *extractor) angularFunctionalGuards(root ts.Node) {
 	if root == nil {
 		return
 	}

--- a/internal/extractors/javascript/branchconditions.go
+++ b/internal/extractors/javascript/branchconditions.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -65,7 +65,7 @@ type branchHit struct {
 // extractBranchHits walks a function/method/arrow body and returns one
 // branchHit per unique condition expression found in an if/ternary/switch
 // whose controlling expression contains a comparison operator.
-func (x *extractor) extractBranchHits(body *sitter.Node) []branchHit {
+func (x *extractor) extractBranchHits(body ts.Node) []branchHit {
 	if body == nil {
 		return nil
 	}
@@ -74,7 +74,7 @@ func (x *extractor) extractBranchHits(body *sitter.Node) []branchHit {
 
 	defer func() { _ = recover() }()
 
-	add := func(cond *sitter.Node, kind branchKind) {
+	add := func(cond ts.Node, kind branchKind) {
 		if cond == nil {
 			return
 		}
@@ -122,7 +122,7 @@ func (x *extractor) extractBranchHits(body *sitter.Node) []branchHit {
 // comparison. It handles binary comparisons directly, and descends through
 // logical && / || compositions so `if (a < b && c !== d)` is recognised by its
 // first comparison operand. A bare boolean (`if (this.enabled)`) returns false.
-func (x *extractor) branchComparisonOp(n *sitter.Node) (string, bool) {
+func (x *extractor) branchComparisonOp(n ts.Node) (string, bool) {
 	if n == nil {
 		return "", false
 	}
@@ -154,7 +154,7 @@ func (x *extractor) branchComparisonOp(n *sitter.Node) (string, bool) {
 // member access or plain identifier worth recording as a branch discriminant
 // (e.g. `this._status`, `mode`). Calls, literals and complex expressions are
 // excluded to keep the signal focused on stateful branching.
-func isBranchOperand(n *sitter.Node) bool {
+func isBranchOperand(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -166,7 +166,7 @@ func isBranchOperand(n *sitter.Node) bool {
 }
 
 // binaryOperator returns the operator token of a binary_expression node.
-func (x *extractor) binaryOperator(n *sitter.Node) string {
+func (x *extractor) binaryOperator(n ts.Node) string {
 	if n == nil {
 		return ""
 	}
@@ -185,7 +185,7 @@ func (x *extractor) binaryOperator(n *sitter.Node) string {
 
 // unwrapParen strips a single layer of parenthesized_expression so callers see
 // the inner comparison directly.
-func unwrapParen(n *sitter.Node) *sitter.Node {
+func unwrapParen(n ts.Node) ts.Node {
 	if n != nil && n.Type() == "parenthesized_expression" {
 		// the inner expression is the named child
 		for i := 0; i < int(n.ChildCount()); i++ {
@@ -207,7 +207,7 @@ func normalizeBranchExpr(s string) string {
 // stampBranchConditions stamps Properties["branch_conditions"] on the last
 // entity appended to x.entities and emits BRANCHES_ON edges (#2885). Called
 // immediately after stampDiscriminators for each emitted method/function/arrow.
-func (x *extractor) stampBranchConditions(body *sitter.Node) {
+func (x *extractor) stampBranchConditions(body ts.Node) {
 	if body == nil || len(x.entities) == 0 {
 		return
 	}

--- a/internal/extractors/javascript/class_arrow_measure_test.go
+++ b/internal/extractors/javascript/class_arrow_measure_test.go
@@ -14,7 +14,8 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tsjavascript "github.com/smacker/go-tree-sitter/javascript"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
@@ -98,13 +99,18 @@ func TestClassArrow_Measurement(t *testing.T) {
 				if err != nil {
 					return nil
 				}
-				parser := sitter.NewParser()
+				var grammar ts.Language
 				if lang == "typescript" {
-					parser.SetLanguage(tstypescript.GetLanguage())
+					grammar = tssmacker.WrapLanguage(tstypescript.GetLanguage())
 				} else {
-					parser.SetLanguage(tsjavascript.GetLanguage())
+					grammar = tssmacker.WrapLanguage(tsjavascript.GetLanguage())
 				}
-				tree, parseErr := parser.ParseCtx(context.Background(), nil, body)
+				parser, parserErr := tssmacker.New().NewParser(grammar)
+				if parserErr != nil {
+					return nil
+				}
+				defer parser.Close()
+				tree, parseErr := parser.Parse(body)
 				if parseErr != nil || tree == nil {
 					return nil
 				}
@@ -112,7 +118,7 @@ func TestClassArrow_Measurement(t *testing.T) {
 					Path:     p,
 					Content:  body,
 					Language: lang,
-					Tree:     tree,
+					TSTree:   tree,
 				})
 				if extractErr != nil {
 					return nil

--- a/internal/extractors/javascript/class_validator_fields.go
+++ b/internal/extractors/javascript/class_validator_fields.go
@@ -3,7 +3,7 @@ package javascript
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // Issue #4858 — per-field validation constraints for DTO fields.
@@ -88,7 +88,7 @@ var scalarArgDecorators = map[string]bool{
 // (or `field_definition`) node and returns the recognised class-validator
 // constraints as a compact, source-ordered list. Returns nil when the field
 // carries no class-validator decorators.
-func (x *extractor) fieldValidations(field *sitter.Node) []string {
+func (x *extractor) fieldValidations(field ts.Node) []string {
 	if field == nil {
 		return nil
 	}
@@ -124,7 +124,7 @@ func (x *extractor) fieldValidations(field *sitter.Node) []string {
 // call_expression when it is a simple numeric / string / identifier literal.
 // Compound arguments (objects, arrays, regexes, expressions) yield "" so the
 // caller falls back to the bare decorator name.
-func firstScalarArg(x *extractor, call *sitter.Node) string {
+func firstScalarArg(x *extractor, call ts.Node) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""

--- a/internal/extractors/javascript/config_consumer.go
+++ b/internal/extractors/javascript/config_consumer.go
@@ -21,7 +21,7 @@
 package javascript
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -29,15 +29,15 @@ import (
 // emitConfigConsumerEdges scans the AST for config-read shapes and appends
 // config-key entities + DEPENDS_ON_CONFIG edges to x.entities. x.entities[0]
 // MUST be the file entity. Safe with an empty tree.
-func (x *extractor) emitConfigConsumerEdges(root *sitter.Node) {
+func (x *extractor) emitConfigConsumerEdges(root ts.Node) {
 	if root == nil || len(x.entities) == 0 {
 		return
 	}
 
 	var reads []extreg.ConfigRead
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -92,7 +92,7 @@ func (x *extractor) emitConfigConsumerEdges(root *sitter.Node) {
 
 // jsMemberConfigKey returns the config key for process.env.KEY or
 // import.meta.env.KEY member expressions, or "" otherwise.
-func jsMemberConfigKey(x *extractor, n *sitter.Node) string {
+func jsMemberConfigKey(x *extractor, n ts.Node) string {
 	obj := n.ChildByFieldName("object")
 	prop := n.ChildByFieldName("property")
 	if obj == nil || prop == nil || prop.Type() != "property_identifier" {
@@ -108,7 +108,7 @@ func jsMemberConfigKey(x *extractor, n *sitter.Node) string {
 
 // jsSubscriptConfigKey returns the config key for process.env['KEY'] /
 // import.meta.env['KEY'] subscript expressions with a literal string index.
-func jsSubscriptConfigKey(x *extractor, n *sitter.Node) string {
+func jsSubscriptConfigKey(x *extractor, n ts.Node) string {
 	obj := n.ChildByFieldName("object")
 	idx := n.ChildByFieldName("index")
 	if obj == nil || idx == nil {
@@ -126,7 +126,7 @@ func jsSubscriptConfigKey(x *extractor, n *sitter.Node) string {
 
 // jsConfigGetKey returns the config key for a node-config `config.get('k')` /
 // `config.has('k')` call with a literal string argument, or "".
-func jsConfigGetKey(x *extractor, call *sitter.Node) string {
+func jsConfigGetKey(x *extractor, call ts.Node) string {
 	fn := call.ChildByFieldName("function")
 	args := call.ChildByFieldName("arguments")
 	if fn == nil || args == nil || fn.Type() != "member_expression" {

--- a/internal/extractors/javascript/dataflow_react.go
+++ b/internal/extractors/javascript/dataflow_react.go
@@ -29,7 +29,7 @@ package javascript
 import (
 	"fmt"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -48,7 +48,7 @@ import (
 //
 // A second `ref`/context parameter (forwardRef) is ignored — only the first
 // parameter carries props in React.
-func (x *extractor) extractComponentProps(params *sitter.Node, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
+func (x *extractor) extractComponentProps(params ts.Node, componentName string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	if params == nil || !isComponentName(componentName) {
 		return nil, nil
 	}
@@ -60,7 +60,7 @@ func (x *extractor) extractComponentProps(params *sitter.Node, componentName str
 	var ents []types.EntityRecord
 	var rels []types.RelationshipRecord
 
-	emit := func(propName, sig string, node *sitter.Node) {
+	emit := func(propName, sig string, node ts.Node) {
 		if propName == "" {
 			return
 		}
@@ -123,7 +123,7 @@ func (x *extractor) extractComponentProps(params *sitter.Node, componentName str
 
 // firstFormalParameter returns the first non-punctuation child of a
 // formal_parameters node (the parameter list `( … )`).
-func firstFormalParameter(params *sitter.Node) *sitter.Node {
+func firstFormalParameter(params ts.Node) ts.Node {
 	for i := 0; i < int(params.ChildCount()); i++ {
 		c := params.Child(i)
 		if c == nil {
@@ -141,7 +141,7 @@ func firstFormalParameter(params *sitter.Node) *sitter.Node {
 // bindingPatternOf unwraps a TS required_parameter/optional_parameter to its
 // `pattern` child, or returns the node directly when it is already a pattern
 // (JS grammar shape).
-func bindingPatternOf(param *sitter.Node) *sitter.Node {
+func bindingPatternOf(param ts.Node) ts.Node {
 	switch param.Type() {
 	case "required_parameter", "optional_parameter":
 		if p := param.ChildByFieldName("pattern"); p != nil {
@@ -164,7 +164,7 @@ func bindingPatternOf(param *sitter.Node) *sitter.Node {
 // object_pattern, handling shorthand (`{ title }`), renamed (`{ title: t }`),
 // and defaulted (`{ count = 0 }`) forms. The key (exported name) is captured —
 // it is the prop the parent passes.
-func objectPatternFields(x *extractor, pat *sitter.Node) []string {
+func objectPatternFields(x *extractor, pat ts.Node) []string {
 	var out []string
 	seen := map[string]bool{}
 	add := func(name string) {

--- a/internal/extractors/javascript/destructure_bindings.go
+++ b/internal/extractors/javascript/destructure_bindings.go
@@ -38,8 +38,8 @@ package javascript
 import (
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // PropViaDestructuredBinding is the Properties["via"] value stamped on CALLS
@@ -86,14 +86,14 @@ type destructureBinding struct {
 // to avoid collecting bindings that are not visible at the caller's scope level.
 //
 // Returns nil when no relevant bindings are found (fast-path).
-func (x *extractor) buildDestructureBindings(scope *sitter.Node) map[string]*destructureBinding {
+func (x *extractor) buildDestructureBindings(scope ts.Node) map[string]*destructureBinding {
 	if scope == nil {
 		return nil
 	}
 
 	result := make(map[string]*destructureBinding)
 
-	stack := make([]*sitter.Node, 0, 32)
+	stack := make([]ts.Node, 0, 32)
 	stack = append(stack, scope)
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
@@ -142,7 +142,7 @@ func (x *extractor) buildDestructureBindings(scope *sitter.Node) map[string]*des
 // When the LHS is a plain identifier and the RHS is a Zustand hook call whose
 // first argument is a simple member-expression arrow (s => s.action or s => s?.action),
 // one binding is registered: localName → actionName via=zustand_selector.
-func (x *extractor) scanDestructureDeclarator(decl *sitter.Node, out map[string]*destructureBinding) {
+func (x *extractor) scanDestructureDeclarator(decl ts.Node, out map[string]*destructureBinding) {
 	nameNode := decl.ChildByFieldName("name")
 	if nameNode == nil {
 		return
@@ -263,7 +263,7 @@ func (x *extractor) scanDestructureDeclarator(decl *sitter.Node, out map[string]
 // return calleeBase="" so the action name is used directly (it is already unique
 // within the store namespace in practice).  For React Query fields like "mutate",
 // the local field name is itself the canonical target.
-func (x *extractor) classifyDestructureRHS(value *sitter.Node) (via, calleeBase string) {
+func (x *extractor) classifyDestructureRHS(value ts.Node) (via, calleeBase string) {
 	if value == nil {
 		return "", ""
 	}
@@ -322,7 +322,7 @@ func (x *extractor) classifyDestructureRHS(value *sitter.Node) (via, calleeBase 
 // Returns (storeVar, actionName) on success or ("", "") when the node does not match.
 // Issue #2631 — storeVar is returned so callers can build the qualified entity ID
 // <storeVar>::<actionName> instead of the bare action name.
-func (x *extractor) parseSelectorArrowFn(value *sitter.Node) (string, string) {
+func (x *extractor) parseSelectorArrowFn(value ts.Node) (string, string) {
 	if value == nil || value.Type() != "call_expression" {
 		return "", ""
 	}
@@ -342,7 +342,7 @@ func (x *extractor) parseSelectorArrowFn(value *sitter.Node) (string, string) {
 		return "", ""
 	}
 	// Find the first non-punctuation child of the arguments node.
-	var arrowNode *sitter.Node
+	var arrowNode ts.Node
 	for i := 0; i < int(argsNode.ChildCount()); i++ {
 		child := argsNode.Child(i)
 		if child == nil {
@@ -372,7 +372,7 @@ func (x *extractor) parseSelectorArrowFn(value *sitter.Node) (string, string) {
 	// For optional_chain (s?.x) the grammar nests differently; normalise by
 	// accepting either member_expression or optional_chain and extracting the
 	// rightmost property identifier.
-	var propNode *sitter.Node
+	var propNode ts.Node
 	switch bodyNode.Type() {
 	case "member_expression":
 		// Verify that the object side is the arrow param — prevents chained
@@ -408,7 +408,7 @@ func (x *extractor) parseSelectorArrowFn(value *sitter.Node) (string, string) {
 // calleeLeafName extracts the trailing identifier name from a function expression node.
 // For `identifier` nodes returns the name directly.
 // For `member_expression` nodes returns the property name.
-func (x *extractor) calleeLeafName(fn *sitter.Node) string {
+func (x *extractor) calleeLeafName(fn ts.Node) string {
 	if fn == nil {
 		return ""
 	}

--- a/internal/extractors/javascript/discriminator.go
+++ b/internal/extractors/javascript/discriminator.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -43,8 +43,8 @@ type discriminatorHit struct {
 // and returns a comma-separated "var=value" string for every discriminator
 // comparison found. Returns "" when no discriminators are found or body is nil.
 //
-// Signature: func (x *extractor) extractDiscriminators(body *sitter.Node) string
-func (x *extractor) extractDiscriminators(body *sitter.Node) string {
+// Signature: func (x *extractor) extractDiscriminators(body ts.Node) string
+func (x *extractor) extractDiscriminators(body ts.Node) string {
 	hits := x.extractDiscriminatorHits(body)
 	if len(hits) == 0 {
 		return ""
@@ -59,7 +59,7 @@ func (x *extractor) extractDiscriminators(body *sitter.Node) string {
 // extractDiscriminatorHits walks the body and returns one discriminatorHit per
 // unique (var, literal) pair found. Used by stampDiscriminators (#2666) to
 // emit DISCRIMINATES_ON edges with line + literal properties.
-func (x *extractor) extractDiscriminatorHits(body *sitter.Node) []discriminatorHit {
+func (x *extractor) extractDiscriminatorHits(body ts.Node) []discriminatorHit {
 	if body == nil {
 		return nil
 	}
@@ -96,7 +96,7 @@ func (x *extractor) extractDiscriminatorHits(body *sitter.Node) []discriminatorH
 //
 // Symmetric form: if LHS is a literal and RHS is an identifier (e.g. `1 === status`)
 // the pair is also captured with (identifier, literal) order.
-func (x *extractor) discriminatorFromBinary(n *sitter.Node) (varName, litVal string, ok bool) {
+func (x *extractor) discriminatorFromBinary(n ts.Node) (varName, litVal string, ok bool) {
 	if n == nil || n.Type() != "binary_expression" {
 		return "", "", false
 	}
@@ -157,7 +157,7 @@ func (x *extractor) discriminatorFromBinary(n *sitter.Node) (varName, litVal str
 // a literal). Note: unary_expression where operator is "-" followed by a number
 // literal (negative numbers) would be missed; that is an acceptable trade-off
 // since negative numeric discriminators are uncommon in real UI code.
-func isDiscriminatorLiteral(n *sitter.Node) bool {
+func isDiscriminatorLiteral(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -174,7 +174,7 @@ func isDiscriminatorLiteral(n *sitter.Node) bool {
 // discriminatorLiteralValue extracts the display value from a literal node.
 // String literals have their surrounding quotes stripped. Other literals
 // return their raw text.
-func (x *extractor) discriminatorLiteralValue(n *sitter.Node) string {
+func (x *extractor) discriminatorLiteralValue(n ts.Node) string {
 	if n == nil {
 		return ""
 	}
@@ -200,7 +200,7 @@ func (x *extractor) discriminatorLiteralValue(n *sitter.Node) string {
 // stampDiscriminators stamps Properties["discriminators"] on the last entity
 // appended to x.entities when the discriminators string is non-empty.
 // Called immediately after emitting a function/method/arrow entity.
-func (x *extractor) stampDiscriminators(body *sitter.Node) {
+func (x *extractor) stampDiscriminators(body ts.Node) {
 	if body == nil || len(x.entities) == 0 {
 		return
 	}

--- a/internal/extractors/javascript/enum_valueset.go
+++ b/internal/extractors/javascript/enum_valueset.go
@@ -18,7 +18,7 @@ package javascript
 //     (`string | Foo`) is NOT an enumerated value-set → no node.
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -26,7 +26,7 @@ import (
 // emitTSEnumValueSet builds the value-carrying SCOPE.Enum node for a TS
 // `enum_declaration`, capturing each member's explicit literal value when the
 // member is an `enum_assignment` with a string/number RHS.
-func (x *extractor) emitTSEnumValueSet(n *sitter.Node, name string) {
+func (x *extractor) emitTSEnumValueSet(n ts.Node, name string) {
 	body := n.ChildByFieldName("body")
 	if body == nil {
 		return
@@ -83,7 +83,7 @@ func (x *extractor) emitTSEnumValueSet(n *sitter.Node, name string) {
 // ONLY when the RHS is a union_type whose EVERY arm is a literal_type wrapping
 // a string/number literal. Any non-literal arm (type reference, predefined
 // type, object type) disqualifies the alias — it is not an enumerated value-set.
-func (x *extractor) emitTSLiteralUnionValueSet(n *sitter.Node, name string) {
+func (x *extractor) emitTSLiteralUnionValueSet(n ts.Node, name string) {
 	valueNode := n.ChildByFieldName("value")
 	if valueNode == nil || valueNode.Type() != "union_type" {
 		return
@@ -105,7 +105,7 @@ func (x *extractor) emitTSLiteralUnionValueSet(n *sitter.Node, name string) {
 // one EnumMember per literal arm. It returns false the moment it encounters a
 // non-literal arm (type reference, predefined type, object type) so the caller
 // emits no value-set node for a non-enumerated union.
-func collectUnionLiterals(u *sitter.Node, x *extractor, out *[]extreg.EnumMember) bool {
+func collectUnionLiterals(u ts.Node, x *extractor, out *[]extreg.EnumMember) bool {
 	for i := 0; i < int(u.ChildCount()); i++ {
 		arm := u.Child(i)
 		if arm == nil || !arm.IsNamed() {
@@ -143,7 +143,7 @@ func collectUnionLiterals(u *sitter.Node, x *extractor, out *[]extreg.EnumMember
 // enumerated constant set and emits no node. The `as const` assertion is the
 // strong signal but not required (a permission-style all-literal map qualifies);
 // any non-literal value disqualifies the object.
-func (x *extractor) emitTSConstObjectValueSet(name string, valueNode *sitter.Node) {
+func (x *extractor) emitTSConstObjectValueSet(name string, valueNode ts.Node) {
 	if name == "" || valueNode == nil {
 		return
 	}
@@ -199,7 +199,7 @@ func (x *extractor) emitTSConstObjectValueSet(name string, valueNode *sitter.Nod
 // `satisfies` assertion is the author's explicit "this is a closed, immutable
 // value-set" signal that distinguishes the v3 PermissionPage map (#4420) from
 // an incidental config object.
-func unwrapAsConstObject(valueNode *sitter.Node) *sitter.Node {
+func unwrapAsConstObject(valueNode ts.Node) ts.Node {
 	switch valueNode.Type() {
 	case "as_expression", "satisfies_expression":
 		if inner := valueNode.NamedChild(0); inner != nil && inner.Type() == "object" {
@@ -212,7 +212,7 @@ func unwrapAsConstObject(valueNode *sitter.Node) *sitter.Node {
 // constObjectKey reduces an object-literal key node to its bare key string,
 // handling `property_identifier` (Foo:), `string` ('Foo':) and `number` keys.
 // Computed keys ([expr]:) yield "" (skipped).
-func constObjectKey(keyNode *sitter.Node, x *extractor) string {
+func constObjectKey(keyNode ts.Node, x *extractor) string {
 	if keyNode == nil {
 		return ""
 	}
@@ -230,7 +230,7 @@ func constObjectKey(keyNode *sitter.Node, x *extractor) string {
 // tsLiteralValue returns the statically-known literal text of a TS value node
 // (string / number / unary minus number), with surrounding quotes stripped.
 // Returns "" for non-literal nodes so callers can treat that as "not a literal".
-func tsLiteralValue(n *sitter.Node, x *extractor) string {
+func tsLiteralValue(n ts.Node, x *extractor) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/javascript/exception_flow.go
+++ b/internal/extractors/javascript/exception_flow.go
@@ -25,7 +25,7 @@
 package javascript
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -33,15 +33,15 @@ import (
 // emitExceptionFlowEdges scans the AST for typed throw / instanceof-catch
 // shapes and appends exception-type entities + THROWS / CATCHES edges to
 // x.entities. x.entities[0] MUST be the file entity. Safe with an empty tree.
-func (x *extractor) emitExceptionFlowEdges(root *sitter.Node) {
+func (x *extractor) emitExceptionFlowEdges(root ts.Node) {
 	if root == nil || len(x.entities) == 0 {
 		return
 	}
 
 	var edges []extreg.ExceptionEdge
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -97,9 +97,9 @@ func (x *extractor) emitExceptionFlowEdges(root *sitter.Node) {
 // (including `throw new mod.X(...)` → bare X), or "" for any non-`new` throw
 // (re-throw of a variable, object literal, computed expression) — those carry
 // no identifiable type and are dropped.
-func jsThrowType(x *extractor, throwNode *sitter.Node) string {
+func jsThrowType(x *extractor, throwNode ts.Node) string {
 	// The thrown expression is the first named child of throw_statement.
-	var expr *sitter.Node
+	var expr ts.Node
 	for i := 0; i < int(throwNode.NamedChildCount()); i++ {
 		c := throwNode.NamedChild(i)
 		if c != nil {
@@ -131,15 +131,15 @@ func jsThrowType(x *extractor, throwNode *sitter.Node) string {
 // bindings are untyped, the instanceof test is the only informative catch
 // signal. Returns nil when the catch body contains no instanceof test (untyped
 // catch → no CATCHES edge, honest-partial).
-func jsCatchInstanceofTypes(x *extractor, catchNode *sitter.Node) []string {
+func jsCatchInstanceofTypes(x *extractor, catchNode ts.Node) []string {
 	body := catchNode.ChildByFieldName("body")
 	if body == nil {
 		return nil
 	}
 	seen := map[string]bool{}
 	var out []string
-	var scan func(n *sitter.Node)
-	scan = func(n *sitter.Node) {
+	var scan func(n ts.Node)
+	scan = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -165,7 +165,7 @@ func jsCatchInstanceofTypes(x *extractor, catchNode *sitter.Node) []string {
 
 // jsInstanceofTypeName extracts the bare type name from the right-hand side of
 // an instanceof test: an identifier, or a qualified `mod.Type` member.
-func jsInstanceofTypeName(x *extractor, right *sitter.Node) string {
+func jsInstanceofTypeName(x *extractor, right ts.Node) string {
 	switch right.Type() {
 	case "identifier", "type_identifier":
 		return x.nodeText(right)

--- a/internal/extractors/javascript/external_service.go
+++ b/internal/extractors/javascript/external_service.go
@@ -36,7 +36,7 @@ package javascript
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -45,7 +45,7 @@ import (
 // rooted at a recognised external-service import and appends external-service
 // entities + DEPENDS_ON_SERVICE edges to x.entities. x.entities[0] MUST be the
 // file entity. Safe with an empty tree or no imports.
-func (x *extractor) emitServiceDependencyEdges(root *sitter.Node) {
+func (x *extractor) emitServiceDependencyEdges(root ts.Node) {
 	if root == nil || len(x.entities) == 0 || len(x.importByLocal) == 0 {
 		return
 	}
@@ -57,8 +57,8 @@ func (x *extractor) emitServiceDependencyEdges(root *sitter.Node) {
 
 	var calls []extreg.ServiceCall
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -117,7 +117,7 @@ func (x *extractor) emitServiceDependencyEdges(root *sitter.Node) {
 // For AWS client constructors (`new S3Client(...)`, `new SESClient(...)`) the
 // service is derived from the constructor name suffix, since aws-sdk v3 names
 // the service in the class.
-func (x *extractor) jsNewExpressionService(newNode *sitter.Node) (string, string) {
+func (x *extractor) jsNewExpressionService(newNode ts.Node) (string, string) {
 	ctor := newNode.ChildByFieldName("constructor")
 	if ctor == nil {
 		return "", ""
@@ -161,7 +161,7 @@ func (x *extractor) jsNewExpressionService(newNode *sitter.Node) (string, string
 // is either a known SDK import binding (`sgMail.send`, `Sentry.init`) or a
 // local variable previously constructed from an SDK (`stripe.charges.create`).
 // Returns the service and the dotted operation tail, or "" when no SDK root.
-func (x *extractor) jsCallService(call *sitter.Node, localVarService map[string]string) (string, string) {
+func (x *extractor) jsCallService(call ts.Node, localVarService map[string]string) (string, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "member_expression" {
 		return "", ""
@@ -200,7 +200,7 @@ func (x *extractor) importedServiceRoot(local string) string {
 // the dotted property tail. For `stripe.charges.create` it returns ("stripe",
 // "charges.create"); for `sgMail.send` it returns ("sgMail", "send"). Returns
 // ("", "") when the chain does not root at a plain identifier.
-func (x *extractor) jsMemberRootAndTail(member *sitter.Node) (string, string) {
+func (x *extractor) jsMemberRootAndTail(member ts.Node) (string, string) {
 	var parts []string
 	node := member
 	for node != nil && node.Type() == "member_expression" {

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -32,7 +32,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -85,7 +85,7 @@ func (e *JSExtractor) Language() string {
 
 // Extract processes a parsed JS/TS source file and returns entity records.
 //
-// The tree-sitter parse tree (file.Tree) may be nil for empty files, in which
+// The tree-sitter parse tree (file.TSTree) may be nil for empty files, in which
 // case an empty slice is returned. Partial results are returned when individual
 // node queries fail; errors are logged but never abort the full extraction.
 func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
@@ -99,7 +99,7 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	)
 	defer span.End()
 
-	if len(file.Content) == 0 || file.Tree == nil {
+	if len(file.Content) == 0 || file.TSTree == nil {
 		span.SetAttributes(
 			attribute.Int("entity_count", 0),
 			attribute.Int("relationship_count", 0),
@@ -107,7 +107,7 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		return nil, nil
 	}
 
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	if root == nil {
 		return nil, nil
 	}
@@ -676,7 +676,7 @@ type classBindings struct {
 }
 
 // nodeText returns the UTF-8 text of a tree-sitter node.
-func (x *extractor) nodeText(n *sitter.Node) string {
+func (x *extractor) nodeText(n ts.Node) string {
 	if n == nil {
 		return ""
 	}
@@ -689,7 +689,7 @@ func (x *extractor) nodeText(n *sitter.Node) string {
 }
 
 // lines returns (startLine, endLine) for a node, 1-indexed.
-func lines(n *sitter.Node) (int, int) {
+func lines(n ts.Node) (int, int) {
 	start := int(n.StartPoint().Row) + 1
 	end := int(n.EndPoint().Row) + 1
 	return start, end
@@ -708,7 +708,7 @@ func (x *extractor) qualify(name string) string {
 }
 
 // emit appends an entity to the extraction results.
-func (x *extractor) emit(name, kind string, n *sitter.Node, subtype string, sig string) {
+func (x *extractor) emit(name, kind string, n ts.Node, subtype string, sig string) {
 	if name == "" || name == "?" {
 		return
 	}
@@ -717,7 +717,7 @@ func (x *extractor) emit(name, kind string, n *sitter.Node, subtype string, sig 
 
 // emitWithRels appends an entity to the extraction results carrying the
 // supplied embedded relationships.
-func (x *extractor) emitWithRels(name, kind string, n *sitter.Node, subtype string, sig string, rels []types.RelationshipRecord) {
+func (x *extractor) emitWithRels(name, kind string, n ts.Node, subtype string, sig string, rels []types.RelationshipRecord) {
 	if name == "" || name == "?" {
 		return
 	}
@@ -763,7 +763,7 @@ func (x *extractor) tagLocalScope(from int) {
 // emitWithProps appends an entity to the extraction results using a caller-supplied
 // Properties map rather than the default {"kind": ..., "subtype": ...} map.
 // Used by handlers that need to store structured metadata (fields, generics, etc.).
-func (x *extractor) emitWithProps(name, kind string, n *sitter.Node, subtype string, sig string, props map[string]string, rels []types.RelationshipRecord) {
+func (x *extractor) emitWithProps(name, kind string, n ts.Node, subtype string, sig string, props map[string]string, rels []types.RelationshipRecord) {
 	if name == "" || name == "?" {
 		return
 	}
@@ -800,7 +800,7 @@ var txOperationSubtypes = map[string]bool{
 // `.transaction(...)` call (or @Transaction() decorator) is lexically present
 // in the entity's source span. No transitive propagation — a callee that merely
 // receives an EntityManager but does not open a transaction is not stamped.
-func (x *extractor) stampTransactional(e *types.EntityRecord, n *sitter.Node, subtype string) {
+func (x *extractor) stampTransactional(e *types.EntityRecord, n ts.Node, subtype string) {
 	if n == nil || !txOperationSubtypes[subtype] {
 		return
 	}
@@ -817,7 +817,7 @@ func (x *extractor) stampTransactional(e *types.EntityRecord, n *sitter.Node, su
 // typed CALLS edges can resolve `this.<field>.<method>` and `<field>.<method>`
 // shapes to the import-declared type (issue #421). cb is nil outside a
 // class body.
-func (x *extractor) walk(n *sitter.Node, parentClass string, cb *classBindings) {
+func (x *extractor) walk(n ts.Node, parentClass string, cb *classBindings) {
 	if n == nil {
 		return
 	}
@@ -873,7 +873,7 @@ func (x *extractor) walk(n *sitter.Node, parentClass string, cb *classBindings) 
 	x.walkChildren(n, parentClass, cb)
 }
 
-func (x *extractor) walkChildren(n *sitter.Node, parentClass string, cb *classBindings) {
+func (x *extractor) walkChildren(n ts.Node, parentClass string, cb *classBindings) {
 	count := int(n.ChildCount())
 	for i := 0; i < count; i++ {
 		x.walk(n.Child(i), parentClass, cb)
@@ -881,7 +881,7 @@ func (x *extractor) walkChildren(n *sitter.Node, parentClass string, cb *classBi
 }
 
 // handleFunctionDeclaration handles: function foo(...) { ... }
-func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string, cb *classBindings) {
+func (x *extractor) handleFunctionDeclaration(n ts.Node, parentClass string, cb *classBindings) {
 	nameNode := n.ChildByFieldName("name")
 	name := x.nodeText(nameNode)
 	if name == "" {
@@ -950,7 +950,7 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 // Emits one CONTAINS edge per method/operation entity declared directly inside
 // the class body. The CONTAINS source is the class entity (FromID empty →
 // substituted at emit time); the target is the bare method name.
-func (x *extractor) handleClassDeclaration(n *sitter.Node) {
+func (x *extractor) handleClassDeclaration(n ts.Node) {
 	nameNode := n.ChildByFieldName("name")
 	className := x.nodeText(nameNode)
 	if className == "" {
@@ -1046,7 +1046,7 @@ func (x *extractor) handleClassDeclaration(n *sitter.Node) {
 }
 
 // handleMethodDefinition handles method definitions inside class bodies.
-func (x *extractor) handleMethodDefinition(n *sitter.Node, _ string, cb *classBindings) {
+func (x *extractor) handleMethodDefinition(n ts.Node, _ string, cb *classBindings) {
 	nameNode := n.ChildByFieldName("name")
 	name := x.nodeText(nameNode)
 	if name == "" || name == "constructor" {
@@ -1103,7 +1103,7 @@ func (x *extractor) handleMethodDefinition(n *sitter.Node, _ string, cb *classBi
 // NOT tagged (it is an ordinary property writer, not an observable state
 // setter), and the notify-call form must target a string-keyed property to
 // avoid catching unrelated set() calls (e.g. Set#add aliased to set).
-func (x *extractor) isNativeScriptStateSetter(body *sitter.Node) bool {
+func (x *extractor) isNativeScriptStateSetter(body ts.Node) bool {
 	if body == nil {
 		return false
 	}
@@ -1113,7 +1113,7 @@ func (x *extractor) isNativeScriptStateSetter(body *sitter.Node) bool {
 // bodyNotifiesObservable returns true when the statement block contains a
 // call to notifyPropertyChange(...) or this.set("<prop>", ...) — the two
 // NativeScript Observable mutation primitives.
-func (x *extractor) bodyNotifiesObservable(n *sitter.Node) bool {
+func (x *extractor) bodyNotifiesObservable(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -1174,7 +1174,7 @@ func (x *extractor) bodyNotifiesObservable(n *sitter.Node) bool {
 //
 // The emitted entity subtype is "method" — consistent with how
 // handleMethodDefinition classifies class methods.
-func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass string, cb *classBindings) {
+func (x *extractor) handlePublicFieldDefinition(n ts.Node, parentClass string, cb *classBindings) {
 	// TypeScript grammar: "name" field; JavaScript grammar: "property" field.
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil {
@@ -1299,7 +1299,7 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 // Also emits one EXTENDS relationship per base interface so the graph
 // captures the structural type hierarchy without requiring a resolver pass.
 // (issue #1343)
-func (x *extractor) handleInterfaceDeclaration(n *sitter.Node) {
+func (x *extractor) handleInterfaceDeclaration(n ts.Node) {
 	nameNode := n.ChildByFieldName("name")
 	name := x.nodeText(nameNode)
 	if name == "" {
@@ -1427,7 +1427,7 @@ func (x *extractor) handleInterfaceDeclaration(n *sitter.Node) {
 //   - "type_body"  : raw text of the right-hand-side type expression
 //
 // (issue #1343)
-func (x *extractor) handleTypeAliasDeclaration(n *sitter.Node) {
+func (x *extractor) handleTypeAliasDeclaration(n ts.Node) {
 	nameNode := n.ChildByFieldName("name")
 	name := x.nodeText(nameNode)
 	if name == "" {
@@ -1560,7 +1560,7 @@ func schemaFieldSignature(name string, optional bool, ann string) string {
 // colon and surrounding whitespace stripped, or "" when the member is
 // untyped. Works for public_field_definition, property_signature and
 // method_signature alike.
-func (x *extractor) fieldTypeAnnotation(member *sitter.Node) string {
+func (x *extractor) fieldTypeAnnotation(member ts.Node) string {
 	typeNode := member.ChildByFieldName("type")
 	if typeNode == nil {
 		return ""
@@ -1574,7 +1574,7 @@ func (x *extractor) fieldTypeAnnotation(member *sitter.Node) string {
 
 // fieldIsOptional reports whether a member declares the TypeScript optional
 // marker `?` (e.g. `name?: string`) as a direct child token.
-func (x *extractor) fieldIsOptional(member *sitter.Node) bool {
+func (x *extractor) fieldIsOptional(member ts.Node) bool {
 	for j := 0; j < int(member.ChildCount()); j++ {
 		if ch := member.Child(j); ch != nil && ch.Type() == "?" {
 			return true
@@ -1583,7 +1583,7 @@ func (x *extractor) fieldIsOptional(member *sitter.Node) bool {
 	return false
 }
 
-func (x *extractor) emitSchemaMemberFields(body *sitter.Node, owner string) ([]string, []types.RelationshipRecord) {
+func (x *extractor) emitSchemaMemberFields(body ts.Node, owner string) ([]string, []types.RelationshipRecord) {
 	if body == nil || owner == "" {
 		return nil, nil
 	}
@@ -1635,7 +1635,7 @@ func (x *extractor) emitSchemaMemberFields(body *sitter.Node, owner string) ([]s
 //   - "members" : comma-separated list of enum member names
 //
 // (issue #1343)
-func (x *extractor) handleEnumDeclaration(n *sitter.Node) {
+func (x *extractor) handleEnumDeclaration(n ts.Node) {
 	nameNode := n.ChildByFieldName("name")
 	name := x.nodeText(nameNode)
 	if name == "" {
@@ -1678,7 +1678,7 @@ func (x *extractor) handleEnumDeclaration(n *sitter.Node) {
 }
 
 // handleVariableDeclaration handles: const/let foo = (...) => {...} or = function(...) {...}
-func (x *extractor) handleVariableDeclaration(n *sitter.Node, parentClass string, cb *classBindings) {
+func (x *extractor) handleVariableDeclaration(n ts.Node, parentClass string, cb *classBindings) {
 	count := int(n.ChildCount())
 	for i := 0; i < count; i++ {
 		child := n.Child(i)
@@ -1689,7 +1689,7 @@ func (x *extractor) handleVariableDeclaration(n *sitter.Node, parentClass string
 }
 
 // handleVariableDeclarator processes a single variable_declarator node.
-func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string, cb *classBindings) {
+func (x *extractor) handleVariableDeclarator(n ts.Node, parentClass string, cb *classBindings) {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil {
 		return
@@ -1974,7 +1974,7 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 // the dotted shapes (`styled.div`, `createSlice(...).reducer`,
 // `Animated.createAnimatedComponent(...)`) we walk down the function
 // child to find the leaf identifier.
-func (x *extractor) isFunctionWrapperCall(n *sitter.Node) bool {
+func (x *extractor) isFunctionWrapperCall(n ts.Node) bool {
 	if n == nil || n.Type() != "call_expression" {
 		return false
 	}
@@ -2063,7 +2063,7 @@ func isHOCName(leaf string) bool {
 }
 
 // callArgCount returns the number of named argument nodes in a call_expression.
-func callArgCount(n *sitter.Node) int {
+func callArgCount(n ts.Node) int {
 	args := n.ChildByFieldName("arguments")
 	if args == nil {
 		return 0
@@ -2084,7 +2084,7 @@ func callArgCount(n *sitter.Node) int {
 //
 // Recognised factories: createContext (React), createNamedContext (common
 // utility wrapper shape), createOptionalContext (pattern from some React libs).
-func (x *extractor) isContextFactory(n *sitter.Node) bool {
+func (x *extractor) isContextFactory(n ts.Node) bool {
 	if n == nil || n.Type() != "call_expression" {
 		return false
 	}
@@ -2112,7 +2112,7 @@ func (x *extractor) isContextFactory(n *sitter.Node) bool {
 // function_expression body inside a wrapper-call value, or nil. Used
 // to attribute CALLS to the wrapped function rather than the wrapper
 // call expression as a whole.
-func (x *extractor) findInnerFunctionBody(n *sitter.Node) *sitter.Node {
+func (x *extractor) findInnerFunctionBody(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -2155,7 +2155,7 @@ func (x *extractor) findInnerFunctionBody(n *sitter.Node) *sitter.Node {
 // expression, producing a cluster of entities all reporting the same
 // start_line. Anchoring on the bound identifier attributes each entity to
 // its real declaration line.
-func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, opLift bool, stateHook bool, parentClass string, cb *classBindings) {
+func (x *extractor) emitDestructuredEntities(pattern, valueNode ts.Node, opLift bool, stateHook bool, parentClass string, cb *classBindings) {
 	if pattern == nil {
 		return
 	}
@@ -2168,7 +2168,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 	// anchorFor returns the node to use for line numbers for a given
 	// binding: the binding's own identifier node when available, else the
 	// shared fallback (#1616).
-	anchorFor := func(bind *sitter.Node) *sitter.Node {
+	anchorFor := func(bind ts.Node) ts.Node {
 		if bind != nil {
 			return bind
 		}
@@ -2194,8 +2194,8 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 		subtype = "const"
 	}
 
-	var walk func(p *sitter.Node, arrayIdx int)
-	walk = func(p *sitter.Node, arrayIdx int) {
+	var walk func(p ts.Node, arrayIdx int)
+	walk = func(p ts.Node, arrayIdx int) {
 		if p == nil {
 			return
 		}
@@ -2310,7 +2310,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 
 // firstIdentifierChild returns the first identifier-typed child of n, or nil.
 // Used to dig out the bound name from a rest_pattern wrapper.
-func firstIdentifierChild(n *sitter.Node) *sitter.Node {
+func firstIdentifierChild(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -2327,7 +2327,7 @@ func firstIdentifierChild(n *sitter.Node) *sitter.Node {
 // represents a JS/TS primitive literal (string, number, boolean, null, undefined,
 // template literal). Used by handleVariableDeclarator (#1968) to decide whether
 // a top-level const declaration should be emitted as SCOPE.Schema/constant.
-func isPrimitiveLiteralNode(n *sitter.Node) bool {
+func isPrimitiveLiteralNode(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -2347,7 +2347,7 @@ func isPrimitiveLiteralNode(n *sitter.Node) bool {
 // primitiveNodeValue returns the raw text of a primitive literal node, trimmed
 // of surrounding quotes for string nodes so the stored value is the bare string
 // content. Returns "" for non-string nodes or when the text is empty.
-func (x *extractor) primitiveNodeValue(n *sitter.Node) string {
+func (x *extractor) primitiveNodeValue(n ts.Node) string {
 	if n == nil {
 		return ""
 	}
@@ -2372,7 +2372,7 @@ func (x *extractor) primitiveNodeValue(n *sitter.Node) string {
 // isStateHookCall returns true when the RHS is a call to one of the built-in
 // React state hooks that return a [value, setter] tuple. Used by #513 to tag
 // array-pattern setters with subtype="state_setter".
-func isStateHookCall(x *extractor, valueNode *sitter.Node) bool {
+func isStateHookCall(x *extractor, valueNode ts.Node) bool {
 	if valueNode == nil || valueNode.Type() != "call_expression" {
 		return false
 	}
@@ -2423,7 +2423,7 @@ func isStateHookCall(x *extractor, valueNode *sitter.Node) bool {
 // non-callable bound name produces no false positives, only a slightly
 // wider candidate set for legitimate callable leaves like `mutate`,
 // `refetch`, `setError`.
-func isMutationStyleHookCall(x *extractor, valueNode *sitter.Node) bool {
+func isMutationStyleHookCall(x *extractor, valueNode ts.Node) bool {
 	if valueNode == nil || valueNode.Type() != "call_expression" {
 		return false
 	}
@@ -2540,7 +2540,7 @@ func isMutationStyleHookName(leaf string) bool {
 // frame carries the receiver-type bindings visible in the caller's scope:
 // merged class fields (from the enclosing class body) + the caller's own
 // typed parameters. nil means "no typed receiver lookup possible".
-func (x *extractor) extractCallRelationships(body *sitter.Node, callerName string, frame *classBindings) []types.RelationshipRecord {
+func (x *extractor) extractCallRelationships(body ts.Node, callerName string, frame *classBindings) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -2803,7 +2803,7 @@ var reactQueryConfigKeys = map[string]bool{
 // isReactHookCallee returns true when the call_expression's callee name
 // matches the React hook naming convention: starts with "use" followed by
 // an uppercase letter (e.g. useQuery, useMutation, useInspections).
-func isReactHookCallee(x *extractor, call *sitter.Node) bool {
+func isReactHookCallee(x *extractor, call ts.Node) bool {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return false
@@ -2825,7 +2825,7 @@ func isReactHookCallee(x *extractor, call *sitter.Node) bool {
 // For each such key whose value is an arrow_function or function_expression,
 // it emits CALLS edges from callerName to every call inside the callback body,
 // marking them with Properties["via"]="react_query_hook". Issue #2554.
-func (x *extractor) extractReactQueryHookCalls(call *sitter.Node, callerName string, frame *classBindings, seen map[string]bool) []types.RelationshipRecord {
+func (x *extractor) extractReactQueryHookCalls(call ts.Node, callerName string, frame *classBindings, seen map[string]bool) []types.RelationshipRecord {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return nil
@@ -2869,7 +2869,7 @@ func (x *extractor) extractReactQueryHookCalls(call *sitter.Node, callerName str
 				valNode = valNode.Child(1)
 			}
 			// Only traverse arrow_function and function_expression values.
-			var callbackBody *sitter.Node
+			var callbackBody ts.Node
 			switch valNode.Type() {
 			case "arrow_function":
 				callbackBody = valNode.ChildByFieldName("body")
@@ -2928,7 +2928,7 @@ func (x *extractor) extractReactQueryHookCalls(call *sitter.Node, callerName str
 //     it or drop it).
 //
 // Issue #2553.
-func (x *extractor) dispatchMapCallEdges(call *sitter.Node, callerName string) []types.RelationshipRecord {
+func (x *extractor) dispatchMapCallEdges(call ts.Node, callerName string) []types.RelationshipRecord {
 	if x.dispatchMaps == nil || call == nil {
 		return nil
 	}
@@ -3052,7 +3052,7 @@ func isBuiltinMethodName(method string) bool {
 // ref ("scope:operation:method:<lang>:<resolved_file>:<method>") instead
 // of the bare trailing identifier. This lets the resolver bind the call
 // to the imported class's method without going through bare-name lookup.
-func (x *extractor) callTarget(call *sitter.Node, frame *classBindings) string {
+func (x *extractor) callTarget(call ts.Node, frame *classBindings) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		// new_expression uses "constructor" field.
@@ -3185,7 +3185,7 @@ func (x *extractor) callTarget(call *sitter.Node, frame *classBindings) string {
 // The cross-file resolver (or the react_props cross-extractor) will bind
 // local tags to the declaring entity. Self-renders (caller == tag name) are
 // skipped.
-func (x *extractor) extractJSXRendersRelationships(body *sitter.Node, callerName string) []types.RelationshipRecord {
+func (x *extractor) extractJSXRendersRelationships(body ts.Node, callerName string) []types.RelationshipRecord {
 	if body == nil || !isComponentName(callerName) {
 		return nil
 	}
@@ -3278,12 +3278,12 @@ func (x *extractor) extractJSXRendersRelationships(body *sitter.Node, callerName
 // entity, which lands in bug-extractor. With the map, callTarget rewrites
 // the target to "ext:<module>" so the external synthesiser handles it
 // correctly. Issue #44 (TS/JS resolver slice).
-func (x *extractor) buildHookVarToModule(root *sitter.Node) map[string]string {
+func (x *extractor) buildHookVarToModule(root ts.Node) map[string]string {
 	if root == nil || x.importByLocal == nil {
 		return nil
 	}
 	result := make(map[string]string)
-	stack := make([]*sitter.Node, 0, 64)
+	stack := make([]ts.Node, 0, 64)
 	stack = append(stack, root)
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
@@ -3343,7 +3343,7 @@ func (x *extractor) buildHookVarToModule(root *sitter.Node) map[string]string {
 //
 // Issue #2553 — surfaced by core-mobile's offline-sync subsystem where
 // syncEngine.ts dispatches through syncResolvers via RESOLVERS[action.kind](args).
-func (x *extractor) buildDispatchMaps(root *sitter.Node) map[string]*dispatchMapInfo {
+func (x *extractor) buildDispatchMaps(root ts.Node) map[string]*dispatchMapInfo {
 	if root == nil {
 		return nil
 	}
@@ -3479,7 +3479,7 @@ func (x *extractor) buildDispatchMaps(root *sitter.Node) map[string]*dispatchMap
 // Only direct call targets (identifier or member_expression property) are
 // returned; nested call chains are not traversed to avoid over-approximation.
 // Deduplication is applied so each target appears at most once.
-func (x *extractor) callTargetsInFunctionNode(fn *sitter.Node) []string {
+func (x *extractor) callTargetsInFunctionNode(fn ts.Node) []string {
 	if fn == nil {
 		return nil
 	}
@@ -3531,7 +3531,7 @@ func isComponentName(name string) bool {
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
 // Iterative to stay safe on deeply-nested trees.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -3539,8 +3539,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -3570,7 +3570,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 // "mod"` produces two edges); the parent SCOPE.Component entity is
 // shared across bindings of the same module so the existing dedup
 // shape is preserved.
-func (x *extractor) collectImports(root *sitter.Node) {
+func (x *extractor) collectImports(root ts.Node) {
 	seen := make(map[string]bool)
 	// Group import bindings by module spec so we can attach all
 	// bindings as separate IMPORTS edges on a single import entity.
@@ -3582,7 +3582,7 @@ func (x *extractor) collectImports(root *sitter.Node) {
 	x.collectImportsNode(root, seen, bindingsByModule)
 }
 
-func (x *extractor) collectImportsNode(n *sitter.Node, seen map[string]bool, bindingsByModule map[string][]*importBinding) {
+func (x *extractor) collectImportsNode(n ts.Node, seen map[string]bool, bindingsByModule map[string][]*importBinding) {
 	if n == nil {
 		return
 	}
@@ -3643,7 +3643,7 @@ func (x *extractor) collectImportsNode(n *sitter.Node, seen map[string]bool, bin
 // without destructuring fall back to a single IMPORTS edge with no
 // per-binding properties so existing downstream consumers still see
 // at least one edge per module.
-func (x *extractor) emitImport(module string, n *sitter.Node, bindings []*importBinding) {
+func (x *extractor) emitImport(module string, n ts.Node, bindings []*importBinding) {
 	// Use the full module path as the entity name for parity with Python indexer.
 	start, end := lines(n)
 	// Issue #570 — FromID is the importing file's path. The extractor

--- a/internal/extractors/javascript/extractor_test.go
+++ b/internal/extractors/javascript/extractor_test.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tsjavascript "github.com/smacker/go-tree-sitter/javascript"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
@@ -19,11 +20,14 @@ import (
 // --------------------------------------------------------------------------
 
 // parseJS parses source with the JavaScript grammar and returns the tree.
-func parseJS(t *testing.T, src []byte) *sitter.Tree {
+func parseJS(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tsjavascript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsjavascript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseJS: %v", err)
 	}
@@ -31,11 +35,14 @@ func parseJS(t *testing.T, src []byte) *sitter.Tree {
 }
 
 // parseTS parses source with the TypeScript grammar and returns the tree.
-func parseTS(t *testing.T, src []byte) *sitter.Tree {
+func parseTS(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstypescript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseTS: %v", err)
 	}
@@ -43,7 +50,7 @@ func parseTS(t *testing.T, src []byte) *sitter.Tree {
 }
 
 // extract runs the extractor and returns the entity slice.
-func extract(t *testing.T, content []byte, language string, tree *sitter.Tree) []types.EntityRecord {
+func extract(t *testing.T, content []byte, language string, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	e := &jsExtractorShim{}
 	got, err := e.extract(content, language, tree)
@@ -56,13 +63,13 @@ func extract(t *testing.T, content []byte, language string, tree *sitter.Tree) [
 // jsExtractorShim invokes the real JSExtractor via the extreg.Extractor interface.
 type jsExtractorShim struct{}
 
-func (s *jsExtractorShim) extract(content []byte, language string, tree *sitter.Tree) ([]types.EntityRecord, error) {
+func (s *jsExtractorShim) extract(content []byte, language string, tree ts.Tree) ([]types.EntityRecord, error) {
 	e := javascript.New()
 	return e.Extract(context.Background(), extreg.FileInput{
 		Path:     "test.go",
 		Content:  content,
 		Language: language,
-		Tree:     tree,
+		TSTree:   tree,
 	})
 }
 

--- a/internal/extractors/javascript/framework_dsl.go
+++ b/internal/extractors/javascript/framework_dsl.go
@@ -46,7 +46,7 @@ package javascript
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // expressFrameworkPkgs is the set of npm package specifiers that introduce
@@ -112,7 +112,7 @@ type frameworkDSLTracker struct {
 //   - variable_declarator nodes whose value is an await_expression
 //     wrapping a member-expression call to NestFactory.create (capturing
 //     `const app = await NestFactory.create(AppModule)`).
-func (x *extractor) buildFrameworkDSLTracker(root *sitter.Node) *frameworkDSLTracker {
+func (x *extractor) buildFrameworkDSLTracker(root ts.Node) *frameworkDSLTracker {
 	t := &frameworkDSLTracker{
 		expressLocals:       make(map[string]bool),
 		nestFactoryLocals:   make(map[string]bool),
@@ -149,8 +149,8 @@ func (x *extractor) buildFrameworkDSLTracker(root *sitter.Node) *frameworkDSLTra
 //     app. Handled by checking if the callee is itself a call_expression
 //     whose function is `require` and whose argument is an express-family
 //     package string.
-func (t *frameworkDSLTracker) scanForFrameworkLocals(x *extractor, root *sitter.Node) {
-	stack := make([]*sitter.Node, 0, 64)
+func (t *frameworkDSLTracker) scanForFrameworkLocals(x *extractor, root ts.Node) {
+	stack := make([]ts.Node, 0, 64)
 	stack = append(stack, root)
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
@@ -180,7 +180,7 @@ func (t *frameworkDSLTracker) scanForFrameworkLocals(x *extractor, root *sitter.
 //   - `const app = express()`                   → expressLocals["app"]
 //   - `const app = require("express")()`        → expressLocals["app"]
 //   - `const app = await NestFactory.create(..)` → nestFactoryLocals["app"]
-func (t *frameworkDSLTracker) processVariableDeclarator(x *extractor, n *sitter.Node) {
+func (t *frameworkDSLTracker) processVariableDeclarator(x *extractor, n ts.Node) {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil || nameNode.Type() != "identifier" {
 		return
@@ -239,7 +239,7 @@ func (t *frameworkDSLTracker) processVariableDeclarator(x *extractor, n *sitter.
 //   - `express.Router()` or `app.use(express.Router())` style (Router factory)
 //   - `require("express")()` — CommonJS factory
 //   - `fastify()`, `new Fastify()`, `Hono()`, `new Koa()` — analogous
-func (t *frameworkDSLTracker) isExpressFactoryCall(x *extractor, callNode *sitter.Node) bool {
+func (t *frameworkDSLTracker) isExpressFactoryCall(x *extractor, callNode ts.Node) bool {
 	fn := callNode.ChildByFieldName("function")
 	if fn == nil {
 		return false
@@ -265,7 +265,7 @@ func (t *frameworkDSLTracker) isExpressFactoryCall(x *extractor, callNode *sitte
 }
 
 // isRequireExpressCall returns true when callNode is `require("<express-pkg>")`.
-func (t *frameworkDSLTracker) isRequireExpressCall(x *extractor, callNode *sitter.Node) bool {
+func (t *frameworkDSLTracker) isRequireExpressCall(x *extractor, callNode ts.Node) bool {
 	if callNode.Type() != "call_expression" {
 		return false
 	}
@@ -297,7 +297,7 @@ func (t *frameworkDSLTracker) isRequireExpressCall(x *extractor, callNode *sitte
 // `NestFactory.create(...)` (any number of arguments; the import-path
 // check is deferred to the caller — NestFactory is always from @nestjs/core
 // in real-world code but we match by name to avoid a package-binding walk).
-func (t *frameworkDSLTracker) isNestFactoryCreateCall(x *extractor, callNode *sitter.Node) bool {
+func (t *frameworkDSLTracker) isNestFactoryCreateCall(x *extractor, callNode ts.Node) bool {
 	fn := callNode.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "member_expression" {
 		return false
@@ -318,7 +318,7 @@ func (t *frameworkDSLTracker) isNestFactoryCreateCall(x *extractor, callNode *si
 // This is the per-call gate: if the receiver is a known framework local,
 // the CALLS edge produced for this call should carry
 // Properties["receiver_package"] = "express".
-func (t *frameworkDSLTracker) receiverPackageForCall(x *extractor, callNode *sitter.Node) string {
+func (t *frameworkDSLTracker) receiverPackageForCall(x *extractor, callNode ts.Node) string {
 	if t == nil {
 		return ""
 	}
@@ -353,7 +353,7 @@ func (t *frameworkDSLTracker) receiverPackageForCall(x *extractor, callNode *sit
 //
 // Stops at depth 4 to avoid spending time on deeply-nested expressions
 // that are unlikely to be framework chains. Returns "" on any miss.
-func (x *extractor) frameworkReceiverIdent(obj *sitter.Node) string {
+func (x *extractor) frameworkReceiverIdent(obj ts.Node) string {
 	const maxDepth = 4
 	cur := obj
 	for depth := 0; depth < maxDepth; depth++ {

--- a/internal/extractors/javascript/framework_dsl_test.go
+++ b/internal/extractors/javascript/framework_dsl_test.go
@@ -14,7 +14,8 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tsjavascript "github.com/smacker/go-tree-sitter/javascript"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
@@ -24,11 +25,14 @@ import (
 )
 
 // parseJSDSL parses JS source with the JS grammar.
-func parseJSDSL(t *testing.T, src []byte) *sitter.Tree {
+func parseJSDSL(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tsjavascript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsjavascript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseJS: %v", err)
 	}
@@ -36,11 +40,14 @@ func parseJSDSL(t *testing.T, src []byte) *sitter.Tree {
 }
 
 // parseTSDSL parses TS source with the TS grammar.
-func parseTSDSL(t *testing.T, src []byte) *sitter.Tree {
+func parseTSDSL(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstypescript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseTS: %v", err)
 	}
@@ -48,14 +55,14 @@ func parseTSDSL(t *testing.T, src []byte) *sitter.Tree {
 }
 
 // runDSL extracts entities from src in the given language.
-func runDSL(t *testing.T, src, language, path string, tree *sitter.Tree) []types.EntityRecord {
+func runDSL(t *testing.T, src, language, path string, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	ext, _ := extractor.Get(language)
 	ents, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:     path,
 		Content:  []byte(src),
 		Language: language,
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/graphql_dataloader.go
+++ b/internal/extractors/javascript/graphql_dataloader.go
@@ -48,8 +48,8 @@ package javascript
 import (
 	"strconv"
 
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // PropViaGraphQLDataLoader is the value stamped on Properties["via"] for every
@@ -72,7 +72,7 @@ type dataLoaderTracker struct {
 //
 // Returns nil when no "dataloader" import is found (fast-path) or when the
 // file contains no statically-named loader.
-func (x *extractor) buildDataLoaderTracker(root *sitter.Node) *dataLoaderTracker {
+func (x *extractor) buildDataLoaderTracker(root ts.Node) *dataLoaderTracker {
 	if x.importByLocal == nil || root == nil {
 		return nil
 	}
@@ -106,8 +106,8 @@ func (x *extractor) buildDataLoaderTracker(root *sitter.Node) *dataLoaderTracker
 //
 // the loader entity (named by the LHS) and a BATCHES edge to the wrapped batch
 // function when it can be statically resolved.
-func (t *dataLoaderTracker) scanForLoaders(x *extractor, root *sitter.Node, ctorLocals map[string]bool) {
-	stack := []*sitter.Node{root}
+func (t *dataLoaderTracker) scanForLoaders(x *extractor, root ts.Node, ctorLocals map[string]bool) {
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -130,7 +130,7 @@ func (t *dataLoaderTracker) scanForLoaders(x *extractor, root *sitter.Node, ctor
 
 // processAssignment records a loader when valueNode is `new DataLoader(...)`
 // and nameNode is a simple identifier / property name.
-func (t *dataLoaderTracker) processAssignment(x *extractor, nameNode, valueNode *sitter.Node, ctorLocals map[string]bool) {
+func (t *dataLoaderTracker) processAssignment(x *extractor, nameNode, valueNode ts.Node, ctorLocals map[string]bool) {
 	if nameNode == nil || valueNode == nil {
 		return
 	}
@@ -172,7 +172,7 @@ func (t *dataLoaderTracker) processAssignment(x *extractor, nameNode, valueNode 
 //   - member_expression     → the trailing property ("this.userLoader" → "userLoader")
 //
 // Returns "" for destructuring / computed / unsupported shapes.
-func loaderLHSName(x *extractor, nameNode *sitter.Node) string {
+func loaderLHSName(x *extractor, nameNode ts.Node) string {
 	switch nameNode.Type() {
 	case "identifier", "property_identifier", "shorthand_property_identifier":
 		return x.nodeText(nameNode)
@@ -187,7 +187,7 @@ func loaderLHSName(x *extractor, nameNode *sitter.Node) string {
 
 // isDataLoaderConstruction reports whether newExpr is `new DataLoader(...)`
 // where the constructor identifier is bound to the "dataloader" package.
-func isDataLoaderConstruction(x *extractor, newExpr *sitter.Node, ctorLocals map[string]bool) bool {
+func isDataLoaderConstruction(x *extractor, newExpr ts.Node, ctorLocals map[string]bool) bool {
 	ctor := newExpr.ChildByFieldName("constructor")
 	if ctor == nil {
 		return false
@@ -217,12 +217,12 @@ func isDataLoaderConstruction(x *extractor, newExpr *sitter.Node, ctorLocals map
 // Returns "" when the batch function cannot be named statically (inline
 // multi-statement body, member-expression callee, etc.). In that honest-partial
 // case the loader entity is still emitted; only the BATCHES edge is omitted.
-func dataLoaderBatchFn(x *extractor, newExpr *sitter.Node) string {
+func dataLoaderBatchFn(x *extractor, newExpr ts.Node) string {
 	args := newExpr.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
 	}
-	var firstArg *sitter.Node
+	var firstArg ts.Node
 	for i := 0; i < int(args.ChildCount()); i++ {
 		ch := args.Child(i)
 		if ch == nil {
@@ -256,7 +256,7 @@ func dataLoaderBatchFn(x *extractor, newExpr *sitter.Node) string {
 //
 // Returns "" when the body is not a simple single-call delegation or when the
 // callee is not a bare identifier (e.g. `this.batch(ids)`).
-func delegatedCallName(x *extractor, body *sitter.Node) string {
+func delegatedCallName(x *extractor, body ts.Node) string {
 	if body == nil {
 		return ""
 	}
@@ -298,7 +298,7 @@ func delegatedCallName(x *extractor, body *sitter.Node) string {
 //	userLoader.load(id)            object = identifier
 //	this.userLoader.load(id)       object = member_expression (trailing prop)
 //	context.userLoader.load(id)    object = member_expression (trailing prop)
-func (t *dataLoaderTracker) dataLoaderLoadEdges(x *extractor, callNode *sitter.Node) []types.RelationshipRecord {
+func (t *dataLoaderTracker) dataLoaderLoadEdges(x *extractor, callNode ts.Node) []types.RelationshipRecord {
 	if t == nil {
 		return nil
 	}
@@ -337,7 +337,7 @@ func (t *dataLoaderTracker) dataLoaderLoadEdges(x *extractor, callNode *sitter.N
 //   - identifier            → its text ("userLoader")
 //   - member_expression     → the trailing property ("this.userLoader" /
 //     "context.loaders.userLoader" → "userLoader")
-func loaderReceiverName(x *extractor, obj *sitter.Node) string {
+func loaderReceiverName(x *extractor, obj ts.Node) string {
 	if obj == nil {
 		return ""
 	}

--- a/internal/extractors/javascript/heritage.go
+++ b/internal/extractors/javascript/heritage.go
@@ -3,7 +3,7 @@ package javascript
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -48,7 +48,7 @@ import (
 // No name is synthesised, and a clause with no resolvable leaf type contributes
 // no edge. Each ToID carries the implementer/target names in Properties for
 // docgen (ClassManifest bases/interfaces) parity with the Java path.
-func (x *extractor) classHeritageRels(class *sitter.Node, className string) []types.RelationshipRecord {
+func (x *extractor) classHeritageRels(class ts.Node, className string) []types.RelationshipRecord {
 	if class == nil || className == "" {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (x *extractor) classHeritageRels(class *sitter.Node, className string) []ty
 // identifiers, type_identifiers, generic_type (Foo<T>), member/qualified names
 // (ns.Foo) — and reduces each to its leaf type name via heritageLeafTypeName.
 // Punctuation tokens (the `extends`/`implements` keywords, commas) are skipped.
-func (x *extractor) heritageClauseTypeNames(clause *sitter.Node) []string {
+func (x *extractor) heritageClauseTypeNames(clause ts.Node) []string {
 	var out []string
 	seen := map[string]bool{}
 	for k := 0; k < int(clause.ChildCount()); k++ {
@@ -153,7 +153,7 @@ var nestMappedTypeHelpers = map[string]bool{
 // arguments of a mapped-type helper call (PartialType(X) -> ["X"]). It returns
 // nil for any call whose callee is not a recognized NestJS mapped-type helper,
 // so non-mapped extends-call shapes contribute no edge (#4845).
-func mappedTypeBaseNames(x *extractor, call *sitter.Node) []string {
+func mappedTypeBaseNames(x *extractor, call ts.Node) []string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return nil

--- a/internal/extractors/javascript/imports.go
+++ b/internal/extractors/javascript/imports.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // osStatRegular reports whether absPath stats as a regular file. Used
@@ -173,13 +173,13 @@ func dottedModuleFromPath(p string) string {
 //
 // The slice is ordered by source position so emitter output is stable
 // across runs.
-func (x *extractor) collectFileImports(root *sitter.Node) []importBinding {
+func (x *extractor) collectFileImports(root ts.Node) []importBinding {
 	var out []importBinding
 	x.collectFileImportsNode(root, &out)
 	return out
 }
 
-func (x *extractor) collectFileImportsNode(n *sitter.Node, out *[]importBinding) {
+func (x *extractor) collectFileImportsNode(n ts.Node, out *[]importBinding) {
 	if n == nil {
 		return
 	}
@@ -207,7 +207,7 @@ func (x *extractor) collectFileImportsNode(n *sitter.Node, out *[]importBinding)
 //
 // Anything else (type-only imports, dynamic import()) is silently
 // dropped — the receiver binder won't have type information for those.
-func (x *extractor) collectFromImportStatement(n *sitter.Node, out *[]importBinding) {
+func (x *extractor) collectFromImportStatement(n ts.Node, out *[]importBinding) {
 	// Specifier (the "..." string) is the import_statement's source field.
 	source := x.findStringChild(n)
 	if source == "" {
@@ -357,7 +357,7 @@ func firstExistingJSPath(repoRoot, candidate string) string {
 //	identifier                 → default import (`express` in `import express from`)
 //	namespace_import           → `* as ns`
 //	named_imports              → `{ Foo, Bar as Baz }`
-func (x *extractor) parseImportClause(clause *sitter.Node, importPath, dotted, resolved string, aliasResolved bool, out *[]importBinding) {
+func (x *extractor) parseImportClause(clause ts.Node, importPath, dotted, resolved string, aliasResolved bool, out *[]importBinding) {
 	count := int(clause.ChildCount())
 	for i := 0; i < count; i++ {
 		ch := clause.Child(i)
@@ -402,7 +402,7 @@ func (x *extractor) parseImportClause(clause *sitter.Node, importPath, dotted, r
 
 // parseNamedImports walks a named_imports node (`{ Foo, Bar as Baz }`)
 // and appends one binding per import_specifier descendant.
-func (x *extractor) parseNamedImports(named *sitter.Node, importPath, dotted, resolved string, aliasResolved bool, out *[]importBinding) {
+func (x *extractor) parseNamedImports(named ts.Node, importPath, dotted, resolved string, aliasResolved bool, out *[]importBinding) {
 	count := int(named.ChildCount())
 	for i := 0; i < count; i++ {
 		ch := named.Child(i)
@@ -436,7 +436,7 @@ func (x *extractor) parseNamedImports(named *sitter.Node, importPath, dotted, re
 
 // findStringChild returns the unquoted text of the first "string" child
 // of n, or "" when none exists.
-func (x *extractor) findStringChild(n *sitter.Node) string {
+func (x *extractor) findStringChild(n ts.Node) string {
 	count := int(n.ChildCount())
 	for i := 0; i < count; i++ {
 		ch := n.Child(i)
@@ -450,7 +450,7 @@ func (x *extractor) findStringChild(n *sitter.Node) string {
 // firstIdentifier returns the text of the first descendant of n whose
 // Type() is "identifier", or "" when none exists. Used to pull the
 // local name out of `* as ns` and quirky import_specifier shapes.
-func (x *extractor) firstIdentifier(n *sitter.Node) string {
+func (x *extractor) firstIdentifier(n ts.Node) string {
 	if n == nil {
 		return ""
 	}
@@ -472,7 +472,7 @@ func (x *extractor) firstIdentifier(n *sitter.Node) string {
 
 // childFieldText returns the text of a named-field child of n, or ""
 // when the field is absent or empty.
-func (x *extractor) childFieldText(n *sitter.Node, field string) string {
+func (x *extractor) childFieldText(n ts.Node, field string) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/javascript/issue1616_jsts_extract_test.go
+++ b/internal/extractors/javascript/issue1616_jsts_extract_test.go
@@ -22,7 +22,7 @@ func extractAtPath(t *testing.T, content []byte, language, path string) []types.
 		Path:     path,
 		Content:  content,
 		Language: language,
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue2320_config_channel_test.go
+++ b/internal/extractors/javascript/issue2320_config_channel_test.go
@@ -12,7 +12,8 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tsjavascript "github.com/smacker/go-tree-sitter/javascript"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -20,11 +21,14 @@ import (
 )
 
 // parseJSForConfig is a local parse helper so this file is self-contained.
-func parseJSForConfig(t *testing.T, src []byte) *sitter.Tree {
+func parseJSForConfig(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tsjavascript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsjavascript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseJSForConfig: %v", err)
 	}
@@ -40,7 +44,7 @@ func extractWithCfg(t *testing.T, src []byte, cfg *extreg.ExtractorConfig) []ent
 		Path:     "test.js",
 		Content:  src,
 		Language: "javascript",
-		Tree:     tree,
+		TSTree:   tree,
 		Config:   cfg,
 	})
 	if err != nil {

--- a/internal/extractors/javascript/issue2553_record_dispatch_test.go
+++ b/internal/extractors/javascript/issue2553_record_dispatch_test.go
@@ -11,7 +11,8 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -19,11 +20,14 @@ import (
 )
 
 // parseTSDispatch parses source with the TypeScript grammar.
-func parseTSDispatch(t *testing.T, src []byte) *sitter.Tree {
+func parseTSDispatch(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstypescript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseTSDispatch: %v", err)
 	}
@@ -44,7 +48,7 @@ func extractTSDispatch(t *testing.T, src string) []types.EntityRecord {
 		Path:     "syncEngine.ts",
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue2654_discriminator_test.go
+++ b/internal/extractors/javascript/issue2654_discriminator_test.go
@@ -18,7 +18,8 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -27,11 +28,14 @@ import (
 )
 
 // parseTSDiscriminator parses source with the TypeScript grammar.
-func parseTSDiscriminator(t *testing.T, src []byte) *sitter.Tree {
+func parseTSDiscriminator(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstypescript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseTSDiscriminator: %v", err)
 	}
@@ -48,7 +52,7 @@ func extractTSForDiscriminator(t *testing.T, src string) []types.EntityRecord {
 		Path:     "test.tsx",
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue2854_angular_test.go
+++ b/internal/extractors/javascript/issue2854_angular_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -18,9 +18,12 @@ import (
 
 func extractAngular(t *testing.T, content []byte) []types.EntityRecord {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, content)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(content)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -29,7 +32,7 @@ func extractAngular(t *testing.T, content []byte) []types.EntityRecord {
 		Path:     "app.component.ts",
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue2854_react_test.go
+++ b/internal/extractors/javascript/issue2854_react_test.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -21,9 +21,12 @@ import (
 
 func extractReact(t *testing.T, path string, content []byte) []types.EntityRecord {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, content)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(content)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -32,7 +35,7 @@ func extractReact(t *testing.T, path string, content []byte) []types.EntityRecor
 		Path:     path,
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue2854_realdata_test.go
+++ b/internal/extractors/javascript/issue2854_realdata_test.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -24,12 +24,12 @@ func TestIssue2854_RealData_AngularComponent(t *testing.T) {
 	if err != nil {
 		t.Skipf("real-world angular fixture not present: %v", err)
 	}
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, _ := p.ParseCtx(context.Background(), nil, content)
+	parser, _ := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	defer parser.Close()
+	tree, _ := parser.Parse(content)
 	ext, _ := extreg.Get("typescript")
 	ents, err := ext.Extract(context.Background(), extreg.FileInput{
-		Path: path, Content: content, Language: "typescript", Tree: tree,
+		Path: path, Content: content, Language: "typescript", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue2855_realdata_test.go
+++ b/internal/extractors/javascript/issue2855_realdata_test.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -24,12 +24,12 @@ func extractRealWorld(t *testing.T, rel string) []types.EntityRecord {
 	if err != nil {
 		t.Skipf("real-world fixture %s not present: %v", rel, err)
 	}
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, _ := p.ParseCtx(context.Background(), nil, content)
+	parser, _ := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	defer parser.Close()
+	tree, _ := parser.Parse(content)
 	ext, _ := extreg.Get("typescript")
 	ents, err := ext.Extract(context.Background(), extreg.FileInput{
-		Path: path, Content: content, Language: "typescript", Tree: tree,
+		Path: path, Content: content, Language: "typescript", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract %s: %v", rel, err)

--- a/internal/extractors/javascript/issue2859_mobile_test.go
+++ b/internal/extractors/javascript/issue2859_mobile_test.go
@@ -38,7 +38,7 @@ func extractFixture(t *testing.T, relPath string) []types.EntityRecord {
 		Path:     relPath,
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract %s: %v", relPath, err)

--- a/internal/extractors/javascript/issue2860_mobile_nav_test.go
+++ b/internal/extractors/javascript/issue2860_mobile_nav_test.go
@@ -41,7 +41,7 @@ func extractFixtureTSX(t *testing.T, relPath string) []types.EntityRecord {
 		Path:     relPath,
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract %s: %v", relPath, err)

--- a/internal/extractors/javascript/issue2874_angular_test.go
+++ b/internal/extractors/javascript/issue2874_angular_test.go
@@ -17,7 +17,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -31,15 +31,18 @@ func extractAngularFixture(t *testing.T) []types.EntityRecord {
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, content)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(content)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	ext, _ := extreg.Get("typescript")
 	ents, err := ext.Extract(context.Background(), extreg.FileInput{
-		Path: path, Content: content, Language: "typescript", Tree: tree,
+		Path: path, Content: content, Language: "typescript", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -181,12 +184,12 @@ func TestIssue2874_RealData_Rxjs(t *testing.T) {
 	if err != nil {
 		t.Skipf("real-world angular fixture not present: %v", err)
 	}
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, _ := p.ParseCtx(context.Background(), nil, content)
+	parser, _ := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	defer parser.Close()
+	tree, _ := parser.Parse(content)
 	ext, _ := extreg.Get("typescript")
 	ents, err := ext.Extract(context.Background(), extreg.FileInput{
-		Path: path, Content: content, Language: "typescript", Tree: tree,
+		Path: path, Content: content, Language: "typescript", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue2875_react_internals_test.go
+++ b/internal/extractors/javascript/issue2875_react_internals_test.go
@@ -40,7 +40,7 @@ func extractTSXFixture(t *testing.T, relPath string) []types.EntityRecord {
 		Path:     relPath,
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract %s: %v", relPath, err)

--- a/internal/extractors/javascript/issue2910_angular_tanstack_test.go
+++ b/internal/extractors/javascript/issue2910_angular_tanstack_test.go
@@ -15,7 +15,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -29,15 +29,18 @@ func extractAngularTanstack(t *testing.T) []types.EntityRecord {
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
 	}
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, content)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(content)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	ext, _ := extreg.Get("typescript")
 	ents, err := ext.Extract(context.Background(), extreg.FileInput{
-		Path: path, Content: content, Language: "typescript", Tree: tree,
+		Path: path, Content: content, Language: "typescript", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue4322_heritage_test.go
+++ b/internal/extractors/javascript/issue4322_heritage_test.go
@@ -13,7 +13,7 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -22,9 +22,12 @@ import (
 
 func extractHeritageTS(t *testing.T, path string, content []byte) []types.EntityRecord {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, content)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(content)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -33,7 +36,7 @@ func extractHeritageTS(t *testing.T, path string, content []byte) []types.Entity
 		Path:     path,
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue4415_angular_route_guards_test.go
+++ b/internal/extractors/javascript/issue4415_angular_route_guards_test.go
@@ -39,7 +39,7 @@ func extractTS4415(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Language: "typescript",
 		Content:  []byte(src),
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract %s: %v", path, err)

--- a/internal/extractors/javascript/issue44_ts_resolver_test.go
+++ b/internal/extractors/javascript/issue44_ts_resolver_test.go
@@ -60,7 +60,7 @@ func extractTS(t *testing.T, src []byte, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  src,
 		Language: "typescript",
-		Tree:     nil, // extractor will parse internally when Tree is nil
+		TSTree:   nil, // no tree supplied → extractor returns no entities
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue4671_localvar_receiver_test.go
+++ b/internal/extractors/javascript/issue4671_localvar_receiver_test.go
@@ -76,7 +76,7 @@ func extractTS4671(t *testing.T, src []byte, path string) []entityRec4671 {
 		Path:     path,
 		Content:  src,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/issue610_jsx_renders_test.go
+++ b/internal/extractors/javascript/issue610_jsx_renders_test.go
@@ -6,7 +6,8 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -14,11 +15,14 @@ import (
 )
 
 // parseTSX parses source with the TypeScript TSX grammar (JSX-enabled).
-func parseTSX(t *testing.T, src []byte) *sitter.Tree {
+func parseTSX(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstsx.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstsx.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseTSX: %v", err)
 	}
@@ -26,14 +30,14 @@ func parseTSX(t *testing.T, src []byte) *sitter.Tree {
 }
 
 // extractTSX runs the extractor on TSX source.
-func extractTSX(t *testing.T, content []byte, tree *sitter.Tree) []types.EntityRecord {
+func extractTSX(t *testing.T, content []byte, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	ext, _ := extreg.Get("typescript")
 	ents, err := ext.Extract(context.Background(), extreg.FileInput{
 		Path:     "test.tsx",
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/mobile_navigation.go
+++ b/internal/extractors/javascript/mobile_navigation.go
@@ -49,7 +49,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -166,7 +166,7 @@ var platformBranchCallees = map[string]bool{
 // emitMobileNavigationSignals runs the four mobile dimensions over the file's
 // AST and decorates entities[0] (the file entity) with summary properties plus
 // reused-kind edges. Called from Extract() after emitPlatformVariantRelationships.
-func (x *extractor) emitMobileNavigationSignals(root *sitter.Node) {
+func (x *extractor) emitMobileNavigationSignals(root ts.Node) {
 	if root == nil || len(x.entities) == 0 {
 		return
 	}
@@ -237,7 +237,7 @@ func isNativeModuleSpecifier(spec string) bool {
 // emitNativeModuleSignals detects native-bridge imports and access and stamps
 // the file entity's `native_modules` property plus a `native_module=1` marker
 // on the matching IMPORTS edge (no new edge kind).
-func (x *extractor) emitNativeModuleSignals(root *sitter.Node, fileEnt *types.EntityRecord) {
+func (x *extractor) emitNativeModuleSignals(root ts.Node, fileEnt *types.EntityRecord) {
 	var mods []string
 	var deps []nativeBridgeDep
 
@@ -386,7 +386,7 @@ func (x *extractor) emitNativeModuleSignals(root *sitter.Node, fileEnt *types.En
 // enclosingCall walks up from a member_expression to the call_expression that
 // invokes it (so TurboModuleRegistry.get('Foo') resolves from the .get member
 // to the call carrying the 'Foo' argument), or returns nil.
-func enclosingCall(mem *sitter.Node) *sitter.Node {
+func enclosingCall(mem ts.Node) ts.Node {
 	for n := mem.Parent(); n != nil; n = n.Parent() {
 		switch n.Type() {
 		case "call_expression":
@@ -470,7 +470,7 @@ func ensurePropsRel(rel *types.RelationshipRecord) {
 }
 
 // stringArg returns the first string-literal argument of a call, unquoted, or "".
-func stringArg(x *extractor, call *sitter.Node) string {
+func stringArg(x *extractor, call ts.Node) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
@@ -488,7 +488,7 @@ func stringArg(x *extractor, call *sitter.Node) string {
 // JSX declarations, stamping `navigators` / `screens` on the file entity and
 // emitting one NAVIGATES_TO edge per declared screen (via=screen_config) so the
 // linker can match screens to route call sites.
-func (x *extractor) emitNavigatorScreenSignals(root *sitter.Node, fileEnt *types.EntityRecord) {
+func (x *extractor) emitNavigatorScreenSignals(root ts.Node, fileEnt *types.EntityRecord) {
 	var navigators, screens []string
 
 	// 1. Navigator factory calls: const Stack = createStackNavigator().
@@ -577,7 +577,7 @@ func isScreenTag(tag string) bool {
 
 // addFileNavEdge appends a NAVIGATES_TO edge to the file entity for a declared
 // screen/route or deep-link target.
-func (x *extractor) addFileNavEdge(fileEnt *types.EntityRecord, route, via string, node *sitter.Node, tag string) {
+func (x *extractor) addFileNavEdge(fileEnt *types.EntityRecord, route, via string, node ts.Node, tag string) {
 	props := map[string]string{
 		"route": route,
 		"line":  strconv.Itoa(int(node.StartPoint().Row) + 1),
@@ -604,7 +604,7 @@ func (x *extractor) addFileNavEdge(fileEnt *types.EntityRecord, route, via strin
 // literal argument of a NativeScript frame.navigate({ moduleName: 'x' }) call,
 // or "" if absent. A bare-string first argument (frame.navigate('home')) is
 // also accepted.
-func (x *extractor) moduleNameArg(call *sitter.Node) string {
+func (x *extractor) moduleNameArg(call ts.Node) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
@@ -637,13 +637,13 @@ func (x *extractor) moduleNameArg(call *sitter.Node) string {
 
 // jsxAttrValue returns the string/template-literal value of the named attribute
 // on a JSX opening/self-closing element, or "" if absent or non-literal.
-func jsxAttrValue(x *extractor, el *sitter.Node, attrName string) string {
+func jsxAttrValue(x *extractor, el ts.Node, attrName string) string {
 	for i := 0; i < int(el.ChildCount()); i++ {
 		attr := el.Child(i)
 		if attr == nil || attr.Type() != "jsx_attribute" {
 			continue
 		}
-		var nameChild *sitter.Node
+		var nameChild ts.Node
 		for j := 0; j < int(attr.ChildCount()); j++ {
 			c := attr.Child(j)
 			if c != nil && (c.Type() == "property_identifier" || c.Type() == "identifier") {
@@ -689,7 +689,7 @@ func jsxAttrValue(x *extractor, el *sitter.Node, attrName string) string {
 // Linking.getInitialURL, and a `linking` config object with prefixes + screens —
 // and stamps `deep_link_prefixes` / `deep_link_screens` plus NAVIGATES_TO edges
 // (via=deep_link) on the file entity.
-func (x *extractor) emitDeepLinkSignals(root *sitter.Node, fileEnt *types.EntityRecord) {
+func (x *extractor) emitDeepLinkSignals(root ts.Node, fileEnt *types.EntityRecord) {
 	var prefixes, screens []string
 
 	// 1. Linking.createURL('/path') / Linking.openURL — the call form is already
@@ -747,7 +747,7 @@ func (x *extractor) emitDeepLinkSignals(root *sitter.Node, fileEnt *types.Entity
 	// 2. A `linking = { prefixes: [...], config: { screens: {...} } }` object —
 	//    the React Navigation deep-link config shape.
 	for _, declr := range findAllNodes(root, "variable_declarator", "pair") {
-		var nameNode, valNode *sitter.Node
+		var nameNode, valNode ts.Node
 		if declr.Type() == "variable_declarator" {
 			nameNode = declr.ChildByFieldName("name")
 			valNode = declr.ChildByFieldName("value")
@@ -782,7 +782,7 @@ func (x *extractor) emitDeepLinkSignals(root *sitter.Node, fileEnt *types.Entity
 
 // parseLinkingConfig extracts the prefixes array entries and the config.screens
 // key names from a React Navigation `linking` config object literal.
-func (x *extractor) parseLinkingConfig(obj *sitter.Node) (prefixes, screens []string) {
+func (x *extractor) parseLinkingConfig(obj ts.Node) (prefixes, screens []string) {
 	for i := 0; i < int(obj.ChildCount()); i++ {
 		pair := obj.Child(i)
 		if pair == nil || pair.Type() != "pair" {
@@ -814,7 +814,7 @@ func (x *extractor) parseLinkingConfig(obj *sitter.Node) (prefixes, screens []st
 
 // linkingScreenKeys returns the screen-name keys from a `config: { screens: {…} }`
 // object — the top-level keys under `screens`.
-func (x *extractor) linkingScreenKeys(config *sitter.Node) []string {
+func (x *extractor) linkingScreenKeys(config ts.Node) []string {
 	var out []string
 	for i := 0; i < int(config.ChildCount()); i++ {
 		pair := config.Child(i)
@@ -850,7 +850,7 @@ func (x *extractor) linkingScreenKeys(config *sitter.Node) []string {
 // on the file entity. The generic branch_conditions pass already emits
 // BRANCHES_ON edges for the `Platform.OS === 'ios'` comparison shape; this
 // summary makes the platform dimension first-class and queryable.
-func (x *extractor) emitPlatformBranchSignals(root *sitter.Node, fileEnt *types.EntityRecord) {
+func (x *extractor) emitPlatformBranchSignals(root ts.Node, fileEnt *types.EntityRecord) {
 	var branches []string
 
 	// 1. File-variant split (.ios.tsx / .android.tsx) — the file IS a platform

--- a/internal/extractors/javascript/navigation.go
+++ b/internal/extractors/javascript/navigation.go
@@ -40,7 +40,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -135,7 +135,7 @@ var navigationReceiverNames = map[string]bool{
 //
 //  4. No first arg (e.g. router.back()):
 //     →  route='<back>'
-func extractNavigationCall(x *extractor, call *sitter.Node) (route string, params []string, varRef string, ok bool) {
+func extractNavigationCall(x *extractor, call ts.Node) (route string, params []string, varRef string, ok bool) {
 	if call == nil {
 		return "", nil, "", false
 	}
@@ -212,7 +212,7 @@ func extractNavigationCall(x *extractor, call *sitter.Node) (route string, param
 
 // firstMeaningfulArg returns the first child of an arguments node that is not
 // a punctuation token ("(", ")", ",").
-func firstMeaningfulArg(args *sitter.Node) *sitter.Node {
+func firstMeaningfulArg(args ts.Node) ts.Node {
 	for i := 0; i < int(args.ChildCount()); i++ {
 		ch := args.Child(i)
 		if ch == nil {
@@ -230,7 +230,7 @@ func firstMeaningfulArg(args *sitter.Node) *sitter.Node {
 // extractObjectFormRoute parses an object literal node for the
 // `pathname` key and the `params` key, returning the route, param key names,
 // and any variable reference (#2672).
-func extractObjectFormRoute(x *extractor, obj *sitter.Node) (route string, params []string, varRef string, ok bool) {
+func extractObjectFormRoute(x *extractor, obj ts.Node) (route string, params []string, varRef string, ok bool) {
 	for i := 0; i < int(obj.ChildCount()); i++ {
 		child := obj.Child(i)
 		if child == nil {
@@ -273,7 +273,7 @@ func extractObjectFormRoute(x *extractor, obj *sitter.Node) (route string, param
 //
 // If the params value is not an object literal, the params slice will be empty
 // and varRef will be non-empty (variable reference case).
-func extractParamKeys(x *extractor, obj *sitter.Node) (params []string, varRef string) {
+func extractParamKeys(x *extractor, obj ts.Node) (params []string, varRef string) {
 	if obj == nil {
 		return nil, ""
 	}
@@ -324,7 +324,7 @@ func extractParamKeys(x *extractor, obj *sitter.Node) (params []string, varRef s
 //   - "via"         : "navigation_call" (traceability tag)
 //   - "_var_ref"    : (temporary, #2672) variable name if params was a reference;
 //     removed after resolution
-func emitNavigationEdge(route string, params []string, varRef string, call *sitter.Node) types.RelationshipRecord {
+func emitNavigationEdge(route string, params []string, varRef string, call ts.Node) types.RelationshipRecord {
 	toID := "route:" + route
 	props := map[string]string{
 		"route": route,
@@ -388,12 +388,12 @@ func (x *extractor) isNavigationHookVar(varName string) bool {
 // pass to resolve the binding to extract param keys.
 type paramsVarRef struct {
 	varName    string
-	sourceNode *sitter.Node
+	sourceNode ts.Node
 }
 
 // recordParamsVarRef records a variable reference for later resolution. Called
 // during initial extraction when a params: <identifier> is encountered.
-func (x *extractor) recordParamsVarRef(varName string, sourceNode *sitter.Node) {
+func (x *extractor) recordParamsVarRef(varName string, sourceNode ts.Node) {
 	if x.paramsVarRefs == nil {
 		x.paramsVarRefs = make([]*paramsVarRef, 0, 8)
 	}
@@ -411,7 +411,7 @@ func (x *extractor) recordParamsVarRef(varName string, sourceNode *sitter.Node) 
 // This is called once per file from Extract() (alongside buildHookVarToModule)
 // and stored on x.navHookVars so extractNavigationCall can consult it via
 // isNavigationHookVar without needing to re-traverse the AST. Phase 2 of #2658.
-func buildNavigationHookVarTable(x *extractor, root *sitter.Node) map[string]bool {
+func buildNavigationHookVarTable(x *extractor, root ts.Node) map[string]bool {
 	if root == nil {
 		return nil
 	}
@@ -420,7 +420,7 @@ func buildNavigationHookVarTable(x *extractor, root *sitter.Node) map[string]boo
 	// Walk the AST looking for:
 	//   const <varName> = <hookName>(...)
 	// where <hookName> ∈ navigationHookNames.
-	stack := make([]*sitter.Node, 0, 64)
+	stack := make([]ts.Node, 0, 64)
 	stack = append(stack, root)
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
@@ -464,7 +464,7 @@ func buildNavigationHookVarTable(x *extractor, root *sitter.Node) map[string]boo
 //
 // Issue #2672: same-file symbol-table resolution for params_keys from variable
 // references. This is a lightweight approach that avoids cross-file data flow.
-func (x *extractor) resolveParamsVarRefs(root *sitter.Node) {
+func (x *extractor) resolveParamsVarRefs(root ts.Node) {
 	if len(x.paramsVarRefs) == 0 {
 		return
 	}
@@ -482,7 +482,7 @@ func (x *extractor) resolveParamsVarRefs(root *sitter.Node) {
 // object literal as its RHS. Returns the extracted keys if found, or nil
 // otherwise. The search looks for the MOST RECENT binding that satisfies the
 // constraints (last-in-scope semantics).
-func (x *extractor) findVariableBinding(root *sitter.Node, varName string, refNode *sitter.Node) []string {
+func (x *extractor) findVariableBinding(root ts.Node, varName string, refNode ts.Node) []string {
 	if root == nil || varName == "" {
 		return nil
 	}
@@ -494,10 +494,10 @@ func (x *extractor) findVariableBinding(root *sitter.Node, varName string, refNo
 	//   2. assignment_expression nodes where LHS is the variable and RHS is an object literal
 	// We collect all candidates and pick the one with the highest row number
 	// that is still before refRow (last-in-scope wins).
-	var bestBinding *sitter.Node
+	var bestBinding ts.Node
 	bestRow := int32(-1) // Use -1 as initial value so any valid row (>=0) will be "better"
 
-	stack := make([]*sitter.Node, 0, 128)
+	stack := make([]ts.Node, 0, 128)
 	stack = append(stack, root)
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
@@ -569,7 +569,7 @@ func (x *extractor) findVariableBinding(root *sitter.Node, varName string, refNo
 
 // isObjectLiteral reports whether a node is an object literal, possibly wrapped
 // in parentheses (unwraps once).
-func isObjectLiteral(node *sitter.Node) bool {
+func isObjectLiteral(node ts.Node) bool {
 	if node == nil {
 		return false
 	}
@@ -595,7 +595,7 @@ func isObjectLiteral(node *sitter.Node) bool {
 // extractParamKeysFromObjectNode is similar to extractParamKeys but directly
 // operates on an object literal node (assumed to be valid). Used by
 // findVariableBinding to extract keys from a resolved variable binding.
-func extractParamKeysFromObjectNode(x *extractor, obj *sitter.Node) []string {
+func extractParamKeysFromObjectNode(x *extractor, obj ts.Node) []string {
 	if obj == nil {
 		return nil
 	}
@@ -702,12 +702,12 @@ func (x *extractor) isNavigatorFnVar(varName string) bool {
 // disjoint receiver semantics — conflating them would cause `useNavigate()`'s
 // return value (a function, not an object) to be matched against
 // receiver-method patterns it cannot satisfy.
-func buildNavigatorFnVarTable(x *extractor, root *sitter.Node) map[string]bool {
+func buildNavigatorFnVarTable(x *extractor, root ts.Node) map[string]bool {
 	if root == nil {
 		return nil
 	}
 	out := make(map[string]bool)
-	stack := make([]*sitter.Node, 0, 64)
+	stack := make([]ts.Node, 0, 64)
 	stack = append(stack, root)
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
@@ -762,7 +762,7 @@ func buildNavigatorFnVarTable(x *extractor, root *sitter.Node) map[string]bool {
 //     navigate({pathname, search, hash})):
 //     navigate({pathname: '/x', search: '?q=1'})
 //     → route='/x', params=['search']
-func extractDirectNavigatorCall(x *extractor, call *sitter.Node) (route string, params []string, ok bool) {
+func extractDirectNavigatorCall(x *extractor, call ts.Node) (route string, params []string, ok bool) {
 	if call == nil {
 		return "", nil, false
 	}
@@ -825,7 +825,7 @@ func extractDirectNavigatorCall(x *extractor, call *sitter.Node) (route string, 
 
 // firstTwoMeaningfulArgs returns the first and second non-punctuation children
 // of an arguments node. Either return may be nil when fewer args are present.
-func firstTwoMeaningfulArgs(args *sitter.Node) (first, second *sitter.Node) {
+func firstTwoMeaningfulArgs(args ts.Node) (first, second ts.Node) {
 	count := 0
 	for i := 0; i < int(args.ChildCount()); i++ {
 		ch := args.Child(i)
@@ -852,7 +852,7 @@ func firstTwoMeaningfulArgs(args *sitter.Node) (first, second *sitter.Node) {
 // `state:` key whose value is itself an object literal, returns that nested
 // object's keys (the most informative case). Otherwise returns the top-level
 // option keys — useful for surfacing `replace`, `relative`, etc.
-func extractNavigateOptionsKeys(x *extractor, obj *sitter.Node) []string {
+func extractNavigateOptionsKeys(x *extractor, obj ts.Node) []string {
 	if obj == nil {
 		return nil
 	}
@@ -912,7 +912,7 @@ var jsxNavTagToProp = map[string][]string{
 //
 // Self-renders are not a concern here: navigation tags are imported components
 // from react-router-dom / next-link, never the enclosing component itself.
-func (x *extractor) extractJSXNavigationRelationships(body *sitter.Node) []types.RelationshipRecord {
+func (x *extractor) extractJSXNavigationRelationships(body ts.Node) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
@@ -974,7 +974,7 @@ func (x *extractor) extractJSXNavigationRelationships(body *sitter.Node) []types
 //
 // Non-literal expressions (identifiers, member expressions, function calls)
 // return "" — they require runtime evaluation we don't do.
-func jsxNavRouteFromAttrs(x *extractor, jx *sitter.Node, propNames []string) (string, int) {
+func jsxNavRouteFromAttrs(x *extractor, jx ts.Node, propNames []string) (string, int) {
 	line := int(jx.StartPoint().Row) + 1
 	for i := 0; i < int(jx.ChildCount()); i++ {
 		attr := jx.Child(i)
@@ -982,7 +982,7 @@ func jsxNavRouteFromAttrs(x *extractor, jx *sitter.Node, propNames []string) (st
 			continue
 		}
 		// First child is the attribute name (property_identifier).
-		var nameChild *sitter.Node
+		var nameChild ts.Node
 		for j := 0; j < int(attr.ChildCount()); j++ {
 			c := attr.Child(j)
 			if c != nil && (c.Type() == "property_identifier" || c.Type() == "identifier") {

--- a/internal/extractors/javascript/node_stdlib.go
+++ b/internal/extractors/javascript/node_stdlib.go
@@ -47,7 +47,7 @@ package javascript
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -219,7 +219,7 @@ func nodeStdlibCanonical(spec string) string {
 // `this.<field>` is NOT supported here: Node.js stdlib imports go into
 // the file scope, not into class fields. The receiver-binder in
 // receiver.go covers the typed-class-field shape independently.
-func (x *extractor) receiverNodeStdlibTarget(memberExpr *sitter.Node, method string) string {
+func (x *extractor) receiverNodeStdlibTarget(memberExpr ts.Node, method string) string {
 	if memberExpr == nil || method == "" {
 		return ""
 	}

--- a/internal/extractors/javascript/observability.go
+++ b/internal/extractors/javascript/observability.go
@@ -44,7 +44,7 @@ package javascript
 import (
 	"strconv"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -90,7 +90,7 @@ var jsPromClientMethods = map[string]bool{
 // prom-client metric declarations and returns a var→metric-name map. A metric
 // whose `name` property is non-literal (or absent) maps to "" (known-metric,
 // dynamic-name). Returns nil when no prom-client metric is declared (fast-path).
-func (x *extractor) buildMetricVars(root *sitter.Node) map[string]string {
+func (x *extractor) buildMetricVars(root ts.Node) map[string]string {
 	if root == nil {
 		return nil
 	}
@@ -126,7 +126,7 @@ func (x *extractor) buildMetricVars(root *sitter.Node) map[string]string {
 // constructor: `new client.Counter(...)` → "Counter", `new Counter(...)` →
 // "Counter". Returns "" when the constructor is neither an identifier nor a
 // member_expression.
-func (x *extractor) newExprConstructorName(newExpr *sitter.Node) string {
+func (x *extractor) newExprConstructorName(newExpr ts.Node) string {
 	if newExpr == nil || newExpr.Type() != "new_expression" {
 		return ""
 	}
@@ -161,7 +161,7 @@ func (x *extractor) newExprConstructorName(newExpr *sitter.Node) string {
 // (name, true) when the options object is present; (name="", true) when the
 // `name` property is absent or non-literal (dynamic); (..., false) when there is
 // no object argument at all.
-func (x *extractor) metricCtorName(newExpr *sitter.Node) (string, bool) {
+func (x *extractor) metricCtorName(newExpr ts.Node) (string, bool) {
 	args := newExpr.ChildByFieldName("arguments")
 	if args == nil {
 		return "", false
@@ -179,7 +179,7 @@ func (x *extractor) metricCtorName(newExpr *sitter.Node) (string, bool) {
 // objectStringProp returns the string-literal value of the property named key in
 // an object literal. The bool is true when a property with that key exists; when
 // true and the value is non-literal the returned string is "".
-func (x *extractor) objectStringProp(obj *sitter.Node, key string) (string, bool) {
+func (x *extractor) objectStringProp(obj ts.Node, key string) (string, bool) {
 	if obj == nil || obj.Type() != "object" {
 		return "", false
 	}
@@ -207,7 +207,7 @@ func (x *extractor) objectStringProp(obj *sitter.Node, key string) (string, bool
 // extractObservabilityHits walks a function/method/arrow body and returns one
 // jsInstrHit per non-OTel instrumentation site (Sentry span/transaction,
 // dd-trace tracer.trace/wrap, prom-client metric mutation).
-func (x *extractor) extractObservabilityHits(body *sitter.Node) []jsInstrHit {
+func (x *extractor) extractObservabilityHits(body ts.Node) []jsInstrHit {
 	if body == nil {
 		return nil
 	}
@@ -275,7 +275,7 @@ func (x *extractor) extractObservabilityHits(body *sitter.Node) []jsInstrHit {
 // firstArgObjectName returns the string `name` property of the first
 // object-literal argument in args. The bool is false when the first arg is not
 // an object literal at all.
-func (x *extractor) firstArgObjectName(args *sitter.Node) (string, bool) {
+func (x *extractor) firstArgObjectName(args ts.Node) (string, bool) {
 	if args == nil {
 		return "", false
 	}
@@ -288,7 +288,7 @@ func (x *extractor) firstArgObjectName(args *sitter.Node) (string, bool) {
 
 // firstArgString returns the value of the first string-literal argument in args,
 // or "" when the first meaningful argument is not a string literal.
-func (x *extractor) firstArgString(args *sitter.Node) string {
+func (x *extractor) firstArgString(args ts.Node) string {
 	if args == nil {
 		return ""
 	}
@@ -303,7 +303,7 @@ func (x *extractor) firstArgString(args *sitter.Node) string {
 // x.entities for every non-OTel instrumentation site found in body. Called
 // immediately after a function/method/arrow entity is emitted, alongside
 // stampTracingSpans (the OTel pass).
-func (x *extractor) stampObservability(body *sitter.Node) {
+func (x *extractor) stampObservability(body ts.Node) {
 	if body == nil || len(x.entities) == 0 {
 		return
 	}

--- a/internal/extractors/javascript/prune_import_placeholders_test.go
+++ b/internal/extractors/javascript/prune_import_placeholders_test.go
@@ -15,7 +15,8 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
 	"github.com/cajasmota/grafel/internal/extractor"
@@ -64,11 +65,14 @@ func findImportOnAny742(ents []types.EntityRecord, spec string) *types.Relations
 	return nil
 }
 
-func parseTS742(t *testing.T, src []byte) *sitter.Tree {
+func parseTS742(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstypescript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -83,7 +87,7 @@ func extractTS742(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/react.go
+++ b/internal/extractors/javascript/react.go
@@ -25,7 +25,7 @@
 package javascript
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -63,7 +63,7 @@ var builtinReactHooks = map[string]bool{
 // when callerName is itself a component (PascalCase) or a custom hook
 // (use-prefixed) — the contexts in which React's Rules of Hooks permit hook
 // calls — so utility functions don't pick up spurious edges.
-func (x *extractor) extractHookCalls(body *sitter.Node, callerName string) []types.RelationshipRecord {
+func (x *extractor) extractHookCalls(body ts.Node, callerName string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}

--- a/internal/extractors/javascript/react_ecosystem.go
+++ b/internal/extractors/javascript/react_ecosystem.go
@@ -48,8 +48,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // Property `via` values stamped on React-Ecosystem entities/edges so the
@@ -374,7 +374,7 @@ func (x *extractor) buildReactEcosystemImports() *reactEcosystemImports {
 // resolveFactory returns the canonical factory name a call's callee resolves to
 // (via import binding when available, falling back to the bare leaf name so
 // re-exported / namespace-accessed factories still match). Returns "".
-func (r *reactEcosystemImports) resolveFactory(x *extractor, call *sitter.Node) string {
+func (r *reactEcosystemImports) resolveFactory(x *extractor, call ts.Node) string {
 	leaf := factoryLeaf(x, call)
 	if leaf == "" {
 		return ""
@@ -392,11 +392,11 @@ func (r *reactEcosystemImports) resolveFactory(x *extractor, call *sitter.Node) 
 
 // factoryLeaf returns the leaf identifier of a call/new callee: bare identifier
 // or the .property of a member expression. "" when not reducible.
-func factoryLeaf(x *extractor, n *sitter.Node) string {
+func factoryLeaf(x *extractor, n ts.Node) string {
 	if n == nil {
 		return ""
 	}
-	var fn *sitter.Node
+	var fn ts.Node
 	switch n.Type() {
 	case "call_expression", "new_expression":
 		fn = n.ChildByFieldName("function")
@@ -427,7 +427,7 @@ func factoryLeaf(x *extractor, n *sitter.Node) string {
 // variable_declarator and emits the decorated slice/store/api + endpoint/hook
 // entities and CONTAINS edges. Mirrors emitStoreActionEntities (#2626): runs
 // before walk() so emitted entities are present for the rest of extraction.
-func (x *extractor) extractReactEcosystem(root *sitter.Node) {
+func (x *extractor) extractReactEcosystem(root ts.Node) {
 	r := x.buildReactEcosystemImports()
 	if r == nil || root == nil {
 		return
@@ -438,7 +438,7 @@ func (x *extractor) extractReactEcosystem(root *sitter.Node) {
 }
 
 // reactEcosystemDeclarator handles `const <name> = <factory>(...)` shapes.
-func (x *extractor) reactEcosystemDeclarator(r *reactEcosystemImports, d *sitter.Node) {
+func (x *extractor) reactEcosystemDeclarator(r *reactEcosystemImports, d ts.Node) {
 	nameNode := d.ChildByFieldName("name")
 	valueNode := d.ChildByFieldName("value")
 	if nameNode == nil || valueNode == nil || nameNode.Type() != "identifier" {
@@ -482,7 +482,7 @@ func (x *extractor) reactEcosystemDeclarator(r *reactEcosystemImports, d *sitter
 // resolveAtomFactory returns the atom-store binding a call's callee resolves to,
 // via the import binding (so an aliased `import { atom as a }` still matches).
 // Returns the zero binding when the leaf is not a tracked atom factory.
-func (r *reactEcosystemImports) resolveAtomFactory(x *extractor, valueNode *sitter.Node) atomFactoryBinding {
+func (r *reactEcosystemImports) resolveAtomFactory(x *extractor, valueNode ts.Node) atomFactoryBinding {
 	leaf := factoryLeaf(x, valueNode)
 	if leaf == "" {
 		return atomFactoryBinding{}
@@ -497,7 +497,7 @@ func (r *reactEcosystemImports) resolveAtomFactory(x *extractor, valueNode *sitt
 // atom or store declaration (#2894 PR2). For Recoil atoms/selectors the `key:`
 // string is stamped (atoms are keyed by a globally-unique string). Decorate-only
 // (#2839): SCOPE.Component subtype, no new EntityKind.
-func (x *extractor) emitAtomStore(name string, valueNode *sitter.Node, ab atomFactoryBinding) {
+func (x *extractor) emitAtomStore(name string, valueNode ts.Node, ab atomFactoryBinding) {
 	subtype := atomStoreSubtype(ab.library, ab.factory)
 	props := map[string]string{
 		"kind":         "SCOPE.Component",
@@ -526,7 +526,7 @@ func (x *extractor) emitAtomStore(name string, valueNode *sitter.Node, ab atomFa
 // surfaces as a USES_HOOK edge via the generic hook pass (react.go); this pass
 // adds the SWR-specific decoration (key + which SWR hook) so the data-fetching
 // idiom is queryable. No-op when swr is not imported. Decorate-only (#2839).
-func (x *extractor) decorateSWR(root *sitter.Node) {
+func (x *extractor) decorateSWR(root ts.Node) {
 	r := x.buildReactEcosystemImports()
 	if r == nil || !r.hasSWR {
 		return
@@ -540,7 +540,7 @@ func (x *extractor) decorateSWR(root *sitter.Node) {
 			}
 		}
 	}
-	scan := func(name string, body *sitter.Node) {
+	scan := func(name string, body ts.Node) {
 		if name == "" || body == nil {
 			return
 		}
@@ -618,7 +618,7 @@ func (x *extractor) decorateSWR(root *sitter.Node) {
 //
 // Decorate-only (#2839): no new EntityKind/RelationshipKind. No-op when neither
 // react-hook-form nor formik is imported.
-func (x *extractor) decorateForms(root *sitter.Node) {
+func (x *extractor) decorateForms(root ts.Node) {
 	r := x.buildReactEcosystemImports()
 	if r == nil || (!r.hasRHF && !r.hasFormik) {
 		return
@@ -632,7 +632,7 @@ func (x *extractor) decorateForms(root *sitter.Node) {
 			}
 		}
 	}
-	scan := func(name string, body *sitter.Node) {
+	scan := func(name string, body ts.Node) {
 		if name == "" || body == nil {
 			return
 		}
@@ -703,7 +703,7 @@ type formInfo struct {
 // Formik takes precedence on library when both appear (a Formik consumer may
 // also import RHF transitively, but the rendered <Formik> is the authoritative
 // form). Field names and resolver schema are recovered only from literals.
-func (x *extractor) collectFormInfo(r *reactEcosystemImports, body *sitter.Node) formInfo {
+func (x *extractor) collectFormInfo(r *reactEcosystemImports, body ts.Node) formInfo {
 	info := formInfo{
 		hooks:      map[string]bool{},
 		components: map[string]bool{},
@@ -770,7 +770,7 @@ func (x *extractor) collectFormInfo(r *reactEcosystemImports, body *sitter.Node)
 
 // collectRHFResolver inspects a useForm({ resolver: zodResolver(schema) }) call
 // and records the resolver schema library + schema identifier when recoverable.
-func (x *extractor) collectRHFResolver(r *reactEcosystemImports, call *sitter.Node, info *formInfo) {
+func (x *extractor) collectRHFResolver(r *reactEcosystemImports, call ts.Node, info *formInfo) {
 	obj := configObjectArg(call)
 	if obj == nil {
 		return
@@ -806,7 +806,7 @@ func (x *extractor) collectRHFResolver(r *reactEcosystemImports, call *sitter.No
 
 // collectFormikSchema inspects useFormik({ validationSchema: schema }) and
 // records the schema expression text when present.
-func (x *extractor) collectFormikSchema(call *sitter.Node, info *formInfo) {
+func (x *extractor) collectFormikSchema(call ts.Node, info *formInfo) {
 	obj := configObjectArg(call)
 	if obj == nil {
 		return
@@ -818,7 +818,7 @@ func (x *extractor) collectFormikSchema(call *sitter.Node, info *formInfo) {
 
 // collectFormikSchemaJSX inspects a <Formik validationSchema={schema}> opening
 // element and records the schema expression text.
-func (x *extractor) collectFormikSchemaJSX(jx *sitter.Node, info *formInfo) {
+func (x *extractor) collectFormikSchemaJSX(jx ts.Node, info *formInfo) {
 	for i := 0; i < int(jx.ChildCount()); i++ {
 		attr := jx.Child(i)
 		if attr == nil || attr.Type() != "jsx_attribute" {
@@ -844,7 +844,7 @@ func (x *extractor) collectFormikSchemaJSX(jx *sitter.Node, info *formInfo) {
 
 // jsxStringAttr returns the string-literal value of a JSX attribute (e.g.
 // `name="email"`), unquoted. Returns "" for expression-container or missing.
-func jsxStringAttr(x *extractor, jx *sitter.Node, attrName string) string {
+func jsxStringAttr(x *extractor, jx ts.Node, attrName string) string {
 	for i := 0; i < int(jx.ChildCount()); i++ {
 		attr := jx.Child(i)
 		if attr == nil || attr.Type() != "jsx_attribute" || attr.ChildCount() == 0 {
@@ -878,7 +878,7 @@ func sortedKeys(m map[string]bool) []string {
 // CONTAINS edge slice→reducer. The generated action creators share the reducer
 // names (RTK derives them 1:1), so we stamp the reducer count + names on the
 // slice entity.
-func (x *extractor) emitReduxSlice(name string, valueNode *sitter.Node) {
+func (x *extractor) emitReduxSlice(name string, valueNode ts.Node) {
 	call := unwrapCall(valueNode)
 	if call == nil {
 		return
@@ -929,7 +929,7 @@ func (x *extractor) emitReduxSlice(name string, valueNode *sitter.Node) {
 
 // emitReduxStore emits a SCOPE.Component subtype="redux_store" decorated with
 // the configured reducer slice keys.
-func (x *extractor) emitReduxStore(name string, valueNode *sitter.Node, canon string) {
+func (x *extractor) emitReduxStore(name string, valueNode ts.Node, canon string) {
 	call := unwrapCall(valueNode)
 	props := map[string]string{
 		"kind":    "SCOPE.Component",
@@ -948,7 +948,7 @@ func (x *extractor) emitReduxStore(name string, valueNode *sitter.Node, canon st
 // emitAsyncThunk emits a SCOPE.Operation subtype="redux_async_thunk" for a
 // createAsyncThunk action creator (redux_async_flow). The type-prefix string
 // (first arg) is stamped so the dispatched action type is queryable.
-func (x *extractor) emitAsyncThunk(name string, valueNode *sitter.Node) {
+func (x *extractor) emitAsyncThunk(name string, valueNode ts.Node) {
 	call := unwrapCall(valueNode)
 	props := map[string]string{
 		"kind":    "SCOPE.Operation",
@@ -970,7 +970,7 @@ func (x *extractor) emitAsyncThunk(name string, valueNode *sitter.Node) {
 // http_method (query→GET / mutation→derived) + the endpoint's query path so the
 // later link pass can wire them to backend endpoints. injected=true for
 // injectEndpoints (extends an existing api).
-func (x *extractor) emitRTKQueryApi(name string, valueNode *sitter.Node, injected bool) {
+func (x *extractor) emitRTKQueryApi(name string, valueNode ts.Node, injected bool) {
 	call := unwrapCall(valueNode)
 	if call == nil {
 		return
@@ -1028,7 +1028,7 @@ func (x *extractor) emitRTKQueryApi(name string, valueNode *sitter.Node, injecte
 
 // stampEcosystem emits a lightweight decorated SCOPE.Component for entities we
 // recognise but don't decompose (QueryClient instance, createEntityAdapter).
-func (x *extractor) stampEcosystem(name string, valueNode *sitter.Node, via, subtype string) {
+func (x *extractor) stampEcosystem(name string, valueNode ts.Node, via, subtype string) {
 	props := map[string]string{
 		"kind":    "SCOPE.Component",
 		"subtype": subtype,
@@ -1046,7 +1046,7 @@ func (x *extractor) stampEcosystem(name string, valueNode *sitter.Node, via, sub
 // stamped saga_role="watcher"; saga workers using put/call/select are stamped
 // saga_role="worker". Epics (functions whose body calls .pipe(...ofType(...)))
 // are stamped redux_epic="true". Decoration only (#2839) — no new entity.
-func (x *extractor) decorateReduxAsyncFlow(root *sitter.Node) {
+func (x *extractor) decorateReduxAsyncFlow(root ts.Node) {
 	r := x.buildReactEcosystemImports()
 	if r == nil || (!r.hasSaga && !x.fileImportsReduxObservable()) {
 		return
@@ -1061,7 +1061,7 @@ func (x *extractor) decorateReduxAsyncFlow(root *sitter.Node) {
 			}
 		}
 	}
-	scan := func(name string, defNode, body *sitter.Node) {
+	scan := func(name string, defNode, body ts.Node) {
 		if name == "" || body == nil {
 			return
 		}
@@ -1169,7 +1169,7 @@ func angularTanstackInjectKind(leaf string) string {
 // @tanstack/angular-query-experimental is imported. Decorate-only (#2839): the
 // SCOPE.Operation kind is reused, mirroring how angularDataFetching models
 // HttpClient call sites.
-func (x *extractor) angularTanstackQuery(body *sitter.Node, className string) ([]types.EntityRecord, []types.RelationshipRecord) {
+func (x *extractor) angularTanstackQuery(body ts.Node, className string) ([]types.EntityRecord, []types.RelationshipRecord) {
 	if body == nil || !x.fileImportsTanstackAngular() {
 		return nil, nil
 	}
@@ -1240,7 +1240,7 @@ func (x *extractor) fileImportsReduxObservable() bool {
 // Returns (watcher, worker, epic). A body using takeEvery/takeLatest/takeLeading
 // is a watcher; one using put/call/select/fork is a worker; one calling
 // .pipe(...) with ofType(...) is an epic.
-func (x *extractor) sagaBodyRoles(r *reactEcosystemImports, body *sitter.Node) (watcher, worker, epic bool) {
+func (x *extractor) sagaBodyRoles(r *reactEcosystemImports, body ts.Node) (watcher, worker, epic bool) {
 	for _, c := range findAllNodes(body, "call_expression") {
 		leaf := factoryLeaf(x, c)
 		switch leaf {
@@ -1262,7 +1262,7 @@ func (x *extractor) sagaBodyRoles(r *reactEcosystemImports, body *sitter.Node) (
 
 // unwrapCall returns the call_expression inside valueNode, unwrapping a single
 // `await`/parenthesised layer. Returns nil when valueNode is not a call.
-func unwrapCall(n *sitter.Node) *sitter.Node {
+func unwrapCall(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -1282,7 +1282,7 @@ func unwrapCall(n *sitter.Node) *sitter.Node {
 }
 
 // firstStringArg returns the first string-literal argument of a call, unquoted.
-func firstStringArg(x *extractor, call *sitter.Node) string {
+func firstStringArg(x *extractor, call ts.Node) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return ""
@@ -1297,7 +1297,7 @@ func firstStringArg(x *extractor, call *sitter.Node) string {
 }
 
 // configObjectArg returns the first object-literal argument of a call.
-func configObjectArg(call *sitter.Node) *sitter.Node {
+func configObjectArg(call ts.Node) ts.Node {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return nil
@@ -1312,7 +1312,7 @@ func configObjectArg(call *sitter.Node) *sitter.Node {
 }
 
 // objectPairValue returns the value node for a given key in an object literal.
-func objectPairValue(x *extractor, obj *sitter.Node, key string) *sitter.Node {
+func objectPairValue(x *extractor, obj ts.Node, key string) ts.Node {
 	if obj == nil {
 		return nil
 	}
@@ -1333,7 +1333,7 @@ func objectPairValue(x *extractor, obj *sitter.Node, key string) *sitter.Node {
 }
 
 // sliceConfigName returns the `name:` string from a createSlice config object.
-func sliceConfigName(x *extractor, call *sitter.Node) string {
+func sliceConfigName(x *extractor, call ts.Node) string {
 	obj := configObjectArg(call)
 	if obj == nil {
 		return ""
@@ -1347,7 +1347,7 @@ func sliceConfigName(x *extractor, call *sitter.Node) string {
 
 // sliceReducers returns the reducer keys (and their function-value nodes) from
 // the `reducers:` object of a createSlice config.
-func sliceReducers(x *extractor, call *sitter.Node) ([]string, map[string]*sitter.Node) {
+func sliceReducers(x *extractor, call ts.Node) ([]string, map[string]ts.Node) {
 	obj := configObjectArg(call)
 	if obj == nil {
 		return nil, nil
@@ -1357,7 +1357,7 @@ func sliceReducers(x *extractor, call *sitter.Node) ([]string, map[string]*sitte
 		return nil, nil
 	}
 	var keys []string
-	nodes := map[string]*sitter.Node{}
+	nodes := map[string]ts.Node{}
 	for i := 0; i < int(reducersObj.ChildCount()); i++ {
 		child := reducersObj.Child(i)
 		if child == nil {
@@ -1392,7 +1392,7 @@ func sliceReducers(x *extractor, call *sitter.Node) ([]string, map[string]*sitte
 
 // configureStoreReducerKeys returns the slice keys from `reducer: { a, b }` of a
 // configureStore config (or the combined keys when reducer is combineReducers).
-func configureStoreReducerKeys(x *extractor, call *sitter.Node) []string {
+func configureStoreReducerKeys(x *extractor, call ts.Node) []string {
 	obj := configObjectArg(call)
 	if obj == nil {
 		return nil
@@ -1415,7 +1415,7 @@ func configureStoreReducerKeys(x *extractor, call *sitter.Node) []string {
 }
 
 // objectKeys returns the keys of an object literal (pairs + shorthand).
-func objectKeys(x *extractor, obj *sitter.Node) []string {
+func objectKeys(x *extractor, obj ts.Node) []string {
 	var keys []string
 	for i := 0; i < int(obj.ChildCount()); i++ {
 		ch := obj.Child(i)
@@ -1445,11 +1445,11 @@ type rtkEndpoint struct {
 	name string
 	kind string // query | mutation
 	path string // best-effort query path string
-	node *sitter.Node
+	node ts.Node
 }
 
 // rtkReducerPath returns the `reducerPath:` string from a createApi config.
-func rtkReducerPath(x *extractor, call *sitter.Node) string {
+func rtkReducerPath(x *extractor, call ts.Node) string {
 	obj := configObjectArg(call)
 	if obj == nil {
 		return ""
@@ -1463,7 +1463,7 @@ func rtkReducerPath(x *extractor, call *sitter.Node) string {
 
 // rtkQueryEndpoints extracts endpoints from the `endpoints: (builder) => ({...})`
 // arrow of a createApi / injectEndpoints config.
-func rtkQueryEndpoints(x *extractor, call *sitter.Node) []rtkEndpoint {
+func rtkQueryEndpoints(x *extractor, call ts.Node) []rtkEndpoint {
 	obj := configObjectArg(call)
 	if obj == nil {
 		return nil
@@ -1509,7 +1509,7 @@ func rtkQueryEndpoints(x *extractor, call *sitter.Node) []rtkEndpoint {
 
 // arrowBody returns the body node of an arrow_function (or the node itself when
 // it is already an object/parenthesized expression).
-func arrowBody(n *sitter.Node) *sitter.Node {
+func arrowBody(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -1521,7 +1521,7 @@ func arrowBody(n *sitter.Node) *sitter.Node {
 
 // builderEndpointKind returns "query" or "mutation" for `builder.query(...)` /
 // `builder.mutation(...)`. "" otherwise.
-func builderEndpointKind(x *extractor, n *sitter.Node) string {
+func builderEndpointKind(x *extractor, n ts.Node) string {
 	call := unwrapCall(n)
 	if call == nil {
 		return ""
@@ -1538,7 +1538,7 @@ func builderEndpointKind(x *extractor, n *sitter.Node) string {
 
 // endpointQueryPath best-effort extracts the path string from a builder endpoint
 // config's `query: () => '/path'` (or `query: () => ({ url: '/path' })`).
-func endpointQueryPath(x *extractor, n *sitter.Node) string {
+func endpointQueryPath(x *extractor, n ts.Node) string {
 	call := unwrapCall(n)
 	if call == nil {
 		return ""

--- a/internal/extractors/javascript/react_internals.go
+++ b/internal/extractors/javascript/react_internals.go
@@ -31,7 +31,7 @@
 package javascript
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // stampProp sets a property on the most-recently-emitted entity (the one a
@@ -52,7 +52,7 @@ func (x *extractor) stampLastEntityProp(key, val string) {
 // Suspense / portal idioms and stamps the matching properties on the entity at
 // the supplied index. idx must point at the SCOPE.Operation entity the caller
 // just emitted for this component.
-func (x *extractor) decorateReactComponentInternals(body *sitter.Node, idx int) {
+func (x *extractor) decorateReactComponentInternals(body ts.Node, idx int) {
 	if body == nil || idx < 0 || idx >= len(x.entities) {
 		return
 	}
@@ -76,7 +76,7 @@ func (x *extractor) decorateReactComponentInternals(body *sitter.Node, idx int) 
 // bodyRendersSuspense reports whether the function body contains a JSX
 // <Suspense> element (opening or self-closing). React.Suspense (member
 // expression) is also matched.
-func (x *extractor) bodyRendersSuspense(body *sitter.Node) bool {
+func (x *extractor) bodyRendersSuspense(body ts.Node) bool {
 	jsxNodes := findAllNodes(body, "jsx_opening_element", "jsx_self_closing_element")
 	for _, jx := range jsxNodes {
 		nameNode := jx.ChildByFieldName("name")
@@ -95,7 +95,7 @@ func (x *extractor) bodyRendersSuspense(body *sitter.Node) bool {
 // bodyUsesCreatePortal reports whether the function body calls createPortal —
 // either bare `createPortal(...)` (named import) or member
 // `ReactDOM.createPortal(...)` / `reactDom.createPortal(...)`.
-func (x *extractor) bodyUsesCreatePortal(body *sitter.Node) bool {
+func (x *extractor) bodyUsesCreatePortal(body ts.Node) bool {
 	calls := findAllNodes(body, "call_expression")
 	for _, c := range calls {
 		if x.calleeLeaf(c) == "createPortal" {
@@ -108,7 +108,7 @@ func (x *extractor) bodyUsesCreatePortal(body *sitter.Node) bool {
 // calleeLeaf returns the leaf identifier of a call_expression's callee: the
 // bare identifier, or the property of a member-expression callee. Returns ""
 // for shapes it cannot reduce (e.g. computed-member callees).
-func (x *extractor) calleeLeaf(call *sitter.Node) string {
+func (x *extractor) calleeLeaf(call ts.Node) string {
 	if call == nil || call.Type() != "call_expression" {
 		return ""
 	}
@@ -138,7 +138,7 @@ func (x *extractor) calleeLeaf(call *sitter.Node) string {
 //   - Pure template:       import(`./SettingsPanel`)  → "./SettingsPanel"
 //   - Interpolated tmpl:   import(`./panels/${name}`) → "./panels/{*}"
 //   - Computed/call expr:  import(getPath())          → "" (unresolvable)
-func (x *extractor) lazyImportModule(valueNode *sitter.Node) string {
+func (x *extractor) lazyImportModule(valueNode ts.Node) string {
 	if x.calleeLeaf(valueNode) != "lazy" {
 		return ""
 	}
@@ -176,14 +176,14 @@ func (x *extractor) lazyImportModule(valueNode *sitter.Node) string {
 // callee leaf is "lazy". Used by extractor.go to unconditionally stamp
 // react_lazy=true on lazy wrapper entities regardless of whether the import
 // specifier is resolvable (issue #2958).
-func (x *extractor) isLazyWrapper(valueNode *sitter.Node) bool {
+func (x *extractor) isLazyWrapper(valueNode ts.Node) bool {
 	return x.calleeLeaf(valueNode) == "lazy"
 }
 
 // classIsErrorBoundary reports whether a class body declares the React error
 // boundary contract: an instance componentDidCatch method or a static
 // getDerivedStateFromError method.
-func (x *extractor) classIsErrorBoundary(body *sitter.Node) bool {
+func (x *extractor) classIsErrorBoundary(body ts.Node) bool {
 	if body == nil {
 		return false
 	}

--- a/internal/extractors/javascript/receiver.go
+++ b/internal/extractors/javascript/receiver.go
@@ -17,7 +17,7 @@
 package javascript
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -48,7 +48,7 @@ import (
 //
 // The frame is append-only: `base` is never mutated. When at least one
 // local is discovered we copy `base` into a fresh frame first.
-func (x *extractor) withLocalReceiverTypes(body *sitter.Node, base *classBindings) *classBindings {
+func (x *extractor) withLocalReceiverTypes(body ts.Node, base *classBindings) *classBindings {
 	if body == nil {
 		return base
 	}
@@ -112,7 +112,7 @@ func (x *extractor) withLocalReceiverTypes(body *sitter.Node, base *classBinding
 //     `<x>.resolve(ClassName)`        — NestJS DI resolution: a member call
 //     whose method is get/resolve and whose
 //     sole argument is a class identifier.
-func (x *extractor) localReceiverBinding(decl *sitter.Node) (string, string) {
+func (x *extractor) localReceiverBinding(decl ts.Node) (string, string) {
 	if decl == nil {
 		return "", ""
 	}
@@ -141,7 +141,7 @@ func (x *extractor) localReceiverBinding(decl *sitter.Node) (string, string) {
 // construction idiom. Handles `new ClassName(...)` and the NestJS DI
 // `<container>.get(ClassName)` / `.resolve(ClassName)` shapes. Awaited DI
 // (`await module.resolve(X)`) is unwrapped first.
-func (x *extractor) constructedTypeName(value *sitter.Node) string {
+func (x *extractor) constructedTypeName(value ts.Node) string {
 	if value == nil {
 		return ""
 	}
@@ -195,7 +195,7 @@ func (x *extractor) constructedTypeName(value *sitter.Node) string {
 // token is intentionally NOT typed — there is no class identifier to bind).
 // Returns "" for any other call shape so non-DI calls (e.g. array.get(0))
 // are ignored.
-func (x *extractor) diResolvedTypeName(call *sitter.Node) string {
+func (x *extractor) diResolvedTypeName(call ts.Node) string {
 	if call == nil {
 		return ""
 	}
@@ -219,7 +219,7 @@ func (x *extractor) diResolvedTypeName(call *sitter.Node) string {
 	// Find the single positional class-identifier argument. More than one
 	// positional argument, or a non-identifier first argument (string DI
 	// token, options object), disqualifies the binding.
-	var typeArg *sitter.Node
+	var typeArg ts.Node
 	posCount := 0
 	count := int(args.ChildCount())
 	for i := 0; i < count; i++ {
@@ -261,7 +261,7 @@ func (x *extractor) diResolvedTypeName(call *sitter.Node) string {
 //
 // `method` is the trailing property identifier already extracted by the
 // caller; we only resolve the receiver here.
-func (x *extractor) receiverTypedTarget(memberExpr *sitter.Node, method string, frame *classBindings) string {
+func (x *extractor) receiverTypedTarget(memberExpr ts.Node, method string, frame *classBindings) string {
 	if memberExpr == nil || method == "" || frame == nil {
 		return ""
 	}
@@ -298,7 +298,7 @@ func (x *extractor) receiverTypedTarget(memberExpr *sitter.Node, method string, 
 // expressions, function-call results) returns "" so the caller drops
 // to the bare-name fallback. Conservative bias: better miss than
 // misresolve.
-func (x *extractor) receiverIdent(obj *sitter.Node) string {
+func (x *extractor) receiverIdent(obj ts.Node) string {
 	if obj == nil {
 		return ""
 	}
@@ -349,7 +349,7 @@ func (x *extractor) receiverIdent(obj *sitter.Node) string {
 //
 // Untyped parameters (`function f(x)`) and parameter destructuring
 // shapes are silently skipped.
-func (x *extractor) functionParamFrame(params *sitter.Node, base *classBindings) *classBindings {
+func (x *extractor) functionParamFrame(params ts.Node, base *classBindings) *classBindings {
 	if params == nil && base == nil {
 		return nil
 	}
@@ -392,7 +392,7 @@ func (x *extractor) functionParamFrame(params *sitter.Node, base *classBindings)
 //     parameter properties.
 //
 // Anything else (untyped fields, methods, getters/setters) is skipped.
-func (x *extractor) collectClassFields(body *sitter.Node, out map[string]string) {
+func (x *extractor) collectClassFields(body ts.Node, out map[string]string) {
 	if body == nil {
 		return
 	}
@@ -450,7 +450,7 @@ func (x *extractor) collectClassFields(body *sitter.Node, out map[string]string)
 // properties for injection, so the rule above (require an access
 // modifier) covers the dominant pattern. Bare-typed constructor
 // parameters do not become class fields (matching TS semantics).
-func (x *extractor) collectConstructorParamProperties(ctor *sitter.Node, out map[string]string) {
+func (x *extractor) collectConstructorParamProperties(ctor ts.Node, out map[string]string) {
 	params := ctor.ChildByFieldName("parameters")
 	if params == nil {
 		return
@@ -481,7 +481,7 @@ func (x *extractor) collectConstructorParamProperties(ctor *sitter.Node, out map
 // declared inline). The grammar exposes the modifier as an
 // `accessibility_modifier` child; `readonly` is a separate
 // `readonly` token.
-func (x *extractor) hasAccessModifier(p *sitter.Node) bool {
+func (x *extractor) hasAccessModifier(p ts.Node) bool {
 	count := int(p.ChildCount())
 	for i := 0; i < count; i++ {
 		ch := p.Child(i)
@@ -500,7 +500,7 @@ func (x *extractor) hasAccessModifier(p *sitter.Node) bool {
 // parameter node. Handles required_parameter and optional_parameter
 // shapes; returns ("", "") when the parameter is untyped or uses a
 // destructuring pattern the extractor does not analyse.
-func (x *extractor) paramNameAndType(p *sitter.Node) (string, string) {
+func (x *extractor) paramNameAndType(p ts.Node) (string, string) {
 	if p == nil {
 		return "", ""
 	}
@@ -532,7 +532,7 @@ func (x *extractor) paramNameAndType(p *sitter.Node) (string, string) {
 //
 // Union and intersection types return "" — picking one branch would
 // be arbitrary.
-func (x *extractor) typeAnnotationLeaf(ann *sitter.Node) string {
+func (x *extractor) typeAnnotationLeaf(ann ts.Node) string {
 	if ann == nil {
 		return ""
 	}
@@ -555,7 +555,7 @@ func (x *extractor) typeAnnotationLeaf(ann *sitter.Node) string {
 }
 
 // typeNodeLeaf walks a type node and returns its leaf type identifier.
-func (x *extractor) typeNodeLeaf(t *sitter.Node) string {
+func (x *extractor) typeNodeLeaf(t ts.Node) string {
 	if t == nil {
 		return ""
 	}

--- a/internal/extractors/javascript/references.go
+++ b/internal/extractors/javascript/references.go
@@ -45,7 +45,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -117,7 +117,7 @@ type fileSymbol struct {
 //
 // Safe to call with an empty entity slice — degenerates to a no-op. Safe
 // to call when the file has no function bodies — degenerates to a no-op.
-func (x *extractor) emitReferences(root *sitter.Node) {
+func (x *extractor) emitReferences(root ts.Node) {
 	if root == nil || len(x.entities) == 0 {
 		return
 	}
@@ -189,8 +189,8 @@ func (x *extractor) emitReferences(root *sitter.Node) {
 	// since they have no entity index). buildReferenceTargetID will handle
 	// the case where a symbol has no entity index by constructing a
 	// structural ref target.
-	var collectConstSymbols func(n *sitter.Node)
-	collectConstSymbols = func(n *sitter.Node) {
+	var collectConstSymbols func(n ts.Node)
+	collectConstSymbols = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -300,8 +300,8 @@ func (x *extractor) emitReferences(root *sitter.Node) {
 	// stack. We push when entering a function-like body and pop on the
 	// way out. The frame stack is shared across recursion; we use an
 	// explicit traversal so the pop point is deterministic.
-	var walk func(n *sitter.Node, fstack []frame)
-	walk = func(n *sitter.Node, fstack []frame) {
+	var walk func(n ts.Node, fstack []frame)
+	walk = func(n ts.Node, fstack []frame) {
 		if n == nil {
 			return
 		}
@@ -516,7 +516,7 @@ func (x *extractor) emitReferences(root *sitter.Node) {
 //
 // Issue #711.
 func (x *extractor) emitExportClauseReferences(
-	root *sitter.Node,
+	root ts.Node,
 	symbols map[string]fileSymbol,
 	fileEntIdx int,
 	seen map[edgeKey]bool,
@@ -525,8 +525,8 @@ func (x *extractor) emitExportClauseReferences(
 		return
 	}
 	fromName := x.entities[fileEntIdx].Name
-	var visit func(n *sitter.Node)
-	visit = func(n *sitter.Node) {
+	var visit func(n ts.Node)
+	visit = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -646,7 +646,7 @@ func buildReferenceTargetID(lang, filePath, name, targetKind string) string {
 // produce an edge to a non-existent target, so over-classifying a few
 // declarations as uses costs at worst a self-edge (filtered by the
 // `from == to` check in emit).
-func isDeclarationPosition(n *sitter.Node) bool {
+func isDeclarationPosition(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false
@@ -695,7 +695,7 @@ func isDeclarationPosition(n *sitter.Node) bool {
 // portion is a property_identifier (not identifier), so the
 // identifier walk doesn't touch it. CALLS still emits its edge to the
 // trailing property name.
-func isCallCallee(n *sitter.Node) bool {
+func isCallCallee(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false
@@ -723,7 +723,7 @@ func isCallCallee(n *sitter.Node) bool {
 // inside the value land at the outer frame (or no frame, at file
 // scope) and produce no REFERENCES edge — better than over-attributing
 // to a const that isn't actually function-shaped.
-func isFunctionLikeValue(n *sitter.Node) bool {
+func isFunctionLikeValue(n ts.Node) bool {
 	if n == nil {
 		return false
 	}

--- a/internal/extractors/javascript/relationships_test.go
+++ b/internal/extractors/javascript/relationships_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tsjavascript "github.com/smacker/go-tree-sitter/javascript"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
@@ -15,11 +16,14 @@ import (
 )
 
 // parseJSRel parses JS source for relationship tests.
-func parseJSRel(t *testing.T, src []byte) *sitter.Tree {
+func parseJSRel(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tsjavascript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsjavascript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -27,32 +31,35 @@ func parseJSRel(t *testing.T, src []byte) *sitter.Tree {
 }
 
 // parseTSRel parses TS source for relationship tests.
-func parseTSRel(t *testing.T, src []byte) *sitter.Tree {
+func parseTSRel(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstypescript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	return tree
 }
 
-func runJS(t *testing.T, src string, language string, tree *sitter.Tree) []types.EntityRecord {
+func runJS(t *testing.T, src string, language string, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	return runJSPath(t, src, language, tree, "test."+extOf(language))
 }
 
 // runJSPath is runJS with an explicit file path — used by tests that
 // exercise relative-import path resolution (issue #421).
-func runJSPath(t *testing.T, src string, language string, tree *sitter.Tree, path string) []types.EntityRecord {
+func runJSPath(t *testing.T, src string, language string, tree ts.Tree, path string) []types.EntityRecord {
 	t.Helper()
 	ext, _ := extractor.Get(language)
 	ents, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:     path,
 		Content:  []byte(src),
 		Language: language,
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/template_render.go
+++ b/internal/extractors/javascript/template_render.go
@@ -24,7 +24,7 @@
 package javascript
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -32,15 +32,15 @@ import (
 // emitTemplateRenderEdges scans the AST for Express/Koa `<res>.render('view')`
 // calls and appends template entities + RENDERS edges to x.entities.
 // x.entities[0] MUST be the file entity. Safe with an empty tree.
-func (x *extractor) emitTemplateRenderEdges(root *sitter.Node) {
+func (x *extractor) emitTemplateRenderEdges(root ts.Node) {
 	if root == nil || len(x.entities) == 0 {
 		return
 	}
 
 	var edges []extreg.TemplateEdge
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -91,7 +91,7 @@ func (x *extractor) emitTemplateRenderEdges(root *sitter.Node) {
 // (res / ctx / response, case-insensitive) and the first argument is a plain
 // string literal. Returns "" otherwise (non-render method, non-response
 // receiver, or dynamic first argument → drop).
-func (x *extractor) jsRenderCallTemplate(call *sitter.Node) string {
+func (x *extractor) jsRenderCallTemplate(call ts.Node) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "member_expression" {
 		return ""

--- a/internal/extractors/javascript/tests.go
+++ b/internal/extractors/javascript/tests.go
@@ -54,7 +54,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -89,7 +89,7 @@ var testBlockCallNames = map[string]bool{
 // function/class declarations.
 //
 // No-op for non-test files and for test files with no module-level blocks.
-func (x *extractor) emitTestScopeOwner(root *sitter.Node) {
+func (x *extractor) emitTestScopeOwner(root ts.Node) {
 	if root == nil || !isJSTestFile(x.filePath) {
 		return
 	}
@@ -135,8 +135,8 @@ func (x *extractor) emitTestScopeOwner(root *sitter.Node) {
 // Blocks may be nested (describe → it); we recurse into a matched block's
 // callback so inner it() bodies are mined too, but we do NOT descend into
 // named function/class declarations (their calls already have owners).
-func (x *extractor) collectTestBlockBodies(root *sitter.Node) []*sitter.Node {
-	var out []*sitter.Node
+func (x *extractor) collectTestBlockBodies(root ts.Node) []ts.Node {
+	var out []ts.Node
 	x.walkTestBlocks(root, &out)
 	return out
 }
@@ -144,7 +144,7 @@ func (x *extractor) collectTestBlockBodies(root *sitter.Node) []*sitter.Node {
 // walkTestBlocks recursively finds test-block call callbacks. It treats a
 // call_expression whose callee leaf is a test-block name as a block, records
 // its callback body, and recurses into that body to catch nested blocks.
-func (x *extractor) walkTestBlocks(n *sitter.Node, out *[]*sitter.Node) {
+func (x *extractor) walkTestBlocks(n ts.Node, out *[]ts.Node) {
 	if n == nil {
 		return
 	}
@@ -172,7 +172,7 @@ func (x *extractor) walkTestBlocks(n *sitter.Node, out *[]*sitter.Node) {
 // arrow/function callback, or nil when the call is not a recognised test
 // block or carries no function callback. Handles `describe('x', () => {...})`,
 // `it('y', async () => {...})`, and `it('y', function () {...})`.
-func (x *extractor) testBlockCallbackBody(call *sitter.Node) *sitter.Node {
+func (x *extractor) testBlockCallbackBody(call ts.Node) ts.Node {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return nil

--- a/internal/extractors/javascript/throws_resolve_4480_test.go
+++ b/internal/extractors/javascript/throws_resolve_4480_test.go
@@ -103,7 +103,7 @@ func extractTSFixture4480(t *testing.T, fixture, repoPath string) []types.Entity
 	tree := parseTS(t, src)
 	e := javascript.New()
 	ents, err := e.Extract(context.Background(), extreg.FileInput{
-		Path: repoPath, Language: "typescript", Content: src, Tree: tree,
+		Path: repoPath, Language: "typescript", Content: src, TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("extract %s: %v", fixture, err)

--- a/internal/extractors/javascript/tracing.go
+++ b/internal/extractors/javascript/tracing.go
@@ -26,7 +26,7 @@ package javascript
 import (
 	"strconv"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -48,7 +48,7 @@ var jsTracingSpanMethods = map[string]bool{
 
 // extractTracingSpanHits walks a function/method/arrow body and returns one
 // jsSpanHit per OpenTelemetry span-creation call found.
-func (x *extractor) extractTracingSpanHits(body *sitter.Node) []jsSpanHit {
+func (x *extractor) extractTracingSpanHits(body ts.Node) []jsSpanHit {
 	if body == nil {
 		return nil
 	}
@@ -75,7 +75,7 @@ func (x *extractor) extractTracingSpanHits(body *sitter.Node) []jsSpanHit {
 		hit := jsSpanHit{api: method, line: line}
 
 		args := call.ChildByFieldName("arguments")
-		var nameNode *sitter.Node
+		var nameNode ts.Node
 		if args != nil {
 			nameNode = firstMeaningfulArg(args)
 		}
@@ -107,7 +107,7 @@ func (x *extractor) extractTracingSpanHits(body *sitter.Node) []jsSpanHit {
 // x.entities for every OpenTelemetry span-creation site found in body. Called
 // immediately after a function/method/arrow entity is emitted (alongside
 // stampDiscriminators / stampBranchConditions).
-func (x *extractor) stampTracingSpans(body *sitter.Node) {
+func (x *extractor) stampTracingSpans(body ts.Node) {
 	if body == nil || len(x.entities) == 0 {
 		return
 	}

--- a/internal/extractors/javascript/translation_key.go
+++ b/internal/extractors/javascript/translation_key.go
@@ -31,7 +31,7 @@ package javascript
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 )
@@ -39,7 +39,7 @@ import (
 // emitTranslationKeyEdges scans the AST for i18n key references rooted at a
 // recognised i18n context and appends translation-key entities +
 // USES_TRANSLATION edges to x.entities. x.entities[0] MUST be the file entity.
-func (x *extractor) emitTranslationKeyEdges(root *sitter.Node) {
+func (x *extractor) emitTranslationKeyEdges(root ts.Node) {
 	if root == nil || len(x.entities) == 0 {
 		return
 	}
@@ -47,8 +47,8 @@ func (x *extractor) emitTranslationKeyEdges(root *sitter.Node) {
 
 	var uses []extreg.TranslationUse
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -100,7 +100,7 @@ func (x *extractor) fileHasI18nImport() bool {
 // jsTranslationCall resolves a call_expression to an i18n key when the call is
 // a recognised translation invocation AND its first argument is a static
 // string literal. Returns (key, framework-tag, true) or ("","",false).
-func (x *extractor) jsTranslationCall(call *sitter.Node, hasI18nImport bool) (string, string, bool) {
+func (x *extractor) jsTranslationCall(call ts.Node, hasI18nImport bool) (string, string, bool) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return "", "", false
@@ -153,7 +153,7 @@ func (x *extractor) jsTranslationCall(call *sitter.Node, hasI18nImport bool) (st
 // static string literal (single/double quote, or a backtick template with NO
 // substitutions). Returns ok=false for a dynamic key (identifier, interpolated
 // template, member access, concatenation) — the honest-partial boundary.
-func (x *extractor) jsFirstStringArg(call *sitter.Node) (string, bool) {
+func (x *extractor) jsFirstStringArg(call ts.Node) (string, bool) {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return "", false
@@ -190,7 +190,7 @@ func (x *extractor) jsFirstStringArg(call *sitter.Node) (string, bool) {
 
 // jsTemplateHasSubstitution reports whether a template_string node contains a
 // `${...}` interpolation (template_substitution child).
-func jsTemplateHasSubstitution(n *sitter.Node) bool {
+func jsTemplateHasSubstitution(n ts.Node) bool {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		if c := n.Child(i); c != nil && c.Type() == "template_substitution" {
 			return true
@@ -202,7 +202,7 @@ func jsTemplateHasSubstitution(n *sitter.Node) bool {
 // jsxTransKey extracts the static `i18nKey="..."` attribute value from a
 // `<Trans i18nKey="x">` element. Returns ("", false) when the element is not a
 // Trans element, has no i18nKey, or the attribute value is dynamic ({expr}).
-func (x *extractor) jsxTransKey(el *sitter.Node) (string, bool) {
+func (x *extractor) jsxTransKey(el ts.Node) (string, bool) {
 	nameNode := el.ChildByFieldName("name")
 	if nameNode == nil {
 		return "", false
@@ -247,7 +247,7 @@ func (x *extractor) jsxTransKey(el *sitter.Node) (string, bool) {
 // "$t"). Returns ("", "") when the receiver is neither a plain identifier nor
 // `this`. (Distinct from external_service.go's jsMemberRootAndTail, which
 // flattens a deep dotted tail and rejects a `this` root.)
-func (x *extractor) i18nMemberRootTail(member *sitter.Node) (string, string) {
+func (x *extractor) i18nMemberRootTail(member ts.Node) (string, string) {
 	prop := member.ChildByFieldName("property")
 	obj := member.ChildByFieldName("object")
 	if prop == nil || obj == nil {

--- a/internal/extractors/javascript/tsconfig_paths_test.go
+++ b/internal/extractors/javascript/tsconfig_paths_test.go
@@ -14,7 +14,8 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tstypescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -23,11 +24,14 @@ import (
 
 // parseTSForAlias is a minimal helper that parses TypeScript source with
 // the tree-sitter TypeScript grammar, used only by this file.
-func parseTSForAlias(t *testing.T, src []byte) *sitter.Tree {
+func parseTSForAlias(t *testing.T, src []byte) ts.Tree {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tstypescript.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tstypescript.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parseTSForAlias: %v", err)
 	}
@@ -36,7 +40,7 @@ func parseTSForAlias(t *testing.T, src []byte) *sitter.Tree {
 
 // extractWithRepo runs the JS/TS extractor with RepoRoot set so alias and
 // filesystem-existence checks are exercised end-to-end.
-func extractWithRepo(t *testing.T, repoRoot, filePath string, content []byte, tree *sitter.Tree) []types.EntityRecord {
+func extractWithRepo(t *testing.T, repoRoot, filePath string, content []byte, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	e := New()
 	entities, err := e.Extract(context.Background(), extreg.FileInput{
@@ -44,7 +48,7 @@ func extractWithRepo(t *testing.T, repoRoot, filePath string, content []byte, tr
 		RepoRoot: repoRoot,
 		Content:  content,
 		Language: "typescript",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/javascript/validation_linkage.go
+++ b/internal/extractors/javascript/validation_linkage.go
@@ -44,8 +44,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // validatorMethodLibrary maps a recognised validation method name to the
@@ -98,7 +98,7 @@ var dtoDecorators = map[string]bool{
 // operation's entity ID at emit time (the same contract as every other
 // per-body relationship emitter). ToID is the synthetic `validator:<lib>`
 // stub.
-func (x *extractor) extractValidationEdge(call *sitter.Node) (types.RelationshipRecord, bool) {
+func (x *extractor) extractValidationEdge(call ts.Node) (types.RelationshipRecord, bool) {
 	if call == nil || call.Type() != "call_expression" {
 		return types.RelationshipRecord{}, false
 	}
@@ -174,7 +174,7 @@ func validatesEdge(library, method, line string) types.RelationshipRecord {
 // which carries a `type` annotation. We require BOTH a recognised DTO
 // decorator AND a class-shaped (PascalCase, non-primitive) type so a bare
 // `@Body() body: any` is not over-claimed.
-func (x *extractor) extractDTOParamEdges(params *sitter.Node) []types.RelationshipRecord {
+func (x *extractor) extractDTOParamEdges(params ts.Node) []types.RelationshipRecord {
 	if params == nil {
 		return nil
 	}
@@ -220,7 +220,7 @@ func (x *extractor) extractDTOParamEdges(params *sitter.Node) []types.Relationsh
 
 // paramDTODecorator returns the recognised NestJS DTO decorator name
 // (Body/Query/Param) applied to a parameter node, or "" when none.
-func paramDTODecorator(x *extractor, param *sitter.Node) string {
+func paramDTODecorator(x *extractor, param ts.Node) string {
 	for i := 0; i < int(param.ChildCount()); i++ {
 		c := param.Child(i)
 		if c == nil || c.Type() != "decorator" {
@@ -236,7 +236,7 @@ func paramDTODecorator(x *extractor, param *sitter.Node) string {
 
 // decoratorLeafName returns the leaf identifier of a `decorator` node,
 // handling both `@Body` and `@Body()` (call_expression) shapes.
-func decoratorLeafName(x *extractor, dec *sitter.Node) string {
+func decoratorLeafName(x *extractor, dec ts.Node) string {
 	for i := 0; i < int(dec.ChildCount()); i++ {
 		c := dec.Child(i)
 		if c == nil {
@@ -335,7 +335,7 @@ func isSchemaVarName(name string) bool {
 //	Yup.object(...)   → "yup"
 //	ajv.compile(...)  → "ajv"
 //	new Ajv().compile → also caught at call-site level
-func schemaLibraryFromCall(n *sitter.Node, nodeText func(*sitter.Node) string) (library string, ok bool) {
+func schemaLibraryFromCall(n ts.Node, nodeText func(ts.Node) string) (library string, ok bool) {
 	if n == nil || n.Type() != "call_expression" {
 		return "", false
 	}
@@ -369,13 +369,13 @@ func schemaLibraryFromCall(n *sitter.Node, nodeText func(*sitter.Node) string) (
 // call (zod/joi/yup/ajv). Returns a map from variable name to library name
 // (e.g. "createUserSchema" → "zod"). Only module-scope declarations are
 // considered (the walker stops at function bodies).
-func (x *extractor) buildSchemaLibDTOs(root *sitter.Node) map[string]string {
+func (x *extractor) buildSchemaLibDTOs(root ts.Node) map[string]string {
 	if root == nil {
 		return nil
 	}
 	result := make(map[string]string)
-	var scan func(n *sitter.Node, depth int)
-	scan = func(n *sitter.Node, depth int) {
+	var scan func(n ts.Node, depth int)
+	scan = func(n ts.Node, depth int) {
 		if n == nil {
 			return
 		}
@@ -431,7 +431,7 @@ func (x *extractor) buildSchemaLibDTOs(root *sitter.Node) map[string]string {
 // This is the Express/Fastify-family analogue of extractDTOParamEdges for
 // NestJS: instead of a @Body() decorator, the DTO is a top-level z.object /
 // Joi.object / yup.object / ajv.compile schema variable.
-func (x *extractor) extractSchemaDTOEdge(call *sitter.Node) (types.RelationshipRecord, bool) {
+func (x *extractor) extractSchemaDTOEdge(call ts.Node) (types.RelationshipRecord, bool) {
 	if call == nil || call.Type() != "call_expression" || len(x.schemaLibDTOs) == 0 {
 		return types.RelationshipRecord{}, false
 	}
@@ -480,7 +480,7 @@ func (x *extractor) extractSchemaDTOEdge(call *sitter.Node) (types.RelationshipR
 // be called after buildSchemaLibDTOs populates x.schemaLibDTOs and before
 // walk() runs so that schema entities are present in the graph even when no
 // handler references them in the same file.
-func (x *extractor) emitSchemaLibDTOEntities(root *sitter.Node) {
+func (x *extractor) emitSchemaLibDTOEntities(root ts.Node) {
 	if len(x.schemaLibDTOs) == 0 {
 		return
 	}
@@ -488,8 +488,8 @@ func (x *extractor) emitSchemaLibDTOEntities(root *sitter.Node) {
 		return
 	}
 	// Walk only the top-level to find the value node for each matching var.
-	var scan func(n *sitter.Node, depth int)
-	scan = func(n *sitter.Node, depth int) {
+	var scan func(n ts.Node, depth int)
+	scan = func(n ts.Node, depth int) {
 		if n == nil {
 			return
 		}

--- a/internal/extractors/javascript/zustand_store.go
+++ b/internal/extractors/javascript/zustand_store.go
@@ -50,8 +50,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // PropViaZustandStore is the value for Properties["via"] stamped on CALLS
@@ -72,7 +72,7 @@ type zustandTracker struct {
 	// the AST node of the function value. Populated alongside storeActions so
 	// that emitStoreActionEntities can derive source-line ranges for each action
 	// method entity (issue #2626).
-	storeActionNodes map[string]map[string]*sitter.Node
+	storeActionNodes map[string]map[string]ts.Node
 
 	// storePartializeFields maps a store variable name to the list of field
 	// names that appear in the partialize config (issue #2626).
@@ -85,7 +85,7 @@ type zustandTracker struct {
 // importByLocal map and an AST walk to find create() assignments.
 //
 // Returns nil when no "zustand" import is found in the file (fast-path).
-func (x *extractor) buildZustandTracker(root *sitter.Node) *zustandTracker {
+func (x *extractor) buildZustandTracker(root ts.Node) *zustandTracker {
 	if x.importByLocal == nil {
 		return nil
 	}
@@ -118,7 +118,7 @@ func (x *extractor) buildZustandTracker(root *sitter.Node) *zustandTracker {
 
 	t := &zustandTracker{
 		storeActions:          make(map[string]map[string]bool),
-		storeActionNodes:      make(map[string]map[string]*sitter.Node),
+		storeActionNodes:      make(map[string]map[string]ts.Node),
 		storePartializeFields: make(map[string][]string),
 	}
 	if root != nil {
@@ -138,8 +138,8 @@ func (x *extractor) buildZustandTracker(root *sitter.Node) *zustandTracker {
 //
 // For each match it records the action keys (function-valued object properties)
 // in storeActions[<storeVar>].
-func (t *zustandTracker) scanForStores(x *extractor, root *sitter.Node, createLocals map[string]bool) {
-	stack := make([]*sitter.Node, 0, 64)
+func (t *zustandTracker) scanForStores(x *extractor, root ts.Node, createLocals map[string]bool) {
+	stack := make([]ts.Node, 0, 64)
 	stack = append(stack, root)
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
@@ -159,7 +159,7 @@ func (t *zustandTracker) scanForStores(x *extractor, root *sitter.Node, createLo
 
 // processVariableDeclarator checks whether the declarator is a zustand create()
 // call and records the action keys.
-func (t *zustandTracker) processVariableDeclarator(x *extractor, n *sitter.Node, createLocals map[string]bool) {
+func (t *zustandTracker) processVariableDeclarator(x *extractor, n ts.Node, createLocals map[string]bool) {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil || nameNode.Type() != "identifier" {
 		return
@@ -204,7 +204,7 @@ func (t *zustandTracker) processVariableDeclarator(x *extractor, n *sitter.Node,
 // unwrapToCallExpression unwraps TS generic call expressions like `create<T>(...)`
 // which tree-sitter may parse as a call_expression wrapping a generic identifier.
 // Returns the call_expression node or nil.
-func unwrapToCallExpression(n *sitter.Node) *sitter.Node {
+func unwrapToCallExpression(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -218,7 +218,7 @@ func unwrapToCallExpression(n *sitter.Node) *sitter.Node {
 
 // isZustandCreateCall returns true when callNode is a call to a local `create`
 // binding that originated from the "zustand" import.
-func (t *zustandTracker) isZustandCreateCall(x *extractor, callNode *sitter.Node, createLocals map[string]bool) bool {
+func (t *zustandTracker) isZustandCreateCall(x *extractor, callNode ts.Node, createLocals map[string]bool) bool {
 	fn := callNode.ChildByFieldName("function")
 	if fn == nil {
 		return false
@@ -265,7 +265,7 @@ func (t *zustandTracker) isZustandCreateCall(x *extractor, callNode *sitter.Node
 // When the first arg to the create() call is itself a call_expression
 // (a middleware wrapper like persist/devtools/immer), we unwrap one level
 // to find the factory arrow/function_expression inside the middleware call.
-func extractStoreActionsWithNodes(x *extractor, createCall *sitter.Node) (map[string]bool, map[string]*sitter.Node) {
+func extractStoreActionsWithNodes(x *extractor, createCall ts.Node) (map[string]bool, map[string]ts.Node) {
 	args := createCall.ChildByFieldName("arguments")
 	if args == nil {
 		return nil, nil
@@ -273,7 +273,7 @@ func extractStoreActionsWithNodes(x *extractor, createCall *sitter.Node) (map[st
 	// Find the first arrow_function or function_expression argument.
 	// If the first non-punctuation arg is a call_expression (middleware wrapper),
 	// unwrap one level to find the factory inside that middleware call.
-	var factoryNode *sitter.Node
+	var factoryNode ts.Node
 	for i := 0; i < int(args.ChildCount()); i++ {
 		ch := args.Child(i)
 		if ch == nil {
@@ -326,7 +326,7 @@ func extractStoreActionsWithNodes(x *extractor, createCall *sitter.Node) (map[st
 // itself a call_expression (nested middleware), it recurses one level.
 //
 // Returns the factory node or nil when the shape is not recognised.
-func extractFactoryFromMiddlewareCall(_ *extractor, middlewareCall *sitter.Node) *sitter.Node {
+func extractFactoryFromMiddlewareCall(_ *extractor, middlewareCall ts.Node) ts.Node {
 	if middlewareCall == nil || middlewareCall.Type() != "call_expression" {
 		return nil
 	}
@@ -358,7 +358,7 @@ func extractFactoryFromMiddlewareCall(_ *extractor, middlewareCall *sitter.Node)
 //	create(factory, { name: 'auth', partialize: (s) => ({ user: s.user, token: s.token }) })
 //
 // Returns nil when no partialize config is found. Issue #2626.
-func extractPartializeFields(x *extractor, createCall *sitter.Node) []string {
+func extractPartializeFields(x *extractor, createCall ts.Node) []string {
 	args := createCall.ChildByFieldName("arguments")
 	if args == nil {
 		return nil
@@ -413,7 +413,7 @@ func extractPartializeFields(x *extractor, createCall *sitter.Node) []string {
 
 // collectPartializeReturnKeys collects the object keys returned by the
 // partialize arrow: (s) => ({ user: s.user, token: s.token }) → ["user", "token"].
-func collectPartializeReturnKeys(x *extractor, fnNode *sitter.Node) []string {
+func collectPartializeReturnKeys(x *extractor, fnNode ts.Node) []string {
 	if fnNode == nil {
 		return nil
 	}
@@ -451,7 +451,7 @@ func collectPartializeReturnKeys(x *extractor, fnNode *sitter.Node) []string {
 //	(set, get) => ({ queue: [], enqueue: fn })   → parenthesized_expression → object
 //	(set, get) => { return { ... } }             → statement_block → return → object
 //	(set, get) => { return persist({ ... }) }    → NOT directly an object (ignored)
-func findObjectLiteral(body *sitter.Node) *sitter.Node {
+func findObjectLiteral(body ts.Node) ts.Node {
 	if body == nil {
 		return nil
 	}
@@ -497,9 +497,9 @@ func findObjectLiteral(body *sitter.Node) *sitter.Node {
 // alongside a map from key to the function-value AST node (for line ranges).
 // Plain state values (arrays, primitives, identifiers that are not functions)
 // are excluded so we don't emit spurious CALLS edges. Issue #2626.
-func collectFunctionValuedKeysWithNodes(x *extractor, obj *sitter.Node) (map[string]bool, map[string]*sitter.Node) {
+func collectFunctionValuedKeysWithNodes(x *extractor, obj ts.Node) (map[string]bool, map[string]ts.Node) {
 	actions := make(map[string]bool)
-	nodes := make(map[string]*sitter.Node)
+	nodes := make(map[string]ts.Node)
 	for i := 0; i < int(obj.ChildCount()); i++ {
 		pair := obj.Child(i)
 		if pair == nil || pair.Type() != "pair" {
@@ -551,7 +551,7 @@ func (t *zustandTracker) emitStoreActionEntities(x *extractor) {
 		nodeMap := t.storeActionNodes[storeVar]
 		partFields := strings.Join(t.storePartializeFields[storeVar], ",")
 		for actionName := range actionNames {
-			var fnNode *sitter.Node
+			var fnNode ts.Node
 			if nodeMap != nil {
 				fnNode = nodeMap[actionName]
 			}
@@ -583,7 +583,7 @@ func (t *zustandTracker) emitStoreActionEntities(x *extractor) {
 
 // isFunctionNode returns true when the node is an arrow_function or
 // function_expression (i.e., a function-valued property → an action).
-func isFunctionNode(n *sitter.Node) bool {
+func isFunctionNode(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -602,7 +602,7 @@ func isFunctionNode(n *sitter.Node) bool {
 //
 // The outer call_expression has a function of type member_expression whose
 // object is itself a call_expression (getState() call).
-func (t *zustandTracker) zustandGetStateActionEdges(x *extractor, callNode *sitter.Node, callerName string) []types.RelationshipRecord {
+func (t *zustandTracker) zustandGetStateActionEdges(x *extractor, callNode ts.Node, callerName string) []types.RelationshipRecord {
 	if t == nil {
 		return nil
 	}
@@ -656,7 +656,7 @@ func (t *zustandTracker) zustandGetStateActionEdges(x *extractor, callNode *sitt
 
 // resolveGetStateCall returns the store variable name when node is a call
 // of the form `<storeVar>.getState()`. Returns "" otherwise.
-func (t *zustandTracker) resolveGetStateCall(x *extractor, node *sitter.Node) string {
+func (t *zustandTracker) resolveGetStateCall(x *extractor, node ts.Node) string {
 	if node == nil || node.Type() != "call_expression" {
 		return ""
 	}
@@ -694,7 +694,7 @@ func (t *zustandTracker) resolveGetStateCall(x *extractor, node *sitter.Node) st
 //	outer: `<inner>()`  where inner = `<storeVar>(s => s.<action>)`
 //
 // We emit a CALLS edge from callerName → actionName with via=zustand_store.
-func (t *zustandTracker) zustandSelectorActionEdges(x *extractor, callNode *sitter.Node, callerName string) []types.RelationshipRecord {
+func (t *zustandTracker) zustandSelectorActionEdges(x *extractor, callNode ts.Node, callerName string) []types.RelationshipRecord {
 	if t == nil {
 		return nil
 	}
@@ -704,7 +704,7 @@ func (t *zustandTracker) zustandSelectorActionEdges(x *extractor, callNode *sitt
 	}
 	// The function of the outer call must be a parenthesized call or call_expression
 	// (the selector invocation).
-	var innerCall *sitter.Node
+	var innerCall ts.Node
 	switch fn.Type() {
 	case "call_expression":
 		innerCall = fn


### PR DESCRIPTION
Migrates the JS/TS extractor (the `javascript` package, which serves both the `javascript` and `typescript` languages — there is no separate `typescript` package) off the concrete smacker `*sitter.Node` / `*sitter.Tree` onto the binding-agnostic `internal/treesitter/ts` façade (`ts.Node` / `ts.Tree`), reading the shared `FileInput.TSTree`. Smacker-backed by default (link-safe), mechanical and behavior-preserving. B2 Phase 1, Batch 2 (#5418). Mirrors Phase-0 (Go, #5430) and Batch-1 (python+java, #5431).

## What changed
- **`extractor.go`** reads `file.TSTree` and early-returns when no tree is supplied. The extractor has **no inline-parse fallback** (it never parsed raw `Content` itself), so — exactly like the java extractor — **no `grammar.go` provider was added**.
- **34 non-test source files:** pure `*sitter.Node` → `ts.Node` swap; the root `smacker/go-tree-sitter` import replaced with `internal/treesitter/ts`. Every node method used (`Type`, `Child`, `ChildCount`, `NamedChild`, `ChildByFieldName`, `Parent`, `StartByte/EndByte`, `StartPoint/EndPoint`, `IsNamed`) is on the façade — no unsupported methods (`NextSibling`, `Range`, `Symbol`, …) anywhere.
- **Test tree-helpers** now build `ts.Tree` via the smacker adapter (`tssmacker.New().NewParser(tssmacker.WrapLanguage(grammar.GetLanguage()))`) and stamp `TSTree` (`Tree:` → `TSTree:`). Grammar **subpackage** imports (`smacker/go-tree-sitter/javascript`, `/typescript/typescript`, `/typescript/tsx`) stay in the test helpers, identical to merged batch 1's java. Files that build an anonymous inline tree (no `ts.Tree` value) drop the unused `ts` import and keep only `tssmacker`. No test assertion changed.

## Validation (default build)
- `go build ./...` ✅ (only the pre-existing upstream `smacker/.../lua` C `-Wnull-character` warning)
- `go vet ./internal/extractors/javascript/` ✅ clean
- `gofmt -l internal/extractors/javascript/` ✅ empty
- `go test -count=1 ./internal/extractors/javascript/` ✅ PASS, unchanged (zero fidelity delta)
- `grep -rn '\*sitter\.\(Node\|Tree\)'` and root `sitter "…/go-tree-sitter"` import → both empty in the package

The `-tags ts_official` full-link still hits the pre-existing 247-dup-symbol blocker — out of scope; only narrow per-package default builds matter for this phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)