### PR TITLE
feat(auth): authorization checks → AUTHORIZES edges (NestJS guards + home-rolled idioms) (#5499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 ## [Unreleased]
 
 ### Added
+- **Authorization checks → AUTHORIZES edges (NestJS guards + home-rolled
+  idioms) (#5499):** the JS/TS auth resolver now recovers an endpoint's
+  authorization posture from two idiom families that did not reach the
+  route/decorator surface. (1) NestJS `@UseGuards(AuthGuard, RolesGuard)` with
+  `@Roles('admin')` / metadata decorators were already resolved at class &
+  method level; (2) NEW — *home-rolled / custom* checks in the handler body:
+  a route-handler / server-action / loader / page whose body OPENS with an
+  inline check — a `require*` / `authorize` / `assertCan` / `checkPermission` /
+  `can` / `hasRole` / `getServerSession`-family call (the auth-idiom set
+  `jsAuthCheckLeafSet`), or an `if (!session|!user) throw|redirect('/login')`
+  guard — now stamps the same AuthPolicy contract (`auth_required`,
+  `auth_method=check`, `auth_guard`, `auth_roles`, `auth_permissions`,
+  `auth_scopes`, plus the JSON `auth_policy` source chain), i.e. the AUTHORIZES
+  relation from the endpoint to its check callee. This greens the meta-framework
+  auth lane (Next.js App-Router route handlers, server actions, Remix/SvelteKit
+  loaders) that gate inside the handler rather than via middleware. Recognition
+  is confined to the body opener and gated on the auth-idiom callee set, so an
+  ordinary call (e.g. `require('./db')`, a business call) is never misread as
+  auth. Honest-partial: a dynamically-dispatched or runtime-assembled check is
+  left to the route/decorator resolvers. Registry: `auth_coverage` added to the
+  `meta_framework` subcategory (new Auth lane) and flipped to `partial` for
+  next-api / nuxt / remix / sveltekit; NestJS notes updated. Part of the
+  framework-stack coverage epic (#5479).
 - **Zod `z.coerce.*` coercion flags (#5498):** the Zod schema extractor now
   recognizes the coercion factory `z.coerce.<type>()`
   (`z.coerce.string/number/boolean/date/bigint`) wherever a plain `z.<type>()`

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -224,17 +224,17 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 
 ## Meta Framework
 
-| Language | Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|---|---|
-| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 5/5 | |
-| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟡 1/2 | 🟢 2/2 | 🔴 0/1 | 🟡 21/24 | 🟡 2/4 | |
-| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 7/7 | |
-| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 11/11 | |
-| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
-| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
-| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | ✅ 2/2 | |
+| Language | Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|---|
+| [elixir](../by-language/elixir.md) | [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🔴 0/1 | 🟢 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 5/5 | |
+| [java](../by-language/java.md) | [Play Framework](../detail/lang.java.framework.play.md) | 🟡 1/2 | — | 🟢 2/2 | 🔴 0/1 | 🟡 21/24 | 🟡 2/4 | |
+| [JS/TS](../by-language/jsts.md) | [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 7/7 | |
+| [JS/TS](../by-language/jsts.md) | [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 11/11 | |
+| [JS/TS](../by-language/jsts.md) | [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| [JS/TS](../by-language/jsts.md) | [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| [scala](../by-language/scala.md) | [Play Framework (Scala)](../detail/lang.scala.framework.play.md) | 🟢 2/2 | — | ✅ 3/3 | ✅ 1/1 | 🟡 22/24 | ✅ 2/2 | |
 
 
 ## Mobile

--- a/docs/coverage/by-language/elixir.md
+++ b/docs/coverage/by-language/elixir.md
@@ -42,9 +42,9 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### Meta Framework
 
-| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|---|
-| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🟢 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 5/5 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Phoenix LiveView](../detail/lang.elixir.framework.phoenix-liveview.md) | 🟢 2/2 | 🔴 0/1 | 🟢 3/3 | ✅ 1/1 | 🟡 23/24 | 🟢 5/5 | |
 
 
 ### RPC Framework

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -55,14 +55,14 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 
 ### Meta Framework
 
-| Name | Routing | Type System | Testing | Substrate | Other capabilities | Notes |
-|---|---|---|---|---|---|---|
-| [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 7/7 | |
-| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
-| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 11/11 | |
-| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
-| [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
-| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Astro](../detail/lang.jsts.framework.astro.md) | ✅ 2/2 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 7/7 | |
+| [Gatsby](../detail/lang.jsts.framework.gatsby.md) | ✅ 2/2 | 🔴 0/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| [Next.js API Routes / App Router](../detail/lang.jsts.framework.next-api.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 11/11 | |
+| [Nuxt](../detail/lang.jsts.framework.nuxt.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| [Remix](../detail/lang.jsts.framework.remix.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
+| [SvelteKit](../detail/lang.jsts.framework.sveltekit.md) | ✅ 2/2 | 🟢 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | ✅ 8/8 | |
 
 
 ### Mobile

--- a/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
+++ b/docs/coverage/detail/lang.elixir.framework.phoenix-liveview.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [elixir](../by-language/elixir.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 37
+- **Capability cells:** 38
 
 ## Capabilities
 
@@ -37,6 +37,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/elixir/phoenix.go`<br>`internal/engine/elixir_routes.go`<br>`internal/engine/elixir_routes_test.go`<br>`internal/engine/phoenix_routes.go` | synthesizePhoenixLive emits the initial-GET http_endpoint for each Phoenix LiveView 'live "/path", Module, :action' route, composing the active scope prefix and normalising :id->{id}; live-module :action attributed as handler (route_type=live). Value-asserting tests (TestPhoenixLive_Routes proves GET /dashboard + GET /users/{id} with handler attribution; TestPhoenixLive_NoAction covers the action-less form). |
 | Router pattern | 🟢 `partial` | — | — | `internal/custom/elixir/phoenix.go` | Phoenix scope blocks extracted as SCOPE.Pattern/scope; pipeline declarations as SCOPE.Pattern; live_session not yet separately tracked |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 5499 | — | #5499: meta_framework Auth lane added. The JS/TS home-rolled body-check resolver (indexAuthBodyChecks) is JS/TS-only; Phoenix LiveView auth (Elixir on_mount / plug pipelines) is unaddressed here — honest missing. |
 
 ### Build
 

--- a/docs/coverage/detail/lang.java.framework.play.md
+++ b/docs/coverage/detail/lang.java.framework.play.md
@@ -38,6 +38,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Route extraction | 🟢 `partial` | — | 3090 | `internal/engine/http_endpoint_synthesis.go` | — |
 | Router pattern | 🔴 `missing` | `2026-05-29` | [link](https://github.com/cajasmota/grafel/issues/3586) | `internal/custom/java/play_routes.go` | playRoutesLineRE in play_routes.go extracts HTTP verb+path patterns from conf/routes DSL (#3178). |
 
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
 ### Build
 
 | Capability | Status | Verified at | Issue | Cites | Notes |

--- a/docs/coverage/detail/lang.jsts.framework.astro.md
+++ b/docs/coverage/detail/lang.jsts.framework.astro.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 39
+- **Capability cells:** 40
 
 ## Capabilities
 
@@ -37,6 +37,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/frameworks/astro.yaml` | — |
 | Router pattern | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/grafel/issues/2857) | `internal/extractors/astro/extractor.go`<br>`internal/extractors/astro/issue2857_routing_test.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 5499 | — | #5499: meta_framework Auth lane added. This framework is predominantly static/build-time and carries no server-side auth-check idiom this pass recognises; honest missing pending a framework-specific auth surface. |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.gatsby.md
+++ b/docs/coverage/detail/lang.jsts.framework.gatsby.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 38
+- **Capability cells:** 39
 
 ## Capabilities
 
@@ -37,6 +37,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/grafel/issues/2857) | `internal/custom/javascript/gatsby.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
 | Router pattern | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/grafel/issues/2857) | `internal/custom/javascript/gatsby.go`<br>`internal/custom/javascript/issue2857_meta_structure_test.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | 5499 | — | #5499: meta_framework Auth lane added. This framework is predominantly static/build-time and carries no server-side auth-check idiom this pass recognises; honest missing pending a framework-specific auth surface. |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.nestjs.md
+++ b/docs/coverage/detail/lang.jsts.framework.nestjs.md
@@ -33,7 +33,7 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Auth coverage | ✅ `full` | `2026-05-28` | — | `cmd/grafel/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`testdata/fixtures/typescript/nestjs_auth.ts` | — |
+| Auth coverage | ✅ `full` | `2026-06-24` | — | `cmd/grafel/audit2852_jsauth_test.go`<br>`internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_auth_test.go`<br>`internal/engine/http_endpoint_jsts_authbody.go`<br>`internal/engine/http_endpoint_jsts_authbody_test.go`<br>`testdata/fixtures/typescript/nestjs_auth.ts` | #5499: a NestJS handler with NO @UseGuards / metadata decorator but a body opening with a home-rolled check (await this.authz.assertCan('x') / requireUser()) is now recovered via indexAuthBodyChecks (auth_method=check). |
 
 ### Validation
 

--- a/docs/coverage/detail/lang.jsts.framework.next-api.md
+++ b/docs/coverage/detail/lang.jsts.framework.next-api.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 41
+- **Capability cells:** 42
 
 ## Capabilities
 
@@ -37,6 +37,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-06-24` | [link](https://github.com/cajasmota/grafel/issues/5486) | `internal/custom/javascript/nextjs.go`<br>`internal/engine/http_endpoint_jsts_extra.go`<br>`internal/engine/http_endpoint_next_route_handler_5486_test.go`<br>`internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | App Router Route Handlers (#5486): each exported HTTP-method handler in app/.../route.{ts,js,tsx} — both `export async function GET(` and `export const GET = ...` forms — is synthesized as one http_endpoint_definition keyed `http:<METHOD>:<path>`. Path = the app/-relative directory with route groups `(group)` stripped and dynamic `[seg]`/`[...seg]` normalised to `{seg}`; Route Handlers are recognised anywhere under app/, not only under api/. Gating on the `route.*` basename keeps page.tsx/layout.tsx and arbitrary verb exports out. The verb-named handler is bound by the resolver to the SCOPE.Operation the JS/TS extractor emits. |
 | Router pattern | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/frameworks/next_js.yaml` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🟢 `partial` | `2026-06-24` | 5499 | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_authbody.go`<br>`internal/engine/http_endpoint_jsts_authbody_test.go` | #5499: home-rolled / custom auth checks in handler bodies. indexAuthBodyChecks scans each route-handler / server-action / loader body opener for an inline authorization check — a require*/authorize/assertCan/checkPermission/getServerSession-family call (jsAuthCheckLeafSet) or an `if (!session|!user) throw|redirect('/login')` guard — and stamps the AuthPolicy contract (auth_required/auth_method=check/auth_guard/auth_roles/auth_permissions/auth_scopes + the JSON source chain), i.e. the AUTHORIZES relation from the endpoint to its check callee. Confined to the body opener (no false positives on ordinary calls). Honest-partial: a dynamically-dispatched / runtime-assembled check, and framework session middleware config, are out of scope here. |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.nuxt.md
+++ b/docs/coverage/detail/lang.jsts.framework.nuxt.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 39
+- **Capability cells:** 40
 
 ## Capabilities
 
@@ -37,6 +37,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/frameworks/nuxt.yaml` | — |
 | Router pattern | ✅ `full` | — | 2880 | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/nuxt.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🟢 `partial` | `2026-06-24` | 5499 | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_authbody.go`<br>`internal/engine/http_endpoint_jsts_authbody_test.go` | #5499: home-rolled / custom auth checks in handler bodies. indexAuthBodyChecks scans each route-handler / server-action / loader body opener for an inline authorization check — a require*/authorize/assertCan/checkPermission/getServerSession-family call (jsAuthCheckLeafSet) or an `if (!session|!user) throw|redirect('/login')` guard — and stamps the AuthPolicy contract (auth_required/auth_method=check/auth_guard/auth_roles/auth_permissions/auth_scopes + the JSON source chain), i.e. the AUTHORIZES relation from the endpoint to its check callee. Confined to the body opener (no false positives on ordinary calls). Honest-partial: a dynamically-dispatched / runtime-assembled check, and framework session middleware config, are out of scope here. |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.remix.md
+++ b/docs/coverage/detail/lang.jsts.framework.remix.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 38
+- **Capability cells:** 39
 
 ## Capabilities
 
@@ -37,6 +37,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/frameworks/remix.yaml` | — |
 | Router pattern | ✅ `full` | `2026-05-28` | [link](https://github.com/cajasmota/grafel/issues/2857) | `internal/custom/javascript/issue2857_meta_structure_test.go`<br>`internal/custom/javascript/remix.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🟢 `partial` | `2026-06-24` | 5499 | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_authbody.go`<br>`internal/engine/http_endpoint_jsts_authbody_test.go` | #5499: home-rolled / custom auth checks in handler bodies. indexAuthBodyChecks scans each route-handler / server-action / loader body opener for an inline authorization check — a require*/authorize/assertCan/checkPermission/getServerSession-family call (jsAuthCheckLeafSet) or an `if (!session|!user) throw|redirect('/login')` guard — and stamps the AuthPolicy contract (auth_required/auth_method=check/auth_guard/auth_roles/auth_permissions/auth_scopes + the JSON source chain), i.e. the AUTHORIZES relation from the endpoint to its check callee. Confined to the body opener (no false positives on ordinary calls). Honest-partial: a dynamically-dispatched / runtime-assembled check, and framework session middleware config, are out of scope here. |
 
 ### Build
 

--- a/docs/coverage/detail/lang.jsts.framework.sveltekit.md
+++ b/docs/coverage/detail/lang.jsts.framework.sveltekit.md
@@ -6,7 +6,7 @@ Auto-generated. Back to [summary](../summary.md).
 - **Language:** [JS/TS](../by-language/jsts.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Meta Framework
-- **Capability cells:** 39
+- **Capability cells:** 40
 
 ## Capabilities
 
@@ -37,6 +37,12 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Route extraction | ✅ `full` | `2026-05-28` | — | `internal/engine/rules/javascript_typescript/frameworks/sveltekit.yaml` | — |
 | Router pattern | ✅ `full` | — | 2880 | `internal/custom/javascript/issue2880_metafw_routing_test.go`<br>`internal/custom/javascript/svelte.go` | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🟢 `partial` | `2026-06-24` | 5499 | `internal/engine/http_endpoint_jsts_auth.go`<br>`internal/engine/http_endpoint_jsts_authbody.go`<br>`internal/engine/http_endpoint_jsts_authbody_test.go` | #5499: home-rolled / custom auth checks in handler bodies. indexAuthBodyChecks scans each route-handler / server-action / loader body opener for an inline authorization check — a require*/authorize/assertCan/checkPermission/getServerSession-family call (jsAuthCheckLeafSet) or an `if (!session|!user) throw|redirect('/login')` guard — and stamps the AuthPolicy contract (auth_required/auth_method=check/auth_guard/auth_roles/auth_permissions/auth_scopes + the JSON source chain), i.e. the AUTHORIZES relation from the endpoint to its check callee. Confined to the body opener (no false positives on ordinary calls). Honest-partial: a dynamically-dispatched / runtime-assembled check, and framework session middleware config, are out of scope here. |
 
 ### Build
 

--- a/docs/coverage/detail/lang.scala.framework.play.md
+++ b/docs/coverage/detail/lang.scala.framework.play.md
@@ -38,6 +38,11 @@ Auto-generated. Back to [summary](../summary.md).
 | Route extraction | ✅ `full` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/custom/scala/routing.go` | Play conf/routes file parsed by rePlayRoute regex (GET/POST/etc path controller.action); controller class patterns in play_framework.yaml. File-local. |
 | Router pattern | 🟢 `partial` | `2026-05-30` | — | `internal/custom/scala/frameworks.go`<br>`internal/engine/rules/scala/frameworks/play_framework.yaml` | Play reverse routing (routes.reverse*, Routes.) detected by rePlayRouterPattern. play_framework.yaml contains route file_conventions. |
 
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+
 ### Build
 
 | Capability | Status | Verified at | Issue | Cites | Notes |

--- a/internal/engine/http_endpoint_jsts_auth.go
+++ b/internal/engine/http_endpoint_jsts_auth.go
@@ -368,6 +368,10 @@ func applyJSTSAuthPolicy(content, path string, entities []types.EntityRecord, be
 	adonisRouteAuth := indexAdonisRouteAuth(content, path)
 	// Index Marble.js per-effect auth middleware by canonical path.
 	marbleRouteAuth := indexMarbleRouteAuth(content, path)
+	// #5499 — index home-rolled / custom auth checks in handler bodies
+	// (`const u = await requireUser()`, `if (!session) redirect('/login')`).
+	// Keyed by handler name and by handler start line.
+	authBodyByName, authBodyByLine := indexAuthBodyChecks(content)
 
 	for i := before; i < len(entities); i++ {
 		e := &entities[i]
@@ -390,9 +394,11 @@ func applyJSTSAuthPolicy(content, path string, entities []types.EntityRecord, be
 		canonical := e.Properties["path"]
 		key := verb + " " + canonical
 
+		bodyPolicy, hasBody := authBodyEndpointKey(e, authBodyByName, authBodyByLine, path)
 		policy := resolveEndpointAuth(
 			framework, key, e.Properties["source_handler"],
 			ctx, routeAuth, methodGuards, methodMetaAuth, hapiRouteAuth, adonisRouteAuth, marbleRouteAuth,
+			bodyPolicy, hasBody,
 		)
 		stampAuthPolicy(e.Properties, policy)
 	}
@@ -416,6 +422,7 @@ func resolveEndpointAuth(
 	hapiRouteAuth map[string]hapiAuth,
 	adonisRouteAuth map[string][]AuthSignal,
 	marbleRouteAuth map[string][]AuthSignal,
+	bodyPolicy AuthPolicy, hasBody bool,
 ) AuthPolicy {
 	// 1a. Express-shaped route-level middleware chain.
 	if sigs, ok := routeAuth[key]; ok && len(sigs) > 0 {
@@ -471,6 +478,15 @@ func resolveEndpointAuth(
 			Required: true, Method: "middleware", Confidence: "high",
 			SourceChain: sigs,
 		}
+	}
+
+	// 2. Home-rolled / custom auth check in the handler body (#5499) —
+	//    `const u = await requireUser()` / `if (!session) redirect('/login')`.
+	//    The check is IN the handler (route-direct), so it ranks above the
+	//    file-scope inherited signals below, but below an explicit route
+	//    middleware / method decorator above (those are the declared gate).
+	if hasBody {
+		return bodyPolicy
 	}
 
 	// 3. File-scope signals (router/app-level middleware, Nest class guards,
@@ -606,6 +622,11 @@ func stampAuthPolicy(props map[string]string, policy AuthPolicy) {
 		switch policy.Method {
 		case "guard":
 			props["auth_guard"] = authEvidenceSymbol(head.Text)
+		case "check":
+			// #5499 — a home-rolled body check. Surface the check-callee symbol
+			// under auth_guard (the MCP signal-1 key) so grafel_auth_coverage
+			// fires without parsing the JSON source chain.
+			props["auth_guard"] = authBodyEvidenceSymbol(head.Text)
 		case "middleware", "config", "framework_default":
 			props["auth_middleware"] = authEvidenceSymbol(head.Text)
 		}

--- a/internal/engine/http_endpoint_jsts_authbody.go
+++ b/internal/engine/http_endpoint_jsts_authbody.go
@@ -1,0 +1,390 @@
+// Home-rolled / custom auth-check recognition for JS/TS endpoints (#5499).
+//
+// The #2852 resolver (http_endpoint_jsts_auth.go) recognises auth that is wired
+// at the ROUTE-REGISTRATION or DECORATOR surface: Express middleware chains,
+// NestJS `@UseGuards`, Hapi route auth, etc. But a very large family of real
+// apps — especially meta-framework route handlers, server actions, loaders and
+// page handlers (Next.js, Remix, SvelteKit, Nuxt) and plain hand-written
+// Express/Koa handlers — does NOT gate at that surface at all. Instead the
+// handler BODY opens with an inline authorization check:
+//
+//	export async function POST(req) {
+//	  const user = await requireUser()          // throws/redirects if anon
+//	  ...
+//	}
+//
+//	export async function action({ request }) {
+//	  const session = await getServerSession()
+//	  if (!session) throw redirect('/login')     // explicit guard
+//	  ...
+//	}
+//
+// These never reach the route/decorator resolver, so the endpoint resolved to
+// method="unknown" even though it is genuinely protected. This pass recovers
+// the posture from the handler body's OPENING statements and stamps the same
+// AuthPolicy property contract (auth_required / auth_method="check" /
+// auth_guard / auth_roles / auth_permissions / auth_policy source chain) — i.e.
+// the AUTHORIZES relation from the endpoint to its auth-check callee.
+//
+// Gating (no false positives): an ordinary call is NOT auth. A body opener
+// counts only when (a) it calls a name in the auth-idiom set
+// (require*/authorize/assertCan/checkPermission/getServerSession/... — see
+// jsAuthCheckCalleeRe), or (b) it is an `if (!session|!user|...) throw|redirect`
+// guard over a recognised session/user binding. Both are confined to the first
+// few statements of the body (an auth check guards the handler; a call buried
+// deep in business logic is not a gate).
+//
+// Honest-partial: a dynamically-dispatched check (`this.authService.check()` on
+// a runtime-resolved service, a check behind an indirection) is recognised only
+// when its leaf callee name is in the idiom set; a check assembled at runtime is
+// left to the route/decorator resolvers and noted as out of scope.
+//
+// Refs #5499 (#5479).
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// jsAuthCheckCalleeRe matches a call whose leaf callee is a recognised
+// home-rolled auth-check idiom. Anchored to the leaf (after the last `.`) so
+// `auth.requireUser()` and `this.authz.assertCan(...)` both match on the leaf.
+// Group 1 = the leaf callee name, group 2 = the raw argument list.
+//
+// The set is the require*/authorize/can/assert*/checkPermission/getSession
+// family the ticket calls out, plus the common spellings that recur across
+// hand-rolled and meta-framework auth helpers. The trailing `\b...\(` pins it
+// to a call, not a bare identifier.
+var jsAuthCheckCalleeRe = regexp.MustCompile(
+	`(?:^|[^\w$])(` +
+		`require(?:User|Auth|Authentication|Session|Login|Admin|Role|Permission|Permissions|Scope|Scopes)?|` +
+		`ensureAuth(?:enticated)?|ensureLoggedIn|ensureSignedIn|` +
+		`authorize|authorization|authenticate|` +
+		`assertCan|assertAuth(?:enticated|orized)?|assertUser|assertSession|assertPermission|` +
+		`checkAuth|checkPermission|checkPermissions|checkScope|checkRole|checkAccess|` +
+		`can|cannot|hasPermission|hasRole|hasScope|hasAccess|` +
+		`getServerSession|getSession|getCurrentUser|getAuthUser|getUser|currentUser|` +
+		`protect|protectRoute|guard|verifyAuth|verifyToken|verifyJwt|verifySession|` +
+		`isAuthenticated|isAuthorized|mustBeAuthenticated|withAuth` +
+		`)\s*\(([^)]*)\)`,
+)
+
+// jsAuthCheckLeafSet is the canonical set of recognised leaf callee names. It
+// gates the regex's broad `require` alternation: a bare `require('fs')` (the
+// CommonJS module loader) must NOT be read as an auth check. Only `require`
+// FOLLOWED BY an auth noun (requireUser/requireAuth/...) or one of the explicit
+// auth verbs counts. We enforce this here rather than in the regex so the
+// callee-name allow-list is auditable in one place.
+var jsAuthCheckLeafSet = map[string]bool{
+	"requireUser": true, "requireAuth": true, "requireAuthentication": true,
+	"requireSession": true, "requireLogin": true, "requireAdmin": true,
+	"requireRole": true, "requirePermission": true, "requirePermissions": true,
+	"requireScope": true, "requireScopes": true,
+	"ensureAuth": true, "ensureAuthenticated": true, "ensureLoggedIn": true,
+	"ensureSignedIn": true,
+	"authorize": true, "authorization": true, "authenticate": true,
+	"assertCan": true, "assertAuth": true, "assertAuthenticated": true,
+	"assertAuthorized": true, "assertUser": true, "assertSession": true,
+	"assertPermission": true,
+	"checkAuth": true, "checkPermission": true, "checkPermissions": true,
+	"checkScope": true, "checkRole": true, "checkAccess": true,
+	"can": true, "hasPermission": true, "hasRole": true, "hasScope": true,
+	"hasAccess": true,
+	"getServerSession": true, "getSession": true, "getCurrentUser": true,
+	"getAuthUser": true,
+	"protect": true, "protectRoute": true, "guard": true,
+	"verifyAuth": true, "verifyToken": true, "verifyJwt": true,
+	"verifySession": true,
+	"isAuthenticated": true, "isAuthorized": true, "mustBeAuthenticated": true,
+	"withAuth": true,
+}
+
+// jsAuthCheckRoleBearing maps a recognised check callee to the bucket its first
+// quoted literal argument belongs to: a role check (`requireRole('admin')`,
+// `hasRole('user')`) names a ROLE; a permission/scope check
+// (`checkPermission('orders:delete')`, `can('delete','Order')`,
+// `requireScope('read')`) names a PERMISSION/SCOPE. Anything else carries no
+// structured grant (the literal, if any, is opaque) and is captured as the
+// guard symbol only.
+var jsAuthCheckRoleCallees = map[string]bool{
+	"requireRole": true, "checkRole": true, "hasRole": true,
+}
+var jsAuthCheckScopeCallees = map[string]bool{
+	"requireScope": true, "requireScopes": true, "checkScope": true,
+	"hasScope": true, "verifyScope": true,
+}
+var jsAuthCheckPermCallees = map[string]bool{
+	"requirePermission": true, "requirePermissions": true, "checkPermission": true,
+	"checkPermissions": true, "hasPermission": true, "assertPermission": true,
+	"assertCan": true, "can": true,
+}
+
+// jsAuthGuardIfRe matches an early-return / early-throw guard over a session or
+// user binding: `if (!session) ...`, `if (!user) ...`, `if (!ctx.session) ...`,
+// `if (!auth) ...`. Group 1 = the negated binding name (leaf). The follow-up
+// `throw`/`redirect`/`return` is confirmed by jsAuthGuardActionRe on the
+// remainder of the statement.
+var jsAuthGuardIfRe = regexp.MustCompile(
+	`\bif\s*\(\s*!\s*(?:[\w$]+\.)*(session|user|auth|currentUser|loggedIn|isAuthenticated|isAuth|token|jwt|principal|identity|account)\b[^)]*\)\s*(.*)`,
+)
+
+// jsAuthGuardActionRe confirms the body of an `if (!session)` guard performs an
+// auth-rejecting action — throwing, redirecting to a login/auth route, or
+// returning a 401/403 / unauthorized response. A guard that merely logs or
+// continues is NOT an auth gate.
+var jsAuthGuardActionRe = regexp.MustCompile(
+	`(?i)\b(?:throw\b|redirect\s*\(|return\s+(?:NextResponse\.)?(?:redirect|json|new\s+Response|unauthorized|forbidden)|res\.(?:status\s*\(\s*(?:401|403)|sendStatus\s*\(\s*(?:401|403)|redirect)|reply\.(?:code\s*\(\s*(?:401|403)|redirect)|signIn\s*\(|notFound\s*\()`,
+)
+
+// jsAuthGuardLoginRedirectRe is a narrower confirmation for a redirect-based
+// guard: a redirect whose target string looks like a login / sign-in / auth
+// route. Used so a generic `redirect('/home')` after `if(!session)` (rare) is
+// still treated as a guard, while keeping the action set honest.
+var jsAuthGuardLoginRedirectRe = regexp.MustCompile(
+	`(?i)redirect\s*\(\s*['"` + "`" + `][^'"` + "`" + `]*(?:login|signin|sign-in|auth|unauthorized|403|401)`,
+)
+
+// authBodyResult is the resolved home-rolled posture for one handler body.
+type authBodyResult struct {
+	guard       string   // the recognised check callee or guard binding (evidence)
+	roles       []string // literal roles (requireRole('admin'))
+	permissions []string // literal permissions (checkPermission('x'), can('delete'))
+	scopes      []string // literal scopes (requireScope('read'))
+	line        int      // 1-based line of the recognised check
+	text        string   // source-chain evidence text
+}
+
+// authBodyOpenWindow caps how far into a handler body we look for the opening
+// auth check. An auth gate is, by construction, one of the first statements;
+// scanning the whole body would mis-read an authorization call buried in
+// business logic as a route gate. ~600 bytes comfortably covers the leading
+// `const x = await requireUser()` / `if(!session) redirect(...)` openers across
+// formatting styles without reaching into deep handler logic.
+const authBodyOpenWindow = 600
+
+// recognizeAuthBodyOpener inspects the OPENING of a handler body for a
+// home-rolled auth check. `body` is the source from just after the handler's
+// opening `{`. Returns (result, true) on a recognised check. baseLine is the
+// 1-based line of the body open, used to compute the check's absolute line.
+func recognizeAuthBodyOpener(body string, baseLine int) (authBodyResult, bool) {
+	window := body
+	if len(window) > authBodyOpenWindow {
+		window = window[:authBodyOpenWindow]
+	}
+
+	// 1. Direct auth-check call: `const u = await requireUser()`,
+	//    `await authorize(ctx, 'orders:read')`, `assertCan('delete', order)`.
+	if m := jsAuthCheckCalleeRe.FindStringSubmatchIndex(window); m != nil {
+		leaf := window[m[2]:m[3]]
+		args := window[m[4]:m[5]]
+		if jsAuthCheckLeafSet[leaf] {
+			res := authBodyResult{
+				guard: leaf,
+				line:  baseLine + strings.Count(window[:m[2]], "\n"),
+				text:  "body-check: " + leaf + "(" + strings.TrimSpace(args) + ")",
+			}
+			classifyAuthCheckArgs(leaf, args, &res)
+			return res, true
+		}
+	}
+
+	// 2. Early-guard over a session/user binding: `if (!session) throw ...` /
+	//    `if (!user) redirect('/login')`.
+	if m := jsAuthGuardIfRe.FindStringSubmatchIndex(window); m != nil {
+		binding := window[m[2]:m[3]]
+		rest := window[m[4]:m[5]]
+		if jsAuthGuardActionRe.MatchString(rest) || jsAuthGuardLoginRedirectRe.MatchString(rest) {
+			return authBodyResult{
+				guard: "!" + binding,
+				line:  baseLine + strings.Count(window[:m[0]], "\n"),
+				text:  "body-guard: if(!" + binding + ") " + strings.TrimSpace(firstLine(rest)),
+			}, true
+		}
+	}
+
+	return authBodyResult{}, false
+}
+
+// classifyAuthCheckArgs routes a check's first quoted literal(s) to the role /
+// permission / scope bucket per the callee's family, so a parameterised check
+// carries the specific required grant. A check with no string literal (a
+// dynamic guard) carries no grant — never fabricated.
+func classifyAuthCheckArgs(leaf, args string, res *authBodyResult) {
+	var lits []string
+	for _, q := range jsQuotedTokenRe.FindAllStringSubmatch(args, -1) {
+		if tok := strings.TrimSpace(q[1]); tok != "" {
+			lits = append(lits, tok)
+		}
+	}
+	if len(lits) == 0 {
+		return
+	}
+	switch {
+	case jsAuthCheckRoleCallees[leaf]:
+		res.roles = append(res.roles, lits...)
+	case jsAuthCheckScopeCallees[leaf]:
+		res.scopes = append(res.scopes, lits...)
+	case jsAuthCheckPermCallees[leaf]:
+		// casl `can('delete', 'Order')` — the action (first literal) is the
+		// permission; the subject is not a grant string.
+		if leaf == "can" {
+			res.permissions = append(res.permissions, lits[0])
+		} else {
+			res.permissions = append(res.permissions, lits...)
+		}
+	}
+}
+
+// authBodyEvidenceSymbol returns a compact symbol for the MCP signal-1
+// auth_guard property from a body-check source-chain text: `body-check:
+// requireUser(...)` → `requireUser`, `body-guard: if(!session) ...` →
+// `!session`.
+func authBodyEvidenceSymbol(text string) string {
+	text = strings.TrimPrefix(text, "body-check: ")
+	if rest, ok := strings.CutPrefix(text, "body-guard: if(!"); ok {
+		if i := strings.IndexByte(rest, ')'); i >= 0 {
+			return "!" + strings.TrimSpace(rest[:i])
+		}
+		return "!" + rest
+	}
+	if i := strings.IndexByte(text, '('); i >= 0 {
+		return strings.TrimSpace(text[:i])
+	}
+	return text
+}
+
+// firstLine returns the first line of s (for compact evidence text).
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// jsHandlerBodyRe matches a function/handler whose body we scan for an opening
+// auth check, covering the shapes meta-framework and hand-rolled handlers use:
+//
+//	export async function GET(req) { ...        (Next.js App Router route handler)
+//	export const action = async ({request}) => { ...   (Remix/SvelteKit action)
+//	async function handler(req, res) { ...       (Next.js Pages API / Express)
+//	export default async function handler(...) { ...
+//	  findOne(@Param() id) { ...                 (Nest handler method — body gate)
+//
+// Group 1 = the handler name (when a named function/const), used as the lookup
+// key. The match index of the opening `{` is recovered separately so the body
+// span can be isolated with findMatchingBrace.
+var jsHandlerBodyRe = regexp.MustCompile(
+	`(?m)(?:export\s+(?:default\s+)?)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\([^;{]*\)\s*(?::[^={;]+)?\{` +
+		`|(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?\([^;{]*\)\s*(?::[^=>{;]+)?=>\s*\{`,
+)
+
+// indexAuthBodyChecks scans every recognisable handler body in the file for an
+// opening home-rolled auth check and returns the results keyed BOTH by handler
+// name and by the handler's 1-based start line (so callers can attribute by
+// whichever the synthetic endpoint carries). Nest handler methods are indexed
+// via the existing nestHandlerMethodRe; top-level/exported handlers via
+// jsHandlerBodyRe.
+func indexAuthBodyChecks(content string) (byName map[string]authBodyResult, byLine map[int]authBodyResult) {
+	byName = map[string]authBodyResult{}
+	byLine = map[int]authBodyResult{}
+	if !authBodyFastPath(content) {
+		return byName, byLine
+	}
+
+	record := func(name string, declOff int) {
+		open := strings.IndexByte(content[declOff:], '{')
+		if open < 0 {
+			return
+		}
+		open += declOff
+		close := findMatchingBrace(content, open)
+		if close < 0 {
+			close = len(content)
+		}
+		body := content[open+1 : close]
+		baseLine := lineAtOffset(content, open)
+		res, ok := recognizeAuthBodyOpener(body, baseLine)
+		if !ok {
+			return
+		}
+		if name != "" {
+			if _, exists := byName[name]; !exists {
+				byName[name] = res
+			}
+		}
+		byLine[lineAtOffset(content, declOff)] = res
+	}
+
+	// Top-level / exported function + arrow handlers (meta-framework & plain).
+	for _, loc := range jsHandlerBodyRe.FindAllStringSubmatchIndex(content, -1) {
+		name := ""
+		if loc[2] >= 0 {
+			name = content[loc[2]:loc[3]]
+		} else if loc[4] >= 0 {
+			name = content[loc[4]:loc[5]]
+		}
+		record(name, loc[0])
+	}
+
+	// Nest handler methods (class methods — `findOne(@Param() id) { ... }`).
+	for _, loc := range nestHandlerMethodRe.FindAllStringSubmatchIndex(content, -1) {
+		record(content[loc[2]:loc[3]], loc[0])
+	}
+
+	return byName, byLine
+}
+
+// authBodyFastPath is the cheap substring gate: skip the (relatively expensive)
+// body scan unless the file mentions at least one auth-check idiom token.
+func authBodyFastPath(content string) bool {
+	for _, tok := range []string{
+		"require", "authorize", "authenticate", "assertCan", "assert",
+		"checkPermission", "checkAuth", "getServerSession", "getSession",
+		"currentUser", "getCurrentUser", "isAuthenticated", "ensureAuth",
+		"hasPermission", "hasRole", "protect", "verifyAuth", "verifyToken",
+		"if (!session", "if(!session", "if (!user", "if(!user", "if (!auth", "if(!auth",
+	} {
+		if strings.Contains(content, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// authBodyPolicy builds an AuthPolicy from a resolved home-rolled body check.
+// method="check" (the route is gated by an inline authorization check in the
+// handler body) at HIGH confidence — the binding is route-direct (the check is
+// IN the handler), not an inherited file-scope default.
+func authBodyPolicy(res authBodyResult, file string) AuthPolicy {
+	return AuthPolicy{
+		Required: true, Method: "check", Confidence: "high",
+		Roles:       dedupeNonEmpty(res.roles),
+		Permissions: dedupeNonEmpty(res.permissions),
+		Scopes:      dedupeNonEmpty(res.scopes),
+		SourceChain: []AuthSignal{{
+			Kind: "check", Text: res.text, File: file, Line: res.line,
+		}},
+	}
+}
+
+// authBodyEndpointKey attributes a body-check result to a synthetic endpoint by
+// the endpoint's source_handler name first, then its StartLine. Returns
+// (policy, true) when a body check covers this endpoint.
+func authBodyEndpointKey(
+	e *types.EntityRecord, byName map[string]authBodyResult, byLine map[int]authBodyResult, file string,
+) (AuthPolicy, bool) {
+	if handler := nestHandlerName(e.Properties["source_handler"]); handler != "" {
+		if res, ok := byName[handler]; ok {
+			return authBodyPolicy(res, file), true
+		}
+	}
+	if e.StartLine > 0 {
+		if res, ok := byLine[e.StartLine]; ok {
+			return authBodyPolicy(res, file), true
+		}
+	}
+	return AuthPolicy{}, false
+}

--- a/internal/engine/http_endpoint_jsts_authbody_test.go
+++ b/internal/engine/http_endpoint_jsts_authbody_test.go
@@ -1,0 +1,151 @@
+package engine
+
+import "testing"
+
+// Home-rolled / custom auth-check recognition (#5499). A handler / server-action
+// / route-handler whose body OPENS with an auth check — a require*/authorize/
+// assertCan/checkPermission/getServerSession call, or an `if (!session)
+// throw/redirect` guard — is an AUTHORIZES relation from the endpoint to the
+// check. These never reach the route/decorator resolver (no middleware, no
+// @UseGuards), so this pass recovers the posture from the body.
+
+// TestAuthBody_NextRouteHandler_RequireUser — a Next.js App Router route handler
+// whose body opens with `const user = await requireUser()` → protected,
+// method="check", guard=requireUser.
+func TestAuthBody_NextRouteHandler_RequireUser(t *testing.T) {
+	src := `
+export async function POST(request: Request) {
+  const user = await requireUser()
+  return Response.json({ ok: true })
+}
+export async function GET(request: Request) {
+  return Response.json([])
+}
+`
+	eps := authProps(t, "typescript", "app/api/orders/route.ts", src)
+	// POST opens with requireUser() → protected via body check.
+	post, ok := eps["POST /api/orders"]
+	if !ok {
+		t.Fatalf("POST /api/orders not synthesised (got %v)", keysOf(eps))
+	}
+	if post.Properties["auth_required"] != "true" {
+		t.Errorf("POST: auth_required=%q want true (props %v)", post.Properties["auth_required"], post.Properties)
+	}
+	if post.Properties["auth_method"] != "check" {
+		t.Errorf("POST: auth_method=%q want check", post.Properties["auth_method"])
+	}
+	if post.Properties["auth_guard"] != "requireUser" {
+		t.Errorf("POST: auth_guard=%q want requireUser", post.Properties["auth_guard"])
+	}
+	// GET has no auth check → no edge (negative).
+	requirePublic(t, eps, "GET /api/orders")
+}
+
+// TestAuthBody_NextRouteHandler_SessionRedirectGuard — a route handler whose
+// body opens with `if (!session) redirect('/login')` → protected, guard=!session.
+func TestAuthBody_NextRouteHandler_SessionRedirectGuard(t *testing.T) {
+	src := `
+import { redirect } from 'next/navigation'
+export async function GET(request: Request) {
+  const session = await getServerSession()
+  if (!session) redirect('/login')
+  return Response.json({ ok: true })
+}
+`
+	eps := authProps(t, "typescript", "app/api/profile/route.ts", src)
+	e, ok := eps["GET /api/profile"]
+	if !ok {
+		t.Fatalf("GET /api/profile not synthesised (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_required"] != "true" || e.Properties["auth_method"] != "check" {
+		t.Errorf("GET: want protected method=check, got %v", e.Properties)
+	}
+	// getServerSession is in the idiom set and appears first → it is the guard.
+	if g := e.Properties["auth_guard"]; g != "getServerSession" && g != "!session" {
+		t.Errorf("GET: auth_guard=%q want getServerSession or !session", g)
+	}
+}
+
+// TestAuthBody_PermissionCheck_CapturesGrant — `await checkPermission('orders:delete')`
+// captures the literal permission.
+func TestAuthBody_PermissionCheck_CapturesGrant(t *testing.T) {
+	src := `
+export async function DELETE(request: Request) {
+  await checkPermission('orders:delete')
+  return new Response(null, { status: 204 })
+}
+`
+	eps := authProps(t, "typescript", "app/api/orders/[id]/route.ts", src)
+	e, ok := eps["DELETE /api/orders/{id}"]
+	if !ok {
+		t.Fatalf("DELETE not synthesised (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_required"] != "true" {
+		t.Errorf("DELETE: want protected, got %v", e.Properties)
+	}
+	if e.Properties["auth_permissions"] != "orders:delete" {
+		t.Errorf("DELETE: auth_permissions=%q want orders:delete", e.Properties["auth_permissions"])
+	}
+}
+
+// TestAuthBody_NoAuthHandler_NoEdge — a plain handler with no auth idiom in its
+// body opener gets NO auth edge (negative; guards against false positives on
+// ordinary calls like a `require('./db')` module import or a business call).
+func TestAuthBody_NoAuthHandler_NoEdge(t *testing.T) {
+	src := `
+export async function GET(request: Request) {
+  const rows = await db.query('SELECT * FROM items')
+  return Response.json(rows)
+}
+`
+	eps := authProps(t, "typescript", "app/api/items/route.ts", src)
+	requirePublic(t, eps, "GET /api/items")
+}
+
+// TestAuthBody_NestHandlerBodyGate — a NestJS handler with NO @UseGuards but a
+// body opening with `await this.authz.assertCan('read', dto)` → protected via
+// the body check (the decorator resolver finds nothing here).
+func TestAuthBody_NestHandlerBodyGate(t *testing.T) {
+	src := `
+import { Controller, Get } from '@nestjs/common'
+
+@Controller('reports')
+export class ReportsController {
+  @Get()
+  async findAll() {
+    await this.authz.assertCan('reports:read')
+    return []
+  }
+}
+`
+	eps := authProps(t, "typescript", "reports.controller.ts", src)
+	e, ok := eps["GET /reports"]
+	if !ok {
+		t.Fatalf("GET /reports not synthesised (got %v)", keysOf(eps))
+	}
+	if e.Properties["auth_required"] != "true" || e.Properties["auth_method"] != "check" {
+		t.Errorf("GET /reports: want protected method=check, got %v", e.Properties)
+	}
+	if e.Properties["auth_permissions"] != "reports:read" {
+		t.Errorf("GET /reports: auth_permissions=%q want reports:read", e.Properties["auth_permissions"])
+	}
+}
+
+// TestAuthBody_RequireRole_CapturesRole — `await requireRole('admin')` captures
+// the role into auth_roles.
+func TestAuthBody_RequireRole_CapturesRole(t *testing.T) {
+	src := `
+export async function POST(request: Request) {
+  await requireRole('admin')
+  return Response.json({})
+}
+`
+	eps := authProps(t, "typescript", "app/api/admin/route.ts", src)
+	e := eps["POST /api/admin"]
+	if e.Properties["auth_required"] != "true" {
+		t.Fatalf("POST /api/admin: want protected, got %v", e.Properties)
+	}
+	if e.Properties["auth_roles"] != "admin" {
+		t.Errorf("POST /api/admin: auth_roles=%q want admin", e.Properties["auth_roles"])
+	}
+}

--- a/tools/coverage/capability-dictionary.yaml
+++ b/tools/coverage/capability-dictionary.yaml
@@ -329,6 +329,7 @@ subcategories:
       - component_extraction
       - hook_recognition
       - router_pattern
+      - auth_coverage
       - interface_extraction
       - type_alias_extraction
       - enum_extraction
@@ -367,6 +368,8 @@ subcategories:
         keys: [server_components, hydration_boundaries]
       - name: Routing
         keys: [route_extraction, router_pattern]
+      - name: Auth
+        keys: [auth_coverage]
       - name: Build
         keys: [static_generation]
       - name: Type System


### PR DESCRIPTION
Closes #5499 (framework-stack coverage epic #5479).

## What

Detect authorization checks and record the **AUTHORIZES relation** from an endpoint to its guard/check — for two idiom families — reusing grafel's existing auth model (no new edge or entity kinds).

The model: authorization posture is the flat `AuthPolicy` contract stamped on the synthetic `http_endpoint` entity (`auth_required` / `auth_method` / `auth_confidence` / `auth_guard` / `auth_roles` / `auth_permissions` / `auth_scopes` + the JSON `auth_policy` carrying a `SourceChain` of evidence). That source chain IS the AUTHORIZES edge.

### Idiom family 1 — NestJS guards
`@UseGuards(AuthGuard, RolesGuard)` + `@Roles('admin')` / metadata decorators are already resolved at class & method level. Verified covered; NestJS notes updated to cite the new body-check fallback for guard-less handlers.

### Idiom family 2 — home-rolled / custom checks (the gap)
A route-handler / server-action / loader / page whose **body opens** with an inline check never reached the route/decorator resolver, so it resolved to `method=unknown` even when genuinely protected. New `indexAuthBodyChecks` (`http_endpoint_jsts_authbody.go`) recovers it:

- a `require*` / `authorize` / `assertCan` / `checkPermission` / `can` / `hasRole` / `getServerSession`-family call (the auth-idiom set `jsAuthCheckLeafSet`), or
- an `if (!session|!user) throw|redirect('/login')` guard,

→ stamps `auth_method=check` at high confidence, capturing the check callee (`auth_guard`) and any literal role / permission / scope.

This greens the meta-framework auth lane (Next.js App-Router route handlers, server actions, Remix/SvelteKit loaders) that gate inside the handler rather than via middleware.

## Auth-callee set
`requireUser/requireAuth/requireSession/requireAdmin/requireRole/requirePermission(s)/requireScope(s)`, `ensureAuth(enticated)/ensureLoggedIn/ensureSignedIn`, `authorize/authenticate`, `assertCan/assertAuth/assertAuthenticated/assertPermission`, `checkAuth/checkPermission(s)/checkScope/checkRole/checkAccess`, `can/hasPermission/hasRole/hasScope/hasAccess`, `getServerSession/getSession/getCurrentUser/getAuthUser`, `protect/protectRoute/guard`, `verifyAuth/verifyToken/verifyJwt/verifySession`, `isAuthenticated/isAuthorized/mustBeAuthenticated/withAuth`.

## No false positives
A match counts only when the leaf callee is in the allow-list (so `require('./db')` and ordinary business calls are not auth) OR it is a negated-session/user guard with a throw/redirect/401 action, and only within the body opener window (~600 bytes). **Honest-partial:** a dynamically-dispatched / runtime-assembled check is left to the route/decorator resolvers.

## Registry / docs
- `auth_coverage` lane added to the `meta_framework` subcategory (new Auth group) in `capability-dictionary.yaml`.
- Flipped to `partial` for next-api / nuxt / remix / sveltekit; honest `missing` for astro / gatsby / phoenix-liveview; NestJS notes updated.
- `coverage validate` + `fmt --check` green; docs regenerated.

## Tests
`http_endpoint_jsts_authbody_test.go`:
- Next.js route handler opening with `const user = await requireUser()` → protected, `method=check`, `guard=requireUser`.
- handler with `getServerSession()` + `if (!session) redirect('/login')` → protected.
- `checkPermission('orders:delete')` → captures permission; `requireRole('admin')` → captures role.
- NestJS handler with NO `@UseGuards` but `await this.authz.assertCan('reports:read')` body → protected.
- plain handler with no auth idiom → **no edge** (negative).

`go test -count=1 ./internal/extractors/... ./internal/custom/javascript/ ./internal/engine/ ./tools/coverage/` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
