### PR TITLE
feat(mcp): fuzzy enum-correction + helpful errors + per-discriminator param clarity (#5578)

### DIFF
--- a/internal/mcp/analysis_merges.go
+++ b/internal/mcp/analysis_merges.go
@@ -32,6 +32,11 @@ import (
 //	impure              → handlePureFunctions     (functions with no effects)
 //	license             → handleLicenseAudit      (dependency-license conflicts)
 func (s *Server) handleAnalysisDebt(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("kind", argString(req, "kind", ""),
+		[]string{"dead_code", "find_dead_code", "unwired", "cycles", "import_cycles", "stubs", "stub", "impure", "pure", "pure_functions", "license", "licenses"},
+		[]string{"dead_code", "cycles", "stubs", "impure", "license"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "kind", "dead_code") {
 	case "find_dead_code", "unwired":
 		return s.handleFindDeadCode(ctx, req)
@@ -57,6 +62,11 @@ func (s *Server) handleAnalysisDebt(ctx context.Context, req mcpapi.CallToolRequ
 //	secrets            → handleSecrets          (hardcoded-secret scan)
 //	auth_coverage      → handleAuthCoverage     (endpoints missing auth)
 func (s *Server) handleAnalysisSecurity(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("kind", argString(req, "kind", ""),
+		[]string{"findings", "secrets", "auth_coverage", "auth"},
+		[]string{"findings", "secrets", "auth_coverage"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "kind", "findings") {
 	case "secrets":
 		return s.handleSecrets(ctx, req)
@@ -75,6 +85,11 @@ func (s *Server) handleAnalysisSecurity(ctx context.Context, req mcpapi.CallTool
 //	contract_effectiveness → handleContractTestEffectiveness (tautological specs)
 //	coverage_effectiveness → handleCoverageEffectiveness  (reachable-but-0%-lines)
 func (s *Server) handleAnalysisTest(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("kind", argString(req, "kind", ""),
+		[]string{"coverage", "reachability", "reach", "contract_effectiveness", "contract_eff", "contract", "coverage_effectiveness", "coverage_eff", "effectiveness"},
+		[]string{"coverage", "reachability", "contract_effectiveness", "coverage_effectiveness"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "kind", "coverage") {
 	case "reachability", "reach":
 		return s.handleTestReachability(ctx, req)
@@ -96,6 +111,11 @@ func (s *Server) handleAnalysisTest(ctx context.Context, req mcpapi.CallToolRequ
 //	graph          → handleGraphPatterns    (indexer-extracted patterns)
 //	template       → handleTemplatePatterns (i18n/log_format/sql literals)
 func (s *Server) handleAnalysisPatterns(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("kind", argString(req, "kind", ""),
+		[]string{"code", "graph", "graph_patterns", "template", "templates", "template_patterns"},
+		[]string{"code", "graph", "template"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "kind", "code") {
 	case "graph", "graph_patterns":
 		// handleGraphPatterns requires action=; default to list when the caller
@@ -117,6 +137,11 @@ func (s *Server) handleAnalysisPatterns(ctx context.Context, req mcpapi.CallTool
 //	list (default) → handleListFindings (enumerate stored findings)
 //	save           → handleSaveResult   (persist a Q&A finding)
 func (s *Server) handleAnalysisFindings(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("action", argString(req, "action", ""),
+		[]string{"list", "save", "store", "persist"},
+		[]string{"list", "save"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "action", "list") {
 	case "save", "store", "persist":
 		return s.handleSaveResult(ctx, req)
@@ -142,6 +167,25 @@ func (s *Server) handleAnalysisFindings(ctx context.Context, req mcpapi.CallTool
 //	literals                 → handleLiteralParity     (ConstantSet/enum parity)
 //	refs                     → handleDiffRefs          (entity/rel deltas, 2 refs)
 func (s *Server) handleAnalysisDiff(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	rawAspect := argString(req, "aspect", "")
+	if e := validateDiscriminator("aspect", rawAspect,
+		[]string{"response_shape", "payload", "payload_drift", "auth", "auth_posture", "literals", "literal", "literal_parity", "refs", "diff_refs"},
+		[]string{"response_shape", "payload", "auth", "literals", "refs"}); e != nil {
+		return e, nil
+	}
+	// Per-aspect required params: the params a grafel_diff call needs depend on
+	// the chosen aspect. Validate the value-specific requirements up front so a
+	// caller gets an aspect-aware message instead of a downstream hard-fail.
+	switch rawAspect {
+	case "refs", "diff_refs":
+		if e := requireArgs(req, "aspect", "refs", "repo", "ref_a", "ref_b"); e != nil {
+			return e, nil
+		}
+	case "literals", "literal", "literal_parity":
+		if e := requireArgs(req, "aspect", "literals", "set"); e != nil {
+			return e, nil
+		}
+	}
 	var (
 		res    *mcpapi.CallToolResult
 		err    error

--- a/internal/mcp/core_merges.go
+++ b/internal/mcp/core_merges.go
@@ -54,6 +54,11 @@ func reqWithArgs(req mcpapi.CallToolRequest, overrides map[string]any) mcpapi.Ca
 //	modules            → handleModuleAnalysis (module SCC/PageRank/betweenness)
 //	stats              → handleGraphStats     (corpus-level metrics)
 func (s *Server) handleCoreOrient(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("view", argString(req, "view", ""),
+		[]string{"overview", "me", "whoami", "clusters", "communities", "topology", "modules", "module_analysis", "stats"},
+		[]string{"overview", "me", "clusters", "topology", "modules", "stats"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "view", "overview") {
 	case "me", "whoami":
 		return s.handleWhoami(ctx, req)
@@ -83,6 +88,11 @@ func (s *Server) handleCoreOrient(ctx context.Context, req mcpapi.CallToolReques
 //	bm25 (default) → handleQueryGraph    (semantic "where is X?" BM25 ranking)
 //	substring      → handleSearchEntities (literal substring over entity names)
 func (s *Server) handleCoreFind(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("search", argString(req, "search", ""),
+		[]string{"bm25", "substring", "literal", "name"},
+		[]string{"bm25", "substring"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "search", "bm25") {
 	case "substring", "literal", "name":
 		return s.handleSearchEntities(ctx, req)
@@ -101,6 +111,11 @@ func (s *Server) handleCoreFind(ctx context.Context, req mcpapi.CallToolRequest)
 //	uses              → handleNavigates(direction=outgoing)  (NAVIGATES_TO out)
 //	used_by           → handleNavigates(direction=incoming)  (NAVIGATES_TO in)
 func (s *Server) handleCoreRelated(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("direction", argString(req, "direction", ""),
+		[]string{"callers", "callees", "neighbors", "both", "uses", "used_by"},
+		[]string{"callers", "callees", "neighbors", "uses", "used_by"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "direction", "callers") {
 	case "callees":
 		return s.handleFindCallees(ctx, req)
@@ -144,6 +159,11 @@ func (s *Server) handleCoreSubgraph(ctx context.Context, req mcpapi.CallToolRequ
 //	flows          → handleFlows        (process-flow diagnostics)
 //	process        → handleTraces       (process-flow traces list/get/follow)
 func (s *Server) handleCoreTrace(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("kind", argString(req, "kind", ""),
+		[]string{"path", "data", "data_flows", "control", "control_flow", "def_use", "defuse", "effects", "flows", "process", "traces"},
+		[]string{"path", "data", "control", "def_use", "effects", "flows", "process"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "kind", "path") {
 	case "data", "data_flows":
 		return s.handleDataFlows(ctx, req)
@@ -173,6 +193,11 @@ func (s *Server) handleCoreTrace(ctx context.Context, req mcpapi.CallToolRequest
 //	contract       → handleEffectiveContract  (per-verb effective contract)
 //	posture        → handleEndpointPosture    (auth/rate_limit/throws/flags)
 func (s *Server) handleCoreEndpoints(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("detail", argString(req, "detail", ""),
+		[]string{"list", "contract", "posture"},
+		[]string{"list", "contract", "posture"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "detail", "list") {
 	case "contract":
 		return s.handleEffectiveContract(ctx, req)
@@ -193,6 +218,11 @@ func (s *Server) handleCoreEndpoints(ctx context.Context, req mcpapi.CallToolReq
 //	entity (default) → handleImpactRadius (inbound blast-radius of one entity)
 //	changeset        → handlePRImpact     (PR/diff impact + merge-risk)
 func (s *Server) handleCoreImpactRadius(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("scope", argString(req, "scope", ""),
+		[]string{"entity", "changeset", "pr", "diff"},
+		[]string{"entity", "changeset"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "scope", "entity") {
 	case "changeset", "pr", "diff":
 		return s.handlePRImpact(ctx, req)

--- a/internal/mcp/discriminator.go
+++ b/internal/mcp/discriminator.go
@@ -1,0 +1,161 @@
+package mcp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// discriminator.go — fuzzy enum-correction + helpful errors for the consolidated
+// canonical MCP tools (#5578, milestone 0.1.6; ref #5546).
+//
+// The 68→22 tool consolidation moved each tool's discriminator from the tool
+// NAME (validated by the MCP tool list) into a param VALUE
+// (aspect/kind/direction/detail/scope/action/view). That created a new failure
+// mode: a caller passing an invalid value (e.g. aspect=shape instead of
+// response_shape) used to be caught by the tool-name registry and now silently
+// falls through to a dispatcher default or hard-fails. This turns that malformed
+// call into a one-round-trip self-correction by returning a clear error naming
+// the closest valid value and the full valid list.
+//
+// The closest-match is a small case-insensitive Levenshtein over the fixed enum
+// set — the same self-correction spirit as the find_callers fuzzy resolver
+// (#5476), but over a tiny known value list rather than entity names, so a plain
+// edit-distance is both cheaper and a better fit than substring matching.
+
+// validateDiscriminator checks a discriminator param's value against its set of
+// accepted values. It returns nil (no error) when:
+//   - value is empty / missing — the handler applies its default, never an error;
+//   - value is one of accepted (canonical value OR an accepted synonym alias).
+//
+// On an unrecognised value it returns a helpful *mcpapi.CallToolResult error:
+//
+//	invalid <param> '<value>' — did you mean '<closest>'? valid: a|b|c
+//
+// The "did you mean" clause is only included when a close-enough match exists
+// (small edit distance); otherwise just the valid list is shown. canonical is
+// the list advertised to agents (synonyms are accepted silently but not
+// suggested), so the suggestion always points at a value the schema documents.
+func validateDiscriminator(param, value string, accepted, canonical []string) *mcpapi.CallToolResult {
+	if value == "" {
+		return nil // missing → handler default
+	}
+	vl := strings.ToLower(value)
+	for _, a := range accepted {
+		if strings.ToLower(a) == vl {
+			return nil
+		}
+	}
+	valid := strings.Join(canonical, "|")
+	if best := closestEnum(vl, canonical); best != "" {
+		return mcpapi.NewToolResultError(fmt.Sprintf(
+			"invalid %s %q — did you mean %q? valid: %s", param, value, best, valid))
+	}
+	return mcpapi.NewToolResultError(fmt.Sprintf(
+		"invalid %s %q — valid: %s", param, value, valid))
+}
+
+// closestEnum returns the canonical value nearest to probe by case-insensitive
+// Levenshtein distance, but only when that distance is small enough to be a
+// plausible typo (≤ max(2, len/2) of the shorter string). Returns "" when no
+// candidate is close enough — better to show only the valid list than to
+// suggest an unrelated value. probe is assumed already lower-cased.
+func closestEnum(probe string, canonical []string) string {
+	// Substring/abbreviation match wins outright — a probe that is a contiguous
+	// fragment of exactly one canonical value (e.g. "shape" in "response_shape",
+	// or "auth" already canonical) is almost certainly that value, even though
+	// the raw edit distance is large. Prefer the shortest containing value when
+	// several contain the probe.
+	if len(probe) >= 3 {
+		sub := ""
+		for _, c := range canonical {
+			if strings.Contains(strings.ToLower(c), probe) {
+				if sub == "" || len(c) < len(sub) {
+					sub = c
+				}
+			}
+		}
+		if sub != "" {
+			return sub
+		}
+	}
+
+	best := ""
+	bestDist := 1 << 30
+	for _, c := range canonical {
+		d := levenshtein(probe, strings.ToLower(c))
+		if d < bestDist {
+			bestDist, best = d, c
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	shorter := len(probe)
+	if l := len(best); l < shorter {
+		shorter = l
+	}
+	threshold := shorter / 2
+	if threshold < 2 {
+		threshold = 2
+	}
+	if bestDist > threshold {
+		return ""
+	}
+	return best
+}
+
+// levenshtein is the classic edit distance between a and b (single-row DP).
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	ra, rb := []rune(a), []rune(b)
+	prev := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		cur := make([]int, len(rb)+1)
+		cur[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			cur[j] = min3(prev[j]+1, cur[j-1]+1, prev[j-1]+cost)
+		}
+		prev = cur
+	}
+	return prev[len(rb)]
+}
+
+// requireArgs returns a helpful error result when any of the named args is
+// missing/empty for the chosen discriminator value, else nil. Used by the
+// polymorphic tools (esp. grafel_diff) where the params a call needs depend on
+// the discriminator value — turning a downstream "missing X" hard-fail into an
+// up-front, value-aware message. names is sorted in the message for stable
+// output.
+func requireArgs(req mcpapi.CallToolRequest, param, value string, names ...string) *mcpapi.CallToolResult {
+	var missing []string
+	for _, n := range names {
+		if argString(req, n, "") == "" {
+			missing = append(missing, n)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return mcpapi.NewToolResultError(fmt.Sprintf(
+		"%s=%s requires: %s — missing: %s",
+		param, value, strings.Join(names, ", "), strings.Join(missing, ", ")))
+}

--- a/internal/mcp/discriminator_test.go
+++ b/internal/mcp/discriminator_test.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// discriminator_test.go — fuzzy enum-correction + helpful errors for the
+// consolidated canonical tools (#5578). A bad discriminator value returns a
+// helpful error naming the closest valid value and the full valid list; a good
+// value dispatches normally (unchanged behaviour); and grafel_diff's per-aspect
+// required-param validation errors helpfully when a value-specific param is
+// missing.
+
+func TestValidateDiscriminator(t *testing.T) {
+	canon := []string{"response_shape", "payload", "auth", "literals", "refs"}
+	acc := append([]string{}, canon...)
+
+	// empty/missing value → default applies, no error.
+	if e := validateDiscriminator("aspect", "", acc, canon); e != nil {
+		t.Fatalf("empty value should be allowed (default), got error")
+	}
+	// canonical value → no error.
+	if e := validateDiscriminator("aspect", "payload", acc, canon); e != nil {
+		t.Fatalf("valid value rejected")
+	}
+	// case-insensitive accept.
+	if e := validateDiscriminator("aspect", "PAYLOAD", acc, canon); e != nil {
+		t.Fatalf("case-insensitive valid value rejected")
+	}
+
+	// typo → helpful error with closest-match suggestion + full valid list.
+	e := validateDiscriminator("aspect", "shape", acc, canon)
+	if e == nil || !e.IsError {
+		t.Fatalf("invalid value should error")
+	}
+	msg := resultText(e)
+	if !strings.Contains(msg, "did you mean") || !strings.Contains(msg, "response_shape") {
+		t.Fatalf("expected closest-match suggestion 'response_shape', got: %s", msg)
+	}
+	for _, v := range canon {
+		if !strings.Contains(msg, v) {
+			t.Fatalf("error should list valid value %q, got: %s", v, msg)
+		}
+	}
+
+	// far-off value → still errors, lists valids, no spurious suggestion.
+	e2 := validateDiscriminator("aspect", "zzzzzzzzzz", acc, canon)
+	if e2 == nil || !e2.IsError {
+		t.Fatalf("far-off value should error")
+	}
+	if strings.Contains(resultText(e2), "did you mean") {
+		t.Fatalf("far-off value should NOT suggest a match, got: %s", resultText(e2))
+	}
+}
+
+func TestClosestEnum(t *testing.T) {
+	canon := []string{"callers", "callees", "neighbors", "uses", "used_by"}
+	cases := map[string]string{
+		"caller":   "callers",
+		"callee":   "callees",
+		"neighbor": "neighbors",
+		"usedby":   "used_by",
+	}
+	for in, want := range cases {
+		if got := closestEnum(in, canon); got != want {
+			t.Errorf("closestEnum(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := closestEnum("zzzzzzz", canon); got != "" {
+		t.Errorf("closestEnum on far-off probe = %q, want empty", got)
+	}
+}
+
+// TestDiffBadAspectHelpfulError exercises the helper through the real dispatcher.
+func TestDiffBadAspectHelpfulError(t *testing.T) {
+	srv := coreTestServer(t)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"aspect": "shape", "group": "g"}
+	res, err := srv.handleAnalysisDiff(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("bad aspect should return error result")
+	}
+	msg := resultText(res)
+	if !strings.Contains(msg, "response_shape") || !strings.Contains(msg, "did you mean") {
+		t.Fatalf("expected suggestion of response_shape, got: %s", msg)
+	}
+}
+
+// TestDiffMissingRequiredParam covers the per-aspect required-param validation:
+// aspect=refs needs repo+ref_a+ref_b; a missing one yields an aspect-aware error
+// BEFORE any dispatch.
+func TestDiffMissingRequiredParam(t *testing.T) {
+	srv := coreTestServer(t)
+	req := mcpapi.CallToolRequest{}
+	// refs aspect with repo + ref_a but no ref_b.
+	req.Params.Arguments = map[string]any{"aspect": "refs", "group": "g", "repo": "r1", "ref_a": "main"}
+	res, err := srv.handleAnalysisDiff(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("missing ref_b should return error result")
+	}
+	msg := resultText(res)
+	if !strings.Contains(msg, "ref_b") || !strings.Contains(msg, "refs") {
+		t.Fatalf("expected aspect=refs missing ref_b error, got: %s", msg)
+	}
+}
+
+// TestGoodDiscriminatorDispatches confirms a valid discriminator value still
+// reaches its delegate (validation does not break the happy path). We assert the
+// validation gate did NOT short-circuit: a good value produces a non-error,
+// aspect-stamped result identical to calling the absorbed handler directly.
+func TestGoodDiscriminatorDispatches(t *testing.T) {
+	srv := coreTestServer(t)
+	// grafel_related direction=callees: valid value must dispatch, not error.
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"entity_id": "missing", "direction": "callees", "group": "g"}
+	res, err := srv.handleCoreRelated(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	// A valid discriminator must NOT produce the "invalid direction" gate error.
+	if res != nil && res.IsError && strings.Contains(resultText(res), "invalid direction") {
+		t.Fatalf("valid direction was rejected by the gate: %s", resultText(res))
+	}
+}

--- a/internal/mcp/meta_merges.go
+++ b/internal/mcp/meta_merges.go
@@ -31,6 +31,11 @@ import (
 //	abort    → handleDocgenAbort    (rm -rf staging, release lock; needs run_id)
 //	validate → handleDocgenValidate (frontmatter+cross-links, read-only)
 func (s *Server) handleWorkflowDocgen(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("action", argString(req, "action", ""),
+		[]string{"start", "start_run", "status", "list", "promote", "abort", "validate"},
+		[]string{"start", "status", "list", "promote", "abort", "validate"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "action", "status") {
 	case "start", "start_run":
 		return s.handleDocgenStartRun(ctx, req)
@@ -58,6 +63,11 @@ func (s *Server) handleWorkflowDocgen(ctx context.Context, req mcpapi.CallToolRe
 //	enrichments         → handleEnrichments (enrichment-candidate queue;
 //	                      reads its own action=list|submit|reject)
 func (s *Server) handleWorkflowDocgenApply(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("kind", argString(req, "kind", ""),
+		[]string{"semantics", "repairs", "repair", "enrichments", "enrichment"},
+		[]string{"semantics", "repairs", "enrichments"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "kind", "semantics") {
 	case "repairs", "repair":
 		// The residual-repair queue (handleRepairs) is driven by action=list|
@@ -80,6 +90,11 @@ func (s *Server) handleWorkflowDocgenApply(ctx context.Context, req mcpapi.CallT
 //	feedback (default) → handleFeedbackEvent (agent-experience; needs outcome)
 //	persona            → handlePersonaEvent  (persona lifecycle; needs persona+event_type)
 func (s *Server) handleMetaEvent(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	if e := validateDiscriminator("kind", argString(req, "kind", ""),
+		[]string{"feedback", "persona"},
+		[]string{"feedback", "persona"}); e != nil {
+		return e, nil
+	}
 	switch argString(req, "kind", "feedback") {
 	case "persona":
 		return s.handlePersonaEvent(ctx, req)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1139,16 +1139,16 @@ func (s *Server) registerTools() {
 	// response_shape/auth/literals=per-endpoint parity verdicts; payload=drift
 	// findings) and the result is stamped with `aspect` so the caller knows which.
 	s.addTool(mcpapi.NewTool("grafel_diff",
-		mcpapi.WithDescription("Compare two refs/versions; aspect picks what to compare (shape varies)."),
+		mcpapi.WithDescription("Compare two refs/versions; aspect picks what (params vary by aspect)."),
 		mcpapi.WithString("aspect", mcpapi.DefaultString("response_shape"),
-			mcpapi.Description("response_shape=per-status field drift; payload=schema/envelope drift; auth=auth-posture parity; literals=enum/ConstantSet parity; refs=entity/rel deltas between two git refs.")),
-		mcpapi.WithString("group_oracle"), // response_shape|auth|literals
-		mcpapi.WithString("group_v3"),     // response_shape|auth|literals
-		mcpapi.WithString("set"),          // aspect=literals
-		mcpapi.WithString("drift_class"),  // aspect=payload
-		mcpapi.WithString("repo"),         // aspect=refs
-		mcpapi.WithString("ref_a"),        // aspect=refs
-		mcpapi.WithString("ref_b"),        // aspect=refs
+			mcpapi.Description("response_shape=per-status field drift (group_oracle+group_v3); payload=schema/envelope drift (group); auth=auth-posture parity (group_oracle+group_v3); literals=enum/ConstantSet parity (group_oracle+group_v3+set); refs=entity/rel deltas between two git refs (repo+ref_a+ref_b).")),
+		mcpapi.WithString("group_oracle", mcpapi.Description("aspect=response_shape|auth|literals: baseline group.")),
+		mcpapi.WithString("group_v3", mcpapi.Description("aspect=response_shape|auth|literals: comparison group.")),
+		mcpapi.WithString("set", mcpapi.Description("aspect=literals (required): ConstantSet/enum name to compare.")),
+		mcpapi.WithString("drift_class", mcpapi.Description("aspect=payload: optional drift-class filter.")),
+		mcpapi.WithString("repo", mcpapi.Description("aspect=refs (required): repo whose two refs are compared.")),
+		mcpapi.WithString("ref_a", mcpapi.Description("aspect=refs (required): first git ref.")),
+		mcpapi.WithString("ref_b", mcpapi.Description("aspect=refs (required): second git ref.")),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("grafel_diff", s.handleAnalysisDiff))


### PR DESCRIPTION
Closes #5578 (ref #5546). Go-only, `internal/mcp`.

The 68→22 tool consolidation moved each tool's discriminator from the tool NAME (validated by the MCP tool list) into a param VALUE. That created a new failure mode: an invalid discriminator value (e.g. `aspect=shape` instead of `response_shape`) was no longer caught up front and silently fell through to a default or hard-failed. This turns the malformed call into a one-round-trip self-correction.

## Shared helper (`internal/mcp/discriminator.go`)
- `validateDiscriminator(param, value, accepted, canonical)` — empty/missing value uses the handler default (never an error); a value in `accepted` (canonical OR synonym alias) passes; an unknown value returns a helpful `NewToolResultError`:
  `invalid <param> '<value>' — did you mean '<closest>'? valid: a|b|c`
- `closestEnum` — closest valid value via substring/abbreviation match (e.g. `shape`→`response_shape`) then case-insensitive Levenshtein, gated by an edit-distance threshold so far-off values get only the valid list, no spurious suggestion. Same self-correction spirit as the find_callers resolver (#5476), over a fixed small enum set.
- `requireArgs` — per-value required-param check for polymorphic tools.

Called at the TOP of every discriminated canonical handler, before dispatch: **orient**(view), **find**(search), **related**(direction), **trace**(kind), **endpoints**(detail), **impact_radius**(scope), **diff**(aspect), **debt**/**security**/**test_analysis**/**patterns**(kind), **findings**(action), **docgen**(action), **docgen_apply**(kind), **event**(kind). Accepted lists include the existing synonym aliases, so back-compat dispatch is byte-identical.

## Per-discriminator param clarity (`grafel_diff` canary)
- Tool description notes params vary by aspect; each param's `Description()` now states which aspect it applies to (`group_oracle/group_v3` for response_shape|auth|literals; `set` for literals; `repo/ref_a/ref_b` for refs; `drift_class` for payload).
- The handler validates the aspect-specific required params up front (refs needs repo+ref_a+ref_b; literals needs set) with an aspect-aware error, instead of a downstream hard-fail.

## Tests
- bad discriminator value → suggestion + full valid list (`aspect=shape` → suggests `response_shape`); far-off value → valid list, no suggestion.
- good value → dispatches unchanged (no gate short-circuit).
- missing aspect-required param → helpful `aspect=refs requires: …` error.
- `go test -count=1 ./internal/mcp/...` green; `mcp-audit` unchanged (no new tools, all descriptions ≤80 chars, handshake within budget); `gofmt -l` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)