### PR TITLE
feat(dashboard): progressive graph rendering — incremental Cosmos feed + progress (#5446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Progressive graph rendering in the dashboard (#5446, increment 2):** the
+  Graph screen now consumes the streaming endpoint (`GET /api/v2/graph/{group}/stream`)
+  and feeds the GPU canvas (cosmos.gl) incrementally, so a large graph **builds
+  up live** with a "building graph… N / total nodes" counter and a subtle
+  progress bar instead of a long blank wait. The SSE consumer accumulates the
+  `meta` → `chunk…` → `done` events into the same normalized payload the
+  full-payload fetch produces (a pure, unit-tested reducer), so it is a drop-in
+  data source. A cold group (503) shows a "warming index…" state and retries
+  with a bounded, capped backoff; a mid-stream drop falls back to the
+  full-payload fetch (identical shape) so the graph still loads. On `done` the
+  canvas runs one canonical re-layout so the complete graph settles cleanly and
+  fits the viewport. A tiny graph still streams in a single round-trip, so the
+  small-graph case stays effectively instant. Frontend only this increment.
 - **Streaming graph endpoint for progressive load (#5446, increment 1):** a new
   `GET /api/v2/graph/{group}/stream` SSE endpoint streams the same node/edge
   shape as `/api/v2/graph/{group}` but progressively — a `meta` event first

--- a/webui-v2/src/hooks/use-graph-stream.ts
+++ b/webui-v2/src/hooks/use-graph-stream.ts
@@ -1,0 +1,216 @@
+/* ============================================================
+   hooks/use-graph-stream.ts — progressive graph SSE consumer.
+
+   Increment 2 of epic #5446. Streams GET /api/v2/graph/:group/stream
+   (SSE: connected → meta → chunk… → done) and accumulates it into the
+   SAME normalized GraphPayload the full-payload fetch yields (via the
+   pure reducer in lib/graph-stream-reducer), so the Graph screen + the
+   cosmos canvas consume the growing graph with NO data-model change and
+   build up live instead of a long blank wait.
+
+   Phases
+     • idle      — disabled / not started.
+     • warming   — the group is cold; the daemon returns 503 and warms in
+                   the background. We surface a "warming index…" state and
+                   retry with a bounded, capped backoff.
+     • streaming — meta received; chunks are arriving, the payload grows,
+                   the progress counter advances.
+     • done      — `done` received; the payload is complete.
+     • error     — the stream dropped AFTER meta (a real mid-stream failure
+                   the caller should fall back from to the full-payload
+                   fetch, since the shapes are identical).
+
+   EventSource can't read a non-2xx body, so a 503 (cold group) surfaces as
+   an `onerror` BEFORE any event. We distinguish that (→ warming, retry)
+   from a drop after meta (→ error, caller falls back).
+   ============================================================ */
+
+import { useEffect, useReducer, useRef, useState } from "react";
+import { api } from "@/lib/api";
+import {
+  initialStreamState,
+  applyMeta,
+  applyChunk,
+  applyDone,
+  type GraphStreamState,
+  type GraphStreamMetaWire,
+  type GraphStreamChunkWire,
+} from "@/lib/graph-stream-reducer";
+
+export type GraphStreamPhase = "idle" | "warming" | "streaming" | "done" | "error";
+
+export interface UseGraphStreamResult {
+  /** The growing (or complete) normalized payload — render it as it builds. */
+  state: GraphStreamState;
+  phase: GraphStreamPhase;
+  /** Nodes received so far (progress numerator). */
+  loadedNodes: number;
+  /** Total nodes from `meta` (progress denominator); 0 until meta arrives. */
+  totalNodes: number;
+}
+
+// Reconnect/retry backoff for a COLD group (503 → warming). Bounded + capped so
+// a slow warm self-heals without hammering the endpoint; clamps to the last
+// element and keeps retrying. Mirrors the use-mcp-activity schedule.
+const WARM_BACKOFF_MS = [1000, 2000, 3500, 5000];
+
+type Action =
+  | { type: "meta"; meta: GraphStreamMetaWire }
+  | { type: "chunk"; chunk: GraphStreamChunkWire }
+  | { type: "done" }
+  | { type: "reset" };
+
+function reducer(state: GraphStreamState, action: Action): GraphStreamState {
+  switch (action.type) {
+    case "meta":
+      return applyMeta(state, action.meta);
+    case "chunk":
+      return applyChunk(state, action.chunk);
+    case "done":
+      return applyDone(state);
+    case "reset":
+      return initialStreamState();
+  }
+}
+
+/**
+ * Consume the progressive graph stream for `groupId`.
+ *
+ * @param enabled  When false (e.g. the caller fell back to the full-payload
+ *                 fetch), no EventSource is opened and the hook stays idle.
+ */
+export function useGraphStream(groupId: string, enabled = true): UseGraphStreamResult {
+  const [state, dispatch] = useReducer(reducer, undefined, initialStreamState);
+  const [phase, setPhase] = useState<GraphStreamPhase>("idle");
+
+  // Latest phase in a ref so the long-lived effect's handlers branch on the
+  // current phase (warming-vs-mid-stream) without re-subscribing.
+  const phaseRef = useRef<GraphStreamPhase>("idle");
+  phaseRef.current = phase;
+
+  useEffect(() => {
+    if (!enabled || !groupId) {
+      setPhase("idle");
+      return;
+    }
+
+    // Fresh group / re-enable → clear any prior accumulation.
+    dispatch({ type: "reset" });
+    setPhase("warming");
+    phaseRef.current = "warming";
+
+    let cancelled = false;
+    let es: EventSource | null = null;
+    let warmAttempt = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    // Whether `meta` has been seen on the CURRENT connection — distinguishes a
+    // 503 cold-start (error before meta → warm + retry) from a real mid-stream
+    // drop (error after meta → surface error so the caller falls back).
+    let sawMeta = false;
+
+    const clearRetry = () => {
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+    };
+
+    const closeES = () => {
+      if (es) {
+        es.onerror = null;
+        es.close();
+        es = null;
+      }
+    };
+
+    const scheduleWarmRetry = () => {
+      if (cancelled || retryTimer !== null) return;
+      const idx = Math.min(warmAttempt, WARM_BACKOFF_MS.length - 1);
+      const delay = WARM_BACKOFF_MS[idx];
+      warmAttempt += 1;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        connect();
+      }, delay);
+    };
+
+    const connect = () => {
+      if (cancelled) return;
+      closeES();
+      sawMeta = false;
+
+      const conn = new EventSource(api.graphStreamUrl(groupId));
+      es = conn;
+
+      conn.addEventListener("meta", (ev: MessageEvent) => {
+        try {
+          const meta: GraphStreamMetaWire = JSON.parse(ev.data as string);
+          sawMeta = true;
+          warmAttempt = 0; // a successful connect resets the warm backoff.
+          dispatch({ type: "reset" });
+          dispatch({ type: "meta", meta });
+          if (!cancelled) {
+            setPhase("streaming");
+            phaseRef.current = "streaming";
+          }
+        } catch {
+          /* malformed meta — leave the onerror path to handle recovery. */
+        }
+      });
+
+      conn.addEventListener("chunk", (ev: MessageEvent) => {
+        try {
+          const chunk: GraphStreamChunkWire = JSON.parse(ev.data as string);
+          dispatch({ type: "chunk", chunk });
+        } catch {
+          /* skip a malformed chunk; the stream continues. */
+        }
+      });
+
+      conn.addEventListener("done", () => {
+        if (cancelled) return;
+        dispatch({ type: "done" });
+        setPhase("done");
+        phaseRef.current = "done";
+        clearRetry();
+        closeES();
+      });
+
+      conn.onerror = () => {
+        if (cancelled) return;
+        // A clean close after `done` lands here too — ignore it.
+        if (phaseRef.current === "done") return;
+        closeES();
+        if (sawMeta) {
+          // Dropped MID-STREAM after meta — a real failure. Surface `error` so
+          // the caller falls back to the full-payload fetch (identical shape).
+          setPhase("error");
+          phaseRef.current = "error";
+          clearRetry();
+          return;
+        }
+        // Error BEFORE meta — the group is cold (daemon returned 503 + is
+        // warming) or the connection failed early. Stay in the warming state
+        // and retry with backoff.
+        setPhase("warming");
+        phaseRef.current = "warming";
+        scheduleWarmRetry();
+      };
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      clearRetry();
+      closeES();
+    };
+  }, [groupId, enabled]);
+
+  return {
+    state,
+    phase,
+    loadedNodes: state.payload.nodes.length,
+    totalNodes: state.totalNodes,
+  };
+}

--- a/webui-v2/src/hooks/use-graph.ts
+++ b/webui-v2/src/hooks/use-graph.ts
@@ -51,12 +51,17 @@ function normalize(w: GraphPayloadWire): GraphPayload {
 export function useGraph(
   groupId: string,
   opts?: { repos?: string[]; filterKind?: string; lod?: string },
+  queryOpts?: { enabled?: boolean },
 ) {
   return useQuery({
     queryKey: graphQueryKey(groupId, opts?.repos, opts?.filterKind, opts?.lod),
     queryFn: async () => normalize(await api.getGraph(groupId, opts)),
     // The payload is large + server-cached (ETag/304); keep it warm.
     staleTime: 5 * 60 * 1000,
+    // #5446 — the full-payload fetch is the FALLBACK path: the Graph screen
+    // prefers the progressive SSE stream and only enables this when the stream
+    // fails. Defaults to enabled so other callers keep their eager behavior.
+    enabled: queryOpts?.enabled ?? true,
   });
 }
 

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -308,6 +308,22 @@ export const api = {
   },
 
   /**
+   * #5446 increment 2 — the absolute URL for the progressive graph SSE stream
+   * (GET /api/v2/graph/:group/stream). Returned (not fetched) because the
+   * stream is consumed via EventSource, not the fetch wrapper; centralizing it
+   * here keeps the configurable v2 base URL in one place. The streamed
+   * node/edge JSON is byte-for-byte the full-payload shape, so the same
+   * normalize path applies.
+   */
+  graphStreamUrl: (groupId: string, params?: { repos?: string[]; filterKind?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.repos && params.repos.length > 0) qs.set("repos", params.repos.join(","));
+    if (params?.filterKind) qs.set("filter_kind", params.filterKind);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return `${BASE_V2}/graph/${encodeURIComponent(groupId)}/stream${suffix}`;
+  },
+
+  /**
    * GET /api/v2/groups/:group/modules/analysis — module-level GDS (SCC,
    * PageRank, betweenness over the aggregated module graph). Powers the
    * "Module overview" mode on the Graph screen (#1386, closes epic #1380

--- a/webui-v2/src/lib/graph-stream-reducer.test.ts
+++ b/webui-v2/src/lib/graph-stream-reducer.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Increment 2 of epic #5446 — progressive graph stream reducer tests.
+ *
+ * Guards the pure accumulation seam the SSE consumer drives:
+ *   meta → chunk → chunk → done builds up the SAME normalized GraphPayload the
+ *   full-payload fetch produces, with the progress denominator from `meta`.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  initialStreamState,
+  applyMeta,
+  applyChunk,
+  applyDone,
+  type GraphStreamMetaWire,
+  type GraphStreamChunkWire,
+} from "./graph-stream-reducer";
+
+const meta: GraphStreamMetaWire = {
+  total_nodes: 3,
+  total_edges: 2,
+  communities: [{ id: 1, label: "core", repo: "r", size: 3, color_index: 0 }],
+  repos: [{ id: "r", language: "go", color_index: 0 }],
+};
+
+const chunk1: GraphStreamChunkWire = {
+  nodes: [
+    { id: "a", label: "A", kind: "func", repo: "r", degree: 2, pagerank: 0.9 },
+    { id: "b", label: "B", kind: "func", repo: "r", degree: 1, pagerank: 0.5, community_id: 1 },
+  ],
+  edges: [{ source: "a", target: "b", kind: "CALLS" }],
+};
+
+const chunk2: GraphStreamChunkWire = {
+  nodes: [{ id: "c", label: "", kind: "type", repo: "r", degree: 1, pagerank: 0.1, source_file: "x/y.go" }],
+  edges: [{ source: "a", target: "c", kind: "REFERENCES" }],
+};
+
+describe("graph-stream-reducer", () => {
+  it("initial state is an empty, renderable payload", () => {
+    const s = initialStreamState();
+    expect(s.payload.nodes).toEqual([]);
+    expect(s.payload.edges).toEqual([]);
+    expect(s.hasMeta).toBe(false);
+    expect(s.done).toBe(false);
+    expect(s.totalNodes).toBe(0);
+  });
+
+  it("applyMeta seeds totals + legend metadata and the totalNodeCount denominator", () => {
+    const s = applyMeta(initialStreamState(), meta);
+    expect(s.hasMeta).toBe(true);
+    expect(s.totalNodes).toBe(3);
+    expect(s.totalEdges).toBe(2);
+    expect(s.payload.totalNodeCount).toBe(3);
+    expect(s.payload.communities).toEqual([
+      { id: 1, label: "core", repo: "r", size: 3, colorIndex: 0 },
+    ]);
+    expect(s.payload.repos).toEqual([{ id: "r", language: "go", colorIndex: 0 }]);
+    // No nodes yet — meta carries only totals + legend.
+    expect(s.payload.nodes).toEqual([]);
+  });
+
+  it("applyChunk appends and normalizes nodes/edges to the growing arrays", () => {
+    let s = applyMeta(initialStreamState(), meta);
+    s = applyChunk(s, chunk1);
+    expect(s.payload.nodes).toHaveLength(2);
+    expect(s.payload.edges).toHaveLength(1);
+    // snake_case → camelCase normalization (pagerank → pageRank, community_id → communityId).
+    expect(s.payload.nodes[0]).toMatchObject({ id: "a", label: "A", pageRank: 0.9, communityId: null });
+    expect(s.payload.nodes[1]).toMatchObject({ communityId: 1 });
+
+    s = applyChunk(s, chunk2);
+    expect(s.payload.nodes).toHaveLength(3);
+    expect(s.payload.edges).toHaveLength(2);
+    // label falls back to id when blank; source_file → sourceFile.
+    expect(s.payload.nodes[2]).toMatchObject({ id: "c", label: "c", sourceFile: "x/y.go" });
+    // Accumulation reaches the meta totals.
+    expect(s.payload.nodes.length).toBe(s.totalNodes);
+    expect(s.payload.edges.length).toBe(s.totalEdges);
+  });
+
+  it("applyChunk returns a new payload reference each time (immutable update)", () => {
+    let s = applyMeta(initialStreamState(), meta);
+    const before = s.payload;
+    s = applyChunk(s, chunk1);
+    expect(s.payload).not.toBe(before);
+    expect(s.payload.nodes).not.toBe(before.nodes);
+  });
+
+  it("applyChunk tolerates empty/edgeless chunks without mutating arrays", () => {
+    let s = applyMeta(initialStreamState(), meta);
+    s = applyChunk(s, chunk1);
+    const nodesRef = s.payload.nodes;
+    s = applyChunk(s, { nodes: [], edges: [] });
+    // Nothing appended → same array reference is reused.
+    expect(s.payload.nodes).toBe(nodesRef);
+    expect(s.payload.nodes).toHaveLength(2);
+  });
+
+  it("applyDone marks the stream finished", () => {
+    let s = applyMeta(initialStreamState(), meta);
+    s = applyChunk(s, chunk1);
+    expect(s.done).toBe(false);
+    s = applyDone(s);
+    expect(s.done).toBe(true);
+    // done preserves the accumulated payload.
+    expect(s.payload.nodes).toHaveLength(2);
+  });
+});

--- a/webui-v2/src/lib/graph-stream-reducer.ts
+++ b/webui-v2/src/lib/graph-stream-reducer.ts
@@ -1,0 +1,147 @@
+/* ============================================================
+   lib/graph-stream-reducer.ts — pure accumulation seam for the
+   progressive graph stream (increment 2 of epic #5446).
+
+   The SSE consumer (hooks/use-graph-stream) is a thin transport
+   wrapper; ALL accumulation logic lives here as a pure reducer so it
+   is unit-testable without a live EventSource:
+
+     meta  → seed totals + legend metadata, start an empty payload
+     chunk → append normalized nodes/edges to the growing arrays
+     done  → mark finished
+
+   The accumulated `payload` is the SAME normalized GraphPayload shape
+   the full-payload fetch (hooks/use-graph → normalize) produces, so the
+   Graph screen + cosmos canvas consume it with no data-model change —
+   the stream is a drop-in source.
+   ============================================================ */
+
+import type {
+  GraphPayload,
+  GraphNodeWire,
+  GraphEdgeWire,
+  GraphCommunityWire,
+  GraphRepoWire,
+} from "@/data/types";
+
+/** `meta` event payload (snake_case wire) — totals + legend metadata. */
+export interface GraphStreamMetaWire {
+  total_nodes: number;
+  total_edges: number;
+  communities: GraphCommunityWire[];
+  repos: GraphRepoWire[];
+}
+
+/** `chunk` event payload (snake_case wire) — a batch of nodes + deliverable edges. */
+export interface GraphStreamChunkWire {
+  nodes: GraphNodeWire[];
+  edges: GraphEdgeWire[];
+}
+
+/**
+ * The accumulating stream state. `payload` is always a valid (possibly
+ * partial) GraphPayload the canvas can render as-is; the counters drive the
+ * progress affordance.
+ */
+export interface GraphStreamState {
+  /** Normalized, growing graph payload (camelCase domain shape). */
+  payload: GraphPayload;
+  /** Totals from `meta` (progress denominator). 0 until meta arrives. */
+  totalNodes: number;
+  totalEdges: number;
+  /** True once `meta` has been applied (payload is initialized + has legend). */
+  hasMeta: boolean;
+  /** True once `done` has been applied (stream finished cleanly). */
+  done: boolean;
+}
+
+/** The empty initial state — before `meta`, an empty renderable payload. */
+export function initialStreamState(): GraphStreamState {
+  return {
+    payload: { nodes: [], edges: [], communities: [], repos: [], totalNodeCount: 0 },
+    totalNodes: 0,
+    totalEdges: 0,
+    hasMeta: false,
+    done: false,
+  };
+}
+
+/** Normalize a wire node into the camelCase domain shape (mirrors use-graph). */
+function normalizeNode(n: GraphNodeWire) {
+  return {
+    id: n.id,
+    label: n.label || n.id,
+    kind: n.kind,
+    repo: n.repo,
+    degree: n.degree,
+    pageRank: n.pagerank,
+    communityId: n.community_id ?? null,
+    sourceFile: n.source_file ?? "",
+  };
+}
+
+/** Apply a `meta` event: seed totals + communities/repos, reset the payload. */
+export function applyMeta(
+  _prev: GraphStreamState,
+  meta: GraphStreamMetaWire,
+): GraphStreamState {
+  return {
+    payload: {
+      nodes: [],
+      edges: [],
+      communities: (meta.communities ?? []).map((c) => ({
+        id: c.id,
+        label: c.label,
+        repo: c.repo,
+        size: c.size,
+        colorIndex: c.color_index,
+      })),
+      repos: (meta.repos ?? []).map((r) => ({
+        id: r.id,
+        language: r.language,
+        colorIndex: r.color_index,
+      })),
+      // The Graph screen's LOD badge reads totalNodeCount as the denominator;
+      // the stream knows the true total up front from `meta`.
+      totalNodeCount: meta.total_nodes,
+    },
+    totalNodes: meta.total_nodes,
+    totalEdges: meta.total_edges,
+    hasMeta: true,
+    done: false,
+  };
+}
+
+/**
+ * Apply a `chunk` event: append the batch's nodes/edges to the growing arrays.
+ *
+ * New arrays are returned (immutable update) so React/consumers see a changed
+ * reference and re-render. The backend guarantees an edge only appears once both
+ * endpoints have streamed, so the appended edges never dangle.
+ */
+export function applyChunk(
+  prev: GraphStreamState,
+  chunk: GraphStreamChunkWire,
+): GraphStreamState {
+  const nodes = chunk.nodes?.length
+    ? prev.payload.nodes.concat(chunk.nodes.map(normalizeNode))
+    : prev.payload.nodes;
+  const edges = chunk.edges?.length
+    ? prev.payload.edges.concat(
+        chunk.edges.map((e: GraphEdgeWire) => ({
+          source: e.source,
+          target: e.target,
+          kind: e.kind,
+        })),
+      )
+    : prev.payload.edges;
+  return {
+    ...prev,
+    payload: { ...prev.payload, nodes, edges },
+  };
+}
+
+/** Apply the `done` event: mark the stream finished. */
+export function applyDone(prev: GraphStreamState): GraphStreamState {
+  return { ...prev, done: true };
+}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -18,6 +18,7 @@ import { X, RotateCcw, SlidersHorizontal, Boxes } from "lucide-react";
 import { SearchInput, Pill, Kbd, useSetInsight } from "@/components/ui";
 import type { InsightValue } from "@/components/ui";
 import { useGraph } from "@/hooks/use-graph";
+import { useGraphStream } from "@/hooks/use-graph-stream";
 import { useModuleAnalysis } from "@/hooks/use-module-analysis";
 import {
   useGraphStore,
@@ -127,7 +128,34 @@ export default function GraphScreen() {
 
   const s = useGraphStore();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { data, isLoading, isError } = useGraph(groupId, { lod: s.lod });
+
+  // #5446 increment 2 — PROGRESSIVE loading path. Prefer the SSE stream so a
+  // large graph builds up live (with a progress counter) instead of a long
+  // blank wait; the streamed node/edge shape is identical to the full-payload
+  // endpoint, so the screen + cosmos canvas consume the growing payload with no
+  // data-model change. If the stream drops mid-way we fall back to the
+  // full-payload fetch (same shape) so the graph still loads.
+  const stream = useGraphStream(groupId);
+  const streamFailed = stream.phase === "error";
+  // The full-payload fetch is the FALLBACK: only enabled once the stream has
+  // genuinely failed. A tiny graph still streams instantly (it's a single
+  // meta+chunk+done round-trip), so the small-graph case is not regressed.
+  const fallback = useGraph(groupId, { lod: s.lod }, { enabled: streamFailed });
+
+  // Unified view-model: the stream is the source of truth until it fails, then
+  // the fallback fetch takes over. `data` is the accumulating (or complete)
+  // payload; `isLoading` is true only while we have nothing renderable yet.
+  const streaming = stream.phase === "warming" || stream.phase === "streaming";
+  const data = streamFailed ? fallback.data : stream.state.payload;
+  const isLoading = streamFailed
+    ? fallback.isLoading
+    : // We're still loading until at least meta + the first nodes have landed.
+      !stream.state.hasMeta || stream.state.payload.nodes.length === 0;
+  const isError = streamFailed && fallback.isError;
+  // Progress affordance state for the "building graph… N / total" overlay.
+  const showStreamProgress =
+    !streamFailed && (streaming || (stream.phase === "done" && stream.state.payload.nodes.length === 0));
+  const isWarming = stream.phase === "warming";
   // #5147 coverage-kind overlay. The cosmos.gl WebGL engine renders nodes from
   // Float32 color buffers with NO per-node DOM/sprite layer, so a per-node tone
   // ring (as on the React-Flow surfaces) is genuinely infeasible here without a
@@ -197,6 +225,23 @@ export default function GraphScreen() {
     },
     [],
   );
+
+  // #5446 increment 2 — FINALIZE on stream done. The cosmos canvas auto-settles
+  // its layout the first time a non-empty graph lands and then PAUSES; while the
+  // graph streams in, later chunks seed new points without re-heating the
+  // (already-settled) sim, so mid-stream positions can look provisional. Once
+  // the full node set has streamed (`done`), trigger ONE canonical fresh
+  // re-layout — the exact routine the Reset button runs — so the complete graph
+  // settles cleanly and fits to the viewport. Fires once per group stream.
+  const finalizedRef = useRef(false);
+  useEffect(() => {
+    if (stream.phase === "streaming" || stream.phase === "warming") finalizedRef.current = false;
+    if (stream.phase === "done" && !finalizedRef.current && stream.state.payload.nodes.length > 0) {
+      finalizedRef.current = true;
+      s.requestRelayout();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stream.phase]);
 
   // ── ?node= deep-link: restore on mount, persist on selection change ──────────
   // On first render, if the URL carries ?node=<id>, apply it as the selected
@@ -672,7 +717,20 @@ export default function GraphScreen() {
           <div className="grid h-full place-items-center bg-bg">
             <div className="flex flex-col items-center gap-3 text-text-3">
               <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-accent" />
-              <span className="text-sm">Loading graph…</span>
+              {/* #5446 — distinguish a COLD group (daemon warming the index in
+                  the background, 503 + retry) from the normal initial wait. As
+                  soon as `meta` lands we know the total and switch to the live
+                  build-up counter (the overlay below), so this only ever shows
+                  before the first nodes arrive. */}
+              {isWarming ? (
+                <span className="text-sm">Warming index… preparing the graph</span>
+              ) : stream.totalNodes > 0 ? (
+                <span className="text-sm tabular-nums">
+                  Building graph… 0 / {stream.totalNodes.toLocaleString()} nodes
+                </span>
+              ) : (
+                <span className="text-sm">Loading graph…</span>
+              )}
             </div>
           </div>
         ) : isError ? (
@@ -761,6 +819,60 @@ export default function GraphScreen() {
               audioOn={replay.audioOn}
               onAudioToggle={replay.setAudioOn}
             />
+
+            {/* #5446 increment 2 — LIVE BUILD-UP progress affordance. While the
+                graph streams in, show a subtle top-center pill with the running
+                "N / total nodes" counter + a thin progress bar so a large graph
+                building up reads as deliberate progress, not a stall. The canvas
+                is already painting the nodes received so far underneath. Hidden
+                the moment `done` lands (showStreamProgress goes false). For a
+                tiny graph this flashes for a single frame, so it still looks
+                instant. Suppressed while focused so it doesn't fight the focus
+                banner. */}
+            {showStreamProgress && !focusActive ? (
+              <div className="absolute left-1/2 top-3 z-30 flex -translate-x-1/2 flex-col items-center gap-1.5 rounded-lg border border-accent/40 bg-surface/90 px-3.5 py-2 shadow-sm backdrop-blur-sm">
+                <div className="flex items-center gap-2 text-sm text-text">
+                  <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-border border-t-accent" />
+                  {isWarming ? (
+                    <span>Warming index…</span>
+                  ) : (
+                    <span className="tabular-nums">
+                      Building graph…{" "}
+                      <span className="font-medium text-text">
+                        {stream.loadedNodes.toLocaleString()}
+                      </span>
+                      {stream.totalNodes > 0 ? (
+                        <span className="text-text-3">
+                          {" "}
+                          / {stream.totalNodes.toLocaleString()}
+                        </span>
+                      ) : null}{" "}
+                      <span className="text-text-3">nodes</span>
+                    </span>
+                  )}
+                </div>
+                {/* Thin determinate bar (indeterminate shimmer while warming). */}
+                <div className="h-1 w-40 overflow-hidden rounded-full bg-border/60">
+                  <div
+                    className={`h-full rounded-full bg-accent transition-[width] duration-200 ease-out ${
+                      isWarming ? "animate-pulse" : ""
+                    }`}
+                    style={{
+                      width: isWarming
+                        ? "40%"
+                        : `${
+                            stream.totalNodes > 0
+                              ? Math.min(
+                                  100,
+                                  Math.round((stream.loadedNodes / stream.totalNodes) * 100),
+                                )
+                              : 5
+                          }%`,
+                    }}
+                  />
+                </div>
+              </div>
+            ) : null}
 
             {/* Fix #1548-3: clear "focused on X — exit" affordance. */}
             {focusActive ? (


### PR DESCRIPTION
Increment 2 of the streaming graph view epic (#5446) — closes #5453. Increment 1 (the backend SSE endpoint) is already merged; this is the **frontend** that consumes it.

## What

The Graph screen used to fetch the whole graph payload in one request before the GPU canvas could paint anything, so a large group showed a long blank wait. This change makes the screen prefer the streaming endpoint and feed the canvas incrementally, so the graph **builds up live** with a progress counter.

## Behaviour

- **`meta`** → initialize + show a progress affordance: "building graph… N / total nodes" with a subtle bar.
- **`chunk`** → append nodes/edges to the accumulating arrays, push to the canvas (live build-up), advance the counter.
- **`done`** → hide the affordance and run one canonical re-layout so the complete graph settles cleanly and fits the viewport.
- **cold group (503)** → show a "warming index…" state and retry with a bounded, capped backoff.
- **mid-stream drop** → fall back to the existing full-payload fetch (the streamed shape is byte-for-byte identical), so the graph still loads.
- A **tiny graph** still streams in a single round-trip, so the small-graph case stays effectively instant.

## How

- `lib/graph-stream-reducer.ts` — a **pure, unit-tested** reducer accumulating `meta` → `chunk…` → `done` into the same normalized payload the full-payload fetch yields, so it is a drop-in data source (no data-model change).
- `hooks/use-graph-stream.ts` — a thin `EventSource` consumer driving the reducer and owning the warming/streaming/done/error phases + warm-retry backoff. A 503 cold start surfaces as an `onerror` before any event (EventSource can't read a non-2xx body), distinguished from a real mid-stream drop.
- `routes/graph.tsx` — prefers the stream; the full-payload fetch (`useGraph`) is only enabled as the fallback once the stream genuinely fails.

### Incremental-feed approach + limitation

The existing canvas is mount-stable and re-packs its WebGL buffers whenever its `nodes`/`edges` props change, so the stream just feeds it the **growing accumulated arrays** — the smoothest "add-and-continue" path for this canvas version without surgery inside it. Trade-off: the canvas auto-settles its force layout once and then pauses, so points seeded by later chunks don't re-heat the already-settled sim mid-stream; positions can look provisional while streaming. We resolve this by triggering **one canonical fresh re-layout on `done`** (the same routine the Reset button runs), so the complete graph settles + fits regardless of mid-stream state.

## Verify

- `npm run build` + `tsc --noEmit` clean in webui-v2.
- New `graph-stream-reducer.test.ts` (6 tests) covers meta→chunks→done accumulation + immutability + the empty/edgeless-chunk case; full `src/lib` suite green (206 tests).
- `make dashboard-build` + `verify-dashboard: OK` (embedded bundle current; the built dist is gitignored and produced by CI/release, so only the source changes are committed).

Do not merge yet.