### PR TITLE
fix(install): preserve embedded %VARS% when updating Windows USER PATH (from #5624)

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -253,8 +253,26 @@ REM --- add %BINDIR% to the USER PATH (non-admin, never touches system PATH) ---
 REM `grafel install` registers MCP/hooks/watchers but does NOT manage the OS
 REM PATH, so the installer owns it here, exactly like install.ps1's
 REM Add-ToUserPath.
+REM IMPORTANT: the USER PATH in the registry often contains unexpanded %VARS%
+REM (e.g. %PNPM_HOME%, %USERPROFILE%\...). Reading it via `for /f %%B` inside
+REM this session (which runs under EnableDelayedExpansion) would silently expand
+REM those vars, so the subsequent `reg add` would write the expanded (absolute)
+REM form back and break every shell that relied on those variables. We therefore
+REM read the raw REG_EXPAND_SZ value inside a `setlocal DisableDelayedExpansion`
+REM subblock and hand it back to the outer scope via a one-line temp file.
+set "GPTMP=%TEMP%\grafel-userpath-%RANDOM%%RANDOM%.tmp"
+setlocal DisableDelayedExpansion
+for /f "usebackq skip=2 tokens=2,*" %%A in (`reg query HKCU\Environment /v Path 2^>nul`) do (
+    echo %%B> "%GPTMP%"
+)
+endlocal
+
+REM Read the raw value back (single line) into USERPATH in the outer scope.
 set "USERPATH="
-for /f "usebackq tokens=2,*" %%A in (`reg query HKCU\Environment /v Path 2^>nul ^| findstr /I "Path"`) do set "USERPATH=%%B"
+if exist "%GPTMP%" (
+    for /f "usebackq delims=" %%L in ("%GPTMP%") do set "USERPATH=%%L"
+    del /f /q "%GPTMP%" >nul 2>&1
+)
 
 set "ALREADY="
 if defined USERPATH (


### PR DESCRIPTION
## What

Net-new fix extracted from community PR #5624 by @walter-ajanel.

The Windows `install.bat` read the USER `PATH` from `HKCU\Environment` with a
`for /f` loop while the script runs under `EnableDelayedExpansion`. Any
unexpanded variables embedded in the stored PATH (e.g. `%PNPM_HOME%`,
`%USERPROFILE%\...`) get silently expanded during that read. The subsequent
`reg add ... REG_EXPAND_SZ` then writes the **expanded (absolute)** form back,
breaking every shell that relied on those variables.

## Fix

Read the raw `REG_EXPAND_SZ` PATH inside a `setlocal DisableDelayedExpansion`
subblock and hand the value back to the outer scope via a one-line temp file,
so embedded `%VARS%` are preserved. The registry-based write (the
setx-1024-char-truncation fix) is unchanged — we only correct the **read**.

## Context

Most of #5624 (the `NoWindow` subprocess helper + the `install.bat`
temp-file / `%%~T` release-tag resolver) already shipped in v0.1.5.4 via #5604,
which is why #5624 conflicts on `main`. This PR carries only the genuinely
net-new delta — the PATH delayed-expansion fix — applied cleanly on top of
current `main`, with credit to the original contributor.

Credit: @walter-ajanel (`Co-authored-by` trailer on the commit).

## Verification

- `setlocal`/`endlocal` balanced (3/3); the raw read is scoped entirely inside
  the `DisableDelayedExpansion` block.
- `go build ./...` unaffected (no Go change in this PR).
- Installer not executed.