### PR TITLE
feat(prisma): resolve modular split schema (prisma/schema/*.prisma) cross-file (#5489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Prisma modular split schema resolved cross-file (#5489):** the Prisma schema
+  extractor now treats a modular split schema — `prisma/schema/*.prisma`, one
+  domain per file, the `prismaSchemaFolder` preview feature — as ONE logical
+  schema. When a `.prisma` file lives in a folder holding multiple `.prisma`
+  files, the extractor unions the model and enum symbol tables across every file
+  in that schema folder before resolving relation targets. As a result a `model
+  Post` in `post.prisma` carrying `author User @relation(...)` now produces a
+  resolved `Post → User` relationship edge even though `model User` lives in
+  `user.prisma`, and a field whose type names an `enum` declared in a sibling
+  file (e.g. `status Status` → `enums.prisma`) resolves to that enum instead of
+  dangling. Cross-file relation fields are no longer dropped as honest-partial.
+  Models keep their real source file and location. The single-`schema.prisma`
+  case is unchanged (one file = the union of one). Part of the framework-stack
+  coverage epic (#5479).
 - **Next.js React Server Component data-fetch edges (#5488):** an async
   App-Router Server Component (a `page.tsx`/`layout.tsx` or other server
   component with no `'use client'` directive) now emits first-class edges to the

--- a/docs/coverage/detail/lang.jsts.orm.prisma.md
+++ b/docs/coverage/detail/lang.jsts.orm.prisma.md
@@ -17,7 +17,7 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/orms/prisma.yaml`<br>`internal/engine/rules/javascript_typescript/orms/prisma_client_js.yaml`<br>`internal/engine/rules/prisma/_manifest.yaml` | — |
 | Model lifecycle extraction | 🔴 `missing` | — | 3628 | — | — |
-| Schema extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/prisma.go` | — |
+| Schema extraction | ✅ `full` | `2026-06-24` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/prisma.go`<br>`internal/custom/javascript/prisma_modular_test.go` | #5489: modular split schema (prismaSchemaFolder) — prisma/schema/*.prisma (one domain per file) is resolved as ONE logical schema. prismaModularSiblings unions model/enum names across every .prisma file in the schema folder, so cross-file @relation targets, relation-field types, and enum references resolve. Models keep their real source file. Single-schema.prisma is the union of one (no regression). Test: TestPrismaModularSplitSchema/TestPrismaSingleFileSchemaNoRegression. |
 
 ### Relationships
 
@@ -26,7 +26,7 @@ Auto-generated. Back to [summary](../summary.md).
 | Association extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/prisma.go` | — |
 | Foreign key extraction | ✅ `full` | `2026-05-29` | 3067 | `internal/custom/javascript/orm_build_3067_test.go`<br>`internal/custom/javascript/prisma.go` | — |
 | Lazy loading recognition | — `not_applicable` | — | — | — | Prisma uses explicit include/select — eager-only per Prisma docs; no transparent lazy loading (#3184) |
-| Relationship extraction | ✅ `full` | `2026-06-02` | — | `internal/custom/javascript/orm_relationship_edges_test.go`<br>`internal/custom/javascript/prisma.go` | Model↔model GRAPH_RELATES edges with cardinality from schema.prisma relation fields: Order[]→one_to_many, Type @relation(fields:...)→many_to_one, Type?→one_to_one; scalar/enum/cross-file types emit no edge. Test: TestPrismaGraphRelatesEdges/TestPrismaScalarFieldNoEdge. |
+| Relationship extraction | ✅ `full` | `2026-06-24` | — | `internal/custom/javascript/orm_relationship_edges_test.go`<br>`internal/custom/javascript/prisma.go`<br>`internal/custom/javascript/prisma_modular_test.go` | Model↔model GRAPH_RELATES edges with cardinality from relation fields: Order[]→one_to_many, Type @relation(fields:...)→many_to_one, Type?→one_to_one; scalar/composite types emit no edge. #5489: under the modular split schema (prismaSchemaFolder, prisma/schema/*.prisma) the model symbol table is the UNION across all .prisma files in the schema folder, so a relation whose target model lives in a sibling file resolves cross-file. Test: TestPrismaGraphRelatesEdges/TestPrismaScalarFieldNoEdge/TestPrismaModularSplitSchema. |
 
 ### Queries
 

--- a/internal/custom/javascript/prisma.go
+++ b/internal/custom/javascript/prisma.go
@@ -3,6 +3,7 @@ package javascript
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -125,6 +126,68 @@ func prismaModelBlocks(src string) []struct {
 	return blocks
 }
 
+// prismaModularSiblings returns the union of model and enum names declared in
+// EVERY `.prisma` file that shares the schema folder with the file at relPath,
+// realizing Prisma's modular split-schema layout (the `prismaSchemaFolder`
+// preview feature: `prisma/schema/*.prisma`, one domain per file). All sibling
+// files form ONE logical schema, so a `model Post` in `post.prisma` can carry
+// `author User @relation(...)` where `model User` lives in `user.prisma`.
+//
+// Detection is structural: the file lives in a directory that holds more than
+// one `.prisma` file (the canonical layout is a `prisma/schema/` folder, but we
+// don't hardcode the name — any multi-`.prisma` folder is treated as a split
+// schema). The single-`schema.prisma` case yields no siblings, so the union
+// collapses to just the in-file symbol table (one file = the union of one).
+//
+// Returns (modelNames, enumNames). Both are nil when repoRoot is empty (direct
+// fixture tests that don't set RepoRoot), when the directory can't be read, or
+// when the file is the only `.prisma` file in its folder.
+func prismaModularSiblings(repoRoot, relPath string) (models, enums map[string]bool) {
+	if repoRoot == "" {
+		return nil, nil
+	}
+	dirAbs := filepath.Dir(filepath.Join(repoRoot, filepath.FromSlash(relPath)))
+	entries, err := os.ReadDir(dirAbs)
+	if err != nil {
+		return nil, nil
+	}
+	var prismaFiles []string
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(ent.Name(), ".prisma") {
+			prismaFiles = append(prismaFiles, ent.Name())
+		}
+	}
+	// A lone `.prisma` file in the folder is the single-file case; the caller's
+	// in-file symbol table already covers it. Only a multi-file folder is a
+	// modular split schema worth unioning.
+	if len(prismaFiles) < 2 {
+		return nil, nil
+	}
+	base := filepath.Base(relPath)
+	models = make(map[string]bool)
+	enums = make(map[string]bool)
+	for _, name := range prismaFiles {
+		if name == base {
+			continue // siblings only; the current file is unioned by the caller
+		}
+		data, err := os.ReadFile(filepath.Join(dirAbs, name))
+		if err != nil {
+			continue
+		}
+		sib := string(data)
+		for _, m := range rePrismaModel.FindAllStringSubmatch(sib, -1) {
+			models[m[1]] = true
+		}
+		for _, m := range rePrismaEnum.FindAllStringSubmatch(sib, -1) {
+			enums[m[1]] = true
+		}
+	}
+	return models, enums
+}
+
 // alterTableOpSubtype maps an ALTER TABLE clause keyword to a schema-change subtype.
 func alterTableOpSubtype(clause string) string {
 	switch strings.ToUpper(clause) {
@@ -183,6 +246,21 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 	// set of known model names so targets resolve in-file.
 	modelIdx := make(map[string]int)
 	knownModels := make(map[string]bool)
+	knownEnums := make(map[string]bool)
+	// Modular split schema (`prismaSchemaFolder`): a `prisma/schema/*.prisma`
+	// folder is ONE logical schema. Seed the symbol table with model/enum names
+	// declared in SIBLING `.prisma` files so cross-file @relation targets, field
+	// types, and enum references resolve. Empty (nil) for the single-file case —
+	// then the union is just this file's own symbols, added below.
+	if isPrismaSchema {
+		sibModels, sibEnums := prismaModularSiblings(file.RepoRoot, file.Path)
+		for name := range sibModels {
+			knownModels[name] = true
+		}
+		for name := range sibEnums {
+			knownEnums[name] = true
+		}
+	}
 	for _, m := range rePrismaModel.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		ent := makeEntity(name, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
@@ -197,6 +275,7 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 	// Prisma schema enums
 	for _, m := range rePrismaEnum.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
+		knownEnums[name] = true
 		ent := makeEntity(name, "SCOPE.Schema", "enum", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "framework", "prisma", "provenance", "INFERRED_FROM_PRISMA_ENUM")
 		addEntity(ent)
@@ -253,6 +332,13 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 				setProps(&ent, "target_model", baseType)
 				ent.Relationships = append(ent.Relationships,
 					referencesClassEdge(ent.ID, baseType, "prisma", fieldName))
+			} else if knownEnums[baseType] {
+				// Enum-typed field — resolves to the enum node (possibly in a
+				// sibling `.prisma` file under the modular split layout). Record
+				// a REFERENCES edge so the cross-file enum is not a dangling type.
+				setProps(&ent, "target_enum", baseType)
+				ent.Relationships = append(ent.Relationships,
+					referencesClassEdge(ent.ID, baseType, "prisma", fieldName))
 			}
 			entities[modelIdx[owner]].Relationships = append(entities[modelIdx[owner]].Relationships,
 				containsFieldEdge(owner, ent.ID, fieldName, "prisma"))
@@ -300,8 +386,12 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 		//	profile  Profile?                             → one_to_one   (back side)
 		//
 		// FromID/ToID use the Class:<Model> convention so the resolver byName
-		// index links them to the model nodes. Cross-file target types are
-		// honest-partial (no edge — the model isn't a known in-file node).
+		// index links them to the model nodes. knownModels is the UNION of this
+		// file's models and those declared in SIBLING `.prisma` files under the
+		// modular split layout (prismaSchemaFolder), so a relation whose target
+		// model lives in another file of the same `prisma/schema/` folder
+		// resolves cross-file. A capitalized type that is neither a model nor an
+		// enum (e.g. a composite `type`) is still skipped — not a model relation.
 		for _, blk := range prismaModelBlocks(src) {
 			ownerIdx, ok := modelIdx[blk.name]
 			if !ok {
@@ -313,7 +403,7 @@ func (e *prismaExtractor) Extract(ctx context.Context, file extreg.FileInput) ([
 				isList := strings.HasSuffix(rawType, "[]")
 				baseType := strings.TrimSuffix(strings.TrimSuffix(rawType, "[]"), "?")
 				if !knownModels[baseType] {
-					continue // scalar/enum/cross-file type — not a model relation
+					continue // scalar/enum/composite type — not a model relation
 				}
 				// Determine cardinality. The list side is always one_to_many.
 				// The singular side is many_to_one when this field owns the FK

--- a/internal/custom/javascript/prisma_modular_test.go
+++ b/internal/custom/javascript/prisma_modular_test.go
@@ -1,0 +1,138 @@
+package javascript_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+
+	_ "github.com/cajasmota/grafel/internal/custom/javascript"
+)
+
+// prismaFileInput reads a `.prisma` file from testdata and returns a FileInput
+// whose Path is repo-root-relative and whose RepoRoot points at the fixture
+// root, so the extractor can discover sibling `.prisma` files (the modular
+// split-schema layout).
+func prismaFileInput(t *testing.T, fixtureRoot, relPath string) extreg.FileInput {
+	t.Helper()
+	abs, err := filepath.Abs(fixtureRoot)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(abs, filepath.FromSlash(relPath)))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", relPath, err)
+	}
+	return extreg.FileInput{
+		Path:     relPath,
+		Language: "prisma",
+		Content:  content,
+		RepoRoot: abs,
+	}
+}
+
+func referencesEdge(ents []types.EntityRecord, target, fieldName string) *types.RelationshipRecord {
+	for ei := range ents {
+		for ri := range ents[ei].Relationships {
+			r := &ents[ei].Relationships[ri]
+			if r.Kind == string(types.RelationshipKindReferences) &&
+				r.ToID == "Class:"+target &&
+				r.Properties["field_name"] == fieldName {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func hasModelEntity(ents []types.EntityRecord, name string) bool {
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "model" && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPrismaModularSplitSchema verifies that under the `prismaSchemaFolder`
+// modular layout (prisma/schema/*.prisma, one domain per file), cross-file
+// model relations and enum references resolve as one logical schema.
+//
+//	user.prisma:  model User  { role Role; posts Post[] }
+//	post.prisma:  model Post  { status Status; author User @relation(...) }
+//	enums.prisma: enum Role / enum Status
+func TestPrismaModularSplitSchema(t *testing.T) {
+	const root = "testdata/prisma_modular"
+
+	// post.prisma — the file with the cross-file @relation to User.
+	postEnts := extractEnts(t, "custom_js_prisma",
+		prismaFileInput(t, root, "prisma/schema/post.prisma"))
+
+	if !hasModelEntity(postEnts, "Post") {
+		t.Fatal("expected model Post extracted from post.prisma")
+	}
+
+	// Post.author User @relation — the singular FK-owning side → many_to_one,
+	// resolving cross-file to User (declared in user.prisma).
+	assertCardinality(t,
+		graphRelatesEdge(postEnts, "Class:Post", "Class:User"),
+		"Class:Post", "Class:User", "many_to_one")
+
+	// The field-level REFERENCES edge to the cross-file User model.
+	if referencesEdge(postEnts, "User", "author") == nil {
+		t.Error("expected cross-file REFERENCES edge author → User")
+	}
+
+	// Post.status Status — enum declared in enums.prisma resolves cross-file.
+	if referencesEdge(postEnts, "Status", "status") == nil {
+		t.Error("expected cross-file REFERENCES edge status → Status (enum)")
+	}
+
+	// user.prisma — model User with posts Post[] (one_to_many) to the
+	// cross-file Post model, plus role Role (cross-file enum).
+	userEnts := extractEnts(t, "custom_js_prisma",
+		prismaFileInput(t, root, "prisma/schema/user.prisma"))
+
+	if !hasModelEntity(userEnts, "User") {
+		t.Fatal("expected model User extracted from user.prisma")
+	}
+	assertCardinality(t,
+		graphRelatesEdge(userEnts, "Class:User", "Class:Post"),
+		"Class:User", "Class:Post", "one_to_many")
+	if referencesEdge(userEnts, "Role", "role") == nil {
+		t.Error("expected cross-file REFERENCES edge role → Role (enum)")
+	}
+
+	// Models keep their real source file (no synthetic relocation).
+	for _, e := range userEnts {
+		if e.Name == "User" && e.SourceFile != "prisma/schema/user.prisma" {
+			t.Errorf("User source file: want prisma/schema/user.prisma, got %q", e.SourceFile)
+		}
+	}
+}
+
+// TestPrismaSingleFileSchemaNoRegression verifies the single-`schema.prisma`
+// case (one file = the union of one) still resolves intra-file relations and
+// does NOT trigger sibling-folder unioning (a lone .prisma file in its folder).
+func TestPrismaSingleFileSchemaNoRegression(t *testing.T) {
+	const root = "testdata/prisma_single"
+
+	ents := extractEnts(t, "custom_js_prisma",
+		prismaFileInput(t, root, "prisma/schema.prisma"))
+
+	if !hasModelEntity(ents, "User") || !hasModelEntity(ents, "Order") {
+		t.Fatal("expected User and Order models from single schema.prisma")
+	}
+	assertCardinality(t,
+		graphRelatesEdge(ents, "Class:User", "Class:Order"),
+		"Class:User", "Class:Order", "one_to_many")
+	assertCardinality(t,
+		graphRelatesEdge(ents, "Class:Order", "Class:User"),
+		"Class:Order", "Class:User", "many_to_one")
+	// Intra-file enum reference still resolves.
+	if referencesEdge(ents, "Role", "role") == nil {
+		t.Error("expected intra-file REFERENCES edge role → Role (enum)")
+	}
+}

--- a/internal/custom/javascript/testdata/prisma_modular/prisma/schema/enums.prisma
+++ b/internal/custom/javascript/testdata/prisma_modular/prisma/schema/enums.prisma
@@ -1,0 +1,9 @@
+enum Role {
+  ADMIN
+  USER
+}
+
+enum Status {
+  DRAFT
+  PUBLISHED
+}

--- a/internal/custom/javascript/testdata/prisma_modular/prisma/schema/post.prisma
+++ b/internal/custom/javascript/testdata/prisma_modular/prisma/schema/post.prisma
@@ -1,0 +1,6 @@
+model Post {
+  id        Int    @id @default(autoincrement())
+  status    Status
+  authorId  Int
+  author    User   @relation(fields: [authorId], references: [id])
+}

--- a/internal/custom/javascript/testdata/prisma_modular/prisma/schema/user.prisma
+++ b/internal/custom/javascript/testdata/prisma_modular/prisma/schema/user.prisma
@@ -1,0 +1,5 @@
+model User {
+  id    Int    @id @default(autoincrement())
+  role  Role
+  posts Post[]
+}

--- a/internal/custom/javascript/testdata/prisma_single/prisma/schema.prisma
+++ b/internal/custom/javascript/testdata/prisma_single/prisma/schema.prisma
@@ -1,0 +1,16 @@
+enum Role {
+  ADMIN
+  USER
+}
+
+model User {
+  id      Int     @id @default(autoincrement())
+  role    Role
+  orders  Order[]
+}
+
+model Order {
+  id      Int   @id
+  userId  Int
+  user    User  @relation(fields: [userId], references: [id])
+}


### PR DESCRIPTION
Resolves #5489 (framework-stack epic #5479).

### Problem
The Prisma schema extractor (`internal/custom/javascript/prisma.go`) runs **per-file** in Pass 1 and built its model symbol table (`knownModels`) from the current file only. Under Prisma's **modular split-schema** layout — `prisma/schema/*.prisma`, one domain per file, the `prismaSchemaFolder` preview feature — a `model Post` in `post.prisma` with `author User @relation(...)` where `model User` lives in `user.prisma` had its cross-file relation **dropped as honest-partial**, and enum-typed fields referencing an enum in another file dangled.

### Approach
Treat all `.prisma` files in a schema folder as **one logical schema**. New `prismaModularSiblings(repoRoot, relPath)` helper: when a `.prisma` file lives in a directory holding **more than one** `.prisma` file (the canonical `prisma/schema/` layout, name not hardcoded), it reads the sibling files and unions their `model`/`enum` names into the symbol table before relation resolution. Detection is structural — a lone `.prisma` file yields no siblings, so the single-file case collapses to the in-file table (the union of one).

With the union table:
- Cross-file model→model `GRAPH_RELATES` edges (with cardinality) and field `REFERENCES` edges are now emitted; they resolve via the global `byName` index at link time (the edges already used the `Class:<Model>` convention — only the Pass-1 same-file gate blocked them).
- Cross-file enum-typed fields gain a `REFERENCES` edge to the sibling enum.
- Models keep their **real source file** and location.

### Single-file regression
A lone `schema.prisma` in its folder produces no siblings → the union is just the in-file table. `TestPrismaSingleFileSchemaNoRegression` asserts intra-file relations + enum refs still resolve. The existing `TestPrismaGraphRelatesEdges` / `TestPrismaScalarFieldNoEdge` are unchanged and green.

### Tests
- `internal/custom/javascript/testdata/prisma_modular/prisma/schema/` — `user.prisma` (model User), `post.prisma` (model Post, `author User @relation`), `enums.prisma` (Role, Status used across both).
- `TestPrismaModularSplitSchema` — asserts User+Post extracted, the cross-file `Post → User` relation resolves (`many_to_one` / `one_to_many`), and the cross-file enum refs (`status → Status`, `role → Role`) resolve.
- `TestPrismaSingleFileSchemaNoRegression` — single-`schema.prisma` fixture.
- `go test -count=1 ./internal/custom/javascript/ ./internal/extractors/... ./tools/coverage/` — all green.

### Registry / docs
Recorded under the existing `schema_extraction` and `relationship_extraction` cells of the Prisma record (with #5489 notes + the new test cites) rather than a new taxonomy key — a new `orm_mapper` key would force a backfill onto 175 unrelated records. `coverage validate` + `fmt --check` green; docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
