### PR TITLE
fix(daemon): route all source parsing through accounted+capped index lane (#5630)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cajasmota/grafel/internal/extractors"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/jobs"
 	"github.com/cajasmota/grafel/internal/mcp"
 	"github.com/cajasmota/grafel/internal/process"
@@ -419,6 +420,19 @@ func runDaemon(argv []string) error {
 		prev := runtime.GOMAXPROCS(gmp)
 		gcLog.Printf("cpu-tune: GRAFEL_DAEMON_GOMAXPROCS=%d applied (was %d, host=%d)", gmp, prev, runtime.NumCPU())
 	}
+
+	// #5630: bound CONCURRENT in-process tree-sitter parses. The reactive
+	// incremental reindex (and the opt-out in-process full index) re-parse
+	// changed files INSIDE the daemon — work that escapes both the IndexGate
+	// (#5493, rebuild-only) and the #5602 reindex GOMAXPROCS cap (subprocess-
+	// only), so it can monopolise the box while index_status reports idle. Cap
+	// it at the daemon's effective GOMAXPROCS (the same core budget the daemon
+	// runtime itself uses) so an in-process parse burst cannot draw more cores
+	// than the daemon is allowed. Mirrors the runtime cap above; honors the same
+	// resolve path so a tightened GRAFEL_DAEMON_GOMAXPROCS also tightens parsing.
+	parseCap := runtime.GOMAXPROCS(0)
+	indexstate.SetParseConcurrency(parseCap)
+	gcLog.Printf("cpu-tune: in-process parse concurrency cap=%d (#5630)", parseCap)
 
 	// Parse daemon-only flags. The root cobra command has flag parsing
 	// disabled for "daemon" so we own the argv. Unknown flags exit

--- a/internal/indexstate/indexstate.go
+++ b/internal/indexstate/indexstate.go
@@ -33,6 +33,21 @@ var (
 	// group-algo pass without conflating it with a reactive reindex count.
 	groupAlgoInFlight atomic.Int64
 
+	// parseInFlight counts in-flight IN-PROCESS tree-sitter parses (#5630). The
+	// reactive scheduler's incremental reindex and the opt-out in-process full
+	// index re-parse changed files INSIDE the daemon process — they never go
+	// through the IndexGate (so concurrency.indexing stays 0) and the #5602
+	// reindex GOMAXPROCS cap (which only sets env on the index-internal SUBPROCESS)
+	// does not touch them. Profiling a hot daemon showed every hot frame in
+	// ts_parser_parse while index_status reported state:current / any_indexing:false
+	// / concurrency.indexing:0 — the parse ran OUTSIDE all the accounted+capped
+	// lanes. This counter is bumped by treesitter.ParserFactory.Parse so that
+	// "the daemon is parsing" is ALWAYS observable (busy signal), regardless of
+	// which path triggered it. Note: each extract subprocess is a separate process
+	// with its own copy of this global, so a subprocess's parses never leak into
+	// the daemon's count — only true in-process daemon parses register here.
+	parseInFlight atomic.Int64
+
 	// indexConcActive / indexConcQueued mirror the daemon-wide index-concurrency
 	// gate (#5493): how many module/repo index operations are running right now
 	// vs. waiting for a free slot. They let `grafel status` / grafel_index_status
@@ -181,6 +196,25 @@ func GroupAlgoEnd() {
 	}
 }
 
+// ParseBegin records the start of an IN-PROCESS tree-sitter parse (#5630).
+// Bracketed by ParseEnd (deferred at the call site in treesitter.ParserFactory.
+// Parse). On the first parse of an otherwise-idle daemon it stamps the busy-
+// period start so indexing_started_at is populated even for a pure in-process
+// parse burst (an incremental reindex re-parsing changed files). Safe to call
+// from any goroutine, including the per-file extract loop.
+func ParseBegin() {
+	if prev := parseInFlight.Add(1); prev == 1 && inFlight.Load() == 0 && groupAlgoInFlight.Load() == 0 {
+		startedUnixNano.CompareAndSwap(0, time.Now().UnixNano())
+	}
+}
+
+// ParseEnd records the completion of an in-process parse. Clamped at 0.
+func ParseEnd() {
+	if n := parseInFlight.Add(-1); n < 0 {
+		parseInFlight.Store(0)
+	}
+}
+
 // Set records the current number of in-flight index jobs. It is idempotent and
 // safe to call from any goroutine. On the transition into a busy period
 // (previous count 0, new count > 0) it stamps the start time; on the
@@ -208,6 +242,17 @@ type Snapshot struct {
 	// GroupAlgoInFlight is the number of group-algorithm passes currently
 	// running (#5349 A3).
 	GroupAlgoInFlight int
+	// ParseInFlight is the number of IN-PROCESS tree-sitter parses currently
+	// running in THIS process (#5630). >0 means the daemon is actively parsing
+	// source (e.g. an incremental reindex re-parsing changed files) even when no
+	// index job is registered in the scheduler — the bug behind "index_status
+	// reports idle while the daemon is CPU-pinned in ts_parser_parse".
+	ParseInFlight int
+	// Busy is the true daemon-activity signal (#5630/#5631): an index job, a
+	// group-algo pass, OR an in-process parse is running. A consumer that needs
+	// "is grafel quiet?" (not just "is the index fresh?") should gate on this,
+	// not on IsIndexing/state==current alone.
+	Busy bool
 	// StartedAt is the wall-clock start of the current busy period, or the
 	// zero Time when idle.
 	StartedAt time.Time
@@ -218,10 +263,13 @@ type Snapshot struct {
 func Get() Snapshot {
 	n := inFlight.Load()
 	ga := groupAlgoInFlight.Load()
+	pf := parseInFlight.Load()
 	s := Snapshot{
 		IsIndexing:        n > 0 || ga > 0,
 		InFlight:          int(n),
 		GroupAlgoInFlight: int(ga),
+		ParseInFlight:     int(pf),
+		Busy:              n > 0 || ga > 0 || pf > 0,
 	}
 	if started := startedUnixNano.Load(); started > 0 {
 		s.StartedAt = time.Unix(0, started)

--- a/internal/indexstate/parse_accounting_5630_test.go
+++ b/internal/indexstate/parse_accounting_5630_test.go
@@ -1,0 +1,164 @@
+package indexstate
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestParseAccounting covers the in-process parse busy counter (#5630): a parse
+// that previously bypassed all accounting now flips ParseInFlight + Busy, and
+// stamps the busy-period start when the daemon was otherwise idle.
+func TestParseAccounting(t *testing.T) {
+	t.Cleanup(func() { ParseEnd(); Set(0); SetParseConcurrency(0) })
+
+	// Idle baseline.
+	Set(0)
+	if s := Get(); s.Busy || s.ParseInFlight != 0 || !s.StartedAt.IsZero() {
+		t.Fatalf("idle: got %+v, want not-busy/0/zero-time", s)
+	}
+
+	// A parse begins: ParseInFlight=1, Busy=true, started-at stamped even though
+	// no index job is registered (the exact #5630 symptom: parsing while the
+	// scheduler reports idle).
+	ParseBegin()
+	s := Get()
+	if !s.Busy || s.ParseInFlight != 1 {
+		t.Fatalf("parsing: got %+v, want busy with 1 parse in flight", s)
+	}
+	if s.IsIndexing {
+		t.Fatalf("parsing must not be conflated with index-job IsIndexing: %+v", s)
+	}
+	if s.StartedAt.IsZero() {
+		t.Fatalf("parsing should stamp the busy-period start when otherwise idle")
+	}
+
+	// Parse ends → back to idle.
+	ParseEnd()
+	if s := Get(); s.Busy || s.ParseInFlight != 0 {
+		t.Fatalf("after parse: got %+v, want not-busy/0", s)
+	}
+}
+
+// TestParseEndClampsAtZero proves an unbalanced ParseEnd cannot drive the
+// counter negative.
+func TestParseEndClampsAtZero(t *testing.T) {
+	t.Cleanup(func() { Set(0) })
+	ParseEnd()
+	ParseEnd()
+	if s := Get(); s.ParseInFlight != 0 {
+		t.Fatalf("clamp: got ParseInFlight=%d, want 0", s.ParseInFlight)
+	}
+}
+
+// TestParseGateCap proves the in-process parse cap actually bounds concurrency:
+// with cap=1 a second acquirer blocks until the first releases.
+func TestParseGateCap(t *testing.T) {
+	t.Cleanup(func() { SetParseConcurrency(0); Set(0) })
+
+	SetParseConcurrency(1)
+	if got := ParseConcurrencyCap(); got != 1 {
+		t.Fatalf("cap: got %d, want 1", got)
+	}
+
+	// First acquire takes the only slot and bumps the busy counter.
+	AcquireParseSlot()
+	if s := Get(); s.ParseInFlight != 1 {
+		t.Fatalf("first acquire: ParseInFlight=%d, want 1", s.ParseInFlight)
+	}
+
+	// Second acquire must block until the first releases.
+	acquired := make(chan struct{})
+	go func() {
+		AcquireParseSlot()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatalf("second AcquireParseSlot returned while slot held — cap not enforced")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: blocked.
+	}
+
+	// Releasing the first slot must wake the blocked acquirer.
+	ReleaseParseSlot()
+	select {
+	case <-acquired:
+		// Expected.
+	case <-time.After(time.Second):
+		t.Fatalf("second AcquireParseSlot did not wake after release — FIFO wake broken")
+	}
+	ReleaseParseSlot()
+
+	if s := Get(); s.ParseInFlight != 0 {
+		t.Fatalf("after both release: ParseInFlight=%d, want 0", s.ParseInFlight)
+	}
+}
+
+// TestParseGateUnboundedIsNoOp proves cap=0 (the non-daemon default) never
+// blocks — many concurrent acquirers all proceed immediately.
+func TestParseGateUnboundedIsNoOp(t *testing.T) {
+	t.Cleanup(func() { SetParseConcurrency(0); Set(0) })
+	SetParseConcurrency(0)
+
+	const n = 8
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			AcquireParseSlot()
+			defer ReleaseParseSlot()
+			<-done // hold the slot; under cap=0 all n proceed without blocking
+		}()
+	}
+
+	// All n should have acquired despite holding; give them a moment then check.
+	deadline := time.After(time.Second)
+	for {
+		if s := Get(); s.ParseInFlight == n {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("unbounded gate blocked: ParseInFlight=%d, want %d", Get().ParseInFlight, n)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	close(done)
+	wg.Wait()
+	if s := Get(); s.ParseInFlight != 0 {
+		t.Fatalf("after release: ParseInFlight=%d, want 0", s.ParseInFlight)
+	}
+}
+
+// TestRaiseCapWakesWaiters proves that raising the cap (SetParseConcurrency)
+// promotes already-queued waiters — so a daemon that tightens then loosens the
+// cap does not strand parses.
+func TestRaiseCapWakesWaiters(t *testing.T) {
+	t.Cleanup(func() { SetParseConcurrency(0); Set(0) })
+
+	SetParseConcurrency(1)
+	AcquireParseSlot() // hold the only slot
+
+	acquired := make(chan struct{})
+	go func() {
+		AcquireParseSlot()
+		close(acquired)
+	}()
+	// Ensure the second acquirer is queued.
+	time.Sleep(20 * time.Millisecond)
+
+	// Raise the cap → the queued waiter should be admitted without a release.
+	SetParseConcurrency(2)
+	select {
+	case <-acquired:
+		// Expected.
+	case <-time.After(time.Second):
+		t.Fatalf("raising the cap did not wake the queued waiter")
+	}
+	ReleaseParseSlot()
+	ReleaseParseSlot()
+}

--- a/internal/indexstate/parsegate.go
+++ b/internal/indexstate/parsegate.go
@@ -1,0 +1,110 @@
+// parsegate.go — the in-process tree-sitter parse CPU/concurrency cap (#5630).
+//
+// PROBLEM. The reactive scheduler's incremental reindex (extractors.
+// TryIncremental) and the opt-out in-process full index re-parse changed files
+// INSIDE the daemon process. That parse goes through neither of the existing
+// throttles:
+//
+//   - the IndexGate (#5493) — only rebuildWorkerPool acquires it, so the
+//     reactive/incremental path never registers in concurrency.indexing; and
+//   - the #5602 reindex CPU ceiling — that sets GOMAXPROCS only on the
+//     index-internal SUBPROCESS, so an in-process parse runs at the daemon's
+//     own GOMAXPROCS (= host core count).
+//
+// Result: a daemon parsing in-process can monopolise the box (the multi-hour
+// 5–7 core burn in #5630) while index_status reports idle.
+//
+// FIX. A single process-wide gate bounds how many in-process tree-sitter
+// parses run CONCURRENTLY. treesitter.ParserFactory.Parse acquires a slot
+// around every parse, so ALL in-process parsing — regardless of caller — is
+// bounded by one daemon-wide ceiling. Excess parses block until a slot frees.
+//
+// The gate is a leaf-package primitive (indexstate imports nothing) so the
+// low-level treesitter package can depend on it without an import cycle. It is
+// off by default (cap 0 = unbounded) so non-daemon callers — plain `grafel
+// index`, the extract subprocesses, tests — are unaffected; the daemon installs
+// a real cap at startup via SetParseConcurrency.
+
+package indexstate
+
+import "sync"
+
+var (
+	parseGateMu sync.Mutex
+	// parseGateCap is the max concurrent in-process parses. 0 means unbounded
+	// (the default for non-daemon processes). The daemon sets a positive cap.
+	parseGateCap int
+	// parseGateActive is the number of parse slots currently held.
+	parseGateActive int
+	// parseGateWaiters is a FIFO of blocked acquirers, each woken with a slot
+	// already charged to it.
+	parseGateWaiters []chan struct{}
+)
+
+// SetParseConcurrency installs the daemon-wide cap on concurrent in-process
+// tree-sitter parses (#5630). A cap <= 0 disables the gate (unbounded), which
+// is the default for non-daemon processes. The daemon calls this once at
+// startup with a resource-safe value (≈ the reindex CPU budget). Safe to call
+// from any goroutine; lowering the cap does not preempt parses already running.
+func SetParseConcurrency(cap int) {
+	parseGateMu.Lock()
+	if cap < 0 {
+		cap = 0
+	}
+	parseGateCap = cap
+	// Raising the cap may free slots for queued waiters; wake any now-eligible.
+	wakeParseWaitersLocked()
+	parseGateMu.Unlock()
+}
+
+// ParseConcurrencyCap returns the configured in-process parse cap (0 = unbounded).
+func ParseConcurrencyCap() int {
+	parseGateMu.Lock()
+	defer parseGateMu.Unlock()
+	return parseGateCap
+}
+
+// AcquireParseSlot blocks until an in-process parse slot is free, then returns.
+// The caller MUST call ReleaseParseSlot exactly once when the parse completes.
+// When the gate is unbounded (cap 0) it returns immediately without queueing.
+// It also brackets the in-process parse accounting (ParseBegin/ParseEnd) so a
+// single call site — treesitter.ParserFactory.Parse — makes every in-process
+// parse both observable (busy signal) and bounded (CPU ceiling).
+func AcquireParseSlot() {
+	ParseBegin()
+	parseGateMu.Lock()
+	if parseGateCap <= 0 || parseGateActive < parseGateCap {
+		parseGateActive++
+		parseGateMu.Unlock()
+		return
+	}
+	ticket := make(chan struct{})
+	parseGateWaiters = append(parseGateWaiters, ticket)
+	parseGateMu.Unlock()
+	<-ticket // woken with a slot already charged to us
+}
+
+// ReleaseParseSlot frees one parse slot and wakes the next waiter (FIFO), and
+// records the parse as complete. MUST be paired with a successful
+// AcquireParseSlot.
+func ReleaseParseSlot() {
+	parseGateMu.Lock()
+	if parseGateActive > 0 {
+		parseGateActive--
+	}
+	wakeParseWaitersLocked()
+	parseGateMu.Unlock()
+	ParseEnd()
+}
+
+// wakeParseWaitersLocked promotes queued waiters into free slots (FIFO). Each
+// promoted ticket has a slot charged to it before being signalled. MUST hold
+// parseGateMu. With cap 0 (unbounded) every waiter is drained.
+func wakeParseWaitersLocked() {
+	for len(parseGateWaiters) > 0 && (parseGateCap <= 0 || parseGateActive < parseGateCap) {
+		t := parseGateWaiters[0]
+		parseGateWaiters = parseGateWaiters[1:]
+		parseGateActive++
+		close(t)
+	}
+}

--- a/internal/mcp/index_status.go
+++ b/internal/mcp/index_status.go
@@ -38,6 +38,18 @@ type indexStatusReply struct {
 	// should NOT use this — it should check its repo's state==current — but it
 	// is a convenient summary when no filter is set.
 	AnyIndexing bool `json:"any_indexing"`
+	// Parsing is the number of IN-PROCESS tree-sitter parses running in the
+	// daemon right now (#5630). The reactive incremental reindex re-parses
+	// changed files inside the daemon process — work that registers in NEITHER
+	// AnyIndexing's per-repo states NOR concurrency.indexing (the IndexGate).
+	// Before this field a daemon CPU-pinned in ts_parser_parse looked idle.
+	// Reported regardless of any filter (it is process-global, not per-repo).
+	Parsing int `json:"parsing"`
+	// Busy is the true daemon-activity signal (#5630/#5631): an index job, a
+	// group-algo pass, OR an in-process parse is running. A consumer that needs
+	// "is grafel quiet?" should gate on this, not on any_indexing alone — the
+	// latter only reflects scheduler index freshness, not in-process parsing.
+	Busy bool `json:"busy"`
 	// Concurrency mirrors the daemon-wide index-concurrency gate (#5493) so a
 	// caller can see how a many-module group is draining: "indexing N, queued M"
 	// with a cap of GRAFEL_INDEX_CONCURRENCY. Reported regardless of any filter.
@@ -101,6 +113,17 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 	// visible (a 30-module group draining 2-at-a-time, not stalled).
 	ic := indexstate.GetIndexConcurrency()
 	out.Concurrency = indexConcurrency{Active: ic.Active, Queued: ic.Queued, Cap: ic.Cap}
+	// #5630: surface in-process parse activity + the true busy signal so a daemon
+	// CPU-pinned in ts_parser_parse no longer reports idle. Process-global, so it
+	// is reported regardless of the repo/group filter and OR-ed into AnyIndexing
+	// (an in-process incremental reindex IS indexing work, even though it never
+	// touched the scheduler's per-repo state or the IndexGate).
+	snap := indexstate.Get()
+	out.Parsing = snap.ParseInFlight
+	out.Busy = snap.Busy
+	if snap.ParseInFlight > 0 {
+		out.AnyIndexing = true
+	}
 	return jsonResult(out), nil
 }
 

--- a/internal/treesitter/parse_accounting_5630_test.go
+++ b/internal/treesitter/parse_accounting_5630_test.go
@@ -1,0 +1,86 @@
+package treesitter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/treesitter"
+)
+
+// TestParse_RegistersBusyCounter proves the #5630 fix: a real (non-empty) parse
+// — the work that previously bypassed ALL accounting — now flips
+// indexstate.ParseInFlight / Busy WHILE it runs, and returns the counter to 0
+// afterwards. We observe "during" by holding the parse gate at cap=1 from a
+// helper goroutine so the factory's Parse blocks in AcquireParseSlot with the
+// busy counter already incremented.
+func TestParse_RegistersBusyCounter(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetParseConcurrency(0); indexstate.Set(0) })
+
+	// Baseline: idle.
+	indexstate.Set(0)
+	if s := indexstate.Get(); s.Busy {
+		t.Fatalf("precondition: daemon must be idle, got %+v", s)
+	}
+
+	// Cap at 1 and take the only slot from a helper so the real Parse below must
+	// queue. The act of queueing already increments ParseInFlight (AcquireParseSlot
+	// calls ParseBegin before blocking), which is exactly the observability we want:
+	// the daemon is provably accounted as "parsing" even before the parse runs.
+	indexstate.SetParseConcurrency(1)
+	indexstate.AcquireParseSlot() // helper holds the slot
+
+	f := treesitter.NewParserFactory(nil)
+	parseDone := make(chan struct{})
+	go func() {
+		_, _ = f.Parse(context.Background(), []byte("package main\nfunc main() {}\n"), "go")
+		close(parseDone)
+	}()
+
+	// The factory's Parse must be blocked acquiring a slot, and the busy counter
+	// must read 2 (helper + the queued parse).
+	deadline := time.After(time.Second)
+	for {
+		s := indexstate.Get()
+		if s.ParseInFlight == 2 {
+			if !s.Busy {
+				t.Fatalf("Busy must be true while parsing, got %+v", s)
+			}
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("parse did not register as busy: ParseInFlight=%d, want 2", indexstate.Get().ParseInFlight)
+		case <-parseDone:
+			t.Fatalf("parse completed while the only slot was held — cap not enforced on the parse path")
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+
+	// Release the helper slot → the parse proceeds and balances the counter.
+	indexstate.ReleaseParseSlot()
+	select {
+	case <-parseDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("parse did not complete after the slot was freed")
+	}
+
+	if s := indexstate.Get(); s.ParseInFlight != 0 || s.Busy {
+		t.Fatalf("after parse the busy counter must clear, got %+v", s)
+	}
+}
+
+// TestParse_EmptySource_DoesNotAccount confirms the empty-source fast path (no
+// real tree-sitter work) does not touch the busy counter — only actual parses
+// count, so the signal stays meaningful.
+func TestParse_EmptySource_DoesNotAccount(t *testing.T) {
+	t.Cleanup(func() { indexstate.Set(0) })
+	f := treesitter.NewParserFactory(nil)
+	if _, err := f.Parse(context.Background(), nil, "go"); err != nil {
+		t.Fatalf("empty parse: unexpected err %v", err)
+	}
+	if s := indexstate.Get(); s.ParseInFlight != 0 || s.Busy {
+		t.Fatalf("empty-source parse must not register busy, got %+v", s)
+	}
+}

--- a/internal/treesitter/parser.go
+++ b/internal/treesitter/parser.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -167,6 +168,20 @@ func (f *ParserFactory) parseOfficial(span trace.Span, source []byte, language s
 	}
 
 	lang, adapter, _ := tsLanguageFor(language)
+
+	// #5630 — account + cap. Every real (non-empty) tree-sitter parse passes
+	// through here, so this is the single chokepoint that makes "the daemon is
+	// parsing" ALWAYS observable (indexstate.ParseInFlight / the busy signal,
+	// surfaced by grafel_index_status) and ALWAYS bounded by the daemon-wide
+	// in-process parse ceiling. It fixes the untracked-parse bug where the
+	// reactive/incremental in-process reindex re-parsed source while
+	// index_status reported idle and the #5602 cap (subprocess-only) could not
+	// throttle it. AcquireParseSlot blocks until a slot is free (no-op when the
+	// gate is unbounded — non-daemon callers); ReleaseParseSlot frees it and
+	// clears the busy counter. The slot is held across the parse + node-walk so
+	// the whole CPU-heavy span counts and is capped.
+	indexstate.AcquireParseSlot()
+	defer indexstate.ReleaseParseSlot()
 
 	// Issue #481 — serialise parse calls across goroutines (see ParserFactory
 	// godoc for the rationale).


### PR DESCRIPTION
## Problem (#5630)

Profiling a hot daemon showed every hot frame in tree-sitter `ts_parser_parse` while `grafel_index_status` reported `state: current`, `any_indexing: false`, `concurrency.indexing: 0`. The daemon was **re-parsing source files outside every tracked + capped lane**, so:

- consumers gating on `any_indexing` / `state==current` saw "idle" while several cores burned, and
- the reindex CPU cap (keyed off index jobs) could not throttle the parse.

This is the primary bug behind "the daemon never returns to idle".

## Root cause

The reactive scheduler's **incremental reindex** (and the opt-out **in-process full index**) re-parse changed files *inside the daemon process*. That parse went through neither existing throttle:

- the index-concurrency gate is acquired only by the boot/explicit rebuild fan-out, so the reactive/incremental path never registers in `concurrency.indexing`; and
- the reindex GOMAXPROCS ceiling sets its cap only on the index **subprocess**, so an in-process parse runs at the daemon's own GOMAXPROCS (= host cores).

So an in-process parse was invisible to the status **and** uncapped.

## Fix

Bracket the single tree-sitter parse chokepoint (`ParserFactory.Parse`) with a leaf-package accounting + gate primitive, so **every** in-process parse — regardless of caller — is:

1. **Observable** — increments an in-flight parse counter and flips a true daemon `busy` signal. `grafel_index_status` now reports `parsing` and `busy`, and OR-s an in-process parse into `any_indexing`. A daemon CPU-pinned in `ts_parser_parse` can no longer look idle. (Also addresses the busy/idle-signal ask in the sibling issue.)
2. **Bounded** — a daemon-wide ceiling caps concurrent in-process parses (set to the daemon's effective GOMAXPROCS at startup), so an in-process parse burst cannot draw more cores than the daemon is allowed.

The gate is **off by default** (unbounded) for non-daemon callers and the extract subprocesses (each subprocess has its own process-local counter, so subprocess parses never leak into the daemon's count). Parse **correctness is unchanged** — only the accounting + throttling envelope.

## Tests

New tests prove a parse that previously bypassed accounting now increments the busy counter and is subject to the cap:
- cap=1 serializes a second parse until the first releases (FIFO wake);
- raising the cap promotes queued waiters (no stranded parses);
- unbounded (cap 0) is a no-op;
- empty-source fast path does not register as busy.

`go build ./...` and `go test` on the touched packages green; `gofmt` clean.