### PR TITLE
fix(install): copy bundled skills to the Claude skills dir on install (macOS + cross-platform)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Fixed
+- **Install now ships the bundled skills, not just the MCP (#5503):** on a
+  released-tarball install (the common path on macOS) the `grafel` binary lands
+  on its own with no `skills/` directory beside it, so `grafel install` found no
+  on-disk skills source, silently skipped the skills step, and registered only
+  the MCP server — leaving users with the grafel MCP tools but none of the
+  `/grafel-*` slash-command skills. The skills are now **embedded in the binary**
+  (single source of truth stays the repo-root `skills/` tree) and skill discovery
+  falls back to materialising them into a stable `~/.grafel/skills-cache` when no
+  on-disk source exists, so `install` copies the full skill set into every
+  detected Claude config's `skills/` dir on macOS, Linux, and Windows alike. A
+  dev/repo checkout still uses the live on-disk tree; the embedded copy is only
+  the last-resort fallback. The copy is idempotent (re-install overwrites
+  cleanly) and `grafel uninstall` removes the installed skills, mirroring the MCP
+  deregistration. All home-derived paths honour `$HOME` consistently with the MCP
+  registration.
 - **Index-concurrency cap — no more all-at-once monorepo storms (#5493):** when a
   group/monorepo with many modules was registered or rebuilt, the daemon indexed
   every module up to the memory-auto-tuned rebuild cap (8 on a 16 GB host, 16 on

--- a/embedassets.go
+++ b/embedassets.go
@@ -1,0 +1,25 @@
+// Package grafelassets embeds repo-root asset trees that ship inside the
+// grafel binary so they are available even when grafel is installed from a
+// released tarball that contains only the executable (no repo checkout
+// alongside it).
+//
+// Today this carries the user-invocable grafel skills (the /grafel-* slash
+// commands). They live at the repo root in skills/ — the single source of
+// truth — and are embedded here so `grafel install` can materialise them on a
+// binary-only install where there is no on-disk skills/ directory next to the
+// binary to copy from (issue #5503).
+//
+// go:embed paths cannot traverse "..", so the only package that can embed the
+// repo-root skills/ tree directly is one rooted at the module root. This file
+// is that package; the install lifecycle consumes SkillsFS via
+// internal/install/skilllink.
+package grafelassets
+
+import "embed"
+
+// SkillsFS holds the bundled grafel skills, rooted so that paths look like
+// "skills/<skill-name>/...". The "all:" prefix ensures dotfiles and files in
+// otherwise-ignored directories are embedded too.
+//
+//go:embed all:skills
+var SkillsFS embed.FS

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -437,21 +437,25 @@ func assertGitignoreEntry(t *testing.T, repoRoot string) {
 	t.Errorf(".gitignore does not contain /.grafel/; content: %q", string(data))
 }
 
-// TestRunCopy_MissingSkillsDirectory_GracefulDegrade verifies that when the
-// skills directory cannot be discovered, RunCopy WARNS and CONTINUES rather
-// than hard-failing (#4460): the install still succeeds, the daemon/MCP steps
-// proceed, and the persisted state records SkillsSkipped=true. The daemon must
-// be installable from a brand-new binary-only checkout with no skills source.
-func TestRunCopy_MissingSkillsDirectory_GracefulDegrade(t *testing.T) {
+// TestRunCopy_NoOnDiskSkills_EmbeddedFallbackInstalls verifies the #5503 fix:
+// when no skills/ directory can be discovered on disk (a brand-new binary-only
+// install — the macOS released-tarball case), RunCopy now falls back to the
+// skills EMBEDDED in the binary and installs them, while the daemon/MCP steps
+// still proceed. Skills are NOT skipped (the pre-#5503 behaviour, where the
+// user got the MCP but none of the skills).
+//
+// The #4460 "install never hard-fails on a missing skills source" guarantee is
+// preserved: even though discovery finds no on-disk tree, the install succeeds.
+func TestRunCopy_NoOnDiskSkills_EmbeddedFallbackInstalls(t *testing.T) {
 	env := newTestEnv(t)
 
 	// Ensure the env-var discovery path can't accidentally satisfy discovery.
 	t.Setenv("GRAFEL_SKILLS_DIR", "")
 
 	// Place the binary in an isolated dir with NO skills/ anywhere on its
-	// sibling/one-up/ancestor path, so discovery genuinely fails (a brand-new
-	// binary-only install). env.fakeBin lives next to env.skillsSourceDir and
-	// would be found via the sibling/ancestor walk.
+	// sibling/one-up/ancestor path, so on-disk discovery genuinely misses and
+	// the embedded fallback is what provides the skills. env.fakeBin lives next
+	// to env.skillsSourceDir and would be found via the sibling/ancestor walk.
 	isoBinDir := filepath.Join(t.TempDir(), "iso", "bin")
 	if err := os.MkdirAll(isoBinDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -479,13 +483,13 @@ func TestRunCopy_MissingSkillsDirectory_GracefulDegrade(t *testing.T) {
 
 	result, err := install.RunCopy(opts)
 	if err != nil {
-		t.Fatalf("expected graceful degrade (no error) when skills dir missing, got: %v", err)
+		t.Fatalf("expected success via embedded fallback when on-disk skills missing, got: %v", err)
 	}
-	if len(result.SkillsInstalled) != 0 {
-		t.Errorf("expected no skills installed, got %v", result.SkillsInstalled)
+	if len(result.SkillsInstalled) == 0 {
+		t.Error("expected embedded skills to install when no on-disk source exists (#5503)")
 	}
 	if !restartCalled {
-		t.Error("expected daemon restart (step 4) to run after skills were skipped")
+		t.Error("expected daemon restart (step 4) to run")
 	}
 	if result.DaemonVersion != "test-daemon-v0" {
 		t.Errorf("expected daemon to be installed, got version %q", result.DaemonVersion)
@@ -493,19 +497,30 @@ func TestRunCopy_MissingSkillsDirectory_GracefulDegrade(t *testing.T) {
 
 	// MCP must still be registered.
 	if len(result.MCPPaths) == 0 {
-		t.Error("expected MCP registration to proceed even though skills were skipped")
+		t.Error("expected MCP registration to proceed")
 	}
 
-	// State must record the skip.
+	// State must record the skills (not a skip) and a complete install.
 	state, err := install.ReadState(env.statePath)
 	if err != nil {
 		t.Fatalf("read state: %v", err)
 	}
-	if !state.SkillsSkipped {
-		t.Error("expected state.SkillsSkipped=true after graceful skills skip")
+	if state.SkillsSkipped {
+		t.Error("expected state.SkillsSkipped=false now that embedded skills install (#5503)")
+	}
+	if len(state.Skills) == 0 {
+		t.Error("expected state.Skills to record the installed embedded skills")
 	}
 	if state.PartialInstall {
-		t.Error("expected a graceful skills-skip to NOT mark the install partial")
+		t.Error("expected a successful install to NOT be marked partial")
+	}
+
+	// The skill files must physically exist under the resolved Claude skills dir.
+	skillsDest := skilllink.ClaudeSkillsDirForConfig(env.claudeJSON)
+	for _, name := range skilllink.SkillNames {
+		if _, serr := os.Stat(filepath.Join(skillsDest, name, "SKILL.md")); serr != nil {
+			t.Errorf("embedded skill %s/SKILL.md missing after install: %v", name, serr)
+		}
 	}
 }
 

--- a/internal/install/skilllink/skilllink.go
+++ b/internal/install/skilllink/skilllink.go
@@ -13,9 +13,12 @@ package skilllink
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+
+	grafelassets "github.com/cajasmota/grafel"
 )
 
 // SkillNames lists the 15 user-invocable grafel skills in canonical order.
@@ -142,9 +145,15 @@ func PruneOrphanSkillSymlinks(out io.Writer, skillsSubdir string) {
 //  5. Walk up ancestor directories from dirname(binPath) up to 5 levels,
 //     checking <ancestor>/skills at each level — handles arbitrary repo layouts
 //     such as repo/build/grafel + repo/skills
+//  6. Fall back to the skills EMBEDDED in the binary (#5503): materialise the
+//     bundled skills/ tree into a stable on-disk cache and return that path.
+//     This is what makes `grafel install` work for a released-tarball,
+//     binary-only install where no skills/ directory exists next to the binary
+//     (the macOS symptom in #5503). Steps 1–5 still win when a real on-disk
+//     source is present (so a dev checkout always uses the live tree).
 //
-// Returns "" if none of the locations exist, which signals the caller to
-// error or skip the step.
+// Returns "" only if every source — including the embedded fallback — is
+// unavailable, which signals the caller to error or skip the step.
 //
 // DiscoverSkillsDir is a thin wrapper over DiscoverSkillsDirVerbose that
 // discards the list of attempted paths.
@@ -224,7 +233,104 @@ func DiscoverSkillsDirVerbose(binPath, skillsSourceDir string) (string, []string
 		}
 	}
 
+	// Final fallback (#5503): no on-disk skills/ source was found next to the
+	// binary or in any ancestor. This is the normal situation for a released
+	// tarball install (the binary ships alone). Materialise the skills that are
+	// embedded in the binary into a stable cache dir and use that. This is what
+	// fixes the macOS symptom where MCP registered but no skills landed.
+	if p, err := MaterializeEmbeddedSkills(); err == nil && p != "" {
+		attempted = append(attempted, fmt.Sprintf("embedded: %s", p))
+		return p, attempted
+	} else if err != nil {
+		attempted = append(attempted, fmt.Sprintf("embedded: %v", err))
+	}
+
 	return "", attempted
+}
+
+// embeddedSkillsCacheDir returns the stable on-disk location where the
+// binary-embedded skills are materialised: $HOME/.grafel/skills-cache.
+// It honours HOME on every platform so tests and sidecar HOMEs resolve
+// consistently with the rest of the install lifecycle (DefaultStatePath,
+// MCP registration). XDG is intentionally not consulted here because the
+// grafel state root is HOME/.grafel everywhere.
+func embeddedSkillsCacheDir() (string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		home = h
+	}
+	return filepath.Join(home, ".grafel", "skills-cache"), nil
+}
+
+// MaterializeEmbeddedSkills extracts the skills bundled into the binary
+// (grafelassets.SkillsFS, embedded from the repo-root skills/ tree) into a
+// stable cache directory and returns that directory's path.
+//
+// The returned directory contains one subdirectory per skill (matching the
+// SkillNames the rest of the install lifecycle copies/symlinks from), so it is
+// a drop-in replacement for an on-disk skills/ source.
+//
+// It is idempotent: a file is only rewritten when its content differs from the
+// embedded copy, so re-installs are cheap and re-materialisation is a no-op
+// when nothing changed (e.g. same binary version).
+func MaterializeEmbeddedSkills() (string, error) {
+	cacheDir, err := embeddedSkillsCacheDir()
+	if err != nil {
+		return "", err
+	}
+	// Walk the embedded "skills" tree and mirror it under cacheDir. The embed
+	// FS roots paths at "skills/...", so we strip that prefix and write the
+	// remainder under cacheDir.
+	const root = "skills"
+	walkErr := fs.WalkDir(grafelassets.SkillsFS, root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(cacheDir, 0o755)
+		}
+		dst := filepath.Join(cacheDir, filepath.FromSlash(rel))
+		if d.IsDir() {
+			return os.MkdirAll(dst, 0o755)
+		}
+		data, err := grafelassets.SkillsFS.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		// Idempotent write: skip if the on-disk file already matches.
+		if existing, rerr := os.ReadFile(dst); rerr == nil && bytesEqual(existing, data) {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(dst, data, 0o644)
+	})
+	if walkErr != nil {
+		return "", fmt.Errorf("materialise embedded skills into %s: %w", cacheDir, walkErr)
+	}
+	return cacheDir, nil
+}
+
+// bytesEqual is a tiny helper avoiding a bytes import for one comparison.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // InstallSkillsInClaudeConfigs symlinks the grafel skills into every

--- a/internal/install/skilllink/skilllink_test.go
+++ b/internal/install/skilllink/skilllink_test.go
@@ -30,10 +30,16 @@ func TestDiscoverSkillsDir(t *testing.T) {
 		}
 	})
 
-	t.Run("explicit skillsSourceDir that does not exist returns empty", func(t *testing.T) {
+	t.Run("explicit skillsSourceDir that does not exist falls back to embedded", func(t *testing.T) {
+		// A bad explicit flag must not short-circuit; with no on-disk source
+		// anywhere, discovery now materialises the binary-embedded skills (#5503).
+		t.Setenv("HOME", t.TempDir())
 		result := DiscoverSkillsDir("", "/nonexistent/path/skills")
-		if result != "" {
-			t.Errorf("expected empty result, got %q", result)
+		if result == "" {
+			t.Error("expected embedded fallback to provide a skills dir, got empty")
+		}
+		if !strings.HasSuffix(filepath.ToSlash(result), ".grafel/skills-cache") {
+			t.Errorf("expected embedded skills-cache dir, got %q", result)
 		}
 	})
 
@@ -101,25 +107,37 @@ func TestDiscoverSkillsDir(t *testing.T) {
 		}
 	})
 
-	t.Run("no skills anywhere on path returns empty", func(t *testing.T) {
+	t.Run("no on-disk skills anywhere falls back to embedded (#5503)", func(t *testing.T) {
+		// The released-tarball case: no skills/ next to the binary or in any
+		// ancestor. Discovery must materialise the embedded skills rather than
+		// return empty (which previously skipped the skills install on macOS).
+		home := t.TempDir()
+		t.Setenv("HOME", home)
 		dir := t.TempDir()
 		// Do NOT create a skills/ directory anywhere.
 		binPath := filepath.Join(dir, "grafel")
 		result := DiscoverSkillsDir(binPath, "")
-		if result != "" {
-			t.Errorf("expected empty result when no skills/ exists, got %q", result)
+		want := filepath.Join(home, ".grafel", "skills-cache")
+		if result != want {
+			t.Errorf("expected embedded fallback cache %q, got %q", want, result)
+		}
+		// And the materialised cache must actually contain the skills.
+		for _, name := range SkillNames {
+			if _, err := os.Stat(filepath.Join(result, name, "SKILL.md")); err != nil {
+				t.Errorf("embedded skill %s/SKILL.md missing in cache: %v", name, err)
+			}
 		}
 	})
 
-	t.Run("no hardcoded home path dependency", func(t *testing.T) {
-		// Override HOME to a temp dir that has no skills/ — ensures no
-		// machine-specific fallback fires.
-		emptyHome := t.TempDir()
-		t.Setenv("HOME", emptyHome)
+	t.Run("embedded cache is HOME-derived (no hardcoded path)", func(t *testing.T) {
+		// Override HOME to a temp dir — the embedded cache must land under it,
+		// proving no machine-specific path is baked in.
+		home := t.TempDir()
+		t.Setenv("HOME", home)
 		dir := t.TempDir()
 		result := DiscoverSkillsDir(filepath.Join(dir, "grafel"), "")
-		if result != "" {
-			t.Errorf("should return empty with empty HOME + no skills layout; got %q", result)
+		if !strings.HasPrefix(result, home) {
+			t.Errorf("embedded cache should live under HOME %q; got %q", home, result)
 		}
 	})
 
@@ -139,22 +157,24 @@ func TestDiscoverSkillsDir(t *testing.T) {
 	})
 }
 
-// TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths verifies that when
-// discovery fails, the returned attempted-paths list names EVERY candidate that
-// was probed (#4459) — including the explicit flag, sibling, one-up, env var,
-// and ancestor walk — so the caller can build a non-misleading error instead of
-// blaming the cwd.
+// TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths verifies that the
+// returned attempted-paths list names EVERY on-disk candidate that was probed
+// (#4459) — explicit flag, sibling, one-up, env var, ancestor walk — AND that
+// when none of them exist, discovery succeeds via the binary-embedded fallback
+// (#5503), which is itself recorded in the attempted list.
 func TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths(t *testing.T) {
 	envSkills := "/nonexistent/env/skills"
 	t.Setenv("GRAFEL_SKILLS_DIR", envSkills)
+	t.Setenv("HOME", t.TempDir())
 
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "deep", "build", "grafel")
 	explicit := "/nonexistent/flag/skills"
 
 	result, attempted := DiscoverSkillsDirVerbose(binPath, explicit)
-	if result != "" {
-		t.Fatalf("expected discovery to fail, got %q", result)
+	// With no on-disk source, the embedded fallback now provides the dir.
+	if result == "" {
+		t.Fatal("expected embedded fallback to provide a skills dir, got empty")
 	}
 
 	joined := strings.Join(attempted, "\n")
@@ -166,10 +186,36 @@ func TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths(t *testing.T) {
 		"GRAFEL_SKILLS_DIR",
 		envSkills,
 		"ancestor",
+		"embedded",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("attempted-paths list missing %q; got:\n%s", want, joined)
 		}
+	}
+}
+
+// TestMaterializeEmbeddedSkills verifies the embedded skills materialise to the
+// HOME-derived cache dir, are complete, and are idempotent on a second run.
+func TestMaterializeEmbeddedSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir, err := MaterializeEmbeddedSkills()
+	if err != nil {
+		t.Fatalf("MaterializeEmbeddedSkills: %v", err)
+	}
+	want := filepath.Join(home, ".grafel", "skills-cache")
+	if dir != want {
+		t.Fatalf("expected cache dir %q, got %q", want, dir)
+	}
+	for _, name := range SkillNames {
+		if _, err := os.Stat(filepath.Join(dir, name, "SKILL.md")); err != nil {
+			t.Errorf("embedded skill %s/SKILL.md missing: %v", name, err)
+		}
+	}
+	// Second run must be a clean no-op (idempotent).
+	if dir2, err := MaterializeEmbeddedSkills(); err != nil || dir2 != want {
+		t.Fatalf("re-materialise not idempotent: dir=%q err=%v", dir2, err)
 	}
 }
 

--- a/internal/install/skills_acceptance_test.go
+++ b/internal/install/skills_acceptance_test.go
@@ -1,0 +1,116 @@
+package install_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/skilllink"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// TestRunCopy_EmbeddedSkillsLandAndUninstallRemoves is the install-acceptance
+// test for #5503: on a binary-only install (a released tarball with NO skills/
+// directory next to the binary — the macOS symptom), `grafel install` must
+// still copy the bundled skills into the Claude skills dir, and `grafel
+// uninstall` must remove them again.
+//
+// The whole test runs against an isolated HOME (t.Setenv + GuardRealHome) so it
+// never touches the developer's real ~/.claude or ~/.grafel.
+func TestRunCopy_EmbeddedSkillsLandAndUninstallRemoves(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Place the fake binary in its OWN isolated subtree with NO skills/ dir in
+	// any ancestor, so on-disk discovery (sibling/one-up/ancestor) all miss and
+	// the install is forced down the embedded-skills fallback — exactly the
+	// released-tarball scenario from #5503.
+	binDir := filepath.Join(tmp, "opt", "grafel", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	fakeBin := filepath.Join(binDir, "grafel")
+	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\necho fake"), 0o755); err != nil {
+		t.Fatalf("write fake bin: %v", err)
+	}
+
+	// A fresh, empty Claude config so skills + MCP have a destination.
+	claudeDir := filepath.Join(tmp, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatalf("create claude dir: %v", err)
+	}
+	claudeJSON := filepath.Join(claudeDir, ".claude.json")
+	if err := os.WriteFile(claudeJSON, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write .claude.json: %v", err)
+	}
+
+	stateDir := filepath.Join(tmp, ".grafel")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatalf("create state dir: %v", err)
+	}
+	statePath := filepath.Join(stateDir, "install.json")
+
+	// Isolate every home-dir-derived path to tmp, then fail closed if the
+	// redirect somehow resolved to the real user home.
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "cfg"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", stateDir)
+	t.Setenv("GRAFEL_HOME", stateDir)
+	// Ensure no env override points discovery at a real on-disk skills tree.
+	t.Setenv("GRAFEL_SKILLS_DIR", "")
+	testsupport.GuardRealHome(t)
+
+	// Sanity: discovery must resolve to the materialised embedded cache, NOT an
+	// on-disk repo tree — proving the fallback is what's being exercised.
+	src := skilllink.DiscoverSkillsDir(fakeBin, "")
+	if src == "" {
+		t.Fatal("DiscoverSkillsDir returned empty even with embedded fallback")
+	}
+	wantCache := filepath.Join(tmp, ".grafel", "skills-cache")
+	if src != wantCache {
+		t.Fatalf("expected discovery to use embedded cache %s, got %s", wantCache, src)
+	}
+
+	opts := install.CopyOptions{
+		BinPath:           fakeBin,
+		SkillsSourceDir:   "", // force discovery → embedded fallback
+		ClaudeConfigDirs:  []string{claudeJSON},
+		StatePath:         statePath,
+		WorkingDir:        tmp,
+		SkipDaemonRestart: true,
+		NoHooks:           true,
+	}
+
+	result, err := install.RunCopy(opts)
+	if err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+	if len(result.SkillsInstalled) == 0 {
+		t.Fatal("install reported zero skills installed; embedded skills did not land (#5503)")
+	}
+
+	// Assert every canonical skill physically exists under the resolved Claude
+	// skills dir with its SKILL.md.
+	skillsDest := skilllink.ClaudeSkillsDirForConfig(claudeJSON)
+	for _, name := range skilllink.SkillNames {
+		skillMd := filepath.Join(skillsDest, name, "SKILL.md")
+		if _, err := os.Stat(skillMd); err != nil {
+			t.Errorf("after install, expected skill file %s to exist: %v", skillMd, err)
+		}
+	}
+
+	// ── uninstall must remove every skill it installed ───────────────────────
+	if _, err := install.RunUninstall(install.UninstallOptions{
+		StatePath:      statePath,
+		SkipDaemonStop: true,
+	}); err != nil {
+		t.Fatalf("RunUninstall: %v", err)
+	}
+	for _, name := range skilllink.SkillNames {
+		skillDir := filepath.Join(skillsDest, name)
+		if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
+			t.Errorf("after uninstall, expected skill %s to be gone, but stat err=%v", skillDir, err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (#5503)

On a released-tarball install — the common path on macOS — the `grafel` binary lands on its own with no `skills/` directory beside it. Skill discovery (`DiscoverSkillsDir`) only looked for an on-disk `skills/` tree relative to the binary (sibling / one-up / ancestor walk) or via `$GRAFEL_SKILLS_DIR`. None of those exist for a binary-only install, so discovery returned empty, the install **silently skipped the skills step** (graceful-degrade), and only the MCP server got registered. Result: users had the grafel MCP tools but **none of the `/grafel-*` slash-command skills**.

This was platform-agnostic in principle but bit macOS users specifically because the tarball install is the dominant path there; a dev/repo checkout always worked because `skills/` sits next to the source.

## Fix

- **Embed the skills into the binary.** New repo-root package `grafelassets` (`embedassets.go`) `//go:embed all:skills`. The single source of truth stays the repo-root `skills/` tree (`go:embed` can't traverse `..`, so the embedding package must be at the module root).
- **Discovery fallback.** `DiscoverSkillsDirVerbose` now, after all on-disk probes miss, materialises the embedded skills into a stable `~/.grafel/skills-cache` (HOME-derived, consistent with `DefaultStatePath` + MCP registration) and returns that path — a drop-in for an on-disk source. A dev checkout still wins via the on-disk tree; the embedded copy is the last-resort fallback only.
- **Idempotent.** `MaterializeEmbeddedSkills` only rewrites a file when its content differs, so re-installs are cheap and a second run is a no-op.
- **Cross-platform.** Both the COPY install path and the legacy symlink path consume the same discovery, so all platforms now install the full skill set into every detected Claude config's `skills/` dir.
- **Uninstall unchanged.** `grafel uninstall` already removed `state.Skills` from each Claude skills dir; it simply never had skills to remove before. Now that install records them, uninstall removes them — mirroring MCP deregistration.

## Tests

- `internal/install`: install-acceptance test (isolated HOME) — binary in an isolated subtree with no `skills/` on its ancestor path forces the embedded fallback; asserts every skill's `SKILL.md` exists under the resolved Claude skills dir after install, and is gone after uninstall. Repurposed the former graceful-degrade test to assert embedded skills now install (not skip) while daemon/MCP still proceed.
- `internal/install/skilllink`: unit tests for `MaterializeEmbeddedSkills` (completeness + idempotency) and the fallback discovery contract; updated the pre-existing tests that asserted the old "returns empty when no on-disk source" behaviour.
- `go test -count=1 ./internal/install/...` green; whole module builds + vets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)