### PR TITLE
feat(solidity): bootstrap framework/tool records — Hardhat/Foundry/Truffle/OpenZeppelin/ethers (#5371)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 109 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2
+**Total**: 111 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -117,3 +117,5 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [rust](../by-language/rust.md) | [wiremock](../detail/test.wiremock.md) | ✅ | ✅ | |
 | [scala](../by-language/scala.md) | [Mill](../detail/build.mill.md) | 🔴 | 🔴 | |
 | [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | ✅ | |
+| [solidity](../by-language/solidity.md) | [Foundry (forge)](../detail/lang.solidity.tool.foundry.md) | 🔴 | 🟢 | |
+| [solidity](../by-language/solidity.md) | [Hardhat](../detail/lang.solidity.tool.hardhat.md) | 🔴 | 🟢 | |

--- a/docs/coverage/by-category/language.md
+++ b/docs/coverage/by-category/language.md
@@ -1,32 +1,34 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # language
 
-**Total**: 23 records · **assembly**: 5 · **clojure**: 1 · **COBOL**: 5 · **crystal**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 2 · **F#**: 1 · **groovy**: 1 · **JCL**: 1 · **lua**: 1 · **nim**: 1 · **scala**: 1 · **swift**: 1
+**Total**: 25 records · **assembly**: 5 · **clojure**: 1 · **COBOL**: 5 · **crystal**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 2 · **F#**: 1 · **groovy**: 1 · **JCL**: 1 · **lua**: 1 · **nim**: 1 · **scala**: 1 · **solidity**: 2 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
-| Language | Name | Call line precision | Core extraction | DB effect | Fs effect | HTTP effect | Import resolution quality | Status | Notes |
-|---|---|---|---|---|---|---|---|---|---|
-| [assembly](../by-language/assembly.md) | [ARM armasm](../detail/lang.assembly.toolchain.armasm.md) | ✅ | 🟢 | — | — | — | ✅ | 🟢 | |
-| [assembly](../by-language/assembly.md) | [GNU as (gas)](../detail/lang.assembly.toolchain.gnu-as.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [assembly](../by-language/assembly.md) | [MASM](../detail/lang.assembly.toolchain.masm.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [assembly](../by-language/assembly.md) | [NASM](../detail/lang.assembly.toolchain.nasm.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [assembly](../by-language/assembly.md) | [RISC-V as (gas)](../detail/lang.assembly.toolchain.riscv.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [clojure](../by-language/clojure.md) | [Clojure (base language)](../detail/lang.clojure.base.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [COBOL](../by-language/cobol.md) | [COBOL](../detail/lang.cobol.core.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [COBOL](../by-language/cobol.md) | [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | ✅ | — | — | ✅ | ✅ | — | ✅ | |
-| [COBOL](../by-language/cobol.md) | [COBOL Embedded DB2 SQL](../detail/lang.cobol.embedded.db2-sql.md) | — | — | ✅ | — | — | — | ✅ | |
-| [COBOL](../by-language/cobol.md) | [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [COBOL](../by-language/cobol.md) | [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| [crystal](../by-language/crystal.md) | [Crystal](../detail/lang.crystal.core.md) | 🟢 | ✅ | — | — | — | 🟢 | 🟢 | |
-| [dart](../by-language/dart.md) | [Dart (base language)](../detail/lang.dart.base.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [elixir](../by-language/elixir.md) | [Elixir (base language)](../detail/lang.elixir.base.md) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| [erlang](../by-language/erlang.md) | [Erlang](../detail/lang.erlang.core.md) | ✅ | ✅ | 🟢 | — | — | ✅ | 🟢 | |
-| [erlang](../by-language/erlang.md) | [Erlang/OTP behaviours](../detail/lang.erlang.runtime.otp.md) | — | ✅ | — | — | — | — | ✅ | |
-| [F#](../by-language/fsharp.md) | [F#](../detail/lang.fsharp.core.md) | ✅ | ✅ | — | — | — | 🟢 | 🟢 | |
-| [groovy](../by-language/groovy.md) | [Groovy (base language)](../detail/lang.groovy.base.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [JCL](../by-language/jcl.md) | [IBM z/OS JCL (JES2/JES3)](../detail/lang.jcl.runtime.zos.md) | ✅ | ✅ | — | ✅ | — | ✅ | ✅ | |
-| [lua](../by-language/lua.md) | [Lua (base language)](../detail/lang.lua.base.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [nim](../by-language/nim.md) | [Nim](../detail/lang.nim.core.md) | ✅ | ✅ | — | — | — | 🟢 | 🟢 | |
-| [scala](../by-language/scala.md) | [Scala (base language)](../detail/lang.scala.base.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
-| [swift](../by-language/swift.md) | [Swift (base language)](../detail/lang.swift.base.md) | ✅ | ✅ | — | — | — | ✅ | ✅ | |
+| Language | Name | Call line precision | Core extraction | DB effect | Discriminates on | Fs effect | HTTP effect | Import resolution quality | Status | Notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| [assembly](../by-language/assembly.md) | [ARM armasm](../detail/lang.assembly.toolchain.armasm.md) | ✅ | 🟢 | — | — | — | — | ✅ | 🟢 | |
+| [assembly](../by-language/assembly.md) | [GNU as (gas)](../detail/lang.assembly.toolchain.gnu-as.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [assembly](../by-language/assembly.md) | [MASM](../detail/lang.assembly.toolchain.masm.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [assembly](../by-language/assembly.md) | [NASM](../detail/lang.assembly.toolchain.nasm.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [assembly](../by-language/assembly.md) | [RISC-V as (gas)](../detail/lang.assembly.toolchain.riscv.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [clojure](../by-language/clojure.md) | [Clojure (base language)](../detail/lang.clojure.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [COBOL](../by-language/cobol.md) | [COBOL](../detail/lang.cobol.core.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [COBOL](../by-language/cobol.md) | [COBOL CICS](../detail/lang.cobol.embedded.cics.md) | ✅ | — | — | — | ✅ | ✅ | — | ✅ | |
+| [COBOL](../by-language/cobol.md) | [COBOL Embedded DB2 SQL](../detail/lang.cobol.embedded.db2-sql.md) | — | — | ✅ | — | — | — | — | ✅ | |
+| [COBOL](../by-language/cobol.md) | [GnuCOBOL](../detail/lang.cobol.runtime.gnucobol.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [COBOL](../by-language/cobol.md) | [IBM Enterprise COBOL](../detail/lang.cobol.runtime.ibm-enterprise.md) | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ | |
+| [crystal](../by-language/crystal.md) | [Crystal](../detail/lang.crystal.core.md) | 🟢 | ✅ | — | — | — | — | 🟢 | 🟢 | |
+| [dart](../by-language/dart.md) | [Dart (base language)](../detail/lang.dart.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [elixir](../by-language/elixir.md) | [Elixir (base language)](../detail/lang.elixir.base.md) | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | ✅ | |
+| [erlang](../by-language/erlang.md) | [Erlang](../detail/lang.erlang.core.md) | ✅ | ✅ | 🟢 | — | — | — | ✅ | 🟢 | |
+| [erlang](../by-language/erlang.md) | [Erlang/OTP behaviours](../detail/lang.erlang.runtime.otp.md) | — | ✅ | — | — | — | — | — | ✅ | |
+| [F#](../by-language/fsharp.md) | [F#](../detail/lang.fsharp.core.md) | ✅ | ✅ | — | — | — | — | 🟢 | 🟢 | |
+| [groovy](../by-language/groovy.md) | [Groovy (base language)](../detail/lang.groovy.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [JCL](../by-language/jcl.md) | [IBM z/OS JCL (JES2/JES3)](../detail/lang.jcl.runtime.zos.md) | ✅ | ✅ | — | — | ✅ | — | ✅ | ✅ | |
+| [lua](../by-language/lua.md) | [Lua (base language)](../detail/lang.lua.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [nim](../by-language/nim.md) | [Nim](../detail/lang.nim.core.md) | ✅ | ✅ | — | — | — | — | 🟢 | 🟢 | |
+| [scala](../by-language/scala.md) | [Scala (base language)](../detail/lang.scala.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [solidity](../by-language/solidity.md) | [OpenZeppelin Contracts](../detail/lang.solidity.framework.openzeppelin.md) | — | — | — | ✅ | — | — | ✅ | ✅ | |
+| [solidity](../by-language/solidity.md) | [Solidity](../detail/lang.solidity.core.md) | 🟢 | ✅ | — | — | — | — | 🟢 | 🟢 | |
+| [swift](../by-language/swift.md) | [Swift (base language)](../detail/lang.swift.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |

--- a/docs/coverage/by-language/solidity.md
+++ b/docs/coverage/by-language/solidity.md
@@ -1,12 +1,34 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Solidity
+# solidity
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 2 · **ORMs**: 0 · **Other**: 2
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/solidity/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.solidity.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Foundry (forge)](../detail/lang.solidity.tool.foundry.md) | 🔴 | — | — | — | 🟢 | |
+| [Hardhat](../detail/lang.solidity.tool.hardhat.md) | 🔴 | — | — | — | 🟢 | |
+
+## Other
+
+| Name | Category | Status | Notes |
+|---|---|---|---|
+| [OpenZeppelin Contracts](../detail/lang.solidity.framework.openzeppelin.md) | [language](../by-category/language.md) | ✅ | |
+| [Solidity](../detail/lang.solidity.core.md) | [language](../by-category/language.md) | 🟢 | |

--- a/docs/coverage/detail/lang.solidity.core.md
+++ b/docs/coverage/detail/lang.solidity.core.md
@@ -1,0 +1,26 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.solidity.core` — Solidity
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [solidity](../by-language/solidity.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 3
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Call line precision | 🟢 `partial` | `2026-06-24` | 5371 | `internal/extractors/solidity/extractor.go`<br>`internal/extractors/solidity/extractor_test.go` | collectCallsFromBody emits CALLS edges per dotted (Type.method()) and bare (fn()) invocation in a function/modifier body, with a solidityKeywords denylist dropping control-flow/builtins/type/visibility tokens and self-recursion filtering on undotted leaves (dotted cross-contract calls preserved, #2114). Partial (honest): edges do NOT yet carry a per-call line property; targets are unresolved name strings, not bound to the callee SCOPE.Operation. |
+| Core extraction | ✅ `full` | `2026-06-24` | 5371 | `internal/extractors/solidity/extractor.go`<br>`internal/extractors/solidity/extractor_test.go` | Regex extractor (no bundled tree-sitter Solidity grammar). contractRE emits contract/library/interface/abstract-contract as SCOPE.Component (subtype contract/library/interface); functionRE/eventRE/modifierRE emit members as SCOPE.Operation (subtype function/event/modifier) with CONTAINS edges from the owning contract. Comments and string literals are scrubbed (stripCommentsAndStrings) and brace-matched bodies extracted (extractBracedBody) before member/call scanning. Proven by the extractor_test.go suite (contract/library/interface discovery, member CONTAINS, signature capture). |
+| Import resolution quality | 🟢 `partial` | `2026-06-24` | 5371 | `internal/extractors/solidity/extractor.go`<br>`internal/extractors/solidity/extractor_test.go` | buildImportEntities parses both import styles (import "./Foo.sol"; and import {Sym} from "pkg/...";), emitting one IMPORTS edge per target path with source_module/imported_name/local_name properties and a SCOPE.Component for the imported unit. Partial (honest): named-symbol imports record only the module path (not per-symbol bindings) and edges point at the raw path string, not a resolved file/contract entity. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.solidity.core ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.solidity.framework.openzeppelin.md
+++ b/docs/coverage/detail/lang.solidity.framework.openzeppelin.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.solidity.framework.openzeppelin` — OpenZeppelin Contracts
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [solidity](../by-language/solidity.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Discriminates on | ✅ `full` | `2026-06-24` | 5371 | `internal/extractors/solidity/extractor.go`<br>`internal/extractors/solidity/frameworks.go`<br>`internal/extractors/solidity/frameworks_test.go` | OpenZeppelin (de-facto Solidity contract library) recognised purely from .sol source: scanImportFrameworks flags any @openzeppelin/contracts(-upgradeable) import, and isOpenZeppelinBase matches a canonical OZ base/mixin in the 'is ...' inheritance list (ERC20/ERC721/ERC1155 + variants, Ownable/Ownable2Step, AccessControl(+Enumerable), Pausable, ReentrancyGuard, Initializable, UUPSUpgradeable, EIP712, ...). Matched contracts are stamped Properties[framework]=openzeppelin + openzeppelin=true and each OZ-base EXTENDS edge carries Properties[framework]=openzeppelin. Detection fires from inheritance ALONE (flattened/vendored source with no import). Proven by TestSolidity_OpenZeppelin_FrameworkStamp / _ExtendsEdgeTagged / _InheritanceOnly / _OpenZeppelinWinsPrecedence and the negative TestSolidity_NoFramework_NotStamped. |
+| Import resolution quality | ✅ `full` | `2026-06-24` | 5371 | `internal/extractors/solidity/frameworks.go`<br>`internal/extractors/solidity/frameworks_test.go` | @openzeppelin/contracts and @openzeppelin/contracts-upgradeable import paths are classified as the OpenZeppelin library binding (scanImportFrameworks) and surfaced on the contract + EXTENDS edges. Existing IMPORTS edges already carry the full OZ module path (token/ERC20/ERC20.sol etc.) via buildImportEntities. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.solidity.framework.openzeppelin ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.solidity.tool.foundry.md
+++ b/docs/coverage/detail/lang.solidity.tool.foundry.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.solidity.tool.foundry` — Foundry (forge)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [solidity](../by-language/solidity.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🔴 `missing` | — | 5371 | — | foundry.toml dependencies/remappings + git-submodule lib/ tree are not parsed (foundry.toml classifies as toml, outside the .sol extractor). Follow-up under epic #5360. |
+| Target extraction | 🟢 `partial` | `2026-06-24` | 5371 | `internal/extractors/solidity/frameworks.go`<br>`internal/extractors/solidity/frameworks_test.go` | Foundry recognised from .sol source: scanImportFrameworks flags forge-std/* (and @forge-std/*) imports, and foundryTestKind classifies a contract by its inheritance list — 'is Test'/'is DSTest' -> foundry_kind=test, 'is Script' -> foundry_kind=script. Matched contracts are stamped Properties[framework]=foundry + foundry=true (+foundry_kind). Proven by TestSolidity_Foundry_TestContract / _Foundry_ScriptContract. Partial (honest): foundry.toml profiles/remappings/[dependencies] and forge cheatcode/dependency-graph extraction are out of this .sol-only extractor's reach (foundry.toml classifies as toml) — follow-up under #5360. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.solidity.tool.foundry ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.solidity.tool.hardhat.md
+++ b/docs/coverage/detail/lang.solidity.tool.hardhat.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.solidity.tool.hardhat` — Hardhat
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [solidity](../by-language/solidity.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🔴 `missing` | — | 5371 | — | Hardhat dependency graph lives in package.json (npm — already covered by build.npm/pkg.npm) and hardhat.config plugin wiring (jsts side). Not synthesised from .sol. Follow-up under epic #5360. |
+| Target extraction | 🟢 `partial` | `2026-06-24` | 5371 | `internal/extractors/solidity/frameworks.go`<br>`internal/extractors/solidity/frameworks_test.go` | Hardhat recognised from .sol source: scanImportFrameworks flags hardhat/* imports (e.g. import "hardhat/console.sol"); matched contracts are stamped Properties[framework]=hardhat + hardhat=true. Proven by TestSolidity_Hardhat_Console. Partial (honest): hardhat.config.{js,ts} task/plugin parsing, deploy scripts, and hardhat-deploy artifacts are jsts-side and out of this .sol-only extractor's reach — follow-up under #5360. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.solidity.tool.hardhat ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (25 active · 14 placeholder) · **Frameworks**: 256 · **ORMs**: 184 · **Tools**: 135 · **Other**: 206
+**Languages**: 39 (26 active · 13 placeholder) · **Frameworks**: 256 · **ORMs**: 184 · **Tools**: 137 · **Other**: 208
 
 ## Coverage by language
 
@@ -32,6 +32,7 @@
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 5 |
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
 | [JCL](by-language/jcl.md) | 0 | 0 | 0 | 1 |
+| [solidity](by-language/solidity.md) | 0 | 2 | 0 | 2 |
 
 ## Cross-cutting infrastructure
 
@@ -77,10 +78,9 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Pony](by-language/pony.md) |
 | [ReScript](by-language/rescript.md) |
 | [ReasonML](by-language/reasonml.md) |
-| [Solidity](by-language/solidity.md) |
 | [Standard ML](by-language/sml.md) |
 | [VHDL](by-language/vhdl.md) |
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 256 frameworks · 135 tools · 184 ORMs · 206 other
+Total: 256 frameworks · 137 tools · 184 ORMs · 208 other

--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -129,18 +129,33 @@ func extractSolidity(src, filePath string) []types.EntityRecord {
 	importEntities := buildImportEntities(filePath, src)
 	entities = append(entities, importEntities...)
 
+	// Framework/tool signals from import paths (OpenZeppelin/Foundry/Hardhat).
+	signals := scanImportFrameworks(collectImportPaths(src))
+
 	// ── 2. Contracts / libraries / interfaces ────────────────────────────
 	scrubbed := stripCommentsAndStrings(src)
-	contracts := findContracts(scrubbed, filePath)
+	contracts := findContracts(scrubbed, filePath, signals)
 	entities = append(entities, contracts...)
 
 	return entities
 }
 
+// collectImportPaths returns the raw import target paths in source order.
+func collectImportPaths(src string) []string {
+	var out []string
+	for _, m := range importRE.FindAllStringSubmatch(src, -1) {
+		if len(m) >= 2 {
+			out = append(out, strings.TrimSpace(m[1]))
+		}
+	}
+	return out
+}
+
 // findContracts locates all contract/library/interface declarations, emits
 // SCOPE.Component entities with EXTENDS and CONTAINS edges, and also emits
-// SCOPE.Operation children (functions/events/modifiers).
-func findContracts(src, filePath string) []types.EntityRecord {
+// SCOPE.Operation children (functions/events/modifiers). The framework signals
+// (from import paths) let it stamp OpenZeppelin/Foundry/Hardhat attributes.
+func findContracts(src, filePath string, signals frameworkSignals) []types.EntityRecord {
 	var out []types.EntityRecord
 
 	matches := contractRE.FindAllStringSubmatchIndex(src, -1)
@@ -204,13 +219,49 @@ func findContracts(src, filePath string) []types.EntityRecord {
 			Signature:  rawSig,
 		}
 
-		// EXTENDS edges.
+		// ── Framework / tool stamping (issue #5371) ──────────────────────
+		// OpenZeppelin: an import of @openzeppelin/contracts OR an EXTENDS
+		// parent that names a canonical OZ base contract.
+		usesOZ := signals.openzeppelin
+		// Foundry: forge-std import OR a forge test/script contract.
+		ftKind := foundryTestKind(extends)
+		usesFoundry := signals.foundry || ftKind != ""
+
+		if usesOZ {
+			setProp(&rec.Properties, "framework", "openzeppelin")
+		} else if usesFoundry {
+			setProp(&rec.Properties, "framework", "foundry")
+		} else if signals.hardhat {
+			setProp(&rec.Properties, "framework", "hardhat")
+		}
+		if usesFoundry {
+			setProp(&rec.Properties, "foundry", "true")
+			if ftKind != "" {
+				setProp(&rec.Properties, "foundry_kind", ftKind)
+			}
+		}
+		if signals.hardhat {
+			setProp(&rec.Properties, "hardhat", "true")
+		}
+
+		// EXTENDS edges. OZ-base parents carry framework="openzeppelin" so the
+		// inheritance edge itself records the library binding.
 		for _, parent := range extends {
-			rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+			edge := types.RelationshipRecord{
 				FromID: filePath,
 				ToID:   parent,
 				Kind:   "EXTENDS",
-			})
+			}
+			if isOpenZeppelinBase(parent) {
+				usesOZ = true
+				setProp(&rec.Properties, "framework", "openzeppelin")
+				setProp(&rec.Properties, "openzeppelin", "true")
+				edge.Properties = map[string]string{"framework": "openzeppelin"}
+			}
+			rec.Relationships = append(rec.Relationships, edge)
+		}
+		if usesOZ {
+			setProp(&rec.Properties, "openzeppelin", "true")
 		}
 
 		contractIdx := len(out)

--- a/internal/extractors/solidity/frameworks.go
+++ b/internal/extractors/solidity/frameworks.go
@@ -1,0 +1,111 @@
+// Solidity framework / tool detection (issue #5371, epic #5360 Group A).
+//
+// The solidity extractor only ever sees `.sol` files — Hardhat/Truffle config
+// files classify as jsts and `foundry.toml` as toml, so config-file parsing is
+// out of this extractor's reach. Everything here is therefore `.sol`-driven and
+// bolts onto the existing contract / IMPORTS / EXTENDS model:
+//
+//   - OpenZeppelin  — de-facto contract library. Detected from `@openzeppelin/
+//     contracts` import paths and from EXTENDS-parents that name
+//     a canonical OZ base (ERC20/ERC721/Ownable/…). Contracts
+//     and their OZ-base EXTENDS edges are stamped
+//     framework="openzeppelin". (genuinely full from .sol)
+//   - Foundry       — `import "forge-std/…"` and forge test/script contracts
+//     (`is Test` / `is Script`). Stamped framework="foundry".
+//     (partial — foundry.toml profiles/remappings are a follow-up)
+//   - Hardhat       — `import "hardhat/console.sol"` and other hardhat/* helpers.
+//     Stamped framework="hardhat". (partial — config tasks/
+//     plugins + deploy scripts are jsts-side follow-ups)
+//
+// Truffle (truffle-config.js + migrations) and ethers/web3 (JS client) are
+// JS-side and intentionally NOT faked here.
+package solidity
+
+import "strings"
+
+// canonical OpenZeppelin base contracts/mixins that show up in `is …` lists.
+var openzeppelinBases = map[string]bool{
+	"ERC20":                   true,
+	"ERC20Burnable":           true,
+	"ERC20Capped":             true,
+	"ERC20Pausable":           true,
+	"ERC20Permit":             true,
+	"ERC20Votes":              true,
+	"ERC20Snapshot":           true,
+	"ERC20FlashMint":          true,
+	"ERC721":                  true,
+	"ERC721Enumerable":        true,
+	"ERC721URIStorage":        true,
+	"ERC721Burnable":          true,
+	"ERC721Pausable":          true,
+	"ERC721Royalty":           true,
+	"ERC1155":                 true,
+	"ERC1155Burnable":         true,
+	"ERC1155Pausable":         true,
+	"ERC1155Supply":           true,
+	"Ownable":                 true,
+	"Ownable2Step":            true,
+	"AccessControl":           true,
+	"AccessControlEnumerable": true,
+	"Pausable":                true,
+	"ReentrancyGuard":         true,
+	"Initializable":           true,
+	"UUPSUpgradeable":         true,
+	"ERC1967Proxy":            true,
+	"Multicall":               true,
+	"Nonces":                  true,
+	"EIP712":                  true,
+}
+
+// frameworkSignals holds what an import scan found for a single `.sol` file.
+type frameworkSignals struct {
+	openzeppelin bool // any @openzeppelin/contracts import
+	foundry      bool // any forge-std import
+	hardhat      bool // any hardhat/* import
+}
+
+// scanImportFrameworks inspects raw import paths for framework signals.
+func scanImportFrameworks(importPaths []string) frameworkSignals {
+	var s frameworkSignals
+	for _, p := range importPaths {
+		switch {
+		case strings.HasPrefix(p, "@openzeppelin/contracts"),
+			strings.HasPrefix(p, "@openzeppelin/contracts-upgradeable"):
+			s.openzeppelin = true
+		case strings.HasPrefix(p, "forge-std/"),
+			strings.HasPrefix(p, "@forge-std/"):
+			s.foundry = true
+		case strings.HasPrefix(p, "hardhat/"):
+			s.hardhat = true
+		}
+	}
+	return s
+}
+
+// isOpenZeppelinBase reports whether a parent name in an `is …` list is a known
+// OpenZeppelin base contract or mixin.
+func isOpenZeppelinBase(parent string) bool {
+	return openzeppelinBases[parent]
+}
+
+// foundryTestKind classifies a contract by its inheritance list as a forge
+// test/script contract. Returns "test", "script", or "" (not foundry).
+func foundryTestKind(extends []string) string {
+	for _, p := range extends {
+		switch p {
+		case "Test", "DSTest":
+			return "test"
+		case "Script":
+			return "script"
+		}
+	}
+	return ""
+}
+
+// setProp sets a property on an entity, allocating the map on first use.
+func setProp(props *map[string]string, key, val string) {
+	if *props == nil {
+		*props = make(map[string]string)
+	}
+	(*props)[key] = val
+}

--- a/internal/extractors/solidity/frameworks_test.go
+++ b/internal/extractors/solidity/frameworks_test.go
@@ -1,0 +1,187 @@
+package solidity_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// solProp returns the value of Properties[key] on the named component, or "".
+func solProp(ents []types.EntityRecord, name, key string) string {
+	c := solFind(ents, name, "SCOPE.Component")
+	if c == nil || c.Properties == nil {
+		return ""
+	}
+	return c.Properties[key]
+}
+
+// ── OpenZeppelin (full) ──────────────────────────────────────────────────────
+
+// Real OZ-based ERC20 with an Ownable mixin — the canonical wizard output.
+const ozTokenSrc = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract MyToken is ERC20, Ownable {
+    constructor(address initialOwner)
+        ERC20("MyToken", "MTK")
+        Ownable(initialOwner)
+    {}
+
+    function mint(address to, uint256 amount) public onlyOwner {
+        _mint(to, amount);
+    }
+}
+`
+
+func TestSolidity_OpenZeppelin_FrameworkStamp(t *testing.T) {
+	ents := runSolidity(t, ozTokenSrc, "MyToken.sol")
+
+	if got := solProp(ents, "MyToken", "framework"); got != "openzeppelin" {
+		t.Errorf("MyToken framework = %q, want openzeppelin", got)
+	}
+	if got := solProp(ents, "MyToken", "openzeppelin"); got != "true" {
+		t.Errorf("MyToken openzeppelin = %q, want true", got)
+	}
+}
+
+func TestSolidity_OpenZeppelin_ExtendsEdgeTagged(t *testing.T) {
+	ents := runSolidity(t, ozTokenSrc, "MyToken.sol")
+	c := solFind(ents, "MyToken", "SCOPE.Component")
+	if c == nil {
+		t.Fatal("MyToken component not found")
+	}
+	tagged := map[string]bool{}
+	for _, r := range c.Relationships {
+		if r.Kind == "EXTENDS" && r.Properties != nil && r.Properties["framework"] == "openzeppelin" {
+			tagged[r.ToID] = true
+		}
+	}
+	for _, base := range []string{"ERC20", "Ownable"} {
+		if !tagged[base] {
+			t.Errorf("EXTENDS %s not tagged framework=openzeppelin", base)
+		}
+	}
+}
+
+// OZ detected purely from the `is …` list even without the canonical import
+// (e.g. flattened / vendored source).
+func TestSolidity_OpenZeppelin_InheritanceOnly(t *testing.T) {
+	src := `pragma solidity ^0.8.20;
+contract Vault is ReentrancyGuard, AccessControl {
+    function withdraw() external nonReentrant {}
+}
+`
+	ents := runSolidity(t, src, "Vault.sol")
+	if got := solProp(ents, "Vault", "framework"); got != "openzeppelin" {
+		t.Errorf("Vault framework = %q, want openzeppelin (inheritance-only)", got)
+	}
+}
+
+// A plain contract with no OZ/forge/hardhat signals must NOT be stamped.
+func TestSolidity_NoFramework_NotStamped(t *testing.T) {
+	src := `pragma solidity ^0.8.20;
+contract Plain {
+    uint256 public x;
+    function set(uint256 v) public { x = v; }
+}
+`
+	ents := runSolidity(t, src, "Plain.sol")
+	if got := solProp(ents, "Plain", "framework"); got != "" {
+		t.Errorf("Plain framework = %q, want empty (no signals)", got)
+	}
+}
+
+// ── Foundry (partial) ────────────────────────────────────────────────────────
+
+// Real forge-std test contract.
+const forgeTestSrc = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {MyToken} from "../src/MyToken.sol";
+
+contract MyTokenTest is Test {
+    MyToken token;
+
+    function setUp() public {
+        token = new MyToken(address(this));
+    }
+
+    function test_Mint() public {
+        token.mint(address(this), 100);
+        assertEq(token.balanceOf(address(this)), 100);
+    }
+}
+`
+
+func TestSolidity_Foundry_TestContract(t *testing.T) {
+	ents := runSolidity(t, forgeTestSrc, "MyToken.t.sol")
+	if got := solProp(ents, "MyTokenTest", "framework"); got != "foundry" {
+		t.Errorf("MyTokenTest framework = %q, want foundry", got)
+	}
+	if got := solProp(ents, "MyTokenTest", "foundry"); got != "true" {
+		t.Errorf("MyTokenTest foundry = %q, want true", got)
+	}
+	if got := solProp(ents, "MyTokenTest", "foundry_kind"); got != "test" {
+		t.Errorf("MyTokenTest foundry_kind = %q, want test", got)
+	}
+}
+
+func TestSolidity_Foundry_ScriptContract(t *testing.T) {
+	src := `pragma solidity ^0.8.20;
+import {Script} from "forge-std/Script.sol";
+contract Deploy is Script {
+    function run() external {}
+}
+`
+	ents := runSolidity(t, src, "Deploy.s.sol")
+	if got := solProp(ents, "Deploy", "framework"); got != "foundry" {
+		t.Errorf("Deploy framework = %q, want foundry", got)
+	}
+	if got := solProp(ents, "Deploy", "foundry_kind"); got != "script" {
+		t.Errorf("Deploy foundry_kind = %q, want script", got)
+	}
+}
+
+// ── Hardhat (partial) ────────────────────────────────────────────────────────
+
+func TestSolidity_Hardhat_Console(t *testing.T) {
+	src := `pragma solidity ^0.8.20;
+import "hardhat/console.sol";
+contract Debuggable {
+    function ping() public view {
+        console.log("ping");
+    }
+}
+`
+	ents := runSolidity(t, src, "Debuggable.sol")
+	if got := solProp(ents, "Debuggable", "framework"); got != "hardhat" {
+		t.Errorf("Debuggable framework = %q, want hardhat", got)
+	}
+	if got := solProp(ents, "Debuggable", "hardhat"); got != "true" {
+		t.Errorf("Debuggable hardhat = %q, want true", got)
+	}
+}
+
+// ── Precedence: OZ wins over hardhat/foundry when a contract uses both ────────
+
+func TestSolidity_OpenZeppelinWinsPrecedence(t *testing.T) {
+	src := `pragma solidity ^0.8.20;
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "hardhat/console.sol";
+contract Mix is ERC20 {
+    constructor() ERC20("Mix","MIX") {}
+}
+`
+	ents := runSolidity(t, src, "Mix.sol")
+	if got := solProp(ents, "Mix", "framework"); got != "openzeppelin" {
+		t.Errorf("Mix framework = %q, want openzeppelin (OZ precedence)", got)
+	}
+	// hardhat marker still recorded.
+	if got := solProp(ents, "Mix", "hardhat"); got != "true" {
+		t.Errorf("Mix hardhat marker = %q, want true", got)
+	}
+}


### PR DESCRIPTION
Bootstrap the first Solidity framework/tool records (#5371, epic #5360 Group A). All detection is `.sol`-driven and honest — Hardhat/Truffle config files classify as jsts and `foundry.toml` as toml, so config-file parsing is out of this extractor's reach and is recorded as honest follow-up, not faked.

### What's added
New `internal/extractors/solidity/frameworks.go` detection pass, wired into `findContracts`, stamping `Properties["framework"]` on contracts + EXTENDS edges:

| Capability | Status | How |
|---|---|---|
| **OpenZeppelin** (`lang.solidity.framework.openzeppelin`) | **full** | `@openzeppelin/contracts(-upgradeable)` imports + canonical OZ base contracts in the `is …` list (ERC20/ERC721/ERC1155 + variants, Ownable/Ownable2Step, AccessControl(+Enumerable), Pausable, ReentrancyGuard, Initializable, UUPSUpgradeable, EIP712, …). Contracts + their OZ-base EXTENDS edges stamped `framework=openzeppelin`. **Fires from inheritance alone** (flattened/vendored source, no import). |
| **Foundry** (`lang.solidity.tool.foundry`) | **partial** | `forge-std/*` imports + forge test/script contracts (`is Test`/`is DSTest` → `foundry_kind=test`, `is Script` → `script`). `foundry.toml` profiles/remappings/dep-graph = honest follow-up. |
| **Hardhat** (`lang.solidity.tool.hardhat`) | **partial** | `hardhat/*` imports (`hardhat/console.sol`). `hardhat.config.{js,ts}` tasks/plugins + deploy scripts = jsts-side follow-up. |
| **Truffle**, **ethers/web3** | not faked | JS-side (truffle-config.js / migrations / client lib) — recorded as honest follow-up, no false-green. |

Plus `lang.solidity.core` uplift (the universal base that already shipped: contracts/functions/events/modifiers, IMPORTS, EXTENDS, CALLS, CONTAINS) — `core_extraction` full, `call_line_precision`/`import_resolution_quality` partial (honest).

### Validation
- Real fixtures (not stubs): OZ-wizard ERC20 (`is ERC20, Ownable`), forge-std test (`is Test`), forge script (`is Script`), `hardhat/console.sol` contract, OZ-inheritance-only (no import), plain contract (negative), OZ+hardhat precedence.
- 8 new tests in `frameworks_test.go`; existing solidity suite unchanged + green.
- Registry minted via `go run ./tools/coverage add`; keys from `capability-dictionary.yaml`; `coverage validate` + `fmt --check` green; coverage docs regenerated **in this PR**.

No CHANGELOG edit (per coverage-doc workflow). Part of epic #5360 (Group A — bootstrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
