### PR TITLE
feat(kysely): query-builder extraction → db_read/db_write effects (#5491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Kysely query-builder data-access → db_read/db_write effects with table attribution (#5491):**
+  Kysely, the type-safe SQL query builder (previously 0 coverage), is now
+  credited with receiver-gated, table-bearing db effects, mirroring the Prisma
+  model-bearing model (#5490). The verb is the chain ROOT method on the
+  `db`/`kysely`/`trx` instance: `db.selectFrom("user")…` is a `db_read`;
+  `db.insertInto("post")`, `db.updateTable(...)`, `db.deleteFrom(...)`, and
+  `db.replaceInto(...)` are `db_write`. Each chain (which terminates in
+  `.execute()` / `.executeTakeFirst()` / `.executeTakeFirstOrThrow()` /
+  `.stream()`) emits the effect attributed to its enclosing function with a
+  table-bearing sink tag (`kysely.read:user`, `kysely.write:post`), so the
+  data-access flow is queryable by table. Raw `` sql`…`.execute(db) `` is
+  classified by the leading SQL keyword (`SELECT`/`WITH` → read;
+  `INSERT`/`UPDATE`/`DELETE`/`REPLACE` → write; undeterminable → a generic
+  `db_read`), and `(db|kysely|trx).executeQuery(…)` is a generic `db_read`. The
+  distinctive Kysely chain-root methods plus the `db`/`kysely`/`trx` receiver
+  gate (`trx` = the transaction-callback handle) keep an unrelated `.execute()`
+  from being misread. Part of the framework-stack coverage epic (#5479).
 - **Prisma model-layer data-access → db_read/db_write effects with model attribution (#5490):**
   the data-access layer — model functions in `*.server.ts` (and `*.server.tsx`)
   modules that wrap the Prisma client — is now credited with a receiver-gated,

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 176 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 19 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
+**Total**: 177 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **elixir**: 10 · **go**: 17 · **java**: 15 · **JS/TS**: 20 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -93,6 +93,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/10 | |
 | [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 8/9 | |
+| [JS/TS](../by-language/jsts.md) | [Kysely (type-safe query builder)](../detail/lang.jsts.orm.kysely.md) | 🟡 1/7 | |
 | [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/11 | |
 | [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 7/10 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # JS/TS
 
-**Frameworks**: 33 · **Tools**: 21 · **ORMs**: 19 · **Other**: 9
+**Frameworks**: 33 · **Tools**: 21 · **ORMs**: 20 · **Other**: 9
 
 Back to [summary](../summary.md).
 
@@ -134,6 +134,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/4 | |
 | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/10 | |
 | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 8/9 | |
+| [Kysely (type-safe query builder)](../detail/lang.jsts.orm.kysely.md) | 🟡 1/7 | |
 | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/11 | |
 | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/4 | |
 | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 7/10 | |

--- a/docs/coverage/detail/lang.jsts.orm.kysely.md
+++ b/docs/coverage/detail/lang.jsts.orm.kysely.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.jsts.orm.kysely` — Kysely (type-safe query builder)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [JS/TS](../by-language/jsts.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | — `not_applicable` | — | — | — | Kysely is a type-safe SQL query builder, not an ORM — its `Database` interface is a compile-time TypeScript type with no runtime model/entity layer to extract. The schema is defined imperatively in migrations, not as decorated model classes. |
+| Model lifecycle extraction | — `not_applicable` | — | — | — | No model/entity layer; Kysely has no lifecycle hooks (no save/beforeCreate equivalents) — queries are explicit chains, not active-record instances. |
+| Schema extraction | 🔴 `missing` | — | 5491 | — | Kysely schema is declared imperatively via the migration schema-builder DSL (db.schema.createTable(...).addColumn(...)). Not yet parsed; tracked separately from the query/effect extraction landed in #5491. |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | — `not_applicable` | — | — | — | Kysely is a SQL query builder with no ORM model layer; associations are expressed ad-hoc per query via .innerJoin()/.leftJoin(), not declared on a model — there is no static association to extract. |
+| Foreign key extraction | 🔴 `missing` | — | 5491 | — | Foreign keys are declared imperatively in the migration schema-builder DSL (.addForeignKeyConstraint(...)); not yet parsed — part of the deferred schema_extraction work. |
+| Lazy loading recognition | — `not_applicable` | — | — | — | Kysely is a SQL query builder with no ORM model layer; there is no relation or lazy-loading concept to recognise — every join is explicit in the query chain. |
+| Relationship extraction | 🔴 `missing` | — | 5491 | — | Table relationships are only declared via migration foreign-key constraints; not yet parsed — part of the deferred schema_extraction work. |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | ✅ `full` | `2026-06-24` | 5491 | `internal/substrate/effect_sinks_jsts.go`<br>`internal/substrate/effect_sinks_kysely_5491_test.go` | #5491 Kysely query-builder data-access effects: the chain ROOT method on a db/kysely/trx receiver determines read vs write — selectFrom("t") -> db_read; insertInto/updateTable/deleteFrom/replaceInto("t") -> db_write — terminating in .execute()/.executeTakeFirst()/.executeTakeFirstOrThrow()/.stream(). The string-literal table arg is captured in a model/table-bearing sink tag (kysely.read:user / kysely.write:post) attributed to the enclosing function, mirroring the #5490 Prisma model-bearing uplift. Raw sql`…`.execute(db) is classified by the leading SQL keyword (SELECT/WITH -> read; INSERT/UPDATE/DELETE/REPLACE -> write; undeterminable -> generic db_read, sink kysely.raw); (db|kysely|trx).executeQuery(...) -> generic db_read. The distinctive chain-root + db/kysely/trx receiver gate (trx = transaction-callback handle) stops an unrelated .execute() from being misread. effect_sinks_jsts.go. Proven by TestKyselyReadEffects_5491 / TestKyselyWriteEffects_5491 / TestKyselyReplaceInto_5491 / TestKyselyRawSQL_5491 / TestKyselyTrxAndKyselyReceiver_5491 / TestKyselyNonKyselyExecuteNotCredited_5491. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | 5491 | — | Kysely migrations are plain TS modules exporting up()/down() that call the imperative schema-builder DSL; not yet parsed. Tracked alongside schema_extraction. |
+| Migration schema ops | 🔴 `missing` | — | 5491 | — | db.schema.createTable/alterTable/dropTable migration ops are not yet converged to MODIFIES_TABLE (the #3628 engine pass that already covers knex/typeorm/sequelize). |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | 5491 | — | db.transaction().execute(async (trx) => ...) interactive-transaction boundary stamping (transactional=true / tx_source) is not yet emitted; the trx handle IS receiver-gated for query/effect attribution (#5491). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.jsts.orm.kysely ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,13 +1,13 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 255 · **ORMs**: 176 · **Tools**: 129 · **Other**: 206
+**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 255 · **ORMs**: 177 · **Tools**: 129 · **Other**: 206
 
 ## Coverage by language
 
 | Language | Frameworks | Tools | ORMs | Other |
 |---|---:|---:|---:|---:|
-| [JS/TS](by-language/jsts.md) | 33 | 21 | 19 | 9 |
+| [JS/TS](by-language/jsts.md) | 33 | 21 | 20 | 9 |
 | [C/C++](by-language/c-cpp.md) | 25 | 16 | 10 | 4 |
 | [python](by-language/python.md) | 25 | 15 | 18 | 10 |
 | [java](by-language/java.md) | 23 | 10 | 15 | 4 |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 255 frameworks · 129 tools · 176 ORMs · 206 other
+Total: 255 frameworks · 129 tools · 177 ORMs · 206 other

--- a/internal/substrate/effect_sinks_jsts.go
+++ b/internal/substrate/effect_sinks_jsts.go
@@ -22,7 +22,10 @@
 // for the substrate, with full lexical accuracy deferred to Phase 4.
 package substrate
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 func init() { RegisterEffectSniffer("jsts", sniffEffectsJSTS) }
 
@@ -268,6 +271,125 @@ func appendPrismaModelMatches(out []EffectMatch, content string, headers []funcH
 	return out
 }
 
+// --- #5491 Kysely type-safe query-builder data-access (db/kysely/trx gate + table) ---
+//
+// Kysely is a type-safe SQL query builder. A query is built by a chain whose
+// ROOT method on the Kysely instance determines read vs write, and which
+// terminates in `.execute()` / `.executeTakeFirst()` / `.executeTakeFirstOrThrow()`
+// / `.stream()`. The chain-root methods (`selectFrom`, `insertInto`,
+// `updateTable`, `deleteFrom`, `replaceInto`) are distinctive to Kysely, so we
+// gate the credit on them (plus a `db`/`kysely`/`trx` receiver) — an unrelated
+// `.execute()` with no Kysely chain root earns no credit. The table name (the
+// string-literal arg to the chain root) is captured in the sink tag
+// (`kysely.read:user` / `kysely.write:post`) and the effect is attributed to the
+// enclosing function, mirroring the #5490 Prisma model-bearing uplift.
+//
+// Verb → effect mapping (chain ROOT method):
+//   - db_read : selectFrom
+//   - db_write: insertInto / updateTable / deleteFrom / replaceInto
+//
+// Raw SQL — `sql`…`.execute(db)` / `db.executeQuery(...)` — is classified by the
+// leading SQL keyword (SELECT → read; INSERT/UPDATE/DELETE/REPLACE → write); an
+// undeterminable raw query earns a generic db effect (read, sink `kysely.raw`).
+//
+// The receiver gate is `(?:this\.)?(?:db|kysely|trx)\.` — `trx` covers the
+// transaction handle (`db.transaction().execute(async (trx) => trx.insertInto(...))`).
+
+// jstsKyselyReadRootRe matches a Kysely read chain root on a gated receiver,
+// capturing the table name (group 1). `selectFrom("user")` is the read root.
+var jstsKyselyReadRootRe = regexp.MustCompile(
+	`(?:this\s*\.\s*)?(?:db|kysely|trx)\s*\.\s*selectFrom\s*\(\s*["'` + "`" + `]([^"'` + "`" + `]+)["'` + "`" + `]`,
+)
+
+// jstsKyselyWriteRootRe matches a Kysely write chain root on a gated receiver,
+// capturing the table name (group 1). insertInto/updateTable/deleteFrom/replaceInto.
+var jstsKyselyWriteRootRe = regexp.MustCompile(
+	`(?:this\s*\.\s*)?(?:db|kysely|trx)\s*\.\s*(?:insertInto|updateTable|deleteFrom|replaceInto)\s*\(\s*["'` + "`" + `]([^"'` + "`" + `]+)["'` + "`" + `]`,
+)
+
+// jstsKyselyRawRe matches a raw `sql`…`` tagged template terminated by
+// `.execute(...)` (the Kysely raw escape hatch), capturing the SQL body
+// (group 1) so the leading keyword can classify read vs write.
+var jstsKyselyRawRe = regexp.MustCompile(
+	`\bsql\s*` + "`" + `([^` + "`" + `]*)` + "`" + `(?:\s*\.\s*[A-Za-z_$][\w$]*\s*\([^)]*\))*?\s*\.\s*execute(?:TakeFirst(?:OrThrow)?)?\s*\(`,
+)
+
+// jstsKyselyExecuteQueryRe matches `(db|kysely|trx).executeQuery(...)` — a
+// compiled-query execution; classified generic db_read (no SQL body in reach).
+var jstsKyselyExecuteQueryRe = regexp.MustCompile(
+	`(?:this\s*\.\s*)?(?:db|kysely|trx)\s*\.\s*executeQuery\s*\(`,
+)
+
+// kyselyRawSQLLeadingVerb returns the effect implied by the leading keyword of a
+// raw SQL body, and whether it was determinable. SELECT → read; INSERT / UPDATE /
+// DELETE / REPLACE → write; anything else → read (generic) + false.
+func kyselyRawSQLLeadingVerb(body string) (Effect, bool) {
+	s := strings.TrimSpace(body)
+	// Skip a leading line/block comment-free fast path: take the first word.
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r' || s[i] == '(') {
+		i++
+	}
+	j := i
+	for j < len(s) && ((s[j] >= 'a' && s[j] <= 'z') || (s[j] >= 'A' && s[j] <= 'Z')) {
+		j++
+	}
+	switch strings.ToUpper(s[i:j]) {
+	case "SELECT", "WITH":
+		return EffectDBRead, true
+	case "INSERT", "UPDATE", "DELETE", "REPLACE":
+		return EffectDBWrite, true
+	}
+	return EffectDBRead, false
+}
+
+// appendKyselyRootMatches credits each gated Kysely chain-root call to its
+// enclosing function with a table-bearing sink tag (`kysely.read:user`).
+func appendKyselyRootMatches(out []EffectMatch, content string, headers []funcHeader, re *regexp.Regexp, eff Effect) []EffectMatch {
+	verb := "read"
+	if eff == EffectDBWrite {
+		verb = "write"
+	}
+	for _, m := range re.FindAllStringSubmatchIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		table := content[m[2]:m[3]]
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     eff,
+			Sink:       "kysely." + verb + ":" + table,
+			Confidence: 0.9,
+		})
+	}
+	return out
+}
+
+// appendKyselyRawMatches credits each raw `sql`…`.execute()` to its enclosing
+// function, classifying read vs write by the leading SQL keyword. An
+// undeterminable body earns a generic db_read with sink `kysely.raw`.
+func appendKyselyRawMatches(out []EffectMatch, content string, headers []funcHeader) []EffectMatch {
+	for _, m := range jstsKyselyRawRe.FindAllStringSubmatchIndex(content, -1) {
+		line := lineOfOffset(content, m[0])
+		eff, ok := kyselyRawSQLLeadingVerb(content[m[2]:m[3]])
+		sink := "kysely.raw"
+		if ok {
+			if eff == EffectDBWrite {
+				sink = "kysely.raw:write"
+			} else {
+				sink = "kysely.raw:read"
+			}
+		}
+		out = append(out, EffectMatch{
+			Function:   nearestHeader(headers, line),
+			Line:       line,
+			Effect:     eff,
+			Sink:       sink,
+			Confidence: 0.85,
+		})
+	}
+	return out
+}
+
 // jstsMutationRe matches `this.<field> = ...` — assignment to a receiver
 // field. We require an assignment operator on the same line and reject
 // `this.<field> ==` (comparison) by anchoring on `=` followed by a
@@ -292,6 +414,12 @@ func sniffEffectsJSTS(content string) []EffectMatch {
 	// with a model-bearing sink tag so the data-access flow is queryable by model.
 	out = appendPrismaModelMatches(out, content, headers, jstsPrismaModelReadRe, EffectDBRead)
 	out = appendPrismaModelMatches(out, content, headers, jstsPrismaModelWriteRe, EffectDBWrite)
+	// #5491 Kysely query-builder data-access: receiver-gated chain-root calls
+	// credited with a table-bearing sink tag (kysely.read:user / kysely.write:post).
+	out = appendKyselyRootMatches(out, content, headers, jstsKyselyReadRootRe, EffectDBRead)
+	out = appendKyselyRootMatches(out, content, headers, jstsKyselyWriteRootRe, EffectDBWrite)
+	out = appendKyselyRawMatches(out, content, headers)
+	out = appendJSTSMatches(out, content, headers, jstsKyselyExecuteQueryRe, EffectDBRead, "kysely.executeQuery", 0.7)
 	out = append(out, jstsBuilderDataAccessMatches(content, headers)...)
 	out = appendJSTSMatches(out, content, headers, jstsFSReadRe, EffectFSRead, "fs.read", 1.0)
 	out = appendJSTSMatches(out, content, headers, jstsFSWriteRe, EffectFSWrite, "fs.write", 1.0)

--- a/internal/substrate/effect_sinks_kysely_5491_test.go
+++ b/internal/substrate/effect_sinks_kysely_5491_test.go
@@ -1,0 +1,161 @@
+package substrate
+
+// effect_sinks_kysely_5491_test.go — the Kysely type-safe query-builder
+// data-access layer (#5491). A Kysely query chain's ROOT method on the
+// db/kysely/trx instance determines read vs write (selectFrom → db_read;
+// insertInto/updateTable/deleteFrom/replaceInto → db_write), terminating in
+// .execute()/.executeTakeFirst()/.executeTakeFirstOrThrow()/.stream(). The
+// string-literal table arg is captured in the sink tag (kysely.read:user /
+// kysely.write:post) and the effect is attributed to the enclosing function,
+// mirroring the #5490 Prisma model-bearing uplift. The chain-root + receiver
+// gate keeps an unrelated .execute() from being misread.
+
+import "testing"
+
+// kyselySinks returns the set of kysely sink tags carried by fn for effect eff.
+func kyselySinks(ms []EffectMatch, fn string, eff Effect) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range ms {
+		if m.Function == fn && m.Effect == eff {
+			out[m.Sink] = true
+		}
+	}
+	return out
+}
+
+// The data-access layer: read (selectFrom), writes (insertInto/updateTable/
+// deleteFrom), executeTakeFirst terminal, and a raw sql`…` query. Each effect
+// lands on the right function with the right table in the sink tag.
+const kyselyUserRepoTS = `
+import { db } from './db';
+import { sql } from 'kysely';
+
+export async function getUsers() {
+  return db.selectFrom("user").selectAll().execute();
+}
+
+export async function getUserById(id) {
+  return db.selectFrom("user").where("id", "=", id).selectAll().executeTakeFirst();
+}
+
+export async function createPost(data) {
+  return db.insertInto("post").values(data).execute();
+}
+
+export async function publishPost(id) {
+  return db.updateTable("post").set({ published: true }).where("id", "=", id).execute();
+}
+
+export async function removePost(id) {
+  return db.deleteFrom("post").where("id", "=", id).execute();
+}
+
+export async function activeCount() {
+  return sql` + "`" + `SELECT count(*) FROM "user" WHERE active` + "`" + `.execute(db);
+}
+
+export async function archiveUser(id) {
+  return sql` + "`" + `UPDATE "user" SET archived = true WHERE id = ${id}` + "`" + `.execute(db);
+}
+`
+
+func TestKyselyReadEffects_5491(t *testing.T) {
+	ms := sniffEffectsJSTS(kyselyUserRepoTS)
+	by := groupByEffect(ms)
+	mustHave(t, by, EffectDBRead, "getUsers")
+	mustHave(t, by, EffectDBRead, "getUserById")
+
+	if got := kyselySinks(ms, "getUsers", EffectDBRead); !got["kysely.read:user"] {
+		t.Errorf("getUsers: expected sink kysely.read:user, got %v", got)
+	}
+	// executeTakeFirst terminal still credits the read with the table.
+	if got := kyselySinks(ms, "getUserById", EffectDBRead); !got["kysely.read:user"] {
+		t.Errorf("getUserById: expected sink kysely.read:user, got %v", got)
+	}
+}
+
+func TestKyselyWriteEffects_5491(t *testing.T) {
+	ms := sniffEffectsJSTS(kyselyUserRepoTS)
+	by := groupByEffect(ms)
+	mustHave(t, by, EffectDBWrite, "createPost")  // insertInto
+	mustHave(t, by, EffectDBWrite, "publishPost") // updateTable
+	mustHave(t, by, EffectDBWrite, "removePost")  // deleteFrom
+
+	if got := kyselySinks(ms, "createPost", EffectDBWrite); !got["kysely.write:post"] {
+		t.Errorf("createPost: expected sink kysely.write:post, got %v", got)
+	}
+	if got := kyselySinks(ms, "publishPost", EffectDBWrite); !got["kysely.write:post"] {
+		t.Errorf("publishPost: expected sink kysely.write:post, got %v", got)
+	}
+	if got := kyselySinks(ms, "removePost", EffectDBWrite); !got["kysely.write:post"] {
+		t.Errorf("removePost: expected sink kysely.write:post, got %v", got)
+	}
+}
+
+// replaceInto is a write chain root too.
+func TestKyselyReplaceInto_5491(t *testing.T) {
+	src := `
+export async function upsertRow(data) {
+  return db.replaceInto("session").values(data).execute();
+}
+`
+	ms := sniffEffectsJSTS(src)
+	if got := kyselySinks(ms, "upsertRow", EffectDBWrite); !got["kysely.write:session"] {
+		t.Errorf("upsertRow: expected sink kysely.write:session, got %v", got)
+	}
+}
+
+// Raw sql`…`.execute(db) is classified by the leading SQL keyword.
+func TestKyselyRawSQL_5491(t *testing.T) {
+	ms := sniffEffectsJSTS(kyselyUserRepoTS)
+	by := groupByEffect(ms)
+	mustHave(t, by, EffectDBRead, "activeCount")  // SELECT → read
+	mustHave(t, by, EffectDBWrite, "archiveUser") // UPDATE → write
+
+	if got := kyselySinks(ms, "activeCount", EffectDBRead); !got["kysely.raw:read"] {
+		t.Errorf("activeCount: expected sink kysely.raw:read, got %v", got)
+	}
+	if got := kyselySinks(ms, "archiveUser", EffectDBWrite); !got["kysely.raw:write"] {
+		t.Errorf("archiveUser: expected sink kysely.raw:write, got %v", got)
+	}
+}
+
+// trx (transaction handle) and kysely are gated receivers too.
+func TestKyselyTrxAndKyselyReceiver_5491(t *testing.T) {
+	src := `
+export async function transfer(trx) {
+  await trx.updateTable("account").set({ balance: 0 }).execute();
+  return trx.selectFrom("ledger").selectAll().execute();
+}
+export async function listAll(kysely) {
+  return kysely.selectFrom("widget").selectAll().execute();
+}
+`
+	ms := sniffEffectsJSTS(src)
+	if got := kyselySinks(ms, "transfer", EffectDBWrite); !got["kysely.write:account"] {
+		t.Errorf("transfer write: expected sink kysely.write:account, got %v", got)
+	}
+	if got := kyselySinks(ms, "transfer", EffectDBRead); !got["kysely.read:ledger"] {
+		t.Errorf("transfer read: expected sink kysely.read:ledger, got %v", got)
+	}
+	if got := kyselySinks(ms, "listAll", EffectDBRead); !got["kysely.read:widget"] {
+		t.Errorf("listAll: expected sink kysely.read:widget, got %v", got)
+	}
+}
+
+// Negative: a non-Kysely .execute() (a plain Promise/builder with no Kysely
+// chain root and no gated receiver) must NOT earn a kysely.* sink.
+func TestKyselyNonKyselyExecuteNotCredited_5491(t *testing.T) {
+	src := `
+export async function run(stmt) {
+  await stmt.execute();                 // plain prepared-statement, no kysely root
+  return somePromise.executeTakeFirst(); // not a kysely chain
+}
+`
+	ms := sniffEffectsJSTS(src)
+	for _, m := range ms {
+		if m.Function == "run" && len(m.Sink) >= 7 && m.Sink[:7] == "kysely." {
+			t.Errorf("non-kysely .execute() was misread as a Kysely effect: %+v", m)
+		}
+	}
+}


### PR DESCRIPTION
Closes #5491. Part of the framework-stack coverage epic #5479.

Extracts **Kysely** (the type-safe SQL query builder — previously **0 coverage**) into model/table-bearing `db_read`/`db_write` effects, mirroring the Prisma model-layer uplift just landed in #5490 (same file, same effect kinds, same sink-tag convention).

## Verb → effect mapping
The verb is the chain ROOT method on a `db`/`kysely`/`trx` receiver:

| Chain root | Effect | Sink |
| --- | --- | --- |
| `db.selectFrom("user")…` | `db_read` | `kysely.read:user` |
| `db.insertInto("post")…` | `db_write` | `kysely.write:post` |
| `db.updateTable("post")…` | `db_write` | `kysely.write:post` |
| `db.deleteFrom("post")…` | `db_write` | `kysely.write:post` |
| `db.replaceInto("session")…` | `db_write` | `kysely.write:session` |

Chains terminate in `.execute()` / `.executeTakeFirst()` / `.executeTakeFirstOrThrow()` / `.stream()`.

**Raw SQL:** `` sql`…`.execute(db) `` is classified by the leading SQL keyword (`SELECT`/`WITH` → read; `INSERT`/`UPDATE`/`DELETE`/`REPLACE` → write; undeterminable → generic `db_read`, sink `kysely.raw`). `(db|kysely|trx).executeQuery(…)` → generic `db_read`.

## Table capture
The string-literal table arg to the chain root is captured into the sink tag, attributed to the enclosing function (reusing the #5490 enclosing-fn + sink machinery), so the data-access flow is queryable by table.

## Receiver gate
Gated on the distinctive Kysely chain-root method names **plus** a `db`/`kysely`/`trx` receiver (`trx` = the transaction-callback handle). An unrelated `.execute()` with no Kysely chain root earns no credit.

## Registry / docs
New `lang.jsts.orm.kysely` record (jsts ORM/query-builder category, shaped like the Knex query-builder record): `query_attribution` **full**; schema / migrations / relationships / transactions tracked as deferred follow-ups (Kysely declares schema imperatively in migrations). `coverage validate` + `fmt --check` green; docs regenerated.

## Tests
`internal/substrate/effect_sinks_kysely_5491_test.go`:
- `selectFrom` → `db_read` + `executeTakeFirst` terminal
- `insertInto`/`updateTable`/`deleteFrom`/`replaceInto` → `db_write`
- raw `` sql`SELECT…` `` → read, `` sql`UPDATE…` `` → write
- `trx`/`kysely` gated receivers
- negative: a non-Kysely `.execute()` earns no `kysely.*` sink

`go test -count=1 ./internal/substrate/ ./internal/custom/javascript/ ./tools/coverage/` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)