### PR TITLE
fix(test): isolate config-writing + store-leak tests + macOS XDG in CI (#5443 #5477 #5474)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,21 @@ jobs:
       # can run, masking the current PR's source changes (refs #2253).
       - run: go clean -cache -testcache
 
+      # Normalize XDG_CONFIG_HOME on macOS so config resolution matches the
+      # Linux/Windows runners (#5477). GitHub's ubuntu/windows runners export
+      # XDG_CONFIG_HOME=$HOME/.config, which registry.ConfigDir honors first, so
+      # an un-isolated config-writing test resolves a path UNDER $HOME and the
+      # #5443 fail-closed write-guard panics — catching the leak. The macOS
+      # runner leaves XDG_CONFIG_HOME unset, so config resolved elsewhere and the
+      # same leak slipped past on macOS-only runs, surfacing only on the two
+      # slower-billed OSes. Exporting it here makes all three runners resolve
+      # config identically, so the leak-detector catches un-isolated tests on
+      # every platform.
+      - name: Normalize XDG_CONFIG_HOME (macOS parity with Linux/Windows)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: echo "XDG_CONFIG_HOME=$HOME/.config" >> "$GITHUB_ENV"
+
       # Race detector policy (#2406):
       #   - push to main → always race (post-merge sanity)
       #   - release event → always race

--- a/internal/daemon/sched/subprocess_runner_test.go
+++ b/internal/daemon/sched/subprocess_runner_test.go
@@ -44,6 +44,16 @@ func TestSubprocessIndexEnabledEnv(t *testing.T) {
 // error when the target binary does not exist (simulates a broken install).
 func TestRunSubprocessIndexMissingBinary(t *testing.T) {
 	t.Setenv("GRAFEL_SUBPROCESS_INDEXER", "1")
+	// #5474: isolate the daemon root AND home so the spawned `index-internal`
+	// child resolves its per-repo store path under a TempDir, never the real
+	// ~/.grafel/store. Without this the child indexes tmpDir and writes a stray
+	// `<slug>-<hash>/refs/_unknown/graph.fb` into the developer's default store
+	// — the load-induced store-leak the package-level leak-detector trips on.
+	// The child inherits these via os.Environ() at exec, so they must be set
+	// BEFORE RunSubprocessIndex spawns it.
+	isoRoot := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", isoRoot)
+	t.Setenv("GRAFEL_HOME", isoRoot)
 
 	// Patch os.Executable to return a non-existent path. We do this by running
 	// a helper binary name that does not exist — we can't easily override


### PR DESCRIPTION
## Summary

Three test-isolation hardenings so config/state-writing tests cannot touch a developer's real home and so CI catches leaks cheaply on all three OSes.

### #5474 — store-leak race (the real bug)
`TestRunSubprocessIndexMissingBinary` set the subprocess-indexer flag but did not isolate the daemon root. The spawned `index-internal` child inherits the parent env at exec, so with no isolated root it resolved the **real default store** and wrote a `graph.fb` (under `refs/_unknown`) for the empty temp dir into it — surfacing under load as the stray `<slug>-<hash>/refs/_unknown/graph.fb` in the default store. Fix: pin `GRAFEL_DAEMON_ROOT` + `GRAFEL_HOME` to a `t.TempDir()` before the child is spawned. Deterministic; no timing reliance.

### #5477 — macOS CI parity
Export `XDG_CONFIG_HOME=$HOME/.config` on the macOS runner (matching the Linux/Windows runners) so config resolves the same way everywhere. An un-isolated config-writing test then resolves a path under $HOME on macOS too, so the existing fail-closed write-guard fires on every OS — catching leaks on the cheap Linux job instead of only the slower-billed ones.

### #5443 — audit (already closed by the merged guard)
Audited the fleet/registry config-writing tests. The overlay-reapply test and its peers already isolate via `testsupport.IsolateHome` (or pass explicit TempDir paths), so the clobber path is closed; no further change needed.

## Verification
- `go build ./...` clean
- `go test -count=1 ./internal/daemon/... ./internal/mcp/...` green
- Affected subprocess tests green at `-count=5`
- `gofmt -l` clean; `test.yml` YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)