### PR TITLE
fix(windows): suppress flashing console windows for all daemon subpro…

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -29,6 +29,8 @@ for /f %%R in ('copy /Z "%~f0" nul') do set "CR=%%R"
 set "TMPZIP=%TEMP%\grafel-%RANDOM%%RANDOM%.zip"
 set "TMPSUMS=%TEMP%\grafel-%RANDOM%%RANDOM%-checksums.txt"
 set "TMPEXTRACT=%TEMP%\grafel-extract-%RANDOM%%RANDOM%"
+set "TMPAPI=%TEMP%\grafel-%RANDOM%%RANDOM%-api.json"
+set "TMPTAG=%TEMP%\grafel-%RANDOM%%RANDOM%-tag.txt"
 
 REM --- architecture detection (mirror install.ps1 Get-Arch) ---
 set "PROC=%PROCESSOR_ARCHITECTURE%"
@@ -66,16 +68,28 @@ REM ("tag_name": "vX.Y.Z"), which is far less error-prone to parse than a
 REM redirect "location:" header (a partial-URL parse there could otherwise leave
 REM a fragment in VERSION and produce a confusing 404). The redirect-header path
 REM is kept ONLY as a fallback for when the API is unreachable/rate-limited.
+REM
+REM We write the API response to a temp file FIRST, then parse with for /f.
+REM Parsing directly from a pipe inside for /f ('curl ... | findstr ...') can
+REM fail silently on some Windows machines (antivirus real-time scanning,
+REM AppLocker, or WDAC policies that block unsigned binaries spawned from a
+REM %TEMP% .bat file). Reading a file instead of a pipe avoids that class of
+REM failure entirely.
 if not defined VERSION (
-    for /f "tokens=2 delims=:, " %%T in ('curl -fsSL "https://api.github.com/repos/%REPO%/releases/latest" 2^>nul ^| findstr /I /C:"tag_name"') do (
-        if not defined VERSION (
-            set "RAW=%%T"
-            REM strip surrounding double quotes from the JSON string value, plus
-            REM any stray CR the header/body might carry.
-            set "RAW=!RAW:"=!"
-            if defined CR set "RAW=!RAW:%CR%=!"
-            set "VERSION=!RAW!"
+    curl -fsSL "https://api.github.com/repos/%REPO%/releases/latest" -o "%TMPAPI%" 2>nul
+    if exist "%TMPAPI%" (
+        REM Extract ONLY the first tag_name line into a single-line scratch
+        REM file. Parsing the full API JSON directly hits multiple tag_name
+        REM occurrences (release assets embed the tag too), so the for /f
+        REM loop would stop on the wrong match. findstr /I /N picks line 1.
+        REM %%~T strips the surrounding JSON double-quotes natively via the
+        REM for /f tilde modifier, avoiding the broken !RAW:"=! delayed-
+        REM expansion quote-replacement (cmd.exe cannot replace '"' that way).
+        findstr /I /C:"tag_name" "%TMPAPI%" >"%TMPTAG%" 2>nul
+        for /f "usebackq tokens=2 delims=:, " %%T in ("%TMPTAG%") do (
+            if not defined VERSION set "VERSION=%%~T"
         )
+        del /f /q "%TMPTAG%" >nul 2>&1
     )
 )
 
@@ -311,5 +325,7 @@ exit /b 1
 :cleanup
 if exist "%TMPZIP%" del /f /q "%TMPZIP%" >nul 2>&1
 if exist "%TMPSUMS%" del /f /q "%TMPSUMS%" >nul 2>&1
+if exist "%TMPAPI%" del /f /q "%TMPAPI%" >nul 2>&1
+if exist "%TMPTAG%" del /f /q "%TMPTAG%" >nul 2>&1
 if exist "%TMPEXTRACT%" rmdir /s /q "%TMPEXTRACT%" >nul 2>&1
 goto :eof

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cajasmota/grafel/internal/classifier"
 	"github.com/cajasmota/grafel/internal/daemon/caps"
 	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/executil"
 	bazelextract "github.com/cajasmota/grafel/internal/extractors/bazel"
 	configextract "github.com/cajasmota/grafel/internal/extractors/config"
 	"github.com/cajasmota/grafel/internal/resolve"
@@ -440,6 +441,9 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 			// inherited value.
 			cmd.Env = childEnv
 			cmd.Stderr = stderr
+			// On Windows, prevent a console window from flashing when the
+			// daemon (running as a Task Scheduler task) spawns this subprocess.
+			executil.NoWindow(cmd)
 			stdout, perr := cmd.StdoutPipe()
 			if perr != nil {
 				setErr(fmt.Errorf("stdout pipe (%s): %w", b.id, perr))

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
@@ -298,6 +299,9 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 				"gomaxprocs", n, "repo", repoPath)
 		}
 	}
+	// On Windows, prevent a console window from flashing when the daemon
+	// (running as a Task Scheduler task) spawns this subprocess.
+	executil.NoWindow(cmd)
 
 	// Pipe child stdout for IPC JSON lines.
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -411,6 +415,9 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	// guarded off on platforms without setpriority (e.g. Windows). See
 	// applyGroupAlgoNice (platform-split files).
 	applyGroupAlgoNice(cmd)
+	// On Windows, prevent a console window from flashing when the daemon
+	// (running as a Task Scheduler task) spawns this subprocess.
+	executil.NoWindow(cmd)
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/transport"
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 const (
@@ -110,6 +111,16 @@ func currentUserSID() string {
 	return strings.TrimSpace(u.Uid)
 }
 
+// schtasksCmd returns an exec.Cmd for schtasks.exe with CREATE_NO_WINDOW set
+// so that the subprocess never flashes a visible console window when grafel is
+// launched from a GUI context (e.g., Task Scheduler running grafel install,
+// or the daemon task itself restarting on logon).
+func schtasksCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("schtasks", args...)
+	executil.NoWindow(cmd)
+	return cmd
+}
+
 // GenerateTaskXML renders the Task Scheduler XML for the given options.
 // Exported for testing; production code calls install() which calls this.
 func GenerateTaskXML(opts Options) ([]byte, error) {
@@ -169,7 +180,7 @@ func (m *schtasksManager) WriteUnit() error {
 }
 
 func (m *schtasksManager) IsLoaded() (bool, error) {
-	if err := exec.Command("schtasks", "/query", "/tn", taskName).Run(); err != nil {
+	if err := schtasksCmd("/query", "/tn", taskName).Run(); err != nil {
 		return false, nil // task doesn't exist
 	}
 	return true, nil
@@ -190,8 +201,8 @@ func (m *schtasksManager) Unload() error {
 	// success-to-proceed (the desired absent state is reached). The English
 	// string match below remains as a best-effort fallback for races where the
 	// task disappears between IsLoaded() and /delete.
-	_ = exec.Command("schtasks", "/end", "/tn", taskName).Run()
-	out, err := exec.Command("schtasks", "/delete", "/tn", taskName, "/f").CombinedOutput()
+	_ = schtasksCmd("/end", "/tn", taskName).Run()
+	out, err := schtasksCmd("/delete", "/tn", taskName, "/f").CombinedOutput()
 	if err != nil {
 		s := string(out)
 		// best-effort race fallback only; the PRIMARY, locale-invariant decision
@@ -209,13 +220,13 @@ func (m *schtasksManager) Unload() error {
 func (m *schtasksManager) Load() error {
 	// /f forces overwrite of any existing task (callers Unload first, but /f
 	// keeps Load itself idempotent against a leftover registration).
-	if out, err := exec.Command("schtasks", "/create", "/tn", taskName, "/xml", m.xmlPath, "/f").CombinedOutput(); err != nil {
+	if out, err := schtasksCmd("/create", "/tn", taskName, "/xml", m.xmlPath, "/f").CombinedOutput(); err != nil {
 		return fmt.Errorf("schtasks /create: %w\n%s", err, out)
 	}
 	// Start now; it would otherwise fire at next logon. A /run failure is
 	// non-fatal — the readiness poll is the real success signal, and the task
 	// will start at next logon regardless.
-	_ = exec.Command("schtasks", "/run", "/tn", taskName).Run()
+	_ = schtasksCmd("/run", "/tn", taskName).Run()
 	return nil
 }
 
@@ -294,7 +305,7 @@ func status(opts Options) (StatusInfo, error) {
 	// Check whether the XML file exists as a proxy for "installed".
 	if _, serr := os.Stat(xmlPath); os.IsNotExist(serr) {
 		// Also check the scheduler directly in case XML was deleted manually.
-		out, qerr := exec.Command("schtasks", "/query", "/tn", taskName, "/fo", "csv", "/v").Output()
+		out, qerr := schtasksCmd("/query", "/tn", taskName, "/fo", "csv", "/v").Output()
 		if qerr != nil {
 			return info, nil // task doesn't exist
 		}
@@ -304,7 +315,7 @@ func status(opts Options) (StatusInfo, error) {
 	}
 	info.Installed = true
 
-	out, err := exec.Command("schtasks", "/query", "/tn", taskName, "/fo", "csv", "/v").Output()
+	out, err := schtasksCmd("/query", "/tn", taskName, "/fo", "csv", "/v").Output()
 	if err != nil {
 		// The task XML exists but schtasks can't find it — scheduler and
 		// filesystem are out of sync; report installed-but-not-running.

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -60,6 +60,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -374,6 +375,7 @@ func runWorktreeList(repoPath string) ([]RawWorktree, error) {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")
 	cmd.Dir = repoPath
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/internal/engine/commit_coupling_edges.go
+++ b/internal/engine/commit_coupling_edges.go
@@ -91,6 +91,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/module"
 )
@@ -358,6 +359,7 @@ func isGitRoot(repoPath string) bool {
 
 	// Step 1: quick guard — must be inside a working tree at all.
 	insideCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--is-inside-work-tree")
+	executil.NoWindow(insideCmd)
 	insideOut, err := insideCmd.Output()
 	if err != nil || strings.TrimSpace(string(insideOut)) != "true" {
 		return false
@@ -368,6 +370,7 @@ func isGitRoot(repoPath string) bool {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel2()
 	topCmd := exec.CommandContext(ctx2, "git", "-C", repoPath, "rev-parse", "--show-toplevel")
+	executil.NoWindow(topCmd)
 	topOut, err := topCmd.Output()
 	if err != nil {
 		return false
@@ -407,6 +410,7 @@ func scanCommitHistory(repoPath string, cfg CommitCouplingConfig) ([]commitRecor
 		"--pretty=format:__grafel_commit__:%H",
 		"--name-only",
 	)
+	executil.NoWindow(cmd)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	stdout, err := cmd.StdoutPipe()

--- a/internal/executil/nowindow_other.go
+++ b/internal/executil/nowindow_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package executil
+
+import "os/exec"
+
+// NoWindow is a no-op on non-Windows platforms.
+func NoWindow(cmd *exec.Cmd) {}

--- a/internal/executil/nowindow_windows.go
+++ b/internal/executil/nowindow_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package executil
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// NoWindow sets CREATE_NO_WINDOW on cmd so that child processes spawned by the
+// daemon never flash a visible console window. This is required on Windows
+// because exec.Command inherits the parent's console by default — when the
+// daemon runs as a Task Scheduler task (no console) Windows allocates a new
+// console window for each child, producing the "flashing terminal" effect.
+func NoWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= 0x08000000 // CREATE_NO_WINDOW
+}

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 // EnvGitTimeout overrides the default external-git deadline (in seconds) used
@@ -53,6 +55,7 @@ func RunGitBounded(dir string, args ...string) (string, bool) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	applyWaitDelay(cmd)
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", false
@@ -86,6 +89,7 @@ func RunGitBoundedC(dir string, args ...string) ([]byte, bool) {
 	full := append([]string{"-C", dir}, args...)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	applyWaitDelay(cmd)
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, false
@@ -153,6 +157,7 @@ func RunGit(dir string, args ...string) string {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/internal/install/gitignore.go
+++ b/internal/install/gitignore.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 // grafelGitignoreEntry is the line we append to .gitignore when the
@@ -74,6 +76,7 @@ func hasGitignoreEntry(content []byte, entry string) bool {
 // always tolerates the case where git is not installed (returns false).
 func DetectGitRepo(cwd string) (string, bool) {
 	cmd := exec.Command("git", "-C", cwd, "rev-parse", "--show-toplevel")
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		// Not a git repo, or git not installed — both are fine; caller handles.

--- a/internal/install/watchers/loader_windows.go
+++ b/internal/install/watchers/loader_windows.go
@@ -9,10 +9,20 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 // windowsLoader implements Loader using schtasks for Windows Task Scheduler.
 type windowsLoader struct{}
+
+// schtasksCmd returns an exec.Cmd for schtasks.exe with CREATE_NO_WINDOW set
+// so that the subprocess never flashes a visible console window.
+func schtasksCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("schtasks", args...)
+	executil.NoWindow(cmd)
+	return cmd
+}
 
 // NewLoader returns the Windows schtasks-based Loader.
 func NewLoader() Loader { return windowsLoader{} }
@@ -35,8 +45,7 @@ func (windowsLoader) Load(u Unit) error {
 
 	// /f forces overwrite of an existing task with the same name so Load
 	// is idempotent even when the task is already registered.
-	out, err := exec.Command(
-		"schtasks",
+	out, err := schtasksCmd(
 		"/create",
 		"/tn", tn,
 		"/xml", path,
@@ -49,7 +58,7 @@ func (windowsLoader) Load(u Unit) error {
 	// Start the task immediately; it will also fire at next logon via
 	// LogonTrigger. A start failure is non-fatal — the task is registered
 	// and will activate on next logon.
-	if out, err := exec.Command("schtasks", "/run", "/tn", tn).CombinedOutput(); err != nil {
+	if out, err := schtasksCmd("/run", "/tn", tn).CombinedOutput(); err != nil {
 		// Log the failure via the returned error wrapped as a non-fatal hint
 		// so callers can surface it as a warning rather than an error.
 		return fmt.Errorf("task registered but /run failed (starts at next logon): %w\n%s", errNonFatal{err}, out)
@@ -75,19 +84,19 @@ func (windowsLoader) Unload(u Unit) error {
 	// (locale-invariant) rather than by matching the localized /delete error
 	// text ("cannot find" etc.), which breaks on non-English Windows. If the
 	// task is not registered there is nothing to delete.
-	if err := exec.Command("schtasks", "/query", "/tn", tn).Run(); err != nil {
+	if err := schtasksCmd("/query", "/tn", tn).Run(); err != nil {
 		return nil // task doesn't exist — already gone
 	}
 
 	// Stop any running instance — ignore errors (may not be running).
-	_ = exec.Command("schtasks", "/end", "/tn", tn).Run()
+	_ = schtasksCmd("/end", "/tn", tn).Run()
 
-	out, err := exec.Command("schtasks", "/delete", "/tn", tn, "/f").CombinedOutput()
+	out, err := schtasksCmd("/delete", "/tn", tn, "/f").CombinedOutput()
 	if err != nil {
 		// Race: the task was registered above but disappeared before /delete.
 		// Re-check via the /query exit code; if it is gone now, the desired
 		// absent state is reached. Never match the localized error text.
-		if qerr := exec.Command("schtasks", "/query", "/tn", tn).Run(); qerr != nil {
+		if qerr := schtasksCmd("/query", "/tn", tn).Run(); qerr != nil {
 			return nil // gone now — success-to-proceed
 		}
 		return fmt.Errorf("schtasks /delete %s: %w\n%s", tn, err, out)
@@ -112,7 +121,7 @@ func (windowsLoader) Status(u Unit) (WatcherStatus, error) {
 	}
 
 	tn := u.Label()
-	out, qerr := exec.Command("schtasks", "/query", "/tn", tn, "/fo", "csv", "/v").Output()
+	out, qerr := schtasksCmd("/query", "/tn", tn, "/fo", "csv", "/v").Output()
 	if qerr != nil {
 		// Task doesn't exist in the scheduler.
 		return ws, nil


### PR DESCRIPTION
…cesses

On Windows, exec.Command inherits the parent console by default. When the daemon runs as a Task Scheduler task (no console), the OS allocates a new visible console window for every child process it spawns -- producing a flood of flashing terminal windows that steal focus and make the machine unusable during indexing.

Root cause: the daemon spawns many child processes across multiple packages (git, schtasks, grafel extract, grafel index-internal, grafel group-algo) and none of them had CREATE_NO_WINDOW set.

Fix:
- Add internal/executil package with a platform-split NoWindow helper that sets CREATE_NO_WINDOW (0x08000000) via SysProcAttr on Windows and is a no-op on other platforms.
- Apply executil.NoWindow to every exec.Command call on the daemon hot-path:
  * internal/gitmeta: RunGit, RunGitBounded, RunGitBoundedC
  * internal/engine/commit_coupling_edges: git rev-parse + git log
  * internal/daemon/worktree: git worktree list
  * internal/install/gitignore: DetectGitRepo git rev-parse
  * internal/daemon/sched/subprocess_runner: grafel index-internal + grafel group-algo
  * internal/daemon/extract/coordinator: grafel extract worker subprocesses
  * internal/daemon/service/schtasks_windows: schtasks.exe daemon task registration
  * internal/install/watchers/loader_windows: schtasks.exe watcher task registration
- Remove duplicate per-package nowindow_windows/other.go files in sched and extract packages in favour of the central executil package.

Also fixes install.bat version resolution: parse tag_name from GitHub API JSON using findstr + for/f with tilde modifier to strip quotes natively, avoiding the delayed-expansion quote-replacement bug that caused GRAFEL_VERSION to be required manually on some Windows environments.

Tested on Windows 11: grafel install + grafel rebuild --full on a 432-file TypeScript monorepo with subprocess=on and multiple concurrent extract workers produced zero visible console windows.

## Summary
<!-- Short description of what changed -->

## Closes / Refs
<!-- REQUIRED — use ONE of: -->
- `Closes #<N>` — this PR fully resolves the issue (GitHub auto-closes on merge)
- `Refs #<N>` — this PR contributes to but doesn't close the issue (e.g., one wave of a multi-wave feature)
- `Closes-epic-on-merge-of-PR-#<X> #<N>` — this PR is part of an epic; explicit closure happens on PR #X
- `board:exempt` label — for docs-only changes or one-off cleanups

## Testing
- [ ] All tests pass: `go test ./...`
- [ ] Relevant fixtures verified
- [ ] No regression in cross-language parity

## Notes
<!-- Optional reviewer notes -->
