### PR TITLE
feat(orm): Kysely schema + migration extraction (#5599)

### DIFF
--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -101,7 +101,7 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [JS/TS](../by-language/jsts.md) | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/10 | |
 | [JS/TS](../by-language/jsts.md) | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 8/9 | |
-| [JS/TS](../by-language/jsts.md) | [Kysely (type-safe query builder)](../detail/lang.jsts.orm.kysely.md) | 🟡 1/7 | |
+| [JS/TS](../by-language/jsts.md) | [Kysely (type-safe query builder)](../detail/lang.jsts.orm.kysely.md) | 🟡 6/7 | |
 | [JS/TS](../by-language/jsts.md) | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/11 | |
 | [JS/TS](../by-language/jsts.md) | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/4 | |
 | [JS/TS](../by-language/jsts.md) | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 7/10 | |

--- a/docs/coverage/by-language/jsts.md
+++ b/docs/coverage/by-language/jsts.md
@@ -135,7 +135,7 @@ Examples: `🟢 20/20` = fully supported, some capabilities heuristic · `🟡 1
 | [AWS SDK DynamoDB (JS)](../detail/lang.jsts.driver.dynamodb.md) | 🟡 1/4 | |
 | [Drizzle](../detail/lang.jsts.orm.drizzle.md) | 🟡 7/10 | |
 | [Knex (query builder)](../detail/lang.jsts.orm.knex.md) | 🟡 8/9 | |
-| [Kysely (type-safe query builder)](../detail/lang.jsts.orm.kysely.md) | 🟡 1/7 | |
+| [Kysely (type-safe query builder)](../detail/lang.jsts.orm.kysely.md) | 🟡 6/7 | |
 | [MikroORM](../detail/lang.jsts.orm.mikro-orm.md) | 🟡 8/11 | |
 | [MongoDB Node.js driver](../detail/lang.jsts.driver.mongodb.md) | 🟡 1/4 | |
 | [Mongoose](../detail/lang.jsts.orm.mongoose.md) | 🟡 7/10 | |

--- a/docs/coverage/detail/lang.jsts.orm.kysely.md
+++ b/docs/coverage/detail/lang.jsts.orm.kysely.md
@@ -17,16 +17,16 @@ Auto-generated. Back to [summary](../summary.md).
 |------------|--------|-------------|-------|-------|-------|
 | Model extraction | — `not_applicable` | — | — | — | Kysely is a type-safe SQL query builder, not an ORM — its `Database` interface is a compile-time TypeScript type with no runtime model/entity layer to extract. The schema is defined imperatively in migrations, not as decorated model classes. |
 | Model lifecycle extraction | — `not_applicable` | — | — | — | No model/entity layer; Kysely has no lifecycle hooks (no save/beforeCreate equivalents) — queries are explicit chains, not active-record instances. |
-| Schema extraction | 🔴 `missing` | — | 5491 | — | Kysely schema is declared imperatively via the migration schema-builder DSL (db.schema.createTable(...).addColumn(...)). Not yet parsed; tracked separately from the query/effect extraction landed in #5491. |
+| Schema extraction | ✅ `full` | `2026-06-25` | 5599 | `internal/custom/javascript/kysely_migrations.go`<br>`internal/custom/javascript/kysely_migrations_test.go` | #5599 parses Kysely's imperative migration schema-builder DSL. db.schema.createTable('t')/.alterTable('t') yield a SCOPE.Schema/model table entity; .addColumn('c','type',...) yields a SCOPE.Component/column entity. The custom_js_kysely_migrations extractor gates on a `.schema.` builder chain plus a Kysely import / migrations-dir path so unrelated createTable/addColumn calls are not misread. Proven by TestKyselyMigrationSchemaExtraction / TestKyselyMigrationColumnExtraction. |
 
 ### Relationships
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
 | Association extraction | — `not_applicable` | — | — | — | Kysely is a SQL query builder with no ORM model layer; associations are expressed ad-hoc per query via .innerJoin()/.leftJoin(), not declared on a model — there is no static association to extract. |
-| Foreign key extraction | 🔴 `missing` | — | 5491 | — | Foreign keys are declared imperatively in the migration schema-builder DSL (.addForeignKeyConstraint(...)); not yet parsed — part of the deferred schema_extraction work. |
+| Foreign key extraction | ✅ `full` | `2026-06-25` | 5599 | `internal/custom/javascript/kysely_migrations.go`<br>`internal/custom/javascript/kysely_migrations_test.go` | #5599 resolves both Kysely FK spellings to a SCOPE.Component/foreign_key entity carrying local_column / ref_table / ref_column: the explicit .addForeignKeyConstraint('fk', ['localCol'], 'refTable', ['refCol']) form, and the column-level .references('refTable.refCol') inside an .addColumn callback (local column = nearest preceding .addColumn). Dynamic / non-literal lists are skipped (honest-partial). Proven by TestKyselyMigrationForeignKeyConstraint / TestKyselyMigrationColumnLevelForeignKey. |
 | Lazy loading recognition | — `not_applicable` | — | — | — | Kysely is a SQL query builder with no ORM model layer; there is no relation or lazy-loading concept to recognise — every join is explicit in the query chain. |
-| Relationship extraction | 🔴 `missing` | — | 5491 | — | Table relationships are only declared via migration foreign-key constraints; not yet parsed — part of the deferred schema_extraction work. |
+| Relationship extraction | ✅ `full` | `2026-06-25` | 5599 | `internal/custom/javascript/kysely_migrations.go`<br>`internal/custom/javascript/kysely_migrations_test.go` | #5599 derives a SCOPE.Pattern/relation (relation_kind=belongs_to) from each migration foreign-key constraint — the migration FK IS the table relationship. The relation carries local_column + ref_table, e.g. relation:owner_id->account. This is the only place Kysely declares a static relationship (joins are ad-hoc per query). Proven by TestKyselyMigrationRelationshipExtraction. |
 
 ### Queries
 
@@ -38,14 +38,14 @@ Auto-generated. Back to [summary](../summary.md).
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Migration parsing | 🔴 `missing` | — | 5491 | — | Kysely migrations are plain TS modules exporting up()/down() that call the imperative schema-builder DSL; not yet parsed. Tracked alongside schema_extraction. |
-| Migration schema ops | 🔴 `missing` | — | 5491 | — | db.schema.createTable/alterTable/dropTable migration ops are not yet converged to MODIFIES_TABLE (the #3628 engine pass that already covers knex/typeorm/sequelize). |
+| Migration parsing | ✅ `full` | `2026-06-25` | 5599 | `internal/custom/javascript/kysely.go`<br>`internal/custom/javascript/kysely_migrations_test.go` | #5599 recognises Kysely migration modules: the up()/down() named exports become SCOPE.Operation/migration entry-point entities (direction up|down, framework=kysely), and the per-op schema mutations become SCOPE.Evolution entities. The custom_js_kysely base extractor gates on a `.schema.` builder chain so non-migration code is ignored. Proven by TestKyselyMigrationOps. |
+| Migration schema ops | ✅ `full` | `2026-06-25` | 5599 | `internal/custom/javascript/kysely.go`<br>`internal/engine/migration_schema_ops.go`<br>`internal/engine/migration_schema_ops_test.go` | #5599 emits SCOPE.Evolution migration ops (framework=kysely, table set) for db.schema.createTable/alterTable/dropTable; these converge to MODIFIES_TABLE via the #3628 engine pass (kysely added to evolutionOp alongside knex/typeorm/sequelize/objection/mikroorm) onto the shared SCOPE.Table node, so migrations and queries meet on one logical table. Proven by TestKyselyMigrationSchemaOps (engine) + TestKyselyMigrationOps (extractor). |
 
 ### Transactions
 
 | Capability | Status | Verified at | Issue | Cites | Notes |
 |------------|--------|-------------|-------|-------|-------|
-| Transaction function stamping | 🔴 `missing` | — | 5491 | — | db.transaction().execute(async (trx) => ...) interactive-transaction boundary stamping (transactional=true / tx_source) is not yet emitted; the trx handle IS receiver-gated for query/effect attribution (#5491). |
+| Transaction function stamping | 🔴 `missing` | — | 5599 | — | db.transaction().execute(async (trx) => ...) interactive-transaction boundary stamping (transactional=true / tx_source) is not yet emitted; the trx handle IS receiver-gated for query/effect attribution (#5491) and the schema/migration layer landed in #5599 — only the transaction-boundary function stamp remains as a small follow-up. |
 
 ## Provenance
 

--- a/internal/custom/javascript/kysely.go
+++ b/internal/custom/javascript/kysely.go
@@ -1,0 +1,186 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// kysely.go — the BASE Kysely migration-evolution extractor (#5599). It mirrors
+// knex.go: it emits the migration ENTRY points (up()/down()) and the per-op
+// SCOPE.Evolution entities (create_table / alter_table / drop_table) that the
+// #3628 engine pass (migration_schema_ops.go, framework=kysely) converges to
+// MODIFIES_TABLE. The companion kysely_migrations.go emits the relational view
+// (Schema / Component / foreign_key / relation).
+//
+// Kysely declares schema imperatively in migration modules via the schema
+// builder:
+//
+//	export async function up(db: Kysely<any>): Promise<void> {
+//	  await db.schema.createTable('person')
+//	    .addColumn('id', 'integer', (cb) => cb.primaryKey())
+//	    .addColumn('owner_id', 'integer', (cb) => cb.references('user.id'))
+//	    .addForeignKeyConstraint('fk_owner', ['owner_id'], 'user', ['id'])
+//	    .execute()
+//	}
+//
+// Unlike knex (`t.string('name')` column builders on a closure arg) the table
+// name is the FIRST string arg to createTable/alterTable/dropTable on the
+// `.schema.` receiver, and columns are `.addColumn('name', 'type', ...)`.
+func init() {
+	extreg.Register("custom_js_kysely", &kyselyExtractor{})
+}
+
+type kyselyExtractor struct{}
+
+func (e *kyselyExtractor) Language() string { return "custom_js_kysely" }
+
+var (
+	// db.schema.createTable('person') / .alterTable('person') / .dropTable('person').
+	// Group 1 = method, group 2 = table-name literal. The `.schema.` receiver and
+	// the table-named methods keep this from firing on unrelated createTable calls.
+	reKyselySchemaOp = regexp.MustCompile(
+		`\.\s*(createTable|alterTable|dropTable)\s*\(\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
+	// .addColumn('name', 'type', ...) — Kysely column builder. Group 1 = column.
+	reKyselyAddColumn = regexp.MustCompile(
+		`\.\s*addColumn\s*\(\s*['"]([A-Za-z0-9_]+)['"]`,
+	)
+	// .dropColumn('name') — column drop op.
+	reKyselyDropColumn = regexp.MustCompile(
+		`\.\s*dropColumn\s*\(\s*['"]([A-Za-z0-9_]+)['"]`,
+	)
+	// Index ops: .createIndex('idx') / .dropIndex('idx').
+	reKyselyIndexOp = regexp.MustCompile(
+		`\.\s*(createIndex|dropIndex)\s*\(`,
+	)
+	// up()/down() migration entry points (named exports or object props).
+	//
+	//	export async function up(db) {...}  /  export const up = async (db) => {...}
+	//	export function down(db) {...}       /  up: async (db) => {...}
+	reKyselyMigrationFn = regexp.MustCompile(
+		`(?:export\s+(?:async\s+)?function\s+(up|down)\b|export\s+const\s+(up|down)\s*=|\b(up|down)\s*:\s*(?:async\s*)?\()`,
+	)
+)
+
+func kyselySchemaOpSubtype(method string) string {
+	switch method {
+	case "createTable":
+		return "create_table"
+	case "dropTable":
+		return "drop_table"
+	case "alterTable":
+		return "alter_table"
+	default:
+		return "schema_change"
+	}
+}
+
+func (e *kyselyExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("grafel/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.kysely_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "kysely"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+
+	// Gate to plausible Kysely migration sources: the schema builder must be
+	// reached via a `.schema.` receiver carrying a table-named op. This keeps a
+	// stray createTable/alterTable call in unrelated code from being read as a
+	// migration op.
+	if !looksLikeKyselyMigration(file.Path, src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// Migration up()/down() entry points (migration_parsing).
+	for _, m := range reKyselyMigrationFn.FindAllStringSubmatchIndex(src, -1) {
+		var dir string
+		for i := 2; i+1 < len(m); i += 2 {
+			if m[i] >= 0 {
+				dir = src[m[i]:m[i+1]]
+				break
+			}
+		}
+		if dir == "" {
+			continue
+		}
+		ent := makeEntity("migration:"+dir, "SCOPE.Operation", "migration", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kysely", "direction", dir,
+			"provenance", "INFERRED_FROM_KYSELY_MIGRATION_FN")
+		addEntity(ent)
+	}
+
+	// Schema-builder table ops (migration_schema_ops → MODIFIES_TABLE via #3628).
+	for _, m := range reKyselySchemaOp.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		table := src[m[4]:m[5]]
+		opSubtype := kyselySchemaOpSubtype(method)
+		ent := makeEntity(opSubtype+":"+table, "SCOPE.Evolution", opSubtype, file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kysely", "migration_op", method, "table", table,
+			"provenance", "INFERRED_FROM_KYSELY_SCHEMA_OP")
+		addEntity(ent)
+	}
+
+	// Column add/drop builders (attribute columns mutated by a migration).
+	for _, m := range reKyselyAddColumn.FindAllStringSubmatchIndex(src, -1) {
+		colName := src[m[2]:m[3]]
+		ent := makeEntity("add_column:"+colName, "SCOPE.Evolution", "add_column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kysely", "column", colName,
+			"provenance", "INFERRED_FROM_KYSELY_ADD_COLUMN")
+		addEntity(ent)
+	}
+	for _, m := range reKyselyDropColumn.FindAllStringSubmatchIndex(src, -1) {
+		colName := src[m[2]:m[3]]
+		ent := makeEntity("drop_column:"+colName, "SCOPE.Evolution", "drop_column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kysely", "column", colName,
+			"provenance", "INFERRED_FROM_KYSELY_DROP_COLUMN")
+		addEntity(ent)
+	}
+
+	// Index ops.
+	for _, m := range reKyselyIndexOp.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		subtype := "create_index"
+		if strings.HasPrefix(method, "drop") {
+			subtype = "drop_index"
+		}
+		ent := makeEntity(subtype+":"+method, "SCOPE.Evolution", subtype, file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kysely", "migration_op", method,
+			"provenance", "INFERRED_FROM_KYSELY_INDEX_OP")
+		addEntity(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}

--- a/internal/custom/javascript/kysely_migrations.go
+++ b/internal/custom/javascript/kysely_migrations.go
@@ -1,0 +1,250 @@
+package javascript
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// kyselyMigrationsExtractor parses Kysely migration sources for the schema-builder
+// DSL and recovers the relational structure that the query builder expresses
+// imperatively (#5599). It mirrors knex_migrations.go:
+//
+//   - db.schema.createTable('person', ...)                → table schema (SCOPE.Schema)
+//   - .addColumn('name', 'varchar', ...)                  → columns      (SCOPE.Component/column)
+//   - .addForeignKeyConstraint('fk', ['owner_id'],
+//     'user', ['id'])                                  → foreign key  (SCOPE.Component/foreign_key)
+//   - .addColumn('owner_id','integer',c=>c.references('user.id'))
+//     → column-level foreign key  (SCOPE.Component/foreign_key)
+//   - each FK additionally yields a relationship/association edge          (SCOPE.Pattern/relation)
+//
+// Kysely is a type-safe SQL query builder (not an ORM): its `Database` interface
+// is a compile-time TS type with no runtime model layer, so the *migration* DDL
+// is the only place the schema and its foreign-key relationships are declared.
+// This extractor therefore powers the schema_extraction / foreign_key_extraction
+// / relationship_extraction capabilities for lang.jsts.orm.kysely.
+//
+// The base kysely.go extractor already emits migration-evolution ops
+// (create_table/alter_table/drop_table, SCOPE.Evolution) for migration_parsing
+// and migration_schema_ops; this extractor is additive and emits the relational
+// view. The two are deduped downstream by (Kind, Name, Subtype).
+func init() {
+	extreg.Register("custom_js_kysely_migrations", &kyselyMigrationsExtractor{})
+}
+
+type kyselyMigrationsExtractor struct{}
+
+func (e *kyselyMigrationsExtractor) Language() string { return "custom_js_kysely_migrations" }
+
+var (
+	// db.schema.createTable('person') / .alterTable('person').
+	// Group 1 = method, group 2 = table name literal.
+	reKyselyMigTable = regexp.MustCompile(
+		`\.\s*(createTable|alterTable)\s*\(\s*['"]([A-Za-z0-9_.]+)['"]`,
+	)
+	// .addColumn('name', 'type', ...) column builder. Group 1 = column name.
+	reKyselyMigColumn = regexp.MustCompile(
+		`\.\s*addColumn\s*\(\s*['"]([A-Za-z0-9_]+)['"]`,
+	)
+	// Explicit composite/named FK:
+	//   .addForeignKeyConstraint('fk_owner', ['owner_id'], 'user', ['id'])
+	// Group 1 = constraint name, group 2 = local cols list, group 3 = ref table,
+	// group 4 = ref cols list.
+	reKyselyMigFKConstraint = regexp.MustCompile(
+		`\.\s*addForeignKeyConstraint\s*\(\s*['"][^'"]*['"]\s*,\s*\[([^\]]*)\]\s*,\s*['"]([A-Za-z0-9_.]+)['"]\s*,\s*\[([^\]]*)\]`,
+	)
+	// Column-level FK: a `.references('user.id')` call inside an addColumn
+	// callback. Group 1 = "table.column" (or bare column) literal.
+	reKyselyMigColRef = regexp.MustCompile(
+		`\.\s*references\s*\(\s*['"]([A-Za-z0-9_.]+)['"]\s*\)`,
+	)
+	// First string literal inside a bracket list, e.g. ['owner_id'] → owner_id.
+	reKyselyFirstListLiteral = regexp.MustCompile(`['"]([A-Za-z0-9_.]+)['"]`)
+)
+
+func (e *kyselyMigrationsExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("grafel/custom/javascript")
+	_, span := tracer.Start(ctx, "indexer.kysely_migrations_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "kysely"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	src := string(file.Content)
+	lang := strings.ToLower(file.Language)
+	if lang != "typescript" && lang != "javascript" {
+		return nil, nil
+	}
+
+	if !looksLikeKyselyMigration(file.Path, src) {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	seen := make(map[string]bool)
+	addEntity := func(ent types.EntityRecord) {
+		key := fmt.Sprintf("%s:%s:%s", ent.Kind, ent.Name, ent.Subtype)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entities = append(entities, ent)
+	}
+
+	// --- schema_extraction: tables -------------------------------------------
+	for _, m := range reKyselyMigTable.FindAllStringSubmatchIndex(src, -1) {
+		method := src[m[2]:m[3]]
+		table := src[m[4]:m[5]]
+		ent := makeEntity(table, "SCOPE.Schema", "model", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kysely", "table", table, "builder_method", method,
+			"provenance", "INFERRED_FROM_KYSELY_MIGRATION_TABLE")
+		addEntity(ent)
+	}
+
+	// --- schema_extraction: columns ------------------------------------------
+	for _, m := range reKyselyMigColumn.FindAllStringSubmatchIndex(src, -1) {
+		colName := src[m[2]:m[3]]
+		ent := makeEntity(colName, "SCOPE.Component", "column", file.Path, file.Language, lineOf(src, m[0]))
+		setProps(&ent, "framework", "kysely", "column", colName,
+			"provenance", "INFERRED_FROM_KYSELY_MIGRATION_COLUMN")
+		addEntity(ent)
+	}
+
+	// --- foreign_key / association / relationship ----------------------------
+	// (1) Explicit .addForeignKeyConstraint('fk', ['localCol'], 'refTable', ['refCol']).
+	for _, m := range reKyselyMigFKConstraint.FindAllStringSubmatchIndex(src, -1) {
+		localCol := firstListLiteral(src[m[2]:m[3]])
+		refTable := src[m[4]:m[5]]
+		refCol := firstListLiteral(src[m[6]:m[7]])
+		emitKyselyFK(addEntity, file, lineOf(src, m[0]), localCol, refTable, refCol)
+	}
+
+	// (2) Column-level .references('refTable.refCol') inside an addColumn callback.
+	// The local column is the nearest preceding .addColumn('col', ...).
+	colAnchors := kyselyColumnAnchors(src)
+	for _, m := range reKyselyMigColRef.FindAllStringSubmatchIndex(src, -1) {
+		refLiteral := src[m[2]:m[3]]
+		refTable, refCol := "", refLiteral
+		if dot := strings.LastIndex(refLiteral, "."); dot >= 0 {
+			refTable = refLiteral[:dot]
+			refCol = refLiteral[dot+1:]
+		}
+		localCol := nearestAnchorBefore(colAnchors, m[0])
+		emitKyselyFK(addEntity, file, lineOf(src, m[0]), localCol, refTable, refCol)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(entities)))
+	return entities, nil
+}
+
+// emitKyselyFK emits the foreign_key + relation/association entities for a
+// resolved (localCol, refTable, refCol) triple. refTable may be empty when a
+// column-level .references() used a bare column with no table prefix.
+func emitKyselyFK(addEntity func(types.EntityRecord), file extreg.FileInput, line int, localCol, refTable, refCol string) {
+	ref := refCol
+	if refTable != "" {
+		ref = refTable + "." + refCol
+	}
+
+	// foreign_key entity (foreign_key_extraction).
+	fkName := "fk:" + ref
+	if localCol != "" {
+		fkName = fmt.Sprintf("fk:%s->%s", localCol, ref)
+	}
+	fk := makeEntity(fkName, "SCOPE.Component", "foreign_key", file.Path, file.Language, line)
+	fkProps := []string{
+		"framework", "kysely",
+		"ref_column", refCol,
+		"provenance", "INFERRED_FROM_KYSELY_MIGRATION_FK",
+	}
+	if refTable != "" {
+		fkProps = append(fkProps, "ref_table", refTable)
+	}
+	if localCol != "" {
+		fkProps = append(fkProps, "local_column", localCol)
+	}
+	setProps(&fk, fkProps...)
+	addEntity(fk)
+
+	// relationship / association entity (relationship_extraction + association).
+	relName := "relation:" + ref
+	if refTable != "" {
+		relName = "relation:->" + refTable
+		if localCol != "" {
+			relName = fmt.Sprintf("relation:%s->%s", localCol, refTable)
+		}
+	}
+	rel := makeEntity(relName, "SCOPE.Pattern", "relation", file.Path, file.Language, line)
+	relProps := []string{
+		"framework", "kysely",
+		"relation_kind", "belongs_to",
+		"provenance", "INFERRED_FROM_KYSELY_MIGRATION_FK",
+	}
+	if refTable != "" {
+		relProps = append(relProps, "ref_table", refTable)
+	}
+	if localCol != "" {
+		relProps = append(relProps, "local_column", localCol)
+	}
+	setProps(&rel, relProps...)
+	addEntity(rel)
+}
+
+// firstListLiteral returns the first string literal inside a Kysely column list
+// such as `['owner_id']` (already sliced to the inner text). Returns "" when no
+// literal is present (dynamic / spread list — honest-partial).
+func firstListLiteral(inner string) string {
+	if m := reKyselyFirstListLiteral.FindStringSubmatch(inner); len(m) >= 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// kyselyColumnAnchors collects all .addColumn('col', ...) declarations so a
+// column-level .references() can be attributed to the column it sits on.
+func kyselyColumnAnchors(src string) []anchor {
+	var out []anchor
+	for _, m := range reKyselyMigColumn.FindAllStringSubmatchIndex(src, -1) {
+		out = append(out, anchor{col: src[m[2]:m[3]], offset: m[0]})
+	}
+	// Already in source order (FindAll returns left-to-right); keep stable.
+	return out
+}
+
+// looksLikeKyselyMigration returns true when the file path or content indicates
+// a Kysely migration rather than arbitrary source that happens to call a method
+// named createTable()/addColumn(). Shared by the base and migrations extractors.
+func looksLikeKyselyMigration(path, src string) bool {
+	p := filepath.ToSlash(path)
+	// A Kysely schema chain is the strongest signal: `.schema.` reached with a
+	// table-named builder op.
+	hasSchemaBuilder := strings.Contains(src, ".schema.") &&
+		(reKyselyMigTable.MatchString(src) || strings.Contains(src, "dropTable"))
+	inMigrationsDir := strings.Contains(p, "/migrations/") || strings.HasPrefix(p, "migrations/")
+	if inMigrationsDir && hasSchemaBuilder {
+		return true
+	}
+	// Import-of-Kysely + schema builder catches inline / non-conventional paths.
+	importsKysely := strings.Contains(src, "from 'kysely'") ||
+		strings.Contains(src, "from \"kysely\"") ||
+		strings.Contains(src, "Kysely<")
+	if hasSchemaBuilder && (importsKysely || reKyselyMigFKConstraint.MatchString(src)) {
+		return true
+	}
+	return false
+}

--- a/internal/custom/javascript/kysely_migrations_test.go
+++ b/internal/custom/javascript/kysely_migrations_test.go
@@ -1,0 +1,140 @@
+package javascript_test
+
+// Tests for issue #5599: Kysely migration schema extractor
+// (custom_js_kysely + custom_js_kysely_migrations). Proves schema_extraction,
+// foreign_key_extraction, relationship_extraction, migration_parsing and
+// migration_schema_ops for lang.jsts.orm.kysely from the imperative
+// schema-builder DSL in Kysely migration modules.
+//
+// These are the proving fixtures cited by the registry.
+
+import (
+	"testing"
+)
+
+// goldenKyselyMigration exercises every extracted pattern: createTable,
+// .addColumn column builders, an explicit .addForeignKeyConstraint FK, a
+// column-level .references() FK, an alterTable, and a dropTable, all inside
+// up()/down() migration modules. Generic table/column names.
+const goldenKyselyMigration = `
+import { Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('account')
+    .addColumn('id', 'serial', (cb) => cb.primaryKey())
+    .addColumn('name', 'varchar(255)', (cb) => cb.notNull())
+    .execute()
+
+  await db.schema
+    .createTable('entry')
+    .addColumn('id', 'serial', (cb) => cb.primaryKey())
+    .addColumn('title', 'text')
+    .addColumn('owner_id', 'integer', (cb) => cb.references('account.id'))
+    .addColumn('editor_id', 'integer')
+    .addForeignKeyConstraint('fk_editor', ['editor_id'], 'account', ['id'])
+    .execute()
+
+  await db.schema.alterTable('account').addColumn('status', 'varchar(32)').execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('entry').execute()
+  await db.schema.dropTable('account').execute()
+}
+`
+
+func TestKyselyMigrationSchemaExtraction(t *testing.T) {
+	ents := extract(t, "custom_js_kysely_migrations", fi("migrations/001_init.ts", "typescript", goldenKyselyMigration))
+	if !containsEntity(ents, "SCOPE.Schema", "account") {
+		t.Error("expected account table schema entity (schema_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Schema", "entry") {
+		t.Error("expected entry table schema entity (schema_extraction)")
+	}
+}
+
+func TestKyselyMigrationColumnExtraction(t *testing.T) {
+	ents := extract(t, "custom_js_kysely_migrations", fi("migrations/001_init.ts", "typescript", goldenKyselyMigration))
+	if !containsEntity(ents, "SCOPE.Component", "name") {
+		t.Error("expected column entity 'name' (schema_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Component", "title") {
+		t.Error("expected column entity 'title' (schema_extraction)")
+	}
+	if !containsSubtype(ents, "column") {
+		t.Error("expected column subtype entities from Kysely .addColumn() builders")
+	}
+}
+
+func TestKyselyMigrationForeignKeyConstraint(t *testing.T) {
+	ents := extract(t, "custom_js_kysely_migrations", fi("migrations/001_init.ts", "typescript", goldenKyselyMigration))
+	if !containsSubtype(ents, "foreign_key") {
+		t.Error("expected foreign_key entity (foreign_key_extraction)")
+	}
+	// Explicit .addForeignKeyConstraint('fk_editor', ['editor_id'], 'account', ['id']).
+	if !containsEntity(ents, "SCOPE.Component", "fk:editor_id->account.id") {
+		t.Error("expected fk:editor_id->account.id from .addForeignKeyConstraint")
+	}
+}
+
+func TestKyselyMigrationColumnLevelForeignKey(t *testing.T) {
+	ents := extract(t, "custom_js_kysely_migrations", fi("migrations/001_init.ts", "typescript", goldenKyselyMigration))
+	// Column-level .references('account.id') on owner_id.
+	if !containsEntity(ents, "SCOPE.Component", "fk:owner_id->account.id") {
+		t.Error("expected fk:owner_id->account.id from column-level .references()")
+	}
+}
+
+func TestKyselyMigrationRelationshipExtraction(t *testing.T) {
+	ents := extract(t, "custom_js_kysely_migrations", fi("migrations/001_init.ts", "typescript", goldenKyselyMigration))
+	if !containsSubtype(ents, "relation") {
+		t.Error("expected relation entity derived from FK (relationship_extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "relation:owner_id->account") {
+		t.Error("expected relation:owner_id->account (relationship/association extraction)")
+	}
+	if !containsEntity(ents, "SCOPE.Pattern", "relation:editor_id->account") {
+		t.Error("expected relation:editor_id->account (relationship/association extraction)")
+	}
+}
+
+// TestKyselyMigrationOps proves the base extractor emits the up()/down()
+// entry points and the SCOPE.Evolution schema ops the #3628 engine pass
+// converges to MODIFIES_TABLE (migration_parsing + migration_schema_ops).
+func TestKyselyMigrationOps(t *testing.T) {
+	ents := extract(t, "custom_js_kysely", fi("migrations/001_init.ts", "typescript", goldenKyselyMigration))
+	if !containsEntity(ents, "SCOPE.Operation", "migration:up") {
+		t.Error("expected migration:up entry-point entity (migration_parsing)")
+	}
+	if !containsEntity(ents, "SCOPE.Operation", "migration:down") {
+		t.Error("expected migration:down entry-point entity (migration_parsing)")
+	}
+	if !containsEntity(ents, "SCOPE.Evolution", "create_table:account") {
+		t.Error("expected create_table:account evolution op (migration_schema_ops)")
+	}
+	if !containsEntity(ents, "SCOPE.Evolution", "alter_table:account") {
+		t.Error("expected alter_table:account evolution op (migration_schema_ops)")
+	}
+	if !containsEntity(ents, "SCOPE.Evolution", "drop_table:entry") {
+		t.Error("expected drop_table:entry evolution op (migration_schema_ops)")
+	}
+}
+
+// TestKyselyMigrationNonMigrationNoop proves the extractors gate on Kysely-shaped
+// sources and do not emit schema entities for arbitrary createTable/addColumn calls.
+func TestKyselyMigrationNonMigrationNoop(t *testing.T) {
+	src := `
+const ui = makeBuilder()
+ui.createTable('not-a-db-table')
+ui.addColumn('not-a-column', 'x')
+`
+	ents := extract(t, "custom_js_kysely_migrations", fi("ui/widget.ts", "typescript", src))
+	if len(ents) != 0 {
+		t.Errorf("expected no entities for non-Kysely source, got %d", len(ents))
+	}
+	ents2 := extract(t, "custom_js_kysely", fi("ui/widget.ts", "typescript", src))
+	if len(ents2) != 0 {
+		t.Errorf("expected no base entities for non-Kysely source, got %d", len(ents2))
+	}
+}

--- a/internal/engine/migration_schema_ops.go
+++ b/internal/engine/migration_schema_ops.go
@@ -287,7 +287,7 @@ func evolutionOp(e *graph.Entity, p map[string]string) []migrationSchemaOp {
 	// objection). These carry `framework` + a `table` property and an op
 	// subtype; `migration_op` is the raw method name.
 	switch p["framework"] {
-	case "knex", "typeorm", "sequelize", "objection", "mikroorm":
+	case "knex", "typeorm", "sequelize", "objection", "mikroorm", "kysely":
 		op := e.Subtype
 		if op == "" {
 			op = p["migration_op"]

--- a/internal/engine/migration_schema_ops_test.go
+++ b/internal/engine/migration_schema_ops_test.go
@@ -167,6 +167,41 @@ func TestTypeORMAddColumn(t *testing.T) {
 	assertModifies(t, doc, "t1", "svc", "users", "add_column", "email")
 }
 
+// TestKyselyMigrationSchemaOps proves Kysely SCOPE.Evolution migration-op
+// entities (framework=kysely, #5599) converge to MODIFIES_TABLE for create,
+// alter and drop table ops — the same convergence as knex/typeorm.
+func TestKyselyMigrationSchemaOps(t *testing.T) {
+	create := graph.Entity{
+		ID: "ky1", Name: "create_table:account", Kind: string(types.EntityKindEvolution),
+		Subtype: "create_table",
+		Properties: map[string]string{
+			"framework": "kysely", "migration_op": "createTable", "table": "account",
+		},
+	}
+	alter := graph.Entity{
+		ID: "ky2", Name: "alter_table:account", Kind: string(types.EntityKindEvolution),
+		Subtype: "alter_table",
+		Properties: map[string]string{
+			"framework": "kysely", "migration_op": "alterTable", "table": "account",
+		},
+	}
+	drop := graph.Entity{
+		ID: "ky3", Name: "drop_table:entry", Kind: string(types.EntityKindEvolution),
+		Subtype: "drop_table",
+		Properties: map[string]string{
+			"framework": "kysely", "migration_op": "dropTable", "table": "entry",
+		},
+	}
+	doc := docOf("svc", create, alter, drop)
+	st := ApplyMigrationSchemaOps(doc)
+	if st.Skipped {
+		t.Fatal("skipped")
+	}
+	assertModifies(t, doc, "ky1", "svc", "account", "create_table", "")
+	assertModifies(t, doc, "ky2", "svc", "account", "alter_table", "")
+	assertModifies(t, doc, "ky3", "svc", "entry", "drop_table", "")
+}
+
 // TestAllographerAlterDropMigration proves a Nim Allographer SCOPE.Evolution
 // migration-op entity (framework=allographer, #5029) derives a MODIFIES_TABLE
 // edge for both a column-scoped alter op and a table-level drop.


### PR DESCRIPTION
Adds Kysely schema/migration extraction (schema-builder DSL: createTable/addColumn/addForeignKeyConstraint, up()/down() migrations → MODIFIES_TABLE via the #3628 pass), filling the previously-missing schema/FK/relationship/migration cells. registry.json + coverage docs updated. Closes #5599.