### PR TITLE
fix(test): update structural-invariant assertions to canonical tool names (consolidation)

### DIFF
--- a/internal/personas/validate_test.go
+++ b/internal/personas/validate_test.go
@@ -80,7 +80,9 @@ const sharedSkillReadRef = "grafel-graph-read"
 const sharedSkillWriteRef = "grafel-graph-write"
 
 // telemetryCall is the MCP tool that must appear in every persona's Lifecycle telemetry section.
-const telemetryCall = "grafel_persona_event"
+// Post-consolidation (#5546), the dedicated grafel_persona_event tool was absorbed into the
+// canonical grafel_event tool (discriminated by kind=persona).
+const telemetryCall = "grafel_event"
 
 // frontmatter holds the parsed YAML frontmatter of a persona file.
 type frontmatter struct {


### PR DESCRIPTION
The MCP tool consolidation renamed the dedicated lifecycle-telemetry tool to the canonical `grafel_event` (discriminated by `kind=persona`). The persona `.md` files were updated accordingly, but `TestPersonaStructuralInvariants` (`internal/personas/validate_test.go`) still asserted the old tool name, breaking the CI gate.

## Change
- Update the `telemetryCall` constant from the old dedicated persona-telemetry tool name to the canonical `grafel_event`.

The structural invariant intent is preserved: every persona file must still reference the telemetry tool in its `## Lifecycle telemetry` section. The persona `.md` files already use `grafel_event (kind=persona)`, so the test fix alone restores the invariant.

## Verification
- `go test -count=1 ./internal/personas/...` — green (was failing for all 12 personas)
- `go build ./...` — clean
- `go vet ./internal/personas/...` — clean
- `gofmt -l` on the touched file — empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)