### PR TITLE
fix(test): enforce config isolation so tests cannot clobber a real ~/.config/grafel (#5443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (`docs/c3-feature-impact-analysis.md`)
 
 ### Fixed
+- **Tests can no longer clobber a developer's real `~/.config/grafel` fleet
+  config (#5443):** a group-overlay test resolved the fleet-config path
+  (`registry.ConfigPathFor` → `registry.ConfigDir`) without redirecting
+  `HOME`/`XDG_CONFIG_HOME`/`GRAFEL_HOME` into a TempDir. When run from a real
+  home it fell back to the live `~/.config/grafel/<group>.fleet.json` and
+  overwrote it, repointing the group's repos at an already-deleted `t.TempDir`
+  so the group dropped to 0 entities. The offending test now isolates via
+  `testsupport.IsolateHome(t)`, and — as a fail-closed guardrail — the registry
+  config writers (`SaveGroupConfig`, the `registry.json` writer) now **panic
+  loudly under `go test` if the write target lands inside the real user home**,
+  so a future un-isolated test fails immediately instead of silently corrupting
+  the developer's live config.
 - **Dashboard/`grafel status` no longer show "0 entities / never indexed" for a
   cold-but-indexed group (#5442):** the WebUI group overview and `grafel status`
   derived per-repo entity counts + last-indexed time only from the

--- a/internal/dashboard/handlers_perf_test.go
+++ b/internal/dashboard/handlers_perf_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/perf"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // newPerfTestServer creates a minimal *Server for perf handler tests,
@@ -18,6 +19,10 @@ import (
 // tests have no disk/network dependencies.
 func newPerfTestServer(t *testing.T) *Server {
 	t.Helper()
+	// #5443: the perf handlers resolve registry.HomeDir() (perf-history.jsonl)
+	// and loadSettings() unconditionally. Isolate HOME/XDG/GRAFEL_HOME so these
+	// reads land in a TempDir, never the developer's real ~/.grafel / ~/.config.
+	testsupport.IsolateHome(t)
 	cfg := Config{
 		PortRange: PortRange{Min: 47270, Max: 47280},
 		Bind:      "127.0.0.1",

--- a/internal/mcp/group_algo_overlay_restamp_5400_test.go
+++ b/internal/mcp/group_algo_overlay_restamp_5400_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -37,6 +38,12 @@ import (
 func setupThreeRepoApplyGroup(t *testing.T) (st *State, overlayPath string, cur map[string]int64,
 	beID, feID, mobID, mobileStateDir string, mobileDoc *graph.Document) {
 	t.Helper()
+	// #5443: isolate HOME / XDG_CONFIG_HOME / GRAFEL_HOME into a per-test
+	// TempDir BEFORE resolving any config path. Without this the fleet config
+	// (registry.ConfigPathFor → registry.ConfigDir) falls back to the REAL
+	// ~/.config/grafel/<group>.fleet.json and SaveGroupConfig below clobbers the
+	// developer's live config, repointing the group at a deleted t.TempDir.
+	testsupport.IsolateHome(t)
 	root := t.TempDir()
 	home := filepath.Join(root, "home")
 	t.Setenv("GRAFEL_HOME", home)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -288,6 +288,7 @@ func Save(r *Registry) error {
 }
 
 func saveTo(path string, r *Registry) error {
+	guardResolvedConfigPath(path, "registry.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -372,6 +373,7 @@ func LoadGroupConfig(path string) (*GroupConfig, error) {
 
 // SaveGroupConfig writes a per-group config atomically.
 func SaveGroupConfig(path string, cfg *GroupConfig) error {
+	guardResolvedConfigPath(path, "fleet config")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/internal/registry/test_isolation_guard.go
+++ b/internal/registry/test_isolation_guard.go
@@ -1,0 +1,82 @@
+package registry
+
+// test_isolation_guard.go — fail-closed guard against the exact incident in
+// #5443: a test that forgot to isolate $HOME/$XDG_CONFIG_HOME/$GRAFEL_HOME
+// resolved the real ~/.config/grafel/<group>.fleet.json (or ~/.grafel) and
+// CLOBBERED the developer's live fleet config, repointing the group's repos at
+// a deleted t.TempDir so the group went to 0 entities.
+//
+// The opt-in TestMain guard (testsupport.GuardRealHomeMain) only fires when a
+// package wires it up AND GRAFEL_TEST_REQUIRE_ISOLATED_HOME=1 is exported — it
+// is trivially skipped, which is how #5443 slipped through. This guard lives in
+// the WRITE path of the registry/fleet-config writers themselves, so it cannot
+// be skipped: any test that is about to PERSIST the registry.json or a
+// <group>.fleet.json into the REAL user home panics LOUDLY before a single byte
+// is written.
+//
+// Why guard the writers and not the path resolvers: a read-only resolve (e.g.
+// the dashboard reporting the perf-history path) is harmless and very common in
+// tests; only a WRITE clobbers the developer's live config. Guarding
+// registry.saveTo / registry.SaveGroupConfig catches the exact #5443 incident
+// (a test persisting a fleet config to ~/.config/grafel) without breaking the
+// many tests that merely resolve a path string.
+//
+// It is inert outside tests (`testing.Testing()` is false in the shipping
+// binary) and inert inside tests that DID isolate (the write target no longer
+// lands under the real home, so the panic condition is never met).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realUserHomeAtInit is captured at package-init time, BEFORE any test has had a
+// chance to call t.Setenv("HOME", ...). It is the home we must never write to
+// from a test. Captured the same way internal/testsupport captures it (kept
+// independent to avoid an import cycle: testsupport is a test helper that may
+// itself depend on registry).
+var realUserHomeAtInit = func() string {
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return filepath.Clean(h)
+	}
+	if h := os.Getenv("HOME"); h != "" {
+		return filepath.Clean(h)
+	}
+	return ""
+}()
+
+// guardResolvedConfigPath panics if, while running under `go test`, the path we
+// are about to WRITE a config/registry/fleet file to lands inside the REAL user
+// home directory. That can only happen when the test failed to redirect
+// HOME / XDG_CONFIG_HOME / GRAFEL_HOME into a TempDir — i.e. the #5443 bug.
+//
+// It is a no-op in the shipping binary (testing.Testing() == false) and a no-op
+// for any test that correctly isolated (the target path is then under a
+// TempDir, not the real home).
+func guardResolvedConfigPath(resolved, what string) {
+	if !testing.Testing() {
+		return
+	}
+	if realUserHomeAtInit == "" || resolved == "" {
+		return
+	}
+	abs := resolved
+	if a, err := filepath.Abs(resolved); err == nil {
+		abs = a
+	}
+	abs = filepath.Clean(abs)
+	home := realUserHomeAtInit
+	if abs == home || strings.HasPrefix(abs+string(filepath.Separator), home+string(filepath.Separator)) {
+		panic(fmt.Sprintf(
+			"registry: TEST SANDBOX ESCAPE — about to WRITE %s to %q, which is inside the "+
+				"REAL user home %q. This test would clobber the developer's live "+
+				"~/.config/grafel/<group>.fleet.json / ~/.grafel/registry.json (see #5443). "+
+				"Call testsupport.IsolateHome(t) at the top of the test before writing any "+
+				"config/registry/fleet file.",
+			what, abs, home,
+		))
+	}
+}

--- a/internal/registry/test_isolation_guard_test.go
+++ b/internal/registry/test_isolation_guard_test.go
@@ -1,0 +1,81 @@
+package registry
+
+// test_isolation_guard_test.go — verifies the #5443 fail-closed guard:
+// a test that would WRITE the registry/fleet config into the REAL user home
+// panics LOUDLY, while a write into an isolated TempDir succeeds.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGuard_PanicsWhenWritingRealHome proves the guard fires when a fleet
+// config write targets a path inside the genuine user home — the exact #5443
+// clobber. We do NOT actually create the file; the guard must panic before any
+// MkdirAll/WriteFile runs.
+func TestGuard_PanicsWhenWritingRealHome(t *testing.T) {
+	if realUserHomeAtInit == "" {
+		t.Skip("no real user home captured; cannot exercise the escape path")
+	}
+
+	// A fleet-config path that lands inside the REAL user home (no isolation).
+	escape := filepath.Join(realUserHomeAtInit, ".config", "grafel", "guardtest.fleet.json")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected guard panic when writing fleet config to real home %q, got none", escape)
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "TEST SANDBOX ESCAPE") || !strings.Contains(msg, "IsolateHome") {
+			t.Fatalf("panic message did not mention the guard / remediation: %q", msg)
+		}
+	}()
+
+	// Must panic before writing anything.
+	_ = SaveGroupConfig(escape, &GroupConfig{Name: "guardtest"})
+	t.Fatalf("SaveGroupConfig returned without panicking — guard did not fire")
+}
+
+// TestGuard_AllowsWriteUnderIsolatedHome proves the guard is inert once the
+// target is under a TempDir (the isolated case), and the write actually lands.
+func TestGuard_AllowsWriteUnderIsolatedHome(t *testing.T) {
+	dir := withHome(t) // sets GRAFEL_HOME + XDG_CONFIG_HOME under a TempDir
+	cfgPath, err := ConfigPathFor("isolated")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity: the resolved config path is NOT under the real home.
+	if realUserHomeAtInit != "" {
+		abs, _ := filepath.Abs(cfgPath)
+		if strings.HasPrefix(filepath.Clean(abs)+string(filepath.Separator), realUserHomeAtInit+string(filepath.Separator)) {
+			t.Fatalf("isolated config path %q unexpectedly under real home %q", abs, realUserHomeAtInit)
+		}
+	}
+
+	if err := SaveGroupConfig(cfgPath, &GroupConfig{Name: "isolated"}); err != nil {
+		t.Fatalf("SaveGroupConfig under isolated home should succeed: %v", err)
+	}
+	got, err := LoadGroupConfig(cfgPath)
+	if err != nil || got.Name != "isolated" {
+		t.Fatalf("roundtrip under isolated home failed: got=%+v err=%v", got, err)
+	}
+	_ = dir
+}
+
+// TestGuard_RegistrySaveAlsoGuarded proves saveTo (registry.json writer, used
+// by AddGroup/RemoveGroup/Save) is guarded too — not just the fleet writer.
+func TestGuard_RegistrySaveAlsoGuarded(t *testing.T) {
+	if realUserHomeAtInit == "" {
+		t.Skip("no real user home captured")
+	}
+	escape := filepath.Join(realUserHomeAtInit, ".grafel", "registry.json")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected guard panic writing registry.json to real home %q", escape)
+		}
+	}()
+	_ = saveTo(escape, &Registry{Version: 1})
+	t.Fatalf("saveTo returned without panicking — guard did not fire")
+}


### PR DESCRIPTION
## Problem (#5443)

A group-overlay test resolved the per-group **fleet-config path**
(`registry.ConfigPathFor` → `registry.ConfigDir`) without first redirecting
`HOME` / `XDG_CONFIG_HOME` / `GRAFEL_HOME` into a `t.TempDir`. The test set
`GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT` but **not** `XDG_CONFIG_HOME`/`HOME`, so
`ConfigDir()` fell back to `os.UserHomeDir()` and resolved the **real**
`~/.config/grafel/<group>.fleet.json`. `SaveGroupConfig` then overwrote the
developer's live fleet config, repointing the group's repos at an
already-deleted `t.TempDir` — so the group dropped to 0 entities.

The existing isolation helper (`testsupport.IsolateHome`) redirects all of
`HOME`/`XDG_CONFIG_HOME`/`GRAFEL_HOME`, but the offending test simply never
called it. The opt-in `TestMain` guard only fires behind an env flag and is
trivially skipped — which is how this slipped through.

## Fix

1. **Offending test** — its shared setup helper now calls
   `testsupport.IsolateHome(t)` before resolving any config path, so the fleet
   config (and registry/state) land under a `t.TempDir`, never the real home.
   This covers every test in the file that uses the helper.

2. **Audit of other skippers** — swept all `*_test.go` for tests that resolve
   the grafel registry/fleet/home path without isolation. Most flagged files
   were false positives (they isolate via a shared helper in a sibling
   `_test.go`, e.g. a `withSandboxHome`/`withHome` that sets all three env vars).
   One real read-only skipper was found: a dashboard perf test whose handler
   resolves the real home for a history path; it now isolates too (defensive,
   harmless even though it only reads).

3. **Fail-closed guardrail** — the registry **write** path is now guarded: under
   `go test` (`testing.Testing()`), `SaveGroupConfig` and the `registry.json`
   writer **panic loudly** if the write target lands inside the real user home,
   with a message pointing at `testsupport.IsolateHome(t)`. A future un-isolated
   test now fails immediately at write time instead of silently clobbering the
   live config.

   **Tradeoff:** the guard sits on the *writers*, not the *path resolvers*. A
   read-only resolve (e.g. reporting a history-path string) is harmless and very
   common in tests; only a **write** clobbers. Guarding the writers catches the
   exact incident — a test persisting a config to the real home — without
   panicking the many tests that merely build a path string.

## Tests

- Guard panics when a config write targets the real user home (no isolation).
- Guard is inert and the write succeeds under an isolated `TempDir`.
- The registry.json writer is guarded too, not just the fleet writer.
- The previously-offending overlay test passes under the guard.

`go test -count=1` green for the touched packages (registry / mcp / dashboard /
testsupport / daemon-state-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)