### PR TITLE
feat(reasonml): bootstrap records — bsconfig + Reason-React + JS-ecosystem reuse (#5379)

### DIFF
--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 262 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **elm**: 1 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **OCaml**: 1 · **php**: 16 · **python**: 25 · **ReScript**: 1 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
+**Total**: 263 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **elm**: 1 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **OCaml**: 1 · **php**: 16 · **python**: 25 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -225,6 +225,7 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [JS/TS](../by-language/jsts.md) | [Svelte](../detail/lang.jsts.framework.svelte.md) | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | 🟢 17/17 | |
 | [JS/TS](../by-language/jsts.md) | [Vue](../detail/lang.jsts.framework.vue.md) | ✅ 3/3 | ✅ 1/1 | 🟢 24/24 | 🟢 19/19 | |
 | [python](../by-language/python.md) | [gql (GraphQL client)](../detail/lang.python.framework.gql-client.md) | 🟡 2/3 | 🔴 0/1 | 🟡 1/24 | 🔴 0/8 | |
+| [ReasonML](../by-language/reasonml.md) | [Reason-React ([@react.component])](../detail/lang.reasonml.framework.reason-react.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/24 | 🟡 2/8 | |
 | [ReScript](../by-language/rescript.md) | [ReScript-React (@rescript/react)](../detail/lang.rescript.framework.rescript-react.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/24 | 🟡 2/8 | |
 | [swift](../by-language/swift.md) | [SwiftUI](../detail/lang.swift.framework.swiftui.md) | 🟡 2/3 | ✅ 1/1 | 🟡 18/24 | 🟡 3/8 | |
 

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 31 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1 · **zig**: 1
+**Total**: 32 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1 · **zig**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -33,6 +33,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | 🟢 | ✅ | |
 | [python](../by-language/python.md) | [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | |
+| [ReasonML](../by-language/reasonml.md) | [bsconfig.json (BuckleScript/Reason manifest)](../detail/lang.reasonml.tool.bsconfig.md) | — | — | 🟢 | |
 | [ReScript](../by-language/rescript.md) | [rescript.json / bsconfig.json (ReScript manifest)](../detail/lang.rescript.tool.rescript-json.md) | — | — | 🟢 | |
 | [ruby](../by-language/ruby.md) | [Gemfile](../detail/pkg.gemfile.md) | — | 🔴 | ✅ | |
 | [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | 🔴 | ✅ | |

--- a/docs/coverage/by-language/reasonml.md
+++ b/docs/coverage/by-language/reasonml.md
@@ -1,12 +1,36 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # ReasonML
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 1 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/reasonml/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.reasonml.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Frameworks
+
+
+### UI Frontend
+
+| Name | Type System | Testing | Substrate | Other capabilities | Notes |
+|---|---|---|---|---|---|
+| [Reason-React ([@react.component])](../detail/lang.reasonml.framework.reason-react.md) | 🔴 0/3 | 🔴 0/1 | 🔴 0/24 | 🟡 2/8 | |
+
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [bsconfig.json (BuckleScript/Reason manifest)](../detail/lang.reasonml.tool.bsconfig.md) | — | — | — | 🟢 | — | |

--- a/docs/coverage/detail/lang.reasonml.framework.reason-react.md
+++ b/docs/coverage/detail/lang.reasonml.framework.reason-react.md
@@ -1,0 +1,93 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.reasonml.framework.reason-react` — Reason-React ([@react.component])
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ReasonML](../by-language/reasonml.md)
+- **Category:** [http_framework](../by-category/http_framework.md)
+- **Subcategory:** UI Frontend
+- **Capability cells:** 36
+
+## Capabilities
+
+
+### Structure
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Component extraction | 🟢 `partial` | `2026-06-24` | 5379 | `internal/extractors/reasonml/extractor.go`<br>`internal/extractors/reasonml/react.go`<br>`internal/extractors/reasonml/react_test.go` | Reason-React ([@react.component]): a [@react.component]-annotated let binding (idiomatically 'make') is re-kinded SCOPE.UIComponent, subtype react_component, Properties[ui_framework]=reason-react. Reason uses the bracket-attribute syntax [@react.component] (vs ReScript's bare @react.component); the React model is shared. Reason compiles to JS and binds the same React runtime as the JS/TS ecosystem, so the JS-ecosystem React model is reused. Partial: hooks (React.useState/useReducer) and context are not separately modelled; JSX RENDERS edges are not emitted by the ReasonML base extractor (deferred); detection is heuristic (attribute + binding-line proximity). |
+| Context extraction | 🔴 `missing` | — | 5379 | — | — |
+
+### Data Flow
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Branch conditions | 🔴 `missing` | — | 5379 | — | — |
+| Data fetching | 🔴 `missing` | — | 5379 | — | — |
+| Prop extraction | 🟢 `partial` | `2026-06-24` | 5379 | `internal/extractors/reasonml/extractor.go`<br>`internal/extractors/reasonml/react.go`<br>`internal/extractors/reasonml/react_test.go` | The labelled-argument names of a [@react.component] binding (~name, ~onClick) are the component props; recorded as Properties[props] (comma-joined), captured across continuation lines up to the => body boundary. Partial: prop NAME set only — prop types and default/optional flags are not separately modelled. |
+| State management | 🔴 `missing` | — | 5379 | — | — |
+
+### Navigation
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Router pattern | 🔴 `missing` | — | 5379 | — | — |
+
+### Type System
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Enum extraction | 🔴 `missing` | — | 5379 | — | — |
+| Interface extraction | 🔴 `missing` | — | 5379 | — | — |
+| Type alias extraction | 🔴 `missing` | — | 5379 | — | — |
+
+### Lifecycle
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| State setter emission | 🔴 `missing` | — | 5379 | — | — |
+
+### Testing
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Tests linkage | 🔴 `missing` | — | 5379 | — | — |
+
+### Substrate
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Confidence overlay | 🔴 `missing` | — | 5379 | — | — |
+| Config consumption | 🔴 `missing` | — | 5379 | — | — |
+| Constant propagation | 🔴 `missing` | — | 5379 | — | — |
+| DB effect | 🔴 `missing` | — | 5379 | — | — |
+| Dead code detection | 🔴 `missing` | — | 5379 | — | — |
+| Def use chain extraction | 🔴 `missing` | — | 5379 | — | — |
+| Env fallback recognition | 🔴 `missing` | — | 5379 | — | — |
+| Error flow | 🔴 `missing` | — | 5379 | — | — |
+| Feature flag gating | 🔴 `missing` | — | 5379 | — | — |
+| Fs effect | 🔴 `missing` | — | 5379 | — | — |
+| HTTP effect | 🔴 `missing` | — | 5379 | — | — |
+| Import resolution quality | 🔴 `missing` | — | 5379 | — | — |
+| Module cycle detection | 🔴 `missing` | — | 5379 | — | — |
+| Mutation effect | 🔴 `missing` | — | 5379 | — | — |
+| Pure function tagging | 🔴 `missing` | — | 5379 | — | — |
+| Reachability analysis | 🔴 `missing` | — | 5379 | — | — |
+| Request shape extraction | 🔴 `missing` | — | 5379 | — | — |
+| Response shape extraction | 🔴 `missing` | — | 5379 | — | — |
+| Sanitizer recognition | 🔴 `missing` | — | 5379 | — | — |
+| Schema drift detection | 🔴 `missing` | — | 5379 | — | — |
+| Taint sink detection | 🔴 `missing` | — | 5379 | — | — |
+| Taint source detection | 🔴 `missing` | — | 5379 | — | — |
+| Template pattern catalog | 🔴 `missing` | — | 5379 | — | — |
+| Vulnerability finding | 🔴 `missing` | — | 5379 | — | — |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.reasonml.framework.reason-react ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.reasonml.tool.bsconfig.md
+++ b/docs/coverage/detail/lang.reasonml.tool.bsconfig.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.reasonml.tool.bsconfig` — bsconfig.json (BuckleScript/Reason manifest)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [ReasonML](../by-language/reasonml.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Lockfile parsing | — `not_applicable` | — | — | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/rescript.go`<br>`internal/extractors/cross/manifest/rescript_test.go` | bsconfig.json is NOT a lockfile — the dependency lists are flat npm package NAMES with no resolved versions. Reason/BuckleScript packages are npm packages, so the resolved dependency tree is recovered by the existing npm/yarn/pnpm lockfile parsers over the sibling lockfile; there is no Reason-specific lockfile format. |
+| Manifest parsing | 🟢 `partial` | `2026-06-24` | 5379 | `internal/classifier/classifier.go`<br>`internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/rescript.go`<br>`internal/extractors/cross/manifest/rescript_test.go` | bsconfig.json is the BuckleScript/Reason manifest — identical schema to ReScript's rescript.json, parsed by the SHARED language-agnostic parser added in #5378 (no duplication). bs-dependencies (runtime), bs-dev-dependencies (dev), pinned-dependencies (runtime) are flat npm package-name arrays (versions resolve from the sibling package.json — Reason/BuckleScript packages ARE npm packages), so package_manager=npm and the JS-ecosystem package.json/lockfile coverage version-resolves them. JSX version/mode + module/suffix/namespace config surfaced on the project anchor as the rescript_config property. Partial: no per-dependency version (bsconfig carries none). |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.reasonml.tool.bsconfig ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (31 active · 8 placeholder) · **Frameworks**: 262 · **ORMs**: 186 · **Tools**: 146 · **Other**: 208
+**Languages**: 39 (32 active · 7 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 147 · **Other**: 208
 
 ## Coverage by language
 
@@ -31,6 +31,7 @@
 | [groovy](by-language/groovy.md) | 1 | 1 | 1 | 1 |
 | [nim](by-language/nim.md) | 1 | 1 | 4 | 1 |
 | [OCaml](by-language/ocaml.md) | 1 | 2 | 1 | 0 |
+| [ReasonML](by-language/reasonml.md) | 1 | 1 | 0 | 0 |
 | [ReScript](by-language/rescript.md) | 1 | 1 | 0 | 0 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 5 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 5 |
@@ -78,9 +79,8 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Idris](by-language/idris.md) |
 | [Lisp](by-language/lisp.md) |
 | [Pony](by-language/pony.md) |
-| [ReasonML](by-language/reasonml.md) |
 | [Standard ML](by-language/sml.md) |
 | [VHDL](by-language/vhdl.md) |
 | [Verilog](by-language/verilog.md) |
 
-Total: 262 frameworks · 146 tools · 186 ORMs · 208 other
+Total: 263 frameworks · 147 tools · 186 ORMs · 208 other

--- a/internal/extractors/reasonml/extractor.go
+++ b/internal/extractors/reasonml/extractor.go
@@ -241,6 +241,11 @@ func extractReasonML(src, filePath string) []types.EntityRecord {
 		})
 	}
 
+	// Reason-React decoration pass (#5379): re-kind [@react.component]-annotated
+	// `let` operations to SCOPE.UIComponent and record their prop set. No-op when
+	// the file declares no [@react.component] component.
+	applyReasonReact(src, entities)
+
 	return entities
 }
 

--- a/internal/extractors/reasonml/react.go
+++ b/internal/extractors/reasonml/react.go
@@ -1,0 +1,169 @@
+// react.go — Reason-React ([@react.component]) decoration pass (#5379, epic
+// #5360 Group A).
+//
+// Reason-React (https://reasonml.github.io/reason-react/) is the idiomatic React
+// binding for ReasonML — the legacy predecessor of ReScript-React. A component
+// is a `let` binding, conventionally named `make`, annotated with the
+// `[@react.component]` attribute. ReasonML uses the BRACKET-ATTRIBUTE syntax
+// `[@react.component]` (OCaml/Reason attributes), where ReScript uses the bare
+// decorator `@react.component`; the React model is otherwise identical. The
+// attribute's labelled arguments (`~name`, `~onClick`) are the component's
+// props.
+//
+// The base extractor (extractor.go) surfaces these as ordinary SCOPE.Operation
+// `let` bindings — the fact that they are React components, and their prop set,
+// is invisible. This pass recognises the pattern and re-kinds the annotated
+// operation, mirroring the ReScript-React bootstrap (internal/extractors/
+// rescript/react.go), the F# Elmish/Feliz bootstrap, and the Elm TEA pass.
+//
+// Reason compiles to JavaScript and Reason-React binds the very same React
+// runtime as the JS/TS ecosystem, so the JS-ecosystem React model is reused
+// rather than re-implemented (the npm package_manager resolves the version via
+// the sibling bsconfig.json / package.json).
+//
+// What it produces (on top of the base extractor's entities):
+//   - a `[@react.component]`-annotated `let` operation → re-kinded
+//     SCOPE.UIComponent, subtype react_component, Properties[ui_framework]=
+//     reason-react, Properties[react_component]=true
+//   - the labelled-argument prop names (~name, ~onClick) → Properties[props]
+//     (comma-joined), so prop_extraction is queryable
+//
+// Honest scope: detection is heuristic (regex over the attribute + the binding's
+// argument list) like the rest of the ReasonML extractor. Prop TYPES, hooks
+// (React.useState/useReducer), context, and JSX RENDERS edges are not modelled
+// here — prop_extraction records the prop NAME set only; the rest is deferred.
+package reasonml
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+var (
+	// reactComponentAttrRE matches the Reason `[@react.component]` attribute
+	// (optionally parameterised, e.g. `[@react.component ~props=...]`) anywhere
+	// on a line. Reason attributes use the bracket form `[@attr]`; the leading
+	// `[@` may be preceded by other tokens (it is commonly on its own line above
+	// the binding, but can also be inline).
+	reactComponentAttrRE = regexp.MustCompile(`\[@react\.component\b`)
+
+	// reactLabelledArgRE matches one labelled argument (a Reason-React prop) in a
+	// binding's argument list: `~name`, `~onClick`, `~name: string`, `~name=?`
+	// (optional). Group 1 is the prop name.
+	reactLabelledArgRE = regexp.MustCompile(`~([a-z_][a-zA-Z0-9_']*)`)
+)
+
+// applyReasonReact decorates the base entities in place when the file declares
+// any [@react.component] component. It is a no-op when the file uses no
+// [@react.component] attribute (a plain ReasonML module is never mis-classified).
+//
+// src is the raw ReasonML source; entities is the slice produced by
+// extractReasonML. An operation is re-kinded to SCOPE.UIComponent when a
+// [@react.component] attribute sits on the line(s) immediately above its `let`
+// binding (blank/comment lines tolerated), or inline on the binding line itself.
+func applyReasonReact(src string, entities []types.EntityRecord) {
+	attrLines := reactComponentAttrLines(src)
+	if len(attrLines) == 0 {
+		return
+	}
+	lines := strings.Split(src, "\n")
+
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != "SCOPE.Operation" || e.Subtype != "let" {
+			continue
+		}
+		if !attrPrecedes(attrLines, e.StartLine) {
+			continue
+		}
+		e.Kind = "SCOPE.UIComponent"
+		e.Subtype = "react_component"
+		setReactProp(e, "ui_framework", "reason-react")
+		setReactProp(e, "react_component", "true")
+		if props := reactComponentProps(lines, e); props != "" {
+			setReactProp(e, "props", props)
+		}
+	}
+}
+
+// reactComponentAttrLines returns the 1-based line numbers carrying a
+// [@react.component] attribute.
+func reactComponentAttrLines(src string) []int {
+	var out []int
+	for _, m := range reactComponentAttrRE.FindAllStringIndex(src, -1) {
+		line := strings.Count(src[:m[0]], "\n") + 1
+		out = append(out, line)
+	}
+	return out
+}
+
+// attrPrecedes reports whether any attribute line sits on or immediately above
+// the binding at bindingLine. An attribute on the binding line itself (inline
+// `[@react.component] let make = ...`), at bindingLine-1 (the common case), or
+// separated only by blank/comment lines qualifies. We accept a small gap
+// (≤2 lines above) to tolerate a doc comment between the attribute and the `let`.
+func attrPrecedes(attrLines []int, bindingLine int) bool {
+	for _, a := range attrLines {
+		if a <= bindingLine && bindingLine-a <= 3 {
+			return true
+		}
+	}
+	return false
+}
+
+// reactComponentProps extracts the labelled-argument prop names from a
+// component binding's `let make = (~a, ~b) => ...` argument list. It scans from
+// the binding's `let` line up to the first `=>` (the body boundary) so props
+// declared on continuation lines are still captured. Returns a comma-joined,
+// deduplicated, declaration-ordered prop list, or "" when none.
+func reactComponentProps(lines []string, e *types.EntityRecord) string {
+	if e.StartLine <= 0 || e.StartLine > len(lines) {
+		return ""
+	}
+	// Collect from the binding line up to the arrow (or a few lines, whichever
+	// comes first) — the argument list lives between `(` and `) =>`.
+	var b strings.Builder
+	end := e.StartLine + 6
+	if e.EndLine > 0 && e.EndLine < end {
+		end = e.EndLine
+	}
+	if end > len(lines) {
+		end = len(lines)
+	}
+	for i := e.StartLine - 1; i < end; i++ {
+		line := lines[i]
+		b.WriteString(line)
+		b.WriteByte('\n')
+		if strings.Contains(line, "=>") {
+			break
+		}
+	}
+	scope := b.String()
+	// Cut at the first `=>` so body labelled-args (e.g. a nested callback) are
+	// not mistaken for props.
+	if idx := strings.Index(scope, "=>"); idx >= 0 {
+		scope = scope[:idx]
+	}
+
+	var props []string
+	seen := map[string]bool{}
+	for _, m := range reactLabelledArgRE.FindAllStringSubmatch(scope, -1) {
+		name := m[1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		props = append(props, name)
+	}
+	return strings.Join(props, ",")
+}
+
+// setReactProp sets a Property on an entity, allocating the map on first use.
+func setReactProp(e *types.EntityRecord, key, val string) {
+	if e.Properties == nil {
+		e.Properties = map[string]string{}
+	}
+	e.Properties[key] = val
+}

--- a/internal/extractors/reasonml/react_test.go
+++ b/internal/extractors/reasonml/react_test.go
@@ -1,0 +1,163 @@
+package reasonml_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReasonReact_ComponentReKinded verifies a [@react.component]-annotated
+// `let make` binding is re-kinded SCOPE.UIComponent with the reason-react
+// framework tag.
+func TestReasonReact_ComponentReKinded(t *testing.T) {
+	src := `
+open React;
+
+[@react.component]
+let make = (~name: string, ~onClick) => {
+  <div>
+    <Header title="My App" />
+    <button onClick> {React.string(name)} </button>
+  </div>;
+};
+`
+	ents := runReasonML(t, src, "Card.re")
+
+	// `make` is now a UIComponent, not a plain Operation.
+	if op := reFind(ents, "make", "SCOPE.Operation"); op != nil {
+		t.Error("[@react.component] make should NOT remain SCOPE.Operation")
+	}
+	comp := reFind(ents, "make", "SCOPE.UIComponent")
+	if comp == nil {
+		t.Fatal("expected 'make' as SCOPE.UIComponent")
+	}
+	if comp.Subtype != "react_component" {
+		t.Errorf("subtype=%q want react_component", comp.Subtype)
+	}
+	if comp.Properties["ui_framework"] != "reason-react" {
+		t.Errorf("ui_framework=%q want reason-react", comp.Properties["ui_framework"])
+	}
+	if comp.Properties["react_component"] != "true" {
+		t.Errorf("react_component=%q want true", comp.Properties["react_component"])
+	}
+}
+
+// TestReasonReact_Props verifies the labelled-argument prop names are recorded.
+func TestReasonReact_Props(t *testing.T) {
+	src := `
+[@react.component]
+let make = (~name: string, ~count: int, ~onClick) => {
+  <div> {React.string(name)} </div>;
+};
+`
+	ents := runReasonML(t, src, "Widget.re")
+	comp := reFind(ents, "make", "SCOPE.UIComponent")
+	if comp == nil {
+		t.Fatal("expected 'make' as SCOPE.UIComponent")
+	}
+	props := comp.Properties["props"]
+	for _, want := range []string{"name", "count", "onClick"} {
+		if !propListHas(props, want) {
+			t.Errorf("props=%q missing %q", props, want)
+		}
+	}
+}
+
+// TestReasonReact_MultilineProps verifies props declared on continuation lines
+// (up to the `=>`) are captured.
+func TestReasonReact_MultilineProps(t *testing.T) {
+	src := `
+[@react.component]
+let make =
+  (
+    ~title: string,
+    ~subtitle: string,
+    ~onSelect,
+  ) => {
+  <section> {React.string(title)} </section>;
+};
+`
+	ents := runReasonML(t, src, "Panel.re")
+	comp := reFind(ents, "make", "SCOPE.UIComponent")
+	if comp == nil {
+		t.Fatal("expected 'make' as SCOPE.UIComponent")
+	}
+	props := comp.Properties["props"]
+	for _, want := range []string{"title", "subtitle", "onSelect"} {
+		if !propListHas(props, want) {
+			t.Errorf("props=%q missing %q", props, want)
+		}
+	}
+}
+
+// TestReasonReact_AttrWithDocComment verifies an attribute separated from the
+// `let` binding by a doc comment (within the small tolerated gap) is recognised.
+func TestReasonReact_AttrWithDocComment(t *testing.T) {
+	src := `
+[@react.component]
+/* A labelled badge. */
+let make = (~label) => <span> {React.string(label)} </span>;
+`
+	ents := runReasonML(t, src, "Badge.re")
+	comp := reFind(ents, "make", "SCOPE.UIComponent")
+	if comp == nil {
+		t.Fatal("expected [@react.component] make (doc-comment gap) as SCOPE.UIComponent")
+	}
+	if !propListHas(comp.Properties["props"], "label") {
+		t.Errorf("props=%q missing label", comp.Properties["props"])
+	}
+}
+
+// TestReasonReact_NoAttrIsPlainOperation verifies a plain `let` binding with no
+// [@react.component] attribute stays a SCOPE.Operation (no misclassify).
+func TestReasonReact_NoAttrIsPlainOperation(t *testing.T) {
+	src := `
+let helper = (x) => x + 1;
+
+let make = (~name) => {
+  <div> {React.string(name)} </div>;
+};
+`
+	ents := runReasonML(t, src, "Plain.re")
+	if reFind(ents, "make", "SCOPE.UIComponent") != nil {
+		t.Error("make without [@react.component] should NOT be a UIComponent")
+	}
+	if reFind(ents, "make", "SCOPE.Operation") == nil {
+		t.Error("make without [@react.component] should remain SCOPE.Operation")
+	}
+	if reFind(ents, "helper", "SCOPE.Operation") == nil {
+		t.Error("helper should remain SCOPE.Operation")
+	}
+}
+
+// TestReasonReact_OnlyAnnotatedReKinded verifies that in a file with a mix of
+// components and helpers, only the [@react.component]-annotated binding is
+// re-kinded.
+func TestReasonReact_OnlyAnnotatedReKinded(t *testing.T) {
+	src := `
+let formatName = (n) => "Hello " ++ n;
+
+[@react.component]
+let make = (~name) => {
+  <div> {React.string(formatName(name))} </div>;
+};
+`
+	ents := runReasonML(t, src, "Mixed.re")
+	if reFind(ents, "make", "SCOPE.UIComponent") == nil {
+		t.Error("annotated make should be a UIComponent")
+	}
+	if reFind(ents, "formatName", "SCOPE.UIComponent") != nil {
+		t.Error("formatName (no attribute) should NOT be a UIComponent")
+	}
+	if reFind(ents, "formatName", "SCOPE.Operation") == nil {
+		t.Error("formatName should remain SCOPE.Operation")
+	}
+}
+
+func propListHas(csv, want string) bool {
+	for _, p := range strings.Split(csv, ",") {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #5379. Part of epic #5360 (Group A — bootstrap). Mirrors the just-merged ReScript bootstrap #5378 for ReasonML, its legacy close cousin.

## What
ReasonML shares ReScript's bsconfig manifest schema and React model, differing only in the **bracket-attribute syntax `[@react.component]`** (vs ReScript's bare `@react.component`).

### 1. Reason-React decoration pass (new)
`internal/extractors/reasonml/react.go` — mirrors `internal/extractors/rescript/react.go`:
- detects `[@react.component]`-annotated `let` bindings (idiomatically `make`)
- re-kinds the base `SCOPE.Operation`/`let` → `SCOPE.UIComponent` subtype `react_component`, `Properties[ui_framework]=reason-react`, `Properties[react_component]=true`
- extracts labelled-arg prop names (`~name`, `~onClick`) → `Properties[props]`, across continuation lines up to the `=>` body boundary
- no-op when no `[@react.component]` present (plain modules never misclassified)
- wired into `extractReasonML`

Reason compiles to JS and binds the same React runtime as the JS/TS ecosystem, so the JS-ecosystem React model is reused (npm resolves the version via the sibling bsconfig/package.json).

### 2. bsconfig.json manifest — shared, no duplication
`bsconfig.json` is already routed through the **language-agnostic npm-schema parser** added in #5378 (`parseReScriptJSON` + `reScriptConfigProperty`). Reason projects use the identical BuckleScript `bsconfig.json`, so it is covered as-is — satisfying the ticket's coordinate-don't-duplicate note. Recorded for reasonml citing the shared parser.

### 3. Registry + coverage docs (same PR)
- `lang.reasonml.framework.reason-react` — `component_extraction` **partial**, `prop_extraction` **partial**
- `lang.reasonml.tool.bsconfig` — `manifest_parsing` **partial**, `lockfile_parsing` **not_applicable** (npm lockfiles resolve versions; no Reason-specific lockfile)
- `backfill` + `validate` + `fmt --check` + `gen` all green

## Honest scope (per capability)
| Capability | Status | Notes |
|---|---|---|
| Component extraction (reason-react) | partial | heuristic attribute+proximity detection; hooks/context and JSX RENDERS edges not modelled |
| Prop extraction (reason-react) | partial | prop NAME set only; types/optional flags deferred |
| Manifest parsing (bsconfig) | partial | shared npm-schema parser; no per-dep version (bsconfig carries none) |
| Lockfile parsing (bsconfig) | not_applicable | npm/yarn/pnpm lockfile parsers resolve the tree |

## Fixtures & tests
`internal/extractors/reasonml/react_test.go` — real `.re` fixtures: re-kind, props, multiline props, doc-comment gap, mixed-helpers (only annotated re-kinded), no-attr negative. bsconfig manifest parsing already covered by the shared `rescript_test.go`.

`go test ./internal/extractors/reasonml/ ./internal/extractors/cross/manifest/ ./tools/coverage/` — all green. `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)