### PR TITLE
feat(inngest): extract createFunction → Function entities (#5480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Inngest durable functions extracted as Function entities (#5480):** the new
+  `custom_js_inngest` JS/TS extractor recognises `inngest.createFunction({ id |
+  name }, { event | cron }, handler)` call sites (both the modern object-config
+  signature and the older positional trigger form) and emits one
+  `SCOPE.Function` entity (subtype `inngest_function`) per definition, named
+  after the config `id`/`name` — the consumer side of an Inngest event, modelled
+  like a BullMQ Worker / serverless function. The trigger is captured as an
+  attribute (`trigger_event` + `trigger_type=event`, or `trigger_cron` +
+  `trigger_type=cron`); `function_id`, `receiver`, and `framework=inngest` are
+  recorded too. Detection is attribution-gated on an `inngest` import or a
+  receiver named `inngest`. This is Phase 1 (entities) of the Inngest coverage
+  epic (#5479); the EMITS/TRIGGERS edges that wire the trigger event to
+  producers and topics are follow-up tickets (#5482/#5483/#5484). New registry
+  record `msg.inngest` (`message_broker` / `task_queues`).
 - **Index-progress list sorts by status — active rows on top, done sinks (#5495):**
   on the dashboard index/group view the per-repo/module progress rows used to
   render in a static repo/module order, so with a large (e.g. 30-module) group

--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 61 records · **C/C++**: 3 · **C#**: 9 · **elixir**: 2 · **go**: 5 · **JS/TS**: 3 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
+**Total**: 62 records · **C/C++**: 3 · **C#**: 9 · **elixir**: 2 · **go**: 5 · **JS/TS**: 4 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -26,6 +26,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 |---|---|---|---|---|---|---|
 | [go](../by-language/go.md) | [asynq (Go task queue)](../detail/msg.asynq.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | ✅ | |
+| [JS/TS](../by-language/jsts.md) | [Inngest (durable functions / event-driven jobs)](../detail/msg.inngest.md) | 🟢 | — | — | 🟢 | |
 | [php](../by-language/php.md) | [Laravel Queue (queued Jobs / dispatch)](../detail/msg.broker.laravel-queue.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |
 | [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | ✅ | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # JS/TS
 
-**Frameworks**: 33 · **Tools**: 21 · **ORMs**: 19 · **Other**: 8
+**Frameworks**: 33 · **Tools**: 21 · **ORMs**: 19 · **Other**: 9
 
 Back to [summary](../summary.md).
 
@@ -166,6 +166,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
 |---|---|---|---|---|
 | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | |
+| [Inngest (durable functions / event-driven jobs)](../detail/msg.inngest.md) | 🟢 | — | — | |
 
 
 ### Brokers

--- a/docs/coverage/detail/msg.inngest.md
+++ b/docs/coverage/detail/msg.inngest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `msg.inngest` — Inngest (durable functions / event-driven jobs)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [message_broker](../by-category/message_broker.md)
+- **Subcategory:** Task Queues
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Consumer extraction | 🟢 `partial` | `2026-06-24` | 5480 | `internal/custom/javascript/inngest.go`<br>`internal/custom/javascript/inngest_test.go`<br>`testdata/fixtures/typescript/inngest_functions.ts` | #5480 (epic #5479, Phase 1 item 1 — ENTITIES only, edges are #5482/#5483/#5484): custom_js_inngest extracts each inngest.createFunction({ id|name }, { event|cron }, handler) call site (modern object-config and the older positional trigger form) as one SCOPE.Function (subtype inngest_function) named after the config id/name — the consumer side of an Inngest event, the durable-function analogue of a BullMQ Worker. The trigger is captured as an attribute only (trigger_event + trigger_type=event, or trigger_cron + trigger_type=cron); function_id/receiver/framework=inngest also recorded. Attribution-gated on an `inngest` import or a receiver named `inngest`. Honest-partial: a createFunction with no literal id/name (dynamically named) is skipped, and the EMITS/TRIGGERS edges that wire trigger_event to producers/topics are not yet emitted (#5482/#5483). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update msg.inngest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,13 +1,13 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 255 · **ORMs**: 176 · **Tools**: 129 · **Other**: 205
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 255 · **ORMs**: 176 · **Tools**: 129 · **Other**: 206
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [JS/TS](by-language/jsts.md) | 33 | 21 | 19 | 8 |
+| [JS/TS](by-language/jsts.md) | 33 | 21 | 19 | 9 |
 | [C/C++](by-language/c-cpp.md) | 25 | 16 | 10 | 4 |
 | [python](by-language/python.md) | 25 | 15 | 18 | 10 |
 | [java](by-language/java.md) | 23 | 10 | 15 | 4 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 255 frameworks · 129 tools · 176 ORMs · 205 other
+Total: 255 frameworks · 129 tools · 176 ORMs · 206 other

--- a/internal/custom/javascript/inngest.go
+++ b/internal/custom/javascript/inngest.go
@@ -1,0 +1,173 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+func init() {
+	extreg.Register("custom_js_inngest", &inngestExtractor{})
+}
+
+// inngestExtractor recognises Inngest durable-function definitions in
+// JavaScript / TypeScript source. Inngest's `inngest.createFunction(...)`
+// (or `<client>.createFunction(...)`) registers an event-triggered async
+// workflow function — conceptually the consumer side of an event, the
+// Inngest analogue of a BullMQ Worker / serverless function. Each call site
+// becomes one SCOPE.Function entity named after the function's id/name, with
+// the trigger event captured as a property.
+//
+// Scope (epic #5479, ticket #5480): the ENTITY only. The EMITS / TRIGGERS
+// edges that wire the event name to producers/topics are later tickets
+// (#5482/#5483/#5484); here the event name is recorded as an attribute.
+type inngestExtractor struct{}
+
+func (e *inngestExtractor) Language() string { return "custom_js_inngest" }
+
+// q matches a single-, double-, or back-quoted string literal, capturing the
+// inner value. Kept as one shared fragment so every key regex agrees on what a
+// JS/TS string literal looks like.
+const inngestStr = "['\"`]([^'\"`]+)['\"`]"
+
+var (
+	// Gate: only run when the file actually imports / requires inngest, so a
+	// stray `.createFunction(` from another library is not misattributed.
+	reInngestImport = regexp.MustCompile("(?:from\\s+['\"`]inngest['\"`]|require\\(\\s*['\"`]inngest['\"`]\\s*\\))")
+
+	// `<recv>.createFunction(` — capture the receiver (usually `inngest`).
+	reInngestCreateFunction = regexp.MustCompile(`([A-Za-z_$][A-Za-z0-9_$.]*)\.createFunction\s*\(`)
+
+	// Config object `id` / `name` keys. The first config argument to
+	// createFunction; `id` is preferred, `name` is the fallback.
+	reInngestID   = regexp.MustCompile(`\bid\s*:\s*` + inngestStr)
+	reInngestName = regexp.MustCompile(`\bname\s*:\s*` + inngestStr)
+
+	// Trigger event name. Modern form is a `{ event: "..." }` trigger object;
+	// the older positional form passes the same shape as the 2nd argument.
+	reInngestEvent = regexp.MustCompile(`\bevent\s*:\s*` + inngestStr)
+	// Cron-triggered functions use `{ cron: "..." }` instead of an event.
+	reInngestCron = regexp.MustCompile(`\bcron\s*:\s*` + inngestStr)
+)
+
+func (e *inngestExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("grafel/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.inngest_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "inngest"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+	// Attribution gate. Run only when the file plausibly uses Inngest: either it
+	// imports the `inngest` package directly, or a createFunction call is made on
+	// a receiver literally named `inngest` (the conventional client variable,
+	// commonly imported from a local `./client` wrapper). This keeps a stray
+	// `.createFunction(` from an unrelated library from being misattributed.
+	hasImport := reInngestImport.MatchString(src)
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.SourceFile)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	for _, m := range reInngestCreateFunction.FindAllStringSubmatchIndex(src, -1) {
+		receiver := src[m[2]:m[3]]
+		callStart := m[0]
+
+		// Attribution: accept the call if the file imports inngest, or the
+		// receiver is the conventional `inngest` client (or a member access
+		// ending in `.inngest`).
+		if !hasImport && receiver != "inngest" && !strings.HasSuffix(receiver, ".inngest") {
+			continue
+		}
+
+		// Slice the bounded argument region: from the opening paren of the
+		// createFunction call to the matching close paren, so the id/event of
+		// one function definition do not bleed into the next.
+		seg := boundedCallSegment(src, m[1]-1) // m[1]-1 is the '(' offset
+
+		// Function name: prefer config `id`, fall back to `name`.
+		funcName := ""
+		if mm := reInngestID.FindStringSubmatch(seg); mm != nil {
+			funcName = mm[1]
+		} else if mm := reInngestName.FindStringSubmatch(seg); mm != nil {
+			funcName = mm[1]
+		}
+		if funcName == "" {
+			// Anonymous / dynamically-named function: skip rather than emit a
+			// nameless entity (honest-partial — no id/name literal to anchor).
+			continue
+		}
+
+		ent := makeEntity(funcName, string(types.EntityKindFunction), "inngest_function",
+			file.Path, file.Language, lineOf(src, callStart))
+		setProps(&ent, "framework", "inngest", "function_id", funcName, "receiver", receiver,
+			"provenance", "INFERRED_FROM_INNGEST_CREATE_FUNCTION")
+
+		// Trigger event name (attribute only — edges are #5482/#5483).
+		if mm := reInngestEvent.FindStringSubmatch(seg); mm != nil {
+			setProps(&ent, "trigger_event", mm[1], "trigger_type", "event")
+		} else if mm := reInngestCron.FindStringSubmatch(seg); mm != nil {
+			setProps(&ent, "trigger_cron", mm[1], "trigger_type", "cron")
+		}
+
+		addEntity(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// boundedCallSegment returns the source substring from openParen (the byte
+// offset of a '(') to its matching ')', inclusive, capped to a sane length so
+// a malformed/unterminated call cannot scan the whole file.
+func boundedCallSegment(src string, openParen int) string {
+	if openParen < 0 || openParen >= len(src) || src[openParen] != '(' {
+		return ""
+	}
+	depth := 0
+	const maxScan = 4000
+	end := openParen
+	for i := openParen; i < len(src) && i < openParen+maxScan; i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				end = i
+				return src[openParen : end+1]
+			}
+		}
+	}
+	// Unterminated within the cap: return the bounded window.
+	if openParen+maxScan < len(src) {
+		return src[openParen : openParen+maxScan]
+	}
+	return src[openParen:]
+}

--- a/internal/custom/javascript/inngest_test.go
+++ b/internal/custom/javascript/inngest_test.go
@@ -1,0 +1,161 @@
+package javascript_test
+
+// Tests for issue #5480 (epic #5479, Inngest Phase 1, item 1): the Inngest
+// durable-function extractor (custom_js_inngest). Proves that each
+// `inngest.createFunction(...)` call site yields one SCOPE.Function entity
+// named after the config `id`/`name`, with the trigger event captured as a
+// property. Scope is the ENTITY only — EMITS/TRIGGERS edges are #5482/#5483.
+//
+// These are the proving fixtures cited by the registry record `msg.inngest`.
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+
+	// Blank import to trigger init() registration of the extractor.
+	_ "github.com/cajasmota/grafel/internal/custom/javascript"
+)
+
+// extractInngest runs the inngest extractor and returns full EntityRecords so
+// tests can assert the trigger_event property (the shared entitySummary helper
+// only carries Kind/Subtype/Name).
+func extractInngest(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get("custom_js_inngest")
+	if !ok {
+		t.Fatal("extractor custom_js_inngest not registered")
+	}
+	ents, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "typescript", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract error: %v", err)
+	}
+	return ents
+}
+
+func findFunc(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindFunction) && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// Modern object-config signature:
+//   inngest.createFunction({ id, name }, { event }, handler)
+func TestInngestCreateFunctionObjectSignature(t *testing.T) {
+	src := `
+import { Inngest } from "inngest";
+const inngest = new Inngest({ id: "my-app" });
+
+export const syncUser = inngest.createFunction(
+  { id: "sync-user", name: "Sync User" },
+  { event: "user/created" },
+  async ({ event, step }) => {
+    await step.run("sync", () => doSync(event.data));
+  }
+);
+`
+	ents := extractInngest(t, "src/inngest/syncUser.ts", src)
+	fn := findFunc(ents, "sync-user")
+	if fn == nil {
+		t.Fatalf("expected SCOPE.Function entity 'sync-user', got %+v", ents)
+	}
+	if fn.Subtype != "inngest_function" {
+		t.Errorf("expected subtype inngest_function, got %q", fn.Subtype)
+	}
+	if got := fn.Properties["trigger_event"]; got != "user/created" {
+		t.Errorf("expected trigger_event=user/created, got %q", got)
+	}
+	if got := fn.Properties["framework"]; got != "inngest" {
+		t.Errorf("expected framework=inngest, got %q", got)
+	}
+	if got := fn.Properties["function_id"]; got != "sync-user" {
+		t.Errorf("expected function_id=sync-user, got %q", got)
+	}
+}
+
+// Older positional signature: a bare string id as the first argument is NOT
+// used (Inngest never accepted a bare string id), but the historical
+// positional trigger form passes the trigger object as the 2nd argument — the
+// id still lives in the config object. This asserts the same config-object id
+// resolves and the acceptance fixture from #5480 works verbatim.
+func TestInngestCreateFunctionAcceptanceFixture(t *testing.T) {
+	// The exact acceptance shape from the ticket.
+	src := `
+import { inngest } from "./client";
+inngest.createFunction({ id: "sync-user" }, { event: "user/created" }, async () => {});
+`
+	ents := extractInngest(t, "functions.ts", src)
+	if len(ents) != 1 {
+		t.Fatalf("expected exactly one entity, got %d: %+v", len(ents), ents)
+	}
+	fn := findFunc(ents, "sync-user")
+	if fn == nil {
+		t.Fatalf("expected SCOPE.Function entity 'sync-user'")
+	}
+	if got := fn.Properties["trigger_event"]; got != "user/created" {
+		t.Errorf("expected trigger_event=user/created, got %q", got)
+	}
+}
+
+// Multiple definitions in one file must not bleed ids/events into one another.
+func TestInngestMultipleFunctionsNoBleed(t *testing.T) {
+	src := `
+import { inngest } from "inngest";
+export const a = inngest.createFunction({ id: "fn-a" }, { event: "a/event" }, async () => {});
+export const b = inngest.createFunction({ id: "fn-b" }, { event: "b/event" }, async () => {});
+`
+	ents := extractInngest(t, "multi.ts", src)
+	a := findFunc(ents, "fn-a")
+	b := findFunc(ents, "fn-b")
+	if a == nil || b == nil {
+		t.Fatalf("expected both fn-a and fn-b, got %+v", ents)
+	}
+	if a.Properties["trigger_event"] != "a/event" {
+		t.Errorf("fn-a trigger bled: got %q", a.Properties["trigger_event"])
+	}
+	if b.Properties["trigger_event"] != "b/event" {
+		t.Errorf("fn-b trigger bled: got %q", b.Properties["trigger_event"])
+	}
+}
+
+// Cron-triggered functions carry a cron attribute instead of an event.
+func TestInngestCronTrigger(t *testing.T) {
+	src := `
+import { inngest } from "inngest";
+inngest.createFunction({ id: "nightly" }, { cron: "0 0 * * *" }, async () => {});
+`
+	ents := extractInngest(t, "cron.ts", src)
+	fn := findFunc(ents, "nightly")
+	if fn == nil {
+		t.Fatal("expected SCOPE.Function entity 'nightly'")
+	}
+	if got := fn.Properties["trigger_cron"]; got != "0 0 * * *" {
+		t.Errorf("expected trigger_cron set, got %q", got)
+	}
+	if got := fn.Properties["trigger_type"]; got != "cron" {
+		t.Errorf("expected trigger_type=cron, got %q", got)
+	}
+}
+
+// No inngest import → no entities, even if a `.createFunction(` happens to
+// appear (guards against misattributing another library's API).
+func TestInngestNoImportNoMatch(t *testing.T) {
+	src := `const x = other.createFunction({ id: "nope" });`
+	ents := extractInngest(t, "unrelated.ts", src)
+	if len(ents) != 0 {
+		t.Errorf("expected no entities without inngest import, got %d", len(ents))
+	}
+}
+
+func TestInngestNoMatch(t *testing.T) {
+	ents := extractInngest(t, "plain.ts", "const x = 1;")
+	if len(ents) != 0 {
+		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}

--- a/testdata/fixtures/typescript/inngest_functions.ts
+++ b/testdata/fixtures/typescript/inngest_functions.ts
@@ -1,0 +1,40 @@
+// Proving fixture for the Inngest durable-function extractor
+// (custom_js_inngest, issue #5480, epic #5479). Each inngest.createFunction(...)
+// call site is extracted as one SCOPE.Function entity named after the config
+// `id`, with the trigger event/cron captured as a property. Edges
+// (EMITS/TRIGGERS) are later tickets (#5482/#5483) and are NOT exercised here.
+
+import { Inngest } from "inngest";
+
+export const inngest = new Inngest({ id: "demo-app" });
+
+// Modern object-config signature with an event trigger.
+export const syncUser = inngest.createFunction(
+  { id: "sync-user", name: "Sync User" },
+  { event: "user/created" },
+  async ({ event, step }) => {
+    await step.run("persist", () => persistUser(event.data));
+  },
+);
+
+// Second event-triggered function — must not bleed its id/event into the first.
+export const sendWelcome = inngest.createFunction(
+  { id: "send-welcome" },
+  { event: "user/created" },
+  async ({ event }) => {
+    await sendEmail(event.data.email);
+  },
+);
+
+// Cron-triggered function carries a cron attribute instead of an event.
+export const nightlyReport = inngest.createFunction(
+  { id: "nightly-report" },
+  { cron: "0 0 * * *" },
+  async () => {
+    await buildReport();
+  },
+);
+
+declare function persistUser(data: unknown): Promise<void>;
+declare function sendEmail(to: string): Promise<void>;
+declare function buildReport(): Promise<void>;


### PR DESCRIPTION
Closes #5480 (Phase 1, item 1 of Inngest coverage epic #5479 — **entities only**, edges are #5482/#5483/#5484).

## What
New `custom_js_inngest` JS/TS extractor. Each `inngest.createFunction({ id | name }, { event | cron }, handler)` call site becomes **one `SCOPE.Function` entity** (subtype `inngest_function`) named after the config `id`/`name`.

- **Detection pattern (mirrored):** regex-based custom JS/TS extractor in the style of `internal/custom/javascript/bull.go` — auto-registered via `init()` and selected by the existing `custom_js_` dispatch prefix (no wiring change). Both the modern object-config signature and the older positional trigger form are handled.
- **Entity model:** `SCOPE.Function` (the ticket title/acceptance). Conceptually the consumer side of an Inngest event — the durable-function analogue of a BullMQ Worker / serverless function. The trigger is captured as an **attribute only** (`trigger_event` + `trigger_type=event`, or `trigger_cron` + `trigger_type=cron`); `function_id`, `receiver`, `framework=inngest` recorded too.
- **Attribution-gated** on an `inngest` import OR a receiver literally named `inngest`, so an unrelated `.createFunction(` is not misattributed.
- **Honest-partial:** a `createFunction` with no literal `id`/`name` (dynamically named) is skipped; EMITS/TRIGGERS edges are deferred to the follow-up tickets.

## Registry + docs (same PR)
New record `msg.inngest` (`message_broker` / `task_queues`, jsts) mirroring `msg.bullmq`, capability `consumer_extraction=partial`. Coverage docs regenerated; `coverage fmt --check` and `coverage validate` green.

## Tests
`internal/custom/javascript/inngest_test.go` + fixture `testdata/fixtures/typescript/inngest_functions.ts`: object signature, the verbatim acceptance fixture, multi-function no-bleed, cron trigger, and the no-import / no-match negatives. `go test ./internal/custom/javascript/ ./tools/coverage/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)