### PR TITLE
fix(dashboard/daemon): report persisted index stats for cold groups (not 0/never)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (`docs/c3-feature-impact-analysis.md`)
 
 ### Fixed
+- **Dashboard/`grafel status` no longer show "0 entities / never indexed" for a
+  cold-but-indexed group (#5442):** the WebUI group overview and `grafel status`
+  derived per-repo entity counts + last-indexed time only from the
+  `graph-stats.json` sidecar, which the daemon's incremental reindex path never
+  wrote (it writes `graph.fb` only). A group maintained by the daemon — or any
+  cold group whose sidecar was absent — therefore reported `0 / never` even
+  though the MCP lazy-loaded `graph.fb` and served real results. On a sidecar
+  miss both surfaces now read the persisted entity/relationship counts and index
+  timestamp **cheaply from the `graph.fb` header** (mmap + vector lengths via
+  `internal/graph/fbreader`, no full graph materialization), and the incremental
+  reindex path now writes the sidecar so future cold reads are correct without
+  the fallback. A truly-never-indexed group (no `graph.fb`) still reports
+  `0 / never`.
 - **Dead-ref GC now bounds grace-protected transient refs (retention cap,
   #5440):** the dead-ref sweeper (#5236) reaps refs git no longer knows about,
   but its 24h grace window had no backstop. A high-churn workload — the rewrite

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -92,8 +92,26 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 				s.TotalEntities += side.TotalEntities
 				s.TotalRelationships += side.TotalRelationships
 			}
+		} else if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+			// Sidecar not yet written (e.g. a graph produced by the daemon's
+			// incremental reindex path, which writes graph.fb but no sidecar).
+			// Read the real counts + index timestamp cheaply from the graph.fb
+			// header so a cold-but-indexed repo reports its true size instead of
+			// "0 entities / (never)" (#5442).
+			rs.Entities = ps.Entities
+			rs.Relationships = ps.Relationships
+			s.TotalEntities += ps.Entities
+			s.TotalRelationships += ps.Relationships
+			if !ps.ComputedAt.IsZero() {
+				rs.LastIndexed = ps.ComputedAt
+				rs.LastIndexedAge = formatTimeSince(ps.ComputedAt)
+			} else if graphPath, modtimeNano := daemon.FindGraphFile(r.Path); graphPath != "" {
+				mtime := time.Unix(0, modtimeNano)
+				rs.LastIndexed = mtime
+				rs.LastIndexedAge = formatTimeSince(mtime)
+			}
 		} else {
-			// Fallback to graph.fb mtime if sidecar doesn't exist.
+			// graph.fb absent/unreadable — fall back to newest graph file mtime.
 			graphPath, modtimeNano := daemon.FindGraphFile(r.Path)
 			if graphPath != "" {
 				mtime := time.Unix(0, modtimeNano)

--- a/internal/cli/status_stats_test.go
+++ b/internal/cli/status_stats_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -224,6 +225,86 @@ func TestRepoStatusWithoutGraphStats(t *testing.T) {
 	}
 	if rs.LastIndexedAge != "(never)" {
 		t.Errorf("expected '(never)', got %q", rs.LastIndexedAge)
+	}
+}
+
+// TestComputeStatusSummary_ColdIndexNoSidecar reproduces #5442: a repo that
+// was indexed by the daemon's incremental path has a graph.fb on disk but no
+// graph-stats.json sidecar. Status must report the persisted entity count and
+// a real last-indexed time (read cheaply from the graph.fb header), not
+// "0 entities / (never)".
+func TestComputeStatusSummary_ColdIndexNoSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath := filepath.Join(tmpDir, "coldrepo")
+	os.MkdirAll(repoPath, 0o755)
+	stateDir := daemon.StateDirForRepo(repoPath)
+	os.MkdirAll(stateDir, 0o755)
+
+	// Write a real graph.fb (3 entities) but deliberately NO graph-stats.json.
+	indexedAt := time.Now().Add(-7 * time.Minute).UTC().Truncate(time.Second)
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: indexedAt,
+		Repo:        repoPath,
+		Stats:       graph.Stats{Entities: 3, Relationships: 1, Files: 2},
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "A", Kind: "function", SourceFile: "a.go", Language: "go"},
+			{ID: "b2", Name: "B", Kind: "function", SourceFile: "b.go", Language: "go"},
+			{ID: "c3", Name: "C", Kind: "function", SourceFile: "c.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "a1", ToID: "b2", Kind: "CALLS"},
+		},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	// Sanity: sidecar absent.
+	if _, err := os.Stat(filepath.Join(stateDir, "graph-stats.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no sidecar, stat err = %v", err)
+	}
+
+	repos := []registry.Repo{{Slug: "coldrepo", Path: repoPath}}
+	summary := ComputeStatusSummary("grp", repos)
+
+	rs, ok := summary.RepoStats["coldrepo"]
+	if !ok {
+		t.Fatal("coldrepo not found in RepoStats")
+	}
+	if rs.Entities != 3 {
+		t.Errorf("Entities = %d, want 3 (persisted count from graph.fb header)", rs.Entities)
+	}
+	if rs.Relationships != 1 {
+		t.Errorf("Relationships = %d, want 1", rs.Relationships)
+	}
+	if summary.TotalEntities != 3 {
+		t.Errorf("TotalEntities = %d, want 3", summary.TotalEntities)
+	}
+	if rs.LastIndexed.IsZero() || rs.LastIndexedAge == "(never)" {
+		t.Errorf("expected a real last-indexed time, got zero/never (age=%q)", rs.LastIndexedAge)
+	}
+	if !rs.LastIndexed.Equal(indexedAt) {
+		t.Errorf("LastIndexed = %v, want %v (graph.fb header ComputedAt)", rs.LastIndexed, indexedAt)
+	}
+}
+
+// TestComputeStatusSummary_TrulyNeverIndexed asserts the negative case still
+// reports 0/never when there is no graph.fb at all.
+func TestComputeStatusSummary_TrulyNeverIndexed(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+	repoPath := filepath.Join(tmpDir, "fresh")
+	os.MkdirAll(repoPath, 0o755)
+
+	summary := ComputeStatusSummary("grp", []registry.Repo{{Slug: "fresh", Path: repoPath}})
+	rs := summary.RepoStats["fresh"]
+	if rs == nil {
+		t.Fatal("fresh repo missing")
+	}
+	if rs.Entities != 0 || rs.LastIndexedAge != "(never)" {
+		t.Errorf("want 0/never, got entities=%d age=%q", rs.Entities, rs.LastIndexedAge)
 	}
 }
 

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -83,8 +83,26 @@ func aggregateGroupStats(groupName string, repos []registry.Repo) (entityCount i
 		sidecarPath := filepath.Join(stateDir, "graph-stats.json")
 		data, err := os.ReadFile(sidecarPath)
 		if err != nil {
-			// Sidecar not yet written — fall back to graph.fb/graph.json mtime.
-			if info, e2 := os.Stat(filepath.Join(stateDir, "graph.fb")); e2 == nil {
+			// Sidecar not yet written (e.g. a graph produced by the daemon's
+			// incremental reindex path, which writes graph.fb but no sidecar).
+			// Read the real entity count + index timestamp cheaply from the
+			// graph.fb header so a cold-but-indexed group reports its true size
+			// instead of "0 entities / never indexed" (#5442).
+			if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+				totalEntities += ps.Entities
+				switch {
+				case !ps.ComputedAt.IsZero():
+					if ps.ComputedAt.After(latest) {
+						latest = ps.ComputedAt
+					}
+				default:
+					// No header timestamp — fall back to graph.fb mtime.
+					if info, e2 := os.Stat(filepath.Join(stateDir, "graph.fb")); e2 == nil && info.ModTime().After(latest) {
+						latest = info.ModTime()
+					}
+				}
+			} else if info, e2 := os.Stat(filepath.Join(stateDir, "graph.fb")); e2 == nil {
+				// graph.fb unreadable but present — fall back to its mtime.
 				if info.ModTime().After(latest) {
 					latest = info.ModTime()
 				}

--- a/internal/dashboard/store_coldstats_test.go
+++ b/internal/dashboard/store_coldstats_test.go
@@ -1,0 +1,88 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestAggregateGroupStats_ColdIndexNoSidecar reproduces #5442 for the dashboard
+// group overview: a repo indexed by the daemon's incremental path has graph.fb
+// on disk but no graph-stats.json sidecar. aggregateGroupStats must report the
+// persisted entity count and a real last-indexed time (read cheaply from the
+// graph.fb header), not 0 entities / never indexed.
+func TestAggregateGroupStats_ColdIndexNoSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+	// Bust the 30s registry-stats cache across runs of this group name.
+	registryStatsMu.Lock()
+	delete(registryStatsCache, "coldgrp")
+	registryStatsMu.Unlock()
+
+	repoPath := filepath.Join(tmpDir, "coldrepo")
+	os.MkdirAll(repoPath, 0o755)
+	stateDir := daemon.StateDirForRepo(repoPath)
+	os.MkdirAll(stateDir, 0o755)
+
+	indexedAt := time.Now().Add(-9 * time.Minute).UTC().Truncate(time.Second)
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: indexedAt,
+		Repo:        repoPath,
+		Stats:       graph.Stats{Entities: 5, Relationships: 2, Files: 3},
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "A", Kind: "function", SourceFile: "a.go", Language: "go"},
+			{ID: "b2", Name: "B", Kind: "function", SourceFile: "b.go", Language: "go"},
+			{ID: "c3", Name: "C", Kind: "function", SourceFile: "c.go", Language: "go"},
+			{ID: "d4", Name: "D", Kind: "function", SourceFile: "d.go", Language: "go"},
+			{ID: "e5", Name: "E", Kind: "function", SourceFile: "e.go", Language: "go"},
+		},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "graph-stats.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no sidecar, stat err = %v", err)
+	}
+
+	repos := []registry.Repo{{Slug: "coldrepo", Path: repoPath}}
+	entityCount, lastIndexed := aggregateGroupStats("coldgrp", repos)
+
+	if entityCount != 5 {
+		t.Errorf("entityCount = %d, want 5 (persisted count from graph.fb header)", entityCount)
+	}
+	if lastIndexed.IsZero() {
+		t.Fatal("lastIndexed is zero, want the graph.fb header ComputedAt")
+	}
+	if !lastIndexed.Equal(indexedAt) {
+		t.Errorf("lastIndexed = %v, want %v", lastIndexed, indexedAt)
+	}
+}
+
+// TestAggregateGroupStats_TrulyNeverIndexed asserts the negative case: no
+// graph.fb at all → 0 entities and a zero last-indexed time.
+func TestAggregateGroupStats_TrulyNeverIndexed(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+	registryStatsMu.Lock()
+	delete(registryStatsCache, "freshgrp")
+	registryStatsMu.Unlock()
+
+	repoPath := filepath.Join(tmpDir, "fresh")
+	os.MkdirAll(repoPath, 0o755)
+
+	repos := []registry.Repo{{Slug: "fresh", Path: repoPath}}
+	entityCount, lastIndexed := aggregateGroupStats("freshgrp", repos)
+	if entityCount != 0 {
+		t.Errorf("entityCount = %d, want 0", entityCount)
+	}
+	if !lastIndexed.IsZero() {
+		t.Errorf("lastIndexed = %v, want zero", lastIndexed)
+	}
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -463,6 +463,25 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		return fallback(t0, "write-graph-fb: "+writeErr.Error())
 	}
 
+	// #5442 — refresh the graph-stats.json sidecar so the dashboard group
+	// overview and `grafel status` report this repo's real entity count and a
+	// real last-indexed time when the group is cold (not loaded in memory).
+	// The incremental path does not run Pass-4 graph-algo, so community /
+	// modularity / god-node fields are omitted; the counts + timestamp are
+	// what those surfaces read. Best-effort: a sidecar write failure never
+	// fails the reindex (graph.fb is already written, and the fbreader-header
+	// fallback still recovers the counts on a sidecar miss).
+	side := &graph.GraphStatsSidecar{
+		Version:            1,
+		ComputedAt:         doc.GeneratedAt,
+		TotalFiles:         doc.Stats.Files,
+		TotalEntities:      doc.Stats.Entities,
+		TotalRelationships: doc.Stats.Relationships,
+	}
+	if serr := graph.WriteSidecar(fbPath, side, false); serr != nil {
+		logger.Printf("incremental: sidecar write failed: %v (non-fatal)", serr)
+	}
+
 	// --- Step 9: update manifest ---
 	diff.UpdateManifest(absRepo, allFiles, manifest)
 	if saveErr := diff.SaveManifest(stateDir, absRepo, manifest); saveErr != nil {

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -75,6 +75,48 @@ func LoadGraphFromDir(dir string) (*Document, error) {
 	}
 }
 
+// PersistedStats is a cheap, on-disk view of a repo's index size and
+// freshness, read from the graph.fb header WITHOUT materializing the
+// entity/relationship vectors. Used by the dashboard group overview and
+// `grafel status` as a fallback when the graph-stats.json sidecar is absent
+// (e.g. a graph written by the daemon's incremental reindex path, which does
+// not emit the sidecar) so a cold-but-indexed group reports its real counts
+// instead of "0 entities / never indexed".
+type PersistedStats struct {
+	Entities      int
+	Relationships int
+	// ComputedAt is the index timestamp stamped into the graph.fb header
+	// (the same value the sidecar's computed_at would carry). Zero when the
+	// header carries no/unparseable timestamp.
+	ComputedAt time.Time
+}
+
+// PersistedStatsFromDir reads cheap persisted stats from <dir>/graph.fb.
+//
+// It mmaps the file and reads the entity/relationship vector lengths and the
+// header timestamp — it does NOT decode any entity or relationship — then
+// closes the mapping immediately. This is the inexpensive way to learn a
+// cold group's true size without paying for a full LoadGraphFromDir.
+//
+// Returns ok=false when graph.fb is absent or cannot be opened (in which case
+// callers should treat the repo as genuinely never-indexed via graph.fb).
+func PersistedStatsFromDir(dir string) (PersistedStats, bool) {
+	fbPath := filepath.Join(dir, "graph.fb")
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		return PersistedStats{}, false
+	}
+	defer r.Close()
+	ps := PersistedStats{
+		Entities:      r.EntityCount(),
+		Relationships: r.RelationshipCount(),
+	}
+	if t, perr := time.Parse(time.RFC3339, r.LoadGraphMeta().ComputedAt); perr == nil {
+		ps.ComputedAt = t
+	}
+	return ps, true
+}
+
 // loadFBDocument decodes a graph.fb file into a *Document. It opens the
 // file with fbreader (mmap + single bulk read), then converts the lazy
 // FlatBuffers view into an in-memory *Document by iterating the entity


### PR DESCRIPTION
Fixes #5444. Dashboard + `grafel status` showed 0 entities / never-indexed for a cold-but-indexed group (stats came from the empty loaded graph). Now reads persisted per-repo entity count + last-indexed; a loaded group still shows live numbers; truly-never-indexed still shows 0/never. Build+vet+gofmt clean; new cold-index tests in internal/cli + internal/dashboard pass.