### PR TITLE
fix(dashboard): upload streamed nodes to canvas per chunk + clear glow on cancel/reset (#5446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,32 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (`docs/c3-feature-impact-analysis.md`)
 
 ### Fixed
+- **Graph view: streamed nodes now reach the canvas every chunk — no more
+  blank-until-done (#5446):** the progressive Graph screen showed a climbing
+  "building graph… N / total" counter while the WebGL canvas stayed blank, then
+  the whole graph popped in at once on `done`. The canvas had a streaming-grow
+  path (seed new nodes near a placed neighbour + re-heat the sim each chunk), but
+  its trigger was gated on an internal post-settle "placed count" ref that is
+  only populated **after** the first settle runs — and the first settle is
+  deferred a frame (a cache-hit mount settles without ever setting it). When
+  chunks arrived faster than that ref was set, every grown chunk fell through to
+  the non-streaming branch, which — because the auto-start flag is already
+  latched during a stream — uploaded the raw seed but never re-heated the
+  simulation, so later nodes sat in the GPU buffers, unlaid-out and invisible,
+  until the stream ended. The trigger now keys on the buffer **actually uploaded
+  to the canvas** (`shouldStreamGrow`, unit-tested) rather than the placed-count
+  ref, so every grown chunk takes the live-grow + re-heat path and the graph
+  visibly grows from the first chunk; the already-merged sim energy (#5461) and
+  camera tracker (#5459/#5463) then make the live explode actually visible.
+- **Graph view: MCP-activity glow no longer leaves stale amber/blue edges + nodes
+  (#5446):** the replay/activity glow restored the base point + link colours only
+  at the animation's natural decay-end. When a pulse was **superseded** (rapid
+  replay-all / the next epoch) or the user pressed **Reset**, the effect cleanup
+  only cancelled the animation frame — the half-tinted colour/size buffers it last
+  uploaded were left on the GPU, so glowed edges and nodes accumulated and
+  persisted. The base point/link colours + sizes are now restored on glow
+  cancel/supersede **and** on Reset, so no stale glow survives (the
+  consecutive-replay dim-focus behaviour is preserved).
 - **Graph view: Reset / re-explode no longer drifts the camera off-screen
   (#5462):** pressing **Reset** (or any path that triggers a fresh re-settle —
   group-by, layout change, deep-link re-explode) made the graph spread but the

--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -48,7 +48,7 @@ import {
   JARVIS_GLOW,
 } from "@/lib/graph-colors";
 import { saveLayout, loadLayout, isDegenerateLayout, isLayoutHealthy } from "@/lib/graph-layout-cache";
-import { isRenderableGraph } from "@/lib/graph-render-guard";
+import { isRenderableGraph, shouldStreamGrow } from "@/lib/graph-render-guard";
 import { shouldFitReplayStep } from "@/lib/replay-glow-visibility";
 import { shouldTrackSettleFit, isGenuineUserCameraMove } from "@/lib/settle-fit-follow";
 import {
@@ -1369,6 +1369,15 @@ function GraphCanvasInner(
       clearTimeout(reheatTimerRef.current);
       reheatTimerRef.current = null;
     }
+    // #5446 — Reset/re-layout must also clear any in-flight MCP-activity glow:
+    // cancel its rAF and restore the base point/link colors + sizes so glowed
+    // (amber/blue) edges and nodes don't persist through the re-explode. Without
+    // this the glow loop kept writing tinted buffers over the fresh layout.
+    if (glowRafRef.current !== null) {
+      cancelAnimationFrame(glowRafRef.current);
+      glowRafRef.current = null;
+    }
+    restoreGlowBuffersRef.current();
     g.setPointPositions(p.positions);
     g.setPointClusters(p.clusters);
     g.setPointClusterStrength(p.clusterStrength);
@@ -1718,9 +1727,21 @@ function GraphCanvasInner(
     // the buffers, and GENTLY re-heats the running sim so the new nodes are laid
     // out and rendered LIVE (the graph grows + jiggles from the first chunk). The
     // final settle/fit is the `done` relayout the route triggers.
-    const grew = packed.positions.length > prev.length && prev.length > 0;
-    if (streaming && grew && placedCountRef.current > 0) {
-      const seeded = seedStreamingPositions(prev, placedCountRef.current);
+    // #5446 — the streaming-grow trigger keys on the buffer ACTUALLY uploaded to
+    // cosmos (`prev`), NOT on placedCountRef. placedCountRef is only set once a
+    // settle has run (kickFreshSettle / streaming reheat), but the first settle is
+    // DEFERRED a frame (mount schedules kickFreshSettle via rAF) and a cache-hit
+    // mount settles WITHOUT ever setting it. When fast chunks arrive before that
+    // ref is populated, the old `placedCountRef.current > 0` guard sent every
+    // grown chunk down the non-streaming path, which (because didAutoStartRef is
+    // already latched during a stream) pushed the raw seed but never re-heated the
+    // sim — so the nodes were uploaded yet never laid out, and the canvas stayed
+    // blank until `done`. Deriving `placed` from prev.length makes EVERY grown
+    // chunk take the live-grow + reheat path. seedStreamingPositions already
+    // handles placed === 0 (it seeds the whole buffer near the group centers).
+    const placed = prev.length / 2;
+    if (shouldStreamGrow(streaming, prev.length, packed.positions.length)) {
+      const seeded = seedStreamingPositions(prev, placed);
       g.setPointPositions(seeded);
       g.setPointSizes(packed.sizes);
       g.setPointClusters(packed.clusters);
@@ -2184,6 +2205,25 @@ function GraphCanvasInner(
   // endpoints are in the highlighted node set (resolved against linkData.links,
   // which is index-based and parallel to the packed link color buffer).
   const glowRafRef = useRef<number | null>(null);
+  // #5446 — restore the BASE point + link colors/sizes, clearing any in-flight
+  // glow tint. The decay-end branch of the glow rAF restores its own snapshot, but
+  // when a pulse is SUPERSEDED (a new epoch / rapid replay-all) or the user hits
+  // Reset, the loop is only `cancelAnimationFrame`d — the half-amber buffers it
+  // last uploaded are left on the GPU, so glowed blue/amber edges + nodes
+  // accumulate and persist. Re-packing from the CURRENT base buffers (theme +
+  // colorMode aware) and uploading them guarantees no stale glow survives a
+  // cancel/supersede/Reset. Re-derived fresh (not from a closure snapshot) so it
+  // is correct even if the data/theme changed since the pulse started.
+  const restoreGlowBuffers = useCallback(() => {
+    const g = graphRef.current;
+    if (!g || !renderableRef.current) return;
+    g.setPointColors(packPointColors());
+    g.setPointSizes(packed.sizes);
+    g.setLinkColors(packLinkColors());
+    g.render();
+  }, [packPointColors, packed, packLinkColors]);
+  const restoreGlowBuffersRef = useRef(restoreGlowBuffers);
+  restoreGlowBuffersRef.current = restoreGlowBuffers;
   // #4643 — the CAPPED, in-view node-index set that the current glow is driving.
   // Shared with the dim-focus selection (applySelection) so both the glow and
   // the "dim everything else" behaviour operate on the SAME bounded set. Empty
@@ -2405,6 +2445,13 @@ function GraphCanvasInner(
       if (glowRafRef.current !== null) {
         cancelAnimationFrame(glowRafRef.current);
         glowRafRef.current = null;
+        // #5446 — the pulse was SUPERSEDED mid-flight (this cleanup runs because a
+        // new epoch is replacing it). cancelAnimationFrame alone leaves the last
+        // half-amber color/size buffers on the GPU, so glowed edges/nodes from the
+        // interrupted step persist (and accumulate across rapid replay-all). Restore
+        // the base buffers so no stale tint survives; the next epoch's frame loop
+        // re-tints from its own (now-clean) base immediately.
+        restoreGlowBuffersRef.current();
       }
       // #4643 — a new epoch supersedes this glow; the next effect run reasserts
       // the focus set from its own (capped) nodes, and a final empty highlight

--- a/webui-v2/src/lib/graph-render-guard.test.ts
+++ b/webui-v2/src/lib/graph-render-guard.test.ts
@@ -4,6 +4,7 @@ import {
   isRenderableGraph,
   clampTextureDim,
   textureSideFor,
+  shouldStreamGrow,
 } from "./graph-render-guard";
 
 describe("isRenderableGraph (#4605)", () => {
@@ -69,5 +70,37 @@ describe("textureSideFor (#4605)", () => {
     expect(textureSideFor(4)).toBe(2);
     expect(textureSideFor(5)).toBe(3); // ceil(sqrt(5)) = 3
     expect(textureSideFor(1316)).toBe(Math.ceil(Math.sqrt(1316)));
+  });
+});
+
+describe("shouldStreamGrow (#5446)", () => {
+  // Buffer lengths are point-count * 2 (x,y per point); the predicate works on
+  // raw lengths so the units don't matter — only "did it grow" does.
+  it("grows when streaming and the new buffer is larger than what cosmos holds", () => {
+    // chunk 2 lands: cosmos holds chunk-1 (200 floats), packed is now 500.
+    expect(shouldStreamGrow(true, 200, 500)).toBe(true);
+  });
+
+  it("does NOT grow on the FIRST chunk (cosmos buffer still empty)", () => {
+    // prevLen === 0 → the fresh-settle seed path owns the first chunk.
+    expect(shouldStreamGrow(true, 0, 500)).toBe(false);
+  });
+
+  it("does NOT grow when not streaming (full-payload / settled path)", () => {
+    expect(shouldStreamGrow(false, 200, 500)).toBe(false);
+  });
+
+  it("does NOT grow when the node set did not actually grow", () => {
+    expect(shouldStreamGrow(true, 500, 500)).toBe(false); // same size (re-push)
+    expect(shouldStreamGrow(true, 500, 300)).toBe(false); // shrank (filter)
+  });
+
+  it("fires regardless of any post-settle placed count (the #5446 fix)", () => {
+    // The OLD gate also required placedCountRef.current > 0, which a fast early
+    // chunk (before the deferred settle) or a cache-hit mount left at 0, so the
+    // grown chunk silently fell through to the non-streaming path and never
+    // re-heated. This predicate keys only on the uploaded buffer length, so the
+    // second chunk grows even when no settle has populated a placed count yet.
+    expect(shouldStreamGrow(true, 200, 240)).toBe(true);
   });
 });

--- a/webui-v2/src/lib/graph-render-guard.ts
+++ b/webui-v2/src/lib/graph-render-guard.ts
@@ -55,3 +55,31 @@ export function textureSideFor(count: number): number {
   if (!Number.isFinite(count) || count <= 0) return MIN_TEXTURE_DIM;
   return clampTextureDim(Math.ceil(Math.sqrt(count)));
 }
+
+/**
+ * #5446 — should the canvas take the STREAMING-GROW upload path for this chunk?
+ *
+ * While a graph streams in, each chunk grows the node set. A grown chunk must be
+ * seeded + uploaded + re-heated LIVE so the canvas visibly grows; otherwise the
+ * new nodes sit in the GPU buffers, never laid out, and the graph stays blank
+ * until `done`.
+ *
+ * The trigger keys on the buffer COUNTS — `nextLen` is the new packed point
+ * buffer length, `prevLen` is the length of the buffer cosmos currently holds
+ * (`g.getPointPositions().length`). It deliberately does NOT depend on any
+ * post-settle "placed count": that value is only set after the first settle has
+ * run, and the first settle is deferred a frame (and a cache-hit mount settles
+ * without setting it), so gating on it dropped fast early chunks onto the
+ * non-streaming path — which never re-heated mid-stream. We grow whenever:
+ *   - we are streaming, AND
+ *   - the new buffer is strictly larger than what cosmos holds, AND
+ *   - cosmos already holds a non-empty buffer (the FIRST chunk, prevLen === 0,
+ *     goes through the normal fresh-settle seed instead).
+ */
+export function shouldStreamGrow(
+  streaming: boolean,
+  prevLen: number,
+  nextLen: number,
+): boolean {
+  return streaming && prevLen > 0 && nextLen > prevLen;
+}


### PR DESCRIPTION
Refs #5446. Fixes #5464.

## Problem
The progressive Graph screen showed a climbing "building graph… N / total" counter while the WebGL canvas stayed **blank**, then the whole graph popped in at once on `done`. Three prior PRs tuned the animation (seed energy, sim energy, camera tracking) but the graph still rendered blank mid-stream — because the streamed nodes never reached the canvas until the stream ended.

## Root cause (the mechanism)
The canvas already had a streaming-grow path: each chunk seeds the new nodes near a placed neighbour and re-heats the simulation. But the **trigger** for that path was gated on an internal post-settle "placed count" ref, which is only populated **after** the first settle runs. Two real paths leave it unset when a grown chunk arrives:

1. **Deferred first settle** — the first settle is scheduled via `requestAnimationFrame`, so a fast second chunk arriving in the same frame sees the ref still at 0.
2. **Cache-hit mount** — a mount that restores a healthy cached layout settles **without** ever setting the ref.

In both cases the grown chunk fell through to the non-streaming branch, which — because the auto-start flag is already latched during a stream — uploaded the raw seed but **never re-heated the simulation**. So the new nodes were pushed into the GPU buffers yet never laid out or rendered, and the canvas stayed blank until `done` flipped streaming off and a full re-settle ran.

## Fix
- Key the streaming-grow trigger on the buffer **actually uploaded to the canvas** (`g.getPointPositions().length`) rather than the placed-count ref, via a small pure, unit-tested predicate `shouldStreamGrow(streaming, prevLen, nextLen)`. Now **every** grown chunk takes the live-grow + re-heat path: seed the new nodes, upload the grown point/size/cluster/colour + link buffers, and re-heat the running sim. The first chunk (empty cosmos buffer) still goes through the normal fresh-settle seed; the `done` finalize step is unchanged. The already-merged sim energy + camera tracker then make the live explode actually visible.

## Glow cleanup (secondary)
The MCP-activity glow restored base colours only at the animation's natural decay-end. When a pulse was **superseded** (rapid replay-all / next epoch) or the user pressed **Reset**, the effect cleanup only `cancelAnimationFrame`d — the half-tinted colour/size buffers it last uploaded were left on the GPU, so glowed (amber/blue) edges + nodes accumulated and persisted. Restore the base point/link colours + sizes on glow cancel/supersede **and** on Reset (via a shared `restoreGlowBuffers` helper). The consecutive-replay dim-focus behaviour is preserved.

## Verification
- `tsc --noEmit` clean; `npm run build` clean.
- `npm test` (canonical `vitest run src/lib`) green — 227 tests, incl. new `shouldStreamGrow` coverage.
- `make dashboard-build` → `verify-dashboard: OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)