### PR TITLE
feat(quarantine): transparency — dashboard panel + grafel quarantine CLI (#5617)

### DIFF
--- a/internal/cli/quarantine.go
+++ b/internal/cli/quarantine.go
@@ -1,0 +1,268 @@
+package cli
+
+// quarantine.go implements `grafel quarantine` (Q2 of the self-healing index
+// quarantine epic #5394, ticket #5617).
+//
+// The self-healing watcher (#5616) auto-quarantines directories that churn
+// pathologically (a build-output loop, generated content, …) so they stop
+// arming reindexes. This command is the operator transparency + override
+// surface over that set:
+//
+//	grafel quarantine list [group]        — show quarantined dirs per repo
+//	grafel quarantine remove <repo> <dir> — manual un-quarantine
+//	grafel quarantine pin    <repo> <dir> — operator override: never auto-heal
+//	grafel quarantine unpin  <repo> <dir> — clear the pin
+//
+// Source of truth is each repo's persisted <repo>/.grafel/quarantine.json (the
+// store the live tracker reloads + rewrites), so the command works daemon-less
+// and stays consistent with a running daemon.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// quarantineRow is one quarantined directory, joined with its owning repo, for
+// `list` output (table + JSON).
+type quarantineRow struct {
+	Group  string `json:"group"`
+	Repo   string `json:"repo"`
+	Path   string `json:"path"`
+	Signal string `json:"signal"`
+	Detail string `json:"detail"`
+	Since  string `json:"since"`
+	Pinned bool   `json:"pinned"`
+}
+
+func newQuarantineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "quarantine",
+		Short: "Inspect and manage auto-quarantined directories",
+		Long: `Surface and override the self-healing index quarantine (#5394).
+
+The watcher auto-quarantines directories that churn pathologically (a
+build-output loop, generated content) so they stop arming reindexes. This
+command shows what is quarantined and lets an operator override.
+
+Examples:
+  grafel quarantine list                  list quarantined dirs across all groups
+  grafel quarantine list mygroup          filter to one group
+  grafel quarantine remove myrepo app/dist  un-quarantine a directory
+  grafel quarantine pin    myrepo app/dist  pin so auto-heal never touches it
+  grafel quarantine unpin  myrepo app/dist  clear the pin`,
+		Args: cobra.NoArgs,
+	}
+	cmd.AddCommand(
+		newQuarantineListCmd(),
+		newQuarantineRemoveCmd(),
+		newQuarantinePinCmd(true),
+		newQuarantinePinCmd(false),
+	)
+	return cmd
+}
+
+func newQuarantineListCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "list [group]",
+		Short: "List quarantined directories per repo",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			groupFilter := ""
+			if len(args) == 1 {
+				groupFilter = args[0]
+			}
+			rows, err := collectQuarantineRows(groupFilter)
+			if err != nil {
+				return err
+			}
+			if jsonOut {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(rows)
+			}
+			printQuarantineRows(cmd.OutOrStdout(), rows)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "machine-readable JSON output")
+	return cmd
+}
+
+func newQuarantineRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove <repo> <dir>",
+		Aliases: []string{"rm"},
+		Short:   "Un-quarantine a directory (manual override)",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoSlug, dir := args[0], args[1]
+			repoPath, err := resolveRepoPath(repoSlug)
+			if err != nil {
+				return err
+			}
+			ok, err := watch.UnquarantineFile(repoPath, dir)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s/%s was not quarantined\n", repoSlug, dir)
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "un-quarantined %s/%s\n", repoSlug, dir)
+			return nil
+		},
+	}
+}
+
+// newQuarantinePinCmd builds either the `pin` or `unpin` subcommand.
+func newQuarantinePinCmd(pin bool) *cobra.Command {
+	use, short := "pin <repo> <dir>", "Pin a directory so auto-heal never removes it"
+	if !pin {
+		use, short = "unpin <repo> <dir>", "Clear an operator pin (re-enable auto-heal)"
+	}
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			repoSlug, dir := args[0], args[1]
+			repoPath, err := resolveRepoPath(repoSlug)
+			if err != nil {
+				return err
+			}
+			ok, err := watch.SetPinFile(repoPath, dir, pin)
+			if err != nil {
+				return err
+			}
+			verb := "pinned"
+			if !pin {
+				verb = "unpinned"
+			}
+			if !ok {
+				fmt.Fprintf(cmd.OutOrStdout(),
+					"%s/%s already %s (or not quarantined)\n", repoSlug, dir, verb)
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s/%s\n", verb, repoSlug, dir)
+			return nil
+		},
+	}
+}
+
+// collectQuarantineRows joins every registered repo's persisted quarantine set
+// into a flat, sorted row list (optionally filtered to one group).
+func collectQuarantineRows(groupFilter string) ([]quarantineRow, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil, err
+	}
+	var rows []quarantineRow
+	for _, g := range groups {
+		if groupFilter != "" && g.Name != groupFilter {
+			continue
+		}
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue // skip misconfigured groups
+		}
+		for _, repo := range cfg.Repos {
+			reasons, err := watch.ReadQuarantineFile(repo.Path)
+			if err != nil {
+				continue // unreadable file → treat as empty
+			}
+			for _, rsn := range reasons {
+				rows = append(rows, quarantineRow{
+					Group:  g.Name,
+					Repo:   repo.Slug,
+					Path:   rsn.Rel,
+					Signal: rsn.Signal,
+					Detail: rsn.Detail,
+					Since:  formatQuarantineSince(rsn.At),
+					Pinned: rsn.Pinned,
+				})
+			}
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Group != rows[j].Group {
+			return rows[i].Group < rows[j].Group
+		}
+		if rows[i].Repo != rows[j].Repo {
+			return rows[i].Repo < rows[j].Repo
+		}
+		return rows[i].Path < rows[j].Path
+	})
+	if rows == nil {
+		rows = []quarantineRow{}
+	}
+	return rows, nil
+}
+
+func printQuarantineRows(w io.Writer, rows []quarantineRow) {
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "No quarantined directories.")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "GROUP\tREPO\tPATH\tSIGNAL\tDETAIL\tSINCE\tPINNED")
+	for _, r := range rows {
+		pinned := ""
+		if r.Pinned {
+			pinned = "yes"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Group, r.Repo, r.Path, r.Signal, r.Detail, r.Since, pinned)
+	}
+	_ = tw.Flush()
+}
+
+// formatQuarantineSince renders the quarantine timestamp as a short relative
+// age ("3m ago"), falling back to "-" for a zero time.
+func formatQuarantineSince(at time.Time) string {
+	if at.IsZero() {
+		return "-"
+	}
+	d := time.Since(at)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+// resolveRepoPath maps a repo slug to its absolute path by scanning every
+// registered group. Slugs are unique within a group; across groups the first
+// match wins.
+func resolveRepoPath(slug string) (string, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return "", err
+	}
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, repo := range cfg.Repos {
+			if repo.Slug == slug {
+				return repo.Path, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("repo %q not found in any registered group", slug)
+}

--- a/internal/cli/quarantine_test.go
+++ b/internal/cli/quarantine_test.go
@@ -1,0 +1,171 @@
+package cli
+
+// quarantine_test.go — end-to-end tests for `grafel quarantine list/remove/pin`.
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// seedQuarantineEnv wires a temp GRAFEL_HOME + XDG config with one group
+// containing one repo, and writes a quarantine.json into that repo. Returns the
+// repo's absolute path.
+func seedQuarantineEnv(t *testing.T, group, repoSlug string, dirs ...watch.QuarantineReason) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	cfgHome := filepath.Join(home, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+
+	cfgDir := filepath.Join(cfgHome, "grafel")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoPath := filepath.Join(home, "repos", repoSlug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(cfgDir, group+".fleet.json")
+	cfg := registry.GroupConfig{
+		Name:  group,
+		Repos: []registry.Repo{{Slug: repoSlug, Path: repoPath}},
+	}
+	cfgData, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(cfgPath, cfgData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registry.Registry{Version: 1, Groups: []registry.GroupRef{{Name: group, ConfigPath: cfgPath}}}
+	regData, _ := json.MarshalIndent(reg, "", "  ")
+	if err := os.WriteFile(filepath.Join(home, "registry.json"), regData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write the quarantine set via the production write helper.
+	qf := struct {
+		Version int                      `json:"version"`
+		Dirs    []watch.QuarantineReason `json:"dirs"`
+	}{Version: 1, Dirs: dirs}
+	qData, _ := json.MarshalIndent(qf, "", "  ")
+	gdir := filepath.Join(repoPath, ".grafel")
+	if err := os.MkdirAll(gdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gdir, "quarantine.json"), qData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repoPath
+}
+
+func runQuarantine(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := newQuarantineCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("quarantine %v: %v\noutput: %s", args, err, buf.String())
+	}
+	return buf.String()
+}
+
+func TestQuarantineListTable(t *testing.T) {
+	at := time.Now().Add(-5 * time.Minute)
+	seedQuarantineEnv(t, "demo", "api",
+		watch.QuarantineReason{Rel: "app/dist", Signal: "churn", Detail: "47 events in 2m0s", At: at, Pinned: true},
+	)
+
+	out := runQuarantine(t, "list")
+	for _, want := range []string{"demo", "api", "app/dist", "churn", "47 events", "yes"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestQuarantineListJSON(t *testing.T) {
+	at := time.Now().Add(-1 * time.Hour)
+	seedQuarantineEnv(t, "demo", "api",
+		watch.QuarantineReason{Rel: "build/out", Signal: "churn", Detail: "d", At: at},
+	)
+	out := runQuarantine(t, "list", "--json")
+	var rows []quarantineRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if len(rows) != 1 || rows[0].Path != "build/out" || rows[0].Repo != "api" {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+}
+
+func TestQuarantineListEmpty(t *testing.T) {
+	seedQuarantineEnv(t, "demo", "api") // no dirs
+	out := runQuarantine(t, "list")
+	if !strings.Contains(out, "No quarantined") {
+		t.Errorf("expected empty message; got %q", out)
+	}
+}
+
+func TestQuarantineRemove(t *testing.T) {
+	repoPath := seedQuarantineEnv(t, "demo", "api",
+		watch.QuarantineReason{Rel: "app/dist", Signal: "churn", At: time.Now()},
+	)
+	out := runQuarantine(t, "remove", "api", "app/dist")
+	if !strings.Contains(out, "un-quarantined") {
+		t.Errorf("expected success message; got %q", out)
+	}
+	got, _ := watch.ReadQuarantineFile(repoPath)
+	if len(got) != 0 {
+		t.Fatalf("dir should be removed; got %+v", got)
+	}
+
+	// Removing again → "was not quarantined".
+	out = runQuarantine(t, "remove", "api", "app/dist")
+	if !strings.Contains(out, "was not quarantined") {
+		t.Errorf("expected not-quarantined message; got %q", out)
+	}
+}
+
+func TestQuarantinePinUnpin(t *testing.T) {
+	repoPath := seedQuarantineEnv(t, "demo", "api",
+		watch.QuarantineReason{Rel: "app/dist", Signal: "churn", At: time.Now()},
+	)
+	out := runQuarantine(t, "pin", "api", "app/dist")
+	if !strings.Contains(out, "pinned api/app/dist") {
+		t.Errorf("expected pinned message; got %q", out)
+	}
+	got, _ := watch.ReadQuarantineFile(repoPath)
+	if len(got) != 1 || !got[0].Pinned {
+		t.Fatalf("dir should be pinned; got %+v", got)
+	}
+
+	out = runQuarantine(t, "unpin", "api", "app/dist")
+	if !strings.Contains(out, "unpinned api/app/dist") {
+		t.Errorf("expected unpinned message; got %q", out)
+	}
+	got, _ = watch.ReadQuarantineFile(repoPath)
+	if got[0].Pinned {
+		t.Fatal("dir should be unpinned")
+	}
+}
+
+func TestQuarantineRemoveUnknownRepo(t *testing.T) {
+	seedQuarantineEnv(t, "demo", "api")
+	cmd := newQuarantineCmd()
+	cmd.SetArgs([]string{"remove", "nope", "x"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for unknown repo")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -63,6 +63,7 @@ func newRoot() *cobra.Command {
 		newPatternsCmd(),
 		newMCPBridgeCmd(),
 		newCleanupCmd(),
+		newQuarantineCmd(),
 		newStoreCmd(),
 		newDocgenCmd(),
 		newRegisterCmd(),
@@ -156,6 +157,10 @@ Branch management (PH6):
 
 Maintenance:
   cleanup [--dry-run]             Remove orphaned registry entries
+  quarantine list [group]         List auto-quarantined directories per repo
+  quarantine remove <repo> <dir>  Un-quarantine a directory (manual override)
+  quarantine pin   <repo> <dir>   Pin a dir so auto-heal never removes it
+  quarantine unpin <repo> <dir>   Clear an operator pin
 
 Daemon (manual):
   start                           Start daemon (MCP + indexer + dashboard + watchers)

--- a/internal/daemon/watch/quarantine.go
+++ b/internal/daemon/watch/quarantine.go
@@ -542,6 +542,145 @@ func (q *QuarantineTracker) Recover(repo, path string) (rel string, recovered bo
 	}
 }
 
+// Pin marks rel as operator-pinned so the self-heal sweep never auto-removes
+// it (the dir stays quarantined until an explicit Unquarantine). The dir must
+// already be quarantined. Returns true if the pin state changed. Q2 operator
+// override.
+func (q *QuarantineTracker) Pin(repo, rel string) bool {
+	return q.setPin(repo, rel, true)
+}
+
+// Unpin clears the operator pin on rel so the dir becomes eligible for
+// auto-heal again. Returns true if the pin state changed.
+func (q *QuarantineTracker) Unpin(repo, rel string) bool {
+	return q.setPin(repo, rel, false)
+}
+
+func (q *QuarantineTracker) setPin(repo, rel string, pinned bool) bool {
+	if q == nil {
+		return false
+	}
+	rel = filepath.ToSlash(rel)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.ensureLoadedLocked(repo)
+	set := q.quarantined[repo]
+	reason, ok := set[rel]
+	if !ok || reason.Pinned == pinned {
+		return false
+	}
+	reason.Pinned = pinned
+	set[rel] = reason
+	q.persistLocked(repo)
+	if q.audit != nil {
+		evt := "pin"
+		if !pinned {
+			evt = "unpin"
+		}
+		q.audit(evt, repo, rel, "operator override")
+	}
+	return true
+}
+
+// ---- daemon-less file surface (Q2 transparency: CLI + dashboard) ----
+//
+// The persisted <repo>/.grafel/quarantine.json is the canonical store across
+// daemon restarts, and the live tracker reloads it lazily + rewrites it on
+// every mutation. These package-level helpers let the CLI and the dashboard
+// read and mutate the set WITHOUT a live tracker handle, staying consistent
+// with the running daemon (which re-reads the file on its next touch of the
+// repo). They are best-effort and never panic on a missing/corrupt file.
+
+// ReadQuarantineFile returns the persisted quarantine set for a repo, sorted by
+// rel. A missing or corrupt file yields an empty slice and no error.
+func ReadQuarantineFile(repo string) ([]QuarantineReason, error) {
+	data, err := os.ReadFile(quarantinePath(repo))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var f quarantineFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, err
+	}
+	out := make([]QuarantineReason, 0, len(f.Dirs))
+	for _, r := range f.Dirs {
+		if r.Rel != "" {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Rel < out[j].Rel })
+	return out, nil
+}
+
+// writeQuarantineFile persists a set of reasons to <repo>/.grafel/quarantine.json
+// (atomic-ish temp+rename), mirroring (*QuarantineTracker).persistLocked.
+func writeQuarantineFile(repo string, dirs []QuarantineReason) error {
+	f := quarantineFile{Version: 1, Dirs: append([]QuarantineReason(nil), dirs...)}
+	sort.Slice(f.Dirs, func(i, j int) bool { return f.Dirs[i].Rel < f.Dirs[j].Rel })
+	if err := os.MkdirAll(filepath.Join(repo, ".grafel"), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := quarantinePath(repo) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, quarantinePath(repo))
+}
+
+// UnquarantineFile removes rel from a repo's persisted quarantine set. Returns
+// true if it was present (and the file rewritten).
+func UnquarantineFile(repo, rel string) (bool, error) {
+	rel = filepath.ToSlash(rel)
+	dirs, err := ReadQuarantineFile(repo)
+	if err != nil {
+		return false, err
+	}
+	out := make([]QuarantineReason, 0, len(dirs))
+	found := false
+	for _, r := range dirs {
+		if r.Rel == rel {
+			found = true
+			continue
+		}
+		out = append(out, r)
+	}
+	if !found {
+		return false, nil
+	}
+	return true, writeQuarantineFile(repo, out)
+}
+
+// SetPinFile sets or clears the operator pin on rel in a repo's persisted
+// quarantine set. Returns true if the pin state changed.
+func SetPinFile(repo, rel string, pinned bool) (bool, error) {
+	rel = filepath.ToSlash(rel)
+	dirs, err := ReadQuarantineFile(repo)
+	if err != nil {
+		return false, err
+	}
+	changed := false
+	for i := range dirs {
+		if dirs[i].Rel == rel {
+			if dirs[i].Pinned != pinned {
+				dirs[i].Pinned = pinned
+				changed = true
+			}
+			break
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	return true, writeQuarantineFile(repo, dirs)
+}
+
 // ---- persistence: <repo>/.grafel/quarantine.json ----
 
 // quarantineFile is the on-disk shape.

--- a/internal/daemon/watch/quarantine_q2_test.go
+++ b/internal/daemon/watch/quarantine_q2_test.go
@@ -1,0 +1,158 @@
+package watch
+
+// quarantine_q2_test.go — tests for the Q2 transparency surface (#5617):
+// the Pin/Unpin tracker methods and the daemon-less file helpers
+// (ReadQuarantineFile / UnquarantineFile / SetPinFile).
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// seedQuarantine writes a quarantine.json with the given reasons into repo's
+// .grafel dir via the production write path.
+func seedQuarantine(t *testing.T, repo string, dirs ...QuarantineReason) {
+	t.Helper()
+	if err := writeQuarantineFile(repo, dirs); err != nil {
+		t.Fatalf("seed quarantine: %v", err)
+	}
+}
+
+func TestPinUnpinTracker(t *testing.T) {
+	repo := t.TempDir()
+	q := NewQuarantineTracker(nil)
+	q.now = func() time.Time { return time.Unix(1000, 0) }
+
+	// Quarantine a dir by tripping churn directly.
+	q.quarantineLocked(repo, "app/dist", "churn", "test", q.now())
+
+	if !q.Pin(repo, "app/dist") {
+		t.Fatal("Pin should report a change the first time")
+	}
+	if q.Pin(repo, "app/dist") {
+		t.Fatal("Pin again should be a no-op (already pinned)")
+	}
+	// Pinned entries must survive a sweep even after the quiet window.
+	q.now = func() time.Time { return time.Unix(1000, 0).Add(24 * time.Hour) }
+	q.Sweep()
+	if got := q.List(repo); len(got) != 1 || !got[0].Pinned {
+		t.Fatalf("pinned dir must survive sweep; got %+v", got)
+	}
+
+	if !q.Unpin(repo, "app/dist") {
+		t.Fatal("Unpin should report a change")
+	}
+	// Now eligible for heal → sweep removes it.
+	q.Sweep()
+	if got := q.List(repo); len(got) != 0 {
+		t.Fatalf("unpinned + quiet dir should heal; got %+v", got)
+	}
+
+	// Pin on a non-quarantined dir is a no-op.
+	if q.Pin(repo, "never/quarantined") {
+		t.Fatal("Pin on unknown dir must be a no-op")
+	}
+}
+
+func TestReadQuarantineFile(t *testing.T) {
+	repo := t.TempDir()
+
+	// Missing file → empty, no error.
+	got, err := ReadQuarantineFile(repo)
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("missing file should be empty; got %+v", got)
+	}
+
+	now := time.Unix(2000, 0)
+	seedQuarantine(t, repo,
+		QuarantineReason{Rel: "z/last", Signal: "churn", At: now},
+		QuarantineReason{Rel: "a/first", Signal: "churn", At: now, Pinned: true},
+	)
+	got, err = ReadQuarantineFile(repo)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 entries; got %d", len(got))
+	}
+	// Sorted by rel.
+	if got[0].Rel != "a/first" || got[1].Rel != "z/last" {
+		t.Fatalf("entries not sorted by rel: %+v", got)
+	}
+	if !got[0].Pinned {
+		t.Fatal("pinned flag not round-tripped")
+	}
+}
+
+func TestUnquarantineFile(t *testing.T) {
+	repo := t.TempDir()
+	now := time.Unix(3000, 0)
+	seedQuarantine(t, repo,
+		QuarantineReason{Rel: "app/dist", Signal: "churn", At: now},
+		QuarantineReason{Rel: "app/cache", Signal: "churn", At: now},
+	)
+
+	// Removing an absent dir → false, no error, file unchanged.
+	changed, err := UnquarantineFile(repo, "not/here")
+	if err != nil || changed {
+		t.Fatalf("removing absent dir: changed=%v err=%v", changed, err)
+	}
+
+	changed, err = UnquarantineFile(repo, "app/dist")
+	if err != nil || !changed {
+		t.Fatalf("remove present dir: changed=%v err=%v", changed, err)
+	}
+	got, _ := ReadQuarantineFile(repo)
+	if len(got) != 1 || got[0].Rel != "app/cache" {
+		t.Fatalf("after removal expected only app/cache; got %+v", got)
+	}
+
+	// ToSlash normalisation: backslash form resolves to the same key.
+	seedQuarantine(t, repo, QuarantineReason{Rel: "win/dir", At: now})
+	changed, err = UnquarantineFile(repo, filepath.FromSlash("win/dir"))
+	if err != nil || !changed {
+		t.Fatalf("slash-normalised remove failed: changed=%v err=%v", changed, err)
+	}
+}
+
+func TestSetPinFile(t *testing.T) {
+	repo := t.TempDir()
+	now := time.Unix(4000, 0)
+	seedQuarantine(t, repo, QuarantineReason{Rel: "app/dist", Signal: "churn", At: now})
+
+	// Pin a present dir.
+	changed, err := SetPinFile(repo, "app/dist", true)
+	if err != nil || !changed {
+		t.Fatalf("pin: changed=%v err=%v", changed, err)
+	}
+	got, _ := ReadQuarantineFile(repo)
+	if !got[0].Pinned {
+		t.Fatal("pin not persisted")
+	}
+
+	// Pinning again → no change.
+	changed, _ = SetPinFile(repo, "app/dist", true)
+	if changed {
+		t.Fatal("re-pin should be a no-op")
+	}
+
+	// Unpin.
+	changed, err = SetPinFile(repo, "app/dist", false)
+	if err != nil || !changed {
+		t.Fatalf("unpin: changed=%v err=%v", changed, err)
+	}
+	got, _ = ReadQuarantineFile(repo)
+	if got[0].Pinned {
+		t.Fatal("unpin not persisted")
+	}
+
+	// Pin on absent dir → no change.
+	changed, _ = SetPinFile(repo, "absent", true)
+	if changed {
+		t.Fatal("pin on absent dir should be a no-op")
+	}
+}

--- a/internal/dashboard/handlers_quarantine.go
+++ b/internal/dashboard/handlers_quarantine.go
@@ -1,0 +1,192 @@
+package dashboard
+
+// handlers_quarantine.go — index-quarantine transparency surface (Q2, #5617).
+//
+// The self-healing watcher (#5616) auto-quarantines directories that churn
+// pathologically so they stop arming reindexes. These endpoints expose that
+// set to the dashboard and let an operator override it:
+//
+//	GET  /api/groups/{group}/quarantine
+//	     → list every quarantined dir across the group's repos
+//	POST /api/groups/{group}/repos/{repo}/quarantine/unquarantine  {rel}
+//	     → manual un-quarantine
+//	POST /api/groups/{group}/repos/{repo}/quarantine/pin           {rel, pinned}
+//	     → operator override: pin (never auto-heal) / unpin
+//
+// Source of truth is each repo's persisted <repo>/.grafel/quarantine.json (the
+// store the live tracker reloads + rewrites), reused here via the watch
+// package's daemon-less file helpers so the surface stays consistent with a
+// running daemon.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// QuarantineEntry is one quarantined directory in the list response.
+type QuarantineEntry struct {
+	Repo   string `json:"repo"`
+	Path   string `json:"path"`
+	Signal string `json:"signal"`
+	Detail string `json:"detail"`
+	At     string `json:"at"`
+	Pinned bool   `json:"pinned"`
+}
+
+// QuarantineListReply is returned by GET /api/groups/{group}/quarantine.
+type QuarantineListReply struct {
+	Group   string            `json:"group"`
+	Entries []QuarantineEntry `json:"entries"`
+}
+
+// quarantineActionRequest is the body for the un-quarantine / pin endpoints.
+type quarantineActionRequest struct {
+	Rel    string `json:"rel"`
+	Pinned bool   `json:"pinned"`
+}
+
+// QuarantineActionReply is returned by the mutating quarantine endpoints.
+type QuarantineActionReply struct {
+	Repo    string `json:"repo"`
+	Rel     string `json:"rel"`
+	Action  string `json:"action"`
+	Changed bool   `json:"changed"`
+}
+
+// handleQuarantineList — GET /api/groups/{group}/quarantine
+func (s *Server) handleQuarantineList(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "missing group slug")
+		return
+	}
+	cfg, err := loadGroupConfigBySlug(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	entries := []QuarantineEntry{}
+	for _, repo := range cfg.Repos {
+		reasons, rerr := watch.ReadQuarantineFile(repo.Path)
+		if rerr != nil {
+			continue // unreadable file → treat as empty
+		}
+		for _, rsn := range reasons {
+			entries = append(entries, QuarantineEntry{
+				Repo:   repo.Slug,
+				Path:   rsn.Rel,
+				Signal: rsn.Signal,
+				Detail: rsn.Detail,
+				At:     rsn.At.UTC().Format("2006-01-02T15:04:05Z07:00"),
+				Pinned: rsn.Pinned,
+			})
+		}
+	}
+	writeJSON(w, http.StatusOK, QuarantineListReply{Group: group, Entries: entries})
+}
+
+// handleQuarantineUnquarantine — POST /api/groups/{group}/repos/{repo}/quarantine/unquarantine
+func (s *Server) handleQuarantineUnquarantine(w http.ResponseWriter, r *http.Request) {
+	group, repoSlug, req, ok := s.parseQuarantineAction(w, r)
+	if !ok {
+		return
+	}
+	repoPath, err := repoPathInGroup(group, repoSlug)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	changed, err := watch.UnquarantineFile(repoPath, req.Rel)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.auditor.OK("quarantine-remove", group, map[string]any{"repo": repoSlug, "rel": req.Rel})
+	writeJSON(w, http.StatusOK, QuarantineActionReply{
+		Repo: repoSlug, Rel: req.Rel, Action: "unquarantine", Changed: changed,
+	})
+}
+
+// handleQuarantinePin — POST /api/groups/{group}/repos/{repo}/quarantine/pin
+func (s *Server) handleQuarantinePin(w http.ResponseWriter, r *http.Request) {
+	group, repoSlug, req, ok := s.parseQuarantineAction(w, r)
+	if !ok {
+		return
+	}
+	repoPath, err := repoPathInGroup(group, repoSlug)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	changed, err := watch.SetPinFile(repoPath, req.Rel, req.Pinned)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	action := "unpin"
+	if req.Pinned {
+		action = "pin"
+	}
+	s.auditor.OK("quarantine-"+action, group,
+		map[string]any{"repo": repoSlug, "rel": req.Rel, "pinned": req.Pinned})
+	writeJSON(w, http.StatusOK, QuarantineActionReply{
+		Repo: repoSlug, Rel: req.Rel, Action: action, Changed: changed,
+	})
+}
+
+// parseQuarantineAction decodes path values + body shared by the mutating
+// quarantine endpoints. It writes the error response and returns ok=false on
+// any validation failure.
+func (s *Server) parseQuarantineAction(w http.ResponseWriter, r *http.Request) (group, repo string, req quarantineActionRequest, ok bool) {
+	group = r.PathValue("group")
+	repo = r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "missing group or repo slug")
+		return "", "", req, false
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return "", "", req, false
+	}
+	if req.Rel == "" {
+		writeErr(w, http.StatusBadRequest, "missing 'rel' (directory) in body")
+		return "", "", req, false
+	}
+	return group, repo, req, true
+}
+
+// loadGroupConfigBySlug resolves a group slug to its config via the registry.
+func loadGroupConfigBySlug(group string) (*registry.GroupConfig, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil, err
+	}
+	for _, g := range groups {
+		if g.Name == group {
+			cfg, cerr := registry.LoadGroupConfig(g.ConfigPath)
+			if cerr != nil {
+				return nil, cerr
+			}
+			return cfg, nil
+		}
+	}
+	return nil, fmt.Errorf("group %q not found in registry", group)
+}
+
+// repoPathInGroup resolves a repo slug within a group to its absolute path.
+func repoPathInGroup(group, slug string) (string, error) {
+	cfg, err := loadGroupConfigBySlug(group)
+	if err != nil {
+		return "", err
+	}
+	for _, repo := range cfg.Repos {
+		if repo.Slug == slug {
+			return repo.Path, nil
+		}
+	}
+	return "", fmt.Errorf("repo %q not found in group %q", slug, group)
+}

--- a/internal/dashboard/handlers_quarantine_test.go
+++ b/internal/dashboard/handlers_quarantine_test.go
@@ -1,0 +1,175 @@
+package dashboard
+
+// handlers_quarantine_test.go — tests for the Q2 quarantine endpoints (#5617).
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// seedQuarantineRegistry wires a temp GRAFEL_HOME registry with one group +
+// repo and writes a quarantine.json into the repo. Returns the repo path.
+func seedQuarantineRegistry(t *testing.T, group, repoSlug string, dirs ...watch.QuarantineReason) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	cfgHome := filepath.Join(home, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+
+	cfgDir := filepath.Join(cfgHome, "grafel")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoPath := filepath.Join(home, "repos", repoSlug)
+	if err := os.MkdirAll(filepath.Join(repoPath, ".grafel"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(cfgDir, group+".fleet.json")
+	cfg := registry.GroupConfig{Name: group, Repos: []registry.Repo{{Slug: repoSlug, Path: repoPath}}}
+	cfgData, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(cfgPath, cfgData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := registry.Registry{Version: 1, Groups: []registry.GroupRef{{Name: group, ConfigPath: cfgPath}}}
+	regData, _ := json.MarshalIndent(reg, "", "  ")
+	if err := os.WriteFile(filepath.Join(home, "registry.json"), regData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	qf := struct {
+		Version int                      `json:"version"`
+		Dirs    []watch.QuarantineReason `json:"dirs"`
+	}{Version: 1, Dirs: dirs}
+	qData, _ := json.MarshalIndent(qf, "", "  ")
+	if err := os.WriteFile(filepath.Join(repoPath, ".grafel", "quarantine.json"), qData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repoPath
+}
+
+func newQuarantineServer(t *testing.T) (string, func()) {
+	t.Helper()
+	return newTestServer(t, newFakeStore(), DefaultConfig())
+}
+
+func TestQuarantineListEndpoint(t *testing.T) {
+	seedQuarantineRegistry(t, "demo", "api",
+		watch.QuarantineReason{Rel: "app/dist", Signal: "churn", Detail: "47 events", At: time.Now(), Pinned: true},
+	)
+	url, done := newQuarantineServer(t)
+	defer done()
+
+	resp, err := http.Get(url + "/api/groups/demo/quarantine")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	var reply QuarantineListReply
+	if err := json.NewDecoder(resp.Body).Decode(&reply); err != nil {
+		t.Fatal(err)
+	}
+	if len(reply.Entries) != 1 {
+		t.Fatalf("want 1 entry; got %+v", reply.Entries)
+	}
+	e := reply.Entries[0]
+	if e.Repo != "api" || e.Path != "app/dist" || !e.Pinned || e.Signal != "churn" {
+		t.Fatalf("unexpected entry: %+v", e)
+	}
+}
+
+func TestQuarantineListUnknownGroup(t *testing.T) {
+	seedQuarantineRegistry(t, "demo", "api")
+	url, done := newQuarantineServer(t)
+	defer done()
+	resp, err := http.Get(url + "/api/groups/nope/quarantine")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404; got %d", resp.StatusCode)
+	}
+}
+
+func TestQuarantineUnquarantineEndpoint(t *testing.T) {
+	repoPath := seedQuarantineRegistry(t, "demo", "api",
+		watch.QuarantineReason{Rel: "app/dist", Signal: "churn", At: time.Now()},
+	)
+	url, done := newQuarantineServer(t)
+	defer done()
+
+	body, _ := json.Marshal(map[string]any{"rel": "app/dist"})
+	resp, err := http.Post(url+"/api/groups/demo/repos/api/quarantine/unquarantine",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	var reply QuarantineActionReply
+	json.NewDecoder(resp.Body).Decode(&reply)
+	if !reply.Changed || reply.Action != "unquarantine" {
+		t.Fatalf("unexpected reply: %+v", reply)
+	}
+	got, _ := watch.ReadQuarantineFile(repoPath)
+	if len(got) != 0 {
+		t.Fatalf("dir should be removed; got %+v", got)
+	}
+}
+
+func TestQuarantinePinEndpoint(t *testing.T) {
+	repoPath := seedQuarantineRegistry(t, "demo", "api",
+		watch.QuarantineReason{Rel: "app/dist", Signal: "churn", At: time.Now()},
+	)
+	url, done := newQuarantineServer(t)
+	defer done()
+
+	body, _ := json.Marshal(map[string]any{"rel": "app/dist", "pinned": true})
+	resp, err := http.Post(url+"/api/groups/demo/repos/api/quarantine/pin",
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	var reply QuarantineActionReply
+	json.NewDecoder(resp.Body).Decode(&reply)
+	if !reply.Changed || reply.Action != "pin" {
+		t.Fatalf("unexpected reply: %+v", reply)
+	}
+	got, _ := watch.ReadQuarantineFile(repoPath)
+	if len(got) != 1 || !got[0].Pinned {
+		t.Fatalf("dir should be pinned; got %+v", got)
+	}
+}
+
+func TestQuarantineActionMissingRel(t *testing.T) {
+	seedQuarantineRegistry(t, "demo", "api")
+	url, done := newQuarantineServer(t)
+	defer done()
+	resp, err := http.Post(url+"/api/groups/demo/repos/api/quarantine/pin",
+		"application/json", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400; got %d", resp.StatusCode)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -563,6 +563,11 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/cleanup/preview", s.handleCleanupPreview)
 	mux.HandleFunc("POST /api/cleanup", s.handleCleanup)
 
+	// Index quarantine transparency surface (Q2, #5617)
+	mux.HandleFunc("GET /api/groups/{group}/quarantine", s.handleQuarantineList)
+	mux.HandleFunc("POST /api/groups/{group}/repos/{repo}/quarantine/unquarantine", s.handleQuarantineUnquarantine)
+	mux.HandleFunc("POST /api/groups/{group}/repos/{repo}/quarantine/pin", s.handleQuarantinePin)
+
 	// Quality surface (#1198, #1236)
 	mux.HandleFunc("GET /api/quality/orphans/{group}", s.handleQualityOrphans)
 	mux.HandleFunc("POST /api/quality/orphans/{group}", s.handleRunQualityOrphans)

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1535,6 +1535,33 @@ export interface CleanupReply {
   message: string;
 }
 
+/**
+ * One auto-quarantined directory (Q2 transparency surface, #5617).
+ * The self-healing watcher quarantines dirs that churn pathologically.
+ */
+export interface QuarantineEntry {
+  repo: string;
+  path: string;
+  signal: string;
+  detail: string;
+  at: string;
+  pinned: boolean;
+}
+
+/** GET /api/groups/{group}/quarantine result. */
+export interface QuarantineListReply {
+  group: string;
+  entries: QuarantineEntry[];
+}
+
+/** Result of an un-quarantine / pin action. */
+export interface QuarantineActionReply {
+  repo: string;
+  rel: string;
+  action: string;
+  changed: boolean;
+}
+
 /** POST /api/v2/update/apply result. */
 export interface UpdateApplyReply {
   exit_code: number;

--- a/webui-v2/src/hooks/use-operations.ts
+++ b/webui-v2/src/hooks/use-operations.ts
@@ -94,6 +94,41 @@ export function useCleanup() {
 }
 
 // ---------------------------------------------------------------------------
+// Index quarantine — transparency surface (Q2, #5617)
+// ---------------------------------------------------------------------------
+
+export const quarantineKey = (groupId: string) => ["ops", "quarantine", groupId] as const;
+
+/** Lists auto-quarantined directories for a group. */
+export function useQuarantine(groupId: string) {
+  return useQuery({
+    queryKey: quarantineKey(groupId),
+    queryFn: () => api.getQuarantine(groupId),
+    enabled: !!groupId,
+    retry: 1,
+  });
+}
+
+/** Manual un-quarantine of a directory. */
+export function useUnquarantine(groupId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (v: { repo: string; rel: string }) => api.unquarantine(groupId, v.repo, v.rel),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: quarantineKey(groupId) }),
+  });
+}
+
+/** Pin (never auto-heal) or unpin a quarantined directory. */
+export function usePinQuarantine(groupId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (v: { repo: string; rel: string; pinned: boolean }) =>
+      api.pinQuarantine(groupId, v.repo, v.rel, v.pinned),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: quarantineKey(groupId) }),
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Patterns
 // ---------------------------------------------------------------------------
 

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -53,6 +53,8 @@ import type {
   JobAck,
   ActionJob,
   CleanupReply,
+  QuarantineListReply,
+  QuarantineActionReply,
   UpdateApplyReply,
   ScanInspectReply,
   WizardRepo,
@@ -988,6 +990,30 @@ export const api = {
   getErrorFlow: (groupId: string) =>
     request<ErrorFlowReport>(
       `/errorflow/${encodeURIComponent(groupId)}`,
+    ),
+
+  // --- Index quarantine transparency (Q2, #5617) ---
+  // The self-healing watcher auto-quarantines dirs that churn pathologically.
+  // These surface that set and let an operator override it.
+
+  /** GET /api/groups/{group}/quarantine — quarantined dirs across the group's repos. */
+  getQuarantine: (groupId: string) =>
+    request<QuarantineListReply>(
+      `/groups/${encodeURIComponent(groupId)}/quarantine`,
+    ),
+
+  /** POST .../quarantine/unquarantine — manual un-quarantine of a directory. */
+  unquarantine: (groupId: string, repo: string, rel: string) =>
+    request<QuarantineActionReply>(
+      `/groups/${encodeURIComponent(groupId)}/repos/${encodeURIComponent(repo)}/quarantine/unquarantine`,
+      { method: "POST", body: JSON.stringify({ rel }) },
+    ),
+
+  /** POST .../quarantine/pin — pin (never auto-heal) or unpin a directory. */
+  pinQuarantine: (groupId: string, repo: string, rel: string, pinned: boolean) =>
+    request<QuarantineActionReply>(
+      `/groups/${encodeURIComponent(groupId)}/repos/${encodeURIComponent(repo)}/quarantine/pin`,
+      { method: "POST", body: JSON.stringify({ rel, pinned }) },
     ),
 };
 

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -38,6 +38,9 @@ import {
   RefreshCw,
   Server,
   SquareTerminal,
+  ShieldAlert,
+  Pin,
+  PinOff,
   Trash2,
   XCircle,
   Zap,
@@ -79,6 +82,9 @@ import {
   useRunOrphanAudit,
   useQualityFixtures,
   useRunRecall,
+  useQuarantine,
+  useUnquarantine,
+  usePinQuarantine,
 } from "@/hooks/use-operations";
 import { useRunDoctor } from "@/hooks/use-settings";
 import { useIndexProgress } from "@/hooks/use-index-progress";
@@ -1832,6 +1838,131 @@ const OPERATIONS_INSIGHT: InsightValue = {
   },
 };
 
+// ---------------------------------------------------------------------------
+// Quarantine tab — index-quarantine transparency surface (Q2, #5617)
+//
+// The self-healing watcher auto-quarantines directories that churn
+// pathologically (a build-output loop, generated content) so they stop arming
+// reindexes. This panel surfaces that set with operator override: un-quarantine
+// or pin (so auto-heal never touches a dir).
+// ---------------------------------------------------------------------------
+
+function QuarantineTab({ groupId }: { groupId: string }) {
+  const { data, isLoading, isError } = useQuarantine(groupId);
+  const unquarantine = useUnquarantine(groupId);
+  const pin = usePinQuarantine(groupId);
+
+  const entries = data?.entries ?? [];
+
+  return (
+    <Section
+      title="Quarantined paths"
+      sub="Directories the self-healing watcher auto-quarantined for pathological churn (e.g. a build-output loop). They stop arming reindexes until healed or overridden."
+    >
+      {isLoading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      ) : isError ? (
+        <p className="text-sm text-text-3">Could not load the quarantine set.</p>
+      ) : entries.length === 0 ? (
+        <div className="flex items-center gap-2 text-sm text-text-3">
+          <ShieldAlert size={15} className="text-text-3" />
+          No directories are quarantined.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border">
+          <table className="w-full text-sm" data-testid="quarantine-table">
+            <thead className="bg-surface-2 text-left text-xs text-text-3">
+              <tr>
+                <th className="px-3 py-2 font-medium">Path</th>
+                <th className="px-3 py-2 font-medium">Repo</th>
+                <th className="px-3 py-2 font-medium">Signal</th>
+                <th className="px-3 py-2 font-medium">Detail</th>
+                <th className="px-3 py-2 font-medium">Since</th>
+                <th className="px-3 py-2 font-medium text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((e) => {
+                const busy =
+                  (unquarantine.isPending &&
+                    unquarantine.variables?.repo === e.repo &&
+                    unquarantine.variables?.rel === e.path) ||
+                  (pin.isPending &&
+                    pin.variables?.repo === e.repo &&
+                    pin.variables?.rel === e.path);
+                return (
+                  <tr key={`${e.repo}:${e.path}`} className="border-t border-border">
+                    <td className="px-3 py-2 font-mono text-xs text-text">
+                      <span className="inline-flex items-center gap-1.5">
+                        {e.path}
+                        {e.pinned && (
+                          <Badge tone="info" className="gap-1">
+                            <Pin size={10} />
+                            pinned
+                          </Badge>
+                        )}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-text-3">{e.repo}</td>
+                    <td className="px-3 py-2 text-text-3">{e.signal}</td>
+                    <td className="px-3 py-2 text-text-3">{e.detail}</td>
+                    <td className="px-3 py-2 text-text-3">{relativeTime(e.at)}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center justify-end gap-1.5">
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          disabled={busy}
+                          onClick={() =>
+                            pin.mutate(
+                              { repo: e.repo, rel: e.path, pinned: !e.pinned },
+                              {
+                                onSuccess: () =>
+                                  toast.success(
+                                    `${e.pinned ? "Unpinned" : "Pinned"} ${e.repo}/${e.path}`,
+                                  ),
+                                onError: (err) => toast.error(String(err)),
+                              },
+                            )
+                          }
+                        >
+                          {e.pinned ? <PinOff size={13} className="mr-1" /> : <Pin size={13} className="mr-1" />}
+                          {e.pinned ? "Unpin" : "Pin"}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          disabled={busy}
+                          onClick={() =>
+                            unquarantine.mutate(
+                              { repo: e.repo, rel: e.path },
+                              {
+                                onSuccess: () =>
+                                  toast.success(`Un-quarantined ${e.repo}/${e.path}`),
+                                onError: (err) => toast.error(String(err)),
+                              },
+                            )
+                          }
+                        >
+                          <Trash2 size={13} className="mr-1" />
+                          Un-quarantine
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Section>
+  );
+}
+
 export default function OperationsScreen() {
   useSetInsight(OPERATIONS_INSIGHT);
   const { groupId = "" } = useParams<{ groupId: string }>();
@@ -1867,6 +1998,10 @@ export default function OperationsScreen() {
               <HardDrive size={13} className="mr-1.5" />
               Quality
             </TabsTrigger>
+            <TabsTrigger value="quarantine">
+              <ShieldAlert size={13} className="mr-1.5" />
+              Quarantine
+            </TabsTrigger>
             <TabsTrigger value="updates">
               <Download size={13} className="mr-1.5" />
               Updates
@@ -1883,6 +2018,10 @@ export default function OperationsScreen() {
 
           <TabsContent value="quality">
             <QualityTab groupId={groupId} />
+          </TabsContent>
+
+          <TabsContent value="quarantine">
+            <QuarantineTab groupId={groupId} />
           </TabsContent>
 
           <TabsContent value="updates">


### PR DESCRIPTION
Closes #5617 (Q2 of the self-healing index quarantine epic #5394).

The watcher auto-quarantines directories that churn pathologically (a build-output loop, generated content) so they stop arming reindexes. This PR adds the **transparency + operator-override surface** over that set — the epic's mandatory trust/safety gate. **Read/override only; no new detection logic.**

## Source of truth
Each repo's persisted `<repo>/.grafel/quarantine.json` (the store the live tracker reloads + rewrites on every mutation). The CLI and dashboard read/mutate that file directly, so the surface works **daemon-less** and stays consistent with a running daemon (which re-reads on its next touch of the repo).

## Tracker
- `Pin` / `Unpin` methods — wire the set/clear path for the pre-existing `Pinned` flag (the sweep already skips pinned entries; this fills in the missing operator path).
- `ReadQuarantineFile` / `UnquarantineFile` / `SetPinFile` — daemon-less file helpers reused by both surfaces.

## CLI — `grafel quarantine`
- `list [group]` — per-repo table (path, signal, detail, since, pinned) + `--json`.
- `remove <repo> <dir>` — manual un-quarantine.
- `pin` / `unpin <repo> <dir>` — operator override so auto-heal never touches a dir.

## Backend endpoint
- `GET  /api/groups/{group}/quarantine`
- `POST /api/groups/{group}/repos/{repo}/quarantine/unquarantine`
- `POST /api/groups/{group}/repos/{repo}/quarantine/pin`

## Dashboard panel
A "Quarantined paths" tab on the Operations screen: lists each quarantined dir with repo, triggering signal, detail, age, and a pinned badge, plus un-quarantine and pin/unpin buttons. Matches the existing Operations panel theme.

## Tests / verification
New tests cover the tracker `Pin`/`Unpin` + file helpers, the CLI commands end-to-end, and the three endpoints. `go build ./...`, targeted `go test`, `go vet`, `gofmt -l`, `tsc --noEmit`, and `npm run build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)