### PR TITLE
feat(indexing): foreground (interactive) index priority over background reindex (#5328)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1078,7 +1078,7 @@ func rebuildWorkerPool(conc int, work []repoWork, workFn func(idx int, rw repoWo
 					results[idx] = repoResult{path: rw.r.Path, slug: rw.r.Slug, err: err}
 					return
 				}
-				defer gate.Release()
+				defer gate.Release(foreground)
 			}
 
 			results[idx] = workFn(idx, rw)
@@ -1150,6 +1150,17 @@ func daemonRebuildFuncCore(
 
 	perRepoTimeout := resolvePerRepoRebuildTimeout()
 
+	// #5328: classify on the interactive-vs-automatic axis, NOT slug-vs-group.
+	// A human-awaited request (dashboard wizard index, explicit CLI
+	// index/rebuild/wizard/repair) sets args.Interactive, regardless of whether
+	// it targets one slug or a whole group. Only the automatic watcher/git-hook
+	// reindex leaves it false. Foreground acquisitions get priority + the
+	// reserved gate slot and the higher rebuild CPU cap so they aren't starved
+	// behind a many-module background storm. (The old `args.Slug != ""` heuristic
+	// miscategorised a wizard whole-group index as background and a watcher
+	// single-slug reindex as foreground — exactly backwards.)
+	foreground := args.Interactive
+
 	// indexOne executes the index function for a single repo and returns its
 	// result. It is shared by both the serial and parallel paths so the logic
 	// (panic recovery, wipe, incremental opts, progress slugs, slug tag) stays
@@ -1181,6 +1192,11 @@ func daemonRebuildFuncCore(
 			opts = append(opts,
 				WithPublisher(daemonProgressBroker),
 				WithProgressSlugs(args.Group, rw.r.Slug))
+			// #5328: run at the foreground (higher) CPU cap only for human-awaited
+			// rebuilds; an automatic watcher/git-hook-triggered rebuild stays at
+			// the throttled background cap. This appears AFTER indexFn's prepended
+			// default so it is the effective WithInteractive value.
+			opts = append(opts, WithInteractive(foreground))
 			// #1576: tag the graph with the CONFIG slug (not the on-disk
 			// directory basename) so doc.Repo matches the slug the dashboard
 			// keys nodes by and the slug the cross-repo link pass emits as the
@@ -1228,12 +1244,6 @@ func daemonRebuildFuncCore(
 			}
 		}
 	}
-
-	// #5493: a single-slug rebuild is an interactive/foreground request (e.g.
-	// `grafel rebuild <slug>`); a whole-group rebuild is background cold-start /
-	// forced-rebuild fan-out. Foreground acquisitions get priority + the reserved
-	// gate slot so they aren't starved behind a many-module background storm.
-	foreground := args.Slug != ""
 
 	var results []repoResult
 	if conc == 1 || len(work) <= 1 {

--- a/internal/cli/group.go
+++ b/internal/cli/group.go
@@ -293,6 +293,7 @@ func indexGroup(group, socketPath string) error {
 	}
 	defer c.Close()
 
-	_, err = c.Rebuild(proto.RebuildArgs{Group: group})
+	// #5328: an explicit CLI group rebuild is human-awaited → foreground.
+	_, err = c.Rebuild(proto.RebuildArgs{Group: group, Interactive: true})
 	return err
 }

--- a/internal/cli/monorepo.go
+++ b/internal/cli/monorepo.go
@@ -185,7 +185,8 @@ func monorepoNotifyDaemon(group, slug string) error {
 		return err
 	}
 	defer c.Close()
-	_, err = c.Rebuild(proto.RebuildArgs{Group: group, Slug: slug})
+	// #5328: an explicit CLI monorepo rebuild is human-awaited → foreground.
+	_, err = c.Rebuild(proto.RebuildArgs{Group: group, Slug: slug, Interactive: true})
 	return err
 }
 

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -182,7 +182,8 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 
 	// --quiet: skip progress, run synchronously with no token.
 	if quiet {
-		reply, err := c.Rebuild(proto.RebuildArgs{Group: group, Slug: slug, Wipe: wipe, Incremental: inc})
+		// #5328: an explicit `grafel rebuild`/repair is human-awaited → foreground.
+		reply, err := c.Rebuild(proto.RebuildArgs{Group: group, Slug: slug, Wipe: wipe, Incremental: inc, Interactive: true})
 		if err != nil {
 			return err
 		}
@@ -212,6 +213,8 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 			Wipe:          wipe,
 			ProgressToken: token,
 			Incremental:   inc,
+			// #5328: explicit user-triggered repair → foreground (priority + cap).
+			Interactive: true,
 		})
 		outcomeCh <- rebuildOutcome{
 			repos:    reply.Repos,
@@ -451,6 +454,8 @@ func indexGroupWithProgress(w, errW io.Writer, group string) error {
 		reply, rpcErr := c.Rebuild(proto.RebuildArgs{
 			Group:         group,
 			ProgressToken: token,
+			// #5328: explicit user-triggered rebuild → foreground (priority + cap).
+			Interactive: true,
 		})
 		outcomeCh <- rebuildOutcome{
 			repos:    reply.Repos,

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -337,7 +337,8 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 func triggerRebuild(c *client.Client, group string, token string) <-chan rebuildOutcome {
 	rpcCh := make(chan rebuildOutcome, 1)
 	go func() {
-		reply, rpcErr := c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token})
+		// #5328: the wizard is human-awaited → foreground (priority + higher CPU cap).
+		reply, rpcErr := c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token, Interactive: true})
 		rpcCh <- rebuildOutcome{
 			repos:    reply.Repos,
 			warning:  reply.Warning,

--- a/internal/daemon/index_concurrency.go
+++ b/internal/daemon/index_concurrency.go
@@ -64,10 +64,11 @@ func resolveIndexConcurrency() int {
 type IndexGate struct {
 	cap int
 
-	mu     sync.Mutex
-	active int             // slots currently held
-	fg     []chan struct{} // FIFO of waiting foreground tickets
-	bg     []chan struct{} // FIFO of waiting background tickets
+	mu       sync.Mutex
+	active   int             // slots currently held
+	fgActive int             // foreground slots currently held (#5328)
+	fg       []chan struct{} // FIFO of waiting foreground tickets
+	bg       []chan struct{} // FIFO of waiting background tickets
 }
 
 // NewIndexGate constructs a gate with the given cap. A cap <= 0 is coerced to 1
@@ -98,6 +99,16 @@ func (g *IndexGate) Stats() (active, queued int) {
 	return g.active, len(g.fg) + len(g.bg)
 }
 
+// ForegroundActive reports how many foreground (interactive) index operations
+// are currently holding a slot (#5328). Background reindex paths consult this to
+// YIELD their core share while a human-awaited foreground index is running, so
+// foreground+background together never exceed the machine's core budget.
+func (g *IndexGate) ForegroundActive() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.fgActive
+}
+
 // reserveForForeground is how many slots are held back from background work so a
 // foreground acquirer is never fully locked out by a background storm (#5328).
 // With cap>=2 we reserve exactly one; with cap==1 we cannot reserve (serial).
@@ -119,6 +130,9 @@ func (g *IndexGate) Acquire(ctx context.Context, foreground bool) error {
 	g.mu.Lock()
 	if g.canAdmitLocked(foreground) {
 		g.active++
+		if foreground {
+			g.fgActive++
+		}
 		g.publishLocked()
 		g.mu.Unlock()
 		return nil
@@ -150,7 +164,7 @@ func (g *IndexGate) Acquire(ctx context.Context, foreground bool) error {
 		// Already signalled between ctx.Done and acquiring the lock: a slot was
 		// charged to us. Release it so it isn't leaked.
 		g.mu.Unlock()
-		g.Release()
+		g.Release(foreground)
 		return ctx.Err()
 	}
 }
@@ -172,11 +186,15 @@ func (g *IndexGate) canAdmitLocked(foreground bool) bool {
 }
 
 // Release frees one slot and wakes the next eligible waiter (foreground first,
-// FIFO within a class). MUST be paired with a successful Acquire.
-func (g *IndexGate) Release() {
+// FIFO within a class). MUST be paired with a successful Acquire, passing the
+// same foreground value so the foreground-active count (#5328) stays balanced.
+func (g *IndexGate) Release(foreground bool) {
 	g.mu.Lock()
 	if g.active > 0 {
 		g.active--
+	}
+	if foreground && g.fgActive > 0 {
+		g.fgActive--
 	}
 	g.wakeLocked()
 	g.publishLocked()
@@ -192,6 +210,7 @@ func (g *IndexGate) wakeLocked() {
 		t := g.fg[0]
 		g.fg = g.fg[1:]
 		g.active++
+		g.fgActive++
 		close(t)
 	}
 	for len(g.bg) > 0 && g.canAdmitLocked(false) {
@@ -225,7 +244,7 @@ func (g *IndexGate) Run(ctx context.Context, foreground bool, fn func() error) e
 	if err := g.Acquire(ctx, foreground); err != nil {
 		return err
 	}
-	defer g.Release()
+	defer g.Release(foreground)
 	return fn()
 }
 
@@ -239,5 +258,5 @@ func (g *IndexGate) publish() {
 // publishLocked mirrors the current counts to the indexstate leaf package so the
 // MCP/status surfaces can read "indexing N, queued M". MUST hold g.mu.
 func (g *IndexGate) publishLocked() {
-	indexstate.SetIndexConcurrency(g.active, len(g.fg)+len(g.bg), g.cap)
+	indexstate.SetIndexConcurrency(g.active, len(g.fg)+len(g.bg), g.cap, g.fgActive)
 }

--- a/internal/daemon/index_concurrency_test.go
+++ b/internal/daemon/index_concurrency_test.go
@@ -116,7 +116,7 @@ func TestIndexGateFIFOOrder(t *testing.T) {
 		waitQueued(t, g, i+1)
 	}
 	// Release the held slot to drain the queue FIFO.
-	g.Release()
+	g.Release(false)
 	done.Wait()
 
 	mu.Lock()
@@ -150,7 +150,7 @@ func TestIndexGateForegroundNotStarved(t *testing.T) {
 			_ = g.Acquire(context.Background(), false)
 			bgHeld.Done()
 			<-release
-			g.Release()
+			g.Release(false)
 		}()
 	}
 	bgHeld.Wait()
@@ -166,7 +166,7 @@ func TestIndexGateForegroundNotStarved(t *testing.T) {
 			return
 		}
 		close(fgGot)
-		g.Release()
+		g.Release(true)
 	}()
 
 	// Free up one slot for the foreground acquirer.
@@ -203,9 +203,152 @@ func TestIndexGateContextCancelDequeues(t *testing.T) {
 		t.Fatal("cancelled Acquire returned nil, want ctx error")
 	}
 	// The held slot is still ours; release it and the gate is empty.
-	g.Release()
+	g.Release(false)
 	if active, queued := g.Stats(); active != 0 || queued != 0 {
 		t.Fatalf("after cancel+release: active=%d queued=%d, want 0/0", active, queued)
+	}
+}
+
+// TestIndexGateForegroundDrainsFirst verifies the #5328 priority guarantee:
+// with the only slot held, a queue of background waiters plus one (later-
+// arriving) foreground waiter must admit the foreground waiter FIRST when the
+// slot frees, regardless of FIFO arrival order across classes.
+func TestIndexGateForegroundDrainsFirst(t *testing.T) {
+	g := NewIndexGate(1)
+
+	// Hold the only slot so every subsequent acquirer queues.
+	if err := g.Acquire(context.Background(), false); err != nil {
+		t.Fatalf("initial acquire: %v", err)
+	}
+
+	const bg = 4
+	var mu sync.Mutex
+	var order []string
+	var done sync.WaitGroup
+
+	// Enqueue background waiters first (they arrive BEFORE the foreground one).
+	for i := 0; i < bg; i++ {
+		done.Add(1)
+		go func() {
+			_ = g.Run(context.Background(), false, func() error {
+				mu.Lock()
+				order = append(order, "bg")
+				mu.Unlock()
+				return nil
+			})
+			done.Done()
+		}()
+		waitQueued(t, g, i+1)
+	}
+	// Now enqueue ONE foreground waiter, last.
+	done.Add(1)
+	go func() {
+		_ = g.Run(context.Background(), true, func() error {
+			mu.Lock()
+			order = append(order, "fg")
+			mu.Unlock()
+			return nil
+		})
+		done.Done()
+	}()
+	waitQueued(t, g, bg+1)
+
+	// Release the held slot; the gate drains the queue one at a time (cap=1).
+	g.Release(false)
+	done.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != bg+1 {
+		t.Fatalf("completed %d, want %d", len(order), bg+1)
+	}
+	// The foreground waiter — though it arrived LAST — must be served FIRST.
+	if order[0] != "fg" {
+		t.Fatalf("first served = %q, want foreground first; order=%v", order[0], order)
+	}
+}
+
+// TestIndexGateForegroundActiveCount verifies ForegroundActive (#5328) reflects
+// exactly how many foreground slots are held, and is balanced on Release — this
+// is the signal background reindexes read to decide whether to yield.
+func TestIndexGateForegroundActiveCount(t *testing.T) {
+	g := NewIndexGate(4)
+
+	if got := g.ForegroundActive(); got != 0 {
+		t.Fatalf("initial ForegroundActive = %d, want 0", got)
+	}
+
+	// One background acquire must NOT bump the foreground-active count.
+	if err := g.Acquire(context.Background(), false); err != nil {
+		t.Fatalf("bg acquire: %v", err)
+	}
+	if got := g.ForegroundActive(); got != 0 {
+		t.Fatalf("after bg acquire ForegroundActive = %d, want 0", got)
+	}
+
+	// Two foreground acquires bump it to 2.
+	if err := g.Acquire(context.Background(), true); err != nil {
+		t.Fatalf("fg acquire 1: %v", err)
+	}
+	if err := g.Acquire(context.Background(), true); err != nil {
+		t.Fatalf("fg acquire 2: %v", err)
+	}
+	if got := g.ForegroundActive(); got != 2 {
+		t.Fatalf("after 2 fg acquires ForegroundActive = %d, want 2", got)
+	}
+
+	// Releasing one foreground slot drops it to 1; the background release must
+	// not touch the foreground count.
+	g.Release(true)
+	if got := g.ForegroundActive(); got != 1 {
+		t.Fatalf("after 1 fg release ForegroundActive = %d, want 1", got)
+	}
+	g.Release(false)
+	if got := g.ForegroundActive(); got != 1 {
+		t.Fatalf("after bg release ForegroundActive = %d, want 1", got)
+	}
+	g.Release(true)
+	if got := g.ForegroundActive(); got != 0 {
+		t.Fatalf("after final fg release ForegroundActive = %d, want 0", got)
+	}
+}
+
+// TestIndexGateForegroundActivePromotedWaiter verifies that a foreground waiter
+// promoted from the QUEUE (woken by Release, not the fast path) is also counted
+// in ForegroundActive — otherwise a background storm could mask an active
+// foreground index from the yield signal.
+func TestIndexGateForegroundActivePromotedWaiter(t *testing.T) {
+	g := NewIndexGate(1)
+
+	// Hold the only slot so the foreground acquirer must queue and be promoted.
+	if err := g.Acquire(context.Background(), false); err != nil {
+		t.Fatalf("initial acquire: %v", err)
+	}
+
+	fgIn := make(chan struct{})
+	go func() {
+		if err := g.Acquire(context.Background(), true); err != nil {
+			t.Errorf("fg acquire: %v", err)
+			return
+		}
+		close(fgIn)
+	}()
+	waitQueued(t, g, 1)
+
+	// Free the slot — the queued foreground waiter is promoted via wakeLocked.
+	g.Release(false)
+
+	select {
+	case <-fgIn:
+	case <-time.After(2 * time.Second):
+		t.Fatal("foreground waiter never promoted")
+	}
+	if got := g.ForegroundActive(); got != 1 {
+		t.Fatalf("promoted foreground waiter not counted: ForegroundActive = %d, want 1", got)
+	}
+	g.Release(true)
+	if got := g.ForegroundActive(); got != 0 {
+		t.Fatalf("after release ForegroundActive = %d, want 0", got)
 	}
 }
 

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -209,6 +209,15 @@ type RebuildArgs struct {
 	// since the last successful run. Wipe=true overrides Incremental (a wipe
 	// is always a full rebuild).
 	Incremental bool `json:"incremental,omitempty"`
+	// Interactive marks this rebuild as a human-awaited FOREGROUND request
+	// (dashboard wizard index, explicit CLI `grafel index`/`rebuild`/`wizard`,
+	// repair) rather than an automatic background watcher/git-hook reindex
+	// (#5328). Foreground rebuilds acquire the index gate on the priority lane
+	// (jump ahead of queued background work, may use the reserved slot) and run
+	// at the higher rebuild CPU cap; background reindexes yield while they run.
+	// Defaults to false so an unset caller is treated as background — the safe,
+	// throttled classification.
+	Interactive bool `json:"interactive,omitempty"`
 }
 
 // RebuildReply lists the repos that were rebuilt and any warning that

--- a/internal/daemon/sched/background_yield_5328_test.go
+++ b/internal/daemon/sched/background_yield_5328_test.go
@@ -1,0 +1,70 @@
+package sched
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// TestBackgroundYieldGOMAXPROCSDefaultAndEnv verifies the yield-cap resolver
+// (#5328): default is backgroundYieldGOMAXPROCSDefault (1), overridable by a
+// strictly-positive GRAFEL_BACKGROUND_YIELD_GOMAXPROCS, with invalid values
+// falling back to the default.
+func TestBackgroundYieldGOMAXPROCSDefaultAndEnv(t *testing.T) {
+	t.Setenv("GRAFEL_BACKGROUND_YIELD_GOMAXPROCS", "")
+	if got := BackgroundYieldGOMAXPROCS(); got != backgroundYieldGOMAXPROCSDefault {
+		t.Fatalf("default = %d, want %d", got, backgroundYieldGOMAXPROCSDefault)
+	}
+	t.Setenv("GRAFEL_BACKGROUND_YIELD_GOMAXPROCS", "2")
+	if got := BackgroundYieldGOMAXPROCS(); got != 2 {
+		t.Fatalf("env override = %d, want 2", got)
+	}
+	t.Setenv("GRAFEL_BACKGROUND_YIELD_GOMAXPROCS", "0")
+	if got := BackgroundYieldGOMAXPROCS(); got != backgroundYieldGOMAXPROCSDefault {
+		t.Fatalf("non-positive env = %d, want default %d", got, backgroundYieldGOMAXPROCSDefault)
+	}
+	t.Setenv("GRAFEL_BACKGROUND_YIELD_GOMAXPROCS", "garbage")
+	if got := BackgroundYieldGOMAXPROCS(); got != backgroundYieldGOMAXPROCSDefault {
+		t.Fatalf("garbage env = %d, want default %d", got, backgroundYieldGOMAXPROCSDefault)
+	}
+}
+
+// TestBackgroundYieldGatedOnForegroundActive is the core #5328 yield proof: a
+// background reindex caps its child's GOMAXPROCS to the yield value ONLY while a
+// foreground (interactive) index is active, and runs at its normal cap (no
+// override) otherwise. The published foreground-active count is the signal — no
+// real CPU load is spawned.
+func TestBackgroundYieldGatedOnForegroundActive(t *testing.T) {
+	t.Setenv("GRAFEL_BACKGROUND_YIELD_GOMAXPROCS", "1")
+
+	// Clean baseline: no index activity → no yield.
+	indexstate.SetIndexConcurrency(0, 0, 2, 0)
+	if n, yield := backgroundYieldGOMAXPROCS(); yield {
+		t.Fatalf("no foreground active: got yield=true n=%d, want yield=false", n)
+	}
+
+	// A background-only index running (active=1) but no FOREGROUND → still no yield.
+	indexstate.SetIndexConcurrency(1, 0, 2, 0)
+	if n, yield := backgroundYieldGOMAXPROCS(); yield {
+		t.Fatalf("background-only active: got yield=true n=%d, want yield=false", n)
+	}
+
+	// A foreground index is active → background yields to the configured cap.
+	indexstate.SetIndexConcurrency(1, 0, 2, 1)
+	n, yield := backgroundYieldGOMAXPROCS()
+	if !yield {
+		t.Fatalf("foreground active: got yield=false, want yield=true")
+	}
+	if n != 1 {
+		t.Fatalf("yield GOMAXPROCS = %d, want 1", n)
+	}
+
+	// Foreground finished (back to 0) → background concurrency restores (no override).
+	indexstate.SetIndexConcurrency(0, 0, 2, 0)
+	if _, yield := backgroundYieldGOMAXPROCS(); yield {
+		t.Fatalf("after foreground finished: got yield=true, want yield=false (restored)")
+	}
+
+	// Reset shared state for other tests in the package.
+	indexstate.SetIndexConcurrency(0, 0, 0, 0)
+}

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -12,7 +12,47 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
 )
+
+// backgroundYieldGOMAXPROCSDefault is the per-child GOMAXPROCS a BACKGROUND
+// (watcher/git-hook) reindex drops to WHILE a foreground (interactive) index is
+// running (#5328). A human is waiting on the foreground index, so background
+// work yields its core share to it instead of adding to it: 1 core keeps the
+// background reindex making slow progress without competing for the foreground
+// index's cores, so foreground+background together stay within the machine's
+// budget. When no foreground index is active the background reindex runs at its
+// normal cap (the child's own GRAFEL_EXTRACT_GOMAXPROCS, default 2). Restored
+// automatically the moment the foreground index finishes — the decision is made
+// per-subprocess at launch and re-evaluated for each subsequent reindex.
+const backgroundYieldGOMAXPROCSDefault = 1
+
+// BackgroundYieldGOMAXPROCS resolves the GOMAXPROCS a background reindex yields
+// to while a foreground index is active, honouring
+// GRAFEL_BACKGROUND_YIELD_GOMAXPROCS (a strictly-positive integer; 1 is valid).
+// Unset, empty, non-numeric, or <= 0 → backgroundYieldGOMAXPROCSDefault.
+func BackgroundYieldGOMAXPROCS() int {
+	if raw := strings.TrimSpace(os.Getenv("GRAFEL_BACKGROUND_YIELD_GOMAXPROCS")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+	}
+	return backgroundYieldGOMAXPROCSDefault
+}
+
+// backgroundYieldGOMAXPROCS returns the GOMAXPROCS the next background reindex
+// subprocess should run under, given the live foreground-index state (#5328).
+// It returns (n, true) — meaning "cap the child at n cores" — only when a
+// foreground index is currently active; otherwise (0, false), and the child
+// resolves its own normal background cap. Reading the published gate state keeps
+// the sched package free of any cmd/grafel import cycle.
+func backgroundYieldGOMAXPROCS() (int, bool) {
+	if indexstate.GetIndexConcurrency().ForegroundActive > 0 {
+		return BackgroundYieldGOMAXPROCS(), true
+	}
+	return 0, false
+}
 
 // groupAlgoGOMAXPROCSDefault is the per-child CPU cap (Go GOMAXPROCS) for the
 // background group-algorithm subprocess. The pass (Louvain + PageRank +
@@ -129,9 +169,25 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 
 	cmd := exec.CommandContext(ctx, binary, args...)
 	// Daemon's state dirs are inherited via the env (GRAFEL_DAEMON_ROOT,
-	// GRAFEL_HOME). Do NOT set cmd.Env explicitly so the child inherits
-	// the daemon's full environment.
+	// GRAFEL_HOME). Start from the daemon's full environment so the child
+	// resolves the same state dirs and caps.
 	cmd.Env = os.Environ()
+	// #5328: if a FOREGROUND (interactive) index is running right now, make this
+	// BACKGROUND reindex yield its core share to it by capping the child's Go
+	// runtime to BackgroundYieldGOMAXPROCS() cores (default 1). GOMAXPROCS is
+	// appended last so it wins over any inherited value; it is omitted entirely
+	// when no foreground index is active, so the child falls back to its normal
+	// background cap (GRAFEL_EXTRACT_GOMAXPROCS, default 2). This is re-evaluated
+	// per subprocess launch, so background concurrency restores automatically the
+	// moment the foreground index finishes. fg preempts bg's share rather than
+	// adding to it, keeping fg+bg within the machine's core budget.
+	if n, yield := backgroundYieldGOMAXPROCS(); yield {
+		cmd.Env = append(cmd.Env, "GOMAXPROCS="+strconv.Itoa(n))
+		if logger != nil {
+			logger.Info("subprocess-indexer: yielding to foreground index",
+				"gomaxprocs", n, "repo", repoPath)
+		}
+	}
 
 	// Pipe child stdout for IPC JSON lines.
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/internal/dashboard/handlers_maintenance.go
+++ b/internal/dashboard/handlers_maintenance.go
@@ -181,6 +181,8 @@ func (s *Server) dispatchRebuild(w http.ResponseWriter, group, repo string, wipe
 		Slug:          repo,
 		Wipe:          wipe,
 		ProgressToken: token,
+		// #5328: a dashboard maintenance rebuild is human-awaited → foreground.
+		Interactive: true,
 	}
 	go func() {
 		bgClient, dialErr := client.Dial()

--- a/internal/dashboard/v2_actions.go
+++ b/internal/dashboard/v2_actions.go
@@ -119,6 +119,8 @@ func (s *Server) dispatchV2Rebuild(w http.ResponseWriter, group, repo string, wi
 		Slug:          repo,
 		Wipe:          wipe,
 		ProgressToken: token,
+		// #5328: a dashboard-initiated rebuild/reindex action is human-awaited → foreground.
+		Interactive: true,
 	}
 
 	// Fire the RPC asynchronously. The handler returns 202 immediately; this

--- a/internal/dashboard/v2_wizard.go
+++ b/internal/dashboard/v2_wizard.go
@@ -420,6 +420,8 @@ func (s *Server) enqueueWizardIndex(w http.ResponseWriter, group string) {
 	args := proto.RebuildArgs{
 		Group:         group,
 		ProgressToken: token,
+		// #5328: the dashboard wizard index is human-awaited → foreground.
+		Interactive: true,
 	}
 	go s.runRebuildJob(job.ID, args)
 

--- a/internal/indexstate/indexstate.go
+++ b/internal/indexstate/indexstate.go
@@ -41,13 +41,18 @@ var (
 	indexConcActive atomic.Int64
 	indexConcQueued atomic.Int64
 	indexConcCap    atomic.Int64
+	// indexConcFgActive mirrors how many FOREGROUND (interactive) index ops hold
+	// a gate slot (#5328). >0 means a human-awaited index is running, so the
+	// background reindex paths yield their core share to it.
+	indexConcFgActive atomic.Int64
 )
 
 // SetIndexConcurrency publishes the daemon-wide index-concurrency gate's current
-// active/queued counts and its configured cap (#5493). Called by the gate on
-// every acquire/release. Negative values are clamped to 0. Safe to call from any
+// active/queued counts, its configured cap (#5493), and the count of in-flight
+// FOREGROUND (interactive) index ops (#5328). Called by the gate on every
+// acquire/release. Negative values are clamped to 0. Safe to call from any
 // goroutine.
-func SetIndexConcurrency(active, queued, cap int) {
+func SetIndexConcurrency(active, queued, cap, foregroundActive int) {
 	if active < 0 {
 		active = 0
 	}
@@ -57,9 +62,13 @@ func SetIndexConcurrency(active, queued, cap int) {
 	if cap < 0 {
 		cap = 0
 	}
+	if foregroundActive < 0 {
+		foregroundActive = 0
+	}
 	indexConcActive.Store(int64(active))
 	indexConcQueued.Store(int64(queued))
 	indexConcCap.Store(int64(cap))
+	indexConcFgActive.Store(int64(foregroundActive))
 }
 
 // IndexConcurrency is a point-in-time view of the daemon-wide index-concurrency
@@ -71,15 +80,19 @@ type IndexConcurrency struct {
 	Queued int
 	// Cap is the configured concurrency limit (GRAFEL_INDEX_CONCURRENCY).
 	Cap int
+	// ForegroundActive is the number of FOREGROUND (interactive) index ops
+	// currently holding a slot (#5328). >0 means background reindexes yield.
+	ForegroundActive int
 }
 
 // GetIndexConcurrency returns the current gate counts. Lock-free; safe from an
 // MCP request handler.
 func GetIndexConcurrency() IndexConcurrency {
 	return IndexConcurrency{
-		Active: int(indexConcActive.Load()),
-		Queued: int(indexConcQueued.Load()),
-		Cap:    int(indexConcCap.Load()),
+		Active:           int(indexConcActive.Load()),
+		Queued:           int(indexConcQueued.Load()),
+		Cap:              int(indexConcCap.Load()),
+		ForegroundActive: int(indexConcFgActive.Load()),
 	}
 }
 


### PR DESCRIPTION
Closes #5328.

## Problem
The ½-core background ``GOMAXPROCS`` cap starves a **foreground** (human-awaited) index — a dashboard wizard index or an explicit CLI ``index``/``rebuild``/``wizard``/repair — when a **background** watcher/git-hook auto-reindex runs concurrently. Both were competing for the same throttled cores, and the rebuild path even classified them on the wrong axis (single-slug vs whole-group).

## Classification axis
Interactive (a human is waiting) vs automatic (nobody is watching) — NOT dashboard-vs-CLI, NOT slug-vs-group.
- **Foreground / priority:** dashboard wizard index, dashboard rebuild/maintenance actions, explicit CLI ``index``/``rebuild``/``wizard``/repair, monorepo/group rebuild.
- **Background / yields:** the file-watcher / git-hook auto-reindex.

## Routing
- Added an explicit ``Interactive`` flag to the rebuild RPC args. Every human-awaited constructor sets it true; the automatic watcher/git-hook reindex leaves it false (default = background, the safe throttled class).
- The rebuild core now derives the index-gate lane and CPU cap from that flag, replacing the old ``slug != ""`` heuristic that miscategorised a wizard whole-group index as background and a watcher single-slug reindex as foreground — exactly backwards.
- The index gate already drains foreground tickets ahead of background (FIFO within class) and reserves a foreground slot; that is now driven by the correct signal.

## Core budget / yield
- The index gate tracks how many **foreground** slots are held and publishes that count.
- While a foreground index is active, the background reindex subprocess caps its child ``GOMAXPROCS`` to a minimal yield value (default 1, env ``GRAFEL_BACKGROUND_YIELD_GOMAXPROCS``) so it **yields its core share** instead of adding to it. Normal background concurrency restores automatically the moment the foreground index finishes. Foreground preempts backgrounds share, keeping the combined ceiling safe.

## Tests (deterministic — no real CPU load)
- A foreground acquire is served ahead of earlier-queued background work (fg drains first).
- The foreground-active count is balanced across the fast path, queued promotion, and release.
- The background-yield resolver caps ``GOMAXPROCS`` only while a foreground index is active and restores afterwards.

``go build ./...`` clean; targeted ``go test`` green for the gate, scheduler, indexstate and proto packages; ``gofmt`` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)