### PR TITLE
fix(dashboard): replay glows every event + camera stays framed during settle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,31 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (`docs/c3-feature-impact-analysis.md`)
 
 ### Fixed
+- **Graph MCP-activity replay now glows EVERY event, not just the last (#5457):**
+  in the graph view's MCP-activity panel, "Replay all" and clicking an individual
+  event entry are meant to make each step's nodes **glow** in sequence. Only the
+  *last* step actually pulsed on screen. Both replay paths feed the same canvas
+  glow, which **caps** the pulse to nodes currently in the viewport (a perf cap)
+  and falls back to an off-screen sample when none are in view — and since the
+  replay camera is **static**, each step's nodes are almost always off-screen, so
+  the pulse fired **invisibly** in a far cluster. The canvas now **pans/fits the
+  camera to a step's nodes** (eased, matching the comet/sweep overlay's per-step
+  motion) whenever the step is fully off-screen, so every replayed event glows in
+  view — replay-all *and* individual clicks. Gated so it never fires in a
+  focus/ego view or during a camera restore, and never when a node is already in
+  view (so a view the user is reading isn't yanked).
+- **Graph force-layout stays centered during the settle instead of drifting to a
+  corner then snapping (#5458):** when the graph "exploded"/settled (initial load,
+  Reset, and streaming) it appeared to shrink toward the upper-right corner each
+  second — sometimes leaving the viewport — then **snapped** to center on a single
+  final `fitView`. The camera was static while the simulation spread the nodes.
+  The canvas now **continuously tracks the camera to the spreading layout**: a
+  throttled, eased fit (~every 350ms while the simulation is running) keeps the
+  graph centered + framed the whole time, and the **final fit is eased/animated**
+  (cosmos.gl `fitView(duration)`) so even an intentional re-fit glides rather than
+  jumps. Auto-fit runs only during the initial settle / explode / stream
+  cool-down — it does **not** fight the user's manual pan/zoom once they've
+  interacted, and does not fit during focus/ego views.
 - **Streamed graph now renders and grows LIVE from the first chunk (#5455,
   epic #5446):** the progressive Graph screen showed a climbing
   "building graph… N / total" counter while the WebGL canvas stayed **blank**,

--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/lib/graph-colors";
 import { saveLayout, loadLayout, isDegenerateLayout, isLayoutHealthy } from "@/lib/graph-layout-cache";
 import { isRenderableGraph } from "@/lib/graph-render-guard";
+import { shouldFitReplayStep } from "@/lib/replay-glow-visibility";
 import {
   autoBasePx,
   type ColorMode,
@@ -70,6 +71,15 @@ const EMPTY_HIGHLIGHT: ReadonlySet<string> = new Set();
 // frame (the base buffers are written once, off the hot path). The same bounded
 // set drives the dim-focus selection so both stay non-blocking.
 const GLOW_CAP = 200;
+
+// #5458 — duration (ms) of the EASED final settle fit. Long enough to read as a
+// glide (not a snap), short enough not to feel sluggish.
+const FINAL_FIT_MS = 320;
+
+// #5457 — duration (ms) of the eased camera pan to an off-screen MCP-replay step.
+// Short enough to keep pace with the ~650ms/step replay cadence so the camera has
+// arrived (and the glow is visible) well before the next step fires.
+const REPLAY_GLOW_FIT_MS = 280;
 
 const SPACE_SIZE = 32768;
 // Fix #1532-3 / #1548-2: a small padding makes the settled graph FILL the
@@ -867,6 +877,10 @@ function GraphCanvasInner(
   // verify-then-retry controller checks it so it only ever auto-corrects the
   // INITIAL collapsed render — once the user takes control we never re-fire.
   const userInteractedRef = useRef(false);
+  // #5458 — live mirror of the isFocusView prop so the mount-stable settle-fit
+  // tracker can gate on it without re-running on every focus toggle.
+  const isFocusViewRef = useRef(isFocusView);
+  isFocusViewRef.current = isFocusView;
   const rafRef = useRef<number | null>(null);
   const motionLoop = useCallback(() => {
     if (!interactingRef.current) {
@@ -948,6 +962,139 @@ function GraphCanvasInner(
   const fitNowRef = useRef(fitNow);
   fitNowRef.current = fitNow;
 
+  // #5458 — EASED fit. cosmos.gl `fitView`/`fitViewByPointIndices` take a
+  // duration (ms) and animate the camera center+zoom over it (d3-zoom transition).
+  // Unlike `fitNow` (duration 0, used at the final pinned settle) this is for the
+  // LIVE, still-running settle where the loop is already painting — so we just ask
+  // the engine to glide the camera; no pause/re-pin dance is needed (the sim owns
+  // the geometry). Sanitize first so a transiently non-finite frame can't size an
+  // Infinity bounds buffer and crash (same guard as fitNow). A no-op if the engine
+  // is paused (cosmos only applies a fit while the render loop runs) — callers gate
+  // on isSimulationRunning so the loop is live when this is used.
+  const fitAnimated = useCallback((durationMs: number) => {
+    const g = graphRef.current;
+    if (!g) return;
+    try {
+      const raw = g.getPointPositions();
+      const { array: clean, repaired } = sanitizePositions(raw);
+      if (repaired) g.setPointPositions(clean, true);
+      g.fitView(durationMs, FIT_PADDING);
+    } catch (err) {
+      console.error("[graph-canvas] fitAnimated failed (ignored)", err);
+    }
+  }, []);
+  const fitAnimatedRef = useRef(fitAnimated);
+  fitAnimatedRef.current = fitAnimated;
+
+  // #5458 — EASED fit to a SPECIFIC node-index set, working whether the engine is
+  // live OR settled (paused). A paused engine ignores any fit (the render loop is
+  // stopped), so we briefly unpause, kick the eased `fitViewByPointIndices`
+  // transition, and re-pin + re-pause once it has run. Used by the MCP-replay glow
+  // (#5457): each replayed step's nodes are usually OFF-SCREEN on the static
+  // settled camera, so the glow resolved to an off-screen sample and only the step
+  // whose nodes happened to be in view ever visibly pulsed. Panning the camera to
+  // each step's nodes (eased, matching the comet/sweep overlay) guarantees every
+  // replayed event glows in view. A larger padding than FIT_PADDING keeps the
+  // (often small) step cluster from filling the whole viewport.
+  const REPLAY_FIT_PADDING = 0.35;
+  // #5457 — monotonic token so a stale re-pin (from a previous step's fit) can't
+  // pause the engine mid-way through the NEXT step's camera transition during a
+  // fast replay-all.
+  const replayFitTokenRef = useRef(0);
+  const fitToIndicesAnimated = useCallback((indices: number[], durationMs: number) => {
+    const g = graphRef.current;
+    if (!g || indices.length === 0) return;
+    const wasSettled = hasSettledRef.current;
+    const token = ++replayFitTokenRef.current;
+    try {
+      const { array: clean, repaired } = sanitizePositions(g.getPointPositions());
+      if (repaired) g.setPointPositions(clean, true);
+      g.unpause();
+      g.fitViewByPointIndices(indices, durationMs, REPLAY_FIT_PADDING);
+      if (wasSettled) {
+        // Re-pin the settled geometry + pause once the camera transition has run,
+        // so the physics can't drift while the glow plays. The eased glide is what
+        // the user sees; the pin underneath holds the layout steady. Skip if a
+        // newer fit has superseded this one (token mismatch).
+        const frozen = clean;
+        setTimeout(() => {
+          if (replayFitTokenRef.current !== token) return; // superseded — leave live
+          const gg = graphRef.current;
+          if (!gg) return;
+          try {
+            gg.setPointPositions(frozen, true);
+            gg.pause();
+            applyZoomSizingRef.current(true);
+            applyZoomLinkWidthsRef.current(true);
+            refreshLabelsRef.current();
+          } catch {
+            /* engine torn down mid-transition — ignore */
+          }
+        }, durationMs + 40);
+      }
+    } catch (err) {
+      console.error("[graph-canvas] fitToIndicesAnimated failed (ignored)", err);
+    }
+  }, []);
+  const fitToIndicesAnimatedRef = useRef(fitToIndicesAnimated);
+  fitToIndicesAnimatedRef.current = fitToIndicesAnimated;
+
+  // #5458 — CONTINUOUS fit-DURING-settle. Historically the camera was static while
+  // the force sim spread the nodes, so the graph appeared to shrink + drift toward
+  // a corner for the whole settle and then SNAPPED to center on the single final
+  // fitView in doSettle. Here we track the camera to the spreading layout: a
+  // THROTTLED eased fit (~every FIT_TRACK_MS) while the simulation is running, so
+  // the graph stays centered + framed the whole time and the end "snap" is just the
+  // last small glide. Self-terminating: stops when the sim stops, on settle, on
+  // user interaction, or on focus/ego (where restoreCamera / the ego fit own the
+  // view). Only ONE tracker runs at a time (settleFitRafRef).
+  const settleFitRafRef = useRef<number | null>(null);
+  const FIT_TRACK_MS = 350; // throttle between tracking fits
+  const stopSettleFitTracking = useCallback(() => {
+    if (settleFitRafRef.current !== null) {
+      cancelAnimationFrame(settleFitRafRef.current);
+      settleFitRafRef.current = null;
+    }
+  }, []);
+  const stopSettleFitTrackingRef = useRef(stopSettleFitTracking);
+  stopSettleFitTrackingRef.current = stopSettleFitTracking;
+  const startSettleFitTracking = useCallback(() => {
+    const g = graphRef.current;
+    if (!g) return;
+    // Don't track during focus/ego (the ego re-fit / camera restore owns the view)
+    // or when a fit is being suppressed for a camera restore.
+    if (isFocusViewRef.current || suppressFitRef.current) return;
+    if (userInteractedRef.current) return; // never fight a manual pan/zoom
+    stopSettleFitTrackingRef.current();
+    let last = 0;
+    const tick = (now: number) => {
+      const gg = graphRef.current;
+      // Stop the moment any owner takes over or the settle finishes.
+      if (
+        !gg ||
+        hasSettledRef.current ||
+        userInteractedRef.current ||
+        isFocusViewRef.current ||
+        suppressFitRef.current ||
+        !gg.isSimulationRunning
+      ) {
+        settleFitRafRef.current = null;
+        return;
+      }
+      if (now - last >= FIT_TRACK_MS) {
+        last = now;
+        // Glide the camera to the current bounds over slightly less than the
+        // throttle interval so each track completes before the next begins —
+        // the graph stays centered + framed instead of drifting then snapping.
+        fitAnimatedRef.current(Math.round(FIT_TRACK_MS * 0.8));
+      }
+      settleFitRafRef.current = requestAnimationFrame(tick);
+    };
+    settleFitRafRef.current = requestAnimationFrame(tick);
+  }, []);
+  const startSettleFitTrackingRef = useRef(startSettleFitTracking);
+  startSettleFitTrackingRef.current = startSettleFitTracking;
+
   // Fix #1548-3: when EXITING focus we restore the snapshotted camera, so the
   // settle handler must NOT auto-fit (which would clobber the restore).
   const suppressFitRef = useRef(false);
@@ -985,39 +1132,48 @@ function GraphCanvasInner(
       saveLayout(group, nodeIds, positions);
     }
 
-    // Fix #1548-2: cosmos.gl `fitView` is a no-op while the render loop is
-    // paused — that was why the settled graph floated off-center and didn't
-    // FILL the viewport. We freeze the geometry (re-pin the settled positions)
-    // and pause the physics FIRST, then use the fitNow helper which briefly
-    // resumes the render loop to apply an INSTANT fit and pauses again — so the
-    // fit lands deterministically on the final geometry with no drift.
-    g.setPointPositions(positions, true);
-    g.pause();
+    // #5458 — stop the during-settle camera tracker; doSettle now owns the
+    // final framing.
+    stopSettleFitTrackingRef.current();
 
     if (suppressFitRef.current) {
-      // Exiting focus: skip the fit (restoreCamera owns the view).
+      // Exiting focus: skip the fit (restoreCamera owns the view). Pin + pause the
+      // geometry as before — restoreCamera reasserts the snapshotted view.
+      g.setPointPositions(positions, true);
+      g.pause();
       suppressFitRef.current = false;
       scheduleLabels();
       onSettledRef.current();
       return;
     }
 
-    fitNowRef.current();
-    // Fix #1607: the fit sets the fitted zoom level → recompute the zoom-driven
-    // point size so the very first painted (fitted) frame already has perceptible,
-    // non-overlapping nodes with no manual tuning.
+    // #5458 — EASED final fit, then pin. With the during-settle tracker the camera
+    // was already kept framed, so the final fit is a small correction rather than
+    // the old corner→center SNAP. We glide it (eased fitView) while the render loop
+    // is STILL LIVE (a fit is a no-op once paused), let the transition finish, then
+    // re-pin the settled positions + pause so the physics can't drift and the
+    // deterministic instant fitNow lands the exact framing. The eased glide is what
+    // the user sees; the instant pin underneath is imperceptible.
+    fitAnimatedRef.current(FINAL_FIT_MS);
     applyZoomSizingRef.current(true);
-    // Fix #2110: also apply zoom-compensated link widths at initial settle so the
-    // very first paint already reflects the fitted zoom level.
     applyZoomLinkWidthsRef.current(true);
     scheduleLabels();
-    // One more fit on the next frames in case the canvas size settled late.
     setTimeout(() => {
+      const gg = graphRef.current;
+      if (!gg) return;
+      // Fix #1548-2 / #1562: pin the (sanitized) settled geometry and pause, then
+      // INSTANT-fit on the pinned frame so the camera lands deterministically.
+      const { array: pinned } = sanitizePositions(gg.getPointPositions());
+      const finalPos = pinned.length > 0 ? pinned : positions;
+      gg.setPointPositions(finalPos, true);
+      gg.pause();
       fitNowRef.current();
+      // Fix #1607 / #2110: recompute zoom-driven point size + link widths so the
+      // first pinned frame already reflects the fitted zoom level.
       applyZoomSizingRef.current(true);
       applyZoomLinkWidthsRef.current(true);
       scheduleLabels();
-    }, 200);
+    }, FINAL_FIT_MS + 40);
     onSettledRef.current();
   }, [group, nodeIds, scheduleLabels]);
   const doSettleRef = useRef(doSettle);
@@ -1154,6 +1310,9 @@ function GraphCanvasInner(
     g.render();
     g.create();
     g.start(1);
+    // #5458 — track the camera to the spreading layout for the whole settle so the
+    // graph stays centered + framed instead of drifting to a corner then snapping.
+    startSettleFitTrackingRef.current();
     // #5455 — a fresh settle re-seeds the FULL buffer, so every current node now
     // has a position; the streaming data-push only seeds nodes beyond this count.
     placedCountRef.current = p.positions.length / 2;
@@ -1362,6 +1521,8 @@ function GraphCanvasInner(
       if (reheatTimerRef.current) clearTimeout(reheatTimerRef.current);
       if (labelTimerRef.current !== null) clearTimeout(labelTimerRef.current);
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      // #5458 — tear down the during-settle camera tracker on unmount.
+      if (settleFitRafRef.current !== null) cancelAnimationFrame(settleFitRafRef.current);
       interactingRef.current = false;
       g.destroy();
       graphRef.current = null;
@@ -1594,6 +1755,8 @@ function GraphCanvasInner(
     reheatedRef.current = true; // skip the early-cool-down guard — this IS the final settle
     g.unpause();
     g.start(STREAM_REHEAT_ALPHA);
+    // #5458 — keep the camera framed during the final stream cool-down too.
+    startSettleFitTrackingRef.current();
     capTimerRef.current = setTimeout(() => {
       if (!hasSettledRef.current) doSettleRef.current();
     }, 900);
@@ -1980,6 +2143,29 @@ function GraphCanvasInner(
       onGlowCapRef.current?.(nodeIdxs.length, matchedTotal);
     } else {
       onGlowCapRef.current?.(nodeIdxs.length, nodeIdxs.length);
+    }
+
+    // #5457 — BUG: an MCP-replay step (replay-all OR a single clicked entry) lands
+    // on the SAME static settled camera, so each step's nodes are almost always
+    // OFF-SCREEN. The cap logic above then falls back to an off-screen `overflow`
+    // sample, which DOES pulse — but invisibly, off in a far cluster — so the user
+    // only ever sees the one step whose nodes happen to sit in the viewport. Fix:
+    // when nothing the step matched is currently in view, PAN/FIT the camera to the
+    // step's nodes (eased, matching the comet/sweep overlay's per-step motion) so
+    // every replayed event visibly glows. We do this only when the step is fully
+    // off-screen (inView empty) and not in a focus/ego view (where the ego fit /
+    // camera restore own the view). When at least one node is already in view we
+    // leave the camera alone so we don't yank a view the user is already reading.
+    if (
+      shouldFitReplayStep({
+        inViewCount: inView.length,
+        resolvedCount: nodeIdxs.length,
+        haveViewport,
+        isFocusView: isFocusViewRef.current,
+        suppressFit: suppressFitRef.current,
+      })
+    ) {
+      fitToIndicesAnimatedRef.current(nodeIdxs, REPLAY_GLOW_FIT_MS);
     }
 
     // Resolve the affected EDGE (link) indices: an edge glows when both its

--- a/webui-v2/src/lib/replay-glow-visibility.test.ts
+++ b/webui-v2/src/lib/replay-glow-visibility.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { shouldFitReplayStep } from "./replay-glow-visibility";
+
+const base = {
+  inViewCount: 0,
+  resolvedCount: 3,
+  haveViewport: true,
+  isFocusView: false,
+  suppressFit: false,
+};
+
+describe("shouldFitReplayStep", () => {
+  it("pans when the step is fully off-screen (the #5457 bug case)", () => {
+    expect(shouldFitReplayStep(base)).toBe(true);
+  });
+
+  it("does NOT pan when at least one node is already in view", () => {
+    expect(shouldFitReplayStep({ ...base, inViewCount: 1 })).toBe(false);
+  });
+
+  it("does NOT pan when the step resolved to no glowable node", () => {
+    expect(shouldFitReplayStep({ ...base, resolvedCount: 0 })).toBe(false);
+  });
+
+  it("does NOT pan without a real viewport", () => {
+    expect(shouldFitReplayStep({ ...base, haveViewport: false })).toBe(false);
+  });
+
+  it("does NOT pan in a focus/ego view (the ego fit owns the camera)", () => {
+    expect(shouldFitReplayStep({ ...base, isFocusView: true })).toBe(false);
+  });
+
+  it("does NOT pan while a camera restore is suppressing the fit", () => {
+    expect(shouldFitReplayStep({ ...base, suppressFit: true })).toBe(false);
+  });
+
+  it("every replayed off-screen step is eligible (so each event glows in turn)", () => {
+    // Three consecutive off-screen steps all want a pan → each visibly glows.
+    const steps = [
+      { ...base, resolvedCount: 2 },
+      { ...base, resolvedCount: 5 },
+      { ...base, resolvedCount: 1 },
+    ];
+    expect(steps.every(shouldFitReplayStep)).toBe(true);
+  });
+});

--- a/webui-v2/src/lib/replay-glow-visibility.ts
+++ b/webui-v2/src/lib/replay-glow-visibility.ts
@@ -1,0 +1,49 @@
+/* ============================================================
+   lib/replay-glow-visibility.ts — pure visibility predicate for the
+   MCP-activity replay glow (#5457).
+
+   BUG (#5457): replaying MCP activity (replay-all OR clicking a single event)
+   lands every step on the SAME static settled camera. Each step's nodes are
+   almost always OFF-SCREEN, so the canvas glow falls back to an off-screen
+   sample that pulses INVISIBLY — the user only ever sees the one step whose
+   nodes happen to sit in the viewport.
+
+   The canvas fixes this by panning the camera to a step's nodes when the step
+   is fully off-screen. The decision "should we pan to this step?" is the pure
+   predicate below, extracted so it can be unit-tested without a WebGL canvas.
+   ============================================================ */
+
+export interface ReplayStepVisibility {
+  /** How many of the step's matched nodes are currently inside the viewport. */
+  inViewCount: number;
+  /** How many matched nodes the step resolved to a glowable index (capped). */
+  resolvedCount: number;
+  /** Viewport is known + non-empty (clientWidth/Height > 0, positions present). */
+  haveViewport: boolean;
+  /** A focus/ego view is active — its own fit/restore owns the camera. */
+  isFocusView: boolean;
+  /** A camera restore is in progress (suppress auto-fit). */
+  suppressFit: boolean;
+}
+
+/**
+ * True when the canvas should PAN/FIT the camera to a replay step's nodes so the
+ * glow is visible. We only pan when:
+ *   • the step resolved to at least one glowable node, AND
+ *   • NONE of them are currently in view (a fully off-screen step — the exact
+ *     case where the glow would otherwise be invisible), AND
+ *   • we have a real viewport to fit into, AND
+ *   • we're not in a focus/ego view or mid camera-restore (those own the view).
+ *
+ * When at least one node is already in view we deliberately leave the camera
+ * alone so we don't yank a view the user is already reading.
+ */
+export function shouldFitReplayStep(v: ReplayStepVisibility): boolean {
+  return (
+    v.resolvedCount > 0 &&
+    v.inViewCount === 0 &&
+    v.haveViewport &&
+    !v.isFocusView &&
+    !v.suppressFit
+  );
+}


### PR DESCRIPTION
Fixes two related bugs in the dashboard graph view's WebGL canvas (cosmos.gl).

## #5457 — MCP-activity replay only glowed the last event
Both "Replay all" and clicking an individual event entry route through the same canvas glow, which **caps** the pulse to nodes currently in the viewport and falls back to an off-screen sample when none are in view. During replay the camera is **static**, so each step's nodes are almost always off-screen → the pulse fires **invisibly** in a far cluster, and the user only ever sees the one step whose nodes happen to be on screen.

**Fix:** when a replayed step's nodes are fully off-screen, **pan/fit the camera to that step's nodes** (eased, matching the comet/sweep overlay's per-step motion) so every replayed event glows in view — replay-all *and* individual clicks. Gated so it never fires in a focus/ego view, during a camera restore, or when a node is already in view (so a view the user is reading isn't yanked). The visibility decision is extracted to a pure, unit-tested helper (`replay-glow-visibility.ts`).

## #5458 — force-layout drifts to a corner then snaps to center
The camera was **static** while the force sim spread the nodes (so the graph appeared to shrink + drift to a corner), then a single final `fitView` snapped it to center.

**Fix:** **continuously track the camera to the spreading layout** during the settle — a throttled, eased fit (~every 350ms while the simulation is running) keeps the graph centered + framed the whole time. The **final fit is eased/animated** (`fitView(duration)`) so even an intentional re-fit glides rather than jumps. Auto-fit runs only during the initial settle / explode / stream cool-down; it does **not** fight a manual pan/zoom or fit during focus/ego views.

## cosmos.gl 2.6.4 camera API used
- `fitView(duration?, padding?)` and `fitViewByPointIndices(indices, duration?, padding?)` — the `duration` (ms) drives the eased d3-zoom camera transition (instant when 0).
- `get isSimulationRunning(): boolean` — gates the during-settle tracker (stops the moment the sim stops).
- `getPointPositions()` + `spaceToScreenPosition()` — project candidates to detect off-screen steps. A paused engine ignores any fit, so the settled-camera replay fit briefly unpauses, eases the fit, then re-pins + re-pauses (token-guarded against a fast replay-all superseding a stale re-pin).

## Verification
- `tsc --noEmit` clean; `npm run build` clean.
- `webui-v2` unit suite green (214 tests) incl. a new `replay-glow-visibility.test.ts` for the visibility predicate.
- `make dashboard-build NPM=npm` + `go run ./cmd/verify-dashboard -root .` OK; `dist/PLACEHOLDER.md` restored so the diff is source-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)