### PR TITLE
feat(ocaml): bootstrap framework/tool records — Dune/opam + Dream + Caqti + alcotest (#5374)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 112 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2
+**Total**: 113 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **OCaml**: 1 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -85,6 +85,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [multi](../by-language/multi.md) | [Dockerfile](../detail/build.dockerfile.md) | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | 🔴 | 🟢 | |
+| [OCaml](../by-language/ocaml.md) | [alcotest (OCaml testing)](../detail/test.alcotest.md) | 🟢 | ✅ | |
 | [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | 🟢 | |
 | [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | 🟢 | |
 | [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | ✅ | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 259 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
+**Total**: 260 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **OCaml**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -95,6 +95,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [lua](../by-language/lua.md) | [Lapis](../detail/lang.lua.framework.lapis.md) | 🟡 3/7 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟡 3/7 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
 | [nim](../by-language/nim.md) | [Jester / Prologue (Nim HTTP)](../detail/lang.nim.framework.jester.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🔴 0/24 | 🟡 1/13 | |
+| [OCaml](../by-language/ocaml.md) | [Dream (OCaml HTTP)](../detail/lang.ocaml.framework.dream.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
 | [php](../by-language/php.md) | [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 4/7 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/12 | |
 | [php](../by-language/php.md) | [API Platform GraphQL](../detail/lang.php.framework.api-platform-graphql.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/13 | |
 | [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 185 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **dart**: 6 · **elixir**: 10 · **go**: 17 · **groovy**: 1 · **haskell**: 1 · **java**: 15 · **JS/TS**: 20 · **kotlin**: 7 · **nim**: 4 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
+**Total**: 186 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **dart**: 6 · **elixir**: 10 · **go**: 17 · **groovy**: 1 · **haskell**: 1 · **java**: 15 · **JS/TS**: 20 · **kotlin**: 7 · **nim**: 4 · **OCaml**: 1 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -128,6 +128,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [nim](../by-language/nim.md) | [Debby (Nim ORM)](../detail/lang.nim.orm.debby.md) | 🟡 8/9 | |
 | [nim](../by-language/nim.md) | [Norm (Nim ORM)](../detail/lang.nim.orm.norm.md) | 🟢 8/8 | |
 | [nim](../by-language/nim.md) | [ormin (Nim compile-time ORM)](../detail/lang.nim.orm.ormin.md) | 🟡 5/8 | |
+| [OCaml](../by-language/ocaml.md) | [Caqti (OCaml DB)](../detail/lang.ocaml.orm.caqti.md) | 🟡 1/11 | |
 | [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/4 | |
 | [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/11 | |
 | [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/11 | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 27 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
+**Total**: 28 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -27,6 +27,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [lua](../by-language/lua.md) | [LuaRocks](../detail/lang.lua.tool.luarocks.md) | — | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Dependency hygiene (used / unused / phantom)](../detail/analysis.dependency-hygiene.md) | ✅ | — | — | |
 | [nim](../by-language/nim.md) | [nimble (Nim package manager)](../detail/lang.nim.tool.nimble.md) | — | — | ✅ | |
+| [OCaml](../by-language/ocaml.md) | [Dune / opam (OCaml build)](../detail/lang.ocaml.tool.dune.md) | — | — | ✅ | |
 | [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | |
 | [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | 🟢 | ✅ | |

--- a/docs/coverage/by-language/ocaml.md
+++ b/docs/coverage/by-language/ocaml.md
@@ -1,12 +1,46 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # OCaml
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 1 · **Tools**: 2 · **ORMs**: 1 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/ocaml/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.ocaml.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Frameworks
+
+
+### Backend HTTP
+
+| Name | Routing | Auth | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|---|---|
+| [Dream (OCaml HTTP)](../detail/lang.ocaml.framework.dream.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
+
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Dune / opam (OCaml build)](../detail/lang.ocaml.tool.dune.md) | — | — | — | ✅ | — | |
+| [alcotest (OCaml testing)](../detail/test.alcotest.md) | 🟢 | — | — | — | ✅ | |
+
+## ORMs
+
+
+### ORM / Data Mapper
+
+| Name | Other capabilities | Notes |
+|---|---|---|
+| [Caqti (OCaml DB)](../detail/lang.ocaml.orm.caqti.md) | 🟡 1/11 | |

--- a/docs/coverage/detail/lang.ocaml.framework.dream.md
+++ b/docs/coverage/detail/lang.ocaml.framework.dream.md
@@ -1,0 +1,132 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ocaml.framework.dream` — Dream (OCaml HTTP)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [OCaml](../by-language/ocaml.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** Backend HTTP
+- **Capability cells:** 50
+
+## Capabilities
+
+
+### Routing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Endpoint deprecation versioning | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint pagination posture | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint response codes | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Endpoint synthesis | ✅ `full` | `2026-06-24` | 5374 | `internal/engine/httproutes/canonicalize.go` | synthesizeDreamRoutes scans OCaml source for Dream verb routes (Dream.get/post/put/delete/patch "/path" handler) with a leading string-literal path, canonicalising :id colon-params via FrameworkDream into the shared {param} form and emitting one http_endpoint_definition each. Gated by dreamHasRoute (Dream. marker + verb pre-filter). Honest exclusion: interpolated/variable (non string-literal) paths are dropped; Dream.scope prefix grouping is not threaded (route emitted with its own inline literal). |
+| Handler attribution | 🟢 `partial` | `2026-06-24` | 5374 | `internal/engine/http_endpoint_dream.go` | Synthesised endpoints carry a Controller handler kind so ResolveHTTPEndpointHandlers binds an IMPLEMENTS edge when a same-named handler is resolvable. Dream handlers are passed as bare function refs after the path literal; a named-handler edge is bound only where a same-named function exists - honest partial. |
+| Route extraction | ✅ `full` | `2026-06-24` | 5374 | `internal/engine/httproutes/canonicalize.go` | Static Dream verb+path routes recovered by synthesizeDreamRoutes (#5374); interpolated/variable paths dropped (honest, see endpoint_synthesis). |
+| Websocket route extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### View
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| View rendering | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Auth
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Auth coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Validation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DTO extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request validation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Middleware
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Middleware coverage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Rate limit stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Schema
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Type graph extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### DI
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DI binding extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI injection point | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DI scope resolution | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Observability
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Log extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Metric extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Trace extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request sink dataflow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ocaml.framework.dream ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ocaml.orm.caqti.md
+++ b/docs/coverage/detail/lang.ocaml.orm.caqti.md
@@ -1,0 +1,58 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ocaml.orm.caqti` — Caqti (OCaml DB)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [OCaml](../by-language/ocaml.md)
+- **Category:** [orm](../by-category/orm.md)
+- **Subcategory:** ORM / Data Mapper
+- **Capability cells:** 11
+
+## Capabilities
+
+
+### Models
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Model extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Model lifecycle extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Relationships
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Association extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Foreign key extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Lazy loading recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Relationship extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Queries
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Query attribution | 🟢 `partial` | `2026-06-24` | 5374 | `internal/extractors/ocaml/extractor.go` | extractCaqtiQueries recognises Caqti query definitions via the Caqti_request.Infix arity operators and ppx_rapper quotations, emitting one SCOPE.Operation(subtype=db_query) per query with db_library=caqti, query_verb and the SQL signature. A SQL verb is required (honest reject of non-SQL strings). Honest partial: typed row encoder/decoder spec, connection-module dispatch (Db.exec/find) and the bound table/model graph are not modelled. Proven by TestCaqti_InfixQueries + TestCaqti_Rapper. |
+
+### Migrations
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Migration parsing | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Migration schema ops | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Transactions
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Transaction function stamping | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ocaml.orm.caqti ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.ocaml.tool.dune.md
+++ b/docs/coverage/detail/lang.ocaml.tool.dune.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.ocaml.tool.dune` — Dune / opam (OCaml build)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [OCaml](../by-language/ocaml.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5374 | `internal/extractors/cross/manifest/extractor.go` | Two OCaml manifest shapes parsed (#5374): *.opam (parseOpam mines the depends: list of quoted package names with {>= "x"} version formulas; a {with-test}/{with-doc} filter flags is_dev; depopts: entries are kind=optional; first version literal of the formula is recorded) and dune-project (parseDuneProject reads the inline (package (depends ...)) generate_opam_files stanza: bare atoms, (caqti (>= 1.9.0)) constrained sub-lists, :with-test dev filters). The ocaml compiler-version floor is kept as a real edge (mirrors nimble nim / luarocks lua). Suffix/exact-name dispatched in IsManifest/detectPackageManager/dispatchParser to package managers opam/dune; emits DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes like every other ecosystem. Honest scope: opam version formula conjunctions/filters reduced to the first version literal; pin-depends:/conflicts:/available: not modelled; plain dune (libraries ...) lists are NOT mined (internal+external indistinguishable; that surface is the source-graph IMPORTS). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.ocaml.tool.dune ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.alcotest.md
+++ b/docs/coverage/detail/test.alcotest.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.alcotest` — alcotest (OCaml testing)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [OCaml](../by-language/ocaml.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🟢 `partial` | `2026-06-24` | 5374 | `internal/extractors/ocaml/depth_test.go` | Each alcotest suite carries a stem-affinity TESTS edge to the module its filename names (math_test->math). Honest partial: direct-call resolution from inside the test_case body and e2e route TESTS edges (test->HTTP endpoint) are not yet wired for OCaml - follow-up. |
+| Target extraction | ✅ `full` | `2026-06-24` | 5374 | `internal/extractors/ocaml/depth_test.go` | alcotest test_case "label" cases (alcotestCaseRE) are lifted into one SCOPE.Operation(subtype=test_suite) per OCaml test file (under a test/tests dir or named *_test.ml / test_*.ml, OR importing Alcotest), carrying example_count and framework=alcotest. A real Alcotest marker is required so a non-alcotest test_case helper never fabricates a suite; a case-less file emits nothing (honest). A stem-affinity TESTS edge links the suite to the tested module (math_test.ml->math). Proven by TestAlcotest_Suite + the two negative guards. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.alcotest ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (27 active · 12 placeholder) · **Frameworks**: 259 · **ORMs**: 185 · **Tools**: 139 · **Other**: 208
+**Languages**: 39 (28 active · 11 placeholder) · **Frameworks**: 260 · **ORMs**: 186 · **Tools**: 141 · **Other**: 208
 
 ## Coverage by language
 
@@ -29,6 +29,7 @@
 | [erlang](by-language/erlang.md) | 1 | 5 | 0 | 2 |
 | [groovy](by-language/groovy.md) | 1 | 1 | 1 | 1 |
 | [nim](by-language/nim.md) | 1 | 1 | 4 | 1 |
+| [OCaml](by-language/ocaml.md) | 1 | 2 | 1 | 0 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 5 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 5 |
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
@@ -74,7 +75,6 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Elm](by-language/elm.md) |
 | [Idris](by-language/idris.md) |
 | [Lisp](by-language/lisp.md) |
-| [OCaml](by-language/ocaml.md) |
 | [Pony](by-language/pony.md) |
 | [ReScript](by-language/rescript.md) |
 | [ReasonML](by-language/reasonml.md) |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 259 frameworks · 139 tools · 185 ORMs · 208 other
+Total: 260 frameworks · 141 tools · 186 ORMs · 208 other

--- a/internal/engine/http_endpoint_dream.go
+++ b/internal/engine/http_endpoint_dream.go
@@ -1,0 +1,107 @@
+// http_endpoint_dream.go — OCaml Dream web route registration → canonical
+// http_endpoint_definition synthesis (#5374, the OCaml slice of the low-ranked-
+// language bootstrap epic #5360).
+//
+// Background
+// ----------
+// The OCaml base extractor (internal/extractors/ocaml/extractor.go) is a
+// regex-based structural extractor: it mines modules, let/let-rec functions,
+// type declarations and IMPORTS/CALLS/CONTAINS edges, but has NO web-framework
+// awareness — Dream `Dream.get "/users/:id" handler` route registrations are not
+// recognised as HTTP endpoints, so no `http_endpoint_definition` entity is ever
+// produced for OCaml. The shared endpoint resolver
+// (ResolveHTTPEndpointHandlers) and the language-agnostic e2e route-test linker
+// (linkE2ERouteTestsToEndpoints, #4351) both key off
+// `http_endpoint_definition` + `path`, so an OCaml route could never surface.
+//
+// This pass closes the PRODUCER-side gap: it emits one canonical
+// http_endpoint_definition per statically-known Dream route, in the SAME shape
+// the axum / Scotty / Kemal / Vapor synthesizers emit.
+//
+// Dream route syntax
+// ------------------
+// Dream (https://aantron.github.io/dream/) registers routes by passing a list of
+// verb-route values to `Dream.router`:
+//
+//	Dream.router [
+//	  Dream.get  "/"            home_handler;
+//	  Dream.get  "/users/:id"   show_user;
+//	  Dream.post "/users"       create_user;
+//	  Dream.delete "/users/:id" delete_user;
+//	]
+//
+// Dream uses the Sinatra/Express-style `:name` colon path-parameter convention,
+// canonicalised through FrameworkDream into the shared `{param}` form.
+//
+// Honest exclusions (no fabricated routes)
+// ----------------------------------------
+//   - Interpolated / variable / non-literal paths (`Dream.get path handler`,
+//     `Dream.get (prefix ^ "/x") h`) — the path must be a STRING LITERAL.
+//   - `Dream.scope "/api" middlewares [ ... ]` prefix grouping is NOT threaded:
+//     a route declared inside a scope is emitted with its OWN literal path, not
+//     the scope-prefixed path. Scope-prefix composition is a documented
+//     follow-up (mirrors the Crystal/Nim/Haskell bootstraps, which likewise emit
+//     the inline literal only).
+//   - WebSocket routes (`Dream.get "/ws" (Dream.websocket ...)`) are still HTTP
+//     GET upgrades and ARE emitted (the verb is a real GET); the websocket
+//     handler body is not inspected.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/engine/httproutes"
+)
+
+// dreamRouteRe matches a Dream verb route registration with a leading
+// string-literal path:
+//
+//	Dream.get  "/users/:id" handler
+//	Dream.post "/users"     handler
+//
+// Group 1 is the verb; group 2 is the path literal. The `Dream.` qualifier is
+// required so an arbitrary `get`/`post` function is never misread.
+var dreamRouteRe = regexp.MustCompile(
+	`\bDream\.(get|post|put|delete|patch|options|head)\s+"([^"\n\r]*)"`,
+)
+
+// dreamHasRoute is a fast pre-filter: the file must reference the Dream module
+// and at least one verb-route registration to be worth scanning.
+func dreamHasRoute(content string) bool {
+	if !strings.Contains(content, "Dream.") {
+		return false
+	}
+	return strings.Contains(content, "Dream.get ") ||
+		strings.Contains(content, "Dream.post ") ||
+		strings.Contains(content, "Dream.put ") ||
+		strings.Contains(content, "Dream.delete ") ||
+		strings.Contains(content, "Dream.patch ") ||
+		strings.Contains(content, "Dream.options ") ||
+		strings.Contains(content, "Dream.head ")
+}
+
+// synthesizeDreamRoutes scans an OCaml source file for Dream verb routes and
+// emits one http_endpoint_definition per statically-known (verb, path).
+func synthesizeDreamRoutes(content string, emit emitFn) {
+	if !dreamHasRoute(content) {
+		return
+	}
+	for _, m := range dreamRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		raw := strings.TrimSpace(m[2])
+		if raw == "" {
+			continue
+		}
+		if !strings.HasPrefix(raw, "/") {
+			raw = "/" + raw
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkDream, raw)
+		if canonical == "" {
+			continue
+		}
+		emit(strings.ToUpper(m[1]), canonical, "dream", "Controller", "")
+	}
+}

--- a/internal/engine/http_endpoint_dream_test.go
+++ b/internal/engine/http_endpoint_dream_test.go
@@ -1,0 +1,77 @@
+package engine
+
+import "testing"
+
+// TestDream_BasicRoutes covers the common Dream verb shapes inside a
+// Dream.router list: Dream.get "/" / Dream.post "/users".
+func TestDream_BasicRoutes(t *testing.T) {
+	src := `
+let () =
+  Dream.run
+  @@ Dream.logger
+  @@ Dream.router [
+       Dream.get "/" (fun _ -> Dream.html "home");
+       Dream.get "/users" list_users;
+       Dream.post "/users" create_user;
+     ]
+`
+	ids, _ := runDetect(t, "ocaml", "lib/app.ml", src)
+	requireContains(t, ids, []string{
+		"http:GET:/",
+		"http:GET:/users",
+		"http:POST:/users",
+	}, "dream-basic-routes")
+}
+
+// TestDream_PathParam covers the Sinatra-style `:param` dynamic segment:
+// Dream.get "/users/:id" → GET /users/{id}.
+func TestDream_PathParam(t *testing.T) {
+	src := `
+let routes = Dream.router [
+  Dream.get "/users/:id" show_user;
+  Dream.delete "/users/:id" delete_user;
+  Dream.put "/users/:id" update_user;
+]
+`
+	ids, _ := runDetect(t, "ocaml", "lib/routes.ml", src)
+	requireContains(t, ids, []string{
+		"http:GET:/users/{id}",
+		"http:DELETE:/users/{id}",
+		"http:PUT:/users/{id}",
+	}, "dream-path-param")
+}
+
+// TestDream_NonWebFileIgnored is the negative guard: an OCaml file with no
+// Dream marker that happens to call a function named `get` must not synthesize
+// an endpoint.
+func TestDream_NonWebFileIgnored(t *testing.T) {
+	src := `
+module Cache = struct
+  let lookup store key = get store key
+end
+`
+	ids, _ := runDetect(t, "ocaml", "lib/cache.ml", src)
+	for _, id := range ids {
+		if id == "http:GET:/store" || id == "http:GET:/key" {
+			t.Fatalf("non-web file must not synthesize an endpoint; got %v", ids)
+		}
+	}
+}
+
+// TestDream_VariablePathExcluded confirms the honest exclusion: a non-literal
+// (variable) path argument is NOT synthesized.
+func TestDream_VariablePathExcluded(t *testing.T) {
+	src := `
+let mount prefix handler =
+  Dream.router [ Dream.get prefix handler ]
+let real = Dream.router [ Dream.get "/health" health ]
+`
+	ids, _ := runDetect(t, "ocaml", "lib/dyn.ml", src)
+	// The literal route IS emitted; the variable-path one is not.
+	requireContains(t, ids, []string{"http:GET:/health"}, "dream-literal-route")
+	for _, id := range ids {
+		if id == "http:GET:prefix" || id == "http:GET:/prefix" {
+			t.Fatalf("variable-path route must not be synthesized; got %v", ids)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -154,6 +154,12 @@ func synthesisSupportsLanguage(lang string) bool {
 	// Files without a Haskell web marker are no-ops inside the synthesizers.
 	case "haskell":
 		return true
+	// #5374 (bootstrap epic #5360): OCaml Dream producer-side route synthesis —
+	// `Dream.get "/path" handler` verb registrations have no compiled YAML
+	// rules, so allow OCaml through for synthesizeDreamRoutes. Files without a
+	// `Dream.` web marker are no-ops inside the synthesizer.
+	case "ocaml":
+		return true
 	// #4749 (epic #4615 tail): Erlang Cowboy producer-side route synthesis —
 	// `cowboy_router:compile([{'_', [{"/path", handler, []}]}])` dispatch tables
 	// have no compiled YAML rules, so allow Erlang through for synthesizeCowboy.
@@ -1473,6 +1479,15 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		synthesizeScottyRoutes(string(content), emit)
 		synthesizeYesodRoutes(string(content), emit)
 		synthesizeServantRoutes(string(content), emit)
+	case "ocaml":
+		// Producer side (#5374, bootstrap epic #5360): OCaml Dream web route
+		// registrations — `Dream.get "/users/:id" handler` verb routes →
+		// canonical http_endpoint_definition, in the same shape
+		// axum/Scotty/Kemal/Vapor emit, so the shared resolver and the e2e
+		// route-test linker (#4351) light up for OCaml. The base ocaml extractor
+		// stays structural-only; this pass adds the canonical definitions the
+		// coverage substrate keys off.
+		synthesizeDreamRoutes(string(content), emit)
 	case "yaml", "json":
 		// Producer side (#3628, area #16): OpenAPI 3.x / Swagger 2.0 spec
 		// files declare the HTTP API surface as ground-truth. Each

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -292,6 +292,10 @@ const (
 	// NORMALISES each `Capture "name" _` to the Express-style `:name` form before
 	// canonicalisation, so it reuses canonicalizeColonParams.
 	FrameworkServant = "servant"
+	// FrameworkDream (#5374) — OCaml Dream `Dream.get "/users/:id" handler` verb
+	// routes. Dream uses the Sinatra/Express-style `:name` colon path-parameter
+	// convention, so canonicalisation reuses canonicalizeColonParams.
+	FrameworkDream = "dream"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -353,7 +357,7 @@ func Canonicalize(framework, raw string) string {
 		FrameworkRobyn, FrameworkPlug, FrameworkCowboy,
 		FrameworkLapis, FrameworkOpenResty, FrameworkVapor, FrameworkClojure,
 		FrameworkKemal, FrameworkRatpack, FrameworkGrape, FrameworkRoda,
-		FrameworkScotty, FrameworkYesod, FrameworkServant:
+		FrameworkScotty, FrameworkYesod, FrameworkServant, FrameworkDream:
 		out = canonicalizeColonParams(raw)
 	case FrameworkGiraffe:
 		// Giraffe `routef "/users/%i"` printf placeholders → `{}` first, then

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -196,6 +196,9 @@ var exactManifestNames = map[string]bool{
 	// The *.cabal Cabal package description is suffix-dispatched below.
 	"stack.yaml":   true,
 	"package.yaml": true,
+	// OCaml — Dune project file (inline (package (depends ...)) stanzas). The
+	// *.opam package manifest is suffix-dispatched below (#5374).
+	"dune-project": true,
 }
 
 // IsManifest returns true when filePath names a supported manifest file.
@@ -229,6 +232,11 @@ func IsManifest(filePath string) bool {
 	// *.cabal — Haskell Cabal package description (the package name is the
 	// file's base name, e.g. mylib.cabal, so it is matched by extension; #5373).
 	if strings.HasSuffix(basename, ".cabal") {
+		return true
+	}
+	// *.opam — OCaml opam package manifest (the package name is the file's base
+	// name, e.g. my-service.opam, so it is matched by extension; #5374).
+	if strings.HasSuffix(basename, ".opam") {
 		return true
 	}
 	return false
@@ -283,6 +291,8 @@ func detectPackageManager(filePath string) string {
 		// Haskell — Stack (extra-deps) + hpack (package.yaml)
 		"stack.yaml":   "stack",
 		"package.yaml": "hpack",
+		// OCaml — Dune project file
+		"dune-project": "dune",
 	}
 	basename := filepath.Base(filePath)
 	if v, ok := pm[basename]; ok {
@@ -307,6 +317,10 @@ func detectPackageManager(filePath string) string {
 	// *.cabal → cabal (Haskell package description)
 	if strings.HasSuffix(basename, ".cabal") {
 		return "cabal"
+	}
+	// *.opam → opam (OCaml package manifest)
+	if strings.HasSuffix(basename, ".opam") {
+		return "opam"
 	}
 	return "unknown"
 }
@@ -1931,6 +1945,8 @@ var parsers = map[string]parserFn{
 	// dispatched below).
 	"stack.yaml":   parseStackYaml,
 	"package.yaml": parsePackageYaml,
+	// OCaml — Dune project file (*.opam is suffix-dispatched below).
+	"dune-project": parseDuneProject,
 }
 
 func dispatchParser(filePath, source string) (string, []dep) {
@@ -1958,6 +1974,10 @@ func dispatchParser(filePath, source string) (string, []dep) {
 	// *.cabal — Haskell Cabal package description.
 	if strings.HasSuffix(basename, ".cabal") {
 		return "cabal", parseCabal(source)
+	}
+	// *.opam — OCaml opam package manifest.
+	if strings.HasSuffix(basename, ".opam") {
+		return "opam", parseOpam(source)
 	}
 	// Makefile — only an erlang.mk build when it includes erlang.mk / declares
 	// PROJECT (requireSignal=true); a plain Makefile is a no-op.

--- a/internal/extractors/cross/manifest/ocaml.go
+++ b/internal/extractors/cross/manifest/ocaml.go
@@ -1,0 +1,324 @@
+// ocaml.go — OCaml opam / Dune package & build manifest parsers (#5374,
+// epic #5360).
+//
+// The OCaml ecosystem declares dependencies across two manifest shapes, both
+// parsed here:
+//
+//	*.opam — the opam package manifest (the canonical OCaml package
+//	  description). Runtime dependencies are declared in a `depends:` field whose
+//	  value is a bracketed list of quoted package names, each optionally followed
+//	  by a `{ ... }` version-and-filter formula:
+//
+//	    opam-version: "2.0"
+//	    name: "my-service"
+//	    depends: [
+//	      "ocaml" {>= "4.14"}
+//	      "dune" {>= "3.0"}
+//	      "dream"
+//	      "caqti" {>= "1.9.0"}
+//	      "alcotest" {with-test}
+//	    ]
+//	    depopts: [ "lwt_ssl" ]
+//
+//	  A dependency carrying a `{with-test}` (or `{with-doc}`) filter is a
+//	  dev/test-only dependency and is flagged is_dev. `depopts:` lists optional
+//	  dependencies (kind="optional"). The `ocaml` compiler-version floor is KEPT
+//	  as a real edge (mirrors the nimble `nim` / luarocks `lua` interpreter-floor
+//	  treatment, #5365/#5367). The version inside the first `{ ... }` formula
+//	  (the constraint preceding any `&`/filter terms) is recorded as the version.
+//
+//	dune-project — the Dune project file. When the project uses Dune's
+//	  generate_opam_files workflow, packages are declared inline with `(package
+//	  (name ...) (depends pkg1 pkg2 (pkg3 (>= 1.0)) ...))` stanzas; the
+//	  `(depends ...)` list is the dependency surface. A bare `(lang dune 3.0)`
+//	  project with no inline `(package ...)` declares no deps here (the *.opam
+//	  file carries them) and is a no-op.
+//
+// Honest scope: only the DECLARED dependency surface is recovered. opam version
+// FORMULAS are reduced to the first version literal (conjunction/disjunction of
+// constraints and non-version filter terms like `{build}` are not threaded);
+// opam `pin-depends:`, `conflicts:` and `available:` os-filters are not modelled;
+// Dune `(libraries ...)` stanzas in plain `dune` files name INTERNAL+external
+// libraries indistinguishably and are intentionally NOT mined as package deps
+// (that surface belongs to the source-graph IMPORTS, not the manifest dep
+// graph). opam has no separate lockfile in wide use, so only manifest_parsing is
+// provided.
+package manifest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Parser: *.opam
+// ---------------------------------------------------------------------------
+
+// opamDependsFieldRE matches the start of a `depends:` / `depopts:` field and
+// captures the field key so the value list (which follows in `[ ... ]`) can be
+// classified runtime vs optional. The field must start at a line boundary so a
+// `depends` substring inside a string/comment never opens a match.
+var opamDependsFieldRE = regexp.MustCompile(`(?m)^(depends|depopts)\s*:\s*\[`)
+
+// opamDepEntryRE matches one dependency entry inside a depends list: a quoted
+// package name optionally followed by a `{ ... }` version/filter formula.
+//
+//	"dune" {>= "3.0"}        → name=dune,     formula=">= "3.0""
+//	"dream"                  → name=dream,    formula=""
+//	"alcotest" {with-test}   → name=alcotest, formula="with-test"
+//
+// Group 1 is the package name; group 2 is the formula body (without braces) or
+// empty. opam package names are letters, digits, `_`, `-` and `+`.
+var opamDepEntryRE = regexp.MustCompile(
+	`"([A-Za-z0-9][A-Za-z0-9_+-]*)"\s*(?:\{([^}]*)\})?`)
+
+// opamFormulaVersionRE pulls the first quoted version literal out of a formula
+// body (`>= "4.14"` → `4.14`), prefixed with the comparison operator if present.
+var opamFormulaVersionRE = regexp.MustCompile(`([<>=~!]*=?)\s*"([^"]+)"`)
+
+// parseOpam parses a `*.opam` manifest and returns its declared dependencies.
+// `depends:` entries are runtime (a `{with-test}`/`{with-doc}` filter flags them
+// is_dev); `depopts:` entries are optional (kind="optional"). First declaration
+// of a name wins.
+func parseOpam(source string) []dep {
+	var out []dep
+	seen := map[string]bool{}
+
+	for _, field := range opamDependsFieldRE.FindAllStringSubmatchIndex(source, -1) {
+		// field[2:4] is the field-key capture; field[1] is the offset just
+		// after the opening `[`.
+		key := source[field[2]:field[3]]
+		body := opamListBody(source, field[1])
+		optional := key == "depopts"
+		for _, dm := range opamDepEntryRE.FindAllStringSubmatch(body, -1) {
+			name := dm[1]
+			if name == "" || seen[name] {
+				continue
+			}
+			formula := dm[2]
+			isDev := strings.Contains(formula, "with-test") || strings.Contains(formula, "with-doc")
+			kind := "runtime"
+			switch {
+			case optional:
+				kind = "optional"
+			case isDev:
+				kind = "dev"
+			}
+			seen[name] = true
+			out = append(out, dep{
+				name:    name,
+				version: opamFormulaVersion(formula),
+				isDev:   isDev,
+				kind:    kind,
+			})
+		}
+	}
+	return out
+}
+
+// opamListBody returns the text of a bracketed list starting just after its
+// opening `[` (at startAfter), up to the matching `]`, honouring nested
+// brackets (a version formula `{ ... }` never contains `]`, but defensive
+// bracket-depth tracking keeps the scan correct for nested `[ ... ]` filters).
+func opamListBody(source string, startAfter int) string {
+	depth := 1
+	for i := startAfter; i < len(source); i++ {
+		switch source[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return source[startAfter:i]
+			}
+		}
+	}
+	return source[startAfter:]
+}
+
+// opamFormulaVersion extracts the first version literal from an opam version
+// formula body (the part before any `&`/filter conjunction). A `with-test`-only
+// filter has no version and yields "".
+func opamFormulaVersion(formula string) string {
+	m := opamFormulaVersionRE.FindStringSubmatch(formula)
+	if m == nil {
+		return ""
+	}
+	op := strings.TrimSpace(m[1])
+	ver := strings.TrimSpace(m[2])
+	if op != "" {
+		return op + " " + ver
+	}
+	return ver
+}
+
+// ---------------------------------------------------------------------------
+// Parser: dune-project
+// ---------------------------------------------------------------------------
+
+// duneProjectHasDepends is a fast pre-filter: a dune-project with no `(depends`
+// sexp declares no inline package deps (they live in the *.opam file) and is a
+// no-op for the manifest dep-graph.
+var duneProjectHasDepends = "(depends"
+
+// duneNonDepAtoms are leading atoms inside a `(depends ...)` body that are NOT
+// package names (constraint operators / filter keywords that can appear as the
+// head of a constrained sub-list or filter).
+var duneNonDepAtoms = map[string]bool{
+	">=": true, "<=": true, "=": true, ">": true, "<": true, "<>": true,
+	"and": true, "or": true, ":with-test": true, ":with-doc": true,
+	":build": true, ":dev": true, ":post": true, ":pinned": true,
+}
+
+// parseDuneProject parses a `dune-project` file and returns the declared
+// dependencies of any inline `(package (name ...) (depends ...))` stanza (the
+// generate_opam_files workflow). A `with-test`/`with-doc`-filtered dep is
+// flagged is_dev. A dune-project with no inline `(depends ...)` is a no-op.
+func parseDuneProject(source string) []dep {
+	if !strings.Contains(source, duneProjectHasDepends) {
+		return nil
+	}
+	var out []dep
+	seen := map[string]bool{}
+
+	for _, body := range duneDependsBodies(source) {
+		for _, entry := range duneDependsEntries(body) {
+			name := entry.name
+			if name == "" || seen[name] || duneNonDepAtoms[name] {
+				continue
+			}
+			seen[name] = true
+			kind := "runtime"
+			if entry.isDev {
+				kind = "dev"
+			}
+			out = append(out, dep{
+				name:    name,
+				version: entry.version,
+				isDev:   entry.isDev,
+				kind:    kind,
+			})
+		}
+	}
+	return out
+}
+
+// duneDependsBodies returns the body text of every `(depends ...)` sexp in a
+// dune-project, balanced on parens.
+func duneDependsBodies(source string) []string {
+	var bodies []string
+	const marker = "(depends"
+	for {
+		idx := strings.Index(source, marker)
+		if idx < 0 {
+			break
+		}
+		// Walk from the opening paren to its matching close.
+		depth := 0
+		end := -1
+		for i := idx; i < len(source); i++ {
+			switch source[i] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					end = i
+				}
+			}
+			if end >= 0 {
+				break
+			}
+		}
+		if end < 0 {
+			bodies = append(bodies, source[idx+len(marker):])
+			break
+		}
+		bodies = append(bodies, source[idx+len(marker):end])
+		source = source[end+1:]
+	}
+	return bodies
+}
+
+// duneDepEntry is one parsed (depends ...) entry.
+type duneDepEntry struct {
+	name    string
+	version string
+	isDev   bool
+}
+
+// duneDependsEntries mines one `(depends ...)` body for dependency entries.
+// A bare atom (`dream`) is a dep with no version; a constrained sub-list
+// (`(caqti (>= 1.9.0))`) yields the leading atom as the name and the version
+// literal as the constraint; a `:with-test`/`:with-doc` filter term inside a
+// sub-list marks the owning dep is_dev.
+func duneDependsEntries(body string) []duneDepEntry {
+	var entries []duneDepEntry
+	i := 0
+	for i < len(body) {
+		c := body[i]
+		switch {
+		case c == '(':
+			// Constrained sub-list: read to matching close.
+			depth := 0
+			end := i
+			for j := i; j < len(body); j++ {
+				if body[j] == '(' {
+					depth++
+				} else if body[j] == ')' {
+					depth--
+					if depth == 0 {
+						end = j
+						break
+					}
+				}
+			}
+			sub := body[i+1 : end]
+			entries = append(entries, parseDuneConstrainedDep(sub))
+			i = end + 1
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		default:
+			// Bare atom.
+			start := i
+			for i < len(body) && !isDuneAtomBreak(body[i]) {
+				i++
+			}
+			atom := body[start:i]
+			entries = append(entries, duneDepEntry{name: atom})
+		}
+	}
+	return entries
+}
+
+func isDuneAtomBreak(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '(' || c == ')'
+}
+
+// parseDuneConstrainedDep parses a constrained dependency sub-list body, e.g.
+// `caqti (>= 1.9.0)` or `alcotest :with-test`.
+func parseDuneConstrainedDep(sub string) duneDepEntry {
+	fields := strings.Fields(sub)
+	if len(fields) == 0 {
+		return duneDepEntry{}
+	}
+	e := duneDepEntry{name: fields[0]}
+	if strings.Contains(sub, ":with-test") || strings.Contains(sub, ":with-doc") {
+		e.isDev = true
+	}
+	// Pull a version literal from a `(>= 1.9.0)` style constraint.
+	if m := duneVersionRE.FindStringSubmatch(sub); m != nil {
+		op := strings.TrimSpace(m[1])
+		ver := strings.TrimSpace(m[2])
+		if op != "" {
+			e.version = op + " " + ver
+		} else {
+			e.version = ver
+		}
+	}
+	return e
+}
+
+// duneVersionRE pulls an operator + version literal out of a dune constraint
+// sub-list (`(>= 1.9.0)` → op=">=", ver="1.9.0").
+var duneVersionRE = regexp.MustCompile(`([<>=~!]*=?)\s*([0-9][A-Za-z0-9_.+-]*)`)

--- a/internal/extractors/cross/manifest/ocaml_test.go
+++ b/internal/extractors/cross/manifest/ocaml_test.go
@@ -1,0 +1,144 @@
+package manifest
+
+import "testing"
+
+// realOpam is a representative *.opam manifest (shape taken from real published
+// OCaml packages). It exercises the depends: list with version formulas, a
+// {with-test} dev filter, a bare (unconstrained) dep, the `ocaml` compiler
+// floor, and a depopts: optional list.
+const realOpam = `opam-version: "2.0"
+name: "my-service"
+synopsis: "A small OCaml web service"
+maintainer: "Jane Doe <jane@example.com>"
+license: "MIT"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "dream"
+  "caqti" {>= "1.9.0"}
+  "caqti-driver-postgresql"
+  "alcotest" {with-test}
+]
+depopts: [
+  "lwt_ssl"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+`
+
+func TestOpam_RuntimeDeps(t *testing.T) {
+	deps := depEntities(runExtract(t, "my-service.opam", realOpam))
+	// 5 runtime (ocaml, dune, dream, caqti, caqti-driver-postgresql)
+	// + 1 dev (alcotest) + 1 optional (lwt_ssl) = 7.
+	if len(deps) != 7 {
+		t.Fatalf("expected 7 deps, got %d: %v", len(deps), depNames(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "opam" {
+			t.Errorf("%s: package_manager=%q want opam", d.Name, d.Properties["package_manager"])
+		}
+	}
+
+	// The ocaml compiler floor is a real runtime edge, with its constraint.
+	if d := depByName(deps, "ocaml"); d == nil {
+		t.Error("expected runtime dep 'ocaml' (compiler floor is a real edge)")
+	} else if d.Properties["version"] != ">= 4.14" {
+		t.Errorf("ocaml version=%q want '>= 4.14'", d.Properties["version"])
+	} else if d.Properties["is_dev"] != "false" {
+		t.Errorf("ocaml should be is_dev=false")
+	}
+
+	if d := depByName(deps, "caqti"); d == nil || d.Properties["version"] != ">= 1.9.0" {
+		t.Errorf("caqti version=%v want '>= 1.9.0'", d)
+	}
+
+	// A bare dep has no version.
+	if d := depByName(deps, "dream"); d == nil {
+		t.Error("expected dep 'dream'")
+	} else if d.Properties["version"] != "" {
+		t.Errorf("dream version=%q want empty (bare)", d.Properties["version"])
+	}
+
+	// alcotest carries {with-test} → dev.
+	if d := depByName(deps, "alcotest"); d == nil {
+		t.Error("expected dev dep 'alcotest'")
+	} else if d.Properties["is_dev"] != "true" {
+		t.Errorf("alcotest is_dev=%q want true ({with-test})", d.Properties["is_dev"])
+	} else if d.Properties["dependency_kind"] != "dev" {
+		t.Errorf("alcotest dependency_kind=%q want dev", d.Properties["dependency_kind"])
+	}
+
+	// depopts entry is optional.
+	if d := depByName(deps, "lwt_ssl"); d == nil {
+		t.Error("expected optional dep 'lwt_ssl'")
+	} else if d.Properties["dependency_kind"] != "optional" {
+		t.Errorf("lwt_ssl dependency_kind=%q want optional", d.Properties["dependency_kind"])
+	}
+}
+
+// realDuneProject is a dune-project using the generate_opam_files workflow with
+// an inline (package (depends ...)) stanza — bare atoms, a constrained sub-list,
+// and a :with-test dev filter.
+const realDuneProject = `(lang dune 3.0)
+(generate_opam_files true)
+
+(package
+ (name my-service)
+ (synopsis "A small OCaml web service")
+ (depends
+  ocaml
+  dune
+  dream
+  (caqti (>= 1.9.0))
+  (alcotest :with-test)))
+`
+
+func TestDuneProject_Deps(t *testing.T) {
+	deps := depEntities(runExtract(t, "dune-project", realDuneProject))
+	// 4 runtime (ocaml, dune, dream, caqti) + 1 dev (alcotest) = 5.
+	if len(deps) != 5 {
+		t.Fatalf("expected 5 deps, got %d: %v", len(deps), depNames(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "dune" {
+			t.Errorf("%s: package_manager=%q want dune", d.Name, d.Properties["package_manager"])
+		}
+	}
+	if d := depByName(deps, "caqti"); d == nil || d.Properties["version"] != ">= 1.9.0" {
+		t.Errorf("caqti version=%v want '>= 1.9.0'", d)
+	}
+	if d := depByName(deps, "dream"); d == nil {
+		t.Error("expected bare dep 'dream'")
+	}
+	if d := depByName(deps, "alcotest"); d == nil {
+		t.Error("expected dev dep 'alcotest'")
+	} else if d.Properties["is_dev"] != "true" {
+		t.Errorf("alcotest is_dev=%q want true (:with-test)", d.Properties["is_dev"])
+	}
+}
+
+// A bare dune-project with no inline (package (depends ...)) declares no deps
+// here (the *.opam file carries them) — a no-op, not a false-positive.
+func TestDuneProject_NoInlineDepends_NoOp(t *testing.T) {
+	const bare = "(lang dune 3.0)\n(name my_project)\n"
+	deps := depEntities(runExtract(t, "dune-project", bare))
+	if len(deps) != 0 {
+		t.Fatalf("expected 0 deps for a bare dune-project, got %d: %v", len(deps), depNames(deps))
+	}
+}
+
+func TestOpam_IsManifestDispatch(t *testing.T) {
+	if !IsManifest("pkgs/my-service.opam") {
+		t.Error("*.opam should be recognised as a manifest")
+	}
+	if !IsManifest("dune-project") {
+		t.Error("dune-project should be recognised as a manifest")
+	}
+	if got := detectPackageManager("my-service.opam"); got != "opam" {
+		t.Errorf("detectPackageManager(*.opam)=%q want opam", got)
+	}
+	if got := detectPackageManager("dune-project"); got != "dune" {
+		t.Errorf("detectPackageManager(dune-project)=%q want dune", got)
+	}
+}

--- a/internal/extractors/ocaml/depth.go
+++ b/internal/extractors/ocaml/depth.go
@@ -1,0 +1,215 @@
+// depth.go — framework-aware OCaml extraction: Caqti DB queries and alcotest
+// test suites (#5374, bootstrap epic #5360).
+//
+// These sit ALONGSIDE the structural base extractor (extractor.go). The base
+// extractor mines modules / let-functions / type declarations and
+// IMPORTS/CALLS/CONTAINS edges; this file adds two framework records:
+//
+//   - Caqti DB: query request definitions written with the `Caqti_request.Infix`
+//     operators (`(unit ->. unit) @:- "SQL"`, `(int ->! string) @@: "SQL"`) and
+//     the `[%rapper ...]` ppx_rapper query quotations are recognised as data-
+//     access call-sites, each emitted as one SCOPE.Operation(subtype=db_query)
+//     carrying db_library=caqti and the recovered SQL verb (SELECT/INSERT/…).
+//     This is the data-access surface the coverage Queries lane keys off.
+//
+//   - alcotest testing: `Alcotest.test_case "name" `Quick f` cases (and the
+//     `Alcotest.run "suite" [...]` driver) are lifted into one
+//     SCOPE.Operation(subtype=test_suite) per test file, carrying the example
+//     count, mirroring the Haskell hspec / Crystal spec-suite model.
+//
+// Honest scope (partial, no fabrication):
+//   - Caqti: the SQL string + leading verb are recovered; the typed
+//     row-encoder/decoder parameter spec, the connection-module dispatch
+//     (`Db.exec` / `Db.find` against a pool) and the bound table/model graph are
+//     NOT modelled — query_attribution is a documented partial.
+//   - alcotest: literal `test_case` cases inside a test file are counted; the
+//     `(group, cases)` nesting structure and QCheck property generators are not
+//     separately modelled (follow-up).
+package ocaml
+
+import (
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Caqti DB queries
+// ---------------------------------------------------------------------------
+
+// caqtiInfixRE matches a Caqti_request.Infix query operator applied to a
+// SQL string literal. The Infix operators encode the result arity:
+//
+//	(unit ->. unit)        @:- "DELETE FROM users WHERE id = ?"   (exec)
+//	(int  ->! string)      @@: "SELECT name FROM users WHERE id = ?"  (find)
+//	(unit ->* string)      ... "SELECT name FROM users"            (collect)
+//
+// The query string is the trailing string literal; capture group 1 is the SQL.
+// Both the `@:-`/`@@:`/`@/`-family operators and a plain string after a Caqti
+// arity arrow are matched by anchoring on the closing `)` of the type spec.
+var caqtiInfixRE = regexp.MustCompile(
+	`->[.!*]\s*[a-zA-Z_][a-zA-Z0-9_' ]*\)\s*[@/:.-]*\s*"([^"]*)"`)
+
+// caqtiRapperRE matches a ppx_rapper query quotation: `[%rapper get_one "SQL"]`
+// / `[%rapper execute "SQL" ...]`. Capture group 1 is the SQL string.
+var caqtiRapperRE = regexp.MustCompile(
+	`\[%rapper\s+\w+\s+"([^"]*)"`)
+
+// sqlVerbRE pulls the leading SQL verb out of a query string.
+var sqlVerbRE = regexp.MustCompile(`(?i)^\s*(select|insert|update|delete|with|create|alter|drop)\b`)
+
+// extractCaqtiQueries scans an OCaml source for Caqti query definitions and
+// emits one SCOPE.Operation(subtype=db_query) per recovered SQL query.
+func extractCaqtiQueries(src, filePath string) []types.EntityRecord {
+	if !strings.Contains(src, "Caqti") && !strings.Contains(src, "rapper") {
+		return nil
+	}
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	emit := func(sql string, pos int) {
+		sql = strings.TrimSpace(sql)
+		if sql == "" {
+			return
+		}
+		// A Caqti query string always contains a SQL verb; reject incidental
+		// matches (e.g. a non-SQL string after an arrow) honestly.
+		vm := sqlVerbRE.FindStringSubmatch(sql)
+		if vm == nil {
+			return
+		}
+		verb := strings.ToUpper(vm[1])
+		key := verb + "|" + sql
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		line := 1 + strings.Count(src[:pos], "\n")
+		// A stable, readable name: the verb + table-ish first words.
+		name := "caqti_query:" + verb + ":" + strconv.Itoa(line)
+		out = append(out, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Operation",
+			Subtype:    "db_query",
+			SourceFile: filePath,
+			Language:   "ocaml",
+			StartLine:  line,
+			EndLine:    line,
+			Signature:  truncateSQL(sql),
+			Properties: map[string]string{
+				"db_library": "caqti",
+				"query_verb": verb,
+				"query":      truncateSQL(sql),
+				"provenance": "INFERRED_FROM_CAQTI_QUERY",
+			},
+		})
+	}
+
+	for _, m := range caqtiInfixRE.FindAllStringSubmatchIndex(src, -1) {
+		emit(src[m[2]:m[3]], m[0])
+	}
+	for _, m := range caqtiRapperRE.FindAllStringSubmatchIndex(src, -1) {
+		emit(src[m[2]:m[3]], m[0])
+	}
+	return out
+}
+
+// truncateSQL caps a recovered SQL string to a readable single-line signature.
+func truncateSQL(sql string) string {
+	sql = strings.Join(strings.Fields(sql), " ")
+	if len(sql) > 120 {
+		return sql[:117] + "..."
+	}
+	return sql
+}
+
+// ---------------------------------------------------------------------------
+// alcotest testing
+// ---------------------------------------------------------------------------
+
+// alcotestCaseRE matches an alcotest `test_case "label" speed fn` test-case
+// constructor. Capture group 1 is the case label. The `Alcotest.` qualifier is
+// optional (modules commonly `open Alcotest`).
+var alcotestCaseRE = regexp.MustCompile(`\btest_case\s+"([^"\n\r]*)"`)
+
+// isAlcotestFile reports whether a path looks like an OCaml test file
+// (conventionally under a `test`/`tests` dir or named *_test.ml / test_*.ml).
+func isAlcotestFile(filePath string) bool {
+	p := filepath.ToSlash(filePath)
+	base := filepath.Base(p)
+	if strings.HasSuffix(base, "_test.ml") || strings.HasPrefix(base, "test_") {
+		return true
+	}
+	for _, seg := range strings.Split(filepath.Dir(p), "/") {
+		if seg == "test" || seg == "tests" {
+			return true
+		}
+	}
+	return false
+}
+
+// extractAlcotestSuite emits one SCOPE.Operation(subtype=test_suite) per OCaml
+// test file carrying the alcotest test_case count. No suite is emitted for a
+// file with no cases or one with no alcotest marker.
+func extractAlcotestSuite(src, filePath string) []types.EntityRecord {
+	hasAlcotest := strings.Contains(src, "Alcotest") || strings.Contains(src, "test_case")
+	if !isAlcotestFile(filePath) && !hasAlcotest {
+		return nil
+	}
+	matches := alcotestCaseRE.FindAllStringSubmatch(src, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	// Require a real alcotest marker so a `test_case` helper in non-alcotest
+	// code does not fabricate a suite.
+	if !strings.Contains(src, "Alcotest") {
+		return nil
+	}
+	exampleCount := len(matches)
+	base := strings.TrimSuffix(filepath.Base(filepath.ToSlash(filePath)), ".ml")
+	rec := types.EntityRecord{
+		Name:       "test_suite:" + base,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "test_suite",
+		SourceFile: filePath,
+		Language:   "ocaml",
+		StartLine:  1,
+		EndLine:    1,
+		Properties: map[string]string{
+			"framework":      "alcotest",
+			"test_framework": "alcotest",
+			"provenance":     "INFERRED_FROM_ALCOTEST_SUITE",
+			"example_count":  strconv.Itoa(exampleCount),
+		},
+	}
+	// Subject affinity: a `foo_test.ml` / `test_foo.ml` file conventionally
+	// tests the module `Foo`, so emit a name-affinity TESTS edge.
+	stem := alcotestSubjectStem(base)
+	if stem != "" && stem != base {
+		rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+			ToID: stem,
+			Kind: string(types.RelationshipKindTests),
+			Properties: map[string]string{
+				"framework":    "alcotest",
+				"match_source": "test_stem_affinity",
+			},
+		})
+	}
+	return []types.EntityRecord{rec}
+}
+
+// alcotestSubjectStem derives the tested-module stem from a test-file base name
+// (`user_test` → `user`, `test_user` → `user`).
+func alcotestSubjectStem(base string) string {
+	switch {
+	case strings.HasSuffix(base, "_test"):
+		return strings.TrimSuffix(base, "_test")
+	case strings.HasPrefix(base, "test_"):
+		return strings.TrimPrefix(base, "test_")
+	default:
+		return ""
+	}
+}

--- a/internal/extractors/ocaml/depth_test.go
+++ b/internal/extractors/ocaml/depth_test.go
@@ -1,0 +1,139 @@
+package ocaml
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+func findBySubtype(recs []types.EntityRecord, subtype string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Subtype == subtype {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestCaqti_InfixQueries covers the Caqti_request.Infix arity-operator query
+// definitions: exec (->.), find (->!) and collect (->*).
+func TestCaqti_InfixQueries(t *testing.T) {
+	src := `
+open Caqti_request.Infix
+open Caqti_type
+
+let list_users =
+  (unit ->* string) "SELECT name FROM users ORDER BY name"
+
+let find_user =
+  (int ->! string) @@: "SELECT name FROM users WHERE id = ?"
+
+let delete_user =
+  (int ->. unit) @:- "DELETE FROM users WHERE id = ?"
+`
+	recs := extractCaqtiQueries(src, "lib/db.ml")
+	queries := findBySubtype(recs, "db_query")
+	if len(queries) != 3 {
+		t.Fatalf("expected 3 caqti queries, got %d: %+v", len(queries), queries)
+	}
+	verbs := map[string]bool{}
+	for _, q := range queries {
+		if q.Properties["db_library"] != "caqti" {
+			t.Errorf("query %s: db_library=%q want caqti", q.Name, q.Properties["db_library"])
+		}
+		verbs[q.Properties["query_verb"]] = true
+	}
+	for _, want := range []string{"SELECT", "DELETE"} {
+		if !verbs[want] {
+			t.Errorf("expected a %s query verb; got verbs=%v", want, verbs)
+		}
+	}
+}
+
+// TestCaqti_Rapper covers the ppx_rapper [%rapper ...] quotation form.
+func TestCaqti_Rapper(t *testing.T) {
+	src := `
+let get_one =
+  [%rapper get_one "SELECT @string{name} FROM users WHERE id = %int{id}"]
+`
+	queries := findBySubtype(extractCaqtiQueries(src, "lib/queries.ml"), "db_query")
+	if len(queries) != 1 {
+		t.Fatalf("expected 1 rapper query, got %d", len(queries))
+	}
+	if queries[0].Properties["query_verb"] != "SELECT" {
+		t.Errorf("rapper query_verb=%q want SELECT", queries[0].Properties["query_verb"])
+	}
+}
+
+// TestCaqti_NonDbFileNoEmit is the negative guard: a file with no Caqti/rapper
+// marker yields no db_query entity.
+func TestCaqti_NonDbFileNoEmit(t *testing.T) {
+	src := `let greet name = "hello " ^ name`
+	if recs := extractCaqtiQueries(src, "lib/util.ml"); len(recs) != 0 {
+		t.Fatalf("non-db file must not emit queries; got %+v", recs)
+	}
+}
+
+// TestAlcotest_Suite covers an alcotest test file: test_case cases counted into
+// one test_suite operation with a stem-affinity TESTS edge.
+func TestAlcotest_Suite(t *testing.T) {
+	// Note: OCaml polymorphic-variant speed tags (`Quick) use a backtick that
+	// cannot appear inside a Go raw string, so this fixture writes the speed
+	// argument as a plain identifier — the test_case label is what the parser
+	// counts.
+	src := "open Alcotest\n" +
+		"\n" +
+		"let test_add () = check int \"1+1\" 2 (1 + 1)\n" +
+		"let test_sub () = check int \"2-1\" 1 (2 - 1)\n" +
+		"\n" +
+		"let () =\n" +
+		"  run \"math\" [\n" +
+		"    \"arith\", [\n" +
+		"      test_case \"add\" `Quick test_add;\n" +
+		"      test_case \"sub\" `Quick test_sub;\n" +
+		"    ];\n" +
+		"  ]\n"
+	recs := extractAlcotestSuite(src, "test/math_test.ml")
+	suites := findBySubtype(recs, "test_suite")
+	if len(suites) != 1 {
+		t.Fatalf("expected 1 alcotest suite, got %d: %+v", len(suites), recs)
+	}
+	s := suites[0]
+	if s.Properties["framework"] != "alcotest" {
+		t.Errorf("framework=%q want alcotest", s.Properties["framework"])
+	}
+	if s.Properties["example_count"] != "2" {
+		t.Errorf("example_count=%q want 2", s.Properties["example_count"])
+	}
+	// Stem-affinity TESTS edge: math_test.ml → math.
+	var hasTests bool
+	for _, rel := range s.Relationships {
+		if rel.Kind == string(types.RelationshipKindTests) && rel.ToID == "math" {
+			hasTests = true
+		}
+	}
+	if !hasTests {
+		t.Errorf("expected stem-affinity TESTS edge to 'math'; got %+v", s.Relationships)
+	}
+}
+
+// TestAlcotest_NoCasesNoEmit confirms an alcotest-importing file with no
+// test_case calls emits no suite (honest).
+func TestAlcotest_NoCasesNoEmit(t *testing.T) {
+	src := `open Alcotest
+let () = run "empty" []`
+	if recs := extractAlcotestSuite(src, "test/empty_test.ml"); len(recs) != 0 {
+		t.Fatalf("a case-less alcotest file must emit no suite; got %+v", recs)
+	}
+}
+
+// TestAlcotest_NonAlcotestNoEmit is the negative guard: a `test_case` helper in
+// a file with no Alcotest marker must not fabricate a suite.
+func TestAlcotest_NonAlcotestNoEmit(t *testing.T) {
+	src := `let test_case name fn = fn name
+let () = test_case "x" print_string`
+	if recs := extractAlcotestSuite(src, "lib/helper.ml"); len(recs) != 0 {
+		t.Fatalf("non-alcotest file must emit no suite; got %+v", recs)
+	}
+}

--- a/internal/extractors/ocaml/extractor.go
+++ b/internal/extractors/ocaml/extractor.go
@@ -117,6 +117,9 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		return nil, nil
 	}
 	out := extractOCaml(string(file.Content), file.Path)
+	// Framework-aware depth pass (#5374): Caqti DB queries + alcotest suites.
+	out = append(out, extractCaqtiQueries(string(file.Content), file.Path)...)
+	out = append(out, extractAlcotestSuite(string(file.Content), file.Path)...)
 	extractor.TagRelationshipsLanguage(out, "ocaml")
 	extractor.TagEntitiesLanguage(out, "ocaml")
 	return out, nil


### PR DESCRIPTION
Bootstraps the OCaml ecosystem (Group A, epic #5360). The base OCaml extractor stays structural-only; framework awareness is added in the same shape the Haskell slice (#5373) landed in this epic.

## Records (honest)

| Record | Category | Capability | Status |
|---|---|---|---|
| `lang.ocaml.tool.dune` | package_manager | manifest_parsing | **full** |
| `lang.ocaml.framework.dream` | http_framework | endpoint_synthesis, route_extraction | **full** |
| | | handler_attribution | partial |
| `lang.ocaml.orm.caqti` | orm | query_attribution | partial |
| `test.alcotest` | build_system | target_extraction | **full** |
| | | dependency_graph | partial |

## What landed

- **Dune / opam manifests** — new `internal/extractors/cross/manifest/ocaml.go`: `*.opam` (`depends:`/`depopts:` lists, `{>= "x"}` version formulas, `{with-test}` dev filter, the `ocaml` compiler floor kept as a real edge) and `dune-project` (inline `(package (depends ...))` generate_opam_files stanzas — bare atoms, `(caqti (>= 1.9.0))` constrained sub-lists, `:with-test` dev). Suffix/exact-name dispatched in `IsManifest`/`detectPackageManager`/`dispatchParser`; emits the standard `DEPENDS_ON` + `DEPENDS_ON_PACKAGE` + SBOM package nodes. Honest scope: opam formula conjunctions reduced to the first version literal; plain `dune` `(libraries ...)` lists not mined (internal+external indistinguishable).
- **Dream (web)** — `synthesizeDreamRoutes` in `internal/engine/http_endpoint_dream.go` maps `Dream.get/post/put/delete/patch "/users/:id" handler` verb routes to canonical `http_endpoint_definition` via a new `FrameworkDream` (colon-params, reuses `canonicalizeColonParams`), dispatched from the per-language synthesis switch. Honest exclusion: interpolated/variable paths dropped; `Dream.scope` prefix grouping not threaded.
- **Caqti (DB)** — `extractCaqtiQueries` in `internal/extractors/ocaml/depth.go` recovers `Caqti_request.Infix` arity-operator query defs and `[%rapper ...]` quotations into `SCOPE.Operation(subtype=db_query)` carrying `db_library=caqti` + SQL verb. Honest partial: typed encoder/decoder spec, connection dispatch and the table/model graph not modelled.
- **alcotest** — `extractAlcotestSuite` lifts `test_case "label"` cases into one `SCOPE.Operation(subtype=test_suite)` per test file with `example_count` and a stem-affinity TESTS edge (`math_test.ml`→`math`). Requires a real `Alcotest` marker (no fabrication); case-less files emit nothing.

## Tests / validation

- New: `ocaml_test.go` (opam + dune-project + no-op + dispatch), `http_endpoint_dream_test.go` (basic routes, path params, negative guard, variable-path exclusion), `depth_test.go` (Caqti Infix + rapper + 2 negative guards; alcotest suite + stem edge + 2 negative guards).
- `go test` green for `internal/extractors/cross/manifest/`, `internal/extractors/ocaml/`, `internal/engine/httproutes/`, `internal/engine/` (Dream + sibling synthesizers), `tools/coverage/`.
- Registry + coverage docs regenerated in this PR; `coverage validate` and `coverage fmt --check` green.

Refs #5360. Closes #5374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
