### PR TITLE
feat(pony): bootstrap records — corral/ponyc manifest + actor topology (#5384)

### DIFF
--- a/docs/coverage/by-category/language.md
+++ b/docs/coverage/by-category/language.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # language
 
-**Total**: 27 records · **assembly**: 5 · **clojure**: 1 · **COBOL**: 5 · **crystal**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 2 · **F#**: 1 · **groovy**: 1 · **JCL**: 1 · **lua**: 1 · **nim**: 1 · **scala**: 1 · **solidity**: 2 · **swift**: 1 · **verilog**: 1 · **VHDL**: 1
+**Total**: 28 records · **assembly**: 5 · **clojure**: 1 · **COBOL**: 5 · **crystal**: 1 · **dart**: 1 · **elixir**: 1 · **erlang**: 2 · **F#**: 1 · **groovy**: 1 · **JCL**: 1 · **lua**: 1 · **nim**: 1 · **pony**: 1 · **scala**: 1 · **solidity**: 2 · **swift**: 1 · **verilog**: 1 · **VHDL**: 1
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -28,6 +28,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [JCL](../by-language/jcl.md) | [IBM z/OS JCL (JES2/JES3)](../detail/lang.jcl.runtime.zos.md) | ✅ | ✅ | — | — | ✅ | — | ✅ | ✅ | |
 | [lua](../by-language/lua.md) | [Lua (base language)](../detail/lang.lua.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
 | [nim](../by-language/nim.md) | [Nim](../detail/lang.nim.core.md) | ✅ | ✅ | — | — | — | — | 🟢 | 🟢 | |
+| [pony](../by-language/pony.md) | [Pony actor model](../detail/lang.pony.runtime.actor.md) | — | 🟢 | — | — | — | — | — | 🟢 | |
 | [scala](../by-language/scala.md) | [Scala (base language)](../detail/lang.scala.base.md) | ✅ | ✅ | — | — | — | — | ✅ | ✅ | |
 | [solidity](../by-language/solidity.md) | [OpenZeppelin Contracts](../detail/lang.solidity.framework.openzeppelin.md) | — | — | — | ✅ | — | — | ✅ | ✅ | |
 | [solidity](../by-language/solidity.md) | [Solidity](../detail/lang.solidity.core.md) | 🟢 | ✅ | — | — | — | — | 🟢 | 🟢 | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 35 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **idris**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **Standard ML**: 2 · **swift**: 1 · **zig**: 1
+**Total**: 36 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **idris**: 1 · **java**: 2 · **JS/TS**: 2 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **pony**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **Standard ML**: 2 · **swift**: 1 · **zig**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -31,6 +31,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [nim](../by-language/nim.md) | [nimble (Nim package manager)](../detail/lang.nim.tool.nimble.md) | — | — | ✅ | |
 | [OCaml](../by-language/ocaml.md) | [Dune / opam (OCaml build)](../detail/lang.ocaml.tool.dune.md) | — | — | ✅ | |
 | [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | |
+| [pony](../by-language/pony.md) | [corral (corral.json)](../detail/manifest.corral.md) | — | — | ✅ | |
 | [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | 🟢 | ✅ | |
 | [python](../by-language/python.md) | [requirements.txt](../detail/pkg.requirements.md) | — | — | ✅ | |

--- a/docs/coverage/by-language/pony.md
+++ b/docs/coverage/by-language/pony.md
@@ -1,12 +1,32 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# Pony
+# pony
 
-**Frameworks**: 0 · **Tools**: 0 · **ORMs**: 0 · **Other**: 0
+**Frameworks**: 0 · **Tools**: 1 · **ORMs**: 0 · **Other**: 1
 
 Back to [summary](../summary.md).
 
-> **No ecosystem records tracked yet.** grafel has extractor support for
-> this language (see `internal/extractors/pony/`), but specific framework,
-> ORM, or tool records haven't been added to the registry yet. Contribute by
-> adding records via `go run ./tools/coverage add` with appropriate IDs
-> (e.g. `lang.pony.framework.<name>`).
+### Legend
+
+Each group column shows `glyph covered/applicable` — **covered** = capabilities with extraction, **applicable** = covered + missing (not-applicable capabilities are excluded from both). The glyph is the group's **support level**:
+
+| Glyph | Level | Meaning |
+|---|---|---|
+| ✅ | **Comprehensive** | every applicable capability is `full` — fixture-proven, resolves the general case |
+| 🟢 | **Supported** | every applicable capability is extracted; some only *heuristically* (detected by pattern, not full AST/data-flow resolution) |
+| 🟡 | **Partial** | some capabilities extracted, some still missing |
+| 🔴 | **Not extracted** | nothing extracted yet |
+| — | **N/A** | capability does not apply to this framework |
+
+Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 12/20` = 8 not yet extracted. Detail pages use the same palette **per cell** (✅ full · 🟢 heuristic/partial · 🔴 missing · — n/a).
+
+## Tools
+
+| Name | Dependency graph | Dependency usage status | Lockfile parsing | Manifest parsing | Target extraction | Notes |
+|---|---|---|---|---|---|---|
+| [corral (corral.json)](../detail/manifest.corral.md) | — | — | — | ✅ | — | |
+
+## Other
+
+| Name | Category | Status | Notes |
+|---|---|---|---|
+| [Pony actor model](../detail/lang.pony.runtime.actor.md) | [language](../by-category/language.md) | 🟢 | |

--- a/docs/coverage/detail/lang.pony.runtime.actor.md
+++ b/docs/coverage/detail/lang.pony.runtime.actor.md
@@ -1,0 +1,24 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `lang.pony.runtime.actor` — Pony actor model
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [pony](../by-language/pony.md)
+- **Category:** [language](../by-category/language.md)
+- **Capability cells:** 1
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Core extraction | 🟢 `partial` | `2026-06-24` | 5384 | `internal/extractors/pony/actor_topology.go`<br>`internal/extractors/pony/actor_topology_test.go`<br>`internal/extractors/pony/extractor.go` | #5384 (epic #5360): Pony actor-model topology enrichment over the existing regex extractor (no new entity Kind, mirroring the lang.erlang.runtime.otp edge-enrichment model; enrichActorTopology). (1) actor Components are Tagged 'actor'; each behaviour (be name(...), Subtype=behavior) owned by an actor is Tagged 'pony_behaviour' with Properties[actor]=<owning actor>. (2) MESSAGE-SEND RECOVERY: a behaviour call site receiver.behaviour(args) (ponyMsgSendRE) is the actor-model equivalent of a gen_server:cast — async delivery to another actor's mailbox; recovered per-operation body and stamped onto the matching CALLS edge (ToID==behaviour name) with Properties pony_msg_send=true / pony_msg_behaviour / pony_msg_receiver (verbatim receiver expr) / pony_msg_actor (target actor), and the sending operation is Tagged pony_msg_out:<behaviour>. Honest PARTIAL: the receiver's static actor TYPE is not resolved (receiver captured verbatim), a send is only recovered when its behaviour name matches a behaviour declared in the SAME file (regex extractor has no cross-file type table), and synchronous fun/constructor calls are intentionally excluded (only behaviours are asynchronous messages). Proven by TestActorTopology_TagsActorsAndBehaviours, _MessageSendEnrichment, _NoActorsNoOp, _SyncFunNotMessage. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update lang.pony.runtime.actor ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/detail/manifest.corral.md
+++ b/docs/coverage/detail/manifest.corral.md
@@ -1,0 +1,25 @@
+<!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
+# `manifest.corral` — corral (corral.json)
+
+Auto-generated. Back to [summary](../summary.md).
+
+- **Language:** [pony](../by-language/pony.md)
+- **Category:** [package_manager](../by-category/package_manager.md)
+- **Capability cells:** 2
+
+## Capabilities
+
+| Capability | Status | Verified at | Issue | Cites | Notes |
+|------------|--------|-------------|-------|-------|-------|
+| Lockfile parsing | — `not_applicable` | — | — | — | #5384: corral has no separate lockfile format — it folds resolved transitive deps into the same corral.json deps[] array, so the manifest IS the resolved set (parsed under manifest_parsing). N/A by ecosystem design. |
+| Manifest parsing | ✅ `full` | `2026-06-24` | 5384 | `internal/extractors/cross/manifest/corral.go`<br>`internal/extractors/cross/manifest/corral_test.go`<br>`internal/extractors/cross/manifest/extractor.go` | #5384 (epic #5360): Pony corral.json (and legacy bundle.json) deps[] array parsed into external_dependency + DEPENDS_ON + SCOPE.Package records (package_manager=corral, parseCorralJSON). Dep name = locator's final path segment with .git stripped (github.com/ponylang/http_server.git -> http_server; corralDepName handles scp-style git@host:owner/name locators); version from the deps[].version field (or legacy deps[].tag). The legacy {type,repo} entry form is also accepted. corral folds resolved transitive deps into the same deps[] array, so the manifest doubles as the resolved set — there is no separate lockfile format. corral.json is wired by exact basename into IsManifest/detectPackageManager/dispatchParser/parsers. bundle.json is an ambiguous basename (collides with JS/webpack bundle artifacts), so it is corral-signal gated: it only anchors + emits deps when it parses to a non-empty corral deps[] array, else a complete no-op (TestBundleJSON_GenericNoOp). Proven by TestCorralJSON_Deps / _VersionCarried, TestBundleJSON_LegacyDeps, TestCorralJSON_NoDepsNoOp, TestCorral_IsManifest. |
+
+## Provenance
+
+This record is sourced from `docs/coverage/registry.json`. To update it, edit the JSON
+(or use `go run ./tools/coverage update manifest.corral ...`) then regenerate:
+
+```
+go run ./tools/coverage validate
+go run ./tools/coverage gen
+```

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # grafel capabilities
 
-**Languages**: 39 (36 active · 3 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 159 · **Other**: 210
+**Languages**: 39 (37 active · 2 placeholder) · **Frameworks**: 263 · **ORMs**: 186 · **Tools**: 160 · **Other**: 211
 
 ## Coverage by language
 
@@ -38,6 +38,7 @@
 | [idris](by-language/idris.md) | 0 | 1 | 0 | 0 |
 | [javascript](by-language/javascript.md) | 0 | 0 | 0 | 1 |
 | [JCL](by-language/jcl.md) | 0 | 0 | 0 | 1 |
+| [pony](by-language/pony.md) | 0 | 1 | 0 | 1 |
 | [Standard ML](by-language/sml.md) | 0 | 2 | 0 | 0 |
 | [solidity](by-language/solidity.md) | 0 | 2 | 0 | 2 |
 | [verilog](by-language/verilog.md) | 0 | 4 | 0 | 1 |
@@ -81,6 +82,5 @@ The [Platform / k8s](by-category/platform.md) category splits into the lanes bel
 |---|
 | [Bicep](by-language/bicep.md) |
 | [Lisp](by-language/lisp.md) |
-| [Pony](by-language/pony.md) |
 
-Total: 263 frameworks · 159 tools · 186 ORMs · 210 other
+Total: 263 frameworks · 160 tools · 186 ORMs · 211 other

--- a/internal/extractors/cross/manifest/corral.go
+++ b/internal/extractors/cross/manifest/corral.go
@@ -1,0 +1,102 @@
+// corral.go — Pony `corral.json` / `bundle.json` package-manifest parser
+// (#5384, epic #5360).
+//
+// corral (https://github.com/ponylang/corral) is the dependency manager for the
+// Pony language. A project's dependencies live in a `corral.json` manifest as a
+// `deps` array; each entry is an object with a `locator` (a VCS path such as
+// `github.com/ponylang/http_server.git`) plus an optional `version` (a git tag
+// or commit). corral also records transitive deps it has resolved into the same
+// `deps` array, so the manifest doubles as the resolved set — there is no
+// separate lockfile format.
+//
+//	{
+//	  "deps": [
+//	    { "locator": "github.com/ponylang/http_server.git", "version": "0.2.1" },
+//	    { "locator": "github.com/ponylang/net_ssl.git",     "version": "1.3.2" }
+//	  ]
+//	}
+//
+// `bundle.json` is the legacy manifest name corral grew out of (the older
+// `pony-stable` tool used it); it carries the same `deps` array shape — entries
+// may use `locator` or the older `{ "type": "github", "repo": "owner/name" }`
+// form. Both are recognised here, package_manager=`corral`.
+//
+// The dependency NAME is the locator's trailing path segment with any `.git`
+// suffix stripped (e.g. `github.com/ponylang/http_server.git` -> `http_server`),
+// which is the package's Pony `use` name. The full locator is preserved in the
+// `version` provenance only when no explicit version is given is NOT done — the
+// version field carries the declared git tag/commit when present.
+package manifest
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// corralManifest is the decoded shape of a corral.json / bundle.json file. Only
+// the dependency-bearing fields are modelled; unknown keys (e.g. `info`,
+// `packages`) are ignored by encoding/json.
+type corralManifest struct {
+	Deps []corralDep `json:"deps"`
+}
+
+// corralDep is one entry of the `deps` array. Both the modern `locator` form and
+// the legacy `{type,repo}` form are accepted; `version` and the legacy `tag` are
+// both treated as the declared version.
+type corralDep struct {
+	Locator string `json:"locator"`
+	Version string `json:"version"`
+	Tag     string `json:"tag"`
+	Repo    string `json:"repo"`
+}
+
+// parseCorralJSON parses a corral.json / bundle.json manifest and returns its
+// declared dependencies (package_manager=corral). The dep name is the locator's
+// final path segment with a trailing `.git` removed; the declared version is the
+// `version` field (or the legacy `tag`). First declaration of a name wins on
+// duplicates.
+func parseCorralJSON(source string) []dep {
+	var data corralManifest
+	if err := json.Unmarshal([]byte(source), &data); err != nil {
+		return nil
+	}
+	var out []dep
+	seen := map[string]bool{}
+	for _, d := range data.Deps {
+		locator := d.Locator
+		if locator == "" {
+			locator = d.Repo // legacy {type,repo} form
+		}
+		name := corralDepName(locator)
+		if name == "" || seen[name] {
+			continue
+		}
+		version := d.Version
+		if version == "" {
+			version = d.Tag
+		}
+		seen[name] = true
+		out = append(out, dep{name: name, version: version, kind: "runtime"})
+	}
+	return out
+}
+
+// corralDepName derives the Pony package name from a corral locator. The locator
+// is a VCS path (e.g. `github.com/ponylang/http_server.git`,
+// `git@github.com:ponylang/net_ssl.git`, or an `owner/name` slug); the package
+// name is its final path segment with a `.git` suffix and any trailing slash
+// removed. Returns "" when nothing usable can be isolated.
+func corralDepName(locator string) string {
+	s := strings.TrimSpace(locator)
+	if s == "" {
+		return ""
+	}
+	s = strings.TrimSuffix(s, "/")
+	// Split on both '/' and ':' so scp-style git@host:owner/name locators reduce
+	// to their final segment too.
+	if i := strings.LastIndexAny(s, "/:"); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.TrimSuffix(s, ".git")
+	return strings.TrimSpace(s)
+}

--- a/internal/extractors/cross/manifest/corral_test.go
+++ b/internal/extractors/cross/manifest/corral_test.go
@@ -1,0 +1,97 @@
+package manifest
+
+import "testing"
+
+// ---------------------------------------------------------------------------
+// corral.json (Pony / corral) — happy path
+// ---------------------------------------------------------------------------
+
+func TestCorralJSON_Deps(t *testing.T) {
+	src := `{
+  "deps": [
+    { "locator": "github.com/ponylang/http_server.git", "version": "0.2.1" },
+    { "locator": "github.com/ponylang/net_ssl.git", "version": "1.3.2" },
+    { "locator": "git@github.com:ponylang/json.git" }
+  ]
+}`
+	got := depNamesSet(t, "/proj/corral.json", src)
+	for _, want := range []string{"http_server", "net_ssl", "json"} {
+		if got[want] != "corral" {
+			t.Errorf("expected dep %q with pm=corral, got pm=%q (deps: %v)", want, got[want], got)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("expected exactly 3 deps, got %d: %v", len(got), got)
+	}
+}
+
+func TestCorralJSON_VersionCarried(t *testing.T) {
+	src := `{"deps":[{"locator":"github.com/ponylang/http_server.git","version":"0.2.1"}]}`
+	records := runExtract(t, "/proj/corral.json", src)
+	found := false
+	for _, r := range records {
+		if r.Subtype == "external_dependency" && r.Name == "http_server" {
+			found = true
+			if r.Properties["version"] != "0.2.1" {
+				t.Errorf("http_server version = %q, want 0.2.1", r.Properties["version"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("http_server dependency not found")
+	}
+}
+
+// Legacy bundle.json with a corral-shaped deps array IS recognised, including
+// the older {type,repo} entry form (with `tag` as version).
+func TestBundleJSON_LegacyDeps(t *testing.T) {
+	src := `{
+  "type": "program",
+  "deps": [
+    { "type": "github", "repo": "ponylang/regex", "tag": "0.4.0" }
+  ]
+}`
+	got := depNamesSet(t, "/proj/bundle.json", src)
+	if got["regex"] != "corral" {
+		t.Errorf("expected legacy bundle.json dep regex with pm=corral, got %v", got)
+	}
+	records := runExtract(t, "/proj/bundle.json", src)
+	for _, r := range records {
+		if r.Subtype == "external_dependency" && r.Name == "regex" && r.Properties["version"] != "0.4.0" {
+			t.Errorf("regex version = %q, want 0.4.0 (from tag)", r.Properties["version"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a generic / non-corral bundle.json is a complete no-op (no deps,
+// no project anchor). bundle.json is an ambiguous basename, so the corral
+// signal (a parseable deps[] array) is required.
+// ---------------------------------------------------------------------------
+
+func TestBundleJSON_GenericNoOp(t *testing.T) {
+	// A typical JS/webpack-style bundle.json with no corral deps array.
+	src := `{"version":3,"sources":["a.js","b.js"],"mappings":"AAAA"}`
+	records := runExtract(t, "/proj/bundle.json", src)
+	if len(records) != 0 {
+		t.Errorf("generic bundle.json must be a no-op (no anchor, no deps), got %d records", len(records))
+	}
+}
+
+func TestCorralJSON_NoDepsNoOp(t *testing.T) {
+	// corral.json is an unambiguous name: it still anchors, but yields no deps.
+	src := `{"info":{"name":"myproj"}}`
+	got := depNamesSet(t, "/proj/corral.json", src)
+	if len(got) != 0 {
+		t.Errorf("corral.json with no deps should yield no dependency records, got %v", got)
+	}
+}
+
+func TestCorral_IsManifest(t *testing.T) {
+	if !IsManifest("/proj/corral.json") {
+		t.Error("corral.json must be treated as a manifest")
+	}
+	if detectPackageManager("/proj/corral.json") != "corral" {
+		t.Errorf("corral.json package manager = %q, want corral", detectPackageManager("/proj/corral.json"))
+	}
+}

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -30,6 +30,8 @@
 //   - paket.dependencies   (paket — .NET/F# manifest_parsing, nuget directives)
 //   - paket.lock           (paket — .NET/F# lockfile_parsing, resolved NUGET tree)
 //   - *.ipkg               (idris2 — Idris manifest_parsing, depends/modules)
+//   - corral.json          (corral — Pony manifest_parsing, deps[].locator)
+//   - bundle.json          (corral — Pony legacy manifest, corral-signal gated)
 //
 // Entity kind: "SCOPE.Component"
 // Relationships emitted: DEPENDS_ON(kind=external_dependency)
@@ -216,6 +218,11 @@ var exactManifestNames = map[string]bool{
 	// the package manager is npm and rescript.json is NOT a lockfile (#5378).
 	"rescript.json": true,
 	"bsconfig.json": true,
+	// Pony — corral (corral.json manifest; legacy bundle.json). corral records
+	// its resolved transitive deps into the same `deps` array, so the manifest
+	// doubles as the resolved set — there is no separate lockfile format (#5384).
+	"corral.json": true,
+	"bundle.json": true,
 }
 
 // IsManifest returns true when filePath names a supported manifest file.
@@ -331,6 +338,9 @@ func detectPackageManager(filePath string) string {
 		// from package.json), so the package manager is npm (#5378).
 		"rescript.json": "npm",
 		"bsconfig.json": "npm",
+		// Pony — corral (corral.json + legacy bundle.json).
+		"corral.json": "corral",
+		"bundle.json": "corral",
 	}
 	basename := filepath.Base(filePath)
 	if v, ok := pm[basename]; ok {
@@ -2010,6 +2020,11 @@ var parsers = map[string]parserFn{
 	// reScriptConfigProperty.
 	"rescript.json": parseReScriptJSON,
 	"bsconfig.json": parseReScriptJSON,
+	// Pony — corral (corral.json manifest + legacy bundle.json). The `deps`
+	// array carries locator + version; corral folds resolved transitive deps
+	// into the same array, so there is no separate lockfile (#5384).
+	"corral.json": parseCorralJSON,
+	"bundle.json": parseCorralJSON,
 }
 
 func dispatchParser(filePath, source string) (string, []dep) {
@@ -2262,6 +2277,18 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	}
 
 	pm, deps := dispatchParser(file.Path, string(file.Content))
+
+	// Pony legacy bundle.json is an ambiguous, generic basename (it collides with
+	// JS/webpack bundle artifacts, etc.). Only treat it as a corral manifest —
+	// and emit its project anchor — when it actually parses to corral deps; an
+	// unrelated bundle.json yields no deps and is a complete no-op (#5384).
+	if filepath.Base(file.Path) == "bundle.json" && len(deps) == 0 {
+		span.SetAttributes(
+			attribute.String("package_manager", "none"),
+			attribute.Int("total_found", 0),
+		)
+		return nil, nil
+	}
 
 	depCount := 0
 	devCount := 0

--- a/internal/extractors/pony/actor_topology.go
+++ b/internal/extractors/pony/actor_topology.go
@@ -1,0 +1,176 @@
+// actor_topology.go — Pony actor-model topology enrichment (#5384, epic #5360).
+//
+// Pony is an actor language: an `actor` declares asynchronous message handlers
+// as BEHAVIOURS (`be name(...)`), and code sends a message by calling a
+// behaviour on an actor reference (`worker.run(payload)`). A behaviour call is
+// the actor-model equivalent of an Erlang/Elixir `gen_server:cast` — fire-and-
+// forget message delivery to another actor's mailbox. This pass surfaces that
+// topology, mirroring the Erlang OTP-deepen edge-enrichment model
+// (lang.erlang.runtime.otp): it adds NO new entity Kind. Instead it
+//
+//  1. tags `actor` Components with "actor" and each of their behaviours with
+//     "pony_behaviour" (+ records the owning actor on the behaviour entity), and
+//  2. recovers `receiver.behaviour(args)` message-sends from operation bodies and
+//     stamps the matching CALLS edge (ToID == behaviour name) with the actor-
+//     message metadata (pony_msg_send / pony_msg_receiver / pony_msg_behaviour),
+//     tagging the sending operation "pony_msg_out:<behaviour>".
+//
+// Honest partial: the receiver expression is captured verbatim (best-effort —
+// the receiver's STATIC actor TYPE is not resolved), and a send is only
+// recovered when its behaviour name matches a behaviour declared in the SAME
+// file (the regex extractor has no cross-file type table). Synchronous `fun`
+// calls and constructor calls are intentionally excluded — only behaviours are
+// asynchronous messages.
+package pony
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ponyMsgSendRE matches a behaviour message-send call site: a receiver
+// expression, a dot, the behaviour name, and an opening paren. The receiver is
+// any dotted/identifier chain (e.g. `worker`, `_pool`, `this.worker`,
+// `env.out`). Group 1 = receiver expression, group 2 = behaviour name.
+var ponyMsgSendRE = regexp.MustCompile(
+	`([A-Za-z_][A-Za-z0-9_'.]*)\.([a-z_][a-zA-Z0-9_']*)\s*\(`,
+)
+
+// enrichActorTopology stamps actor-model topology metadata onto the entity set
+// produced by extractPony. It is a no-op when the file declares no actors.
+//
+// `src` is the raw file content (used to recover message-send call sites);
+// `entities` is mutated in place.
+func enrichActorTopology(src string, entities []types.EntityRecord) {
+	// 1. Identify actors and their behaviours from the entity set.
+	actorNames := map[string]bool{}      // actor component name -> true
+	behaviourOwner := map[string]string{} // behaviour name -> owning actor name
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind == "SCOPE.Component" && e.Subtype == "actor" {
+			actorNames[e.Name] = true
+			addTag(e, "actor")
+		}
+	}
+	if len(actorNames) == 0 {
+		return // not an actor file — nothing to enrich.
+	}
+
+	// 2. Tag behaviours and record their owning actor. A behaviour entity is
+	// named "<Actor>.<behaviour>" (see extractPony); only behaviours owned by a
+	// real actor are part of the message protocol.
+	behaviourNames := map[string]bool{} // bare behaviour name -> true
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != "SCOPE.Operation" || e.Subtype != "behavior" {
+			continue
+		}
+		owner, bare := splitMember(e.Name)
+		if owner == "" || !actorNames[owner] {
+			continue
+		}
+		addTag(e, "pony_behaviour")
+		if e.Properties == nil {
+			e.Properties = map[string]string{}
+		}
+		e.Properties["actor"] = owner
+		behaviourNames[bare] = true
+		behaviourOwner[bare] = owner
+	}
+	if len(behaviourNames) == 0 {
+		return
+	}
+
+	// 3. Recover message-sends. For each sending operation, scan its body slice
+	// of the source for `receiver.behaviour(...)` where behaviour is a known
+	// in-file behaviour name, and stamp the matching CALLS edge.
+	scrubbed := stripStringsAndComments(src)
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != "SCOPE.Operation" {
+			continue
+		}
+		// The operation body is the source between its start and end lines.
+		body := lineSlice(scrubbed, e.StartLine, e.EndLine)
+		if body == "" {
+			continue
+		}
+		// Recover behaviour sends -> receiver, keyed by behaviour name. First
+		// concrete receiver wins per behaviour.
+		sends := map[string]string{}
+		for _, m := range ponyMsgSendRE.FindAllStringSubmatch(body, -1) {
+			receiver, behaviour := m[1], m[2]
+			if !behaviourNames[behaviour] {
+				continue
+			}
+			// A receiver that is itself an actor TYPE name is a constructor /
+			// static reference, not a message target; skip the self `this`/`me`
+			// noise only if it adds nothing — keep verbatim otherwise.
+			if _, ok := sends[behaviour]; !ok {
+				sends[behaviour] = receiver
+			}
+		}
+		if len(sends) == 0 {
+			continue
+		}
+		// Stamp the matching CALLS edges (ToID == behaviour name) and tag the
+		// sending operation.
+		for j := range e.Relationships {
+			rel := &e.Relationships[j]
+			if rel.Kind != "CALLS" {
+				continue
+			}
+			recv, ok := sends[rel.ToID]
+			if !ok {
+				continue
+			}
+			if rel.Properties == nil {
+				rel.Properties = map[string]string{}
+			}
+			rel.Properties["pony_msg_send"] = "true"
+			rel.Properties["pony_msg_behaviour"] = rel.ToID
+			rel.Properties["pony_msg_receiver"] = recv
+			if owner := behaviourOwner[rel.ToID]; owner != "" {
+				rel.Properties["pony_msg_actor"] = owner
+			}
+			addTag(e, "pony_msg_out:"+rel.ToID)
+		}
+	}
+}
+
+// addTag appends tag to e.Tags if not already present.
+func addTag(e *types.EntityRecord, tag string) {
+	for _, t := range e.Tags {
+		if t == tag {
+			return
+		}
+	}
+	e.Tags = append(e.Tags, tag)
+}
+
+// splitMember splits a "Type.member" entity name into its owner and bare member.
+// Returns ("","") when there is no dot.
+func splitMember(name string) (owner, member string) {
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		return name[:i], name[i+1:]
+	}
+	return "", ""
+}
+
+// lineSlice returns the [startLine, endLine] inclusive (1-based) slice of src.
+// Returns "" for an invalid range.
+func lineSlice(src string, startLine, endLine int) string {
+	if startLine <= 0 || endLine < startLine {
+		return ""
+	}
+	lines := strings.Split(src, "\n")
+	if startLine > len(lines) {
+		return ""
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	return strings.Join(lines[startLine-1:endLine], "\n")
+}

--- a/internal/extractors/pony/actor_topology_test.go
+++ b/internal/extractors/pony/actor_topology_test.go
@@ -1,0 +1,142 @@
+package pony_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// hasTag reports whether e carries tag.
+func hasTag(e *types.EntityRecord, tag string) bool {
+	if e == nil {
+		return false
+	}
+	for _, t := range e.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+const actorSrc = `use "collections"
+
+actor Worker
+  let _env: Env
+  new create(env: Env) =>
+    _env = env
+  be run(payload: String) =>
+    _env.out.print(payload)
+  be stop() =>
+    None
+
+actor Main
+  new create(env: Env) =>
+    let w: Worker = Worker(env)
+    w.run("hello")
+    w.stop()
+`
+
+func TestActorTopology_TagsActorsAndBehaviours(t *testing.T) {
+	ents := runPony(t, actorSrc, "/proj/main.pony")
+
+	worker := ponyFind(ents, "Worker", "SCOPE.Component")
+	if worker == nil {
+		t.Fatal("Worker actor not extracted")
+	}
+	if !hasTag(worker, "actor") {
+		t.Errorf("Worker should be tagged 'actor', tags=%v", worker.Tags)
+	}
+
+	run := ponyFind(ents, "Worker.run", "SCOPE.Operation")
+	if run == nil {
+		t.Fatal("Worker.run behaviour not extracted")
+	}
+	if !hasTag(run, "pony_behaviour") {
+		t.Errorf("Worker.run should be tagged 'pony_behaviour', tags=%v", run.Tags)
+	}
+	if run.Properties["actor"] != "Worker" {
+		t.Errorf("Worker.run actor property = %q, want Worker", run.Properties["actor"])
+	}
+}
+
+func TestActorTopology_MessageSendEnrichment(t *testing.T) {
+	ents := runPony(t, actorSrc, "/proj/main.pony")
+
+	// Main.create sends `w.run(...)` and `w.stop()` — both behaviour sends.
+	mainCtor := ponyFind(ents, "Main.create", "SCOPE.Operation")
+	if mainCtor == nil {
+		t.Fatal("Main.create not extracted")
+	}
+
+	foundRun := false
+	for _, rel := range mainCtor.Relationships {
+		if rel.Kind != "CALLS" || rel.ToID != "run" {
+			continue
+		}
+		foundRun = true
+		if rel.Properties["pony_msg_send"] != "true" {
+			t.Errorf("run CALLS edge not marked pony_msg_send, props=%v", rel.Properties)
+		}
+		if rel.Properties["pony_msg_receiver"] != "w" {
+			t.Errorf("run receiver = %q, want w", rel.Properties["pony_msg_receiver"])
+		}
+		if rel.Properties["pony_msg_behaviour"] != "run" {
+			t.Errorf("run behaviour = %q, want run", rel.Properties["pony_msg_behaviour"])
+		}
+		if rel.Properties["pony_msg_actor"] != "Worker" {
+			t.Errorf("run target actor = %q, want Worker", rel.Properties["pony_msg_actor"])
+		}
+	}
+	if !foundRun {
+		t.Error("expected a CALLS edge to behaviour 'run' from Main.create")
+	}
+	if !hasTag(mainCtor, "pony_msg_out:run") {
+		t.Errorf("Main.create should be tagged pony_msg_out:run, tags=%v", mainCtor.Tags)
+	}
+}
+
+// A file with no actors must not gain any topology tags/props (no-op path).
+func TestActorTopology_NoActorsNoOp(t *testing.T) {
+	src := `class Greeter
+  fun greet(name: String): String =>
+    "hi " + name
+`
+	ents := runPony(t, src, "/proj/greeter.pony")
+	for i := range ents {
+		e := &ents[i]
+		if hasTag(e, "actor") || hasTag(e, "pony_behaviour") {
+			t.Errorf("non-actor file gained topology tag on %s: %v", e.Name, e.Tags)
+		}
+		for _, rel := range e.Relationships {
+			if rel.Properties["pony_msg_send"] == "true" {
+				t.Errorf("non-actor file gained a pony_msg_send edge on %s", e.Name)
+			}
+		}
+	}
+}
+
+// A non-behaviour synchronous fun call must NOT be marked as a message send.
+func TestActorTopology_SyncFunNotMessage(t *testing.T) {
+	src := `actor Worker
+  be run() =>
+    None
+  fun helper(): None =>
+    None
+
+actor Main
+  new create() =>
+    let w: Worker = Worker
+    w.helper()
+`
+	ents := runPony(t, src, "/proj/sync.pony")
+	mainCtor := ponyFind(ents, "Main.create", "SCOPE.Operation")
+	if mainCtor == nil {
+		t.Fatal("Main.create not extracted")
+	}
+	for _, rel := range mainCtor.Relationships {
+		if rel.ToID == "helper" && rel.Properties["pony_msg_send"] == "true" {
+			t.Error("synchronous fun call 'helper' must not be marked pony_msg_send")
+		}
+	}
+}

--- a/internal/extractors/pony/extractor.go
+++ b/internal/extractors/pony/extractor.go
@@ -126,7 +126,12 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	if len(file.Content) == 0 {
 		return nil, nil
 	}
-	out := extractPony(string(file.Content), file.Path)
+	src := string(file.Content)
+	out := extractPony(src, file.Path)
+	// Actor-model topology enrichment (#5384): tag actors/behaviours and stamp
+	// recovered behaviour message-sends onto their CALLS edges. No-op when the
+	// file declares no actors.
+	enrichActorTopology(src, out)
 	extractor.TagRelationshipsLanguage(out, "pony")
 	extractor.TagEntitiesLanguage(out, "pony")
 	return out, nil


### PR DESCRIPTION
Closes #5384 (epic #5360, milestone 0.1.5 — Group A bootstrap/defer set). Go-only, tightly scoped per `phase:later`.

## corral / ponyc manifest (`manifest_parsing` = full)
`corral.json` (and the legacy `bundle.json`) are the Pony/corral package manifests. `parseCorralJSON` (`internal/extractors/cross/manifest/corral.go`) mines the `deps[]` array into the standard `external_dependency` + `DEPENDS_ON` + `SCOPE.Package` records under `package_manager=corral`, wired into `IsManifest`/`detectPackageManager`/`dispatchParser`/`parsers` by exact basename.

- Dep name = locator final path segment with `.git` stripped (`github.com/ponylang/http_server.git` → `http_server`; scp-style `git@host:owner/name` handled).
- Version from `deps[].version` (or legacy `deps[].tag`); legacy `{type,repo}` entry form accepted.
- corral folds resolved transitive deps into the same `deps[]` array, so the manifest **is** the resolved set — **no separate lockfile** (`lockfile_parsing` = N/A by design).
- `bundle.json` is an ambiguous basename (collides with JS/webpack bundle artifacts), so it is **corral-signal gated**: it only anchors/emits deps when it parses to a non-empty corral `deps[]` array, else a complete no-op.

## Actor-model topology (`core_extraction` = partial, honest)
`enrichActorTopology` (`internal/extractors/pony/actor_topology.go`) extends the existing regex extractor with **no new entity Kind**, mirroring the `lang.erlang.runtime.otp` edge-enrichment model:

- `actor` Components tagged `actor`; behaviours (`be name(...)`) owned by an actor tagged `pony_behaviour` with `Properties[actor]`.
- `receiver.behaviour(args)` message-sends (the actor-model equivalent of `gen_server:cast`) recovered per operation body and stamped onto the matching `CALLS` edge: `pony_msg_send` / `pony_msg_behaviour` / `pony_msg_receiver` / `pony_msg_actor`, plus a `pony_msg_out:<behaviour>` tag on the sender.
- **Honest partial:** receiver static actor TYPE not resolved (verbatim receiver expr); sends matched against same-file behaviours only (regex extractor has no cross-file type table); synchronous `fun`/constructor calls excluded (only behaviours are async messages).

## Registry + docs (same PR)
`manifest.corral` (package_manager) and `lang.pony.runtime.actor` (language) added via the coverage CLI; coverage docs regenerated; `coverage validate` (exit 0) + `fmt --check` (canonical) green.

## Tests
Per-capability on real fixtures:
- manifest: `TestCorralJSON_Deps` / `_VersionCarried`, `TestBundleJSON_LegacyDeps` / `_GenericNoOp`, `TestCorralJSON_NoDepsNoOp`, `TestCorral_IsManifest`.
- topology: `TestActorTopology_TagsActorsAndBehaviours` / `_MessageSendEnrichment` / `_NoActorsNoOp` / `_SyncFunNotMessage`.

`go test ./internal/extractors/pony/ ./internal/extractors/cross/manifest/ ./tools/coverage/` all green; `go vet` + `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)