### PR TITLE
feat(dashboard): topology screen renders Inngest event→function workflows (#5485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Topology screen renders Inngest event→function workflows (#5485):** the
+  dashboard topology surface now reflects the Inngest async-workflow graph.
+  Inngest event topics (`framework=inngest`) are grouped under a dedicated
+  `inngest` broker band (previously they fell into the generic `unknown`
+  bucket), so the event→function→event chain — a function emitting an event that
+  triggers another function, wired by the `PUBLISHES_TO`/`SUBSCRIBES_TO` edges
+  from #5482/#5483 — reads as one connected workflow. The topology detail panel
+  badges producers/consumers as "Inngest function" / "Inngest event" and, for
+  each Inngest function, lists its durable step structure inline (#5484's
+  `inngest_step` children: `run`/`sleep`/`sleepUntil`/`waitForEvent`/`invoke`,
+  with the awaited event for `waitForEvent` and the invoked target for
+  `invoke`). Extends the existing pub-sub/queue topology rendering — no new
+  extraction. Completes the Inngest epic (#5479) headline.
 - **Inngest durable functions extracted as Function entities (#5480):** the new
   `custom_js_inngest` JS/TS extractor recognises `inngest.createFunction({ id |
   name }, { event | cron }, handler)` call sites (both the modern object-config

--- a/internal/dashboard/handlers_topology.go
+++ b/internal/dashboard/handlers_topology.go
@@ -915,6 +915,12 @@ func brokerCanonical(broker, framework string) string {
 		return "sidekiq"
 	case "bullmq", "bull":
 		return "bullmq"
+	case "inngest":
+		// Inngest event topics carry framework=inngest and no broker name. Map
+		// them to their own canonical so the topology bands them under an Inngest
+		// group and the frontend can render the event→function→event workflow with
+		// Inngest-specific labeling instead of the generic "unknown" bucket (#5485).
+		return "inngest"
 	case "hangfire":
 		return "hangfire"
 	case "quartz", "quartz.net":

--- a/internal/dashboard/handlers_topology_detail.go
+++ b/internal/dashboard/handlers_topology_detail.go
@@ -12,6 +12,7 @@ package dashboard
 import (
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -33,6 +34,27 @@ type topicEntityRecord struct {
 	StartLine      int      `json:"start_line"`
 	Repo           string   `json:"repo"`
 	FlowProcessIDs []string `json:"flow_process_ids"`
+	// Framework labels the entity's messaging framework (e.g. "inngest") so the
+	// detail panel can badge an Inngest function/event distinctly (#5485).
+	Framework string `json:"framework,omitempty"`
+	// InngestSteps lists the durable step structure of an Inngest function
+	// (#5484's inngest_step Operation children, CONTAINED by the Function). Only
+	// populated for Inngest functions; empty for everything else (#5485). Lets
+	// the topology detail panel show a function's durable steps inline.
+	InngestSteps []inngestStepRecord `json:"inngest_steps,omitempty"`
+}
+
+// inngestStepRecord is one durable step of an Inngest function — a #5484
+// inngest_step Operation. step_kind is one of run/sleep/sleepUntil/
+// waitForEvent/invoke; wait_event / invoke_target are populated for the
+// cross-function step kinds.
+type inngestStepRecord struct {
+	StepID       string `json:"step_id"`
+	StepKind     string `json:"step_kind"`
+	SourceFile   string `json:"source_file,omitempty"`
+	StartLine    int    `json:"start_line,omitempty"`
+	WaitEvent    string `json:"wait_event,omitempty"`
+	InvokeTarget string `json:"invoke_target,omitempty"`
 }
 
 // topicDetailResponse is the wire shape for GET /api/topology/{group}/topic/{topicId}.
@@ -166,6 +188,14 @@ func buildTopicDetail(grp *DashGroup, groupName, topicID string) (topicDetailRes
 
 	producers := resolveEntityRecords(grp, topicRepoSlug, rawProducerIDs)
 	consumers := resolveEntityRecords(grp, topicRepoSlug, rawConsumerIDs)
+
+	// #5485: for Inngest event topics, surface each producer/consumer function's
+	// durable step structure (#5484 inngest_step children) inline so the panel
+	// shows the run/sleep/waitForEvent/invoke steps of the event→function chain.
+	if framework == "inngest" {
+		attachInngestSteps(grp, producers)
+		attachInngestSteps(grp, consumers)
+	}
 
 	// Populate FlowProcessIDs for each producer/consumer so the ↗ flow action
 	// on the topology right panel can deep-link to the relevant flow (#1943).
@@ -475,7 +505,70 @@ func entityToRecord(repo string, e *graph.Entity) topicEntityRecord {
 		StartLine:      e.StartLine,
 		Repo:           repo,
 		FlowProcessIDs: []string{},
+		Framework:      e.Properties["framework"],
 	}
+}
+
+// attachInngestSteps populates InngestSteps on every Inngest function in recs by
+// scanning the group for the function's #5484 inngest_step Operation children,
+// found via CONTAINS edges (Function → step). No-op for non-Inngest entities.
+// This surfaces a durable function's step structure in the topology detail panel
+// (#5485): clicking an Inngest event shows each producer/consumer function's
+// run/sleep/waitForEvent/invoke steps inline.
+func attachInngestSteps(grp *DashGroup, recs []topicEntityRecord) {
+	for i := range recs {
+		if recs[i].Framework != "inngest" {
+			continue
+		}
+		_, localID := dashSplitPrefixed(recs[i].EntityID)
+		steps := collectInngestSteps(grp, recs[i].Repo, localID)
+		if len(steps) > 0 {
+			recs[i].InngestSteps = steps
+		}
+	}
+}
+
+// collectInngestSteps returns the inngest_step Operation children of the Inngest
+// function with local ID funcLocalID in repo funcRepo, resolved via CONTAINS
+// edges. Steps are returned in source order (by start line) for stable display.
+func collectInngestSteps(grp *DashGroup, funcRepo, funcLocalID string) []inngestStepRecord {
+	r, ok := grp.Repos[funcRepo]
+	if !ok || r.Doc == nil {
+		return nil
+	}
+	// Build a lookup of step entities by local ID for this repo.
+	stepByID := map[string]*graph.Entity{}
+	for i := range r.Doc.Entities {
+		e := &r.Doc.Entities[i]
+		if dashStripScopePrefix(e.Kind) == "Operation" && e.Properties["framework"] == "inngest" {
+			stepByID[e.ID] = e
+		}
+	}
+	if len(stepByID) == 0 {
+		return nil
+	}
+	var out []inngestStepRecord
+	seen := map[string]bool{}
+	for _, rel := range r.Doc.Relationships {
+		if rel.Kind != "CONTAINS" || rel.FromID != funcLocalID {
+			continue
+		}
+		e := stepByID[rel.ToID]
+		if e == nil || seen[e.ID] {
+			continue
+		}
+		seen[e.ID] = true
+		out = append(out, inngestStepRecord{
+			StepID:       e.Properties["step_id"],
+			StepKind:     e.Properties["step_kind"],
+			SourceFile:   e.SourceFile,
+			StartLine:    e.StartLine,
+			WaitEvent:    e.Properties["wait_event"],
+			InvokeTarget: e.Properties["invoke_target"],
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].StartLine < out[j].StartLine })
+	return out
 }
 
 // findFlowsForEntityAndTopic returns the prefixed Process entity IDs of every

--- a/internal/dashboard/handlers_topology_inngest_test.go
+++ b/internal/dashboard/handlers_topology_inngest_test.go
@@ -1,0 +1,175 @@
+package dashboard
+
+// handlers_topology_inngest_test.go — #5485 (epic #5479, headline)
+//
+// The topology screen must reflect the Inngest async-workflow graph: events as
+// MessageTopic nodes, functions wired in via PUBLISHES_TO / SUBSCRIBES_TO, and
+// the event→function→event chain legible. Inngest entities reuse grafel's pub-
+// sub kinds, so these tests assert the Inngest-specific labeling and the step
+// detail wiring that #5485 adds on top of the existing renderer.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// inngestWorkflowDoc builds a two-function Inngest workflow chained by an
+// intermediate event:
+//
+//	order/created → send-email → email/sent → archive
+//
+// send-email is triggered by (SUBSCRIBES_TO) order/created and emits
+// (PUBLISHES_TO) email/sent; archive is triggered by email/sent. send-email has
+// two durable steps (a run + a waitForEvent).
+func inngestWorkflowDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{ID: "topic:order.created", Name: "order/created", Kind: "SCOPE.MessageTopic",
+				SourceFile: "events.ts", StartLine: 1,
+				Properties: map[string]string{"framework": "inngest", "topic_id": "event:order/created"}},
+			{ID: "topic:email.sent", Name: "email/sent", Kind: "SCOPE.MessageTopic",
+				SourceFile: "events.ts", StartLine: 2,
+				Properties: map[string]string{"framework": "inngest", "topic_id": "event:email/sent"}},
+			{ID: "fn:send-email", Name: "send-email", Kind: "SCOPE.Function",
+				SourceFile: "fns.ts", StartLine: 10,
+				Properties: map[string]string{"framework": "inngest", "function_id": "send-email"}},
+			{ID: "fn:archive", Name: "archive", Kind: "SCOPE.Function",
+				SourceFile: "fns.ts", StartLine: 40,
+				Properties: map[string]string{"framework": "inngest", "function_id": "archive"}},
+			// #5484 durable steps of send-email.
+			{ID: "step:fetch", Name: "fetch-user", Kind: "SCOPE.Operation",
+				SourceFile: "fns.ts", StartLine: 12,
+				Properties: map[string]string{"framework": "inngest", "step_kind": "run", "step_id": "fetch-user"}},
+			{ID: "step:wait", Name: "await-confirm", Kind: "SCOPE.Operation",
+				SourceFile: "fns.ts", StartLine: 20,
+				Properties: map[string]string{"framework": "inngest", "step_kind": "waitForEvent", "step_id": "await-confirm", "wait_event": "user/confirmed"}},
+		},
+		Relationships: []graph.Relationship{
+			// send-email triggered by order/created, emits email/sent.
+			{ID: "e1", FromID: "fn:send-email", ToID: "topic:order.created", Kind: "SUBSCRIBES_TO",
+				Properties: map[string]string{"framework": "inngest"}},
+			{ID: "e2", FromID: "fn:send-email", ToID: "topic:email.sent", Kind: "PUBLISHES_TO",
+				Properties: map[string]string{"framework": "inngest"}},
+			// archive triggered by email/sent.
+			{ID: "e3", FromID: "fn:archive", ToID: "topic:email.sent", Kind: "SUBSCRIBES_TO",
+				Properties: map[string]string{"framework": "inngest"}},
+			// CONTAINS: send-email → its two steps.
+			{ID: "c1", FromID: "fn:send-email", ToID: "step:fetch", Kind: "CONTAINS"},
+			{ID: "c2", FromID: "fn:send-email", ToID: "step:wait", Kind: "CONTAINS"},
+		},
+	}
+}
+
+func inngestGroup() *DashGroup {
+	return &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: inngestWorkflowDoc()}},
+	}
+}
+
+// TestCollectTopology_InngestWorkflowChain asserts the event→function→event
+// workflow renders: both events appear as topic nodes labeled with the inngest
+// broker_canonical, and the PUBLISHES_TO/SUBSCRIBES_TO edges form the chain via
+// each topic's producers/consumers (the function names).
+func TestCollectTopology_InngestWorkflowChain(t *testing.T) {
+	resp := collectTopologyResponse(inngestGroup(), "", nil)
+
+	if len(resp.Topics) != 2 {
+		t.Fatalf("expected 2 Inngest event topics, got %d", len(resp.Topics))
+	}
+
+	byLabel := map[string]map[string]any{}
+	for _, tp := range resp.Topics {
+		byLabel[tp["label"].(string)] = tp
+		if got := tp["broker_canonical"]; got != "inngest" {
+			t.Errorf("topic %v broker_canonical = %v, want inngest", tp["label"], got)
+		}
+	}
+
+	// order/created → send-email (consumer/trigger), no producer.
+	oc := byLabel["order/created"]
+	if oc == nil {
+		t.Fatal("missing order/created topic")
+	}
+	if cs, _ := oc["consumers"].([]string); len(cs) != 1 || cs[0] != "svc::fn:send-email" {
+		t.Errorf("order/created consumers = %v, want [svc::fn:send-email]", oc["consumers"])
+	}
+
+	// email/sent: produced by send-email, consumed by archive — the chain link.
+	es := byLabel["email/sent"]
+	if es == nil {
+		t.Fatal("missing email/sent topic")
+	}
+	if ps, _ := es["producers"].([]string); len(ps) != 1 || ps[0] != "svc::fn:send-email" {
+		t.Errorf("email/sent producers = %v, want [svc::fn:send-email]", es["producers"])
+	}
+	if cs, _ := es["consumers"].([]string); len(cs) != 1 || cs[0] != "svc::fn:archive" {
+		t.Errorf("email/sent consumers = %v, want [svc::fn:archive]", es["consumers"])
+	}
+
+	// A broker_groups band must be present for the inngest canonical.
+	foundBand := false
+	for _, bg := range resp.BrokerGroups {
+		if bg.Broker == "inngest" {
+			foundBand = true
+		}
+	}
+	if !foundBand {
+		t.Error("expected an 'inngest' broker_groups band")
+	}
+}
+
+// TestBrokerCanonical_Inngest asserts framework=inngest (with no broker name)
+// maps to the inngest canonical instead of "unknown".
+func TestBrokerCanonical_Inngest(t *testing.T) {
+	if got := brokerCanonical("", "inngest"); got != "inngest" {
+		t.Errorf("brokerCanonical(\"\", \"inngest\") = %q, want inngest", got)
+	}
+}
+
+// TestBuildTopicDetail_InngestSteps asserts the topology detail panel surfaces an
+// Inngest function's durable step structure (#5484 inngest_step children) and the
+// inngest framework label, on the chain-link event email/sent.
+func TestBuildTopicDetail_InngestSteps(t *testing.T) {
+	grp := inngestGroup()
+	detail, found := buildTopicDetail(grp, "", "svc::topic:email.sent")
+	if !found {
+		t.Fatal("email/sent topic detail not found")
+	}
+	if detail.Framework != "inngest" {
+		t.Errorf("detail.Framework = %q, want inngest", detail.Framework)
+	}
+
+	// send-email is the producer; it must carry its two durable steps.
+	var sendEmail *topicEntityRecord
+	for i := range detail.Producers {
+		if detail.Producers[i].Name == "send-email" {
+			sendEmail = &detail.Producers[i]
+		}
+	}
+	if sendEmail == nil {
+		t.Fatalf("send-email not found among producers: %+v", detail.Producers)
+	}
+	if sendEmail.Framework != "inngest" {
+		t.Errorf("send-email.Framework = %q, want inngest", sendEmail.Framework)
+	}
+	if len(sendEmail.InngestSteps) != 2 {
+		t.Fatalf("send-email InngestSteps = %d, want 2 (%+v)", len(sendEmail.InngestSteps), sendEmail.InngestSteps)
+	}
+	// Steps are in source order: run(fetch-user) then waitForEvent(await-confirm).
+	if sendEmail.InngestSteps[0].StepKind != "run" || sendEmail.InngestSteps[0].StepID != "fetch-user" {
+		t.Errorf("step[0] = %+v, want run/fetch-user", sendEmail.InngestSteps[0])
+	}
+	if sendEmail.InngestSteps[1].StepKind != "waitForEvent" || sendEmail.InngestSteps[1].WaitEvent != "user/confirmed" {
+		t.Errorf("step[1] = %+v, want waitForEvent wait_event=user/confirmed", sendEmail.InngestSteps[1])
+	}
+
+	// archive (consumer of email/sent) has no steps — InngestSteps must be empty.
+	for _, c := range detail.Consumers {
+		if c.Name == "archive" && len(c.InngestSteps) != 0 {
+			t.Errorf("archive should have 0 steps, got %d", len(c.InngestSteps))
+		}
+	}
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -341,6 +341,7 @@ export type BrokerCanonical =
   | "celery"
   | "task-queue"
   | "serverless"
+  | "inngest"
   | "unknown"
   | (string & Record<never, never>); // allow extension strings
 
@@ -453,6 +454,26 @@ export interface TopologyEntityRef {
   /** Prefixed Process entity IDs of flows that contain both this entity and
    *  the channel as steps — powers the ↗ flow action (#1943). */
   flow_process_ids?: string[];
+  /** Messaging framework of the entity (e.g. "inngest") — lets the detail panel
+   *  badge an Inngest function/event distinctly (#5485). */
+  framework?: string;
+  /** Durable step structure of an Inngest function (#5484 inngest_step children).
+   *  Present only for Inngest functions; powers the step list in the topology
+   *  detail panel (#5485). */
+  inngest_steps?: InngestStep[];
+}
+
+/** One durable step of an Inngest function (#5484 inngest_step Operation). */
+export interface InngestStep {
+  step_id: string;
+  /** run | sleep | sleepUntil | waitForEvent | invoke */
+  step_kind: string;
+  source_file?: string;
+  start_line?: number;
+  /** Awaited event name for a waitForEvent step. */
+  wait_event?: string;
+  /** Invoked-function reference for an invoke step. */
+  invoke_target?: string;
 }
 
 /** Detailed channel view — GET /api/topology/:group/topic/:topicId.

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -91,8 +91,23 @@ const BROKER_META: Record<
   celery:                { color: "#a3e635", bgColor: "#a3e63522", shape: "clock-shape" },
   "task-queue":          { color: "#a3e635", bgColor: "#a3e63522", shape: "clock-shape" },
   serverless:            { color: "#fde047", bgColor: "#fde04722", shape: "bolt" },
+  // Inngest event→function→event workflows (#5485). A bolt nods to the durable
+  // async-function model; the indigo hue distinguishes Inngest events from the
+  // yellow serverless bolt.
+  inngest:               { color: "#6366f1", bgColor: "#6366f122", shape: "bolt" },
   unknown:               { color: "#94a3b8", bgColor: "#94a3b822", shape: "circle" },
 };
+
+/** Human label for a topology entity's framework badge (#5485). Inngest events
+ *  and functions read as "Inngest event" / "Inngest function" so the workflow
+ *  graph is legible as Inngest rather than a generic pub-sub topic. */
+function inngestEntityLabel(framework?: string, kind?: string): string | null {
+  if (framework !== "inngest") return null;
+  const k = (kind ?? "").toLowerCase();
+  if (k === "function") return "Inngest function";
+  if (k === "messagetopic") return "Inngest event";
+  return "Inngest";
+}
 
 function brokerMeta(canonical: BrokerCanonical) {
   return BROKER_META[canonical] ?? BROKER_META["unknown"];
@@ -1131,6 +1146,12 @@ function EntityRefList({
         const flowProcessIds: string[] =
           typeof entry !== "string" ? (entry.flow_process_ids ?? []) : [];
         const firstFlowId = flowProcessIds[0] ?? null;
+        // #5485: Inngest function step structure + framework badge.
+        const framework =
+          typeof entry !== "string" ? entry.framework : undefined;
+        const inngestSteps =
+          typeof entry !== "string" ? (entry.inngest_steps ?? []) : [];
+        const inngestLabel = inngestEntityLabel(framework, ref.kind);
 
         return (
           <div
@@ -1157,10 +1178,25 @@ function EntityRefList({
                   {ref.name}
                 </span>
               )}
-              {ref.kind && ref.kind !== "unresolved" && (
-                <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-4 border border-border shrink-0 tabular-nums">
-                  {ref.kind}
+              {inngestLabel ? (
+                <span
+                  className="text-[10px] px-1.5 py-0.5 rounded shrink-0 border"
+                  style={{
+                    color: BROKER_META.inngest.color,
+                    background: BROKER_META.inngest.bgColor,
+                    borderColor: BROKER_META.inngest.color + "55",
+                  }}
+                  title={inngestLabel}
+                >
+                  {inngestLabel}
                 </span>
+              ) : (
+                ref.kind &&
+                ref.kind !== "unresolved" && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-2 text-text-4 border border-border shrink-0 tabular-nums">
+                    {ref.kind}
+                  </span>
+                )
               )}
               {/* ↗ flow action — links to first matching flow */}
               {firstFlowId && (
@@ -1201,6 +1237,47 @@ function EntityRefList({
               <p className="mt-0.5 text-[10px] text-text-4 italic">
                 Synthetic publisher (no resolved entity)
               </p>
+            )}
+
+            {/* #5485: Inngest durable step structure — run / sleep / waitForEvent
+                / invoke. Surfaced so clicking an Inngest event shows the steps of
+                the producer/consumer function inline. */}
+            {inngestSteps.length > 0 && (
+              <ol className="mt-1.5 space-y-0.5 border-l-2 border-[#6366f155] pl-2">
+                {inngestSteps.map((s, si) => (
+                  <li
+                    key={s.step_id || si}
+                    className="flex items-baseline gap-1.5 text-[11px]"
+                  >
+                    <span className="text-text-4 tabular-nums shrink-0">
+                      {si + 1}.
+                    </span>
+                    <span
+                      className="font-mono px-1 rounded shrink-0"
+                      style={{
+                        color: BROKER_META.inngest.color,
+                        background: BROKER_META.inngest.bgColor,
+                      }}
+                      title={`step.${s.step_kind}`}
+                    >
+                      {s.step_kind}
+                    </span>
+                    <span className="font-mono text-text-2 truncate">
+                      {s.step_id}
+                    </span>
+                    {s.wait_event && (
+                      <span className="text-text-4 truncate">
+                        ↦ {s.wait_event}
+                      </span>
+                    )}
+                    {s.invoke_target && (
+                      <span className="text-text-4 truncate">
+                        → {s.invoke_target}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ol>
             )}
           </div>
         );


### PR DESCRIPTION
## Summary

Makes the dashboard **topology** screen reflect the Inngest library: it now renders the event→function→event async-workflow graph. Closes the headline of the Inngest epic (#5479, item 6).

Inngest entities reuse grafel's existing pub-sub/topology kinds (events as `message_topic`, functions as `SCOPE.Function`, wired by `PUBLISHES_TO`/`SUBSCRIBES_TO`), so the workflow chain was already structurally present in the topic-grouped renderer. This change adds the Inngest-specific labeling and step detail on top — no new extraction.

## What already rendered vs. what changed

**Already rendered:** both event topics, with each function appearing in the topic's producer/consumer columns — so the `event→function→event` chain (a function emitting an event that triggers another function) was visible, matching how Kafka/BullMQ render.

**Gaps fixed:**
1. `brokerCanonical("", "inngest")` returned `unknown` (Inngest events carry only `framework=inngest`, no broker) → events fell into the generic bucket. Now mapped to a dedicated `inngest` canonical band.
2. No Inngest labeling. Now badged "Inngest event" / "Inngest function".
3. The `inngest_step` durable steps (#5484) were never surfaced. Now listed inline in the detail panel.

## Changes

- **Backend** (`internal/dashboard`):
  - `brokerCanonical`: `framework=inngest` → `inngest` canonical.
  - Topic detail: resolves each producer/consumer function's `inngest_step` children via CONTAINS edges and emits them as `inngest_steps` (sorted by source line); adds a per-entity `framework` label.
- **Frontend** (`webui-v2`):
  - `inngest` added to `BrokerCanonical` + `BROKER_META` (indigo bolt) so the band gets its own icon/color.
  - "Inngest event" / "Inngest function" badge and an inline durable-step list (`run`/`sleep`/`waitForEvent`/`invoke`, showing the awaited event / invoke target) in the topology detail panel.

## Verification
- `go test -count=1 ./internal/dashboard/...` — green (new `handlers_topology_inngest_test.go` asserts both events + both functions render, the chain edges form via producers/consumers, the `inngest` broker band exists, and the step detail surfaces with framework labels).
- `tsc --noEmit` clean; `npm run build` OK; webui-v2 unit tests green (232).
- `make dashboard-build NPM=npm` + `verify-dashboard` OK; embedded dist restored to source-only `PLACEHOLDER.md` (diff is source-only).
- `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)