### PR TITLE
chore(release): 0.1.5 CHANGELOG + coverage-matrix/doc pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,41 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
-### Added
+---
+
+## [0.1.5] — 2026-06-24
+
+**MCP-surface consolidation + TypeScript-stack & broad-language coverage
+release.** The MCP tool surface is consolidated from 68 tools down to 22
+intent-named canonical tools — cutting the handshake token cost roughly in half
+— with all former names kept as hidden back-compat aliases. Coverage lands for a
+modern Next.js App Router + Prisma + Inngest TypeScript stack (Inngest
+event→function topology, App-Router route handlers / Server Actions / RSC
+data-fetch, modular Prisma schema + data-access effects, Kysely, TanStack Query,
+deeper Zod, home-rolled auth, OTEL JS/TS, Pulumi-AWS, common SaaS SDKs, and a
+package.json/lockfile dependency manifest with dead-dependency detection). 24
+lower-ranked languages are newly bootstrapped or uplifted across three waves.
+Plus an index-concurrency cap to stop monorepo index storms and a batch of
+cross-repo / install / dashboard fixes.
+
+### MCP tool consolidation
+- **68 → 22 intent-named canonical tools (#5546):** the MCP surface is
+  consolidated from 68 narrow tools to 22 task-oriented, intent-named tools,
+  cutting the handshake token overhead from ~7.6k to ~3.5k tokens (−53%). Related
+  tools are merged behind discriminated parameters across three clusters —
+  **core** (`orient`/`find`/`related`/`trace`/`endpoints`/`impact`/`subgraph`,
+  #5549), **analysis** (`debt`/`security`/`test_analysis`/`patterns`/`findings`/
+  `diff`, #5550), and **workflow + meta** (`docgen`/`docgen_apply`/`event`,
+  #5551) — with the canonical high-traffic tools kept as-is. Every removed tool
+  name remains callable as a **hidden back-compat alias** (#5552) so existing
+  agents and scripts keep working; aliases are omitted from the handshake to keep
+  the advertised surface lean. The in-context routing guidance (mcpInstructions +
+  the install-generated agent files, #5555), the tool reference docs (#5553), and
+  the `/grafel-*` skills (#5554) were all rewritten to the 22-tool, task-oriented
+  surface with disambiguators and no deprecated names; the token-overhead
+  reduction was validated and recorded against the 7592-token baseline (#5556).
+
+### TypeScript-stack coverage (#5479)
 - **Common TS SaaS SDKs → external-service dependencies via one shared
   allow-list (#5502):** the shared third-party-integration dictionary
   (`extractor.ServiceForImportSource`) now recognises the common TypeScript
@@ -384,6 +418,35 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   unrelated repos advance, and a single-repo / all-same-status list renders
   exactly as before.
 
+### New & uplifted language coverage (#5360)
+- **Wave 1 — coverage uplift for 8 established languages:** existing language
+  support was deepened with framework routing, ORM/persistence drivers,
+  dependency manifests, and test runners. **Dart** (#5361) — persistence ORMs,
+  `pubspec.lock`, widget-tree/prop depth; **Clojure** (#5362) — Ring/Pedestal
+  routing, next.jdbc/HoneySQL/datalog drivers; **Erlang** (#5363) — OTP
+  supervision trees, `gen_server` edges, Cowboy depth; **Groovy** (#5364) —
+  Gradle DSL, GORM, Grails routing, Spock; **Lua** (#5365) — luarocks,
+  OpenResty/Kong routing depth, busted; **Crystal** (#5366) — shards, ORMs,
+  Lucky, spec; **Nim** (#5367) — nimble, Jester/Prologue routing, ORMs, unittest;
+  **F#** (#5368) — Giraffe/Saturn computation-expression routing, Paket
+  dep-graph, EF Core reuse.
+- **Wave 2 — bootstrap records for 6 high-value languages:** newly recognised
+  with framework/tool/IaC records. **Solidity** (#5371) — Hardhat/Foundry/Truffle,
+  OpenZeppelin, ethers; **Bicep** (#5372) — Azure resource-provider catalog,
+  `bicepconfig`/module-registry; **Haskell** (#5373) — Servant/Yesod/Scotty,
+  Stack/Cabal, persistent, hspec; **OCaml** (#5374) — Dune/opam, Dream, Caqti,
+  alcotest; **Elm** (#5375) — The Elm Architecture, `elm.json`, elm-test;
+  **Zig** (#5377) — `build.zig` build system, `zig test`.
+- **Wave 3 — bootstrap records for 9 niche languages + mainframe spike:**
+  **ReScript** (#5378) — `rescript.json`/bsconfig, ReScript-React, JS-ecosystem
+  reuse; **ReasonML** (#5379) — bsconfig, Reason-React, JS-ecosystem reuse;
+  **Verilog** (#5380) and **VHDL** (#5381) — module/entity/port/instance
+  topology plus sim/synth tools; **Idris** (#5382) — `ipkg` manifest;
+  **Standard ML** (#5383) — CM/`.mlb` build files, compiler toolchain;
+  **Pony** (#5384) — corral/ponyc manifest, actor topology; **Lisp** (#5385) —
+  ASDF/Quicklisp system definitions; and an **opt-in COBOL/JCL mainframe lineage
+  spike** (#5369) — PERFORM/CALL, copybook fields, JCL job→pgm→dataset wiring.
+
 ### Fixed
 - **Windows: cross-repo string pass no longer aborts on the synthetic
   `<config>` SourceFile (#5523):** the cross-repo string pass scanned each
@@ -431,6 +494,12 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
   (#5328). `grafel_index_status` now reports the gate's `concurrency` block
   (`indexing` / `queued` / `cap`) so a draining group reads "indexing 2, queued 28"
   instead of looking stalled.
+- **Tighter cross-repo HTTP resolution + endpoint-detection confidence
+  (#5527):** the cross-repo HTTP linker now normalizes paths and parameters
+  (trailing slashes, `:id`/`{id}`/`[id]` segment forms) before matching a
+  client call to a server endpoint, and the endpoint-detection confidence
+  scoring was tightened so genuine `fetch`/`axios` call sites bind across repos
+  while ambiguous ones no longer over-match — reducing residual `orphan_calls`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Status: v0.x](https://img.shields.io/badge/status-v0.x-blue.svg)](CHANGELOG.md)
 
-**grafel** is a local code-knowledge-graph daemon that gives AI agents structural navigation across one or many repos — call graphs, cross-repo traces, HTTP surface maps, process flows — via 65 MCP tools.
+**grafel** is a local code-knowledge-graph daemon that gives AI agents structural navigation across one or many repos — call graphs, cross-repo traces, HTTP surface maps, process flows — via 22 MCP tools.
 
 **A companion to `grep`, not a replacement:** `grep` finds text, grafel maps structure. Its value is **navigation** — where `X` is defined, who calls `Y`, how a request flows end-to-end, the blast radius of a change — the questions grep can't answer. (Fewer file reads also means fewer tokens — a side effect, not the point.)
 
@@ -199,13 +199,13 @@ Each extractor emits language-specific edges (HTTP endpoints, ORM queries, dynam
 
 ### Coverage
 
-grafel tracks **39 languages (25 active), 255 frameworks, 176 ORMs, 129 tools, and 205 other** capabilities, plus cross-cutting infrastructure: databases, platform/k8s, message brokers, CI/CD, security, observability, protocols, and build systems.
+grafel tracks **39 languages (38 active), 263 frameworks, 186 ORMs, 161 tools, and 211 other** capabilities, plus cross-cutting infrastructure: databases, platform/k8s, message brokers, CI/CD, security, observability, protocols, and build systems.
 
 Top languages by framework support:
 
 | Language | Frameworks | ORMs | Tools |
 |----------|-----------:|-----:|------:|
-| JS/TS | 33 | 19 | 21 |
+| JS/TS | 33 | 20 | 22 |
 | C/C++ | 25 | 10 | 16 |
 | python | 25 | 18 | 15 |
 | java | 23 | 15 | 10 |


### PR DESCRIPTION
Pre-tag documentation pass for the 0.1.5 milestone. Docs only — no feature code.

## CHANGELOG
New grouped `## [0.1.5] — 2026-06-24` section with a summary paragraph and four themed subsections:
- **MCP tool consolidation** — 68 → 22 intent-named canonical tools (handshake ~7.6k → ~3.5k tokens, −53%); old names kept as hidden back-compat aliases; routing/docs/skills rewritten (#5546 and cluster PRs #5549–#5556).
- **TypeScript-stack coverage (#5479)** — the existing per-PR Added entries (Inngest topology, Next.js route handlers / Server Actions / RSC, modular Prisma + data-access effects, Kysely, TanStack Query, Zod depth, home-rolled auth, OTEL JS/TS, Pulumi-AWS, SaaS SDKs, package.json/lockfile manifests) regrouped under one theme.
- **New & uplifted language coverage (#5360)** — 24 languages across Wave 1 (uplift: dart/clojure/erlang/groovy/lua/crystal/nim/fsharp), Wave 2 (bootstrap: solidity/bicep/haskell/ocaml/elm/zig), Wave 3 (rescript/reasonml/verilog/vhdl/idris/sml/pony/lisp + COBOL/JCL spike).
- **Fixed** — index-concurrency cap, dashboard index-list sorting, macOS skills-install, Windows synthetic-SourceFile cross-repo abort, cross-repo HTTP / fetch-axios confidence.

`[Unreleased]` retained as an empty placeholder above it.

## Coverage matrix
`coverage gen` produced no diff (per-PR agents already regenerated the docs); `validate` exits 0, `fmt --check` reports canonical. Matrix is current: 39 languages (38 active), 263 frameworks, 186 ORMs, 161 tools, 211 other.

## README
- Fixed stale "65 MCP tools" → "22 MCP tools".
- Refreshed coverage counts (39 / 263 / 186 / 161 / 211) and the JS/TS row.
- No deprecated tool names present.

## Verify
`go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)