### PR TITLE
cutover(b2): official providers for elixir/ocaml/php/scala/swift (#5418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,27 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (0 keeps no grace-protected dead refs); a negative int disables the cap
   backstop; unparseable values fall back to the default. Mirrors the existing
   `GRAFEL_TIER_*`/`GRAFEL_EXTRACT_GOMAXPROCS` env pattern.
+- **Official tree-sitter grammar providers — batch B2
+  (#5418, B2 cutover Part B):** ABI-≤14-pinned official-runtime grammar packages
+  for **elixir, ocaml, php, scala, swift** under
+  `internal/treesitter/ts/grammars/`, mirroring the Phase-0 Go provider and wired
+  into `migratedLanguages` behind the `ts_official` build tag (each with an ABI
+  smoke-parse guard test asserting a non-nil, non-error root of the expected top
+  kind: elixir `source`, ocaml `compilation_unit`, php `program`, scala
+  `compilation_unit`, swift `source_file`). Modules/versions:
+  tree-sitter-elixir `v0.3.4` (via an `elixir-lang` → canonical-path replace),
+  tree-sitter-ocaml `v0.23.2` (`LanguageOCaml`), tree-sitter-php `v0.23.11`
+  (`LanguagePHP`), tree-sitter-scala `v0.23.4`, and alex-pinkus/tree-sitter-swift
+  at the `0.7.3-with-generated-files` tag (parser.c is checked in only on the
+  `-with-generated-files` tags) — all `LANGUAGE_VERSION ≤14`, inside the v0.24.0
+  runtime's 13–14 window. **kotlin and sql are intentionally deferred:** their go
+  bindings `#include` a generated `src/parser.c` that is unreachable from a module
+  download (kotlin's lives outside the nested `bindings/go` module boundary;
+  `DerekStride/tree-sitter-sql` `.gitignore`s `src/parser.c`, so it is never
+  committed), so both need the vendored-C track (cutover plan §3/§4), not this
+  official-binding pattern. The **default build is unchanged** (100% smacker); the
+  `ts_official` path is only populated so the eventual default-flip has these
+  providers ready and validated. Additive prep — not the big-bang flip.
 - **Official tree-sitter grammar providers — batch B
   (#5418, B2 cutover Part B):** ABI-14-pinned official-runtime grammar packages
   for **bash, c, cpp, css, html, ruby** under `internal/treesitter/ts/grammars/`,

--- a/go.mod
+++ b/go.mod
@@ -18,19 +18,24 @@ require (
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
+	github.com/alex-pinkus/tree-sitter-swift v0.0.0-20260601004120-31d17fe7e818
 	github.com/tree-sitter/go-tree-sitter v0.24.0
 	github.com/tree-sitter/tree-sitter-bash v0.23.3
 	github.com/tree-sitter/tree-sitter-c v0.23.6
 	github.com/tree-sitter/tree-sitter-c-sharp v0.23.1
 	github.com/tree-sitter/tree-sitter-cpp v0.23.4
 	github.com/tree-sitter/tree-sitter-css v0.23.2
+	github.com/tree-sitter/tree-sitter-elixir v0.3.4
 	github.com/tree-sitter/tree-sitter-go v0.23.4
 	github.com/tree-sitter/tree-sitter-html v0.23.2
 	github.com/tree-sitter/tree-sitter-java v0.23.5
 	github.com/tree-sitter/tree-sitter-javascript v0.23.1
+	github.com/tree-sitter/tree-sitter-ocaml v0.23.2
+	github.com/tree-sitter/tree-sitter-php v0.23.11
 	github.com/tree-sitter/tree-sitter-python v0.23.6
 	github.com/tree-sitter/tree-sitter-ruby v0.23.1
 	github.com/tree-sitter/tree-sitter-rust v0.23.2
+	github.com/tree-sitter/tree-sitter-scala v0.23.4
 	github.com/tree-sitter/tree-sitter-typescript v0.23.2
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
@@ -104,3 +109,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 )
+
+replace github.com/tree-sitter/tree-sitter-elixir v0.3.4 => github.com/elixir-lang/tree-sitter-elixir v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
+github.com/alex-pinkus/tree-sitter-swift v0.0.0-20260601004120-31d17fe7e818 h1:oNZZFKvqDFHCSg+Ard8elsRqDKsstebWlzXNrgrApOM=
+github.com/alex-pinkus/tree-sitter-swift v0.0.0-20260601004120-31d17fe7e818/go.mod h1:nMZLtsEtko+0F2g09G5Tm16uRdDoczLZDE5O207ruYQ=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -69,6 +71,8 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/elixir-lang/tree-sitter-elixir v0.3.4 h1:M0Wc3XXEJyGpVELOzxqhV069bBsRAQyGdehWw/G+nWk=
+github.com/elixir-lang/tree-sitter-elixir v0.3.4/go.mod h1:wNBVf64kzvhSbZ8ojVtBF1jRiqGY0lsuK5Kx/60s6Z0=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -199,12 +203,18 @@ github.com/tree-sitter/tree-sitter-java v0.23.5 h1:J9YeMGMwXYlKSP3K4Us8CitC6hjtM
 github.com/tree-sitter/tree-sitter-java v0.23.5/go.mod h1:NRKlI8+EznxA7t1Yt3xtraPk1Wzqh3GAIC46wxvc320=
 github.com/tree-sitter/tree-sitter-javascript v0.23.1 h1:1fWupaRC0ArlHJ/QJzsfQ3Ibyopw7ZfQK4xXc40Zveo=
 github.com/tree-sitter/tree-sitter-javascript v0.23.1/go.mod h1:lmGD1EJdCA+v0S1u2fFgepMg/opzSg/4pgFym2FPGAs=
+github.com/tree-sitter/tree-sitter-ocaml v0.23.2 h1:mSOJwWYT4PA0AyrnoGTsiBinSde7RpyBaA7Qri3Zx3c=
+github.com/tree-sitter/tree-sitter-ocaml v0.23.2/go.mod h1:18SxqyGRpOHl8CmxfC2oTs5mXRDveWhtCnprYBAT0oc=
+github.com/tree-sitter/tree-sitter-php v0.23.11 h1:iHewsLNDmznh8kgGyfWfujsZxIz1YGbSd2ZTEM0ZiP8=
+github.com/tree-sitter/tree-sitter-php v0.23.11/go.mod h1:T/kbfi+UcCywQfUNAJnGTN/fMSUjnwPXA8k4yoIks74=
 github.com/tree-sitter/tree-sitter-python v0.23.6 h1:qHnWFR5WhtMQpxBZRwiaU5Hk/29vGju6CVtmvu5Haas=
 github.com/tree-sitter/tree-sitter-python v0.23.6/go.mod h1:cpdthSy/Yoa28aJFBscFHlGiU+cnSiSh1kuDVtI8YeM=
 github.com/tree-sitter/tree-sitter-ruby v0.23.1 h1:T/NKHUA+iVbHM440hFx+lzVOzS4dV6z8Qw8ai+72bYo=
 github.com/tree-sitter/tree-sitter-ruby v0.23.1/go.mod h1:kUS4kCCQloFcdX6sdpr8p6r2rogbM6ZjTox5ZOQy8cA=
 github.com/tree-sitter/tree-sitter-rust v0.23.2 h1:6AtoooCW5GqNrRpfnvl0iUhxTAZEovEmLKDbyHlfw90=
 github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaOAguCFJRo3RBbs7QJ6D7MI=
+github.com/tree-sitter/tree-sitter-scala v0.23.4 h1:YZvk3rEQVEKnc82Wltq1DdCJsmlN4Q3+UvdtQu8dR+8=
+github.com/tree-sitter/tree-sitter-scala v0.23.4/go.mod h1:BmDV0f9rgsnGuG9QtKXQZnqJvECyR9fM8wVg984ulBo=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
 github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/viant/afs v1.30.0 h1:dbgVVSCPwGHUgpgkWJ5gdjKBqssT7OV7Z2M81CjwZEY=

--- a/internal/treesitter/adapters_official.go
+++ b/internal/treesitter/adapters_official.go
@@ -11,13 +11,18 @@ import (
 	tscpp "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/cpp"
 	tscsharp "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/csharp"
 	tscss "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/css"
+	tselixir "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/elixir"
 	tsgolang "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/golang"
 	tshtml "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/html"
 	tsjava "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/java"
 	tsjavascript "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/javascript"
+	tsocaml "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/ocaml"
+	tsphp "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/php"
 	tspython "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/python"
 	tsruby "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/ruby"
 	tsrust "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/rust"
+	tsscala "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/scala"
+	tsswift "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/swift"
 	tstypescript "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/typescript"
 	tsofficial "github.com/cajasmota/grafel/internal/treesitter/ts/official"
 	tssmacker "github.com/cajasmota/grafel/internal/treesitter/ts/smacker"
@@ -56,6 +61,17 @@ var migratedLanguages = map[string]ts.Language{
 	"css":  tscss.Language(),
 	"html": tshtml.Language(),
 	"ruby": tsruby.Language(),
+	// B2 cutover Part B batch 2 (#5418): official-binding providers — all ABI ≤14.
+	// kotlin and sql are deferred: their go bindings #include a generated
+	// src/parser.c that is unreachable from a module download (kotlin's lives
+	// outside the nested bindings/go module boundary; DerekStride/tree-sitter-sql
+	// .gitignores src/parser.c, so it is never committed). Both need the
+	// vendored-C track (cutover plan §3/§4), not this official-binding pattern.
+	"elixir": tselixir.Language(),
+	"ocaml":  tsocaml.Language(),
+	"php":    tsphp.Language(),
+	"scala":  tsscala.Language(),
+	"swift":  tsswift.Language(),
 }
 
 // abiProbeSource is trivial, valid source per migrated language for the ABI guard.
@@ -74,6 +90,11 @@ var abiProbeSource = map[string][]byte{
 	"css":        []byte(".a { color: red; }\n"),
 	"html":       []byte("<div><p>hi</p></div>\n"),
 	"ruby":       []byte("def f\n  1\nend\n"),
+	"elixir":     []byte("defmodule M do\n  def f, do: 1\nend\n"),
+	"ocaml":      []byte("let f x = x + 1\n"),
+	"php":        []byte("<?php function f() { return 1; }\n"),
+	"scala":      []byte("object M { def f: Int = 1 }\n"),
+	"swift":      []byte("func f() -> Int { return 1 }\n"),
 }
 
 // tsLanguageFor resolves a language to the official adapter (if migrated) or the

--- a/internal/treesitter/ts/grammars/elixir/elixir.go
+++ b/internal/treesitter/ts/grammars/elixir/elixir.go
@@ -1,0 +1,28 @@
+// Package elixir provides the Elixir grammar via the official tree-sitter
+// binding, wrapped as a ts.Language for the official adapter. Sibling of the
+// Phase-0 golang/ package (B2 cutover Part B, ADR 0023, #5418): migrating a
+// language is a package like this one plus a migratedLanguages line in
+// adapters_official.go.
+//
+// ABI pin. The grammar is pinned to tree-sitter-elixir v0.3.4 against runtime
+// v0.24.0 — its generated src/parser.c carries LANGUAGE_VERSION 14, inside the
+// runtime's 13–14 window. The latest upstream (v0.3.5) is ABI 15: it compiles
+// but SIGSEGVs at RootNode (ADR 0023 §6). v0.3.4 is the freshest ABI-14 tag.
+// The binding's go.mod declares the canonical module path
+// github.com/tree-sitter/tree-sitter-elixir while the source lives in the
+// elixir-lang/tree-sitter-elixir repo, so go.mod carries a matching replace.
+// Do not bump past ABI 14 without the smoke-parse + benchmark gate.
+package elixir
+
+import (
+	tsofficial "github.com/tree-sitter/go-tree-sitter"
+	tselixir "github.com/tree-sitter/tree-sitter-elixir/bindings/go"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// Language returns the Elixir grammar as a ts.Language bound to the official adapter.
+func Language() ts.Language {
+	return official.WrapLanguage(tsofficial.NewLanguage(tselixir.Language()))
+}

--- a/internal/treesitter/ts/grammars/elixir/elixir_smoke_test.go
+++ b/internal/treesitter/ts/grammars/elixir/elixir_smoke_test.go
@@ -1,0 +1,43 @@
+package elixir
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// TestElixirSmokeParse is the ABI guard for the official Elixir grammar (ADR
+// 0023 §6): an ABI-incompatible bump compiles but SIGSEGVs at RootNode, so this
+// catches it at CI instead of in production.
+func TestElixirSmokeParse(t *testing.T) {
+	adapter := official.New()
+	parser, err := adapter.NewParser(Language())
+	if err != nil {
+		t.Fatalf("NewParser failed (ABI mismatch?): %v", err)
+	}
+	defer parser.Close()
+
+	src := []byte("defmodule M do\n  def f, do: 1\nend\n")
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("RootNode is nil (ABI mismatch crashes here in the bad pairing)")
+	}
+	if got := root.Type(); got != "source" {
+		t.Fatalf("root kind = %q, want source", got)
+	}
+	if root.IsError() {
+		t.Fatal("root is an ERROR node")
+	}
+	if root.ChildCount() == 0 {
+		t.Fatal("root has no children (expected a module)")
+	}
+}

--- a/internal/treesitter/ts/grammars/ocaml/ocaml.go
+++ b/internal/treesitter/ts/grammars/ocaml/ocaml.go
@@ -1,0 +1,27 @@
+// Package ocaml provides the OCaml grammar via the official tree-sitter
+// binding, wrapped as a ts.Language for the official adapter. Sibling of the
+// Phase-0 golang/ package (B2 cutover Part B, ADR 0023, #5418): migrating a
+// language is a package like this one plus a migratedLanguages line in
+// adapters_official.go.
+//
+// ABI pin. The grammar is pinned to tree-sitter-ocaml v0.23.2 against runtime
+// v0.24.0 — its generated src/parser.c carries LANGUAGE_VERSION 14, inside the
+// runtime's 13–14 window. The latest upstream (v0.25.0) is ABI 15: it compiles
+// but SIGSEGVs at RootNode (ADR 0023 §6). v0.23.2 is the freshest ABI-14 tag.
+// The binding entry is binding_ocaml.go, exporting LanguageOCaml (the .ml
+// dialect); the package also ships LanguageOCamlInterface for .mli files. Do
+// not bump past ABI 14 without the smoke-parse + benchmark gate.
+package ocaml
+
+import (
+	tsofficial "github.com/tree-sitter/go-tree-sitter"
+	tsocaml "github.com/tree-sitter/tree-sitter-ocaml/bindings/go"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// Language returns the OCaml grammar as a ts.Language bound to the official adapter.
+func Language() ts.Language {
+	return official.WrapLanguage(tsofficial.NewLanguage(tsocaml.LanguageOCaml()))
+}

--- a/internal/treesitter/ts/grammars/ocaml/ocaml_smoke_test.go
+++ b/internal/treesitter/ts/grammars/ocaml/ocaml_smoke_test.go
@@ -1,0 +1,43 @@
+package ocaml
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// TestOCamlSmokeParse is the ABI guard for the official OCaml grammar (ADR 0023
+// §6): an ABI-incompatible bump compiles but SIGSEGVs at RootNode, so this
+// catches it at CI instead of in production.
+func TestOCamlSmokeParse(t *testing.T) {
+	adapter := official.New()
+	parser, err := adapter.NewParser(Language())
+	if err != nil {
+		t.Fatalf("NewParser failed (ABI mismatch?): %v", err)
+	}
+	defer parser.Close()
+
+	src := []byte("let f x = x + 1\n")
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("RootNode is nil (ABI mismatch crashes here in the bad pairing)")
+	}
+	if got := root.Type(); got != "compilation_unit" {
+		t.Fatalf("root kind = %q, want compilation_unit", got)
+	}
+	if root.IsError() {
+		t.Fatal("root is an ERROR node")
+	}
+	if root.ChildCount() == 0 {
+		t.Fatal("root has no children (expected a let binding)")
+	}
+}

--- a/internal/treesitter/ts/grammars/php/php.go
+++ b/internal/treesitter/ts/grammars/php/php.go
@@ -1,0 +1,26 @@
+// Package php provides the PHP grammar via the official tree-sitter binding,
+// wrapped as a ts.Language for the official adapter. Sibling of the Phase-0
+// golang/ package (B2 cutover Part B, ADR 0023, #5418): migrating a language is
+// a package like this one plus a migratedLanguages line in adapters_official.go.
+//
+// ABI pin. The grammar is pinned to tree-sitter-php v0.23.11 against runtime
+// v0.24.0 — its generated src/parser.c carries LANGUAGE_VERSION 14, inside the
+// runtime's 13–14 window. The latest upstream (v0.24.x) is ABI 15: it compiles
+// but SIGSEGVs at RootNode (ADR 0023 §6). v0.23.11 is the freshest ABI-14 tag.
+// The binding entry is php.go, exporting LanguagePHP (the full php/ grammar,
+// HTML-aware); the package also ships LanguagePHPOnly for embedded <?php. Do
+// not bump past ABI 14 without the smoke-parse + benchmark gate.
+package php
+
+import (
+	tsofficial "github.com/tree-sitter/go-tree-sitter"
+	tsphp "github.com/tree-sitter/tree-sitter-php/bindings/go"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// Language returns the PHP grammar as a ts.Language bound to the official adapter.
+func Language() ts.Language {
+	return official.WrapLanguage(tsofficial.NewLanguage(tsphp.LanguagePHP()))
+}

--- a/internal/treesitter/ts/grammars/php/php_smoke_test.go
+++ b/internal/treesitter/ts/grammars/php/php_smoke_test.go
@@ -1,0 +1,43 @@
+package php
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// TestPHPSmokeParse is the ABI guard for the official PHP grammar (ADR 0023 §6):
+// an ABI-incompatible bump compiles but SIGSEGVs at RootNode, so this catches it
+// at CI instead of in production.
+func TestPHPSmokeParse(t *testing.T) {
+	adapter := official.New()
+	parser, err := adapter.NewParser(Language())
+	if err != nil {
+		t.Fatalf("NewParser failed (ABI mismatch?): %v", err)
+	}
+	defer parser.Close()
+
+	src := []byte("<?php function f() { return 1; }\n")
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("RootNode is nil (ABI mismatch crashes here in the bad pairing)")
+	}
+	if got := root.Type(); got != "program" {
+		t.Fatalf("root kind = %q, want program", got)
+	}
+	if root.IsError() {
+		t.Fatal("root is an ERROR node")
+	}
+	if root.ChildCount() == 0 {
+		t.Fatal("root has no children (expected a function)")
+	}
+}

--- a/internal/treesitter/ts/grammars/scala/scala.go
+++ b/internal/treesitter/ts/grammars/scala/scala.go
@@ -1,0 +1,25 @@
+// Package scala provides the Scala grammar via the official tree-sitter
+// binding, wrapped as a ts.Language for the official adapter. Sibling of the
+// Phase-0 golang/ package (B2 cutover Part B, ADR 0023, #5418): migrating a
+// language is a package like this one plus a migratedLanguages line in
+// adapters_official.go.
+//
+// ABI pin. The grammar is pinned to tree-sitter-scala v0.23.4 against runtime
+// v0.24.0 — its generated src/parser.c carries LANGUAGE_VERSION 14, inside the
+// runtime's 13–14 window. The latest upstream (v0.26.0) is ABI 15: it compiles
+// but SIGSEGVs at RootNode (ADR 0023 §6). v0.23.4 is the freshest ABI-14 tag.
+// Do not bump past ABI 14 without the smoke-parse + benchmark gate.
+package scala
+
+import (
+	tsofficial "github.com/tree-sitter/go-tree-sitter"
+	tsscala "github.com/tree-sitter/tree-sitter-scala/bindings/go"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// Language returns the Scala grammar as a ts.Language bound to the official adapter.
+func Language() ts.Language {
+	return official.WrapLanguage(tsofficial.NewLanguage(tsscala.Language()))
+}

--- a/internal/treesitter/ts/grammars/scala/scala_smoke_test.go
+++ b/internal/treesitter/ts/grammars/scala/scala_smoke_test.go
@@ -1,0 +1,43 @@
+package scala
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// TestScalaSmokeParse is the ABI guard for the official Scala grammar (ADR 0023
+// §6): an ABI-incompatible bump compiles but SIGSEGVs at RootNode, so this
+// catches it at CI instead of in production.
+func TestScalaSmokeParse(t *testing.T) {
+	adapter := official.New()
+	parser, err := adapter.NewParser(Language())
+	if err != nil {
+		t.Fatalf("NewParser failed (ABI mismatch?): %v", err)
+	}
+	defer parser.Close()
+
+	src := []byte("object M { def f: Int = 1 }\n")
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("RootNode is nil (ABI mismatch crashes here in the bad pairing)")
+	}
+	if got := root.Type(); got != "compilation_unit" {
+		t.Fatalf("root kind = %q, want compilation_unit", got)
+	}
+	if root.IsError() {
+		t.Fatal("root is an ERROR node")
+	}
+	if root.ChildCount() == 0 {
+		t.Fatal("root has no children (expected an object)")
+	}
+}

--- a/internal/treesitter/ts/grammars/swift/swift.go
+++ b/internal/treesitter/ts/grammars/swift/swift.go
@@ -1,0 +1,26 @@
+// Package swift provides the Swift grammar via the official tree-sitter
+// binding, wrapped as a ts.Language for the official adapter. Sibling of the
+// Phase-0 golang/ package (B2 cutover Part B, ADR 0023, #5418): migrating a
+// language is a package like this one plus a migratedLanguages line in
+// adapters_official.go.
+//
+// ABI pin. The grammar is pinned to alex-pinkus/tree-sitter-swift at the
+// 0.7.3-with-generated-files tag against runtime v0.24.0 — that tag is ABI 14
+// (inside the runtime's 13–14 window). The generated src/parser.c is checked in
+// only on the "-with-generated-files" tags, so the binding is consumed via the
+// pseudo-version of that tag's commit. Do not bump past ABI 14 without the
+// smoke-parse + benchmark gate.
+package swift
+
+import (
+	tsswift "github.com/alex-pinkus/tree-sitter-swift/bindings/go"
+	tsofficial "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// Language returns the Swift grammar as a ts.Language bound to the official adapter.
+func Language() ts.Language {
+	return official.WrapLanguage(tsofficial.NewLanguage(tsswift.Language()))
+}

--- a/internal/treesitter/ts/grammars/swift/swift_smoke_test.go
+++ b/internal/treesitter/ts/grammars/swift/swift_smoke_test.go
@@ -1,0 +1,43 @@
+package swift
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// TestSwiftSmokeParse is the ABI guard for the official Swift grammar (ADR 0023
+// §6): an ABI-incompatible bump compiles but SIGSEGVs at RootNode, so this
+// catches it at CI instead of in production.
+func TestSwiftSmokeParse(t *testing.T) {
+	adapter := official.New()
+	parser, err := adapter.NewParser(Language())
+	if err != nil {
+		t.Fatalf("NewParser failed (ABI mismatch?): %v", err)
+	}
+	defer parser.Close()
+
+	src := []byte("func f() -> Int { return 1 }\n")
+	tree, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+	if root == nil {
+		t.Fatal("RootNode is nil (ABI mismatch crashes here in the bad pairing)")
+	}
+	if got := root.Type(); got != "source_file" {
+		t.Fatalf("root kind = %q, want source_file", got)
+	}
+	if root.IsError() {
+		t.Fatal("root is an ERROR node")
+	}
+	if root.ChildCount() == 0 {
+		t.Fatal("root has no children (expected a function)")
+	}
+}


### PR DESCRIPTION
Additive **B2 cutover Part B, batch 2** (#5418): official-binding tree-sitter grammar provider packages behind the `ts_official` build tag, mirroring batch 1 (#5466) and the Phase-0 `golang/` template. **Not** the big-bang flip — the default build is unchanged (100% smacker); the `ts_official` path is only populated so the eventual default-flip has these providers ready and validated.

### Added (5 of the planned 7)

Each is `internal/treesitter/ts/grammars/<lang>/` with a `Language()` provider wrapping the official binding (`official.WrapLanguage(tsofficial.NewLanguage(<mod>.Language()))`) + an ABI smoke-parse guard test asserting a non-nil, non-error root of the expected top kind. Wired into `migratedLanguages` + `abiProbeSource` in `adapters_official.go`.

| lang | module / version | source fn | top kind |
|---|---|---|---|
| elixir | `tree-sitter-elixir` v0.3.4 (canonical-path replace → `elixir-lang`) | `Language()` | `source` |
| ocaml | `tree-sitter-ocaml` v0.23.2 | `LanguageOCaml()` | `compilation_unit` |
| php | `tree-sitter-php` v0.23.11 | `LanguagePHP()` | `program` |
| scala | `tree-sitter-scala` v0.23.4 | `Language()` | `compilation_unit` |
| swift | `tree-sitter-swift` `0.7.3-with-generated-files` (pseudo `v0.0.0-20260601004120-31d17fe7e818`) | `Language()` | `source_file` |

All ABI ≤14 against the v0.24.0 runtime (the smoke-parse gate is the ABI proof). `go.mod` hand-edited (no `go mod tidy`): the 5 modules added to the direct-require block + targeted go.sum hashes + one `replace` for elixir's canonical-vs-source path mismatch.

### Deferred (2) — upstream packaging, need the vendored-C track (plan §3/§4)

- **kotlin** — go binding `#include`s `../../src/parser.c`, but it is a nested `bindings/go` module, so the parent `src/` is excluded from the module download → cgo `parser.c file not found`.
- **sql** — `DerekStride/tree-sitter-sql` `.gitignore`s `/src/parser.c`; it is never committed on any ref (generated at build time).

Suggest a small follow-up to vendor `parser.c`/`scanner.c` for those two.

### Verification (scoped to the 5)

- `go build -tags ts_official ./internal/treesitter/...` — clean.
- `go test -tags ts_official -count=1 -run Smoke ./internal/treesitter/ts/grammars/{elixir,ocaml,php,scala,swift}/` — all pass.
- `gofmt -l` + `go vet -tags ts_official` clean on touched files.
- **No-tag build still compiles:** `go build ./internal/treesitter/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
