### PR TITLE
feat(verilog): bootstrap records — module/port/instance topology + sim/synth tools (#5380)

### DIFF
--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 115 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **OCaml**: 1 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2 · **zig**: 2
+**Total**: 119 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **OCaml**: 1 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2 · **verilog**: 4 · **zig**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -121,5 +121,9 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [scala](../by-language/scala.md) | [SBT](../detail/build.sbt.md) | ✅ | ✅ | |
 | [solidity](../by-language/solidity.md) | [Foundry (forge)](../detail/lang.solidity.tool.foundry.md) | 🔴 | 🟢 | |
 | [solidity](../by-language/solidity.md) | [Hardhat](../detail/lang.solidity.tool.hardhat.md) | 🔴 | 🟢 | |
+| [verilog](../by-language/verilog.md) | [Quartus](../detail/build.verilog.quartus.md) | 🟢 | — | |
+| [verilog](../by-language/verilog.md) | [Verilator](../detail/build.verilog.verilator.md) | 🟢 | — | |
+| [verilog](../by-language/verilog.md) | [Vivado](../detail/build.verilog.vivado.md) | 🟢 | — | |
+| [verilog](../by-language/verilog.md) | [Yosys](../detail/build.verilog.yosys.md) | 🟢 | — | |
 | [zig](../by-language/zig.md) | [zig build (build.zig)](../detail/build.zig.md) | ✅ | ✅ | |
 | [zig](../by-language/zig.md) | [zig test](../detail/test.zig.md) | ✅ | ✅ | |

--- a/docs/coverage/by-category/language.md
+++ b/docs/coverage/by-category/language.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # language
 
-**Total**: 25 records · **assembly**: 5 · **clojure**: 1 · **COBOL**: 5 · **crystal**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 2 · **F#**: 1 · **groovy**: 1 · **JCL**: 1 · **lua**: 1 · **nim**: 1 · **scala**: 1 · **solidity**: 2 · **swift**: 1
+**Total**: 26 records · **assembly**: 5 · **clojure**: 1 · **COBOL**: 5 · **crystal**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 2 · **F#**: 1 · **groovy**: 1 · **JCL**: 1 · **lua**: 1 · **nim**: 1 · **scala**: 1 · **solidity**: 2 · **swift**: 1 · **verilog**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -32,3 +32,4 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [solidity](../by-language/solidity.md) | [OpenZeppelin Contracts](../detail/lang.solidity.framework.openzeppelin.md) | — | — | — | ✅ | — | — | ✅ | ✅ | |
 | [solidity](../by-language/solidity.md) | [Solidity](../detail/lang.solidity.core.md) | 🟢 | ✅ | — | — | — | — | 🟢 | 🟢 | |
 | [swift](../by-language/swift.md) | [Swift (base language)](../detail/lang.swift.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
+| [verilog](../by-language/verilog.md) | [Verilog / SystemVerilog](../detail/lang.verilog.core.md) | — | 🟢 | — | — | — | — | — | 🟢 | |

--- a/docs/coverage/by-language/verilog.md
+++ b/docs/coverage/by-language/verilog.md
@@ -1,12 +1,35 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Verilog
+# verilog
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 4 · **ORMs**: 0 · **Other**: 1
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/verilog/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.verilog.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [Quartus](../detail/build.verilog.quartus.md) | 🟢 | — | — | — | — | |
+| [Verilator](../detail/build.verilog.verilator.md) | 🟢 | — | — | — | — | |
+| [Vivado](../detail/build.verilog.vivado.md) | 🟢 | — | — | — | — | |
+| [Yosys](../detail/build.verilog.yosys.md) | 🟢 | — | — | — | — | |
+
+## Other
+
+| Name | Category | Status | Notes |
+|---|---|---|---|
+| [Verilog / SystemVerilog](../detail/lang.verilog.core.md) | [language](../by-category/language.md) | 🟢 | |

--- a/docs/coverage/detail/build.verilog.quartus.md
+++ b/docs/coverage/detail/build.verilog.quartus.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.verilog.quartus` — Quartus
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [verilog](../by-language/verilog.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🟢 `partial` | `2026-06-24` | 5380 | `internal/extractors/verilog/extractor.go`<br>`internal/extractors/verilog/extractor_test.go` | Quartus synthesis attributes detected from HDL signals — (* keep *) / (* preserve *) / (* altera_attribute *) / (* syn_keep *) / (* syn_preserve *) ... (#5380 synthAttrRE); emits SCOPE.Component(subtype=tool, tool=synthesis). Partial: in-HDL synthesis-attribute signal detection (shared Vivado/Quartus synthesis flow), NOT .qpf/.qsf project parsing. Proven by TestVerilog_SynthesisAttrs. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.verilog.quartus ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.verilog.verilator.md
+++ b/docs/coverage/detail/build.verilog.verilator.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.verilog.verilator` — Verilator
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [verilog](../by-language/verilog.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🟢 `partial` | `2026-06-24` | 5380 | `internal/extractors/verilog/extractor.go`<br>`internal/extractors/verilog/extractor_test.go` | Verilator detected from HDL signals — /* verilator lint_off|lint_on|coverage_off|public|... */ pragmas and `verilator_config (#5380 toolSpecs/buildToolEntities); emits SCOPE.Component(subtype=tool) + file->tool USES edge. Partial: signal-detection from inside HDL source (the only files routed to this extractor), NOT project-file (Makefile/.vc/-f filelist) parsing; no build-target/dependency-graph extraction. Proven by TestVerilog_VerilatorPragma / _VerilatorConfig / _NoToolFalsePositive. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.verilog.verilator ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.verilog.vivado.md
+++ b/docs/coverage/detail/build.verilog.vivado.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.verilog.vivado` — Vivado
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [verilog](../by-language/verilog.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🟢 `partial` | `2026-06-24` | 5380 | `internal/extractors/verilog/extractor.go`<br>`internal/extractors/verilog/extractor_test.go` | Vivado synthesis attributes detected from HDL signals — (* synthesis *) / (* keep *) / (* dont_touch *) / (* mark_debug *) / (* ram_style *) / (* async_reg *) ... (#5380 synthAttrRE); emits SCOPE.Component(subtype=tool, tool=synthesis). Partial: in-HDL synthesis-attribute signal detection (shared Vivado/Quartus synthesis flow), NOT .xpr/.tcl project parsing. Proven by TestVerilog_SynthesisAttrs. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.verilog.vivado ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/build.verilog.yosys.md
+++ b/docs/coverage/detail/build.verilog.yosys.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `build.verilog.yosys` — Yosys
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [verilog](../by-language/verilog.md)
+- **Category:** [build_system](../by-category/build_system.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Dependency graph | 🟢 `partial` | `2026-06-24` | 5380 | `internal/extractors/verilog/extractor.go`<br>`internal/extractors/verilog/extractor_test.go` | Yosys detected from HDL attributes — (* top *) / (* blackbox *) / (* whitebox *) / (* abc9_box *) / (* nomem2reg *) ... (#5380 yosysAttrRE); emits SCOPE.Component(subtype=tool, tool=yosys). Partial: in-HDL attribute signal detection, NOT .ys script / synth_* command parsing. Proven by TestVerilog_YosysAttr. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update build.verilog.yosys ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.verilog.core.md
+++ b/docs/coverage/detail/lang.verilog.core.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.verilog.core` — Verilog / SystemVerilog
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [verilog](../by-language/verilog.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Core extraction | 🟢 `partial` | `2026-06-24` | 5380 | `internal/extractors/verilog/extractor.go`<br>`internal/extractors/verilog/extractor_test.go` | Regex bootstrap (no tree-sitter grammar). Module/interface/package/class -> SCOPE.Component; function/task -> SCOPE.Operation; input/output/inout ports (ANSI header + classic body) -> SCOPE.Schema(subtype=port) with direction + width props, CONTAINS-wired from the owning module (#5380 buildPortEntities); module instantiations -> USES edges carrying instance_name + module_type + parameterized props so the instance topology graph is navigable (#5380 collectInstantiations); import/`include -> IMPORTS. Partial: no full type resolution / no signal-level dataflow / no generate-block elaboration (regex limits). Proven by TestVerilog_ANSIPorts / _ClassicPorts / _PortDedup / _InstanceTopology. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.verilog.core ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (32 active · 7 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 147 · **Other**: 208
+**Languages**: 39 (33 active · 6 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 151 · **Other**: 209
 
 ## Coverage by language
 
@@ -38,6 +38,7 @@
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
 | [JCL](by-language/jcl.md) | 0 | 0 | 0 | 1 |
 | [solidity](by-language/solidity.md) | 0 | 2 | 0 | 2 |
+| [verilog](by-language/verilog.md) | 0 | 4 | 0 | 1 |
 | [zig](by-language/zig.md) | 0 | 3 | 0 | 0 |
 
 ## Cross-cutting infrastructure
@@ -81,6 +82,5 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Pony](by-language/pony.md) |
 | [Standard ML](by-language/sml.md) |
 | [VHDL](by-language/vhdl.md) |
-| [Verilog](by-language/verilog.md) |
 
-Total: 263 frameworks · 147 tools · 186 ORMs · 208 other
+Total: 263 frameworks · 151 tools · 186 ORMs · 209 other

--- a/internal/extractors/verilog/extractor.go
+++ b/internal/extractors/verilog/extractor.go
@@ -11,9 +11,11 @@
 //   - `class Foo; ... endclass`                  → SCOPE.Component (class, SV)
 //   - `function [type] name(...); ... endfunction` → SCOPE.Operation (function)
 //   - `task name(...); ... endtask`              → SCOPE.Operation (task)
-//   - `Foo inst_name(...)` — module instantiations → USES edges
+//   - `input/output/inout` ports                → SCOPE.Schema(subtype=port)
+//   - `Foo inst_name(...)` — module instantiations → USES edges (with instance_name)
 //   - `import Pkg::*;` / `import Pkg::item;`     → IMPORTS (SV)
 //   - “ `include "foo.vh" “                    → IMPORTS
+//   - sim/synth tool signals (verilator/synth-attr/yosys) → SCOPE.Component(subtype=tool)
 //
 // File extensions handled: .v, .vh (Verilog), .sv, .svh (SystemVerilog).
 //
@@ -113,10 +115,44 @@ var (
 	//   ModuleName inst_name (...)
 	//   ModuleName #(...) inst_name (...)
 	// Group 1: module type name (leading uppercase or known pattern)
-	// Group 2: instance name
+	// Group 2: optional parameter-override block #(...)
+	// Group 3: instance name
 	instantiationRE = regexp.MustCompile(
-		`(?m)^\s*([A-Za-z_][A-Za-z0-9_$]*)\s+(?:#\s*\([^)]*\)\s+)?([A-Za-z_][A-Za-z0-9_$]*)\s*\(`,
+		`(?m)^\s*([A-Za-z_][A-Za-z0-9_$]*)\s+(#\s*\((?:[^()]|\([^()]*\))*\)\s+)?([A-Za-z_][A-Za-z0-9_$]*)\s*\(`,
 	)
+
+	// portDeclRE matches port direction declarations, both ANSI header style
+	// and classic body style:
+	//   input  wire        clk
+	//   output reg  [7:0]  data
+	//   inout              bus
+	//   input  logic [W-1:0] sel,
+	// Group 1: direction (input|output|inout)
+	// Group 2: optional net/var type + width modifiers (wire/reg/logic/[..])
+	// Group 3: port identifier
+	portDeclRE = regexp.MustCompile(
+		`(?m)(?:^|[,(])\s*(input|output|inout)\s+((?:wire|reg|logic|bit|signed|unsigned|tri|var|integer|real|time|byte|shortint|int|longint)\s+)*(?:\[[^\]]*\]\s*)*([A-Za-z_][A-Za-z0-9_$]*)`,
+	)
+
+	// portWidthRE extracts the packed dimension (width) preceding a port name,
+	// used to stamp a `width` property on the port entity.
+	portWidthRE = regexp.MustCompile(`\[[^\]]*\]`)
+
+	// verilatorPragmaRE matches Verilator-specific lint/config pragmas:
+	//   /* verilator lint_off WIDTH */   (handled pre-scrub on raw src)
+	//   `verilator_config
+	verilatorLintRE   = regexp.MustCompile(`verilator\s+(?:lint_off|lint_on|lint_save|lint_restore|coverage_off|coverage_on|public|isolate_assignments|tracing_off|tracing_on|no_inline)`)
+	verilatorConfigRE = regexp.MustCompile("(?m)`verilator_config")
+
+	// synthAttrRE matches synthesis attributes used by Vivado/Quartus/generic
+	// synthesis flows:
+	//   (* synthesis, ... *)   (* keep = "true" *)   (* dont_touch *)
+	//   (* mark_debug = "true" *)   (* ram_style = "block" *)
+	synthAttrRE = regexp.MustCompile(`\(\*\s*(synthesis|keep|keep_hierarchy|dont_touch|mark_debug|ram_style|rom_style|fsm_encoding|use_dsp|async_reg|max_fanout|syn_keep|syn_preserve|altera_attribute|preserve)\b`)
+
+	// yosysAttrRE matches Yosys-style attributes:
+	//   (* top *)   (* blackbox *)   (* whitebox *)   (* gentb_skip *)
+	yosysAttrRE = regexp.MustCompile(`\(\*\s*(top|blackbox|whitebox|abc9_box|gentb_clock|nomem2reg|mem2reg)\b`)
 )
 
 // verilogFunctionKeywords is the set of names that must NOT be treated as
@@ -221,7 +257,90 @@ func extractVerilog(src, filePath, lang string) []types.EntityRecord {
 	// ── 3. Module declarations ────────────────────────────────────────────
 	entities = append(entities, findComponents(scrubbed, src, filePath, lang)...)
 
+	// ── 4. Sim/synth toolchain detection ──────────────────────────────────
+	entities = append(entities, buildToolEntities(src, scrubbed, filePath, lang)...)
+
 	return entities
+}
+
+// -----------------------------------------------------------------------
+// Sim/synth toolchain detection
+// -----------------------------------------------------------------------
+
+// toolSpec describes a sim/synth toolchain recognised from signals present
+// inside HDL source (the only files routed to this extractor). Each spec is a
+// signal heuristic — not project-file parsing — so recognition is honest
+// "partial".
+type toolSpec struct {
+	id            string            // tool record id, e.g. "verilator"
+	label         string            // display name
+	matchRaw      func(string) bool // applied to raw source (catches comment pragmas)
+	matchScrubbed func(string) bool // applied to comment-stripped source (attributes)
+}
+
+var toolSpecs = []toolSpec{
+	{
+		id:    "verilator",
+		label: "Verilator",
+		matchRaw: func(raw string) bool {
+			return verilatorLintRE.MatchString(raw) || verilatorConfigRE.MatchString(raw)
+		},
+	},
+	{
+		id:            "synthesis",
+		label:         "Synthesis (Vivado/Quartus)",
+		matchScrubbed: func(s string) bool { return synthAttrRE.MatchString(s) },
+	},
+	{
+		id:            "yosys",
+		label:         "Yosys",
+		matchScrubbed: func(s string) bool { return yosysAttrRE.MatchString(s) },
+	},
+}
+
+// buildToolEntities emits one SCOPE.Component(subtype=tool) entity per
+// recognised sim/synth toolchain whose signals appear in the file, with a
+// USES edge file → tool so the toolchain is navigable from the source.
+func buildToolEntities(src, scrubbed, filePath, lang string) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	for _, spec := range toolSpecs {
+		matched := false
+		if spec.matchRaw != nil && spec.matchRaw(src) {
+			matched = true
+		}
+		if !matched && spec.matchScrubbed != nil && spec.matchScrubbed(scrubbed) {
+			matched = true
+		}
+		if !matched || seen[spec.id] {
+			continue
+		}
+		seen[spec.id] = true
+
+		out = append(out, types.EntityRecord{
+			Name:       spec.label,
+			Kind:       "SCOPE.Component",
+			Subtype:    "tool",
+			SourceFile: filePath,
+			Language:   lang,
+			Properties: map[string]string{
+				"tool":           spec.id,
+				"toolchain_kind": "sim_synth",
+			},
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   spec.id,
+					Kind:   "USES",
+					Properties: map[string]string{
+						"tool": spec.id,
+					},
+				},
+			},
+		})
+	}
+	return out
 }
 
 // -----------------------------------------------------------------------
@@ -382,8 +501,95 @@ func findComponents(scrubbed, src, filePath, lang string) []types.EntityRecord {
 			for _, u := range usesRels {
 				out[compIdx].Relationships = append(out[compIdx].Relationships, u)
 			}
+
+			// ── Ports (module/interface I/O topology) ─────────────────────
+			// Ports may be declared in the ANSI header (between the module
+			// declaration and the terminating ';') or classic-style in the body.
+			if spec.subtype == "module" || spec.subtype == "interface" {
+				header := scrubbed[m[0]:m[1]]
+				portRecs := buildPortEntities(header, body, name, filePath, lang, startLine)
+				for i := range portRecs {
+					out = append(out, portRecs[i])
+					toID := extractor.BuildOperationStructuralRef(lang, filePath, portRecs[i].Name)
+					out[compIdx].Relationships = append(out[compIdx].Relationships, types.RelationshipRecord{
+						ToID: toID,
+						Kind: "CONTAINS",
+					})
+				}
+			}
 		}
 	}
+
+	return out
+}
+
+// -----------------------------------------------------------------------
+// Port extraction (module/interface I/O topology)
+// -----------------------------------------------------------------------
+
+// buildPortEntities scans a module/interface header and body for port
+// direction declarations (input/output/inout) and emits one SCOPE.Schema
+// entity per port, stamped with direction and (when present) width.
+//
+// ANSI-style ports live in the header:  module foo (input wire clk, output [7:0] q);
+// Classic-style ports live in the body: module foo (clk, q); input clk; output [7:0] q;
+//
+// De-duplicated by port name so a classic port re-declared in the body is
+// emitted once.
+func buildPortEntities(header, body, ownerName, filePath, lang string, ownerLine int) []types.EntityRecord {
+	seen := make(map[string]bool)
+	var out []types.EntityRecord
+
+	scan := func(text string, lineBase int) {
+		for _, pm := range portDeclRE.FindAllStringSubmatchIndex(text, -1) {
+			if len(pm) < 8 {
+				continue
+			}
+			direction := text[pm[2]:pm[3]]
+			portName := text[pm[6]:pm[7]]
+			if verilogKeywords[portName] {
+				continue
+			}
+			if seen[portName] {
+				continue
+			}
+			seen[portName] = true
+
+			// Width: the last packed dimension before the name, if any.
+			width := ""
+			decl := text[pm[0]:pm[7]]
+			if w := portWidthRE.FindAllString(decl, -1); len(w) > 0 {
+				width = w[len(w)-1]
+			}
+
+			qualName := ownerName + "." + portName
+			line := lineBase + strings.Count(text[:pm[0]], "\n")
+
+			props := map[string]string{
+				"direction": direction,
+				"port":      portName,
+			}
+			if width != "" {
+				props["width"] = width
+			}
+
+			out = append(out, types.EntityRecord{
+				Name:       qualName,
+				Kind:       "SCOPE.Schema",
+				Subtype:    "port",
+				SourceFile: filePath,
+				Language:   lang,
+				StartLine:  line,
+				EndLine:    line,
+				Properties: props,
+			})
+		}
+	}
+
+	// Header ports are on the owner declaration line(s).
+	scan(header, ownerLine)
+	// Body ports follow the header.
+	scan(body, ownerLine)
 
 	return out
 }
@@ -492,11 +698,12 @@ func collectInstantiations(body, ownerName string) []types.RelationshipRecord {
 	var out []types.RelationshipRecord
 
 	for _, m := range instantiationRE.FindAllStringSubmatch(body, -1) {
-		if len(m) < 3 {
+		if len(m) < 4 {
 			continue
 		}
 		typeName := m[1]
-		instName := m[2]
+		hasParamOverride := strings.TrimSpace(m[2]) != ""
+		instName := m[3]
 
 		// Skip keywords, built-ins, and the owner's own name.
 		if verilogKeywords[typeName] || verilogKeywords[strings.ToLower(typeName)] {
@@ -530,9 +737,18 @@ func collectInstantiations(body, ownerName string) []types.RelationshipRecord {
 		}
 		seen[key] = true
 
+		props := map[string]string{
+			"instance_name": instName,
+			"module_type":   typeName,
+		}
+		if hasParamOverride {
+			props["parameterized"] = "true"
+		}
+
 		out = append(out, types.RelationshipRecord{
-			ToID: typeName,
-			Kind: "USES",
+			ToID:       typeName,
+			Kind:       "USES",
+			Properties: props,
 		})
 	}
 	return out

--- a/internal/extractors/verilog/extractor_test.go
+++ b/internal/extractors/verilog/extractor_test.go
@@ -686,3 +686,182 @@ func TestSV_ALUPackageFixture(t *testing.T) {
 		t.Error("expected IMPORTS edge for alu_sv_pkg")
 	}
 }
+
+// ── Port topology tests (#5380) ───────────────────────────────────────────────
+
+func vFindPort(ents []types.EntityRecord, name string) *types.EntityRecord {
+	return vFindSubtype(ents, name, "SCOPE.Schema", "port")
+}
+
+func TestVerilog_ANSIPorts(t *testing.T) {
+	src := `module adder (
+		input  wire        clk,
+		input  wire [7:0]  a,
+		input  wire [7:0]  b,
+		output reg  [8:0]  sum,
+		inout              bus
+	);
+	endmodule`
+	ents := runVerilog(t, src, "adder.v", "verilog")
+
+	for _, tc := range []struct{ name, dir, width string }{
+		{"adder.clk", "input", ""},
+		{"adder.a", "input", "[7:0]"},
+		{"adder.b", "input", "[7:0]"},
+		{"adder.sum", "output", "[8:0]"},
+		{"adder.bus", "inout", ""},
+	} {
+		p := vFindPort(ents, tc.name)
+		if p == nil {
+			t.Errorf("missing port %s", tc.name)
+			continue
+		}
+		if p.Properties["direction"] != tc.dir {
+			t.Errorf("%s: direction=%q want %q", tc.name, p.Properties["direction"], tc.dir)
+		}
+		if p.Properties["width"] != tc.width {
+			t.Errorf("%s: width=%q want %q", tc.name, p.Properties["width"], tc.width)
+		}
+	}
+
+	// CONTAINS edges module → ports.
+	if !vHasRelPartial(ents, "adder", "SCOPE.Component", "CONTAINS", "adder.clk") {
+		t.Error("expected CONTAINS edge adder → adder.clk")
+	}
+}
+
+func TestVerilog_ClassicPorts(t *testing.T) {
+	src := `module legacy (clk, a, q);
+		input        clk;
+		input  [3:0] a;
+		output [3:0] q;
+	endmodule`
+	ents := runVerilog(t, src, "legacy.v", "verilog")
+
+	for _, name := range []string{"legacy.clk", "legacy.a", "legacy.q"} {
+		if vFindPort(ents, name) == nil {
+			t.Errorf("missing classic-style port %s", name)
+		}
+	}
+	if p := vFindPort(ents, "legacy.q"); p != nil && p.Properties["direction"] != "output" {
+		t.Errorf("legacy.q direction=%q want output", p.Properties["direction"])
+	}
+}
+
+func TestVerilog_PortDedup(t *testing.T) {
+	// Classic header lists the port, body re-declares its direction. One entity.
+	src := `module dut (clk);
+		input clk;
+	endmodule`
+	ents := runVerilog(t, src, "dut.v", "verilog")
+	count := 0
+	for i := range ents {
+		if ents[i].Name == "dut.clk" && ents[i].Subtype == "port" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 dut.clk port entity, got %d", count)
+	}
+}
+
+// ── Instance topology tests (#5380) ───────────────────────────────────────────
+
+func TestVerilog_InstanceTopology(t *testing.T) {
+	src := `module top (input clk);
+		sub_a u_a (.clk(clk));
+		sub_b #(.W(8)) u_b (.clk(clk));
+	endmodule`
+	ents := runVerilog(t, src, "top.v", "verilog")
+
+	top := vFind(ents, "top", "SCOPE.Component")
+	if top == nil {
+		t.Fatal("missing top module")
+	}
+	got := map[string]types.RelationshipRecord{}
+	for _, r := range top.Relationships {
+		if r.Kind == "USES" {
+			got[r.ToID] = r
+		}
+	}
+	a, ok := got["sub_a"]
+	if !ok {
+		t.Fatal("missing USES edge top → sub_a")
+	}
+	if a.Properties["instance_name"] != "u_a" {
+		t.Errorf("sub_a instance_name=%q want u_a", a.Properties["instance_name"])
+	}
+	b, ok := got["sub_b"]
+	if !ok {
+		t.Fatal("missing USES edge top → sub_b")
+	}
+	if b.Properties["instance_name"] != "u_b" {
+		t.Errorf("sub_b instance_name=%q want u_b", b.Properties["instance_name"])
+	}
+	if b.Properties["parameterized"] != "true" {
+		t.Errorf("sub_b should be flagged parameterized; props=%v", b.Properties)
+	}
+}
+
+// ── Sim/synth tool detection tests (#5380) ────────────────────────────────────
+
+func vFindTool(ents []types.EntityRecord, label string) *types.EntityRecord {
+	return vFindSubtype(ents, label, "SCOPE.Component", "tool")
+}
+
+func TestVerilog_VerilatorPragma(t *testing.T) {
+	src := `module m;
+		/* verilator lint_off WIDTH */
+		wire x;
+		/* verilator lint_on WIDTH */
+	endmodule`
+	ents := runVerilog(t, src, "m.v", "verilog")
+	tool := vFindTool(ents, "Verilator")
+	if tool == nil {
+		t.Fatal("expected Verilator tool entity")
+	}
+	if tool.Properties["tool"] != "verilator" {
+		t.Errorf("tool prop=%q want verilator", tool.Properties["tool"])
+	}
+}
+
+func TestVerilog_VerilatorConfig(t *testing.T) {
+	src := "`verilator_config\nlint_off -rule WIDTH\n"
+	ents := runVerilog(t, src, "cfg.vlt", "verilog")
+	if vFindTool(ents, "Verilator") == nil {
+		t.Fatal("expected Verilator tool entity from `verilator_config")
+	}
+}
+
+func TestVerilog_SynthesisAttrs(t *testing.T) {
+	src := `module m (input clk);
+		(* keep = "true" *) reg r;
+		(* dont_touch = "true" *) wire w;
+	endmodule`
+	ents := runVerilog(t, src, "m.sv", "systemverilog")
+	if vFindTool(ents, "Synthesis (Vivado/Quartus)") == nil {
+		t.Fatal("expected synthesis tool entity from (* keep *) / (* dont_touch *)")
+	}
+}
+
+func TestVerilog_YosysAttr(t *testing.T) {
+	src := `(* top *)
+	module m (input clk);
+	endmodule`
+	ents := runVerilog(t, src, "m.v", "verilog")
+	if vFindTool(ents, "Yosys") == nil {
+		t.Fatal("expected Yosys tool entity from (* top *)")
+	}
+}
+
+func TestVerilog_NoToolFalsePositive(t *testing.T) {
+	src := `module m (input clk, output q);
+		assign q = clk;
+	endmodule`
+	ents := runVerilog(t, src, "m.v", "verilog")
+	for i := range ents {
+		if ents[i].Subtype == "tool" {
+			t.Errorf("unexpected tool entity %q on plain module", ents[i].Name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #5380 (epic #5360, Group A — bootstrap). Go-only; no tree-sitter grammar; regex bootstrap.

## What
Module/port/instance **topology depth** + **sim/synth toolchain** records for the Verilog/SystemVerilog extractor.

### Topology — `lang.verilog.core` / `core_extraction` (partial)
- **Ports**: `input/output/inout` declarations (ANSI header *and* classic body style) -> `SCOPE.Schema(subtype=port)` stamped with `direction` + `width`, `CONTAINS`-wired from the owning module/interface. De-duplicated by port name.
- **Instances**: module instantiations now carry `instance_name` + `module_type` + `parameterized` props on the `USES` edge, so the instance graph is navigable rather than just type->type. The instantiation regex was widened to tolerate nested-paren parameter overrides (`sub #(.W(8)) u (...)`).

### Sim/synth tools — `build_system` (partial)
Detected from signals present **inside HDL source** (the only files routed to this extractor; `.tcl/.xpr/Makefile` are not). Each emits `SCOPE.Component(subtype=tool)` + a `file -> tool` `USES` edge:
- **Verilator** — `/* verilator lint_off|coverage_off|public|tracing_off|... */` pragmas + `` `verilator_config ``.
- **Vivado** / **Quartus** — synthesis attributes `(* keep *)` `(* dont_touch *)` `(* mark_debug *)` `(* ram_style *)` `(* altera_attribute *)` `(* syn_preserve *)` ...
- **Yosys** — `(* top *)` `(* blackbox *)` `(* whitebox *)` `(* abc9_box *)` ...

**Icarus Verilog** intentionally **omitted** — it has no distinct in-HDL signal to detect honestly (its signals are command-line flags); recording it would be a false-green.

## Honesty
Everything is `partial` — regex bootstrap, no AST/dataflow resolution; tools are in-HDL signal detection, not project-file parsing. Notes on each registry cell spell out the boundary.

## Coverage
`docs/coverage/registry.json` + regenerated docs updated in this PR (`coverage add` + `update`, `validate` + `fmt --check` green, `gen` re-run). New records: `lang.verilog.core`, `build.verilog.{verilator,vivado,quartus,yosys}`.

## Tests
Per-capability fixtures in `internal/extractors/verilog/extractor_test.go`:
- `TestVerilog_ANSIPorts` / `_ClassicPorts` / `_PortDedup` — ports + direction + width + dedup.
- `TestVerilog_InstanceTopology` — instance_name + parameterized props.
- `TestVerilog_VerilatorPragma` / `_VerilatorConfig` / `_SynthesisAttrs` / `_YosysAttr` / `_NoToolFalsePositive` — tool detection + no false positives on plain modules.

`go test ./internal/extractors/verilog/ ./tools/coverage/ ./internal/types/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)