### PR TITLE
fix(install): grafel update extracts browser_download_url via JSON unmarshal (#5587)

### DIFF
--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -17,6 +17,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -518,48 +519,36 @@ func writeBinaryMember(src io.Reader, destPath string) error {
 	return nil
 }
 
+// ghRelease is a minimal projection of the GitHub Releases API response,
+// covering only the asset name and download URL fields we need.
+type ghRelease struct {
+	Assets []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
 // findAssetDownloadURL parses a GitHub releases API JSON response and returns
 // the browser_download_url for the asset whose name matches assetName.
-func findAssetDownloadURL(json, assetName string) (string, error) {
-	// Look for the asset name in the JSON.  The structure is:
-	//   "assets": [ { "name": "...", "browser_download_url": "..." }, ... ]
-	// We scan for the name match, then find the download URL nearby.
-	nameKey := `"name":"` + assetName + `"`
-	// Also accept with spaces: "name": "grafel-..."
-	if !strings.Contains(json, `"name":"`+assetName+`"`) &&
-		!strings.Contains(json, `"name": "`+assetName+`"`) {
-		return "", fmt.Errorf("asset %q not found in release", assetName)
+//
+// It unmarshals the response into a minimal struct rather than scanning the
+// raw bytes: the real API places a large nested "uploader" object between an
+// asset's "name" and "browser_download_url" fields, so a naive proximity scan
+// misses the URL (and is brittle to field ordering and dotted asset names).
+func findAssetDownloadURL(body, assetName string) (string, error) {
+	var rel ghRelease
+	if err := json.Unmarshal([]byte(body), &rel); err != nil {
+		return "", fmt.Errorf("parse release JSON: %w", err)
 	}
 
-	// Find the position of the name.
-	idx := strings.Index(json, nameKey)
-	if idx < 0 {
-		// Try with space.
-		nameKey = `"name": "` + assetName + `"`
-		idx = strings.Index(json, nameKey)
-	}
-	if idx < 0 {
-		return "", fmt.Errorf("asset %q not found in release assets", assetName)
+	for _, asset := range rel.Assets {
+		if asset.Name == assetName {
+			if asset.BrowserDownloadURL == "" {
+				return "", fmt.Errorf("asset %q has no browser_download_url", assetName)
+			}
+			return asset.BrowserDownloadURL, nil
+		}
 	}
 
-	// Look for browser_download_url within the next 512 bytes.
-	window := json[idx:]
-	if len(window) > 512 {
-		window = window[:512]
-	}
-	urlKey := `"browser_download_url":"`
-	urlIdx := strings.Index(window, urlKey)
-	if urlIdx < 0 {
-		urlKey = `"browser_download_url": "`
-		urlIdx = strings.Index(window, urlKey)
-	}
-	if urlIdx < 0 {
-		return "", fmt.Errorf("browser_download_url not found near asset %q", assetName)
-	}
-	rest := window[urlIdx+len(urlKey):]
-	end := strings.Index(rest, `"`)
-	if end < 0 {
-		return "", fmt.Errorf("malformed browser_download_url for asset %q", assetName)
-	}
-	return rest[:end], nil
+	return "", fmt.Errorf("asset %q not found in release", assetName)
 }

--- a/internal/install/update_findasset_test.go
+++ b/internal/install/update_findasset_test.go
@@ -1,0 +1,105 @@
+package install
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// realisticReleaseJSON mirrors the shape of a real GitHub Releases API
+// response for a tag: each asset carries a sizeable nested "uploader" object
+// sitting BETWEEN its "name" and "browser_download_url" fields. This is the
+// exact shape that broke the old naive proximity scanner, which looked for
+// browser_download_url within a fixed window after the asset name.
+func realisticReleaseJSON(tag string) string {
+	version := strings.TrimPrefix(tag, "v")
+	asset := func(id int, name string) string {
+		return fmt.Sprintf(`{
+      "url": "https://api.github.com/repos/cajasmota/grafel/releases/assets/%d",
+      "id": %d,
+      "node_id": "RA_kwDOABCDEF%d",
+      "name": "%s",
+      "label": "",
+      "uploader": {
+        "login": "cajasmota",
+        "id": 123456,
+        "node_id": "MDQ6VXNlcjEyMzQ1Ng==",
+        "avatar_url": "https://avatars.githubusercontent.com/u/123456?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/cajasmota",
+        "html_url": "https://github.com/cajasmota",
+        "type": "User",
+        "site_admin": false
+      },
+      "content_type": "application/gzip",
+      "state": "uploaded",
+      "size": 12345678,
+      "download_count": 7,
+      "created_at": "2026-06-23T00:00:00Z",
+      "updated_at": "2026-06-23T00:00:00Z",
+      "browser_download_url": "https://github.com/cajasmota/grafel/releases/download/%s/%s"
+    }`, id, id, id, name, tag, name)
+	}
+
+	return fmt.Sprintf(`{
+  "url": "https://api.github.com/repos/cajasmota/grafel/releases/12345",
+  "tag_name": "%s",
+  "name": "%s",
+  "draft": false,
+  "prerelease": false,
+  "assets": [
+    %s,
+    %s,
+    %s
+  ],
+  "body": "release notes"
+}`,
+		tag, tag,
+		asset(1, fmt.Sprintf("grafel_%s_macos_arm64.tar.gz", version)),
+		asset(2, fmt.Sprintf("grafel_%s_windows_x86_64.zip", version)),
+		asset(3, "checksums.txt"),
+	)
+}
+
+func TestFindAssetDownloadURL(t *testing.T) {
+	const tag = "v0.1.5.1"
+	body := realisticReleaseJSON(tag)
+
+	t.Run("dotted-name asset resolves", func(t *testing.T) {
+		want := "https://github.com/cajasmota/grafel/releases/download/v0.1.5.1/grafel_0.1.5.1_macos_arm64.tar.gz"
+		got, err := findAssetDownloadURL(body, "grafel_0.1.5.1_macos_arm64.tar.gz")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != want {
+			t.Fatalf("download URL mismatch:\n got = %q\nwant = %q", got, want)
+		}
+	})
+
+	t.Run("windows zip asset resolves", func(t *testing.T) {
+		want := "https://github.com/cajasmota/grafel/releases/download/v0.1.5.1/grafel_0.1.5.1_windows_x86_64.zip"
+		got, err := findAssetDownloadURL(body, "grafel_0.1.5.1_windows_x86_64.zip")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != want {
+			t.Fatalf("download URL mismatch:\n got = %q\nwant = %q", got, want)
+		}
+	})
+
+	t.Run("missing asset errors cleanly", func(t *testing.T) {
+		_, err := findAssetDownloadURL(body, "grafel_0.1.5.1_linux_arm64.tar.gz")
+		if err == nil {
+			t.Fatal("expected an error for an absent asset, got nil")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("error should mention the asset is not found, got: %v", err)
+		}
+	})
+
+	t.Run("malformed JSON errors cleanly", func(t *testing.T) {
+		if _, err := findAssetDownloadURL("{not json", "anything"); err == nil {
+			t.Fatal("expected a parse error for malformed JSON, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Closes #5587.

After the asset-name fix, `grafel update` found the right release asset but failed to read its download URL:

```
✗ update failed: download release vX.Y.Z: find asset grafel_X.Y.Z_macos_arm64.tar.gz in release vX.Y.Z: browser_download_url not found near asset "grafel_X.Y.Z_macos_arm64.tar.gz"
```

## Root cause

`findAssetDownloadURL` scanned the API JSON naively: locate the asset `name` field, then search for `browser_download_url` within the next 512 bytes. Real API payloads place a large nested `uploader` object between an asset's `name` and `browser_download_url`, pushing the URL outside the window — so it was never found, breaking update on every platform.

## Fix

Replace the proximity scan with proper JSON unmarshaling into a minimal `ghRelease` struct over `assets[].name` / `assets[].browser_download_url`. Return the matching asset's URL, with a clear error when none matches. This is robust to field ordering and the dotted release filename. Function signature and the sole caller are unchanged.

## Test

New `TestFindAssetDownloadURL` feeds a realistic Releases API fixture (each asset carries an `uploader` object between `name` and `browser_download_url`) and asserts:
- the dotted-name `tar.gz` asset resolves to the correct URL
- the windows `.zip` asset resolves
- an absent asset errors cleanly ("not found")
- malformed JSON errors cleanly

Verified the OLD naive scanner fails this fixture; it passes only with the unmarshal fix.

`go test ./internal/install/...` green; `go build ./...` clean; `gofmt -l` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)