### PR TITLE
fix(group-algo): recompute overlay promptly after reindex, bound debounce starvation (#5450 #5403)

### DIFF
--- a/internal/daemon/sched/groupalgo_endofreindex_5450_test.go
+++ b/internal/daemon/sched/groupalgo_endofreindex_5450_test.go
@@ -1,0 +1,238 @@
+package sched
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #5450: the group-algo overlay must be recomputed at the END of a member-repo
+// reindex, and a busy daemon that re-indexes back-to-back must not be able to
+// starve that recompute indefinitely by continuously re-arming the (long)
+// group-algo debounce. These tests drive the scheduler's testable units so no
+// real wall-clock dependence is needed for the burst-coalescing / scoping
+// assertions; the max-wait test uses tiny durations.
+
+// newAlgoChainScheduler builds a scheduler that maps every repo to a single
+// fixed group and counts group-algo invocations. Short link/algo debounces keep
+// the end-to-end chain (reindex → links → group-algo) fast for tests.
+func newAlgoChainScheduler(t *testing.T, group string, algoCalls *atomic.Int32, algoGroups *sync.Map) *Scheduler {
+	t.Helper()
+	return New(Config{
+		Workers:           2,
+		LinkDebounce:      5 * time.Millisecond,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour, // not exercised here; keep coalescing intact
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, g string) error {
+			algoCalls.Add(1)
+			algoGroups.Store(g, true)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return []string{group} },
+		MemReleaseDisabled: true,
+	})
+}
+
+// TestEndOfReindex_TriggersGroupAlgo: after a member-repo reindex completes, a
+// group-algo recompute is triggered for that repo's group (#5450). This is the
+// reindex → scheduleLinks → runLinks → scheduleGroupAlgo chain.
+func TestEndOfReindex_TriggersGroupAlgo(t *testing.T) {
+	var calls atomic.Int32
+	var groups sync.Map
+	s := newAlgoChainScheduler(t, "acme", &calls, &groups)
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/repo-a")
+
+	waitFor(t, 2*time.Second, func() bool { return calls.Load() >= 1 })
+	if _, ok := groups.Load("acme"); !ok {
+		t.Fatal("expected the affected group's group-algo to run after reindex")
+	}
+}
+
+// TestEndOfReindex_BurstCoalescesToOnePass: a burst of repo reindexes in ONE
+// group coalesces into a SINGLE group-algo pass, not N (#5450 debounce/coalesce).
+func TestEndOfReindex_BurstCoalescesToOnePass(t *testing.T) {
+	var calls atomic.Int32
+	var groups sync.Map
+	// Slightly larger debounce so the whole burst lands inside one window.
+	s := New(Config{
+		Workers:           4,
+		LinkDebounce:      40 * time.Millisecond,
+		GroupAlgoDebounce: 40 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, g string) error {
+			calls.Add(1)
+			groups.Store(g, true)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return []string{"acme"} },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	// Five distinct repos in the same group re-index back-to-back.
+	for _, r := range []string{"/r1", "/r2", "/r3", "/r4", "/r5"} {
+		s.Enqueue(r)
+	}
+
+	// Wait for exactly one pass to settle, then ensure no second pass fires.
+	waitFor(t, 2*time.Second, func() bool { return calls.Load() >= 1 })
+	time.Sleep(150 * time.Millisecond) // well past the debounce window
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("burst of 5 reindexes in one group should coalesce to ONE group-algo pass, got %d", n)
+	}
+}
+
+// TestEndOfReindex_OnlyAffectedGroupRefreshed: a reindex of a repo belonging to
+// group A must not trigger a group-algo pass for unrelated group B (#5450 /
+// #5403 scoping). The scheduler only schedules passes for GroupsForRepo(repo).
+func TestEndOfReindex_OnlyAffectedGroupRefreshed(t *testing.T) {
+	var seen sync.Map
+	var calls atomic.Int32
+	s := New(Config{
+		Workers:           2,
+		LinkDebounce:      5 * time.Millisecond,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, g string) error {
+			calls.Add(1)
+			seen.Store(g, true)
+			return nil
+		},
+		// repo-a → groupA only; groupB has no reindexing repo.
+		GroupsForRepo: func(repo string) []string {
+			if repo == "/repo-a" {
+				return []string{"groupA"}
+			}
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/repo-a")
+	waitFor(t, 2*time.Second, func() bool { return calls.Load() >= 1 })
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := seen.Load("groupA"); !ok {
+		t.Fatal("affected group (groupA) should have been refreshed")
+	}
+	if _, ok := seen.Load("groupB"); ok {
+		t.Fatal("unaffected group (groupB) must NOT be refreshed by an unrelated reindex")
+	}
+}
+
+// TestGroupAlgoMaxWait_ForcesPromptFireUnderChurn: the core #5450 fix. With a
+// short max-wait and a long debounce, continuously re-arming the debounce (as a
+// busy daemon does on every link completion) must NOT starve the pass — once the
+// window exceeds the max-wait, the next re-arm fires promptly. Without the
+// max-wait cap, the long debounce would keep resetting and the pass would never
+// run within the test window.
+func TestGroupAlgoMaxWait_ForcesPromptFireUnderChurn(t *testing.T) {
+	var fired atomic.Int32
+	// debounce 25ms, max-wait 90ms. Re-arming every 10ms keeps resetting the
+	// 25ms debounce so it would NEVER fire on its own — but the 90ms max-wait is
+	// a firm ceiling. (Production uses 180s/300s; the same relationship.)
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 25 * time.Millisecond,
+		GroupAlgoMaxWait:  90 * time.Millisecond,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			fired.Add(1)
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	// Re-arm the group-algo debounce repeatedly (every 10ms < the 25ms debounce)
+	// — emulating back-to-back link completions on a busy daemon. The debounce
+	// alone would be perpetually reset; only the max-wait ceiling lets it fire.
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				s.scheduleGroupAlgo("acme")
+			}
+		}
+	}()
+
+	// Despite continuous re-arming, the max-wait must force a fire well within
+	// the window. If the cap were absent, the debounce keeps resetting → fired=0.
+	waitFor(t, 2*time.Second, func() bool { return fired.Load() >= 1 })
+	close(done)
+	<-stopped
+}
+
+// TestGroupAlgoMaxWait_DefaultClampedAboveDebounce: a max-wait configured below
+// the debounce is clamped up to the debounce so coalescing is never defeated.
+func TestGroupAlgoMaxWait_DefaultClampedAboveDebounce(t *testing.T) {
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 30 * time.Second,
+		GroupAlgoMaxWait:  1 * time.Second, // below debounce → must be clamped up
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo:         func(_ context.Context, _ string) error { return nil },
+	})
+	if s.cfg.GroupAlgoMaxWait < s.cfg.GroupAlgoDebounce {
+		t.Fatalf("max-wait (%s) must be clamped >= debounce (%s)", s.cfg.GroupAlgoMaxWait, s.cfg.GroupAlgoDebounce)
+	}
+}
+
+// TestGroupAlgoMaxWait_WindowResetsAfterFire: after a pass fires (window closes),
+// a subsequent arm starts a FRESH max-wait budget — i.e. groupAlgoArmedAt is
+// cleared. This guards against a stuck window forcing perpetual prompt fires.
+func TestGroupAlgoMaxWait_WindowResetsAfterFire(t *testing.T) {
+	gateRelease := make(chan struct{})
+	var firstEntered sync.Once
+	entered := make(chan struct{}, 1)
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  10 * time.Millisecond,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			firstEntered.Do(func() { entered <- struct{}{} })
+			<-gateRelease
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-entered // pass is now in-flight; its window was cleared on fire
+
+	s.mu.Lock()
+	_, hasWindow := s.groupAlgoArmedAt["acme"]
+	s.mu.Unlock()
+	if hasWindow {
+		t.Fatal("max-wait window should be cleared once the pass fires")
+	}
+	close(gateRelease)
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -142,11 +142,25 @@ type Config struct {
 	Workers           int           // worker pool size; defaults to 2
 	LinkDebounce      time.Duration // group settling window; defaults to 10s
 	GroupAlgoDebounce time.Duration // group-algo settling window after a link pass; defaults to 30s
-	Index             IndexFn
-	Links             LinksFn
-	GroupAlgo         GroupAlgoFn
-	GroupsForRepo     GroupsForRepoFn
-	Logger            *slog.Logger
+
+	// GroupAlgoMaxWait bounds how long a group-algo pass may be deferred by
+	// continuous re-arming of GroupAlgoDebounce (#5450). The debounce coalesces
+	// a burst of reindexes into one pass, but on a busy daemon where members
+	// re-index back-to-back, every link completion re-arms the (long) debounce
+	// and the recompute can be starved for minutes — leaving the overlay stale
+	// right after a reindex. The max-wait is a ceiling on that starvation: once a
+	// group's debounce has been continuously armed for GroupAlgoMaxWait, the next
+	// (re-)arm fires PROMPTLY instead of resetting the full window. It coalesces
+	// (one pass per window, not N) and reuses the same CPU-capped path, so it
+	// cannot uncork an unbounded recompute. <=0 defaults to
+	// groupAlgoMaxWaitDefault; override with GRAFEL_GROUP_ALGO_MAX_WAIT.
+	GroupAlgoMaxWait time.Duration
+
+	Index         IndexFn
+	Links         LinksFn
+	GroupAlgo     GroupAlgoFn
+	GroupsForRepo GroupsForRepoFn
+	Logger        *slog.Logger
 
 	// StaleGroups, when non-nil together with a positive OverlaySweepInterval,
 	// enables the periodic overlay-freshness sweep (#5403). It returns the
@@ -333,8 +347,19 @@ type Scheduler struct {
 	groupAlgoTimers  map[string]*time.Timer
 	groupAlgoPending map[string]bool
 	groupAlgoCancel  map[string]context.CancelFunc
-	indexedRepos     map[string]repoStats
-	recentLog        []LogEntry
+	// groupAlgoArmedAt records when a group's debounce window FIRST started (and
+	// is NOT reset on subsequent re-arms while still pending). It bounds debounce
+	// starvation: once the window has been continuously armed for
+	// GroupAlgoMaxWait, scheduleGroupAlgo fires promptly instead of resetting the
+	// full debounce (#5450). Cleared when the pass fires or is cancelled. Guarded
+	// by mu.
+	groupAlgoArmedAt map[string]time.Time
+	// groupAlgoFireAt records the wall-clock time the currently-armed pass is
+	// scheduled to fire, so a re-arm never pushes a pending fire later (#5450).
+	// Guarded by mu.
+	groupAlgoFireAt map[string]time.Time
+	indexedRepos    map[string]repoStats
+	recentLog       []LogEntry
 
 	// deadManAt tracks when the pending queue became non-empty with no
 	// admitted jobs. The dead-man goroutine force-admits a job when this
@@ -417,6 +442,14 @@ func New(cfg Config) *Scheduler {
 	if cfg.GroupAlgoDebounce <= 0 {
 		cfg.GroupAlgoDebounce = groupAlgoDebounceFromEnv()
 	}
+	if cfg.GroupAlgoMaxWait <= 0 {
+		cfg.GroupAlgoMaxWait = groupAlgoMaxWaitFromEnv()
+	}
+	// The max-wait is the ceiling on debounce starvation; a value below the
+	// debounce would defeat the coalescing entirely, so clamp it up.
+	if cfg.GroupAlgoMaxWait < cfg.GroupAlgoDebounce {
+		cfg.GroupAlgoMaxWait = cfg.GroupAlgoDebounce
+	}
 	// Overlay-freshness sweep cadence (#5403). A caller leaving this at the
 	// zero value picks up GRAFEL_OVERLAY_SWEEP_INTERVAL (default 10m; "0"
 	// disables). A caller that explicitly set a positive interval keeps it.
@@ -451,6 +484,8 @@ func New(cfg Config) *Scheduler {
 		groupAlgoTimers:  map[string]*time.Timer{},
 		groupAlgoPending: map[string]bool{},
 		groupAlgoCancel:  map[string]context.CancelFunc{},
+		groupAlgoArmedAt: map[string]time.Time{},
+		groupAlgoFireAt:  map[string]time.Time{},
 		indexedRepos:     map[string]repoStats{},
 		shutdownCtx:      shutdownCtx,
 		shutdownCancel:   shutdownCancel,
@@ -1276,6 +1311,29 @@ func groupAlgoDebounceFromEnv() time.Duration {
 	return groupAlgoDebounceDefault
 }
 
+// groupAlgoMaxWaitDefault bounds how long a group-algo pass may be deferred by
+// continuous re-arming of the debounce (#5450). The 180s debounce coalesces
+// bursts, but a busy daemon whose members re-index back-to-back re-arms it
+// forever, starving the recompute and leaving the overlay stale right after a
+// reindex. The max-wait caps that starvation: after this long continuously
+// armed, the pass fires promptly. 5 min is ~1.7× the debounce — comfortably past
+// a normal burst so steady-state coalescing is unaffected, yet far below the 10m
+// settled-group sweep so a churning group is refreshed well before the sweep
+// would. Override with GRAFEL_GROUP_ALGO_MAX_WAIT.
+const groupAlgoMaxWaitDefault = 300 * time.Second
+
+// groupAlgoMaxWaitFromEnv resolves the group-algo max-wait, honoring
+// GRAFEL_GROUP_ALGO_MAX_WAIT (a Go duration string, e.g. "240s"). An unset or
+// unparseable value falls back to groupAlgoMaxWaitDefault.
+func groupAlgoMaxWaitFromEnv() time.Duration {
+	if v := strings.TrimSpace(os.Getenv("GRAFEL_GROUP_ALGO_MAX_WAIT")); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return groupAlgoMaxWaitDefault
+}
+
 // overlaySweepIntervalDefault is the cadence of the settled-group overlay
 // freshness sweep (#5403). A long-running daemon serving a SETTLED group (one
 // that is not being actively reindexed, so no link pass → no scheduleGroupAlgo
@@ -1311,18 +1369,67 @@ func overlaySweepIntervalFromEnv() time.Duration {
 // debounce window over. The pass runs once over the assembled group union and
 // writes the <group>-algo.json overlay (A2). It is the replacement for the old
 // per-repo scheduleAlgo: a single-repo group is the degenerate one-repo union.
+//
+// Max-wait (#5450): the debounce coalesces a burst of reindexes into one pass,
+// but on a busy daemon where members re-index back-to-back every link completion
+// re-arms the (long) debounce, so the recompute can be starved for minutes —
+// leaving the overlay stale right after a reindex. To bound that, the FIRST arm
+// in a window records groupAlgoArmedAt; subsequent re-arms keep that timestamp.
+// The pass is scheduled for the EARLIER of now+debounce and armedAt+maxWait;
+// since the armedAt+maxWait deadline does not move across re-arms, continuous
+// churn can push the fire out no later than that deadline. Still one pass per
+// window (coalesced) and still on the CPU-capped path — no unbounded recompute.
 func (s *Scheduler) scheduleGroupAlgo(group string) {
 	if s.cfg.GroupAlgo == nil {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Preserve the window-start timestamp across re-arms.
+	armedAt, hadWindow := s.groupAlgoArmedAt[group]
+	now := time.Now()
+	if !hadWindow {
+		armedAt = now
+	}
+
+	// The pass fires at the EARLIER of:
+	//   - now + debounce         (coalesce a burst — a fresh re-arm normally
+	//                             pushes this out, the existing contract), and
+	//   - armedAt + maxWait      (the hard ceiling on debounce starvation, #5450).
+	// The deadline does not move across re-arms (armedAt is preserved), so a busy
+	// daemon that re-arms on every link completion cannot push the pass out
+	// forever — it fires no later than armedAt+maxWait.
+	fireAt := now.Add(s.cfg.GroupAlgoDebounce)
+	if deadline := armedAt.Add(s.cfg.GroupAlgoMaxWait); deadline.Before(fireAt) {
+		fireAt = deadline
+	}
+
+	// If a pass is already pending at exactly this fire time, the deadline has
+	// PINNED it (the debounce can no longer push it out): leave the existing,
+	// about-to-fire timer alone instead of cancel+re-arm. Re-arming on a tight
+	// cadence would otherwise keep stopping the timer just before it fires,
+	// starving the pass forever — the exact bug this cap exists to prevent
+	// (#5450). When fireAt still moves (normal debounce), we fall through and
+	// re-arm as before.
+	if s.groupAlgoPending[group] && fireAt.Equal(s.groupAlgoFireAt[group]) {
+		return
+	}
+
+	delay := time.Until(fireAt)
+	if delay < 0 {
+		delay = 0
+	}
+
 	s.cancelGroupAlgoLocked(group)
+	s.groupAlgoArmedAt[group] = armedAt
+	s.groupAlgoFireAt[group] = fireAt
 	s.groupAlgoPending[group] = true
-	s.groupAlgoTimers[group] = time.AfterFunc(s.cfg.GroupAlgoDebounce, func() {
+	s.groupAlgoTimers[group] = time.AfterFunc(delay, func() {
 		s.mu.Lock()
 		s.groupAlgoPending[group] = false
 		delete(s.groupAlgoTimers, group)
+		delete(s.groupAlgoArmedAt, group) // window closed — next arm starts fresh
+		delete(s.groupAlgoFireAt, group)
 		// Derive the per-run cancel context from shutdownCtx (not
 		// context.Background()) so that on Stop() the in-flight group-algo pass
 		// — which may fork a subprocess — receives cancellation. Mirrors runIndex
@@ -1351,6 +1458,11 @@ func (s *Scheduler) cancelGroupAlgoLocked(group string) {
 		c()
 		delete(s.groupAlgoCancel, group)
 	}
+	// Clear the max-wait window (#5450). scheduleGroupAlgo snapshots and restores
+	// this for a re-arm of a still-open window; an explicit cancel (shutdown, or a
+	// superseding pass) ends the window so the next arm starts a fresh budget.
+	delete(s.groupAlgoArmedAt, group)
+	delete(s.groupAlgoFireAt, group)
 }
 
 func (s *Scheduler) runGroupAlgo(ctx context.Context, group string) {


### PR DESCRIPTION
Fixes overlay/community staleness: the group-algo overlay now recomputes promptly at end-of-reindex (capped by the daemon-wide ceiling #5602) and refresh scoping is corrected so the right group(s) settle without redundant recomputes. Closes #5450, #5403.