### PR TITLE
fix(links): skip synthetic <config> SourceFile in string pass — Windows cross-repo edges = 0 (#5523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,24 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   exactly as before.
 
 ### Fixed
+- **Windows: cross-repo string pass no longer aborts on the synthetic
+  `<config>` SourceFile (#5523):** the cross-repo string pass scanned each
+  entity's SourceFile against the filesystem and `os.Stat`'d the synthetic
+  sentinel `<config>` (`extractor.ConfigKeySourceFile`, emitted for every
+  `config_key` / `SCOPE.Config` entity). On POSIX `<config>` is a legal filename
+  so the stat returned `fs.ErrNotExist`, which the scanner already swallowed; on
+  Windows the characters `<`/`>` are illegal so the stat failed with
+  `ERROR_INVALID_NAME` (123, *"The filename, directory name, or volume label
+  syntax is incorrect"*), which was **not** tolerated — aborting the entire
+  string-pass stage and leaving **cross-repo edges = 0** for any group whose
+  repos read a literal config key (very common). Synthetic SourceFile sentinels
+  are now skipped before any filesystem access via a shared
+  `extractor.IsSyntheticSourceFile` helper (covers `<config>`, `<exception>`,
+  `<external-service>`, `<translation-key>`, `<template>`, and any future
+  `<…>`-shaped sentinel), and `scanFile` additionally tolerates
+  `ERROR_INVALID_NAME` / `ENOTDIR` / invalid-path stat errors as a skip rather
+  than a fatal abort (belt-and-suspenders; genuine I/O errors still propagate).
+  Per-repo graphs were unaffected; only the cross-repo link passes failed.
 - **Install now ships the bundled skills, not just the MCP (#5503):** on a
   released-tarball install (the common path on macOS) the `grafel` binary lands
   on its own with no `skills/` directory beside it, so `grafel install` found no

--- a/internal/extractor/synthetic_source.go
+++ b/internal/extractor/synthetic_source.go
@@ -1,0 +1,50 @@
+package extractor
+
+// synthetic_source.go — shared helper for recognizing the synthetic SourceFile
+// sentinels grafel emits for entities that have no real backing file on disk.
+//
+// Several extractors assign a constant, angle-bracketed SourceFile to entities
+// that are aggregated to a single graph node rather than tied to one physical
+// file (config keys, exception types, external services, translation keys,
+// templates). These sentinels are NOT real paths and must never be handed to
+// the filesystem (os.Stat / os.Open / os.ReadFile): the characters "<" and ">"
+// are legal on POSIX (where a stat merely returns fs.ErrNotExist) but ILLEGAL
+// on Windows, where the syscall returns ERROR_INVALID_NAME (123). A pass that
+// only tolerates fs.ErrNotExist therefore aborts on Windows — see issue #5523,
+// where the cross-repo string pass zeroed out all cross-repo edges.
+//
+// Any pass that scans entity SourceFiles against the filesystem should call
+// IsSyntheticSourceFile and skip matches BEFORE touching the filesystem.
+
+// syntheticSourceFiles is the set of known synthetic SourceFile sentinels.
+// Keep this in sync with the per-extractor constants:
+//   - ConfigKeySourceFile        ("<config>")        — config_key.go
+//   - ExceptionTypeSourceFile    ("<exception>")     — exception_flow.go
+//   - ExternalServiceSourceFile  ("<external-service>") — external_service.go
+//   - TranslationKeySourceFile   ("<translation-key>")  — translation_key.go
+//   - TemplateSourceFile         ("<template>")      — template_render.go
+var syntheticSourceFiles = map[string]bool{
+	ConfigKeySourceFile:       true,
+	ExceptionTypeSourceFile:   true,
+	ExternalServiceSourceFile: true,
+	TranslationKeySourceFile:  true,
+	TemplateSourceFile:        true,
+}
+
+// IsSyntheticSourceFile reports whether path is a synthetic SourceFile sentinel
+// — either one of the known constants above, or any value matching the general
+// "<...>" angle-bracketed shape grafel uses for synthetic sources. Such a value
+// never corresponds to a real file on any platform and must be skipped before
+// any filesystem access (it is a hard error on Windows).
+func IsSyntheticSourceFile(path string) bool {
+	if syntheticSourceFiles[path] {
+		return true
+	}
+	// General shape guard: a non-empty value wrapped in angle brackets, e.g.
+	// "<config>", "<generated>", "<stdin>", "<synthetic>". This future-proofs
+	// the check against new synthetic sentinels added without updating the set.
+	if len(path) >= 2 && path[0] == '<' && path[len(path)-1] == '>' {
+		return true
+	}
+	return false
+}

--- a/internal/extractor/synthetic_source_test.go
+++ b/internal/extractor/synthetic_source_test.go
@@ -1,0 +1,38 @@
+package extractor
+
+import "testing"
+
+func TestIsSyntheticSourceFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// Known constant sentinels.
+		{ConfigKeySourceFile, true},       // "<config>"
+		{ExceptionTypeSourceFile, true},   // "<exception>"
+		{ExternalServiceSourceFile, true}, // "<external-service>"
+		{TranslationKeySourceFile, true},  // "<translation-key>"
+		{TemplateSourceFile, true},        // "<template>"
+		// General angle-bracket shape (future synthetic sentinels).
+		{"<config>", true},
+		{"<generated>", true},
+		{"<stdin>", true},
+		{"<synthetic>", true},
+		{"<anything>", true},
+		// Real paths must not match.
+		{"src/handler.go", false},
+		{"internal/links/string_pass.go", false},
+		{"C:\\Users\\me\\app.go", false},
+		{"a/b/c.py", false},
+		{"", false},
+		// Partial / malformed brackets are not sentinels.
+		{"<config", false},
+		{"config>", false},
+		{"<", false},
+	}
+	for _, c := range cases {
+		if got := IsSyntheticSourceFile(c.path); got != c.want {
+			t.Errorf("IsSyntheticSourceFile(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/internal/links/links_test.go
+++ b/internal/links/links_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 )
@@ -369,6 +371,89 @@ func TestStringPass_HTTPPath(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected string match for /api/v1/orders/{id}, got %+v", doc.Links)
+	}
+}
+
+// TestStringPass_SkipsSyntheticConfigSourceFile guards #5523: a group whose
+// entities include a config_key with the synthetic SourceFile "<config>"
+// alongside real-file entities must still complete the string pass and emit the
+// cross-repo edges from the real files. On Windows os.Stat("<config>") fails
+// with ERROR_INVALID_NAME (123) — an un-tolerated error that previously aborted
+// the pass and left cross-repo edges = 0. The synthetic entry must be skipped
+// before any filesystem access.
+func TestStringPass_SkipsSyntheticConfigSourceFile(t *testing.T) {
+	root := fixtureRoot(t)
+	mkRepo := func(name, src string) {
+		dir := filepath.Join(root, name, "src")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		f := filepath.Join(dir, "h.go")
+		if err := os.WriteFile(f, []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		writeFixture(t, root, fixtureGraph{
+			Repo: name,
+			Entities: []map[string]any{
+				{"id": name + "_e", "name": "Handler", "kind": "function", "source_file": "src/h.go"},
+				// Synthetic config-key entity: SourceFile "<config>" has no
+				// backing file. Stat'ing it must never abort the pass.
+				{"id": name + "_cfg", "name": "config:API_URL", "kind": "config_key", "source_file": extractor.ConfigKeySourceFile},
+			},
+		})
+	}
+	// Both repos read the same literal HTTP path → cross-repo string edge.
+	mkRepo("alpha", "package main\nvar p = \"/api/v1/orders/{id}\"\n")
+	mkRepo("beta", "package main\nvar p = \"/api/v1/orders/{id}\"\n")
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g5523", root, home); err != nil {
+		t.Fatalf("pass aborted (synthetic <config> not skipped): %v", err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g5523-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method == MethodString && l.Identifier != nil && *l.Identifier == "/api/v1/orders/{id}" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected cross-repo string edge despite synthetic <config> entity, got %+v", doc.Links)
+	}
+}
+
+// TestScanFile_ToleratesSyntheticSourceFile asserts scanFile treats a synthetic
+// sentinel as a skip (nil, nil) rather than touching the filesystem — the unit
+// guard for #5523 that holds on every platform (on Windows the stat would
+// otherwise fail with ERROR_INVALID_NAME).
+func TestScanFile_ToleratesSyntheticSourceFile(t *testing.T) {
+	exs, err := scanFile(extractor.ConfigKeySourceFile, extractor.ConfigKeySourceFile, "")
+	if err != nil {
+		t.Fatalf("scanFile(<config>) should be a silent skip, got err: %v", err)
+	}
+	if len(exs) != 0 {
+		t.Fatalf("scanFile(<config>) should yield no extractions, got %d", len(exs))
+	}
+}
+
+// TestIsUnstattablePathErr verifies the defensive errno tolerance: an
+// ERROR_INVALID_NAME-style errno (123) and ENOTDIR are treated as skips, while
+// a genuine permission error is not.
+func TestIsUnstattablePathErr(t *testing.T) {
+	if !isUnstattablePathErr(syscall.Errno(123)) {
+		t.Error("ERROR_INVALID_NAME (123) should be tolerated as un-stattable")
+	}
+	if !isUnstattablePathErr(syscall.ENOTDIR) {
+		t.Error("ENOTDIR should be tolerated as un-stattable")
+	}
+	if isUnstattablePathErr(syscall.EACCES) {
+		t.Error("EACCES (permission denied) is a genuine error, must NOT be tolerated")
+	}
+	if isUnstattablePathErr(nil) {
+		t.Error("nil error must not be reported as un-stattable")
 	}
 }
 

--- a/internal/links/string_pass.go
+++ b/internal/links/string_pass.go
@@ -12,6 +12,9 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"syscall"
+
+	"github.com/cajasmota/grafel/internal/extractor"
 )
 
 // extractionCategory identifies a string-pattern bucket.
@@ -219,13 +222,54 @@ type scanCacheEntry struct {
 	Values []Extraction `json:"values"`
 }
 
+// isUnstattablePathErr reports whether a stat error means the path is
+// syntactically impossible / cannot exist on this platform (rather than a
+// genuine I/O failure on a real path). Such errors must be tolerated as a skip
+// so one bad synthetic entry can't abort the whole pass. Specifically:
+//
+//   - Windows ERROR_INVALID_NAME (123): "<…>" sentinels contain characters that
+//     are illegal in Windows filenames; GetFileAttributesEx fails before any
+//     real lookup. POSIX never returns this for "<config>" (it's a legal name,
+//     yielding fs.ErrNotExist), so this is a no-op on Linux/macOS.
+//   - ENOTDIR: a path component is not a directory — the path cannot resolve.
+//   - fs.ErrInvalid: a malformed argument.
+//
+// Genuine errors (permission denied on a real file, etc.) are NOT swallowed.
+func isUnstattablePathErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, fs.ErrInvalid) || errors.Is(err, syscall.ENOTDIR) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		// 123 == ERROR_INVALID_NAME on Windows ("The filename, directory name,
+		// or volume label syntax is incorrect."). Compared numerically so this
+		// builds and is harmless on every platform.
+		if errno == syscall.Errno(123) {
+			return true
+		}
+	}
+	return false
+}
+
 // scanFile reads a single file, classifies its string literals, and
 // caches the result. cacheDir is the per-repo directory; pass "" to
 // disable caching.
 func scanFile(absPath, relPath, cacheDir string) ([]Extraction, error) {
+	// Defense in depth: synthetic sentinels are skipped before scanRepo is
+	// reached, but guard the stat itself too. A path that cannot exist on this
+	// platform (e.g. a "<…>" sentinel on Windows yields ERROR_INVALID_NAME, or
+	// a non-directory component yields ENOTDIR) must be treated as a skip, not
+	// a fatal abort — a single un-stattable synthetic entry must never zero out
+	// cross-repo edges (#5523). Genuine I/O errors still propagate.
+	if extractor.IsSyntheticSourceFile(relPath) || extractor.IsSyntheticSourceFile(absPath) {
+		return nil, nil
+	}
 	fi, err := os.Stat(absPath)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) || isUnstattablePathErr(err) {
 			return nil, nil
 		}
 		return nil, err
@@ -361,6 +405,13 @@ func runStringPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 		var files []string
 		for _, e := range g.Entities {
 			if e.SourceFile == "" {
+				continue
+			}
+			// Synthetic SourceFile sentinels (<config>, <exception>, …) are not
+			// real paths; stat'ing them is a no-op on POSIX but a hard error on
+			// Windows (ERROR_INVALID_NAME), which would abort the whole pass and
+			// zero out cross-repo edges (#5523). Skip them before any FS access.
+			if extractor.IsSyntheticSourceFile(e.SourceFile) {
 				continue
 			}
 			if _, ok := entityForFile[e.SourceFile]; !ok {


### PR DESCRIPTION
Closes #5523.

## Problem
On Windows the cross-repo **string pass** (`internal/links/string_pass.go`) aborts when it `os.Stat`s the synthetic SourceFile sentinel `<config>` (`extractor.ConfigKeySourceFile`, emitted for every `config_key` / `SCOPE.Config` entity). `<`/`>` are illegal in Windows filenames, so the stat fails with `ERROR_INVALID_NAME` (123). Unlike `fs.ErrNotExist` (which POSIX returns for the same legal-on-POSIX name and which the scanner already swallows), that error was **not** tolerated → the whole string-pass stage aborts → **cross-repo edges = 0** for any group whose repos read a literal config key. Per-repo graphs are unaffected.

## Sentinels found
Five synthetic SourceFile sentinels are emitted by the extractors, all of which would trip the same Windows abort:
- `<config>` (`ConfigKeySourceFile`)
- `<exception>` (`ExceptionTypeSourceFile`)
- `<external-service>` (`ExternalServiceSourceFile`)
- `<translation-key>` (`TranslationKeySourceFile`)
- `<template>` (`TemplateSourceFile`)

## Fix
1. **Shared helper** `extractor.IsSyntheticSourceFile(path)` (new `internal/extractor/synthetic_source.go`, next to the sentinel constants) — matches the known constants OR the general `<…>` angle-bracket shape (future-proof). Reusable by any pass.
2. **String pass skips synthetic SourceFiles before any filesystem access** (at the scan-list collection point in `runStringPass`).
3. **Belt-and-suspenders errno tolerance** in `scanFile`: a stat failure that is `ERROR_INVALID_NAME` (123) / `ENOTDIR` / `fs.ErrInvalid` is treated as a skip rather than a fatal abort (portable numeric errno compare — no-op on POSIX). Genuine I/O errors (e.g. `EACCES`) still propagate.

## Sibling-pass audit
The other link passes that read SourceFiles (dataflow, taint, def-use, reachability, effect/constant propagation, template-pattern, complexity, payload-drift) already swallow their `os.ReadFile` errors with a per-file `continue`, so they were not vulnerable to the fatal abort. The string pass was the **sole** fatal `os.Stat` of a SourceFile. (`loadAllGraphs` stats the graphs *directory*, a real path — unaffected.)

## Tests
- `TestStringPass_SkipsSyntheticConfigSourceFile` — a 2-repo group with a `config_key` entity (`SourceFile = <config>`) alongside real-file entities: the pass completes and still emits the cross-repo string edge.
- `TestScanFile_ToleratesSyntheticSourceFile` — `scanFile(<config>)` is a silent skip, never touches the FS.
- `TestIsUnstattablePathErr` — errno 123 and `ENOTDIR` tolerated; `EACCES` and `nil` are not.
- `TestIsSyntheticSourceFile` — all five constants + `<…>` shapes true; real paths / malformed brackets false.

`go test -count=1 ./internal/links/... ./internal/extractor/...` green locally (macOS). The logic is platform-agnostic; the 3-OS CI gate confirms Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)