### PR TITLE
fix(daemon): cap concurrent index operations (GRAFEL_INDEX_CONCURRENCY, default 2) — no more all-at-once storms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Fixed
+- **Index-concurrency cap — no more all-at-once monorepo storms (#5493):** when a
+  group/monorepo with many modules was registered or rebuilt, the daemon indexed
+  every module up to the memory-auto-tuned rebuild cap (8 on a 16 GB host, 16 on
+  32 GB) simultaneously. The per-index core cap (`GRAFEL_EXTRACT_GOMAXPROCS`)
+  bounds cores *within* one index but not the *number* of concurrent indexes, so
+  a 30-module group spun up ~8–16 indexers at once and pinned the machine. A new
+  daemon-wide **index-concurrency gate** now bounds concurrent module/repo index
+  operations to `GRAFEL_INDEX_CONCURRENCY` (**default 2**); excess indexes queue
+  FIFO and run as slots free, so a 30-module group drains 2-at-a-time. One slot is
+  reserved for foreground/interactive index so a background storm can't starve it
+  (#5328). `grafel_index_status` now reports the gate's `concurrency` block
+  (`indexing` / `queued` / `cap`) so a draining group reads "indexing 2, queued 28"
+  instead of looking stalled.
+
 ---
 
 ## [0.1.4] — 2026-06-24

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -55,6 +55,17 @@ import (
 // created once in runDaemon before the RPC + dashboard servers start.
 var daemonProgressBroker = progress.NewBroker()
 
+// daemonIndexGate is the process-wide index-concurrency gate (#5493). Every
+// per-module/per-repo index dispatched by the rebuild fan-out drains through it,
+// so a group/monorepo with many modules indexes at most GRAFEL_INDEX_CONCURRENCY
+// (default 2) at a time instead of all-at-once — the fix for the 30-module
+// monorepo storm. The rebuild worker pool may still SIZE itself to the larger
+// memory-auto-tuned cap, but this gate is the real throttle on simultaneous
+// indexes; the per-index core cap (GRAFEL_EXTRACT_GOMAXPROCS) only bounds cores
+// WITHIN one index. One slot is reserved for foreground/interactive index so a
+// background storm cannot lock it out (#5328).
+var daemonIndexGate = daemon.NewIndexGateFromEnv()
+
 // daemonActivityBroker is the process-wide MCP activity broker, captured at
 // dashboard wiring time so the graceful-stop path (ShutdownCleanup) can flush
 // and close its disk log handle (~/.grafel/mcp-activity.jsonl) before anything
@@ -1028,7 +1039,12 @@ type repoWork struct {
 // it fires even if the goroutine panics after launch but before acquiring the
 // slot — in that rare edge the slot is simply never acquired and the result
 // slot stays at its zero value.
-func rebuildWorkerPool(conc int, work []repoWork, workFn func(idx int, rw repoWork) repoResult) []repoResult {
+// gate, when non-nil, is the daemon-wide index-concurrency gate (#5493). Every
+// work item additionally acquires a gate slot before running, so concurrent
+// indexes are bounded by min(conc, gate.Cap()) — in practice the gate (default
+// 2) is the tighter throttle. foreground requests priority + the reserved slot.
+// nil disables the gate (tests / legacy paths).
+func rebuildWorkerPool(conc int, work []repoWork, workFn func(idx int, rw repoWork) repoResult, gate *daemon.IndexGate, foreground bool) []repoResult {
 	results := make([]repoResult, len(work))
 	sem := make(chan struct{}, conc)
 	var wg sync.WaitGroup
@@ -1037,10 +1053,22 @@ func rebuildWorkerPool(conc int, work []repoWork, workFn func(idx int, rw repoWo
 		go func(idx int, rw repoWork) {
 			defer wg.Done()
 
-			// Acquire semaphore slot. This MUST come before any panic-recovery
+			// Acquire the local pool slot. This MUST come before any panic-recovery
 			// defer so the defer's <-sem only fires once the slot is actually held.
 			sem <- struct{}{}
 			defer func() { <-sem }()
+
+			// #5493: also drain through the daemon-wide index-concurrency gate so
+			// a many-module group cannot run more than GRAFEL_INDEX_CONCURRENCY
+			// indexes at once, regardless of the (larger) local pool size. Excess
+			// items block here and run as slots free.
+			if gate != nil {
+				if err := gate.Acquire(context.Background(), foreground); err != nil {
+					results[idx] = repoResult{path: rw.r.Path, slug: rw.r.Slug, err: err}
+					return
+				}
+				defer gate.Release()
+			}
 
 			results[idx] = workFn(idx, rw)
 		}(i, w)
@@ -1190,16 +1218,21 @@ func daemonRebuildFuncCore(
 		}
 	}
 
+	// #5493: a single-slug rebuild is an interactive/foreground request (e.g.
+	// `grafel rebuild <slug>`); a whole-group rebuild is background cold-start /
+	// forced-rebuild fan-out. Foreground acquisitions get priority + the reserved
+	// gate slot so they aren't starved behind a many-module background storm.
+	foreground := args.Slug != ""
+
 	var results []repoResult
 	if conc == 1 || len(work) <= 1 {
-		// --- Serial path ---
-		results = make([]repoResult, len(work))
-		for i, w := range work {
-			results[i] = indexOne(i, w)
-		}
+		// --- Serial path ---. Each repo still drains through the daemon-wide
+		// gate so that even serial group rebuilds running concurrently (up to
+		// MaxConcurrentGroups) cannot collectively exceed GRAFEL_INDEX_CONCURRENCY.
+		results = rebuildWorkerPool(1, work, indexOne, daemonIndexGate, foreground)
 	} else {
 		// --- Parallel path: delegate to rebuildWorkerPool ---
-		results = rebuildWorkerPool(conc, work, indexOne)
+		results = rebuildWorkerPool(conc, work, indexOne, daemonIndexGate, foreground)
 	}
 
 	// Collect successful paths; log per-repo wall time; gather errors.

--- a/internal/daemon/index_concurrency.go
+++ b/internal/daemon/index_concurrency.go
@@ -1,0 +1,243 @@
+// index_concurrency.go — the daemon-wide index-concurrency gate (#5493).
+//
+// PROBLEM. When a group/monorepo with many modules is registered or rebuilt,
+// the rebuild fan-out (cmd/grafel: rebuildWorkerPool) used to index every module
+// up to the memory-auto-tuned rebuild cap (8 on a 16GB host, 16 on 32GB). The
+// per-index core cap (GRAFEL_EXTRACT_GOMAXPROCS, default 2) bounds cores PER
+// index but NOT the number of concurrent indexes — so a 30-module group spun up
+// ~8-16 indexers at once × 2 cores = 16-32 cores of pressure and pinned the
+// machine (real user report: 30-module monorepo storm).
+//
+// FIX. A single process-wide IndexGate bounds the number of module/repo index
+// operations that may run CONCURRENTLY to N (default 2, env
+// GRAFEL_INDEX_CONCURRENCY). Excess index operations block in Acquire and run as
+// slots free, so a 30-module group drains 2-at-a-time instead of 30-at-once.
+// Acquisition is FIFO (a ticket queue) so a long backlog cannot starve early
+// arrivals, and one slot is RESERVED for foreground/interactive work so a burst
+// of background reindexes can never lock an interactive index out (#5328).
+//
+// The gate publishes its active/queued counts to the indexstate leaf package so
+// `grafel status` and grafel_index_status can show "indexing 2, queued 28".
+package daemon
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// IndexConcurrencyEnv is the env var that overrides the default concurrency cap.
+const IndexConcurrencyEnv = "GRAFEL_INDEX_CONCURRENCY"
+
+// defaultIndexConcurrency is the safe default for the foreground+background mix:
+// 2 concurrent indexes × ~2 cores each (GRAFEL_EXTRACT_GOMAXPROCS) ≈ 4 cores of
+// pressure, which leaves headroom on a typical machine. The old rebuild cap of 8
+// (× 2 cores = 16) oversubscribed; 2 is the storm-safe default.
+const defaultIndexConcurrency = 2
+
+// resolveIndexConcurrency returns the effective concurrency cap, honoring
+// GRAFEL_INDEX_CONCURRENCY (a positive integer). An unset, non-numeric, or
+// non-positive value falls back to defaultIndexConcurrency.
+func resolveIndexConcurrency() int {
+	if v := os.Getenv(IndexConcurrencyEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 1 {
+			return n
+		}
+	}
+	return defaultIndexConcurrency
+}
+
+// IndexGate is a fair, FIFO, daemon-wide semaphore bounding how many module/repo
+// index operations run concurrently (#5493). It is the single throttle for the
+// group/monorepo module fan-out: callers wrap each per-module index in
+// Acquire/Release (or the Run helper) and the gate ensures at most cap run at
+// once, the rest queueing.
+//
+// Foreground priority: foreground (interactive) acquisitions are served ahead of
+// background ones at the head of the queue, and one slot is reserved so the
+// background fan-out can never consume every slot and lock foreground out. With
+// the default cap of 2 this means background uses at most cap-1=1 slot until a
+// foreground acquirer is satisfied, then both can run.
+type IndexGate struct {
+	cap int
+
+	mu        sync.Mutex
+	active    int      // slots currently held
+	fg        []chan struct{} // FIFO of waiting foreground tickets
+	bg        []chan struct{} // FIFO of waiting background tickets
+}
+
+// NewIndexGate constructs a gate with the given cap. A cap <= 0 is coerced to 1
+// (fully serial) so the gate is never a no-op.
+func NewIndexGate(cap int) *IndexGate {
+	if cap < 1 {
+		cap = 1
+	}
+	g := &IndexGate{cap: cap}
+	g.publish()
+	return g
+}
+
+// NewIndexGateFromEnv constructs a gate sized from GRAFEL_INDEX_CONCURRENCY
+// (default 2). This is the production constructor.
+func NewIndexGateFromEnv() *IndexGate {
+	return NewIndexGate(resolveIndexConcurrency())
+}
+
+// Cap returns the configured concurrency limit.
+func (g *IndexGate) Cap() int { return g.cap }
+
+// Stats returns the current (active, queued) counts. Queued is the total of
+// foreground + background waiters.
+func (g *IndexGate) Stats() (active, queued int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.active, len(g.fg) + len(g.bg)
+}
+
+// reserveForForeground is how many slots are held back from background work so a
+// foreground acquirer is never fully locked out by a background storm (#5328).
+// With cap>=2 we reserve exactly one; with cap==1 we cannot reserve (serial).
+func (g *IndexGate) reserveForForeground() int {
+	if g.cap >= 2 {
+		return 1
+	}
+	return 0
+}
+
+// Acquire blocks until a slot is free (respecting foreground priority and the
+// reserved foreground slot), then returns. The caller MUST call Release exactly
+// once when its index operation completes. It honors ctx: if ctx is cancelled
+// while waiting, Acquire returns ctx.Err() and holds no slot.
+//
+// foreground=true requests an interactive/priority acquisition: it jumps ahead
+// of queued background work and may use the reserved slot.
+func (g *IndexGate) Acquire(ctx context.Context, foreground bool) error {
+	g.mu.Lock()
+	if g.canAdmitLocked(foreground) {
+		g.active++
+		g.publishLocked()
+		g.mu.Unlock()
+		return nil
+	}
+	// No slot: enqueue a ticket and wait.
+	ticket := make(chan struct{})
+	if foreground {
+		g.fg = append(g.fg, ticket)
+	} else {
+		g.bg = append(g.bg, ticket)
+	}
+	g.publishLocked()
+	g.mu.Unlock()
+
+	select {
+	case <-ticket:
+		// Woken with a slot already charged to us by Release.
+		return nil
+	case <-ctx.Done():
+		// Cancelled while waiting. Remove our ticket if it's still queued; if it
+		// was already signalled (slot charged), hand the slot back via Release.
+		g.mu.Lock()
+		if g.removeTicketLocked(ticket, foreground) {
+			// Still queued — we never got a slot.
+			g.publishLocked()
+			g.mu.Unlock()
+			return ctx.Err()
+		}
+		// Already signalled between ctx.Done and acquiring the lock: a slot was
+		// charged to us. Release it so it isn't leaked.
+		g.mu.Unlock()
+		g.Release()
+		return ctx.Err()
+	}
+}
+
+// canAdmitLocked reports whether an acquirer of the given priority may take a
+// slot right now. Background acquirers must leave the reserved foreground slot
+// free; foreground acquirers may use the full cap. MUST hold g.mu.
+func (g *IndexGate) canAdmitLocked(foreground bool) bool {
+	limit := g.cap
+	if !foreground {
+		// Background can only use slots beyond the foreground reservation IF a
+		// foreground acquirer is actually waiting; otherwise background may use
+		// the whole cap (no point idling a slot when no foreground wants it).
+		if len(g.fg) > 0 {
+			limit -= g.reserveForForeground()
+		}
+	}
+	return g.active < limit
+}
+
+// Release frees one slot and wakes the next eligible waiter (foreground first,
+// FIFO within a class). MUST be paired with a successful Acquire.
+func (g *IndexGate) Release() {
+	g.mu.Lock()
+	if g.active > 0 {
+		g.active--
+	}
+	g.wakeLocked()
+	g.publishLocked()
+	g.mu.Unlock()
+}
+
+// wakeLocked promotes queued waiters into freed slots: all eligible foreground
+// tickets first (FIFO), then background tickets (FIFO) subject to the reserved
+// slot. MUST hold g.mu. Each promoted ticket has a slot charged to it (active++)
+// before being signalled, so the woken goroutine returns holding the slot.
+func (g *IndexGate) wakeLocked() {
+	for len(g.fg) > 0 && g.active < g.cap {
+		t := g.fg[0]
+		g.fg = g.fg[1:]
+		g.active++
+		close(t)
+	}
+	for len(g.bg) > 0 && g.canAdmitLocked(false) {
+		t := g.bg[0]
+		g.bg = g.bg[1:]
+		g.active++
+		close(t)
+	}
+}
+
+// removeTicketLocked removes a still-queued ticket. Returns true if the ticket
+// was found in the queue (i.e. it had NOT been signalled yet). MUST hold g.mu.
+func (g *IndexGate) removeTicketLocked(ticket chan struct{}, foreground bool) bool {
+	q := &g.bg
+	if foreground {
+		q = &g.fg
+	}
+	for i, t := range *q {
+		if t == ticket {
+			*q = append((*q)[:i], (*q)[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// Run acquires a slot, invokes fn, and releases the slot — the convenience
+// wrapper around Acquire/Release for the common case. If Acquire fails (ctx
+// cancelled while queued) it returns that error and does NOT call fn.
+func (g *IndexGate) Run(ctx context.Context, foreground bool, fn func() error) error {
+	if err := g.Acquire(ctx, foreground); err != nil {
+		return err
+	}
+	defer g.Release()
+	return fn()
+}
+
+// publish mirrors the current counts to indexstate (no lock held).
+func (g *IndexGate) publish() {
+	g.mu.Lock()
+	g.publishLocked()
+	g.mu.Unlock()
+}
+
+// publishLocked mirrors the current counts to the indexstate leaf package so the
+// MCP/status surfaces can read "indexing N, queued M". MUST hold g.mu.
+func (g *IndexGate) publishLocked() {
+	indexstate.SetIndexConcurrency(g.active, len(g.fg)+len(g.bg), g.cap)
+}

--- a/internal/daemon/index_concurrency_test.go
+++ b/internal/daemon/index_concurrency_test.go
@@ -1,0 +1,209 @@
+package daemon
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestIndexGateCapsConcurrency is the core #5493 guarantee: with cap=2, enqueue
+// M index requests → at most 2 run concurrently, and all M eventually complete.
+func TestIndexGateCapsConcurrency(t *testing.T) {
+	const cap = 2
+	const m = 30
+	g := NewIndexGate(cap)
+
+	var cur, peak int64
+	var completed int64
+	var wg sync.WaitGroup
+	start := make(chan struct{}) // release all goroutines at once to maximize contention
+
+	for i := 0; i < m; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			err := g.Run(context.Background(), false, func() error {
+				n := atomic.AddInt64(&cur, 1)
+				for {
+					p := atomic.LoadInt64(&peak)
+					if n <= p || atomic.CompareAndSwapInt64(&peak, p, n) {
+						break
+					}
+				}
+				// Hold the slot briefly so concurrency actually overlaps.
+				time.Sleep(2 * time.Millisecond)
+				atomic.AddInt64(&cur, -1)
+				atomic.AddInt64(&completed, 1)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("Run returned error: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&peak); got > cap {
+		t.Fatalf("peak concurrency = %d, want <= %d", got, cap)
+	}
+	if got := atomic.LoadInt64(&completed); got != m {
+		t.Fatalf("completed = %d, want %d (all must eventually run)", got, m)
+	}
+	// Gate must be fully drained afterwards.
+	active, queued := g.Stats()
+	if active != 0 || queued != 0 {
+		t.Fatalf("after drain: active=%d queued=%d, want 0/0", active, queued)
+	}
+}
+
+// TestIndexGateFIFOOrder verifies roughly-FIFO admission within a priority class:
+// with cap=1, requests acquired in order 0..N complete in that same order.
+func TestIndexGateFIFOOrder(t *testing.T) {
+	const n = 8
+	g := NewIndexGate(1)
+
+	// Acquire the only slot up front so every request below must queue.
+	if err := g.Acquire(context.Background(), false); err != nil {
+		t.Fatalf("initial acquire: %v", err)
+	}
+
+	var mu sync.Mutex
+	var order []int
+	var started sync.WaitGroup
+	var done sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		started.Add(1)
+		done.Add(1)
+		go func(idx int) {
+			// Stagger enqueue so tickets queue in a deterministic order.
+			time.Sleep(time.Duration(idx) * 2 * time.Millisecond)
+			started.Done()
+			_ = g.Run(context.Background(), false, func() error {
+				mu.Lock()
+				order = append(order, idx)
+				mu.Unlock()
+				return nil
+			})
+			done.Done()
+		}(i)
+	}
+	// Wait until all are queued, then release the held slot to drain them FIFO.
+	started.Wait()
+	time.Sleep(20 * time.Millisecond) // let the last enqueues settle into the queue
+	g.Release()
+	done.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != n {
+		t.Fatalf("completed %d, want %d", len(order), n)
+	}
+	for i, v := range order {
+		if v != i {
+			t.Fatalf("order = %v, want FIFO 0..%d", order, n-1)
+		}
+	}
+}
+
+// TestIndexGateForegroundNotStarved verifies the reserved-slot guarantee
+// (#5328): a foreground acquirer is admitted promptly even while a background
+// storm holds every non-reserved slot.
+func TestIndexGateForegroundNotStarved(t *testing.T) {
+	const cap = 2
+	g := NewIndexGate(cap)
+
+	// Background work fills the non-reserved slots and holds them.
+	release := make(chan struct{})
+	var bgHeld sync.WaitGroup
+	// With cap=2 and a 1-slot foreground reservation, background may take cap=2
+	// while no foreground waits; once a foreground waiter appears, background is
+	// limited to cap-1=1. To make the test deterministic, hold cap slots first.
+	for i := 0; i < cap; i++ {
+		bgHeld.Add(1)
+		go func() {
+			_ = g.Acquire(context.Background(), false)
+			bgHeld.Done()
+			<-release
+			g.Release()
+		}()
+	}
+	bgHeld.Wait()
+
+	// Now a foreground acquirer queues. Release ONE background slot; the reserved
+	// slot must let the foreground acquirer in ahead of any further background.
+	fgGot := make(chan struct{})
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := g.Acquire(ctx, true); err != nil {
+			t.Errorf("foreground acquire failed/timed out: %v", err)
+			return
+		}
+		close(fgGot)
+		g.Release()
+	}()
+
+	// Free up one slot for the foreground acquirer.
+	release <- struct{}{}
+
+	select {
+	case <-fgGot:
+		// good — foreground got in promptly
+	case <-time.After(2 * time.Second):
+		t.Fatal("foreground acquirer was starved")
+	}
+	// Drain the rest.
+	close(release)
+}
+
+// TestIndexGateContextCancelDequeues verifies a queued acquirer that is
+// cancelled releases its ticket and holds no slot.
+func TestIndexGateContextCancelDequeues(t *testing.T) {
+	g := NewIndexGate(1)
+	if err := g.Acquire(context.Background(), false); err != nil {
+		t.Fatalf("initial acquire: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- g.Acquire(ctx, false) }()
+	// Give the goroutine time to enqueue.
+	time.Sleep(20 * time.Millisecond)
+	if _, queued := g.Stats(); queued != 1 {
+		t.Fatalf("queued = %d, want 1", queued)
+	}
+	cancel()
+	if err := <-errCh; err == nil {
+		t.Fatal("cancelled Acquire returned nil, want ctx error")
+	}
+	// The held slot is still ours; release it and the gate is empty.
+	g.Release()
+	if active, queued := g.Stats(); active != 0 || queued != 0 {
+		t.Fatalf("after cancel+release: active=%d queued=%d, want 0/0", active, queued)
+	}
+}
+
+// TestResolveIndexConcurrencyDefault verifies the default and env override.
+func TestResolveIndexConcurrencyDefault(t *testing.T) {
+	t.Setenv(IndexConcurrencyEnv, "")
+	if got := resolveIndexConcurrency(); got != defaultIndexConcurrency {
+		t.Fatalf("default = %d, want %d", got, defaultIndexConcurrency)
+	}
+	t.Setenv(IndexConcurrencyEnv, "5")
+	if got := resolveIndexConcurrency(); got != 5 {
+		t.Fatalf("env override = %d, want 5", got)
+	}
+	t.Setenv(IndexConcurrencyEnv, "0")
+	if got := resolveIndexConcurrency(); got != defaultIndexConcurrency {
+		t.Fatalf("non-positive env = %d, want default %d", got, defaultIndexConcurrency)
+	}
+	t.Setenv(IndexConcurrencyEnv, "garbage")
+	if got := resolveIndexConcurrency(); got != defaultIndexConcurrency {
+		t.Fatalf("garbage env = %d, want default %d", got, defaultIndexConcurrency)
+	}
+}

--- a/internal/indexstate/indexstate.go
+++ b/internal/indexstate/indexstate.go
@@ -32,7 +32,56 @@ var (
 	// Tracked separately from index jobs so is_indexing reflects a background
 	// group-algo pass without conflating it with a reactive reindex count.
 	groupAlgoInFlight atomic.Int64
+
+	// indexConcActive / indexConcQueued mirror the daemon-wide index-concurrency
+	// gate (#5493): how many module/repo index operations are running right now
+	// vs. waiting for a free slot. They let `grafel status` / grafel_index_status
+	// surface "indexing N, queued M" so a 30-module group draining 2-at-a-time is
+	// visible rather than looking stalled. Written by the gate, read lock-free.
+	indexConcActive atomic.Int64
+	indexConcQueued atomic.Int64
+	indexConcCap    atomic.Int64
 )
+
+// SetIndexConcurrency publishes the daemon-wide index-concurrency gate's current
+// active/queued counts and its configured cap (#5493). Called by the gate on
+// every acquire/release. Negative values are clamped to 0. Safe to call from any
+// goroutine.
+func SetIndexConcurrency(active, queued, cap int) {
+	if active < 0 {
+		active = 0
+	}
+	if queued < 0 {
+		queued = 0
+	}
+	if cap < 0 {
+		cap = 0
+	}
+	indexConcActive.Store(int64(active))
+	indexConcQueued.Store(int64(queued))
+	indexConcCap.Store(int64(cap))
+}
+
+// IndexConcurrency is a point-in-time view of the daemon-wide index-concurrency
+// gate (#5493).
+type IndexConcurrency struct {
+	// Active is the number of index operations currently holding a gate slot.
+	Active int
+	// Queued is the number of index operations waiting for a slot to free.
+	Queued int
+	// Cap is the configured concurrency limit (GRAFEL_INDEX_CONCURRENCY).
+	Cap int
+}
+
+// GetIndexConcurrency returns the current gate counts. Lock-free; safe from an
+// MCP request handler.
+func GetIndexConcurrency() IndexConcurrency {
+	return IndexConcurrency{
+		Active: int(indexConcActive.Load()),
+		Queued: int(indexConcQueued.Load()),
+		Cap:    int(indexConcCap.Load()),
+	}
+}
 
 // Per-repo index freshness (#5433). The scheduler is the single writer; it
 // publishes a defensive copy of its per-repo state under its own lock via

--- a/internal/mcp/index_status.go
+++ b/internal/mcp/index_status.go
@@ -38,6 +38,20 @@ type indexStatusReply struct {
 	// should NOT use this — it should check its repo's state==current — but it
 	// is a convenient summary when no filter is set.
 	AnyIndexing bool `json:"any_indexing"`
+	// Concurrency mirrors the daemon-wide index-concurrency gate (#5493) so a
+	// caller can see how a many-module group is draining: "indexing N, queued M"
+	// with a cap of GRAFEL_INDEX_CONCURRENCY. Reported regardless of any filter.
+	Concurrency indexConcurrency `json:"concurrency"`
+}
+
+// indexConcurrency is the wire shape for the gate counts (#5493).
+type indexConcurrency struct {
+	// Active is the number of module/repo indexes running concurrently right now.
+	Active int `json:"indexing"`
+	// Queued is the number of indexes waiting for a free slot.
+	Queued int `json:"queued"`
+	// Cap is the configured concurrency limit (GRAFEL_INDEX_CONCURRENCY).
+	Cap int `json:"cap"`
 }
 
 // handleIndexStatus answers grafel_index_status. Optional args:
@@ -83,6 +97,10 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 			out.AnyIndexing = true
 		}
 	}
+	// #5493: surface the daemon-wide gate counts so "indexing 2, queued 28" is
+	// visible (a 30-module group draining 2-at-a-time, not stalled).
+	ic := indexstate.GetIndexConcurrency()
+	out.Concurrency = indexConcurrency{Active: ic.Active, Queued: ic.Queued, Cap: ic.Cap}
 	return jsonResult(out), nil
 }
 


### PR DESCRIPTION
Closes #5493.

## Problem

When a group/monorepo with many modules is registered or rebuilt, the daemon indexed every module at once. The rebuild fan-out (`rebuildWorkerPool`) ran up to the memory-auto-tuned rebuild cap — `min(16, sysMB/2048)` floored at 2, i.e. **8 on a 16 GB host, 16 on 32 GB** (this is the `in_flight=N / cap=8` the status RPC reports). The per-index core cap `GRAFEL_EXTRACT_GOMAXPROCS` (default 2) bounds cores *within* one index but **not the number of concurrent indexes**, so a 30-module group spun up ~8–16 indexers × 2 cores = 16–32 cores of pressure and pinned the machine (real user report).

## Fix

A new daemon-wide **index-concurrency gate** (`internal/daemon`: `IndexGate`) bounds concurrent module/repo index operations to `GRAFEL_INDEX_CONCURRENCY` (**default 2**). Excess indexes queue **FIFO** and run as slots free, so a 30-module group drains 2-at-a-time instead of 30-at-once.

- **Reconciled with the existing cap, not parallel to it.** The rebuild worker pool may still *size* itself to the larger memory-auto-tuned value, but every per-module index now also drains through this gate, which is the tighter (default 2) throttle on simultaneous indexes. 8 concurrent × 2 cores oversubscribes a typical machine; 2 is the safe default for the foreground+background mix.
- **Foreground not starved (#5328).** Acquisition is fair; foreground/interactive acquirers get priority + one **reserved slot** so a background module storm can never lock interactive index out. A single-slug `grafel rebuild <slug>` acquires foreground; whole-group cold-start/forced rebuild acquires background.
- **Surfacing.** Active/queued/cap counts are published to `indexstate` and exposed in `grafel_index_status` as a `concurrency` block (`indexing` / `queued` / `cap`), so a draining group reads "indexing 2, queued 28" rather than looking stalled.

## Tests

`internal/daemon/index_concurrency_test.go`:
- cap=2, enqueue 30 → peak concurrency ≤ 2, all 30 complete, gate drains to 0/0
- FIFO order within a priority class
- foreground acquirer admitted promptly while background holds every slot (reserved-slot guarantee)
- ctx-cancel dequeues a waiter cleanly (holds no slot)
- env default / override / non-positive / garbage parsing

`go test -count=1 ./internal/daemon/...` and the indexstate + mcp index_status/schema tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)