### PR TITLE
feat(nextjs): extract route.ts HTTP-method handlers → endpoints (#5486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Next.js App Router `route.ts` HTTP-method handlers extracted as endpoints
+  (#5486):** each exported HTTP-method handler in an App Router Route Handler
+  file (`app/.../route.{ts,js,tsx}`) is now synthesized as a per-method
+  `http_endpoint_definition` keyed `http:<METHOD>:<path>`. Both export forms are
+  recognised — the function declaration (`export async function GET(req) {…}`)
+  and the const arrow / function-expression (`export const GET = (req) => {…}`)
+  — for the full verb set (`GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`HEAD`/
+  `OPTIONS`). The endpoint path is derived from the file's `app/`-relative
+  directory using the App Router convention: route groups `(group)` are stripped
+  (invisible to routing), dynamic segments `[id]`/`[...slug]` are normalised to
+  the canonical `{id}`/`{slug}` form, and Route Handlers are recognised anywhere
+  under `app/`, not only under `api/` (e.g. `app/feed/route.ts` → `GET /feed`,
+  `app/api/users/[id]/route.ts` → `GET /api/users/{id}`,
+  `app/(admin)/api/x/route.ts` → `GET /api/x`). Detection gates on the `route.*`
+  basename, so a `page.tsx` exporting a `GET` function is not mistaken for a
+  Route Handler. Reuses the existing `http_endpoint_definition` model; the
+  verb-named handler binds to the `SCOPE.Operation` the JS/TS extractor emits.
+  Part of the Next.js routing-coverage epic (#5479).
 - **Topology screen renders Inngest event→function workflows (#5485):** the
   dashboard topology surface now reflects the Inngest async-workflow graph.
   Inngest event topics (`framework=inngest`) are grouped under a dedicated

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -35,7 +35,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Route extraction | ✅ `full` | `2026-05-28` | 2932 | `internal/custom/javascript/nextjs.go`<br>`internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
+| Route extraction | ✅ `full` | `2026-06-24` | [link](https://github.com/cajasmota/grafel/issues/5486) | `internal/custom/javascript/nextjs.go`<br>`internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_next_route_handler_5486_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | App Router Route Handlers (#5486): each exported HTTP-method handler in app/.../route.{ts,js,tsx} — both `export async function GET(` and `export const GET = ...` forms — is synthesized as one http_endpoint_definition keyed `http:<METHOD>:<path>`. Path = the app/-relative directory with route groups `(group)` stripped and dynamic `[seg]`/`[...seg]` normalised to `{seg}`; Route Handlers are recognised anywhere under app/, not only under api/. Gating on the `route.*` basename keeps page.tsx/layout.tsx and arbitrary verb exports out. The verb-named handler is bound by the resolver to the SCOPE.Operation the JS/TS extractor emits. |
 | Router pattern | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
 
 ### Build

--- a/internal/custom/javascript/extractors_test.go
+++ b/internal/custom/javascript/extractors_test.go
@@ -2,6 +2,7 @@ package javascript_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	extreg "github.com/cajasmota/grafel/internal/extractor"
@@ -380,6 +381,34 @@ export async function POST(request: Request) { return Response.json({}) }
 	ents := extract(t, "custom_js_nextjs", fi("app/api/users/route.ts", "typescript", src))
 	if !containsSubtype(ents, "endpoint") {
 		t.Error("expected endpoint entity")
+	}
+}
+
+// #5486: `export const GET = ...` route-handler form is recognised, and a
+// Route Handler outside /api/ (App Router permits route.* anywhere under app/)
+// still yields an endpoint.
+func TestNextjsHTTPHandlerConstForm(t *testing.T) {
+	src := `
+export const GET = async (req: Request) => Response.json([])
+export const POST = async (req: Request) => Response.json({})
+`
+	ents := extract(t, "custom_js_nextjs", fi("app/feed/route.ts", "typescript", src))
+	if !containsSubtype(ents, "endpoint") {
+		t.Error("expected endpoint entity from const-form route handler")
+	}
+}
+
+// #5486: a page.tsx exporting a GET function is NOT a Route Handler — it must
+// not yield an http-method endpoint (it may still be a page-route entity, but
+// none carrying an http_method property).
+func TestNextjsPageGetExportNotEndpoint(t *testing.T) {
+	src := `export async function GET(req: Request) { return Response.json({}) }`
+	ents := extract(t, "custom_js_nextjs", fi("app/dashboard/page.tsx", "typescript", src))
+	for _, e := range ents {
+		// HTTP-method route-handler endpoints are named "<VERB> <path>".
+		if strings.HasPrefix(e.Name, "GET ") {
+			t.Errorf("page.tsx GET export must NOT produce an http-method endpoint; got %q", e.Name)
+		}
 	}
 }
 

--- a/internal/custom/javascript/nextjs.go
+++ b/internal/custom/javascript/nextjs.go
@@ -24,8 +24,13 @@ type nextjsExtractor struct{}
 func (e *nextjsExtractor) Language() string { return "custom_js_nextjs" }
 
 var (
+	// App-Router Route Handler verb exports — both the function-declaration
+	// form (`export async function GET(`) and the const arrow / function-expr
+	// form (`export const GET = `) (#5486). Group 1 (function) or group 2
+	// (const) is the verb.
 	reNextjsHTTPHandler = regexp.MustCompile(
-		`export\s+(?:async\s+)?function\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(`,
+		`export\s+(?:async\s+)?function\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*\(` +
+			`|export\s+const\s+(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s*=`,
 	)
 	reNextjsServerSideProps = regexp.MustCompile(
 		`export\s+(?:async\s+)?function\s+(getServerSideProps|getStaticProps|getStaticPaths)\s*\(`,
@@ -141,12 +146,27 @@ func (e *nextjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 	// Accept both absolute (/app/) and relative (app/) path prefixes.
 	isAppRouter := strings.Contains(fp, "/app/") || strings.HasPrefix(fp, "app/")
 	isPagesRouter := strings.Contains(fp, "/pages/") || strings.HasPrefix(fp, "pages/")
-	isAPIRoute := strings.Contains(fp, "/api/") || strings.HasPrefix(fp, "api/") || stem == "route"
 
-	// App Router: HTTP method handlers in route.ts
-	if isAppRouter && isAPIRoute {
+	// App Router: HTTP method handlers in route.{ts,js,tsx} (#5486). Gate on
+	// the `route` basename so page.tsx / arbitrary verb exports under /api/ are
+	// NOT treated as Route Handlers; App Router permits route.* anywhere under
+	// app/, not only under api/.
+	if isAppRouter && stem == "route" {
+		seenVerb := make(map[string]bool)
 		for _, m := range reNextjsHTTPHandler.FindAllStringSubmatchIndex(src, -1) {
-			method := src[m[2]:m[3]]
+			// Group 1 = function form; group 2 = const form.
+			var method string
+			if m[2] >= 0 {
+				method = src[m[2]:m[3]]
+			} else if m[4] >= 0 {
+				method = src[m[4]:m[5]]
+			} else {
+				continue
+			}
+			if seenVerb[method] {
+				continue
+			}
+			seenVerb[method] = true
 			routePath := normalizeNextjsPath(fp)
 			// strip app/ prefix and route/page suffixes
 			if idx := strings.Index(routePath, "/app/"); idx >= 0 {

--- a/internal/engine/http_endpoint_jsts_extra.go
+++ b/internal/engine/http_endpoint_jsts_extra.go
@@ -257,16 +257,31 @@ func synthesizeFastify(content string, emit emitFn) {
 // dispatch happens inside the handler at runtime).
 var nextPagesAPIRe = regexp.MustCompile(`(?:^|/)pages/api/(.+?)(?:\.(?:ts|tsx|js|jsx|mjs|cjs))$`)
 
-// nextAppRouterRe matches an `app/api/<segments>/route.{ts,js}` file path
-// (app router). Each verb is an exported function `export async function GET`
-// etc.; we emit one endpoint per exported verb.
-var nextAppRouterRe = regexp.MustCompile(`(?:^|/)app/api/(.+?)/route\.(?:ts|tsx|js|jsx|mjs|cjs)$`)
+// nextAppRouterRe matches any App-Router Route Handler file
+// `app/.../route.{ts,tsx,js,jsx,mjs,cjs}` (#5486). Route Handlers are NOT
+// restricted to an `api/` segment — `app/app/feed/route.ts`,
+// `app/(admin)/users/route.ts`, etc. are all valid. Capture group 1 is the
+// `app/`-relative directory (which may be empty for a top-level
+// `app/route.ts`); the route groups `(group)` and dynamic `[seg]` segments are
+// normalised by nextNormalizePath at emit time. Gating on the `route.*`
+// basename keeps `page.tsx`/`layout.tsx` and arbitrary verb exports out.
+var nextAppRouterRe = regexp.MustCompile(`(?:^|/)app/(?:(.+?)/)?route\.(?:ts|tsx|js|jsx|mjs|cjs)$`)
 
-// nextAppRouterVerbRe captures `export (async )?function <VERB>(` for the
-// app-router verb exports. We accept GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS.
-// Group 1 = verb.
+// nextRouteGroupRe matches an App-Router route group segment `(group)` — a
+// path component wrapped in parentheses. Route groups organise files without
+// affecting the URL, so the whole segment is removed during normalisation.
+var nextRouteGroupRe = regexp.MustCompile(`(?:^|/)\([^/]*\)(?:/|$)`)
+
+// nextAppRouterVerbRe captures the two App-Router verb-export forms (#5486):
+//
+//	export (async )?function GET(req) { … }   // function declaration
+//	export const GET = (req) => { … }          // const arrow / function expr
+//
+// We accept GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS. Group 1 (function form)
+// or group 2 (const form) is the verb.
 var nextAppRouterVerbRe = regexp.MustCompile(
-	`export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(`,
+	`export\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(` +
+		`|export\s+const\s+(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*=`,
 )
 
 // nextPagesHandlerNameRe captures the function name on
@@ -287,14 +302,26 @@ func synthesizeNextAPIRoute(filePath, content string, emit emitFn) {
 	}
 	slash := filepath.ToSlash(filePath)
 
-	// App router: app/api/<segments>/route.ts → verbs from named exports.
+	// App router: app/.../route.ts → one endpoint per exported verb handler.
+	// The path is the `app/`-relative directory; route groups `(group)` and
+	// dynamic `[seg]` segments are normalised by nextNormalizePath (#5486).
 	if m := nextAppRouterRe.FindStringSubmatch(slash); len(m) == 2 {
-		canonical := nextNormalizePath("/api/" + m[1])
+		canonical := nextNormalizePath("/" + m[1])
+		seen := make(map[string]bool)
 		for _, vm := range nextAppRouterVerbRe.FindAllStringSubmatch(content, -1) {
-			if len(vm) < 2 {
+			// Group 1 = `export function GET`; group 2 = `export const GET =`.
+			raw := vm[1]
+			if raw == "" {
+				raw = vm[2]
+			}
+			if raw == "" {
 				continue
 			}
-			verb := strings.ToUpper(vm[1])
+			verb := strings.ToUpper(raw)
+			if seen[verb] {
+				continue
+			}
+			seen[verb] = true
 			// The handler IS the verb function — name it by its export
 			// (GET/POST/...) so the resolver can bind it to the
 			// SCOPE.Operation entity the JS/TS extractor emits.
@@ -330,8 +357,29 @@ func synthesizeNextAPIRoute(filePath, content string, emit emitFn) {
 //	[...slug]    → {slug}
 //	[[...slug]]  → {slug}
 //
-// Index routes (`/api/users/index`) collapse to `/api/users`.
+// App-Router route groups `(group)` are organisational only — invisible to
+// routing — so they are stripped (#5486). Index routes (`/api/users/index`)
+// collapse to `/api/users`.
 func nextNormalizePath(p string) string {
+	// Strip App-Router route groups `(group)` — they do not appear in the URL.
+	// Replace the matched `/group/` with a single `/` so adjacent segments stay
+	// joined; run repeatedly to catch consecutive groups.
+	for nextRouteGroupRe.MatchString(p) {
+		p = nextRouteGroupRe.ReplaceAllString(p, "/")
+	}
+	// Collapse any resulting double slashes and re-establish a leading slash.
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	if p == "" {
+		p = "/"
+	} else if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	p = strings.TrimSuffix(p, "/")
+	if p == "" {
+		p = "/"
+	}
 	// Strip trailing `/index` — Next.js treats `pages/api/users/index.ts`
 	// the same as `pages/api/users.ts`.
 	if strings.HasSuffix(p, "/index") {

--- a/internal/engine/http_endpoint_next_route_handler_5486_test.go
+++ b/internal/engine/http_endpoint_next_route_handler_5486_test.go
@@ -1,0 +1,77 @@
+package engine
+
+import "testing"
+
+// Next.js App Router Route Handlers (#5486): every exported HTTP-method handler
+// in an `app/.../route.{ts,js,tsx}` file becomes one http_endpoint_definition,
+// with method = the export name and path = the `app/`-relative directory
+// (route groups `(group)` stripped, dynamic `[seg]` → `{seg}`).
+
+// TestNextRouteHandler_FunctionForm covers the `export async function GET/POST`
+// declaration form in app/api/users/route.ts → one endpoint per verb.
+func TestNextRouteHandler_FunctionForm(t *testing.T) {
+	src := `
+export async function GET(request: Request) { return Response.json([]) }
+export async function POST(request: Request) { return Response.json({}) }
+`
+	ids, _ := runDetect(t, "typescript", "app/api/users/route.ts", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+	}
+	requireContains(t, ids, want, "next-route-handler-function-form")
+}
+
+// TestNextRouteHandler_DynamicSegment covers a dynamic `[id]` segment in
+// app/api/users/[id]/route.ts → path normalised to `{id}`.
+func TestNextRouteHandler_DynamicSegment(t *testing.T) {
+	src := `export async function GET(req: Request, ctx: { params: { id: string } }) { return Response.json({}) }`
+	ids, _ := runDetect(t, "typescript", "app/api/users/[id]/route.ts", src)
+	want := []string{"http:GET:/api/users/{id}"}
+	requireContains(t, ids, want, "next-route-handler-dynamic-segment")
+}
+
+// TestNextRouteHandler_RouteGroup covers a route group `(admin)` — invisible to
+// routing — in app/(admin)/api/x/route.ts → group stripped from the path.
+func TestNextRouteHandler_RouteGroup(t *testing.T) {
+	src := `export async function GET(req: Request) { return Response.json({}) }`
+	ids, _ := runDetect(t, "typescript", "app/(admin)/api/x/route.ts", src)
+	want := []string{"http:GET:/api/x"}
+	requireContains(t, ids, want, "next-route-handler-route-group")
+}
+
+// TestNextRouteHandler_ConstForm covers the `export const GET = (...) => {}`
+// arrow/function-expression export form.
+func TestNextRouteHandler_ConstForm(t *testing.T) {
+	src := `
+export const GET = async (req: Request) => Response.json([])
+export const DELETE = async (req: Request) => new Response(null, { status: 204 })
+`
+	ids, _ := runDetect(t, "typescript", "app/api/items/route.ts", src)
+	want := []string{
+		"http:GET:/api/items",
+		"http:DELETE:/api/items",
+	}
+	requireContains(t, ids, want, "next-route-handler-const-form")
+}
+
+// TestNextRouteHandler_NonApiRoute covers a Route Handler NOT under `api/` —
+// App Router permits `route.ts` anywhere under `app/` (#5486).
+func TestNextRouteHandler_NonApiRoute(t *testing.T) {
+	src := `export async function GET(req: Request) { return Response.json({}) }`
+	ids, _ := runDetect(t, "typescript", "app/feed/route.ts", src)
+	want := []string{"http:GET:/feed"}
+	requireContains(t, ids, want, "next-route-handler-non-api")
+}
+
+// TestNextRouteHandler_PageNotEndpoint proves a `page.tsx` exporting a `GET`
+// function is NOT a Route Handler and produces no http_endpoint_definition —
+// the gating is on the `route.*` basename, not arbitrary verb exports.
+func TestNextRouteHandler_PageNotEndpoint(t *testing.T) {
+	src := `export async function GET(req: Request) { return Response.json({}) }`
+	ids, _ := runDetect(t, "typescript", "app/dashboard/page.tsx", src)
+	requireNotContains(t, ids, []string{
+		"http:GET:/dashboard",
+		"http:GET:/dashboard/page",
+	}, "next-page-not-endpoint")
+}


### PR DESCRIPTION
## Summary

Closes the App Router method-level Route Handler gap (#5486, milestone 0.1.5, epic #5479). Next.js routing was mostly covered already (file-based `page`/`pages` routes, data loaders, RSC boundaries, middleware); this fills in the **per-method HTTP handlers** in `app/.../route.{ts,js,tsx}`.

Each exported HTTP-method handler becomes one `http_endpoint_definition` keyed `http:<METHOD>:<path>`:

- **Both export forms** — `export async function GET(req) {…}` and `export const GET = (req) => {…}` — for `GET`/`POST`/`PUT`/`PATCH`/`DELETE`/`HEAD`/`OPTIONS`.
- **Recognised anywhere under `app/`**, not only `app/api/` (App Router permits `route.*` in any segment).
- **Gated on the `route.*` basename**, so `page.tsx`/`layout.tsx` and arbitrary verb exports do not produce endpoints.

### Path derivation

Path = the file's `app/`-relative directory, normalised by `nextNormalizePath`:

| File | Endpoint |
|---|---|
| `app/api/users/route.ts` (GET, POST) | `GET /api/users`, `POST /api/users` |
| `app/api/users/[id]/route.ts` | `GET /api/users/{id}` |
| `app/(admin)/api/x/route.ts` | `GET /api/x` (route group stripped) |
| `app/feed/route.ts` | `GET /feed` (no `api/`) |
| `app/dashboard/page.tsx` (GET export) | *(none)* |

Route groups `(group)` are stripped (invisible to routing); dynamic `[seg]`/`[...seg]`/`[[...seg]]` map to the canonical `{seg}` form already used by the cross-repo linker.

### Endpoint model reused

The canonical producer-side `http_endpoint_definition` (`internal/engine/http_endpoint_jsts_extra.go::synthesizeNextAPIRoute`), via the shared engine `emit` closure — same path the existing pages-router / `app/api` synthesizer used. The verb-named handler binds to the `SCOPE.Operation` the JS/TS extractor emits, so the existing handler→file/line resolver applies unchanged.

The custom extractor's app-router handler regex (`internal/custom/javascript/nextjs.go`) is widened to the const form and re-gated on the `route` basename for binding parity.

### Tests

- `internal/engine/http_endpoint_next_route_handler_5486_test.go` — function form (GET+POST), dynamic segment, route group, const form, non-`api` route, and a `page.tsx` negative.
- `internal/custom/javascript/extractors_test.go` — const-form + page.tsx negative for the custom extractor.

`go test ./internal/engine/... ./internal/custom/javascript/... ./tools/coverage/` green; `coverage validate` + `fmt --check` green; docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)