### PR TITLE
feat(sml): bootstrap records — CM/.mlb build files + compiler toolchain (#5383)

### DIFF
--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 33 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **idris**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **swift**: 1 · **zig**: 1
+**Total**: 35 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **idris**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **Standard ML**: 2 · **swift**: 1 · **zig**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -39,5 +39,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [ruby](../by-language/ruby.md) | [Gemfile](../detail/pkg.gemfile.md) | — | 🔴 | ✅ | |
 | [rust](../by-language/rust.md) | [Cargo.toml](../detail/pkg.cargo.md) | — | 🔴 | ✅ | |
 | [scala](../by-language/scala.md) | [build.sbt](../detail/pkg.sbt.md) | — | — | 🔴 | |
+| [Standard ML](../by-language/sml.md) | [CM (SML/NJ Compilation Manager build file)](../detail/lang.sml.tool.cm.md) | — | — | ✅ | |
+| [Standard ML](../by-language/sml.md) | [MLB (MLton ML Basis build file)](../detail/lang.sml.tool.mlb.md) | — | — | ✅ | |
 | [swift](../by-language/swift.md) | [Package.swift / Podfile](../detail/pkg.swift-package.md) | — | — | 🟢 | |
 | [zig](../by-language/zig.md) | [build.zig.zon (Zig package manifest)](../detail/pkg.zig-zon.md) | — | — | ✅ | |

--- a/docs/coverage/by-language/sml.md
+++ b/docs/coverage/by-language/sml.md
@@ -1,12 +1,27 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # Standard ML
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 2 · **ORMs**: 0 · **Other**: 0
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/sml/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.sml.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [CM (SML/NJ Compilation Manager build file)](../detail/lang.sml.tool.cm.md) | — | — | — | ✅ | — | |
+| [MLB (MLton ML Basis build file)](../detail/lang.sml.tool.mlb.md) | — | — | — | ✅ | — | |

--- a/docs/coverage/detail/lang.sml.tool.cm.md
+++ b/docs/coverage/detail/lang.sml.tool.cm.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.sml.tool.cm` — CM (SML/NJ Compilation Manager build file)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [Standard ML](../by-language/sml.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Lockfile parsing | — `not_applicable` | `2026-06-24` | — | `internal/extractors/cross/manifest/sml.go` | CM has no lockfile format — the SML/NJ Compilation Manager resolves and pins the dependency closure at build time from the anchored .cm group graph (CM/anchors path config), not a per-unit lockfile. There is no version-constraint syntax in .cm, so there is nothing to lock at the manifest level. |
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5383 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/sml.go`<br>`internal/extractors/cross/manifest/sml_test.go` | parseCM mines the SML/NJ *.cm group/library member list (between the `is` keyword and the closing `end`, after an optional `( <exports> )` clause; (* ... *) comments stripped). Library references — anchored SML/NJ stdlib refs ($/basis.cm, $smlnj/...) plus relative .cm includes (util/util.cm, basename-converged) — become DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes (package_manager=smlnj_cm) with EMPTY version (CM has no version-constraint syntax; honest). The toolchain stdlib floor ($/basis.cm) is KEPT as a real edge, mirroring cabal base / nimble nim / idris base (#5373/#5367/#5382). Source-file members (.sml/.sig/.fun/.ml) and the group/library export kind are surfaced on the project anchor as a compact cm_config property (no new entity kind; same model as ipkg_config / Zig build_targets). Suffix-dispatched in IsManifest/detectPackageManager/dispatchParser. Compiler toolchain: SML/NJ (CM), also consumable by MLton via cm2mlb. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.sml.tool.cm ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/lang.sml.tool.mlb.md
+++ b/docs/coverage/detail/lang.sml.tool.mlb.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.sml.tool.mlb` — MLB (MLton ML Basis build file)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [Standard ML](../by-language/sml.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Lockfile parsing | — `not_applicable` | `2026-06-24` | — | `internal/extractors/cross/manifest/sml.go` | MLB has no lockfile format — MLton resolves the basis/source closure at compile time from the ordered .mlb include graph (the MLB semantics ARE the resolution), not a separate lockfile. There is no version-constraint syntax in .mlb, so there is nothing to lock at the manifest level. |
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5383 | `internal/extractors/cross/manifest/extractor.go`<br>`internal/extractors/cross/manifest/sml.go`<br>`internal/extractors/cross/manifest/sml_test.go` | parseMLB mines the MLton *.mlb ML Basis path list (basis/local/in/end/open/ann declaration keywords and ann "..." annotation strings skipped; (* ... *) comments stripped). The .mlb includes — the anchored MLton stdlib basis $(SML_LIB)/basis/basis.mlb plus nested .mlb includes (basename-converged) — become DEPENDS_ON + DEPENDS_ON_PACKAGE + SBOM package nodes (package_manager=mlton_mlb) with EMPTY version (MLB has no version-constraint syntax; honest). The stdlib basis floor (basis.mlb) is KEPT as a real edge (mirrors cabal base / nimble nim / idris base, #5373/#5367/#5382). Source-file members (.sml/.sig/.fun/.ml) are surfaced on the project anchor as a compact mlb_config property (no new entity kind; same model as cm_config / ipkg_config). Suffix-dispatched in IsManifest/detectPackageManager/dispatchParser. Compiler toolchain: MLton; Poly/ML uses its own use-file model. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.sml.tool.mlb ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (35 active · 4 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 157 · **Other**: 210
+**Languages**: 39 (36 active · 3 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 159 · **Other**: 210
 
 ## Coverage by language
 
@@ -38,6 +38,7 @@
 | [idris](by-language/idris.md) | 0 | 1 | 0 | 0 |
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
 | [JCL](by-language/jcl.md) | 0 | 0 | 0 | 1 |
+| [Standard ML](by-language/sml.md) | 0 | 2 | 0 | 0 |
 | [solidity](by-language/solidity.md) | 0 | 2 | 0 | 2 |
 | [verilog](by-language/verilog.md) | 0 | 4 | 0 | 1 |
 | [VHDL](by-language/vhdl.md) | 0 | 5 | 0 | 1 |
@@ -81,6 +82,5 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 | [Bicep](by-language/bicep.md) |
 | [Lisp](by-language/lisp.md) |
 | [Pony](by-language/pony.md) |
-| [Standard ML](by-language/sml.md) |
 
-Total: 263 frameworks · 157 tools · 186 ORMs · 210 other
+Total: 263 frameworks · 159 tools · 186 ORMs · 210 other

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -261,6 +261,12 @@ func IsManifest(filePath string) bool {
 	if strings.HasSuffix(basename, ".ipkg") {
 		return true
 	}
+	// *.cm — SML/NJ Compilation Manager group/library build file; *.mlb — MLton
+	// ML Basis build file. Both are SML build manifests listing sources + library
+	// deps, matched by extension (the unit name is the file's base name; #5383).
+	if strings.HasSuffix(basename, ".cm") || strings.HasSuffix(basename, ".mlb") {
+		return true
+	}
 	return false
 }
 
@@ -357,6 +363,14 @@ func detectPackageManager(filePath string) string {
 	// *.ipkg → idris2 (Idris package manifest)
 	if strings.HasSuffix(basename, ".ipkg") {
 		return "idris2"
+	}
+	// *.cm → smlnj_cm (SML/NJ Compilation Manager); *.mlb → mlton_mlb (MLton ML
+	// Basis). Two SML build toolchains, distinct package-manager labels (#5383).
+	if strings.HasSuffix(basename, ".cm") {
+		return "smlnj_cm"
+	}
+	if strings.HasSuffix(basename, ".mlb") {
+		return "mlton_mlb"
 	}
 	return "unknown"
 }
@@ -2032,6 +2046,14 @@ func dispatchParser(filePath, source string) (string, []dep) {
 	if strings.HasSuffix(basename, ".ipkg") {
 		return "idris2", parseIpkg(source)
 	}
+	// *.cm — SML/NJ Compilation Manager group/library build file.
+	if strings.HasSuffix(basename, ".cm") {
+		return "smlnj_cm", parseCM(source)
+	}
+	// *.mlb — MLton ML Basis build file.
+	if strings.HasSuffix(basename, ".mlb") {
+		return "mlton_mlb", parseMLB(source)
+	}
 	// Makefile — only an erlang.mk build when it includes erlang.mk / declares
 	// PROJECT (requireSignal=true); a plain Makefile is a no-op.
 	if basename == "Makefile" {
@@ -2290,6 +2312,29 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 				anchorProps = map[string]string{}
 			}
 			anchorProps["ipkg_config"] = cfg
+		}
+	}
+
+	// SML *.cm — surface the CM group/library export kind + source-file member
+	// list on the project anchor as a "cm_config" property (no new entity kind;
+	// same model as ipkg_config). #5383.
+	if strings.HasSuffix(filepath.Base(file.Path), ".cm") {
+		if cfg := cmConfigProperty(string(file.Content)); cfg != "" {
+			if anchorProps == nil {
+				anchorProps = map[string]string{}
+			}
+			anchorProps["cm_config"] = cfg
+		}
+	}
+
+	// SML *.mlb — surface the MLB source-file member list on the project anchor
+	// as a "mlb_config" property (no new entity kind). #5383.
+	if strings.HasSuffix(filepath.Base(file.Path), ".mlb") {
+		if cfg := mlbConfigProperty(string(file.Content)); cfg != "" {
+			if anchorProps == nil {
+				anchorProps = map[string]string{}
+			}
+			anchorProps["mlb_config"] = cfg
 		}
 	}
 

--- a/internal/extractors/cross/manifest/sml.go
+++ b/internal/extractors/cross/manifest/sml.go
@@ -1,0 +1,293 @@
+// sml.go — Standard ML build-manifest parsers (#5383, epic #5360).
+//
+// Standard ML has no real package-manager ecosystem (academic language), but it
+// has two widely-used BUILD MANIFEST formats that enumerate the source files and
+// library dependencies of a compilation unit. Both are parsed here as
+// suffix-dispatched manifests (mirroring the OCaml *.opam / Idris *.ipkg
+// precedent, #5374/#5382):
+//
+//	*.cm — SML/NJ Compilation Manager group/library description. A group is a
+//	  `Group is ... end` (or `Library ... is ... end`) body listing member
+//	  entries, one per line: source files (foo.sml / foo.sig / foo.fun) and
+//	  library references — anchored stdlib refs ($/basis.cm, $smlnj/...),
+//	  pathname-anchored refs ($(ANCHOR)/lib.cm), and plain relative .cm includes
+//	  (util/util.cm). An optional `(<exports>)` clause may precede `is`:
+//
+//	    Library
+//	      structure Foo
+//	      signature BAR
+//	    is
+//	      $/basis.cm
+//	      $/smlnj-lib.cm
+//	      foo.sml
+//	      bar/bar.sig
+//	      util/util.cm
+//	    end
+//
+//	*.mlb — MLton ML Basis file. A flat, ordered list of paths plus `basis`/
+//	  `local`/`open`/`ann` declarations. Library dependencies are other `.mlb`
+//	  includes — most importantly the MLton stdlib basis `$(SML_LIB)/basis/
+//	  basis.mlb`; source members are .sml / .sig / .fun files:
+//
+//	    $(SML_LIB)/basis/basis.mlb
+//	    $(SML_LIB)/smlnj-lib/Util/smlnj-lib.mlb
+//	    local
+//	      util/util.mlb
+//	      foo.sml
+//	    in
+//	      bar.sml
+//	    end
+//
+// Dependency surface — library references (.cm / .mlb includes, including the
+// anchored stdlib basis):
+//
+//	Every library reference becomes a DEPENDS_ON / DEPENDS_ON_PACKAGE edge with
+//	an EMPTY version (CM/MLB carry no version-constraint syntax — the compiler
+//	toolchain resolves the closure; honest). The toolchain stdlib floor
+//	($/basis.cm, $smlnj/..., $(SML_LIB)/.../basis.mlb) is KEPT as a real edge,
+//	mirroring the cabal `base` / nimble `nim` / luarocks `lua` / idris `base`
+//	interpreter-floor treatment (#5373/#5367/#5382). The package manager is
+//	`smlnj_cm` (CM, SML/NJ) or `mlton_mlb` (MLB, MLton) so the build toolchain is
+//	queryable from the dep records.
+//
+// Manifest metadata — surfaced on the project anchor (no new entity kind, same
+// model as the Idris ipkg_config / Zig build_targets props):
+//
+//	sources — the space-joined member source-file list (.sml/.sig/.fun)
+//	export  — (CM only) the group/library export kind: "group" or "library"
+//
+// joined into a compact, deterministic `cm_config` / `mlb_config` property so the
+// source membership + group kind is queryable without a new entity kind.
+//
+// Honest scope: only the DECLARED build surface is recovered. There are no
+// versions (CM/MLB have no constraint syntax) and no lockfile format (the
+// toolchain resolves and pins the closure at build time, not a per-unit
+// manifest), so lockfile_parsing is not_applicable. CM conditional-compilation
+// directives (#if/#elif preprocessor) and MLB `ann "..."` annotation strings are
+// not interpreted (every branch's members are mined; annotations ignored).
+package manifest
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// smlLibRefSuffix reports whether a member token is a library reference (another
+// CM group / MLB basis include) rather than a source file.
+func smlLibRefSuffix(tok string) bool {
+	low := strings.ToLower(tok)
+	return strings.HasSuffix(low, ".cm") || strings.HasSuffix(low, ".mlb")
+}
+
+// smlSourceSuffix reports whether a member token is an SML source file.
+func smlSourceSuffix(tok string) bool {
+	low := strings.ToLower(tok)
+	return strings.HasSuffix(low, ".sml") ||
+		strings.HasSuffix(low, ".sig") ||
+		strings.HasSuffix(low, ".fun") ||
+		strings.HasSuffix(low, ".ml")
+}
+
+// smlDepName normalises a library-reference path to a stable dependency name.
+// The basename (last path segment) is used so $(SML_LIB)/basis/basis.mlb and a
+// sibling-relative basis.mlb converge, while anchored stdlib refs keep their
+// leading anchor token visible (e.g. "$/basis.cm" stays "$/basis.cm") so the
+// toolchain floor is recognisable.
+func smlDepName(ref string) string {
+	ref = strings.TrimSpace(ref)
+	// Keep a bare SML/NJ anchor reference verbatim ("$/basis.cm", "$smlnj/x.cm").
+	if strings.HasPrefix(ref, "$/") || strings.HasPrefix(ref, "$smlnj") {
+		return ref
+	}
+	// $(SML_LIB)/basis/basis.mlb → basis.mlb (the stable, convergent name).
+	return filepath.Base(ref)
+}
+
+// ---------------------------------------------------------------------------
+// Parser: *.cm (SML/NJ Compilation Manager)
+// ---------------------------------------------------------------------------
+
+// cmCommentRE strips SML `(* ... *)` block comments (CM uses SML comment
+// syntax). Non-greedy, dot-matches-newline for multi-line comments.
+var cmCommentRE = regexp.MustCompile(`(?s)\(\*.*?\*\)`)
+
+// cmGroupHeadRE matches the `Group`/`Library` head keyword (case-insensitive) so
+// the export kind can be recorded. Group 1 is the keyword.
+var cmGroupHeadRE = regexp.MustCompile(`(?im)^\s*(group|library)\b`)
+
+// cmMemberBody returns the member-list body of a CM file: the text between the
+// `is` keyword and the closing `end`. The optional `( <exports> )` clause and
+// the head keyword precede `is`; members follow it.
+func cmMemberBody(source string) string {
+	// Locate the `is` keyword that opens the member list. It appears on its own
+	// or at the end of the export clause; match the first whole-word `is`.
+	loc := regexp.MustCompile(`(?im)\bis\b`).FindStringIndex(source)
+	if loc == nil {
+		return source
+	}
+	body := source[loc[1]:]
+	// Trim a trailing `end` (with optional trailing `;`/whitespace).
+	if m := regexp.MustCompile(`(?is)\bend\b\s*;?\s*$`).FindStringIndex(body); m != nil {
+		body = body[:m[0]]
+	}
+	return body
+}
+
+// parseCM parses an SML/NJ `*.cm` group/library file and returns its library
+// dependencies (.cm includes, including anchored stdlib refs). Source-file
+// members are not deps (they are the unit's own sources, surfaced on the anchor
+// via cmConfigProperty). First reference of a name wins on duplicates.
+func parseCM(source string) []dep {
+	source = cmCommentRE.ReplaceAllString(source, " ")
+	body := cmMemberBody(source)
+
+	var out []dep
+	seen := map[string]bool{}
+	for _, tok := range cmMemberTokens(body) {
+		if !smlLibRefSuffix(tok) {
+			continue
+		}
+		name := smlDepName(tok)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, dep{name: name, version: "", kind: "runtime"})
+	}
+	return out
+}
+
+// cmMemberTokens splits a CM member-list body into member path tokens, one per
+// whitespace-separated token, dropping CM tool annotations like `(tool:...)` and
+// `:tool` suffixes that are not paths.
+func cmMemberTokens(body string) []string {
+	var out []string
+	for _, f := range strings.Fields(body) {
+		f = strings.TrimSpace(f)
+		// Drop a `(...)` tool-class annotation token.
+		if strings.HasPrefix(f, "(") {
+			continue
+		}
+		// Drop a `: toolname` class suffix appended to a member (rare); keep the
+		// path part before any whitespace (already split) — a bare `:` token is
+		// dropped.
+		if f == ":" || f == "" {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// cmConfigProperty returns a compact, deterministic summary of a CM file's
+// build metadata (export kind + source-file member list), surfaced on the
+// project anchor as the "cm_config" property, or "" when none is present.
+func cmConfigProperty(source string) string {
+	source = cmCommentRE.ReplaceAllString(source, " ")
+	var parts []string
+
+	if m := cmGroupHeadRE.FindStringSubmatch(source); m != nil {
+		parts = append(parts, "export="+strings.ToLower(m[1]))
+	}
+	var sources []string
+	seen := map[string]bool{}
+	for _, tok := range cmMemberTokens(cmMemberBody(source)) {
+		if smlSourceSuffix(tok) && !seen[tok] {
+			seen[tok] = true
+			sources = append(sources, tok)
+		}
+	}
+	if len(sources) > 0 {
+		parts = append(parts, "sources="+strings.Join(sources, " "))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// ---------------------------------------------------------------------------
+// Parser: *.mlb (MLton ML Basis)
+// ---------------------------------------------------------------------------
+
+// mlbCommentRE strips MLB `(* ... *)` block comments (same syntax as SML).
+var mlbCommentRE = regexp.MustCompile(`(?s)\(\*.*?\*\)`)
+
+// mlbKeywords are MLB declaration keywords that are NOT path members; a token
+// equal to one of these (case-insensitive) is skipped during the path scan.
+var mlbKeywords = map[string]bool{
+	"basis": true, "local": true, "in": true, "end": true, "open": true,
+	"let": true, "ann": true, "and": true, "functor": true, "signature": true,
+	"structure": true, "=": true,
+}
+
+// mlbPathTokens scans an MLB body for path tokens — the whitespace-separated
+// tokens that look like file paths (carry a known SML/basis suffix). Declaration
+// keywords, `ann "..."` annotation strings, and `basis B = ...`/`open B` basis
+// identifiers are skipped (only suffix-bearing path members are kept).
+func mlbPathTokens(body string) []string {
+	var out []string
+	for _, f := range strings.Fields(body) {
+		f = strings.Trim(f, ";")
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		// Skip quoted annotation strings ("redundantMatch warn" etc.).
+		if strings.HasPrefix(f, `"`) {
+			continue
+		}
+		if mlbKeywords[strings.ToLower(f)] {
+			continue
+		}
+		if smlLibRefSuffix(f) || smlSourceSuffix(f) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// parseMLB parses a MLton `*.mlb` ML Basis file and returns its library
+// dependencies — other `.mlb` includes, including the anchored MLton stdlib
+// basis ($(SML_LIB)/basis/basis.mlb). Source-file members (.sml/.sig/.fun) are
+// the unit's own sources (surfaced on the anchor via mlbConfigProperty), not
+// deps. First reference of a name wins on duplicates.
+func parseMLB(source string) []dep {
+	source = mlbCommentRE.ReplaceAllString(source, " ")
+
+	var out []dep
+	seen := map[string]bool{}
+	for _, tok := range mlbPathTokens(source) {
+		if !smlLibRefSuffix(tok) {
+			continue
+		}
+		name := smlDepName(tok)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, dep{name: name, version: "", kind: "runtime"})
+	}
+	return out
+}
+
+// mlbConfigProperty returns a compact, deterministic summary of a MLB file's
+// source-file member list, surfaced on the project anchor as the "mlb_config"
+// property, or "" when the file declares no source members.
+func mlbConfigProperty(source string) string {
+	source = mlbCommentRE.ReplaceAllString(source, " ")
+	var sources []string
+	seen := map[string]bool{}
+	for _, tok := range mlbPathTokens(source) {
+		if smlSourceSuffix(tok) && !seen[tok] {
+			seen[tok] = true
+			sources = append(sources, tok)
+		}
+	}
+	if len(sources) == 0 {
+		return ""
+	}
+	return "sources=" + strings.Join(sources, " ")
+}

--- a/internal/extractors/cross/manifest/sml_test.go
+++ b/internal/extractors/cross/manifest/sml_test.go
@@ -1,0 +1,196 @@
+package manifest
+
+import "testing"
+
+// realCM is a representative SML/NJ *.cm group/library file. It exercises the
+// `Library ( <exports> ) is ... end` shape, the SML/NJ stdlib-anchor floor
+// ($/basis.cm, $/smlnj-lib.cm) kept as real deps, a nested .cm library include,
+// plain .sml/.sig source members in subdirs, and a (* ... *) comment.
+const realCM = `(* myproject.cm — the project library *)
+Library
+  structure Foo
+  signature BAR
+is
+  $/basis.cm
+  $/smlnj-lib.cm
+  util/util.cm
+  foo.sml
+  bar/bar.sig
+  baz.fun
+end
+`
+
+func TestCM_Dependencies(t *testing.T) {
+	deps := depEntities(runExtract(t, "myproject.cm", realCM))
+	// Library refs only: $/basis.cm, $/smlnj-lib.cm, util/util.cm = 3 deps.
+	// Source files (foo.sml/bar.sig/baz.fun) are NOT deps.
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 deps, got %d: %+v", len(deps), depNames(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "smlnj_cm" {
+			t.Errorf("%s: package_manager=%q want smlnj_cm", d.Name, d.Properties["package_manager"])
+		}
+		// CM has no version-constraint syntax → always empty (honest).
+		if d.Properties["version"] != "" {
+			t.Errorf("%s: version=%q want empty (CM has no constraint syntax)", d.Name, d.Properties["version"])
+		}
+	}
+	// The SML/NJ stdlib floor is kept as a real edge (verbatim anchor name).
+	if depByName(deps, "$/basis.cm") == nil {
+		t.Error("expected stdlib-floor dep '$/basis.cm' (kept as a real edge)")
+	}
+	if depByName(deps, "$/smlnj-lib.cm") == nil {
+		t.Error("expected stdlib-floor dep '$/smlnj-lib.cm'")
+	}
+	// A relative .cm include converges to its basename.
+	if depByName(deps, "util.cm") == nil {
+		t.Error("expected library include 'util.cm' from util/util.cm")
+	}
+	// Source files must NOT appear as deps.
+	if depByName(deps, "foo.sml") != nil || depByName(deps, "baz.fun") != nil {
+		t.Error("source files must not be emitted as deps")
+	}
+}
+
+func TestCM_ConfigAnchor(t *testing.T) {
+	anchor := anchorRecord(runExtract(t, "myproject.cm", realCM))
+	if anchor == nil {
+		t.Fatal("no project anchor emitted for myproject.cm")
+	}
+	cfg := anchor.Properties["cm_config"]
+	if cfg == "" {
+		t.Fatal("cm_config property is empty")
+	}
+	for _, want := range []string{
+		"export=library",
+		"sources=foo.sml bar/bar.sig baz.fun",
+	} {
+		if !containsSub(cfg, want) {
+			t.Errorf("cm_config=%q missing %q", cfg, want)
+		}
+	}
+}
+
+func TestCM_GroupExport(t *testing.T) {
+	anchor := anchorRecord(runExtract(t, "g.cm",
+		`Group is
+  $/basis.cm
+  main.sml
+end
+`))
+	if anchor == nil {
+		t.Fatal("no anchor for g.cm")
+	}
+	if !containsSub(anchor.Properties["cm_config"], "export=group") {
+		t.Errorf("cm_config=%q want export=group", anchor.Properties["cm_config"])
+	}
+}
+
+// realMLB is a representative MLton *.mlb ML Basis file. It exercises the MLton
+// stdlib basis floor ($(SML_LIB)/basis/basis.mlb) kept as a real dep, a nested
+// .mlb include, a local/in/end block, .sml/.sig source members, an `ann "..."`
+// annotation that must be ignored, and a (* ... *) comment.
+const realMLB = `(* sources.mlb *)
+$(SML_LIB)/basis/basis.mlb
+$(SML_LIB)/smlnj-lib/Util/smlnj-lib.mlb
+ann "redundantMatch warn" in
+  local
+    util/util.mlb
+    foo.sml
+  in
+    bar.sig
+    main.sml
+  end
+end
+`
+
+func TestMLB_Dependencies(t *testing.T) {
+	deps := depEntities(runExtract(t, "sources.mlb", realMLB))
+	// .mlb includes only: basis.mlb, smlnj-lib.mlb, util.mlb = 3 deps.
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 deps, got %d: %+v", len(deps), depNames(deps))
+	}
+	for _, d := range deps {
+		if d.Properties["package_manager"] != "mlton_mlb" {
+			t.Errorf("%s: package_manager=%q want mlton_mlb", d.Name, d.Properties["package_manager"])
+		}
+		if d.Properties["version"] != "" {
+			t.Errorf("%s: version=%q want empty (MLB has no constraint syntax)", d.Name, d.Properties["version"])
+		}
+	}
+	// The MLton stdlib basis floor is kept as a real edge (basename-converged).
+	if depByName(deps, "basis.mlb") == nil {
+		t.Error("expected stdlib-floor dep 'basis.mlb' from $(SML_LIB)/basis/basis.mlb")
+	}
+	if depByName(deps, "smlnj-lib.mlb") == nil {
+		t.Error("expected dep 'smlnj-lib.mlb'")
+	}
+	if depByName(deps, "util.mlb") == nil {
+		t.Error("expected nested include 'util.mlb'")
+	}
+	// Source files / keywords / annotation strings must NOT be deps.
+	for _, bad := range []string{"foo.sml", "bar.sig", "ann", "local", "redundantMatch"} {
+		if depByName(deps, bad) != nil {
+			t.Errorf("%q must not be emitted as a dep", bad)
+		}
+	}
+}
+
+func TestMLB_ConfigAnchor(t *testing.T) {
+	anchor := anchorRecord(runExtract(t, "sources.mlb", realMLB))
+	if anchor == nil {
+		t.Fatal("no project anchor emitted for sources.mlb")
+	}
+	cfg := anchor.Properties["mlb_config"]
+	if cfg == "" {
+		t.Fatal("mlb_config property is empty")
+	}
+	// Source members, in declaration order, comments/annotations excluded.
+	if !containsSub(cfg, "sources=foo.sml bar.sig main.sml") {
+		t.Errorf("mlb_config=%q missing source list", cfg)
+	}
+}
+
+func TestMLB_DependsOnEdges(t *testing.T) {
+	rels := dependsOnRels(runExtract(t, "x.mlb",
+		`$(SML_LIB)/basis/basis.mlb
+lib/dep.mlb
+main.sml
+`))
+	if len(rels) != 2 {
+		t.Fatalf("expected 2 DEPENDS_ON edges, got %d", len(rels))
+	}
+	for _, r := range rels {
+		if r.Properties["package_manager"] != "mlton_mlb" {
+			t.Errorf("edge package_manager=%q want mlton_mlb", r.Properties["package_manager"])
+		}
+	}
+}
+
+func TestSML_IsManifest(t *testing.T) {
+	for _, p := range []string{"foo/myproject.cm", "sources.mlb"} {
+		if !IsManifest(p) {
+			t.Errorf("IsManifest should recognise %q", p)
+		}
+	}
+	if detectPackageManager("myproject.cm") != "smlnj_cm" {
+		t.Errorf("detectPackageManager(*.cm)=%q want smlnj_cm", detectPackageManager("myproject.cm"))
+	}
+	if detectPackageManager("sources.mlb") != "mlton_mlb" {
+		t.Errorf("detectPackageManager(*.mlb)=%q want mlton_mlb", detectPackageManager("sources.mlb"))
+	}
+}
+
+func TestSML_NoDependencies(t *testing.T) {
+	// A CM group of pure local sources (no library includes) emits no deps.
+	deps := depEntities(runExtract(t, "leaf.cm",
+		`Group is
+  a.sml
+  b.sml
+end
+`))
+	if len(deps) != 0 {
+		t.Fatalf("expected 0 deps for a source-only group, got %d: %+v", len(deps), depNames(deps))
+	}
+}


### PR DESCRIPTION
Closes #5383 (epic #5360, milestone 0.1.5 — Group A bootstrap).

Standard ML has no real package-manager ecosystem, but it has two widely-used **build-manifest** formats that enumerate a compilation unit's source files + library dependencies. Both are added as suffix-dispatched parsers in `internal/extractors/cross/manifest/`, following the OCaml `*.opam` / Idris `*.ipkg` precedent (#5374/#5382). Go-only; heuristic (no bundled grammar needed).

## What landed

**`internal/extractors/cross/manifest/sml.go`** — two parsers:

- **`*.cm` (SML/NJ Compilation Manager)** — `parseCM` mines the `Group`/`Library ( <exports> ) is ... end` member list. `.cm` library references — the anchored SML/NJ stdlib floor (`$/basis.cm`, `$smlnj/...`) plus relative `.cm` includes (basename-converged) — become `DEPENDS_ON` + `DEPENDS_ON_PACKAGE` + SBOM package nodes (`package_manager=smlnj_cm`). Source members (`.sml/.sig/.fun/.ml`) + the group/library export kind are surfaced on the project anchor as a compact `cm_config` property.
- **`*.mlb` (MLton ML Basis)** — `parseMLB` mines the path list (`basis`/`local`/`in`/`end`/`open`/`ann` keywords + `ann "..."` annotation strings skipped). `.mlb` includes — the MLton stdlib basis `$(SML_LIB)/basis/basis.mlb` floor plus nested includes — become deps (`package_manager=mlton_mlb`); source members are surfaced as `mlb_config`.

`(* ... *)` comments stripped in both. The toolchain stdlib floor is **kept** as a real edge (mirrors cabal `base` / nimble `nim` / idris `base`).

Wired into `IsManifest` / `detectPackageManager` / `dispatchParser` and the `Extract` anchor-prop step.

## Per-capability (honest)

| Record | manifest_parsing | lockfile_parsing |
|---|---|---|
| `lang.sml.tool.cm` | **full** — group/library member list, lib-ref deps, source/export anchor | **not_applicable** — CM resolves the closure at build time; no lockfile, no version syntax |
| `lang.sml.tool.mlb` | **full** — basis path list, `.mlb`-include deps, source anchor | **not_applicable** — MLton resolves the closure at compile time; no lockfile, no version syntax |

Honest scope: no versions (CM/MLB have no constraint syntax → all dep versions empty); CM `#if` preprocessor branches all mined; MLB annotation strings ignored.

## Fixtures + tests

`internal/extractors/cross/manifest/sml_test.go` — real `.cm`/`.mlb` fixtures exercising: stdlib-anchor floor deps, nested `.cm`/`.mlb` includes, source-vs-lib member discrimination, `local/in/end` blocks, `ann "..."` annotations + comments excluded, `Group` vs `Library` export kind, `cm_config`/`mlb_config` anchor props, DEPENDS_ON edges, source-only no-dep group.

## Validation

- `go test ./internal/extractors/cross/manifest/ ./tools/coverage/` green.
- Registry + coverage docs regenerated this PR; `coverage validate` 0 errors (818 records), `coverage fmt --check` canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)