### PR TITLE
fix(dashboard): render graph incrementally during stream — grow live from first chunk (#5446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,26 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (`docs/c3-feature-impact-analysis.md`)
 
 ### Fixed
+- **Streamed graph now renders and grows LIVE from the first chunk (#5455,
+  epic #5446):** the progressive Graph screen showed a climbing
+  "building graph… N / total" counter while the WebGL canvas stayed **blank**,
+  then the whole graph popped in at once on `done`. The force-directed canvas
+  auto-settled the first chunk and then **paused** the simulation, so nodes
+  added by later chunks were pushed into the GPU buffers but never laid out (the
+  sim was paused) and sat invisible until the end. The canvas now has a
+  **streaming mode**: each chunk keeps the simulation warm and **gently re-heats**
+  it (`Graph.start(0.35)` — a low-alpha pulse, not a full reset), so the newly
+  arrived nodes are laid out and rendered immediately and the graph **grows +
+  jiggles live** from the first chunk. New nodes are **seeded next to an
+  already-placed neighbor** (their primary edge endpoint, with a small jitter) —
+  or near the centroid of the placed mass when they have no placed neighbor yet —
+  so they don't all fly in from the origin. On `done` the canvas runs a short
+  final cool-down + camera fit on the layout the live stream already produced (a
+  polish step, not the first paint) instead of the previous destructive full
+  re-layout that reshuffled the whole graph. Small graphs still stream in a
+  single round-trip and look instant; the progress counter, warming state, and
+  mid-stream fallback are unchanged. A partial streamed layout is never persisted
+  to the layout cache. Frontend only.
 - **Tests can no longer clobber a developer's real `~/.config/grafel` fleet
   config (#5443):** a group-overlay test resolved the fleet-config path
   (`registry.ConfigPathFor` → `registry.ConfigDir`) without redirecting

--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -228,6 +228,18 @@ export interface GraphCanvasProps {
   isFocusView: boolean;
   /** changes to this nonce force a fresh re-layout (skip cache). */
   relayoutNonce: number;
+  /**
+   * #5455 — true while the graph is actively STREAMING in (epic #5446). In this
+   * mode the canvas must NOT settle-and-pause after the first chunk: instead it
+   * keeps the simulation warm and GENTLY re-heats on each data push so the nodes
+   * that later chunks add get laid out and rendered live (the graph grows +
+   * jiggles from the first chunk), rather than sitting unplaced/invisible until
+   * `done`. New nodes are seeded near an already-placed neighbor so they don't
+   * fly in from the origin. When streaming ends the normal settle/fit (a
+   * relayoutNonce bump on `done`) finalizes the layout. Defaults to false, so the
+   * non-streaming (full-payload / focus / reset) paths are unchanged.
+   */
+  streaming?: boolean;
   onNodeClick: (node: GraphNode | null) => void;
   onNodeHover: (node: GraphNode | null) => void;
   onSettled: () => void;
@@ -302,6 +314,7 @@ function GraphCanvasInner(
     focusedCommunityId,
     isFocusView,
     relayoutNonce,
+    streaming = false,
     onNodeClick,
     onNodeHover,
     onSettled,
@@ -344,6 +357,15 @@ function GraphCanvasInner(
   const hoveredRef = useRef<string | null>(hoveredNodeId);
   hoveredRef.current = hoveredNodeId;
   const relayoutRef = useRef(relayoutNonce);
+  // #5455 — live streaming flag for the mount-only data-push / settle handlers.
+  const streamingRef = useRef(streaming);
+  streamingRef.current = streaming;
+  // #5455 — number of points the engine currently holds laid-out positions for.
+  // Used by the streaming data-push to detect which trailing nodes are NEW (just
+  // arrived in this chunk) so it can seed them near a placed neighbor and re-heat
+  // the sim, instead of resetting the whole layout. Reset whenever a fresh settle
+  // re-seeds the full buffer (kickFreshSettle) or the node set is swapped.
+  const placedCountRef = useRef(0);
 
   const idToIdx = useMemo(() => {
     const m = new Map<string, number>();
@@ -955,7 +977,11 @@ function GraphCanvasInner(
     // while Reset (re-run sim) looked right. Skip the cache write on a degenerate
     // (collapsed / tiny-bbox) layout so the next load re-settles instead of
     // restoring junk. (We never load a degenerate cache either — see load paths.)
-    if (positions.length > 0 && !isDegenerateLayout(positions)) {
+    // #5455 — never persist a layout cache for a PARTIAL streamed graph: a
+    // mid-stream settle holds only the chunks received so far, and caching it
+    // would make the next reload restore an incomplete graph. The `done` relayout
+    // settles + caches the complete graph.
+    if (positions.length > 0 && !isDegenerateLayout(positions) && !streamingRef.current) {
       saveLayout(group, nodeIds, positions);
     }
 
@@ -1128,6 +1154,9 @@ function GraphCanvasInner(
     g.render();
     g.create();
     g.start(1);
+    // #5455 — a fresh settle re-seeds the FULL buffer, so every current node now
+    // has a position; the streaming data-push only seeds nodes beyond this count.
+    placedCountRef.current = p.positions.length / 2;
     const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
     // Mid-settle re-heat: a single alpha pass partway through cools down before the
     // strong center/gravity finish pulling the islands inward (the hollow-ring
@@ -1341,6 +1370,75 @@ function GraphCanvasInner(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // #5455 — STREAMING re-heat alpha. A gentle pulse (not a full 1.0 reset) so the
+  // existing, already-placed mass barely shifts while the freshly-seeded new
+  // nodes are pulled into place by the link-spring/center. Low enough that the
+  // graph "jiggles as it grows" rather than fully reshuffling every chunk.
+  const STREAM_REHEAT_ALPHA = 0.35;
+
+  // #5455 — build the position buffer for a STREAMING data push. The first
+  // `placed` nodes keep their CURRENT live positions (so the laid-out mass stays
+  // put); every node beyond `placed` is NEW (just arrived in this chunk) and is
+  // seeded NEAR an already-placed neighbor (its primary edge endpoint) with a
+  // small jitter — or, if it has no placed neighbor yet, near the centroid of the
+  // placed mass — so new nodes don't all spawn at the origin and explode in. The
+  // running sim then refines these seeds live.
+  const seedStreamingPositions = useCallback(
+    (live: number[] | Float32Array, placed: number): Float32Array => {
+      const target = packed.positions; // length = current node count * 2
+      const out = new Float32Array(target.length);
+      // Keep the already-placed prefix at its live (laid-out) position.
+      const keep = Math.min(placed * 2, live.length, out.length);
+      for (let i = 0; i < keep; i++) out[i] = live[i];
+
+      // Centroid of the placed mass = fallback seed for new nodes with no placed
+      // neighbor (e.g. the first nodes of a brand-new community).
+      let cx = 0;
+      let cy = 0;
+      let cn = 0;
+      for (let i = 0; i + 1 < keep; i += 2) {
+        const x = live[i];
+        const y = live[i + 1];
+        if (Number.isFinite(x) && Number.isFinite(y)) {
+          cx += x;
+          cy += y;
+          cn++;
+        }
+      }
+      if (cn > 0) {
+        cx /= cn;
+        cy /= cn;
+      }
+
+      // Seed each NEW node near a placed neighbor (or the centroid) + jitter.
+      const placedCount = keep / 2;
+      for (let i = placedCount; i < target.length / 2; i++) {
+        const n = nodes[i];
+        let sx = cx;
+        let sy = cy;
+        const nbId = n ? renderedDegree.primary.get(n.id) : undefined;
+        const j = nbId !== undefined ? idToIdx.get(nbId) : undefined;
+        if (j !== undefined && j < placedCount) {
+          // Neighbor already placed → seed right beside it.
+          sx = out[j * 2];
+          sy = out[j * 2 + 1];
+        } else if (n) {
+          // No placed neighbor yet → keep the packed group-center seed (which is
+          // already near the middle) but bias it toward the placed centroid so it
+          // lands in the existing mass, not off in the seed field.
+          sx = (packed.positions[i * 2] + cx) / 2;
+          sy = (packed.positions[i * 2 + 1] + cy) / 2;
+        }
+        const a = Math.random() * 2 * Math.PI;
+        const r = Math.random() * 40;
+        out[i * 2] = sx + r * Math.cos(a);
+        out[i * 2 + 1] = sy + r * Math.sin(a);
+      }
+      return sanitizePositions(out).array;
+    },
+    [packed, nodes, renderedDegree, idToIdx],
+  );
+
   // ── data push (positions / colors / sizes / clusters / links) ───────────────
   useEffect(() => {
     const g = graphRef.current;
@@ -1350,6 +1448,38 @@ function GraphCanvasInner(
     // buffer; the empty-state overlay (below) is shown instead.
     if (!renderable) return;
     const prev = g.getPointPositions();
+
+    // #5455 — STREAMING-GROW path. While the graph streams in, each chunk grows
+    // the node set. The first chunk seeds + starts a normal warm settle; every
+    // SUBSEQUENT chunk that ADDS nodes must NOT settle-and-pause — it seeds the
+    // new nodes near a placed neighbor, keeps the already-placed mass put, pushes
+    // the buffers, and GENTLY re-heats the running sim so the new nodes are laid
+    // out and rendered LIVE (the graph grows + jiggles from the first chunk). The
+    // final settle/fit is the `done` relayout the route triggers.
+    const grew = packed.positions.length > prev.length && prev.length > 0;
+    if (streaming && grew && placedCountRef.current > 0) {
+      const seeded = seedStreamingPositions(prev, placedCountRef.current);
+      g.setPointPositions(seeded);
+      g.setPointSizes(packed.sizes);
+      g.setPointClusters(packed.clusters);
+      g.setPointClusterStrength(packed.clusterStrength);
+      g.setPointColors(packPointColors());
+      g.setLinks(linkData.links);
+      g.setLinkColors(packLinkColors());
+      g.setLinkWidths(packLinkWidths());
+      g.render();
+      g.create();
+      // Keep the sim warm: a gentle re-heat so the new nodes settle into place
+      // without fully reshuffling the placed graph. Never pause during a stream.
+      hasSettledRef.current = false;
+      didAutoStartRef.current = true;
+      g.unpause();
+      g.start(STREAM_REHEAT_ALPHA);
+      placedCountRef.current = packed.positions.length / 2;
+      scheduleLabels();
+      return;
+    }
+
     if (hasSettledRef.current && prev.length === packed.positions.length) {
       // Fix #1562: re-pin the settled geometry, but sanitize first so a diverged
       // layout never gets pushed back into the engine.
@@ -1378,9 +1508,12 @@ function GraphCanvasInner(
         kickFreshSettleRef.current();
       }
     }
-    if (hasSettledRef.current) g.pause();
+    // #5455 — don't freeze a graph that is still streaming in: keep the sim warm
+    // so the next chunk's nodes can be laid out. Only the normal (non-streaming)
+    // settled path re-pauses here.
+    if (hasSettledRef.current && !streaming) g.pause();
     scheduleLabels();
-  }, [renderable, packed, packPointColors, linkData, packLinkColors, packLinkWidths, group, nodeIds, scheduleLabels]);
+  }, [renderable, packed, packPointColors, linkData, packLinkColors, packLinkWidths, group, nodeIds, scheduleLabels, streaming, seedStreamingPositions]);
 
   // ── recolor on theme / colorMode ────────────────────────────────────────────
   useEffect(() => {
@@ -1435,6 +1568,38 @@ function GraphCanvasInner(
     kickFreshSettleRef.current();
   }, [relayoutNonce, packed]);
 
+  // ── #5455: STREAMING FINALIZE — gentle settle + fit when the stream ends ──────
+  // While streaming, the data-push keeps the sim warm and grows the graph live, so
+  // by the time `streaming` flips false (`done`) the graph is ALREADY rendered and
+  // mostly settled. We must NOT throw that away with a fresh full re-seed (which
+  // would reshuffle the whole graph from the unspread packed seeds). Instead, run a
+  // SHORT final cool-down on the CURRENT live positions, then doSettle (which fits
+  // the camera + caches the now-complete layout). This is the polish step — not the
+  // first paint. Only fires on the true→false streaming transition.
+  const wasStreamingRef = useRef(streaming);
+  useEffect(() => {
+    const was = wasStreamingRef.current;
+    wasStreamingRef.current = streaming;
+    if (!(was && !streaming)) return; // only on stream end
+    const g = graphRef.current;
+    if (!g) return;
+    if (!renderableRef.current) return;
+    // A brief gentle re-heat to let the last chunk's nodes finish settling, then a
+    // hard cap → doSettle (fit + cache the complete graph). Keeps the layout the
+    // live stream already produced; doesn't re-seed from scratch.
+    hasSettledRef.current = false;
+    didAutoStartRef.current = true;
+    if (capTimerRef.current) clearTimeout(capTimerRef.current);
+    if (reheatTimerRef.current) clearTimeout(reheatTimerRef.current);
+    reheatedRef.current = true; // skip the early-cool-down guard — this IS the final settle
+    g.unpause();
+    g.start(STREAM_REHEAT_ALPHA);
+    capTimerRef.current = setTimeout(() => {
+      if (!hasSettledRef.current) doSettleRef.current();
+    }, 900);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [streaming]);
+
   // ── #4641: AUTO-SETTLE on first data load (the recurring "explode"/clumped
   //    bug, #4492/#2107). On the very first render of a NON-EMPTY renderable
   //    graph the canvas used to arrive clumped — the seed positions paused
@@ -1478,6 +1643,12 @@ function GraphCanvasInner(
   useEffect(() => {
     if (autoCorrectDoneRef.current) return;
     if (!renderable) return; // crash-guard: never seed/start an empty graph
+    // #5455 — while the graph is STREAMING in, the live-grow data-push owns the
+    // layout (seed-near-neighbor + gentle re-heat per chunk). The auto-correct
+    // verify-retry kick re-seeds the WHOLE buffer from the unspread packed seeds,
+    // which would reshuffle the growing graph every cycle — skip it during a
+    // stream. The `done` relayout runs the canonical settle once complete.
+    if (streaming) return;
     const g = graphRef.current;
     if (!g) return;
 
@@ -1573,7 +1744,10 @@ function GraphCanvasInner(
       cancelled = true;
       if (verifyTimer) clearTimeout(verifyTimer);
     };
-  }, [renderable, group, nodeIds]);
+    // #5455 — `streaming` is a dep so the controller re-arms when the stream ends
+    // (streaming → false on `done`), letting the post-stream graph self-correct if
+    // the final settle ever arrives collapsed.
+  }, [renderable, group, nodeIds, streaming]);
 
   // ── re-layout when the node SET changes (Fix #1548-3 ego enter/exit) ─────────
   // Entering/leaving focus swaps `group` (…::ego) and the node set. The settled

--- a/webui-v2/src/lib/graph-stream-reducer.test.ts
+++ b/webui-v2/src/lib/graph-stream-reducer.test.ts
@@ -96,6 +96,22 @@ describe("graph-stream-reducer", () => {
     expect(s.payload.nodes).toHaveLength(2);
   });
 
+  it("appends new nodes to the TAIL, preserving earlier indices (#5455 live-grow invariant)", () => {
+    // The canvas's incremental live-render seeds only the TRAILING (newly arrived)
+    // nodes near a placed neighbor and leaves the already-placed prefix put. That
+    // depends on the reducer APPENDING new chunks — never reordering or reindexing
+    // earlier ones — so index i is stable across chunks for a node already present.
+    let s = applyMeta(initialStreamState(), meta);
+    s = applyChunk(s, chunk1);
+    const idsAfter1 = s.payload.nodes.map((n) => n.id);
+    expect(idsAfter1).toEqual(["a", "b"]);
+    s = applyChunk(s, chunk2);
+    const idsAfter2 = s.payload.nodes.map((n) => n.id);
+    // The earlier nodes keep their positions; the new node is strictly appended.
+    expect(idsAfter2.slice(0, idsAfter1.length)).toEqual(idsAfter1);
+    expect(idsAfter2[idsAfter2.length - 1]).toBe("c");
+  });
+
   it("applyDone marks the stream finished", () => {
     let s = applyMeta(initialStreamState(), meta);
     s = applyChunk(s, chunk1);

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -226,22 +226,15 @@ export default function GraphScreen() {
     [],
   );
 
-  // #5446 increment 2 — FINALIZE on stream done. The cosmos canvas auto-settles
-  // its layout the first time a non-empty graph lands and then PAUSES; while the
-  // graph streams in, later chunks seed new points without re-heating the
-  // (already-settled) sim, so mid-stream positions can look provisional. Once
-  // the full node set has streamed (`done`), trigger ONE canonical fresh
-  // re-layout — the exact routine the Reset button runs — so the complete graph
-  // settles cleanly and fits to the viewport. Fires once per group stream.
-  const finalizedRef = useRef(false);
-  useEffect(() => {
-    if (stream.phase === "streaming" || stream.phase === "warming") finalizedRef.current = false;
-    if (stream.phase === "done" && !finalizedRef.current && stream.state.payload.nodes.length > 0) {
-      finalizedRef.current = true;
-      s.requestRelayout();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stream.phase]);
+  // #5446 / #5455 — FINALIZE on stream done is now owned by the CANVAS. While the
+  // graph streams in, the canvas keeps the sim warm and grows the layout LIVE
+  // (seed-near-neighbor + gentle per-chunk re-heat), so by the time the stream
+  // ends the graph is already rendered and mostly settled. When the `streaming`
+  // prop flips false (on `done`), the canvas runs a short final cool-down + fit on
+  // the live positions it already produced — a polish step, not a destructive full
+  // re-seed. We deliberately DON'T trigger a full requestRelayout() here anymore:
+  // that re-seeded from the unspread packed positions and reshuffled the whole
+  // graph, undoing the live-grown layout the user just watched build up.
 
   // ── ?node= deep-link: restore on mount, persist on selection change ──────────
   // On first render, if the URL carries ?node=<id>, apply it as the selected
@@ -759,6 +752,7 @@ export default function GraphScreen() {
                 nodes={egoNodes}
                 edges={egoEdges}
                 isFocusView={focusActive}
+                streaming={stream.phase === "streaming" && !focusActive}
                 selectedNodeId={s.selectedNodeId}
                 hoveredNodeId={s.hoveredNodeId}
                 isDark={isDark}


### PR DESCRIPTION
## Problem
The progressive graph streaming (epic #5446, increments 1+2) shows a `building graph… N/total` counter, but the WebGL canvas stays **blank** during streaming — the graph only pops in all at once on `done`. Closes #5455.

## Root cause
The force-directed canvas auto-settles the first chunk and then **pauses** the simulation. Nodes appended by later chunks are pushed into the GPU buffers but never laid out (the sim is paused), so they sit at unspread seed positions / invisible until `done` triggers one final re-layout.

## Fix (frontend only, `webui-v2`)
- **Streaming mode on the canvas** (new `streaming` prop, true while `phase === 'streaming'`). Each chunk's data-push:
  - keeps the already-placed mass put and seeds only the **new trailing nodes** near an already-placed neighbor (their primary edge endpoint, with a small jitter) — or near the placed-mass centroid when they have no placed neighbor yet — so new nodes don't fly in from the origin;
  - **gently re-heats** the running simulation with `Graph.start(0.35)` (a low-alpha pulse — the cosmos.gl 2.6.4 sim-control API; `render()` does NOT touch the sim) and **never pauses** during the stream, so the new nodes are laid out and rendered live (the graph grows + jiggles from the first chunk).
- **`done` is a polish step, not the first paint.** When `streaming` flips false the canvas runs a short final cool-down + camera fit on the layout the live stream already produced, instead of the previous destructive full re-layout (which re-seeded from the unspread packed positions and reshuffled the whole graph).
- The auto-settle verify/retry controller is disabled during a stream (it would re-seed the whole buffer each cycle), and a **partial streamed layout is never persisted** to the layout cache.

## No regression
Small graphs still stream in a single round-trip and look instant; the progress counter, warming state, and mid-stream full-payload fallback are unchanged.

## Verification
- `tsc --noEmit` clean; `npm run build` clean.
- Full `webui-v2` unit suite green (207 tests, 19 files); added a reducer test asserting the prefix-stability invariant the live-grow seeding relies on (earlier chunks keep their indices as later chunks append).
- `make dashboard-build` + `go run ./cmd/verify-dashboard` OK.

Refs #5446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)