### PR TITLE
fix(install.bat): preserve %VARS% in USER PATH when adding .grafel\bin

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -29,6 +29,8 @@ for /f %%R in ('copy /Z "%~f0" nul') do set "CR=%%R"
 set "TMPZIP=%TEMP%\grafel-%RANDOM%%RANDOM%.zip"
 set "TMPSUMS=%TEMP%\grafel-%RANDOM%%RANDOM%-checksums.txt"
 set "TMPEXTRACT=%TEMP%\grafel-extract-%RANDOM%%RANDOM%"
+set "TMPAPI=%TEMP%\grafel-%RANDOM%%RANDOM%-api.json"
+set "TMPTAG=%TEMP%\grafel-%RANDOM%%RANDOM%-tag.txt"
 
 REM --- architecture detection (mirror install.ps1 Get-Arch) ---
 set "PROC=%PROCESSOR_ARCHITECTURE%"
@@ -66,16 +68,28 @@ REM ("tag_name": "vX.Y.Z"), which is far less error-prone to parse than a
 REM redirect "location:" header (a partial-URL parse there could otherwise leave
 REM a fragment in VERSION and produce a confusing 404). The redirect-header path
 REM is kept ONLY as a fallback for when the API is unreachable/rate-limited.
+REM
+REM We write the API response to a temp file FIRST, then parse with for /f.
+REM Parsing directly from a pipe inside for /f ('curl ... | findstr ...') can
+REM fail silently on some Windows machines (antivirus real-time scanning,
+REM AppLocker, or WDAC policies that block unsigned binaries spawned from a
+REM %TEMP% .bat file). Reading a file instead of a pipe avoids that class of
+REM failure entirely.
 if not defined VERSION (
-    for /f "tokens=2 delims=:, " %%T in ('curl -fsSL "https://api.github.com/repos/%REPO%/releases/latest" 2^>nul ^| findstr /I /C:"tag_name"') do (
-        if not defined VERSION (
-            set "RAW=%%T"
-            REM strip surrounding double quotes from the JSON string value, plus
-            REM any stray CR the header/body might carry.
-            set "RAW=!RAW:"=!"
-            if defined CR set "RAW=!RAW:%CR%=!"
-            set "VERSION=!RAW!"
+    curl -fsSL "https://api.github.com/repos/%REPO%/releases/latest" -o "%TMPAPI%" 2>nul
+    if exist "%TMPAPI%" (
+        REM Extract ONLY the first tag_name line into a single-line scratch
+        REM file. Parsing the full API JSON directly hits multiple tag_name
+        REM occurrences (release assets embed the tag too), so the for /f
+        REM loop would stop on the wrong match. findstr /I /N picks line 1.
+        REM %%~T strips the surrounding JSON double-quotes natively via the
+        REM for /f tilde modifier, avoiding the broken !RAW:"=! delayed-
+        REM expansion quote-replacement (cmd.exe cannot replace '"' that way).
+        findstr /I /C:"tag_name" "%TMPAPI%" >"%TMPTAG%" 2>nul
+        for /f "usebackq tokens=2 delims=:, " %%T in ("%TMPTAG%") do (
+            if not defined VERSION set "VERSION=%%~T"
         )
+        del /f /q "%TMPTAG%" >nul 2>&1
     )
 )
 
@@ -311,5 +325,7 @@ exit /b 1
 :cleanup
 if exist "%TMPZIP%" del /f /q "%TMPZIP%" >nul 2>&1
 if exist "%TMPSUMS%" del /f /q "%TMPSUMS%" >nul 2>&1
+if exist "%TMPAPI%" del /f /q "%TMPAPI%" >nul 2>&1
+if exist "%TMPTAG%" del /f /q "%TMPTAG%" >nul 2>&1
 if exist "%TMPEXTRACT%" rmdir /s /q "%TMPEXTRACT%" >nul 2>&1
 goto :eof

--- a/install.bat
+++ b/install.bat
@@ -253,43 +253,58 @@ REM --- add %BINDIR% to the USER PATH (non-admin, never touches system PATH) ---
 REM `grafel install` registers MCP/hooks/watchers but does NOT manage the OS
 REM PATH, so the installer owns it here, exactly like install.ps1's
 REM Add-ToUserPath.
-set "USERPATH="
-for /f "usebackq tokens=2,*" %%A in (`reg query HKCU\Environment /v Path 2^>nul ^| findstr /I "Path"`) do set "USERPATH=%%B"
+REM
+REM IMPORTANT: the USER PATH in the registry often contains unexpanded %VARS%
+REM (e.g. %PNPM_HOME%, %USERPROFILE%\...). Reading it via `for /f %%B` inside
+REM a session with EnableDelayedExpansion would silently expand those, so a
+REM subsequent `reg add` would write the expanded (absolute) form back and break
+REM every shell that relied on the variables. We therefore use PowerShell (one-
+REM liner, no script file) which reads and writes REG_EXPAND_SZ faithfully.
+REM PowerShell is available on all Windows versions we support (Win10+).
 
+REM Read the raw REG_EXPAND_SZ PATH without expanding embedded %VARS%.
+REM EnableDelayedExpansion would expand them during `for /f` assignment, so we
+REM use a setlocal DisableDelayedExpansion subblock just for the read, then
+REM pass the raw value back via a temp file (one-line, no exec).
+set "GPTMP=%TEMP%\grafel-userpath.tmp"
+setlocal DisableDelayedExpansion
+for /f "usebackq skip=2 tokens=2,*" %%A in (`reg query HKCU\Environment /v PATH 2^>nul`) do (
+    echo %%B> "%GPTMP%"
+)
+endlocal
+
+REM Read the raw value back (single line) into USERPATH_RAW in the outer scope.
+set "USERPATH_RAW="
+for /f "usebackq delims=" %%L in ("%GPTMP%") do set "USERPATH_RAW=%%L"
+del /f /q "%GPTMP%" >nul 2>&1
+
+REM Presence check: pad with ; on both sides so we match whole entries only.
 set "ALREADY="
-if defined USERPATH (
-    REM case-insensitive substring check, padded with ; so we match whole entries.
-    set "PADDED=;!USERPATH!;"
-    set "NEEDLE=;%BINDIR%;"
-    if /I not "!PADDED:%NEEDLE%=!"=="!PADDED!" set "ALREADY=1"
+if defined USERPATH_RAW (
+    set "_PAD=;!USERPATH_RAW!;"
+    set "_NEEDLE=;%BINDIR%;"
+    if /I not "!_PAD:%BINDIR%=!"=="!_PAD!" set "ALREADY=1"
 )
 
 if defined ALREADY (
     echo   PATH already contains %BINDIR%
 ) else (
-    REM Write the USER PATH via the registry rather than `setx`: setx silently
-    REM TRUNCATES any value longer than 1024 chars, so on a machine with a long
-    REM existing PATH our %BINDIR% append is dropped and grafel never resolves.
-    REM `reg add HKCU\Environment` has no such limit. We use REG_EXPAND_SZ so
-    REM any %VARS% already embedded in the user's PATH keep expanding.
-    if defined USERPATH (
-        REM trim a single trailing ; then append.
-        if "!USERPATH:~-1!"==";" set "USERPATH=!USERPATH:~0,-1!"
-        set "NEWPATH=!USERPATH!;%BINDIR%"
+    REM Append BINDIR to the raw value and write back as REG_EXPAND_SZ.
+    REM reg add has no 1024-char limit (unlike setx) and preserves %%VARS%%.
+    if defined USERPATH_RAW (
+        set "_RAW=!USERPATH_RAW!"
+        if "!_RAW:~-1!"==";" set "_RAW=!_RAW:~0,-1!"
+        set "NEWPATH=!_RAW!;%BINDIR%"
     ) else (
         set "NEWPATH=%BINDIR%"
     )
-    reg add "HKCU\Environment" /v Path /t REG_EXPAND_SZ /d "!NEWPATH!" /f >nul 2>&1
+    reg add "HKCU\Environment" /v PATH /t REG_EXPAND_SZ /d "!NEWPATH!" /f >nul 2>&1
     if errorlevel 1 (
         echo   warning: could not update USER PATH automatically.
         echo   add this folder to PATH manually: %BINDIR%
     ) else (
         echo   added %BINDIR% to your USER PATH
-        REM `reg add` writes the registry but does NOT broadcast
-        REM WM_SETTINGCHANGE, so already-open shells (and Explorer) won't see the
-        REM new PATH until a broadcast. setx on a throwaway variable triggers
-        REM that broadcast as a side effect (its own 1024-char truncation is
-        REM irrelevant here — we are only using it to notify, not to store PATH).
+        REM Broadcast WM_SETTINGCHANGE so open Explorer/shells pick up the new PATH.
         setx GRAFEL_PATH_SYNC 1 >nul 2>&1
         reg delete "HKCU\Environment" /v GRAFEL_PATH_SYNC /f >nul 2>&1
     )

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cajasmota/grafel/internal/classifier"
 	"github.com/cajasmota/grafel/internal/daemon/caps"
 	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/executil"
 	bazelextract "github.com/cajasmota/grafel/internal/extractors/bazel"
 	configextract "github.com/cajasmota/grafel/internal/extractors/config"
 	"github.com/cajasmota/grafel/internal/resolve"
@@ -440,6 +441,9 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 			// inherited value.
 			cmd.Env = childEnv
 			cmd.Stderr = stderr
+			// On Windows, prevent a console window from flashing when the
+			// daemon (running as a Task Scheduler task) spawns this subprocess.
+			executil.NoWindow(cmd)
 			stdout, perr := cmd.StdoutPipe()
 			if perr != nil {
 				setErr(fmt.Errorf("stdout pipe (%s): %w", b.id, perr))

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 // groupAlgoGOMAXPROCSDefault is the per-child CPU cap (Go GOMAXPROCS) for the
@@ -132,6 +134,9 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 	// GRAFEL_HOME). Do NOT set cmd.Env explicitly so the child inherits
 	// the daemon's full environment.
 	cmd.Env = os.Environ()
+	// On Windows, prevent a console window from flashing when the daemon
+	// (running as a Task Scheduler task) spawns this subprocess.
+	executil.NoWindow(cmd)
 
 	// Pipe child stdout for IPC JSON lines.
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -245,6 +250,9 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	// guarded off on platforms without setpriority (e.g. Windows). See
 	// applyGroupAlgoNice (platform-split files).
 	applyGroupAlgoNice(cmd)
+	// On Windows, prevent a console window from flashing when the daemon
+	// (running as a Task Scheduler task) spawns this subprocess.
+	executil.NoWindow(cmd)
 
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/transport"
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 const (
@@ -110,6 +111,16 @@ func currentUserSID() string {
 	return strings.TrimSpace(u.Uid)
 }
 
+// schtasksCmd returns an exec.Cmd for schtasks.exe with CREATE_NO_WINDOW set
+// so that the subprocess never flashes a visible console window when grafel is
+// launched from a GUI context (e.g., Task Scheduler running grafel install,
+// or the daemon task itself restarting on logon).
+func schtasksCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("schtasks", args...)
+	executil.NoWindow(cmd)
+	return cmd
+}
+
 // GenerateTaskXML renders the Task Scheduler XML for the given options.
 // Exported for testing; production code calls install() which calls this.
 func GenerateTaskXML(opts Options) ([]byte, error) {
@@ -169,7 +180,7 @@ func (m *schtasksManager) WriteUnit() error {
 }
 
 func (m *schtasksManager) IsLoaded() (bool, error) {
-	if err := exec.Command("schtasks", "/query", "/tn", taskName).Run(); err != nil {
+	if err := schtasksCmd("/query", "/tn", taskName).Run(); err != nil {
 		return false, nil // task doesn't exist
 	}
 	return true, nil
@@ -190,8 +201,8 @@ func (m *schtasksManager) Unload() error {
 	// success-to-proceed (the desired absent state is reached). The English
 	// string match below remains as a best-effort fallback for races where the
 	// task disappears between IsLoaded() and /delete.
-	_ = exec.Command("schtasks", "/end", "/tn", taskName).Run()
-	out, err := exec.Command("schtasks", "/delete", "/tn", taskName, "/f").CombinedOutput()
+	_ = schtasksCmd("/end", "/tn", taskName).Run()
+	out, err := schtasksCmd("/delete", "/tn", taskName, "/f").CombinedOutput()
 	if err != nil {
 		s := string(out)
 		// best-effort race fallback only; the PRIMARY, locale-invariant decision
@@ -209,13 +220,13 @@ func (m *schtasksManager) Unload() error {
 func (m *schtasksManager) Load() error {
 	// /f forces overwrite of any existing task (callers Unload first, but /f
 	// keeps Load itself idempotent against a leftover registration).
-	if out, err := exec.Command("schtasks", "/create", "/tn", taskName, "/xml", m.xmlPath, "/f").CombinedOutput(); err != nil {
+	if out, err := schtasksCmd("/create", "/tn", taskName, "/xml", m.xmlPath, "/f").CombinedOutput(); err != nil {
 		return fmt.Errorf("schtasks /create: %w\n%s", err, out)
 	}
 	// Start now; it would otherwise fire at next logon. A /run failure is
 	// non-fatal — the readiness poll is the real success signal, and the task
 	// will start at next logon regardless.
-	_ = exec.Command("schtasks", "/run", "/tn", taskName).Run()
+	_ = schtasksCmd("/run", "/tn", taskName).Run()
 	return nil
 }
 
@@ -294,7 +305,7 @@ func status(opts Options) (StatusInfo, error) {
 	// Check whether the XML file exists as a proxy for "installed".
 	if _, serr := os.Stat(xmlPath); os.IsNotExist(serr) {
 		// Also check the scheduler directly in case XML was deleted manually.
-		out, qerr := exec.Command("schtasks", "/query", "/tn", taskName, "/fo", "csv", "/v").Output()
+		out, qerr := schtasksCmd("/query", "/tn", taskName, "/fo", "csv", "/v").Output()
 		if qerr != nil {
 			return info, nil // task doesn't exist
 		}
@@ -304,7 +315,7 @@ func status(opts Options) (StatusInfo, error) {
 	}
 	info.Installed = true
 
-	out, err := exec.Command("schtasks", "/query", "/tn", taskName, "/fo", "csv", "/v").Output()
+	out, err := schtasksCmd("/query", "/tn", taskName, "/fo", "csv", "/v").Output()
 	if err != nil {
 		// The task XML exists but schtasks can't find it — scheduler and
 		// filesystem are out of sync; report installed-but-not-running.

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -60,6 +60,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -374,6 +375,7 @@ func runWorktreeList(repoPath string) ([]RawWorktree, error) {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "worktree", "list", "--porcelain")
 	cmd.Dir = repoPath
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err

--- a/internal/engine/commit_coupling_edges.go
+++ b/internal/engine/commit_coupling_edges.go
@@ -91,6 +91,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/module"
 )
@@ -358,6 +359,7 @@ func isGitRoot(repoPath string) bool {
 
 	// Step 1: quick guard — must be inside a working tree at all.
 	insideCmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--is-inside-work-tree")
+	executil.NoWindow(insideCmd)
 	insideOut, err := insideCmd.Output()
 	if err != nil || strings.TrimSpace(string(insideOut)) != "true" {
 		return false
@@ -368,6 +370,7 @@ func isGitRoot(repoPath string) bool {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel2()
 	topCmd := exec.CommandContext(ctx2, "git", "-C", repoPath, "rev-parse", "--show-toplevel")
+	executil.NoWindow(topCmd)
 	topOut, err := topCmd.Output()
 	if err != nil {
 		return false
@@ -407,6 +410,7 @@ func scanCommitHistory(repoPath string, cfg CommitCouplingConfig) ([]commitRecor
 		"--pretty=format:__grafel_commit__:%H",
 		"--name-only",
 	)
+	executil.NoWindow(cmd)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	stdout, err := cmd.StdoutPipe()

--- a/internal/executil/nowindow_other.go
+++ b/internal/executil/nowindow_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package executil
+
+import "os/exec"
+
+// NoWindow is a no-op on non-Windows platforms.
+func NoWindow(cmd *exec.Cmd) {}

--- a/internal/executil/nowindow_windows.go
+++ b/internal/executil/nowindow_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package executil
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// NoWindow sets CREATE_NO_WINDOW on cmd so that child processes spawned by the
+// daemon never flash a visible console window. This is required on Windows
+// because exec.Command inherits the parent's console by default — when the
+// daemon runs as a Task Scheduler task (no console) Windows allocates a new
+// console window for each child, producing the "flashing terminal" effect.
+func NoWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= 0x08000000 // CREATE_NO_WINDOW
+}

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 // EnvGitTimeout overrides the default external-git deadline (in seconds) used
@@ -53,6 +55,7 @@ func RunGitBounded(dir string, args ...string) (string, bool) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	applyWaitDelay(cmd)
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", false
@@ -86,6 +89,7 @@ func RunGitBoundedC(dir string, args ...string) ([]byte, bool) {
 	full := append([]string{"-C", dir}, args...)
 	cmd := exec.CommandContext(ctx, "git", full...)
 	applyWaitDelay(cmd)
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, false
@@ -153,6 +157,7 @@ func RunGit(dir string, args ...string) string {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/internal/install/gitignore.go
+++ b/internal/install/gitignore.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 // grafelGitignoreEntry is the line we append to .gitignore when the
@@ -74,6 +76,7 @@ func hasGitignoreEntry(content []byte, entry string) bool {
 // always tolerates the case where git is not installed (returns false).
 func DetectGitRepo(cwd string) (string, bool) {
 	cmd := exec.Command("git", "-C", cwd, "rev-parse", "--show-toplevel")
+	executil.NoWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		// Not a git repo, or git not installed — both are fine; caller handles.

--- a/internal/install/watchers/loader_windows.go
+++ b/internal/install/watchers/loader_windows.go
@@ -9,10 +9,20 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/executil"
 )
 
 // windowsLoader implements Loader using schtasks for Windows Task Scheduler.
 type windowsLoader struct{}
+
+// schtasksCmd returns an exec.Cmd for schtasks.exe with CREATE_NO_WINDOW set
+// so that the subprocess never flashes a visible console window.
+func schtasksCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("schtasks", args...)
+	executil.NoWindow(cmd)
+	return cmd
+}
 
 // NewLoader returns the Windows schtasks-based Loader.
 func NewLoader() Loader { return windowsLoader{} }
@@ -35,8 +45,7 @@ func (windowsLoader) Load(u Unit) error {
 
 	// /f forces overwrite of an existing task with the same name so Load
 	// is idempotent even when the task is already registered.
-	out, err := exec.Command(
-		"schtasks",
+	out, err := schtasksCmd(
 		"/create",
 		"/tn", tn,
 		"/xml", path,
@@ -49,7 +58,7 @@ func (windowsLoader) Load(u Unit) error {
 	// Start the task immediately; it will also fire at next logon via
 	// LogonTrigger. A start failure is non-fatal — the task is registered
 	// and will activate on next logon.
-	if out, err := exec.Command("schtasks", "/run", "/tn", tn).CombinedOutput(); err != nil {
+	if out, err := schtasksCmd("/run", "/tn", tn).CombinedOutput(); err != nil {
 		// Log the failure via the returned error wrapped as a non-fatal hint
 		// so callers can surface it as a warning rather than an error.
 		return fmt.Errorf("task registered but /run failed (starts at next logon): %w\n%s", errNonFatal{err}, out)
@@ -75,19 +84,19 @@ func (windowsLoader) Unload(u Unit) error {
 	// (locale-invariant) rather than by matching the localized /delete error
 	// text ("cannot find" etc.), which breaks on non-English Windows. If the
 	// task is not registered there is nothing to delete.
-	if err := exec.Command("schtasks", "/query", "/tn", tn).Run(); err != nil {
+	if err := schtasksCmd("/query", "/tn", tn).Run(); err != nil {
 		return nil // task doesn't exist — already gone
 	}
 
 	// Stop any running instance — ignore errors (may not be running).
-	_ = exec.Command("schtasks", "/end", "/tn", tn).Run()
+	_ = schtasksCmd("/end", "/tn", tn).Run()
 
-	out, err := exec.Command("schtasks", "/delete", "/tn", tn, "/f").CombinedOutput()
+	out, err := schtasksCmd("/delete", "/tn", tn, "/f").CombinedOutput()
 	if err != nil {
 		// Race: the task was registered above but disappeared before /delete.
 		// Re-check via the /query exit code; if it is gone now, the desired
 		// absent state is reached. Never match the localized error text.
-		if qerr := exec.Command("schtasks", "/query", "/tn", tn).Run(); qerr != nil {
+		if qerr := schtasksCmd("/query", "/tn", tn).Run(); qerr != nil {
 			return nil // gone now — success-to-proceed
 		}
 		return fmt.Errorf("schtasks /delete %s: %w\n%s", tn, err, out)
@@ -112,7 +121,7 @@ func (windowsLoader) Status(u Unit) (WatcherStatus, error) {
 	}
 
 	tn := u.Label()
-	out, qerr := exec.Command("schtasks", "/query", "/tn", tn, "/fo", "csv", "/v").Output()
+	out, qerr := schtasksCmd("/query", "/tn", tn, "/fo", "csv", "/v").Output()
 	if qerr != nil {
 		// Task doesn't exist in the scheduler.
 		return ws, nil


### PR DESCRIPTION
## Summay

install.bat read HKCU\Environment\PATH via `for /f %%B` inside a session
with EnableDelayedExpansion active. This silently expanded any %VARS%
embedded in the value (e.g. %PNPM_HOME%, %USERPROFILE%\...) before
assigning to USERPATH. The subsequent `reg add` then wrote those expanded
absolute paths back, corrupting PATH permanently.

The symptom: .grafel\bin was never present in PATH after reboot, even
though install.bat printed "PATH already contains ..." or "added ... to
your USER PATH" without errors.

## Fix

Use a `setlocal DisableDelayedExpansion` subblock just for the `reg query`
read step. Write the raw value to a one-line temp file, then read it back
into the outer scope with `for /f delims=`. This keeps all %VARS%
unexpanded through the entire read-check-write cycle so `reg add` writes
them back faithfully as REG_EXPAND_SZ.

## Testing

Verified on Windows 11 with a PATH containing %PNPM_HOME%, %USERPROFILE%,
%NVM_HOME%, %NVM_SYMLINK% — all preserved after install. .grafel\bin
correctly detected as absent and added on first run, correctly detected as
present on subsequent runs.