### PR TITLE
feat(daemon): GRAFEL_REF_RETENTION_CAP env override for dead-ref cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Env-tunable dead-ref retention cap (`GRAFEL_REF_RETENTION_CAP`, #5447):** the
+  ceiling on grace-protected dead-in-git ref graphs the daemon keeps per repo
+  (default 8) can now be overridden via the environment, letting an operator
+  shrink the dead-ref footprint on a machine with heavy transient-ref churn
+  (e.g. set it to 4). Unset → default 8; a non-negative int sets the cap
+  (0 keeps no grace-protected dead refs); a negative int disables the cap
+  backstop; unparseable values fall back to the default. Mirrors the existing
+  `GRAFEL_TIER_*`/`GRAFEL_EXTRACT_GOMAXPROCS` env pattern.
 - **Official tree-sitter grammar providers for the high-value languages
   (#5418, B2 cutover Part A):** ABI-14-pinned official-runtime grammar packages
   for **python, java, csharp, typescript (+tsx), javascript, rust** under

--- a/internal/daemon/deadref.go
+++ b/internal/daemon/deadref.go
@@ -39,7 +39,9 @@
 //     RetentionCap bounds the number of dead-in-git refs the grace window may
 //     protect per repo: the N most-recently-indexed are kept, the rest are
 //     reaped immediately. Live/primary/HEAD/worktree refs never count toward
-//     the cap and are never reaped by it.
+//     the cap and are never reaped by it. The cap is env-tunable via
+//     GRAFEL_REF_RETENTION_CAP (default 8; 0 keeps none; negative disables the
+//     backstop) — see EnvRefRetentionCap.
 //   - Fail-closed: if git ref enumeration fails for a repo, that repo is
 //     skipped entirely — nothing is reaped. A flaky/locked git can never cause
 //     a live ref's graph to be nuked.
@@ -52,6 +54,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -109,7 +112,8 @@ type DeadRefConfig struct {
 	// grace-protected, the oldest (by graph.fb mtime) beyond the cap are reaped
 	// immediately — the backstop against high-churn transient-ref creation
 	// (#5440). Live/primary/HEAD/worktree refs never count toward the cap.
-	// Default (zero): DefaultRefRetentionCap. A negative value disables the cap.
+	// Default (zero): resolved from GRAFEL_REF_RETENTION_CAP, falling back to
+	// DefaultRefRetentionCap. A negative value disables the cap.
 	RetentionCap int
 
 	// Now returns the current time; nil → time.Now. Injected in tests.
@@ -143,6 +147,37 @@ type DeadRefResult struct {
 // transient-ref workload cannot pile up ~1GB of dead graphs (#5440).
 const DefaultRefRetentionCap = 8
 
+// RefRetentionCapEnv is the env var an operator may set to override
+// DefaultRefRetentionCap. A lower value (e.g. 4) shrinks the dead-ref footprint
+// on a machine with heavy transient-ref churn; 0 keeps only live/primary/HEAD/
+// worktree refs; a negative value disables the cap backstop entirely (the grace
+// window alone then governs retention). See EnvRefRetentionCap.
+const RefRetentionCapEnv = "GRAFEL_REF_RETENTION_CAP"
+
+// EnvRefRetentionCap resolves the dead-ref retention cap, honouring the
+// GRAFEL_REF_RETENTION_CAP override. Semantics:
+//
+//   - unset / empty            → DefaultRefRetentionCap (8)
+//   - a valid non-negative int → that value (0 = keep no grace-protected dead
+//     refs; only live/primary/HEAD/worktree refs survive)
+//   - a valid negative int     → that value, which DeadRefSweeper treats as
+//     "cap disabled" (the existing RetentionCap < 0 backstop-off semantics)
+//   - unparseable garbage      → DefaultRefRetentionCap (fail-safe)
+//
+// Mirrors the GRAFEL_TIER_*/GRAFEL_EXTRACT_GOMAXPROCS env-reading pattern, but
+// permits 0 and negative values, which those positive-only helpers reject.
+func EnvRefRetentionCap() int {
+	s := strings.TrimSpace(os.Getenv(RefRetentionCapEnv))
+	if s == "" {
+		return DefaultRefRetentionCap
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return DefaultRefRetentionCap
+	}
+	return n
+}
+
 // DeadRefSweeper reclaims store dirs + resident graphs for refs/worktrees that
 // git no longer knows about, within still-present repos.
 type DeadRefSweeper struct {
@@ -161,7 +196,13 @@ func NewDeadRefSweeper(cfg DeadRefConfig) *DeadRefSweeper {
 		cfg.GraceWindow = 24 * time.Hour
 	}
 	if cfg.RetentionCap == 0 {
-		cfg.RetentionCap = DefaultRefRetentionCap
+		// Zero means "caller did not set it" — resolve from the environment
+		// (GRAFEL_REF_RETENTION_CAP), which itself falls back to
+		// DefaultRefRetentionCap when unset. An operator who explicitly wants a
+		// cap of 0 (keep no grace-protected dead refs) sets the env to "0";
+		// callers that need a literal 0 regardless of env can pass a negative
+		// value, which disables the backstop.
+		cfg.RetentionCap = EnvRefRetentionCap()
 	}
 	if cfg.Now == nil {
 		cfg.Now = time.Now

--- a/internal/daemon/deadref_test.go
+++ b/internal/daemon/deadref_test.go
@@ -355,6 +355,54 @@ func TestDeadRef_retentionCapDisabled(t *testing.T) {
 	}
 }
 
+// TestDeadRef_envRetentionCapParse exercises EnvRefRetentionCap's parsing of
+// GRAFEL_REF_RETENTION_CAP: unset → default 8, "4" → 4, "0" → 0, "-1" → -1
+// (cap disabled), garbage → default 8.
+func TestDeadRef_envRetentionCapParse(t *testing.T) {
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		want int
+	}{
+		{name: "unset", set: false, want: DefaultRefRetentionCap},
+		{name: "empty", set: true, val: "", want: DefaultRefRetentionCap},
+		{name: "whitespace", set: true, val: "   ", want: DefaultRefRetentionCap},
+		{name: "four", set: true, val: "4", want: 4},
+		{name: "padded", set: true, val: " 4 ", want: 4},
+		{name: "zero", set: true, val: "0", want: 0},
+		{name: "negative", set: true, val: "-1", want: -1},
+		{name: "garbage", set: true, val: "garbage", want: DefaultRefRetentionCap},
+		{name: "float", set: true, val: "4.5", want: DefaultRefRetentionCap},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.set {
+				t.Setenv(RefRetentionCapEnv, c.val)
+			} else {
+				os.Unsetenv(RefRetentionCapEnv)
+			}
+			if got := EnvRefRetentionCap(); got != c.want {
+				t.Fatalf("EnvRefRetentionCap()=%d want %d (env set=%v val=%q)", got, c.want, c.set, c.val)
+			}
+		})
+	}
+}
+
+// TestDeadRef_envRetentionCapWiredThroughConstructor verifies the env value
+// flows into the sweeper when the caller leaves RetentionCap at its zero value.
+func TestDeadRef_envRetentionCapWiredThroughConstructor(t *testing.T) {
+	t.Setenv(RefRetentionCapEnv, "3")
+	s := NewDeadRefSweeper(DeadRefConfig{
+		TrackedRepos:   func() []string { return nil },
+		LiveRefs:       func(string) (map[string]struct{}, bool) { return map[string]struct{}{}, true },
+		RefsDirForRepo: func(string) string { return "" },
+	})
+	if s.cfg.RetentionCap != 3 {
+		t.Fatalf("constructor RetentionCap=%d want 3 (from env)", s.cfg.RetentionCap)
+	}
+}
+
 // itoa is a tiny strconv.Itoa to avoid an extra import in this table.
 func itoa(i int) string {
 	if i == 0 {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -528,6 +528,14 @@ func Run(ctx context.Context, cfg Config) error {
 			// #5236: dead-ref / dead-worktree sweep. Reclaims store dirs +
 			// resident graphs for refs git no longer knows about, within
 			// still-present repos. Driven by the reaper on the shared cadence.
+			// Retention cap is env-tunable (GRAFEL_REF_RETENTION_CAP) so an
+			// operator can shrink the dead-ref footprint on a machine with
+			// heavy transient-ref churn (e.g. set it to 4). Resolved here so the
+			// effective value is logged; NewDeadRefSweeper would resolve the same
+			// value from a zero RetentionCap on its own.
+			refRetentionCap := EnvRefRetentionCap()
+			logger.Info("deadref: retention cap configured",
+				"cap", refRetentionCap, "env", RefRetentionCapEnv)
 			deadRefSweeper := NewDeadRefSweeper(DeadRefConfig{
 				TrackedRepos:   trackedRepos,
 				LiveRefs:       LiveGitRefs,
@@ -535,6 +543,7 @@ func Run(ctx context.Context, cfg Config) error {
 				RefsDirForRepo: RefsDirForRepo,
 				DropReader:     cfg.DeadRefDropReader,
 				Tier:           cfg.DeadRefTier,
+				RetentionCap:   refRetentionCap,
 				Logger:         logger,
 			})
 			// #5263: orphan top-level store-root sweep. Reaps whole


### PR DESCRIPTION
## What
Make the dead-ref store sweeper's retention cap env-tunable via `GRAFEL_REF_RETENTION_CAP`.

The sweeper bounds how many grace-protected dead-in-git ref graphs it keeps per repo (default 8, the `DefaultRefRetentionCap` const). Until now that was hardcoded with no override, so an operator on a machine with heavy transient-ref churn couldn't lower it for a smaller footprint.

## Behaviour
`EnvRefRetentionCap()` resolves the override:
- unset / empty / whitespace → default 8
- valid non-negative int → that value (0 keeps no grace-protected dead refs; only live/primary/HEAD/worktree refs survive)
- valid negative int → cap disabled (the existing `RetentionCap < 0` backstop-off semantics)
- unparseable → falls back to default 8

`NewDeadRefSweeper` resolves it from the environment whenever `RetentionCap` is left at its zero value, so existing callers pick it up transparently. The daemon wiring in `server.go` resolves and logs the effective value explicitly.

## Where it's wired
- `internal/daemon/deadref.go`: `RefRetentionCapEnv` const + `EnvRefRetentionCap()` parser; constructor consults it; package-header + field docs updated.
- `internal/daemon/server.go`: `DeadRefConfig.RetentionCap` set from `EnvRefRetentionCap()`, with an info log of the effective cap.

## Tests
- `TestDeadRef_envRetentionCapParse` — table: unset→8, ""→8, "4"→4, " 4 "→4, "0"→0, "-1"→-1, "garbage"→8, "4.5"→8.
- `TestDeadRef_envRetentionCapWiredThroughConstructor` — env flows into the sweeper when the caller leaves `RetentionCap` zero.

`go build`, `go vet`, `gofmt -l`, and `go test -run TestDeadRef ./internal/daemon/...` all clean.

Closes #5447

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)