### PR TITLE
feat(mcp): workflow/meta canonical tools — docgen/docgen_apply/event + kept metrics/index_status (#5551)

### DIFF
--- a/internal/mcp/meta_merges.go
+++ b/internal/mcp/meta_merges.go
@@ -1,0 +1,89 @@
+package mcp
+
+import (
+	"context"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// meta_merges.go — WORKFLOW + META-cluster canonical tool dispatchers (epic
+// #5546, #5551).
+//
+// Third of the 0.1.5 MCP-consolidation clusters (CORE lives in core_merges.go
+// #5549, ANALYSIS in analysis_merges.go #5550). Each canonical tool reads a
+// single discriminator argument (action / kind) and dispatches to the EXISTING
+// handler funcs unchanged — behaviour is byte-identical to the absorbed tools.
+// No logic lives here; this is pure routing. The absorbed tools stay registered
+// as standalone tools for back-compat until #5552 converts them to hidden
+// aliases.
+//
+// reqWithArgs (defined in core_merges.go) is reused where a discriminator's
+// value must be rewritten into an inner argument the delegate reads itself.
+
+// handleWorkflowDocgen routes grafel_docgen by action= over the six docgen
+// staging-run lifecycle handlers. Default action=status — the read-only "what's
+// in flight?" case (cheaper and side-effect-free than start).
+//
+//	start    → handleDocgenStartRun (create/resume staging run; needs group)
+//	status   → handleDocgenStatus   (files written + per-file SHA; needs run_id)
+//	list     → handleDocgenList     (enumerate canonical docs; needs group)
+//	promote  → handleDocgenPromote  (atomic staging→canonical; needs run_id)
+//	abort    → handleDocgenAbort    (rm -rf staging, release lock; needs run_id)
+//	validate → handleDocgenValidate (frontmatter+cross-links, read-only)
+func (s *Server) handleWorkflowDocgen(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "action", "status") {
+	case "start", "start_run":
+		return s.handleDocgenStartRun(ctx, req)
+	case "list":
+		return s.handleDocgenList(ctx, req)
+	case "promote":
+		return s.handleDocgenPromote(ctx, req)
+	case "abort":
+		return s.handleDocgenAbort(ctx, req)
+	case "validate":
+		return s.handleDocgenValidate(ctx, req)
+	default: // "status"
+		return s.handleDocgenStatus(ctx, req)
+	}
+}
+
+// handleWorkflowDocgenApply routes grafel_docgen_apply by kind= over the
+// doc-enrichment / repair apply handlers. Default kind=semantics (Layer-2
+// DesignDecision apply step).
+//
+//	semantics (default) → handleApplyDocSemantics (L2 DesignDecision + RATIONALE_FOR)
+//	repairs             → handleApplyDocgenRepairs (docgen→graph repair apply)
+//	                      OR handleRepairs when action= is present (residual
+//	                      repair queue list/submit) — keeps both surfaces reachable.
+//	enrichments         → handleEnrichments (enrichment-candidate queue;
+//	                      reads its own action=list|submit|reject)
+func (s *Server) handleWorkflowDocgenApply(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "kind", "semantics") {
+	case "repairs", "repair":
+		// The residual-repair queue (handleRepairs) is driven by action=list|
+		// submit; the docgen→graph apply step (handleApplyDocgenRepairs) takes
+		// no action. Route on the presence of action so neither is lost.
+		if argString(req, "action", "") != "" {
+			return s.handleRepairs(ctx, req)
+		}
+		return s.handleApplyDocgenRepairs(ctx, req)
+	case "enrichments", "enrichment":
+		return s.handleEnrichments(ctx, req)
+	default: // "semantics"
+		return s.handleApplyDocSemantics(ctx, req)
+	}
+}
+
+// handleMetaEvent routes grafel_event by kind= over the local-only telemetry
+// handlers. Default kind=feedback (agent-experience feedback).
+//
+//	feedback (default) → handleFeedbackEvent (agent-experience; needs outcome)
+//	persona            → handlePersonaEvent  (persona lifecycle; needs persona+event_type)
+func (s *Server) handleMetaEvent(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	switch argString(req, "kind", "feedback") {
+	case "persona":
+		return s.handlePersonaEvent(ctx, req)
+	default: // "feedback"
+		return s.handleFeedbackEvent(ctx, req)
+	}
+}

--- a/internal/mcp/meta_merges_test.go
+++ b/internal/mcp/meta_merges_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"testing"
+)
+
+// meta_merges_test.go — dispatch tests for the WORKFLOW/META-cluster canonical
+// tools (#5546/#5551). Each test asserts that a discriminator value on the new
+// canonical handler produces the same output as the absorbed handler it routes
+// to. Helpers coreTestServer / assertSameDispatch are shared from
+// core_merges_test.go. The docgen members return deterministic errors for
+// unknown run_ids in the test registry; routing is verified by canonical and
+// absorbed handlers producing the identical result for the same args.
+
+// 1. grafel_docgen action= → start/status/list/promote/abort/validate.
+func TestWorkflowDocgenDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	runID := "2026-05-26-testid01"
+	start := map[string]any{"group": "g", "no_git": true}
+	status := map[string]any{"run_id": runID, "no_git": true}
+	validate := map[string]any{"run_id": runID, "no_git": true}
+	promote := map[string]any{"run_id": runID, "group": "g", "no_git": true}
+	abort := map[string]any{"run_id": runID, "group": "g", "no_git": true}
+	list := map[string]any{"group": "g"}
+
+	with := func(base map[string]any, action string) map[string]any {
+		out := map[string]any{"action": action}
+		for k, v := range base {
+			out[k] = v
+		}
+		return out
+	}
+
+	// start mutates persistent staging state (a second identical call resumes
+	// rather than creates), so the double-call assertSameDispatch comparison
+	// doesn't apply. Verify routing directly: action=start must reach
+	// handleDocgenStartRun and return a fresh run (resumed=false, has run_id).
+	startOut := callBare(t, srv.handleWorkflowDocgen, with(start, "start"))
+	if !contains(startOut, `"run_id"`) || !contains(startOut, `"resumed":false`) {
+		t.Errorf("action=start did not route to handleDocgenStartRun: %s", startOut)
+	}
+	assertSameDispatch(t, "action=status", srv.handleWorkflowDocgen, with(status, "status"), srv.handleDocgenStatus, status)
+	// default action=status.
+	assertSameDispatch(t, "action=default", srv.handleWorkflowDocgen, status, srv.handleDocgenStatus, status)
+	assertSameDispatch(t, "action=list", srv.handleWorkflowDocgen, with(list, "list"), srv.handleDocgenList, list)
+	assertSameDispatch(t, "action=promote", srv.handleWorkflowDocgen, with(promote, "promote"), srv.handleDocgenPromote, promote)
+	assertSameDispatch(t, "action=abort", srv.handleWorkflowDocgen, with(abort, "abort"), srv.handleDocgenAbort, abort)
+	assertSameDispatch(t, "action=validate", srv.handleWorkflowDocgen, with(validate, "validate"), srv.handleDocgenValidate, validate)
+}
+
+// 2. grafel_docgen_apply kind= → semantics/repairs(apply|queue)/enrichments.
+func TestWorkflowDocgenApplyDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	g := map[string]any{"group": "g", "dry_run": true}
+
+	// semantics → handleApplyDocSemantics.
+	assertSameDispatch(t, "kind=semantics", srv.handleWorkflowDocgenApply,
+		map[string]any{"group": "g", "dry_run": true, "kind": "semantics"}, srv.handleApplyDocSemantics, g)
+	// default kind=semantics.
+	assertSameDispatch(t, "kind=default", srv.handleWorkflowDocgenApply, g, srv.handleApplyDocSemantics, g)
+	// repairs (no action) → handleApplyDocgenRepairs (docgen→graph apply step).
+	assertSameDispatch(t, "kind=repairs", srv.handleWorkflowDocgenApply,
+		map[string]any{"group": "g", "dry_run": true, "kind": "repairs"}, srv.handleApplyDocgenRepairs, g)
+	// repairs WITH action → handleRepairs (residual-repair queue).
+	queue := map[string]any{"group": "g", "action": "list"}
+	assertSameDispatch(t, "kind=repairs,action=list", srv.handleWorkflowDocgenApply,
+		map[string]any{"group": "g", "kind": "repairs", "action": "list"}, srv.handleRepairs, queue)
+	// enrichments → handleEnrichments (candidate queue; reads its own action=).
+	enr := map[string]any{"group": "g", "action": "list"}
+	assertSameDispatch(t, "kind=enrichments", srv.handleWorkflowDocgenApply,
+		map[string]any{"group": "g", "kind": "enrichments", "action": "list"}, srv.handleEnrichments, enr)
+}
+
+// 3. grafel_event kind= → feedback/persona.
+func TestMetaEventDispatch(t *testing.T) {
+	srv := coreTestServer(t)
+	feedback := map[string]any{"outcome": "helped"}
+	persona := map[string]any{"persona": "architect", "event_type": "invoke"}
+
+	assertSameDispatch(t, "kind=feedback", srv.handleMetaEvent,
+		map[string]any{"outcome": "helped", "kind": "feedback"}, srv.handleFeedbackEvent, feedback)
+	// default kind=feedback.
+	assertSameDispatch(t, "kind=default", srv.handleMetaEvent, feedback, srv.handleFeedbackEvent, feedback)
+	assertSameDispatch(t, "kind=persona", srv.handleMetaEvent,
+		map[string]any{"persona": "architect", "event_type": "invoke", "kind": "persona"}, srv.handlePersonaEvent, persona)
+}
+
+// 4. All three WORKFLOW/META canonical tools plus the two kept-as-is tools are
+// registered (#5546/#5551).
+func TestMetaCanonicalToolsRegistered(t *testing.T) {
+	srv := coreTestServer(t)
+	registered := map[string]bool{}
+	for _, st := range srv.MCP.ListTools() {
+		registered[st.Tool.Name] = true
+	}
+	for _, n := range []string{
+		"grafel_docgen", "grafel_docgen_apply", "grafel_event",
+		// kept-as-is canonical tools the epic confirms remain registered.
+		"grafel_mcp_metrics", "grafel_index_status",
+	} {
+		if !registered[n] {
+			t.Errorf("WORKFLOW/META canonical tool %q not registered", n)
+		}
+	}
+}

--- a/internal/mcp/schema_trim_5386_test.go
+++ b/internal/mcp/schema_trim_5386_test.go
@@ -182,4 +182,8 @@ var wantToolParams = map[string]string{
 	"grafel_test_analysis": "cwd,entity_id,group,kind,limit,ref,repo_filter,severity|req:",
 	"grafel_findings":      "action,answer,cwd,group,question|req:",
 	"grafel_diff":          "aspect,cwd,drift_class,group,group_oracle,group_v3,ref_a,ref_b,repo,set|req:",
+	// #5546/#5551 WORKFLOW/META-cluster canonical tools.
+	"grafel_docgen":       "action,cwd,force,group,no_git,resume,run_id|req:",
+	"grafel_docgen_apply": "action,candidate_id,confidence,cwd,dry_run,group,kind,limit,reason,repo_filter,value|req:",
+	"grafel_event":        "capability,chain,depth,event_type,group,kind,library,metadata,note,outcome,persona,phase,target_persona|req:",
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1454,6 +1454,38 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("grafel_docgen_list", s.handleDocgenList))
 
+	// grafel_docgen — WORKFLOW canonical docgen-lifecycle tool (#5546/#5551).
+	// action= routes over the six docgen staging handlers; default status.
+	s.addTool(mcpapi.NewTool("grafel_docgen",
+		mcpapi.WithDescription("Docgen run lifecycle. action=start|status|list|promote|abort|validate."),
+		mcpapi.WithString("action", mcpapi.DefaultString("status"),
+			mcpapi.Description("start=open run(group); status=files+SHAs(run_id); list=canonical docs(group); promote/abort=run_id; validate=lint(run_id).")),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("run_id"),
+		mcpapi.WithBoolean("resume", mcpapi.DefaultBool(true)),
+		mcpapi.WithBoolean("no_git", mcpapi.DefaultBool(false)),
+		mcpapi.WithBoolean("force", mcpapi.DefaultBool(false)),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("grafel_docgen", s.handleWorkflowDocgen))
+
+	// grafel_docgen_apply — WORKFLOW canonical doc-enrichment/repair apply tool
+	// (#5546/#5551). kind= routes over the apply/queue handlers; default semantics.
+	s.addTool(mcpapi.NewTool("grafel_docgen_apply",
+		mcpapi.WithDescription("Apply doc enrichments/repairs. kind=semantics|repairs|enrichments."),
+		mcpapi.WithString("kind", mcpapi.DefaultString("semantics"),
+			mcpapi.Description("semantics=L2 DesignDecision apply; repairs=docgen→graph apply (or residual queue w/ action); enrichments=candidate queue (action=list|submit|reject).")),
+		mcpapi.WithString("action"),
+		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithBoolean("dry_run"),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(10)),
+		mcpapi.WithAny("candidate_id"),
+		mcpapi.WithAny("value"),
+		mcpapi.WithNumber("confidence", mcpapi.DefaultNumber(1)),
+		mcpapi.WithAny("reason"),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("grafel_docgen_apply", s.handleWorkflowDocgenApply))
+
 	// grafel_navigates — NAVIGATES_TO edge query tool (#2658).
 	// Phase 2 of #2655: filter NAVIGATES_TO edges by route, param, direction.
 	// mode=flow enables multi-hop BFS following navigation chains.
@@ -1499,6 +1531,26 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("capability"),
 		mcpapi.WithAny("note"),
 	), s.wrap("grafel_feedback_event", s.handleFeedbackEvent))
+
+	// grafel_event — META canonical telemetry tool (#5546/#5551). kind= routes
+	// over the local-only event handlers; default feedback. LOCAL ONLY.
+	s.addTool(mcpapi.NewTool("grafel_event",
+		mcpapi.WithDescription("Emit local telemetry. kind=feedback|persona (def feedback). LOCAL ONLY."),
+		mcpapi.WithString("kind", mcpapi.DefaultString("feedback"),
+			mcpapi.Description("feedback=agent-experience(outcome req); persona=lifecycle(persona+event_type req).")),
+		mcpapi.WithAny("outcome"),
+		mcpapi.WithAny("phase"),
+		mcpapi.WithAny("library"),
+		mcpapi.WithAny("capability"),
+		mcpapi.WithAny("note"),
+		mcpapi.WithAny("persona"),
+		mcpapi.WithAny("event_type"),
+		mcpapi.WithAny("target_persona"),
+		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(0)),
+		mcpapi.WithArray("chain"),
+		mcpapi.WithAny("metadata"),
+		mcpapi.WithAny("group"),
+	), s.wrap("grafel_event", s.handleMetaEvent))
 
 	// grafel_mcp_metrics — per-tool session metrics + daily rollup (#2192).
 	// Returns in-memory per-tool counters (calls, errors, p50/p95 ms) for the

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -628,6 +628,10 @@ func TestToolNameSurface(t *testing.T) {
 		// existing name (re-pointed to the kind= dispatcher); these five are new.
 		"grafel_debt", "grafel_security", "grafel_test_analysis",
 		"grafel_findings", "grafel_diff",
+		// #5546/#5551 WORKFLOW/META-cluster canonical tools. grafel_mcp_metrics
+		// and grafel_index_status are kept-as-is (already registered above);
+		// these three are new.
+		"grafel_docgen", "grafel_docgen_apply", "grafel_event",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -736,8 +740,10 @@ func TestToolNameSurface(t *testing.T) {
 	//    existing tool names so add no new registrations).
 	// +5 grafel_debt/security/test_analysis/findings/diff (#5546/#5550 ANALYSIS-
 	//    cluster canonicals; grafel_patterns reuses an existing name).
-	if got := len(allRegisteredTools); got != 75 {
-		t.Errorf("expected 75 registered tools, got %d — update this count if tools are added/removed (added analysis cluster #5550)", got)
+	// +3 grafel_docgen/docgen_apply/event (#5546/#5551 WORKFLOW/META-cluster
+	//    canonicals; grafel_mcp_metrics + grafel_index_status are kept-as-is).
+	if got := len(allRegisteredTools); got != 78 {
+		t.Errorf("expected 78 registered tools, got %d — update this count if tools are added/removed (added workflow/meta cluster #5551)", got)
 	}
 }
 
@@ -3289,6 +3295,10 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"grafel_test_analysis": {"group": "g"},                         // kind=coverage default
 		"grafel_findings":      {"group": "g"},                         // action=list default
 		"grafel_diff":          {"group_oracle": "g", "group_v3": "g"}, // aspect=response_shape default
+		// #5546/#5551 WORKFLOW/META-cluster canonical tools.
+		"grafel_docgen":       {"action": "list", "group": "g"},                     // action=status default needs run_id; list needs only group
+		"grafel_docgen_apply": {"kind": "semantics", "group": "g", "dry_run": true}, // kind=semantics default
+		"grafel_event":        {"outcome": "helped"},                                // kind=feedback default
 	}
 
 	// extractElapsedMS mirrors the bench extraction logic:
@@ -3333,8 +3343,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 75 {
-		t.Errorf("expected 75 registered tools, got %d — update minimalArgs if tools are added/removed (added grafel_debt/security/test_analysis/findings/diff #5550)", len(tools))
+	if len(tools) != 78 {
+		t.Errorf("expected 78 registered tools, got %d — update minimalArgs if tools are added/removed (added grafel_docgen/docgen_apply/event #5551)", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
Closes #5551 (part of epic #5546 — consolidate ~68 MCP tools → 22 canonical intent-named tools).

Third consolidation cluster after CORE (#5549) and ANALYSIS (#5550). Same pattern: new canonical tools route a discriminator over the EXISTING handlers (byte-identical behaviour). Absorbed tools stay registered for back-compat until #5552 converts them to hidden aliases.

## New canonical tools (3)
| Tool | Discriminator | Routes to |
|---|---|---|
| `grafel_docgen` | `action`=start·status(default)·list·promote·abort·validate | handleDocgenStartRun / Status / List / Promote / Abort / Validate |
| `grafel_docgen_apply` | `kind`=semantics(default)·repairs·enrichments | handleApplyDocSemantics / handleApplyDocgenRepairs (or handleRepairs residual queue when `action=` present) / handleEnrichments |
| `grafel_event` | `kind`=feedback(default)·persona | handleFeedbackEvent / handlePersonaEvent (LOCAL ONLY) |

`grafel_docgen_apply` keeps all four absorbed handlers reachable: `repairs` routes to the docgen→graph apply step by default, or to the residual-repair queue when an `action=list|submit` is supplied.

## Kept-as-is canonical tools (confirmed)
`grafel_mcp_metrics` and `grafel_index_status` are already registered on `main` over real handlers (`handleMCPMetrics`, `handleIndexStatus`) with tight descriptions — `index_status` is NOT a thin/new registration, it's the existing per-repo freshness handler the live daemon already serves. No change needed beyond confirming.

## Tests
- `meta_merges.go` / `meta_merges_test.go` — per-discriminator dispatch tests asserting canonical output == absorbed-handler output (the stateful `start` action is verified by direct routing assertion).
- Golden guards: registered-tool count 75→78, `wantPresent` + `minimalArgs` + `wantToolParams` (+3).
- `go test -count=1 ./internal/mcp/...` green.
- `go run ./cmd/mcp-audit`: **78 tools, handshake 7881 tokens** (ceiling 8000), all descriptions ≤80 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)