### PR TITLE
fix(dashboard): keep graph framed through Reset/re-explode settle (camera drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,25 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (`docs/c3-feature-impact-analysis.md`)
 
 ### Fixed
+- **Graph view: Reset / re-explode no longer drifts the camera off-screen
+  (#5462):** pressing **Reset** (or any path that triggers a fresh re-settle —
+  group-by, layout change, deep-link re-explode) made the graph spread but the
+  camera drifted off toward a corner instead of staying centered + framed,
+  sometimes leaving the viewport entirely; the initial page load framed fine. The
+  during-settle camera tracker self-terminated on "user interaction" via a
+  **sticky** latch that flips true on the first canvas click/pan/zoom and never
+  resets — so because the user has almost always clicked/selected a node before
+  pressing Reset, the tracker bailed the instant the explode began and the spread
+  ran with a frozen camera. A programmatic re-settle now ARMS an **auto-follow
+  window** that keeps the camera tracking the live node bounding box through the
+  *entire* explode regardless of that latch; only a **genuine** subsequent user
+  pan/zoom/drag during the settle stops auto-following. Real vs. programmatic
+  camera moves are told apart via cosmos.gl's `userDriven` flag (the tracker's own
+  `fitView` glides report `userDriven === false`, so they don't self-cancel the
+  window they serve), and the fit cadence was tightened (~120ms) so a fast
+  `start(1)` explode never outruns the camera. Initial-load framing and the
+  streaming live-explode are unchanged. The interaction-vs-programmatic decision is
+  extracted to a pure, unit-tested helper.
 - **Streaming graph now visibly spreads/explodes live instead of staying a
   clustered blob until done (#5446, #5460):** when the Graph screen loaded a
   large group progressively (chunked stream), the layout stayed a tight,

--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -50,6 +50,7 @@ import {
 import { saveLayout, loadLayout, isDegenerateLayout, isLayoutHealthy } from "@/lib/graph-layout-cache";
 import { isRenderableGraph } from "@/lib/graph-render-guard";
 import { shouldFitReplayStep } from "@/lib/replay-glow-visibility";
+import { shouldTrackSettleFit, isGenuineUserCameraMove } from "@/lib/settle-fit-follow";
 import {
   autoBasePx,
   type ColorMode,
@@ -878,6 +879,20 @@ function GraphCanvasInner(
   // verify-then-retry controller checks it so it only ever auto-corrects the
   // INITIAL collapsed render — once the user takes control we never re-fire.
   const userInteractedRef = useRef(false);
+  // #5462 — "auto-follow window" flag. A PROGRAMMATIC re-settle (Reset / any
+  // kickFreshSettle: group-by, layout change, deep-link re-explode) ARMS this so
+  // the during-settle camera tracker follows the explode the whole way EVEN THOUGH
+  // userInteractedRef has long since latched true (the user almost always clicked /
+  // panned / selected a node before pressing Reset). Without this, the sticky
+  // userInteractedRef latch made startSettleFitTracking bail on its first line, so
+  // the graph spread with a frozen camera and drifted off to a corner. Only a
+  // GENUINE subsequent user camera move during the settle clears it (see
+  // cancelProgrammaticFollow), so we still never fight a real pan/zoom/drag. The
+  // triggering button click is a DOM click on the toolbar, not a canvas event, so
+  // it never reaches here; and the tracker's OWN fitView transitions are
+  // programmatic (d3 sourceEvent === null → userDriven === false), so they don't
+  // self-cancel.
+  const programmaticFollowRef = useRef(false);
   // #5458 — live mirror of the isFocusView prop so the mount-stable settle-fit
   // tracker can gate on it without re-running on every focus toggle.
   const isFocusViewRef = useRef(isFocusView);
@@ -899,12 +914,34 @@ function GraphCanvasInner(
     applyZoomLinkWidthsRef.current();
     rafRef.current = requestAnimationFrame(motionLoop);
   }, []);
-  const startInteraction = useCallback(() => {
-    interactingRef.current = true;
-    // #4654: latch — the user is now driving the camera; stop any auto-correct.
-    userInteractedRef.current = true;
-    if (rafRef.current === null) rafRef.current = requestAnimationFrame(motionLoop);
-  }, [motionLoop]);
+  // #5462 — a GENUINE user camera move (real pointer drag, real wheel/pinch zoom,
+  // or a canvas click) cancels the programmatic auto-follow window so we stop
+  // re-framing and hand the camera back to the user mid-settle. Programmatic fits
+  // (the tracker's own fitView, which emit zoom events with userDriven === false)
+  // must NOT call this.
+  const cancelProgrammaticFollow = useCallback(() => {
+    programmaticFollowRef.current = false;
+    stopSettleFitTrackingRef.current();
+  }, []);
+  const cancelProgrammaticFollowRef = useRef(cancelProgrammaticFollow);
+  cancelProgrammaticFollowRef.current = cancelProgrammaticFollow;
+  // #5462 — `userDriven` distinguishes a real user pan/zoom/drag (d3 sourceEvent
+  // present) from a programmatic camera transition (our own fitView, sourceEvent
+  // null). Only a user-driven move latches userInteractedRef and cancels the
+  // auto-follow window; a programmatic fit just keeps the rAF label loop alive.
+  const startInteraction = useCallback(
+    (userDriven = true) => {
+      interactingRef.current = true;
+      if (userDriven) {
+        // #4654: latch — the user is now driving the camera; stop any auto-correct.
+        userInteractedRef.current = true;
+        // #5462: a genuine move during a Reset/re-explode settle ends auto-follow.
+        cancelProgrammaticFollowRef.current();
+      }
+      if (rafRef.current === null) rafRef.current = requestAnimationFrame(motionLoop);
+    },
+    [motionLoop],
+  );
   const endInteraction = useCallback(() => {
     interactingRef.current = false;
     if (rafRef.current !== null) {
@@ -1050,7 +1087,12 @@ function GraphCanvasInner(
   // user interaction, or on focus/ego (where restoreCamera / the ego fit own the
   // view). Only ONE tracker runs at a time (settleFitRafRef).
   const settleFitRafRef = useRef<number | null>(null);
-  const FIT_TRACK_MS = 350; // throttle between tracking fits
+  // #5462 — tighter cadence than the original 350ms. A fresh start(1) explode
+  // spreads FAST in its first ~half-second; at 350ms the camera lagged far enough
+  // behind that the layout had already shot toward a corner between fits. ~120ms
+  // keeps the camera glued to the live bbox through the energetic spread, then the
+  // eased FINAL_FIT_MS glide in doSettle lands the final framing.
+  const FIT_TRACK_MS = 120; // throttle between tracking fits
   const stopSettleFitTracking = useCallback(() => {
     if (settleFitRafRef.current !== null) {
       cancelAnimationFrame(settleFitRafRef.current);
@@ -1062,22 +1104,41 @@ function GraphCanvasInner(
   const startSettleFitTracking = useCallback(() => {
     const g = graphRef.current;
     if (!g) return;
-    // Don't track during focus/ego (the ego re-fit / camera restore owns the view)
-    // or when a fit is being suppressed for a camera restore.
-    if (isFocusViewRef.current || suppressFitRef.current) return;
-    if (userInteractedRef.current) return; // never fight a manual pan/zoom
+    // #5462 — gate on the pure decision: the sticky userInteractedRef latch must
+    // NOT block a PROGRAMMATIC re-settle (Reset / kickFreshSettle armed
+    // programmaticFollowRef). During the auto-follow window we ignore the latch
+    // entirely; outside it we keep the old "never fight a manual pan/zoom" guard.
+    // Focus/ego and a camera-restore suppression always win. A genuine user move
+    // during the window clears programmaticFollowRef (cancelProgrammaticFollow) and
+    // stops the tracker.
+    if (
+      !shouldTrackSettleFit({
+        programmaticFollow: programmaticFollowRef.current,
+        userInteracted: userInteractedRef.current,
+        isFocusView: isFocusViewRef.current,
+        suppressFit: suppressFitRef.current,
+      })
+    ) {
+      return;
+    }
     stopSettleFitTrackingRef.current();
     let last = 0;
     const tick = (now: number) => {
       const gg = graphRef.current;
-      // Stop the moment any owner takes over or the settle finishes.
+      // Stop the moment any owner takes over or the settle finishes. The
+      // userInteractedRef check is skipped while the auto-follow window is armed
+      // (a real move clears the window via cancelProgrammaticFollow, so this still
+      // bails the instant the user genuinely takes over). (#5462)
       if (
         !gg ||
         hasSettledRef.current ||
-        userInteractedRef.current ||
-        isFocusViewRef.current ||
-        suppressFitRef.current ||
-        !gg.isSimulationRunning
+        !gg.isSimulationRunning ||
+        !shouldTrackSettleFit({
+          programmaticFollow: programmaticFollowRef.current,
+          userInteracted: userInteractedRef.current,
+          isFocusView: isFocusViewRef.current,
+          suppressFit: suppressFitRef.current,
+        })
       ) {
         settleFitRafRef.current = null;
         return;
@@ -1134,7 +1195,10 @@ function GraphCanvasInner(
     }
 
     // #5458 — stop the during-settle camera tracker; doSettle now owns the
-    // final framing.
+    // final framing. #5462 — close the auto-follow window: the settle is complete,
+    // so from here the sticky userInteractedRef latch governs again and we never
+    // re-fit behind a manual pan.
+    programmaticFollowRef.current = false;
     stopSettleFitTrackingRef.current();
 
     if (suppressFitRef.current) {
@@ -1311,6 +1375,13 @@ function GraphCanvasInner(
     g.render();
     g.create();
     g.start(1);
+    // #5462 — ARM the auto-follow window: this is a PROGRAMMATIC re-settle (the
+    // user pressed Reset / changed group-by / a deep-link re-explode), so the
+    // camera must follow the explode even though userInteractedRef latched true on
+    // an earlier click/pan. Set BEFORE startSettleFitTracking so the tracker's
+    // userInteractedRef guard is bypassed. Cleared at doSettle, or earlier by a
+    // genuine user pan/zoom/drag during the settle (cancelProgrammaticFollow).
+    programmaticFollowRef.current = true;
     // #5458 — track the camera to the spreading layout for the whole settle so the
     // graph stays centered + framed instead of drifting to a corner then snapping.
     startSettleFitTrackingRef.current();
@@ -1439,6 +1510,7 @@ function GraphCanvasInner(
       onSimulationTick: scheduleLabelsLive,
       onClick: (index?: number) => {
         userInteractedRef.current = true; // #4654: user took control → no auto-correct
+        cancelProgrammaticFollowRef.current(); // #5462: a real click ends auto-follow
         if (index === undefined) {
           onNodeClickRef.current(null);
           return;
@@ -1465,8 +1537,16 @@ function GraphCanvasInner(
       // so onZoomStart/onZoomEnd bracket every camera move. Start the per-frame
       // rAF label loop on start, stop it on end. onZoom still nudges a refresh
       // for the (rare) single-shot zoom that doesn't emit start/end.
-      onZoomStart: () => startInteractionRef.current(),
-      onZoom: () => {
+      // #5462 — cosmos passes `userDriven` (d3 sourceEvent !== null) as the 2nd
+      // arg: TRUE for a real wheel/pinch/pan, FALSE for a PROGRAMMATIC transition
+      // (our during-settle tracker's own fitView). We MUST forward it: the tracker
+      // fires onZoomStart/onZoom on every glide, and if those were treated as user
+      // input they'd latch userInteractedRef + cancel the auto-follow window the
+      // very first track — re-breaking the drift. Only a user-driven zoom latches /
+      // cancels; a programmatic fit just keeps the rAF label loop alive.
+      onZoomStart: (_e, userDriven) =>
+        startInteractionRef.current(isGenuineUserCameraMove(userDriven)),
+      onZoom: (_e, userDriven) => {
         // Fix #1607: drive the sublinear, capped point size off every zoom event
         // (covers the single-shot wheel zoom that doesn't bracket start/end). The
         // rAF motion loop handles continuous zoom/pan; this catches the rest.
@@ -1474,10 +1554,18 @@ function GraphCanvasInner(
         // Fix #2110: also re-pack link widths with updated zoom compensation on
         // single-shot wheel zoom events not bracketed by start/end.
         applyZoomLinkWidthsRef.current();
+        // #5462: a user-driven single-shot wheel zoom (not bracketed by start/end)
+        // must still latch + end the auto-follow window; a programmatic fit must not.
+        if (isGenuineUserCameraMove(userDriven)) {
+          userInteractedRef.current = true;
+          cancelProgrammaticFollowRef.current();
+        }
         if (!interactingRef.current) scheduleLabelsLive();
       },
       onZoomEnd: () => endInteractionRef.current(),
-      onDragStart: () => startInteractionRef.current(),
+      // Dragging the canvas is ALWAYS a genuine user move (only a real pointer can
+      // drag), so it latches + cancels the auto-follow window unconditionally.
+      onDragStart: () => startInteractionRef.current(true),
       onDragEnd: () => endInteractionRef.current(),
     });
     graphRef.current = g;
@@ -1775,6 +1863,9 @@ function GraphCanvasInner(
     // step is just polish, so use the gentle cool-down alpha (not the full live one).
     g.start(STREAM_FINAL_COOLDOWN_ALPHA);
     // #5458 — keep the camera framed during the final stream cool-down too.
+    // #5462 — programmatic re-settle: arm the auto-follow window so the final fit
+    // tracks even if the user clicked/panned a node while the stream was running.
+    programmaticFollowRef.current = true;
     startSettleFitTrackingRef.current();
     capTimerRef.current = setTimeout(() => {
       if (!hasSettledRef.current) doSettleRef.current();

--- a/webui-v2/src/lib/settle-fit-follow.test.ts
+++ b/webui-v2/src/lib/settle-fit-follow.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { shouldTrackSettleFit, isGenuineUserCameraMove } from "./settle-fit-follow";
+
+describe("shouldTrackSettleFit (#5462)", () => {
+  const base = {
+    programmaticFollow: false,
+    userInteracted: false,
+    isFocusView: false,
+    suppressFit: false,
+  };
+
+  it("tracks on a clean initial load (no interaction, no window)", () => {
+    expect(shouldTrackSettleFit(base)).toBe(true);
+  });
+
+  it("does NOT track once the user has latched, outside an auto-follow window", () => {
+    // Steady-state: a manual pan latched userInteracted; nothing should re-fit.
+    expect(shouldTrackSettleFit({ ...base, userInteracted: true })).toBe(false);
+  });
+
+  it("THE BUG: a programmatic re-settle tracks even though userInteracted latched", () => {
+    // Reset pressed after the user had already clicked/panned a node. Before the
+    // fix the sticky latch killed the tracker → drift. The armed window overrides.
+    expect(
+      shouldTrackSettleFit({ ...base, programmaticFollow: true, userInteracted: true }),
+    ).toBe(true);
+  });
+
+  it("tracks during a programmatic window even with no prior interaction", () => {
+    expect(shouldTrackSettleFit({ ...base, programmaticFollow: true })).toBe(true);
+  });
+
+  it("never tracks in focus/ego view (ego fit / camera restore owns the view)", () => {
+    expect(
+      shouldTrackSettleFit({ ...base, programmaticFollow: true, isFocusView: true }),
+    ).toBe(false);
+    expect(shouldTrackSettleFit({ ...base, isFocusView: true })).toBe(false);
+  });
+
+  it("never tracks while a camera-restore fit is suppressed", () => {
+    expect(
+      shouldTrackSettleFit({ ...base, programmaticFollow: true, suppressFit: true }),
+    ).toBe(false);
+  });
+});
+
+describe("isGenuineUserCameraMove (#5462)", () => {
+  it("treats a user-driven (real pointer/wheel) move as genuine", () => {
+    // d3 sourceEvent present → cancels the auto-follow window.
+    expect(isGenuineUserCameraMove(true)).toBe(true);
+  });
+
+  it("treats a programmatic fitView transition as NOT a user move", () => {
+    // The tracker's own glide (sourceEvent === null) must not cancel the window
+    // it is serving — otherwise it self-cancels on the first frame.
+    expect(isGenuineUserCameraMove(false)).toBe(false);
+  });
+});

--- a/webui-v2/src/lib/settle-fit-follow.ts
+++ b/webui-v2/src/lib/settle-fit-follow.ts
@@ -1,0 +1,59 @@
+/* ============================================================
+   lib/settle-fit-follow.ts — pure decisions for the during-settle camera
+   auto-follow window (#5462).
+
+   The graph canvas keeps the camera framed while a force layout explodes/settles
+   via a throttled fitView tracker. Two sticky/transient flags govern it:
+
+     • userInteracted — STICKY: latches true on the first GENUINE user camera move
+       (pan / wheel-zoom / drag) or canvas click, and never resets. Used so the
+       steady-state never re-fits behind a manual pan.
+     • programmaticFollow — the "auto-follow window": armed when a PROGRAMMATIC
+       re-settle starts (Reset, group-by/layout change, deep-link re-explode,
+       stream-finalize). While armed the tracker follows the explode even though
+       userInteracted has long since latched.
+
+   The bug these pure helpers guard against: a programmatic re-settle is almost
+   always initiated AFTER the user has already clicked/panned something, so the
+   sticky userInteracted latch was suppressing the tracker the instant Reset began
+   → the graph spread with a frozen camera and drifted off-screen. The fix lets the
+   auto-follow window override the latch, and uses cosmos.gl's `userDriven` flag
+   (d3 sourceEvent !== null) to tell a REAL user move from the tracker's OWN
+   programmatic fitView (which also emits zoom events).
+   ============================================================ */
+
+/**
+ * Should the during-settle camera tracker run / keep running this frame?
+ *
+ * The sticky `userInteracted` latch is IGNORED while the programmatic auto-follow
+ * window is armed — that's the whole point: a Reset issued after an earlier click
+ * must still follow the explode. Outside the window the latch governs as before
+ * (never fight a manual pan). Owners that always win (focus/ego view, a camera
+ * restore in progress) hard-stop tracking regardless.
+ */
+export function shouldTrackSettleFit(opts: {
+  programmaticFollow: boolean;
+  userInteracted: boolean;
+  isFocusView: boolean;
+  suppressFit: boolean;
+}): boolean {
+  if (opts.isFocusView || opts.suppressFit) return false;
+  if (opts.programmaticFollow) return true; // window armed → override the latch
+  return !opts.userInteracted; // outside the window: never fight a manual pan
+}
+
+/**
+ * Does this camera event represent a GENUINE user move that should latch
+ * `userInteracted` and cancel the auto-follow window?
+ *
+ * cosmos.gl reports `userDriven` (true ⇔ d3 sourceEvent is present) on zoom
+ * events: a real wheel/pinch/pan is user-driven; the tracker's OWN fitView glide
+ * is NOT (sourceEvent === null). If we treated the tracker's programmatic fits as
+ * user input they'd cancel the very window they're serving on the first frame —
+ * re-introducing the drift. Pointer drags and canvas clicks are inherently
+ * user-driven (only a real pointer produces them), so callers pass `userDriven:
+ * true` for those.
+ */
+export function isGenuineUserCameraMove(userDriven: boolean): boolean {
+  return userDriven === true;
+}


### PR DESCRIPTION
Closes #5462.

## Problem
In the dashboard graph view, pressing **Reset** (or any path that triggers a fresh re-settle — group-by, layout change, deep-link re-explode) made the graph explode and spread, but the camera **drifted off toward a corner** instead of staying centered + framed, sometimes leaving the viewport entirely. Initial page load framed correctly, which masked the bug.

## Root cause
The during-settle camera tracker (`startSettleFitTracking`) self-terminates on "user interaction". It gated on a **sticky** `userInteracted` latch that flips true on the first canvas click/pan/zoom/drag and **never resets**. Because the user has almost always clicked/selected/panned a node before pressing Reset, that latch is already true — so when the programmatic re-settle started the tracker, it bailed on its very first line. The graph then spread with a **frozen camera** and drifted; a single final fit couldn't recover a layout that had already left the frame.

The latch is correct for *steady state* (don't fight a manual pan after settle), but it must not suppress auto-follow during a **programmatic** re-settle the user themselves initiated via a button.

## Fix
- A programmatic re-settle (`kickFreshSettle`: Reset, group-by, layout change, deep-link re-explode, and stream-finalize) **ARMS an auto-follow window** (`programmaticFollowRef`). While armed, the tracker follows the live node bounding box through the **entire** explode → settle, overriding the sticky latch. The window is closed at `doSettle`.
- Only a **genuine** subsequent user pan/zoom/drag during the settle clears the window and stops auto-following — so we still never fight a real manual move.
- **Telling a real move from a programmatic one:** cosmos.gl reports `userDriven` (true ⇔ d3 `sourceEvent !== null`) on zoom events. The tracker's own `fitView` glides report `userDriven === false`, so they don't self-cancel the window they serve; a real wheel/pinch/pan reports `true`. Pointer drags and canvas clicks are inherently user-driven. The triggering Reset is a toolbar **DOM** click, not a canvas event, so it never reaches these handlers at all.
- Fit cadence tightened (350 → ~120ms) so a fast `start(1)` explode can't outrun the camera; the final eased `FINAL_FIT_MS` glide in `doSettle` still lands the framing.
- Initial-load framing and the streaming live-explode (which also rely on the tracker) are unchanged.

## Tests
- The track-vs-skip and genuine-move decisions are extracted to a pure helper `lib/settle-fit-follow.ts` with 8 unit tests (incl. the regression: "a programmatic re-settle tracks even though userInteracted latched"). The canvas calls the same helpers.
- `tsc --noEmit` clean; `npm run build` clean; webui-v2 unit suite green (222 passed).
- `make dashboard-build NPM=npm` + `go run ./cmd/verify-dashboard -root .` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)