### PR TITLE
feat(mcp): analysis-cluster canonical tools — debt/security/test_analysis/patterns/findings/diff (#5550)

### DIFF
--- a/internal/mcp/analysis_merges.go
+++ b/internal/mcp/analysis_merges.go
@@ -1,0 +1,201 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// analysis_merges.go — ANALYSIS-cluster canonical tool dispatchers (epic #5546,
+// #5550).
+//
+// Second of the 0.1.5 MCP-consolidation clusters (the CORE cluster lives in
+// core_merges.go, #5549). Each canonical tool reads a single discriminator
+// argument (kind / action / aspect) and dispatches to the EXISTING analysis
+// handler funcs unchanged — behaviour is byte-identical to the absorbed tools.
+// No analytical logic lives here; this is pure routing. The absorbed tools stay
+// registered as standalone tools for back-compat until #5552 converts them to
+// hidden aliases.
+//
+// reqWithArgs (defined in core_merges.go) is reused where a discriminator's
+// value must be rewritten into an inner argument the delegate reads itself.
+
+// handleAnalysisDebt routes grafel_debt by kind= over the tech-debt /
+// code-health handlers. Default kind=dead_code — the hot "what's unwired?" case.
+//
+//	dead_code (default) → handleDeadCode          (reachability dead-code)
+//	find_dead_code      → handleFindDeadCode      (isolated/marked-unused/test-only)
+//	cycles              → handleQualityCycles     (import cycles, Tarjan SCC)
+//	import_cycles       → handleModuleCyclesSidecar (IMPORTS SCC sidecar)
+//	stubs               → handleStubDetector      (v3 pure where oracle computes)
+//	impure              → handlePureFunctions     (functions with no effects)
+//	license             → handleLicenseAudit      (dependency-license conflicts)
+func (s *Server) handleAnalysisDebt(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "kind", "dead_code") {
+	case "find_dead_code", "unwired":
+		return s.handleFindDeadCode(ctx, req)
+	case "cycles":
+		return s.handleQualityCycles(ctx, req)
+	case "import_cycles":
+		return s.handleModuleCyclesSidecar(ctx, req)
+	case "stubs", "stub":
+		return s.handleStubDetector(ctx, req)
+	case "impure", "pure", "pure_functions":
+		return s.handlePureFunctions(ctx, req)
+	case "license", "licenses":
+		return s.handleLicenseAudit(ctx, req)
+	default: // "dead_code"
+		return s.handleDeadCode(ctx, req)
+	}
+}
+
+// handleAnalysisSecurity routes grafel_security by kind=. Default kind=findings
+// (taint-flow security findings).
+//
+//	findings (default) → handleSecurityFindings (taint source→sink paths)
+//	secrets            → handleSecrets          (hardcoded-secret scan)
+//	auth_coverage      → handleAuthCoverage     (endpoints missing auth)
+func (s *Server) handleAnalysisSecurity(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "kind", "findings") {
+	case "secrets":
+		return s.handleSecrets(ctx, req)
+	case "auth_coverage", "auth":
+		return s.handleAuthCoverage(ctx, req)
+	default: // "findings"
+		return s.handleSecurityFindings(ctx, req)
+	}
+}
+
+// handleAnalysisTest routes grafel_test_analysis by kind=. Default
+// kind=coverage (production entities with no TESTS edge).
+//
+//	coverage (default)     → handleTestCoverage           (no TESTS edge)
+//	reachability           → handleTestReachability       (no test path / orphans)
+//	contract_effectiveness → handleContractTestEffectiveness (tautological specs)
+//	coverage_effectiveness → handleCoverageEffectiveness  (reachable-but-0%-lines)
+func (s *Server) handleAnalysisTest(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "kind", "coverage") {
+	case "reachability", "reach":
+		return s.handleTestReachability(ctx, req)
+	case "contract_effectiveness", "contract_eff", "contract":
+		return s.handleContractTestEffectiveness(ctx, req)
+	case "coverage_effectiveness", "coverage_eff", "effectiveness":
+		return s.handleCoverageEffectiveness(ctx, req)
+	default: // "coverage"
+		return s.handleTestCoverage(ctx, req)
+	}
+}
+
+// handleAnalysisPatterns routes grafel_patterns by kind=. Default kind=code
+// preserves the existing agent pattern store (handlePatterns reads its own
+// action=query|record), so back-compat is byte-identical for callers that pass
+// only action=.
+//
+//	code (default) → handlePatterns         (agent-learned pattern store)
+//	graph          → handleGraphPatterns    (indexer-extracted patterns)
+//	template       → handleTemplatePatterns (i18n/log_format/sql literals)
+func (s *Server) handleAnalysisPatterns(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "kind", "code") {
+	case "graph", "graph_patterns":
+		// handleGraphPatterns requires action=; default to list when the caller
+		// routed in via kind= without an explicit action.
+		if argString(req, "action", "") == "" {
+			req = reqWithArgs(req, map[string]any{"action": "list"})
+		}
+		return s.handleGraphPatterns(ctx, req)
+	case "template", "templates", "template_patterns":
+		return s.handleTemplatePatterns(ctx, req)
+	default: // "code"
+		return s.handlePatterns(ctx, req)
+	}
+}
+
+// handleAnalysisFindings routes grafel_findings by action= over the findings
+// store. Default action=list (read-only enumeration).
+//
+//	list (default) → handleListFindings (enumerate stored findings)
+//	save           → handleSaveResult   (persist a Q&A finding)
+func (s *Server) handleAnalysisFindings(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "action", "list") {
+	case "save", "store", "persist":
+		return s.handleSaveResult(ctx, req)
+	default: // "list"
+		return s.handleListFindings(ctx, req)
+	}
+}
+
+// handleAnalysisDiff routes grafel_diff by aspect= over the comparison
+// handlers. Default aspect=response_shape.
+//
+// The members do NOT share one return shape — this is a DISCRIMINATED UNION
+// keyed by `aspect`: refs returns entity/relationship deltas;
+// response_shape/auth/literals return per-endpoint parity verdicts; payload
+// returns drift findings. The dispatcher stamps the chosen `aspect` onto the
+// JSON-object result (via stampAspect) so the caller can tell which shape it
+// received without forcing a common schema. Error/non-object results pass
+// through unchanged.
+//
+//	response_shape (default) → handleResponseShapeDiff (per-status field drift)
+//	payload                  → handlePayloadDrift      (schema/envelope drift)
+//	auth                     → handleAuthPostureDiff   (auth-posture parity)
+//	literals                 → handleLiteralParity     (ConstantSet/enum parity)
+//	refs                     → handleDiffRefs          (entity/rel deltas, 2 refs)
+func (s *Server) handleAnalysisDiff(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	var (
+		res    *mcpapi.CallToolResult
+		err    error
+		aspect string
+	)
+	switch argString(req, "aspect", "response_shape") {
+	case "payload", "payload_drift":
+		aspect = "payload"
+		res, err = s.handlePayloadDrift(ctx, req)
+	case "auth", "auth_posture":
+		aspect = "auth"
+		res, err = s.handleAuthPostureDiff(ctx, req)
+	case "literals", "literal", "literal_parity":
+		aspect = "literals"
+		res, err = s.handleLiteralParity(ctx, req)
+	case "refs", "diff_refs":
+		aspect = "refs"
+		res, err = s.handleDiffRefs(ctx, req)
+	default: // "response_shape"
+		aspect = "response_shape"
+		res, err = s.handleResponseShapeDiff(ctx, req)
+	}
+	if err != nil {
+		return res, err
+	}
+	return stampAspect(res, aspect), nil
+}
+
+// stampAspect injects "aspect":<value> as a top-level key into a JSON-object
+// tool result so grafel_diff's discriminated union is self-describing. If the
+// result is not a JSON object (an error result, a JSON array, or plain text) it
+// is returned unchanged — the dispatch must never corrupt an absorbed handler's
+// payload.
+func stampAspect(res *mcpapi.CallToolResult, aspect string) *mcpapi.CallToolResult {
+	if res == nil || res.IsError {
+		return res
+	}
+	for i, c := range res.Content {
+		tc, ok := c.(mcpapi.TextContent)
+		if !ok {
+			continue
+		}
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(tc.Text), &obj); err != nil {
+			return res // not a JSON object — leave verbatim
+		}
+		obj["aspect"] = json.RawMessage(`"` + aspect + `"`)
+		out, err := json.Marshal(obj)
+		if err != nil {
+			return res
+		}
+		tc.Text = string(out)
+		res.Content[i] = tc
+		return res
+	}
+	return res
+}

--- a/internal/mcp/analysis_merges_test.go
+++ b/internal/mcp/analysis_merges_test.go
@@ -1,0 +1,187 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// analysis_merges_test.go — dispatch tests for the ANALYSIS-cluster canonical
+// tools (#5546/#5550). Each test asserts that a discriminator value on the new
+// canonical handler produces the same output as the absorbed handler it routes
+// to (order-insensitive via normalizeForCompare, defined in core_merges_test.go).
+// Helpers coreTestServer / callBare / assertSameDispatch are shared from there.
+
+// 1. grafel_debt kind= → dead_code/find_dead_code/cycles/import_cycles/stubs/impure/license.
+func TestAnalysisDebtDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	g := map[string]any{"group": "g"}
+	with := func(kind string) map[string]any {
+		return map[string]any{"group": "g", "kind": kind}
+	}
+	stub := map[string]any{"group_v3": "g", "group_oracle": "g"}
+	stubKind := map[string]any{"group_v3": "g", "group_oracle": "g", "kind": "stubs"}
+	assertSameDispatch(t, "kind=dead_code", srv.handleAnalysisDebt, with("dead_code"), srv.handleDeadCode, g)
+	assertSameDispatch(t, "kind=default", srv.handleAnalysisDebt, g, srv.handleDeadCode, g)
+	assertSameDispatch(t, "kind=find_dead_code", srv.handleAnalysisDebt, with("find_dead_code"), srv.handleFindDeadCode, g)
+	assertSameDispatch(t, "kind=cycles", srv.handleAnalysisDebt, with("cycles"), srv.handleQualityCycles, g)
+	assertSameDispatch(t, "kind=import_cycles", srv.handleAnalysisDebt, with("import_cycles"), srv.handleModuleCyclesSidecar, g)
+	assertSameDispatch(t, "kind=stubs", srv.handleAnalysisDebt, stubKind, srv.handleStubDetector, stub)
+	assertSameDispatch(t, "kind=impure", srv.handleAnalysisDebt, with("impure"), srv.handlePureFunctions, g)
+	assertSameDispatch(t, "kind=license", srv.handleAnalysisDebt, with("license"), srv.handleLicenseAudit, g)
+}
+
+// 2. grafel_security kind= → findings/secrets/auth_coverage.
+func TestAnalysisSecurityDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	g := map[string]any{"group": "g"}
+	with := func(kind string) map[string]any {
+		return map[string]any{"group": "g", "kind": kind}
+	}
+	assertSameDispatch(t, "kind=findings", srv.handleAnalysisSecurity, with("findings"), srv.handleSecurityFindings, g)
+	assertSameDispatch(t, "kind=default", srv.handleAnalysisSecurity, g, srv.handleSecurityFindings, g)
+	assertSameDispatch(t, "kind=secrets", srv.handleAnalysisSecurity, with("secrets"), srv.handleSecrets, g)
+	assertSameDispatch(t, "kind=auth_coverage", srv.handleAnalysisSecurity, with("auth_coverage"), srv.handleAuthCoverage, g)
+}
+
+// 3. grafel_test_analysis kind= → coverage/reachability/contract_effectiveness/coverage_effectiveness.
+func TestAnalysisTestDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	g := map[string]any{"group": "g"}
+	with := func(kind string) map[string]any {
+		return map[string]any{"group": "g", "kind": kind}
+	}
+	assertSameDispatch(t, "kind=coverage", srv.handleAnalysisTest, with("coverage"), srv.handleTestCoverage, g)
+	assertSameDispatch(t, "kind=default", srv.handleAnalysisTest, g, srv.handleTestCoverage, g)
+	assertSameDispatch(t, "kind=reachability", srv.handleAnalysisTest, with("reachability"), srv.handleTestReachability, g)
+	assertSameDispatch(t, "kind=contract_effectiveness", srv.handleAnalysisTest, with("contract_effectiveness"), srv.handleContractTestEffectiveness, g)
+	assertSameDispatch(t, "kind=coverage_effectiveness", srv.handleAnalysisTest, with("coverage_effectiveness"), srv.handleCoverageEffectiveness, g)
+}
+
+// 4. grafel_patterns kind= → code (agent store) / graph / template.
+func TestAnalysisPatternsDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	// code: handlePatterns reads its own action=; query is the read path.
+	codeArgs := map[string]any{"group": "g", "action": "query", "text": "x"}
+	assertSameDispatch(t, "kind=code", srv.handleAnalysisPatterns,
+		map[string]any{"group": "g", "kind": "code", "action": "query", "text": "x"},
+		srv.handlePatterns, codeArgs)
+	assertSameDispatch(t, "kind=default", srv.handleAnalysisPatterns, codeArgs, srv.handlePatterns, codeArgs)
+	// graph: dispatcher defaults action=list.
+	assertSameDispatch(t, "kind=graph", srv.handleAnalysisPatterns,
+		map[string]any{"group": "g", "kind": "graph"},
+		srv.handleGraphPatterns, map[string]any{"group": "g", "action": "list"})
+	// template.
+	assertSameDispatch(t, "kind=template", srv.handleAnalysisPatterns,
+		map[string]any{"group": "g", "kind": "template"},
+		srv.handleTemplatePatterns, map[string]any{"group": "g"})
+}
+
+// 5. grafel_findings action= → list / save.
+func TestAnalysisFindingsDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	g := map[string]any{"group": "g"}
+	assertSameDispatch(t, "action=list", srv.handleAnalysisFindings,
+		map[string]any{"group": "g", "action": "list"}, srv.handleListFindings, g)
+	assertSameDispatch(t, "action=default", srv.handleAnalysisFindings, g, srv.handleListFindings, g)
+	// save: handleSaveResult requires question + answer.
+	save := map[string]any{"group": "g", "question": "q", "answer": "a"}
+	assertSameDispatch(t, "action=save", srv.handleAnalysisFindings,
+		map[string]any{"group": "g", "action": "save", "question": "q", "answer": "a"},
+		srv.handleSaveResult, save)
+}
+
+// 6. grafel_diff aspect= → response_shape/payload/auth/literals/refs.
+// The return is a discriminated union keyed by `aspect`: we compare the
+// canonical result with the absorbed handler's result after STRIPPING the
+// injected aspect key, then separately assert the aspect key is present + correct.
+func TestAnalysisDiffDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	cross := func(aspect string) map[string]any {
+		return map[string]any{"group_oracle": "g", "group_v3": "g", "aspect": aspect}
+	}
+	crossBare := map[string]any{"group_oracle": "g", "group_v3": "g"}
+
+	type diffCase struct {
+		aspect  string
+		canon   map[string]any
+		old     func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error)
+		oldArgs map[string]any
+	}
+	cases := []diffCase{
+		{"response_shape", cross("response_shape"), srv.handleResponseShapeDiff, crossBare},
+		{"payload", map[string]any{"group": "g", "aspect": "payload"}, srv.handlePayloadDrift, map[string]any{"group": "g"}},
+		{"auth", cross("auth"), srv.handleAuthPostureDiff, crossBare},
+		{"literals", map[string]any{"group_oracle": "g", "group_v3": "g", "set": "page_slugs", "aspect": "literals"}, srv.handleLiteralParity, map[string]any{"group_oracle": "g", "group_v3": "g", "set": "page_slugs"}},
+		{"refs", map[string]any{"group": "g", "repo": "r1", "ref_a": "main", "ref_b": "main", "aspect": "refs"}, srv.handleDiffRefs, map[string]any{"group": "g", "repo": "r1", "ref_a": "main", "ref_b": "main"}},
+	}
+	for _, c := range cases {
+		got := callBare(t, srv.handleAnalysisDiff, c.canon)
+		want := callBare(t, c.old, c.oldArgs)
+		assertDiffAspect(t, c.aspect, got, want)
+	}
+
+	// default aspect=response_shape.
+	gotDefault := callBare(t, srv.handleAnalysisDiff, crossBare)
+	wantDefault := callBare(t, srv.handleResponseShapeDiff, crossBare)
+	assertDiffAspect(t, "response_shape", gotDefault, wantDefault)
+}
+
+// assertDiffAspect verifies the canonical grafel_diff result equals the absorbed
+// handler's result once the injected aspect key is removed, and that the aspect
+// key was present with the expected value. Non-JSON-object (error) results pass
+// through unchanged, in which case got must equal want verbatim.
+func assertDiffAspect(t *testing.T, aspect, got, want string) {
+	t.Helper()
+	var gotObj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got), &gotObj); err != nil {
+		// Not a JSON object (error/text result) — stampAspect is a no-op, so
+		// the canonical result must be byte-identical to the absorbed handler.
+		if got != want {
+			t.Errorf("aspect=%s (non-object): canonical=%q want=%q", aspect, got, want)
+		}
+		return
+	}
+	a, ok := gotObj["aspect"]
+	if !ok {
+		t.Errorf("aspect=%s: result missing injected aspect key", aspect)
+		return
+	}
+	if string(a) != `"`+aspect+`"` {
+		t.Errorf("aspect=%s: injected aspect=%s, want %q", aspect, a, aspect)
+	}
+	delete(gotObj, "aspect")
+	stripped, err := json.Marshal(gotObj)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	// want is the absorbed handler's native JSON object; re-marshal it through
+	// the same map round-trip so key ordering matches.
+	var wantObj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(want), &wantObj); err != nil {
+		t.Fatalf("aspect=%s: absorbed handler result not a JSON object: %v", aspect, err)
+	}
+	wantNorm, _ := json.Marshal(wantObj)
+	if string(stripped) != string(wantNorm) {
+		t.Errorf("aspect=%s: stripped canonical differs from absorbed handler\n got=%s\nwant=%s", aspect, stripped, wantNorm)
+	}
+}
+
+// 7. All six ANALYSIS canonical tools are registered (#5546/#5550).
+func TestAnalysisCanonicalToolsRegistered(t *testing.T) {
+	srv := coreTestServer(t)
+	registered := map[string]bool{}
+	for _, st := range srv.MCP.ListTools() {
+		registered[st.Tool.Name] = true
+	}
+	for _, n := range []string{
+		"grafel_debt", "grafel_security", "grafel_test_analysis",
+		"grafel_patterns", "grafel_findings", "grafel_diff",
+	} {
+		if !registered[n] {
+			t.Errorf("ANALYSIS canonical tool %q not registered", n)
+		}
+	}
+}

--- a/internal/mcp/schema_trim_5386_test.go
+++ b/internal/mcp/schema_trim_5386_test.go
@@ -153,7 +153,7 @@ var wantToolParams = map[string]string{
 	"grafel_neighbors":                   "cwd,depth,direction,entity_id,fields,group,ref,token_budget|req:entity_id",
 	"grafel_orient":                      "cwd,group,max_questions,ref,repo_filter,top_edges,top_entities,topic_id,view|req:",
 	"grafel_related":                     "cwd,depth,direction,entity_id,fields,group,ref,repo_filter,token_budget|req:entity_id",
-	"grafel_patterns":                    "action,category,cwd,exemplars,group,limit,steps,text|req:action",
+	"grafel_patterns":                    "action,category,cwd,exemplars,group,kind,limit,repo_filter,steps,text|req:",
 	"grafel_payload_drift":               "cwd,drift_class,group|req:",
 	"grafel_persona_event":               "chain,depth,event_type,metadata,persona,target_persona|req:event_type,persona",
 	"grafel_pr_impact":                   "base,cwd,group,head,hops,refs,repo|req:repo",
@@ -176,4 +176,10 @@ var wantToolParams = map[string]string{
 	"grafel_trace":                       "action,cwd,detail,entity_id,group,include,kind,limit,ref,repo_filter,sink_kind,source,target|req:",
 	"grafel_traces":                      "action,cwd,entry_point_id,group,limit,max_depth,process_id,ref,repo_filter,token_budget|req:",
 	"grafel_whoami":                      "cwd,group,ref|req:",
+	// #5546/#5550 ANALYSIS-cluster canonical tools.
+	"grafel_debt":          "cwd,group,group_oracle,group_v3,kind,kind_filter,limit,ref,repo_filter|req:",
+	"grafel_security":      "category,cwd,format,group,kind,limit,min_confidence,ref,repo_filter,severity,source_repo|req:",
+	"grafel_test_analysis": "cwd,entity_id,group,kind,limit,ref,repo_filter,severity|req:",
+	"grafel_findings":      "action,answer,cwd,group,question|req:",
+	"grafel_diff":          "aspect,cwd,drift_class,group,group_oracle,group_v3,ref_a,ref_b,repo,set|req:",
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -915,17 +915,104 @@ func (s *Server) registerTools() {
 	// grafel_get_telemetry dropped (dashboard-only; use HTTP /api/telemetry instead).
 
 	// grafel_patterns — ADR-0018. action=query|record.
+	// grafel_patterns — ANALYSIS canonical patterns tool (#5546/#5550). kind=
+	// routes over the three pattern surfaces; default code = the agent pattern
+	// store (which still reads its own action=query|record), preserving the
+	// pre-merge behaviour byte-for-byte for callers that pass only action=.
 	s.addTool(mcpapi.NewTool("grafel_patterns",
-		mcpapi.WithDescription("Agent pattern store: query=find by task, record=store with exemplars."),
-		mcpapi.WithString("action", mcpapi.Required()),
+		mcpapi.WithDescription("Patterns. kind=code(def,agent store)|graph(extracted)|template(literals)."),
+		mcpapi.WithString("kind", mcpapi.DefaultString("code"),
+			mcpapi.Description("code=agent store (needs action=query|record); graph=indexer-extracted; template=i18n/log/sql literals.")),
+		mcpapi.WithString("action"), // kind=code (query|record), kind=graph (list|get)
 		mcpapi.WithAny("text"),
 		mcpapi.WithAny("category"),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(10)),
 		mcpapi.WithArray("steps"),
 		mcpapi.WithArray("exemplars"),
+		mcpapi.WithArray("repo_filter"), // kind=graph|template
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
-	), s.wrap("grafel_patterns", s.handlePatterns))
+	), s.wrap("grafel_patterns", s.handleAnalysisPatterns))
+
+	// grafel_debt — ANALYSIS canonical tech-debt / code-health tool (#5546/#5550).
+	// kind= routes over dead-code, cycle, stub, purity, and license analyses.
+	s.addTool(mcpapi.NewTool("grafel_debt",
+		mcpapi.WithDescription("Code smells/dead code/cycles. kind=dead_code(def)|cycles|stubs|impure|license."),
+		mcpapi.WithString("kind", mcpapi.DefaultString("dead_code"),
+			mcpapi.Description("dead_code=unreached entities; cycles=import cycles; stubs=v3 fakes; impure=fns w/ effects-free; license=dep-license conflicts.")),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithAny("kind_filter"), // kind=dead_code
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
+		mcpapi.WithString("group_oracle"), // kind=stubs
+		mcpapi.WithString("group_v3"),     // kind=stubs
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+		mcpapi.WithAny("ref"),
+	), s.wrap("grafel_debt", s.handleAnalysisDebt))
+
+	// grafel_security — ANALYSIS canonical security-posture tool (#5546/#5550).
+	s.addTool(mcpapi.NewTool("grafel_security",
+		mcpapi.WithDescription("Security posture. kind=findings(def,taint)|secrets|auth_coverage."),
+		mcpapi.WithString("kind", mcpapi.DefaultString("findings"),
+			mcpapi.Description("findings=taint source→sink paths; secrets=hardcoded-credential scan; auth_coverage=endpoints missing auth.")),
+		mcpapi.WithString("category"),       // kind=findings
+		mcpapi.WithNumber("min_confidence"), // kind=findings
+		mcpapi.WithString("source_repo"),    // kind=findings
+		mcpapi.WithAny("severity"),          // kind=secrets
+		mcpapi.WithArray("repo_filter"),     // kind=auth_coverage
+		mcpapi.WithString("format"),         // kind=auth_coverage
+		mcpapi.WithNumber("limit"),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+		mcpapi.WithAny("ref"),
+	), s.wrap("grafel_security", s.handleAnalysisSecurity))
+
+	// grafel_test_analysis — ANALYSIS canonical test coverage/reach/effectiveness
+	// tool (#5546/#5550).
+	s.addTool(mcpapi.NewTool("grafel_test_analysis",
+		mcpapi.WithDescription("Tests. kind=coverage(def)|reachability|contract_eff|coverage_eff."),
+		mcpapi.WithString("kind", mcpapi.DefaultString("coverage"),
+			mcpapi.Description("coverage=no TESTS edge; reachability=no test path/orphans; contract_effectiveness=tautological specs; coverage_effectiveness=reachable-but-0%-lines.")),
+		mcpapi.WithString("entity_id"),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithAny("severity"),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+		mcpapi.WithAny("ref"),
+	), s.wrap("grafel_test_analysis", s.handleAnalysisTest))
+
+	// grafel_findings — ANALYSIS canonical findings-store tool (#5546/#5550).
+	// action= picks list (read) vs save (persist a Q&A finding).
+	s.addTool(mcpapi.NewTool("grafel_findings",
+		mcpapi.WithDescription("Findings store. action=list(def,enumerate)|save(persist a Q&A finding)."),
+		mcpapi.WithString("action", mcpapi.DefaultString("list"),
+			mcpapi.Description("list=enumerate stored findings; save=persist (requires question + answer).")),
+		mcpapi.WithString("question"), // action=save
+		mcpapi.WithString("answer"),   // action=save
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("grafel_findings", s.handleAnalysisFindings))
+
+	// grafel_diff — ANALYSIS canonical compare tool (#5546/#5550). aspect= picks
+	// WHAT to compare. The return is a DISCRIMINATED UNION keyed by `aspect`:
+	// each aspect returns its handler's native shape (refs=entity/rel deltas;
+	// response_shape/auth/literals=per-endpoint parity verdicts; payload=drift
+	// findings) and the result is stamped with `aspect` so the caller knows which.
+	s.addTool(mcpapi.NewTool("grafel_diff",
+		mcpapi.WithDescription("Compare two refs/versions; aspect picks what to compare (shape varies)."),
+		mcpapi.WithString("aspect", mcpapi.DefaultString("response_shape"),
+			mcpapi.Description("response_shape=per-status field drift; payload=schema/envelope drift; auth=auth-posture parity; literals=enum/ConstantSet parity; refs=entity/rel deltas between two git refs.")),
+		mcpapi.WithString("group_oracle"), // response_shape|auth|literals
+		mcpapi.WithString("group_v3"),     // response_shape|auth|literals
+		mcpapi.WithString("set"),          // aspect=literals
+		mcpapi.WithString("drift_class"),  // aspect=payload
+		mcpapi.WithString("repo"),         // aspect=refs
+		mcpapi.WithString("ref_a"),        // aspect=refs
+		mcpapi.WithString("ref_b"),        // aspect=refs
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("grafel_diff", s.handleAnalysisDiff))
 
 	// grafel_topology — message-channel topology (#1281). action=orphan_publishers|orphan_subscribers|topic_detail.
 	// verbose=true (default false) read from request map to stay under token ceiling.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -624,6 +624,10 @@ func TestToolNameSurface(t *testing.T) {
 		"grafel_control_flow",
 		// #4893 tautological/oracle-blind spec detector (contract_test_effectiveness).
 		"grafel_contract_test_effectiveness",
+		// #5546/#5550 ANALYSIS-cluster canonical tools. grafel_patterns reuses an
+		// existing name (re-pointed to the kind= dispatcher); these five are new.
+		"grafel_debt", "grafel_security", "grafel_test_analysis",
+		"grafel_findings", "grafel_diff",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -730,8 +734,10 @@ func TestToolNameSurface(t *testing.T) {
 	// +1 grafel_related (#5546/#5549 CORE-cluster canonical: callers/callees/
 	//    neighbors/uses/used_by discriminator; the other 7 CORE canonicals reuse
 	//    existing tool names so add no new registrations).
-	if got := len(allRegisteredTools); got != 70 {
-		t.Errorf("expected 70 registered tools, got %d — update this count if tools are added/removed (added grafel_related #5549)", got)
+	// +5 grafel_debt/security/test_analysis/findings/diff (#5546/#5550 ANALYSIS-
+	//    cluster canonicals; grafel_patterns reuses an existing name).
+	if got := len(allRegisteredTools); got != 75 {
+		t.Errorf("expected 75 registered tools, got %d — update this count if tools are added/removed (added analysis cluster #5550)", got)
 	}
 }
 
@@ -3275,6 +3281,14 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"grafel_stub_detector":               {"group_v3": "g", "group_oracle": "g"},
 		"grafel_response_shape_diff":         {"group_oracle": "g", "group_v3": "g"},
 		"grafel_contract_test_effectiveness": {"group": "g"},
+		// #5546/#5550 ANALYSIS-cluster canonical tools. Each routes to an absorbed
+		// handler via its discriminator default; the args mirror that handler's
+		// minimal args so the wrapper + elapsed_ms trailer is exercised.
+		"grafel_debt":          {"group": "g"},                         // kind=dead_code default
+		"grafel_security":      {"group": "g"},                         // kind=findings default
+		"grafel_test_analysis": {"group": "g"},                         // kind=coverage default
+		"grafel_findings":      {"group": "g"},                         // action=list default
+		"grafel_diff":          {"group_oracle": "g", "group_v3": "g"}, // aspect=response_shape default
 	}
 
 	// extractElapsedMS mirrors the bench extraction logic:
@@ -3319,8 +3333,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 70 {
-		t.Errorf("expected 70 registered tools, got %d — update minimalArgs if tools are added/removed (added grafel_related #5549)", len(tools))
+	if len(tools) != 75 {
+		t.Errorf("expected 75 registered tools, got %d — update minimalArgs if tools are added/removed (added grafel_debt/security/test_analysis/findings/diff #5550)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
Second cluster of the 0.1.5 MCP consolidation (epic #5546). Follows the just-merged core-cluster #5549 and reuses its pattern: new intent-named canonical tools route a discriminator over the **existing** handlers (behaviour byte-identical), and the absorbed tools stay registered until #5552 converts them to hidden aliases. Go-only, `internal/mcp`.

New file `internal/mcp/analysis_merges.go` reuses the `reqWithArgs` helper from #5549.

### Routing
| Tool | Discriminator | → handlers |
|---|---|---|
| `grafel_debt` | `kind`=dead_code(def)·cycles·stubs·impure·license (+ `find_dead_code`, `import_cycles` aliases) | handleDeadCode / handleFindDeadCode / handleQualityCycles / handleModuleCyclesSidecar / handleStubDetector / handlePureFunctions / handleLicenseAudit |
| `grafel_security` | `kind`=findings(def)·secrets·auth_coverage | handleSecurityFindings / handleSecrets / handleAuthCoverage |
| `grafel_test_analysis` | `kind`=coverage(def)·reachability·contract_effectiveness·coverage_effectiveness | handleTestCoverage / handleTestReachability / handleContractTestEffectiveness / handleCoverageEffectiveness |
| `grafel_patterns` | `kind`=code(def)·graph·template | handlePatterns / handleGraphPatterns / handleTemplatePatterns |
| `grafel_findings` | `action`=list(def)·save | handleListFindings / handleSaveResult |
| `grafel_diff` | `aspect`=response_shape(def)·payload·auth·literals·refs | handleResponseShapeDiff / handlePayloadDrift / handleAuthPostureDiff / handleLiteralParity / handleDiffRefs |

`grafel_patterns` reuses an existing tool name — its registration is re-pointed to the `kind=` dispatcher; default `kind=code` preserves the agent-pattern-store behaviour byte-for-byte (it still reads its own `action=query|record`), so no count change and back-compat holds.

### grafel_diff discriminated union
The members do **not** share one return shape: `refs` returns entity/relationship deltas; `response_shape`/`auth`/`literals` return per-endpoint parity verdicts; `payload` returns drift findings. Rather than force a common schema, the dispatcher routes to the native handler unchanged and **stamps the chosen `aspect` onto the JSON-object result** (`stampAspect`) so the caller knows which shape it received. Error / non-object / array results pass through unchanged — the dispatch never corrupts an absorbed handler's payload.

**Review flag (per the ticket):** the shapes are divergent but each is self-describing via the stamped `aspect`, and they all share the "compare two refs/versions" intent, so keeping them unified under `grafel_diff` reads well. I did not split `refs` back out. Happy to split if review disagrees.

### Tests
`internal/mcp/analysis_merges_test.go` — per-tool/per-discriminator dispatch tests asserting each value returns the same as the old tool (order-insensitive via the shared `normalizeForCompare`; for `grafel_diff`, compare the stripped-of-`aspect` payload + assert the `aspect` key). Golden guards updated: tool-count 70→75 (two guards in `server_test.go`), `grafel_patterns` param surface + 5 new tool entries in `schema_trim_5386_test.go`, and the `minimalArgs` / `wantPresent` lists.

`go test -count=1 ./internal/mcp/...` green. `go run ./cmd/mcp-audit` green: **75 tools, handshake 7455 tokens (was 6721), ceiling 8000** — +734 tokens for the 5 new tools, well within budget. All descriptions ≤80 chars.

Does NOT touch CHANGELOG.md. Ref #5546. Closes #5550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
