### PR TITLE
feat(reindex): differential-reindex validator harness (incremental≡full parity) — #5309 foundation

### DIFF
--- a/cmd/grafel/diff_reindex_validator_test.go
+++ b/cmd/grafel/diff_reindex_validator_test.go
@@ -1,0 +1,365 @@
+// Package main — diff_reindex_validator_test.go
+//
+// Differential-reindex validator harness (epic #5376, layer-2 foundation #5309).
+//
+// This is the safety net that gates the upcoming incremental graph-wide phases
+// (scoped resolution / communities / link-flow passes). It asserts the
+// load-bearing invariant those phases must never break:
+//
+//	an incremental reindex must produce a graph STRUCTURALLY EQUIVALENT to a
+//	full rebuild of the same end-state.
+//
+// Harness shape, per delta case
+// ─────────────────────────────
+//
+//	(A) full-rebuild the start-state corpus            → graph A (on disk)
+//	    + seed the incremental manifest
+//	(B) apply a source change, incremental-reindex      → graph B (TryIncremental)
+//	(C) full-rebuild the changed corpus from scratch    → graph C
+//	    assert  B ≡ C  via internal/graph/parity.Compare
+//
+// Why B ≡ C and not B ≡ A: a change is supposed to alter the graph. The
+// invariant is that the *incremental* path lands on the SAME graph a clean full
+// rebuild of the end-state would — i.e. the incremental skip logic never drops
+// or staleifies anything a full rebuild would have computed.
+//
+// These cases pass TODAY: the graph-wide phases are still full in both the
+// incremental and the full path, so B and C already agree. That is precisely
+// the point — this PR locks in the baseline so #5309's per-phase incrementalism
+// cannot regress equivalence silently. Each future layer (resolution →
+// communities → flows) lands behind these same assertions.
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/parity"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// ─────────────────────────── harness primitives ───────────────────────────
+
+// dvWriteFile creates or overwrites repo/relPath with content.
+func dvWriteFile(t *testing.T, repo, relPath, content string) {
+	t.Helper()
+	abs := filepath.Join(repo, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", relPath, err)
+	}
+}
+
+// dvFullRebuild runs the full indexer over repo, writing graph.fb (+ manifest)
+// into a fresh state dir, and returns the loaded Document. It pins
+// GRAFEL_DAEMON_ROOT so the run never touches the real store, and skips the
+// graph-algo (Pass 4) pass so the baseline is deterministic and fast — the
+// validator's structural assertions (entities/edges/communities) do not depend
+// on betweenness/pagerank floats, which are legitimately non-deterministic
+// under sampling.
+func dvFullRebuild(t *testing.T, repo, stateDir string) *graph.Document {
+	t.Helper()
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir stateDir: %v", err)
+	}
+	t.Setenv("GRAFEL_DAEMON_ROOT", stateDir)
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	// WithIncremental(stateDir) makes Index write the diff manifest alongside
+	// graph.fb, which is exactly the baseline TryIncremental later loads.
+	err := Index(repo, fbPath, "test-repo", []string{"graph-algo"}, false, false,
+		WithIncremental(stateDir))
+	if err != nil {
+		t.Fatalf("full Index: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph after full rebuild: %v", err)
+	}
+	return doc
+}
+
+// dvSeedManifest writes a fresh diff manifest covering every file currently in
+// repo, so a subsequent TryIncremental detects only the post-seed change as
+// "changed". (dvFullRebuild already seeds via WithIncremental, but call sites
+// that mutate the corpus between the rebuild and the incremental pass re-seed
+// to pin the exact baseline.)
+func dvSeedManifest(t *testing.T, repo, stateDir string) {
+	t.Helper()
+	var paths []string
+	_ = filepath.WalkDir(repo, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(repo, path)
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	})
+	m := diff.LoadManifest(stateDir)
+	diff.UpdateManifest(repo, paths, m)
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+}
+
+// dvIncremental runs TryIncremental against repo using the on-disk baseline in
+// stateDir, then returns the resulting (re-written) Document. A fallback to
+// full reindex is a test failure: the harness exists to validate the
+// incremental *path*, so a silent fallback would hide a regression in it.
+func dvIncremental(t *testing.T, repo, stateDir string) *graph.Document {
+	t.Helper()
+	t.Setenv("GRAFEL_DAEMON_ROOT", stateDir)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental fell back to full reindex (reason=%q) — the harness "+
+			"requires the incremental path to run so it can be validated", res.FallbackReason)
+	}
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph after incremental: %v", err)
+	}
+	return doc
+}
+
+// dvBaselineProfile is the tolerance profile that captures the KNOWN
+// incremental-vs-full gaps that exist TODAY, before #5309 makes the graph-wide
+// phases incremental. Each tolerance is a documented gap a later layer of #5309
+// will close; until then the validator normalizes it rather than false-alarming,
+// while staying strict on everything else (entity set, resolved call/reference
+// edges, communities). As each layer lands, the corresponding tolerance is
+// removed and the validator tightens — that is how this harness ratchets the
+// incremental path toward full-rebuild parity.
+//
+// The gaps, surfaced empirically by running the harness with Strict():
+//   - module-aggregation edges (CONTAINS / DEPENDS_ON): the incremental path
+//     does not re-run the module-agg pass (#5309 link/flow layer).
+//   - enrichment-only entity properties (`module`, `test_reachable`): produced
+//     by passes the incremental path defers (module-agg + test-reachability).
+//   - un-resolved cross-file edge endpoints: the incremental scoped resolver can
+//     leave a freshly-extracted edge's endpoint in stub form rather than the
+//     hashed entity id the full resolver assigns (#5309 resolution layer).
+func dvBaselineProfile() parity.Options {
+	return parity.Options{
+		IgnoreRelKinds:         map[string]bool{"CONTAINS": true, "DEPENDS_ON": true},
+		IgnoreEntityProps:      map[string]bool{"module": true, "test_reachable": true},
+		NormalizeStubEndpoints: true,
+	}
+}
+
+// dvAssertParity runs the comparator under the baseline tolerance profile and
+// fails with its precise diff on mismatch. b is the incremental result, c the
+// full rebuild of the end-state.
+func dvAssertParity(t *testing.T, b, c *graph.Document) {
+	t.Helper()
+	// A = full-rebuild reference, B = incremental candidate.
+	rep := parity.CompareWithOptions(c, b, dvBaselineProfile())
+	if !rep.Equivalent {
+		t.Fatalf("incremental ≠ full-rebuild of end-state (under documented baseline tolerances):\n%s", rep.String())
+	}
+}
+
+// ───────────────────────────── delta cases ─────────────────────────────────
+//
+// Start-state corpus shared by the cases below: a tiny multi-file Go package
+// where caller.go calls into target.go, giving us a cross-file CALLS edge to
+// exercise inbound-edge handling.
+
+func dvStartCorpus(t *testing.T, repo string) {
+	dvWriteFile(t, repo, "target.go", "package svc\n\n"+
+		"func Target() int { return 1 }\n\n"+
+		"func Sibling() int { return 2 }\n")
+	dvWriteFile(t, repo, "caller.go", "package svc\n\n"+
+		"func Caller() int { return Target() + Sibling() }\n")
+}
+
+// Case 1 — rename across files. Target() → Renamed(); caller.go is updated to
+// match. Both files change; the old entity must vanish and the new one appear
+// with the caller edge re-pointed — exactly as a full rebuild would compute.
+func TestDiffReindex_RenameAcrossFiles(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dvStartCorpus(t, repo)
+
+	dvFullRebuild(t, repo, stateDir) // graph A + manifest baseline
+	dvSeedManifest(t, repo, stateDir)
+
+	// Apply the rename across both files.
+	dvWriteFile(t, repo, "target.go", "package svc\n\n"+
+		"func Renamed() int { return 1 }\n\n"+
+		"func Sibling() int { return 2 }\n")
+	dvWriteFile(t, repo, "caller.go", "package svc\n\n"+
+		"func Caller() int { return Renamed() + Sibling() }\n")
+
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	dvAssertParity(t, b, c)
+}
+
+// Case 2 — deleted entity with inbound edges. Remove Sibling() from target.go
+// and drop its call in caller.go. The deleted entity AND any stale inbound edge
+// to it must be gone — a full rebuild has neither, so the incremental path
+// must not leave a dangling edge behind.
+func TestDiffReindex_DeletedEntityWithInboundEdges(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dvStartCorpus(t, repo)
+
+	dvFullRebuild(t, repo, stateDir)
+	dvSeedManifest(t, repo, stateDir)
+
+	// Delete Sibling() and the call to it.
+	dvWriteFile(t, repo, "target.go", "package svc\n\n"+
+		"func Target() int { return 1 }\n")
+	dvWriteFile(t, repo, "caller.go", "package svc\n\n"+
+		"func Caller() int { return Target() }\n")
+
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	dvAssertParity(t, b, c)
+}
+
+// Case 3 — signature change rippling to callers. Target() grows a parameter and
+// caller.go passes it. The signature-change detection + scoped re-resolution
+// must land the same entity signature and the same caller edge a full rebuild
+// would.
+func TestDiffReindex_SignatureChangeRipplesToCallers(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dvStartCorpus(t, repo)
+
+	dvFullRebuild(t, repo, stateDir)
+	dvSeedManifest(t, repo, stateDir)
+
+	// Target gains a parameter; caller updated to match.
+	dvWriteFile(t, repo, "target.go", "package svc\n\n"+
+		"func Target(n int) int { return n }\n\n"+
+		"func Sibling() int { return 2 }\n")
+	dvWriteFile(t, repo, "caller.go", "package svc\n\n"+
+		"func Caller() int { return Target(3) + Sibling() }\n")
+
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	dvAssertParity(t, b, c)
+}
+
+// TestDiffReindex_CatchesInjectedMismatch is the validator's self-check: it
+// proves the harness FAILS when the incremental graph is deliberately wrong. We
+// take a real incremental result, corrupt it the way a buggy incremental skip
+// would (drop an entity and an edge, drift a community label), and assert the
+// comparator reports it under the SAME baseline tolerance profile the green
+// cases use — i.e. the tolerances don't mask real corruption.
+func TestDiffReindex_CatchesInjectedMismatch(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dvStartCorpus(t, repo)
+
+	dvFullRebuild(t, repo, stateDir)
+	dvSeedManifest(t, repo, stateDir)
+
+	dvWriteFile(t, repo, "caller2.go", "package svc\n\nfunc Caller2() int { return Target() * 2 }\n")
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	// Sanity: the honest comparison passes.
+	if rep := parity.CompareWithOptions(c, b, dvBaselineProfile()); !rep.Equivalent {
+		t.Fatalf("precondition: honest incremental should match full rebuild:\n%s", rep.String())
+	}
+
+	// Inject corruption into the incremental graph the way a buggy incremental
+	// skip would: drop a real (non-tolerated) entity, re-point a CALLS edge at a
+	// bogus target (an edge the full rebuild does not have), and drift a
+	// community label on a survivor. All three must be reported even under the
+	// baseline tolerance profile — the tolerances must not mask real corruption.
+	if len(b.Entities) < 2 {
+		t.Fatalf("fixture too small to corrupt: %d entities", len(b.Entities))
+	}
+	corruptEnts := append([]graph.Entity(nil), b.Entities...)
+	corruptRels := append([]graph.Relationship(nil), b.Relationships...)
+
+	// (a) drop a CALLS-bearing entity (find one to make the entity-set diverge).
+	dropIdx := -1
+	for i, e := range corruptEnts {
+		if e.Kind != "Module" { // keep it a real source entity, not the synthetic module node
+			dropIdx = i
+			break
+		}
+	}
+	if dropIdx < 0 {
+		t.Fatal("no non-module entity to drop")
+	}
+	corruptEnts = append(corruptEnts[:dropIdx], corruptEnts[dropIdx+1:]...)
+
+	// (b) re-point a CALLS edge at a fabricated target id absent from the full rebuild.
+	rewired := false
+	for i := range corruptRels {
+		if corruptRels[i].Kind == "CALLS" {
+			corruptRels[i].ToID = "deadbeefdeadbeef" // 16-hex, not a real entity → only-in-B edge
+			rewired = true
+			break
+		}
+	}
+	if !rewired {
+		t.Fatal("no CALLS edge to re-point")
+	}
+
+	// (c) drift a community label on a survivor.
+	drift := 999999
+	corruptEnts[0].CommunityID = &drift
+
+	corrupt := &graph.Document{Entities: corruptEnts, Relationships: corruptRels}
+
+	rep := parity.CompareWithOptions(c, corrupt, dvBaselineProfile())
+	if rep.Equivalent {
+		t.Fatal("validator FAILED to catch an injected mismatch — the safety net is not actually checking structure")
+	}
+	if len(rep.EntitiesOnlyInA) == 0 {
+		t.Errorf("expected the dropped entity to be reported as only-in-A; report:\n%s", rep.String())
+	}
+	if len(rep.RelsOnlyInB) == 0 {
+		t.Errorf("expected the re-pointed bogus edge to be reported as only-in-B; report:\n%s", rep.String())
+	}
+	if len(rep.CommunityAssignmentDiffs) == 0 {
+		t.Errorf("expected the community drift to be reported; report:\n%s", rep.String())
+	}
+	t.Logf("validator correctly caught injected mismatch:\n%s", rep.String())
+}
+
+// Case 4 — new cross-file call edge. Add a brand-new caller file that calls into
+// the existing target. The new entity AND the new cross-file CALLS edge must
+// match a full rebuild — this exercises the scoped resolver's inbound-edge
+// creation on the incremental path.
+func TestDiffReindex_NewCrossFileCall(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dvStartCorpus(t, repo)
+
+	dvFullRebuild(t, repo, stateDir)
+	dvSeedManifest(t, repo, stateDir)
+
+	// Add a second caller file that also calls Target().
+	dvWriteFile(t, repo, "caller2.go", "package svc\n\n"+
+		"func Caller2() int { return Target() * 2 }\n")
+
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	dvAssertParity(t, b, c)
+}

--- a/internal/graph/parity/parity.go
+++ b/internal/graph/parity/parity.go
@@ -1,0 +1,578 @@
+// Package parity provides a strict, order-independent structural-equivalence
+// comparator for two graph Documents — the safety net for grafel's incremental
+// reindex work (epic #5376, layer 2 #5309).
+//
+// Why this exists
+// ───────────────
+// #5309 will make grafel's graph-wide reindex phases (relationship resolution,
+// community detection, link / process-flow / event-flow passes) *incremental*
+// — scoped to the blast radius of a change instead of recomputed over the whole
+// graph on every push. That is correctness-sensitive: a wrongly-skipped
+// re-resolution silently yields a subtly incorrect graph (missing edges, stale
+// flows, drifted communities) that no test would otherwise catch.
+//
+// The differential validator asserts the load-bearing invariant:
+//
+//	an incremental reindex must produce a graph STRUCTURALLY EQUIVALENT to a
+//	full rebuild of the same end-state.
+//
+// Compare(full, incremental) returns a Report. When the graphs are structurally
+// equivalent the report is Equivalent and empty; on any mismatch it carries a
+// precise, human-readable diff (which entities / edges / community assignments
+// differ, and per-field deltas) so a future incremental bug is debuggable, not
+// just "not equal".
+//
+// Design
+// ──────
+//   - Order-independent: everything is set/map compared, never slice-index
+//     compared. Two documents that list the same entities in a different order
+//     are equivalent.
+//   - Strict on graph STRUCTURE: entity identity + structural fields,
+//     relationship (from, to, kind) + properties, and per-entity community
+//     assignment.
+//   - Tolerant of legitimately non-deterministic / cosmetic fields: see
+//     toleratedEntityField / the document-level skips below. These never affect
+//     query correctness, so requiring byte-equality on them would make the
+//     validator flaky without buying any safety.
+//
+// Flows & links: grafel models process-flows, event-flows and links as ordinary
+// entities (kinds such as `process_flow`) plus edges (`STEP_IN_PROCESS`,
+// `ENTRY_POINT_OF`, link edges). They therefore fall out of the entity/edge
+// comparison automatically — there is no separate flow collection on Document.
+//
+// This package is pure-Go, zero-dependency, and never mutates its inputs.
+package parity
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Options tunes the comparator's tolerance profile. The zero value is the
+// STRICTEST setting: every entity, edge, property and community assignment must
+// match exactly. Tolerances exist for the dimensions the incremental reindex
+// path legitimately defers TODAY (before #5309 lands per-phase incrementalism)
+// — each one is a known incremental-vs-full gap a later layer will close, not a
+// licence to ignore real graph corruption. Keep this list small and explicit.
+type Options struct {
+	// IgnoreRelKinds suppresses edges of these kinds from the relationship
+	// comparison (both presence and properties). Use for edge classes a pass
+	// the incremental path does not yet run would produce (e.g. module-aggregation
+	// CONTAINS / DEPENDS_ON edges, which #5309's link/flow layer will scope).
+	IgnoreRelKinds map[string]bool
+
+	// IgnoreEntityProps suppresses these entity Properties keys from the
+	// structural comparison. Use for enrichment-pass outputs the incremental
+	// path does not yet recompute (e.g. `module`, `test_reachable`).
+	IgnoreEntityProps map[string]bool
+
+	// IgnoreRelProps suppresses these relationship Properties keys.
+	IgnoreRelProps map[string]bool
+
+	// NormalizeStubEndpoints folds the not-yet-resolved "stub" edge endpoint
+	// form the incremental scoped-resolver can leave on a freshly-extracted
+	// cross-file edge onto the entity it names, so an edge that is structurally
+	// the same in both graphs but carries a stub id on one side still matches.
+	// This is the edge-FromID normalization gap #5309 will close in the scoped
+	// resolver; until then the validator normalizes rather than false-alarms.
+	NormalizeStubEndpoints bool
+}
+
+// Strict returns the zero-tolerance options (exact structural equality).
+func Strict() Options { return Options{} }
+
+// Report is the result of Compare. The zero value (Equivalent: true, empty
+// slices) means the two graphs are structurally identical.
+type Report struct {
+	// Equivalent is true iff the two documents are structurally equivalent.
+	Equivalent bool
+
+	// EntitiesOnlyInA / EntitiesOnlyInB list entity identities (see entityKey)
+	// present in exactly one document.
+	EntitiesOnlyInA []string
+	EntitiesOnlyInB []string
+
+	// EntityFieldDiffs lists entities present in BOTH documents whose
+	// structural fields differ, with a per-field description.
+	EntityFieldDiffs []FieldDiff
+
+	// RelsOnlyInA / RelsOnlyInB list relationship identities (from→to:kind)
+	// present in exactly one document.
+	RelsOnlyInA []string
+	RelsOnlyInB []string
+
+	// RelPropDiffs lists relationships present in both whose properties differ.
+	RelPropDiffs []FieldDiff
+
+	// CommunityAssignmentDiffs lists entities whose community_id differs between
+	// the two documents (a community split / merge / relabel that drifted).
+	CommunityAssignmentDiffs []FieldDiff
+
+	// CommunitySetDiff is non-empty when the corpus-level community membership
+	// (the set of {community → sorted member ids}) differs.
+	CommunitySetDiff []string
+}
+
+// FieldDiff describes a single divergence on an entity/relationship/community
+// that exists in both documents.
+type FieldDiff struct {
+	Key    string // the entity / relationship / entity identity this concerns
+	Detail string // human-readable description of the divergence
+}
+
+// String renders a precise, multi-line diff suitable for a test failure
+// message. It is empty when the report is Equivalent.
+func (r Report) String() string {
+	if r.Equivalent {
+		return "graphs are structurally equivalent"
+	}
+	var b strings.Builder
+	b.WriteString("graphs are NOT structurally equivalent:\n")
+
+	writeList := func(title string, items []string) {
+		if len(items) == 0 {
+			return
+		}
+		fmt.Fprintf(&b, "  %s (%d):\n", title, len(items))
+		shown := items
+		const cap = 40
+		truncated := false
+		if len(shown) > cap {
+			shown = shown[:cap]
+			truncated = true
+		}
+		for _, it := range shown {
+			fmt.Fprintf(&b, "    - %s\n", it)
+		}
+		if truncated {
+			fmt.Fprintf(&b, "    … and %d more\n", len(items)-cap)
+		}
+	}
+	writeFieldDiffs := func(title string, items []FieldDiff) {
+		if len(items) == 0 {
+			return
+		}
+		fmt.Fprintf(&b, "  %s (%d):\n", title, len(items))
+		shown := items
+		const cap = 40
+		truncated := false
+		if len(shown) > cap {
+			shown = shown[:cap]
+			truncated = true
+		}
+		for _, it := range shown {
+			fmt.Fprintf(&b, "    - %s: %s\n", it.Key, it.Detail)
+		}
+		if truncated {
+			fmt.Fprintf(&b, "    … and %d more\n", len(items)-cap)
+		}
+	}
+
+	writeList("entities only in A (full rebuild)", r.EntitiesOnlyInA)
+	writeList("entities only in B (incremental)", r.EntitiesOnlyInB)
+	writeFieldDiffs("entity field diffs", r.EntityFieldDiffs)
+	writeList("relationships only in A (full rebuild)", r.RelsOnlyInA)
+	writeList("relationships only in B (incremental)", r.RelsOnlyInB)
+	writeFieldDiffs("relationship property diffs", r.RelPropDiffs)
+	writeFieldDiffs("community assignment diffs", r.CommunityAssignmentDiffs)
+	writeList("community membership diffs", r.CommunitySetDiff)
+	return b.String()
+}
+
+// Compare returns a Report describing the strict structural equivalence of two
+// documents (no tolerances). It is a thin wrapper over CompareWithOptions with
+// Strict() options. By convention a is the reference (full rebuild) and b is
+// the candidate (incremental result). Neither argument is mutated.
+func Compare(a, b *graph.Document) Report {
+	return CompareWithOptions(a, b, Strict())
+}
+
+// CompareWithOptions is Compare with an explicit tolerance profile (see Options).
+//
+// A nil document is treated as an empty document.
+func CompareWithOptions(a, b *graph.Document, opts Options) Report {
+	if a == nil {
+		a = &graph.Document{}
+	}
+	if b == nil {
+		b = &graph.Document{}
+	}
+
+	r := Report{Equivalent: true}
+
+	compareEntities(a, b, &r, opts)
+	compareRelationships(a, b, &r, opts)
+	compareCommunities(a, b, &r)
+
+	if len(r.EntitiesOnlyInA) > 0 || len(r.EntitiesOnlyInB) > 0 ||
+		len(r.EntityFieldDiffs) > 0 ||
+		len(r.RelsOnlyInA) > 0 || len(r.RelsOnlyInB) > 0 ||
+		len(r.RelPropDiffs) > 0 ||
+		len(r.CommunityAssignmentDiffs) > 0 || len(r.CommunitySetDiff) > 0 {
+		r.Equivalent = false
+	}
+	return r
+}
+
+// ───────────────────────────── entities ─────────────────────────────
+
+// entityKey is the stable identity of an entity for set comparison. The graph's
+// own EntityID is a hash of (repo, kind, name, source_file); we key on the id
+// when present, but fold in the human-readable identity so the diff output is
+// legible and so two entities with a hash collision (astronomically unlikely)
+// still compare on their real fields.
+func entityKey(e graph.Entity) string {
+	id := e.ID
+	if id == "" {
+		id = graph.EntityID("", e.Kind, e.Name, e.SourceFile)
+	}
+	// Name is folded into the key purely for legibility of the diff output —
+	// the id already hashes (kind, name, source_file), so two entities that
+	// share a key necessarily share these fields.
+	return fmt.Sprintf("%s|%s|%s|%s|%s", id, e.Kind, e.Name, e.QualifiedName, e.SourceFile)
+}
+
+func compareEntities(a, b *graph.Document, r *Report, opts Options) {
+	mapA := make(map[string]graph.Entity, len(a.Entities))
+	for _, e := range a.Entities {
+		mapA[entityKey(e)] = e
+	}
+	mapB := make(map[string]graph.Entity, len(b.Entities))
+	for _, e := range b.Entities {
+		mapB[entityKey(e)] = e
+	}
+
+	for k, ea := range mapA {
+		eb, ok := mapB[k]
+		if !ok {
+			r.EntitiesOnlyInA = append(r.EntitiesOnlyInA, k)
+			continue
+		}
+		if diff := entityStructuralDiff(ea, eb, opts); diff != "" {
+			r.EntityFieldDiffs = append(r.EntityFieldDiffs, FieldDiff{Key: k, Detail: diff})
+		}
+	}
+	for k := range mapB {
+		if _, ok := mapA[k]; !ok {
+			r.EntitiesOnlyInB = append(r.EntitiesOnlyInB, k)
+		}
+	}
+
+	sort.Strings(r.EntitiesOnlyInA)
+	sort.Strings(r.EntitiesOnlyInB)
+	sortFieldDiffs(r.EntityFieldDiffs)
+}
+
+// entityStructuralDiff compares the structural (correctness-bearing) fields of
+// two entities with the SAME identity key and returns a description of any
+// divergence, or "" when equivalent. Tolerated / cosmetic fields (see below)
+// are intentionally NOT compared.
+//
+// NB: community_id is compared separately in compareCommunities so that a
+// community drift is reported in its own bucket rather than as a generic field
+// diff — it is the single most likely thing the incremental community phase
+// will get wrong.
+func entityStructuralDiff(a, b graph.Entity, opts Options) string {
+	var diffs []string
+	cmpStr := func(name, va, vb string) {
+		if va != vb {
+			diffs = append(diffs, fmt.Sprintf("%s %q≠%q", name, va, vb))
+		}
+	}
+	cmpInt := func(name string, va, vb int) {
+		if va != vb {
+			diffs = append(diffs, fmt.Sprintf("%s %d≠%d", name, va, vb))
+		}
+	}
+	cmpStr("name", a.Name, b.Name)
+	cmpStr("qualified_name", a.QualifiedName, b.QualifiedName)
+	cmpStr("kind", a.Kind, b.Kind)
+	cmpStr("subtype", a.Subtype, b.Subtype)
+	cmpStr("source_file", a.SourceFile, b.SourceFile)
+	cmpStr("language", a.Language, b.Language)
+	cmpStr("signature", a.Signature, b.Signature)
+	cmpInt("start_line", a.StartLine, b.StartLine)
+	cmpInt("end_line", a.EndLine, b.EndLine)
+
+	if d := stringSliceDiff("tags", a.Tags, b.Tags); d != "" {
+		diffs = append(diffs, d)
+	}
+	if d := stringMapDiff("properties", filterMap(a.Properties, opts.IgnoreEntityProps), filterMap(b.Properties, opts.IgnoreEntityProps)); d != "" {
+		diffs = append(diffs, d)
+	}
+
+	return strings.Join(diffs, "; ")
+}
+
+// ─────────────────────────── relationships ──────────────────────────
+
+func relKey(fromID, toID, kind string) string {
+	return fromID + "→" + toID + ":" + kind
+}
+
+func compareRelationships(a, b *graph.Document, r *Report, opts Options) {
+	// Build a stub→entity-id resolver over the union of both entity sets so that
+	// an un-resolved cross-file edge endpoint (the incremental scoped-resolver
+	// gap) folds onto the entity it names. No-op unless NormalizeStubEndpoints.
+	resolver := newEndpointResolver(a, b, opts)
+
+	mapA := make(map[string]graph.Relationship, len(a.Relationships))
+	for _, rel := range a.Relationships {
+		if opts.IgnoreRelKinds[rel.Kind] {
+			continue
+		}
+		mapA[relKey(resolver(rel.FromID), resolver(rel.ToID), rel.Kind)] = rel
+	}
+	mapB := make(map[string]graph.Relationship, len(b.Relationships))
+	for _, rel := range b.Relationships {
+		if opts.IgnoreRelKinds[rel.Kind] {
+			continue
+		}
+		mapB[relKey(resolver(rel.FromID), resolver(rel.ToID), rel.Kind)] = rel
+	}
+
+	for k, ra := range mapA {
+		rb, ok := mapB[k]
+		if !ok {
+			r.RelsOnlyInA = append(r.RelsOnlyInA, k)
+			continue
+		}
+		if d := stringMapDiff("properties", filterMap(ra.Properties, opts.IgnoreRelProps), filterMap(rb.Properties, opts.IgnoreRelProps)); d != "" {
+			r.RelPropDiffs = append(r.RelPropDiffs, FieldDiff{Key: k, Detail: d})
+		}
+	}
+	for k := range mapB {
+		if _, ok := mapA[k]; !ok {
+			r.RelsOnlyInB = append(r.RelsOnlyInB, k)
+		}
+	}
+
+	sort.Strings(r.RelsOnlyInA)
+	sort.Strings(r.RelsOnlyInB)
+	sortFieldDiffs(r.RelPropDiffs)
+}
+
+// ──────────────────────────── communities ───────────────────────────
+
+// compareCommunities asserts two things:
+//
+//  1. Per-entity community assignment parity: every entity present in both
+//     graphs has the same community_id. (Community IDs are integer labels; the
+//     incremental community phase must not relabel an unchanged partition.)
+//  2. Corpus membership parity: the set of {community_id → sorted member
+//     entity-keys} matches. This catches a split/merge that happens to leave
+//     most per-entity labels intact.
+//
+// Only entities present in BOTH graphs are considered for assignment parity —
+// entities that are added/removed are already reported by compareEntities, and
+// re-reporting their (necessarily different) community here would be noise.
+func compareCommunities(a, b *graph.Document, r *Report) {
+	keyA := make(map[string]graph.Entity, len(a.Entities))
+	for _, e := range a.Entities {
+		keyA[entityKey(e)] = e
+	}
+
+	for _, eb := range b.Entities {
+		k := entityKey(eb)
+		ea, ok := keyA[k]
+		if !ok {
+			continue // entity-set diff already reports this
+		}
+		ca, cb := communityLabel(ea), communityLabel(eb)
+		if ca != cb {
+			r.CommunityAssignmentDiffs = append(r.CommunityAssignmentDiffs,
+				FieldDiff{Key: k, Detail: fmt.Sprintf("community_id %s≠%s", ca, cb)})
+		}
+	}
+	sortFieldDiffs(r.CommunityAssignmentDiffs)
+
+	// Corpus membership: community label → sorted member entity-keys, over the
+	// shared entity set only (so add/remove churn doesn't masquerade as a
+	// community-detection change).
+	shared := func(d *graph.Document, other map[string]graph.Entity) map[string][]string {
+		m := make(map[string][]string)
+		for _, e := range d.Entities {
+			k := entityKey(e)
+			if _, ok := other[k]; !ok {
+				continue
+			}
+			m[communityLabel(e)] = append(m[communityLabel(e)], k)
+		}
+		for lbl := range m {
+			sort.Strings(m[lbl])
+		}
+		return m
+	}
+	keyB := make(map[string]graph.Entity, len(b.Entities))
+	for _, e := range b.Entities {
+		keyB[entityKey(e)] = e
+	}
+	memA := shared(a, keyB)
+	memB := shared(b, keyA)
+
+	labels := make(map[string]struct{})
+	for l := range memA {
+		labels[l] = struct{}{}
+	}
+	for l := range memB {
+		labels[l] = struct{}{}
+	}
+	var lbls []string
+	for l := range labels {
+		lbls = append(lbls, l)
+	}
+	sort.Strings(lbls)
+	for _, l := range lbls {
+		ma, mb := memA[l], memB[l]
+		if strings.Join(ma, ",") != strings.Join(mb, ",") {
+			r.CommunitySetDiff = append(r.CommunitySetDiff,
+				fmt.Sprintf("community %s: %d member(s) in A, %d in B", l, len(ma), len(mb)))
+		}
+	}
+}
+
+// communityLabel renders an entity's community_id as a stable string ("∅" when
+// unset / nil), so the maps above never key on a *int.
+func communityLabel(e graph.Entity) string {
+	if e.CommunityID == nil {
+		return "∅"
+	}
+	return fmt.Sprintf("%d", *e.CommunityID)
+}
+
+// ─────────────────────────── shared helpers ─────────────────────────
+
+func stringSliceDiff(name string, a, b []string) string {
+	sa := append([]string(nil), a...)
+	sb := append([]string(nil), b...)
+	sort.Strings(sa)
+	sort.Strings(sb)
+	if strings.Join(sa, ",") == strings.Join(sb, ",") {
+		return ""
+	}
+	return fmt.Sprintf("%s [%s]≠[%s]", name, strings.Join(sa, ","), strings.Join(sb, ","))
+}
+
+func stringMapDiff(name string, a, b map[string]string) string {
+	if len(a) == 0 && len(b) == 0 {
+		return ""
+	}
+	keys := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		keys[k] = struct{}{}
+	}
+	for k := range b {
+		keys[k] = struct{}{}
+	}
+	var ks []string
+	for k := range keys {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	var parts []string
+	for _, k := range ks {
+		va, oka := a[k]
+		vb, okb := b[k]
+		switch {
+		case oka && !okb:
+			parts = append(parts, fmt.Sprintf("-%s=%q", k, va))
+		case !oka && okb:
+			parts = append(parts, fmt.Sprintf("+%s=%q", k, vb))
+		case va != vb:
+			parts = append(parts, fmt.Sprintf("%s %q≠%q", k, va, vb))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s {%s}", name, strings.Join(parts, ", "))
+}
+
+func sortFieldDiffs(d []FieldDiff) {
+	sort.Slice(d, func(i, j int) bool { return d[i].Key < d[j].Key })
+}
+
+// filterMap returns a copy of m with any keys present in drop removed. Returns
+// m unchanged when drop is empty (the common strict path).
+func filterMap(m map[string]string, drop map[string]bool) map[string]string {
+	if len(drop) == 0 || len(m) == 0 {
+		return m
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if !drop[k] {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// newEndpointResolver returns a function that maps a relationship endpoint id to
+// a canonical entity id. When NormalizeStubEndpoints is off it is the identity.
+// When on, an endpoint that is NOT a known 16-hex entity id is treated as a
+// "stub" of the form "...:<EntityName>" (the form the incremental scoped
+// resolver can leave on a freshly-extracted cross-file edge); its final
+// colon-segment is resolved via a name→id index built over BOTH entity sets, so
+// the same logical edge matches regardless of which side resolved it.
+func newEndpointResolver(a, b *graph.Document, opts Options) func(string) string {
+	if !opts.NormalizeStubEndpoints {
+		return func(s string) string { return s }
+	}
+	nameToID := make(map[string]string)
+	add := func(e graph.Entity) {
+		if e.ID == "" {
+			return
+		}
+		if e.Name != "" {
+			// First writer wins; collisions across files are rare for the tiny
+			// fixtures this targets, and a collision only weakens normalization
+			// (it can't manufacture a false match that strict structure misses).
+			if _, ok := nameToID[e.Name]; !ok {
+				nameToID[e.Name] = e.ID
+			}
+		}
+		if e.QualifiedName != "" {
+			if _, ok := nameToID[e.QualifiedName]; !ok {
+				nameToID[e.QualifiedName] = e.ID
+			}
+		}
+	}
+	for _, e := range a.Entities {
+		add(e)
+	}
+	for _, e := range b.Entities {
+		add(e)
+	}
+	return func(s string) string {
+		if isHexID(s) {
+			return s
+		}
+		// Try the whole string, then its final colon-segment (the entity name
+		// in a "scope:operation:...:Name" stub).
+		if id, ok := nameToID[s]; ok {
+			return id
+		}
+		if i := strings.LastIndex(s, ":"); i >= 0 && i+1 < len(s) {
+			if id, ok := nameToID[s[i+1:]]; ok {
+				return id
+			}
+		}
+		return s
+	}
+}
+
+// isHexID reports whether s is a 16-char lowercase-hex grafel entity id.
+func isHexID(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/graph/parity/parity_test.go
+++ b/internal/graph/parity/parity_test.go
@@ -1,0 +1,241 @@
+package parity
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// ent is a tiny helper for building a structurally-complete entity.
+func ent(kind, name, file string) graph.Entity {
+	return graph.Entity{
+		ID:         graph.EntityID("repo", kind, name, file),
+		Name:       name,
+		Kind:       kind,
+		SourceFile: file,
+		Language:   "go",
+	}
+}
+
+func ci(v int) *int { return &v }
+
+func TestCompare_IdenticalGraphsAreEquivalent(t *testing.T) {
+	a := &graph.Document{
+		Entities: []graph.Entity{
+			ent("SCOPE.Operation", "Alpha", "a.go"),
+			ent("SCOPE.Operation", "Beta", "b.go"),
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "x", ToID: "y", Kind: "CALLS"},
+		},
+	}
+	// b is the same entities/edges in a DIFFERENT order — must still be equivalent.
+	b := &graph.Document{
+		Entities: []graph.Entity{
+			ent("SCOPE.Operation", "Beta", "b.go"),
+			ent("SCOPE.Operation", "Alpha", "a.go"),
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "x", ToID: "y", Kind: "CALLS"},
+		},
+	}
+	rep := Compare(a, b)
+	if !rep.Equivalent {
+		t.Fatalf("expected equivalent, got:\n%s", rep.String())
+	}
+}
+
+// TestCompare_TimestampToleranceOnly verifies the comparator ignores the
+// non-deterministic document-level GeneratedAt while staying strict on
+// structure.
+func TestCompare_TimestampToleranceOnly(t *testing.T) {
+	a := &graph.Document{
+		GeneratedAt: mustTime("2024-01-01T00:00:00Z"),
+		Entities:    []graph.Entity{ent("SCOPE.Operation", "Alpha", "a.go")},
+	}
+	b := &graph.Document{
+		GeneratedAt: mustTime("2025-06-25T12:34:56Z"),
+		Entities:    []graph.Entity{ent("SCOPE.Operation", "Alpha", "a.go")},
+	}
+	if rep := Compare(a, b); !rep.Equivalent {
+		t.Fatalf("timestamps must be tolerated; got:\n%s", rep.String())
+	}
+}
+
+func TestCompare_DetectsEntityOnlyInOneSide(t *testing.T) {
+	a := &graph.Document{Entities: []graph.Entity{
+		ent("SCOPE.Operation", "Alpha", "a.go"),
+		ent("SCOPE.Operation", "Gone", "g.go"),
+	}}
+	b := &graph.Document{Entities: []graph.Entity{
+		ent("SCOPE.Operation", "Alpha", "a.go"),
+	}}
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("expected NOT equivalent (missing entity)")
+	}
+	if len(rep.EntitiesOnlyInA) != 1 {
+		t.Fatalf("EntitiesOnlyInA=%v want 1", rep.EntitiesOnlyInA)
+	}
+	if !strings.Contains(rep.EntitiesOnlyInA[0], "Gone") {
+		t.Errorf("diff should name the missing entity, got %q", rep.EntitiesOnlyInA[0])
+	}
+}
+
+func TestCompare_DetectsEntityFieldDrift(t *testing.T) {
+	base := ent("SCOPE.Operation", "Alpha", "a.go")
+	drifted := base
+	drifted.Signature = "func Alpha(x int)" // same identity, changed signature
+	a := &graph.Document{Entities: []graph.Entity{base}}
+	b := &graph.Document{Entities: []graph.Entity{drifted}}
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("expected NOT equivalent (signature drift)")
+	}
+	if len(rep.EntityFieldDiffs) != 1 || !strings.Contains(rep.EntityFieldDiffs[0].Detail, "signature") {
+		t.Fatalf("expected a signature field diff, got %+v", rep.EntityFieldDiffs)
+	}
+}
+
+func TestCompare_DetectsRelationshipDrift(t *testing.T) {
+	a := &graph.Document{Relationships: []graph.Relationship{
+		{FromID: "x", ToID: "y", Kind: "CALLS"},
+		{FromID: "x", ToID: "z", Kind: "CALLS"}, // only in A
+	}}
+	b := &graph.Document{Relationships: []graph.Relationship{
+		{FromID: "x", ToID: "y", Kind: "CALLS"},
+		{FromID: "x", ToID: "w", Kind: "CALLS"}, // only in B
+	}}
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("expected NOT equivalent (edge set differs)")
+	}
+	if len(rep.RelsOnlyInA) != 1 || len(rep.RelsOnlyInB) != 1 {
+		t.Fatalf("RelsOnlyInA=%v RelsOnlyInB=%v want 1/1", rep.RelsOnlyInA, rep.RelsOnlyInB)
+	}
+}
+
+func TestCompare_DetectsRelationshipPropertyDrift(t *testing.T) {
+	a := &graph.Document{Relationships: []graph.Relationship{
+		{FromID: "x", ToID: "y", Kind: "CALLS", Properties: map[string]string{"callsite_count": "1"}},
+	}}
+	b := &graph.Document{Relationships: []graph.Relationship{
+		{FromID: "x", ToID: "y", Kind: "CALLS", Properties: map[string]string{"callsite_count": "2"}},
+	}}
+	rep := Compare(a, b)
+	if rep.Equivalent || len(rep.RelPropDiffs) != 1 {
+		t.Fatalf("expected one rel property diff, got equivalent=%v diffs=%+v", rep.Equivalent, rep.RelPropDiffs)
+	}
+}
+
+// TestCompare_DetectsCommunityDrift is the headline case for #5309: the entity
+// set and edge set are identical, but the incremental community phase relabelled
+// a partition. The comparator must catch this in its dedicated bucket.
+func TestCompare_DetectsCommunityDrift(t *testing.T) {
+	e := ent("SCOPE.Operation", "Alpha", "a.go")
+	ea, eb := e, e
+	ea.CommunityID = ci(3)
+	eb.CommunityID = ci(7) // drifted assignment
+	a := &graph.Document{Entities: []graph.Entity{ea}}
+	b := &graph.Document{Entities: []graph.Entity{eb}}
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("expected NOT equivalent (community drift)")
+	}
+	if len(rep.CommunityAssignmentDiffs) != 1 {
+		t.Fatalf("expected one community assignment diff, got %+v", rep.CommunityAssignmentDiffs)
+	}
+	if len(rep.CommunitySetDiff) == 0 {
+		t.Error("expected a corpus community membership diff too")
+	}
+}
+
+func TestCompare_SameCommunityIsEquivalent(t *testing.T) {
+	e := ent("SCOPE.Operation", "Alpha", "a.go")
+	ea, eb := e, e
+	ea.CommunityID = ci(5)
+	eb.CommunityID = ci(5)
+	a := &graph.Document{Entities: []graph.Entity{ea}}
+	b := &graph.Document{Entities: []graph.Entity{eb}}
+	if rep := Compare(a, b); !rep.Equivalent {
+		t.Fatalf("identical community assignment must be equivalent, got:\n%s", rep.String())
+	}
+}
+
+// TestCompareWithOptions_TolerancesNarrowlyApply verifies each tolerance knob
+// suppresses exactly its target dimension and nothing else.
+func TestCompareWithOptions_TolerancesNarrowlyApply(t *testing.T) {
+	// Ignored relationship kind: a CONTAINS edge present only in A is tolerated,
+	// but a CALLS edge only in A is still caught.
+	a := &graph.Document{Relationships: []graph.Relationship{
+		{FromID: "m", ToID: "x", Kind: "CONTAINS"},
+		{FromID: "x", ToID: "y", Kind: "CALLS"},
+	}}
+	b := &graph.Document{Relationships: []graph.Relationship{
+		{FromID: "x", ToID: "y", Kind: "CALLS"},
+	}}
+	opts := Options{IgnoreRelKinds: map[string]bool{"CONTAINS": true}}
+	if rep := CompareWithOptions(a, b, opts); !rep.Equivalent {
+		t.Fatalf("CONTAINS should be tolerated:\n%s", rep.String())
+	}
+	// Now make the CALLS edge diverge too — must be caught even with the tolerance.
+	b.Relationships = nil
+	if rep := CompareWithOptions(a, b, opts); rep.Equivalent {
+		t.Fatal("a missing CALLS edge must still be caught under a CONTAINS tolerance")
+	}
+
+	// Ignored entity property: `module` drift tolerated, `kind` still strict.
+	ea := ent("SCOPE.Operation", "Alpha", "a.go")
+	eb := ea
+	ea.Properties = map[string]string{"module": "core"}
+	eb.Properties = map[string]string{"module": "api"}
+	da := &graph.Document{Entities: []graph.Entity{ea}}
+	db := &graph.Document{Entities: []graph.Entity{eb}}
+	popts := Options{IgnoreEntityProps: map[string]bool{"module": true}}
+	if rep := CompareWithOptions(da, db, popts); !rep.Equivalent {
+		t.Fatalf("module property drift should be tolerated:\n%s", rep.String())
+	}
+}
+
+// TestCompareWithOptions_NormalizeStubEndpoints folds an un-resolved stub
+// endpoint onto the entity it names so a structurally-identical edge matches.
+func TestCompareWithOptions_NormalizeStubEndpoints(t *testing.T) {
+	target := ent("SCOPE.Operation", "Target", "t.go")
+	caller := ent("SCOPE.Operation", "Caller", "c.go")
+	// Full rebuild: edge uses resolved hashed ids.
+	a := &graph.Document{
+		Entities:      []graph.Entity{target, caller},
+		Relationships: []graph.Relationship{{FromID: caller.ID, ToID: target.ID, Kind: "CALLS"}},
+	}
+	// Incremental: same edge, but FromID left as a stub naming the caller.
+	b := &graph.Document{
+		Entities:      []graph.Entity{target, caller},
+		Relationships: []graph.Relationship{{FromID: "scope:operation:method:go:c.go:Caller", ToID: target.ID, Kind: "CALLS"}},
+	}
+	if rep := Compare(a, b); rep.Equivalent {
+		t.Fatal("strict compare should see the stub vs hashed FromID as different edges")
+	}
+	if rep := CompareWithOptions(a, b, Options{NormalizeStubEndpoints: true}); !rep.Equivalent {
+		t.Fatalf("stub endpoint should normalize to the named entity:\n%s", rep.String())
+	}
+}
+
+func TestReport_StringIsEmptyish_WhenEquivalent(t *testing.T) {
+	rep := Compare(&graph.Document{}, &graph.Document{})
+	if !rep.Equivalent {
+		t.Fatal("two empty docs must be equivalent")
+	}
+	if !strings.Contains(rep.String(), "equivalent") {
+		t.Errorf("String() = %q", rep.String())
+	}
+}


### PR DESCRIPTION
## Differential-reindex validator harness — #5309 foundation

#5309 (epic #5376) will make the graph-wide reindex phases (relationship resolution, community detection, link/process-flow passes) **incremental — scoped to the blast radius of a change** instead of recomputed over the whole graph on every push. That is correctness-sensitive: a wrongly-skipped re-resolution silently yields a subtly incorrect graph (missing edges, stale flows, drifted communities) that no existing test catches.

Before any incremental code, this PR builds the **safety net**: a harness that asserts an **incremental reindex produces a graph structurally equivalent to a full rebuild of the same end-state**. **No incremental behaviour changes here** — validator + baseline only.

### What's in it

**`internal/graph/parity` — the comparator**
- `Compare(a, b)` / `CompareWithOptions(a, b, opts)` — order-independent, set/map-based structural equivalence over:
  - **entities** keyed by stable id + (kind, name, qualified-name, source-file), comparing structural fields (kind/subtype/name/qname/source/lang/signature/lines/sorted-tags/properties);
  - **relationships** keyed by (from, to, kind) + sorted properties;
  - **per-entity + corpus-level community assignments** (the thing the incremental community phase is most likely to get wrong).
- Flows/links need no special handling — they're modelled as entities (`process_flow`, …) + edges (`STEP_IN_PROCESS`, `ENTRY_POINT_OF`, links), so they fall out of the entity/edge comparison.
- **Tolerant** of legitimately non-deterministic fields (timestamps); **strict** on structure. Emits a precise, multi-line diff on mismatch (only-in-A / only-in-B / per-field deltas) so a future incremental bug is debuggable, not just "not equal".
- An explicit `Options` tolerance profile captures the **known incremental-vs-full gaps that exist today**, each tagged for a later #5309 layer to close (and then remove the tolerance, tightening the validator). The zero value is strict.

**`cmd/grafel` — the differential harness + delta cases**
- Per case: full-rebuild start-state → **A**; apply a source change, incremental-reindex → **B**; full-rebuild the changed corpus from scratch → **C**; assert **B ≡ C** via the comparator.
- Baseline delta cases (the tricky ones from #5309): **rename across files**, **deleted entity with inbound edges**, **signature change rippling to callers**, **new cross-file call**.
- A **self-check** that the validator FAILS on a deliberately-injected mismatch (dropped entity + re-pointed bogus edge + drifted community) — proving the safety net actually checks structure and the tolerances don't mask real corruption.

### Why the baseline holds today (and what it surfaced)
Running the harness with the strict profile surfaced the real, expected gaps between today's incremental path and a full rebuild: the incremental path defers the module-aggregation pass (CONTAINS/DEPENDS_ON edges + `module`/`test_reachable` properties) and the scoped resolver can leave a freshly-extracted cross-file edge endpoint in stub form. These are exactly the dimensions the upcoming #5309 layers will make incremental; the documented tolerance profile normalizes them now so the baseline locks in green, while staying strict on the entity set, resolved call/reference edges, and communities. As each layer lands, its tolerance is removed and the validator tightens.

### Verify
- `go build ./...` clean.
- `go test ./internal/graph/parity/` and the new harness in `cmd/grafel` green.
- The injected-mismatch self-check confirms the comparator FAILS on a wrong graph.
- `gofmt -l` clean.

### Next (each gated by this validator)
incremental resolution → incremental communities → incremental link/flow passes.
