### PR TITLE
feat(reindex): incremental resolution parity — scoped re-resolve closes stub gap (#5309 layer 1)

### DIFF
--- a/cmd/grafel/diff_reindex_validator_test.go
+++ b/cmd/grafel/diff_reindex_validator_test.go
@@ -140,14 +140,18 @@ func dvIncremental(t *testing.T, repo, stateDir string) *graph.Document {
 //     does not re-run the module-agg pass (#5309 link/flow layer).
 //   - enrichment-only entity properties (`module`, `test_reachable`): produced
 //     by passes the incremental path defers (module-agg + test-reachability).
-//   - un-resolved cross-file edge endpoints: the incremental scoped resolver can
-//     leave a freshly-extracted edge's endpoint in stub form rather than the
-//     hashed entity id the full resolver assigns (#5309 resolution layer).
+//
+// RESOLUTION PARITY — closed (#5309 layer 1). The scoped resolver previously
+// left a freshly-extracted edge's endpoint in stub form rather than the hashed
+// entity id the full resolver assigns; the validator normalized it via
+// NormalizeStubEndpoints. The scoped resolver now re-resolves the full blast
+// radius (both endpoints of every affected edge) via the same Format A ladder
+// the full resolver uses, so that tolerance is removed — the harness asserts
+// STRICT resolution parity on resolved call/reference endpoints.
 func dvBaselineProfile() parity.Options {
 	return parity.Options{
-		IgnoreRelKinds:         map[string]bool{"CONTAINS": true, "DEPENDS_ON": true},
-		IgnoreEntityProps:      map[string]bool{"module": true, "test_reachable": true},
-		NormalizeStubEndpoints: true,
+		IgnoreRelKinds:    map[string]bool{"CONTAINS": true, "DEPENDS_ON": true},
+		IgnoreEntityProps: map[string]bool{"module": true, "test_reachable": true},
 	}
 }
 

--- a/internal/extractors/sresolver/scoped.go
+++ b/internal/extractors/sresolver/scoped.go
@@ -33,9 +33,51 @@ package sresolver
 
 import (
 	"log"
+	"strings"
 
 	"github.com/cajasmota/grafel/internal/graph"
 )
+
+// Format A structural-ref stub constants — kept in lockstep with the canonical
+// definitions in internal/resolve (refs.go: stubPrefixScope / stubDelim /
+// stubScopeSegments / stubScopeFileIndex / stubScopeTailIndex / stubMemberDelim).
+// They are duplicated here rather than imported because internal/resolve is a
+// heavy package whose test suite imports internal/extractors; this package is
+// deliberately kept light (see the package doc). The values are stable wire
+// format, asserted against the resolver in scoped_test.go.
+const (
+	stubPrefixScope    = "scope:"
+	stubDelim          = ":"
+	stubMemberDelim    = '#'
+	stubScopeSegments  = 6
+	stubScopeFileIndex = 4
+	stubScopeTailIndex = 5
+)
+
+// splitFormatAStructuralRef parses a Format A structural-ref stub
+// (`scope:<kind>:<subtype>:<lang>:<file>:<name>`) into its file path and bare
+// tail name. Returns ok=false for shapes that are not a 6-segment Format A stub
+// or whose tail carries the Format B member delimiter `#`. Mirrors
+// internal/resolve/imports.go:splitFormatAStructuralRef so the scoped resolver
+// binds the same stubs the full resolver does.
+func splitFormatAStructuralRef(stub string) (filePath, name string, ok bool) {
+	if !strings.HasPrefix(stub, stubPrefixScope) {
+		return "", "", false
+	}
+	parts := strings.SplitN(stub, stubDelim, stubScopeSegments)
+	if len(parts) != stubScopeSegments {
+		return "", "", false
+	}
+	filePath = parts[stubScopeFileIndex]
+	tail := parts[stubScopeTailIndex]
+	if filePath == "" || tail == "" {
+		return "", "", false
+	}
+	if strings.IndexByte(tail, stubMemberDelim) >= 0 {
+		return "", "", false
+	}
+	return filePath, tail, true
+}
 
 // ScopedResult is the output of ResolveScoped.
 type ScopedResult struct {
@@ -118,38 +160,75 @@ func ResolveScoped(
 
 	// Build name → ID index: existing first, then new (new entities win on conflict).
 	nameToID := make(map[string]string, len(newEntities)+len(existingEntities))
-	for _, e := range existingEntities {
-		if e.Name != "" {
-			nameToID[e.Name] = e.ID
-		}
-		if e.QualifiedName != "" {
-			nameToID[e.QualifiedName] = e.ID
+	// Build a (file, name) → ID location index so a Format A structural stub
+	// (`scope:operation:method:<lang>:<file>:<name>`) binds to a SAME-FILE callee
+	// first — mirroring the full resolver's byLocation tier — before falling back
+	// to the unique bare-name index. byLocation[file][name] holds "" as an
+	// ambiguity sentinel when two entities in the same file share a name.
+	byLocation := make(map[string]map[string]string)
+	addName := func(name, id string) {
+		if name != "" {
+			nameToID[name] = id
 		}
 	}
+	addLocation := func(e graph.Entity) {
+		if e.SourceFile == "" || e.Name == "" {
+			return
+		}
+		bucket := byLocation[e.SourceFile]
+		if bucket == nil {
+			bucket = make(map[string]string)
+			byLocation[e.SourceFile] = bucket
+		}
+		if prev, seen := bucket[e.Name]; seen && prev != e.ID {
+			bucket[e.Name] = "" // ambiguous within the file
+		} else {
+			bucket[e.Name] = e.ID
+		}
+	}
+	for _, e := range existingEntities {
+		addName(e.Name, e.ID)
+		addName(e.QualifiedName, e.ID)
+		addLocation(e)
+	}
 	for _, e := range newEntities {
-		if e.Name != "" {
-			nameToID[e.Name] = e.ID
+		addName(e.Name, e.ID)
+		addName(e.QualifiedName, e.ID)
+		addLocation(e)
+	}
+
+	// resolveStub maps a non-hex relationship endpoint to a canonical entity ID,
+	// returning ok=false when it cannot be bound (the stub is then left verbatim,
+	// exactly as the full resolver leaves an unresolved structural ref). The ladder
+	// mirrors internal/resolve/refs.go:lookupStructural for Format A stubs:
+	//   1. whole-string name / qualified-name match (handles bare-name stubs);
+	//   2. Format A (file, tail): same-file byLocation, then unique bare-name.
+	resolveStub := func(stub string) (string, bool) {
+		if id, ok := nameToID[stub]; ok && id != "" {
+			return id, true
 		}
-		if e.QualifiedName != "" {
-			nameToID[e.QualifiedName] = e.ID
+		file, tail, ok := splitFormatAStructuralRef(stub)
+		if !ok {
+			return "", false
 		}
+		if bucket, ok := byLocation[file]; ok {
+			if id, ok := bucket[tail]; ok {
+				if id == "" {
+					return "", false // ambiguous within the file → leave verbatim
+				}
+				return id, true
+			}
+		}
+		if id, ok := nameToID[tail]; ok && id != "" {
+			return id, true
+		}
+		return "", false
 	}
 
 	// Build source-file set for re-extracted files (for safety-net check).
 	newFileSet := make(map[string]bool, len(newEntities))
 	for _, e := range newEntities {
 		newFileSet[e.SourceFile] = true
-	}
-
-	// Build name set for newly extracted entities (for inbound-fixup).
-	newEntityByName := make(map[string]graph.Entity, len(newEntities))
-	for _, e := range newEntities {
-		if e.Name != "" {
-			newEntityByName[e.Name] = e
-		}
-		if e.QualifiedName != "" {
-			newEntityByName[e.QualifiedName] = e
-		}
 	}
 
 	// Build set of signature-changed entity IDs for fast lookup (#2170).
@@ -164,15 +243,30 @@ func ResolveScoped(
 		newEntityByID[e.ID] = e
 	}
 
-	// Step 1: resolve stub ToIDs in newRels.
+	// Step 1: resolve stub endpoints in newRels. The full resolver rewrites BOTH
+	// the from- and to-side of every edge (refs.go logs `from: rw=N to: rw=N`);
+	// the scoped pass must too, or an outbound edge from a freshly-extracted
+	// entity is left with a stub FromID (e.g. a class→method CONTAINS edge, or a
+	// caller whose own structural-ref the extractor emits) that a full rebuild
+	// resolves to the hashed id (#5309 resolution parity).
 	resolvedNewRels := make([]graph.Relationship, 0, len(newRels))
 	for _, r := range newRels {
-		if !isHexID(r.ToID) {
-			if resolved, ok := nameToID[r.ToID]; ok {
-				r.ToID = resolved
-				r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
+		changed := false
+		if !isHexID(r.FromID) {
+			if resolved, ok := resolveStub(r.FromID); ok {
+				r.FromID = resolved
+				changed = true
 			}
-			// Unresolved stubs are kept as-is — same behaviour as the full resolver.
+		}
+		if !isHexID(r.ToID) {
+			if resolved, ok := resolveStub(r.ToID); ok {
+				r.ToID = resolved
+				changed = true
+			}
+		}
+		// Unresolved stubs are kept as-is — same behaviour as the full resolver.
+		if changed {
+			r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
 		}
 		resolvedNewRels = append(resolvedNewRels, r)
 	}
@@ -184,9 +278,12 @@ func ResolveScoped(
 	updatedExistingRels := make([]graph.Relationship, 0, len(existingRels))
 	for _, r := range existingRels {
 		if !isHexID(r.ToID) {
-			if newE, ok := newEntityByName[r.ToID]; ok {
-				// Update to the new entity's ID.
-				r.ToID = newE.ID
+			if resolved, ok := resolveStub(r.ToID); ok {
+				// Bind the inbound stub to the (possibly re-keyed) entity ID via
+				// the same Format A ladder the full resolver uses, so a cross-file
+				// edge from a surviving file is never left in stub form when a
+				// full rebuild would resolve it (#5309 resolution parity).
+				r.ToID = resolved
 				r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
 				inboundFixed++
 			} else if newFileSet[r.ToID] {


### PR DESCRIPTION
## What

Layer 1 of the incremental graph-wide reindex work (#5309): make the incremental **resolution** phase produce the same resolved edges as a full rebuild.

The differential-reindex validator (the parity harness) found the scoped/incremental resolver leaves cross-file edge endpoints in **stub form** (`scope:operation:method:<lang>:<file>:<name>`) where a full rebuild resolves them to the hashed entity id — a real correctness divergence that a one-line push would otherwise bake into the graph.

## The gap

Surfaced by running the harness with strict resolution:

1. The scoped pass matched a stub only against the **whole-string** name index, so a 6-segment Format A structural-ref (the form extractors emit for call/contains targets) never bound.
2. The scoped pass rewrote only the **to-side** of an edge; the full resolver rewrites **both** endpoints, so an outbound edge from a freshly-extracted entity kept a stub **FromID**.

## The fix

In the scoped resolver:

- Add a Format A stub parser + a `(file, name)` location index, and a `resolveStub` ladder that mirrors the full resolver's `lookupStructural`: whole-string name → same-file `byLocation[file][tail]` (with an ambiguity sentinel) → unique bare-name. Built only over the changed ∪ surviving entities, so it stays **blast-radius scoped** — no whole-graph re-resolve; correctly-resolved unchanged edges are untouched.
- Resolve **both** FromID and ToID on new edges; resolve inbound stubs from surviving files through the same ladder. The deleted-entity safety-net fallback is preserved.

## Proof of parity

Removed the resolution/stub tolerance (`NormalizeStubEndpoints`) from the validator's baseline profile so the harness now asserts **strict resolution parity**. All four delta cases pass strict:

- rename across files
- deleted entity with inbound edges
- signature change rippling to callers
- new cross-file call

The injected-mismatch self-check still fails as designed. The module-aggregation (`CONTAINS`/`DEPENDS_ON`) and enrichment-property tolerances remain for the next layer.

## Verify

- `go build ./...`
- `go test ./internal/resolve/... ./internal/graph/parity/... ./internal/extractors/... ./cmd/grafel/ -run DiffReindex` — green
- existing resolution + incremental (incl. golden semantic-equivalence) tests — green
- `gofmt -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)