### PR TITLE
feat(dashboard): streaming graph endpoint for progressive load (#5446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Streaming graph endpoint for progressive load (#5446, increment 1):** a new
+  `GET /api/v2/graph/{group}/stream` SSE endpoint streams the same node/edge
+  shape as `/api/v2/graph/{group}` but progressively — a `meta` event first
+  (`total_nodes`/`total_edges` for a progress counter), then `chunk` events of
+  ~750 nodes (plus the edges that became deliverable) ordered **important-first**
+  (centrality/PageRank descending from the group-algo overlay, falling back to
+  connectivity/degree when no overlay is present), then a final `{"done":true}`.
+  This lets the renderer (GPU canvas) start painting the most central part of a
+  large graph immediately instead of waiting for the whole payload to serialise.
+  Streams from the warm cache only (never force-loads); a cold group returns the
+  503 not-loaded signal. The existing full-payload endpoint is unchanged, so the
+  frontend can switch with no data-model change. Backend only this increment.
 - **Env-tunable dead-ref retention cap (`GRAFEL_REF_RETENTION_CAP`, #5447):** the
   ceiling on grace-protected dead-in-git ref graphs the daemon keeps per repo
   (default 8) can now be overridden via the environment, letting an operator

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -723,6 +723,12 @@ func (s *Server) routes() http.Handler {
 	// Carries pagerank + source_file for cosmos.gl node sizing + module group-by.
 	// PH1c (#2087): accepts ?ref= to query a specific git ref's graph.
 	mux.HandleFunc("GET /api/v2/graph/{group}", s.handleV2Graph)
+	// Streaming graph (#5446, increment 1): SSE stream of the SAME node/edge
+	// shape as /api/v2/graph/{group}, important-first, so the frontend can feed
+	// Cosmos progressively instead of waiting for the whole payload. Path ends
+	// in /stream so withGzip leaves it uncompressed (chunks flush live). Streams
+	// from the warm cache only; a cold group returns 503 (warm-up is separate).
+	mux.HandleFunc("GET /api/v2/graph/{group}/stream", s.handleV2GraphStream)
 
 	// PH1c (#2087): list available refs (branches/tags) for each repo in the group.
 	// Returns which refs have an indexed graph on disk and their tier (hot/cold).

--- a/internal/dashboard/v2_graph_stream.go
+++ b/internal/dashboard/v2_graph_stream.go
@@ -1,0 +1,251 @@
+// v2_graph_stream.go — GET /api/v2/graph/{group}/stream
+//
+// Streaming counterpart to handleV2Graph (v2_graph.go). After indexing a large
+// group the full-payload endpoint serialises the WHOLE graph before the browser
+// can render anything, so a multi-second wait reads as "broken". Rendering is
+// done by Cosmos (cosmos.gl, GPU) which is fine with big graphs — the bottleneck
+// is *data delivery*. This endpoint streams the same node/edge shape
+// progressively so a later frontend increment can feed Cosmos as data arrives.
+//
+// Increment 1 of epic #5446 — BACKEND ONLY. The existing /api/v2/graph/{group}
+// full-payload endpoint is left untouched; the frontend can switch to this
+// stream later with no data-model change because the per-node / per-edge JSON
+// is byte-for-byte the same shape buildV2Graph produces (v2GraphNode /
+// v2GraphEdge).
+//
+// ── Format: SSE (not NDJSON) ─────────────────────────────────────────────────
+//
+// The dashboard already has a documented SSE convention (API_V2.md §3:
+// setV2SSEHeaders / writeV2SSEEvent, `connected`→domain→`close` lifecycle) used
+// by index-progress, mcp-activity, audit and job feeds. The withGzip middleware
+// in server.go already excludes any path ending in `/stream` from compression
+// (so chunks actually flush). Choosing SSE over NDJSON keeps this endpoint
+// consistent with the rest of the v2 streaming surface and reuses the existing
+// helpers + gzip exclusion — no new infra. The path therefore ends in `/stream`.
+//
+// ── Event lifecycle ──────────────────────────────────────────────────────────
+//
+//	event: connected   data: {"subscribed_at": <unix-ms>}
+//	event: meta        data: {"total_nodes":N,"total_edges":M,"communities":[…],"repos":[…]}
+//	event: chunk       data: {"nodes":[…],"edges":[…]}        (repeated, important-first)
+//	event: done        data: {"done":true}
+//
+// `meta` is always first (the frontend's progress counter reads total_nodes /
+// total_edges); `chunk`s follow important-first; `done` is always last.
+//
+// ── Important-first ordering ─────────────────────────────────────────────────
+//
+// Nodes are streamed highest-importance first so the most structurally central
+// part of the graph paints immediately. Importance is taken from the group-algo
+// overlay when present: PageRank (centrality / god-nodes) descending, ties
+// broken by served degree. When no overlay has run (every PageRank == 0) it
+// falls back to served degree descending — pure connectivity. A node's edges
+// are emitted in the first chunk by which BOTH of its endpoints have already
+// been streamed, so the frontend never references a node it has not seen.
+//
+// ── No force-load ────────────────────────────────────────────────────────────
+//
+// Streams only from the already-warm DashGroup cache (GetGroupCachedForRef,
+// which never loads from disk or recomputes algorithms). A cold group returns
+// 503 `unavailable` — the same not-loaded signal other best-effort handlers use
+// — and kicks off a background warm; the frontend handles warm-up separately.
+
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// graphStreamChunkSize is the number of nodes emitted per `chunk` event. Sized
+// so each flush is a meaningful render step without being chatty; edges that
+// become deliverable at a given chunk ride along in that chunk.
+const graphStreamChunkSize = 750
+
+// v2GraphStreamMeta is the first (`meta`) event payload. It carries the totals
+// the frontend's progress counter needs plus the legend/filter metadata
+// (communities + repos) so those panels can render before the node chunks land.
+type v2GraphStreamMeta struct {
+	TotalNodes  int                `json:"total_nodes"`
+	TotalEdges  int                `json:"total_edges"`
+	Communities []v2GraphCommunity `json:"communities"`
+	Repos       []v2GraphRepo      `json:"repos"`
+}
+
+// v2GraphStreamChunk is a `chunk` event payload: a batch of nodes plus every
+// edge that became deliverable (both endpoints already streamed) by this batch.
+// Nodes/edges are the SAME shape as the full-payload endpoint.
+type v2GraphStreamChunk struct {
+	Nodes []v2GraphNode `json:"nodes"`
+	Edges []v2GraphEdge `json:"edges"`
+}
+
+// handleV2GraphStream — GET /api/v2/graph/{group}/stream
+//
+// SSE stream of the v2 graph, important-first, from the warm cache only.
+// Honours the same ?repos= / ?filter_kind= / ?include_external= / ?view=modules
+// / ?ref= query params as handleV2Graph so the two endpoints agree on which
+// nodes/edges exist. No ?lod= thinning — Cosmos handles scale on the GPU and the
+// point of streaming is to deliver the full graph progressively.
+func (s *Server) handleV2GraphStream(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "group required")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", "streaming unsupported")
+		return
+	}
+
+	filterKind := r.URL.Query().Get("filter_kind")
+	reposParam := r.URL.Query().Get("repos")
+	includeExternal := r.URL.Query().Get("include_external") == "true"
+	includeModules := r.URL.Query().Get("view") == "modules" ||
+		r.URL.Query().Get("include") == "modules"
+	refParam := r.URL.Query().Get("ref")
+
+	// Warm-cache only — never force a disk load or algorithm recompute from a
+	// stream request. A cold group returns the not-loaded signal (503) and warms
+	// in the background; the frontend handles warm-up separately.
+	grp, warm := s.graphs.GetGroupCachedForRef(group, refParam)
+	if !warm {
+		writeV2Err(w, http.StatusServiceUnavailable, "unavailable",
+			"group not loaded; warming up — retry shortly")
+		return
+	}
+
+	repos := sortedRepos(grp)
+	if reposParam != "" {
+		slugSet := map[string]bool{}
+		for _, sl := range strings.Split(reposParam, ",") {
+			slugSet[strings.TrimSpace(sl)] = true
+		}
+		var filtered []*DashRepo
+		for _, rp := range repos {
+			if slugSet[rp.Slug] {
+				filtered = append(filtered, rp)
+			}
+		}
+		repos = filtered
+	}
+
+	// Reuse the exact full-payload build so the streamed shape is identical.
+	resp := s.buildV2Graph(repos, grp, filterKind, includeExternal, includeModules)
+
+	orderGraphStreamNodes(resp.Nodes)
+
+	setV2SSEHeaders(w)
+	w.WriteHeader(http.StatusOK)
+
+	writeV2SSEEvent(w, "connected", fmt.Sprintf(`{"subscribed_at":%d}`, time.Now().UnixMilli()))
+	flusher.Flush()
+
+	meta := v2GraphStreamMeta{
+		TotalNodes:  len(resp.Nodes),
+		TotalEdges:  len(resp.Edges),
+		Communities: resp.Communities,
+		Repos:       resp.Repos,
+	}
+	writeV2SSEEvent(w, "meta", jsonString(meta))
+	flusher.Flush()
+
+	streamGraphChunks(w, flusher, resp.Nodes, resp.Edges)
+
+	writeV2SSEEvent(w, "done", jsonString(map[string]any{"done": true}))
+	flusher.Flush()
+}
+
+// orderGraphStreamNodes sorts nodes important-first in place. Overlay present
+// (any non-zero PageRank): PageRank desc, ties → degree desc. No overlay
+// (all PageRank == 0): degree desc. Final tie-break on ID keeps the order
+// deterministic across requests.
+func orderGraphStreamNodes(nodes []v2GraphNode) {
+	hasOverlay := false
+	for i := range nodes {
+		if nodes[i].PageRank != 0 {
+			hasOverlay = true
+			break
+		}
+	}
+	sort.SliceStable(nodes, func(i, j int) bool {
+		a, b := nodes[i], nodes[j]
+		if hasOverlay && a.PageRank != b.PageRank {
+			return a.PageRank > b.PageRank
+		}
+		if a.Degree != b.Degree {
+			return a.Degree > b.Degree
+		}
+		return a.ID < b.ID
+	})
+}
+
+// streamGraphChunks emits the ordered nodes in batches of graphStreamChunkSize,
+// flushing after each. An edge rides in the first chunk by which BOTH of its
+// endpoints have already been streamed, so the frontend never sees an edge that
+// references a node it has not received yet. Any edge whose endpoint never
+// appears in the served node set (should not happen — buildV2Graph filters
+// edges to visible nodes) is skipped.
+func streamGraphChunks(w http.ResponseWriter, flusher http.Flusher, nodes []v2GraphNode, edges []v2GraphEdge) {
+	// chunkIndex[id] = index of the chunk in which the node is streamed.
+	chunkIndex := make(map[string]int, len(nodes))
+	for i := range nodes {
+		chunkIndex[nodes[i].ID] = i / graphStreamChunkSize
+	}
+
+	// Bucket each edge into the chunk at which both endpoints are available =
+	// max(chunk(source), chunk(target)).
+	totalChunks := 0
+	if len(nodes) > 0 {
+		totalChunks = (len(nodes)-1)/graphStreamChunkSize + 1
+	}
+	edgeBuckets := make([][]v2GraphEdge, totalChunks)
+	for _, e := range edges {
+		cs, okS := chunkIndex[e.Source]
+		ct, okT := chunkIndex[e.Target]
+		if !okS || !okT {
+			continue
+		}
+		c := cs
+		if ct > c {
+			c = ct
+		}
+		edgeBuckets[c] = append(edgeBuckets[c], e)
+	}
+
+	for c := 0; c < totalChunks; c++ {
+		start := c * graphStreamChunkSize
+		end := start + graphStreamChunkSize
+		if end > len(nodes) {
+			end = len(nodes)
+		}
+		chunk := v2GraphStreamChunk{
+			Nodes: nodes[start:end],
+			Edges: edgeBuckets[c],
+		}
+		// Wire contract (#4516): nil slices serialize as [] not null, so the
+		// frontend always gets arrays.
+		if chunk.Edges == nil {
+			chunk.Edges = []v2GraphEdge{}
+		}
+		writeV2SSEEvent(w, "chunk", jsonString(chunk))
+		flusher.Flush()
+	}
+}
+
+// jsonString marshals v to a compact JSON string for an SSE data field. On the
+// (practically impossible) marshal error it returns an empty object so the
+// stream stays well-formed.
+func jsonString(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}

--- a/internal/dashboard/v2_graph_stream_test.go
+++ b/internal/dashboard/v2_graph_stream_test.go
@@ -1,0 +1,338 @@
+package dashboard
+
+// v2_graph_stream_test.go — unit tests for GET /api/v2/graph/{group}/stream
+// (#5446 increment 1). Verifies the SSE event ordering (connected → meta →
+// chunk* → done), that the meta totals match the served graph, that nodes are
+// streamed important-first when a pagerank overlay is present, that an edge is
+// never streamed before both of its endpoints, that the node/edge JSON shape
+// matches the full-payload endpoint, and that a cold group returns 503.
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// sseEvent is one parsed SSE `event:`/`data:` block.
+type sseEvent struct {
+	Type string
+	Data string
+}
+
+// readSSE consumes the whole SSE body into an ordered slice of events.
+func readSSE(t *testing.T, body string) []sseEvent {
+	t.Helper()
+	var out []sseEvent
+	sc := bufio.NewScanner(strings.NewReader(body))
+	sc.Buffer(make([]byte, 0, 1<<20), 1<<24)
+	var cur sseEvent
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			cur.Type = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			cur.Data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if cur.Type != "" {
+				out = append(out, cur)
+			}
+			cur = sseEvent{}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan SSE: %v", err)
+	}
+	return out
+}
+
+// fetchGraphStream GETs the stream endpoint and returns the parsed events.
+func fetchGraphStream(t *testing.T, ts *httptest.Server, query string) []sseEvent {
+	t.Helper()
+	url := ts.URL + "/api/v2/graph/testgrp/stream"
+	if query != "" {
+		url += "?" + query
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d (want 200)", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return readSSE(t, string(b))
+}
+
+// makeStreamTestGroup builds a group of n entities with pagerank i/n (so e0 is
+// lowest, e[n-1] highest) and a simple chain of relationships e0->e1->...->e[n-1].
+func makeStreamTestGroup(n int) *DashGroup {
+	entities := make([]graph.Entity, n)
+	for i := range entities {
+		pr := float64(i) / float64(n)
+		entities[i] = graph.Entity{
+			ID:       fmt.Sprintf("e%d", i),
+			Kind:     "function",
+			PageRank: &pr,
+		}
+	}
+	rels := make([]graph.Relationship, 0, n-1)
+	for i := 0; i < n-1; i++ {
+		rels = append(rels, graph.Relationship{
+			FromID: fmt.Sprintf("e%d", i),
+			ToID:   fmt.Sprintf("e%d", i+1),
+			Kind:   "CALLS",
+		})
+	}
+	return makeGraphTestGroup(entities, rels)
+}
+
+func TestGraphStream_OrderingAndTotals(t *testing.T) {
+	const n = 1800 // > 2 chunks (chunk size 750)
+	grp := makeStreamTestGroup(n)
+	ts := newV2GraphTestServerWithGroup(t, grp)
+
+	events := fetchGraphStream(t, ts, "")
+	if len(events) < 4 {
+		t.Fatalf("want at least connected+meta+chunk+done, got %d events", len(events))
+	}
+
+	// First event must be connected, second meta, last done.
+	if events[0].Type != "connected" {
+		t.Errorf("first event = %q, want connected", events[0].Type)
+	}
+	if events[1].Type != "meta" {
+		t.Errorf("second event = %q, want meta", events[1].Type)
+	}
+	if last := events[len(events)-1]; last.Type != "done" {
+		t.Errorf("last event = %q, want done", last.Type)
+	} else if last.Data != `{"done":true}` {
+		t.Errorf("done payload = %q, want {\"done\":true}", last.Data)
+	}
+
+	var meta v2GraphStreamMeta
+	if err := json.Unmarshal([]byte(events[1].Data), &meta); err != nil {
+		t.Fatalf("meta unmarshal: %v", err)
+	}
+	if meta.TotalNodes != n {
+		t.Errorf("meta.total_nodes = %d, want %d", meta.TotalNodes, n)
+	}
+	if meta.TotalEdges != n-1 {
+		t.Errorf("meta.total_edges = %d, want %d", meta.TotalEdges, n-1)
+	}
+
+	// Collect chunks (everything between meta and done).
+	var streamedNodes []v2GraphNode
+	var streamedEdges []v2GraphEdge
+	seen := map[string]int{} // node id -> order index streamed
+	idx := 0
+	chunkCount := 0
+	for _, ev := range events[2 : len(events)-1] {
+		if ev.Type != "chunk" {
+			t.Fatalf("unexpected event %q between meta and done", ev.Type)
+		}
+		chunkCount++
+		var ch v2GraphStreamChunk
+		if err := json.Unmarshal([]byte(ev.Data), &ch); err != nil {
+			t.Fatalf("chunk unmarshal: %v", err)
+		}
+		for _, nnode := range ch.Nodes {
+			seen[nnode.ID] = idx
+			idx++
+			streamedNodes = append(streamedNodes, nnode)
+		}
+		// Every edge in this chunk must reference only nodes already streamed
+		// (this chunk inclusive) — i.e. both endpoints seen.
+		for _, e := range ch.Edges {
+			if _, ok := seen[e.Source]; !ok {
+				t.Errorf("edge source %q streamed before its node", e.Source)
+			}
+			if _, ok := seen[e.Target]; !ok {
+				t.Errorf("edge target %q streamed before its node", e.Target)
+			}
+		}
+		streamedEdges = append(streamedEdges, ch.Edges...)
+	}
+
+	if len(streamedNodes) != n {
+		t.Errorf("streamed %d nodes, want %d", len(streamedNodes), n)
+	}
+	if len(streamedEdges) != n-1 {
+		t.Errorf("streamed %d edges, want %d", len(streamedEdges), n-1)
+	}
+	if chunkCount < 3 {
+		t.Errorf("expected at least 3 chunks for n=%d, got %d", n, chunkCount)
+	}
+
+	// Important-first: pagerank strictly descending across the streamed order.
+	for i := 1; i < len(streamedNodes); i++ {
+		if streamedNodes[i].PageRank > streamedNodes[i-1].PageRank {
+			t.Errorf("node order not pagerank-desc at %d: %.4f after %.4f",
+				i, streamedNodes[i].PageRank, streamedNodes[i-1].PageRank)
+			break
+		}
+	}
+	// The single highest-pagerank node (e1799) must be in the very first chunk.
+	if got := streamedNodes[0].ID; got != "testrepo::e1799" {
+		t.Errorf("first streamed node = %q, want testrepo::e1799 (highest pagerank)", got)
+	}
+}
+
+// TestGraphStream_ShapeMatchesFullPayload asserts the streamed node/edge JSON is
+// the same shape (same fields) as the non-streaming /api/v2/graph endpoint, so
+// the frontend can switch with no data-model change.
+func TestGraphStream_ShapeMatchesFullPayload(t *testing.T) {
+	grp := makeStreamTestGroup(10)
+	ts := newV2GraphTestServerWithGroup(t, grp)
+
+	// Full payload.
+	full := fetchV2Graph(t, ts, "full")
+	fullNodeByID := map[string]v2GraphNode{}
+	for _, nnode := range full.Nodes {
+		fullNodeByID[nnode.ID] = nnode
+	}
+	fullEdgeSet := map[string]bool{}
+	for _, e := range full.Edges {
+		fullEdgeSet[e.Source+"|"+e.Target+"|"+e.Kind] = true
+	}
+
+	// Streamed.
+	events := fetchGraphStream(t, ts, "")
+	var streamNodes []v2GraphNode
+	var streamEdges []v2GraphEdge
+	for _, ev := range events {
+		if ev.Type != "chunk" {
+			continue
+		}
+		var ch v2GraphStreamChunk
+		if err := json.Unmarshal([]byte(ev.Data), &ch); err != nil {
+			t.Fatalf("chunk unmarshal: %v", err)
+		}
+		streamNodes = append(streamNodes, ch.Nodes...)
+		streamEdges = append(streamEdges, ch.Edges...)
+	}
+
+	if len(streamNodes) != len(full.Nodes) {
+		t.Fatalf("node count mismatch: stream %d vs full %d", len(streamNodes), len(full.Nodes))
+	}
+	for _, sn := range streamNodes {
+		fn, ok := fullNodeByID[sn.ID]
+		if !ok {
+			t.Errorf("streamed node %q absent from full payload", sn.ID)
+			continue
+		}
+		// Compare the full struct: same fields, same values (shape match).
+		if sn != fn {
+			t.Errorf("node %q differs between stream and full payload:\n stream=%+v\n full=%+v", sn.ID, sn, fn)
+		}
+	}
+	if len(streamEdges) != len(full.Edges) {
+		t.Errorf("edge count mismatch: stream %d vs full %d", len(streamEdges), len(full.Edges))
+	}
+	for _, se := range streamEdges {
+		if !fullEdgeSet[se.Source+"|"+se.Target+"|"+se.Kind] {
+			t.Errorf("streamed edge %+v absent from full payload", se)
+		}
+	}
+}
+
+// TestGraphStream_NoOverlayFallsBackToDegree verifies that when no pagerank
+// overlay is present (all pagerank == 0) ordering falls back to degree desc.
+func TestGraphStream_NoOverlayFallsBackToDegree(t *testing.T) {
+	// star: hub e0 connected to e1..e4; no pagerank set on any entity.
+	entities := []graph.Entity{
+		{ID: "e0", Kind: "function"},
+		{ID: "e1", Kind: "function"},
+		{ID: "e2", Kind: "function"},
+		{ID: "e3", Kind: "function"},
+		{ID: "e4", Kind: "function"},
+	}
+	rels := []graph.Relationship{
+		{FromID: "e0", ToID: "e1", Kind: "CALLS"},
+		{FromID: "e0", ToID: "e2", Kind: "CALLS"},
+		{FromID: "e0", ToID: "e3", Kind: "CALLS"},
+		{FromID: "e0", ToID: "e4", Kind: "CALLS"},
+	}
+	grp := makeGraphTestGroup(entities, rels)
+	ts := newV2GraphTestServerWithGroup(t, grp)
+
+	events := fetchGraphStream(t, ts, "")
+	var first v2GraphNode
+	got := false
+	for _, ev := range events {
+		if ev.Type != "chunk" {
+			continue
+		}
+		var ch v2GraphStreamChunk
+		if err := json.Unmarshal([]byte(ev.Data), &ch); err != nil {
+			t.Fatalf("chunk unmarshal: %v", err)
+		}
+		if len(ch.Nodes) > 0 {
+			first = ch.Nodes[0]
+			got = true
+			break
+		}
+	}
+	if !got {
+		t.Fatal("no node chunk received")
+	}
+	// Hub e0 has degree 4, others degree 1 → hub must stream first.
+	if first.ID != "testrepo::e0" {
+		t.Errorf("first node = %q, want testrepo::e0 (highest degree, no overlay)", first.ID)
+	}
+}
+
+// TestGraphStream_ColdGroupReturns503 verifies a not-warm group yields the
+// not-loaded signal rather than force-loading from disk.
+func TestGraphStream_ColdGroupReturns503(t *testing.T) {
+	st := newFakeStore()
+	st.groups["testgrp"] = GroupSummary{
+		Name: "testgrp", ConfigPath: "/tmp/testgrp.json", Repos: []string{"testrepo"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// Deliberately do NOT populate srv.graphs.entries → cold.
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/v2/graph/testgrp/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("cold group status = %d, want 503", resp.StatusCode)
+	}
+	var env struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode err body: %v", err)
+	}
+	if env.OK || env.Error.Code != "unavailable" {
+		t.Errorf("cold group body = %+v, want ok=false code=unavailable", env)
+	}
+	// Give the background warm goroutine a beat so it doesn't race t.Cleanup.
+	time.Sleep(10 * time.Millisecond)
+}


### PR DESCRIPTION
Increment 1 of epic #5446. Closes #5451.

### What
A new streaming graph endpoint so the dashboard can render a large graph progressively instead of waiting for the whole payload to serialise (the wait currently reads as "broken"). The GPU canvas renderer is fine with big graphs — this fixes *data delivery*. Backend only this increment; no frontend changes.

### Route + format
- `GET /api/v2/graph/{group}/stream` — group-scoped, path ends in `/stream` so the `withGzip` middleware leaves it uncompressed and chunks flush live.
- **SSE**, chosen over NDJSON to reuse the existing documented v2 streaming convention (`setV2SSEHeaders` / `writeV2SSEEvent`, `connected`→domain→done lifecycle, `/stream` gzip exclusion) — consistent with index-progress / mcp-activity / audit / job feeds, no new infra.

### Event lifecycle
1. `connected` — `{"subscribed_at": <unix-ms>}`
2. `meta` — `{"total_nodes":N,"total_edges":M,"communities":[…],"repos":[…]}` (drives the frontend progress counter + legend)
3. `chunk` × — `{"nodes":[…],"edges":[…]}`, batches of ~750 nodes, important-first
4. `done` — `{"done":true}`

### Shape matched
Nodes/edges are emitted in the **same shape as the existing `/api/v2/graph/{group}` full-payload endpoint** (built via the same `buildV2Graph`): per node `id,label,kind,repo,degree,pagerank,community_id?,source_file?`; per edge `source,target,kind`. A test asserts struct-equality between streamed and full-payload nodes so the frontend can switch with no data-model change.

### Important-first ordering
Source: the **group-algo overlay** — PageRank (centrality / god-nodes) descending, ties broken by served degree. When no overlay has run (all PageRank == 0) it falls back to **degree** descending (pure connectivity). An edge is only emitted in the first chunk by which both of its endpoints have already been streamed, so the frontend never references an unseen node.

### Warm-cache only
Streams via `GetGroupCachedForRef`, which never force-loads from disk or recomputes algorithms. A cold group returns **503 `unavailable`** (the standard not-loaded signal) and kicks off a background warm; the frontend handles warm-up separately. The existing full-payload endpoint is untouched.

### Tests
`httptest` against a small in-memory `DashGroup`: meta-first/chunks/done-last ordering, totals match, important-first ordering with and without an overlay, edge-after-both-endpoints invariant, streamed↔full-payload shape equality, and cold group → 503. `go build`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)