### PR TITLE
feat(zig): bootstrap tool records — build.zig build system + zig test (#5377)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 113 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **OCaml**: 1 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2
+**Total**: 115 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **OCaml**: 1 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2 · **zig**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -121,3 +121,5 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | ✅ | |
 | [solidity](../by-language/solidity.md) | [Foundry (forge)](../detail/lang.solidity.tool.foundry.md) | 🔴 | 🟢 | |
 | [solidity](../by-language/solidity.md) | [Hardhat](../detail/lang.solidity.tool.hardhat.md) | 🔴 | 🟢 | |
+| [zig](../by-language/zig.md) | [zig build (build.zig)](../detail/build.zig.md) | ✅ | ✅ | |
+| [zig](../by-language/zig.md) | [zig test](../detail/test.zig.md) | ✅ | ✅ | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 29 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1
+**Total**: 30 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1 · **zig**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -37,3 +37,4 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | 🔴 | ✅ | |
 | [scala](../by-language/scala.md) | [build.sbt](../detail/pkg.sbt.md) | — | — | 🔴 | |
 | [swift](../by-language/swift.md) | [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | 🟢 | |
+| [zig](../by-language/zig.md) | [build.zig.zon (Zig package manifest)](../detail/pkg.zig-zon.md) | — | — | ✅ | |

--- a/docs/coverage/by-language/zig.md
+++ b/docs/coverage/by-language/zig.md
@@ -1,12 +1,28 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Zig
+# zig
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 3 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/zig/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.zig.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [build.zig.zon (Zig package manifest)](../detail/pkg.zig-zon.md) | — | — | — | ✅ | — | |
+| [zig build (build.zig)](../detail/build.zig.md) | ✅ | — | — | — | ✅ | |
+| [zig test](../detail/test.zig.md) | ✅ | — | — | — | ✅ | |

--- a/docs/coverage/detail/build.zig.md
+++ b/docs/coverage/detail/build.zig.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.zig` — zig build (build.zig)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [zig](../by-language/zig.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | ✅ `full` | `2026-06-24` | 5377 | `internal/extractors/cross/manifest/buildzig.go`<br>`internal/extractors/cross/manifest/buildzig_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | build.zig b.dependency("name", ...) calls parsed into external_dependency + DEPENDS_ON + SCOPE.Package records under package_manager=zig (buildZigDependencyRE; receiver-agnostic so non-canonical builder names match). zig build is both build orchestrator and dependency fetcher — there is no separate package-manager binary. Wired into IsManifest/detectPackageManager/dispatchParser/parsers by exact basename build.zig. Proven by TestBuildZig_DependencyGraph / _DependsOnEdges. |
+| Target extraction | ✅ `full` | `2026-06-24` | 5377 | `internal/extractors/cross/manifest/buildzig.go`<br>`internal/extractors/cross/manifest/buildzig_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | build.zig declared build targets (addExecutable/addStaticLibrary/addSharedLibrary/addObject/addModule/addTest/addLibrary) are mined by extractBuildZigTargets (name from the .name="..." options field or the leading positional string for addModule; quote-aware matchingParen arg-slice walk) and surfaced as a comma-joined build_targets property on the manifest project anchor — queryable without a new entity kind, mirroring the cmake target treatment. build.zig.zon does NOT carry build_targets. Honest partial slice: comptime-generated targets are not modelled. Proven by TestBuildZig_TargetExtraction / TestBuildZigZon_NoBuildTargets. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.zig ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/pkg.zig-zon.md
+++ b/docs/coverage/detail/pkg.zig-zon.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `pkg.zig-zon` — build.zig.zon (Zig package manifest)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [zig](../by-language/zig.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Lockfile parsing | — `not_applicable` | `2026-06-24` | 5377 | `internal/classifier/classifier.go`<br>`internal/extractors/cross/manifest/buildzig.go`<br>`internal/extractors/cross/manifest/buildzig_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | build.zig.zon IS the lockfile — every dependency is content-addressed by a SHA-256 .hash (the exact, immutable pin), so there is no separate lockfile format. The pinned version is recovered directly from manifest_parsing (the .hash value). |
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5377 | `internal/classifier/classifier.go`<br>`internal/extractors/cross/manifest/buildzig.go`<br>`internal/extractors/cross/manifest/buildzig_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | build.zig.zon is the Zig Object Notation package manifest (since Zig 0.11). parseBuildZigZon locates the top-level .dependencies = .{ ... } anonymous-struct literal (zonDependenciesHeadRE + a quote-aware matchingBrace hand-walk since regex cannot balance nested .{ }), then mines each .name = .{ .url=..., .hash=... } entry (zonDepEntryRE; bare .ident and .@"quoted ident" field shapes). The version is the content .hash (preferred — the exact pin) falling back to the .url archive. package_manager=zig; emits DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes like every other ecosystem. Wired into IsManifest/detectPackageManager/dispatchParser/parsers by exact basename build.zig.zon. Proven by TestBuildZigZon_Dependencies / TestBuildZig_DependsOnEdges / TestBuildZig_IsManifest. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update pkg.zig-zon ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/test.zig.md
+++ b/docs/coverage/detail/test.zig.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `test.zig` — zig test
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [zig](../by-language/zig.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | ✅ `full` | `2026-06-24` | 5377 | `internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_zig.go`<br>`internal/extractors/cross/testmap/frameworks_zig_test.go`<br>`internal/extractors/cross/testmap/resolver.go` | zig test linkage via the cross-language testmap extractor. detectZigTest (frameworks_zig.go) detects top-level test "name" { ... } / test ident { ... } / anonymous test { ... } blocks (zigTestRE, line-anchored so a test substring in an ident/string/comment never opens a block). Each block's balanced brace body (extractBraceBody) is scanned by the resolver: a direct production call (add(2,2), invisible-free via directCallRE) resolves to a high-confidence TESTS edge, and the identifier form test add { } seeds add as the naming-convention subject. The std.testing.* assertion DSL (expect/expectEqual/expectError/... bare + dotted forms) plus the bare try/expect tokens are denylisted in resolver.go so test-harness plumbing never surfaces as the SUT. FILENAME gated on the .zig extension (Zig tests live in ANY .zig file, often the production source itself) — NOT import gated (a bare test token would over-match the substring import matcher, e.g. C++ gtest/gtest.h; the elm-test precedent). The detector self-confirms — a .zig file with no test block yields zero cases and is dropped. Proven by TestZigTest_DirectCallHighConfidence / _IdentifierForm / _BodyScoped / _AssertionDSLNotSubject / _NonTestZigDropped. |
+| Target extraction | ✅ `full` | `2026-06-24` | 5377 | `internal/extractors/cross/testmap/frameworks.go`<br>`internal/extractors/cross/testmap/frameworks_zig.go`<br>`internal/extractors/cross/testmap/frameworks_zig_test.go`<br>`internal/extractors/cross/testmap/resolver.go` | Each test block becomes one SCOPE.Pattern test_case entity: quoted descriptions normalise to a bare snake_case qname (nimTestCaseName — no framework prefix), the identifier form keeps the ident, and anonymous tests get an indexed anonymous_test_N name. Sibling-test bodies are isolated (the brace walk is balanced + quote-aware) so a call in one test never leaks into another. Honest partial slice: comptime/dynamically-generated tests are not modelled. Proven by TestZigTest_BodyScoped / _IdentifierForm. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update test.zig ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (29 active · 10 placeholder) · **Frameworks**: 261 · **ORMs**: 186 · **Tools**: 142 · **Other**: 208
+**Languages**: 39 (30 active · 9 placeholder) · **Frameworks**: 261 · **ORMs**: 186 · **Tools**: 145 · **Other**: 208
 
 ## Coverage by language
 
@@ -36,6 +36,7 @@
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
 | [JCL](by-language/jcl.md) | 0 | 0 | 0 | 1 |
 | [solidity](by-language/solidity.md) | 0 | 2 | 0 | 2 |
+| [zig](by-language/zig.md) | 0 | 3 | 0 | 0 |
 
 ## Cross-cutting infrastructure
 
@@ -81,6 +82,5 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Standard ML](by-language/sml.md) |
 | [VHDL](by-language/vhdl.md) |
 | [Verilog](by-language/verilog.md) |
-| [Zig](by-language/zig.md) |
 
-Total: 261 frameworks · 142 tools · 186 ORMs · 208 other
+Total: 261 frameworks · 145 tools · 186 ORMs · 208 other

--- a/internal/extractors/cross/manifest/buildzig.go
+++ b/internal/extractors/cross/manifest/buildzig.go
@@ -1,0 +1,264 @@
+// buildzig.go — Zig build system + package manifest parsers (#5377, epic #5360).
+//
+// Zig has no separate package-manager binary: `zig build` is both the build
+// orchestrator and the dependency fetcher. Two files describe a Zig package:
+//
+//	build.zig      — the build script (Zig source). `pub fn build(b: *std.Build)`
+//	                 declares build TARGETS (b.addExecutable / addStaticLibrary /
+//	                 addSharedLibrary / addObject / addModule / addTest) and pulls
+//	                 in declared dependencies via b.dependency("name", …). It is
+//	                 the Zig analog of CMakeLists.txt / a Makefile (modelled here
+//	                 as a build_system, like cmake/make/xmake).
+//	build.zig.zon  — the package MANIFEST (Zig Object Notation, since Zig 0.11).
+//	                 The `.dependencies = .{ .name = .{ .url=…, .hash=… } }` map
+//	                 declares external dependencies; `.name`/`.version` describe
+//	                 the package itself. Dependencies are content-addressed by a
+//	                 SHA-256 `.hash`, so build.zig.zon IS the lockfile — there is
+//	                 no separate lockfile format (lockfile_parsing is N/A).
+//
+// Both feed the shared manifest entity/edge builder (DEPENDS_ON +
+// DEPENDS_ON_PACKAGE + SBOM package nodes) under package_manager "zig". The
+// build.zig TARGET names are surfaced as a comma-joined "build_targets" property
+// on the project anchor so target_extraction is queryable without a new entity
+// kind, mirroring the cmake target treatment.
+package manifest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Parser: build.zig.zon  (Zig package manifest — manifest_parsing)
+// ---------------------------------------------------------------------------
+
+// zonDependenciesBlockRE captures the body of the top-level `.dependencies =
+// .{ … }` anonymous-struct literal. Group 1 is the inner content, which
+// zonDepEntryRE then mines for individual `.name = .{ … }` entries. The match is
+// brace-balanced via a hand walk (regex cannot balance nested `.{ }`), so this
+// RE only locates the `.dependencies = .{` head; the caller slices to the
+// matching close brace.
+var zonDependenciesHeadRE = regexp.MustCompile(`(?s)\.dependencies\s*=\s*\.\{`)
+
+// zonDepEntryRE matches one dependency entry header inside the dependencies
+// block: `.foo = .{`. Group 1 is the dependency name (the field identifier).
+// Zig field names are `.ident` or `.@"quoted ident"`; both shapes are captured.
+var zonDepEntryRE = regexp.MustCompile(`\.(?:@"([^"\n]+)"|([A-Za-z_][\w]*))\s*=\s*\.\{`)
+
+// zonUrlRE / zonHashRE pull the `.url = "…"` and `.hash = "…"` fields out of a
+// single dependency entry body so the resolved version (the content hash, or the
+// archive URL tail) can be recorded as the dep version.
+var zonUrlRE = regexp.MustCompile(`\.url\s*=\s*"([^"\n]+)"`)
+var zonHashRE = regexp.MustCompile(`\.hash\s*=\s*"([^"\n]+)"`)
+
+// matchingBrace returns the index just past the `}` that closes the `.{` whose
+// opening brace is at openIdx (openIdx points at the `{`). Returns -1 when no
+// balanced close is found. Quote-aware so a `{`/`}` inside a string literal is
+// ignored.
+func matchingBrace(s string, openIdx int) int {
+	depth := 0
+	inStr := false
+	for i := openIdx; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}
+
+// parseBuildZigZon parses a build.zig.zon manifest and returns its declared
+// external dependencies. Each `.name = .{ .url=…, .hash=… }` entry under the
+// top-level `.dependencies` block is one runtime dependency; the version is the
+// content hash (preferred — it is the exact pin) falling back to the archive URL.
+func parseBuildZigZon(source string) []dep {
+	head := zonDependenciesHeadRE.FindStringIndex(source)
+	if head == nil {
+		return nil
+	}
+	// head[1]-1 is the `{` of the `.{` that opens the dependencies block.
+	open := head[1] - 1
+	end := matchingBrace(source, open)
+	if end < 0 {
+		end = len(source)
+	}
+	block := source[open+1 : end-1]
+
+	var out []dep
+	seen := map[string]bool{}
+	entries := zonDepEntryRE.FindAllStringSubmatchIndex(block, -1)
+	for i, m := range entries {
+		// Group 1 (quoted) or group 2 (bare) is the dependency name.
+		name := ""
+		if m[2] >= 0 {
+			name = block[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			name = block[m[4]:m[5]]
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		// The entry body runs from this entry's `.{` to the next entry header
+		// (or the end of the block) — a cheap slice that need not be balanced
+		// since we only mine .url/.hash scalar fields from it.
+		bodyStart := m[1]
+		bodyEnd := len(block)
+		if i+1 < len(entries) {
+			bodyEnd = entries[i+1][0]
+		}
+		body := block[bodyStart:bodyEnd]
+		version := ""
+		if hm := zonHashRE.FindStringSubmatch(body); hm != nil {
+			version = hm[1]
+		} else if um := zonUrlRE.FindStringSubmatch(body); um != nil {
+			version = um[1]
+		}
+		out = append(out, dep{name: name, version: version, kind: "runtime"})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Parser: build.zig  (Zig build system — dependency_graph + target_extraction)
+// ---------------------------------------------------------------------------
+
+// buildZigDependencyRE matches a `b.dependency("name", …)` call (the build-script
+// side of a build.zig.zon dependency: it materialises a declared dependency for
+// use in the build graph). Group 1 is the dependency name. The receiver is any
+// identifier (`b`, `builder`, …) so non-canonical builder names still match.
+var buildZigDependencyRE = regexp.MustCompile(`\b\w+\.dependency\(\s*"([^"\n]+)"`)
+
+// buildZigTargetRE matches the build-target constructors. Zig 0.12+ takes an
+// options struct whose `.name = "…"` field is the target name:
+//
+//	const exe = b.addExecutable(.{ .name = "myapp", … });
+//	const lib = b.addStaticLibrary(.{ .name = "mylib", … });
+//	const mod = b.addModule("mymod", .{ … });            // addModule: positional
+//
+// Group 1 is the constructor (addExecutable/…); group 2 is the positional name
+// string when present (addModule form); the struct-field `.name` form is mined
+// separately from the call's argument slice.
+var buildZigTargetRE = regexp.MustCompile(
+	`\b\w+\.(addExecutable|addStaticLibrary|addSharedLibrary|addObject|addModule|addTest|addLibrary)\s*\(`)
+
+// buildZigNameFieldRE pulls a `.name = "…"` field out of a target constructor's
+// argument slice.
+var buildZigNameFieldRE = regexp.MustCompile(`\.name\s*=\s*"([^"\n]+)"`)
+
+// buildZigPositionalNameRE pulls the leading positional `"name"` argument of an
+// addModule("name", .{…}) call.
+var buildZigPositionalNameRE = regexp.MustCompile(`^\s*"([^"\n]+)"`)
+
+// extractBuildZigTargets returns the names of the build targets declared in a
+// build.zig (addExecutable/addStaticLibrary/addSharedLibrary/addObject/addModule/
+// addTest/addLibrary). Names come from the `.name = "…"` options field or the
+// leading positional string (addModule). Deduplicated, declaration order kept.
+func extractBuildZigTargets(source string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, m := range buildZigTargetRE.FindAllStringSubmatchIndex(source, -1) {
+		// The call's argument slice runs from the `(` (m[1]-1) to its matching `)`.
+		argStart := m[1] - 1
+		argEnd := matchingParen(source, argStart)
+		if argEnd < 0 {
+			argEnd = len(source)
+		}
+		args := source[argStart+1 : argEnd-1]
+		name := ""
+		if pm := buildZigPositionalNameRE.FindStringSubmatch(args); pm != nil {
+			name = pm[1]
+		} else if nm := buildZigNameFieldRE.FindStringSubmatch(args); nm != nil {
+			name = nm[1]
+		}
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
+}
+
+// matchingParen returns the index just past the `)` that closes the `(` at
+// openIdx. Quote-aware. Returns -1 on imbalance.
+func matchingParen(s string, openIdx int) int {
+	depth := 0
+	inStr := false
+	for i := openIdx; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}
+
+// parseBuildZig parses a build.zig build script and returns the dependencies it
+// materialises via b.dependency("…", …). The declared build TARGET names are NOT
+// dependencies; they are surfaced separately by extractBuildZigTargets and
+// attached to the project anchor as a property (see buildZigTargetsProperty).
+func parseBuildZig(source string) []dep {
+	var out []dep
+	seen := map[string]bool{}
+	for _, m := range buildZigDependencyRE.FindAllStringSubmatch(source, -1) {
+		name := m[1]
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, dep{name: name, kind: "runtime"})
+	}
+	return out
+}
+
+// buildZigTargetsProperty returns the comma-joined build-target names for a
+// build.zig source, or "" when none are found / the file is not a build.zig.
+// Surfaced on the manifest project anchor as the "build_targets" property so
+// target_extraction is queryable without introducing a new entity kind.
+func buildZigTargetsProperty(filePath, source string) string {
+	if !strings.HasSuffix(filePath, "build.zig") {
+		return ""
+	}
+	targets := extractBuildZigTargets(source)
+	if len(targets) == 0 {
+		return ""
+	}
+	return strings.Join(targets, ",")
+}

--- a/internal/extractors/cross/manifest/buildzig_test.go
+++ b/internal/extractors/cross/manifest/buildzig_test.go
@@ -1,0 +1,187 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// realBuildZigZon is a representative build.zig.zon package manifest (shape from
+// `zig init` + a couple of fetched deps). It exercises the .dependencies map,
+// the content-addressed .hash pin (which IS the lockfile), and a .url fallback.
+const realBuildZigZon = `.{
+    .name = "myapp",
+    .version = "0.1.0",
+    .minimum_zig_version = "0.13.0",
+    .dependencies = .{
+        .zap = .{
+            .url = "https://github.com/zigzap/zap/archive/v0.8.0.tar.gz",
+            .hash = "1220abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345",
+        },
+        .known_folders = .{
+            .url = "https://github.com/ziglibs/known-folders/archive/main.tar.gz",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}`
+
+// realBuildZig is a representative build.zig build script. It declares an
+// executable + a static library target and pulls in a build-graph dependency
+// via b.dependency(...).
+const realBuildZig = `const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "myapp",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const lib = b.addStaticLibrary(.{
+        .name = "mylib",
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const utils = b.addModule("utils", .{
+        .root_source_file = b.path("src/utils.zig"),
+    });
+    _ = utils;
+
+    const zap = b.dependency("zap", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.root_module.addImport("zap", zap.module("zap"));
+
+    b.installArtifact(exe);
+    b.installArtifact(lib);
+}
+`
+
+func anchorRecord(records []types.EntityRecord) *types.EntityRecord {
+	for i := range records {
+		if records[i].Kind == "SCOPE.Component" && records[i].Subtype == "project" {
+			return &records[i]
+		}
+	}
+	return nil
+}
+
+// TestBuildZigZon_Dependencies proves the ZON manifest's .dependencies map is
+// parsed into runtime deps under package_manager=zig, with the content hash as
+// the pinned version (and a .url fallback when no .hash is present).
+func TestBuildZigZon_Dependencies(t *testing.T) {
+	deps := depEntities(runExtract(t, "build.zig.zon", realBuildZigZon))
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps, got %d: %+v", len(deps), depNames(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "zig" {
+			t.Errorf("%s: package_manager=%q want zig", d.Name, d.Properties["package_manager"])
+		}
+	}
+	// zap pins to its content hash.
+	if d := depByName(deps, "zap"); d == nil {
+		t.Error("zap dep missing")
+	} else if !strings.HasPrefix(d.Properties["version"], "1220") {
+		t.Errorf("zap version=%q want the content hash", d.Properties["version"])
+	}
+	// known_folders has no .hash, so the version falls back to the archive URL.
+	if d := depByName(deps, "known_folders"); d == nil {
+		t.Error("known_folders dep missing")
+	} else if !strings.Contains(d.Properties["version"], "known-folders") {
+		t.Errorf("known_folders version=%q want the url fallback", d.Properties["version"])
+	}
+}
+
+// TestBuildZig_DependencyGraph proves b.dependency("name", …) calls in the build
+// script materialise build-graph dependencies under package_manager=zig.
+func TestBuildZig_DependencyGraph(t *testing.T) {
+	deps := depEntities(runExtract(t, "build.zig", realBuildZig))
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 build-graph dep, got %d: %+v", len(deps), depNames(deps))
+	}
+	if d := depByName(deps, "zap"); d == nil {
+		t.Error("zap build-graph dep missing")
+	} else if d.Properties["package_manager"] != "zig" {
+		t.Errorf("zap package_manager=%q want zig", d.Properties["package_manager"])
+	}
+}
+
+// TestBuildZig_TargetExtraction proves the declared build targets (addExecutable
+// / addStaticLibrary / addModule) are surfaced as the project anchor's
+// "build_targets" property.
+func TestBuildZig_TargetExtraction(t *testing.T) {
+	records := runExtract(t, "build.zig", realBuildZig)
+	anchor := anchorRecord(records)
+	if anchor == nil {
+		t.Fatal("no project anchor emitted for build.zig")
+	}
+	targets := anchor.Properties["build_targets"]
+	if targets == "" {
+		t.Fatal("build_targets property is empty")
+	}
+	for _, want := range []string{"myapp", "mylib", "utils"} {
+		if !strings.Contains(targets, want) {
+			t.Errorf("build_targets=%q missing target %q", targets, want)
+		}
+	}
+}
+
+// TestBuildZigZon_NoBuildTargets proves the build_targets property is NOT set on
+// a build.zig.zon manifest (target extraction is a build.zig-only concern).
+func TestBuildZigZon_NoBuildTargets(t *testing.T) {
+	records := runExtract(t, "build.zig.zon", realBuildZigZon)
+	anchor := anchorRecord(records)
+	if anchor == nil {
+		t.Fatal("no project anchor emitted for build.zig.zon")
+	}
+	if anchor.Properties["build_targets"] != "" {
+		t.Errorf("build.zig.zon must not carry build_targets, got %q",
+			anchor.Properties["build_targets"])
+	}
+}
+
+// TestBuildZig_DependsOnEdges confirms the manifest emits DEPENDS_ON edges like
+// every other ecosystem (the cross-manifest contract).
+func TestBuildZig_DependsOnEdges(t *testing.T) {
+	records := runExtract(t, "build.zig.zon", realBuildZigZon)
+	var dependsOn int
+	for _, r := range records {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "DEPENDS_ON" {
+				dependsOn++
+				if rel.Properties["package_manager"] != "zig" {
+					t.Errorf("DEPENDS_ON package_manager=%q want zig", rel.Properties["package_manager"])
+				}
+			}
+		}
+	}
+	if dependsOn != 2 {
+		t.Errorf("expected 2 DEPENDS_ON edges, got %d", dependsOn)
+	}
+}
+
+// TestBuildZig_IsManifest pins the dispatch wiring: build.zig and build.zig.zon
+// are recognised and routed to the zig package manager.
+func TestBuildZig_IsManifest(t *testing.T) {
+	for _, p := range []string{"build.zig", "build.zig.zon", "sub/build.zig"} {
+		if !IsManifest(p) {
+			t.Errorf("%s should be recognised as a manifest", p)
+		}
+		if pm := detectPackageManager(p); pm != "zig" {
+			t.Errorf("detectPackageManager(%s)=%q want zig", p, pm)
+		}
+	}
+}

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -203,6 +203,12 @@ var exactManifestNames = map[string]bool{
 	// and package (flat version-range) shapes. elm.json IS the lockfile (deps are
 	// exactly pinned), so there is no separate lockfile format.
 	"elm.json": true,
+	// Zig — `zig build` is both build orchestrator and dependency fetcher (#5377).
+	// build.zig is the build script (targets + b.dependency() deps); build.zig.zon
+	// is the content-addressed package manifest. build.zig.zon IS the lockfile
+	// (.hash pins each dep), so there is no separate lockfile format.
+	"build.zig":     true,
+	"build.zig.zon": true,
 }
 
 // IsManifest returns true when filePath names a supported manifest file.
@@ -299,6 +305,9 @@ func detectPackageManager(filePath string) string {
 		"dune-project": "dune",
 		// Elm — elm.json manifest
 		"elm.json": "elm",
+		// Zig — build.zig (build system) + build.zig.zon (package manifest)
+		"build.zig":     "zig",
+		"build.zig.zon": "zig",
 	}
 	basename := filepath.Base(filePath)
 	if v, ok := pm[basename]; ok {
@@ -1955,6 +1964,11 @@ var parsers = map[string]parserFn{
 	"dune-project": parseDuneProject,
 	// Elm — elm.json manifest (application + package shapes).
 	"elm.json": parseElmJSON,
+	// Zig — build.zig (b.dependency() build-graph deps) + build.zig.zon (ZON
+	// package manifest). Build-target extraction for build.zig is handled in
+	// buildEntitiesAndRels via buildZigTargetsProperty (#5377).
+	"build.zig":     parseBuildZig,
+	"build.zig.zon": parseBuildZigZon,
 }
 
 func dispatchParser(filePath, source string) (string, []dep) {
@@ -2000,6 +2014,13 @@ func dispatchParser(filePath, source string) (string, []dep) {
 // ---------------------------------------------------------------------------
 
 func buildEntitiesAndRels(filePath, packageManager string, deps []dep) []types.EntityRecord {
+	return buildEntitiesAndRelsWithProps(filePath, packageManager, deps, nil)
+}
+
+// buildEntitiesAndRelsWithProps is buildEntitiesAndRels with extra properties to
+// merge onto the project-anchor entity (e.g. the Zig build.zig "build_targets"
+// list). A nil/empty map is identical to buildEntitiesAndRels.
+func buildEntitiesAndRelsWithProps(filePath, packageManager string, deps []dep, anchorProps map[string]string) []types.EntityRecord {
 	var out []types.EntityRecord
 	projRef := projectRef(filePath)
 	seen := map[string]bool{}
@@ -2018,6 +2039,16 @@ func buildEntitiesAndRels(filePath, packageManager string, deps []dep) []types.E
 	// language-level entity. The `ref` property is what byQualifiedName
 	// keys off (resolve/refs.go line ~1662); we set QualifiedName too for
 	// belt-and-braces resolution.
+	anchorProperties := map[string]string{
+		"package_manager": packageManager,
+		"ref":             projRef,
+		"provenance":      "INFERRED_FROM_PACKAGE_MANIFEST",
+	}
+	// Merge caller-supplied anchor properties (e.g. the Zig build.zig
+	// "build_targets" list, #5377). A nil/empty map is a no-op.
+	for k, v := range anchorProps {
+		anchorProperties[k] = v
+	}
 	out = append(out, types.EntityRecord{
 		Name:          filepath.Base(filePath),
 		Kind:          "SCOPE.Component",
@@ -2025,12 +2056,8 @@ func buildEntitiesAndRels(filePath, packageManager string, deps []dep) []types.E
 		SourceFile:    filePath,
 		Language:      "",
 		QualifiedName: projRef,
-		Properties: map[string]string{
-			"package_manager": packageManager,
-			"ref":             projRef,
-			"provenance":      "INFERRED_FROM_PACKAGE_MANIFEST",
-		},
-		QualityScore: 0.5,
+		Properties:    anchorProperties,
+		QualityScore:  0.5,
 	})
 
 	for _, d := range deps {
@@ -2200,5 +2227,14 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		attribute.Int("total_found", depCount+devCount),
 	)
 
-	return buildEntitiesAndRels(file.Path, pm, deps), nil
+	// Zig build.zig — surface the declared build-target names (addExecutable/
+	// addStaticLibrary/addModule/…) on the project anchor as a "build_targets"
+	// property so target_extraction is queryable without a new entity kind
+	// (#5377). Empty for every other manifest.
+	var anchorProps map[string]string
+	if targets := buildZigTargetsProperty(file.Path, string(file.Content)); targets != "" {
+		anchorProps = map[string]string{"build_targets": targets}
+	}
+
+	return buildEntitiesAndRelsWithProps(file.Path, pm, deps, anchorProps), nil
 }

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -2384,6 +2384,22 @@ var frameworkOrder = []frameworkEntry{
 		},
 		detect: detectElmTest,
 	},
+	// Zig — `zig test` (#5377). Top-level `test "name" { … }` / `test ident { … }`
+	// blocks compiled by `zig test` / `zig build test`. Zig tests live in ANY
+	// `.zig` file (commonly the production source itself), so the entry is
+	// FILENAME-gated on the `.zig` extension and the detector SELF-CONFIRMS — a
+	// `.zig` file with no `test` block yields zero cases and is dropped downstream
+	// (exactly like the rust_test / fsharp-expecto entries). It is deliberately
+	// NOT import-token gated: a bare `test` token would over-match the substring
+	// import matcher against unrelated header paths (e.g. C++ `gtest/gtest.h`
+	// contains "test"), the precedent the elm-test entry documents.
+	{
+		name: "zig-test",
+		filenameHints: []*regexp.Regexp{
+			regexp.MustCompile(`\.zig$`),
+		},
+		detect: detectZigTest,
+	},
 	// ---------------------------------------------------------------------
 	// C/C++ — gtest, catch2, doctest, boost.test, cppunit, cpputest (#3495).
 	//

--- a/internal/extractors/cross/testmap/frameworks_zig.go
+++ b/internal/extractors/cross/testmap/frameworks_zig.go
@@ -1,0 +1,120 @@
+// Package testmap — Zig test-block detection and call resolution.
+//
+// #5377 (epic #5360 Group A — bootstrap). Linkage for `zig test`, Zig's
+// built-in test runner. Zig has no separate test framework: top-level
+// `test "name" { … }` (or `test name { … }` / bare `test { … }`) blocks are
+// compiled and run by `zig test file.zig` / `zig build test`:
+//
+//	const std = @import("std");
+//	const expect = std.testing.expect;
+//
+//	fn add(a: i32, b: i32) i32 { return a + b; }
+//
+//	test "add sums two numbers" {
+//	    try expect(add(2, 2) == 4);
+//	}
+//
+//	test add {                       // identifier form (doc-test for `add`)
+//	    try expect(add(1, 1) == 2);
+//	}
+//
+// Each `test` block is one test case. Its brace body is scanned by the shared
+// resolver for direct production calls (`add(2, 2)` → the `add` operation). The
+// `std.testing.*` assertion DSL is denylisted in resolver.go so it never
+// surfaces as the production subject.
+//
+// GATING (important): Zig test blocks live in ANY `.zig` file — frequently the
+// production source file itself, not a separate test file. The framework entry
+// is therefore FILENAME-gated on the `.zig` extension and the detector
+// SELF-CONFIRMS: a `.zig` file with no `test` block yields zero cases and is
+// dropped downstream (exactly like the rust_test / fsharp-expecto entries). It
+// is deliberately NOT import-token gated — a bare `test` token would over-match
+// the substring import matcher against unrelated header paths (e.g. C++
+// `gtest/gtest.h` contains "test"), the precedent the elm-test entry documents.
+package testmap
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// zigTestRE matches a top-level Zig test-block header in its three forms:
+//
+//	test "describes the case" {      → group 1 = the quoted description
+//	test add {                       → group 2 = the identifier (doc-test target)
+//	test {                           → neither group (anonymous test)
+//
+// The `test` keyword must start a line (allowing indentation) so a `test`
+// substring inside an identifier/string/comment never opens a block. The match
+// ends at the opening `{`, from which extractBraceBody captures the balanced
+// body. `comptime`-prefixed and nested constructs are out of scope (honest
+// partial — dynamic/comptime-generated tests are not modelled).
+var zigTestRE = regexp.MustCompile(
+	`(?m)^[ \t]*test\b[ \t]*(?:"([^"\n\r]{1,200})"|([A-Za-z_]\w*))?[ \t]*\{`,
+)
+
+// zigTestSubject returns the production symbol an identifier-form test exercises
+// (`test add { … }` → `add`). The quoted-description form carries no structural
+// subject (the resolver relies on the body call scan); an empty string is
+// returned so the resolver does not invent one.
+func zigTestSubject(ident string) string {
+	if ident == "" {
+		return ""
+	}
+	return ident
+}
+
+// zigTestCaseName normalises a test header into a stable identifier:
+//   - quoted description "add sums two numbers" → add_sums_two_numbers
+//   - identifier form     add                   → add
+//   - anonymous test                            → anonymous_test_<n> (caller indexes)
+//
+// Reuses the Nim snake-case normaliser for the quoted form (spaces/punctuation →
+// underscores, no framework prefix — Zig test names are bare).
+func zigTestCaseName(desc, ident string) string {
+	if ident != "" {
+		return ident
+	}
+	if desc == "" {
+		return ""
+	}
+	return nimTestCaseName(desc)
+}
+
+// detectZigTest detects `zig test` blocks in a .zig source file. Each block is
+// one test case; the body is captured for the shared resolver's production-call
+// scan, and an identifier-form test (`test add { … }`) carries `add` as the
+// naming-convention subject-under-test fallback.
+func detectZigTest(source string) []testFunction {
+	var out []testFunction
+	seen := map[string]bool{}
+	anon := 0
+	for _, m := range zigTestRE.FindAllStringSubmatchIndex(source, -1) {
+		desc := ""
+		if m[2] >= 0 && m[3] >= 0 {
+			desc = source[m[2]:m[3]]
+		}
+		ident := ""
+		if m[4] >= 0 && m[5] >= 0 {
+			ident = source[m[4]:m[5]]
+		}
+		name := zigTestCaseName(desc, ident)
+		if name == "" {
+			anon++
+			name = "anonymous_test_" + strconv.Itoa(anon)
+		}
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		// The body begins at the opening `{` (the last byte of the match).
+		body := extractBraceBody(source, m[1]-1)
+		out = append(out, testFunction{
+			qname:           name,
+			body:            body,
+			describeSubject: zigTestSubject(ident),
+			lang:            "zig",
+		})
+	}
+	return out
+}

--- a/internal/extractors/cross/testmap/frameworks_zig_test.go
+++ b/internal/extractors/cross/testmap/frameworks_zig_test.go
@@ -1,0 +1,118 @@
+// Package testmap — value-asserting tests for the `zig test` detector (#5377).
+package testmap
+
+import "testing"
+
+// TestZigTest_DirectCallHighConfidence proves a direct production call inside a
+// `test "..." { … }` body yields a TESTS edge, attributed to zig-test.
+func TestZigTest_DirectCallHighConfidence(t *testing.T) {
+	src := `const std = @import("std");
+const expect = std.testing.expect;
+
+fn add(a: i32, b: i32) i32 {
+    return a + b;
+}
+
+test "add sums two numbers" {
+    try expect(add(2, 2) == 4);
+}
+`
+	recs := runExtract(t, "src/math.zig", "zig", src)
+	if len(recs) == 0 {
+		t.Fatalf("expected >=1 testmap entity for zig-test")
+	}
+	rec := findByTested(t, recs, "add_sums_two_numbers", "add")
+	if rec.Properties["test_framework"] != "zig-test" {
+		t.Errorf("framework=%q, want zig-test", rec.Properties["test_framework"])
+	}
+	if !hasEdge(recs, "add_sums_two_numbers", "add") {
+		t.Errorf("missing TESTS edge add_sums_two_numbers -> add")
+	}
+}
+
+// TestZigTest_IdentifierForm proves the `test add { … }` identifier form is
+// detected and carries `add` as the naming-convention subject-under-test.
+func TestZigTest_IdentifierForm(t *testing.T) {
+	src := `const std = @import("std");
+
+fn parse(s: []const u8) u32 {
+    return s.len;
+}
+
+test parse {
+    try std.testing.expectEqual(@as(u32, 3), parse("abc"));
+}
+`
+	recs := runExtract(t, "src/parser.zig", "zig", src)
+	if !hasEdgeAny(recs, "parse", "parse") {
+		t.Errorf("expected identifier-form test parse -> parse edge")
+	}
+}
+
+// TestZigTest_BodyScoped proves the brace-body extractor scans only the block's
+// own body — a call in a SIBLING test must not leak into another test's body.
+func TestZigTest_BodyScoped(t *testing.T) {
+	src := `const std = @import("std");
+
+fn runAlpha(x: i32) bool { return x > 0; }
+fn runBeta(x: i32) bool { return x < 0; }
+
+test "alpha" {
+    try std.testing.expect(runAlpha(1));
+}
+
+test "beta" {
+    try std.testing.expect(runBeta(2));
+}
+`
+	recs := runExtract(t, "src/svc.zig", "zig", src)
+	if !hasEdgeAny(recs, "alpha", "runAlpha") {
+		t.Errorf("expected alpha -> runAlpha edge")
+	}
+	if !hasEdgeAny(recs, "beta", "runBeta") {
+		t.Errorf("expected beta -> runBeta edge")
+	}
+	if hasEdgeAny(recs, "alpha", "runBeta") {
+		t.Errorf("alpha test body leaked into sibling beta (runBeta)")
+	}
+}
+
+// TestZigTest_AssertionDSLNotSubject proves the std.testing.* assertion DSL is
+// stop-worded — it never surfaces as the production subject under test.
+func TestZigTest_AssertionDSLNotSubject(t *testing.T) {
+	src := `const std = @import("std");
+
+test "only assertions" {
+    try std.testing.expectEqual(@as(i32, 1), @as(i32, 1));
+    try std.testing.expect(true);
+}
+`
+	recs := runExtract(t, "src/dsl.zig", "zig", src)
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind != "TESTS" {
+				continue
+			}
+			if containsAny(rel.Properties["tested"],
+				"expect", "expectEqual", "testing", "std", "expect_equal") {
+				t.Errorf("DSL identifier surfaced as production subject: %s", rel.Properties["tested"])
+			}
+		}
+	}
+}
+
+// TestZigTest_NonTestZigDropped proves a plain .zig source file with NO test
+// block yields zero testmap entities (the detector self-confirms; the `.zig`
+// filename gate alone must not produce a spurious test record).
+func TestZigTest_NonTestZigDropped(t *testing.T) {
+	src := `const std = @import("std");
+
+pub fn main() void {
+    std.debug.print("hello\n", .{});
+}
+`
+	recs := runExtract(t, "src/main.zig", "zig", src)
+	if len(recs) != 0 {
+		t.Errorf("non-test .zig file produced %d testmap entities, want 0", len(recs))
+	}
+}

--- a/internal/extractors/cross/testmap/resolver.go
+++ b/internal/extractors/cross/testmap/resolver.go
@@ -562,7 +562,7 @@ var stopwords = map[string]bool{
 	"expect.true": true, "expect.false": true, "expect.err": true,
 	"expect.ok": true, "expect.equallists": true, "expect.equaldicts": true,
 	"expect.equalsets": true,
-	"fuzz.int": true, "fuzz.string": true, "fuzz.bool": true, "fuzz.float": true,
+	"fuzz.int":         true, "fuzz.string": true, "fuzz.bool": true, "fuzz.float": true,
 	"fuzz.list": true, "fuzz.constant": true, "fuzz.map": true, "fuzz.andmap": true,
 	"fuzz.intrange": true, "fuzz.oneof": true, "fuzz.frequency": true,
 	// Common language keywords that end up in call-like positions
@@ -587,6 +587,23 @@ var stopwords = map[string]bool{
 	"error": true, "assert_": true, "table.insert": true, "table.remove": true,
 	"table.concat": true, "table.sort": true, "string.format": true,
 	"string.match": true, "string.gmatch": true, "string.gsub": true,
+	// Zig — `zig test` (#5377). The std.testing assertion DSL is test-harness
+	// plumbing, never the production subject. `try expect(...)` already denies
+	// the bare `expect`/`try` tokens above; these add the dotted std.testing.*
+	// forms and the bare assertion tails that surface after the `)` chain break.
+	"std.testing.expect": true, "std.testing.expectequal": true,
+	"std.testing.expecterror": true, "std.testing.expectequalstrings": true,
+	"std.testing.expectequalslices": true, "std.testing.expectequaldeep": true,
+	"std.testing.expectapproxeqabs": true, "std.testing.expectapproxeqrel": true,
+	"std.testing.expectfmt": true, "std.testing.expectstringstartswith": true,
+	"std.testing.expectstringendswith": true, "std.testing.refalldecls": true,
+	"testing.expect": true, "testing.expectequal": true, "testing.expecterror": true,
+	"testing.expectequalstrings": true, "testing.expectequalslices": true,
+	"testing.expectequaldeep": true, "testing.expectapproxeqabs": true,
+	"testing.expectapproxeqrel": true, "testing.refalldecls": true,
+	"expectequal": true, "expecterror": true, "expectequalstrings": true,
+	"expectequalslices": true, "expectequaldeep": true, "expectapproxeqabs": true,
+	"expectapproxeqrel": true, "expectfmt": true, "refalldecls": true,
 }
 
 // isStopword reports whether id is a test-helper, assertion, mock library,


### PR DESCRIPTION
Bootstrap Zig tool/test coverage (epic #5360, Group A — bootstrap). Closes #5377.

## What

Zig has no separate package-manager binary — `zig build` is both the build orchestrator and the dependency fetcher — so two files describe a package, and both feed the shared cross-manifest entity/edge builder (DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes) under `package_manager=zig`.

### build.zig — build system (dependency_graph + target_extraction) — full
- `b.dependency("name", ...)` calls -> build-graph external dependencies (receiver-agnostic, so non-canonical builder names match).
- Declared build TARGETS (`addExecutable`/`addStaticLibrary`/`addSharedLibrary`/`addObject`/`addModule`/`addTest`/`addLibrary`) mined via a quote-aware balanced-paren arg-slice walk and surfaced as a comma-joined `build_targets` property on the manifest project anchor — queryable without a new entity kind, mirroring the cmake treatment.

### build.zig.zon — package manifest (manifest_parsing full; lockfile_parsing N/A)
- The ZON `.dependencies = .{ .name = .{ .url=…, .hash=… } }` map is parsed via a quote-aware balanced-brace hand-walk (regex cannot balance nested `.{ }`). Bare `.ident` and `.@"quoted ident"` field shapes are both handled.
- The content-addressed `.hash` is the pinned version (`.url` fallback), so build.zig.zon IS the lockfile — no separate lockfile format.

### zig test — test framework (dependency_graph + target_extraction) — full
- Top-level `test "name" { … }` / `test ident { … }` / anonymous `test { … }` blocks become test_case records with high-confidence TESTS edges to the production calls in their (balanced, quote-aware) bodies, via the cross-language testmap extractor.
- The identifier form `test add { … }` seeds `add` as the naming-convention subject-under-test.
- **Gating:** FILENAME-gated on the `.zig` extension (Zig tests live in any `.zig` file, often the production source itself) and the detector self-confirms (a `.zig` file with no `test` block yields zero cases and is dropped). Deliberately **NOT** import-token gated — a bare `test` token would over-match the substring import matcher (e.g. C++ `gtest/gtest.h` contains "test"), the precedent the elm-test entry documents.
- The `std.testing.*` assertion DSL (`expect`/`expectEqual`/`expectError`/…, bare + dotted) plus the bare `try`/`expect` tokens are denylisted so test plumbing never surfaces as the SUT.

## Coverage (honest)
| Record | Capability | Status |
|---|---|---|
| build.zig | dependency_graph | full |
| build.zig | target_extraction | full (comptime-generated targets deferred) |
| pkg.zig-zon | manifest_parsing | full |
| pkg.zig-zon | lockfile_parsing | not_applicable (.zon IS the lockfile) |
| test.zig | dependency_graph | full |
| test.zig | target_extraction | full (comptime/dynamic tests deferred) |

Registry + coverage docs updated in the same PR; `coverage validate` + `fmt --check` green; docs regenerated.

## Tests
- Manifest: `TestBuildZigZon_Dependencies`, `TestBuildZig_DependencyGraph`, `TestBuildZig_TargetExtraction`, `TestBuildZigZon_NoBuildTargets`, `TestBuildZig_DependsOnEdges`, `TestBuildZig_IsManifest` (real `build.zig` / `build.zig.zon` fixtures).
- Testmap: `TestZigTest_DirectCallHighConfidence`, `_IdentifierForm`, `_BodyScoped`, `_AssertionDSLNotSubject`, `_NonTestZigDropped`.
- `go build ./...`, `go vet`, and `./tools/coverage/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)