### PR TITLE
fix(daemon): GC stale per-ref graphs for deleted refs (store/RSS bloat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (`docs/c3-feature-impact-analysis.md`)
 
 ### Fixed
+- **Dead-ref GC now bounds grace-protected transient refs (retention cap,
+  #5440):** the dead-ref sweeper (#5236) reaps refs git no longer knows about,
+  but its 24h grace window had no backstop. A high-churn workload — the rewrite
+  agent's `merge-NNNN` branches, created + deleted minutes apart but each indexed
+  — left every deleted ref's fresh ~80MB `graph.fb` grace-protected for a full
+  24h. On `core-backend-v3` this piled up **~1GB of dead-ref graphs** (12
+  `merge-NNNN` dirs alongside `main` while `git for-each-ref` showed only
+  `main`), mmap'd into the daemon and inflating RSS to ~1.6GB. The sweeper now
+  applies a **retention cap** (`DefaultRefRetentionCap` = 8) per repo: of the
+  dead-in-git refs the grace window protects, only the N most-recently-indexed
+  are kept; the oldest beyond the cap are reaped immediately (mmap released via
+  the existing `DropReader` path before unlink, Windows-safe). Live / primary /
+  HEAD / active-worktree refs and the `_unknown` sentinel never count toward the
+  cap and are never evicted by it; the fail-closed git-enumeration guard is
+  unchanged. Runs on the existing reaper cadence — no new goroutine.
 - **group-algo overlay now reports god-nodes' real PageRank (was 0):** the
   determinism rounding (`roundForDeterminism`) bucketed every score to a fixed
   **1e-4 absolute** quantum. On large group unions (28k+ entities) PageRank mass

--- a/internal/daemon/deadref.go
+++ b/internal/daemon/deadref.go
@@ -31,6 +31,15 @@
 //   - Grace window: a ref whose graph.fb was written within GraceWindow
 //     (default 24h) is kept, so an in-flight / just-finished index pass is
 //     never raced into deletion.
+//   - Retention cap: the grace window alone has no backstop against a
+//     high-churn workload that creates+deletes many transient refs (e.g. the
+//     rewrite agent's `merge-NNNN` branches). Each is indexed, then deleted
+//     from git minutes later, but its fresh graph.fb keeps it grace-protected
+//     for 24h — so ~1GB of dead-ref graphs piled up on core-backend-v3 (#5440).
+//     RetentionCap bounds the number of dead-in-git refs the grace window may
+//     protect per repo: the N most-recently-indexed are kept, the rest are
+//     reaped immediately. Live/primary/HEAD/worktree refs never count toward
+//     the cap and are never reaped by it.
 //   - Fail-closed: if git ref enumeration fails for a repo, that repo is
 //     skipped entirely — nothing is reaped. A flaky/locked git can never cause
 //     a live ref's graph to be nuked.
@@ -42,6 +51,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -94,6 +104,14 @@ type DeadRefConfig struct {
 	// 24h. A negative value disables the grace guard (tests).
 	GraceWindow time.Duration
 
+	// RetentionCap bounds the number of dead-in-git ref graphs the grace window
+	// may protect per repo. When more than RetentionCap dead-in-git refs are
+	// grace-protected, the oldest (by graph.fb mtime) beyond the cap are reaped
+	// immediately — the backstop against high-churn transient-ref creation
+	// (#5440). Live/primary/HEAD/worktree refs never count toward the cap.
+	// Default (zero): DefaultRefRetentionCap. A negative value disables the cap.
+	RetentionCap int
+
 	// Now returns the current time; nil → time.Now. Injected in tests.
 	Now func() time.Time
 
@@ -114,7 +132,16 @@ type DeadRefResult struct {
 	SlotsForgotten int
 	// FreedBytes is the total bytes reclaimed from deleted ref store dirs.
 	FreedBytes int64
+	// CapEvicted is the number of grace-protected dead refs reaped by the
+	// retention cap (i.e. they would have survived on the grace window alone).
+	CapEvicted int
 }
+
+// DefaultRefRetentionCap is the default ceiling on grace-protected dead-in-git
+// ref graphs kept per repo. Picked as a small backstop: enough headroom for a
+// handful of genuinely in-flight reindexes, low enough that a high-churn
+// transient-ref workload cannot pile up ~1GB of dead graphs (#5440).
+const DefaultRefRetentionCap = 8
 
 // DeadRefSweeper reclaims store dirs + resident graphs for refs/worktrees that
 // git no longer knows about, within still-present repos.
@@ -132,6 +159,9 @@ func NewDeadRefSweeper(cfg DeadRefConfig) *DeadRefSweeper {
 	}
 	if cfg.GraceWindow == 0 {
 		cfg.GraceWindow = 24 * time.Hour
+	}
+	if cfg.RetentionCap == 0 {
+		cfg.RetentionCap = DefaultRefRetentionCap
 	}
 	if cfg.Now == nil {
 		cfg.Now = time.Now
@@ -161,6 +191,7 @@ func (s *DeadRefSweeper) Sweep() DeadRefResult {
 			"repos_scanned", res.ReposScanned,
 			"repos_skipped", res.ReposSkipped,
 			"refs_reaped", res.RefsReaped,
+			"cap_evicted", res.CapEvicted,
 			"slots_forgotten", res.SlotsForgotten,
 			"freed_bytes", res.FreedBytes)
 	}
@@ -198,6 +229,10 @@ func (s *DeadRefSweeper) sweepRepo(repo string, res *DeadRefResult) {
 
 	graceCutoff := s.cfg.Now().Add(-s.cfg.GraceWindow)
 
+	// graceHeld collects dead-in-git refs that the grace window protects, so the
+	// retention cap can evict the oldest beyond the cap as a backstop (#5440).
+	var graceHeld []graceHeldRef
+
 	for _, e := range stored {
 		if !e.IsDir() {
 			continue
@@ -217,31 +252,88 @@ func (s *DeadRefSweeper) sweepRepo(repo string, res *DeadRefResult) {
 			continue
 		}
 		refDir := filepath.Join(refsDir, refSafe)
-		// Guard: grace window — keep recently-indexed refs.
+		// Guard: grace window — defer recently-indexed refs to the retention-cap
+		// pass below rather than keeping them unconditionally. The cap evicts the
+		// oldest of these when there are too many (high-churn transient refs);
+		// the rest are kept exactly as before.
 		if s.cfg.GraceWindow >= 0 && recentlyIndexed(refDir, graceCutoff) {
-			s.logger.Info("deadref: ref dead in git but recently indexed — keeping (grace window)", "repo", repo, "ref", ref)
+			graceHeld = append(graceHeld, graceHeldRef{ref: ref, dir: refDir, mtime: refGraphMtime(refDir)})
 			continue
 		}
 
-		// Reap: remove store dir, drop reader, forget slot.
-		sz, rmErr := s.removeRefStore(refDir)
-		if rmErr != nil {
-			s.logger.Warn("deadref: ref store removal failed (non-fatal)", "repo", repo, "ref", ref, "dir", refDir, "err", rmErr)
-			continue
-		}
-		res.RefsReaped++
-		if sz > 0 {
-			res.FreedBytes += sz
-		}
-		s.logger.Info("deadref: reaped dead ref", "repo", repo, "ref", ref, "dir", refDir, "freed_bytes", sz)
+		s.reapRef(repo, ref, refDir, res, false)
+	}
 
-		if s.cfg.DropReader != nil {
-			s.cfg.DropReader(repo, ref)
+	// Retention-cap backstop: of the grace-protected dead refs, keep only the
+	// RetentionCap most-recently-indexed; reap the rest (oldest first).
+	if s.cfg.RetentionCap >= 0 && len(graceHeld) > s.cfg.RetentionCap {
+		// Newest first so the head of the slice is the keep-set.
+		sort.Slice(graceHeld, func(i, j int) bool {
+			return graceHeld[i].mtime.After(graceHeld[j].mtime)
+		})
+		for _, h := range graceHeld[s.cfg.RetentionCap:] {
+			s.logger.Info("deadref: grace-protected dead ref over retention cap — reaping", "repo", repo, "ref", h.ref, "cap", s.cfg.RetentionCap)
+			if s.reapRef(repo, h.ref, h.dir, res, true) {
+				res.CapEvicted++
+			}
 		}
-		if s.cfg.Tier != nil && s.cfg.Tier.ForgetRef(repo, ref) {
-			res.SlotsForgotten++
+		for _, h := range graceHeld[:s.cfg.RetentionCap] {
+			s.logger.Info("deadref: ref dead in git but recently indexed — keeping (grace window, within cap)", "repo", repo, "ref", h.ref)
+		}
+	} else {
+		for _, h := range graceHeld {
+			s.logger.Info("deadref: ref dead in git but recently indexed — keeping (grace window)", "repo", repo, "ref", h.ref)
 		}
 	}
+}
+
+// graceHeldRef is a dead-in-git ref kept by the grace window, a candidate for
+// retention-cap eviction.
+type graceHeldRef struct {
+	ref   string
+	dir   string
+	mtime time.Time
+}
+
+// reapRef removes a ref's store dir, drops its cached reader, and forgets its
+// tier slot, updating res. Returns true when the store dir was removed. The
+// caller logs the higher-level reason; reapRef logs the reap itself.
+func (s *DeadRefSweeper) reapRef(repo, ref, refDir string, res *DeadRefResult, capEvict bool) bool {
+	sz, rmErr := s.removeRefStore(refDir)
+	if rmErr != nil {
+		s.logger.Warn("deadref: ref store removal failed (non-fatal)", "repo", repo, "ref", ref, "dir", refDir, "err", rmErr)
+		return false
+	}
+	res.RefsReaped++
+	if sz > 0 {
+		res.FreedBytes += sz
+	}
+	s.logger.Info("deadref: reaped dead ref", "repo", repo, "ref", ref, "dir", refDir, "freed_bytes", sz, "cap_evicted", capEvict)
+
+	if s.cfg.DropReader != nil {
+		s.cfg.DropReader(repo, ref)
+	}
+	if s.cfg.Tier != nil && s.cfg.Tier.ForgetRef(repo, ref) {
+		res.SlotsForgotten++
+	}
+	return true
+}
+
+// refGraphMtime returns the newest graph.fb / graph.json mtime under refDir, or
+// the zero time when neither exists. Used to order grace-protected refs for the
+// retention cap (oldest evicted first).
+func refGraphMtime(refDir string) time.Time {
+	var newest time.Time
+	for _, name := range []string{"graph.fb", "graph.json"} {
+		fi, err := os.Stat(filepath.Join(refDir, name))
+		if err != nil {
+			continue
+		}
+		if fi.ModTime().After(newest) {
+			newest = fi.ModTime()
+		}
+	}
+	return newest
 }
 
 // recentlyIndexed reports whether the ref dir holds a graph.fb (or graph.json)

--- a/internal/daemon/deadref_test.go
+++ b/internal/daemon/deadref_test.go
@@ -233,6 +233,141 @@ func TestDeadRef_skipsUnknownSentinel(t *testing.T) {
 	}
 }
 
+// TestDeadRef_retentionCapEvictsOldestGraceHeld: when more dead-in-git refs are
+// grace-protected than the retention cap allows, the oldest beyond the cap are
+// reaped while the N most-recent survive — and primary is never counted/reaped.
+func TestDeadRef_retentionCapEvictsOldestGraceHeld(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	now := time.Unix(1_700_000_000, 0)
+
+	// Primary, indexed long ago — survives on the primary guard, never counts.
+	writeRefStore(t, refsRoot, "main", 1000, now.Add(-100*time.Hour))
+
+	// 5 dead-in-git transient refs, ALL fresh (within 24h grace), distinct mtimes.
+	// merge-1 is oldest … merge-5 is newest.
+	for i := 1; i <= 5; i++ {
+		writeRefStore(t, refsRoot, "merge-"+itoa(i), 80, now.Add(-time.Duration(6-i)*time.Hour))
+	}
+
+	ff := &fakeRefForgetter{held: map[[2]string]bool{
+		{repo, "merge-1"}: true, {repo, "merge-2"}: true,
+	}}
+	var dropped [][2]string
+	// git lists only main as live; the merge-* refs are all dead-in-git.
+	s := NewDeadRefSweeper(DeadRefConfig{
+		TrackedRepos:   func() []string { return []string{repo} },
+		LiveRefs:       func(string) (map[string]struct{}, bool) { return map[string]struct{}{"main": {}}, true },
+		PrimaryRef:     func(string) string { return "main" },
+		RefsDirForRepo: func(string) string { return refsRoot },
+		Tier:           ff,
+		DropReader:     func(rp, ref string) { dropped = append(dropped, [2]string{rp, ref}) },
+		GraceWindow:    24 * time.Hour,
+		RetentionCap:   3, // keep 3 newest grace-held; evict the 2 oldest.
+		Now:            func() time.Time { return now },
+	})
+
+	res := s.Sweep()
+
+	if res.RefsReaped != 2 || res.CapEvicted != 2 {
+		t.Fatalf("RefsReaped=%d CapEvicted=%d want 2/2", res.RefsReaped, res.CapEvicted)
+	}
+	// merge-1 and merge-2 (oldest) gone; merge-3..5 + main kept.
+	for _, gone := range []string{"merge-1", "merge-2"} {
+		if _, err := os.Stat(filepath.Join(refsRoot, gone)); !os.IsNotExist(err) {
+			t.Errorf("%s should have been cap-evicted: %v", gone, err)
+		}
+	}
+	for _, kept := range []string{"merge-3", "merge-4", "merge-5", "main"} {
+		if _, err := os.Stat(filepath.Join(refsRoot, kept)); err != nil {
+			t.Errorf("%s should have survived: %v", kept, err)
+		}
+	}
+	// Reader/slot drops only for the held evicted refs.
+	if res.SlotsForgotten != 2 {
+		t.Errorf("SlotsForgotten=%d want 2", res.SlotsForgotten)
+	}
+	if len(dropped) != 2 {
+		t.Errorf("DropReader calls=%v want 2", dropped)
+	}
+}
+
+// TestDeadRef_retentionCapNeverEvictsPrimary: a fresh primary ref is never
+// counted toward or evicted by the retention cap, even when many transient
+// dead refs exceed the cap. With a cap of 1, exactly the newest transient ref
+// is kept and the primary always survives.
+func TestDeadRef_retentionCapNeverEvictsPrimary(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	now := time.Unix(1_700_000_000, 0)
+
+	// Primary, fresh — must survive regardless of the cap and never be counted.
+	writeRefStore(t, refsRoot, "main", 1000, now.Add(-1*time.Hour))
+	// 3 fresh dead transient refs; merge-3 is newest.
+	for i := 1; i <= 3; i++ {
+		writeRefStore(t, refsRoot, "merge-"+itoa(i), 80, now.Add(-time.Duration(4-i)*time.Hour))
+	}
+
+	s := NewDeadRefSweeper(DeadRefConfig{
+		TrackedRepos:   func() []string { return []string{repo} },
+		LiveRefs:       func(string) (map[string]struct{}, bool) { return map[string]struct{}{"main": {}}, true },
+		PrimaryRef:     func(string) string { return "main" },
+		RefsDirForRepo: func(string) string { return refsRoot },
+		GraceWindow:    24 * time.Hour,
+		RetentionCap:   1, // keep 1 newest transient; primary excluded from count.
+		Now:            func() time.Time { return now },
+	})
+
+	res := s.Sweep()
+
+	if res.CapEvicted != 2 { // merge-1, merge-2 evicted; merge-3 kept.
+		t.Fatalf("CapEvicted=%d want 2", res.CapEvicted)
+	}
+	if _, err := os.Stat(filepath.Join(refsRoot, "main")); err != nil {
+		t.Errorf("primary reaped by cap: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(refsRoot, "merge-3")); err != nil {
+		t.Errorf("newest transient (within cap) reaped: %v", err)
+	}
+}
+
+// TestDeadRef_retentionCapDisabled: a negative cap disables the backstop — all
+// grace-held dead refs survive regardless of count.
+func TestDeadRef_retentionCapDisabled(t *testing.T) {
+	repo := mkLiveRepo(t)
+	refsRoot := filepath.Join(t.TempDir(), "refs")
+	now := time.Unix(1_700_000_000, 0)
+	for i := 1; i <= 20; i++ {
+		writeRefStore(t, refsRoot, "merge-"+itoa(i), 80, now.Add(-1*time.Hour))
+	}
+	s := NewDeadRefSweeper(DeadRefConfig{
+		TrackedRepos:   func() []string { return []string{repo} },
+		LiveRefs:       func(string) (map[string]struct{}, bool) { return map[string]struct{}{}, true },
+		PrimaryRef:     func(string) string { return "main" },
+		RefsDirForRepo: func(string) string { return refsRoot },
+		GraceWindow:    24 * time.Hour,
+		RetentionCap:   -1, // disabled
+		Now:            func() time.Time { return now },
+	})
+	res := s.Sweep()
+	if res.RefsReaped != 0 || res.CapEvicted != 0 {
+		t.Fatalf("cap disabled: RefsReaped=%d CapEvicted=%d want 0/0", res.RefsReaped, res.CapEvicted)
+	}
+}
+
+// itoa is a tiny strconv.Itoa to avoid an extra import in this table.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
 // TestDeadRef_reaperDrivesSweep: the Reaper invokes the dead-ref sweep on its
 // Sweep() and surfaces the result.
 func TestDeadRef_reaperDrivesSweep(t *testing.T) {


### PR DESCRIPTION
Closes #5440.

## Problem

The per-ref graph store accumulates stale graphs for transient git refs a concurrent agent creates and quickly deletes. On `the v3 backend repo`, `store/.../refs/` held 14 ref dirs (`main`, `_unknown`, `merge-N`…`merge-N`) while `git for-each-ref` showed only `main` — ~12 deleted `merge-NNNN` refs each kept their ~80MB `graph.fb` (~1GB dead, mmap'd → RSS ~1.6GB) and drove reindex churn.

## Root cause

The dead-ref sweeper (#5236, `internal/daemon/deadref.go`) already reaps refs absent from git, but its **24h grace window has no backstop**. The agent creates+destroys `merge-NNNN` branches within minutes, indexing each. Once deleted, the ref is gone from git, but its fresh `graph.fb` (mtime < 24h) keeps it grace-protected for a full 24h. At ~12+ transient refs/day × ~80MB, ~1GB sits in the rolling grace window.

## Fix

Add a per-repo **retention cap** on grace-protected dead-in-git refs:
- Of the dead-in-git refs the grace window protects, keep only the `RetentionCap` (default `DefaultRefRetentionCap = 8`) most-recently-indexed (by `graph.fb` mtime); reap the oldest beyond the cap immediately.
- mmap released via the existing `DropReader` path **before** unlink (Windows-safe — reuses the evict path).
- Tier slot forgotten via `ForgetRef` for each evicted ref.

### Guards preserved
- Live / primary / HEAD / active-worktree refs and the `_unknown` sentinel **never count toward or are evicted by the cap**.
- Grace window still keeps the N most-recent (no change for low-churn repos).
- Fail-closed on git-enumeration error unchanged.
- A negative `RetentionCap` disables the backstop.

### Cadence
Runs inside the existing dead-ref sweep, driven by the reaper on its shared 5-minute cadence — **no new goroutine**.

## Trigger / cadence
`Reaper.Sweep()` → `DeadRefSweeper.Sweep()` per still-present tracked repo, every 5 min (existing).

## Keep / delete rule
KEEP: any live ref, primary/default, HEAD, active-worktree ref, `_unknown`, and the `RetentionCap` newest grace-protected dead refs. DELETE: dead-in-git refs past the grace window, **plus** grace-protected dead refs beyond the cap (oldest first).

## Transient-ref indexing gate
**Not done** in this PR (documented follow-up on #5440). The `merge-NNNN` refs arrive via the worktree watcher while HEAD is on a real branch the agent legitimately works on; gating "only index tracked branches" risks dropping legitimate active feature-branch indexing. The retention cap bounds the damage cleanly without that risk.

## Tests
Unit tests in `deadref_test.go` (`go test -count=1 -run TestDeadRef ./internal/daemon/`, all green):
- cap evicts oldest grace-held beyond cap, keeps N newest + main;
- cap never counts/evicts primary;
- negative cap disables the backstop;
- existing reap / primary+grace / fail-closed / worktree / sentinel cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)