### PR TITLE
test(mcp): consolidation regression gate — 22 advertised + token ceiling (#5556)

### DIFF
--- a/cmd/mcp-audit/main.go
+++ b/cmd/mcp-audit/main.go
@@ -1,21 +1,28 @@
 // cmd/mcp-audit measures the MCP handshake token budget.
 //
 // It instantiates the MCP server against a minimal empty registry, captures
-// every registered tool definition via the server's internal tool list, and
-// estimates the handshake token count using a conservative 4-chars-per-token
-// ratio (matches Claude's cl100k tokenizer within 5 % on English text).
+// every ADVERTISED tool definition via the server's internal tool list
+// (hidden #5546 aliases are excluded — see toolsFromServer), and estimates the
+// handshake token count using a conservative 4-chars-per-token ratio (matches
+// Claude's cl100k tokenizer within 5 % on English text).
+//
+// After the #5546 consolidation (68 → 22 intent-named tools, validated in
+// #5556), the advertised surface is the 22 canonical tools plus the
+// grafel_status sentinel (23 rows here; the live tools/list handshake drops
+// the sentinel → exactly 22). The measured handshake is ~3,545 tokens, down
+// from the 7,592-token, 68-tool baseline (~53 % reduction).
 //
 // # Usage
 //
 //	go run ./cmd/mcp-audit                   # human-readable report
 //	go run ./cmd/mcp-audit -json             # machine-readable JSON
-//	go run ./cmd/mcp-audit -ceiling 3500     # override token ceiling
+//	go run ./cmd/mcp-audit -ceiling 4500     # override token ceiling
 //	make mcp-audit                           # CI gate (uses AUDIT_CEILING env)
 //
 // # Environment variables
 //
-//	AUDIT_CEILING   token ceiling (default 3500). Exit 1 when exceeded.
-//	AUDIT_BASELINE  baseline token count for delta output.
+//	AUDIT_CEILING   token ceiling (default mcp.TokenCeiling). Exit 1 when exceeded.
+//	AUDIT_BASELINE  baseline token count for delta output (default defaultBaseline).
 package main
 
 import (
@@ -42,6 +49,13 @@ import (
 // See that file's const comment for the full bump history.
 // To raise the ceiling, update TokenCeiling in internal/mcp/budget.go only.
 var defaultCeiling = mcp.TokenCeiling
+
+// defaultBaseline is the pre-#5546 handshake cost (68 tools, 7,592 tokens via
+// this same chars/4 estimator + envelope), recorded by #5556 as the reference
+// for the consolidation delta. Reported out-of-the-box; override with
+// AUDIT_BASELINE or -baseline. Post-consolidation the advertised handshake is
+// ~3,545 tokens (~53 % reduction).
+const defaultBaseline = 7592
 
 // maxDescLen is the per-tool description character limit.
 const maxDescLen = 80
@@ -90,7 +104,7 @@ func main() {
 		ceiling = *ceilingFlag
 	}
 
-	baseline := 0
+	baseline := defaultBaseline
 	if v := os.Getenv("AUDIT_BASELINE"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			baseline = n

--- a/internal/mcp/consolidation_gate_test.go
+++ b/internal/mcp/consolidation_gate_test.go
@@ -1,0 +1,120 @@
+package mcp
+
+// consolidation_gate_test.go — the #5556 final regression gate for the
+// #5546 MCP tool consolidation (68 → 22 intent-named tools).
+//
+// The consolidation collapsed 55 legacy tools into hidden, dispatchable
+// back-compat aliases and now advertises exactly 22 canonical tools in the
+// tools/list handshake. That dropped the per-connect handshake cost from a
+// ~7,592-token baseline to ~3,545 tokens (~53% reduction).
+//
+// The structural guards (advertised==22, no alias leak, aliases still
+// dispatchable, partition invariant) live in hidden_aliases_5552_test.go,
+// and the instructions-name guard lives in server_test.go. What was missing —
+// and what THIS file adds — is a TIGHT TOKEN CEILING on the advertised
+// handshake. The pre-existing budget test (budget_test.go) measures against
+// mcp.TokenCeiling (8000), which is loose enough that silently un-hiding the
+// 55 aliases (~7,592 tokens) would NOT trip it. AdvertisedTokenCeiling closes
+// that hole: any un-consolidation or schema bloat that pushes the advertised
+// surface back over ~4,500 tokens fails the build.
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+)
+
+// AdvertisedTokenCeiling is the regression ceiling for the *advertised*
+// (22-tool) handshake in tokens, using the same conservative 4-chars-per-token
+// estimator as cmd/mcp-audit. The post-#5546 floor is ~3,545; 4,500 leaves
+// comfortable headroom for tight per-tool schema growth while sitting well
+// under the old 7,592-token, 68-tool baseline. If un-consolidation (un-hiding
+// aliases) or schema bloat pushes the advertised surface past this, the build
+// fails — that is the point. Raise it ONLY with a recorded justification.
+const AdvertisedTokenCeiling = 4500
+
+// advertisedEnvelopeBytes mirrors the cmd/mcp-audit init-envelope estimate
+// (server name/version + JSON-RPC framing + the mcpInstructions orientation
+// map). Kept here so this gate measures the same per-connect cost the audit
+// reports, without importing the cmd package.
+const advertisedEnvelopeBytes = 2392
+
+// TestConsolidationAdvertisedTokenCeiling asserts the advertised handshake
+// stays under AdvertisedTokenCeiling. This is the #5556 anti-un-consolidation
+// gate: it trips if the 55 hidden aliases are ever re-advertised, or if schema
+// bloat erodes the ~53% reduction the consolidation delivered.
+func TestConsolidationAdvertisedTokenCeiling(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"mygroup": {"myrepo": repoDir},
+	})
+
+	entries, err := srv.ListToolsForCWD(repoDir)
+	if err != nil {
+		t.Fatalf("ListToolsForCWD: %v", err)
+	}
+
+	totalChars := advertisedEnvelopeBytes
+	for _, e := range entries {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal advertised tool %s: %v", e.Name, err)
+		}
+		totalChars += len(b)
+	}
+	tokens := int(math.Ceil(float64(totalChars) / 4))
+
+	t.Logf("advertised=%d tools  chars=%d  tokens=%d  ceiling=%d (baseline was 7592 @ 68 tools)",
+		len(entries), totalChars, tokens, AdvertisedTokenCeiling)
+
+	if tokens > AdvertisedTokenCeiling {
+		t.Errorf("advertised handshake %d tokens exceeds ceiling %d — the #5546 consolidation may have regressed (aliases un-hidden or schema bloat). Re-run `go run ./cmd/mcp-audit` and investigate before raising the ceiling.",
+			tokens, AdvertisedTokenCeiling)
+	}
+}
+
+// TestConsolidationAdvertisesExactly22 re-asserts the canonical allow-list in
+// the same file as the token gate so the two move together: the headline
+// "22 advertised + token ceiling" invariant lives in one place for #5556.
+// (Structural detail is also covered by hidden_aliases_5552_test.go.)
+func TestConsolidationAdvertisesExactly22(t *testing.T) {
+	repoDir := t.TempDir()
+	srv := makeTestServer(t, map[string]map[string]string{
+		"mygroup": {"myrepo": repoDir},
+	})
+
+	entries, err := srv.ListToolsForCWD(repoDir)
+	if err != nil {
+		t.Fatalf("ListToolsForCWD: %v", err)
+	}
+
+	if len(canonicalToolNames) != 22 {
+		t.Fatalf("canonicalToolNames has %d entries, want 22 — the #5546 allow-list changed", len(canonicalToolNames))
+	}
+	if len(entries) != 22 {
+		t.Errorf("advertised %d tools, want exactly 22: %v", len(entries), toolNames(entries))
+	}
+
+	for _, e := range entries {
+		if !canonicalToolNames[e.Name] {
+			t.Errorf("advertised non-canonical tool %q", e.Name)
+		}
+		if aliasToolNames[e.Name] {
+			t.Errorf("hidden alias %q leaked into the advertised handshake", e.Name)
+		}
+	}
+}
+
+// TestConsolidationInstructionsHaveNoAliases asserts the mcpInstructions
+// orientation map (shipped in the initialize envelope) names none of the 55
+// absorbed legacy tools — so the in-context routing guidance can't drift back
+// to teaching deprecated names. (server_test.go also covers this; kept here as
+// a cheap co-located guard for the consolidation end-state.)
+func TestConsolidationInstructionsHaveNoAliases(t *testing.T) {
+	for alias := range aliasToolNames {
+		if strings.Contains(mcpInstructions, alias) {
+			t.Errorf("mcpInstructions names absorbed alias %q — route via its canonical tool instead", alias)
+		}
+	}
+}


### PR DESCRIPTION
Closes #5556. Part of #5546 — the final validation gate (sub-ticket 8/8).

## What this does

Validates the MCP tool consolidation end-state on current `main` and adds the one regression gate that was still missing so it cannot silently un-consolidate.

### Validation results (current `main`)
- **Advertised tools: 22** — `fullToolList()` (the live tools/list handshake) returns exactly the 22 canonical intent-named tools. `mcp-audit` reports 23 because it includes the `grafel_status` sentinel, which the real handshake drops.
- **Registered surface: 78** = 22 canonical + 55 hidden back-compat aliases + 1 sentinel.
- **Handshake tokens: 3,545** (chars/4 estimator + envelope), down from the **7,592**-token, 68-tool baseline = **−4,047 (~53.3% reduction)**. Matches the ~3.5k scoping projection.
- **Back-compat:** `grafel_find_callers`, `grafel_response_shape_diff`, `grafel_data_flows` (sampled) stay registered/dispatchable and are excluded from the advertised handshake.
- **Doc/skill/install cleanliness:** README, `skills/`, `internal/install/` reference only canonical tool names. The only appearance of any absorbed-alias name anywhere is historical ADR-0018 (`grafel_enrichments`/`grafel_repairs` cited as the action-arg design precedent) — not a routing doc or generated agent file, so not a leftover.

### The gate (the missing piece)
The structural guards already exist (`hidden_aliases_5552_test.go`: advertised==22, no alias leak, aliases still dispatchable, partition invariant; `server_test.go`: instructions name no aliases). What was missing was a **tight token ceiling on the advertised handshake** — the pre-existing budget test measures against `mcp.TokenCeiling` (8000), loose enough that silently un-hiding the 55 aliases (~7,592 tokens) would NOT trip it.

`internal/mcp/consolidation_gate_test.go` adds:
- **`TestConsolidationAdvertisedTokenCeiling`** — advertised handshake must stay **≤ 4,500 tokens** (floor ~3,545; well under the old 7,592). Un-consolidation or schema bloat fails the build. This is the headline anti-regression assertion.
- **`TestConsolidationAdvertisesExactly22`** — co-located 22-count + no-alias-leak guard.
- **`TestConsolidationInstructionsHaveNoAliases`** — `mcpInstructions` names none of the 55 absorbed tools.

Unit tests only, no integration.

### cmd/mcp-audit
- Doc comments now record the consolidation end-state (22 advertised, 7592 → 3545, ~53%).
- `AUDIT_BASELINE` now defaults to 7592 so the run reports the delta out of the box.

`make mcp-audit` passes; full `internal/mcp` suite green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)