### PR TITLE
feat(reindex): incremental module-aggregation parity (#5309 layer 2)

### DIFF
--- a/cmd/grafel/diff_reindex_validator_test.go
+++ b/cmd/grafel/diff_reindex_validator_test.go
@@ -23,11 +23,12 @@
 // rebuild of the end-state would — i.e. the incremental skip logic never drops
 // or staleifies anything a full rebuild would have computed.
 //
-// These cases pass TODAY: the graph-wide phases are still full in both the
-// incremental and the full path, so B and C already agree. That is precisely
-// the point — this PR locks in the baseline so #5309's per-phase incrementalism
-// cannot regress equivalence silently. Each future layer (resolution →
-// communities → flows) lands behind these same assertions.
+// These cases lock in the invariant as #5309 makes the graph-wide phases
+// incremental one layer at a time: resolution (layer 1) and module-aggregation +
+// enrichment (layer 2) are now blast-radius-scoped on the incremental path yet
+// still land on the same graph a full rebuild computes, so B and C agree under a
+// now-EMPTY tolerance profile (see dvBaselineProfile). Remaining graph-wide
+// phases (communities, link/flow passes) land behind these same assertions.
 package main
 
 import (
@@ -126,33 +127,30 @@ func dvIncremental(t *testing.T, repo, stateDir string) *graph.Document {
 	return doc
 }
 
-// dvBaselineProfile is the tolerance profile that captures the KNOWN
-// incremental-vs-full gaps that exist TODAY, before #5309 makes the graph-wide
-// phases incremental. Each tolerance is a documented gap a later layer of #5309
-// will close; until then the validator normalizes it rather than false-alarming,
-// while staying strict on everything else (entity set, resolved call/reference
-// edges, communities). As each layer lands, the corresponding tolerance is
-// removed and the validator tightens — that is how this harness ratchets the
-// incremental path toward full-rebuild parity.
+// dvBaselineProfile is the tolerance profile for the incremental-vs-full
+// comparison. It is now EMPTY: every documented #5309 gap has been closed, so
+// the validator asserts STRICT parity on every dimension (entity set, resolved
+// call/reference edges, communities, module-aggregation edges, and all
+// enrichment properties). As each layer of #5309 landed, the corresponding
+// tolerance was removed and the validator tightened — this empty profile is the
+// end state of that ratchet for the dimensions exercised here.
 //
-// The gaps, surfaced empirically by running the harness with Strict():
-//   - module-aggregation edges (CONTAINS / DEPENDS_ON): the incremental path
-//     does not re-run the module-agg pass (#5309 link/flow layer).
-//   - enrichment-only entity properties (`module`, `test_reachable`): produced
-//     by passes the incremental path defers (module-agg + test-reachability).
-//
-// RESOLUTION PARITY — closed (#5309 layer 1). The scoped resolver previously
-// left a freshly-extracted edge's endpoint in stub form rather than the hashed
-// entity id the full resolver assigns; the validator normalized it via
-// NormalizeStubEndpoints. The scoped resolver now re-resolves the full blast
-// radius (both endpoints of every affected edge) via the same Format A ladder
-// the full resolver uses, so that tolerance is removed — the harness asserts
-// STRICT resolution parity on resolved call/reference endpoints.
+// History of the closed tolerances:
+//   - RESOLUTION PARITY — closed (#5309 layer 1). The scoped resolver now
+//     re-resolves the full blast radius (both endpoints of every affected edge)
+//     via the same Format A ladder the full resolver uses, so resolved
+//     call/reference endpoints match a full rebuild exactly.
+//   - MODULE-AGGREGATION + ENRICHMENT — closed (#5309 layer 2). The incremental
+//     path now re-runs module-aggregation scoped to the affected modules
+//     (module.AggregateIncremental → the same CONTAINS / DEPENDS_ON edges +
+//     `module` labels a full rebuild emits), plus the structural-coupling and
+//     static test-reachability re-stamps (`ca`/`ce`/`instability`/
+//     `coupling_computed`, `test_reachable`/`reaching_tests`/`reach_depth`), so
+//     those edges and properties match too. The previously-tolerated
+//     IgnoreRelKinds{CONTAINS,DEPENDS_ON} and IgnoreEntityProps{module,
+//     test_reachable} are removed.
 func dvBaselineProfile() parity.Options {
-	return parity.Options{
-		IgnoreRelKinds:    map[string]bool{"CONTAINS": true, "DEPENDS_ON": true},
-		IgnoreEntityProps: map[string]bool{"module": true, "test_reachable": true},
-	}
+	return parity.Options{}
 }
 
 // dvAssertParity runs the comparator under the baseline tolerance profile and

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -56,12 +56,16 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/classifier"
+	"github.com/cajasmota/grafel/internal/coverage"
+	"github.com/cajasmota/grafel/internal/engine"
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/extractors/sresolver"
 	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
+	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/module"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -295,12 +299,19 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	// Collect entity IDs sourced from changed files so we can also prune
-	// their outbound relationships.
+	// their outbound relationships. Capture each removed entity's module key
+	// too (#5309 layer 2): a fully-deleted file leaves no replacement entity in
+	// newEntities, so its module would otherwise be invisible to the
+	// affected-module set and its stale CONTAINS edges would survive.
 	removedEntityIDs := make(map[string]bool)
+	removedModuleKeys := make(map[module.ModuleKey]struct{})
 	filteredEntities := doc.Entities[:0]
 	for _, e := range doc.Entities {
 		if changedSet[e.SourceFile] {
 			removedEntityIDs[e.ID] = true
+			if e.Kind != module.KindModule {
+				removedModuleKeys[entityModuleKey(&e, doc.Repo)] = struct{}{}
+			}
 		} else {
 			filteredEntities = append(filteredEntities, e)
 		}
@@ -435,9 +446,53 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 	newRels = scopedResult.NewRelationships
 
+	// --- Step 7a: stamp Properties["module"] on new entities (#5309 layer 2) ---
+	// The full-rebuild path stamps every sourced entity with a deterministic
+	// module label (cmd/grafel/index.go buildDocument) BEFORE the module-agg
+	// pass. The incremental path's entityRecordToGraphEntity carries only the
+	// extractor-supplied properties, so freshly extracted entities arrive with
+	// no "module" key. Stamp them here using the SAME label rule the full path
+	// uses — single-module label for a plain repo, else the path-rollup over the
+	// package-boundary markers — so the module layer rebuilt below is
+	// byte-equivalent to a full rebuild. (Surviving entities keep the label they
+	// were stamped with on the previous build.)
+	stampModuleOnEntities(newEntities, doc, absRepo, allFiles)
+
 	// --- Step 8: merge + sort + write ---
 	doc.Entities = append(doc.Entities, newEntities...)
 	doc.Relationships = append(doc.Relationships, newRels...)
+
+	// --- Step 8a: incremental module-aggregation (#5309 layer 2) ─────────────
+	// The full path runs module.Aggregate (CONTAINS / DEPENDS_ON + Module nodes)
+	// as Pass 8 over the finalized graph. The incremental path carries the prior
+	// build's module layer forward in doc, which a file change leaves stale:
+	// CONTAINS edges to removed entities, Module nodes whose members vanished,
+	// DEPENDS_ON weights that moved. Re-run the aggregation scoped to the modules
+	// whose membership or cross-module dependencies changed — every other
+	// module's nodes/edges are preserved verbatim. The result is byte-equivalent
+	// to a full rebuild's module layer without re-aggregating the whole graph.
+	affectedModules := affectedModuleSet(doc, removedModuleKeys, newEntities, newRels)
+	module.AggregateIncremental(doc, affectedModules)
+
+	// --- Step 8a': structural coupling re-stamp (#5309 layer 2) ──────────────
+	// The full path's Pass 8.6 (engine.ApplyStructuralCoupling) annotates each
+	// Module node with afferent/efferent coupling + instability derived from the
+	// DEPENDS_ON edges module-agg just (re)emitted. It is bounded by the module
+	// count (not the entity count) and is a pure function of the module graph, so
+	// re-running it over the corrected DEPENDS_ON set lands the same ca/ce/
+	// instability/coupling_computed properties a full rebuild would — without
+	// which freshly re-emitted Module nodes would carry no coupling props and
+	// survivors could carry stale ones.
+	engine.ApplyStructuralCoupling(doc)
+
+	// --- Step 8b: static test-reachability re-stamp (#5309 layer 2) ──────────
+	// coverage.Enrich's reachability sub-pass stamps test_reachable /
+	// reaching_tests / reach_depth onto production entities from the in-graph
+	// TESTS+CALLS edges. It is a deterministic function of the (now finalized)
+	// graph with no external dependency, so re-running it after the merge lands
+	// the same property set a full rebuild would. New entities get stamped and
+	// survivors are refreshed in case a changed edge moved their reachability.
+	coverage.Enrich(doc, absRepo, coverage.Config{})
 
 	// #2706 — belt-and-suspenders prune of Django migration entities.
 	// The incremental path bypasses the per-extractor prune gates only
@@ -496,6 +551,158 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		ChangedFiles: len(reallyChanged),
 		Duration:     dur,
 	}
+}
+
+// stampModuleOnEntities stamps Properties["module"] on each entity in ents that
+// does not already carry one, matching the full-rebuild path's labeling
+// (cmd/grafel/index.go buildDocument):
+//
+//   - PLAIN repo → one label for every sourced entity. The full path uses
+//     repoSlug-or-repoTag; we recover that label from the existing graph (in a
+//     plain repo every sourced entity already shares one "module" value).
+//   - MONOREPO  → the deterministic path rollup over the package-boundary
+//     markers, via module.Derive.
+//
+// Sourceless synthetic entities are stamped "_external", mirroring the full
+// path's post-assembly _external sweep.
+func stampModuleOnEntities(ents []graph.Entity, doc *graph.Document, absRepo string, allFiles []string) {
+	if len(ents) == 0 {
+		return
+	}
+
+	// Determine the plain-repo single label, matching the full-rebuild path
+	// (cmd/grafel/index.go Run): a PLAIN (non-monorepo) repo forces every sourced
+	// entity into ONE module label == repoSlug-or-repoTag (issue #1628); a TRUE
+	// monorepo (>1 workspace package) uses the per-package path rollup.
+	//
+	// The full path's label is repoSlug (falling back to repoTag); the
+	// incremental path only has doc.Repo (the repoTag), which equals the full
+	// path's label whenever repoSlug is empty or equal to repoTag — the normal
+	// case. We cross-check against the existing graph: in a plain repo every
+	// sourced survivor already shares one "module" value, which is the
+	// authoritative label the previous full build stamped. Prefer that recovered
+	// label (exact, even when repoSlug != repoTag); fall back to doc.Repo.
+	plainLabel := ""
+	if mono, derr := detect.DetectMonorepo(absRepo); derr != nil || mono.Kind == detect.KindNone || len(mono.Packages) <= 1 {
+		// Plain repo. Recover the exact label the previous build used, if any
+		// sourced survivor carries one; otherwise use the repo tag.
+		single, multiple := "", false
+		for k := range doc.Entities {
+			e := &doc.Entities[k]
+			if e.Kind == module.KindModule || e.SourceFile == "" || e.Properties == nil {
+				continue
+			}
+			m, ok := e.Properties["module"]
+			if !ok || m == "" || m == "_external" {
+				continue
+			}
+			if single == "" {
+				single = m
+			} else if single != m {
+				multiple = true
+				break
+			}
+		}
+		switch {
+		case single != "" && !multiple:
+			plainLabel = single
+		case doc.Repo != "":
+			plainLabel = doc.Repo
+		}
+	}
+
+	// Markers for the monorepo path. BuildMarkerSet expects repo-relative
+	// forward-slash paths — exactly what walkSourceFiles produced into allFiles.
+	markers := module.BuildMarkerSet(allFiles)
+
+	for i := range ents {
+		e := &ents[i]
+		if e.Properties != nil {
+			if v, ok := e.Properties["module"]; ok && v != "" {
+				continue // extractor-supplied label preserved
+			}
+		}
+		var label string
+		switch {
+		case e.SourceFile == "":
+			label = "_external"
+		case plainLabel != "":
+			label = plainLabel
+		default:
+			label = module.Derive(e.SourceFile, markers)
+		}
+		if e.Properties == nil {
+			e.Properties = map[string]string{}
+		}
+		e.Properties["module"] = label
+	}
+}
+
+// affectedModuleSet computes the blast radius of a reindex in module-key terms:
+// the modules whose membership or cross-module dependencies could have changed.
+// This is the union of:
+//
+//   - the modules of every re-extracted (new) entity — their membership and the
+//     cross-module edges they originate changed;
+//   - the modules of every removed entity — CONTAINS/membership shrank and the
+//     edges they originated vanished;
+//   - both endpoint modules of every newly added relationship — a new
+//     cross-module edge moves a DEPENDS_ON weight.
+//
+// Returned as the ModuleKey set AggregateIncremental scopes its strip+rebuild
+// to. doc must already hold the merged (post-Step-8) entity set so endpoint
+// module lookups resolve.
+func affectedModuleSet(doc *graph.Document, removedModuleKeys map[module.ModuleKey]struct{}, newEnts []graph.Entity, newRels []graph.Relationship) map[module.ModuleKey]struct{} {
+	// id → module key over the merged graph (used to resolve relationship
+	// endpoints, including survivors).
+	idMod := make(map[string]module.ModuleKey, len(doc.Entities))
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.Kind == module.KindModule {
+			continue
+		}
+		idMod[e.ID] = entityModuleKey(e, doc.Repo)
+	}
+
+	affected := make(map[module.ModuleKey]struct{})
+	add := func(mk module.ModuleKey) { affected[mk] = struct{}{} }
+
+	for i := range newEnts {
+		add(entityModuleKey(&newEnts[i], doc.Repo))
+	}
+	// Removed entities (incl. fully-deleted files with no replacement): their
+	// module's membership shrank, so its CONTAINS / DEPENDS_ON must be re-derived.
+	for mk := range removedModuleKeys {
+		add(mk)
+	}
+
+	for i := range newRels {
+		r := &newRels[i]
+		if mk, ok := idMod[r.FromID]; ok {
+			add(mk)
+		}
+		if mk, ok := idMod[r.ToID]; ok {
+			add(mk)
+		}
+	}
+	return affected
+}
+
+// entityModuleKey mirrors module.AggregateIncremental's per-entity key
+// derivation: Properties["module"] (default "_external") + Properties["repo"]
+// (default docRepo).
+func entityModuleKey(e *graph.Entity, docRepo string) module.ModuleKey {
+	mod := "_external"
+	repo := docRepo
+	if e.Properties != nil {
+		if v, ok := e.Properties["module"]; ok && v != "" {
+			mod = v
+		}
+		if v, ok := e.Properties["repo"]; ok && v != "" {
+			repo = v
+		}
+	}
+	return module.NewModuleKey(repo, mod)
 }
 
 // fallback returns a Result with Done=false and the given reason.

--- a/internal/module/aggregate.go
+++ b/internal/module/aggregate.go
@@ -73,13 +73,21 @@ type AggregateResult struct {
 	DependsOnEdges int
 }
 
-// moduleKey uniquely identifies a module node within the document.  Each
+// ModuleKey uniquely identifies a module node within the document.  Each
 // entity carries a repo tag and a module label; cross-repo module nodes are
-// fully distinct.
-type moduleKey struct {
+// fully distinct. Exported so the incremental path (AggregateIncremental) can
+// describe the affected blast radius in the same terms.
+type ModuleKey struct {
 	repo string
 	name string
 }
+
+// NewModuleKey builds a ModuleKey from a repo tag and module label. Used by the
+// incremental path to assemble the affected-module set.
+func NewModuleKey(repo, name string) ModuleKey { return ModuleKey{repo: repo, name: name} }
+
+// moduleNodeID returns the synthetic Module node ID for a key.
+func moduleNodeID(mk ModuleKey) string { return moduleNodeEntityID(mk.repo, mk.name) }
 
 // Aggregate runs the module-level aggregation pass over doc.  It appends
 // Module entities and their edges to doc.Entities / doc.Relationships and
@@ -102,7 +110,7 @@ func Aggregate(doc *graph.Document) AggregateResult {
 	// ── Step 1: build entity-id → module key lookup ─────────────────────────
 	// We need to know which module each entity belongs to so that we can
 	// resolve both endpoints of every relationship.
-	entityModule := make(map[string]moduleKey, len(doc.Entities))
+	entityModule := make(map[string]ModuleKey, len(doc.Entities))
 	// Use Document.Repo for same-repo entities. Cross-repo entity IDs
 	// in a multi-repo group document carry a per-entity repo tag in
 	// Properties["repo"]; single-repo documents use doc.Repo for all.
@@ -111,35 +119,34 @@ func Aggregate(doc *graph.Document) AggregateResult {
 		if e.Kind == KindModule {
 			continue
 		}
-		mod := "_external"
-		if e.Properties != nil {
-			if v, ok := e.Properties["module"]; ok && v != "" {
-				mod = v
-			}
-		}
-		repo := doc.Repo
-		if e.Properties != nil {
-			if v, ok := e.Properties["repo"]; ok && v != "" {
-				repo = v
-			}
-		}
-		entityModule[e.ID] = moduleKey{repo: repo, name: mod}
+		entityModule[e.ID] = moduleKeyForEntity(e, doc.Repo)
 	}
 
-	// ── Step 2: collect distinct module keys ────────────────────────────────
-	// Use a sorted slice for deterministic iteration order later.
-	moduleSet := make(map[moduleKey]struct{})
+	// emit for every module (the full-rebuild caller has no scoping filter).
+	return aggregateModules(doc, entityModule, func(ModuleKey) bool { return true })
+}
+
+// aggregateModules is the shared emission core for both the full-rebuild
+// Aggregate and the blast-radius-scoped AggregateIncremental. It (re-)emits
+// Module nodes, CONTAINS edges, and Module→Module DEPENDS_ON edges for every
+// module key satisfying include(mk), seeding its idempotency gates from the
+// Module artifacts already present in doc so it never double-emits an edge that
+// survived an incremental strip. entityModule maps every (non-Module) entity ID
+// to its module key.
+//
+// DEPENDS_ON weights are computed over the FULL relationship set (the true
+// cross-module fan-in/-out of an included module spans edges from any module),
+// but an edge is only EMITTED when its from-module is included — so a scoped run
+// re-derives exactly the pairs the strip removed, with the same weights a full
+// rebuild computes.
+func aggregateModules(doc *graph.Document, entityModule map[string]ModuleKey, include func(ModuleKey) bool) AggregateResult {
+	// Distinct module keys.
+	moduleSet := make(map[ModuleKey]struct{})
 	for _, mk := range entityModule {
 		moduleSet[mk] = struct{}{}
 	}
 
-	// ── Step 3: build module-key → stable module node ID ────────────────────
-	moduleNodeID := make(map[moduleKey]string, len(moduleSet))
-	for mk := range moduleSet {
-		moduleNodeID[mk] = moduleNodeEntityID(mk.repo, mk.name)
-	}
-
-	// ── Step 4: check which Module nodes already exist (idempotency) ────────
+	// Which Module nodes already exist (idempotency seed).
 	existingModuleIDs := make(map[string]bool, len(doc.Entities))
 	for k := range doc.Entities {
 		if doc.Entities[k].Kind == KindModule {
@@ -147,9 +154,8 @@ func Aggregate(doc *graph.Document) AggregateResult {
 		}
 	}
 
-	// ── Step 5: emit Module container entities ───────────────────────────────
-	// Collect and sort for stable output.
-	sortedModuleKeys := make([]moduleKey, 0, len(moduleSet))
+	// ── Emit Module container entities (sorted for stable output) ────────────
+	sortedModuleKeys := make([]ModuleKey, 0, len(moduleSet))
 	for mk := range moduleSet {
 		sortedModuleKeys = append(sortedModuleKeys, mk)
 	}
@@ -162,34 +168,33 @@ func Aggregate(doc *graph.Document) AggregateResult {
 
 	newModuleCount := 0
 	for _, mk := range sortedModuleKeys {
-		mid := moduleNodeID[mk]
+		if !include(mk) {
+			continue
+		}
+		mid := moduleNodeID(mk)
 		if existingModuleIDs[mid] {
 			continue
 		}
 		existingModuleIDs[mid] = true
-		props := map[string]string{
-			"module":    mk.name,
-			"repo":      mk.repo,
-			"synthetic": "true",
-		}
 		doc.Entities = append(doc.Entities, graph.Entity{
-			ID:         mid,
-			Name:       mk.name,
-			Kind:       KindModule,
-			Properties: props,
+			ID:   mid,
+			Name: mk.name,
+			Kind: KindModule,
+			Properties: map[string]string{
+				"module":    mk.name,
+				"repo":      mk.repo,
+				"synthetic": "true",
+			},
 		})
 		newModuleCount++
 	}
 
-	// ── Step 6: emit CONTAINS edges (Module → entity) ────────────────────────
-	// Build a dedup set seeded with existing CONTAINS edges so re-runs are
-	// idempotent.
+	// ── Emit CONTAINS edges (Module → entity) ────────────────────────────────
 	existingRels := make(map[string]bool, len(doc.Relationships))
 	for k := range doc.Relationships {
 		existingRels[doc.Relationships[k].ID] = true
 	}
 
-	// Sort entity IDs for stable CONTAINS emission order.
 	sortedEntityIDs := make([]string, 0, len(entityModule))
 	for eid := range entityModule {
 		sortedEntityIDs = append(sortedEntityIDs, eid)
@@ -199,7 +204,10 @@ func Aggregate(doc *graph.Document) AggregateResult {
 	containsCount := 0
 	for _, eid := range sortedEntityIDs {
 		mk := entityModule[eid]
-		mid := moduleNodeID[mk]
+		if !include(mk) {
+			continue
+		}
+		mid := moduleNodeID(mk)
 		rid := graph.RelationshipID(mid, eid, KindContains)
 		if existingRels[rid] {
 			continue
@@ -214,16 +222,12 @@ func Aggregate(doc *graph.Document) AggregateResult {
 		containsCount++
 	}
 
-	// ── Step 7: aggregate Module→Module DEPENDS_ON edges ─────────────────────
-	// Walk every entity-level relationship; if the from/to entities are in
-	// different modules, accumulate the count into a from-module→to-module
-	// pair.
-	type modPair struct{ from, to moduleKey }
+	// ── Aggregate Module→Module DEPENDS_ON edges ─────────────────────────────
+	type modPair struct{ from, to ModuleKey }
 	edgeWeight := make(map[modPair]int)
 	for k := range doc.Relationships {
 		r := &doc.Relationships[k]
 		if r.Kind == KindContains || r.Kind == KindDependsOn {
-			// Skip meta-edges we are generating ourselves.
 			continue
 		}
 		fromMK, fromOK := entityModule[r.FromID]
@@ -232,13 +236,11 @@ func Aggregate(doc *graph.Document) AggregateResult {
 			continue
 		}
 		if fromMK == toMK {
-			// Same module — self-edge: skip.
 			continue
 		}
 		edgeWeight[modPair{from: fromMK, to: toMK}]++
 	}
 
-	// Sort pairs for deterministic emission.
 	sortedPairs := make([]modPair, 0, len(edgeWeight))
 	for p := range edgeWeight {
 		sortedPairs = append(sortedPairs, p)
@@ -259,27 +261,38 @@ func Aggregate(doc *graph.Document) AggregateResult {
 
 	dependsOnCount := 0
 	for _, p := range sortedPairs {
-		fromMID := moduleNodeID[p.from]
-		toMID := moduleNodeID[p.to]
+		// Emit iff the from-module is in scope. A scoped strip removed every
+		// DEPENDS_ON whose from OR to is affected; re-emitting on the from side
+		// for every affected module re-creates the strip's removals (the to-only
+		// affected edges are re-emitted when their own from-module is iterated,
+		// which it is because that from-module's outbound edge count changed only
+		// if it too is affected — and a to-only change cannot alter a from-only
+		// module's emitted set). Concretely: include(from) covers every pair the
+		// scoped strip dropped, because the strip drops on from||to and we
+		// recompute from the full edge set.
+		if !include(p.from) && !include(p.to) {
+			continue
+		}
+		fromMID := moduleNodeID(p.from)
+		toMID := moduleNodeID(p.to)
 		rid := graph.RelationshipID(fromMID, toMID, KindDependsOn)
 		if existingRels[rid] {
 			continue
 		}
 		existingRels[rid] = true
-		w := edgeWeight[p]
 		doc.Relationships = append(doc.Relationships, graph.Relationship{
 			ID:     rid,
 			FromID: fromMID,
 			ToID:   toMID,
 			Kind:   KindDependsOn,
 			Properties: map[string]string{
-				"weight": fmt.Sprintf("%d", w),
+				"weight": fmt.Sprintf("%d", edgeWeight[p]),
 			},
 		})
 		dependsOnCount++
 	}
 
-	// ── Step 8: update document stats ────────────────────────────────────────
+	// ── Update document stats ────────────────────────────────────────────────
 	doc.Stats.Entities = len(doc.Entities)
 	doc.Stats.Relationships = len(doc.Relationships)
 
@@ -296,4 +309,114 @@ func Aggregate(doc *graph.Document) AggregateResult {
 // always have a non-empty sourceFile).
 func moduleNodeEntityID(repo, name string) string {
 	return graph.EntityID(repo, KindModule, name, "")
+}
+
+// AggregateIncremental re-runs the module-aggregation pass on the blast radius
+// of a change (issue #5309, layer 2), producing a graph byte-equivalent to what
+// a full rebuild's Aggregate would, WITHOUT re-deriving the module layer for the
+// whole graph.
+//
+// The full-rebuild path (cmd/grafel/index.go Pass 8) calls Aggregate on a fresh
+// document that has no Module nodes / CONTAINS / DEPENDS_ON edges yet. The
+// incremental path, by contrast, carries the previous build's module layer
+// forward in doc; a file change can leave it stale:
+//
+//   - CONTAINS edges to removed entities (or from now-empty modules),
+//   - Module nodes whose membership vanished,
+//   - DEPENDS_ON edges whose cross-module weight changed or which no longer
+//     have any underlying entity edge.
+//
+// affected is the set of module keys whose membership or dependency endpoints
+// changed in this reindex (the union of the modules of removed and re-extracted
+// entities, plus the modules on either side of any added/removed cross-module
+// edge). The pass strips ONLY the module-layer artifacts touching an affected
+// module, then re-derives them via the same logic Aggregate uses — so unchanged
+// modules' nodes/edges are preserved untouched while the changed ones land
+// exactly where a full rebuild would.
+//
+// When affected is empty the document's module layer is already correct and the
+// function is a no-op. Passing the full module-key set degenerates to a complete
+// module-layer rebuild (equivalent to stripping every Module artifact and
+// calling Aggregate), which is the conservative fallback.
+func AggregateIncremental(doc *graph.Document, affected map[ModuleKey]struct{}) AggregateResult {
+	if doc == nil || len(affected) == 0 {
+		return AggregateResult{}
+	}
+
+	// ── Step A: map every (current) entity to its module key. ────────────────
+	// This is the post-merge membership the rebuilt layer must reflect.
+	entityModule := make(map[string]ModuleKey, len(doc.Entities))
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.Kind == KindModule {
+			continue
+		}
+		entityModule[e.ID] = moduleKeyForEntity(e, doc.Repo)
+	}
+
+	// affectedModuleID is the set of synthetic Module node IDs that belong to an
+	// affected module key — the only Module nodes we may drop/re-emit.
+	affectedModuleID := make(map[string]bool, len(affected))
+	for mk := range affected {
+		affectedModuleID[moduleNodeID(mk)] = true
+	}
+
+	// ── Step B: strip stale module-layer artifacts touching an affected module.
+	// A CONTAINS/DEPENDS_ON edge or a Module node is "stale" iff it references an
+	// affected module; everything else is preserved verbatim so unchanged
+	// modules stay byte-identical to the prior build.
+	keptEntities := doc.Entities[:0]
+	for _, e := range doc.Entities {
+		if e.Kind == KindModule && affectedModuleID[e.ID] {
+			continue // drop — will be re-emitted if it still has members
+		}
+		keptEntities = append(keptEntities, e)
+	}
+	doc.Entities = keptEntities
+
+	keptRels := doc.Relationships[:0]
+	for _, r := range doc.Relationships {
+		switch r.Kind {
+		case KindContains:
+			// FromID is the Module node; drop iff that module is affected.
+			if affectedModuleID[r.FromID] {
+				continue
+			}
+		case KindDependsOn:
+			// Drop iff either endpoint module is affected (its weight may move).
+			if affectedModuleID[r.FromID] || affectedModuleID[r.ToID] {
+				continue
+			}
+		}
+		keptRels = append(keptRels, r)
+	}
+	doc.Relationships = keptRels
+
+	// ── Step C: re-derive the stripped artifacts. We reuse the same emission
+	// logic as Aggregate but limit it to affected modules so the result is
+	// byte-equivalent to a full rebuild over the affected blast radius. After
+	// the strip the doc has NO Module/CONTAINS/DEPENDS_ON for affected modules,
+	// so the idempotency gates inside the helpers below re-create exactly the
+	// set a fresh Aggregate would for those modules.
+	return aggregateModules(doc, entityModule, func(mk ModuleKey) bool {
+		_, ok := affected[mk]
+		return ok
+	})
+}
+
+// moduleKeyForEntity computes the (repo, module) key for a single entity using
+// the same rules as Aggregate's Step 1: Properties["module"] (default
+// "_external") and Properties["repo"] (default docRepo).
+func moduleKeyForEntity(e *graph.Entity, docRepo string) ModuleKey {
+	mod := "_external"
+	repo := docRepo
+	if e.Properties != nil {
+		if v, ok := e.Properties["module"]; ok && v != "" {
+			mod = v
+		}
+		if v, ok := e.Properties["repo"]; ok && v != "" {
+			repo = v
+		}
+	}
+	return ModuleKey{repo: repo, name: mod}
 }


### PR DESCRIPTION
## What

Make the incremental reindex's **module-aggregation phase** match a full rebuild, scoped to the blast radius of the change (layer 2 of #5309).

Previously the incremental path made only AST parse + scoped resolution incremental. The module-aggregation pass (CONTAINS / DEPENDS_ON edges, `module` labels) was never re-run, so the incremental graph carried the prior build's module layer forward stale and freshly extracted entities had no `module` property. The differential-reindex validator tolerated this with `IgnoreRelKinds{CONTAINS, DEPENDS_ON}` + `IgnoreEntityProps{module, test_reachable}`.

## How

- Extract the full-rebuild aggregation's emission core into a shared `aggregateModules` helper, and add **`module.AggregateIncremental(doc, affected)`**: it strips and re-derives only the Module nodes / CONTAINS / DEPENDS_ON edges that touch an **affected module** (union of the modules of re-extracted + removed entities, plus both endpoints of any added cross-module edge). Unchanged modules are preserved verbatim; DEPENDS_ON weights are computed over the full edge set but emitted only for affected pairs — byte-equivalent to a full rebuild over the blast radius, without re-aggregating the whole graph.
- Stamp `Properties["module"]` on newly extracted entities using the same label rule the full path uses (plain-repo single label via monorepo detection, else the path rollup over package-boundary markers).
- Re-run the two cheap module-graph enrichments the full path runs after aggregation and that depend on the corrected DEPENDS_ON edges: structural coupling (`ca`/`ce`/`instability`/`coupling_computed`) and the static test-reachability sub-pass (`test_reachable`/`reaching_tests`/`reach_depth`). Both are bounded by module/entity count, not by re-extraction.

## Validator

Removes both tolerances from `dvBaselineProfile()` (now **empty**) — the harness asserts strict parity on the module-aggregation edges and all enrichment properties. All four delta cases (rename, deleted-entity-with-inbound-edges, signature-change, new-cross-file-call) plus the injected-mismatch self-check pass.

## Verification

`go build ./...`; the `diff_reindex_validator` cases + the module / parity / extractors / engine / coverage suites green; `gofmt -l` clean.

## Remaining

Communities and the link / process-flow / event-flow passes are still full on the incremental path — the remaining graph-wide phases to scope in later layers.
