### PR TITLE
fix(install): Windows hardening — PATH via registry, stop-daemon-before-copy, robust tag resolution

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -54,11 +54,32 @@ if /I "%PROC%"=="AMD64" (
 )
 
 REM --- resolve version (mirror install.ps1 Resolve-Version) ---
+REM Explicit override is the fast path and skips all network resolution.
 if defined GRAFEL_VERSION (
     if /I not "%GRAFEL_VERSION%"=="latest" (
         set "VERSION=%GRAFEL_VERSION%"
     )
 )
+
+REM Prefer the GitHub releases API: it returns the tag in a single JSON field
+REM ("tag_name": "vX.Y.Z"), which is far less error-prone to parse than a
+REM redirect "location:" header (a partial-URL parse there could otherwise leave
+REM a fragment in VERSION and produce a confusing 404). The redirect-header path
+REM is kept ONLY as a fallback for when the API is unreachable/rate-limited.
+if not defined VERSION (
+    for /f "tokens=2 delims=:, " %%T in ('curl -fsSL "https://api.github.com/repos/%REPO%/releases/latest" 2^>nul ^| findstr /I /C:"tag_name"') do (
+        if not defined VERSION (
+            set "RAW=%%T"
+            REM strip surrounding double quotes from the JSON string value, plus
+            REM any stray CR the header/body might carry.
+            set "RAW=!RAW:"=!"
+            if defined CR set "RAW=!RAW:%CR%=!"
+            set "VERSION=!RAW!"
+        )
+    )
+)
+
+REM --- fallback: parse the /releases/latest redirect if the API gave nothing ---
 if not defined VERSION (
     REM /releases/latest 302-redirects to /releases/tag/<version>. curl -sI
     REM prints the redirect target in the "location:" header; parse the tag.
@@ -77,27 +98,10 @@ if not defined VERSION (
         REM scrub the trailing CR that HTTP headers carry FIRST, so the tag has
         REM no stray CR, THEN slice off the URL prefix up to and incl. "/tag/".
         if defined CR set "LOC=!LOC:%CR%=!"
-        REM only slice if the marker is actually present (substring replace is a
-        REM no-op when "/tag/" is absent, which would leave the full URL — we
-        REM guard against that below by validating the resulting VERSION).
+        REM The substring replace below is a no-op when "/tag/" is absent, which
+        REM would leave the full URL in VERSION — the strict validation block
+        REM further down rejects any value still containing a '/'.
         set "VERSION=!LOC:*/tag/=!"
-    )
-)
-
-REM --- fallback: GitHub releases API if the redirect parse failed or produced
-REM     something that still contains a URL separator (no real tag has '/'). ---
-set "BADVER="
-if defined VERSION if not "!VERSION:/=!"=="!VERSION!" set "BADVER=1"
-if not defined VERSION set "BADVER=1"
-if defined BADVER (
-    set "VERSION="
-    for /f "tokens=2 delims=:, " %%T in ('curl -fsSL "https://api.github.com/repos/%REPO%/releases/latest" 2^>nul ^| findstr /I /C:"tag_name"') do (
-        if not defined VERSION (
-            set "RAW=%%T"
-            REM strip surrounding double quotes from the JSON string value.
-            set "RAW=!RAW:"=!"
-            set "VERSION=!RAW!"
-        )
     )
 )
 
@@ -213,6 +217,18 @@ if not defined BINSRC (
     goto :fail
 )
 
+REM --- stop a running daemon BEFORE overwriting the binary ---
+REM Windows cannot overwrite an .exe that is open in a running process, so on an
+REM upgrade the copy below fails ("being used by another process") while the
+REM registered daemon holds grafel.exe. Stop it first (best-effort: a missing
+REM task or no running process is fine). `grafel install` re-registers/restarts
+REM the daemon further down, so this is the Windows analog of the macOS/Linux
+REM update-aware restart — except the STOP must precede the copy.
+if exist "%BINDIR%\grafel.exe" (
+    schtasks /end /tn com.grafel.daemon >nul 2>&1
+    taskkill /im grafel.exe /f >nul 2>&1
+)
+
 copy /Y "%BINSRC%" "%BINDIR%\grafel.exe" >nul
 if errorlevel 1 (
     echo error: failed to copy grafel.exe into %BINDIR%
@@ -237,18 +253,31 @@ if defined USERPATH (
 if defined ALREADY (
     echo   PATH already contains %BINDIR%
 ) else (
+    REM Write the USER PATH via the registry rather than `setx`: setx silently
+    REM TRUNCATES any value longer than 1024 chars, so on a machine with a long
+    REM existing PATH our %BINDIR% append is dropped and grafel never resolves.
+    REM `reg add HKCU\Environment` has no such limit. We use REG_EXPAND_SZ so
+    REM any %VARS% already embedded in the user's PATH keep expanding.
     if defined USERPATH (
         REM trim a single trailing ; then append.
         if "!USERPATH:~-1!"==";" set "USERPATH=!USERPATH:~0,-1!"
-        setx Path "!USERPATH!;%BINDIR%" >nul
+        set "NEWPATH=!USERPATH!;%BINDIR%"
     ) else (
-        setx Path "%BINDIR%" >nul
+        set "NEWPATH=%BINDIR%"
     )
+    reg add "HKCU\Environment" /v Path /t REG_EXPAND_SZ /d "!NEWPATH!" /f >nul 2>&1
     if errorlevel 1 (
         echo   warning: could not update USER PATH automatically.
         echo   add this folder to PATH manually: %BINDIR%
     ) else (
         echo   added %BINDIR% to your USER PATH
+        REM `reg add` writes the registry but does NOT broadcast
+        REM WM_SETTINGCHANGE, so already-open shells (and Explorer) won't see the
+        REM new PATH until a broadcast. setx on a throwaway variable triggers
+        REM that broadcast as a side effect (its own 1024-char truncation is
+        REM irrelevant here — we are only using it to notify, not to store PATH).
+        setx GRAFEL_PATH_SYNC 1 >nul 2>&1
+        reg delete "HKCU\Environment" /v GRAFEL_PATH_SYNC /f >nul 2>&1
     )
 )
 REM make grafel.exe resolvable in THIS session for the install step below.

--- a/install.ps1
+++ b/install.ps1
@@ -43,28 +43,61 @@ function Get-Arch {
     }
 }
 
+# Test-Version validates a resolved tag strictly: it must start with 'v',
+# contain at least one digit, and contain no '/' (which would mean a URL
+# fragment leaked in). This guarantees we can never build a download URL from
+# garbage and instead fail with the clear GRAFEL_VERSION hint.
+function Test-Version($v) {
+    if (-not $v) { return $false }
+    return ($v -match '^v[0-9][A-Za-z0-9.+_-]*$')
+}
+
 function Resolve-Version {
+    # Explicit override is the fast path and skips all network resolution.
     if ($env:GRAFEL_VERSION -and $env:GRAFEL_VERSION -ne 'latest') {
         return $env:GRAFEL_VERSION
     }
-    $url = "https://github.com/$Repo/releases/latest"
+
+    $ver = $null
+
+    # Prefer the GitHub releases API: it returns the tag in a single JSON field
+    # (tag_name), which is far more reliable than scraping a redirect header.
     try {
-        $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -MaximumRedirection 0 -ErrorAction SilentlyContinue
+        $api = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" -UseBasicParsing -ErrorAction Stop
+        if ($api -and $api.tag_name) { $ver = $api.tag_name.Trim() }
     } catch {
-        $resp = $_.Exception.Response
+        $ver = $null
     }
-    $loc = $null
-    if ($resp -and $resp.Headers) {
-        if ($resp.Headers['Location']) { $loc = $resp.Headers['Location'] }
-        elseif ($resp.Headers.Location) { $loc = $resp.Headers.Location }
+
+    # Fallback: parse the /releases/latest redirect target when the API is
+    # unreachable or rate-limited.
+    if (-not (Test-Version $ver)) {
+        $url = "https://github.com/$Repo/releases/latest"
+        try {
+            $resp = Invoke-WebRequest -Uri $url -UseBasicParsing -MaximumRedirection 0 -ErrorAction SilentlyContinue
+        } catch {
+            $resp = $_.Exception.Response
+        }
+        $loc = $null
+        if ($resp -and $resp.Headers) {
+            if ($resp.Headers['Location']) { $loc = $resp.Headers['Location'] }
+            elseif ($resp.Headers.Location) { $loc = $resp.Headers.Location }
+        }
+        if (-not $loc) {
+            # Last resort: follow redirects and read the final URI.
+            try {
+                $resp2 = Invoke-WebRequest -Uri $url -UseBasicParsing
+                $loc = $resp2.BaseResponse.ResponseUri.AbsoluteUri
+            } catch { $loc = $null }
+        }
+        if ($loc -and ($loc -match '/tag/([^/]+)/?$')) { $ver = $Matches[1] }
     }
-    if (-not $loc) {
-        # Fallback: follow redirects and read the final URI
-        $resp2 = Invoke-WebRequest -Uri $url -UseBasicParsing
-        $loc = $resp2.BaseResponse.ResponseUri.AbsoluteUri
+
+    # Strict validation: never proceed with a URL fragment or other junk.
+    if (-not (Test-Version $ver)) {
+        Fail "failed to resolve a valid latest release tag (got '$ver'). Set GRAFEL_VERSION explicitly (e.g. v0.1.0)."
     }
-    if ($loc -match '/tag/([^/]+)/?$') { return $Matches[1] }
-    Fail "failed to resolve latest release tag from $loc"
+    return $ver
 }
 
 function Get-FileWithRetry($Uri, $OutFile) {
@@ -98,6 +131,22 @@ function Add-ToUserPath($Dir) {
     [Environment]::SetEnvironmentVariable('Path', $new, 'User')
     # Update current session too.
     $env:Path = $env:Path.TrimEnd(';') + ';' + $Dir
+}
+
+# Stop-Daemon stops a running grafel daemon BEFORE the new binary is copied.
+# Windows cannot overwrite an .exe that is open in a running process, so on an
+# upgrade the Copy-Item would otherwise fail ("being used by another process")
+# while the registered daemon holds grafel.exe. Best-effort: a missing task or
+# no running process is fine and never aborts the installer.
+function Stop-Daemon {
+    $taskName = 'com.grafel.daemon'
+    if (Get-Command schtasks.exe -ErrorAction SilentlyContinue) {
+        & schtasks.exe /end /tn $taskName 2>$null | Out-Null
+    }
+    # Kill any lingering process holding the exe (ignore "not found").
+    try {
+        Get-Process -Name 'grafel' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    } catch { }
 }
 
 # Restart-Daemon restarts an already-registered grafel daemon so it runs the
@@ -171,6 +220,11 @@ try {
 
     $binSrc = Get-ChildItem -Path $extractDir -Recurse -Filter 'grafel.exe' | Select-Object -First 1
     if (-not $binSrc) { Fail "archive did not contain grafel.exe" }
+
+    # On an upgrade, stop the running daemon BEFORE overwriting the binary —
+    # Windows cannot replace an .exe that is open in a running process. The
+    # daemon is re-registered/restarted by Restart-Daemon further down.
+    if (Test-Path $existing) { Stop-Daemon }
 
     Copy-Item -Path $binSrc.FullName -Destination $existing -Force
 


### PR DESCRIPTION
Fixes three Windows-only install bugs (CMD `install.bat` and `install.ps1`). All shell/batch/PowerShell — no Go changes.

Closes #5589
Closes #5590
Closes #5591

## A — USER PATH update lost on long PATHs (#5589)
`install.bat` appended the bin dir with `setx Path`, but `setx` silently truncates any value over 1024 chars. On a machine with a long existing USER PATH the appended bin dir was dropped, so the CLI never resolved even in a fresh shell. Now the USER PATH is written via `reg add "HKCU\Environment" /v Path /t REG_EXPAND_SZ /d ... /f` (registry has no 1024 limit), still idempotent (no double-append), followed by a throwaway-var `setx` to broadcast WM_SETTINGCHANGE so new shells pick it up. `install.ps1` already used the registry-backed `[Environment]::SetEnvironmentVariable(...,'User')` API, so it was unaffected — confirmed, left as-is.

## B — upgrade fails: binary in use (#5590)
On upgrade the running daemon holds an open handle on `grafel.exe`; Windows cannot overwrite a running executable, so the copy failed ("being used by another process") before the binary was replaced. Both installers now STOP the daemon BEFORE the copy — end the scheduled task (`com.grafel.daemon`, the name registered by the service layer) and best-effort kill any lingering process — then copy, then re-register/restart via the existing install step. This is the Windows analog of the macOS/Linux update-aware restart, except the stop must precede the copy.

## C — brittle tag resolution (#5591)
Latest-tag resolution was cache/redirect-dependent and could leave a URL fragment in the version, producing a confusing 404. Both installers now prefer the GitHub releases API (`/releases/latest` -> `tag_name`), keep the redirect-header parse as a fallback and the explicit-version override as the fast path, and validate the result strictly (must be `v` + a digit, no `/` or other junk) — failing fast with the existing override hint on any doubt.

## Testing
Syntax/convention review only; **this could not be tested on Windows in the authoring environment.**

### Windows re-test checklist
1. **PATH (A):** on a machine with a long existing USER PATH (>1024 chars), run the installer, open a NEW shell, confirm `grafel` resolves and the prior PATH entries are all intact.
2. **Upgrade (B):** install, let the daemon run, then re-run the installer to upgrade — confirm the copy succeeds (no "being used by another process") and the daemon comes back on the new binary.
3. **Tag resolution (C):** run the installer with no `GRAFEL_VERSION` and confirm it resolves the correct latest tag; confirm a forced bad/empty resolution fails fast with the `GRAFEL_VERSION` hint rather than a 404.
4. Repeat 1-3 via `install.ps1` for parity.