### PR TITLE
refactor(extractors): migrate remaining extractors to ts.Node — Phase 1 complete (B2 #5418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,24 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   derive-macro scan requires. Default builds stay 100% smacker-backed and
   link-safe; mechanical and behavior-preserving — the ruby+php+csharp+rust
   extractor suites pass unchanged (zero fidelity delta).
+- **Migrated the remaining extractors to the `ts.Node` abstraction — B2 Phase 1
+  is complete; every extractor is now binding-agnostic** (#5418, ADR 0023). The
+  final batch covers `cpp` (C/C++), `css`, `dockerfile`, `elixir`, `groovy`,
+  `hcl`, `html`, `kotlin`, `lua`, `proto`, `scala`, `shell` (bash), `swift`,
+  `yaml`, and the `cross/abibridge` test harness. All now traverse the
+  binding-agnostic `internal/treesitter/ts` façade (`ts.Node`/`ts.Tree`) and read
+  the shared `FileInput.TSTree` instead of the concrete `smacker/go-tree-sitter`
+  `*sitter.Node`/`*sitter.Tree`. Extractors with an inline-parse fallback (`cpp`,
+  `dockerfile`, `hcl`, `html`, `yaml`) gained an untagged smacker grammar provider
+  (their `language.go`/`grammar.go`) that the fallback constructs via the ts
+  adapter; the others early-return on a nil tree. The `ts.Node` façade gains a
+  `FieldNameForChild(i int) string` method (added to the interface and BOTH the
+  smacker and official adapters — the official adapter reconciles the `int`↔`uint32`
+  index width) that the Dockerfile extractor's field lookup requires; it compiles
+  under `-tags ts_official` too. With this batch **no extractor imports the root
+  `github.com/smacker/go-tree-sitter` binding** any longer. Default builds stay
+  100% smacker-backed and link-safe; mechanical and behavior-preserving — every
+  migrated extractor suite passes unchanged (zero fidelity delta).
 
 ## [0.1.3] — 2026-06-23
 

--- a/internal/extractors/cpp/exception_flow.go
+++ b/internal/extractors/cpp/exception_flow.go
@@ -45,7 +45,7 @@
 package cpp
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -57,7 +57,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, src []byte, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -68,8 +68,8 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 	// (matching extractFunction's resolveFunctionName leaf), or "" at file
 	// scope. Lambdas inside a function keep the outer function's name so the
 	// edge stays attributed to the host operation.
-	var walk func(n *sitter.Node, enclosingFn string)
-	walk = func(n *sitter.Node, enclosingFn string) {
+	var walk func(n ts.Node, enclosingFn string)
+	walk = func(n ts.Node, enclosingFn string) {
 		if n == nil {
 			return
 		}
@@ -116,7 +116,7 @@ func emitExceptionFlowEdges(root *sitter.Node, src []byte, entities *[]types.Ent
 //
 // An `identifier` child (`throw ex;`) or no expression child (`throw;`) returns
 // "" — a re-throw introduces no new type.
-func cppThrowType(throwNode *sitter.Node, src []byte) string {
+func cppThrowType(throwNode ts.Node, src []byte) string {
 	for i := 0; i < int(throwNode.NamedChildCount()); i++ {
 		c := throwNode.NamedChild(i)
 		if c == nil {
@@ -147,7 +147,7 @@ func cppThrowType(throwNode *sitter.Node, src []byte) string {
 // parameter_declaration's `type` field always names the bare type X regardless
 // of const-qualification or reference/pointer declarators (those are sibling
 // nodes), so reference, pointer, and by-value catches all yield X.
-func cppCatchType(catchNode *sitter.Node, src []byte) string {
+func cppCatchType(catchNode ts.Node, src []byte) string {
 	params := catchNode.ChildByFieldName("parameters")
 	if params == nil {
 		return ""

--- a/internal/extractors/cpp/extractor.go
+++ b/internal/extractors/cpp/extractor.go
@@ -40,7 +40,7 @@ import (
 	"context"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -85,16 +85,19 @@ func (e *CppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		return nil, nil
 	}
 
-	tree := file.Tree
+	tree := file.TSTree
 	if tree == nil {
-		parser := sitter.NewParser()
+		grammar := cppGrammar()
 		if lang == "c" {
-			parser.SetLanguage(cGrammar())
-		} else {
-			parser.SetLanguage(cppGrammar())
+			grammar = cGrammar()
 		}
+		parser, perr := cppAdapter.NewParser(grammar)
+		if perr != nil {
+			return nil, perr
+		}
+		defer parser.Close()
 		var err error
-		tree, err = parser.ParseCtx(ctx, nil, file.Content)
+		tree, err = parser.Parse(file.Content)
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +162,7 @@ func (e *CppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 // `container` is the name of the enclosing class/struct/union (NOT
 // namespace) when we're inside its body — used so methods attach CONTAINS
 // to that container and self-recursion is detected for CALLS dedup.
-func walkStructural(n *sitter.Node, src []byte, path, lang, container string, out *[]types.EntityRecord) {
+func walkStructural(n ts.Node, src []byte, path, lang, container string, out *[]types.EntityRecord) {
 	if n == nil {
 		return
 	}
@@ -370,7 +373,7 @@ func walkStructural(n *sitter.Node, src []byte, path, lang, container string, ou
 
 // findClassBody returns the field_declaration_list child of a class/struct/
 // union specifier, or nil when no body is present (forward declarations).
-func findClassBody(n *sitter.Node) *sitter.Node {
+func findClassBody(n ts.Node) ts.Node {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		if ch.Type() == "field_declaration_list" {
@@ -382,7 +385,7 @@ func findClassBody(n *sitter.Node) *sitter.Node {
 
 // findNamespaceBody returns the declaration_list child of a namespace
 // definition, or nil for namespace alias / anonymous declarations.
-func findNamespaceBody(n *sitter.Node) *sitter.Node {
+func findNamespaceBody(n ts.Node) ts.Node {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		if ch.Type() == "declaration_list" {
@@ -470,7 +473,7 @@ var cppKeywordStop = map[string]bool{
 // identifier — the trailing simple identifier when the call is on a
 // member access (`obj.method`, `ptr->method`) or qualified
 // (`Foo::method`). Self-recursion is dropped.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -511,7 +514,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 //   - qualified_identifier     → `Foo::method` — return the trailing name
 //   - template_function        → `foo<int>()` — return the inner name
 //   - parenthesized_expression → recurse into inner
-func cppCallTarget(call *sitter.Node, src []byte) string {
+func cppCallTarget(call ts.Node, src []byte) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		// Fallback: first non-argument_list child.
@@ -528,7 +531,7 @@ func cppCallTarget(call *sitter.Node, src []byte) string {
 
 // resolveCallee unpacks a function-expression node to its trailing
 // identifier name. Returns "" when the shape is unrecognised.
-func resolveCallee(n *sitter.Node, src []byte) string {
+func resolveCallee(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -583,7 +586,7 @@ func resolveCallee(n *sitter.Node, src []byte) string {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -591,8 +594,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -611,7 +614,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 // ----------------------------------------------------------------
 
 // findFirst returns the first descendant node (depth-first) matching any of the given types.
-func findFirst(root *sitter.Node, types ...string) *sitter.Node {
+func findFirst(root ts.Node, types ...string) ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -619,7 +622,7 @@ func findFirst(root *sitter.Node, types ...string) *sitter.Node {
 	for _, t := range types {
 		typeSet[t] = true
 	}
-	stack := []*sitter.Node{root}
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -638,7 +641,7 @@ func findFirst(root *sitter.Node, types ...string) *sitter.Node {
 // Text helpers
 // ----------------------------------------------------------------
 
-func nodeText(n *sitter.Node, src []byte) string {
+func nodeText(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -650,7 +653,7 @@ func nodeText(n *sitter.Node, src []byte) string {
 	return string(src[s:e])
 }
 
-func nodeLines(n *sitter.Node) (int, int) {
+func nodeLines(n ts.Node) (int, int) {
 	return int(n.StartPoint().Row) + 1, int(n.EndPoint().Row) + 1
 }
 
@@ -663,7 +666,7 @@ func nodeLines(n *sitter.Node) (int, int) {
 // Out-of-line definitions like `void Foo::bar()` capture the qualifier
 // in Metadata["qualified_scope"] = "Foo" so attachOutOfLineContains can
 // later wire a CONTAINS edge from the Foo entity.
-func extractFunction(n *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractFunction(n ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	decl := n.ChildByFieldName("declarator")
 	if decl == nil {
 		return types.EntityRecord{}, false
@@ -693,7 +696,7 @@ func extractFunction(n *sitter.Node, src []byte, path, lang string) (types.Entit
 
 // resolveFunctionName drills through pointer/ref declarators to the
 // function_declarator and returns its identifier.
-func resolveFunctionName(decl *sitter.Node, src []byte) string {
+func resolveFunctionName(decl ts.Node, src []byte) string {
 	if decl == nil {
 		return ""
 	}
@@ -729,7 +732,7 @@ func resolveFunctionName(decl *sitter.Node, src []byte) string {
 // in-class or unqualified definitions returns "". Walks through pointer/
 // reference / function declarators to find a qualified_identifier whose
 // scope child names the qualifier.
-func resolveQualifiedScope(decl *sitter.Node, src []byte) string {
+func resolveQualifiedScope(decl ts.Node, src []byte) string {
 	if decl == nil {
 		return ""
 	}
@@ -753,7 +756,7 @@ func resolveQualifiedScope(decl *sitter.Node, src []byte) string {
 
 // rightmostIdentifier returns the rightmost identifier name in a chain of
 // qualified_identifier / namespace_identifier nodes.
-func rightmostIdentifier(n *sitter.Node, src []byte) string {
+func rightmostIdentifier(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -779,7 +782,7 @@ func rightmostIdentifier(n *sitter.Node, src []byte) string {
 
 // resolveIdentifier extracts the name text from identifier-like nodes,
 // including qualified names (scope_resolution).
-func resolveIdentifier(n *sitter.Node, src []byte) string {
+func resolveIdentifier(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -805,7 +808,7 @@ func resolveIdentifier(n *sitter.Node, src []byte) string {
 }
 
 // extractClassLike handles class_specifier, struct_specifier, union_specifier.
-func extractClassLike(n *sitter.Node, src []byte, path, lang, subtype string) (types.EntityRecord, bool) {
+func extractClassLike(n ts.Node, src []byte, path, lang, subtype string) (types.EntityRecord, bool) {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil {
 		// Anonymous struct/class — skip.
@@ -858,8 +861,8 @@ func extractClassLike(n *sitter.Node, src []byte, path, lang, subtype string) (t
 // cppBaseClasses returns the inherited base classes of a class/struct
 // specifier as []map{"name","access"} where access is the explicit
 // access-specifier ("public"/"protected"/"private") when present.
-func cppBaseClasses(n *sitter.Node, src []byte) []map[string]interface{} {
-	var clause *sitter.Node
+func cppBaseClasses(n ts.Node, src []byte) []map[string]interface{} {
+	var clause ts.Node
 	for i := 0; i < int(n.ChildCount()); i++ {
 		if n.Child(i).Type() == "base_class_clause" {
 			clause = n.Child(i)
@@ -893,7 +896,7 @@ func cppBaseClasses(n *sitter.Node, src []byte) []map[string]interface{} {
 // cppClassMembers walks a field_declaration_list returning the data members
 // (name + type + current access section) and whether the class is abstract
 // (has at least one pure-virtual method, i.e. a `pure_virtual_clause`).
-func cppClassMembers(body *sitter.Node, src []byte) (fields []map[string]interface{}, abstract bool) {
+func cppClassMembers(body ts.Node, src []byte) (fields []map[string]interface{}, abstract bool) {
 	access := "private" // class default; struct/union default is public but
 	// access is tracked relative to the explicit specifiers we see.
 	for i := 0; i < int(body.ChildCount()); i++ {
@@ -937,7 +940,7 @@ func cppClassMembers(body *sitter.Node, src []byte) (fields []map[string]interfa
 
 // cppFirstChildOfType returns the first direct child of n with the given
 // node type, or nil.
-func cppFirstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func cppFirstChildOfType(n ts.Node, typ string) ts.Node {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		if n.Child(i).Type() == typ {
 			return n.Child(i)
@@ -947,7 +950,7 @@ func cppFirstChildOfType(n *sitter.Node, typ string) *sitter.Node {
 }
 
 // extractNamespace extracts a namespace_definition node.
-func extractNamespace(n *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractNamespace(n ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	nameNode := n.ChildByFieldName("name")
 	name := ""
 	if nameNode != nil {
@@ -973,7 +976,7 @@ func extractNamespace(n *sitter.Node, src []byte, path, lang string) (types.Enti
 
 // extractTemplate extracts a template_declaration node.
 // Tries to get the name from the inner declaration (class/function).
-func extractTemplate(n *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractTemplate(n ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	// The body is the last child (after template parameter list).
 	// It can be a function_definition, class_specifier, alias_declaration, etc.
 	name := ""
@@ -1024,7 +1027,7 @@ func extractTemplate(n *sitter.Node, src []byte, path, lang string) (types.Entit
 //   - enumerators:     ordered list of {name, value?} for each enumerator,
 //     where value is the explicit `= <expr>` text when given
 //   - enumerator_count: convenience count
-func extractEnum(n *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractEnum(n ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil {
 		return types.EntityRecord{}, false
@@ -1083,8 +1086,8 @@ func extractEnum(n *sitter.Node, src []byte, path, lang string) (types.EntityRec
 // cppEnumerators returns the ordered enumerators of an enum_specifier as
 // []map{"name","value"} where value is the explicit initialiser text (or
 // absent when the enumerator has no `= <expr>`).
-func cppEnumerators(n *sitter.Node, src []byte) []map[string]interface{} {
-	var list *sitter.Node
+func cppEnumerators(n ts.Node, src []byte) []map[string]interface{} {
+	var list ts.Node
 	for i := 0; i < int(n.ChildCount()); i++ {
 		if n.Child(i).Type() == "enumerator_list" {
 			list = n.Child(i)
@@ -1145,7 +1148,7 @@ func cppEnumerators(n *sitter.Node, src []byte) []map[string]interface{} {
 //
 //	tmpl is the enclosing template_declaration (for span/template params),
 //	cn   is the concept_definition node carrying the concept name.
-func extractConcept(tmpl, cn *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractConcept(tmpl, cn ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	name := ""
 	if nameNode := cn.ChildByFieldName("name"); nameNode != nil {
 		name = nodeText(nameNode, src)
@@ -1181,7 +1184,7 @@ func extractConcept(tmpl, cn *sitter.Node, src []byte, path, lang string) (types
 
 // cppTemplateParams returns the names of a template_declaration's parameters
 // (e.g. `template<class T, int N>` → ["T","N"]).
-func cppTemplateParams(tmpl *sitter.Node, src []byte) []string {
+func cppTemplateParams(tmpl ts.Node, src []byte) []string {
 	list := cppFirstChildOfType(tmpl, "template_parameter_list")
 	if list == nil {
 		return nil
@@ -1213,10 +1216,10 @@ func cppTemplateParams(tmpl *sitter.Node, src []byte) []string {
 //	                              local_name when the include has no
 //	                              prefix.
 //	Properties["imported_name"] — equal to local_name.
-func extractInclude(n *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractInclude(n ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	// preproc_include children: '#include' keyword + path node
 	// path node types: string_literal, system_lib_string
-	var pathNode *sitter.Node
+	var pathNode ts.Node
 	count := int(n.ChildCount())
 	for i := 0; i < count; i++ {
 		child := n.Child(i)
@@ -1271,7 +1274,7 @@ func extractInclude(n *sitter.Node, src []byte, path, lang string) (types.Entity
 // Plain `using namespace std;` is also captured. Returns a SCOPE.Component
 // entity whose Name is the imported leaf. The same Properties contract used
 // for #include is applied (`::` is normalised to `.` for source_module).
-func extractUsing(n *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractUsing(n ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	raw := strings.TrimSpace(nodeText(n, src))
 	// Strip the leading "using" keyword and trailing ";".
 	raw = strings.TrimPrefix(raw, "using")
@@ -1321,7 +1324,7 @@ func extractUsing(n *sitter.Node, src []byte, path, lang string) (types.EntityRe
 
 // extractMacro extracts a preproc_def node.
 // Name is the macro identifier.
-func extractMacro(n *sitter.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
+func extractMacro(n ts.Node, src []byte, path, lang string) (types.EntityRecord, bool) {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil {
 		return types.EntityRecord{}, false

--- a/internal/extractors/cpp/extractor_test.go
+++ b/internal/extractors/cpp/extractor_test.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsc "github.com/smacker/go-tree-sitter/c"
 	tscpp "github.com/smacker/go-tree-sitter/cpp"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/cpp" // trigger init()
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -18,20 +19,26 @@ import (
 // Helpers
 // ----------------------------------------------------------------
 
-func parseCPP(src []byte) *sitter.Tree {
-	p := sitter.NewParser()
-	p.SetLanguage(tscpp.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+func parseCPP(src []byte) ts.Tree {
+	p, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tscpp.GetLanguage()))
+	if err != nil {
+		panic("test helper: cpp parser init failed: " + err.Error())
+	}
+	defer p.Close()
+	tree, err := p.Parse(src)
 	if err != nil {
 		panic("test helper: cpp parse failed: " + err.Error())
 	}
 	return tree
 }
 
-func parseC(src []byte) *sitter.Tree {
-	p := sitter.NewParser()
-	p.SetLanguage(tsc.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+func parseC(src []byte) ts.Tree {
+	p, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsc.GetLanguage()))
+	if err != nil {
+		panic("test helper: c parser init failed: " + err.Error())
+	}
+	defer p.Close()
+	tree, err := p.Parse(src)
 	if err != nil {
 		panic("test helper: c parse failed: " + err.Error())
 	}
@@ -49,7 +56,7 @@ func extractCPP(src, path string) ([]types.EntityRecord, error) {
 		Path:     path,
 		Content:  content,
 		Language: "cpp",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 }
 
@@ -64,7 +71,7 @@ func extractC(src, path string) ([]types.EntityRecord, error) {
 		Path:     path,
 		Content:  content,
 		Language: "c",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 }
 

--- a/internal/extractors/cpp/language.go
+++ b/internal/extractors/cpp/language.go
@@ -1,17 +1,24 @@
 package cpp
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
 	tsc "github.com/smacker/go-tree-sitter/c"
 	tscpp "github.com/smacker/go-tree-sitter/cpp"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
+// C/C++ grammar providers for the extractor's inline-parse fallback (B2 Phase 1,
+// #5418, ADR 0023). The extractor traverses the binding-agnostic ts façade; this
+// is the single place that names a concrete binding. Smacker-backed in both build
+// configurations (no official C/C++ grammar module is wired yet), so the file is
+// untagged: `go build` and `go build -tags ts_official` both compile it unchanged.
+
 // cGrammar returns the tree-sitter grammar for C.
-func cGrammar() *sitter.Language {
-	return tsc.GetLanguage()
-}
+func cGrammar() ts.Language { return tssmacker.WrapLanguage(tsc.GetLanguage()) }
 
 // cppGrammar returns the tree-sitter grammar for C++.
-func cppGrammar() *sitter.Language {
-	return tscpp.GetLanguage()
-}
+func cppGrammar() ts.Language { return tssmacker.WrapLanguage(tscpp.GetLanguage()) }
+
+// cppAdapter is the binding adapter used to construct parsers in the fallback.
+var cppAdapter = tssmacker.New()

--- a/internal/extractors/cpp/struct_fields.go
+++ b/internal/extractors/cpp/struct_fields.go
@@ -3,7 +3,7 @@ package cpp
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -38,7 +38,7 @@ import (
 // (`int* p;`, `char buf[8];`, `T& ref;`) still resolves to its inner
 // field_identifier.
 func emitClassFieldMembers(
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	ownerName, filePath, lang string,
 ) []types.EntityRecord {
@@ -107,7 +107,7 @@ func emitClassFieldMembers(
 // cppFieldNames returns every member name declared by a field_declaration,
 // descending through pointer/array/reference declarator decoration to the
 // inner field_identifier(s). Returns nil for a member function declaration.
-func cppFieldNames(fieldDecl *sitter.Node, src []byte) []string {
+func cppFieldNames(fieldDecl ts.Node, src []byte) []string {
 	var names []string
 	for i := 0; i < int(fieldDecl.ChildCount()); i++ {
 		ch := fieldDecl.Child(i)
@@ -126,7 +126,7 @@ func cppFieldNames(fieldDecl *sitter.Node, src []byte) []string {
 
 // cppDescendantFieldIdentifier returns the first field_identifier reachable
 // from n (used to unwrap pointer/array/reference/init declarator decoration).
-func cppDescendantFieldIdentifier(n *sitter.Node) *sitter.Node {
+func cppDescendantFieldIdentifier(n ts.Node) ts.Node {
 	if n == nil {
 		return nil
 	}

--- a/internal/extractors/cross/abibridge/extractor_test.go
+++ b/internal/extractors/cross/abibridge/extractor_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsc "github.com/smacker/go-tree-sitter/c"
 
 	"github.com/cajasmota/grafel/internal/extractor"
@@ -15,6 +14,8 @@ import (
 	_ "github.com/cajasmota/grafel/internal/extractors/cross/abibridge"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -36,17 +37,20 @@ func loadFixture(t *testing.T, name string) []byte {
 // Pass 3), returning the merged entity slice.
 func extractAll(t *testing.T, path string, content []byte, lang string) []types.EntityRecord {
 	t.Helper()
-	var tree *sitter.Tree
+	var tree ts.Tree
 	if lang == "c" {
-		p := sitter.NewParser()
-		p.SetLanguage(tsc.GetLanguage())
-		tr, err := p.ParseCtx(context.Background(), nil, content)
+		p, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsc.GetLanguage()))
+		if err != nil {
+			t.Fatalf("parser init %s: %v", path, err)
+		}
+		defer p.Close()
+		tr, err := p.Parse(content)
 		if err != nil {
 			t.Fatalf("parse %s: %v", path, err)
 		}
 		tree = tr
 	}
-	in := extractor.FileInput{Path: path, Content: content, Language: lang, Tree: tree}
+	in := extractor.FileInput{Path: path, Content: content, Language: lang, TSTree: tree}
 
 	var out []types.EntityRecord
 	// Pass 1: the language extractor.

--- a/internal/extractors/css/css.go
+++ b/internal/extractors/css/css.go
@@ -31,7 +31,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -86,11 +86,11 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		return entities, nil
 	default:
 		// Plain CSS: tree-sitter parse required.
-		if file.Tree == nil {
+		if file.TSTree == nil {
 			return nil, nil
 		}
 		var entities []types.EntityRecord
-		root := file.Tree.RootNode()
+		root := file.TSTree.RootNode()
 		extractCSS(root, file, &entities)
 		extractor.TagRelationshipsLanguage(entities, "css")
 		extractor.TagEntitiesLanguage(entities, "css")
@@ -99,13 +99,13 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 }
 
 // extractCSS traverses the CSS tree collecting all entity types.
-func extractCSS(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func extractCSS(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	// Collect selectors, keyframes, at_rules in one pass.
 	seenVars := make(map[string]bool)
 	walkCSS(root, file, seenVars, out)
 }
 
-func walkCSS(node *sitter.Node, file extractor.FileInput, seenVars map[string]bool, out *[]types.EntityRecord) {
+func walkCSS(node ts.Node, file extractor.FileInput, seenVars map[string]bool, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -138,14 +138,14 @@ func walkCSS(node *sitter.Node, file extractor.FileInput, seenVars map[string]bo
 	}
 }
 
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
 	return string(src[node.StartByte():node.EndByte()])
 }
 
-func childByType(node *sitter.Node, types ...string) *sitter.Node {
+func childByType(node ts.Node, types ...string) ts.Node {
 	typeSet := make(map[string]bool, len(types))
 	for _, t := range types {
 		typeSet[t] = true
@@ -159,7 +159,7 @@ func childByType(node *sitter.Node, types ...string) *sitter.Node {
 	return nil
 }
 
-func buildSelector(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildSelector(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	selectorsNode := childByType(node, "selectors")
 	if selectorsNode == nil {
 		return types.EntityRecord{}, false
@@ -184,7 +184,7 @@ func buildSelector(node *sitter.Node, file extractor.FileInput) (types.EntityRec
 	}, true
 }
 
-func buildKeyframe(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildKeyframe(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	nameNode := childByType(node, "keyframes_name")
 	name := "?"
 	if nameNode != nil {
@@ -203,7 +203,7 @@ func buildKeyframe(node *sitter.Node, file extractor.FileInput) (types.EntityRec
 	}, true
 }
 
-func buildAtRule(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildAtRule(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	kwNode := childByType(node, "at_keyword")
 	if kwNode == nil {
 		return types.EntityRecord{}, false
@@ -240,7 +240,7 @@ func buildAtRule(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 //
 // Media queries trailing the directive (e.g. `screen`, `print`) are
 // ignored — they don't change the import target.
-func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	module := importModuleRef(node, file.Content)
 	if module == "" {
 		return types.EntityRecord{}, false
@@ -266,7 +266,7 @@ func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 // importModuleRef extracts the imported module path from an import_statement
 // node, handling both bare-string and url(...) forms. Returns "" if no
 // module ref can be located.
-func importModuleRef(node *sitter.Node, src []byte) string {
+func importModuleRef(node ts.Node, src []byte) string {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch == nil {
@@ -290,7 +290,7 @@ func importModuleRef(node *sitter.Node, src []byte) string {
 
 // unquoteStringValue strips the surrounding "" or ” quote tokens from a
 // tree-sitter string_value node and returns the inner text.
-func unquoteStringValue(node *sitter.Node, src []byte) string {
+func unquoteStringValue(node ts.Node, src []byte) string {
 	raw := nodeText(node, src)
 	raw = strings.TrimSpace(raw)
 	if len(raw) >= 2 {
@@ -302,7 +302,7 @@ func unquoteStringValue(node *sitter.Node, src []byte) string {
 	return raw
 }
 
-func buildVariable(node *sitter.Node, file extractor.FileInput, seen map[string]bool) (types.EntityRecord, bool) {
+func buildVariable(node ts.Node, file extractor.FileInput, seen map[string]bool) (types.EntityRecord, bool) {
 	propNode := childByType(node, "property_name")
 	if propNode == nil {
 		return types.EntityRecord{}, false

--- a/internal/extractors/css/css_test.go
+++ b/internal/extractors/css/css_test.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tscss "github.com/smacker/go-tree-sitter/css"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/css"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tscss.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tscss.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -49,7 +53,7 @@ func TestCSSExtractor_Selectors(t *testing.T) {
 		Path:     "styles.css",
 		Content:  []byte(src),
 		Language: "css",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -82,7 +86,7 @@ func TestCSSExtractor_CSSVariables(t *testing.T) {
 		Path:     "vars.css",
 		Content:  []byte(src),
 		Language: "css",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -112,7 +116,7 @@ func TestCSSExtractor_Keyframes(t *testing.T) {
 		Path:     "anim.css",
 		Content:  []byte(src),
 		Language: "css",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/css/relationships_test.go
+++ b/internal/extractors/css/relationships_test.go
@@ -63,7 +63,7 @@ body { color: red; }
 		Path:     "main.css",
 		Content:  []byte(src),
 		Language: "css",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -176,7 +176,7 @@ func TestCSSExtractor_NoCalls(t *testing.T) {
 	tree := parseForTest(t, cssSrc)
 	ext, _ := extractor.Get("css")
 	entities, _ := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "x.css", Content: []byte(cssSrc), Language: "css", Tree: tree,
+		Path: "x.css", Content: []byte(cssSrc), Language: "css", TSTree: tree,
 	})
 	for _, e := range entities {
 		for _, r := range e.Relationships {
@@ -206,7 +206,7 @@ $x: 1;
 		var input extractor.FileInput
 		input = extractor.FileInput{Path: path, Content: src, Language: "css"}
 		if path == "a.css" {
-			input.Tree = parseForTest(t, string(src))
+			input.TSTree = parseForTest(t, string(src))
 		}
 		entities, _ := ext.Extract(context.Background(), input)
 		for _, e := range entities {

--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -21,8 +21,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tsdockerfile "github.com/smacker/go-tree-sitter/dockerfile"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -50,7 +49,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	)
 	defer span.End()
 
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		span.SetAttributes(
 			attribute.Int("file_line_count", 0),
 			attribute.Int("entity_count", 0),
@@ -60,12 +59,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	}
 
 	// Reuse pre-parsed tree or parse inline.
-	tree := file.Tree
+	tree := file.TSTree
 	if tree == nil {
-		parser := sitter.NewParser()
-		parser.SetLanguage(tsdockerfile.GetLanguage())
+		parser, perr := dockerfileAdapter.NewParser(dockerfileGrammar())
+		if perr != nil {
+			return nil, perr
+		}
+		defer parser.Close()
 		var err error
-		tree, err = parser.ParseCtx(ctx, nil, file.Content)
+		tree, err = parser.Parse(file.Content)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +119,7 @@ type dockerfileData struct {
 }
 
 // buildDockerfileEntity walks the CST and returns a single file-level entity.
-func buildDockerfileEntity(root *sitter.Node, file extractor.FileInput) (types.EntityRecord, int) {
+func buildDockerfileEntity(root ts.Node, file extractor.FileInput) (types.EntityRecord, int) {
 	if root == nil {
 		return types.EntityRecord{}, 0
 	}
@@ -233,7 +235,7 @@ func buildProperties(d *dockerfileData) map[string]string {
 
 // collectFrom processes a FROM instruction: accumulates stage metadata and
 // emits an IMPORTS edge (file → base-image).
-func collectFrom(node *sitter.Node, file extractor.FileInput, currentStage *string, d *dockerfileData) {
+func collectFrom(node ts.Node, file extractor.FileInput, currentStage *string, d *dockerfileData) {
 	spec := childByType(node, "image_spec")
 	if spec == nil {
 		return
@@ -288,14 +290,14 @@ func collectFrom(node *sitter.Node, file extractor.FileInput, currentStage *stri
 	})
 }
 
-func collectRun(node *sitter.Node, file extractor.FileInput, d *dockerfileData) {
+func collectRun(node ts.Node, file extractor.FileInput, d *dockerfileData) {
 	sig := strings.TrimSpace(nodeText(node, file.Content))
 	if sig != "" {
 		d.runCommands = append(d.runCommands, sig)
 	}
 }
 
-func collectCopy(node *sitter.Node, file extractor.FileInput, currentStage string, d *dockerfileData) {
+func collectCopy(node ts.Node, file extractor.FileInput, currentStage string, d *dockerfileData) {
 	sig := strings.TrimSpace(nodeText(node, file.Content))
 	if sig != "" {
 		d.copyInstructions = append(d.copyInstructions, sig)
@@ -335,14 +337,14 @@ func collectCopy(node *sitter.Node, file extractor.FileInput, currentStage strin
 	}
 }
 
-func collectAdd(node *sitter.Node, file extractor.FileInput, d *dockerfileData) {
+func collectAdd(node ts.Node, file extractor.FileInput, d *dockerfileData) {
 	sig := strings.TrimSpace(nodeText(node, file.Content))
 	if sig != "" {
 		d.copyInstructions = append(d.copyInstructions, sig)
 	}
 }
 
-func collectExpose(node *sitter.Node, file extractor.FileInput, d *dockerfileData) {
+func collectExpose(node ts.Node, file extractor.FileInput, d *dockerfileData) {
 	portNode := childByType(node, "expose_port")
 	if portNode == nil {
 		return
@@ -353,7 +355,7 @@ func collectExpose(node *sitter.Node, file extractor.FileInput, d *dockerfileDat
 	}
 }
 
-func collectEnv(node *sitter.Node, file extractor.FileInput, d *dockerfileData) {
+func collectEnv(node ts.Node, file extractor.FileInput, d *dockerfileData) {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch == nil || ch.Type() != "env_pair" {
@@ -370,7 +372,7 @@ func collectEnv(node *sitter.Node, file extractor.FileInput, d *dockerfileData) 
 	}
 }
 
-func collectArg(node *sitter.Node, file extractor.FileInput, d *dockerfileData) {
+func collectArg(node ts.Node, file extractor.FileInput, d *dockerfileData) {
 	nameNode := childByField(node, "name")
 	if nameNode == nil {
 		return
@@ -381,7 +383,7 @@ func collectArg(node *sitter.Node, file extractor.FileInput, d *dockerfileData) 
 	}
 }
 
-func collectEntrypointOrCmd(node *sitter.Node, file extractor.FileInput, instruction string, d *dockerfileData) {
+func collectEntrypointOrCmd(node ts.Node, file extractor.FileInput, instruction string, d *dockerfileData) {
 	sig := strings.TrimSpace(nodeText(node, file.Content))
 	if sig == "" {
 		sig = instruction
@@ -392,7 +394,7 @@ func collectEntrypointOrCmd(node *sitter.Node, file extractor.FileInput, instruc
 // ── tree-sitter helpers ───────────────────────────────────────────────────────
 
 // nodeText returns the UTF-8 text span of a node in the source.
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -400,7 +402,7 @@ func nodeText(node *sitter.Node, src []byte) string {
 }
 
 // childByField returns the first child with the given field name.
-func childByField(node *sitter.Node, field string) *sitter.Node {
+func childByField(node ts.Node, field string) ts.Node {
 	for i := range node.ChildCount() {
 		if node.FieldNameForChild(int(i)) == field {
 			return node.Child(int(i))
@@ -410,7 +412,7 @@ func childByField(node *sitter.Node, field string) *sitter.Node {
 }
 
 // childByType returns the first child with the given node type.
-func childByType(node *sitter.Node, t string) *sitter.Node {
+func childByType(node ts.Node, t string) ts.Node {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch != nil && ch.Type() == t {

--- a/internal/extractors/dockerfile/dockerfile_test.go
+++ b/internal/extractors/dockerfile/dockerfile_test.go
@@ -5,26 +5,30 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsdockerfile "github.com/smacker/go-tree-sitter/dockerfile"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/dockerfile"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsdockerfile.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsdockerfile.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
 	return tree
 }
 
-func extractEntities(t *testing.T, path, src string, tree *sitter.Tree) []types.EntityRecord {
+func extractEntities(t *testing.T, path, src string, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	ext, ok := extractor.Get("dockerfile")
 	if !ok {
@@ -34,7 +38,7 @@ func extractEntities(t *testing.T, path, src string, tree *sitter.Tree) []types.
 		Path:     path,
 		Content:  []byte(src),
 		Language: "dockerfile",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -85,7 +89,7 @@ func TestDockerfileExtractor_NilTree(t *testing.T) {
 		Path:     "Dockerfile",
 		Content:  []byte("FROM ubuntu:22.04\n"),
 		Language: "dockerfile",
-		Tree:     nil, // nil tree → empty result per spec
+		TSTree:   nil, // nil tree → empty result per spec
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/dockerfile/grammar.go
+++ b/internal/extractors/dockerfile/grammar.go
@@ -1,0 +1,19 @@
+package dockerfile
+
+import (
+	tsdockerfile "github.com/smacker/go-tree-sitter/dockerfile"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
+)
+
+// Dockerfile grammar provider for the extractor's inline-parse fallback (B2
+// Phase 1, #5418, ADR 0023). The extractor traverses the binding-agnostic ts
+// façade; this is the single place that names a concrete binding. Smacker-backed
+// in both build configurations (no official Dockerfile grammar module is wired
+// yet), so the file is untagged: `go build` and `go build -tags ts_official`
+// both compile it unchanged.
+
+func dockerfileGrammar() ts.Language { return tssmacker.WrapLanguage(tsdockerfile.GetLanguage()) }
+
+var dockerfileAdapter = tssmacker.New()

--- a/internal/extractors/elixir/elixir.go
+++ b/internal/extractors/elixir/elixir.go
@@ -37,7 +37,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -55,7 +55,7 @@ func (e *Extractor) Language() string { return "elixir" }
 
 // Extract walks the tree-sitter CST and returns entity records.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -65,11 +65,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	walkNode(file.Tree.RootNode(), file, &entities)
+	walkNode(file.TSTree.RootNode(), file, &entities)
 	// Epic #3628 — error_flow: emit THROWS / CATCHES edges from def/defp
 	// bodies to the shared SCOPE.ExceptionType convergence node for typed
 	// `raise Type` / `rescue e in [Type]` shapes.
-	emitExceptionFlowEdges(file.Tree.RootNode(), file, &entities)
+	emitExceptionFlowEdges(file.TSTree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "elixir")
 	extractor.TagEntitiesLanguage(entities, "elixir")
@@ -82,7 +82,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // def/defp declared inside the body, every def body is scanned for `call`
 // nodes that yield CALLS edges, and the four import forms (alias/import/
 // use/require) emit IMPORTS entities with the property contract.
-func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walkNode(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -143,7 +143,7 @@ func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRe
 
 // handleModule emits a SCOPE.Component for defmodule/defprotocol and walks
 // its body, then attaches a CONTAINS edge per def/defp found inside.
-func handleModule(node *sitter.Node, file extractor.FileInput, subtype string, out *[]types.EntityRecord) {
+func handleModule(node ts.Node, file extractor.FileInput, subtype string, out *[]types.EntityRecord) {
 	rec, ok := buildModule(node, file, subtype)
 	if !ok {
 		// Still descend so nested entities aren't lost.
@@ -182,7 +182,7 @@ func handleModule(node *sitter.Node, file extractor.FileInput, subtype string, o
 }
 
 // findDoBlock returns the `do_block` child of a call node, or nil.
-func findDoBlock(node *sitter.Node) *sitter.Node {
+func findDoBlock(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "do_block" {
@@ -198,7 +198,7 @@ func findDoBlock(node *sitter.Node) *sitter.Node {
 //   - Inline keyword form `defp foo, do: expr` — body is the `keywords`
 //     subtree under `arguments` (we return the arguments node and let the
 //     caller walk descendants).
-func findDefBody(node *sitter.Node) *sitter.Node {
+func findDefBody(node ts.Node) ts.Node {
 	if b := findDoBlock(node); b != nil {
 		return b
 	}
@@ -215,7 +215,7 @@ func findDefBody(node *sitter.Node) *sitter.Node {
 // callHeadName returns the head identifier of a call node — i.e. the first
 // child when it is an `identifier`. Returns "" for dotted heads like
 // `Repo.all` (those are method calls, not def-defining forms).
-func callHeadName(node *sitter.Node, src []byte) string {
+func callHeadName(node ts.Node, src []byte) string {
 	if node.ChildCount() == 0 {
 		return ""
 	}
@@ -259,7 +259,7 @@ var elixirCallStop = map[string]bool{
 //     trailing identifier
 //
 // Self-recursion is dropped. Keywords / def-defining forms are filtered.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -293,7 +293,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 }
 
 // elixirCallTarget resolves the callee name from a `call` node.
-func elixirCallTarget(call *sitter.Node, src []byte) string {
+func elixirCallTarget(call ts.Node, src []byte) string {
 	if call.ChildCount() == 0 {
 		return ""
 	}
@@ -315,7 +315,7 @@ func elixirCallTarget(call *sitter.Node, src []byte) string {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -323,8 +323,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -339,7 +339,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 }
 
 // buildSchema creates a SCOPE.Schema entity for Ecto `schema "table_name" do` calls.
-func buildSchema(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildSchema(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := extractFirstArg(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -361,7 +361,7 @@ func buildSchema(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 }
 
 // buildModule creates a SCOPE.Component entity for defmodule/defprotocol.
-func buildModule(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildModule(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := extractFirstArg(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -380,7 +380,7 @@ func buildModule(node *sitter.Node, file extractor.FileInput, subtype string) (t
 }
 
 // buildFunction creates a SCOPE.Operation entity for def/defp calls.
-func buildFunction(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildFunction(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := extractFunctionName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -415,7 +415,7 @@ func buildFunction(node *sitter.Node, file extractor.FileInput, subtype string) 
 //	Properties["imported_name"] — equal to local_name.
 //	Properties["import_kind"]   — preserved discriminator: "alias",
 //	                              "import", "use", or "require".
-func buildImportRecord(node *sitter.Node, file extractor.FileInput, kind string) (types.EntityRecord, bool) {
+func buildImportRecord(node ts.Node, file extractor.FileInput, kind string) (types.EntityRecord, bool) {
 	raw := extractFirstArg(node, file.Content)
 	if raw == "" {
 		return types.EntityRecord{}, false
@@ -456,7 +456,7 @@ func buildImportRecord(node *sitter.Node, file extractor.FileInput, kind string)
 }
 
 // extractFirstArg returns the text of the first non-keyword argument of a call node.
-func extractFirstArg(node *sitter.Node, src []byte) string {
+func extractFirstArg(node ts.Node, src []byte) string {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if i == 0 {
@@ -478,7 +478,7 @@ func extractFirstArg(node *sitter.Node, src []byte) string {
 }
 
 // extractFunctionName extracts the function name from a def/defp call node.
-func extractFunctionName(node *sitter.Node, src []byte) string {
+func extractFunctionName(node ts.Node, src []byte) string {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if i == 0 {
@@ -506,7 +506,7 @@ func extractFunctionName(node *sitter.Node, src []byte) string {
 }
 
 // extractIdentifier finds the first identifier in a node subtree.
-func extractIdentifier(node *sitter.Node, src []byte) string {
+func extractIdentifier(node ts.Node, src []byte) string {
 	if node.Type() == "identifier" {
 		return string(src[node.StartByte():node.EndByte()])
 	}
@@ -519,7 +519,7 @@ func extractIdentifier(node *sitter.Node, src []byte) string {
 }
 
 // firstLine returns the first line of the node's source text.
-func firstLine(src []byte, node *sitter.Node) string {
+func firstLine(src []byte, node ts.Node) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "\n"); idx >= 0 {
 		return strings.TrimSpace(raw[:idx])

--- a/internal/extractors/elixir/elixir_test.go
+++ b/internal/extractors/elixir/elixir_test.go
@@ -5,19 +5,23 @@ import (
 	"errors"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tselixir "github.com/smacker/go-tree-sitter/elixir"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/elixir"
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tselixir.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tselixir.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -52,7 +56,7 @@ end
 		Path:     "user_controller.ex",
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -103,7 +107,7 @@ end
 		Path:     "foo.ex",
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -144,7 +148,7 @@ end
 		Path:     "mod.ex",
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -177,7 +181,7 @@ end
 		Path:     "mod.ex",
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -212,7 +216,7 @@ end
 		Path:     "foo.ex",
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -240,7 +244,7 @@ func TestElixirExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.ex",
 		Content:  []byte(""),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -257,7 +261,7 @@ func TestElixirExtractor_NilTree(t *testing.T) {
 		Path:     "nil.ex",
 		Content:  []byte("defmodule Foo do\nend"),
 		Language: "elixir",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -291,7 +295,7 @@ end
 		Path:     "printable.ex",
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/elixir/exception_flow.go
+++ b/internal/extractors/elixir/exception_flow.go
@@ -29,7 +29,7 @@
 package elixir
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -42,7 +42,7 @@ import (
 // *entities in place. Safe with nil / empty input. raise / rescue outside any
 // def (module scope) attach to the file entity via EmitExceptionEdges's
 // fallback.
-func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -54,8 +54,8 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 	// enclosing-function scope. We track the nearest def/defp name so each
 	// raise / rescue is attributed to the right SCOPE.Operation (matched by
 	// Name inside EmitExceptionEdges).
-	var walk func(n *sitter.Node, current string)
-	walk = func(n *sitter.Node, current string) {
+	var walk func(n ts.Node, current string)
+	walk = func(n ts.Node, current string) {
 		if n == nil {
 			return
 		}
@@ -115,7 +115,7 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 // NOTE: `reraise err, __STACKTRACE__` is a DIFFERENT call head ("reraise"),
 // never reaches this function, and so emits no edge — honest, since the type
 // is a bound variable.
-func elixirRaiseType(raiseCall *sitter.Node, src []byte) string {
+func elixirRaiseType(raiseCall ts.Node, src []byte) string {
 	args := childOfType(raiseCall, "arguments")
 	if args == nil {
 		return ""
@@ -136,7 +136,7 @@ func elixirRaiseType(raiseCall *sitter.Node, src []byte) string {
 //	_ -> …  /  e -> …                  identifier (untyped catch-all)        → {}
 //
 // Untyped catch-alls and non-alias shapes yield nothing (honest-partial).
-func elixirRescueTypes(rescueBlock *sitter.Node, src []byte) []string {
+func elixirRescueTypes(rescueBlock ts.Node, src []byte) []string {
 	var out []string
 	for i := 0; i < int(rescueBlock.NamedChildCount()); i++ {
 		stab := rescueBlock.NamedChild(i)
@@ -171,7 +171,7 @@ func elixirRescueTypes(rescueBlock *sitter.Node, src []byte) []string {
 // aliasTokens collects exception-module tokens from a rescue RHS that is
 // either a single `alias` or a `list` of `alias` nodes. Non-alias elements
 // are skipped.
-func aliasTokens(n *sitter.Node, src []byte) []string {
+func aliasTokens(n ts.Node, src []byte) []string {
 	switch n.Type() {
 	case "alias":
 		return []string{nodeSrc(n, src)}
@@ -189,7 +189,7 @@ func aliasTokens(n *sitter.Node, src []byte) []string {
 }
 
 // childOfType returns the first direct child of n whose Type() == t, or nil.
-func childOfType(n *sitter.Node, t string) *sitter.Node {
+func childOfType(n ts.Node, t string) ts.Node {
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		if ch != nil && ch.Type() == t {
@@ -200,7 +200,7 @@ func childOfType(n *sitter.Node, t string) *sitter.Node {
 }
 
 // firstNamedChild returns the first named child of n, or nil.
-func firstNamedChild(n *sitter.Node) *sitter.Node {
+func firstNamedChild(n ts.Node) ts.Node {
 	if n.NamedChildCount() == 0 {
 		return nil
 	}
@@ -208,7 +208,7 @@ func firstNamedChild(n *sitter.Node) *sitter.Node {
 }
 
 // nthNamedChild returns the i-th named child of n (0-based), or nil.
-func nthNamedChild(n *sitter.Node, i int) *sitter.Node {
+func nthNamedChild(n ts.Node, i int) ts.Node {
 	if i < 0 || i >= int(n.NamedChildCount()) {
 		return nil
 	}
@@ -216,6 +216,6 @@ func nthNamedChild(n *sitter.Node, i int) *sitter.Node {
 }
 
 // nodeSrc returns the verbatim source text spanned by n.
-func nodeSrc(n *sitter.Node, src []byte) string {
+func nodeSrc(n ts.Node, src []byte) string {
 	return string(src[n.StartByte():n.EndByte()])
 }

--- a/internal/extractors/elixir/exception_flow_test.go
+++ b/internal/extractors/elixir/exception_flow_test.go
@@ -21,7 +21,7 @@ func extractEx(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/elixir/live_fire_test.go
+++ b/internal/extractors/elixir/live_fire_test.go
@@ -26,7 +26,7 @@ func TestLiveFireEx(t *testing.T) {
 		t.Fatal("elixir extractor not registered")
 	}
 	recs, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "lib/accounts.ex", Content: src, Language: "elixir", Tree: res.Tree,
+		Path: "lib/accounts.ex", Content: src, Language: "elixir", TSTree: res.TSTree,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/extractors/elixir/relationships_test.go
+++ b/internal/extractors/elixir/relationships_test.go
@@ -18,7 +18,7 @@ func runElixir(t *testing.T, src string) []types.EntityRecord {
 		Path:     "test.ex",
 		Content:  []byte(src),
 		Language: "elixir",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -34,7 +34,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -52,11 +52,11 @@ func (e *Extractor) Language() string { return "groovy" }
 
 // Extract walks the tree-sitter CST and returns entity records.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	imports := collectImports(root, file.Content)
 	var entities []types.EntityRecord
 	// Issue #372: emit IMPORTS edges as standalone SCOPE.Component records
@@ -71,11 +71,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 // walkGroovy performs a depth-first traversal collecting entity nodes.
 // inClass tracks whether we're inside a class body (for method vs function distinction).
-func walkGroovy(node *sitter.Node, file extractor.FileInput, imports []string, out *[]types.EntityRecord) {
+func walkGroovy(node ts.Node, file extractor.FileInput, imports []string, out *[]types.EntityRecord) {
 	walkGroovyWithContext(node, file, imports, out, false)
 }
 
-func walkGroovyWithContext(node *sitter.Node, file extractor.FileInput, imports []string, out *[]types.EntityRecord, inClass bool) {
+func walkGroovyWithContext(node ts.Node, file extractor.FileInput, imports []string, out *[]types.EntityRecord, inClass bool) {
 	if node == nil {
 		return
 	}
@@ -171,14 +171,14 @@ func walkGroovyWithContext(node *sitter.Node, file extractor.FileInput, imports 
 	}
 }
 
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
 	return string(src[node.StartByte():node.EndByte()])
 }
 
-func childByType(node *sitter.Node, types_ ...string) *sitter.Node {
+func childByType(node ts.Node, types_ ...string) ts.Node {
 	set := make(map[string]bool, len(types_))
 	for _, t := range types_ {
 		set[t] = true
@@ -192,7 +192,7 @@ func childByType(node *sitter.Node, types_ ...string) *sitter.Node {
 	return nil
 }
 
-func buildClass(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildClass(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	nameNode := childByType(node, "identifier")
 	if nameNode == nil {
 		return types.EntityRecord{}, false
@@ -217,7 +217,7 @@ func buildClass(node *sitter.Node, file extractor.FileInput, imports []string) (
 	}, true
 }
 
-func buildMethod(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildMethod(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	name, sig := extractMethodSignature(node, file.Content)
 	if name == "" || name == "?" {
 		return types.EntityRecord{}, false
@@ -240,7 +240,7 @@ func buildMethod(node *sitter.Node, file extractor.FileInput, imports []string) 
 
 // buildFunctionAsMethod handles function_definition nodes inside a class body,
 // treating them as methods with proper signature extraction.
-func buildFunctionAsMethod(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildFunctionAsMethod(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	nameNode := childByType(node, "identifier")
 	if nameNode == nil {
 		return types.EntityRecord{}, false
@@ -267,7 +267,7 @@ func buildFunctionAsMethod(node *sitter.Node, file extractor.FileInput, imports 
 }
 
 // extractGroovySignature extracts the raw signature from a Groovy function/method node.
-func extractGroovySignature(node *sitter.Node, src []byte) string {
+func extractGroovySignature(node ts.Node, src []byte) string {
 	text := nodeText(node, src)
 	// Find the opening brace and take everything before it.
 	braceIdx := strings.Index(text, "{")
@@ -308,7 +308,7 @@ func normalizeMethodSignature(sig string) string {
 	return sig
 }
 
-func buildFunction(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildFunction(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	nameNode := childByType(node, "identifier")
 	if nameNode == nil {
 		return types.EntityRecord{}, false
@@ -335,7 +335,7 @@ func buildFunction(node *sitter.Node, file extractor.FileInput, imports []string
 }
 
 // extractMethodSignature builds (name, signature) for a method_declaration node.
-func extractMethodSignature(node *sitter.Node, src []byte) (string, string) {
+func extractMethodSignature(node ts.Node, src []byte) (string, string) {
 	nameNode := childByType(node, "identifier")
 	name := "?"
 	if nameNode != nil {
@@ -380,13 +380,13 @@ func extractMethodSignature(node *sitter.Node, src []byte) (string, string) {
 }
 
 // collectImports gathers import_declaration nodes.
-func collectImports(root *sitter.Node, src []byte) []string {
+func collectImports(root ts.Node, src []byte) []string {
 	var imports []string
 	walkForImports(root, src, &imports)
 	return imports
 }
 
-func walkForImports(node *sitter.Node, src []byte, out *[]string) {
+func walkForImports(node ts.Node, src []byte, out *[]string) {
 	if node == nil {
 		return
 	}
@@ -405,7 +405,7 @@ func walkForImports(node *sitter.Node, src []byte, out *[]string) {
 // buildGradleTaskDeclaration detects `task taskName { ... }` — the smacker
 // Groovy grammar parses this as a declaration node whose first identifier
 // child is "task" and second identifier child is the task name.
-func buildGradleTaskDeclaration(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildGradleTaskDeclaration(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	// Collect all direct identifier children.
 	var ids []string
 	for i := range node.ChildCount() {
@@ -443,7 +443,7 @@ func buildGradleTaskDeclaration(node *sitter.Node, file extractor.FileInput, imp
 // smacker grammar parses this as a juxt_function_call whose first identifier
 // child is "apply" and whose argument list contains a map_item with key
 // "plugin" and a string value.
-func buildGradleApplyPlugin(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildGradleApplyPlugin(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	if node.ChildCount() < 2 {
 		return types.EntityRecord{}, false
 	}
@@ -481,7 +481,7 @@ func buildGradleApplyPlugin(node *sitter.Node, file extractor.FileInput, imports
 
 // extractPluginIDFromArgList walks an argument_list node looking for a
 // map_item whose key identifier is "plugin" and returns its string value.
-func extractPluginIDFromArgList(argList *sitter.Node, src []byte) string {
+func extractPluginIDFromArgList(argList ts.Node, src []byte) string {
 	for i := range argList.ChildCount() {
 		child := argList.Child(int(i))
 		if child == nil {
@@ -499,8 +499,8 @@ func extractPluginIDFromArgList(argList *sitter.Node, src []byte) string {
 
 // extractPluginIDFromMapItem checks a map_item node: key must be identifier
 // "plugin", value must be a string node — returns the string content.
-func extractPluginIDFromMapItem(mapItem *sitter.Node, src []byte) string {
-	var keyNode, valNode *sitter.Node
+func extractPluginIDFromMapItem(mapItem ts.Node, src []byte) string {
+	var keyNode, valNode ts.Node
 	for i := range mapItem.ChildCount() {
 		ch := mapItem.Child(int(i))
 		if ch == nil {
@@ -538,7 +538,7 @@ func extractPluginIDFromMapItem(mapItem *sitter.Node, src []byte) string {
 // grammar parses this as a juxt_function_call whose first identifier is "task"
 // and whose argument_list contains a function_call whose first identifier is
 // the task name.
-func buildGradleTaskJuxt(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildGradleTaskJuxt(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	if node.ChildCount() < 2 {
 		return types.EntityRecord{}, false
 	}
@@ -599,7 +599,7 @@ var groovyKeywordStop = map[string]bool{
 // findFunctionBody returns the closure child of a function_definition /
 // method_declaration that holds the call expressions, or nil when the
 // declaration has no body (abstract/interface method).
-func findFunctionBody(node *sitter.Node) *sitter.Node {
+func findFunctionBody(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -618,7 +618,7 @@ func findFunctionBody(node *sitter.Node) *sitter.Node {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -626,8 +626,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -656,7 +656,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 //     Properties[receiver_type]=<Type>.
 //   - function_call      → curried call (`f()(x)`); recurse to find the
 //     leaf method name.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -729,7 +729,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 // dotted_identifier receiver looks like a PascalCase type. This is the
 // no-locals convenience wrapper retained for callers that don't carry a
 // local-variable type table.
-func groovyCallTarget(call *sitter.Node, src []byte) (string, string) {
+func groovyCallTarget(call ts.Node, src []byte) (string, string) {
 	return groovyCallTargetWithLocals(call, src, nil)
 }
 
@@ -739,7 +739,7 @@ func groovyCallTarget(call *sitter.Node, src []byte) (string, string) {
 // initialiser, the target is resolved to `<Type>.<method>` (with
 // receiver_type=<Type>), exactly as a PascalCase static-receiver call is. The
 // table may be nil.
-func groovyCallTargetWithLocals(call *sitter.Node, src []byte, localVarTypes map[string]string) (string, string) {
+func groovyCallTargetWithLocals(call ts.Node, src []byte, localVarTypes map[string]string) (string, string) {
 	if call == nil || call.ChildCount() == 0 {
 		return "", ""
 	}
@@ -755,7 +755,7 @@ func groovyCallTargetWithLocals(call *sitter.Node, src []byte, localVarTypes map
 		// The trailing identifier is the method, the leading identifier
 		// is the receiver. Nested function_call children (`Service().run`)
 		// indicate chained-call receivers — fall back to bare leaf.
-		var idents []*sitter.Node
+		var idents []ts.Node
 		hasNestedCall := false
 		for i := 0; i < int(first.ChildCount()); i++ {
 			ch := first.Child(i)
@@ -804,11 +804,11 @@ func groovyCallTargetWithLocals(call *sitter.Node, src []byte, localVarTypes map
 // operand of a `new` unary_op (i.e. constructor calls `new ClassName(...)`).
 // These are object instantiations, not outbound method CALLS, so they are
 // excluded from the CALLS edge set (#4749).
-func groovyConstructorCalls(body *sitter.Node) map[*sitter.Node]bool {
+func groovyConstructorCalls(body ts.Node) map[ts.Node]bool {
 	if body == nil {
 		return nil
 	}
-	out := map[*sitter.Node]bool{}
+	out := map[ts.Node]bool{}
 	for _, uo := range findAllNodes(body, "unary_op") {
 		hasNew := false
 		for j := 0; j < int(uo.ChildCount()); j++ {
@@ -848,7 +848,7 @@ func groovyConstructorCalls(body *sitter.Node) map[*sitter.Node]bool {
 // the local is left out of the map, so its later receiver calls degrade to the
 // bare leaf and no spurious `<Class>.method` edge is forged (the Java #4682
 // negative-case guarantee).
-func collectGroovyLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
+func collectGroovyLocalVarTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -873,7 +873,7 @@ func collectGroovyLocalVarTypes(body *sitter.Node, src []byte) map[string]string
 
 // groovyDeclVarAndNewType returns (varName, ClassName) for a `declaration` node
 // whose RHS is a `new ClassName(...)` constructor, or ("","") otherwise.
-func groovyDeclVarAndNewType(decl *sitter.Node, src []byte) (string, string) {
+func groovyDeclVarAndNewType(decl ts.Node, src []byte) (string, string) {
 	// Find the `=` position; the var name is the identifier just before it.
 	eqIdx := -1
 	for i := 0; i < int(decl.ChildCount()); i++ {
@@ -885,7 +885,7 @@ func groovyDeclVarAndNewType(decl *sitter.Node, src []byte) (string, string) {
 	if eqIdx <= 0 {
 		return "", ""
 	}
-	var varNode *sitter.Node
+	var varNode ts.Node
 	for i := eqIdx - 1; i >= 0; i-- {
 		if ch := decl.Child(i); ch != nil && ch.Type() == "identifier" {
 			varNode = ch
@@ -911,14 +911,14 @@ func groovyDeclVarAndNewType(decl *sitter.Node, src []byte) (string, string) {
 // groovyNewTypeFromRHS returns the type-name identifier node of a
 // `new ClassName(...)` RHS that follows the `=` at eqIdx in decl, or nil when
 // the RHS is not a direct constructor call.
-func groovyNewTypeFromRHS(decl *sitter.Node, eqIdx int) *sitter.Node {
+func groovyNewTypeFromRHS(decl ts.Node, eqIdx int) ts.Node {
 	for i := eqIdx + 1; i < int(decl.ChildCount()); i++ {
 		ch := decl.Child(i)
 		if ch == nil || ch.Type() != "unary_op" {
 			continue
 		}
 		hasNew := false
-		var ctorCall *sitter.Node
+		var ctorCall ts.Node
 		for j := 0; j < int(ch.ChildCount()); j++ {
 			c := ch.Child(j)
 			if c == nil {
@@ -968,7 +968,7 @@ func isPascalCase(s string) bool {
 //	import foo.something.*      → ToID=foo.something, wildcard=1
 //	import static foo.Util.helper → ToID=foo.Util.helper, import_kind=static
 //	import static foo.Util.*    → ToID=foo.Util,  wildcard=1, import_kind=static
-func buildImportRecords(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func buildImportRecords(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	imports := findAllNodes(root, "groovy_import", "import_declaration")
 	if len(imports) == 0 {
 		return nil
@@ -985,7 +985,7 @@ func buildImportRecords(root *sitter.Node, file extractor.FileInput) []types.Ent
 }
 
 // buildImportRecord builds a single import edge from a groovy_import node.
-func buildImportRecord(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildImportRecord(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	var path string
 	var alias string
 	hasWildcard := false

--- a/internal/extractors/groovy/groovy_grails_gradle_test.go
+++ b/internal/extractors/groovy/groovy_grails_gradle_test.go
@@ -76,7 +76,7 @@ class Application extends GrailsAutoConfiguration {
 		Path:     "grails_application_class.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -100,7 +100,7 @@ class Application extends GrailsAutoConfiguration {
 		Path:     "Application.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -122,7 +122,7 @@ class Application extends GrailsAutoConfiguration {
 		Path:     "Application.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -154,7 +154,7 @@ func TestGrailsApplicationClass_MethodEntities(t *testing.T) {
 		Path:     "Application.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -197,7 +197,7 @@ class MyGrailsService {
 		Path:     "grails_application_lifecycle.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -224,7 +224,7 @@ func TestGrailsServiceMethods_KindAndSubtype(t *testing.T) {
 		Path:     "MyGrailsService.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -255,7 +255,7 @@ apply plugin: 'com.example.my-gradle-plugin'
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -277,7 +277,7 @@ func TestGradlePlugin_ApplyPlugin_Kind(t *testing.T) {
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -306,7 +306,7 @@ func TestGradlePlugin_TaskDeclaration_Basic(t *testing.T) {
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -327,7 +327,7 @@ func TestGradlePlugin_TaskDeclaration_Kind(t *testing.T) {
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -354,7 +354,7 @@ task buildJar(type: Jar) {
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -403,7 +403,7 @@ task integrationTest(dependsOn: compileGroovy) {
 		Path:     "gradle_plugin.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -428,7 +428,7 @@ task build(type: Jar) { }
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -454,7 +454,7 @@ task test { }
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -479,7 +479,7 @@ apply {
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -503,7 +503,7 @@ func TestGradlePlugin_GradlePropertySignature(t *testing.T) {
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -526,7 +526,7 @@ func TestGradlePlugin_PluginIDSignature(t *testing.T) {
 		Path:     "build.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/groovy/groovy_test.go
+++ b/internal/extractors/groovy/groovy_test.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsgroovy "github.com/smacker/go-tree-sitter/groovy"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/groovy"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsgroovy.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsgroovy.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -50,7 +54,7 @@ func TestGroovyExtractor_ClassAndMethods(t *testing.T) {
 		Path:     "UserController.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -92,7 +96,7 @@ func TestGroovyExtractor_TopLevelFunction(t *testing.T) {
 		Path:     "handler.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -135,7 +139,7 @@ func TestGroovyExtractor_Language(t *testing.T) {
 		Path:     "Foo.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/groovy/relationships_test.go
+++ b/internal/extractors/groovy/relationships_test.go
@@ -18,7 +18,7 @@ func runGroovy(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.groovy",
 		Content:  []byte(src),
 		Language: "groovy",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/groovy/types.go
+++ b/internal/extractors/groovy/types.go
@@ -45,7 +45,7 @@ package groovy
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -59,7 +59,7 @@ import (
 // parent is the node whose child list contains both `decl` (at index declIdx)
 // and the body closure — i.e. the enum's lexical container (source_file, a
 // class closure for a nested enum, …).
-func buildGroovyEnumValueSet(parent *sitter.Node, declIdx int, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildGroovyEnumValueSet(parent ts.Node, declIdx int, file extractor.FileInput) (types.EntityRecord, bool) {
 	decl := parent.Child(declIdx)
 	if decl == nil {
 		return types.EntityRecord{}, false
@@ -85,7 +85,7 @@ func buildGroovyEnumValueSet(parent *sitter.Node, declIdx int, file extractor.Fi
 
 // enumHeaderName returns the enum type name when decl is an `enum X` header
 // (`declaration[ identifier("enum"), identifier("X") ]`), or "" otherwise.
-func enumHeaderName(decl *sitter.Node, src []byte) string {
+func enumHeaderName(decl ts.Node, src []byte) string {
 	if decl == nil || decl.Type() != "declaration" {
 		return ""
 	}
@@ -104,7 +104,7 @@ func enumHeaderName(decl *sitter.Node, src []byte) string {
 
 // nextClosureSibling returns the first `closure` node that follows declIdx in
 // parent's child list, skipping anonymous separators, or nil.
-func nextClosureSibling(parent *sitter.Node, declIdx int) *sitter.Node {
+func nextClosureSibling(parent ts.Node, declIdx int) ts.Node {
 	for i := declIdx + 1; i < int(parent.ChildCount()); i++ {
 		ch := parent.Child(i)
 		if ch == nil {
@@ -125,7 +125,7 @@ func nextClosureSibling(parent *sitter.Node, declIdx int) *sitter.Node {
 // collectGroovyEnumMembers walks the enum body closure for constant members.
 // Collection stops at the first `declaration` (an enum field like
 // `double mass`), so the trailing constructor `function_call` is never counted.
-func collectGroovyEnumMembers(body *sitter.Node, src []byte) []extractor.EnumMember {
+func collectGroovyEnumMembers(body ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	seen := map[string]bool{}
 	add := func(name, value string, line int) {
@@ -166,7 +166,7 @@ func collectGroovyEnumMembers(body *sitter.Node, src []byte) []extractor.EnumMem
 // constant such as `ACTIVE(1)` or `HEARTS('red')`. The value is the single
 // leading literal argument (number/string/bool); multi-arg or non-literal
 // constructors keep the constant but drop the value.
-func groovyEnumValuedConst(fc *sitter.Node, src []byte) (string, string) {
+func groovyEnumValuedConst(fc ts.Node, src []byte) (string, string) {
 	nameNode := childByType(fc, "identifier")
 	if nameNode == nil {
 		return "", ""
@@ -198,7 +198,7 @@ func groovyEnumValuedConst(fc *sitter.Node, src []byte) (string, string) {
 
 // collectEnumBareConsts walks a parameter_list (possibly the direct node or a
 // descendant of an ERROR node) collecting bare constant identifiers.
-func collectEnumBareConsts(node *sitter.Node, src []byte, add func(name, value string, line int)) {
+func collectEnumBareConsts(node ts.Node, src []byte, add func(name, value string, line int)) {
 	for _, pl := range findAllNodes(node, "parameter_list") {
 		for i := 0; i < int(pl.ChildCount()); i++ {
 			p := pl.Child(i)
@@ -216,7 +216,7 @@ func collectEnumBareConsts(node *sitter.Node, src []byte, add func(name, value s
 
 // groovyStringLiteralContent returns the inner content of a `string` node,
 // stripping the surrounding quote tokens.
-func groovyStringLiteralContent(node *sitter.Node, src []byte) string {
+func groovyStringLiteralContent(node ts.Node, src []byte) string {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch != nil && ch.Type() == "string_content" {

--- a/internal/extractors/groovy/types_test.go
+++ b/internal/extractors/groovy/types_test.go
@@ -4,26 +4,29 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsgroovy "github.com/smacker/go-tree-sitter/groovy"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
 // extractGroovy parses src and runs the Groovy extractor, returning all records.
 func extractGroovy(t *testing.T, src string) []types.EntityRecord {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsgroovy.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsgroovy.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	recs, err := (&Extractor{}).Extract(context.Background(), extractor.FileInput{
 		Path:    "Sample.groovy",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/hcl/cross_module.go
+++ b/internal/extractors/hcl/cross_module.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -60,7 +60,7 @@ import (
 // name, the consuming attribute, and a derived semantic label. selfRef is the
 // canonical ref of the consuming block (used as the edge FromID and to derive
 // semantics from the consuming resource type).
-func extractCrossModuleRefs(body *sitter.Node, src []byte, path, lang, selfRef string) []types.RelationshipRecord {
+func extractCrossModuleRefs(body ts.Node, src []byte, path, lang, selfRef string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
@@ -70,8 +70,8 @@ func extractCrossModuleRefs(body *sitter.Node, src []byte, path, lang, selfRef s
 
 	// walk descends an attribute value tree carrying the enclosing attribute
 	// key (argName) so the semantic derivation can use the consuming attribute.
-	var walk func(n *sitter.Node, argName string)
-	walk = func(n *sitter.Node, argName string) {
+	var walk func(n ts.Node, argName string)
+	walk = func(n ts.Node, argName string) {
 		if n == nil {
 			return
 		}
@@ -106,8 +106,8 @@ func extractCrossModuleRefs(body *sitter.Node, src []byte, path, lang, selfRef s
 
 	// Walk top-level attributes and nested blocks, tracking the attribute key
 	// that encloses each reference so semantics can use it.
-	var descend func(n *sitter.Node)
-	descend = func(n *sitter.Node) {
+	var descend func(n ts.Node)
+	descend = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -145,7 +145,7 @@ func extractCrossModuleRefs(body *sitter.Node, src []byte, path, lang, selfRef s
 // `module.<name>.<output>` reference (optionally with deeper attribute access,
 // in which case outputName is the first attribute after the module name). It
 // returns ("","") for non-module refs or bare `module.<name>` (no output).
-func moduleOutputRef(expr *sitter.Node, src []byte) (string, string) {
+func moduleOutputRef(expr ts.Node, src []byte) (string, string) {
 	parts := referenceParts(expr, src)
 	if len(parts) >= 3 && parts[0] == "module" {
 		return parts[1], parts[2]

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -31,7 +31,7 @@ import (
 	"context"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -79,12 +79,15 @@ func (e *HCLExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		return nil, nil
 	}
 
-	tree := file.Tree
+	tree := file.TSTree
 	if tree == nil {
-		parser := sitter.NewParser()
-		parser.SetLanguage(hclGrammar())
+		parser, perr := hclAdapter.NewParser(hclGrammar())
+		if perr != nil {
+			return nil, perr
+		}
+		defer parser.Close()
 		var err error
-		tree, err = parser.ParseCtx(ctx, nil, file.Content)
+		tree, err = parser.Parse(file.Content)
 		if err != nil {
 			return nil, err
 		}
@@ -125,12 +128,12 @@ func (e *HCLExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 // walkBody walks a config_file or body node, dispatching top-level blocks.
 // Only top-level blocks are dispatched; nested blocks (e.g., statement inside
 // data) are not emitted as separate entities.
-func walkBody(root *sitter.Node, src []byte, path, lang string, out *[]types.EntityRecord) {
+func walkBody(root ts.Node, src []byte, path, lang string, out *[]types.EntityRecord) {
 	if root == nil {
 		return
 	}
 	// root may be config_file → body, or body directly.
-	var body *sitter.Node
+	var body ts.Node
 	if root.Type() == "config_file" {
 		body = firstChildByType(root, "body")
 	} else if root.Type() == "body" {
@@ -154,7 +157,7 @@ func walkBody(root *sitter.Node, src []byte, path, lang string, out *[]types.Ent
 
 // extractBlock handles a single HCL block node and returns 0–N EntityRecords.
 // Returns multiple records for locals blocks (one per attribute).
-func extractBlock(n *sitter.Node, src []byte, path, lang string) ([]types.EntityRecord, bool) {
+func extractBlock(n ts.Node, src []byte, path, lang string) ([]types.EntityRecord, bool) {
 	// Block structure: identifier [string_lit ...] block_start body block_end
 	blockType := blockTypeIdent(n, src)
 	if blockType == "" {
@@ -187,7 +190,7 @@ func extractBlock(n *sitter.Node, src []byte, path, lang string) ([]types.Entity
 }
 
 // extractResourceBlock: resource "type" "name" → SCOPE.Component / resource
-func extractResourceBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+func extractResourceBlock(n ts.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
 	labels := blockLabels(n, src)
 	if len(labels) < 2 {
 		return nil, false
@@ -264,7 +267,7 @@ func extractResourceBlock(n *sitter.Node, src []byte, path, lang string, start, 
 }
 
 // extractDataBlock: data "type" "name" → SCOPE.Component / data_source
-func extractDataBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+func extractDataBlock(n ts.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
 	labels := blockLabels(n, src)
 	if len(labels) < 2 {
 		return nil, false
@@ -309,7 +312,7 @@ func extractDataBlock(n *sitter.Node, src []byte, path, lang string, start, end 
 }
 
 // extractModuleBlock: module "name" → SCOPE.Component / module
-func extractModuleBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+func extractModuleBlock(n ts.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
 	labels := blockLabels(n, src)
 	if len(labels) < 1 {
 		return nil, false
@@ -365,7 +368,7 @@ func extractModuleBlock(n *sitter.Node, src []byte, path, lang string, start, en
 }
 
 // extractVariableBlock: variable "name" → SCOPE.Schema / variable
-func extractVariableBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+func extractVariableBlock(n ts.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
 	labels := blockLabels(n, src)
 	if len(labels) < 1 {
 		return nil, false
@@ -390,7 +393,7 @@ func extractVariableBlock(n *sitter.Node, src []byte, path, lang string, start, 
 }
 
 // extractOutputBlock: output "name" → SCOPE.Schema / output
-func extractOutputBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+func extractOutputBlock(n ts.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
 	labels := blockLabels(n, src)
 	if len(labels) < 1 {
 		return nil, false
@@ -415,7 +418,7 @@ func extractOutputBlock(n *sitter.Node, src []byte, path, lang string, start, en
 }
 
 // extractProviderBlock: provider "name" → SCOPE.Component / provider
-func extractProviderBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+func extractProviderBlock(n ts.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
 	labels := blockLabels(n, src)
 	if len(labels) < 1 {
 		return nil, false
@@ -440,7 +443,7 @@ func extractProviderBlock(n *sitter.Node, src []byte, path, lang string, start, 
 }
 
 // extractLocalsBlock: locals { key = val ... } → one SCOPE.Schema / local per key
-func extractLocalsBlock(n *sitter.Node, src []byte, path, lang string) ([]types.EntityRecord, bool) {
+func extractLocalsBlock(n ts.Node, src []byte, path, lang string) ([]types.EntityRecord, bool) {
 	body := blockBody(n)
 	if body == nil {
 		return nil, false
@@ -490,7 +493,7 @@ func extractLocalsBlock(n *sitter.Node, src []byte, path, lang string) ([]types.
 //
 // depends_on = [resource.type.name, module.name]
 // The AST: attribute → identifier("depends_on") / expression → collection_value → tuple → expression → ...
-func extractDependsOn(body *sitter.Node, src []byte, fromPath, lang string) []types.RelationshipRecord {
+func extractDependsOn(body ts.Node, src []byte, fromPath, lang string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
@@ -516,7 +519,7 @@ func extractDependsOn(body *sitter.Node, src []byte, fromPath, lang string) []ty
 // The AST path is: attribute → expression → collection_value → tuple →
 // expression* (one per element). Each element expression contains variable_expr
 // and get_attr siblings that form the dotted reference.
-func parseDependsOnTuple(attr *sitter.Node, src []byte, fromPath, lang string) []types.RelationshipRecord {
+func parseDependsOnTuple(attr ts.Node, src []byte, fromPath, lang string) []types.RelationshipRecord {
 	if attr == nil {
 		return nil
 	}
@@ -526,8 +529,8 @@ func parseDependsOnTuple(attr *sitter.Node, src []byte, fromPath, lang string) [
 	// Find all "expression" nodes that are direct children of a "tuple" node.
 	// We walk the full subtree but only emit references for expressions whose
 	// parent is a tuple (list element), not the top-level attribute expression.
-	var collectTupleExprs func(n *sitter.Node)
-	collectTupleExprs = func(n *sitter.Node) {
+	var collectTupleExprs func(n ts.Node)
+	collectTupleExprs = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -563,7 +566,7 @@ func parseDependsOnTuple(attr *sitter.Node, src []byte, fromPath, lang string) [
 
 // resolveReference builds a dotted reference string from an expression node.
 // Handles: variable_expr followed by get_attr children (e.g., aws_iam_role.lambda_role).
-func resolveReference(expr *sitter.Node, src []byte) string {
+func resolveReference(expr ts.Node, src []byte) string {
 	if expr == nil {
 		return ""
 	}
@@ -598,7 +601,7 @@ func resolveReference(expr *sitter.Node, src []byte) string {
 // ----------------------------------------------------------------
 
 // blockTypeIdent returns the block type identifier (first identifier child).
-func blockTypeIdent(block *sitter.Node, src []byte) string {
+func blockTypeIdent(block ts.Node, src []byte) string {
 	if block == nil {
 		return ""
 	}
@@ -614,7 +617,7 @@ func blockTypeIdent(block *sitter.Node, src []byte) string {
 
 // blockLabels returns all string_lit label values for a block (after the type identifier).
 // For `resource "aws_lambda_function" "grafel"` returns ["aws_lambda_function", "grafel"].
-func blockLabels(block *sitter.Node, src []byte) []string {
+func blockLabels(block ts.Node, src []byte) []string {
 	if block == nil {
 		return nil
 	}
@@ -641,7 +644,7 @@ func blockLabels(block *sitter.Node, src []byte) []string {
 }
 
 // stringLitValue extracts the text content of a string_lit node (the template_literal child).
-func stringLitValue(n *sitter.Node, src []byte) string {
+func stringLitValue(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -658,13 +661,13 @@ func stringLitValue(n *sitter.Node, src []byte) string {
 }
 
 // blockBody returns the body child of a block node.
-func blockBody(block *sitter.Node) *sitter.Node {
+func blockBody(block ts.Node) ts.Node {
 	return firstChildByType(block, "body")
 }
 
 // attributeStringValue finds an attribute by key name inside a body node
 // and returns its string value (template_literal).
-func attributeStringValue(body *sitter.Node, key string, src []byte) string {
+func attributeStringValue(body ts.Node, key string, src []byte) string {
 	if body == nil {
 		return ""
 	}
@@ -686,12 +689,12 @@ func attributeStringValue(body *sitter.Node, key string, src []byte) string {
 
 // extractStringFromAttr extracts the first template_literal string value
 // from an attribute node's expression subtree.
-func extractStringFromAttr(attr *sitter.Node, src []byte) string {
+func extractStringFromAttr(attr ts.Node, src []byte) string {
 	if attr == nil {
 		return ""
 	}
 	// Walk the expression subtree for template_literal.
-	stack := []*sitter.Node{attr}
+	stack := []ts.Node{attr}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -712,7 +715,7 @@ func extractStringFromAttr(attr *sitter.Node, src []byte) string {
 // ----------------------------------------------------------------
 
 // firstChildByType returns the first child of n with the given type.
-func firstChildByType(n *sitter.Node, typ string) *sitter.Node {
+func firstChildByType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -727,7 +730,7 @@ func firstChildByType(n *sitter.Node, typ string) *sitter.Node {
 }
 
 // nodeText returns the source text for a node.
-func nodeText(n *sitter.Node, src []byte) string {
+func nodeText(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -740,6 +743,6 @@ func nodeText(n *sitter.Node, src []byte) string {
 }
 
 // nodeLines returns (startLine, endLine) 1-indexed for a node.
-func nodeLines(n *sitter.Node) (int, int) {
+func nodeLines(n ts.Node) (int, int) {
 	return int(n.StartPoint().Row) + 1, int(n.EndPoint().Row) + 1
 }

--- a/internal/extractors/hcl/extractor_test.go
+++ b/internal/extractors/hcl/extractor_test.go
@@ -5,11 +5,12 @@ import (
 	"os"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tshcl "github.com/smacker/go-tree-sitter/hcl"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/hcl" // trigger init()
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -17,10 +18,13 @@ import (
 // Helpers
 // ----------------------------------------------------------------
 
-func parseHCL(src []byte) *sitter.Tree {
-	p := sitter.NewParser()
-	p.SetLanguage(tshcl.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+func parseHCL(src []byte) ts.Tree {
+	p, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tshcl.GetLanguage()))
+	if err != nil {
+		panic("test helper: hcl parser init failed: " + err.Error())
+	}
+	defer p.Close()
+	tree, err := p.Parse(src)
 	if err != nil {
 		panic("test helper: hcl parse failed: " + err.Error())
 	}
@@ -38,7 +42,7 @@ func extractHCL(src, path string) ([]types.EntityRecord, error) {
 		Path:     path,
 		Content:  content,
 		Language: "hcl",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 }
 
@@ -53,7 +57,7 @@ func extractTerraform(src, path string) ([]types.EntityRecord, error) {
 		Path:     path,
 		Content:  content,
 		Language: "terraform",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 }
 

--- a/internal/extractors/hcl/language.go
+++ b/internal/extractors/hcl/language.go
@@ -1,11 +1,19 @@
 package hcl
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
 	tshcl "github.com/smacker/go-tree-sitter/hcl"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-// hclGrammar returns the tree-sitter grammar for HCL.
-func hclGrammar() *sitter.Language {
-	return tshcl.GetLanguage()
-}
+// hclGrammar returns the tree-sitter grammar for HCL for the extractor's
+// inline-parse fallback (B2 Phase 1, #5418, ADR 0023). The extractor traverses
+// the binding-agnostic ts façade; this is the single place that names a concrete
+// binding. Smacker-backed in both build configurations (no official HCL
+// grammar module is wired yet), so the file is untagged: `go build` and
+// `go build -tags ts_official` both compile it unchanged.
+func hclGrammar() ts.Language { return tssmacker.WrapLanguage(tshcl.GetLanguage()) }
+
+// hclAdapter is the binding adapter used to construct parsers in the fallback.
+var hclAdapter = tssmacker.New()

--- a/internal/extractors/hcl/relationships.go
+++ b/internal/extractors/hcl/relationships.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -77,11 +77,11 @@ func blockReferenceName(blockType string, labels []string, localKey string) stri
 // SCOPE.Component / file entity carrying CONTAINS edges to every top-level
 // block, plus IMPORTS edges for module sources and provider blocks. Returns
 // nil if the file has no top-level blocks.
-func emitFileLevelRelationships(root *sitter.Node, src []byte, path, lang string) *types.EntityRecord {
+func emitFileLevelRelationships(root ts.Node, src []byte, path, lang string) *types.EntityRecord {
 	if root == nil {
 		return nil
 	}
-	var body *sitter.Node
+	var body ts.Node
 	if root.Type() == "config_file" {
 		body = firstChildByType(root, "body")
 	} else if root.Type() == "body" {
@@ -215,15 +215,15 @@ func emitFileLevelRelationships(root *sitter.Node, src []byte, path, lang string
 // refs (the dominant case inside `examples/<x>/main.tf`) resolve cleanly;
 // cross-file refs in a multi-file module fall back to the dynamic-pattern
 // catalog in internal/resolve/refs.go (hclDynamicPatterns).
-func extractCalls(body *sitter.Node, src []byte, path, lang, fromRef, selfRef string) []types.RelationshipRecord {
+func extractCalls(body ts.Node, src []byte, path, lang, fromRef, selfRef string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
 	seen := map[string]struct{}{}
 	var rels []types.RelationshipRecord
 
-	var walk func(n *sitter.Node)
-	walk = func(n *sitter.Node) {
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -284,7 +284,7 @@ func extractCalls(body *sitter.Node, src []byte, path, lang, fromRef, selfRef st
 //	otherwise         → "<parts[0]>.<parts[1]>" (resource ref)
 //
 // Returns "" if there are fewer than 2 parts.
-func canonicalRefFromExpression(expr *sitter.Node, src []byte) string {
+func canonicalRefFromExpression(expr ts.Node, src []byte) string {
 	if expr == nil {
 		return ""
 	}

--- a/internal/extractors/hcl/resource_properties.go
+++ b/internal/extractors/hcl/resource_properties.go
@@ -3,7 +3,7 @@ package hcl
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // resource_properties.go — epic #4194 (iac_resource_property_extraction).
@@ -68,7 +68,7 @@ var curatedResourceScalarKeys = map[string]struct{}{
 // stampResourceScalarProperties scans a resource block body for the curated
 // scalar attributes and stamps them onto rec.Properties. No-op when the body
 // has no matching scalar attributes (Properties stays nil to avoid empty maps).
-func stampResourceScalarProperties(rec *EntityProps, body *sitter.Node, src []byte) {
+func stampResourceScalarProperties(rec *EntityProps, body ts.Node, src []byte) {
 	if body == nil || rec == nil {
 		return
 	}
@@ -113,7 +113,7 @@ type EntityProps struct {
 // quotes are stripped (the template_literal text is returned). For any
 // non-literal value (references, interpolated templates, collections, function
 // calls) it returns ("", false).
-func scalarLiteralValue(attr *sitter.Node, src []byte) (string, bool) {
+func scalarLiteralValue(attr ts.Node, src []byte) (string, bool) {
 	expr := firstChildByType(attr, "expression")
 	if expr == nil {
 		return "", false
@@ -149,7 +149,7 @@ func scalarLiteralValue(attr *sitter.Node, src []byte) (string, bool) {
 // expressions). A string containing ${...} interpolation is a reference-bearing
 // template and is NOT a scalar — those are mined as CALLS edges, so we return
 // ("", false) for them.
-func scalarStringLit(n *sitter.Node, src []byte) (string, bool) {
+func scalarStringLit(n ts.Node, src []byte) (string, bool) {
 	if n == nil {
 		return "", false
 	}

--- a/internal/extractors/hcl/terraform_deep.go
+++ b/internal/extractors/hcl/terraform_deep.go
@@ -3,7 +3,7 @@ package hcl
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -42,7 +42,7 @@ import (
 // reference name of the iteration source if it is an entity reference (e.g.
 // "var.instances", "local.subnets", "module.net"); srcRef is "" for literal
 // counts like `count = 2`.
-func iterationMeta(body *sitter.Node, src []byte) (mode, srcRef string) {
+func iterationMeta(body ts.Node, src []byte) (mode, srcRef string) {
 	if body == nil {
 		return "", ""
 	}
@@ -71,7 +71,7 @@ func iterationMeta(body *sitter.Node, src []byte) (mode, srcRef string) {
 
 // applyIterationMeta records iteration metadata on a block entity and appends
 // a USES edge to the iteration source when it is a resolvable entity ref.
-func applyIterationMeta(rec *types.EntityRecord, body *sitter.Node, src []byte, path, lang, selfRef string) {
+func applyIterationMeta(rec *types.EntityRecord, body ts.Node, src []byte, path, lang, selfRef string) {
 	mode, srcRef := iterationMeta(body, src)
 	if mode == "" {
 		return
@@ -102,7 +102,7 @@ func applyIterationMeta(rec *types.EntityRecord, body *sitter.Node, src []byte, 
 // the dynamic block's name and to draw a CONTAINS edge). The dynamic block's
 // own for_each meta-arg is recognised and its content interpolations become
 // CALLS edges.
-func extractDynamicBlocks(body *sitter.Node, src []byte, path, lang, parentRef string) []types.EntityRecord {
+func extractDynamicBlocks(body ts.Node, src []byte, path, lang, parentRef string) []types.EntityRecord {
 	if body == nil {
 		return nil
 	}
@@ -165,7 +165,7 @@ func extractDynamicBlocks(body *sitter.Node, src []byte, path, lang, parentRef s
 // argument name. This is the headline module-to-module wiring edge: it is
 // distinct from the generic CALLS edge (which only records the reference) by
 // carrying the consuming input arg in its properties.
-func extractModuleDataFlow(body *sitter.Node, src []byte, path, lang, selfRef string) []types.RelationshipRecord {
+func extractModuleDataFlow(body ts.Node, src []byte, path, lang, selfRef string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
@@ -185,8 +185,8 @@ func extractModuleDataFlow(body *sitter.Node, src []byte, path, lang, selfRef st
 			continue
 		}
 		// Walk the attribute value expression for module.X references.
-		var walk func(n *sitter.Node)
-		walk = func(n *sitter.Node) {
+		var walk func(n ts.Node)
+		walk = func(n ts.Node) {
 			if n == nil {
 				return
 			}
@@ -222,15 +222,15 @@ func extractModuleDataFlow(body *sitter.Node, src []byte, path, lang, selfRef st
 // cross-stack DEPENDS_ON edge to the remote-state data source (one per distinct
 // remote-state name). These are deliberately NOT generic data-source CALLS
 // edges: they wire one Terraform stack to another stack's published outputs.
-func extractRemoteStateDeps(body *sitter.Node, src []byte, path, lang, fromRef string) []types.RelationshipRecord {
+func extractRemoteStateDeps(body ts.Node, src []byte, path, lang, fromRef string) []types.RelationshipRecord {
 	if body == nil {
 		return nil
 	}
 	var rels []types.RelationshipRecord
 	seen := map[string]struct{}{}
 
-	var walk func(n *sitter.Node)
-	walk = func(n *sitter.Node) {
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -261,7 +261,7 @@ func extractRemoteStateDeps(body *sitter.Node, src []byte, path, lang, fromRef s
 
 // remoteStateName returns the remote-state name if the expression is a
 // data.terraform_remote_state.<name>.* reference, else "".
-func remoteStateName(expr *sitter.Node, src []byte) string {
+func remoteStateName(expr ts.Node, src []byte) string {
 	parts := referenceParts(expr, src)
 	if len(parts) >= 3 && parts[0] == "data" && parts[1] == "terraform_remote_state" {
 		return parts[2]
@@ -272,7 +272,7 @@ func remoteStateName(expr *sitter.Node, src []byte) string {
 // referenceParts returns the dotted identifier parts of a reference expression
 // (variable_expr + get_attr chain). Shared shape with
 // canonicalRefFromExpression but returns the raw parts.
-func referenceParts(expr *sitter.Node, src []byte) []string {
+func referenceParts(expr ts.Node, src []byte) []string {
 	if expr == nil {
 		return nil
 	}
@@ -305,7 +305,7 @@ func referenceParts(expr *sitter.Node, src []byte) []string {
 // (provider source + version) and backend (type). Returns (record, true) when
 // the block carries at least one provider requirement or a backend; otherwise
 // (zero, false) so empty/version-only terraform blocks stay metadata-only.
-func extractTerraformBlock(n *sitter.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
+func extractTerraformBlock(n ts.Node, src []byte, path, lang string, start, end int) ([]types.EntityRecord, bool) {
 	body := blockBody(n)
 	if body == nil {
 		return nil, false
@@ -388,7 +388,7 @@ func extractTerraformBlock(n *sitter.Node, src []byte, path, lang string, start,
 // string (empty when absent). It handles the object form:
 //
 //	aws = { source = "hashicorp/aws", version = "~> 5.0" }
-func parseRequiredProviders(block *sitter.Node, src []byte) map[string]string {
+func parseRequiredProviders(block ts.Node, src []byte) map[string]string {
 	body := blockBody(block)
 	if body == nil {
 		return nil
@@ -414,7 +414,7 @@ func parseRequiredProviders(block *sitter.Node, src []byte) map[string]string {
 
 // objectAttrString finds `key = "..."` inside an attribute's object value and
 // returns the string literal, else "". Used for required_providers entries.
-func objectAttrString(attr *sitter.Node, key string, src []byte) string {
+func objectAttrString(attr ts.Node, key string, src []byte) string {
 	obj := findFirstByType(attr, "object")
 	if obj == nil {
 		return ""
@@ -438,7 +438,7 @@ func objectAttrString(attr *sitter.Node, key string, src []byte) string {
 }
 
 // firstIdentText returns the text of the first identifier descendant.
-func firstIdentText(n *sitter.Node, src []byte) string {
+func firstIdentText(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -457,10 +457,10 @@ func firstIdentText(n *sitter.Node, src []byte) string {
 // only after the `=` sign (i.e. the value side). Simpler: scan all
 // template_literal descendants and return the last one, which is the value in
 // an object_elem (key side is an identifier, not a string).
-func firstTemplateLiteral(n *sitter.Node, src []byte) string {
+func firstTemplateLiteral(n ts.Node, src []byte) string {
 	var found string
-	var walk func(x *sitter.Node)
-	walk = func(x *sitter.Node) {
+	var walk func(x ts.Node)
+	walk = func(x ts.Node) {
 		if x == nil {
 			return
 		}
@@ -476,7 +476,7 @@ func firstTemplateLiteral(n *sitter.Node, src []byte) string {
 }
 
 // findFirstByType returns the first descendant (DFS) of n with the given type.
-func findFirstByType(n *sitter.Node, typ string) *sitter.Node {
+func findFirstByType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -495,7 +495,7 @@ func findFirstByType(n *sitter.Node, typ string) *sitter.Node {
 // nested blocks and returns the list of recognised meta-block names. These are
 // recorded in resource Metadata so downstream consumers can see that a resource
 // declares lifecycle rules without us synthesising spurious entities.
-func hasLifecycleMetaBlocks(body *sitter.Node, src []byte) []string {
+func hasLifecycleMetaBlocks(body ts.Node, src []byte) []string {
 	if body == nil {
 		return nil
 	}

--- a/internal/extractors/html/extractor.go
+++ b/internal/extractors/html/extractor.go
@@ -29,7 +29,7 @@ import (
 	"regexp"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -159,12 +159,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	}
 
 	// Reuse pre-parsed tree or parse inline.
-	tree := file.Tree
+	tree := file.TSTree
 	if tree == nil {
-		parser := sitter.NewParser()
-		parser.SetLanguage(htmlGrammar())
+		parser, perr := htmlAdapter.NewParser(htmlGrammar())
+		if perr != nil {
+			return nil, perr
+		}
+		defer parser.Close()
 		var err error
-		tree, err = parser.ParseCtx(ctx, nil, file.Content)
+		tree, err = parser.Parse(file.Content)
 		if err != nil {
 			return nil, err
 		}
@@ -188,13 +191,13 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 }
 
 // walkDocument traverses the full document tree, collecting entities from all nodes.
-func walkDocument(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func walkDocument(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	if root == nil {
 		return nil
 	}
 
 	var entities []types.EntityRecord
-	stack := []*sitter.Node{root}
+	stack := []ts.Node{root}
 
 	for len(stack) > 0 {
 		node := stack[len(stack)-1]
@@ -245,7 +248,7 @@ func walkDocument(root *sitter.Node, file extractor.FileInput) []types.EntityRec
 // isFormElement reports whether node is an <element> whose start tag is <form>.
 // Used by walkDocument to avoid re-pushing form children onto the stack after
 // visitElement has already descended into them.
-func isFormElement(node *sitter.Node, file extractor.FileInput) bool {
+func isFormElement(node ts.Node, file extractor.FileInput) bool {
 	startTag := childByType(node, "start_tag")
 	if startTag == nil {
 		return false
@@ -260,7 +263,7 @@ func isFormElement(node *sitter.Node, file extractor.FileInput) bool {
 // visitElement handles <form>, <link rel="stylesheet">, and custom elements.
 // For <form> elements it also descends into children to extract form fields.
 // Also checks attributes for Vue/Angular directives.
-func visitElement(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func visitElement(node ts.Node, file extractor.FileInput) []types.EntityRecord {
 	var recs []types.EntityRecord
 
 	startTag := childByType(node, "start_tag")
@@ -371,12 +374,12 @@ func visitElement(node *sitter.Node, file extractor.FileInput) []types.EntityRec
 // visitFormFields walks the immediate and nested children of a <form> element
 // and emits SCOPE.UIComponent entities for <input>, <select>, <textarea>,
 // and <button> tags.
-func visitFormFields(formNode *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func visitFormFields(formNode ts.Node, file extractor.FileInput) []types.EntityRecord {
 	var recs []types.EntityRecord
 
 	// BFS over all descendants of the form node (not just direct children,
 	// to handle divs/fieldsets wrapping the fields).
-	queue := []*sitter.Node{}
+	queue := []ts.Node{}
 	for i := range formNode.ChildCount() {
 		if ch := formNode.Child(int(i)); ch != nil {
 			queue = append(queue, ch)
@@ -430,7 +433,7 @@ func visitFormFields(formNode *sitter.Node, file extractor.FileInput) []types.En
 // buildFormFieldEntity constructs a SCOPE.UIComponent entity record for a
 // form field element. It prefers the "name" attribute for the entity name,
 // falls back to "id", then to the tag name itself.
-func buildFormFieldEntity(node *sitter.Node, attrSource *sitter.Node, tagName string, file extractor.FileInput) types.EntityRecord {
+func buildFormFieldEntity(node ts.Node, attrSource ts.Node, tagName string, file extractor.FileInput) types.EntityRecord {
 	name := attrValue(attrSource, "name", file.Content)
 	if name == "" {
 		name = attrValue(attrSource, "id", file.Content)
@@ -517,7 +520,7 @@ func extractJinja2Directives(file extractor.FileInput) []types.EntityRecord {
 }
 
 // visitScriptElement handles <script src="..."> includes.
-func visitScriptElement(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func visitScriptElement(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	startTag := childByType(node, "start_tag")
 	if startTag == nil {
 		return types.EntityRecord{}, false
@@ -554,7 +557,7 @@ func visitScriptElement(node *sitter.Node, file extractor.FileInput) (types.Enti
 // The HTML grammar parses these as self_closing_tag nodes rather than as
 // element/script_element wrappers, so we cover them separately here to
 // keep IMPORTS coverage symmetric with the start_tag form.
-func visitSelfClosingTag(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func visitSelfClosingTag(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	tagNameNode := childByType(node, "tag_name")
 	if tagNameNode == nil {
 		return types.EntityRecord{}, false
@@ -678,7 +681,7 @@ func assetBasename(ref string) string {
 // visitTextNode scans text content for {{ }} mustache template expressions.
 // Emits only expressions that contain a dot or pipe (filter) character to
 // reduce noise from simple variable references.
-func visitTextNode(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func visitTextNode(node ts.Node, file extractor.FileInput) []types.EntityRecord {
 	text := nodeText(node, file.Content)
 	if text == "" {
 		return nil
@@ -719,7 +722,7 @@ func visitTextNode(node *sitter.Node, file extractor.FileInput) []types.EntityRe
 
 // visitAttributes walks attribute nodes in a start_tag and emits Vue/Angular
 // directive entities.
-func visitAttributes(startTag *sitter.Node, file extractor.FileInput, tagName string, startLine, endLine int) []types.EntityRecord {
+func visitAttributes(startTag ts.Node, file extractor.FileInput, tagName string, startLine, endLine int) []types.EntityRecord {
 	var recs []types.EntityRecord
 
 	for i := range startTag.ChildCount() {
@@ -771,7 +774,7 @@ func visitAttributes(startTag *sitter.Node, file extractor.FileInput, tagName st
 }
 
 // nodeText returns the UTF-8 text span of a node in the source.
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -784,7 +787,7 @@ func nodeText(node *sitter.Node, src []byte) string {
 }
 
 // childByType returns the first child with the given node type.
-func childByType(node *sitter.Node, t string) *sitter.Node {
+func childByType(node ts.Node, t string) ts.Node {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch != nil && ch.Type() == t {
@@ -796,7 +799,7 @@ func childByType(node *sitter.Node, t string) *sitter.Node {
 
 // attrValue looks up the value of a named attribute in a start_tag node.
 // Returns empty string if the attribute is absent or has no value.
-func attrValue(startTag *sitter.Node, name string, src []byte) string {
+func attrValue(startTag ts.Node, name string, src []byte) string {
 	for i := range startTag.ChildCount() {
 		ch := startTag.Child(int(i))
 		if ch == nil || ch.Type() != "attribute" {

--- a/internal/extractors/html/extractor_test.go
+++ b/internal/extractors/html/extractor_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tshtml "github.com/smacker/go-tree-sitter/html"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/html"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -17,18 +18,21 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
-func parseHTML(t *testing.T, src string) *sitter.Tree {
+func parseHTML(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tshtml.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tshtml.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
 	return tree
 }
 
-func extractEntities(t *testing.T, path, src string, tree *sitter.Tree) []types.EntityRecord {
+func extractEntities(t *testing.T, path, src string, tree ts.Tree) []types.EntityRecord {
 	t.Helper()
 	ext, ok := extractor.Get("html")
 	if !ok {
@@ -38,7 +42,7 @@ func extractEntities(t *testing.T, path, src string, tree *sitter.Tree) []types.
 		Path:     path,
 		Content:  []byte(src),
 		Language: "html",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -110,7 +114,7 @@ func TestHTMLExtractor_NilTree_InlineParse(t *testing.T) {
 		Path:     "index.html",
 		Content:  []byte(src),
 		Language: "html",
-		Tree:     nil, // triggers inline parse
+		TSTree:   nil, // triggers inline parse
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree + inline parse: %v", err)
@@ -470,7 +474,7 @@ func TestHTMLExtractor_InvokedByPipeline(t *testing.T) {
 		Path:     "pipeline.html",
 		Content:  []byte(src),
 		Language: "html",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/html/language.go
+++ b/internal/extractors/html/language.go
@@ -1,12 +1,19 @@
 package html
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
 	tshtml "github.com/smacker/go-tree-sitter/html"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-// htmlGrammar returns the tree-sitter grammar for HTML.
-// Isolated here to keep the CGO import contained.
-func htmlGrammar() *sitter.Language {
-	return tshtml.GetLanguage()
-}
+// htmlGrammar returns the tree-sitter grammar for HTML for the extractor's
+// inline-parse fallback (B2 Phase 1, #5418, ADR 0023). The extractor traverses
+// the binding-agnostic ts façade; this is the single place that names a concrete
+// binding. Smacker-backed in both build configurations (no official HTML
+// grammar module is wired yet), so the file is untagged: `go build` and
+// `go build -tags ts_official` both compile it unchanged.
+func htmlGrammar() ts.Language { return tssmacker.WrapLanguage(tshtml.GetLanguage()) }
+
+// htmlAdapter is the binding adapter used to construct parsers in the fallback.
+var htmlAdapter = tssmacker.New()

--- a/internal/extractors/kotlin/const_valueset.go
+++ b/internal/extractors/kotlin/const_valueset.go
@@ -24,7 +24,7 @@ package kotlin
 // `"literal" to "literal"` pair (any non-literal pair disqualifies the map).
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -34,7 +34,7 @@ import (
 // `enum class`, capturing each entry's first string-literal constructor
 // argument as its value. ok=false when the declaration is not an enum class or
 // has no entries.
-func emitEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func emitEnumValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := firstChildOfType(node, file.Content, "type_identifier")
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -70,7 +70,7 @@ func emitEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.Entity
 // string-literal properties of an object/class body. groupName names the
 // enclosing object/class. ok=false when fewer than two such members exist (a
 // single constant is not an enumerated value-set).
-func emitConstGroupValueSet(body *sitter.Node, file extractor.FileInput, groupName string) (types.EntityRecord, bool) {
+func emitConstGroupValueSet(body ts.Node, file extractor.FileInput, groupName string) (types.EntityRecord, bool) {
 	if body == nil || groupName == "" {
 		return types.EntityRecord{}, false
 	}
@@ -106,7 +106,7 @@ func emitConstGroupValueSet(body *sitter.Node, file extractor.FileInput, groupNa
 // property_declaration (top-level or object/class-level). ok=false when the
 // initialiser is not a mapOf call, has no arguments, or any argument is not a
 // closed `"literal" to "literal"` pair (honest-partial).
-func emitMapValueSet(prop *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func emitMapValueSet(prop ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	varDecl := findChildByTypeKt(prop, "variable_declaration")
 	if varDecl == nil {
 		return types.EntityRecord{}, false
@@ -162,7 +162,7 @@ func emitMapValueSet(prop *sitter.Node, file extractor.FileInput) (types.EntityR
 // infixToPair reads a `"key" to "value"` infix_expression: the operator must be
 // the `to` infix function and both operands must be string literals. ok=false
 // otherwise (a non-`to` infix, or a non-literal operand).
-func infixToPair(infix *sitter.Node, file extractor.FileInput) (key, val string, ok bool) {
+func infixToPair(infix ts.Node, file extractor.FileInput) (key, val string, ok bool) {
 	// Shape: string_literal | simple_identifier("to") | string_literal.
 	var lits []string
 	sawTo := false
@@ -190,7 +190,7 @@ func infixToPair(infix *sitter.Node, file extractor.FileInput) (key, val string,
 
 // constValStringProp reads a `const val NAME = "literal"` property's name and
 // string value. ok=false when the initialiser is not a single string literal.
-func constValStringProp(prop *sitter.Node, file extractor.FileInput) (name, val string, ok bool) {
+func constValStringProp(prop ts.Node, file extractor.FileInput) (name, val string, ok bool) {
 	varDecl := findChildByTypeKt(prop, "variable_declaration")
 	if varDecl == nil {
 		return "", "", false
@@ -210,7 +210,7 @@ func constValStringProp(prop *sitter.Node, file extractor.FileInput) (name, val 
 // property modifier (`modifiers > property_modifier`). The grammar represents
 // the `const` keyword as the property_modifier node's own text (it has no child
 // `const` token), so the modifier text is compared directly.
-func hasConstModifier(prop *sitter.Node, src []byte) bool {
+func hasConstModifier(prop ts.Node, src []byte) bool {
 	mods := findChildByTypeKt(prop, "modifiers")
 	if mods == nil {
 		return false
@@ -229,7 +229,7 @@ func hasConstModifier(prop *sitter.Node, src []byte) bool {
 
 // firstStringArg returns the inner text of the first string_literal inside a
 // value_arguments node, or "" when none is present (a value-less enum entry).
-func firstStringArg(args *sitter.Node, file extractor.FileInput) string {
+func firstStringArg(args ts.Node, file extractor.FileInput) string {
 	if args == nil {
 		return ""
 	}
@@ -248,7 +248,7 @@ func firstStringArg(args *sitter.Node, file extractor.FileInput) string {
 // ktStringText returns the inner text of a Kotlin string_literal node. The
 // grammar exposes the body as `string_content` child(ren); falling back to
 // StripLiteralQuotes covers an empty / interpolated literal.
-func ktStringText(lit *sitter.Node, src []byte) string {
+func ktStringText(lit ts.Node, src []byte) string {
 	if lit == nil {
 		return ""
 	}
@@ -270,7 +270,7 @@ func isMapFactory(fn string) bool {
 
 // findChildByTypeKt returns the first direct child of node with the given type,
 // or nil.
-func findChildByTypeKt(node *sitter.Node, t string) *sitter.Node {
+func findChildByTypeKt(node ts.Node, t string) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -284,7 +284,7 @@ func findChildByTypeKt(node *sitter.Node, t string) *sitter.Node {
 }
 
 // nodeTextKt returns the source text spanned by node.
-func nodeTextKt(node *sitter.Node, src []byte) string {
+func nodeTextKt(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}

--- a/internal/extractors/kotlin/crosspath.go
+++ b/internal/extractors/kotlin/crosspath.go
@@ -37,7 +37,7 @@ package kotlin
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 )
 
 // kotlinCrossCtx is the per-file resolution context derived from the file's
@@ -97,7 +97,7 @@ type kotlinCrossCtx struct {
 // tell from the import alone, so the imported leaf is registered in BOTH
 // importedTypes and importedFuncs and the resolver disambiguates by which
 // package index actually holds the (type, leaf) vs (leaf) binding.
-func buildKotlinCrossCtx(root *sitter.Node, src []byte) *kotlinCrossCtx {
+func buildKotlinCrossCtx(root ts.Node, src []byte) *kotlinCrossCtx {
 	if root == nil {
 		return nil
 	}
@@ -149,7 +149,7 @@ func buildKotlinCrossCtx(root *sitter.Node, src []byte) *kotlinCrossCtx {
 
 // kotlinPackageOfHeader returns the dotted package path of a package_header
 // node (`package com.app.services`), or "" when absent.
-func kotlinPackageOfHeader(n *sitter.Node, src []byte) string {
+func kotlinPackageOfHeader(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -170,7 +170,7 @@ func kotlinPackageOfHeader(n *sitter.Node, src []byte) string {
 // parseKotlinImport returns the dotted import path (wildcard suffix stripped),
 // the `as` alias (or ""), and whether the import is a `.*` wildcard. Mirrors
 // buildImport's text shaping so the two stay consistent.
-func parseKotlinImport(n *sitter.Node, src []byte) (full, alias string, star bool) {
+func parseKotlinImport(n ts.Node, src []byte) (full, alias string, star bool) {
 	raw := strings.TrimSpace(string(src[n.StartByte():n.EndByte()]))
 	raw = strings.TrimPrefix(raw, "import ")
 	raw = strings.TrimSpace(raw)
@@ -215,7 +215,7 @@ type qualifiedKotlinCall struct {
 // to the class method via a (package, Type=that class, leaf) stamp — the #4687
 // local-variable / MockK receiver-typing path. Empty/nil → no typed-local path.
 func (c *kotlinCrossCtx) resolveKotlinQualifiedCall(
-	call *sitter.Node,
+	call ts.Node,
 	src []byte,
 	localNames map[string]bool,
 	recvTypes map[string]string,
@@ -252,7 +252,7 @@ func (c *kotlinCrossCtx) resolveKotlinQualifiedCall(
 // trailing navigation_suffix identifier is the leaf; the segments before it are
 // the receiver path. A statically-qualified receiver maps to (package, type).
 func (c *kotlinCrossCtx) resolveKotlinNavigationCall(
-	nav *sitter.Node,
+	nav ts.Node,
 	src []byte,
 	localNames map[string]bool,
 	recvTypes map[string]string,
@@ -357,7 +357,7 @@ func (c *kotlinCrossCtx) resolveKotlinNavigationCall(
 // call (`val c = makeController()`), a method chain, a non-PascalCase callee, a
 // `mockk()` with no static type argument, a literal, a cast — anything whose
 // class is not statically recoverable. First binding per name wins.
-func kotlinLocalReceiverTypes(body *sitter.Node, src []byte) map[string]string {
+func kotlinLocalReceiverTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -389,7 +389,7 @@ func kotlinLocalReceiverTypes(body *sitter.Node, src []byte) map[string]string {
 // variable_declaration node from a property_declaration
 // (`val a: T = …` / `var a = …`). Returns ("", nil) when no variable_declaration
 // child is present (multi-declaration / destructuring shapes are skipped).
-func kotlinPropertyVarNameNode(decl *sitter.Node, src []byte) (string, *sitter.Node) {
+func kotlinPropertyVarNameNode(decl ts.Node, src []byte) (string, ts.Node) {
 	for i := 0; i < int(decl.ChildCount()); i++ {
 		ch := decl.Child(i)
 		if ch.Type() != "variable_declaration" {
@@ -409,11 +409,11 @@ func kotlinPropertyVarNameNode(decl *sitter.Node, src []byte) (string, *sitter.N
 // explicit type annotation (`a: XController` → "XController"), stripping any
 // package/generic wrapping by taking the first type_identifier descendant of the
 // user_type. Returns "" when the declaration has no explicit type.
-func kotlinUserTypeLeaf(vd *sitter.Node, src []byte) string {
+func kotlinUserTypeLeaf(vd ts.Node, src []byte) string {
 	if vd == nil {
 		return ""
 	}
-	var ut *sitter.Node
+	var ut ts.Node
 	for i := 0; i < int(vd.ChildCount()); i++ {
 		if vd.Child(i).Type() == "user_type" {
 			ut = vd.Child(i)
@@ -438,7 +438,7 @@ func kotlinUserTypeLeaf(vd *sitter.Node, src []byte) string {
 // kotlinPropertyInitCall returns the initializer call_expression of a
 // property_declaration (`val c = XController(svc)` → the `XController(svc)`
 // call_expression), or nil when the RHS is not a direct call expression.
-func kotlinPropertyInitCall(decl *sitter.Node) *sitter.Node {
+func kotlinPropertyInitCall(decl ts.Node) ts.Node {
 	// The RHS is the child following the `=` token. Find `=`, then the next
 	// non-trivial sibling.
 	sawEq := false
@@ -469,7 +469,7 @@ func kotlinPropertyInitCall(decl *sitter.Node) *sitter.Node {
 //
 // Returns "" for any other call (factory/`make()`, lowercase callee, `mockk()`
 // with no type argument, navigation chains) so the receiver stays bare.
-func kotlinConstructedOrMockType(call *sitter.Node, src []byte) string {
+func kotlinConstructedOrMockType(call ts.Node, src []byte) string {
 	if call == nil || call.ChildCount() == 0 {
 		return ""
 	}
@@ -495,7 +495,7 @@ func kotlinConstructedOrMockType(call *sitter.Node, src []byte) string {
 // kotlinCallSuffixTypeArg returns the leaf type_identifier of the first
 // type_arguments projection on a call_expression's call_suffix
 // (`mockk<XController>()` → "XController"), or "" when absent.
-func kotlinCallSuffixTypeArg(call *sitter.Node, src []byte) string {
+func kotlinCallSuffixTypeArg(call ts.Node, src []byte) string {
 	for i := 0; i < int(call.ChildCount()); i++ {
 		cs := call.Child(i)
 		if cs.Type() != "call_suffix" {
@@ -568,7 +568,7 @@ func appendUniqueKt(s []string, v string) []string {
 // expression, a call_expression, an index/element access, a string template,
 // etc.) appears in the receiver chain — those are instance chains the base
 // extractor owns.
-func flattenKotlinNavigation(n *sitter.Node, src []byte) ([]string, bool) {
+func flattenKotlinNavigation(n ts.Node, src []byte) ([]string, bool) {
 	if n == nil {
 		return nil, false
 	}
@@ -577,8 +577,8 @@ func flattenKotlinNavigation(n *sitter.Node, src []byte) ([]string, bool) {
 		return []string{string(src[n.StartByte():n.EndByte()])}, true
 	case "navigation_expression":
 		// navigation_expression → <receiver> navigation_suffix
-		var receiver *sitter.Node
-		var suffix *sitter.Node
+		var receiver ts.Node
+		var suffix ts.Node
 		for i := 0; i < int(n.ChildCount()); i++ {
 			ch := n.Child(i)
 			switch ch.Type() {

--- a/internal/extractors/kotlin/exception_flow.go
+++ b/internal/extractors/kotlin/exception_flow.go
@@ -35,7 +35,7 @@ package kotlin
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -51,7 +51,7 @@ import (
 // file scope (or in a function whose entity was not emitted) fall back to the
 // file entity inside EmitExceptionEdges. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -59,8 +59,8 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 
 	var edges []extractor.ExceptionEdge
 
-	var walk func(n *sitter.Node, enclosingFn string)
-	walk = func(n *sitter.Node, enclosingFn string) {
+	var walk func(n ts.Node, enclosingFn string)
+	walk = func(n ts.Node, enclosingFn string) {
 		if n == nil {
 			return
 		}
@@ -112,7 +112,7 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 // kotlinFunctionName returns the bare declared name of a function_declaration,
 // matching the Name buildOperation emits (Kotlin function entities are not
 // class-qualified), or "" so the edge falls back to the file entity.
-func kotlinFunctionName(fn *sitter.Node, src []byte) string {
+func kotlinFunctionName(fn ts.Node, src []byte) string {
 	if name := strings.TrimSpace(childFieldText(fn, "name", src)); name != "" {
 		return name
 	}
@@ -124,7 +124,7 @@ func kotlinFunctionName(fn *sitter.Node, src []byte) string {
 // (`return`/`break`/`continue`), a bare re-throw of a variable (`throw e`), or
 // a factory call (`throw makeError()` — lowercase callee). Only an explicit
 // `throw <Constructor>(...)` whose callee is a PascalCase type token is taken.
-func kotlinThrowType(jump *sitter.Node, src []byte) string {
+func kotlinThrowType(jump ts.Node, src []byte) string {
 	// jump_expression covers return/throw/break/continue. Require a leading
 	// `throw` keyword token among the (unnamed) children.
 	if !jumpIsThrow(jump) {
@@ -132,7 +132,7 @@ func kotlinThrowType(jump *sitter.Node, src []byte) string {
 	}
 	// The thrown expression is the first named child (a call_expression for
 	// `throw X(...)`).
-	var expr *sitter.Node
+	var expr ts.Node
 	for i := 0; i < int(jump.NamedChildCount()); i++ {
 		if c := jump.NamedChild(i); c != nil {
 			expr = c
@@ -169,7 +169,7 @@ func kotlinThrowType(jump *sitter.Node, src []byte) string {
 
 // jumpIsThrow reports whether a jump_expression is a `throw ...` (vs
 // return/break/continue) by inspecting its leading keyword token.
-func jumpIsThrow(jump *sitter.Node) bool {
+func jumpIsThrow(jump ts.Node) bool {
 	for i := 0; i < int(jump.ChildCount()); i++ {
 		c := jump.Child(i)
 		if c == nil {
@@ -191,7 +191,7 @@ func jumpIsThrow(jump *sitter.Node) bool {
 // (`catch (e: SqlException) { ... }`), taken from its user_type child, or "".
 // Kotlin catch clauses are single-type (no Java-style `A | B` multi-catch), so
 // at most one type is returned.
-func kotlinCatchType(catchBlock *sitter.Node, src []byte) string {
+func kotlinCatchType(catchBlock ts.Node, src []byte) string {
 	ut := firstNamedChildOfType(catchBlock, "user_type")
 	if ut == nil {
 		return ""
@@ -204,7 +204,7 @@ func kotlinCatchType(catchBlock *sitter.Node, src []byte) string {
 // (the @ControllerAdvice / @RestControllerAdvice handler idiom). An
 // @ExceptionHandler with no class argument (the type is then inferred from the
 // method's parameter) yields none here — precision-first, no fabricated node.
-func kotlinExceptionHandlerTypes(fn *sitter.Node, src []byte) []string {
+func kotlinExceptionHandlerTypes(fn ts.Node, src []byte) []string {
 	mods := firstNamedChildOfType(fn, "modifiers")
 	if mods == nil {
 		return nil
@@ -258,7 +258,7 @@ func kotlinExceptionHandlerTypes(fn *sitter.Node, src []byte) []string {
 // call. The shape is a call_expression whose callee simple_identifier is
 // `exception` and whose call_suffix carries exactly one type argument — the
 // handled exception class.
-func kotlinKtorStatusPagesType(call *sitter.Node, src []byte) string {
+func kotlinKtorStatusPagesType(call ts.Node, src []byte) string {
 	callee := call.NamedChild(0)
 	if callee == nil || callee.Type() != "simple_identifier" {
 		return ""
@@ -283,7 +283,7 @@ func kotlinKtorStatusPagesType(call *sitter.Node, src []byte) string {
 
 // firstNamedChildOfType returns the first (depth-first) descendant of n whose
 // node type equals typ, or nil.
-func firstNamedChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func firstNamedChildOfType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}
@@ -303,7 +303,7 @@ func firstNamedChildOfType(n *sitter.Node, typ string) *sitter.Node {
 }
 
 // nodeText returns the source text spanned by a node.
-func nodeText(n *sitter.Node, src []byte) string {
+func nodeText(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/extractors/kotlin/exception_flow_test.go
+++ b/internal/extractors/kotlin/exception_flow_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tskotlin "github.com/smacker/go-tree-sitter/kotlin"
 
 	"github.com/cajasmota/grafel/internal/extractor"
@@ -26,7 +26,7 @@ func extractKotlinRaw(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Demo.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -325,15 +325,18 @@ func TestKotlinExceptionFlow_LiveFixture(t *testing.T) {
 	if err != nil {
 		t.Skipf("fixture unavailable: %v", err)
 	}
-	parser := sitter.NewParser()
-	parser.SetLanguage(tskotlin.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, src)
+	parser, perr := tssmacker.New().NewParser(tssmacker.WrapLanguage(tskotlin.GetLanguage()))
+	if perr != nil {
+		t.Fatalf("parser init: %v", perr)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	ext, _ := extractor.Get("kotlin")
 	recs, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: path, Content: src, Language: "kotlin", Tree: tree,
+		Path: path, Content: src, Language: "kotlin", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/kotlin/imports_test.go
+++ b/internal/extractors/kotlin/imports_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tskotlin "github.com/smacker/go-tree-sitter/kotlin"
 
 	"github.com/cajasmota/grafel/internal/extractor"
@@ -20,9 +20,12 @@ import (
 // bubble up via t.Fatal so callers can assume non-nil non-empty output.
 func runKotlinExtract(t *testing.T, src string) []types.EntityRecord {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tskotlin.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, perr := tssmacker.New().NewParser(tssmacker.WrapLanguage(tskotlin.GetLanguage()))
+	if perr != nil {
+		t.Fatalf("parser init: %v", perr)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -31,7 +34,7 @@ func runKotlinExtract(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Demo.kt",
 		Language: "kotlin",
 		Content:  []byte(src),
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/kotlin/issue4375_crosspkg_test.go
+++ b/internal/extractors/kotlin/issue4375_crosspkg_test.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	tskotlin "github.com/smacker/go-tree-sitter/kotlin"
 
 	"github.com/cajasmota/grafel/internal/extractor"
@@ -48,14 +48,17 @@ func extractKotlinProjectForTest(t *testing.T, files map[string]string) []types.
 	}
 	var merged []types.EntityRecord
 	for rel, src := range files {
-		parser := sitter.NewParser()
-		parser.SetLanguage(tskotlin.GetLanguage())
-		tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+		parser, perr := tssmacker.New().NewParser(tssmacker.WrapLanguage(tskotlin.GetLanguage()))
+		if perr != nil {
+			t.Fatalf("parser init: %v", perr)
+		}
+		defer parser.Close()
+		tree, err := parser.Parse([]byte(src))
 		if err != nil {
 			t.Fatalf("parse %s: %v", rel, err)
 		}
 		ents, err := ext.Extract(context.Background(), extractor.FileInput{
-			Path: rel, Language: "kotlin", Content: []byte(src), Tree: tree,
+			Path: rel, Language: "kotlin", Content: []byte(src), TSTree: tree,
 		})
 		if err != nil {
 			t.Fatalf("extract %s: %v", rel, err)

--- a/internal/extractors/kotlin/issue4428_constmap_test.go
+++ b/internal/extractors/kotlin/issue4428_constmap_test.go
@@ -34,7 +34,7 @@ func extractKotlinRecords(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract failed: %v", err)

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -33,7 +33,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -51,7 +51,7 @@ func (e *Extractor) Language() string { return "kotlin" }
 
 // Extract walks the tree-sitter CST and returns entity records for the Kotlin file.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -61,7 +61,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	// #4375 — per-file cross-package context (package + imports). Threaded into
 	// the call extractor so a qualified `pkg.Type.method()` / imported-fn /
 	// `Type.method()` call stamps its resolved (package[, type], leaf) onto the
@@ -130,7 +130,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // per function declared inside the body, and every function body is scanned
 // for call_expression / call_suffix nodes that yield CALLS edges with stub
 // to_id. Imports are still NOT emitted.
-func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord, ctx *kotlinCrossCtx) {
+func walk(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord, ctx *kotlinCrossCtx) {
 	if node == nil {
 		return
 	}
@@ -351,7 +351,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 
 // findClassBody returns the class_body / object_body / enum_class_body child
 // of a class/object declaration, or nil when the declaration has no body.
-func findClassBody(node *sitter.Node) *sitter.Node {
+func findClassBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		t := ch.Type()
@@ -365,7 +365,7 @@ func findClassBody(node *sitter.Node) *sitter.Node {
 // findFunctionBody returns the function_body child of a function_declaration,
 // or nil when the function is abstract / interface / expression-body without
 // a block. Tree-sitter-kotlin uses an unnamed `function_body` child.
-func findFunctionBody(node *sitter.Node) *sitter.Node {
+func findFunctionBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "function_body" {
@@ -406,7 +406,7 @@ var kotlinKeywordStop = map[string]bool{
 // `kotlin_call_type` (declaring type; absent for a top-level-function call), and
 // `call_leaf` (the bare callee name) so the resolver can bind it through the
 // package-keyed index instead of the ambiguous bare-name path.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string, ctx *kotlinCrossCtx) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string, ctx *kotlinCrossCtx) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -495,7 +495,7 @@ func stampKotlinEnclosingType(e *types.EntityRecord, typeName string) {
 // gathers `val`/`var` property_declaration and variable_declaration names. A
 // head segment matching one of these marks an INSTANCE receiver, which the
 // cross-package qualifier resolver must skip (no false static-qualifier stamp).
-func kotlinLocalValueNames(body *sitter.Node, src []byte) map[string]bool {
+func kotlinLocalValueNames(body ts.Node, src []byte) map[string]bool {
 	names := map[string]bool{}
 	for _, vd := range findAllNodes(body, "variable_declaration", "property_declaration") {
 		for i := 0; i < int(vd.ChildCount()); i++ {
@@ -527,7 +527,7 @@ func kotlinLocalValueNames(body *sitter.Node, src []byte) map[string]bool {
 // (e.g. `chat` for `chat.lastMessages.add()`), producing the
 // false-positive same-class field-access CALLS that dominated the
 // ktor-samples bug-extractor rate. Issue #122.
-func kotlinCallTarget(call *sitter.Node, src []byte) string {
+func kotlinCallTarget(call ts.Node, src []byte) string {
 	if !hasCallSuffix(call) {
 		return ""
 	}
@@ -541,7 +541,7 @@ func kotlinCallTarget(call *sitter.Node, src []byte) string {
 	case "navigation_expression":
 		// The callee name is the last `simple_identifier` of the
 		// trailing navigation_suffix (`.method`).
-		var lastSuffix *sitter.Node
+		var lastSuffix ts.Node
 		for i := 0; i < int(first.ChildCount()); i++ {
 			ch := first.Child(i)
 			if ch.Type() == "navigation_suffix" {
@@ -565,7 +565,7 @@ func kotlinCallTarget(call *sitter.Node, src []byte) string {
 // child. Tree-sitter-kotlin requires this child for a real invocation —
 // its presence (parentheses or trailing lambda) is what distinguishes a
 // method call from a bare identifier or property reference. Issue #122.
-func hasCallSuffix(call *sitter.Node) bool {
+func hasCallSuffix(call ts.Node) bool {
 	for i := 0; i < int(call.ChildCount()); i++ {
 		if call.Child(i).Type() == "call_suffix" {
 			return true
@@ -575,7 +575,7 @@ func hasCallSuffix(call *sitter.Node) bool {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -583,8 +583,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -609,7 +609,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 //   - otherwise          → "class"
 //
 // Issue #3275 — type-system CST extraction.
-func classDeclarationSubtype(node *sitter.Node, src []byte) string {
+func classDeclarationSubtype(node ts.Node, src []byte) string {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		switch node.Child(i).Type() {
 		case "interface":
@@ -633,7 +633,7 @@ func classDeclarationSubtype(node *sitter.Node, src []byte) string {
 //
 // Mirrors the Go and Python extractors which emit SCOPE.Schema/type_alias for
 // language-level type alias declarations (#3275 — type-system CST extraction).
-func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildTypeAlias(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := firstChildOfType(node, file.Content, "type_identifier")
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -650,7 +650,7 @@ func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRe
 }
 
 // buildComponent creates a Component entity for class/object declarations.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	// Kotlin grammar uses type_identifier for class/object names (no "name" field).
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
@@ -695,7 +695,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 // `post(...)` — must only classify as external when the source file
 // imports an `io.ktor.server.*` package, per the same precision model
 // the Go chi-router gate uses, #131).
-func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	// import_header text shape: `import io.ktor.server.routing.*`
 	// or `import io.ktor.server.routing.get`. Strip the leading
 	// `import` keyword + trailing wildcard, comments, and the optional
@@ -749,7 +749,7 @@ func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 }
 
 // buildOperation creates an Operation entity for function declarations.
-func buildOperation(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildOperation(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	// Kotlin grammar uses simple_identifier for function names (no "name" field).
 	name := childFieldText(node, "name", file.Content)
 	if name == "" {
@@ -793,7 +793,7 @@ var springStereotypes = map[string]bool{
 //	qualified_name = "<source_file>::<class_name>"
 //	provenance     = "@<StereotypeName>" (e.g. "@RestController")
 //	source_type    = "class"
-func buildSpringService(node *sitter.Node, file extractor.FileInput, className string) (types.EntityRecord, bool) {
+func buildSpringService(node ts.Node, file extractor.FileInput, className string) (types.EntityRecord, bool) {
 	if className == "" {
 		return types.EntityRecord{}, false
 	}
@@ -856,7 +856,7 @@ func findSpringStereotype(header string) string {
 // the CONTAINS stub to the field entity.
 //
 // Issue #690 — closes the Kotlin analog of the Python field orphan gap (#689).
-func buildProperty(node *sitter.Node, file extractor.FileInput, parentType string) (types.EntityRecord, bool) {
+func buildProperty(node ts.Node, file extractor.FileInput, parentType string) (types.EntityRecord, bool) {
 	// property_declaration structure:
 	//   binding_pattern_kind (val|var)
 	//   variable_declaration
@@ -912,7 +912,7 @@ func buildProperty(node *sitter.Node, file extractor.FileInput, parentType strin
 //	class_parameter carries binding_pattern_kind (val|var) when the
 //	parameter is a property; plain parameters have no such child.
 func emitPrimaryConstructorFields(
-	classNode *sitter.Node,
+	classNode ts.Node,
 	file extractor.FileInput,
 	className string,
 	classIdx int,
@@ -971,7 +971,7 @@ func emitPrimaryConstructorFields(
 }
 
 // childFieldText extracts the text of a named child field.
-func childFieldText(node *sitter.Node, field string, src []byte) string {
+func childFieldText(node ts.Node, field string, src []byte) string {
 	child := node.ChildByFieldName(field)
 	if child == nil {
 		return ""
@@ -980,7 +980,7 @@ func childFieldText(node *sitter.Node, field string, src []byte) string {
 }
 
 // firstChildOfType returns the text of the first direct child with the given node type.
-func firstChildOfType(node *sitter.Node, src []byte, nodeType string) string {
+func firstChildOfType(node ts.Node, src []byte, nodeType string) string {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch.Type() == nodeType {
@@ -993,7 +993,7 @@ func firstChildOfType(node *sitter.Node, src []byte, nodeType string) string {
 // buildFunSignature builds a function signature (up to body).
 // Strips top-level annotations but keeps parameter annotations (e.g., @RequestBody).
 // Python convention: "fun name(@ParamAnnotation param: Type): ReturnType".
-func buildFunSignature(node *sitter.Node, src []byte) string {
+func buildFunSignature(node ts.Node, src []byte) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	// Strip body block
 	if idx := strings.Index(raw, " {"); idx >= 0 {
@@ -1018,7 +1018,7 @@ func buildFunSignature(node *sitter.Node, src []byte) string {
 
 // buildClassSignature constructs a readable signature up to the class body.
 // Strips annotations to match Python convention: "class Foo" or "data class Foo(...)".
-func buildClassSignature(node *sitter.Node, src []byte, name string) string {
+func buildClassSignature(node ts.Node, src []byte, name string) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "{"); idx >= 0 {
 		raw = raw[:idx]

--- a/internal/extractors/kotlin/kotlin_test.go
+++ b/internal/extractors/kotlin/kotlin_test.go
@@ -5,19 +5,23 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tskotlin "github.com/smacker/go-tree-sitter/kotlin"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/kotlin"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
 // parseForTest parses Kotlin source using the real grammar.
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tskotlin.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tskotlin.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -48,7 +52,7 @@ class UserService {
 		Path:     "UserService.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -85,7 +89,7 @@ class Foo {
 		Path:     "Foo.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -124,7 +128,7 @@ class Svc {
 		Path:     "svc.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -154,7 +158,7 @@ object MySingleton {
 		Path:     "singleton.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -202,7 +206,7 @@ class Foo {}
 		Path:     "imports.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -252,7 +256,7 @@ class Bar {
 		Path:     "Bar.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -290,7 +294,7 @@ class UserController {
 		Path:     "UserController.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -361,7 +365,7 @@ func TestKotlinExtractor_AllSpringStereotypesEmitService(t *testing.T) {
 				Path:     tc.className + ".kt",
 				Content:  []byte(src),
 				Language: "kotlin",
-				Tree:     tree,
+				TSTree:   tree,
 			})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -396,7 +400,7 @@ class PlainOldKotlinClass {
 		Path:     "plain.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -416,7 +420,7 @@ func TestKotlinExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.kt",
 		Content:  []byte(""),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -433,7 +437,7 @@ func TestKotlinExtractor_NilTree(t *testing.T) {
 		Path:     "nil.kt",
 		Content:  []byte("class Foo {}"),
 		Language: "kotlin",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -459,7 +463,7 @@ class BadClass {
 		Path:     "malformed.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on malformed file: %v", err)
@@ -502,7 +506,7 @@ interface Greeter {
 		Path:     "Greeter.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -532,7 +536,7 @@ func TestKotlinExtractor_InterfaceNotClass(t *testing.T) {
 	tree := parseForTest(t, src)
 	ext, _ := extractor.Get("kotlin")
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "Repo.kt", Content: []byte(src), Language: "kotlin", Tree: tree,
+		Path: "Repo.kt", Content: []byte(src), Language: "kotlin", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -559,7 +563,7 @@ enum class Direction {
 		Path:     "Direction.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -583,7 +587,7 @@ func TestKotlinExtractor_EnumNotClass(t *testing.T) {
 	tree := parseForTest(t, src)
 	ext, _ := extractor.Get("kotlin")
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "Color.kt", Content: []byte(src), Language: "kotlin", Tree: tree,
+		Path: "Color.kt", Content: []byte(src), Language: "kotlin", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -609,7 +613,7 @@ typealias UserId = Int
 		Path:     "aliases.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -655,7 +659,7 @@ class Box(val width: Double, val height: Double) : Shape {
 	tree := parseForTest(t, src)
 	ext, _ := extractor.Get("kotlin")
 	got, err := ext.Extract(context.Background(), extractor.FileInput{
-		Path: "shapes.kt", Content: []byte(src), Language: "kotlin", Tree: tree,
+		Path: "shapes.kt", Content: []byte(src), Language: "kotlin", TSTree: tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -698,7 +702,7 @@ func TestKotlinExtractor_LineNumbers(t *testing.T) {
 		Path:     "lines.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/kotlin/references.go
+++ b/internal/extractors/kotlin/references.go
@@ -77,7 +77,7 @@ package kotlin
 import (
 	"path/filepath"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -138,7 +138,7 @@ type kotlinFrame struct {
 // to the enclosing operation entity.
 //
 // Mutates entities in place. Safe to call with an empty slice — no-op.
-func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitReferences(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -221,8 +221,8 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 			})
 	}
 
-	var walk func(n *sitter.Node, parentClass string, fstack []kotlinFrame)
-	walk = func(n *sitter.Node, parentClass string, fstack []kotlinFrame) {
+	var walk func(n ts.Node, parentClass string, fstack []kotlinFrame)
+	walk = func(n ts.Node, parentClass string, fstack []kotlinFrame) {
 		if n == nil {
 			return
 		}
@@ -310,7 +310,7 @@ func findKotlinEntityIndex(entities []types.EntityRecord, emittedName, filePath 
 // declaration. Tree-sitter-kotlin uses `type_identifier` for
 // class/object names and `simple_identifier` for function names; both
 // shapes are accepted via the field name or first-child fallback.
-func kotlinDeclName(n *sitter.Node, src []byte) string {
+func kotlinDeclName(n ts.Node, src []byte) string {
 	if name := n.ChildByFieldName("name"); name != nil {
 		return string(src[name.StartByte():name.EndByte()])
 	}
@@ -327,7 +327,7 @@ func kotlinDeclName(n *sitter.Node, src []byte) string {
 // kotlinFindBody returns the body child of a class/object/companion
 // declaration. Tree-sitter-kotlin uses `class_body` / `object_body` /
 // `enum_class_body` depending on the declaration shape.
-func kotlinFindBody(node *sitter.Node) *sitter.Node {
+func kotlinFindBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		t := ch.Type()
@@ -345,12 +345,12 @@ func kotlinFindBody(node *sitter.Node) *sitter.Node {
 // `this.<method>` and `ClassName.<method>` resolve via dottedSymbols
 // to the same emitted entity.
 func synthesiseKotlinDottedMembers(
-	root *sitter.Node,
+	root ts.Node,
 	file extractor.FileInput,
 	bareSymbols, dottedSymbols map[string]kotlinSymbol,
 ) {
-	var walk func(n *sitter.Node, parentClass string)
-	walk = func(n *sitter.Node, parentClass string) {
+	var walk func(n ts.Node, parentClass string)
+	walk = func(n ts.Node, parentClass string) {
 		if n == nil {
 			return
 		}
@@ -408,7 +408,7 @@ func synthesiseKotlinDottedMembers(
 //     leaf name).
 //   - otherwise look up in bareSymbols and emit.
 func handleKotlinIdentifier(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	fstack []kotlinFrame,
 	bareSymbols map[string]kotlinSymbol,
@@ -447,7 +447,7 @@ func handleKotlinIdentifier(
 // `is` check, generic parameter, local variable type annotation, or
 // return-type position). These are strictly REFERENCES, never CALLS.
 func handleKotlinTypeIdentifier(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	fstack []kotlinFrame,
 	bareSymbols map[string]kotlinSymbol,
@@ -491,7 +491,7 @@ func handleKotlinTypeIdentifier(
 //     the recursion will descend into the receiver and handle each
 //     `simple_identifier` independently.
 func handleKotlinNavigationExpression(
-	n *sitter.Node,
+	n ts.Node,
 	file extractor.FileInput,
 	fstack []kotlinFrame,
 	bareSymbols, dottedSymbols map[string]kotlinSymbol,
@@ -509,7 +509,7 @@ func handleKotlinNavigationExpression(
 	}
 
 	// Find the trailing navigation_suffix and extract its simple_identifier.
-	var lastSuffix *sitter.Node
+	var lastSuffix ts.Node
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		if ch.Type() == "navigation_suffix" {
@@ -536,7 +536,7 @@ func handleKotlinNavigationExpression(
 
 	// The receiver is the first child (anything that's not a
 	// navigation_suffix and appears before the first suffix).
-	var receiver *sitter.Node
+	var receiver ts.Node
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		if ch.Type() == "navigation_suffix" {
@@ -616,7 +616,7 @@ func handleKotlinNavigationExpression(
 //	parent is `property_declaration` and the identifier appears before
 //	  any `=` in the original source (defensive — the variable_declaration
 //	  guard above handles the common case).
-func isKotlinDeclarationPosition(n *sitter.Node) bool {
+func isKotlinDeclarationPosition(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false
@@ -659,7 +659,7 @@ func isKotlinDeclarationPosition(n *sitter.Node) bool {
 // the callee head of a `call_expression` node (the first child when
 // that child is `simple_identifier`). CALLS owns those edges —
 // REFERENCES would double-count.
-func isKotlinCallCallee(n *sitter.Node) bool {
+func isKotlinCallCallee(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false
@@ -674,7 +674,7 @@ func isKotlinCallCallee(n *sitter.Node) bool {
 // node is the trailing identifier of a `navigation_suffix` node. The
 // navigation_expression handler owns the binding decision; the bare
 // identifier walk should skip it to avoid double-emission.
-func isKotlinNavigationSuffixField(n *sitter.Node) bool {
+func isKotlinNavigationSuffixField(n ts.Node) bool {
 	parent := n.Parent()
 	if parent == nil {
 		return false

--- a/internal/extractors/kotlin/relationships_test.go
+++ b/internal/extractors/kotlin/relationships_test.go
@@ -17,7 +17,7 @@ func runKotlin(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.kt",
 		Content:  []byte(src),
 		Language: "kotlin",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/kotlin/tests.go
+++ b/internal/extractors/kotlin/tests.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -41,7 +41,7 @@ var kotestSpecBaseTypes = map[string]bool{
 // classes whose lambda resolves no CALLS (shape-only specs → no owner, honest
 // exclusion).
 func emitKotestTestScopeOwner(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	className string,
 	ctx *kotlinCrossCtx,
@@ -113,7 +113,7 @@ var kotestDSLScaffolding = map[string]bool{
 //	  └ delegation_specifier → constructor_invocation
 //	       ├ user_type → type_identifier  (the base spec type)
 //	       └ value_arguments → value_argument → lambda_literal → <body>
-func kotestSpecLambdaBody(node *sitter.Node, src []byte) (*sitter.Node, string) {
+func kotestSpecLambdaBody(node ts.Node, src []byte) (ts.Node, string) {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ds := node.Child(i)
 		if ds.Type() != "delegation_specifier" {
@@ -149,7 +149,7 @@ func kotestSpecLambdaBody(node *sitter.Node, src []byte) (*sitter.Node, string) 
 
 // firstChildOfTypeNode returns the first direct child of n whose Type() == kind,
 // or nil.
-func firstChildOfTypeNode(n *sitter.Node, kind string) *sitter.Node {
+func firstChildOfTypeNode(n ts.Node, kind string) ts.Node {
 	if n == nil {
 		return nil
 	}

--- a/internal/extractors/lua/lua.go
+++ b/internal/extractors/lua/lua.go
@@ -42,7 +42,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -60,11 +60,11 @@ func (e *Extractor) Language() string { return "lua" }
 
 // Extract walks the tree-sitter CST and returns entity records.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	imports := collectRequires(root, file.Content)
 
 	var entities []types.EntityRecord
@@ -113,7 +113,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // global and local functions (local functions have a "local" keyword child).
 // "function_declaration" and "local_function" are kept for compatibility with
 // older grammar versions.
-func walkLua(node *sitter.Node, file extractor.FileInput, imports []string, moduleIdx map[string]int, out *[]types.EntityRecord) {
+func walkLua(node ts.Node, file extractor.FileInput, imports []string, moduleIdx map[string]int, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -162,7 +162,7 @@ func walkLua(node *sitter.Node, file extractor.FileInput, imports []string, modu
 // findFunctionBody returns the `function_body` child of a function node, or
 // nil. Used for both function_statement and the older function_declaration
 // shapes.
-func findFunctionBody(node *sitter.Node) *sitter.Node {
+func findFunctionBody(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -187,7 +187,7 @@ func findFunctionBody(node *sitter.Node) *sitter.Node {
 // "M" for `function M.foo`). It's "" for plain `function foo` and local
 // functions. The walker uses receiver to attach CONTAINS edges from
 // matching `local M = {}` module-table components (#375).
-func buildFunctionStatement(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, string, bool) {
+func buildFunctionStatement(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, string, bool) {
 	// Determine if this is a local function (has "local" keyword child).
 	isLocal := false
 	for i := range node.ChildCount() {
@@ -261,7 +261,7 @@ func buildFunctionStatement(node *sitter.Node, file extractor.FileInput, imports
 
 // buildFunctionDecl handles function_declaration nodes (global or dot/colon notation)
 // from older tree-sitter-lua grammar versions.
-func buildFunctionDecl(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, string, bool) {
+func buildFunctionDecl(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, string, bool) {
 	nameNode := node.ChildByFieldName("name")
 	if nameNode == nil {
 		return types.EntityRecord{}, "", false
@@ -305,9 +305,9 @@ func buildFunctionDecl(node *sitter.Node, file extractor.FileInput, imports []st
 }
 
 // buildLocalFunction handles local_function nodes (older grammars).
-func buildLocalFunction(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildLocalFunction(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	// local_function: local function <identifier> <parameters> <block> end
-	var nameNode *sitter.Node
+	var nameNode ts.Node
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch != nil && ch.Type() == "identifier" {
@@ -348,13 +348,13 @@ func buildLocalFunction(node *sitter.Node, file extractor.FileInput, imports []s
 // collectRequires gathers require("module") calls as the legacy
 // Properties["imports"] string list (preserved for backwards compatibility
 // with the existing Operation-entity contract).
-func collectRequires(root *sitter.Node, src []byte) []string {
+func collectRequires(root ts.Node, src []byte) []string {
 	var imports []string
 	walkForRequires(root, src, &imports)
 	return imports
 }
 
-func walkForRequires(node *sitter.Node, src []byte, out *[]string) {
+func walkForRequires(node ts.Node, src []byte, out *[]string) {
 	if node == nil {
 		return
 	}
@@ -374,7 +374,7 @@ func walkForRequires(node *sitter.Node, src []byte, out *[]string) {
 // requireArgPath extracts the string path from a `require(...)` /
 // `require "..."` function_call node. Returns "" if the head isn't require
 // or no string argument is present.
-func requireArgPath(call *sitter.Node, src []byte) string {
+func requireArgPath(call ts.Node, src []byte) string {
 	if call == nil || call.ChildCount() == 0 {
 		return ""
 	}
@@ -408,7 +408,7 @@ func requireArgPath(call *sitter.Node, src []byte) string {
 
 // extractStringContent extracts the string value from a string node,
 // handling both bare text and nested string_content child.
-func extractStringContent(node *sitter.Node, src []byte) string {
+func extractStringContent(node ts.Node, src []byte) string {
 	// Try string_content child first (smacker grammar).
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
@@ -425,11 +425,11 @@ func extractStringContent(node *sitter.Node, src []byte) string {
 // require call, carrying an IMPORTS relationship. Mirrors the elixir/dart
 // pattern (#370/#369): each import is its own entity record so the resolver
 // can dispatch on Properties["language"].
-func emitImportRecords(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitImportRecords(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	walkForImportEdges(root, file, out)
 }
 
-func walkForImportEdges(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walkForImportEdges(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -458,7 +458,7 @@ func walkForImportEdges(node *sitter.Node, file extractor.FileInput, out *[]type
 // analyzeRequireDecl checks whether a variable_declaration node has the shape
 // `local <ident> = require("path")`. Returns the required path and the LHS
 // identifier on success.
-func analyzeRequireDecl(decl *sitter.Node, src []byte) (string, string, bool) {
+func analyzeRequireDecl(decl ts.Node, src []byte) (string, string, bool) {
 	var lhs string
 	var requirePath string
 	for i := 0; i < int(decl.ChildCount()); i++ {
@@ -534,7 +534,7 @@ func makeImportRecord(file extractor.FileInput, requirePath, lhs string) types.E
 // and returns it as a SCOPE.Component entity. CONTAINS edges are filled in
 // later by walkLua as it encounters `function <Name>.x` / `function <Name>:x`
 // declarations (#375).
-func collectModuleTables(root *sitter.Node, file extractor.FileInput) map[string]types.EntityRecord {
+func collectModuleTables(root ts.Node, file extractor.FileInput) map[string]types.EntityRecord {
 	src := file.Content
 	out := make(map[string]types.EntityRecord)
 	for i := 0; i < int(root.ChildCount()); i++ {
@@ -617,7 +617,7 @@ var luaCallStop = map[string]bool{
 //   - Method `obj:bar(args)`    — same, with `self_call_colon` instead of "."
 //
 // Self-recursion is dropped. `require` is filtered (handled by IMPORTS).
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -663,7 +663,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 // For bare `helper()` the first child is the only identifier and IS the
 // callee. The rule: take the LAST identifier child that appears before the
 // first paren/arguments/string-argument child.
-func luaCallTarget(call *sitter.Node, src []byte) string {
+func luaCallTarget(call ts.Node, src []byte) string {
 	if call == nil || call.ChildCount() == 0 {
 		return ""
 	}
@@ -686,7 +686,7 @@ func luaCallTarget(call *sitter.Node, src []byte) string {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -694,8 +694,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]

--- a/internal/extractors/lua/lua_test.go
+++ b/internal/extractors/lua/lua_test.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tslua "github.com/smacker/go-tree-sitter/lua"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/lua"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tslua.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tslua.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -52,7 +56,7 @@ return M
 		Path:     "module.lua",
 		Content:  []byte(src),
 		Language: "lua",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -96,7 +100,7 @@ end
 		Path:     "test.lua",
 		Content:  []byte(src),
 		Language: "lua",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -147,7 +151,7 @@ return Dog
 		Path:     "animal.lua",
 		Content:  []byte(src),
 		Language: "lua",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -195,7 +199,7 @@ return Derived
 		Path:     "derived.lua",
 		Content:  []byte(src),
 		Language: "lua",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -248,7 +252,7 @@ end
 		Path:     "test.lua",
 		Content:  []byte(src),
 		Language: "lua",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/lua/relationships_test.go
+++ b/internal/extractors/lua/relationships_test.go
@@ -18,7 +18,7 @@ func runLua(t *testing.T, src string) []types.EntityRecord {
 		Path:     "test.lua",
 		Content:  []byte(src),
 		Language: "lua",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -30,7 +30,7 @@ import (
 	"fmt"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -48,12 +48,12 @@ func (e *Extractor) Language() string { return "proto" }
 
 // Extract walks the tree-sitter CST and returns entity records.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
 	var entities []types.EntityRecord
-	walkProto(file.Tree.RootNode(), file, &entities)
+	walkProto(file.TSTree.RootNode(), file, &entities)
 
 	// Append IMPORTS stub entities, one per `import "..."` directive.
 	importEntities := buildImportEntities(file)
@@ -64,14 +64,14 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	return entities, nil
 }
 
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
 	return string(src[node.StartByte():node.EndByte()])
 }
 
-func childByType(node *sitter.Node, types_ ...string) *sitter.Node {
+func childByType(node ts.Node, types_ ...string) ts.Node {
 	set := make(map[string]bool, len(types_))
 	for _, t := range types_ {
 		set[t] = true
@@ -101,7 +101,7 @@ func fileContainsRel(filePath, name string) types.RelationshipRecord {
 	}
 }
 
-func walkProto(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walkProto(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -136,7 +136,7 @@ func walkProto(node *sitter.Node, file extractor.FileInput, out *[]types.EntityR
 	}
 }
 
-func buildService(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildService(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	nameNode := childByType(node, "service_name")
 	if nameNode == nil {
 		return types.EntityRecord{}, false
@@ -189,7 +189,7 @@ func buildService(node *sitter.Node, file extractor.FileInput) (types.EntityReco
 	}, true
 }
 
-func buildRPC(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildRPC(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	// rpc: rpc <rpc_name> ( <msg_type> ) returns ( <msg_type> ) ;
 	nameNode := childByType(node, "rpc_name")
 	if nameNode == nil {
@@ -243,7 +243,7 @@ func buildRPC(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, 
 	}, true
 }
 
-func buildMessage(node *sitter.Node, file extractor.FileInput) ([]types.EntityRecord, bool) {
+func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord, bool) {
 	nameNode := childByType(node, "message_name")
 	if nameNode == nil {
 		return nil, false
@@ -334,7 +334,7 @@ func buildMessage(node *sitter.Node, file extractor.FileInput) ([]types.EntityRe
 // it coincides with the message→field CONTAINS edge target. Properties carry the
 // resolved field type and the proto label (repeated/optional/required) when one
 // is present.
-func buildField(file extractor.FileInput, parent, fname, ftype, label string, node *sitter.Node) types.EntityRecord {
+func buildField(file extractor.FileInput, parent, fname, ftype, label string, node ts.Node) types.EntityRecord {
 	props := map[string]string{"type": ftype}
 	if label != "" {
 		props["label"] = label
@@ -363,7 +363,7 @@ func buildField(file extractor.FileInput, parent, fname, ftype, label string, no
 	}
 }
 
-func buildEnum(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildEnum(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	nameNode := childByType(node, "enum_name")
 	if nameNode == nil {
 		return types.EntityRecord{}, false
@@ -422,7 +422,7 @@ func buildEnum(node *sitter.Node, file extractor.FileInput) (types.EntityRecord,
 //	  identifier   ← field name
 //	  =
 //	  field_number
-func fieldName(node *sitter.Node, src []byte) string {
+func fieldName(node ts.Node, src []byte) string {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch == nil {
@@ -450,7 +450,7 @@ var protoScalars = map[string]bool{
 // identifier, `=`, and the field number. The `type` node wraps either a scalar
 // keyword, a `message_or_enum_type`, or a `map_type` (`map<K, V>`); we return
 // the textual type (e.g. "string", "Order", "map<string, Order>").
-func fieldTypeAndLabel(node *sitter.Node, src []byte) (ftype, label string) {
+func fieldTypeAndLabel(node ts.Node, src []byte) (ftype, label string) {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch == nil {
@@ -482,7 +482,7 @@ func fieldTypeAndLabel(node *sitter.Node, src []byte) (ftype, label string) {
 //
 //	map_field
 //	  map  <  key_type  ,  type  >  identifier  =  field_number  ;
-func mapFieldTypeAndLabel(node *sitter.Node, src []byte) (ftype, label string) {
+func mapFieldTypeAndLabel(node ts.Node, src []byte) (ftype, label string) {
 	var key, val string
 	if k := childByType(node, "key_type"); k != nil {
 		key = strings.TrimSpace(nodeText(k, src))
@@ -535,7 +535,7 @@ func namedTypeRefs(ftype string) []string {
 //	  identifier   ← value name (e.g. UNKNOWN)
 //	  =
 //	  int_lit
-func enumValueName(node *sitter.Node, src []byte) string {
+func enumValueName(node ts.Node, src []byte) string {
 	if id := childByType(node, "identifier"); id != nil {
 		return nodeText(id, src)
 	}
@@ -547,7 +547,7 @@ func enumValueName(node *sitter.Node, src []byte) string {
 // each carrying an IMPORTS edge from file.Path → target. `import public`
 // imports carry Properties["public"]="true" on the relationship.
 func buildImportEntities(file extractor.FileInput) []types.EntityRecord {
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	var entities []types.EntityRecord
 	for i := range root.ChildCount() {
 		ch := root.Child(int(i))
@@ -590,7 +590,7 @@ func buildImportEntities(file extractor.FileInput) []types.EntityRecord {
 //	  [public|weak]   (optional modifier)
 //	  string          ("path/to.proto")
 //	  ;
-func parseImport(node *sitter.Node, src []byte) (path string, public bool) {
+func parseImport(node ts.Node, src []byte) (path string, public bool) {
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch == nil {

--- a/internal/extractors/proto/proto_test.go
+++ b/internal/extractors/proto/proto_test.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsproto "github.com/smacker/go-tree-sitter/protobuf"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/proto"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsproto.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsproto.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -43,7 +47,7 @@ service UserService {
 		Path:     "user.proto",
 		Content:  []byte(src),
 		Language: "proto",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -98,7 +102,7 @@ enum Status {
 		Path:     "types.proto",
 		Content:  []byte(src),
 		Language: "proto",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -148,7 +152,7 @@ message Foo { string id = 1; }
 		Path:     "foo.proto",
 		Content:  []byte(src),
 		Language: "proto",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/proto/relationships_test.go
+++ b/internal/extractors/proto/relationships_test.go
@@ -19,7 +19,7 @@ func extract(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "proto",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/scala/constantset.go
+++ b/internal/extractors/scala/constantset.go
@@ -41,7 +41,7 @@ package scala
 // for a parity-audit.
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -52,7 +52,7 @@ import (
 // SCOPE.Enum value-set node per detected collection. It is independent of the
 // structural walkNode pass (which emits Components / Operations / Schemas), so
 // the two never interfere.
-func emitConstantSets(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitConstantSets(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if root == nil {
 		return
 	}
@@ -63,7 +63,7 @@ func emitConstantSets(root *sitter.Node, file extractor.FileInput, out *[]types.
 // collects sealed-trait case-object enumerations (which span sibling
 // declarations) once, then per-node handles enum / Map-val / object-const-group
 // shapes, recursing into container bodies.
-func emitConstantSetsIn(scope *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitConstantSetsIn(scope ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	// (4) sealed-trait / case-object enumerations are scoped: gather every
 	// `case object X extends Parent` declared directly in this scope and group
 	// them by Parent, so `sealed trait Status` + N `case object`s become one
@@ -125,7 +125,7 @@ func emitConstantSetsIn(scope *sitter.Node, file extractor.FileInput, out *[]typ
 // Vector / Array) carrying literal entries, returns the SCOPE.Enum value-set
 // node for it. kind_hint distinguishes a Map (key→value entries) from a
 // sequence (literal elements).
-func buildValMapValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildValMapValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -170,7 +170,7 @@ func buildValMapValueSet(node *sitter.Node, file extractor.FileInput) (types.Ent
 // vals.
 //
 // kind_hint is "scala_const_object".
-func buildObjectConstGroupValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildObjectConstGroupValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -221,7 +221,7 @@ func buildObjectConstGroupValueSet(node *sitter.Node, file extractor.FileInput) 
 // parity-audit can see the per-case payload.
 //
 // kind_hint is "scala_enum".
-func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildEnumValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -272,7 +272,7 @@ func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.Entit
 // enumeration.
 //
 // kind_hint is "scala_sealed_enum".
-func emitCaseObjectEnumerations(scope *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitCaseObjectEnumerations(scope ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	type group struct {
 		members   []extractor.EnumMember
 		startLine int
@@ -333,7 +333,7 @@ func emitCaseObjectEnumerations(scope *sitter.Node, file extractor.FileInput, ou
 
 // templateBodyOf returns the template_body / enum_body / block child of a
 // container declaration, or nil when it has no body.
-func templateBodyOf(node *sitter.Node) *sitter.Node {
+func templateBodyOf(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -346,7 +346,7 @@ func templateBodyOf(node *sitter.Node) *sitter.Node {
 }
 
 // childByType returns the first direct child of node with the given type.
-func childByType(node *sitter.Node, typ string) *sitter.Node {
+func childByType(node ts.Node, typ string) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -363,7 +363,7 @@ func childByType(node *sitter.Node, typ string) *sitter.Node {
 // definition. A type ascription (`val x: T = expr`) means the value is the
 // child following the `=` token, not the type_identifier; this returns the
 // node after `=`.
-func valDefinitionRHS(node *sitter.Node) *sitter.Node {
+func valDefinitionRHS(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -386,7 +386,7 @@ func valDefinitionRHS(node *sitter.Node) *sitter.Node {
 // callExpressionCalleeName returns the simple callee name of a call_expression
 // (`Map(...)` → "Map"). For a qualified callee (`immutable.Map(...)`) it returns
 // the trailing identifier.
-func callExpressionCalleeName(call *sitter.Node, src []byte) string {
+func callExpressionCalleeName(call ts.Node, src []byte) string {
 	if call == nil {
 		return ""
 	}
@@ -423,14 +423,14 @@ func isCollectionCtor(name string) bool {
 // mapArgMembers builds members from a Map(...) arguments node. Each entry is an
 // `infix_expression` of the form `key -> value`. Non-literal keys/values record
 // their source expression text.
-func mapArgMembers(args *sitter.Node, src []byte) []extractor.EnumMember {
+func mapArgMembers(args ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	for i := 0; i < int(args.ChildCount()); i++ {
 		entry := args.Child(i)
 		if entry == nil {
 			continue
 		}
-		var key, valNode *sitter.Node
+		var key, valNode ts.Node
 		switch entry.Type() {
 		case "infix_expression":
 			// key -> value  (operator_identifier "->" / "→")
@@ -468,7 +468,7 @@ func mapArgMembers(args *sitter.Node, src []byte) []extractor.EnumMember {
 // seqArgMembers builds members from a Seq/Set/List(...) arguments node. Each
 // literal element becomes BOTH the member key and value so the value-set carries
 // the literal element set.
-func seqArgMembers(args *sitter.Node, src []byte) []extractor.EnumMember {
+func seqArgMembers(args ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	for i := 0; i < int(args.ChildCount()); i++ {
 		el := args.Child(i)
@@ -491,7 +491,7 @@ func seqArgMembers(args *sitter.Node, src []byte) []extractor.EnumMember {
 // enumCaseValue returns the source text of an enum arm's constructor arguments
 // (`case Mercury extends Planet(1.0)` → "1.0"), or "" for a bare arm. This lets
 // a parity-audit compare per-case payloads.
-func enumCaseValue(arm *sitter.Node, src []byte) string {
+func enumCaseValue(arm ts.Node, src []byte) string {
 	ext := childByType(arm, "extends_clause")
 	if ext == nil {
 		return ""
@@ -510,7 +510,7 @@ func enumCaseValue(arm *sitter.Node, src []byte) string {
 // (string / number / boolean / identifier), or — for any other non-literal node
 // (a method call, an interpolation) — the trimmed source EXPRESSION TEXT
 // (#4432: non-literal values are recorded, not dropped).
-func scalaScalarValue(n *sitter.Node, src []byte) string {
+func scalaScalarValue(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -531,7 +531,7 @@ func scalaScalarValue(n *sitter.Node, src []byte) string {
 
 // isCaseObject reports whether an object_definition / class_definition node
 // carries the `case` modifier (`case object X` / `case class X`).
-func isCaseObject(node *sitter.Node) bool {
+func isCaseObject(node ts.Node) bool {
 	if node == nil {
 		return false
 	}
@@ -556,7 +556,7 @@ func isCaseObject(node *sitter.Node) bool {
 
 // extendsTypeName returns the supertype name from a declaration's
 // extends_clause (`case object Active extends Status` → "Status").
-func extendsTypeName(node *sitter.Node, src []byte) string {
+func extendsTypeName(node ts.Node, src []byte) string {
 	ext := childByType(node, "extends_clause")
 	if ext == nil {
 		return ""
@@ -578,7 +578,7 @@ func extendsTypeName(node *sitter.Node, src []byte) string {
 }
 
 // firstIdentifier returns the first identifier/type_identifier text under node.
-func firstIdentifier(node *sitter.Node, src []byte) string {
+func firstIdentifier(node ts.Node, src []byte) string {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch == nil {
@@ -593,7 +593,7 @@ func firstIdentifier(node *sitter.Node, src []byte) string {
 
 // lastIdentifier returns the trailing identifier of a dotted / field
 // expression (`immutable.Map` → "Map").
-func lastIdentifier(node *sitter.Node, src []byte) string {
+func lastIdentifier(node ts.Node, src []byte) string {
 	last := ""
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
@@ -611,8 +611,8 @@ func lastIdentifier(node *sitter.Node, src []byte) string {
 }
 
 // namedChildren returns the named children of a node in order.
-func namedChildren(node *sitter.Node) []*sitter.Node {
-	var out []*sitter.Node
+func namedChildren(node ts.Node) []ts.Node {
+	var out []ts.Node
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch != nil && ch.IsNamed() {
@@ -623,7 +623,7 @@ func namedChildren(node *sitter.Node) []*sitter.Node {
 }
 
 // nodeStr returns the trimmed source text of a node.
-func nodeStr(node *sitter.Node, src []byte) string {
+func nodeStr(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}

--- a/internal/extractors/scala/exception_flow.go
+++ b/internal/extractors/scala/exception_flow.go
@@ -32,7 +32,7 @@ package scala
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -43,7 +43,7 @@ import (
 //
 // entities[0] MUST be the file entity. Mutates *entities in place. Safe with
 // nil / empty input.
-func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+func emitExceptionFlowEdges(root ts.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
 	if root == nil || entities == nil || len(*entities) == 0 {
 		return
 	}
@@ -51,8 +51,8 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 
 	var edges []extractor.ExceptionEdge
 
-	var walk func(n *sitter.Node, enclosingFn string)
-	walk = func(n *sitter.Node, enclosingFn string) {
+	var walk func(n ts.Node, enclosingFn string)
+	walk = func(n ts.Node, enclosingFn string) {
 		if n == nil {
 			return
 		}
@@ -101,7 +101,7 @@ func emitExceptionFlowEdges(root *sitter.Node, file extractor.FileInput, entitie
 // `throw new X(...)` (the throw_expression's instance_expression child names
 // the type), or "" for a re-throw of a variable (`throw e`) — which carries no
 // NEW type — or any non-`new` thrown expression.
-func scalaThrowType(throwNode *sitter.Node, src []byte) string {
+func scalaThrowType(throwNode ts.Node, src []byte) string {
 	for i := 0; i < int(throwNode.ChildCount()); i++ {
 		c := throwNode.Child(i)
 		if c == nil || c.Type() != "instance_expression" {
@@ -118,7 +118,7 @@ func scalaThrowType(throwNode *sitter.Node, src []byte) string {
 // scalaIsRecoverCall reports whether a call_expression is a `.recover` /
 // `.recoverWith` invocation that carries a case_block handler — the Try / Future
 // error-recovery idiom whose typed cases catch specific exceptions.
-func scalaIsRecoverCall(call *sitter.Node, src []byte) bool {
+func scalaIsRecoverCall(call ts.Node, src []byte) bool {
 	if call.ChildCount() == 0 {
 		return false
 	}
@@ -138,7 +138,7 @@ func scalaIsRecoverCall(call *sitter.Node, src []byte) bool {
 		return false
 	}
 	// Trailing identifier of the field_expression is the method name.
-	var last *sitter.Node
+	var last ts.Node
 	for i := 0; i < int(first.ChildCount()); i++ {
 		if first.Child(i).Type() == "identifier" {
 			last = first.Child(i)
@@ -158,7 +158,7 @@ func scalaIsRecoverCall(call *sitter.Node, src []byte) bool {
 // static exception type and are skipped — precision over recall. Qualified
 // types (`java.io.IOException`) are normalized to their bare class downstream
 // by extractor.NormalizeExceptionType.
-func scalaCaseBlockCatchTypes(parent *sitter.Node, src []byte) []string {
+func scalaCaseBlockCatchTypes(parent ts.Node, src []byte) []string {
 	caseBlock := firstChildOfType(parent, "case_block")
 	if caseBlock == nil {
 		return nil
@@ -185,7 +185,7 @@ func scalaCaseBlockCatchTypes(parent *sitter.Node, src []byte) []string {
 // (`case _ =>`), a stable-identifier value pattern, or an extractor pattern
 // (`case NonFatal(e) =>`) — none of which name a statically-caught exception
 // type.
-func scalaTypedPatternType(caseClause *sitter.Node, src []byte) string {
+func scalaTypedPatternType(caseClause ts.Node, src []byte) string {
 	tp := firstChildOfType(caseClause, "typed_pattern")
 	if tp == nil {
 		return ""
@@ -217,7 +217,7 @@ func scalaTypedPatternType(caseClause *sitter.Node, src []byte) string {
 // (`java.io.IOException`) yields its full dotted text (normalized to the bare
 // leaf downstream). An `instance_expression` (`new X(...)`) yields the type of
 // its first type-bearing child. Returns "" for any other node.
-func scalaTypeNodeText(n *sitter.Node, src []byte) string {
+func scalaTypeNodeText(n ts.Node, src []byte) string {
 	switch n.Type() {
 	case "type_identifier", "stable_type_identifier":
 		return strings.TrimSpace(string(src[n.StartByte():n.EndByte()]))
@@ -244,7 +244,7 @@ func scalaTypeNodeText(n *sitter.Node, src []byte) string {
 // firstChildOfType returns the first depth-first descendant of n whose Type()
 // equals typ, or nil. Used to reach case_block / typed_pattern without
 // hard-coding child indices across grammar versions.
-func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func firstChildOfType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}

--- a/internal/extractors/scala/exception_flow_test.go
+++ b/internal/extractors/scala/exception_flow_test.go
@@ -22,7 +22,7 @@ func extractScalaRaw(t *testing.T, src string) []types.EntityRecord {
 		Path:     "demo.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/scala/issue4432_constantset_test.go
+++ b/internal/extractors/scala/issue4432_constantset_test.go
@@ -81,7 +81,7 @@ func extractScala(t *testing.T, path, src string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/scala/relationships_test.go
+++ b/internal/extractors/scala/relationships_test.go
@@ -17,7 +17,7 @@ func runScala(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/scala/scala.go
+++ b/internal/extractors/scala/scala.go
@@ -34,7 +34,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -52,7 +52,7 @@ func (e *Extractor) Language() string { return "scala" }
 
 // Extract walks the tree-sitter CST and returns entity records.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -74,16 +74,16 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		// JS/TS fix from #570/#575.
 		entities = append(entities, extractor.FileEntity(file))
 	}
-	walkNode(file.Tree.RootNode(), file, nil, &entities)
+	walkNode(file.TSTree.RootNode(), file, nil, &entities)
 	// #4432 — index Scala constant collections / enumerations (object const
 	// groups, `val X = Map(...)`, Scala 3 `enum`, sealed-trait + case-object
 	// enumerations) as searchable SCOPE.Enum value-sets carrying structured
 	// members_json. Runs independently of the structural walk above.
-	emitConstantSets(file.Tree.RootNode(), file, &entities)
+	emitConstantSets(file.TSTree.RootNode(), file, &entities)
 	// Epic #3628 — error-flow topology: THROWS / CATCHES edges from functions
 	// to shared SCOPE.ExceptionType convergence nodes. Runs after the main
 	// walk so the SCOPE.Operation host entities exist for FromName attachment.
-	emitExceptionFlowEdges(file.Tree.RootNode(), file, &entities)
+	emitExceptionFlowEdges(file.TSTree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "scala")
 	extractor.TagEntitiesLanguage(entities, "scala")
@@ -119,7 +119,7 @@ type classCtx struct {
 // Issue #379: class/object/trait declarations attach CONTAINS edges per
 // function declared inside their template_body, and every function body
 // is scanned for call_expression descendants that yield CALLS edges.
-func walkNode(node *sitter.Node, file extractor.FileInput, cc *classCtx, out *[]types.EntityRecord) {
+func walkNode(node ts.Node, file extractor.FileInput, cc *classCtx, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -176,7 +176,7 @@ func walkNode(node *sitter.Node, file extractor.FileInput, cc *classCtx, out *[]
 // fields/parameters are passed down via classCtx so member functions can
 // resolve receiver types on call_expression nodes.
 func emitContainerWithMembers(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	subtype string,
 	out *[]types.EntityRecord,
@@ -246,7 +246,7 @@ func emitContainerWithMembers(
 
 // findTemplateBody returns the template_body child of a class/object/
 // trait declaration, or nil when the declaration has no body.
-func findTemplateBody(node *sitter.Node) *sitter.Node {
+func findTemplateBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "template_body" {
@@ -259,7 +259,7 @@ func findTemplateBody(node *sitter.Node) *sitter.Node {
 // findFunctionBody returns the block child of a function_definition that
 // holds the call expressions, or nil when the function is abstract
 // (function_declaration) / expression-body without a block.
-func findFunctionBody(node *sitter.Node) *sitter.Node {
+func findFunctionBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "block" {
@@ -277,7 +277,7 @@ func findFunctionBody(node *sitter.Node) *sitter.Node {
 // definition, var_definition and class_parameter. Generic parameters
 // are stripped so `List[Owner]` yields "List" — matching the java
 // resolver's index shape.
-func collectContainerFieldTypes(node *sitter.Node, src []byte) map[string]string {
+func collectContainerFieldTypes(node ts.Node, src []byte) map[string]string {
 	out := map[string]string{}
 
 	// Class parameters (`class C(val repo: Repo, x: Int)`).
@@ -321,7 +321,7 @@ func collectContainerFieldTypes(node *sitter.Node, src []byte) map[string]string
 // extractNamedTypePair returns (name, leafType) for a node that has a
 // direct identifier child followed (optionally) by a type_identifier or
 // generic_type child. Returns ("", "") when either is missing.
-func extractNamedTypePair(node *sitter.Node, src []byte) (string, string) {
+func extractNamedTypePair(node ts.Node, src []byte) (string, string) {
 	var name, typ string
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
@@ -354,7 +354,7 @@ func extractNamedTypePair(node *sitter.Node, src []byte) (string, string) {
 // type for every parameter declared on a function_definition /
 // function_declaration node. Used by the receiver binder so a call like
 // `p.go()` inside `def f(p: Param)` resolves to "Param.go".
-func collectParamTypes(node *sitter.Node, src []byte) map[string]string {
+func collectParamTypes(node ts.Node, src []byte) map[string]string {
 	out := map[string]string{}
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
@@ -395,7 +395,7 @@ func collectParamTypes(node *sitter.Node, src []byte) map[string]string {
 // class is not statically recoverable from a `new` or an explicit annotation.
 // First binding per name wins. Generic wrappers are stripped to the leaf type
 // (`new List[Owner]` → "List") to match the field/param index shape.
-func collectScalaLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
+func collectScalaLocalVarTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -425,7 +425,7 @@ func collectScalaLocalVarTypes(body *sitter.Node, src []byte) map[string]string 
 // scalaLocalVarName returns the bound name of a val_definition/var_definition —
 // the first direct `identifier` child (`val c: T = …` → "c"). Returns "" for a
 // pattern/destructuring binding with no plain identifier.
-func scalaLocalVarName(decl *sitter.Node, src []byte) string {
+func scalaLocalVarName(decl ts.Node, src []byte) string {
 	for i := 0; i < int(decl.ChildCount()); i++ {
 		ch := decl.Child(i)
 		if ch.Type() == "identifier" {
@@ -439,7 +439,7 @@ func scalaLocalVarName(decl *sitter.Node, src []byte) string {
 // instance_expression initializer constructs (`val c = new FooController(svc)` →
 // "FooController"). Returns "" when the RHS is not a direct `new` expression.
 // A generic_type leaf is stripped to its first type_identifier.
-func scalaInstanceExprType(decl *sitter.Node, src []byte) string {
+func scalaInstanceExprType(decl ts.Node, src []byte) string {
 	for i := 0; i < int(decl.ChildCount()); i++ {
 		ch := decl.Child(i)
 		if ch.Type() != "instance_expression" {
@@ -480,7 +480,7 @@ var scalaKeywordStop = map[string]bool{
 // Self-recursion is dropped to match the java/kotlin extractor dedup
 // semantics.
 func extractCallRelationships(
-	body *sitter.Node,
+	body ts.Node,
 	src []byte,
 	callerName string,
 	cc *classCtx,
@@ -549,7 +549,7 @@ func extractCallRelationships(
 // Returns (target, receiverType). receiverType is non-empty only when a
 // field_expression receiver bound to a known type.
 func scalaCallTarget(
-	call *sitter.Node,
+	call ts.Node,
 	src []byte,
 	cc *classCtx,
 	paramTypes map[string]string,
@@ -566,7 +566,7 @@ func scalaCallTarget(
 		// field_expression has children: identifier "." identifier ...
 		// Method = last identifier; receiver = first identifier.
 		var method, receiver string
-		var idents []*sitter.Node
+		var idents []ts.Node
 		for i := 0; i < int(first.ChildCount()); i++ {
 			ch := first.Child(i)
 			if ch.Type() == "identifier" {
@@ -631,7 +631,7 @@ func isPascalCase(s string) bool {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -639,8 +639,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -660,7 +660,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 // matches.
 //
 // Issue #690 — closes the Scala analog of the Python field orphan gap (#689).
-func buildScalaField(node *sitter.Node, file extractor.FileInput, parentType string) (types.EntityRecord, bool) {
+func buildScalaField(node ts.Node, file extractor.FileInput, parentType string) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -694,7 +694,7 @@ func buildScalaField(node *sitter.Node, file extractor.FileInput, parentType str
 // regardless of whether they carry a `val`/`var` modifier (case classes
 // generate accessors by default).
 func emitScalaCaseClassFields(
-	classNode *sitter.Node,
+	classNode ts.Node,
 	file extractor.FileInput,
 	className string,
 	classIdx int,
@@ -740,7 +740,7 @@ func emitScalaCaseClassFields(
 }
 
 // buildComponent creates a SCOPE.Component entity.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -759,7 +759,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 }
 
 // buildOperation creates a SCOPE.Operation entity for function definitions.
-func buildOperation(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildOperation(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -796,7 +796,7 @@ func buildOperation(node *sitter.Node, file extractor.FileInput, subtype string)
 // "import" identifier "." identifier ... [namespace_selectors |
 // namespace_wildcard | identifier]. We reconstruct the dotted base
 // path from the direct children.
-func buildImports(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func buildImports(node ts.Node, file extractor.FileInput) []types.EntityRecord {
 	var pathParts []string
 	var selectors []string
 	hasWildcard := false
@@ -911,7 +911,7 @@ func buildImports(node *sitter.Node, file extractor.FileInput) []types.EntityRec
 }
 
 // extractName finds the name of a declaration node.
-func extractName(node *sitter.Node, src []byte) string {
+func extractName(node ts.Node, src []byte) string {
 	if child := node.ChildByFieldName("name"); child != nil {
 		return string(src[child.StartByte():child.EndByte()])
 	}
@@ -935,7 +935,7 @@ func extractName(node *sitter.Node, src []byte) string {
 }
 
 // firstLine returns the first line of the node's source text.
-func firstLine(src []byte, node *sitter.Node) string {
+func firstLine(src []byte, node ts.Node) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "\n"); idx >= 0 {
 		raw = raw[:idx]
@@ -945,7 +945,7 @@ func firstLine(src []byte, node *sitter.Node) string {
 
 // methodSignature extracts a clean method signature, truncating at body.
 // Matches Python's behavior: "def name(params): ReturnType" without body.
-func methodSignature(src []byte, node *sitter.Node) string {
+func methodSignature(src []byte, node ts.Node) string {
 	raw := firstLine(src, node)
 	// Remove "override " prefix for cleaner parity
 	raw = strings.TrimPrefix(raw, "override ")
@@ -960,7 +960,7 @@ func methodSignature(src []byte, node *sitter.Node) string {
 
 // classSignature extracts a clean class/trait signature without body.
 // Strips extends/with clauses and type parameters to match Python convention.
-func classSignature(src []byte, node *sitter.Node) string {
+func classSignature(src []byte, node ts.Node) string {
 	raw := firstLine(src, node)
 	// Truncate at opening brace or opening paren for case classes with params.
 	if idx := strings.Index(raw, "{"); idx >= 0 {

--- a/internal/extractors/scala/scala_test.go
+++ b/internal/extractors/scala/scala_test.go
@@ -5,19 +5,23 @@ import (
 	"errors"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsscala "github.com/smacker/go-tree-sitter/scala"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/scala"
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsscala.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsscala.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -57,7 +61,7 @@ trait Repository[T] {
 		Path:     "service.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -109,7 +113,7 @@ class Foo {
 		Path:     "foo.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -145,7 +149,7 @@ trait Serializable {
 		Path:     "serializable.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -175,7 +179,7 @@ object Config {
 		Path:     "config.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -205,7 +209,7 @@ class MathHelper {
 		Path:     "math.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -239,7 +243,7 @@ class Foo {}
 		Path:     "imports.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -267,7 +271,7 @@ func TestScalaExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.scala",
 		Content:  []byte(""),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -284,7 +288,7 @@ func TestScalaExtractor_NilTree(t *testing.T) {
 		Path:     "nil.scala",
 		Content:  []byte("class Foo {}"),
 		Language: "scala",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)
@@ -316,7 +320,7 @@ case class Point(x: Double, y: Double)
 		Path:     "point.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -348,7 +352,7 @@ object App {}
 		Path:     "multi.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -398,7 +402,7 @@ class Views {}
 		Path:     "app/views/index.scala.html",
 		Content:  []byte(minimalScala),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -429,7 +433,7 @@ func TestScalaExtractor_RegularScalaFileNotTwirl(t *testing.T) {
 		Path:     "app/models/Foo.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -461,7 +465,7 @@ func TestScalaExtractor_TwirlVariantExtensions(t *testing.T) {
 			Path:     path,
 			Content:  []byte(src),
 			Language: "scala",
-			Tree:     tree,
+			TSTree:   tree,
 		})
 		if err != nil {
 			t.Fatalf("unexpected error for %s: %v", path, err)
@@ -501,7 +505,7 @@ object MyController {
 		Path:     "controllers/MyController.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -543,7 +547,7 @@ class TickService(val counter: Counter) {
 		Path:     "services/TickService.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -589,7 +593,7 @@ class OrderProcessor {
 		Path:     "OrderProcessor.scala",
 		Content:  []byte(src),
 		Language: "scala",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/shell/issue5158_literal_binding_test.go
+++ b/internal/extractors/shell/issue5158_literal_binding_test.go
@@ -23,7 +23,7 @@ func extractShell5158(t *testing.T, src string) []types.EntityRecord {
 		Path:     "dispatch.sh",
 		Content:  []byte(src),
 		Language: "shell",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/shell/relationships_test.go
+++ b/internal/extractors/shell/relationships_test.go
@@ -60,7 +60,7 @@ main() {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "test.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -88,7 +88,7 @@ foo() { :; }
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "test.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -140,7 +140,7 @@ other_thing() {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "test.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -175,7 +175,7 @@ main() {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "test.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -207,7 +207,7 @@ func TestShell_Calls_DropSelfRecursion(t *testing.T) {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "test.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -232,7 +232,7 @@ main() {
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "test.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -258,7 +258,7 @@ main() { :; }
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "scripts/run.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)
@@ -295,7 +295,7 @@ main() { helper; }
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:    "x.sh",
 		Content: []byte(src),
-		Tree:    tree,
+		TSTree:  tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/shell/shell.go
+++ b/internal/extractors/shell/shell.go
@@ -34,7 +34,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -57,11 +57,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	// Fall back to regex if no tree is available.
-	if file.Tree == nil {
+	if file.TSTree == nil {
 		return extractRegex(file), nil
 	}
 
-	root := file.Tree.RootNode()
+	root := file.TSTree.RootNode()
 	imports := collectSources(root, file.Content)
 
 	// Pass 1: IMPORTS — emit one stub entity per `source`/`.` command.
@@ -92,7 +92,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 }
 
 // walkShell performs a depth-first traversal collecting function_definition nodes.
-func walkShell(node *sitter.Node, file extractor.FileInput, imports []string, localFns map[string]bool, out *[]types.EntityRecord) {
+func walkShell(node ts.Node, file extractor.FileInput, imports []string, localFns map[string]bool, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -111,7 +111,7 @@ func walkShell(node *sitter.Node, file extractor.FileInput, imports []string, lo
 
 // findCompoundStatement returns the `compound_statement` body child of a
 // function_definition node, or nil.
-func findCompoundStatement(node *sitter.Node) *sitter.Node {
+func findCompoundStatement(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -125,7 +125,7 @@ func findCompoundStatement(node *sitter.Node) *sitter.Node {
 }
 
 // buildFunction creates a SCOPE.Operation entity for a function_definition node.
-func buildFunction(node *sitter.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
+func buildFunction(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
 	nameNode := node.ChildByFieldName("name")
 	if nameNode == nil {
 		// Try first word child.
@@ -164,13 +164,13 @@ func buildFunction(node *sitter.Node, file extractor.FileInput, imports []string
 // collectSources collects source/. commands as the legacy
 // Properties["imports"] string list (preserved for backwards compatibility
 // with the existing Operation-entity contract).
-func collectSources(root *sitter.Node, src []byte) []string {
+func collectSources(root ts.Node, src []byte) []string {
 	var imports []string
 	walkForSources(root, src, &imports)
 	return imports
 }
 
-func walkForSources(node *sitter.Node, src []byte, out *[]string) {
+func walkForSources(node ts.Node, src []byte, out *[]string) {
 	if node == nil {
 		return
 	}
@@ -191,7 +191,7 @@ func walkForSources(node *sitter.Node, src []byte, out *[]string) {
 //	  command_name
 //	    word "source"   (or word ".")
 //	  word "<path>"
-func sourceCommandArg(node *sitter.Node, src []byte) string {
+func sourceCommandArg(node ts.Node, src []byte) string {
 	if node == nil || node.Type() != "command" || node.ChildCount() < 2 {
 		return ""
 	}
@@ -222,11 +222,11 @@ func sourceCommandArg(node *sitter.Node, src []byte) string {
 // source/. command, each carrying a single IMPORTS edge file→path. Mirrors
 // the lua/dart/elixir contract: per-import entity records so the resolver
 // can dispatch on Properties["language"] (#90).
-func emitImportStubs(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func emitImportStubs(root ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	walkForImportStubs(root, file, out)
 }
 
-func walkForImportStubs(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walkForImportStubs(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -276,13 +276,13 @@ func makeImportStub(file extractor.FileInput, path string) types.EntityRecord {
 // restrict CALLS edges to identifiers known to be functions defined in this
 // file (the issue spec — bash can't reliably distinguish function calls from
 // external program invocations otherwise).
-func collectLocalFunctionNames(root *sitter.Node, src []byte) map[string]bool {
+func collectLocalFunctionNames(root ts.Node, src []byte) map[string]bool {
 	out := make(map[string]bool)
 	walkForFnNames(root, src, out)
 	return out
 }
 
-func walkForFnNames(node *sitter.Node, src []byte, out map[string]bool) {
+func walkForFnNames(node ts.Node, src []byte, out map[string]bool) {
 	if node == nil {
 		return
 	}
@@ -313,7 +313,7 @@ func walkForFnNames(node *sitter.Node, src []byte, out map[string]bool) {
 // command head inside body whose identifier matches a known local function
 // (localFns). External program invocations are dropped. Self-recursion is
 // dropped, results are deduped.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string, localFns map[string]bool) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string, localFns map[string]bool) []types.RelationshipRecord {
 	if body == nil || callerName == "" || len(localFns) == 0 {
 		return nil
 	}
@@ -329,8 +329,8 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string, 
 
 	// Walk the body in document order so a binding established earlier is visible
 	// to a later command head (last-write-wins / taint semantics).
-	var walk func(n *sitter.Node)
-	walk = func(n *sitter.Node) {
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -372,14 +372,14 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string, 
 //	cmd=do_work        → Bind("cmd", "do_work")
 //	other="run_it"     → Bind("other", "run_it")
 //	bad=$(date)        → Taint("bad")
-func recordShellAssignment(n *sitter.Node, src []byte, binder *extractor.LiteralBindingResolver) {
+func recordShellAssignment(n ts.Node, src []byte, binder *extractor.LiteralBindingResolver) {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil || nameNode.Type() != "variable_name" {
 		return
 	}
 	name := string(src[nameNode.StartByte():nameNode.EndByte()])
 	// The value is the first non-(variable_name,"=") child.
-	var val *sitter.Node
+	var val ts.Node
 	for i := 0; i < int(n.ChildCount()); i++ {
 		ch := n.Child(i)
 		if ch == nil {
@@ -408,7 +408,7 @@ func recordShellAssignment(n *sitter.Node, src []byte, binder *extractor.Literal
 // a bare `word` (cmd=do_work) and a double/single-quoted `string` whose only
 // content is a single string_content child (other="run_it"). A quoted string
 // containing an expansion or anything other than literal text is rejected.
-func shellStringLiteral(val *sitter.Node, src []byte) (string, bool) {
+func shellStringLiteral(val ts.Node, src []byte) (string, bool) {
 	if val == nil {
 		return "", false
 	}
@@ -425,7 +425,7 @@ func shellStringLiteral(val *sitter.Node, src []byte) (string, bool) {
 	case "string":
 		// Accept only "literal" — exactly one string_content child between the
 		// quotes. Anything with an expansion/substitution child is non-static.
-		var content *sitter.Node
+		var content ts.Node
 		for i := 0; i < int(val.ChildCount()); i++ {
 			ch := val.Child(i)
 			if ch == nil {
@@ -465,7 +465,7 @@ func shellStringLiteral(val *sitter.Node, src []byte) (string, bool) {
 //	  command_name                            (or string wrapping it: "$cmd")
 //	    simple_expansion
 //	      $ ; variable_name "<var>"
-func commandHeadName(cmd *sitter.Node, src []byte, binder *extractor.LiteralBindingResolver) (head, dynVar string) {
+func commandHeadName(cmd ts.Node, src []byte, binder *extractor.LiteralBindingResolver) (head, dynVar string) {
 	if cmd == nil || cmd.ChildCount() == 0 {
 		return "", ""
 	}
@@ -496,7 +496,7 @@ func commandHeadName(cmd *sitter.Node, src []byte, binder *extractor.LiteralBind
 // exactly one `$var` simple_expansion, optionally wrapped in a double-quoted
 // string ("$var"); "" when the head is anything else (literal text, multiple
 // expansions, concatenations, ${var}-with-ops, etc.).
-func loneExpansionVar(nameNode *sitter.Node, src []byte) string {
+func loneExpansionVar(nameNode ts.Node, src []byte) string {
 	// Unwrap a single double-quoted string child.
 	node := nameNode
 	if c := singleSignificantChild(node); c != nil && c.Type() == "string" {
@@ -518,11 +518,11 @@ func loneExpansionVar(nameNode *sitter.Node, src []byte) string {
 // singleSignificantChild returns the unique non-quote child of node, or nil when
 // node has zero or more than one significant child. Quote (`"`) tokens are
 // ignored so a `"$var"` string is treated as wrapping a single expansion.
-func singleSignificantChild(node *sitter.Node) *sitter.Node {
+func singleSignificantChild(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
-	var only *sitter.Node
+	var only ts.Node
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch == nil || ch.Type() == "\"" {
@@ -537,7 +537,7 @@ func singleSignificantChild(node *sitter.Node) *sitter.Node {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -545,8 +545,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]

--- a/internal/extractors/shell/shell_test.go
+++ b/internal/extractors/shell/shell_test.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsbash "github.com/smacker/go-tree-sitter/bash"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/shell"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsbash.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsbash.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -54,7 +58,7 @@ build_image() {
 		Path:     "test.sh",
 		Content:  []byte(src),
 		Language: "shell",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -108,7 +112,7 @@ func TestShellExtractor_Signatures(t *testing.T) {
 		Path:     "test.sh",
 		Content:  []byte(src),
 		Language: "shell",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -148,7 +152,7 @@ cleanup() {
 		Path:     "test.sh",
 		Content:  []byte(src),
 		Language: "shell",
-		Tree:     nil, // force regex fallback
+		TSTree:   nil, // force regex fallback
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/extractors/swift/field_members.go
+++ b/internal/extractors/swift/field_members.go
@@ -3,7 +3,7 @@ package swift
 import (
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -28,7 +28,7 @@ import (
 //	Name      = "<Owner>.<prop>"
 //	Signature = "<type> <prop>"
 func emitSwiftFieldMembers(
-	node, body *sitter.Node,
+	node, body ts.Node,
 	src []byte,
 	ownerName, filePath string,
 ) ([]types.EntityRecord, []string) {
@@ -92,7 +92,7 @@ func emitSwiftFieldMembers(
 // swiftPropertyName returns the bound identifier of a property_declaration's
 // `pattern` child (the first simple_identifier). Tuple bindings
 // (`let (a, b)`) yield only the first identifier — best-effort.
-func swiftPropertyName(prop *sitter.Node, src []byte) string {
+func swiftPropertyName(prop ts.Node, src []byte) string {
 	pat := firstChildOfType(prop, "pattern")
 	if pat == nil {
 		return ""
@@ -108,7 +108,7 @@ func swiftPropertyName(prop *sitter.Node, src []byte) string {
 // distinguish a superclass from adopted protocols, so all are returned; the
 // caller's in-file filter keeps only types we actually modeled (a struct's
 // `: Codable` thus drops out, while `class B: A` keeps the in-file A).
-func swiftInheritedTypeNames(node *sitter.Node, src []byte) []string {
+func swiftInheritedTypeNames(node ts.Node, src []byte) []string {
 	if node == nil {
 		return nil
 	}
@@ -126,7 +126,7 @@ func swiftInheritedTypeNames(node *sitter.Node, src []byte) []string {
 }
 
 // firstChildOfType returns the first direct child of n with the given type.
-func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+func firstChildOfType(n ts.Node, typ string) ts.Node {
 	if n == nil {
 		return nil
 	}

--- a/internal/extractors/swift/issue4854_field_membership_test.go
+++ b/internal/extractors/swift/issue4854_field_membership_test.go
@@ -30,7 +30,7 @@ func swExtract(t *testing.T, src, path string) []types.EntityRecord {
 		Path:     path,
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/swift/relationships_test.go
+++ b/internal/extractors/swift/relationships_test.go
@@ -18,7 +18,7 @@ func runSwift(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Test.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("Extract: %v", err)

--- a/internal/extractors/swift/swift.go
+++ b/internal/extractors/swift/swift.go
@@ -36,7 +36,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -54,7 +54,7 @@ func (e *Extractor) Language() string { return "swift" }
 
 // Extract walks the tree-sitter CST and returns entity records.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
-	if file.Tree == nil || len(file.Content) == 0 {
+	if file.TSTree == nil || len(file.Content) == 0 {
 		return nil, nil
 	}
 
@@ -64,7 +64,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// originating repo via the resolver's byName index. Generalises the
 	// JS/TS fix from #570/#575.
 	entities = append(entities, extractor.FileEntity(file))
-	walkNode(file.Tree.RootNode(), file, &entities)
+	walkNode(file.TSTree.RootNode(), file, &entities)
 	// Issue #4854 — in-file base-class EXTENDS for field-membership recursion.
 	entities = attachSwiftExtends(entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
@@ -79,7 +79,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 // function declared inside the body, and every function body is scanned for
 // call_expression nodes that yield CALLS edges. import_declaration emits
 // IMPORTS with the property contract.
-func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walkNode(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -208,7 +208,7 @@ func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRe
 // walkBody recurses into a class/struct/enum body, emitting Operation
 // entities for each function and propagating field types so CALLS edges
 // inside method bodies can carry a receiver_type property.
-func walkBody(node *sitter.Node, file extractor.FileInput, fieldTypes map[string]string, _ string, out *[]types.EntityRecord) {
+func walkBody(node ts.Node, file extractor.FileInput, fieldTypes map[string]string, _ string, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
@@ -226,7 +226,7 @@ func walkBody(node *sitter.Node, file extractor.FileInput, fieldTypes map[string
 }
 
 // findClassBody returns the body child of a class/struct/enum declaration.
-func findClassBody(node *sitter.Node) *sitter.Node {
+func findClassBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		t := ch.Type()
@@ -238,7 +238,7 @@ func findClassBody(node *sitter.Node) *sitter.Node {
 }
 
 // findFunctionBody returns the function_body child of a function_declaration.
-func findFunctionBody(node *sitter.Node) *sitter.Node {
+func findFunctionBody(node ts.Node) ts.Node {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "function_body" {
@@ -253,7 +253,7 @@ func findFunctionBody(node *sitter.Node) *sitter.Node {
 // properties with an explicit type_annotation participate. Used to attach
 // receiver_type to CALLS edges where the receiver is a known same-class
 // field.
-func collectFieldTypes(body *sitter.Node, src []byte) map[string]string {
+func collectFieldTypes(body ts.Node, src []byte) map[string]string {
 	if body == nil {
 		return nil
 	}
@@ -289,7 +289,7 @@ func collectFieldTypes(body *sitter.Node, src []byte) map[string]string {
 
 // firstDescendantText returns the source text of the first descendant of
 // node whose type is `kind`, or "" when none exists.
-func firstDescendantText(node *sitter.Node, src []byte, kind string) string {
+func firstDescendantText(node ts.Node, src []byte, kind string) string {
 	if node == nil {
 		return ""
 	}
@@ -340,7 +340,7 @@ var swiftBareInitFiltered = map[string]bool{
 // When the receiver is a known same-class field, the edge carries
 // Properties["receiver_type"]=<DeclaredType>. Self-recursion is dropped to
 // match Python/Go extractor dedup semantics.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string, fieldTypes map[string]string) []types.RelationshipRecord {
+func extractCallRelationships(body ts.Node, src []byte, callerName string, fieldTypes map[string]string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -411,7 +411,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string, 
 // rightmost `simple_identifier` of the trailing `navigation_suffix`, NOT
 // the leftmost descendant. The receiver root is the leftmost
 // simple_identifier of the chain — used to look up a declared field type.
-func swiftCallTarget(call *sitter.Node, src []byte) (target, receiverRoot string) {
+func swiftCallTarget(call ts.Node, src []byte) (target, receiverRoot string) {
 	if !hasCallSuffix(call) {
 		return "", ""
 	}
@@ -424,7 +424,7 @@ func swiftCallTarget(call *sitter.Node, src []byte) (target, receiverRoot string
 		return string(src[first.StartByte():first.EndByte()]), ""
 	case "navigation_expression":
 		// Trailing navigation_suffix gives the method name.
-		var lastSuffix *sitter.Node
+		var lastSuffix ts.Node
 		for i := 0; i < int(first.ChildCount()); i++ {
 			ch := first.Child(i)
 			if ch.Type() == "navigation_suffix" {
@@ -470,7 +470,7 @@ func swiftCallTarget(call *sitter.Node, src []byte) (target, receiverRoot string
 // hasCallSuffix reports whether a call_expression node has a `call_suffix`
 // child — its presence (parentheses or trailing closure) is what makes the
 // node a real invocation rather than a bare property reference.
-func hasCallSuffix(call *sitter.Node) bool {
+func hasCallSuffix(call ts.Node) bool {
 	for i := 0; i < int(call.ChildCount()); i++ {
 		if call.Child(i).Type() == "call_suffix" {
 			return true
@@ -480,7 +480,7 @@ func hasCallSuffix(call *sitter.Node) bool {
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.
-func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+func findAllNodes(root ts.Node, kinds ...string) []ts.Node {
 	if root == nil {
 		return nil
 	}
@@ -488,8 +488,8 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 	for _, k := range kinds {
 		set[k] = true
 	}
-	var out []*sitter.Node
-	stack := []*sitter.Node{root}
+	var out []ts.Node
+	stack := []ts.Node{root}
 	for len(stack) > 0 {
 		n := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
@@ -504,7 +504,7 @@ func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
 }
 
 // buildComponent creates a SCOPE.Component entity.
-func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildComponent(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -525,7 +525,7 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 }
 
 // buildOperation creates a SCOPE.Operation entity.
-func buildOperation(node *sitter.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
+func buildOperation(node ts.Node, file extractor.FileInput, subtype string) (types.EntityRecord, bool) {
 	name := extractName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -546,7 +546,7 @@ func buildOperation(node *sitter.Node, file extractor.FileInput, subtype string)
 
 // methodSignature extracts a clean method signature matching Python's format:
 // "func name() -> ReturnType" — uses "()" placeholder and only includes return type.
-func methodSignature(src []byte, node *sitter.Node) string {
+func methodSignature(src []byte, node ts.Node) string {
 	name := extractName(node, src)
 	if name == "" {
 		return ""
@@ -588,7 +588,7 @@ func methodSignature(src []byte, node *sitter.Node) string {
 //  2. Name is namespaced as `<file>::import::<module>` so that even if
 //     a downstream consumer ignores Subtype the carrier name cannot
 //     match a bare Swift type/target identifier.
-func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	raw := extractImportPath(node, file.Content)
 	if raw == "" {
 		return types.EntityRecord{}, false
@@ -637,11 +637,11 @@ func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 // (e.g. `_documentation.visibility.internal._exported.Foundation`).
 // Detection is by tree-sitter node type — not by hardcoded attribute name —
 // so any current or future Swift attribute spelling is skipped.
-func extractImportPath(node *sitter.Node, src []byte) string {
+func extractImportPath(node ts.Node, src []byte) string {
 	// Collect all identifier-like child segments and join with '.'.
 	var parts []string
-	var collect func(n *sitter.Node)
-	collect = func(n *sitter.Node) {
+	var collect func(n ts.Node)
+	collect = func(n ts.Node) {
 		if n == nil {
 			return
 		}
@@ -685,7 +685,7 @@ func extractImportPath(node *sitter.Node, src []byte) string {
 }
 
 // extractName finds the name of a declaration node.
-func extractName(node *sitter.Node, src []byte) string {
+func extractName(node ts.Node, src []byte) string {
 	if child := node.ChildByFieldName("name"); child != nil {
 		return string(src[child.StartByte():child.EndByte()])
 	}
@@ -711,7 +711,7 @@ func extractName(node *sitter.Node, src []byte) string {
 }
 
 // firstLine returns the first line of the node's source text.
-func firstLine(src []byte, node *sitter.Node) string {
+func firstLine(src []byte, node ts.Node) string {
 	raw := string(src[node.StartByte():node.EndByte()])
 	if idx := strings.Index(raw, "\n"); idx >= 0 {
 		return strings.TrimSpace(raw[:idx])

--- a/internal/extractors/swift/swift_test.go
+++ b/internal/extractors/swift/swift_test.go
@@ -6,19 +6,23 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsswift "github.com/smacker/go-tree-sitter/swift"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/swift"
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-func parseForTest(t *testing.T, src string) *sitter.Tree {
+func parseForTest(t *testing.T, src string) ts.Tree {
 	t.Helper()
-	parser := sitter.NewParser()
-	parser.SetLanguage(tsswift.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, []byte(src))
+	parser, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsswift.GetLanguage()))
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -57,7 +61,7 @@ protocol Repository {
 		Path:     "service.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -109,7 +113,7 @@ class Foo {
 		Path:     "foo.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -146,7 +150,7 @@ struct Point {
 		Path:     "point.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -176,7 +180,7 @@ protocol Drawable {
 		Path:     "drawable.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -208,7 +212,7 @@ class Svc {
 		Path:     "svc.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -239,7 +243,7 @@ class App {}
 		Path:     "app.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -290,7 +294,7 @@ class App {
 		Path:     "main.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -361,7 +365,7 @@ import Vapor
 		Path:     "imports.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -420,7 +424,7 @@ class C {
 		Path:     "c.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -481,7 +485,7 @@ class D {
 		Path:     "d.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -510,7 +514,7 @@ func TestSwiftExtractor_EmptyFile(t *testing.T) {
 		Path:     "empty.swift",
 		Content:  []byte(""),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -527,7 +531,7 @@ func TestSwiftExtractor_NilTree(t *testing.T) {
 		Path:     "nil.swift",
 		Content:  []byte("class Foo {}"),
 		Language: "swift",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error on nil tree: %v", err)

--- a/internal/extractors/swift/types.go
+++ b/internal/extractors/swift/types.go
@@ -38,7 +38,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -47,7 +47,7 @@ import (
 // buildEnumValueSet parses an `enum` class_declaration into a SCOPE.Enum
 // value-set carrying its case members. Returns false when the enum has no
 // extractable cases (e.g. a generic-parameter-only forward decl).
-func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildEnumValueSet(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	name := enumName(node, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
@@ -64,7 +64,7 @@ func buildEnumValueSet(node *sitter.Node, file extractor.FileInput) (types.Entit
 }
 
 // enumName returns the type_identifier name child of an enum declaration.
-func enumName(node *sitter.Node, src []byte) string {
+func enumName(node ts.Node, src []byte) string {
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "type_identifier" {
@@ -77,7 +77,7 @@ func enumName(node *sitter.Node, src []byte) string {
 // collectEnumCases walks the enum_class_body for enum_entry nodes and emits
 // one EnumMember per declared case identifier. A `case a, b` group yields two
 // members; a `case x = <literal>` raw value is lifted to the member value.
-func collectEnumCases(body *sitter.Node, src []byte) []extractor.EnumMember {
+func collectEnumCases(body ts.Node, src []byte) []extractor.EnumMember {
 	var members []extractor.EnumMember
 	for i := 0; i < int(body.ChildCount()); i++ {
 		entry := body.Child(i)
@@ -121,7 +121,7 @@ func collectEnumCases(body *sitter.Node, src []byte) []extractor.EnumMember {
 
 // buildTypeAlias parses a `typealias_declaration` into a SCOPE.Schema
 // type_alias record carrying the aliased type body.
-func buildTypeAlias(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildTypeAlias(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
 	var name, body string
 	sawEq := false
 	for i := 0; i < int(node.ChildCount()); i++ {

--- a/internal/extractors/swift/types_test.go
+++ b/internal/extractors/swift/types_test.go
@@ -20,7 +20,7 @@ func extractSwift(t *testing.T, src string) []types.EntityRecord {
 		Path:     "Types.swift",
 		Content:  []byte(src),
 		Language: "swift",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 	if err != nil {
 		t.Fatalf("extract: %v", err)

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -54,7 +54,7 @@ import (
 	"strconv"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -91,12 +91,15 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 		return nil, nil
 	}
 
-	tree := file.Tree
+	tree := file.TSTree
 	if tree == nil {
-		parser := sitter.NewParser()
-		parser.SetLanguage(yamlGrammar())
+		parser, perr := yamlAdapter.NewParser(yamlGrammar())
+		if perr != nil {
+			return nil, perr
+		}
+		defer parser.Close()
 		var err error
-		tree, err = parser.ParseCtx(ctx, nil, file.Content)
+		tree, err = parser.Parse(file.Content)
 		if err != nil {
 			return nil, err
 		}
@@ -311,7 +314,7 @@ func containsTopLevelKey(content, key string) bool {
 // Dispatch
 // ---------------------------------------------------------------------------
 
-func extractByFlavor(flavor string, root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractByFlavor(flavor string, root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("yaml: extraction panic for flavor %s: %v", flavor, r)
@@ -367,7 +370,7 @@ func extractByFlavor(flavor string, root *sitter.Node, file extractor.FileInput)
 // Document from an Ansible playbook Document.
 //
 // Issue #474 chain-fix.
-func buildYAMLDocument(flavor string, root *sitter.Node, file extractor.FileInput) types.EntityRecord {
+func buildYAMLDocument(flavor string, root ts.Node, file extractor.FileInput) types.EntityRecord {
 	endLine := bytes.Count(file.Content, []byte("\n")) + 1
 	if root != nil {
 		endLine = int(root.EndPoint().Row) + 1
@@ -394,7 +397,7 @@ func buildYAMLDocument(flavor string, root *sitter.Node, file extractor.FileInpu
 // ---------------------------------------------------------------------------
 
 // nodeText returns the text of a node from source bytes.
-func nodeText(node *sitter.Node, src []byte) string {
+func nodeText(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -422,8 +425,8 @@ func entity(kind, name, subtype, qualifiedName, sourcefile, language string, sta
 // topLevelMappings returns the direct block_mapping_pair children of the document root.
 // YAML tree-sitter structure: stream -> document -> block_node -> block_mapping -> block_mapping_pair
 // Only the FIRST document in the stream is returned. For multi-document files use allDocuments.
-func topLevelMappings(root *sitter.Node) []*sitter.Node {
-	var pairs []*sitter.Node
+func topLevelMappings(root ts.Node) []ts.Node {
+	var pairs []ts.Node
 	if root == nil {
 		return pairs
 	}
@@ -436,8 +439,8 @@ func topLevelMappings(root *sitter.Node) []*sitter.Node {
 }
 
 // documentMappings returns block_mapping_pair children from a single document node.
-func documentMappings(doc *sitter.Node) []*sitter.Node {
-	var pairs []*sitter.Node
+func documentMappings(doc ts.Node) []ts.Node {
+	var pairs []ts.Node
 	if doc == nil {
 		return pairs
 	}
@@ -459,8 +462,8 @@ func documentMappings(doc *sitter.Node) []*sitter.Node {
 }
 
 // allDocuments returns all document nodes in the stream (multi-document YAML support).
-func allDocuments(root *sitter.Node) []*sitter.Node {
-	var docs []*sitter.Node
+func allDocuments(root ts.Node) []ts.Node {
+	var docs []ts.Node
 	if root == nil {
 		return docs
 	}
@@ -474,7 +477,7 @@ func allDocuments(root *sitter.Node) []*sitter.Node {
 }
 
 // findFirstChild returns the first direct child of node with the given type.
-func findFirstChild(node *sitter.Node, nodeType string) *sitter.Node {
+func findFirstChild(node ts.Node, nodeType string) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -490,7 +493,7 @@ func findFirstChild(node *sitter.Node, nodeType string) *sitter.Node {
 // pairValueNode returns the block_node or flow_node value child of a block_mapping_pair.
 // It skips the key node (first flow_node/scalar) and the colon separator, returning
 // the second flow_node or the block_node that holds the value.
-func pairValueNode(pair *sitter.Node) *sitter.Node {
+func pairValueNode(pair ts.Node) ts.Node {
 	if pair == nil {
 		return nil
 	}
@@ -513,7 +516,7 @@ func pairValueNode(pair *sitter.Node) *sitter.Node {
 }
 
 // getBlockMapping returns the block_mapping inside a block_node (or nil).
-func getBlockMapping(node *sitter.Node) *sitter.Node {
+func getBlockMapping(node ts.Node) ts.Node {
 	if node == nil {
 		return nil
 	}
@@ -525,7 +528,7 @@ func getBlockMapping(node *sitter.Node) *sitter.Node {
 
 // getMappingPairsForKey finds the block_mapping_pair with a given key in a list of pairs,
 // then returns child pairs of its value mapping.
-func getMappingPairsForKey(pairs []*sitter.Node, key string, src []byte) []*sitter.Node {
+func getMappingPairsForKey(pairs []ts.Node, key string, src []byte) []ts.Node {
 	for _, p := range pairs {
 		k := pairKeyText(p, src)
 		if k == key {
@@ -534,7 +537,7 @@ func getMappingPairsForKey(pairs []*sitter.Node, key string, src []byte) []*sitt
 			if bm == nil {
 				return nil
 			}
-			var children []*sitter.Node
+			var children []ts.Node
 			for i := range bm.ChildCount() {
 				child := bm.Child(int(i))
 				if child != nil && child.Type() == "block_mapping_pair" {
@@ -549,7 +552,7 @@ func getMappingPairsForKey(pairs []*sitter.Node, key string, src []byte) []*sitt
 
 // pairKeyText extracts clean key text from a block_mapping_pair, handling
 // the different ways tree-sitter YAML represents keys.
-func pairKeyText(pair *sitter.Node, src []byte) string {
+func pairKeyText(pair ts.Node, src []byte) string {
 	if pair == nil {
 		return ""
 	}
@@ -577,7 +580,7 @@ func pairKeyText(pair *sitter.Node, src []byte) string {
 }
 
 // getSequenceItems returns string values from a block_sequence under a block_node.
-func getSequenceItems(valueNode *sitter.Node, src []byte) []string {
+func getSequenceItems(valueNode ts.Node, src []byte) []string {
 	if valueNode == nil {
 		return nil
 	}
@@ -607,7 +610,7 @@ func getSequenceItems(valueNode *sitter.Node, src []byte) []string {
 }
 
 // getSequenceItemMappings returns block_mapping_pair slices for each sequence item.
-func getSequenceItemMappings(valueNode *sitter.Node, src []byte) [][]*sitter.Node {
+func getSequenceItemMappings(valueNode ts.Node, src []byte) [][]ts.Node {
 	if valueNode == nil {
 		return nil
 	}
@@ -615,7 +618,7 @@ func getSequenceItemMappings(valueNode *sitter.Node, src []byte) [][]*sitter.Nod
 	if seq == nil {
 		return nil
 	}
-	var result [][]*sitter.Node
+	var result [][]ts.Node
 	for i := range seq.ChildCount() {
 		item := seq.Child(int(i))
 		if item == nil || item.Type() != "block_sequence_item" {
@@ -628,7 +631,7 @@ func getSequenceItemMappings(valueNode *sitter.Node, src []byte) [][]*sitter.Nod
 			}
 			bm := getBlockMapping(child)
 			if bm != nil {
-				var pairs []*sitter.Node
+				var pairs []ts.Node
 				for k := range bm.ChildCount() {
 					cp := bm.Child(int(k))
 					if cp != nil && cp.Type() == "block_mapping_pair" {
@@ -643,7 +646,7 @@ func getSequenceItemMappings(valueNode *sitter.Node, src []byte) [][]*sitter.Nod
 }
 
 // getPairValueText returns the scalar text value of a block_mapping_pair.
-func getPairValueText(pair *sitter.Node, src []byte) string {
+func getPairValueText(pair ts.Node, src []byte) string {
 	if pair == nil {
 		return ""
 	}
@@ -655,7 +658,7 @@ func getPairValueText(pair *sitter.Node, src []byte) string {
 }
 
 // findPairValueText finds a key in a slice of pairs and returns its value text.
-func findPairValueText(pairs []*sitter.Node, key string, src []byte) string {
+func findPairValueText(pairs []ts.Node, key string, src []byte) string {
 	for _, p := range pairs {
 		if pairKeyText(p, src) == key {
 			return getPairValueText(p, src)
@@ -668,7 +671,7 @@ func findPairValueText(pairs []*sitter.Node, key string, src []byte) string {
 // GitHub Actions extractor
 // ---------------------------------------------------------------------------
 
-func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractGitHubActions(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord
@@ -741,7 +744,7 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 				if jobMapping == nil {
 					continue
 				}
-				var jobPairList []*sitter.Node
+				var jobPairList []ts.Node
 				for i := range jobMapping.ChildCount() {
 					child := jobMapping.Child(int(i))
 					if child != nil && child.Type() == "block_mapping_pair" {
@@ -811,7 +814,7 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 }
 
 // findValueNodeForKey finds a key in a slice of pairs and returns the value node.
-func findValueNodeForKey(pairs []*sitter.Node, key string, src []byte) *sitter.Node {
+func findValueNodeForKey(pairs []ts.Node, key string, src []byte) ts.Node {
 	for _, p := range pairs {
 		if pairKeyText(p, src) == key {
 			return pairValueNode(p)
@@ -821,7 +824,7 @@ func findValueNodeForKey(pairs []*sitter.Node, key string, src []byte) *sitter.N
 }
 
 // pairsLineRange returns the start/end lines covering a slice of pairs.
-func pairsLineRange(pairs []*sitter.Node) (start, end int) {
+func pairsLineRange(pairs []ts.Node) (start, end int) {
 	if len(pairs) == 0 {
 		return 0, 0
 	}
@@ -841,7 +844,7 @@ var gitlabReservedKeys = map[string]bool{
 	"after_script": true, "cache": true,
 }
 
-func extractGitLabCI(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractGitLabCI(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord
@@ -884,7 +887,7 @@ func extractGitLabCI(root *sitter.Node, file extractor.FileInput) []types.Entity
 			if jobBM == nil {
 				continue
 			}
-			var jobPairs []*sitter.Node
+			var jobPairs []ts.Node
 			for i := range jobBM.ChildCount() {
 				child := jobBM.Child(int(i))
 				if child != nil && child.Type() == "block_mapping_pair" {
@@ -910,7 +913,7 @@ func extractGitLabCI(root *sitter.Node, file extractor.FileInput) []types.Entity
 // Docker Compose extractor
 // ---------------------------------------------------------------------------
 
-func extractDockerCompose(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractDockerCompose(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord
@@ -947,7 +950,7 @@ func extractDockerCompose(root *sitter.Node, file extractor.FileInput) []types.E
 					entities = append(entities, svcEnt)
 					continue
 				}
-				var svcPairs []*sitter.Node
+				var svcPairs []ts.Node
 				for i := range svcBM.ChildCount() {
 					child := svcBM.Child(int(i))
 					if child != nil && child.Type() == "block_mapping_pair" {
@@ -1051,7 +1054,7 @@ func extractDockerCompose(root *sitter.Node, file extractor.FileInput) []types.E
 // Kubernetes extractor
 // ---------------------------------------------------------------------------
 
-func extractKubernetes(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractKubernetes(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	var entities []types.EntityRecord
 	// Multi-document YAML: iterate all documents in the stream.
 	for _, doc := range allDocuments(root) {
@@ -1075,7 +1078,7 @@ func extractKubernetes(root *sitter.Node, file extractor.FileInput) []types.Enti
 //	Ingress spec.rules[].host:         → SCOPE.ExternalAPI, subtype="ingress_host"
 //	Ingress spec.rules[].http.paths[].path: → SCOPE.Operation, subtype="ingress_path"
 //	Service selector + ports:          → existing extractK8sService logic
-func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractKubernetesDoc(doc ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	pairs := documentMappings(doc)
 	var entities []types.EntityRecord
@@ -1350,7 +1353,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 
 // k8sTemplatePairs returns (templatePairs, innerSpecPairs) for Deployment/StatefulSet/DaemonSet.
 // innerSpecPairs is spec.template.spec pairs.
-func k8sTemplatePairs(specPairs []*sitter.Node, src []byte) ([]*sitter.Node, []*sitter.Node) {
+func k8sTemplatePairs(specPairs []ts.Node, src []byte) ([]ts.Node, []ts.Node) {
 	templatePairs := getMappingPairsForKey(specPairs, "template", src)
 	if templatePairs == nil {
 		return nil, nil
@@ -1361,7 +1364,7 @@ func k8sTemplatePairs(specPairs []*sitter.Node, src []byte) ([]*sitter.Node, []*
 
 // extractK8sIngress extracts entities from a Kubernetes Ingress spec.
 // Emits ingress_host (SCOPE.ExternalAPI) and ingress_path (SCOPE.Operation).
-func extractK8sIngress(specPairs []*sitter.Node, ingressName, refPrefix string, file extractor.FileInput, src []byte) []types.EntityRecord {
+func extractK8sIngress(specPairs []ts.Node, ingressName, refPrefix string, file extractor.FileInput, src []byte) []types.EntityRecord {
 	var entities []types.EntityRecord
 
 	rulesMappings := getSequenceItemMappings(findValueNodeForKey(specPairs, "rules", src), src)
@@ -1402,7 +1405,7 @@ func extractK8sIngress(specPairs []*sitter.Node, ingressName, refPrefix string, 
 
 // extractK8sService extracts entities from a Kubernetes Service spec.
 // Emits selector labels as SCOPE.Component and service ports as SCOPE.Component.
-func extractK8sService(specPairs []*sitter.Node, svcName, refPrefix string, file extractor.FileInput, src []byte, startLine, endLine int) []types.EntityRecord {
+func extractK8sService(specPairs []ts.Node, svcName, refPrefix string, file extractor.FileInput, src []byte, startLine, endLine int) []types.EntityRecord {
 	var entities []types.EntityRecord
 
 	// Selector entries.
@@ -1449,7 +1452,7 @@ func extractK8sService(specPairs []*sitter.Node, svcName, refPrefix string, file
 // (kind/plural/singular/listKind) as Properties so downstream tooling can map
 // instances of the custom resource back to their schema (#3551). The CRD's own
 // metadata.name is conventionally "<plural>.<group>".
-func extractK8sCRD(pairs []*sitter.Node, crdName, refPrefix string, file extractor.FileInput, src []byte, startLine, endLine int) []types.EntityRecord {
+func extractK8sCRD(pairs []ts.Node, crdName, refPrefix string, file extractor.FileInput, src []byte, startLine, endLine int) []types.EntityRecord {
 	var entities []types.EntityRecord
 	if crdName == "" {
 		return entities
@@ -1548,7 +1551,7 @@ func k8sNamespacedKind(kindVal string) bool {
 
 // findK8sContainers searches for containers in specPairs, drilling into
 // template.spec if needed (Deployment/StatefulSet pattern).
-func findK8sContainers(specPairs []*sitter.Node, src []byte) [][]*sitter.Node {
+func findK8sContainers(specPairs []ts.Node, src []byte) [][]ts.Node {
 	// Try direct spec.containers first
 	containersNode := findValueNodeForKey(specPairs, "containers", src)
 	if containersNode != nil {
@@ -1574,7 +1577,7 @@ func findK8sContainers(specPairs []*sitter.Node, src []byte) [][]*sitter.Node {
 // Ansible extractor
 // ---------------------------------------------------------------------------
 
-func extractAnsible(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractAnsible(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	var entities []types.EntityRecord
 
@@ -1594,7 +1597,7 @@ func extractAnsible(root *sitter.Node, file extractor.FileInput) []types.EntityR
 }
 
 // isDocSequence returns true when a document node has a top-level block_sequence.
-func isDocSequence(doc *sitter.Node) bool {
+func isDocSequence(doc ts.Node) bool {
 	if doc == nil {
 		return false
 	}
@@ -1606,7 +1609,7 @@ func isDocSequence(doc *sitter.Node) bool {
 }
 
 // extractAnsiblePlaybookDoc processes a single document node in playbook format.
-func extractAnsiblePlaybookDoc(doc *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractAnsiblePlaybookDoc(doc ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	var entities []types.EntityRecord
 
@@ -1638,7 +1641,7 @@ func extractAnsiblePlaybookDoc(doc *sitter.Node, file extractor.FileInput) []typ
 			if bm == nil {
 				continue
 			}
-			var playPairs []*sitter.Node
+			var playPairs []ts.Node
 			for k := range bm.ChildCount() {
 				cp := bm.Child(int(k))
 				if cp != nil && cp.Type() == "block_mapping_pair" {
@@ -1690,7 +1693,7 @@ func extractAnsiblePlaybookDoc(doc *sitter.Node, file extractor.FileInput) []typ
 // parentRef is the canonical ref of the enclosing play (e.g. "ansible/play/X")
 // or "" when there's no enclosing play (flat task file). When non-empty, every
 // emitted child carries a CONTAINS edge from parentRef.
-func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []byte, parentRef string) []types.EntityRecord {
+func extractAnsibleSectionPairs(p ts.Node, file extractor.FileInput, src []byte, parentRef string) []types.EntityRecord {
 	key := pairKeyText(p, src)
 	valNode := pairValueNode(p)
 	var entities []types.EntityRecord
@@ -1804,7 +1807,7 @@ func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []
 // All IMPORTS/PATCHES edges originate from the kustomization entity whose
 // QualifiedName equals file.Path, so they resolve against the per-file
 // SCOPE.Document anchor (issue #474 chain-fix) via byQualifiedName.
-func extractKustomize(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractKustomize(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord
@@ -1945,7 +1948,7 @@ func kustPatchTargetStub(targetKind, targetName, patchFile string) string {
 //	patchesStrategicMerge: [ file.yaml, ... ]            (scalar file paths)
 //	patches:              [ { path|patch, target:{kind,name} }, ... ]
 //	patchesJson6902:      [ { target:{group,version,kind,name}, path|patch }, ... ]
-func kustExtractPatches(kustEnt *types.EntityRecord, pairs []*sitter.Node, kustRef string, file extractor.FileInput, src []byte) {
+func kustExtractPatches(kustEnt *types.EntityRecord, pairs []ts.Node, kustRef string, file extractor.FileInput, src []byte) {
 	patchesRel := func(toID, style, targetKind, targetName string) {
 		rel := types.RelationshipRecord{
 			FromID: kustRef,
@@ -1989,7 +1992,7 @@ func kustExtractPatches(kustEnt *types.EntityRecord, pairs []*sitter.Node, kustR
 
 // kustEmitPatchMapping resolves a single patch mapping's target (from a nested
 // target: {kind,name}) and file/inline body, then emits one PATCHES edge.
-func kustEmitPatchMapping(pp []*sitter.Node, style string, emit func(toID, style, targetKind, targetName string), src []byte) {
+func kustEmitPatchMapping(pp []ts.Node, style string, emit func(toID, style, targetKind, targetName string), src []byte) {
 	targetPairs := getMappingPairsForKey(pp, "target", src)
 	targetKind := findPairValueText(targetPairs, "kind", src)
 	targetName := findPairValueText(targetPairs, "name", src)
@@ -2005,7 +2008,7 @@ func kustEmitPatchMapping(pp []*sitter.Node, style string, emit func(toID, style
 // configMapGenerator: / secretGenerator:. The entity Name is the generator's
 // name:; the literals/files it pulls are recorded in Properties so the
 // generated config surface is visible without re-parsing.
-func kustExtractGenerators(pairs []*sitter.Node, kustRef string, file extractor.FileInput, src []byte) []types.EntityRecord {
+func kustExtractGenerators(pairs []ts.Node, kustRef string, file extractor.FileInput, src []byte) []types.EntityRecord {
 	var entities []types.EntityRecord
 
 	for _, gen := range []struct{ field, subtype, kind string }{
@@ -2066,7 +2069,7 @@ func kustExtractGenerators(pairs []*sitter.Node, kustRef string, file extractor.
 // Generic extractor
 // ---------------------------------------------------------------------------
 
-func extractGeneric(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractGeneric(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord

--- a/internal/extractors/yaml/extractor_test.go
+++ b/internal/extractors/yaml/extractor_test.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	sitter "github.com/smacker/go-tree-sitter"
 	tsyaml "github.com/smacker/go-tree-sitter/yaml"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/yaml" // trigger init()
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -19,10 +20,13 @@ import (
 // Helpers
 // ---------------------------------------------------------------------------
 
-func parseYAML(src []byte) *sitter.Tree {
-	p := sitter.NewParser()
-	p.SetLanguage(tsyaml.GetLanguage())
-	tree, err := p.ParseCtx(context.Background(), nil, src)
+func parseYAML(src []byte) ts.Tree {
+	p, err := tssmacker.New().NewParser(tssmacker.WrapLanguage(tsyaml.GetLanguage()))
+	if err != nil {
+		panic("test helper: yaml parser init failed: " + err.Error())
+	}
+	defer p.Close()
+	tree, err := p.Parse(src)
 	if err != nil {
 		panic("test helper: yaml parse failed: " + err.Error())
 	}
@@ -39,7 +43,7 @@ func extractYAML(src []byte, path string) ([]types.EntityRecord, error) {
 		Path:     path,
 		Content:  src,
 		Language: "yaml",
-		Tree:     tree,
+		TSTree:   tree,
 	})
 }
 
@@ -52,7 +56,7 @@ func extractYAMLNoTree(src []byte, path string) ([]types.EntityRecord, error) {
 		Path:     path,
 		Content:  src,
 		Language: "yaml",
-		Tree:     nil,
+		TSTree:   nil,
 	})
 }
 
@@ -2297,7 +2301,7 @@ func extractYAMLWithRoot(src []byte, path, repoRoot string) ([]types.EntityRecor
 		Path:     path,
 		Content:  src,
 		Language: "yaml",
-		Tree:     tree,
+		TSTree:   tree,
 		RepoRoot: repoRoot,
 	})
 }

--- a/internal/extractors/yaml/helm.go
+++ b/internal/extractors/yaml/helm.go
@@ -41,13 +41,12 @@ package yaml
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
@@ -379,7 +378,7 @@ const helmPlaceholder = "__helm__"
 // extractHelm dispatches to the appropriate Helm sub-extractor. Unlike the
 // other flavors it may re-parse the file content (templates need the stripped
 // text), so it takes the original root only as a fallback.
-func extractHelm(flavor string, root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractHelm(flavor string, root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	switch flavor {
 	case flavorHelmChart:
 		return extractHelmChart(root, file)
@@ -396,7 +395,7 @@ func extractHelm(flavor string, root *sitter.Node, file extractor.FileInput) []t
 // extractHelmChart processes a Chart.yaml: emits a chart entity and one IMPORTS
 // edge per dependency (chart → subchart). The dependency's repository + version
 // are recorded on the edge Properties for provenance.
-func extractHelmChart(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractHelmChart(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord
@@ -477,7 +476,7 @@ func extractHelmChart(root *sitter.Node, file extractor.FileInput) []types.Entit
 // "values_key" entity per LEAF path in the value tree, with the dotted path as
 // the QualifiedName so template `.Values.<path>` binding edges resolve against
 // it.
-func extractHelmValues(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+func extractHelmValues(root ts.Node, file extractor.FileInput) []types.EntityRecord {
 	src := file.Content
 	topPairs := topLevelMappings(root)
 	var entities []types.EntityRecord
@@ -490,8 +489,8 @@ func extractHelmValues(root *sitter.Node, file extractor.FileInput) []types.Enti
 	// a content-side channel the test wires through.
 	subcharts := helmSiblingSubcharts(file)
 
-	var walk func(pairs []*sitter.Node, prefix string, subchart string)
-	walk = func(pairs []*sitter.Node, prefix string, subchart string) {
+	var walk func(pairs []ts.Node, prefix string, subchart string)
+	walk = func(pairs []ts.Node, prefix string, subchart string) {
 		for _, p := range pairs {
 			key := pairKeyText(p, src)
 			if key == "" {
@@ -539,7 +538,7 @@ func extractHelmValues(root *sitter.Node, file extractor.FileInput) []types.Enti
 				// Nested map → recurse; emit the intermediate node too so a
 				// `.Values.parent` reference (whole sub-tree) can still bind.
 				entities = append(entities, ent)
-				var childPairs []*sitter.Node
+				var childPairs []ts.Node
 				for i := range childBM.ChildCount() {
 					c := childBM.Child(int(i))
 					if c != nil && c.Type() == "block_mapping_pair" {
@@ -677,13 +676,14 @@ func extractHelmTemplate(file extractor.FileInput) []types.EntityRecord {
 		Content:  res.stripped,
 		Language: "yaml",
 	}
-	parser := sitter.NewParser()
-	parser.SetLanguage(yamlGrammar())
-	tree, err := parser.ParseCtx(context.Background(), nil, res.stripped)
-	if err == nil && tree != nil {
-		root := tree.RootNode()
-		if root != nil {
-			entities = append(entities, extractKubernetes(root, cleaned)...)
+	if parser, perr := yamlAdapter.NewParser(yamlGrammar()); perr == nil {
+		defer parser.Close()
+		tree, err := parser.Parse(res.stripped)
+		if err == nil && tree != nil {
+			root := tree.RootNode()
+			if root != nil {
+				entities = append(entities, extractKubernetes(root, cleaned)...)
+			}
 		}
 	}
 

--- a/internal/extractors/yaml/language.go
+++ b/internal/extractors/yaml/language.go
@@ -1,12 +1,19 @@
 package yaml
 
 import (
-	sitter "github.com/smacker/go-tree-sitter"
 	tsyaml "github.com/smacker/go-tree-sitter/yaml"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
 )
 
-// yamlGrammar returns the tree-sitter grammar for YAML.
-// Isolated here to keep the CGO import contained.
-func yamlGrammar() *sitter.Language {
-	return tsyaml.GetLanguage()
-}
+// yamlGrammar returns the tree-sitter grammar for YAML for the extractor's
+// inline-parse fallback (B2 Phase 1, #5418, ADR 0023). The extractor traverses
+// the binding-agnostic ts façade; this is the single place that names a concrete
+// binding. Smacker-backed in both build configurations (no official YAML
+// grammar module is wired yet), so the file is untagged: `go build` and
+// `go build -tags ts_official` both compile it unchanged.
+func yamlGrammar() ts.Language { return tssmacker.WrapLanguage(tsyaml.GetLanguage()) }
+
+// yamlAdapter is the binding adapter used to construct parsers in the fallback.
+var yamlAdapter = tssmacker.New()

--- a/internal/treesitter/ts/official/official.go
+++ b/internal/treesitter/ts/official/official.go
@@ -124,6 +124,7 @@ func (w node) StartByte() uint32       { return uint32(w.n.StartByte()) }
 func (w node) EndByte() uint32         { return uint32(w.n.EndByte()) }
 
 func (w node) ChildByFieldName(f string) ts.Node { return wrapNode(w.n.ChildByFieldName(f)) }
+func (w node) FieldNameForChild(i int) string    { return w.n.FieldNameForChild(uint32(i)) }
 func (w node) Parent() ts.Node                   { return wrapNode(w.n.Parent()) }
 func (w node) PrevSibling() ts.Node              { return wrapNode(w.n.PrevSibling()) }
 

--- a/internal/treesitter/ts/smacker/smacker.go
+++ b/internal/treesitter/ts/smacker/smacker.go
@@ -117,6 +117,7 @@ func (w node) ChildCount() uint32                { return w.n.ChildCount() }
 func (w node) NamedChild(i int) ts.Node          { return wrapNode(w.n.NamedChild(i)) }
 func (w node) NamedChildCount() uint32           { return w.n.NamedChildCount() }
 func (w node) ChildByFieldName(f string) ts.Node { return wrapNode(w.n.ChildByFieldName(f)) }
+func (w node) FieldNameForChild(i int) string    { return w.n.FieldNameForChild(i) }
 func (w node) Parent() ts.Node                   { return wrapNode(w.n.Parent()) }
 func (w node) PrevSibling() ts.Node              { return wrapNode(w.n.PrevSibling()) }
 func (w node) StartByte() uint32                 { return w.n.StartByte() }

--- a/internal/treesitter/ts/ts.go
+++ b/internal/treesitter/ts/ts.go
@@ -58,6 +58,11 @@ type Node interface {
 	NamedChildCount() uint32
 	// ChildByFieldName returns the child bound to the given grammar field, or nil.
 	ChildByFieldName(field string) Node
+	// FieldNameForChild returns the grammar field name of the child at index i,
+	// or "" if that child is unnamed or i is out of range. Maps to both bindings'
+	// Node.FieldNameForChild() (smacker takes int, the official binding uint32;
+	// the adapters reconcile the width).
+	FieldNameForChild(i int) string
 	// Parent returns the parent node, or nil for the root.
 	Parent() Node
 	// PrevSibling returns the node's previous sibling (named or anonymous), or


### PR DESCRIPTION
## B2 Phase 1, Batch 4 (final) — Phase 1 COMPLETE

Migrates the **remaining** extractors off the concrete `*sitter.Node`/`*sitter.Tree`
(`github.com/smacker/go-tree-sitter`) onto the binding-agnostic
`internal/treesitter/ts` abstraction, **smacker-backed** (default build,
link-safe, ZERO behavior change). This finishes Phase 1 — batches 0–3 (go,
python, java, javascript, ruby, php, csharp, rust) are already merged.

### Packages migrated (this batch)
`cpp` (C/C++), `css`, `dockerfile`, `elixir`, `groovy`, `hcl`, `html`, `kotlin`,
`lua`, `proto`, `scala`, `shell` (bash), `swift`, `yaml`, plus the
`cross/abibridge` test harness (parses C via smacker in-test → now via the ts
adapter, stamps `TSTree`).

Each extractor now traverses `ts.Node`/`ts.Tree` and reads the shared
`FileInput.TSTree`. Packages with an **inline-parse fallback** (`cpp`,
`dockerfile`, `hcl`, `html`, `yaml`) gained an **untagged smacker grammar
provider** (`language.go`/`grammar.go`) that the fallback constructs via the ts
adapter; the rest **early-return on a nil tree** (no provider). Test
tree-helpers build `ts.Tree` via the smacker adapter and stamp `TSTree`.

### Façade addition
`ts.Node` gains **`FieldNameForChild(i int) string`** — added to the interface
and BOTH adapters (`ts/smacker`, `ts/official`). The smacker method takes `int`,
the official binding `uint32`; the official adapter reconciles the index width.
Required by the Dockerfile extractor's field lookup. Verified to compile under
`-tags ts_official`.

### Phase 1 done
After this batch, **no extractor imports the root smacker binding**. (The only
remaining match — `golang/imports.go:346` — is a map **string literal** in the
third-party-import-path detection data, not a Go import.)

### Validation (zero fidelity delta)
- `go build ./...` clean (default + `-tags ts_official` for ts/extractors).
- `go vet ./internal/extractors/... ./internal/treesitter/...` clean.
- `gofmt -l` clean.
- `go test -count=1 ./internal/extractors/... ./internal/treesitter/...` — all PASS, zero failures.

CHANGELOG `### Changed` updated (Phase 1 complete + façade addition noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)