### PR TITLE
feat(elm): bootstrap framework/tool records — The Elm Architecture + elm.json + elm-test (#5375)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 260 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **OCaml**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
+**Total**: 261 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **elm**: 1 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **OCaml**: 1 · **php**: 16 · **python**: 25 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -215,6 +215,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [C#](../by-language/csharp.md) | [Blazor Server / WebAssembly](../detail/lang.csharp.framework.blazor.md) | ✅ 2/2 | 🟢 1/1 | 🟢 24/24 | 🟢 8/8 | |
 | [C#](../by-language/csharp.md) | [Blazor WebAssembly](../detail/lang.csharp.framework.blazor-wasm.md) | ✅ 2/2 | 🟢 1/1 | 🟢 24/24 | 🟢 8/8 | |
 | [dart](../by-language/dart.md) | [Flutter](../detail/lang.dart.framework.flutter.md) | 🟢 3/3 | 🟢 1/1 | 🟡 14/24 | 🟡 6/8 | |
+| [elm](../by-language/elm.md) | [The Elm Architecture (Elm frontend)](../detail/lang.elm.framework.tea.md) | 🔴 0/3 | ✅ 1/1 | 🔴 0/24 | 🟡 2/8 | |
 | [F#](../by-language/fsharp.md) | [Fable Elmish/Feliz (F# frontend)](../detail/lang.fsharp.framework.elmish.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/24 | 🟡 6/14 | |
 | [java](../by-language/java.md) | [Google Web Toolkit (GWT)](../detail/lang.java.framework.gwt.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |
 | [java](../by-language/java.md) | [Vaadin (UI-as-server)](../detail/lang.java.framework.vaadin.md) | 🟢 2/2 | 🔴 0/1 | 🟡 21/22 | 🔴 0/3 | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 28 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
+**Total**: 29 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -16,6 +16,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [C#](../by-language/csharp.md) | [.csproj / packages.config](../detail/pkg.csproj.md) | — | ✅ | ✅ | |
 | [dart](../by-language/dart.md) | [pubspec.yaml](../detail/pkg.pubspec.md) | — | ✅ | ✅ | |
 | [elixir](../by-language/elixir.md) | [mix.exs](../detail/pkg.mix.md) | — | — | 🔴 | |
+| [elm](../by-language/elm.md) | [elm.json (Elm package manager)](../detail/lang.elm.tool.elm-json.md) | — | — | ✅ | |
 | [erlang](../by-language/erlang.md) | [rebar3 / hex.pm (rebar.config, rebar.lock)](../detail/pkg.rebar3.md) | — | ✅ | ✅ | |
 | [F#](../by-language/fsharp.md) | [Paket (.NET/F# package manager)](../detail/lang.fsharp.tool.paket.md) | — | ✅ | ✅ | |
 | [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | ✅ | ✅ | |

--- a/docs/coverage/by-language/elm.md
+++ b/docs/coverage/by-language/elm.md
@@ -1,12 +1,36 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Elm
+# elm
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/elm/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.elm.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Frameworks
+
+
+### UI Frontend
+
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [The Elm Architecture (Elm frontend)](../detail/lang.elm.framework.tea.md) | 🔴 0/3 | ✅ 1/1 | 🔴 0/24 | 🟡 2/8 | |
+
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [elm.json (Elm package manager)](../detail/lang.elm.tool.elm-json.md) | — | — | — | ✅ | — | |

--- a/docs/coverage/detail/lang.elm.framework.tea.md
+++ b/docs/coverage/detail/lang.elm.framework.tea.md
@@ -1,0 +1,93 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elm.framework.tea` — The Elm Architecture (Elm frontend)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elm](../by-language/elm.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** UI Frontend
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Structure
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Component extraction | 🟢 `partial` | `2026-06-24` | 5375 | `internal/extractors/elm/extractor.go`<br>`internal/extractors/elm/tea.go`<br>`internal/extractors/elm/tea_test.go` | The TEA view operation is tagged Properties[tea_role]=view (the render half of the MVU triad); the Model/Msg data types are re-kinded SCOPE.Model/SCOPE.Event. Honest-partial: unlike the F# Feliz pass, Elm view functions are not re-kinded SCOPE.UIComponent and no RENDERS edges between nested view helpers are emitted (the Html DSL is heuristic-only) — deferred. |
+| Context extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Data fetching | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Prop extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| State management | ✅ `full` | `2026-06-24` | 5375 | `internal/extractors/elm/extractor.go`<br>`internal/extractors/elm/tea.go`<br>`internal/extractors/elm/tea_test.go` | TEA MVU: the Model type alias re-kinded SCOPE.Model (tea_model, tea_role=model), the Msg custom type re-kinded SCOPE.Event (tea_msg) with its '|'-separated constructor variants recorded on Properties[tea_variants] as the event set, and init/update/view tagged Properties[tea_role]. The Browser.sandbox/element/document/application program entry (idiomatically main) is flagged Properties[tea_program]=true + tea_program_kind. Import-gated on Browser/Html (no-op for a plain Elm helper module). Proven by TestTEA_ModelRekind / _MsgRekindWithVariants / _TriadRoles / _ProgramFlagged / _NonFrontendNoop. |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Router pattern | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Interface extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Type alias extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | ✅ `full` | `2026-06-24` | 5375 | `internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_elm.go`<br>`internal/extractors/cross/testmap/frameworks_elm_test.go`<br>`internal/extractors/cross/testmap/resolver.go` | elm-test linkage via the cross-language testmap extractor. detectElmTest (frameworks_elm.go) detects describe "Subject" [ test "..." <| \_ -> ... ] leaves plus fuzz/fuzzN/fuzzWith property cases; the description is the LAST string literal (fuzz leaves carry a fuzzer arg first). Each leaf's list/off-side-rule-bounded body (extractElmTestBody, ends at the next ,/]/column-0 dedent) is scanned by the resolver: an Elm SPACE-APPLIED production call (add 2 2 — Elm is curried, invisible to the paren directCallRE) resolves to a high-confidence TESTS edge via elmSpaceAppRE (gated tf.lang==elm, keyword+stopword filtered), and the describe subject seeds a medium-confidence subject edge. The elm-test/Expect/Fuzz DSL (describe/test/fuzz*/Expect.*/Fuzz.*) is denylisted in resolver.go so it never surfaces as the SUT. FILENAME/PATH gated (*Test.elm / *Tests.elm / /tests/) — NOT import gated (the bare test/expect tokens would over-match the substring import matcher). Proven by TestElmTest_DirectCallHighConfidence / _BodyScoped / _FuzzCase / _AssertionDSLNotSubject. |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Config consumption | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Constant propagation | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| DB effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Dead code detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Def use chain extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Env fallback recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Error flow | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Feature flag gating | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Fs effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| HTTP effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Import resolution quality | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Module cycle detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Mutation effect | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Pure function tagging | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Reachability analysis | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Request shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Response shape extraction | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Schema drift detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint sink detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Taint source detection | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Template pattern catalog | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+| Vulnerability finding | 🔴 `missing` | — | backfill:dictionary-completeness | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elm.framework.tea ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.elm.tool.elm-json.md
+++ b/docs/coverage/detail/lang.elm.tool.elm-json.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.elm.tool.elm-json` — elm.json (Elm package manager)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [elm](../by-language/elm.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Lockfile parsing | — `not_applicable` | `2026-06-24` | 5375 | `internal/classifier/classifier.go`<br>`internal/extractors/cross/manifest/elm.go`<br>`internal/extractors/cross/manifest/elm_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | elm.json IS the lockfile — an application's direct/indirect dependency versions are EXACTLY pinned (the indirect block is the resolved transitive closure), so there is no separate lockfile format. The resolved tree is recovered directly from manifest_parsing (indirect deps flagged indirect=true). |
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5375 | `internal/classifier/classifier.go`<br>`internal/extractors/cross/manifest/elm.go`<br>`internal/extractors/cross/manifest/elm_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | elm.json is JSON with two shapes distinguished by the type field. parseElmJSON handles both: an application's dependencies block ({direct:{...},indirect:{...}} of exactly-pinned versions, indirect deps flagged indirect=true) and a package's flat {author/project: version-range} map; both carry a test-dependencies block flagged is_dev=true. First-declaration-wins on duplicates (direct>indirect>test). elm.json is classified elm (classifier.go exactBasenameLanguageMap) so it reaches the _cross_manifest pass, and is wired into IsManifest/detectPackageManager/dispatchParser/parsers by exact basename to package_manager=elm; emits DEPENDS_ON + DEPENDS_ON_PACKAGE edges + SBOM package nodes like every other ecosystem. Proven by TestElmJSON_ApplicationDeps / _PackageDeps / _DependsOnEdges / _IsManifest. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.elm.tool.elm-json ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (28 active · 11 placeholder) · **Frameworks**: 260 · **ORMs**: 186 · **Tools**: 141 · **Other**: 208
+**Languages**: 39 (29 active · 10 placeholder) · **Frameworks**: 261 · **ORMs**: 186 · **Tools**: 142 · **Other**: 208
 
 ## Coverage by language
 
@@ -26,6 +26,7 @@
 | [haskell](by-language/haskell.md) | 3 | 2 | 1 | 0 |
 | [crystal](by-language/crystal.md) | 2 | 1 | 5 | 1 |
 | [F#](by-language/fsharp.md) | 2 | 2 | 0 | 2 |
+| [elm](by-language/elm.md) | 1 | 1 | 0 | 0 |
 | [erlang](by-language/erlang.md) | 1 | 5 | 0 | 2 |
 | [groovy](by-language/groovy.md) | 1 | 1 | 1 | 1 |
 | [nim](by-language/nim.md) | 1 | 1 | 4 | 1 |
@@ -72,7 +73,6 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | Language |
 |---|
 | [Bicep](by-language/bicep.md) |
-| [Elm](by-language/elm.md) |
 | [Idris](by-language/idris.md) |
 | [Lisp](by-language/lisp.md) |
 | [Pony](by-language/pony.md) |
@@ -83,4 +83,4 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Verilog](by-language/verilog.md) |
 | [Zig](by-language/zig.md) |
 
-Total: 260 frameworks · 141 tools · 186 ORMs · 208 other
+Total: 261 frameworks · 142 tools · 186 ORMs · 208 other

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -640,6 +640,11 @@ var extensionLanguageMap = map[string]string{
 // the tree-sitter-based generic Swift extractor ("swift").
 var exactBasenameLanguageMap = map[string]string{
 	"Package.swift": "swift_package",
+	// Elm manifest (#5375) — elm.json is JSON but has no other meaning than the
+	// Elm project manifest. Classified as "elm" (rather than dropped by the
+	// generic .json routing) so it reaches the _cross_manifest extractor, which
+	// exact-name-matches it and parses its application/package dependency blocks.
+	"elm.json": "elm",
 }
 
 // apiGwOcelotJSONRe matches Ocelot config files with the conventional

--- a/internal/extractors/cross/manifest/elm.go
+++ b/internal/extractors/cross/manifest/elm.go
@@ -1,0 +1,105 @@
+// elm.go — Elm `elm.json` package manifest parser (#5375, epic #5360).
+//
+// elm.json (https://github.com/elm/compiler/blob/master/docs/elm.json/) is the
+// manifest for an Elm project. It comes in two shapes distinguished by the
+// `"type"` field:
+//
+//	APPLICATION (an app you compile and run):
+//	  {
+//	    "type": "application",
+//	    "dependencies": {
+//	      "direct":   { "elm/browser": "1.0.2", "elm/html": "1.0.0" },
+//	      "indirect": { "elm/virtual-dom": "1.0.3" }
+//	    },
+//	    "test-dependencies": {
+//	      "direct":   { "elm-explorations/test": "2.1.0" },
+//	      "indirect": {}
+//	    }
+//	  }
+//
+//	PACKAGE (a reusable library published to the Elm registry):
+//	  {
+//	    "type": "package",
+//	    "dependencies":      { "elm/core": "1.0.0 <= v < 2.0.0" },
+//	    "test-dependencies": { "elm-explorations/test": "2.0.0 <= v < 3.0.0" }
+//	  }
+//
+// An application's `dependencies` is an object with `direct`/`indirect` sub-maps
+// of EXACTLY-PINNED versions (elm.json IS the lockfile — there is no separate
+// lockfile format), so indirect deps are flagged indirect=true. A package's
+// `dependencies` is a FLAT map of version-RANGE constraints. Both shapes carry a
+// `test-dependencies` block whose deps are flagged is_dev=true. The package
+// manager is `elm`; the registry is the Elm package website (package.elm-lang.org)
+// and package names are GitHub-style `author/project` slugs.
+package manifest
+
+import "encoding/json"
+
+// parseElmJSON parses an Elm `elm.json` manifest (application or package shape)
+// and returns its declared dependencies. Application indirect deps are flagged
+// indirect=true; every test-dependency is flagged is_dev=true. First declaration
+// of a name wins on duplicates (direct runtime > indirect > test).
+func parseElmJSON(source string) []dep {
+	// The two shapes differ in the value type of "dependencies":
+	//   application: { "direct": {...}, "indirect": {...} }
+	//   package:     { "elm/core": "..." }
+	// We decode "dependencies"/"test-dependencies" into json.RawMessage and then
+	// try the nested-object shape first, falling back to the flat-map shape.
+	var data struct {
+		Type         string          `json:"type"`
+		Dependencies json.RawMessage `json:"dependencies"`
+		TestDeps     json.RawMessage `json:"test-dependencies"`
+	}
+	if err := json.Unmarshal([]byte(source), &data); err != nil {
+		return nil
+	}
+
+	var out []dep
+	seen := map[string]bool{}
+	emit := func(name, version string, isDev, indirect bool) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		kind := "runtime"
+		if isDev {
+			kind = "dev"
+		}
+		out = append(out, dep{name: name, version: version, isDev: isDev, kind: kind, indirect: indirect})
+	}
+
+	// emitBlock decodes one dependency block (the application nested
+	// direct/indirect form OR the package flat-map form) and emits its deps.
+	emitBlock := func(raw json.RawMessage, isDev bool) {
+		if len(raw) == 0 {
+			return
+		}
+		// Application shape: { "direct": {...}, "indirect": {...} }.
+		var nested struct {
+			Direct   map[string]string `json:"direct"`
+			Indirect map[string]string `json:"indirect"`
+		}
+		if err := json.Unmarshal(raw, &nested); err == nil && (nested.Direct != nil || nested.Indirect != nil) {
+			for name, ver := range nested.Direct {
+				emit(name, ver, isDev, false)
+			}
+			for name, ver := range nested.Indirect {
+				emit(name, ver, isDev, true)
+			}
+			return
+		}
+		// Package shape: flat { "author/project": "constraint" }.
+		var flat map[string]string
+		if err := json.Unmarshal(raw, &flat); err == nil {
+			for name, ver := range flat {
+				emit(name, ver, isDev, false)
+			}
+		}
+	}
+
+	// Runtime deps first so a name shared with a test dep keeps its runtime
+	// classification (first-declaration-wins on the `seen` guard).
+	emitBlock(data.Dependencies, false)
+	emitBlock(data.TestDeps, true)
+	return out
+}

--- a/internal/extractors/cross/manifest/elm_test.go
+++ b/internal/extractors/cross/manifest/elm_test.go
@@ -1,0 +1,150 @@
+package manifest
+
+import "testing"
+
+// realElmApplication is a representative elm.json application manifest (shape
+// taken from `elm init` + `elm-test init`). It exercises the direct/indirect
+// split, the test-dependencies block, and the exact-pinned versions that make
+// elm.json its own lockfile.
+const realElmApplication = `{
+    "type": "application",
+    "source-directories": [ "src" ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/virtual-dom": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.1.0"
+        },
+        "indirect": {}
+    }
+}`
+
+// realElmPackage is a representative elm.json package manifest (a published
+// library). Its dependencies are a FLAT map of version-RANGE constraints (no
+// direct/indirect split).
+const realElmPackage = `{
+    "type": "package",
+    "name": "elm/html",
+    "summary": "Fast HTML, rendered with virtual DOM diffing",
+    "license": "BSD-3-Clause",
+    "version": "1.0.0",
+    "exposed-modules": [ "Html", "Html.Attributes" ],
+    "elm-version": "0.19.0 <= v < 0.20.0",
+    "dependencies": {
+        "elm/core": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.0.0 <= v < 2.0.0",
+        "elm/virtual-dom": "1.0.0 <= v < 2.0.0"
+    },
+    "test-dependencies": {
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
+    }
+}`
+
+func TestElmJSON_ApplicationDeps(t *testing.T) {
+	deps := depEntities(runExtract(t, "elm.json", realElmApplication))
+	// 3 direct + 2 indirect runtime + 1 test = 6.
+	if len(deps) != 6 {
+		t.Fatalf("expected 6 deps, got %d: %+v", len(deps), depNames(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "elm" {
+			t.Errorf("%s: package_manager=%q want elm", d.Name, d.Properties["package_manager"])
+		}
+	}
+
+	// A direct runtime dep carries its exact version, is_dev=false, not indirect.
+	if d := depByName(deps, "elm/browser"); d == nil {
+		t.Error("elm/browser direct dep missing")
+	} else {
+		if d.Properties["version"] != "1.0.2" {
+			t.Errorf("elm/browser version=%q want 1.0.2", d.Properties["version"])
+		}
+		if d.Properties["is_dev"] != "false" {
+			t.Errorf("elm/browser is_dev=%q want false", d.Properties["is_dev"])
+		}
+		if d.Properties["indirect"] != "false" {
+			t.Errorf("elm/browser indirect=%q want false", d.Properties["indirect"])
+		}
+	}
+
+	// An indirect runtime dep is flagged indirect=true.
+	if d := depByName(deps, "elm/virtual-dom"); d == nil {
+		t.Error("elm/virtual-dom indirect dep missing")
+	} else if d.Properties["indirect"] != "true" {
+		t.Errorf("elm/virtual-dom indirect=%q want true", d.Properties["indirect"])
+	}
+
+	// The test dep is flagged is_dev=true / dependency_kind=dev.
+	if d := depByName(deps, "elm-explorations/test"); d == nil {
+		t.Error("elm-explorations/test dep missing")
+	} else {
+		if d.Properties["is_dev"] != "true" {
+			t.Errorf("elm-explorations/test is_dev=%q want true", d.Properties["is_dev"])
+		}
+		if d.Properties["dependency_kind"] != "dev" {
+			t.Errorf("elm-explorations/test dependency_kind=%q want dev", d.Properties["dependency_kind"])
+		}
+	}
+}
+
+func TestElmJSON_PackageDeps(t *testing.T) {
+	deps := depEntities(runExtract(t, "elm.json", realElmPackage))
+	// 3 runtime (flat map) + 1 test = 4.
+	if len(deps) != 4 {
+		t.Fatalf("expected 4 deps, got %d: %+v", len(deps), depNames(deps))
+	}
+
+	// Flat-map (package) deps carry the version-range constraint as version.
+	if d := depByName(deps, "elm/core"); d == nil {
+		t.Error("elm/core dep missing")
+	} else if d.Properties["version"] != "1.0.0 <= v < 2.0.0" {
+		t.Errorf("elm/core version=%q want range constraint", d.Properties["version"])
+	}
+
+	if d := depByName(deps, "elm-explorations/test"); d == nil {
+		t.Error("elm-explorations/test dep missing")
+	} else if d.Properties["is_dev"] != "true" {
+		t.Errorf("elm-explorations/test should be is_dev=true")
+	}
+}
+
+// TestElmJSON_DependsOnEdges confirms the manifest emits DEPENDS_ON edges + SBOM
+// package nodes like every other ecosystem (the cross-manifest contract).
+func TestElmJSON_DependsOnEdges(t *testing.T) {
+	records := runExtract(t, "elm.json", realElmApplication)
+	var dependsOn int
+	for _, r := range records {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "DEPENDS_ON" {
+				dependsOn++
+				if rel.Properties["package_manager"] != "elm" {
+					t.Errorf("DEPENDS_ON package_manager=%q want elm", rel.Properties["package_manager"])
+				}
+			}
+		}
+	}
+	if dependsOn != 6 {
+		t.Errorf("expected 6 DEPENDS_ON edges, got %d", dependsOn)
+	}
+}
+
+// TestElmJSON_IsManifest pins the dispatch wiring: elm.json is recognised and
+// routed to the elm package manager.
+func TestElmJSON_IsManifest(t *testing.T) {
+	if !IsManifest("frontend/elm.json") {
+		t.Error("elm.json should be recognised as a manifest")
+	}
+	if pm := detectPackageManager("frontend/elm.json"); pm != "elm" {
+		t.Errorf("detectPackageManager(elm.json)=%q want elm", pm)
+	}
+}

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -199,6 +199,10 @@ var exactManifestNames = map[string]bool{
 	// OCaml — Dune project file (inline (package (depends ...)) stanzas). The
 	// *.opam package manifest is suffix-dispatched below (#5374).
 	"dune-project": true,
+	// Elm — elm.json manifest (#5375). Application (direct/indirect + test-deps)
+	// and package (flat version-range) shapes. elm.json IS the lockfile (deps are
+	// exactly pinned), so there is no separate lockfile format.
+	"elm.json": true,
 }
 
 // IsManifest returns true when filePath names a supported manifest file.
@@ -293,6 +297,8 @@ func detectPackageManager(filePath string) string {
 		"package.yaml": "hpack",
 		// OCaml — Dune project file
 		"dune-project": "dune",
+		// Elm — elm.json manifest
+		"elm.json": "elm",
 	}
 	basename := filepath.Base(filePath)
 	if v, ok := pm[basename]; ok {
@@ -1947,6 +1953,8 @@ var parsers = map[string]parserFn{
 	"package.yaml": parsePackageYaml,
 	// OCaml — Dune project file (*.opam is suffix-dispatched below).
 	"dune-project": parseDuneProject,
+	// Elm — elm.json manifest (application + package shapes).
+	"elm.json": parseElmJSON,
 }
 
 func dispatchParser(filePath, source string) (string, []dep) {

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -2365,6 +2365,25 @@ var frameworkOrder = []frameworkEntry{
 		},
 		detect: detectFSharpExpecto,
 	},
+	// Elm — elm-test (#5375). describe "..." [ test "..." <| \_ -> … ] leaves +
+	// fuzz/fuzzN/fuzzWith property cases. FILENAME/PATH gated (the standard
+	// elm-test conventions `*Test.elm` / `*Tests.elm` / files under `tests/`) and
+	// NOT import gated: Elm's `import Test`/`import Expect` would yield the bare
+	// tokens `test`/`expect`, which the substring import matcher would over-match
+	// against unrelated tokens (e.g. C++ `gtest/gtest.h` contains "test"). The
+	// detector self-confirms — a non-test .elm yields zero cases and is dropped
+	// downstream, exactly like the rust_test / fsharp-expecto entries.
+	{
+		name: "elm-test",
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`Test\.elm$`),
+			regexp.MustCompile(`Tests\.elm$`),
+		},
+		pathHints: []*regexp.Regexp{
+			regexp.MustCompile(`/tests?/.*\.elm$`),
+		},
+		detect: detectElmTest,
+	},
 	// ---------------------------------------------------------------------
 	// C/C++ — gtest, catch2, doctest, boost.test, cppunit, cpputest (#3495).
 	//

--- a/internal/extractors/cross/testmap/frameworks_elm.go
+++ b/internal/extractors/cross/testmap/frameworks_elm.go
@@ -1,0 +1,164 @@
+// Package testmap — Elm test-framework (elm-test) detection and call resolution.
+//
+// #5375 (epic #5360 Group A — bootstrap). Linkage for elm-test
+// (https://github.com/elm-explorations/test), the standard Elm test runner:
+//
+//	import Test exposing (..)
+//	import Expect
+//
+//	suite : Test
+//	suite =
+//	    describe "Math"
+//	        [ test "adds two numbers" <|
+//	            \_ -> Expect.equal 4 (add 2 2)
+//	        , fuzz int "is commutative" <|
+//	            \n -> Expect.equal (add n 1) (add 1 n)
+//	        ]
+//
+// Each `test "..."` / `fuzz* "..."` leaf is a test case. Its body — the
+// `<| \_ -> …` thunk that follows — is scanned by the shared resolver for direct
+// production calls (`add 2 2` → the `add` operation). The enclosing
+// `describe "Subject"` is carried as a naming-convention subject-under-test
+// fallback (the Elm analog of the Nim `suite` / RSpec `describe` subject path),
+// used only when the subject is identifier-shaped.
+//
+// Elm test bodies are delimited by the off-side rule (top-level declarations
+// start at column 0) AND by the surrounding `[ … ]` list / `( … )` group. A
+// `test`/`fuzz` leaf header (`test "desc" <|`) introduces a body that runs until
+// the next `, test`/`, fuzz` list element, the closing `]`, or a dedent to
+// column 0 — whichever comes first. extractElmTestBody captures that run,
+// quote-aware so a `test` keyword inside a string never opens a block. The
+// elm-test / Expect / Fuzz DSL (Expect.*, Fuzz.*, describe/test/fuzz combinators)
+// is denylisted in resolver.go so it never surfaces as the production subject.
+//
+// elm-test files use `import Test`/`import Expect`; the framework entry is
+// IMPORT-token gated on those plus the `tests/` path / `*Test.elm` filename
+// conventions, and the detector self-confirms (a non-test .elm yields zero cases
+// and is dropped downstream, like the rust_test / fsharp-expecto entries).
+package testmap
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// elm-test — describe "..." [ test "..." <| \_ -> … ]
+// ---------------------------------------------------------------------------
+
+// elmTestCaseRE matches an elm-test leaf case header:
+//
+//	test "adds two numbers" <|
+//	fuzz int "is commutative" <|
+//	fuzz2 int int "is associative" <|
+//	test "trims" <|              (the `<|` may sit on the next line, see below)
+//
+// The description string is the LAST string literal on the header (fuzz* leaves
+// carry a fuzzer argument BEFORE the description). Group 1 captures the leading
+// keyword (test / fuzz / fuzz2 / fuzz3 / fuzzWith); the description is captured by
+// elmTestDescRE applied to the matched header line.
+var elmTestCaseRE = regexp.MustCompile(
+	`(?m)^[ \t]*[\[,]?[ \t]*(test|fuzz[0-9]?|fuzzWith)\s+[^\n\r]*?"([^"\n\r]{1,200})"\s*(?:<\|)?[ \t]*$`,
+)
+
+// elmDescribeRE matches an elm-test container: `describe "Subject"`. The first
+// describe whose subject is identifier-shaped seeds the subject-under-test
+// fallback (mirrors nimUnittestSuiteRE / fsharpExpectoListRE).
+var elmDescribeRE = regexp.MustCompile(
+	`(?m)^[ \t]*describe\s+"([^"\n\r]{1,200})"`,
+)
+
+// elmSubjectIdentRE recognises a describe subject that names a code symbol
+// (CamelCase / dotted / lower-ident), so a prose subject ("returns 200 on GET")
+// is rejected.
+var elmSubjectIdentRE = regexp.MustCompile(`^[A-Za-z_][\w]*(?:[.][A-Za-z_][\w]*)*$`)
+
+// elmDescribeSubject returns the first identifier-shaped describe subject, or "".
+func elmDescribeSubject(source string) string {
+	for _, m := range elmDescribeRE.FindAllStringSubmatch(source, -1) {
+		subj := strings.TrimSpace(m[1])
+		if elmSubjectIdentRE.MatchString(subj) {
+			if idx := strings.LastIndexByte(subj, '.'); idx >= 0 {
+				if tail := subj[idx+1:]; tail != "" {
+					return tail
+				}
+			}
+			return subj
+		}
+	}
+	return ""
+}
+
+// extractElmTestBody returns the source slice of the test-leaf body whose header
+// line begins at byte offset headerStart. The body is the run of subsequent lines
+// up to (but excluding) the next list element — a line whose first non-space
+// character is a `,` introducing the next `test`/`fuzz`, the closing `]` of the
+// describe list, or a dedent to column 0 (the next top-level declaration). The
+// header line itself is included so an inline `\_ -> Expect.equal 4 (add 2 2)`
+// body is captured. Quote-/comment-awareness is handled by the shared resolver's
+// scrub; here we only need line-structural bounds.
+func extractElmTestBody(source string, headerStart int) string {
+	nl := strings.IndexByte(source[headerStart:], '\n')
+	bodyStart := headerStart
+	if nl < 0 {
+		return source[headerStart:]
+	}
+	headerLine := source[headerStart : headerStart+nl]
+	headerIndent := indentWidth(headerLine)
+
+	i := headerStart + nl + 1
+	n := len(source)
+	for i < n {
+		lineEnd := strings.IndexByte(source[i:], '\n')
+		var line string
+		if lineEnd < 0 {
+			line = source[i:]
+		} else {
+			line = source[i : i+lineEnd]
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			ind := indentWidth(line)
+			// Next list element (`, test …` / `, fuzz …`) at or below the header
+			// indent ends this body. A leading `]` (list close) or a dedent to
+			// column 0 (next top-level decl) also ends it.
+			if ind <= headerIndent && (strings.HasPrefix(trimmed, ",") || strings.HasPrefix(trimmed, "]")) {
+				return source[bodyStart:i]
+			}
+			if ind == 0 {
+				return source[bodyStart:i]
+			}
+		}
+		if lineEnd < 0 {
+			return source[bodyStart:]
+		}
+		i += lineEnd + 1
+	}
+	return source[bodyStart:]
+}
+
+// elmTestCaseName normalises a `test "does a thing"` description into a snake
+// case-ish identifier. Reuses the Nim normaliser (a pure identifier helper).
+func elmTestCaseName(desc string) string { return nimTestCaseName(desc) }
+
+func detectElmTest(source string) []testFunction {
+	subject := elmDescribeSubject(source)
+
+	var out []testFunction
+	seen := map[string]bool{}
+	for _, m := range elmTestCaseRE.FindAllStringSubmatchIndex(source, -1) {
+		// Group 2 (m[4]:m[5]) is the description string.
+		if m[4] < 0 || m[5] < 0 {
+			continue
+		}
+		desc := source[m[4]:m[5]]
+		name := elmTestCaseName(desc)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		body := extractElmTestBody(source, m[0])
+		out = append(out, testFunction{qname: name, body: body, describeSubject: subject, lang: "elm"})
+	}
+	return out
+}

--- a/internal/extractors/cross/testmap/frameworks_elm_test.go
+++ b/internal/extractors/cross/testmap/frameworks_elm_test.go
@@ -1,0 +1,126 @@
+// Package testmap — value-asserting tests for the elm-test detector (#5375).
+package testmap
+
+import "testing"
+
+// TestElmTest_DirectCallHighConfidence proves a direct production call inside a
+// `test "..." <| \_ -> …` body yields a TESTS edge, attributed to elm-test.
+func TestElmTest_DirectCallHighConfidence(t *testing.T) {
+	src := `module MathTest exposing (suite)
+
+import Test exposing (..)
+import Expect
+
+
+suite : Test
+suite =
+    describe "Math"
+        [ test "adds two numbers" <|
+            \_ -> Expect.equal 4 (add 2 2)
+        ]
+`
+	recs := runExtract(t, "tests/MathTest.elm", "elm", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 testmap entity for elm-test")
+	}
+	rec := findByTested(t, recs, "adds_two_numbers", "add")
+	if rec.Properties["test_framework"] != "elm-test" {
+		t.Errorf("framework=%q, want elm-test", rec.Properties["test_framework"])
+	}
+	if !hasEdge(recs, "adds_two_numbers", "add") {
+		t.Errorf("missing TESTS edge adds_two_numbers -> add")
+	}
+}
+
+// TestElmTest_BodyScoped proves the body extractor scans only the leaf's own
+// body — a call in a SIBLING test must not leak into another test case's body.
+func TestElmTest_BodyScoped(t *testing.T) {
+	src := `module SvcTest exposing (suite)
+
+import Test exposing (..)
+import Expect
+
+
+suite : Test
+suite =
+    describe "Svc"
+        [ test "alpha" <|
+            \_ -> Expect.equal True (runAlpha 1)
+        , test "beta" <|
+            \_ -> Expect.equal True (runBeta 2)
+        ]
+`
+	recs := runExtract(t, "tests/SvcTest.elm", "elm", src)
+	if !hasEdgeAny(recs, "alpha", "runAlpha") {
+		t.Errorf("expected alpha -> runAlpha edge")
+	}
+	if !hasEdgeAny(recs, "beta", "runBeta") {
+		t.Errorf("expected beta -> runBeta edge")
+	}
+	// alpha's body must NOT reach runBeta (sibling leak).
+	if hasEdgeAny(recs, "alpha", "runBeta") {
+		t.Errorf("alpha test body leaked into sibling beta (runBeta)")
+	}
+}
+
+// TestElmTest_FuzzCase proves a `fuzz` property leaf is detected (the description
+// is the LAST string literal, after the fuzzer argument).
+func TestElmTest_FuzzCase(t *testing.T) {
+	src := `module AddTest exposing (suite)
+
+import Test exposing (..)
+import Expect
+import Fuzz exposing (int)
+
+
+suite : Test
+suite =
+    describe "Add"
+        [ fuzz int "is commutative" <|
+            \n -> Expect.equal (add n 1) (add 1 n)
+        ]
+`
+	recs := runExtract(t, "tests/AddTest.elm", "elm", src)
+	if !hasEdgeAny(recs, "is_commutative", "add") {
+		t.Errorf("expected fuzz case is_commutative -> add edge")
+	}
+}
+
+// TestElmTest_AssertionDSLNotSubject proves the Expect.*/describe/test DSL is
+// stop-worded — it never surfaces as the production subject under test.
+func TestElmTest_AssertionDSLNotSubject(t *testing.T) {
+	src := `module DslTest exposing (suite)
+
+import Test exposing (..)
+import Expect
+
+
+suite : Test
+suite =
+    describe "Dsl"
+        [ test "only assertions" <|
+            \_ -> Expect.equal 1 1
+        ]
+`
+	recs := runExtract(t, "tests/DslTest.elm", "elm", src)
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind != "TESTS" {
+				continue
+			}
+			low := rel.ToID
+			if containsAny(low, "Expect", "expect", "equal", "describe") {
+				t.Errorf("DSL identifier surfaced as production subject: %s", rel.ToID)
+			}
+		}
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if s == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -75,6 +75,35 @@ var fsharpKeywordHeads = map[string]bool{
 	"sizeof": true, "nameof": true, "mutable": true, "rec": true,
 }
 
+// elmSpaceAppRE captures an Elm SPACE-APPLIED call head (`add 2 2`), the
+// dominant curried-application idiom that produces no paren match and is
+// therefore invisible to directCallRE. Mirrors the F# space-app port (#5375):
+// Elm, like F#, is whitespace-sensitive and curried, so the head must sit at a
+// CLAUSE-STARTER position and be followed by at least one whitespace-separated
+// ARGUMENT-STARTER. Recognised clause starters: line start (after indentation),
+// `=`, `(`, `[`, `,`, the pipe operators `|>` / `<|`, the lambda/case arrow
+// `->`, and the keywords `of`/`then`/`else`/`in`. The argument starter is a
+// string/char/number literal, an opening paren/bracket, or a lower-case
+// identifier (an upper-case follower is a type/constructor, excluded).
+//
+// Gated to tf.lang == "elm" so other languages' false-positive rates are
+// untouched. Heads pass the Elm keyword gate AND the shared isStopword denylist
+// (Expect/Fuzz/describe/test combinators are stop-worded in #5375).
+var elmSpaceAppRE = regexp.MustCompile(
+	`(?m)(?:^[ \t]*|[=([,]\s*|\|>\s*|<\|\s*|->\s*|\bof\s+|\bthen\s+|\belse\s+|\bin\s+)` +
+		`([a-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)` +
+		`[ \t]+(?:"|'|[0-9]|\(|\[|[a-z_])`,
+)
+
+// elmKeywordHeads are Elm keywords that elmSpaceAppRE can match in a head
+// position but are never production-call targets.
+var elmKeywordHeads = map[string]bool{
+	"if": true, "then": true, "else": true,
+	"case": true, "of": true, "let": true, "in": true,
+	"type": true, "alias": true, "module": true, "import": true,
+	"exposing": true, "as": true, "port": true, "where": true,
+}
+
 // mockSetupRE captures common mock-library setup lines. The first capture
 // group is the qualified production identifier being stubbed.
 //
@@ -520,6 +549,22 @@ var stopwords = map[string]bool{
 	// xUnit / NUnit (F# usage) — FsUnit `should` combinator (the Assert.* family
 	// is already covered by the C# xUnit denylist block above).
 	"should": true,
+	// Elm — elm-test (#5375). The describe/test/fuzz case combinators and the
+	// Expect.* / Fuzz.* assertion+fuzzer families are test-harness identifiers and
+	// must never surface as the Elm production subject under test. (`test` and
+	// `expect.equal` are already denied above; these add the Elm-specific
+	// combinators and the Expect/Fuzz surfaces not shared with the F# block.)
+	"fuzz": true, "fuzz2": true, "fuzz3": true, "fuzzwith": true,
+	"skip": true, "only": true, "concat": true,
+	"expect.atleast": true, "expect.atmost": true, "expect.greaterthan": true,
+	"expect.lessthan": true, "expect.within": true, "expect.notwithin": true,
+	"expect.pass": true, "expect.fail": true, "expect.ontag": true,
+	"expect.true": true, "expect.false": true, "expect.err": true,
+	"expect.ok": true, "expect.equallists": true, "expect.equaldicts": true,
+	"expect.equalsets": true,
+	"fuzz.int": true, "fuzz.string": true, "fuzz.bool": true, "fuzz.float": true,
+	"fuzz.list": true, "fuzz.constant": true, "fuzz.map": true, "fuzz.andmap": true,
+	"fuzz.intrange": true, "fuzz.oneof": true, "fuzz.frequency": true,
 	// Common language keywords that end up in call-like positions
 	"if": true, "for": true, "while": true, "switch": true, "return": true,
 	"func": true, "def": true, "class": true, "struct": true, "new": true,
@@ -765,6 +810,39 @@ func resolveCalls(tf testFunction, prodFile, convSymbol string, importedSyms map
 			}
 			qname := m[1]
 			if fsharpKeywordHeads[headIdent(qname)] {
+				continue
+			}
+			if isStopword(qname) || isStopword(tailIdent(qname)) {
+				continue
+			}
+			tail := tailIdent(qname)
+			if len(tail) < 3 {
+				continue
+			}
+			conf := "high"
+			if gateImports {
+				head := headIdent(qname)
+				if !importedSyms[head] && !importedSyms[qname] {
+					conf = "medium"
+				}
+			}
+			upgrade(qname, conf)
+		}
+	}
+
+	// Pass 1c (Elm only): space-applied calls (`add 2 2`). Elm's curried-
+	// application idiom is not paren-captured by directCallRE, so an elm-test case
+	// that exercises the SUT via space application yields no direct-call signal
+	// without this gated head-symbol scan (#5375). Gated to tf.lang == "elm" so
+	// other languages are untouched; heads pass the Elm keyword gate AND the
+	// shared isStopword denylist (Expect/Fuzz/describe/test combinators).
+	if tf.lang == "elm" {
+		for _, m := range elmSpaceAppRE.FindAllStringSubmatch(tf.body, -1) {
+			if len(m) < 2 {
+				continue
+			}
+			qname := m[1]
+			if elmKeywordHeads[headIdent(qname)] {
 				continue
 			}
 			if isStopword(qname) || isStopword(tailIdent(qname)) {

--- a/internal/extractors/elm/extractor.go
+++ b/internal/extractors/elm/extractor.go
@@ -271,6 +271,11 @@ func extractElm(src, filePath string) []types.EntityRecord {
 		}
 	}
 
+	// #5375: The Elm Architecture decoration. Import-gated — a no-op for any
+	// file that does not import Browser/Html. Mutates entities in place (re-kinds
+	// Model/Msg, tags the init/update/view triad, flags the Browser program).
+	applyTEA(src, imports, entities)
+
 	return entities
 }
 

--- a/internal/extractors/elm/tea.go
+++ b/internal/extractors/elm/tea.go
@@ -1,0 +1,200 @@
+// The Elm Architecture (TEA) decoration pass (#5375, epic #5360 Group A).
+//
+// Every non-trivial Elm app is structured as The Elm Architecture: an immutable
+// `Model` carrying the app state, a `Msg` custom type enumerating every event,
+// an `update : Msg -> Model -> ...` reducer, a `view : Model -> Html Msg`
+// renderer, and a `main` value wired through `Browser.sandbox/element/document/
+// application`. The base extractor (extractor.go) surfaces all of these as
+// undifferentiated SCOPE.Component / SCOPE.Operation entities — the state/event/
+// render triad is invisible. This pass recognises the pattern and decorates the
+// already-extracted entities so the MVU flow is queryable, mirroring the F#
+// Elmish/Feliz bootstrap (internal/extractors/fsharp/elmish_feliz.go) — Elmish is
+// the F# port of TEA, so the model is directly reusable.
+//
+// Detection is import-gated (`import Browser` / `import Html`) so a plain Elm
+// module (a helper library with no UI) is never mis-classified. When detection
+// fails the pass is a no-op — every base entity is returned unchanged.
+//
+// What it produces (all on top of the base extractor's entities):
+//   - the `Model` type alias       → re-kinded SCOPE.Model, subtype tea_model,
+//     Properties[tea_role]=model
+//   - the `Msg` custom type         → re-kinded SCOPE.Event, subtype tea_msg,
+//     Properties[tea_role]=msg (its `|`-separated variants are recorded on
+//     Properties[tea_variants] as the event set)
+//   - `init` / `update` / `view`    → Properties[tea_role] = init|update|view
+//   - the operation wiring `Browser.sandbox/element/document/application`
+//     (idiomatically `main`) → Properties[tea_program]=true +
+//     Properties[tea_program_kind] = sandbox|element|document|application
+//
+// Honest scope: detection and decoration are structural (regex/heuristic) like
+// the rest of the Elm extractor. Subscriptions, ports, and Cmd/Sub effect
+// threading are recognised only insofar as the program operation is flagged;
+// per-effect extraction is deferred.
+package elm
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+var (
+	// teaImportPrefixes are the import markers that flip a file into TEA mode.
+	// `Browser` hosts every program entry point; `Html` is present in every
+	// view. Either one (prefix match) is sufficient.
+	teaImportPrefixes = []string{"Browser", "Html"}
+
+	// teaProgramRE matches the Browser program entry that wires the MVU triad
+	// into a running program: Browser.sandbox / element / document / application.
+	// Group 1 is the program kind.
+	teaProgramRE = regexp.MustCompile(`\bBrowser\.(sandbox|element|document|application)\b`)
+
+	// teaMsgVariantsRE captures the right-hand side of a `type Msg = ...`
+	// custom-type declaration so its `|`-separated constructor names can be
+	// recorded as the event set. Group 1 is the body up to the next top-level
+	// declaration (a line starting at column 0).
+	teaMsgVariantsRE = regexp.MustCompile(`(?sm)^type\s+Msg\b[^=]*=\s*(.*?)(?:\n\S|\z)`)
+
+	// teaVariantHeadRE pulls the leading constructor name from one `|`-separated
+	// custom-type alternative (e.g. "Increment", "SetName String").
+	teaVariantHeadRE = regexp.MustCompile(`^\s*([A-Z][A-Za-z0-9_]*)`)
+)
+
+// fileUsesTEA reports whether any import marks the file as a TEA frontend module.
+func fileUsesTEA(imports []string) bool {
+	for _, imp := range imports {
+		for _, p := range teaImportPrefixes {
+			if imp == p || strings.HasPrefix(imp, p+".") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// applyTEA decorates the base entities in place when the file is a TEA frontend
+// module. It is a no-op for non-TEA files (wrong language never reaches here;
+// no-match files have no Browser/Html imports).
+//
+// src is the raw Elm source, imports the collected import targets, and entities
+// the slice produced by extractElm.
+func applyTEA(src string, imports []string, entities []types.EntityRecord) {
+	if !fileUsesTEA(imports) {
+		return
+	}
+
+	msgVariants := teaMsgVariants(src)
+
+	// Pass 1: re-kind the MVU data types (Model / Msg) and tag the triad
+	// operations.
+	for i := range entities {
+		e := &entities[i]
+		switch {
+		case e.Kind == "SCOPE.Component" && e.Name == "Model" &&
+			(e.Subtype == "typealias" || e.Subtype == "type"):
+			e.Kind = "SCOPE.Model"
+			e.Subtype = "tea_model"
+			setTEAProp(e, "tea_role", "model")
+			setTEAProp(e, "tea_frontend", "true")
+		case e.Kind == "SCOPE.Component" && e.Name == "Msg" && e.Subtype == "type":
+			e.Kind = "SCOPE.Event"
+			e.Subtype = "tea_msg"
+			setTEAProp(e, "tea_role", "msg")
+			setTEAProp(e, "tea_frontend", "true")
+			if msgVariants != "" {
+				setTEAProp(e, "tea_variants", msgVariants)
+			}
+		case e.Kind == "SCOPE.Operation":
+			if role, ok := teaTriadRole(e.Name); ok {
+				setTEAProp(e, "tea_role", role)
+				setTEAProp(e, "tea_frontend", "true")
+			}
+		}
+	}
+
+	// Pass 2: flag the Browser program bootstrap. The program operation
+	// (idiomatically `main`) is the one whose body wires sandbox/element/
+	// document/application. We re-derive the body from the entity's line span.
+	lines := strings.Split(src, "\n")
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != "SCOPE.Operation" {
+			continue
+		}
+		body := teaEntityBody(lines, e)
+		if body == "" {
+			continue
+		}
+		if m := teaProgramRE.FindStringSubmatch(body); m != nil {
+			setTEAProp(e, "tea_program", "true")
+			setTEAProp(e, "tea_program_kind", m[1])
+			setTEAProp(e, "tea_frontend", "true")
+		}
+	}
+}
+
+// teaTriadRole classifies an operation name as part of the TEA MVU triad. The
+// convention names these `init`, `update`, and `view`; a trailing qualifier is
+// tolerated (`updateForm`, `viewMain`) so a component module's locally-scoped
+// triad is still recognised.
+func teaTriadRole(name string) (string, bool) {
+	switch name {
+	case "init":
+		return "init", true
+	case "update":
+		return "update", true
+	case "view":
+		return "view", true
+	}
+	switch {
+	case strings.HasPrefix(name, "init"):
+		return "init", true
+	case strings.HasPrefix(name, "update"):
+		return "update", true
+	case strings.HasPrefix(name, "view"):
+		return "view", true
+	}
+	return "", false
+}
+
+// teaMsgVariants returns a comma-separated list of the `Msg` custom type's
+// constructor names (the event set), or "" when no `type Msg = ...` is present.
+func teaMsgVariants(src string) string {
+	m := teaMsgVariantsRE.FindStringSubmatch(src)
+	if m == nil {
+		return ""
+	}
+	var variants []string
+	seen := map[string]bool{}
+	for _, alt := range strings.Split(m[1], "|") {
+		hm := teaVariantHeadRE.FindStringSubmatch(alt)
+		if hm == nil {
+			continue
+		}
+		name := hm[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		variants = append(variants, name)
+	}
+	return strings.Join(variants, ",")
+}
+
+// teaEntityBody re-derives the source body for an entity from its [StartLine,
+// EndLine] span (1-based, inclusive). Returns "" when the span is degenerate.
+func teaEntityBody(lines []string, e *types.EntityRecord) string {
+	if e.StartLine <= 0 || e.EndLine < e.StartLine || e.EndLine > len(lines) {
+		return ""
+	}
+	return strings.Join(lines[e.StartLine-1:e.EndLine], "\n")
+}
+
+// setTEAProp sets a Property on an entity, allocating the map on first use.
+func setTEAProp(e *types.EntityRecord, key, val string) {
+	if e.Properties == nil {
+		e.Properties = map[string]string{}
+	}
+	e.Properties[key] = val
+}

--- a/internal/extractors/elm/tea_test.go
+++ b/internal/extractors/elm/tea_test.go
@@ -1,0 +1,136 @@
+package elm_test
+
+import "testing"
+
+// teaCounter is a canonical The-Elm-Architecture counter app: a Model alias, a
+// Msg custom type, the init/update/view triad, and the Browser.sandbox program
+// entry wired through `main`.
+const teaCounter = `module Main exposing (main)
+
+import Browser
+import Html exposing (Html, button, div, text)
+import Html.Events exposing (onClick)
+
+
+type alias Model =
+    { count : Int }
+
+
+type Msg
+    = Increment
+    | Decrement
+    | Reset
+
+
+init : Model
+init =
+    { count = 0 }
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        Increment ->
+            { model | count = model.count + 1 }
+
+        Decrement ->
+            { model | count = model.count - 1 }
+
+        Reset ->
+            { model | count = 0 }
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        , text (String.fromInt model.count)
+        , button [ onClick Increment ] [ text "+" ]
+        ]
+
+
+main : Program () Model Msg
+main =
+    Browser.sandbox { init = init, update = update, view = view }
+`
+
+func TestTEA_ModelRekind(t *testing.T) {
+	ents := runElm(t, teaCounter, "src/Main.elm")
+	m := elmFind(ents, "Model", "SCOPE.Model")
+	if m == nil {
+		t.Fatal("Model not re-kinded to SCOPE.Model")
+	}
+	if m.Subtype != "tea_model" {
+		t.Errorf("Model subtype=%q want tea_model", m.Subtype)
+	}
+	if m.Properties["tea_role"] != "model" {
+		t.Errorf("Model tea_role=%q want model", m.Properties["tea_role"])
+	}
+}
+
+func TestTEA_MsgRekindWithVariants(t *testing.T) {
+	ents := runElm(t, teaCounter, "src/Main.elm")
+	msg := elmFind(ents, "Msg", "SCOPE.Event")
+	if msg == nil {
+		t.Fatal("Msg not re-kinded to SCOPE.Event")
+	}
+	if msg.Subtype != "tea_msg" {
+		t.Errorf("Msg subtype=%q want tea_msg", msg.Subtype)
+	}
+	if got := msg.Properties["tea_variants"]; got != "Increment,Decrement,Reset" {
+		t.Errorf("Msg tea_variants=%q want Increment,Decrement,Reset", got)
+	}
+}
+
+func TestTEA_TriadRoles(t *testing.T) {
+	ents := runElm(t, teaCounter, "src/Main.elm")
+	want := map[string]string{"init": "init", "update": "update", "view": "view"}
+	for name, role := range want {
+		op := elmFind(ents, name, "SCOPE.Operation")
+		if op == nil {
+			t.Fatalf("%s operation missing", name)
+		}
+		if op.Properties["tea_role"] != role {
+			t.Errorf("%s tea_role=%q want %q", name, op.Properties["tea_role"], role)
+		}
+	}
+}
+
+func TestTEA_ProgramFlagged(t *testing.T) {
+	ents := runElm(t, teaCounter, "src/Main.elm")
+	main := elmFind(ents, "main", "SCOPE.Operation")
+	if main == nil {
+		t.Fatal("main operation missing")
+	}
+	if main.Properties["tea_program"] != "true" {
+		t.Errorf("main tea_program=%q want true", main.Properties["tea_program"])
+	}
+	if main.Properties["tea_program_kind"] != "sandbox" {
+		t.Errorf("main tea_program_kind=%q want sandbox", main.Properties["tea_program_kind"])
+	}
+}
+
+// TestTEA_NonFrontendNoop confirms a plain Elm helper module (no Browser/Html
+// import) is NOT decorated — Model/Msg stay plain SCOPE.Component entities.
+func TestTEA_NonFrontendNoop(t *testing.T) {
+	const helper = `module Util exposing (clamp)
+
+import String
+
+
+type alias Model =
+    { x : Int }
+
+
+clamp : Int -> Int
+clamp n =
+    String.length (String.fromInt n)
+`
+	ents := runElm(t, helper, "src/Util.elm")
+	if m := elmFind(ents, "Model", "SCOPE.Model"); m != nil {
+		t.Error("Model should NOT be re-kinded in a non-frontend module")
+	}
+	if m := elmFind(ents, "Model", "SCOPE.Component"); m == nil {
+		t.Error("Model should remain a plain SCOPE.Component in a non-frontend module")
+	}
+}


### PR DESCRIPTION
Closes #5375 (epic #5360, Group A — bootstrap). Three coherent, honest records for the Elm ecosystem, all heuristic (no bundled grammar), mirroring the F# Elmish/Feliz + Nim/Lua manifest/testmap precedents.

## 1. The Elm Architecture (TEA) — `internal/extractors/elm/tea.go`
Import-gated (`Browser`/`Html`) decoration over the base extractor's entities (no-op for a plain Elm helper module):
- `type alias Model` → re-kinded **SCOPE.Model** (`tea_model`, `tea_role=model`)
- `type Msg = A | B | ...` → re-kinded **SCOPE.Event** (`tea_msg`); the `|`-separated variants recorded on `Properties[tea_variants]` as the event set
- `init` / `update` / `view` → `Properties[tea_role]`
- the `Browser.sandbox/element/document/application` program entry (idiomatically `main`) → `Properties[tea_program]=true` + `tea_program_kind`

Record `lang.elm.framework.tea` (http_framework / ui_frontend): **state_management** full, **component_extraction** partial (view tagged; no RENDERS edges — honest, unlike the F# Feliz pass), **tests_linkage** full.

## 2. elm.json — `internal/extractors/cross/manifest/elm.go`
JSON manifest parser for both shapes: **application** (`dependencies.direct`/`indirect` exact-pinned + `test-dependencies`; indirect deps flagged `indirect=true`, test deps `is_dev=true`) and **package** (flat `author/project: version-range` map). `elm.json` is classified `elm` (so it reaches the cross-manifest pass) and wired into IsManifest/detectPackageManager/dispatchParser/parsers as `package_manager=elm`; emits DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes like every ecosystem.

Record `lang.elm.tool.elm-json` (package_manager): **manifest_parsing** full, **lockfile_parsing** N/A (elm.json IS the exact-pinned lock).

## 3. elm-test — `internal/extractors/cross/testmap/frameworks_elm.go`
`describe "..." [ test "..." <| \_ -> ... ]` / `fuzz*` leaf detection (description = last string literal), list/off-side-rule body extractor, and an **Elm space-applied call resolver** (`elmSpaceAppRE`, gated `lang==elm`) that links curried production calls (`add 2 2` — invisible to the paren `directCallRE`) to high-confidence TESTS edges. Expect/Fuzz/describe/test DSL stop-worded. FILENAME/PATH gated (`*Test.elm` / `tests/`) — deliberately NOT import gated, since the bare `test`/`expect` tokens would over-match the substring import matcher (e.g. `gtest/gtest.h`).

## Fixtures & tests (per capability, value-asserting)
- TEA: `tea_test.go` — counter app; ModelRekind / MsgRekindWithVariants / TriadRoles / ProgramFlagged / NonFrontendNoop
- elm.json: `elm_test.go` — application + package fixtures; ApplicationDeps / PackageDeps / DependsOnEdges / IsManifest
- elm-test: `frameworks_elm_test.go` — DirectCallHighConfidence / BodyScoped (sibling no-leak) / FuzzCase / AssertionDSLNotSubject

All touched packages green (`go test` elm / manifest / testmap / classifier / types); `coverage validate` + `fmt --check` green; coverage docs regenerated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)