### PR TITLE
feat(reindex): incremental link/flow passes — blast-radius scoped, parity maintained (#5309 layer 3)

### DIFF
--- a/cmd/grafel/diff_reindex_validator_test.go
+++ b/cmd/grafel/diff_reindex_validator_test.go
@@ -342,6 +342,80 @@ func TestDiffReindex_CatchesInjectedMismatch(t *testing.T) {
 	t.Logf("validator correctly caught injected mismatch:\n%s", rep.String())
 }
 
+// ─────────────────────── flow-pass delta cases (#5309 layer 3) ──────────────
+//
+// The start-state corpus above (caller.go → target.go) is a 2-node chain, below
+// the process-flow MinSteps threshold, so it emits no Process entities — the
+// flow-pass parity is exercised trivially there. These cases use a deeper call
+// chain that DOES emit a Process flow, so the incremental flow pass
+// (engine.RunFlowsIncremental) is actually compared against a full rebuild's
+// Pass 7 / 7.5 output.
+
+// dvFlowCorpus writes a 4-deep call chain (Handler → StepB → StepC → StepD) that
+// the process-flow walker materialises into one Process entity (+ its
+// ENTRY_POINT_OF / STEP_IN_PROCESS edges) — plus a separate plain helper so a
+// docs-only/unrelated change has something inert to touch.
+func dvFlowCorpus(t *testing.T, repo string) {
+	dvWriteFile(t, repo, "chain.go", "package svc\n\n"+
+		"func Handler() int { return StepB() }\n"+
+		"func StepB() int { return StepC() }\n"+
+		"func StepC() int { return StepD() }\n"+
+		"func StepD() int { return 1 }\n")
+	dvWriteFile(t, repo, "README.md", "# svc\n\nInitial docs.\n")
+}
+
+// Case 5 — call-chain change ripples into the process flow. Lengthening the
+// chain (StepD now calls a new StepE) changes the Process entity's chain hash +
+// step edges. The incremental flow pass must strip the stale Process and re-emit
+// exactly the Process a full rebuild's Pass 7 computes for the new chain.
+func TestDiffReindex_FlowChainChange(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dvFlowCorpus(t, repo)
+
+	dvFullRebuild(t, repo, stateDir)
+	dvSeedManifest(t, repo, stateDir)
+
+	// Extend the chain: StepD now calls a new StepE, lengthening the flow.
+	dvWriteFile(t, repo, "chain.go", "package svc\n\n"+
+		"func Handler() int { return StepB() }\n"+
+		"func StepB() int { return StepC() }\n"+
+		"func StepC() int { return StepD() }\n"+
+		"func StepD() int { return StepE() }\n"+
+		"func StepE() int { return 1 }\n")
+
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	dvAssertParity(t, b, c)
+}
+
+// Case 6 — docs-only change with a live process flow. Editing README.md touches
+// no call structure, so the blast radius cannot affect the flow; the incremental
+// path keeps the prior Process verbatim. It must still match a full rebuild,
+// which recomputes the identical Process from the unchanged chain — proving the
+// "keep flows verbatim when unaffected" branch is byte-correct.
+func TestDiffReindex_FlowDocsOnlyChange(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dvFlowCorpus(t, repo)
+
+	dvFullRebuild(t, repo, stateDir)
+	dvSeedManifest(t, repo, stateDir)
+
+	// Docs-only edit — no call/HTTP/pub-sub structure changes.
+	dvWriteFile(t, repo, "README.md", "# svc\n\nUpdated docs — no code change.\n")
+
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	dvAssertParity(t, b, c)
+}
+
 // Case 4 — new cross-file call edge. Add a brand-new caller file that calls into
 // the existing target. The new entity AND the new cross-file CALLS edge must
 // match a full rebuild — this exercises the scoped resolver's inbound-edge

--- a/internal/engine/flow_incremental.go
+++ b/internal/engine/flow_incremental.go
@@ -1,0 +1,208 @@
+// Package engine — flow_incremental.go implements the blast-radius-scoped
+// incremental re-run of the per-repo flow passes (process-flow + event-flow)
+// for #5309 layer 3.
+//
+// # Why this exists
+//
+// The full-rebuild path runs RunProcessFlow + RunEventFlow as Pass 7 / 7.5 over
+// the finalized single-repo graph. The incremental path (internal/extractors/
+// incremental.go) previously skipped both passes entirely, carrying the prior
+// build's Process / EventFlow entities (and their ENTRY_POINT_OF /
+// STEP_IN_PROCESS / SEED_OF_EVENT_FLOW / STEP_IN_EVENT_FLOW edges) forward
+// verbatim — which a file change can staleify (a renamed entity in a chain, a
+// new call that lengthens a flow, a deleted publisher that removes one).
+//
+// # The scoping
+//
+// Both flow walkers are pure, deterministic, bounded functions of a small slice
+// of the graph: the CALLS / FETCHES / phantom-CALLS adjacency + the HTTP
+// boundary edges (IMPLEMENTS / ROUTES_TO / SERVES) + http_endpoint entities for
+// process-flow, and the PUBLISHES_TO / SUBSCRIBES_TO edges + channel entities
+// for event-flow. Their output is keyed by deterministic content hashes over
+// the chain (computeProcessID / the event-flow id), so a re-run over an
+// unchanged input slice reproduces byte-identical flows.
+//
+// That gives a clean blast-radius gate: if the reindex's blast radius does not
+// touch any flow-input edge or any flow-relevant entity, the prior flows are
+// already exactly what a full rebuild would compute, so we keep them verbatim
+// and skip the walkers. If the blast radius DOES touch a flow input, we strip
+// the stale flows and re-run both walkers over the finalized graph — which is
+// byte-equivalent to a full rebuild for the affected scope (and, because the
+// walkers are global per-repo BFS with cross-flow ranking/caps, re-running both
+// in full is the only partition that preserves strict parity; they are bounded
+// by entry-point count × MaxDepth, not by graph size).
+//
+// The predicate is a deliberate over-approximation: re-running when nothing
+// actually changed a flow is merely wasted (bounded) work; SKIPPING a re-run
+// that a full rebuild would have changed is a correctness bug. So the predicate
+// errs toward recompute.
+package engine
+
+import "github.com/cajasmota/grafel/internal/graph"
+
+// flowEntityKinds are the entity kinds emitted by the flow walkers. They are
+// stripped before a re-run and never count as a flow-input change themselves
+// (the walkers regenerate them).
+var flowEntityKinds = map[string]bool{
+	EntityKindProcess:   true,
+	EntityKindEventFlow: true,
+}
+
+// flowEdgeKinds are the relationship kinds emitted by the flow walkers. They are
+// stripped before a re-run (the walkers regenerate them) and do not themselves
+// count as a flow-input change.
+var flowEdgeKinds = map[string]bool{
+	RelationshipKindEntryPointOf:    true,
+	RelationshipKindStepInProcess:   true,
+	RelationshipKindSeedOfEventFlow: true,
+	RelationshipKindStepInEventFlow: true,
+}
+
+// flowInputEdgeKinds are the relationship kinds the flow walkers consume.
+// A new or removed edge of one of these kinds is a flow-input change.
+//   - CALLS / FETCHES drive the process-flow BFS adjacency (FETCHES is also the
+//     consumer-HTTP bridge).
+//   - the phantom cross-repo CALLS edge is a CALLS edge carrying cross_repo=true,
+//     so it is already covered by the CALLS entry below.
+//   - IMPLEMENTS / ROUTES_TO / SERVES form the HTTP-boundary set used by entry
+//     ranking + cross-stack detection.
+//   - PUBLISHES_TO / SUBSCRIBES_TO drive the event-flow pub/sub adjacency.
+var flowInputEdgeKinds = map[string]bool{
+	RelationshipKindCalls:   true,
+	RelationshipKindFetches: true,
+	"IMPLEMENTS":            true,
+	"ROUTES_TO":             true,
+	"SERVES":                true,
+	"PUBLISHES_TO":          true,
+	"SUBSCRIBES_TO":         true,
+}
+
+// FlowsAffectedByDelta reports whether the blast radius of an incremental
+// reindex could change the per-repo flow walkers' output, so the caller can
+// decide between a cheap "keep prior flows verbatim" and a re-run.
+//
+// It is a conservative over-approximation. Flows are considered affected when
+// the blast radius contains, ignoring the walker-emitted flow entities/edges
+// themselves:
+//
+//   - any newly extracted entity (it may be a new entry point, call step, HTTP
+//     endpoint, or channel — and entry ranking depends on the entity set), or
+//   - any removed entity (it may have been a step / entry / channel), or
+//   - any new relationship of a flow-input kind, or
+//   - any removed relationship of a flow-input kind.
+//
+// removedEntityIDs is the set of entity IDs sourced from changed/deleted files
+// that were pruned. newEntities / newRels are the freshly extracted set.
+// removedRels is the set of relationships pruned during the incremental pass
+// (outbound rels of removed entities + dangling inbound edges).
+func FlowsAffectedByDelta(
+	newEntities []graph.Entity,
+	removedEntityIDs map[string]bool,
+	newRels []graph.Relationship,
+	removedRels []graph.Relationship,
+) bool {
+	// A removed real (non-flow) entity may have been a flow node.
+	if len(removedEntityIDs) > 0 {
+		return true
+	}
+	for i := range newEntities {
+		if !flowEntityKinds[newEntities[i].Kind] {
+			return true
+		}
+	}
+	for i := range newRels {
+		if flowInputEdgeKinds[newRels[i].Kind] {
+			return true
+		}
+	}
+	for i := range removedRels {
+		if flowInputEdgeKinds[removedRels[i].Kind] {
+			return true
+		}
+	}
+	return false
+}
+
+// stripFlows removes every walker-emitted Process / EventFlow entity and every
+// walker-emitted flow edge from doc in place, so a subsequent RunProcessFlow /
+// RunEventFlow re-run does not double-emit. Returns the number of entities and
+// relationships removed. Edges are stripped both by kind AND by endpoint: a
+// flow entity's id can appear on either side of an edge whose kind is not in
+// flowEdgeKinds only via the walker, but the kind filter is exhaustive for the
+// walker's output; the endpoint filter is a belt-and-suspenders sweep for any
+// stray edge touching a stripped flow node.
+func stripFlows(doc *graph.Document) (entsRemoved, relsRemoved int) {
+	if doc == nil {
+		return 0, 0
+	}
+	flowIDs := make(map[string]bool)
+	keptEnts := doc.Entities[:0]
+	for _, e := range doc.Entities {
+		if flowEntityKinds[e.Kind] {
+			flowIDs[e.ID] = true
+			entsRemoved++
+			continue
+		}
+		keptEnts = append(keptEnts, e)
+	}
+	doc.Entities = keptEnts
+
+	keptRels := doc.Relationships[:0]
+	for _, r := range doc.Relationships {
+		if flowEdgeKinds[r.Kind] || flowIDs[r.FromID] || flowIDs[r.ToID] {
+			relsRemoved++
+			continue
+		}
+		keptRels = append(keptRels, r)
+	}
+	doc.Relationships = keptRels
+	return entsRemoved, relsRemoved
+}
+
+// RunFlowsIncremental makes the per-repo process-flow + event-flow passes
+// blast-radius-scoped on the incremental reindex path (#5309 layer 3).
+//
+//   - When the blast radius cannot affect any flow input (FlowsAffectedByDelta
+//     is false — e.g. a docs-only or comment-only change, or a change that
+//     touches no call/HTTP/pub-sub structure), the prior flows carried forward
+//     in doc are already byte-equivalent to a full rebuild, so they are kept
+//     verbatim and the walkers are skipped.
+//   - Otherwise the stale flows are stripped and both walkers are re-run over
+//     the finalized graph, reproducing exactly the Process / EventFlow entities
+//   - edges a full rebuild would emit for this repo.
+//
+// It must be called BEFORE module-aggregation but over the otherwise-finalized
+// graph (merged + scoped-resolved entities/edges), mirroring the full path where
+// the flow passes (Pass 7 / 7.5) run just before module-agg (Pass 8).
+//
+// Returns:
+//   - recomputed: true when the walkers re-ran, false when prior flows were kept;
+//   - flowEnts / flowRels: the Process / EventFlow entities and edges freshly
+//     emitted by this re-run (empty when prior flows were kept). The caller folds
+//     these into the affected-module set so module-aggregation re-derives their
+//     `_external` Module node + CONTAINS edges exactly as a full rebuild's Pass 8
+//     would.
+func RunFlowsIncremental(
+	doc *graph.Document,
+	newEntities []graph.Entity,
+	removedEntityIDs map[string]bool,
+	newRels []graph.Relationship,
+	removedRels []graph.Relationship,
+) (recomputed bool, flowEnts []graph.Entity, flowRels []graph.Relationship) {
+	if doc == nil {
+		return false, nil, nil
+	}
+	if !FlowsAffectedByDelta(newEntities, removedEntityIDs, newRels, removedRels) {
+		return false, nil, nil
+	}
+	stripFlows(doc)
+	entsBefore := len(doc.Entities)
+	relsBefore := len(doc.Relationships)
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	RunEventFlow(doc, DefaultEventFlowConfig())
+	// Copy out the freshly emitted flow artefacts; copies are stable even if doc's
+	// backing arrays are later reallocated by the module-agg append churn.
+	flowEnts = append(flowEnts, doc.Entities[entsBefore:]...)
+	flowRels = append(flowRels, doc.Relationships[relsBefore:]...)
+	return true, flowEnts, flowRels
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -324,10 +324,15 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// (entity IDs are deterministic over kind/name/source_file, so re-extracting
 	// a file usually re-creates entities with the same ID — keeping inbound
 	// cross-file edges valid for free).
+	// Track removed relationships so the incremental flow pass (#5309 layer 3)
+	// can tell whether the blast radius touched a flow-input edge.
+	var removedRels []graph.Relationship
 	filteredRels := doc.Relationships[:0]
 	for _, r := range doc.Relationships {
 		if !removedEntityIDs[r.FromID] {
 			filteredRels = append(filteredRels, r)
+		} else {
+			removedRels = append(removedRels, r)
 		}
 	}
 	doc.Relationships = filteredRels
@@ -402,7 +407,8 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	prunedInbound := doc.Relationships[:0]
 	for _, r := range doc.Relationships {
 		if removedEntityIDs[r.ToID] && !reEmittedIDs[r.ToID] {
-			continue // truly removed → drop the dangling inbound edge
+			removedRels = append(removedRels, r) // truly removed → drop the dangling inbound edge
+			continue
 		}
 		prunedInbound = append(prunedInbound, r)
 	}
@@ -462,6 +468,26 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	doc.Entities = append(doc.Entities, newEntities...)
 	doc.Relationships = append(doc.Relationships, newRels...)
 
+	// --- Step 8·flows: incremental per-repo flow passes (#5309 layer 3) ───────
+	// The full path runs RunProcessFlow (Pass 7) + RunEventFlow (Pass 7.5) over
+	// the finalized graph, BEFORE module-aggregation (Pass 8). The incremental
+	// path previously skipped both, carrying the prior build's Process /
+	// EventFlow entities + their ENTRY_POINT_OF / STEP_IN_PROCESS /
+	// SEED_OF_EVENT_FLOW / STEP_IN_EVENT_FLOW edges forward — which a code change
+	// can staleify. engine.RunFlowsIncremental is blast-radius-scoped: when the
+	// change cannot touch a flow input (CALLS / FETCHES / HTTP-boundary / pub-sub
+	// edges or any flow-relevant entity — e.g. docs/comment-only changes) the
+	// prior flows are already byte-equivalent to a full rebuild and are kept
+	// verbatim; otherwise the stale flows are stripped and both walkers re-run
+	// over the finalized graph, reproducing exactly what a full rebuild emits.
+	//
+	// Run BEFORE module-aggregation so the ordering matches the full path: a full
+	// rebuild's Pass 8 sees the Process / EventFlow entities Pass 7 emitted and
+	// folds them into the module layer (a CONTAINS edge from the `_external`
+	// Module node for each). Capture the flow-emitted entities/edges and feed them
+	// into the affected-module set so that module layer is re-derived too.
+	flowsRecomputed, flowEntities, flowRels := engine.RunFlowsIncremental(doc, newEntities, removedEntityIDs, newRels, removedRels)
+
 	// --- Step 8a: incremental module-aggregation (#5309 layer 2) ─────────────
 	// The full path runs module.Aggregate (CONTAINS / DEPENDS_ON + Module nodes)
 	// as Pass 8 over the finalized graph. The incremental path carries the prior
@@ -471,8 +497,28 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// whose membership or cross-module dependencies changed — every other
 	// module's nodes/edges are preserved verbatim. The result is byte-equivalent
 	// to a full rebuild's module layer without re-aggregating the whole graph.
-	affectedModules := affectedModuleSet(doc, removedModuleKeys, newEntities, newRels)
+	//
+	// The freshly (re)emitted flow entities/edges (#5309 layer 3) join the
+	// affected set so their `_external` Module node + CONTAINS edges are
+	// (re-)derived exactly as a full rebuild's Pass 8 would, and so a flow strip
+	// that removed the last member of a module triggers that module's re-derive.
+	aggNewEnts := append(append([]graph.Entity(nil), newEntities...), flowEntities...)
+	aggNewRels := append(append([]graph.Relationship(nil), newRels...), flowRels...)
+	affectedModules := affectedModuleSet(doc, removedModuleKeys, aggNewEnts, aggNewRels)
 	module.AggregateIncremental(doc, affectedModules)
+
+	// --- Step 8a.9: lib-boundary re-stamp (#5309 layer 3) ────────────────────
+	// The full path's Pass 8.9 (engine.ApplyLibBoundary) classifies every
+	// DEPENDS_ON edge first_party/third_party from the locality/kind props the
+	// extractors already attached. It runs AFTER module-aggregation (the agg
+	// pass emits fresh Module→Module DEPENDS_ON edges carrying only a `weight`
+	// prop). The incremental path's module-agg likewise emits unstamped
+	// DEPENDS_ON edges, so the `boundary` property must be (re)applied here or
+	// the freshly (re)emitted edges diverge from a full rebuild — surfaced once
+	// the flow Process entities (Pass 7) introduce new `_external`→first-party
+	// DEPENDS_ON pairs. The pass is deterministic, idempotent and bounded by the
+	// DEPENDS_ON edge count (a pure function of the now-finalized edge set).
+	engine.ApplyLibBoundary(doc)
 
 	// --- Step 8a': structural coupling re-stamp (#5309 layer 2) ──────────────
 	// The full path's Pass 8.6 (engine.ApplyStructuralCoupling) annotates each
@@ -543,8 +589,8 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	dur := time.Since(t0)
-	logger.Printf("incremental: done changed=%d entities=%d rels=%d took=%s",
-		len(reallyChanged), len(newEntities), len(newRels), dur.Truncate(time.Millisecond))
+	logger.Printf("incremental: done changed=%d entities=%d rels=%d flows_recomputed=%t took=%s",
+		len(reallyChanged), len(newEntities), len(newRels), flowsRecomputed, dur.Truncate(time.Millisecond))
 
 	return Result{
 		Done:         true,


### PR DESCRIPTION
## What

Layer 3 of the incremental-reindex performance work (#5309): make the per-repo **flow passes** (process-flow + event-flow) **blast-radius scoped** on the incremental reindex path, while keeping the differential-reindex validator strict (its tolerance profile stays EMPTY).

## Why

After layers 1–2 the incremental path matched a full rebuild for resolution + module-aggregation, but the per-repo flow walkers (process-flow Pass 7 + event-flow Pass 7.5) were **never re-run** on the incremental path — it carried the prior build's `SCOPE.Process` / `SCOPE.EventFlow` entities and their `ENTRY_POINT_OF` / `STEP_IN_PROCESS` / `SEED_OF_EVENT_FLOW` / `STEP_IN_EVENT_FLOW` edges forward verbatim. A code change that lengthens / renames / removes a call or pub-sub chain leaves those flows stale versus a full rebuild.

## How

Both flow walkers are pure, deterministic, bounded functions of a small input slice (CALLS / FETCHES / phantom-CALLS adjacency + HTTP-boundary edges + http_endpoint entities for process-flow; PUBLISHES_TO / SUBSCRIBES_TO + channel entities for event-flow), keyed by deterministic content hashes. That gives a clean blast-radius gate, reusing the phantom-edge "affected" scoping pattern:

- `engine.RunFlowsIncremental` gates on `FlowsAffectedByDelta` (a conservative over-approximation). When the blast radius can't touch a flow input (docs / comment-only / config changes), the prior flows are kept **verbatim** and the walkers are skipped. Otherwise the stale flows are stripped and both walkers re-run over the finalized graph — byte-equivalent to a full rebuild. The walkers are global per-repo BFS with cross-flow entry-ranking/caps, so re-running both in full is the only partition that preserves strict parity; they are bounded by entry-point count × MaxDepth (≤10), not by graph size. The predicate errs toward recompute — a needless re-run is bounded waste; a missed re-run is a correctness bug.
- Runs **before** module-aggregation so ordering matches the full path (Pass 7 → Pass 8); the freshly emitted flow entities/edges are folded into the affected-module set so their `_external` Module node + CONTAINS edges are re-derived identically.

Also closes a layer-2 gap the flow entities surfaced: the incremental path never re-ran **Pass 8.9 `engine.ApplyLibBoundary`**, so freshly emitted `DEPENDS_ON` edges (including the new `_external`→first-party pairs from flow entities) lacked the `boundary=first_party` property a full rebuild stamps. Added the deterministic, idempotent, DEPENDS_ON-bounded lib-boundary re-stamp after incremental module-agg.

## Parity

`dvBaselineProfile()` stays **EMPTY** (strict). Added two flow delta cases to `cmd/grafel/diff_reindex_validator_test.go` over a 4-deep call chain that actually materialises a Process entity:

- `FlowChainChange` — lengthening the chain ripples into the flow (recompute branch);
- `FlowDocsOnlyChange` — a docs-only edit keeps the prior flow verbatim (skip branch).

Both assert incremental ≡ full-rebuild-of-end-state under the empty profile, alongside the four existing delta cases + the injected-mismatch self-check.

## Verify

- `go build ./...`
- `go test ./internal/engine/... ./internal/module/... ./internal/links/... ./internal/graph/parity/... ./internal/extractors/ ./cmd/grafel/` green
- `gofmt -l` clean

## Remaining

Communities (incremental / local community update) is the last graph-wide phase still full on the incremental path.

Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
