### PR TITLE
feat(mcp): hide absorbed tools — 22 advertised, old names callable aliases (#5552)

### DIFF
--- a/cmd/mcp-audit/main.go
+++ b/cmd/mcp-audit/main.go
@@ -145,10 +145,16 @@ func collectTools() []mcpapi.Tool {
 
 // toolsFromServer extracts the tool list from an mcp-go MCPServer via
 // the public ListTools accessor (mcp-go ≥ 0.52).
+// Hidden aliases (#5546/#5552) are registered/callable but excluded from the
+// tools/list handshake, so they must NOT count against the handshake budget —
+// the audit measures the *advertised* surface (the real per-connect cost).
 func toolsFromServer(s *mcpsrv.MCPServer) []mcpapi.Tool {
 	byName := s.ListTools()
 	out := make([]mcpapi.Tool, 0, len(byName))
-	for _, st := range byName {
+	for name, st := range byName {
+		if mcp.IsHiddenAlias(name) {
+			continue
+		}
 		out = append(out, st.Tool)
 	}
 	return out

--- a/internal/mcp/budget_test.go
+++ b/internal/mcp/budget_test.go
@@ -58,7 +58,15 @@ func TestMCPHandshakeBudget(t *testing.T) {
 	totalChars := envelopeBytes
 	var descViolations []string
 
+	advertised := 0
 	for name, st := range byName {
+		// Hidden aliases (#5546/#5552) are callable but excluded from the
+		// handshake, so they do not count against the budget. Measure the
+		// advertised surface only.
+		if mcp.IsHiddenAlias(name) {
+			continue
+		}
+		advertised++
 		b, err := json.Marshal(st.Tool)
 		if err != nil {
 			t.Fatalf("marshal tool %s: %v", name, err)
@@ -73,8 +81,8 @@ func TestMCPHandshakeBudget(t *testing.T) {
 
 	handshakeTokens := int(math.Ceil(float64(totalChars) / charsPerToken))
 
-	t.Logf("tools=%d  chars=%d  tokens=%d  ceiling=%d",
-		len(byName), totalChars, handshakeTokens, tokenCeiling)
+	t.Logf("advertised=%d (of %d registered)  chars=%d  tokens=%d  ceiling=%d",
+		advertised, len(byName), totalChars, handshakeTokens, tokenCeiling)
 
 	for _, v := range descViolations {
 		t.Errorf("description too long: %s", v)

--- a/internal/mcp/hidden_aliases_5552_test.go
+++ b/internal/mcp/hidden_aliases_5552_test.go
@@ -1,0 +1,160 @@
+package mcp
+
+// hidden_aliases_5552_test.go — guards for the #5546/#5552 consolidation:
+// the handshake advertises exactly the 22 canonical tools, while the ~56
+// absorbed legacy names stay REGISTERED and dispatchable for one release
+// (code-only back-compat aliases hidden from tools/list).
+
+import (
+	"context"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestAdvertisedHandshakeIs22 — fullToolList() (the per-connect tools/list
+// payload) advertises exactly the 22 canonical tools and zero hidden aliases.
+func TestAdvertisedHandshakeIs22(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"mygroup": {"myrepo": repoDir},
+	})
+
+	entries, err := srv.ListToolsForCWD(repoDir)
+	if err != nil {
+		t.Fatalf("ListToolsForCWD: %v", err)
+	}
+
+	got := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		got[e.Name] = true
+	}
+
+	if len(entries) != len(canonicalToolNames) {
+		t.Errorf("advertised %d tools, want %d (the canonical set): got %v",
+			len(entries), len(canonicalToolNames), toolNames(entries))
+	}
+
+	// Every advertised name must be canonical; no alias may leak.
+	for _, e := range entries {
+		if !canonicalToolNames[e.Name] {
+			t.Errorf("advertised non-canonical tool %q", e.Name)
+		}
+		if aliasToolNames[e.Name] {
+			t.Errorf("hidden alias %q leaked into the handshake", e.Name)
+		}
+	}
+	// Every canonical name must be advertised.
+	for name := range canonicalToolNames {
+		if !got[name] {
+			t.Errorf("canonical tool %q missing from the advertised handshake", name)
+		}
+	}
+}
+
+// TestAdvertisedCount22 — explicit count guard (22 advertised).
+func TestAdvertisedCount22(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"mygroup": {"myrepo": repoDir},
+	})
+	entries, err := srv.ListToolsForCWD(repoDir)
+	if err != nil {
+		t.Fatalf("ListToolsForCWD: %v", err)
+	}
+	if len(entries) != 22 {
+		t.Errorf("expected 22 advertised tools, got %d — update this guard only if the canonical set changes (#5546)", len(entries))
+	}
+}
+
+// TestHiddenAliasStillDispatchable — a hidden alias (grafel_find_callers) is
+// excluded from the handshake yet stays REGISTERED and callable directly, so
+// un-redeployed consumers keep working for one release (back-compat).
+func TestHiddenAliasStillDispatchable(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"mygroup": {"myrepo": repoDir},
+	})
+
+	const alias = "grafel_find_callers"
+	if !aliasToolNames[alias] {
+		t.Fatalf("%q expected to be a hidden alias", alias)
+	}
+
+	// Hidden from the advertised list.
+	entries, err := srv.ListToolsForCWD(repoDir)
+	if err != nil {
+		t.Fatalf("ListToolsForCWD: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name == alias {
+			t.Fatalf("hidden alias %q must not be advertised", alias)
+		}
+	}
+
+	// Still registered → still dispatchable directly.
+	st, ok := srv.MCP.ListTools()[alias]
+	if !ok {
+		t.Fatalf("hidden alias %q must remain REGISTERED for back-compat", alias)
+	}
+	if st.Handler == nil {
+		t.Fatalf("hidden alias %q has no handler", alias)
+	}
+	req := mcpapi.CallToolRequest{}
+	req.Params.Name = alias
+	req.Params.Arguments = map[string]any{"entity_id": "nonexistent", "group": "mygroup"}
+	// The handler must resolve and return (an error result is fine — we only
+	// assert the alias is wired to a live handler, not that the entity exists).
+	if _, err := st.Handler(context.Background(), req); err != nil {
+		// A Go-level error is acceptable here (entity-not-found may surface as
+		// a CallToolResult or an error); the point is the handler ran.
+		t.Logf("alias %q handler returned err (acceptable): %v", alias, err)
+	}
+}
+
+// TestHiddenAliasPartition — invariant: the alias set is exactly
+// registered − canonical − sentinel. Guards against a new tool being added
+// without classifying it (advertised vs hidden), or an alias being misspelled.
+func TestHiddenAliasPartition(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"mygroup": {"myrepo": repoDir},
+	})
+
+	registered := srv.MCP.ListTools()
+
+	// Every registered tool is exactly one of: sentinel, canonical, or alias.
+	for name := range registered {
+		if name == sentinelToolName {
+			continue
+		}
+		canon := canonicalToolNames[name]
+		alias := aliasToolNames[name]
+		if canon && alias {
+			t.Errorf("tool %q is in BOTH canonical and alias sets", name)
+		}
+		if !canon && !alias {
+			t.Errorf("registered tool %q is neither canonical nor a hidden alias — classify it (#5546)", name)
+		}
+	}
+
+	// Every canonical name must actually be registered.
+	for name := range canonicalToolNames {
+		if _, ok := registered[name]; !ok {
+			t.Errorf("canonical tool %q is not registered", name)
+		}
+	}
+	// Every alias name must actually be registered (else it can't be callable).
+	for name := range aliasToolNames {
+		if _, ok := registered[name]; !ok {
+			t.Errorf("alias tool %q is not registered — it cannot be callable", name)
+		}
+	}
+
+	// Count check: registered == sentinel + canonical + alias.
+	want := 1 + len(canonicalToolNames) + len(aliasToolNames)
+	if len(registered) != want {
+		t.Errorf("registered=%d, want sentinel(1)+canonical(%d)+alias(%d)=%d",
+			len(registered), len(canonicalToolNames), len(aliasToolNames), want)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -90,6 +90,122 @@ const sentinelToolName = "grafel_status"
 // notifications/tools/list_changed (tracked in #1772).
 const sentinelToolDescription = "Grafel: no indexed group covers cwd. Run install or cd to a repo."
 
+// canonicalToolNames is the advertised allow-list — the 22 intent-named tools
+// surfaced in the tools/list handshake (#5546 consolidation). Every other
+// registered tool is an absorbed alias (see aliasToolNames) that stays callable
+// but is hidden from the handshake. The 8 CORE + 6 ANALYSIS + 3 WORKFLOW/META
+// canonicals route discriminators over the existing handlers (tickets #5549–#5551);
+// several reuse a pre-existing tool name (find, inspect, get_source, index_status,
+// cross_links, impact_radius, endpoints, trace, patterns, mcp_metrics, orient),
+// so they are inherently advertised and need no special-casing here.
+var canonicalToolNames = map[string]bool{
+	// CORE (13)
+	"grafel_orient":        true,
+	"grafel_index_status":  true,
+	"grafel_find":          true,
+	"grafel_inspect":       true,
+	"grafel_get_source":    true,
+	"grafel_related":       true,
+	"grafel_find_paths":    true,
+	"grafel_subgraph":      true,
+	"grafel_trace":         true,
+	"grafel_endpoints":     true,
+	"grafel_cross_links":   true,
+	"grafel_impact_radius": true,
+	"grafel_diff":          true,
+	// ANALYSIS (5)
+	"grafel_debt":          true,
+	"grafel_security":      true,
+	"grafel_test_analysis": true,
+	"grafel_patterns":      true,
+	"grafel_findings":      true,
+	// WORKFLOW (2)
+	"grafel_docgen":       true,
+	"grafel_docgen_apply": true,
+	// META (2)
+	"grafel_event":       true,
+	"grafel_mcp_metrics": true,
+}
+
+// aliasToolNames is the set of absorbed legacy tool names (#5546). They remain
+// REGISTERED (over their own handlers) so un-redeployed consumers can still call
+// them directly for one release, but they are hidden from the tools/list
+// handshake (see fullToolList) so the advertised surface is exactly the 22
+// canonical tools. This drops the per-connect handshake token cost from ~7,900
+// toward ~3,540 without removing any capability.
+//
+// hidden aliases — callable for back-compat, removed next release.
+//
+// Invariant (asserted by TestHiddenAliasPartition): this set must equal
+// registered − canonical − sentinel. Do not let the two drift.
+var aliasToolNames = map[string]bool{
+	// CORE absorbs
+	"grafel_whoami":              true, // → grafel_orient view=me
+	"grafel_stats":               true, // → grafel_orient view=overview
+	"grafel_clusters":            true, // → grafel_orient view=clusters
+	"grafel_module_analysis":     true, // → grafel_orient view=modules
+	"grafel_topology":            true, // → grafel_orient view=topology
+	"grafel_search_entities":     true, // → grafel_find
+	"grafel_find_callers":        true, // → grafel_related direction=callers
+	"grafel_find_callees":        true, // → grafel_related direction=callees
+	"grafel_neighbors":           true, // → grafel_related direction=neighbors
+	"grafel_navigates":           true, // → grafel_related direction=navigates
+	"grafel_expand":              true, // → grafel_subgraph
+	"grafel_data_flows":          true, // → grafel_trace kind=data
+	"grafel_control_flow":        true, // → grafel_trace kind=control
+	"grafel_def_use":             true, // → grafel_trace kind=def_use
+	"grafel_effects":             true, // → grafel_trace kind=effects
+	"grafel_flows":               true, // → grafel_trace
+	"grafel_traces":              true, // → grafel_trace
+	"grafel_effective_contract":  true, // → grafel_endpoints detail=contract
+	"grafel_endpoint_posture":    true, // → grafel_endpoints detail=posture
+	"grafel_pr_impact":           true, // → grafel_impact_radius scope=changeset
+	"grafel_response_shape_diff": true, // → grafel_diff aspect=response_shape
+	"grafel_payload_drift":       true, // → grafel_diff aspect=payload
+	"grafel_auth_posture_diff":   true, // → grafel_diff aspect=auth
+	"grafel_diff_refs":           true, // → grafel_diff aspect=refs
+	"grafel_literal_parity":      true, // → grafel_diff aspect=literals
+	// ANALYSIS absorbs
+	"grafel_dead_code":                   true, // → grafel_debt kind=dead_code
+	"grafel_find_dead_code":              true, // → grafel_debt kind=dead_code
+	"grafel_pure_functions":              true, // → grafel_debt kind=impure
+	"grafel_stub_detector":               true, // → grafel_debt kind=stubs
+	"grafel_import_cycles":               true, // → grafel_debt kind=cycles
+	"grafel_quality_cycles":              true, // → grafel_debt kind=cycles
+	"grafel_license_audit":               true, // → grafel_debt kind=license
+	"grafel_security_findings":           true, // → grafel_security kind=findings
+	"grafel_secrets":                     true, // → grafel_security kind=secrets
+	"grafel_auth_coverage":               true, // → grafel_security kind=auth_coverage
+	"grafel_test_coverage":               true, // → grafel_test_analysis kind=coverage
+	"grafel_test_reachability":           true, // → grafel_test_analysis kind=reachability
+	"grafel_contract_test_effectiveness": true, // → grafel_test_analysis kind=contract_effectiveness
+	"grafel_coverage_effectiveness":      true, // → grafel_test_analysis kind=coverage
+	"grafel_graph_patterns":              true, // → grafel_patterns kind=graph
+	"grafel_template_patterns":           true, // → grafel_patterns kind=template
+	"grafel_list_findings":               true, // → grafel_findings action=list
+	"grafel_save_finding":                true, // → grafel_findings action=save
+	// WORKFLOW absorbs
+	"grafel_docgen_start_run":     true, // → grafel_docgen action=start
+	"grafel_docgen_status":        true, // → grafel_docgen action=status
+	"grafel_docgen_list":          true, // → grafel_docgen action=list
+	"grafel_docgen_promote":       true, // → grafel_docgen action=promote
+	"grafel_docgen_abort":         true, // → grafel_docgen action=abort
+	"grafel_docgen_validate":      true, // → grafel_docgen action=validate
+	"grafel_apply_doc_semantics":  true, // → grafel_docgen_apply kind=semantics
+	"grafel_apply_docgen_repairs": true, // → grafel_docgen_apply kind=repairs
+	"grafel_repairs":              true, // → grafel_docgen_apply kind=repairs
+	"grafel_enrichments":          true, // → grafel_docgen_apply kind=enrichments
+	// META absorbs
+	"grafel_feedback_event": true, // → grafel_event kind=feedback
+	"grafel_persona_event":  true, // → grafel_event kind=persona
+}
+
+// IsHiddenAlias reports whether name is an absorbed legacy tool that is still
+// registered/callable but hidden from the tools/list handshake (#5546/#5552).
+// Exported so the handshake-budget tooling (cmd/mcp-audit) and tests can measure
+// the *advertised* surface rather than the raw registered set.
+func IsHiddenAlias(name string) bool { return aliasToolNames[name] }
+
 // Config controls server construction.
 type Config struct {
 	RegistryPath string
@@ -392,6 +508,13 @@ func (s *Server) fullToolList() ([]MCPToolEntry, error) {
 	for n := range toolMap {
 		if n == sentinelToolName {
 			continue // exclude sentinel from full handshake
+		}
+		// hidden aliases — callable for back-compat, removed next release.
+		// Absorbed legacy tools stay registered (still dispatchable) but are
+		// excluded from tools/list so the handshake advertises exactly the 22
+		// canonical tools (#5546/#5552).
+		if aliasToolNames[n] {
+			continue
 		}
 		names = append(names, n)
 	}


### PR DESCRIPTION
Sub-ticket 4 of 8 of the MCP consolidation epic #5546. Hides the absorbed tools so the handshake advertises only the 22 canonical tools, while the old names stay CALLABLE for one release (code-only back-compat).

## What

The 22 canonical intent-named tools and the ~55 absorbed legacy tools were all registered by tickets #5549–#5551 — every old tool is already reachable via its canonical tool. This PR removes the redundant legacy names from the per-connect handshake:

- `internal/mcp/server.go`: adds `canonicalToolNames` (the advertised allow-list of 22) and `aliasToolNames` (the 55 absorbed names). `fullToolList()` now skips `aliasToolNames` — exactly like the existing `sentinelToolName` skip — so `tools/list` advertises exactly 22. The aliases stay REGISTERED over their own handlers, so un-redeployed consumers can still call them directly for one release. Exposes `IsHiddenAlias(name)`.
- `cmd/mcp-audit` + `budget_test.go`: measure the *advertised* surface (the real per-connect cost), not the raw registered set.
- `hidden_aliases_5552_test.go`: asserts (a) the handshake advertises exactly the 22 canonical names with zero aliases leaking, (b) a hidden name (`grafel_find_callers`) is still dispatchable directly, and (c) the partition invariant `registered == sentinel(1) + canonical(22) + alias(55) = 78`.

Removal of the aliases is a follow-up in the NEXT release.

## Handshake token cost

| | tools advertised | handshake tokens |
|---|---|---|
| before | 77 + sentinel | **7,881** |
| after | 22 (+sentinel in no-group ctx) | **3,327** |

**−4,554 tokens (~58% reduction)** — `go run ./cmd/mcp-audit` reports `delta: -4554`.

## Back-compat verified

`grafel_find_callers` (and the other 54 aliases) remain registered with live handlers and dispatch directly; they are simply absent from `tools/list`. Test `TestHiddenAliasStillDispatchable` guards this.

`go test -count=1 ./internal/mcp/...` green.

Refs #5546.

🤖 Generated with [Claude Code](https://claude.com/claude-code)