### PR TITLE
fix(daemon): spawn watchers via own binary path + reap stale/orphan watchers (#5632)

### DIFF
--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
+	"github.com/cajasmota/grafel/internal/daemon/watchscan"
 	"github.com/cajasmota/grafel/internal/process"
 )
 
@@ -77,6 +78,28 @@ type ReaperConfig struct {
 	// watcher reaping (e.g. modes without standalone watchers).
 	WatchRegistry *watchreg.Registry
 
+	// ManagedRepo, when non-nil, reports whether a repo path is one the daemon
+	// manages. It gates the foreign/orphan-watcher sweep (#5632): only watchers
+	// for managed repos are ever reaped. nil disables that sweep — the
+	// watchreg-based sweep above still runs.
+	ManagedRepo func(repoPath string) bool
+
+	// SelfExe returns the daemon's own executable path (os.Executable() in
+	// production). The foreign-watcher sweep (#5632) reaps `grafel watch`
+	// processes whose executable differs from this. nil → os.Executable.
+	SelfExe func() (string, error)
+
+	// ListWatchProcs enumerates live `grafel watch <repo>` processes for the
+	// foreign-watcher sweep (#5632). nil → process.ListWatchProcesses. A lister
+	// error (or an unsupported platform) makes the sweep a best-effort no-op.
+	ListWatchProcs func() ([]process.WatchProc, error)
+
+	// KillWatchProc terminates the foreign/duplicate watcher with the given pid
+	// (#5632). nil → sigtermPID (a graceful SIGTERM, matching the watchreg
+	// sweep). Injectable for tests so the sweep can be exercised without
+	// touching real processes.
+	KillWatchProc func(pid int) error
+
 	// LiveDaemonPID returns the PID of the currently-live daemon, used to detect
 	// orphaned watchers. nil → os.Getpid (the running daemon owns the sweep).
 	LiveDaemonPID func() int
@@ -116,6 +139,11 @@ type ReapResult struct {
 	// WatchersReaped is the number of stale/orphaned `grafel watch` PID
 	// registry entries reaped this sweep (#5142).
 	WatchersReaped int
+	// ForeignWatchersReaped is the number of live `grafel watch` processes
+	// reaped this sweep because their executable differed from the daemon's own
+	// (version skew / orphan) or they duplicated a managed repo's watcher
+	// (#5632). Independent of the watchreg-based count above.
+	ForeignWatchersReaped int
 	// DeadRefs summarises the dead-ref / dead-worktree sub-sweep (#5236).
 	DeadRefs DeadRefResult
 	// OrphanRoots summarises the orphan top-level store-root sub-sweep (#5263).
@@ -172,6 +200,12 @@ func (r *Reaper) Sweep() ReapResult {
 	// #5142: reap stale/orphaned `grafel watch` PIDs. Independent of the
 	// vanished-repo GC below, so it runs even in configs without TrackedRepos.
 	res.WatchersReaped = r.sweepWatchers()
+	// #5632: reap live `grafel watch` processes for MANAGED repos whose
+	// executable differs from the daemon's own (version skew / init-reparented
+	// orphans the watchreg sweep misses), and collapse duplicate watchers to one
+	// per repo. Best-effort: an unsupported platform / enumeration error is a
+	// no-op. Independent of the watchreg sweep above.
+	res.ForeignWatchersReaped = r.sweepForeignWatchers()
 	// #5236: dead-ref / dead-worktree sweep. Independent of the vanished-repo
 	// GC below; runs on the same cadence so a deleted branch's store + resident
 	// graph are reclaimed without a separate scheduler.
@@ -262,6 +296,74 @@ func (r *Reaper) sweepWatchers() int {
 			"dead", res.Dead, "orphaned", res.Orphaned, "kill_errors", len(res.KillErrors))
 	}
 	return res.Reaped()
+}
+
+// sweepForeignWatchers reaps live standalone `grafel watch <repo>` processes
+// for repos the daemon MANAGES whose executable differs from the daemon's own
+// (#5632) — the stale-`$GOPATH/bin`-version watcher and the init-reparented
+// orphan that the watchreg sweep cannot see (it only knows self-registered
+// PIDs, and only flags owner-PID mismatches, never executable skew). It also
+// collapses duplicate watchers down to one per managed repo. Returns the number
+// of processes reaped.
+//
+// Strictly scoped + fail-safe:
+//   - only processes targeting a MANAGED repo are ever considered;
+//   - the decision (watchscan.Compute) is pure and unit-tested;
+//   - enumeration is best-effort — a lister error or an unsupported platform
+//     yields an empty plan and the daemon is undisturbed;
+//   - a nil ManagedRepo disables the sweep entirely.
+func (r *Reaper) sweepForeignWatchers() int {
+	if r.cfg.ManagedRepo == nil {
+		return 0
+	}
+	list := r.cfg.ListWatchProcs
+	if list == nil {
+		list = process.ListWatchProcesses
+	}
+	selfExeFn := r.cfg.SelfExe
+	if selfExeFn == nil {
+		selfExeFn = os.Executable
+	}
+	selfExe, _ := selfExeFn() // empty self-exe → watchscan never declares a mismatch.
+
+	kill := r.cfg.KillWatchProc
+	if kill == nil {
+		kill = sigtermPID
+	}
+
+	plan := watchscan.Compute(watchscan.Deps{
+		SelfExe: selfExe,
+		Managed: r.cfg.ManagedRepo,
+		List: func() ([]watchscan.Proc, error) {
+			procs, err := list()
+			if err != nil {
+				return nil, err
+			}
+			out := make([]watchscan.Proc, 0, len(procs))
+			for _, p := range procs {
+				out = append(out, watchscan.Proc{PID: p.PID, Exe: p.Exe, Repo: p.Repo})
+			}
+			return out, nil
+		},
+	})
+
+	pids := plan.PIDs()
+	reaped := 0
+	for _, pid := range pids {
+		if pid == os.Getpid() {
+			continue // never signal the daemon itself.
+		}
+		if err := kill(pid); err != nil {
+			r.logger.Warn("reaper: foreign-watcher SIGTERM failed (non-fatal)", "pid", pid, "err", err)
+			continue
+		}
+		reaped++
+	}
+	if reaped > 0 {
+		r.logger.Info("reaper: reaped foreign/duplicate grafel-watch processes",
+			"reaped", reaped, "foreign", len(plan.Foreign), "duplicate", len(plan.Duplicate))
+	}
+	return reaped
 }
 
 // pidAliveProbe reports whether pid names a live process (signal-0 existence

--- a/internal/daemon/reaper_foreign_watch_test.go
+++ b/internal/daemon/reaper_foreign_watch_test.go
@@ -1,0 +1,82 @@
+package daemon
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// TestReaper_sweepForeignWatchers verifies the #5632 wiring: a foreign-version
+// `grafel watch` process for a MANAGED repo is SIGTERM'd, while a same-exe
+// watcher and a watcher for an UNMANAGED repo are left alone. Kills are observed
+// via the injected KillWatchProc so no real process is touched.
+func TestReaper_sweepForeignWatchers(t *testing.T) {
+	const self = "/home/u/.grafel/bin/grafel"
+	managed := map[string]bool{"/work/repo-a": true}
+
+	var killed []int
+	r := NewReaper(ReaperConfig{
+		SelfExe:     func() (string, error) { return self, nil },
+		ManagedRepo: func(p string) bool { return managed[p] },
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			return []process.WatchProc{
+				{PID: 100, Exe: "/home/u/go/bin/grafel", Repo: "/work/repo-a"},  // foreign, managed → reap
+				{PID: 101, Exe: self, Repo: "/work/repo-a"},                     // own, managed → keep
+				{PID: 102, Exe: "/home/u/go/bin/grafel", Repo: "/other/repo-z"}, // foreign, UNMANAGED → keep
+			}, nil
+		},
+		KillWatchProc: func(pid int) error { killed = append(killed, pid); return nil },
+	})
+
+	res := r.Sweep()
+	if res.ForeignWatchersReaped != 1 {
+		t.Fatalf("ForeignWatchersReaped = %d, want 1", res.ForeignWatchersReaped)
+	}
+	if !reflect.DeepEqual(killed, []int{100}) {
+		t.Fatalf("killed = %v, want [100] (only the foreign managed-repo watcher)", killed)
+	}
+}
+
+// Duplicate same-exe watchers for one managed repo are collapsed to one.
+func TestReaper_sweepForeignWatchers_DuplicateCollapse(t *testing.T) {
+	const self = "/opt/grafel"
+	var killed []int
+	r := NewReaper(ReaperConfig{
+		SelfExe:     func() (string, error) { return self, nil },
+		ManagedRepo: func(p string) bool { return p == "/work/repo-a" },
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			return []process.WatchProc{
+				{PID: 200, Exe: self, Repo: "/work/repo-a"},
+				{PID: 300, Exe: self, Repo: "/work/repo-a"},
+				{PID: 400, Exe: self, Repo: "/work/repo-a"},
+			}, nil
+		},
+		KillWatchProc: func(pid int) error { killed = append(killed, pid); return nil },
+	})
+	res := r.Sweep()
+	sort.Ints(killed)
+	if res.ForeignWatchersReaped != 2 || !reflect.DeepEqual(killed, []int{300, 400}) {
+		t.Fatalf("reaped=%d killed=%v, want 2 killed=[300 400] (200 survives)", res.ForeignWatchersReaped, killed)
+	}
+}
+
+// With nil ManagedRepo the foreign-watcher sweep is disabled entirely.
+func TestReaper_foreignSweepDisabledWhenNoManaged(t *testing.T) {
+	called := false
+	r := NewReaper(ReaperConfig{
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			called = true
+			return []process.WatchProc{{PID: 1, Exe: "/stale", Repo: "/x"}}, nil
+		},
+		KillWatchProc: func(int) error { t.Fatal("must not kill when sweep disabled"); return nil },
+	})
+	res := r.Sweep()
+	if res.ForeignWatchersReaped != 0 {
+		t.Fatalf("ForeignWatchersReaped = %d, want 0", res.ForeignWatchersReaped)
+	}
+	if called {
+		t.Fatal("lister must not be invoked when ManagedRepo is nil")
+	}
+}

--- a/internal/daemon/reaper_foreign_watch_test.go
+++ b/internal/daemon/reaper_foreign_watch_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -8,18 +9,32 @@ import (
 	"github.com/cajasmota/grafel/internal/process"
 )
 
-// TestReaper_sweepForeignWatchers verifies the #5632 wiring: a foreign-version
-// `grafel watch` process for a MANAGED repo is SIGTERM'd, while a same-exe
-// watcher and a watcher for an UNMANAGED repo are left alone. Kills are observed
-// via the injected KillWatchProc so no real process is touched.
+// managedClean returns a ManagedRepo predicate matching cleaned paths, so the
+// test fixtures (forward-slash literals) match watchscan's filepath.Clean
+// normalization on EVERY OS — including Windows, where Clean rewrites the
+// separators. This mirrors the production makeManagedRepoPredicate, which also
+// compares cleaned-absolute paths on both sides.
+func managedClean(repos ...string) func(string) bool {
+	m := map[string]bool{}
+	for _, r := range repos {
+		m[filepath.Clean(r)] = true
+	}
+	return func(p string) bool { return m[filepath.Clean(p)] }
+}
+
+// TestReaper_sweepForeignWatchers verifies the #5632 wiring on ALL platforms by
+// injecting a FAKE process list through the ListWatchProcs seam (so the unix-
+// only live enumeration is bypassed): a foreign-version `grafel watch` process
+// for a MANAGED repo is SIGTERM'd, while a same-exe watcher and a watcher for an
+// UNMANAGED repo are left alone. Kills are observed via the injected
+// KillWatchProc so no real process is touched.
 func TestReaper_sweepForeignWatchers(t *testing.T) {
 	const self = "/home/u/.grafel/bin/grafel"
-	managed := map[string]bool{"/work/repo-a": true}
 
 	var killed []int
 	r := NewReaper(ReaperConfig{
 		SelfExe:     func() (string, error) { return self, nil },
-		ManagedRepo: func(p string) bool { return managed[p] },
+		ManagedRepo: managedClean("/work/repo-a"),
 		ListWatchProcs: func() ([]process.WatchProc, error) {
 			return []process.WatchProc{
 				{PID: 100, Exe: "/home/u/go/bin/grafel", Repo: "/work/repo-a"},  // foreign, managed → reap
@@ -39,13 +54,14 @@ func TestReaper_sweepForeignWatchers(t *testing.T) {
 	}
 }
 
-// Duplicate same-exe watchers for one managed repo are collapsed to one.
+// Duplicate same-exe watchers for one managed repo are collapsed to one. Driven
+// through the ListWatchProcs seam so it runs on every OS.
 func TestReaper_sweepForeignWatchers_DuplicateCollapse(t *testing.T) {
 	const self = "/opt/grafel"
 	var killed []int
 	r := NewReaper(ReaperConfig{
 		SelfExe:     func() (string, error) { return self, nil },
-		ManagedRepo: func(p string) bool { return p == "/work/repo-a" },
+		ManagedRepo: managedClean("/work/repo-a"),
 		ListWatchProcs: func() ([]process.WatchProc, error) {
 			return []process.WatchProc{
 				{PID: 200, Exe: self, Repo: "/work/repo-a"},

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -572,9 +572,16 @@ func Run(ctx context.Context, cfg Config) error {
 				// #5142: also reap stale/orphaned `grafel watch` PIDs that
 				// registered in the daemon-owned registry under the daemon root.
 				WatchRegistry: watchreg.New(watchreg.DefaultPath(cfg.Layout.Root)),
-				DeadRefs:      deadRefSweeper,
-				OrphanRoots:   orphanRootSweeper,
-				Logger:        logger,
+				// #5632: also reap live `grafel watch` processes for managed
+				// repos that run from a STALE/foreign binary (version skew) or
+				// duplicate an existing watcher. ManagedRepo gates the sweep to
+				// the daemon's tracked repos only; the watcher's repo arg is
+				// matched (cleaned-absolute) against this set so unrelated
+				// processes are never touched.
+				ManagedRepo: makeManagedRepoPredicate(trackedRepos),
+				DeadRefs:    deadRefSweeper,
+				OrphanRoots: orphanRootSweeper,
+				Logger:      logger,
 			})
 			reaperStop := make(chan struct{})
 			reaper.Start(reaperStop)

--- a/internal/daemon/watchscan/watchscan.go
+++ b/internal/daemon/watchscan/watchscan.go
@@ -1,0 +1,190 @@
+// Package watchscan finds and reaps stale-version / orphaned standalone
+// `grafel watch <repo>` processes for the daemon's MANAGED repos (issue #5632).
+//
+// # Problem
+//
+// A standalone `grafel watch <repo>` process is launched by an OS unit
+// (launchd/systemd/schtasks) whose exec line is `<BinPath> watch <repo>`. If a
+// stale `go install` build still has a unit registered (a `$GOPATH/bin/grafel`
+// from an older version), or a watcher was started by hand, the daemon can end
+// up with a watcher running from an OUT-OF-DATE binary alongside the installed
+// daemon — version skew. Orphan watchers reparented to init also survive daemon
+// restarts. The existing watchreg-based reaper (#5142) only reaps watchers that
+// SELF-REGISTERED in watchers.json, and only on PID-liveness / owner mismatch —
+// it never compares the watcher's EXECUTABLE to the daemon's own, so a
+// foreign-binary watcher whose owner stamp happens to match (or that never
+// registered) is invisible to it.
+//
+// # Design
+//
+// watchscan is the executable-aware complement to the watchreg sweep. It
+// enumerates live `grafel watch <repo>` processes (via an injectable lister so
+// the decision logic is unit-testable with no real processes), and for each one
+// targeting a repo the daemon MANAGES it decides whether to reap it:
+//
+//   - a watcher whose executable path differs from the daemon's own
+//     os.Executable() is a stale/foreign-version watcher → reap; and
+//   - among watchers for the SAME managed repo, keep exactly one (the
+//     daemon's-own-exe one if present, else the lowest PID) and reap the rest.
+//
+// It NEVER touches a process for a repo the daemon does not manage, and it is
+// strictly best-effort: a lister error (or a platform that cannot enumerate)
+// yields an empty plan, so the daemon is never destabilized by enumeration
+// failure.
+package watchscan
+
+import (
+	"path/filepath"
+	"sort"
+)
+
+// Proc is one live `grafel watch <repo>` process the lister found.
+type Proc struct {
+	// PID is the watcher process id.
+	PID int
+	// Exe is the absolute path to the executable backing the process, when the
+	// platform could resolve it. May be empty if unresolved.
+	Exe string
+	// Repo is the absolute repo path the watcher targets (its `watch <repo>`
+	// argument), normalized to an absolute path by the lister when possible.
+	Repo string
+}
+
+// Deps are the injectable primitives the scan needs.
+type Deps struct {
+	// List returns the currently-live `grafel watch <repo>` processes. A nil
+	// List, or one that errors, makes Plan return an empty plan (best-effort).
+	List func() ([]Proc, error)
+	// SelfExe is the daemon's own executable path (os.Executable() in
+	// production). A watcher whose Exe differs from this — when both are known —
+	// is treated as a stale/foreign-version watcher.
+	SelfExe string
+	// Managed reports whether repoPath is a repo the daemon manages. Only
+	// watchers for managed repos are ever reaped. Required; a nil Managed makes
+	// the plan empty (nothing is considered managed).
+	Managed func(repoPath string) bool
+}
+
+// Plan is the set of PIDs that should be reaped.
+type Plan struct {
+	// Foreign are PIDs reaped because their executable differs from the daemon's
+	// own (version skew / orphan from a different install).
+	Foreign []int
+	// Duplicate are PIDs reaped because another watcher already covers the same
+	// managed repo (one-watcher-per-repo).
+	Duplicate []int
+}
+
+// PIDs returns every PID the plan would reap (foreign + duplicate), sorted and
+// de-duplicated.
+func (p Plan) PIDs() []int {
+	seen := map[int]struct{}{}
+	var out []int
+	for _, pid := range p.Foreign {
+		if _, ok := seen[pid]; !ok {
+			seen[pid] = struct{}{}
+			out = append(out, pid)
+		}
+	}
+	for _, pid := range p.Duplicate {
+		if _, ok := seen[pid]; !ok {
+			seen[pid] = struct{}{}
+			out = append(out, pid)
+		}
+	}
+	sort.Ints(out)
+	return out
+}
+
+// sameExe reports whether two executable paths refer to the same binary. Both
+// must be non-empty to compare; an unknown path (empty) is never declared a
+// mismatch, so we don't reap a watcher merely because we couldn't read its exe.
+func sameExe(a, b string) bool {
+	if a == "" || b == "" {
+		return true
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+// Compute computes which managed-repo watchers to reap. It is pure (no process
+// side effects): the caller terminates the returned PIDs. Determinism: within a
+// repo, watchers are considered in ascending PID order, and the kept survivor is
+// the daemon's-own-exe watcher if one exists, otherwise the lowest PID.
+func Compute(deps Deps) Plan {
+	var plan Plan
+	if deps.List == nil || deps.Managed == nil {
+		return plan
+	}
+	procs, err := deps.List()
+	if err != nil {
+		return plan // best-effort: enumeration failure → reap nothing.
+	}
+
+	// Group managed-repo watchers by normalized repo path.
+	byRepo := map[string][]Proc{}
+	for _, p := range procs {
+		if p.PID <= 0 || p.Repo == "" {
+			continue
+		}
+		repo := filepath.Clean(p.Repo)
+		if !deps.Managed(repo) {
+			continue // never touch a watcher for an unmanaged repo.
+		}
+		byRepo[repo] = append(byRepo[repo], p)
+	}
+
+	// Deterministic repo iteration order for stable output.
+	repos := make([]string, 0, len(byRepo))
+	for repo := range byRepo {
+		repos = append(repos, repo)
+	}
+	sort.Strings(repos)
+
+	for _, repo := range repos {
+		group := byRepo[repo]
+		sort.Slice(group, func(i, j int) bool { return group[i].PID < group[j].PID })
+
+		// First, flag every foreign-exe watcher for reaping.
+		foreign := map[int]bool{}
+		for _, p := range group {
+			if !sameExe(p.Exe, deps.SelfExe) {
+				plan.Foreign = append(plan.Foreign, p.PID)
+				foreign[p.PID] = true
+			}
+		}
+
+		// Among the survivors (own-exe / unknown-exe watchers), keep exactly one
+		// and reap the rest as duplicates. Prefer a watcher whose exe matches the
+		// daemon's own; otherwise the lowest PID (group is PID-sorted).
+		var survivors []Proc
+		for _, p := range group {
+			if !foreign[p.PID] {
+				survivors = append(survivors, p)
+			}
+		}
+		if len(survivors) <= 1 {
+			continue
+		}
+		keep := pickSurvivor(survivors, deps.SelfExe)
+		for _, p := range survivors {
+			if p.PID != keep {
+				plan.Duplicate = append(plan.Duplicate, p.PID)
+			}
+		}
+	}
+	return plan
+}
+
+// pickSurvivor returns the PID to keep among same-repo survivor watchers:
+// the one whose exe matches the daemon's own if present, else the lowest PID.
+// survivors is assumed PID-sorted ascending.
+func pickSurvivor(survivors []Proc, selfExe string) int {
+	if selfExe != "" {
+		for _, p := range survivors {
+			if p.Exe != "" && filepath.Clean(p.Exe) == filepath.Clean(selfExe) {
+				return p.PID
+			}
+		}
+	}
+	return survivors[0].PID
+}

--- a/internal/daemon/watchscan/watchscan_test.go
+++ b/internal/daemon/watchscan/watchscan_test.go
@@ -2,17 +2,22 @@ package watchscan
 
 import (
 	"errors"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
 
-// managedSet builds a Managed predicate from a fixed set of repo paths.
+// managedSet builds a Managed predicate from a fixed set of repo paths. Both
+// the stored set and the lookup are filepath.Clean'd so the forward-slash test
+// literals match Compute's internally-cleaned repo paths on EVERY OS — on
+// Windows, Clean rewrites "/work/repo-a" to "\work\repo-a", and Compute calls
+// Managed with that cleaned form.
 func managedSet(repos ...string) func(string) bool {
 	m := map[string]bool{}
 	for _, r := range repos {
-		m[r] = true
+		m[filepath.Clean(r)] = true
 	}
-	return func(p string) bool { return m[p] }
+	return func(p string) bool { return m[filepath.Clean(p)] }
 }
 
 // A foreign-exe watcher for a MANAGED repo is selected; a same-exe watcher and

--- a/internal/daemon/watchscan/watchscan_test.go
+++ b/internal/daemon/watchscan/watchscan_test.go
@@ -1,0 +1,135 @@
+package watchscan
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// managedSet builds a Managed predicate from a fixed set of repo paths.
+func managedSet(repos ...string) func(string) bool {
+	m := map[string]bool{}
+	for _, r := range repos {
+		m[r] = true
+	}
+	return func(p string) bool { return m[p] }
+}
+
+// A foreign-exe watcher for a MANAGED repo is selected; a same-exe watcher and
+// an UNRELATED-repo watcher are skipped.
+func TestCompute_ForeignWatcherSelected_UnrelatedSkipped(t *testing.T) {
+	self := "/home/u/.grafel/bin/grafel"
+	plan := Compute(Deps{
+		SelfExe: self,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{
+				// foreign-version watcher for a managed repo → reap.
+				{PID: 100, Exe: "/home/u/go/bin/grafel", Repo: "/work/repo-a"},
+				// same-exe watcher for a managed repo → keep.
+				{PID: 101, Exe: self, Repo: "/work/repo-a"},
+				// foreign watcher for an UNMANAGED repo → never touched.
+				{PID: 102, Exe: "/home/u/go/bin/grafel", Repo: "/other/repo-z"},
+			}, nil
+		},
+	})
+	if got, want := plan.PIDs(), []int{100}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PIDs() = %v, want %v (only the foreign managed-repo watcher)", got, want)
+	}
+	if len(plan.Foreign) != 1 || plan.Foreign[0] != 100 {
+		t.Fatalf("Foreign = %v, want [100]", plan.Foreign)
+	}
+}
+
+// Among multiple SAME-exe watchers for one managed repo, exactly one survives.
+func TestCompute_DuplicateCollapse_KeepsOne(t *testing.T) {
+	self := "/opt/grafel"
+	plan := Compute(Deps{
+		SelfExe: self,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{
+				{PID: 300, Exe: self, Repo: "/work/repo-a"},
+				{PID: 200, Exe: self, Repo: "/work/repo-a"},
+				{PID: 400, Exe: self, Repo: "/work/repo-a"},
+			}, nil
+		},
+	})
+	// All three are own-exe; two are duplicates. The kept one is the own-exe
+	// match with the lowest PID (200).
+	if got, want := plan.PIDs(), []int{300, 400}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PIDs() = %v, want %v (200 survives)", got, want)
+	}
+}
+
+// A foreign watcher is preferred for reaping; the own-exe survivor is kept even
+// if it has a higher PID than the foreign one.
+func TestCompute_PrefersOwnExeSurvivor(t *testing.T) {
+	self := "/opt/grafel"
+	plan := Compute(Deps{
+		SelfExe: self,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{
+				{PID: 10, Exe: "/stale/grafel", Repo: "/work/repo-a"}, // foreign
+				{PID: 20, Exe: self, Repo: "/work/repo-a"},            // own → keep
+			}, nil
+		},
+	})
+	if got, want := plan.PIDs(), []int{10}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PIDs() = %v, want %v (foreign reaped, own kept)", got, want)
+	}
+}
+
+// An unknown (empty) exe is never declared a mismatch — we don't reap a watcher
+// merely because we couldn't read its executable. With a single such watcher it
+// is kept.
+func TestCompute_UnknownExeKept(t *testing.T) {
+	plan := Compute(Deps{
+		SelfExe: "/opt/grafel",
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{{PID: 50, Exe: "", Repo: "/work/repo-a"}}, nil
+		},
+	})
+	if pids := plan.PIDs(); len(pids) != 0 {
+		t.Fatalf("PIDs() = %v, want empty (unknown exe is not a mismatch)", pids)
+	}
+}
+
+// A lister error → empty plan (best-effort; never destabilize the daemon).
+func TestCompute_ListErrorIsNoOp(t *testing.T) {
+	plan := Compute(Deps{
+		SelfExe: "/opt/grafel",
+		Managed: managedSet("/work/repo-a"),
+		List:    func() ([]Proc, error) { return nil, errors.New("ps failed") },
+	})
+	if pids := plan.PIDs(); len(pids) != 0 {
+		t.Fatalf("PIDs() = %v, want empty on lister error", pids)
+	}
+}
+
+// nil List or nil Managed disables the plan entirely.
+func TestCompute_NilDepsAreNoOp(t *testing.T) {
+	if pids := Compute(Deps{Managed: managedSet("/x")}).PIDs(); len(pids) != 0 {
+		t.Fatalf("nil List: got %v, want empty", pids)
+	}
+	if pids := Compute(Deps{List: func() ([]Proc, error) { return []Proc{{PID: 1, Repo: "/x", Exe: "/stale"}}, nil }}).PIDs(); len(pids) != 0 {
+		t.Fatalf("nil Managed: got %v, want empty", pids)
+	}
+}
+
+// Empty SelfExe means we cannot establish skew → no foreign reaping (only
+// duplicates, by PID, would still collapse — verified separately).
+func TestCompute_EmptySelfExeNoForeignReap(t *testing.T) {
+	plan := Compute(Deps{
+		SelfExe: "",
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{{PID: 1, Exe: "/anything/grafel", Repo: "/work/repo-a"}}, nil
+		},
+	})
+	if pids := plan.PIDs(); len(pids) != 0 {
+		t.Fatalf("PIDs() = %v, want empty when self-exe unknown", pids)
+	}
+}

--- a/internal/daemon/worktree_gate.go
+++ b/internal/daemon/worktree_gate.go
@@ -12,6 +12,8 @@
 package daemon
 
 import (
+	"path/filepath"
+
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
 )
 
@@ -65,6 +67,37 @@ func makeReaperTrackedRepos(reposToWatch func() []string, wtStore *worktree.Stor
 			}
 		}
 		return out
+	}
+}
+
+// makeManagedRepoPredicate returns the foreign-watcher sweep's ManagedRepo
+// gate (#5632): reports whether repoPath is one of the daemon's currently
+// tracked repos. The tracked set is re-read on every call (so repos
+// registered/worktrees added after boot are covered), and both sides are
+// compared as cleaned-absolute paths so a watcher's `watch <repo>` argument
+// matches regardless of how it was written. A nil trackedRepos disables the
+// sweep (the predicate is nil → reaper skips it).
+func makeManagedRepoPredicate(trackedRepos func() []string) func(string) bool {
+	if trackedRepos == nil {
+		return nil
+	}
+	cleanAbs := func(p string) string {
+		if abs, err := filepath.Abs(p); err == nil {
+			return filepath.Clean(abs)
+		}
+		return filepath.Clean(p)
+	}
+	return func(repoPath string) bool {
+		if repoPath == "" {
+			return false
+		}
+		want := cleanAbs(repoPath)
+		for _, r := range trackedRepos() {
+			if r != "" && cleanAbs(r) == want {
+				return true
+			}
+		}
+		return false
 	}
 }
 

--- a/internal/process/watchprocs.go
+++ b/internal/process/watchprocs.go
@@ -1,0 +1,73 @@
+package process
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// WatchProc is a live `grafel watch <repo>` process: its PID, the absolute
+// executable backing it (when resolvable), and the repo path it targets (the
+// `watch <repo>` argument). Used by the daemon to reap stale-version / orphan
+// watchers (#5632).
+type WatchProc struct {
+	PID  int
+	Exe  string
+	Repo string
+}
+
+// ListWatchProcesses returns every live `grafel watch <repo>` process visible
+// on this host. The platform-specific enumeration lives in
+// watchprocs_unix.go (darwin/linux, via ps/proc) and watchprocs_other.go
+// (Windows and unsupported platforms, which return ErrUnsupported). Callers
+// treat any error — including ErrUnsupported — as "could not enumerate" and
+// skip reaping rather than failing.
+func ListWatchProcesses() ([]WatchProc, error) {
+	return listWatchProcesses()
+}
+
+// parseWatchArgs extracts the repo argument from a tokenized `grafel watch
+// <repo> [flags]` command line and reports whether this is a watch invocation
+// at all. argv[0] is the program; we look for the `watch` subcommand followed
+// by the first non-flag token (the repo path). Returns ("", false) when the
+// command is not a `grafel watch` invocation or has no repo argument.
+func parseWatchArgs(argv []string) (repo string, ok bool) {
+	// Find the `watch` subcommand token.
+	watchIdx := -1
+	for i := 1; i < len(argv); i++ {
+		if argv[i] == "watch" {
+			watchIdx = i
+			break
+		}
+	}
+	if watchIdx < 0 {
+		return "", false
+	}
+	// The repo is the first non-flag token after `watch`. Flags (e.g.
+	// --interval, --group) and their values are skipped conservatively: a
+	// `--flag=value` token is a single skip; a bare `--flag` consumes the next
+	// token as its value. The repo is a path, never a flag.
+	for i := watchIdx + 1; i < len(argv); i++ {
+		tok := argv[i]
+		if strings.HasPrefix(tok, "-") {
+			if !strings.Contains(tok, "=") {
+				i++ // bare flag consumes its value
+			}
+			continue
+		}
+		return tok, true
+	}
+	return "", false
+}
+
+// absRepo normalizes a repo argument to a cleaned absolute path when possible,
+// falling back to a cleaned relative path. Best-effort: the watcher's matching
+// against the daemon's managed set is done on cleaned absolute paths.
+func absRepo(repo string) string {
+	if repo == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(repo); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(repo)
+}

--- a/internal/process/watchprocs_other.go
+++ b/internal/process/watchprocs_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package process
+
+// listWatchProcesses is not implemented on platforms without cheap full-argv
+// process enumeration (Windows and others). It returns ErrUnsupported so the
+// daemon's watcher reaper treats the platform as "cannot enumerate" and skips
+// the foreign/orphan-watcher sweep rather than failing — the watchreg-based
+// reaper (#5142) remains the fallback on these platforms.
+func listWatchProcesses() ([]WatchProc, error) {
+	return nil, ErrUnsupported
+}

--- a/internal/process/watchprocs_test.go
+++ b/internal/process/watchprocs_test.go
@@ -1,0 +1,54 @@
+package process
+
+import "testing"
+
+func TestParseWatchArgs(t *testing.T) {
+	cases := []struct {
+		name     string
+		argv     []string
+		wantRepo string
+		wantOK   bool
+	}{
+		{
+			name:     "plain watch repo",
+			argv:     []string{"/opt/grafel", "watch", "/work/repo-a"},
+			wantRepo: "/work/repo-a", wantOK: true,
+		},
+		{
+			name:     "flag before repo (value form)",
+			argv:     []string{"grafel", "watch", "--interval", "10s", "/work/repo-a"},
+			wantRepo: "/work/repo-a", wantOK: true,
+		},
+		{
+			name:     "flag=value before repo",
+			argv:     []string{"grafel", "watch", "--group=mygroup", "/work/repo-a"},
+			wantRepo: "/work/repo-a", wantOK: true,
+		},
+		{
+			name:     "repo then trailing flags",
+			argv:     []string{"grafel", "watch", "/work/repo-a", "--interval=30s"},
+			wantRepo: "/work/repo-a", wantOK: true,
+		},
+		{
+			name:   "not a watch invocation",
+			argv:   []string{"grafel", "index", "/work/repo-a"},
+			wantOK: false,
+		},
+		{
+			name:   "watch with no repo arg",
+			argv:   []string{"grafel", "watch", "--interval", "10s"},
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, ok := parseWatchArgs(tc.argv)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && repo != tc.wantRepo {
+				t.Fatalf("repo = %q, want %q", repo, tc.wantRepo)
+			}
+		})
+	}
+}

--- a/internal/process/watchprocs_unix.go
+++ b/internal/process/watchprocs_unix.go
@@ -1,0 +1,77 @@
+//go:build darwin || linux
+
+package process
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// listWatchProcesses enumerates live `grafel watch <repo>` processes on
+// darwin/linux via a single `ps` invocation that yields the FULL argument
+// vector (so we can read the `watch <repo>` arg) and the command path (so we
+// can read the executable backing the watcher). One shell-out is acceptable:
+// the daemon calls this at most once per reaper sweep (every few minutes).
+//
+// We deliberately use `ps` on BOTH platforms here (rather than /proc on Linux):
+// the format is identical, the parsing is shared, and the volume is tiny. A ps
+// failure returns an error, which the caller treats as "could not enumerate"
+// and skips reaping.
+func listWatchProcesses() ([]WatchProc, error) {
+	// pid + the full command line (with argv). `args` is the full command with
+	// arguments on both BSD (macOS) and GNU/Linux ps. We request it last so any
+	// embedded spaces in the path stay on the same line as the rest of argv.
+	out, err := exec.Command("ps", "-ax", "-o", "pid=,args=").Output()
+	if err != nil {
+		return nil, fmt.Errorf("ps: %w", err)
+	}
+	return parseWatchPsArgs(string(out)), nil
+}
+
+// parseWatchPsArgs parses `ps -ax -o pid=,args=` output into the subset of
+// processes that are `grafel watch <repo>` invocations. Each line is
+// `<pid> <argv0> <argv1> ...`. argv0 is the executable path (used as Exe), and
+// the repo is the first non-flag token after the `watch` subcommand.
+func parseWatchPsArgs(out string) []WatchProc {
+	var result []WatchProc
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		argv := fields[1:]
+		exe := argv[0]
+		// Cheap pre-filter: the executable basename must look like grafel and
+		// the argv must contain a `watch` token. This avoids parsing every
+		// process on the box.
+		if !exeBaseNameIsGrafel(baseName(exe)) {
+			continue
+		}
+		repo, ok := parseWatchArgs(argv)
+		if !ok {
+			continue
+		}
+		result = append(result, WatchProc{PID: pid, Exe: exe, Repo: absRepo(repo)})
+	}
+	return result
+}
+
+// baseName returns the last path element of p without importing path/filepath
+// at the call site (keeps the hot parse loop dependency-light). It mirrors
+// filepath.Base for the unix separator.
+func baseName(p string) string {
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}

--- a/internal/process/watchprocs_unix_test.go
+++ b/internal/process/watchprocs_unix_test.go
@@ -1,0 +1,24 @@
+//go:build darwin || linux
+
+package process
+
+import "testing"
+
+func TestParseWatchPsArgs(t *testing.T) {
+	out := "" +
+		"  100 /home/u/go/bin/grafel watch /work/repo-a --interval 30s\n" +
+		"  101 /home/u/.grafel/bin/grafel watch /work/repo-b\n" +
+		"  102 /usr/bin/some-other-tool watch /work/repo-c\n" + // not grafel → skipped
+		"  103 /home/u/.grafel/bin/grafel index /work/repo-d\n" + // not watch → skipped
+		"  104 /home/u/.grafel/bin/grafel daemon\n" // no watch → skipped
+	got := parseWatchPsArgs(out)
+	if len(got) != 2 {
+		t.Fatalf("got %d watch procs, want 2: %+v", len(got), got)
+	}
+	if got[0].PID != 100 || got[0].Exe != "/home/u/go/bin/grafel" || got[0].Repo == "" {
+		t.Fatalf("proc[0] = %+v, want pid 100 exe /home/u/go/bin/grafel non-empty repo", got[0])
+	}
+	if got[1].PID != 101 || got[1].Exe != "/home/u/.grafel/bin/grafel" {
+		t.Fatalf("proc[1] = %+v, want pid 101 exe /home/u/.grafel/bin/grafel", got[1])
+	}
+}


### PR DESCRIPTION
Closes #5632.

## Problem
A standalone `watch <repo>` process can end up running from a STALE binary (an old `go install` build) alongside the installed daemon — version skew — and init-reparented orphan watchers survive daemon restarts. The daemon’s existing PID-registry reaper only reaps watchers that self-registered, and only on PID-liveness / owner-PID mismatch; it never compares the watcher’s **executable** to the daemon’s own, so a foreign-binary watcher is invisible to it.

## Fix
1. **Spawn via own binary (lock-in).** The watcher OS unit’s exec line is `<BinPath> watch <repo>`, and `BinPath` is already sourced from `os.Executable()` at install/update time — never a PATH-resolved bare name. The unit-render tests lock that in.
2. **Executable-aware reaping (the real fix).**
   - New `internal/daemon/watchscan`: pure, unit-tested decision logic. Given the live `watch` processes, the daemon’s own exe, and a managed-repo predicate, it plans which to reap — any watcher whose exe differs from the daemon’s own (version skew / orphan) for a **managed** repo, plus duplicates collapsed to one watcher per repo.
   - New `process.ListWatchProcesses` enumerates live `watch <repo>` processes with full exe path + repo arg (`ps` on darwin/linux; `ErrUnsupported` on Windows/other).
   - `reaper.sweepForeignWatchers` wires these on the existing reaper cadence, **scoped strictly to managed repos**, best-effort (enumeration failure or unsupported platform → no-op), never signalling the daemon itself.
3. **One watcher per repo.** The same plan collapses same-repo duplicates to a single survivor (preferring the daemon’s-own-exe one).

## Safety
- Only watchers whose `watch <repo>` arg matches the daemon’s managed set (cleaned-absolute) are ever touched — unrelated processes are never signalled.
- Enumeration is fully guarded: any `ps`/`/proc` failure or an unsupported platform yields an empty plan; the watchreg-based reaper remains the fallback.

## Tests
`go build ./...` clean; `gofmt -l` clean; new + existing tests green on touched packages (`internal/daemon/watchscan`, `internal/process`, `internal/daemon`, `internal/install/watchers`):
- spawn-uses-own-exe (unit render),
- watchscan selects a foreign managed-repo watcher while skipping same-exe and unmanaged ones,
- duplicate collapse keeps exactly one,
- lister-error / nil-deps / empty-self-exe / unknown-exe are no-ops,
- reaper sweep SIGTERMs exactly the planned PIDs via an injected killer,
- `parseWatchArgs` flag/repo parsing + `ps`-output parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)