### PR TITLE
fix(ui): Windows drive selection in the folder picker

### DIFF
--- a/internal/dashboard/v2_fs.go
+++ b/internal/dashboard/v2_fs.go
@@ -29,6 +29,12 @@ import (
 	"strings"
 )
 
+// drivesSentinel is the virtual path representing the "drives level" above the
+// per-drive roots on Windows (C:\, D:\, …). Listing it returns one entry per
+// available drive; navigating "up" from a drive root yields it. It is never a
+// real on-disk path, so it is meaningless (and unreachable) off Windows.
+const drivesSentinel = "drives:"
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Wire shapes
 // ─────────────────────────────────────────────────────────────────────────────
@@ -62,6 +68,13 @@ type v2FsListReply struct {
 	Entries []v2FsEntry `json:"entries"`
 	// Shortcuts are quick-jump targets (only populated for the default/home view).
 	Shortcuts []v2FsShortcut `json:"shortcuts,omitempty"`
+	// Drives lists the available drive roots on Windows (C:\, D:\, …). It is
+	// populated on EVERY listing so the frontend can render a drive selector and
+	// let the user switch drives without first navigating up. Empty off Windows.
+	Drives []v2FsEntry `json:"drives,omitempty"`
+	// IsDrives is true when Path is the virtual "drives level" (Windows only):
+	// Entries are the drive roots themselves and there is no parent.
+	IsDrives bool `json:"isDrives,omitempty"`
 	// Error is a human-readable reason when the path could not be listed
 	// (nonexistent / permission denied). Entries is empty in that case.
 	Error string `json:"error,omitempty"`
@@ -80,6 +93,20 @@ func (s *Server) handleV2FsList(w http.ResponseWriter, r *http.Request) {
 	raw := strings.TrimSpace(r.URL.Query().Get("path"))
 
 	home, _ := os.UserHomeDir()
+
+	// Windows "drives level": list the available drive roots so the user can
+	// switch C:→D: etc. This sits above every drive root; it has no parent.
+	if drivesSupported && raw == drivesSentinel {
+		drives := listDrives()
+		writeV2JSON(w, http.StatusOK, v2OK(v2FsListReply{
+			Path:     drivesSentinel,
+			Parent:   "",
+			Entries:  drives,
+			Drives:   drives,
+			IsDrives: true,
+		}))
+		return
+	}
 
 	// Default start: the user's home directory.
 	if raw == "" {
@@ -154,6 +181,16 @@ func (s *Server) handleV2FsList(w http.ResponseWriter, r *http.Request) {
 	// one-click jumps without the user typing.
 	if home != "" && abs == home {
 		reply.Shortcuts = homeShortcuts(home)
+	}
+
+	// On Windows attach the available drives to EVERY listing (so the UI can
+	// render a drive selector) and ensure "up" from a drive root ascends to the
+	// drives level rather than dead-ending on the same drive.
+	if drivesSupported {
+		reply.Drives = listDrives()
+		if isDriveRoot(abs) {
+			reply.Parent = drivesSentinel
+		}
 	}
 
 	writeV2JSON(w, http.StatusOK, v2OK(reply))

--- a/internal/dashboard/v2_fs_drives_other.go
+++ b/internal/dashboard/v2_fs_drives_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package dashboard
+
+// drivesSupported is false on non-Windows platforms: there is a single
+// filesystem root ("/"), so there is no "drives" level and "up" from the root
+// correctly yields "" (no parent). These stubs let the shared handler call the
+// same helpers unconditionally.
+const drivesSupported = false
+
+// listDrives never returns entries off Windows.
+func listDrives() []v2FsEntry { return nil }
+
+// isDriveRoot is always false off Windows.
+func isDriveRoot(string) bool { return false }

--- a/internal/dashboard/v2_fs_drives_windows.go
+++ b/internal/dashboard/v2_fs_drives_windows.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package dashboard
+
+import (
+	"os"
+)
+
+// drivesSupported reports whether the host has a "drives" level above the
+// filesystem root. On Windows there is no single root ("/") — each drive
+// (C:\, D:\, …) is its own tree — so the picker needs a virtual level above
+// the drive roots that lists the available drive letters.
+const drivesSupported = true
+
+// listDrives enumerates the drive letters that currently exist on this Windows
+// host (A:..Z:), probing each with os.Stat on "<letter>:\". Only drives that
+// resolve are returned, in ascending order. Each entry's Path is the drive
+// root (e.g. "C:\\") so selecting it navigates into that drive.
+func listDrives() []v2FsEntry {
+	out := make([]v2FsEntry, 0, 26)
+	for c := 'A'; c <= 'Z'; c++ {
+		root := string(c) + `:\`
+		if info, err := os.Stat(root); err == nil && info.IsDir() {
+			out = append(out, v2FsEntry{
+				Name:   string(c) + ":",
+				Path:   root,
+				IsDir:  true,
+				Hidden: false,
+			})
+		}
+	}
+	return out
+}
+
+// isDriveRoot reports whether abs is a bare drive root such as "C:\" or "C:".
+// At a drive root the "up" control should ascend to the drives level rather
+// than returning "" (filepath.Dir("C:\\") == "C:\\", which would otherwise
+// trap the user on a single drive — the bug this fixes).
+func isDriveRoot(abs string) bool {
+	// Forms: `C:\` (len 3) or `C:` (len 2).
+	switch len(abs) {
+	case 2:
+		return abs[1] == ':' && isDriveLetter(abs[0])
+	case 3:
+		return abs[1] == ':' && (abs[2] == '\\' || abs[2] == '/') && isDriveLetter(abs[0])
+	}
+	return false
+}
+
+func isDriveLetter(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}

--- a/internal/dashboard/v2_fs_drives_windows_test.go
+++ b/internal/dashboard/v2_fs_drives_windows_test.go
@@ -1,0 +1,49 @@
+//go:build windows
+
+package dashboard
+
+import "testing"
+
+// TestIsDriveRoot exercises the drive-root detection that decides when "up"
+// should ascend to the drives level (the Windows-only fix for the picker being
+// stuck on C:). Table-driven; Windows-guarded since isDriveRoot is too.
+func TestIsDriveRoot(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`C:\`, true},
+		{`D:\`, true},
+		{`c:\`, true},
+		{`Z:/`, true},
+		{`C:`, true},
+		{`C:\Users`, false},
+		{`C:\Users\foo`, false},
+		{`\\server\share`, false},
+		{``, false},
+		{`/`, false},
+		{`12`, false},
+	}
+	for _, c := range cases {
+		if got := isDriveRoot(c.in); got != c.want {
+			t.Errorf("isDriveRoot(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestListDrives sanity-checks that at least one drive is discovered on a real
+// Windows host and that every returned entry is a valid drive root.
+func TestListDrives(t *testing.T) {
+	drives := listDrives()
+	if len(drives) == 0 {
+		t.Fatal("listDrives returned no drives on a Windows host")
+	}
+	for _, d := range drives {
+		if !isDriveRoot(d.Path) {
+			t.Errorf("drive Path %q is not a drive root", d.Path)
+		}
+		if !d.IsDir {
+			t.Errorf("drive %q IsDir = false", d.Name)
+		}
+	}
+}

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -260,6 +260,16 @@ export function ScanWizard(props: ScanWizardProps) {
   // back to the manual-paste field when the user typed a path instead.
   const browsePath = fs.data?.path ?? "";
 
+  // The drive root (e.g. "C:\\") that the current browse path lives on, so the
+  // Windows drive <select> reflects the active drive. null when at the drives
+  // level or off Windows (no drives reported). Compared on the leading
+  // "<letter>:" segment so any depth under C:\ maps back to the C:\ option.
+  const currentDrive =
+    fs.data?.drives?.find((d) => {
+      const letter = d.path.slice(0, 2).toLowerCase(); // "c:"
+      return browsePath.slice(0, 2).toLowerCase() === letter;
+    })?.path ?? null;
+
   // runDetect scans an explicit absolute path. The folder browser passes the
   // directory the user navigated into; the manual field passes its trimmed
   // text. Either way a single value drives the Detect step — no typing needed
@@ -515,8 +525,28 @@ export function ScanWizard(props: ScanWizardProps) {
                 title={browsePath}
                 data-testid="wizard-fs-cwd"
               >
-                {browsePath || "…"}
+                {fs.data?.isDrives ? "Drives" : browsePath || "…"}
               </code>
+
+              {/* Windows drive selector — lets the user switch C:→D: directly
+                  without first navigating up to the drives level (#5595). Only
+                  rendered when the backend reports drives (Windows hosts). */}
+              {fs.data?.drives && fs.data.drives.length > 0 && (
+                <select
+                  className="shrink-0 rounded-md border border-border bg-surface px-2 py-1.5 font-mono text-xs text-text-2"
+                  value={currentDrive ?? ""}
+                  onChange={(e) => setBrowseDir(e.target.value)}
+                  data-testid="wizard-fs-drive"
+                  title="Switch drive"
+                >
+                  {currentDrive === null && <option value="">Drive…</option>}
+                  {fs.data.drives.map((d) => (
+                    <option key={d.path} value={d.path}>
+                      {d.name}
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
 
             {/* Shortcuts (home view only) */}
@@ -591,7 +621,9 @@ export function ScanWizard(props: ScanWizardProps) {
                 // overflowed the fixed-height border box — reading as a double
                 // border. Keep it a single-line pill with one clean border (#1531).
                 className="shrink-0 whitespace-nowrap"
-                disabled={!browsePath || inspect.isPending}
+                // The virtual drives level (Windows) is not a real folder, so
+                // it cannot be selected/indexed — only its drive entries can.
+                disabled={!browsePath || fs.data?.isDrives || inspect.isPending}
                 onClick={() => {
                   setPath(browsePath);
                   void runDetect(browsePath);

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1426,6 +1426,13 @@ export interface FsListReply {
   parent: string;
   entries: FsEntry[];
   shortcuts?: FsShortcut[];
+  /**
+   * Available drive roots on Windows (C:\, D:\, …), attached to every listing
+   * so the picker can render a drive selector. Empty/absent off Windows.
+   */
+  drives?: FsEntry[];
+  /** True when `path` is the virtual "drives level" (Windows): entries ARE the drives. */
+  isDrives?: boolean;
   /** Human-readable reason when the path couldn't be listed. */
   error?: string;
 }


### PR DESCRIPTION
Fixes #5595.

## Problem
The dashboard "Index a new group" wizard folder picker was **stuck on one drive on Windows**. With no single filesystem root, "up" from a drive root dead-ended (`filepath.Dir("C:\")` == `C:\`) and there was no drive selector — so a user with repos on `D:` could not navigate there. Only the "paste an absolute path" field worked as a workaround.

## Fix
**Backend** (`internal/dashboard/v2_fs.go` + build-tagged helpers):
- Add a virtual "drives level" sentinel above the per-drive roots; listing it returns one entry per available drive.
- On Windows, enumerate existing drives (`A:`..`Z:` via `os.Stat` on `<letter>:\`) and attach them to **every** listing, and make "up" from a drive root ascend to the drives level instead of dead-ending.
- Non-Windows behavior is unchanged via `!windows` stubs (single root `/`).

**Frontend** (`webui-v2` ScanWizard picker):
- Add a compact **drive dropdown** at the top of the picker (Windows only, shown when the backend reports drives) so the user can switch `C:→D:` directly.
- "up" from a drive root now surfaces the drive list; the virtual drives level is not selectable.
- The manual absolute-path field is retained as the existing workaround.

## Tests / verification
- `go build ./...`, `gofmt -l`, and `go test ./internal/dashboard -run TestV2FsList` clean.
- `webui-v2`: `tsc --noEmit` and `npm run build` clean.
- Added Windows-guarded, table-driven unit tests for the drive-enumeration helpers.

## Re-test on Windows
Drive enumeration is Windows-only and was developed on macOS — needs a final manual re-test on a real Windows host with repos on a non-`C:` drive: open the wizard picker, confirm the drive dropdown lists all drives, switch to `D:`, navigate, and "up" from a drive root shows the drive list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)