### PR TITLE
feat(dashboard): sort index-progress list by status — active on top, done sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Added
+- **Index-progress list sorts by status — active rows on top, done sinks (#5495):**
+  on the dashboard index/group view the per-repo/module progress rows used to
+  render in a static repo/module order, so with a large (e.g. 30-module) group
+  you couldn't see what was actively working — completed and not-yet-started rows
+  were interleaved with the live ones. The list is now sorted by a status rank:
+  actively-indexing rows stay pinned at the **top**, queued (registered but
+  not-yet-started) rows sit just below them, and completed/failed rows sink to
+  the **bottom** as they finish. The sort is stable within each status band — the
+  original repo-then-module order is preserved — so rows don't jump around as
+  unrelated repos advance, and a single-repo / all-same-status list renders
+  exactly as before.
+
 ### Fixed
 - **Install now ships the bundled skills, not just the MCP (#5503):** on a
   released-tarball install (the common path on macOS) the `grafel` binary lands

--- a/webui-v2/src/lib/index-progress-fold.test.ts
+++ b/webui-v2/src/lib/index-progress-fold.test.ts
@@ -11,6 +11,7 @@ import {
   rowsTerminal,
   seedRows,
   sortRows,
+  statusRank,
 } from "./index-progress-fold";
 import type { ProgressEvent, ProgressRow } from "@/data/types";
 
@@ -490,13 +491,56 @@ describe("seedRows — show every repo before any event (#5340)", () => {
       "ivivo",
       ["backend", "frontend"],
     );
-    expect(rows.map((r) => r.repoSlug)).toEqual(["backend", "frontend"]);
+    // Both repos are present; the still-queued frontend now sorts ABOVE the
+    // completed backend (active/queued on top, done sinks — #5495).
+    expect(new Set(rows.map((r) => r.repoSlug))).toEqual(new Set(["backend", "frontend"]));
+    expect(rows.map((r) => r.repoSlug)).toEqual(["frontend", "backend"]);
     const fe = rows.find((r) => r.repoSlug === "frontend")!;
     expect(fe.phase).toBe("scanning"); // still seeded
   });
 
   it("skips empty slugs", () => {
     expect(sortRows(seedRows(["", "backend"]).values()).map((r) => r.repoSlug)).toEqual(["backend"]);
+  });
+});
+
+describe("sortRows / statusRank — active on top, done sinks (#5495)", () => {
+  it("ranks indexing(0) < queued(1) < done/error(2)", () => {
+    expect(statusRank(row({ phase: "extracting_ast", ts: 5 }))).toBe(0);
+    expect(statusRank(row({ phase: "scanning", ts: 0 }))).toBe(1); // seeded/queued
+    expect(statusRank(row({ phase: "done", ts: 9 }))).toBe(2);
+    expect(statusRank(row({ phase: "error", ts: 9 }))).toBe(2);
+  });
+
+  it("a still-scanning row that has emitted (ts > 0) counts as actively indexing", () => {
+    expect(statusRank(row({ phase: "scanning", ts: 3 }))).toBe(0);
+  });
+
+  it("sorts active rows above queued above completed, regardless of name", () => {
+    const rows = sortRows([
+      row({ repoSlug: "zeta", phase: "done", ts: 9 }), // completed
+      row({ repoSlug: "alpha", phase: "scanning", ts: 0 }), // queued (seeded)
+      row({ repoSlug: "mu", phase: "extracting_ast", ts: 4 }), // indexing
+    ]);
+    expect(rows.map((r) => r.repoSlug)).toEqual(["mu", "alpha", "zeta"]);
+  });
+
+  it("is stable by name WITHIN a status band", () => {
+    const rows = sortRows([
+      row({ repoSlug: "frontend", phase: "extracting_ast", ts: 4 }),
+      row({ repoSlug: "backend", phase: "resolving_refs", ts: 4 }),
+      row({ repoSlug: "api", phase: "done", ts: 9 }),
+    ]);
+    // backend, frontend are both indexing → name order; api (done) sinks last.
+    expect(rows.map((r) => r.repoSlug)).toEqual(["backend", "frontend", "api"]);
+  });
+
+  it("single-repo / all-same-status list is unchanged (name order preserved)", () => {
+    const rows = sortRows([
+      row({ repoSlug: "backend", phase: "done", ts: 9 }),
+      row({ repoSlug: "api", phase: "done", ts: 9 }),
+    ]);
+    expect(rows.map((r) => r.repoSlug)).toEqual(["api", "backend"]);
   });
 });
 

--- a/webui-v2/src/lib/index-progress-fold.ts
+++ b/webui-v2/src/lib/index-progress-fold.ts
@@ -330,9 +330,42 @@ export function overallPhaseLabel(
   return repoLabel;
 }
 
-/** Stable sort for rendering: by repo, then module label. */
+/**
+ * Status rank for sort ordering — lower sorts HIGHER (nearer the top) so the
+ * rows the user cares about are always in view (#5495):
+ *
+ *   0  indexing  — actively working (non-terminal AND it has emitted at least
+ *                  one real event, i.e. ts > 0)
+ *   1  queued    — registered but not started yet (a seeded row still at its
+ *                  initial "scanning"/ts === 0 state)
+ *   2  done/error — terminal; sinks to the bottom as it finishes
+ *
+ * As a row crosses into a terminal phase its rank rises from 0→2 and it drops
+ * below every still-active/queued row, so with a 30-module group the rows that
+ * are actively indexing stay pinned at the top while completed rows pile up at
+ * the bottom. Single-repo / all-same-status lists are unaffected (every row
+ * shares one rank, so the stable secondary key — repo then module — is what
+ * orders them, exactly as before).
+ */
+export function statusRank(row: Pick<ProgressRow, "phase" | "ts">): number {
+  if (row.phase === "done" || row.phase === "error") return 2;
+  // A seeded, not-yet-started row sits at "scanning" with ts === 0 → queued.
+  if (row.ts <= 0) return 1;
+  return 0; // a real event has advanced it → actively indexing.
+}
+
+/**
+ * Stable sort for rendering: status first (active → queued → done, #5495), then
+ * the original repo/module order WITHIN each status band so rows don't jump
+ * around as unrelated repos advance. The status key is the only change from the
+ * historical pure repo/module sort; within one status band the order is
+ * identical to before, so the small/single-repo case is unaffected.
+ */
 export function sortRows(rows: Iterable<ProgressRow>): ProgressRow[] {
   return [...rows].sort((a, b) => {
+    const ra = statusRank(a);
+    const rb = statusRank(b);
+    if (ra !== rb) return ra - rb;
     if (a.repoSlug !== b.repoSlug) return a.repoSlug.localeCompare(b.repoSlug);
     return (a.module ?? "").localeCompare(b.module ?? "");
   });


### PR DESCRIPTION
Closes #5495.

On the dashboard index/group view the per-repo/module progress rows rendered in a static repo/module order, so with a large (e.g. 30-module) group you couldn't tell what was actively working — completed and not-yet-started rows were interleaved with the live ones.

## Change
`sortRows` (in `webui-v2/src/lib/index-progress-fold.ts`) now sorts by a **status rank** first, then falls back to the original repo-then-module key within each band:

| rank | status | derived from |
|---|---|---|
| 0 | indexing (active) | non-terminal phase AND `ts > 0` (has emitted a real event) |
| 1 | queued | seeded row still at `scanning` / `ts === 0` |
| 2 | done / error | terminal phase |

Active rows stay pinned at the top, queued rows sit just below, completed/failed rows sink to the bottom as they finish. The sort is **stable within each status band** (original repo→module order preserved) so rows don't jump around as unrelated repos advance.

`sortRows` is the single sort used by the progress hook that feeds `IndexProgressFeed`, so both the index wizard and the Operations screen pick this up. A small `statusRank` helper is extracted and unit-tested.

## Why this is safe
- Single-repo / all-same-status lists share one rank, so ordering is identical to before (no visible change).
- One existing seedRows test changed its expected order to reflect the intended new behavior (a queued repo now sorts above a completed one).

## Verify
- `npm run build` clean, `tsc --noEmit` clean.
- 55 fold/sort unit tests green (incl. new `statusRank` / `sortRows` cases).
- `make dashboard-build` + `verify-dashboard` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)