### PR TITLE
feat(quarantine): auto-recover a quarantined dir on query/reference (#5618)

### DIFF
--- a/cmd/grafel/daemon_tier.go
+++ b/cmd/grafel/daemon_tier.go
@@ -190,6 +190,20 @@ func onWatcherReady(w *watch.Watcher, logger *slog.Logger) {
 		daemonTierMgr.SetWatcherHook(mgr)
 		logger.Info("tier: watcher pause/resume hook wired (M2 lazy-subscribe — 0 subscriptions at boot)")
 	}
+
+	// Q3 (#5618): wire the index-quarantine auto-recover hook into the MCP
+	// server. The watcher owns the QuarantineTracker; the MCP query path calls
+	// Recover when it resolves an entity, so a dir quarantined as index trash
+	// that later proves real (its content is queried) is un-quarantined
+	// immediately rather than waiting out the quiet-window self-heal. Best-effort:
+	// if the MCP server is not yet initialised, the hook is simply not wired (the
+	// quiet-window Sweep still recovers genuinely-idle dirs).
+	if qt := w.Quarantine(); qt != nil {
+		if srv, err := mcpServerInstance(); err == nil && srv != nil {
+			srv.SetQuarantineRecoverer(qt)
+			logger.Info("quarantine: auto-recover-on-query hook wired into MCP server (#5618)")
+		}
+	}
 }
 
 // SubscribeGroupWatcher lazily subscribes the fsnotify watcher for all repos

--- a/internal/daemon/watch/quarantine.go
+++ b/internal/daemon/watch/quarantine.go
@@ -474,6 +474,74 @@ func (q *QuarantineTracker) Unquarantine(repo, rel string) bool {
 	return true
 }
 
+// Recover auto-un-quarantines the quarantined directory that contains path,
+// when that path later proves to be REAL — i.e. its content is queried (an MCP
+// tool resolves an entity whose source file is under a quarantined dir) or
+// referenced (the graph has an edge into a quarantined dir's content). This is
+// the Q3 self-heal-on-demand signal (#5618): we never want to keep hiding data
+// that the rest of the system actually needs.
+//
+// It is the cheap counterpart to Sweep's quiet-window heal: a single query or
+// reference un-quarantines immediately rather than waiting out HealQuiet.
+//
+// Contract:
+//   - path is the absolute path to the referenced/queried file (e.g. an
+//     entity's source file). Its DIRECTORY is matched against the quarantine
+//     set, walking up to the nearest quarantined ancestor (so a query for
+//     `app/build/x/y.go` recovers the quarantined `app/build`).
+//   - PINNED entries are respected: an operator-pinned dir stays exactly as the
+//     user set it and is NOT auto-recovered (returns false).
+//   - On a hit it removes the entry, clears the churn bookkeeping so indexing
+//     re-arms cleanly, persists, and audits. Returns the recovered rel.
+//   - On no quarantined ancestor (the common case) it is a cheap membership
+//     check that returns ("", false) — safe to call on every query/reference.
+//
+// Anti-flap: if the dir was quarantined for genuine churn and is still
+// thrashing, the churn detector (Observe) will simply re-quarantine it on the
+// next burst — a real-but-churning dir surfaces, then re-quarantines. That is
+// the intended behaviour, not a defect.
+func (q *QuarantineTracker) Recover(repo, path string) (rel string, recovered bool) {
+	if q == nil || q.cfg.disabled {
+		return "", false
+	}
+	dirRel, ok := relDir(repo, path)
+	if !ok {
+		return "", false
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.ensureLoadedLocked(repo)
+
+	set := q.quarantined[repo]
+	if len(set) == 0 {
+		return "", false
+	}
+	// Walk up to the nearest quarantined ancestor of the path's directory.
+	cur := dirRel
+	for {
+		if reason, hit := set[cur]; hit {
+			if reason.Pinned {
+				// Operator-pinned: leave exactly as the user set it.
+				return "", false
+			}
+			delete(set, cur)
+			if m := q.churn[repo]; m != nil {
+				delete(m, cur)
+			}
+			q.persistLocked(repo)
+			if q.audit != nil {
+				q.audit("unquarantine", repo, cur, "recover on query/reference")
+			}
+			return cur, true
+		}
+		parent := slashDir(cur)
+		if parent == cur {
+			return "", false
+		}
+		cur = parent
+	}
+}
+
 // ---- persistence: <repo>/.grafel/quarantine.json ----
 
 // quarantineFile is the on-disk shape.

--- a/internal/daemon/watch/quarantine_recover_test.go
+++ b/internal/daemon/watch/quarantine_recover_test.go
@@ -1,0 +1,171 @@
+package watch
+
+// quarantine_recover_test.go — Q3 auto-recover-on-query/reference (#5618).
+//
+// These tests exercise QuarantineTracker.Recover deterministically (fake clock,
+// injected tracker, temp repo for persistence). They verify the four contract
+// points from #5618:
+//   - a query/reference to a path UNDER a quarantined dir un-quarantines it;
+//   - a query to a NON-quarantined path is a cheap no-op;
+//   - a PINNED dir is never auto-recovered (operator override is respected);
+//   - after recovery, continued churn RE-quarantines (anti-flap is "surface
+//     then re-quarantine", not "stay recovered while thrashing").
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// quarantineDir drives a dir into churn-quarantine and asserts it landed.
+func quarantineDir(t *testing.T, q *QuarantineTracker, repo, rel string) {
+	t.Helper()
+	p := filepath.Join(repo, filepath.FromSlash(rel), "trash.o")
+	pump(q, repo, p, 10) // threshold is 10 in newTestTracker
+	for _, r := range q.List(repo) {
+		if r.Rel == rel {
+			return
+		}
+	}
+	t.Fatalf("setup: expected %q to be quarantined, got %+v", rel, q.List(repo))
+}
+
+func TestRecover_QueryUnderQuarantinedDirRecovers(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	quarantineDir(t, q, repo, "app/build")
+
+	// A query resolves an entity whose source file lives under the quarantined
+	// dir — that dir is genuinely needed, so it must be recovered immediately.
+	queried := filepath.Join(repo, "app", "build", "generated", "real.go")
+	rel, recovered := q.Recover(repo, queried)
+	if !recovered {
+		t.Fatalf("Recover should un-quarantine the ancestor of a queried path")
+	}
+	if rel != "app/build" {
+		t.Fatalf("recovered rel = %q, want app/build", rel)
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("dir should be gone from the quarantine set after recover: %+v", q.List(repo))
+	}
+
+	// Idempotent: a second query for the same (now-clean) path is a no-op.
+	if _, again := q.Recover(repo, queried); again {
+		t.Fatalf("second Recover on an already-clean path must be a no-op")
+	}
+}
+
+func TestRecover_ExactDirPathRecovers(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	quarantineDir(t, q, repo, "gen")
+
+	// A file directly in the quarantined dir (not a descendant) also recovers.
+	rel, recovered := q.Recover(repo, filepath.Join(repo, "gen", "schema.ts"))
+	if !recovered || rel != "gen" {
+		t.Fatalf("Recover(file in quarantined dir) = (%q,%v), want (gen,true)", rel, recovered)
+	}
+}
+
+func TestRecover_NonQuarantinedPathIsNoOp(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	quarantineDir(t, q, repo, "app/build")
+
+	// A query for a path NOT under any quarantined dir changes nothing.
+	rel, recovered := q.Recover(repo, filepath.Join(repo, "src", "service.go"))
+	if recovered || rel != "" {
+		t.Fatalf("Recover of a non-quarantined path must be a no-op, got (%q,%v)", rel, recovered)
+	}
+	// The unrelated quarantine is untouched.
+	if got := q.List(repo); len(got) != 1 || got[0].Rel != "app/build" {
+		t.Fatalf("unrelated quarantine must survive, got %+v", got)
+	}
+}
+
+func TestRecover_PinnedDirIsNotAutoRecovered(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	quarantineDir(t, q, repo, "vendor/gen")
+
+	// Operator pins the dir (Q2 override). Pin it in place.
+	q.mu.Lock()
+	reason := q.quarantined[repo]["vendor/gen"]
+	reason.Pinned = true
+	q.quarantined[repo]["vendor/gen"] = reason
+	q.mu.Unlock()
+
+	// A query under the pinned dir must NOT auto-recover it.
+	rel, recovered := q.Recover(repo, filepath.Join(repo, "vendor", "gen", "x.go"))
+	if recovered || rel != "" {
+		t.Fatalf("pinned dir must not be auto-recovered, got (%q,%v)", rel, recovered)
+	}
+	if got := q.List(repo); len(got) != 1 || !got[0].Pinned {
+		t.Fatalf("pinned dir must stay quarantined and pinned, got %+v", got)
+	}
+}
+
+func TestRecover_ReQuarantinesIfChurnContinues(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	quarantineDir(t, q, repo, "build")
+
+	// A query recovers it.
+	if _, recovered := q.Recover(repo, filepath.Join(repo, "build", "real.go")); !recovered {
+		t.Fatalf("expected recover")
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("expected recovered (empty) set")
+	}
+
+	// It is still a churning build dir: continued churn re-quarantines it. The
+	// counter was reset on recover, so a fresh threshold's worth of events trips
+	// it again — real-but-churning dirs surface, then re-quarantine.
+	churnPath := filepath.Join(repo, "build", "out.o")
+	if drops := pump(q, repo, churnPath, 9); drops != 0 {
+		t.Fatalf("9 post-recovery events should not re-quarantine yet, got %d", drops)
+	}
+	if !q.Observe(repo, churnPath) {
+		t.Fatalf("10th post-recovery event should re-quarantine the still-churning dir")
+	}
+	if got := q.List(repo); len(got) != 1 || got[0].Rel != "build" {
+		t.Fatalf("expected build re-quarantined, got %+v", got)
+	}
+}
+
+func TestRecover_PersistsAcrossReload(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	quarantineDir(t, q, repo, "dist")
+	if _, recovered := q.Recover(repo, filepath.Join(repo, "dist", "app.js")); !recovered {
+		t.Fatalf("expected recover")
+	}
+
+	// A fresh tracker reads the persisted set: the recovered dir must be gone.
+	q2, _ := newTestTracker(t)
+	if got := q2.List(repo); len(got) != 0 {
+		t.Fatalf("recover must persist (empty set after reload), got %+v", got)
+	}
+}
+
+func TestRecover_NilAndDisabledSafe(t *testing.T) {
+	var nilq *QuarantineTracker
+	if rel, ok := nilq.Recover("/repo", "/repo/x/y.go"); ok || rel != "" {
+		t.Fatalf("nil receiver Recover must be a safe no-op, got (%q,%v)", rel, ok)
+	}
+
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	q.cfg.disabled = true
+	if rel, ok := q.Recover(repo, filepath.Join(repo, "build", "x.o")); ok || rel != "" {
+		t.Fatalf("disabled tracker Recover must be a no-op, got (%q,%v)", rel, ok)
+	}
+}
+
+func TestRecover_PathOutsideRepoIsNoOp(t *testing.T) {
+	repo := t.TempDir()
+	q, _ := newTestTracker(t)
+	quarantineDir(t, q, repo, "build")
+	if rel, ok := q.Recover(repo, "/some/other/place/file.go"); ok || rel != "" {
+		t.Fatalf("path outside repo must be a no-op, got (%q,%v)", rel, ok)
+	}
+}

--- a/internal/mcp/quarantine_recover_5618_test.go
+++ b/internal/mcp/quarantine_recover_5618_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+// quarantine_recover_5618_test.go — Q3 query-side hook (#5618).
+//
+// Verifies that the MCP server's noteEntityAccess feeds the query/reference
+// signal to a wired QuarantineRecoverer with a correctly-resolved absolute path,
+// and is a safe no-op when no recoverer is wired or inputs are empty. The
+// tracker's own Recover semantics (pin-respect, re-quarantine, persistence) are
+// covered in internal/daemon/watch/quarantine_recover_test.go.
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+type fakeRecoverer struct {
+	calls []struct{ repo, path string }
+	ret   bool
+}
+
+func (f *fakeRecoverer) Recover(repo, path string) (string, bool) {
+	f.calls = append(f.calls, struct{ repo, path string }{repo, path})
+	return "", f.ret
+}
+
+func TestNoteEntityAccess_RelativeSourceResolvedToAbs(t *testing.T) {
+	fr := &fakeRecoverer{}
+	s := &Server{}
+	s.SetQuarantineRecoverer(fr)
+
+	lr := &LoadedRepo{Repo: "r", Path: "/proj/repo"}
+	s.noteEntityAccess(lr, filepath.Join("app", "build", "x.go"))
+
+	if len(fr.calls) != 1 {
+		t.Fatalf("expected 1 Recover call, got %d", len(fr.calls))
+	}
+	wantPath := filepath.Join("/proj/repo", "app", "build", "x.go")
+	if fr.calls[0].repo != "/proj/repo" || fr.calls[0].path != wantPath {
+		t.Fatalf("Recover called with (%q,%q), want (/proj/repo,%q)",
+			fr.calls[0].repo, fr.calls[0].path, wantPath)
+	}
+}
+
+func TestNoteEntityAccess_AbsoluteSourcePassedThrough(t *testing.T) {
+	fr := &fakeRecoverer{}
+	s := &Server{}
+	s.SetQuarantineRecoverer(fr)
+
+	abs := filepath.Join("/proj/repo", "gen", "y.ts")
+	s.noteEntityAccess(&LoadedRepo{Repo: "r", Path: "/proj/repo"}, abs)
+
+	if len(fr.calls) != 1 || fr.calls[0].path != abs {
+		t.Fatalf("absolute source should pass through unchanged, got %+v", fr.calls)
+	}
+}
+
+func TestNoteEntityAccess_NoRecovererIsNoOp(t *testing.T) {
+	s := &Server{} // no recoverer wired
+	// Must not panic and must do nothing.
+	s.noteEntityAccess(&LoadedRepo{Repo: "r", Path: "/proj/repo"}, "a/b.go")
+}
+
+func TestNoteEntityAccess_EmptyInputsAreNoOp(t *testing.T) {
+	fr := &fakeRecoverer{}
+	s := &Server{}
+	s.SetQuarantineRecoverer(fr)
+
+	s.noteEntityAccess(nil, "a/b.go")                       // nil repo
+	s.noteEntityAccess(&LoadedRepo{Path: ""}, "a/b.go")     // no repo root
+	s.noteEntityAccess(&LoadedRepo{Path: "/proj/repo"}, "") // no source file
+
+	if len(fr.calls) != 0 {
+		t.Fatalf("empty inputs must not call Recover, got %+v", fr.calls)
+	}
+}

--- a/internal/mcp/quarantine_recover_5618_test.go
+++ b/internal/mcp/quarantine_recover_5618_test.go
@@ -9,9 +9,26 @@ package mcp
 // covered in internal/daemon/watch/quarantine_recover_test.go.
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
+
+// absRepoRoot returns an OS-absolute repo root used by these tests. A literal
+// "/proj/repo" is absolute on unix but NOT on Windows (filepath.IsAbs needs a
+// volume like C:\ or a UNC path), so we prefix the current working directory's
+// volume name. This keeps the path absolute on every platform without touching
+// the filesystem.
+func absRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// On unix VolumeName is "" so this is just "/proj/repo"; on Windows it is
+	// e.g. "C:" giving "C:\proj\repo" — absolute in both cases.
+	return filepath.Join(filepath.VolumeName(wd)+string(filepath.Separator), "proj", "repo")
+}
 
 type fakeRecoverer struct {
 	calls []struct{ repo, path string }
@@ -28,16 +45,17 @@ func TestNoteEntityAccess_RelativeSourceResolvedToAbs(t *testing.T) {
 	s := &Server{}
 	s.SetQuarantineRecoverer(fr)
 
-	lr := &LoadedRepo{Repo: "r", Path: "/proj/repo"}
+	root := absRepoRoot(t)
+	lr := &LoadedRepo{Repo: "r", Path: root}
 	s.noteEntityAccess(lr, filepath.Join("app", "build", "x.go"))
 
 	if len(fr.calls) != 1 {
 		t.Fatalf("expected 1 Recover call, got %d", len(fr.calls))
 	}
-	wantPath := filepath.Join("/proj/repo", "app", "build", "x.go")
-	if fr.calls[0].repo != "/proj/repo" || fr.calls[0].path != wantPath {
-		t.Fatalf("Recover called with (%q,%q), want (/proj/repo,%q)",
-			fr.calls[0].repo, fr.calls[0].path, wantPath)
+	wantPath := filepath.Join(root, "app", "build", "x.go")
+	if fr.calls[0].repo != root || fr.calls[0].path != wantPath {
+		t.Fatalf("Recover called with (%q,%q), want (%q,%q)",
+			fr.calls[0].repo, fr.calls[0].path, root, wantPath)
 	}
 }
 
@@ -46,8 +64,9 @@ func TestNoteEntityAccess_AbsoluteSourcePassedThrough(t *testing.T) {
 	s := &Server{}
 	s.SetQuarantineRecoverer(fr)
 
-	abs := filepath.Join("/proj/repo", "gen", "y.ts")
-	s.noteEntityAccess(&LoadedRepo{Repo: "r", Path: "/proj/repo"}, abs)
+	root := absRepoRoot(t)
+	abs := filepath.Join(root, "gen", "y.ts")
+	s.noteEntityAccess(&LoadedRepo{Repo: "r", Path: root}, abs)
 
 	if len(fr.calls) != 1 || fr.calls[0].path != abs {
 		t.Fatalf("absolute source should pass through unchanged, got %+v", fr.calls)
@@ -57,7 +76,7 @@ func TestNoteEntityAccess_AbsoluteSourcePassedThrough(t *testing.T) {
 func TestNoteEntityAccess_NoRecovererIsNoOp(t *testing.T) {
 	s := &Server{} // no recoverer wired
 	// Must not panic and must do nothing.
-	s.noteEntityAccess(&LoadedRepo{Repo: "r", Path: "/proj/repo"}, "a/b.go")
+	s.noteEntityAccess(&LoadedRepo{Repo: "r", Path: absRepoRoot(t)}, "a/b.go")
 }
 
 func TestNoteEntityAccess_EmptyInputsAreNoOp(t *testing.T) {
@@ -65,9 +84,9 @@ func TestNoteEntityAccess_EmptyInputsAreNoOp(t *testing.T) {
 	s := &Server{}
 	s.SetQuarantineRecoverer(fr)
 
-	s.noteEntityAccess(nil, "a/b.go")                       // nil repo
-	s.noteEntityAccess(&LoadedRepo{Path: ""}, "a/b.go")     // no repo root
-	s.noteEntityAccess(&LoadedRepo{Path: "/proj/repo"}, "") // no source file
+	s.noteEntityAccess(nil, "a/b.go")                         // nil repo
+	s.noteEntityAccess(&LoadedRepo{Path: ""}, "a/b.go")       // no repo root
+	s.noteEntityAccess(&LoadedRepo{Path: absRepoRoot(t)}, "") // no source file
 
 	if len(fr.calls) != 0 {
 		t.Fatalf("empty inputs must not call Recover, got %+v", fr.calls)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -242,6 +242,15 @@ type Server struct {
 	// Optional: when nil, events are silently dropped.
 	activityBroker *MCPActivityBroker
 
+	// quarantineRecoverer, when set, is invoked when an MCP query resolves an
+	// entity — so a directory that was quarantined as index trash but later
+	// turns out to be real (its content is queried) is auto-un-quarantined
+	// immediately (Q3, #5618). nil disables the hook (the default in tooling
+	// that has no live watcher). The daemon wires this to its
+	// watch.QuarantineTracker (which satisfies QuarantineRecoverer) via
+	// SetQuarantineRecoverer.
+	quarantineRecoverer QuarantineRecoverer
+
 	// reloadDebounceMu / reloadLastAt implement the per-call reload debounce
 	// (#2550, widened #3367). reloadLastAt is the Unix-nano timestamp of the
 	// most recent reloadBeforeCall() attempt that actually ran. Subsequent
@@ -266,6 +275,42 @@ func (s *Server) SetActivityBroker(b *MCPActivityBroker) {
 // ActivityBroker returns the wired broker, or nil when not set.
 func (s *Server) ActivityBroker() *MCPActivityBroker {
 	return s.activityBroker
+}
+
+// QuarantineRecoverer is the minimal surface the MCP query path needs from the
+// daemon's index quarantine tracker (Q3, #5618): given a repo root and the
+// absolute path of a queried/referenced file, un-quarantine the containing dir
+// if it was quarantined (and is not operator-pinned). It is satisfied by
+// *watch.QuarantineTracker without the mcp package importing daemon/watch.
+type QuarantineRecoverer interface {
+	// Recover un-quarantines the quarantined directory containing path, if any.
+	// Returns the recovered rel and whether anything changed. A no-op (and
+	// cheap) when path is not under a quarantined dir.
+	Recover(repo, path string) (rel string, recovered bool)
+}
+
+// SetQuarantineRecoverer wires the index-quarantine auto-recover hook (#5618)
+// into the server. Call this from the daemon entrypoint once the watcher (which
+// owns the QuarantineTracker) is ready. Passing nil disables the hook.
+func (s *Server) SetQuarantineRecoverer(r QuarantineRecoverer) {
+	s.quarantineRecoverer = r
+}
+
+// noteEntityAccess feeds the query/reference signal to the quarantine tracker:
+// when an MCP tool resolves an entity, the directory of its source file proves
+// to be real, so any quarantine on that directory is lifted immediately. Cheap
+// and nil-safe — a membership check that only acts on a hit. lr is the resolved
+// repo (for its root path); srcFile is the entity's recorded source file
+// (relative to the repo root, or absolute).
+func (s *Server) noteEntityAccess(lr *LoadedRepo, srcFile string) {
+	if s == nil || s.quarantineRecoverer == nil || lr == nil || lr.Path == "" || srcFile == "" {
+		return
+	}
+	abs := srcFile
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(lr.Path, srcFile)
+	}
+	s.quarantineRecoverer.Recover(lr.Path, abs)
 }
 
 // NewServer wires everything together: loads the registry, performs an

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2562,6 +2562,14 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 	e := resn.entity
 	lr := resn.repo
 
+	// Q3 (#5618) — auto-recover on query. The caller just resolved a real
+	// entity, so the directory holding its source is genuinely needed. If that
+	// directory was quarantined as index trash, un-quarantine it immediately
+	// (the cheap on-demand counterpart to the quiet-window self-heal). No-op and
+	// nil-safe when no recoverer is wired or the dir is not quarantined; pinned
+	// dirs are respected by the tracker.
+	s.noteEntityAccess(lr, e.SourceFile)
+
 	// #3833 — MRO-aware resolution. When the entity is an INHERITED member (a
 	// bodyless DRF synthetic, or a method resolved via EXTENDS to a base that
 	// defines it) resolve it to the DEFINING class body instead of returning the


### PR DESCRIPTION
## What

Q3 of the self-healing index quarantine (epic #5394, builds on the #5616 substrate). The churn detector quarantines pathologically-churning directories and stops watching/indexing them. But if a quarantined dir later proves **real** — its content is queried via MCP, or referenced by an indexed entity — we must never keep hiding needed data. This adds the cheap, on-demand counterpart to the quiet-window self-heal: a single query/reference un-quarantines immediately.

## Mechanism

- **`QuarantineTracker.Recover(repo, path)`** (new, additive method) — given the absolute path of a queried/referenced file, walks up to the nearest quarantined ancestor of its directory and un-quarantines it: clears the churn bookkeeping so indexing re-arms cleanly, persists, and audits. A cheap membership check that no-ops when the path is not under a quarantined dir.
  - **Respects pins**: an operator-pinned dir is left exactly as set — never auto-recovered.
  - **Nil / disabled / out-of-repo safe.**
- **MCP query hook** — an optional `QuarantineRecoverer` interface on the server, wired by the daemon from the watcher's tracker via `SetQuarantineRecoverer` (same pattern as `SetActivityBroker`). `handleGetNodeSource` — the busiest tool, where the resolved entity and its repo are already in hand — calls `noteEntityAccess` on resolution success, feeding the query/reference signal to `Recover` with the entity's source file. The `mcp` package does not import `daemon/watch`; the tracker satisfies the interface structurally.

## Anti-flap

Intentional and safe: a still-thrashing dir that a single query recovers is simply re-quarantined by the churn detector on its next burst — real-but-churning dirs **surface, then re-quarantine**.

## Scope / churn

Deliberately additive (new tracker method + one MCP hook helper + one daemon wiring line; no edits to existing tracker methods) so it rebases cleanly against the parallel transparency work (#5617) on the same file.

## Tests

Deterministic — fake clock / injected tracker / fake recoverer, no live fsnotify or real timing:
- recover a query/reference under a quarantined dir; exact-dir recover; non-quarantined path is a no-op; **pinned dir is not auto-recovered**; **re-quarantine after recovery when churn continues**; persistence across reload; nil/disabled/out-of-repo safety; and the MCP hook's relative→absolute path resolution + empty-input/no-recoverer no-op guards.

`go build ./...`, `go test -count=1 ./internal/daemon/watch/... ./internal/mcp/... ./internal/links/...`, `gofmt -l`, `go vet` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)