### PR TITLE
fix(test): de-flake perf-ratio scaling tests — wider gap + median + margin

### DIFF
--- a/internal/resolve/scale_bench_test.go
+++ b/internal/resolve/scale_bench_test.go
@@ -14,6 +14,7 @@ package resolve
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -284,45 +285,72 @@ func TestMergeModuleBatch_SingleBatch(t *testing.T) {
 // O(N log N) scaling assertion
 // ─────────────────────────────────────────────────────────────────────────────
 
-// TestBuildIndexFromModules_SubQuadratic runs BuildIndexFromModules at 100 and
-// 500 modules and asserts the 500-module build takes less than 5× longer than
-// the 100-module build (not 25×, which would be O(N²)).  This is a loose bound
-// that catches catastrophic regressions without being brittle to CPU noise.
+// TestBuildIndexFromModules_SubQuadratic times BuildIndexFromModules at two
+// corpus sizes and asserts the build does not scale quadratically in module
+// count.
 //
 // This test is intentionally NOT a benchmark (b.N loop) so it runs in the
 // normal test suite with a deterministic pass/fail gate.
+//
+// De-flaking rationale (#5636): the original compared 100 vs 500 modules (only
+// a 5x corpus) against a 12x bound. For an O(N log N) build the expected ratio
+// is ~5 × log(500)/log(100) ≈ 6.5, so the headroom to the 12x bound was barely
+// ~1.85x — and ordinary CI jitter (GC pauses, CPU throttling, co-scheduled
+// load) routinely ate that headroom with no real complexity regression
+// (12.25x observed on a loaded macOS runner). It was the third perf-ratio
+// scaling test to flake this way after #5607 and #5628.
+//
+// We apply the #5607 pattern: a wide 10x corpus gap and the MEDIAN of several
+// timing runs per size. The wide gap is what makes the bound robust — it places
+// a large window between the expected complexity and the next-worse one:
+//
+//   - O(N log N): 1000/100 × log(1000)/log(100) ≈ 10 × 1.5 = 15x
+//   - O(N²):      1000²/100²                     = 100x
+//
+// A 40x bound sits ~2.7x above the n-log-n expectation (generous slack for
+// fixed overhead and CI noise) yet ~2.5x below the quadratic signal, so a
+// genuine O(N²) reintroduction still fails loudly (~100x) while CI jitter
+// never does.
 func TestBuildIndexFromModules_SubQuadratic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping scaling test in short mode")
 	}
 
-	const entPerMod = 50
+	const (
+		entPerMod = 50
+		smallN    = 100
+		largeN    = 1000 // 10x corpus → n-log-n ≈ 15x time, quadratic ≈ 100x
+		samples   = 5    // median of N runs damps CI outliers
+		bound     = 40.0 // ~2.7x over n-log-n (15x), ~2.5x under quadratic (100x)
+	)
 
-	run := func(numMods int) int64 {
+	// median times BuildIndexFromModules `samples` times at the given module
+	// count and returns the median, which is far more stable than a single
+	// timing under CI noise (one GC pause or co-scheduled spike can multiply a
+	// lone run).
+	median := func(numMods int) int64 {
 		modules, _ := syntheticModules(numMods, entPerMod)
-		// Time N iterations to reduce clock jitter.
-		const iters = 3
-		var total int64
-		for i := 0; i < iters; i++ {
+		runs := make([]int64, samples)
+		for i := range runs {
 			t0 := nanoTime()
 			_ = BuildIndexFromModules(modules, 0)
-			total += nanoTime() - t0
+			runs[i] = nanoTime() - t0
 		}
-		return total / iters
+		sort.Slice(runs, func(a, b int) bool { return runs[a] < runs[b] })
+		return runs[len(runs)/2]
 	}
 
-	t100 := run(100)
-	t500 := run(500)
+	tSmall := median(smallN)
+	tLarge := median(largeN)
 
-	ratio := float64(t500) / float64(t100)
-	t.Logf("100-mod avg: %dns  500-mod avg: %dns  ratio: %.2fx", t100, t500, ratio)
+	// +1µs floor on the denominator guards against a 0ns small measurement.
+	ratio := float64(tLarge) / float64(tSmall+1000)
+	t.Logf("%d-mod median: %dns  %d-mod median: %dns  ratio: %.2fx (n-log-n≈15.0, quadratic≈100.0)",
+		smallN, tSmall, largeN, tLarge, ratio)
 
-	// O(N log N): 500/100 = 5, so the theoretical ceiling is
-	// 5 × log(500)/log(100) ≈ 6.5. We allow up to 12× to absorb measurement
-	// noise, GC pauses, and CPU throttling on loaded CI runners (previously 8×,
-	// raised because the test was flaking intermittently on all platforms).
-	if ratio > 12 {
-		t.Errorf("scaling ratio %.2fx exceeds 12× threshold — possible O(N²) regression", ratio)
+	if ratio > bound {
+		t.Errorf("scaling ratio %.2fx exceeds %.0fx threshold (%dx corpus) — possible O(N²) regression",
+			ratio, bound, largeN/smallN)
 	}
 }
 


### PR DESCRIPTION
## Problem

`TestBuildIndexFromModules_SubQuadratic` (`internal/resolve/scale_bench_test.go`) failed CI at ratio **12.25x** on a loaded macOS runner — the **third** perf-ratio scaling test to flake under load after `TestResponseShapePython_NearLinearScaling` (#5607) and the findings scaling test (#5628).

The flake is structural, not a real complexity regression. The test compared a **100-vs-500 module corpus (only a 5x gap)** against a **12x bound**. For an O(N log N) build the expected ratio is ~5 × log(500)/log(100) ≈ **6.5x**, leaving only ~1.85x of headroom to the bound — so ordinary CI jitter (GC pauses, CPU throttling, co-scheduled load) routinely ate that margin with no real regression. The single-window timing (only 3 iters averaged) made it worse.

## Fix — apply the #5607 de-flake pattern

`TestBuildIndexFromModules_SubQuadratic`:
- **Widened the corpus gap to 10x** — 100 vs 1000 modules — so the complexity classes separate unmistakably:
  - O(N log N): 1000/100 × log(1000)/log(100) ≈ **15x**
  - O(N²): 1000²/100² = **100x**
- **Median of 5 runs** per size to damp outliers (replaces the 3-iter average).
- **Bound raised to 40x**, documented in the test: ~2.7x over the n-log-n expectation (slack for noise) yet ~2.5x below the quadratic signal — a genuine O(N²) reintroduction still fails loudly (~100x) while CI jitter never does.

The test still genuinely guards against an O(N²) regression; it just no longer pins a noise-sensitive threshold.

## Tests touched + new bounds

| Test | File | Corpus gap | Aggregation | New bound (margin) |
|------|------|-----------|-------------|--------------------|
| `TestBuildIndexFromModules_SubQuadratic` | `internal/resolve/scale_bench_test.go` | 100 vs 1000 (10x) | median of 5 | **40x** (~2.7x over n-log-n ≈15x, ~2.5x under quadratic ≈100x) |

## Sweep of the class

Swept all repo-wide `ratio` / scaling / complexity tests. The only other timing-ratio scaling test, `TestResponseShapePython_NearLinearScaling`, was already de-flaked under #5607 with this exact pattern. The remaining `ratio` tests are **not** timing-based and are not in this flake class:
- PageRank Service/peer ratio (`groupalgo`), parser `error_ratio`, watcher dedup ratio — value ratios, not wall-clock.
- Heap/memory-bound assertions (`fbwriter` streaming) — resource bounds, not scaling ratios.
- Daemon parallel speedup ratio — already CI-gated/skipped (#4285).

## Verification

- `go build ./...` clean; `gofmt -l` clean.
- 3× `-count` runs pass at **11.6–13.6x** under load avg 17, comfortably under the 40x bound.

Closes #5636

🤖 Generated with [Claude Code](https://claude.com/claude-code)
