### PR TITLE
fix(install): make install.sh/install.ps1 restart the daemon on re-run (update-aware) (#5582)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -100,6 +100,34 @@ function Add-ToUserPath($Dir) {
     $env:Path = $env:Path.TrimEnd(';') + ';' + $Dir
 }
 
+# Restart-Daemon restarts an already-registered grafel daemon so it runs the
+# freshly-installed binary. Best-effort: a missing tool or a failed restart
+# prints a hint and returns $false, but never aborts the installer.
+# grafel install registers a Task Scheduler task named 'com.grafel.daemon'.
+function Restart-Daemon {
+    $taskName = 'com.grafel.daemon'
+    $hint = "re-run 'grafel install' or restart the daemon to finish the update"
+
+    if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+
+    # Detect a registered task (schtasks /query exits non-zero when absent).
+    & schtasks.exe /query /tn $taskName 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        return $false
+    }
+
+    # Stop then start the task so it re-launches the new binary.
+    & schtasks.exe /end /tn $taskName 2>$null | Out-Null
+    & schtasks.exe /run /tn $taskName 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Info "warning: failed to restart the grafel daemon; $hint"
+        return $false
+    }
+    return $true
+}
+
 # --- main ---
 
 $arch    = Get-Arch
@@ -155,8 +183,16 @@ try {
         try { & $existing --version } catch { }
     }
 
+    # If a daemon is already registered, restart it so it picks up the new
+    # binary. Best-effort: Restart-Daemon never aborts the installer.
+    $daemonRestarted = Restart-Daemon
+
     Write-Info ""
-    Write-Info "grafel installed. Run `"grafel wizard`" to set up your first group."
+    if ($daemonRestarted) {
+        Write-Info "grafel updated and daemon restarted."
+    } else {
+        Write-Info "grafel installed. Run `"grafel wizard`" to set up your first group."
+    }
     Write-Info "(open a new terminal so PATH picks up $BinDir)"
 }
 finally {

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,50 @@ update_path_fish() {
   } >> "$rc_file"
 }
 
+# restart_daemon restarts an already-registered grafel daemon so it runs the
+# freshly-installed binary. It is best-effort: a missing tool or a failed
+# restart prints a hint and returns non-zero, but never aborts the installer.
+# Echoes "restarted" on stdout when a registered daemon was restarted.
+restart_daemon() {
+  os=$1
+  hint="re-run 'grafel install' or restart the daemon to finish the update"
+
+  case "$os" in
+    macos)
+      command -v launchctl >/dev/null 2>&1 || return 1
+      uid=$(id -u)
+      target="gui/${uid}/com.grafel.daemon"
+      # Detect a registered launchd agent (print, falling back to list).
+      if launchctl print "$target" >/dev/null 2>&1 ||
+         launchctl list 2>/dev/null | grep -q "com.grafel.daemon"; then
+        if launchctl kickstart -k "$target" >/dev/null 2>&1; then
+          echo "restarted"
+          return 0
+        fi
+        info "warning: failed to restart the grafel daemon; $hint" >&2
+        return 1
+      fi
+      return 1
+      ;;
+    linux)
+      command -v systemctl >/dev/null 2>&1 || return 1
+      # Match the user unit grafel install registers (grafel-daemon.service).
+      unit=$(systemctl --user list-unit-files 2>/dev/null \
+        | awk '/grafel/ {print $1; exit}')
+      [ -n "$unit" ] || return 1
+      if systemctl --user restart "$unit" >/dev/null 2>&1; then
+        echo "restarted"
+        return 0
+      fi
+      info "warning: failed to restart the grafel daemon; $hint" >&2
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 configure_path() {
   shell_name=""
   if [ -n "${SHELL:-}" ]; then
@@ -207,8 +251,16 @@ main() {
     "$BIN_DIR/grafel" --version 2>/dev/null || true
   fi
 
+  # If a daemon is already registered, restart it so it picks up the new
+  # binary. Best-effort: restart_daemon never aborts the installer.
+  daemon_restarted=$(restart_daemon "$os" || true)
+
   info ""
-  info "grafel installed. Run \"grafel wizard\" to set up your first group."
+  if [ "$daemon_restarted" = "restarted" ]; then
+    info "grafel updated and daemon restarted."
+  else
+    info "grafel installed. Run \"grafel wizard\" to set up your first group."
+  fi
   info "(restart your shell or 'source' your rc file so PATH picks up $BIN_DIR)"
 }
 


### PR DESCRIPTION
## Summary

The one-line installers dropped the new binary into `~/.grafel/bin` but never touched a running daemon, so after a re-run the registered service kept executing the **old** binary until the user manually re-ran the install command. This makes both installers update-aware: after installing the binary they detect an already-registered daemon and restart it.

Closes #5582. Refs #5581.

## Detection + restart (mirrors the service names the install command registers)

| OS | Detect | Restart |
|----|--------|---------|
| macOS | `launchctl print gui/<uid>/com.grafel.daemon` (falls back to `launchctl list \| grep`) | `launchctl kickstart -k gui/<uid>/com.grafel.daemon` |
| Linux | `systemctl --user list-unit-files` matching the `grafel` user unit (`grafel-daemon.service`) | `systemctl --user restart <unit>` |
| Windows | `schtasks /query /tn com.grafel.daemon` | `schtasks /end` then `/run` |

## Behaviour

- Runs only after the binary is installed, and only when a daemon is already registered.
- **Best-effort**: a missing tool or a failed restart prints a hint (`re-run 'grafel install' or restart the daemon to finish the update`) and continues — it never aborts the installer.
- **Messaging**: when a registered daemon is restarted, the installer prints `grafel updated and daemon restarted` instead of the fresh-install wizard line. The fresh-install (no daemon) path is unchanged.

## Verification

- `bash -n install.sh` — OK.
- `shellcheck install.sh` — clean on the new code; only the two pre-existing SC2016 info nits on the untouched PATH-block `printf` lines remain.
- pwsh was unavailable in the build env; the PowerShell was reviewed by hand and follows the file's existing `$LASTEXITCODE` / `Write-Info` conventions.
- Installers were **not** executed.

Pure shell / PowerShell; no Go changes; no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
