### PR TITLE
docs(skills): canonical 22-tool guidance, task-oriented routing (#5554)

### DIFF
--- a/skills/extend-convention/SKILL.md
+++ b/skills/extend-convention/SKILL.md
@@ -52,12 +52,12 @@ Run, against the user's repo:
 grafel index <repo>          # if not already indexed
 ```
 
-Then via MCP, with the repo's CWD active so `grafel_whoami` resolves correctly:
+Then via MCP, with the repo's CWD active so `grafel_orient (view=me)` resolves correctly:
 
-- `grafel_graph_stats(repo_filter=["<repo>"])` — top entity kinds and edge kinds tell you what the indexer found.
-- `grafel_search(question="entry points")` — confirms what runs the app.
-- `grafel_search(question="public API surface")` — confirms what's exposed.
-- `grafel_list_clusters(repo_filter=["<repo>"])` — confirms the natural module boundary.
+- `grafel_orient(view="overview", repo_filter=["<repo>"])` — top entity kinds and edge kinds tell you what the indexer found.
+- `grafel_find(question="entry points")` — confirms what runs the app.
+- `grafel_find(question="public API surface")` — confirms what's exposed.
+- `grafel_orient(view="clusters", repo_filter=["<repo>"])` — confirms the natural module boundary.
 
 Read at most ~10 source files to confirm structural assumptions. Do not read the whole repo — the question is structural, not behavioral.
 
@@ -69,13 +69,13 @@ You must ask, even if the codebase suggests answers:
 2. **Public surface.** Which of these does the framework consider "public":
    - HTTP routes / RPC services / CLI entries / package exports / event handlers / scheduled tasks / native modules / IaC outputs?
    - Anything else specific to the stack?
-3. **Module shape.** What is the directory layout the framework expects or its community has standardized on? Are there places where `grafel_list_clusters` will reliably mis-cluster?
+3. **Module shape.** What is the directory layout the framework expects or its community has standardized on? Are there places where `grafel_orient (view=clusters)` will reliably mis-cluster?
 4. **Entry points.** What file does the framework start at? What declares config? What declares dependencies?
 5. **Dynamic edges.** What runtime couplings does the stack create that static analysis misses? List 2-5 patterns. (Examples to prompt the user with: middleware ordering, signal dispatch, plugin discovery, dependency injection containers, ARN references, label selectors.)
 6. **Deployment signals.** How does this stack typically deploy? Containers, serverless, static hosting, on-prem? What configuration files are involved?
 7. **Manifest files.** Which files declare dependencies? Which lockfile is canonical?
 8. **Cross-cutting pitfalls.** What is the top "gotcha" for a new engineer joining a project on this stack? Aim for 2-4 items.
-9. **Cross-repo signals.** How does a service on this stack typically connect to other services? Which signals does grafel's `grafel_list_link_candidates` need to trust by default?
+9. **Cross-repo signals.** How does a service on this stack typically connect to other services? Which signals does grafel's `grafel_cross_links` need to trust by default?
 
 ### Step 4 — Draft the convention
 

--- a/skills/grafel-aware-review/SKILL.md
+++ b/skills/grafel-aware-review/SKILL.md
@@ -22,7 +22,7 @@ into a systematic second opinion on every PR — one that catches impact leakage
 broken call chains, and pattern drift that diff-only review misses.
 
 Prerequisite: the `/using-grafel` skill. This skill assumes you already
-know all 19 MCP tools and the Pass-based orientation workflow.
+know the 22 MCP tools and the orientation workflow.
 
 ---
 
@@ -61,20 +61,18 @@ structural pass and review the diff purely on its own terms.
 When time is short, a single call surfaces most structural risk:
 
 ```
-grafel_find(
-  question="<paste the name of the changed entity>",
-  depth=2,
-  token_budget=800
+grafel_impact_radius(
+  target="<the changed entity>",
+  scope="entity"
 )
 ```
 
 This call returns:
-- The entity's direct callers and callees (depth-1 neighbours).
-- Their callers and callees (depth-2 neighbours).
-- Whether any neighbours live in a different repo (cross-repo risk).
-- PageRank of the changed entity (high PageRank = high blast radius).
+- The blast radius of the change — directly and transitively affected entities.
+- Whether any affected entities live in a different repo (cross-repo risk).
+- The PageRank weight of the changed entity (high = high blast radius).
 
-If the entity is not found (`hits: []`), it is either brand-new (check for
+If the entity is not found, it is either brand-new (check for
 orphan callers of the new name) or the repo has not been re-indexed since the
 PR was opened.
 
@@ -93,16 +91,16 @@ or assume a return type that no longer exists.
 
 ```
 # Step 1: Find the entity and all depth-2 callers
-grafel_find(question="<FunctionName>", depth=2, context_filter=["CALLS"])
+grafel_related(entity="<FunctionName>", direction="callers")
 
 # Step 2: Inspect for PageRank (blast-radius indicator)
-grafel_inspect(label_or_id="<FunctionName>")
+grafel_inspect(entity="<FunctionName>")
 
 # Step 3: For each top caller — does its call site match the new signature?
-grafel_get_source(node_id="<CallerEntityId>", context_lines=20)
+grafel_get_source(entity="<CallerEntityId>", context_lines=20)
 
 # Step 4: Check cross-repo callers
-grafel_expand(node="<FunctionName>", depth=1)
+grafel_related(entity="<FunctionName>", direction="callers")
 # Look for entries where entity_id prefix differs from current repo slug
 ```
 
@@ -119,15 +117,15 @@ creating dead code (orphan callers).
 
 ```
 # Step 1: Find all callers before deletion is confirmed as safe
-grafel_find(question="<DeletedFunctionName>", depth=1)
-# If hits is empty: the entity was already absent from the index — safe.
-# If hits exist: callers remain.
+grafel_related(entity="<DeletedFunctionName>", direction="callers")
+# If callers is empty: the entity was already absent from the index — safe.
+# If callers exist: call-sites remain.
 
 # Step 2: Expand to enumerate every direct caller
-grafel_expand(node="<DeletedFunctionName>", depth=1)
+grafel_related(entity="<DeletedFunctionName>", direction="callers")
 
 # Step 3: Source-read each caller to verify it is also removed in this PR
-grafel_get_source(node_id="<CallerId>", context_lines=15)
+grafel_get_source(entity="<CallerId>", context_lines=15)
 ```
 
 **Review comment trigger:** any caller not removed in the same PR. Block
@@ -142,18 +140,18 @@ if caller is in a different repo (cross-repo breakage).
 
 ```
 # Step 1: Confirm the new endpoint appears in the index (may need re-index)
-grafel_endpoint_definitions(repo_filter=["<server-repo>"])
+grafel_endpoints(detail="list", repo_filter=["<server-repo>"])
 # Look for the new path+method pair in the returned list.
 
 # Step 2: Check if any client call-site targets this path
-grafel_endpoint_calls(repo_filter=["<client-repo>"])
-# If none match: the endpoint is currently unused — note it.
+grafel_cross_links(group="<group>")
+# If no client join matches: the endpoint is currently unused — note it.
 
 # Step 3: Check for route conflicts (same path, any method)
-grafel_find(question="<new-route-path>", depth=1)
+grafel_find(query="<new-route-path>")
 
 # Step 4: Endpoint stats for overall orphan picture
-grafel_endpoint_stats()
+grafel_endpoints(detail="list")
 ```
 
 **Review comment trigger:** no matching client call found (potential dead
@@ -169,15 +167,15 @@ the old path.
 
 ```
 # Step 1: Find orphan callers after the change
-grafel_endpoint_calls(orphan_only=true)
-# Any entry here references an endpoint that no longer has a definition.
+grafel_cross_links(group="<group>")
+# Look for client joins that no longer resolve to a definition (orphaned).
 
 # Step 2: Confirm the specific old path is now orphaned
-grafel_find(question="<old-route-path>", depth=1)
+grafel_find(query="<old-route-path>")
 
 # Step 3: Source-read each orphan caller to confirm it is updated in this PR
-grafel_inspect(label_or_id="<orphan-caller-entity-id>")
-grafel_get_source(node_id="<orphan-caller-entity-id>", context_lines=20)
+grafel_inspect(entity="<orphan-caller-entity-id>")
+grafel_get_source(entity="<orphan-caller-entity-id>", context_lines=20)
 ```
 
 **Review comment trigger:** any orphan caller that is NOT updated in this
@@ -192,20 +190,20 @@ introduces a cluster-level cycle, or violates an established layering pattern.
 
 ```
 # Step 1: Orient — which clusters do the importer and importee belong to?
-grafel_clusters()
+grafel_orient(view="clusters")
 # Note cluster IDs for both the importing and imported entity.
 
 # Step 2: Inspect both entities for cluster membership
-grafel_inspect(label_or_id="<ImportingModule>")
-grafel_inspect(label_or_id="<ImportedModule>")
+grafel_inspect(entity="<ImportingModule>")
+grafel_inspect(entity="<ImportedModule>")
 # Compare `community_id` fields.
 
 # Step 3: Check if a reverse path already exists (cycle detection)
-grafel_trace(source="<ImportedModule>", target="<ImportingModule>")
+grafel_find_paths(from="<ImportedModule>", to="<ImportingModule>")
 # If found=true: this import creates a cycle — block.
 
 # Step 4: Look for established layering patterns
-grafel_list_findings(entity_id="<ImportingModule>")
+grafel_findings(action="list", entity_id="<ImportingModule>")
 # Prior agents may have recorded "this cluster must not depend on <other>".
 ```
 
@@ -222,16 +220,15 @@ a new subscribe has no publisher (orphan subscriber).
 
 ```
 # Step 1: Find the message topic entity
-grafel_find(question="<TopicName OR event name>", depth=1,
-                context_filter=["PUBLISHES_TO", "SUBSCRIBES_TO"])
+grafel_find(query="<TopicName OR event name>")
 
 # Step 2: Expand to see full publish/subscribe graph around the topic
-grafel_expand(node="<TopicEntityId>", depth=2)
+grafel_subgraph(entities=["<TopicEntityId>"], depth=2)
 # Look for at least one PUBLISHES_TO and one SUBSCRIBES_TO edge.
 
 # Step 3: Check cross-repo — publisher and subscriber may be in different repos
-grafel_stats()  # verify both repos loaded without error
-grafel_trace(source="<PublisherEntity>", target="<SubscriberEntity>")
+grafel_orient(view="overview")  # verify both repos loaded without error
+grafel_find_paths(from="<PublisherEntity>", to="<SubscriberEntity>")
 ```
 
 **Review comment trigger:** publish with no subscriber (dead message —
@@ -251,11 +248,11 @@ grafel_cross_links(action="list", repo_filter=["<calling-repo>"], limit=20)
 # Find the new candidate corresponding to the added call.
 
 # Step 2: Inspect the target entity in the remote repo
-grafel_inspect(label_or_id="<remote-repo>::<TargetEntityId>")
+grafel_inspect(entity="<remote-repo>::<TargetEntityId>")
 # If not found: the target may not be indexed yet — note as risk.
 
 # Step 3: Trace the end-to-end path
-grafel_trace(source="<local-caller>", target="<remote-repo>::<target>")
+grafel_find_paths(from="<local-caller>", to="<remote-repo>::<target>")
 # Verify crosses_repos=true and weakest_link_confidence is acceptable.
 ```
 
@@ -272,19 +269,19 @@ for entities of this kind in this cluster.
 
 ```
 # Step 1: Find an existing entity of the same kind for comparison
-grafel_find(question="<existing example of same pattern>", depth=1)
+grafel_find(query="<existing example of same pattern>")
 
 # Step 2: Expand both the existing and new entity to compare neighbour sets
-grafel_expand(node="<ExistingPatternEntity>", depth=1)
-grafel_expand(node="<NewEntity>", depth=1)
+grafel_related(entity="<ExistingPatternEntity>", direction="neighbors")
+grafel_related(entity="<NewEntity>", direction="neighbors")
 # Compare edge kinds: both should have the same set (e.g., CALLS, REGISTERED_IN, USES).
 
 # Step 3: Check saved pattern findings
-grafel_list_findings(entity_id="<ExistingPatternEntity>")
+grafel_findings(action="list", entity_id="<ExistingPatternEntity>")
 # Look for findings of type="decision" that record the expected structure.
 
 # Step 4: Discover patterns if none are saved
-grafel_find(question="<pattern keyword> convention structure", depth=2)
+grafel_patterns(kind="code")
 ```
 
 **Review comment trigger:** missing edge that all existing entities of this
@@ -304,7 +301,7 @@ Use this rubric to decide how strongly to flag an grafel finding.
 | **Note** | New entity with low PageRank and no cross-cluster callers. Pattern difference that is documented as intentional. | Inline comment only — informational. |
 | **Pass** | Entity not found in index (brand-new, not yet indexed). Style-only diff. Pure test code with no exported names. | Skip grafel check — not applicable. |
 
-**Confidence threshold:** any `grafel_trace` path with
+**Confidence threshold:** any `grafel_find_paths` path with
 `weakest_link_confidence < 0.5` should be verified with `grafel_get_source`
 before escalating to Block. Low confidence edges may be indexer stubs, not
 real edges.
@@ -322,9 +319,9 @@ self-check from Section 1 first.
 
 ### Do not skip Pass 0 even in review context
 
-`grafel_whoami` + `grafel_stats` still costs ~200 tokens and prevents
+`grafel_orient(view="me")` + `grafel_orient(view="overview")` still costs ~200 tokens and prevents
 querying the wrong group or a repo that failed to load. A repo that shows
-`status: "load_error"` in stats means grafel results for that repo are
+`status: "load_error"` in the overview means grafel results for that repo are
 stale — lower confidence thresholds accordingly.
 
 ### Do not treat "entity not found" as "safe"
@@ -340,18 +337,18 @@ Grafel tells you about the structural graph — it does not know what
 changed in the PR. Always read the diff first; use grafel to answer
 follow-up structural questions the diff raises.
 
-### Do not escalate low-confidence traces to Block without source verification
+### Do not escalate low-confidence paths to Block without source verification
 
-`grafel_trace` with `weakest_link_confidence < 0.5` means at least one
+`grafel_find_paths` with `weakest_link_confidence < 0.5` means at least one
 edge in the path is an indexer stub, not a confirmed call. Verify with
 `grafel_get_source` before blocking a PR on the basis of that trace.
 
-### Do not call grafel_expand at depth > 2 during review
+### Do not call grafel_subgraph at depth > 2 during review
 
-Review bandwidth is limited. `grafel_expand` at depth 3 on a
+Review bandwidth is limited. `grafel_subgraph` at depth 3 on a
 high-PageRank entity returns hundreds of edges and is nearly impossible to
-interpret in a review comment. Cap at depth 2; use `context_filter` to
-narrow to the relevant edge kind.
+interpret in a review comment. Cap at depth 2; use `grafel_related` with a
+`direction` to narrow to the relevant edge kind.
 
 ---
 
@@ -370,21 +367,20 @@ Each example follows the same structure: PR summary → tool sequence → findin
 **Tool sequence:**
 
 ```
-grafel_whoami()
+grafel_orient(view="me")
 # → group: "orders-platform", repo: "orders-api"
 
-grafel_find(question="OrderService create_order", depth=2,
-                context_filter=["CALLS"])
-# → hits: [OrderService (orders-api), CheckoutController (orders-api),
-#           MobileCheckoutFlow (mobile-app)]
+grafel_related(entity="OrderService.create_order", direction="callers")
+# → callers: [CheckoutController (orders-api),
+#             MobileCheckoutFlow (mobile-app)]
 
-grafel_inspect(label_or_id="CheckoutController")
+grafel_inspect(entity="CheckoutController")
 # → source_file: src/controllers/checkout.py, community_id: 2
 
-grafel_get_source(node_id="CheckoutController", context_lines=15)
+grafel_get_source(entity="CheckoutController", context_lines=15)
 # → line 88: self.order_service.create_order(cart)  ← old name, not updated
 
-grafel_inspect(label_or_id="mobile-app::MobileCheckoutFlow")
+grafel_inspect(entity="mobile-app::MobileCheckoutFlow")
 # → cross-repo caller, not in this PR's diff
 ```
 
@@ -411,16 +407,16 @@ grafel_inspect(label_or_id="mobile-app::MobileCheckoutFlow")
 **Tool sequence:**
 
 ```
-grafel_endpoint_definitions(repo_filter=["billing-api"])
+grafel_endpoints(detail="list", repo_filter=["billing-api"])
 # → definitions include: { method: "POST", path: "/api/v2/invoices/bulk", ... }
 
-grafel_endpoint_calls(repo_filter=["admin-frontend"])
-# → no call matching "/api/v2/invoices/bulk"
+grafel_cross_links(group="billing-platform")
+# → no client join matching "/api/v2/invoices/bulk"
 
-grafel_endpoint_calls(orphan_only=true)
+grafel_endpoints(detail="posture")
 # → 0 orphan callers (this is a new definition, not a changed one)
 
-grafel_endpoint_stats()
+grafel_endpoints(detail="list")
 # → definitions: 14, calls: 11, orphan_calls: 0
 ```
 
@@ -445,14 +441,14 @@ Client not updated.
 **Tool sequence:**
 
 ```
-grafel_endpoint_calls(orphan_only=true)
-# → [{ entity_id: "mobile-app::OrderListScreen", method: "GET",
-#       path: "/api/v1/orders" }]
+grafel_cross_links(group="orders-platform")
+# → orphan client join: { entity_id: "mobile-app::OrderListScreen",
+#                         method: "GET", path: "/api/v1/orders" }
 
-grafel_inspect(label_or_id="mobile-app::OrderListScreen")
+grafel_inspect(entity="mobile-app::OrderListScreen")
 # → source_file: src/screens/OrderList.tsx, repo: mobile-app
 
-grafel_get_source(node_id="mobile-app::OrderListScreen", context_lines=10)
+grafel_get_source(entity="mobile-app::OrderListScreen", context_lines=10)
 # → line 22: fetch("/api/v1/orders")  ← old path
 ```
 
@@ -477,23 +473,23 @@ path which is now orphaned.
 **Tool sequence:**
 
 ```
-grafel_whoami()
-grafel_clusters()
+grafel_orient(view="me")
+grafel_orient(view="clusters")
 # → cluster 1: payments (top entities: PaymentGateway, ChargeService)
 # → cluster 4: reporting (top entities: MetricsDashboard, ReportingClient)
 
-grafel_inspect(label_or_id="PaymentGateway")
+grafel_inspect(entity="PaymentGateway")
 # → community_id: 1
 
-grafel_inspect(label_or_id="ReportingClient")
+grafel_inspect(entity="ReportingClient")
 # → community_id: 4
 
-grafel_trace(source="ReportingClient", target="PaymentGateway")
+grafel_find_paths(from="ReportingClient", to="PaymentGateway")
 # → found: true, path: [ReportingClient → ... → PaymentGateway]
 # → weakest_link_confidence: 0.92
 
 # Now check the reverse (new import direction)
-grafel_trace(source="PaymentGateway", target="ReportingClient")
+grafel_find_paths(from="PaymentGateway", to="ReportingClient")
 # → found: true (via the new import in this PR)
 # Together these confirm a cycle: payments ↔ reporting
 ```
@@ -527,11 +523,11 @@ grafel_cross_links(action="list", repo_filter=["admin-frontend"], limit=10)
 # → [{ candidate_id: "lc-a1b2c3", source: "admin-frontend::BillingWidget",
 #       target: "billing-api::??", status: "pending" }]
 
-grafel_inspect(label_or_id="billing-api::BillingSummaryHandler")
+grafel_inspect(entity="billing-api::BillingSummaryHandler")
 # → found, source_file: api/billing/views.py, community_id: 3
 
-grafel_trace(source="admin-frontend::BillingWidget",
-                 target="billing-api::BillingSummaryHandler")
+grafel_find_paths(from="admin-frontend::BillingWidget",
+                  to="billing-api::BillingSummaryHandler")
 # → found: true, crosses_repos: true, weakest_link_confidence: 0.70
 ```
 
@@ -559,17 +555,17 @@ but does not register it in `billing/api.py`.
 **Tool sequence:**
 
 ```
-grafel_find(question="serializer billing", depth=1)
+grafel_find(query="serializer billing")
 # → hits: [InvoiceSerializer, LineItemSerializer, InvoiceItemSerializer]
 
-grafel_expand(node="InvoiceSerializer", depth=1)
+grafel_related(entity="InvoiceSerializer", direction="neighbors")
 # → edges: [CALLS → validate, REGISTERED_IN → billing/api.py::BillingRouter]
 
-grafel_expand(node="InvoiceItemSerializer", depth=1)
+grafel_related(entity="InvoiceItemSerializer", direction="neighbors")
 # → edges: [CALLS → validate]
 # ← missing REGISTERED_IN edge
 
-grafel_list_findings(entity_id="InvoiceSerializer")
+grafel_findings(action="list", entity_id="InvoiceSerializer")
 # → finding: "All billing serializers must be registered in BillingRouter
 #              to be reachable from the API."
 ```
@@ -596,7 +592,8 @@ After completing a structural review, save any non-obvious decisions for
 future agents:
 
 ```
-grafel_save_finding(
+grafel_findings(
+  action="save",
   question="Why does payments cluster not import from reporting?",
   answer="Cycle prevention — see PR #<N>. Use core/instrumentation for
           shared metric-push. Enforced by cluster layering rule.",
@@ -606,7 +603,7 @@ grafel_save_finding(
 ```
 
 This takes ~50 tokens and means the next reviewer sees the rationale
-immediately via `grafel_inspect` without re-running the trace.
+immediately via `grafel_inspect` without re-running the path query.
 
 ---
 
@@ -631,7 +628,7 @@ immediately via `grafel_inspect` without re-running the trace.
 - ADR-0018 — Agent-learned pattern store.
 - ADR-0020 — Multi-branch + worktree graph snapshots. When reviewing a PR that
   is not yet merged, the branch's graph may already be indexed; use
-  `grafel_diff(ref_a="main", ref_b="feature/...")` to get a structural
+  `grafel_diff(left="main", right="feature/...", aspect="refs")` to get a structural
   summary before examining the line-level diff. See also
   [docs/user-guide/multi-branch.md](../../docs/user-guide/multi-branch.md).
 - Issue #1269 — tracking issue for this skill.

--- a/skills/grafel-business-docs/SKILL.md
+++ b/skills/grafel-business-docs/SKILL.md
@@ -17,11 +17,11 @@ This skill does **NOT** hard-depend on `/grafel-tech-docs` having been run. Ever
 
 ## CRITICAL TOOL DISCIPLINE
 
-For ANY structural question about the codebase, use grafel MCP tools: `grafel_whoami`, `grafel_find`, `grafel_inspect`, `grafel_expand`, `grafel_traces`, `grafel_clusters`, `grafel_stats`. Do NOT grep or read source files for entity discovery.
+For ANY structural question about the codebase, use grafel MCP tools: `grafel_orient (view=me)`, `grafel_find`, `grafel_inspect`, `grafel_subgraph`, `grafel_trace`, `grafel_orient (view=clusters)`, `grafel_orient (view=overview)`. Do NOT grep or read source files for entity discovery.
 
 ### Pre-flight assertion
 
-Call `grafel_whoami` before doing anything. If it errors: ABORT with "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/grafel-business-docs`."
+Call `grafel_orient (view=me)` before doing anything. If it errors: ABORT with "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/grafel-business-docs`."
 
 ## When to use this skill
 
@@ -40,9 +40,9 @@ Every business pass reads `snippets/business-voice.md` first (if present). The c
 ## Staging-dir + atomic promote architecture
 
 Same pattern as `/grafel-tech-docs`:
-1. Pass 15 (first pass) calls `grafel_docgen_start_run(group="<group>")` → receives `run_id` and `staging_path`.
+1. Pass 15 (first pass) calls `grafel_docgen(action="start", group="<group>")` → receives `run_id` and `staging_path`.
 2. Passes 15–19 write all files into `<staging_path>/<relative-path>`.
-3. Pass 19 (last pass) calls `grafel_docgen_validate(run_id)` then `grafel_docgen_promote(run_id)`.
+3. Pass 19 (last pass) calls `grafel_docgen(action="validate", run_id)` then `grafel_docgen(action="promote", run_id)`.
 
 ## Pass chain
 
@@ -77,12 +77,12 @@ The business tier is **not per-repo**. It is synthesised across every repo in th
 
 ## grafel MCP tool surface
 
-- `grafel_whoami` — group/repo resolution.
-- `grafel_find`, `grafel_inspect`, `grafel_expand` — entity navigation.
-- `grafel_traces`, `grafel_clusters` — flow and cluster navigation.
-- `grafel_enrichments` — read enriched frontmatter for endpoint/flow summaries.
-- `grafel_save_finding` — persist domain interview answers.
-- `grafel_docgen_start_run`, `grafel_docgen_validate`, `grafel_docgen_promote` — staging lifecycle.
+- `grafel_orient (view=me)` — group/repo resolution.
+- `grafel_find`, `grafel_inspect`, `grafel_subgraph` — entity navigation.
+- `grafel_trace`, `grafel_orient (view=clusters)` — flow and cluster navigation.
+- `grafel_docgen_apply (kind=enrichments)` — read enriched frontmatter for endpoint/flow summaries.
+- `grafel_findings (action=save)` — persist domain interview answers.
+- `grafel_docgen (action=start)`, `grafel_docgen (action=validate)`, `grafel_docgen (action=promote)` — staging lifecycle.
 
 ## Related
 

--- a/skills/grafel-business-docs/prompts/15-business-domain.md
+++ b/skills/grafel-business-docs/prompts/15-business-domain.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -141,11 +141,9 @@ Use `source: "generate-docs/pass-15"` in all candidates. Append to
 Run `snippets/verification-checklist.md` (business-voice section applies).
 
 ```
-grafel_save_finding(
-  question="What is the business domain glossary for the <group> group?",
+grafel_findings(action="save", question="What is the business domain glossary for the <group> group?",
   answer="<file: ~/.grafel/docs/<group>/business/domain-glossary.md>",
-  type="business_domain",
-)
+  type="business_domain",)
 ```
 
 Hand back to the orchestrator. Pass 16 (capabilities) and Pass 17 (journeys)

--- a/skills/grafel-business-docs/prompts/16-business-capabilities.md
+++ b/skills/grafel-business-docs/prompts/16-business-capabilities.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -63,12 +63,12 @@ kebab-case business name (e.g. `schedule-inspection`, `submit-report`,
 
 ```
 grafel_endpoints(repo_filter=null, limit=500)        # what the product exposes
-grafel_flows(repo_filter=null, limit=200)            # process flows / call chains
+grafel_trace(repo_filter=null, limit=200)            # process flows / call chains
 grafel_find(question="scheduled jobs and background processing", repo_filter=null, depth=2, token_budget=1000)
 grafel_find(question="message topics and events the system emits", repo_filter=null, depth=2, token_budget=1000)
 ```
 
-If `grafel_endpoints` / `grafel_flows` are unavailable, fall back to
+If `grafel_endpoints` / `grafel_trace` are unavailable, fall back to
 reading the technical-tier `reference/api.md` and module `flows.md`.
 
 ### Step 2 — Cluster into capabilities
@@ -99,7 +99,7 @@ references only in the collapsed `<details>` block.
 ### Step 5 — Emit repair candidates
 
 Run the emission step from `snippets/docgen-repair-emission.md`. This pass
-calls `grafel_endpoints` and `grafel_flows`, which surfaces concrete
+calls `grafel_endpoints` and `grafel_trace`, which surfaces concrete
 entity data. The expected repair types are:
 
 - **`merge_flow`** — Step 2's clustering often reveals two process-flow or
@@ -115,7 +115,7 @@ entity data. The expected repair types are:
     "source_entity_id": "<checkout_legacy_flow entity id>",
     "target": "<checkout_flow entity id>",
     "confidence": 0.78,
-    "evidence": "grafel_flows result: checkout_legacy_flow and checkout_flow both terminate at OrderConfirmed — same business outcome, merged into capability 'conduct-checkout'",
+    "evidence": "grafel_trace result: checkout_legacy_flow and checkout_flow both terminate at OrderConfirmed — same business outcome, merged into capability 'conduct-checkout'",
     "source": "generate-docs/pass-16",
     "emitted_at": "<ISO 8601 timestamp>"
   }
@@ -125,8 +125,8 @@ entity data. The expected repair types are:
   catalogued as `Function` but are clearly HTTP endpoints (they have a route
   path and method). Emit a `fix_kind` if you observe this.
 
-Only emit when `grafel_endpoints` / `grafel_flows` data or a direct
-`grafel_expand` result provides concrete evidence. Business-layer
+Only emit when `grafel_endpoints` / `grafel_trace` data or a direct
+`grafel_subgraph` result provides concrete evidence. Business-layer
 clustering reasoning alone does not reach the 0.5 threshold.
 
 Use `source: "generate-docs/pass-16"` in all candidates. Append to
@@ -137,11 +137,9 @@ Use `source: "generate-docs/pass-16"` in all candidates. Append to
 Run `snippets/verification-checklist.md`. Then once, for the capability set:
 
 ```
-grafel_save_finding(
-  question="What product capabilities does the <group> group provide?",
+grafel_findings(action="save", question="What product capabilities does the <group> group provide?",
   answer="<files: ~/.grafel/docs/<group>/business/capabilities/*.md>",
-  type="business_capabilities",
-)
+  type="business_capabilities",)
 ```
 
 Hand back. Pass 19 (business overview) will index every capability page you

--- a/skills/grafel-business-docs/prompts/17-business-journeys.md
+++ b/skills/grafel-business-docs/prompts/17-business-journeys.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -69,8 +69,8 @@ kebab-case (e.g. `field-inspection-day`, `customer-places-order`,
 A journey is a goal a real user accomplishes, end to end. Find them from:
 
 ```
-grafel_flows(repo_filter=null, limit=200)
-grafel_traces(action=list, repo_filter=null, limit=50)
+grafel_trace(repo_filter=null, limit=200)
+grafel_trace(action=list, repo_filter=null, limit=50)
 grafel_cross_links(action=list, limit=200)   # cross-repo legs of a journey
 ```
 
@@ -102,14 +102,14 @@ file paths ONLY in the collapsed `<details>` block.
 ### Step 5 — Emit repair candidates
 
 Run the emission step from `snippets/docgen-repair-emission.md`. This pass
-calls `grafel_flows`, `grafel_traces`, and `grafel_cross_links`.
+calls `grafel_trace`, `grafel_trace`, and `grafel_cross_links`.
 The expected repair types here are narrow:
 
 - **`merge_flow`** — Step 1 may reveal two flow entities returned by
-  `grafel_flows` that represent legs of the same end-to-end journey (e.g.
+  `grafel_trace` that represent legs of the same end-to-end journey (e.g.
   `sync_to_office_flow` and `offline_sync_flow` are the same flow triggered
   from two contexts). Emit a `merge_flow` only when the evidence from
-  `grafel_traces` or `grafel_cross_links` makes the identity
+  `grafel_trace` or `grafel_cross_links` makes the identity
   unambiguous (confidence ≥ 0.75).
 
   Example:
@@ -120,7 +120,7 @@ The expected repair types here are narrow:
     "source_entity_id": "<offline_sync_flow entity id>",
     "target": "<sync_to_office_flow entity id>",
     "confidence": 0.76,
-    "evidence": "grafel_traces result: offline_sync_flow and sync_to_office_flow share identical call chain terminating at SyncService.commit — same business journey, different connectivity contexts",
+    "evidence": "grafel_trace result: offline_sync_flow and sync_to_office_flow share identical call chain terminating at SyncService.commit — same business journey, different connectivity contexts",
     "source": "generate-docs/pass-17",
     "emitted_at": "<ISO 8601 timestamp>"
   }
@@ -137,11 +137,9 @@ Use `source: "generate-docs/pass-17"` in all candidates. Append to
 Run `snippets/verification-checklist.md`. Then:
 
 ```
-grafel_save_finding(
-  question="What are the business user journeys for the <group> group?",
+grafel_findings(action="save", question="What are the business user journeys for the <group> group?",
   answer="<files: ~/.grafel/docs/<group>/business/journeys/*.md>",
-  type="business_journeys",
-)
+  type="business_journeys",)
 ```
 
 Hand back; report the list of journey slugs for Pass 19's index.

--- a/skills/grafel-business-docs/prompts/18-business-rules.md
+++ b/skills/grafel-business-docs/prompts/18-business-rules.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -137,11 +137,9 @@ Use `source: "generate-docs/pass-18"` in all candidates. Append to
 Run `snippets/verification-checklist.md`. Then:
 
 ```
-grafel_save_finding(
-  question="What business rules does the <group> group enforce?",
+grafel_findings(action="save", question="What business rules does the <group> group enforce?",
   answer="<file: ~/.grafel/docs/<group>/business/rules/index.md>",
-  type="business_rules",
-)
+  type="business_rules",)
 ```
 
 Hand back to the orchestrator.

--- a/skills/grafel-business-docs/prompts/19-business-overview.md
+++ b/skills/grafel-business-docs/prompts/19-business-overview.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -88,11 +88,9 @@ confirm every link from `overview.md` resolves to a file that exists under
 `business/`.
 
 ```
-grafel_save_finding(
-  question="What is the business overview of the <group> group?",
+grafel_findings(action="save", question="What is the business overview of the <group> group?",
   answer="<file: ~/.grafel/docs/<group>/business/overview.md>",
-  type="business_overview",
-)
+  type="business_overview",)
 ```
 
 Hand back to the orchestrator. The business tier is complete:

--- a/skills/grafel-business-docs/snippets/docgen-repair-emission.md
+++ b/skills/grafel-business-docs/snippets/docgen-repair-emission.md
@@ -39,7 +39,7 @@ After the doc is written (AFTER — do not interrupt prose generation):
    ~/.grafel/groups/<group>/docgen-repairs.jsonl
    ```
 
-   To obtain the exact path, call `grafel_apply_docgen_repairs` with no
+   To obtain the exact path, call `grafel_docgen_apply (kind=repairs)` with no
    parameters and read the `state_dir` field, or use the path recorded in
    `docgen-state.json`.
 
@@ -207,7 +207,7 @@ business workflow, distinguished only by an A/B flag at entry. Emission:
 - Never emit below confidence 0.5. If you are not sure, use the Pass 3a
   "Runtime-resolved edge" callout in prose instead.
 - Emission is additive: if the same repair was already submitted by Pass 1a or
-  Pass 3a via `grafel_repairs(action=submit)`, the daemon deduplicates; you
+  Pass 3a via `grafel_docgen_apply(kind="repairs", action=submit)`, the daemon deduplicates; you
   may still emit it here — the duplicate will be silently dropped.
 - The JSONL file may already contain entries from a prior pass or a prior run;
   always append, never overwrite.

--- a/skills/grafel-business-docs/snippets/link-hygiene.md
+++ b/skills/grafel-business-docs/snippets/link-hygiene.md
@@ -47,7 +47,7 @@ The registry slug (`upvate-core`, hyphenated) and the on-disk directory
 `upvate_core`).
 
 - **Relative link paths** (`../../<dir>/docs/...`) MUST use the actual
-  filesystem directory name. Resolve it from `grafel_whoami` /
+  filesystem directory name. Resolve it from `grafel_orient (view=me)` /
   `inventory.json` `repo.path` (the last path segment), not from the slug.
 - **Prose / display text** may use the human slug.
 

--- a/skills/grafel-consult/SKILL.md
+++ b/skills/grafel-consult/SKILL.md
@@ -24,7 +24,7 @@ If tech docs are missing, the skill aborts:
 
 ## CRITICAL TOOL DISCIPLINE
 
-The active persona MUST use grafel MCP tools for ALL graph navigation. Pre-flight: call `grafel_whoami` first.
+The active persona MUST use grafel MCP tools for ALL graph navigation. Pre-flight: call `grafel_orient (view=me)` first.
 
 ## When to use this skill
 
@@ -143,7 +143,7 @@ The session directory `~/.grafel/sessions/` is created if it does not exist (use
 
 ### Pre-flight (once per invocation)
 
-1. Call `grafel_whoami` — confirm group.
+1. Call `grafel_orient (view=me)` — confirm group.
 2. Verify tech docs exist at `~/.grafel/docs/<group>/modules/`. If not, abort with the message above.
 3. Scan `skills/grafel-consult/personas/*.md` + `~/.claude/agents/grafel-*.md` to build the catalog.
 4. If `--list` / `--catalog`: print the catalog (name + one-line description from frontmatter) and exit.
@@ -218,12 +218,10 @@ Cap Consult-Outs at 2 per conversation to prevent panel sprawl. Beyond that, sug
 If the user explicitly asks ("save this finding to the graph"), the active persona calls:
 
 ```
-grafel_save_finding(
-  type="consultant_finding",
+grafel_findings(action="save", type="consultant_finding",
   question="<persona>: <finding_title>",
   answer="<explanation>",
-  entity_id="<entity_id if applicable>"
-)
+  entity_id="<entity_id if applicable>")
 ```
 
 The skill does NOT auto-save. v1/v2's `confidence >= 0.7` auto-save behaviour is retired.
@@ -243,9 +241,9 @@ This is not as robust as Claude Code's true subagent isolation. The known failur
 
 ## grafel MCP tool surface
 
-All personas use: `grafel_whoami`, `grafel_find`, `grafel_inspect`, `grafel_expand`, `grafel_traces`, `grafel_clusters`, `grafel_stats`.
+All personas use: `grafel_orient (view=me)`, `grafel_find`, `grafel_inspect`, `grafel_subgraph`, `grafel_trace`, `grafel_orient (view=clusters)`, `grafel_orient (view=overview)`.
 
-User-opt-in: `grafel_save_finding`, `grafel_list_findings`.
+User-opt-in: `grafel_findings (action=save)`, `grafel_findings (action=list)`.
 
 Cross-repo: `grafel_cross_links`.
 

--- a/skills/grafel-consult/personas/api-designer.md
+++ b/skills/grafel-consult/personas/api-designer.md
@@ -67,7 +67,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -76,16 +76,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="api-designer", event_type="invoke")
+grafel_event(kind="persona", persona="api-designer", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="api-designer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="api-designer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/architect.md
+++ b/skills/grafel-consult/personas/architect.md
@@ -23,7 +23,7 @@ Follow `grafel-graph-read` (status → inspect → expand). Stop reading when th
 When a user question touches structural concerns, run these angles through your head. Cite at least one entity ID or graph path per claim. If the evidence is missing, say so explicitly to the user rather than speculating — do not silently fill the gap.
 
 1. **Layering violations**: Are there calls from a lower-layer module (e.g. data/persistence) directly into a higher-layer module (e.g. presentation/HTTP handler) that bypass the expected service layer? List the violating edges.
-2. **Circular dependencies**: Does `grafel_expand` reveal any import/dependency cycles between modules? List cycles by module pair.
+2. **Circular dependencies**: Does `grafel_subgraph` reveal any import/dependency cycles between modules? List cycles by module pair.
 3. **God modules**: Which modules have the highest combined fan-in + fan-out? Do their names match what they actually own (check entity names vs module doc)? List the top-3 god-module candidates.
 4. **Boundary violations**: Are there entities in one community that are called predominantly by entities in a different community? This signals a module that belongs elsewhere.
 5. **Cross-boundary call volume**: What fraction of all edges cross community boundaries? High fraction (> 40%) signals over-coupling.
@@ -65,7 +65,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -74,16 +74,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="architect", event_type="invoke")
+grafel_event(kind="persona", persona="architect", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="architect", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="architect", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/business-analyst.md
+++ b/skills/grafel-consult/personas/business-analyst.md
@@ -66,7 +66,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -75,16 +75,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="business-analyst", event_type="invoke")
+grafel_event(kind="persona", persona="business-analyst", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="business-analyst", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="business-analyst", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/compliance-officer.md
+++ b/skills/grafel-consult/personas/compliance-officer.md
@@ -38,11 +38,11 @@ You are an **interactive consultant**: you answer the user's questions in conver
 
 Complete all steps in order before beginning analysis.
 
-1. Call `grafel_whoami` — confirm group name and which repos are indexed.
+1. Call `grafel_orient (view=me)` — confirm group name and which repos are indexed.
 2. Call `grafel_find` with query `ssn` — enumerate model fields or entities referencing social security numbers or equivalent.
 3. Call `grafel_find` for each of: `dob`, `date_of_birth`, `email`, `card_number`, `credit_card`, `phone`, `address`, `passport`, `tax_id`, `national_id` — build a candidate PII field list. Note: many matches will be false positives.
 4. For each entity in the candidate list: call `grafel_inspect` — determine which model/class it belongs to, and whether it has any field-level annotations suggesting intentional handling (e.g. encrypted, hashed, masked).
-5. Call `grafel_expand` direction `downstream` from flagged entities — trace which endpoints or services read or write these fields. Look for `READS_FIELD` and `WRITES_FIELD` edges; if absent in graph, note that field-level tracing is limited.
+5. Call `grafel_subgraph` direction `downstream` from flagged entities — trace which endpoints or services read or write these fields. Look for `READS_FIELD` and `WRITES_FIELD` edges; if absent in graph, note that field-level tracing is limited.
 6. Call `grafel_find` with query `audit_log` or `audit_trail` or `audit_event` — identify whether an audit-log write mechanism exists. If it does: for each sensitive-field-touching endpoint from step 5, check whether an audit-log write appears in its call chain.
 7. Call `grafel_find` with query `encrypt` or `hash` or `mask` — identify whether field-level encryption/hashing utilities exist and which fields they're applied to.
 8. Read `~/.grafel/docs/<group>/modules/` — read overview docs for modules owning the flagged models.
@@ -95,7 +95,7 @@ Respond to the user's question in whatever shape best serves it. There is no fix
 
 You MUST rate every finding by confidence and include a human-verification step. Do not assert compliance status — only surface candidates.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -103,20 +103,20 @@ The session ends when the user releases you (`/grafel-consult --release`) or swi
 
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.grafel/groups/<group>/findings/compliance-officer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
-You may also use `grafel_save_finding` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
+You may also use `grafel_findings (action=save)` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="compliance-officer", event_type="invoke")
+grafel_event(kind="persona", persona="compliance-officer", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="compliance-officer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="compliance-officer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/data-engineer.md
+++ b/skills/grafel-consult/personas/data-engineer.md
@@ -65,7 +65,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -74,16 +74,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="data-engineer", event_type="invoke")
+grafel_event(kind="persona", persona="data-engineer", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="data-engineer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="data-engineer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/devops-reviewer.md
+++ b/skills/grafel-consult/personas/devops-reviewer.md
@@ -32,8 +32,8 @@ You are an **interactive consultant**: you answer the user's questions in conver
 
 Complete all steps in order before beginning analysis.
 
-1. Call `grafel_whoami` — confirm group name and which repos are indexed.
-2. Call `grafel_status` — note overall graph health and which file types were indexed.
+1. Call `grafel_orient (view=me)` — confirm group name and which repos are indexed.
+2. Call `grafel_orient (view=overview)` — note overall graph health and which file types were indexed.
 3. Call `grafel_find` with query `workflow` — enumerate CI workflow files the graph knows about (`.github/workflows/*.yml`, `.gitlab-ci.yml`, etc.).
 4. For each workflow file found: call `grafel_inspect` on the entity — read job structure, trigger conditions, environment variable references, and any `uses:` action references.
 5. Call `grafel_find` with query `Makefile` or `build` — identify build entry points. Note any that reference infrastructure commands (docker build, terraform, kubectl).
@@ -84,7 +84,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full CI audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -92,20 +92,20 @@ The session ends when the user releases you (`/grafel-consult --release`) or swi
 
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.grafel/groups/<group>/findings/devops-reviewer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
-You may also use `grafel_save_finding` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
+You may also use `grafel_findings (action=save)` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="devops-reviewer", event_type="invoke")
+grafel_event(kind="persona", persona="devops-reviewer", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="devops-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="devops-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/dx-engineer.md
+++ b/skills/grafel-consult/personas/dx-engineer.md
@@ -18,7 +18,7 @@ This persona was built without its original gate met (DX hypothesis testing). Re
 
 - **(a) Inconsistent test setup across modules** — modules that have tests vs modules that don't, visible via `TESTS` edges
 - **(b) Modules without any tests** — zero `TESTS`-edge coverage
-- **(c) Circular imports that hurt onboarding** — import cycles detected via `grafel_expand`, which increase cognitive load for new contributors
+- **(c) Circular imports that hurt onboarding** — import cycles detected via `grafel_subgraph`, which increase cognitive load for new contributors
 - **(d) Very large entry-point functions** — high fan-out from a single entity suggests poor decomposition that makes the codebase hard to navigate
 
 **What this persona CANNOT deliver in current state:**
@@ -40,12 +40,12 @@ You are an **interactive consultant**: you answer the user's questions in conver
 
 Complete all steps in order before beginning analysis.
 
-1. Call `grafel_whoami` — confirm group name and which repos are indexed.
-2. Call `grafel_status` — note entity count and whether test entities are indexed (look for TESTS edge count > 0).
-3. Call `grafel_clusters` — get the Louvain community partition. Note the module list; this is the scope for per-module DX analysis.
-4. For each module/community: call `grafel_expand` with direction `both` and edge type `TESTS` — enumerate which entities in each module have test coverage. Build a per-module coverage map: covered entities / total entities. Flag modules with 0% coverage and modules significantly below the group median.
-5. Call `grafel_expand` with direction `both` and edge type `IMPORTS`, depth 3, on the top-5 highest fan-in modules — detect circular import chains. A cycle in the import graph means a new contributor cannot understand module A without also understanding module B (and vice versa).
-6. Call `grafel_stats` — identify the top-10 highest fan-out entities (the entities that call the most things). Very high fan-out from a single function/class suggests it is an undifferentiated entry point that should be decomposed.
+1. Call `grafel_orient (view=me)` — confirm group name and which repos are indexed.
+2. Call `grafel_orient (view=overview)` — note entity count and whether test entities are indexed (look for TESTS edge count > 0).
+3. Call `grafel_orient (view=clusters)` — get the Louvain community partition. Note the module list; this is the scope for per-module DX analysis.
+4. For each module/community: call `grafel_subgraph` with direction `both` and edge type `TESTS` — enumerate which entities in each module have test coverage. Build a per-module coverage map: covered entities / total entities. Flag modules with 0% coverage and modules significantly below the group median.
+5. Call `grafel_subgraph` with direction `both` and edge type `IMPORTS`, depth 3, on the top-5 highest fan-in modules — detect circular import chains. A cycle in the import graph means a new contributor cannot understand module A without also understanding module B (and vice versa).
+6. Call `grafel_orient (view=overview)` — identify the top-10 highest fan-out entities (the entities that call the most things). Very high fan-out from a single function/class suggests it is an undifferentiated entry point that should be decomposed.
 7. Call `grafel_find` with query `__init__` or `main` or `index` or `app` or `router` — identify primary entry points. Call `grafel_inspect` on the top-3 largest by fan-out to assess their decomposition state.
 8. Read `~/.grafel/docs/<group>/modules/` — scan module overview docs for any that mention onboarding, setup, or known complexity.
 
@@ -93,7 +93,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full DX audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -101,20 +101,20 @@ The session ends when the user releases you (`/grafel-consult --release`) or swi
 
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.grafel/groups/<group>/findings/dx-engineer-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
-You may also use `grafel_save_finding` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
+You may also use `grafel_findings (action=save)` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="dx-engineer", event_type="invoke")
+grafel_event(kind="persona", persona="dx-engineer", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="dx-engineer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="dx-engineer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/performance-reviewer.md
+++ b/skills/grafel-consult/personas/performance-reviewer.md
@@ -64,7 +64,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -73,16 +73,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="performance-reviewer", event_type="invoke")
+grafel_event(kind="persona", persona="performance-reviewer", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="performance-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="performance-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/qa-reviewer.md
+++ b/skills/grafel-consult/personas/qa-reviewer.md
@@ -66,7 +66,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -75,16 +75,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="qa-reviewer", event_type="invoke")
+grafel_event(kind="persona", persona="qa-reviewer", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="qa-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="qa-reviewer", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/refactor-critic.md
+++ b/skills/grafel-consult/personas/refactor-critic.md
@@ -36,7 +36,7 @@ Prioritize findings by estimated maintainability impact (high complexity + wide 
 You respond to the user in whatever shape best serves the question. Your toolkit for this domain:
 
 - **Hotspot table** — entity, complexity proxy (fan-in × fan-out), test coverage, age.
-- **Dead-code list** — entity_id, zero-caller evidence from `grafel_expand`.
+- **Dead-code list** — entity_id, zero-caller evidence from `grafel_subgraph`.
 - **Duplication clusters** — groups of entities with similar call patterns.
 - **Long-chain diagram (ASCII)** — call depth visualised.
 - **Refactor sketch (code sample)** — a small, concrete worked example of an extraction.
@@ -65,7 +65,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -74,16 +74,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="refactor-critic", event_type="invoke")
+grafel_event(kind="persona", persona="refactor-critic", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="refactor-critic", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="refactor-critic", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/security-auditor.md
+++ b/skills/grafel-consult/personas/security-auditor.md
@@ -65,7 +65,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -74,16 +74,16 @@ Follow `grafel-graph-write` (explicit request only — never auto-save).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="security-auditor", event_type="invoke")
+grafel_event(kind="persona", persona="security-auditor", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="security-auditor", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="security-auditor", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-consult/personas/solutions-architect.md
+++ b/skills/grafel-consult/personas/solutions-architect.md
@@ -15,7 +15,7 @@ model: opus
 
 This persona was built without its original gate met (cross_links coverage validation). Read this section before hiring.
 
-**Signal quality depends on your group composition.** This persona depends on `cross_links` data being populated. If your group has multiple repos indexed AND HTTP/Kafka/WebSocket clients have been traced between them, this persona will surface meaningful cross-service findings. If you are inspecting a single-repo group, this persona will have substantially less to say than `architect` — prefer `architect` in that case. If your group is multi-repo but cross-links are sparse (because HTTP client calls have not been resolved to destinations), findings will be incomplete. Use `grafel_status` at step 1 to confirm cross-links count before proceeding.
+**Signal quality depends on your group composition.** This persona depends on `cross_links` data being populated. If your group has multiple repos indexed AND HTTP/Kafka/WebSocket clients have been traced between them, this persona will surface meaningful cross-service findings. If you are inspecting a single-repo group, this persona will have substantially less to say than `architect` — prefer `architect` in that case. If your group is multi-repo but cross-links are sparse (because HTTP client calls have not been resolved to destinations), findings will be incomplete. Use `grafel_orient (view=overview)` at step 1 to confirm cross-links count before proceeding.
 
 **What this persona CAN deliver in current state:** cross-service call inventory, bidirectional dependency flags, blast-radius estimates based on available link data.
 
@@ -31,16 +31,16 @@ You are an **interactive consultant**: you answer the user's questions in conver
 
 Complete all steps in order before beginning analysis.
 
-1. Call `grafel_whoami` — confirm group name, which repos are indexed, and how many cross-links exist. **If cross-links count is 0 and group has only 1 repo**, warn the user that signal will be very limited and suggest `architect` instead.
-2. Call `grafel_status` — note overall graph health and whether cross-link resolution has run.
+1. Call `grafel_orient (view=me)` — confirm group name, which repos are indexed, and how many cross-links exist. **If cross-links count is 0 and group has only 1 repo**, warn the user that signal will be very limited and suggest `architect` instead.
+2. Call `grafel_orient (view=overview)` — note overall graph health and whether cross-link resolution has run.
 3. Call `grafel_cross_links` — enumerate all inter-repo HTTP, Kafka, and WebSocket links. For each link: source repo, target repo, link type (HTTP/Kafka/WS), and any latency/contract metadata if available.
 4. Build a directed service dependency graph from the cross-links: node per repo, edge per link type. Identify:
    - Bidirectional dependencies (A → B and B → A) — flag these as coupling candidates.
    - Services with the highest in-degree (most depended-upon) — flag as critical-path services.
    - Services with zero in-degree — flag as leaf services (low blast-radius concerns).
-5. Call `grafel_expand` direction `both` on the top-3 highest-in-degree entities from step 4, depth 2 — trace the import/call surfaces around the most critical cross-service touch points.
-6. Call `grafel_clusters` — note inter-community edge ratios; high ratios may indicate intra-repo modules that should be separate services (extraction candidates).
-7. Call `grafel_traces` starting from HTTP entry points in each repo — identify any trace that crosses 2+ service boundaries (multi-hop flows). Flag flows where a failure mid-chain would cascade silently.
+5. Call `grafel_subgraph` direction `both` on the top-3 highest-in-degree entities from step 4, depth 2 — trace the import/call surfaces around the most critical cross-service touch points.
+6. Call `grafel_orient (view=clusters)` — note inter-community edge ratios; high ratios may indicate intra-repo modules that should be separate services (extraction candidates).
+7. Call `grafel_trace` starting from HTTP entry points in each repo — identify any trace that crosses 2+ service boundaries (multi-hop flows). Flag flows where a failure mid-chain would cascade silently.
 8. Read `~/.grafel/docs/<group>/modules/` — scan overview docs for the top-3 critical-path services identified in step 4.
 
 ## ANALYSIS lens
@@ -91,7 +91,7 @@ Always include the entity_ids under discussion, the user's original question (ve
 
 Respond to the user's question in whatever shape best serves it. There is no fixed report template — you are an interactive consultant, not a report generator. If the user asks a narrow question, answer that narrow question; do not deliver an unsolicited full system audit. If the user asks for a broad review, broaden — using the ANALYSIS lens above as a checklist of angles to consider.
 
-You may save findings to the graph via `grafel_save_finding` only when the user explicitly asks ("save this finding"). Do not auto-save.
+You may save findings to the graph via `grafel_findings (action=save)` only when the user explicitly asks ("save this finding"). Do not auto-save.
 
 The session ends when the user releases you (`/grafel-consult --release`) or switches consultants (`/grafel-consult --switch <name>`). There is no fixed STOP criterion.
 
@@ -99,20 +99,20 @@ The session ends when the user releases you (`/grafel-consult --release`) or swi
 
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.grafel/groups/<group>/findings/solutions-architect-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
-You may also use `grafel_save_finding` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
+You may also use `grafel_findings (action=save)` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
 
 ## Lifecycle telemetry
 
-Call `grafel_persona_event` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
+Call `grafel_event (kind=persona)` at two lifecycle points. This is LOCAL ONLY — no remote data leaves the machine.
 
 **On session start** (immediately after the user hires you):
 ```
-grafel_persona_event(persona="solutions-architect", event_type="invoke")
+grafel_event(kind="persona", persona="solutions-architect", event_type="invoke")
 ```
 
 **On each Consult-Out** (when proposing to bring in a peer and the user says yes):
 ```
-grafel_persona_event(persona="solutions-architect", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
+grafel_event(kind="persona", persona="solutions-architect", event_type="consult_out", target_persona="<peer-name>", depth=<current-depth>, chain=[<chain-list>])
 ```
 
 Do not call this tool at any other point. Telemetry failures (tool returns `recorded=false`) are silent — continue the session normally.

--- a/skills/grafel-graph-enrich/SKILL.md
+++ b/skills/grafel-graph-enrich/SKILL.md
@@ -26,13 +26,13 @@ Do **not** invoke it for prose documentation (that is `/grafel-tech-docs`). Do n
 
 ## Inputs the skill expects
 
-- A running grafel daemon (`grafel_whoami` must succeed).
-- A registered, indexed group with enrichment candidates in the queue (`grafel_enrichments(action=list, status="pending")` returns results).
+- A running grafel daemon (`grafel_orient (view=me)` must succeed).
+- A registered, indexed group with enrichment candidates in the queue (`grafel_docgen_apply(kind="enrichments", action=list, status="pending")` returns results).
 - Optional: `--delta-only` flag — process only entities with `status="pending"` that are newly added since the last run (the default behaviour; the flag makes it explicit).
 - Optional: `--yes` flag — skip the cost-estimate confirmation prompt (for automation).
 - Optional: `--group <name>` — override group when CWD is ambiguous.
 
-If `grafel_enrichments(action=list, status="pending")` returns zero results, the skill exits with "No pending enrichment candidates. Nothing to do." (success).
+If `grafel_docgen_apply(kind="enrichments", action=list, status="pending")` returns zero results, the skill exits with "No pending enrichment candidates. Nothing to do." (success).
 
 ## Cost and model selection
 
@@ -49,7 +49,7 @@ Typical cost for a 5,800-entity group: **$5–$15** total. A 1,000-entity group:
 
 ## Idempotency and delta mode
 
-Phase 1 always begins by fetching `grafel_enrichments(action=list, status="enriched")` and excluding those entity IDs from all batches. This makes the skill safe to restart after any failure without re-enriching or incurring duplicate LLM costs.
+Phase 1 always begins by fetching `grafel_docgen_apply(kind="enrichments", action=list, status="enriched")` and excluding those entity IDs from all batches. This makes the skill safe to restart after any failure without re-enriching or incurring duplicate LLM costs.
 
 State is persisted at `~/.grafel/groups/<group>/grafel-graph-enrich/state.json`:
 
@@ -64,16 +64,16 @@ State is persisted at `~/.grafel/groups/<group>/grafel-graph-enrich/state.json`:
 ## Procedure
 
 ### Pre-flight
-Call `grafel_whoami`. If it errors: abort with "grafel MCP not configured for this directory. Run `/mcp` to fix."
+Call `grafel_orient (view=me)`. If it errors: abort with "grafel MCP not configured for this directory. Run `/mcp` to fix."
 
 ### Phase 1 — Enrichment
 Follow the full procedure in `prompts/13-enrichment.md`. Key steps:
 1. Resume check: fetch already-enriched IDs (skip them).
 2. Collect all pending candidates (three kinds: `http_endpoint`, `process_flow`, `message_topic`).
-3. Build entity stubs with `grafel_expand(node=<id>, depth=2)` for neighbour context.
+3. Build entity stubs with `grafel_subgraph(node=<id>, depth=2)` for neighbour context.
 4. Partition by `criticality_band` → Sonnet vs Haiku batches.
 5. Print cost estimate; gate on user confirmation (or `--yes`).
-6. Dispatch batches, write YAML frontmatter to doc files, call `grafel_enrichments(action=submit)`.
+6. Dispatch batches, write YAML frontmatter to doc files, call `grafel_docgen_apply(kind="enrichments", action=submit)`.
 7. Run verification checklist on a sample of ≥10 entities per tier.
 
 ### Phase 2 — Validation
@@ -85,10 +85,10 @@ End with:
 
 ## grafel MCP tool surface
 
-- `grafel_whoami` — group/repo resolution.
-- `grafel_enrichments` — primary tool (`action=list|submit|reject`).
-- `grafel_expand` — depth-2 neighbour context for entity stubs.
-- `grafel_save_finding` — persist the Phase 2 validation report.
+- `grafel_orient (view=me)` — group/repo resolution.
+- `grafel_docgen_apply (kind=enrichments)` — primary tool (`action=list|submit|reject`).
+- `grafel_subgraph` — depth-2 neighbour context for entity stubs.
+- `grafel_findings (action=save)` — persist the Phase 2 validation report.
 
 ## Output layout
 

--- a/skills/grafel-graph-enrich/prompts/13-enrichment.md
+++ b/skills/grafel-graph-enrich/prompts/13-enrichment.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -48,7 +48,7 @@ badges, rank scores, gap warnings, and disqualification signals.
 
 - Group inventory already produced in Passes 1–2.
 - Existing doc files under `~/.grafel/docs/<group>/<repo-slug>/` (Pass 4–6 output) — enrich in-place.
-- `grafel_enrichments(action=list)` — pre-computed enrichment candidates
+- `grafel_docgen_apply(kind="enrichments", action=list)` — pre-computed enrichment candidates
   from the daemon; use as signals, not as verbatim output.
 - Per-kind templates at `skills/generate-docs/templates/<kind>.md` — use as
   starting point when creating new files.
@@ -68,9 +68,9 @@ Build a working list of entity IDs grouped by kind.
 ### Step 2 — Enrichment candidates queue
 
 ```
-grafel_enrichments(action=list, kind="http_endpoint")
-grafel_enrichments(action=list, kind="process_flow")
-grafel_enrichments(action=list, kind="message_topic")
+grafel_docgen_apply(kind="enrichments", action=list, entity_kind="http_endpoint")
+grafel_docgen_apply(kind="enrichments", action=list, entity_kind="process_flow")
+grafel_docgen_apply(kind="enrichments", action=list, entity_kind="message_topic")
 ```
 
 Merge candidates into your working list; they carry pre-computed signals
@@ -84,7 +84,7 @@ For each entity in the working list:
    inbound FETCHES:
 
    ```
-   grafel_expand(node="<entity_id>", depth=2)
+   grafel_subgraph(node="<entity_id>", depth=2)
    ```
 
 2. **Decide merge / disqualify** — if two entities are near-duplicates (same
@@ -142,8 +142,8 @@ confident data for:
 - `auth` — one-sentence description of the auth requirement.
 - `effects` — the handler's transitive effect closure (#2811): any of
   `db_read`, `db_write`, `http_out`, `fs_read`, `fs_write`, `mutation`, `env`.
-  Copy verbatim from `grafel_endpoints(action=definitions)` (the `effects`
-  field) or `grafel_effects(entity_id=<endpoint id>)` — both read it from
+  Copy verbatim from `grafel_endpoints(detail=list)` (the `effects`
+  field) or `grafel_trace(kind=effects, target=<endpoint id>)` — both read it from
   the effects sidecar, so you do not need to re-derive it. Lets the Paths panel
   answer "which endpoints write to the DB / touch the filesystem / mutate state".
 - `tables_touched` — list DB tables or ORM models that this handler reads or writes.
@@ -231,12 +231,10 @@ After writing the frontmatter, record the enrichment in the daemon so the
 group state reflects it and the `docgen_status` transitions to `enriched`:
 
 ```
-grafel_enrichments(
-  action=submit,
+grafel_docgen_apply(kind="enrichments", action=submit,
   entity_id="<id>",
   summary="<one-sentence summary>",
-  kind="<kind>",
-)
+  kind="<kind>",)
 ```
 
 ### Step 6 — Verification
@@ -258,12 +256,12 @@ verify:
 ### Step 7 — Emit repair candidates
 
 Run the emission step from `snippets/docgen-repair-emission.md`. Pass 13 reads
-`grafel_expand` neighborhoods for every entity in the working list; this is
+`grafel_subgraph` neighborhoods for every entity in the working list; this is
 rich signal for repair candidates.
 
 Primary discovery types in this pass:
 
-- **`fix_kind`** — the enrichment candidate list from `grafel_enrichments`
+- **`fix_kind`** — the enrichment candidate list from `grafel_docgen_apply (kind=enrichments)`
   may contain entities whose graph kind contradicts what you observe. For
   example, a `process_flow` entity that is actually an `http_endpoint` (a
   handler with route metadata), or a `message_topic` catalogued as `Class`.
@@ -315,11 +313,9 @@ Use `source: "generate-docs/pass-13"` in all candidates. Append to
 Save a finding summarising enrichment coverage:
 
 ```
-grafel_save_finding(
-  question="What enrichment data was produced for this group?",
+grafel_findings(action="save", question="What enrichment data was produced for this group?",
   answer="Pass 13 enriched <N> http_endpoints, <M> process_flows, <K> message_topics. <X> disqualified. <Y> merged. Health coverage: <Z> message_topics at 6/6, <W> process_flows at 5/5.",
-  type="enrichment",
-)
+  type="enrichment",)
 ```
 
 Hand control back to the orchestrator. The orchestrator marks Pass 13 complete

--- a/skills/grafel-graph-enrich/prompts/14-frontmatter-validation.md
+++ b/skills/grafel-graph-enrich/prompts/14-frontmatter-validation.md
@@ -6,8 +6,8 @@
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -20,7 +20,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -33,7 +33,7 @@ blank panel in the dashboard.
 > **Read-only pass** — Pass 14 does not modify any doc file. It only reports.
 > Re-run Pass 13 to fix any entity with validation failures.
 
-> **Note:** Pass 14 and Pass 8 both call `grafel_docgen_validate`. They are
+> **Note:** Pass 14 and Pass 8 both call `grafel_docgen (action=validate)`. They are
 > not consolidated (out of scope for #2215) but the duplication is intentional:
 > Pass 8 focuses on link hygiene and cross-repo candidates; Pass 14 focuses on
 > enrichment frontmatter schema correctness. The `validate` response contains
@@ -50,10 +50,10 @@ blank panel in the dashboard.
 
 ### Step 1 — Run structured validation via MCP
 
-Call `grafel_docgen_validate` with the `run_id` from `plan.json`:
+Call `grafel_docgen (action=validate)` with the `run_id` from `plan.json`:
 
 ```
-grafel_docgen_validate(run_id="<run_id>")
+grafel_docgen(action="validate", run_id="<run_id>")
 # response: { "frontmatter_errors": [...], "link_errors": [...], "ok": true|false }
 ```
 
@@ -166,11 +166,9 @@ Produce a structured summary with:
 ### Step 4 — Save finding
 
 ```
-grafel_save_finding(
-  question="Pass 14 frontmatter validation report",
+grafel_findings(action="save", question="Pass 14 frontmatter validation report",
   answer="<Structured summary: N files scanned, M passed, K failed. Failing files: [list]. Incomplete health: [list]>",
-  type="enrichment_validation",
-)
+  type="enrichment_validation",)
 ```
 
 ### Step 5 — Hand back

--- a/skills/grafel-graph-quality/SKILL.md
+++ b/skills/grafel-graph-quality/SKILL.md
@@ -41,8 +41,8 @@ It runs **before** `/generate-docs` because docgen amplifies whatever bias the M
 
 ## Inputs the skill expects
 
-- A resolved grafel group (the skill calls `grafel_whoami` first to confirm).
-- A running grafel daemon (per the user's `grafel install` setup). **The skill never spawns a daemon.** If `grafel_whoami` fails, stop and tell the user to start their daemon.
+- A resolved grafel group (the skill calls `grafel_orient (view=me)` first to confirm).
+- A running grafel daemon (per the user's `grafel install` setup). **The skill never spawns a daemon.** If `grafel_orient (view=me)` fails, stop and tell the user to start their daemon.
 - Optional flags:
   - `--output <path>` - report destination. Default: `~/private/benchmarks/mcp-quality-bench-<YYYY-MM-DD>.md`.
   - `--iterations N` - run each question N times for noise reduction. Default 1. Reports median + stddev when N > 1.
@@ -50,7 +50,7 @@ It runs **before** `/generate-docs` because docgen amplifies whatever bias the M
   - `--question-set <path>` - JSON file with a user-curated question set instead of auto-generated. Schema documented in Phase 1.
   - `--baseline <path>` - prior report markdown to diff against. Surfaces deltas in token/quality/speed.
   - `--no-calibration` - skip Phase 6 (the extraction over/under audit). By default calibration always runs.
-  - `--since <sha>` — delta mode: restrict Phase 1 question generation and Phase 6 calibration to entities whose source files changed since `<sha>`. Reads `grafel_recent_activity(since=<sha>)` to get the entity set. Full benchmark phases 2/3/4/5 still run on the restricted question set. See `prompts/07-delta-mode.md` for the complete delta procedure.
+  - `--since <sha>` — delta mode: restrict Phase 1 question generation and Phase 6 calibration to entities whose source files changed since `<sha>`. Reads `grafel_index_status(since=<sha>)` to get the entity set. Full benchmark phases 2/3/4/5 still run on the restricted question set. See `prompts/07-delta-mode.md` for the complete delta procedure.
 
 ## Daemon discipline
 
@@ -68,7 +68,7 @@ The skill is a strict pipeline. Each phase has a dedicated prompt under `prompts
 
 | Phase | Prompt | Purpose |
 |------|--------|---------|
-| 1 | `prompts/01-question-generation.md` | Call `grafel_whoami`, learn the group's real entities, generate ~10-15 questions across nine categories. Persist as `questions.json`. |
+| 1 | `prompts/01-question-generation.md` | Call `grafel_orient (view=me)`, learn the group's real entities, generate ~10-15 questions across nine categories. Persist as `questions.json`. |
 | 2 | `prompts/02-without-mcp-run.md` | Answer every question using **only** `rg` / `grep` / `Read` / `Bash`. No grafel MCP. Record tokens / time / tool calls / confidence per question. Persist as `without-mcp.json`. **Runs FIRST** — fresh context, no MCP results in scope. |
 | 3 | `prompts/03-with-mcp-run.md` | Answer the **same** questions using grafel MCP tools only. Same metrics. Persist as `with-mcp.json`. **Runs SECOND** — fresh context that has not seen Phase 2's transcript. See `prompts/03a-rpc-capture.md` for the daemon RPC capture protocol. |
 | 3a | `prompts/03a-rpc-capture.md` | Daemon RPC capture protocol: log-offset snapshot procedure, CLI helper invocation, field semantics, error handling. Referenced by Phase 3 per-question metric collection. |
@@ -103,7 +103,7 @@ Each phase reads its predecessor's output from the run directory:
 
 ## Question categories
 
-Phase 1 generates questions across nine categories. Each question is adapted to the registered group's actual entities (e.g., "what is UserService?" only if a `UserService`-like entity exists; otherwise substitute a real entity discovered via `grafel_search`).
+Phase 1 generates questions across nine categories. Each question is adapted to the registered group's actual entities (e.g., "what is UserService?" only if a `UserService`-like entity exists; otherwise substitute a real entity discovered via `grafel_find`).
 
 1. **Entity lookup** - "what is `<ClassName>`?"
 2. **Reference finding** - "what calls `<Class>.<method>`?"
@@ -162,7 +162,7 @@ Quantify each as a count and a rate (share of the affected kind or of total enti
 Things that SHOULD be in the graph but are missing:
 
 - **Missing relationships that should exist** - e.g. test entities present but **zero** `TESTS` edges; Celery/pub-sub topics with null publishers or subscribers; cross-repo HTTP calls left as orphans because the client path (`/inspections/{id}`) doesn't match the server route (`/api/v1/inspections/{pk}`) — a prefix/param-name normalization gap, not a real missing endpoint. Quantify orphan-call rate and cross-repo link coverage (linked ÷ linkable).
-- **Missing entities** - real symbols grep finds that `grafel_search` / `grafel_inspect` cannot. Sample a few known classes/functions from each repo and confirm presence.
+- **Missing entities** - real symbols grep finds that `grafel_find` / `grafel_inspect` cannot. Sample a few known classes/functions from each repo and confirm presence.
 - **Empty qualified_names** - entities whose `qualified_name` is `""`. These break path-finding and cross-repo joins. Report the rate by kind.
 - **Unlinked framework patterns** - DI bindings, signal/event handlers, route→handler wiring that exist in source but produce no edge.
 - **Missing kinds** - structurally important kinds that are absent or near-empty (e.g. a `Process` label expected but unpopulated).
@@ -217,7 +217,7 @@ Source snippets are referenced by path+line, not embedded. The raw-data appendix
 
 - The skill's six prompt files exist: `01` through `06`, with `02-without-mcp-run.md` (grep first) preceding `03-with-mcp-run.md` (MCP second).
 - The orchestrator spawns Phase 2 and Phase 3 as independent subagents with no shared transcript.
-- The skill calls `grafel_whoami` before generating any question, and questions reference only entities actually present in the group.
+- The skill calls `grafel_orient (view=me)` before generating any question, and questions reference only entities actually present in the group.
 - Token counts come from the host's `usage_info`, with a labeled estimation fallback.
 - Phase 3 captures `[mcp-rpc] tool=<X> elapsed=<N>ms` lines from `~/.grafel/logs/daemon.log` during each question by running `grafel bench-capture rpc --start $START --end $END` (#2298) and merges its JSON into the question's `metrics` block. The `mcp_rpc_*` field definitions are the authoritative schema in `schema/with-mcp-artifact.schema.json` (#2302). The Phase 5 report includes a "Handler vs Transport" subsection splitting wall time into handler and transport (#2291).
 - Ground truth is established by an independent grep+read pass in Phase 4 before scoring either answer — Phase 4 does not read `without-mcp.json` or `with-mcp.json` until after its own grep pass is committed.

--- a/skills/grafel-graph-quality/prompts/01-question-generation.md
+++ b/skills/grafel-graph-quality/prompts/01-question-generation.md
@@ -55,8 +55,8 @@ Entity-lookup questions that stand alone without a follow-up are **not permitted
 ## Setup
 
 1. Confirm the run directory: `~/.grafel/quality-check/<YYYY-MM-DD-HHMMSS>/` (the orchestrator passes the exact path). Create it if missing.
-2. Call `grafel_whoami` to resolve the group, repos, and entity stats. If this fails, **stop** and report "no daemon running" - do not start one.
-3. Capture the group's entity-kind distribution and top entities by degree using `grafel_stats` and `grafel_clusters`.
+2. Call `grafel_orient (view=me)` to resolve the group, repos, and entity stats. If this fails, **stop** and report "no daemon running" - do not start one.
+3. Capture the group's entity-kind distribution and top entities by degree using `grafel_orient (view=overview)` and `grafel_orient (view=clusters)`.
 
 ## Category definitions
 
@@ -82,7 +82,7 @@ Entity-lookup questions that stand alone without a follow-up are **not permitted
 
 ## Adaptation rules
 
-- Never invent entity names. Every entity in every question MUST exist in the group (verified via `grafel_search_entities` or `grafel_inspect`).
+- Never invent entity names. Every entity in every question MUST exist in the group (verified via `grafel_find` or `grafel_inspect`).
 - If a category cannot be filled (e.g., single-repo group has no cross-stack trace), record `"skipped": true` for that category with a reason string. The final report flags skipped categories.
 - For single-repo groups: treat "cross-repo" questions as "cross-subsystem" — trace across API, service, and persistence layers instead of across repos.
 - If `--focus <category>` is set, only generate questions from that category (4-8 of them) and skip the others entirely.

--- a/skills/grafel-graph-quality/prompts/03-with-mcp-run.md
+++ b/skills/grafel-graph-quality/prompts/03-with-mcp-run.md
@@ -6,7 +6,7 @@ Answer every question from `questions.json` using **only grafel MCP tools**. Rec
 
 ## Allowed tools
 
-You may call any grafel MCP tool: `grafel_whoami`, `grafel_search`, `grafel_describe`, `grafel_related`, `grafel_trace`, `grafel_list_clusters`, `grafel_get_source`, `grafel_recent_activity`, `grafel_list_link_candidates`, `grafel_list_enrichment_candidates`, `grafel_graph_stats`, `grafel_patterns`, `grafel_get_telemetry`, etc.
+You may call any grafel MCP tool: `grafel_orient (view=me)`, `grafel_find`, `grafel_inspect`, `grafel_related`, `grafel_trace`, `grafel_orient (view=clusters)`, `grafel_get_source`, `grafel_index_status`, `grafel_cross_links`, `grafel_docgen_apply (kind=enrichments)`, `grafel_orient (view=overview)`, `grafel_patterns`, `grafel_mcp_metrics`, etc.
 
 You may **not** call `rg`, `grep`, `Read` on source files, or any other non-MCP file-inspection tool. If a question is unanswerable through MCP alone, record `confidence: 0.0` and mark `unknown: true` - that is a valid result.
 
@@ -47,10 +47,10 @@ See `prompts/03a-rpc-capture.md` for the detailed daemon RPC capture protocol, i
       "confidence": 0.85,
       "unknown": false,
       "tool_calls": [
-        {"tool": "grafel_search", "args_digest": "sha256:...", "ok": true, "ms": 142}
+        {"tool": "grafel_find", "args_digest": "sha256:...", "ok": true, "ms": 142}
       ],
       "tool_call_count": 4,
-      "tools_used": ["grafel_search", "grafel_describe", "grafel_related"],
+      "tools_used": ["grafel_find", "grafel_inspect", "grafel_related"],
       "metrics": {
         "input_tokens": 12345,
         "output_tokens": 678,
@@ -62,14 +62,14 @@ See `prompts/03a-rpc-capture.md` for the detailed daemon RPC capture protocol, i
         "mcp_rpc_handler_ms_p50": 1850,
         "mcp_rpc_handler_ms_p99": 2410,
         "mcp_rpc_per_tool": {
-          "grafel_search": {"count": 2, "sum_ms": 3600, "sum_bytes": 4096, "sum_token_est": 1024},
-          "grafel_describe": {"count": 1, "sum_ms": 2120, "sum_bytes": 1536, "sum_token_est": 384},
+          "grafel_find": {"count": 2, "sum_ms": 3600, "sum_bytes": 4096, "sum_token_est": 1024},
+          "grafel_inspect": {"count": 1, "sum_ms": 2120, "sum_bytes": 1536, "sum_token_est": 384},
           "grafel_related": {"count": 1, "sum_ms": 2260, "sum_bytes": 2048, "sum_token_est": 512}
         },
         "mcp_rpc_wire_bytes_sum": 7680,
         "mcp_rpc_payload_token_estimate_sum": 1920
       },
-      "notes": "Mentioned grafel_search returned 0 hits initially; widened query."
+      "notes": "Mentioned grafel_find returned 0 hits initially; widened query."
     }
   ]
 }

--- a/skills/grafel-graph-quality/prompts/05-report.md
+++ b/skills/grafel-graph-quality/prompts/05-report.md
@@ -105,7 +105,7 @@ Token ratio formatted as `0.42×` (MCP saved 58%) or `2.10×` (MCP burned 110% m
 - `<question id + concrete example>` - bullet describing the win with the cite to the per-question row.
 
 ### Where MCP loses
-- `<question id + concrete example>` - what MCP missed or burned tokens on, plus the visible root cause if any (e.g., "grafel_search returned 0 hits because the entity name uses a non-ASCII suffix").
+- `<question id + concrete example>` - what MCP missed or burned tokens on, plus the visible root cause if any (e.g., "grafel_find returned 0 hits because the entity name uses a non-ASCII suffix").
 
 ### Surprising patterns
 - Anything that does not fit the above two buckets.
@@ -126,7 +126,7 @@ Concrete tuning ideas for the grafel coordinator. Each recommendation cites the 
 - **Tool description for `grafel_<X>`** - rewrite to clarify `<Y>` (cites: q03, q07).
 - **Add cache for `<call pattern>`** - the agent ran the same call N times on q05; consider memoization.
 - **Pattern discovery weak on `<kind>`** - q08 missed obvious recurrence; suggests Phase 4 of ADR-0018 needs `<X>`.
-- **Doc-gen flow should leverage `<MCP capability>`** - q02 showed a 6× token saving for reference finding; docgen should call this tool directly instead of round-tripping through `grafel_search`.
+- **Doc-gen flow should leverage `<MCP capability>`** - q02 showed a 6× token saving for reference finding; docgen should call this tool directly instead of round-tripping through `grafel_find`.
 
 ### Anti-patterns to avoid
 - `<X>` - observed in q04, costs N tokens per occurrence.

--- a/skills/grafel-graph-quality/prompts/06-extraction-calibration.md
+++ b/skills/grafel-graph-quality/prompts/06-extraction-calibration.md
@@ -6,33 +6,33 @@ Skip this phase only if the user passed `--no-calibration`.
 
 ## Inputs
 
-- The resolved group (confirm with `grafel_whoami` if not already known).
-- `grafel_stats` for the entity/relationship/cross-repo totals (the denominators).
+- The resolved group (confirm with `grafel_orient (view=me)` if not already known).
+- `grafel_orient (view=overview)` for the entity/relationship/cross-repo totals (the denominators).
 - The real repos on disk for grep+read ground truth (the judge uses `rg`/`Read`, never the MCP, so the audit is honest).
 
 ## Protocol
 
 ### Step A - Establish the denominators
 
-Call `grafel_stats`. Record total entities, total relationships, cross-repo links, and per-repo counts. Every rate you report is `count ÷ one of these denominators` (or ÷ the affected kind's count) — always state which.
+Call `grafel_orient (view=overview)`. Record total entities, total relationships, cross-repo links, and per-repo counts. Every rate you report is `count ÷ one of these denominators` (or ÷ the affected kind's count) — always state which.
 
 ### Step B - Over-extraction probes
 
 For each category, gather counts via MCP, then confirm with grep+read that the flagged nodes really are noise/dupes.
 
-1. **Duplicate-kind nodes.** Pick several representative symbols (a Django ViewSet/Model, a Celery task, a serializer). For each, `grafel_search_entities query=<name>` and group results by `(name, source_file)`. Count distinct `entity_id` and the set of `kind` values per group. If one source symbol yields >1 node, that is duplication. Report the duplication factor (nodes per real symbol) and the kind-pairs observed (e.g. `Component`+`View`, `ScheduledJob`+`Task`+`Operation`).
+1. **Duplicate-kind nodes.** Pick several representative symbols (a Django ViewSet/Model, a Celery task, a serializer). For each, `grafel_find query=<name>` and group results by `(name, source_file)`. Count distinct `entity_id` and the set of `kind` values per group. If one source symbol yields >1 node, that is duplication. Report the duplication factor (nodes per real symbol) and the kind-pairs observed (e.g. `Component`+`View`, `ScheduledJob`+`Task`+`Operation`).
 2. **Statement-level noise.** Search for entity names that are clearly not declarations: contains `= f"`, `= {`, `return `, ` == `, leading whitespace, or is not a valid identifier. Each hit is an expression mis-extracted as an entity. Estimate the rate within the affected kind (usually `Operation`).
-3. **Framework scaffolding.** `grafel_endpoints action=definitions`. Count auto-generated routes (Django `/admin/...`, DRF browsable-API, framework health routes) vs hand-written app routes. Report scaffolding share of total endpoints.
+3. **Framework scaffolding.** `grafel_endpoints detail=list`. Count auto-generated routes (Django `/admin/...`, DRF browsable-API, framework health routes) vs hand-written app routes. Report scaffolding share of total endpoints.
 4. **Generated / vendored pollution.** Sample `source_file` paths for `node_modules/`, `dist/`, `build/`, `migrations/`, `*.generated.*`, `*_pb2.py`, openapi output. Count nodes from such paths.
-5. **Phantom edges (spot check).** Take 3-5 high-confidence edges (`grafel_find_callers`/`find_callees`) and grep the source to confirm the call really exists. Note any that don't.
+5. **Phantom edges (spot check).** Take 3-5 high-confidence edges (`grafel_related` with `direction=callers` / `direction=callees`) and grep the source to confirm the call really exists. Note any that don't.
 
 ### Step C - Under-extraction probes
 
 1. **Missing relationships.**
-   - `grafel_test_coverage` - if test entities exist but `TESTS edges (total) = 0`, that is total under-extraction of test linkage. Report covered% and edge count.
-   - `grafel_topology action=orphan_publishers` / `orphan_subscribers` - count pub/sub topics with null counterpart. Cross-check Celery `@shared_task` / `.delay()` / `.apply_async()` call sites in source that produce no edge.
-   - `grafel_endpoints action=calls orphan_only=true` - count orphan cross-repo HTTP calls. Then check WHY: compare a client path (e.g. `/inspections/{id}`) to the server route (`/api/v1/inspections/{pk}`). If the endpoint genuinely exists server-side, the orphan is a **normalization gap** (prefix/param-name), not a real missing endpoint — say so. Report cross-repo link coverage as `linked ÷ linkable`.
-2. **Missing entities.** Pick 3-5 classes/functions per repo you can see with `rg`. Confirm each via `grafel_inspect` / `grafel_search_entities`. Any grep-visible symbol the MCP can't find is a miss.
+   - `grafel_test_analysis (kind=coverage)` - if test entities exist but `TESTS edges (total) = 0`, that is total under-extraction of test linkage. Report covered% and edge count.
+   - `grafel_orient (view=topology) action=orphan_publishers` / `orphan_subscribers` - count pub/sub topics with null counterpart. Cross-check Celery `@shared_task` / `.delay()` / `.apply_async()` call sites in source that produce no edge.
+   - `grafel_cross_links` - count orphan cross-repo HTTP calls. Then check WHY: compare a client path (e.g. `/inspections/{id}`) to the server route (`/api/v1/inspections/{pk}`). If the endpoint genuinely exists server-side, the orphan is a **normalization gap** (prefix/param-name), not a real missing endpoint — say so. Report cross-repo link coverage as `linked ÷ linkable`.
+2. **Missing entities.** Pick 3-5 classes/functions per repo you can see with `rg`. Confirm each via `grafel_inspect` / `grafel_find`. Any grep-visible symbol the MCP can't find is a miss.
 3. **Empty qualified_names.** `grafel_inspect` a sample of entities across kinds; count those with `qualified_name == ""`. Report rate by kind. Empty qnames break path-finding and cross-repo joins.
 4. **Unlinked framework patterns.** Look for DI bindings, Django signals (`@receiver`), route→handler wiring in source; check whether the graph has the corresponding edge.
 5. **Missing kinds.** Note any structurally important kind that is absent or near-empty when source clearly contains instances.

--- a/skills/grafel-graph-quality/prompts/07-delta-mode.md
+++ b/skills/grafel-graph-quality/prompts/07-delta-mode.md
@@ -10,12 +10,12 @@ This phase executes only when `/grafel-graph-quality` is invoked with `--since <
 
 ## Pre-flight assertion
 
-Call `grafel_whoami` before doing anything. If it errors, abort with:
+Call `grafel_orient (view=me)` before doing anything. If it errors, abort with:
 "grafel MCP not configured for this directory. Run `/mcp` to fix."
 
 ## Inputs
 
-- `--since <sha>`: the git commit SHA to diff against. The skill treats this as an opaque identifier passed to `grafel_recent_activity(since=<sha>)`.
+- `--since <sha>`: the git commit SHA to diff against. The skill treats this as an opaque identifier passed to `grafel_index_status(since=<sha>)`.
 - Existing full-benchmark output at `~/.grafel/quality-check/<prior-timestamp>/` (optional — used as baseline if `--baseline` is also set).
 
 ## Procedure
@@ -23,10 +23,10 @@ Call `grafel_whoami` before doing anything. If it errors, abort with:
 ### Step 1 — Resolve the changed entity set
 
 ```
-changed = grafel_recent_activity(since=<sha>)
+changed = grafel_index_status(since=<sha>)
 ```
 
-`grafel_recent_activity` returns entities whose source files changed since the given timestamp or SHA. If the result is empty (nothing changed), print:
+`grafel_index_status` returns entities whose source files changed since the given timestamp or SHA. If the result is empty (nothing changed), print:
 
 > No entities changed since `<sha>`. Nothing to benchmark. Exiting.
 
@@ -36,7 +36,7 @@ and exit cleanly (success, not error).
 
 Run Phase 1 (`prompts/01-question-generation.md`) with the restriction: generate questions **only** about entities in `changed`. Use the same nine question categories but constrain entity picks to `changed`.
 
-If `changed` contains fewer than 5 entities, generate at minimum 5 questions by expanding to the 1-hop neighbours of the changed entities (via `grafel_expand`). This avoids a degenerate benchmark on trivial diffs.
+If `changed` contains fewer than 5 entities, generate at minimum 5 questions by expanding to the 1-hop neighbours of the changed entities (via `grafel_subgraph`). This avoids a degenerate benchmark on trivial diffs.
 
 Persist as `questions.json` in the run directory (same format as a full benchmark run).
 

--- a/skills/grafel-graph-quality/schema/with-mcp-artifact.schema.json
+++ b/skills/grafel-graph-quality/schema/with-mcp-artifact.schema.json
@@ -105,7 +105,7 @@
       "properties": {
         "tool": {
           "type": "string",
-          "description": "MCP tool name (e.g. 'grafel_search')."
+          "description": "MCP tool name (e.g. 'grafel_find')."
         },
         "args_digest": {
           "type": "string",

--- a/skills/grafel-graph-read/SKILL.md
+++ b/skills/grafel-graph-read/SKILL.md
@@ -6,7 +6,7 @@ description: Shared grafel read protocol — status → inspect → expand. Comp
 # READ Protocol
 
 ## Step 1 — status
-Call `grafel_whoami` first. Confirms the group name and which repos are indexed. If no graph is loaded, ask the user to run `grafel index <path>` first.
+Call `grafel_orient (view=me)` first. Confirms the group name and which repos are indexed. If no graph is loaded, ask the user to run `grafel index <path>` first.
 
 ## Step 2 — inspect
 For each entity of interest (a class, function, file path the user named):
@@ -19,16 +19,16 @@ For each entity of interest (a class, function, file path the user named):
 
 ## Step 3 — expand
 When you need to traverse:
-- `grafel_expand entity_id=<id> edge=CALLS direction=incoming` for callers
-- `grafel_expand entity_id=<id> edge=CALLS direction=outgoing` for callees
+- `grafel_subgraph entity_id=<id> edge=CALLS direction=incoming` for callers
+- `grafel_subgraph entity_id=<id> edge=CALLS direction=outgoing` for callees
 - `grafel_find name=<substring>` if you don't have an id yet
 
-Other useful read tools to layer in: `grafel_traces` (process-flow BFS), `grafel_cross_links` (HTTP/Kafka/WS cross-repo), `grafel_clusters` (Louvain communities), `grafel_module_analysis`, `grafel_subgraph`.
+Other useful read tools to layer in: `grafel_trace` (process-flow BFS), `grafel_cross_links` (HTTP/Kafka/WS cross-repo), `grafel_orient (view=clusters)` (Louvain communities), `grafel_orient (view=modules)`, `grafel_subgraph`.
 
 ### In-app navigation (#2665)
 For Expo Router / React Navigation / Next.js push-sites, two shortcuts fold the NAVIGATES_TO graph into the existing read tools:
 - `grafel_endpoints(kind="navigation")` — list distinct routes, with merged `params_keys` (sorted, deduped JSON array) per route. Use this to answer "which screens take param X?".
-- `grafel_find_callers("/route/literal")` — pass a literal beginning with `/`; the handler reverse-traverses NAVIGATES_TO and returns push-site callers with `file`, `line`, and per-call `params_keys`. Use this when adding a required param: callers whose `params_keys` is missing the new key are the diff candidates.
+- `grafel_related(direction="callers", "/route/literal")` — pass a literal beginning with `/`; the handler reverse-traverses NAVIGATES_TO and returns push-site callers with `file`, `line`, and per-call `params_keys`. Use this when adding a required param: callers whose `params_keys` is missing the new key are the diff candidates.
 
 ## When the READ phase is enough
 Many user questions resolve at Step 2 (inspect a single entity, read the neighbors). Don't over-traverse. Three rules:

--- a/skills/grafel-graph-write/SKILL.md
+++ b/skills/grafel-graph-write/SKILL.md
@@ -7,7 +7,7 @@ description: Shared grafel persistence protocol — save findings only on explic
 
 If the user says "save this", "write a report", "create a follow-up doc", or similar, use the host agent's Write tool to save the analysis as a markdown file. Default location: `~/.grafel/groups/<group>/findings/<persona>-<short-slug>-<YYYY-MM-DD>.md` (the host agent has full toolset per the inheritance rule established in #2465). Confirm the path with the user before writing if the location is ambiguous.
 
-You may also use `grafel_save_finding` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
+You may also use `grafel_findings (action=save)` if the host MCP exposes it (this is the canonical persistence path for grafel findings).
 
 ## Invariant: explicit request only
 Personas MUST NOT auto-save findings. Persistence happens only when the user explicitly asks.

--- a/skills/grafel-patterns-discover/SKILL.md
+++ b/skills/grafel-patterns-discover/SKILL.md
@@ -14,7 +14,7 @@ Do NOT invoke this skill on first install when no group is registered, when `gra
 
 ## Inputs the skill expects
 
-- A registered group resolvable via `grafel_whoami`.
+- A registered group resolvable via `grafel_orient (view=me)`.
 - An up-to-date `<repo>/.grafel/graph.json` per repo. If any repo's graph is stale, stop and tell the user to run `grafel rebuild <group>` first.
 - Read access to `<group>/.grafel/patterns.json` (the pattern store) and `patterns-config.json` (thresholds — defaults applied when absent).
 
@@ -22,7 +22,7 @@ Do NOT invoke this skill on first install when no group is registered, when `gra
 
 ### Step 1 — Slice the codebase
 
-Dispatch one subagent per top-level module cluster (as returned by `grafel_list_clusters`). Each subagent receives:
+Dispatch one subagent per top-level module cluster (as returned by `grafel_orient (view=clusters)`). Each subagent receives:
 
 - Its cluster's entity ID set.
 - A read-only copy of the existing pattern store (so it can skip shapes already covered).

--- a/skills/grafel-resolve/SKILL.md
+++ b/skills/grafel-resolve/SKILL.md
@@ -6,9 +6,9 @@ when-to-use: User asks to "show me grafel's residuals", "help me annotate runtim
 
 # grafel-resolve
 
-Stand-alone resolution flow for ADR-0015 residual edges. Lists pending resolution candidates surfaced by `grafel index`, walks the user through resolutions, and submits each via the `grafel_repairs` MCP tool. Companion to `/generate-docs`, but can be invoked independently when the user just wants to clean up residuals without regenerating docs.
+Stand-alone resolution flow for ADR-0015 residual edges. Lists pending resolution candidates surfaced by `grafel index`, walks the user through resolutions, and submits each via the `grafel_docgen_apply (kind=repairs)` MCP tool. Companion to `/generate-docs`, but can be invoked independently when the user just wants to clean up residuals without regenerating docs.
 
-> **Backward-compatibility note:** The MCP tool name `grafel_repairs` and on-disk file names `repair-history.json` / `repair-templates.json` are preserved for backward compatibility. A separate ticket will address the API rename.
+> **Backward-compatibility note:** The MCP tool name `grafel_docgen_apply (kind=repairs)` and on-disk file names `repair-history.json` / `repair-templates.json` are preserved for backward compatibility. A separate ticket will address the API rename.
 
 ## When to use this skill
 
@@ -25,25 +25,25 @@ Do **not** invoke it inside `/generate-docs`; that flow has its own integrated r
 
 ## Inputs
 
-- A resolved grafel group (the skill calls `grafel_whoami` first).
+- A resolved grafel group (the skill calls `grafel_orient (view=me)` first).
 - Per-repo `<repo>/.grafel/enrichment-candidates.json` with `kind: "repair_edge"` records (emitted by `grafel index` per ADR-0015).
 - Optional: `~/.grafel/groups/<group>/repair-history.json` (prior answers).
 - Optional: `~/.grafel/groups/<group>/repair-templates.json` (saved templates).
 
-If `grafel_repairs(action=list, limit=1)` returns `total == 0` for every repo, the skill exits with "No residuals to resolve." after a one-line summary.
+If `grafel_docgen_apply(kind="repairs", action=list, limit=1)` returns `total == 0` for every repo, the skill exits with "No residuals to resolve." after a one-line summary.
 
 ## Procedure
 
 ### Step 0 — Confirm scope
 
-`grafel_whoami` → confirm group + repo set with the user. If the user wants a single repo, capture the slug; otherwise iterate the full group.
+`grafel_orient (view=me)` → confirm group + repo set with the user. If the user wants a single repo, capture the slug; otherwise iterate the full group.
 
 ### Step 1 — List residuals
 
 For each repo `<r>`:
 
 ```
-grafel_repairs(action=list, repo_filter=["<r>"], limit=50, offset=0)
+grafel_docgen_apply(kind="repairs", action=list, repo_filter=["<r>"], limit=50, offset=0)
 ```
 
 Continue paging while `len(residuals) == limit`. Display per-repo counts to the user up front:
@@ -62,7 +62,7 @@ Before prompting the user, auto-resolve anything that:
 - Matches a template in `repair-templates.json` with `confidence >= 0.8`, OR
 - Has a prior successful resolution in `repair-history.json` keyed by `residual_id`.
 
-Submit those via `grafel_repairs(action=submit, source="grafel-resolve/auto")` and tell the user how many were auto-applied:
+Submit those via `grafel_docgen_apply(kind="repairs", action=submit, source="grafel-resolve/auto")` and tell the user how many were auto-applied:
 
 > Auto-applied 14 from templates / 6 from prior history. 42 left to walk.
 
@@ -79,7 +79,7 @@ Same Q-shape as `/generate-docs` Pass 1b — one residual at a time:
 > - **D.** Abandon.
 > - **S.** Skip for now.
 
-Translate the answer to `grafel_repairs(action=submit, ..., source="grafel-resolve")` using the same translation table as Pass 1b.
+Translate the answer to `grafel_docgen_apply(kind="repairs", action=submit, ..., source="grafel-resolve")` using the same translation table as Pass 1b.
 
 ### Step 4 — Handle rejections
 
@@ -107,16 +107,16 @@ Optionally offer to invoke `grafel index` for the affected repos. The skill does
 
 ## Outputs
 
-- Side effects: zero or more `grafel_repairs(action=submit)` calls.
+- Side effects: zero or more `grafel_docgen_apply(kind="repairs", action=submit)` calls.
 - `~/.grafel/groups/<group>/repair-history.json` — appended.
 - `~/.grafel/groups/<group>/repair-templates.json` — possibly extended with new templates.
 - `~/.grafel/groups/<group>/repair-session-<rfc3339>.md` — human-readable transcript of this session (count, applied list, deferred list).
 
 ## grafel MCP tool surface
 
-- `grafel_whoami` — group/repo resolution.
-- `grafel_repairs(action=list|submit)` — primary tool.
-- `grafel_describe`, `grafel_related`, `grafel_search` — for inspecting candidate targets when the user asks "what would that bind to?".
+- `grafel_orient (view=me)` — group/repo resolution.
+- `grafel_docgen_apply(kind="repairs", action=list|submit)` — primary tool.
+- `grafel_inspect`, `grafel_related`, `grafel_find` — for inspecting candidate targets when the user asks "what would that bind to?".
 
 ## Quality gates
 
@@ -133,14 +133,14 @@ This skill absorbs and supersedes two passes that previously lived inside
 behaviour without triggering a full doc-gen pipeline.
 
 - **Pass 1a** (`prompts/01a-residual-repair-sweep.md`) — pre-Q&A sweep: auto-resolves residuals matching saved templates (confidence ≥ 0.8) and known third-party stubs. Does NOT attempt `bind_to_entity` resolutions — those go to Pass 1b or the 3a hook inside tech-docs.
-- **Pass 1b** (`prompts/01b-repair-aware-qa.md`) — interactive Q&A: walks the user through residuals 1a could not auto-resolve; each answer becomes an `grafel_repairs(action=submit)` call.
+- **Pass 1b** (`prompts/01b-repair-aware-qa.md`) — interactive Q&A: walks the user through residuals 1a could not auto-resolve; each answer becomes an `grafel_docgen_apply(kind="repairs", action=submit)` call.
 
 ## Related
 
 - `skills/generate-docs/SKILL.md` — for the integrated resolution flow inside doc generation (Pass 1a, 1b, 3a).
 - ADR-0015 (`docs/adrs/0015-residual-repair-agent-enrichment.md`) — design rationale.
 - `docs/specs/repair-trust-model.md` — allowlist + verification rules enforced by the MCP tool.
-- `internal/mcp/SCHEMA.md` §`grafel_repairs` — tool reference.
+- `internal/mcp/SCHEMA.md` §`grafel_docgen_apply (kind=repairs)` — tool reference.
 
 ## Read next
 

--- a/skills/grafel-resolve/prompts/01a-residual-repair-sweep.md
+++ b/skills/grafel-resolve/prompts/01a-residual-repair-sweep.md
@@ -6,8 +6,8 @@
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -20,7 +20,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -28,11 +28,11 @@ ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, th
 
 Runs **after Pass 1 (inventory)** and **before any deeper writer passes**. Closes the gap between the static-analysis recall ceiling (~85% on cross-repo b→a) and full coverage by annotating runtime-resolved edges that the resolver structurally cannot bind.
 
-This pass is the doc skill's integration with the ADR-0015 residual-repair mechanism. The MCP tool `grafel_repairs` is the only surface used; do **not** read or write `repair.json` directly. See `docs/specs/repair-trust-model.md` for the allowlist of resolutions and verification rules.
+This pass is the doc skill's integration with the ADR-0015 residual-repair mechanism. The MCP tool `grafel_docgen_apply (kind=repairs)` is the only surface used; do **not** read or write `repair.json` directly. See `docs/specs/repair-trust-model.md` for the allowlist of resolutions and verification rules.
 
 ## When to skip
 
-- If `grafel_repairs(action=list, limit=1)` returns `total == 0` for every repo in the group, write a single line into `~/.grafel/groups/<group>/repair-sweep.md` ("No residuals at sweep time.") and hand back to the orchestrator.
+- If `grafel_docgen_apply(kind="repairs", action=list, limit=1)` returns `total == 0` for every repo in the group, write a single line into `~/.grafel/groups/<group>/repair-sweep.md` ("No residuals at sweep time.") and hand back to the orchestrator.
 - If a previous run of this pass already produced `repair-sweep.md` for the current commit (track via `git rev-parse HEAD` of each repo recorded inside the file's frontmatter), do **not** re-ask the user about the same residuals. Only surface deltas. This implements the "repair history" bonus from #732.
 
 ## Inputs
@@ -46,7 +46,7 @@ This pass is the doc skill's integration with the ADR-0015 residual-repair mecha
 
 - `~/.grafel/groups/<group>/repair-sweep.md` — human-readable summary (counts per repo, auto-resolved sample, pending-for-user list).
 - `~/.grafel/groups/<group>/repair-questions.json` — machine-readable list of residuals that need user input, consumed by Pass 1b (repair-aware Q&A).
-- Side effects: zero or more `grafel_repairs(action=submit)` calls per auto-resolved residual.
+- Side effects: zero or more `grafel_docgen_apply(kind="repairs", action=submit)` calls per auto-resolved residual.
 
 ## Procedure
 
@@ -55,7 +55,7 @@ This pass is the doc skill's integration with the ADR-0015 residual-repair mecha
 For each repo `<r>` in the group, page through:
 
 ```
-grafel_repairs(action=list, repo_filter=["<r>"], limit=50, offset=0)
+grafel_docgen_apply(kind="repairs", action=list, repo_filter=["<r>"], limit=50, offset=0)
 ```
 
 Continue paging while the returned `residuals[]` length equals `limit`. Cap total per-repo scan at 1,000 residuals for Phase 1 — if a repo has more, record the truncation in `repair-sweep.md` and surface the count to the user; the deferred residuals will roll forward to the next run.
@@ -67,7 +67,7 @@ For each residual returned, decide one of:
 1. **Auto-resolve** — apply a repair without asking the user. Allowed only when:
    - A repair template (Step 4) matches the residual's shape with `confidence >= 0.8`, OR
    - The residual is a recognised third-party API call (e.g., `original_stub` starts with `https://api.<vendor>/` or matches a well-known SDK stub like `stripe.charges.create`) and the relation is `CALLS` → `reclassify_as_external` with `module=<vendor>`.
-   - **DO NOT auto-resolve `bind_to_entity` here.** Pass 1 (inventory) produces a corpus census (top-5 entities per community, kind counts). It does not provide full entity-level data, so there is no reliable way to confirm that a single unambiguous binding target exists. All `bind_to_entity` candidates must go to bucket 2 (Ask user) or be deferred to Pass 3a (generation-time, where the writer has full subgraph context via `grafel_expand`).
+   - **DO NOT auto-resolve `bind_to_entity` here.** Pass 1 (inventory) produces a corpus census (top-5 entities per community, kind counts). It does not provide full entity-level data, so there is no reliable way to confirm that a single unambiguous binding target exists. All `bind_to_entity` candidates must go to bucket 2 (Ask user) or be deferred to Pass 3a (generation-time, where the writer has full subgraph context via `grafel_subgraph`).
 2. **Ask user** — surface to Pass 1b. Use this for `bind_to_entity` candidates, dynamic baseURL / tenant-prefixed routes, and any runtime-resolved edge where the resolution is not mechanically deterministic.
 3. **Defer** — skip for this run (record reason). Defer is only legal when residual carries no actionable context window (extremely rare; should not happen on real corpora).
 
@@ -78,8 +78,7 @@ Every auto-resolve decision must have a one-sentence `reasoning` string and a `c
 For each residual classified as auto-resolve, call:
 
 ```
-grafel_repairs(
-  action=submit,
+grafel_docgen_apply(kind="repairs", action=submit,
   residual_id="er:...",
   resolution=<bind_to_entity | reclassify_as_external | reclassify_as_dynamic | reclassify_as_resolved | abandon>,
   target_entity_id=...,      # if bind_to_entity
@@ -89,8 +88,7 @@ grafel_repairs(
   abandon_reason=...,        # if abandon
   confidence=<0..1>,
   reasoning="<one sentence>",
-  source="generate-docs/pass-1a"
-)
+  source="generate-docs/pass-1a")
 ```
 
 Inspect the response. If `rejected_reason` is present (e.g., `target_entity_not_found`, `self_loop_disallowed`), demote the residual to the user-question bucket and record the rejection reason. The trust model rejections are non-recoverable from inside this pass — the agent must hand to the user.
@@ -199,7 +197,7 @@ If any repo could not be scanned (MCP error, missing `.grafel/enrichment-candida
 
 ## Cross-link to patterns (bonus from #732)
 
-Before recording a `PatternCandidate` in Pass 4 / aggregating in Pass 10, the agent checks whether the exemplar entity has any unresolved outbound edges via `grafel_repairs(action=list, repo_filter=[<r>])`. If so, the pattern record flow attempts a repair (Step 3 procedure) before storing the exemplar. This keeps pattern exemplars from referencing dangling targets.
+Before recording a `PatternCandidate` in Pass 4 / aggregating in Pass 10, the agent checks whether the exemplar entity has any unresolved outbound edges via `grafel_docgen_apply(kind="repairs", action=list, repo_filter=[<r>])`. If so, the pattern record flow attempts a repair (Step 3 procedure) before storing the exemplar. This keeps pattern exemplars from referencing dangling targets.
 
 ## Invariants
 

--- a/skills/grafel-resolve/prompts/01b-repair-aware-qa.md
+++ b/skills/grafel-resolve/prompts/01b-repair-aware-qa.md
@@ -6,8 +6,8 @@
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -20,13 +20,13 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
 ---
 
-Surfaces the residuals Pass 1a could not auto-resolve (see Pass 1a § "Classify each residual" for the narrowed auto-resolve scope). The user answers in plain language; the agent translates each answer into an `grafel_repairs(action=submit)` call.
+Surfaces the residuals Pass 1a could not auto-resolve (see Pass 1a § "Classify each residual" for the narrowed auto-resolve scope). The user answers in plain language; the agent translates each answer into an `grafel_docgen_apply(kind="repairs", action=submit)` call.
 
 This pass handles all three resolution kinds — `bind_to_entity`, `reclassify_as_external`, `reclassify_as_dynamic` — because the user's answer provides the disambiguation that Pass 1a lacked. When the user provides a binding target for `bind_to_entity`, use `grafel_find` to confirm the entity exists before submitting; do not fabricate ids.
 
@@ -40,7 +40,7 @@ This pass is **skipped** when `~/.grafel/groups/<group>/repair-questions.json` i
 
 ## Outputs
 
-- Side effects: one `grafel_repairs(action=submit)` call per answered question.
+- Side effects: one `grafel_docgen_apply(kind="repairs", action=submit)` call per answered question.
 - `~/.grafel/groups/<group>/repair-history.json` — appended with this run's Q/A pairs (per-residual). Keyed by `residual_id`. On the next run, Pass 1a consults this file before re-asking.
 - `~/.grafel/groups/<group>/repair-sweep.md` — appended with a "User-answered" section.
 
@@ -80,7 +80,7 @@ For each question in `repair-questions.json`, present it in this shape:
 
 ### Step 4 — Translate answer → submit
 
-Translate the user's natural-language answer into the corresponding `grafel_repairs(action=submit, ...)` call. Required fields per `docs/specs/repair-trust-model.md`:
+Translate the user's natural-language answer into the corresponding `grafel_docgen_apply(kind="repairs", action=submit, ...)` call. Required fields per `docs/specs/repair-trust-model.md`:
 
 | Answer | resolution | Required extra fields |
 |---|---|---|
@@ -97,7 +97,7 @@ Always set:
 
 ### Step 5 — Handle rejections
 
-If `grafel_repairs(action=submit)` returns `rejected_reason`, do not silently retry. Surface the reason to the user in their own terms:
+If `grafel_docgen_apply(kind="repairs", action=submit)` returns `rejected_reason`, do not silently retry. Surface the reason to the user in their own terms:
 
 - `target_entity_not_found` → "That id doesn't exist in the graph for this group. Did you mean one of: <top-3 fuzzy matches from `inventory.json`>?"
 - `self_loop_disallowed` → "That would point the edge back at itself. Was this a typo, or should we abandon the edge?"

--- a/skills/grafel-security-audit/SKILL.md
+++ b/skills/grafel-security-audit/SKILL.md
@@ -8,7 +8,7 @@ when-to-use: User asks to "audit security", "find security issues", "run the sec
 
 Run a two-phase security audit against the indexed grafel group.
 
-- **Phase 1 — Static analysis** (`prompts/01-static-analysis.md`): deterministic rule-based checks run against the graph. Finds missing auth decorators, publicly reachable endpoints with no permission check, orphan routes, exposed PII fields, and other structural patterns. Includes the Phase 2B taint-flow analysis (#2772) — `grafel_security_findings` returns source→sink paths through the CALLS graph that lack an intervening sanitizer, ranked by confidence (default floor 0.7). Essentially free — no LLM calls.
+- **Phase 1 — Static analysis** (`prompts/01-static-analysis.md`): deterministic rule-based checks run against the graph. Finds missing auth decorators, publicly reachable endpoints with no permission check, orphan routes, exposed PII fields, and other structural patterns. Includes the Phase 2B taint-flow analysis (#2772) — `grafel_security (kind=findings)` returns source→sink paths through the CALLS graph that lack an intervening sanitizer, ranked by confidence (default floor 0.7). Essentially free — no LLM calls.
 - **Phase 2 — LLM semantic pass** (`prompts/02-semantic-confirmation.md`): LLM-driven confirmation, ranking, and explanation. Confirms or dismisses Phase 1 findings, adds severity scores, writes human-readable explanations, and surfaces findings the static pass missed. Interactive by default — the user reviews findings before they are submitted to the graph.
 
 ## When to use this skill
@@ -28,11 +28,11 @@ Do **not** invoke for code quality, documentation, or enrichment — those are s
 
 ## CRITICAL TOOL DISCIPLINE
 
-Use grafel MCP tools for ALL graph navigation: `grafel_whoami`, `grafel_find`, `grafel_inspect`, `grafel_expand`, `grafel_traces`. Do NOT grep source for structural questions.
+Use grafel MCP tools for ALL graph navigation: `grafel_orient (view=me)`, `grafel_find`, `grafel_inspect`, `grafel_subgraph`, `grafel_trace`. Do NOT grep source for structural questions.
 
 ### Pre-flight assertion
 
-Call `grafel_whoami` first. If it errors: ABORT with "grafel MCP not configured. Run `/mcp` to fix."
+Call `grafel_orient (view=me)` first. If it errors: ABORT with "grafel MCP not configured. Run `/mcp` to fix."
 
 ## Cost and mode
 
@@ -49,13 +49,13 @@ Call `grafel_whoami` first. If it errors: ABORT with "grafel MCP not configured.
 
 Follow `prompts/01-static-analysis.md`. Key checks:
 
-0. **Taint-flow security findings (#2772)** — call `grafel_security_findings(min_confidence=0.7)` first. Each finding is a source→sink path through the CALLS graph (request input / env var / deserialised JSON reaches SQL exec / shell exec / eval / regex constructor / file write / HTML output without an intervening sanitizer). The pass is deterministic, conservative (drops anything below 0.5 confidence), and language-aware across T1 (jsts, python, java, go). Treat every finding ≥0.85 confidence as a Phase 2 candidate by default; findings 0.7-0.85 deserve LLM confirmation. Categories surfaced: `sql_injection`, `command_injection`, `path_traversal`, `xss`, `redos`, `deserialization`, `ssrf`.
+0. **Taint-flow security findings (#2772)** — call `grafel_security(kind="findings", min_confidence=0.7)` first. Each finding is a source→sink path through the CALLS graph (request input / env var / deserialised JSON reaches SQL exec / shell exec / eval / regex constructor / file write / HTML output without an intervening sanitizer). The pass is deterministic, conservative (drops anything below 0.5 confidence), and language-aware across T1 (jsts, python, java, go). Treat every finding ≥0.85 confidence as a Phase 2 candidate by default; findings 0.7-0.85 deserve LLM confirmation. Categories surfaced: `sql_injection`, `command_injection`, `path_traversal`, `xss`, `redos`, `deserialization`, `ssrf`.
 1. **Auth coverage** — for every `http_endpoint` entity, check whether the graph contains an `AUTHENTICATED_BY` or `REQUIRES_PERMISSION` edge. Endpoints with no such edge are flagged `auth_missing`.
 2. **Reachability** — identify endpoints reachable from the public internet (no internal-only marker) with `auth_missing`. These become `severity=high` findings.
 3. **Orphan endpoints** — endpoints with no callers AND no auth edge. Could be dead code or unauthenticated surface.
 4. **PII exposure** — entities of kind `DataField` tagged `pii=true` that are returned by an unauthenticated endpoint.
 5. **Overly broad permissions** — permission checks that resolve to `*` or `admin_only` when the endpoint clearly only needs a scoped permission.
-6. **Residual edges on security-sensitive paths** — any endpoint that has an unresolved outbound edge (detected via `grafel_repairs(action=list)`) on a path marked as authentication-related.
+6. **Residual edges on security-sensitive paths** — any endpoint that has an unresolved outbound edge (detected via `grafel_docgen_apply(kind="repairs", action=list)`) on a path marked as authentication-related.
 
 Each finding gets a fingerprint: `sha256(entity_id + check_name)`. The fingerprint is stable across re-runs so re-running doesn't create duplicate findings.
 
@@ -65,11 +65,11 @@ Output: `~/.grafel/groups/<group>/grafel-security-audit/phase1-findings.json`.
 
 Follow `prompts/02-semantic-confirmation.md`. For each Phase 1 finding:
 
-1. Load the entity's `grafel_expand(node=<id>, depth=2)` for neighbour context.
+1. Load the entity's `grafel_subgraph(node=<id>, depth=2)` for neighbour context.
 2. If `/grafel-tech-docs` output exists for the entity's module, load the relevant section.
 3. Ask the LLM: is this finding a real security issue, a false positive, or needs-more-info? Assign `severity` (critical/high/medium/low/info) and write a human-readable `explanation`.
 4. Present to the user for confirmation (unless `--auto`).
-5. On confirmation: call `grafel_save_finding(type="security_finding", ...)` to persist. In interactive mode, the user can dismiss, escalate, or edit the severity before submission.
+5. On confirmation: call `grafel_findings(action="save", type="security_finding", ...)` to persist. In interactive mode, the user can dismiss, escalate, or edit the severity before submission.
 
 Output: per-finding markdown pages at `~/.grafel/docs/<group>/security/`.
 
@@ -87,12 +87,12 @@ Output: per-finding markdown pages at `~/.grafel/docs/<group>/security/`.
 
 ## grafel MCP tool surface
 
-- `grafel_whoami`, `grafel_find`, `grafel_inspect`, `grafel_expand`
-- `grafel_security_findings` — Phase 2B taint-flow source→sink findings (#2772). Args: `category`, `min_confidence` (default 0.7), `limit`, `source_repo`. Returns deterministic SecurityFinding records ranked by confidence.
-- `grafel_repairs` — check for residual edges on security-sensitive paths
-- `grafel_enrichments` — read enriched endpoint metadata
-- `grafel_save_finding` — promote a confirmed finding to a first-class `security_finding` record. Args: `question`, `answer` (required); `type="security_finding"`, `nodes=["<entity_id>"]`, `repo_filter` (optional). It does NOT accept `entity_id`/`severity` top-level — carry the entity in `nodes` and severity in the question/answer text.
-- `grafel_list_findings` — load prior findings to avoid duplicates. Pass `type="security_finding"` to query only promoted security findings, or `entity_id=<id>` to find findings touching a specific entity.
+- `grafel_orient (view=me)`, `grafel_find`, `grafel_inspect`, `grafel_subgraph`
+- `grafel_security (kind=findings)` — Phase 2B taint-flow source→sink findings (#2772). Args: `category`, `min_confidence` (default 0.7), `limit`, `source_repo`. Returns deterministic SecurityFinding records ranked by confidence.
+- `grafel_docgen_apply (kind=repairs)` — check for residual edges on security-sensitive paths
+- `grafel_docgen_apply (kind=enrichments)` — read enriched endpoint metadata
+- `grafel_findings (action=save)` — promote a confirmed finding to a first-class `security_finding` record. Args: `question`, `answer` (required); `type="security_finding"`, `nodes=["<entity_id>"]`, `repo_filter` (optional). It does NOT accept `entity_id`/`severity` top-level — carry the entity in `nodes` and severity in the question/answer text.
+- `grafel_findings (action=list)` — load prior findings to avoid duplicates. Pass `type="security_finding"` to query only promoted security findings, or `entity_id=<id>` to find findings touching a specific entity.
 
 ## Related
 

--- a/skills/grafel-security-audit/prompts/01-static-analysis.md
+++ b/skills/grafel-security-audit/prompts/01-static-analysis.md
@@ -4,9 +4,9 @@ Runs deterministic, graph-based security checks. No LLM calls. Produces `phase1-
 
 ## Pre-flight
 
-Call `grafel_whoami`. If it errors, abort.
+Call `grafel_orient (view=me)`. If it errors, abort.
 
-If `--since <sha>` was passed: call `grafel_recent_activity(since=<sha>)` to get the changed entity set and restrict all queries below to that set.
+If `--since <sha>` was passed: call `grafel_index_status(since=<sha>)` to get the changed entity set and restrict all queries below to that set.
 
 ## Step 1 — Auth coverage sweep
 
@@ -16,7 +16,7 @@ endpoints = grafel_find(query="kind:http_endpoint", limit=500)
 ```
 
 For each endpoint:
-- Call `grafel_expand(node=<id>, depth=1)` to see its edges.
+- Call `grafel_subgraph(node=<id>, depth=1)` to see its edges.
 - Check for any edge of kind `AUTHENTICATED_BY`, `REQUIRES_PERMISSION`, or `GUARDED_BY`.
 - If none found: classify as `auth_missing`.
 
@@ -43,7 +43,7 @@ For each PII field: trace whether any `http_endpoint` returns it AND that endpoi
 ## Step 5 — Residual edges on auth paths
 
 ```
-residuals = grafel_repairs(action=list, limit=100)
+residuals = grafel_docgen_apply(kind="repairs", action=list, limit=100)
 ```
 
 For each residual whose `from_entity` is an `http_endpoint` or `middleware`: classify as `residual_on_security_path`, severity: info. These are candidates for `/grafel-resolve`.

--- a/skills/grafel-security-audit/prompts/02-semantic-confirmation.md
+++ b/skills/grafel-security-audit/prompts/02-semantic-confirmation.md
@@ -6,7 +6,7 @@ Reads `phase1-findings.json`, confirms or dismisses each finding with LLM reason
 
 - Load `phase1-findings.json` from `~/.grafel/groups/<group>/grafel-security-audit/`.
 - Load prior `~/.grafel/groups/<group>/grafel-security-audit/state.json` (if exists) to skip already-confirmed findings by fingerprint.
-- Also call `grafel_list_findings(type="security_finding")` to load findings already promoted to the graph (the `fingerprint=` trailer in each `answer` is the dedup key) so a re-run does not double-promote.
+- Also call `grafel_findings(action="list", type="security_finding")` to load findings already promoted to the graph (the `fingerprint=` trailer in each `answer` is the dedup key) so a re-run does not double-promote.
 - If no findings remain after deduplication: print "No new findings to confirm." and exit. An EMPTY finding set is the expected, correct outcome on a clean codebase — still write the index (Step 4) with all-zero counts; do not error or fabricate findings.
 
 ## Step 1 — Cost estimate
@@ -20,7 +20,7 @@ Gate on user confirmation unless `--auto` is set.
 
 For each finding in priority order (critical first, then high, medium, low, info):
 
-1. Call `grafel_expand(node=<entity_id>, depth=2)` to get neighbour context.
+1. Call `grafel_subgraph(node=<entity_id>, depth=2)` to get neighbour context.
 2. If tech docs exist at `~/.grafel/docs/<group>/<repo>/modules/`, load the relevant module README section.
 3. Construct an LLM prompt:
    > Entity: `<name>` (`<kind>`) in `<repo>`
@@ -40,25 +40,23 @@ For each finding in priority order (critical first, then high, medium, low, info
 
 ## Step 3 — Persist confirmed findings
 
-For each confirmed finding, call `grafel_save_finding` to promote it into
+For each confirmed finding, call `grafel_findings (action=save)` to promote it into
 the group memory store as a first-class, queryable `security_finding` record:
 ```
-grafel_save_finding(
-  type="security_finding",
+grafel_findings(action="save", type="security_finding",
   question="[<SEVERITY>] <check_name> on <entity_name>",
   answer="<explanation>\n\nseverity=<severity>; fingerprint=<fingerprint>; check=<check_name>",
-  nodes=["<entity_id>"]
-)
+  nodes=["<entity_id>"])
 ```
 
 Field mapping (the tool persists `type`, `nodes`, and `repo_filter` alongside
 `question`/`answer`):
 - `type="security_finding"` — promotes the record so it is queryable in
-  isolation via `grafel_list_findings(type="security_finding")`, separate
+  isolation via `grafel_findings(action="list", type="security_finding")`, separate
   from ordinary `note` findings.
 - `nodes=["<entity_id>"]` — the entity reference. This is what makes the
   finding graph-queryable by entity:
-  `grafel_list_findings(entity_id="<entity_id>")`. Do NOT pass `entity_id`
+  `grafel_findings(action="list", entity_id="<entity_id>")`. Do NOT pass `entity_id`
   or `severity` as top-level args — the tool ignores them; carry severity in
   the `question` prefix and the `answer` trailer instead.
 

--- a/skills/grafel-tech-docs/SKILL.md
+++ b/skills/grafel-tech-docs/SKILL.md
@@ -12,7 +12,7 @@ This skill is a direct extraction of the technical tier (Passes 0–12 + Pass 20
 
 ## CRITICAL TOOL DISCIPLINE (enforced on every pass — read before ANY action)
 
-For ANY question about "what entities/files exist in this codebase", "who calls X", "what does Y import", "what's in module Z", you MUST use grafel MCP tools: `grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`, `grafel_clusters`, `grafel_traces`, `grafel_whoami`.
+For ANY question about "what entities/files exist in this codebase", "who calls X", "what does Y import", "what's in module Z", you MUST use grafel MCP tools: `grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`, `grafel_orient (view=clusters)`, `grafel_trace`, `grafel_orient (view=me)`.
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase **for entity discovery**. Use Bash ONLY for reading specific source line ranges that `grafel_get_source` returns, running `grafel docgen --llm-mode=apply`, and writing output files into the staging directory.
 
@@ -20,7 +20,7 @@ If the MCP returns empty or seems wrong, file a side ticket and ABORT — do NOT
 
 ### Pre-flight assertion (FIRST action in every pass)
 
-Call `grafel_whoami` before doing anything else. If it errors: ABORT with "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/grafel-tech-docs`."
+Call `grafel_orient (view=me)` before doing anything else. If it errors: ABORT with "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/grafel-tech-docs`."
 
 ## When to use this skill
 
@@ -44,10 +44,10 @@ Do not invoke it for business-tier docs (that is `/grafel-business-docs`), enric
 
 Documentation is written into a **staging directory** during the run and atomically promoted to the canonical store only when all passes complete without errors. This makes in-repo write accidents architecturally impossible.
 
-1. **Pass 2** calls `grafel_docgen_start_run(group="<group>")` → receives `run_id` and `staging_path`.
+1. **Pass 2** calls `grafel_docgen(action="start", group="<group>")` → receives `run_id` and `staging_path`.
 2. **Passes 3–12** write doc files into `<staging_path>/<relative-path>` using the Write tool.
-3. **Pass 8** and **Pass 14** (if enrichment exists) call `grafel_docgen_validate(run_id)`.
-4. **Pass 20** (or end of pass chain) calls `grafel_docgen_promote(run_id)` to atomically move staging → canonical.
+3. **Pass 8** and **Pass 14** (if enrichment exists) call `grafel_docgen(action="validate", run_id)`.
+4. **Pass 20** (or end of pass chain) calls `grafel_docgen(action="promote", run_id)` to atomically move staging → canonical.
 
 ## Pass chain
 
@@ -117,13 +117,13 @@ Writer passes (3, 3a, 4, 5, 6, 12) emit repair candidates to `docgen-repairs.jso
 
 ## grafel MCP tool surface
 
-- `grafel_whoami`, `grafel_find`, `grafel_inspect`, `grafel_expand`
-- `grafel_trace`, `grafel_traces`, `grafel_clusters`, `grafel_stats`
-- `grafel_get_source`, `grafel_recent_activity`
-- `grafel_save_finding`, `grafel_list_findings`
-- `grafel_cross_links`, `grafel_enrichments`, `grafel_repairs`
+- `grafel_orient (view=me)`, `grafel_find`, `grafel_inspect`, `grafel_subgraph`
+- `grafel_trace`, `grafel_trace`, `grafel_orient (view=clusters)`, `grafel_orient (view=overview)`
+- `grafel_get_source`, `grafel_index_status`
+- `grafel_findings (action=save)`, `grafel_findings (action=list)`
+- `grafel_cross_links`, `grafel_docgen_apply (kind=enrichments)`, `grafel_docgen_apply (kind=repairs)`
 - `grafel_patterns`
-- `grafel_docgen_start_run`, `grafel_docgen_status`, `grafel_docgen_validate`, `grafel_docgen_promote`, `grafel_docgen_abort`, `grafel_docgen_list`
+- `grafel_docgen (action=start)`, `grafel_docgen (action=status)`, `grafel_docgen (action=validate)`, `grafel_docgen (action=promote)`, `grafel_docgen (action=abort)`, `grafel_docgen (action=list)`
 
 ## Related
 

--- a/skills/grafel-tech-docs/conventions/django.md
+++ b/skills/grafel-tech-docs/conventions/django.md
@@ -30,7 +30,7 @@ A Django "app" is the natural module boundary. For each app:
 - `migrations/*.py` are usually summarized, not described per-file.
 - `tests/` is excluded from generated docs.
 
-A community detected by `grafel_clusters` that mixes two apps is rare in idiomatic Django. When it happens, split it back along app boundaries.
+A community detected by `grafel_orient (view=clusters)` that mixes two apps is rare in idiomatic Django. When it happens, split it back along app boundaries.
 
 ## Entry points (Pass 3)
 

--- a/skills/grafel-tech-docs/conventions/react.md
+++ b/skills/grafel-tech-docs/conventions/react.md
@@ -35,7 +35,7 @@ src/
   routes/           # or app/ for Next.js
 ```
 
-An `grafel_clusters` cluster usually maps to one feature folder. When two features share a hook in `shared/hooks/`, that hook shows up as central in both communities — describe it in `shared`'s module page, not in either feature.
+An `grafel_orient (view=clusters)` cluster usually maps to one feature folder. When two features share a hook in `shared/hooks/`, that hook shows up as central in both communities — describe it in `shared`'s module page, not in either feature.
 
 ## Entry points (Pass 3)
 
@@ -82,4 +82,4 @@ A React repo connects out via:
 - WebSocket / SSE — note both ends.
 - Shared component package — if the repo consumes a sibling component library, that's a static import edge.
 
-For HTTP edges, the path is the most reliable join key. When `grafel_cross_links(action=list)` proposes `<this repo>.api/foo` → `<backend repo>.routes.foo`, accept if the path matches; the user's intent in question 10 of Pass 0 should already have predicted these. Note that `FETCHES` edges (HTTP consumer → endpoint) are now emitted by the indexer for fetch/axios calls — they appear in `grafel_expand` results and should be cited as first-class connections in module docs.
+For HTTP edges, the path is the most reliable join key. When `grafel_cross_links(action=list)` proposes `<this repo>.api/foo` → `<backend repo>.routes.foo`, accept if the path matches; the user's intent in question 10 of Pass 0 should already have predicted these. Note that `FETCHES` edges (HTTP consumer → endpoint) are now emitted by the indexer for fetch/axios calls — they appear in `grafel_subgraph` results and should be cited as first-class connections in module docs.

--- a/skills/grafel-tech-docs/output-templates/module-readme.md
+++ b/skills/grafel-tech-docs/output-templates/module-readme.md
@@ -8,7 +8,7 @@
 | ------ | ---- | ---- | ---- |
 | `<entity>` | Component\|Module\|Function\|Class | `<file:line>` | <one line> |
 
-> Pulled from `grafel_find` + `grafel_expand`. Sort by centrality. Entity names always backticked.
+> Pulled from `grafel_find` + `grafel_subgraph`. Sort by centrality. Entity names always backticked.
 
 ## Responsibilities
 
@@ -39,4 +39,4 @@
 
 ## Known gaps
 
-> If `grafel_enrichments(action=list)` returned anything blocking accurate documentation of this module, list it here. Each item: candidate id, what is unknown, what would unblock it.
+> If `grafel_docgen_apply(kind="enrichments", action=list)` returned anything blocking accurate documentation of this module, list it here. Each item: candidate id, what is unknown, what would unblock it.

--- a/skills/grafel-tech-docs/output-templates/reference-config.md
+++ b/skills/grafel-tech-docs/output-templates/reference-config.md
@@ -28,4 +28,4 @@
 
 ## Known gaps
 
-> List `grafel_enrichments(action=list, kind="env-var")` blockers here verbatim. Do not fabricate values.
+> List `grafel_docgen_apply(kind="enrichments", action=list, entity_kind="env-var")` blockers here verbatim. Do not fabricate values.

--- a/skills/grafel-tech-docs/output-templates/reference-deployment.md
+++ b/skills/grafel-tech-docs/output-templates/reference-deployment.md
@@ -37,4 +37,4 @@
 
 ## Known deployment pitfalls
 
-> Pull from the convention's `cross_cutting_pitfalls` and from prior incidents (if `grafel_recent_activity` surfaced any).
+> Pull from the convention's `cross_cutting_pitfalls` and from prior incidents (if `grafel_index_status` surfaced any).

--- a/skills/grafel-tech-docs/prompts/00-domain-qa.md
+++ b/skills/grafel-tech-docs/prompts/00-domain-qa.md
@@ -6,8 +6,8 @@
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -20,7 +20,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 

--- a/skills/grafel-tech-docs/prompts/01-inventory.md
+++ b/skills/grafel-tech-docs/prompts/01-inventory.md
@@ -6,8 +6,8 @@
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -20,7 +20,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -37,14 +37,14 @@ Discover what is actually in each repo by querying grafel. Do not read source fi
 
 ### Step 1 — Confirm group
 
-Call `grafel_whoami`. Verify the resolved group matches what the user expected. If it does not, stop and ask the user to set `cwd` or pass `group` explicitly.
+Call `grafel_orient (view=me)`. Verify the resolved group matches what the user expected. If it does not, stop and ask the user to set `cwd` or pass `group` explicitly.
 
 ### Step 2 — Corpus metrics
 
 For each repo `<r>` in the group:
 
 ```
-grafel_stats(repo_filter=["<r>"])
+grafel_orient(view="overview", repo_filter=["<r>"])
 ```
 
 Record: total nodes, total edges, top entity kinds, top edge kinds, communities count, bridge-doc count.
@@ -54,7 +54,7 @@ Record: total nodes, total edges, top entity kinds, top edge kinds, communities 
 For each repo:
 
 ```
-grafel_clusters(repo_filter=["<r>"])
+grafel_orient(view="clusters", repo_filter=["<r>"])
 ```
 
 A community is a candidate "module" for Pass 2 to plan around. Capture community id, size, and the top-5 entities (by centrality) in each. This is your raw module list before grouping.
@@ -72,14 +72,14 @@ These are pending cross-repo edges. Note them — Pass 8 will resolve them, but 
 For each repo:
 
 ```
-grafel_enrichments(action=list, repo_filter=["<r>"], limit=20)
+grafel_docgen_apply(kind="enrichments", action=list, repo_filter=["<r>"], limit=20)
 ```
 
 If anything blocks accurate documentation (e.g., an unresolved env-var, a class with unknown base), flag it. Pass 4 writers will need to either route around it or prompt the user during the deep-dive.
 
 ### Step 6 — Recent activity (optional)
 
-If the user said "regenerate after the recent refactor", call `grafel_recent_activity(since=<timestamp>)` and tag those entities so Pass 2 prioritizes their modules.
+If the user said "regenerate after the recent refactor", call `grafel_index_status(since=<timestamp>)` and tag those entities so Pass 2 prioritizes their modules.
 
 ## Output
 

--- a/skills/grafel-tech-docs/prompts/02-plan.md
+++ b/skills/grafel-tech-docs/prompts/02-plan.md
@@ -6,8 +6,8 @@
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -20,7 +20,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -30,14 +30,14 @@ Convert the raw community list from Pass 1 into a documentation plan. The plan i
 
 ## Staging run
 
-**FIRST action in this pass** (after `grafel_whoami`): call `grafel_docgen_start_run` to create a staging run for this group. Capture `run_id` and `staging_path` from the response and carry them through every subsequent write in this pass and all downstream passes.
+**FIRST action in this pass** (after `grafel_orient (view=me)`): call `grafel_docgen (action=start)` to create a staging run for this group. Capture `run_id` and `staging_path` from the response and carry them through every subsequent write in this pass and all downstream passes.
 
 ```
-grafel_docgen_start_run(group="<group>")
+grafel_docgen(action="start", group="<group>")
 # response: { "run_id": "<id>", "staging_path": "<project>/.grafel/staging/<id>/" }
 ```
 
-All doc files written in Passes 2–19 MUST target `<staging_path>/<relative-path>` rather than `~/.grafel/docs/<group>/`. The daemon promotes the staging directory to canonical at the end of Pass 20 via `grafel_docgen_promote`. Do NOT write to `~/.grafel/docs/` directly.
+All doc files written in Passes 2–19 MUST target `<staging_path>/<relative-path>` rather than `~/.grafel/docs/<group>/`. The daemon promotes the staging directory to canonical at the end of Pass 20 via `grafel_docgen (action=promote)`. Do NOT write to `~/.grafel/docs/` directly.
 
 Pass the `run_id` and `staging_path` to every downstream writer subagent and the orchestrator.
 
@@ -50,12 +50,12 @@ Pass the `run_id` and `staging_path` to every downstream writer subagent and the
 
 ### Step 1 — Group communities into modules
 
-A Louvain community from `grafel_clusters` is a graph cluster, not necessarily a "module" a human would want documented. Merge or split as needed:
+A Louvain community from `grafel_orient (view=clusters)` is a graph cluster, not necessarily a "module" a human would want documented. Merge or split as needed:
 
 - Merge two communities if they share more than 30% of their bridge-doc nodes or if their top-entity names share a clear prefix (e.g., `users.views`, `users.serializers` -> module `users`).
 - Split a community if it contains entities from two unrelated layers (e.g., HTTP handlers + DB migrations); rare, but the convention file for the stack tells you when to expect it.
 
-**Prefer real graph communities over directory fallback.** Call `grafel_clusters(repo_filter=["<r>"])` first. As of grafel #1620 communities persist through the daemon load path, so a non-empty cluster list is the norm. Only fall back to directory-derived modules when `grafel_clusters` genuinely returns `[]` for a repo.
+**Prefer real graph communities over directory fallback.** Call `grafel_orient(view="clusters", repo_filter=["<r>"])` first. As of grafel #1620 communities persist through the daemon load path, so a non-empty cluster list is the norm. Only fall back to directory-derived modules when `grafel_orient (view=clusters)` genuinely returns `[]` for a repo.
 
 #### Step 1b — Volume control (fragmentation guard)
 
@@ -84,8 +84,8 @@ Write `~/.grafel/groups/<group>/plan.json` (this is group metadata, NOT a doc fi
 ```json
 {
   "group": "<group>",
-  "run_id": "<run_id from grafel_docgen_start_run>",
-  "staging_path": "<staging_path from grafel_docgen_start_run>",
+  "run_id": "<run_id from grafel_docgen (action=start)>",
+  "staging_path": "<staging_path from grafel_docgen (action=start)>",
   "tiers": ["technical", "business"],
   "primary_repo": "<slug>",
   "volume_control": {

--- a/skills/grafel-tech-docs/prompts/03-overview.md
+++ b/skills/grafel-tech-docs/prompts/03-overview.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -48,7 +48,7 @@ For each repo `<r>`:
 
 ### Step 1 — Confirm scope
 
-Call `grafel_whoami` with `cwd=<repo absolute path>` so subsequent calls scope correctly. Then `grafel_stats(repo_filter=["<r>"])` to confirm the inventory numbers match.
+Call `grafel_orient (view=me)` with `cwd=<repo absolute path>` so subsequent calls scope correctly. Then `grafel_orient(view="overview", repo_filter=["<r>"])` to confirm the inventory numbers match.
 
 ### Step 2 — Identify the architectural skeleton
 
@@ -103,12 +103,10 @@ Use `source: "generate-docs/pass-3"` in every candidate emitted here.
 Call:
 
 ```
-grafel_save_finding(
-  question="What is the architectural overview of <repo>?",
+grafel_findings(action="save", question="What is the architectural overview of <repo>?",
   answer="<file: ~/.grafel/docs/<group>/<repo-slug>/overview.md>",
   type="overview",
-  repo_filter=["<r>"]
-)
+  repo_filter=["<r>"])
 ```
 
 This creates a memory entry the future grooming agents can find by query.

--- a/skills/grafel-tech-docs/prompts/03a-generation-time-repair.md
+++ b/skills/grafel-tech-docs/prompts/03a-generation-time-repair.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,20 +24,20 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
 ---
 
-A **hook**, not a standalone pass. Every writer subagent in Passes 3, 4, 5, 6, and 12 runs this check immediately before emitting prose that describes an entity. The hook is the primary site for `bind_to_entity` resolutions — Pass 1a deliberately defers those here because the writer has full local subgraph context via `grafel_expand`. It also catches residuals discovered late (after Pass 1a) that the earlier sweep missed.
+A **hook**, not a standalone pass. Every writer subagent in Passes 3, 4, 5, 6, and 12 runs this check immediately before emitting prose that describes an entity. The hook is the primary site for `bind_to_entity` resolutions — Pass 1a deliberately defers those here because the writer has full local subgraph context via `grafel_subgraph`. It also catches residuals discovered late (after Pass 1a) that the earlier sweep missed.
 
 ## When the hook fires
 
 Every time a writer is about to write a paragraph about an entity `E`, run:
 
 ```
-grafel_repairs(action=list, repo_filter=[<repo of E>], limit=20)
+grafel_docgen_apply(kind="repairs", action=list, repo_filter=[<repo of E>], limit=20)
 ```
 
 Filter the result client-side to residuals whose `from_entity.id == E.id`. If the filtered set is empty, write the prose as planned and continue.
@@ -46,12 +46,12 @@ Filter the result client-side to residuals whose `from_entity.id == E.id`. If th
 
 For each residual where `from_entity.id == E.id`:
 
-1. Inspect the residual's `original_stub`, `relation`, and the entity's neighborhood (`grafel_expand(node=E.id, depth=1)` or `grafel_inspect`).
+1. Inspect the residual's `original_stub`, `relation`, and the entity's neighborhood (`grafel_subgraph(node=E.id, depth=1)` or `grafel_inspect`).
 2. Decide whether you can submit a repair **without asking the user**. The same auto-resolve criteria from Pass 1a apply:
    - Unambiguous binding target visible in the local subgraph, OR
    - Matches an active template in `repair-templates.json`, OR
    - Recognised third-party module.
-3. If auto-resolve is possible: `grafel_repairs(action=submit, ...)` with `source="generate-docs/pass-3a"`, then write the prose **as if the edge were resolved** — describe the target the repair points at, not the original stub.
+3. If auto-resolve is possible: `grafel_docgen_apply(kind="repairs", action=submit, ...)` with `source="generate-docs/pass-3a"`, then write the prose **as if the edge were resolved** — describe the target the repair points at, not the original stub.
 4. If auto-resolve is not possible: write the prose with an explicit "runtime-resolved" callout (see template below). Do **not** silently drop the edge.
 
 ## Prose template for unresolved residuals
@@ -67,13 +67,13 @@ The phrasing must match this shape so downstream readers (and ADR-0007's doc-as-
 ## What NOT to do
 
 - Do **not** invent a target entity to make the prose flow nicely. If the static graph doesn't have it and the agent can't repair it, the callout is the right output.
-- Do **not** call `grafel_repairs(action=submit)` with `reasoning` that's just the entity name. Reasoning must be a sentence (R7 in the trust model treats short reasoning as suspicious).
+- Do **not** call `grafel_docgen_apply(kind="repairs", action=submit)` with `reasoning` that's just the entity name. Reasoning must be a sentence (R7 in the trust model treats short reasoning as suspicious).
 - Do **not** spam the user with questions mid-prose-generation. The user-interactive surface for residuals is Pass 1b. If a residual escaped Pass 1b, this hook either repairs it silently or documents it as runtime-resolved — never breaks out to ask.
 - Do **not** modify the writer's existing output template structure. The "Runtime-resolved edge" callout is inserted as an admonition inside whatever section was already going to describe the entity's outbound calls.
 
 ## Throughput considerations
 
-Phase 1 of #732 ships the synchronous in-prose hook. On a 5k-residual graph this adds one `grafel_repairs(action=list)` per entity. Mitigations:
+Phase 1 of #732 ships the synchronous in-prose hook. On a 5k-residual graph this adds one `grafel_docgen_apply(kind="repairs", action=list)` per entity. Mitigations:
 
 - Cache the per-repo residual list at the start of each writer subagent's run; refresh only if a submit was made.
 - Skip the hook for entities whose `from_entity.id` does not appear in the cached residual set — most entities will have zero residuals.
@@ -83,7 +83,7 @@ Phase 1 of #732 ships the synchronous in-prose hook. On a 5k-residual graph this
 
 The Pass 3a hook is also the primary site for **docgen repair emission** per
 `snippets/docgen-repair-emission.md`. The hook's repair submissions go through
-`grafel_repairs(action=submit)` (the existing channel). But when the hook
+`grafel_docgen_apply(kind="repairs", action=submit)` (the existing channel). But when the hook
 sees facts about an entity that are broader than the residual being acted on —
 for example, while resolving a residual for `OrderService` you notice that a
 _separate_ `UNRESOLVED` stub elsewhere in the subgraph resolves to a visible
@@ -94,14 +94,14 @@ Use `source: "generate-docs/pass-3a"` in all candidates emitted from this hook.
 
 Confidence rules: same as `snippets/docgen-repair-emission.md`. The two
 channels complement each other:
-- `grafel_repairs(action=submit)` — fixes the residual in the daemon
+- `grafel_docgen_apply(kind="repairs", action=submit)` — fixes the residual in the daemon
   immediately (this pass always did this).
-- `docgen-repairs.jsonl` append — feeds the post-run `grafel_apply_docgen_repairs`
+- `docgen-repairs.jsonl` append — feeds the post-run `grafel_docgen_apply (kind=repairs)`
   batch for fidelity tracking and for repairs that touch entities outside the
   current residual set (e.g. kind mis-classifications, external library labels).
 
 Do NOT double-count: if you already submitted a repair via
-`grafel_repairs(action=submit)`, you MAY also emit the same observation to
+`grafel_docgen_apply(kind="repairs", action=submit)`, you MAY also emit the same observation to
 `docgen-repairs.jsonl` — the daemon deduplicates. This lets the fidelity delta
 capture every discovery regardless of which path applied it.
 
@@ -120,7 +120,7 @@ When a pattern's recipe references an entity with unresolved outbound edges, the
 ## Invariants
 
 - The hook runs at every "describe-this-entity" boundary. Never skip for performance — the cache makes it cheap.
-- Writes go through `grafel_repairs(action=submit)` only. No direct file writes.
+- Writes go through `grafel_docgen_apply(kind="repairs", action=submit)` only. No direct file writes.
 - The hook is idempotent: running it twice on the same entity produces zero new submits because the second pass sees `total == 0` for that `from_entity.id`.
 - Source attribution: every submit from this pass uses `source="generate-docs/pass-3a"` so the audit trail distinguishes sweep-time from generation-time repairs.
 

--- a/skills/grafel-tech-docs/prompts/04-cluster.md
+++ b/skills/grafel-tech-docs/prompts/04-cluster.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -71,7 +71,7 @@ grafel_find(
 Then for each of the top-5 entities in the module:
 
 ```
-grafel_expand(node="<entity>", depth=2, repo_filter=["<repo>"])
+grafel_subgraph(node="<entity>", depth=2, repo_filter=["<repo>"])
 ```
 
 These neighbors are what you describe in the module README's "Key entities" section.
@@ -98,17 +98,17 @@ When you find one, name both ends of the connection in a backticked heading insi
 **Process flows (added in #724).** For modules that own entry points (HTTP route handlers, scheduled jobs, message consumers), call:
 
 ```
-grafel_traces(action=list, repo_filter=["<repo>"], limit=25)
+grafel_trace(action=list, repo_filter=["<repo>"], limit=25)
 ```
 
 This returns pre-computed BFS call chains from the indexer's pass over the CALLS graph. For each process whose `entry_id` falls within your module's community, either:
 
 - Include the call chain directly in `flows.md` as a numbered list under a `## Process flows` section, OR
-- Call `grafel_traces(action=follow, entry_point_id=<id>, max_depth=8)` for entities that were not selected as pre-computed entry points.
+- Call `grafel_trace(action=follow, entry_point_id=<id>, max_depth=8)` for entities that were not selected as pre-computed entry points.
 
-Until #769 lands, `grafel_traces` returns chains that stay within a single repo — describe cross-repo flows from `grafel_cross_links` instead.
+Until #769 lands, `grafel_trace` returns chains that stay within a single repo — describe cross-repo flows from `grafel_cross_links` instead.
 
-**New edge kinds to surface in prose.** grafel now emits several richer edge kinds introduced in 2026-05. When you encounter these via `grafel_expand` or `grafel_find`, include the corresponding narrative:
+**New edge kinds to surface in prose.** grafel now emits several richer edge kinds introduced in 2026-05. When you encounter these via `grafel_subgraph` or `grafel_find`, include the corresponding narrative:
 
 - **`FETCHES`** (HTTP consumer → endpoint): "Frontend `X` FETCHES backend endpoint `Y` via `Z`." Include in `flows.md` under an "HTTP consumer flows" section.
 - **`QUERIES`** (code → ORM table/column): "Service `A` QUERIES table `B` (columns `C`, `D`)." Include in `flows.md` under "Data access flows" or in `reference/api.md` if the module is the primary owner.
@@ -119,7 +119,7 @@ Until #769 lands, `grafel_traces` returns chains that stay within a single repo 
 
 When you find entities of kind `Queue` (generic message broker abstraction, e.g., RabbitMQ, SQS, Google Pub-Sub) or `MessageTopic` (Kafka-specific topic), treat them as message destinations and document them in the event-flows section rather than the data-model section. Note the distinction: `Queue` is a broker-agnostic concept, while `MessageTopic` is Kafka-specific.
 
-**Empty-result rule (#1618 — the top quality failure).** When `grafel_find_callees`, `grafel_find_callers`, `grafel_expand`, or `grafel_traces(action=follow)` returns an empty edge list for a valid entity, the response carries `"result": "no_outgoing_edges"` / `"no_incoming_edges"` / `"no_edges"` / `"no_outgoing_calls"`. This is an explicit graph signal, not a gap to fill.
+**Empty-result rule (#1618 — the top quality failure).** When `grafel_related (direction=callees)`, `grafel_related (direction=callers)`, `grafel_subgraph`, or `grafel_trace(action=follow)` returns an empty edge list for a valid entity, the response carries `"result": "no_outgoing_edges"` / `"no_incoming_edges"` / `"no_edges"` / `"no_outgoing_calls"`. This is an explicit graph signal, not a gap to fill.
 
 Required behaviour:
 - **State the absence verbatim**: "The graph records no callee/edge for `X`."
@@ -163,13 +163,11 @@ Use `source: "generate-docs/pass-4"` in every candidate.
 ### Step 8 — Save
 
 ```
-grafel_save_finding(
-  question="What does the <module-slug> module do in <repo>?",
+grafel_findings(action="save", question="What does the <module-slug> module do in <repo>?",
   answer="<file: ~/.grafel/docs/<group>/<repo-slug>/modules/<module-slug>/README.md>",
   type="module",
   nodes=["<top-entity-1>", "<top-entity-2>"],
-  repo_filter=["<repo>"],
-)
+  repo_filter=["<repo>"],)
 ```
 
 Hand control back to the orchestrator. The orchestrator joins all writer subagents and starts Pass 5 only when every module has produced verified output.

--- a/skills/grafel-tech-docs/prompts/05-reference.md
+++ b/skills/grafel-tech-docs/prompts/05-reference.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -72,10 +72,10 @@ For each route/export, capture: name (in backticks), kind, file path, and a one-
 ```
 grafel_find(question="environment variables", repo_filter=["<r>"], depth=2, token_budget=900)
 grafel_find(question="settings constants", repo_filter=["<r>"], depth=2, token_budget=900)
-grafel_enrichments(action=list, repo_filter=["<r>"], kind="env-var")
+grafel_docgen_apply(kind="enrichments", action=list, repo_filter=["<r>"], entity_kind="env-var")
 ```
 
-If `grafel_enrichments(action=list)` returns blocking unknowns, list them in a "Known gaps" section. Do not fabricate values.
+If `grafel_docgen_apply(kind="enrichments", action=list)` returns blocking unknowns, list them in a "Known gaps" section. Do not fabricate values.
 
 ### `deployment.md`
 
@@ -150,12 +150,10 @@ Use `source: "generate-docs/pass-5"` in every candidate. Append to
 Then save:
 
 ```
-grafel_save_finding(
-  question="What is the reference documentation for <repo>?",
+grafel_findings(action="save", question="What is the reference documentation for <repo>?",
   answer="<paths to reference/*.md>",
   type="reference",
-  repo_filter=["<r>"],
-)
+  repo_filter=["<r>"],)
 ```
 
 When all repos in the group have completed reference docs, hand back to the orchestrator.

--- a/skills/grafel-tech-docs/prompts/06-cross-cutting.md
+++ b/skills/grafel-tech-docs/prompts/06-cross-cutting.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 

--- a/skills/grafel-tech-docs/prompts/07-group-synthesis.md
+++ b/skills/grafel-tech-docs/prompts/07-group-synthesis.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -71,7 +71,7 @@ Fill `output-templates/group-synthesis.md`. Required sections:
 1. **What this group does** — one-paragraph mission lifted from `domain.md`.
 2. **Repos at a glance** — table from `domain.md` repos block.
 3. **Runtime communication map** — describe the synchronous and asynchronous edges across repos. Include:
-   - HTTP call chains surfaced via `grafel_traces` (process flows). Note: until #769 lands, only single-repo chains are available; describe cross-repo flows via `grafel_cross_links` instead.
+   - HTTP call chains surfaced via `grafel_trace` (process flows). Note: until #769 lands, only single-repo chains are available; describe cross-repo flows via `grafel_cross_links` instead.
    - `FETCHES` edges: which frontend/consumer calls which backend endpoint.
    - `PUBLISHES_TO` / `SUBSCRIBES_TO` / `TRANSFORMS` edges: event flows through `Queue` (generic brokers) and `MessageTopic` (Kafka-specific) entities.
    - Real-time edges (`WS_SUBSCRIBES_TO`, `WS_EMITS`, `GRAPHQL_SUBSCRIBES`, `GRAPHQL_PUBLISHES`, `STREAMS_FROM`, `STREAMS_TO`): WebSocket, SSE, and GraphQL subscription flows.
@@ -88,11 +88,9 @@ Every code identifier in every heading must be backticked. The synthesis page is
 ### Step 5 — Save
 
 ```
-grafel_save_finding(
-  question="What is the synthesized architecture of the <group> group?",
+grafel_findings(action="save", question="What is the synthesized architecture of the <group> group?",
   answer="<file: ~/.grafel/groups/<group>/docs/group-synthesis.md>",
-  type="synthesis",
-)
+  type="synthesis",)
 ```
 
 Hand back to the orchestrator.

--- a/skills/grafel-tech-docs/prompts/08-cross-link.md
+++ b/skills/grafel-tech-docs/prompts/08-cross-link.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -37,12 +37,12 @@ Two responsibilities:
 
 ## Step 1 — Static link check via MCP
 
-Call `grafel_docgen_validate` to lint frontmatter and cross-links across the
+Call `grafel_docgen (action=validate)` to lint frontmatter and cross-links across the
 entire staging tree in a single structured response. Pass the `run_id` from
 `plan.json`:
 
 ```
-grafel_docgen_validate(run_id="<run_id>")
+grafel_docgen(action="validate", run_id="<run_id>")
 # response: { "frontmatter_errors": [...], "link_errors": [...], "ok": true|false }
 ```
 
@@ -51,7 +51,7 @@ links. Broken links must be repaired (or downgraded to backticked identifiers)
 before the run can be considered clean — the report's "Broken intra-doc links"
 section must be empty.
 
-The `grafel_docgen_validate` tool applies the same rules as
+The `grafel_docgen (action=validate)` tool applies the same rules as
 `snippets/link-hygiene.md` and `snippets/anchor-contract.md` (which remain the
 source-of-truth documentation for WHAT constitutes a valid link/anchor). The
 tool enforces them across the whole staging tree including:
@@ -104,13 +104,13 @@ Record every decision in `~/.grafel/groups/<group>/docs/cross-links.md` so a hum
 Anything that blocked a doc page in earlier passes shows up in:
 
 ```
-grafel_enrichments(action=list, limit=100)
+grafel_docgen_apply(kind="enrichments", action=list, limit=100)
 ```
 
 For each:
 
-- If you can answer it from the docs you just wrote, call `grafel_enrichments(action=submit, candidate_id=..., value=..., confidence=...)`.
-- If you cannot, call `grafel_enrichments(action=reject, candidate_id=..., reason=...)`.
+- If you can answer it from the docs you just wrote, call `grafel_docgen_apply(kind="enrichments", action=submit, candidate_id=..., value=..., confidence=...)`.
+- If you cannot, call `grafel_docgen_apply(kind="enrichments", action=reject, candidate_id=..., reason=...)`.
 - If a human must decide, leave it alone and list it in the cross-link report under "Human-required enrichment".
 
 ## Step 4 — Report

--- a/skills/grafel-tech-docs/prompts/10-pattern-convergence.md
+++ b/skills/grafel-tech-docs/prompts/10-pattern-convergence.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 

--- a/skills/grafel-tech-docs/prompts/11-pattern-cross-link.md
+++ b/skills/grafel-tech-docs/prompts/11-pattern-cross-link.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 

--- a/skills/grafel-tech-docs/prompts/12-pattern-prose.md
+++ b/skills/grafel-tech-docs/prompts/12-pattern-prose.md
@@ -10,8 +10,8 @@ Read `run_id` and `staging_path` from `~/.grafel/groups/<group>/plan.json` (writ
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -24,7 +24,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -96,7 +96,7 @@ If a heading legitimately contains a CamelCase word that is NOT a code identifie
 For each approved pattern `p` (every pattern with `is_candidate=false`) that was newly promoted in this run OR refined in this run:
 
 1. Resolve exemplar entities to `ExemplarRef` tuples via `grafel_inspect(label_or_id=<entity_name>)` for entity-name + `grafel_get_source` for file path + line range.
-2. Resolve all outgoing pattern-relationship edges via `grafel_expand(node=<pattern_id>, depth=1)`:
+2. Resolve all outgoing pattern-relationship edges via `grafel_subgraph(node=<pattern_id>, depth=1)`:
    - **`SUPERSEDES`** → RelatedPattern (this pattern replaces the linked one).
    - **`CO_APPLIES_WITH`** → RelatedPattern (typically applied together).
    - **`PREREQUISITE`** → RelatedPattern (the linked pattern must be satisfied first).

--- a/skills/grafel-tech-docs/prompts/20-llm-orchestrate.md
+++ b/skills/grafel-tech-docs/prompts/20-llm-orchestrate.md
@@ -6,8 +6,8 @@
 ========================
 For ANY question about "what entities/files exist in this codebase", "who calls X",
 "what does Y import", "what's in module Z", you MUST use grafel MCP tools:
-`grafel_inspect`, `grafel_find`, `grafel_expand`, `grafel_stats`,
-`grafel_clusters`, `grafel_whoami`, (full list in SKILL.md).
+`grafel_inspect`, `grafel_find`, `grafel_subgraph`, `grafel_orient (view=overview)`,
+`grafel_orient (view=clusters)`, `grafel_orient (view=me)`, (full list in SKILL.md).
 
 You are STRICTLY FORBIDDEN from using `find`/`ls`/`wc`/`grep` on the codebase for
 entity discovery, or reading source files directly to enumerate APIs.
@@ -20,7 +20,7 @@ do NOT silently substitute grep results for graph queries.
 
 ### Pre-flight assertion -- FIRST action in this pass
 
-Call `grafel_whoami` before doing anything else in this pass. If it errors:
+Call `grafel_orient (view=me)` before doing anything else in this pass. If it errors:
 ABORT with: "grafel MCP not configured for this directory. Run `/mcp` to fix, then re-invoke `/generate-docs`."
 
 
@@ -238,12 +238,12 @@ LLM orchestrate complete
 ### Step 8 — Promote staging to canonical
 
 Once all bundles are processed and `contract failures: 0`, call
-`grafel_docgen_promote` to atomically move the staging directory to the
+`grafel_docgen (action=promote)` to atomically move the staging directory to the
 canonical docs location. Read `run_id` from
 `~/.grafel/groups/<group>/plan.json`.
 
 ```
-grafel_docgen_promote(run_id="<run_id>")
+grafel_docgen(action="promote", run_id="<run_id>")
 # response: { "promoted": true, "canonical_path": "~/.grafel/docs/<group>/",
 #             "files_promoted": N }
 ```
@@ -258,7 +258,7 @@ not have. Report the exact error to the user:
 
 > "Promote refused: SSG scaffolding detected (`<file>`). The generate-docs skill
 > must not emit build manifests. Remove the offending file from the staging
-> directory and re-try promote, or run `grafel_docgen_abort(run_id=...)` to
+> directory and re-try promote, or run `grafel_docgen(action="abort", run_id=...)` to
 > discard the run and start over."
 
 Do NOT silently remove the offending file. Surface it to the user so the writer

--- a/skills/grafel-tech-docs/snippets/docgen-repair-emission.md
+++ b/skills/grafel-tech-docs/snippets/docgen-repair-emission.md
@@ -39,7 +39,7 @@ After the doc is written (AFTER — do not interrupt prose generation):
    ~/.grafel/groups/<group>/docgen-repairs.jsonl
    ```
 
-   To obtain the exact path, call `grafel_apply_docgen_repairs` with no
+   To obtain the exact path, call `grafel_docgen_apply (kind=repairs)` with no
    parameters and read the `state_dir` field, or use the path recorded in
    `docgen-state.json`.
 
@@ -207,7 +207,7 @@ business workflow, distinguished only by an A/B flag at entry. Emission:
 - Never emit below confidence 0.5. If you are not sure, use the Pass 3a
   "Runtime-resolved edge" callout in prose instead.
 - Emission is additive: if the same repair was already submitted by Pass 1a or
-  Pass 3a via `grafel_repairs(action=submit)`, the daemon deduplicates; you
+  Pass 3a via `grafel_docgen_apply(kind="repairs", action=submit)`, the daemon deduplicates; you
   may still emit it here — the duplicate will be silently dropped.
 - The JSONL file may already contain entries from a prior pass or a prior run;
   always append, never overwrite.

--- a/skills/grafel-tech-docs/snippets/link-hygiene.md
+++ b/skills/grafel-tech-docs/snippets/link-hygiene.md
@@ -47,7 +47,7 @@ The registry slug (`upvate-core`, hyphenated) and the on-disk directory
 `upvate_core`).
 
 - **Relative link paths** (`../../<dir>/docs/...`) MUST use the actual
-  filesystem directory name. Resolve it from `grafel_whoami` /
+  filesystem directory name. Resolve it from `grafel_orient (view=me)` /
   `inventory.json` `repo.path` (the last path segment), not from the slug.
 - **Prose / display text** may use the human slug.
 

--- a/skills/using-grafel/SKILL.md
+++ b/skills/using-grafel/SKILL.md
@@ -2,702 +2,306 @@
 name: using-grafel
 description: >
   Teaches an AI agent how to use grafel MCP tools effectively when working
-  on a registered codebase. Covers tool selection, Pass-based orientation
-  workflows, worked examples, and explicit anti-patterns.
+  on a registered codebase. A task-oriented intent-to-tool map over the 22
+  canonical tools, plus orientation workflow and hard anti-patterns.
 type: behavior
 when-to-use: >
   Invoke when you open a codebase that has grafel indexed, when you are
   about to navigate a large or unfamiliar codebase, or when you are asked a
-  structural question (trace a flow, find callers, understand module layout)
-  and the grafel daemon is running. Do NOT invoke for single-symbol lookups
-  or for codebases that have never been indexed.
+  structural question (trace a flow, find callers, compare two endpoints,
+  understand module layout) and the grafel daemon is running. Do NOT invoke
+  for single-symbol lookups or for codebases that have never been indexed.
 ---
 
 # using-grafel
 
-A practical guide for AI agents working in an grafel-registered codebase.
-This skill covers when to use grafel vs. grep, which of the 28 MCP tools
-to call for which task, Pass-based workflows, and hard anti-patterns.
+A practical routing guide for AI agents in a grafel-registered codebase.
+grafel exposes **22 intent-named tools**. Each one collapses a family of
+related operations under a single verb with a discriminator parameter
+(`kind` / `direction` / `aspect` / `detail` / `action` / `scope`). Pick the
+tool by **intent**, then pick the discriminator value for the specific
+question.
+
+The single biggest win: **stop reasoning over raw source by hand.** When the
+question is "are these two things different?", "what's affected?", "what
+calls this?", or "what flows through here?", there is a dedicated tool that
+answers it structurally. Reaching for `grafel_get_source` + manual reading is
+the slow, error-prone path.
 
 ---
 
-## 1. Should I use grafel at all?
+## 1. Intent → tool map
 
-Use grafel when the answer requires **graph traversal** — understanding
-relationships between entities, tracing call chains, discovering callers,
-mapping module clusters. Reach for grep/Read when you need **text search** —
-find where a string literal appears, read a specific file, check a config value.
+### Comparison & analysis (reach here FIRST)
 
-### Decision matrix
+| Your intent | Tool + discriminator |
+|---|---|
+| Compare reference vs candidate response shape | `grafel_diff` `aspect=response_shape` — **not** `get_source` + eyeball |
+| Compare request payloads between two refs | `grafel_diff` `aspect=payload` |
+| Compare auth posture between two refs | `grafel_diff` `aspect=auth` |
+| Compare constant/literal parity between two refs | `grafel_diff` `aspect=literals` |
+| Compare arbitrary entity sets between two refs | `grafel_diff` `aspect=refs` |
+| What's affected if I change X (one entity) | `grafel_impact_radius` `scope=entity` |
+| What's affected by this changeset / PR | `grafel_impact_radius` `scope=changeset` |
+| Tech-debt: dead code | `grafel_debt` `kind=dead_code` |
+| Tech-debt: import/dependency cycles | `grafel_debt` `kind=cycles` |
+| Tech-debt: stub / unimplemented functions | `grafel_debt` `kind=stubs` |
+| Tech-debt: impure functions | `grafel_debt` `kind=impure` |
+| License audit | `grafel_debt` `kind=license` |
+| Security findings | `grafel_security` `kind=findings` |
+| Hardcoded secrets | `grafel_security` `kind=secrets` |
+| Auth coverage across endpoints | `grafel_security` `kind=auth_coverage` |
+| Test coverage | `grafel_test_analysis` `kind=coverage` |
+| Test reachability | `grafel_test_analysis` `kind=reachability` |
+| Contract-test effectiveness | `grafel_test_analysis` `kind=contract_effectiveness` |
+| Recurring code patterns | `grafel_patterns` `kind=code` |
+| Recurring graph patterns | `grafel_patterns` `kind=graph` |
+| Template patterns | `grafel_patterns` `kind=template` |
 
-| Task | Tool |
-|------|------|
-| "What calls `PaymentService.charge`?" | `grafel_find` + `grafel_expand` |
-| "Where is the string `PAYMENT_GATEWAY_URL` used?" | `grep` / `rg` |
-| "Trace from the checkout route to the database write" | `grafel_trace` or `grafel_traces` |
-| "Read the implementation of `OrderSerializer`" | `grafel_get_source` |
-| "Which modules exist in this repo?" | `grafel_clusters` |
-| "What changed in the last hour?" | `grafel_recent_activity` |
-| "How many entities does this group have?" | `grafel_stats` |
-| "Find where `ORDER_STATUS_PENDING` is defined" | `grep` / `rg` |
-| "Which HTTP endpoints does the frontend call?" | `grafel_endpoints(action=calls)` |
-| "Are there any orphan call-sites (calls with no handler)?" | `grafel_endpoints(action=calls, orphan_only=true)` |
-| "What is the overall architecture of this group?" | `grafel_clusters` + `grafel_stats` |
-| "What is `OrderViewSet`'s source?" | `grafel_get_source` |
+### Navigation & traversal
 
-**Skip grafel entirely** when:
-- The question is answered by reading a single known file.
-- You only need to search for a literal string or regex pattern.
-- The repo has never been indexed (check: `grafel_whoami` returns `source: "none"`).
-- The task takes fewer steps via grep than via graph query.
+| Your intent | Tool + discriminator |
+|---|---|
+| What calls X | `grafel_related` `direction=callers` |
+| What X calls | `grafel_related` `direction=callees` |
+| Direct neighbours of X | `grafel_related` `direction=neighbors` |
+| What X uses | `grafel_related` `direction=uses` |
+| What uses X | `grafel_related` `direction=used_by` |
+| Route(s) between two entities | `grafel_find_paths` |
+| Graph slice around entity(s) | `grafel_subgraph` |
+| Trace data flow | `grafel_trace` `kind=data` |
+| Trace control flow | `grafel_trace` `kind=control` |
+| Trace def-use | `grafel_trace` `kind=def_use` |
+| Trace effects | `grafel_trace` `kind=effects` |
 
----
+### Locate & read
 
-## 2. Orientation (Pass 0 — always run first)
+| Your intent | Tool |
+|---|---|
+| Find entities by name/pattern/kind | `grafel_find` |
+| Full detail on one entity | `grafel_inspect` |
+| Raw source for an entity/range | `grafel_get_source` |
 
-Before doing anything else in an unfamiliar codebase, run a three-call
-orientation sequence. This costs ~200 tokens and prevents dozens of wasted
-traversals.
+### HTTP surface
 
-```
-# Step 1: Am I in a registered group? Which repo am I in?
-grafel_whoami()
+| Your intent | Tool + discriminator |
+|---|---|
+| List HTTP endpoints | `grafel_endpoints` `detail=list` |
+| Endpoint contract (request/response shape) | `grafel_endpoints` `detail=contract` |
+| Endpoint security posture | `grafel_endpoints` `detail=posture` |
+| Cross-repo client→server HTTP joins | `grafel_cross_links` |
 
-# Step 2: How big is this group? Any repos unavailable?
-grafel_stats()
+### Orientation
 
-# Step 3: What are the major subsystems (Louvain communities)?
-grafel_clusters()
-```
+| Your intent | Tool + discriminator |
+|---|---|
+| Where am I / which group+repo | `grafel_orient` `view=me` |
+| Codebase overview | `grafel_orient` `view=overview` |
+| Module clusters | `grafel_orient` `view=clusters` |
+| Topology | `grafel_orient` `view=topology` |
+| Module breakdown | `grafel_orient` `view=modules` |
+| Per-repo freshness / is it indexed | `grafel_index_status` |
 
-From these three calls you learn:
-- The group name, the active repo, and any sibling repos.
-- Total entity + relationship counts per repo (ballpark for scoping decisions).
-- The top-3 entities in each community, which is a fast module map.
+### Findings & workflow
 
-**Only proceed to deeper passes once you know the landscape.**
+| Your intent | Tool + discriminator |
+|---|---|
+| List saved findings | `grafel_findings` `action=list` |
+| Save a finding | `grafel_findings` `action=save` |
+| Run docgen lifecycle | `grafel_docgen` `action=start·status·list·promote·abort·validate` |
+| Apply doc semantics/repairs/enrichments | `grafel_docgen_apply` `kind=semantics·repairs·enrichments` |
 
----
+### Meta
 
-## 3. Tool catalogue (all 28 tools)
-
-### 3.1 Orientation tools
-
-#### `grafel_whoami`
-Resolves the group and repo for your current working directory. Call this
-first in every session. Returns `source` (`cwd-marker`, `singleton`, `none`)
-so you know how confident the resolution is.
-
-```
-grafel_whoami()
-→ { "group": "orders-platform", "repo": "orders-api", "source": "cwd-marker" }
-```
-
-CLI equivalent: `grafel status`
-
-#### `grafel_stats`
-Corpus-level counts: entities, relationships, communities per repo, plus any
-repos that failed to load. Use to scope token budgets — a 50k-entity repo
-needs tighter `token_budget` limits than a 2k-entity one.
-
-```
-grafel_stats()
-→ { "entities": 8432, "relationships": 41200, "cross_repo_links": 23, "repos": [...] }
-```
-
-CLI equivalent: `grafel stats` (not yet implemented; use MCP)
-
-#### `grafel_clusters`
-Returns Louvain communities pre-computed during indexing. Each cluster has a
-`size`, a `modularity` score, and `top_entities` — the highest-PageRank
-entities in the cluster. Use to discover module names you can then target with
-`grafel_find`.
-
-```
-grafel_clusters(repo_filter=["orders-api"])
-→ [{ "id": 3, "size": 47, "modularity": 0.41, "top_entities": ["OrderViewSet", ...] }]
-```
+| Your intent | Tool + discriminator |
+|---|---|
+| Emit feedback telemetry | `grafel_event` `kind=feedback` |
+| Emit persona telemetry | `grafel_event` `kind=persona` |
+| Tool-call metrics | `grafel_mcp_metrics` |
 
 ---
 
-### 3.2 Discovery tools
+## 2. Should I use grafel at all?
 
-#### `grafel_find`
-BM25-ranked graph query, optionally BFS-expanded from each top hit. The
-primary discovery tool — reach for it when you know what you are looking for
-but not where it lives.
+Use grafel when the answer requires **graph traversal or structural
+comparison** — relationships, call chains, flows, impact, diffs, posture.
+Reach for grep/Read when you need **text search** — find a literal string,
+read one known file, check a config value.
 
-**Scope default (since #2643):** by default the search is scoped to the
-cwd-resolved repo (eliminates cross-repo noise in single-repo workflows).
-Pass `cross_repo=true` to span all repos in the group, or use `repo_filter`
-to select specific repos explicitly.
-
-Key parameters:
-- `question` — natural-language query (BM25 tokenises it against entity labels
-  and qualified names).
-- `depth` — BFS hops from each match (default 3; use 1 for a tight result set,
-  0 to skip BFS entirely).
-- `token_budget` — max approximate tokens in compact output (default 800;
-  lower for orientation, higher for deep inventory).
-- `repo_filter` — restrict to one or more repos by slug (takes priority over
-  `cross_repo`).
-- `cross_repo` — set `true` to search all repos in the group (opt-in; default
-  `false`).
-- `context_filter` — restrict BFS traversal to specific edge kinds
-  (`CALLS`, `IMPORTS`, `PUBLISHES_TO`, etc.).
-
-```
-grafel_find(question="payment processing charge refund", depth=2, token_budget=600)
-grafel_find(question="order HTTP routes endpoints", repo_filter=["orders-api"], depth=1)
-grafel_find(question="auth token validation middleware", context_filter=["CALLS"], depth=3)
-grafel_find(question="auth token", cross_repo=true)   # span all repos
-```
-
-CLI equivalent: `grafel search "payment processing"` (thin RPC wrapper)
-
-#### `grafel_inspect`
-Look up a single entity by ID, prefixed cross-repo ID, qualified name, or
-label. Use when `grafel_find` gave you an ID and you want the full
-structured record (file, line range, PageRank, community, properties). Also
-auto-attaches any saved findings that reference this entity.
-
-The response includes **line-precise edge arrays** (Pass-3 READ protocol):
-- `calls[]` — outbound CALLS edges: `{target, target_path, line, via}` where
-  `line` is the line in the inspected entity's body where the call appears.
-- `called_by[]` — inbound CALLS edges: `{source, source_path, line, context}`
-  where `line` is the line in the caller's body and `context` is a ~40-char
-  snippet around the call site (empty when source not on disk).
-
-Use these to answer "which line invokes what" without calling `get_source`.
-
-```
-grafel_inspect(label_or_id="OrderViewSet")
-grafel_inspect(label_or_id="orders-api::a1b2c3d4e5f60718")
-```
+**Skip grafel** when:
+- The question is answered by reading a single known file (use `Read`).
+- You only need a literal string or regex (`rg`).
+- The repo has never been indexed (check `grafel_index_status`).
 
 ---
 
-### 3.3 Traversal tools
+## 3. Orientation (always run first)
 
-#### `grafel_expand`
-BFS neighbour expansion from a single node. Use after `grafel_inspect` to
-walk outward from a known entity. Returns cross-repo overlay edges when they
-exist.
+Before deep work in an unfamiliar codebase, orient. This costs ~200 tokens
+and prevents dozens of wasted traversals.
 
 ```
-grafel_expand(node="OrderViewSet", depth=2)
-grafel_expand(node="orders-api::a1b2c3d4e5f60718", depth=1)
+grafel_orient(view="me")         # which group + repo am I in?
+grafel_orient(view="overview")   # size, repos, any unavailable
+grafel_orient(view="clusters")   # major subsystems / module map
+grafel_findings(action="list")   # prior session context
 ```
 
-CLI equivalent: `grafel expand <id>` (partial; MCP preferred)
-
-#### `grafel_trace`
-Confidence-weighted shortest path (Dijkstra) between two nodes. Use when you
-want to verify that a known source entity connects to a known target entity,
-and you want to see the exact edge sequence. Cross-repo aware.
-
-```
-grafel_trace(source="CheckoutController", target="PaymentsTable")
-→ { "path": ["CheckoutController","ChargeService","PaymentsRepository","PaymentsTable"],
-    "edges": [{"kind":"CALLS"},{"kind":"CALLS"},{"kind":"USES"}],
-    "weakest_link_confidence": 0.7, "crosses_repos": false, "found": true }
-```
-
-CLI equivalent: `grafel trace <source> <target>`
-
-#### `grafel_traces`
-Pre-computed process flow traces. The indexer runs BFS from heuristically
-detected entry points (route handlers, `main`, framework lifecycle hooks) and
-stores linearised call chains as `Process` entities. Three sub-actions:
-
-- `list` — top-ranked processes (optionally cross-stack-only).
-- `get` — full step chain for a specific `process_id`.
-- `follow` — ad-hoc forward BFS from any entity (not just pre-computed entry
-  points). Useful for probing flows the indexer did not auto-detect.
-
-```
-# Discover what complex flows exist
-grafel_traces(action="list", cross_stack_only=true, limit=10)
-
-# Inspect a specific flow in full
-grafel_traces(action="get", process_id="orders-api::proc:df0cd633e7f8f7f4")
-
-# Probe a custom entry point
-grafel_traces(action="follow", entry_point_id="InvoiceController", max_depth=6)
-```
+Exit when you know the group, the active repo, the approximate size, and the
+top-level module names.
 
 ---
 
-### 3.4 Source tools
+## 4. Worked examples
 
-#### `grafel_get_source`
-Returns the actual source lines for a node, with configurable context lines.
-Use after identifying an entity via `grafel_find` or `grafel_inspect`
-when you need to read the implementation, not just its graph metadata.
+### "Are the reference and candidate endpoints in sync?"
 
 ```
-grafel_get_source(node_id="OrderViewSet", context_lines=30)
-→ line-numbered source text from core/views/order.py:42
+# Don't get_source both and diff by hand — ask structurally:
+grafel_diff(left="<ref>", right="<candidate>", aspect="response_shape")
+grafel_diff(left="<ref>", right="<candidate>", aspect="payload")
+grafel_diff(left="<ref>", right="<candidate>", aspect="auth")
 ```
 
-CLI equivalent: read the file manually at the reported `source_file:start_line`
-
-#### `grafel_recent_activity`
-Returns entities whose source files were modified after a given RFC3339
-timestamp. Use at the start of an investigation when you need to find what
-changed recently (e.g. after a deploy, or to scope a code-review).
+### "What's affected if I change PaymentService.charge?"
 
 ```
-grafel_recent_activity(since="2026-05-20T00:00:00Z", limit=20)
+grafel_impact_radius(target="PaymentService.charge", scope="entity")
 ```
 
----
-
-### 3.5 HTTP endpoint tools
-
-`grafel_endpoints` (#1281 consolidation of endpoint_definitions + endpoint_calls + endpoint_stats):
-
-#### `grafel_endpoints(action=definitions)`
-Lists HTTP endpoint handler/route definitions (`http_endpoint_definition`
-kind). Use to audit what server-side routes exist.
+### "Where is this HTTP endpoint implemented, and is it authed?"
 
 ```
-grafel_endpoints(action="definitions", repo_filter=["orders-api"])
-→ { "definitions": [{ "entity_id": "...", "method": "POST", "path": "/api/v1/orders" }], "count": 7 }
-```
-
-#### `grafel_endpoints(action=calls)`
-Lists client-side call-sites (`http_endpoint_call` kind). Use to find what
-HTTP calls clients make, and to surface orphan callers (calls with no matching
-definition in the group).
-
-```
-grafel_endpoints(action="calls", repo_filter=["mobile-app"])
-grafel_endpoints(action="calls", orphan_only=true)  # only unmatched calls
-```
-
-#### `grafel_endpoints(action=stats)`
-Counts definitions vs. calls vs. legacy entities vs. orphan callers per repo.
-Use to assess migration progress or quickly understand the HTTP surface size.
-
-```
-grafel_endpoints(action="stats")
-→ { "totals": { "definitions": 12, "calls": 8, "orphan_calls": 2 }, "migrated": true }
-```
-
-#### `grafel_endpoints(kind="navigation")` — in-app navigation routes (#2665)
-Surfaces NAVIGATES_TO routes (Expo Router, React Navigation, Next.js) through
-the same endpoints tool. Each entry merges param keys across all call-sites as
-a sorted JSON array, so you can answer "which screens take param X / which
-are missing it?" with one call.
-
-```
-grafel_endpoints(kind="navigation", path_contains="/users")
-→ { "routes": [{ "route": "/users/[id]", "call_sites": 3, "params_keys": "[\"id\",\"mode\"]", ... }] }
-
-# Side-by-side with HTTP definitions:
-grafel_endpoints(action="definitions", include_navigation=true)
-→ { "definitions": [...], "navigation_routes": [...], "navigation_count": 4 }
-```
-
-`grafel_find_callers("/route/literal")` is the natural inverse: pass a
-literal beginning with `/` and the handler resolves it via reverse
-NAVIGATES_TO traversal, returning push-site callers with `file`, `line`, and
-`params_keys` for each call.
-
----
-
-### 3.6 Queue management tools
-
-#### `grafel_enrichments`
-Manages enrichment candidates — LLM-enrichable entities (`http_endpoint`,
-`process_flow`, `message_topic`) pre-identified by the indexer. Use when you
-want to submit or review structured metadata (summary, rank, gaps) for
-dashboard surfaces.
-
-```
-grafel_enrichments(action="list", kind="http_endpoint", limit=10)
-grafel_enrichments(action="submit", candidate_id="ec-1", value="Handles order creation", confidence=0.9)
-grafel_enrichments(action="reject", candidate_id="ec-2", reason="False positive — test fixture")
-```
-
-#### `grafel_cross_links`
-Manages cross-repo link candidates detected by the indexer. Use when you want
-to confirm, override, or reject candidate edges between repos.
-
-```
-grafel_cross_links(action="list", repo_filter=["mobile-app"], limit=5)
-grafel_cross_links(action="accept", candidate_id="lc-abc123")
-grafel_cross_links(action="reject", candidate_id="lc-def456", reason="Same-repo false positive")
-```
-
-#### `grafel_repairs`
-Manages residual-edge repair queue (unresolved stubs from the indexer).
-Use during repair sessions to annotate stubs with their correct resolutions.
-See the `/grafel-repair` skill for the full flow.
-
-```
-grafel_repairs(action="list", repo_filter=["orders-api"], limit=20)
-grafel_repairs(action="submit", residual_id="er:deadbeef00000001",
-                   resolution="bind_to_entity", target_entity_id="a1b2c3d4e5f60718",
-                   confidence=0.95)
-```
-
----
-
-### 3.7 Memory tools
-
-#### `grafel_save_finding`
-Persists a Q/A pair to the group's memory directory. Use to record decisions,
-insights, or cross-session notes so future agents pick them up.
-
-```
-grafel_save_finding(
-  question="How does the refund flow connect to billing?",
-  answer="RefundService.issue → BillingGateway.reverse → stripe.charges.create",
-  type="decision",
-  nodes=["orders-api::refund-service-id", "billing-api::billing-gateway-id"]
-)
-```
-
-#### `grafel_list_findings`
-Reads back previously saved findings, optionally filtered by entity or
-timestamp. Call at the start of a session to load prior context before
-querying the graph.
-
-```
-grafel_list_findings(since="2026-05-01T00:00:00Z")
-grafel_list_findings(entity_id="ChargeService")
-```
-
----
-
-## 4. Pass-based workflows
-
-Structure investigations as a series of passes, each with a clear scope and
-exit condition. This prevents token waste from over-querying.
-
-### Pass 0 — Orient (always)
-
-```
-grafel_whoami()                          # confirm group + repo
-grafel_stats()                           # entity counts, any unavailable repos
-grafel_clusters()                        # module map
-grafel_list_findings(since="<last-week>")  # prior session context
-```
-
-Exit when: you know the group, the active repo, the approximate size, and
-the top-level module names.
-
-### Pass 1 — Locate
-
-Find the entities relevant to your task using BM25.
-
-```
-grafel_find(question="<your topic>", depth=1, token_budget=600)
-```
-
-Use `depth=1` or `depth=0` first to keep results tight. If no hits, broaden
-the query. Note the entity IDs of top hits.
-
-Exit when: you have a ranked list of candidate entities with IDs and file
-locations.
-
-### Pass 2 — Inspect and expand
-
-Zoom in on the top candidates.
-
-```
-grafel_inspect(label_or_id="<entity>")   # full record + attached findings
-grafel_expand(node="<entity>", depth=2)  # neighbours
-```
-
-Use `grafel_get_source` when you need to read the actual code. Reserve
-this for entities where graph metadata alone is insufficient.
-
-Exit when: you understand the entity's role, its immediate dependencies, and
-its callers.
-
-### Pass 3 — Trace (if flow is the question)
-
-When the question is about a process ("how does X reach Y?"):
-
-```
-grafel_traces(action="list", cross_stack_only=true)   # find pre-computed flows
-grafel_traces(action="get", process_id="<id>")         # full step chain
-# OR for ad-hoc:
-grafel_trace(source="<start>", target="<end>")
-grafel_traces(action="follow", entry_point_id="<start>", max_depth=6)
-```
-
-Exit when: you have a step-by-step chain from entry point to terminal, with
-edge kinds.
-
-### Pass 4 — Synthesise
-
-Save your conclusions so future agents benefit.
-
-```
-grafel_save_finding(
-  question="<the question you answered>",
-  answer="<your synthesis>",
-  type="note",
-  nodes=["<entity-id-1>", "<entity-id-2>"]
-)
-```
-
----
-
-## 5. Common workflows with examples
-
-### "Where is this HTTP endpoint implemented?"
-
-```
-# 1. Orient
-grafel_whoami()
-
-# 2. List server-side definitions
-grafel_endpoints(action="definitions", repo_filter=["orders-api"])
-
-# 3. Find the matching entity
-grafel_find(question="POST /api/v1/orders create order", depth=1)
-
-# 4. Inspect + expand for auth and DB edges
-grafel_inspect(label_or_id="createOrder")
-grafel_expand(node="createOrder", depth=2)
-
-# 5. Read source if needed
-grafel_get_source(node_id="createOrder", context_lines=40)
+grafel_endpoints(detail="list")                      # find the route
+grafel_find(query="POST /api/v1/orders create order")
+grafel_inspect(entity="createOrder")
+grafel_endpoints(detail="posture")                   # auth/posture per endpoint
 ```
 
 ### "Trace a process flow end to end"
 
 ```
-# 1. List pre-computed cross-stack flows
-grafel_traces(action="list", cross_stack_only=true, limit=15)
-
-# 2. Get the full step chain for a candidate
-grafel_traces(action="get", process_id="orders-api::proc:df0cd633e7f8f7f4")
-
-# 3. If the entry point is not pre-computed, follow from it
-grafel_traces(action="follow", entry_point_id="CheckoutController.submit",
-                  max_depth=8, branching_factor=3)
-```
-
-### "Find orphan code (callers with no matching handler)"
-
-```
-grafel_endpoints(action="stats")                          # check orphan_calls count
-grafel_endpoints(action="calls", orphan_only=true)        # list them
-# For each orphan call:
-grafel_inspect(label_or_id="<orphan-entity-id>")
-grafel_expand(node="<orphan-entity-id>", depth=1)
-```
-
-### "Understand what changed since the last deploy"
-
-```
-grafel_recent_activity(since="2026-05-20T10:00:00Z", limit=30)
-# For high-impact changed entities:
-grafel_expand(node="<changed-entity>", depth=2)
-```
-
-### "Map cross-repo dependencies"
-
-```
-grafel_stats()                                    # see cross_repo_links count
-grafel_cross_links(action="list", limit=20)       # inspect candidates
-grafel_trace(source="mobile-app::UIComponent",
-                 target="api-backend::OrderService")  # verify a specific chain
+grafel_trace(target="CheckoutController.submit", kind="control")
+grafel_trace(target="CheckoutController.submit", kind="data")
 ```
 
 ### "Find all callers of a function"
 
 ```
-# grafel_find does BFS from the entity — callers appear as CALLS neighbours
-grafel_find(question="PaymentService.charge", depth=2, context_filter=["CALLS"])
-# OR
-grafel_inspect(label_or_id="PaymentService.charge")  # check pagerank for importance
-grafel_expand(node="PaymentService.charge", depth=1)  # direct neighbours include callers
+grafel_related(entity="PaymentService.charge", direction="callers")
+```
+
+### "Map cross-repo dependencies"
+
+```
+grafel_cross_links(group="orders-platform")
+grafel_find_paths(from="mobile-app::UIComponent", to="api-backend::OrderService")
+```
+
+### "Audit code health"
+
+```
+grafel_debt(kind="dead_code")
+grafel_debt(kind="cycles")
+grafel_security(kind="findings")
+grafel_test_analysis(kind="coverage")
 ```
 
 ---
 
-## 6. Empty-result contract — never fabricate edges
+## 5. Empty-result contract — never fabricate edges
 
-**The top quality failure** in grafel-assisted analysis is confident fabrication:
-an agent invents a plausible relationship (e.g. "create() does an ORM save",
-"mobile store calls LoginSerializer") when a traversal tool returned zero edges.
+**The top quality failure** in grafel-assisted analysis is confident
+fabrication: inventing a plausible relationship when a traversal tool
+returned zero edges.
 
-### The contract
+When `grafel_related`, `grafel_subgraph`, or `grafel_trace` returns an empty
+edge list for a **valid** entity, the response carries an explicit signal
+(`result: "no_outgoing_edges"`, `"no_incoming_edges"`, `"no_edges"`, with a
+human-readable `note`). These are distinct from `entity not found` errors
+(`IsError: true`).
 
-When `grafel_find_callees`, `grafel_find_callers`, `grafel_expand`,
-or `grafel_traces(action=follow)` returns an empty edge list for a **valid**
-entity, the response carries an explicit signal:
-
-| Field | Value | Meaning |
-|-------|-------|---------|
-| `result` | `"no_outgoing_edges"` | Entity found; graph has zero outbound edges |
-| `result` | `"no_incoming_edges"` | Entity found; graph has zero inbound edges |
-| `result` | `"no_edges"` | Entity found; graph has zero neighbours of any kind |
-| `result` | `"no_outgoing_calls"` | Entry point found; no CALLS chain in the graph |
-| `note` | (human-readable message) | Instruction not to infer |
-
-These are distinct from `entity not found` errors (which return `IsError: true`).
-
-### Required behaviour
-
-- If a traversal tool returns a `result` field (no-edge signal): **state that the graph shows no edge here**. Do not speculate, do not fill the gap from training data, do not describe a "likely" or "probable" relationship.
-- Phrase it explicitly: _"The graph shows no callees for `create()`. No relationship was found between these entities."_
-- **Only** after confirming no graph edge exists may you note that the connection may exist but was not extracted (extraction gaps are real). Even then, mark it as unverified — do not state it as fact.
-
-### Pattern that causes fabrication (avoid)
+Required behaviour:
+- If a traversal returns a no-edge `result`: **state that the graph shows no
+  edge here.** Do not speculate or fill the gap from training data.
+- Phrase it explicitly: _"The graph shows no callers for `create()`. No
+  relationship was found."_
+- Only after confirming no graph edge may you note the connection might exist
+  but was not extracted — and mark it unverified.
 
 ```
-# WRONG — invents a relationship when the graph returned no callees:
-grafel_find_callees(entity_id="orders-api::create")
-→ { "callees": [], "result": "no_outgoing_edges", "note": "..." }
-# Agent output: "create() calls the ORM save method to persist the order"  ← FABRICATION
+# WRONG:
+grafel_related(entity="orders-api::create", direction="callees")
+→ { "result": "no_outgoing_edges", "note": "..." }
+# Agent output: "create() calls the ORM save method"  ← FABRICATION
 
 # RIGHT:
-# Agent output: "The graph shows no outgoing edges from create(). No callee
-# relationship is recorded. If an ORM save is expected, this may be an
-# extraction gap — verify via grafel_get_source before asserting it."
+# "The graph shows no outgoing edges from create(). If an ORM save is
+#  expected, this may be an extraction gap — verify with grafel_get_source
+#  before asserting it."
 ```
 
 ---
 
-## 7. Anti-patterns
+## 6. Anti-patterns
 
-### Do not use grafel for symbol lookup
+### Don't reason over raw source when a tool answers it
+Comparing two responses → `grafel_diff`, not `get_source` + manual diff.
+Finding callers → `grafel_related direction=callers`, not reading every file.
+Impact of a change → `grafel_impact_radius`, not tracing by hand.
 
+### Don't use grafel for symbol lookup
 ```
-# WRONG — grep is faster and exact:
-grafel_find(question="PAYMENT_GATEWAY_URL")
-
-# RIGHT:
-rg "PAYMENT_GATEWAY_URL" .
-```
-
-### Do not use grafel_find with depth=3 for orientation
-
-A wide BFS at depth=3 from a BM25 hit can return hundreds of entities and
-blow the token budget. Start at `depth=1` or `depth=0` and expand only when
-needed.
-
-```
-# WRONG for orientation:
-grafel_find(question="auth", depth=3, token_budget=2000)
-
-# RIGHT:
-grafel_find(question="auth middleware", depth=1, token_budget=500)
+# WRONG: grafel_find(query="PAYMENT_GATEWAY_URL")
+# RIGHT: rg "PAYMENT_GATEWAY_URL" .
 ```
 
-### Do not skip Pass 0
+### Don't skip orientation
+Jumping straight to `grafel_find` without `grafel_orient(view="me")` can mean
+querying the wrong group or an unavailable repo.
 
-Jumping straight to `grafel_find` without `grafel_whoami` can mean
-you are querying the wrong group, or an unavailable repo. Pass 0 costs ~200
-tokens and prevents misrouted queries.
+### Don't use grafel for reading a known file
+If you know the path, use `Read`. `grafel_get_source` is for when you only
+know the entity label and want the graph to resolve the file.
 
-### Do not use grafel for reading a known file
-
-If you already know the file path, use `Read` — it is cheaper and exact.
-`grafel_get_source` is for when you only know the entity label and want
-the graph to resolve the file for you.
-
-### Do not over-call grafel_expand
-
-`grafel_expand` at depth 3 on a high-PageRank `Component` can return
-thousands of edges. Cap depth at 2 for routine use; use depth=3 only when
-specifically mapping a large subsystem.
-
-### Do not use the old tool names
-
-Tool names changed in #668. The following names no longer exist and will
-return "tool not found" errors:
-
-| Old name (broken) | Current name |
-|-------------------|--------------|
-| `grafel_search` | `grafel_find` |
-| `grafel_describe` | `grafel_inspect` |
-| `grafel_related` | `grafel_expand` |
-| `grafel_list_clusters` | `grafel_clusters` |
-| `grafel_graph_stats` | `grafel_stats` |
-| `grafel_list_enrichment_candidates` | `grafel_enrichments(action=list)` |
-| `grafel_submit_enrichment` | `grafel_enrichments(action=submit)` |
-| `grafel_reject_enrichment` | `grafel_enrichments(action=reject)` |
-| `grafel_list_link_candidates` | `grafel_cross_links(action=list)` |
-| `grafel_resolve_link_candidate` | `grafel_cross_links(action=accept\|reject)` |
-| `grafel_list_residuals` | `grafel_repairs(action=list)` |
-| `grafel_submit_repair` | `grafel_repairs(action=submit)` |
+### Don't over-expand
+`grafel_subgraph` at high depth on a high-PageRank node can return thousands
+of edges. Keep depth at 2 for routine use.
 
 ---
 
-## 8. Reading responses
+## 7. Reading responses
 
-### Entity IDs
-
-- **Bare ID** (`a1b2c3d4e5f60718`) — single-repo scope. Safe to use without prefix.
-- **Prefixed ID** (`orders-api::a1b2c3d4e5f60718`) — multi-repo response. Preserve
-  the prefix when passing the ID back to another tool call.
-
-### Entity kinds
-
-The MCP strips the `SCOPE.` prefix. You will see `Component`, `Operation`,
-`Schema`, `Queue`, etc. — not `SCOPE.Component`. The internal `graph.json`
-uses the prefixed form; agent code should use the stripped form.
-
-### Confidence values
-
-`grafel_trace` returns `weakest_link_confidence` — the lowest-confidence
-edge along the path. Intra-repo edges default to 0.95; cross-repo overlay
-edges default to 0.7 unless explicitly set. A path with confidence < 0.5
-should be verified with `grafel_get_source` before relying on it.
-
-### `findings` on inspect/trace
-
-`grafel_inspect` and `grafel_trace` auto-attach a `findings` array
-of previously saved Q/A pairs that reference the queried entity. Read these
-before querying further — a prior agent may have already answered your
-question.
+- **Bare ID** (`a1b2c3d4e5f60718`) — single-repo scope.
+- **Prefixed ID** (`orders-api::a1b2c3d4e5f60718`) — multi-repo; preserve the
+  prefix when passing it back.
+- Entity kinds are returned without the `SCOPE.` prefix (`Component`,
+  `Operation`, `Schema`, `Queue`, …).
+- `grafel_find_paths` returns `weakest_link_confidence`; a path < 0.5 should
+  be verified with `grafel_get_source`.
+- `grafel_inspect` auto-attaches saved findings that reference the entity —
+  read them before querying further.
 
 ---
 
-## 9. Scoping rules
+## 8. Scoping rules
 
 | Scenario | How to scope |
-|----------|-------------|
-| Single repo question | `repo_filter=["<repo-slug>"]` |
-| Cross-repo question | Omit `repo_filter` (default = whole group) |
-| Different group | `group="<group-name>"` (rarely needed) |
+|---|---|
+| Single repo | `repo_filter=["<repo-slug>"]` |
+| Cross-repo | omit `repo_filter` (default = whole group) |
+| Different group | `group="<group-name>"` |
 | All repos explicitly | `repo_filter=["*"]` |
 
-The daemon resolves your group from CWD by default (ADR-0008). If
-`grafel_whoami` returns `source: "none"`, the daemon could not infer a
-group — provide `group=` explicitly or navigate to a registered repo.
+The daemon resolves your group from CWD by default. If `grafel_orient(view="me")`
+returns `source: "none"`, provide `group=` explicitly or navigate to a
+registered repo.
 
 ---
 
-## 10. Related skills
+## 9. Related skills
 
-- `/generate-docs` — full documentation pipeline that uses grafel at every
-  pass. This skill is a prerequisite for understanding what `/generate-docs`
-  is doing internally.
-- `/grafel-repair` — standalone repair flow for residual edges. Uses
-  `grafel_repairs` (Passes 1a, 1b, 3a in `/generate-docs`).
-- `/grafel-quality-check` — benchmarks grafel MCP against grep+read
-  before a docgen run.
-- `/grafel-patterns-discover` — finds and records structural patterns
-  across the codebase.
-
-## 11. References
-
-- `internal/mcp/SCHEMA.md` — canonical tool contract (inputs, outputs, notes)
-- ADR-0003 — SCOPE entity taxonomy (kind names)
-- ADR-0008 — CWD-aware group routing
-- ADR-0009 — Cross-repo ID namespacing (`<repo>::<localId>`)
-- ADR-0015 — Residual-edge repair flow
-- ADR-0018 — Agent-learned pattern store
-- ADR-0020 — Multi-branch + worktree support. The MCP server automatically
-  resolves the ref from the agent's CWD; pass `ref=` explicitly to target a
-  specific branch. See [docs/user-guide/multi-branch.md](../../docs/user-guide/multi-branch.md).
+- `/grafel-tech-docs` — full documentation pipeline that uses grafel at every pass.
+- `/grafel-resolve` — residual-edge repair flow.
+- `/grafel-graph-quality` — benchmarks grafel MCP against grep+read.
+- `/grafel-patterns-discover` — finds and records structural patterns.


### PR DESCRIPTION
Closes #5554. Part of #5546.

Updates **all grafel skill markdown** to the canonical 22 intent-named tools with discriminators. Every absorbed/legacy tool name is purged; the old "deprecated names" table in `using-grafel` is removed.

## What changed
- **`using-grafel/SKILL.md`** — rewritten as a **task-oriented intent→tool map** over the 22, leading with the comparison/analysis cluster ("comparing reference vs candidate response → `grafel_diff aspect=response_shape`, not `get_source` + manual diff"). Tightened from ~700 lines to a scannable routing table + worked examples + anti-patterns.
- **`grafel-aware-review/SKILL.md`** — all per-change-type sequences and worked examples migrated to canonical tools (`grafel_related direction=callers`, `grafel_find_paths`, `grafel_impact_radius`, `grafel_diff`, `grafel_orient`, `grafel_findings`, `grafel_endpoints detail=…`).
- **All other skills** (consult personas, tech-docs, business-docs, resolve, security-audit, graph-enrich, graph-quality, graph-read/write, patterns-discover, extend-convention) — migrated via deterministic token mapping + manual cleanup of call syntax (merged `tool(disc=val)(args)` artifacts, fixed a double-`kind` collision by renaming the entity-kind filter to `entity_kind`).

## Mapping applied
Absorbed → canonical + discriminator: callers/callees/neighbors/uses → `grafel_related direction=…`; whoami/stats/clusters/topology/modules → `grafel_orient view=…`; search_entities → `grafel_find`; expand → `grafel_subgraph`; data/control/def_use/effects/flows/traces → `grafel_trace kind=…`; effective_contract/endpoint_posture → `grafel_endpoints detail=…`; pr_impact → `grafel_impact_radius scope=changeset`; response_shape_diff/payload_drift/auth_posture_diff/diff_refs/literal_parity → `grafel_diff aspect=…`; dead_code/cycles/stubs/impure/license → `grafel_debt kind=…`; security_findings/secrets/auth_coverage → `grafel_security kind=…`; test_* → `grafel_test_analysis kind=…`; graph/template_patterns → `grafel_patterns kind=…`; list/save findings → `grafel_findings action=…`; docgen_* → `grafel_docgen action=…`; apply_doc_semantics/apply_docgen_repairs/repairs/enrichments → `grafel_docgen_apply kind=…`; feedback/persona_event → `grafel_event kind=…`. Also-removed tokens with no #5546 row mapped to nearest canonical: status→`orient view=overview`, search→`find`, describe→`inspect`, list_clusters→`orient view=clusters`, graph_stats→`orient view=overview`, list_link_candidates→`cross_links`, list_enrichment_candidates→`docgen_apply kind=enrichments`, get_telemetry→`mcp_metrics`, recent_activity→`index_status`.

## Verification
The absorbed-tool-name grep over `skills/` returns **zero deprecated tool names**. The only residual hits from the broad acceptance regex are **canonical discriminator *values*** the spec requires agents to learn — `kind=dead_code`, `kind=def_use`, `kind=auth_coverage` — not tool names. These are the new vocabulary per #5546 req 4 (teach which value for which intent).

Skills only — no Go code. CHANGELOG untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)