### PR TITLE
feat(nextjs): RSC server-component data-fetch → CALLS/READS edges (#5488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Next.js React Server Component data-fetch edges (#5488):** an async
+  App-Router Server Component (a `page.tsx`/`layout.tsx` or other server
+  component with no `'use client'` directive) now emits first-class edges to the
+  data sources it awaits during render, so the server-side data flow of a route
+  is queryable. An awaited call to a local/imported data function — `await
+  getUser(id)`, `await db.user.findMany()`, a `*.server.ts` model fn — produces a
+  `CALLS` edge from the component to the callee, and a direct `await fetch(url)`
+  produces a `data_fetch` site plus a `READS_FROM` edge. Both are tagged
+  `rsc_data_fetch=true` (with the resolved `url`/`callee` and `rendering=server`).
+  The pass is gated to server components — App-Router page/layout files with no
+  module-level `'use client'` — so client components and their event handlers,
+  which use the same call syntax, are never mislabelled as server data-fetches.
+  Completes the Next.js routing-coverage epic (#5479).
 - **Next.js Server Actions extracted as operations, including the `action()`
   wrapper pattern (#5487):** Server Actions are now recognised in three forms,
   each emitted as a `SCOPE.Operation`/`server_action` operation bound to its

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -22,7 +22,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Data loaders | ✅ `full` | — | [link](https://github.com/cajasmota/grafel/issues/2858) | `internal/custom/javascript/issue2858_metafw_server_test.go`<br>`internal/custom/javascript/issue2858_realdata_test.go`<br>`internal/custom/javascript/nextjs.go` | — |
+| Data loaders | ✅ `full` | — | [link](https://github.com/cajasmota/grafel/issues/2858) | `internal/custom/javascript/issue2858_metafw_server_test.go`<br>`internal/custom/javascript/issue2858_realdata_test.go`<br>`internal/custom/javascript/issue5488_rsc_datafetch_test.go`<br>`internal/custom/javascript/nextjs.go`<br>`internal/custom/javascript/rsc_datafetch.go` | #5488 (epic #5479): App-Router async Server Components now emit server-side data-fetch edges — CALLS to awaited data fns / *.server.ts model fns and READS_FROM for direct await fetch(url), each tagged rsc_data_fetch=true. Gated to server components (no use client) so client event handlers are not mislabelled. |
 
 ### Server
 

--- a/internal/custom/javascript/issue5488_rsc_datafetch_test.go
+++ b/internal/custom/javascript/issue5488_rsc_datafetch_test.go
@@ -1,0 +1,152 @@
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// issue5488_rsc_datafetch_test.go — React Server Component data-fetch edges
+// (#5488, epic #5479).
+//
+// Proves an async App-Router Server Component (a `page.tsx`/`layout.tsx` with no
+// `'use client'`) emits server-side data-fetch edges to the data sources it awaits:
+//   - `await getUser(id)` (a `*.server.ts` model fn / imported data fn) → CALLS
+//     edge component→getUser, tagged rsc_data_fetch=true.
+//   - `await fetch(url)` → a data_fetch site + READS_FROM edge, tagged
+//     rsc_data_fetch=true.
+// Negative: a `'use client'` component making the same calls is NOT tagged as an
+// RSC data-fetch (those are client-side event handlers / effects).
+
+// serverComponent returns the implicit Server Component marker entity (or nil).
+func serverComponent(ents []types.EntityRecord) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Pattern" && ents[i].Subtype == "server_component" {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func rscEdge(e *types.EntityRecord, kind, toLeaf string) *types.RelationshipRecord {
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == kind && r.Properties["rsc_data_fetch"] == "true" {
+			if toLeaf == "" || r.ToID == toLeaf {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func TestNextjs5488RSCCallsModelFn(t *testing.T) {
+	src := `import { getUser } from '@/lib/users.server'
+
+export default async function Page({ params }: { params: { id: string } }) {
+  const user = await getUser(params.id)
+  return <div>{user.name}</div>
+}
+`
+	ents := extractNext(t, "app/users/[id]/page.tsx", src)
+	sc := serverComponent(ents)
+	if sc == nil {
+		t.Fatal("expected implicit Server Component marker")
+	}
+	if sc.Properties["rsc_data_fetch"] != "true" {
+		t.Errorf("server component should be tagged rsc_data_fetch=true, props=%v", sc.Properties)
+	}
+	e := rscEdge(sc, "CALLS", "getUser")
+	if e == nil {
+		t.Fatalf("expected CALLS edge component→getUser tagged rsc_data_fetch, rels=%v", sc.Relationships)
+	}
+	if e.Properties["rendering"] != "server" {
+		t.Errorf("CALLS edge rendering = %q, want server", e.Properties["rendering"])
+	}
+}
+
+func TestNextjs5488RSCMemberChainCall(t *testing.T) {
+	src := `export default async function Page() {
+  const users = await db.user.findMany()
+  return <ul>{users.map(u => <li key={u.id}>{u.name}</li>)}</ul>
+}
+`
+	ents := extractNext(t, "app/page.tsx", src)
+	sc := serverComponent(ents)
+	// member chain `db.user.findMany` binds on its leaf name.
+	if rscEdge(sc, "CALLS", "findMany") == nil {
+		t.Fatalf("expected CALLS edge component→findMany (db.user.findMany), rels=%v", relsOf(sc))
+	}
+}
+
+func TestNextjs5488RSCAwaitFetch(t *testing.T) {
+	src := `export default async function Page() {
+  const res = await fetch('https://api.example.com/users')
+  const users = await res.json()
+  return <div>{users.length}</div>
+}
+`
+	ents := extractNext(t, "app/dashboard/page.tsx", src)
+	sc := serverComponent(ents)
+	if sc == nil {
+		t.Fatal("expected implicit Server Component marker")
+	}
+	e := rscEdge(sc, "READS_FROM", "")
+	if e == nil {
+		t.Fatalf("expected READS_FROM edge for await fetch, rels=%v", relsOf(sc))
+	}
+	if got := e.Properties["url"]; got != "https://api.example.com/users" {
+		t.Errorf("fetch url = %q, want the literal URL", got)
+	}
+	// The data_fetch site entity must exist and be tagged.
+	var site *types.EntityRecord
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Operation" && ents[i].Subtype == "data_fetch" {
+			site = &ents[i]
+		}
+	}
+	if site == nil {
+		t.Fatal("expected a data_fetch site entity for await fetch")
+	}
+	if site.Properties["rsc_data_fetch"] != "true" {
+		t.Errorf("data_fetch site should be tagged rsc_data_fetch=true, props=%v", site.Properties)
+	}
+}
+
+func TestNextjs5488ClientComponentNotTagged(t *testing.T) {
+	// A 'use client' component making the same calls inside a handler must NOT be
+	// tagged as an RSC server data-fetch.
+	src := `'use client'
+import { getUser } from '@/lib/users.server'
+
+export default function Page() {
+  const onClick = async () => {
+    const user = await getUser('1')
+    await fetch('/api/log')
+  }
+  return <button onClick={onClick}>load</button>
+}
+`
+	ents := extractNext(t, "app/profile/page.tsx", src)
+	// No server_component marker (it's a client component), so no rsc edge anywhere.
+	if sc := serverComponent(ents); sc != nil {
+		t.Errorf("'use client' file must not produce a server_component marker")
+	}
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Properties["rsc_data_fetch"] == "true" {
+				t.Errorf("client component must not emit rsc_data_fetch edges, got %+v on %s", r, ents[i].Name)
+			}
+		}
+	}
+}
+
+func relsOf(e *types.EntityRecord) []types.RelationshipRecord {
+	if e == nil {
+		return nil
+	}
+	return e.Relationships
+}

--- a/internal/custom/javascript/nextjs.go
+++ b/internal/custom/javascript/nextjs.go
@@ -366,7 +366,22 @@ func (e *nextjsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 	// Component (the RSC default). Gated to genuine route component files so
 	// non-route .ts utilities don't get the implicit-server marker.
 	if isJSXFile && isAppRouter && nextjsPageFiles[stem] && !hasUseClient {
-		addEntity(metafwServerComponentEntity(stem, file.Path, file.Language, "nextjs"))
+		sc := metafwServerComponentEntity(stem, file.Path, file.Language, "nextjs")
+		// RSC data-fetch edges (#5488): an async server component loads its data on
+		// the server by awaiting data-access calls (`await getUsers()`,
+		// `await db.user.findMany()`) and direct `await fetch(url)`. Emit the
+		// component → data-source edges, tagged rsc_data_fetch. Gated to a server
+		// component above (no `'use client'`, App-Router page/layout), so client
+		// components / event handlers are never mislabelled as server data-fetches.
+		dfEnts, dfRels := rscDataFetchEdges(&sc, src, file.Path, file.Language)
+		if len(dfRels) > 0 {
+			setProps(&sc, "rsc_data_fetch", "true")
+			sc.Relationships = append(sc.Relationships, dfRels...)
+		}
+		addEntity(sc)
+		for _, de := range dfEnts {
+			addEntity(de)
+		}
 	}
 
 	// Server Actions (#2858, #5487). Recognised in three forms, each emitted as a

--- a/internal/custom/javascript/rsc_datafetch.go
+++ b/internal/custom/javascript/rsc_datafetch.go
@@ -1,0 +1,125 @@
+package javascript
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// rsc_datafetch.go — React Server Component data-fetch edges (#5488, epic #5479).
+//
+// An App-Router React Server Component (an async `page.tsx`/`layout.tsx` or other
+// server component with NO `'use client'` directive) loads its data on the server
+// during render. It does so by `await`-ing data-access calls: a local/imported
+// data function (`getUsers()`, `fetchPost(id)`, a `*.server.ts` model fn) or a
+// direct `await fetch(url)`. Those awaited data-access sites are the server-side
+// data-flow of the route — but they were not surfaced as edges from the component.
+//
+// This pass lifts that flow to a first-class edge from the server-component entity
+// to the data source it awaits:
+//
+//   - `await getUsers()` / `await db.user.findMany()` → CALLS edge component→callee,
+//     tagged `rsc_data_fetch=true` so the RSC→data flow is queryable. The resolver
+//     binds the callee name to the real function/model entity (esp. `*.server.ts`).
+//   - `await fetch(url)`                              → a data-fetch site
+//     (SCOPE.Operation subtype="data_fetch") + a READS_FROM edge, tagged
+//     `rsc_data_fetch=true`.
+//
+// Gating: only runs for a *server* component — an App-Router `page`/`layout`/server
+// component file with no module-level `'use client'`. Client components (which use
+// the same call syntax inside event handlers / effects) are NOT tagged, so client
+// event handlers are never mislabelled as server data-fetches.
+
+var (
+	// reRSCAwaitCall matches an awaited call to a bare identifier or a member
+	// chain — `await getUsers(`, `await db.user.findMany(`, `await api.posts.list(`.
+	// Group 1 is the full callee expression (identifier or dotted member ref). The
+	// `fetch` builtin is handled separately (reRSCAwaitFetch) and filtered out here.
+	reRSCAwaitCall = regexp.MustCompile(`\bawait\s+([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(`)
+
+	// reRSCAwaitFetch matches a direct `await fetch('url'|"url"|`url`|expr)` — the
+	// Web fetch data load. Group 1 (when present) is the literal URL.
+	reRSCAwaitFetch = regexp.MustCompile(`\bawait\s+fetch\s*\(\s*(?:['"` + "`" + `]([^'"` + "`" + `]*)['"` + "`" + `])?`)
+)
+
+// rscDataFetchOwner emits the server-side data-fetch edges for a server-component
+// owner. owner is the EntityRecord representing the (implicit) Server Component;
+// src is the full module source. It returns the data-fetch site entities to add
+// plus the edges to hang off the owner. callers gate this on the file being a
+// server component (no `'use client'`, App-Router page/layout/server component).
+//
+// Both CALLS (function/model fetch) and READS_FROM (`await fetch`) edges carry
+// `rsc_data_fetch=true` so a consumer can ask "what does this server component
+// load during render".
+func rscDataFetchEdges(owner *types.EntityRecord, src, filePath, language string) (ents []types.EntityRecord, rels []types.RelationshipRecord) {
+	seenCall := map[string]bool{}
+
+	// Direct `await fetch(url)` → data_fetch site + READS_FROM edge.
+	seenFetch := map[string]bool{}
+	for _, m := range reRSCAwaitFetch.FindAllStringSubmatchIndex(src, -1) {
+		url := ""
+		if m[2] >= 0 {
+			url = src[m[2]:m[3]]
+		}
+		key := "fetch|" + url
+		if seenFetch[key] {
+			continue
+		}
+		seenFetch[key] = true
+		name := "fetch"
+		if url != "" {
+			name = "fetch " + url
+		}
+		site := makeEntity(name, "SCOPE.Operation", "data_fetch", filePath, language, lineOf(src, m[0]))
+		setProps(&site, "framework", "nextjs", "fetch_kind", "web_fetch",
+			"url", url, "rsc_data_fetch", "true", "rendering", "server",
+			"provenance", "INFERRED_FROM_RSC_FETCH")
+		ents = append(ents, site)
+		rels = append(rels, types.RelationshipRecord{
+			FromID: owner.Name,
+			ToID:   site.ID,
+			Kind:   string(types.RelationshipKindReadsFrom),
+			Properties: map[string]string{
+				"framework":      "nextjs",
+				"rsc_data_fetch": "true",
+				"fetch_kind":     "web_fetch",
+				"url":            url,
+				"provenance":     "INFERRED_FROM_RSC_FETCH",
+			},
+		})
+	}
+
+	// Awaited data-access calls → CALLS edge component→callee.
+	for _, m := range reRSCAwaitCall.FindAllStringSubmatchIndex(src, -1) {
+		callee := src[m[2]:m[3]]
+		// `await fetch(...)` is modelled above as a READS_FROM data-fetch site.
+		if callee == "fetch" {
+			continue
+		}
+		if seenCall[callee] {
+			continue
+		}
+		seenCall[callee] = true
+		// The resolver binds the callee name to the real function / model entity
+		// (a local helper, an imported `getX`/`fetchX`, or a `*.server.ts` model
+		// fn). Use the leaf name as the bind target; keep the full chain for context.
+		leaf := callee
+		if i := strings.LastIndexByte(callee, '.'); i >= 0 {
+			leaf = callee[i+1:]
+		}
+		rels = append(rels, types.RelationshipRecord{
+			FromID: owner.Name,
+			ToID:   leaf,
+			Kind:   string(types.RelationshipKindCalls),
+			Properties: map[string]string{
+				"framework":      "nextjs",
+				"rsc_data_fetch": "true",
+				"callee":         callee,
+				"rendering":      "server",
+				"provenance":     "INFERRED_FROM_RSC_DATA_FETCH",
+			},
+		})
+	}
+	return ents, rels
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -2323,6 +2323,19 @@ records:
 
   lang.jsts.framework.next-api:
     capabilities:
+      Data Flow:
+        data_loaders:
+          status: full
+          symbols:
+            - file: internal/custom/javascript/nextjs.go
+              functions: [Extract]
+            - file: internal/custom/javascript/rsc_datafetch.go
+              functions: [rscDataFetchEdges]
+          tests:
+            - file: internal/custom/javascript/issue5488_rsc_datafetch_test.go
+              functions: [TestNextjs5488RSCCallsModelFn, TestNextjs5488RSCMemberChainCall, TestNextjs5488RSCAwaitFetch, TestNextjs5488ClientComponentNotTagged]
+          issues_implemented: ["2858", "5488"]
+          verified_at: "2026-06-24"
       Routing:
         route_extraction:
           status: full


### PR DESCRIPTION
Closes #5488. Refs #5479 (final Next.js item, Phase 4).

## What
An async App-Router **React Server Component** (a `page.tsx`/`layout.tsx` or other server component with **no** `'use client'` directive) now emits first-class edges to the data sources it awaits during render, so the server-side data flow of a route is queryable.

- `await getUser(id)` / `await db.user.findMany()` / an imported `*.server.ts` model fn → **CALLS** edge component→callee (leaf-name bound by the resolver), reusing the existing kind.
- direct `await fetch(url)` → a `SCOPE.Operation`/`data_fetch` site + a **READS_FROM** edge, with the literal URL captured.

Both edges are tagged `rsc_data_fetch=true` (plus `rendering=server` and the resolved `callee`/`url`).

## Investigation: existed vs added
The Next.js extractor (#2858) already recognised the server-vs-client split as **markers** (`'use client'`/`'use server'`, `*.server.*`, the implicit-Server-Component default) and the framework **data loaders** — but it never traversed the async component body for the data-access it awaits, so there was **no edge** from the component to `getUser()` / `fetch(url)`. This PR adds that pass (`internal/custom/javascript/rsc_datafetch.go`).

## The RSC gate
Edges are emitted only from the existing implicit-server-component path, gated on `isJSXFile && isAppRouter && nextjsPageFiles[stem] && !hasUseClient`. A `'use client'` file produces no `server_component` marker and therefore **no** `rsc_data_fetch` edges — client components / event handlers using the same call syntax are never mislabelled.

## Tests
`internal/custom/javascript/issue5488_rsc_datafetch_test.go`: imported `*.server.ts` model fn → CALLS; member-chain `db.user.findMany()` → CALLS on the leaf; `await fetch(url)` → data_fetch site + READS_FROM with URL; `'use client'` component with the same calls → **NOT** tagged.

## Registry / docs
`data_loaders` (Data Flow group) on `next-api` uplifted with the new files + #5488 note. `coverage validate` exit 0, `coverage fmt --check` canonical, docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)