### PR TITLE
feat(mcp): grafel_index_status — per-repo index freshness (no more global-is_indexing blocking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,22 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   a genuinely unrecoverable error exits.
 
 ### Added
+- **`grafel_index_status` — per-repo index freshness (#5433):** a new
+  **lightweight** MCP tool that reports each registered repo's index state
+  (`current` \| `queued` \| `indexing` \| `dirty`) plus `indexed_ref` / `head_ref`,
+  with optional `repo` (substring/exact) and `group` filters. It reads ONLY the
+  scheduler's in-memory snapshot — it does **not** load or assemble the group
+  graph — so agents can poll it cheaply. Fixes a head-of-line blocking footgun:
+  the global `grafel_stats.is_indexing` flag is a single process-wide bool, so an
+  agent that polled it to gate "is my repo ready?" was blocked by **any** repo's
+  indexing, including unrelated ones (multi-agent / multi-worktree setups
+  deadlock-waited). Agents should now gate on **their** repo's
+  `state == "current"` (and `indexed_ref == head_ref` where both are known)
+  instead of the global flag. The same `repo_index_states` array is also surfaced
+  in `grafel_stats` for one-shot inspection. The data already existed in the
+  scheduler (`inflight`/`pendingIndex`/`dirty`/`pendingRefs`); it is published via
+  the existing `indexstate` leaf-package bridge (no new lock path, no import
+  cycle). Closes #5433.
 - **Binding-agnostic tree-sitter abstraction + Go on the official binding
   (#5418, B2 Phase 0, ADR 0023):** new `internal/treesitter/ts` façade (a minimal
   `Node`/`Tree`/`Parser`/`Language`/`Adapter` interface modelled on grafel's

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -44,6 +44,7 @@ Orientation, search, and single-entity lookup. **Call `grafel_whoami` first.**
 |------|-----------------|
 | [`grafel_whoami`](mcp-tools/status-and-discovery.md#grafel_whoami) | Resolve group/repo/ref for the agent's cwd. **Call this first.** |
 | [`grafel_stats`](mcp-tools/status-and-discovery.md#grafel_stats) | Corpus-level entity + relationship counts. Use to scope token budgets. |
+| [`grafel_index_status`](mcp-tools/status-and-discovery.md#grafel_index_status) | Per-repo index freshness; gate on YOUR repo's state, not global is_indexing. |
 | [`grafel_orient`](mcp-tools/status-and-discovery.md#grafel_orient) | Orientation analysis: key entities, cross-cutting edges, orientation questions. |
 | [`grafel_search_entities`](mcp-tools/status-and-discovery.md#grafel_search_entities) | Substring search over entity names; ranked matches with source locations. |
 | [`grafel_find`](mcp-tools/status-and-discovery.md#grafel_find) | BM25-ranked graph query with optional BFS expansion. Primary discovery tool. |

--- a/docs/mcp-tools/status-and-discovery.md
+++ b/docs/mcp-tools/status-and-discovery.md
@@ -24,7 +24,21 @@ Corpus-level metrics.
 
 Key parameters: `group`/`cwd`, `repo_filter[]`, `breakdown` (`"unresolved_imports"` adds edge taxonomy).
 
-Output: entity counts per kind, relationship counts, unresolved import breakdown when requested.
+Output: entity counts per kind, relationship counts, unresolved import breakdown when requested. Also includes a `repo_index_states` array (per-repo freshness) when available — but prefer `grafel_index_status` for a cheap poll.
+
+---
+
+## `grafel_index_status`
+
+Per-repo index freshness. **Lightweight** — reads only the scheduler snapshot; does NOT load or assemble the group graph, so it is cheap to poll.
+
+Each repo reports `state` ∈ `current` | `queued` | `indexing` | `dirty`, plus `indexed_ref` (ref the last completed index ran against) and `head_ref` (ref the pending/in-flight work targets).
+
+Key parameters: `repo` (case-insensitive substring or exact path match), `group`.
+
+Output: `{repos: [{repo, group, state, indexed_ref, head_ref, dirty}], any_indexing}`.
+
+**Gating rule:** an agent should gate on **its own** repo's `state == "current"` (and `indexed_ref == head_ref` where both are known) — **not** on the global `grafel_stats.is_indexing` flag, which is process-wide and blocks on *any* repo's indexing (head-of-line blocking across unrelated repos / worktrees).
 
 ---
 

--- a/internal/daemon/sched/repostates_5433_test.go
+++ b/internal/daemon/sched/repostates_5433_test.go
@@ -1,0 +1,115 @@
+package sched
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// TestPublishRepoStatesDerivation drives the in-flight/queued/dirty/current
+// derivation directly against the scheduler maps (no goroutines) and asserts
+// publishRepoStatesLocked emits the right per-repo state, indexed_ref, and
+// head_ref through the indexstate bridge (#5433).
+func TestPublishRepoStatesDerivation(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
+
+	s := New(Config{Workers: 1})
+
+	s.mu.Lock()
+	// /idx: indexing now, head ref captured, last completed index at an older ref.
+	s.inflight["/idx"] = 100
+	s.pendingRefs["/idx"] = "headsha-idx"
+	s.indexedRepos["/idx"] = repoStats{LastIndexedRef: "oldsha-idx"}
+	// /queued: enqueued, not yet running.
+	s.pendingIndex["/queued"] = true
+	s.pendingRefs["/queued"] = "headsha-queued"
+	// /dirty: indexing AND a follow-up already pending → strongest signal.
+	s.inflight["/dirty"] = 50
+	s.dirty["/dirty"] = true
+	s.pendingRefs["/dirty"] = "headsha-dirty"
+	// /current: fully indexed, idle.
+	s.indexedRepos["/current"] = repoStats{LastIndexedRef: "sha-current"}
+
+	s.publishRepoStatesLocked()
+	s.mu.Unlock()
+
+	byPath := map[string]indexstate.RepoState{}
+	for _, st := range indexstate.RepoStates() {
+		byPath[st.Path] = st
+	}
+
+	if got := byPath["/idx"]; got.State != indexstate.StateIndexing ||
+		got.HeadRef != "headsha-idx" || got.IndexedRef != "oldsha-idx" {
+		t.Errorf("/idx = %+v, want indexing head=headsha-idx indexed=oldsha-idx", got)
+	}
+	if got := byPath["/queued"]; got.State != indexstate.StateQueued || got.HeadRef != "headsha-queued" {
+		t.Errorf("/queued = %+v, want queued head=headsha-queued", got)
+	}
+	if got := byPath["/dirty"]; got.State != indexstate.StateDirty || !got.Dirty {
+		t.Errorf("/dirty = %+v, want dirty with Dirty=true", got)
+	}
+	if got := byPath["/current"]; got.State != indexstate.StateCurrent || got.IndexedRef != "sha-current" {
+		t.Errorf("/current = %+v, want current indexed=sha-current", got)
+	}
+	if len(byPath) != 4 {
+		t.Errorf("expected 4 repos, got %d: %+v", len(byPath), byPath)
+	}
+}
+
+// TestPublishRepoStatesLiveQueuedThenCurrent proves the live path: an enqueued
+// repo is observable as queued/indexing while in flight, then current after.
+func TestPublishRepoStatesLiveQueuedThenCurrent(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetRepoStates(nil); indexstate.Set(0) })
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	s := New(Config{
+		Workers: 1,
+		Index: func(_ context.Context, _ string, _ string) error {
+			close(started)
+			<-release
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.EnqueueRef("/repo-live", "live-ref")
+
+	select {
+	case <-started:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Index callback never entered")
+	}
+
+	var inflightState string
+	for _, st := range indexstate.RepoStates() {
+		if st.Path == "/repo-live" {
+			inflightState = st.State
+		}
+	}
+	if inflightState != indexstate.StateIndexing {
+		t.Fatalf("mid-run state=%q want indexing", inflightState)
+	}
+
+	close(release)
+	deadline := time.After(10 * time.Second)
+	for {
+		var cur string
+		for _, st := range indexstate.RepoStates() {
+			if st.Path == "/repo-live" {
+				cur = st.State
+			}
+		}
+		if cur == indexstate.StateCurrent {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("repo never reached current: %+v", indexstate.RepoStates())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -371,6 +371,12 @@ type repoStats struct {
 	LastErr     string
 	LastPeakMB  int64 // observed peak (history) — 0 if predictor-only
 	PredictedMB int64 // last predicted MB charged for this repo
+	// LastIndexedRef is the git ref the most recent COMPLETED index ran
+	// against (#5433). Used by grafel_index_status to let an agent compare its
+	// repo's indexed_ref against head_ref and gate on real freshness rather
+	// than the process-global is_indexing flag. Empty until a first index
+	// completes in this daemon's lifetime.
+	LastIndexedRef string
 }
 
 // LogEntry is a single structured event captured for /status. Kept in
@@ -569,6 +575,7 @@ func (s *Scheduler) dedupLoop() {
 				if req.ref != "" {
 					s.pendingRefs[p] = req.ref
 				}
+				s.publishRepoStatesLocked() // #5433: repo just went dirty.
 				s.mu.Unlock()
 				continue
 			}
@@ -589,6 +596,7 @@ func (s *Scheduler) dedupLoop() {
 			if len(s.inflight) == 0 && s.deadManAt.IsZero() {
 				s.deadManAt = time.Now()
 			}
+			s.publishRepoStatesLocked() // #5433: repo just entered the queue.
 			s.mu.Unlock()
 			s.poke()
 		}
@@ -740,6 +748,67 @@ func (s *Scheduler) memReleaseLoop() {
 // called with s.mu held, immediately after any mutation of s.inflight.
 func (s *Scheduler) publishIndexStateLocked() {
 	indexstate.Set(len(s.inflight))
+	s.publishRepoStatesLocked()
+}
+
+// publishRepoStatesLocked mirrors the scheduler's per-repo index state to the
+// process-global indexstate record so the in-daemon MCP server can answer
+// grafel_index_status WITHOUT a scheduler reference or a group-graph load
+// (#5433). The derivation matches the doc:
+//
+//	inflight[repo]>0      → indexing  (and if also dirty → dirty, the strongest
+//	                        signal: indexing now AND a follow-up already pending)
+//	pendingIndex[repo]    → queued    (enqueued, not yet running)
+//	otherwise             → current
+//
+// A repo is included if the scheduler knows about it at all: it is currently
+// inflight/queued/dirty, OR it has a completed-index record in indexedRepos.
+// Must be called with s.mu held.
+func (s *Scheduler) publishRepoStatesLocked() {
+	// Union of every repo the scheduler has any state for.
+	seen := make(map[string]struct{})
+	add := func(p string) { seen[p] = struct{}{} }
+	for p := range s.inflight {
+		add(p)
+	}
+	for p, v := range s.pendingIndex {
+		if v {
+			add(p)
+		}
+	}
+	for p, v := range s.dirty {
+		if v {
+			add(p)
+		}
+	}
+	for p := range s.indexedRepos {
+		add(p)
+	}
+
+	out := make([]indexstate.RepoState, 0, len(seen))
+	for p := range seen {
+		rs := indexstate.RepoState{Path: p, HeadRef: s.pendingRefs[p]}
+		if st, ok := s.indexedRepos[p]; ok {
+			rs.IndexedRef = st.LastIndexedRef
+		}
+		dirty := s.dirty[p]
+		rs.Dirty = dirty
+		switch {
+		case s.inflight[p] > 0 && dirty:
+			// Indexing now, but changes arrived mid-run → a follow-up is
+			// already pending. Surface the stronger "dirty" signal so an agent
+			// knows the current run will not be the last word.
+			rs.State = indexstate.StateDirty
+		case s.inflight[p] > 0:
+			rs.State = indexstate.StateIndexing
+		case s.pendingIndex[p]:
+			rs.State = indexstate.StateQueued
+		default:
+			rs.State = indexstate.StateCurrent
+		}
+		out = append(out, rs)
+	}
+	indexstate.SetRepoStates(out)
 }
 
 // busyLocked reports whether any indexing-related work is in flight or
@@ -1058,6 +1127,9 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	stats.LastIndex = time.Now()
 	stats.IndexCount++
 	stats.PredictedMB = tok.predictedMB
+	// #5433: record the ref this completed index ran against so
+	// grafel_index_status can report indexed_ref per repo.
+	stats.LastIndexedRef = tok.ref
 	if observedPeakMB > 0 {
 		stats.LastPeakMB = observedPeakMB
 	}

--- a/internal/indexstate/indexstate.go
+++ b/internal/indexstate/indexstate.go
@@ -15,6 +15,8 @@
 package indexstate
 
 import (
+	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -31,6 +33,74 @@ var (
 	// group-algo pass without conflating it with a reactive reindex count.
 	groupAlgoInFlight atomic.Int64
 )
+
+// Per-repo index freshness (#5433). The scheduler is the single writer; it
+// publishes a defensive copy of its per-repo state under its own lock via
+// SetRepoStates. The in-daemon MCP server (grafel_index_status) is the reader
+// and calls RepoStates lock-free-for-the-caller — a single mutex guards the
+// stored slice so a reader never observes a torn write. This is the same
+// import-cycle-avoiding bridge pattern as the global is_indexing flag above:
+// scheduler (sched) and MCP both import this leaf package, neither imports the
+// other.
+const (
+	// StateCurrent — the repo is fully indexed and idle (no queued/in-flight
+	// work and no coalesced dirty marker). An agent gating on its own repo
+	// should treat current (ideally with indexed_ref == head_ref) as "ready".
+	StateCurrent = "current"
+	// StateQueued — an index for this repo is enqueued but not yet running.
+	StateQueued = "queued"
+	// StateIndexing — an index for this repo is running right now.
+	StateIndexing = "indexing"
+	// StateDirty — a reindex is in flight AND further changes arrived during
+	// it, so a follow-up reindex is already pending (#5138 coalescing).
+	StateDirty = "dirty"
+)
+
+// RepoState is one repo's index-freshness slice, mirrored from the scheduler.
+type RepoState struct {
+	// Path is the repo's on-disk path (the scheduler's map key).
+	Path string
+	// State is one of the State* constants.
+	State string
+	// IndexedRef is the git ref the last completed index ran against, or empty
+	// if the repo has never been indexed in this daemon's lifetime.
+	IndexedRef string
+	// HeadRef is the ref captured at the latest enqueue (the ref the pending /
+	// in-flight work targets), or empty when nothing is pending.
+	HeadRef string
+	// Dirty is true when a coalesced follow-up reindex is pending (#5138).
+	Dirty bool
+}
+
+var (
+	repoStatesMu sync.RWMutex
+	repoStates   []RepoState
+)
+
+// SetRepoStates replaces the published per-repo index-state snapshot. The
+// scheduler calls this under its own lock immediately after publishing the
+// global in-flight count; it passes a freshly built slice (not an alias of any
+// internal map) so the stored value is safe to hand to readers. Idempotent and
+// safe to call from any goroutine.
+func SetRepoStates(states []RepoState) {
+	cp := make([]RepoState, len(states))
+	copy(cp, states)
+	repoStatesMu.Lock()
+	repoStates = cp
+	repoStatesMu.Unlock()
+}
+
+// RepoStates returns a copy of the current per-repo index-state snapshot,
+// sorted by Path for determinism. Lock-free for the caller's downstream use
+// (it gets its own slice). Safe to call from an MCP request handler.
+func RepoStates() []RepoState {
+	repoStatesMu.RLock()
+	out := make([]RepoState, len(repoStates))
+	copy(out, repoStates)
+	repoStatesMu.RUnlock()
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
 
 // GroupAlgoBegin records the start of a group-algorithm pass. Safe to call from
 // any goroutine; balanced by GroupAlgoEnd (deferred at the call site).

--- a/internal/indexstate/repostates_5433_test.go
+++ b/internal/indexstate/repostates_5433_test.go
@@ -1,0 +1,38 @@
+package indexstate
+
+import "testing"
+
+// TestSetRepoStatesDefensiveCopyAndSort verifies SetRepoStates stores a copy
+// (mutating the caller's slice afterwards does not corrupt the published view)
+// and RepoStates returns Path-sorted rows.
+func TestSetRepoStatesDefensiveCopyAndSort(t *testing.T) {
+	in := []RepoState{
+		{Path: "/b", State: StateCurrent},
+		{Path: "/a", State: StateIndexing},
+	}
+	SetRepoStates(in)
+	// Mutate the caller's slice after publishing — must not affect the snapshot.
+	in[0].State = "MUTATED"
+	in[0].Path = "/zzz"
+
+	got := RepoStates()
+	if len(got) != 2 {
+		t.Fatalf("len=%d want 2", len(got))
+	}
+	if got[0].Path != "/a" || got[1].Path != "/b" {
+		t.Fatalf("not sorted by path: %+v", got)
+	}
+	if got[1].State != StateCurrent {
+		t.Fatalf("defensive copy failed, state=%q", got[1].State)
+	}
+	// Reset for other tests in the package.
+	SetRepoStates(nil)
+}
+
+// TestRepoStatesEmpty verifies the zero-value path returns an empty slice.
+func TestRepoStatesEmpty(t *testing.T) {
+	SetRepoStates(nil)
+	if got := RepoStates(); len(got) != 0 {
+		t.Fatalf("want empty, got %+v", got)
+	}
+}

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -113,6 +113,7 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`grafel_traces`](#grafel_traces) | Process-flow traces (action: list\|get\|follow). |
 | [`grafel_clusters`](#grafel_clusters) | List Louvain communities; group-scoped (can span repos via `repos[]`/`cross_repo`) when the group-algo overlay is applied. |
 | [`grafel_stats`](#grafel_stats) | Corpus-level metrics for the resolved group. |
+| [`grafel_index_status`](#grafel_index_status) | Per-repo index freshness; gate on YOUR repo's state, not global is_indexing. |
 | [`grafel_enrichments`](#grafel_enrichments) | Manage enrichment candidates (action: list\|submit\|reject). |
 | [`grafel_cross_links`](#grafel_cross_links) | Manage cross-repo link candidates (action: list\|accept\|reject). |
 | [`grafel_repairs`](#grafel_repairs) | Manage residual-edge repair queue (action: list\|submit). |
@@ -628,6 +629,58 @@ both mean "every loaded repo".
   "unavailable": ["legacy-tools: open .grafel/graph.json: no such file"]
 }
 ```
+
+`grafel_stats` also includes a `repo_index_states` array (same per-repo shape as
+`grafel_index_status`) when the daemon has per-repo state. For a cheap freshness
+poll that does NOT assemble the group graph, prefer `grafel_index_status`.
+
+---
+
+### `grafel_index_status`
+
+Per-repo index freshness (#5433). **Lightweight**: reads only the scheduler's
+in-memory snapshot — it does NOT load or assemble the group graph, so it is
+cheap to poll on a tight loop.
+
+The global `is_indexing` flag (in `grafel_stats`) is a single process-wide bool:
+an agent that polls it to decide "is my repo ready?" is blocked by **any** repo's
+indexing, including unrelated ones — head-of-line blocking across independent
+repos in multi-agent / multi-worktree setups. This tool exposes **per-repo**
+state so an agent gates on its own repo.
+
+**Gating rule** — an agent should treat its repo as ready when
+`state == "current"` **and** (when both refs are known) `indexed_ref == head_ref`.
+Do **not** gate on the global `is_indexing`.
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `repo` | string | no | — | Filter to repos whose path matches (case-insensitive substring or exact). |
+| `group` | string | no | — | Only return repos in this group. |
+
+**Output** — `state` ∈ `current` \| `queued` \| `indexing` \| `dirty`.
+
+```json
+{
+  "repos": [
+    {
+      "repo": "/Users/me/Projects/upvate_core",
+      "group": "upvate",
+      "state": "current",
+      "indexed_ref": "a1b2c3d",
+      "head_ref": "a1b2c3d",
+      "dirty": false
+    }
+  ],
+  "any_indexing": false
+}
+```
+
+State derivation (from the scheduler maps): `inflight>0` → `indexing` (and if a
+mid-run change also arrived, `dirty`); `pendingIndex`/queued → `queued`;
+otherwise `current`. `head_ref` is the ref captured at the latest enqueue;
+`indexed_ref` is the ref the last completed index ran against.
 
 ---
 

--- a/internal/mcp/index_status.go
+++ b/internal/mcp/index_status.go
@@ -1,0 +1,115 @@
+// grafel_index_status — per-repo index freshness (#5433).
+//
+// The global is_indexing flag (grafel_stats) is a single process-wide bool: an
+// agent that polls it to decide "is my repo ready?" is blocked by ANY repo's
+// indexing, including unrelated ones — head-of-line blocking across independent
+// repos in multi-agent / multi-worktree setups.
+//
+// This tool exposes PER-REPO index state so an agent gates on its own repo. It
+// is deliberately LIGHTWEIGHT: it reads ONLY the scheduler's published snapshot
+// (via the indexstate leaf bridge) and the in-memory registry. It does NOT load
+// or assemble the group graph, so it is cheap to poll on a tight loop.
+package mcp
+
+import (
+	"context"
+	"strings"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// indexStatusRepo is one repo's wire-shape row in grafel_index_status.
+type indexStatusRepo struct {
+	Repo       string `json:"repo"`
+	Group      string `json:"group,omitempty"`
+	State      string `json:"state"`
+	IndexedRef string `json:"indexed_ref,omitempty"`
+	HeadRef    string `json:"head_ref,omitempty"`
+	Dirty      bool   `json:"dirty"`
+}
+
+// indexStatusReply is the grafel_index_status response envelope.
+type indexStatusReply struct {
+	Repos []indexStatusRepo `json:"repos"`
+	// AnyIndexing is true if at least one of the RETURNED repos is currently
+	// indexing or dirty (after filters apply). An agent gating on its own repo
+	// should NOT use this — it should check its repo's state==current — but it
+	// is a convenient summary when no filter is set.
+	AnyIndexing bool `json:"any_indexing"`
+}
+
+// handleIndexStatus answers grafel_index_status. Optional args:
+//
+//	repo  — substring OR exact match against the repo path (case-insensitive).
+//	group — exact group name; only repos in that group are returned.
+//
+// Each row reports state ∈ {current, queued, indexing, dirty}, plus indexed_ref
+// (last completed index's ref) and head_ref (ref the pending/in-flight work
+// targets). An agent gates on its repo with: state=="current" && indexed_ref
+// (when both refs are known) == head_ref.
+func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	repoFilter := strings.TrimSpace(argString(req, "repo", ""))
+	groupFilter := strings.TrimSpace(argString(req, "group", ""))
+
+	// Build a repo-path → group index from the registry so each row can be
+	// attributed to its group. The scheduler keys on the same on-disk path the
+	// registry stores, so an exact-path match attaches the group.
+	pathToGroup := s.repoPathToGroup()
+
+	states := indexstate.RepoStates()
+	out := indexStatusReply{Repos: make([]indexStatusRepo, 0, len(states))}
+	for _, st := range states {
+		group := pathToGroup[st.Path]
+
+		if groupFilter != "" && group != groupFilter {
+			continue
+		}
+		if repoFilter != "" && !repoMatches(st.Path, repoFilter) {
+			continue
+		}
+
+		row := indexStatusRepo{
+			Repo:       st.Path,
+			Group:      group,
+			State:      st.State,
+			IndexedRef: st.IndexedRef,
+			HeadRef:    st.HeadRef,
+			Dirty:      st.Dirty,
+		}
+		out.Repos = append(out.Repos, row)
+		if st.State == indexstate.StateIndexing || st.State == indexstate.StateDirty {
+			out.AnyIndexing = true
+		}
+	}
+	return jsonResult(out), nil
+}
+
+// repoPathToGroup builds a path→group lookup from the registry. A repo path may
+// appear in only one group in practice; if it appears in several, the last one
+// scanned wins (group attribution is best-effort metadata, not a gate).
+func (s *Server) repoPathToGroup() map[string]string {
+	m := map[string]string{}
+	if s == nil || s.State == nil {
+		return m
+	}
+	for gName, grp := range s.State.registry.Groups {
+		for _, r := range grp.Repos {
+			if r.Path != "" {
+				m[r.Path] = gName
+			}
+		}
+	}
+	return m
+}
+
+// repoMatches reports whether the repo path satisfies the caller's repo filter.
+// Matches if the filter equals the path, OR is a case-insensitive substring of
+// it (so "upvate_core" matches "/Users/x/Projects/upvate_core").
+func repoMatches(path, filter string) bool {
+	if path == filter {
+		return true
+	}
+	return strings.Contains(strings.ToLower(path), strings.ToLower(filter))
+}

--- a/internal/mcp/index_status_5433_test.go
+++ b/internal/mcp/index_status_5433_test.go
@@ -1,0 +1,98 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// TestIndexStatusSerializationAndFilter verifies grafel_index_status reads the
+// per-repo scheduler snapshot (via indexstate), attaches the group from the
+// registry, serializes the {repo,group,state,indexed_ref,head_ref,dirty} shape,
+// honours the repo= substring filter, and sets any_indexing (#5433).
+func TestIndexStatusSerializationAndFilter(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
+
+	dir := t.TempDir()
+	rAlpha := filepath.Join(dir, "alpha")
+	rBeta := filepath.Join(dir, "beta")
+	_ = os.MkdirAll(rAlpha, 0o755)
+	_ = os.MkdirAll(rBeta, 0o755)
+	writeGraph(t, rAlpha, fixtureDoc("alpha"))
+	writeGraph(t, rBeta, fixtureDoc("beta"))
+	regPath := makeRegistry(t, dir, map[string]map[string]string{
+		"g": {"alpha": rAlpha, "beta": rBeta},
+	})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	indexstate.SetRepoStates([]indexstate.RepoState{
+		{Path: rAlpha, State: indexstate.StateIndexing, HeadRef: "h-alpha", IndexedRef: "i-alpha"},
+		{Path: rBeta, State: indexstate.StateCurrent, IndexedRef: "i-beta"},
+	})
+
+	parse := func(args map[string]any) map[string]any {
+		t.Helper()
+		res := callTool(t, srv, "grafel_index_status", args)
+		var m map[string]any
+		if err := json.Unmarshal([]byte(resultText(res)), &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return m
+	}
+
+	// No filter: both repos, any_indexing=true (alpha is indexing).
+	all := parse(nil)
+	repos, _ := all["repos"].([]any)
+	if len(repos) != 2 {
+		t.Fatalf("want 2 repos, got %d: %v", len(repos), all["repos"])
+	}
+	if v, _ := all["any_indexing"].(bool); !v {
+		t.Fatalf("any_indexing = %v, want true", all["any_indexing"])
+	}
+	// Verify the alpha row shape including group attribution.
+	var foundAlpha bool
+	for _, r := range repos {
+		row := r.(map[string]any)
+		if row["repo"] == rAlpha {
+			foundAlpha = true
+			if row["group"] != "g" {
+				t.Errorf("alpha group = %v, want g", row["group"])
+			}
+			if row["state"] != indexstate.StateIndexing {
+				t.Errorf("alpha state = %v, want indexing", row["state"])
+			}
+			if row["head_ref"] != "h-alpha" || row["indexed_ref"] != "i-alpha" {
+				t.Errorf("alpha refs = head:%v indexed:%v", row["head_ref"], row["indexed_ref"])
+			}
+		}
+	}
+	if !foundAlpha {
+		t.Fatal("alpha row missing")
+	}
+
+	// repo= substring filter narrows to beta only; any_indexing=false now.
+	beta := parse(map[string]any{"repo": "beta"})
+	bRepos, _ := beta["repos"].([]any)
+	if len(bRepos) != 1 {
+		t.Fatalf("repo=beta want 1 row, got %d", len(bRepos))
+	}
+	if bRepos[0].(map[string]any)["repo"] != rBeta {
+		t.Fatalf("repo=beta returned wrong repo: %v", bRepos[0])
+	}
+	if v, _ := beta["any_indexing"].(bool); v {
+		t.Fatalf("repo=beta any_indexing = true, want false (beta is current)")
+	}
+
+	// group filter that matches nothing → empty.
+	none := parse(map[string]any{"group": "nope"})
+	nRepos, _ := none["repos"].([]any)
+	if len(nRepos) != 0 {
+		t.Fatalf("group=nope want 0 rows, got %d", len(nRepos))
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -813,6 +813,15 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("ref"), // PH1c: optional git ref
 	), s.wrap("grafel_stats", s.handleGraphStats))
 
+	// grafel_index_status — per-repo index freshness (#5433). LIGHTWEIGHT: reads
+	// only the scheduler snapshot (no group-graph load) so agents can poll it to
+	// gate on THEIR repo (state==current) instead of the global is_indexing flag.
+	s.addTool(mcpapi.NewTool("grafel_index_status",
+		mcpapi.WithDescription("Per-repo index freshness; gate on YOUR repo state==current, not is_indexing."),
+		mcpapi.WithString("repo", mcpapi.Description("Filter to repos whose path matches (case-insensitive substring or exact).")),
+		mcpapi.WithAny("group"),
+	), s.wrap("grafel_index_status", s.handleIndexStatus))
+
 	// grafel_enrichments — action: list|submit|reject.
 	s.addTool(mcpapi.NewTool("grafel_enrichments",
 		mcpapi.WithDescription("Enrichment candidates: list=pending, submit=resolve, reject=discard."),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3022,6 +3022,25 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 		}
 	}
 
+	// #5433: surface per-repo index freshness cheaply (the snapshot is already
+	// in process memory — no group-graph load). Agents should prefer the
+	// dedicated lightweight grafel_index_status tool to avoid paying for the
+	// rest of grafel_stats, but expose it here too for one-shot inspection.
+	if rs := indexstate.RepoStates(); len(rs) > 0 {
+		perRepo := make([]map[string]any, 0, len(rs))
+		for _, st := range rs {
+			row := map[string]any{"repo": st.Path, "state": st.State, "dirty": st.Dirty}
+			if st.IndexedRef != "" {
+				row["indexed_ref"] = st.IndexedRef
+			}
+			if st.HeadRef != "" {
+				row["head_ref"] = st.HeadRef
+			}
+			perRepo = append(perRepo, row)
+		}
+		totals["repo_index_states"] = perRepo
+	}
+
 	return jsonResult(totals), nil
 }
 


### PR DESCRIPTION
Closes #5433.

## The footgun

`grafel_stats.is_indexing` is a single **process-global bool** (`internal/indexstate`). An agent that polls it to gate *"is my repo ready?"* is blocked by **any** repo's indexing — including completely unrelated ones.

In multi-agent / multi-worktree setups this **deadlock-waits**: Agent A on repo X waits forever for `is_indexing` to clear because Agent B keeps repo Y reindexing in a loop. Head-of-line blocking across independent repos.

## The fix — per-repo state

Expose **per-repo** index state so an agent gates on its own repo. The data **already existed** in the scheduler — this is low-effort exposure, not new tracking:

| scheduler field (`internal/daemon/sched/scheduler.go`) | meaning |
|---|---|
| `inflight map[string]int64` | indexing right now |
| `pendingIndex map[string]bool` | queued (enqueued, not running) |
| `dirty map[string]bool` | coalesced changes pending mid-run (#5138) |
| `pendingRefs map[string]string` | head ref captured at enqueue |

Derivation: `inflight>0` → `indexing` (also `dirty` → `dirty`); `pendingIndex` → `queued`; else `current`. Read under the scheduler's **existing** mutex — no new lock path.

### Wiring (no import cycle)

The scheduler publishes a `RepoState{Path,State,IndexedRef,HeadRef,Dirty}` snapshot through the existing **`indexstate` leaf-package bridge** — the same mechanism that already carries the global `is_indexing` from scheduler → in-daemon MCP server (MCP can't import `sched`; both import the leaf). `publishIndexStateLocked` now also publishes per-repo state, plus a publish at the enqueue `queued`/`dirty` transitions. The scheduler now also records each completed index's ref (`LastIndexedRef`) so `indexed_ref` is real.

## New tool — `grafel_index_status` (lightweight)

Reads **ONLY** the scheduler snapshot — it does **NOT** load or assemble the group graph — so agents can poll it cheaply on a tight loop. Optional `repo` (substring/exact) + `group` filters.

```json
{
  "repos": [
    {"repo": "/path/the backend repo", "group": "the multi-repo group", "state": "current", "indexed_ref": "a1b2c3d", "head_ref": "a1b2c3d", "dirty": false}
  ],
  "any_indexing": false
}
```

**Gating rule:** agents gate on **their** repo's `state == "current"` (and `indexed_ref == head_ref` where both known) — not the global `is_indexing`.

`grafel_stats` also surfaces a `repo_index_states` array for one-shot inspection (cheap — the snapshot is already in process memory).

## Tests
- State derivation: indexing / queued / dirty / current (direct, no goroutines).
- Live queued→current transition through the real scheduler.
- `indexstate` defensive-copy + Path-sort.
- MCP serialization + `repo` substring filter + `group` filter + `any_indexing`.
- Handshake token-budget audit still passes (per-tool desc ≤80 chars).

`go build ./...`, `go vet`, `gofmt -l` clean. Daemon was **not** run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)