### PR TITLE
fix(daemon): Windows daemon detached launch + clean install status (no HTML dump)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -486,6 +486,17 @@ func runDaemon(argv []string) error {
 			os.Getenv(daemon.EnvRoot))
 	}
 
+	// Windows: detach from any inherited console window so the background daemon
+	// survives the launching terminal. When `grafel install` (or a Task
+	// Scheduler InteractiveToken action) starts the daemon, it can inherit the
+	// installing shell's console; closing that window would otherwise take the
+	// daemon — and the dashboard it serves — down with it. FreeConsole drops the
+	// association. Skipped in foreground mode, where the console is intentionally
+	// the log sink (CI / container). No-op on macOS/Linux. See detachconsole_*.go.
+	if !foreground {
+		detachConsole()
+	}
+
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		return fmt.Errorf("resolve daemon layout: %w", err)

--- a/cmd/grafel/detachconsole_other.go
+++ b/cmd/grafel/detachconsole_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// detachConsole is a no-op on non-Windows platforms. On macOS/Linux the daemon
+// is launched by launchd/systemd (or `grafel start` with Setsid), which already
+// detach it from any controlling terminal — there is no console to free.
+func detachConsole() {}

--- a/cmd/grafel/detachconsole_windows.go
+++ b/cmd/grafel/detachconsole_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+// detachConsole drops the daemon's association with any console window it
+// inherited from the launching process.
+//
+// Why this matters: on Windows, a console application that is started as a child
+// of an interactive shell (e.g. `grafel install` opening a second terminal, or a
+// Task Scheduler action running with an InteractiveToken) shares that console.
+// When the user closes the terminal window, Windows delivers CTRL_CLOSE_EVENT to
+// every process attached to the console and then terminates them — taking the
+// daemon (and the dashboard it serves) down with the window.
+//
+// See #5594. FreeConsole detaches the calling process from its console. After this call the
+// daemon has no controlling console, so closing the launching terminal can no
+// longer signal or kill it. The daemon logs to its log file (not the console),
+// so losing the console has no functional downside in service mode.
+//
+// Errors are intentionally ignored: if the process has no console to begin with
+// (the desired end state — e.g. spawned with DETACHED_PROCESS/CREATE_NO_WINDOW),
+// FreeConsole returns an error that is simply a no-op for our purposes.
+func detachConsole() {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	freeConsole := kernel32.NewProc("FreeConsole")
+	_, _, _ = freeConsole.Call()
+}

--- a/internal/cli/detach_windows.go
+++ b/internal/cli/detach_windows.go
@@ -5,11 +5,29 @@ package cli
 import "syscall"
 
 // detachSysProcAttr returns a SysProcAttr that detaches the daemon on
-// Windows. Phase A doesn't ship Windows service install, but the
-// `grafel start` command still needs to spawn a background daemon
-// the CLI can disown.
+// Windows so it survives the launching shell/console.
+//
+// The `grafel start` command (and any direct daemon spawn) must produce a
+// process that is NOT tied to the launching console window — otherwise closing
+// that terminal takes the daemon (and the dashboard it serves) down with it.
+// We therefore:
+//
+//   - DETACHED_PROCESS: the child does not inherit the parent's console; it has
+//     no controlling console, so a closed terminal cannot signal it.
+//   - CREATE_NEW_PROCESS_GROUP: the child is not in the launcher's process
+//     group, so a Ctrl-C / Ctrl-Break to the launcher is not propagated.
+//   - CREATE_NO_WINDOW: do not allocate a new console window for the daemon
+//     (it is a background service, not an interactive program).
+//   - HideWindow: belt-and-suspenders — if a window would otherwise appear,
+//     start it hidden (SW_HIDE).
 func detachSysProcAttr() *syscall.SysProcAttr {
-	const detachedProcess = 0x00000008
-	const createNewProcessGroup = 0x00000200
-	return &syscall.SysProcAttr{CreationFlags: detachedProcess | createNewProcessGroup}
+	const (
+		detachedProcess       = 0x00000008
+		createNewProcessGroup = 0x00000200
+		createNoWindow        = 0x08000000
+	)
+	return &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: detachedProcess | createNewProcessGroup | createNoWindow,
+	}
 }

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -57,7 +57,7 @@ const daemonTaskXMLTemplate = `<?xml version="1.0" encoding="UTF-16"?>
     <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
     <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
     <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
-    <Hidden>false</Hidden>
+    <Hidden>true</Hidden>
     <RestartOnFailure>
       <Interval>PT1M</Interval>
       <Count>3</Count>

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -99,8 +99,38 @@ func defaultHealthzGet(port int) (string, error) {
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("/healthz returned HTTP %d", resp.StatusCode)
 	}
+	// The daemon dashboard does not register a dedicated /healthz route, so an
+	// unmatched GET /healthz falls through to the SPA catch-all and returns the
+	// dashboard index.html (HTTP 200 + HTML) rather than a version string. If we
+	// see an HTML content-type, treat /healthz as unavailable so the caller
+	// keeps the real version from the socket Ping instead of echoing the HTML
+	// body as the "daemon" version (#5596). See looksLikeVersion / waitForDaemonReady.
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(strings.ToLower(ct), "text/html") {
+		return "", fmt.Errorf("/healthz returned HTML (SPA fallback, no version endpoint)")
+	}
 	body, _ := io.ReadAll(resp.Body)
 	return string(body), nil
+}
+
+// looksLikeVersion reports whether s is a plausible daemon version string
+// (short, single-line, not an HTML/JSON document). It is the last line of
+// defense against the /healthz SPA-fallback bug: even if a future /healthz
+// response slips past the content-type check, we never let a multi-line HTML
+// blob become the printed "daemon" version. A real version looks like
+// "0.1.5.2", "v0.1.5", "1.2.3-socket", or "dev".
+func looksLikeVersion(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" || len(s) > 64 {
+		return false
+	}
+	if strings.ContainsAny(s, "\n\r<>") {
+		return false
+	}
+	lower := strings.ToLower(s)
+	if strings.HasPrefix(lower, "<!doctype") || strings.HasPrefix(lower, "<html") {
+		return false
+	}
+	return true
 }
 
 // defaultDaemonRestart is the production daemon restart implementation.
@@ -734,7 +764,11 @@ func waitForDaemonReady(socketPath string, port int, timeout time.Duration, ping
 			// enrich the version string, but do NOT block on it (it lags behind
 			// the cold index).
 			if healthz != nil {
-				if body, herr := healthz(port); herr == nil && strings.TrimSpace(body) != "" {
+				// Only let /healthz enrich the version when its body actually
+				// looks like a version string. A future SPA-fallback (HTML body)
+				// or any garbage must never replace the real socket-Ping version
+				// — otherwise install prints `daemon: <!doctype html>...`.
+				if body, herr := healthz(port); herr == nil && looksLikeVersion(body) {
 					version = strings.TrimSpace(body)
 				}
 			}

--- a/internal/install/readiness_test.go
+++ b/internal/install/readiness_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -49,6 +50,54 @@ func TestWaitForDaemonReady_HealthzEnrichesVersion(t *testing.T) {
 	}
 	if version != "healthz-ver" {
 		t.Errorf("expected /healthz body to enrich version, got %q", version)
+	}
+}
+
+// TestWaitForDaemonReady_HealthzHTMLDoesNotOverrideVersion is the regression
+// guard for the install "daemon: <!doctype html>..." bug. The daemon dashboard
+// has no dedicated /healthz route, so an unmatched GET falls through to the SPA
+// catch-all and returns the dashboard index.html (HTTP 200 + HTML). That HTML
+// must NEVER replace the real socket-Ping version — install would otherwise
+// print the entire HTML document as the "daemon" status line.
+func TestWaitForDaemonReady_HealthzHTMLDoesNotOverrideVersion(t *testing.T) {
+	ping := func(socketPath string) (string, error) { return "0.1.5.2", nil }
+	healthz := func(port int) (string, error) {
+		return "<!doctype html><html lang=\"en\"><head><title>grafel</title></head><body></body></html>", nil
+	}
+
+	version, err := waitForDaemonReady("/tmp/fake.sock", 47274, 2*time.Second, ping, healthz)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "0.1.5.2" {
+		t.Errorf("expected the socket-Ping version to be kept (HTML body ignored), got %q", version)
+	}
+}
+
+// TestLooksLikeVersion exercises the version-string sanity guard that protects
+// the printed "daemon:" status line from non-version bodies (the SPA-fallback
+// HTML dump in particular).
+func TestLooksLikeVersion(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"0.1.5.2", true},
+		{"v0.1.5", true},
+		{"1.2.3-socket", true},
+		{"  dev  ", true}, // trimmed
+		{"", false},
+		{"<!doctype html><html></html>", false},
+		{"<html><body>hi</body></html>", false},
+		{"line1\nline2", false},          // multi-line
+		{strings.Repeat("a", 65), false}, // too long
+		{"{\"version\":\"1.0\"}", true},  // short JSON is tolerated (no angle brackets / newline)
+		{"<svg>", false},                 // angle brackets
+	}
+	for _, c := range cases {
+		if got := looksLikeVersion(c.in); got != c.want {
+			t.Errorf("looksLikeVersion(%q) = %v, want %v", c.in, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes two Windows daemon bugs. Closes #5594, closes #5596.

## A — Daemon dies when the launching terminal closes (#5594)
On Windows the background daemon inherited the launching shell's console window, so closing that window signalled (`CTRL_CLOSE_EVENT`) and killed the daemon and its dashboard.

- Add `HideWindow: true` and `CREATE_NO_WINDOW` to the Windows detach `SysProcAttr` (`internal/cli/detach_windows.go`).
- Call `FreeConsole` at daemon startup on Windows so it drops any inherited console association (`cmd/grafel/detachconsole_windows.go`); no-op on macOS/Linux (`detachconsole_other.go`). Skipped in foreground/CI mode where the console is the intended log sink.
- Set the Task Scheduler task to `<Hidden>true</Hidden>`.
- macOS/Linux behavior unchanged (build-tag guarded).

## B — `install` prints raw dashboard HTML as the daemon status (#5596)
The dashboard has no `/healthz` route, so the best-effort version probe fell through to the SPA catch-all and got `index.html`; the whole HTML body was printed as `daemon: <!doctype html>...`.

- Reject `text/html` `/healthz` responses, and add a `looksLikeVersion` guard so only a short single-line non-HTML body may enrich the version. Otherwise the real socket-Ping version is kept and printed (e.g. `daemon: <version>`).
- Adds unit tests for the HTML-suppression path and the version formatter.

## Verification
- `go build ./...` (host) clean; changed Windows packages cross-compile clean; Windows syscall symbols verified.
- `gofmt -l` clean.
- Targeted `internal/install` tests pass.
- Not testable on Windows here — needs Windows re-test (see issues).

## Re-test on Windows
1. `install`, close the opened terminal — daemon + dashboard keep running; no stray console window.
2. `install` status line shows a clean version, never an HTML dump.
3. Daemon restarts at next logon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)