### PR TITLE
feat(idris): bootstrap records — ipkg manifest (#5382)

### DIFF
--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 32 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1 · **zig**: 1
+**Total**: 33 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **idris**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1 · **zig**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -21,6 +21,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [F#](../by-language/fsharp.md) | [Paket (.NET/F# package manager)](../detail/lang.fsharp.tool.paket.md) | — | ✅ | ✅ | |
 | [go](../by-language/go.md) | [go.mod](../detail/pkg.go-mod.md) | — | ✅ | ✅ | |
 | [haskell](../by-language/haskell.md) | [Cabal / Stack / hpack (Haskell build)](../detail/lang.haskell.tool.cabal.md) | — | — | ✅ | |
+| [idris](../by-language/idris.md) | [ipkg (Idris package manifest)](../detail/lang.idris.tool.ipkg.md) | — | — | ✅ | |
 | [java](../by-language/java.md) | [build.gradle / build.gradle.kts](../detail/pkg.gradle.md) | — | 🔴 | 🟢 | |
 | [java](../by-language/java.md) | [pom.xml](../detail/pkg.pom.md) | — | — | ✅ | |
 | [JS/TS](../by-language/jsts.md) | [npm / yarn / pnpm (package.json + lockfile)](../detail/lang.jsts.tool.npm-manifest.md) | ✅ | ✅ | ✅ | |

--- a/docs/coverage/by-language/idris.md
+++ b/docs/coverage/by-language/idris.md
@@ -1,12 +1,26 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Idris
+# idris
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 1 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/idris/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.idris.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [ipkg (Idris package manifest)](../detail/lang.idris.tool.ipkg.md) | — | — | — | ✅ | — | |

--- a/docs/coverage/detail/lang.idris.tool.ipkg.md
+++ b/docs/coverage/detail/lang.idris.tool.ipkg.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.idris.tool.ipkg` — ipkg (Idris package manifest)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [idris](../by-language/idris.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Lockfile parsing | — `not_applicable` | `2026-06-24` | 5382 | `internal/extractors/cross/manifest/ipkg.go` | ipkg has no lockfile format — the resolved dependency set is pinned by the package collection / pack (pack.toml), which is not a per-package manifest. depends names are bare (no version-constraint syntax), so there is nothing to lock at the manifest level. |
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5382 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/ipkg.go`<br>`internal/extractors/cross/manifest/ipkg_test.go` | parseIpkg mines the *.ipkg `depends` field (and the `pkgs` synonym) — a comma/newline-separated list of bare package names (the canonical multi-line layout starts continuation lines with a leading comma; -- line comments stripped). Idris's ipkg depends has NO version-constraint syntax, so every dep version is empty (honest). The Idris stdlib floor (base/prelude/contrib/network/…) is KEPT as a real edge, mirroring the nimble nim / luarocks lua / cabal base interpreter-floor treatment (#5365/#5367/#5373). Manifest metadata (package header, modules list, main, executable, sourcedir, version) is surfaced on the project anchor as a compact deterministic `ipkg_config` property — no new entity kind, the same model as the Zig build_targets / ReScript rescript_config props (#5377/#5378). Suffix-dispatched in IsManifest/detectPackageManager/dispatchParser to package_manager=idris2; emits DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes like every other ecosystem. Proven by TestIpkg_Dependencies / _DependsOnEdges / _ConfigAnchor / _PkgsSynonym / _IsManifest / _NoDependencies. Honest scope: only the declared manifest dependency/metadata surface is recovered. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.idris.tool.ipkg ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (34 active · 5 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 156 · **Other**: 210
+**Languages**: 39 (35 active · 4 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 157 · **Other**: 210
 
 ## Coverage by language
 
@@ -35,6 +35,7 @@
 | [ReScript](by-language/rescript.md) | 1 | 1 | 0 | 0 |
 | [assembly](by-language/assembly.md) | 0 | 0 | 0 | 5 |
 | [COBOL](by-language/cobol.md) | 0 | 0 | 0 | 5 |
+| [idris](by-language/idris.md) | 0 | 1 | 0 | 0 |
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
 | [JCL](by-language/jcl.md) | 0 | 0 | 0 | 1 |
 | [solidity](by-language/solidity.md) | 0 | 2 | 0 | 2 |
@@ -78,9 +79,8 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | Language |
 |---|
 | [Bicep](by-language/bicep.md) |
-| [Idris](by-language/idris.md) |
 | [Lisp](by-language/lisp.md) |
 | [Pony](by-language/pony.md) |
 | [Standard ML](by-language/sml.md) |
 
-Total: 263 frameworks · 156 tools · 186 ORMs · 210 other
+Total: 263 frameworks · 157 tools · 186 ORMs · 210 other

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -29,6 +29,7 @@
 //   - *.nimble             (nimble — Nim manifest_parsing, requires directives)
 //   - paket.dependencies   (paket — .NET/F# manifest_parsing, nuget directives)
 //   - paket.lock           (paket — .NET/F# lockfile_parsing, resolved NUGET tree)
+//   - *.ipkg               (idris2 — Idris manifest_parsing, depends/modules)
 //
 // Entity kind: "SCOPE.Component"
 // Relationships emitted: DEPENDS_ON(kind=external_dependency)
@@ -255,6 +256,11 @@ func IsManifest(filePath string) bool {
 	if strings.HasSuffix(basename, ".opam") {
 		return true
 	}
+	// *.ipkg — Idris (Idris2) package manifest (the package name is the file's
+	// base name, e.g. myproject.ipkg, so it is matched by extension; #5382).
+	if strings.HasSuffix(basename, ".ipkg") {
+		return true
+	}
 	return false
 }
 
@@ -347,6 +353,10 @@ func detectPackageManager(filePath string) string {
 	// *.opam → opam (OCaml package manifest)
 	if strings.HasSuffix(basename, ".opam") {
 		return "opam"
+	}
+	// *.ipkg → idris2 (Idris package manifest)
+	if strings.HasSuffix(basename, ".ipkg") {
+		return "idris2"
 	}
 	return "unknown"
 }
@@ -2018,6 +2028,10 @@ func dispatchParser(filePath, source string) (string, []dep) {
 	if strings.HasSuffix(basename, ".opam") {
 		return "opam", parseOpam(source)
 	}
+	// *.ipkg — Idris (Idris2) package manifest.
+	if strings.HasSuffix(basename, ".ipkg") {
+		return "idris2", parseIpkg(source)
+	}
 	// Makefile — only an erlang.mk build when it includes erlang.mk / declares
 	// PROJECT (requireSignal=true); a plain Makefile is a no-op.
 	if basename == "Makefile" {
@@ -2263,6 +2277,19 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 				anchorProps = map[string]string{}
 			}
 			anchorProps["rescript_config"] = cfg
+		}
+	}
+
+	// Idris *.ipkg — surface the declared package/modules/main/executable/
+	// sourcedir metadata on the project anchor as an "ipkg_config" property so
+	// the package configuration is queryable without a new entity kind (#5382).
+	// Empty for every other manifest.
+	if strings.HasSuffix(filepath.Base(file.Path), ".ipkg") {
+		if cfg := ipkgConfigProperty(string(file.Content)); cfg != "" {
+			if anchorProps == nil {
+				anchorProps = map[string]string{}
+			}
+			anchorProps["ipkg_config"] = cfg
 		}
 	}
 

--- a/internal/extractors/cross/manifest/ipkg.go
+++ b/internal/extractors/cross/manifest/ipkg.go
@@ -1,0 +1,203 @@
+// ipkg.go — Idris (Idris2) *.ipkg package manifest parser (#5382, epic #5360).
+//
+// An Idris package is described by a `*.ipkg` manifest. It is a small, line- and
+// field-oriented format (one `key = value` per logical field, values may span
+// lines via a trailing operator/comma):
+//
+//	package myproject
+//
+//	authors = "Jane Doe"
+//	version = 0.1.0
+//	sourcedir = "src"
+//
+//	depends = base
+//	        , contrib
+//	        , network
+//
+//	modules = Data.Foo
+//	        , Data.Bar
+//	        , Main
+//
+//	main = Main
+//	executable = myproject
+//
+// Dependency surface — `depends`:
+//
+//	The `depends` field is a comma-separated list of bare package names (Idris's
+//	ipkg `depends` has NO version-constraint syntax — a dep is just a package
+//	name resolved by the package collection / `pack`). Each name becomes a
+//	DEPENDS_ON / DEPENDS_ON_PACKAGE edge with an EMPTY version (honest: there is
+//	no version literal to record). The Idris stdlib floor packages (`base`,
+//	`prelude`, `contrib`, `network`, `linear`, …) are KEPT as real edges,
+//	mirroring the nimble `nim` / luarocks `lua` / cabal `base` interpreter-floor
+//	treatment (#5365/#5367/#5373). Some build setups also use a `pkgs` field as a
+//	synonym for the dependency list; it is parsed identically.
+//
+// Manifest metadata — surfaced on the project anchor (no new entity kind, the
+// same model as the Zig `build_targets` / ReScript `rescript_config` props):
+//
+//	package    — the declared package name
+//	modules    — the comma-separated module list (Data.Foo, Data.Bar, Main)
+//	main       — the program entry module
+//	executable — the produced executable name
+//	sourcedir  — the source root directory
+//
+// These are joined into a compact, deterministic `ipkg_config` property so the
+// package/modules/executable/sourcedir configuration is queryable without
+// introducing a new entity kind.
+//
+// Honest scope: only the declared manifest surface is recovered. `depends`
+// versions are always empty (ipkg has no constraint syntax); there is no ipkg
+// lockfile format (the package collection / `pack.toml` pins the resolved set,
+// which is not a per-package manifest), so lockfile_parsing is not_applicable.
+package manifest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ipkgFieldRE matches an `ipkg` field key at the start of a logical line, e.g.
+// `depends`, `modules`, `package`, `executable`. Group 1 is the field key. The
+// `package`/`module` declaration headers (`package foo`, no `=`) are handled
+// separately because they have no `=` separator.
+var ipkgFieldRE = regexp.MustCompile(`(?mi)^[ \t]*([A-Za-z_][A-Za-z0-9_-]*)[ \t]*=`)
+
+// ipkgPackageHeaderRE matches the `package <name>` declaration header (the one
+// field written without an `=`). Group 1 is the package name.
+var ipkgPackageHeaderRE = regexp.MustCompile(`(?mi)^[ \t]*package[ \t]+([A-Za-z0-9_.-]+)[ \t]*$`)
+
+// ipkgNameTokenRE validates/extracts a single dependency or module token: an
+// Idris identifier path (letters, digits, `_`, `-` and `.` for module names).
+var ipkgNameTokenRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_.-]*$`)
+
+// parseIpkg parses an Idris `*.ipkg` manifest and returns its declared
+// dependencies (the `depends`/`pkgs` field). Dependency versions are always
+// empty (ipkg has no version-constraint syntax). First declaration of a name
+// wins on duplicates.
+func parseIpkg(source string) []dep {
+	var out []dep
+	seen := map[string]bool{}
+
+	for _, field := range []string{"depends", "pkgs"} {
+		body := ipkgFieldValue(source, field)
+		if body == "" {
+			continue
+		}
+		for _, name := range splitIpkgList(body) {
+			if name == "" || seen[name] || !ipkgNameTokenRE.MatchString(name) {
+				continue
+			}
+			seen[name] = true
+			out = append(out, dep{name: name, version: "", kind: "runtime"})
+		}
+	}
+	return out
+}
+
+// ipkgFieldValue returns the raw value body of the named `key = value` field,
+// gathering field continuations. An ipkg field value continues onto subsequent
+// lines while those lines are indented MORE than the field key (the standard
+// ipkg layout for multi-line `depends`/`modules` lists, whose continuation lines
+// start with a leading `,`). Returns "" when the field is absent.
+func ipkgFieldValue(source, key string) string {
+	lines := strings.Split(source, "\n")
+	keyRE := regexp.MustCompile(`(?i)^[ \t]*` + regexp.QuoteMeta(key) + `[ \t]*=`)
+	for i := 0; i < len(lines); i++ {
+		if !keyRE.MatchString(lines[i]) {
+			continue
+		}
+		fieldIndent := indentWidth(lines[i])
+		body := lines[i][strings.IndexByte(lines[i], '=')+1:]
+		for j := i + 1; j < len(lines); j++ {
+			cont := lines[j]
+			if strings.TrimSpace(cont) == "" {
+				break
+			}
+			// A continuation line is more-indented than the field key, OR begins
+			// with a leading comma (the canonical multi-line-list layout).
+			if indentWidth(cont) > fieldIndent || strings.HasPrefix(strings.TrimSpace(cont), ",") {
+				body += "\n" + cont
+				continue
+			}
+			break
+		}
+		return body
+	}
+	return ""
+}
+
+// splitIpkgList splits a comma/newline-separated ipkg field body into trimmed,
+// unquoted tokens, dropping `--`/`---` line comments.
+func splitIpkgList(body string) []string {
+	// Strip `-- ...` line comments from each line first.
+	var cleaned strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		if idx := strings.Index(line, "--"); idx >= 0 {
+			line = line[:idx]
+		}
+		cleaned.WriteString(line)
+		cleaned.WriteByte('\n')
+	}
+	fields := strings.FieldsFunc(cleaned.String(), func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r'
+	})
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		f = strings.Trim(f, `"'`)
+		f = strings.TrimSpace(f)
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ipkgConfigProperty returns a compact, deterministic summary of an `*.ipkg`
+// manifest's metadata fields (package/modules/main/executable/sourcedir),
+// surfaced on the project anchor as the "ipkg_config" property, or "" when the
+// source declares none of them. Mirrors the Zig build_targets / ReScript
+// rescript_config anchor-property model — no new entity kind.
+func ipkgConfigProperty(source string) string {
+	var parts []string
+
+	if m := ipkgPackageHeaderRE.FindStringSubmatch(source); m != nil {
+		parts = append(parts, "package="+strings.TrimSpace(m[1]))
+	}
+	// scalar single-value fields
+	for _, key := range []string{"main", "executable", "sourcedir", "version"} {
+		if v := ipkgScalarField(source, key); v != "" {
+			parts = append(parts, key+"="+v)
+		}
+	}
+	// module list (comma-joined)
+	if body := ipkgFieldValue(source, "modules"); body != "" {
+		var mods []string
+		for _, mod := range splitIpkgList(body) {
+			if ipkgNameTokenRE.MatchString(mod) {
+				mods = append(mods, mod)
+			}
+		}
+		if len(mods) > 0 {
+			parts = append(parts, "modules="+strings.Join(mods, " "))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// ipkgScalarField returns the trimmed, unquoted single-line value of a scalar
+// `key = value` field (main/executable/sourcedir/version), or "".
+func ipkgScalarField(source, key string) string {
+	body := ipkgFieldValue(source, key)
+	if body == "" {
+		return ""
+	}
+	// Scalar value: first non-empty token only (strip a trailing comment).
+	if idx := strings.Index(body, "--"); idx >= 0 {
+		body = body[:idx]
+	}
+	body = strings.TrimSpace(body)
+	body = strings.Trim(body, `"'`)
+	return strings.TrimSpace(body)
+}

--- a/internal/extractors/cross/manifest/ipkg_test.go
+++ b/internal/extractors/cross/manifest/ipkg_test.go
@@ -1,0 +1,128 @@
+package manifest
+
+import "testing"
+
+// realIpkg is a representative Idris (Idris2) *.ipkg manifest. It exercises the
+// `package` header, a multi-line comma-leading `depends` list (including the
+// `base`/`contrib` stdlib floor), a multi-line `modules` list, and the
+// main/executable/sourcedir scalar metadata fields.
+const realIpkg = `package myproject
+
+authors = "Jane Doe"
+version = 0.1.0
+sourcedir = "src"
+
+depends = base
+        , contrib
+        , network
+
+modules = Data.Foo
+        , Data.Bar
+        , Main
+
+main = Main
+executable = myproject
+`
+
+func TestIpkg_Dependencies(t *testing.T) {
+	deps := depEntities(runExtract(t, "myproject.ipkg", realIpkg))
+	// base, contrib, network = 3 runtime deps.
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 deps, got %d: %+v", len(deps), depNames(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "idris2" {
+			t.Errorf("%s: package_manager=%q want idris2", d.Name, d.Properties["package_manager"])
+		}
+		if d.Properties["is_dev"] != "false" {
+			t.Errorf("%s: is_dev=%q want false", d.Name, d.Properties["is_dev"])
+		}
+		// ipkg depends has no version-constraint syntax → always empty (honest).
+		if d.Properties["version"] != "" {
+			t.Errorf("%s: version=%q want empty (ipkg has no constraint syntax)", d.Name, d.Properties["version"])
+		}
+	}
+	// The stdlib floor (base/contrib) is kept as a real edge.
+	if depByName(deps, "base") == nil {
+		t.Error("expected stdlib-floor dep 'base' (kept as a real edge)")
+	}
+	if depByName(deps, "contrib") == nil {
+		t.Error("expected dep 'contrib' from multi-line depends list")
+	}
+	if depByName(deps, "network") == nil {
+		t.Error("expected dep 'network' from multi-line depends list")
+	}
+}
+
+func TestIpkg_DependsOnEdges(t *testing.T) {
+	rels := dependsOnRels(runExtract(t, "lib.ipkg",
+		`package lib
+depends = base, prelude
+`))
+	if len(rels) != 2 {
+		t.Fatalf("expected 2 DEPENDS_ON edges, got %d", len(rels))
+	}
+	for _, r := range rels {
+		if r.Properties["package_manager"] != "idris2" {
+			t.Errorf("edge package_manager=%q want idris2", r.Properties["package_manager"])
+		}
+	}
+}
+
+func TestIpkg_ConfigAnchor(t *testing.T) {
+	records := runExtract(t, "myproject.ipkg", realIpkg)
+	anchor := anchorRecord(records)
+	if anchor == nil {
+		t.Fatal("no project anchor emitted for myproject.ipkg")
+	}
+	cfg := anchor.Properties["ipkg_config"]
+	if cfg == "" {
+		t.Fatal("ipkg_config property is empty")
+	}
+	for _, want := range []string{
+		"package=myproject",
+		"main=Main",
+		"executable=myproject",
+		"sourcedir=src",
+		"modules=Data.Foo Data.Bar Main",
+	} {
+		if !containsSub(cfg, want) {
+			t.Errorf("ipkg_config=%q missing %q", cfg, want)
+		}
+	}
+}
+
+func TestIpkg_PkgsSynonym(t *testing.T) {
+	// Some build setups use `pkgs` as a synonym for the dependency list.
+	deps := depEntities(runExtract(t, "alt.ipkg",
+		`package alt
+pkgs = base, sop
+`))
+	if len(deps) != 2 {
+		t.Fatalf("expected 2 deps from pkgs field, got %d: %+v", len(deps), depNames(deps))
+	}
+	if depByName(deps, "sop") == nil {
+		t.Error("expected dep 'sop' from pkgs field")
+	}
+}
+
+func TestIpkg_IsManifest(t *testing.T) {
+	if !IsManifest("foo/myproject.ipkg") {
+		t.Error("IsManifest should recognise *.ipkg")
+	}
+	if detectPackageManager("myproject.ipkg") != "idris2" {
+		t.Errorf("detectPackageManager(*.ipkg)=%q want idris2", detectPackageManager("myproject.ipkg"))
+	}
+}
+
+func TestIpkg_NoDependencies(t *testing.T) {
+	deps := depEntities(runExtract(t, "empty.ipkg",
+		`package empty
+version = 0.1.0
+modules = Main
+main = Main
+`))
+	if len(deps) != 0 {
+		t.Errorf("expected 0 deps, got %d: %+v", len(deps), depNames(deps))
+	}
+}


### PR DESCRIPTION
Implements #5382 (epic #5360, milestone 0.1.5, group A bootstrap/defer set): the one concrete, broadly-applicable Idris record — the `*.ipkg` package manifest.

## What
- **New `internal/extractors/cross/manifest/ipkg.go`** — `parseIpkg` mines the `depends` field (and the `pkgs` synonym): a comma/newline-separated list of bare package names. The canonical multi-line layout (continuation lines starting with a leading comma) and `--` line comments are handled. Idris ipkg `depends` has **no version-constraint syntax**, so dep versions are empty (honest). The Idris stdlib floor (`base`/`prelude`/`contrib`/`network`/…) is **kept as a real edge**, mirroring the nimble `nim` / luarocks `lua` / cabal `base` interpreter-floor treatment (#5365/#5367/#5373).
- **Manifest metadata on the project anchor** — `package`/`modules`/`main`/`executable`/`sourcedir`/`version` are surfaced as a compact deterministic `ipkg_config` property. No new entity kind — the same model as the Zig `build_targets` / ReScript `rescript_config` anchor props (#5377/#5378).
- **Wiring** — `.ipkg` suffix added to `IsManifest` / `detectPackageManager` / `dispatchParser` → `package_manager=idris2`; emits `DEPENDS_ON` + `DEPENDS_ON_PACKAGE` + SBOM package nodes like every other ecosystem. No classifier entry needed (the `_cross_manifest` pass runs over all files, same as cabal/opam).

## Per-capability (honest)
| Capability | Status |
|---|---|
| `manifest_parsing` | **full** — depends/pkgs deps + package/modules/main/executable/sourcedir metadata |
| `lockfile_parsing` | **not_applicable** — no ipkg lockfile format (the package collection / `pack` pins the resolved set, not a per-package manifest; bare deps have nothing to lock) |

## Fixtures / tests
`ipkg_test.go` runs the parser over realistic `*.ipkg` content:
- `TestIpkg_Dependencies` — multi-line `depends` list, stdlib floor kept, empty versions, `package_manager=idris2`
- `TestIpkg_DependsOnEdges` — DEPENDS_ON edge shape
- `TestIpkg_ConfigAnchor` — `ipkg_config` carries package/main/executable/sourcedir/modules
- `TestIpkg_PkgsSynonym` — `pkgs` field parsed identically
- `TestIpkg_IsManifest` — suffix dispatch
- `TestIpkg_NoDependencies` — metadata-only manifest yields zero deps

`go test ./internal/extractors/cross/manifest/ ./tools/coverage/` green.

## Coverage
New `package_manager` record `lang.idris.tool.ipkg` added via the coverage CLI; registry + `docs/coverage/*` regenerated in this PR. `coverage validate` + `coverage fmt --check` green.

Refs #5360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)