### PR TITLE
feat(inngest): extract event definitions → Event/topic entities (#5481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   epic (#5479); the EMITS/TRIGGERS edges that wire the trigger event to
   producers and topics are follow-up tickets (#5482/#5483/#5484). New registry
   record `msg.inngest` (`message_broker` / `task_queues`).
+- **Inngest event names extracted as MessageTopic entities (#5481):** the
+  `custom_js_inngest` extractor now also emits one `SCOPE.MessageTopic` entity
+  (subtype `inngest`, `framework=inngest`, `topic_id=event:<name>`) per
+  **distinct** Inngest event name — the event analogue of a BullMQ/Kafka topic.
+  Event names are harvested from `createFunction({ event: "..." })` triggers,
+  `<client>.send`/`sendEvent({ name: "..." })` producer payloads, and typed
+  `new EventSchemas().fromRecord<{ "name": ... }>()` / `fromUnion` schema
+  definitions (the quoted keys of the balanced type-argument record). Topics are
+  deduped by event name within a file and carry the first reference site as their
+  source location, attribution-gated on the same `inngest` import / receiver as
+  the function extractor. Phase 1 (entities) of the Inngest epic (#5479); the
+  EMITS/TRIGGERS edges wiring topics to their producers/consumers are #5482/#5483.
+  Records the `topic_attribution` capability on `msg.inngest`.
 - **Index-progress list sorts by status — active rows on top, done sinks (#5495):**
   on the dashboard index/group view the per-repo/module progress rows used to
   render in a static repo/module order, so with a large (e.g. 30-module) group

--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -26,7 +26,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 |---|---|---|---|---|---|---|
 | [go](../by-language/go.md) | [asynq (Go task queue)](../detail/msg.asynq.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | ✅ | |
-| [JS/TS](../by-language/jsts.md) | [Inngest (durable functions / event-driven jobs)](../detail/msg.inngest.md) | 🟢 | — | — | 🟢 | |
+| [JS/TS](../by-language/jsts.md) | [Inngest (durable functions / event-driven jobs)](../detail/msg.inngest.md) | 🟢 | — | 🟢 | 🟢 | |
 | [php](../by-language/php.md) | [Laravel Queue (queued Jobs / dispatch)](../detail/msg.broker.laravel-queue.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |
 | [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | ✅ | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -166,7 +166,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | Name | Consumer extraction | Producer extraction | Topic attribution | Notes |
 |---|---|---|---|---|
 | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | |
-| [Inngest (durable functions / event-driven jobs)](../detail/msg.inngest.md) | 🟢 | — | — | |
+| [Inngest (durable functions / event-driven jobs)](../detail/msg.inngest.md) | 🟢 | — | 🟢 | |
 
 
 ### Brokers

--- a/docs/coverage/detail/msg.inngest.md
+++ b/docs/coverage/detail/msg.inngest.md
@@ -6,13 +6,14 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
 - **Subcategory:** Task Queues
-- **Capability cells:** 1
+- **Capability cells:** 2
 
 ## Capabilities
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Consumer extraction | 🟢 `partial` | `2026-06-24` | 5480 | `internal/custom/javascript/inngest.go`<br>`internal/custom/javascript/inngest_test.go`<br>`testdata/fixtures/typescript/inngest_functions.ts` | #5480 (epic #5479, Phase 1 item 1 — ENTITIES only, edges are #5482/#5483/#5484): custom_js_inngest extracts each inngest.createFunction({ id|name }, { event|cron }, handler) call site (modern object-config and the older positional trigger form) as one SCOPE.Function (subtype inngest_function) named after the config id/name — the consumer side of an Inngest event, the durable-function analogue of a BullMQ Worker. The trigger is captured as an attribute only (trigger_event + trigger_type=event, or trigger_cron + trigger_type=cron); function_id/receiver/framework=inngest also recorded. Attribution-gated on an `inngest` import or a receiver named `inngest`. Honest-partial: a createFunction with no literal id/name (dynamically named) is skipped, and the EMITS/TRIGGERS edges that wire trigger_event to producers/topics are not yet emitted (#5482/#5483). |
+| Topic attribution | 🟢 `partial` | `2026-06-24` | 5481 | `internal/custom/javascript/inngest.go`<br>`internal/custom/javascript/inngest_test.go`<br>`testdata/fixtures/typescript/inngest_functions.ts` | #5481 (epic #5479, Phase 1 item 2 — ENTITIES only): each DISTINCT Inngest event name becomes one SCOPE.MessageTopic (subtype inngest, framework=inngest, topic_id=event:<name>) — the Inngest event analogue of a BullMQ/Kafka topic. Event names are harvested from createFunction `{ event: "..." }` triggers, `<client>.send/sendEvent({ name: "..." })` producer payloads (one topic per name: key in the bounded send region), and typed `new EventSchemas().fromRecord<{ "name": ... }>()` / fromUnion schema definitions (the quoted keys of the balanced type-argument record). Deduped by event name within a file; the first reference site is the topic's source location, with provenance INFERRED_FROM_INNGEST_EVENT_REFERENCE or INFERRED_FROM_INNGEST_EVENT_SCHEMA. Same attribution gate as the function extractor (inngest import or a receiver named/ending in `inngest`). Honest-partial: dynamic/computed event names and schema records referenced via a named type alias (fromRecord<Events>) rather than an inline literal are not resolved; the EMITS/TRIGGERS edges wiring topics to their producers/consumers are #5482/#5483. |
 
 ## Provenance
 

--- a/internal/custom/javascript/inngest.go
+++ b/internal/custom/javascript/inngest.go
@@ -26,9 +26,17 @@ func init() {
 // becomes one SCOPE.Function entity named after the function's id/name, with
 // the trigger event captured as a property.
 //
-// Scope (epic #5479, ticket #5480): the ENTITY only. The EMITS / TRIGGERS
-// edges that wire the event name to producers/topics are later tickets
-// (#5482/#5483/#5484); here the event name is recorded as an attribute.
+// Scope (epic #5479, ticket #5480): the consumer SCOPE.Function ENTITY. The
+// EMITS / TRIGGERS edges that wire the event name to producers/topics are later
+// tickets (#5482/#5483/#5484); here the event name is recorded as an attribute.
+//
+// Ticket #5481 (epic #5479, Phase 1 item 2) adds, on top of the function
+// entities, one SCOPE.MessageTopic entity per DISTINCT Inngest event name —
+// the Inngest event analogue of a BullMQ/Kafka topic. Event names are harvested
+// from createFunction `{ event: "..." }` triggers, `<client>.send({ name })`
+// producer payloads, and typed `new EventSchemas().fromRecord<{ "name": ... }>()`
+// schema definitions. The topic is deduped by event name; the EMITS/TRIGGERS
+// edges that wire the topic to its producers/consumers remain #5482/#5483.
 type inngestExtractor struct{}
 
 func (e *inngestExtractor) Language() string { return "custom_js_inngest" }
@@ -56,6 +64,20 @@ var (
 	reInngestEvent = regexp.MustCompile(`\bevent\s*:\s*` + inngestStr)
 	// Cron-triggered functions use `{ cron: "..." }` instead of an event.
 	reInngestCron = regexp.MustCompile(`\bcron\s*:\s*` + inngestStr)
+
+	// `<recv>.send(` and `<recv>.sendEvent(` — the producer side. The event
+	// name lives in a `{ name: "..." }` payload (single event) or an array of
+	// such payloads.
+	reInngestSend = regexp.MustCompile(`([A-Za-z_$][A-Za-z0-9_$.]*)\.(?:send|sendEvent)\s*\(`)
+	// Event payload name key inside a send() call or a typed-schema entry.
+	reInngestNameKey = regexp.MustCompile(`\bname\s*:\s*` + inngestStr)
+
+	// Typed event-schema definition. The conventional form is
+	// `new EventSchemas().fromRecord<{ "user/created": {...}; ... }>()`, where
+	// the event names are the keys of the typed record. We pull the type-arg
+	// region after `fromRecord` / `fromUnion` and harvest its quoted keys.
+	reInngestEventSchemas = regexp.MustCompile(`\bnew\s+EventSchemas\s*\(`)
+	reInngestSchemaKey    = regexp.MustCompile(inngestStr + `\s*:`)
 )
 
 func (e *inngestExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
@@ -95,6 +117,26 @@ func (e *inngestExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		entities = append(entities, ent)
 	}
 
+	// Event-name → MessageTopic, deduped by event name within this file. The
+	// first reference site wins as the topic's source location; a later typed
+	// schema definition is preferred over a bare reference if it shows up.
+	eventTopics := make(map[string]bool)
+	addEventTopic := func(name string, line int, fromSchema bool) {
+		if name == "" || eventTopics[name] {
+			return
+		}
+		eventTopics[name] = true
+		ent := makeEntity(name, string(types.EntityKindMessageTopic), "inngest",
+			file.Path, file.Language, line)
+		src := "INFERRED_FROM_INNGEST_EVENT_REFERENCE"
+		if fromSchema {
+			src = "INFERRED_FROM_INNGEST_EVENT_SCHEMA"
+		}
+		setProps(&ent, "framework", "inngest", "topic", name,
+			"topic_id", "event:"+name, "provenance", src)
+		addEntity(ent)
+	}
+
 	for _, m := range reInngestCreateFunction.FindAllStringSubmatchIndex(src, -1) {
 		receiver := src[m[2]:m[3]]
 		callStart := m[0]
@@ -132,6 +174,8 @@ func (e *inngestExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		// Trigger event name (attribute only — edges are #5482/#5483).
 		if mm := reInngestEvent.FindStringSubmatch(seg); mm != nil {
 			setProps(&ent, "trigger_event", mm[1], "trigger_type", "event")
+			// #5481: the triggered event name is also a distinct MessageTopic.
+			addEventTopic(mm[1], lineOf(src, callStart), false)
 		} else if mm := reInngestCron.FindStringSubmatch(seg); mm != nil {
 			setProps(&ent, "trigger_cron", mm[1], "trigger_type", "cron")
 		}
@@ -139,8 +183,83 @@ func (e *inngestExtractor) Extract(ctx context.Context, file extreg.FileInput) (
 		addEntity(ent)
 	}
 
+	// #5481: producer side — `<client>.send({ name: "..." })` /
+	// `.sendEvent(...)`. The same attribution gate applies (import present, or a
+	// receiver named/ending in `inngest`). Each distinct event name becomes a
+	// MessageTopic. An array of payloads yields one topic per `name:` key in the
+	// bounded send() region.
+	for _, m := range reInngestSend.FindAllStringSubmatchIndex(src, -1) {
+		receiver := src[m[2]:m[3]]
+		if !hasImport && receiver != "inngest" && !strings.HasSuffix(receiver, ".inngest") {
+			continue
+		}
+		seg := boundedCallSegment(src, m[1]-1)
+		for _, nm := range reInngestNameKey.FindAllStringSubmatch(seg, -1) {
+			addEventTopic(nm[1], lineOf(src, m[0]), false)
+		}
+	}
+
+	// #5481: typed event-schema definitions —
+	// `new EventSchemas().fromRecord<{ "user/created": {...}; ... }>()`. The
+	// event names are the quoted keys of the typed record. We scan a bounded
+	// window after the `new EventSchemas(` call (covering the chained
+	// .fromRecord<...>() type argument) and harvest its quoted keys as schema-
+	// sourced topics. Gated on the inngest import.
+	if hasImport {
+		for _, m := range reInngestEventSchemas.FindAllStringSubmatchIndex(src, -1) {
+			seg := schemaWindow(src, m[1])
+			for _, km := range reInngestSchemaKey.FindAllStringSubmatch(seg, -1) {
+				addEventTopic(km[1], lineOf(src, m[0]), true)
+			}
+		}
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(entities)))
 	return entities, nil
+}
+
+// schemaWindow returns the type-argument region of a chained
+// `.fromRecord<{ ... }>()` / `.fromUnion<...>()` that follows `new EventSchemas(`
+// at byte offset `start`. It locates the next `fromRecord`/`fromUnion` within a
+// bounded window, then returns the balanced `<...>` type-argument substring so
+// event-name keys can be harvested. Returns "" if no such typed schema is found.
+func schemaWindow(src string, start int) string {
+	if start < 0 || start >= len(src) {
+		return ""
+	}
+	const maxScan = 4000
+	hi := start + maxScan
+	if hi > len(src) {
+		hi = len(src)
+	}
+	region := src[start:hi]
+	// Anchor on the typed-schema builder call.
+	idx := strings.Index(region, "fromRecord")
+	if idx < 0 {
+		idx = strings.Index(region, "fromUnion")
+	}
+	if idx < 0 {
+		return ""
+	}
+	// Find the opening `<` after the builder name, then its matching `>`.
+	open := strings.IndexByte(region[idx:], '<')
+	if open < 0 {
+		return ""
+	}
+	open += idx
+	depth := 0
+	for i := open; i < len(region); i++ {
+		switch region[i] {
+		case '<':
+			depth++
+		case '>':
+			depth--
+			if depth == 0 {
+				return region[open : i+1]
+			}
+		}
+	}
+	return region[open:]
 }
 
 // boundedCallSegment returns the source substring from openParen (the byte

--- a/internal/custom/javascript/inngest_test.go
+++ b/internal/custom/javascript/inngest_test.go
@@ -45,8 +45,29 @@ func findFunc(ents []types.EntityRecord, name string) *types.EntityRecord {
 	return nil
 }
 
+// findTopic returns the SCOPE.MessageTopic entity for an event name, or nil.
+func findTopic(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindMessageTopic) && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func countTopics(ents []types.EntityRecord) int {
+	n := 0
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindMessageTopic) {
+			n++
+		}
+	}
+	return n
+}
+
 // Modern object-config signature:
-//   inngest.createFunction({ id, name }, { event }, handler)
+//
+//	inngest.createFunction({ id, name }, { event }, handler)
 func TestInngestCreateFunctionObjectSignature(t *testing.T) {
 	src := `
 import { Inngest } from "inngest";
@@ -91,8 +112,15 @@ import { inngest } from "./client";
 inngest.createFunction({ id: "sync-user" }, { event: "user/created" }, async () => {});
 `
 	ents := extractInngest(t, "functions.ts", src)
-	if len(ents) != 1 {
-		t.Fatalf("expected exactly one entity, got %d: %+v", len(ents), ents)
+	// Exactly one Function entity (the consumer) ...
+	funcs := 0
+	for i := range ents {
+		if ents[i].Kind == string(types.EntityKindFunction) {
+			funcs++
+		}
+	}
+	if funcs != 1 {
+		t.Fatalf("expected exactly one Function entity, got %d: %+v", funcs, ents)
 	}
 	fn := findFunc(ents, "sync-user")
 	if fn == nil {
@@ -100,6 +128,13 @@ inngest.createFunction({ id: "sync-user" }, { event: "user/created" }, async () 
 	}
 	if got := fn.Properties["trigger_event"]; got != "user/created" {
 		t.Errorf("expected trigger_event=user/created, got %q", got)
+	}
+	// ... plus one MessageTopic for the triggered event (#5481).
+	if countTopics(ents) != 1 {
+		t.Errorf("expected exactly one MessageTopic, got %d: %+v", countTopics(ents), ents)
+	}
+	if findTopic(ents, "user/created") == nil {
+		t.Errorf("expected MessageTopic 'user/created'")
 	}
 }
 
@@ -157,5 +192,78 @@ func TestInngestNoMatch(t *testing.T) {
 	ents := extractInngest(t, "plain.ts", "const x = 1;")
 	if len(ents) != 0 {
 		t.Errorf("expected no entities, got %d", len(ents))
+	}
+}
+
+// #5481: each DISTINCT event name referenced in a createFunction trigger or an
+// inngest.send({ name }) producer call yields one SCOPE.MessageTopic entity,
+// deduped by event name, framework=inngest.
+func TestInngestEventTopics(t *testing.T) {
+	src := `
+import { inngest } from "./client";
+
+inngest.createFunction({ id: "sync-user" }, { event: "user/created" }, async () => {});
+
+export async function fanOut(id: string) {
+  // Same event referenced again as a producer — must dedupe to one topic.
+  await inngest.send({ name: "user/created", data: { id } });
+  await inngest.send({ name: "user/deleted", data: { id } });
+}
+`
+	ents := extractInngest(t, "events.ts", src)
+
+	if got := countTopics(ents); got != 2 {
+		t.Fatalf("expected 2 distinct MessageTopic entities, got %d: %+v", got, ents)
+	}
+	for _, name := range []string{"user/created", "user/deleted"} {
+		tp := findTopic(ents, name)
+		if tp == nil {
+			t.Fatalf("expected MessageTopic %q, got %+v", name, ents)
+		}
+		if tp.Subtype != "inngest" {
+			t.Errorf("topic %q: expected subtype inngest, got %q", name, tp.Subtype)
+		}
+		if got := tp.Properties["framework"]; got != "inngest" {
+			t.Errorf("topic %q: expected framework=inngest, got %q", name, got)
+		}
+		if got := tp.Properties["topic_id"]; got != "event:"+name {
+			t.Errorf("topic %q: expected topic_id=event:%s, got %q", name, name, got)
+		}
+	}
+}
+
+// #5481: typed event-schema definitions — the quoted keys of a
+// new EventSchemas().fromRecord<{ ... }>() type record become MessageTopics.
+func TestInngestEventSchemaTopics(t *testing.T) {
+	src := `
+import { Inngest, EventSchemas } from "inngest";
+
+export const inngest = new Inngest({
+  id: "app",
+  schemas: new EventSchemas().fromRecord<{
+    "user/created": { data: { id: string } };
+    "order/placed": { data: { total: number } };
+  }>(),
+});
+`
+	ents := extractInngest(t, "schemas.ts", src)
+	for _, name := range []string{"user/created", "order/placed"} {
+		tp := findTopic(ents, name)
+		if tp == nil {
+			t.Fatalf("expected MessageTopic %q from schema, got %+v", name, ents)
+		}
+		if got := tp.Properties["framework"]; got != "inngest" {
+			t.Errorf("topic %q: expected framework=inngest, got %q", name, got)
+		}
+	}
+}
+
+// #5481: the send() producer is attribution-gated just like createFunction —
+// no inngest import and a non-inngest receiver yields no topics.
+func TestInngestSendNoImportNoTopic(t *testing.T) {
+	src := `const x = mq.send({ name: "user/created" });`
+	ents := extractInngest(t, "unrelated.ts", src)
+	if countTopics(ents) != 0 {
+		t.Errorf("expected no topics without inngest attribution, got %+v", ents)
 	}
 }

--- a/testdata/fixtures/typescript/inngest_functions.ts
+++ b/testdata/fixtures/typescript/inngest_functions.ts
@@ -35,6 +35,14 @@ export const nightlyReport = inngest.createFunction(
   },
 );
 
+// #5481: producer side — inngest.send({ name }) references the same
+// "user/created" event (must dedupe with the trigger above) plus a new
+// "user/deleted" event, so this file declares two distinct MessageTopics.
+export async function deleteUser(id: string) {
+  await inngest.send({ name: "user/deleted", data: { id } });
+  await inngest.send({ name: "user/created", data: { id } });
+}
+
 declare function persistUser(data: unknown): Promise<void>;
 declare function sendEmail(to: string): Promise<void>;
 declare function buildReport(): Promise<void>;


### PR DESCRIPTION
Closes #5481 (epic #5479, Inngest Phase 1 — item 2, ENTITIES only).

## What
Extends the `custom_js_inngest` extractor (added in #5480) to emit one **`SCOPE.MessageTopic`** entity per **distinct** Inngest event name — the Inngest event analogue of a BullMQ/Kafka topic.

### Model
- Kind `SCOPE.MessageTopic`, subtype `inngest`, `framework=inngest`, `topic_id=event:<name>` (forward-compat for the #5482/#5483 edges).
- **Deduped by event name** within a file. First reference site is the topic source location; `provenance` is `INFERRED_FROM_INNGEST_EVENT_REFERENCE` or `INFERRED_FROM_INNGEST_EVENT_SCHEMA`.

### Event names are harvested from
1. `createFunction(..., { event: "user/created" }, ...)` triggers,
2. `<client>.send`/`sendEvent({ name: "user/created" })` producer payloads (one topic per `name:` key in the bounded send region),
3. typed `new EventSchemas().fromRecord<{ "user/created": ...; ... }>()` / `fromUnion` schema definitions — the quoted keys of the **balanced `<...>` type-argument** record.

Reuses #5480's import / `inngest`-receiver attribution gate and bounded-arg-region scanning, so only real Inngest code matches.

### Scope
Entity only — the EMITS/TRIGGERS edges wiring topics to producers/consumers stay in #5482/#5483.

## Registry + docs
Records the **`topic_attribution`** capability on `msg.inngest`. Note: the ticket suggested `event_extraction`, but the only valid `message_broker`/`task_queues` capability key in `capability-dictionary.yaml` for topic/event extraction is `topic_attribution` — so the capability is recorded there. `coverage validate` + `fmt --check` green; the three affected coverage docs regenerated.

## Tests
`go test -count=1 ./internal/custom/javascript/ ./tools/coverage/` green. New tests assert distinct, **deduped** MessageTopics across triggers + `inngest.send` (`user/created` referenced by both trigger and send → one topic), schema-record keys, `framework=inngest`, and that the send producer is attribution-gated. Fixture extended with an `inngest.send` producer.

### Honest-partial
Dynamic/computed event names and schema records referenced via a named type alias (`fromRecord<Events>`) rather than an inline literal are not resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)