### PR TITLE
fix(mcp): find_callers fuzzy input resolution + recover dropped cross-repo callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,26 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   and the smacker parser factory stay on the concrete binding by design.
 
 ### Fixed
+- **`find_callers`: fuzzy input resolution + recover dropped cross-repo callers
+  (#5475):** `find_callers` was the most-failed neighbor tool — a ~20-44%
+  "entity not found" rate for its heaviest consumer, plus a silent caller
+  under-report. Two bugs, one shared root cause (unresolved / cross-repo ids).
+  (1) The shared `resolveEntityArg` path resolved `entity_id` only by exact hex
+  id → exact unique Name/QualifiedName, then errored — while `find` resolved the
+  same reference fuzzily (different case, a qualified-name suffix like
+  `svc.Target`, a substring). It now falls through to the *same* case-insensitive
+  substring match `find` uses (extracted into a shared `fuzzyMatchEntities`
+  helper), preferring a unique exact-case-insensitive name and returning a
+  disambiguation envelope when the probe matches many; the exact-id + exact-name
+  happy path is byte-for-byte unchanged and a genuine miss still errors. (2) When
+  an inbound caller edge's `FromID` was an unresolved id (the cross-repo linker
+  never rewrote a raw path / placeholder to a stamped entity id), only file-ref
+  and projected-semantic edges got the synthetic-caller fallback; the remaining
+  real caller kinds (CALLS, TESTS, IMPLEMENTS, HANDLES, ROUTES_TO, inheritance,
+  …) were silently dropped, so `find_callers` returned N-1 callers. The fallback
+  now covers every id that reached the walk via the `isInboundNeighborKind`
+  gate. The resolver fix is shared, so `find_callees` / `neighbors` benefit too
+  (verified not regressed).
 - **Graph view: streamed nodes now reach the canvas every chunk — no more
   blank-until-done (#5446):** the progressive Graph screen showed a climbing
   "building graph… N / total" counter while the WebGL canvas stayed blank, then

--- a/internal/mcp/find_callers_fuzzy_5475_test.go
+++ b/internal/mcp/find_callers_fuzzy_5475_test.go
@@ -1,0 +1,152 @@
+package mcp
+
+// find_callers_fuzzy_5475_test.go — #5475.
+//
+// Two distinct bugs in grafel_find_callers, shared root cause (incomplete
+// cross-repo / unresolved-id handling):
+//
+//	BUG 1 (error rate): resolveEntityArg only resolved an exact hex id or an
+//	  EXACT unique Name/QualifiedName. References that grafel_find resolves
+//	  fuzzily (different case, a qualified-name suffix, a substring) hard-errored
+//	  with "entity not found". The shared fuzzyMatchEntities fall-through (reused
+//	  from grafel_find / handleSearchEntities) now rescues them.
+//
+//	BUG 2 (dropped callers): when a caller edge's FromID was an unresolved id
+//	  (byID[id]==nil — the cross-repo linker rewrite gap), only file-ref and
+//	  semantic edge kinds got a synthetic-caller fallback; CALLS-class edges were
+//	  silently dropped, so find_callers returned N-1 callers. The fallback now
+//	  covers every real inbound caller kind.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// --- BUG 1: fuzzy input resolution -----------------------------------------
+
+// buildFuzzyResDoc: Caller --CALLS--> Target. Target's name is "Target" with
+// qualified name "core.svc.Target".
+func buildFuzzyResDoc() *graph.Document {
+	return minDoc(
+		[]graph.Entity{
+			{ID: "ent-target", Name: "Target", QualifiedName: "core.svc.Target", Kind: "Function", SourceFile: "svc.py", StartLine: 10},
+			{ID: "ent-caller", Name: "Caller", QualifiedName: "core.svc.Caller", Kind: "Function", SourceFile: "svc.py", StartLine: 20},
+		},
+		[]graph.Relationship{
+			{FromID: "ent-caller", ToID: "ent-target", Kind: "CALLS"},
+		},
+	)
+}
+
+// TestFindCallers_ByDifferentCaseName: a name with different case ("target")
+// is not an exact match but grafel_find resolves it; find_callers now does too.
+func TestFindCallers_ByDifferentCaseName(t *testing.T) {
+	srv := newTestServer(t, buildFuzzyResDoc())
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "target"})
+	if out["entity_name"] != "Target" {
+		t.Fatalf("entity_name = %v, want Target (case-insensitive resolution)", out["entity_name"])
+	}
+	cs := callersOf(t, out)
+	if len(cs) != 1 || cs[0].(map[string]any)["name"] != "Caller" {
+		t.Fatalf("case-insensitive resolution lost the caller: %+v", cs)
+	}
+}
+
+// TestFindCallers_ByQualifiedNameSuffix: a partial qualified name ("svc.Target")
+// is not an exact Name/QualifiedName but is a substring grafel_find resolves.
+func TestFindCallers_ByQualifiedNameSuffix(t *testing.T) {
+	srv := newTestServer(t, buildFuzzyResDoc())
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "svc.Target"})
+	if out["entity_name"] != "Target" {
+		t.Fatalf("entity_name = %v, want Target (qualified-name suffix resolution)", out["entity_name"])
+	}
+	if len(callersOf(t, out)) != 1 {
+		t.Fatalf("qualified-name suffix resolution lost the caller: %+v", out)
+	}
+}
+
+// TestFindCallers_FuzzyAmbiguous: a substring matching >1 entity returns a
+// disambiguation envelope, NOT a bare error and NOT an arbitrary pick.
+func TestFindCallers_FuzzyAmbiguous(t *testing.T) {
+	doc := minDoc(
+		[]graph.Entity{
+			{ID: "ent-pa", Name: "PaymentService", QualifiedName: "core.pay.PaymentService", Kind: "Class", SourceFile: "pay.py", StartLine: 1},
+			{ID: "ent-pb", Name: "PaymentGateway", QualifiedName: "core.pay.PaymentGateway", Kind: "Class", SourceFile: "pay.py", StartLine: 5},
+		},
+		[]graph.Relationship{},
+	)
+	srv := newTestServer(t, doc)
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "Payment"})
+	if out["ambiguous"] != true {
+		t.Fatalf("expected ambiguous=true for fuzzy multi-match, got %+v", out)
+	}
+	cands, ok := out["candidates"].([]any)
+	if !ok || len(cands) != 2 {
+		t.Fatalf("expected 2 fuzzy candidates, got %T %+v", out["candidates"], out["candidates"])
+	}
+}
+
+// TestFindCallers_FuzzyNonexistent: a probe matching nothing even fuzzily still
+// errors verbatim (genuine not-found case preserved).
+func TestFindCallers_FuzzyNonexistent(t *testing.T) {
+	srv := newTestServer(t, buildFuzzyResDoc())
+	got := callFlowToolError(t, srv.handleFindCallers, map[string]any{"entity_id": "zzzznope"})
+	if got == "" {
+		t.Fatalf("expected an error result for a genuine miss")
+	}
+}
+
+// TestFindCallees_FuzzyNotRegressed: the shared resolver also powers
+// find_callees; a fuzzy name there resolves too (no regression).
+func TestFindCallees_FuzzyNotRegressed(t *testing.T) {
+	srv := newTestServer(t, buildFuzzyResDoc())
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{"entity_id": "caller"})
+	callees, ok := out["callees"].([]any)
+	if !ok || len(callees) != 1 || callees[0].(map[string]any)["name"] != "Target" {
+		t.Fatalf("find_callees fuzzy resolution failed/regressed: %+v", out)
+	}
+}
+
+// --- BUG 2: dropped callers on unresolved CALLS FromID ----------------------
+
+// buildDroppedCallerDoc: Target has TWO callers — RealCaller (resolved) and an
+// unresolved FromID "phantom/lib.py::caller" on a CALLS edge that the cross-repo
+// linker never rewrote to a stamped entity id. Pre-fix find_callers returned
+// only RealCaller (N-1).
+func buildDroppedCallerDoc() *graph.Document {
+	return minDoc(
+		[]graph.Entity{
+			{ID: "ent-target", Name: "Target", QualifiedName: "core.svc.Target", Kind: "Function", SourceFile: "svc.py", StartLine: 10},
+			{ID: "ent-real", Name: "RealCaller", QualifiedName: "core.svc.RealCaller", Kind: "Function", SourceFile: "svc.py", StartLine: 20},
+		},
+		[]graph.Relationship{
+			{FromID: "ent-real", ToID: "ent-target", Kind: "CALLS"},
+			// Unresolved FromID — the source entity was never stamped (linker gap).
+			{FromID: "phantom/lib/PhantomCaller", ToID: "ent-target", Kind: "CALLS"},
+		},
+	)
+}
+
+// TestFindCallers_UnresolvedCallsFromIDNotDropped: the unresolved-FromID CALLS
+// caller now appears as a synthetic caller (#5475) instead of being silently
+// dropped, so the count is the full 2.
+func TestFindCallers_UnresolvedCallsFromIDNotDropped(t *testing.T) {
+	srv := newTestServer(t, buildDroppedCallerDoc())
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{"entity_id": "ent-target"})
+	cs := callersOf(t, out)
+	if len(cs) != 2 {
+		t.Fatalf("want 2 callers (resolved + synthetic unresolved-FromID), got %d: %+v", len(cs), cs)
+	}
+	names := map[string]bool{}
+	for _, c := range cs {
+		names[c.(map[string]any)["name"].(string)] = true
+	}
+	if !names["RealCaller"] {
+		t.Fatalf("lost the resolved caller: %+v", names)
+	}
+	// Synthetic caller is named from the trailing path/id segment.
+	if !names["PhantomCaller"] {
+		t.Fatalf("unresolved-FromID CALLS caller was dropped (BUG 2 not fixed): %+v", names)
+	}
+}

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -341,7 +341,21 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 				// callees-side JOINS_COLLECTION fix). inspect's semantic_edges emits
 				// these regardless of resolution; neighbors must not silently drop
 				// them.
-				if !isFileRefEdge && !isSemanticEdgeKind(dk) {
+				//
+				// #5475: extend the fallback to the REMAINING real caller edge kinds
+				// too (CALLS / TESTS / IMPLEMENTS / HANDLES / ROUTES_TO / … and the
+				// inheritance kinds). Every id that reaches this loop was discovered
+				// via isInboundNeighborKind, which is precisely the "this is a real
+				// caller relationship" gate — pure-structural noise (CONTAINS /
+				// DECLARES / DEFINES) is already excluded upstream. So when byID[id]
+				// is nil because the edge's FromID was never rewritten from a raw
+				// path / cross-repo placeholder to a stamped entity id (the linker /
+				// resolver rewrite gap), the caller is REAL and must not be silently
+				// dropped: emit a synthetic caller using the id, exactly as #2015 /
+				// #4288 do, so find_callers stops returning N-1 callers. The
+				// remaining guard only filters the genuinely-structural inbound kinds
+				// that should never have produced a caller in the first place.
+				if !isFileRefEdge && !isSemanticEdgeKind(dk) && !isInboundNeighborKind(dk) {
 					continue
 				}
 				name := id
@@ -949,8 +963,113 @@ func resolveImpactTarget(repos []*LoadedRepo, target string) impactResolution {
 		return impactResolution{candidates: byName}
 	}
 
-	// Pass 3: nothing matched.
-	return impactResolution{}
+	// Pass 2.5 (#5475): fuzzy fall-through. The exact id + exact name passes
+	// above are intentionally strict, but agents routinely pass a reference that
+	// grafel_find resolves and find_callers misses (e.g. a different-case name, a
+	// partial / suffix of a qualified name like "svc.Target", or a substring).
+	// grafel_find (handleSearchEntities) resolves these via a case-insensitive
+	// substring match on Name/QualifiedName, ranking an exact case-insensitive
+	// name first. Reuse that SAME logic here, but only as a fallback once the
+	// strict passes have missed — so the exact-match happy path is byte-for-byte
+	// unchanged and only genuine "would-have-errored" calls are rescued. We drop
+	// de-noise entities (file/module containers, shadows, schema fields) so the
+	// fuzzy candidate set stays signal, mirroring grafel_find's default ranking.
+	fuzzy := fuzzyMatchEntities(repos, probeForFuzzy(target))
+	switch len(fuzzy.hits) {
+	case 0:
+		// Nothing matched even fuzzily.
+		return impactResolution{}
+	case 1:
+		return impactResolution{repo: fuzzy.hits[0].repo, localID: fuzzy.hits[0].id}
+	default:
+		// A fuzzy probe legitimately matches many entities; surface the same
+		// disambiguation envelope the exact-name-ambiguous branch uses so the
+		// agent can re-issue against a precise entity_id rather than getting a
+		// bare error.
+		return impactResolution{candidates: fuzzy.candidates}
+	}
+}
+
+// probeForFuzzy normalises the fuzzy probe. An empty/whitespace probe must NOT
+// match every entity (substring "" matches all), so it is returned unchanged
+// and fuzzyMatchEntities short-circuits on it.
+func probeForFuzzy(target string) string { return strings.TrimSpace(target) }
+
+// fuzzyHit is a single fuzzy entity match.
+type fuzzyHit struct {
+	repo *LoadedRepo
+	id   string
+}
+
+// fuzzyMatchResult carries the fuzzy matches plus pre-built disambiguation
+// candidates (only meaningful when len(hits) > 1).
+type fuzzyMatchResult struct {
+	hits       []fuzzyHit
+	candidates []impactCandidate
+}
+
+// fuzzyMatchEntities is the SHARED fuzzy name lookup, extracted from grafel_find
+// (handleSearchEntities, #5475). It performs a case-insensitive substring match
+// on Name / QualifiedName across the in-scope repos, dropping de-noise entities,
+// and orders the matches so an exact case-insensitive Name match sorts first
+// (identical to handleSearchEntities' sort). When exactly one entity matches the
+// probe as a case-insensitive Name (and no other is exactly-named), that single
+// entity is treated as the unique resolution even if the substring also matched
+// other entities — this is the common "Caller" vs "CallerFactory" case.
+//
+// It is intentionally pure (no Server / request state) so resolveImpactTarget
+// and handleSearchEntities can both consume it without duplicating the match
+// rules that historically drift apart between the two surfaces.
+func fuzzyMatchEntities(repos []*LoadedRepo, probe string) fuzzyMatchResult {
+	if probe == "" {
+		return fuzzyMatchResult{}
+	}
+	ql := strings.ToLower(probe)
+
+	var exact []fuzzyHit
+	var exactC []impactCandidate
+	var sub []fuzzyHit
+	var subC []impactCandidate
+	for _, r := range repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if isNoise(e) {
+				continue
+			}
+			nameL := strings.ToLower(e.Name)
+			qnL := strings.ToLower(e.QualifiedName)
+			if !strings.Contains(nameL, ql) && !strings.Contains(qnL, ql) {
+				continue
+			}
+			cand := impactCandidate{
+				EntityID:   prefixedID(r.Repo, e.ID),
+				Name:       e.Name,
+				Kind:       stripScopePrefix(e.Kind),
+				Repo:       r.Repo,
+				SourceFile: e.SourceFile,
+			}
+			if nameL == ql || qnL == ql {
+				exact = append(exact, fuzzyHit{repo: r, id: e.ID})
+				exactC = append(exactC, cand)
+				continue
+			}
+			sub = append(sub, fuzzyHit{repo: r, id: e.ID})
+			subC = append(subC, cand)
+		}
+	}
+	// A unique exact-(case-insensitive) name/qualified-name match wins outright,
+	// even if substrings also matched — this mirrors grafel_find floating the
+	// exact name to the top and is what makes "caller" resolve to "Caller".
+	if len(exact) == 1 {
+		return fuzzyMatchResult{hits: exact[:1], candidates: exactC[:1]}
+	}
+	if len(exact) > 1 {
+		return fuzzyMatchResult{hits: exact, candidates: exactC}
+	}
+	return fuzzyMatchResult{hits: sub, candidates: subC}
 }
 
 // resolveEntityArg is the SHARED entity_id resolution path for the neighbor


### PR DESCRIPTION
Closes #5475.

`find_callers` is the most-failed neighbor tool for its heaviest consumer (~20-44% "entity not found"), and it silently under-reports callers. Two distinct bugs, one shared root cause — incomplete handling of unresolved / cross-repo entity ids. Go-only, `internal/mcp`.

## Bug 1 — input resolution too strict (the error rate)
The shared `resolveEntityArg` path (`find_callers` / `find_callees` / `neighbors`) resolved `entity_id` only by **exact hex id → exact unique Name/QualifiedName**, then errored. The `find` tool resolves the *same* references fuzzily (different case, a qualified-name suffix like `svc.Target`, a substring), so an agent passes a reference `find` accepts but `find_callers` rejects.

**Fix:** `resolveImpactTarget` (which backs `resolveEntityArg`) now adds a *Pass 2.5* fuzzy fall-through that reuses the **same** case-insensitive substring match-on Name/QualifiedName logic the `find` tool uses — extracted into a shared, pure `fuzzyMatchEntities` helper so the two surfaces can't drift. It prefers a unique exact-case-insensitive name and returns the existing disambiguation envelope when the probe matches many. The exact-id + exact-name happy path runs first and is byte-for-byte unchanged; the fuzzy pass only runs once both strict passes miss; a genuine miss still returns the verbatim `entity not found` error.

## Bug 2 — dropped callers (silent under-report)
When an inbound caller edge's `FromID` was an unresolved id (the cross-repo linker never rewrote the raw path / placeholder to a stamped entity id), only file-ref (REFERENCES/IMPORTS) and projected-semantic edges got the synthetic-caller fallback; the remaining **real** caller kinds (CALLS, TESTS, IMPLEMENTS, HANDLES, ROUTES_TO, the inheritance kinds, …) were silently `continue`-dropped → N-1 callers.

**Fix:** the fallback's drop guard now also lets through any id that reached the walk via the `isInboundNeighborKind` gate — which is precisely the "this is a real caller relationship" filter (pure-structural CONTAINS/DECLARES/DEFINES are excluded upstream). Such a caller is real, so it is emitted as a synthetic caller from the id (same pattern as the existing file-ref / semantic fallback) rather than dropped.

## Tests (`internal/mcp/find_callers_fuzzy_5475_test.go`)
- different-case name (`target`) and qualified-name suffix (`svc.Target`) now resolve + return the caller;
- a fuzzy multi-match returns a disambiguation envelope, not an error / arbitrary pick;
- a genuine miss still errors;
- an unresolved-FromID **CALLS** caller now appears (count is full N, not N-1);
- existing exact-id / exact-name / ambiguous happy paths unchanged;
- `find_callees` / `neighbors` fuzzy paths verified not regressed.

`go test -count=1 -run 'TestFindCallers|TestFindCallees|TestNeighbors' ./internal/mcp/` is green. (The full `./internal/mcp/...` run hits one **pre-existing, unrelated** failure — `TestApplyOverlay_GroupValuesAppliedAtLoad`, a test-isolation/#5443 sandbox-HOME guard — confirmed failing identically on pristine `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)