### PR TITLE
cutover(b2): migrate extractor files *sitter.Node → ts.Node (step A, #5418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,20 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   all gated on the B1 grammar-bump / B2 smacker-decouple cutover.
   (`docs/c3-feature-impact-analysis.md`)
 
+### Changed
+- **B2 cutover, Step A — node-traversing extractors moved onto the
+  binding-agnostic `ts.Node` façade (#5418):** the remaining extractor files
+  that still typed their CST walks against the concrete smacker `*sitter.Node`
+  now traverse `ts.Node` / `ts.Tree` instead, sourcing the tree from the parser
+  factory's always-populated `ParseResult.TSTree`. Migrated: the Spring (Java),
+  Spring (Kotlin) and Django route-composition passes, plus the custom Ktor
+  nested-route extractor; two now-redundant `*sitter`-import compile shims were
+  removed. Purely mechanical — same nodes extracted, no behaviour change (route
+  golden tests unchanged). Runs under the **default** build, so the smacker
+  removal and runtime flip remain a separate later step; the grammar-handle
+  registration files (`*_smacker.go`, per-language `language.go`/`grammar.go`)
+  and the smacker parser factory stay on the concrete binding by design.
+
 ### Fixed
 - **Graph view: streamed nodes now reach the canvas every chunk — no more
   blank-until-done (#5446):** the progressive Graph screen showed a climbing

--- a/internal/custom/kotlin/ktor_routes.go
+++ b/internal/custom/kotlin/ktor_routes.go
@@ -25,10 +25,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-	tskotlin "github.com/smacker/go-tree-sitter/kotlin"
-
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -77,13 +76,12 @@ func (e *ktorRoutesExtractor) Extract(_ context.Context, file extractor.FileInpu
 		}
 	}
 
-	parser := sitter.NewParser()
-	parser.SetLanguage(tskotlin.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, file.Content)
-	if err != nil || tree == nil {
+	factory := treesitter.NewParserFactory(nil)
+	pr, err := factory.Parse(context.Background(), file.Content, "kotlin")
+	if err != nil || pr == nil || pr.TSTree == nil {
 		return nil, nil //nolint:nilerr // parse failures are non-fatal for custom extractors
 	}
-	defer tree.Close()
+	defer pr.TSTree.Close()
 
 	seen := make(map[string]bool)
 	var entities []types.EntityRecord
@@ -97,7 +95,7 @@ func (e *ktorRoutesExtractor) Extract(_ context.Context, file extractor.FileInpu
 		entities = append(entities, ent)
 	}
 
-	walkRoutes(tree.RootNode(), file, []string{}, add)
+	walkRoutes(pr.TSTree.RootNode(), file, []string{}, add)
 	return entities, nil
 }
 
@@ -105,7 +103,7 @@ func (e *ktorRoutesExtractor) Extract(_ context.Context, file extractor.FileInpu
 // route("…") DSL blocks and emitting endpoint entities when HTTP verb handlers
 // (get/post/put/delete/patch/head/options) are encountered.
 func walkRoutes(
-	node *sitter.Node,
+	node ts.Node,
 	file extractor.FileInput,
 	prefixes []string,
 	add func(types.EntityRecord),
@@ -172,7 +170,7 @@ func walkRoutes(
 //	  call_suffix (annotated_lambda)
 //
 // We handle both shapes.
-func parseKtorCallExpr(node *sitter.Node, src []byte) (callName, path string, lambda *sitter.Node) {
+func parseKtorCallExpr(node ts.Node, src []byte) (callName, path string, lambda ts.Node) {
 	if node.ChildCount() == 0 {
 		return "", "", nil
 	}
@@ -222,7 +220,7 @@ func parseKtorCallExpr(node *sitter.Node, src []byte) (callName, path string, la
 
 // extractStringFromValueArgs returns the first string literal content found
 // inside a call_suffix > value_arguments > value_argument > string_literal.
-func extractStringFromValueArgs(callSuffix *sitter.Node, src []byte) string {
+func extractStringFromValueArgs(callSuffix ts.Node, src []byte) string {
 	if callSuffix == nil {
 		return ""
 	}
@@ -248,7 +246,7 @@ func extractStringFromValueArgs(callSuffix *sitter.Node, src []byte) string {
 
 // firstStringContent finds the first string_content descendant and returns its
 // text, which is the path without surrounding quotes.
-func firstStringContent(node *sitter.Node, src []byte) string {
+func firstStringContent(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""
 	}
@@ -265,7 +263,7 @@ func firstStringContent(node *sitter.Node, src []byte) string {
 
 // extractLambdaNode finds an annotated_lambda > lambda_literal > statements
 // node inside a call_suffix, which represents the DSL block body.
-func extractLambdaNode(callSuffix *sitter.Node) *sitter.Node {
+func extractLambdaNode(callSuffix ts.Node) ts.Node {
 	if callSuffix == nil {
 		return nil
 	}

--- a/internal/engine/django_routes.go
+++ b/internal/engine/django_routes.go
@@ -34,9 +34,8 @@ import (
 	"strings"
 	"sync"
 
-	sitter "github.com/smacker/go-tree-sitter"
-
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -383,11 +382,11 @@ func extractDjangoComposedRoutes(ctx context.Context, path string, content []byt
 
 	factory := treesitter.NewParserFactory(nil)
 	pr, err := factory.Parse(ctx, content, "python")
-	if err != nil || pr == nil || pr.Tree == nil {
+	if err != nil || pr == nil || pr.TSTree == nil {
 		return out, false
 	}
 
-	root := pr.Tree.RootNode()
+	root := pr.TSTree.RootNode()
 
 	// Pass 1: collect all `path("<prefix>", include(<router>.urls))` bindings.
 	// router var name -> prefix string (raw, as written in source, without
@@ -407,7 +406,7 @@ func extractDjangoComposedRoutes(ctx context.Context, path string, content []byt
 // router-variable -> prefix binding. The prefix is also added to
 // claimedIncludePrefixes so the engine can drop the duplicate YAML Route.
 func collectIncludePrefixes(
-	node *sitter.Node,
+	node ts.Node,
 	src []byte,
 	routerPrefixes map[string]string,
 	claimedPrefixes map[string]bool,
@@ -432,14 +431,14 @@ func collectIncludePrefixes(
 // pathIncludeBinding inspects a `path(...)` call node. If its arguments are
 // (string_prefix, include(<router>.urls)) it returns the prefix string,
 // the router variable name, and true.
-func pathIncludeBinding(call *sitter.Node, src []byte) (string, string, bool) {
+func pathIncludeBinding(call ts.Node, src []byte) (string, string, bool) {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return "", "", false
 	}
 	// Walk the argument list: first positional must be a string literal,
 	// second positional must be `include(<router>.urls)`.
-	var positional []*sitter.Node
+	var positional []ts.Node
 	for i := 0; i < int(args.ChildCount()); i++ {
 		ch := args.Child(i)
 		t := ch.Type()
@@ -468,7 +467,7 @@ func pathIncludeBinding(call *sitter.Node, src []byte) (string, string, bool) {
 
 // includeRouterUrls inspects a node that should be `include(<router>.urls)`
 // and returns the router variable name on success.
-func includeRouterUrls(node *sitter.Node, src []byte) (string, bool) {
+func includeRouterUrls(node ts.Node, src []byte) (string, bool) {
 	if node == nil || node.Type() != "call" {
 		return "", false
 	}
@@ -505,7 +504,7 @@ func includeRouterUrls(node *sitter.Node, src []byte) (string, bool) {
 // `<router>.register("<name>", <ViewSet>)` call whose receiver is in
 // routerPrefixes, and emits composed Route + ROUTES_TO records.
 func collectRegisterCalls(
-	node *sitter.Node,
+	node ts.Node,
 	src []byte,
 	path string,
 	routerPrefixes map[string]string,
@@ -559,12 +558,12 @@ func collectRegisterCalls(
 // returns (name, viewSet, true) on success. `name` is the bare URL
 // fragment (e.g. "users"); `viewSet` is the identifier passed as the second
 // positional argument (e.g. "UserViewSet").
-func registerArgs(call *sitter.Node, src []byte) (string, string, bool) {
+func registerArgs(call ts.Node, src []byte) (string, string, bool) {
 	args := call.ChildByFieldName("arguments")
 	if args == nil {
 		return "", "", false
 	}
-	var positional []*sitter.Node
+	var positional []ts.Node
 	for i := 0; i < int(args.ChildCount()); i++ {
 		ch := args.Child(i)
 		t := ch.Type()
@@ -592,7 +591,7 @@ func registerArgs(call *sitter.Node, src []byte) (string, string, bool) {
 
 // callFunctionName returns the bare function name of a `call` node when the
 // callee is a simple identifier. Returns "" for attribute calls.
-func callFunctionName(call *sitter.Node, src []byte) string {
+func callFunctionName(call ts.Node, src []byte) string {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return ""
@@ -606,7 +605,7 @@ func callFunctionName(call *sitter.Node, src []byte) string {
 // callReceiverAndMethod returns (receiver, method) when the call is
 // `<receiver>.<method>(...)` with a simple identifier receiver. Otherwise
 // returns ("", "").
-func callReceiverAndMethod(call *sitter.Node, src []byte) (string, string) {
+func callReceiverAndMethod(call ts.Node, src []byte) (string, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil || fn.Type() != "attribute" {
 		return "", ""
@@ -626,7 +625,7 @@ func callReceiverAndMethod(call *sitter.Node, src []byte) (string, string) {
 // supporting the raw-string form (`r"..."` / `r'...'`) used by Django URL
 // patterns. It returns the inner text (without the surrounding quotes) and
 // true on success.
-func stringLiteralValue(node *sitter.Node, src []byte) (string, bool) {
+func stringLiteralValue(node ts.Node, src []byte) (string, bool) {
 	if node == nil || node.Type() != "string" {
 		return "", false
 	}

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -21,9 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -150,18 +149,18 @@ func extractSpringComposedRoutes(ctx context.Context, path string, content []byt
 
 	factory := treesitter.NewParserFactory(nil)
 	pr, err := factory.Parse(ctx, content, "java")
-	if err != nil || pr == nil || pr.Tree == nil {
+	if err != nil || pr == nil || pr.TSTree == nil {
 		return out, false
 	}
 
-	root := pr.Tree.RootNode()
+	root := pr.TSTree.RootNode()
 	walkSpringClasses(root, content, path, &out)
 	return out, true
 }
 
 // walkSpringClasses traverses the tree, looking for class_declaration nodes
 // that carry both a controller annotation and a class-level @RequestMapping.
-func walkSpringClasses(node *sitter.Node, src []byte, path string, out *composedSpringRoutes) {
+func walkSpringClasses(node ts.Node, src []byte, path string, out *composedSpringRoutes) {
 	if node == nil {
 		return
 	}
@@ -178,7 +177,7 @@ func walkSpringClasses(node *sitter.Node, src []byte, path string, out *composed
 // controller (carries @RestController or @Controller) AND has a class-level
 // @RequestMapping prefix, every method-level mapping inside its body is
 // emitted as a composed Route.
-func processSpringClass(class *sitter.Node, src []byte, path string, out *composedSpringRoutes) {
+func processSpringClass(class ts.Node, src []byte, path string, out *composedSpringRoutes) {
 	annos := classLevelAnnotations(class)
 	isController := false
 	prefix := ""
@@ -263,8 +262,8 @@ func processSpringClass(class *sitter.Node, src []byte, path string, out *compos
 
 // classLevelAnnotations returns the modifier annotations attached to a
 // class_declaration (the modifiers child holds them).
-func classLevelAnnotations(class *sitter.Node) []*sitter.Node {
-	var out []*sitter.Node
+func classLevelAnnotations(class ts.Node) []ts.Node {
+	var out []ts.Node
 	for i := 0; i < int(class.ChildCount()); i++ {
 		ch := class.Child(i)
 		if ch.Type() != "modifiers" {
@@ -282,7 +281,7 @@ func classLevelAnnotations(class *sitter.Node) []*sitter.Node {
 
 // methodLevelAnnotations is the same shape as classLevelAnnotations, applied
 // to a method_declaration.
-func methodLevelAnnotations(method *sitter.Node) []*sitter.Node {
+func methodLevelAnnotations(method ts.Node) []ts.Node {
 	return classLevelAnnotations(method)
 }
 
@@ -290,7 +289,7 @@ func methodLevelAnnotations(method *sitter.Node) []*sitter.Node {
 // and, if present, the first string-literal argument's value (e.g. "/orders").
 // Supports `@Foo("/x")`, `@Foo(value="/x")`, `@Foo(path="/x")`, and bare
 // `@Foo` (returns empty path).
-func annotationNameAndPath(anno *sitter.Node, src []byte) (string, string) {
+func annotationNameAndPath(anno ts.Node, src []byte) (string, string) {
 	if anno == nil {
 		return "", ""
 	}
@@ -388,7 +387,7 @@ func httpMethodForAnnotation(name string) string {
 }
 
 // nodeText returns the source text covered by node.
-func nodeText(n *sitter.Node, src []byte) string {
+func nodeText(n ts.Node, src []byte) string {
 	if n == nil {
 		return ""
 	}
@@ -426,7 +425,7 @@ func extractRoutePathParams(path string) string {
 
 // nodeFieldText returns the text of node.ChildByFieldName(field), or "" if
 // the field is absent.
-func nodeFieldText(n *sitter.Node, field string, src []byte) string {
+func nodeFieldText(n ts.Node, field string, src []byte) string {
 	if n == nil {
 		return ""
 	}

--- a/internal/engine/spring_routes_kotlin.go
+++ b/internal/engine/spring_routes_kotlin.go
@@ -27,10 +27,9 @@ import (
 	"fmt"
 	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-
 	"github.com/cajasmota/grafel/internal/engine/httproutes"
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -67,7 +66,7 @@ func applySpringRouteCompositionKotlin(args DetectorPassArgs) DetectorPassResult
 func extractKotlinSpringEndpoints(ctx context.Context, path string, content []byte) ([]types.EntityRecord, []types.RelationshipRecord) {
 	factory := treesitter.NewParserFactory(nil)
 	pr, err := factory.Parse(ctx, content, "kotlin")
-	if err != nil || pr == nil || pr.Tree == nil {
+	if err != nil || pr == nil || pr.TSTree == nil {
 		return nil, nil
 	}
 
@@ -75,7 +74,7 @@ func extractKotlinSpringEndpoints(ctx context.Context, path string, content []by
 	var rels []types.RelationshipRecord
 	seen := map[string]bool{}
 
-	root := pr.Tree.RootNode()
+	root := pr.TSTree.RootNode()
 	walkKotlinClasses(root, content, path, &entities, &rels, seen)
 	return entities, rels
 }
@@ -83,7 +82,7 @@ func extractKotlinSpringEndpoints(ctx context.Context, path string, content []by
 // walkKotlinClasses does a depth-first walk looking for class_declaration nodes
 // and delegating to processKotlinSpringClass for each one.
 func walkKotlinClasses(
-	node *sitter.Node,
+	node ts.Node,
 	src []byte,
 	path string,
 	entities *[]types.EntityRecord,
@@ -107,7 +106,7 @@ func walkKotlinClasses(
 // class-level @RequestMapping, each function_declaration inside the class_body
 // that carries a verb annotation is emitted as an http_endpoint_definition.
 func processKotlinSpringClass(
-	class *sitter.Node,
+	class ts.Node,
 	src []byte,
 	path string,
 	entities *[]types.EntityRecord,
@@ -134,7 +133,7 @@ func processKotlinSpringClass(
 	}
 
 	// Find the class_body child.
-	var body *sitter.Node
+	var body ts.Node
 	for i := 0; i < int(class.ChildCount()); i++ {
 		ch := class.Child(i)
 		if ch.Type() == "class_body" {
@@ -230,11 +229,11 @@ func processKotlinSpringClass(
 
 // kotlinClassModifiers returns the annotation children from the modifiers node
 // of a class_declaration or function_declaration.
-func kotlinClassModifiers(node *sitter.Node) []*sitter.Node {
+func kotlinClassModifiers(node ts.Node) []ts.Node {
 	if node == nil {
 		return nil
 	}
-	var out []*sitter.Node
+	var out []ts.Node
 	for i := 0; i < int(node.ChildCount()); i++ {
 		ch := node.Child(i)
 		if ch.Type() == "modifiers" {
@@ -261,7 +260,7 @@ func kotlinClassModifiers(node *sitter.Node) []*sitter.Node {
 //	  Positional:    value_argument → string_literal
 //	  Named value=:  value_argument → simple_identifier("value") + "=" + string_literal
 //	  Named path=:   value_argument → simple_identifier("path") + "=" + string_literal
-func kotlinAnnotationNameAndPath(anno *sitter.Node, src []byte) (string, string) {
+func kotlinAnnotationNameAndPath(anno ts.Node, src []byte) (string, string) {
 	if anno == nil || anno.Type() != "annotation" {
 		return "", ""
 	}
@@ -300,7 +299,7 @@ func kotlinAnnotationNameAndPath(anno *sitter.Node, src []byte) (string, string)
 
 // kotlinUserTypeName returns the type_identifier text from a user_type node,
 // handling optional package qualification (the last type_identifier segment).
-func kotlinUserTypeName(userType *sitter.Node, src []byte) string {
+func kotlinUserTypeName(userType ts.Node, src []byte) string {
 	if userType == nil {
 		return ""
 	}
@@ -321,7 +320,7 @@ func kotlinUserTypeName(userType *sitter.Node, src []byte) string {
 //   - positional: value_argument → string_literal
 //   - named value=: value_argument → simple_identifier("value") + "=" + string_literal
 //   - named path=: value_argument → simple_identifier("path") + "=" + string_literal
-func kotlinExtractPathFromValueArgs(args *sitter.Node, src []byte) string {
+func kotlinExtractPathFromValueArgs(args ts.Node, src []byte) string {
 	if args == nil {
 		return ""
 	}
@@ -333,7 +332,7 @@ func kotlinExtractPathFromValueArgs(args *sitter.Node, src []byte) string {
 		}
 		// Inspect children of value_argument.
 		key := ""
-		var strLit *sitter.Node
+		var strLit ts.Node
 		for j := 0; j < int(va.ChildCount()); j++ {
 			vc := va.Child(j)
 			switch vc.Type() {
@@ -368,7 +367,7 @@ func kotlinExtractPathFromValueArgs(args *sitter.Node, src []byte) string {
 // kotlinRequestMappingMethod extracts the HTTP verb from a @RequestMapping
 // annotation's `method = [RequestMethod.GET]` (or similar) argument.
 // Returns an empty string when the argument is absent (caller keeps "ANY").
-func kotlinRequestMappingMethod(anno *sitter.Node, src []byte) string {
+func kotlinRequestMappingMethod(anno ts.Node, src []byte) string {
 	if anno == nil {
 		return ""
 	}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -63,7 +63,6 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
 	"github.com/cajasmota/grafel/internal/types"
-	sitter "github.com/smacker/go-tree-sitter"
 )
 
 // defaultIncrementalFiles is the raised default trigger limit for feature
@@ -648,8 +647,3 @@ func entityPropertiesHash(e graph.Entity) string {
 	}
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
-
-// parseTree is kept as a compile-time reference so the sitter import is used.
-// The actual tree-sitter parse happens inside each language extractor; we do
-// not re-parse here (the extractor does it if file.Tree is nil).
-var _ = (*sitter.Tree)(nil)


### PR DESCRIPTION
## B2 cutover — Step A: extractor `*sitter.Node` → `ts.Node`

Moves the remaining node-traversing extractor files off the concrete smacker `*sitter.Node`/`*sitter.Tree` onto the binding-agnostic `ts.Node` / `ts.Tree` façade (`internal/treesitter/ts`), sourcing the tree from the parser factory's always-populated `ParseResult.TSTree`.

Done under the **default (smacker) build** — the `ts` façade resolves to the smacker adapter by default, so the tree stays green throughout. **No big-bang risk**: the actual runtime flip + smacker removal is a separate later step.

### Migrated (4 node-traversing files)
- `internal/engine/spring_routes.go` — Spring (Java) route composition
- `internal/engine/spring_routes_kotlin.go` — Spring (Kotlin) route composition
- `internal/engine/django_routes.go` — Django URLconf route composition
- `internal/custom/kotlin/ktor_routes.go` — custom Ktor nested-route extractor (now parses via the factory instead of building its own smacker parser)

Plus removed 2 redundant `*sitter`-import compile shims (`internal/extractors/incremental.go`).

### Why only 4 (not ~97)
The original sweep estimate was dominated by already-migrated files whose only remaining match was a *comment*, plus grammar-side smacker imports. After filtering comment-only hits and the grammar-handle layer, the real node-traversal targets were the 4 above.

### No interface change
Every node method used (`Type`/`Child`/`ChildCount`/`ChildByFieldName`/`StartByte`/`EndByte`/`StartPoint`/`String`) is already on the `ts.Node` interface, so the migration was a pure mechanical type swap — no `ts.Node` extension required.

### Deferred by design (later flip, not Step A)
- grammar-handle registration files (`*_smacker.go`, per-language `language.go`/`grammar.go`)
- the smacker parser factory
- the legacy `ParseResult.Tree` / `FileInput.Tree` fields (kept until all languages migrate)

### Verification
- `go build ./...` (no tag = default/smacker) — **green** end-to-end
- `go vet` + `gofmt -l` — clean on all touched files
- `go test -count=1` on the touched packages (engine route tests, `custom/kotlin`, `extractors`) — **pass**, same nodes extracted (route golden tests unchanged)

Refs #5418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
