### PR TITLE
feat(daemon): self-healing index quarantine — dynamic trash detection (#5394)

### DIFF
--- a/internal/daemon/watch/quarantine.go
+++ b/internal/daemon/watch/quarantine.go
@@ -1,0 +1,547 @@
+// Package watch — quarantine.go
+//
+// Self-healing index quarantine (epic #5394, tier T1: churn-based).
+//
+// The static skip list (skip.go) + .gitignore (gitignore.go, #5395) catch the
+// ~90% of *known* index trash cheaply. This file is the ADAPTIVE layer that
+// catches the long tail: a custom build-output dir, non-gitignored generated
+// content, or a per-repo oddity the static list can't anticipate, that churns
+// pathologically and trips a continuous reindex loop (the #5392 incident
+// class).
+//
+// Mechanism (T1 — the clearest, safest signal):
+//
+//		Observe → Detect → Quarantine → (persist) → Self-heal
+//
+//	  - Observe: every watcher event that survives the static + gitignore filter
+//	    is attributed to its DIRECTORY. We keep a sliding-window churn count per
+//	    directory ("this dir produced N reindex-arming events in the last
+//	    ChurnWindow").
+//	  - Detect / Quarantine: when a directory's windowed churn crosses
+//	    ChurnThreshold it is QUARANTINED — added to a per-repo set so subsequent
+//	    events under it are dropped at the event boundary (it stops arming
+//	    reindexes), and the decision is appended to an audit log.
+//	  - Persist: the quarantine set is written to <repo>/.grafel/quarantine.json
+//	    so it survives a daemon restart (a build loop that quarantined itself
+//	    does not re-thrash on reboot).
+//	  - Self-heal: Sweep() periodically re-evaluates quarantined dirs and
+//	    un-quarantines any that have gone quiet for HealQuiet — so a dir that was
+//	    a build output during a build window, but is now a legitimate (or simply
+//	    idle) source dir, recovers automatically.
+//
+// SAFETY (epic #5394, non-negotiable): we must NEVER quarantine a legitimately
+// active source directory. Guarding invariants:
+//   - Conservative, *sustained* churn requirement: a normal human edit burst
+//     (a handful of saves) stays well under ChurnThreshold; only a mechanical
+//     build loop (tens–hundreds of writes within the window) trips it.
+//   - Hysteresis via the heal cool-down (HealQuiet ≫ ChurnWindow) so we never
+//     flap quarantine↔active.
+//   - Everything is env-tunable so an operator can loosen/tighten or disable.
+//   - The quarantine set extends — never duplicates — the static + gitignore
+//     skip (this layer only ever sees paths those already let through).
+//
+// The tracker is self-contained and clock-injectable (the `now` field) so the
+// detect/quarantine/heal logic is testable deterministically without real
+// timing or a live fsnotify stream.
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Quarantine tuning. All values are env-overridable (see quarantineConfig).
+//
+// Defaults are deliberately conservative: a directory must produce
+// defaultChurnThreshold (40) reindex-arming events within defaultChurnWindow
+// (2 min) to be quarantined — far above any human edit burst, squarely in
+// mechanical-build-loop territory. A quarantined dir self-heals after
+// defaultHealQuiet (15 min) of no observed events.
+const (
+	defaultChurnThreshold = 40
+	defaultChurnWindow    = 2 * time.Minute
+	defaultHealQuiet      = 15 * time.Minute
+)
+
+// quarantineConfig holds the resolved (env-aware) thresholds.
+type quarantineConfig struct {
+	threshold int
+	window    time.Duration
+	healQuiet time.Duration
+	disabled  bool
+}
+
+var (
+	quarantineCfgOnce sync.Once
+	quarantineCfg     quarantineConfig
+)
+
+// loadQuarantineConfig parses the env once. Recognised vars:
+//
+//	GRAFEL_QUARANTINE_DISABLE=1            — turn the feature off entirely
+//	GRAFEL_QUARANTINE_CHURN_THRESHOLD=<n>  — events/window to quarantine
+//	GRAFEL_QUARANTINE_CHURN_WINDOW_SEC=<n> — sliding window, seconds
+//	GRAFEL_QUARANTINE_HEAL_QUIET_SEC=<n>   — quiet period before auto-heal
+func loadQuarantineConfig() quarantineConfig {
+	quarantineCfgOnce.Do(func() {
+		c := quarantineConfig{
+			threshold: defaultChurnThreshold,
+			window:    defaultChurnWindow,
+			healQuiet: defaultHealQuiet,
+		}
+		if v := os.Getenv("GRAFEL_QUARANTINE_DISABLE"); v == "1" || v == "true" {
+			c.disabled = true
+		}
+		if v := os.Getenv("GRAFEL_QUARANTINE_CHURN_THRESHOLD"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				c.threshold = n
+			}
+		}
+		if v := os.Getenv("GRAFEL_QUARANTINE_CHURN_WINDOW_SEC"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				c.window = time.Duration(n) * time.Second
+			}
+		}
+		if v := os.Getenv("GRAFEL_QUARANTINE_HEAL_QUIET_SEC"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				c.healQuiet = time.Duration(n) * time.Second
+			}
+		}
+		quarantineCfg = c
+	})
+	return quarantineCfg
+}
+
+// quarantineSweepInterval is how often the watcher's self-heal sweep runs. It
+// is a fraction of the heal window (capped to a sane floor) so recovery is
+// responsive without busy-looping. Env-overridable via
+// GRAFEL_QUARANTINE_SWEEP_SEC.
+func quarantineSweepInterval() time.Duration {
+	if v := os.Getenv("GRAFEL_QUARANTINE_SWEEP_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	c := loadQuarantineConfig()
+	d := c.healQuiet / 4
+	if d < time.Minute {
+		d = time.Minute
+	}
+	return d
+}
+
+// QuarantineReason records why a directory was quarantined, for the audit log
+// and the (future, Q2) transparency surface.
+type QuarantineReason struct {
+	// Rel is the directory path relative to the repo root (forward-slash).
+	Rel string `json:"rel"`
+	// Signal is the triggering detector, e.g. "churn".
+	Signal string `json:"signal"`
+	// Detail is a human-readable explanation (e.g. "47 events in 2m0s").
+	Detail string `json:"detail"`
+	// At is when the quarantine decision was made.
+	At time.Time `json:"at"`
+	// Pinned, when true, means an operator explicitly quarantined this path
+	// (or asked never to auto-heal it). Reserved for Q2; auto-heal skips
+	// pinned entries.
+	Pinned bool `json:"pinned,omitempty"`
+}
+
+// dirChurn is the sliding-window churn bookkeeping for one directory.
+type dirChurn struct {
+	// windowStart is the start of the current counting window.
+	windowStart time.Time
+	count       int
+	// lastEvent is when we last observed an event for this dir (used by heal).
+	lastEvent time.Time
+}
+
+// QuarantineTracker is the per-repo churn observer + quarantine set. One
+// tracker instance serves all repos; state is keyed by absolute repo root.
+//
+// It is goroutine-safe. All decisions go through a single mutex because the
+// per-event work is cheap (map lookups + integer math) and the volume that
+// reaches this layer is already filtered down by the static + gitignore skips.
+type QuarantineTracker struct {
+	cfg quarantineConfig
+	// now is injectable for deterministic tests; defaults to time.Now.
+	now func() time.Time
+	// audit, when non-nil, is invoked for every quarantine / un-quarantine
+	// decision (the daemon wires this to its structured logger).
+	audit func(event, repo, rel, detail string)
+
+	mu sync.Mutex
+	// churn[repo][relDir] → sliding-window state.
+	churn map[string]map[string]*dirChurn
+	// quarantined[repo][relDir] → reason. Presence == quarantined.
+	quarantined map[string]map[string]QuarantineReason
+	// loaded tracks which repos have had their persisted set read in.
+	loaded map[string]bool
+}
+
+// NewQuarantineTracker constructs a tracker. audit may be nil.
+func NewQuarantineTracker(audit func(event, repo, rel, detail string)) *QuarantineTracker {
+	return &QuarantineTracker{
+		cfg:         loadQuarantineConfig(),
+		now:         time.Now,
+		audit:       audit,
+		churn:       make(map[string]map[string]*dirChurn),
+		quarantined: make(map[string]map[string]QuarantineReason),
+		loaded:      make(map[string]bool),
+	}
+}
+
+// relDir returns the slash-form directory of the event path relative to the
+// repo root. The repo root itself maps to "." — we never quarantine the root.
+// Returns ("", false) when path is not under repo.
+func relDir(repo, path string) (string, bool) {
+	dir := filepath.Dir(path)
+	rel, err := filepath.Rel(repo, dir)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	// "." is the repo root itself — never quarantine the root. "" / ".." mean
+	// the path is not under the repo.
+	if rel == "." || rel == ".." || rel == "" {
+		return "", false
+	}
+	if len(rel) >= 2 && rel[:2] == ".." {
+		return "", false
+	}
+	return rel, true
+}
+
+// IsQuarantined reports whether the directory containing path is quarantined.
+// Cheap fast path used at the watcher event boundary. Loads persisted state on
+// first touch of a repo.
+func (q *QuarantineTracker) IsQuarantined(repo, path string) bool {
+	if q == nil || q.cfg.disabled {
+		return false
+	}
+	rel, ok := relDir(repo, path)
+	if !ok {
+		return false
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.ensureLoadedLocked(repo)
+	return q.isQuarantinedRelLocked(repo, rel)
+}
+
+// isQuarantinedRelLocked reports whether rel OR any ancestor directory of rel
+// is quarantined (so quarantining `app/build` also drops `app/build/sub`).
+func (q *QuarantineTracker) isQuarantinedRelLocked(repo, rel string) bool {
+	set := q.quarantined[repo]
+	if len(set) == 0 {
+		return false
+	}
+	cur := rel
+	for {
+		if _, ok := set[cur]; ok {
+			return true
+		}
+		parent := slashDir(cur)
+		if parent == cur {
+			return false
+		}
+		cur = parent
+	}
+}
+
+// slashDir returns the parent of a slash-form rel dir, or the input when at the
+// top level (which signals "no more ancestors").
+func slashDir(rel string) string {
+	i := lastSlash(rel)
+	if i < 0 {
+		return rel // top-level: parent would be ".", which we never quarantine
+	}
+	return rel[:i]
+}
+
+func lastSlash(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '/' {
+			return i
+		}
+	}
+	return -1
+}
+
+// Observe records one reindex-arming event for the directory containing path
+// and returns true if the event should be DROPPED (i.e. the directory is — or
+// just became — quarantined). The caller arms a reindex only when this returns
+// false.
+//
+// This is the single hot-path entry point from handleEvent.
+func (q *QuarantineTracker) Observe(repo, path string) (drop bool) {
+	if q == nil || q.cfg.disabled {
+		return false
+	}
+	rel, ok := relDir(repo, path)
+	if !ok {
+		return false
+	}
+	now := q.now()
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.ensureLoadedLocked(repo)
+
+	// Already quarantined (this dir or an ancestor) → drop, no further work.
+	if q.isQuarantinedRelLocked(repo, rel) {
+		// Keep lastEvent fresh so heal only fires after genuine quiet.
+		q.touchLocked(repo, rel, now)
+		return true
+	}
+
+	// Sliding-window churn accounting.
+	byDir := q.churn[repo]
+	if byDir == nil {
+		byDir = make(map[string]*dirChurn)
+		q.churn[repo] = byDir
+	}
+	dc := byDir[rel]
+	if dc == nil {
+		dc = &dirChurn{windowStart: now}
+		byDir[rel] = dc
+	}
+	// Roll the window if it has elapsed.
+	if now.Sub(dc.windowStart) > q.cfg.window {
+		dc.windowStart = now
+		dc.count = 0
+	}
+	dc.count++
+	dc.lastEvent = now
+
+	if dc.count >= q.cfg.threshold {
+		detail := strconv.Itoa(dc.count) + " events in " + q.cfg.window.String()
+		q.quarantineLocked(repo, rel, "churn", detail, now)
+		// Reset the counter so a future un-quarantine starts clean.
+		delete(byDir, rel)
+		return true
+	}
+	return false
+}
+
+// touchLocked refreshes lastEvent for a quarantined dir's nearest quarantined
+// ancestor (or itself), so Sweep's quiet timer reflects ongoing churn.
+func (q *QuarantineTracker) touchLocked(repo, rel string, now time.Time) {
+	set := q.quarantined[repo]
+	cur := rel
+	for {
+		if _, ok := set[cur]; ok {
+			if dc := q.churnEntryLocked(repo, cur); dc != nil {
+				dc.lastEvent = now
+			} else {
+				q.churn[repo] = ensureMap(q.churn[repo])
+				q.churn[repo][cur] = &dirChurn{lastEvent: now, windowStart: now}
+			}
+			return
+		}
+		parent := slashDir(cur)
+		if parent == cur {
+			return
+		}
+		cur = parent
+	}
+}
+
+func (q *QuarantineTracker) churnEntryLocked(repo, rel string) *dirChurn {
+	if m := q.churn[repo]; m != nil {
+		return m[rel]
+	}
+	return nil
+}
+
+func ensureMap(m map[string]*dirChurn) map[string]*dirChurn {
+	if m == nil {
+		return make(map[string]*dirChurn)
+	}
+	return m
+}
+
+// quarantineLocked records a quarantine decision, persists, and audits.
+func (q *QuarantineTracker) quarantineLocked(repo, rel, signal, detail string, now time.Time) {
+	set := q.quarantined[repo]
+	if set == nil {
+		set = make(map[string]QuarantineReason)
+		q.quarantined[repo] = set
+	}
+	if _, exists := set[rel]; exists {
+		return
+	}
+	set[rel] = QuarantineReason{Rel: rel, Signal: signal, Detail: detail, At: now}
+	// Track lastEvent so heal can measure quiet from the quarantine moment.
+	q.churn[repo] = ensureMap(q.churn[repo])
+	q.churn[repo][rel] = &dirChurn{lastEvent: now, windowStart: now}
+	q.persistLocked(repo)
+	if q.audit != nil {
+		q.audit("quarantine", repo, rel, signal+": "+detail)
+	}
+}
+
+// Sweep re-evaluates every quarantined directory and auto-un-quarantines any
+// that has been quiet for at least healQuiet. Returns the rels that were
+// healed (for logging/observability). Safe to call on a timer.
+func (q *QuarantineTracker) Sweep() (healed map[string][]string) {
+	if q == nil || q.cfg.disabled {
+		return nil
+	}
+	now := q.now()
+	healed = make(map[string][]string)
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for repo, set := range q.quarantined {
+		var dirty bool
+		for rel, reason := range set {
+			if reason.Pinned {
+				continue // operator-pinned: never auto-heal
+			}
+			last := reason.At
+			if dc := q.churnEntryLocked(repo, rel); dc != nil && dc.lastEvent.After(last) {
+				last = dc.lastEvent
+			}
+			if now.Sub(last) >= q.cfg.healQuiet {
+				delete(set, rel)
+				if m := q.churn[repo]; m != nil {
+					delete(m, rel)
+				}
+				dirty = true
+				healed[repo] = append(healed[repo], rel)
+				if q.audit != nil {
+					q.audit("unquarantine", repo, rel, "quiet for "+q.cfg.healQuiet.String())
+				}
+			}
+		}
+		if dirty {
+			q.persistLocked(repo)
+		}
+	}
+	if len(healed) == 0 {
+		return nil
+	}
+	return healed
+}
+
+// List returns a snapshot of the quarantined directories for a repo, sorted by
+// rel. Used by the (Q2) transparency surface and tests.
+func (q *QuarantineTracker) List(repo string) []QuarantineReason {
+	if q == nil {
+		return nil
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.ensureLoadedLocked(repo)
+	set := q.quarantined[repo]
+	out := make([]QuarantineReason, 0, len(set))
+	for _, r := range set {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Rel < out[j].Rel })
+	return out
+}
+
+// Unquarantine manually removes rel from a repo's quarantine set (operator
+// override, Q2). Returns true if it was present.
+func (q *QuarantineTracker) Unquarantine(repo, rel string) bool {
+	if q == nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.ensureLoadedLocked(repo)
+	set := q.quarantined[repo]
+	if _, ok := set[rel]; !ok {
+		return false
+	}
+	delete(set, rel)
+	if m := q.churn[repo]; m != nil {
+		delete(m, rel)
+	}
+	q.persistLocked(repo)
+	if q.audit != nil {
+		q.audit("unquarantine", repo, rel, "manual override")
+	}
+	return true
+}
+
+// ---- persistence: <repo>/.grafel/quarantine.json ----
+
+// quarantineFile is the on-disk shape.
+type quarantineFile struct {
+	Version int                `json:"version"`
+	Dirs    []QuarantineReason `json:"dirs"`
+}
+
+func quarantinePath(repo string) string {
+	return filepath.Join(repo, ".grafel", "quarantine.json")
+}
+
+// ensureLoadedLocked lazily reads the persisted quarantine set for a repo on
+// first touch. Errors are non-fatal (a missing/corrupt file just means "no
+// quarantines yet").
+func (q *QuarantineTracker) ensureLoadedLocked(repo string) {
+	if q.loaded[repo] {
+		return
+	}
+	q.loaded[repo] = true
+	data, err := os.ReadFile(quarantinePath(repo))
+	if err != nil {
+		return
+	}
+	var f quarantineFile
+	if json.Unmarshal(data, &f) != nil {
+		return
+	}
+	set := make(map[string]QuarantineReason, len(f.Dirs))
+	for _, r := range f.Dirs {
+		if r.Rel == "" {
+			continue
+		}
+		set[r.Rel] = r
+	}
+	if len(set) > 0 {
+		q.quarantined[repo] = set
+	}
+}
+
+// persistLocked writes the repo's quarantine set to disk. Best-effort: a write
+// failure is logged via audit but never blocks the decision.
+func (q *QuarantineTracker) persistLocked(repo string) {
+	set := q.quarantined[repo]
+	f := quarantineFile{Version: 1}
+	for _, r := range set {
+		f.Dirs = append(f.Dirs, r)
+	}
+	sort.Slice(f.Dirs, func(i, j int) bool { return f.Dirs[i].Rel < f.Dirs[j].Rel })
+
+	dir := filepath.Join(repo, ".grafel")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		if q.audit != nil {
+			q.audit("persist-error", repo, "", err.Error())
+		}
+		return
+	}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return
+	}
+	// Atomic-ish: write temp then rename.
+	tmp := quarantinePath(repo) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		if q.audit != nil {
+			q.audit("persist-error", repo, "", err.Error())
+		}
+		return
+	}
+	_ = os.Rename(tmp, quarantinePath(repo))
+}

--- a/internal/daemon/watch/quarantine_test.go
+++ b/internal/daemon/watch/quarantine_test.go
@@ -1,0 +1,269 @@
+package watch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeClock is a manually-advanced clock for deterministic quarantine tests.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newTestTracker builds a tracker with a fixed config and a fake clock so the
+// detect/quarantine/heal logic is exercised without real timing, env, or fs
+// dependence beyond the temp repo dir for persistence.
+func newTestTracker(t *testing.T) (*QuarantineTracker, *fakeClock) {
+	t.Helper()
+	clk := &fakeClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	q := &QuarantineTracker{
+		cfg: quarantineConfig{
+			threshold: 10,
+			window:    2 * time.Minute,
+			healQuiet: 15 * time.Minute,
+		},
+		now:         clk.now,
+		churn:       make(map[string]map[string]*dirChurn),
+		quarantined: make(map[string]map[string]QuarantineReason),
+		loaded:      make(map[string]bool),
+	}
+	return q, clk
+}
+
+// pump fires n Observe calls for the same path and returns how many were
+// dropped (quarantined).
+func pump(q *QuarantineTracker, repo, path string, n int) int {
+	dropped := 0
+	for i := 0; i < n; i++ {
+		if q.Observe(repo, path) {
+			dropped++
+		}
+	}
+	return dropped
+}
+
+func TestQuarantine_ChurnTripsQuarantine(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	buildFile := filepath.Join(repo, "app", "build", "out.o")
+
+	// Threshold is 10. The 10th event should quarantine; from then on events
+	// under that dir are dropped.
+	drops := pump(q, repo, buildFile, 9)
+	if drops != 0 {
+		t.Fatalf("9 events should not quarantine yet, got %d drops", drops)
+	}
+	if q.Observe(repo, buildFile) != true {
+		t.Fatalf("10th event should trip quarantine and be dropped")
+	}
+	// Subsequent events are dropped without further accounting.
+	if !q.Observe(repo, buildFile) {
+		t.Fatalf("post-quarantine event should be dropped")
+	}
+
+	list := q.List(repo)
+	if len(list) != 1 || list[0].Rel != "app/build" {
+		t.Fatalf("expected app/build quarantined, got %+v", list)
+	}
+	if list[0].Signal != "churn" {
+		t.Fatalf("expected churn signal, got %q", list[0].Signal)
+	}
+}
+
+func TestQuarantine_NormalEditBurstDoesNotQuarantine(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newTestTracker(t)
+	src := filepath.Join(repo, "src", "service.go")
+
+	// A realistic human edit burst: a handful of saves, well under threshold.
+	if drops := pump(q, repo, src, 6); drops != 0 {
+		t.Fatalf("edit burst should not quarantine, got %d drops", drops)
+	}
+	// Even spread across several windows, as long as no single window crosses
+	// the threshold, it never quarantines.
+	for i := 0; i < 5; i++ {
+		clk.advance(3 * time.Minute) // each save in a fresh window
+		if q.Observe(repo, src) {
+			t.Fatalf("spread-out edits should never quarantine")
+		}
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("normal source dir must not be quarantined: %+v", q.List(repo))
+	}
+}
+
+func TestQuarantine_WindowRollResetsCount(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newTestTracker(t)
+	p := filepath.Join(repo, "gen", "x.ts")
+
+	// 9 events, then roll the window past 2m, then 9 more: never reaches 10
+	// within a single window → no quarantine.
+	pump(q, repo, p, 9)
+	clk.advance(3 * time.Minute)
+	if drops := pump(q, repo, p, 9); drops != 0 {
+		t.Fatalf("window should have rolled; no quarantine expected, got %d", drops)
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("expected no quarantine after window roll")
+	}
+}
+
+func TestQuarantine_SelfHealAfterQuiet(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newTestTracker(t)
+	p := filepath.Join(repo, "build", "a.o")
+
+	pump(q, repo, p, 10) // quarantine
+	if len(q.List(repo)) != 1 {
+		t.Fatalf("expected quarantine")
+	}
+
+	// Not quiet long enough → no heal.
+	clk.advance(10 * time.Minute)
+	if healed := q.Sweep(); len(healed) != 0 {
+		t.Fatalf("should not heal before quiet window, got %+v", healed)
+	}
+	if len(q.List(repo)) != 1 {
+		t.Fatalf("still quarantined expected")
+	}
+
+	// Past the 15m quiet window → heal.
+	clk.advance(6 * time.Minute)
+	healed := q.Sweep()
+	if len(healed[repo]) != 1 || healed[repo][0] != "build" {
+		t.Fatalf("expected build healed, got %+v", healed)
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("expected un-quarantined after heal")
+	}
+
+	// After heal, the dir is observed fresh again (events not dropped).
+	if q.Observe(repo, p) {
+		t.Fatalf("healed dir should accept events again")
+	}
+}
+
+func TestQuarantine_OngoingChurnDelaysHeal(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newTestTracker(t)
+	p := filepath.Join(repo, "build", "a.o")
+	pump(q, repo, p, 10)
+
+	// A still-thrashing dir keeps emitting events; each refreshes lastEvent so
+	// the quiet timer never elapses.
+	for i := 0; i < 5; i++ {
+		clk.advance(10 * time.Minute)
+		q.Observe(repo, p) // dropped, but refreshes lastEvent
+		if healed := q.Sweep(); len(healed) != 0 {
+			t.Fatalf("dir still churning must not heal, iter %d: %+v", i, healed)
+		}
+	}
+	if len(q.List(repo)) != 1 {
+		t.Fatalf("expected still quarantined")
+	}
+}
+
+func TestQuarantine_AncestorDropsDescendants(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	dir := filepath.Join(repo, "out")
+	pump(q, repo, filepath.Join(dir, "a.js"), 10) // quarantine "out"
+
+	// An event in a nested subdir of the quarantined dir is dropped too.
+	if !q.Observe(repo, filepath.Join(dir, "nested", "deep", "b.js")) {
+		t.Fatalf("event under quarantined ancestor should be dropped")
+	}
+	if !q.IsQuarantined(repo, filepath.Join(dir, "nested", "x")) {
+		t.Fatalf("nested path should report quarantined via ancestor")
+	}
+}
+
+func TestQuarantine_PersistAndReload(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	pump(q, repo, filepath.Join(repo, "build", "a.o"), 10)
+
+	// File should exist on disk.
+	data, err := os.ReadFile(quarantinePath(repo))
+	if err != nil {
+		t.Fatalf("expected persisted quarantine file: %v", err)
+	}
+	var f quarantineFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("bad json: %v", err)
+	}
+	if len(f.Dirs) != 1 || f.Dirs[0].Rel != "build" {
+		t.Fatalf("unexpected persisted content: %+v", f)
+	}
+
+	// A fresh tracker over the same repo loads the persisted set on first touch.
+	q2 := NewQuarantineTracker(nil)
+	if !q2.IsQuarantined(repo, filepath.Join(repo, "build", "z.o")) {
+		t.Fatalf("reloaded tracker should honour persisted quarantine")
+	}
+}
+
+func TestQuarantine_ManualUnquarantine(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	pump(q, repo, filepath.Join(repo, "build", "a.o"), 10)
+
+	if !q.Unquarantine(repo, "build") {
+		t.Fatalf("expected manual un-quarantine to remove entry")
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("expected empty after manual override")
+	}
+	if q.Unquarantine(repo, "nope") {
+		t.Fatalf("un-quarantining a non-quarantined dir should return false")
+	}
+}
+
+func TestQuarantine_DisabledIsNoOp(t *testing.T) {
+	repo := t.TempDir()
+	q := &QuarantineTracker{
+		cfg:         quarantineConfig{disabled: true},
+		now:         time.Now,
+		churn:       make(map[string]map[string]*dirChurn),
+		quarantined: make(map[string]map[string]QuarantineReason),
+		loaded:      make(map[string]bool),
+	}
+	for i := 0; i < 100; i++ {
+		if q.Observe(repo, filepath.Join(repo, "build", "a.o")) {
+			t.Fatalf("disabled tracker must never drop")
+		}
+	}
+}
+
+func TestQuarantine_NilReceiverSafe(t *testing.T) {
+	var q *QuarantineTracker
+	if q.Observe("/repo", "/repo/x") {
+		t.Fatalf("nil tracker Observe must be a no-op")
+	}
+	if q.IsQuarantined("/repo", "/repo/x") {
+		t.Fatalf("nil tracker IsQuarantined must be false")
+	}
+	if q.Sweep() != nil {
+		t.Fatalf("nil tracker Sweep must return nil")
+	}
+}
+
+func TestQuarantine_RepoRootNotQuarantined(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	// Events for a file directly at the repo root (dir == ".") must never
+	// quarantine the root.
+	for i := 0; i < 50; i++ {
+		if q.Observe(repo, filepath.Join(repo, "main.go")) {
+			t.Fatalf("repo-root events must never be quarantined")
+		}
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("root must not appear in quarantine set")
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -104,14 +104,18 @@ type Watcher struct {
 	cfg       Config
 	sink      EventSink
 	extraSkip map[string]struct{}
-	mu        sync.Mutex
-	fs        *fsnotify.Watcher
-	repos     map[string]*repoState // key: absolute repo path
-	dirToRepo map[string]string     // key: absolute dir path → repo path
-	stopOnce  sync.Once
-	stopCh    chan struct{}
-	stoppedCh chan struct{}
-	restartCh chan struct{} // signals heartbeat loop to recreate fsnotify
+	// quarantine is the adaptive trash detector (#5394). When non-nil, it
+	// observes per-directory churn at the event boundary and drops events
+	// under directories it has quarantined. nil disables the feature.
+	quarantine *QuarantineTracker
+	mu         sync.Mutex
+	fs         *fsnotify.Watcher
+	repos      map[string]*repoState // key: absolute repo path
+	dirToRepo  map[string]string     // key: absolute dir path → repo path
+	stopOnce   sync.Once
+	stopCh     chan struct{}
+	stoppedCh  chan struct{}
+	restartCh  chan struct{} // signals heartbeat loop to recreate fsnotify
 	// counters — accessed atomically outside mu where latency matters
 	totalEvents   uint64
 	droppedSkips  uint64
@@ -177,9 +181,48 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		stoppedCh: make(chan struct{}),
 		restartCh: make(chan struct{}, 1),
 	}
+	// Adaptive index-trash quarantine (#5394). The tracker observes
+	// per-directory churn at the event boundary and quarantines dirs that
+	// thrash pathologically (build loops the static skip + gitignore missed),
+	// then self-heals when they go quiet. Wired with the watcher's logger as
+	// the audit sink. nil/disabled is a transparent no-op.
+	logfn := func(event, repo, rel, detail string) {
+		w.logger.Info("watcher: quarantine", "event", event, "repo", repo, "dir", rel, "detail", detail)
+	}
+	w.quarantine = NewQuarantineTracker(logfn)
+
 	go w.loop()
 	go w.heartbeat()
+	go w.quarantineSweep()
 	return w, nil
+}
+
+// Quarantine returns the watcher's quarantine tracker (#5394) for the
+// transparency surface / CLI (Q2). May be nil if the feature is disabled.
+func (w *Watcher) Quarantine() *QuarantineTracker { return w.quarantine }
+
+// quarantineSweep periodically re-evaluates quarantined directories and
+// auto-un-quarantines any that have gone quiet (self-heal). The interval is a
+// fraction of the heal window so recovery is responsive without busy-looping.
+func (w *Watcher) quarantineSweep() {
+	interval := quarantineSweepInterval()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			if w.quarantine == nil {
+				continue
+			}
+			if healed := w.quarantine.Sweep(); len(healed) > 0 {
+				for repo, dirs := range healed {
+					w.logger.Info("watcher: quarantine self-heal", "repo", repo, "dirs", dirs)
+				}
+			}
+		}
+	}
 }
 
 // shouldSkipDir extends the package-level ShouldSkipDir with instance
@@ -540,6 +583,17 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 	// the reindex loop + heap thrash even when the artifact dir doesn't
 	// match a well-known static name.
 	if ShouldSkipPathForRepo(repo, ev.Name) {
+		atomic.AddUint64(&w.droppedSkips, 1)
+		return
+	}
+
+	// Adaptive quarantine (#5394): the static + gitignore filters above catch
+	// KNOWN trash; this catches the long tail. Observe per-directory churn and
+	// drop the event if its directory is — or just became — quarantined for
+	// pathological churn (a build loop the lists above didn't anticipate). A
+	// normal human edit burst stays well under the threshold, so legitimate
+	// source dirs are never quarantined.
+	if w.quarantine.Observe(repo, ev.Name) {
 		atomic.AddUint64(&w.droppedSkips, 1)
 		return
 	}


### PR DESCRIPTION
## What

Implements the **core of the self-healing index quarantine** (epic #5394, tier T1 — churn-based, the `Q0` substrate + `Q1` churn detector).

The static skip list + `.gitignore` filter (#5395) catch the ~90% of *known* index trash cheaply. This PR adds the **adaptive layer** that catches the long tail: a custom build-output dir, non-gitignored generated content, or a per-repo oddity the static list can't anticipate, that churns pathologically and trips a continuous reindex loop (the incident class fixed reactively by #5395).

## Mechanism

`Observe → Detect → Quarantine → persist → Self-heal`

- **Observe** — every watcher event that survives the static + gitignore filters is attributed to its *directory*; a per-directory sliding-window churn counter tracks "N reindex-arming events in the last window".
- **Detect / Quarantine** — when a directory's windowed churn crosses a conservative threshold it is quarantined: added to a per-repo set so subsequent events under it (and any descendant) are dropped at the event boundary — it stops arming reindexes.
- **Persist** — the set is written to `<repo>/.grafel/quarantine.json`, so a build loop that quarantined itself does not re-thrash after a daemon restart.
- **Self-heal** — a background sweep re-evaluates quarantined dirs and un-quarantines any that has gone quiet for the cool-down. Ongoing churn refreshes the quiet timer, so a still-thrashing dir stays quarantined (hysteresis — never flaps).

## Safety (the non-negotiables from the epic)

- **Conservative sustained-churn requirement** — default 40 events / 2 min. A normal human edit burst (a handful of saves) stays far below; only a mechanical build loop trips it.
- **Hysteresis** — heal cool-down (default 15 min) ≫ churn window; ongoing churn refreshes it.
- **Never quarantines the repo root.**
- **Env-tunable + kill switch** — `GRAFEL_QUARANTINE_DISABLE`, `..._CHURN_THRESHOLD`, `..._CHURN_WINDOW_SEC`, `..._HEAL_QUIET_SEC`, `..._SWEEP_SEC`.
- **Audit log** — every quarantine / un-quarantine decision logged via the watcher logger with the triggering signal.
- **Extends, never duplicates** the static + gitignore skip (this layer only sees paths those already let through).

## Code

- `internal/daemon/watch/quarantine.go` — `QuarantineTracker` (clock-injectable, goroutine-safe, nil-safe). Observe/Sweep/List/Unquarantine + persistence.
- `internal/daemon/watch/watcher.go` — wired into `handleEvent` after the static+gitignore filters; background `quarantineSweep` goroutine; `Quarantine()` accessor for the future transparency surface.

## Tests

Deterministic via an injected fake clock (no real timing, no live fsnotify):
churn trips quarantine; **normal edit burst does NOT**; window roll resets the count; self-heal after quiet; ongoing churn delays heal; ancestor drops descendants; persist + reload across a fresh tracker; manual override; disabled no-op; nil-receiver safety; repo root never quarantined.

`go build ./...`, `go test -count=1 ./internal/daemon/watch/...`, `gofmt -l`, `go vet` — all green.

## Scope / follow-ups (still in 0.1.6 — filed, not dropped)

This PR is the substrate + churn detector. Remaining epic tiers are filed as focused sub-issues:
- **Q2** — transparency surface: dashboard "Quarantined paths" panel + `grafel quarantine list/add/remove/pin` CLI (the tracker already exposes `List` / `Unquarantine` / `Pinned`).
- **Q3** — auto-recover on query/reference (un-quarantine a path that later gets queried).
- **Q4** — value-based detection (T2: expensive-to-index ∧ unused).
- **Q5** — content-signature detection (T3: minified/generated/vendored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
