### PR TITLE
refactor(extractors): migrate ruby+php+csharp+rust to ts.Node (B2 Phase 1 #5418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,18 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   smacker adapter and stamp `TSTree`. Default builds stay 100% smacker-backed and
   link-safe; mechanical and behavior-preserving — the javascript+typescript
   extractor suite passes unchanged (zero fidelity delta).
+- **Migrated the `ruby`, `php`, `csharp` and `rust` extractors to the `ts.Node`
+  abstraction (smacker-backed, no behavior change)** — B2 Phase 1 (#5418). All
+  four extractors now traverse the binding-agnostic `internal/treesitter/ts`
+  façade (`ts.Node`/`ts.Tree`) and read the shared `FileInput.TSTree` instead of
+  the concrete `smacker/go-tree-sitter` `*sitter.Node`/`*sitter.Tree`. Each
+  early-returns when no tree is supplied (no inline parse fallback), so no grammar
+  provider was added; test tree-helpers build `ts.Tree` via the smacker adapter
+  and stamp `TSTree`. The `ts.Node` façade gains a `PrevSibling()` method (added
+  to both the smacker and official adapters) that the Rust extractor's
+  derive-macro scan requires. Default builds stay 100% smacker-backed and
+  link-safe; mechanical and behavior-preserving — the ruby+php+csharp+rust
+  extractor suites pass unchanged (zero fidelity delta).
 
 ## [0.1.3] — 2026-06-23
 

--- a/internal/extractors/csharp/config_consumer.go
+++ b/internal/extractors/csharp/config_consumer.go
@@ -24,7 +24,7 @@ package csharp
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -36,15 +36,15 @@ import (
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitConfigConsumerEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitConfigConsumerEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
 
 	var reads []extractor.ConfigRead
 
-	var walk func(n *sitter.Node, enclosingType, enclosing string)
-	walk = func(n *sitter.Node, enclosingType, enclosing string) {
+	var walk func(n ts.Node, enclosingType, enclosing string)
+	walk = func(n ts.Node, enclosingType, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -90,7 +90,7 @@ func emitConfigConsumerEdges(root *sitter.Node, src []byte, entities *[]types.En
 //	<cfg>.GetConnectionString("name")                  → "get_connection_string"
 //	<cfg>.GetSection("k") / <cfg>.GetRequiredSection   → "get_section"
 //	Environment.GetEnvironmentVariable("X")            → "env_var"
-func csharpInvocationConfigKey(call *sitter.Node, src []byte) (string, string) {
+func csharpInvocationConfigKey(call ts.Node, src []byte) (string, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "member_access_expression" {
 		return "", ""
@@ -150,7 +150,7 @@ func csharpInvocationConfigKey(call *sitter.Node, src []byte) (string, string) {
 // csharpElementAccessConfigKey returns the config key for a
 // Configuration["KEY"] / _config["KEY"] element-access expression with a
 // literal string index, or "".
-func csharpElementAccessConfigKey(n *sitter.Node, src []byte) string {
+func csharpElementAccessConfigKey(n ts.Node, src []byte) string {
 	exprNode := n.ChildByFieldName("expression")
 	if exprNode == nil {
 		// expression is the first child when the field is unnamed.
@@ -166,7 +166,7 @@ func csharpElementAccessConfigKey(n *sitter.Node, src []byte) string {
 		return ""
 	}
 	// The subscript lives in the bracketed_argument_list child.
-	var bracket *sitter.Node
+	var bracket ts.Node
 	for i := 0; i < int(n.NamedChildCount()); i++ {
 		if n.NamedChild(i).Type() == "bracketed_argument_list" {
 			bracket = n.NamedChild(i)
@@ -203,7 +203,7 @@ func csharpLooksLikeConfig(recv string) bool {
 // csharpFirstStringArg returns the literal content of the first string argument
 // in an argument_list / bracketed_argument_list node, or "" when the first
 // argument is missing or non-literal (dynamic) — honest-partial.
-func csharpFirstStringArg(args *sitter.Node, src []byte) string {
+func csharpFirstStringArg(args ts.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
@@ -230,7 +230,7 @@ func csharpFirstStringArg(args *sitter.Node, src []byte) string {
 // dropping the surrounding quotes. Handles regular, verbatim (@"..."), and
 // interpolated strings — returns "" for an interpolated string carrying an
 // `interpolation` part (dynamic), honest-partial.
-func csharpStringLiteral(node *sitter.Node, src []byte) string {
+func csharpStringLiteral(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}

--- a/internal/extractors/csharp/config_consumer_test.go
+++ b/internal/extractors/csharp/config_consumer_test.go
@@ -22,7 +22,7 @@ func extractCSharpRecords(t *testing.T, src string) []types.EntityRecord {
 		Path:     "cfg.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/csharp/const_valueset.go
+++ b/internal/extractors/csharp/const_valueset.go
@@ -23,7 +23,7 @@ package csharp
 // not a value-set).
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -33,7 +33,7 @@ import (
 // class body and emits value-set nodes for the two C# constant-collection
 // shapes. className names the enclosing class (used as the const-group node
 // name). Appended nodes never replace the field entities the default walk emits.
-func emitConstCollectionsForClass(body *sitter.Node, file extractor.FileInput, className string, out *[]types.EntityRecord) {
+func emitConstCollectionsForClass(body ts.Node, file extractor.FileInput, className string, out *[]types.EntityRecord) {
 	if body == nil {
 		return
 	}
@@ -73,7 +73,7 @@ func emitConstCollectionsForClass(body *sitter.Node, file extractor.FileInput, c
 
 // fieldConstKind reports whether a field_declaration carries the `const`
 // modifier, or both `static` and `readonly` modifiers.
-func fieldConstKind(fld *sitter.Node) (isConst, isStaticReadonly bool) {
+func fieldConstKind(fld ts.Node) (isConst, isStaticReadonly bool) {
 	var static, readonly bool
 	for i := 0; i < int(fld.ChildCount()); i++ {
 		ch := fld.Child(i)
@@ -100,7 +100,7 @@ func fieldConstKind(fld *sitter.Node) (isConst, isStaticReadonly bool) {
 // value and 1-indexed line. ok=false when the field is not a single
 // string-literal-valued declarator (e.g. a Dictionary map, an int const, or a
 // non-literal initialiser).
-func constStringField(fld *sitter.Node, file extractor.FileInput) (name, value string, line int, ok bool) {
+func constStringField(fld ts.Node, file extractor.FileInput) (name, value string, line int, ok bool) {
 	decl := findChildByType(fld, "variable_declaration")
 	if decl == nil {
 		return "", "", 0, false
@@ -146,7 +146,7 @@ func constStringField(fld *sitter.Node, file extractor.FileInput) (name, value s
 // the field is not a Dictionary-shaped map, has no initialiser entries, or any
 // entry is not a {string-literal key, string-literal value} pair (honest-partial
 // closed value-set).
-func buildConstMapValueSet(fld *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildConstMapValueSet(fld ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	decl := findChildByType(fld, "variable_declaration")
 	if decl == nil {
 		return types.EntityRecord{}, false
@@ -197,7 +197,7 @@ func buildConstMapValueSet(fld *sitter.Node, file extractor.FileInput) (types.En
 // either nested `{ "k", "v" }` element initialisers or `["k"] = "v"` indexer
 // assignments. It returns ok=false the moment any entry is not a
 // string-literal/string-literal pair so a non-closed map emits no node.
-func collectMapInitMembers(init *sitter.Node, file extractor.FileInput) ([]extractor.EnumMember, bool) {
+func collectMapInitMembers(init ts.Node, file extractor.FileInput) ([]extractor.EnumMember, bool) {
 	var members []extractor.EnumMember
 	for i := 0; i < int(init.ChildCount()); i++ {
 		entry := init.Child(i)
@@ -229,7 +229,7 @@ func collectMapInitMembers(init *sitter.Node, file extractor.FileInput) ([]extra
 // twoStringLiterals reads the first two string_literal children of a nested
 // `{ "k", "v" }` element initializer. ok=false when fewer than two string
 // literals are present (a non-string key or value disqualifies the map).
-func twoStringLiterals(entry *sitter.Node, file extractor.FileInput) (key, val string, ok bool) {
+func twoStringLiterals(entry ts.Node, file extractor.FileInput) (key, val string, ok bool) {
 	var lits []string
 	for i := 0; i < int(entry.ChildCount()); i++ {
 		ch := entry.Child(i)
@@ -247,7 +247,7 @@ func twoStringLiterals(entry *sitter.Node, file extractor.FileInput) (key, val s
 // indexerAssignment reads an `["key"] = "value"` assignment_expression: the key
 // is the string_literal inside the element_binding_expression, the value is the
 // string_literal RHS. ok=false when either side is not a string literal.
-func indexerAssignment(entry *sitter.Node, file extractor.FileInput) (key, val string, ok bool) {
+func indexerAssignment(entry ts.Node, file extractor.FileInput) (key, val string, ok bool) {
 	binding := findChildByType(entry, "element_binding_expression")
 	if binding == nil {
 		return "", "", false
@@ -275,7 +275,7 @@ func indexerAssignment(entry *sitter.Node, file extractor.FileInput) (key, val s
 // findDeepStringLiteral returns the text of the first string_literal found in a
 // shallow DFS of node, or "" when none is present. Used to pull the key out of
 // an `["key"]` element_binding_expression's `argument` wrapper.
-func findDeepStringLiteral(node *sitter.Node, file extractor.FileInput) string {
+func findDeepStringLiteral(node ts.Node, file extractor.FileInput) string {
 	if node == nil {
 		return ""
 	}
@@ -294,7 +294,7 @@ func findDeepStringLiteral(node *sitter.Node, file extractor.FileInput) string {
 // the surrounding quotes stripped. Tree-sitter exposes the content as a
 // `string_literal_content` child; falling back to StripLiteralQuotes over the
 // raw token covers verbatim/interpolated tokens that lack that child.
-func stringLiteralText(lit *sitter.Node, src []byte) string {
+func stringLiteralText(lit ts.Node, src []byte) string {
 	if lit == nil {
 		return ""
 	}

--- a/internal/extractors/csharp/crosspath.go
+++ b/internal/extractors/csharp/crosspath.go
@@ -32,7 +32,7 @@ package csharp
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // csharpCrossCtx is the per-file resolution context derived from the file's
@@ -64,7 +64,7 @@ type csharpCrossCtx struct {
 
 // buildCrossCtx scans the compilation unit for namespace + using declarations
 // and assembles the per-file C# cross-namespace context.
-func buildCrossCtx(root *sitter.Node, src []byte) *csharpCrossCtx {
+func buildCrossCtx(root ts.Node, src []byte) *csharpCrossCtx {
 	if root == nil {
 		return nil
 	}
@@ -134,7 +134,7 @@ type qualifiedCallBinding struct {
 // unqualified bare calls, unresolvable chains) so the base extractor's target
 // is used unchanged.
 func (c *csharpCrossCtx) resolveQualifiedCall(
-	fn *sitter.Node,
+	fn ts.Node,
 	src []byte,
 	cc *classCtx,
 	locals map[string]string,
@@ -225,7 +225,7 @@ func (c *csharpCrossCtx) resolveQualifiedCall(
 // alias_qualified_name (`global::App`) into its dotted segments. Returns
 // (nil, false) the moment a non-static node (e.g. `this`, an invocation, an
 // element access) appears — those are instance chains the base extractor owns.
-func flattenStaticPath(n *sitter.Node, src []byte) ([]string, bool) {
+func flattenStaticPath(n ts.Node, src []byte) ([]string, bool) {
 	if n == nil {
 		return nil, false
 	}

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -41,7 +41,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -59,7 +59,7 @@ func (e *Extractor) Language() string { return "csharp" }
 
 // Extract walks the tree-sitter CST and returns entity records for the C# file.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -69,7 +69,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	imports := collectImportNames(root, file.Content)
 	// Issue #4374 — per-file cross-namespace context (namespaces, usings,
 	// aliases, `using static` types) used to bind qualified cross-namespace
@@ -106,7 +106,7 @@ type classCtx struct {
 // every Component/Operation/Schema entity so the resolver can build a
 // namespace-keyed member index for cross-namespace CALLS binding.
 func walk(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	parentType string,
 	ns string,
@@ -271,7 +271,7 @@ func stampNamespace(rec *types.EntityRecord, ns string) {
 
 // findTypeBody returns the declaration_list child of a class/interface/
 // struct declaration, or nil when the type has no body.
-func findTypeBody(node *sitter.Node) *sitter.Node {
+func findTypeBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch != nil && ch.Type() == "declaration_list" {
@@ -282,7 +282,7 @@ func findTypeBody(node *sitter.Node) *sitter.Node {
 }
 
 // buildComponent creates a SCOPE.Component entity for class/interface/struct declarations.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -304,7 +304,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 // buildEnumEntity creates a SCOPE.Schema entity (subtype="enum") for enum declarations.
 // Enum member names are collected and stored in the Signature field as a comma-separated
 // list so the graph carries the full member set without additional enrichment.
-func buildEnumEntity(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildEnumEntity(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -347,7 +347,7 @@ func buildEnumEntity(node *sitter.Node, file extractor.FileInput) (types.EntityR
 // capturing each member's explicit literal value (`Active = 1`) when present.
 // Members with no explicit value (`Active,` — C# auto-assigns the position) are
 // recorded value-less; honest-partial avoids fabricating the implicit ordinal.
-func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildEnumValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -394,7 +394,7 @@ func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.Entit
 //
 // Issue #65 parity: when parentType is non-empty, Name is emitted as
 // "<parentType>.<member>".
-func buildOperation(node *sitter.Node, file extractor.FileInput, subtype, parentType string) (types.EntityRecord, bool) {
+func buildOperation(node ts.Node, file extractor.FileInput, subtype, parentType string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -434,7 +434,7 @@ func buildOperation(node *sitter.Node, file extractor.FileInput, subtype, parent
 // `using A = System.Console;` (alias) →
 //
 //	local_name="A", source_module="System", imported_name="Console"
-func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	raw, alias := extractUsingTargetWithAlias(node, file.Content)
 	if raw == "" {
 		return types.EntityRecord{}, false
@@ -486,7 +486,7 @@ func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 // `using A = X.Y;`. The path itself appears as a sibling
 // qualified_name / identifier / member_access_expression child without
 // a field name.
-func extractUsingTargetWithAlias(node *sitter.Node, src []byte) (string, string) {
+func extractUsingTargetWithAlias(node ts.Node, src []byte) (string, string) {
 	var alias string
 	// Detect alias via the "name" field (only present in `using A = X.Y;`).
 	if n := node.ChildByFieldName("name"); n != nil && n.Type() == "identifier" {
@@ -531,7 +531,7 @@ func extractUsingTargetWithAlias(node *sitter.Node, src []byte) (string, string)
 // collectImportNames scans the file for top-level using_directive nodes
 // and returns a set of locally-bound simple names. Used by the receiver
 // binder as a confirming signal for PascalCase static-call shapes.
-func collectImportNames(root *sitter.Node, src []byte) map[string]bool {
+func collectImportNames(root ts.Node, src []byte) map[string]bool {
 	if root == nil {
 		return nil
 	}
@@ -560,7 +560,7 @@ func collectImportNames(root *sitter.Node, src []byte) map[string]bool {
 // or locals produce dotted "<Type>.<method>" targets; PascalCase bare
 // receivers stay dotted; everything else falls back to the bare leaf.
 func extractCallRelationships(
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	callerName string,
 	cc *classCtx,
@@ -640,7 +640,7 @@ func extractCallRelationships(
 // csharpCallTarget resolves the callee target from an invocation_expression
 // or object_creation_expression node.
 func csharpCallTarget(
-	call *sitter.Node,
+	call ts.Node,
 	src []byte,
 	cc *classCtx,
 	paramTypes map[string]string,
@@ -693,7 +693,7 @@ func csharpCallTarget(
 // receiverTypeName returns the declared type of a member-access receiver
 // when statically determinable, or "" otherwise.
 func receiverTypeName(
-	obj *sitter.Node,
+	obj ts.Node,
 	src []byte,
 	cc *classCtx,
 	paramTypes map[string]string,
@@ -762,7 +762,7 @@ func isPascalCase(s string) bool {
 //
 // Multi-declarator fields (`int x, y;`) bind every variable to the
 // declared type. Fields without a parseable type are dropped.
-func collectFieldTypes(body *sitter.Node, src []byte) map[string]string {
+func collectFieldTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -825,7 +825,7 @@ func collectFieldTypes(body *sitter.Node, src []byte) map[string]string {
 
 // collectParamTypes returns parameter-name → leaf-type for every formal
 // parameter on a method/constructor declaration.
-func collectParamTypes(node *sitter.Node, src []byte) map[string]string {
+func collectParamTypes(node ts.Node, src []byte) map[string]string {
 	if node == nil {
 		return nil
 	}
@@ -855,7 +855,7 @@ func collectParamTypes(node *sitter.Node, src []byte) map[string]string {
 // collectLocalVarTypes walks descendants of body and returns
 // local-name → declared leaf type for local_declaration_statement
 // nodes. Implicitly-typed `var` declarations are not bound.
-func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
+func collectLocalVarTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -954,7 +954,7 @@ func isImplicitVarType(declType string) bool {
 // emitted. Target-typed `new(...)` is handled on the explicit-declared-type
 // path (the declared type is concrete there), so it is intentionally NOT
 // inferred here (an implicit `var x = new();` does not type-check in C#).
-func inferImplicitLocalType(declarator *sitter.Node, src []byte) string {
+func inferImplicitLocalType(declarator ts.Node, src []byte) string {
 	if declarator == nil {
 		return ""
 	}
@@ -1013,12 +1013,12 @@ var diServiceTypeArgMethods = map[string]bool{
 // taken from the invocation's function node: either a bare `generic_name`
 // (`GetRequiredService<T>()`) or a `member_access_expression` whose `name` is a
 // `generic_name` (`sp.GetRequiredService<T>()`).
-func diServiceTypeArg(call *sitter.Node, src []byte) string {
+func diServiceTypeArg(call ts.Node, src []byte) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return ""
 	}
-	var gen *sitter.Node
+	var gen ts.Node
 	switch fn.Type() {
 	case "generic_name":
 		gen = fn
@@ -1047,7 +1047,7 @@ func diServiceTypeArg(call *sitter.Node, src []byte) string {
 	if tal == nil {
 		return ""
 	}
-	var args []*sitter.Node
+	var args []ts.Node
 	for i := 0; i < int(tal.NamedChildCount()); i++ {
 		if c := tal.NamedChild(i); c != nil {
 			args = append(args, c)
@@ -1065,7 +1065,7 @@ func diServiceTypeArg(call *sitter.Node, src []byte) string {
 // leafTypeName returns the leaf type identifier of a C# type node,
 // stripping generic parameters, nullable markers, and array suffixes.
 // Returns "" for type nodes the function can't characterise.
-func leafTypeName(typ *sitter.Node, src []byte) string {
+func leafTypeName(typ ts.Node, src []byte) string {
 	if typ == nil {
 		return ""
 	}
@@ -1108,7 +1108,7 @@ func leafTypeName(typ *sitter.Node, src []byte) string {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -1116,8 +1116,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -1135,7 +1135,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 }
 
 // findChildByType returns the first direct child of node with type t.
-func findChildByType(node *sitter.Node, t string) *sitter.Node {
+func findChildByType(node ts.Node, t string) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -1149,7 +1149,7 @@ func findChildByType(node *sitter.Node, t string) *sitter.Node {
 }
 
 // nodeText returns the source text covered by node.
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -1157,7 +1157,7 @@ func nodeText(node *sitter.Node, src []byte) string {
 }
 
 // childFieldText extracts the text of a named child field (e.g. "name").
-func childFieldText(node *sitter.Node, field string, src []byte) string {
+func childFieldText(node ts.Node, field string, src []byte) string {
 	child := node.ChildByFieldName(field)
 	if child == nil {
 		return ""
@@ -1167,7 +1167,7 @@ func childFieldText(node *sitter.Node, field string, src []byte) string {
 
 // buildMethodSignature builds a Python-parity method signature for C#.
 // Collapses multi-line declarations, strips attribute args, keeps visibility.
-func buildMethodSignature(src []byte, node *sitter.Node) string {
+func buildMethodSignature(src []byte, node ts.Node) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	// Strip attribute arguments FIRST to remove braces inside attribute args
 	// like [HttpGet("{id}")] → [HttpGet], before body-brace search.
@@ -1187,7 +1187,7 @@ func buildMethodSignature(src []byte, node *sitter.Node) string {
 
 // buildClassSignature returns a short signature for class/interface declarations.
 // Strips attributes and inheritance to match Python convention: "public class Name".
-func buildClassSignature(node *sitter.Node, src []byte) string {
+func buildClassSignature(node ts.Node, src []byte) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "{"); idx >= 0 {
 		raw = raw[:idx]

--- a/internal/extractors/csharp/csharp_test.go
+++ b/internal/extractors/csharp/csharp_test.go
@@ -6,20 +6,27 @@ import (
 	"strconv"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tscsharp "github.com/smacker/go-tree-sitter/csharp"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/csharp"
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-// parseForTest parses C# source using the real grammar.
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+// parseForTest parses C# source into a ts.Tree via the smacker adapter. Tests
+// stamp the result on FileInput.TSTree (which the migrated C# extractor
+// consumes); the smacker adapter keeps these tests linkable in the default build
+// while exercising the ts façade (B2 #5418).
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tscsharp.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tscsharp.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -61,7 +68,7 @@ namespace SampleApi
 		Path:     "service.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -109,7 +116,7 @@ public class Foo
 		Path:     "foo.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -149,7 +156,7 @@ public interface IRepository
 		Path:     "repo.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -180,7 +187,7 @@ public class Svc
 		Path:     "svc.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -214,7 +221,7 @@ public class Foo {}
 		Path:     "imports.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -245,7 +252,7 @@ func TestCSharpExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.cs",
 		Content:  []byte(""),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -262,7 +269,7 @@ func TestCSharpExtractor_NilTree(t *testing.T) {
 		Path:     "nil.cs",
 		Content:  []byte("public class Foo {}"),
 		Language: "csharp",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -296,7 +303,7 @@ func TestCSharpExtractor_LineNumbers(t *testing.T) {
 		Path:     "lines.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -331,7 +338,7 @@ public class Caller {
 		Path:     "test.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/csharp/exception_flow.go
+++ b/internal/extractors/csharp/exception_flow.go
@@ -29,7 +29,7 @@
 package csharp
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -41,7 +41,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -51,8 +51,8 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 	// enclosingClass is the innermost type name (matching buildOperation, which
 	// prefixes only the immediate parent type). enclosingMethod is the host
 	// SCOPE.Operation Name (`<class>.<method>`), or "" at file scope.
-	var walk func(n *sitter.Node, enclosingClass, enclosingMethod string)
-	walk = func(n *sitter.Node, enclosingClass, enclosingMethod string) {
+	var walk func(n ts.Node, enclosingClass, enclosingMethod string)
+	walk = func(n ts.Node, enclosingClass, enclosingMethod string) {
 		if n == nil {
 			return
 		}
@@ -103,7 +103,7 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 // (`throw;`) or a re-throw of a variable (`throw ex;`) which carries no NEW
 // type. The raw (possibly qualified) type text is returned verbatim;
 // extractor.NormalizeExceptionType collapses it to the bare class name.
-func csharpThrowType(throwNode *sitter.Node, src []byte) string {
+func csharpThrowType(throwNode ts.Node, src []byte) string {
 	creation := findChildByType(throwNode, "object_creation_expression")
 	if creation == nil {
 		return "" // `throw;` or `throw ex;` — no NEW type
@@ -130,7 +130,7 @@ func csharpThrowType(throwNode *sitter.Node, src []byte) string {
 // The `when (...)` filter is a separate catch_filter_clause sibling and is
 // never inspected, so only the declared type is recorded. C# has no `|`
 // multi-catch (that shape parses as an ERROR node and yields no type here).
-func csharpCatchType(catchNode *sitter.Node, src []byte) string {
+func csharpCatchType(catchNode ts.Node, src []byte) string {
 	decl := findChildByType(catchNode, "catch_declaration")
 	if decl == nil {
 		return "" // bare `catch { }` — untyped, honest drop

--- a/internal/extractors/csharp/exception_flow_test.go
+++ b/internal/extractors/csharp/exception_flow_test.go
@@ -20,7 +20,7 @@ func extractCSharpExc(t *testing.T, src string) []types.EntityRecord {
 		Path:     "svc.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/csharp/field_members.go
+++ b/internal/extractors/csharp/field_members.go
@@ -1,7 +1,7 @@
 package csharp
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -27,8 +27,8 @@ import (
 //	Name      = "<Owner>.<member>"
 //	Signature = "<type> <member>"
 func emitFieldMembers(
-	node *sitter.Node,
-	body *sitter.Node,
+	node ts.Node,
+	body ts.Node,
 	src []byte,
 	ownerName, filePath string,
 ) ([]types.EntityRecord, []string) {
@@ -39,7 +39,7 @@ func emitFieldMembers(
 	var fields []types.EntityRecord
 	seen := make(map[string]bool)
 
-	add := func(name, typ string, startNode *sitter.Node) {
+	add := func(name, typ string, startNode ts.Node) {
 		if name == "" || seen[name] {
 			return
 		}
@@ -134,7 +134,7 @@ func emitFieldMembers(
 // caller). C# does not distinguish base class from implemented interfaces in
 // the grammar's base_list, so we return all of them; the in-file filter keeps
 // only types we actually modeled.
-func csBaseTypeNames(node *sitter.Node, src []byte) []string {
+func csBaseTypeNames(node ts.Node, src []byte) []string {
 	if node == nil {
 		return nil
 	}

--- a/internal/extractors/csharp/issue4374_crossns_test.go
+++ b/internal/extractors/csharp/issue4374_crossns_test.go
@@ -27,13 +27,13 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tscsharp "github.com/smacker/go-tree-sitter/csharp"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/csharp"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/resolve"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -45,15 +45,19 @@ func extractCSharpProjectForTest(t *testing.T, files map[string]string) []types.
 	}
 	var merged []types.EntityRecord
 	for rel, src := range files {
-		parser := sitter.NewParser()
-		parser.SetLanguage(tscsharp.GetLanguage())
-		tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+		parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tscsharp.GetLanguage()))
 		if err != nil {
+			t.Fatalf("parser init %s: %v", rel, err)
+		}
+		tree, err := parser.Parse([]byte(src))
+		if err != nil {
+			parser.Close()
 			t.Fatalf("parse %s: %v", rel, err)
 		}
 		ents, err := ext.Extract(context.Background(), extractor.FileInput{
-			Path: rel, Language: "csharp", Content: []byte(src), Tree: tree,
+			Path: rel, Language: "csharp", Content: []byte(src), TSTree: tree,
 		})
+		parser.Close()
 		if err != nil {
 			t.Fatalf("extract %s: %v", rel, err)
 		}

--- a/internal/extractors/csharp/issue4854_field_membership_test.go
+++ b/internal/extractors/csharp/issue4854_field_membership_test.go
@@ -30,7 +30,7 @@ func csExtract(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/csharp/relationships_test.go
+++ b/internal/extractors/csharp/relationships_test.go
@@ -18,7 +18,7 @@ func runCSharp(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/csharp/typesystem_test.go
+++ b/internal/extractors/csharp/typesystem_test.go
@@ -32,7 +32,7 @@ public enum OrderStatus
 		Path:     "OrderStatus.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -62,7 +62,7 @@ func TestCSharpExtractor_EnumSimpleOneLine(t *testing.T) {
 		Path:     "Color.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -88,7 +88,7 @@ func TestCSharpExtractor_RecordDeclarationPositional(t *testing.T) {
 		Path:     "UserDto.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -120,7 +120,7 @@ public record OrderRecord
 		Path:     "OrderRecord.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -154,7 +154,7 @@ public record InvoiceDto(string Number, decimal Amount);
 		Path:     "types.cs",
 		Content:  []byte(src),
 		Language: "csharp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/php/config_consumer.go
+++ b/internal/extractors/php/config_consumer.go
@@ -24,7 +24,7 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -36,7 +36,7 @@ import (
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitConfigConsumerEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -44,8 +44,8 @@ func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entiti
 
 	var reads []extractor.ConfigRead
 
-	var walk func(n *sitter.Node, enclosingClass, enclosing string)
-	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+	var walk func(n ts.Node, enclosingClass, enclosing string)
+	walk = func(n ts.Node, enclosingClass, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -97,7 +97,7 @@ func emitConfigConsumerEdges(root *sitter.Node, file extractor.FileInput, entiti
 //	getenv('X')          → "env_getenv"
 //	env('X')             → "laravel_env"     (Laravel global helper)
 //	config('app.x')      → "laravel_config"  (Laravel global helper)
-func phpFunctionCallConfigKey(call *sitter.Node, src []byte) (string, string) {
+func phpFunctionCallConfigKey(call ts.Node, src []byte) (string, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "name" {
 		return "", ""
@@ -124,10 +124,10 @@ func phpFunctionCallConfigKey(call *sitter.Node, src []byte) (string, string) {
 // $_SERVER['X']) subscript expression with a literal string index, or "".
 //
 // tree-sitter-php shape: (subscript_expression (variable_name) (string ...)).
-func phpSuperglobalEnvKey(n *sitter.Node, src []byte) string {
+func phpSuperglobalEnvKey(n ts.Node, src []byte) string {
 	// The subscripted object is the first child; the index is field "index" in
 	// most grammar revisions, else the last named child.
-	var obj *sitter.Node
+	var obj ts.Node
 	for i := 0; i < int(n.NamedChildCount()); i++ {
 		obj = n.NamedChild(i)
 		break
@@ -155,7 +155,7 @@ func phpSuperglobalEnvKey(n *sitter.Node, src []byte) string {
 // phpFirstStringArg returns the literal content of the first string argument in
 // an `arguments` node, or "" when the first argument is missing or non-literal
 // (dynamic) — honest-partial.
-func phpFirstStringArg(args *sitter.Node, src []byte) string {
+func phpFirstStringArg(args ts.Node, src []byte) string {
 	if args == nil || args.NamedChildCount() == 0 {
 		return ""
 	}
@@ -174,7 +174,7 @@ func phpFirstStringArg(args *sitter.Node, src []byte) string {
 // phpStringLiteral extracts the literal content of a PHP string node, dropping
 // the surrounding quotes. Returns "" for an interpolated (encapsed) string that
 // contains a variable / expression — honest-partial, no fabrication.
-func phpStringLiteral(node *sitter.Node, src []byte) string {
+func phpStringLiteral(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}

--- a/internal/extractors/php/config_consumer_test.go
+++ b/internal/extractors/php/config_consumer_test.go
@@ -22,7 +22,7 @@ func extractPHPRecords(t *testing.T, src string) []types.EntityRecord {
 		Path:     "cfg.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/php/const_valueset.go
+++ b/internal/extractors/php/const_valueset.go
@@ -38,7 +38,7 @@ package php
 // member (its literal in the Name slot) so the member roster stays complete.
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -47,14 +47,14 @@ import (
 // emitConstValueSets walks the CST and appends one SCOPE.Enum value-set node
 // per recognised PHP constant collection (array-const map, class-const group,
 // backed enum, define() map). Called from Extract after the structural walk.
-func emitConstValueSets(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitConstValueSets(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	walkConstValueSets(node, file, "", out)
 }
 
 // walkConstValueSets is a class-aware DFS. parentType is the bare name of the
 // immediately-enclosing class/interface/trait (or "" at file scope) so a group
 // of scalar class constants can be named after its declaring type.
-func walkConstValueSets(node *sitter.Node, file extractor.FileInput, parentType string, out *[]types.EntityRecord) {
+func walkConstValueSets(node ts.Node, file extractor.FileInput, parentType string, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -104,7 +104,7 @@ func walkConstValueSets(node *sitter.Node, file extractor.FileInput, parentType 
 // in a const_declaration whose value is an array literal. A `const` with a
 // scalar value contributes nothing here (scalars are grouped at class scope by
 // buildClassConstGroup). Returns nil for empty arrays (honest-partial).
-func buildArrayConstValueSets(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func buildArrayConstValueSets(node ts.Node, file extractor.FileInput) []types.EntityRecord {
 	var recs []types.EntityRecord
 	for i := range int(node.ChildCount()) {
 		el := node.Child(i)
@@ -135,7 +135,7 @@ func buildArrayConstValueSets(node *sitter.Node, file extractor.FileInput) []typ
 // Array-valued constants are excluded (they get their own node via
 // buildArrayConstValueSets). Returns ok=false when the type has no scalar
 // constants (honest-partial).
-func buildClassConstGroup(typeName string, body *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildClassConstGroup(typeName string, body ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	if typeName == "" || body == nil {
 		return types.EntityRecord{}, false
 	}
@@ -178,7 +178,7 @@ func buildClassConstGroup(typeName string, body *sitter.Node, file extractor.Fil
 // buildEnumValueSet emits a value-set node for a PHP 8.1 enum_declaration,
 // mapping each case name to its backing value (pure enums emit value-less
 // members). Additive to the SCOPE.Schema/enum node from buildEnum.
-func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildEnumValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -211,7 +211,7 @@ func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.Entit
 // buildDefineValueSet emits a value-set node for a `define('NAME', [...])`
 // call whose second argument is an array literal. Non-array define() calls
 // and dynamic names emit nothing (honest-partial).
-func buildDefineValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildDefineValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	fn := node.ChildByFieldName("function")
 	if fn == nil {
 		fn = firstChildOfTypePHP(node, "name")
@@ -228,7 +228,7 @@ func buildDefineValueSet(node *sitter.Node, file extractor.FileInput) (types.Ent
 	}
 
 	var name string
-	var arr *sitter.Node
+	var arr ts.Node
 	for i := range int(args.ChildCount()) {
 		a := args.Child(i)
 		if a == nil || a.Type() != "argument" {
@@ -263,7 +263,7 @@ func buildDefineValueSet(node *sitter.Node, file extractor.FileInput) (types.Ent
 // (bare value, no `=>`) becomes a value-less member whose name is the literal
 // (so the roster stays complete for a list of constants). Non-literal values
 // record their source expression text rather than being dropped.
-func arrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
+func arrayMembers(arr ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	for i := range int(arr.ChildCount()) {
 		el := arr.Child(i)
@@ -292,8 +292,8 @@ func arrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
 // value nodes. When the element has a `=>` token the named child before it is
 // the key and the one after it the value; otherwise it is a list element and
 // the (single) named child is the value (key == nil).
-func arrayElementKeyValue(el *sitter.Node) (key, val *sitter.Node) {
-	var named []*sitter.Node
+func arrayElementKeyValue(el ts.Node) (key, val ts.Node) {
+	var named []ts.Node
 	hasArrow := false
 	for i := range int(el.ChildCount()) {
 		ch := el.Child(i)
@@ -319,9 +319,9 @@ func arrayElementKeyValue(el *sitter.Node) (key, val *sitter.Node) {
 
 // constElementValue returns the statically-known literal of a const_element's
 // value, or the raw expression text for a non-literal value (honest-partial).
-func constElementValue(el *sitter.Node, src []byte) string {
+func constElementValue(el ts.Node, src []byte) string {
 	// The value node is the last named child after the `=` token.
-	var val *sitter.Node
+	var val ts.Node
 	seenEq := false
 	for i := range int(el.ChildCount()) {
 		ch := el.Child(i)
@@ -346,7 +346,7 @@ func constElementValue(el *sitter.Node, src []byte) string {
 // literals are unquoted; integer / float / boolean / name literals are
 // returned verbatim. Any other (computed / dynamic) expression returns its
 // source text so the value is recorded rather than dropped (honest-partial).
-func literalValueNode(n *sitter.Node, src []byte) string {
+func literalValueNode(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -362,7 +362,7 @@ func literalValueNode(n *sitter.Node, src []byte) string {
 
 // --- small node helpers (local to this file) ---------------------------------
 
-func firstChildOfTypePHP(n *sitter.Node, typ string) *sitter.Node {
+func firstChildOfTypePHP(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -375,7 +375,7 @@ func firstChildOfTypePHP(n *sitter.Node, typ string) *sitter.Node {
 	return nil
 }
 
-func firstNamedChild(n *sitter.Node) *sitter.Node {
+func firstNamedChild(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -391,14 +391,14 @@ func firstNamedChild(n *sitter.Node) *sitter.Node {
 // firstNamedChildText returns the text of the first named child whose type is
 // excludeAfter-agnostic match by type, used as a fallback when the "name"
 // field is unlabelled in the grammar revision.
-func firstNamedChildText(n *sitter.Node, typ string, src []byte) string {
+func firstNamedChildText(n ts.Node, typ string, src []byte) string {
 	if c := firstChildOfTypePHP(n, typ); c != nil {
 		return nodeTextPHP(c, src)
 	}
 	return ""
 }
 
-func nodeTextPHP(n *sitter.Node, src []byte) string {
+func nodeTextPHP(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/php/const_valueset_test.go
+++ b/internal/extractors/php/const_valueset_test.go
@@ -23,7 +23,7 @@ func extractPHPForConst(t *testing.T, path, src string) []types.EntityRecord {
 		t.Fatal("php extractor not registered")
 	}
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: path, Content: []byte(src), Language: "php", Tree: tree,
+		Path: path, Content: []byte(src), Language: "php", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/php/eloquent.go
+++ b/internal/extractors/php/eloquent.go
@@ -24,7 +24,7 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -65,7 +65,7 @@ var laravelControllerBaseClasses = map[string]struct{}{
 // grammar does not expose the base class as a named field — it sits as
 // a `base_clause` child whose first meaningful token is the parent
 // class name.
-func classExtends(node *sitter.Node, src []byte) string {
+func classExtends(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -106,7 +106,7 @@ func classExtends(node *sitter.Node, src []byte) string {
 //
 // The function is purely additive: if no Laravel signal is detected,
 // the record is left untouched.
-func tagEloquent(rec *types.EntityRecord, node *sitter.Node, src []byte, path string) {
+func tagEloquent(rec *types.EntityRecord, node ts.Node, src []byte, path string) {
 	if rec == nil {
 		return
 	}

--- a/internal/extractors/php/eloquent_test.go
+++ b/internal/extractors/php/eloquent_test.go
@@ -20,7 +20,7 @@ func extractPHPFile(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/php/exception_flow.go
+++ b/internal/extractors/php/exception_flow.go
@@ -40,7 +40,7 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -66,7 +66,7 @@ func phpExceptionLeaf(raw string) string {
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -78,8 +78,8 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 	// walk(), which dots only the immediate parent). enclosing is the host
 	// SCOPE.Operation Name (`<class>.<method>` for methods, bare leaf for free
 	// functions), or "" at file scope.
-	var walk func(n *sitter.Node, enclosingClass, enclosing string)
-	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+	var walk func(n ts.Node, enclosingClass, enclosing string)
+	walk = func(n ts.Node, enclosingClass, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -138,7 +138,7 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 // when the thrown value is `new X(...)`. The type leaf is the first
 // `name` / `qualified_name` child after the `new` keyword (the `type` field is
 // not consistently set across grammar revisions).
-func phpThrowType(throwNode *sitter.Node, src []byte) string {
+func phpThrowType(throwNode ts.Node, src []byte) string {
 	creation := findFirstChildOfType(throwNode, "object_creation_expression")
 	if creation == nil {
 		return "" // `throw $e;` or `throw mk();` — no NEW type
@@ -161,7 +161,7 @@ func phpThrowType(throwNode *sitter.Node, src []byte) string {
 //
 // PHP has no untyped `catch { }` (the type_list is mandatory), so this never
 // needs to drop a bare catch — every clause yields at least one type.
-func phpCatchTypes(catchNode *sitter.Node, src []byte) []string {
+func phpCatchTypes(catchNode ts.Node, src []byte) []string {
 	typeList := catchNode.ChildByFieldName("type")
 	if typeList == nil {
 		typeList = findFirstChildOfType(catchNode, "type_list")

--- a/internal/extractors/php/exception_flow_test.go
+++ b/internal/extractors/php/exception_flow_test.go
@@ -21,7 +21,7 @@ func extractPHPForExc(t *testing.T, src string) []types.EntityRecord {
 		Path:     "svc.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/php/field_members.go
+++ b/internal/extractors/php/field_members.go
@@ -3,7 +3,7 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -29,8 +29,8 @@ import (
 //	Name      = "<Owner>.<member>"
 //	Signature = "<type> $<member>"
 func emitPhpFieldMembers(
-	node *sitter.Node,
-	body *sitter.Node,
+	node ts.Node,
+	body ts.Node,
 	src []byte,
 	ownerName, filePath string,
 ) ([]types.EntityRecord, string) {
@@ -41,7 +41,7 @@ func emitPhpFieldMembers(
 	var fields []types.EntityRecord
 	seen := make(map[string]bool)
 
-	add := func(name, typ string, at *sitter.Node) {
+	add := func(name, typ string, at ts.Node) {
 		name = strings.TrimPrefix(name, "$")
 		if name == "" || seen[name] {
 			return
@@ -122,7 +122,7 @@ func emitPhpFieldMembers(
 
 // phpVariableName returns the bare identifier of a variable_name node
 // (`$name` → "name").
-func phpVariableName(vn *sitter.Node, src []byte) string {
+func phpVariableName(vn ts.Node, src []byte) string {
 	if id := findFirstChildOfType(vn, "name"); id != nil {
 		return string(src[id.StartByte():id.EndByte()])
 	}
@@ -132,7 +132,7 @@ func phpVariableName(vn *sitter.Node, src []byte) string {
 // phpDeclaredType returns the textual type annotation that precedes the
 // property_element / variable_name in a property_declaration or
 // property_promotion_parameter. Returns "" for untyped members.
-func phpDeclaredType(n *sitter.Node, src []byte) string {
+func phpDeclaredType(n ts.Node, src []byte) string {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		switch ch.Type() {
@@ -148,7 +148,7 @@ func phpDeclaredType(n *sitter.Node, src []byte) string {
 // declaration's base_clause (`class A extends B` → "B"), or "" for none.
 // Interfaces appear under class_interface_clause and are intentionally
 // excluded.
-func phpBaseClassName(node *sitter.Node, src []byte) string {
+func phpBaseClassName(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}

--- a/internal/extractors/php/issue4686_test_scope_test.go
+++ b/internal/extractors/php/issue4686_test_scope_test.go
@@ -23,7 +23,7 @@ func extractPHP4686(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/php/issue4854_field_membership_test.go
+++ b/internal/extractors/php/issue4854_field_membership_test.go
@@ -30,7 +30,7 @@ func phpExtract(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -37,7 +37,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -55,7 +55,7 @@ func (e *Extractor) Language() string { return "php" }
 
 // Extract walks the tree-sitter CST and returns entity records for the PHP file.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -65,7 +65,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	walk(root, file, "", &entities)
 	// Issue #3641 (epic #3625) — config-key consumption edges
 	// (getenv / $_ENV / Laravel env() / config()) → shared SCOPE.Config nodes.
@@ -111,7 +111,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // file scope) — methods declared inside a class body are emitted with
 // Name="<Class>.<method>" so two classes in the same file declaring a
 // same-named method produce distinct entity IDs (issue #145).
-func walk(node *sitter.Node, file extractor.FileInput, parentClass string, out *[]types.EntityRecord) {
+func walk(node ts.Node, file extractor.FileInput, parentClass string, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -301,7 +301,7 @@ func walk(node *sitter.Node, file extractor.FileInput, parentClass string, out *
 // Eloquent / Laravel framework labelling is applied via tagEloquent:
 // models, migrations and controllers get framework="laravel" plus a kind
 // discriminator in Properties.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -333,7 +333,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 //	                       (e.g. "Active='active',Inactive='inactive'").
 //	                       Omitted for pure enums (no backing type).
 //	"enum_backing_type"  → "string" or "int" when a backing type is declared.
-func buildEnum(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildEnum(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -397,7 +397,7 @@ func buildEnum(node *sitter.Node, file extractor.FileInput) (types.EntityRecord,
 // phpEnumBackingType returns the backing type text ("string"/"int") of a
 // backed PHP 8.1 enum, or "" for pure enums. Tree-sitter PHP grammar
 // places the backing type as a child node between `:` and the body.
-func phpEnumBackingType(node *sitter.Node, src []byte) string {
+func phpEnumBackingType(node ts.Node, src []byte) string {
 	// Scan direct children for a named_type or primitive_type child that
 	// follows the colon token. The colon itself appears as a ":" leaf.
 	seenColon := false
@@ -425,7 +425,7 @@ func phpEnumBackingType(node *sitter.Node, src []byte) string {
 // trait/enum node, trying the named "body" field first and falling back to
 // scanning for a declaration_list or enum_declaration_list child. This is
 // needed because older grammar revisions may not label the body field.
-func phpDeclBody(node *sitter.Node) *sitter.Node {
+func phpDeclBody(node ts.Node) ts.Node {
 	if body := node.ChildByFieldName("body"); body != nil {
 		return body
 	}
@@ -440,7 +440,7 @@ func phpDeclBody(node *sitter.Node) *sitter.Node {
 }
 
 // buildOperation creates an Operation entity for method/function declarations.
-func buildOperation(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildOperation(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -460,7 +460,7 @@ func buildOperation(node *sitter.Node, file extractor.FileInput, subtype string)
 }
 
 // buildNamespace emits a Component representing a PHP namespace.
-func buildNamespace(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildNamespace(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		// Fallback: extract text after "namespace " keyword
@@ -508,7 +508,7 @@ func buildNamespace(node *sitter.Node, file extractor.FileInput) (types.EntityRe
 // Aliases are intentionally stripped: the synth allowlist matches on the
 // root namespace segment (Symfony, Doctrine, Twig, ...), so emitting the
 // canonical FQN gives the synth `\`-branch a clean root to classify.
-func buildUseImports(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func buildUseImports(node ts.Node, file extractor.FileInput) []types.EntityRecord {
 	if node == nil {
 		return nil
 	}
@@ -547,7 +547,7 @@ func buildUseImports(node *sitter.Node, file extractor.FileInput) []types.Entity
 
 // buildUseGroup expands a `namespace_use_group` node by joining each
 // clause's name onto the shared prefix. Issue #102.
-func buildUseGroup(group *sitter.Node, file extractor.FileInput, prefix string) []types.EntityRecord {
+func buildUseGroup(group ts.Node, file extractor.FileInput, prefix string) []types.EntityRecord {
 	if group == nil || prefix == "" {
 		return nil
 	}
@@ -573,7 +573,7 @@ func buildUseGroup(group *sitter.Node, file extractor.FileInput, prefix string) 
 // useClauseFQN returns the qualified-name text of a namespace_use_clause,
 // stripping any trailing `as Alias` segment. Returns "" when the clause
 // has no qualified_name child (defensive — malformed input).
-func useClauseFQN(clause *sitter.Node, src []byte) string {
+func useClauseFQN(clause ts.Node, src []byte) string {
 	for i := range int(clause.ChildCount()) {
 		ch := clause.Child(i)
 		// `qualified_name` / `name` cover plain `use` clauses;
@@ -662,7 +662,7 @@ func useImportRecord(fqn, srcPath string) types.EntityRecord {
 }
 
 // childFieldText extracts the text of a named child field.
-func childFieldText(node *sitter.Node, field string, src []byte) string {
+func childFieldText(node ts.Node, field string, src []byte) string {
 	child := node.ChildByFieldName(field)
 	if child == nil {
 		return ""
@@ -674,7 +674,7 @@ func childFieldText(node *sitter.Node, field string, src []byte) string {
 // Python strips visibility modifiers and return types, keeping only:
 //
 //	function name(params)
-func buildMethodSignature(node *sitter.Node, src []byte) string {
+func buildMethodSignature(node ts.Node, src []byte) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "\n"); idx >= 0 {
 		raw = raw[:idx]
@@ -702,7 +702,7 @@ func buildMethodSignature(node *sitter.Node, src []byte) string {
 }
 
 // buildClassSignature constructs a readable signature up to the class body.
-func buildClassSignature(node *sitter.Node, src []byte, name string) string {
+func buildClassSignature(node ts.Node, src []byte, name string) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "{"); idx >= 0 {
 		return strings.TrimSpace(raw[:idx])
@@ -716,7 +716,7 @@ func buildClassSignature(node *sitter.Node, src []byte, name string) string {
 // findFirstChildOfType returns the first direct child whose Type() == kind.
 // Used as a fallback when ChildByFieldName("body") fails on older grammar
 // revisions that didn't label the body field.
-func findFirstChildOfType(n *sitter.Node, kind string) *sitter.Node {
+func findFirstChildOfType(n ts.Node, kind string) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -730,7 +730,7 @@ func findFirstChildOfType(n *sitter.Node, kind string) *sitter.Node {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -738,8 +738,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -779,7 +779,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 // FromID is left empty so buildDocument substitutes the caller's entity ID
 // at emit time. Self-recursion (target leaf == callerName, dotted match
 // against parentClass + "." + callerName included) is dropped.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName, parentClass string) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName, parentClass string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -834,7 +834,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, parentC
 // phpCallTarget resolves the callee target from one of the four PHP
 // invocation nodes. Returns (target, receiverType). receiverType is "" when
 // no static type for the receiver is determinable. Issue #376.
-func phpCallTarget(call *sitter.Node, src []byte, parentClass string, locals map[string]string) (string, string) {
+func phpCallTarget(call ts.Node, src []byte, parentClass string, locals map[string]string) (string, string) {
 	switch call.Type() {
 	case "function_call_expression":
 		fn := call.ChildByFieldName("function")
@@ -918,7 +918,7 @@ func phpCallTarget(call *sitter.Node, src []byte, parentClass string, locals map
 		// this as a constructor reference so framework classes
 		// (Symfony Request, Doctrine EntityManager, …) appear as
 		// outgoing edges from the calling method.
-		var typeNode *sitter.Node
+		var typeNode ts.Node
 		// `type`/`name` fields are not consistently set across grammar
 		// revisions; the type is the first `name` or `qualified_name`
 		// child after the `new` keyword.
@@ -961,7 +961,7 @@ var docblockVarRE = regexp.MustCompile(`@var\s+\??([A-Za-z_\\][A-Za-z0-9_\\]*)\s
 //
 // Returned keys carry the leading `$` so callers can match them directly
 // against `variable_name` token text.
-func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
+func collectLocalVarTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -980,7 +980,7 @@ func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
 			continue
 		}
 		// Type leaf — first name/qualified_name child of the new-expr.
-		var typeNode *sitter.Node
+		var typeNode ts.Node
 		for i := range int(right.ChildCount()) {
 			ch := right.Child(i)
 			if ch.Type() == "name" || ch.Type() == "qualified_name" {

--- a/internal/extractors/php/php_test.go
+++ b/internal/extractors/php/php_test.go
@@ -5,19 +5,26 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsphp "github.com/smacker/go-tree-sitter/php"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/php"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-// parseForTest parses PHP source using the real grammar.
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+// parseForTest parses PHP source into a ts.Tree via the smacker adapter. Tests
+// stamp the result on FileInput.TSTree (which the migrated PHP extractor
+// consumes); the smacker adapter keeps these tests linkable in the default build
+// while exercising the ts façade (B2 #5418).
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsphp.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsphp.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -55,7 +62,7 @@ function handleRequest(string $method): void {}
 		Path:     "controller.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -102,7 +109,7 @@ class Foo {
 		Path:     "foo.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -141,7 +148,7 @@ interface IRepository {
 		Path:     "repo.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -171,7 +178,7 @@ class Svc {
 		Path:     "svc.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -204,7 +211,7 @@ function handleRequest(string $method): void {
 		Path:     "func.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -229,7 +236,7 @@ func TestPHPExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.php",
 		Content:  []byte(""),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -246,7 +253,7 @@ func TestPHPExtractor_NilTree(t *testing.T) {
 		Path:     "nil.php",
 		Content:  []byte("<?php class Foo {}"),
 		Language: "php",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -272,7 +279,7 @@ class BadClass {
 		Path:     "malformed.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on malformed file: %v", err)
@@ -320,7 +327,7 @@ class PostType extends AbstractType {}
 		Path:     "src/Form/PostType.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -377,7 +384,7 @@ class PostType extends AbstractType {}
 		Path:     "src/Form/PostType.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -442,7 +449,7 @@ class Alpha {
 		Path:     "lines.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -481,7 +488,7 @@ class OrderRepo {
 		Path:     "repos.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -566,7 +573,7 @@ enum Direction {
 		Path:     "direction.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -617,7 +624,7 @@ enum Status: string {
 		Path:     "status.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -672,7 +679,7 @@ enum Priority: int {
 		Path:     "priority.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -721,7 +728,7 @@ interface Repository {
 		Path:     "repository.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -800,7 +807,7 @@ trait Timestampable {
 		Path:     "timestampable.php",
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/php/relationships_test.go
+++ b/internal/extractors/php/relationships_test.go
@@ -19,7 +19,7 @@ func runPHP(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "php",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/php/template_render.go
+++ b/internal/extractors/php/template_render.go
@@ -25,7 +25,7 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -37,7 +37,7 @@ import (
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitTemplateRenderEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -45,8 +45,8 @@ func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entiti
 
 	var edges []extractor.TemplateEdge
 
-	var walk func(n *sitter.Node, enclosingClass, enclosing string)
-	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+	var walk func(n ts.Node, enclosingClass, enclosing string)
+	walk = func(n ts.Node, enclosingClass, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -94,7 +94,7 @@ func emitTemplateRenderEdges(root *sitter.Node, file extractor.FileInput, entiti
 // phpViewCallTemplate returns the literal Blade view name + detector label when
 // the call is the Laravel `view('name')` global helper with a literal first
 // string argument, or ("","") otherwise (including dynamic names → drop).
-func phpViewCallTemplate(call *sitter.Node, src []byte) (string, string) {
+func phpViewCallTemplate(call ts.Node, src []byte) (string, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "name" {
 		return "", ""
@@ -112,7 +112,7 @@ func phpViewCallTemplate(call *sitter.Node, src []byte) (string, string) {
 // phpViewMakeTemplate returns the literal Blade view name + detector label when
 // the call is the Laravel `View::make('name')` facade with a literal first
 // string argument, or ("","") otherwise.
-func phpViewMakeTemplate(call *sitter.Node, src []byte) (string, string) {
+func phpViewMakeTemplate(call ts.Node, src []byte) (string, string) {
 	nameNode := call.ChildByFieldName("name")
 	if nameNode == nil || nameNode.Type() != "name" {
 		return "", ""

--- a/internal/extractors/php/tests.go
+++ b/internal/extractors/php/tests.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -43,7 +43,7 @@ import (
 // path — this owner is purely for closure-body CALLS.
 //
 // No-op for non-test files and for spec files whose closures resolve no CALLS.
-func emitPHPTestScopeOwner(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitPHPTestScopeOwner(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if root == nil || !isPHPTestFile(file.Path) {
 		return
 	}
@@ -112,13 +112,13 @@ var pestBlockMethods = map[string]bool{
 // closure's body so inner it() closures are mined too. We do NOT descend into a
 // `method_declaration` / `function_definition` — walk() already owns their CALLS
 // edges (no double-emit).
-func collectPestClosureBodies(root *sitter.Node, src []byte) []*sitter.Node {
-	var out []*sitter.Node
+func collectPestClosureBodies(root ts.Node, src []byte) []ts.Node {
+	var out []ts.Node
 	walkPestBlocks(root, src, &out)
 	return out
 }
 
-func walkPestBlocks(n *sitter.Node, src []byte, out *[]*sitter.Node) {
+func walkPestBlocks(n ts.Node, src []byte, out *[]ts.Node) {
 	if n == nil {
 		return
 	}
@@ -147,7 +147,7 @@ func walkPestBlocks(n *sitter.Node, src []byte, out *[]*sitter.Node) {
 // isPestDSLCall reports whether a function_call_expression invokes a bare Pest
 // DSL function (it/test/describe/beforeEach/...). The callee must be a plain
 // `name` leaf — a namespaced or variable callee is not a Pest global.
-func isPestDSLCall(call *sitter.Node, src []byte) bool {
+func isPestDSLCall(call ts.Node, src []byte) bool {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "name" {
 		return false
@@ -162,7 +162,7 @@ func isPestDSLCall(call *sitter.Node, src []byte) bool {
 // callback, or a higher-order chain). The closure is the
 // anonymous_function_creation_expression / arrow_function inside the call's
 // `arguments`.
-func pestClosureBody(call *sitter.Node) *sitter.Node {
+func pestClosureBody(call ts.Node) ts.Node {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return nil
@@ -170,7 +170,7 @@ func pestClosureBody(call *sitter.Node) *sitter.Node {
 	for i := 0; i < int(args.NamedChildCount()); i++ {
 		arg := args.NamedChild(i)
 		// `arguments` wraps each value in an `argument` node.
-		var val *sitter.Node = arg
+		var val ts.Node = arg
 		if arg.Type() == "argument" && arg.NamedChildCount() > 0 {
 			val = arg.NamedChild(0)
 		}

--- a/internal/extractors/php/translation_key.go
+++ b/internal/extractors/php/translation_key.go
@@ -26,7 +26,7 @@ package php
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -43,7 +43,7 @@ var laravelTransHelpers = map[string]bool{
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitTranslationKeyEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -51,8 +51,8 @@ func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entiti
 
 	var uses []extractor.TranslationUse
 
-	var walk func(n *sitter.Node, enclosingClass, enclosing string)
-	walk = func(n *sitter.Node, enclosingClass, enclosing string) {
+	var walk func(n ts.Node, enclosingClass, enclosing string)
+	walk = func(n ts.Node, enclosingClass, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -96,7 +96,7 @@ func emitTranslationKeyEdges(root *sitter.Node, file extractor.FileInput, entiti
 // phpTranslationCall returns the literal key when the call is a recognised
 // Laravel translation helper (`__`, `trans`, `trans_choice`) with a static
 // first string argument, or ("", false).
-func phpTranslationCall(call *sitter.Node, src []byte) (string, bool) {
+func phpTranslationCall(call ts.Node, src []byte) (string, bool) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "name" {
 		return "", false

--- a/internal/extractors/ruby/config_consumer.go
+++ b/internal/extractors/ruby/config_consumer.go
@@ -23,7 +23,7 @@ package ruby
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -35,15 +35,15 @@ import (
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitConfigConsumerEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitConfigConsumerEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
 
 	var reads []extractor.ConfigRead
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -80,7 +80,7 @@ func emitConfigConsumerEdges(root *sitter.Node, src []byte, entities *[]types.En
 // with a literal string index, or "" otherwise.
 //
 // tree-sitter-ruby shape: (element_reference object: (constant) (string ...)).
-func rubyEnvElementKey(n *sitter.Node, src []byte) string {
+func rubyEnvElementKey(n ts.Node, src []byte) string {
 	obj := n.ChildByFieldName("object")
 	if obj == nil || strings.TrimSpace(rubyNodeText(obj, src)) != "ENV" {
 		return ""
@@ -102,7 +102,7 @@ func rubyEnvElementKey(n *sitter.Node, src []byte) string {
 
 // rubyEnvFetchKey returns the config key for an ENV.fetch('KEY' [, default])
 // call with a literal first string argument, or "" otherwise.
-func rubyEnvFetchKey(n *sitter.Node, src []byte) string {
+func rubyEnvFetchKey(n ts.Node, src []byte) string {
 	recv := n.ChildByFieldName("receiver")
 	method := n.ChildByFieldName("method")
 	if recv == nil || method == nil {
@@ -128,7 +128,7 @@ func rubyEnvFetchKey(n *sitter.Node, src []byte) string {
 // rubyStringContent extracts the literal content of a tree-sitter-ruby string
 // node, dropping the surrounding quotes. Returns "" for an interpolated string
 // (one carrying an `interpolation` child) — honest-partial, no fabrication.
-func rubyStringContent(strNode *sitter.Node, src []byte) string {
+func rubyStringContent(strNode ts.Node, src []byte) string {
 	for i := 0; i < int(strNode.NamedChildCount()); i++ {
 		if strNode.NamedChild(i).Type() == "interpolation" {
 			return "" // dynamic content → skip
@@ -146,7 +146,7 @@ func rubyStringContent(strNode *sitter.Node, src []byte) string {
 }
 
 // rubyNodeText returns the raw source text spanned by node.
-func rubyNodeText(node *sitter.Node, src []byte) string {
+func rubyNodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}

--- a/internal/extractors/ruby/config_consumer_test.go
+++ b/internal/extractors/ruby/config_consumer_test.go
@@ -22,7 +22,7 @@ func extractRubyRecords(t *testing.T, src string) []types.EntityRecord {
 		Path:     "cfg.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/ruby/const_valueset.go
+++ b/internal/extractors/ruby/const_valueset.go
@@ -35,7 +35,7 @@ package ruby
 // rather than being dropped, so the key set stays complete for a parity-audit.
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -48,7 +48,7 @@ import (
 //
 // kind_hint is "ruby_const_hash" for hash collections and "ruby_const_array"
 // for array collections, so a downstream consumer can tell the member shape.
-func buildConstCollectionValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildConstCollectionValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	if node == nil || node.Type() != "assignment" {
 		return types.EntityRecord{}, false
 	}
@@ -98,7 +98,7 @@ func buildConstCollectionValueSet(node *sitter.Node, file extractor.FileInput) (
 // buildConstCollectionValueSet, so it is excluded here).
 //
 // kind_hint is "ruby_const_module".
-func buildModuleConstGroupValueSet(scopeName string, body *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildModuleConstGroupValueSet(scopeName string, body ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	if body == nil || scopeName == "" {
 		return types.EntityRecord{}, false
 	}
@@ -142,7 +142,7 @@ func buildModuleConstGroupValueSet(scopeName string, body *sitter.Node, file ext
 // `{ a: 1 }.freeze` tree-sitter wraps the hash in a `call` whose receiver is
 // the hash; this returns that hash. A bare `{ a: 1 }` / `%w[..]` returns the
 // node unchanged.
-func unwrapFreeze(n *sitter.Node) *sitter.Node {
+func unwrapFreeze(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -165,7 +165,7 @@ func unwrapFreeze(n *sitter.Node) *sitter.Node {
 
 // isCollectionNode reports whether n is one of the literal collection node
 // types this extractor materialises into a value-set.
-func isCollectionNode(n *sitter.Node) bool {
+func isCollectionNode(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -180,7 +180,7 @@ func isCollectionNode(n *sitter.Node) bool {
 // (`core_admin:`) and string/rocket keys (`'free' => 10`) are both handled.
 // A non-literal value records its source expression text (#4427) rather than
 // being dropped.
-func constHashMembers(hash *sitter.Node, src []byte) []extractor.EnumMember {
+func constHashMembers(hash ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	for i := 0; i < int(hash.ChildCount()); i++ {
 		pair := hash.Child(i)
@@ -225,7 +225,7 @@ func constHashMembers(hash *sitter.Node, src []byte) []extractor.EnumMember {
 // (`%w[...]`) / `symbol_array` (`%i[...]`) node. Each element's literal becomes
 // BOTH the member key and value so the value-set carries the literal set; a
 // non-literal element records its expression text.
-func constArrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
+func constArrayMembers(arr ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	for i := 0; i < int(arr.ChildCount()); i++ {
 		el := arr.Child(i)
@@ -257,7 +257,7 @@ func constArrayMembers(arr *sitter.Node, src []byte) []extractor.EnumMember {
 // non-literal node (a method call, an interpolation) — the trimmed source
 // EXPRESSION TEXT (#4427: non-literal values are recorded as expression text,
 // not dropped).
-func constScalarValue(n *sitter.Node, src []byte) string {
+func constScalarValue(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/ruby/enum_valueset.go
+++ b/internal/extractors/ruby/enum_valueset.go
@@ -18,7 +18,7 @@ package ruby
 // skipped — only literal hash/array forms produce a node.
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -27,7 +27,7 @@ import (
 // buildRailsEnumValueSet inspects a `call` node and, when it is a Rails
 // `enum <name>: {...}` / `enum <name>: [...]` / `enum :<name>, {...}`
 // declaration, returns the SCOPE.Enum value-set node for it.
-func buildRailsEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildRailsEnumValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	if node == nil || node.Type() != "call" {
 		return types.EntityRecord{}, false
 	}
@@ -57,7 +57,7 @@ func buildRailsEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.
 // railsEnumNameAndValues extracts the enum attribute name and the node holding
 // its members from a `enum` call's argument_list. Handles both the
 // `status: {...}` pair form and the `:status, {...}` positional form.
-func railsEnumNameAndValues(args *sitter.Node, src []byte) (string, *sitter.Node) {
+func railsEnumNameAndValues(args ts.Node, src []byte) (string, ts.Node) {
 	// Pair form: `enum status: { ... }` → a single `pair` argument.
 	if pair := firstChildOfType(args, "pair"); pair != nil {
 		key := pairKeyName(pair, src)
@@ -68,7 +68,7 @@ func railsEnumNameAndValues(args *sitter.Node, src []byte) (string, *sitter.Node
 	}
 	// Positional form: `enum :status, { ... }` → simple_symbol then hash/array.
 	var name string
-	var values *sitter.Node
+	var values ts.Node
 	for i := 0; i < int(args.ChildCount()); i++ {
 		ch := args.Child(i)
 		if ch == nil || !ch.IsNamed() {
@@ -93,7 +93,7 @@ func railsEnumNameAndValues(args *sitter.Node, src []byte) (string, *sitter.Node
 
 // railsEnumMembers builds EnumMembers from a hash (`{ active: 0 }`) or array
 // (`[:active, :archived]`) value node.
-func railsEnumMembers(val *sitter.Node, src []byte) []extractor.EnumMember {
+func railsEnumMembers(val ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	switch val.Type() {
 	case "hash":
@@ -131,7 +131,7 @@ func railsEnumMembers(val *sitter.Node, src []byte) []extractor.EnumMember {
 
 // railsLiteral returns the statically-known literal value of a hash value node,
 // or "" for non-literal values (honest-partial).
-func railsLiteral(n *sitter.Node, src []byte) string {
+func railsLiteral(n ts.Node, src []byte) string {
 	switch n.Type() {
 	case "integer", "float":
 		return nodeText(n, src)
@@ -145,7 +145,7 @@ func railsLiteral(n *sitter.Node, src []byte) string {
 
 // --- small node helpers (local to this file) ---------------------------------
 
-func rubyCallIsNamed(call *sitter.Node, src []byte, name string) bool {
+func rubyCallIsNamed(call ts.Node, src []byte, name string) bool {
 	if m := call.ChildByFieldName("method"); m != nil {
 		return nodeText(m, src) == name
 	}
@@ -156,7 +156,7 @@ func rubyCallIsNamed(call *sitter.Node, src []byte, name string) bool {
 	return false
 }
 
-func pairKeyName(pair *sitter.Node, src []byte) string {
+func pairKeyName(pair ts.Node, src []byte) string {
 	if k := pair.ChildByFieldName("key"); k != nil {
 		return trimLeadingColon(nodeText(k, src))
 	}
@@ -169,7 +169,7 @@ func pairKeyName(pair *sitter.Node, src []byte) string {
 	return ""
 }
 
-func pairValueNode(pair *sitter.Node) *sitter.Node {
+func pairValueNode(pair ts.Node) ts.Node {
 	if v := pair.ChildByFieldName("value"); v != nil {
 		return v
 	}
@@ -183,7 +183,7 @@ func pairValueNode(pair *sitter.Node) *sitter.Node {
 	return nil
 }
 
-func nodeIsHashOrArray(n *sitter.Node) bool {
+func nodeIsHashOrArray(n ts.Node) bool {
 	return n != nil && (n.Type() == "hash" || n.Type() == "array")
 }
 
@@ -194,7 +194,7 @@ func trimLeadingColon(s string) string {
 	return s
 }
 
-func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func firstChildOfType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -207,7 +207,7 @@ func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
 	return nil
 }
 
-func nodeText(n *sitter.Node, src []byte) string {
+func nodeText(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/ruby/enum_valueset_test.go
+++ b/internal/extractors/ruby/enum_valueset_test.go
@@ -19,7 +19,7 @@ func extractRubyForEnum(t *testing.T, path, src string) []types.EntityRecord {
 		t.Fatal("ruby extractor not registered")
 	}
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: path, Content: []byte(src), Language: "ruby", Tree: tree,
+		Path: path, Content: []byte(src), Language: "ruby", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/ruby/exception_flow.go
+++ b/internal/extractors/ruby/exception_flow.go
@@ -33,7 +33,7 @@
 package ruby
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -47,7 +47,7 @@ import (
 // *entities in place. Safe with nil / empty input. raise / rescue / rescue_from
 // outside any method (class or module scope, e.g. a controller-level
 // `rescue_from`) attach to the file entity via EmitExceptionEdges's fallback.
-func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -58,8 +58,8 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 	// rescue / rescue_from is attributed to the right SCOPE.Operation (matched by
 	// Name inside EmitExceptionEdges). The method NAME mirrors operation naming in
 	// ruby.go (buildMethod uses the bare `name` field), so attribution is exact.
-	var walk func(n *sitter.Node, current string)
-	walk = func(n *sitter.Node, current string) {
+	var walk func(n ts.Node, current string)
+	walk = func(n ts.Node, current string) {
 		if n == nil {
 			return
 		}
@@ -113,7 +113,7 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 // Returns "" for `raise "msg"` (string → implicit RuntimeError), bare `raise`
 // (re-raise — which the grammar exposes as a lone `identifier`, never a call
 // with arguments, so it never reaches here), and `raise var` / computed types.
-func rubyRaiseType(raiseCall *sitter.Node, src []byte) string {
+func rubyRaiseType(raiseCall ts.Node, src []byte) string {
 	args := raiseCall.ChildByFieldName("arguments")
 	if args == nil {
 		return "" // bare `raise` re-raise (no arguments) — no static type
@@ -143,7 +143,7 @@ func rubyRaiseType(raiseCall *sitter.Node, src []byte) string {
 //
 // Untyped catch-alls (bare `rescue`) carry no static class → dropped, matching
 // the flagship catch-all convention (precision over recall).
-func rubyRescueTypes(rescueNode *sitter.Node, src []byte) []string {
+func rubyRescueTypes(rescueNode ts.Node, src []byte) []string {
 	exc := rescueNode.ChildByFieldName("exceptions")
 	if exc == nil {
 		return nil // bare `rescue => e` / `rescue` — catch-all, no type
@@ -174,7 +174,7 @@ func rubyRescueTypes(rescueNode *sitter.Node, src []byte) []string {
 //
 // Only `constant` / `scope_resolution` arguments yield a type; `pair`
 // (keyword args like `with:`) and anything else are skipped (honest-partial).
-func rubyRescueFromTypes(call *sitter.Node, src []byte) []string {
+func rubyRescueFromTypes(call ts.Node, src []byte) []string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return nil
@@ -195,7 +195,7 @@ func rubyRescueFromTypes(call *sitter.Node, src []byte) []string {
 }
 
 // firstNamedChildRuby returns the first named child of n, or nil.
-func firstNamedChildRuby(n *sitter.Node) *sitter.Node {
+func firstNamedChildRuby(n ts.Node) ts.Node {
 	if n == nil || n.NamedChildCount() == 0 {
 		return nil
 	}

--- a/internal/extractors/ruby/exception_flow_test.go
+++ b/internal/extractors/ruby/exception_flow_test.go
@@ -22,7 +22,7 @@ func extractRuby(t *testing.T, path, src string) []types.EntityRecord {
 		t.Fatal("ruby extractor not registered")
 	}
 	recs, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: path, Content: []byte(src), Language: "ruby", Tree: tree,
+		Path: path, Content: []byte(src), Language: "ruby", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -289,7 +289,7 @@ func TestLiveFireRb(t *testing.T) {
 		t.Fatal("ruby extractor not registered")
 	}
 	recs, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "app/models/accounts.rb", Content: src, Language: "ruby", Tree: res.Tree,
+		Path: "app/models/accounts.rb", Content: src, Language: "ruby", TSTree: res.TSTree,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/extractors/ruby/field_members.go
+++ b/internal/extractors/ruby/field_members.go
@@ -3,7 +3,7 @@ package ruby
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -29,7 +29,7 @@ import (
 func emitRubyAttrFields(
 	records *[]types.EntityRecord,
 	ownerIdx int,
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	ownerName, filePath string,
 ) {
@@ -66,7 +66,7 @@ func emitRubyAttrFields(
 // member, with class→field CONTAINS edges, mirroring the data-class shape the
 // shape walker expects. Returns nil when the assignment is not a Struct.new /
 // Data.define form.
-func emitRubyStructDefine(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func emitRubyStructDefine(node ts.Node, file extractor.FileInput) []types.EntityRecord {
 	if node == nil || node.Type() != "assignment" {
 		return nil
 	}
@@ -125,7 +125,7 @@ func emitRubyStructDefine(node *sitter.Node, file extractor.FileInput) []types.E
 
 // rubyFieldEntity builds a SCOPE.Schema/field entity for member `field` of
 // owner `owner`, positioned at `at`.
-func rubyFieldEntity(owner, field, source, filePath string, at *sitter.Node) types.EntityRecord {
+func rubyFieldEntity(owner, field, source, filePath string, at ts.Node) types.EntityRecord {
 	dotted := owner + "." + field
 	return types.EntityRecord{
 		Name:          dotted,
@@ -151,7 +151,7 @@ func rubyFieldEntity(owner, field, source, filePath string, at *sitter.Node) typ
 // rubyCallIdentifier returns the bare method name of a `call` node, whether it
 // carries an explicit "method" field (receiver.method form) or a leading
 // identifier child (bare attr_accessor form).
-func rubyCallIdentifier(call *sitter.Node, src []byte) string {
+func rubyCallIdentifier(call ts.Node, src []byte) string {
 	if m := call.ChildByFieldName("method"); m != nil {
 		return nodeText(m, src)
 	}
@@ -165,7 +165,7 @@ func rubyCallIdentifier(call *sitter.Node, src []byte) string {
 
 // rubyCallSymbolArgs returns the bare names of the simple_symbol arguments of a
 // `call` node (`attr_accessor :a, :b` → ["a","b"]).
-func rubyCallSymbolArgs(call *sitter.Node, src []byte) []string {
+func rubyCallSymbolArgs(call ts.Node, src []byte) []string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		for i := 0; i < int(call.ChildCount()); i++ {

--- a/internal/extractors/ruby/issue4684_localvar_receiver_test.go
+++ b/internal/extractors/ruby/issue4684_localvar_receiver_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsruby "github.com/smacker/go-tree-sitter/ruby"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -26,13 +26,16 @@ import (
 
 func parseRubyFixture(t *testing.T, path, src string) extractor.FileInput {
 	t.Helper()
-	p := sitter.NewParser()
-	p.SetLanguage(tsruby.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsruby.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	return extractor.FileInput{Path: path, Language: "ruby", Content: []byte(src), Tree: tree}
+	return extractor.FileInput{Path: path, Language: "ruby", Content: []byte(src), TSTree: tree}
 }
 
 func extractRuby(t *testing.T, path, src string) []types.EntityRecord {

--- a/internal/extractors/ruby/issue4854_field_membership_test.go
+++ b/internal/extractors/ruby/issue4854_field_membership_test.go
@@ -34,7 +34,7 @@ func rbExtract(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/ruby/rails.go
+++ b/internal/extractors/ruby/rails.go
@@ -24,7 +24,7 @@ package ruby
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -61,7 +61,7 @@ var railsModelSuperclasses = map[string]struct{}{
 //
 // will yield a field child `superclass` whose subtree serialises back
 // to "< Bar". We strip the leading "< " to return just "Bar".
-func classSuperclass(node *sitter.Node, src []byte) string {
+func classSuperclass(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -80,7 +80,7 @@ func classSuperclass(node *sitter.Node, src []byte) string {
 //
 // The function is purely additive: if no Rails signal is detected, the
 // record is left untouched.
-func tagRails(rec *types.EntityRecord, node *sitter.Node, src []byte, path string) {
+func tagRails(rec *types.EntityRecord, node ts.Node, src []byte, path string) {
 	if rec == nil {
 		return
 	}

--- a/internal/extractors/ruby/rails_test.go
+++ b/internal/extractors/ruby/rails_test.go
@@ -22,7 +22,7 @@ func extractRubyFile(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/ruby/relationships_test.go
+++ b/internal/extractors/ruby/relationships_test.go
@@ -18,7 +18,7 @@ func runRuby(t *testing.T, src string) []types.EntityRecord {
 		Path:     "test.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
@@ -100,7 +100,7 @@ end
 		Path:     nativePath,
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -15,7 +15,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/txscope"
@@ -34,7 +34,7 @@ func (e *Extractor) Language() string { return "ruby" }
 
 // Extract walks the tree-sitter CST and returns entity records for the Ruby file.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -44,7 +44,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	walk(root, file, &entities)
 	// Issue #3641 (epic #3625) — config-key consumption edges
 	// (ENV['X'] / ENV.fetch('X')) → shared SCOPE.Config config_key nodes.
@@ -97,7 +97,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // per method declared inside the body, every method body emits CALLS edges
 // with stub to_id, and top-level `require`/`require_relative`/`load` calls
 // emit IMPORTS module entities mirroring the Python extractor's shape.
-func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walk(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -260,7 +260,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 // All three shapes resolve to a bare callee name; FromID is left empty so
 // buildDocument substitutes the caller's entity ID at emit time. Self-recursion
 // is dropped.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -268,7 +268,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 	var rels []types.RelationshipRecord
 	// addAt appends a CALLS edge with a 1-based line number sourced from the
 	// tree-sitter node that represents the call site.
-	addAt := func(target string, callNode *sitter.Node) {
+	addAt := func(target string, callNode ts.Node) {
 		if target == "" || target == callerName {
 			return
 		}
@@ -308,7 +308,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 // Ruby's tree-sitter grammar uses field names "method" (the called name)
 // and "receiver" (optional left-hand side). Falls back to the first
 // identifier child for older grammar variants.
-func rubyCallTarget(call *sitter.Node, src []byte) string {
+func rubyCallTarget(call ts.Node, src []byte) string {
 	if m := call.ChildByFieldName("method"); m != nil {
 		t := m.Type()
 		if t == "identifier" || t == "constant" || t == "operator" {
@@ -329,7 +329,7 @@ func rubyCallTarget(call *sitter.Node, src []byte) string {
 // when an ActiveRecord `Model.transaction do ... end` / `Model.transaction { }`
 // block is lexically present in the method's source span. No transitive
 // propagation — only the method where `transaction do` appears is stamped.
-func stampRubyTx(node *sitter.Node, file extractor.FileInput, props map[string]string) map[string]string {
+func stampRubyTx(node ts.Node, file extractor.FileInput, props map[string]string) map[string]string {
 	src := string(file.Content[node.StartByte():node.EndByte()])
 	return txscope.DetectRuby(src).Apply(props)
 }
@@ -337,7 +337,7 @@ func stampRubyTx(node *sitter.Node, file extractor.FileInput, props map[string]s
 // buildRequireImport emits a SCOPE.Component module entity with a single
 // IMPORTS relationship for top-level require / require_relative / load calls.
 // Returns (_, false) for any other call node.
-func buildRequireImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildRequireImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	// Only consider call nodes whose method identifier is one of the loaders.
 	method := node.ChildByFieldName("method")
 	if method == nil {
@@ -410,7 +410,7 @@ func buildRequireImport(node *sitter.Node, file extractor.FileInput) (types.Enti
 // Returns "" when no constant is recoverable (e.g. a leaf that isn't a legal
 // constant stem). The synth layer keys the per-symbol node by this name; an
 // over-eager guess merely mints an extra node, so we stay conservative.
-func rubyRequireConstant(node *sitter.Node, file extractor.FileInput, mname, raw string) string {
+func rubyRequireConstant(node ts.Node, file extractor.FileInput, mname, raw string) string {
 	if mname == "autoload" {
 		// `autoload :Const, 'path'` — first argument is the explicit symbol.
 		if args := node.ChildByFieldName("arguments"); args != nil {
@@ -490,7 +490,7 @@ func rubyCamelizeConstant(leaf string) string {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -498,8 +498,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -517,7 +517,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 // Rails-specific framework labelling is applied via tagRails:
 // controllers, models, migrations and routes get framework="rails" plus
 // a kind discriminator in Properties.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -539,7 +539,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 }
 
 // buildMethod creates an Operation entity for method definitions.
-func buildMethod(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildMethod(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -564,7 +564,7 @@ func buildMethod(node *sitter.Node, file extractor.FileInput, subtype string) (t
 }
 
 // childFieldText extracts the text of a named child field.
-func childFieldText(node *sitter.Node, field string, src []byte) string {
+func childFieldText(node ts.Node, field string, src []byte) string {
 	child := node.ChildByFieldName(field)
 	if child == nil {
 		return ""
@@ -573,7 +573,7 @@ func childFieldText(node *sitter.Node, field string, src []byte) string {
 }
 
 // buildMethodSignature builds a def signature (first line).
-func buildMethodSignature(node *sitter.Node, src []byte) string {
+func buildMethodSignature(node ts.Node, src []byte) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "\n"); idx >= 0 {
 		return strings.TrimSpace(raw[:idx])
@@ -582,7 +582,7 @@ func buildMethodSignature(node *sitter.Node, src []byte) string {
 }
 
 // buildClassSignature constructs a readable signature for class/module.
-func buildClassSignature(node *sitter.Node, src []byte, name string) string {
+func buildClassSignature(node ts.Node, src []byte, name string) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "\n"); idx >= 0 {
 		return strings.TrimSpace(raw[:idx])

--- a/internal/extractors/ruby/ruby_test.go
+++ b/internal/extractors/ruby/ruby_test.go
@@ -4,19 +4,26 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsruby "github.com/smacker/go-tree-sitter/ruby"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/ruby"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-// parseForTest parses Ruby source using the real grammar.
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+// parseForTest parses Ruby source into a ts.Tree via the smacker adapter. Tests
+// stamp the result on FileInput.TSTree (which the migrated Ruby extractor
+// consumes); the smacker adapter keeps these tests linkable in the default build
+// while exercising the ts façade (B2 #5418).
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsruby.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsruby.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -47,7 +54,7 @@ end
 		Path:     "user.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -91,7 +98,7 @@ end
 		Path:     "foo.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -132,7 +139,7 @@ end
 		Path:     "module.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -164,7 +171,7 @@ end
 		Path:     "svc.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -192,7 +199,7 @@ func TestRubyExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.rb",
 		Content:  []byte(""),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -209,7 +216,7 @@ func TestRubyExtractor_NilTree(t *testing.T) {
 		Path:     "nil.rb",
 		Content:  []byte("class Foo; end"),
 		Language: "ruby",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -236,7 +243,7 @@ def orphan_method(x
 		Path:     "malformed.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on malformed file: %v", err)
@@ -274,7 +281,7 @@ end
 		Path:     "lines.rb",
 		Content:  []byte(src),
 		Language: "ruby",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/ruby/template_render.go
+++ b/internal/extractors/ruby/template_render.go
@@ -29,7 +29,7 @@ package ruby
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -41,15 +41,15 @@ import (
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitTemplateRenderEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitTemplateRenderEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
 
 	var edges []extractor.TemplateEdge
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -83,7 +83,7 @@ func emitTemplateRenderEdges(root *sitter.Node, src []byte, entities *[]types.En
 //
 // A bare receiver (`obj.render`) is NOT a Rails controller render and is
 // rejected. Symbol args (render :index) and variable/object args are dropped.
-func rubyRenderTemplate(call *sitter.Node, src []byte) (string, string) {
+func rubyRenderTemplate(call ts.Node, src []byte) (string, string) {
 	// Must be a receiver-less `render ...` call (Rails controller DSL).
 	if recv := call.ChildByFieldName("receiver"); recv != nil {
 		return "", ""
@@ -136,7 +136,7 @@ func rubyRenderTemplate(call *sitter.Node, src []byte) (string, string) {
 // rubyPairParts returns the hash_key_symbol name and, if the value is a literal
 // string, its content — for a `key: 'value'` pair. A non-string value yields
 // ("key", "").
-func rubyPairParts(pair *sitter.Node, src []byte) (string, string) {
+func rubyPairParts(pair ts.Node, src []byte) (string, string) {
 	var key, val string
 	if k := pair.ChildByFieldName("key"); k != nil {
 		key = strings.TrimSpace(rubyNodeText(k, src))

--- a/internal/extractors/ruby/tests.go
+++ b/internal/extractors/ruby/tests.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -42,7 +42,7 @@ import (
 // the RSpec custom extractor's e2e_route_calls path (#4371) and is unchanged.
 //
 // No-op for non-spec files and for spec files whose blocks resolve no CALLS.
-func emitRubyTestScopeOwner(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitRubyTestScopeOwner(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if root == nil || !isRubySpecFile(file.Path) {
 		return
 	}
@@ -195,7 +195,7 @@ func rubyCamelize(snake string) string {
 // The suite Name is namespaced (`minitest_suite:<file>:<Class>`) so the
 // resolver's by-name index never confuses it with the production class of the
 // same base name and re-orphans it (the #4366 MergeWithCustom / #4343 lesson).
-func emitRubyMinitestSuite(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitRubyMinitestSuite(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if root == nil || !isRubyTestFile(file.Path) {
 		return
 	}
@@ -268,7 +268,7 @@ func isMinitestSuperclass(super string) bool {
 // a Minitest test-case class body. Only methods whose name starts with `test_`
 // (or is exactly `test`) are Minitest examples; helpers / `setup` / `teardown`
 // are excluded from the count.
-func countMinitestExamples(cls *sitter.Node, src []byte) int {
+func countMinitestExamples(cls ts.Node, src []byte) int {
 	n := 0
 	for _, m := range findAllNodes(cls, "method") {
 		name := childFieldText(m, "name", src)
@@ -325,7 +325,7 @@ func isRubyTestFile(path string) bool {
 // rspecBlock is an RSpec example/hook block body paired with the class constant
 // of the nearest enclosing `describe`/`context` (for `described_class` typing).
 type rspecBlock struct {
-	body           *sitter.Node
+	body           ts.Node
 	describedClass string
 }
 
@@ -345,13 +345,13 @@ var rspecBlockMethods = map[string]bool{
 // matched block's body so inner `it` bodies are mined too, threading the
 // described-class down. We do NOT descend into `method`/`singleton_method`
 // declarations — walk() already owns their CALLS edges.
-func collectRSpecBlockBodies(root *sitter.Node, src []byte) []rspecBlock {
+func collectRSpecBlockBodies(root ts.Node, src []byte) []rspecBlock {
 	var out []rspecBlock
 	walkRSpecBlocks(root, src, "", &out)
 	return out
 }
 
-func walkRSpecBlocks(n *sitter.Node, src []byte, describedClass string, out *[]rspecBlock) {
+func walkRSpecBlocks(n ts.Node, src []byte, describedClass string, out *[]rspecBlock) {
 	if n == nil {
 		return
 	}
@@ -389,7 +389,7 @@ func walkRSpecBlocks(n *sitter.Node, src []byte, describedClass string, out *[]r
 // rspecBlockMethodName returns the RSpec DSL block method name (it/describe/...)
 // of a `call` node when it is one of rspecBlockMethods, or "" otherwise. Handles
 // both the bare form (`it 'x' do`) and the `RSpec.describe X do` receiver form.
-func rspecBlockMethodName(call *sitter.Node, src []byte) string {
+func rspecBlockMethodName(call ts.Node, src []byte) string {
 	m := call.ChildByFieldName("method")
 	if m == nil {
 		// Bare `it 'x' do` parses with the method as the first identifier child.
@@ -414,7 +414,7 @@ func rspecBlockMethodName(call *sitter.Node, src []byte) string {
 
 // rubyDoBlockBody returns the body_statement of a call's trailing `do ... end`
 // block (or `{ ... }` brace block), or nil when the call has no block.
-func rubyDoBlockBody(call *sitter.Node) *sitter.Node {
+func rubyDoBlockBody(call ts.Node) ts.Node {
 	for i := 0; i < int(call.ChildCount()); i++ {
 		ch := call.Child(i)
 		if ch.Type() == "do_block" || ch.Type() == "block" {
@@ -435,7 +435,7 @@ func rubyDoBlockBody(call *sitter.Node) *sitter.Node {
 // rspecConstantArg returns the first constant argument of a `describe X`/
 // `context X` call (e.g. `RSpec.describe ProposalsController` → "ProposalsController"),
 // or "" when the first argument is a string label / not a constant.
-func rspecConstantArg(call *sitter.Node, src []byte) string {
+func rspecConstantArg(call ts.Node, src []byte) string {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		for i := 0; i < int(call.ChildCount()); i++ {
@@ -470,7 +470,7 @@ func rspecConstantArg(call *sitter.Node, src []byte) string {
 // CALLS edge here; bare unresolvable calls (DSL matchers like `expect`,
 // `have_http_status`) are dropped — the test-scope owner exists to credit the
 // production handler the spec exercises, not to enumerate matcher noise.
-func extractTestScopeCallRelationships(body *sitter.Node, src []byte, describedClass string) []types.RelationshipRecord {
+func extractTestScopeCallRelationships(body ts.Node, src []byte, describedClass string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
@@ -507,7 +507,7 @@ func extractTestScopeCallRelationships(body *sitter.Node, src []byte, describedC
 // `described_class` keyword, typed from the enclosing describe). A factory
 // helper (`x = make_thing()`), a namespaced/unknown receiver, or a non-`.new`
 // RHS yields no entry — honest exclusion. First binding wins on re-assign.
-func rubyLocalReceiverTypes(body *sitter.Node, src []byte, describedClass string) map[string]string {
+func rubyLocalReceiverTypes(body ts.Node, src []byte, describedClass string) map[string]string {
 	var locals map[string]string
 	for _, a := range findAllNodes(body, "assignment") {
 		lhs := a.ChildByFieldName("left")
@@ -540,7 +540,7 @@ func rubyLocalReceiverTypes(body *sitter.Node, src []byte, describedClass string
 // or "" when the RHS is not a recognised user-class construction. Handles
 // `ProposalsController.new` (PascalCase constant receiver) and
 // `described_class.new` (typed from the enclosing describe constant).
-func rubyConstructedClass(call *sitter.Node, src []byte, describedClass string) string {
+func rubyConstructedClass(call ts.Node, src []byte, describedClass string) string {
 	method := call.ChildByFieldName("method")
 	if method == nil || string(src[method.StartByte():method.EndByte()]) != "new" {
 		return ""
@@ -568,7 +568,7 @@ func rubyConstructedClass(call *sitter.Node, src []byte, describedClass string) 
 // typed local / known constant. A receiver that is a PascalCase constant
 // (`ProposalsController.create`) types directly. The `.new` constructor itself
 // and DSL/bare calls without a typed receiver are dropped.
-func rubyTypedCallTarget(call *sitter.Node, src []byte, locals map[string]string) string {
+func rubyTypedCallTarget(call ts.Node, src []byte, locals map[string]string) string {
 	method := call.ChildByFieldName("method")
 	if method == nil {
 		return ""

--- a/internal/extractors/ruby/transaction_boundary_test.go
+++ b/internal/extractors/ruby/transaction_boundary_test.go
@@ -19,7 +19,7 @@ func extractRubyTx(t *testing.T, src string) []types.EntityRecord {
 		t.Fatal("ruby extractor not registered")
 	}
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "account.rb", Content: []byte(src), Language: "ruby", Tree: tree,
+		Path: "account.rb", Content: []byte(src), Language: "ruby", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/ruby/translation_key.go
+++ b/internal/extractors/ruby/translation_key.go
@@ -29,7 +29,7 @@ package ruby
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -40,15 +40,15 @@ import (
 //
 // (*entities)[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitTranslationKeyEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitTranslationKeyEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
 
 	var uses []extractor.TranslationUse
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -78,7 +78,7 @@ func emitTranslationKeyEdges(root *sitter.Node, src []byte, entities *[]types.En
 //
 //	I18n.t('x') / I18n.translate('x')  → explicit-receiver i18n
 //	t('.relative')                     → relative-key i18n (leading dot)
-func rubyTranslationCall(call *sitter.Node, src []byte) (string, bool) {
+func rubyTranslationCall(call ts.Node, src []byte) (string, bool) {
 	method := call.ChildByFieldName("method")
 	if method == nil {
 		return "", false
@@ -116,7 +116,7 @@ func rubyTranslationCall(call *sitter.Node, src []byte) (string, bool) {
 
 // rubyFirstStringArg returns the first positional argument when it is a static
 // string literal, or ("", false) for a dynamic / symbol / interpolated arg.
-func rubyFirstStringArg(call *sitter.Node, src []byte) (string, bool) {
+func rubyFirstStringArg(call ts.Node, src []byte) (string, bool) {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return "", false

--- a/internal/extractors/rust/config_consumer.go
+++ b/internal/extractors/rust/config_consumer.go
@@ -48,7 +48,7 @@ package rust
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -59,7 +59,7 @@ import (
 //
 // records[0] MUST be the file entity. Mutates *records in place. Safe with
 // nil / empty input.
-func emitConfigConsumerEdges(root *sitter.Node, src []byte, records *[]types.EntityRecord) {
+func emitConfigConsumerEdges(root ts.Node, src []byte, records *[]types.EntityRecord) {
 	if root == nil || records == nil || len(*records) == 0 {
 		return
 	}
@@ -73,8 +73,8 @@ func emitConfigConsumerEdges(root *sitter.Node, src []byte, records *[]types.Ent
 
 	var reads []extractor.ConfigRead
 
-	var walk func(n *sitter.Node, enclosing string)
-	walk = func(n *sitter.Node, enclosing string) {
+	var walk func(n ts.Node, enclosing string)
+	walk = func(n ts.Node, enclosing string) {
 		if n == nil {
 			return
 		}
@@ -115,7 +115,7 @@ func emitConfigConsumerEdges(root *sitter.Node, src []byte, records *[]types.Ent
 // makes a method's FromName "Foo.method", matching the receiver-qualified names
 // the main walk emits for SCOPE.Operation methods so the edge attaches to the
 // right host.
-func rustImplOwnerName(fn *sitter.Node, src []byte) string {
+func rustImplOwnerName(fn ts.Node, src []byte) string {
 	for p := fn.Parent(); p != nil; p = p.Parent() {
 		if p.Type() == "impl_item" {
 			if t := p.ChildByFieldName("type"); t != nil {
@@ -139,7 +139,7 @@ func rustImplOwnerName(fn *sitter.Node, src []byte) string {
 //	env::var("KEY") / std::env::var("KEY") / env::var_os("KEY")  → "env_var"
 //	dotenvy::var("KEY")                                          → "dotenvy"
 //	Env::prefixed("PREFIX")                                      → "figment"
-func rustConfigKeyFromCall(call *sitter.Node, src []byte) (string, string) {
+func rustConfigKeyFromCall(call ts.Node, src []byte) (string, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil && call.ChildCount() > 0 {
 		fn = call.Child(0)
@@ -204,7 +204,7 @@ func rustConfigKeyFromCall(call *sitter.Node, src []byte) (string, string) {
 
 // fieldName returns the method/field name of a field_expression's `field`
 // child, or "" when absent.
-func fieldName(fieldExpr *sitter.Node, src []byte) string {
+func fieldName(fieldExpr ts.Node, src []byte) string {
 	if fieldExpr == nil {
 		return ""
 	}

--- a/internal/extractors/rust/config_consumer_test.go
+++ b/internal/extractors/rust/config_consumer_test.go
@@ -23,7 +23,7 @@ func extractRustForConfig(t *testing.T, src string) []types.EntityRecord {
 		Path:     "config.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/rust/crosspath.go
+++ b/internal/extractors/rust/crosspath.go
@@ -39,7 +39,7 @@ package rust
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // rustCrossCtx is the per-file context used to translate a call-site path
@@ -77,7 +77,7 @@ type rustCrossCtx struct {
 // buildRustCrossCtx builds the per-file cross-module resolution context from
 // the file path and its `use` declarations. root is the tree-sitter root node;
 // src the file bytes; filePath the repo-relative source path.
-func buildRustCrossCtx(root *sitter.Node, src []byte, filePath string) *rustCrossCtx {
+func buildRustCrossCtx(root ts.Node, src []byte, filePath string) *rustCrossCtx {
 	ctx := &rustCrossCtx{aliases: map[string][]string{}}
 	ctx.crateSrc, ctx.selfModDir, ctx.superModDir = rustModuleDirs(filePath)
 	if ctx.crateSrc == "" {
@@ -165,7 +165,7 @@ func pathDir(p string) string {
 // Grouped uses (`use a::{b, c as d}`) are intentionally NOT expanded — they
 // rarely qualify a call by alias and adding them risks mis-binding; the
 // conservative skip leaves the bare-name fallback in place.
-func collectRustUseAliases(root *sitter.Node, src []byte, ctx *rustCrossCtx) {
+func collectRustUseAliases(root ts.Node, src []byte, ctx *rustCrossCtx) {
 	for _, u := range findAllNodes(root, "use_declaration") {
 		raw := strings.TrimSpace(string(src[u.StartByte():u.EndByte()]))
 		raw = stripRustVisibility(raw)

--- a/internal/extractors/rust/enum_valueset.go
+++ b/internal/extractors/rust/enum_valueset.go
@@ -46,7 +46,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -58,7 +58,7 @@ import (
 // the main walk so it never interferes with the struct/enum Component entities
 // the walk already emits — the value-set node is an ADDITIONAL, name-searchable
 // view of the same source-of-truth, keyed on a distinct QualifiedName.
-func emitRustConstValueSets(root *sitter.Node, src []byte, filePath string, out *[]types.EntityRecord) {
+func emitRustConstValueSets(root ts.Node, src []byte, filePath string, out *[]types.EntityRecord) {
 	if root == nil {
 		return
 	}
@@ -129,7 +129,7 @@ func emitRustConstValueSets(root *sitter.Node, src []byte, filePath string, out 
 // calls (rustInsertMembers). One value-set is emitted per binding with a
 // literal-insert body. Also covers `once_cell` Lazy maps when expressed via the
 // same insert pattern.
-func emitRustLazyStaticValueSets(macro *sitter.Node, src []byte, filePath string, out *[]types.EntityRecord) {
+func emitRustLazyStaticValueSets(macro ts.Node, src []byte, filePath string, out *[]types.EntityRecord) {
 	if rustMacroName(macro, src) != "lazy_static" {
 		return
 	}
@@ -181,7 +181,7 @@ func emitRustLazyStaticValueSets(macro *sitter.Node, src []byte, filePath string
 // `enum_item`. Each enum_variant contributes its name; an explicit `= <literal>`
 // discriminant contributes the value. Data-carrying variants (tuple/struct)
 // record the name only. Emitted ONLY when the enum has ≥1 variant.
-func emitRustEnumValueSet(node *sitter.Node, src []byte, filePath string, out *[]types.EntityRecord) {
+func emitRustEnumValueSet(node ts.Node, src []byte, filePath string, out *[]types.EntityRecord) {
 	name := childFieldText(node, "name", src)
 	if name == "" {
 		if id := firstChildOfType(node, "type_identifier"); id != nil {
@@ -249,7 +249,7 @@ func emitRustEnumValueSet(node *sitter.Node, src []byte, filePath string, out *[
 // lazy_static!/once_cell map), emits a value-set node and returns true. A plain
 // scalar binding (or any non-map value) returns false so the caller can fold it
 // into the module constant group.
-func emitRustConstCollection(item *sitter.Node, src []byte, filePath string, out *[]types.EntityRecord) bool {
+func emitRustConstCollection(item ts.Node, src []byte, filePath string, out *[]types.EntityRecord) bool {
 	name := childFieldText(item, "name", src)
 	if name == "" {
 		if id := firstChildOfType(item, "identifier"); id != nil {
@@ -306,7 +306,7 @@ func emitRustConstCollection(item *sitter.Node, src []byte, filePath string, out
 // rustInitExpr returns the initializer expression node of a const_item /
 // static_item — the named expression child appearing after the `=` token.
 // Returns nil when the item has no initializer.
-func rustInitExpr(item *sitter.Node) *sitter.Node {
+func rustInitExpr(item ts.Node) ts.Node {
 	sawEq := false
 	for i := 0; i < int(item.ChildCount()); i++ {
 		ch := item.Child(i)
@@ -329,7 +329,7 @@ func rustInitExpr(item *sitter.Node) *sitter.Node {
 // literals; any other element disqualifies the whole map (ok=false). A single
 // literal-element array (`["a", "b"]`, a value LIST) yields name=value members
 // where key==value, so a const value list is still an enumerable set.
-func rustSliceTupleMembers(arr *sitter.Node, src []byte) ([]extreg.EnumMember, bool) {
+func rustSliceTupleMembers(arr ts.Node, src []byte) ([]extreg.EnumMember, bool) {
 	var members []extreg.EnumMember
 	sawTuple := false
 	for i := 0; i < int(arr.ChildCount()); i++ {
@@ -340,7 +340,7 @@ func rustSliceTupleMembers(arr *sitter.Node, src []byte) ([]extreg.EnumMember, b
 		switch el.Type() {
 		case "tuple_expression":
 			sawTuple = true
-			var lits []*sitter.Node
+			var lits []ts.Node
 			for j := 0; j < int(el.ChildCount()); j++ {
 				c := el.Child(j)
 				if c != nil && c.IsNamed() {
@@ -380,7 +380,7 @@ func rustSliceTupleMembers(arr *sitter.Node, src []byte) ([]extreg.EnumMember, b
 // across `=>` tokens. It also recognises a lazy_static! body whose statements
 // are `m.insert(<lit>, <lit>)` calls. Returns ok=false when no literal pair is
 // found, so a non-map macro emits no node.
-func rustPhfMapMembers(macro *sitter.Node, src []byte) ([]extreg.EnumMember, bool) {
+func rustPhfMapMembers(macro ts.Node, src []byte) ([]extreg.EnumMember, bool) {
 	macroName := rustMacroName(macro, src)
 	tt := firstChildOfType(macro, "token_tree")
 	if tt == nil {
@@ -430,9 +430,9 @@ func rustPhfMapMembers(macro *sitter.Node, src []byte) ([]extreg.EnumMember, boo
 // call statements (the canonical lazy_static! / once_cell HashMap build form)
 // and returns one member per insert. The receiver / method-name tokens are
 // ignored; only the literal argument pair matters.
-func rustInsertMembers(tt *sitter.Node, src []byte) []extreg.EnumMember {
+func rustInsertMembers(tt ts.Node, src []byte) []extreg.EnumMember {
 	var members []extreg.EnumMember
-	stack := []*sitter.Node{tt}
+	stack := []ts.Node{tt}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -466,7 +466,7 @@ func rustInsertMembers(tt *sitter.Node, src []byte) []extreg.EnumMember {
 // const_item / static_item's initializer when it is a plain scalar literal
 // (string / int / float / bool / char). Returns "" for collection / non-literal
 // initializers (which are handled by emitRustConstCollection or skipped).
-func rustScalarLiteralValue(item *sitter.Node, src []byte) string {
+func rustScalarLiteralValue(item ts.Node, src []byte) string {
 	val := rustInitExpr(item)
 	if val == nil {
 		return ""
@@ -476,7 +476,7 @@ func rustScalarLiteralValue(item *sitter.Node, src []byte) string {
 
 // rustLiteralText returns the normalised literal text of a Rust literal node
 // (quotes stripped for strings/chars), or "" when n is not a literal.
-func rustLiteralText(n *sitter.Node, src []byte) string {
+func rustLiteralText(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -492,7 +492,7 @@ func rustLiteralText(n *sitter.Node, src []byte) string {
 }
 
 // isRustLiteralNode reports whether n is a Rust literal value node.
-func isRustLiteralNode(n *sitter.Node) bool {
+func isRustLiteralNode(n ts.Node) bool {
 	if n == nil {
 		return false
 	}
@@ -507,7 +507,7 @@ func isRustLiteralNode(n *sitter.Node) bool {
 
 // flatNode pairs a token-tree descendant node with its 1-based source line.
 type flatNode struct {
-	node *sitter.Node
+	node ts.Node
 	line int
 }
 
@@ -515,7 +515,7 @@ type flatNode struct {
 // EXCEPT it does not descend into nested token_tree groups whose own children
 // are arguments (so a `phf_map!` arrow body is read at one level). The `=>`
 // arrow tokens are unnamed but significant, so they are included explicitly.
-func flattenNamed(tt *sitter.Node) []flatNode {
+func flattenNamed(tt ts.Node) []flatNode {
 	var out []flatNode
 	for i := 0; i < int(tt.ChildCount()); i++ {
 		ch := tt.Child(i)
@@ -553,7 +553,7 @@ func nextLiteral(flat []flatNode, i int, src []byte) string {
 
 // literalChildren returns the normalised literal texts of the direct named
 // literal children of node (used for `insert(<lit>, <lit>)` argument trees).
-func literalChildren(node *sitter.Node, src []byte) []string {
+func literalChildren(node ts.Node, src []byte) []string {
 	var out []string
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
@@ -568,13 +568,13 @@ func literalChildren(node *sitter.Node, src []byte) []string {
 // both a plain `identifier` (`phf_map!`) and a path-qualified
 // `scoped_identifier` (`lazy_static::lazy_static!`) — for the latter the LAST
 // path segment (the macro name) is returned.
-func rustMacroName(macro *sitter.Node, src []byte) string {
+func rustMacroName(macro ts.Node, src []byte) string {
 	if id := firstChildOfType(macro, "identifier"); id != nil {
 		return nodeTextR(id, src)
 	}
 	if sc := firstChildOfType(macro, "scoped_identifier"); sc != nil {
 		// Last identifier child is the macro name.
-		var last *sitter.Node
+		var last ts.Node
 		for i := 0; i < int(sc.ChildCount()); i++ {
 			if ch := sc.Child(i); ch != nil && ch.Type() == "identifier" {
 				last = ch
@@ -588,7 +588,7 @@ func rustMacroName(macro *sitter.Node, src []byte) string {
 }
 
 // firstChildOfType returns the first direct child of node with the given type.
-func firstChildOfType(node *sitter.Node, kind string) *sitter.Node {
+func firstChildOfType(node ts.Node, kind string) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -603,7 +603,7 @@ func firstChildOfType(node *sitter.Node, kind string) *sitter.Node {
 
 // nextSiblingOfType returns the first sibling AFTER index i (among parent's
 // children) whose type matches kind.
-func nextSiblingOfType(parent *sitter.Node, i int, kind string) *sitter.Node {
+func nextSiblingOfType(parent ts.Node, i int, kind string) ts.Node {
 	for j := i + 1; j < int(parent.ChildCount()); j++ {
 		ch := parent.Child(j)
 		if ch != nil && ch.Type() == kind {
@@ -614,7 +614,7 @@ func nextSiblingOfType(parent *sitter.Node, i int, kind string) *sitter.Node {
 }
 
 // nodeTextR returns the source text of a node.
-func nodeTextR(n *sitter.Node, src []byte) string {
+func nodeTextR(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/rust/exception_flow.go
+++ b/internal/extractors/rust/exception_flow.go
@@ -70,7 +70,7 @@ package rust
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -82,7 +82,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -95,8 +95,8 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 	//   - impl Type { fn } → impl-qualified ("Type.find")
 	// implType is the current impl's implementing-type name ("" when not in an
 	// impl), so a nested function_item inside an impl gets "Type.fn".
-	var walk func(n *sitter.Node, enclosingFn, implType string)
-	walk = func(n *sitter.Node, enclosingFn, implType string) {
+	var walk func(n ts.Node, enclosingFn, implType string)
+	walk = func(n ts.Node, enclosingFn, implType string) {
 		if n == nil {
 			return
 		}
@@ -164,7 +164,7 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 // rustImplTypeName returns the implementing-type name of an impl_item, mirroring
 // buildImpl's resolution (the "type" field, with a type_identifier/generic_type
 // fallback). Returns "" if it cannot be resolved.
-func rustImplTypeName(n *sitter.Node, src []byte) string {
+func rustImplTypeName(n ts.Node, src []byte) string {
 	if ty := n.ChildByFieldName("type"); ty != nil {
 		return nodeStr(ty, src)
 	}
@@ -178,7 +178,7 @@ func rustImplTypeName(n *sitter.Node, src []byte) string {
 }
 
 // childIdentText returns the text of a node's "name" field, or "" if absent.
-func childIdentText(n *sitter.Node, src []byte) string {
+func childIdentText(n ts.Node, src []byte) string {
 	if name := n.ChildByFieldName("name"); name != nil {
 		return nodeStr(name, src)
 	}
@@ -207,7 +207,7 @@ func childIdentText(n *sitter.Node, src []byte) string {
 //	Err(Box::new(e))       scoped ctor whose leading segment `Box` would be
 //	                       credited; this is the boxed-trait-object false-positive
 //	                       guarded against by rejecting the `Box` leading segment.
-func rustThrowFromCall(call *sitter.Node, src []byte) string {
+func rustThrowFromCall(call ts.Node, src []byte) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "identifier" || nodeStr(fn, src) != "Err" {
 		return ""
@@ -249,7 +249,7 @@ func rustThrowFromCall(call *sitter.Node, src []byte) string {
 // rustThrowFromOkOr recognises `recv.ok_or(<type-arg>)` /
 // `recv.ok_or_else(|| <type-expr>)` — the Option→Result conversions that inject
 // a specific error type into a Result — and returns that error TYPE, or "".
-func rustThrowFromOkOr(call *sitter.Node, src []byte) string {
+func rustThrowFromOkOr(call ts.Node, src []byte) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "field_expression" {
 		return ""
@@ -284,7 +284,7 @@ func rustThrowFromOkOr(call *sitter.Node, src []byte) string {
 // The macro token_tree is an unparsed token stream; we scan it for the LAST
 // `Ident :: Ident` run (the error expression) and credit its leading segment.
 // `bail!("plain message")` (string only) yields "".
-func rustThrowFromMacro(mac *sitter.Node, src []byte) string {
+func rustThrowFromMacro(mac ts.Node, src []byte) string {
 	name := mac.ChildByFieldName("macro")
 	if name == nil {
 		return ""
@@ -312,7 +312,7 @@ func rustThrowFromMacro(mac *sitter.Node, src []byte) string {
 
 // rustCatchFromMapErr recognises `recv.map_err(|e: T| ..)` and returns the typed
 // closure-parameter type T (the error being handled), or "".
-func rustCatchFromMapErr(call *sitter.Node, src []byte) string {
+func rustCatchFromMapErr(call ts.Node, src []byte) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "field_expression" {
 		return ""
@@ -354,7 +354,7 @@ func rustCatchFromMapErr(call *sitter.Node, src []byte) string {
 //	Err(NotFoundError)     inner identifier         → NotFoundError
 //	Err(MyError::Bad)      inner scoped_identifier  → MyError (enum → ENUM type)
 //	Err(_) / Err(e)        wildcard / binding       → "" (no type, no edge)
-func rustCatchFromErrPattern(pat *sitter.Node, src []byte) string {
+func rustCatchFromErrPattern(pat ts.Node, src []byte) string {
 	if pat == nil || pat.Type() != "tuple_struct_pattern" {
 		return ""
 	}
@@ -364,7 +364,7 @@ func rustCatchFromErrPattern(pat *sitter.Node, src []byte) string {
 		return ""
 	}
 	// The inner element after the `Err` ctor is the matched payload pattern.
-	var inner *sitter.Node
+	var inner ts.Node
 	seenCtor := false
 	for i := 0; i < int(pat.NamedChildCount()); i++ {
 		c := pat.NamedChild(i)
@@ -405,7 +405,7 @@ func rustCatchFromErrPattern(pat *sitter.Node, src []byte) string {
 //	MyError::Variant       scoped_identifier  → MyError
 //	MyError::new()         call → scoped fn    → MyError
 //	MyError                identifier          → MyError (if type-shaped)
-func rustErrorExprType(expr *sitter.Node, src []byte) string {
+func rustErrorExprType(expr ts.Node, src []byte) string {
 	if expr == nil {
 		return ""
 	}
@@ -455,7 +455,7 @@ func rustErrorTypeToken(raw string) string {
 // scoped_identifier (`MyError::NotFound` → `MyError`, `a::b::C` → `a`). For Rust
 // error paths the leading segment is the carrying TYPE. Returns "" if the node
 // has no leading identifier.
-func leadingScopedSegment(n *sitter.Node, src []byte) string {
+func leadingScopedSegment(n ts.Node, src []byte) string {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		c := n.Child(i)
 		switch c.Type() {
@@ -486,14 +486,14 @@ func looksLikeTypeName(id string) bool {
 
 // --- small CST helpers (kept local so the pass is self-contained) ---
 
-func nodeStr(n *sitter.Node, src []byte) string {
+func nodeStr(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
 	return string(src[n.StartByte():n.EndByte()])
 }
 
-func firstNamedChild(n *sitter.Node) *sitter.Node {
+func firstNamedChild(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -503,7 +503,7 @@ func firstNamedChild(n *sitter.Node) *sitter.Node {
 	return n.NamedChild(0)
 }
 
-func childOfType(n *sitter.Node, typ string) *sitter.Node {
+func childOfType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -517,7 +517,7 @@ func childOfType(n *sitter.Node, typ string) *sitter.Node {
 
 // closureBody returns the body expression of a closure_expression (the child
 // after the closure_parameters), or nil.
-func closureBody(cl *sitter.Node) *sitter.Node {
+func closureBody(cl ts.Node) ts.Node {
 	if cl == nil {
 		return nil
 	}
@@ -540,7 +540,7 @@ func closureBody(cl *sitter.Node) *sitter.Node {
 // matchArmPattern returns the tuple_struct_pattern inside a match_arm's
 // match_pattern, or nil. A match_arm is `match_pattern => body`; the pattern
 // wraps the actual pattern (here we want `Err(..)`).
-func matchArmPattern(arm *sitter.Node) *sitter.Node {
+func matchArmPattern(arm ts.Node) ts.Node {
 	mp := childOfType(arm, "match_pattern")
 	if mp == nil {
 		return nil
@@ -550,6 +550,6 @@ func matchArmPattern(arm *sitter.Node) *sitter.Node {
 
 // letConditionPattern returns the tuple_struct_pattern inside a let_condition
 // (`let Err(..) = expr`), or nil.
-func letConditionPattern(lc *sitter.Node) *sitter.Node {
+func letConditionPattern(lc ts.Node) ts.Node {
 	return childOfType(lc, "tuple_struct_pattern")
 }

--- a/internal/extractors/rust/issue4373_crossmod_test.go
+++ b/internal/extractors/rust/issue4373_crossmod_test.go
@@ -23,13 +23,13 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsrust "github.com/smacker/go-tree-sitter/rust"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/rust"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/resolve"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -45,15 +45,19 @@ func extractRustCrateForTest(t *testing.T, files map[string]string) []types.Enti
 	}
 	var merged []types.EntityRecord
 	for rel, src := range files {
-		parser := sitter.NewParser()
-		parser.SetLanguage(tsrust.GetLanguage())
-		tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+		parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsrust.GetLanguage()))
 		if err != nil {
+			t.Fatalf("parser init %s: %v", rel, err)
+		}
+		tree, err := parser.Parse([]byte(src))
+		if err != nil {
+			parser.Close()
 			t.Fatalf("parse %s: %v", rel, err)
 		}
 		ents, err := ext.Extract(context.Background(), extractor.FileInput{
-			Path: rel, Language: "rust", Content: []byte(src), Tree: tree,
+			Path: rel, Language: "rust", Content: []byte(src), TSTree: tree,
 		})
+		parser.Close()
 		if err != nil {
 			t.Fatalf("extract %s: %v", rel, err)
 		}

--- a/internal/extractors/rust/relationships_test.go
+++ b/internal/extractors/rust/relationships_test.go
@@ -17,7 +17,7 @@ func runRust(t *testing.T, src string) []types.EntityRecord {
 		Path:     "test.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -43,7 +43,7 @@ func (e *Extractor) Language() string { return "rust" }
 
 // Extract walks the tree-sitter CST and returns entity records for the Rust file.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -56,25 +56,25 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// Issue #4373 — per-file cross-module call-path resolution context, built
 	// once from the file path + `use` declarations and threaded into call
 	// extraction so cross-module CALLS carry a stamped module qualifier.
-	crossCtx := buildRustCrossCtx(file.Tree.RootNode(), file.Content, file.Path)
-	walk(file.Tree.RootNode(), file, &entities, crossCtx)
+	crossCtx := buildRustCrossCtx(file.TSTree.RootNode(), file.Content, file.Path)
+	walk(file.TSTree.RootNode(), file, &entities, crossCtx)
 	// Epic #3628 — error-flow topology: typed THROWS / CATCHES edges to the
 	// shared SCOPE.ExceptionType convergence node. Runs after walk so the
 	// host SCOPE.Operation entities (including impl-qualified method names)
 	// already exist for FromName attachment.
-	emitExceptionFlowEdges(file.Tree.RootNode(), file.Content, &entities)
+	emitExceptionFlowEdges(file.TSTree.RootNode(), file.Content, &entities)
 	// Ticket #4431 — index const/static constant collections (const slice maps,
 	// phf_map!/lazy_static! maps, module constant groups) and data-enums as
 	// queryable SCOPE.Enum value-sets, reusing the shared cross-language builder
 	// (extends #4420/#4429). Append-only supplemental pass: it never replaces the
 	// struct/enum Component entities the walk already emitted.
-	emitRustConstValueSets(file.Tree.RootNode(), file.Content, file.Path, &entities)
+	emitRustConstValueSets(file.TSTree.RootNode(), file.Content, file.Path, &entities)
 	// Issue #5020 — config-consumption topology: literal env/config-crate key
 	// reads (env::var / dotenvy::var / figment Env::prefixed) become shared
 	// SCOPE.Config config-key nodes + DEPENDS_ON_CONFIG edges from the reading
 	// function, the config-change blast radius (parity with go/java/php/python).
 	// Append-only supplemental pass; entities[0] is the file entity.
-	emitConfigConsumerEdges(file.Tree.RootNode(), file.Content, &entities)
+	emitConfigConsumerEdges(file.TSTree.RootNode(), file.Content, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "rust")
 	extractor.TagEntitiesLanguage(entities, "rust")
@@ -87,7 +87,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // per function_item declared inside their declaration_list, every
 // function_item body emits CALLS edges with stub to_id, and use_declaration
 // nodes already emit IMPORTS (untouched).
-func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord, crossCtx *rustCrossCtx) {
+func walk(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord, crossCtx *rustCrossCtx) {
 	if node == nil {
 		return
 	}
@@ -233,7 +233,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 
 // findRustDeclList returns the declaration_list child of a trait_item or
 // impl_item, or nil when the body is missing.
-func findRustDeclList(node *sitter.Node) *sitter.Node {
+func findRustDeclList(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "declaration_list" {
@@ -252,7 +252,7 @@ func findRustDeclList(node *sitter.Node) *sitter.Node {
 // "Foo"); it enables `self.method()` calls to resolve to "Foo.method".
 // paramTypes maps parameter names to their declared types so that calls
 // through typed receivers (e.g. `r: &dyn Repo`) resolve to "Repo.method".
-func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerName string, paramTypes map[string]string, crossCtx *rustCrossCtx) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName, ownerName string, paramTypes map[string]string, crossCtx *rustCrossCtx) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -311,7 +311,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerNa
 // ["OrderService","new"]), or nil for bare / receiver / macro calls. The
 // caller uses it to stamp a cross-module qualifier so the resolver can bind to
 // the exact callee module instead of the ambiguity-prone bare leaf.
-func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes map[string]string) (string, []string) {
+func rustCallTarget(call ts.Node, src []byte, ownerName string, paramTypes map[string]string) (string, []string) {
 	switch call.Type() {
 	case "call_expression":
 		fn := call.ChildByFieldName("function")
@@ -394,7 +394,7 @@ func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes 
 // path keywords (which appear as crate/self/super nodes). Turbofish generics
 // are stripped per-segment by splitRustPath. Returns nil when the path cannot
 // be cleanly segmented (e.g. contains a non-identifier element).
-func rustScopedPathSegments(node *sitter.Node, src []byte) []string {
+func rustScopedPathSegments(node ts.Node, src []byte) []string {
 	raw := strings.TrimSpace(string(src[node.StartByte():node.EndByte()]))
 	if raw == "" {
 		return nil
@@ -409,7 +409,7 @@ func rustScopedPathSegments(node *sitter.Node, src []byte) []string {
 //
 // Issue #616 — used by extractCallRelationships to qualify dyn-receiver
 // CALLS edges (e.g. `r.find(1)` → "Repo.find").
-func collectRustParamTypes(node *sitter.Node, src []byte) map[string]string {
+func collectRustParamTypes(node ts.Node, src []byte) map[string]string {
 	out := map[string]string{}
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
@@ -468,7 +468,7 @@ func normalizeRustType(typ string) string {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -476,8 +476,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -502,7 +502,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 //	enum   → "variants" (variant idents), "generics", "derives"
 //	trait  → "methods" (signature + default-body fn idents),
 //	          "supertraits", "generics", plus EXTENDS edges per supertrait
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -563,7 +563,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 // rustGenerics returns a comma-separated list of generic type-parameter names
 // declared on a struct/enum/trait/type item (the `type_parameters` field).
 // Lifetime params (`'a`) and const params are included as written.
-func rustGenerics(node *sitter.Node, src []byte) string {
+func rustGenerics(node ts.Node, src []byte) string {
 	tp := node.ChildByFieldName("type_parameters")
 	if tp == nil {
 		return ""
@@ -584,7 +584,7 @@ func rustGenerics(node *sitter.Node, src []byte) string {
 // rustStructFields returns the field names of a struct_item. For a named-field
 // struct it returns the field identifiers; for a tuple struct it returns the
 // positional indices ("0, 1, ..."); for a unit struct it returns "".
-func rustStructFields(node *sitter.Node, src []byte) string {
+func rustStructFields(node ts.Node, src []byte) string {
 	body := node.ChildByFieldName("body")
 	if body == nil {
 		// Tuple/unit structs place the field list in an unnamed child.
@@ -629,7 +629,7 @@ func rustStructFields(node *sitter.Node, src []byte) string {
 
 // isRustTypeNode reports whether a node represents a type expression that would
 // occupy a positional slot in a tuple struct's ordered field list.
-func isRustTypeNode(n *sitter.Node) bool {
+func isRustTypeNode(n ts.Node) bool {
 	switch n.Type() {
 	case "(", ")", ",", "visibility_modifier":
 		return false
@@ -641,7 +641,7 @@ func isRustTypeNode(n *sitter.Node) bool {
 // an enum_item's enum_variant_list. Tuple (`Foo(i32)`), struct
 // (`Bar { x: u8 }`), and discriminant (`Baz = 1`) variants all contribute their
 // leading identifier.
-func rustEnumVariants(node *sitter.Node, src []byte) string {
+func rustEnumVariants(node ts.Node, src []byte) string {
 	body := node.ChildByFieldName("body")
 	if body == nil {
 		return ""
@@ -662,7 +662,7 @@ func rustEnumVariants(node *sitter.Node, src []byte) string {
 // rustTraitMethods returns a comma-separated list of method names declared in a
 // trait's declaration_list — both required signatures (function_signature_item)
 // and provided/default methods (function_item).
-func rustTraitMethods(node *sitter.Node, src []byte) string {
+func rustTraitMethods(node ts.Node, src []byte) string {
 	body := findRustDeclList(node)
 	if body == nil {
 		return ""
@@ -681,7 +681,7 @@ func rustTraitMethods(node *sitter.Node, src []byte) string {
 
 // rustSupertraits returns the supertrait names from a trait_item's `bounds`
 // field (e.g. `trait A: B + C` → ["B", "C"]). Lifetime bounds are skipped.
-func rustSupertraits(node *sitter.Node, src []byte) []string {
+func rustSupertraits(node ts.Node, src []byte) []string {
 	bounds := node.ChildByFieldName("bounds")
 	if bounds == nil {
 		return nil
@@ -707,7 +707,7 @@ func rustSupertraits(node *sitter.Node, src []byte) []string {
 // a type via `#[derive(...)]`. Derive attributes are emitted by the grammar as
 // `attribute_item` siblings immediately preceding the type item, so we scan
 // backwards over the previous siblings (skipping other attributes / comments).
-func rustDerives(node *sitter.Node, src []byte) string {
+func rustDerives(node ts.Node, src []byte) string {
 	var out []string
 	for prev := node.PrevSibling(); prev != nil; prev = prev.PrevSibling() {
 		t := prev.Type()
@@ -724,8 +724,8 @@ func rustDerives(node *sitter.Node, src []byte) string {
 
 // rustParseDerive extracts the derive names from a single attribute_item node
 // when it is a `#[derive(...)]`; returns nil for non-derive attributes.
-func rustParseDerive(attr *sitter.Node, src []byte) []string {
-	var inner *sitter.Node
+func rustParseDerive(attr ts.Node, src []byte) []string {
+	var inner ts.Node
 	for i := 0; i < int(attr.ChildCount()); i++ {
 		if attr.Child(i).Type() == "attribute" {
 			inner = attr.Child(i)
@@ -758,7 +758,7 @@ func rustParseDerive(attr *sitter.Node, src []byte) []string {
 
 // buildImpl creates a Component entity for impl blocks.
 // impl_item uses "type" field (impl Foo) or "trait" + "type" (impl Trait for Foo).
-func buildImpl(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildImpl(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	// "type" field holds the implementing type.
 	name := childFieldText(node, "type", file.Content)
 	if name == "" {
@@ -790,7 +790,7 @@ func buildImpl(node *sitter.Node, file extractor.FileInput) (types.EntityRecord,
 }
 
 // buildOperation creates an Operation entity for function items.
-func buildOperation(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildOperation(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -818,7 +818,7 @@ func buildOperation(node *sitter.Node, file extractor.FileInput) (types.EntityRe
 // (`type X = Y;`). The aliased type is captured in the "aliased_type" property.
 //
 // Issue #3269 — type_alias_extraction capability.
-func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildTypeAlias(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -862,7 +862,7 @@ func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRe
 //     intra-crate references; emitting them as IMPORTS guarantees a
 //     bug-extractor since they cannot be on any external allowlist.
 //     We drop them entirely.
-func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	raw := strings.TrimSpace(string(file.Content[node.StartByte():node.EndByte()]))
 	// Visibility modifiers — `pub use ...`, `pub(crate) use ...`,
 	// `pub(super) use ...`. Strip the modifier before the `use` token.
@@ -1091,7 +1091,7 @@ func stripRustVisibility(s string) string {
 }
 
 // childFieldText extracts the text of a named child field.
-func childFieldText(node *sitter.Node, field string, src []byte) string {
+func childFieldText(node ts.Node, field string, src []byte) string {
 	child := node.ChildByFieldName(field)
 	if child == nil {
 		return ""
@@ -1100,7 +1100,7 @@ func childFieldText(node *sitter.Node, field string, src []byte) string {
 }
 
 // buildFnSignature builds the function signature (up to the body block).
-func buildFnSignature(node *sitter.Node, src []byte) string {
+func buildFnSignature(node ts.Node, src []byte) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, " {"); idx >= 0 {
 		return strings.TrimSpace(raw[:idx])
@@ -1112,7 +1112,7 @@ func buildFnSignature(node *sitter.Node, src []byte) string {
 }
 
 // buildTypeSignature constructs a readable signature for struct/enum/trait/impl.
-func buildTypeSignature(node *sitter.Node, src []byte, name string) string {
+func buildTypeSignature(node ts.Node, src []byte, name string) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "{"); idx >= 0 {
 		return strings.TrimSpace(raw[:idx])

--- a/internal/extractors/rust/rust_test.go
+++ b/internal/extractors/rust/rust_test.go
@@ -5,20 +5,27 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsrust "github.com/smacker/go-tree-sitter/rust"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/rust"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
-// parseForTest parses Rust source using the real grammar.
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+// parseForTest parses Rust source into a ts.Tree via the smacker adapter. Tests
+// stamp the result on FileInput.TSTree (which the migrated Rust extractor
+// consumes); the smacker adapter keeps these tests linkable in the default build
+// while exercising the ts façade (B2 #5418).
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsrust.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsrust.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -60,7 +67,7 @@ fn create_user(name: String) -> User {
 		Path:     "main.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -112,7 +119,7 @@ func extractRust(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract %q: %v", path, err)
@@ -252,7 +259,7 @@ struct Foo {
 		Path:     "foo.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -293,7 +300,7 @@ enum Color {
 		Path:     "color.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -323,7 +330,7 @@ trait Animal {
 		Path:     "animal.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -353,7 +360,7 @@ fn create_user(name: String) -> User {
 		Path:     "func.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -385,7 +392,7 @@ fn main() {}
 		Path:     "imports.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -416,7 +423,7 @@ func TestRustExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.rs",
 		Content:  []byte(""),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -433,7 +440,7 @@ func TestRustExtractor_NilTree(t *testing.T) {
 		Path:     "nil.rs",
 		Content:  []byte("fn main() {}"),
 		Language: "rust",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -460,7 +467,7 @@ fn bad_function(x: u32
 		Path:     "malformed.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on malformed file: %v", err)
@@ -502,7 +509,7 @@ use super::parent::Other;
 		Path:     "imports.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -552,7 +559,7 @@ func TestRustExtractor_ImportRootOnly(t *testing.T) {
 		Path:     "root_only.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -587,7 +594,7 @@ impl Foo {
 		Path:     "foo.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -650,7 +657,7 @@ impl B { fn world(&self) {} }
 		Path:     "multi.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -695,7 +702,7 @@ impl Processor for MyImpl {
 		Path:     "processor.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -732,7 +739,7 @@ fn use_repo(r: &dyn Repo) {
 		Path:     "repo.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -768,7 +775,7 @@ trait MyTrait {
 		Path:     "trait.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -804,7 +811,7 @@ fn method1() -> u32 { 1 }
 		Path:     "lines.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -842,7 +849,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 		Path:     "types.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -880,7 +887,7 @@ func findRustEntity(t *testing.T, src, subtype, name string) map[string]string {
 	tree := parseForTest(t, src)
 	ext, _ := extractor.Get("rust")
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "ts.rs", Content: []byte(src), Language: "rust", Tree: tree,
+		Path: "ts.rs", Content: []byte(src), Language: "rust", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -943,7 +950,7 @@ trait Animal: Eq + Clone {
 	tree := parseForTest(t, src)
 	ext, _ := extractor.Get("rust")
 	got, _ := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "animal.rs", Content: []byte(src), Language: "rust", Tree: tree,
+		Path: "animal.rs", Content: []byte(src), Language: "rust", TSTree: tree,
 	})
 
 	var props map[string]string
@@ -1054,7 +1061,7 @@ func TestRustExtractor_TypeAlias_Properties(t *testing.T) {
 		Path:     "types.rs",
 		Content:  []byte(src),
 		Language: "rust",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/rust/struct_fields.go
+++ b/internal/extractors/rust/struct_fields.go
@@ -3,7 +3,7 @@ package rust
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -29,7 +29,7 @@ import (
 //	Name      = "<Owner>.<wire>"
 //	Signature = "<type> <wire>"
 func emitRustStructFields(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	ownerName string,
 ) []types.EntityRecord {
@@ -45,7 +45,7 @@ func emitRustStructFields(
 // "<Enum>.<Variant>.<field>". Tuple/unit variants carry no named fields and
 // contribute none (best-effort: Rust has no field name to model).
 func emitRustEnumVariantFields(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	ownerName string,
 ) []types.EntityRecord {
@@ -84,7 +84,7 @@ func emitRustEnumVariantFields(
 // field_declaration_list, applying the serde rename/skip attribute that
 // immediately precedes each field.
 func rustFieldsFromList(
-	body *sitter.Node,
+	body ts.Node,
 	file extractor.FileInput,
 	owner string,
 ) []types.EntityRecord {
@@ -164,7 +164,7 @@ func rustFieldsFromList(
 // rustSerdeAttr parses an attribute_item, returning the serde rename target
 // (if any) and whether the field is serde-skipped. Mirrors the regex logic in
 // internal/custom/rust/fw_validation.go so the wire names align for dedup.
-func rustSerdeAttr(attr *sitter.Node, src []byte) (rename string, skip bool) {
+func rustSerdeAttr(attr ts.Node, src []byte) (rename string, skip bool) {
 	text := string(src[attr.StartByte():attr.EndByte()])
 	if !strings.Contains(text, "serde") {
 		return "", false
@@ -186,7 +186,7 @@ func rustSerdeAttr(attr *sitter.Node, src []byte) (rename string, skip bool) {
 
 // findRustFieldList returns the field_declaration_list child of a struct_item,
 // or nil for a tuple/unit struct (no named fields).
-func findRustFieldList(node *sitter.Node) *sitter.Node {
+func findRustFieldList(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -197,7 +197,7 @@ func findRustFieldList(node *sitter.Node) *sitter.Node {
 }
 
 // findChildOfType returns the first direct child of n with the given type.
-func findChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func findChildOfType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}

--- a/internal/treesitter/ts/official/official.go
+++ b/internal/treesitter/ts/official/official.go
@@ -125,6 +125,7 @@ func (w node) EndByte() uint32         { return uint32(w.n.EndByte()) }
 
 func (w node) ChildByFieldName(f string) ts.Node { return wrapNode(w.n.ChildByFieldName(f)) }
 func (w node) Parent() ts.Node                   { return wrapNode(w.n.Parent()) }
+func (w node) PrevSibling() ts.Node              { return wrapNode(w.n.PrevSibling()) }
 
 // StartPoint/EndPoint map the official StartPosition()/EndPosition() and narrow
 // the uint Row/Column to uint32 to match ts.Point.

--- a/internal/treesitter/ts/smacker/smacker.go
+++ b/internal/treesitter/ts/smacker/smacker.go
@@ -118,6 +118,7 @@ func (w node) NamedChild(i int) ts.Node          { return wrapNode(w.n.NamedChil
 func (w node) NamedChildCount() uint32           { return w.n.NamedChildCount() }
 func (w node) ChildByFieldName(f string) ts.Node { return wrapNode(w.n.ChildByFieldName(f)) }
 func (w node) Parent() ts.Node                   { return wrapNode(w.n.Parent()) }
+func (w node) PrevSibling() ts.Node              { return wrapNode(w.n.PrevSibling()) }
 func (w node) StartByte() uint32                 { return w.n.StartByte() }
 func (w node) EndByte() uint32                   { return w.n.EndByte() }
 func (w node) StartPoint() ts.Point {

--- a/internal/treesitter/ts/ts.go
+++ b/internal/treesitter/ts/ts.go
@@ -12,7 +12,8 @@
 // Surface scope. The interface is deliberately minimal — it mirrors only the
 // CST methods grafel actually calls (verified by grepping the extractor layer:
 // Type/Kind, Child, ChildByFieldName, NamedChild, ChildCount, NamedChildCount,
-// StartByte/EndByte, StartPoint/EndPoint, Parent, IsNamed, IsError, String).
+// StartByte/EndByte, StartPoint/EndPoint, Parent, PrevSibling, IsNamed,
+// IsError, String).
 // grafel does not use the native query engine (Query/QueryCursor) anywhere, nor
 // tree cursors, so those are intentionally absent. Text extraction is done by
 // the callers via byte-slicing on StartByte/EndByte, so no Content/Utf8Text
@@ -59,6 +60,10 @@ type Node interface {
 	ChildByFieldName(field string) Node
 	// Parent returns the parent node, or nil for the root.
 	Parent() Node
+	// PrevSibling returns the node's previous sibling (named or anonymous), or
+	// nil when the node is the first child of its parent. Maps to both bindings'
+	// Node.PrevSibling().
+	PrevSibling() Node
 
 	// StartByte / EndByte are byte offsets into the source buffer.
 	StartByte() uint32


### PR DESCRIPTION
## B2 Phase 1, Batch 3 — #5418

Migrates the **ruby, php, csharp, rust** extractors off the concrete smacker `*sitter.Node` / `*sitter.Tree` onto the binding-agnostic `internal/treesitter/ts` façade (`ts.Node` / `ts.Tree`), reading the shared `FileInput.TSTree`. **Smacker-backed by default, link-safe, zero behavior change.** Mirrors the merged Batches 0/1/2 (go, python, java, javascript).

### What changed
- All four extractors **early-return** when no tree is supplied (no inline parse fallback) — same shape as the java and javascript migrations, so **no `grammar.go` provider** was added.
- Non-test files: pure `*sitter.Node` → `ts.Node` swap + root smacker import → `internal/treesitter/ts`.
- Test tree-helpers (`parseForTest`, `parseRubyFixture`, the cross-module/cross-namespace fixture loaders) now build `ts.Tree` via the smacker adapter (`tssmacker.New().NewParser(tssmacker.WrapLanguage(...))`) and stamp `FileInput.TSTree` (`Tree:` → `TSTree:`). The ruby live-fire path reads `res.TSTree` off the `ParserFactory.Parse` result. **No test assertion changed.**
- **`ts.Node` gains a `PrevSibling()` method** (added to the interface and to *both* the smacker and official adapters). The Rust extractor's `rustDerives` derive-macro scan walks previous siblings; the façade previously exposed no sibling accessor. Smacker `Node.PrevSibling()` and official `Node.PrevSibling()` both back it; nil contract preserved via `wrapNode`.

### Validation (default build)
- `go build ./...` ✅  `go vet` (4 pkgs) ✅  `gofmt -l` clean ✅
- `go test -count=1 ./internal/extractors/{ruby,php,csharp,rust}/` — **all PASS**, unchanged:
  - ruby 2.80s, php 0.65s, csharp 1.49s, rust 2.06s
- `go build -tags ts_official ./internal/treesitter/...` ✅ (the `PrevSibling` addition compiles on the official adapter too)
- No `*sitter.Node` / `*sitter.Tree` / root smacker import remains in the four packages.

### Remaining Phase-1 worklist (extractor packages still on the root smacker binding)
For the final batch(es):

- `internal/extractors/cpp/`
- `internal/extractors/cross/`
- `internal/extractors/css/`
- `internal/extractors/dockerfile/`
- `internal/extractors/elixir/`
- `internal/extractors/groovy/`
- `internal/extractors/hcl/`
- `internal/extractors/html/`
- `internal/extractors/kotlin/`
- `internal/extractors/lua/`
- `internal/extractors/proto/`
- `internal/extractors/scala/`
- `internal/extractors/shell/`
- `internal/extractors/swift/`
- `internal/extractors/yaml/`

(`internal/extractors/golang/` shows up in the raw `grep` only as a **string literal** in a data map in `imports.go` — it has no actual smacker import and is already migrated; not part of the worklist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)