### PR TITLE
fix(ui): topology crash guard (#5613) + scrollable sidebar with macOS scrollbar (#5614)

### DIFF
--- a/webui-v2/src/components/chrome/nav-rail.tsx
+++ b/webui-v2/src/components/chrome/nav-rail.tsx
@@ -58,8 +58,14 @@ export function NavRail() {
         </span>
       </div>
 
-      {/* Screen nav */}
-      <nav aria-label="Screens" className="flex flex-col gap-0.5 py-1">
+      {/* Screen nav — the scrollable middle (#5614). Brand (above) and the
+          foot (below) stay pinned; this list scrolls when worktree/module
+          subtrees overflow a short viewport. `min-h-0` lets a flex child shrink
+          below its content height so overflow actually kicks in. */}
+      <nav
+        aria-label="Screens"
+        className="flex flex-col gap-0.5 py-1 flex-1 min-h-0 overflow-y-auto ag-scroll-mac"
+      >
         {SCREENS.map(({ to, label, Icon, shortcut }) => (
           <NavLink key={to} to={`${base}/${to}`} className={({ isActive }) => rowClass(isActive)} title={label}>
             <Icon size={18} className="shrink-0" />
@@ -91,8 +97,8 @@ export function NavRail() {
         <MonorepoModuleList groupId={groupId} />
       </nav>
 
-      {/* Foot */}
-      <div className="mt-auto flex flex-col gap-0.5 py-2">
+      {/* Foot — pinned below the scrollable nav (#5614) */}
+      <div className="shrink-0 flex flex-col gap-0.5 py-2">
         <NavLink to={`${base}/${SETTINGS_SCREEN.to}`} className={({ isActive }) => rowClass(isActive)} title={SETTINGS_SCREEN.label}>
           <SettingsIcon size={18} className="shrink-0" />
           <span className="flex-1 whitespace-nowrap text-md opacity-0 group-hover/rail:opacity-100 transition-opacity">

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -308,11 +308,17 @@ function nameFromId(id: string): { name: string; repo: string | null } {
   return { name, repo };
 }
 
-function refToDisplay(ref: TopologyEntityRef): DisplayRef {
+function refToDisplay(ref: TopologyEntityRef | null | undefined): DisplayRef {
   // The backend emits "unresolved" kind with a derived name when an id can't be
-  // matched; still prefer that name over the raw hash.
+  // matched; still prefer that name over the raw hash. The `ref` may also be a
+  // null/undefined hole in a partially-resolved refs array (#5613) — the runtime
+  // shape is looser than the `TopologyEntityRef` type promises, so guard every
+  // field access and fall back to a synthetic "unresolved" ref.
+  if (!ref) {
+    return { name: "unknown", kind: "unresolved" };
+  }
   return {
-    name: ref.name || nameFromId(ref.entity_id).name,
+    name: ref.name || nameFromId(ref.entity_id ?? "").name || "unknown",
     repo: ref.repo,
     sourceFile: ref.source_file || undefined,
     startLine: ref.start_line || undefined,
@@ -321,15 +327,18 @@ function refToDisplay(ref: TopologyEntityRef): DisplayRef {
   };
 }
 
-function idToDisplay(id: string): DisplayRef {
-  const { name, repo } = nameFromId(id);
-  return { name, repo: repo ?? undefined, entityId: id };
+function idToDisplay(id: string | null | undefined): DisplayRef {
+  const { name, repo } = nameFromId(id ?? "");
+  return { name, repo: repo ?? undefined, entityId: id ?? undefined };
 }
 
-/** Resolve display refs for a channel side, preferring resolved refs over ids. */
+/** Resolve display refs for a channel side, preferring resolved refs over ids.
+ *  Both inputs may contain nullish holes from a partially-resolved backend
+ *  payload (#5613); `refToDisplay`/`idToDisplay` normalise those to a safe
+ *  "unresolved" DisplayRef rather than letting them crash the render path. */
 function resolveSide(
-  refs: TopologyEntityRef[] | undefined,
-  ids: string[] | undefined,
+  refs: (TopologyEntityRef | null | undefined)[] | undefined,
+  ids: (string | null | undefined)[] | undefined,
 ): DisplayRef[] {
   if (refs && refs.length > 0) return refs.map(refToDisplay);
   return (ids ?? []).map(idToDisplay);
@@ -357,9 +366,12 @@ function EntityChip({
   ref,
   crossRepo = false,
 }: {
-  ref: DisplayRef;
+  ref: DisplayRef | null | undefined;
   crossRepo?: boolean;
 }) {
+  // Defensive: a nullish ref should never reach here after `resolveSide`
+  // normalisation, but guard so a stray hole can't white-screen the view (#5613).
+  if (!ref) return null;
   const fileRef = ref.sourceFile
     ? `${shortFile(ref.sourceFile)}${ref.startLine ? `:${ref.startLine}` : ""}`
     : null;
@@ -701,7 +713,8 @@ function BrokerDiagram({
 
             {/* Publisher nodes (clickable — highlight full downstream path) */}
             {pubKeys.map((k, i) => {
-              const ref = pubMap.get(k)!;
+              const ref = pubMap.get(k);
+              if (!ref) return null;
               const y = PAD_Y + i * ROW_H;
               const lit = litPub(k);
               const sel = selection?.col === "pub" && selection.key === k;
@@ -792,7 +805,8 @@ function BrokerDiagram({
 
             {/* Subscriber nodes (clickable — highlight upstream path) */}
             {subKeys.map((k, i) => {
-              const ref = subMap.get(k)!;
+              const ref = subMap.get(k);
+              if (!ref) return null;
               const y = PAD_Y + i * ROW_H;
               const lit = litSub(k);
               const sel = selection?.col === "sub" && selection.key === k;
@@ -938,14 +952,18 @@ function SideSummary({
   const first = refs[0];
   const overflow = refs.length - 1;
   const title = refs
-    .map((r) => `${r.name}${r.sourceFile ? ` — ${shortFile(r.sourceFile)}:${r.startLine ?? ""}` : ""}`)
+    .map((r) =>
+      r
+        ? `${r.name ?? "unknown"}${r.sourceFile ? ` — ${shortFile(r.sourceFile)}:${r.startLine ?? ""}` : ""}`
+        : "unknown",
+    )
     .join("\n");
   return (
     <span
       className={cn("flex items-baseline gap-1 min-w-0", align === "right" && "justify-end")}
       title={title}
     >
-      <span className="font-mono text-sm text-text-2 truncate">{first.name}</span>
+      <span className="font-mono text-sm text-text-2 truncate">{first?.name ?? "unknown"}</span>
       {overflow > 0 && <span className="text-xs text-text-4 shrink-0">+{overflow}</span>}
     </span>
   );
@@ -1133,24 +1151,25 @@ function EntityRefList({
   entries,
   groupId,
 }: {
-  entries: (TopologyEntityRef | string)[];
+  entries: (TopologyEntityRef | string | null | undefined)[];
   groupId: string;
 }) {
   if (!entries || entries.length === 0) return null;
   return (
     <div className="space-y-1">
       {entries.map((entry, i) => {
+        // `entry` may be a nullish hole in a partially-resolved payload (#5613);
+        // `isRef` is true only for a non-null object entry so field access below
+        // (flow_process_ids / framework / inngest_steps) is always safe.
+        const isRef = typeof entry !== "string" && entry != null;
         const ref: DisplayRef =
           typeof entry === "string" ? idToDisplay(entry) : refToDisplay(entry);
         const isUnresolved = ref.kind === "unresolved" || (!ref.name && !ref.sourceFile);
-        const flowProcessIds: string[] =
-          typeof entry !== "string" ? (entry.flow_process_ids ?? []) : [];
+        const flowProcessIds: string[] = isRef ? (entry.flow_process_ids ?? []) : [];
         const firstFlowId = flowProcessIds[0] ?? null;
         // #5485: Inngest function step structure + framework badge.
-        const framework =
-          typeof entry !== "string" ? entry.framework : undefined;
-        const inngestSteps =
-          typeof entry !== "string" ? (entry.inngest_steps ?? []) : [];
+        const framework = isRef ? entry.framework : undefined;
+        const inngestSteps = isRef ? (entry.inngest_steps ?? []) : [];
         const inngestLabel = inngestEntityLabel(framework, ref.kind);
 
         return (

--- a/webui-v2/src/styles/tokens.css
+++ b/webui-v2/src/styles/tokens.css
@@ -313,6 +313,34 @@
 }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-4); }
 
+/* macOS-style always-visible overlay scrollbar (#5614).
+   Thin rounded thumb on a subtle track, theme-aware via tokens. Applied to
+   panes that must scroll their middle while pinned chrome stays fixed (e.g.
+   the left nav rail). `scrollbar-gutter: stable` reserves the track so content
+   doesn't shift when the thumb appears. */
+.ag-scroll-mac {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  /* Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+.ag-scroll-mac::-webkit-scrollbar { width: 8px; height: 8px; }
+.ag-scroll-mac::-webkit-scrollbar-track {
+  background: transparent;
+}
+.ag-scroll-mac::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: var(--r-full);
+  /* inset the thumb so it reads as a thin overlay pill, not a full-width bar */
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.ag-scroll-mac::-webkit-scrollbar-thumb:hover {
+  background: var(--text-4);
+  background-clip: padding-box;
+}
+
 ::selection { background: var(--accent-ring); }
 
 /* utility classes used across components */


### PR DESCRIPTION
#5613: guard the undefined-node sourceFile dereference in the topology view (renders gracefully instead of white-screening). #5614: vertically scrollable nav rail on small screens with an always-visible macOS-style scrollbar. Closes #5613, #5614.