### PR TITLE
feat(haskell): bootstrap framework/ORM/tool records — Servant/Yesod/Scotty + Stack-Cabal + persistent + hspec (#5373)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 111 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2
+**Total**: 112 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -51,6 +51,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [go](../by-language/go.md) | [go testing (stdlib)](../detail/test.go-testing.md) | ✅ | ✅ | |
 | [go](../by-language/go.md) | [testify](../detail/test.testify.md) | ✅ | ✅ | |
 | [groovy](../by-language/groovy.md) | [Spock](../detail/test.spock.md) | 🔴 | 🔴 | |
+| [haskell](../by-language/haskell.md) | [hspec (Haskell testing)](../detail/test.hspec.md) | 🟢 | ✅ | |
 | [java](../by-language/java.md) | [AssertJ](../detail/test.assertj.md) | 🔴 | 🔴 | |
 | [java](../by-language/java.md) | [Gradle (Groovy + Kotlin DSL)](../detail/build.gradle.md) | ✅ | ✅ | |
 | [java](../by-language/java.md) | [JUnit 4](../detail/test.junit4.md) | 🟢 | 🟢 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 256 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
+**Total**: 259 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -73,6 +73,9 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [go](../by-language/go.md) | [net/http (stdlib)](../detail/lang.go.framework.net-http.md) | 🟡 6/7 | — | 🟢 3/3 | 🟢 1/1 | 🟢 24/24 | 🟡 7/12 | |
 | [go](../by-language/go.md) | [uber/fx (DI)](../detail/lang.go.framework.fx.md) | 🔴 0/7 | 🔴 0/1 | 🟡 1/4 | 🔴 0/1 | 🟡 12/24 | 🟡 2/11 | |
 | [groovy](../by-language/groovy.md) | [Grails / Ratpack (Groovy HTTP)](../detail/lang.groovy.framework.grails.md) | 🟡 3/7 | 🔴 0/1 | 🟡 3/4 | ✅ 1/1 | 🔴 0/24 | 🔴 0/13 | |
+| [haskell](../by-language/haskell.md) | [Scotty (Haskell HTTP)](../detail/lang.haskell.framework.scotty.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
+| [haskell](../by-language/haskell.md) | [Servant (Haskell type-level API)](../detail/lang.haskell.framework.servant.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
+| [haskell](../by-language/haskell.md) | [Yesod (Haskell web framework)](../detail/lang.haskell.framework.yesod.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
 | [JS/TS](../by-language/jsts.md) | [AdonisJS](../detail/lang.jsts.framework.adonisjs.md) | 🟡 5/7 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 24/24 | 🟡 6/11 | |
 | [JS/TS](../by-language/jsts.md) | [Express](../detail/lang.jsts.framework.express.md) | 🟡 6/7 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 24/24 | 🟡 10/13 | |
 | [JS/TS](../by-language/jsts.md) | [Fastify](../detail/lang.jsts.framework.fastify.md) | 🟡 5/7 | ✅ 1/1 | ✅ 4/4 | ✅ 1/1 | 🟢 24/24 | 🟡 8/13 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 184 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **dart**: 6 · **elixir**: 10 · **go**: 17 · **groovy**: 1 · **java**: 15 · **JS/TS**: 20 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
+**Total**: 185 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **dart**: 6 · **elixir**: 10 · **go**: 17 · **groovy**: 1 · **haskell**: 1 · **java**: 15 · **JS/TS**: 20 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -81,6 +81,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [go](../by-language/go.md) | [sqlx](../detail/lang.go.orm.sqlx.md) | 🟡 6/8 | |
 | [go](../by-language/go.md) | [xo (codegen)](../detail/lang.go.orm.xo.md) | 🟡 6/9 | |
 | [groovy](../by-language/groovy.md) | [GORM (Grails ORM)](../detail/lang.groovy.orm.gorm.md) | 🟡 8/10 | |
+| [haskell](../by-language/haskell.md) | [persistent (Haskell ORM)](../detail/lang.haskell.orm.persistent.md) | 🟡 3/11 | |
 | [java](../by-language/java.md) | [AWS SDK DynamoDB (Java)](../detail/lang.java.orm.dynamodb.md) | 🟡 2/6 | |
 | [java](../by-language/java.md) | [Ebean ORM](../detail/lang.java.orm.ebean.md) | 🟡 7/10 | |
 | [java](../by-language/java.md) | [EclipseLink](../detail/lang.java.orm.eclipselink.md) | 🟡 7/10 | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 26 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
+**Total**: 27 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -19,6 +19,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [erlang](../by-language/erlang.md) | [rebar3 / hex.pm (rebar.config, rebar.lock)](../detail/pkg.rebar3.md) | — | ✅ | ✅ | |
 | [F#](../by-language/fsharp.md) | [Paket (.NET/F# package manager)](../detail/lang.fsharp.tool.paket.md) | — | ✅ | ✅ | |
 | [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | ✅ | ✅ | |
+| [haskell](../by-language/haskell.md) | [Cabal / Stack / hpack (Haskell build)](../detail/lang.haskell.tool.cabal.md) | — | — | ✅ | |
 | [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | 🔴 | 🟢 | |
 | [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | ✅ | |
 | [JS/TS](../by-language/jsts.md) | [npm / yarn / pnpm (package.json + lockfile)](../detail/lang.jsts.tool.npm-manifest.md) | ✅ | ✅ | ✅ | |

--- a/docs/coverage/by-language/haskell.md
+++ b/docs/coverage/by-language/haskell.md
@@ -1,12 +1,48 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Haskell
+# haskell
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 3 · **Tools**: 2 · **ORMs**: 1 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/haskell/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.haskell.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Frameworks
+
+
+### Backend HTTP
+
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Scotty (Haskell HTTP)](../detail/lang.haskell.framework.scotty.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
+| [Servant (Haskell type-level API)](../detail/lang.haskell.framework.servant.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
+| [Yesod (Haskell web framework)](../detail/lang.haskell.framework.yesod.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
+
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Cabal / Stack / hpack (Haskell build)](../detail/lang.haskell.tool.cabal.md) | — | — | — | ✅ | — | |
+| [hspec (Haskell testing)](../detail/test.hspec.md) | 🟢 | — | — | — | ✅ | |
+
+## ORMs
+
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [persistent (Haskell ORM)](../detail/lang.haskell.orm.persistent.md) | 🟡 3/11 | |

--- a/docs/coverage/detail/lang.haskell.framework.scotty.md
+++ b/docs/coverage/detail/lang.haskell.framework.scotty.md
@@ -1,0 +1,132 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.haskell.framework.scotty` — Scotty (Haskell HTTP)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [haskell](../by-language/haskell.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 50
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint response codes | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go`<br>`internal/engine/http_endpoint_haskell_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | synthesizeScottyRoutes scans Haskell source for Scotty verb calls (get/post/put/delete/patch "/path") with a leading string-literal path, canonicalising :id colon-params via FrameworkScotty into the shared {param} form and emitting one http_endpoint_definition each. Gated by hsScottyHasRoute (Web.Scotty marker + verb pre-filter). Honest exclusion: interpolated/variable (non string-literal) paths are dropped. |
+| Handler attribution | 🟢 `partial` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go` | Synthesised endpoints carry a Controller handler kind so ResolveHTTPEndpointHandlers binds an IMPLEMENTS edge when a same-named handler is resolvable. Scotty handler bodies are anonymous do-blocks ($ do ...), so a named-handler edge is bound only where a same-named function exists — honest partial. |
+| Route extraction | ✅ `full` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go`<br>`internal/engine/http_endpoint_haskell_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | Static Scotty verb+path routes recovered by synthesizeScottyRoutes (#5373); interpolated/variable paths dropped (honest, see endpoint_synthesis). |
+| Websocket route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Rate limit stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request sink dataflow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.haskell.framework.scotty ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.haskell.framework.servant.md
+++ b/docs/coverage/detail/lang.haskell.framework.servant.md
@@ -1,0 +1,132 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.haskell.framework.servant` — Servant (Haskell type-level API)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [haskell](../by-language/haskell.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 50
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint response codes | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | 🟢 `partial` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go`<br>`internal/engine/http_endpoint_haskell_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | synthesizeServantRoutes parses the type-level API DSL: each :<|>-separated alternative whose inline :>-chain ends in a verb combinator (Get/Post/Put/Delete/Patch) yields one http_endpoint_definition. String-literal components are path segments; Capture "name" Type → {name} via FrameworkServant. Honest partial: HList type-family composition and named sub-APIs spread across separate 'type' aliases (type API = UserAPI :<|> ItemAPI where the operands are bare type names) are NOT resolved across declarations — only inline :>-chains are emitted. |
+| Handler attribution | 🟢 `partial` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go` | Servant decouples the API TYPE from the handler server via a typeclass-derived record; the endpoint carries a Controller kind and binds a same-named handler IMPLEMENTS edge where resolvable, but the type→server-handler mapping is positional (HList), so named attribution is honest-partial. |
+| Route extraction | 🟢 `partial` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go`<br>`internal/engine/http_endpoint_haskell_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | Inline Servant :>-chain routes (literal segments + Capture params + leaf verb) recovered by synthesizeServantRoutes (#5373). Cross-declaration type-alias composition is the documented exclusion — partial. |
+| Websocket route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Rate limit stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request sink dataflow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.haskell.framework.servant ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.haskell.framework.yesod.md
+++ b/docs/coverage/detail/lang.haskell.framework.yesod.md
@@ -1,0 +1,132 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.haskell.framework.yesod` — Yesod (Haskell web framework)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [haskell](../by-language/haskell.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 50
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint response codes | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go`<br>`internal/engine/http_endpoint_haskell_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | synthesizeYesodRoutes parses the [parseRoutes| ... |] QuasiQuote route table: each line /path Resource VERB... yields one http_endpoint_definition per declared HTTP verb. Typed captures #Type (single-segment) and *Type (multi-segment) are normalised to :type then canonicalised via FrameworkYesod into {type}. Honest exclusions: type-safe URL interpolation @{...} (a consumer concern), subsite mounts and attribute route options are not threaded. |
+| Handler attribution | 🟢 `partial` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go` | Yesod routes name a ResourceR (e.g. UserR); the handler is a getUserR/postUserR convention function. Synthesised endpoints carry a Controller kind so a same-named handler IMPLEMENTS edge binds where resolvable; full verb+resource→handler-name derivation is a follow-up. Honest partial. |
+| Route extraction | ✅ `full` | `2026-06-24` | 5373 | `internal/engine/http_endpoint_haskell.go`<br>`internal/engine/http_endpoint_haskell_test.go`<br>`internal/engine/http_endpoint_synthesis.go`<br>`internal/engine/httproutes/canonicalize.go` | Static Yesod parseRoutes verb+path lines recovered by synthesizeYesodRoutes (#5373), including #Type/*Type typed captures. Interpolation/subsite forms excluded (honest, see endpoint_synthesis). |
+| Websocket route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Rate limit stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request sink dataflow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.haskell.framework.yesod ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.haskell.orm.persistent.md
+++ b/docs/coverage/detail/lang.haskell.orm.persistent.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.haskell.orm.persistent` — persistent (Haskell ORM)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [haskell](../by-language/haskell.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | ✅ `full` | `2026-06-24` | 5373 | `internal/extractors/haskell/depth.go`<br>`internal/extractors/haskell/depth_test.go`<br>`internal/extractors/haskell/extractor.go` | extractPersistentEntities parses the [persistLowerCase| ... |] / [persistUpperCase| ... |] QuasiQuote schema blocks: each column-0 capitalised header is an entity, emitted as one SCOPE.Component(subtype=orm_model) carrying orm=persistent, orm_model, table_name and a MAPS_TO edge to the derived table (snake_case of the entity, e.g. BlogPost→blog_post), in the same (orm_model,table_name) contract the cross-language ormlink sentinel uses. Proven by TestPersistent_EntityBlock. |
+| Model lifecycle extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🟢 `partial` | `2026-06-24` | 5373 | `internal/extractors/haskell/depth.go`<br>`internal/extractors/haskell/depth_test.go`<br>`internal/extractors/haskell/extractor.go` | Entity field names are recovered from indented 'fieldName Type ...' lines (persistFieldRE) into a fields/field_count Property; deriving/primary/foreign/unique clause lines are excluded. Honest partial: field SQL types, Maybe-nullability, sql= overrides and !force attributes are not modelled as separate schema columns — follow-up. |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🟢 `partial` | `2026-06-24` | 5373 | `internal/extractors/haskell/depth.go`<br>`internal/extractors/haskell/depth_test.go`<br>`internal/extractors/haskell/extractor.go` | A persistent foreign key is the conventional 'authorId UserId' field referencing another entity's auto Id; it is currently recorded as a plain field on the owning entity (no dedicated REFERENCES edge to the target entity/table yet). Honest partial — FK edge synthesis is a follow-up. |
+| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Migration schema ops | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.haskell.orm.persistent ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.haskell.tool.cabal.md
+++ b/docs/coverage/detail/lang.haskell.tool.cabal.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.haskell.tool.cabal` — Cabal / Stack / hpack (Haskell build)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [haskell](../by-language/haskell.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5373 | `internal/extractors/cross/manifest/cabal.go`<br>`internal/extractors/cross/manifest/cabal_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | Three Haskell manifest shapes are parsed (#5373): *.cabal (parseCabal mines every build-depends: field across library/executable/test-suite/benchmark stanzas, comma+newline split, test-suite/benchmark deps flagged is_dev), package.yaml (parsePackageYaml reads the hpack dependencies: YAML list, tests:/benchmarks: blocks flagged is_dev) and stack.yaml (parseStackYaml emits extra-deps as pinned kind=locked: <name>-<version> versioned form + git github:/git: source pins). The GHC 'base' floor is kept as a real edge (mirrors nimble nim / luarocks lua). Suffix/exact-name dispatched in IsManifest/detectPackageManager/dispatchParser to package managers cabal/hpack/stack; emits DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes like every other ecosystem. Honest scope: cabal 'if flag(...)' conditionals are flattened; the Stack resolver snapshot set is not enumerated (remote package set, not a local manifest). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.haskell.tool.cabal ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.hspec.md
+++ b/docs/coverage/detail/test.hspec.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.hspec` — hspec (Haskell testing)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [haskell](../by-language/haskell.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🟢 `partial` | `2026-06-24` | 5373 | `internal/extractors/haskell/depth.go`<br>`internal/extractors/haskell/depth_test.go` | Each hspec suite carries a stem-affinity TESTS edge to the module its filename names (UserSpec→User). Honest partial: direct-call resolution from inside the it() body and e2e route TESTS edges (test→HTTP endpoint) are not yet wired for Haskell — follow-up. |
+| Target extraction | ✅ `full` | `2026-06-24` | 5373 | `internal/extractors/haskell/depth.go`<br>`internal/extractors/haskell/depth_test.go` | hspec describe/context/it/specify spec blocks (hspecBlockRE) are lifted into one SCOPE.Operation(subtype=test_suite) per *Spec.hs / *Test.hs file (or any file importing Test.Hspec), carrying example_count (it+specify leaves) and framework=hspec. A stem-affinity TESTS edge links the suite to the tested module (UserSpec→User). An example-less spec emits no suite (honest). Proven by TestHspec_SpecSuite + TestHspec_ExampleLessNoEmit. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.hspec ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (26 active · 13 placeholder) · **Frameworks**: 256 · **ORMs**: 184 · **Tools**: 137 · **Other**: 208
+**Languages**: 39 (27 active · 12 placeholder) · **Frameworks**: 259 · **ORMs**: 185 · **Tools**: 139 · **Other**: 208
 
 ## Coverage by language
 
@@ -23,6 +23,7 @@
 | [clojure](by-language/clojure.md) | 4 | 4 | 5 | 1 |
 | [lua](by-language/lua.md) | 4 | 2 | 0 | 1 |
 | [dart](by-language/dart.md) | 3 | 1 | 6 | 1 |
+| [haskell](by-language/haskell.md) | 3 | 2 | 1 | 0 |
 | [crystal](by-language/crystal.md) | 2 | 1 | 5 | 1 |
 | [F#](by-language/fsharp.md) | 2 | 2 | 0 | 2 |
 | [erlang](by-language/erlang.md) | 1 | 5 | 0 | 2 |
@@ -71,7 +72,6 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 |---|
 | [Bicep](by-language/bicep.md) |
 | [Elm](by-language/elm.md) |
-| [Haskell](by-language/haskell.md) |
 | [Idris](by-language/idris.md) |
 | [Lisp](by-language/lisp.md) |
 | [OCaml](by-language/ocaml.md) |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 256 frameworks · 137 tools · 184 ORMs · 208 other
+Total: 259 frameworks · 139 tools · 185 ORMs · 208 other

--- a/internal/engine/http_endpoint_haskell.go
+++ b/internal/engine/http_endpoint_haskell.go
@@ -1,0 +1,292 @@
+// http_endpoint_haskell.go — Haskell web route registration → canonical
+// http_endpoint_definition synthesis (#5373, the Haskell slice of the
+// low-ranked-language bootstrap epic #5360).
+//
+// Background
+// ----------
+// The Haskell base extractor (internal/extractors/haskell/extractor.go) is a
+// regex/layout-heuristic structural extractor: it mines modules, type
+// signatures + definitions (SCOPE.Operation), data/newtype/class/instance
+// SCOPE.Component entities and IMPORTS/CALLS/CONTAINS edges, but has NO
+// web-framework awareness — Scotty `get "/users/:id"` verb routes, Yesod
+// `parseRoutes` quasiquote route tables and Servant type-level API DSLs are not
+// recognised as HTTP endpoints, so no `http_endpoint_definition` entity is ever
+// produced for Haskell. The shared endpoint resolver
+// (ResolveHTTPEndpointHandlers) and the language-agnostic e2e route-test linker
+// (linkE2ERouteTestsToEndpoints, #4351) both key off
+// `http_endpoint_definition` + `path`, so a Haskell route could never surface.
+//
+// This pass closes the PRODUCER-side gap: it emits one canonical
+// http_endpoint_definition per statically-known Haskell route, in the SAME
+// shape the axum / Vapor / Kemal / Clojure synthesizers emit.
+//
+// Haskell web route syntax
+// ------------------------
+//   - Scotty (cheapest first; Sinatra-like): a top-level verb function takes a
+//     string-literal path pattern and a handler `do` block:
+//
+//	get  "/users/:id" $ do ...        → GET  /users/{id}
+//	post "/users"     $ do ...        → POST /users
+//	delete "/users/:id" handler       → DELETE /users/{id}
+//
+//     Scotty uses the Express-style `:name` colon path-parameter convention.
+//
+//   - Yesod: routes live in a `parseRoutes` quasiquote (usually inside
+//     `mkYesod "App" [parseRoutes| ... |]`). Each line is
+//     `/path/segments  ResourceR  GET POST ...`:
+//
+//	/users          UsersR    GET POST     → GET /users, POST /users
+//	/user/#UserId   UserR     GET          → GET /user/{userid}
+//	/static/*Texts  StaticR   GET          → GET /static/{texts}
+//
+//     A `#Type` segment is a typed single-segment capture; a `*Type` segment is
+//     a typed multi-segment capture. Both are normalised to the Express-style
+//     `:name` form (lower-cased type name) before canonicalisation.
+//
+//   - Servant: the API is a TYPE — a chain of `:>`-combined components ending in
+//     a verb combinator. String-literal segments are path literals;
+//     `Capture "name" Type` segments are path params; `:<|>` alternates
+//     sub-APIs:
+//
+//	type API = "users" :> Capture "id" Int :> Get '[JSON] User
+//	      :<|> "users" :> ReqBody '[JSON] User :> Post '[JSON] User
+//	  → GET /users/{id} , POST /users
+//
+// Honest exclusions (no fabricated routes)
+// -----------------------------------------
+//   - Scotty: interpolated / variable / non-literal paths (`get path $ ...`,
+//     `get (mconcat [...]) ...`) — the path must be a STRING LITERAL.
+//   - Yesod: type-safe URL interpolation (`@{UserR uid}`) is a CONSUMER concern,
+//     not a route declaration, and is not emitted. Subsite mounts
+//     (`/admin AdminR Admin getAdmin`) and attribute/`!` route options are not
+//     threaded. The synthesizer reads the literal `parseRoutes` block only.
+//   - Servant: the verb is read from the LEAF combinator on a `:>` chain; HList
+//     type-family composition, named sub-APIs spread across `type` aliases
+//     (`type API = UserAPI :<|> ItemAPI`) and `:<|>` whose operands are bare
+//     type names (not inline `:>` chains) are NOT resolved across declarations
+//     — a documented partial. Each inline `:>` chain that ends in a verb is
+//     emitted.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Scotty
+// ---------------------------------------------------------------------------
+
+// hsScottyRouteRe matches a Scotty verb function call with a leading
+// string-literal path:
+//
+//	get    "/users/:id" $ do ...
+//	post   "/users"     handler
+//	delete "/users/:id" $ ...
+//
+// The verb must appear at a statement boundary (start of line after optional
+// indentation) so an arbitrary function named `get`/`post` invoked with a `.`
+// receiver is not misread. Capture group 1 is the verb; group 2 is the path
+// literal.
+var hsScottyRouteRe = regexp.MustCompile(
+	`(?m)^[ \t]*(get|post|put|delete|patch|options|head)\s+"([^"\n\r]*)"`,
+)
+
+// hsScottyHasRoute is a fast pre-filter: the file must reference a Scotty marker
+// AND a verb call with a leading string literal to be worth scanning.
+func hsScottyHasRoute(content string) bool {
+	if !strings.Contains(content, "Web.Scotty") && !strings.Contains(content, "scotty") {
+		return false
+	}
+	return strings.Contains(content, `get "`) ||
+		strings.Contains(content, `post "`) ||
+		strings.Contains(content, `put "`) ||
+		strings.Contains(content, `delete "`) ||
+		strings.Contains(content, `patch "`) ||
+		strings.Contains(content, `options "`) ||
+		strings.Contains(content, `head "`)
+}
+
+// synthesizeScottyRoutes scans a Haskell source file for Scotty verb routes and
+// emits one http_endpoint_definition per statically-known (verb, path).
+func synthesizeScottyRoutes(content string, emit emitFn) {
+	if !hsScottyHasRoute(content) {
+		return
+	}
+	for _, m := range hsScottyRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		raw := strings.TrimSpace(m[2])
+		if raw == "" {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkScotty, raw)
+		if canonical == "" {
+			continue
+		}
+		emit(strings.ToUpper(m[1]), canonical, "scotty", "Controller", "")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Yesod
+// ---------------------------------------------------------------------------
+
+// hsYesodBlockRe captures the body of a `parseRoutes` quasiquote:
+//
+//	[parseRoutes|
+//	  /users        UsersR   GET POST
+//	  /user/#UserId UserR    GET
+//	|]
+//
+// Capture group 1 is the block body between the opening `|` and the closing `|]`.
+var hsYesodBlockRe = regexp.MustCompile(`(?s)parseRoutes\|(.*?)\|\]`)
+
+// hsYesodLineRe matches one route line inside a parseRoutes block:
+//
+//	/user/#UserId UserR GET POST
+//
+// Capture group 1 is the path; group 2 is the trailing remainder (resource name
+// + verbs / handler refs). A line with no uppercase verb token is a subsite /
+// resource-only mount and is skipped by the verb scan.
+var hsYesodLineRe = regexp.MustCompile(`(?m)^\s*(/\S*)\s+(.*)$`)
+
+// hsYesodVerbRe extracts an HTTP-verb token from the trailing remainder of a
+// Yesod route line. Verbs are bare uppercase words (GET POST PUT DELETE PATCH).
+var hsYesodVerbRe = regexp.MustCompile(`\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b`)
+
+// hsYesodCaptureRe rewrites a Yesod typed capture segment `#Type` (single) or
+// `*Type` / `+Type` (multi) into the Express-style `:type` form so the shared
+// colon canonicaliser folds it to `{type}`.
+var hsYesodCaptureRe = regexp.MustCompile(`[#*+]([A-Za-z][A-Za-z0-9_']*)`)
+
+// synthesizeYesodRoutes scans a Haskell source file for a Yesod `parseRoutes`
+// quasiquote and emits one http_endpoint_definition per (verb, path).
+func synthesizeYesodRoutes(content string, emit emitFn) {
+	if !strings.Contains(content, "parseRoutes") {
+		return
+	}
+	for _, block := range hsYesodBlockRe.FindAllStringSubmatch(content, -1) {
+		if len(block) < 2 {
+			continue
+		}
+		for _, ln := range hsYesodLineRe.FindAllStringSubmatch(block[1], -1) {
+			if len(ln) < 3 {
+				continue
+			}
+			rawPath := ln[1]
+			// Normalise `#Type` / `*Type` captures to `:type`.
+			rawPath = hsYesodCaptureRe.ReplaceAllStringFunc(rawPath, func(seg string) string {
+				m := hsYesodCaptureRe.FindStringSubmatch(seg)
+				return ":" + strings.ToLower(m[1])
+			})
+			canonical := httproutes.Canonicalize(httproutes.FrameworkYesod, rawPath)
+			if canonical == "" {
+				continue
+			}
+			verbs := hsYesodVerbRe.FindAllStringSubmatch(ln[2], -1)
+			seen := map[string]bool{}
+			for _, vm := range verbs {
+				verb := vm[1]
+				if seen[verb] {
+					continue
+				}
+				seen[verb] = true
+				emit(verb, canonical, "yesod", "Controller", "")
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Servant
+// ---------------------------------------------------------------------------
+
+// hsServantVerbRe matches a Servant leaf verb combinator. Servant verb
+// combinators are `Get`/`Post`/`Put`/`Delete`/`Patch` (capitalised), optionally
+// preceded by a content-type / status modifier in the same `:>` chain.
+var hsServantVerbRe = regexp.MustCompile(`\b(Get|Post|Put|Delete|Patch)\b`)
+
+// hsServantLiteralRe matches a Servant string-literal path segment
+// (`"users"`) — a path component in the type-level DSL.
+var hsServantLiteralRe = regexp.MustCompile(`"([^"\n\r]*)"`)
+
+// hsServantCaptureRe matches a Servant `Capture "name" Type` /
+// `CaptureAll "name" Type` path-parameter combinator. Capture group 1 is the
+// parameter name.
+var hsServantCaptureRe = regexp.MustCompile(`Capture(?:All)?\s+"([^"\n\r]+)"`)
+
+// hsServantHasAPI is a fast pre-filter: the file must reference Servant and a
+// verb combinator with a `:>` chain to be worth scanning.
+func hsServantHasAPI(content string) bool {
+	if !strings.Contains(content, "Servant") && !strings.Contains(content, "servant") {
+		return false
+	}
+	return strings.Contains(content, ":>")
+}
+
+// synthesizeServantRoutes scans a Haskell source for Servant type-level API
+// declarations and emits one http_endpoint_definition per inline `:>` chain
+// that terminates in a verb combinator. Each `:<|>`-separated operand is a
+// candidate chain; only operands that are themselves inline `:>` chains ending
+// in a verb are emitted (bare type-name operands are an honest exclusion).
+func synthesizeServantRoutes(content string, emit emitFn) {
+	if !hsServantHasAPI(content) {
+		return
+	}
+	// Each `:<|>`-separated alternative is a route candidate. Splitting on the
+	// alternation operator isolates one inline `:>` chain per route.
+	for _, alt := range strings.Split(content, ":<|>") {
+		// A route chain must contain at least one `:>` combinator and a verb.
+		if !strings.Contains(alt, ":>") {
+			continue
+		}
+		// The first operand carries the file's leading content + `type Name =`
+		// before the first segment; keep only the text from the last `=` that
+		// introduces the API type so the leading `:>` component is the first
+		// path segment (`"users"`) rather than imports/pragmas. Subsequent
+		// `:<|>` operands have no `=` and are unaffected.
+		if eq := strings.LastIndex(alt, "="); eq >= 0 && strings.Contains(alt[eq:], ":>") {
+			alt = alt[eq+1:]
+		}
+		verbMatch := hsServantVerbRe.FindString(alt)
+		if verbMatch == "" {
+			continue
+		}
+		// Walk the `:>`-separated components in order, building the path from
+		// string-literal segments and `Capture "name" _` params. Stop at the
+		// verb combinator (the leaf).
+		var segs []string
+		for _, comp := range strings.Split(alt, ":>") {
+			comp = strings.TrimSpace(comp)
+			if hsServantVerbRe.MatchString(comp) {
+				break
+			}
+			if cm := hsServantCaptureRe.FindStringSubmatch(comp); cm != nil {
+				segs = append(segs, "{"+cm[1]+"}")
+				continue
+			}
+			// A bare string-literal component is a path segment. Guard against
+			// non-path combinators that happen to carry a string (rare) by
+			// requiring the component to be ONLY a quoted literal.
+			if lm := hsServantLiteralRe.FindStringSubmatch(comp); lm != nil &&
+				strings.HasPrefix(comp, `"`) {
+				if lm[1] != "" {
+					segs = append(segs, lm[1])
+				}
+			}
+		}
+		path := "/" + strings.Join(segs, "/")
+		canonical := httproutes.Canonicalize(httproutes.FrameworkServant, path)
+		if canonical == "" {
+			continue
+		}
+		emit(strings.ToUpper(verbMatch), canonical, "servant", "Controller", "")
+	}
+}

--- a/internal/engine/http_endpoint_haskell_test.go
+++ b/internal/engine/http_endpoint_haskell_test.go
@@ -1,0 +1,101 @@
+package engine
+
+import "testing"
+
+// TestScotty_BasicRoute covers the common Scotty verb shape:
+// get "/todos" $ do ... / post "/todos" $ do ...
+func TestScotty_BasicRoute(t *testing.T) {
+	src := `
+{-# LANGUAGE OverloadedStrings #-}
+import Web.Scotty
+
+main :: IO ()
+main = scotty 3000 $ do
+  get "/todos" $ do
+    json allTodos
+  post "/todos" $ do
+    json newTodo
+`
+	ids, _ := runDetect(t, "haskell", "app/Main.hs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos",
+		"http:POST:/todos",
+	}, "scotty-basic-route")
+}
+
+// TestScotty_PathParam covers the Sinatra-style `:param` dynamic segment:
+// get "/todos/:id" → GET /todos/{id}.
+func TestScotty_PathParam(t *testing.T) {
+	src := `
+import Web.Scotty
+
+main = scotty 3000 $ do
+  get "/todos/:id" $ do
+    tid <- param "id"
+    json (findTodo tid)
+  delete "/todos/:id" $ text "deleted"
+`
+	ids, _ := runDetect(t, "haskell", "app/Routes.hs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/todos/{id}",
+		"http:DELETE:/todos/{id}",
+	}, "scotty-path-param")
+}
+
+// TestScotty_NonWebFileIgnored is the negative guard: a Haskell file with no
+// Scotty marker that happens to call a function named `get` must not synthesize
+// an endpoint.
+func TestScotty_NonWebFileIgnored(t *testing.T) {
+	src := `
+module Cache where
+
+lookup' :: Store -> Key -> Maybe Value
+lookup' store key = get store key
+`
+	ids, _ := runDetect(t, "haskell", "src/Cache.hs", src)
+	for _, id := range ids {
+		if id == "http:GET:/store" || id == "http:GET:/key" {
+			t.Fatalf("non-web file must not synthesize an endpoint; got %v", ids)
+		}
+	}
+}
+
+// TestYesod_ParseRoutes covers the Yesod parseRoutes quasiquote: a literal
+// route, a typed single-segment capture `#UserId` and multi-verb lines.
+func TestYesod_ParseRoutes(t *testing.T) {
+	src := `
+{-# LANGUAGE QuasiQuotes #-}
+import Yesod
+
+mkYesod "App" [parseRoutes|
+/users        UsersR  GET POST
+/user/#UserId UserR   GET
+/static/*Texts StaticR GET
+|]
+`
+	ids, _ := runDetect(t, "haskell", "src/Foundation.hs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users",
+		"http:POST:/users",
+		"http:GET:/user/{userid}",
+		"http:GET:/static/{texts}",
+	}, "yesod-parse-routes")
+}
+
+// TestServant_TypeLevelAPI covers the Servant `:>`-chain type-level DSL with a
+// Capture path param and a `:<|>` alternation.
+func TestServant_TypeLevelAPI(t *testing.T) {
+	src := `
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+import Servant
+
+type API = "users" :> Capture "id" Int :> Get '[JSON] User
+      :<|> "users" :> ReqBody '[JSON] User :> Post '[JSON] User
+`
+	ids, _ := runDetect(t, "haskell", "src/Api.hs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users/{id}",
+		"http:POST:/users",
+	}, "servant-type-level-api")
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -146,6 +146,14 @@ func synthesisSupportsLanguage(lang string) bool {
 	// #3484: Lua Lapis / OpenResty producer-side route synthesis.
 	case "lua":
 		return true
+	// #5373 (bootstrap epic #5360): Haskell Scotty / Yesod / Servant producer-
+	// side route synthesis — Scotty `get "/path"` verb calls, Yesod
+	// `[parseRoutes| ... |]` quasiquotes and Servant `:>`-chain type-level APIs
+	// have no compiled YAML rules, so allow Haskell through for
+	// synthesizeScottyRoutes / synthesizeYesodRoutes / synthesizeServantRoutes.
+	// Files without a Haskell web marker are no-ops inside the synthesizers.
+	case "haskell":
+		return true
 	// #4749 (epic #4615 tail): Erlang Cowboy producer-side route synthesis —
 	// `cowboy_router:compile([{'_', [{"/path", handler, []}]}])` dispatch tables
 	// have no compiled YAML rules, so allow Erlang through for synthesizeCowboy.
@@ -1452,6 +1460,19 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// extractor stays structural-only; this pass adds the canonical
 		// definitions the coverage substrate keys off.
 		synthesizeGroovyRoutes(string(content), path, emit)
+	case "haskell":
+		// Producer side (#5373, bootstrap epic #5360): Haskell web route
+		// registrations — Scotty (`get "/users/:id" $ do …`), Yesod
+		// (`[parseRoutes| /user/#UserId UserR GET |]`) and Servant type-level
+		// API DSL (`"users" :> Capture "id" Int :> Get '[JSON] User`) →
+		// canonical http_endpoint_definition, in the same shape
+		// axum/Express/Vapor/Kemal/Clojure emit, so the shared resolver and the
+		// e2e route-test linker (#4351) light up for Haskell. The base haskell
+		// extractor stays structural-only; this pass adds the canonical
+		// definitions the coverage substrate keys off.
+		synthesizeScottyRoutes(string(content), emit)
+		synthesizeYesodRoutes(string(content), emit)
+		synthesizeServantRoutes(string(content), emit)
 	case "yaml", "json":
 		// Producer side (#3628, area #16): OpenAPI 3.x / Swagger 2.0 spec
 		// files declare the HTTP API surface as ground-truth. Each

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -274,6 +274,24 @@ const (
 	// segment is rewritten to the Express-style `:param` form, so canonicalisation
 	// reuses canonicalizeColonParams.
 	FrameworkRoda = "roda"
+	// FrameworkScotty (#5373) — Haskell Scotty `get "/users/:id"` verb routes.
+	// Scotty uses the Sinatra/Express-style `:name` colon path-parameter
+	// convention, so canonicalisation reuses canonicalizeColonParams.
+	FrameworkScotty = "scotty"
+	// FrameworkYesod (#5373) — Haskell Yesod `parseRoutes` quasiquote route
+	// table. A path segment is either a literal, a typed single-segment capture
+	// `#Type` (e.g. `/user/#UserId`) or a typed multi-segment capture `*Type`
+	// (e.g. `/static/*Texts`). The synthesizer NORMALISES `#Foo`/`*Foo` capture
+	// segments to the Express-style `:foo` form (lower-cased type name) before
+	// canonicalisation, so it reuses canonicalizeColonParams.
+	FrameworkYesod = "yesod"
+	// FrameworkServant (#5373) — Haskell Servant type-level API DSL. A route is a
+	// chain of `:>`-combined components ending in a verb combinator
+	// (`Get`/`Post`/…): string-literal segments are path literals and
+	// `Capture "name" Type` segments are path params. The synthesizer
+	// NORMALISES each `Capture "name" _` to the Express-style `:name` form before
+	// canonicalisation, so it reuses canonicalizeColonParams.
+	FrameworkServant = "servant"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -334,7 +352,8 @@ func Canonicalize(framework, raw string) string {
 		FrameworkAdonis, FrameworkMarble, FrameworkPolka, FrameworkRestify, FrameworkSails,
 		FrameworkRobyn, FrameworkPlug, FrameworkCowboy,
 		FrameworkLapis, FrameworkOpenResty, FrameworkVapor, FrameworkClojure,
-		FrameworkKemal, FrameworkRatpack, FrameworkGrape, FrameworkRoda:
+		FrameworkKemal, FrameworkRatpack, FrameworkGrape, FrameworkRoda,
+		FrameworkScotty, FrameworkYesod, FrameworkServant:
 		out = canonicalizeColonParams(raw)
 	case FrameworkGiraffe:
 		// Giraffe `routef "/users/%i"` printf placeholders → `{}` first, then

--- a/internal/extractors/cross/manifest/cabal.go
+++ b/internal/extractors/cross/manifest/cabal.go
@@ -1,0 +1,357 @@
+// cabal.go — Haskell Cabal / Stack / hpack package manifest parsers (#5373,
+// epic #5360).
+//
+// The Haskell build ecosystem has three manifest shapes, all parsed here:
+//
+//	*.cabal — the Cabal package description. Dependencies are declared with the
+//	  `build-depends:` field inside library / executable / test-suite stanzas. The
+//	  field value is a comma-separated list of `<name> <version-constraint>`
+//	  entries that may span many lines:
+//
+//	    library
+//	      build-depends:  base >=4.14 && <5
+//	                    , text
+//	                    , aeson >= 2.0
+//	      hs-source-dirs: src
+//
+//	    test-suite spec
+//	      build-depends: base, hspec >= 2.7, mylib
+//
+//	  A dependency entry's leading token (letters/digits/`-`) is the package
+//	  name; the remainder is the version constraint. `base` (the GHC base library
+//	  floor) is KEPT — it is a real edge in the dependency graph, mirroring the
+//	  LuaRocks `lua` / nimble `nim` interpreter-floor treatment (#5365/#5367).
+//	  Dependencies in a `test-suite` / `benchmark` stanza are flagged is_dev.
+//
+//	package.yaml — the hpack manifest (a higher-level YAML that hpack compiles to
+//	  a .cabal). Dependencies are a YAML list under a top-level `dependencies:`
+//	  key (runtime) and/or under per-component `tests:`/`benchmarks:` sections:
+//
+//	    dependencies:
+//	      - base >= 4.14 && < 5
+//	      - text
+//	      - aeson
+//
+//	    tests:
+//	      spec:
+//	        dependencies:
+//	          - hspec
+//
+//	stack.yaml — the Stack project/build config. Its `extra-deps:` list pins
+//	  packages NOT on the chosen resolver/snapshot (the snapshot itself provides
+//	  the bulk of the dependency set and is not enumerated here):
+//
+//	    resolver: lts-21.0
+//	    extra-deps:
+//	      - acme-missiles-0.3
+//	      - github: foo/bar
+//	        commit: abc123
+//
+//	  An `extra-deps` entry of the `<name>-<version>` form is split into name +
+//	  version (the trailing `-<version>` semver suffix is the pinned version);
+//	  source-pinned entries (git `github:`/`commit:` maps) record the repo name
+//	  with an empty version and kind="locked" (an exactly-pinned source dep).
+//
+// Honest scope: only the declared/manifest dependency surface is recovered.
+// Cabal conditional `if flag(...)` stanzas are flattened (all build-depends
+// across conditionals are emitted); Stack snapshot-provided packages are not
+// enumerated (the resolver is a remote set, not a local manifest).
+package manifest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Parser: *.cabal
+// ---------------------------------------------------------------------------
+
+// cabalStanzaHeadRE matches a stanza header that starts a component block. Only
+// the kind matters for dev-classification; the optional name is ignored.
+var cabalStanzaHeadRE = regexp.MustCompile(
+	`(?mi)^(library|executable|test-suite|benchmark|foreign-library)\b`)
+
+// cabalBuildDependsRE captures the value body of a `build-depends:` field. The
+// value runs from the colon to the first subsequent line that begins at the
+// SAME-or-shallower indentation as the field name with a non-comma, non-blank
+// field key (i.e. the next field/stanza). Because Cabal field continuations are
+// indented MORE than the field key, the body is the field key's line plus every
+// following line that is either blank, a comment, or more-indented.
+var cabalBuildDependsRE = regexp.MustCompile(
+	`(?mi)^[ \t]*build-depends[ \t]*:`)
+
+// cabalDepEntryRE splits one dependency entry into name + version constraint.
+//
+//	"base >=4.14 && <5"  → name=base,  version=">=4.14 && <5"
+//	"text"               → name=text,  version=""
+//	"aeson >= 2.0"       → name=aeson, version=">= 2.0"
+//
+// Cabal package names are letters/digits separated by `-` (e.g. `bytestring`,
+// `optparse-applicative`). The version constraint is whatever follows the first
+// run of whitespace.
+var cabalDepEntryRE = regexp.MustCompile(
+	`^([A-Za-z0-9][A-Za-z0-9_-]*)\s*(.*)$`)
+
+// parseCabal parses a `*.cabal` manifest. Dependencies are mined from every
+// `build-depends:` field; an entry inside a `test-suite`/`benchmark` stanza is
+// flagged is_dev. First declaration of a name wins (runtime beats a later dev
+// declaration of the same name).
+func parseCabal(source string) []dep {
+	lines := strings.Split(source, "\n")
+	var out []dep
+	seen := map[string]bool{}
+
+	// Track the kind of the current stanza so build-depends can be classified.
+	currentDev := false
+
+	emit := func(body string, isDev bool) {
+		// The body is a comma-separated list (possibly across lines). Split on
+		// commas and newlines, then parse each entry.
+		fields := strings.FieldsFunc(body, func(r rune) bool {
+			return r == ',' || r == '\n' || r == '\r'
+		})
+		for _, f := range fields {
+			f = strings.TrimSpace(f)
+			if f == "" || strings.HasPrefix(f, "--") {
+				continue
+			}
+			m := cabalDepEntryRE.FindStringSubmatch(f)
+			if m == nil {
+				continue
+			}
+			name := m[1]
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			kind := "runtime"
+			if isDev {
+				kind = "dev"
+			}
+			out = append(out, dep{
+				name:    name,
+				version: strings.TrimSpace(m[2]),
+				isDev:   isDev,
+				kind:    kind,
+			})
+		}
+	}
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if h := cabalStanzaHeadRE.FindStringSubmatch(line); h != nil {
+			kind := strings.ToLower(h[1])
+			currentDev = kind == "test-suite" || kind == "benchmark"
+			continue
+		}
+		if cabalBuildDependsRE.MatchString(line) {
+			// Field key indentation defines the continuation boundary.
+			fieldIndent := indentWidth(line)
+			// Body starts after the first colon on this line.
+			body := line[strings.IndexByte(line, ':')+1:]
+			// Gather more-indented / blank / comment continuation lines.
+			j := i + 1
+			for j < len(lines) {
+				cont := lines[j]
+				if strings.TrimSpace(cont) == "" {
+					body += "\n"
+					j++
+					continue
+				}
+				if indentWidth(cont) > fieldIndent {
+					body += "\n" + cont
+					j++
+					continue
+				}
+				break
+			}
+			emit(body, currentDev)
+			i = j - 1
+		}
+	}
+	return out
+}
+
+// indentWidth returns the number of leading whitespace columns (tabs count as 1)
+// of a line.
+func indentWidth(s string) int {
+	n := 0
+	for _, r := range s {
+		if r == ' ' || r == '\t' {
+			n++
+			continue
+		}
+		break
+	}
+	return n
+}
+
+// ---------------------------------------------------------------------------
+// Parser: package.yaml (hpack)
+// ---------------------------------------------------------------------------
+
+// hpackDepListItemRE matches one YAML list item in a `dependencies:` block:
+//
+//	  - base >= 4.14 && < 5   → name=base
+//	  - text                  → name=text
+//
+// Group 1 is the package name; group 2 is the trailing version constraint.
+var hpackDepListItemRE = regexp.MustCompile(
+	`^[ \t]*-\s*([A-Za-z0-9][A-Za-z0-9_-]*)\s*(.*)$`)
+
+// hpackDepsKeyRE matches a `dependencies:` YAML key (runtime deps). hpack also
+// allows per-component (tests:/benchmarks:) dependency blocks; those are
+// detected by an enclosing dev section tracked in parseHpackPackageYaml.
+var hpackDepsKeyRE = regexp.MustCompile(`(?m)^([ \t]*)dependencies\s*:`)
+
+// hpackDevSectionRE matches the start of a tests:/benchmarks: section so deps
+// declared underneath are classified is_dev.
+var hpackDevSectionRE = regexp.MustCompile(`(?m)^([ \t]*)(tests|benchmarks)\s*:`)
+
+// parsePackageYaml parses an hpack `package.yaml` manifest. A `dependencies:`
+// list under a tests:/benchmarks: section is flagged is_dev; a top-level
+// `dependencies:` list is runtime.
+func parsePackageYaml(source string) []dep {
+	lines := strings.Split(source, "\n")
+	var out []dep
+	seen := map[string]bool{}
+
+	// devIndent is the indentation of the active tests:/benchmarks: section, or
+	// -1 when not inside one. A line at <= devIndent ends the dev section.
+	devIndent := -1
+
+	emit := func(start int, keyIndent int, isDev bool) int {
+		j := start + 1
+		for j < len(lines) {
+			cur := lines[j]
+			if strings.TrimSpace(cur) == "" {
+				j++
+				continue
+			}
+			// A dependency list item must be MORE indented than the key.
+			if indentWidth(cur) <= keyIndent {
+				break
+			}
+			m := hpackDepListItemRE.FindStringSubmatch(cur)
+			if m == nil {
+				// Non-list-item line at deeper indent ends the inline list.
+				break
+			}
+			name := m[1]
+			if name != "" && !seen[name] {
+				seen[name] = true
+				kind := "runtime"
+				if isDev {
+					kind = "dev"
+				}
+				out = append(out, dep{
+					name:    name,
+					version: strings.TrimSpace(m[2]),
+					isDev:   isDev,
+					kind:    kind,
+				})
+			}
+			j++
+		}
+		return j - 1
+	}
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		ind := indentWidth(line)
+		// Leaving a dev section.
+		if devIndent >= 0 && ind <= devIndent && strings.TrimSpace(line) != "" {
+			if !hpackDevSectionRE.MatchString(line) {
+				devIndent = -1
+			}
+		}
+		if m := hpackDevSectionRE.FindStringSubmatch(line); m != nil {
+			devIndent = len(m[1])
+			continue
+		}
+		if m := hpackDepsKeyRE.FindStringSubmatch(line); m != nil {
+			keyIndent := len(m[1])
+			isDev := devIndent >= 0 && keyIndent > devIndent
+			i = emit(i, keyIndent, isDev)
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: stack.yaml
+// ---------------------------------------------------------------------------
+
+// stackExtraDepsKeyRE matches the `extra-deps:` YAML key.
+var stackExtraDepsKeyRE = regexp.MustCompile(`(?m)^([ \t]*)extra-deps\s*:`)
+
+// stackVersionedDepRE matches an `extra-deps` list item of the `<name>-<version>`
+// form, splitting the trailing semver suffix off as the pinned version:
+//
+//	- acme-missiles-0.3   → name=acme-missiles, version=0.3
+//	- text-2.0.1          → name=text,          version=2.0.1
+//
+// The name is the longest leading run of `-`-separated identifier segments
+// before the final `-<numeric-version>` segment.
+var stackVersionedDepRE = regexp.MustCompile(
+	`^[ \t]*-\s*([A-Za-z0-9][A-Za-z0-9_-]*?)-([0-9][A-Za-z0-9.]*)\s*$`)
+
+// stackBareDepRE matches an `extra-deps` list item with no version suffix
+// (a bare package name) — rare but valid.
+var stackBareDepRE = regexp.MustCompile(
+	`^[ \t]*-\s*([A-Za-z0-9][A-Za-z0-9_-]*)\s*$`)
+
+// stackGitRepoRE matches a source-pinned git extra-dep map entry's repo:
+//
+//	- github: foo/bar   → name=bar
+//	- git: https://example.com/foo/baz.git → name=baz
+var stackGitRepoRE = regexp.MustCompile(
+	`^[ \t]*-?\s*(?:github|git)\s*:\s*(?:\S*/)?([A-Za-z0-9._-]+?)(?:\.git)?/?\s*$`)
+
+// parseStackYaml parses a `stack.yaml` and returns its `extra-deps` entries as
+// pinned (kind="locked") dependencies. The resolver/snapshot set is NOT
+// enumerated (it is a remote package set, not a local manifest).
+func parseStackYaml(source string) []dep {
+	lines := strings.Split(source, "\n")
+	var out []dep
+	seen := map[string]bool{}
+
+	add := func(name, version string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		out = append(out, dep{name: name, version: version, kind: "locked"})
+	}
+
+	for i := 0; i < len(lines); i++ {
+		if m := stackExtraDepsKeyRE.FindStringSubmatch(lines[i]); m != nil {
+			keyIndent := len(m[1])
+			for j := i + 1; j < len(lines); j++ {
+				cur := lines[j]
+				if strings.TrimSpace(cur) == "" {
+					continue
+				}
+				// A list entry must be more-indented than the key; a same-or-
+				// shallower key ends the block.
+				if indentWidth(cur) <= keyIndent && !strings.HasPrefix(strings.TrimSpace(cur), "-") {
+					i = j - 1
+					break
+				}
+				if gm := stackGitRepoRE.FindStringSubmatch(cur); gm != nil {
+					add(gm[1], "")
+				} else if vm := stackVersionedDepRE.FindStringSubmatch(cur); vm != nil {
+					add(vm[1], vm[2])
+				} else if bm := stackBareDepRE.FindStringSubmatch(cur); bm != nil {
+					add(bm[1], "")
+				}
+				i = j
+			}
+		}
+	}
+	return out
+}

--- a/internal/extractors/cross/manifest/cabal_test.go
+++ b/internal/extractors/cross/manifest/cabal_test.go
@@ -1,0 +1,160 @@
+package manifest
+
+import "testing"
+
+// realCabal is a representative *.cabal manifest exercising a library stanza
+// (runtime build-depends spanning multiple comma-led continuation lines), a
+// test-suite stanza (dev deps), the `base` GHC floor, a bare dep, and version
+// constraints.
+const realCabal = `cabal-version:      2.4
+name:               mylib
+version:            0.1.0.0
+
+library
+    exposed-modules:  MyLib
+    build-depends:    base >=4.14 && <5
+                    , text
+                    , aeson >= 2.0
+    hs-source-dirs:   src
+    default-language: Haskell2010
+
+test-suite spec
+    type:             exitcode-stdio-1.0
+    main-is:          Spec.hs
+    build-depends:    base, hspec >= 2.7, mylib
+    hs-source-dirs:   test
+`
+
+func TestCabal_LibraryAndTestDeps(t *testing.T) {
+	deps := depEntities(runExtract(t, "mylib.cabal", realCabal))
+	// runtime: base, text, aeson (+ base seen first so it stays runtime) ;
+	// dev-only new names: hspec, mylib. base/aeson/text first-declaration-wins.
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "cabal" {
+			t.Errorf("%s: package_manager=%q want cabal", d.Name, d.Properties["package_manager"])
+		}
+	}
+
+	if d := depByName(deps, "base"); d == nil {
+		t.Error("expected runtime dep 'base' (GHC floor is a real edge)")
+	} else if d.Properties["version"] != ">=4.14 && <5" {
+		t.Errorf("base version=%q want '>=4.14 && <5'", d.Properties["version"])
+	} else if d.Properties["is_dev"] != "false" {
+		t.Errorf("base should be is_dev=false (first declared in library)")
+	}
+
+	if d := depByName(deps, "aeson"); d == nil || d.Properties["version"] != ">= 2.0" {
+		t.Errorf("aeson version=%v want '>= 2.0'", d)
+	}
+	if d := depByName(deps, "text"); d == nil {
+		t.Error("expected dep 'text'")
+	} else if d.Properties["version"] != "" {
+		t.Errorf("text version=%q want empty (bare)", d.Properties["version"])
+	}
+
+	// hspec is declared only in the test-suite stanza → is_dev=true.
+	if d := depByName(deps, "hspec"); d == nil {
+		t.Error("expected dev dep 'hspec' from test-suite stanza")
+	} else if d.Properties["is_dev"] != "true" {
+		t.Errorf("hspec should be is_dev=true (test-suite stanza); got %q", d.Properties["is_dev"])
+	}
+	if d := depByName(deps, "mylib"); d == nil || d.Properties["is_dev"] != "true" {
+		t.Errorf("mylib should be is_dev=true (test-suite stanza); got %v", d)
+	}
+}
+
+// realPackageYaml is a representative hpack package.yaml with a top-level
+// runtime dependencies list and a per-test dependencies block.
+const realPackageYaml = `name:    mylib
+version: 0.1.0.0
+
+dependencies:
+  - base >= 4.14 && < 5
+  - text
+  - aeson
+
+library:
+  source-dirs: src
+
+tests:
+  mylib-test:
+    main: Spec.hs
+    source-dirs: test
+    dependencies:
+      - hspec
+`
+
+func TestPackageYaml_RuntimeAndTestDeps(t *testing.T) {
+	deps := depEntities(runExtract(t, "package.yaml", realPackageYaml))
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "hpack" {
+			t.Errorf("%s: package_manager=%q want hpack", d.Name, d.Properties["package_manager"])
+		}
+	}
+	if d := depByName(deps, "base"); d == nil {
+		t.Error("expected runtime dep 'base'")
+	} else if d.Properties["version"] != ">= 4.14 && < 5" {
+		t.Errorf("base version=%q want '>= 4.14 && < 5'", d.Properties["version"])
+	}
+	if d := depByName(deps, "aeson"); d == nil {
+		t.Error("expected runtime dep 'aeson'")
+	}
+	if d := depByName(deps, "hspec"); d == nil {
+		t.Error("expected dev dep 'hspec' from tests: section")
+	} else if d.Properties["is_dev"] != "true" {
+		t.Errorf("hspec should be is_dev=true (tests: section); got %q", d.Properties["is_dev"])
+	}
+}
+
+// realStackYaml is a representative stack.yaml with a versioned extra-dep, a
+// second versioned extra-dep, and a git source-pinned extra-dep.
+const realStackYaml = `resolver: lts-21.0
+
+packages:
+  - .
+
+extra-deps:
+  - acme-missiles-0.3
+  - text-2.0.1
+  - github: foo/bar
+    commit: abc123
+`
+
+func TestStackYaml_ExtraDeps(t *testing.T) {
+	deps := depEntities(runExtract(t, "stack.yaml", realStackYaml))
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "stack" {
+			t.Errorf("%s: package_manager=%q want stack", d.Name, d.Properties["package_manager"])
+		}
+	}
+	if d := depByName(deps, "acme-missiles"); d == nil {
+		t.Error("expected extra-dep 'acme-missiles'")
+	} else if d.Properties["version"] != "0.3" {
+		t.Errorf("acme-missiles version=%q want '0.3'", d.Properties["version"])
+	}
+	if d := depByName(deps, "text"); d == nil || d.Properties["version"] != "2.0.1" {
+		t.Errorf("text version=%v want '2.0.1'", d)
+	}
+	// git source-pinned repo name recorded with empty version.
+	if d := depByName(deps, "bar"); d == nil {
+		t.Error("expected git source-pinned extra-dep 'bar'")
+	}
+	// The resolver/snapshot itself must NOT be enumerated as a dependency.
+	if d := depByName(deps, "lts-21.0"); d != nil {
+		t.Error("resolver/snapshot must not be emitted as a dependency")
+	}
+}
+
+// TestCabal_PackageYaml_NotManifestNeg guards that a plain non-Haskell YAML
+// named neither stack.yaml/package.yaml nor *.cabal is not parsed here.
+func TestCabal_NonManifestExtensionIgnored(t *testing.T) {
+	if IsManifest("src/Main.hs") {
+		t.Error("a .hs source file must not be treated as a manifest")
+	}
+	if !IsManifest("mylib.cabal") {
+		t.Error("*.cabal must be recognised as a manifest")
+	}
+	if !IsManifest("stack.yaml") || !IsManifest("package.yaml") {
+		t.Error("stack.yaml / package.yaml must be recognised as manifests")
+	}
+}

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -192,6 +192,10 @@ var exactManifestNames = map[string]bool{
 	// .NET / F# — Paket (paket.dependencies manifest + paket.lock lockfile)
 	"paket.dependencies": true,
 	"paket.lock":         true,
+	// Haskell — Stack project config (extra-deps) + hpack manifest (#5373).
+	// The *.cabal Cabal package description is suffix-dispatched below.
+	"stack.yaml":   true,
+	"package.yaml": true,
 }
 
 // IsManifest returns true when filePath names a supported manifest file.
@@ -220,6 +224,11 @@ func IsManifest(filePath string) bool {
 	// *.nimble — Nim nimble package manifest (the package name is the file's
 	// base name, e.g. jester.nimble, so it is matched by extension; #5367).
 	if strings.HasSuffix(basename, ".nimble") {
+		return true
+	}
+	// *.cabal — Haskell Cabal package description (the package name is the
+	// file's base name, e.g. mylib.cabal, so it is matched by extension; #5373).
+	if strings.HasSuffix(basename, ".cabal") {
 		return true
 	}
 	return false
@@ -271,6 +280,9 @@ func detectPackageManager(filePath string) string {
 		// .NET / F# — Paket
 		"paket.dependencies": "paket",
 		"paket.lock":         "paket",
+		// Haskell — Stack (extra-deps) + hpack (package.yaml)
+		"stack.yaml":   "stack",
+		"package.yaml": "hpack",
 	}
 	basename := filepath.Base(filePath)
 	if v, ok := pm[basename]; ok {
@@ -291,6 +303,10 @@ func detectPackageManager(filePath string) string {
 	// *.nimble → nimble (Nim package manifest)
 	if strings.HasSuffix(basename, ".nimble") {
 		return "nimble"
+	}
+	// *.cabal → cabal (Haskell package description)
+	if strings.HasSuffix(basename, ".cabal") {
+		return "cabal"
 	}
 	return "unknown"
 }
@@ -1911,6 +1927,10 @@ var parsers = map[string]parserFn{
 	// .NET / F# — Paket
 	"paket.dependencies": parsePaketDependencies,
 	"paket.lock":         parsePaketLock,
+	// Haskell — Stack project config + hpack manifest (*.cabal is suffix-
+	// dispatched below).
+	"stack.yaml":   parseStackYaml,
+	"package.yaml": parsePackageYaml,
 }
 
 func dispatchParser(filePath, source string) (string, []dep) {
@@ -1934,6 +1954,10 @@ func dispatchParser(filePath, source string) (string, []dep) {
 	// *.nimble — Nim nimble package manifest.
 	if strings.HasSuffix(basename, ".nimble") {
 		return "nimble", parseNimble(source)
+	}
+	// *.cabal — Haskell Cabal package description.
+	if strings.HasSuffix(basename, ".cabal") {
+		return "cabal", parseCabal(source)
 	}
 	// Makefile — only an erlang.mk build when it includes erlang.mk / declares
 	// PROJECT (requireSignal=true); a plain Makefile is a no-op.

--- a/internal/extractors/haskell/depth.go
+++ b/internal/extractors/haskell/depth.go
@@ -1,0 +1,264 @@
+// depth.go — framework-aware Haskell extraction: persistent ORM entity blocks
+// and hspec test suites (#5373, bootstrap epic #5360).
+//
+// These sit ALONGSIDE the structural base extractor (extractor.go). The base
+// extractor mines modules / functions / data / class / instance entities; this
+// file adds two framework records:
+//
+//   - persistent ORM: the `[persistLowerCase| ... |]` / `[persistUpperCase| ... |]`
+//     QuasiQuote entity-definition blocks (the canonical persistent schema DSL)
+//     are parsed into one ORM-model SCOPE.Component per entity, carrying a
+//     MAPS_TO edge to the derived table name plus the entity's field list. This
+//     is the same (orm_model, table_name) contract the cross-language ormlink
+//     sentinel emits, so the topology / data-coupling passes light up for
+//     Haskell persistent schemas.
+//
+//   - hspec testing: `describe "..."` / `it "..."` spec blocks are lifted into
+//     one SCOPE.Operation(subtype="test_suite") per spec file, carrying the
+//     example count, mirroring the Crystal/Ruby spec-suite model.
+//
+// Honest scope (partial, no fabrication):
+//   - persistent: the entity name + field names are recovered from the
+//     persistLowerCase block. Migrations (`runMigration`), relations
+//     (`<entity>Id` foreign keys are recorded as plain fields), `deriving`
+//     clauses and the `!force`/`Maybe`/`sql=` field attributes are not modelled
+//     as separate edges — a documented follow-up.
+//   - hspec: literal `describe`/`it` strings inside a Spec module are counted;
+//     `hspec-discover` auto-generated spec aggregation and QuickCheck `prop_`
+//     property functions are NOT linked here (follow-up).
+package haskell
+
+import (
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// persistent ORM
+// ---------------------------------------------------------------------------
+
+// persistBlockRE captures the body of a persistent QuasiQuote schema block:
+//
+//	share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+//	User
+//	    name String
+//	    age  Int Maybe
+//	    deriving Show
+//	Post
+//	    title String
+//	    authorId UserId
+//	|]
+//
+// Capture group 1 is the block body between the opening `|` and the closing `|]`.
+// Both persistLowerCase and persistUpperCase (and the rarer persistFileWith) are
+// matched.
+var persistBlockRE = regexp.MustCompile(`(?s)persist(?:LowerCase|UpperCase)\|(.*?)\|\]`)
+
+// persistEntityHeadRE matches an entity header line inside a persistent block:
+// a line beginning at column 0 (no leading whitespace) with a capitalised
+// identifier. Fields and clauses are indented beneath it.
+var persistEntityHeadRE = regexp.MustCompile(`^([A-Z][A-Za-z0-9_']*)\s*$`)
+
+// persistFieldRE matches an entity field line: indented `fieldName Type ...`.
+// Capture group 1 is the field name (lower-camel-case).
+var persistFieldRE = regexp.MustCompile(`^\s+([a-z][A-Za-z0-9_']*)\s+\S`)
+
+// persistClauseWords are the indented keywords that are NOT fields (clauses).
+var persistClauseWords = map[string]bool{
+	"deriving": true, "primary": true, "foreign": true, "unique": true,
+}
+
+// extractPersistentEntities parses persistent QuasiQuote schema blocks and emits
+// one orm_model SCOPE.Component per entity with a MAPS_TO edge to its table.
+func extractPersistentEntities(src, filePath string) []types.EntityRecord {
+	if !strings.Contains(src, "persistLowerCase") && !strings.Contains(src, "persistUpperCase") {
+		return nil
+	}
+	var out []types.EntityRecord
+	for _, block := range persistBlockRE.FindAllStringSubmatch(src, -1) {
+		if len(block) < 2 {
+			continue
+		}
+		body := block[1]
+		blockStart := strings.Index(src, block[0])
+		lines := strings.Split(body, "\n")
+
+		var (
+			curEntity string
+			curFields []string
+			curLine   int
+		)
+		flush := func() {
+			if curEntity == "" {
+				return
+			}
+			out = append(out, buildPersistentModel(curEntity, curFields, filePath, curLine))
+			curEntity = ""
+			curFields = nil
+		}
+
+		for idx, ln := range lines {
+			if strings.TrimSpace(ln) == "" {
+				continue
+			}
+			if h := persistEntityHeadRE.FindStringSubmatch(ln); h != nil {
+				flush()
+				curEntity = h[1]
+				// Approximate the entity's source line from the block offset.
+				curLine = strings.Count(src[:blockStart], "\n") + 1 + idx + 1
+				continue
+			}
+			if curEntity == "" {
+				continue
+			}
+			// An indented clause keyword (deriving / primary / foreign / unique)
+			// is not a field.
+			trimmed := strings.Fields(strings.TrimSpace(ln))
+			if len(trimmed) > 0 && persistClauseWords[trimmed[0]] {
+				continue
+			}
+			if f := persistFieldRE.FindStringSubmatch(ln); f != nil {
+				curFields = append(curFields, f[1])
+			}
+		}
+		flush()
+	}
+	return out
+}
+
+// persistTableName derives the SQL table name persistent generates for an entity
+// (default: snake_case of the entity name, lower-cased — `BlogPost` → `blog_post`).
+func persistTableName(entity string) string {
+	var b strings.Builder
+	for i, r := range entity {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r - 'A' + 'a')
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// buildPersistentModel builds the orm_model SCOPE.Component for one persistent
+// entity, carrying the (orm_model, table_name) contract + a MAPS_TO edge, in the
+// same shape the cross-language ormlink sentinel emits.
+func buildPersistentModel(entity string, fields []string, filePath string, line int) types.EntityRecord {
+	table := persistTableName(entity)
+	fromRef := "scope:ormmodel:" + filePath + "#" + entity
+	return types.EntityRecord{
+		Name:          entity,
+		Kind:          "SCOPE.Component",
+		Subtype:       "orm_model",
+		QualifiedName: fromRef,
+		SourceFile:    filePath,
+		Language:      "haskell",
+		StartLine:     line,
+		EndLine:       line,
+		Signature:     "persistent entity " + entity,
+		Properties: map[string]string{
+			"orm_model":   entity,
+			"table_name":  table,
+			"orm":         "persistent",
+			"fields":      strings.Join(fields, ","),
+			"field_count": strconv.Itoa(len(fields)),
+			"provenance":  "INFERRED_FROM_ORM_MODEL",
+		},
+		Relationships: []types.RelationshipRecord{
+			{
+				FromID: fromRef,
+				ToID:   table,
+				Kind:   "MAPS_TO",
+				Properties: map[string]string{
+					"orm_model":  entity,
+					"table_name": table,
+				},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hspec testing
+// ---------------------------------------------------------------------------
+
+// hspecBlockRE matches an hspec `describe`/`context`/`it`/`specify` call with a
+// leading string-literal label. Capture group 1 is the keyword; group 2 is the
+// label.
+var hspecBlockRE = regexp.MustCompile(`\b(describe|context|it|specify)\s+"([^"\n\r]*)"`)
+
+// isHspecFile reports whether a path looks like an hspec spec file
+// (conventionally `*Spec.hs` or a file under a `test`/`spec` dir).
+func isHspecFile(filePath string) bool {
+	base := filepath.Base(filepath.ToSlash(filePath))
+	if strings.HasSuffix(base, "Spec.hs") || strings.HasSuffix(base, "Test.hs") {
+		return true
+	}
+	return false
+}
+
+// extractHspecSuite emits one SCOPE.Operation(subtype="test_suite") per hspec
+// spec file carrying the example (`it`/`specify`) count. No suite is emitted for
+// a file with no examples or a non-spec file with no hspec marker.
+func extractHspecSuite(src, filePath string) []types.EntityRecord {
+	hasHspecImport := strings.Contains(src, "Test.Hspec") || strings.Contains(src, "hspec")
+	if !isHspecFile(filePath) && !hasHspecImport {
+		return nil
+	}
+	matches := hspecBlockRE.FindAllStringSubmatch(src, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	exampleCount := 0
+	subject := ""
+	for _, m := range matches {
+		switch m[1] {
+		case "it", "specify":
+			exampleCount++
+		case "describe", "context":
+			if subject == "" {
+				subject = m[2]
+			}
+		}
+	}
+	if exampleCount == 0 {
+		return nil
+	}
+	base := strings.TrimSuffix(filepath.Base(filepath.ToSlash(filePath)), ".hs")
+	rec := types.EntityRecord{
+		Name:       "spec_suite:" + base,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: filePath,
+		Language:   "haskell",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":      "hspec",
+			"test_framework": "hspec",
+			"provenance":     "INFERRED_FROM_HSPEC_SUITE",
+			"example_count":  strconv.Itoa(exampleCount),
+		},
+	}
+	// Subject affinity: a `*Spec.hs` file conventionally tests the module named
+	// by its stem (`UserSpec.hs` → `User`), so emit a name-affinity TESTS edge.
+	stemSubject := strings.TrimSuffix(strings.TrimSuffix(base, "Spec"), "Test")
+	if stemSubject != "" && stemSubject != base {
+		rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+			ToID: stemSubject,
+			Kind: string(types.RelationshipKindTests),
+			Properties: map[string]string{
+				"framework":    "hspec",
+				"match_source": "spec_stem_affinity",
+			},
+		})
+	}
+	return []types.EntityRecord{rec}
+}

--- a/internal/extractors/haskell/depth_test.go
+++ b/internal/extractors/haskell/depth_test.go
@@ -1,0 +1,138 @@
+package haskell_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestPersistent_EntityBlock covers the canonical persistent schema QuasiQuote:
+// two entities with fields → two orm_model SCOPE.Components with MAPS_TO edges.
+func TestPersistent_EntityBlock(t *testing.T) {
+	src := `{-# LANGUAGE QuasiQuotes #-}
+module Model where
+
+import Database.Persist.TH
+
+share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+User
+    name String
+    age  Int Maybe
+    deriving Show
+BlogPost
+    title String
+    authorId UserId
+|]
+`
+	ents := runHaskell(t, src, "src/Model.hs")
+
+	user := hsFind(ents, "User", "SCOPE.Component")
+	if user == nil || user.Subtype != "orm_model" {
+		t.Fatalf("expected orm_model entity 'User'; got %+v", user)
+	}
+	if user.Properties["table_name"] != "user" {
+		t.Errorf("User table_name=%q want 'user'", user.Properties["table_name"])
+	}
+	if user.Properties["orm"] != "persistent" {
+		t.Errorf("User orm=%q want 'persistent'", user.Properties["orm"])
+	}
+	if f := user.Properties["fields"]; !strings.Contains(f, "name") || !strings.Contains(f, "age") {
+		t.Errorf("User fields=%q want name,age", f)
+	}
+	// MAPS_TO edge to the table.
+	hasMaps := false
+	for _, r := range user.Relationships {
+		if r.Kind == "MAPS_TO" && r.ToID == "user" {
+			hasMaps = true
+		}
+	}
+	if !hasMaps {
+		t.Errorf("expected User --MAPS_TO--> user edge; got %+v", user.Relationships)
+	}
+
+	bp := hsFind(ents, "BlogPost", "SCOPE.Component")
+	if bp == nil || bp.Subtype != "orm_model" {
+		t.Fatalf("expected orm_model entity 'BlogPost'")
+	}
+	// snake_case table derivation.
+	if bp.Properties["table_name"] != "blog_post" {
+		t.Errorf("BlogPost table_name=%q want 'blog_post'", bp.Properties["table_name"])
+	}
+	// authorId foreign-key field is recorded as a plain field (honest partial).
+	if f := bp.Properties["fields"]; !strings.Contains(f, "authorId") {
+		t.Errorf("BlogPost fields=%q want authorId", f)
+	}
+}
+
+// TestPersistent_NoBlockNoEmit is the negative guard: a Haskell file with no
+// persistent QuasiQuote emits no orm_model entity.
+func TestPersistent_NoBlockNoEmit(t *testing.T) {
+	src := `module Plain where
+data User = User { name :: String }
+`
+	ents := runHaskell(t, src, "src/Plain.hs")
+	for _, e := range ents {
+		if e.Subtype == "orm_model" {
+			t.Fatalf("non-persistent file must not emit orm_model; got %q", e.Name)
+		}
+	}
+}
+
+// TestHspec_SpecSuite covers hspec describe/it extraction: a *Spec.hs file with
+// examples → one test_suite carrying the example count + a stem-affinity TESTS
+// edge to the tested module.
+func TestHspec_SpecSuite(t *testing.T) {
+	src := `module UserSpec (spec) where
+
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "User.create" $ do
+    it "creates a user" $ do
+      True ` + "`shouldBe`" + ` True
+    it "rejects a blank name" $ do
+      True ` + "`shouldBe`" + ` True
+  describe "User.delete" $ do
+    specify "removes a user" $ do
+      True ` + "`shouldBe`" + ` True
+`
+	ents := runHaskell(t, src, "test/UserSpec.hs")
+	suite := hsFind(ents, "spec_suite:UserSpec", "SCOPE.Operation")
+	if suite == nil || suite.Subtype != "test_suite" {
+		t.Fatalf("expected test_suite 'spec_suite:UserSpec'; got %+v", suite)
+	}
+	if suite.Properties["framework"] != "hspec" {
+		t.Errorf("framework=%q want hspec", suite.Properties["framework"])
+	}
+	// 2 it + 1 specify = 3 examples.
+	if suite.Properties["example_count"] != "3" {
+		t.Errorf("example_count=%q want 3", suite.Properties["example_count"])
+	}
+	// Stem-affinity TESTS edge to the tested module (UserSpec → User).
+	hasTests := false
+	for _, r := range suite.Relationships {
+		if r.Kind == string(types.RelationshipKindTests) && r.ToID == "User" {
+			hasTests = true
+		}
+	}
+	if !hasTests {
+		t.Errorf("expected TESTS edge from suite to 'User'; got %+v", suite.Relationships)
+	}
+}
+
+// TestHspec_ExampleLessNoEmit is the honest guard: a spec module with describe
+// blocks but no `it`/`specify` examples exercises nothing → no suite.
+func TestHspec_ExampleLessNoEmit(t *testing.T) {
+	src := `module EmptySpec where
+import Test.Hspec
+spec = describe "nothing yet" $ return ()
+`
+	ents := runHaskell(t, src, "test/EmptySpec.hs")
+	for _, e := range ents {
+		if e.Subtype == "test_suite" {
+			t.Fatalf("example-less spec must not emit a suite; got %q", e.Name)
+		}
+	}
+}

--- a/internal/extractors/haskell/extractor.go
+++ b/internal/extractors/haskell/extractor.go
@@ -133,7 +133,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	if len(file.Content) == 0 {
 		return nil, nil
 	}
-	out := extractHaskell(string(file.Content), file.Path)
+	src := string(file.Content)
+	out := extractHaskell(src, file.Path)
+	// #5373: framework-aware records alongside the structural base.
+	out = append(out, extractPersistentEntities(src, file.Path)...)
+	out = append(out, extractHspecSuite(src, file.Path)...)
 	extractor.TagRelationshipsLanguage(out, "haskell")
 	extractor.TagEntitiesLanguage(out, "haskell")
 	return out, nil


### PR DESCRIPTION
Closes the biggest "serious production language with zero framework records" gap. Bootstrap epic #5360 (Group A), issue #5373. Go-only, heuristic (no bundled grammar — not blocked).

## Web frameworks → canonical `http_endpoint_definition`
New engine synthesizer `internal/engine/http_endpoint_haskell.go`, wired into the new `case "haskell"` of `http_endpoint_synthesis.go` + `synthesisSupportsLanguage`. Emits in the SAME shape axum/Vapor/Kemal/Clojure emit, so the shared resolver and the e2e route-test linker (#4351) light up for Haskell.

| Framework | endpoint_synthesis | notes |
|---|---|---|
| **Scotty** | full | `get "/users/:id" $ do …` verb routes; `:id` colon-params. Interpolated paths dropped (honest). |
| **Yesod** | full | `[parseRoutes\| /user/#UserId UserR GET POST \|]` quasiquote table; `#Type`/`*Type` typed captures → `{param}`; one endpoint per declared verb. URL-interpolation/subsite forms excluded. |
| **Servant** | partial | inline `:>`-chain type-level API; `Capture "id" Int` → `{id}`; `:<\|>` alternation. Cross-declaration `type`-alias composition (`type API = UserAPI :<\|> ItemAPI`) is the documented exclusion. |

New `httproutes` Framework consts (Scotty/Yesod/Servant) reuse the colon-param canonicaliser.

## Build manifests
`internal/extractors/cross/manifest/cabal.go` (mirrors the rockspec/nimble pattern):
- `*.cabal` — `build-depends:` across library/executable/test-suite/benchmark stanzas (comma+newline lists); test-suite/benchmark deps flagged `is_dev`.
- `package.yaml` — hpack `dependencies:` YAML list + `tests:`/`benchmarks:` blocks (dev).
- `stack.yaml` — `extra-deps:` as pinned `kind=locked` (`<name>-<version>` + git `github:`/`git:` source pins).

Suffix/exact-name dispatched to package managers `cabal`/`hpack`/`stack`; emits `DEPENDS_ON` + `DEPENDS_ON_PACKAGE` + SBOM package nodes like every other ecosystem. The GHC `base` floor is kept as a real edge (mirrors nimble `nim` / luarocks `lua`).

## persistent ORM (partial)
`internal/extractors/haskell/depth.go`: `[persistLowerCase\| … \|]` / `[persistUpperCase\| … \|]` entity blocks → one `orm_model` SCOPE.Component per entity with a `MAPS_TO` edge to the snake_case table (`BlogPost`→`blog_post`) + the field list — the same `(orm_model, table_name)` contract the cross-language ormlink sentinel uses. Honest partial: SQL field types / nullability and dedicated FK edges are follow-ups (FKs recorded as plain fields).

## hspec testing (full target_extraction)
`describe`/`context`/`it`/`specify` blocks → one `test_suite` per `*Spec.hs` carrying `example_count` + a stem-affinity `TESTS` edge to the tested module (`UserSpec`→`User`). Example-less specs emit nothing.

## Registry + docs (same PR)
6 new records (scotty/yesod/servant frameworks, persistent ORM, cabal package-manager, hspec test). Only genuinely-implemented cells flipped (honest partials labelled with their exclusions); lane-backfilled. `coverage validate` → **0 errors**, `fmt --check` canonical, docs regenerated.

## Validation
Per-capability table-driven tests on real fixtures (not stubs): `http_endpoint_haskell_test.go`, `cabal_test.go` (`*.cabal`/`stack.yaml`/`package.yaml`), `depth_test.go` (persistent + hspec). Full `internal/engine`, `internal/extractors/cross/manifest`, `internal/extractors/haskell`, `internal/types`, `tools/coverage` suites green; `go vet` clean.

Refs #5360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)