### PR TITLE
feat(zod): recognize z.coerce.* coercion flags (#5498)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Zod `z.coerce.*` coercion flags (#5498):** the Zod schema extractor now
+  recognizes the coercion factory `z.coerce.<type>()`
+  (`z.coerce.string/number/boolean/date/bigint`) wherever a plain `z.<type>()`
+  base type is recognized — object fields, nested `z.object()` fields, and
+  bare scalar schemas. A coerced field keeps its underlying scalar type
+  (`z.coerce.number()` → type `number`) and additionally carries a coercion
+  attribute: the expanded field member gets `coerced=true` plus
+  `coercion_type=<underlying>`, the owning schema entity gets a per-field
+  `field_<name>_coerced=true` marker, and a bare `const Flag = z.coerce.boolean()`
+  is emitted as a `SCOPE.Schema` with `scalar_kind=boolean` + `coerced=true`.
+  Non-coerced `z.number()` / `z.string()` carry no coercion attribute. Last Zod
+  item in the framework-stack coverage epic (#5479).
 - **Zod `.refine()` / `.superRefine()` / `.transform()` / `.pipe()` →
   entities (#5497):** the Zod schema extractor now captures the schema-level
   custom-validator chain that follows a schema declaration, which the

--- a/docs/coverage/by-category/validation.md
+++ b/docs/coverage/by-category/validation.md
@@ -16,7 +16,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [java](../by-language/java.md) | [Bean Validation (Jakarta/javax)](../detail/lang.java.validation.bean-validation.md) | 🔴 0/1 | ✅ 4/4 | 🔴 | |
 | [JS/TS](../by-language/jsts.md) | [Joi (@hapi/joi)](../detail/lang.jsts.validation.joi.md) | 🟢 1/1 | 🟡 2/5 | 🔴 | |
 | [JS/TS](../by-language/jsts.md) | [Yup](../detail/lang.jsts.validation.yup.md) | 🟢 1/1 | 🟡 2/5 | 🔴 | |
-| [JS/TS](../by-language/jsts.md) | [Zod](../detail/lang.jsts.validation.zod.md) | 🟢 1/1 | 🟡 4/5 | 🔴 | |
+| [JS/TS](../by-language/jsts.md) | [Zod](../detail/lang.jsts.validation.zod.md) | 🟢 1/1 | 🟢 5/5 | 🟢 | |
 | [JS/TS](../by-language/jsts.md) | [class-validator (NestJS DTOs)](../detail/lang.jsts.validation.class-validator.md) | 🟢 1/1 | 🟡 3/5 | 🔴 | |
 | [kotlin](../by-language/kotlin.md) | [Bean Validation / konform / Valiktor (Kotlin)](../detail/lang.kotlin.validation.bean-validation.md) | 🟢 1/1 | 🟢 4/4 | 🟢 | |
 | [python](../by-language/python.md) | [Pydantic](../detail/lang.python.validation.pydantic.md) | 🟢 1/1 | 🟢 5/5 | 🟢 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -190,5 +190,5 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 |---|---|---|---|
 | [Joi (@hapi/joi)](../detail/lang.jsts.validation.joi.md) | 🟢 1/1 | 🟡 2/5 | |
 | [Yup](../detail/lang.jsts.validation.yup.md) | 🟢 1/1 | 🟡 2/5 | |
-| [Zod](../detail/lang.jsts.validation.zod.md) | 🟢 1/1 | 🟡 4/5 | |
+| [Zod](../detail/lang.jsts.validation.zod.md) | 🟢 1/1 | 🟢 5/5 | |
 | [class-validator (NestJS DTOs)](../detail/lang.jsts.validation.class-validator.md) | 🟢 1/1 | 🟡 3/5 | |

--- a/docs/coverage/detail/lang.jsts.validation.zod.md
+++ b/docs/coverage/detail/lang.jsts.validation.zod.md
@@ -29,7 +29,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Type coercion recognition | 🔴 `missing` | — | 4925 | `internal/custom/javascript/validation_schema.go`<br>`internal/custom/javascript/validation_schema_test.go` | z.coerce.* coercion wrappers are not recognized as coercion flags. |
+| Type coercion recognition | ✅ `full` | `2026-06-24` | 5498 | `internal/custom/javascript/validation_schema.go`<br>`internal/custom/javascript/validation_schema_test.go` | extractSchemaFields recognizes zod's coercion factory z.coerce.<type>() (z.coerce.string/number/boolean/date/bigint) wherever a z.<type>() base type is recognized — object fields, nested z.object() fields, scalar schemas. The field/schema keeps its underlying scalar type AND carries a coercion attribute: the field member gets coerced=true + coercion_type=<underlying> (e.g. z.coerce.number() -> field_type=number, coerced=true, coercion_type=number), the owning schema entity gets a per-field field_<name>_coerced=true marker, and a bare scalar 'const Flag = z.coerce.boolean()' is emitted as a SCOPE.Schema with scalar_kind=boolean + coerced=true. Non-coerced z.number()/z.string() carry no coercion attribute (regression-guarded). Proven by TestZodCoerce_ObjectFields, TestZodCoerce_ScalarSchema, TestZodCoerce_BareScalarStillSkipped, TestZodCoerce_NonCoercedRegression. |
 
 ### Testing
 

--- a/internal/custom/javascript/validation_schema.go
+++ b/internal/custom/javascript/validation_schema.go
@@ -47,7 +47,7 @@ var (
 	// pass to attach a refine/transform/pipe chain to non-object zod schemas; the
 	// object pass owns `z.object`.
 	zodScalarSchemaRe = regexp.MustCompile(
-		`(?m)(?:const|let|var)\s+([A-Za-z_]\w*)\s*(?::\s*[\w.<>\[\] ]+)?\s*=\s*(?:z|zod)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+		`(?m)(?:const|let|var)\s+(?P<name>[A-Za-z_]\w*)\s*(?::\s*[\w.<>\[\] ]+)?\s*=\s*(?:z|zod)\s*\.\s*(?P<coerce>coerce\s*\.\s*)?(?P<kind>[A-Za-z_]\w*)\s*\(`)
 	// joiSchemaRe: `const CreateUser = Joi.object({ ... })`.
 	joiSchemaRe = regexp.MustCompile(
 		`(?m)(?:const|let|var)\s+([A-Za-z_]\w*)\s*(?::\s*[\w.<>\[\] ]+)?\s*=\s*(Joi|joi)\s*\.\s*object\s*\(`)
@@ -60,12 +60,16 @@ var (
 	classValidatorDtoRe = regexp.MustCompile(
 		`(?m)(?:export\s+)?(?:abstract\s+)?class\s+([A-Za-z_]\w*)\s*(?:extends\s+[\w.<>, ]+?)?\s*\{`)
 
-	// zod field: `name: z.string()`, `age: z.number().int()`.
-	zodFieldRe = regexp.MustCompile(`(?m)([A-Za-z_]\w*)\s*:\s*(?:z|zod)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+	// zod field: `name: z.string()`, `age: z.number().int()`. The optional
+	// `coerce.` segment (#5498) recognises zod's coercion factory
+	// `z.coerce.<type>()` (`z.coerce.number()`, `z.coerce.date()`, …): the
+	// captured `kind` is still the underlying scalar type and the `coerce` group
+	// marks the field as coerced.
+	zodFieldRe = regexp.MustCompile(`(?m)(?P<name>[A-Za-z_]\w*)\s*:\s*(?:z|zod)\s*\.\s*(?P<coerce>coerce\s*\.\s*)?(?P<kind>[A-Za-z_]\w*)\s*\(`)
 	// joi field: `name: Joi.string()`.
-	joiFieldRe = regexp.MustCompile(`(?m)([A-Za-z_]\w*)\s*:\s*(?:Joi|joi)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+	joiFieldRe = regexp.MustCompile(`(?m)(?P<name>[A-Za-z_]\w*)\s*:\s*(?:Joi|joi)\s*\.\s*(?P<kind>[A-Za-z_]\w*)\s*\(`)
 	// yup field: `name: yup.string()`.
-	yupFieldRe = regexp.MustCompile(`(?m)([A-Za-z_]\w*)\s*:\s*(?:yup|Yup)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+	yupFieldRe = regexp.MustCompile(`(?m)(?P<name>[A-Za-z_]\w*)\s*:\s*(?:yup|Yup)\s*\.\s*(?P<kind>[A-Za-z_]\w*)\s*\(`)
 	// cvNestedTypeRe: a class-transformer `@Type(() => TargetClass)` thunk,
 	// optionally preceded/followed by other decorators, bound to a property name.
 	// Group 1 = target class, group 2 = field name. Issue #4328.
@@ -195,9 +199,14 @@ func (e *validationSchemaExtractor) Extract(ctx context.Context, file extreg.Fil
 	// refine/superRefine/transform/pipe link — a bare `z.string()` const carries
 	// nothing this issue models and would just add noise, so it is skipped
 	// (honest-partial). Object schemas are already handled above (skip them here).
+	scalarNameIdx := zodScalarSchemaRe.SubexpIndex("name")
+	scalarKindIdx := zodScalarSchemaRe.SubexpIndex("kind")
+	scalarCoerceIdx := zodScalarSchemaRe.SubexpIndex("coerce")
 	for _, m := range zodScalarSchemaRe.FindAllStringSubmatchIndex(src, -1) {
-		name := src[m[2]:m[3]]
-		factory := src[m[4]:m[5]]
+		name := src[m[2*scalarNameIdx]:m[2*scalarNameIdx+1]]
+		factory := src[m[2*scalarKindIdx]:m[2*scalarKindIdx+1]]
+		// zod `const X = z.coerce.<type>()` (#5498): a coerced scalar schema.
+		coerced := scalarCoerceIdx >= 0 && m[2*scalarCoerceIdx] >= 0
 		if factory == "object" {
 			continue // handled by the object pass (with field expansion)
 		}
@@ -207,13 +216,17 @@ func (e *validationSchemaExtractor) Extract(ctx context.Context, file extreg.Fil
 		openParen := m[1] - 1 // header ends at the `(` of `.<factory>(`
 		tail := schemaTailChain(src, openParen)
 		links := parseZodSchemaChain(tail)
-		if len(links) == 0 {
-			continue // no custom-validator chain — nothing to record here
+		if len(links) == 0 && !coerced {
+			continue // no custom-validator chain and not coerced — nothing to record
 		}
 		ent := makeEntity(name, "SCOPE.Schema", "validation_schema", file.Path, file.Language, lineOf(src, m[0]))
 		setProps(&ent, "library", "zod", "pattern_type", "validation_schema",
 			"scalar_kind", normalizeScalar(factory),
 			"provenance", "INFERRED_FROM_ZOD_SCALAR")
+		// Coercion attribute on the scalar schema itself (#5498).
+		if coerced {
+			setProps(&ent, "coerced", "true", "coercion_type", normalizeScalar(factory))
+		}
 		applyFieldProps(&ent, nil)
 		chainKids := emitZodSchemaChainEntities(&ent, name, tail, file.Path, file.Language, lineOf(src, m[0]))
 		addSchema(ent)
@@ -420,6 +433,12 @@ type schemaField struct {
 	// onto the field member's Properties["validations"] for the ShapeTree.
 	validations []string
 	optional    bool
+	// coerced records whether the field is declared with zod's coercion factory
+	// `z.coerce.<type>()` (#5498). When true, coercionType carries the underlying
+	// coerced scalar type (`number`, `date`, `boolean`, …). The field's `typ`
+	// remains the coerced (underlying) type — coercion is an attribute on top.
+	coerced      bool
+	coercionType string
 }
 
 // extractSchemaFields pulls `name: lib.<kind>()` field declarations out of a
@@ -432,22 +451,33 @@ type schemaField struct {
 func extractSchemaFields(re *regexp.Regexp, body string, lib string) []schemaField {
 	var fields []schemaField
 	seen := make(map[string]bool)
+	nameIdx := re.SubexpIndex("name")
+	kindIdx := re.SubexpIndex("kind")
+	coerceIdx := re.SubexpIndex("coerce") // -1 for joi/yup (no coerce group)
 	for _, m := range re.FindAllStringSubmatchIndex(body, -1) {
-		name := body[m[2]:m[3]]
+		name := body[m[2*nameIdx]:m[2*nameIdx+1]]
 		if seen[name] {
 			continue
 		}
 		seen[name] = true
-		kind := body[m[4]:m[5]]
+		kind := body[m[2*kindIdx]:m[2*kindIdx+1]]
+		// zod `z.coerce.<type>()` coercion (#5498): the `coerce` group matched, so
+		// the field's underlying type is `kind` and it carries a coercion attribute.
+		coerced := coerceIdx >= 0 && m[2*coerceIdx] >= 0
 		// The chain begins at the factory call's opening `(` (one char before the
 		// match end) and runs to the end of this field's value (the next
 		// top-level comma in the object body, or EOF).
 		chain := fieldChain(body, m[1]-1)
 		chips := parseChainConstraints(lib, kind, chain)
 		optional := chainIsOptional(lib, kind, chips, chain)
-		fields = append(fields, schemaField{
+		f := schemaField{
 			name: name, typ: normalizeScalar(kind), validations: chips, optional: optional,
-		})
+		}
+		if coerced {
+			f.coerced = true
+			f.coercionType = normalizeScalar(kind)
+		}
+		fields = append(fields, f)
 	}
 	return fields
 }
@@ -912,6 +942,12 @@ func applyFieldProps(ent *types.EntityRecord, fields []schemaField) {
 	names := make([]string, 0, len(fields))
 	for _, f := range fields {
 		setProps(ent, "field_"+f.name, f.typ)
+		// zod `z.coerce.<type>()` coercion (#5498): surface the coercion flag at the
+		// schema-entity level too, keyed per field, so consumers reading the entity
+		// props (not just the expanded field member) see it.
+		if f.coerced {
+			setProps(ent, "field_"+f.name+"_coerced", "true")
+		}
 		names = append(names, f.name)
 	}
 	sort.Strings(names)
@@ -973,6 +1009,14 @@ func emitSchemaFieldMembers(owner *types.EntityRecord, fields []schemaField, lib
 			"provenance", "INFERRED_FROM_SCHEMA_FIELD_MEMBERSHIP")
 		if f.optional {
 			setProps(&child, "optional", "true")
+		}
+		// zod `z.coerce.<type>()` coercion (#5498): flag the coerced field and
+		// record the coerced (underlying) scalar type.
+		if f.coerced {
+			setProps(&child, "coerced", "true")
+			if f.coercionType != "" {
+				setProps(&child, "coercion_type", f.coercionType)
+			}
 		}
 		if len(annots) > 0 {
 			setProps(&child, "validators", strings.Join(annots, " "))

--- a/internal/custom/javascript/validation_schema_test.go
+++ b/internal/custom/javascript/validation_schema_test.go
@@ -166,6 +166,130 @@ router.post('/users', (req, res) => { CreateUser.parse(req.body); res.json({}); 
 }
 
 // ---------------------------------------------------------------------------
+// z.coerce.* coercion flags (issue #5498)
+// ---------------------------------------------------------------------------
+
+// A zod object schema mixing coerced (`z.coerce.number()`, `z.coerce.date()`)
+// and non-coerced (`z.string()`) fields: the coerced fields carry the
+// underlying type AND a `coerced=true` / `coercion_type` attribute; the
+// non-coerced field carries neither (regression guard).
+func TestZodCoerce_ObjectFields(t *testing.T) {
+	src := `import { z } from 'zod';
+const Filter = z.object({ age: z.coerce.number(), when: z.coerce.date(), name: z.string() });
+router.post('/f', (req, res) => { Filter.parse(req.body); res.json({}); });`
+	ents := extractFull(t, "custom_js_validation_schema", fi("f.ts", "typescript", src))
+
+	se := schemaEntity(ents, "Filter")
+	if se == nil {
+		t.Fatal("expected SCOPE.Schema Filter")
+	}
+	// Underlying types preserved.
+	wantField(t, se, "age", "number")
+	wantField(t, se, "when", "date")
+	wantField(t, se, "name", "string")
+	// Entity-level coercion flags.
+	if se.Properties["field_age_coerced"] != "true" {
+		t.Errorf("age field_age_coerced = %q, want true (props=%v)", se.Properties["field_age_coerced"], se.Properties)
+	}
+	if se.Properties["field_when_coerced"] != "true" {
+		t.Errorf("when field_when_coerced = %q, want true", se.Properties["field_when_coerced"])
+	}
+	if _, ok := se.Properties["field_name_coerced"]; ok {
+		t.Errorf("non-coerced name must not carry field_name_coerced (props=%v)", se.Properties)
+	}
+
+	// Coerced field member carries coerced=true + coercion_type=<underlying>.
+	age := fieldChild(ents, "Filter.age")
+	if age == nil {
+		t.Fatal("expected field sub-entity Filter.age")
+	}
+	if age.Properties["coerced"] != "true" {
+		t.Errorf("Filter.age coerced = %q, want true (props=%v)", age.Properties["coerced"], age.Properties)
+	}
+	if age.Properties["coercion_type"] != "number" {
+		t.Errorf("Filter.age coercion_type = %q, want number", age.Properties["coercion_type"])
+	}
+	if age.Properties["field_type"] != "number" {
+		t.Errorf("Filter.age field_type = %q, want number (coerced base type)", age.Properties["field_type"])
+	}
+
+	when := fieldChild(ents, "Filter.when")
+	if when == nil || when.Properties["coerced"] != "true" || when.Properties["coercion_type"] != "date" {
+		t.Errorf("Filter.when coercion model wrong (props=%v)", when.Properties)
+	}
+
+	// Regression: non-coerced field must NOT carry the coercion attribute.
+	name := fieldChild(ents, "Filter.name")
+	if name == nil {
+		t.Fatal("expected field sub-entity Filter.name")
+	}
+	if _, ok := name.Properties["coerced"]; ok {
+		t.Errorf("non-coerced Filter.name must not carry coerced (props=%v)", name.Properties)
+	}
+	if _, ok := name.Properties["coercion_type"]; ok {
+		t.Errorf("non-coerced Filter.name must not carry coercion_type (props=%v)", name.Properties)
+	}
+}
+
+// A bare scalar coercion schema `const Flag = z.coerce.boolean()` is emitted as
+// a SCOPE.Schema carrying scalar_kind=boolean + coerced=true / coercion_type.
+func TestZodCoerce_ScalarSchema(t *testing.T) {
+	src := `import { z } from 'zod';
+const Flag = z.coerce.boolean();`
+	ents := extractFull(t, "custom_js_validation_schema", fi("flag.ts", "typescript", src))
+
+	se := schemaEntity(ents, "Flag")
+	if se == nil {
+		t.Fatal("expected SCOPE.Schema Flag for coerced scalar")
+	}
+	if se.Properties["scalar_kind"] != "boolean" {
+		t.Errorf("Flag scalar_kind = %q, want boolean", se.Properties["scalar_kind"])
+	}
+	if se.Properties["coerced"] != "true" {
+		t.Errorf("Flag coerced = %q, want true (props=%v)", se.Properties["coerced"], se.Properties)
+	}
+	if se.Properties["coercion_type"] != "boolean" {
+		t.Errorf("Flag coercion_type = %q, want boolean", se.Properties["coercion_type"])
+	}
+}
+
+// Regression: a bare non-coerced scalar `const S = z.string()` with no chain is
+// still skipped (honest-partial) — coercion handling must not start emitting
+// noise schemas for plain scalars.
+func TestZodCoerce_BareScalarStillSkipped(t *testing.T) {
+	src := `import { z } from 'zod';
+const S = z.string();`
+	ents := extractFull(t, "custom_js_validation_schema", fi("s.ts", "typescript", src))
+	if schemaEntity(ents, "S") != nil {
+		t.Error("bare non-coerced scalar z.string() must not emit a schema entity")
+	}
+}
+
+// Regression: a non-coerced object schema carries no coercion attributes at all.
+func TestZodCoerce_NonCoercedRegression(t *testing.T) {
+	src := `import { z } from 'zod';
+const Plain = z.object({ age: z.number(), name: z.string() });
+router.post('/p', (req, res) => { Plain.parse(req.body); res.json({}); });`
+	ents := extractFull(t, "custom_js_validation_schema", fi("p.ts", "typescript", src))
+	se := schemaEntity(ents, "Plain")
+	if se == nil {
+		t.Fatal("expected SCOPE.Schema Plain")
+	}
+	wantField(t, se, "age", "number")
+	for k := range se.Properties {
+		if k == "field_age_coerced" || k == "field_name_coerced" {
+			t.Errorf("non-coerced schema must not carry %q", k)
+		}
+	}
+	age := fieldChild(ents, "Plain.age")
+	if age != nil {
+		if _, ok := age.Properties["coerced"]; ok {
+			t.Errorf("non-coerced Plain.age must not carry coerced (props=%v)", age.Properties)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Nested z.object() → nested schema tree (issue #5496)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #5498. Part of epic #5479 (final Zod item).

## What
Recognize zod's coercion factory `z.coerce.<type>()` (`z.coerce.string/number/boolean/date/bigint`) wherever a plain `z.<type>()` base type is recognized today — object fields, nested `z.object()` fields, and bare scalar schemas.

## Coercion attribute model
A coerced field keeps its **underlying scalar type** (`z.coerce.number()` → type `number`) and additionally carries a coercion attribute:
- Expanded field member (`SCOPE.Schema/field`): `coerced=true` + `coercion_type=<underlying>` (e.g. `field_type=number, coerced=true, coercion_type=number`).
- Owning schema entity: per-field `field_<name>_coerced=true` marker, so consumers reading entity props (not just the expanded member) see it.
- A bare `const Flag = z.coerce.boolean()` is emitted as a `SCOPE.Schema` with `scalar_kind=boolean` + `coerced=true` + `coercion_type=boolean`.

Implemented by adding an optional `(?P<coerce>coerce\.)?` segment to `zodFieldRe` / `zodScalarSchemaRe` (named groups, so the shared `extractSchemaFields` index lookups stay robust and joi/yup are unaffected).

## Regression check
Non-coerced `z.number()` / `z.string()` carry **no** coercion attribute (absent, not `false`). A bare non-coerced scalar `const S = z.string()` with no chain is still skipped (honest-partial) — coercion handling does not start emitting noise schemas for plain scalars. Both guarded by tests.

## Registry/docs
`lang.jsts.validation.zod` Coercion.type_coercion_recognition `missing` → `full` (#5498). `coverage validate` + `fmt --check` green; docs regenerated.

## Tests (all pass)
`go test -count=1 ./internal/custom/javascript/ ./tools/coverage/ ./internal/types/`
- `TestZodCoerce_ObjectFields` — mixed `z.coerce.number()`/`z.coerce.date()`/`z.string()`: coerced fields carry `coerced=true` + right `coercion_type`, underlying types preserved, non-coerced `name` carries neither.
- `TestZodCoerce_ScalarSchema` — bare `z.coerce.boolean()` schema.
- `TestZodCoerce_BareScalarStillSkipped` — non-coerced bare scalar regression.
- `TestZodCoerce_NonCoercedRegression` — non-coerced object schema carries no coercion attrs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)